### PR TITLE
refactor: cni package + tests

### DIFF
--- a/internal/cni/bootstrap.go
+++ b/internal/cni/bootstrap.go
@@ -18,22 +18,6 @@ package cni
 
 import "os"
 
-// BootstrapReport captures CNI environment checks and actions.
-type BootstrapReport struct {
-	CniConfigDir        string
-	CniCacheDir         string
-	CniBinDir           string
-	ConfigDirExistsPre  bool
-	CacheDirExistsPre   bool
-	BinDirExistsPre     bool
-	ConfigDirCreated    bool
-	CacheDirCreated     bool
-	BinDirCreated       bool
-	ConfigDirExistsPost bool
-	CacheDirExistsPost  bool
-	BinDirExistsPost    bool
-}
-
 // BootstrapCNI ensures required directories exist and the bin directory is present.
 // If any directory is empty, the defaults from config.go are used.
 func BootstrapCNI(cfgDir, cacheDir, binDir string) (BootstrapReport, error) {

--- a/internal/cni/bootstrap_test.go
+++ b/internal/cni/bootstrap_test.go
@@ -1,0 +1,271 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cni "github.com/eminwux/kukeon/internal/cni"
+)
+
+func TestBootstrapCNI(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfgDir     string
+		cacheDir   string
+		binDir     string
+		setup      func(t *testing.T, baseDir string) (string, string, string)
+		wantReport func(t *testing.T, report cni.BootstrapReport)
+		wantErr    bool
+	}{
+		{
+			name: "success with all directories provided",
+			setup: func(_ *testing.T, baseDir string) (string, string, string) {
+				cfgDir := filepath.Join(baseDir, "config")
+				cacheDir := filepath.Join(baseDir, "cache")
+				binDir := filepath.Join(baseDir, "bin")
+				return cfgDir, cacheDir, binDir
+			},
+			wantReport: func(t *testing.T, report cni.BootstrapReport) {
+				// Verify directories were created
+				if !report.ConfigDirExistsPost {
+					t.Error("ConfigDirExistsPost = false, want true")
+				}
+				if !report.CacheDirExistsPost {
+					t.Error("CacheDirExistsPost = false, want true")
+				}
+				if !report.BinDirExistsPost {
+					t.Error("BinDirExistsPost = false, want true")
+				}
+
+				// Verify report fields
+				if report.CniConfigDir == "" {
+					t.Error("CniConfigDir is empty")
+				}
+				if report.CniCacheDir == "" {
+					t.Error("CniCacheDir is empty")
+				}
+				if report.CniBinDir == "" {
+					t.Error("CniBinDir is empty")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with empty directories (uses defaults)",
+			setup: func(_ *testing.T, _ string) (string, string, string) {
+				return "", "", ""
+			},
+			wantReport: func(t *testing.T, report cni.BootstrapReport) {
+				// Verify defaults are used
+				if report.CniConfigDir != "/opt/cni/net.d" {
+					t.Errorf("CniConfigDir = %q, want %q", report.CniConfigDir, "/opt/cni/net.d")
+				}
+				if report.CniCacheDir != "/opt/cni/cache" {
+					t.Errorf("CniCacheDir = %q, want %q", report.CniCacheDir, "/opt/cni/cache")
+				}
+				if report.CniBinDir != "/opt/cni/bin" {
+					t.Errorf("CniBinDir = %q, want %q", report.CniBinDir, "/opt/cni/bin")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "creates missing directories",
+			setup: func(_ *testing.T, baseDir string) (string, string, string) {
+				cfgDir := filepath.Join(baseDir, "config")
+				cacheDir := filepath.Join(baseDir, "cache")
+				binDir := filepath.Join(baseDir, "bin")
+				return cfgDir, cacheDir, binDir
+			},
+			wantReport: func(t *testing.T, report cni.BootstrapReport) {
+				// Verify directories were created
+				if !report.ConfigDirCreated {
+					t.Error("ConfigDirCreated = false, want true")
+				}
+				if !report.CacheDirCreated {
+					t.Error("CacheDirCreated = false, want true")
+				}
+				if !report.BinDirCreated {
+					t.Error("BinDirCreated = false, want true")
+				}
+
+				// Verify pre-state was false
+				if report.ConfigDirExistsPre {
+					t.Error("ConfigDirExistsPre = true, want false")
+				}
+				if report.CacheDirExistsPre {
+					t.Error("CacheDirExistsPre = true, want false")
+				}
+				if report.BinDirExistsPre {
+					t.Error("BinDirExistsPre = true, want false")
+				}
+
+				// Verify post-state is true
+				if !report.ConfigDirExistsPost {
+					t.Error("ConfigDirExistsPost = false, want true")
+				}
+				if !report.CacheDirExistsPost {
+					t.Error("CacheDirExistsPost = false, want true")
+				}
+				if !report.BinDirExistsPost {
+					t.Error("BinDirExistsPost = false, want true")
+				}
+
+				// Verify directories actually exist
+				if _, err := os.Stat(report.CniConfigDir); err != nil {
+					t.Errorf("config directory does not exist: %v", err)
+				}
+				if _, err := os.Stat(report.CniCacheDir); err != nil {
+					t.Errorf("cache directory does not exist: %v", err)
+				}
+				if _, err := os.Stat(report.CniBinDir); err != nil {
+					t.Errorf("bin directory does not exist: %v", err)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "reports correct pre/post states when directories exist",
+			setup: func(t *testing.T, baseDir string) (string, string, string) {
+				cfgDir := filepath.Join(baseDir, "config")
+				cacheDir := filepath.Join(baseDir, "cache")
+				binDir := filepath.Join(baseDir, "bin")
+
+				// Create directories before bootstrap
+				if err := os.MkdirAll(cfgDir, 0o750); err != nil {
+					t.Fatalf("failed to create config dir: %v", err)
+				}
+				if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+					t.Fatalf("failed to create cache dir: %v", err)
+				}
+				if err := os.MkdirAll(binDir, 0o750); err != nil {
+					t.Fatalf("failed to create bin dir: %v", err)
+				}
+
+				return cfgDir, cacheDir, binDir
+			},
+			wantReport: func(t *testing.T, report cni.BootstrapReport) {
+				// Verify pre-state was true
+				if !report.ConfigDirExistsPre {
+					t.Error("ConfigDirExistsPre = false, want true")
+				}
+				if !report.CacheDirExistsPre {
+					t.Error("CacheDirExistsPre = false, want true")
+				}
+				if !report.BinDirExistsPre {
+					t.Error("BinDirExistsPre = false, want true")
+				}
+
+				// Verify directories were not created
+				if report.ConfigDirCreated {
+					t.Error("ConfigDirCreated = true, want false")
+				}
+				if report.CacheDirCreated {
+					t.Error("CacheDirCreated = true, want false")
+				}
+				if report.BinDirCreated {
+					t.Error("BinDirCreated = true, want false")
+				}
+
+				// Verify post-state is true
+				if !report.ConfigDirExistsPost {
+					t.Error("ConfigDirExistsPost = false, want true")
+				}
+				if !report.CacheDirExistsPost {
+					t.Error("CacheDirExistsPost = false, want true")
+				}
+				if !report.BinDirExistsPost {
+					t.Error("BinDirExistsPost = false, want true")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "idempotent (can be called multiple times)",
+			setup: func(_ *testing.T, baseDir string) (string, string, string) {
+				cfgDir := filepath.Join(baseDir, "config")
+				cacheDir := filepath.Join(baseDir, "cache")
+				binDir := filepath.Join(baseDir, "bin")
+				return cfgDir, cacheDir, binDir
+			},
+			wantReport: func(t *testing.T, report cni.BootstrapReport) {
+				// First call should create directories
+				if !report.ConfigDirCreated {
+					t.Error("first call: ConfigDirCreated = false, want true")
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseDir := t.TempDir()
+			cfgDir, cacheDir, binDir := tt.setup(t, baseDir)
+
+			report, err := cni.BootstrapCNI(cfgDir, cacheDir, binDir)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("BootstrapCNI() error = nil, want error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("BootstrapCNI() error = %v, want nil", err)
+			}
+
+			if tt.wantReport != nil {
+				tt.wantReport(t, report)
+			}
+
+			// Test idempotency for the "idempotent" test case
+			if tt.name == "idempotent (can be called multiple times)" {
+				report2, err2 := cni.BootstrapCNI(cfgDir, cacheDir, binDir)
+				if err2 != nil {
+					t.Fatalf("second BootstrapCNI() call error = %v, want nil", err2)
+				}
+
+				// Second call should not create directories
+				if report2.ConfigDirCreated {
+					t.Error("second call: ConfigDirCreated = true, want false")
+				}
+				if report2.CacheDirCreated {
+					t.Error("second call: CacheDirCreated = true, want false")
+				}
+				if report2.BinDirCreated {
+					t.Error("second call: BinDirCreated = true, want false")
+				}
+
+				// Pre-state should be true on second call
+				if !report2.ConfigDirExistsPre {
+					t.Error("second call: ConfigDirExistsPre = false, want true")
+				}
+				if !report2.CacheDirExistsPre {
+					t.Error("second call: CacheDirExistsPre = false, want true")
+				}
+				if !report2.BinDirExistsPre {
+					t.Error("second call: BinDirExistsPre = false, want true")
+				}
+			}
+		})
+	}
+}

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -18,16 +18,6 @@ package cni
 
 import "encoding/json"
 
-// NetworkConfig represents the desired parameters for creating a CNI network.
-type NetworkConfig struct {
-	// Name is the CNI network name and the filename (without extension).
-	Name string
-	// BridgeName is the bridge device name. Defaults to "cni0" when empty.
-	BridgeName string
-	// SubnetCIDR is the IPAM subnet CIDR. Defaults to "10.88.0.0/16" when empty.
-	SubnetCIDR string
-}
-
 // NewCNINetworkConfig builds a NetworkConfig with sensible defaults.
 func NewCNINetworkConfig(name string) NetworkConfig {
 	return NetworkConfig{
@@ -35,47 +25,6 @@ func NewCNINetworkConfig(name string) NetworkConfig {
 		BridgeName: name,
 		SubnetCIDR: defaultSubnetCIDR,
 	}
-}
-
-const (
-	defaultCniConfDir  = "/opt/cni/net.d"
-	defaultCniBinDir   = "/opt/cni/bin"
-	defaultCniCacheDir = "/opt/cni/cache"
-	defaultCNIVersion  = "0.4.0"
-	defaultBridgeName  = "cni0"
-	defaultSubnetCIDR  = "10.88.0.0/16"
-)
-
-// CNINetworksDir is the standard directory where CNI stores network state and IPAM allocations.
-// This is the default location used by CNI plugins for host-local IPAM.
-const CNINetworksDir = "/var/lib/cni/networks"
-
-type ConflistModel struct {
-	CNIVersion string        `json:"cniVersion"`
-	Name       string        `json:"name"`
-	Plugins    []interface{} `json:"plugins"`
-}
-
-type BridgePluginModel struct {
-	Type      string           `json:"type"`
-	Bridge    string           `json:"bridge"`
-	IsGateway bool             `json:"isGateway"`
-	IPMasq    bool             `json:"ipMasq"`
-	IPAM      BridgeIPAMConfig `json:"ipam"`
-}
-
-type BridgeIPAMConfig struct {
-	Type   string                `json:"type"`
-	Ranges [][]map[string]string `json:"ranges"`
-	Routes []RouteModel          `json:"routes"`
-}
-
-type RouteModel struct {
-	Dst string `json:"dst"`
-}
-
-type LoopbackPluginModel struct {
-	Type string `json:"type"`
 }
 
 // BuildDefaultConflist generates a default conflist JSON using provided parameters.

--- a/internal/cni/config_test.go
+++ b/internal/cni/config_test.go
@@ -1,0 +1,269 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	cni "github.com/eminwux/kukeon/internal/cni"
+)
+
+func TestNewCNINetworkConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkName string
+		wantBridge  string
+		wantSubnet  string
+	}{
+		{
+			name:        "success with name provided",
+			networkName: "test-network",
+			wantBridge:  "test-network",
+			wantSubnet:  "10.88.0.0/16",
+		},
+		{
+			name:        "success with empty name",
+			networkName: "",
+			wantBridge:  "",
+			wantSubnet:  "10.88.0.0/16",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := cni.NewCNINetworkConfig(tt.networkName)
+
+			if cfg.Name != tt.networkName {
+				t.Errorf("NewCNINetworkConfig() name = %q, want %q", cfg.Name, tt.networkName)
+			}
+
+			if cfg.BridgeName != tt.wantBridge {
+				t.Errorf("NewCNINetworkConfig() bridgeName = %q, want %q", cfg.BridgeName, tt.wantBridge)
+			}
+
+			if cfg.SubnetCIDR != tt.wantSubnet {
+				t.Errorf("NewCNINetworkConfig() subnetCIDR = %q, want %q", cfg.SubnetCIDR, tt.wantSubnet)
+			}
+		})
+	}
+}
+
+func TestBuildDefaultConflist(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkName string
+		bridge      string
+		subnet      string
+		validate    func(t *testing.T, data []byte)
+	}{
+		{
+			name:        "success with all parameters",
+			networkName: "test-network",
+			bridge:      "test-bridge",
+			subnet:      "10.1.0.0/16",
+			validate: func(t *testing.T, data []byte) {
+				var conf cni.ConflistModel
+				if err := json.Unmarshal(data, &conf); err != nil {
+					t.Fatalf("failed to unmarshal JSON: %v", err)
+				}
+
+				// Verify CNI version
+				if conf.CNIVersion != "0.4.0" {
+					t.Errorf("CNIVersion = %q, want %q", conf.CNIVersion, "0.4.0")
+				}
+
+				// Verify name
+				if conf.Name != "test-network" {
+					t.Errorf("name = %q, want %q", conf.Name, "test-network")
+				}
+
+				// Verify plugins array
+				if len(conf.Plugins) < 2 {
+					t.Fatalf("plugins length = %d, want at least 2", len(conf.Plugins))
+				}
+
+				// Verify bridge plugin
+				bridgePlugin, ok := conf.Plugins[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("first plugin is not a map")
+				}
+
+				if bridgePlugin["type"] != "bridge" {
+					t.Errorf("bridge plugin type = %v, want %q", bridgePlugin["type"], "bridge")
+				}
+
+				if bridgePlugin["bridge"] != "test-bridge" {
+					t.Errorf("bridge = %v, want %q", bridgePlugin["bridge"], "test-bridge")
+				}
+
+				if bridgePlugin["isGateway"] != true {
+					t.Errorf("isGateway = %v, want true", bridgePlugin["isGateway"])
+				}
+
+				if bridgePlugin["ipMasq"] != true {
+					t.Errorf("ipMasq = %v, want true", bridgePlugin["ipMasq"])
+				}
+
+				// Verify IPAM configuration
+				ipam, ok := bridgePlugin["ipam"].(map[string]interface{})
+				if !ok {
+					t.Fatal("ipam is not a map")
+				}
+
+				if ipam["type"] != "host-local" {
+					t.Errorf("ipam type = %v, want %q", ipam["type"], "host-local")
+				}
+
+				ranges, ok := ipam["ranges"].([]interface{})
+				if !ok || len(ranges) == 0 {
+					t.Fatal("ranges is empty or not an array")
+				}
+
+				range0, ok := ranges[0].([]interface{})
+				if !ok || len(range0) == 0 {
+					t.Fatal("first range is empty or not an array")
+				}
+
+				subnetMap, ok := range0[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("subnet is not a map")
+				}
+
+				if subnetMap["subnet"] != "10.1.0.0/16" {
+					t.Errorf("subnet = %v, want %q", subnetMap["subnet"], "10.1.0.0/16")
+				}
+
+				// Verify routes
+				routes, ok := ipam["routes"].([]interface{})
+				if !ok || len(routes) == 0 {
+					t.Fatal("routes is empty or not an array")
+				}
+
+				route0, ok := routes[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("first route is not a map")
+				}
+
+				if route0["dst"] != "0.0.0.0/0" {
+					t.Errorf("route dst = %v, want %q", route0["dst"], "0.0.0.0/0")
+				}
+
+				// Verify loopback plugin
+				loopbackPlugin, ok := conf.Plugins[1].(map[string]interface{})
+				if !ok {
+					t.Fatal("second plugin is not a map")
+				}
+
+				if loopbackPlugin["type"] != "loopback" {
+					t.Errorf("loopback plugin type = %v, want %q", loopbackPlugin["type"], "loopback")
+				}
+
+				// Verify JSON is properly formatted (indented)
+				// Re-marshal to check indentation
+				indented, err := json.MarshalIndent(conf, "", "  ")
+				if err != nil {
+					t.Fatalf("failed to marshal: %v", err)
+				}
+
+				// Compare lengths - indented should be longer
+				if len(data) < len(indented)/2 {
+					t.Error("JSON appears to not be indented")
+				}
+			},
+		},
+		{
+			name:        "success with empty bridge name",
+			networkName: "test-network",
+			bridge:      "",
+			subnet:      "10.1.0.0/16",
+			validate: func(t *testing.T, data []byte) {
+				var conf cni.ConflistModel
+				if err := json.Unmarshal(data, &conf); err != nil {
+					t.Fatalf("failed to unmarshal JSON: %v", err)
+				}
+
+				bridgePlugin, ok := conf.Plugins[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("first plugin is not a map")
+				}
+
+				if bridgePlugin["bridge"] != "" {
+					t.Errorf("bridge = %v, want empty string", bridgePlugin["bridge"])
+				}
+			},
+		},
+		{
+			name:        "success with empty subnet",
+			networkName: "test-network",
+			bridge:      "test-bridge",
+			subnet:      "",
+			validate: func(t *testing.T, data []byte) {
+				var conf cni.ConflistModel
+				if err := json.Unmarshal(data, &conf); err != nil {
+					t.Fatalf("failed to unmarshal JSON: %v", err)
+				}
+
+				bridgePlugin, ok := conf.Plugins[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("first plugin is not a map")
+				}
+
+				ipam, ok := bridgePlugin["ipam"].(map[string]interface{})
+				if !ok {
+					t.Fatal("ipam is not a map")
+				}
+
+				ranges, ok := ipam["ranges"].([]interface{})
+				if !ok || len(ranges) == 0 {
+					t.Fatal("ranges is empty or not an array")
+				}
+
+				range0, ok := ranges[0].([]interface{})
+				if !ok || len(range0) == 0 {
+					t.Fatal("first range is empty or not an array")
+				}
+
+				subnetMap, ok := range0[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("subnet is not a map")
+				}
+
+				if subnetMap["subnet"] != "" {
+					t.Errorf("subnet = %v, want empty string", subnetMap["subnet"])
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := cni.BuildDefaultConflist(tt.networkName, tt.bridge, tt.subnet)
+			if err != nil {
+				t.Fatalf("BuildDefaultConflist() error = %v, want nil", err)
+			}
+
+			if len(data) == 0 {
+				t.Fatal("BuildDefaultConflist() returned empty data")
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, data)
+			}
+		})
+	}
+}

--- a/internal/cni/container.go
+++ b/internal/cni/container.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni
+
+import (
+	"context"
+
+	libcni "github.com/containernetworking/cni/libcni"
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// AddContainerToNetwork adds a container to the CNI network.
+func (m *Manager) AddContainerToNetwork(ctx context.Context, containerID, netnsPath string) error {
+	if m.netConf == nil {
+		return errdefs.ErrNetworkConfigNotLoaded
+	}
+
+	rt := buildRuntimeConf(containerID, netnsPath)
+	_, err := m.cniConf.AddNetworkList(ctx, m.netConf, rt)
+	return err
+}
+
+// DelContainerFromNetwork removes a container from the CNI network.
+func (m *Manager) DelContainerFromNetwork(ctx context.Context, containerID, netnsPath string) error {
+	if m.netConf == nil {
+		return errdefs.ErrNetworkConfigNotLoaded
+	}
+
+	rt := buildRuntimeConf(containerID, netnsPath)
+	return m.cniConf.DelNetworkList(ctx, m.netConf, rt)
+}
+
+// buildRuntimeConf builds a RuntimeConf for container network operations.
+func buildRuntimeConf(containerID, netnsPath string) *libcni.RuntimeConf {
+	return &libcni.RuntimeConf{
+		ContainerID: containerID,
+		NetNS:       netnsPath, // e.g. /proc/<pid>/ns/net
+		IfName:      "eth0",
+	}
+}

--- a/internal/cni/container_test.go
+++ b/internal/cni/container_test.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	cni "github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+func setupTestManager(t *testing.T, configDir string) *cni.Manager {
+	t.Helper()
+	mgr, err := cni.NewManager("", configDir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+	return mgr
+}
+
+func TestManager_AddContainerToNetwork(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*testing.T) *cni.Manager
+		containerID string
+		netnsPath   string
+		wantErr     error
+	}{
+		{
+			name: "network config not loaded",
+			setup: func(t *testing.T) *cni.Manager {
+				// Create manager without loading config
+				return setupTestManager(t, t.TempDir())
+			},
+			containerID: "test-container",
+			netnsPath:   "/proc/123/ns/net",
+			wantErr:     errdefs.ErrNetworkConfigNotLoaded,
+		},
+		// Note: Full integration test with loaded config requires mocking libcni.CNI interface.
+		// This is complex and better suited for integration tests. We focus on validation here.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := tt.setup(t)
+			err := mgr.AddContainerToNetwork(context.Background(), tt.containerID, tt.netnsPath)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("AddContainerToNetwork() error = nil, want %v", tt.wantErr)
+				} else if !errors.Is(err, tt.wantErr) {
+					t.Errorf("AddContainerToNetwork() error = %v, want %v", err, tt.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("AddContainerToNetwork() error = %v, want nil", err)
+				}
+			}
+		})
+	}
+}
+
+func TestManager_DelContainerFromNetwork(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(*testing.T) *cni.Manager
+		containerID string
+		netnsPath   string
+		wantErr     error
+	}{
+		{
+			name: "network config not loaded",
+			setup: func(t *testing.T) *cni.Manager {
+				// Create manager without loading config
+				return setupTestManager(t, t.TempDir())
+			},
+			containerID: "test-container",
+			netnsPath:   "/proc/123/ns/net",
+			wantErr:     errdefs.ErrNetworkConfigNotLoaded,
+		},
+		// Note: Full integration test with loaded config requires mocking libcni.CNI interface.
+		// This is complex and better suited for integration tests. We focus on validation here.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := tt.setup(t)
+			err := mgr.DelContainerFromNetwork(context.Background(), tt.containerID, tt.netnsPath)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("DelContainerFromNetwork() error = nil, want %v", tt.wantErr)
+				} else if !errors.Is(err, tt.wantErr) {
+					t.Errorf("DelContainerFromNetwork() error = %v, want %v", err, tt.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("DelContainerFromNetwork() error = %v, want nil", err)
+				}
+			}
+		})
+	}
+}

