### PR TITLE
fix: self-heal stale space conflist with mismatched bridge name

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -114,6 +114,10 @@ var (
 	KUKE_INIT_KUKEOND_IMAGE = DefineKV("KUKE_INIT_KUKEOND_IMAGE", "kuke/init/kukeondImage")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_INIT_NO_WAIT = DefineKV("KUKE_INIT_NO_WAIT", "kuke/init/noWait", "false")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_INIT_FORCE_REGENERATE_CNI = DefineKV(
+		"KUKE_INIT_FORCE_REGENERATE_CNI", "kuke/init/forceRegenerateCNI", "false",
+	)
 
 	// Create command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -95,6 +95,19 @@ func setFlags(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("failed to bind flag: %w", err)
 	}
+
+	cmd.Flags().Bool(
+		"force-regenerate-cni", false,
+		"Rewrite space CNI conflists even when they already exist; use to "+
+			"recover from stale on-disk state after a generator fix",
+	)
+	err = viper.BindPFlag(
+		config.KUKE_INIT_FORCE_REGENERATE_CNI.ViperKey,
+		cmd.Flags().Lookup("force-regenerate-cni"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to bind flag: %w", err)
+	}
 	return nil
 }
 
@@ -138,10 +151,11 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	image := resolveKukeondImage()
 
 	opts := controller.Options{
-		RunPath:          viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
-		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
-		KukeondImage:     image,
-		KukeondSocket:    socketPath,
+		RunPath:            viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket:   viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+		KukeondImage:       image,
+		KukeondSocket:      socketPath,
+		ForceRegenerateCNI: viper.GetBool(config.KUKE_INIT_FORCE_REGENERATE_CNI.ViperKey),
 	}
 
 	logger.DebugContext(cmd.Context(), "running init", "opts", opts)

