### PR TITLE
feat: promote container volumes to structured bind mounts

### DIFF
--- a/cmd/kuke/create/container/container.go
+++ b/cmd/kuke/create/container/container.go
@@ -192,6 +192,10 @@ func runCreateContainer(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	volumeMounts, err := parseVolumeFlags(volumesList)
+	if err != nil {
+		return err
+	}
 	networksList, err := cmd.Flags().GetStringArray("network")
 	if err != nil {
 		return err
@@ -266,7 +270,7 @@ func runCreateContainer(cmd *cobra.Command, args []string) error {
 			Args:                   argsList,
 			Env:                    envList,
 			Ports:                  portsList,
-			Volumes:                volumesList,
+			Volumes:                volumeMounts,
 			Networks:               networksList,
 			NetworksAliases:        networkAliasesList,
 			Privileged:             privileged,
@@ -365,6 +369,57 @@ func trimAndDropEmpty(in []string) []string {
 		out = append(out, v)
 	}
 	return out
+}
+
+// parseVolumeFlags parses docker-style `--volume SRC:DST[:ro|rw]` flag values
+// into structured VolumeMounts. Missing mode defaults to rw; any other mode
+// value is rejected.
+func parseVolumeFlags(entries []string) ([]v1beta1.VolumeMount, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	out := make([]v1beta1.VolumeMount, 0, len(entries))
+	for _, raw := range entries {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		parts := strings.Split(entry, ":")
+		if len(parts) < 2 || len(parts) > 3 {
+			return nil, fmt.Errorf(
+				"invalid --volume %q: expected SRC:DST[:ro|rw]",
+				raw,
+			)
+		}
+		src := strings.TrimSpace(parts[0])
+		dst := strings.TrimSpace(parts[1])
+		if src == "" || dst == "" {
+			return nil, fmt.Errorf(
+				"invalid --volume %q: source and target are both required",
+				raw,
+			)
+		}
+		var readOnly bool
+		if len(parts) == 3 {
+			switch strings.TrimSpace(parts[2]) {
+			case "ro":
+				readOnly = true
+			case "rw", "":
+				readOnly = false
+			default:
+				return nil, fmt.Errorf(
+					"invalid --volume %q: mode must be ro or rw",
+					raw,
+				)
+			}
+		}
+		out = append(out, v1beta1.VolumeMount{
+			Source:   src,
+			Target:   dst,
+			ReadOnly: readOnly,
+		})
+	}
+	return out, nil
 }
 
 // parseTmpfsFlags parses docker-style "--tmpfs path[:opt1,opt2,...]" entries.

--- a/cmd/kuke/create/container/parse_volumes_test.go
+++ b/cmd/kuke/create/container/parse_volumes_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"testing"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestParseVolumeFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		want    []v1beta1.VolumeMount
+		wantErr bool
+	}{
+		{name: "empty", entries: nil, want: nil},
+		{
+			name:    "src and dst",
+			entries: []string{"/host/src:/container/dst"},
+			want:    []v1beta1.VolumeMount{{Source: "/host/src", Target: "/container/dst"}},
+		},
+		{
+			name:    "readonly",
+			entries: []string{"/host/src:/container/dst:ro"},
+			want: []v1beta1.VolumeMount{
+				{Source: "/host/src", Target: "/container/dst", ReadOnly: true},
+			},
+		},
+		{
+			name:    "explicit rw",
+			entries: []string{"/host/src:/container/dst:rw"},
+			want: []v1beta1.VolumeMount{
+				{Source: "/host/src", Target: "/container/dst", ReadOnly: false},
+			},
+		},
+		{
+			name: "multiple",
+			entries: []string{
+				"/a:/a",
+				"/b:/b:ro",
+			},
+			want: []v1beta1.VolumeMount{
+				{Source: "/a", Target: "/a"},
+				{Source: "/b", Target: "/b", ReadOnly: true},
+			},
+		},
+		{name: "single segment rejected", entries: []string{"/only"}, wantErr: true},
+		{name: "four segments rejected", entries: []string{"/a:/b:ro:extra"}, wantErr: true},
+		{name: "empty source rejected", entries: []string{":/dst"}, wantErr: true},
+		{name: "empty target rejected", entries: []string{"/src:"}, wantErr: true},
+		{name: "unknown mode rejected", entries: []string{"/a:/b:zz"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVolumeFlags(tt.entries)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseVolumeFlags(%v) = %v, want error", tt.entries, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseVolumeFlags(%v) unexpected error: %v", tt.entries, err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (%+v)", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/docs/site/concepts/container.md
+++ b/docs/site/concepts/container.md
@@ -39,7 +39,10 @@ spec:
   env:
     - "NGINX_HOST=example.com"
   ports: []
-  volumes: []
+  volumes:
+    - source: /srv/html
+      target: /usr/share/nginx/html
+      readOnly: true
   networks: []
   networksAliases: []
   privileged: false

--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -23,7 +23,10 @@ spec:
   env:
     - "NGINX_HOST=example.com"
   ports: []
-  volumes: []
+  volumes:
+    - source: /srv/html
+      target: /usr/share/nginx/html
+      readOnly: true
   networks: []
   networksAliases: []
   privileged: false
@@ -56,7 +59,7 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 | `args`             | array of string  | no       | Arguments. Combined with `command`.                                                     |
 | `env`              | array of string  | no       | `KEY=VALUE` environment variables                                                       |
 | `ports`            | array of string  | no       | Reserved — port mapping semantics are not finalized                                     |
-| `volumes`          | array of string  | no       | Reserved — volume mount semantics are not finalized                                     |
+| `volumes`          | array of `VolumeMount` | no | Bind-mount host paths into the container (see [VolumeMount](#volumemount))            |
 | `networks`         | array of string  | no       | Additional CNI networks to join beyond the cell's default                               |
 | `networksAliases`  | array of string  | no       | DNS aliases for the container within its CNI networks                                   |
 | `privileged`       | bool             | no       | Run privileged (full capabilities, access to `/dev`, etc.)                              |
@@ -64,7 +67,17 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 | `restartPolicy`    | string           | no       | Restart policy. Reserved — restart semantics are not finalized.                         |
 
 !!! warning "Fields marked reserved"
-    `ports`, `volumes`, and `restartPolicy` are accepted by the schema today but their semantics are still being designed. Values round-trip (you can read back what you applied), but the controller does not act on them. See [ROADMAP.md](https://github.com/eminwux/kukeon/blob/main/ROADMAP.md) for the backlog.
+    `ports` and `restartPolicy` are accepted by the schema today but their semantics are still being designed. Values round-trip (you can read back what you applied), but the controller does not act on them. See [ROADMAP.md](https://github.com/eminwux/kukeon/blob/main/ROADMAP.md) for the backlog.
+
+### VolumeMount
+
+Each entry in `spec.volumes` is a bind mount of a host path into the container.
+
+| Field      | Type   | Required | Description                                                                 |
+|------------|--------|----------|-----------------------------------------------------------------------------|
+| `source`   | string | yes      | Absolute host path. Must exist at apply time. Named / managed volumes are not supported. |
+| `target`   | string | yes      | Absolute path inside the container                                          |
+| `readOnly` | bool   | no       | Mount read-only when `true` (writes fail with `EROFS`). Defaults to `false`. |
 
 ## status
 

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -274,7 +274,7 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				Args:                   in.Spec.Args,
 				Env:                    in.Spec.Env,
 				Ports:                  in.Spec.Ports,
-				Volumes:                in.Spec.Volumes,
+				Volumes:                volumeMountsToInternal(in.Spec.Volumes),
 				Networks:               in.Spec.Networks,
 				NetworksAliases:        in.Spec.NetworksAliases,
 				Privileged:             in.Spec.Privileged,
@@ -327,7 +327,7 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				Args:                   in.Spec.Args,
 				Env:                    in.Spec.Env,
 				Ports:                  in.Spec.Ports,
-				Volumes:                in.Spec.Volumes,
+				Volumes:                volumeMountsToExternal(in.Spec.Volumes),
 				Networks:               in.Spec.Networks,
 				NetworksAliases:        in.Spec.NetworksAliases,
 				Privileged:             in.Spec.Privileged,
@@ -383,7 +383,7 @@ func convertContainerSpecToInternal(in ext.ContainerSpec) intmodel.ContainerSpec
 		Args:                   in.Args,
 		Env:                    in.Env,
 		Ports:                  in.Ports,
-		Volumes:                in.Volumes,
+		Volumes:                volumeMountsToInternal(in.Volumes),
 		Networks:               in.Networks,
 		NetworksAliases:        in.NetworksAliases,
 		Privileged:             in.Privileged,
@@ -414,7 +414,7 @@ func BuildContainerSpecExternalFromInternal(in intmodel.ContainerSpec) ext.Conta
 		Args:                   in.Args,
 		Env:                    in.Env,
 		Ports:                  in.Ports,
-		Volumes:                in.Volumes,
+		Volumes:                volumeMountsToExternal(in.Volumes),
 		Networks:               in.Networks,
 		NetworksAliases:        in.NetworksAliases,
 		Privileged:             in.Privileged,
@@ -499,6 +499,36 @@ func buildResourcesExternalFromInternal(in *intmodel.ContainerResources) *ext.Co
 		CPUShares:        in.CPUShares,
 		PidsLimit:        in.PidsLimit,
 	}
+}
+
+func volumeMountsToInternal(in []ext.VolumeMount) []intmodel.VolumeMount {
+	if in == nil {
+		return nil
+	}
+	out := make([]intmodel.VolumeMount, len(in))
+	for i, v := range in {
+		out[i] = intmodel.VolumeMount{
+			Source:   v.Source,
+			Target:   v.Target,
+			ReadOnly: v.ReadOnly,
+		}
+	}
+	return out
+}
+
+func volumeMountsToExternal(in []intmodel.VolumeMount) []ext.VolumeMount {
+	if in == nil {
+		return nil
+	}
+	out := make([]ext.VolumeMount, len(in))
+	for i, v := range in {
+		out[i] = ext.VolumeMount{
+			Source:   v.Source,
+			Target:   v.Target,
+			ReadOnly: v.ReadOnly,
+		}
+	}
+	return out
 }
 
 // convertContainerStatusesToInternal converts a slice of external ContainerStatus to internal ContainerStatus.

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -223,6 +223,10 @@ func TestContainerRoundTripV1Beta1(t *testing.T) {
 			Args:     []string{"-c", "echo hello"},
 			Env:      []string{"ENV_VAR=value"},
 			Ports:    []string{"8080:80"},
+			Volumes: []ext.VolumeMount{
+				{Source: "/host/src", Target: "/container/dst"},
+				{Source: "/host/ro", Target: "/container/ro", ReadOnly: true},
+			},
 			Networks: []string{"network0"},
 		},
 		Status: ext.ContainerStatus{
@@ -258,6 +262,14 @@ func TestContainerRoundTripV1Beta1(t *testing.T) {
 	}
 	if output.Status.State != ext.ContainerStateReady {
 		t.Fatalf("unexpected output status: %+v", output.Status)
+	}
+	if len(output.Spec.Volumes) != len(input.Spec.Volumes) {
+		t.Fatalf("volumes len = %d, want %d", len(output.Spec.Volumes), len(input.Spec.Volumes))
+	}
+	for i, v := range input.Spec.Volumes {
+		if output.Spec.Volumes[i] != v {
+			t.Errorf("volume[%d] = %+v, want %+v", i, output.Spec.Volumes[i], v)
+		}
 	}
 }
 

--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -517,7 +517,7 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec) DiffResult {
 		result.Details["ports"] = "ports changed"
 	}
 
-	if !slicesEqual(desired.Volumes, actual.Volumes) {
+	if !volumeMountsEqual(desired.Volumes, actual.Volumes) {
 		result.HasChanges = true
 		if result.ChangeType == ChangeTypeNone {
 			result.ChangeType = ChangeTypeCompatible
@@ -686,6 +686,18 @@ func mapsEqual(a, b map[string]string) bool {
 }
 
 func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func volumeMountsEqual(a, b []intmodel.VolumeMount) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -423,16 +423,17 @@ func kukeondCellDoc(image, socketPath, runPath, containerdSocket string) *v1beta
 		args = append(args, "--containerd-socket", containerdSocket)
 	}
 
-	volumes := []string{
-		fmt.Sprintf("%s:%s", socketDir(socketPath), socketDir(socketPath)),
+	sockDir := socketDir(socketPath)
+	volumes := []v1beta1.VolumeMount{
+		{Source: sockDir, Target: sockDir},
 	}
-	if runPath != "" && runPath != socketDir(socketPath) {
-		volumes = append(volumes, fmt.Sprintf("%s:%s", runPath, runPath))
+	if runPath != "" && runPath != sockDir {
+		volumes = append(volumes, v1beta1.VolumeMount{Source: runPath, Target: runPath})
 	}
 	if containerdSocket != "" {
 		ctrdDir := socketDir(containerdSocket)
-		if ctrdDir != socketDir(socketPath) && ctrdDir != runPath {
-			volumes = append(volumes, fmt.Sprintf("%s:%s", ctrdDir, ctrdDir))
+		if ctrdDir != sockDir && ctrdDir != runPath {
+			volumes = append(volumes, v1beta1.VolumeMount{Source: ctrdDir, Target: ctrdDir})
 		}
 	}
 

--- a/internal/controller/create_container.go
+++ b/internal/controller/create_container.go
@@ -19,6 +19,8 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -72,6 +74,11 @@ func (b *Exec) CreateContainer(container intmodel.Container) (CreateContainerRes
 		return res, errdefs.ErrInvalidImage
 	}
 
+	volumes, err := validateVolumes(container.Spec.Volumes)
+	if err != nil {
+		return res, err
+	}
+
 	// Build container spec to merge into cell
 	newContainerSpec := intmodel.ContainerSpec{
 		ID:                     container.Spec.ID,
@@ -82,6 +89,7 @@ func (b *Exec) CreateContainer(container intmodel.Container) (CreateContainerRes
 		Image:                  image,
 		Command:                container.Spec.Command,
 		Args:                   container.Spec.Args,
+		Volumes:                volumes,
 		User:                   container.Spec.User,
 		ReadOnlyRootFilesystem: container.Spec.ReadOnlyRootFilesystem,
 		Capabilities:           container.Spec.Capabilities,
@@ -256,4 +264,74 @@ func containerSpecExistsInternal(specs []intmodel.ContainerSpec, id string) bool
 		}
 	}
 	return false
+}
+
+// validateVolumes enforces the bind-mount contract: source and target are
+// required, both must be absolute paths, source must exist on the host, and
+// named / managed volumes (non-absolute source) are rejected.
+func validateVolumes(in []intmodel.VolumeMount) ([]intmodel.VolumeMount, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	out := make([]intmodel.VolumeMount, len(in))
+	for i, v := range in {
+		src := strings.TrimSpace(v.Source)
+		dst := strings.TrimSpace(v.Target)
+		if src == "" {
+			return nil, fmt.Errorf("%w (volume[%d])", errdefs.ErrVolumeSourceRequired, i)
+		}
+		if dst == "" {
+			return nil, fmt.Errorf("%w (volume[%d])", errdefs.ErrVolumeTargetRequired, i)
+		}
+		// Named / managed volumes have non-path sources (e.g. "my-vol"). Reject
+		// anything that is not an absolute host path so the user gets a clear
+		// error pointing at the deferred feature rather than a mount failure
+		// buried in containerd logs.
+		if !filepath.IsAbs(src) {
+			if !strings.ContainsRune(src, os.PathSeparator) {
+				return nil, fmt.Errorf(
+					"%w (volume[%d] source %q)",
+					errdefs.ErrVolumeNamedNotSupported,
+					i,
+					src,
+				)
+			}
+			return nil, fmt.Errorf(
+				"%w (volume[%d] source %q)",
+				errdefs.ErrVolumeSourceNotAbsolute,
+				i,
+				src,
+			)
+		}
+		if !filepath.IsAbs(dst) {
+			return nil, fmt.Errorf(
+				"%w (volume[%d] target %q)",
+				errdefs.ErrVolumeTargetNotAbsolute,
+				i,
+				dst,
+			)
+		}
+		if _, statErr := os.Stat(src); statErr != nil {
+			if os.IsNotExist(statErr) {
+				return nil, fmt.Errorf(
+					"%w (volume[%d] source %q)",
+					errdefs.ErrVolumeSourceNotFound,
+					i,
+					src,
+				)
+			}
+			return nil, fmt.Errorf(
+				"failed to stat volume[%d] source %q: %w",
+				i,
+				src,
+				statErr,
+			)
+		}
+		out[i] = intmodel.VolumeMount{
+			Source:   src,
+			Target:   dst,
+			ReadOnly: v.ReadOnly,
+		}
+	}
+	return out, nil
 }

--- a/internal/controller/validate_volumes_test.go
+++ b/internal/controller/validate_volumes_test.go
@@ -1,0 +1,109 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+func TestValidateVolumes(t *testing.T) {
+	tmpDir := t.TempDir()
+	existing := tmpDir
+
+	tests := []struct {
+		name    string
+		in      []intmodel.VolumeMount
+		wantErr error
+	}{
+		{name: "empty", in: nil},
+		{
+			name: "valid rw",
+			in:   []intmodel.VolumeMount{{Source: existing, Target: "/dst"}},
+		},
+		{
+			name: "valid ro",
+			in:   []intmodel.VolumeMount{{Source: existing, Target: "/dst", ReadOnly: true}},
+		},
+		{
+			name:    "missing source",
+			in:      []intmodel.VolumeMount{{Target: "/dst"}},
+			wantErr: errdefs.ErrVolumeSourceRequired,
+		},
+		{
+			name:    "missing target",
+			in:      []intmodel.VolumeMount{{Source: existing}},
+			wantErr: errdefs.ErrVolumeTargetRequired,
+		},
+		{
+			name:    "named volume rejected",
+			in:      []intmodel.VolumeMount{{Source: "my-vol", Target: "/dst"}},
+			wantErr: errdefs.ErrVolumeNamedNotSupported,
+		},
+		{
+			name:    "relative source rejected",
+			in:      []intmodel.VolumeMount{{Source: "relative/path", Target: "/dst"}},
+			wantErr: errdefs.ErrVolumeSourceNotAbsolute,
+		},
+		{
+			name:    "relative target rejected",
+			in:      []intmodel.VolumeMount{{Source: existing, Target: "relative"}},
+			wantErr: errdefs.ErrVolumeTargetNotAbsolute,
+		},
+		{
+			name:    "source does not exist",
+			in:      []intmodel.VolumeMount{{Source: filepath.Join(tmpDir, "nope"), Target: "/dst"}},
+			wantErr: errdefs.ErrVolumeSourceNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := validateVolumes(tt.in)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("err = %v, want is %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(out) != len(tt.in) {
+				t.Fatalf("len = %d, want %d", len(out), len(tt.in))
+			}
+		})
+	}
+}
+
+func TestValidateVolumes_TrimsWhitespace(t *testing.T) {
+	tmpDir := t.TempDir()
+	in := []intmodel.VolumeMount{{Source: "  " + tmpDir + "  ", Target: "  /dst  "}}
+	out, err := validateVolumes(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out[0].Source != tmpDir || out[0].Target != "/dst" {
+		t.Errorf("got %+v, expected source=%q target=\"/dst\"", out[0], tmpDir)
+	}
+}

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -201,7 +201,7 @@ func BuildContainerSpec(
 		specOpts = append(specOpts, oci.WithPrivileged)
 	}
 
-	if mounts := parseVolumeMounts(containerSpec.Volumes); len(mounts) > 0 {
+	if mounts := buildBindMounts(containerSpec.Volumes); len(mounts) > 0 {
 		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
 
@@ -216,44 +216,26 @@ func BuildContainerSpec(
 	}
 }
 
-// parseVolumeMounts translates the docker-style volume strings in
-// ContainerSpec.Volumes ("src:dst[:ro]") into OCI bind mounts. Entries that
-// do not contain a ":" are skipped (anonymous / named volumes are not yet
-// supported).
-func parseVolumeMounts(volumes []string) []runtimespec.Mount {
+// buildBindMounts translates ContainerSpec.Volumes into OCI bind mounts.
+// Entries are expected to be already validated (absolute source/target).
+func buildBindMounts(volumes []intmodel.VolumeMount) []runtimespec.Mount {
 	if len(volumes) == 0 {
 		return nil
 	}
 	mounts := make([]runtimespec.Mount, 0, len(volumes))
-	for _, raw := range volumes {
-		v := strings.TrimSpace(raw)
-		if v == "" {
-			continue
-		}
-		parts := strings.Split(v, ":")
-		if len(parts) < 2 {
-			continue
-		}
-		src, dst := parts[0], parts[1]
-		if src == "" || dst == "" {
+	for _, v := range volumes {
+		if v.Source == "" || v.Target == "" {
 			continue
 		}
 		options := []string{"rbind"}
-		if len(parts) >= 3 {
-			switch parts[2] {
-			case "ro":
-				options = append(options, "ro")
-			case "rw":
-				options = append(options, "rw")
-			default:
-				options = append(options, "rw")
-			}
+		if v.ReadOnly {
+			options = append(options, "ro")
 		} else {
 			options = append(options, "rw")
 		}
 		mounts = append(mounts, runtimespec.Mount{
-			Destination: dst,
-			Source:      src,
+			Destination: v.Target,
+			Source:      v.Source,
 			Type:        "bind",
 			Options:     options,
 		})

--- a/internal/ctr/volumes_test.go
+++ b/internal/ctr/volumes_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+func TestBuildBindMounts(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []intmodel.VolumeMount
+		wantLen int
+		wantRO  []bool // per-mount; "ro" option expected
+	}{
+		{name: "empty", in: nil, wantLen: 0},
+		{
+			name:    "rw",
+			in:      []intmodel.VolumeMount{{Source: "/a", Target: "/b"}},
+			wantLen: 1,
+			wantRO:  []bool{false},
+		},
+		{
+			name:    "ro",
+			in:      []intmodel.VolumeMount{{Source: "/a", Target: "/b", ReadOnly: true}},
+			wantLen: 1,
+			wantRO:  []bool{true},
+		},
+		{
+			name: "mixed",
+			in: []intmodel.VolumeMount{
+				{Source: "/a", Target: "/a"},
+				{Source: "/b", Target: "/b", ReadOnly: true},
+			},
+			wantLen: 2,
+			wantRO:  []bool{false, true},
+		},
+		{
+			name:    "skip empty source",
+			in:      []intmodel.VolumeMount{{Source: "", Target: "/b"}},
+			wantLen: 0,
+		},
+		{
+			name:    "skip empty target",
+			in:      []intmodel.VolumeMount{{Source: "/a", Target: ""}},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildBindMounts(tt.in)
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tt.wantLen)
+			}
+			for i, m := range got {
+				if m.Type != "bind" {
+					t.Errorf("[%d] Type = %q, want \"bind\"", i, m.Type)
+				}
+				if m.Source != tt.in[i].Source || m.Destination != tt.in[i].Target {
+					t.Errorf("[%d] Source/Destination = %q/%q, want %q/%q",
+						i, m.Source, m.Destination, tt.in[i].Source, tt.in[i].Target)
+				}
+				hasRO := false
+				hasRW := false
+				hasRbind := false
+				for _, o := range m.Options {
+					switch o {
+					case "ro":
+						hasRO = true
+					case "rw":
+						hasRW = true
+					case "rbind":
+						hasRbind = true
+					}
+				}
+				if !hasRbind {
+					t.Errorf("[%d] Options %v missing rbind", i, m.Options)
+				}
+				if tt.wantRO[i] {
+					if !hasRO || hasRW {
+						t.Errorf("[%d] Options %v want ro", i, m.Options)
+					}
+				} else {
+					if hasRO || !hasRW {
+						t.Errorf("[%d] Options %v want rw", i, m.Options)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -97,6 +97,17 @@ var (
 	ErrTaskNotFound      = errors.New("task not found")
 	ErrTaskNotRunning    = errors.New("task is not running")
 
+	// Volume-related errors.
+
+	ErrVolumeSourceRequired    = errors.New("volume source is required")
+	ErrVolumeTargetRequired    = errors.New("volume target is required")
+	ErrVolumeSourceNotAbsolute = errors.New("volume source must be an absolute host path")
+	ErrVolumeTargetNotAbsolute = errors.New("volume target must be an absolute container path")
+	ErrVolumeSourceNotFound    = errors.New("volume source does not exist on the host")
+	ErrVolumeNamedNotSupported = errors.New(
+		"named or managed volumes are not supported; use an absolute host path as source",
+	)
+
 	// CNI-related errors.
 
 	ErrBridgeNameTooLong = errors.New("bridge name exceeds Linux IFNAMSIZ limit")

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -42,7 +42,7 @@ type ContainerSpec struct {
 	Args                   []string
 	Env                    []string
 	Ports                  []string
-	Volumes                []string
+	Volumes                []VolumeMount
 	Networks               []string
 	NetworksAliases        []string
 	Privileged             bool
@@ -54,6 +54,13 @@ type ContainerSpec struct {
 	Resources              *ContainerResources
 	CNIConfigPath          string
 	RestartPolicy          string
+}
+
+// VolumeMount is a bind mount of a host path into a container.
+type VolumeMount struct {
+	Source   string
+	Target   string
+	ReadOnly bool
 }
 
 // ContainerCapabilities groups Linux capability deltas applied relative to the

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -117,7 +117,7 @@ func NewCellDoc(from *CellDoc) *CellDoc {
 			containers[i].Args = cloneSlice(container.Args)
 			containers[i].Env = cloneSlice(container.Env)
 			containers[i].Ports = cloneSlice(container.Ports)
-			containers[i].Volumes = cloneSlice(container.Volumes)
+			containers[i].Volumes = cloneVolumeMounts(container.Volumes)
 			containers[i].Networks = cloneSlice(container.Networks)
 			containers[i].NetworksAliases = cloneSlice(container.NetworksAliases)
 		}

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -44,7 +44,7 @@ type ContainerSpec struct {
 	Args                   []string               `json:"args"                             yaml:"args"`
 	Env                    []string               `json:"env"                              yaml:"env"`
 	Ports                  []string               `json:"ports"                            yaml:"ports"`
-	Volumes                []string               `json:"volumes"                          yaml:"volumes"`
+	Volumes                []VolumeMount          `json:"volumes"                          yaml:"volumes"`
 	Networks               []string               `json:"networks"                         yaml:"networks"`
 	NetworksAliases        []string               `json:"networksAliases"                  yaml:"networksAliases"`
 	Privileged             bool                   `json:"privileged"                       yaml:"privileged"`
@@ -56,6 +56,13 @@ type ContainerSpec struct {
 	Resources              *ContainerResources    `json:"resources,omitempty"              yaml:"resources,omitempty"`
 	CNIConfigPath          string                 `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
 	RestartPolicy          string                 `json:"restartPolicy"                    yaml:"restartPolicy"`
+}
+
+// VolumeMount is a bind mount of a host path into a container.
+type VolumeMount struct {
+	Source   string `json:"source"             yaml:"source"`
+	Target   string `json:"target"             yaml:"target"`
+	ReadOnly bool   `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
 }
 
 // ContainerCapabilities groups Linux capability deltas applied to the
@@ -147,7 +154,7 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 				Args:            []string{},
 				Env:             []string{},
 				Ports:           []string{},
-				Volumes:         []string{},
+				Volumes:         []VolumeMount{},
 				Networks:        []string{},
 				NetworksAliases: []string{},
 				Privileged:      false,
@@ -183,7 +190,7 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 	out.Spec.Args = cloneSlice(out.Spec.Args)
 	out.Spec.Env = cloneSlice(out.Spec.Env)
 	out.Spec.Ports = cloneSlice(out.Spec.Ports)
-	out.Spec.Volumes = cloneSlice(out.Spec.Volumes)
+	out.Spec.Volumes = cloneVolumeMounts(out.Spec.Volumes)
 	out.Spec.Networks = cloneSlice(out.Spec.Networks)
 	out.Spec.NetworksAliases = cloneSlice(out.Spec.NetworksAliases)
 	out.Spec.SecurityOpts = cloneSlice(out.Spec.SecurityOpts)
@@ -218,6 +225,16 @@ func cloneSlice(in []string) []string {
 	}
 
 	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneVolumeMounts(in []VolumeMount) []VolumeMount {
+	if in == nil {
+		return []VolumeMount{}
+	}
+
+	out := make([]VolumeMount, len(in))
 	copy(out, in)
 	return out
 }


### PR DESCRIPTION
## Summary
- Replace `Volumes []string` with `Volumes []VolumeMount{Source,Target,ReadOnly}` across the external (`v1beta1`) and internal (`modelhub`) Container specs. The docker-style `--volume SRC:DST[:ro|rw]` CLI flag is preserved and parsed into the structured type.
- Validate each volume at apply time: absolute host path, source exists on disk, absolute container target. Named / managed volumes are rejected with a dedicated error pointing at the deferred feature.
- Forward `Volumes` through `controller.CreateContainer` (previously dropped there), so bind mounts actually reach `BuildContainerSpec` → `oci.WithMounts`.
- Migrate the internal `kuke init` bootstrap (the kukeond cell) to the structured shape.

Closes #42

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v '/e2e$')` — all non-e2e tests pass; the two pre-existing `internal/ctr` failures (`TestDefaultRootContainerSpec`, `TestBuildRootContainerSpec`) reproduce on `main` and are unrelated to this change
- [x] `make kuke` builds an ELF binary
- [x] `./kuke create container test --volume nope --cell foo` → clear parse error
- [x] `./kuke create container test --volume /src:/dst:wrong --cell foo` → mode-validation error
- [ ] Daemon-parity smoke test from CLAUDE.md (`kuke init` + `kuke get realms` via daemon and `--no-daemon`) — requires a host with containerd and root privileges; not runnable in this sandbox