### PR TITLE
test: add e2e for apply+delete cmd

### DIFF
--- a/e2e/e2e_kuke_apply_test.go
+++ b/e2e/e2e_kuke_apply_test.go
@@ -17,114 +17,758 @@
 package e2e_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/eminwux/kukeon/internal/consts"
 )
 
-func TestKukeApply_Realm(t *testing.T) {
-	t.Parallel()
+// readTestdataYAML reads a YAML file from the testdata directory.
+func readTestdataYAML(t *testing.T, filename string) string {
+	t.Helper()
 
-	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
-
-	realmName := generateUniqueRealmName(t)
-
-	// Create a temporary YAML file
-	tmpDir := t.TempDir()
-	yamlFile := filepath.Join(tmpDir, "realm.yaml")
-	yaml := `apiVersion: v1beta1
-kind: Realm
-metadata:
-  name: ` + realmName + `
-spec:
-  namespace: ` + realmName + `-ns
-`
-
-	err := os.WriteFile(yamlFile, []byte(yaml), 0o644)
+	// Get the testdata directory path
+	// testdata is at cmd/kuke/apply/testdata/ relative to repo root
+	// e2e tests are in e2e/ directory
+	cwd, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("failed to write YAML file: %v", err)
+		t.Fatalf("could not get working dir: %v", err)
 	}
 
-	// Run apply command
-	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", yamlFile)
-	output := runReturningBinary(t, nil, kuke, args...)
+	// Navigate from e2e/ to cmd/kuke/apply/testdata/
+	testdataPath := filepath.Join(cwd, "..", "cmd", "kuke", "apply", "testdata", filename)
 
-	if len(output) == 0 {
-		t.Fatal("expected output from apply command")
+	content, err := os.ReadFile(testdataPath)
+	if err != nil {
+		t.Fatalf("failed to read testdata YAML file %q: %v", filename, err)
 	}
 
-	// Verify realm was created
-	if !verifyRealmInList(t, runPath, realmName) {
-		t.Errorf("realm %q not found in list after apply", realmName)
+	return string(content)
+}
+
+// verifyYAMLCompleteness validates that a YAML file has all required fields.
+func verifyYAMLCompleteness(t *testing.T, filename string) {
+	t.Helper()
+
+	content := readTestdataYAML(t, filename)
+
+	// Basic checks for required fields
+	if !strings.Contains(content, "apiVersion: v1beta1") {
+		t.Errorf("YAML file %q missing apiVersion: v1beta1", filename)
 	}
 
-	// Verify metadata exists
-	if !verifyRealmMetadataExists(t, runPath, realmName) {
-		t.Errorf("realm metadata file not found for %q", realmName)
+	if !strings.Contains(content, "kind:") {
+		t.Errorf("YAML file %q missing kind field", filename)
+	}
+
+	if !strings.Contains(content, "metadata:") {
+		t.Errorf("YAML file %q missing metadata section", filename)
+	}
+
+	if !strings.Contains(content, "name:") {
+		t.Errorf("YAML file %q missing name field in metadata", filename)
+	}
+
+	if !strings.Contains(content, "spec:") {
+		t.Errorf("YAML file %q missing spec section", filename)
+	}
+
+	// Resource-specific checks
+	if strings.Contains(content, "kind: Realm") {
+		if !strings.Contains(content, "namespace:") {
+			t.Errorf("YAML file %q (Realm) missing spec.namespace", filename)
+		}
+	}
+
+	if strings.Contains(content, "kind: Space") {
+		if !strings.Contains(content, "realmId:") {
+			t.Errorf("YAML file %q (Space) missing spec.realmId", filename)
+		}
+	}
+
+	if strings.Contains(content, "kind: Stack") {
+		if !strings.Contains(content, "id:") {
+			t.Errorf("YAML file %q (Stack) missing spec.id", filename)
+		}
+		if !strings.Contains(content, "realmId:") {
+			t.Errorf("YAML file %q (Stack) missing spec.realmId", filename)
+		}
+		if !strings.Contains(content, "spaceId:") {
+			t.Errorf("YAML file %q (Stack) missing spec.spaceId", filename)
+		}
+	}
+
+	if strings.Contains(content, "kind: Cell") {
+		if !strings.Contains(content, "id:") {
+			t.Errorf("YAML file %q (Cell) missing spec.id", filename)
+		}
+		if !strings.Contains(content, "realmId:") {
+			t.Errorf("YAML file %q (Cell) missing spec.realmId", filename)
+		}
+		if !strings.Contains(content, "spaceId:") {
+			t.Errorf("YAML file %q (Cell) missing spec.spaceId", filename)
+		}
+		if !strings.Contains(content, "stackId:") {
+			t.Errorf("YAML file %q (Cell) missing spec.stackId", filename)
+		}
+		if !strings.Contains(content, "containers:") {
+			t.Errorf("YAML file %q (Cell) missing spec.containers", filename)
+		}
 	}
 }
 
-func TestKukeApply_MultiResource(t *testing.T) {
+// TestKukeApply_VerifyTestdataYAMLs tests that all testdata YAML files are complete.
+func TestKukeApply_VerifyTestdataYAMLs(t *testing.T) {
 	t.Parallel()
 
-	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
+	testFiles := []string{
+		"realm.yaml",
+		"space.yaml",
+		"stack.yaml",
+		"cell.yaml",
+		"multi-resource.yaml",
+	}
 
-	realmName := generateUniqueRealmName(t)
-	spaceName := "apply-space-" + strings.TrimPrefix(realmName, "e-r-")
+	for _, filename := range testFiles {
+		t.Run(filename, func(t *testing.T) {
+			t.Parallel()
+			verifyYAMLCompleteness(t, filename)
+		})
+	}
+}
 
-	// Create a temporary YAML file with multiple resources
+// applyYAMLFile reads a YAML file, applies string replacements, writes to temp file, runs apply command.
+func applyYAMLFile(t *testing.T, runPath, yamlFile string, replacements map[string]string) []byte {
+	t.Helper()
+
+	// Read the YAML file
+	yamlContent := readTestdataYAML(t, yamlFile)
+
+	// Apply replacements
+	for old, new := range replacements {
+		yamlContent = strings.ReplaceAll(yamlContent, old, new)
+	}
+
+	// Write to temporary file
 	tmpDir := t.TempDir()
-	yamlFile := filepath.Join(tmpDir, "multi.yaml")
-	yaml := `apiVersion: v1beta1
-kind: Realm
-metadata:
-  name: ` + realmName + `
-spec:
-  namespace: ` + realmName + `-ns
----
-apiVersion: v1beta1
-kind: Space
-metadata:
-  name: ` + spaceName + `
-spec:
-  realmId: ` + realmName + `
-`
-
-	err := os.WriteFile(yamlFile, []byte(yaml), 0o644)
+	tmpFile := filepath.Join(tmpDir, yamlFile)
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0o644)
 	if err != nil {
-		t.Fatalf("failed to write YAML file: %v", err)
+		t.Fatalf("failed to write temporary YAML file: %v", err)
 	}
 
 	// Run apply command
-	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", yamlFile)
+	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", tmpFile)
 	output := runReturningBinary(t, nil, kuke, args...)
+
+	return output
+}
+
+// getContainerIDsFromCell gets all container IDs from a cell's spec.
+func getContainerIDsFromCell(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) []string {
+	t.Helper()
+
+	args := append(
+		buildKukeRunPathArgs(runPath),
+		"get",
+		"cell",
+		cellName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+		"--stack",
+		stackName,
+		"--output",
+		"json",
+	)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	cell, err := parseCellJSON(t, output)
+	if err != nil {
+		t.Fatalf("failed to parse cell JSON: %v", err)
+	}
+
+	containerIDs := make([]string, 0, len(cell.Spec.Containers))
+	for _, container := range cell.Spec.Containers {
+		if container.ID != "" {
+			containerIDs = append(containerIDs, container.ID)
+		}
+	}
+
+	return containerIDs
+}
+
+// verifyCellContainersExist verifies all containers from a cell exist in containerd.
+func verifyCellContainersExist(t *testing.T, namespace, spaceName, stackName, cellID string, containerIDs []string) {
+	t.Helper()
+
+	for _, containerID := range containerIDs {
+		// Build containerd ID: {spaceName}_{stackName}_{cellID}_{containerID}
+		containerdID := fmt.Sprintf("%s_%s_%s_%s", spaceName, stackName, cellID, containerID)
+
+		// Verify container exists
+		if !verifyContainerExists(t, namespace, containerdID) {
+			t.Errorf(
+				"container %q (containerd ID: %q) not found in containerd namespace %q",
+				containerID,
+				containerdID,
+				namespace,
+			)
+		}
+
+		// Verify container task exists
+		if !verifyContainerTaskExists(t, namespace, containerdID) {
+			t.Errorf(
+				"container task %q (containerd ID: %q) not found in containerd namespace %q",
+				containerID,
+				containerdID,
+				namespace,
+			)
+		}
+	}
+}
+
+// TestKukeApply_Realm_VerifyState tests realm apply with comprehensive verification.
+func TestKukeApply_Realm_VerifyState(t *testing.T) {
+	t.Parallel()
+
+	// Setup
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+	realmName := generateUniqueRealmName(t)
+
+	// Cleanup: Delete realm
+	t.Cleanup(func() {
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Apply realm.yaml with name replacements
+	replacements := map[string]string{
+		"test-realm": realmName,
+		"test-ns":    realmName + "-ns",
+	}
+	output := applyYAMLFile(t, runPath, "realm.yaml", replacements)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from apply command")
+	}
+
+	// Verify containerd namespace exists
+	namespace := realmName + "-ns"
+	if !verifyContainerdNamespace(t, namespace) {
+		t.Fatalf("containerd namespace %q not found after apply", namespace)
+	}
+
+	// Verify metadata file exists
+	if !verifyRealmMetadataExists(t, runPath, realmName) {
+		t.Fatalf("realm metadata file not found for realm %q", realmName)
+	}
+
+	// Verify realm appears in list
+	if !verifyRealmInList(t, runPath, realmName) {
+		t.Fatalf("realm %q not found in realm list", realmName)
+	}
+
+	// Verify realm can be retrieved individually
+	if !verifyRealmExists(t, runPath, realmName) {
+		t.Fatalf("realm %q cannot be retrieved individually", realmName)
+	}
+
+	// Verify cgroup path exists
+	args := append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	realmOutput := runReturningBinary(t, nil, kuke, args...)
+
+	realm, err := parseRealmJSON(t, realmOutput)
+	if err != nil {
+		t.Fatalf("failed to parse realm JSON: %v", err)
+	}
+
+	if realm.Status.CgroupPath == "" {
+		t.Fatal("realm cgroup path is empty")
+	}
+
+	// Verify cgroup path exists in filesystem
+	if !verifyCgroupPathExists(t, realm.Status.CgroupPath) {
+		relativePath := strings.TrimPrefix(realm.Status.CgroupPath, "/")
+		fullPath := filepath.Join(consts.CgroupFilesystemPath, relativePath)
+		t.Fatalf("cgroup path %q (full path: %q) does not exist in filesystem", realm.Status.CgroupPath, fullPath)
+	}
+
+	// Verify expected cgroup path structure
+	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName
+	if !strings.HasSuffix(realm.Status.CgroupPath, expectedCgroupPath) {
+		t.Logf(
+			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",
+			realm.Status.CgroupPath,
+			expectedCgroupPath,
+		)
+	}
+}
+
+// TestKukeApply_Space_VerifyState tests space apply with comprehensive verification.
+func TestKukeApply_Space_VerifyState(t *testing.T) {
+	t.Parallel()
+
+	// Setup
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+
+	// Cleanup: Delete space first, then realm (reverse dependency order)
+	t.Cleanup(func() {
+		cleanupSpace(t, runPath, realmName, spaceName)
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Step 1: Create realm (prerequisite)
+	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 2: Apply space.yaml with name replacements
+	replacements := map[string]string{
+		"test-space": spaceName,
+		"test-realm": realmName,
+	}
+	output := applyYAMLFile(t, runPath, "space.yaml", replacements)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from apply command")
+	}
+
+	// Verify CNI config file exists
+	if !verifySpaceCNIConfigExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("CNI config file not found for space %q", spaceName)
+	}
+
+	// Verify metadata file exists
+	if !verifySpaceMetadataExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("space metadata file not found for space %q", spaceName)
+	}
+
+	// Verify space appears in list
+	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+		t.Fatalf("space %q not found in space list", spaceName)
+	}
+
+	// Verify space can be retrieved individually
+	if !verifySpaceExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("space %q cannot be retrieved individually", spaceName)
+	}
+
+	// Verify cgroup path exists
+	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	spaceOutput := runReturningBinary(t, nil, kuke, args...)
+
+	space, err := parseSpaceJSON(t, spaceOutput)
+	if err != nil {
+		t.Fatalf("failed to parse space JSON: %v", err)
+	}
+
+	if space.Status.CgroupPath == "" {
+		t.Fatal("space cgroup path is empty")
+	}
+
+	// Verify cgroup path exists in filesystem
+	if !verifyCgroupPathExists(t, space.Status.CgroupPath) {
+		t.Fatalf("cgroup path %q does not exist in filesystem", space.Status.CgroupPath)
+	}
+
+	// Verify expected cgroup path structure
+	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName
+	if !strings.HasSuffix(space.Status.CgroupPath, expectedCgroupPath) {
+		t.Logf(
+			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",
+			space.Status.CgroupPath,
+			expectedCgroupPath,
+		)
+	}
+}
+
+// TestKukeApply_Stack_VerifyState tests stack apply with comprehensive verification.
+func TestKukeApply_Stack_VerifyState(t *testing.T) {
+	t.Parallel()
+
+	// Setup
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+
+	// Cleanup: Delete stack, space, realm (reverse dependency order)
+	t.Cleanup(func() {
+		cleanupStack(t, runPath, realmName, spaceName, stackName)
+		cleanupSpace(t, runPath, realmName, spaceName)
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Step 1: Create realm (prerequisite)
+	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 2: Create space (prerequisite)
+	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 3: Apply stack.yaml with name replacements
+	replacements := map[string]string{
+		"test-stack": stackName,
+		"test-realm": realmName,
+		"test-space": spaceName,
+	}
+	output := applyYAMLFile(t, runPath, "stack.yaml", replacements)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from apply command")
+	}
+
+	// Verify metadata file exists
+	if !verifyStackMetadataExists(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack metadata file not found for stack %q", stackName)
+	}
+
+	// Verify stack appears in list
+	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack %q not found in stack list", stackName)
+	}
+
+	// Verify stack can be retrieved individually
+	if !verifyStackExists(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack %q cannot be retrieved individually", stackName)
+	}
+
+	// Verify cgroup path exists
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"get",
+		"stack",
+		stackName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+		"--output",
+		"json",
+	)
+	stackOutput := runReturningBinary(t, nil, kuke, args...)
+
+	stack, err := parseStackJSON(t, stackOutput)
+	if err != nil {
+		t.Fatalf("failed to parse stack JSON: %v", err)
+	}
+
+	if stack.Status.CgroupPath == "" {
+		t.Fatal("stack cgroup path is empty")
+	}
+
+	// Verify cgroup path exists in filesystem
+	if !verifyCgroupPathExists(t, stack.Status.CgroupPath) {
+		t.Fatalf("cgroup path %q does not exist in filesystem", stack.Status.CgroupPath)
+	}
+
+	// Verify expected cgroup path structure
+	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName
+	if !strings.HasSuffix(stack.Status.CgroupPath, expectedCgroupPath) {
+		t.Logf(
+			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",
+			stack.Status.CgroupPath,
+			expectedCgroupPath,
+		)
+	}
+}
+
+// TestKukeApply_Cell_VerifyState tests cell apply with comprehensive verification.
+func TestKukeApply_Cell_VerifyState(t *testing.T) {
+	t.Parallel()
+
+	// Setup
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+	cellName := generateUniqueCellName(t)
+
+	// Cleanup: Delete cell, stack, space, realm (reverse dependency order)
+	t.Cleanup(func() {
+		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, runPath, realmName, spaceName, stackName)
+		cleanupSpace(t, runPath, realmName, spaceName)
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Step 1: Create realm (prerequisite)
+	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 2: Create space (prerequisite)
+	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 3: Create stack (prerequisite)
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"create",
+		"stack",
+		stackName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+	)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 4: Apply cell.yaml with name replacements
+	replacements := map[string]string{
+		"test-cell":  cellName,
+		"test-realm": realmName,
+		"test-space": spaceName,
+		"test-stack": stackName,
+	}
+	output := applyYAMLFile(t, runPath, "cell.yaml", replacements)
+
+	if len(output) == 0 {
+		t.Fatal("expected output from apply command")
+	}
+
+	// Verify metadata file exists
+	if !verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {
+		t.Fatalf("cell metadata file not found for cell %q", cellName)
+	}
+
+	// Verify cell appears in list
+	if !verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+		t.Fatalf("cell %q not found in cell list", cellName)
+	}
+
+	// Verify cell can be retrieved individually
+	if !verifyCellExists(t, runPath, realmName, spaceName, stackName, cellName) {
+		t.Fatalf("cell %q cannot be retrieved individually", cellName)
+	}
+
+	// Verify cgroup path exists
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"get",
+		"cell",
+		cellName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+		"--stack",
+		stackName,
+		"--output",
+		"json",
+	)
+	cellOutput := runReturningBinary(t, nil, kuke, args...)
+
+	cell, err := parseCellJSON(t, cellOutput)
+	if err != nil {
+		t.Fatalf("failed to parse cell JSON: %v", err)
+	}
+
+	if cell.Status.CgroupPath == "" {
+		t.Fatal("cell cgroup path is empty")
+	}
+
+	// Verify cgroup path exists in filesystem
+	if !verifyCgroupPathExists(t, cell.Status.CgroupPath) {
+		t.Fatalf("cgroup path %q does not exist in filesystem", cell.Status.CgroupPath)
+	}
+
+	// Verify expected cgroup path structure
+	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName + "/" + cellName
+	if !strings.HasSuffix(cell.Status.CgroupPath, expectedCgroupPath) {
+		t.Logf(
+			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",
+			cell.Status.CgroupPath,
+			expectedCgroupPath,
+		)
+	}
+
+	// Verify cell state is Ready (apply should start cells automatically)
+	// CellStateReady = 1
+	if cell.Status.State != 1 {
+		t.Fatalf("cell state after apply: %d, expected Ready (1)", cell.Status.State)
+	}
+
+	// Get realm namespace for container verification
+	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	if err != nil {
+		t.Fatalf("failed to get realm namespace: %v", err)
+	}
+	if realmNamespace == "" {
+		t.Fatal("realm namespace is empty")
+	}
+
+	// Get cell ID
+	cellID := cell.Spec.ID
+	if cellID == "" {
+		t.Fatal("cell ID is empty")
+	}
+
+	// Verify root container exists
+	rootContainerID := fmt.Sprintf("%s_%s_%s_root", spaceName, stackName, cellID)
+	if !verifyRootContainerExists(t, realmNamespace, rootContainerID) {
+		t.Fatalf("root container %q not found in containerd namespace %q", rootContainerID, realmNamespace)
+	}
+
+	// Verify root container task exists (cell should be started by apply)
+	if !verifyRootContainerTaskExists(t, realmNamespace, rootContainerID) {
+		t.Fatalf("root container task %q not found in containerd namespace %q", rootContainerID, realmNamespace)
+	}
+
+	// Get all container IDs from cell spec
+	containerIDs := getContainerIDsFromCell(t, runPath, realmName, spaceName, stackName, cellName)
+
+	// Verify all containers exist in containerd
+	verifyCellContainersExist(t, realmNamespace, spaceName, stackName, cellID, containerIDs)
+}
+
+// TestKukeApply_MultiResource_VerifyState tests multi-resource apply with comprehensive verification.
+func TestKukeApply_MultiResource_VerifyState(t *testing.T) {
+	t.Parallel()
+
+	// Setup
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+
+	// Cleanup: Delete stack, space, realm (reverse dependency order)
+	t.Cleanup(func() {
+		cleanupStack(t, runPath, realmName, spaceName, stackName)
+		cleanupSpace(t, runPath, realmName, spaceName)
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Apply multi-resource.yaml with name replacements
+	replacements := map[string]string{
+		"multi-realm": realmName,
+		"multi-ns":    realmName + "-ns",
+		"multi-space": spaceName,
+		"multi-stack": stackName,
+	}
+	output := applyYAMLFile(t, runPath, "multi-resource.yaml", replacements)
 
 	if len(output) == 0 {
 		t.Fatal("expected output from apply command")
 	}
 
 	// Verify realm was created
+	namespace := realmName + "-ns"
+	if !verifyContainerdNamespace(t, namespace) {
+		t.Fatalf("containerd namespace %q not found after apply", namespace)
+	}
+
+	if !verifyRealmMetadataExists(t, runPath, realmName) {
+		t.Fatalf("realm metadata file not found for realm %q", realmName)
+	}
+
 	if !verifyRealmInList(t, runPath, realmName) {
-		t.Errorf("realm %q not found in list after apply", realmName)
+		t.Fatalf("realm %q not found in realm list", realmName)
+	}
+
+	if !verifyRealmExists(t, runPath, realmName) {
+		t.Fatalf("realm %q cannot be retrieved individually", realmName)
+	}
+
+	// Verify realm cgroup path
+	args := append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	realmOutput := runReturningBinary(t, nil, kuke, args...)
+
+	realm, err := parseRealmJSON(t, realmOutput)
+	if err != nil {
+		t.Fatalf("failed to parse realm JSON: %v", err)
+	}
+
+	if realm.Status.CgroupPath == "" {
+		t.Fatal("realm cgroup path is empty")
+	}
+
+	if !verifyCgroupPathExists(t, realm.Status.CgroupPath) {
+		t.Fatalf("realm cgroup path %q does not exist in filesystem", realm.Status.CgroupPath)
 	}
 
 	// Verify space was created
-	spaceArgs := append(
+	if !verifySpaceCNIConfigExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("CNI config file not found for space %q", spaceName)
+	}
+
+	if !verifySpaceMetadataExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("space metadata file not found for space %q", spaceName)
+	}
+
+	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+		t.Fatalf("space %q not found in space list", spaceName)
+	}
+
+	if !verifySpaceExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("space %q cannot be retrieved individually", spaceName)
+	}
+
+	// Verify space cgroup path
+	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	spaceOutput := runReturningBinary(t, nil, kuke, args...)
+
+	space, err := parseSpaceJSON(t, spaceOutput)
+	if err != nil {
+		t.Fatalf("failed to parse space JSON: %v", err)
+	}
+
+	if space.Status.CgroupPath == "" {
+		t.Fatal("space cgroup path is empty")
+	}
+
+	if !verifyCgroupPathExists(t, space.Status.CgroupPath) {
+		t.Fatalf("space cgroup path %q does not exist in filesystem", space.Status.CgroupPath)
+	}
+
+	// Verify stack was created
+	if !verifyStackMetadataExists(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack metadata file not found for stack %q", stackName)
+	}
+
+	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack %q not found in stack list", stackName)
+	}
+
+	if !verifyStackExists(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack %q cannot be retrieved individually", stackName)
+	}
+
+	// Verify stack cgroup path
+	args = append(
 		buildKukeRunPathArgs(runPath),
 		"get",
-		"space",
-		spaceName,
+		"stack",
+		stackName,
 		"--realm",
 		realmName,
+		"--space",
+		spaceName,
 		"--output",
 		"json",
 	)
