### PR TITLE
feat: add apply/delete cmds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ kill:
 	(killall kukeond || true )
 
 test:
-	go test ./...
+	go test $(shell go list ./... | grep -v /e2e)
 
 e2e: test-e2e
 .PHONY: test-e2e

--- a/cmd/kuke/apply/apply.go
+++ b/cmd/kuke/apply/apply.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/kuke/create/shared"
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+type applyController interface {
+	ApplyDocuments(docs []parser.Document) (controller.ApplyResult, error)
+}
+
+// MockControllerKey is used to inject mock controllers in tests via context.
+type MockControllerKey struct{}
+
+func NewApplyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "apply -f <file>",
+		Short:         "Apply resource definitions from YAML file",
+		Long:          "Apply resource definitions from a YAML file or stdin. Supports multi-document YAML separated by '---'.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			file, err := cmd.Flags().GetString("file")
+			if err != nil {
+				return err
+			}
+			if file == "" {
+				return errors.New("file flag is required (use -f <file> or -f - for stdin)")
+			}
+
+			output, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return err
+			}
+
+			// Read input
+			var reader io.Reader
+			if file == "-" {
+				reader = os.Stdin
+			} else {
+				f, openErr := os.Open(file)
+				if openErr != nil {
+					return fmt.Errorf("failed to open file %q: %w", file, openErr)
+				}
+				defer f.Close()
+				reader = f
+			}
+
+			// Parse YAML documents
+			rawDocs, err := parser.ParseDocuments(reader)
+			if err != nil {
+				return fmt.Errorf("failed to parse YAML: %w", err)
+			}
+
+			// Parse and validate each document
+			docs := make([]parser.Document, 0, len(rawDocs))
+			var validationErrors []*parser.ValidationError
+
+			for i, rawDoc := range rawDocs {
+				doc, parseErr := parser.ParseDocument(i, rawDoc)
+				if parseErr != nil {
+					validationErrors = append(validationErrors, &parser.ValidationError{
+						Index: i,
+						Err:   parseErr,
+					})
+					continue
+				}
+
+				validationErr := parser.ValidateDocument(doc)
+				if validationErr != nil {
+					validationErrors = append(validationErrors, validationErr)
+					continue
+				}
+
+				docs = append(docs, *doc)
+			}
+
+			// Report validation errors
+			if len(validationErrors) > 0 {
+				var errMsgs []string
+				for _, validationErr := range validationErrors {
+					errMsgs = append(errMsgs, validationErr.Error())
+				}
+				return fmt.Errorf("validation errors:\n  %s", strings.Join(errMsgs, "\n  "))
+			}
+
+			if len(docs) == 0 {
+				return errors.New("no valid documents found in input")
+			}
+
+			// Get controller
+			var ctrl applyController
+			if mockCtrl, ok := cmd.Context().Value(MockControllerKey{}).(applyController); ok {
+				ctrl = mockCtrl
+			} else {
+				realCtrl, ctrlErr := shared.ControllerFromCmd(cmd)
+				if ctrlErr != nil {
+					return ctrlErr
+				}
+				ctrl = realCtrl
+			}
+
+			// Apply documents
+			result, err := ctrl.ApplyDocuments(docs)
+			if err != nil {
+				return fmt.Errorf("failed to apply documents: %w", err)
+			}
+
+			// Print results
+			if output == "json" || output == "yaml" {
+				return printApplyResultJSON(cmd, result, output)
+			}
+			return printApplyResult(cmd, result)
+		},
+	}
+
+	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin)")
+	_ = cmd.MarkFlagRequired("file")
+
+	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
+
+	return cmd
+}
+
+func printApplyResult(cmd *cobra.Command, result controller.ApplyResult) error {
+	hasFailures := false
+	for _, resource := range result.Resources {
+		switch resource.Action {
+		case "created":
+			cmd.Printf("%s %q: created\n", resource.Kind, resource.Name)
+		case "updated":
+			cmd.Printf("%s %q: updated\n", resource.Kind, resource.Name)
+			for _, change := range resource.Changes {
+				cmd.Printf("  - %s\n", change)
+			}
+		case "unchanged":
+			cmd.Printf("%s %q: unchanged\n", resource.Kind, resource.Name)
+		case "failed":
+			hasFailures = true
+			cmd.Printf("%s %q: failed\n", resource.Kind, resource.Name)
+			if resource.Error != nil {
+				cmd.Printf("  Error: %v\n", resource.Error)
+			}
+		}
+	}
+
+	if hasFailures {
+		return fmt.Errorf("%w: some resources failed to apply", errdefs.ErrConfig)
+	}
+
+	return nil
+}
+
+func printApplyResultJSON(cmd *cobra.Command, result controller.ApplyResult, format string) error {
+	// Simple JSON output (can be enhanced later)
+	output := struct {
+		Resources []controller.ResourceResult `json:"resources"`
+	}{
+		Resources: result.Resources,
+	}
+
+	var outputStr string
+	var err error
+
+	if format == "json" {
+		var b []byte
+		b, err = json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		outputStr = string(b)
+	} else {
+		var b []byte
+		b, err = yaml.Marshal(output)
+		if err != nil {
+			return fmt.Errorf("failed to marshal YAML: %w", err)
+		}
+		outputStr = string(b)
+	}
+
+	cmd.Print(outputStr)
+	return nil
+}