--- a/internal/cni/manager.go
+++ b/internal/cni/manager.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni
+
+import (
+	libcni "github.com/containernetworking/cni/libcni"
+)
+
+// NewManager creates a new CNI manager with the provided directories.
+// cniBinDir: where plugins live, e.g. /opt/cni/bin
+// cniConfigDir: where network configs live, e.g. /opt/cni/net.d
+// cniCacheDir: where CNI stores cache, e.g. /opt/cni/cache.
+func NewManager(cniBinDir, cniConfigDir, cniCacheDir string) (*Manager, error) {
+	// Apply defaults BEFORE creating the CNI config to ensure non-empty paths
+	if cniConfigDir == "" {
+		cniConfigDir = defaultCniConfDir
+	}
+
+	if cniBinDir == "" {
+		cniBinDir = defaultCniBinDir
+	}
+
+	if cniCacheDir == "" {
+		cniCacheDir = defaultCniCacheDir
+	}
+
+	cniConf := libcni.NewCNIConfigWithCacheDir(
+		[]string{cniBinDir},
+		cniCacheDir,
+		nil,
+	)
+
+	var netConf *libcni.NetworkConfigList
+
+	return &Manager{
+		cniConf: cniConf,
+		netConf: netConf,
+		conf: Conf{
+			CniConfigDir: cniConfigDir,
+			CniBinDir:    cniBinDir,
+			CniCacheDir:  cniCacheDir,
+		},
+	}, nil
+}

