### PR TITLE
feat: kukeond daemon parity — mount containerd socket and runPath into system cell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# Testing `kuke init` locally
+
+This document describes how to tear down an existing kukeon runtime, rebuild
+`kuke`/`kukeond` from source, load the daemon image into containerd without
+pushing to a remote registry, and re-run `kuke init` end-to-end.
+
+## The two default realms
+
+`kuke init` provisions **two** realms, each mapped to its own containerd
+namespace (see `internal/consts/consts.go`):
+
+| Realm         | Containerd namespace    | Purpose                                                      |
+| ------------- | ----------------------- | ------------------------------------------------------------ |
+| `default`     | `kukeon.io`             | User workloads. Created empty so `kuke create …` has a home. |
+| `kuke-system` | `kuke-system.kukeon.io` | System workloads owned by kukeon itself.                     |
+
+The `kukeond` daemon runs inside the **`kuke-system`** realm — specifically
+as a container inside the cell
+`kuke-system / kukeon / kukeon / kukeond`
+(realm / space / stack / cell). The `default` realm is deliberately left
+user-owned so `kuke purge --cascade` on it can never take down the daemon.
+
+## Tear down the existing runtime
+
+Only the `kuke-system` cell needs to be removed; user-realm data under
+`/opt/kukeon/default` is left intact. All commands below use `--no-daemon`
+because the daemon itself is what we're tearing down.
+
+```bash
+# 1. Stop the kukeond cell containers (sends SIGKILL via the runner).
+sudo kuke kill cell kukeond \
+    --realm kuke-system --space kukeon --stack kukeon \
+    --no-daemon
+
+# 2. Remove the cell metadata so bootstrap re-creates it fresh.
+sudo kuke delete cell kukeond \
+    --realm kuke-system --space kukeon --stack kukeon \
+    --no-daemon
+
+# 3. Remove the stale socket and pid file left by the old daemon.
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+```
+
+After these three commands: no containerd tasks in
+`kuke-system.kukeon.io`, no cell metadata in
+`/opt/kukeon/kuke-system/kukeon/kukeon/`, and `/run/kukeon/` is empty.
+
+## Build the binaries
+
+```bash
+rm -f kuke kukeond
+make kuke          # produces ./kuke
+ln -sf kuke kukeond # kukeond is argv[0]-dispatched from the same binary
+```
+
+## Build and load the local `kukeond` image (no registry push)
+
+The bootstrap resolves the kukeond container image from `--kukeond-image`.
+For local iteration we build with docker, tag it, and import the tarball
+directly into containerd's `kuke-system.kukeon.io` namespace — **no push to
+ghcr.io or any other registry is required**.
+
+```bash
+# Build. VERSION only affects the embedded kuke --version string.
+docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+
+# (Optional) re-tag for clarity — the import below uses whatever tag you pass.
+docker tag kukeon-local:dev docker.io/library/kukeon-local:dev
+
+# Load the image into containerd under the system realm's namespace so
+# bootstrap can find it without a pull.
+docker save kukeon-local:dev | \
+    sudo ctr -n kuke-system.kukeon.io images import -
+
+# Verify the image is present.
+sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
+```
+
+## Run `kuke init`
+
+```bash
+sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+```
+
+Expected tail of the output:
+
+```
+    - cell "kukeond": created (image docker.io/library/kukeon-local:dev)
+    - cell cgroup: created
+    - cell root container cgroup: created
+    - cell containers cgroup: created
+kukeond is ready (unix:///run/kukeon/kukeond.sock)
+```
+
+## Verify daemon parity with `--no-daemon`
+
+Both commands must return identical output. This is the regression guard for
+the run-path bind-mount — if the daemon sees a different view of `/opt/kukeon`
+than the in-process controller, only the `--no-daemon` list will be populated.
+
+```bash
+# Goes through kukeond over the unix socket.
+sudo ./kuke get realms
+
+# Bypasses kukeond; reads /opt/kukeon in-process.
+sudo ./kuke get realms --no-daemon
+```
+
+Expected (identical) output:
+
+```
+NAME         NAMESPACE              STATE  CGROUP
+-----------  ---------------------  -----  -------------------
+default      kukeon.io              Ready  /kukeon/default
+kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+```
+
+## Inspecting the running daemon
+
+Confirm the bind-mount and `--run-path` flag are wired up on the kukeond
+container:
+
+```bash
+# Expect two bind mounts: /run/kukeon and /opt/kukeon (both host→container same path).
+sudo ctr -n kuke-system.kukeon.io container info \
+    kukeon_kukeon_kukeond_kukeond | \
+    python3 -c "import sys,json; print(json.dumps([m for m in json.load(sys.stdin)['Spec']['mounts'] if m.get('type')=='bind'],indent=2))"
+
+# Expect: /bin/kukeond serve --socket /run/kukeon/kukeond.sock --run-path /opt/kukeon
+ps -ef | grep '[k]ukeond serve'
+```