--- a/cmd/kuke/apply/apply_test.go
+++ b/cmd/kuke/apply/apply_test.go
@@ -1,0 +1,290 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/kuke/apply"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/controller"
+)
+
+type fakeApplyController struct {
+	applyDocumentsFn func(docs []parser.Document) (controller.ApplyResult, error)
+}
+
+func (f *fakeApplyController) ApplyDocuments(docs []parser.Document) (controller.ApplyResult, error) {
+	if f.applyDocumentsFn == nil {
+		return controller.ApplyResult{}, nil
+	}
+	return f.applyDocumentsFn(docs)
+}
+
+func TestNewApplyCmd(t *testing.T) {
+	cmd := apply.NewApplyCmd()
+	if cmd == nil {
+		t.Fatal("expected command to be created")
+	}
+	if cmd.Use != "apply -f <file>" {
+		t.Errorf("expected Use to be 'apply -f <file>', got %q", cmd.Use)
+	}
+}
+
+func TestNewApplyCmd_FileFlag(t *testing.T) {
+	cmd := apply.NewApplyCmd()
+	fileFlag := cmd.Flags().Lookup("file")
+	if fileFlag == nil {
+		t.Fatal("expected 'file' flag to exist")
+	}
+	if fileFlag.Usage != "File to read YAML from (use - for stdin)" {
+		t.Errorf("unexpected file flag usage: %q", fileFlag.Usage)
+	}
+}
+
+func TestNewApplyCmd_RunE_ValidationError(t *testing.T) {
+	cmd := apply.NewApplyCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", "/nonexistent/file.yaml"})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to open file") {
+		t.Errorf("expected error about file opening, got: %v", err)
+	}
+}
+
+func TestNewApplyCmd_RunE_InvalidYAML(t *testing.T) {
+	// Create temporary file with invalid YAML
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("invalid: yaml: [")
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := apply.NewApplyCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name()})
+	err = cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse YAML") {
+		t.Errorf("expected error about YAML parsing, got: %v", err)
+	}
+}
+
+func TestNewApplyCmd_RunE_Success(t *testing.T) {
+	// Create temporary file with valid YAML
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	_, err = tmpFile.WriteString(yaml)
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := apply.NewApplyCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeApplyController{
+		applyDocumentsFn: func(docs []parser.Document) (controller.ApplyResult, error) {
+			if len(docs) != 1 {
+				t.Errorf("expected 1 document, got %d", len(docs))
+			}
+			return controller.ApplyResult{
+				Resources: []controller.ResourceResult{
+					{
+						Index:  0,
+						Kind:   "Realm",
+						Name:   "test-realm",
+						Action: "created",
+					},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, apply.MockControllerKey{}, fakeCtrl)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name()})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := outBuf.String()
+	if !strings.Contains(output, "Realm \"test-realm\": created") {
+		t.Errorf("expected output to contain 'Realm \"test-realm\": created', got: %q", output)
+	}
+}
+
+func TestNewApplyCmd_RunE_Stdin(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+
+	cmd := apply.NewApplyCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeApplyController{
+		applyDocumentsFn: func(_ []parser.Document) (controller.ApplyResult, error) {
+			return controller.ApplyResult{
+				Resources: []controller.ResourceResult{
+					{
+						Index:  0,
+						Kind:   "Realm",
+						Name:   "test-realm",
+						Action: "created",
+					},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, apply.MockControllerKey{}, fakeCtrl)
+	cmd.SetContext(ctx)
+
+	// Create a pipe to simulate stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	go func() {
+		defer w.Close()
+		_, _ = w.WriteString(yaml)
+	}()
+
+	// Replace os.Stdin temporarily
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = oldStdin
+		r.Close()
+	}()
+
+	cmd.SetArgs([]string{"-f", "-"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestNewApplyCmd_TestdataFixtures(t *testing.T) {
+	testdataDir := "testdata"
+	files := []string{
+		"realm.yaml",
+		"space.yaml",
+		"stack.yaml",
+		"cell.yaml",
+		"cell-updated.yaml",
+		"cell-removed-container.yaml",
+		"multi-resource.yaml",
+	}
+
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			path := filepath.Join(testdataDir, file)
+			if _, err := os.Stat(path); err != nil {
+				t.Skipf("test fixture %q not found", path)
+			}
+
+			// Just verify the file can be parsed
+			f, err := os.Open(path)
+			if err != nil {
+				t.Fatalf("failed to open fixture: %v", err)
+			}
+			defer f.Close()
+
+			docs, err := parser.ParseDocuments(f)
+			if err != nil {
+				t.Fatalf("failed to parse fixture: %v", err)
+			}
+
+			if len(docs) == 0 {
+				t.Fatal("expected at least one document")
+			}
+
+			// Parse and validate each document
+			for i, rawDoc := range docs {
+				doc, parseErr := parser.ParseDocument(i, rawDoc)
+				if parseErr != nil {
+					t.Fatalf("failed to parse document %d: %v", i, parseErr)
+				}
+
+				validationErr := parser.ValidateDocument(doc)
+				if validationErr != nil {
+					t.Fatalf("document %d failed validation: %v", i, validationErr)
+				}
+			}
+		})
+	}
+}

--- a/cmd/kuke/apply/testdata/cell-removed-container.yaml
+++ b/cmd/kuke/apply/testdata/cell-removed-container.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: test-cell
+spec:
+  id: test-cell
+  realmId: test-realm
+  spaceId: test-space
+  stackId: test-stack
+  containers:
+    - id: root
+      root: true
+      image: docker.io/library/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: worker
+      image: docker.io/library/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+      env:
+        - WORKER_MODE=active

--- a/cmd/kuke/apply/testdata/cell-updated.yaml
+++ b/cmd/kuke/apply/testdata/cell-updated.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: test-cell
+spec:
+  id: test-cell
+  realmId: test-realm
+  spaceId: test-space
+  stackId: test-stack
+  containers:
+    - id: root
+      root: true
+      image: docker.io/library/busybox:latest
+      command: sleep
+      args:
+        - "7200"
+    - id: worker
+      image: docker.io/library/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+      env:
+        - WORKER_MODE=active
+        - WORKER_THREADS=4

--- a/cmd/kuke/apply/testdata/cell.yaml
+++ b/cmd/kuke/apply/testdata/cell.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: test-cell
+spec:
+  id: test-cell
+  realmId: test-realm
+  spaceId: test-space
+  stackId: test-stack
+  containers:
+    - id: root
+      root: true
+      image: docker.io/library/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: worker
+      image: docker.io/library/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+      env:
+        - WORKER_MODE=active
+    - id: cache
+      image: docker.io/library/busybox:latest
+      command: sleep
+      args:
+        - "3600"

--- a/cmd/kuke/apply/testdata/multi-resource.yaml
+++ b/cmd/kuke/apply/testdata/multi-resource.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: multi-realm
+spec:
+  namespace: multi-ns
+---
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: multi-space
+spec:
+  realmId: multi-realm
+---
+apiVersion: v1beta1
+kind: Stack
+metadata:
+  name: multi-stack
+spec:
+  id: multi-stack
+  realmId: multi-realm
+  spaceId: multi-space

--- a/cmd/kuke/apply/testdata/realm.yaml
+++ b/cmd/kuke/apply/testdata/realm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns

--- a/cmd/kuke/apply/testdata/space.yaml
+++ b/cmd/kuke/apply/testdata/space.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: test-space
+spec:
+  realmId: test-realm

--- a/cmd/kuke/apply/testdata/stack.yaml
+++ b/cmd/kuke/apply/testdata/stack.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1beta1
+kind: Stack
+metadata:
+  name: test-stack
+spec:
+  id: test-stack
+  realmId: test-realm
+  spaceId: test-space

--- a/cmd/kuke/delete/delete_test.go
+++ b/cmd/kuke/delete/delete_test.go
@@ -18,11 +18,18 @@ package deletecmd_test
 
 import (
 	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	deletecmd "github.com/eminwux/kukeon/cmd/kuke/delete"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -56,7 +63,11 @@ func TestNewDeleteCmdMetadata(t *testing.T) {
 				cmd.SetOut(buf)
 				cmd.SetErr(buf)
 
-				cmd.Run(cmd, nil)
+				// RunE should show help when no -f flag is provided
+				err := cmd.RunE(cmd, nil)
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
 
 				output := buf.String()
 				if !strings.Contains(output, "Usage:") {
@@ -242,4 +253,448 @@ func findSubCommand(cmd *cobra.Command, name string) *cobra.Command {
 		}
 	}
 	return nil
+}
+
+type fakeDeleteController struct {
+	deleteDocumentsFn func(docs []parser.Document, cascade, force bool) (controller.DeleteResult, error)
+}
+
+func (f *fakeDeleteController) DeleteDocuments(
+	docs []parser.Document,
+	cascade, force bool,
+) (controller.DeleteResult, error) {
+	if f.deleteDocumentsFn == nil {
+		return controller.DeleteResult{}, nil
+	}
+	return f.deleteDocumentsFn(docs, cascade, force)
+}
+
+func TestNewDeleteCmd_FileFlag(t *testing.T) {
+	cmd := deletecmd.NewDeleteCmd()
+	fileFlag := cmd.Flags().Lookup("file")
+	if fileFlag == nil {
+		t.Fatal("expected 'file' flag to exist")
+	}
+	if fileFlag.Usage != "File to read YAML from (use - for stdin)" {
+		t.Errorf("unexpected file flag usage: %q", fileFlag.Usage)
+	}
+}
+
+func TestNewDeleteCmd_OutputFlag(t *testing.T) {
+	cmd := deletecmd.NewDeleteCmd()
+	outputFlag := cmd.Flags().Lookup("output")
+	if outputFlag == nil {
+		t.Fatal("expected 'output' flag to exist")
+	}
+	if outputFlag.Usage != "Output format: json, yaml (default: human-readable)" {
+		t.Errorf("unexpected output flag usage: %q", outputFlag.Usage)
+	}
+}
+
+func TestNewDeleteCmd_RunE_FileNotFound(t *testing.T) {
+	cmd := deletecmd.NewDeleteCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", "/nonexistent/file.yaml"})
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to open file") {
+		t.Errorf("expected error about file opening, got: %v", err)
+	}
+}
+
+func TestNewDeleteCmd_RunE_InvalidYAML(t *testing.T) {
+	// Create temporary file with invalid YAML
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("invalid: yaml: [")
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name()})
+	err = cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	// Invalid YAML can result in either parsing error or validation error
+	if !strings.Contains(err.Error(), "failed to parse YAML") && !strings.Contains(err.Error(), "validation errors") {
+		t.Errorf("expected error about YAML parsing or validation, got: %v", err)
+	}
+}
+
+func TestNewDeleteCmd_RunE_Success(t *testing.T) {
+	// Create temporary file with valid YAML
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	_, err = tmpFile.WriteString(yaml)
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeDeleteController{
+		deleteDocumentsFn: func(docs []parser.Document, cascade, force bool) (controller.DeleteResult, error) {
+			if len(docs) != 1 {
+				t.Errorf("expected 1 document, got %d", len(docs))
+			}
+			if cascade {
+				t.Error("expected cascade to be false")
+			}
+			if force {
+				t.Error("expected force to be false")
+			}
+			return controller.DeleteResult{
+				Resources: []controller.ResourceDeleteResult{
+					{
+						Index:  0,
+						Kind:   "Realm",
+						Name:   "test-realm",
+						Action: "deleted",
+					},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name()})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := outBuf.String()
+	if !strings.Contains(output, "Realm \"test-realm\": deleted") {
+		t.Errorf("expected output to contain 'Realm \"test-realm\": deleted', got: %q", output)
+	}
+}
+
+func TestNewDeleteCmd_RunE_NotFound(t *testing.T) {
+	// Create temporary file with valid YAML
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	_, err = tmpFile.WriteString(yaml)
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeDeleteController{
+		deleteDocumentsFn: func(_ []parser.Document, _ bool, _ bool) (controller.DeleteResult, error) {
+			return controller.DeleteResult{
+				Resources: []controller.ResourceDeleteResult{
+					{
+						Index:  0,
+						Kind:   "Realm",
+						Name:   "test-realm",
+						Action: "not found",
+					},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name()})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error for not found (idempotent), got: %v", err)
+	}
+
+	output := outBuf.String()
+	if !strings.Contains(output, "Realm \"test-realm\": not found") {
+		t.Errorf("expected output to contain 'Realm \"test-realm\": not found', got: %q", output)
+	}
+}
+
+func TestNewDeleteCmd_RunE_CascadeFlag(t *testing.T) {
+	// Create temporary file with valid YAML
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	_, err = tmpFile.WriteString(yaml)
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeDeleteController{
+		deleteDocumentsFn: func(_ []parser.Document, cascade, _ bool) (controller.DeleteResult, error) {
+			if !cascade {
+				t.Error("expected cascade to be true")
+			}
+			return controller.DeleteResult{
+				Resources: []controller.ResourceDeleteResult{
+					{
+						Index:    0,
+						Kind:     "Realm",
+						Name:     "test-realm",
+						Action:   "deleted",
+						Cascaded: []string{"default"},
+					},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name(), "--cascade"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := outBuf.String()
+	if !strings.Contains(output, "Realm \"test-realm\": deleted") {
+		t.Errorf("expected output to contain 'Realm \"test-realm\": deleted', got: %q", output)
+	}
+	if !strings.Contains(output, "1 space(s) deleted (cascade)") {
+		t.Errorf("expected output to contain cascaded resources, got: %q", output)
+	}
+}
+
+func TestNewDeleteCmd_RunE_JSONOutput(t *testing.T) {
+	// Create temporary file with valid YAML
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	_, err = tmpFile.WriteString(yaml)
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeDeleteController{
+		deleteDocumentsFn: func(_ []parser.Document, _ bool, _ bool) (controller.DeleteResult, error) {
+			return controller.DeleteResult{
+				Resources: []controller.ResourceDeleteResult{
+					{
+						Index:  0,
+						Kind:   "Realm",
+						Name:   "test-realm",
+						Action: "deleted",
+					},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name(), "--output", "json"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	output := outBuf.String()
+	if !strings.Contains(output, "kind") || !strings.Contains(output, "Realm") {
+		t.Errorf("expected JSON output with kind and Realm, got: %q", output)
+	}
+	if !strings.Contains(output, "name") || !strings.Contains(output, "test-realm") {
+		t.Errorf("expected JSON output with name and test-realm, got: %q", output)
+	}
+	if !strings.Contains(output, "action") || !strings.Contains(output, "deleted") {
+		t.Errorf("expected JSON output with action and deleted, got: %q", output)
+	}
+}
+
+func TestNewDeleteCmd_RunE_Stdin(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+
+	cmd := deletecmd.NewDeleteCmd()
+	var outBuf, errBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&errBuf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeDeleteController{
+		deleteDocumentsFn: func(_ []parser.Document, _ bool, _ bool) (controller.DeleteResult, error) {
+			return controller.DeleteResult{
+				Resources: []controller.ResourceDeleteResult{
+					{
+						Index:  0,
+						Kind:   "Realm",
+						Name:   "test-realm",
+						Action: "deleted",
+					},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	cmd.SetContext(ctx)
+
+	// Create a pipe to simulate stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+
+	go func() {
+		defer w.Close()
+		_, _ = w.WriteString(yaml)
+	}()
+
+	// Replace os.Stdin temporarily
+	oldStdin := os.Stdin
+	os.Stdin = r
+	defer func() {
+		os.Stdin = oldStdin
+		r.Close()
+	}()
+
+	cmd.SetArgs([]string{"-f", "-"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestNewDeleteCmd_RunE_ValidationError(t *testing.T) {
+	// Create temporary file with invalid document (missing required field)
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ""
+spec:
+  namespace: test-ns
+`
+	_, err = tmpFile.WriteString(yaml)
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name()})
+	err = cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error for validation failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "validation errors") {
+		t.Errorf("expected error about validation, got: %v", err)
+	}
 }

--- a/cmd/kuke/delete/shared/shared.go
+++ b/cmd/kuke/delete/shared/shared.go
@@ -20,20 +20,20 @@ import (
 	"log/slog"
 
 	"github.com/eminwux/kukeon/cmd/config"
-	createshared "github.com/eminwux/kukeon/cmd/kuke/create/shared"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-// ControllerFromCmd reuses the controller helper from create/shared.
+// ControllerFromCmd uses the centralized controller helper from kuke/shared.
 func ControllerFromCmd(cmd *cobra.Command) (*controller.Exec, error) {
-	return createshared.ControllerFromCmd(cmd)
+	return kukshared.ControllerFromCmd(cmd)
 }
 
-// LoggerFromCmd reuses the logger helper from create/shared.
+// LoggerFromCmd uses the centralized logger helper from kuke/shared.
 func LoggerFromCmd(cmd *cobra.Command) (*slog.Logger, error) {
-	return createshared.LoggerFromCmd(cmd)
+	return kukshared.LoggerFromCmd(cmd)
 }
 
 // ParseCascadeFlag reads the persistent --cascade flag from the command.

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	applycmd "github.com/eminwux/kukeon/cmd/kuke/apply"
 	autocompletecmd "github.com/eminwux/kukeon/cmd/kuke/autocomplete"
 	createcmd "github.com/eminwux/kukeon/cmd/kuke/create"
 	deletecmd "github.com/eminwux/kukeon/cmd/kuke/delete"
@@ -115,6 +116,7 @@ func NewKukeCmd() (*cobra.Command, error) {
 
 func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(initcmd.NewInitCmd())
+	rootCmd.AddCommand(applycmd.NewApplyCmd())
 	rootCmd.AddCommand(createcmd.NewCreateCmd())
 	rootCmd.AddCommand(getcmd.NewGetCmd())
 	rootCmd.AddCommand(deletecmd.NewDeleteCmd())

--- a/cmd/kuke/shared/controller.go
+++ b/cmd/kuke/shared/controller.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"log/slog"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// LoggerFromCmd extracts the slog logger from the Cobra command context.
+func LoggerFromCmd(cmd *cobra.Command) (*slog.Logger, error) {
+	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+	if !ok || logger == nil {
+		return nil, errdefs.ErrLoggerNotFound
+	}
+	return logger, nil
+}
+
+// ControllerFromCmd instantiates a controller.Exec configured with the shared
+// persistent flags (run path, containerd socket) used by the parent command.
+func ControllerFromCmd(cmd *cobra.Command) (*controller.Exec, error) {
+	logger, err := LoggerFromCmd(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := controller.Options{
+		RunPath:          viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	}
+
+	return controller.NewControllerExec(cmd.Context(), logger, opts), nil
+}
+
+// GetControllerWithMock is a generic helper to get a controller from context,
+// supporting mock injection via a context key. If a mock is found in the context,
+// it is returned. Otherwise, a real controller is created using ControllerFromCmd.
+// The mockKey should be a unique type used as the context key.
+func GetControllerWithMock[T any](
+	cmd *cobra.Command,
+	mockKey any,
+	realController func(*cobra.Command) (T, error),
+) (T, error) {
+	// Check for mock controller in context
+	if mockCtrl, ok := cmd.Context().Value(mockKey).(T); ok {
+		return mockCtrl, nil
+	}
+
+	// Get real controller
+	return realController(cmd)
+}
+
+// GetControllerWithMockWrapper is a convenience function that wraps GetControllerWithMock
+// to use ControllerFromCmd as the real controller factory.
+func GetControllerWithMockWrapper[T any](cmd *cobra.Command, mockKey any, wrapper func(*controller.Exec) T) (T, error) {
+	var zero T
+
+	// Check for mock controller in context
+	if mockCtrl, ok := cmd.Context().Value(mockKey).(T); ok {
+		return mockCtrl, nil
+	}
+
+	// Get real controller and wrap it
+	realCtrl, err := ControllerFromCmd(cmd)
+	if err != nil {
+		return zero, err
+	}
+
+	return wrapper(realCtrl), nil
+}

--- a/cmd/kuke/shared/file.go
+++ b/cmd/kuke/shared/file.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+)
+
+// ReadFileOrStdin reads from a file or stdin if file is "-".
+// Returns the reader and a cleanup function that should be called when done.
+// If file is "-", the cleanup function is a no-op.
+func ReadFileOrStdin(file string) (io.Reader, func() error, error) {
+	if file == "-" {
+		return os.Stdin, func() error { return nil }, nil
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open file %q: %w", file, err)
+	}
+
+	return f, f.Close, nil
+}
+
+// ParseAndValidateDocuments parses and validates YAML documents from a reader.
+// Returns the parsed documents and any validation errors encountered.
+// If there are validation errors, they are returned as a slice, but the function
+// still returns the successfully parsed documents.
+func ParseAndValidateDocuments(reader io.Reader) ([]parser.Document, []*parser.ValidationError, error) {
+	// Parse YAML documents
+	rawDocs, err := parser.ParseDocuments(reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	// Parse and validate each document
+	docs := make([]parser.Document, 0, len(rawDocs))
+	var validationErrors []*parser.ValidationError
+
+	for i, rawDoc := range rawDocs {
+		doc, parseErr := parser.ParseDocument(i, rawDoc)
+		if parseErr != nil {
+			validationErrors = append(validationErrors, &parser.ValidationError{
+				Index: i,
+				Err:   parseErr,
+			})
+			continue
+		}
+
+		validationErr := parser.ValidateDocument(doc)
+		if validationErr != nil {
+			validationErrors = append(validationErrors, validationErr)
+			continue
+		}
+
+		docs = append(docs, *doc)
+	}
+
+	return docs, validationErrors, nil
+}
+
+// FormatValidationErrors formats validation errors into a single error message.
+// If all errors are parsing errors (contain "failed to parse"), it returns
+// a YAML parsing error instead of a validation error.
+func FormatValidationErrors(validationErrors []*parser.ValidationError) error {
+	if len(validationErrors) == 0 {
+		return nil
+	}
+
+	// Check if all errors are parsing errors
+	allParsingErrors := true
+	for _, validationErr := range validationErrors {
+		errMsg := validationErr.Error()
+		if !strings.Contains(errMsg, "failed to parse") {
+			allParsingErrors = false
+			break
+		}
+	}
+
+	// If all errors are parsing errors, return as YAML parsing error
+	if allParsingErrors && len(validationErrors) > 0 {
+		// Return the first error as a YAML parsing error
+		return fmt.Errorf("failed to parse YAML: %w", validationErrors[0].Err)
+	}
+
+	// Otherwise, return as validation errors
+	var errMsgs []string
+	for _, validationErr := range validationErrors {
+		errMsgs = append(errMsgs, validationErr.Error())
+	}
+	return fmt.Errorf("validation errors:\n  %s", strings.Join(errMsgs, "\n  "))
+}

--- a/cmd/kuke/shared/output.go
+++ b/cmd/kuke/shared/output.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// PrintJSONOrYAML prints data in JSON or YAML format.
+// The data parameter should be a struct that can be marshaled.
+func PrintJSONOrYAML(cmd *cobra.Command, data interface{}, format string) error {
+	var outputStr string
+	var err error
+
+	if format == "json" {
+		var b []byte
+		b, err = json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal JSON: %w", err)
+		}
+		outputStr = string(b)
+	} else {
+		var b []byte
+		b, err = yaml.Marshal(data)
+		if err != nil {
+			return fmt.Errorf("failed to marshal YAML: %w", err)
+		}
+		outputStr = string(b)
+	}
+
+	cmd.Print(outputStr)
+	return nil
+}

--- a/e2e/e2e_kuke_apply_test.go
+++ b/e2e/e2e_kuke_apply_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestKukeApply_Realm(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+
+	// Create a temporary YAML file
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "realm.yaml")
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+`
+
+	err := os.WriteFile(yamlFile, []byte(yaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write YAML file: %v", err)
+	}
+
+	// Run apply command
+	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", yamlFile)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from apply command")
+	}
+
+	// Verify realm was created
+	if !verifyRealmInList(t, runPath, realmName) {
+		t.Errorf("realm %q not found in list after apply", realmName)
+	}
+
+	// Verify metadata exists
+	if !verifyRealmMetadataExists(t, runPath, realmName) {
+		t.Errorf("realm metadata file not found for %q", realmName)
+	}
+}
+
+func TestKukeApply_MultiResource(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := "apply-space-" + strings.TrimPrefix(realmName, "e-r-")
+
+	// Create a temporary YAML file with multiple resources
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "multi.yaml")
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+---
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: ` + spaceName + `
+spec:
+  realmId: ` + realmName + `
+`
+
+	err := os.WriteFile(yamlFile, []byte(yaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write YAML file: %v", err)
+	}
+
+	// Run apply command
+	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", yamlFile)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from apply command")
+	}
+
+	// Verify realm was created
+	if !verifyRealmInList(t, runPath, realmName) {
+		t.Errorf("realm %q not found in list after apply", realmName)
+	}
+
+	// Verify space was created
+	spaceArgs := append(
+		buildKukeRunPathArgs(runPath),
+		"get",
+		"space",
+		spaceName,
+		"--realm",
+		realmName,
+		"--output",
+		"json",
+	)
+	spaceOutput := runReturningBinary(t, nil, kuke, spaceArgs...)
+
+	if len(spaceOutput) == 0 {
+		t.Errorf("space %q not found after apply", spaceName)
+	}
+}

--- a/e2e/e2e_kuke_delete_f_test.go
+++ b/e2e/e2e_kuke_delete_f_test.go
@@ -1,0 +1,300 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestKukeDeleteF_Realm(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+
+	// First, create a realm using apply
+	tmpDir := t.TempDir()
+	applyYamlFile := filepath.Join(tmpDir, "realm-apply.yaml")
+	applyYaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+`
+
+	err := os.WriteFile(applyYamlFile, []byte(applyYaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write YAML file: %v", err)
+	}
+
+	// Apply to create the realm
+	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", applyYamlFile)
+	_ = runReturningBinary(t, nil, kuke, args...)
+
+	// Verify realm was created
+	if !verifyRealmInList(t, runPath, realmName) {
+		t.Fatalf("realm %q not found after apply", realmName)
+	}
+
+	// Now delete it using delete -f
+	deleteYamlFile := filepath.Join(tmpDir, "realm-delete.yaml")
+	deleteYaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+`
+
+	err = os.WriteFile(deleteYamlFile, []byte(deleteYaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write delete YAML file: %v", err)
+	}
+
+	// Delete the realm
+	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from delete command")
+	}
+
+	// Verify realm was deleted
+	if verifyRealmInList(t, runPath, realmName) {
+		t.Errorf("realm %q still found in list after delete", realmName)
+	}
+
+	// Verify metadata is removed
+	if verifyRealmMetadataExists(t, runPath, realmName) {
+		t.Errorf("realm metadata file still exists for %q", realmName)
+	}
+}
+
+func TestKukeDeleteF_MultiResource(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := "delete-space-" + strings.TrimPrefix(realmName, "e-r-")
+
+	// First, create resources using apply
+	tmpDir := t.TempDir()
+	applyYamlFile := filepath.Join(tmpDir, "multi-apply.yaml")
+	applyYaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+---
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: ` + spaceName + `
+spec:
+  realmId: ` + realmName + `
+`
+
+	err := os.WriteFile(applyYamlFile, []byte(applyYaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write YAML file: %v", err)
+	}
+
+	// Apply to create resources
+	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", applyYamlFile)
+	_ = runReturningBinary(t, nil, kuke, args...)
+
+	// Verify resources were created
+	if !verifyRealmInList(t, runPath, realmName) {
+		t.Fatalf("realm %q not found after apply", realmName)
+	}
+	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+		t.Fatalf("space %q not found after apply", spaceName)
+	}
+
+	// Now delete them using delete -f (in reverse order)
+	deleteYamlFile := filepath.Join(tmpDir, "multi-delete.yaml")
+	deleteYaml := `apiVersion: v1beta1
+kind: Space
+metadata:
+  name: ` + spaceName + `
+spec:
+  realmId: ` + realmName + `
+---
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+`
+
+	err = os.WriteFile(deleteYamlFile, []byte(deleteYaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write delete YAML file: %v", err)
+	}
+
+	// Delete resources (should delete in reverse dependency order: Space first, then Realm)
+	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from delete command")
+	}
+
+	// Verify resources were deleted
+	if verifySpaceInList(t, runPath, realmName, spaceName) {
+		t.Errorf("space %q still found in list after delete", spaceName)
+	}
+	if verifyRealmInList(t, runPath, realmName) {
+		t.Errorf("realm %q still found in list after delete", realmName)
+	}
+}
+
+func TestKukeDeleteF_Cascade(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := "delete-cascade-space-" + strings.TrimPrefix(realmName, "e-r-")
+
+	// First, create resources using apply
+	tmpDir := t.TempDir()
+	applyYamlFile := filepath.Join(tmpDir, "cascade-apply.yaml")
+	applyYaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+---
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: ` + spaceName + `
+spec:
+  realmId: ` + realmName + `
+`
+
+	err := os.WriteFile(applyYamlFile, []byte(applyYaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write YAML file: %v", err)
+	}
+
+	// Apply to create resources
+	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", applyYamlFile)
+	_ = runReturningBinary(t, nil, kuke, args...)
+
+	// Verify resources were created
+	if !verifyRealmInList(t, runPath, realmName) {
+		t.Fatalf("realm %q not found after apply", realmName)
+	}
+	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+		t.Fatalf("space %q not found after apply", spaceName)
+	}
+
+	// Now delete realm with cascade
+	deleteYamlFile := filepath.Join(tmpDir, "cascade-delete.yaml")
+	deleteYaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+`
+
+	err = os.WriteFile(deleteYamlFile, []byte(deleteYaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write delete YAML file: %v", err)
+	}
+
+	// Delete realm with cascade flag
+	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile, "--cascade")
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from delete command")
+	}
+
+	// Verify both resources were deleted (cascade)
+	if verifySpaceInList(t, runPath, realmName, spaceName) {
+		t.Errorf("space %q still found in list after cascade delete", spaceName)
+	}
+	if verifyRealmInList(t, runPath, realmName) {
+		t.Errorf("realm %q still found in list after delete", realmName)
+	}
+}
+
+func TestKukeDeleteF_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+
+	// Create a delete YAML file for a non-existent realm
+	tmpDir := t.TempDir()
+	deleteYamlFile := filepath.Join(tmpDir, "nonexistent-delete.yaml")
+	deleteYaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ` + realmName + `
+spec:
+  namespace: ` + realmName + `-ns
+`
+
+	err := os.WriteFile(deleteYamlFile, []byte(deleteYaml), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write delete YAML file: %v", err)
+	}
+
+	// Try to delete non-existent realm (should be idempotent, not an error)
+	args := append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile)
+	output1 := runReturningBinary(t, nil, kuke, args...)
+
+	if len(output1) == 0 {
+		t.Fatal("expected output from delete command")
+	}
+
+	// Try again (should still be idempotent)
+	output2 := runReturningBinary(t, nil, kuke, args...)
+
+	if len(output2) == 0 {
+		t.Fatal("expected output from second delete command")
+	}
+
+	// Both should report "not found" (idempotent)
+	output1Str := string(output1)
+	output2Str := string(output2)
+	if !strings.Contains(output1Str, "not found") && !strings.Contains(output1Str, "Not found") {
+		t.Errorf("expected 'not found' in first delete output, got: %q", output1Str)
+	}
+	if !strings.Contains(output2Str, "not found") && !strings.Contains(output2Str, "Not found") {
+		t.Errorf("expected 'not found' in second delete output, got: %q", output2Str)
+	}
+}

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -1,0 +1,370 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// Document represents a parsed YAML document with its type information.
+type Document struct {
+	Index        int
+	Raw          []byte
+	APIVersion   v1beta1.Version
+	Kind         v1beta1.Kind
+	RealmDoc     *v1beta1.RealmDoc
+	SpaceDoc     *v1beta1.SpaceDoc
+	StackDoc     *v1beta1.StackDoc
+	CellDoc      *v1beta1.CellDoc
+	ContainerDoc *v1beta1.ContainerDoc
+}
+
+// ValidationError represents a validation error for a specific document.
+type ValidationError struct {
+	Index int
+	Kind  v1beta1.Kind
+	Name  string
+	Err   error
+}
+
+func (e *ValidationError) Error() string {
+	if e.Name != "" {
+		return fmt.Sprintf("document %d (%s %q): %v", e.Index, e.Kind, e.Name, e.Err)
+	}
+	return fmt.Sprintf("document %d (%s): %v", e.Index, e.Kind, e.Err)
+}
+
+// ParseDocuments reads YAML from the given reader and splits it into multiple documents.
+// Documents are separated by `---`.
+func ParseDocuments(r io.Reader) ([][]byte, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read input: %w", err)
+	}
+
+	// Split on document separator
+	docs := strings.Split(string(data), "---")
+	result := make([][]byte, 0, len(docs))
+
+	for _, doc := range docs {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue // Skip empty documents
+		}
+		result = append(result, []byte(doc))
+	}
+
+	if len(result) == 0 {
+		return nil, errors.New("no documents found in input")
+	}
+
+	return result, nil
+}
+
+// DetectKind extracts the kind from raw YAML bytes.
+func DetectKind(raw []byte) (v1beta1.Kind, error) {
+	var header struct {
+		Kind v1beta1.Kind `yaml:"kind"`
+	}
+	if err := yaml.Unmarshal(raw, &header); err != nil {
+		return "", fmt.Errorf("failed to parse kind: %w", err)
+	}
+	return header.Kind, nil
+}
+
+// ParseDocument parses a single YAML document and returns a Document with the appropriate typed doc.
+func ParseDocument(index int, raw []byte) (*Document, error) {
+	doc := &Document{
+		Index: index,
+		Raw:   raw,
+	}
+
+	// First, detect kind
+	kind, err := DetectKind(raw)
+	if err != nil {
+		return nil, fmt.Errorf("document %d: %w", index, err)
+	}
+	doc.Kind = kind
+
+	// Parse based on kind
+	switch kind {
+	case v1beta1.KindRealm:
+		var realmDoc v1beta1.RealmDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &realmDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse Realm: %w", index, unmarshalErr)
+		}
+		doc.RealmDoc = &realmDoc
+		doc.APIVersion = realmDoc.APIVersion
+
+	case v1beta1.KindSpace:
+		var spaceDoc v1beta1.SpaceDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &spaceDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse Space: %w", index, unmarshalErr)
+		}
+		doc.SpaceDoc = &spaceDoc
+		doc.APIVersion = spaceDoc.APIVersion
+
+	case v1beta1.KindStack:
+		var stackDoc v1beta1.StackDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &stackDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse Stack: %w", index, unmarshalErr)
+		}
+		doc.StackDoc = &stackDoc
+		doc.APIVersion = stackDoc.APIVersion
+
+	case v1beta1.KindCell:
+		var cellDoc v1beta1.CellDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &cellDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse Cell: %w", index, unmarshalErr)
+		}
+		doc.CellDoc = &cellDoc
+		doc.APIVersion = cellDoc.APIVersion
+
+	case v1beta1.KindContainer:
+		var containerDoc v1beta1.ContainerDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &containerDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse Container: %w", index, unmarshalErr)
+		}
+		doc.ContainerDoc = &containerDoc
+		doc.APIVersion = containerDoc.APIVersion
+
+	default:
+		return nil, fmt.Errorf("document %d: %w: %s", index, errdefs.ErrUnknownKind, kind)
+	}
+
+	return doc, nil
+}
+
+// ValidateDocument validates a parsed document for required fields and constraints.
+func ValidateDocument(doc *Document) *ValidationError {
+	// Validate apiVersion
+	apiVersion := apischeme.DefaultVersion(doc.APIVersion)
+	if apiVersion != apischeme.VersionV1Beta1 {
+		return &ValidationError{
+			Index: doc.Index,
+			Kind:  doc.Kind,
+			Err: fmt.Errorf(
+				"%w: %s (expected %s)",
+				errdefs.ErrUnsupportedAPIVersion,
+				doc.APIVersion,
+				apischeme.VersionV1Beta1,
+			),
+		}
+	}
+
+	// Validate kind
+	switch doc.Kind {
+	case v1beta1.KindRealm, v1beta1.KindSpace, v1beta1.KindStack, v1beta1.KindCell, v1beta1.KindContainer:
+		// Valid kind
+	default:
+		return &ValidationError{
+			Index: doc.Index,
+			Kind:  doc.Kind,
+			Err:   fmt.Errorf("%w: %s", errdefs.ErrUnknownKind, doc.Kind),
+		}
+	}
+
+	// Validate resource-specific fields
+	switch doc.Kind {
+	case v1beta1.KindRealm:
+		if doc.RealmDoc == nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("realm document is nil"),
+			}
+		}
+		if doc.RealmDoc.Metadata.Name == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("metadata.name is required"),
+			}
+		}
+
+	case v1beta1.KindSpace:
+		if doc.SpaceDoc == nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("space document is nil"),
+			}
+		}
+		if doc.SpaceDoc.Metadata.Name == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.SpaceDoc.Metadata.Name,
+				Err:   errors.New("metadata.name is required"),
+			}
+		}
+		if doc.SpaceDoc.Spec.RealmID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.SpaceDoc.Metadata.Name,
+				Err:   errors.New("spec.realmId is required"),
+			}
+		}
+
+	case v1beta1.KindStack:
+		if doc.StackDoc == nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("stack document is nil"),
+			}
+		}
+		if doc.StackDoc.Metadata.Name == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("metadata.name is required"),
+			}
+		}
+		if doc.StackDoc.Spec.RealmID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.StackDoc.Metadata.Name,
+				Err:   errors.New("spec.realmId is required"),
+			}
+		}
+		if doc.StackDoc.Spec.SpaceID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.StackDoc.Metadata.Name,
+				Err:   errors.New("spec.spaceId is required"),
+			}
+		}
+
+	case v1beta1.KindCell:
+		if doc.CellDoc == nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("cell document is nil"),
+			}
+		}
+		if doc.CellDoc.Metadata.Name == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("metadata.name is required"),
+			}
+		}
+		if doc.CellDoc.Spec.RealmID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.CellDoc.Metadata.Name,
+				Err:   errors.New("spec.realmId is required"),
+			}
+		}
+		if doc.CellDoc.Spec.SpaceID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.CellDoc.Metadata.Name,
+				Err:   errors.New("spec.spaceId is required"),
+			}
+		}
+		if doc.CellDoc.Spec.StackID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.CellDoc.Metadata.Name,
+				Err:   errors.New("spec.stackId is required"),
+			}
+		}
+		if len(doc.CellDoc.Spec.Containers) == 0 {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.CellDoc.Metadata.Name,
+				Err:   errors.New("spec.containers is required and cannot be empty"),
+			}
+		}
+
+	case v1beta1.KindContainer:
+		if doc.ContainerDoc == nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("container document is nil"),
+			}
+		}
+		if doc.ContainerDoc.Metadata.Name == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("metadata.name is required"),
+			}
+		}
+		if doc.ContainerDoc.Spec.RealmID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.ContainerDoc.Metadata.Name,
+				Err:   errors.New("spec.realmId is required"),
+			}
+		}
+		if doc.ContainerDoc.Spec.SpaceID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.ContainerDoc.Metadata.Name,
+				Err:   errors.New("spec.spaceId is required"),
+			}
+		}
+		if doc.ContainerDoc.Spec.StackID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.ContainerDoc.Metadata.Name,
+				Err:   errors.New("spec.stackId is required"),
+			}
+		}
+		if doc.ContainerDoc.Spec.CellID == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.ContainerDoc.Metadata.Name,
+				Err:   errors.New("spec.cellId is required"),
+			}
+		}
+		if doc.ContainerDoc.Spec.Image == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.ContainerDoc.Metadata.Name,
+				Err:   errors.New("spec.image is required"),
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/apply/parser/parser_test.go
+++ b/internal/apply/parser/parser_test.go
@@ -1,0 +1,348 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package parser_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestParseDocuments_SingleDocument(t *testing.T) {
+	yaml := `
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	docs, err := parser.ParseDocuments(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocuments failed: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+}
+
+func TestParseDocuments_MultiDocument(t *testing.T) {
+	yaml := `
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: realm1
+---
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: space1
+spec:
+  realmId: realm1
+`
+	docs, err := parser.ParseDocuments(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocuments failed: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 documents, got %d", len(docs))
+	}
+}
+
+func TestParseDocuments_EmptyDocuments(t *testing.T) {
+	yaml := `
+---
+---
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+---
+`
+	docs, err := parser.ParseDocuments(strings.NewReader(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocuments failed: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document (empty ones skipped), got %d", len(docs))
+	}
+}
+
+func TestParseDocuments_NoDocuments(t *testing.T) {
+	yaml := `---
+---
+`
+	_, err := parser.ParseDocuments(strings.NewReader(yaml))
+	if err == nil {
+		t.Fatal("expected error for no documents, got nil")
+	}
+}
+
+func TestDetectKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantKind v1beta1.Kind
+		wantErr  bool
+	}{
+		{
+			name: "realm",
+			yaml: `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test
+`,
+			wantKind: v1beta1.KindRealm,
+		},
+		{
+			name: "space",
+			yaml: `apiVersion: v1beta1
+kind: Space
+metadata:
+  name: test
+`,
+			wantKind: v1beta1.KindSpace,
+		},
+		{
+			name:    "invalid yaml",
+			yaml:    `invalid: yaml: [`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, err := parser.DetectKind([]byte(tt.yaml))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DetectKind failed: %v", err)
+			}
+			if kind != tt.wantKind {
+				t.Errorf("expected kind %q, got %q", tt.wantKind, kind)
+			}
+		})
+	}
+}
+
+func TestParseDocument_Realm(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+	if doc.Kind != v1beta1.KindRealm {
+		t.Errorf("expected kind Realm, got %q", doc.Kind)
+	}
+	if doc.RealmDoc == nil {
+		t.Fatal("expected RealmDoc to be set")
+	}
+	if doc.RealmDoc.Metadata.Name != "test-realm" {
+		t.Errorf("expected name test-realm, got %q", doc.RealmDoc.Metadata.Name)
+	}
+}
+
+func TestParseDocument_Space(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Space
+metadata:
+  name: test-space
+spec:
+  realmId: test-realm
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+	if doc.Kind != v1beta1.KindSpace {
+		t.Errorf("expected kind Space, got %q", doc.Kind)
+	}
+	if doc.SpaceDoc == nil {
+		t.Fatal("expected SpaceDoc to be set")
+	}
+	if doc.SpaceDoc.Metadata.Name != "test-space" {
+		t.Errorf("expected name test-space, got %q", doc.SpaceDoc.Metadata.Name)
+	}
+}
+
+func TestParseDocument_UnknownKind(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Unknown
+metadata:
+  name: test
+`
+	_, err := parser.ParseDocument(0, []byte(yaml))
+	if err == nil {
+		t.Fatal("expected error for unknown kind, got nil")
+	}
+	if !strings.Contains(err.Error(), errdefs.ErrUnknownKind.Error()) {
+		t.Errorf("expected error to contain ErrUnknownKind, got: %v", err)
+	}
+}
+
+func TestValidateDocument_Realm_Valid(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr != nil {
+		t.Fatalf("expected no validation error, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_Realm_MissingName(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: ""
+spec:
+  namespace: test-ns
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for missing name, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), "metadata.name is required") {
+		t.Errorf("expected error about metadata.name, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_Space_MissingRealmID(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Space
+metadata:
+  name: test-space
+spec:
+  realmId: ""
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for missing realmId, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), "spec.realmId is required") {
+		t.Errorf("expected error about spec.realmId, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_Cell_MissingContainers(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: test-cell
+spec:
+  realmId: test-realm
+  spaceId: test-space
+  stackId: test-stack
+  containers: []
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for empty containers, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), "spec.containers is required") {
+		t.Errorf("expected error about spec.containers, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_UnsupportedAPIVersion(t *testing.T) {
+	yaml := `apiVersion: v1alpha1
+kind: Realm
+metadata:
+  name: test-realm
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for unsupported apiVersion, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), errdefs.ErrUnsupportedAPIVersion.Error()) {
+		t.Errorf("expected error about unsupported apiVersion, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_DefaultAPIVersion(t *testing.T) {
+	yaml := `kind: Realm
+metadata:
+  name: test-realm
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr != nil {
+		t.Fatalf("expected no validation error (empty apiVersion should default), got: %v", validationErr)
+	}
+}
+
+func TestParseDocuments_FromStdin(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+`
+	docs, err := parser.ParseDocuments(bytes.NewReader([]byte(yaml)))
+	if err != nil {
+		t.Fatalf("ParseDocuments failed: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(docs))
+	}
+}

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	applypkg "github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+const (
+	actionFailed = "failed"
+)
+
+// ApplyResult represents the result of applying a set of resources.
+type ApplyResult struct {
+	Resources []ResourceResult
+}
+
+// ResourceResult represents the result of applying a single resource.
+type ResourceResult struct {
+	Index   int
+	Kind    string
+	Name    string
+	Action  string // "created", "updated", "unchanged", "failed"
+	Error   error
+	Changes []string
+	Details map[string]string
+}
+
+// ApplyDocuments applies a set of resource documents in dependency order.
+// Documents are sorted: Realm → Space → Stack → Cell → Container.
+// Returns a summary of actions taken for each resource.
+func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
+	defer b.runner.Close()
+
+	result := ApplyResult{
+		Resources: make([]ResourceResult, 0, len(docs)),
+	}
+
+	// Sort documents by dependency order
+	sortedDocs := sortDocumentsByDependency(docs)
+
+	// Apply each document in order
+	for _, doc := range sortedDocs {
+		resourceResult := ResourceResult{
+			Index:   doc.Index,
+			Kind:    string(doc.Kind),
+			Details: make(map[string]string),
+		}
+
+		// Convert to internal model and reconcile
+		var reconcileResult applypkg.ReconcileResult
+		var reconcileErr error
+
+		switch doc.Kind {
+		case v1beta1.KindRealm:
+			if doc.RealmDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("realm document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			realm, _, err := apischeme.NormalizeRealm(*doc.RealmDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = realm.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileRealm(b.runner, realm)
+
+		case v1beta1.KindSpace:
+			if doc.SpaceDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("space document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			space, _, err := apischeme.NormalizeSpace(*doc.SpaceDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = space.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileSpace(b.runner, space)
+
+		case v1beta1.KindStack:
+			if doc.StackDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("stack document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			stack, _, err := apischeme.NormalizeStack(*doc.StackDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = stack.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileStack(b.runner, stack)
+
+		case v1beta1.KindCell:
+			if doc.CellDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("cell document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			cell, _, err := apischeme.NormalizeCell(*doc.CellDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = cell.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileCell(b.runner, cell)
+
+		case v1beta1.KindContainer:
+			if doc.ContainerDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("container document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			container, _, err := apischeme.NormalizeContainer(*doc.ContainerDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = container.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileContainer(b.runner, container)
+
+		default:
+			resourceResult.Action = actionFailed
+			resourceResult.Error = fmt.Errorf("%w: %s", errdefs.ErrUnknownKind, doc.Kind)
+			result.Resources = append(result.Resources, resourceResult)
+			continue
+		}
+
+		if reconcileErr != nil {
+			resourceResult.Action = actionFailed
+			resourceResult.Error = reconcileErr
+		} else {
+			resourceResult.Action = reconcileResult.Action
+			resourceResult.Changes = reconcileResult.Changes
+			resourceResult.Details = reconcileResult.Details
+		}
+
+		result.Resources = append(result.Resources, resourceResult)
+	}
+
+	return result, nil
+}
+
+// sortDocumentsByDependency sorts documents by dependency order:
+// Realm → Space → Stack → Cell → Container.
+func sortDocumentsByDependency(docs []parser.Document) []parser.Document {
+	// Create a copy to avoid modifying the original
+	sorted := make([]parser.Document, len(docs))
+	copy(sorted, docs)
+
+	// Define dependency order
+	kindOrder := map[v1beta1.Kind]int{
+		v1beta1.KindRealm:     1,
+		v1beta1.KindSpace:     2,
+		v1beta1.KindStack:     3,
+		v1beta1.KindCell:      4,
+		v1beta1.KindContainer: 5,
+	}
+
+	// Sort by kind order, then by original index
+	sort.Slice(sorted, func(i, j int) bool {
+		orderI := kindOrder[sorted[i].Kind]
+		orderJ := kindOrder[sorted[j].Kind]
+		if orderI != orderJ {
+			return orderI < orderJ
+		}
+		return sorted[i].Index < sorted[j].Index
+	})
+
+	return sorted
+}

--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -1,0 +1,603 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply
+
+import (
+	"fmt"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+const (
+	labelsChangedMsg = "labels changed"
+)
+
+// ChangeType classifies the type of change detected.
+type ChangeType int
+
+const (
+	// ChangeTypeNone indicates no changes detected.
+	ChangeTypeNone ChangeType = iota
+	// ChangeTypeAdditive indicates new fields or resources added.
+	ChangeTypeAdditive
+	// ChangeTypeCompatible indicates backward-compatible changes (labels, env vars, etc.).
+	ChangeTypeCompatible
+	// ChangeTypeBreaking indicates breaking changes that require destructive operations.
+	ChangeTypeBreaking
+)
+
+// DiffResult represents the result of comparing desired vs actual state.
+type DiffResult struct {
+	HasChanges      bool
+	ChangeType      ChangeType
+	ChangedFields   []string
+	BreakingChanges []string
+	Details         map[string]string // field -> description of change
+}
+
+// ContainerDiff represents changes to a container within a cell.
+type ContainerDiff struct {
+	Name            string
+	Action          string // "add", "remove", "update"
+	ChangedFields   []string
+	BreakingChanges []string
+	Details         map[string]string
+}
+
+// CellDiffResult extends DiffResult with container-level diffs.
+type CellDiffResult struct {
+	DiffResult
+
+	RootContainerChanged bool
+	RootContainerDetails map[string]string
+	Containers           []ContainerDiff
+	Orphans              []string // container IDs to be removed
+}
+
+// DiffRealm compares desired and actual realm states.
+func DiffRealm(desired, actual intmodel.Realm) DiffResult {
+	result := DiffResult{
+		Details: make(map[string]string),
+	}
+
+	// Check for breaking changes: name or namespace change
+	if desired.Metadata.Name != actual.Metadata.Name {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "metadata.name")
+		result.Details["metadata.name"] = fmt.Sprintf(
+			"name changed from %q to %q (breaking)",
+			actual.Metadata.Name,
+			desired.Metadata.Name,
+		)
+		return result
+	}
+
+	// Namespace change is breaking
+	if desired.Spec.Namespace != "" && desired.Spec.Namespace != actual.Spec.Namespace {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.namespace")
+		result.Details["spec.namespace"] = fmt.Sprintf(
+			"namespace changed from %q to %q (breaking)",
+			actual.Spec.Namespace,
+			desired.Spec.Namespace,
+		)
+		return result
+	}
+
+	// Compatible changes: labels
+	if !mapsEqual(desired.Metadata.Labels, actual.Metadata.Labels) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "metadata.labels")
+		result.Details["metadata.labels"] = labelsChangedMsg
+	}
+
+	// Registry credentials changes are compatible
+	if !registryCredentialsEqual(desired.Spec.RegistryCredentials, actual.Spec.RegistryCredentials) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "spec.registryCredentials")
+		result.Details["spec.registryCredentials"] = "registry credentials changed"
+	}
+
+	return result
+}
+
+// DiffSpace compares desired and actual space states.
+func DiffSpace(desired, actual intmodel.Space) DiffResult {
+	result := DiffResult{
+		Details: make(map[string]string),
+	}
+
+	// Check for breaking changes: name or realm association change
+	if desired.Metadata.Name != actual.Metadata.Name {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "metadata.name")
+		result.Details["metadata.name"] = fmt.Sprintf(
+			"name changed from %q to %q (breaking)",
+			actual.Metadata.Name,
+			desired.Metadata.Name,
+		)
+		return result
+	}
+
+	if desired.Spec.RealmName != actual.Spec.RealmName {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.realmName")
+		result.Details["spec.realmName"] = fmt.Sprintf(
+			"realm changed from %q to %q (breaking)",
+			actual.Spec.RealmName,
+			desired.Spec.RealmName,
+		)
+		return result
+	}
+
+	// CNI config path change is breaking (requires network recreation)
+	if desired.Spec.CNIConfigPath != "" && desired.Spec.CNIConfigPath != actual.Spec.CNIConfigPath {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.cniConfigPath")
+		result.Details["spec.cniConfigPath"] = fmt.Sprintf(
+			"CNI config path changed from %q to %q (breaking - requires network recreation)",
+			actual.Spec.CNIConfigPath,
+			desired.Spec.CNIConfigPath,
+		)
+		return result
+	}
+
+	// Compatible changes: labels
+	if !mapsEqual(desired.Metadata.Labels, actual.Metadata.Labels) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "metadata.labels")
+		result.Details["metadata.labels"] = labelsChangedMsg
+	}
+
+	return result
+}
+
+// DiffStack compares desired and actual stack states.
+func DiffStack(desired, actual intmodel.Stack) DiffResult {
+	result := DiffResult{
+		Details: make(map[string]string),
+	}
+
+	// Check for breaking changes: name or parent association changes
+	if desired.Metadata.Name != actual.Metadata.Name {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "metadata.name")
+		result.Details["metadata.name"] = fmt.Sprintf(
+			"name changed from %q to %q (breaking)",
+			actual.Metadata.Name,
+			desired.Metadata.Name,
+		)
+		return result
+	}
+
+	if desired.Spec.RealmName != actual.Spec.RealmName {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.realmName")
+		result.Details["spec.realmName"] = fmt.Sprintf(
+			"realm changed from %q to %q (breaking)",
+			actual.Spec.RealmName,
+			desired.Spec.RealmName,
+		)
+		return result
+	}
+
+	if desired.Spec.SpaceName != actual.Spec.SpaceName {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.spaceName")
+		result.Details["spec.spaceName"] = fmt.Sprintf(
+			"space changed from %q to %q (breaking)",
+			actual.Spec.SpaceName,
+			desired.Spec.SpaceName,
+		)
+		return result
+	}
+
+	// Compatible changes: labels, ID
+	if !mapsEqual(desired.Metadata.Labels, actual.Metadata.Labels) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "metadata.labels")
+		result.Details["metadata.labels"] = "labels changed"
+	}
+
+	if desired.Spec.ID != "" && desired.Spec.ID != actual.Spec.ID {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "spec.id")
+		result.Details["spec.id"] = fmt.Sprintf("ID changed from %q to %q", actual.Spec.ID, desired.Spec.ID)
+	}
+
+	return result
+}
+
+// DiffCell compares desired and actual cell states.
+func DiffCell(desired, actual intmodel.Cell) CellDiffResult {
+	result := CellDiffResult{
+		DiffResult: DiffResult{
+			Details: make(map[string]string),
+		},
+		RootContainerDetails: make(map[string]string),
+		Containers:           []ContainerDiff{},
+		Orphans:              []string{},
+	}
+
+	// Check for breaking changes: name or parent association changes
+	if desired.Metadata.Name != actual.Metadata.Name {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "metadata.name")
+		result.Details["metadata.name"] = fmt.Sprintf(
+			"name changed from %q to %q (breaking)",
+			actual.Metadata.Name,
+			desired.Metadata.Name,
+		)
+		return result
+	}
+
+	if desired.Spec.RealmName != actual.Spec.RealmName {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.realmName")
+		result.Details["spec.realmName"] = fmt.Sprintf(
+			"realm changed from %q to %q (breaking)",
+			actual.Spec.RealmName,
+			desired.Spec.RealmName,
+		)
+		return result
+	}
+
+	if desired.Spec.SpaceName != actual.Spec.SpaceName {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.spaceName")
+		result.Details["spec.spaceName"] = fmt.Sprintf(
+			"space changed from %q to %q (breaking)",
+			actual.Spec.SpaceName,
+			desired.Spec.SpaceName,
+		)
+		return result
+	}
+
+	if desired.Spec.StackName != actual.Spec.StackName {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.stackName")
+		result.Details["spec.stackName"] = fmt.Sprintf(
+			"stack changed from %q to %q (breaking)",
+			actual.Spec.StackName,
+			desired.Spec.StackName,
+		)
+		return result
+	}
+
+	// Compatible changes: labels
+	if !mapsEqual(desired.Metadata.Labels, actual.Metadata.Labels) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "metadata.labels")
+		result.Details["metadata.labels"] = labelsChangedMsg
+	}
+
+	// Find root container in desired and actual
+	desiredRoot := findRootContainer(desired.Spec.Containers)
+	actualRoot := findRootContainer(actual.Spec.Containers)
+
+	// Check if root container spec changed (breaking)
+	switch {
+	case desiredRoot != nil && actualRoot != nil:
+		if rootContainerSpecChanged(desiredRoot, actualRoot) {
+			result.HasChanges = true
+			result.ChangeType = ChangeTypeBreaking
+			result.RootContainerChanged = true
+			result.BreakingChanges = append(result.BreakingChanges, "spec.rootContainer")
+			result.RootContainerDetails["rootContainer"] = "root container spec changed (image, command, or args)"
+		}
+	case desiredRoot != nil && actualRoot == nil:
+		// Root container added
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.RootContainerChanged = true
+		result.BreakingChanges = append(result.BreakingChanges, "spec.rootContainer")
+		result.RootContainerDetails["rootContainer"] = "root container added"
+	case desiredRoot == nil && actualRoot != nil:
+		// Root container removed
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.RootContainerChanged = true
+		result.BreakingChanges = append(result.BreakingChanges, "spec.rootContainer")
+		result.RootContainerDetails["rootContainer"] = "root container removed"
+	}
+
+	// Diff child containers
+	desiredContainers := make(map[string]*intmodel.ContainerSpec)
+	actualContainers := make(map[string]*intmodel.ContainerSpec)
+
+	for i := range desired.Spec.Containers {
+		container := &desired.Spec.Containers[i]
+		if !container.Root && container.ID != "" {
+			desiredContainers[container.ID] = container
+		}
+	}
+
+	for i := range actual.Spec.Containers {
+		container := &actual.Spec.Containers[i]
+		if !container.Root && container.ID != "" {
+			actualContainers[container.ID] = container
+		}
+	}
+
+	// Find containers to add, update, or remove
+	for id, desiredContainer := range desiredContainers {
+		actualContainer, exists := actualContainers[id]
+		if !exists {
+			// Container to add
+			result.HasChanges = true
+			if result.ChangeType == ChangeTypeNone {
+				result.ChangeType = ChangeTypeAdditive
+			}
+			result.Containers = append(result.Containers, ContainerDiff{
+				Name:   id,
+				Action: "add",
+			})
+		} else {
+			// Container to update
+			containerDiff := diffContainerSpec(desiredContainer, actualContainer)
+			if containerDiff.HasChanges {
+				result.HasChanges = true
+				if containerDiff.ChangeType == ChangeTypeBreaking {
+					result.ChangeType = ChangeTypeBreaking
+				} else if result.ChangeType == ChangeTypeNone {
+					result.ChangeType = containerDiff.ChangeType
+				}
+				result.Containers = append(result.Containers, ContainerDiff{
+					Name:            id,
+					Action:          "update",
+					ChangedFields:   containerDiff.ChangedFields,
+					BreakingChanges: containerDiff.BreakingChanges,
+					Details:         containerDiff.Details,
+				})
+			}
+		}
+	}
+
+	// Find orphans (containers in actual but not in desired)
+	for id := range actualContainers {
+		if _, exists := desiredContainers[id]; !exists {
+			result.HasChanges = true
+			if result.ChangeType == ChangeTypeNone {
+				result.ChangeType = ChangeTypeAdditive
+			}
+			result.Orphans = append(result.Orphans, id)
+		}
+	}
+
+	return result
+}
+
+// DiffContainer compares desired and actual container states.
+func DiffContainer(desired, actual intmodel.Container) DiffResult {
+	result := DiffResult{
+		Details: make(map[string]string),
+	}
+
+	// Check for breaking changes: name or parent association changes
+	if desired.Metadata.Name != actual.Metadata.Name {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "metadata.name")
+		result.Details["metadata.name"] = fmt.Sprintf(
+			"name changed from %q to %q (breaking)",
+			actual.Metadata.Name,
+			desired.Metadata.Name,
+		)
+		return result
+	}
+
+	if desired.Spec.RealmName != actual.Spec.RealmName ||
+		desired.Spec.SpaceName != actual.Spec.SpaceName ||
+		desired.Spec.StackName != actual.Spec.StackName ||
+		desired.Spec.CellName != actual.Spec.CellName {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.parent")
+		result.Details["spec.parent"] = "parent resource changed (breaking)"
+		return result
+	}
+
+	// Compatible changes: labels
+	if !mapsEqual(desired.Metadata.Labels, actual.Metadata.Labels) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "metadata.labels")
+		result.Details["metadata.labels"] = labelsChangedMsg
+	}
+
+	// Diff container spec
+	specDiff := diffContainerSpec(&desired.Spec, &actual.Spec)
+	if specDiff.HasChanges {
+		result.HasChanges = true
+		if specDiff.ChangeType == ChangeTypeBreaking {
+			result.ChangeType = ChangeTypeBreaking
+		} else if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = specDiff.ChangeType
+		}
+		result.ChangedFields = append(result.ChangedFields, specDiff.ChangedFields...)
+		result.BreakingChanges = append(result.BreakingChanges, specDiff.BreakingChanges...)
+		for k, v := range specDiff.Details {
+			result.Details[k] = v
+		}
+	}
+
+	return result
+}
+
+// diffContainerSpec compares two container specs.
+func diffContainerSpec(desired, actual *intmodel.ContainerSpec) DiffResult {
+	result := DiffResult{
+		Details: make(map[string]string),
+	}
+
+	// Breaking changes: image, command, args
+	if desired.Image != actual.Image {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "image")
+		result.Details["image"] = fmt.Sprintf("image changed from %q to %q", actual.Image, desired.Image)
+	}
+
+	if desired.Command != actual.Command {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "command")
+		result.Details["command"] = fmt.Sprintf("command changed from %q to %q", actual.Command, desired.Command)
+	}
+
+	if !slicesEqual(desired.Args, actual.Args) {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "args")
+		result.Details["args"] = "args changed"
+	}
+
+	// Compatible changes: env, ports, volumes, etc.
+	if !slicesEqual(desired.Env, actual.Env) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "env")
+		result.Details["env"] = "environment variables changed"
+	}
+
+	if !slicesEqual(desired.Ports, actual.Ports) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "ports")
+		result.Details["ports"] = "ports changed"
+	}
+
+	if !slicesEqual(desired.Volumes, actual.Volumes) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "volumes")
+		result.Details["volumes"] = "volumes changed"
+	}
+
+	if desired.Privileged != actual.Privileged {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "privileged")
+		result.Details["privileged"] = fmt.Sprintf(
+			"privileged changed from %v to %v",
+			actual.Privileged,
+			desired.Privileged,
+		)
+	}
+
+	return result
+}
+
+// Helper functions
+
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func registryCredentialsEqual(a, b []intmodel.RegistryCredentials) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Username != b[i].Username ||
+			a[i].Password != b[i].Password ||
+			a[i].ServerAddress != b[i].ServerAddress {
+			return false
+		}
+	}
+	return true
+}
+
+func findRootContainer(containers []intmodel.ContainerSpec) *intmodel.ContainerSpec {
+	for i := range containers {
+		if containers[i].Root {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func rootContainerSpecChanged(desired, actual *intmodel.ContainerSpec) bool {
+	return desired.Image != actual.Image ||
+		desired.Command != actual.Command ||
+		!slicesEqual(desired.Args, actual.Args)
+}
+
+// isBreakingChange returns true if the change type is breaking.
+func isBreakingChange(changeType ChangeType) bool {
+	return changeType == ChangeTypeBreaking
+}

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply_test
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/controller/apply"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+func TestDiffRealm_NoChanges(t *testing.T) {
+	desired := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name:   "test-realm",
+			Labels: map[string]string{"env": "test"},
+		},
+		Spec: intmodel.RealmSpec{
+			Namespace: "test-ns",
+		},
+	}
+
+	actual := desired
+
+	diff := apply.DiffRealm(desired, actual)
+	if diff.HasChanges {
+		t.Error("expected no changes")
+	}
+}
+
+func TestDiffRealm_BreakingChange_Name(t *testing.T) {
+	desired := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: "new-realm",
+		},
+	}
+
+	actual := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: "old-realm",
+		},
+	}
+
+	diff := apply.DiffRealm(desired, actual)
+	if !diff.HasChanges {
+		t.Error("expected changes")
+	}
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Errorf("expected breaking change, got %v", diff.ChangeType)
+	}
+	if len(diff.BreakingChanges) == 0 {
+		t.Error("expected breaking changes")
+	}
+}
+
+func TestDiffRealm_CompatibleChange_Labels(t *testing.T) {
+	desired := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name:   "test-realm",
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+
+	actual := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name:   "test-realm",
+			Labels: map[string]string{"env": "test"},
+		},
+	}
+
+	diff := apply.DiffRealm(desired, actual)
+	if !diff.HasChanges {
+		t.Error("expected changes")
+	}
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Errorf("expected compatible change, got %v", diff.ChangeType)
+	}
+}
+
+func TestDiffCell_RootContainerChanged(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name: "test-cell",
+		},
+		Spec: intmodel.CellSpec{
+			RealmName: "realm",
+			SpaceName: "space",
+			StackName: "stack",
+			Containers: []intmodel.ContainerSpec{
+				{
+					ID:    "root",
+					Root:  true,
+					Image: "busybox:latest",
+				},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name: "test-cell",
+		},
+		Spec: intmodel.CellSpec{
+			RealmName: "realm",
+			SpaceName: "space",
+			StackName: "stack",
+			Containers: []intmodel.ContainerSpec{
+				{
+					ID:    "root",
+					Root:  true,
+					Image: "alpine:latest",
+				},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Error("expected changes")
+	}
+	if !diff.RootContainerChanged {
+		t.Error("expected root container to be changed")
+	}
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Errorf("expected breaking change, got %v", diff.ChangeType)
+	}
+}

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -1,0 +1,505 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/eminwux/kukeon/internal/controller/runner"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+const (
+	actionCreated = "created"
+	actionUpdated = "updated"
+)
+
+// ReconcileRealm reconciles a desired realm state with the actual state.
+func ReconcileRealm(r runner.Runner, desired intmodel.Realm) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "Realm",
+		Name:   desired.Metadata.Name,
+	}
+
+	// Get actual state
+	actual, err := r.GetRealm(desired)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			// Realm doesn't exist, create it
+			created, createErr := r.CreateRealm(desired)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create realm: %w", createErr)
+			}
+			result.Action = actionCreated
+			result.Resource = created
+			return result, nil
+		}
+		return result, fmt.Errorf("failed to get realm: %w", err)
+	}
+
+	// Diff desired vs actual
+	diff := DiffRealm(desired, actual)
+	if !diff.HasChanges {
+		result.Resource = actual
+		return result, nil
+	}
+
+	// Check for breaking changes
+	if isBreakingChange(diff.ChangeType) {
+		return result, fmt.Errorf(
+			"realm %q has breaking changes: %v. Delete the realm and recreate it with the new spec",
+			desired.Metadata.Name,
+			diff.BreakingChanges,
+		)
+	}
+
+	// Apply compatible changes
+	updated, updateErr := r.UpdateRealm(desired)
+	if updateErr != nil {
+		return result, fmt.Errorf("failed to update realm: %w", updateErr)
+	}
+
+	result.Action = actionUpdated
+	result.Resource = updated
+	result.Changes = diff.ChangedFields
+	result.Details = diff.Details
+
+	return result, nil
+}
+
+// ReconcileSpace reconciles a desired space state with the actual state.
+func ReconcileSpace(r runner.Runner, desired intmodel.Space) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "Space",
+		Name:   desired.Metadata.Name,
+	}
+
+	// Ensure parent realm exists
+	realm := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: desired.Spec.RealmName,
+		},
+	}
+	_, err := r.GetRealm(realm)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			// Create parent realm if it doesn't exist
+			_, createErr := r.CreateRealm(realm)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create parent realm %q: %w", desired.Spec.RealmName, createErr)
+			}
+		} else {
+			return result, fmt.Errorf("failed to get parent realm %q: %w", desired.Spec.RealmName, err)
+		}
+	}
+
+	// Get actual state
+	actual, err := r.GetSpace(desired)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrSpaceNotFound) {
+			// Space doesn't exist, create it
+			created, createErr := r.CreateSpace(desired)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create space: %w", createErr)
+			}
+			result.Action = actionCreated
+			result.Resource = created
+			return result, nil
+		}
+		return result, fmt.Errorf("failed to get space: %w", err)
+	}
+
+	// Diff desired vs actual
+	diff := DiffSpace(desired, actual)
+	if !diff.HasChanges {
+		result.Resource = actual
+		return result, nil
+	}
+
+	// Check for breaking changes
+	if isBreakingChange(diff.ChangeType) {
+		return result, fmt.Errorf(
+			"space %q has breaking changes: %v. Delete the space and recreate it with the new spec",
+			desired.Metadata.Name,
+			diff.BreakingChanges,
+		)
+	}
+
+	// Apply compatible changes
+	updated, updateErr := r.UpdateSpace(desired)
+	if updateErr != nil {
+		return result, fmt.Errorf("failed to update space: %w", updateErr)
+	}
+
+	result.Action = actionUpdated
+	result.Resource = updated
+	result.Changes = diff.ChangedFields
+	result.Details = diff.Details
+
+	return result, nil
+}
+
+// ReconcileStack reconciles a desired stack state with the actual state.
+func ReconcileStack(r runner.Runner, desired intmodel.Stack) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "Stack",
+		Name:   desired.Metadata.Name,
+	}
+
+	// Ensure parent realm and space exist
+	realm := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: desired.Spec.RealmName,
+		},
+	}
+	_, err := r.GetRealm(realm)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			_, createErr := r.CreateRealm(realm)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create parent realm %q: %w", desired.Spec.RealmName, createErr)
+			}
+		} else {
+			return result, fmt.Errorf("failed to get parent realm %q: %w", desired.Spec.RealmName, err)
+		}
+	}
+
+	space := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{
+			Name: desired.Spec.SpaceName,
+		},
+		Spec: intmodel.SpaceSpec{
+			RealmName: desired.Spec.RealmName,
+		},
+	}
+	_, err = r.GetSpace(space)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrSpaceNotFound) {
+			_, createErr := r.CreateSpace(space)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create parent space %q: %w", desired.Spec.SpaceName, createErr)
+			}
+		} else {
+			return result, fmt.Errorf("failed to get parent space %q: %w", desired.Spec.SpaceName, err)
+		}
+	}
+
+	// Get actual state
+	actual, err := r.GetStack(desired)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrStackNotFound) {
+			// Stack doesn't exist, create it
+			created, createErr := r.CreateStack(desired)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create stack: %w", createErr)
+			}
+			result.Action = actionCreated
+			result.Resource = created
+			return result, nil
+		}
+		return result, fmt.Errorf("failed to get stack: %w", err)
+	}
+
+	// Diff desired vs actual
+	diff := DiffStack(desired, actual)
+	if !diff.HasChanges {
+		result.Resource = actual
+		return result, nil
+	}
+
+	// Check for breaking changes
+	if isBreakingChange(diff.ChangeType) {
+		return result, fmt.Errorf(
+			"stack %q has breaking changes: %v. Delete the stack and recreate it with the new spec",
+			desired.Metadata.Name,
+			diff.BreakingChanges,
+		)
+	}
+
+	// Apply compatible changes
+	updated, updateErr := r.UpdateStack(desired)
+	if updateErr != nil {
+		return result, fmt.Errorf("failed to update stack: %w", updateErr)
+	}
+
+	result.Action = actionUpdated
+	result.Resource = updated
+	result.Changes = diff.ChangedFields
+	result.Details = diff.Details
+
+	return result, nil
+}
+
+// ReconcileCell reconciles a desired cell state with the actual state.
+func ReconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "Cell",
+		Name:   desired.Metadata.Name,
+	}
+
+	// Ensure parent resources exist
+	realm := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: desired.Spec.RealmName,
+		},
+	}
+	_, err := r.GetRealm(realm)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			_, createErr := r.CreateRealm(realm)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create parent realm %q: %w", desired.Spec.RealmName, createErr)
+			}
+		} else {
+			return result, fmt.Errorf("failed to get parent realm %q: %w", desired.Spec.RealmName, err)
+		}
+	}
+
+	space := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{
+			Name: desired.Spec.SpaceName,
+		},
+		Spec: intmodel.SpaceSpec{
+			RealmName: desired.Spec.RealmName,
+		},
+	}
+	_, err = r.GetSpace(space)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrSpaceNotFound) {
+			_, createErr := r.CreateSpace(space)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create parent space %q: %w", desired.Spec.SpaceName, createErr)
+			}
+		} else {
+			return result, fmt.Errorf("failed to get parent space %q: %w", desired.Spec.SpaceName, err)
+		}
+	}
+
+	stack := intmodel.Stack{
+		Metadata: intmodel.StackMetadata{
+			Name: desired.Spec.StackName,
+		},
+		Spec: intmodel.StackSpec{
+			RealmName: desired.Spec.RealmName,
+			SpaceName: desired.Spec.SpaceName,
+		},
+	}
+	_, err = r.GetStack(stack)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrStackNotFound) {
+			_, createErr := r.CreateStack(stack)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create parent stack %q: %w", desired.Spec.StackName, createErr)
+			}
+		} else {
+			return result, fmt.Errorf("failed to get parent stack %q: %w", desired.Spec.StackName, err)
+		}
+	}
+
+	// Get actual state
+	actual, err := r.GetCell(desired)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrCellNotFound) {
+			// Cell doesn't exist, create it
+			created, createErr := r.CreateCell(desired)
+			if createErr != nil {
+				return result, fmt.Errorf("failed to create cell: %w", createErr)
+			}
+			result.Action = actionCreated
+			result.Resource = created
+			return result, nil
+		}
+		return result, fmt.Errorf("failed to get cell: %w", err)
+	}
+
+	// Diff desired vs actual
+	diff := DiffCell(desired, actual)
+	if !diff.HasChanges {
+		result.Resource = actual
+		return result, nil
+	}
+
+	// Check for breaking changes (root container spec change)
+	if diff.RootContainerChanged {
+		// Recreate cell with new root container spec
+		recreated, recreateErr := r.RecreateCell(desired)
+		if recreateErr != nil {
+			return result, fmt.Errorf("failed to recreate cell: %w", recreateErr)
+		}
+		result.Action = "updated"
+		result.Resource = recreated
+		result.Changes = []string{"root container recreated"}
+		result.Details = diff.RootContainerDetails
+		return result, nil
+	}
+
+	// Check for other breaking changes
+	if isBreakingChange(diff.ChangeType) {
+		return result, fmt.Errorf(
+			"cell %q has breaking changes: %v. Delete the cell and recreate it with the new spec",
+			desired.Metadata.Name,
+			diff.BreakingChanges,
+		)
+	}
+
+	// Apply compatible changes (container updates, metadata)
+	updated, updateErr := r.UpdateCell(desired)
+	if updateErr != nil {
+		return result, fmt.Errorf("failed to update cell: %w", updateErr)
+	}
+
+	result.Action = "updated"
+	result.Resource = updated
+	result.Changes = diff.ChangedFields
+	result.Details = diff.Details
+
+	// Add container change details
+	for _, containerDiff := range diff.Containers {
+		switch containerDiff.Action {
+		case "add":
+			result.Changes = append(result.Changes, fmt.Sprintf("container %q added", containerDiff.Name))
+		case "update":
+			result.Changes = append(result.Changes, fmt.Sprintf("container %q updated", containerDiff.Name))
+		}
+	}
+	for _, orphan := range diff.Orphans {
+		result.Changes = append(result.Changes, fmt.Sprintf("container %q removed", orphan))
+	}
+
+	return result, nil
+}
+
+// ReconcileContainer reconciles a desired container state with the actual state.
+func ReconcileContainer(r runner.Runner, desired intmodel.Container) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "Container",
+		Name:   desired.Metadata.Name,
+	}
+
+	// Ensure parent cell exists
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name: desired.Spec.CellName,
+		},
+		Spec: intmodel.CellSpec{
+			RealmName: desired.Spec.RealmName,
+			SpaceName: desired.Spec.SpaceName,
+			StackName: desired.Spec.StackName,
+		},
+	}
+	_, err := r.GetCell(cell)
+	if err != nil {
+		return result, fmt.Errorf("parent cell %q not found: %w", desired.Spec.CellName, err)
+	}
+
+	// Get actual state (need to get cell and find container in it)
+	actualCell, err := r.GetCell(cell)
+	if err != nil {
+		return result, fmt.Errorf("failed to get cell: %w", err)
+	}
+
+	// Find container in cell
+	var actualContainer *intmodel.ContainerSpec
+	for i := range actualCell.Spec.Containers {
+		if actualCell.Spec.Containers[i].ID == desired.Spec.ID {
+			actualContainer = &actualCell.Spec.Containers[i]
+			break
+		}
+	}
+
+	if actualContainer == nil {
+		// Container doesn't exist, create it
+		updatedCell, createErr := r.CreateContainer(cell, desired.Spec)
+		if createErr != nil {
+			return result, fmt.Errorf("failed to create container: %w", createErr)
+		}
+		result.Action = actionCreated
+		// Extract container from updated cell
+		for i := range updatedCell.Spec.Containers {
+			if updatedCell.Spec.Containers[i].ID == desired.Spec.ID {
+				result.Resource = intmodel.Container{
+					Metadata: desired.Metadata,
+					Spec:     updatedCell.Spec.Containers[i],
+				}
+				break
+			}
+		}
+		return result, nil
+	}
+
+	// Build actual container for diff
+	actual := intmodel.Container{
+		Metadata: desired.Metadata, // Use desired metadata for comparison
+		Spec:     *actualContainer,
+	}
+
+	// Diff desired vs actual
+	diff := DiffContainer(desired, actual)
+	if !diff.HasChanges {
+		result.Resource = actual
+		return result, nil
+	}
+
+	// Check for breaking changes
+	if isBreakingChange(diff.ChangeType) {
+		return result, fmt.Errorf(
+			"container %q has breaking changes: %v. Delete the container and recreate it with the new spec",
+			desired.Metadata.Name,
+			diff.BreakingChanges,
+		)
+	}
+
+	// Apply compatible changes
+	updatedCell, updateErr := r.UpdateContainer(cell, desired.Spec)
+	if updateErr != nil {
+		return result, fmt.Errorf("failed to update container: %w", updateErr)
+	}
+
+	result.Action = "updated"
+	result.Changes = diff.ChangedFields
+	result.Details = diff.Details
+
+	// Extract updated container from cell
+	for i := range updatedCell.Spec.Containers {
+		if updatedCell.Spec.Containers[i].ID == desired.Spec.ID {
+			result.Resource = intmodel.Container{
+				Metadata: desired.Metadata,
+				Spec:     updatedCell.Spec.Containers[i],
+			}
+			break
+		}
+	}
+
+	return result, nil
+}
+
+// ReconcileResult represents the result of reconciling a resource.
+type ReconcileResult struct {
+	Action   string            // "created", "updated", "unchanged", "deleted"
+	Kind     string            // Resource kind
+	Name     string            // Resource name
+	Resource interface{}       // The reconciled resource (internal model)
+	Changes  []string          // List of changed fields
+	Details  map[string]string // Detailed change descriptions
+}