--- a/docs/gaps-2026-04-19.md
+++ b/docs/gaps-2026-04-19.md
@@ -1,0 +1,229 @@
+# Kukeon Operator Gaps — 2026-04-19
+
+This document captures functionality that was missing or rough when rebuilding
+kukeon from source and running `kuke init` end-to-end. Each gap is written so it
+can be picked up as a standalone implementation task.
+
+The session that produced this list went roughly:
+
+1. Tear down the existing `kuke-system` cell (3 manual commands).
+2. Rebuild `kuke`/`kukeond` with `make kuke`.
+3. `docker build` + `docker save | ctr -n kuke-system.kukeon.io images import`.
+4. `kuke init` — **failed** with `numerical result out of range` because a
+   stale conflist on disk pinned an 18-char bridge name.
+5. `rm /opt/kukeon/kuke-system/kukeon/network.conflist`; re-run `kuke init`.
+6. Manual verification via `kuke get realms` (with/without `--no-daemon`),
+   `ctr container info`, `ps -ef`, `ip link`.
+
+Items below are ordered by the pain they caused in that flow.
+
+---
+
+## 1. `kuke init` does not self-heal stale on-disk config *(correctness bug)* — **DONE 2026-04-20**
+
+**Symptom.** After merging `SafeBridgeName` (commit `6a46bc4`), re-running
+`kuke init` on a host with a pre-fix conflist fails at
+`failed to attach root container kukeon_kukeon_kukeond_root to network:
+plugin type="bridge" failed (add): failed to create bridge
+"kuke-system-kukeon": could not add "kuke-system-kukeon":
+numerical result out of range`.
+
+**Root cause.** `internal/controller/runner/provision.go:196` checks only
+"does a conflist exist?" before deciding to skip regeneration
+(`WriteSpaceNetworkConfig`). The stored bridge name is never compared against
+`cni.SafeBridgeName(networkName)`, so fixes to the generator never propagate
+to hosts that already have state on disk.
+
+**Resolution.**
+- `cni.Manager.ReadBridgeName` (`internal/cni/network.go`) parses an existing
+  conflist and returns the bridge-plugin's `bridge` field, with sentinel
+  errors `errdefs.ErrNetworkNotFound` and `errdefs.ErrBridgePluginMissing`.
+- `ensureSpaceCNIConfig` now compares the on-disk bridge against
+  `cni.SafeBridgeName(networkName)` and regenerates on mismatch (via the new
+  `shouldRegenerateSpaceCNI` helper), with a structured log recording the
+  reason. `createSpaceCNIConfig` is left alone — its contract is
+  "create-only", and the stale-state scenario only reaches
+  `ensureSpaceCNIConfig` on re-init.
+- `kuke init --force-regenerate-cni` flag added as an operator escape hatch
+  (`KUKE_INIT_FORCE_REGENERATE_CNI`); it threads through
+  `controller.Options.ForceRegenerateCNI` → `runner.Options.ForceRegenerateCNI`.
+- Unit tests in `internal/controller/runner/provision_test.go` cover:
+  heal-stale, leave-matching-alone, force-overwrite, and create-when-missing.
+  Bridge-parsing edge cases (missing plugin, malformed JSON, empty path) are
+  covered in `internal/cni/network_test.go`.
+
+**Files touched.** `internal/cni/network.go`, `internal/cni/network_test.go`,
+`internal/errdefs/errdefs.go`, `internal/controller/runner/provision.go`,
+`internal/controller/runner/provision_test.go`,
+`internal/controller/runner/runner.go`,
+`internal/controller/controller.go`, `cmd/config/env.go`,
+`cmd/kuke/init/init.go`.
+
+---
+
+## 2. No single-command teardown
+
+**Symptom.** Tearing down the kukeond system cell currently requires three
+coordinated commands plus knowledge of the internal realm/space/stack coords:
+
+```bash
+sudo kuke kill   cell kukeond --realm kuke-system --space kukeon --stack kukeon --no-daemon
+sudo kuke delete cell kukeond --realm kuke-system --space kukeon --stack kukeon --no-daemon
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+```
+
+Anyone iterating on `kukeond` hits this every rebuild.
+
+**Proposed fix.** Add `kuke reset` (or `kuke down`). Semantics:
+- Stop + delete the `kuke-system/kukeon/kukeon/kukeond` cell.
+- Remove `/run/kukeon/kukeond.{sock,pid}`.
+- Leave `/opt/kukeon/default/**` untouched (user realm data).
+- Flags: `--purge-system` (also remove `/opt/kukeon/kuke-system`),
+  `--purge-all` (also remove user realms — destructive, confirm).
+- `--no-daemon` implicit — the daemon is what's being stopped.
+
+**Files.** New `cmd/reset/` or `cmd/down/`, wiring the existing
+`kill`/`delete` runner logic.
+
+---
+
+## 3. No `kuke image load`
+
+**Symptom.** Loading a locally built image into the right containerd
+namespace requires:
+
+```bash
+docker save kukeon-local:dev | \
+    sudo ctr -n kuke-system.kukeon.io images import -
+```
+
+Users must know which namespace corresponds to which realm. Easy to load
+into `kukeon.io` (default realm) by mistake and wonder why `kuke init`
+can't find the image.
+
+**Proposed fix.** `kuke image load <tarball-or-docker-ref> --realm <name>`.
+- Default `--realm` to `kuke-system` for `kukeond` images.
+- Accept either a `docker save` tarball path, `-` for stdin, or a local
+  docker reference (shell out to `docker save` internally).
+- `kuke image ls --realm <name>` for symmetry.
+
+**Files.** New `cmd/image/`; uses `github.com/containerd/containerd` client
+scoped to the realm's namespace (lookup via `internal/consts/consts.go`).
+
+---
+
+## 4. No `kuke logs` for cells
+
+**Symptom.** To see kukeond's output I had to drop to `ctr -n
+kuke-system.kukeon.io tasks attach` (or inspect the container's log path
+manually). There is no first-class way to read the daemon's stdout/stderr.
+
+**Proposed fix.** `kuke logs <cell> [--follow] [--realm ...] [--space ...]
+[--stack ...]`. Default target: the kukeond cell. Should work whether the
+daemon is up (via socket) or down (read the log file directly, like the
+existing `--no-daemon` pattern).
+
+**Files.** New `cmd/logs/`; needs a convention for where container stdout
+is persisted (today it appears to go to the containerd shim's default,
+which isn't readable without root + digging).
+
+---
+
+## 5. No version / client-daemon compatibility check
+
+**Symptom.** After rebuilding, it's easy to forget to re-import the image —
+the CLI is new, the daemon is old. Nothing tells you.
+
+**Proposed fix.**
+- `kuke version` prints the CLI version + build info.
+- When `--no-daemon` is absent, also query the daemon's `/version` endpoint
+  and print its version alongside. Warn on mismatch.
+- Optional: soft-fail `kuke init` if the loaded `--kukeond-image` digest
+  doesn't match the CLI binary's build (embed image digest at build time).
+
+**Files.** `cmd/version/`, `kukeond` gRPC/HTTP API (add a Version RPC),
+`cmd/config/version.go` (already stores `Version`).
+
+---
+
+## 6. No `kuke doctor` / preflight
+
+**Symptom.** The class of problems I hit are all detectable ahead of time:
+- Stale conflist with oversized bridge name.
+- Missing kukeond image in the system namespace.
+- Orphaned sockets in `/run/kukeon/`.
+- Missing CNI plugins in `/opt/cni/bin/`.
+- Mismatched CLI/daemon versions.
+
+**Proposed fix.** `kuke doctor` that runs checks and prints a status
+report. Each check has: name, status (ok/warn/fail), remediation hint.
+Return non-zero on any `fail`. CI-friendly `--json` output.
+
+**Files.** New `cmd/doctor/`; reuse existing accessors from
+`internal/util/fs/` and `internal/cni/`.
+
+---
+
+## 7. Raw kernel/netlink errors reach the user unexplained
+
+**Symptom.** `"numerical result out of range"` is `ERANGE` from netlink
+when an interface name exceeds `IFNAMSIZ-1` (15 chars). The user sees only
+the raw string.
+
+**Proposed fix.** In `internal/cni/network.go` (where bridge creation is
+dispatched) wrap the CNI plugin error. When creating a bridge, if the
+intended name exceeds `maxBridgeNameLen`, fail fast with
+`bridge name %q exceeds Linux 15-char limit (IFNAMSIZ); this should have
+been truncated by SafeBridgeName — file a bug`. For other `ERANGE` /
+common errnos from netlink, translate into user-meaningful messages.
+
+**Files.** `internal/cni/network.go`,
+`internal/errdefs/` (new error kinds).
+
+---
+
+## 8. No `kuke ping` / daemon health probe
+
+**Symptom.** `kuke init` ends with `kukeond is ready
+(unix:///run/kukeon/kukeond.sock)`, but there's no lightweight way to
+re-verify later without issuing a real `get` that may have side effects
+(or fail for an unrelated reason).
+
+**Proposed fix.** `kuke ping` that dials the socket, calls a
+`Health`/`Ping` RPC, prints round-trip time, exits non-zero on failure.
+
+**Files.** `cmd/ping/`, `kukeond` API (Health RPC).
+
+---
+
+## 9. Daemon-parity regression test is documented but not automated
+
+**Symptom.** `CLAUDE.md` tells users to manually diff
+`kuke get realms` and `kuke get realms --no-daemon` after `kuke init`.
+This is the actual regression guard for the run-path bind-mount bug — and
+it runs only when a human remembers to run it.
+
+**Proposed fix.** `kuke selftest` (or extend `kuke doctor`) that:
+- Runs every `kuke get <resource>` both ways and diffs.
+- Fails on any divergence with a pointer to which resource disagrees.
+- Optional: also verify the kukeond container's mount spec includes
+  `/run/kukeon` and `/opt/kukeon` as bind mounts.
+
+**Files.** New `cmd/selftest/`; reuses existing `get` runners.
+
+---
+
+## Priority suggestion
+
+If picking up one at a time, I'd tackle them in this order:
+
+| Order | Item | Why first |
+| ----- | --------------------------------------------- | ---------------------------------------------------------- |
+| 1     | ~~#1 Self-heal stale conflist~~ (done)        | Latent correctness bug; silently breaks re-init across fix commits. |
+| 2     | #7 Translate raw netlink errors               | Cheap; makes #1-class bugs self-diagnosing going forward.  |
+| 3     | #2 `kuke reset`                               | Removes the biggest daily papercut for anyone hacking on kukeond. |
+| 4     | #6 `kuke doctor`                              | Central place to land preflight checks as they're written. |
+| 5     | #3 `kuke image load`                          | Removes the second-biggest papercut in the dev loop.       |
+| 6     | #5 `kuke version` w/ client-daemon check      | Prevents the "forgot to reimport image" foot-gun.          |
+| 7     | #4 `kuke logs`                                | Needed once users start debugging their own cells.         |
+| 8     | #8 `kuke ping` + #9 `kuke selftest`           | Polish; both fit naturally under `doctor`.                 |

--- a/internal/cni/network.go
+++ b/internal/cni/network.go
@@ -68,6 +68,49 @@ func (m *Manager) ExistsNetworkConfig(networkName, configPath string) (bool, str
 	return true, configPath, nil
 }
 
+// ReadBridgeName parses the conflist at configPath and returns the `bridge` field of
+// the first plugin whose `type` is "bridge". Returns errdefs.ErrNetworkNotFound if the
+// file is missing, errdefs.ErrBridgePluginMissing if no bridge plugin is present, and
+// a wrapped JSON error for malformed content. The returned string may be empty when
+// the bridge plugin has no `bridge` field, which callers should treat as a mismatch.
+func (m *Manager) ReadBridgeName(configPath string) (string, error) {
+	if configPath == "" {
+		return "", errors.New("network config path is required")
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", errdefs.ErrNetworkNotFound
+		}
+		return "", err
+	}
+
+	var raw map[string]interface{}
+	if uErr := json.Unmarshal(data, &raw); uErr != nil {
+		return "", fmt.Errorf("parse conflist: %w", uErr)
+	}
+
+	plugins, ok := raw["plugins"].([]interface{})
+	if !ok {
+		return "", errdefs.ErrBridgePluginMissing
+	}
+
+	for _, p := range plugins {
+		plugin, pOK := p.(map[string]interface{})
+		if !pOK {
+			continue
+		}
+		if t, tOK := plugin["type"].(string); !tOK || t != "bridge" {
+			continue
+		}
+		bridge, _ := plugin["bridge"].(string)
+		return bridge, nil
+	}
+
+	return "", errdefs.ErrBridgePluginMissing
+}
+
 // CreateNetworkWithConfig creates a CNI network conflist file using the provided NetworkConfig.
 func (m *Manager) CreateNetworkWithConfig(cfg NetworkConfig) (string, error) {
 	bridge := cfg.BridgeName

--- a/internal/cni/network_test.go
+++ b/internal/cni/network_test.go
@@ -294,6 +294,114 @@ func TestManager_ExistsNetworkConfig(t *testing.T) {
 	}
 }
 
