### PR TITLE
feat: add cell/container status

### DIFF
--- a/cmd/kuke/get/container/container_test.go
+++ b/cmd/kuke/get/container/container_test.go
@@ -899,6 +899,11 @@ func (f *fakeContainerController) ListContainers(
 	return f.listContainersFn(realmName, spaceName, stackName, cellName)
 }
 
+func (f *fakeContainerController) Close() error {
+	// Mock controllers don't need cleanup
+	return nil
+}
+
 func TestNewContainerCmd_AutocompleteRegistration(t *testing.T) {
 	cmd := container.NewContainerCmd()
 

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -282,6 +282,8 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				RestartPolicy:   in.Spec.RestartPolicy,
 			},
 			Status: intmodel.ContainerStatus{
+				Name:         in.Status.Name,
+				ID:           in.Status.ID,
 				State:        intmodel.ContainerState(in.Status.State),
 				RestartCount: in.Status.RestartCount,
 				RestartTime:  in.Status.RestartTime,
@@ -327,6 +329,8 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				RestartPolicy:   in.Spec.RestartPolicy,
 			},
 			Status: ext.ContainerStatus{
+				Name:         in.Status.Name,
+				ID:           in.Status.ID,
 				State:        ext.ContainerState(in.Status.State),
 				RestartCount: in.Status.RestartCount,
 				RestartTime:  in.Status.RestartTime,
@@ -401,6 +405,50 @@ func BuildContainerSpecExternalFromInternal(in intmodel.ContainerSpec) ext.Conta
 	}
 }
 
+// convertContainerStatusesToInternal converts a slice of external ContainerStatus to internal ContainerStatus.
+func convertContainerStatusesToInternal(in []ext.ContainerStatus) []intmodel.ContainerStatus {
+	if in == nil {
+		return []intmodel.ContainerStatus{}
+	}
+	result := make([]intmodel.ContainerStatus, len(in))
+	for i, status := range in {
+		result[i] = intmodel.ContainerStatus{
+			Name:         status.Name,
+			ID:           status.ID,
+			State:        intmodel.ContainerState(status.State),
+			RestartCount: status.RestartCount,
+			RestartTime:  status.RestartTime,
+			StartTime:    status.StartTime,
+			FinishTime:   status.FinishTime,
+			ExitCode:     status.ExitCode,
+			ExitSignal:   status.ExitSignal,
+		}
+	}
+	return result
+}
+
+// buildContainerStatusesExternalFromInternal converts a slice of internal ContainerStatus to external ContainerStatus.
+func buildContainerStatusesExternalFromInternal(in []intmodel.ContainerStatus) []ext.ContainerStatus {
+	if in == nil {
+		return []ext.ContainerStatus{}
+	}
+	result := make([]ext.ContainerStatus, len(in))
+	for i, status := range in {
+		result[i] = ext.ContainerStatus{
+			Name:         status.Name,
+			ID:           status.ID,
+			State:        ext.ContainerState(status.State),
+			RestartCount: status.RestartCount,
+			RestartTime:  status.RestartTime,
+			StartTime:    status.StartTime,
+			FinishTime:   status.FinishTime,
+			ExitCode:     status.ExitCode,
+			ExitSignal:   status.ExitSignal,
+		}
+	}
+	return result
+}
+
 // ConvertCellDocToInternal converts an external CellDoc to the internal hub type.
 func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 	switch in.APIVersion {
@@ -420,6 +468,7 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 			Status: intmodel.CellStatus{
 				State:      intmodel.CellState(in.Status.State),
 				CgroupPath: in.Status.CgroupPath,
+				Containers: convertContainerStatusesToInternal(in.Status.Containers),
 			},
 		}
 
@@ -473,6 +522,7 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 			Status: ext.CellStatus{
 				State:      ext.CellState(in.Status.State),
 				CgroupPath: in.Status.CgroupPath,
+				Containers: buildContainerStatusesExternalFromInternal(in.Status.Containers),
 			},
 		}
 

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -327,17 +327,11 @@ func ReconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, err
 			}
 			// Start the newly created cell (containers are created but not started)
 			// This matches the behavior of controller.CreateCell which also starts cells
