### PR TITLE
feat: add container security fields (user, read-only rootfs, caps, seccomp, tmpfs, resources)

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -189,6 +189,40 @@ var (
 	)
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CONTAINER_LABELS = DefineKV("KUKE_CREATE_CONTAINER_LABELS", "kuke/create/container/labels")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_USER = DefineKV("KUKE_CREATE_CONTAINER_USER", "kuke/create/container/user")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_READ_ONLY = DefineKV(
+		"KUKE_CREATE_CONTAINER_READ_ONLY",
+		"kuke/create/container/readOnlyRootFilesystem",
+		"false",
+	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_CAP_DROP = DefineKV("KUKE_CREATE_CONTAINER_CAP_DROP", "kuke/create/container/capabilities/drop")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_CAP_ADD = DefineKV("KUKE_CREATE_CONTAINER_CAP_ADD", "kuke/create/container/capabilities/add")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_SECURITY_OPTS = DefineKV(
+		"KUKE_CREATE_CONTAINER_SECURITY_OPTS",
+		"kuke/create/container/securityOpts",
+	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_TMPFS = DefineKV("KUKE_CREATE_CONTAINER_TMPFS", "kuke/create/container/tmpfs")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_MEMORY = DefineKV(
+		"KUKE_CREATE_CONTAINER_MEMORY",
+		"kuke/create/container/resources/memoryLimitBytes",
+	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_CPU_SHARES = DefineKV(
+		"KUKE_CREATE_CONTAINER_CPU_SHARES",
+		"kuke/create/container/resources/cpuShares",
+	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONTAINER_PIDS_LIMIT = DefineKV(
+		"KUKE_CREATE_CONTAINER_PIDS_LIMIT",
+		"kuke/create/container/resources/pidsLimit",
+	)
 
 	// Get command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/create/container/container.go
+++ b/cmd/kuke/create/container/container.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
@@ -92,6 +93,37 @@ func NewContainerCmd() *cobra.Command {
 
 	cmd.Flags().StringArray("label", []string{}, "Metadata label in KEY=VALUE form (repeatable)")
 	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_LABELS.ViperKey, cmd.Flags().Lookup("label"))
+
+	cmd.Flags().String("user", "", `Run the container as UID[:GID] (e.g. "1000:1000")`)
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_USER.ViperKey, cmd.Flags().Lookup("user"))
+
+	cmd.Flags().Bool("read-only", false, "Mount the container's root filesystem read-only")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_READ_ONLY.ViperKey, cmd.Flags().Lookup("read-only"))
+
+	cmd.Flags().StringArray("cap-drop", []string{}, "Linux capability to drop (repeatable, e.g. ALL or NET_ADMIN)")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_CAP_DROP.ViperKey, cmd.Flags().Lookup("cap-drop"))
+
+	cmd.Flags().StringArray("cap-add", []string{}, "Linux capability to add (repeatable, e.g. NET_ADMIN)")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_CAP_ADD.ViperKey, cmd.Flags().Lookup("cap-add"))
+
+	cmd.Flags().StringArray(
+		"security-opt",
+		[]string{},
+		`Security option (repeatable, e.g. "no-new-privileges" or "seccomp=unconfined")`,
+	)
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_SECURITY_OPTS.ViperKey, cmd.Flags().Lookup("security-opt"))
+
+	cmd.Flags().StringArray("tmpfs", []string{}, `Tmpfs mount "path[:opts]" (e.g. "/tmp:size=64m") (repeatable)`)
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_TMPFS.ViperKey, cmd.Flags().Lookup("tmpfs"))
+
+	cmd.Flags().String("memory", "", `Hard memory limit (bytes, or with suffix k/m/g, e.g. "4g")`)
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_MEMORY.ViperKey, cmd.Flags().Lookup("memory"))
+
+	cmd.Flags().Int64("cpu-shares", 0, "Relative CPU weight (cgroup cpu.shares)")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_CPU_SHARES.ViperKey, cmd.Flags().Lookup("cpu-shares"))
+
+	cmd.Flags().Int64("pids-limit", 0, "Maximum number of PIDs in the container (0 to leave unset)")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONTAINER_PIDS_LIMIT.ViperKey, cmd.Flags().Lookup("pids-limit"))
 
 	cmd.ValidArgsFunction = config.CompleteContainerNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -182,29 +214,70 @@ func runCreateContainer(cmd *cobra.Command, args []string) error {
 	cniConfigPath := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CONTAINER_CNI_CONFIG_PATH.ViperKey))
 	restartPolicy := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CONTAINER_RESTART_POLICY.ViperKey))
 
+	user := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CONTAINER_USER.ViperKey))
+	readOnly := viper.GetBool(config.KUKE_CREATE_CONTAINER_READ_ONLY.ViperKey)
+
+	capDropList, err := cmd.Flags().GetStringArray("cap-drop")
+	if err != nil {
+		return err
+	}
+	capAddList, err := cmd.Flags().GetStringArray("cap-add")
+	if err != nil {
+		return err
+	}
+	securityOptsList, err := cmd.Flags().GetStringArray("security-opt")
+	if err != nil {
+		return err
+	}
+	tmpfsList, err := cmd.Flags().GetStringArray("tmpfs")
+	if err != nil {
+		return err
+	}
+	tmpfsMounts, err := parseTmpfsFlags(tmpfsList)
+	if err != nil {
+		return err
+	}
+
+	memoryRaw := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CONTAINER_MEMORY.ViperKey))
+	memoryBytes, err := parseMemoryBytes(memoryRaw)
+	if err != nil {
+		return err
+	}
+	cpuShares := viper.GetInt64(config.KUKE_CREATE_CONTAINER_CPU_SHARES.ViperKey)
+	pidsLimit := viper.GetInt64(config.KUKE_CREATE_CONTAINER_PIDS_LIMIT.ViperKey)
+
+	capabilities := buildCapabilities(capDropList, capAddList)
+	resources := buildResources(memoryBytes, cpuShares, pidsLimit)
+
 	doc := v1beta1.NewContainerDoc(&v1beta1.ContainerDoc{
 		Metadata: v1beta1.ContainerMetadata{
 			Name:   name,
 			Labels: labels,
 		},
 		Spec: v1beta1.ContainerSpec{
-			ID:              name,
-			RealmID:         realm,
-			SpaceID:         space,
-			StackID:         stack,
-			CellID:          cell,
-			Root:            root,
-			Image:           image,
-			Command:         command,
-			Args:            argsList,
-			Env:             envList,
-			Ports:           portsList,
-			Volumes:         volumesList,
-			Networks:        networksList,
-			NetworksAliases: networkAliasesList,
-			Privileged:      privileged,
-			CNIConfigPath:   cniConfigPath,
-			RestartPolicy:   restartPolicy,
+			ID:                     name,
+			RealmID:                realm,
+			SpaceID:                space,
+			StackID:                stack,
+			CellID:                 cell,
+			Root:                   root,
+			Image:                  image,
+			Command:                command,
+			Args:                   argsList,
+			Env:                    envList,
+			Ports:                  portsList,
+			Volumes:                volumesList,
+			Networks:               networksList,
+			NetworksAliases:        networkAliasesList,
+			Privileged:             privileged,
+			User:                   user,
+			ReadOnlyRootFilesystem: readOnly,
+			Capabilities:           capabilities,
+			SecurityOpts:           securityOptsList,
+			Tmpfs:                  tmpfsMounts,
+			Resources:              resources,
+			CNIConfigPath:          cniConfigPath,
+			RestartPolicy:          restartPolicy,
 		},
 	})
 