--- a/internal/controller/apply_test.go
+++ b/internal/controller/apply_test.go
@@ -1,0 +1,205 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/controller"
+	"gopkg.in/yaml.v3"
+)
+
+func TestResourceResult_MarshalJSON_WithError(t *testing.T) {
+	result := controller.ResourceResult{
+		Index:  0,
+		Kind:   "Realm",
+		Name:   "test-realm",
+		Action: "failed",
+		Error:  errors.New("conversion failed: invalid namespace"),
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify error field is a string
+	errorVal, ok := unmarshaled["error"]
+	if !ok {
+		t.Fatal("expected 'error' field to be present")
+	}
+
+	errorStr, ok := errorVal.(string)
+	if !ok {
+		t.Fatalf("expected error to be a string, got %T: %v", errorVal, errorVal)
+	}
+
+	if errorStr != "conversion failed: invalid namespace" {
+		t.Errorf("expected error message 'conversion failed: invalid namespace', got %q", errorStr)
+	}
+}
+
+func TestResourceResult_MarshalJSON_WithoutError(t *testing.T) {
+	result := controller.ResourceResult{
+		Index:  0,
+		Kind:   "Realm",
+		Name:   "test-realm",
+		Action: "created",
+		Error:  nil,
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify error field is omitted (due to omitempty)
+	if _, ok := unmarshaled["error"]; ok {
+		t.Error("expected 'error' field to be omitted when nil")
+	}
+}
+
+func TestResourceResult_MarshalJSON_WithChangesAndDetails(t *testing.T) {
+	result := controller.ResourceResult{
+		Index:   1,
+		Kind:    "Space",
+		Name:    "test-space",
+		Action:  "updated",
+		Error:   nil,
+		Changes: []string{"spec.realmID changed", "spec.network changed"},
+		Details: map[string]string{
+			"network": "test-network",
+		},
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	if unmarshaled["index"].(float64) != 1 {
+		t.Errorf("expected index 1, got %v", unmarshaled["index"])
+	}
+
+	if unmarshaled["kind"].(string) != "Space" {
+		t.Errorf("expected kind 'Space', got %q", unmarshaled["kind"])
+	}
+
+	changes, ok := unmarshaled["changes"].([]interface{})
+	if !ok {
+		t.Fatalf("expected changes to be an array, got %T", unmarshaled["changes"])
+	}
+
+	if len(changes) != 2 {
+		t.Errorf("expected 2 changes, got %d", len(changes))
+	}
+}
+
+func TestResourceResult_MarshalYAML_WithError(t *testing.T) {
+	result := controller.ResourceResult{
+		Index:  0,
+		Kind:   "Realm",
+		Name:   "test-realm",
+		Action: "failed",
+		Error:  errors.New("conversion failed: invalid namespace"),
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal YAML: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = yaml.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	// Verify error field is a string
+	errorVal, ok := unmarshaled["error"]
+	if !ok {
+		t.Fatal("expected 'error' field to be present")
+	}
+
+	errorStr, ok := errorVal.(string)
+	if !ok {
+		t.Fatalf("expected error to be a string, got %T: %v", errorVal, errorVal)
+	}
+
+	if errorStr != "conversion failed: invalid namespace" {
+		t.Errorf("expected error message 'conversion failed: invalid namespace', got %q", errorStr)
+	}
+
+	// Verify YAML contains the error as a string (may be quoted)
+	yamlStr := string(data)
+	if !strings.Contains(yamlStr, "conversion failed: invalid namespace") {
+		t.Errorf("expected YAML to contain error message, got:\n%s", yamlStr)
+	}
+	if !strings.Contains(yamlStr, "error:") {
+		t.Errorf("expected YAML to contain error field, got:\n%s", yamlStr)
+	}
+}
+
+func TestResourceResult_MarshalYAML_WithoutError(t *testing.T) {
+	result := controller.ResourceResult{
+		Index:  0,
+		Kind:   "Realm",
+		Name:   "test-realm",
+		Action: "created",
+		Error:  nil,
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal YAML: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = yaml.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	// Verify error field is omitted (due to omitempty)
+	if _, ok := unmarshaled["error"]; ok {
+		t.Error("expected 'error' field to be omitted when nil")
+	}
+
+	// Verify YAML doesn't contain error field
+	yamlStr := string(data)
+	if strings.Contains(yamlStr, "error:") {
+		t.Errorf("expected YAML to not contain error field, got:\n%s", yamlStr)
+	}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -93,6 +93,14 @@ type fakeRunner struct {
 
 	// Close
 	CloseFn func() error
+
+	// Apply methods
+	UpdateRealmFn     func(realm intmodel.Realm) (intmodel.Realm, error)
+	UpdateSpaceFn     func(space intmodel.Space) (intmodel.Space, error)
+	UpdateStackFn     func(stack intmodel.Stack) (intmodel.Stack, error)
+	UpdateCellFn      func(cell intmodel.Cell) (intmodel.Cell, error)
+	RecreateCellFn    func(cell intmodel.Cell) (intmodel.Cell, error)
+	UpdateContainerFn func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
 }
 
 // Realm methods
@@ -407,6 +415,50 @@ func (f *fakeRunner) Close() error {
 		return f.CloseFn()
 	}
 	return nil
+}
+
+// Apply
+
+func (f *fakeRunner) UpdateRealm(realm intmodel.Realm) (intmodel.Realm, error) {
+	if f.UpdateRealmFn != nil {
+		return f.UpdateRealmFn(realm)
+	}
+	return intmodel.Realm{}, errors.New("unexpected call to UpdateRealm")
+}
+
+func (f *fakeRunner) UpdateSpace(space intmodel.Space) (intmodel.Space, error) {
+	if f.UpdateSpaceFn != nil {
+		return f.UpdateSpaceFn(space)
+	}
+	return intmodel.Space{}, errors.New("unexpected call to UpdateSpace")
+}
+
+func (f *fakeRunner) UpdateStack(stack intmodel.Stack) (intmodel.Stack, error) {
+	if f.UpdateStackFn != nil {
+		return f.UpdateStackFn(stack)
+	}
+	return intmodel.Stack{}, errors.New("unexpected call to UpdateStack")
+}
+
+func (f *fakeRunner) UpdateCell(cell intmodel.Cell) (intmodel.Cell, error) {
+	if f.UpdateCellFn != nil {
+		return f.UpdateCellFn(cell)
+	}
+	return intmodel.Cell{}, errors.New("unexpected call to UpdateCell")
+}
+
+func (f *fakeRunner) RecreateCell(cell intmodel.Cell) (intmodel.Cell, error) {
+	if f.RecreateCellFn != nil {
+		return f.RecreateCellFn(cell)
+	}
+	return intmodel.Cell{}, errors.New("unexpected call to RecreateCell")
+}
+
+func (f *fakeRunner) UpdateContainer(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error) {
+	if f.UpdateContainerFn != nil {
+		return f.UpdateContainerFn(cell, container)
+	}
+	return intmodel.Cell{}, errors.New("unexpected call to UpdateContainer")
 }
 
 // Test helper functions

--- a/internal/controller/delete_documents.go
+++ b/internal/controller/delete_documents.go
@@ -1,0 +1,310 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+const (
+	actionDeleted  = "deleted"
+	actionNotFound = "not found"
+	// actionFailed is defined in apply.go.
+)
+
+// DeleteResult represents the result of deleting a set of resources.
+type DeleteResult struct {
+	Resources []ResourceDeleteResult
+}
+
+// ResourceDeleteResult represents the result of deleting a single resource.
+type ResourceDeleteResult struct {
+	Index    int
+	Kind     string
+	Name     string
+	Action   string // "deleted", "not found", "failed"
+	Error    error
+	Cascaded []string // Child resources deleted (if cascade=true)
+	Details  map[string]string
+}
+
+// resourceDeleteResultJSON is a helper type for JSON/YAML serialization.
+type resourceDeleteResultJSON struct {
+	Index    int               `json:"index"              yaml:"index"`
+	Kind     string            `json:"kind"               yaml:"kind"`
+	Name     string            `json:"name"               yaml:"name"`
+	Action   string            `json:"action"             yaml:"action"`
+	Error    *string           `json:"error,omitempty"    yaml:"error,omitempty"`
+	Cascaded []string          `json:"cascaded,omitempty" yaml:"cascaded,omitempty"`
+	Details  map[string]string `json:"details,omitempty"  yaml:"details,omitempty"`
+}
+
+// MarshalJSON implements json.Marshaler for ResourceDeleteResult.
+func (r ResourceDeleteResult) MarshalJSON() ([]byte, error) {
+	result := resourceDeleteResultJSON{
+		Index:    r.Index,
+		Kind:     r.Kind,
+		Name:     r.Name,
+		Action:   r.Action,
+		Cascaded: r.Cascaded,
+		Details:  r.Details,
+	}
+	if r.Error != nil {
+		errMsg := r.Error.Error()
+		result.Error = &errMsg
+	}
+	return json.Marshal(result)
+}
+
+// MarshalYAML implements yaml.Marshaler for ResourceDeleteResult.
+func (r ResourceDeleteResult) MarshalYAML() (interface{}, error) {
+	result := resourceDeleteResultJSON{
+		Index:    r.Index,
+		Kind:     r.Kind,
+		Name:     r.Name,
+		Action:   r.Action,
+		Cascaded: r.Cascaded,
+		Details:  r.Details,
+	}
+	if r.Error != nil {
+		errMsg := r.Error.Error()
+		result.Error = &errMsg
+	}
+	return result, nil
+}
+
+// DeleteDocuments deletes a set of resource documents in reverse dependency order.
+// Documents are sorted: Container → Cell → Stack → Space → Realm.
+// Returns a summary of actions taken for each resource.
+func (b *Exec) DeleteDocuments(docs []parser.Document, cascade, force bool) (DeleteResult, error) {
+	defer b.runner.Close()
+
+	result := DeleteResult{
+		Resources: make([]ResourceDeleteResult, 0, len(docs)),
+	}
+
+	// Sort documents by reverse dependency order
+	sortedDocs := SortDocumentsByKind(docs, true)
+
+	// Delete each document in order
+	for _, doc := range sortedDocs {
+		resourceResult := ResourceDeleteResult{
+			Index:    doc.Index,
+			Kind:     string(doc.Kind),
+			Details:  make(map[string]string),
+			Cascaded: []string{},
+		}
+
+		// Convert to internal model and delete
+		switch doc.Kind {
+		case v1beta1.KindRealm:
+			if doc.RealmDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("realm document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			realm, _, err := apischeme.NormalizeRealm(*doc.RealmDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = realm.Metadata.Name
+			deleteResult, deleteErr := b.DeleteRealm(realm, force, cascade)
+			if deleteErr != nil {
+				if isNotFoundError(deleteErr) {
+					resourceResult.Action = actionNotFound
+				} else {
+					resourceResult.Action = actionFailed
+					resourceResult.Error = deleteErr
+				}
+			} else {
+				resourceResult.Action = actionDeleted
+				extractCascadedResources(&resourceResult, deleteResult.Deleted, "space")
+			}
+
+		case v1beta1.KindSpace:
+			if doc.SpaceDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("space document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			space, _, err := apischeme.NormalizeSpace(*doc.SpaceDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = space.Metadata.Name
+			deleteResult, deleteErr := b.DeleteSpace(space, force, cascade)
+			if deleteErr != nil {
+				if isNotFoundError(deleteErr) {
+					resourceResult.Action = actionNotFound
+				} else {
+					resourceResult.Action = actionFailed
+					resourceResult.Error = deleteErr
+				}
+			} else {
+				resourceResult.Action = actionDeleted
+				extractCascadedResources(&resourceResult, deleteResult.Deleted, "stack")
+			}
+
+		case v1beta1.KindStack:
+			if doc.StackDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("stack document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			stack, _, err := apischeme.NormalizeStack(*doc.StackDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = stack.Metadata.Name
+			deleteResult, deleteErr := b.DeleteStack(stack, force, cascade)
+			if deleteErr != nil {
+				if isNotFoundError(deleteErr) {
+					resourceResult.Action = actionNotFound
+				} else {
+					resourceResult.Action = actionFailed
+					resourceResult.Error = deleteErr
+				}
+			} else {
+				resourceResult.Action = actionDeleted
+				extractCascadedResources(&resourceResult, deleteResult.Deleted, "cell")
+			}
+
+		case v1beta1.KindCell:
+			if doc.CellDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("cell document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			cell, _, err := apischeme.NormalizeCell(*doc.CellDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = cell.Metadata.Name
+			deleteResult, deleteErr := b.DeleteCell(cell)
+			if deleteErr != nil {
+				if isNotFoundError(deleteErr) {
+					resourceResult.Action = actionNotFound
+				} else {
+					resourceResult.Action = actionFailed
+					resourceResult.Error = deleteErr
+				}
+			} else {
+				resourceResult.Action = actionDeleted
+				if deleteResult.ContainersDeleted {
+					// Count containers that were deleted
+					containerCount := len(cell.Spec.Containers)
+					if containerCount > 0 {
+						resourceResult.Details["containers"] = fmt.Sprintf("%d deleted", containerCount)
+					}
+				}
+			}
+
+		case v1beta1.KindContainer:
+			if doc.ContainerDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("container document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			container, _, err := apischeme.NormalizeContainer(*doc.ContainerDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = container.Metadata.Name
+			_, deleteErr := b.DeleteContainer(container)
+			if deleteErr != nil {
+				if isNotFoundError(deleteErr) {
+					resourceResult.Action = actionNotFound
+				} else {
+					resourceResult.Action = actionFailed
+					resourceResult.Error = deleteErr
+				}
+			} else {
+				resourceResult.Action = actionDeleted
+				resourceResult.Details["containers"] = "1 deleted"
+			}
+
+		default:
+			resourceResult.Action = actionFailed
+			resourceResult.Error = fmt.Errorf("%w: %s", errdefs.ErrUnknownKind, doc.Kind)
+			result.Resources = append(result.Resources, resourceResult)
+			continue
+		}
+
+		result.Resources = append(result.Resources, resourceResult)
+	}
+
+	return result, nil
+}
+
+// isNotFoundError checks if an error indicates a resource was not found.
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for specific not found errors
+	if errors.Is(err, errdefs.ErrRealmNotFound) ||
+		errors.Is(err, errdefs.ErrSpaceNotFound) ||
+		errors.Is(err, errdefs.ErrStackNotFound) ||
+		errors.Is(err, errdefs.ErrCellNotFound) {
+		return true
+	}
+
+	// Check error message for "not found" pattern
+	errMsg := strings.ToLower(err.Error())
+	return strings.Contains(errMsg, "not found")
+}
+
+// extractCascadedResources extracts cascaded resource names from the Deleted slice.
+// It looks for entries starting with "prefix:" and adds them to the cascaded list.
+func extractCascadedResources(result *ResourceDeleteResult, deleted []string, prefix string) {
+	for _, item := range deleted {
+		if strings.HasPrefix(item, prefix+":") {
+			// Extract name after "prefix:"
+			name := strings.TrimPrefix(item, prefix+":")
+			result.Cascaded = append(result.Cascaded, name)
+		}
+	}
+}

--- a/internal/controller/delete_documents_test.go
+++ b/internal/controller/delete_documents_test.go
@@ -1,0 +1,664 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDeleteDocuments_ReverseDependencyOrder(t *testing.T) {
+	// Create documents in forward dependency order (should be sorted to reverse)
+	docs := []parser.Document{
+		{
+			Index: 0,
+			Kind:  v1beta1.KindRealm,
+			RealmDoc: &v1beta1.RealmDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindRealm,
+				Metadata: v1beta1.RealmMetadata{
+					Name: "test-realm",
+				},
+				Spec: v1beta1.RealmSpec{
+					Namespace: "test-ns",
+				},
+			},
+		},
+		{
+			Index: 1,
+			Kind:  v1beta1.KindContainer,
+			ContainerDoc: &v1beta1.ContainerDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindContainer,
+				Metadata: v1beta1.ContainerMetadata{
+					Name: "test-container",
+				},
+				Spec: v1beta1.ContainerSpec{
+					ID:      "test-container",
+					RealmID: "test-realm",
+					SpaceID: "test-space",
+					StackID: "test-stack",
+					CellID:  "test-cell",
+					Image:   "test-image",
+					Root:    false,
+					Command: "echo",
+					Args:    []string{"test"},
+				},
+			},
+		},
+	}
+
+	fake := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) {
+			return realm, nil
+		},
+		DeleteRealmFn: func(_ intmodel.Realm) error {
+			return nil
+		},
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return intmodel.Cell{
+				Metadata: intmodel.CellMetadata{Name: "test-cell"},
+				Spec: intmodel.CellSpec{
+					RealmName: "test-realm",
+					SpaceName: "test-space",
+					StackName: "test-stack",
+					Containers: []intmodel.ContainerSpec{
+						{ID: "test-container"},
+					},
+				},
+			}, nil
+		},
+		DeleteContainerFn: func(_ intmodel.Cell, _ string) error {
+			return nil
+		},
+		UpdateCellMetadataFn: func(_ intmodel.Cell) error {
+			return nil
+		},
+	}
+
+	exec := setupTestController(t, fake)
+	result, err := exec.DeleteDocuments(docs, false, false)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(result.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(result.Resources))
+	}
+
+	// Container should be deleted first (index 1, but processed first)
+	if result.Resources[0].Kind != "Container" {
+		t.Errorf("expected first resource to be Container, got %s", result.Resources[0].Kind)
+	}
+	if result.Resources[0].Index != 1 {
+		t.Errorf("expected first resource index to be 1, got %d", result.Resources[0].Index)
+	}
+
+	// Realm should be deleted second (index 0, but processed second)
+	if result.Resources[1].Kind != "Realm" {
+		t.Errorf("expected second resource to be Realm, got %s", result.Resources[1].Kind)
+	}
+	if result.Resources[1].Index != 0 {
+		t.Errorf("expected second resource index to be 0, got %d", result.Resources[1].Index)
+	}
+}
+
+func TestDeleteDocuments_NotFound_Idempotent(t *testing.T) {
+	docs := []parser.Document{
+		{
+			Index: 0,
+			Kind:  v1beta1.KindRealm,
+			RealmDoc: &v1beta1.RealmDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindRealm,
+				Metadata: v1beta1.RealmMetadata{
+					Name: "nonexistent-realm",
+				},
+				Spec: v1beta1.RealmSpec{
+					Namespace: "test-ns",
+				},
+			},
+		},
+	}
+
+	fake := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errdefs.ErrRealmNotFound
+		},
+	}
+
+	exec := setupTestController(t, fake)
+	result, err := exec.DeleteDocuments(docs, false, false)
+	if err != nil {
+		t.Fatalf("expected no error (idempotent), got: %v", err)
+	}
+
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+
+	if result.Resources[0].Action != "not found" {
+		t.Errorf("expected action to be 'not found', got %q", result.Resources[0].Action)
+	}
+
+	if result.Resources[0].Error != nil {
+		t.Errorf("expected no error for not found, got: %v", result.Resources[0].Error)
+	}
+}
+
+func TestDeleteDocuments_Cascade(t *testing.T) {
+	docs := []parser.Document{
+		{
+			Index: 0,
+			Kind:  v1beta1.KindRealm,
+			RealmDoc: &v1beta1.RealmDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindRealm,
+				Metadata: v1beta1.RealmMetadata{
+					Name: "test-realm",
+				},
+				Spec: v1beta1.RealmSpec{
+					Namespace: "test-ns",
+				},
+			},
+		},
+	}
+
+	fake := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) {
+			return realm, nil
+		},
+		ListSpacesFn: func(_ string) ([]intmodel.Space, error) {
+			return []intmodel.Space{
+				{Metadata: intmodel.SpaceMetadata{Name: "test-space"}},
+			}, nil
+		},
+		GetSpaceFn: func(space intmodel.Space) (intmodel.Space, error) {
+			return space, nil
+		},
+		ListStacksFn: func(_, _ string) ([]intmodel.Stack, error) {
+			return nil, nil
+		},
+		DeleteSpaceFn: func(_ intmodel.Space) error {
+			return nil
+		},
+		DeleteRealmFn: func(_ intmodel.Realm) error {
+			return nil
+		},
+	}
+
+	exec := setupTestController(t, fake)
+	result, err := exec.DeleteDocuments(docs, true, false) // cascade=true
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+
+	if result.Resources[0].Action != "deleted" {
+		t.Errorf("expected action to be 'deleted', got %q", result.Resources[0].Action)
+	}
+
+	if len(result.Resources[0].Cascaded) != 1 {
+		t.Errorf("expected 1 cascaded resource, got %d", len(result.Resources[0].Cascaded))
+	}
+
+	if result.Resources[0].Cascaded[0] != "test-space" {
+		t.Errorf("expected cascaded resource to be 'test-space', got %q", result.Resources[0].Cascaded[0])
+	}
+}
+
+func TestDeleteDocuments_Force(t *testing.T) {
+	docs := []parser.Document{
+		{
+			Index: 0,
+			Kind:  v1beta1.KindRealm,
+			RealmDoc: &v1beta1.RealmDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindRealm,
+				Metadata: v1beta1.RealmMetadata{
+					Name: "test-realm",
+				},
+				Spec: v1beta1.RealmSpec{
+					Namespace: "test-ns",
+				},
+			},
+		},
+	}
+
+	fake := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) {
+			return realm, nil
+		},
+		ListSpacesFn: func(_ string) ([]intmodel.Space, error) {
+			return []intmodel.Space{
+				{Metadata: intmodel.SpaceMetadata{Name: "test-space"}},
+			}, nil
+		},
+		DeleteRealmFn: func(_ intmodel.Realm) error {
+			return nil
+		},
+	}
+
+	exec := setupTestController(t, fake)
+	result, err := exec.DeleteDocuments(docs, false, true) // force=true
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+
+	if result.Resources[0].Action != "deleted" {
+		t.Errorf("expected action to be 'deleted', got %q", result.Resources[0].Action)
+	}
+}
+
+func TestDeleteDocuments_ContinueOnFailure(t *testing.T) {
+	docs := []parser.Document{
+		{
+			Index: 0,
+			Kind:  v1beta1.KindRealm,
+			RealmDoc: &v1beta1.RealmDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindRealm,
+				Metadata: v1beta1.RealmMetadata{
+					Name: "test-realm",
+				},
+				Spec: v1beta1.RealmSpec{
+					Namespace: "test-ns",
+				},
+			},
+		},
+		{
+			Index: 1,
+			Kind:  v1beta1.KindSpace,
+			SpaceDoc: &v1beta1.SpaceDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindSpace,
+				Metadata: v1beta1.SpaceMetadata{
+					Name: "test-space",
+				},
+				Spec: v1beta1.SpaceSpec{
+					RealmID: "test-realm",
+				},
+			},
+		},
+	}
+
+	fake := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errors.New("delete failed")
+		},
+		GetSpaceFn: func(space intmodel.Space) (intmodel.Space, error) {
+			return space, nil
+		},
+		ListStacksFn: func(_, _ string) ([]intmodel.Stack, error) {
+			return nil, nil
+		},
+		DeleteSpaceFn: func(_ intmodel.Space) error {
+			return nil
+		},
+	}
+
+	exec := setupTestController(t, fake)
+	result, err := exec.DeleteDocuments(docs, false, false)
+	if err != nil {
+		t.Fatalf("expected no error (continue on failure), got: %v", err)
+	}
+
+	if len(result.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(result.Resources))
+	}
+
+	// Space should be deleted first (reverse dependency order)
+	// First resource should be Space (succeeds)
+	if result.Resources[0].Kind != "Space" {
+		t.Errorf("expected first resource to be Space, got %q", result.Resources[0].Kind)
+	}
+	if result.Resources[0].Action != "deleted" {
+		t.Errorf("expected first resource action to be 'deleted', got %q", result.Resources[0].Action)
+	}
+
+	// Second resource should be Realm (fails)
+	if result.Resources[1].Kind != "Realm" {
+		t.Errorf("expected second resource to be Realm, got %q", result.Resources[1].Kind)
+	}
+	if result.Resources[1].Action != "failed" {
+		t.Errorf("expected second resource action to be 'failed', got %q", result.Resources[1].Action)
+	}
+}
+
+func TestDeleteDocuments_Cell_ContainersDeleted(t *testing.T) {
+	docs := []parser.Document{
+		{
+			Index: 0,
+			Kind:  v1beta1.KindCell,
+			CellDoc: &v1beta1.CellDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindCell,
+				Metadata: v1beta1.CellMetadata{
+					Name: "test-cell",
+				},
+				Spec: v1beta1.CellSpec{
+					RealmID: "test-realm",
+					SpaceID: "test-space",
+					StackID: "test-stack",
+					Containers: []v1beta1.ContainerSpec{
+						{ID: "container1"},
+						{ID: "container2"},
+					},
+				},
+			},
+		},
+	}
+
+	existingCell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "test-cell"},
+		Spec: intmodel.CellSpec{
+			RealmName: "test-realm",
+			SpaceName: "test-space",
+			StackName: "test-stack",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "container1"},
+				{ID: "container2"},
+			},
+		},
+	}
+
+	fake := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return existingCell, nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		DeleteCellFn: func(_ intmodel.Cell) error {
+			return nil
+		},
+	}
+
+	exec := setupTestController(t, fake)
+	result, err := exec.DeleteDocuments(docs, false, false)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+
+	if result.Resources[0].Action != "deleted" {
+		t.Errorf("expected action to be 'deleted', got %q", result.Resources[0].Action)
+	}
+
+	if result.Resources[0].Details["containers"] != "2 deleted" {
+		t.Errorf("expected 2 containers deleted, got %q", result.Resources[0].Details["containers"])
+	}
+}
+
+func TestDeleteDocuments_Container_Deleted(t *testing.T) {
+	docs := []parser.Document{
+		{
+			Index: 0,
+			Kind:  v1beta1.KindContainer,
+			ContainerDoc: &v1beta1.ContainerDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindContainer,
+				Metadata: v1beta1.ContainerMetadata{
+					Name: "test-container",
+				},
+				Spec: v1beta1.ContainerSpec{
+					ID:      "test-container",
+					RealmID: "test-realm",
+					SpaceID: "test-space",
+					StackID: "test-stack",
+					CellID:  "test-cell",
+					Image:   "test-image",
+					Root:    false,
+					Command: "echo",
+					Args:    []string{"test"},
+				},
+			},
+		},
+	}
+
+	fake := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return intmodel.Cell{
+				Metadata: intmodel.CellMetadata{Name: "test-cell"},
+				Spec: intmodel.CellSpec{
+					RealmName: "test-realm",
+					SpaceName: "test-space",
+					StackName: "test-stack",
+					Containers: []intmodel.ContainerSpec{
+						{ID: "test-container"},
+					},
+				},
+			}, nil
+		},
+		DeleteContainerFn: func(_ intmodel.Cell, _ string) error {
+			return nil
+		},
+		UpdateCellMetadataFn: func(_ intmodel.Cell) error {
+			return nil
+		},
+	}
+
+	exec := setupTestController(t, fake)
+	result, err := exec.DeleteDocuments(docs, false, false)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+
+	if result.Resources[0].Action != "deleted" {
+		t.Errorf("expected action to be 'deleted', got %q", result.Resources[0].Action)
+	}
+
+	if result.Resources[0].Details["containers"] != "1 deleted" {
+		t.Errorf("expected 1 container deleted, got %q", result.Resources[0].Details["containers"])
+	}
+}
+
+func TestResourceDeleteResult_MarshalJSON_WithError(t *testing.T) {
+	result := controller.ResourceDeleteResult{
+		Index:  0,
+		Kind:   "Realm",
+		Name:   "test-realm",
+		Action: "failed",
+		Error:  errors.New("delete failed: resource in use"),
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify error field is a string
+	errorVal, ok := unmarshaled["error"]
+	if !ok {
+		t.Fatal("expected 'error' field to be present")
+	}
+
+	errorStr, ok := errorVal.(string)
+	if !ok {
+		t.Fatalf("expected error to be a string, got %T: %v", errorVal, errorVal)
+	}
+
+	if errorStr != "delete failed: resource in use" {
+		t.Errorf("expected error message 'delete failed: resource in use', got %q", errorStr)
+	}
+}
+
+func TestResourceDeleteResult_MarshalJSON_WithoutError(t *testing.T) {
+	result := controller.ResourceDeleteResult{
+		Index:  0,
+		Kind:   "Realm",
+		Name:   "test-realm",
+		Action: "deleted",
+		Error:  nil,
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	// Verify error field is omitted (due to omitempty)
+	if _, ok := unmarshaled["error"]; ok {
+		t.Error("expected 'error' field to be omitted when nil")
+	}
+}
+
+func TestResourceDeleteResult_MarshalJSON_WithCascaded(t *testing.T) {
+	result := controller.ResourceDeleteResult{
+		Index:    1,
+		Kind:     "Realm",
+		Name:     "test-realm",
+		Action:   "deleted",
+		Error:    nil,
+		Cascaded: []string{"test-space", "another-space"},
+		Details: map[string]string{
+			"spaces": "2 deleted",
+		},
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = json.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	cascaded, ok := unmarshaled["cascaded"].([]interface{})
+	if !ok {
+		t.Fatalf("expected cascaded to be an array, got %T", unmarshaled["cascaded"])
+	}
+
+	if len(cascaded) != 2 {
+		t.Errorf("expected 2 cascaded resources, got %d", len(cascaded))
+	}
+}
+
+func TestResourceDeleteResult_MarshalYAML_WithError(t *testing.T) {
+	result := controller.ResourceDeleteResult{
+		Index:  0,
+		Kind:   "Realm",
+		Name:   "test-realm",
+		Action: "failed",
+		Error:  errors.New("delete failed: resource in use"),
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal YAML: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = yaml.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	// Verify error field is a string
+	errorVal, ok := unmarshaled["error"]
+	if !ok {
+		t.Fatal("expected 'error' field to be present")
+	}
+
+	errorStr, ok := errorVal.(string)
+	if !ok {
+		t.Fatalf("expected error to be a string, got %T: %v", errorVal, errorVal)
+	}
+
+	if errorStr != "delete failed: resource in use" {
+		t.Errorf("expected error message 'delete failed: resource in use', got %q", errorStr)
+	}
+
+	// Verify YAML contains the error as a string (may be quoted)
+	yamlStr := string(data)
+	if !strings.Contains(yamlStr, "delete failed: resource in use") {
+		t.Errorf("expected YAML to contain error message, got:\n%s", yamlStr)
+	}
+	if !strings.Contains(yamlStr, "error:") {
+		t.Errorf("expected YAML to contain error field, got:\n%s", yamlStr)
+	}
+}
+
+func TestResourceDeleteResult_MarshalYAML_WithoutError(t *testing.T) {
+	result := controller.ResourceDeleteResult{
+		Index:  0,
+		Kind:   "Realm",
+		Name:   "test-realm",
+		Action: "deleted",
+		Error:  nil,
+	}
+
+	data, err := yaml.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal YAML: %v", err)
+	}
+
+	var unmarshaled map[string]interface{}
+	if err = yaml.Unmarshal(data, &unmarshaled); err != nil {
+		t.Fatalf("failed to unmarshal YAML: %v", err)
+	}
+
+	// Verify error field is omitted (due to omitempty)
+	if _, ok := unmarshaled["error"]; ok {
+		t.Error("expected 'error' field to be omitted when nil")
+	}
+
+	// Verify YAML doesn't contain error field
+	yamlStr := string(data)
+	if strings.Contains(yamlStr, "error:") {
+		t.Errorf("expected YAML to not contain error field, got:\n%s", yamlStr)
+	}
+}

--- a/internal/controller/documents.go
+++ b/internal/controller/documents.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"sort"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// SortDocumentsByKind sorts documents by kind order.
+// If reverse is true, sorts in reverse dependency order (Container → Cell → Stack → Space → Realm).
+// If reverse is false, sorts in dependency order (Realm → Space → Stack → Cell → Container).
+// Within the same kind, documents are sorted by their original index.
+func SortDocumentsByKind(docs []parser.Document, reverse bool) []parser.Document {
+	// Create a copy to avoid modifying the original
+	sorted := make([]parser.Document, len(docs))
+	copy(sorted, docs)
+
+	// Define kind order
+	kindOrder := map[v1beta1.Kind]int{
+		v1beta1.KindRealm:     1,
+		v1beta1.KindSpace:     2,
+		v1beta1.KindStack:     3,
+		v1beta1.KindCell:      4,
+		v1beta1.KindContainer: 5,
+	}
+
+	// Sort by kind order, then by original index
+	sort.Slice(sorted, func(i, j int) bool {
+		orderI := kindOrder[sorted[i].Kind]
+		orderJ := kindOrder[sorted[j].Kind]
+		if orderI != orderJ {
+			if reverse {
+				return orderI > orderJ // Descending order for reverse
+			}
+			return orderI < orderJ // Ascending order for forward
+		}
+		return sorted[i].Index < sorted[j].Index
+	})
+
+	return sorted
+}

--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -81,7 +81,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		// Stop container
-		_, err = r.ctrClient.StopContainer(r.ctx, containerID, ctr.StopContainerOptions{})
+		_, err = r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{})
 		if err != nil {
 			r.logger.WarnContext(
 				r.ctx,
@@ -92,7 +92,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		// Delete container
-		err = r.ctrClient.DeleteContainer(r.ctx, containerID, ctr.ContainerDeleteOptions{
+		err = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
 		})
 		if err != nil {
@@ -111,7 +111,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to build root container containerd ID: %w", err)
 	}
 
-	_, err = r.ctrClient.StopContainer(r.ctx, rootContainerID, ctr.StopContainerOptions{Force: true})
+	_, err = r.ctrClient.StopContainer(rootContainerID, ctr.StopContainerOptions{Force: true})
 	if err != nil {
 		r.logger.WarnContext(
 			r.ctx,
@@ -121,7 +121,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		)
 	}
 
-	err = r.ctrClient.DeleteContainer(r.ctx, rootContainerID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(rootContainerID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {

--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -1,0 +1,159 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
+)
+
+// RecreateCell stops all containers in the cell, deletes them, and recreates the cell
+// with the new root container spec. This is used when the root container spec changes
+// (image, command, or args).
+func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
+	// Get existing cell
+	existing, err := r.GetCell(desired)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
+	}
+
+	// Stop all containers in the cell
+	if stopErr := r.StopCell(existing); stopErr != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"failed to stop cell containers, continuing with deletion",
+			"cell", existing.Metadata.Name,
+			"error", stopErr,
+		)
+	}
+
+	// Delete all containers
+	if connectErr := r.ensureClientConnected(); connectErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, connectErr)
+	}
+
+	cellID := existing.Spec.ID
+	if cellID == "" {
+		cellID = existing.Metadata.Name
+	}
+
+	realmName := strings.TrimSpace(existing.Spec.RealmName)
+	spaceName := strings.TrimSpace(existing.Spec.SpaceName)
+	stackName := strings.TrimSpace(existing.Spec.StackName)
+
+	// Get realm to access namespace
+	lookupRealm := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: realmName,
+		},
+	}
+	internalRealm, err := r.GetRealm(lookupRealm)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to get realm: %w", err)
+	}
+
+	r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
+
+	// Delete all containers in the cell
+	for _, containerSpec := range existing.Spec.Containers {
+		containerID := containerSpec.ContainerdID
+		if containerID == "" {
+			continue
+		}
+
+		// Stop container
+		_, err = r.ctrClient.StopContainer(r.ctx, containerID, ctr.StopContainerOptions{})
+		if err != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to stop container, continuing with deletion",
+				"container", containerID,
+				"error", err,
+			)
+		}
+
+		// Delete container
+		err = r.ctrClient.DeleteContainer(r.ctx, containerID, ctr.ContainerDeleteOptions{
+			SnapshotCleanup: true,
+		})
+		if err != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to delete container, continuing",
+				"container", containerID,
+				"error", err,
+			)
+		}
+	}
+
+	// Delete root container
+	rootContainerID, err := naming.BuildRootContainerdID(spaceName, stackName, cellID)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to build root container containerd ID: %w", err)
+	}
+
+	_, err = r.ctrClient.StopContainer(r.ctx, rootContainerID, ctr.StopContainerOptions{Force: true})
+	if err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"failed to stop root container, continuing with deletion",
+			"container", rootContainerID,
+			"error", err,
+		)
+	}
+
+	err = r.ctrClient.DeleteContainer(r.ctx, rootContainerID, ctr.ContainerDeleteOptions{
+		SnapshotCleanup: true,
+	})
+	if err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"failed to delete root container, continuing",
+			"container", rootContainerID,
+			"error", err,
+		)
+	}
+
+	// Clear containerd IDs from desired cell so containers will be recreated
+	for i := range desired.Spec.Containers {
+		desired.Spec.Containers[i].ContainerdID = ""
+	}
+
+	// Preserve existing metadata and status where appropriate
+	desired.Status.CgroupPath = existing.Status.CgroupPath
+
+	// Recreate cell containers (this will create root container and all child containers)
+	_, err = r.createCellContainers(&desired)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to recreate cell containers: %w", err)
+	}
+
+	// Update cell state
+	desired.Status.State = intmodel.CellStateReady
+
+	// Update metadata
+	if updateErr := r.UpdateCellMetadata(desired); updateErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, updateErr)
+	}
+
+	return desired, nil
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -32,6 +32,7 @@ type Runner interface {
 	ListRealms() ([]intmodel.Realm, error)
 	CreateRealm(realm intmodel.Realm) (intmodel.Realm, error)
 	EnsureRealm(realm intmodel.Realm) (intmodel.Realm, error)
+	UpdateRealm(realm intmodel.Realm) (intmodel.Realm, error)
 	ExistsRealmContainerdNamespace(namespace string) (bool, error)
 	DeleteRealm(realm intmodel.Realm) error
 
@@ -39,6 +40,7 @@ type Runner interface {
 	ListSpaces(realmName string) ([]intmodel.Space, error)
 	CreateSpace(space intmodel.Space) (intmodel.Space, error)
 	EnsureSpace(space intmodel.Space) (intmodel.Space, error)
+	UpdateSpace(space intmodel.Space) (intmodel.Space, error)
 	ExistsSpaceCNIConfig(space intmodel.Space) (bool, error)
 	DeleteSpace(space intmodel.Space) error
 
@@ -56,6 +58,9 @@ type Runner interface {
 	DeleteContainer(cell intmodel.Cell, containerID string) error
 	CreateContainer(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
 	EnsureContainer(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
+	UpdateCell(cell intmodel.Cell) (intmodel.Cell, error)
+	RecreateCell(cell intmodel.Cell) (intmodel.Cell, error)
+	UpdateContainer(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
 	UpdateCellMetadata(cell intmodel.Cell) error
 	ExistsCellRootContainer(cell intmodel.Cell) (bool, error)
 	DeleteCell(cell intmodel.Cell) error
@@ -64,6 +69,7 @@ type Runner interface {
 	ListStacks(realmName, spaceName string) ([]intmodel.Stack, error)
 	CreateStack(stack intmodel.Stack) (intmodel.Stack, error)
 	EnsureStack(stack intmodel.Stack) (intmodel.Stack, error)
+	UpdateStack(stack intmodel.Stack) (intmodel.Stack, error)
 	DeleteStack(stack intmodel.Stack) error
 
 	ExistsCgroup(doc any) (bool, error)

--- a/internal/controller/runner/update_cell.go
+++ b/internal/controller/runner/update_cell.go
@@ -1,0 +1,177 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// UpdateCell updates an existing cell with new metadata and container changes.
+// It handles:
+// - Metadata updates (labels)
+// - Container additions (containers in desired but not in actual)
+// - Container updates (containers in both, with spec changes)
+// - Container removals (orphans: containers in actual but not in desired)
+//
+// Breaking changes (root container spec changes, parent associations) should be rejected before calling this method.
+func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
+	// Get existing cell
+	existing, err := r.GetCell(desired)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
+	}
+
+	// Update compatible metadata fields
+	existing.Metadata.Labels = desired.Metadata.Labels
+
+	// Build maps of desired and actual containers by ID
+	desiredContainers := make(map[string]*intmodel.ContainerSpec)
+	actualContainers := make(map[string]*intmodel.ContainerSpec)
+
+	for i := range desired.Spec.Containers {
+		container := &desired.Spec.Containers[i]
+		if container.ID != "" {
+			desiredContainers[container.ID] = container
+		}
+	}
+
+	for i := range existing.Spec.Containers {
+		container := &existing.Spec.Containers[i]
+		if container.ID != "" {
+			actualContainers[container.ID] = container
+		}
+	}
+
+	// Handle orphan containers (in actual but not in desired)
+	for id := range actualContainers {
+		if _, exists := desiredContainers[id]; !exists {
+			// Container should be removed
+			if stopErr := r.StopContainer(existing, id); stopErr != nil {
+				r.logger.WarnContext(
+					r.ctx,
+					"failed to stop container for removal, continuing",
+					"cell", existing.Metadata.Name,
+					"container", id,
+					"error", stopErr,
+				)
+			}
+			if deleteErr := r.DeleteContainer(existing, id); deleteErr != nil {
+				r.logger.WarnContext(
+					r.ctx,
+					"failed to delete container for removal, continuing",
+					"cell", existing.Metadata.Name,
+					"container", id,
+					"error", deleteErr,
+				)
+			}
+		}
+	}
+
+	// Update existing cell's containers list to match desired
+	// Preserve root container and existing containerd IDs where possible
+	newContainers := make([]intmodel.ContainerSpec, 0, len(desired.Spec.Containers))
+	for _, desiredContainer := range desired.Spec.Containers {
+		if actualContainer, exists := actualContainers[desiredContainer.ID]; exists {
+			// Container exists, preserve containerd ID but update spec
+			desiredContainer.ContainerdID = actualContainer.ContainerdID
+			// Check if container spec changed (image, command, args) - if so, recreate
+			if containerSpecChanged(&desiredContainer, actualContainer) {
+				// Stop and delete old container
+				if stopErr := r.StopContainer(existing, desiredContainer.ID); stopErr != nil {
+					r.logger.WarnContext(
+						r.ctx,
+						"failed to stop container for update, continuing",
+						"cell", existing.Metadata.Name,
+						"container", desiredContainer.ID,
+						"error", stopErr,
+					)
+				}
+				if deleteErr := r.DeleteContainer(existing, desiredContainer.ID); deleteErr != nil {
+					r.logger.WarnContext(
+						r.ctx,
+						"failed to delete container for update, continuing",
+						"cell", existing.Metadata.Name,
+						"container", desiredContainer.ID,
+						"error", deleteErr,
+					)
+				}
+				// Clear containerd ID so it will be recreated
+				desiredContainer.ContainerdID = ""
+			}
+		}
+		// Ensure container has proper parent references
+		if desiredContainer.RealmName == "" {
+			desiredContainer.RealmName = existing.Spec.RealmName
+		}
+		if desiredContainer.SpaceName == "" {
+			desiredContainer.SpaceName = existing.Spec.SpaceName
+		}
+		if desiredContainer.StackName == "" {
+			desiredContainer.StackName = existing.Spec.StackName
+		}
+		if desiredContainer.CellName == "" {
+			desiredContainer.CellName = existing.Spec.ID
+			if desiredContainer.CellName == "" {
+				desiredContainer.CellName = existing.Metadata.Name
+			}
+		}
+		newContainers = append(newContainers, desiredContainer)
+	}
+
+	// Update cell with new containers list
+	existing.Spec.Containers = newContainers
+	existing.Spec.RootContainerID = desired.Spec.RootContainerID
+
+	// Ensure all containers exist (will create missing ones, update existing ones)
+	if connectErr := r.ensureClientConnected(); connectErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, connectErr)
+	}
+
+	_, ensureErr := r.ensureCellContainers(&existing)
+	if ensureErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to ensure cell containers: %w", ensureErr)
+	}
+
+	// Update metadata
+	if updateErr := r.UpdateCellMetadata(existing); updateErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, updateErr)
+	}
+
+	return existing, nil
+}
+
+// containerSpecChanged checks if a container spec has breaking changes (image, command, args).
+func containerSpecChanged(desired, actual *intmodel.ContainerSpec) bool {
+	return desired.Image != actual.Image ||
+		desired.Command != actual.Command ||
+		!stringSlicesEqual(desired.Args, actual.Args)
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return true // Different length means changed
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return true // Different content means changed
+		}
+	}
+	return false // Same content means unchanged
+}