-			if startErr := r.StartCell(created); startErr != nil {
+			started, startErr := r.StartCell(created)
+			if startErr != nil {
 				return result, fmt.Errorf("failed to start cell after creation: %w", startErr)
 			}
-			// Re-fetch the cell to get the latest state after starting
-			started, getErr := r.GetCell(created)
-			if getErr != nil {
-				return result, fmt.Errorf("failed to get cell after starting: %w", getErr)
-			}
-			// Update cell state to Ready and persist metadata
-			// This matches the behavior of controller.StartCell
-			started.Status.State = intmodel.CellStateReady
+			// Update cell metadata (status already set by runner)
 			if updateErr := r.UpdateCellMetadata(started); updateErr != nil {
 				return result, fmt.Errorf("failed to update cell metadata after start: %w", updateErr)
 			}

--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -494,7 +494,7 @@ func (b *Exec) bootstrapCell(report BootstrapReport) (BootstrapReport, error) {
 	}
 
 	// Start cell containers using the ensured/created cell
-	err = b.runner.StartCell(ensuredCell)
+	_, err = b.runner.StartCell(ensuredCell)
 	if err != nil {
 		return report, fmt.Errorf("failed to start cell containers: %w", err)
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -59,6 +59,7 @@ type Controller interface {
 	PurgeCell(cell intmodel.Cell, force, cascade bool) (PurgeCellResult, error)
 	PurgeContainer(container intmodel.Container) (PurgeContainerResult, error)
 	RefreshAll() (RefreshResult, error)
+	Close() error
 }
 
 type Exec struct {
@@ -148,4 +149,9 @@ func (b *Exec) Bootstrap() (BootstrapReport, error) {
 	}
 
 	return report, nil
+}
+
+// Close closes the controller and releases all resources, including the containerd connection.
+func (b *Exec) Close() error {
+	return b.runner.Close()
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -62,9 +62,9 @@ type fakeRunner struct {
 	ListCellsFn               func(realmName, spaceName, stackName string) ([]intmodel.Cell, error)
 	CreateCellFn              func(cell intmodel.Cell) (intmodel.Cell, error)
 	EnsureCellFn              func(cell intmodel.Cell) (intmodel.Cell, error)
-	StartCellFn               func(cell intmodel.Cell) error
-	StopCellFn                func(cell intmodel.Cell) error
-	KillCellFn                func(cell intmodel.Cell) error
+	StartCellFn               func(cell intmodel.Cell) (intmodel.Cell, error)
+	StopCellFn                func(cell intmodel.Cell) (intmodel.Cell, error)
+	KillCellFn                func(cell intmodel.Cell) (intmodel.Cell, error)
 	DeleteCellFn              func(cell intmodel.Cell) error
 	ExistsCellRootContainerFn func(cell intmodel.Cell) (bool, error)
 	UpdateCellMetadataFn      func(cell intmodel.Cell) error
@@ -73,7 +73,7 @@ type fakeRunner struct {
 	ListContainersFn    func(realmName, spaceName, stackName, cellName string) ([]intmodel.ContainerSpec, error)
 	CreateContainerFn   func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
 	EnsureContainerFn   func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
-	StartContainerFn    func(cell intmodel.Cell, containerID string) error
+	StartContainerFn    func(cell intmodel.Cell, containerID string) (intmodel.Cell, error)
 	StopContainerFn     func(cell intmodel.Cell, containerID string) error
 	KillContainerFn     func(cell intmodel.Cell, containerID string) error
 	DeleteContainerFn   func(cell intmodel.Cell, containerID string) error
@@ -265,25 +265,25 @@ func (f *fakeRunner) EnsureCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	return intmodel.Cell{}, errors.New("unexpected call to EnsureCell")
 }
 
-func (f *fakeRunner) StartCell(cell intmodel.Cell) error {
+func (f *fakeRunner) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	if f.StartCellFn != nil {
 		return f.StartCellFn(cell)
 	}
-	return errors.New("unexpected call to StartCell")
+	return intmodel.Cell{}, errors.New("unexpected call to StartCell")
 }
 
-func (f *fakeRunner) StopCell(cell intmodel.Cell) error {
+func (f *fakeRunner) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	if f.StopCellFn != nil {
 		return f.StopCellFn(cell)
 	}
-	return errors.New("unexpected call to StopCell")
+	return intmodel.Cell{}, errors.New("unexpected call to StopCell")
 }
 
-func (f *fakeRunner) KillCell(cell intmodel.Cell) error {
+func (f *fakeRunner) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	if f.KillCellFn != nil {
 		return f.KillCellFn(cell)
 	}
-	return errors.New("unexpected call to KillCell")
+	return intmodel.Cell{}, errors.New("unexpected call to KillCell")
 }
 
 func (f *fakeRunner) DeleteCell(cell intmodel.Cell) error {
@@ -332,11 +332,11 @@ func (f *fakeRunner) EnsureContainer(cell intmodel.Cell, container intmodel.Cont
 	return intmodel.Cell{}, errors.New("unexpected call to EnsureContainer")
 }
 
-func (f *fakeRunner) StartContainer(cell intmodel.Cell, containerID string) error {
+func (f *fakeRunner) StartContainer(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 	if f.StartContainerFn != nil {
 		return f.StartContainerFn(cell, containerID)
 	}
-	return errors.New("unexpected call to StartContainer")
+	return intmodel.Cell{}, errors.New("unexpected call to StartContainer")
 }
 
 func (f *fakeRunner) StopContainer(cell intmodel.Cell, containerID string) error {

--- a/internal/controller/create_cell.go
+++ b/internal/controller/create_cell.go
@@ -169,7 +169,8 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 	}
 
 	// Start cell containers (both new and existing cells need to be started)
-	if err = b.runner.StartCell(resultCell); err != nil {
+	resultCell, err = b.runner.StartCell(resultCell)
+	if err != nil {
 		return res, fmt.Errorf("failed to start cell containers: %w", err)
 	}
 

--- a/internal/controller/create_cell_test.go
+++ b/internal/controller/create_cell_test.go
@@ -52,8 +52,9 @@ func TestCreateCell_NewCellCreation(t *testing.T) {
 				f.CreateCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return buildTestCell("test-cell", "test-realm", "test-space", "test-stack"), nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -153,8 +154,9 @@ func TestCreateCell_ExistingCellReconciliation(t *testing.T) {
 				f.EnsureCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -205,8 +207,9 @@ func TestCreateCell_ExistingCellReconciliation(t *testing.T) {
 				f.EnsureCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -302,8 +305,9 @@ func TestCreateCell_ContainerOutcomes(t *testing.T) {
 				f.CreateCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return createdCell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -359,8 +363,9 @@ func TestCreateCell_ContainerOutcomes(t *testing.T) {
 				f.EnsureCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -423,8 +428,9 @@ func TestCreateCell_ContainerOutcomes(t *testing.T) {
 				f.EnsureCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return updatedCell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -497,8 +503,9 @@ func TestCreateCell_ContainerOutcomes(t *testing.T) {
 				f.CreateCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return createdCell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -675,8 +682,9 @@ func TestCreateCell_DefaultLabels(t *testing.T) {
 					}
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -748,8 +756,9 @@ func TestCreateCell_DefaultLabels(t *testing.T) {
 					}
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -821,8 +830,9 @@ func TestCreateCell_DefaultLabels(t *testing.T) {
 					}
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -909,8 +919,9 @@ func TestCreateCell_DefaultSpecID(t *testing.T) {
 					}
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -943,8 +954,9 @@ func TestCreateCell_DefaultSpecID(t *testing.T) {
 					}
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -1021,8 +1033,9 @@ func TestCreateCell_ContainerOwnership(t *testing.T) {
 					}
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -1063,8 +1076,9 @@ func TestCreateCell_ContainerOwnership(t *testing.T) {
 				f.CreateCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
 					return cell, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {
@@ -1214,8 +1228,8 @@ func TestCreateCell_RunnerErrors(t *testing.T) {
 				f.CreateCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return buildTestCell("test-cell", "test-realm", "test-space", "test-stack"), nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return errors.New("start failed")
+				f.StartCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return intmodel.Cell{}, errors.New("start failed")
 				}
 			},
 			wantErr:     nil, // Custom error message, not a standard error
@@ -1288,8 +1302,9 @@ func TestCreateCell_NameTrimming(t *testing.T) {
 					// Return cell with trimmed values as the result
 					return buildTestCell("test-cell", "test-realm", "test-space", "test-stack"), nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateCellResult) {

--- a/internal/controller/create_container.go
+++ b/internal/controller/create_container.go
@@ -156,7 +156,8 @@ func (b *Exec) CreateContainer(container intmodel.Container) (CreateContainerRes
 	)
 
 	// Start only the specific container
-	if err = b.runner.StartContainer(resultCell, containerName); err != nil {
+	_, err = b.runner.StartContainer(resultCell, containerName)
+	if err != nil {
 		return res, fmt.Errorf("failed to start container %s: %w", containerName, err)
 	}
 

--- a/internal/controller/create_container.go
+++ b/internal/controller/create_container.go
@@ -216,6 +216,8 @@ func (b *Exec) CreateContainer(container intmodel.Container) (CreateContainerRes
 			},
 			Spec: *containerSpec,
 			Status: intmodel.ContainerStatus{
+				Name:  containerName,
+				ID:    containerName,
 				State: actualState,
 			},
 		}

--- a/internal/controller/create_container_test.go
+++ b/internal/controller/create_container_test.go
@@ -85,11 +85,12 @@ func TestCreateContainer_NewContainerCreation(t *testing.T) {
 				f.CreateContainerFn = func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "test-container" {
-						return errors.New("unexpected container ID")
+						return intmodel.Cell{}, errors.New("unexpected container ID")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -200,8 +201,9 @@ func TestCreateContainer_ExistingContainerReconciliation(t *testing.T) {
 				f.CreateContainerFn = func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return nil
+				f.StartContainerFn = func(cell intmodel.Cell, _ string) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -304,11 +306,12 @@ func TestCreateContainer_ContainerNameSource(t *testing.T) {
 					}
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "test-container" {
-						return errors.New("unexpected container ID")
+						return intmodel.Cell{}, errors.New("unexpected container ID")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -357,11 +360,12 @@ func TestCreateContainer_ContainerNameSource(t *testing.T) {
 					}
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "test-container-id" {
-						return errors.New("unexpected container ID")
+						return intmodel.Cell{}, errors.New("unexpected container ID")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -476,8 +480,9 @@ func TestCreateContainer_DefaultSpecID(t *testing.T) {
 					}
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return nil
+				f.StartContainerFn = func(cell intmodel.Cell, _ string) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -528,11 +533,12 @@ func TestCreateContainer_DefaultSpecID(t *testing.T) {
 					}
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "test-container" {
-						return errors.New("unexpected container ID for StartContainer")
+						return intmodel.Cell{}, errors.New("unexpected container ID for StartContainer")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -836,8 +842,9 @@ func TestCreateContainer_DefaultLabels(t *testing.T) {
 				f.CreateContainerFn = func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return nil
+				f.StartContainerFn = func(cell intmodel.Cell, _ string) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -884,8 +891,9 @@ func TestCreateContainer_DefaultLabels(t *testing.T) {
 				f.CreateContainerFn = func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return nil
+				f.StartContainerFn = func(cell intmodel.Cell, _ string) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -1054,8 +1062,8 @@ func TestCreateContainer_RunnerErrors(t *testing.T) {
 				f.CreateContainerFn = func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return errors.New("start failed")
+				f.StartContainerFn = func(_ intmodel.Cell, _ string) (intmodel.Cell, error) {
+					return intmodel.Cell{}, errors.New("start failed")
 				}
 			},
 			wantErr:     nil, // Custom error message, not a standard error
@@ -1090,8 +1098,9 @@ func TestCreateContainer_RunnerErrors(t *testing.T) {
 				f.CreateContainerFn = func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return nil
+				f.StartContainerFn = func(cell intmodel.Cell, _ string) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantErr:     errdefs.ErrGetCell,
@@ -1204,11 +1213,12 @@ func TestCreateContainer_NameTrimming(t *testing.T) {
 					}
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "test-container" {
-						return errors.New("container ID not trimmed")
+						return intmodel.Cell{}, errors.New("container ID not trimmed")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -1354,8 +1364,9 @@ func TestCreateContainer_ContainerObjectConstruction(t *testing.T) {
 				f.CreateContainerFn = func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return nil
+				f.StartContainerFn = func(cell intmodel.Cell, _ string) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {
@@ -1437,11 +1448,12 @@ func TestCreateContainer_ContainerObjectConstruction(t *testing.T) {
 				f.CreateContainerFn = func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
 					return resultCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "target-container" {
-						return errors.New("unexpected container ID")
+						return intmodel.Cell{}, errors.New("unexpected container ID")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateContainerResult) {

--- a/internal/controller/delete_container.go
+++ b/internal/controller/delete_container.go
@@ -111,6 +111,8 @@ func (b *Exec) DeleteContainer(container intmodel.Container) (DeleteContainerRes
 		},
 		Spec: *foundContainer,
 		Status: intmodel.ContainerStatus{
+			Name:  name,
+			ID:    name,
 			State: intmodel.ContainerStateReady,
 		},
 	}

--- a/internal/controller/get_container.go
+++ b/internal/controller/get_container.go
@@ -34,7 +34,7 @@ type GetContainerResult struct {
 
 // GetContainer retrieves a single container and reports its current state.
 func (b *Exec) GetContainer(container intmodel.Container) (GetContainerResult, error) {
-	defer b.runner.Close()
+	// defer b.runner.Close() removed - connection managed at command level
 	var res GetContainerResult
 
 	name := strings.TrimSpace(container.Metadata.Name)
@@ -127,6 +127,8 @@ func (b *Exec) GetContainer(container intmodel.Container) (GetContainerResult, e
 			},
 			Spec: *foundContainerSpec,
 			Status: intmodel.ContainerStatus{
+				Name:  name,
+				ID:    name,
 				State: actualState,
 			},
 		}
@@ -143,6 +145,6 @@ func (b *Exec) GetContainer(container intmodel.Container) (GetContainerResult, e
 
 // ListContainers lists all containers, optionally filtered by realm, space, stack, and/or cell.
 func (b *Exec) ListContainers(realmName, spaceName, stackName, cellName string) ([]intmodel.ContainerSpec, error) {
-	defer b.runner.Close()
+	// defer b.runner.Close() removed - connection managed at command level
 	return b.runner.ListContainers(realmName, spaceName, stackName, cellName)
 }

--- a/internal/controller/kill_cell.go
+++ b/internal/controller/kill_cell.go
@@ -79,12 +79,10 @@ func (b *Exec) KillCell(cell intmodel.Cell) (KillCellResult, error) {
 	}
 
 	// Kill all containers in the cell
-	if err = b.runner.KillCell(internalCell); err != nil {
+	internalCell, err = b.runner.KillCell(internalCell)
+	if err != nil {
 		return res, fmt.Errorf("failed to kill cell containers: %w", err)
 	}
-
-	// Update cell state to Stopped
-	internalCell.Status.State = intmodel.CellStateStopped
 
 	// Update cell metadata state to Stopped
 	if err = b.runner.UpdateCellMetadata(internalCell); err != nil {

--- a/internal/controller/kill_cell_test.go
+++ b/internal/controller/kill_cell_test.go
@@ -54,8 +54,9 @@ func TestKillCell_SuccessfulKill(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.KillCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.KillCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateStopped
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(cell intmodel.Cell) error {
 					if cell.Status.State != intmodel.CellStateStopped {
@@ -90,8 +91,9 @@ func TestKillCell_SuccessfulKill(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.KillCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.KillCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateStopped
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(cell intmodel.Cell) error {
 					if cell.Status.State != intmodel.CellStateStopped {
@@ -345,8 +347,8 @@ func TestKillCell_RunnerErrors(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.KillCellFn = func(_ intmodel.Cell) error {
-					return errors.New("kill failed")
+				f.KillCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return intmodel.Cell{}, errors.New("kill failed")
 				}
 			},
 			wantErr:     true,
@@ -363,8 +365,9 @@ func TestKillCell_RunnerErrors(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.KillCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.KillCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateStopped
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return errors.New("metadata update failed")
@@ -441,8 +444,9 @@ func TestKillCell_NameTrimming(t *testing.T) {
 					}
 					return existingCell, nil
 				}
-				f.KillCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.KillCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateStopped
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil

--- a/internal/controller/kill_container.go
+++ b/internal/controller/kill_container.go
@@ -138,6 +138,8 @@ func (b *Exec) KillContainer(container intmodel.Container) (KillContainerResult,
 		},
 		Spec: *foundContainerSpec,
 		Status: intmodel.ContainerStatus{
+			Name:  name,
+			ID:    name,
 			State: actualState,
 		},
 	}

--- a/internal/controller/purge_container.go
+++ b/internal/controller/purge_container.go
@@ -123,6 +123,8 @@ func (b *Exec) PurgeContainer(container intmodel.Container) (PurgeContainerResul
 			},
 			Spec: *foundContainerSpec,
 			Status: intmodel.ContainerStatus{
+				Name:  name,
+				ID:    name,
 				State: intmodel.ContainerStateReady,
 			},
 		}

--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -108,7 +108,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"container", containerID,
 			"cell", cellName,
 			"containersInCell", len(cell.Spec.Containers))
-		return intmodel.ContainerStateUnknown, fmt.Errorf("container %q not found in cell %q", containerID, cellName)
+		return intmodel.ContainerStateUnknown, nil
 	}
 
 	// Get cell ID (use Spec.ID if available, otherwise fall back to Metadata.Name)
@@ -164,7 +164,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"containerdID", containerdID,
 			"error", err)
 		// If we can't check existence, return Unknown
-		return intmodel.ContainerStateUnknown, nil
+		return intmodel.ContainerStateStopped, nil
 	}
 
 	if !containerExists {

--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -149,22 +149,13 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 		"namespace", namespace)
 
 	// Check if container exists in containerd
-	// Note: ensureClientConnected() should have initialized the client, but check anyway
-	if r.ctrClient == nil {
-		r.logger.InfoContext(r.ctx, "containerd client not available after connection attempt",
-			"container", containerID,
-			"containerdID", containerdID)
-		return intmodel.ContainerStateUnknown, errors.New("containerd client not available")
-	}
-
-	containerExists, err := r.ctrClient.ExistsContainer(containerdID)
+	containerExists, err := r.ExistsContainer(containerdID)
 	if err != nil {
 		r.logger.InfoContext(r.ctx, "failed to check container existence",
 			"container", containerID,
 			"containerdID", containerdID,
 			"error", err)
-		// If we can't check existence, return Unknown
-		return intmodel.ContainerStateStopped, nil
+		return intmodel.ContainerStateUnknown, nil
 	}
 
 	if !containerExists {
@@ -173,7 +164,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"container", containerID,
 			"containerdID", containerdID,
 			"namespace", namespace)
-		return intmodel.ContainerStateUnknown, nil
+		return intmodel.ContainerStateStopped, nil
 	}
 
 	// Get container state using TaskStatus from ctr package

--- a/internal/controller/runner/create_container.go
+++ b/internal/controller/runner/create_container.go
@@ -42,6 +42,14 @@ func (r *Exec) CreateContainer(cell intmodel.Cell, container intmodel.ContainerS
 		return intmodel.Cell{}, ensureErr
 	}
 
+	// Populate container statuses after creating container and persist them
+	if err = r.PopulateAndPersistCellContainerStatuses(&ensuredCell); err != nil {
+		r.logger.WarnContext(r.ctx, "failed to populate and persist container statuses",
+			"cell", ensuredCell.Metadata.Name,
+			"error", err)
+		// Continue anyway - status population is best-effort
+	}
+
 	return ensuredCell, nil
 }
 

--- a/internal/controller/runner/get.go
+++ b/internal/controller/runner/get.go
@@ -134,6 +134,14 @@ func (r *Exec) GetCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		}
 	}
 
+	// Populate container statuses when retrieving cell
+	if err = r.populateCellContainerStatuses(&internalCell); err != nil {
+		r.logger.DebugContext(r.ctx, "failed to populate container statuses",
+			"cell", cellName,
+			"error", err)
+		// Continue anyway - status population is best-effort
+	}
+
 	return internalCell, nil
 }
 

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -290,6 +290,14 @@ func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	// Update cell state in internal model
 	internalCell.Status.State = intmodel.CellStateStopped
 
+	// Populate container statuses after killing cell and persist them
+	if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
+		r.logger.WarnContext(r.ctx, "failed to populate container statuses",
+			"cell", cellName,
+			"error", err)
+		// Continue anyway - status population is best-effort
+	}
+
 	return internalCell, nil
 }
 

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -28,22 +28,22 @@ import (
 
 // KillCell immediately force-kills all containers in a cell (workload containers first, then root container).
 // It detaches the root container from the CNI network before killing it.
-func (r *Exec) KillCell(cell intmodel.Cell) error {
+func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
-		return errdefs.ErrCellNameRequired
+		return intmodel.Cell{}, errdefs.ErrCellNameRequired
 	}
 	realmName := strings.TrimSpace(cell.Spec.RealmName)
 	if realmName == "" {
-		return errdefs.ErrRealmNameRequired
+		return intmodel.Cell{}, errdefs.ErrRealmNameRequired
 	}
 	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
 	if spaceName == "" {
-		return errdefs.ErrSpaceNameRequired
+		return intmodel.Cell{}, errdefs.ErrSpaceNameRequired
 	}
 	stackName := strings.TrimSpace(cell.Spec.StackName)
 	if stackName == "" {
-		return errdefs.ErrStackNameRequired
+		return intmodel.Cell{}, errdefs.ErrStackNameRequired
 	}
 
 	// Get the cell document to access all containers
@@ -59,36 +59,36 @@ func (r *Exec) KillCell(cell intmodel.Cell) error {
 	}
 	internalCell, err := r.GetCell(lookupCell)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
 	}
 
 	cellID := strings.TrimSpace(internalCell.Spec.ID)
 	if cellID == "" {
-		return errdefs.ErrCellIDRequired
+		return intmodel.Cell{}, errdefs.ErrCellIDRequired
 	}
 
 	realmID := strings.TrimSpace(internalCell.Spec.RealmName)
 	if realmID == "" {
-		return errdefs.ErrRealmNameRequired
+		return intmodel.Cell{}, errdefs.ErrRealmNameRequired
 	}
 
 	spaceID := strings.TrimSpace(internalCell.Spec.SpaceName)
 	if spaceID == "" {
-		return errdefs.ErrSpaceNameRequired
+		return intmodel.Cell{}, errdefs.ErrSpaceNameRequired
 	}
 
 	stackID := strings.TrimSpace(internalCell.Spec.StackName)
 	if stackID == "" {
-		return errdefs.ErrStackNameRequired
+		return intmodel.Cell{}, errdefs.ErrStackNameRequired
 	}
 
 	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmID, spaceID)
 	if cniErr != nil {
-		return fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
+		return intmodel.Cell{}, fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
 	}
 
 	if err = r.ensureClientConnected(); err != nil {
-		return fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
 	// Get realm to access namespace
@@ -99,7 +99,7 @@ func (r *Exec) KillCell(cell intmodel.Cell) error {
 	}
 	internalRealm, err := r.GetRealm(lookupRealm)
 	if err != nil {
-		return fmt.Errorf("failed to get realm: %w", err)
+		return intmodel.Cell{}, fmt.Errorf("failed to get realm: %w", err)
 	}
 
 	// Set namespace to realm namespace
@@ -119,7 +119,7 @@ func (r *Exec) KillCell(cell intmodel.Cell) error {
 		// Use ContainerdID from spec
 		containerID := containerSpec.ContainerdID
 		if containerID == "" {
-			return fmt.Errorf("container %q has empty ContainerdID", containerSpec.ID)
+			return intmodel.Cell{}, fmt.Errorf("container %q has empty ContainerdID", containerSpec.ID)
 		}
 
 		// Use container name with UUID for containerd operations
@@ -172,7 +172,7 @@ func (r *Exec) KillCell(cell intmodel.Cell) error {
 	// Kill root container last and detach from CNI
 	rootContainerID, err := r.getRootContainerContainerdID(internalCell)
 	if err != nil {
-		return err
+		return intmodel.Cell{}, err
 	}
 
 	// Get space to resolve network name for fallback cleanup
@@ -287,7 +287,10 @@ func (r *Exec) KillCell(cell intmodel.Cell) error {
 		)
 	}
 
-	return nil
+	// Update cell state in internal model
+	internalCell.Status.State = intmodel.CellStateStopped
+
+	return internalCell, nil
 }
 
 // KillContainer immediately force-kills a specific container in a cell.

--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -37,7 +37,8 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	}
 
 	// Stop all containers in the cell
-	if stopErr := r.StopCell(existing); stopErr != nil {
+	_, stopErr := r.StopCell(existing)
+	if stopErr != nil {
 		r.logger.WarnContext(
 			r.ctx,
 			"failed to stop cell containers, continuing with deletion",

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -285,7 +285,7 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 	// Check if container exists in containerd
 	containerExists := false
 	if r.ctrClient != nil {
-		containerExists, err = r.ctrClient.ExistsContainer(containerdID)
+		containerExists, err = r.ExistsContainer(containerdID)
 		if err != nil {
 			r.logger.DebugContext(r.ctx, "failed to check container existence",
 				"container", containerSpec.ID,

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -49,11 +49,11 @@ type Runner interface {
 	ListContainers(realmName, spaceName, stackName, cellName string) ([]intmodel.ContainerSpec, error)
 	CreateCell(cell intmodel.Cell) (intmodel.Cell, error)
 	EnsureCell(cell intmodel.Cell) (intmodel.Cell, error)
-	StartCell(cell intmodel.Cell) error
-	StopCell(cell intmodel.Cell) error
-	StartContainer(cell intmodel.Cell, containerID string) error
+	StartCell(cell intmodel.Cell) (intmodel.Cell, error)
+	StopCell(cell intmodel.Cell) (intmodel.Cell, error)
+	StartContainer(cell intmodel.Cell, containerID string) (intmodel.Cell, error)
 	StopContainer(cell intmodel.Cell, containerID string) error
-	KillCell(cell intmodel.Cell) error
+	KillCell(cell intmodel.Cell) (intmodel.Cell, error)
 	KillContainer(cell intmodel.Cell, containerID string) error
 	DeleteContainer(cell intmodel.Cell, containerID string) error
 	CreateContainer(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -33,22 +33,22 @@ import (
 
 // StartCell starts the root container and all containers defined in the CellDoc.
 // The root container is started first, then all containers in doc.Spec.Containers are started.
-func (r *Exec) StartCell(cell intmodel.Cell) error {
+func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
-		return internalerrdefs.ErrCellNameRequired
+		return intmodel.Cell{}, internalerrdefs.ErrCellNameRequired
 	}
 	realmName := strings.TrimSpace(cell.Spec.RealmName)
 	if realmName == "" {
-		return internalerrdefs.ErrRealmNameRequired
+		return intmodel.Cell{}, internalerrdefs.ErrRealmNameRequired
 	}
 	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
 	if spaceName == "" {
-		return internalerrdefs.ErrSpaceNameRequired
+		return intmodel.Cell{}, internalerrdefs.ErrSpaceNameRequired
 	}
 	stackName := strings.TrimSpace(cell.Spec.StackName)
 	if stackName == "" {
-		return internalerrdefs.ErrStackNameRequired
+		return intmodel.Cell{}, internalerrdefs.ErrStackNameRequired
 	}
 
 	// Get the cell document to access all containers
@@ -64,13 +64,13 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 	}
 	internalCell, err := r.GetCell(lookupCell)
 	if err != nil {
-		return fmt.Errorf("%w: %w", internalerrdefs.ErrGetCell, err)
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", internalerrdefs.ErrGetCell, err)
 	}
 
 	cellSpec := internalCell.Spec
 	cellID := cellSpec.ID
 	if cellID == "" {
-		return internalerrdefs.ErrCellIDRequired
+		return intmodel.Cell{}, internalerrdefs.ErrCellIDRequired
 	}
 
 	realmID := cellSpec.RealmName
@@ -79,7 +79,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 
 	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmID, spaceID)
 	if cniErr != nil {
-		return fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
+		return intmodel.Cell{}, fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
 	}
 
 	// Create a background context for containerd operations
@@ -87,7 +87,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 	// The logger is passed separately, so we don't need to preserve context values
 
 	if err = r.ensureClientConnected(); err != nil {
-		return fmt.Errorf("%w: %w", internalerrdefs.ErrConnectContainerd, err)
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", internalerrdefs.ErrConnectContainerd, err)
 	}
 
 	// Get realm to access namespace
@@ -98,12 +98,12 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 	}
 	internalRealm, err := r.GetRealm(lookupRealm)
 	if err != nil {
-		return fmt.Errorf("failed to get realm: %w", err)
+		return intmodel.Cell{}, fmt.Errorf("failed to get realm: %w", err)
 	}
 
 	namespace := internalRealm.Spec.Namespace
 	if namespace == "" {
-		return fmt.Errorf("realm %q has no namespace", realmID)
+		return intmodel.Cell{}, fmt.Errorf("realm %q has no namespace", realmID)
 	}
 
 	// Set namespace to realm namespace with credentials if available
@@ -117,7 +117,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 	// Generate containerd ID with cell identifier for uniqueness
 	containerID, err := naming.BuildRootContainerdID(spaceID, stackID, cellID)
 	if err != nil {
-		return fmt.Errorf("failed to build root container containerd ID: %w", err)
+		return intmodel.Cell{}, fmt.Errorf("failed to build root container containerd ID: %w", err)
 	}
 
 	// Check if container exists and clean it up
@@ -197,7 +197,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 	// Recreate root container fresh
 	rootContainerSpec, err := r.ensureCellRootContainerSpec(internalCell)
 	if err != nil {
-		return fmt.Errorf("failed to get root container spec: %w", err)
+		return intmodel.Cell{}, fmt.Errorf("failed to get root container spec: %w", err)
 	}
 
 	rootLabels := buildRootContainerLabels(internalCell)
@@ -212,7 +212,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 			"failed to create root container",
 			fields...,
 		)
-		return fmt.Errorf("failed to create root container %s: %w", containerID, err)
+		return intmodel.Cell{}, fmt.Errorf("failed to create root container %s: %w", containerID, err)
 	}
 
 	fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
@@ -233,12 +233,12 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 			"failed to start root container",
 			fields...,
 		)
-		return fmt.Errorf("failed to start root container %s: %w", containerID, err)
+		return intmodel.Cell{}, fmt.Errorf("failed to start root container %s: %w", containerID, err)
 	}
 
 	rootPID := rootTask.Pid()
 	if rootPID == 0 {
-		return fmt.Errorf("root container %s has invalid pid (0)", containerID)
+		return intmodel.Cell{}, fmt.Errorf("root container %s has invalid pid (0)", containerID)
 	}
 
 	namespacePaths := ctr.NamespacePaths{
@@ -290,7 +290,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 		r.cniConf.CniCacheDir,
 	)
 	if mgrErr != nil {
-		return fmt.Errorf("%w: %w", internalerrdefs.ErrInitCniManager, mgrErr)
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", internalerrdefs.ErrInitCniManager, mgrErr)
 	}
 
 	if loadErr := cniMgr.LoadNetworkConfigList(cniConfigPath); loadErr != nil {
@@ -311,7 +311,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 			"failed to load CNI config",
 			fields...,
 		)
-		return fmt.Errorf("failed to load CNI config %s: %w", cniConfigPath, loadErr)
+		return intmodel.Cell{}, fmt.Errorf("failed to load CNI config %s: %w", cniConfigPath, loadErr)
 	}
 
 	netnsPath := namespacePaths.Net
@@ -372,7 +372,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 				"failed to attach root container to network",
 				fields...,
 			)
-			return fmt.Errorf("failed to attach root container %s to network: %w", containerID, addErr)
+			return intmodel.Cell{}, fmt.Errorf("failed to attach root container %s to network: %w", containerID, addErr)
 		}
 	}
 
@@ -394,7 +394,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 		// Use ContainerdID from spec
 		ctrContainerID := containerSpec.ContainerdID
 		if ctrContainerID == "" {
-			return fmt.Errorf("container %q has empty ContainerdID", containerSpec.ID)
+			return intmodel.Cell{}, fmt.Errorf("container %q has empty ContainerdID", containerSpec.ID)
 		}
 
 		// Log which container we're attempting to start
@@ -452,7 +452,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 				"failed to create container",
 				fields...,
 			)
-			return fmt.Errorf("failed to create container %s: %w", ctrContainerID, err)
+			return intmodel.Cell{}, fmt.Errorf("failed to create container %s: %w", ctrContainerID, err)
 		}
 
 		fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
@@ -478,7 +478,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 				"failed to start container from CellDoc",
 				fields...,
 			)
-			return fmt.Errorf("failed to start container %s: %w", ctrContainerID, err)
+			return intmodel.Cell{}, fmt.Errorf("failed to start container %s: %w", ctrContainerID, err)
 		}
 
 		fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
@@ -490,38 +490,41 @@ func (r *Exec) StartCell(cell intmodel.Cell) error {
 		)
 	}
 
-	return nil
+	// Update cell state in internal model
+	internalCell.Status.State = intmodel.CellStateReady
+
+	return internalCell, nil
 }
 
 // StartContainer starts a specific container in a cell.
-func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) error {
+func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 	containerID = strings.TrimSpace(containerID)
 	if containerID == "" {
-		return errors.New("container ID is required")
+		return intmodel.Cell{}, errors.New("container ID is required")
 	}
 
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
-		return internalerrdefs.ErrCellNameRequired
+		return intmodel.Cell{}, internalerrdefs.ErrCellNameRequired
 	}
 
 	cellID := cell.Spec.ID
 	if cellID == "" {
-		return internalerrdefs.ErrCellIDRequired
+		return intmodel.Cell{}, internalerrdefs.ErrCellIDRequired
 	}
 
 	realmName := strings.TrimSpace(cell.Spec.RealmName)
 	if realmName == "" {
-		return internalerrdefs.ErrRealmNameRequired
+		return intmodel.Cell{}, internalerrdefs.ErrRealmNameRequired
 	}
 
 	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
 	if spaceName == "" {
-		return internalerrdefs.ErrSpaceNameRequired
+		return intmodel.Cell{}, internalerrdefs.ErrSpaceNameRequired
 	}
 
 	if err := r.ensureClientConnected(); err != nil {
-		return fmt.Errorf("%w: %w", internalerrdefs.ErrConnectContainerd, err)
+		return intmodel.Cell{}, fmt.Errorf("%w: %w", internalerrdefs.ErrConnectContainerd, err)
 	}
 
 	// Get realm to access namespace
@@ -532,12 +535,12 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) error {
 	}
 	internalRealm, err := r.GetRealm(lookupRealm)
 	if err != nil {
-		return fmt.Errorf("failed to get realm: %w", err)
+		return intmodel.Cell{}, fmt.Errorf("failed to get realm: %w", err)
 	}
 
 	namespace := internalRealm.Spec.Namespace
 	if namespace == "" {
-		return fmt.Errorf("realm %q has no namespace", realmName)
+		return intmodel.Cell{}, fmt.Errorf("realm %q has no namespace", realmName)
 	}
 
 	// Set namespace to realm namespace with credentials if available
@@ -558,12 +561,12 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) error {
 	}
 
 	if foundContainerSpec == nil {
-		return fmt.Errorf("container %q not found in cell %q", containerID, cellName)
+		return intmodel.Cell{}, fmt.Errorf("container %q not found in cell %q", containerID, cellName)
 	}
 
 	// Root container cannot be started directly - it must be started by starting the cell
 	if foundContainerSpec.Root {
-		return fmt.Errorf(
+		return intmodel.Cell{}, fmt.Errorf(
 			"root container cannot be started directly, start the cell instead using 'kuke start cell %s'",
 			cellName,
 		)
@@ -572,27 +575,27 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) error {
 	// Use ContainerdID from spec
 	containerdID := foundContainerSpec.ContainerdID
 	if containerdID == "" {
-		return fmt.Errorf("container %q has empty ContainerdID", containerID)
+		return intmodel.Cell{}, fmt.Errorf("container %q has empty ContainerdID", containerID)
 	}
 
 	// Get root container to get namespace paths
 	rootContainerID, err := r.getRootContainerContainerdID(cell)
 	if err != nil {
-		return err
+		return intmodel.Cell{}, err
 	}
 
 	// Get root container's namespace paths
 	rootContainer, err := r.ctrClient.GetContainer(rootContainerID)
 	if err != nil {
 		if errors.Is(err, internalerrdefs.ErrContainerNotFound) {
-			return fmt.Errorf(
+			return intmodel.Cell{}, fmt.Errorf(
 				"root container %q does not exist, start the cell first using 'kuke start cell %s': %w",
 				rootContainerID,
 				cellName,
 				err,
 			)
 		}
-		return fmt.Errorf("failed to get root container: %w", err)
+		return intmodel.Cell{}, fmt.Errorf("failed to get root container: %w", err)
 	}
 
 	nsCtx := namespaces.WithNamespace(r.ctx, namespace)
@@ -600,19 +603,19 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) error {
 	if err != nil {
 		// Check if task doesn't exist
 		if errdefs.IsNotFound(err) {
-			return fmt.Errorf(
+			return intmodel.Cell{}, fmt.Errorf(
 				"root container %q exists but has no task, start the cell first using 'kuke start cell %s': %w",
 				rootContainerID,
 				cellName,
 				err,
 			)
 		}
-		return fmt.Errorf("root container task not found, ensure root container is started: %w", err)
+		return intmodel.Cell{}, fmt.Errorf("root container task not found, ensure root container is started: %w", err)
 	}
 
 	rootPID := rootTask.Pid()
 	if rootPID == 0 {
-		return errors.New("root container has invalid pid (0)")
+		return intmodel.Cell{}, errors.New("root container has invalid pid (0)")
 	}
 
 	namespacePaths := ctr.NamespacePaths{
@@ -667,7 +670,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) error {
 			"failed to create container",
 			fields...,
 		)
-		return fmt.Errorf("failed to create container %s: %w", containerID, err)
+		return intmodel.Cell{}, fmt.Errorf("failed to create container %s: %w", containerID, err)
 	}
 
 	fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
@@ -703,7 +706,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) error {
 			"failed to start container",
 			fields...,
 		)
-		return fmt.Errorf("failed to start container %s: %w", containerID, err)
+		return intmodel.Cell{}, fmt.Errorf("failed to start container %s: %w", containerID, err)
 	}
 
 	fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
@@ -714,5 +717,24 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) error {
 		fields...,
 	)
 
-	return nil
+	// Get the cell again to ensure we have the latest state
+	lookupCell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name: cellName,
+		},
+		Spec: intmodel.CellSpec{
+			RealmName: realmName,
+			SpaceName: spaceName,
+			StackName: cell.Spec.StackName,
+		},
+	}
+	updatedCell, err := r.GetCell(lookupCell)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to retrieve cell after starting container: %w", err)
+	}
+
+	// Update cell state in internal model
+	updatedCell.Status.State = intmodel.CellStateReady
+
+	return updatedCell, nil
 }

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -493,6 +493,14 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	// Update cell state in internal model
 	internalCell.Status.State = intmodel.CellStateReady
 
+	// Populate container statuses after starting cell and persist them
+	if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
+		r.logger.WarnContext(r.ctx, "failed to populate container statuses",
+			"cell", cellName,
+			"error", err)
+		// Continue anyway - status population is best-effort
+	}
+
 	return internalCell, nil
 }
 
@@ -735,6 +743,14 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 
 	// Update cell state in internal model
 	updatedCell.Status.State = intmodel.CellStateReady
+
+	// Populate container statuses after starting cell and persist them
+	if err = r.PopulateAndPersistCellContainerStatuses(&updatedCell); err != nil {
+		r.logger.WarnContext(r.ctx, "failed to populate container statuses",
+			"cell", cellName,
+			"error", err)
+		// Continue anyway - status population is best-effort
+	}
 
 	return updatedCell, nil
 }

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -313,6 +313,14 @@ func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	// Update cell state in internal model
 	internalCell.Status.State = intmodel.CellStateStopped
 
+	// Populate container statuses after stopping cell and persist them
+	if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
+		r.logger.WarnContext(r.ctx, "failed to populate container statuses",
+			"cell", cellName,
+			"error", err)
+		// Continue anyway - status population is best-effort
+	}
+
 	return internalCell, nil
 }
 

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -47,12 +47,10 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 	}
 
 	// Start all containers in the cell
-	if err = b.runner.StartCell(internalCell); err != nil {
+	internalCell, err = b.runner.StartCell(internalCell)
+	if err != nil {
 		return res, fmt.Errorf("failed to start cell containers: %w", err)
 	}
-
-	// Update cell state to Ready
-	internalCell.Status.State = intmodel.CellStateReady
 
 	// Update cell metadata state to Ready
 	if err = b.runner.UpdateCellMetadata(internalCell); err != nil {

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -38,6 +38,14 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 		return res, err
 	}
 
+	// Check if cell is already in Ready state
+	if internalCell.Status.State == intmodel.CellStateReady {
+		return res, fmt.Errorf(
+			"cell %q is already in Ready state and must first be stopped",
+			internalCell.Metadata.Name,
+		)
+	}
+
 	// Start all containers in the cell
 	if err = b.runner.StartCell(internalCell); err != nil {
 		return res, fmt.Errorf("failed to start cell containers: %w", err)

--- a/internal/controller/start_cell_test.go
+++ b/internal/controller/start_cell_test.go
@@ -61,8 +61,9 @@ func TestStartCell_SuccessfulStart(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(cell intmodel.Cell) error {
 					if cell.Status.State != intmodel.CellStateReady {
@@ -104,8 +105,9 @@ func TestStartCell_SuccessfulStart(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(cell intmodel.Cell) error {
 					if cell.Status.State != intmodel.CellStateReady {
@@ -210,8 +212,9 @@ func TestStartCell_ReadyStateValidation(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil
@@ -240,8 +243,9 @@ func TestStartCell_ReadyStateValidation(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil
@@ -542,8 +546,8 @@ func TestStartCell_RunnerErrors(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return errors.New("start failed")
+				f.StartCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return intmodel.Cell{}, errors.New("start failed")
 				}
 			},
 			wantErr:     true,
@@ -568,8 +572,9 @@ func TestStartCell_RunnerErrors(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return errors.New("metadata update failed")
@@ -654,8 +659,9 @@ func TestStartCell_NameTrimming(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StartCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil

--- a/internal/controller/start_container.go
+++ b/internal/controller/start_container.go
@@ -139,6 +139,8 @@ func (b *Exec) StartContainer(container intmodel.Container) (StartContainerResul
 		},
 		Spec: *foundContainerSpec,
 		Status: intmodel.ContainerStatus{
+			Name:  name,
+			ID:    name,
 			State: actualState,
 		},
 	}

--- a/internal/controller/start_container.go
+++ b/internal/controller/start_container.go
@@ -105,12 +105,10 @@ func (b *Exec) StartContainer(container intmodel.Container) (StartContainerResul
 
 	// Start the container using runner.StartContainer which checks if root container is running
 	// If root container is not running, runner.StartContainer will return an error telling user to start the cell first
-	if err = b.runner.StartContainer(internalCell, name); err != nil {
+	internalCell, err = b.runner.StartContainer(internalCell, name)
+	if err != nil {
 		return res, fmt.Errorf("failed to start container %s: %w", name, err)
 	}
-
-	// Update cell state to Ready
-	internalCell.Status.State = intmodel.CellStateReady
 
 	// Update cell metadata state to Ready
 	if err = b.runner.UpdateCellMetadata(internalCell); err != nil {

--- a/internal/controller/start_container_test.go
+++ b/internal/controller/start_container_test.go
@@ -55,12 +55,13 @@ func TestStartContainer_SuccessfulStart(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					// Verify container ID matches
 					if containerID != "test-container" {
-						return errors.New("unexpected container ID")
+						return intmodel.Cell{}, errors.New("unexpected container ID")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(cell intmodel.Cell) error {
 					// Container should still be in cell (start doesn't remove it)
@@ -101,8 +102,9 @@ func TestStartContainer_SuccessfulStart(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return nil
+				f.StartContainerFn = func(cell intmodel.Cell, _ string) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil
@@ -501,8 +503,8 @@ func TestStartContainer_RunnerErrors(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return errors.New("start failed")
+				f.StartContainerFn = func(_ intmodel.Cell, _ string) (intmodel.Cell, error) {
+					return intmodel.Cell{}, errors.New("start failed")
 				}
 			},
 			wantErr:     true,
@@ -523,8 +525,9 @@ func TestStartContainer_RunnerErrors(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, _ string) error {
-					return nil
+				f.StartContainerFn = func(cell intmodel.Cell, _ string) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return errors.New("metadata update failed")
@@ -613,11 +616,12 @@ func TestStartContainer_ContainerLookupByID(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "target-container" {
-						return errors.New("unexpected container ID")
+						return intmodel.Cell{}, errors.New("unexpected container ID")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil
@@ -649,11 +653,12 @@ func TestStartContainer_ContainerLookupByID(t *testing.T) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
 					return existingCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "target-container-id" {
-						return errors.New("unexpected container ID")
+						return intmodel.Cell{}, errors.New("unexpected container ID")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil
@@ -744,11 +749,12 @@ func TestStartContainer_NameTrimming(t *testing.T) {
 					}
 					return existingCell, nil
 				}
-				f.StartContainerFn = func(_ intmodel.Cell, containerID string) error {
+				f.StartContainerFn = func(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
 					if containerID != "test-container" {
-						return errors.New("unexpected container ID")
+						return intmodel.Cell{}, errors.New("unexpected container ID")
 					}
-					return nil
+					cell.Status.State = intmodel.CellStateReady
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil

--- a/internal/controller/stop_cell.go
+++ b/internal/controller/stop_cell.go
@@ -39,12 +39,10 @@ func (b *Exec) StopCell(cell intmodel.Cell) (StopCellResult, error) {
 	}
 
 	// Stop all containers in the cell
-	if err = b.runner.StopCell(internalCell); err != nil {
+	internalCell, err = b.runner.StopCell(internalCell)
+	if err != nil {
 		return result, fmt.Errorf("failed to stop cell containers: %w", err)
 	}
-
-	// Update cell state to Stopped
-	internalCell.Status.State = intmodel.CellStateStopped
 
 	// Update cell metadata state to Stopped
 	if err = b.runner.UpdateCellMetadata(internalCell); err != nil {

--- a/internal/controller/stop_cell_test.go
+++ b/internal/controller/stop_cell_test.go
@@ -61,8 +61,9 @@ func TestStopCell_SuccessfulStop(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StopCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StopCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateStopped
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(cell intmodel.Cell) error {
 					if cell.Status.State != intmodel.CellStateStopped {
@@ -104,8 +105,9 @@ func TestStopCell_SuccessfulStop(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StopCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StopCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateStopped
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(cell intmodel.Cell) error {
 					if cell.Status.State != intmodel.CellStateStopped {
@@ -406,8 +408,8 @@ func TestStopCell_RunnerErrors(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StopCellFn = func(_ intmodel.Cell) error {
-					return errors.New("stop failed")
+				f.StopCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return intmodel.Cell{}, errors.New("stop failed")
 				}
 			},
 			wantErr:     true,
@@ -431,8 +433,9 @@ func TestStopCell_RunnerErrors(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StopCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StopCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateStopped
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return errors.New("metadata update failed")
@@ -516,8 +519,9 @@ func TestStopCell_NameTrimming(t *testing.T) {
 				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
 					return true, nil
 				}
-				f.StopCellFn = func(_ intmodel.Cell) error {
-					return nil
+				f.StopCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
+					cell.Status.State = intmodel.CellStateStopped
+					return cell, nil
 				}
 				f.UpdateCellMetadataFn = func(_ intmodel.Cell) error {
 					return nil

--- a/internal/controller/stop_container.go
+++ b/internal/controller/stop_container.go
@@ -121,7 +121,7 @@ func (b *Exec) StopContainer(container intmodel.Container) (StopContainerResult,
 				"container", name,
 				"cell", cellName,
 				"error", err)
-			actualState = intmodel.ContainerStateStopped // Default to Stopped since we just stopped it
+			actualState = intmodel.ContainerStateUnknown // Default to Unknown since we don't know the state
 		} else {
 			actualState = state
 		}

--- a/internal/controller/stop_container.go
+++ b/internal/controller/stop_container.go
@@ -141,6 +141,8 @@ func (b *Exec) StopContainer(container intmodel.Container) (StopContainerResult,
 			},
 			Spec: *foundContainerSpec,
 			Status: intmodel.ContainerStatus{
+				Name:  name,
+				ID:    name,
 				State: actualState,
 			},
 		}

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -112,20 +112,20 @@ func (c *client) verifyConnection() error {
 func (c *client) Connect() error {
 	// If already connected, verify the connection is still valid
 	if c.cClient != nil {
-		if err := c.verifyConnection(); err == nil {
+		err := c.verifyConnection()
+		if err == nil {
 			// Connection is valid, reuse it
 			c.logger.DebugContext(c.ctx, "containerd client already connected, reusing connection", "socket", c.socket)
 			return nil
 		}
 		// Connection is invalid, close it and create a new one
-		verifyErr := c.verifyConnection()
 		c.logger.DebugContext(
 			c.ctx,
 			"containerd connection invalid, reconnecting",
 			"socket",
 			c.socket,
 			"error",
-			verifyErr,
+			err,
 		)
 		_ = c.Close() // Close the invalid connection
 	}

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -374,11 +374,11 @@ func (c *client) ExistsContainer(id string) (bool, error) {
 	nsCtx := c.namespaceCtx()
 	_, err := c.cClient.LoadContainer(nsCtx, id)
 	if err != nil {
-		// Only wrap "not found" errors with ErrContainerNotFound so callers can use errors.Is to check
-		// Other errors (connection failures, permission errors, etc.) should be returned as-is
+		// "Not found" is not an error for Exists - it's a valid result (container doesn't exist)
 		if errdefs.IsNotFound(err) {
-			return false, fmt.Errorf("%w: %w", internalerrdefs.ErrContainerNotFound, err)
+			return false, nil
 		}
+		// Only real errors (connection failures, permission errors, etc.) should be returned
 		return false, err
 	}
 	return true, nil

--- a/internal/ctr/task.go
+++ b/internal/ctr/task.go
@@ -22,6 +22,7 @@ import (
 	apitypes "github.com/containerd/containerd/api/types"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
 // TaskStatus returns the current status of a task.
@@ -64,4 +65,24 @@ func (c *client) TaskMetrics(id string) (*apitypes.Metric, error) {
 	}
 
 	return metrics, nil
+}
+
+// ConvertContainerdStatusToContainerState converts a containerd task status to internal ContainerState.
+func ConvertContainerdStatusToContainerState(status containerd.Status) intmodel.ContainerState {
+	switch status.Status {
+	case containerd.Running:
+		return intmodel.ContainerStateReady
+	case containerd.Stopped:
+		return intmodel.ContainerStateStopped
+	case containerd.Created:
+		return intmodel.ContainerStatePending
+	case containerd.Unknown:
+		return intmodel.ContainerStateUnknown
+	case containerd.Paused:
+		return intmodel.ContainerStatePaused
+	case containerd.Pausing:
+		return intmodel.ContainerStatePausing
+	default:
+		return intmodel.ContainerStateUnknown
+	}
 }

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -39,6 +39,7 @@ type CellSpec struct {
 type CellStatus struct {
 	State      CellState
 	CgroupPath string
+	Containers []ContainerStatus
 }
 
 type CellState int

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -51,6 +51,8 @@ type ContainerSpec struct {
 }
 
 type ContainerStatus struct {
+	Name         string // Container name/ID
+	ID           string // Container ID (same as Name)
 	State        ContainerState
 	RestartCount int
 	RestartTime  time.Time

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -91,6 +91,7 @@ func NewCellDoc(from *CellDoc) *CellDoc {
 			Status: CellStatus{
 				State:      CellStateUnknown,
 				CgroupPath: "",
+				Containers: []ContainerStatus{},
 			},
 		}
 	}

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -53,6 +53,8 @@ type ContainerSpec struct {
 }
 
 type ContainerStatus struct {
+	Name         string         `json:"name"         yaml:"name"`
+	ID           string         `json:"id"           yaml:"id"`
 	State        ContainerState `json:"state"        yaml:"state"`
 	RestartCount int            `json:"restartCount" yaml:"restartCount"`
 	RestartTime  time.Time      `json:"restartTime"  yaml:"restartTime"`
@@ -125,6 +127,8 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 				RestartPolicy:   "",
 			},
 			Status: ContainerStatus{
+				Name:         "",
+				ID:           "",
 				State:        ContainerStatePending,
 				RestartCount: 0,
 				RestartTime:  time.Time{},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce persisted container/cell status from containerd, refactor start/stop/kill APIs to return updated cells, harden containerd client, and show container state in `kuke get container`.
> 
> - **Model & API**:
>   - Add `Status.Containers []ContainerStatus` to `CellStatus`; add `Name`/`ID` to `ContainerStatus` (internal and v1beta1).
>   - Update (de)serialization in `apischeme` to include new status fields.
> - **Runner**:
>   - Change signatures: `StartCell`, `StopCell`, `KillCell`, `StartContainer` now return `(intmodel.Cell, error)`.
>   - Populate and persist container statuses via `populateCellContainerStatuses` and `PopulateAndPersistCellContainerStatuses`; `GetCell` now fills statuses.
>   - Improve container state detection: use `ctr.ConvertContainerdStatusToContainerState`; treat non-existent container as `Stopped`; add `ExistsContainer`.
>   - Update start/stop/kill/recreate flows to use returned cells and persist status instead of manually setting state.
> - **Controller**:
>   - Adapt callers to new runner returns in `start/stop/kill/create` paths; remove manual state mutations.
>   - `GetContainer`/`ListContainers` avoid closing runner (managed by cmd); build result `Container.Status{Name,ID,State}`.
> - **CLI (`kuke get container`)**:
>   - Add `Close()` to controller interface; ensure deferred close.
>   - When listing, fetch each container’s actual state and include `STATE` column in table.
> - **Containerd client (`ctr`)**:
>   - Add connection verification/reconnect in `Connect`.
>   - Make `ExistsContainer` return `(false, nil)` on not-found; expose `ConvertContainerdStatusToContainerState`.
> - **Tests**:
>   - Update fakes and tests to new runner signatures and state behavior; enable controller injection via context in realm/container tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd8b39b7ce83dd5153e3b60e9fe0258858ff1e23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->