### PR TITLE
feat: add refresh cmd + fixes

### DIFF
--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -33,6 +33,7 @@ import (
 	initcmd "github.com/eminwux/kukeon/cmd/kuke/init"
 	killcmd "github.com/eminwux/kukeon/cmd/kuke/kill"
 	purgecmd "github.com/eminwux/kukeon/cmd/kuke/purge"
+	refreshcmd "github.com/eminwux/kukeon/cmd/kuke/refresh"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/start"
 	stopcmd "github.com/eminwux/kukeon/cmd/kuke/stop"
 	"github.com/eminwux/kukeon/cmd/kuke/version"
@@ -124,6 +125,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(stopcmd.NewStopCmd())
 	rootCmd.AddCommand(killcmd.NewKillCmd())
 	rootCmd.AddCommand(purgecmd.NewPurgeCmd())
+	rootCmd.AddCommand(refreshcmd.NewRefreshCmd())
 	rootCmd.AddCommand(autocompletecmd.NewAutocompleteCmd())
 	rootCmd.AddCommand(version.NewVersionCmd())
 

--- a/cmd/kuke/refresh/refresh.go
+++ b/cmd/kuke/refresh/refresh.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package refresh
+
+import (
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/spf13/cobra"
+)
+
+// RefreshResult is an alias for controller.RefreshResult.
+type RefreshResult = controller.RefreshResult
+
+// RefreshController defines the interface for refresh operations.
+type RefreshController interface {
+	RefreshAll() (RefreshResult, error)
+}
+
+// MockControllerKey is used to inject mock controllers in tests via context.
+type MockControllerKey struct{}
+
+type controllerWrapper struct {
+	ctrl *controller.Exec
+}
+
+func (w *controllerWrapper) RefreshAll() (RefreshResult, error) {
+	return w.ctrl.RefreshAll()
+}
+
+func NewRefreshCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "refresh",
+		Short:        "Refresh metadata status by introspecting containerd and CNI for all entities",
+		Long:         "Refresh metadata status by introspecting containerd and CNI for all entities. Updates only .status fields to reflect current runtime state without modifying .spec or runtime state.",
+		SilenceUsage: true,
+		RunE:         runRefreshCmd,
+	}
+
+	return cmd
+}
+
+func runRefreshCmd(cmd *cobra.Command, _ []string) error {
+	var ctrl RefreshController
+	if mockCtrl, ok := cmd.Context().Value(MockControllerKey{}).(RefreshController); ok {
+		ctrl = mockCtrl
+	} else {
+		realCtrl, err := shared.ControllerFromCmd(cmd)
+		if err != nil {
+			return err
+		}
+		ctrl = &controllerWrapper{ctrl: realCtrl}
+	}
+
+	result, err := ctrl.RefreshAll()
+	if err != nil {
+		return err
+	}
+
+	// Print summary
+	cmd.Printf("Refreshed metadata status:\n")
+	printEntityList(cmd, "  Realms", result.RealmsFound)
+	printEntityList(cmd, "  Spaces", result.SpacesFound)
+	printEntityList(cmd, "  Stacks", result.StacksFound)
+	printEntityList(cmd, "  Cells", result.CellsFound)
+	printEntityList(cmd, "  Containers", result.ContainersFound)
+	cmd.Printf("\n")
+
+	cmd.Printf("Updated:\n")
+	hasUpdates := false
+	if len(result.RealmsUpdated) > 0 {
+		printEntityList(cmd, "  Realms", result.RealmsUpdated)
+		hasUpdates = true
+	}
+	if len(result.SpacesUpdated) > 0 {
+		printEntityList(cmd, "  Spaces", result.SpacesUpdated)
+		hasUpdates = true
+	}
+	if len(result.StacksUpdated) > 0 {
+		printEntityList(cmd, "  Stacks", result.StacksUpdated)
+		hasUpdates = true
+	}
+	if len(result.CellsUpdated) > 0 {
+		printEntityList(cmd, "  Cells", result.CellsUpdated)
+		hasUpdates = true
+	}
+	if len(result.ContainersUpdated) > 0 {
+		printEntityList(cmd, "  Containers", result.ContainersUpdated)
+		hasUpdates = true
+	}
+	if !hasUpdates {
+		cmd.Printf("  (none)\n")
+	}
+	cmd.Printf("\n")
+
+	cmd.Printf("Errors:\n")
+	if len(result.Errors) > 0 {
+		for _, errMsg := range result.Errors {
+			cmd.Printf("  %s\n", errMsg)
+		}
+	} else {
+		cmd.Printf("  (none)\n")
+	}
+
+	return nil
+}
+
+// printEntityList prints a list of entities with count and names.
+// Format: "Label: count (name1, name2, ...)" or "Label: count" if empty.
+func printEntityList(cmd *cobra.Command, label string, entities []string) {
+	count := len(entities)
+	if count == 0 {
+		cmd.Printf("%s: 0\n", label)
+		return
+	}
+
+	const maxEntitiesToShow = 5
+	if count <= maxEntitiesToShow {
+		// For small lists, show all names
+		cmd.Printf("%s: %d (%s)\n", label, count, strings.Join(entities, ", "))
+	} else {
+		// For large lists, show first few and count
+		cmd.Printf("%s: %d (%s, ...)\n", label, count, strings.Join(entities[:maxEntitiesToShow], ", "))
+	}
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -58,6 +58,7 @@ type Controller interface {
 	PurgeStack(stack intmodel.Stack, force, cascade bool) (PurgeStackResult, error)
 	PurgeCell(cell intmodel.Cell, force, cascade bool) (PurgeCellResult, error)
 	PurgeContainer(container intmodel.Container) (PurgeContainerResult, error)
+	RefreshAll() (RefreshResult, error)
 }
 
 type Exec struct {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -101,6 +101,12 @@ type fakeRunner struct {
 	UpdateCellFn      func(cell intmodel.Cell) (intmodel.Cell, error)
 	RecreateCellFn    func(cell intmodel.Cell) (intmodel.Cell, error)
 	UpdateContainerFn func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
+
+	// Refresh methods
+	RefreshRealmFn func(realm intmodel.Realm) (intmodel.Realm, bool, error)
+	RefreshSpaceFn func(space intmodel.Space) (intmodel.Space, bool, error)
+	RefreshStackFn func(stack intmodel.Stack) (intmodel.Stack, bool, error)
+	RefreshCellFn  func(cell intmodel.Cell) (intmodel.Cell, int, error)
 }
 
 // Realm methods
@@ -459,6 +465,36 @@ func (f *fakeRunner) UpdateContainer(cell intmodel.Cell, container intmodel.Cont
 		return f.UpdateContainerFn(cell, container)
 	}
 	return intmodel.Cell{}, errors.New("unexpected call to UpdateContainer")
+}
+
+// Refresh methods
+
+func (f *fakeRunner) RefreshRealm(realm intmodel.Realm) (intmodel.Realm, bool, error) {
+	if f.RefreshRealmFn != nil {
+		return f.RefreshRealmFn(realm)
+	}
+	return intmodel.Realm{}, false, errors.New("unexpected call to RefreshRealm")
+}
+
+func (f *fakeRunner) RefreshSpace(space intmodel.Space) (intmodel.Space, bool, error) {
+	if f.RefreshSpaceFn != nil {
+		return f.RefreshSpaceFn(space)
+	}
+	return intmodel.Space{}, false, errors.New("unexpected call to RefreshSpace")
+}
+
+func (f *fakeRunner) RefreshStack(stack intmodel.Stack) (intmodel.Stack, bool, error) {
+	if f.RefreshStackFn != nil {
+		return f.RefreshStackFn(stack)
+	}
+	return intmodel.Stack{}, false, errors.New("unexpected call to RefreshStack")
+}
+
+func (f *fakeRunner) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
+	if f.RefreshCellFn != nil {
+		return f.RefreshCellFn(cell)
+	}
+	return intmodel.Cell{}, 0, errors.New("unexpected call to RefreshCell")
 }
 
 // Test helper functions

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -70,13 +70,14 @@ type fakeRunner struct {
 	UpdateCellMetadataFn      func(cell intmodel.Cell) error
 
 	// Container methods
-	ListContainersFn  func(realmName, spaceName, stackName, cellName string) ([]intmodel.ContainerSpec, error)
-	CreateContainerFn func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
-	EnsureContainerFn func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
-	StartContainerFn  func(cell intmodel.Cell, containerID string) error
-	StopContainerFn   func(cell intmodel.Cell, containerID string) error
-	KillContainerFn   func(cell intmodel.Cell, containerID string) error
-	DeleteContainerFn func(cell intmodel.Cell, containerID string) error
+	ListContainersFn    func(realmName, spaceName, stackName, cellName string) ([]intmodel.ContainerSpec, error)
+	CreateContainerFn   func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
+	EnsureContainerFn   func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
+	StartContainerFn    func(cell intmodel.Cell, containerID string) error
+	StopContainerFn     func(cell intmodel.Cell, containerID string) error
+	KillContainerFn     func(cell intmodel.Cell, containerID string) error
+	DeleteContainerFn   func(cell intmodel.Cell, containerID string) error
+	GetContainerStateFn func(cell intmodel.Cell, containerID string) (intmodel.ContainerState, error)
 
 	// Utility methods
 	ExistsCgroupFn func(doc any) (bool, error)
@@ -357,6 +358,13 @@ func (f *fakeRunner) DeleteContainer(cell intmodel.Cell, containerID string) err
 		return f.DeleteContainerFn(cell, containerID)
 	}
 	return errors.New("unexpected call to DeleteContainer")
