### PR TITLE
chore: move CLAUDE.md to agents/dev with PR-review playbook

### DIFF
--- a/agents/dev/CLAUDE.md
+++ b/agents/dev/CLAUDE.md
@@ -129,3 +129,74 @@ sudo ctr -n kuke-system.kukeon.io container info \
 # Expect: /bin/kukeond serve --socket /run/kukeon/kukeond.sock --run-path /opt/kukeon
 ps -ef | grep '[k]ukeond serve'
 ```
+
+## Commit message style
+
+Commit subjects in this repo are **single-line only** — no body, no
+trailers. Match the prevailing `type: short imperative summary` shape
+(see `git log --oneline`) and keep everything in the subject; do not
+add a blank line + paragraph body, and do **not** append a
+`Co-Authored-By:` trailer.
+
+## Pushing PR fix-up commits
+
+When the task is "address a review comment on PR #N", the fix is only
+visible on GitHub after it's **pushed** to the PR's head branch. After
+committing locally, push to the PR's `headRefName` (check with
+`gh pr view N --json headRefName`) before reporting the task done. A
+local commit on the correct branch is not the same as a commit on the
+PR.
+
+## Reviewing PR comments and addressing fixes
+
+When the user asks to review a PR's comments and fix them, follow this
+sequence end-to-end:
+
+1. **Find the review feedback.** Check both channels — GitHub surfaces
+   inline review comments and top-level discussion separately:
+   ```bash
+   gh pr view <N>                                  # summary, state
+   gh api repos/<owner>/<repo>/pulls/<N>/comments  # inline/review comments
+   gh api repos/<owner>/<repo>/issues/<N>/comments # top-level discussion
+   ```
+   Read every comment — don't act on only the first one.
+
+2. **Check out the PR's head branch, not main.** Resolve it first so
+   you push to the right place:
+   ```bash
+   gh pr view <N> --json headRefName,headRepository
+   git fetch origin <headRefName> && git checkout <headRefName>
+   ```
+   A local commit on `main` or on a stale branch does **not** show up
+   on the PR.
+
+3. **Separate blocking items from non-blocking suggestions.** Reviewers
+   often mark some items as "nits" or "non-blocking". Address the
+   blocking ones; surface the non-blocking ones to the user with a
+   short recommendation so they can choose.
+
+4. **Verify each claim before acting.** If the reviewer says a symbol
+   is dead code, `grep` for it. If they say a test fails, run it. Do
+   not delete/edit code on the reviewer's word alone — their comment
+   may be based on stale state.
+
+5. **Make the fix, then validate locally.** Run the same checks the
+   PR's test plan calls out (typically `go build ./...`, `go vet ./...`,
+   and the affected package tests) before committing. Fix-up commits
+   that break CI waste a round-trip.
+
+6. **Commit in the repo's style** (see "Commit message style" above):
+   single-line `type: summary`, no body, no trailers.
+
+7. **Push to the PR branch and confirm.** After `git push`, verify the
+   new commit appears on the PR:
+   ```bash
+   gh pr view <N> --json commits --jq '.commits[-1] | "\(.oid[:7]) \(.messageHeadline)"'
+   ```
+   Only then is the task done.
+
+8. **Do not scope-creep.** Keep the fix-up commit narrowly focused on
+   what the reviewer asked for. Unrelated cleanups, doc tweaks, or
+   personal-notes files (like edits to this CLAUDE.md) do not belong
+   on the PR branch — stash them or commit them separately on another
+   branch.


### PR DESCRIPTION
## Summary
- Relocates the repo's Claude Code project instructions from `CLAUDE.md` (root) to `agents/dev/CLAUDE.md` so agent-facing docs sit under a dedicated `agents/` tree.
- Adds new sections to the playbook: **Commit message style** (single-line subjects, no body, no `Co-Authored-By`), **Pushing PR fix-up commits** (push to the PR's head branch before reporting done), and **Reviewing PR comments and addressing fixes** (8-step workflow — check both `/pulls/N/comments` and `/issues/N/comments`, checkout `headRefName`, verify reviewer claims, run the PR's test plan, commit in repo style, push, confirm, stay scoped).

## Test plan
- [x] `git log --oneline` on this branch shows a single-line commit matching repo style
- [ ] Reviewer confirms `agents/dev/` is the intended location for agent-facing docs (move is reversible if not)