--- a/README.md
+++ b/README.md
@@ -86,6 +86,104 @@ default  main   default  Running  /kukeon/main/default/default
 
 Add `-o yaml` or `-o json` for full resource details.
 
+### Run a hello-world cell
+
+A minimal example that brings up a single container serving a static HTML page with busybox httpd lives at [`docs/examples/hello-world.yaml`](docs/examples/hello-world.yaml):
+
+```yaml
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: hello-world
+spec:
+  id: hello-world
+  realmId: default
+  spaceId: default
+  stackId: default
+  containers:
+    - id: web
+      image: docker.io/library/busybox:latest
+      command: /bin/sh
+      args:
+        - -c
+        - |
+          mkdir -p /www && \
+          cat > /www/index.html <<'HTML'
+          <!doctype html>
+          <html>
+            <head><meta charset="utf-8"><title>kukeon hello-world</title></head>
+            <body style="font-family: sans-serif">
+              <h1>Hello, world from kukeon!</h1>
+              <p>Served by busybox httpd inside a cell in the <code>default</code> realm.</p>
+            </body>
+          </html>
+          HTML
+          exec busybox httpd -f -v -p 8080 -h /www
+```
+
+Apply it and verify the cell is running. Cell creation currently goes in-process (`--no-daemon`) because the `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`:
+
+```bash
+# Create the cell (containers auto-start).
+sudo kuke apply -f docs/examples/hello-world.yaml --no-daemon
+
+# Confirm the cell is Ready.
+sudo kuke get cells --realm default --space default --stack default
+
+# Find the root container's IP on the default-default bridge (10.88.0.0/16) and curl it.
+ROOT_PID=$(sudo ctr -n kukeon.io task ls | awk '/hello-world_root/ {print $2}')
+CELL_IP=$(sudo nsenter -t "${ROOT_PID}" -n ip -4 -o addr show eth0 | awk '{print $4}' | cut -d/ -f1)
+curl http://${CELL_IP}:8080/
+```
+
+Tear it down with:
+
+```bash
+sudo kuke delete cell hello-world \
+    --realm default --space default --stack default --cascade --no-daemon
+```
+
+### Development environment
+
+Iterating on `kuke`/`kukeond` without a registry push: build from source, load the image into containerd by hand, then `kuke init` against it.
+
+**Prerequisite — create the `kuke-system.kukeon.io` namespace first.** `ctr images import` needs the target namespace to already exist; if it doesn't, the import succeeds silently but nothing lands in the namespace and the next `kuke init` will fail to find the image. The simplest bootstrap order is to let `kuke init` create the namespace first, then import, then re-run `kuke init` with your local image:
+
+```bash
+# 1. First bootstrap: creates the kuke-system.kukeon.io containerd namespace
+#    (and the rest of the hierarchy). The kukeond cell will fail to pull the
+#    default ghcr.io image without network — that's fine, we only need the
+#    namespace to exist. Alternatively create it directly:
+sudo ctr namespaces create kuke-system.kukeon.io
+
+# 2. Build the binaries. kukeond is argv[0]-dispatched from the kuke binary.
+rm -f kuke kukeond
+make kuke
+ln -sf kuke kukeond
+
+# 3. Build the container image and import it into the kuke-system namespace.
+#    VERSION only affects the embedded kuke --version string.
+docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+docker save kukeon-local:dev | \
+    sudo ctr -n kuke-system.kukeon.io images import -
+
+# 4. Verify the image is present in the namespace.
+sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
+
+# 5. Run (or re-run) kuke init pointed at the locally-loaded image.
+sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+```
+
+To iterate after a change, tear down just the kukeond cell (user data under `/opt/kukeon/default` is left intact) and repeat steps 2–5:
+
+```bash
+sudo kuke kill cell kukeond \
+    --realm kuke-system --space kukeon --stack kukeon --no-daemon
+sudo kuke delete cell kukeond \
+    --realm kuke-system --space kukeon --stack kukeon --no-daemon
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+```
+
 ### Autocomplete
 
 ```bash

--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -54,18 +54,9 @@ func NewCellCmd() *cobra.Command {
 				return err
 			}
 
-			realm := strings.TrimSpace(viper.GetString(config.KUKE_GET_CELL_REALM.ViperKey))
-			if realm == "" {
-				realm = strings.TrimSpace(config.KUKE_GET_CELL_REALM.ValueOrDefault())
-			}
-			space := strings.TrimSpace(viper.GetString(config.KUKE_GET_CELL_SPACE.ViperKey))
-			if space == "" {
-				space = strings.TrimSpace(config.KUKE_GET_CELL_SPACE.ValueOrDefault())
-			}
-			stack := strings.TrimSpace(viper.GetString(config.KUKE_GET_CELL_STACK.ViperKey))
-			if stack == "" {
-				stack = strings.TrimSpace(config.KUKE_GET_CELL_STACK.ValueOrDefault())
-			}
+			realm := shared.ExplicitFlag(cmd, "realm", config.KUKE_GET_CELL_REALM.ViperKey)
+			space := shared.ExplicitFlag(cmd, "space", config.KUKE_GET_CELL_SPACE.ViperKey)
+			stack := shared.ExplicitFlag(cmd, "stack", config.KUKE_GET_CELL_STACK.ViperKey)
 
 			var name string
 			if len(args) > 0 {
@@ -75,6 +66,15 @@ func NewCellCmd() *cobra.Command {
 			}
 
 			if name != "" {
+				if realm == "" {
+					realm = strings.TrimSpace(config.KUKE_GET_CELL_REALM.ValueOrDefault())
+				}
+				if space == "" {
+					space = strings.TrimSpace(config.KUKE_GET_CELL_SPACE.ValueOrDefault())
+				}
+				if stack == "" {
+					stack = strings.TrimSpace(config.KUKE_GET_CELL_STACK.ValueOrDefault())
+				}
 				if realm == "" {
 					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
 				}

--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -106,19 +106,10 @@ func runContainerCmdWithDeps(
 		return err
 	}
 
-	realm := strings.TrimSpace(viper.GetString(config.KUKE_GET_CONTAINER_REALM.ViperKey))
-	if realm == "" {
-		realm = strings.TrimSpace(config.KUKE_GET_CONTAINER_REALM.ValueOrDefault())
-	}
-	space := strings.TrimSpace(viper.GetString(config.KUKE_GET_CONTAINER_SPACE.ViperKey))
-	if space == "" {
-		space = strings.TrimSpace(config.KUKE_GET_CONTAINER_SPACE.ValueOrDefault())
-	}
-	stack := strings.TrimSpace(viper.GetString(config.KUKE_GET_CONTAINER_STACK.ViperKey))
-	if stack == "" {
-		stack = strings.TrimSpace(config.KUKE_GET_CONTAINER_STACK.ValueOrDefault())
-	}
-	cell := strings.TrimSpace(viper.GetString(config.KUKE_GET_CONTAINER_CELL.ViperKey))
+	realm := shared.ExplicitFlag(cmd, "realm", config.KUKE_GET_CONTAINER_REALM.ViperKey)
+	space := shared.ExplicitFlag(cmd, "space", config.KUKE_GET_CONTAINER_SPACE.ViperKey)
+	stack := shared.ExplicitFlag(cmd, "stack", config.KUKE_GET_CONTAINER_STACK.ViperKey)
+	cell := shared.ExplicitFlag(cmd, "cell", config.KUKE_GET_CONTAINER_CELL.ViperKey)
 
 	var name string
 	if len(args) > 0 {
@@ -128,6 +119,15 @@ func runContainerCmdWithDeps(
 	}
 
 	if name != "" {
+		if realm == "" {
+			realm = strings.TrimSpace(config.KUKE_GET_CONTAINER_REALM.ValueOrDefault())
+		}
+		if space == "" {
+			space = strings.TrimSpace(config.KUKE_GET_CONTAINER_SPACE.ValueOrDefault())
+		}
+		if stack == "" {
+			stack = strings.TrimSpace(config.KUKE_GET_CONTAINER_STACK.ValueOrDefault())
+		}
 		if realm == "" {
 			return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
 		}

--- a/cmd/kuke/get/shared/shared.go
+++ b/cmd/kuke/get/shared/shared.go
@@ -26,8 +26,19 @@ import (
 	createshared "github.com/eminwux/kukeon/cmd/kuke/create/shared"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
+
+// ExplicitFlag returns the flag's value only when the user explicitly provided it.
+// This avoids viper.SetDefault side-effects leaking hardcoded defaults (e.g. "default")
+// into list-operation filters, where an unset flag must mean "no filter".
+func ExplicitFlag(cmd *cobra.Command, flagName, viperKey string) string {
+	if cmd != nil && cmd.Flags().Changed(flagName) {
+		return strings.TrimSpace(viper.GetString(viperKey))
+	}
+	return ""
+}
 
 // OutputFormat represents the output format type.
 type OutputFormat string

--- a/cmd/kuke/get/space/space.go
+++ b/cmd/kuke/get/space/space.go
@@ -54,10 +54,7 @@ func NewSpaceCmd() *cobra.Command {
 				return err
 			}
 
-			realm := strings.TrimSpace(viper.GetString(config.KUKE_GET_SPACE_REALM.ViperKey))
-			if realm == "" {
-				realm = strings.TrimSpace(config.KUKE_GET_SPACE_REALM.ValueOrDefault())
-			}
+			realm := shared.ExplicitFlag(cmd, "realm", config.KUKE_GET_SPACE_REALM.ViperKey)
 
 			var name string
 			if len(args) > 0 {
@@ -67,6 +64,9 @@ func NewSpaceCmd() *cobra.Command {
 			}
 
 			if name != "" {
+				if realm == "" {
+					realm = strings.TrimSpace(config.KUKE_GET_SPACE_REALM.ValueOrDefault())
+				}
 				if realm == "" {
 					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
 				}

--- a/cmd/kuke/get/stack/stack.go
+++ b/cmd/kuke/get/stack/stack.go
@@ -54,14 +54,8 @@ func NewStackCmd() *cobra.Command {
 				return err
 			}
 
-			realm := strings.TrimSpace(viper.GetString(config.KUKE_GET_STACK_REALM.ViperKey))
-			if realm == "" {
-				realm = strings.TrimSpace(config.KUKE_GET_STACK_REALM.ValueOrDefault())
-			}
-			space := strings.TrimSpace(viper.GetString(config.KUKE_GET_STACK_SPACE.ViperKey))
-			if space == "" {
-				space = strings.TrimSpace(config.KUKE_GET_STACK_SPACE.ValueOrDefault())
-			}
+			realm := shared.ExplicitFlag(cmd, "realm", config.KUKE_GET_STACK_REALM.ViperKey)
+			space := shared.ExplicitFlag(cmd, "space", config.KUKE_GET_STACK_SPACE.ViperKey)
 
 			var name string
 			if len(args) > 0 {
@@ -71,6 +65,12 @@ func NewStackCmd() *cobra.Command {
 			}
 
 			if name != "" {
+				if realm == "" {
+					realm = strings.TrimSpace(config.KUKE_GET_STACK_REALM.ValueOrDefault())
+				}
+				if space == "" {
+					space = strings.TrimSpace(config.KUKE_GET_STACK_SPACE.ValueOrDefault())
+				}
 				if realm == "" {
 					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
 				}

--- a/docs/examples/hello-world.yaml
+++ b/docs/examples/hello-world.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: hello-world
+spec:
+  id: hello-world
+  realmId: default
+  spaceId: default
+  stackId: default
+  containers:
+    - id: web
+      image: docker.io/library/busybox:latest
+      command: /bin/sh
+      args:
+        - -c
+        - |
+          mkdir -p /www && \
+          cat > /www/index.html <<'HTML'
+          <!doctype html>
+          <html>
+            <head><meta charset="utf-8"><title>kukeon hello-world</title></head>
+            <body style="font-family: sans-serif">
+              <h1>Hello, world from kukeon!</h1>
+              <p>Served by busybox httpd inside a cell in the <code>default</code> realm.</p>
+            </body>
+          </html>
+          HTML
+          exec busybox httpd -f -v -p 8080 -h /www

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -16,15 +16,54 @@
 
 package cni
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"hash/fnv"
+	"strings"
+)
+
+// maxBridgeNameLen is the Linux IFNAMSIZ-1 limit for network interface names.
+const maxBridgeNameLen = 15
 
 // NewCNINetworkConfig builds a NetworkConfig with sensible defaults.
 func NewCNINetworkConfig(name string) NetworkConfig {
 	return NetworkConfig{
 		Name:       name,
-		BridgeName: name,
+		BridgeName: SafeBridgeName(name),
 		SubnetCIDR: defaultSubnetCIDR,
 	}
+}
+
+// SafeBridgeName derives a Linux-legal bridge device name from a CNI network
+// name. Names within the IFNAMSIZ limit pass through unchanged; longer ones
+// are deterministically truncated to a 6-char prefix plus an 8-hex-char FNV-1a
+// suffix (total 15 chars) to preserve readability while staying unique.
+// The empty string is preserved so callers can detect "unset".
+func SafeBridgeName(name string) string {
+	if len(name) <= maxBridgeNameLen {
+		return name
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(name))
+	sum := h.Sum32()
+	prefix := strings.ReplaceAll(name[:6], "/", "-")
+	return prefixHashBridgeName(prefix, sum)
+}
+
+func prefixHashBridgeName(prefix string, sum uint32) string {
+	const (
+		hexLen     = 8
+		bitsPerHex = 4
+		hexMask    = 0xf
+		hex        = "0123456789abcdef"
+	)
+	buf := make([]byte, 0, len(prefix)+1+hexLen)
+	buf = append(buf, prefix...)
+	buf = append(buf, '-')
+	for i := hexLen - 1; i >= 0; i-- {
+		buf = append(buf, hex[(sum>>(uint(i)*bitsPerHex))&hexMask])
+	}
+	return string(buf)
 }
 
 // BuildDefaultConflist generates a default conflist JSON using provided parameters.

--- a/internal/cni/config_test.go
+++ b/internal/cni/config_test.go
@@ -42,6 +42,12 @@ func TestNewCNINetworkConfig(t *testing.T) {
 			wantBridge:  "",
 			wantSubnet:  "10.88.0.0/16",
 		},
+		{
+			name:        "long name is truncated to IFNAMSIZ-safe bridge",
+			networkName: "kuke-system-kukeon",
+			wantBridge:  cni.SafeBridgeName("kuke-system-kukeon"),
+			wantSubnet:  "10.88.0.0/16",
+		},
 	}
 
 	for _, tt := range tests {
@@ -58,6 +64,37 @@ func TestNewCNINetworkConfig(t *testing.T) {
 
 			if cfg.SubnetCIDR != tt.wantSubnet {
 				t.Errorf("NewCNINetworkConfig() subnetCIDR = %q, want %q", cfg.SubnetCIDR, tt.wantSubnet)
+			}
+		})
+	}
+}
+
+func TestSafeBridgeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantLen  int
+		wantSame bool
+	}{
+		{name: "empty", input: "", wantLen: 0, wantSame: true},
+		{name: "short passes through", input: "default-default", wantLen: 15, wantSame: true},
+		{name: "long is truncated to 15", input: "kuke-system-kukeon", wantLen: 15, wantSame: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cni.SafeBridgeName(tt.input)
+			if len(got) != tt.wantLen {
+				t.Errorf("SafeBridgeName(%q) length = %d, want %d (got %q)", tt.input, len(got), tt.wantLen, got)
+			}
+			if tt.wantSame && got != tt.input {
+				t.Errorf("SafeBridgeName(%q) = %q, want unchanged", tt.input, got)
+			}
+			if !tt.wantSame && tt.input != "" && got == tt.input {
+				t.Errorf("SafeBridgeName(%q) unchanged, want truncated", tt.input)
+			}
+			if cni.SafeBridgeName(tt.input) != got {
+				t.Errorf("SafeBridgeName is not deterministic for %q", tt.input)
 			}
 		})
 	}

--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/eminwux/kukeon/internal/apischeme"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -408,7 +409,33 @@ func (b *Exec) bootstrapStack(section *StackSection, realmName, spaceName, stack
 }
 
 // kukeondCellDoc builds the CellDoc describing the kukeond system cell.
-func kukeondCellDoc(image, socketPath string) *v1beta1.CellDoc {
+// The host runPath is bind-mounted into the container at the same path and
+// passed via --run-path so that kukeond reads/writes the same metadata store
+// that kuke uses in --no-daemon mode. The host containerd socket directory is
+// also bind-mounted and --containerd-socket is forwarded so kukeond can reach
+// the same containerd daemon as kuke does on the host.
+func kukeondCellDoc(image, socketPath, runPath, containerdSocket string) *v1beta1.CellDoc {
+	args := []string{"serve", "--socket", socketPath}
+	if runPath != "" {
+		args = append(args, "--run-path", runPath)
+	}
+	if containerdSocket != "" {
+		args = append(args, "--containerd-socket", containerdSocket)
+	}
+
+	volumes := []string{
+		fmt.Sprintf("%s:%s", socketDir(socketPath), socketDir(socketPath)),
+	}
+	if runPath != "" && runPath != socketDir(socketPath) {
+		volumes = append(volumes, fmt.Sprintf("%s:%s", runPath, runPath))
+	}
+	if containerdSocket != "" {
+		ctrdDir := socketDir(containerdSocket)
+		if ctrdDir != socketDir(socketPath) && ctrdDir != runPath {
+			volumes = append(volumes, fmt.Sprintf("%s:%s", ctrdDir, ctrdDir))
+		}
+	}
+
 	return &v1beta1.CellDoc{
 		Metadata: v1beta1.CellMetadata{
 			Name: consts.KukeSystemCellName,
@@ -426,22 +453,30 @@ func kukeondCellDoc(image, socketPath string) *v1beta1.CellDoc {
 			StackID: consts.KukeSystemStackName,
 			Containers: []v1beta1.ContainerSpec{
 				{
-					ID:      consts.KukeSystemContainerName,
-					RealmID: consts.KukeSystemRealmName,
-					SpaceID: consts.KukeSystemSpaceName,
-					StackID: consts.KukeSystemStackName,
-					CellID:  consts.KukeSystemCellName,
-					Image:   image,
-					Command: "/bin/kukeond",
-					Args:    []string{"serve", "--socket", socketPath},
-					Volumes: []string{
-						fmt.Sprintf("%s:%s", socketDir(socketPath), socketDir(socketPath)),
-					},
+					ID:         consts.KukeSystemContainerName,
+					RealmID:    consts.KukeSystemRealmName,
+					SpaceID:    consts.KukeSystemSpaceName,
+					StackID:    consts.KukeSystemStackName,
+					CellID:     consts.KukeSystemCellName,
+					Image:      image,
+					Command:    "/bin/kukeond",
+					Args:       args,
+					Volumes:    volumes,
 					Privileged: true,
 				},
 			},
 		},
 	}
+}
+
+// ensureSocketDir creates the parent directory of the kukeond unix socket so
+// that the bind-mount into the kukeond container has a source to mount.
+func ensureSocketDir(socketPath string) error {
+	dir := socketDir(socketPath)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create kukeond socket dir %q: %w", dir, err)
+	}
+	return nil
 }
 
 // socketDir returns the parent directory of the kukeond unix socket path.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -175,7 +175,15 @@ func (b *Exec) Bootstrap() (BootstrapReport, error) {
 	// System cell: kukeond. Provisioned only when an image is configured (lets
 	// callers opt out in tests / non-daemon setups).
 	if b.opts.KukeondImage != "" {
-		cellDoc := kukeondCellDoc(b.opts.KukeondImage, b.opts.KukeondSocket)
+		if err = ensureSocketDir(b.opts.KukeondSocket); err != nil {
+			return report, err
+		}
+		cellDoc := kukeondCellDoc(
+			b.opts.KukeondImage,
+			b.opts.KukeondSocket,
+			b.opts.RunPath,
+			b.opts.ContainerdSocket,
+		)
 		if err = b.bootstrapCell(&report.SystemCell, cellDoc); err != nil {
 			return report, err
 		}


### PR DESCRIPTION
## Summary
- **Daemon parity fix**: the `kukeond` cell was bind-mounted only with `/run/kukeon`, so any RPC that reached containerd (e.g. `kuke get container`, which probes state via `GetContainerState` per container) hung dialing the missing socket inside the container. Commands that only touched the filesystem (`kuke get realms`) worked, which masked the issue. Bootstrap now bind-mounts the host `runPath` and the containerd socket directory into the system cell and forwards `--run-path` and `--containerd-socket` so the daemon operates against the same state as `kuke --no-daemon`.
- **`get` list-filter fix**: `DefineKV` registers every filter's hardcoded default via `viper.SetDefault`, so `viper.GetString` returned `"default"` for flags the user didn't pass. `kuke get container --realm kuke-system` silently became `--realm kuke-system --space default --stack default` and resolved to a non-existent path, hiding every cell/container outside the `default` realm. `get cell`/`get stack` had the same bug. List paths now read filters through a new `shared.ExplicitFlag` helper that only returns a value when `cmd.Flags().Changed(name)` is true; singleton `get` paths still fall back to `ValueOrDefault()` so `kuke get cell hello-world` keeps its convenience defaults.
- **CNI bridge-name safety**: `SafeBridgeName` truncates long CNI network names (e.g. `kuke-system-kukeon`) to the Linux IFNAMSIZ 15-char limit with a deterministic FNV-1a hash suffix so bridge creation doesn't fail at the netlink layer.
- **Docs**: README "Run a hello-world cell" walkthrough and a "Development environment" section covering the local build-and-load flow (including the `kuke-system.kukeon.io` containerd namespace prerequisite for `ctr images import`). Example cell at `docs/examples/hello-world.yaml`. `CLAUDE.md` checks in the local testing notes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/... ./internal/controller/... ./internal/daemon/...` (green; pre-existing `internal/ctr` and `e2e` failures are unrelated)
- [x] End-to-end: `kuke get container --realm kuke-system` and `kuke get container --realm kuke-system --no-daemon` both return the kukeond + root containers; `kuke get cell` (no filter) walks every realm
- [x] `ctr container info kukeon_kukeon_kukeond_kukeond` shows bind mounts for `/run/kukeon`, `/opt/kukeon`, and `/run/containerd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)