+}
+
+func (f *fakeRunner) GetContainerState(cell intmodel.Cell, containerID string) (intmodel.ContainerState, error) {
+	if f.GetContainerStateFn != nil {
+		return f.GetContainerStateFn(cell, containerID)
+	}
+	return intmodel.ContainerStateUnknown, errors.New("unexpected call to GetContainerState")
 }
 
 // Utility methods

--- a/internal/controller/refresh.go
+++ b/internal/controller/refresh.go
@@ -1,0 +1,278 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"fmt"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// RefreshResult contains the summary of the refresh operation.
+type RefreshResult struct {
+	RealmsFound       []string
+	SpacesFound       []string
+	StacksFound       []string
+	CellsFound        []string
+	ContainersFound   []string
+	RealmsUpdated     []string
+	SpacesUpdated     []string
+	StacksUpdated     []string
+	CellsUpdated      []string
+	ContainersUpdated []string
+	Errors            []string
+}
+
+// RefreshAll refreshes all metadata entities by introspecting containerd and CNI.
+func (b *Exec) RefreshAll() (RefreshResult, error) {
+	defer b.runner.Close()
+	result := RefreshResult{
+		RealmsFound:       []string{},
+		SpacesFound:       []string{},
+		StacksFound:       []string{},
+		CellsFound:        []string{},
+		ContainersFound:   []string{},
+		RealmsUpdated:     []string{},
+		SpacesUpdated:     []string{},
+		StacksUpdated:     []string{},
+		CellsUpdated:      []string{},
+		ContainersUpdated: []string{},
+		Errors:            []string{},
+	}
+
+	// Ensure containerd client is connected (via runner)
+	// This is done implicitly when refresh methods are called
+
+	// List and refresh realms
+	realms, err := b.runner.ListRealms()
+	if err != nil {
+		b.logger.ErrorContext(b.ctx, "failed to list realms", "error", err)
+		result.Errors = append(result.Errors, fmt.Sprintf("failed to list realms: %v", err))
+		return result, nil
+	}
+
+	for _, realm := range realms {
+		b.refreshRealmAndChildren(realm, &result)
+	}
+
+	return result, nil
+}
+
+// refreshRealmAndChildren refreshes a realm and all its child resources.
+func (b *Exec) refreshRealmAndChildren(realm intmodel.Realm, result *RefreshResult) {
+	realmName := realm.Metadata.Name
+	result.RealmsFound = append(result.RealmsFound, realmName)
+
+	// Refresh realm
+	updatedRealm, realmUpdated, refreshErr := b.runner.RefreshRealm(realm)
+	if refreshErr != nil {
+		b.logger.WarnContext(b.ctx, "failed to refresh realm status", "realm", realmName, "error", refreshErr)
+		result.Errors = append(result.Errors, fmt.Sprintf("failed to refresh realm '%s': %v", realmName, refreshErr))
+	} else if realmUpdated {
+		result.RealmsUpdated = append(result.RealmsUpdated, realmName)
+		_ = updatedRealm // Updated realm is persisted by RefreshRealm
+	}
+
+	// List and refresh spaces in this realm
+	spaces, err := b.runner.ListSpaces(realmName)
+	if err != nil {
+		b.logger.WarnContext(b.ctx, "failed to list spaces", "realm", realmName, "error", err)
+		result.Errors = append(result.Errors, fmt.Sprintf("failed to list spaces in realm '%s': %v", realmName, err))
+		return
+	}
+
+	for _, space := range spaces {
+		b.refreshSpaceAndChildren(realmName, space, result)
+	}
+}
+
+// refreshSpaceAndChildren refreshes a space and all its child resources.
+func (b *Exec) refreshSpaceAndChildren(realmName string, space intmodel.Space, result *RefreshResult) {
+	spaceName := space.Metadata.Name
+	result.SpacesFound = append(result.SpacesFound, spaceName)
+
+	// Refresh space
+	updatedSpace, spaceUpdated, spaceErr := b.runner.RefreshSpace(space)
+	if spaceErr != nil {
+		b.logger.WarnContext(
+			b.ctx,
+			"failed to refresh space status",
+			"realm",
+			realmName,
+			"space",
+			spaceName,
+			"error",
+			spaceErr,
+		)
+		result.Errors = append(
+			result.Errors,
+			fmt.Sprintf("failed to refresh space '%s' in realm '%s': %v", spaceName, realmName, spaceErr),
+		)
+	} else if spaceUpdated {
+		result.SpacesUpdated = append(result.SpacesUpdated, spaceName)
+		_ = updatedSpace // Updated space is persisted by RefreshSpace
+	}
+
+	// List and refresh stacks in this space
+	stacks, err := b.runner.ListStacks(realmName, spaceName)
+	if err != nil {
+		b.logger.WarnContext(b.ctx, "failed to list stacks", "realm", realmName, "space", spaceName, "error", err)
+		result.Errors = append(
+			result.Errors,
+			fmt.Sprintf("failed to list stacks in realm '%s', space '%s': %v", realmName, spaceName, err),
+		)
+		return
+	}
+
+	for _, stack := range stacks {
+		b.refreshStackAndChildren(realmName, spaceName, stack, result)
+	}
+}
+
+// refreshStackAndChildren refreshes a stack and all its child resources.
+func (b *Exec) refreshStackAndChildren(realmName, spaceName string, stack intmodel.Stack, result *RefreshResult) {
+	stackName := stack.Metadata.Name
+	result.StacksFound = append(result.StacksFound, stackName)
+
+	// Refresh stack
+	updatedStack, stackUpdated, stackErr := b.runner.RefreshStack(stack)
+	if stackErr != nil {
+		b.logger.WarnContext(
+			b.ctx,
+			"failed to refresh stack status",
+			"realm",
+			realmName,
+			"space",
+			spaceName,
+			"stack",
+			stackName,
+			"error",
+			stackErr,
+		)
+		result.Errors = append(
+			result.Errors,
+			fmt.Sprintf(
+				"failed to refresh stack '%s' in realm '%s', space '%s': %v",
+				stackName,
+				realmName,
+				spaceName,
+				stackErr,
+			),
+		)
+	} else if stackUpdated {
+		result.StacksUpdated = append(result.StacksUpdated, stackName)
+		_ = updatedStack // Updated stack is persisted by RefreshStack
+	}
+
+	// List and refresh cells in this stack
+	cells, err := b.runner.ListCells(realmName, spaceName, stackName)
+	if err != nil {
+		b.logger.WarnContext(
+			b.ctx,
+			"failed to list cells",
+			"realm",
+			realmName,
+			"space",
+			spaceName,
+			"stack",
+			stackName,
+			"error",
+			err,
+		)
+		result.Errors = append(
+			result.Errors,
+			fmt.Sprintf(
+				"failed to list cells in realm '%s', space '%s', stack '%s': %v",
+				realmName,
+				spaceName,
+				stackName,
+				err,
+			),
+		)
+		return
+	}
+
+	for _, cell := range cells {
+		b.refreshCellAndContainers(realmName, spaceName, stackName, cell, result)
+	}
+}
+
+// refreshCellAndContainers refreshes a cell and tracks its containers.
+func (b *Exec) refreshCellAndContainers(
+	realmName, spaceName, stackName string,
+	cell intmodel.Cell,
+	result *RefreshResult,
+) {
+	cellName := cell.Metadata.Name
+	result.CellsFound = append(result.CellsFound, cellName)
+
+	// Track all containers from cell spec with fully qualified names
+	for _, containerSpec := range cell.Spec.Containers {
+		containerName := fmt.Sprintf("%s/%s/%s/%s/%s", realmName, spaceName, stackName, cellName, containerSpec.ID)
+		result.ContainersFound = append(result.ContainersFound, containerName)
+	}
+
+	// Store original cell status for comparison
+	originalCellStatus := cell.Status
+
+	updatedCell, containersUpdated, cellErr := b.runner.RefreshCell(cell)
+	if cellErr != nil {
+		b.logger.WarnContext(
+			b.ctx,
+			"failed to refresh cell status",
+			"realm",
+			realmName,
+			"space",
+			spaceName,
+			"stack",
+			stackName,
+			"cell",
+			cellName,
+			"error",
+			cellErr,
+		)
+		result.Errors = append(
+			result.Errors,
+			fmt.Sprintf(
+				"failed to refresh cell '%s' in realm '%s', space '%s', stack '%s': %v",
+				cellName,
+				realmName,
+				spaceName,
+				stackName,
+				cellErr,
+			),
+		)
+		return
+	}
+
+	// If containers were updated, we add all containers from this cell to ContainersUpdated
+	// since RefreshCell only returns a count, not which specific containers were updated
+	if containersUpdated > 0 {
+		for _, containerSpec := range updatedCell.Spec.Containers {
+			containerName := fmt.Sprintf("%s/%s/%s/%s/%s", realmName, spaceName, stackName, cellName, containerSpec.ID)
+			result.ContainersUpdated = append(result.ContainersUpdated, containerName)
+		}
+	}
+
+	// Check if cell status changed or if containers were updated (which triggers metadata write)
+	if originalCellStatus.State != updatedCell.Status.State ||
+		originalCellStatus.CgroupPath != updatedCell.Status.CgroupPath ||
+		containersUpdated > 0 {
+		result.CellsUpdated = append(result.CellsUpdated, cellName)
+	}
+	_ = updatedCell // Updated cell is persisted by RefreshCell
+}

