### PR TITLE
fix: translate raw CNI/netlink errors + fail-fast on oversized bridges

### DIFF
--- a/internal/cni/container.go
+++ b/internal/cni/container.go
@@ -31,7 +31,7 @@ func (m *Manager) AddContainerToNetwork(ctx context.Context, containerID, netnsP
 
 	rt := buildRuntimeConf(containerID, netnsPath)
 	_, err := m.cniConf.AddNetworkList(ctx, m.netConf, rt)
-	return err
+	return translateCNIError(err, m.netConf.Name, bridgeNameFromNetConf(m.netConf))
 }
 
 // DelContainerFromNetwork removes a container from the CNI network.
@@ -41,7 +41,15 @@ func (m *Manager) DelContainerFromNetwork(ctx context.Context, containerID, netn
 	}
 
 	rt := buildRuntimeConf(containerID, netnsPath)
-	return m.cniConf.DelNetworkList(ctx, m.netConf, rt)
+	err := m.cniConf.DelNetworkList(ctx, m.netConf, rt)
+	return translateCNIError(err, m.netConf.Name, bridgeNameFromNetConf(m.netConf))
+}
+
+// BridgeName returns the bridge device name from the currently loaded
+// CNI conflist, or "" if no conflist is loaded or the conflist has no
+// bridge plugin.
+func (m *Manager) BridgeName() string {
+	return bridgeNameFromNetConf(m.netConf)
 }
 
 // buildRuntimeConf builds a RuntimeConf for container network operations.

--- a/internal/cni/container.go
+++ b/internal/cni/container.go
@@ -45,13 +45,6 @@ func (m *Manager) DelContainerFromNetwork(ctx context.Context, containerID, netn
 	return translateCNIError(err, m.netConf.Name, bridgeNameFromNetConf(m.netConf))
 }
 