+func TestManager_ReadBridgeName(t *testing.T) {
+	bridgeFirst := `{
+  "cniVersion": "0.4.0",
+  "name": "net",
+  "plugins": [
+    {"type": "bridge", "bridge": "kuke-s-abcdef12"},
+    {"type": "loopback"}
+  ]
+}`
+	bridgeSecond := `{
+  "cniVersion": "0.4.0",
+  "name": "net",
+  "plugins": [
+    {"type": "loopback"},
+    {"type": "bridge", "bridge": "cni0"}
+  ]
+}`
+	noBridge := `{
+  "cniVersion": "0.4.0",
+  "name": "net",
+  "plugins": [{"type": "loopback"}]
+}`
+	missingPlugins := `{"cniVersion": "0.4.0", "name": "net"}`
+	preFixStale := `{
+  "cniVersion": "0.4.0",
+  "name": "kuke-system-kukeon",
+  "plugins": [
+    {"type": "bridge", "bridge": "kuke-system-kukeon"}
+  ]
+}`
+
+	tests := []struct {
+		name       string
+		contents   string // written if non-empty
+		setupNoOp  bool   // when true, do not create the file
+		wantBridge string
+		wantErr    error
+	}{
+		{name: "bridge plugin first", contents: bridgeFirst, wantBridge: "kuke-s-abcdef12"},
+		{name: "bridge plugin second", contents: bridgeSecond, wantBridge: "cni0"},
+		{name: "no bridge plugin", contents: noBridge, wantErr: errdefs.ErrBridgePluginMissing},
+		{name: "plugins field absent", contents: missingPlugins, wantErr: errdefs.ErrBridgePluginMissing},
+		{name: "pre-fix stale bridge name preserved for comparison", contents: preFixStale, wantBridge: "kuke-system-kukeon"},
+		{name: "file missing", setupNoOp: true, wantErr: errdefs.ErrNetworkNotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "network.conflist")
+			if !tt.setupNoOp {
+				if err := os.WriteFile(configPath, []byte(tt.contents), 0o600); err != nil {
+					t.Fatalf("failed to write conflist: %v", err)
+				}
+			}
+
+			mgr, err := cni.NewManager("", dir, "")
+			if err != nil {
+				t.Fatalf("failed to create manager: %v", err)
+			}
+
+			got, err := mgr.ReadBridgeName(configPath)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("ReadBridgeName() error = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadBridgeName() error = %v, want nil", err)
+			}
+			if got != tt.wantBridge {
+				t.Errorf("ReadBridgeName() = %q, want %q", got, tt.wantBridge)
+			}
+		})
+	}
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		dir := t.TempDir()
+		configPath := filepath.Join(dir, "network.conflist")
+		if err := os.WriteFile(configPath, []byte("not json"), 0o600); err != nil {
+			t.Fatalf("failed to write conflist: %v", err)
+		}
+		mgr, err := cni.NewManager("", dir, "")
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		_, err = mgr.ReadBridgeName(configPath)
+		if err == nil {
+			t.Fatal("ReadBridgeName() error = nil on malformed JSON, want error")
+		}
+		if errors.Is(err, errdefs.ErrNetworkNotFound) || errors.Is(err, errdefs.ErrBridgePluginMissing) {
+			t.Fatalf("ReadBridgeName() error = %v; want a JSON parse error (not a sentinel)", err)
+		}
+	})
+
+	t.Run("empty path", func(t *testing.T) {
+		dir := t.TempDir()
+		mgr, err := cni.NewManager("", dir, "")
+		if err != nil {
+			t.Fatalf("failed to create manager: %v", err)
+		}
+		if _, err = mgr.ReadBridgeName(""); err == nil {
+			t.Fatal("ReadBridgeName(\"\") error = nil, want error")
+		}
+	})
+}
+
 func TestManager_CreateNetworkWithConfig(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -79,6 +79,10 @@ type Options struct {
 	// KukeondSocket is the unix socket path kukeond serves on. Used by bootstrap
 	// to build the bind-mount for the system cell.
 	KukeondSocket string
+	// ForceRegenerateCNI forces bootstrap to rewrite space conflists even when
+	// they already exist with the expected bridge name. Surfaces via
+	// `kuke init --force-regenerate-cni`.
+	ForceRegenerateCNI bool
 }
 
 func NewControllerExec(ctx context.Context, logger *slog.Logger, opts Options) *Exec {
@@ -87,8 +91,9 @@ func NewControllerExec(ctx context.Context, logger *slog.Logger, opts Options) *
 		logger: logger,
 		opts:   opts,
 		runner: runner.NewRunner(ctx, logger, runner.Options{
-			ContainerdSocket: opts.ContainerdSocket,
-			RunPath:          opts.RunPath,
+			ContainerdSocket:   opts.ContainerdSocket,
+			RunPath:            opts.RunPath,
+			ForceRegenerateCNI: opts.ForceRegenerateCNI,
 		}),
 	}
 }

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -192,12 +192,31 @@ func (r *Exec) ensureSpaceCNIConfig(space intmodel.Space) (intmodel.Space, error
 		return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrCheckNetworkExists, err)
 	}
 