--- a/internal/cni/manager_test.go
+++ b/internal/cni/manager_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni_test
+
+import (
+	"testing"
+
+	cni "github.com/eminwux/kukeon/internal/cni"
+)
+
+func TestNewManager(t *testing.T) {
+	tests := []struct {
+		name      string
+		binDir    string
+		configDir string
+		cacheDir  string
+		wantErr   bool
+	}{
+		{
+			name:      "success with all directories provided",
+			binDir:    "/test/bin",
+			configDir: "/test/config",
+			cacheDir:  "/test/cache",
+			wantErr:   false,
+		},
+		{
+			name:      "success with empty directories (defaults applied)",
+			binDir:    "",
+			configDir: "",
+			cacheDir:  "",
+			wantErr:   false,
+		},
+		{
+			name:      "success with partial directories (some defaults)",
+			binDir:    "/test/bin",
+			configDir: "",
+			cacheDir:  "/test/cache",
+			wantErr:   false,
+		},
+		{
+			name:      "success with only config dir provided",
+			binDir:    "",
+			configDir: "/test/config",
+			cacheDir:  "",
+			wantErr:   false,
+		},
+		{
+			name:      "success with only bin dir provided",
+			binDir:    "/test/bin",
+			configDir: "",
+			cacheDir:  "",
+			wantErr:   false,
+		},
+		{
+			name:      "success with only cache dir provided",
+			binDir:    "",
+			configDir: "",
+			cacheDir:  "/test/cache",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr, err := cni.NewManager(tt.binDir, tt.configDir, tt.cacheDir)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("NewManager() error = nil, want error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("NewManager() error = %v, want nil", err)
+			}
+
+			if mgr == nil {
+				t.Fatal("NewManager() returned nil manager")
+			}
+
+			// Note: We cannot directly access the conf field in external tests.
+			// Directory configuration is tested indirectly through methods that use it
+			// (e.g., CreateNetworkWithConfig uses the config directory).
+		})
+	}
+}