--- a/internal/controller/runner/update_cell.go
+++ b/internal/controller/runner/update_cell.go
@@ -166,12 +166,12 @@ func containerSpecChanged(desired, actual *intmodel.ContainerSpec) bool {
 
 func stringSlicesEqual(a, b []string) bool {
 	if len(a) != len(b) {
-		return true // Different length means changed
+		return false // Different length means not equal
 	}
 	for i := range a {
 		if a[i] != b[i] {
-			return true // Different content means changed
+			return false // Different content means not equal
 		}
 	}
-	return false // Same content means unchanged
+	return true // Same content means equal
 }

--- a/internal/controller/runner/update_container.go
+++ b/internal/controller/runner/update_container.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// UpdateContainer updates an existing container within a cell.
+// If the container spec has breaking changes (image, command, args), it will
+// stop, delete, and recreate the container. Otherwise, it updates the container spec in metadata.
+func (r *Exec) UpdateContainer(cell intmodel.Cell, desiredContainer intmodel.ContainerSpec) (intmodel.Cell, error) {
+	// Get existing cell
+	existing, err := r.GetCell(cell)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
+	}
+
+	// Find the container in the cell
+	var actualContainer *intmodel.ContainerSpec
+	containerIndex := -1
+	for i := range existing.Spec.Containers {
+		if existing.Spec.Containers[i].ID == desiredContainer.ID {
+			actualContainer = &existing.Spec.Containers[i]
+			containerIndex = i
+			break
+		}
+	}
+
+	if actualContainer == nil {
+		// Container doesn't exist, create it
+		return r.CreateContainer(cell, desiredContainer)
+	}
+
+	// Check if container spec has breaking changes
+	if containerSpecChanged(&desiredContainer, actualContainer) {
+		// Breaking change: stop, delete, and recreate
+		if stopErr := r.StopContainer(existing, desiredContainer.ID); stopErr != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to stop container for update, continuing",
+				"cell", existing.Metadata.Name,
+				"container", desiredContainer.ID,
+				"error", stopErr,
+			)
+		}
+
+		if deleteErr := r.DeleteContainer(existing, desiredContainer.ID); deleteErr != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to delete container for update, continuing",
+				"cell", existing.Metadata.Name,
+				"container", desiredContainer.ID,
+				"error", deleteErr,
+			)
+		}
+
+		// Clear containerd ID so container will be recreated
+		desiredContainer.ContainerdID = ""
+	}
+
+	// Ensure container has proper parent references
+	if desiredContainer.RealmName == "" {
+		desiredContainer.RealmName = existing.Spec.RealmName
+	}
+	if desiredContainer.SpaceName == "" {
+		desiredContainer.SpaceName = existing.Spec.SpaceName
+	}
+	if desiredContainer.StackName == "" {
+		desiredContainer.StackName = existing.Spec.StackName
+	}
+	if desiredContainer.CellName == "" {
+		desiredContainer.CellName = existing.Spec.ID
+		if desiredContainer.CellName == "" {
+			desiredContainer.CellName = existing.Metadata.Name
+		}
+	}
+
+	// Update container in cell's containers list
+	if containerIndex >= 0 {
+		// Preserve containerd ID if not cleared
+		if desiredContainer.ContainerdID == "" && actualContainer.ContainerdID != "" {
+			desiredContainer.ContainerdID = actualContainer.ContainerdID
+		}
+		existing.Spec.Containers[containerIndex] = desiredContainer
+	} else {
+		// Add new container
+		existing.Spec.Containers = append(existing.Spec.Containers, desiredContainer)
+	}
+
+	// Ensure container exists (will create if needed)
+	if connectErr := r.ensureClientConnected(); connectErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, connectErr)
+	}
+
+	_, ensureErr := r.ensureCellContainers(&existing)
+	if ensureErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to ensure container: %w", ensureErr)
+	}
+
+	// Update metadata
+	if updateErr := r.UpdateCellMetadata(existing); updateErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, updateErr)
+	}
+
+	return existing, nil
+}