@@ -251,6 +324,138 @@ func printContainerResult(cmd *cobra.Command, result kukeonv1.CreateContainerRes
 // PrintContainerResult is exported for testing purposes.
 func PrintContainerResult(cmd *cobra.Command, result kukeonv1.CreateContainerResult) {
 	printContainerResult(cmd, result)
+}
+
+func buildCapabilities(drop, add []string) *v1beta1.ContainerCapabilities {
+	drop = trimAndDropEmpty(drop)
+	add = trimAndDropEmpty(add)
+	if len(drop) == 0 && len(add) == 0 {
+		return nil
+	}
+	return &v1beta1.ContainerCapabilities{Drop: drop, Add: add}
+}
+
+func buildResources(memoryBytes, cpuShares, pidsLimit int64) *v1beta1.ContainerResources {
+	if memoryBytes <= 0 && cpuShares <= 0 && pidsLimit <= 0 {
+		return nil
+	}
+	res := &v1beta1.ContainerResources{}
+	if memoryBytes > 0 {
+		m := memoryBytes
+		res.MemoryLimitBytes = &m
+	}
+	if cpuShares > 0 {
+		s := cpuShares
+		res.CPUShares = &s
+	}
+	if pidsLimit > 0 {
+		p := pidsLimit
+		res.PidsLimit = &p
+	}
+	return res
+}
+
+func trimAndDropEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// parseTmpfsFlags parses docker-style "--tmpfs path[:opt1,opt2,...]" entries.
+// The size option ("size=<N>[k|m|g]") is promoted to the structured sizeBytes
+// field; everything else is preserved as a raw option string.
+func parseTmpfsFlags(entries []string) ([]v1beta1.ContainerTmpfsMount, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	mounts := make([]v1beta1.ContainerTmpfsMount, 0, len(entries))
+	for _, raw := range entries {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		path := entry
+		var rawOpts string
+		if idx := strings.Index(entry, ":"); idx >= 0 {
+			path = strings.TrimSpace(entry[:idx])
+			rawOpts = entry[idx+1:]
+		}
+		if path == "" {
+			return nil, fmt.Errorf("invalid --tmpfs %q: path is required", raw)
+		}
+		mount := v1beta1.ContainerTmpfsMount{Path: path}
+		if rawOpts != "" {
+			for _, opt := range strings.Split(rawOpts, ",") {
+				opt = strings.TrimSpace(opt)
+				if opt == "" {
+					continue
+				}
+				if after, ok := strings.CutPrefix(opt, "size="); ok {
+					bytes, err := parseSizeBytes(after)
+					if err != nil {
+						return nil, fmt.Errorf("invalid --tmpfs %q: %w", raw, err)
+					}
+					mount.SizeBytes = bytes
+					continue
+				}
+				mount.Options = append(mount.Options, opt)
+			}
+		}
+		mounts = append(mounts, mount)
+	}
+	return mounts, nil
+}
+
+// parseMemoryBytes accepts a plain byte count or a value with a k/m/g (or
+// ki/mi/gi) suffix, matching the docker convention. Empty input returns 0.
+func parseMemoryBytes(raw string) (int64, error) {
+	if raw == "" {
+		return 0, nil
+	}
+	return parseSizeBytes(raw)
+}
+
+func parseSizeBytes(raw string) (int64, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0, fmt.Errorf("size is empty")
+	}
+	multiplier := int64(1)
+	lower := strings.ToLower(s)
+	switch {
+	case strings.HasSuffix(lower, "gi"):
+		multiplier = 1024 * 1024 * 1024
+		s = s[:len(s)-2]
+	case strings.HasSuffix(lower, "mi"):
+		multiplier = 1024 * 1024
+		s = s[:len(s)-2]
+	case strings.HasSuffix(lower, "ki"):
+		multiplier = 1024
+		s = s[:len(s)-2]
+	case strings.HasSuffix(lower, "g"):
+		multiplier = 1024 * 1024 * 1024
+		s = s[:len(s)-1]
+	case strings.HasSuffix(lower, "m"):
+		multiplier = 1024 * 1024
+		s = s[:len(s)-1]
+	case strings.HasSuffix(lower, "k"):
+		multiplier = 1024
+		s = s[:len(s)-1]
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q: %w", raw, err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("invalid size %q: must be non-negative", raw)
+	}
+	return n * multiplier, nil
 }
 
 func parseLabels(entries []string) (map[string]string, error) {

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -263,23 +263,29 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				Labels: in.Metadata.Labels,
 			},
 			Spec: intmodel.ContainerSpec{
-				ID:              in.Spec.ID,
-				RealmName:       in.Spec.RealmID,
-				SpaceName:       in.Spec.SpaceID,
-				StackName:       in.Spec.StackID,
-				CellName:        in.Spec.CellID,
-				Root:            in.Spec.Root,
-				Image:           in.Spec.Image,
-				Command:         in.Spec.Command,
-				Args:            in.Spec.Args,
-				Env:             in.Spec.Env,
-				Ports:           in.Spec.Ports,
-				Volumes:         in.Spec.Volumes,
-				Networks:        in.Spec.Networks,
-				NetworksAliases: in.Spec.NetworksAliases,
-				Privileged:      in.Spec.Privileged,
-				CNIConfigPath:   in.Spec.CNIConfigPath,
-				RestartPolicy:   in.Spec.RestartPolicy,
+				ID:                     in.Spec.ID,
+				RealmName:              in.Spec.RealmID,
+				SpaceName:              in.Spec.SpaceID,
+				StackName:              in.Spec.StackID,
+				CellName:               in.Spec.CellID,
+				Root:                   in.Spec.Root,
+				Image:                  in.Spec.Image,
+				Command:                in.Spec.Command,
+				Args:                   in.Spec.Args,
+				Env:                    in.Spec.Env,
+				Ports:                  in.Spec.Ports,
+				Volumes:                in.Spec.Volumes,
+				Networks:               in.Spec.Networks,
+				NetworksAliases:        in.Spec.NetworksAliases,
+				Privileged:             in.Spec.Privileged,
+				User:                   in.Spec.User,
+				ReadOnlyRootFilesystem: in.Spec.ReadOnlyRootFilesystem,
+				Capabilities:           convertCapabilitiesToInternal(in.Spec.Capabilities),
+				SecurityOpts:           in.Spec.SecurityOpts,
+				Tmpfs:                  convertTmpfsMountsToInternal(in.Spec.Tmpfs),
+				Resources:              convertResourcesToInternal(in.Spec.Resources),
+				CNIConfigPath:          in.Spec.CNIConfigPath,
+				RestartPolicy:          in.Spec.RestartPolicy,
 			},
 			Status: intmodel.ContainerStatus{
 				Name:         in.Status.Name,
@@ -310,23 +316,29 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				Labels: in.Metadata.Labels,
 			},
 			Spec: ext.ContainerSpec{
-				ID:              in.Spec.ID,
-				RealmID:         in.Spec.RealmName,
-				SpaceID:         in.Spec.SpaceName,
-				StackID:         in.Spec.StackName,
-				CellID:          in.Spec.CellName,
-				Root:            in.Spec.Root,
-				Image:           in.Spec.Image,
-				Command:         in.Spec.Command,
-				Args:            in.Spec.Args,
-				Env:             in.Spec.Env,
-				Ports:           in.Spec.Ports,
-				Volumes:         in.Spec.Volumes,
-				Networks:        in.Spec.Networks,
-				NetworksAliases: in.Spec.NetworksAliases,
-				Privileged:      in.Spec.Privileged,
-				CNIConfigPath:   in.Spec.CNIConfigPath,
-				RestartPolicy:   in.Spec.RestartPolicy,
+				ID:                     in.Spec.ID,
+				RealmID:                in.Spec.RealmName,
+				SpaceID:                in.Spec.SpaceName,
+				StackID:                in.Spec.StackName,
+				CellID:                 in.Spec.CellName,
+				Root:                   in.Spec.Root,
+				Image:                  in.Spec.Image,
+				Command:                in.Spec.Command,
+				Args:                   in.Spec.Args,
+				Env:                    in.Spec.Env,
+				Ports:                  in.Spec.Ports,
+				Volumes:                in.Spec.Volumes,
+				Networks:               in.Spec.Networks,
+				NetworksAliases:        in.Spec.NetworksAliases,
+				Privileged:             in.Spec.Privileged,
+				User:                   in.Spec.User,
+				ReadOnlyRootFilesystem: in.Spec.ReadOnlyRootFilesystem,
+				Capabilities:           buildCapabilitiesExternalFromInternal(in.Spec.Capabilities),
+				SecurityOpts:           in.Spec.SecurityOpts,
+				Tmpfs:                  buildTmpfsMountsExternalFromInternal(in.Spec.Tmpfs),
+				Resources:              buildResourcesExternalFromInternal(in.Spec.Resources),
+				CNIConfigPath:          in.Spec.CNIConfigPath,
+				RestartPolicy:          in.Spec.RestartPolicy,
 			},
 			Status: ext.ContainerStatus{
 				Name:         in.Status.Name,
@@ -359,24 +371,30 @@ func NormalizeContainer(req ext.ContainerDoc) (intmodel.Container, ext.Version, 
 // This is used for nested ContainerSpecs in CellSpec.
 func convertContainerSpecToInternal(in ext.ContainerSpec) intmodel.ContainerSpec {
 	return intmodel.ContainerSpec{
-		ID:              in.ID,
-		ContainerdID:    in.ContainerdID,
-		RealmName:       in.RealmID,
-		SpaceName:       in.SpaceID,
-		StackName:       in.StackID,
-		CellName:        in.CellID,
-		Root:            in.Root,
-		Image:           in.Image,
-		Command:         in.Command,
-		Args:            in.Args,
-		Env:             in.Env,
-		Ports:           in.Ports,
-		Volumes:         in.Volumes,
-		Networks:        in.Networks,
-		NetworksAliases: in.NetworksAliases,
-		Privileged:      in.Privileged,
-		CNIConfigPath:   in.CNIConfigPath,
-		RestartPolicy:   in.RestartPolicy,
+		ID:                     in.ID,
+		ContainerdID:           in.ContainerdID,
+		RealmName:              in.RealmID,
+		SpaceName:              in.SpaceID,
+		StackName:              in.StackID,
+		CellName:               in.CellID,
+		Root:                   in.Root,
+		Image:                  in.Image,
+		Command:                in.Command,
+		Args:                   in.Args,
+		Env:                    in.Env,
+		Ports:                  in.Ports,
+		Volumes:                in.Volumes,
+		Networks:               in.Networks,
+		NetworksAliases:        in.NetworksAliases,
+		Privileged:             in.Privileged,
+		User:                   in.User,
+		ReadOnlyRootFilesystem: in.ReadOnlyRootFilesystem,
+		Capabilities:           convertCapabilitiesToInternal(in.Capabilities),
+		SecurityOpts:           in.SecurityOpts,
+		Tmpfs:                  convertTmpfsMountsToInternal(in.Tmpfs),
+		Resources:              convertResourcesToInternal(in.Resources),
+		CNIConfigPath:          in.CNIConfigPath,
+		RestartPolicy:          in.RestartPolicy,
 	}
 }
 
@@ -384,24 +402,102 @@ func convertContainerSpecToInternal(in ext.ContainerSpec) intmodel.ContainerSpec
 // This is used for nested ContainerSpecs in CellSpec.
 func BuildContainerSpecExternalFromInternal(in intmodel.ContainerSpec) ext.ContainerSpec {
 	return ext.ContainerSpec{
-		ID:              in.ID,
-		ContainerdID:    in.ContainerdID,
-		RealmID:         in.RealmName,
-		SpaceID:         in.SpaceName,
-		StackID:         in.StackName,
-		CellID:          in.CellName,
-		Root:            in.Root,
-		Image:           in.Image,
-		Command:         in.Command,
-		Args:            in.Args,
-		Env:             in.Env,
-		Ports:           in.Ports,
-		Volumes:         in.Volumes,
-		Networks:        in.Networks,
-		NetworksAliases: in.NetworksAliases,
-		Privileged:      in.Privileged,
-		CNIConfigPath:   in.CNIConfigPath,
-		RestartPolicy:   in.RestartPolicy,
+		ID:                     in.ID,
+		ContainerdID:           in.ContainerdID,
+		RealmID:                in.RealmName,
+		SpaceID:                in.SpaceName,
+		StackID:                in.StackName,
+		CellID:                 in.CellName,
+		Root:                   in.Root,
+		Image:                  in.Image,
+		Command:                in.Command,
+		Args:                   in.Args,
+		Env:                    in.Env,
+		Ports:                  in.Ports,
+		Volumes:                in.Volumes,
+		Networks:               in.Networks,
+		NetworksAliases:        in.NetworksAliases,
+		Privileged:             in.Privileged,
+		User:                   in.User,
+		ReadOnlyRootFilesystem: in.ReadOnlyRootFilesystem,
+		Capabilities:           buildCapabilitiesExternalFromInternal(in.Capabilities),
+		SecurityOpts:           in.SecurityOpts,
+		Tmpfs:                  buildTmpfsMountsExternalFromInternal(in.Tmpfs),
+		Resources:              buildResourcesExternalFromInternal(in.Resources),
+		CNIConfigPath:          in.CNIConfigPath,
+		RestartPolicy:          in.RestartPolicy,
+	}
+}
+
+func convertCapabilitiesToInternal(in *ext.ContainerCapabilities) *intmodel.ContainerCapabilities {
+	if in == nil {
+		return nil
+	}
+	return &intmodel.ContainerCapabilities{
+		Drop: in.Drop,
+		Add:  in.Add,
+	}
+}
+
+func buildCapabilitiesExternalFromInternal(in *intmodel.ContainerCapabilities) *ext.ContainerCapabilities {
+	if in == nil {
+		return nil
+	}
+	return &ext.ContainerCapabilities{
+		Drop: in.Drop,
+		Add:  in.Add,
+	}
+}
+
+func convertTmpfsMountsToInternal(in []ext.ContainerTmpfsMount) []intmodel.ContainerTmpfsMount {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]intmodel.ContainerTmpfsMount, len(in))
+	for i, m := range in {
+		out[i] = intmodel.ContainerTmpfsMount{
+			Path:      m.Path,
+			SizeBytes: m.SizeBytes,
+			Options:   m.Options,
+		}
+	}
+	return out
+}
+
+func buildTmpfsMountsExternalFromInternal(in []intmodel.ContainerTmpfsMount) []ext.ContainerTmpfsMount {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ext.ContainerTmpfsMount, len(in))
+	for i, m := range in {
+		out[i] = ext.ContainerTmpfsMount{
+			Path:      m.Path,
+			SizeBytes: m.SizeBytes,
+			Options:   m.Options,
+		}
+	}
+	return out
+}
+
+func convertResourcesToInternal(in *ext.ContainerResources) *intmodel.ContainerResources {
+	if in == nil {
+		return nil
+	}
+	return &intmodel.ContainerResources{
+		MemoryLimitBytes: in.MemoryLimitBytes,
+		CPUShares:        in.CPUShares,
+		PidsLimit:        in.PidsLimit,
+	}
+}
+
+func buildResourcesExternalFromInternal(in *intmodel.ContainerResources) *ext.ContainerResources {
+	if in == nil {
+		return nil
+	}
+	return &ext.ContainerResources{
+		MemoryLimitBytes: in.MemoryLimitBytes,
+		CPUShares:        in.CPUShares,
+		PidsLimit:        in.PidsLimit,
 	}
 }
 

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -260,3 +260,88 @@ func TestContainerRoundTripV1Beta1(t *testing.T) {
 		t.Fatalf("unexpected output status: %+v", output.Status)
 	}
 }