--- a/internal/cni/network_test.go
+++ b/internal/cni/network_test.go
@@ -1,0 +1,678 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cni "github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+func TestManager_LoadNetworkConfigList(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, dir string) string // Returns config path
+		wantErr   bool
+		checkConf func(t *testing.T, mgr *cni.Manager)
+	}{
+		{
+			name: "error with empty config path",
+			setup: func(_ *testing.T, _ string) string {
+				return ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with non-existent file",
+			setup: func(_ *testing.T, dir string) string {
+				return filepath.Join(dir, "nonexistent.conflist")
+			},
+			wantErr: true,
+		},
+		{
+			name: "error with invalid JSON",
+			setup: func(t *testing.T, dir string) string {
+				configPath := filepath.Join(dir, "invalid.conflist")
+				err := os.WriteFile(configPath, []byte("invalid json"), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write invalid JSON file: %v", err)
+				}
+				return configPath
+			},
+			wantErr: true,
+		},
+		{
+			name: "success with valid conflist file",
+			setup: func(t *testing.T, dir string) string {
+				configPath := filepath.Join(dir, "test.conflist")
+				conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "test-network",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [
+            {
+              "subnet": "10.88.0.0/16"
+            }
+          ]
+        ],
+        "routes": [
+          {
+            "dst": "0.0.0.0/0"
+          }
+        ]
+      }
+    },
+    {
+      "type": "loopback"
+    }
+  ]
+}`
+				err := os.WriteFile(configPath, []byte(conflist), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write conflist file: %v", err)
+				}
+				return configPath
+			},
+			wantErr: false,
+			checkConf: func(t *testing.T, mgr *cni.Manager) {
+				// Verify config was loaded by trying to use it
+				// We can't directly access netConf, but we can verify it's loaded
+				// by checking that AddContainerToNetwork doesn't return ErrNetworkConfigNotLoaded
+				err := mgr.AddContainerToNetwork(context.Background(), "test-container", "/proc/123/ns/net")
+				if err != nil && !errors.Is(err, errdefs.ErrNetworkConfigNotLoaded) {
+					// Config is loaded (error is from libcni, not from missing config)
+					return
+				}
+				if errors.Is(err, errdefs.ErrNetworkConfigNotLoaded) {
+					t.Error("LoadNetworkConfigList() did not load config")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := tt.setup(t, dir)
+
+			mgr, err := cni.NewManager("", dir, "")
+			if err != nil {
+				t.Fatalf("failed to create manager: %v", err)
+			}
+
+			err = mgr.LoadNetworkConfigList(configPath)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("LoadNetworkConfigList() error = nil, want error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("LoadNetworkConfigList() error = %v, want nil", err)
+			}
+
+			if tt.checkConf != nil {
+				tt.checkConf(t, mgr)
+			}
+		})
+	}
+}
+
+func TestManager_ExistsNetworkConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, dir string) // Sets up test files
+		networkName string
+		configPath  string
+		wantExists  bool
+		wantPath    string
+		wantErr     error
+	}{
+		{
+			name: "network not found (file doesn't exist)",
+			setup: func(_ *testing.T, _ string) {
+				// No files created
+			},
+			networkName: "test-network",
+			configPath:  "",
+			wantExists:  false,
+			wantErr:     errdefs.ErrNetworkNotFound,
+		},
+		{
+			name: "network not found (name mismatch)",
+			setup: func(t *testing.T, dir string) {
+				configPath := filepath.Join(dir, "other-network.conflist")
+				conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "other-network",
+  "plugins": []
+}`
+				err := os.WriteFile(configPath, []byte(conflist), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write conflist file: %v", err)
+				}
+			},
+			networkName: "test-network",
+			configPath:  "",
+			wantExists:  false,
+			wantErr:     errdefs.ErrNetworkNotFound,
+		},
+		{
+			name: "network not found (invalid JSON)",
+			setup: func(t *testing.T, dir string) {
+				configPath := filepath.Join(dir, "test-network.conflist")
+				err := os.WriteFile(configPath, []byte("invalid json"), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write invalid JSON file: %v", err)
+				}
+			},
+			networkName: "test-network",
+			configPath:  "",
+			wantExists:  false,
+			wantErr:     nil, // JSON unmarshal error, not ErrNetworkNotFound
+		},
+		{
+			name: "success with matching network",
+			setup: func(t *testing.T, dir string) {
+				configPath := filepath.Join(dir, "test-network.conflist")
+				conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "test-network",
+  "plugins": []
+}`
+				err := os.WriteFile(configPath, []byte(conflist), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write conflist file: %v", err)
+				}
+			},
+			networkName: "test-network",
+			configPath:  "",
+			wantExists:  true,
+			wantPath:    "", // Will be auto-constructed
+			wantErr:     nil,
+		},
+		{
+			name: "success with explicit config path",
+			setup: func(t *testing.T, dir string) {
+				configPath := filepath.Join(dir, "custom.conflist")
+				conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "test-network",
+  "plugins": []
+}`
+				err := os.WriteFile(configPath, []byte(conflist), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write conflist file: %v", err)
+				}
+			},
+			networkName: "test-network",
+			configPath:  "", // Will be set to dir/custom.conflist in test
+			wantExists:  true,
+			wantErr:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, dir)
+			}
+
+			mgr, err := cni.NewManager("", dir, "")
+			if err != nil {
+				t.Fatalf("failed to create manager: %v", err)
+			}
+
+			// Update configPath if it's empty to use the test directory
+			configPath := tt.configPath
+			if configPath == "" {
+				if tt.name == "success with explicit config path" {
+					configPath = filepath.Join(dir, "custom.conflist")
+				} else if tt.networkName != "" {
+					configPath = filepath.Join(dir, tt.networkName+".conflist")
+				}
+			}
+
+			exists, path, err := mgr.ExistsNetworkConfig(tt.networkName, configPath)
+
+			if tt.wantErr != nil {
+				if err == nil {
+					t.Errorf("ExistsNetworkConfig() error = nil, want %v", tt.wantErr)
+				} else if !errors.Is(err, tt.wantErr) {
+					t.Errorf("ExistsNetworkConfig() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil && tt.wantErr == nil {
+				// Allow JSON unmarshal errors in invalid JSON test case
+				if tt.name != "network not found (invalid JSON)" {
+					t.Fatalf("ExistsNetworkConfig() error = %v, want nil", err)
+				}
+				return
+			}
+
+			if exists != tt.wantExists {
+				t.Errorf("ExistsNetworkConfig() exists = %v, want %v", exists, tt.wantExists)
+			}
+
+			if tt.wantExists && path == "" {
+				t.Error("ExistsNetworkConfig() path = empty, want non-empty")
+			}
+		})
+	}
+}
+
+func TestManager_CreateNetworkWithConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        cni.NetworkConfig
+		wantBridge string
+		wantSubnet string
+		validate   func(t *testing.T, path string, data []byte)
+	}{
+		{
+			name: "success with all fields provided",
+			cfg: cni.NetworkConfig{
+				Name:       "test-network",
+				BridgeName: "test-bridge",
+				SubnetCIDR: "10.1.0.0/16",
+			},
+			wantBridge: "test-bridge",
+			wantSubnet: "10.1.0.0/16",
+			validate: func(t *testing.T, path string, data []byte) {
+				// Verify file exists
+				if _, err := os.Stat(path); err != nil {
+					t.Fatalf("config file does not exist: %v", err)
+				}
+
+				// Verify file permissions (0o600)
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatalf("failed to stat file: %v", err)
+				}
+				perm := info.Mode().Perm()
+				if perm != 0o600 {
+					t.Errorf("file permissions = %o, want 0o600", perm)
+				}
+
+				// Verify JSON structure
+				var conf cni.ConflistModel
+				if err = json.Unmarshal(data, &conf); err != nil {
+					t.Fatalf("failed to unmarshal JSON: %v", err)
+				}
+
+				if conf.Name != "test-network" {
+					t.Errorf("config name = %q, want %q", conf.Name, "test-network")
+				}
+
+				if len(conf.Plugins) < 1 {
+					t.Fatal("config plugins is empty")
+				}
+
+				// Verify bridge plugin
+				bridgePlugin, ok := conf.Plugins[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("first plugin is not a map")
+				}
+
+				if bridgePlugin["bridge"] != "test-bridge" {
+					t.Errorf("bridge = %v, want %q", bridgePlugin["bridge"], "test-bridge")
+				}
+			},
+		},
+		{
+			name: "success with empty BridgeName (uses default)",
+			cfg: cni.NetworkConfig{
+				Name:       "test-network",
+				BridgeName: "",
+				SubnetCIDR: "10.1.0.0/16",
+			},
+			wantBridge: "cni0",
+			wantSubnet: "10.1.0.0/16",
+			validate: func(t *testing.T, _ string, data []byte) {
+				var conf cni.ConflistModel
+				if err := json.Unmarshal(data, &conf); err != nil {
+					t.Fatalf("failed to unmarshal JSON: %v", err)
+				}
+
+				bridgePlugin, ok := conf.Plugins[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("first plugin is not a map")
+				}
+
+				if bridgePlugin["bridge"] != "cni0" {
+					t.Errorf("bridge = %v, want %q", bridgePlugin["bridge"], "cni0")
+				}
+			},
+		},
+		{
+			name: "success with empty SubnetCIDR (uses default)",
+			cfg: cni.NetworkConfig{
+				Name:       "test-network",
+				BridgeName: "test-bridge",
+				SubnetCIDR: "",
+			},
+			wantBridge: "test-bridge",
+			wantSubnet: "10.88.0.0/16",
+			validate: func(t *testing.T, _ string, data []byte) {
+				var conf cni.ConflistModel
+				if err := json.Unmarshal(data, &conf); err != nil {
+					t.Fatalf("failed to unmarshal JSON: %v", err)
+				}
+
+				bridgePlugin, ok := conf.Plugins[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("first plugin is not a map")
+				}
+
+				ipam, ok := bridgePlugin["ipam"].(map[string]interface{})
+				if !ok {
+					t.Fatal("ipam is not a map")
+				}
+
+				ranges, ok := ipam["ranges"].([]interface{})
+				if !ok || len(ranges) == 0 {
+					t.Fatal("ranges is empty or not an array")
+				}
+
+				range0, ok := ranges[0].([]interface{})
+				if !ok || len(range0) == 0 {
+					t.Fatal("first range is empty or not an array")
+				}
+
+				subnetMap, ok := range0[0].(map[string]interface{})
+				if !ok {
+					t.Fatal("subnet is not a map")
+				}
+
+				if subnetMap["subnet"] != "10.88.0.0/16" {
+					t.Errorf("subnet = %v, want %q", subnetMap["subnet"], "10.88.0.0/16")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mgr, err := cni.NewManager("", dir, "")
+			if err != nil {
+				t.Fatalf("failed to create manager: %v", err)
+			}
+
+			path, err := mgr.CreateNetworkWithConfig(tt.cfg)
+			if err != nil {
+				t.Fatalf("CreateNetworkWithConfig() error = %v, want nil", err)
+			}
+
+			if path == "" {
+				t.Fatal("CreateNetworkWithConfig() path = empty, want non-empty")
+			}
+
+			// Read file content
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read config file: %v", err)
+			}
+
+			if tt.validate != nil {
+				tt.validate(t, path, data)
+			}
+		})
+	}
+}
+
+func TestManager_CreateNetwork(t *testing.T) {
+	tests := []struct {
+		name        string
+		networkName string
+		bridgeName  string
+		subnetCIDR  string
+		wantBridge  string
+		wantSubnet  string
+	}{
+		{
+			name:        "success with all parameters",
+			networkName: "test-network",
+			bridgeName:  "test-bridge",
+			subnetCIDR:  "10.1.0.0/16",
+			wantBridge:  "test-bridge",
+			wantSubnet:  "10.1.0.0/16",
+		},
+		{
+			name:        "success with empty bridgeName (uses default)",
+			networkName: "test-network",
+			bridgeName:  "",
+			subnetCIDR:  "10.1.0.0/16",
+			wantBridge:  "cni0",
+			wantSubnet:  "10.1.0.0/16",
+		},
+		{
+			name:        "success with empty subnetCIDR (uses default)",
+			networkName: "test-network",
+			bridgeName:  "test-bridge",
+			subnetCIDR:  "",
+			wantBridge:  "test-bridge",
+			wantSubnet:  "10.88.0.0/16",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mgr, err := cni.NewManager("", dir, "")
+			if err != nil {
+				t.Fatalf("failed to create manager: %v", err)
+			}
+
+			path, err := mgr.CreateNetwork(tt.networkName, tt.bridgeName, tt.subnetCIDR)
+			if err != nil {
+				t.Fatalf("CreateNetwork() error = %v, want nil", err)
+			}
+
+			if path == "" {
+				t.Fatal("CreateNetwork() path = empty, want non-empty")
+			}
+
+			// Verify it calls CreateNetworkWithConfig correctly by reading the file
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read config file: %v", err)
+			}
+
+			var conf cni.ConflistModel
+			if err = json.Unmarshal(data, &conf); err != nil {
+				t.Fatalf("failed to unmarshal JSON: %v", err)
+			}
+
+			if conf.Name != tt.networkName {
+				t.Errorf("config name = %q, want %q", conf.Name, tt.networkName)
+			}
+
+			bridgePlugin, ok := conf.Plugins[0].(map[string]interface{})
+			if !ok {
+				t.Fatal("first plugin is not a map")
+			}
+
+			if bridgePlugin["bridge"] != tt.wantBridge {
+				t.Errorf("bridge = %v, want %q", bridgePlugin["bridge"], tt.wantBridge)
+			}
+		})
+	}
+}
+
+func TestManager_DeleteNetwork(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, dir string)
+		networkName string
+		configPath  string
+		wantErr     bool
+		verify      func(t *testing.T, dir string, networkName string)
+	}{
+		{
+			name:        "error with empty network name",
+			setup:       func(_ *testing.T, _ string) {},
+			networkName: "",
+			configPath:  "",
+			wantErr:     true,
+		},
+		{
+			name: "success when file doesn't exist (idempotent)",
+			setup: func(_ *testing.T, _ string) {
+				// No files created
+			},
+			networkName: "test-network",
+			configPath:  "",
+			wantErr:     false,
+			verify: func(t *testing.T, dir string, networkName string) {
+				// File should not exist
+				path := filepath.Join(dir, networkName+".conflist")
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Errorf("file should not exist: %v", err)
+				}
+			},
+		},
+		{
+			name: "success when network name doesn't match (idempotent)",
+			setup: func(t *testing.T, dir string) {
+				configPath := filepath.Join(dir, "other-network.conflist")
+				conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "other-network",
+  "plugins": []
+}`
+				err := os.WriteFile(configPath, []byte(conflist), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write conflist file: %v", err)
+				}
+			},
+			networkName: "test-network",
+			configPath:  "",
+			wantErr:     false,
+			verify: func(t *testing.T, dir string, _ string) {
+				// Other file should still exist
+				otherPath := filepath.Join(dir, "other-network.conflist")
+				if _, err := os.Stat(otherPath); err != nil {
+					t.Errorf("other file should still exist: %v", err)
+				}
+			},
+		},
+		{
+			name: "success deleting existing network",
+			setup: func(t *testing.T, dir string) {
+				configPath := filepath.Join(dir, "test-network.conflist")
+				conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "test-network",
+  "plugins": []
+}`
+				err := os.WriteFile(configPath, []byte(conflist), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write conflist file: %v", err)
+				}
+			},
+			networkName: "test-network",
+			configPath:  "",
+			wantErr:     false,
+			verify: func(t *testing.T, dir string, networkName string) {
+				// File should be deleted
+				path := filepath.Join(dir, networkName+".conflist")
+				if _, err := os.Stat(path); !os.IsNotExist(err) {
+					t.Errorf("file should be deleted: %v", err)
+				}
+			},
+		},
+		{
+			name: "success with explicit config path",
+			setup: func(t *testing.T, dir string) {
+				configPath := filepath.Join(dir, "custom.conflist")
+				conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "test-network",
+  "plugins": []
+}`
+				err := os.WriteFile(configPath, []byte(conflist), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write conflist file: %v", err)
+				}
+			},
+			networkName: "test-network",
+			configPath:  "", // Will be set in test to use dir/custom.conflist
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, dir)
+			}
+
+			mgr, err := cni.NewManager("", dir, "")
+			if err != nil {
+				t.Fatalf("failed to create manager: %v", err)
+			}
+
+			// Update configPath if it's empty to use the test directory
+			configPath := tt.configPath
+			if configPath == "" {
+				if tt.name == "success with explicit config path" {
+					configPath = filepath.Join(dir, "custom.conflist")
+				} else if tt.networkName != "" {
+					configPath = filepath.Join(dir, tt.networkName+".conflist")
+				}
+			}
+
+			err = mgr.DeleteNetwork(tt.networkName, configPath)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("DeleteNetwork() error = nil, want error")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("DeleteNetwork() error = %v, want nil", err)
+			}
+
+			if tt.verify != nil {
+				tt.verify(t, dir, tt.networkName)
+			}
+		})
+	}
+}

--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni
+
+import (
+	libcni "github.com/containernetworking/cni/libcni"
+)
+
+// Manager manages CNI network operations.
+type Manager struct {
+	cniConf libcni.CNI
+	netConf *libcni.NetworkConfigList
+	conf    Conf
+}
+
+// Conf holds CNI configuration paths.
+type Conf struct {
+	CniConfigDir string
+	CniBinDir    string
+	CniCacheDir  string
+}
+
+// NetworkConfig represents the desired parameters for creating a CNI network.
+type NetworkConfig struct {
+	// Name is the CNI network name and the filename (without extension).
+	Name string
+	// BridgeName is the bridge device name. Defaults to "cni0" when empty.
+	BridgeName string
+	// SubnetCIDR is the IPAM subnet CIDR. Defaults to "10.88.0.0/16" when empty.
+	SubnetCIDR string
+}
+
+// BootstrapReport captures CNI environment checks and actions.
+type BootstrapReport struct {
+	CniConfigDir        string
+	CniCacheDir         string
+	CniBinDir           string
+	ConfigDirExistsPre  bool
+	CacheDirExistsPre   bool
+	BinDirExistsPre     bool
+	ConfigDirCreated    bool
+	CacheDirCreated     bool
+	BinDirCreated       bool
+	ConfigDirExistsPost bool
+	CacheDirExistsPost  bool
+	BinDirExistsPost    bool
+}
+
+// ConflistModel represents the structure of a CNI conflist file.
+type ConflistModel struct {
+	CNIVersion string        `json:"cniVersion"`
+	Name       string        `json:"name"`
+	Plugins    []interface{} `json:"plugins"`
+}
+
+// BridgePluginModel represents the bridge plugin configuration in a conflist.
+type BridgePluginModel struct {
+	Type      string           `json:"type"`
+	Bridge    string           `json:"bridge"`
+	IsGateway bool             `json:"isGateway"`
+	IPMasq    bool             `json:"ipMasq"`
+	IPAM      BridgeIPAMConfig `json:"ipam"`
+}
+
+// BridgeIPAMConfig represents the IPAM configuration for the bridge plugin.
+type BridgeIPAMConfig struct {
+	Type   string                `json:"type"`
+	Ranges [][]map[string]string `json:"ranges"`
+	Routes []RouteModel          `json:"routes"`
+}
+
+// RouteModel represents a route in the IPAM configuration.
+type RouteModel struct {
+	Dst string `json:"dst"`
+}
+
+// LoopbackPluginModel represents the loopback plugin configuration in a conflist.
+type LoopbackPluginModel struct {
+	Type string `json:"type"`
+}
+
+const (
+	defaultCniConfDir  = "/opt/cni/net.d"
+	defaultCniBinDir   = "/opt/cni/bin"
+	defaultCniCacheDir = "/opt/cni/cache"
+	defaultCNIVersion  = "0.4.0"
+	defaultBridgeName  = "cni0"
+	defaultSubnetCIDR  = "10.88.0.0/16"
+)
+
+// CNINetworksDir is the standard directory where CNI stores network state and IPAM allocations.
+// This is the default location used by CNI plugins for host-local IPAM.
+const CNINetworksDir = "/var/lib/cni/networks"


### PR DESCRIPTION
@cursor review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorganizes `internal/cni` into focused modules, adds helpers for managing CNI configs and container attach/detach, and introduces extensive unit tests.
> 
> - **CNI package reorganization**:
>   - Extract shared models, defaults, and `BootstrapReport` into `internal/cni/types.go`.
>   - Move manager construction to `internal/cni/manager.go` (`NewManager`).
>   - Split container operations into `internal/cni/container.go` (`AddContainerToNetwork`, `DelContainerFromNetwork`).
>   - Simplify `internal/cni/network.go` to focus on conflist/file ops: `LoadNetworkConfigList`, `ExistsNetworkConfig`, `CreateNetworkWithConfig`, `CreateNetwork`, `DeleteNetwork`.
>   - Keep config builders in `internal/cni/config.go` (`NewCNINetworkConfig`, `BuildDefaultConflist`).
> - **Bootstrap**:
>   - `internal/cni/bootstrap.go`: directory setup with defaults and detailed pre/post report via `BootstrapCNI`.
> - **Tests**:
>   - Add extensive unit tests: `bootstrap_test.go`, `config_test.go`, `container_test.go`, `manager_test.go`, `network_test.go` covering defaults, file IO, idempotency, and validation paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5a58ae62410e23a5850c86c0278760b34b4315d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->