--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -1,0 +1,224 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
+)
+
+// GetContainerState queries containerd for the actual task status of a container
+// and converts it to the internal ContainerState.
+func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmodel.ContainerState, error) {
+	containerID = strings.TrimSpace(containerID)
+	if containerID == "" {
+		return intmodel.ContainerStateUnknown, errors.New("container ID is required")
+	}
+
+	cellName := strings.TrimSpace(cell.Metadata.Name)
+	if cellName == "" {
+		return intmodel.ContainerStateUnknown, errdefs.ErrCellNotFound
+	}
+
+	realmName := strings.TrimSpace(cell.Spec.RealmName)
+	if realmName == "" {
+		return intmodel.ContainerStateUnknown, errdefs.ErrRealmNameRequired
+	}
+
+	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
+	if spaceName == "" {
+		return intmodel.ContainerStateUnknown, errdefs.ErrSpaceNameRequired
+	}
+
+	stackName := strings.TrimSpace(cell.Spec.StackName)
+	if stackName == "" {
+		return intmodel.ContainerStateUnknown, errdefs.ErrStackNameRequired
+	}
+
+	if err := r.ensureClientConnected(); err != nil {
+		r.logger.InfoContext(r.ctx, "failed to connect to containerd",
+			"container", containerID,
+			"error", err)
+		return intmodel.ContainerStateUnknown, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+
+	// Get realm to access namespace
+	lookupRealm := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: realmName,
+		},
+	}
+	internalRealm, err := r.GetRealm(lookupRealm)
+	if err != nil {
+		r.logger.InfoContext(r.ctx, "failed to get realm for container state",
+			"container", containerID,
+			"realm", realmName,
+			"error", err)
+		return intmodel.ContainerStateUnknown, fmt.Errorf("failed to get realm: %w", err)
+	}
+
+	namespace := internalRealm.Spec.Namespace
+	if namespace == "" {
+		// Fallback to realm name if namespace is not set
+		namespace = realmName
+		r.logger.DebugContext(r.ctx, "realm has no namespace, using realm name as fallback",
+			"realm", realmName,
+			"namespace", namespace)
+	}
+
+	// Set namespace for containerd operations
+	if r.ctrClient != nil {
+		r.ctrClient.SetNamespace(namespace)
+		r.logger.DebugContext(r.ctx, "set containerd namespace",
+			"namespace", namespace,
+			"realm", realmName)
+	}
+
+	// Find container in cell spec to get ContainerdID
+	var foundContainerSpec *intmodel.ContainerSpec
+	for i := range cell.Spec.Containers {
+		if cell.Spec.Containers[i].ID == containerID {
+			foundContainerSpec = &cell.Spec.Containers[i]
+			break
+		}
+	}
+
+	if foundContainerSpec == nil {
+		r.logger.InfoContext(r.ctx, "container not found in cell spec",
+			"container", containerID,
+			"cell", cellName,
+			"containersInCell", len(cell.Spec.Containers))
+		return intmodel.ContainerStateUnknown, fmt.Errorf("container %q not found in cell %q", containerID, cellName)
+	}
+
+	// Get cell ID (use Spec.ID if available, otherwise fall back to Metadata.Name)
+	cellID := strings.TrimSpace(cell.Spec.ID)
+	if cellID == "" {
+		cellID = strings.TrimSpace(cell.Metadata.Name)
+	}
+	if cellID == "" {
+		return intmodel.ContainerStateUnknown, errdefs.ErrCellIDRequired
+	}
+
+	// Get containerd ID
+	containerdID := foundContainerSpec.ContainerdID
+	if containerdID == "" {
+		// Build containerd ID if not set
+		if foundContainerSpec.Root {
+			containerdID, err = naming.BuildRootContainerdID(
+				cell.Spec.SpaceName,
+				cell.Spec.StackName,
+				cellID,
+			)
+		} else {
+			containerdID, err = naming.BuildContainerdID(
+				cell.Spec.SpaceName,
+				cell.Spec.StackName,
+				cellID,
+				foundContainerSpec.ID,
+			)
+		}
+		if err != nil {
+			return intmodel.ContainerStateUnknown, fmt.Errorf("failed to build containerd ID: %w", err)
+		}
+	}
+
+	r.logger.DebugContext(r.ctx, "querying container state",
+		"container", containerID,
+		"containerdID", containerdID,
+		"namespace", namespace)
+
+	// Check if container exists in containerd
+	// Note: ensureClientConnected() should have initialized the client, but check anyway
+	if r.ctrClient == nil {
+		r.logger.InfoContext(r.ctx, "containerd client not available after connection attempt",
+			"container", containerID,
+			"containerdID", containerdID)
+		return intmodel.ContainerStateUnknown, errors.New("containerd client not available")
+	}
+
+	containerExists, err := r.ctrClient.ExistsContainer(containerdID)
+	if err != nil {
+		r.logger.InfoContext(r.ctx, "failed to check container existence",
+			"container", containerID,
+			"containerdID", containerdID,
+			"error", err)
+		// If we can't check existence, return Unknown
+		return intmodel.ContainerStateUnknown, nil
+	}
+
+	if !containerExists {
+		// Container doesn't exist in containerd
+		r.logger.InfoContext(r.ctx, "container does not exist in containerd",
+			"container", containerID,
+			"containerdID", containerdID,
+			"namespace", namespace)
+		return intmodel.ContainerStateUnknown, nil
+	}
+
+	// Get task status if container exists
+	taskStatus, err := r.ctrClient.TaskStatus(containerdID)
+	if err != nil {
+		// Task might not exist even if container does (container was stopped/deleted)
+		r.logger.DebugContext(r.ctx, "failed to get task status (container exists but task may not)",
+			"container", containerID,
+			"containerdID", containerdID,
+			"error", err)
+		// Container exists but no task - container is stopped, return Stopped
+		return intmodel.ContainerStateStopped, nil
+	}
+
+	// Convert containerd status to internal container state
+	state := convertContainerdStatusToContainerState(taskStatus, true)
+	r.logger.InfoContext(r.ctx, "container state determined",
+		"container", containerID,
+		"containerdID", containerdID,
+		"namespace", namespace,
+		"taskStatus", taskStatus.Status,
+		"internalState", state)
+	return state, nil
+}
+
+// convertContainerdStatusToContainerState converts a containerd task status to internal ContainerState.
+func convertContainerdStatusToContainerState(status containerd.Status, hasTask bool) intmodel.ContainerState {
+	if !hasTask {
+		return intmodel.ContainerStateUnknown
+	}
+
+	switch status.Status {
+	case containerd.Running:
+		return intmodel.ContainerStateReady
+	case containerd.Stopped:
+		return intmodel.ContainerStateStopped
+	case containerd.Created:
+		return intmodel.ContainerStatePending
+	case containerd.Unknown:
+		return intmodel.ContainerStateUnknown
+	case containerd.Paused:
+		return intmodel.ContainerStatePaused
+	case containerd.Pausing:
+		return intmodel.ContainerStatePausing
+	default:
+		return intmodel.ContainerStateUnknown
+	}
+}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -1,0 +1,339 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
+)
+
+// RefreshRealm refreshes the status of a realm by checking cgroup and containerd namespace.
+// Returns the updated realm, whether it was updated, and any error.
+func (r *Exec) RefreshRealm(realm intmodel.Realm) (intmodel.Realm, bool, error) {
+	originalStatus := realm.Status
+	newStatus := intmodel.RealmStatus{
+		State:      intmodel.RealmStateUnknown, // Default to Unknown - will be updated if checks succeed
+		CgroupPath: originalStatus.CgroupPath,
+	}
+
+	// Check cgroup existence
+	cgroupExists, err := r.ExistsCgroup(realm)
+	switch {
+	case err != nil:
+		r.logger.DebugContext(r.ctx, "failed to check realm cgroup", "realm", realm.Metadata.Name, "error", err)
+		// If check fails, state remains Unknown (already set)
+	case cgroupExists:
+		newStatus.State = intmodel.RealmStateReady
+	default:
+		// Cgroup doesn't exist - realm is unknown
+		newStatus.State = intmodel.RealmStateUnknown
+	}
+
+	// Check containerd namespace (only if cgroup check succeeded without error)
+	if err == nil {
+		namespace := realm.Spec.Namespace
+		if namespace == "" {
+			namespace = realm.Metadata.Name
+		}
+		namespaceExists, namespaceErr := r.ExistsRealmContainerdNamespace(namespace)
+		switch {
+		case namespaceErr != nil:
+			r.logger.DebugContext(
+				r.ctx,
+				"failed to check realm namespace",
+				"realm",
+				realm.Metadata.Name,
+				"error",
+				namespaceErr,
+			)
+			// If namespace check fails, set state to Unknown (cannot determine state)
+			newStatus.State = intmodel.RealmStateUnknown
+		case namespaceExists && newStatus.State == intmodel.RealmStateReady:
+			// Namespace exists and cgroup exists - realm is ready
+			newStatus.State = intmodel.RealmStateReady
+		case !namespaceExists && newStatus.State == intmodel.RealmStateReady:
+			// Cgroup exists but namespace doesn't - realm is in inconsistent state
+			newStatus.State = intmodel.RealmStateUnknown
+		}
+	}
+
+	// Update if status changed
+	updated := false
+	if newStatus.State != originalStatus.State || newStatus.CgroupPath != originalStatus.CgroupPath {
+		realm.Status = newStatus
+		if updateErr := r.UpdateRealmMetadata(realm); updateErr != nil {
+			return realm, false, fmt.Errorf("failed to update realm metadata: %w", updateErr)
+		}
+		updated = true
+	}
+
+	return realm, updated, nil
+}
+
+// RefreshSpace refreshes the status of a space by checking CNI config.
+// Returns the updated space, whether it was updated, and any error.
+func (r *Exec) RefreshSpace(space intmodel.Space) (intmodel.Space, bool, error) {
+	originalStatus := space.Status
+	newStatus := intmodel.SpaceStatus{
+		State:      intmodel.SpaceStateUnknown, // Default to Unknown - will be updated if checks succeed
+		CgroupPath: originalStatus.CgroupPath,
+	}
+
+	// Check CNI config existence
+	cniExists, err := r.ExistsSpaceCNIConfig(space)
+	switch {
+	case err != nil:
+		r.logger.DebugContext(r.ctx, "failed to check space CNI config", "space", space.Metadata.Name, "error", err)
+		// If check fails, state remains Unknown (already set)
+	case cniExists:
+		newStatus.State = intmodel.SpaceStateReady
+	default:
+		// CNI config doesn't exist - space is unknown
+		newStatus.State = intmodel.SpaceStateUnknown
+	}
+
+	// Check cgroup existence (only if CNI check succeeded without error)
+	if err == nil {
+		cgroupExists, cgroupErr := r.ExistsCgroup(space)
+		switch {
+		case cgroupErr != nil:
+			r.logger.DebugContext(
+				r.ctx,
+				"failed to check space cgroup",
+				"space",
+				space.Metadata.Name,
+				"error",
+				cgroupErr,
+			)
+			// If cgroup check fails, set state to Unknown (cannot determine state)
+			newStatus.State = intmodel.SpaceStateUnknown
+		case cgroupExists && newStatus.State == intmodel.SpaceStateReady:
+			// Both CNI and cgroup exist - space is ready
+			newStatus.State = intmodel.SpaceStateReady
+		case !cgroupExists && newStatus.State == intmodel.SpaceStateReady:
+			// CNI exists but cgroup doesn't - space is in inconsistent state
+			newStatus.State = intmodel.SpaceStateUnknown
+		}
+	}
+
+	// Update if status changed
+	updated := false
+	if newStatus.State != originalStatus.State || newStatus.CgroupPath != originalStatus.CgroupPath {
+		space.Status = newStatus
+		if updateErr := r.UpdateSpaceMetadata(space); updateErr != nil {
+			return space, false, fmt.Errorf("failed to update space metadata: %w", updateErr)
+		}
+		updated = true
+	}
+
+	return space, updated, nil
+}
+
+// RefreshStack refreshes the status of a stack by checking cgroup.
+// Returns the updated stack, whether it was updated, and any error.
+func (r *Exec) RefreshStack(stack intmodel.Stack) (intmodel.Stack, bool, error) {
+	originalStatus := stack.Status
+	newStatus := intmodel.StackStatus{
+		State:      intmodel.StackStateUnknown, // Default to Unknown - will be updated if checks succeed
+		CgroupPath: originalStatus.CgroupPath,
+	}
+
+	// Check cgroup existence
+	cgroupExists, err := r.ExistsCgroup(stack)
+	switch {
+	case err != nil:
+		r.logger.DebugContext(r.ctx, "failed to check stack cgroup", "stack", stack.Metadata.Name, "error", err)
+		// If check fails, state remains Unknown (already set)
+	case cgroupExists:
+		newStatus.State = intmodel.StackStateReady
+	default:
+		// Cgroup doesn't exist - stack is unknown
+		newStatus.State = intmodel.StackStateUnknown
+	}
+
+	// Update if status changed
+	updated := false
+	if newStatus.State != originalStatus.State || newStatus.CgroupPath != originalStatus.CgroupPath {
+		stack.Status = newStatus
+		if updateErr := r.UpdateStackMetadata(stack); updateErr != nil {
+			return stack, false, fmt.Errorf("failed to update stack metadata: %w", updateErr)
+		}
+		updated = true
+	}
+
+	return stack, updated, nil
+}
+
+// RefreshCell refreshes the status of a cell and its containers.
+// Returns the updated cell, number of containers updated, and any error.
+func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
+	originalStatus := cell.Status
+	newStatus := intmodel.CellStatus{
+		State:      intmodel.CellStateUnknown, // Default to Unknown - will be updated if checks succeed
+		CgroupPath: originalStatus.CgroupPath,
+	}
+
+	// Check cgroup existence
+	cgroupExists, err := r.ExistsCgroup(cell)
+	switch {
+	case err != nil:
+		r.logger.DebugContext(r.ctx, "failed to check cell cgroup", "cell", cell.Metadata.Name, "error", err)
+		// If check fails, state remains Unknown (already set)
+	case cgroupExists:
+		newStatus.State = intmodel.CellStateReady
+	default:
+		// Cgroup doesn't exist - cell is unknown
+		newStatus.State = intmodel.CellStateUnknown
+	}
+
+	// Refresh all containers in the cell (always attempt, regardless of cgroup check result)
+	containersUpdated := 0
+	for i := range cell.Spec.Containers {
+		containerSpec := &cell.Spec.Containers[i]
+		updated, containerErr := r.refreshContainerStatus(cell, containerSpec)
+		if containerErr != nil {
+			r.logger.WarnContext(r.ctx, "failed to refresh container status",
+				"cell", cell.Metadata.Name,
+				"container", containerSpec.ID,
+				"error", containerErr)
+			// Continue with other containers
+		} else if updated {
+			containersUpdated++
+		}
+	}
+
+	// Update cell metadata if status changed or containers were updated
+	cellUpdated := false
+	if newStatus.State != originalStatus.State || newStatus.CgroupPath != originalStatus.CgroupPath {
+		cell.Status = newStatus
+		cellUpdated = true
+	}
+
+	if cellUpdated || containersUpdated > 0 {
+		if updateErr := r.UpdateCellMetadata(cell); updateErr != nil {
+			return cell, containersUpdated, fmt.Errorf("failed to update cell metadata: %w", updateErr)
+		}
+		return cell, containersUpdated, nil
+	}
+
+	return cell, containersUpdated, nil
+}
+
+// refreshContainerStatus refreshes the status of a container by introspecting containerd.
+func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmodel.ContainerSpec) (bool, error) {
+	// Get realm to access namespace
+	lookupRealm := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: cell.Spec.RealmName,
+		},
+	}
+	internalRealm, err := r.GetRealm(lookupRealm)
+	if err != nil {
+		return false, fmt.Errorf("failed to get realm: %w", err)
+	}
+
+	namespace := internalRealm.Spec.Namespace
+	if namespace == "" {
+		namespace = internalRealm.Metadata.Name
+	}
+
+	// Set namespace for containerd operations
+	if r.ctrClient != nil {
+		r.ctrClient.SetNamespace(namespace)
+	}
+
+	// Get containerd ID
+	containerdID := containerSpec.ContainerdID
+	if containerdID == "" {
+		// Build containerd ID if not set
+		if containerSpec.Root {
+			containerdID, err = naming.BuildRootContainerdID(
+				cell.Spec.SpaceName,
+				cell.Spec.StackName,
+				cell.Spec.ID,
+			)
+		} else {
+			containerdID, err = naming.BuildContainerdID(
+				cell.Spec.SpaceName,
+				cell.Spec.StackName,
+				cell.Spec.ID,
+				containerSpec.ID,
+			)
+		}
+		if err != nil {
+			return false, fmt.Errorf("failed to build containerd ID: %w", err)
+		}
+	}
+
+	// Check if container exists in containerd
+	containerExists := false
+	if r.ctrClient != nil {
+		containerExists, err = r.ctrClient.ExistsContainer(containerdID)
+		if err != nil {
+			r.logger.DebugContext(r.ctx, "failed to check container existence",
+				"container", containerSpec.ID,
+				"containerdID", containerdID,
+				"error", err)
+			// Continue - assume container doesn't exist
+		}
+	}
+
+	// Get task status if container exists
+	var taskStatus containerd.Status
+	taskExists := false
+	if containerExists && r.ctrClient != nil {
+		taskStatus, err = r.ctrClient.TaskStatus(containerdID)
+		if err != nil {
+			// Task might not exist even if container does
+			r.logger.DebugContext(r.ctx, "failed to get task status",
+				"container", containerSpec.ID,
+				"containerdID", containerdID,
+				"error", err)
+		} else {
+			taskExists = true
+		}
+	}
+
+	// Log container state for debugging
+	switch {
+	case taskExists:
+		r.logger.DebugContext(r.ctx, "container task status",
+			"container", containerSpec.ID,
+			"containerdID", containerdID,
+			"status", taskStatus.Status)
+	case containerExists:
+		r.logger.DebugContext(r.ctx, "container exists but no task",
+			"container", containerSpec.ID,
+			"containerdID", containerdID)
+	default:
+		r.logger.DebugContext(r.ctx, "container not found in containerd",
+			"container", containerSpec.ID,
+			"containerdID", containerdID)
+	}
+
+	// Update container's ContainerdID if it was missing and we successfully built it
+	updated := false
+	if containerSpec.ContainerdID == "" && containerdID != "" {
+		containerSpec.ContainerdID = containerdID
+		updated = true
+	}
+
+	return updated, nil
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -80,6 +80,11 @@ type Runner interface {
 	PurgeCell(cell intmodel.Cell) error
 	PurgeContainer(realm intmodel.Realm, containerID string) error
 
+	RefreshRealm(realm intmodel.Realm) (intmodel.Realm, bool, error)
+	RefreshSpace(space intmodel.Space) (intmodel.Space, bool, error)
+	RefreshStack(stack intmodel.Stack) (intmodel.Stack, bool, error)
+	RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error)
+
 	Close() error
 }
 

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -85,6 +85,8 @@ type Runner interface {
 	RefreshStack(stack intmodel.Stack) (intmodel.Stack, bool, error)
 	RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error)
 