-	spaceOutput := runReturningBinary(t, nil, kuke, spaceArgs...)
+	stackOutput := runReturningBinary(t, nil, kuke, args...)
 
-	if len(spaceOutput) == 0 {
-		t.Errorf("space %q not found after apply", spaceName)
+	stack, err := parseStackJSON(t, stackOutput)
+	if err != nil {
+		t.Fatalf("failed to parse stack JSON: %v", err)
+	}
+
+	if stack.Status.CgroupPath == "" {
+		t.Fatal("stack cgroup path is empty")
+	}
+
+	if !verifyCgroupPathExists(t, stack.Status.CgroupPath) {
+		t.Fatalf("stack cgroup path %q does not exist in filesystem", stack.Status.CgroupPath)
 	}
 }

--- a/e2e/e2e_kuke_delete_f_test.go
+++ b/e2e/e2e_kuke_delete_f_test.go
@@ -17,10 +17,13 @@
 package e2e_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/eminwux/kukeon/internal/consts"
 )
 
 func TestKukeDeleteF_Realm(t *testing.T) {
@@ -296,5 +299,675 @@ spec:
 	}
 	if !strings.Contains(output2Str, "not found") && !strings.Contains(output2Str, "Not found") {
 		t.Errorf("expected 'not found' in second delete output, got: %q", output2Str)
+	}
+}
+
+// TestDeleteF_VerifyTestdataYAMLsComplete tests that all testdata YAML files are complete.
+func TestDeleteF_VerifyTestdataYAMLsComplete(t *testing.T) {
+	t.Parallel()
+
+	testFiles := []string{
+		"realm.yaml",
+		"space.yaml",
+		"stack.yaml",
+		"cell.yaml",
+		"multi-resource.yaml",
+	}
+
+	for _, filename := range testFiles {
+		t.Run(filename, func(t *testing.T) {
+			t.Parallel()
+			verifyYAMLCompleteness(t, filename)
+		})
+	}
+}
+
+// writeTempYAMLFile reads a YAML file from testdata, applies string replacements, and writes to a temporary file.
+func writeTempYAMLFile(t *testing.T, yamlFile string, replacements map[string]string) string {
+	t.Helper()
+
+	// Read the YAML file from testdata
+	yamlContent := readTestdataYAML(t, yamlFile)
+
+	// Apply replacements
+	for old, new := range replacements {
+		yamlContent = strings.ReplaceAll(yamlContent, old, new)
+	}
+
+	// Write to temporary file
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, yamlFile)
+	err := os.WriteFile(tmpFile, []byte(yamlContent), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write temporary YAML file: %v", err)
+	}
+
+	return tmpFile
+}
+
+// applyYAMLFileFromTestdata reads a YAML file from testdata, applies replacements, and runs apply command.
+func applyYAMLFileFromTestdata(t *testing.T, runPath, yamlFile string, replacements map[string]string) []byte {
+	t.Helper()
+
+	tmpFile := writeTempYAMLFile(t, yamlFile, replacements)
+
+	// Run apply command
+	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", tmpFile)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	return output
+}
+
+// deleteYAMLFileFromTestdata reads a YAML file from testdata, applies replacements, and runs delete command.
+func deleteYAMLFileFromTestdata(
+	t *testing.T,
+	runPath, yamlFile string,
+	replacements map[string]string,
+	cascade bool,
+) []byte {
+	t.Helper()
+
+	tmpFile := writeTempYAMLFile(t, yamlFile, replacements)
+
+	// Build delete command arguments
+	args := append(buildKukeRunPathArgs(runPath), "delete", "-f", tmpFile)
+	if cascade {
+		args = append(args, "--cascade")
+	}
+
+	// Run delete command
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	return output
+}
+
+// TestDeleteF_Realm_VerifyAllResourcesDeleted tests realm deletion with comprehensive verification.
+func TestDeleteF_Realm_VerifyAllResourcesDeleted(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	namespace := realmName + "-ns"
+
+	// Cleanup: Safety net
+	t.Cleanup(func() {
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Step 1: Apply realm.yaml to create the realm
+	replacements := map[string]string{
+		"test-realm": realmName,
+		"test-ns":    namespace,
+	}
+	_ = applyYAMLFileFromTestdata(t, runPath, "realm.yaml", replacements)
+
+	// Step 2: Verify realm was created
+	if !verifyContainerdNamespace(t, namespace) {
+		t.Fatalf("containerd namespace %q not found after apply", namespace)
+	}
+
+	if !verifyRealmMetadataExists(t, runPath, realmName) {
+		t.Fatalf("realm metadata file not found for realm %q", realmName)
+	}
+
+	if !verifyRealmInList(t, runPath, realmName) {
+		t.Fatalf("realm %q not found in realm list", realmName)
+	}
+
+	// Get realm JSON to extract cgroup path
+	args := append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	realm, err := parseRealmJSON(t, output)
+	if err != nil {
+		t.Fatalf("failed to parse realm JSON: %v", err)
+	}
+
+	if realm.Status.CgroupPath == "" {
+		t.Fatal("realm cgroup path is empty")
+	}
+
+	cgroupPath := realm.Status.CgroupPath
+
+	if !verifyCgroupPathExists(t, cgroupPath) {
+		t.Fatalf("cgroup path %q does not exist in filesystem", cgroupPath)
+	}
+
+	// Step 3: Delete using delete -f
+	_ = deleteYAMLFileFromTestdata(t, runPath, "realm.yaml", replacements, false)
+
+	// Step 4: Verify containerd namespace does NOT exist
+	if verifyContainerdNamespace(t, namespace) {
+		t.Fatalf("containerd namespace %q still exists after deletion", namespace)
+	}
+
+	// Step 5: Verify cgroup path does NOT exist
+	if verifyCgroupPathExists(t, cgroupPath) {
+		relativePath := strings.TrimPrefix(cgroupPath, "/")
+		fullPath := filepath.Join(consts.CgroupFilesystemPath, relativePath)
+		t.Fatalf("cgroup path %q (full path: %q) still exists after realm deletion", cgroupPath, fullPath)
+	}
+
+	// Step 6: Verify metadata file does NOT exist
+	if verifyRealmMetadataExists(t, runPath, realmName) {
+		t.Fatalf("realm metadata file still exists for realm %q after deletion", realmName)
+	}
+
+	// Step 7: Verify realm does NOT appear in list
+	if verifyRealmInList(t, runPath, realmName) {
+		t.Fatalf("realm %q still appears in realm list after deletion", realmName)
+	}
+}
+
+// TestDeleteF_Space_VerifyAllResourcesDeleted tests space deletion with comprehensive verification.
+func TestDeleteF_Space_VerifyAllResourcesDeleted(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+
+	// Cleanup: Safety net
+	t.Cleanup(func() {
+		cleanupSpace(t, runPath, realmName, spaceName)
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Step 1: Create realm (prerequisite)
+	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 2: Apply space.yaml to create the space
+	replacements := map[string]string{
+		"test-space": spaceName,
+		"test-realm": realmName,
+	}
+	_ = applyYAMLFileFromTestdata(t, runPath, "space.yaml", replacements)
+
+	// Step 3: Verify space was created
+	if !verifySpaceCNIConfigExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("CNI config file not found for space %q", spaceName)
+	}
+
+	if !verifySpaceMetadataExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("space metadata file not found for space %q", spaceName)
+	}
+
+	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+		t.Fatalf("space %q not found in space list", spaceName)
+	}
+
+	// Get space JSON to extract cgroup path
+	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	space, err := parseSpaceJSON(t, output)
+	if err != nil {
+		t.Fatalf("failed to parse space JSON: %v", err)
+	}
+
+	if space.Status.CgroupPath == "" {
+		t.Fatal("space cgroup path is empty")
+	}
+
+	cgroupPath := space.Status.CgroupPath
+
+	if !verifyCgroupPathExists(t, cgroupPath) {
+		t.Fatalf("cgroup path %q does not exist in filesystem", cgroupPath)
+	}
+
+	// Step 4: Delete using delete -f
+	_ = deleteYAMLFileFromTestdata(t, runPath, "space.yaml", replacements, false)
+
+	// Step 5: Verify CNI config file does NOT exist (network)
+	if verifySpaceCNIConfigExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("CNI config file still exists for space %q after deletion", spaceName)
+	}
+
+	// Step 6: Verify cgroup path does NOT exist
+	if verifyCgroupPathExists(t, cgroupPath) {
+		relativePath := strings.TrimPrefix(cgroupPath, "/")
+		fullPath := filepath.Join(consts.CgroupFilesystemPath, relativePath)
+		t.Fatalf("cgroup path %q (full path: %q) still exists after space deletion", cgroupPath, fullPath)
+	}
+
+	// Step 7: Verify metadata file does NOT exist
+	if verifySpaceMetadataExists(t, runPath, realmName, spaceName) {
+		t.Fatalf("space metadata file still exists for space %q after deletion", spaceName)
+	}
+
+	// Step 8: Verify space does NOT appear in list
+	if verifySpaceInList(t, runPath, realmName, spaceName) {
+		t.Fatalf("space %q still appears in space list after deletion", spaceName)
+	}
+}
+
+// TestDeleteF_Stack_VerifyAllResourcesDeleted tests stack deletion with comprehensive verification.
+func TestDeleteF_Stack_VerifyAllResourcesDeleted(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+
+	// Cleanup: Safety net
+	t.Cleanup(func() {
+		cleanupStack(t, runPath, realmName, spaceName, stackName)
+		cleanupSpace(t, runPath, realmName, spaceName)
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Step 1: Create realm (prerequisite)
+	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 2: Create space (prerequisite)
+	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 3: Apply stack.yaml to create the stack
+	replacements := map[string]string{
+		"test-stack": stackName,
+		"test-realm": realmName,
+		"test-space": spaceName,
+	}
+	_ = applyYAMLFileFromTestdata(t, runPath, "stack.yaml", replacements)
+
+	// Step 4: Verify stack was created
+	if !verifyStackMetadataExists(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack metadata file not found for stack %q", stackName)
+	}
+
+	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack %q not found in stack list", stackName)
+	}
+
+	// Get stack JSON to extract cgroup path
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"get",
+		"stack",
+		stackName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+		"--output",
+		"json",
+	)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	stack, err := parseStackJSON(t, output)
+	if err != nil {
+		t.Fatalf("failed to parse stack JSON: %v", err)
+	}
+
+	if stack.Status.CgroupPath == "" {
+		t.Fatal("stack cgroup path is empty")
+	}
+
+	cgroupPath := stack.Status.CgroupPath
+
+	if !verifyCgroupPathExists(t, cgroupPath) {
+		t.Fatalf("cgroup path %q does not exist in filesystem", cgroupPath)
+	}
+
+	// Step 5: Delete using delete -f
+	_ = deleteYAMLFileFromTestdata(t, runPath, "stack.yaml", replacements, false)
+
+	// Step 6: Verify cgroup path does NOT exist
+	if verifyCgroupPathExists(t, cgroupPath) {
+		relativePath := strings.TrimPrefix(cgroupPath, "/")
+		fullPath := filepath.Join(consts.CgroupFilesystemPath, relativePath)
+		t.Fatalf("cgroup path %q (full path: %q) still exists after stack deletion", cgroupPath, fullPath)
+	}
+
+	// Step 7: Verify metadata file does NOT exist
+	if verifyStackMetadataExists(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack metadata file still exists for stack %q after deletion", stackName)
+	}
+
+	// Step 8: Verify stack does NOT appear in list
+	if verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+		t.Fatalf("stack %q still appears in stack list after deletion", stackName)
+	}
+}
+
+// TestDeleteF_Cell_VerifyAllResourcesDeleted tests cell deletion with comprehensive verification.
+func TestDeleteF_Cell_VerifyAllResourcesDeleted(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+	cellName := generateUniqueCellName(t)
+
+	// Cleanup: Safety net
+	t.Cleanup(func() {
+		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, runPath, realmName, spaceName, stackName)
+		cleanupSpace(t, runPath, realmName, spaceName)
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Step 1: Create realm (prerequisite)
+	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 2: Create space (prerequisite)
+	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 3: Create stack (prerequisite)
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"create",
+		"stack",
+		stackName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+	)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 4: Apply cell.yaml to create the cell
+	replacements := map[string]string{
+		"test-cell":  cellName,
+		"test-realm": realmName,
+		"test-space": spaceName,
+		"test-stack": stackName,
+	}
+	_ = applyYAMLFileFromTestdata(t, runPath, "cell.yaml", replacements)
+
+	// Step 5: Verify cell was created
+	if !verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {
+		t.Fatalf("cell metadata file not found for cell %q", cellName)
+	}
+
+	if !verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+		t.Fatalf("cell %q not found in cell list", cellName)
+	}
+
+	// Get cell JSON to extract cgroup path and cell ID
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"get",
+		"cell",
+		cellName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+		"--stack",
+		stackName,
+		"--output",
+		"json",
+	)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	cell, err := parseCellJSON(t, output)
+	if err != nil {
+		t.Fatalf("failed to parse cell JSON: %v", err)
+	}
+
+	if cell.Status.CgroupPath == "" {
+		t.Fatal("cell cgroup path is empty")
+	}
+
+	cgroupPath := cell.Status.CgroupPath
+
+	if !verifyCgroupPathExists(t, cgroupPath) {
+		t.Fatalf("cgroup path %q does not exist in filesystem", cgroupPath)
+	}
+
+	// Get realm namespace and cell ID for root container verification
+	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	if err != nil {
+		t.Fatalf("failed to get realm namespace: %v", err)
+	}
+
+	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	if err != nil {
+		t.Fatalf("failed to get cell ID: %v", err)
+	}
+
+	// Build root container ID: {spaceName}_{stackName}_{cellID}_root
+	rootContainerID := fmt.Sprintf("%s_%s_%s_root", spaceName, stackName, cellID)
+
+	// Verify root container exists initially
+	if !verifyRootContainerExists(t, realmNamespace, rootContainerID) {
+		t.Fatalf("root container %q not found in containerd namespace %q", rootContainerID, realmNamespace)
+	}
+
+	// Step 6: Delete using delete -f
+	_ = deleteYAMLFileFromTestdata(t, runPath, "cell.yaml", replacements, false)
+
+	// Step 7: Verify cgroup path does NOT exist
+	if verifyCgroupPathExists(t, cgroupPath) {
+		relativePath := strings.TrimPrefix(cgroupPath, "/")
+		fullPath := filepath.Join(consts.CgroupFilesystemPath, relativePath)
+		t.Fatalf("cgroup path %q (full path: %q) still exists after cell deletion", cgroupPath, fullPath)
+	}
+
+	// Step 8: Verify metadata file does NOT exist
+	if verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {
+		t.Fatalf("cell metadata file still exists for cell %q after deletion", cellName)
+	}
+
+	// Step 9: Verify root container does NOT exist
+	if verifyRootContainerExists(t, realmNamespace, rootContainerID) {
+		t.Fatalf(
+			"root container %q still exists in containerd namespace %q after cell deletion",
+			rootContainerID,
+			realmNamespace,
+		)
+	}
+
+	// Step 10: Verify cell does NOT appear in list
+	if verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+		t.Fatalf("cell %q still appears in cell list after deletion", cellName)
+	}
+}
+
+// TestDeleteF_Container_VerifyAllResourcesDeleted tests container deletion with comprehensive verification.
+func TestDeleteF_Container_VerifyAllResourcesDeleted(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+	cellName := generateUniqueCellName(t)
+	containerName := "worker" // Use a non-root container from cell.yaml
+
+	// Cleanup: Safety net
+	t.Cleanup(func() {
+		cleanupContainer(t, runPath, realmName, spaceName, stackName, cellName, containerName)
+		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, runPath, realmName, spaceName, stackName)
+		cleanupSpace(t, runPath, realmName, spaceName)
+		cleanupRealm(t, runPath, realmName)
+	})
+
+	// Step 1: Create realm (prerequisite)
+	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 2: Create space (prerequisite)
+	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 3: Create stack (prerequisite)
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"create",
+		"stack",
+		stackName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+	)
+	runReturningBinary(t, nil, kuke, args...)
+
+	// Step 4: Apply cell.yaml to create the cell with containers
+	replacements := map[string]string{
+		"test-cell":  cellName,
+		"test-realm": realmName,
+		"test-space": spaceName,
+		"test-stack": stackName,
+	}
+	_ = applyYAMLFileFromTestdata(t, runPath, "cell.yaml", replacements)
+
+	// Step 5: Verify cell and container were created
+	if !verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {
+		t.Fatalf("cell metadata file not found for cell %q", cellName)
+	}
+
+	// Get realm namespace and cell ID
+	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	if err != nil {
+		t.Fatalf("failed to get realm namespace: %v", err)
+	}
+
+	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	if err != nil {
+		t.Fatalf("failed to get cell ID: %v", err)
+	}
+
+	// Build container containerd ID: {spaceName}_{stackName}_{cellID}_{containerName}
+	containerContainerdID := fmt.Sprintf("%s_%s_%s_%s", spaceName, stackName, cellID, containerName)
+
+	// Verify container exists initially
+	if !verifyContainerExists(t, realmNamespace, containerContainerdID) {
+		t.Fatalf("container %q not found in containerd namespace %q", containerContainerdID, realmNamespace)
+	}
+
+	// Verify container task exists initially
+	if !verifyContainerTaskExists(t, realmNamespace, containerContainerdID) {
+		t.Fatalf("container task %q not found in containerd namespace %q", containerContainerdID, realmNamespace)
+	}
+
+	// Get cell JSON to verify container is in cell metadata
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"get",
+		"cell",
+		cellName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+		"--stack",
+		stackName,
+		"--output",
+		"json",
+	)
+	output := runReturningBinary(t, nil, kuke, args...)
+
+	cellBefore, err := parseCellJSON(t, output)
+	if err != nil {
+		t.Fatalf("failed to parse cell JSON: %v", err)
+	}
+
+	// Verify container exists in cell spec and get its image
+	containerFound := false
+	var containerImage string
+	for _, container := range cellBefore.Spec.Containers {
+		if container.ID == containerName {
+			containerFound = true
+			containerImage = container.Image
+			break
+		}
+	}
+	if !containerFound {
+		t.Fatalf("container %q not found in cell %q spec", containerName, cellName)
+	}
+	if containerImage == "" {
+		t.Fatalf("container %q image is empty in cell %q spec", containerName, cellName)
+	}
+
+	// Step 6: Create container YAML file for deletion (including image field required by validation)
+	containerYAML := fmt.Sprintf(`apiVersion: v1beta1
+kind: Container
+metadata:
+  name: %s
+spec:
+  realmId: %s
+  spaceId: %s
+  stackId: %s
+  cellId: %s
+  image: %s
+`, containerName, realmName, spaceName, stackName, cellName, containerImage)
+
+	tmpDir := t.TempDir()
+	containerYAMLFile := filepath.Join(tmpDir, "container-delete.yaml")
+	err = os.WriteFile(containerYAMLFile, []byte(containerYAML), 0o644)
+	if err != nil {
+		t.Fatalf("failed to write container YAML file: %v", err)
+	}
+
+	// Step 7: Delete using delete -f
+	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", containerYAMLFile)
+	_ = runReturningBinary(t, nil, kuke, args...)
+
+	// Step 8: Verify container does NOT exist in containerd
+	if verifyContainerExists(t, realmNamespace, containerContainerdID) {
+		t.Fatalf(
+			"container %q still exists in containerd namespace %q after deletion",
+			containerContainerdID,
+			realmNamespace,
+		)
+	}
+
+	// Step 9: Verify container task does NOT exist
+	if verifyContainerTaskExists(t, realmNamespace, containerContainerdID) {
+		t.Fatalf(
+			"container task %q still exists in containerd namespace %q after deletion",
+			containerContainerdID,
+			realmNamespace,
+		)
+	}
+
+	// Step 10: Verify container removed from cell metadata
+	args = append(
+		buildKukeRunPathArgs(runPath),
+		"get",
+		"cell",
+		cellName,
+		"--realm",
+		realmName,
+		"--space",
+		spaceName,
+		"--stack",
+		stackName,
+		"--output",
+		"json",
+	)
+	output = runReturningBinary(t, nil, kuke, args...)
+
+	cellAfter, err := parseCellJSON(t, output)
+	if err != nil {
+		t.Fatalf("failed to parse cell JSON after deletion: %v", err)
+	}
+
+	// Verify container is NOT in cell spec anymore
+	for _, container := range cellAfter.Spec.Containers {
+		if container.ID == containerName {
+			t.Fatalf("container %q still found in cell %q spec after deletion", containerName, cellName)
+		}
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds thorough e2e coverage for apply/delete across Realm/Space/Stack/Cell and updates cell reconcile to start newly created cells and persist Ready state.
> 
> - **Tests (e2e)**:
>   - **Apply**: New state-verification tests for `realm`, `space`, `stack`, `cell`, and `multi-resource` using YAML fixtures; validate containerd namespaces, cgroup paths, metadata, listing, and retrieval; for `cell`, verify root/child containers exist and status is Ready.
>   - **Delete -f**: New tests for `realm`, `space`, `stack`, `cell`, and `container`, including cascade and idempotency; verify removal of containerd namespaces, cgroup paths, CNI configs, metadata, and container tasks.
>   - **Helpers**: Add YAML readers/writers, field-completeness checks, and utility functions to apply/delete and assert runtime/containerd state.
> - **Controller (apply)**:
>   - `ReconcileCell`: After creating a cell, start it, re-fetch, set `Status.State=Ready`, update metadata, and return the started resource.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfa6f773eba41696b11399852035cceb8378c1d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->