-// BridgeName returns the bridge device name from the currently loaded
-// CNI conflist, or "" if no conflist is loaded or the conflist has no
-// bridge plugin.
-func (m *Manager) BridgeName() string {
-	return bridgeNameFromNetConf(m.netConf)
-}
-
 // buildRuntimeConf builds a RuntimeConf for container network operations.
 func buildRuntimeConf(containerID, netnsPath string) *libcni.RuntimeConf {
 	return &libcni.RuntimeConf{

--- a/internal/cni/errors.go
+++ b/internal/cni/errors.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	libcni "github.com/containernetworking/cni/libcni"
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// translateCNIError inspects an error returned by libcni when adding or
+// deleting a container on a network and, when possible, wraps it with an
+// actionable errdefs sentinel. Unclassified errors are returned unchanged so
+// this function is strictly additive — callers can continue to use errors.Is
+// against the sentinels they already know about.
+//
+// bridge is the bridge device name from the loaded conflist (may be empty if
+// the caller could not determine it); it is used to disambiguate ERANGE
+// (IFNAMSIZ) from other out-of-range conditions.
+func translateCNIError(err error, networkName, bridge string) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+
+	// IFNAMSIZ: libcni surfaces netlink ERANGE as "numerical result out of
+	// range". This is only meaningful if the bridge name itself is too long;
+	// other ERANGE causes (e.g. route table overflow) are left untranslated.
+	if strings.Contains(msg, "numerical result out of range") && len(bridge) > maxBridgeNameLen {
+		return fmt.Errorf(
+			"%w: bridge %q is %d chars, max %d (IFNAMSIZ-1); SafeBridgeName was expected to truncate — file a bug: %w",
+			errdefs.ErrBridgeNameTooLong, bridge, len(bridge), maxBridgeNameLen, err,
+		)
+	}
+
+	// Missing CNI plugin binary. libcni reports this as either "failed to
+	// find plugin" or an exec error like `exec: "bridge": executable file not
+	// found in $PATH`. The bridge plugin is the common offender on fresh hosts.
+	if strings.Contains(msg, "failed to find plugin") ||
+		strings.Contains(msg, "executable file not found") {
+		return fmt.Errorf(
+			"%w: required CNI plugin missing on host — install the standard CNI plugins (e.g. apt install containernetworking-plugins) so %q resolves: %w",
+			errdefs.ErrCNIPluginNotFound, networkName, err,
+		)
+	}
+
+	return err
+}
+
+// bridgeNameFromNetConf extracts the bridge device name from the first bridge
+// plugin in a loaded CNI conflist. Returns "" when the conflist is nil, has no
+// bridge plugin, or is unparseable — callers should treat "" as "unknown".
+func bridgeNameFromNetConf(netConf *libcni.NetworkConfigList) string {
+	if netConf == nil {
+		return ""
+	}
+	for _, p := range netConf.Plugins {
+		if p == nil || len(p.Bytes) == 0 {
+			continue
+		}
+		var raw struct {
+			Type   string `json:"type"`
+			Bridge string `json:"bridge"`
+		}
+		if err := json.Unmarshal(p.Bytes, &raw); err != nil {
+			continue
+		}
+		if raw.Type == "bridge" && raw.Bridge != "" {
+			return raw.Bridge
+		}
+	}
+	return ""
+}

--- a/internal/cni/errors_test.go
+++ b/internal/cni/errors_test.go
@@ -1,0 +1,166 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	libcni "github.com/containernetworking/cni/libcni"
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+func TestTranslateCNIError(t *testing.T) {
+	// The real-world error from the gaps doc — plugin output concatenated by libcni.
+	rangeErr := errors.New(`plugin type="bridge" failed (add): failed to create bridge "kuke-system-kukeon": could not add "kuke-system-kukeon": numerical result out of range`)
+
+	tests := []struct {
+		name         string
+		err          error
+		networkName  string
+		bridge       string
+		wantSentinel error
+		wantSubstr   string
+		// nil means: output == input (passthrough).
+		passthrough bool
+	}{
+		{
+			name: "nil error passes through",
+			err:  nil,
+		},
+		{
+			name:         "ERANGE + oversized bridge → ErrBridgeNameTooLong",
+			err:          rangeErr,
+			networkName:  "kuke-system-kukeon",
+			bridge:       "kuke-system-kukeon", // 18 chars
+			wantSentinel: errdefs.ErrBridgeNameTooLong,
+			wantSubstr:   "IFNAMSIZ",
+		},
+		{
+			name:        "ERANGE but short bridge → passthrough (unrelated cause)",
+			err:         rangeErr,
+			networkName: "net",
+			bridge:      "cni0",
+			passthrough: true,
+		},
+		{
+			name:         "missing plugin binary → ErrCNIPluginNotFound",
+			err:          errors.New(`failed to find plugin "bridge" in path [/opt/cni/bin]`),
+			networkName:  "net",
+			bridge:       "cni0",
+			wantSentinel: errdefs.ErrCNIPluginNotFound,
+			wantSubstr:   "containernetworking-plugins",
+		},
+		{
+			name:         "exec not found → ErrCNIPluginNotFound",
+			err:          errors.New(`fork/exec /opt/cni/bin/bridge: executable file not found in $PATH`),
+			networkName:  "net",
+			bridge:       "cni0",
+			wantSentinel: errdefs.ErrCNIPluginNotFound,
+			wantSubstr:   "CNI plugin",
+		},
+		{
+			name:        "unrelated error → passthrough",
+			err:         errors.New("connection refused"),
+			networkName: "net",
+			bridge:      "cni0",
+			passthrough: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := translateCNIError(tt.err, tt.networkName, tt.bridge)
+
+			if tt.err == nil {
+				if got != nil {
+					t.Fatalf("translateCNIError(nil) = %v, want nil", got)
+				}
+				return
+			}
+
+			if tt.passthrough {
+				if got != tt.err {
+					t.Fatalf("passthrough expected: got %v, want identical to input %v", got, tt.err)
+				}
+				return
+			}
+
+			if !errors.Is(got, tt.wantSentinel) {
+				t.Errorf("sentinel: got %v, want errors.Is(_, %v) == true", got, tt.wantSentinel)
+			}
+			if !errors.Is(got, tt.err) {
+				t.Errorf("original error not preserved via %%w: %v", got)
+			}
+			if tt.wantSubstr != "" && !strings.Contains(got.Error(), tt.wantSubstr) {
+				t.Errorf("message %q missing substring %q", got.Error(), tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestBridgeNameFromNetConf(t *testing.T) {
+	tests := []struct {
+		name string
+		conf *libcni.NetworkConfigList
+		want string
+	}{
+		{
+			name: "nil conflist",
+			conf: nil,
+			want: "",
+		},
+		{
+			name: "bridge plugin present",
+			conf: &libcni.NetworkConfigList{
+				Plugins: []*libcni.NetworkConfig{
+					{Bytes: []byte(`{"type":"bridge","bridge":"kuke0"}`)},
+					{Bytes: []byte(`{"type":"loopback"}`)},
+				},
+			},
+			want: "kuke0",
+		},
+		{
+			name: "no bridge plugin",
+			conf: &libcni.NetworkConfigList{
+				Plugins: []*libcni.NetworkConfig{
+					{Bytes: []byte(`{"type":"loopback"}`)},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "malformed plugin bytes skipped",
+			conf: &libcni.NetworkConfigList{
+				Plugins: []*libcni.NetworkConfig{
+					{Bytes: []byte(`not-json`)},
+					{Bytes: []byte(`{"type":"bridge","bridge":"kuke1"}`)},
+				},
+			},
+			want: "kuke1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bridgeNameFromNetConf(tt.conf); got != tt.want {
+				t.Errorf("bridgeNameFromNetConf() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cni/network.go
+++ b/internal/cni/network.go
@@ -74,6 +74,16 @@ func (m *Manager) CreateNetworkWithConfig(cfg NetworkConfig) (string, error) {
 	if bridge == "" {
 		bridge = defaultBridgeName
 	}
+	// Defense-in-depth: SafeBridgeName is supposed to truncate, but a caller
+	// bypassing it (or a future bug there) would otherwise write a conflist
+	// that fails at bridge-create time with netlink ERANGE — a far less
+	// diagnosable error than this one.
+	if len(bridge) > maxBridgeNameLen {
+		return "", fmt.Errorf(
+			"%w: bridge %q is %d chars, max %d (IFNAMSIZ-1); call SafeBridgeName first",
+			errdefs.ErrBridgeNameTooLong, bridge, len(bridge), maxBridgeNameLen,
+		)
+	}
 	subnet := cfg.SubnetCIDR
 	if subnet == "" {
 		subnet = defaultSubnetCIDR

--- a/internal/cni/network_test.go
+++ b/internal/cni/network_test.go
@@ -454,6 +454,33 @@ func TestManager_CreateNetworkWithConfig(t *testing.T) {
 	}
 }
 
+func TestManager_CreateNetworkWithConfig_RejectsOversizedBridge(t *testing.T) {
+	dir := t.TempDir()
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// 18 chars — exceeds IFNAMSIZ-1 (15). Mimics the gap-doc scenario where
+	// a caller bypassed SafeBridgeName.
+	_, err = mgr.CreateNetworkWithConfig(cni.NetworkConfig{
+		Name:       "kuke-system-kukeon",
+		BridgeName: "kuke-system-kukeon",
+		SubnetCIDR: "10.88.0.0/16",
+	})
+	if err == nil {
+		t.Fatal("CreateNetworkWithConfig() err = nil, want ErrBridgeNameTooLong")
+	}
+	if !errors.Is(err, errdefs.ErrBridgeNameTooLong) {
+		t.Errorf("CreateNetworkWithConfig() err = %v, want errors.Is(_, ErrBridgeNameTooLong)", err)
+	}
+
+	// No conflist file should have been written.
+	if _, statErr := os.Stat(filepath.Join(dir, "kuke-system-kukeon.conflist")); !os.IsNotExist(statErr) {
+		t.Errorf("conflist should not exist after fail-fast: %v", statErr)
+	}
+}
+
 func TestManager_CreateNetwork(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -95,4 +95,10 @@ var (
 	ErrContainerNotFound = errors.New("container not found")
 	ErrTaskNotFound      = errors.New("task not found")
 	ErrTaskNotRunning    = errors.New("task is not running")
+
+	// CNI-related errors.
+
+	ErrBridgeNameTooLong = errors.New("bridge name exceeds Linux IFNAMSIZ limit")
+	ErrCNIPluginNotFound = errors.New("cni plugin not found")
+	ErrCNIBridgeCreate   = errors.New("failed to create bridge")
 )

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -100,5 +100,4 @@ var (
 
 	ErrBridgeNameTooLong = errors.New("bridge name exceeds Linux IFNAMSIZ limit")
 	ErrCNIPluginNotFound = errors.New("cni plugin not found")
-	ErrCNIBridgeCreate   = errors.New("failed to create bridge")
 )


### PR DESCRIPTION
## Summary
- Classify libcni errors and wrap them with actionable `errdefs` sentinels: ERANGE + oversized bridge → `ErrBridgeNameTooLong` (with IFNAMSIZ explanation); missing plugin binary → `ErrCNIPluginNotFound` (with install hint). Unclassified errors pass through unchanged, so the change is strictly additive for callers using `errors.Is`.
- Fail-fast in `CreateNetworkWithConfig` when the bridge name exceeds `maxBridgeNameLen` (15 chars) — defense-in-depth against a caller bypassing `SafeBridgeName`, so the failure happens at conflist-write time with a clear message instead of at netlink-dispatch time as a raw ERANGE.
- Addresses item #7 in `docs/gaps-2026-04-19.md`. Closes nothing automatically; the gaps doc is not yet tracked.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/cni/... ./internal/errdefs/...\` passes (new \`TestTranslateCNIError\`, \`TestBridgeNameFromNetConf\`, \`TestManager_CreateNetworkWithConfig_RejectsOversizedBridge\`)
- [ ] End-to-end repro per gap doc: pre-seed \`/opt/kukeon/kuke-system/kukeon/network.conflist\` with an 18-char bridge, run \`sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev\`, confirm the \`ErrBridgeNameTooLong\` message replaces the raw \`numerical result out of range\`
- [ ] Daemon-parity: \`sudo ./kuke get realms\` vs \`sudo ./kuke get realms --no-daemon\` return identical output (per CLAUDE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)