--- a/internal/controller/runner/update_realm.go
+++ b/internal/controller/runner/update_realm.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// UpdateRealm updates an existing realm with new metadata and compatible spec fields.
+// It only updates fields that are backward-compatible (labels, registry credentials).
+// Breaking changes (name, namespace) should be rejected before calling this method.
+func (r *Exec) UpdateRealm(desired intmodel.Realm) (intmodel.Realm, error) {
+	// Get existing realm
+	existing, err := r.GetRealm(desired)
+	if err != nil {
+		return intmodel.Realm{}, fmt.Errorf("%w: %w", errdefs.ErrGetRealm, err)
+	}
+
+	// Update compatible fields
+	existing.Metadata.Labels = desired.Metadata.Labels
+	existing.Spec.RegistryCredentials = desired.Spec.RegistryCredentials
+
+	// Update metadata file
+	if updateErr := r.UpdateRealmMetadata(existing); updateErr != nil {
+		return intmodel.Realm{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateRealmMetadata, updateErr)
+	}
+
+	return existing, nil
+}

--- a/internal/controller/runner/update_space.go
+++ b/internal/controller/runner/update_space.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// UpdateSpace updates an existing space with new metadata and compatible spec fields.
+// It only updates fields that are backward-compatible (labels).
+// Breaking changes (name, realm association, CNI config path) should be rejected before calling this method.
+func (r *Exec) UpdateSpace(desired intmodel.Space) (intmodel.Space, error) {
+	// Get existing space
+	existing, err := r.GetSpace(desired)
+	if err != nil {
+		return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrGetSpace, err)
+	}
+
+	// Update compatible fields
+	existing.Metadata.Labels = desired.Metadata.Labels
+	// Note: CNIConfigPath is not updated as it's a breaking change
+
+	// Update metadata file
+	if updateErr := r.UpdateSpaceMetadata(existing); updateErr != nil {
+		return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateSpaceMetadata, updateErr)
+	}
+
+	return existing, nil
+}