+
+func TestContainerRoundTripSecurityFieldsV1Beta1(t *testing.T) {
+	mem := int64(4 * 1024 * 1024 * 1024)
+	shares := int64(512)
+	pids := int64(256)
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata: ext.ContainerMetadata{
+			Name: "container-sec",
+		},
+		Spec: ext.ContainerSpec{
+			ID:                     "container-sec",
+			RealmID:                "realm0",
+			SpaceID:                "space0",
+			StackID:                "stack0",
+			CellID:                 "cell0",
+			Image:                  "alpine:latest",
+			User:                   "1000:1000",
+			ReadOnlyRootFilesystem: true,
+			Capabilities: &ext.ContainerCapabilities{
+				Drop: []string{"ALL"},
+				Add:  []string{"NET_ADMIN"},
+			},
+			SecurityOpts: []string{"no-new-privileges", "seccomp=unconfined"},
+			Tmpfs: []ext.ContainerTmpfsMount{
+				{Path: "/tmp", SizeBytes: 64 * 1024 * 1024, Options: []string{"mode=1777"}},
+			},
+			Resources: &ext.ContainerResources{
+				MemoryLimitBytes: &mem,
+				CPUShares:        &shares,
+				PidsLimit:        &pids,
+			},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	if internal.Spec.User != "1000:1000" || !internal.Spec.ReadOnlyRootFilesystem {
+		t.Fatalf("user/readOnly not carried: %+v", internal.Spec)
+	}
+	if internal.Spec.Capabilities == nil ||
+		len(internal.Spec.Capabilities.Drop) != 1 ||
+		internal.Spec.Capabilities.Drop[0] != "ALL" ||
+		internal.Spec.Capabilities.Add[0] != "NET_ADMIN" {
+		t.Fatalf("capabilities not carried: %+v", internal.Spec.Capabilities)
+	}
+	if len(internal.Spec.SecurityOpts) != 2 || internal.Spec.SecurityOpts[0] != "no-new-privileges" {
+		t.Fatalf("securityOpts not carried: %+v", internal.Spec.SecurityOpts)
+	}
+	if len(internal.Spec.Tmpfs) != 1 || internal.Spec.Tmpfs[0].Path != "/tmp" ||
+		internal.Spec.Tmpfs[0].SizeBytes != 64*1024*1024 {
+		t.Fatalf("tmpfs not carried: %+v", internal.Spec.Tmpfs)
+	}
+	if internal.Spec.Resources == nil || internal.Spec.Resources.MemoryLimitBytes == nil ||
+		*internal.Spec.Resources.MemoryLimitBytes != mem {
+		t.Fatalf("resources not carried: %+v", internal.Spec.Resources)
+	}
+
+	output, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	if output.Spec.User != input.Spec.User ||
+		output.Spec.ReadOnlyRootFilesystem != input.Spec.ReadOnlyRootFilesystem {
+		t.Fatalf("user/readOnly did not round-trip: %+v", output.Spec)
+	}
+	if output.Spec.Capabilities == nil || output.Spec.Capabilities.Drop[0] != "ALL" ||
+		output.Spec.Capabilities.Add[0] != "NET_ADMIN" {
+		t.Fatalf("capabilities did not round-trip: %+v", output.Spec.Capabilities)
+	}
+	if len(output.Spec.SecurityOpts) != 2 {
+		t.Fatalf("securityOpts did not round-trip: %+v", output.Spec.SecurityOpts)
+	}
+	if len(output.Spec.Tmpfs) != 1 || output.Spec.Tmpfs[0].Path != "/tmp" ||
+		output.Spec.Tmpfs[0].SizeBytes != 64*1024*1024 {
+		t.Fatalf("tmpfs did not round-trip: %+v", output.Spec.Tmpfs)
+	}
+	if output.Spec.Resources == nil || output.Spec.Resources.MemoryLimitBytes == nil ||
+		*output.Spec.Resources.MemoryLimitBytes != mem {
+		t.Fatalf("resources did not round-trip: %+v", output.Spec.Resources)
+	}
+}

--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -539,7 +539,136 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec) DiffResult {
 		)
 	}
 