+	GetContainerState(cell intmodel.Cell, containerID string) (intmodel.ContainerState, error)
+
 	Close() error
 }
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -28,10 +28,14 @@ import (
 )
 
 func existsFilePath(filepath string) bool {
-	if _, err := os.Stat(filepath); err == nil {
+	_, err := os.Stat(filepath)
+	if err == nil {
 		return true
 	}
-	return false
+	// Only return false if the error is specifically "file does not exist"
+	// For other errors (like permission denied), return true so we attempt
+	// to read the file anyway and let the read operation provide the actual error
+	return !os.IsNotExist(err)
 }
 
 func WriteMetadata(ctx context.Context, logger *slog.Logger, metadata any, file string) error {

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -65,6 +65,9 @@ type ContainerState int
 const (
 	ContainerStatePending ContainerState = iota
 	ContainerStateReady
+	ContainerStateStopped
+	ContainerStatePaused
+	ContainerStatePausing
 	ContainerStateFailed
 	ContainerStateUnknown
 )

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -39,6 +39,9 @@ const (
 const (
 	StatePendingStr  = "Pending"
 	StateReadyStr    = "Ready"
+	StateStoppedStr  = "Stopped"
+	StatePausedStr   = "Paused"
+	StatePausingStr  = "Pausing"
 	StateFailedStr   = "Failed"
 	StateUnknownStr  = "Unknown"
 	StateCreatingStr = "Creating"

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -67,6 +67,9 @@ type ContainerState int
 const (
 	ContainerStatePending ContainerState = iota
 	ContainerStateReady
+	ContainerStateStopped
+	ContainerStatePaused
+	ContainerStatePausing
 	ContainerStateFailed
 	ContainerStateUnknown
 )
@@ -77,6 +80,12 @@ func (c *ContainerState) String() string {
 		return StatePendingStr
 	case ContainerStateReady:
 		return StateReadyStr
+	case ContainerStateStopped:
+		return StateStoppedStr
+	case ContainerStatePaused:
+		return StatePausedStr
+	case ContainerStatePausing:
+		return StatePausingStr
 	case ContainerStateFailed:
 		return StateFailedStr
 	case ContainerStateUnknown:
@@ -116,7 +125,7 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 				RestartPolicy:   "",
 			},
 			Status: ContainerStatus{
-				State:        ContainerStateUnknown,
+				State:        ContainerStatePending,
 				RestartCount: 0,
 				RestartTime:  time.Time{},
 				StartTime:    time.Time{},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `kuke refresh` to reconcile .status from containerd/CNI, implements container state querying, shows state in `get container` output, and updates start/stop/kill flows and models.
> 
> - **CLI**:
>   - Add `refresh` command to introspect containerd/CNI and update metadata `.status` with a summarized report.
>   - `get container` now queries actual container state and displays a `STATE` column when listing.
> - **Controller/Runner**:
>   - Add `RefreshAll` orchestration and runner methods `RefreshRealm/Space/Stack/Cell`.
>   - Implement `GetContainerState` (containerd task status → internal state) with namespace handling and fallbacks.
>   - Start/stop/kill/create container paths now return containers with actual runtime state.
> - **API/Model**:
>   - Extend `ContainerState` with `Stopped`, `Paused`, `Pausing`; add corresponding printable strings.
>   - Default external `ContainerStatus.State` initialized to `Pending`.
> - **Misc**:
>   - Improve metadata file existence check to treat non-ENOENT errors as existing.
>   - Wire `refresh` into root command; update interfaces/tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3c731ef6d96d5448606b1dadc8d86038832c87b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->