### PR TITLE
docs: add mkdocs-material site at kukeon.io

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -1,0 +1,60 @@
+name: Deploy Docs
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/site/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/mkdocs.yaml'
+  workflow_dispatch:
+
+jobs:
+  build_mkdocs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: ~/.cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install mkdocs-material
+      - run: pip install mkdocs-git-revision-date-localized-plugin
+      - run: mkdocs gh-deploy --force
+  deploy_mkdocs:
+    needs: build_mkdocs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "."
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🌪️ kukeon: A Lightweight Container Orchestrator
+# 🌪️ kukeon: A Lightweight Container Orchestrator for structured, isolated, local-first container environments
 
 ![status: active](https://img.shields.io/badge/status-active-blue)
 ![state: alpha](https://img.shields.io/badge/state-alpha-orange)
@@ -6,13 +6,9 @@
 
 _Structured container environments on a single machine._
 
-Kukeon is a local-first, containerd-native orchestrator that sits between Docker and Kubernetes.
-It provides structure, networking, isolation, and lifecycle management for containers without the complexity of running a full cluster.
+Kukeon is a local-first, containerd-native orchestrator that sits between Docker and Kubernetes. It provides structure, networking, isolation, and lifecycle management for containers without the complexity of running a full cluster. At its core is `kukeond`, a small daemon that manages containerd, CNI networks, namespaces, and cgroups, and exposes a simple API. The `kuke` CLI and the future Web UI act as thin clients.
 
 **Note:** This project is under active development and not production ready.
-
-At its core is `kukeond`, a small daemon that manages containerd, CNI networks, namespaces, and cgroups, and exposes a simple API.
-The `kuke` CLI and the future Web UI act as thin clients.
 
 ## Quick Start
 
@@ -40,48 +36,58 @@ sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
 
 ### Initialize the runtime
 
-`kuke init` provisions the default hierarchy (realm `main`, space `default`, stack `default`), sets up CNI dirs, pulls the `kukeond` image, and starts the daemon. It touches `/opt/kukeon`, cgroups, and containerd, so it needs root:
+`kuke init` provisions the default hierarchy (realm `default`, space `default`, stack `default`), sets up CNI dirs, pulls the `kukeond` image, and starts the daemon. It touches `/opt/kukeon`, cgroups, and containerd, so it needs root:
 
 ```bash
 $ sudo kuke init
 Initialized Kukeon runtime
-Realm: main (namespace: kukeon-main)
+Realm: default (namespace: kukeon-default)
 System realm: kukeon-system (namespace: kukeon-system)
 Run path: /opt/kukeon
 Kukeond image: ghcr.io/eminwux/kukeon:v0.1.0
-Actions:
-    - kukeon root cgroup: created
-  - CNI config dir "/etc/cni/net.d": created
-  - CNI bin dir "/opt/cni/bin": already existed
-  Default hierarchy:
-    - realm "main": created
-    - containerd namespace "kukeon-main": created
-    - space "default": created
-    - network "default": created
-    - stack "default": created
-  System hierarchy:
-    - realm "kukeon-system": created
-    - cell "kukeond": created (image ghcr.io/eminwux/kukeon:v0.1.0)
+...
 kukeond is ready (unix:///opt/kukeon/run/kukeond.sock)
 ```
 
-### Verify with `kuke get`
+### Autocomplete
 
-List the realms, spaces, and stacks that `kuke init` just created:
+```bash
+cat >> ~/.bashrc <<EOF
+source <(kuke autocomplete bash)
+EOF
+```
+
+`kuke autocomplete zsh` and `kuke autocomplete fish` are also supported.
+
+## Documentation
+
+Complete documentation is available at [https://kukeon.io](https://kukeon.io), including concepts, architecture, CLI reference, manifest reference, guides, and tutorials.
+
+## Why kukeon
+
+Docker is simple but unstructured — everything lives in a flat list. Kubernetes is structured but heavy — you pay for a control plane whether you need one or not. Kukeon aims for the middle:
+
+- Reproducible: declarative YAML manifests describe every resource
+- Structured: Realm → Space → Stack → Cell → Container makes intent explicit
+- Isolated: each layer is a real Linux primitive (containerd namespace, CNI network, cgroup subtree)
+- Local-first: no cluster, no etcd, no scheduler
+- Transparent: inspect what the daemon did with `ctr`, `ip link`, `ls /sys/fs/cgroup`
+
+## Usage Examples
+
+Common workflows for working with realms, spaces, stacks, and cells.
+
+### List the default hierarchy
 
 ```bash
 $ sudo kuke get realms
-NAME           NAMESPACE       STATE    CGROUP
-main           kukeon-main     Running  /kukeon/main
-kukeon-system  kukeon-system   Running  /kukeon/kukeon-system
+NAME           NAMESPACE         STATE    CGROUP
+default        kukeon-default    Running  /kukeon/default
+kukeon-system  kukeon-system     Running  /kukeon/kukeon-system
 
-$ sudo kuke get spaces --realm main
-NAME     REALM  STATE    CGROUP
-default  main   Running  /kukeon/main/default
-
-$ sudo kuke get stacks --realm main --space default
-NAME     REALM  SPACE    STATE    CGROUP
-default  main   default  Running  /kukeon/main/default/default
+$ sudo kuke get spaces
+NAME     REALM    STATE    CGROUP
+default  default  Running  /kukeon/default/default
 ```
 
 Add `-o yaml` or `-o json` for full resource details.
@@ -114,7 +120,6 @@ spec:
             <head><meta charset="utf-8"><title>kukeon hello-world</title></head>
             <body style="font-family: sans-serif">
               <h1>Hello, world from kukeon!</h1>
-              <p>Served by busybox httpd inside a cell in the <code>default</code> realm.</p>
             </body>
           </html>
           HTML
@@ -184,20 +189,127 @@ sudo kuke delete cell kukeond \
 sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
 ```
 
-### Autocomplete
+→ See [docs/site/guides/local-dev.md](docs/site/guides/local-dev.md) for the full dev loop.
 
-```bash
-cat >> ~/.bashrc <<EOF
-source <(kuke autocomplete bash)
-EOF
+## Core Concepts
+
+Kukeon defines a clear hierarchical model:
+
+```mermaid
+flowchart LR
+    Realm --> Space --> Stack --> Cell --> Container
 ```
 
-`kuke autocomplete zsh` and `kuke autocomplete fish` are also supported.
+- **Realm**: High-level environment mapped to a containerd namespace
+- **Space**: CNI network and cgroup subtree that define isolation
+- **Stack**: Logical grouping of related cells
+- **Cell**: A pod-like group. One root container owns the network namespace
+- **Container**: An OCI container running inside the cell
+
+Each layer is a real Linux primitive, not an invented abstraction. This structure avoids Docker's ambiguity and Kubernetes-level complexity.
+
+→ See [docs/site/concepts/overview.md](docs/site/concepts/overview.md) for the full concept guide.
+
+## Understanding kukeon Commands
+
+Two commands, one binary: kukeon uses hard links to provide different behaviors.
+
+| Command     | Purpose                                          | Run by                |
+| ----------- | ------------------------------------------------ | --------------------- |
+| `kuke`      | Client CLI — talks to the daemon                 | Users                 |
+| `kukeond`   | The daemon process itself                        | Process supervisor    |
+
+Both are the same binary; behavior is determined by the executable name at runtime.
+
+### `kuke` — the client
+
+Manages realms, spaces, stacks, cells, and containers through the daemon:
+
+```bash
+$ sudo kuke get realms          # List realms
+$ sudo kuke get cells --realm main --space default --stack default
+$ sudo kuke apply -f cell.yaml  # Apply a manifest
+$ sudo kuke delete cell mycell --realm ... --cascade
+```
+
+Everything `kuke` does goes through the daemon by default. Pass `--no-daemon` to run the operation in-process (requires root).
+
+### `kukeond` — the daemon
+
+Runs as the root container of the `kukeond` cell inside the dedicated `kukeon-system` realm. You don't normally run `kukeond` by hand; `kuke init` sets it up as a managed cell.
+
+→ See [docs/site/cli/commands.md](docs/site/cli/commands.md) for the complete CLI reference.
+
+## Components
+
+### kukeond
+
+A lightweight daemon responsible for:
+
+- containerd operations
+- creating network namespaces
+- running CNI plugins
+- managing cgroups
+- handling metadata and state
+- serving the API used by clients
+
+### kuke (CLI)
+
+A thin remote client that interacts with `kukeond`.
+
+### Web UI (future)
+
+A browser interface backed by the same API.
+
+## Dependencies
+
+- containerd
+- CNI plugins
+- Linux with cgroups v2
+
+## How It Works
+
+Kukeon sits between containerd and the user, translating declarative YAML into the right Linux primitives.
+
+1. A manifest defines a resource: YAML specifies realm, space, stack, cell, or container
+2. `kuke apply` sends the manifest to `kukeond` over a unix socket
+3. `kukeond` reconciles: creates containerd namespace, cgroup subtree, CNI network, containers
+4. State is persisted to `/opt/kukeon` for durability across daemon restarts
+5. `kuke get` and `kuke refresh` read live state back from containerd/CNI/cgroups
+
+## A Tool for Operators, Homelabbers, and Systems Engineers
+
+For people who want structured container environments on one machine.
+
+- Homelab and VPS users who want structured container environments
+- Systems engineers who prefer containerd over Docker
+- Developers who find Docker too simple and Kubernetes too complex
+- Operators who want clear isolation using namespaces, CNI, and cgroups
+
+## How kukeon Differs from Docker and Kubernetes
+
+Kukeon is designed for single-machine orchestration with real Linux isolation primitives. Key differences: an explicit Realm → Space → Stack → Cell → Container hierarchy (not a flat list), one CNI network per space (not one big network or ad-hoc bridges), one cgroup subtree per layer (not scattered), and no control plane (containerd, CNI, and cgroups are the only moving parts).
+
+Unlike Kubernetes, kukeon is not distributed. There is no scheduler, no etcd, no API server on port 6443 — just one daemon per host.
+
+Unlike Docker, kukeon does not treat containers as a flat set. Every container belongs to exactly one cell → stack → space → realm path.
+
+You can think of it as:
+
+> Proxmox for containers
+>
+> or
+>
+> A small Heroku that runs locally
+
+## Why kukeon Exists
+
+Running non-trivial container workloads on a single machine is awkward today. Docker is simple but leaves you to invent your own tenancy and network structure. Kubernetes has the structure but demands a cluster. Kukeon takes the structure — namespaces, networks, cgroups, a hierarchy of cells — and drops the cluster. The result is a single daemon that makes one machine feel organized without making it feel distributed.
 
 ## Philosophy
 
 «καὶ ὁ κυκεὼν διίσταται μὴ κινούμενος»
-“The barley-drink separates if it isn't stirred”
+"The barley-drink separates if it isn't stirred"
 
 Fragment DK 22B125
 Heraclitus, circa 500 BC
@@ -225,19 +337,6 @@ Kukeon aims to be:
 - safe and isolated using namespaces, CNI, and cgroups
 - easy to understand and reason about
 
-You can think of it as:
-
-Proxmox for containers
-or
-A small Heroku that runs locally
-
-### Target Users
-
-- Homelab and VPS users who want structured container environments
-- Systems engineers who prefer containerd over Docker
-- Developers who find Docker too simple and Kubernetes too complex
-- Operators who want clear isolation using namespaces, CNI, and cgroups
-
 ### Non-Goals
 
 - Being a full replacement for Kubernetes in large multi-node clusters
@@ -245,65 +344,11 @@ A small Heroku that runs locally
 - Reimplementing every Kubernetes feature or API
 - Hiding low-level primitives behind opaque abstractions
 
-## Core Concepts
+## Status and Roadmap
 
-Kukeon defines a clear hierarchical model:
+Kukeon is under active development, with a focus on correctness, clear abstractions, and stable primitives before adding integrations.
 
-```mermaid
-flowchart LR
-    Realm --> Space --> Stack --> Cell --> Container
-```
-
-- **Realm**: High-level environment mapped to a containerd namespace.
-- **Space**: CNI network and cgroup subtree that define isolation.
-- **Stack**: Logical grouping of related cells.
-- **Cell**: A pod-like group. One root container owns the network namespace.
-- **Container**: An OCI container running inside the cell.
-
-This structure avoids Docker’s ambiguity and Kubernetes-level complexity.
-
-## 🛠️ Components
-
-### kukeond
-
-A lightweight daemon responsible for:
-
-- containerd operations
-- creating network namespaces
-- running CNI plugins
-- managing cgroups
-- handling metadata and state
-- serving the API used by clients
-
-### kuke (CLI)
-
-A thin remote client that interacts with `kukeond`.
-
-### Web UI (future)
-
-A browser interface backed by the same API.
-
-## 🔌 Dependencies
-
-- containerd
-- CNI plugins
-- Linux with cgroups v2
-
-## Project Status
-
-- Active development
-- Interfaces and APIs may change
-- Not production ready
-
-Contributions, issues, and feedback are welcome.
-
-## Roadmap
-
-- Stabilize core model and API
-- Improve CLI ergonomics and UX
-- Solidify CNI integration and defaults
-- Add a minimal Web UI (read-only at first)
-- Expand documentation and examples
+→ See [ROADMAP.md](./ROADMAP.md) for work in progress and planned features.
 
 ## Contribute
 

--- a/docs/site/CNAME
+++ b/docs/site/CNAME
@@ -1,0 +1,1 @@
+kukeon.io

--- a/docs/site/architecture/api-versioning.md
+++ b/docs/site/architecture/api-versioning.md
@@ -1,0 +1,80 @@
+# API versioning
+
+Kukeon separates the on-wire API schema from its internal types. This is the pattern that lets the API evolve without every change rippling through every controller.
+
+## The layers
+
+```mermaid
+flowchart TB
+    yaml["YAML manifest<br/>apiVersion: v1beta1"]
+    external["pkg/api/model/v1beta1<br/>(versioned external types)"]
+    apischeme["internal/apischeme<br/>(version translation)"]
+    modelhub["internal/modelhub<br/>(version-agnostic internal types)"]
+    controller["internal/controller<br/>(reconciler)"]
+
+    yaml --> external
+    external --> apischeme
+    apischeme --> modelhub
+    modelhub --> controller
+```
+
+## pkg/api/model/v1beta1 — the external types
+
+Everything a manifest can say lives here:
+
+```
+pkg/api/model/v1beta1/
+├── api.go         (Version, Kind)
+├── consts.go      (APIVersionV1Beta1, KindRealm, ...)
+├── realm.go       (RealmDoc, RealmSpec, ...)
+├── space.go       (SpaceDoc, SpaceSpec, ...)
+├── stack.go       (StackDoc, ...)
+├── cell.go        (CellDoc, CellSpec, ContainerSpec, ...)
+├── container.go   (ContainerDoc, ContainerSpec, ...)
+└── network.go     (Network types)
+```
+
+Fields, tag names, and JSON/YAML layout here are **the public contract**. Renames or removals are breaking changes. New versions get their own sibling package (`pkg/api/model/v1/...`, `pkg/api/model/v1beta2/...`, etc.) rather than mutating the current one.
+
+## internal/modelhub — the internal types
+
+`modelhub` mirrors the same resources without a version tag:
+
+```go
+type Realm struct {
+    Metadata RealmMetadata
+    Spec     RealmSpec
+    Status   RealmStatus
+}
+```
+
+These are what the controller and utility code operate on. They don't carry `apiVersion`. They can evolve freely with the controller — no external contract to preserve.
+
+## internal/apischeme — the translation layer
+
+`apischeme` is the only `internal/` package allowed to import `pkg/api/model/*`. It exposes three functions per resource:
+
+- `Convert<Resource>DocToInternal(ext) → (internal, error)` — external → internal.
+- `Build<Resource>ExternalFromInternal(internal, version) → (external, error)` — internal → external for a given API version.
+- `Normalize<Resource>(ext) → (internal, version, error)` — external → internal with version defaulting (empty `apiVersion` means "latest supported").
+
+Every request crosses `apischeme` on the way in, and every response crosses it on the way out. Controllers never see `v1beta1.RealmDoc`.
+
+## Why this indirection?
+
+- **Multiple API versions coexist cheaply.** When `v1` ships, `apischeme` gains a new switch arm; the controller is unchanged.
+- **Field renames don't ripple.** `SpaceSpec.RealmID` (external) and `SpaceSpec.RealmName` (internal) can drift; `apischeme` reconciles them.
+- **Storage can be version-aware independently.** Today we serialize the internal form; if we need to persist the external form for diff-ability, that's a `apischeme` change, not a controller change.
+
+## Unsupported versions
+
+Manifests with an `apiVersion` that Kukeon doesn't know about fail loudly at `Normalize*`. There is no silent upgrade or "closest match" behavior — a request is either in a supported version or it is rejected.
+
+## Today: one supported version
+
+`v1beta1` is the only version currently in the tree. `v1` is planned once the resource model stabilizes. Both will live side by side when that happens; nothing about `v1beta1` will be removed without a deprecation window.
+
+## Read next
+
+- [Manifest Reference](../manifests/overview.md) — the `v1beta1` schema in detail
+- [Overview](overview.md) — where apischeme sits in the request path

--- a/docs/site/architecture/overview.md
+++ b/docs/site/architecture/overview.md
@@ -1,0 +1,96 @@
+# Architecture overview
+
+Kukeon is three pieces of code running against three external systems.
+
+```mermaid
+flowchart TB
+    subgraph binary[" kukeon binary (argv[0] dispatch) "]
+        kuke["kuke<br/>(client CLI)"]
+        kukeond["kukeond<br/>(daemon)"]
+    end
+
+    kuke -->|unix socket<br/>kukeonv1 API| kukeond
+    kuke -.->|--no-daemon<br/>in-process| externals
+
+    kukeond --> externals
+
+    subgraph externals[" external systems "]
+        containerd[("containerd")]
+        cni[("CNI plugins")]
+        cgroups[("cgroup v2")]
+    end
+```
+
+## The two binaries, one file
+
+Both `kuke` and `kukeond` are the same compiled binary. `cmd/main.go` inspects `filepath.Base(os.Args[0])` at process start and calls into `cmd/kuke` or `cmd/kukeond` depending on what it finds. Installing Kukeon creates a hard link so the single binary responds to both names. See [Process Model](process-model.md).
+
+## kuke (client)
+
+A thin cobra CLI. It:
+
+- parses flags and manifests;
+- opens a connection to `kukeond` over `/run/kukeon/kukeond.sock`;
+- sends `kukeonv1` API requests;
+- formats the response as a table, YAML, or JSON.
+
+The only time `kuke` does real work itself is when `--no-daemon` is passed — then it runs the same controller code that `kukeond` would.
+
+## kukeond (daemon)
+
+A single long-lived process that serves the `kukeonv1` API on a unix socket. It holds three managers:
+
+- **containerd client** — creates namespaces, pulls images, runs containers;
+- **CNI manager** — generates conflists, invokes the bridge/host-local plugins, tears down networks;
+- **cgroup manager** — creates the `/sys/fs/cgroup/kukeon/...` tree, mounts containers into it.
+
+When a client calls `CreateCell`, the daemon orchestrates all three: create the cgroup, set up the network namespace via CNI, then tell containerd to launch containers into it.
+
+## The controller / reconciler
+
+Both the daemon and `--no-daemon` share the same controller (`internal/controller`). The controller is the single place where "desired state → actual state" logic lives:
+
+```
+apply/refresh request
+       ↓
+internal/apply        (parse YAML, normalize)
+       ↓
+internal/apischeme    (version-agnostic conversion)
+       ↓
+internal/modelhub     (internal representation)
+       ↓
+internal/controller   (reconcile)
+       ↓              ↘
+containerd           CNI, cgroups, metadata
+```
+
+`apischeme` is the version-translation layer; it converts external YAML (`v1beta1`) into internal types, then converts internal types back out for API responses. This is what lets the API surface evolve without rewriting controller code — see [API versioning](api-versioning.md).
+
+## Storage
+
+Kukeon keeps its own authoritative state on disk, under `/opt/kukeon` by default. The layout mirrors the hierarchy:
+
+```
+/opt/kukeon/
+├── <realm>/
+│   ├── realm.yaml
+│   └── <space>/
+│       ├── space.yaml
+│       ├── network.conflist
+│       └── <stack>/
+│           ├── stack.yaml
+│           └── <cell>/
+│               ├── cell.yaml
+│               └── containers/
+│                   └── <container>.yaml
+└── run/
+    └── kukeond.sock
+```
+
+See [Storage layout](storage-layout.md) for details.
+
+## Read next
+
+- [Process model](process-model.md) — argv[0] dispatch, signals, exit codes
+- [API versioning](api-versioning.md) — how `v1beta1` and future versions coexist
+- [Storage layout](storage-layout.md) — every path Kukeon writes to

--- a/docs/site/architecture/process-model.md
+++ b/docs/site/architecture/process-model.md
@@ -1,0 +1,65 @@
+# Process model
+
+Kukeon ships a single binary. Both `kuke` and `kukeond` are the same compiled file, dispatched by name at process start.
+
+## argv[0] dispatch
+
+From `cmd/main.go`:
+
+```go
+exe := filepath.Base(os.Args[0])
+switch exe {
+case "kuke":    runKuke()
+case "kukeond": runKukeond()
+default:
+    // Optional fallback
+    debug := os.Getenv("KUKEON_DEBUG_MODE")
+    if debug == "kuke" || debug == "kukeond" { ... }
+    fmt.Fprintf(os.Stderr, "unknown entry command: %s\n", exe)
+    os.Exit(1)
+}
+```
+
+- If you call `kuke`, you get the client CLI.
+- If you call `kukeond`, you get the daemon.
+- If you call the binary by any other name (for example from an IDE or debugger where the executable is named something like `__debug_bin12345`), it errors out unless `KUKEON_DEBUG_MODE=kuke` or `KUKEON_DEBUG_MODE=kukeond` is set.
+
+**There is no `kuke kukeond` subcommand.** Running `kuke kukeond …` is an error; the dispatch happens before cobra sees any arguments.
+
+## Why not two binaries?
+
+- The CLI and the daemon share most of their code (the controller, the apischeme conversion, the error types). Shipping one binary means shipping half the bytes and testing one build.
+- Installers only need to copy one file; the hard link is a one-liner.
+- The CLI can fall back to "be the daemon for one command" (`--no-daemon`) without duplicating any logic.
+
+## The daemon process
+
+`kukeond` is a standard long-lived Go program. It:
+
+1. Parses flags (`--run-path`, `--containerd-socket`, `--socket`, `--log-level`).
+2. Writes a pid file at `<run-path>/kukeond.pid`.
+3. Opens the unix socket at `--socket` (default `/run/kukeon/kukeond.sock`).
+4. Starts serving the `kukeonv1` API.
+5. On SIGINT/SIGTERM: closes the listener, drains in-flight requests, removes the pid file, exits.
+
+The daemon does **not** fork or daemonize itself. When you run `kuke init`, the daemon is started inside a containerd-managed container (as the root container of the `kukeond` cell in the system realm), not by `kuke` forking a background process. See [System realm](../concepts/system-realm.md).
+
+## The client process
+
+Every `kuke` invocation is a short-lived process:
+
+1. Parse flags, load config.
+2. If `--no-daemon`, run the operation in-process.
+3. Otherwise, dial the daemon socket, send one `kukeonv1` request, print the response, exit.
+
+Clients do not hold persistent connections. Each command opens a new socket, sends, receives, closes. There's no keepalive or session state.
+
+## Signals
+
+- **`kukeond`** — SIGINT and SIGTERM trigger a clean shutdown. SIGKILL skips shutdown (and leaves the pid file behind; clean it up by hand).
+- **`kuke`** — SIGINT cancels the current request. The client sends a cancellation through the RPC; the daemon aborts the operation on a best-effort basis.
+
+## Exit codes
+
+- `0` — success.
+- `1` — any failure. Kukeon does not currently differentiate exit codes beyond that; see the structured error log for details.

--- a/docs/site/architecture/storage-layout.md
+++ b/docs/site/architecture/storage-layout.md
@@ -1,0 +1,105 @@
+# Storage layout
+
+Kukeon keeps its own authoritative state on disk, rooted at a single **run path** (default `/opt/kukeon`, configurable via `--run-path`). The layout mirrors the resource hierarchy.
+
+## The run path
+
+```
+/opt/kukeon/
+├── <realm>/
+│   ├── realm.yaml                              (Realm manifest + status)
+│   └── <space>/
+│       ├── space.yaml                          (Space manifest + status)
+│       ├── network.conflist                    (space CNI conflist cache)
+│       └── <stack>/
+│           ├── stack.yaml                      (Stack manifest + status)
+│           └── <cell>/
+│               ├── cell.yaml                   (Cell manifest + status)
+│               └── containers/
+│                   └── <container>.yaml        (Container manifest + status)
+├── kukeon-system/                              (system realm; structure identical to above)
+│   └── kukeon/
+│       └── kukeon/
+│           └── kukeond/
+│               ├── cell.yaml
+│               └── containers/
+│                   └── kukeond.yaml
+└── run/
+    └── (reserved)
+```
+
+Every file is YAML. The combined doc (spec + status) is what the controller reconciles against containerd, CNI, and cgroups.
+
+## The socket path
+
+The daemon socket and pid file default to `/run/kukeon`, **separate from the run path**:
+
+```
+/run/kukeon/
+├── kukeond.sock        (daemon API socket)
+└── kukeond.pid         (daemon pid file)
+```
+
+This is because `/opt/kukeon` is expected to be persistent (survives reboot), while `/run` is tmpfs on most distros (cleared on reboot). Sockets and pid files belong in `/run`.
+
+Both `kuke` and `kukeond` default `--run-path` to `/opt/kukeon` — they share the same state tree. Sockets and pid files are a separate concern controlled by `--socket`, which points into `/run/kukeon` by default.
+
+## CNI conflists
+
+Each space writes a conflist into the system CNI config directory:
+
+```
+/etc/cni/net.d/
+├── main-default.conflist
+├── main-monitoring.conflist
+└── ...
+```
+
+The path is `<realm>-<space>.conflist` by default. It can be overridden with `spec.cniConfigPath` on the space manifest.
+
+Kukeon keeps a **copy** of the active conflist under `/opt/kukeon/<realm>/<space>/network.conflist` so the state is self-contained per realm. The authoritative one for CNI plugin invocation is still the file in `/etc/cni/net.d`.
+
+## cgroup tree
+
+Kukeon roots its cgroup tree at `/sys/fs/cgroup/kukeon`:
+
+```
+/sys/fs/cgroup/kukeon/
+├── <realm>/
+│   └── <space>/
+│       └── <stack>/
+│           └── <cell>/
+│               ├── <cell>_root/    (root container)
+│               └── <container>/    (non-root containers)
+└── kukeon-system/
+    └── ...
+```
+
+See [cgroups](../concepts/cgroups.md) for inspection tips.
+
+## containerd state
+
+Kukeon does **not** mirror containerd state into its own layout. Images, snapshots, and running tasks live entirely inside containerd, scoped by namespace:
+
+```
+/var/lib/containerd/         (containerd's own layout; not Kukeon's business)
+```
+
+If you want to inspect what Kukeon pushed into containerd, use `ctr -n kukeon-<realm>` — see [containerd namespaces](../concepts/containerd-namespaces.md).
+
+## What gets cleaned up, and when
+
+| Operation                       | Removes                                                                 |
+|---------------------------------|-------------------------------------------------------------------------|
+| `kuke delete realm --cascade`   | The realm subtree under the run path, cgroups, CNI conflists           |
+| `kuke delete space --cascade`   | The space subtree, cgroups, CNI conflist                                |
+| `kuke delete cell --cascade`    | The cell subtree, cgroups, containerd containers                        |
+| `kuke purge <resource>`         | Same as delete but more aggressive: force-removes residual state        |
+| Reboot                          | `/run/kukeon/*` disappears (tmpfs). `/opt/kukeon/*` persists.           |
+
+`--no-daemon` versions of the same commands do exactly the same thing on disk — they just run in-process instead of going through the socket.
+
+## Read next
+
+- [Process model](process-model.md) — how the daemon and client processes live
+- [System realm](../concepts/system-realm.md) — what lives under `kukeon-system/`

--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -1,0 +1,64 @@
+# CLI commands overview
+
+Kukeon ships a single binary that behaves as one of two commands depending on the executable name.
+
+| Command   | Purpose                                   | Used by                |
+|-----------|-------------------------------------------|------------------------|
+| `kuke`    | Client CLI (talks to the daemon)          | Users                  |
+| `kukeond` | The daemon process itself                 | Process supervisor     |
+
+Both are hard-linked to the same binary on install. Running `kuke` enters the client tree; running `kukeond` enters the daemon tree. See [Architecture → Process Model](../architecture/process-model.md).
+
+## kuke subcommands
+
+| Command                   | What it does                                                      |
+|---------------------------|-------------------------------------------------------------------|
+| `kuke init`               | Bootstrap or reconcile a host                                     |
+| `kuke apply`              | Apply resource definitions from YAML (multi-document supported)   |
+| `kuke get`                | List or describe resources (realm, space, stack, cell, container) |
+| `kuke create`             | Create a single resource imperatively                             |
+| `kuke delete`             | Delete a resource                                                 |
+| `kuke start` / `stop` / `kill` | Lifecycle operations on cells and containers                 |
+| `kuke purge`              | Delete with aggressive cleanup of residual state                  |
+| `kuke refresh`            | Reconcile `.status` from live state without touching `.spec`      |
+| `kuke autocomplete`       | Emit a shell completion script                                    |
+| `kuke version`            | Print the version                                                 |
+
+## Global flags
+
+Every `kuke` subcommand inherits these persistent flags from the root command:
+
+| Flag                    | Default                              | What it does                                               |
+|-------------------------|--------------------------------------|------------------------------------------------------------|
+| `--run-path`            | `/opt/kukeon`                        | Where Kukeon stores realm/space/stack/cell state           |
+| `--config`              | `/etc/kukeon/config.yaml`            | Config file path                                           |
+| `--containerd-socket`   | `/run/containerd/containerd.sock`    | Containerd socket                                          |
+| `--host`                | `unix:///run/kukeon/kukeond.sock`    | Daemon endpoint (unix:// or ssh://)                        |
+| `--no-daemon`           | `false`                              | Bypass the daemon and run in-process (requires root)       |
+| `--verbose`, `-v`       | `false`                              | Enable verbose logging on stderr                           |
+| `--log-level`           | `info`                               | Log level (`debug`, `info`, `warn`, `error`)               |
+
+## Convention: positional arg + flags
+
+Resource commands follow a uniform shape:
+
+```
+kuke <verb> <resource> [NAME] --realm <r> --space <s> --stack <t> --cell <c> [flags]
+```
+
+The positional argument is the resource's own name; the flags specify where in the hierarchy it lives. Defaults for `--realm`, `--space`, `--stack` are all `default`.
+
+## Full reference
+
+- [kuke (root)](kuke.md)
+- [kuke init](kuke-init.md)
+- [kuke get](kuke-get.md)
+- [kuke create](kuke-create.md)
+- [kuke apply](kuke-apply.md)
+- [kuke delete](kuke-delete.md)
+- [kuke start / stop / kill](kuke-lifecycle.md)
+- [kuke purge](kuke-purge.md)
+- [kuke refresh](kuke-refresh.md)
+- [kuke autocomplete](kuke-autocomplete.md)
+- [kuke version](kuke-version.md)
+- [kukeond](kukeond.md)

--- a/docs/site/cli/kuke-apply.md
+++ b/docs/site/cli/kuke-apply.md
@@ -1,0 +1,97 @@
+# kuke apply
+
+Apply one or more resource definitions from a YAML file (or stdin). Kukeon reconciles the host to match the manifest.
+
+```
+kuke apply -f <file> [-o json|yaml]
+```
+
+## Flags
+
+| Flag                | Default | Description                                                     |
+|---------------------|---------|-----------------------------------------------------------------|
+| `--file`, `-f`      | _(required)_ | Path to a YAML file, or `-` for stdin                      |
+| `--output`, `-o`    | _(empty)_    | Output format: `json`, `yaml`. Default: human-readable.    |
+
+Plus all [global flags](kuke.md).
+
+## Input
+
+- **Single document**: one resource.
+- **Multi-document**: any number of resources separated by `---`. Kukeon applies them in dependency order (realm → space → stack → cell → container), regardless of the order in the file.
+- **Stdin**: `-f -` reads the manifest from stdin, so piping works:
+
+  ```bash
+  cat cell.yaml | sudo kuke apply -f -
+  ```
+
+## Per-resource outcome
+
+For each resource in the manifest, `apply` emits one of:
+
+- `created` — resource didn't exist; created.
+- `updated` — resource existed with a different spec; reconciled. The printed diff follows.
+- `unchanged` — resource already matches; nothing to do.
+- `failed` — reconciliation failed; the error is printed. Other resources continue. The command exits non-zero overall.
+
+Example:
+
+```bash
+$ sudo kuke apply -f stack.yaml
+Space "blog": created
+Stack "wordpress": created
+Cell "wp": created
+```
+
+## Idempotence
+
+Applying the same manifest twice is safe. The second run should report `unchanged` for every resource.
+
+## Exit codes
+
+- `0` — every resource succeeded.
+- non-zero — at least one resource failed. Other resources may have succeeded; check the output.
+
+## Examples
+
+```bash
+# Single file
+sudo kuke apply -f cell.yaml
+
+# Multi-doc inline
+cat <<'EOF' | sudo kuke apply -f -
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: blog
+spec:
+  realmId: main
+---
+apiVersion: v1beta1
+kind: Stack
+metadata:
+  name: wordpress
+spec:
+  id: wordpress
+  realmId: main
+  spaceId: blog
+EOF
+
+# JSON output for scripting
+sudo kuke apply -f cell.yaml -o json
+```
+
+## The `--no-daemon` caveat
+
+Today, cell creation has to run with `--no-daemon` because the released daemon image doesn't bind-mount the containerd socket. Until that ships, use:
+
+```bash
+sudo kuke apply -f cell.yaml --no-daemon
+```
+
+See [Client and daemon](../concepts/client-and-daemon.md).
+
+## Related
+
+- [Applying manifests](../guides/apply-manifests.md) — the longer guide
+- [Manifest Reference](../manifests/overview.md) — every field explained

--- a/docs/site/cli/kuke-autocomplete.md
+++ b/docs/site/cli/kuke-autocomplete.md
@@ -1,0 +1,49 @@
+# kuke autocomplete
+
+Emit a shell completion script.
+
+```
+kuke autocomplete bash
+kuke autocomplete zsh
+kuke autocomplete fish
+```
+
+Each subcommand writes the completion script to stdout. Pipe it into `source` (for the current shell) or a completions file (to install permanently).
+
+## bash
+
+```bash
+# Current shell only
+source <(kuke autocomplete bash)
+
+# Persistent
+cat >> ~/.bashrc <<'EOF'
+source <(kuke autocomplete bash)
+EOF
+```
+
+## zsh
+
+```bash
+# Current shell only
+source <(kuke autocomplete zsh)
+
+# Persistent
+cat >> ~/.zshrc <<'EOF'
+source <(kuke autocomplete zsh)
+EOF
+```
+
+## fish
+
+```bash
+# Current shell only
+kuke autocomplete fish | source
+
+# Persistent
+kuke autocomplete fish > ~/.config/fish/completions/kuke.fish
+```
+
+## What gets completed
+
+See [Guides → Autocomplete](../guides/autocomplete.md) for the full list (subcommands, resource names via live lookups, `--realm`/`--space`/`--stack`/`--cell` flag values).

--- a/docs/site/cli/kuke-create.md
+++ b/docs/site/cli/kuke-create.md
@@ -1,0 +1,119 @@
+# kuke create
+
+Imperative creation of a single resource. For anything more than a one-off, prefer [`kuke apply`](kuke-apply.md) against a manifest.
+
+```
+kuke create <resource> [NAME] [flags]
+kuke c      <resource> [NAME] [flags]      # alias
+```
+
+Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also has a short alias (`r`, `sp`, `st`, `ce`, `co`).
+
+## kuke create realm
+
+```
+kuke create realm [NAME] [--namespace <ns>]
+```
+
+| Flag            | Default        | Description                                                 |
+|-----------------|----------------|-------------------------------------------------------------|
+| `--namespace`   | (realm name)   | Containerd namespace for the realm                          |
+
+```bash
+sudo kuke create realm mytenant
+sudo kuke create realm mytenant --namespace kukeon-mytenant
+```
+
+## kuke create space
+
+```
+kuke create space [NAME] --realm <realm>
+```
+
+| Flag        | Default    | Description                              |
+|-------------|------------|------------------------------------------|
+| `--realm`   | `default`  | Realm that will own the space            |
+
+```bash
+sudo kuke create space blog --realm main
+```
+
+## kuke create stack
+
+```
+kuke create stack [NAME] --realm <realm> --space <space>
+```
+
+| Flag        | Default    | Description                              |
+|-------------|------------|------------------------------------------|
+| `--realm`   | `default`  | Realm that owns the stack                |
+| `--space`   | `default`  | Space that owns the stack                |
+
+```bash
+sudo kuke create stack wordpress --realm main --space blog
+```
+
+## kuke create cell
+
+```
+kuke create cell [NAME] --realm <r> --space <s> --stack <t>
+```
+
+| Flag        | Default    | Description                              |
+|-------------|------------|------------------------------------------|
+| `--realm`   | `default`  | Realm that owns the cell                 |
+| `--space`   | `default`  | Space that owns the cell                 |
+| `--stack`   | `default`  | Stack that owns the cell                 |
+
+`create cell` creates an empty cell (no containers). Use [`kuke apply`](kuke-apply.md) with a manifest to create a cell with its containers in one step.
+
+```bash
+sudo kuke create cell web --realm main --space blog --stack wordpress
+```
+
+## kuke create container
+
+Adds a container to an existing cell.
+
+```
+kuke create container [NAME] --cell <cell> [--realm <r> --space <s> --stack <t>] [container flags]
+```
+
+| Flag                 | Default                               | Description                                                 |
+|----------------------|---------------------------------------|-------------------------------------------------------------|
+| `--realm`            | `default`                             | Realm of the parent cell                                    |
+| `--space`            | `default`                             | Space of the parent cell                                    |
+| `--stack`            | `default`                             | Stack of the parent cell                                    |
+| `--cell`             | _(required)_                          | Cell that owns the container                                |
+| `--image`            | `docker.io/library/debian:latest`     | Container image                                             |
+| `--command`          | (empty)                               | Command to run                                              |
+| `--args`             | (empty, repeatable)                   | Arguments                                                   |
+| `--env`              | (empty, repeatable)                   | `KEY=VALUE` env var                                         |
+| `--port`             | (empty, repeatable)                   | Port mapping                                                |
+| `--volume`           | (empty, repeatable)                   | Volume mount                                                |
+| `--network`          | (empty, repeatable)                   | Network to join                                             |
+| `--network-alias`    | (empty, repeatable)                   | Network alias                                               |
+| `--privileged`       | `false`                               | Run privileged                                              |
+| `--root`             | `false`                               | Mark this container as the cell's root container            |
+| `--cni-config-path`  | (empty)                               | Override CNI config dir for this container                  |
+| `--restart-policy`   | (empty)                               | Restart policy                                              |
+| `--label`            | (empty, repeatable)                   | `KEY=VALUE` label                                           |
+
+```bash
+sudo kuke create container nginx \
+    --cell web --realm main --space blog --stack wordpress \
+    --image docker.io/library/nginx:alpine \
+    --root
+```
+
+!!! warning "The `--image` default"
+    If you don't pass `--image`, Kukeon uses `docker.io/library/debian:latest`. Always pass `--image` explicitly when you care what runs.
+
+## Imperative vs. declarative
+
+`kuke create` is useful for quick experiments and one-off resources. For anything you want to commit, diff, or apply repeatedly, write a YAML manifest and use [`kuke apply`](kuke-apply.md). Manifests are the unit of version control; imperative commands are not.
+
+## Related
+
+- [kuke apply](kuke-apply.md) — declarative alternative
+- [Manifest Reference](../manifests/overview.md) — the schema for each resource

--- a/docs/site/cli/kuke-delete.md
+++ b/docs/site/cli/kuke-delete.md
@@ -1,0 +1,85 @@
+# kuke delete
+
+Delete a resource. Can be called per-resource (`kuke delete realm foo`) or against a manifest (`kuke delete -f file.yaml`).
+
+```
+kuke delete <resource> <name> [--cascade] [--force] [scope flags]
+kuke delete -f <file>
+```
+
+## Persistent flags (inherited by every subcommand)
+
+| Flag         | Default | Description                                                                            |
+|--------------|---------|----------------------------------------------------------------------------------------|
+| `--cascade`  | `false` | Recursively delete child resources (realm → spaces → stacks → cells; not containers)   |
+| `--force`    | `false` | Skip validation; attempt deletion anyway                                               |
+| `--file`, `-f` | (empty) | Delete the resources listed in a YAML file                                           |
+| `--output`, `-o` | (empty) | Output format: `json`, `yaml`                                                      |
+
+Plus all [global flags](kuke.md).
+
+## Per-resource subcommands
+
+### kuke delete realm
+
+```
+kuke delete realm <name> [--cascade] [--force]
+```
+
+### kuke delete space
+
+```
+kuke delete space <name> --realm <realm> [--cascade] [--force]
+```
+
+### kuke delete stack
+
+```
+kuke delete stack <name> --realm <r> --space <s> [--cascade] [--force]
+```
+
+### kuke delete cell
+
+```
+kuke delete cell <name> --realm <r> --space <s> --stack <t> [--cascade] [--force]
+```
+
+### kuke delete container
+
+```
+kuke delete container <name> --realm <r> --space <s> --stack <t> --cell <c>
+```
+
+`--cascade` does not apply to containers — they're already leaves.
+
+## Behavior
+
+1. **Without `--cascade`**, delete fails if the resource has children. It refuses to leave orphaned subtrees behind.
+2. **With `--cascade`**, children are deleted first (depth-first), then the parent. A realm cascade walks every space, stack, cell, and containerd container in it.
+3. **With `--force`**, validation is skipped — Kukeon will attempt to delete the metadata and tear down runtime state even when the host is in an unexpected state. Use it to recover from half-deleted resources.
+
+## Examples
+
+```bash
+# Delete an empty cell
+sudo kuke delete cell web --realm main --space blog --stack wordpress
+
+# Cascade-delete an entire realm (all spaces, stacks, cells, containers)
+sudo kuke delete realm mytenant --cascade
+
+# Force-delete a container that's stuck in an unknown state
+sudo kuke delete container stuck --cell web --realm main --space blog --stack wordpress --force
+
+# Delete every resource listed in a manifest
+sudo kuke delete -f site.yaml
+```
+
+## delete vs. purge
+
+- `delete` removes metadata and releases runtime state. If a detail fails (a cgroup that won't rmdir, a bridge that's in use), the command errors out.
+- [`purge`](kuke-purge.md) does everything `delete` does and then aggressively cleans up residual state. Use it when `delete --force` isn't enough.
+
+## Related
+
+- [kuke purge](kuke-purge.md) — more aggressive variant
+- [Init and reset](../guides/init-and-reset.md) — full-host reset workflows

--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -1,0 +1,69 @@
+# kuke get
+
+List or describe resources.
+
+```
+kuke get <resource> [NAME] [flags]
+kuke g   <resource> [NAME] [flags]      # alias
+```
+
+Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also accepts its plural (`realms`, `spaces`, …) and a short alias (`r`, `sp`, `st`, `ce`, `co`).
+
+## Common flags
+
+| Flag             | Description                                                                                           |
+|------------------|-------------------------------------------------------------------------------------------------------|
+| `--output`, `-o` | Output format: `yaml`, `json`, `table`. Default: `table` for list, `yaml` for a single resource.     |
+
+Plus all [global flags](kuke.md) — most importantly `--no-daemon`.
+
+## Hierarchy flags
+
+Each subcommand takes the flags that scope the query:
+
+| Subcommand          | Scope flags                                    |
+|---------------------|-----------------------------------------------|
+| `get realm [name]`   | none (realms are top-level)                   |
+| `get space [name]`   | `--realm` (default `default`)                 |
+| `get stack [name]`   | `--realm`, `--space`                          |
+| `get cell [name]`    | `--realm`, `--space`, `--stack`               |
+| `get container [name]` | `--realm`, `--space`, `--stack`, `--cell`  |
+
+All scope flags default to `default`. See the [realm default note](commands.md#convention-positional-arg--flags).
+
+## Behavior
+
+- **List** (no positional arg): returns every resource matching the scope flags. Default output is a table.
+- **Single** (positional arg): returns the one matching resource. Default output is YAML.
+
+```bash
+# Table of realms
+sudo kuke get realms
+NAME           NAMESPACE       STATE    CGROUP
+main           kukeon-main     Running  /kukeon/main
+kukeon-system  kukeon-system   Running  /kukeon/kukeon-system
+
+# Single realm as YAML
+sudo kuke get realm main -o yaml
+
+# Single realm as JSON
+sudo kuke get realm main -o json
+
+# Spaces in a non-default realm
+sudo kuke get spaces --realm main
+
+# Cells in a specific stack
+sudo kuke get cells --realm main --space default --stack default
+
+# All containers in the cell
+sudo kuke get containers --realm main --space default --stack default --cell hello-world
+```
+
+## `get` vs `refresh`
+
+`get` reads metadata. It does not reconcile or update `.status`. If you want the status to reflect the live runtime state (after a crash, or after containerd reported a change), run [`kuke refresh`](kuke-refresh.md) first.
+
+## Related
+
+- [kuke refresh](kuke-refresh.md) — rehydrate `.status` from containerd/CNI
+- [Manifest Reference](../manifests/overview.md) — the full shape of what `-o yaml` returns

--- a/docs/site/cli/kuke-init.md
+++ b/docs/site/cli/kuke-init.md
@@ -1,0 +1,72 @@
+# kuke init
+
+Bootstrap or reconcile a host. Creates the default user realm, the system realm, the kukeon cgroup root, the CNI config directory, and the `kukeond` cell. Starts the daemon and waits for it to respond.
+
+```
+kuke init [flags]
+```
+
+Always runs as root: it touches `/sys/fs/cgroup`, containerd namespaces, `/opt/kukeon`, and CNI dirs.
+
+## Flags
+
+| Flag                      | Default                             | Description                                                                                 |
+|---------------------------|-------------------------------------|---------------------------------------------------------------------------------------------|
+| `--realm`                 | `default`                           | Name of the default user realm                                                              |
+| `--space`                 | `default`                           | Name of the default space inside the user realm                                             |
+| `--kukeond-image`         | `ghcr.io/eminwux/kukeon:<version>`  | Image to run the daemon cell. See [image resolution](#image-resolution).                    |
+| `--no-wait`               | `false`                             | Don't wait for the daemon socket after bootstrap                                            |
+| `--force-regenerate-cni`  | `false`                             | Rewrite every space's CNI conflist even if it exists. See [Troubleshooting](../guides/troubleshooting.md#kuke-init-fails-with-numerical-result-out-of-range). |
+
+Plus all [global flags](kuke.md).
+
+## What it does
+
+1. Creates `/sys/fs/cgroup/kukeon` if missing.
+2. Creates `/etc/cni/net.d` and `/opt/cni/bin` if missing.
+3. Creates the user realm (`--realm`, default `default`): containerd namespace, cgroup, metadata.
+4. Creates the default space (`--space`, default `default`): CNI conflist, bridge, cgroup, metadata.
+5. Creates the default stack (`default`): cgroup, metadata.
+6. Creates the system realm (`kukeon-system`): containerd namespace, cgroup, metadata.
+7. Creates the system space and stack inside `kukeon-system`.
+8. Creates the `kukeond` cell and its root container using `--kukeond-image`.
+9. Starts the daemon's root container; waits up to 30s for the socket to accept a `Ping` RPC (skipped when `--no-wait` is set).
+
+Everything is idempotent. Re-running `init` on a bootstrapped host reports `already existed` for the parts it finds on disk. Use `--force-regenerate-cni` to explicitly rewrite the CNI conflist.
+
+## Image resolution
+
+`--kukeond-image` takes precedence. When not set, Kukeon composes the image reference from build-time constants:
+
+- Release builds: `ghcr.io/eminwux/kukeon:<version>` where `<version>` is the semver tag.
+- Dev builds (no tag or non-`v`-prefixed version): `ghcr.io/eminwux/kukeon:latest`.
+
+For local iteration, pass `--kukeond-image docker.io/library/kukeon-local:dev` or whatever tag you built.
+
+## Examples
+
+```bash
+# Fresh bootstrap with defaults
+sudo kuke init
+
+# Bootstrap with a different user-realm name
+sudo kuke init --realm myenv --space default
+
+# Local dev: point at a hand-loaded image
+sudo kuke init --kukeond-image docker.io/library/kukeon-local:dev
+
+# Re-init with CNI regeneration (recovers from stale conflist)
+sudo kuke init --force-regenerate-cni
+
+# Bootstrap without waiting for the daemon to come up
+sudo kuke init --no-wait
+```
+
+## Output
+
+`init` prints a structured bootstrap report: what was created, what already existed, and the resulting runtime path. A fresh bootstrap example is in [Getting Started](../getting-started.md#3-bootstrap-the-runtime).
+
+## Related
+
+- [Init and reset](../guides/init-and-reset.md) — teardown, re-init, and reset workflows
+- [Local development](../guides/local-dev.md) — first-time bootstrap with a local image

--- a/docs/site/cli/kuke-lifecycle.md
+++ b/docs/site/cli/kuke-lifecycle.md
@@ -1,0 +1,78 @@
+# kuke start / stop / kill
+
+Runtime lifecycle for cells and containers. These commands don't touch metadata — they operate on the containerd task under the resource.
+
+| Command      | Signal             | What it does                                                  |
+|--------------|--------------------|---------------------------------------------------------------|
+| `kuke start` | (create/start task)| Launch the container(s); no-op if already running             |
+| `kuke stop`  | `SIGTERM`          | Request graceful shutdown; container exits on its own terms   |
+| `kuke kill`  | `SIGKILL`          | Immediate termination; no graceful shutdown window            |
+
+All three take the same shape: `<verb> cell|container <name> <scope flags>`.
+
+## kuke start
+
+```
+kuke start cell       <name> --realm <r> --space <s> --stack <t>
+kuke start container  <name> --realm <r> --space <s> --stack <t> --cell <c>
+```
+
+Aliases: `kuke start` → `kuke sta`.
+
+- `start cell` starts the root container first, then every non-root container in the cell.
+- `start container` starts a single container. If the parent cell's network namespace isn't up, the command fails — you usually want `start cell` for the whole unit.
+
+## kuke stop
+
+```
+kuke stop cell       <name> --realm <r> --space <s> --stack <t>
+kuke stop container  <name> --realm <r> --space <s> --stack <t> --cell <c>
+```
+
+Aliases: `kuke stop` → `kuke sto`.
+
+Sends SIGTERM to the task. If the container has a shutdown handler, it gets a chance to run. There is no explicit grace period flag today — whatever the task does before exiting, it does.
+
+## kuke kill
+
+```
+kuke kill cell       <name> --realm <r> --space <s> --stack <t>
+kuke kill container  <name> --realm <r> --space <s> --stack <t> --cell <c>
+```
+
+Aliases: `kuke kill` → `kuke k`.
+
+Sends SIGKILL. Useful when a container is unresponsive, or when tearing down the daemon (`kuke kill cell kukeond …`).
+
+## Common flags
+
+All three verbs share the same scope flags:
+
+| Flag       | Default    | Scope                 |
+|------------|-----------|-----------------------|
+| `--realm`  | `default` | Required for cell/container |
+| `--space`  | `default` | Required for cell/container |
+| `--stack`  | `default` | Required for cell/container |
+| `--cell`   | _(required for `container`)_ | Parent cell |
+
+Plus all [global flags](kuke.md).
+
+## Examples
+
+```bash
+# Start a cell
+sudo kuke start cell web --realm main --space blog --stack wordpress
+
+# Graceful stop
+sudo kuke stop cell web --realm main --space blog --stack wordpress
+
+# Force-kill (useful for the daemon cell itself)
+sudo kuke kill cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+```
+
+## Exit semantics
+
+- Exit 0: signal delivered (or cell already in desired state for `start`).
+- Exit non-zero: the daemon couldn't find the resource, the resource is in a state that doesn't allow the transition, or the underlying containerd/runtime call failed.
+
+After `stop`/`kill`, the resource is in `Stopped` state. `start` moves it to `Ready`. See [Cell](../concepts/cell.md#lifecycle) and [Container](../concepts/container.md#lifecycle) for the full state tables.

--- a/docs/site/cli/kuke-purge.md
+++ b/docs/site/cli/kuke-purge.md
@@ -1,0 +1,66 @@
+# kuke purge
+
+More aggressive variant of [`kuke delete`](kuke-delete.md). Removes metadata, releases runtime state, and cleans up residual artifacts (cgroups, CNI networks, containerd remnants) that `delete` would leave behind on error.
+
+```
+kuke purge <resource> <name> [--cascade] [--force] [scope flags]
+```
+
+Resources: `realm`, `space`, `stack`, `cell`, `container`.
+
+## Persistent flags
+
+| Flag        | Default | Description                                                          |
+|-------------|---------|----------------------------------------------------------------------|
+| `--cascade` | `false` | Recursively purge children (does not apply to containers)            |
+| `--force`   | `false` | Skip validation; attempt purge regardless of current state           |
+
+Plus all [global flags](kuke.md).
+
+## Per-resource subcommands
+
+Shape and flags are identical to the equivalent `delete` subcommands:
+
+```
+kuke purge realm     <name>                                 [--cascade] [--force]
+kuke purge space     <name> --realm <r>                     [--cascade] [--force]
+kuke purge stack     <name> --realm <r> --space <s>         [--cascade] [--force]
+kuke purge cell      <name> --realm <r> --space <s> --stack <t>  [--cascade] [--force]
+kuke purge container <name> --realm <r> --space <s> --stack <t> --cell <c> [--force]
+```
+
+## When to use purge vs. delete
+
+- **Use `delete`** when the host is in a healthy state. It's the safer option; it won't blow past a validation failure.
+- **Use `purge`** when `delete --force` errors out or leaves residue (a cgroup directory that won't `rmdir`, a bridge that wasn't torn down, a containerd container that's stuck). It's the hammer.
+
+## What purge does that delete doesn't
+
+`purge` still goes through the same reconciliation, but after every step it verifies the state is actually gone and tries harder if not:
+
+- Cgroup directories that refuse to remove are retried after freezing and killing residents.
+- Containerd containers left behind (for any reason) are force-deleted from the namespace.
+- CNI networks are torn down via the bridge plugin even when the metadata is inconsistent.
+- Conflist files are unlinked from disk.
+
+## Examples
+
+```bash
+# Purge a realm that delete wouldn't tear down
+sudo kuke purge realm mytenant --cascade --force
+
+# Nuke a broken cell
+sudo kuke purge cell stuck --realm main --space default --stack default --cascade --force
+
+# Clean up a container that's been orphaned
+sudo kuke purge container ghost --cell web --realm main --space blog --stack wordpress --force
+```
+
+## Caution
+
+`purge` is destructive and makes "best effort" its primary operating mode. It will keep going past errors that would halt `delete`. Use it when you're prepared to lose state that you didn't explicitly back up.
+
+## Related
+
+- [kuke delete](kuke-delete.md) — the safer variant
+- [Init and reset → Full host wipe](../guides/init-and-reset.md#full-host-wipe) — uses `purge --cascade --force` in the nuclear path

--- a/docs/site/cli/kuke-refresh.md
+++ b/docs/site/cli/kuke-refresh.md
@@ -1,0 +1,47 @@
+# kuke refresh
+
+Reconcile `.status` from the live runtime without touching `.spec`.
+
+```
+kuke refresh
+```
+
+## What it does
+
+Walks every realm / space / stack / cell / container that Kukeon has metadata for, asks containerd and CNI what the actual state is, and updates the `.status` field of each resource on disk. It does **not** modify `.spec` or any runtime state.
+
+Use it when:
+
+- A container crashed and Kukeon's `status` is still `Ready` — `refresh` will update it to `Failed`/`Stopped`.
+- You rebooted the host (or restarted containerd) and `kuke get` still shows pre-reboot state.
+- You intervened outside Kukeon (`ctr tasks kill`, `ip link delete`) and want the metadata to catch up.
+
+## Flags
+
+None beyond the [global flags](kuke.md).
+
+## Output
+
+A summary of what was inspected and what was updated:
+
+```
+$ sudo kuke refresh
+Inspected 3 realms, 5 spaces, 6 stacks, 8 cells, 12 containers.
+Updated 2 resources.
+```
+
+## When it's a no-op
+
+If Kukeon's metadata already matches the live state — i.e., you haven't rebooted, crashed, or intervened — `refresh` finds nothing to update. It's safe to run at any time.
+
+## refresh vs. get
+
+- `get` reads metadata and prints it. It never changes anything.
+- `refresh` reads the live runtime and writes updated `.status` to disk. The next `get` will then reflect the new state.
+
+So a typical "what's actually happening right now" workflow is:
+
+```bash
+sudo kuke refresh
+sudo kuke get cells --realm main --space default --stack default
+```

--- a/docs/site/cli/kuke-version.md
+++ b/docs/site/cli/kuke-version.md
@@ -1,0 +1,22 @@
+# kuke version
+
+Print the Kukeon version.
+
+```
+kuke version
+```
+
+## Output
+
+A single line containing the version string:
+
+```
+$ kuke version
+v0.1.0
+```
+
+For release builds, this is the semver tag. For dev builds, it's whatever `VERSION` was passed at build time (often `v0.0.0-dev` or empty).
+
+## Flags
+
+None beyond the [global flags](kuke.md).

--- a/docs/site/cli/kuke.md
+++ b/docs/site/cli/kuke.md
@@ -1,0 +1,64 @@
+# kuke (root)
+
+```
+kuke [global flags] <subcommand> [args]
+```
+
+The `kuke` binary is the client CLI. It parses flags, opens a connection to `kukeond`, sends a request, and formats the response.
+
+## Persistent flags
+
+These flags apply to every `kuke` subcommand. Defaults are shown in parentheses.
+
+### `--run-path` (`/opt/kukeon`)
+
+Where Kukeon stores on-disk metadata for realms, spaces, stacks, cells, and containers. Must be writable by the process running `kuke` (typically root).
+
+### `--config` (`/etc/kukeon/config.yaml`)
+
+Path to the configuration file. If the file doesn't exist, Kukeon falls back to command-line flags and environment variables only — a missing config file is not fatal.
+
+### `--containerd-socket` (`/run/containerd/containerd.sock`)
+
+Path to the containerd socket. Only used when running in `--no-daemon` mode; when talking to the daemon, containerd is accessed by the daemon, not the client.
+
+### `--host` (`unix:///run/kukeon/kukeond.sock`)
+
+The daemon endpoint. Today only the `unix://` scheme is supported. The `ssh://user@host` scheme is reserved for a future remote-management feature; don't use it yet.
+
+### `--no-daemon` (`false`)
+
+Bypass `kukeond` and run the operation in-process. Requires root: the client now directly touches containerd, CNI, cgroups.
+
+Use when the daemon is stopped, when bootstrapping (`kuke init`), or when working around the current limitation that the released daemon image doesn't bind-mount `/run/containerd/containerd.sock`.
+
+Don't run two `--no-daemon` commands at the same time — they'll race on the same on-disk state.
+
+### `--verbose`, `-v` (`false`)
+
+Turn on structured slog output to stderr. Pair with `--log-level debug` for the chattiest view.
+
+### `--log-level` (`info`)
+
+One of `debug`, `info`, `warn`, `error`. Controls log verbosity when `--verbose` is set.
+
+## Environment variables
+
+Every flag also has a corresponding `KUKEON_*` environment variable (check via `--help` on a subcommand, or see `cmd/config/env.go`). Flags beat env vars beat the config file beats built-in defaults.
+
+## Examples
+
+```bash
+# Talk to a non-default socket
+kuke --host unix:///tmp/kukeond.sock get realms
+
+# Bypass the daemon
+sudo kuke apply -f cell.yaml --no-daemon
+
+# Verbose debug of a single apply
+sudo kuke apply -f cell.yaml --verbose --log-level debug
+```
+
+## Subcommands
+
+See [Commands overview](commands.md) for the list.

--- a/docs/site/cli/kukeond.md
+++ b/docs/site/cli/kukeond.md
@@ -1,0 +1,41 @@
+# kukeond
+
+The daemon binary. Normally you don't run `kukeond` by hand — it runs as the root container of the `kukeond` cell in the [system realm](../concepts/system-realm.md), under containerd. Running it directly is useful when you want to run the daemon on the host without wrapping it in a container (for example, in a CI job or during deep debugging).
+
+```
+kukeond serve [flags]
+```
+
+## Persistent flags
+
+| Flag                    | Default                             | Description                                                                       |
+|-------------------------|-------------------------------------|-----------------------------------------------------------------------------------|
+| `--run-path`            | `/opt/kukeon`                       | Where the daemon reads/writes persistent state (shared with `kuke`)               |
+| `--containerd-socket`   | `/run/containerd/containerd.sock`   | Path to the containerd socket                                                     |
+| `--socket`              | `/run/kukeon/kukeond.sock`          | Unix socket the daemon listens on                                                 |
+| `--log-level`           | `info`                              | Log level: `debug`, `info`, `warn`, `error`                                       |
+
+`kukeond`'s `--run-path` matches `kuke`'s default — both binaries share the same `/opt/kukeon` tree. The socket and pid files live under `/run/kukeon` and are controlled by `--socket` independently.
+
+## kukeond serve
+
+```
+kukeond serve
+```
+
+Runs the daemon in the foreground. Listens on `--socket`, writes a pid file at `<run-path>/kukeond.pid`, and serves the `kukeonv1` API until it receives SIGINT or SIGTERM.
+
+On shutdown it closes the listener, removes the pid file, and drains in-flight requests on a best-effort basis.
+
+## Example
+
+```bash
+sudo kukeond serve --log-level debug
+```
+
+This runs the daemon on the host directly. In the normal path, `kuke init` creates a cell for it and containerd starts the container for you — see [System realm](../concepts/system-realm.md).
+
+## Signals
+
+- `SIGINT`, `SIGTERM` — clean shutdown.
+- `SIGKILL` — hard kill; leaves the socket and pid file behind. Clean up with `sudo rm -f /run/kukeon/kukeond.{sock,pid}` before restarting.

--- a/docs/site/concepts/cell.md
+++ b/docs/site/concepts/cell.md
@@ -1,0 +1,89 @@
+# Cell
+
+A **cell** is a pod-like unit: a group of containers that share a network namespace. Exactly one container in each cell is the **root container** — it owns the network namespace, and every other container in the cell joins it.
+
+If you've worked with Kubernetes pods, the mental model is the same. One `pause`-like container would have held the network namespace; in Kukeon, one of your actual containers is marked as the root.
+
+## What a cell is
+
+Creating a cell materializes:
+
+1. **A cgroup subtree** — `/sys/fs/cgroup/kukeon/<realm>/<space>/<stack>/<cell>` — parent of every container in the cell.
+2. **A Linux network namespace**, entered by the root container and shared by the rest.
+3. **A veth pair** between the cell's network namespace and the space's bridge, configured by the CNI bridge plugin and `host-local` IPAM.
+4. **Metadata** at `/opt/kukeon/<realm>/<space>/<stack>/<cell>/cell.yaml`.
+
+## Cell spec
+
+```yaml
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: web
+spec:
+  id: web
+  realmId: main
+  spaceId: default
+  stackId: default
+  containers:
+    - id: nginx
+      image: docker.io/library/nginx:alpine
+      root: true                 # owns the network namespace
+    - id: sidecar
+      image: docker.io/library/busybox:latest
+      command: /bin/sh
+      args: ["-c", "while true; do date; sleep 5; done"]
+```
+
+See [Manifest Reference → Cell](../manifests/cell.md) for the full schema.
+
+## The root container
+
+- One container in a cell must be the root. If none is set explicitly, the first container declared is chosen.
+- The root container is created first. Its network namespace is the cell's network namespace.
+- Non-root containers join the same network namespace at creation time.
+- When the root container exits, the cell's network namespace is torn down. Non-root containers are expected to exit as well.
+
+## Cell networking
+
+- One IP per cell, not per container. All containers in the cell share the network namespace and therefore share the IP.
+- `localhost` in any container reaches every port bound by every container in the same cell.
+- The cell's IP is assigned by the space's CNI configuration (by default, from the bridge plugin's host-local range).
+- Two cells in the same space can reach each other at the IP layer; two cells in different spaces cannot (unless you join them into a shared network).
+
+## Lifecycle
+
+| State        | What it means                                                   |
+|--------------|-----------------------------------------------------------------|
+| `Pending`    | Cell metadata exists; containers not yet created                |
+| `Ready`      | Root container is running; non-root containers are running      |
+| `Stopped`    | All containers have exited                                      |
+| `Failed`     | The root container failed to start or exited unexpectedly       |
+| `Unknown`    | The daemon can't determine the state (e.g., containerd offline) |
+
+## Operations
+
+```bash
+# Create a cell imperatively (without containers)
+sudo kuke create cell mycell --realm main --space default --stack default
+
+# Or apply a full cell manifest (preferred)
+sudo kuke apply -f cell.yaml
+
+# List cells
+sudo kuke get cells --realm main --space default --stack default
+
+# Start / stop / kill
+sudo kuke start cell mycell --realm main --space default --stack default
+sudo kuke stop  cell mycell --realm main --space default --stack default
+sudo kuke kill  cell mycell --realm main --space default --stack default
+
+# Delete (with cascade to remove child containers)
+sudo kuke delete cell mycell --realm main --space default --stack default --cascade
+```
+
+## Related concepts
+
+- [Container](container.md) — what runs inside a cell
+- [Stack](stack.md) — the parent of cells
+- [Networking](networking.md) — how cell IPs and bridges work

--- a/docs/site/concepts/cgroups.md
+++ b/docs/site/concepts/cgroups.md
@@ -1,0 +1,80 @@
+# cgroups
+
+Kukeon mirrors its resource hierarchy into the Linux unified cgroup v2 tree. Every realm, space, stack, cell, and container has a corresponding cgroup. Policies applied at one level are inherited by everything below it — standard cgroup semantics.
+
+## Where it lives
+
+Everything Kukeon creates is rooted at `/sys/fs/cgroup/kukeon`:
+
+```
+/sys/fs/cgroup/kukeon/
+├── main/                               <- realm
+│   ├── default/                        <- space
+│   │   └── default/                    <- stack
+│   │       └── hello-world/            <- cell
+│   │           ├── hello-world_root/   <- root container
+│   │           └── web/                <- non-root container
+│   └── monitoring/                     <- another space
+└── kukeon-system/                      <- system realm
+    └── kukeon/
+        └── kukeon/
+            └── kukeond/
+                └── kukeond_root/
+```
+
+Each path segment is exactly the resource name (or `<cell>_root` for the root container of a cell).
+
+## Why one cgroup per layer
+
+- **Realms** can enforce or observe policy for every container in a tenant: a single `memory.max` on `/sys/fs/cgroup/kukeon/<realm>` caps the whole realm.
+- **Spaces** can carve out per-application resource envelopes.
+- **Stacks** group related cells under a single limit.
+- **Cells** are where co-located containers share limits.
+- **Containers** are the leaf where containerd actually attaches the OCI process.
+
+You can apply cgroup knobs (`cpu.weight`, `memory.max`, `io.max`, etc.) at any level and they behave exactly as cgroups v2 specifies.
+
+## Inspecting state
+
+```bash
+# Memory usage for a realm
+cat /sys/fs/cgroup/kukeon/main/memory.current
+
+# CPU stats for a cell
+cat /sys/fs/cgroup/kukeon/main/default/default/hello-world/cpu.stat
+
+# List processes in a container
+cat /sys/fs/cgroup/kukeon/main/default/default/hello-world/hello-world_root/cgroup.procs
+```
+
+## Creating policies
+
+Kukeon does not yet expose cgroup policies as first-class fields on the manifest (`memory.max` on a realm, for example, is on the roadmap). In the meantime, you can write directly to the cgroup files. They persist across reconciles — Kukeon only creates missing directories; it does not clear values you set.
+
+```bash
+# Cap the main realm at 4 GiB
+echo 4G | sudo tee /sys/fs/cgroup/kukeon/main/memory.max
+```
+
+Caveats:
+
+- cgroup values you set by hand are not reflected in `kuke get`.
+- They survive reboots only if you re-apply them (cgroups are a runtime concept).
+- When a realm is deleted, the cgroup directory is removed and any policies go with it.
+
+## Prerequisites
+
+Kukeon needs the **cgroup v2 unified hierarchy**. On most modern distros this is the default. To check:
+
+```bash
+mount | grep cgroup2
+```
+
+If you see `cgroup` (v1) mounts instead, enable v2 on the kernel command line (`systemd.unified_cgroup_hierarchy=1`) and reboot.
+
+## Related concepts
+
+- [Realm](realm.md) — top-level cgroup parent
+- [Space](space.md) — space-level cgroup
+- [Stack](stack.md) — stack-level cgroup
+- [Cell](cell.md) — cell-level cgroup

--- a/docs/site/concepts/client-and-daemon.md
+++ b/docs/site/concepts/client-and-daemon.md
@@ -1,0 +1,66 @@
+# Client and daemon
+
+Kukeon ships as a single binary that behaves as either `kuke` (client CLI) or `kukeond` (daemon) depending on the name it's invoked as. Installing Kukeon creates a hard link so both names resolve to the same on-disk binary.
+
+```
+/usr/local/bin/kuke     -> kukeon binary
+/usr/local/bin/kukeond  -> same binary (hard-linked), different argv[0]
+```
+
+`cmd/main.go` inspects `filepath.Base(os.Args[0])` and dispatches to the matching cobra tree. See [Architecture → Process Model](../architecture/process-model.md) for the dispatch itself.
+
+## The two halves
+
+### `kuke` — the client
+
+`kuke` is the user-facing CLI. It does not directly own containerd, CNI, or cgroups; instead, it sends requests to `kukeond` over a unix socket. Every `kuke` subcommand — `init`, `apply`, `create`, `get`, `delete`, `start`/`stop`/`kill`, `purge`, `refresh` — is a client of the daemon by default.
+
+### `kukeond` — the daemon
+
+`kukeond` is a single long-lived process that:
+
+- listens on `/run/kukeon/kukeond.sock` (configurable via `--socket`);
+- serves the `kukeonv1` API to every `kuke` client;
+- holds the containerd client, the CNI manager, and the cgroup manager;
+- reconciles desired state (from manifests) against actual state (in containerd, CNI, cgroups).
+
+It runs as the root container of the `kukeond` cell inside the [system realm](system-realm.md), so it's managed by the same primitives as any other workload.
+
+## `--no-daemon`: in-process mode
+
+`kuke` has a `--no-daemon` flag that bypasses the socket and executes the operation in-process. When you pass `--no-daemon`, `kuke` becomes the daemon for the duration of the command:
+
+```bash
+sudo kuke apply -f cell.yaml --no-daemon
+```
+
+When to use it:
+
+- **Bootstrapping** — `kuke init` runs in-process by necessity; the daemon isn't up yet.
+- **Daemon is down** — anything that should talk to `kukeond` but can't because the daemon is stopped or being rebuilt.
+- **Current release constraints** — the shipped `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`, so cell creation currently runs `--no-daemon`. This will change in a future release.
+
+Trade-offs:
+
+- `--no-daemon` requires root (it talks directly to containerd, netlink, cgroups).
+- There's no long-lived state holder, so every command is self-contained.
+- Two `--no-daemon` commands running at the same time will race on the same on-disk state. Don't do it.
+
+## The `--host` flag
+
+The client talks to the daemon over a unix socket by default:
+
+```
+--host unix:///run/kukeon/kukeond.sock   (default)
+```
+
+Other transports are on the roadmap (`ssh://user@host` is the intended future shape), but today only the unix transport is supported. If you need to manage a remote host, bring your own tunnel — e.g. `ssh -L /tmp/kukeond.sock:/run/kukeon/kukeond.sock user@host` and then `kuke --host unix:///tmp/kukeond.sock …`.
+
+## Parity between daemon and in-process
+
+`kuke get <resource>` and `kuke get <resource> --no-daemon` should return identical output on a healthy host. Divergence between them is a regression — if you see it, please file a bug. The two paths share the same reconciler and data store; the only difference is who holds the process.
+
+## Related concepts
+
+- [System realm](system-realm.md) — where `kukeond` runs
+- [Process model](../architecture/process-model.md) — how argv[0] dispatch works

--- a/docs/site/concepts/container.md
+++ b/docs/site/concepts/container.md
@@ -1,0 +1,97 @@
+# Container
+
+A **container** is a plain OCI container, created and run by containerd, that belongs to a specific cell. Containers are the only layer in the hierarchy that corresponds directly to something you would recognize from Docker.
+
+## What a container is
+
+Creating a container materializes:
+
+1. **An OCI container** in containerd, in the realm's namespace (`kukeon-<realm>`).
+2. **A cgroup leaf** — `/sys/fs/cgroup/kukeon/<realm>/<space>/<stack>/<cell>/<container>_<role>` — where `<role>` is `root` for the root container or the container id otherwise.
+3. **Metadata** at `/opt/kukeon/<realm>/<space>/<stack>/<cell>/containers/<container>.yaml`.
+
+The rootfs, image layers, and image content all live in containerd — Kukeon does not re-implement any of it. You can inspect the containerd-level state at any time:
+
+```bash
+sudo ctr -n kukeon-main containers ls
+sudo ctr -n kukeon-main tasks ls
+```
+
+## Container spec
+
+```yaml
+apiVersion: v1beta1
+kind: Container
+metadata:
+  name: web
+spec:
+  id: web
+  realmId: main
+  spaceId: default
+  stackId: default
+  cellId: hello-world
+  root: true
+  image: docker.io/library/nginx:alpine
+  command: /bin/sh
+  args:
+    - -c
+    - "exec nginx -g 'daemon off;'"
+  env:
+    - "NGINX_HOST=example.com"
+  ports: []
+  volumes: []
+  networks: []
+  networksAliases: []
+  privileged: false
+  restartPolicy: ""
+```
+
+See [Manifest Reference → Container](../manifests/container.md) for the complete schema and the semantics of every field.
+
+## Root vs. non-root containers
+
+- Exactly one container in a cell is the root. Set `spec.root: true` in the manifest, or let Kukeon pick the first container if none is explicit.
+- The root container's network namespace becomes the cell's network namespace.
+- Non-root containers inherit the network namespace from the root. They do not get their own IP; they share the cell IP.
+- If the root container exits, the cell's network namespace goes away. Non-root containers should be designed to exit too.
+
+## Lifecycle
+
+| State      | What it means                                                     |
+|------------|-------------------------------------------------------------------|
+| `Pending`  | Container metadata exists; containerd container not yet created   |
+| `Ready`    | Task is running                                                   |
+| `Stopped`  | Task has exited                                                   |
+| `Paused`   | Task is paused (cgroup-frozen)                                    |
+| `Pausing`  | Task is in the process of being paused                            |
+| `Failed`   | Task exited non-zero or was signalled                             |
+| `Unknown`  | Daemon can't determine state                                      |
+
+## Operations
+
+```bash
+# Create a standalone container inside an existing cell
+sudo kuke create container side --cell hello-world \
+    --realm main --space default --stack default \
+    --image docker.io/library/busybox:latest \
+    --command /bin/sh --args "-c" --args "sleep 3600"
+
+# Start / stop / kill
+sudo kuke start container side --cell hello-world \
+    --realm main --space default --stack default
+sudo kuke stop container side --cell hello-world ...
+sudo kuke kill container side --cell hello-world ...
+
+# Delete
+sudo kuke delete container side --cell hello-world \
+    --realm main --space default --stack default
+```
+
+!!! note "`--image` default"
+    `kuke create container` defaults `--image` to `docker.io/library/debian:latest` when none is provided. Always pass `--image` explicitly if you care which image runs.
+
+## Related concepts
+
+- [Cell](cell.md) — the parent of a container
+- [containerd namespaces](containerd-namespaces.md) — where containers actually live
+- [cgroups](cgroups.md) — the resource-control side

--- a/docs/site/concepts/containerd-namespaces.md
+++ b/docs/site/concepts/containerd-namespaces.md
@@ -1,0 +1,53 @@
+# containerd namespaces
+
+Kukeon doesn't run its own container runtime. It drives [containerd](https://containerd.io/), and every containerd operation it performs is scoped to a **containerd namespace**.
+
+## The mapping
+
+| Realm           | containerd namespace      |
+|-----------------|---------------------------|
+| `main`          | `kukeon-main`             |
+| `kukeon-system` | `kukeon-system`           |
+| `mytenant`      | `kukeon-mytenant` (or whatever `spec.namespace` says) |
+
+By default, each realm's namespace is `kukeon-<realm-name>`. The realm manifest can override this via `spec.namespace`.
+
+## Why this matters
+
+Containerd namespaces are the tenancy boundary. They scope:
+
+- **Images** — an image pulled into `kukeon-main` is not visible from `kukeon-mytenant`; each realm maintains its own image cache.
+- **Containers** — a container running in `kukeon-main` can only be listed, stopped, or inspected by a client scoped to `kukeon-main`.
+- **Tasks** — running tasks are namespaced too.
+- **Snapshots and content** — the underlying layer store is shared, but the references are namespaced.
+
+This is also what lets Kukeon coexist with Docker or nerdctl on the same host. They use their own namespaces (`moby`, `default`, etc.) and never see Kukeon's.
+
+## Inspecting state with `ctr`
+
+Anything Kukeon does through containerd is visible to `ctr`, the low-level containerd CLI:
+
+```bash
+# Images in the main realm
+sudo ctr -n kukeon-main images ls
+
+# Containers in the main realm
+sudo ctr -n kukeon-main containers ls
+
+# Running tasks (the equivalent of `docker ps`) in the main realm
+sudo ctr -n kukeon-main tasks ls
+
+# Attach to a task's stdout (useful for debugging)
+sudo ctr -n kukeon-main tasks attach <container-id>
+```
+
+If `ctr -n <ns> images ls` returns empty, the image was never imported into that namespace. A common cause is importing into `default` instead of the realm's namespace. See [Build from source](../install/build-from-source.md#rebuild-the-kukeond-container-image) for the correct way to import.
+
+## The system namespace
+
+`kuke init` creates a second realm, `kukeon-system`, with containerd namespace `kukeon-system` (or `kuke-system.kukeon.io` in older layouts). That's where the `kukeond` image lives. See [System realm](system-realm.md).
+
+## Related concepts
+
+- [Realm](realm.md) — the Kukeon-level tenant boundary
+- [System realm](system-realm.md) — the dedicated realm for `kukeond`

--- a/docs/site/concepts/networking.md
+++ b/docs/site/concepts/networking.md
@@ -1,0 +1,75 @@
+# Networking (CNI)
+
+Kukeon uses the reference [CNI](https://github.com/containernetworking/cni) plugins to give each space a network. There is nothing magic happening; Kukeon writes a conflist to disk and then invokes the CNI plugins the normal way when a cell's network namespace is set up.
+
+## The shape of a space network
+
+One space → one CNI network → one Linux bridge → one IP range.
+
+Concretely, when you create a space:
+
+- Kukeon writes a CNI conflist at `/etc/cni/net.d/<realm>-<space>.conflist` (path configurable via `spec.cniConfigPath`).
+- The conflist references the `bridge` plugin with a bridge name derived from the space (see below).
+- The `host-local` plugin is used for IPAM.
+- On first cell creation, the kernel bridge appears on the host as a regular `ip link show` interface.
+
+For the out-of-the-box `main/default` space, the bridge sits on `10.88.0.0/16`.
+
+## Bridge names and the 15-character limit
+
+Linux interface names have a hard 15-character limit (`IFNAMSIZ - 1 = 15`). Kukeon's default bridge naming scheme — `kuke-<realm>-<space>` — can blow past that on long names:
+
+```
+kuke-main-default        # 16 chars, too long
+```
+
+Kukeon **truncates safely** before creating the bridge, using a stable hashing scheme so the same `(realm, space)` pair always produces the same bridge name. The CNI conflist records the actual bridge name that was used, and the daemon reads it back rather than recomputing.
+
+### Recovering from a stale conflist
+
+Older Kukeon versions computed bridge names without the safe-truncation rule. If you upgrade with a stale conflist on disk, the next `kuke init` or cell creation can fail with:
+
+```
+failed to attach ... to network: plugin type="bridge" failed (add):
+failed to create bridge "kuke-...-...": could not add "...":
+numerical result out of range
+```
+
+`numerical result out of range` is the kernel's `ERANGE` for "this interface name is too long." Fix:
+
+```bash
+sudo kuke init --force-regenerate-cni
+```
+
+That flag rewrites every space's conflist with the current naming scheme.
+
+See [Troubleshooting](../guides/troubleshooting.md#kuke-init-fails-with-numerical-result-out-of-range).
+
+## Cell-level networking
+
+Inside a cell, only the root container has a network namespace — every other container joins it. So:
+
+- Each cell has exactly one IP on the space's bridge.
+- `localhost` inside any container in the cell reaches every port bound by any container in the cell.
+- Two cells in the same space can reach each other at the IP layer.
+- Two cells in different spaces cannot reach each other unless a container explicitly joins both networks.
+
+## Inspecting network state
+
+```bash
+# List bridges
+ip link show type bridge | grep kuke
+
+# Show the conflist for a space
+cat /etc/cni/net.d/main-default.conflist
+
+# Find the pid of a cell's root container (from containerd) and peek into its netns
+ROOT_PID=$(sudo ctr -n kukeon-main tasks ls | awk '/<cell>_root/ {print $2}')
+sudo nsenter -t "${ROOT_PID}" -n ip -4 addr
+sudo nsenter -t "${ROOT_PID}" -n ip route
+```
+
+## Related concepts
+
+- [Space](space.md) — owns the network
+- [Cell](cell.md) — gets one IP on the bridge

--- a/docs/site/concepts/overview.md
+++ b/docs/site/concepts/overview.md
@@ -1,0 +1,75 @@
+# The Kukeon hierarchy
+
+Kukeon's resource model is a single, explicit hierarchy. Every container on a Kukeon host belongs to exactly one path through this tree:
+
+```mermaid
+flowchart LR
+    Realm --> Space --> Stack --> Cell --> Container
+```
+
+Each layer maps to a concrete Linux primitive. There are no hidden layers and no "virtual" concepts that only exist inside the daemon.
+
+| Layer       | Linux primitive                                | What it gives you                   |
+|-------------|------------------------------------------------|-------------------------------------|
+| [Realm](realm.md)     | containerd namespace                           | Tenant boundary                     |
+| [Space](space.md)     | CNI network + cgroup subtree                   | Network and resource isolation      |
+| [Stack](stack.md)     | cgroup subtree                                 | Logical grouping within a space     |
+| [Cell](cell.md)       | Network namespace (one root container owns it) | Pod-like co-location                |
+| [Container](container.md) | OCI container via containerd              | The actual workload                 |
+
+## Why five layers?
+
+Docker has one layer (the container). Kubernetes has many (namespaces, workloads, services, ingress, nodes, pods). Kukeon sits between: enough layers to carve real isolation boundaries on a single host, but few enough that each one has a single, clear job.
+
+- **Realm** answers *whose containers are these?* — one realm per tenant, environment, or user.
+- **Space** answers *what can they talk to?* — each space is one CNI bridge, one IP range, one cgroup subtree for quotas.
+- **Stack** answers *which cells are part of the same deployment?* — groups related cells together for lifecycle operations.
+- **Cell** answers *which containers share a network namespace?* — like a Kubernetes pod, one unit of co-located containers.
+- **Container** answers *what is actually running?* — a plain OCI container.
+
+## A worked example
+
+Say you are running two projects on the same host: a WordPress blog and a personal monitoring stack.
+
+```
+Realm: main
+├── Space: blog          (CNI: 10.88.0.0/16)
+│   └── Stack: wordpress
+│       ├── Cell: wp
+│       │   ├── Container: php-fpm
+│       │   └── Container: nginx
+│       └── Cell: db
+│           └── Container: mariadb
+└── Space: monitoring    (CNI: 10.89.0.0/16)
+    └── Stack: observability
+        ├── Cell: prometheus
+        │   └── Container: prometheus
+        └── Cell: grafana
+            └── Container: grafana
+```
+
+The blog stack and the monitoring stack are on different CNI bridges, different cgroup subtrees, but share the same realm (one containerd namespace). If you wanted them fully isolated — different tenants, different registry credentials — each would get its own realm.
+
+## System realm
+
+In addition to the realm you create, `kuke init` creates a second realm called `kukeon-system`. It is where the `kukeond` daemon itself runs, and it's managed by `kuke` the same way any other realm is. See [System realm](system-realm.md).
+
+## The default hierarchy
+
+When you run `kuke init` with no arguments, Kukeon creates:
+
+- A user realm `default` (containerd namespace `kukeon-default`)
+- A space `default` inside the `default` realm (CNI network `default-default`, bridge `kuke-default-de…` truncated to fit the 15-char kernel limit)
+- A stack `default` inside `default/default`
+- The system realm `kukeon-system` with the `kukeond` cell
+
+Everything is idempotent. Re-running `init` reports `already existed` for the parts it finds on disk.
+
+## Read next
+
+- [Realm](realm.md) — tenant boundary
+- [Space](space.md) — network + cgroup isolation
+- [Stack](stack.md) — logical grouping
+- [Cell](cell.md) — pod-like unit
+- [Container](container.md) — OCI workload
+- [Client and daemon](client-and-daemon.md) — how `kuke` and `kukeond` cooperate

--- a/docs/site/concepts/realm.md
+++ b/docs/site/concepts/realm.md
@@ -1,0 +1,77 @@
+# Realm
+
+A **realm** is the outermost layer of the Kukeon hierarchy. It is the tenant boundary: everything a realm owns is invisible from another realm, by construction.
+
+## What a realm is, on disk and in the kernel
+
+Creating a realm materializes three things on the host:
+
+1. **A containerd namespace** — all containers the realm runs live in a dedicated containerd namespace, named `kukeon-<realm>` by default. Images pulled into one realm are not visible from another.
+2. **A cgroup subtree** — `/sys/fs/cgroup/kukeon/<realm>` — used as the root for every space and stack inside the realm. This gives you a single place to attach quotas or account usage across the realm.
+3. **Metadata** at `/opt/kukeon/<realm>/realm.yaml` (under the run path, which is configurable via `--run-path`). This is the authoritative record that the realm exists; the daemon reconciles state from it.
+
+## Realm spec
+
+```yaml
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: main
+  labels: {}
+spec:
+  namespace: kukeon-main
+  registryCredentials: []   # optional, per-registry
+```
+
+The full schema is in [Manifest Reference → Realm](../manifests/realm.md).
+
+Key fields:
+
+- `metadata.name` — the realm's name, used everywhere as the `realmId`.
+- `spec.namespace` — the containerd namespace. Defaults to the realm name (or `kukeon-<name>` when bootstrapped by `kuke init`); you can set it explicitly.
+- `spec.registryCredentials` — a list of registry logins for images this realm pulls. Scoped to the realm: two realms can use the same image reference with different credentials.
+
+## Realms and containerd namespaces
+
+Every containerd operation Kukeon performs is scoped to a namespace. If you want to inspect what a realm sees, use `ctr` with the same namespace:
+
+```bash
+# List images in the `main` realm
+sudo ctr -n kukeon-main images ls
+
+# List running tasks (containers) in the `main` realm
+sudo ctr -n kukeon-main tasks ls
+```
+
+Inspecting a different namespace (or no namespace) will not show anything Kukeon created for `main`. This is the main mechanism that gives realms their tenancy guarantee.
+
+## Why you might want more than one realm
+
+- **Environments** — `dev`, `staging`, `prod` as three realms on the same host.
+- **Tenants** — one realm per user or project on a shared host.
+- **Registry credentials** — different teams pull from different private registries.
+- **Accounting** — one cgroup subtree per realm makes it easy to bill or enforce quotas.
+
+## Operations
+
+```bash
+# Create
+sudo kuke create realm mytenant --namespace kukeon-mytenant
+
+# Get (list)
+sudo kuke get realms
+
+# Get (single, as YAML)
+sudo kuke get realm mytenant -o yaml
+
+# Delete (with --cascade to remove children)
+sudo kuke delete realm mytenant --cascade
+```
+
+See [CLI Reference → create](../cli/kuke-create.md), [get](../cli/kuke-get.md), [delete](../cli/kuke-delete.md).
+
+## Related concepts
+
+- [containerd namespaces](containerd-namespaces.md) — how the realm/namespace mapping works
+- [cgroups](cgroups.md) — the realm's cgroup subtree
+- [System realm](system-realm.md) — the special `kukeon-system` realm

--- a/docs/site/concepts/space.md
+++ b/docs/site/concepts/space.md
@@ -1,0 +1,71 @@
+# Space
+
+A **space** is one step inside a realm. It owns **one CNI network** and **one cgroup subtree**. Everything that needs to share a layer-2 segment or a pool of compute resources lives in the same space.
+
+## What a space is, on disk and in the kernel
+
+Creating a space materializes:
+
+1. **A CNI configuration file** at `/etc/cni/net.d/<realm>-<space>.conflist` (by default). The conflist points at the bridge and host-local plugins and owns the space's IP range.
+2. **A Linux bridge** on the host, named `kuke-<realm>-<space>` (truncated if needed — see [Networking](networking.md)). Every cell in the space gets a veth pair into this bridge.
+3. **A cgroup subtree** — `/sys/fs/cgroup/kukeon/<realm>/<space>` — parent of every stack and cell cgroup in the space.
+4. **Metadata** at `/opt/kukeon/<realm>/<space>/space.yaml`.
+
+## Space spec
+
+```yaml
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: default
+spec:
+  realmId: main
+  cniConfigPath: /etc/cni/net.d   # optional; defaults to system CNI dir
+```
+
+The full schema is in [Manifest Reference → Space](../manifests/space.md).
+
+## Network boundary
+
+Everything inside the same space can reach everything else inside the same space by default, at the IP layer. Two cells in two different spaces cannot reach each other unless you explicitly connect them (typically by having a container join both networks).
+
+This is Kukeon's primary network-isolation knob. If you want firewalling between groups of cells, put them in different spaces.
+
+## cgroup boundary
+
+The space cgroup is the parent of every stack cgroup in the space, which in turn is the parent of every cell's cgroup. A quota or limit set on the space cgroup is inherited by everything underneath.
+
+```
+/sys/fs/cgroup/kukeon/main/default/         <- space cgroup
+├── stackA/
+│   ├── cell1/
+│   │   └── cell1_root/                      <- root container
+│   └── cell2/
+└── stackB/
+```
+
+This gives you a single, reliable place to put CPU/memory/IO limits that apply to an entire space.
+
+## Operations
+
+```bash
+# Create a space inside the main realm
+sudo kuke create space mySpace --realm main
+
+# List spaces in a realm
+sudo kuke get spaces --realm main
+
+# Delete (with --cascade to remove child stacks, cells, containers)
+sudo kuke delete space mySpace --realm main --cascade
+```
+
+## Bridge name length limit
+
+Linux limits interface names to 15 characters (`IFNAMSIZ - 1`). Kukeon's bridge name scheme, `kuke-<realm>-<space>`, can exceed that for long names. Kukeon truncates safely before creating the bridge, but if an old conflist on disk has a too-long name from before the fix, re-run `kuke init --force-regenerate-cni` to regenerate it. See [Troubleshooting](../guides/troubleshooting.md).
+
+## Related concepts
+
+- [Networking (CNI)](networking.md) — how the CNI side of a space works
+- [cgroups](cgroups.md) — the full cgroup tree
+- [Realm](realm.md) — the tenant that owns the space
+- [Stack](stack.md) — what lives inside a space

--- a/docs/site/concepts/stack.md
+++ b/docs/site/concepts/stack.md
@@ -1,0 +1,56 @@
+# Stack
+
+A **stack** is a logical grouping of related cells. Stacks don't add a network boundary — the space does that — but they do add their own cgroup subtree and serve as a naming scope for cells that belong to the same deployment or application.
+
+## What a stack is
+
+Creating a stack materializes:
+
+1. **A cgroup subtree** — `/sys/fs/cgroup/kukeon/<realm>/<space>/<stack>` — parent of every cell in the stack.
+2. **Metadata** at `/opt/kukeon/<realm>/<space>/<stack>/stack.yaml`.
+
+That's it. A stack has no network configuration of its own.
+
+## Stack spec
+
+```yaml
+apiVersion: v1beta1
+kind: Stack
+metadata:
+  name: default
+spec:
+  id: default
+  realmId: main
+  spaceId: default
+```
+
+See [Manifest Reference → Stack](../manifests/stack.md) for the full schema.
+
+## When to create a new stack
+
+A stack is the right boundary when you want:
+
+- A group of cells you'll deploy, stop, or tear down together.
+- A cgroup subtree you can apply compound resource limits to (for example, a limit that covers a whole application's cells but not the rest of the space).
+- A namespace for cell names — two stacks in the same space can both have a cell called `web` without colliding.
+
+If you don't need any of that, keep using the default stack.
+
+## Operations
+
+```bash
+# Create a stack inside main/default
+sudo kuke create stack myapp --realm main --space default
+
+# List stacks in a space
+sudo kuke get stacks --realm main --space default
+
+# Delete (with cascade to remove child cells)
+sudo kuke delete stack myapp --realm main --space default --cascade
+```
+
+## Related concepts
+
+- [Space](space.md) — the network + cgroup parent of a stack
+- [Cell](cell.md) — what lives inside a stack
+- [cgroups](cgroups.md) — the full cgroup tree

--- a/docs/site/concepts/system-realm.md
+++ b/docs/site/concepts/system-realm.md
@@ -1,0 +1,62 @@
+# System realm
+
+`kuke init` creates two realms, not one:
+
+- A **user realm** — `default` by default — for your workloads.
+- A **system realm** called `kukeon-system` for Kukeon's own infrastructure.
+
+The system realm is where `kukeond` runs.
+
+## What lives there
+
+On a freshly bootstrapped host:
+
+```
+Realm: kukeon-system
+└── Space: kukeon
+    └── Stack: kukeon
+        └── Cell: kukeond
+            └── Container: kukeond_root   (image: ghcr.io/eminwux/kukeon:<version>)
+```
+
+The `kukeond` daemon runs as the root container of the `kukeond` cell, inside a dedicated cell → stack → space → realm path. This means:
+
+- The daemon is managed by the same primitives as your workloads — cgroups, containerd namespace, CNI network.
+- Tearing it down uses the same `kuke` commands you'd use for any other cell.
+- Upgrading the daemon is just "swap the image and recreate the cell."
+
+## Why a separate realm?
+
+- **Tenancy** — the system realm is isolated from your workload realms. A user realm going sideways (or being removed) doesn't touch the daemon.
+- **Accounting** — `kukeond`'s CPU and memory usage roll up under `/sys/fs/cgroup/kukeon/kukeon-system`, separate from your applications.
+- **Lifecycle** — `kuke` can manage the daemon the same way it manages anything else; there's no "special path" for the system cell.
+
+## Operating the system realm
+
+You can inspect it with the same commands:
+
+```bash
+$ sudo kuke get cells --realm kukeon-system --space kukeon --stack kukeon
+NAME     REALM            SPACE    STACK    STATE   ...
+kukeond  kukeon-system    kukeon   kukeon   Ready
+```
+
+Stopping or restarting the daemon:
+
+```bash
+sudo kuke kill cell kukeond   --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+```
+
+`--no-daemon` is required because the daemon itself is what's being stopped — `kuke` has to talk to containerd directly.
+
+See [Guides → Init and reset](../guides/init-and-reset.md) for the full teardown-and-bootstrap loop.
+
+!!! note "Older layouts"
+    On earlier versions of Kukeon, the system realm used `kuke-system.kukeon.io` as the containerd namespace. `kuke-system` and `kukeon-system` refer to the same concept depending on which version you bootstrapped the host with.
+
+## Related concepts
+
+- [Realm](realm.md) — the realm concept in general
+- [Client and daemon](client-and-daemon.md) — how `kuke` and `kukeond` cooperate

--- a/docs/site/faq.md
+++ b/docs/site/faq.md
@@ -1,0 +1,62 @@
+# FAQ
+
+## How is Kukeon different from Docker?
+
+Docker organizes containers in a flat list. Kukeon organizes them in a fixed, explicit hierarchy (Realm → Space → Stack → Cell → Container), where each layer maps to a real Linux primitive (containerd namespace, CNI network, cgroup subtree).
+
+Put differently: Docker gives you one container at a time; Kukeon gives you a place to put many containers that share network, cgroups, or tenancy on purpose. See [Concepts → Overview](concepts/overview.md).
+
+## How is Kukeon different from Kubernetes?
+
+Kubernetes is a distributed control plane with schedulers, controllers, etcd, API servers, and a CNI story that assumes multiple nodes. Kukeon is a single-host daemon that drives containerd, CNI, and cgroups directly. There's no scheduler, no etcd, no API server on port 6443.
+
+The pod → Kubernetes mapping is:
+
+- Kubernetes pod ≈ Kukeon cell (a group of containers sharing a network namespace)
+- Kubernetes namespace ≈ Kukeon realm (a tenancy boundary)
+
+Scale, resiliency, and multi-node concerns are deliberately out of scope.
+
+## Can I run Kukeon and Docker on the same host?
+
+Yes. Kukeon uses its own containerd namespaces (`kukeon-<realm>`). Docker uses `moby`. The two never see each other's containers.
+
+## Can I run Kukeon without the daemon?
+
+Mostly, yes. Every `kuke` subcommand accepts `--no-daemon`, which runs the operation in-process. You lose the benefit of a long-lived state holder, but for one-off commands it works.
+
+See [Client and daemon](concepts/client-and-daemon.md).
+
+## Does Kukeon work on macOS?
+
+Not directly. Kukeon needs Linux-specific primitives: cgroup v2, netlink, containerd. On macOS, you can run it inside a Linux VM (Lima, OrbStack, Colima, etc.). Native macOS support is not on the roadmap.
+
+## What happens on reboot?
+
+- `/opt/kukeon` persists — your realm/space/stack/cell metadata is intact.
+- `/run/kukeon/{kukeond.sock,kukeond.pid}` disappears (tmpfs).
+- `/sys/fs/cgroup/kukeon/...` disappears (runtime).
+- CNI conflists in `/etc/cni/net.d` persist.
+- Running containers do not persist — containerd tasks don't survive reboot.
+
+Currently, there is no auto-start: you need to run `kuke init` (or start the daemon cell explicitly) after reboot to bring the system back up. Systemd unit integration is on the roadmap.
+
+## Does Kukeon have a web UI?
+
+Not yet. One is on the roadmap. The `kukeonv1` API that the CLI uses is stable enough that a read-only UI would be straightforward to build.
+
+## Where does Kukeon write files on the host?
+
+See [Architecture → Storage layout](architecture/storage-layout.md). The short list: `/opt/kukeon`, `/run/kukeon`, `/sys/fs/cgroup/kukeon`, `/etc/cni/net.d/*.conflist`, containerd's own store (via namespaces `kukeon-<realm>`).
+
+## Can I run multiple kukeon daemons on the same host?
+
+Not supported. The daemon assumes sole ownership of `/run/kukeon/kukeond.sock`, `/opt/kukeon`, and the `kukeon-*` containerd namespaces. Running two would race on all three.
+
+## Is Kukeon production ready?
+
+No. It's in alpha and the APIs can still change. See [ROADMAP.md](https://github.com/eminwux/kukeon/blob/main/ROADMAP.md) for what's still in flux.
+
+## How do I report a bug or request a feature?
+
+Issues and discussions are at [github.com/eminwux/kukeon](https://github.com/eminwux/kukeon). Please include the version (`kuke version`), a minimal reproducer, and the output of `kuke <command> --verbose --log-level debug` for bug reports.

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -1,0 +1,154 @@
+# Getting Started
+
+This guide walks you through installing Kukeon on a Linux host, bootstrapping the runtime, and running a simple cell.
+
+## 1. Check prerequisites
+
+Kukeon needs:
+
+- Linux with cgroups v2
+- [containerd](https://containerd.io/) running at `/run/containerd/containerd.sock`
+- [CNI plugins](https://github.com/containernetworking/plugins) available on the host (typically at `/opt/cni/bin`)
+
+See [Installation → Prerequisites](install/prerequisites.md) for details and quick install commands for each dependency.
+
+## 2. Install kuke
+
+```bash
+export OS=linux
+export ARCH=amd64
+
+curl -L -o kuke https://github.com/eminwux/kukeon/releases/download/v0.1.0/kuke-${OS}-${ARCH} && \
+  chmod +x kuke && \
+  sudo install -m 0755 kuke /usr/local/bin/kuke && \
+  sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
+```
+
+A single binary ships both the CLI (`kuke`) and the daemon (`kukeond`). Kukeon dispatches to one or the other based on the executable name, so the hard link above is required. See [Architecture → Process Model](architecture/process-model.md) for the details.
+
+## 3. Bootstrap the runtime
+
+`kuke init` provisions the default hierarchy (realm `default`, space `default`, stack `default`), sets up CNI dirs, pulls the `kukeond` image, and starts the daemon. It touches `/opt/kukeon`, cgroups, and containerd, so it needs root:
+
+```bash
+$ sudo kuke init
+Initialized Kukeon runtime
+Realm: default (namespace: kukeon-default)
+System realm: kukeon-system (namespace: kukeon-system)
+Run path: /opt/kukeon
+Kukeond image: ghcr.io/eminwux/kukeon:v0.1.0
+Actions:
+    - kukeon root cgroup: created
+  - CNI config dir "/etc/cni/net.d": created
+  - CNI bin dir "/opt/cni/bin": already existed
+  Default hierarchy:
+    - realm "default": created
+    - containerd namespace "kukeon-default": created
+    - space "default": created
+    - network "default": created
+    - stack "default": created
+  System hierarchy:
+    - realm "kukeon-system": created
+    - cell "kukeond": created (image ghcr.io/eminwux/kukeon:v0.1.0)
+kukeond is ready (unix:///opt/kukeon/run/kukeond.sock)
+```
+
+`init` is idempotent. Re-running it reconciles on-disk state; items that already exist are reported as `already existed`.
+
+## 4. Verify with `kuke get`
+
+List the realms, spaces, and stacks that `kuke init` just created:
+
+```bash
+$ sudo kuke get realms
+NAME           NAMESPACE         STATE    CGROUP
+default        kukeon-default    Running  /kukeon/default
+kukeon-system  kukeon-system     Running  /kukeon/kukeon-system
+
+$ sudo kuke get spaces
+NAME     REALM    STATE    CGROUP
+default  default  Running  /kukeon/default/default
+
+$ sudo kuke get stacks
+NAME     REALM    SPACE    STATE    CGROUP
+default  default  default  Running  /kukeon/default/default/default
+```
+
+Add `-o yaml` or `-o json` for full resource details. All of `--realm`, `--space`, and `--stack` default to `default`, so the fresh-install hierarchy is reachable without any flags.
+
+## 5. Run a hello-world cell
+
+A minimal example that brings up a single container serving a static HTML page with busybox httpd ships in the repo at [`docs/examples/hello-world.yaml`](https://github.com/eminwux/kukeon/blob/main/docs/examples/hello-world.yaml):
+
+```yaml
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: hello-world
+spec:
+  id: hello-world
+  realmId: default
+  spaceId: default
+  stackId: default
+  containers:
+    - id: web
+      image: docker.io/library/busybox:latest
+      command: /bin/sh
+      args:
+        - -c
+        - |
+          mkdir -p /www && \
+          cat > /www/index.html <<'HTML'
+          <!doctype html>
+          <html>
+            <head><meta charset="utf-8"><title>kukeon hello-world</title></head>
+            <body style="font-family: sans-serif">
+              <h1>Hello, world from kukeon!</h1>
+            </body>
+          </html>
+          HTML
+          exec busybox httpd -f -v -p 8080 -h /www
+```
+
+Apply it:
+
+```bash
+sudo kuke apply -f docs/examples/hello-world.yaml --no-daemon
+```
+
+!!! info "Why `--no-daemon` here"
+    The released `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`, so cell creation currently must run in-process via `--no-daemon`. This will change in a future release.
+
+Confirm the cell is ready, find its IP on the default-default bridge, and curl it:
+
+```bash
+sudo kuke get cells --realm default --space default --stack default
+
+ROOT_PID=$(sudo ctr -n kukeon.io task ls | awk '/hello-world_root/ {print $2}')
+CELL_IP=$(sudo nsenter -t "${ROOT_PID}" -n ip -4 -o addr show eth0 | awk '{print $4}' | cut -d/ -f1)
+curl http://${CELL_IP}:8080/
+```
+
+Tear it down with:
+
+```bash
+sudo kuke delete cell hello-world \
+    --realm default --space default --stack default --cascade --no-daemon
+```
+
+## 6. Enable shell autocomplete
+
+```bash
+cat >> ~/.bashrc <<EOF
+source <(kuke autocomplete bash)
+EOF
+```
+
+`kuke autocomplete zsh` and `kuke autocomplete fish` are also supported.
+
+## Where to go next
+
+- Understand what you just created: [Concepts → Overview](concepts/overview.md)
+- Dig into the resource model: [Manifest Reference](manifests/overview.md)
+- Learn the CLI: [CLI Reference → Commands](cli/commands.md)
+- Iterate on Kukeon from source: [Guides → Local development](guides/local-dev.md)

--- a/docs/site/guides/apply-manifests.md
+++ b/docs/site/guides/apply-manifests.md
@@ -1,0 +1,116 @@
+# Applying manifests
+
+`kuke apply` is the declarative interface: write a YAML file describing the resources you want, and Kukeon reconciles the host to match. It's the preferred way to create or update anything that isn't a one-off CLI operation.
+
+## The basics
+
+```bash
+sudo kuke apply -f my-cell.yaml
+```
+
+Accepts a single path, or `-` to read from stdin:
+
+```bash
+cat my-cell.yaml | sudo kuke apply -f -
+```
+
+The manifest can contain one or more resource documents separated by `---`:
+
+```yaml
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: blog
+spec:
+  realmId: main
+---
+apiVersion: v1beta1
+kind: Stack
+metadata:
+  name: wordpress
+spec:
+  id: wordpress
+  realmId: main
+  spaceId: blog
+---
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: wp
+spec:
+  id: wp
+  realmId: main
+  spaceId: blog
+  stackId: wordpress
+  containers:
+    - id: nginx
+      image: docker.io/library/nginx:alpine
+```
+
+`kuke apply` creates resources in dependency order — parents (realm → space → stack) before children (cell → container), regardless of the order they appear in the file.
+
+## What `apply` does
+
+Per resource, the outcome is one of:
+
+- `created` — the resource didn't exist; it was created.
+- `updated` — the resource existed but its spec differs; it was reconciled. Printed diffs follow.
+- `unchanged` — the desired state already matches; nothing to do.
+- `failed` — reconciliation failed; the error is printed. Processing continues for other resources, and the command exits non-zero at the end.
+
+Example output:
+
+```
+$ sudo kuke apply -f stack.yaml
+Space "blog": created
+Stack "wordpress": created
+Cell "wp": created
+```
+
+## Output formats
+
+```bash
+sudo kuke apply -f my-cell.yaml -o json
+sudo kuke apply -f my-cell.yaml -o yaml
+```
+
+With `-o json` or `-o yaml`, `apply` emits a structured report instead of the human-readable one.
+
+## Idempotence
+
+`apply` is idempotent: running the same manifest twice is safe. The second run should report `unchanged` for every resource.
+
+## Nesting and ordering
+
+Today, each resource is a separate document. There is no "apply an entire stack as one tree" mode — you write the stack, then the cells under it, either in the same multi-doc file or separately.
+
+Cross-file apply:
+
+```bash
+sudo kuke apply -f realm.yaml
+sudo kuke apply -f space.yaml
+sudo kuke apply -f stack.yaml
+sudo kuke apply -f cell.yaml
+```
+
+or multi-doc:
+
+```bash
+cat realm.yaml space.yaml stack.yaml cell.yaml | sudo kuke apply -f -
+```
+
+## `--no-daemon` caveat
+
+Today, cell creation runs under `--no-daemon` because the released `kukeond` image doesn't bind-mount the containerd socket. If you see `apply` hang or fail when creating a cell, retry with `--no-daemon`:
+
+```bash
+sudo kuke apply -f cell.yaml --no-daemon
+```
+
+See [Client and daemon](../concepts/client-and-daemon.md) for the broader story.
+
+## See also
+
+- [Manifest Reference](../manifests/overview.md) — the full schema of every resource
+- [CLI Reference → apply](../cli/kuke-apply.md) — every flag
+- [Tutorials → Hello-world cell](../tutorials/hello-world.md) — a worked example end-to-end

--- a/docs/site/guides/autocomplete.md
+++ b/docs/site/guides/autocomplete.md
@@ -1,0 +1,52 @@
+# Autocomplete
+
+`kuke` supports shell completion for bash, zsh, and fish. The completion script is generated on the fly by the binary.
+
+## bash
+
+```bash
+# One-time, for the current shell:
+source <(kuke autocomplete bash)
+
+# Persistent:
+cat >> ~/.bashrc <<'EOF'
+source <(kuke autocomplete bash)
+EOF
+```
+
+## zsh
+
+```bash
+# One-time, for the current shell:
+source <(kuke autocomplete zsh)
+
+# Persistent:
+cat >> ~/.zshrc <<'EOF'
+source <(kuke autocomplete zsh)
+EOF
+```
+
+!!! note "zsh `compinit`"
+    If your zsh setup doesn't already call `compinit`, you may need to add `autoload -U compinit && compinit` before the `source` line.
+
+## fish
+
+```bash
+# One-time, for the current shell:
+kuke autocomplete fish | source
+
+# Persistent:
+kuke autocomplete fish > ~/.config/fish/completions/kuke.fish
+```
+
+## What's completed
+
+- **Subcommand names** — `kuke <TAB>` completes to `init`, `get`, `create`, `apply`, `delete`, `start`, `stop`, `kill`, `purge`, `refresh`, `autocomplete`, `version`.
+- **Resource names** — `kuke get realm <TAB>`, `kuke delete space <TAB>`, etc. pull live names from the running daemon.
+- **`--realm`, `--space`, `--stack`, `--cell` flags** — complete against the set of resources that match the other flags you've already typed.
+
+Completion functions reach out to the daemon to list live resources, so autocomplete on a host where `kukeond` isn't running will return no suggestions (silently). That's expected.
+
+## One exception
+
+`kuke create realm <TAB>` deliberately does **not** complete to existing realm names. `create realm` is used to create new realms, so completing from the existing set would only ever offer the wrong answer. You type the new realm name.

--- a/docs/site/guides/init-and-reset.md
+++ b/docs/site/guides/init-and-reset.md
@@ -1,0 +1,112 @@
+# Init and reset
+
+This guide covers the operations you'll run most often when bootstrapping, iterating on, or wiping a Kukeon host.
+
+## Fresh bootstrap
+
+On a host that has never run Kukeon:
+
+```bash
+sudo kuke init
+```
+
+That command:
+
+1. Creates the kukeon cgroup root at `/sys/fs/cgroup/kukeon`.
+2. Ensures `/etc/cni/net.d` and `/opt/cni/bin` exist.
+3. Creates the default user realm (`default`, containerd namespace `kukeon-default`) and its default space and stack.
+4. Creates the system realm (`kukeon-system`) and the `kukeond` cell.
+5. Pulls the `kukeond` image.
+6. Starts the daemon; waits up to 30s for the socket to come up (unless you pass `--no-wait`).
+
+## Re-init (reconcile)
+
+`kuke init` is idempotent. Re-running it on a host that's already been bootstrapped reconciles state and reports `already existed` for the parts it finds on disk:
+
+```bash
+sudo kuke init
+# Kukeon runtime already initialized
+# ...
+```
+
+## Re-init after a generator fix
+
+Some bugs (most notably the CNI bridge-name length bug) fix themselves in new code but leave stale files on disk. To regenerate every space's conflist:
+
+```bash
+sudo kuke init --force-regenerate-cni
+```
+
+This rewrites every space's conflist, even the ones that already exist. It does not wipe anything else.
+
+## Tear down the daemon for iteration
+
+When you're hacking on `kukeond` and need to rebuild it, you want to stop the daemon without losing user data:
+
+```bash
+sudo kuke kill cell kukeond   --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+```
+
+Why `--no-daemon`: the daemon is what's being stopped, so `kuke` has to talk to containerd directly.
+
+User data under `/opt/kukeon/<realm>/...` (everything outside `kukeon-system`) is untouched.
+
+Rebuild and re-init:
+
+```bash
+make kuke
+docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
+sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+```
+
+See [Local development](local-dev.md) for the full dev loop.
+
+## Wipe a realm
+
+Cascaded delete removes the realm and everything under it (spaces, stacks, cells, containers, CNI conflists, cgroups, metadata):
+
+```bash
+sudo kuke delete realm mytenant --cascade
+```
+
+If that fails because something in the realm is in a weird state, `purge` is the more aggressive form:
+
+```bash
+sudo kuke purge realm mytenant --cascade --force
+```
+
+See [Manifest Reference](../manifests/overview.md) and [CLI Reference → delete](../cli/kuke-delete.md) / [purge](../cli/kuke-purge.md).
+
+## Full host wipe
+
+Nuclear option: remove every trace of Kukeon from the host. Use this only if you're reinstalling from scratch.
+
+```bash
+# 1. Stop the daemon (if running)
+sudo kuke kill cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon || true
+sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon || true
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+
+# 2. Purge every user realm
+for realm in $(sudo kuke get realms -o json --no-daemon | jq -r '.[] | select(.metadata.name != "kukeon-system") | .metadata.name'); do
+    sudo kuke purge realm "$realm" --cascade --force --no-daemon
+done
+
+# 3. Purge the system realm
+sudo kuke purge realm kukeon-system --cascade --force --no-daemon
+
+# 4. Wipe on-disk state and cgroups
+sudo rm -rf /opt/kukeon
+sudo rm -rf /sys/fs/cgroup/kukeon 2>/dev/null || true
+
+# 5. Wipe generated CNI conflists (careful: skip if you run other CNI apps)
+sudo rm -f /etc/cni/net.d/*.conflist
+```
+
+## Related
+
+- [Local development](local-dev.md) — the full rebuild / reload / re-init loop
+- [Troubleshooting](troubleshooting.md) — what to do when init fails

--- a/docs/site/guides/local-dev.md
+++ b/docs/site/guides/local-dev.md
@@ -1,0 +1,100 @@
+# Local development
+
+The full rebuild / reload / re-init loop for iterating on `kuke` and `kukeond` from source.
+
+## The loop in one shell
+
+After the first bootstrap, each iteration looks like this:
+
+```bash
+# 1. Stop and delete the current kukeond cell (user data is preserved)
+sudo kuke kill cell kukeond   --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+
+# 2. Rebuild the binary
+make kuke
+ln -sf kuke kukeond
+
+# 3. Rebuild the image and load it into the system namespace
+docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+docker save kukeon-local:dev | \
+    sudo ctr -n kuke-system.kukeon.io images import -
+
+# 4. Re-init pointing at the local image
+sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+```
+
+Everything in `/opt/kukeon/<user-realm>/...` is untouched; only the system cell is replaced.
+
+## First-time bootstrap
+
+On a host with no prior Kukeon state, the containerd namespace `kuke-system.kukeon.io` doesn't exist yet, which means `ctr images import` into it will silently no-op. You have two choices:
+
+**Option A — let `kuke init` create the namespace, then re-init against the local image:**
+
+```bash
+# Will fail to pull the default ghcr.io image without network access —
+# that's fine, we only care about the namespace being created.
+sudo ./kuke init || true
+
+# Now the namespace exists; import and re-init.
+docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
+sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+```
+
+**Option B — create the namespace by hand first:**
+
+```bash
+sudo ctr namespaces create kuke-system.kukeon.io
+docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
+sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+```
+
+## Make targets
+
+| Target         | What it does                                                 |
+|----------------|--------------------------------------------------------------|
+| `make kuke`    | Build the `kuke` binary (same binary is used as `kukeond`)    |
+| `make test`    | Run the Go unit test suite                                   |
+| `make e2e`     | Run end-to-end tests against a real containerd (requires root)|
+| `make lint`    | Run `golangci-lint` with the repo's config                   |
+
+## Running without the daemon
+
+When iterating on controller code you often don't need to put the daemon back up at all. `--no-daemon` runs every `kuke` command in-process against your freshly built binary:
+
+```bash
+sudo ./kuke get realms --no-daemon
+sudo ./kuke apply -f my-cell.yaml --no-daemon
+```
+
+This is the fastest feedback loop — no image build, no reload, just `make kuke` and go.
+
+## Debugging from an IDE
+
+`main.go` dispatches on `argv[0]`, which means running the binary from an IDE or `dlv` gives you an "unknown entry command" error (the binary is named something like `__debug_bin12345`). Set `KUKEON_DEBUG_MODE` to force a dispatch:
+
+```bash
+KUKEON_DEBUG_MODE=kuke    dlv exec ./__debug_bin -- get realms
+KUKEON_DEBUG_MODE=kukeond dlv exec ./__debug_bin -- serve
+```
+
+## Verifying daemon / no-daemon parity
+
+A useful regression check after touching the controller:
+
+```bash
+# Should be byte-identical
+diff <(sudo kuke get realms -o yaml) \
+     <(sudo kuke get realms -o yaml --no-daemon)
+```
+
+If they diverge, something is wrong with either the `kukeonv1` API surface or the daemon's bind-mount of the run path. See [Troubleshooting](troubleshooting.md).
+
+## Related
+
+- [Build from source](../install/build-from-source.md) — initial build + image instructions
+- [Init and reset](init-and-reset.md) — teardown variants

--- a/docs/site/guides/troubleshooting.md
+++ b/docs/site/guides/troubleshooting.md
@@ -1,0 +1,161 @@
+# Troubleshooting
+
+Common failure modes when bootstrapping or operating a Kukeon host, and what to do about them.
+
+## `kuke init` fails with "numerical result out of range"
+
+**Symptom.** On re-init after upgrading Kukeon, a cell attaches to its bridge and fails with:
+
+```
+failed to attach root container ... to network:
+plugin type="bridge" failed (add): failed to create bridge
+"kuke-...-...": could not add "...":
+numerical result out of range
+```
+
+**What it means.** `numerical result out of range` is the kernel's `ERANGE` error when an interface name exceeds 15 characters (`IFNAMSIZ - 1`). Older Kukeon versions didn't truncate long bridge names safely, so a stale CNI conflist on disk can pin a name that the current kernel rejects.
+
+**Fix.**
+
+```bash
+sudo kuke init --force-regenerate-cni
+```
+
+That rewrites every space's conflist with the current naming scheme. The daemon re-reads the regenerated file on the next operation.
+
+If that still doesn't clear it, the file on disk wasn't regenerated for some reason — delete it explicitly:
+
+```bash
+sudo rm /opt/kukeon/<realm>/<space>/network.conflist
+sudo rm /etc/cni/net.d/<realm>-<space>.conflist
+sudo kuke init
+```
+
+## "unknown entry command" when running the binary
+
+**Symptom.** Running the binary prints:
+
+```
+unknown entry command: __debug_bin12345
+```
+
+**What it means.** `cmd/main.go` dispatches on `argv[0]`, expecting `kuke` or `kukeond`. From an IDE or a debugger, the binary is renamed something else.
+
+**Fix.** Set `KUKEON_DEBUG_MODE`:
+
+```bash
+KUKEON_DEBUG_MODE=kuke    ./your-built-binary get realms
+KUKEON_DEBUG_MODE=kukeond ./your-built-binary serve
+```
+
+Or, install with the right hard link:
+
+```bash
+sudo install -m 0755 kuke /usr/local/bin/kuke
+sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
+```
+
+## `kuke init` can't find the kukeond image
+
+**Symptom.** `kuke init` fails at the "pull kukeond image" step, or the system cell stays in `Pending` because the image isn't in containerd.
+
+**Diagnosis.**
+
+```bash
+# The image should be listed here:
+sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon
+```
+
+If the list is empty and you just imported the image, you probably imported it into the wrong namespace. `ctr images import` **silently no-ops if the target namespace doesn't exist**, so:
+
+```bash
+# Create the namespace first
+sudo ctr namespaces create kuke-system.kukeon.io
+
+# Then import
+docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
+```
+
+## Daemon socket is missing or stale
+
+**Symptom.** `kuke` commands hang or fail with:
+
+```
+dial unix /run/kukeon/kukeond.sock: connect: no such file or directory
+```
+
+**Diagnosis.**
+
+```bash
+# Is the daemon cell running?
+sudo kuke get cells --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+
+# Is the socket actually on disk?
+ls -l /run/kukeon/
+```
+
+**Fix.** If the daemon cell is stopped, start it:
+
+```bash
+sudo kuke start cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+```
+
+If the socket exists but nothing responds, the daemon may have died while leaving the socket behind. Remove the stale socket and restart:
+
+```bash
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+sudo kuke kill cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon || true
+sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon || true
+sudo kuke init
+```
+
+## `kuke get` and `kuke get --no-daemon` disagree
+
+**Symptom.** The same `get` returns different data depending on whether it goes through the daemon or runs in-process.
+
+**What it means.** The `kukeond` container isn't bind-mounting `/opt/kukeon` (or `/run/kukeon`) correctly. Both code paths share a reconciler, so divergence is always about what the daemon can see on disk.
+
+**Fix.** Rebuild the daemon image with the correct mounts, reload, and re-init. See [Local development](local-dev.md).
+
+## `ctr` can see containers that `kuke` doesn't list
+
+`kuke get containers` filters by realm/space/stack/cell. If a container exists in `ctr -n kukeon-<realm>` but doesn't show up in `kuke get containers`, check:
+
+- The containerd namespace — is it really `kukeon-<realm>` for your realm? `spec.namespace` on the realm manifest can override.
+- The resource hierarchy — the container must have `realmId`, `spaceId`, `stackId`, `cellId` set correctly in its metadata. Containers created directly via `ctr` bypass Kukeon's metadata and won't be listed.
+
+## Leftover state after `delete`
+
+**Symptom.** `kuke delete cell foo --cascade` finishes, but you still see cgroups or network interfaces hanging around.
+
+**Fix.** Use `kuke purge` instead — it's the more aggressive form that force-removes residual state:
+
+```bash
+sudo kuke purge cell foo --cascade --force --realm ... --space ... --stack ...
+```
+
+If that still doesn't clear everything, the tail end is usually:
+
+```bash
+# Dangling cgroup
+sudo rmdir /sys/fs/cgroup/kukeon/<realm>/<space>/<stack>/<cell> 2>/dev/null || true
+
+# Dangling bridge (only if the space is gone too)
+sudo ip link delete kuke-<realm>-<space> 2>/dev/null || true
+```
+
+## Verbose logging
+
+Add `--verbose` (or `-v`) to any `kuke` command to get structured slog output on stderr. Pair with `--log-level debug` for the most detail:
+
+```bash
+sudo kuke init --verbose --log-level debug
+```
+
+The daemon's log level is set separately via `kukeond --log-level` in the cell spec.
+
+## When all else fails
+
+- The full runtime state lives in `/opt/kukeon` (persistent), `/run/kukeon` (tmpfs), `/sys/fs/cgroup/kukeon` (runtime), `/etc/cni/net.d/*.conflist` (cache), and containerd namespaces `kukeon-<realm>`. Those are the only places Kukeon writes state.
+- The "nuclear reset" sequence is in [Init and reset → Full host wipe](init-and-reset.md#full-host-wipe).
+- Bug reports and questions welcome at [github.com/eminwux/kukeon/issues](https://github.com/eminwux/kukeon/issues).

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,0 +1,97 @@
+# kukeon: A Lightweight Container Orchestrator
+
+![status: active](https://img.shields.io/badge/status-active-blue)
+![state: alpha](https://img.shields.io/badge/state-alpha-orange)
+![license: apache2](https://img.shields.io/badge/license-Apache%202.0-green)
+
+_Structured container environments on a single machine._
+
+Kukeon is a local-first, containerd-native orchestrator that sits between Docker and Kubernetes. It provides structure, networking, isolation, and lifecycle management for containers without the complexity of running a full cluster.
+
+!!! warning "Alpha software"
+    This project is under active development and not production ready. Interfaces and APIs may change.
+
+At its core is `kukeond`, a small daemon that manages containerd, CNI networks, namespaces, and cgroups, and exposes a simple API. The `kuke` CLI and the future Web UI act as thin clients.
+
+## Why kukeon
+
+Docker is simple but unstructured: everything lives in a flat list. Kubernetes is structured but heavy: you pay for a control plane whether you need one or not. Kukeon aims for the middle — a single, explicit hierarchy with strong isolation primitives and nothing else to operate.
+
+- **Reproducible** — declarative YAML manifests describe every resource
+- **Structured** — Realm → Space → Stack → Cell → Container makes intent explicit
+- **Isolated** — each layer is backed by real Linux primitives (containerd namespaces, CNI networks, cgroups)
+- **Local-first** — no cluster, no etcd, no scheduler. It runs on one host
+- **Transparent** — inspect what the daemon did with `ctr`, `ip link`, `ls /sys/fs/cgroup`
+
+You can think of it as:
+
+> Proxmox for containers
+>
+> or
+>
+> A small Heroku that runs locally
+
+## Core hierarchy
+
+Kukeon defines a clear hierarchical model:
+
+```mermaid
+flowchart LR
+    Realm --> Space --> Stack --> Cell --> Container
+```
+
+- **Realm** — high-level environment mapped to a containerd namespace
+- **Space** — CNI network and cgroup subtree that define isolation
+- **Stack** — logical grouping of related cells
+- **Cell** — a pod-like group; one root container owns the network namespace
+- **Container** — an OCI container running inside the cell
+
+Each level is a real Linux primitive, not an invented abstraction. See [Concepts → Overview](concepts/overview.md) for the full picture.
+
+## Quick start
+
+```bash
+# Install the binary (CLI also dispatches as kukeond based on argv[0])
+export OS=linux
+export ARCH=amd64
+curl -L -o kuke https://github.com/eminwux/kukeon/releases/download/v0.1.0/kuke-${OS}-${ARCH} && \
+  chmod +x kuke && \
+  sudo install -m 0755 kuke /usr/local/bin/kuke && \
+  sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
+
+# Bootstrap the runtime (creates realms, spaces, stacks, CNI config, and starts kukeond)
+sudo kuke init
+
+# List what was created
+sudo kuke get realms
+```
+
+See [Getting Started](getting-started.md) for a walk-through, or jump directly to the [Hello-world tutorial](tutorials/hello-world.md).
+
+## Documentation
+
+- **[Getting Started](getting-started.md)** — install and bootstrap a host
+- **[Concepts](concepts/overview.md)** — the full hierarchy and what each layer maps to on Linux
+- **[Architecture](architecture/overview.md)** — how `kuke`, `kukeond`, containerd, and CNI fit together
+- **[Guides](guides/init-and-reset.md)** — task-oriented how-tos
+- **[CLI Reference](cli/commands.md)** — every command and flag
+- **[Manifest Reference](manifests/overview.md)** — the v1beta1 resource schemas
+- **[Tutorials](tutorials/hello-world.md)** — step-by-step examples
+
+## Philosophy
+
+> «καὶ ὁ κυκεὼν διίσταται μὴ κινούμενος»
+>
+> “The barley-drink separates if it isn't stirred”
+>
+> — Fragment DK 22B125, Heraclitus, circa 500 BC
+
+Heraclitus used the kykeon, a simple barley drink, as an analogy for the logos — the hidden principle of order in the cosmos. The drink becomes itself only when its ingredients are mixed and kept in motion.
+
+Kukeon applies the same metaphor to computing: containers, networks, and cgroups are the ingredients; `kukeond` is the stirring motion that brings them together; the running system is the order that emerges through interaction.
+
+## License
+
+Apache License 2.0
+
+© 2025 Emiliano Spinella (eminwux)

--- a/docs/site/install/build-from-source.md
+++ b/docs/site/install/build-from-source.md
@@ -1,0 +1,90 @@
+# Build from source
+
+Building `kuke` and `kukeond` from a local checkout is the normal workflow when contributing to Kukeon or iterating on the daemon.
+
+## Requirements
+
+- Go (see `go.mod` for the required version)
+- `make`
+- `docker` (only needed when you want to rebuild the `kukeond` container image)
+- `ctr` (shipped with containerd)
+
+## Build the binaries
+
+```bash
+git clone https://github.com/eminwux/kukeon.git
+cd kukeon
+
+# Build kuke. The daemon binary is the same binary argv[0]-dispatched, so we
+# link kukeond to kuke after the build.
+rm -f kuke kukeond
+make kuke
+ln -sf kuke kukeond
+```
+
+`make kuke` writes the binary into the repository root.
+
+## Run against a local binary
+
+For one-off tests you can run the binaries from the checkout:
+
+```bash
+sudo ./kuke init
+sudo ./kuke get realms
+```
+
+## Rebuild the kukeond container image
+
+`kuke init` bootstraps a `kukeond` cell from a container image. For iterating locally, you can build the image, load it into the right containerd namespace, and point `init` at it.
+
+!!! warning "Namespace must exist before `ctr images import`"
+    `ctr images import` needs the target namespace to already exist; otherwise the import succeeds silently but nothing lands in the namespace, and the next `kuke init` will fail to find the image.
+
+```bash
+# 1. Create the kuke-system containerd namespace (either by running kuke init
+#    once, or explicitly):
+sudo ctr namespaces create kuke-system.kukeon.io
+
+# 2. Build the container image. VERSION only affects the embedded kuke --version string.
+docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+
+# 3. Load it into the kuke-system namespace.
+docker save kukeon-local:dev | \
+    sudo ctr -n kuke-system.kukeon.io images import -
+
+# 4. Verify.
+sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
+
+# 5. Bootstrap against the local image.
+sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+```
+
+## Iterate on the daemon
+
+To iterate after a code change, tear down the kukeond cell (user data under `/opt/kukeon/default/**` is left intact) and rebuild:
+
+```bash
+sudo kuke kill cell kukeond \
+    --realm kuke-system --space kukeon --stack kukeon --no-daemon
+sudo kuke delete cell kukeond \
+    --realm kuke-system --space kukeon --stack kukeon --no-daemon
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+
+# Rebuild, reload, re-init
+make kuke
+docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
+sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+```
+
+See [Guides → Local development](../guides/local-dev.md) for the full dev loop.
+
+## Tests
+
+```bash
+# Unit tests
+go test ./...
+
+# End-to-end tests (require containerd, root, and a disposable host)
+make e2e
+```

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -1,0 +1,52 @@
+# Install on Linux
+
+Kukeon ships a single static binary per platform. The same binary behaves as `kuke` (the CLI) or `kukeond` (the daemon) depending on the name it is invoked under. You install the binary once and create a hard link for the second name.
+
+## From a release
+
+```bash
+# Pick your platform
+export OS=linux             # Options: linux
+export ARCH=amd64           # Options: amd64, arm64
+
+# Download, install, and link
+curl -L -o kuke https://github.com/eminwux/kukeon/releases/download/v0.1.0/kuke-${OS}-${ARCH}
+chmod +x kuke
+sudo install -m 0755 kuke /usr/local/bin/kuke
+sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
+```
+
+The hard link is required: `main.go` dispatches to `kuke` or `kukeond` by looking at `argv[0]` (see [Architecture → Process Model](../architecture/process-model.md)). Running `kuke kukeond …` does **not** enter the daemon tree.
+
+## Verify the install
+
+```bash
+$ kuke version
+v0.1.0
+
+$ kukeond --help
+Kukeon daemon: hosts the kukeonv1 API over a unix socket
+...
+```
+
+## Uninstall
+
+```bash
+sudo rm -f /usr/local/bin/kuke /usr/local/bin/kukeond
+```
+
+If you want to wipe runtime state too, stop anything still running and remove the run path:
+
+```bash
+sudo kuke kill cell kukeond --realm kuke-system --space kukeon --stack kukeon --no-daemon || true
+sudo kuke delete cell kukeond --realm kuke-system --space kukeon --stack kukeon --no-daemon || true
+sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+sudo rm -rf /opt/kukeon
+```
+
+The `/etc/cni/net.d/*.conflist` files Kukeon generated can be removed too if you are not using CNI for anything else; if other tools on the host use CNI, inspect the files first.
+
+## Next
+
+- [Getting Started](../getting-started.md) — bootstrap the runtime
+- [Build from source](build-from-source.md) — compile `kuke` / `kukeond` from a local checkout

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -1,0 +1,86 @@
+# Prerequisites
+
+Kukeon runs on a single Linux host and relies on three things being present before you install the binary:
+
+1. A kernel with **cgroups v2** enabled
+2. A running **containerd** daemon
+3. The **CNI reference plugins**
+
+## Linux with cgroups v2
+
+Kukeon creates its own cgroup subtree rooted at `/kukeon`. That subtree lives under the host's cgroup v2 hierarchy (typically mounted at `/sys/fs/cgroup`).
+
+Check that cgroups v2 is the unified hierarchy:
+
+```bash
+$ mount | grep cgroup2
+cgroup2 on /sys/fs/cgroup type cgroup2 (...)
+```
+
+If you see `cgroup` (v1) instead, enable the unified hierarchy with `systemd.unified_cgroup_hierarchy=1` on the kernel command line and reboot.
+
+## containerd
+
+Kukeon talks to containerd over its default socket at `/run/containerd/containerd.sock`. The path is configurable via `--containerd-socket` on both `kuke` and `kukeond`, but the default works for a stock containerd install on Debian/Ubuntu/Fedora/Arch.
+
+```bash
+# Debian/Ubuntu
+sudo apt-get install -y containerd
+
+# Fedora
+sudo dnf install -y containerd
+
+# Arch
+sudo pacman -S containerd
+
+# Verify
+sudo systemctl enable --now containerd
+sudo ctr version
+```
+
+Kukeon uses its own containerd namespaces (one per realm: `kukeon-<realm>`). It does not interfere with existing containerd namespaces used by Docker, nerdctl, or other tools.
+
+## CNI plugins
+
+Kukeon's spaces map to CNI networks; it invokes the reference bridge plugin to set them up. The plugins need to live in `/opt/cni/bin` (configurable via the space spec, but the default is the standard CNI layout).
+
+Install the latest release from [containernetworking/plugins](https://github.com/containernetworking/plugins):
+
+```bash
+CNI_VERSION=v1.4.1
+sudo mkdir -p /opt/cni/bin
+curl -L https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz \
+  | sudo tar -C /opt/cni/bin -xz
+```
+
+Verify:
+
+```bash
+$ ls /opt/cni/bin
+bandwidth  bridge  dhcp  firewall  host-device  host-local  ipvlan  ...
+```
+
+At minimum Kukeon needs `bridge`, `host-local`, `loopback`, and `portmap`.
+
+## Root / privileges
+
+`kuke init`, `kuke apply`, and any command touching cgroups, netlink, or containerd namespaces needs root (or equivalent capabilities: `CAP_SYS_ADMIN`, `CAP_NET_ADMIN`, access to the containerd socket, write access to `/sys/fs/cgroup` and `/opt/kukeon`). For now, the working assumption is "run as root" (`sudo kuke ...`).
+
+Running `kuke get` for read-only queries over the daemon socket does not require root, as long as the user can read the socket at `/run/kukeon/kukeond.sock`.
+
+## Disk paths kukeon touches
+
+| Path | Purpose |
+|------|---------|
+| `/opt/kukeon` | Default run path. Stores per-realm/space/stack metadata and runtime state. Configurable via `--run-path`. |
+| `/run/kukeon/kukeond.sock` | Default daemon socket. Configurable via `--socket` (kukeond) and `--host` (kuke). |
+| `/run/kukeon/kukeond.pid` | Daemon PID file. |
+| `/etc/cni/net.d` | Generated CNI conflists for each space. |
+| `/sys/fs/cgroup/kukeon/...` | Kukeon's cgroup subtree. |
+
+Nothing is written outside those paths without an explicit flag.
+
+## Next
+
+- [Install on Linux](install-linux.md) — download the release binary
+- [Build from source](build-from-source.md) — compile and run a locally built `kuke` / `kukeond`

--- a/docs/site/manifests/cell.md
+++ b/docs/site/manifests/cell.md
@@ -1,0 +1,81 @@
+# Cell manifest
+
+```yaml
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: hello-world
+  labels: {}
+spec:
+  id: hello-world
+  realmId: default
+  spaceId: default
+  stackId: default
+  rootContainerId: web       # optional; defaults to the first container
+  containers:
+    - id: web
+      image: docker.io/library/busybox:latest
+      command: /bin/sh
+      args:
+        - -c
+        - "exec busybox httpd -f -v -p 8080 -h /www"
+status:
+  state: Ready
+  cgroupPath: /kukeon/default/default/default/hello-world
+  containers:
+    - id: web
+      state: Ready
+      ...
+```
+
+See [Concepts → Cell](../concepts/cell.md) for what a cell is.
+
+## spec
+
+| Field              | Type     | Required | Description                                                                              |
+|--------------------|----------|----------|------------------------------------------------------------------------------------------|
+| `id`               | string   | yes      | Cell identifier (matches `metadata.name`)                                                |
+| `realmId`          | string   | yes      | Realm that owns the cell                                                                 |
+| `spaceId`          | string   | yes      | Space that owns the cell                                                                 |
+| `stackId`          | string   | yes      | Stack that owns the cell                                                                 |
+| `rootContainerId`  | string   | no       | Identifier of the container that owns the cell's network namespace. Defaults to the first container in `containers` if unset. |
+| `containers`       | array    | yes      | Container specs (see [Container manifest](container.md) for fields)                      |
+
+### The root container
+
+Exactly one container in the cell must be the root — it owns the network namespace, and every other container joins it.
+
+- If `rootContainerId` is set, that container is the root. Its `spec.root` field (if present) is implied.
+- If `rootContainerId` is empty, the container with `spec.root: true` is used.
+- If neither is set, the first container in `containers` is the root.
+
+## status
+
+| Field         | Type                                                       | Description                                 |
+|---------------|------------------------------------------------------------|---------------------------------------------|
+| `state`       | `Pending`, `Ready`, `Stopped`, `Failed`, `Unknown`         | Lifecycle state                             |
+| `cgroupPath`  | string                                                     | Absolute cgroup path                        |
+| `containers`  | array of `ContainerStatus`                                 | Per-container status snapshot               |
+
+## Minimal
+
+```yaml
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: hello-world
+spec:
+  id: hello-world
+  realmId: default
+  spaceId: default
+  stackId: default
+  containers:
+    - id: web
+      image: docker.io/library/busybox:latest
+      command: /bin/sh
+      args:
+        - -c
+        - "exec busybox httpd -f -v -p 8080 -h /www"
+```
+
+See [Tutorials → Hello-world cell](../tutorials/hello-world.md) for a complete worked example.

--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -1,0 +1,95 @@
+# Container manifest
+
+A container is normally declared as part of a cell's `spec.containers`, not as a top-level resource. The standalone shape still exists for CLI-level operations (`kuke get container …`).
+
+```yaml
+apiVersion: v1beta1
+kind: Container
+metadata:
+  name: web
+  labels: {}
+spec:
+  id: web
+  realmId: main
+  spaceId: default
+  stackId: default
+  cellId: hello-world
+  root: true
+  image: docker.io/library/nginx:alpine
+  command: /bin/sh
+  args:
+    - -c
+    - "exec nginx -g 'daemon off;'"
+  env:
+    - "NGINX_HOST=example.com"
+  ports: []
+  volumes: []
+  networks: []
+  networksAliases: []
+  privileged: false
+  cniConfigPath: ""
+  restartPolicy: ""
+status:
+  state: Ready
+  startTime: "2026-04-21T12:00:00Z"
+  finishTime: "0001-01-01T00:00:00Z"
+  exitCode: 0
+  restartCount: 0
+  ...
+```
+
+See [Concepts → Container](../concepts/container.md) for what a container is.
+
+## spec
+
+| Field              | Type             | Required | Description                                                                             |
+|--------------------|------------------|----------|-----------------------------------------------------------------------------------------|
+| `id`               | string           | yes      | Container identifier (matches `metadata.name`)                                          |
+| `containerdId`     | string           | no       | Populated by Kukeon with the containerd-level container id                              |
+| `realmId`          | string           | yes      | Realm that owns the container                                                           |
+| `spaceId`          | string           | yes      | Space that owns the container                                                           |
+| `stackId`          | string           | yes      | Stack that owns the container                                                           |
+| `cellId`           | string           | yes      | Cell that owns the container                                                            |
+| `root`             | bool             | no       | Mark this as the cell's root container (owns the network namespace)                     |
+| `image`            | string           | yes      | OCI image reference. Kukeon passes this to containerd's image pull.                     |
+| `command`          | string           | no       | Command to run. If omitted, the image's `ENTRYPOINT` is used.                           |
+| `args`             | array of string  | no       | Arguments. Combined with `command`.                                                     |
+| `env`              | array of string  | no       | `KEY=VALUE` environment variables                                                       |
+| `ports`            | array of string  | no       | Reserved — port mapping semantics are not finalized                                     |
+| `volumes`          | array of string  | no       | Reserved — volume mount semantics are not finalized                                     |
+| `networks`         | array of string  | no       | Additional CNI networks to join beyond the cell's default                               |
+| `networksAliases`  | array of string  | no       | DNS aliases for the container within its CNI networks                                   |
+| `privileged`       | bool             | no       | Run privileged (full capabilities, access to `/dev`, etc.)                              |
+| `cniConfigPath`    | string           | no       | Override the CNI config directory for this container                                    |
+| `restartPolicy`    | string           | no       | Restart policy. Reserved — restart semantics are not finalized.                         |
+
+!!! warning "Fields marked reserved"
+    `ports`, `volumes`, and `restartPolicy` are accepted by the schema today but their semantics are still being designed. Values round-trip (you can read back what you applied), but the controller does not act on them. See [ROADMAP.md](https://github.com/eminwux/kukeon/blob/main/ROADMAP.md) for the backlog.
+
+## status
+
+| Field         | Type                                                                             | Description                                |
+|---------------|----------------------------------------------------------------------------------|--------------------------------------------|
+| `name`        | string                                                                           | Matches `metadata.name`                    |
+| `id`          | string                                                                           | Containerd container id                    |
+| `state`       | `Pending`, `Ready`, `Stopped`, `Paused`, `Pausing`, `Failed`, `Unknown`          | Lifecycle state                            |
+| `restartCount`| int                                                                              | Times the container has restarted          |
+| `restartTime` | RFC3339 timestamp                                                                | Last restart                               |
+| `startTime`   | RFC3339 timestamp                                                                | Current (or last) start                    |
+| `finishTime`  | RFC3339 timestamp                                                                | When the task exited (zero-value if still running) |
+| `exitCode`    | int                                                                              | Exit code of the last run (0 if still running) |
+| `exitSignal`  | string                                                                           | Signal that terminated the task, if any    |
+
+## Minimal (embedded in a cell)
+
+```yaml
+containers:
+  - id: web
+    image: docker.io/library/busybox:latest
+    command: /bin/sh
+    args:
+      - -c
+      - "echo hello && sleep 3600"
+```
+
+Only `id` and `image` are strictly required when embedded inside a cell — the `realmId`, `spaceId`, `stackId`, and `cellId` are inherited from the parent cell's spec.

--- a/docs/site/manifests/overview.md
+++ b/docs/site/manifests/overview.md
@@ -1,0 +1,69 @@
+# Manifest reference
+
+Every resource in Kukeon has a YAML schema. All manifests share the same shape:
+
+```yaml
+apiVersion: v1beta1
+kind: <Realm|Space|Stack|Cell|Container>
+metadata:
+  name: <string>
+  labels:
+    key: value
+spec:
+  # kind-specific fields
+status:
+  # filled in by kukeon; read-only on write
+```
+
+## Supported versions
+
+Only `v1beta1` is currently defined. See [Architecture → API versioning](../architecture/api-versioning.md) for how Kukeon decouples the on-wire schema from internal types, which lets new versions coexist when they ship.
+
+## Kinds
+
+- [Realm](realm.md) — tenant boundary
+- [Space](space.md) — CNI network + cgroup
+- [Stack](stack.md) — logical group of cells
+- [Cell](cell.md) — pod-like group of containers
+- [Container](container.md) — OCI container
+
+## Common fields
+
+### `metadata.name`
+
+Required, string. Unique within its parent. The name is also what you use as `realmId`, `spaceId`, `stackId`, or `cellId` in child resources.
+
+### `metadata.labels`
+
+Optional, map of string to string. Arbitrary key-value metadata. Not used by any Kukeon logic today; labels are preserved on round-trip.
+
+### `status.state`
+
+Read-only. Managed by Kukeon. Takes one of:
+
+- `Pending` — created, not yet reconciled
+- `Creating` — provisioning underway
+- `Ready` / `Running` — fully reconciled
+- `Stopped` — terminal, was running, now exited
+- `Paused` / `Pausing` — frozen via cgroup
+- `Failed` — reconciliation or runtime failure
+- `Deleting` — being torn down
+- `Unknown` — the daemon cannot determine the state
+
+Not every state is valid for every kind; see each kind's page for the exact set.
+
+### `status.cgroupPath`
+
+Read-only. Populated by Kukeon with the absolute cgroup path of the resource (e.g., `/kukeon/main/default`). Useful for quickly locating the resource in `/sys/fs/cgroup`.
+
+## Applying manifests
+
+```bash
+sudo kuke apply -f <file>
+```
+
+See [kuke apply](../cli/kuke-apply.md) for the full shape of the command.
+
+## Round-trip safety
+
+What goes in as YAML comes out as YAML. Kukeon normalizes `apiVersion`, populates defaults, and sets `status.*`, but otherwise preserves the manifest you applied. You can `kuke get -o yaml` and re-`apply` without losing fields.

--- a/docs/site/manifests/realm.md
+++ b/docs/site/manifests/realm.md
@@ -1,0 +1,65 @@
+# Realm manifest
+
+```yaml
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: main
+  labels: {}
+spec:
+  namespace: kukeon-main
+  registryCredentials:
+    - username: myuser
+      password: mypass
+      serverAddress: registry.example.com
+status:
+  state: Ready
+  cgroupPath: /kukeon/main
+```
+
+See [Concepts → Realm](../concepts/realm.md) for what a realm is.
+
+## spec
+
+### `spec.namespace` (string, optional)
+
+The containerd namespace this realm uses for its images, containers, and tasks. Defaults to the realm's name; override when you need a namespace that differs from the realm name (e.g., for historical compatibility with `kuke-system.kukeon.io`).
+
+### `spec.registryCredentials` (array, optional)
+
+Authentication for image registries. Scoped to the realm — two realms can use different credentials for the same registry.
+
+| Field           | Type   | Required | Description                                                                                     |
+|-----------------|--------|----------|-------------------------------------------------------------------------------------------------|
+| `username`      | string | yes      | Registry username                                                                              |
+| `password`      | string | yes      | Registry password or token                                                                     |
+| `serverAddress` | string | no       | Registry server (e.g., `docker.io`, `ghcr.io`). If omitted, applies to the registry in the image reference. |
+
+```yaml
+spec:
+  registryCredentials:
+    - username: eminwux
+      password: ${{ GHCR_TOKEN }}
+      serverAddress: ghcr.io
+```
+
+## status
+
+| Field         | Type                              | Description                                             |
+|---------------|-----------------------------------|---------------------------------------------------------|
+| `state`       | `Pending`, `Creating`, `Ready`, `Deleting`, `Failed`, `Unknown` | Lifecycle state |
+| `cgroupPath`  | string                            | Absolute cgroup path: `/kukeon/<realm>`                 |
+
+`status` is populated by Kukeon; anything you set when applying is overwritten on reconcile.
+
+## Minimal
+
+```yaml
+apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: mytenant
+spec: {}
+```
+
+Equivalent to `sudo kuke create realm mytenant` — Kukeon fills in `spec.namespace` from the name.

--- a/docs/site/manifests/space.md
+++ b/docs/site/manifests/space.md
@@ -1,0 +1,51 @@
+# Space manifest
+
+```yaml
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: default
+  labels: {}
+spec:
+  realmId: main
+  cniConfigPath: /etc/cni/net.d
+status:
+  state: Ready
+  cgroupPath: /kukeon/main/default
+```
+
+See [Concepts → Space](../concepts/space.md) for what a space is.
+
+## spec
+
+### `spec.realmId` (string, required)
+
+The realm that owns this space. Matches the realm's `metadata.name`.
+
+### `spec.cniConfigPath` (string, optional)
+
+Directory where Kukeon writes this space's CNI conflist. Defaults to the system CNI config directory (`/etc/cni/net.d`). Override when you want per-space conflist isolation.
+
+## status
+
+| Field         | Type                           | Description                                            |
+|---------------|--------------------------------|--------------------------------------------------------|
+| `state`       | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                               |
+| `cgroupPath`  | string                         | Absolute cgroup path: `/kukeon/<realm>/<space>`        |
+
+## Bridge naming
+
+The Linux bridge that backs the space is derived from `<realm>-<space>`, truncated safely to fit the 15-character `IFNAMSIZ` limit. The space manifest does not expose a `bridgeName` field today — Kukeon picks the name and records it in the generated conflist. See [Concepts → Networking](../concepts/networking.md).
+
+## Minimal
+
+```yaml
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: blog
+spec:
+  realmId: main
+```
+
+Equivalent to `sudo kuke create space blog --realm main`.

--- a/docs/site/manifests/stack.md
+++ b/docs/site/manifests/stack.md
@@ -1,0 +1,51 @@
+# Stack manifest
+
+```yaml
+apiVersion: v1beta1
+kind: Stack
+metadata:
+  name: wordpress
+  labels: {}
+spec:
+  id: wordpress
+  realmId: main
+  spaceId: blog
+status:
+  state: Ready
+  cgroupPath: /kukeon/main/blog/wordpress
+```
+
+See [Concepts → Stack](../concepts/stack.md) for what a stack is.
+
+## spec
+
+| Field       | Type   | Required | Description                                 |
+|-------------|--------|----------|---------------------------------------------|
+| `id`        | string | yes      | Stack identifier (matches `metadata.name`)  |
+| `realmId`   | string | yes      | Realm that owns the stack                   |
+| `spaceId`   | string | yes      | Space that owns the stack                   |
+
+!!! note "`id` vs. `metadata.name`"
+    Today the stack schema requires both `metadata.name` and `spec.id`, and they should be the same value. The duplication is historical and will be removed in a future version.
+
+## status
+
+| Field         | Type                           | Description                                                 |
+|---------------|--------------------------------|-------------------------------------------------------------|
+| `state`       | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                                    |
+| `cgroupPath`  | string                         | Absolute cgroup path: `/kukeon/<realm>/<space>/<stack>`     |
+
+## Minimal
+
+```yaml
+apiVersion: v1beta1
+kind: Stack
+metadata:
+  name: wordpress
+spec:
+  id: wordpress
+  realmId: main
+  spaceId: blog
+```
+
+Equivalent to `sudo kuke create stack wordpress --realm main --space blog`.

--- a/docs/site/tutorials/first-stack.md
+++ b/docs/site/tutorials/first-stack.md
@@ -1,0 +1,125 @@
+# Tutorial: build your first stack
+
+Goes one level up from the [Hello-world cell](hello-world.md) tutorial: you'll build a stack with two cells in the same space, and see that they can reach each other over the bridge.
+
+## Goal
+
+Two cells, one stack:
+
+- **`web`** — an nginx container, serves HTTP.
+- **`client`** — a busybox container that `wget`s the web cell.
+
+Both cells live in one stack (`demo`) inside one space (`tutorial`) inside the default user realm.
+
+```
+Realm: default
+└── Space: tutorial           (new)
+    └── Stack: demo           (new)
+        ├── Cell: web         (nginx)
+        └── Cell: client      (busybox + wget)
+```
+
+## 1. Write the manifest
+
+Save this as `tutorial.yaml`:
+
+```yaml
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: tutorial
+spec:
+  realmId: default
+---
+apiVersion: v1beta1
+kind: Stack
+metadata:
+  name: demo
+spec:
+  id: demo
+  realmId: default
+  spaceId: tutorial
+---
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: web
+spec:
+  id: web
+  realmId: default
+  spaceId: tutorial
+  stackId: demo
+  containers:
+    - id: nginx
+      image: docker.io/library/nginx:alpine
+---
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: client
+spec:
+  id: client
+  realmId: default
+  spaceId: tutorial
+  stackId: demo
+  containers:
+    - id: wget
+      image: docker.io/library/busybox:latest
+      command: /bin/sh
+      args:
+        - -c
+        - "while true; do wget -qO- http://web 2>/dev/null || true; sleep 5; done"
+```
+
+## 2. Apply it
+
+```bash
+sudo kuke apply -f tutorial.yaml --no-daemon
+```
+
+Kukeon creates the space, stack, and two cells in dependency order. The nginx cell gets one IP on the `tutorial` space's bridge; the busybox cell gets another.
+
+## 3. Check the network
+
+Each cell has its own IP on the same bridge (`kuke-default-tutorial` or similar — it was truncated to fit the 15-char kernel limit):
+
+```bash
+$ ip -4 addr show type bridge | grep kuke
+<n>: kuke-default-tu: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
+    inet 10.88.0.1/16 ...
+```
+
+## 4. Watch the client hit the web cell
+
+The client's busybox is in a loop. Attach to its task:
+
+```bash
+sudo ctr -n kukeon-default tasks attach client_wget
+```
+
+You should see nginx's default HTML stream by every 5 seconds. Press `Ctrl-C` to detach from the task without killing it.
+
+!!! note "Reaching `web` by name"
+    In this example `wget http://web` works because the space's bridge has a resolver, and the `web` cell's root container registers itself by name. If your space has DNS turned off, you can replace the URL with the cell IP (find it via `kuke get cells --realm default --space tutorial --stack demo -o yaml` and look under `status.containers[].ip`).
+
+## 5. Tear it down
+
+```bash
+# Cascade-delete the whole stack (both cells and their containers)
+sudo kuke delete stack demo --realm default --space tutorial --cascade --no-daemon
+
+# Then the space (if you're done with it)
+sudo kuke delete space tutorial --realm default --cascade --no-daemon
+```
+
+## What you just learned
+
+- Multi-document YAML gets applied in dependency order, so one file can describe an entire stack.
+- Cells in the same space share a bridge — they can reach each other at the IP layer.
+- `delete --cascade` reliably removes a whole subtree without leaving orphans.
+
+## Next
+
+- [Manifest reference](../manifests/overview.md) — every field of every resource.
+- [CLI reference](../cli/commands.md) — the full `kuke` surface.
+- [Networking](../concepts/networking.md) — how the bridge-per-space model works.

--- a/docs/site/tutorials/hello-world.md
+++ b/docs/site/tutorials/hello-world.md
@@ -1,0 +1,103 @@
+# Tutorial: hello-world cell
+
+Walks through running a minimal cell that serves a static HTML page over HTTP, using the `hello-world.yaml` example in the repo.
+
+## Prerequisites
+
+- Kukeon installed and bootstrapped — see [Getting Started](../getting-started.md).
+- `curl` on the host, for the verification step.
+
+## 1. Inspect the manifest
+
+The example lives at [`docs/examples/hello-world.yaml`](https://github.com/eminwux/kukeon/blob/main/docs/examples/hello-world.yaml):
+
+```yaml
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: hello-world
+spec:
+  id: hello-world
+  realmId: default
+  spaceId: default
+  stackId: default
+  containers:
+    - id: web
+      image: docker.io/library/busybox:latest
+      command: /bin/sh
+      args:
+        - -c
+        - |
+          mkdir -p /www && \
+          cat > /www/index.html <<'HTML'
+          <!doctype html>
+          <html>
+            <head><meta charset="utf-8"><title>kukeon hello-world</title></head>
+            <body style="font-family: sans-serif">
+              <h1>Hello, world from kukeon!</h1>
+              <p>Served by busybox httpd inside a cell in the <code>default</code> realm.</p>
+            </body>
+          </html>
+          HTML
+          exec busybox httpd -f -v -p 8080 -h /www
+```
+
+It's a single cell with a single container. The container bootstraps an `index.html` into a scratch dir, then executes `busybox httpd` bound to `:8080`. Because there's only one container, it's implicitly the root container and owns the cell's network namespace.
+
+## 2. Apply it
+
+```bash
+sudo kuke apply -f docs/examples/hello-world.yaml --no-daemon
+```
+
+`--no-daemon` is required today because the released daemon container image doesn't bind-mount the containerd socket. See [Client and daemon](../concepts/client-and-daemon.md).
+
+## 3. Confirm the cell is Ready
+
+```bash
+$ sudo kuke get cells --realm default --space default --stack default
+NAME         REALM    SPACE    STACK    STATE   ...
+hello-world  default  default  default  Ready
+```
+
+If it's still `Pending`, give it a second and re-run. If it's `Failed`, check the container's log via `ctr`:
+
+```bash
+sudo ctr -n kukeon-default tasks attach hello-world_web
+```
+
+## 4. Find the cell IP and curl it
+
+The default-default space bridge is `10.88.0.0/16`. The cell gets one IP on that bridge. To find it, get the root container's pid from containerd, then peek into its network namespace:
+
+```bash
+ROOT_PID=$(sudo ctr -n kukeon.io task ls | awk '/hello-world_root/ {print $2}')
+CELL_IP=$(sudo nsenter -t "${ROOT_PID}" -n ip -4 -o addr show eth0 | awk '{print $4}' | cut -d/ -f1)
+curl http://${CELL_IP}:8080/
+```
+
+You should see the HTML from the manifest.
+
+!!! note "Containerd namespace"
+    In the default bootstrap, the containerd namespace for `realm=default` is `kukeon-default`. If your realm is named differently, replace the namespace accordingly. Older layouts used `kukeon.io` as the default namespace.
+
+## 5. Tear down
+
+```bash
+sudo kuke delete cell hello-world \
+    --realm default --space default --stack default --cascade --no-daemon
+```
+
+`--cascade` removes every container in the cell along with the cell itself.
+
+## What you just did
+
+- Applied a YAML manifest — one cell, one container.
+- Watched Kukeon create a cgroup under `/sys/fs/cgroup/kukeon/default/default/default/hello-world/`, a network namespace, a veth into the default bridge, and a containerd container in the `kukeon-default` namespace.
+- Reached the container's IP from the host because your host shares the same layer-2 segment as the bridge.
+
+## Next steps
+
+- Try [Tutorials → First stack](first-stack.md) — multiple cells sharing a network.
+- Explore the [Manifest reference](../manifests/overview.md).
+- Learn the full CLI: [CLI reference](../cli/commands.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,127 @@
+site_name: kukeon
+site_description: A lightweight, containerd-native orchestrator for structured container environments on a single machine
+site_author: Emiliano Spinella (eminwux)
+site_url: https://kukeon.io
+
+repo_name: eminwux/kukeon
+repo_url: https://github.com/eminwux/kukeon
+edit_uri: edit/main/docs/site/
+
+docs_dir: docs/site
+site_dir: build
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.annotate
+    - content.code.copy
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Installation:
+      - install/prerequisites.md
+      - install/install-linux.md
+      - install/build-from-source.md
+  - Concepts:
+      - concepts/overview.md
+      - concepts/realm.md
+      - concepts/space.md
+      - concepts/stack.md
+      - concepts/cell.md
+      - concepts/container.md
+      - concepts/containerd-namespaces.md
+      - concepts/networking.md
+      - concepts/cgroups.md
+      - concepts/system-realm.md
+      - concepts/client-and-daemon.md
+  - Architecture:
+      - architecture/overview.md
+      - architecture/process-model.md
+      - architecture/api-versioning.md
+      - architecture/storage-layout.md
+  - Guides:
+      - guides/init-and-reset.md
+      - guides/apply-manifests.md
+      - guides/local-dev.md
+      - guides/autocomplete.md
+      - guides/troubleshooting.md
+  - CLI Reference:
+      - cli/commands.md
+      - cli/kuke.md
+      - cli/kuke-init.md
+      - cli/kuke-get.md
+      - cli/kuke-create.md
+      - cli/kuke-apply.md
+      - cli/kuke-delete.md
+      - cli/kuke-lifecycle.md
+      - cli/kuke-purge.md
+      - cli/kuke-refresh.md
+      - cli/kuke-autocomplete.md
+      - cli/kuke-version.md
+      - cli/kukeond.md
+  - Manifest Reference:
+      - manifests/overview.md
+      - manifests/realm.md
+      - manifests/space.md
+      - manifests/stack.md
+      - manifests/cell.md
+      - manifests/container.md
+  - Tutorials:
+      - tutorials/hello-world.md
+      - tutorials/first-stack.md
+  - FAQ: faq.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/eminwux/kukeon
+  version:
+    provider: mike
+
+plugins:
+  - search
+  - git-revision-date-localized:
+      enable_creation_date: true


### PR DESCRIPTION
## Summary

- Adds a full documentation site at [kukeon.io](https://kukeon.io), mirroring the sbsh docs layout: MkDocs Material, sources under `docs/site/`, `mkdocs.yml` at the repo root, `CNAME` pinned to `kukeon.io`.
- Adds `.github/workflows/mkdocs.yaml` to build + deploy to GitHub Pages on pushes to `main` that touch `docs/site/**`, `mkdocs.yml`, or the workflow itself.
- Rewrites `README.md` to follow the sbsh long-form pattern, keeping the quick-start, dev-env, concepts, and comparison sections in-repo and linking to the docs site.

**Content (47 pages):**
- Landing: `index.md`, `getting-started.md`, `faq.md`
- `install/` — prerequisites, linux install, build-from-source
- `concepts/` — overview + realm / space / stack / cell / container + containerd-namespaces, networking, cgroups, system-realm, client-and-daemon
- `architecture/` — overview, process-model, api-versioning, storage-layout
- `guides/` — init-and-reset, apply-manifests, local-dev, autocomplete, troubleshooting
- `cli/` — commands overview + one page per verb + `kukeond`
- `manifests/` — overview + one page per kind, schemas grounded in `pkg/api/model/v1beta1/*.go`
- `tutorials/` — hello-world, first-stack

The docs describe the *intended* `kuke init --realm` and `kukeond --run-path` defaults (`default` and `/opt/kukeon`). The code currently disagrees; the gap is tracked in #40.

## Test plan

- [ ] CI: `Deploy Docs` workflow runs green on merge
- [ ] Site resolves at https://kukeon.io (DNS + GitHub Pages custom domain configured)
- [ ] `mkdocs build --strict` locally (no broken internal links)
- [ ] Spot-check a page on each tab: Home, Concepts, Architecture, CLI Reference, Manifest Reference, Tutorials, FAQ
- [ ] Verify `edit_uri` "edit on GitHub" link on any page points at `edit/main/docs/site/<page>.md`