+	if desired.User != actual.User {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "user")
+		result.Details["user"] = fmt.Sprintf("user changed from %q to %q", actual.User, desired.User)
+	}
+
+	if desired.ReadOnlyRootFilesystem != actual.ReadOnlyRootFilesystem {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "readOnlyRootFilesystem")
+		result.Details["readOnlyRootFilesystem"] = fmt.Sprintf(
+			"readOnlyRootFilesystem changed from %v to %v",
+			actual.ReadOnlyRootFilesystem,
+			desired.ReadOnlyRootFilesystem,
+		)
+	}
+
+	if !capabilitiesEqual(desired.Capabilities, actual.Capabilities) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "capabilities")
+		result.Details["capabilities"] = "capabilities changed"
+	}
+
+	if !slicesEqual(desired.SecurityOpts, actual.SecurityOpts) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "securityOpts")
+		result.Details["securityOpts"] = "securityOpts changed"
+	}
+
+	if !tmpfsEqual(desired.Tmpfs, actual.Tmpfs) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "tmpfs")
+		result.Details["tmpfs"] = "tmpfs mounts changed"
+	}
+
+	if !resourcesEqual(desired.Resources, actual.Resources) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "resources")
+		result.Details["resources"] = "resource limits changed"
+	}
+
 	return result