--- a/internal/controller/runner/update_stack.go
+++ b/internal/controller/runner/update_stack.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// UpdateStack updates an existing stack with new metadata and compatible spec fields.
+// It only updates fields that are backward-compatible (labels, ID).
+// Breaking changes (name, realm/space association) should be rejected before calling this method.
+func (r *Exec) UpdateStack(desired intmodel.Stack) (intmodel.Stack, error) {
+	// Get existing stack
+	existing, err := r.GetStack(desired)
+	if err != nil {
+		return intmodel.Stack{}, fmt.Errorf("%w: %w", errdefs.ErrGetStack, err)
+	}
+
+	// Update compatible fields
+	existing.Metadata.Labels = desired.Metadata.Labels
+	if desired.Spec.ID != "" {
+		existing.Spec.ID = desired.Spec.ID
+	}
+
+	// Update metadata file
+	if updateErr := r.UpdateStackMetadata(existing); updateErr != nil {
+		return intmodel.Stack{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateStackMetadata, updateErr)
+	}
+
+	return existing, nil
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `kuke apply` and file-based `kuke delete -f`, with YAML parsing/validation, dependency-ordered apply/delete, diff/reconcile logic, and tests.
> 
> - **CLI**:
>   - **Apply**: New `kuke apply -f` with optional `--output` json|yaml; registers in root.
>   - **Delete**: `kuke delete -f` supports stdin/files, `--cascade`, `--force`, and `--output`.
>   - **Shared utils**: Centralized controller wiring, file/STDIN reading, YAML parse/validate, and JSON/YAML printing.
> - **Controller**:
>   - **Apply/Delete**: Process multi-doc YAML in dependency order (apply) and reverse (delete); return structured results.
>   - **Diff/Reconcile**: Added diffing for Realm/Space/Stack/Cell/Container and reconcile/update paths (including cell recreate on root changes).
>   - **Runner**: New update/recreate methods for realm/space/stack/cell/container.
> - **Parser**:
>   - YAML document splitter, kind detection, strict per-kind validation (v1beta1).
> - **Tests**:
>   - Extensive unit tests for CLI, parser, controller; e2e for apply and delete -f.
> - **Build**:
>   - `make test` skips `e2e` by default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc72a51e7e96eb47d0c4506c17c837e34919ec94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->