-	// Ensure a network exists for this space
+	// Ensure a network exists for this space. Self-heal stale conflists on
+	// disk: if the file exists but its bridge name disagrees with
+	// SafeBridgeName(networkName), the conflist was written before the
+	// IFNAMSIZ fix (commit 6a46bc4) and will fail netlink with ERANGE when
+	// the CNI plugin tries to create the bridge. Regenerate in place so
+	// fixes to the name generator propagate to hosts with pre-existing
+	// state on re-run.
 	exists, _, err := mgr.ExistsNetworkConfig(networkName, confPath)
 	if err != nil && !errors.Is(err, errdefs.ErrNetworkNotFound) {
 		return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrCheckNetworkExists, err)
 	}
-	if !exists {
+	regenerate, regenReason, regenErr := r.shouldRegenerateSpaceCNI(mgr, space, networkName, confPath, exists)
+	if regenErr != nil {
+		return intmodel.Space{}, regenErr
+	}
+	if regenerate {
+		if regenReason != "" {
+			r.logger.InfoContext(
+				r.ctx,
+				"regenerating space network conflist",
+				"space", space.Metadata.Name,
+				"network", networkName,
+				"reason", regenReason,
+			)
+		}
 		if writeErr := fs.WriteSpaceNetworkConfig(confPath, networkName); writeErr != nil {
 			return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrCreateNetwork, writeErr)
 		}
@@ -248,6 +267,43 @@ func (r *Exec) ensureSpaceCNIConfig(space intmodel.Space) (intmodel.Space, error
 		confPath,
 	)
 	return space, nil
+}
+
+// shouldRegenerateSpaceCNI decides whether ensureSpaceCNIConfig needs to
+// rewrite the on-disk conflist. Returns (regenerate, humanReason, fatalErr).
+// The reason is empty when the decision is the trivial "file missing" case so
+// callers can suppress logging on first-time provision.
+func (r *Exec) shouldRegenerateSpaceCNI(
+	mgr *cni.Manager,
+	space intmodel.Space,
+	networkName, confPath string,
+	exists bool,
+) (bool, string, error) {
+	if !exists {
+		return true, "", nil
+	}
+	if r.opts.ForceRegenerateCNI {
+		return true, "force-regenerate-cni flag set", nil
+	}
+	onDiskBridge, readErr := mgr.ReadBridgeName(confPath)
+	switch {
+	case readErr == nil:
+		expected := cni.SafeBridgeName(networkName)
+		if onDiskBridge != expected {
+			return true, fmt.Sprintf(
+				"bridge name %q does not match expected %q (stale pre-SafeBridgeName conflist)",
+				onDiskBridge, expected,
+			), nil
+		}
+		return false, "", nil
+	case errors.Is(readErr, errdefs.ErrBridgePluginMissing):
+		return true, "bridge plugin missing from conflist", nil
+	case errors.Is(readErr, errdefs.ErrNetworkNotFound):
+		// Race: ExistsNetworkConfig saw the file; it's gone now. Regenerate.
+		return true, "conflist disappeared after existence check", nil
+	default:
+		return false, "", fmt.Errorf("%w: %w", errdefs.ErrCheckNetworkExists, readErr)
+	}
 }
 
 func (r *Exec) createSpaceCNIConfig(space intmodel.Space) (string, error) {

--- a/internal/controller/runner/provision_test.go
+++ b/internal/controller/runner/provision_test.go
@@ -1,0 +1,230 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests exercise private methods on *Exec
+package runner
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cni"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// newProvisionTestExec builds a minimal *Exec suitable for exercising
+// provision-path helpers that touch the filesystem but not containerd.
+func newProvisionTestExec(t *testing.T, runPath string, forceRegenerateCNI bool) *Exec {
+	t.Helper()
+	opts := Options{
+		RunPath: runPath,
+		CniConf: cni.Conf{
+			CniConfigDir: filepath.Join(runPath, "cni", "config"),
+			CniCacheDir:  filepath.Join(runPath, "cni", "cache"),
+			CniBinDir:    filepath.Join(runPath, "cni", "bin"),
+		},
+		ForceRegenerateCNI: forceRegenerateCNI,
+	}
+	return &Exec{
+		ctx:     context.Background(),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:    opts,
+		cniConf: &opts.CniConf,
+	}
+}
+
+// writeStaleConflist writes a pre-SafeBridgeName conflist at the expected
+// space-network-config path so ensureSpaceCNIConfig has something to self-heal.
+// The realm/space name pair chosen by the caller must be long enough to force
+// SafeBridgeName to truncate, so the "stale" bridge can differ from the fixed one.
+func writeStaleConflist(t *testing.T, runPath, realmName, spaceName, staleBridge string) string {
+	t.Helper()
+	confPath, err := fs.SpaceNetworkConfigPath(runPath, realmName, spaceName)
+	if err != nil {
+		t.Fatalf("SpaceNetworkConfigPath: %v", err)
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(confPath), 0o750); mkErr != nil {
+		t.Fatalf("mkdir conflist parent: %v", mkErr)
+	}
+	// Deliberately hand-rolled to mirror what a pre-fix release wrote: the
+	// bridge field carries the raw network name, which exceeds IFNAMSIZ-1.
+	contents := `{
+  "cniVersion": "0.4.0",
+  "name": "` + realmName + `-` + spaceName + `",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "` + staleBridge + `",
+      "isGateway": true,
+      "ipMasq": true,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [[{"subnet": "10.22.0.0/16"}]],
+        "routes": [{"dst": "0.0.0.0/0"}]
+      }
+    },
+    {"type": "loopback"}
+  ]
+}`
+	if wErr := os.WriteFile(confPath, []byte(contents), 0o600); wErr != nil {
+		t.Fatalf("write stale conflist: %v", wErr)
+	}
+	return confPath
+}
+
+func TestEnsureSpaceCNIConfig_HealsStaleBridgeName(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+
+	// Pick names whose concatenation exceeds IFNAMSIZ so SafeBridgeName will
+	// produce a hashed bridge, making the stale → fresh transition observable.
+	const realmName = "kuke-system"
+	const spaceName = "kukeon"
+	staleBridge := realmName + "-" + spaceName // 18 chars — the pre-fix bug
+	confPath := writeStaleConflist(t, runPath, realmName, spaceName, staleBridge)
+
+	mgr, err := cni.NewManager(r.cniConf.CniBinDir, r.cniConf.CniConfigDir, r.cniConf.CniCacheDir)
+	if err != nil {
+		t.Fatalf("cni.NewManager: %v", err)
+	}
+	if got, rErr := mgr.ReadBridgeName(confPath); rErr != nil || got != staleBridge {
+		t.Fatalf("precondition: expected stale bridge %q on disk, got %q (err=%v)", staleBridge, got, rErr)
+	}
+
+	space := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: spaceName},
+		Spec:     intmodel.SpaceSpec{RealmName: realmName},
+	}
+	if _, err = r.ensureSpaceCNIConfig(space); err != nil {
+		t.Fatalf("ensureSpaceCNIConfig: %v", err)
+	}
+
+	got, err := mgr.ReadBridgeName(confPath)
+	if err != nil {
+		t.Fatalf("ReadBridgeName after ensure: %v", err)
+	}
+	want := cni.SafeBridgeName(realmName + "-" + spaceName)
+	if got != want {
+		t.Errorf("bridge after self-heal = %q, want %q", got, want)
+	}
+	if len(got) > 15 {
+		t.Errorf("bridge after self-heal is %d chars, exceeds IFNAMSIZ-1", len(got))
+	}
+}
+
+func TestEnsureSpaceCNIConfig_LeavesMatchingConflistAlone(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+
+	const realmName = "kuke-system"
+	const spaceName = "kukeon"
+	correctBridge := cni.SafeBridgeName(realmName + "-" + spaceName)
+	confPath := writeStaleConflist(t, runPath, realmName, spaceName, correctBridge)
+
+	before, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	space := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: spaceName},
+		Spec:     intmodel.SpaceSpec{RealmName: realmName},
+	}
+	if _, err = r.ensureSpaceCNIConfig(space); err != nil {
+		t.Fatalf("ensureSpaceCNIConfig: %v", err)
+	}
+
+	after, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("conflist was rewritten despite matching bridge name\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestEnsureSpaceCNIConfig_ForceRegenerateCNIOverwrites(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, true)
+
+	const realmName = "kuke-system"
+	const spaceName = "kukeon"
+	correctBridge := cni.SafeBridgeName(realmName + "-" + spaceName)
+	confPath := writeStaleConflist(t, runPath, realmName, spaceName, correctBridge)
+
+	before, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	space := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: spaceName},
+		Spec:     intmodel.SpaceSpec{RealmName: realmName},
+	}
+	if _, err = r.ensureSpaceCNIConfig(space); err != nil {
+		t.Fatalf("ensureSpaceCNIConfig: %v", err)
+	}
+
+	after, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	// The rewritten conflist uses BuildDefaultConflist, which emits pretty-printed
+	// JSON different from our hand-rolled test fixture — so forcing a regenerate
+	// must change the bytes on disk even though the bridge name already matched.
+	if string(before) == string(after) {
+		t.Error("ForceRegenerateCNI did not rewrite conflist when bridge name matched")
+	}
+}
+
+func TestEnsureSpaceCNIConfig_CreatesWhenMissing(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+
+	const realmName = "kuke-system"
+	const spaceName = "kukeon"
+
+	space := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: spaceName},
+		Spec:     intmodel.SpaceSpec{RealmName: realmName},
+	}
+	if _, err := r.ensureSpaceCNIConfig(space); err != nil {
+		t.Fatalf("ensureSpaceCNIConfig: %v", err)
+	}
+
+	confPath, err := fs.SpaceNetworkConfigPath(runPath, realmName, spaceName)
+	if err != nil {
+		t.Fatalf("SpaceNetworkConfigPath: %v", err)
+	}
+	mgr, err := cni.NewManager(r.cniConf.CniBinDir, r.cniConf.CniConfigDir, r.cniConf.CniCacheDir)
+	if err != nil {
+		t.Fatalf("cni.NewManager: %v", err)
+	}
+	got, err := mgr.ReadBridgeName(confPath)
+	if err != nil {
+		t.Fatalf("ReadBridgeName: %v", err)
+	}
+	if want := cni.SafeBridgeName(realmName + "-" + spaceName); got != want {
+		t.Errorf("bridge on created conflist = %q, want %q", got, want)
+	}
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -105,6 +105,10 @@ type Options struct {
 	ContainerdSocket string
 	RunPath          string
 	CniConf          cni.Conf
+	// ForceRegenerateCNI forces ensureSpaceCNIConfig to rewrite an existing conflist
+	// even when one is present and its bridge name matches SafeBridgeName. Set by
+	// `kuke init --force-regenerate-cni` as an operator escape hatch.
+	ForceRegenerateCNI bool
 }
 
 func NewRunner(ctx context.Context, logger *slog.Logger, opts Options) Runner {

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -43,6 +43,7 @@ var (
 	ErrConversionFailed        = errors.New("conversion failed")
 	ErrDefaultingFailed        = errors.New("defaulting failed")
 	ErrCheckNetworkExists      = errors.New("failed to check if network exists")
+	ErrBridgePluginMissing     = errors.New("bridge plugin missing from conflist")
 	ErrGetSpace                = errors.New("failed to get space")
 	ErrSpaceNotFound           = errors.New("space not found")
 	ErrSpaceDocRequired        = errors.New("space document is required")


### PR DESCRIPTION
## Summary
- `ensureSpaceCNIConfig` now compares the on-disk conflist's bridge name against `cni.SafeBridgeName(networkName)` and regenerates in place on mismatch, so hosts that already have a pre-`SafeBridgeName` conflist (e.g. the 18-char `kuke-system-kukeon` bridge that trips netlink's `ERANGE`) recover on the next `kuke init` instead of failing to attach the kukeond root container. A new `--force-regenerate-cni` flag on `kuke init` is the operator escape hatch for forcing a rewrite without the diff check.
- Introduces `cni.Manager.ReadBridgeName` + `errdefs.ErrBridgePluginMissing` as the primitives that drive the self-heal decision, and records the regeneration reason in a structured log line for post-mortems.
- Closes gap #1 from `docs/gaps-2026-04-19.md`; the doc is updated in this PR to reflect the resolution.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/controller/runner/...` (new `TestEnsureSpaceCNIConfig_*` cases: heals stale, leaves matching alone, force-overwrites, creates-when-missing)
- [x] `go test ./internal/cni/...` (existing `ReadBridgeName` coverage)
- [ ] Manual: plant a stale `kuke-system-kukeon` bridge conflist, re-run `sudo ./kuke init`, confirm it regenerates (and parity via `kuke get realms` with/without `--no-daemon`)
- [ ] Manual: `sudo ./kuke init --force-regenerate-cni` on a host with a correct conflist, confirm it rewrites