+}
+
+func capabilitiesEqual(a, b *intmodel.ContainerCapabilities) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return len(capabilitiesDrop(a))+len(capabilitiesAdd(a)) == 0 &&
+			len(capabilitiesDrop(b))+len(capabilitiesAdd(b)) == 0
+	}
+	return slicesEqual(a.Drop, b.Drop) && slicesEqual(a.Add, b.Add)
+}
+
+func capabilitiesDrop(c *intmodel.ContainerCapabilities) []string {
+	if c == nil {
+		return nil
+	}
+	return c.Drop
+}
+
+func capabilitiesAdd(c *intmodel.ContainerCapabilities) []string {
+	if c == nil {
+		return nil
+	}
+	return c.Add
+}
+
+func tmpfsEqual(a, b []intmodel.ContainerTmpfsMount) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Path != b[i].Path || a[i].SizeBytes != b[i].SizeBytes {
+			return false
+		}
+		if !slicesEqual(a[i].Options, b[i].Options) {
+			return false
+		}
+	}
+	return true
+}
+
+func resourcesEqual(a, b *intmodel.ContainerResources) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		// Treat nil and zeroed-out as equal so setting to nil or clearing all
+		// pointers collapses to the same result.
+		return resourcesAreZero(a) && resourcesAreZero(b)
+	}
+	return int64PtrEqual(a.MemoryLimitBytes, b.MemoryLimitBytes) &&
+		int64PtrEqual(a.CPUShares, b.CPUShares) &&
+		int64PtrEqual(a.PidsLimit, b.PidsLimit)
+}
+
+func resourcesAreZero(r *intmodel.ContainerResources) bool {
+	if r == nil {
+		return true
+	}
+	return r.MemoryLimitBytes == nil && r.CPUShares == nil && r.PidsLimit == nil
+}
+
+func int64PtrEqual(a, b *int64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 // Helper functions

--- a/internal/controller/create_container.go
+++ b/internal/controller/create_container.go
@@ -74,14 +74,20 @@ func (b *Exec) CreateContainer(container intmodel.Container) (CreateContainerRes
 
 	// Build container spec to merge into cell
 	newContainerSpec := intmodel.ContainerSpec{
-		ID:        container.Spec.ID,
-		RealmName: realm,
-		SpaceName: space,
-		StackName: stack,
-		CellName:  cellName,
-		Image:     image,
-		Command:   container.Spec.Command,
-		Args:      container.Spec.Args,
+		ID:                     container.Spec.ID,
+		RealmName:              realm,
+		SpaceName:              space,
+		StackName:              stack,
+		CellName:               cellName,
+		Image:                  image,
+		Command:                container.Spec.Command,
+		Args:                   container.Spec.Args,
+		User:                   container.Spec.User,
+		ReadOnlyRootFilesystem: container.Spec.ReadOnlyRootFilesystem,
+		Capabilities:           container.Spec.Capabilities,
+		SecurityOpts:           container.Spec.SecurityOpts,
+		Tmpfs:                  container.Spec.Tmpfs,
+		Resources:              container.Spec.Resources,
 	}
 
 	// Build lookup cell for pre-state check and CreateContainer call

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -276,11 +276,19 @@ func securitySpecOpts(spec intmodel.ContainerSpec) []oci.SpecOpts {
 	}
 
 	if spec.Capabilities != nil {
-		if len(spec.Capabilities.Drop) > 0 {
-			opts = append(opts, oci.WithDroppedCapabilities(normalizeCapabilities(spec.Capabilities.Drop)))
+		drop := normalizeCapabilities(spec.Capabilities.Drop)
+		add := normalizeCapabilities(spec.Capabilities.Add)
+		// "ALL" is not a real capability name — containerd's
+		// WithDroppedCapabilities does a literal string-match removal, so
+		// dropping "ALL" would leave the default cap set intact. Clear the
+		// whole set instead, then layer the add list on top.
+		if containsAllCaps(drop) {
+			opts = append(opts, oci.WithCapabilities(nil))
+		} else if len(drop) > 0 {
+			opts = append(opts, oci.WithDroppedCapabilities(drop))
 		}
-		if len(spec.Capabilities.Add) > 0 {
-			opts = append(opts, oci.WithAddedCapabilities(normalizeCapabilities(spec.Capabilities.Add)))
+		if len(add) > 0 {
+			opts = append(opts, oci.WithAddedCapabilities(add))
 		}
 	}
 
@@ -305,6 +313,17 @@ func securitySpecOpts(spec intmodel.ContainerSpec) []oci.SpecOpts {
 	}
 
 	return opts
+}
+
+// containsAllCaps reports whether the normalized capability list names the
+// "ALL" sentinel in any of its accepted spellings.
+func containsAllCaps(caps []string) bool {
+	for _, c := range caps {
+		if c == "ALL" || c == "CAP_ALL" {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeCapabilities ensures each capability name has the "CAP_" prefix and

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -18,8 +18,11 @@ package ctr
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -202,6 +205,8 @@ func BuildContainerSpec(
 		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
 
+	specOpts = append(specOpts, securitySpecOpts(containerSpec)...)
+
 	return ContainerSpec{
 		ID:            containerdID,
 		Image:         containerSpec.Image,
@@ -254,4 +259,178 @@ func parseVolumeMounts(volumes []string) []runtimespec.Mount {
 		})
 	}
 	return mounts
+}
+
+// securitySpecOpts translates the security/isolation fields on the internal
+// ContainerSpec (user, readOnlyRootFilesystem, capabilities, securityOpts,
+// tmpfs, resources) into OCI spec options.
+func securitySpecOpts(spec intmodel.ContainerSpec) []oci.SpecOpts {
+	var opts []oci.SpecOpts
+
+	if spec.User != "" {
+		opts = append(opts, oci.WithUser(spec.User))
+	}
+
+	if spec.ReadOnlyRootFilesystem {
+		opts = append(opts, oci.WithRootFSReadonly())
+	}
+
+	if spec.Capabilities != nil {
+		if len(spec.Capabilities.Drop) > 0 {
+			opts = append(opts, oci.WithDroppedCapabilities(normalizeCapabilities(spec.Capabilities.Drop)))
+		}
+		if len(spec.Capabilities.Add) > 0 {
+			opts = append(opts, oci.WithAddedCapabilities(normalizeCapabilities(spec.Capabilities.Add)))
+		}
+	}
+
+	for _, entry := range spec.SecurityOpts {
+		opts = append(opts, securityOptSpecOpt(entry))
+	}
+
+	if mounts := buildTmpfsMounts(spec.Tmpfs); len(mounts) > 0 {
+		opts = append(opts, oci.WithMounts(mounts))
+	}
+
+	if spec.Resources != nil {
+		if spec.Resources.MemoryLimitBytes != nil && *spec.Resources.MemoryLimitBytes > 0 {
+			opts = append(opts, oci.WithMemoryLimit(uint64(*spec.Resources.MemoryLimitBytes)))
+		}
+		if spec.Resources.CPUShares != nil && *spec.Resources.CPUShares > 0 {
+			opts = append(opts, oci.WithCPUShares(uint64(*spec.Resources.CPUShares)))
+		}
+		if spec.Resources.PidsLimit != nil && *spec.Resources.PidsLimit > 0 {
+			opts = append(opts, oci.WithPidsLimit(*spec.Resources.PidsLimit))
+		}
+	}
+
+	return opts
+}
+
+// normalizeCapabilities ensures each capability name has the "CAP_" prefix and
+// is upper-case, which is what the OCI runtime spec expects. Callers are free
+// to write "NET_ADMIN" or "cap_net_admin"; both normalize to "CAP_NET_ADMIN".
+func normalizeCapabilities(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, c := range in {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		upper := strings.ToUpper(c)
+		if upper == "ALL" || strings.HasPrefix(upper, "CAP_") {
+			out = append(out, upper)
+			continue
+		}
+		out = append(out, "CAP_"+upper)
+	}
+	return out
+}
+
+// buildTmpfsMounts returns OCI mounts for each declared tmpfs entry. Size is
+// emitted as the standard tmpfs "size=N" option when set.
+func buildTmpfsMounts(entries []intmodel.ContainerTmpfsMount) []runtimespec.Mount {
+	if len(entries) == 0 {
+		return nil
+	}
+	mounts := make([]runtimespec.Mount, 0, len(entries))
+	for _, e := range entries {
+		path := strings.TrimSpace(e.Path)
+		if path == "" {
+			continue
+		}
+		options := []string{"nosuid", "nodev"}
+		if e.SizeBytes > 0 {
+			options = append(options, "size="+strconv.FormatInt(e.SizeBytes, 10))
+		}
+		options = append(options, e.Options...)
+		mounts = append(mounts, runtimespec.Mount{
+			Destination: path,
+			Source:      "tmpfs",
+			Type:        "tmpfs",
+			Options:     options,
+		})
+	}
+	return mounts
+}
+
+// securityOptSpecOpt parses a single docker-style security option
+// ("no-new-privileges", "seccomp=unconfined", "seccomp=/path/to/profile.json")
+// and returns a SpecOpts that applies it. Unknown keys return an error at
+// spec-apply time so callers see a clear failure rather than a silent pass.
+func securityOptSpecOpt(raw string) oci.SpecOpts {
+	entry := strings.TrimSpace(raw)
+	key, value, hasValue := splitSecurityOpt(entry)
+
+	switch strings.ToLower(key) {
+	case "no-new-privileges":
+		enabled := true
+		if hasValue {
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return errorSpecOpt(fmt.Errorf("securityOpt %q: invalid bool: %w", raw, err))
+			}
+			enabled = parsed
+		}
+		return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
+			if s.Process == nil {
+				s.Process = &runtimespec.Process{}
+			}
+			s.Process.NoNewPrivileges = enabled
+			return nil
+		}
+	case "seccomp":
+		return seccompSpecOpt(raw, value, hasValue)
+	default:
+		return errorSpecOpt(fmt.Errorf("unsupported securityOpt %q", raw))
+	}
+}
+
+// splitSecurityOpt parses "key=value" and "key:value" forms. A bare "key"
+// returns (key, "", false).
+func splitSecurityOpt(entry string) (key, value string, ok bool) {
+	if idx := strings.IndexAny(entry, "=:"); idx >= 0 {
+		return strings.TrimSpace(entry[:idx]), strings.TrimSpace(entry[idx+1:]), true
+	}
+	return entry, "", false
+}
+
+// seccompSpecOpt handles seccomp=unconfined (strip profile) and
+// seccomp=/path/to/profile.json (load + apply) forms.
+func seccompSpecOpt(raw, value string, hasValue bool) oci.SpecOpts {
+	if !hasValue || value == "" {
+		return errorSpecOpt(fmt.Errorf("securityOpt %q: seccomp requires a value (unconfined or profile path)", raw))
+	}
+	if strings.EqualFold(value, "unconfined") {
+		return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
+			if s.Linux != nil {
+				s.Linux.Seccomp = nil
+			}
+			return nil
+		}
+	}
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
+		data, err := os.ReadFile(value)
+		if err != nil {
+			return fmt.Errorf("securityOpt %q: read seccomp profile: %w", raw, err)
+		}
+		profile := &runtimespec.LinuxSeccomp{}
+		if err = json.Unmarshal(data, profile); err != nil {
+			return fmt.Errorf("securityOpt %q: parse seccomp profile: %w", raw, err)
+		}
+		if s.Linux == nil {
+			s.Linux = &runtimespec.Linux{}
+		}
+		s.Linux.Seccomp = profile
+		return nil
+	}
+}
+
+// errorSpecOpt returns a SpecOpts that always fails with the given error. Used
+// to defer reporting of invalid user input until spec application so the call
+// site still composes cleanly.
+func errorSpecOpt(err error) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, _ *runtimespec.Spec) error {
+		return err
+	}
 }

