### PR TITLE
fix: align kuke init --realm and kukeond --run-path defaults

### DIFF
--- a/cmd/config/defaults.go
+++ b/cmd/config/defaults.go
@@ -24,7 +24,7 @@ import (
 )
 
 func DefaultRunPath() string {
-	return filepath.Join("/", "run", "kukeon")
+	return filepath.Join("/", "opt", "kukeon")
 }
 
 func GetRunPathFromEnvAndFlags(cmd *cobra.Command, viperKey string) (string, error) {

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -66,7 +66,7 @@ func setupInitCmd(cmd *cobra.Command) error {
 }
 
 func setFlags(cmd *cobra.Command) error {
-	cmd.Flags().String("realm", "main", "Name of default realm")
+	cmd.Flags().String("realm", "default", "Name of default realm")
 	err := viper.BindPFlag(config.KUKE_INIT_REALM.ViperKey, cmd.Flags().Lookup("realm"))
 	if err != nil {
 		return fmt.Errorf("failed to bind flag: %w", err)

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -142,7 +142,7 @@ func TestSetFlags(t *testing.T) {
 		{
 			name:      "defaults",
 			args:      nil,
-			wantRealm: "main",
+			wantRealm: "default",
 			wantSpace: "default",
 		},
 		{


### PR DESCRIPTION
## Summary
- `kuke init --realm` defaulted to `main`, diverging from every other `kuke` subcommand (which default to `default`). Users hit a nonexistent realm on the very next command unless they remembered `--realm main`.
- `kukeond --run-path` defaulted to `/run/kukeon` (tmpfs) while `kuke` hard-coded `/opt/kukeon` for the same flag. Aligning both on `/opt/kukeon` keeps persistent state where it belongs and removes the client/daemon divergence.
- The socket/pid default (`/run/kukeon/kukeond.sock`) is unrelated and untouched.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/...` — all green, including the updated `TestSetFlags/defaults` assertion
- [x] `./kuke init --help` shows `--realm` default `"default"`
- [x] `./kukeond serve --help` shows `--run-path` default `"/opt/kukeon"`
- [x] Full CLAUDE.md smoke test: teardown → rebuild → image import → `sudo ./kuke init` → daemon-parity check (`sudo ./kuke get realms` vs `--no-daemon`) — identical two-realm output

Closes #40