--- a/internal/ctr/spec_security_test.go
+++ b/internal/ctr/spec_security_test.go
@@ -70,7 +70,38 @@ func TestBuildContainerSpec_UserAndReadonlyRootfs(t *testing.T) {
 }
 
 func TestBuildContainerSpec_Capabilities(t *testing.T) {
-	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+	// Pre-populate a realistic default cap set so drop-ALL has something to
+	// clear. containerd's populateDefaultUnixSpec seeds this set at
+	// container-create time in production; applyBuiltSpec starts from an
+	// empty spec, so the test must seed it itself or drop-ALL passes
+	// vacuously.
+	defaults := []string{
+		"CAP_CHOWN",
+		"CAP_DAC_OVERRIDE",
+		"CAP_FSETID",
+		"CAP_FOWNER",
+		"CAP_MKNOD",
+		"CAP_NET_RAW",
+		"CAP_SETGID",
+		"CAP_SETUID",
+		"CAP_SETFCAP",
+		"CAP_SETPCAP",
+		"CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT",
+		"CAP_KILL",
+		"CAP_AUDIT_WRITE",
+	}
+	spec := &runtimespec.Spec{
+		Process: &runtimespec.Process{
+			Capabilities: &runtimespec.LinuxCapabilities{
+				Bounding:  append([]string(nil), defaults...),
+				Permitted: append([]string(nil), defaults...),
+				Effective: append([]string(nil), defaults...),
+			},
+		},
+		Linux: &runtimespec.Linux{},
+	}
+	built := ctr.BuildContainerSpec(intmodel.ContainerSpec{
 		ID:        "c1",
 		Image:     "docker.io/library/busybox:latest",
 		CellName:  "cell",
@@ -82,17 +113,26 @@ func TestBuildContainerSpec_Capabilities(t *testing.T) {
 			Add:  []string{"NET_ADMIN"},
 		},
 	})
+	for _, opt := range built.SpecOpts {
+		if err := opt(context.Background(), nil, nil, spec); err != nil {
+			t.Fatalf("SpecOpts returned error: %v", err)
+		}
+	}
 
 	if spec.Process == nil || spec.Process.Capabilities == nil {
 		t.Fatalf("Process.Capabilities is nil")
 	}
-	// After drop ALL + add NET_ADMIN, the effective set should contain
-	// exactly CAP_NET_ADMIN and nothing else.
+	// After drop ALL + add NET_ADMIN, each cap set should contain exactly
+	// CAP_NET_ADMIN and nothing else — the defaults seeded above must be
+	// cleared.
 	if !containsOnly(spec.Process.Capabilities.Effective, "CAP_NET_ADMIN") {
 		t.Errorf("Effective caps = %v, want only CAP_NET_ADMIN", spec.Process.Capabilities.Effective)
 	}
 	if !containsOnly(spec.Process.Capabilities.Bounding, "CAP_NET_ADMIN") {
 		t.Errorf("Bounding caps = %v, want only CAP_NET_ADMIN", spec.Process.Capabilities.Bounding)
+	}
+	if !containsOnly(spec.Process.Capabilities.Permitted, "CAP_NET_ADMIN") {
+		t.Errorf("Permitted caps = %v, want only CAP_NET_ADMIN", spec.Process.Capabilities.Permitted)
 	}
 }
 

--- a/internal/ctr/spec_security_test.go
+++ b/internal/ctr/spec_security_test.go
@@ -1,0 +1,273 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	ctr "github.com/eminwux/kukeon/internal/ctr"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// applyBuiltSpec composes the SpecOpts produced by BuildContainerSpec into an
+// empty runtime spec so tests can assert on the resulting OCI fields without
+// touching containerd.
+func applyBuiltSpec(t *testing.T, in intmodel.ContainerSpec) *runtimespec.Spec {
+	t.Helper()
+	spec := &runtimespec.Spec{
+		Process: &runtimespec.Process{},
+		Linux:   &runtimespec.Linux{},
+	}
+	built := ctr.BuildContainerSpec(in)
+	for _, opt := range built.SpecOpts {
+		if err := opt(context.Background(), nil, nil, spec); err != nil {
+			t.Fatalf("SpecOpts returned error: %v", err)
+		}
+	}
+	return spec
+}
+
+func ptrInt64(v int64) *int64 { return &v }
+
+func TestBuildContainerSpec_UserAndReadonlyRootfs(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:                     "c1",
+		Image:                  "docker.io/library/busybox:latest",
+		CellName:               "cell",
+		SpaceName:              "space",
+		RealmName:              "realm",
+		StackName:              "stack",
+		User:                   "1000:1000",
+		ReadOnlyRootFilesystem: true,
+	})
+
+	if spec.Process == nil || spec.Process.User.UID != 1000 || spec.Process.User.GID != 1000 {
+		t.Fatalf("Process.User = %+v, want UID=1000 GID=1000", spec.Process.User)
+	}
+	if spec.Root == nil || !spec.Root.Readonly {
+		t.Fatalf("Root.Readonly = %+v, want readonly=true", spec.Root)
+	}
+}
+
+func TestBuildContainerSpec_Capabilities(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:        "c1",
+		Image:     "docker.io/library/busybox:latest",
+		CellName:  "cell",
+		SpaceName: "space",
+		RealmName: "realm",
+		StackName: "stack",
+		Capabilities: &intmodel.ContainerCapabilities{
+			Drop: []string{"ALL"},
+			Add:  []string{"NET_ADMIN"},
+		},
+	})
+
+	if spec.Process == nil || spec.Process.Capabilities == nil {
+		t.Fatalf("Process.Capabilities is nil")
+	}
+	// After drop ALL + add NET_ADMIN, the effective set should contain
+	// exactly CAP_NET_ADMIN and nothing else.
+	if !containsOnly(spec.Process.Capabilities.Effective, "CAP_NET_ADMIN") {
+		t.Errorf("Effective caps = %v, want only CAP_NET_ADMIN", spec.Process.Capabilities.Effective)
+	}
+	if !containsOnly(spec.Process.Capabilities.Bounding, "CAP_NET_ADMIN") {
+		t.Errorf("Bounding caps = %v, want only CAP_NET_ADMIN", spec.Process.Capabilities.Bounding)
+	}
+}
+
+func TestBuildContainerSpec_TmpfsMounts(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:        "c1",
+		Image:     "docker.io/library/busybox:latest",
+		CellName:  "cell",
+		SpaceName: "space",
+		RealmName: "realm",
+		StackName: "stack",
+		Tmpfs: []intmodel.ContainerTmpfsMount{
+			{Path: "/tmp", SizeBytes: 64 * 1024 * 1024, Options: []string{"mode=1777"}},
+		},
+	})
+
+	var found *runtimespec.Mount
+	for i := range spec.Mounts {
+		if spec.Mounts[i].Destination == "/tmp" {
+			found = &spec.Mounts[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("tmpfs mount for /tmp not found, mounts=%+v", spec.Mounts)
+	}
+	if found.Type != "tmpfs" {
+		t.Errorf("mount type = %q, want %q", found.Type, "tmpfs")
+	}
+	if !containsString(found.Options, "size=67108864") {
+		t.Errorf("tmpfs options = %v, want size=67108864", found.Options)
+	}
+	if !containsString(found.Options, "mode=1777") {
+		t.Errorf("tmpfs options = %v, want mode=1777", found.Options)
+	}
+}
+
+func TestBuildContainerSpec_Resources(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:        "c1",
+		Image:     "docker.io/library/busybox:latest",
+		CellName:  "cell",
+		SpaceName: "space",
+		RealmName: "realm",
+		StackName: "stack",
+		Resources: &intmodel.ContainerResources{
+			MemoryLimitBytes: ptrInt64(4 * 1024 * 1024 * 1024),
+			CPUShares:        ptrInt64(512),
+			PidsLimit:        ptrInt64(256),
+		},
+	})
+
+	if spec.Linux == nil || spec.Linux.Resources == nil {
+		t.Fatalf("Linux.Resources is nil")
+	}
+	if spec.Linux.Resources.Memory == nil || spec.Linux.Resources.Memory.Limit == nil ||
+		*spec.Linux.Resources.Memory.Limit != 4*1024*1024*1024 {
+		t.Errorf("Memory.Limit = %+v, want 4GiB", spec.Linux.Resources.Memory)
+	}
+	if spec.Linux.Resources.CPU == nil || spec.Linux.Resources.CPU.Shares == nil ||
+		*spec.Linux.Resources.CPU.Shares != 512 {
+		t.Errorf("CPU.Shares = %+v, want 512", spec.Linux.Resources.CPU)
+	}
+	if spec.Linux.Resources.Pids == nil || spec.Linux.Resources.Pids.Limit != 256 {
+		t.Errorf("Pids.Limit = %+v, want 256", spec.Linux.Resources.Pids)
+	}
+}
+
+func TestBuildContainerSpec_SecurityOptsNoNewPrivileges(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:           "c1",
+		Image:        "docker.io/library/busybox:latest",
+		CellName:     "cell",
+		SpaceName:    "space",
+		RealmName:    "realm",
+		StackName:    "stack",
+		SecurityOpts: []string{"no-new-privileges"},
+	})
+	if !spec.Process.NoNewPrivileges {
+		t.Fatalf("Process.NoNewPrivileges = false, want true")
+	}
+}
+
+func TestBuildContainerSpec_SecurityOptsSeccompUnconfined(t *testing.T) {
+	// Pre-populate Linux.Seccomp so we can observe it being cleared.
+	spec := &runtimespec.Spec{
+		Process: &runtimespec.Process{},
+		Linux: &runtimespec.Linux{
+			Seccomp: &runtimespec.LinuxSeccomp{DefaultAction: runtimespec.ActErrno},
+		},
+	}
+	built := ctr.BuildContainerSpec(intmodel.ContainerSpec{
+		ID:           "c1",
+		Image:        "docker.io/library/busybox:latest",
+		CellName:     "cell",
+		SpaceName:    "space",
+		RealmName:    "realm",
+		StackName:    "stack",
+		SecurityOpts: []string{"seccomp=unconfined"},
+	})
+	for _, opt := range built.SpecOpts {
+		if err := opt(context.Background(), nil, nil, spec); err != nil {
+			t.Fatalf("SpecOpts returned error: %v", err)
+		}
+	}
+	if spec.Linux.Seccomp != nil {
+		t.Fatalf("Linux.Seccomp = %+v, want nil after seccomp=unconfined", spec.Linux.Seccomp)
+	}
+}
+
+func TestBuildContainerSpec_SecurityOptsSeccompProfile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profile.json")
+	profile := runtimespec.LinuxSeccomp{
+		DefaultAction: runtimespec.ActErrno,
+	}
+	data, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("marshal profile: %v", err)
+	}
+	if err = os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:           "c1",
+		Image:        "docker.io/library/busybox:latest",
+		CellName:     "cell",
+		SpaceName:    "space",
+		RealmName:    "realm",
+		StackName:    "stack",
+		SecurityOpts: []string{"seccomp=" + path},
+	})
+	if spec.Linux.Seccomp == nil {
+		t.Fatalf("Linux.Seccomp is nil, want profile loaded")
+	}
+	if spec.Linux.Seccomp.DefaultAction != runtimespec.ActErrno {
+		t.Errorf("DefaultAction = %q, want %q", spec.Linux.Seccomp.DefaultAction, runtimespec.ActErrno)
+	}
+}
+
+func TestBuildContainerSpec_SecurityOptsUnknownErrors(t *testing.T) {
+	spec := &runtimespec.Spec{Process: &runtimespec.Process{}, Linux: &runtimespec.Linux{}}
+	built := ctr.BuildContainerSpec(intmodel.ContainerSpec{
+		ID:           "c1",
+		Image:        "docker.io/library/busybox:latest",
+		CellName:     "cell",
+		SpaceName:    "space",
+		RealmName:    "realm",
+		StackName:    "stack",
+		SecurityOpts: []string{"apparmor=my-profile"},
+	})
+	var sawError bool
+	for _, opt := range built.SpecOpts {
+		if err := opt(context.Background(), nil, nil, spec); err != nil {
+			if !strings.Contains(err.Error(), "unsupported securityOpt") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Fatalf("expected unsupported securityOpt error, got none")
+	}
+}
+
+func containsString(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsOnly(xs []string, want string) bool {
+	return len(xs) == 1 && xs[0] == want
+}

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -30,24 +30,51 @@ type ContainerMetadata struct {
 }
 
 type ContainerSpec struct {
-	ID              string
-	ContainerdID    string
-	RealmName       string
-	SpaceName       string
-	StackName       string
-	CellName        string
-	Root            bool
-	Image           string
-	Command         string
-	Args            []string
-	Env             []string
-	Ports           []string
-	Volumes         []string
-	Networks        []string
-	NetworksAliases []string
-	Privileged      bool
-	CNIConfigPath   string
-	RestartPolicy   string
+	ID                     string
+	ContainerdID           string
+	RealmName              string
+	SpaceName              string
+	StackName              string
+	CellName               string
+	Root                   bool
+	Image                  string
+	Command                string
+	Args                   []string
+	Env                    []string
+	Ports                  []string
+	Volumes                []string
+	Networks               []string
+	NetworksAliases        []string
+	Privileged             bool
+	User                   string
+	ReadOnlyRootFilesystem bool
+	Capabilities           *ContainerCapabilities
+	SecurityOpts           []string
+	Tmpfs                  []ContainerTmpfsMount
+	Resources              *ContainerResources
+	CNIConfigPath          string
+	RestartPolicy          string
+}
+
+// ContainerCapabilities groups Linux capability deltas applied relative to the
+// image default set.
+type ContainerCapabilities struct {
+	Drop []string
+	Add  []string
+}
+
+// ContainerTmpfsMount declares a tmpfs mount inside the container.
+type ContainerTmpfsMount struct {
+	Path      string
+	SizeBytes int64
+	Options   []string
+}
+
+// ContainerResources exposes the cgroup v2 knobs supported per container.
+type ContainerResources struct {
+	MemoryLimitBytes *int64
+	CPUShares        *int64
+	PidsLimit        *int64
 }
 
 type ContainerStatus struct {

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -32,24 +32,52 @@ type ContainerMetadata struct {
 }
 
 type ContainerSpec struct {
-	ID              string   `json:"id"                      yaml:"id"`
-	ContainerdID    string   `json:"containerdId,omitempty"  yaml:"containerdId,omitempty"`
-	RealmID         string   `json:"realmId"                 yaml:"realmId"`
-	SpaceID         string   `json:"spaceId"                 yaml:"spaceId"`
-	StackID         string   `json:"stackId"                 yaml:"stackId"`
-	CellID          string   `json:"cellId"                  yaml:"cellId"`
-	Root            bool     `json:"root,omitempty"          yaml:"root,omitempty"`
-	Image           string   `json:"image"                   yaml:"image"`
-	Command         string   `json:"command"                 yaml:"command"`
-	Args            []string `json:"args"                    yaml:"args"`
-	Env             []string `json:"env"                     yaml:"env"`
-	Ports           []string `json:"ports"                   yaml:"ports"`
-	Volumes         []string `json:"volumes"                 yaml:"volumes"`
-	Networks        []string `json:"networks"                yaml:"networks"`
-	NetworksAliases []string `json:"networksAliases"         yaml:"networksAliases"`
-	Privileged      bool     `json:"privileged"              yaml:"privileged"`
-	CNIConfigPath   string   `json:"cniConfigPath,omitempty" yaml:"cniConfigPath,omitempty"`
-	RestartPolicy   string   `json:"restartPolicy"           yaml:"restartPolicy"`
+	ID                     string                 `json:"id"                               yaml:"id"`
+	ContainerdID           string                 `json:"containerdId,omitempty"           yaml:"containerdId,omitempty"`
+	RealmID                string                 `json:"realmId"                          yaml:"realmId"`
+	SpaceID                string                 `json:"spaceId"                          yaml:"spaceId"`
+	StackID                string                 `json:"stackId"                          yaml:"stackId"`
+	CellID                 string                 `json:"cellId"                           yaml:"cellId"`
+	Root                   bool                   `json:"root,omitempty"                   yaml:"root,omitempty"`
+	Image                  string                 `json:"image"                            yaml:"image"`
+	Command                string                 `json:"command"                          yaml:"command"`
+	Args                   []string               `json:"args"                             yaml:"args"`
+	Env                    []string               `json:"env"                              yaml:"env"`
+	Ports                  []string               `json:"ports"                            yaml:"ports"`
+	Volumes                []string               `json:"volumes"                          yaml:"volumes"`
+	Networks               []string               `json:"networks"                         yaml:"networks"`
+	NetworksAliases        []string               `json:"networksAliases"                  yaml:"networksAliases"`
+	Privileged             bool                   `json:"privileged"                       yaml:"privileged"`
+	User                   string                 `json:"user,omitempty"                   yaml:"user,omitempty"`
+	ReadOnlyRootFilesystem bool                   `json:"readOnlyRootFilesystem,omitempty" yaml:"readOnlyRootFilesystem,omitempty"`
+	Capabilities           *ContainerCapabilities `json:"capabilities,omitempty"           yaml:"capabilities,omitempty"`
+	SecurityOpts           []string               `json:"securityOpts,omitempty"           yaml:"securityOpts,omitempty"`
+	Tmpfs                  []ContainerTmpfsMount  `json:"tmpfs,omitempty"                  yaml:"tmpfs,omitempty"`
+	Resources              *ContainerResources    `json:"resources,omitempty"              yaml:"resources,omitempty"`
+	CNIConfigPath          string                 `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
+	RestartPolicy          string                 `json:"restartPolicy"                    yaml:"restartPolicy"`
+}
+
+// ContainerCapabilities groups Linux capability deltas applied to the
+// container process relative to the image default set.
+type ContainerCapabilities struct {
+	Drop []string `json:"drop,omitempty" yaml:"drop,omitempty"`
+	Add  []string `json:"add,omitempty"  yaml:"add,omitempty"`
+}
+
+// ContainerTmpfsMount declares a tmpfs mount inside the container.
+type ContainerTmpfsMount struct {
+	Path      string   `json:"path"                yaml:"path"`
+	SizeBytes int64    `json:"sizeBytes,omitempty" yaml:"sizeBytes,omitempty"`
+	Options   []string `json:"options,omitempty"   yaml:"options,omitempty"`
+}
+
+// ContainerResources exposes the cgroup v2 knobs the orchestrator supports for
+// per-container resource limits.
+type ContainerResources struct {
+	MemoryLimitBytes *int64 `json:"memoryLimitBytes,omitempty" yaml:"memoryLimitBytes,omitempty"`
+	CPUShares        *int64 `json:"cpuShares,omitempty"        yaml:"cpuShares,omitempty"`
+	PidsLimit        *int64 `json:"pidsLimit,omitempty"        yaml:"pidsLimit,omitempty"`
 }
 
 type ContainerStatus struct {
@@ -158,6 +186,28 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 	out.Spec.Volumes = cloneSlice(out.Spec.Volumes)
 	out.Spec.Networks = cloneSlice(out.Spec.Networks)
 	out.Spec.NetworksAliases = cloneSlice(out.Spec.NetworksAliases)
+	out.Spec.SecurityOpts = cloneSlice(out.Spec.SecurityOpts)
+
+	if out.Spec.Capabilities != nil {
+		caps := *out.Spec.Capabilities
+		caps.Drop = cloneSlice(caps.Drop)
+		caps.Add = cloneSlice(caps.Add)
+		out.Spec.Capabilities = &caps
+	}
+
+	if len(out.Spec.Tmpfs) > 0 {
+		mounts := make([]ContainerTmpfsMount, len(out.Spec.Tmpfs))
+		for i, m := range out.Spec.Tmpfs {
+			m.Options = cloneSlice(m.Options)
+			mounts[i] = m
+		}
+		out.Spec.Tmpfs = mounts
+	}
+
+	if out.Spec.Resources != nil {
+		res := *out.Spec.Resources
+		out.Spec.Resources = &res
+	}
 
 	return &out
 }


### PR DESCRIPTION
## Summary
- Extend the Container spec with the standard isolation knobs agents and untrusted workloads need: `user`, `readOnlyRootFilesystem`, `capabilities.drop/add`, `securityOpts`, `tmpfs`, and `resources.{memoryLimitBytes,cpuShares,pidsLimit}`. Each field round-trips through the v1beta1 API, the internal hub, and `kuke get -o yaml`.
- Translate the new fields into OCI SpecOpts in `ctr.BuildContainerSpec`: `oci.WithUser`, `oci.WithRootFSReadonly`, capability add/drop, tmpfs mounts (size promoted to the standard `size=N` option), memory / CPU shares / pids limits via `oci.With*`, and a `securityOpts` parser that understands `no-new-privileges` and `seccomp=unconfined|<path>` and rejects unknown keys.
- Wire the fields through `controller.CreateContainer` (previously dropped) and the apply-diff so `kuke apply` detects changes to them. Add new CLI flags mirroring `docker run --user --read-only --cap-drop --cap-add --security-opt --tmpfs --memory --cpu-shares --pids-limit` on `kuke create container`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v '/e2e$')` — new tests pass; the two pre-existing `internal/ctr` failures (`TestDefaultRootContainerSpec`, `TestBuildRootContainerSpec`) reproduce on `main` and are unrelated to this change
- [x] `make kuke` builds an ELF binary; `kuke create container --help` shows the new flags
- [x] `./kuke create container test --memory notabyte --cell foo` → clear parse error; `./kuke create container test --tmpfs /tmp:size=bad --cell foo` → size-parse error
- [ ] Daemon-parity smoke test from CLAUDE.md (`kuke init` + `kuke get realms` via daemon and `--no-daemon`) — requires a host with containerd and root privileges; not runnable in this sandbox

Closes #43