### PR TITLE
feat: add container secrets with fromFile/fromEnv injection

### DIFF
--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -63,6 +63,7 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 | `networks`         | array of string  | no       | Additional CNI networks to join beyond the cell's default                               |
 | `networksAliases`  | array of string  | no       | DNS aliases for the container within its CNI networks                                   |
 | `privileged`       | bool             | no       | Run privileged (full capabilities, access to `/dev`, etc.)                              |
+| `secrets`          | array of `ContainerSecret` | no | Inject credentials resolved by the daemon — never written to status or YAML (see [ContainerSecret](#containersecret)) |
 | `cniConfigPath`    | string           | no       | Override the CNI config directory for this container                                    |
 | `restartPolicy`    | string           | no       | Restart policy. Reserved — restart semantics are not finalized.                         |
 
@@ -78,6 +79,32 @@ Each entry in `spec.volumes` is a bind mount of a host path into the container.
 | `source`   | string | yes      | Absolute host path. Must exist at apply time. Named / managed volumes are not supported. |
 | `target`   | string | yes      | Absolute path inside the container                                          |
 | `readOnly` | bool   | no       | Mount read-only when `true` (writes fail with `EROFS`). Defaults to `false`. |
+
+### ContainerSecret
+
+Each entry in `spec.secrets` references a credential the daemon resolves at apply time. Only the reference is persisted — the resolved value never appears in `kuke get -o yaml`, in object status, or in daemon logs.
+
+| Field        | Type   | Required | Description                                                                                                |
+|--------------|--------|----------|------------------------------------------------------------------------------------------------------------|
+| `name`       | string | yes      | Environment-variable name (default mode) or basename of the mounted secret file when `mountPath` is set    |
+| `fromFile`   | string | one of required | Absolute host path the daemon reads at apply time. Missing files produce a clear error.             |
+| `fromEnv`    | string | one of required | Name of an environment variable set on the daemon host. Missing env vars produce a clear error.     |
+| `mountPath`  | string | no       | Absolute path inside the container. When set, the secret is staged with mode `0400` and bind-mounted read-only instead of being injected as an env var. |
+
+Exactly one of `fromFile` / `fromEnv` must be set. Example:
+
+```yaml
+secrets:
+  - name: ANTHROPIC_API_KEY
+    fromFile: /etc/kukeon/secrets/anthropic.key
+  - name: GITHUB_TOKEN
+    fromEnv: GITHUB_TOKEN_SCOPED
+  - name: tls.crt
+    fromFile: /etc/kukeon/secrets/tls.crt
+    mountPath: /run/secrets/tls.crt
+```
+
+File-mount mode stages secrets under `/run/kukeon/secrets/<containerdId>/<name>` on the host, with owner-only read perms, then bind-mounts them read-only into the container. Because containerd persists resolved env vars in its own runtime spec, env-injection mode leaves the value in containerd's state; file-mount mode keeps it only in the tmpfs staging file.
 
 ## status
 

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -284,6 +284,7 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				SecurityOpts:           in.Spec.SecurityOpts,
 				Tmpfs:                  convertTmpfsMountsToInternal(in.Spec.Tmpfs),
 				Resources:              convertResourcesToInternal(in.Spec.Resources),
+				Secrets:                convertSecretsToInternal(in.Spec.Secrets),
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
 			},
@@ -337,6 +338,7 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				SecurityOpts:           in.Spec.SecurityOpts,
 				Tmpfs:                  buildTmpfsMountsExternalFromInternal(in.Spec.Tmpfs),
 				Resources:              buildResourcesExternalFromInternal(in.Spec.Resources),
+				Secrets:                buildSecretsExternalFromInternal(in.Spec.Secrets),
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
 			},
@@ -393,6 +395,7 @@ func convertContainerSpecToInternal(in ext.ContainerSpec) intmodel.ContainerSpec
 		SecurityOpts:           in.SecurityOpts,
 		Tmpfs:                  convertTmpfsMountsToInternal(in.Tmpfs),
 		Resources:              convertResourcesToInternal(in.Resources),
+		Secrets:                convertSecretsToInternal(in.Secrets),
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
 	}
@@ -424,6 +427,7 @@ func BuildContainerSpecExternalFromInternal(in intmodel.ContainerSpec) ext.Conta
 		SecurityOpts:           in.SecurityOpts,
 		Tmpfs:                  buildTmpfsMountsExternalFromInternal(in.Tmpfs),
 		Resources:              buildResourcesExternalFromInternal(in.Resources),
+		Secrets:                buildSecretsExternalFromInternal(in.Secrets),
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
 	}
@@ -499,6 +503,42 @@ func buildResourcesExternalFromInternal(in *intmodel.ContainerResources) *ext.Co
 		CPUShares:        in.CPUShares,
 		PidsLimit:        in.PidsLimit,
 	}
+}
+
+// convertSecretsToInternal copies external secret references into the internal
+// model. Only the reference metadata (name + source + optional mountPath) is
+// carried; there is no value field on either side.
+func convertSecretsToInternal(in []ext.ContainerSecret) []intmodel.ContainerSecret {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]intmodel.ContainerSecret, len(in))
+	for i, s := range in {
+		out[i] = intmodel.ContainerSecret{
+			Name:      s.Name,
+			FromFile:  s.FromFile,
+			FromEnv:   s.FromEnv,
+			MountPath: s.MountPath,
+		}
+	}
+	return out
+}
+
+// buildSecretsExternalFromInternal is the inverse of convertSecretsToInternal.
+func buildSecretsExternalFromInternal(in []intmodel.ContainerSecret) []ext.ContainerSecret {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ext.ContainerSecret, len(in))
+	for i, s := range in {
+		out[i] = ext.ContainerSecret{
+			Name:      s.Name,
+			FromFile:  s.FromFile,
+			FromEnv:   s.FromEnv,
+			MountPath: s.MountPath,
+		}
+	}
+	return out
 }
 
 func volumeMountsToInternal(in []ext.VolumeMount) []intmodel.VolumeMount {

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -17,11 +17,13 @@
 package apischeme_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/apischeme"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRealmRoundTripV1Beta1(t *testing.T) {
@@ -355,5 +357,105 @@ func TestContainerRoundTripSecurityFieldsV1Beta1(t *testing.T) {
 	if output.Spec.Resources == nil || output.Spec.Resources.MemoryLimitBytes == nil ||
 		*output.Spec.Resources.MemoryLimitBytes != mem {
 		t.Fatalf("resources did not round-trip: %+v", output.Spec.Resources)
+	}
+}
+
+func TestContainerSecretsRoundTripV1Beta1(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "container-secrets"},
+		Spec: ext.ContainerSpec{
+			ID:      "container-secrets",
+			RealmID: "realm0",
+			SpaceID: "space0",
+			StackID: "stack0",
+			CellID:  "cell0",
+			Image:   "alpine:latest",
+			Secrets: []ext.ContainerSecret{
+				{Name: "ANTHROPIC_API_KEY", FromFile: "/etc/kukeon/secrets/anthropic.key"},
+				{Name: "GITHUB_TOKEN", FromEnv: "GITHUB_TOKEN_SCOPED"},
+				{
+					Name:      "tls.crt",
+					FromFile:  "/etc/kukeon/secrets/tls.crt",
+					MountPath: "/run/secrets/tls.crt",
+				},
+			},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	if len(internal.Spec.Secrets) != 3 {
+		t.Fatalf("expected 3 internal secrets, got %d", len(internal.Spec.Secrets))
+	}
+	if internal.Spec.Secrets[0].Name != "ANTHROPIC_API_KEY" ||
+		internal.Spec.Secrets[0].FromFile != "/etc/kukeon/secrets/anthropic.key" ||
+		internal.Spec.Secrets[0].FromEnv != "" ||
+		internal.Spec.Secrets[0].MountPath != "" {
+		t.Fatalf("secret[0] did not normalize: %+v", internal.Spec.Secrets[0])
+	}
+	if internal.Spec.Secrets[2].MountPath != "/run/secrets/tls.crt" {
+		t.Fatalf("secret[2] mountPath did not normalize: %+v", internal.Spec.Secrets[2])
+	}
+
+	output, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	if len(output.Spec.Secrets) != len(input.Spec.Secrets) {
+		t.Fatalf(
+			"secrets len = %d, want %d",
+			len(output.Spec.Secrets),
+			len(input.Spec.Secrets),
+		)
+	}
+	for i, want := range input.Spec.Secrets {
+		got := output.Spec.Secrets[i]
+		if got != want {
+			t.Errorf("secret[%d] round-trip = %+v, want %+v", i, got, want)
+		}
+	}
+}
+
+// TestContainerSecretYAMLNeverLeaksValues ensures that a round-trip through
+// the external doc + YAML marshal path only serializes the reference fields,
+// never a resolved secret value. The internal model has no value field, so a
+// serialized container doc can only ever contain name + source metadata.
+func TestContainerSecretYAMLNeverLeaksValues(t *testing.T) {
+	internal := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "c"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "c",
+			RealmName: "r", SpaceName: "s", StackName: "k", CellName: "cl",
+			Image: "alpine:latest",
+			Secrets: []intmodel.ContainerSecret{
+				{Name: "API_KEY", FromEnv: "API_KEY_SRC"},
+				{Name: "tls.crt", FromFile: "/etc/kukeon/secrets/tls.crt", MountPath: "/run/s/tls.crt"},
+			},
+		},
+	}
+
+	doc, err := apischeme.BuildContainerExternalFromInternal(internal, ext.APIVersionV1Beta1)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	rendered := string(out)
+
+	// The external secret struct only has name/fromFile/fromEnv/mountPath —
+	// any value-carrying field would appear here. Fail loudly if that
+	// invariant ever regresses. "data:" is omitted because "metadata:"
+	// contains it as a substring; "value:" and "contents:" are the keys we
+	// would expect to see if someone added a value-bearing field.
+	for _, forbidden := range []string{"value:", "contents:"} {
+		if strings.Contains(rendered, forbidden) {
+			t.Fatalf("rendered YAML contains forbidden key %q; full doc:\n%s", forbidden, rendered)
+		}
 	}
 }

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -374,7 +375,45 @@ func ValidateDocument(doc *Document) *ValidationError {
 				Err:   errors.New("spec.image is required"),
 			}
 		}
+		if secretErr := validateSecrets(doc.ContainerDoc.Spec.Secrets); secretErr != nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.ContainerDoc.Metadata.Name,
+				Err:   secretErr,
+			}
+		}
 	}
 
+	return nil
+}
+
+// validateSecrets enforces the shape of secret references: name required,
+// exactly one of fromFile/fromEnv, and mountPath (if set) absolute.
+func validateSecrets(secrets []v1beta1.ContainerSecret) error {
+	for i, s := range secrets {
+		name := strings.TrimSpace(s.Name)
+		if name == "" {
+			return fmt.Errorf("%w (secrets[%d])", errdefs.ErrSecretNameRequired, i)
+		}
+		fromFile := strings.TrimSpace(s.FromFile)
+		fromEnv := strings.TrimSpace(s.FromEnv)
+		switch {
+		case fromFile == "" && fromEnv == "":
+			return fmt.Errorf("%w (secrets[%d] %q)", errdefs.ErrSecretSourceRequired, i, name)
+		case fromFile != "" && fromEnv != "":
+			return fmt.Errorf("%w (secrets[%d] %q)", errdefs.ErrSecretMultipleSources, i, name)
+		}
+		mountPath := strings.TrimSpace(s.MountPath)
+		if mountPath != "" && !filepath.IsAbs(mountPath) {
+			return fmt.Errorf(
+				"%w (secrets[%d] %q mountPath %q)",
+				errdefs.ErrSecretMountPathNotAbsolute,
+				i,
+				name,
+				mountPath,
+			)
+		}
+	}
 	return nil
 }

--- a/internal/apply/parser/parser_test.go
+++ b/internal/apply/parser/parser_test.go
@@ -296,6 +296,157 @@ spec:
 	}
 }
 
+func TestValidateDocument_Container_SecretMissingSource(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  secrets:
+    - name: BROKEN
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for missing secret source, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), errdefs.ErrSecretSourceRequired.Error()) {
+		t.Errorf("expected ErrSecretSourceRequired, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_Container_SecretMultipleSources(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  secrets:
+    - name: BOTH
+      fromFile: /etc/foo
+      fromEnv: FOO
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for multiple secret sources, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), errdefs.ErrSecretMultipleSources.Error()) {
+		t.Errorf("expected ErrSecretMultipleSources, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_Container_SecretMissingName(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  secrets:
+    - fromEnv: FOO
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for missing secret name, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), errdefs.ErrSecretNameRequired.Error()) {
+		t.Errorf("expected ErrSecretNameRequired, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_Container_SecretMountPathNotAbsolute(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  secrets:
+    - name: TLS
+      fromFile: /etc/kukeon/secrets/tls.crt
+      mountPath: relative/tls.crt
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for relative mountPath, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), errdefs.ErrSecretMountPathNotAbsolute.Error()) {
+		t.Errorf("expected ErrSecretMountPathNotAbsolute, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_Container_SecretValidFormsAccepted(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  secrets:
+    - name: ANTHROPIC_API_KEY
+      fromFile: /etc/kukeon/secrets/anthropic.key
+    - name: GITHUB_TOKEN
+      fromEnv: GITHUB_TOKEN_SCOPED
+    - name: tls.crt
+      fromFile: /etc/kukeon/secrets/tls.crt
+      mountPath: /run/secrets/tls.crt
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	if validationErr := parser.ValidateDocument(doc); validationErr != nil {
+		t.Fatalf("expected valid secrets to pass, got: %v", validationErr)
+	}
+}
+
 func TestValidateDocument_UnsupportedAPIVersion(t *testing.T) {
 	yaml := `apiVersion: v1alpha1
 kind: Realm

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -47,7 +47,6 @@ type client struct {
 	cgroupMountpointOnce  sync.Once
 	cgroupMountpoint      string
 	cgroupMountpointErr   error
-	secretsStagingDir     string
 }
 
 type Client interface {
@@ -72,7 +71,6 @@ type Client interface {
 	LoadCgroup(group string, mountpoint string) (*cgroup2.Manager, error)
 	DeleteCgroup(group, mountpoint string) error
 	CreateContainerFromSpec(intmodel.ContainerSpec) (containerd.Container, error)
-	SetSecretsStagingDir(dir string)
 
 	CreateContainer(spec ContainerSpec) (containerd.Container, error)
 	GetContainer(id string) (containerd.Container, error)
@@ -88,26 +86,14 @@ type Client interface {
 
 func NewClient(ctx context.Context, logger *slog.Logger, socket string) Client {
 	return &client{
-		ctx:               ctx,
-		logger:            logger,
-		socket:            socket,
-		namespace:         namespaces.Default,
-		cgroups:           make(map[string]*cgroup2.Manager),
-		containers:        make(map[string]containerd.Container),
-		tasks:             make(map[string]containerd.Task),
-		secretsStagingDir: DefaultSecretsStagingDir,
+		ctx:        ctx,
+		logger:     logger,
+		socket:     socket,
+		namespace:  namespaces.Default,
+		cgroups:    make(map[string]*cgroup2.Manager),
+		containers: make(map[string]containerd.Container),
+		tasks:      make(map[string]containerd.Task),
 	}
-}
-
-// SetSecretsStagingDir overrides the host directory under which per-container
-// secret files are staged before bind-mounting. Falls back to
-// DefaultSecretsStagingDir when dir is empty.
-func (c *client) SetSecretsStagingDir(dir string) {
-	if dir == "" {
-		c.secretsStagingDir = DefaultSecretsStagingDir
-		return
-	}
-	c.secretsStagingDir = dir
 }
 
 // verifyConnection checks if the containerd client connection is still valid

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -47,6 +47,7 @@ type client struct {
 	cgroupMountpointOnce  sync.Once
 	cgroupMountpoint      string
 	cgroupMountpointErr   error
+	secretsStagingDir     string
 }
 
 type Client interface {
@@ -71,6 +72,7 @@ type Client interface {
 	LoadCgroup(group string, mountpoint string) (*cgroup2.Manager, error)
 	DeleteCgroup(group, mountpoint string) error
 	CreateContainerFromSpec(intmodel.ContainerSpec) (containerd.Container, error)
+	SetSecretsStagingDir(dir string)
 
 	CreateContainer(spec ContainerSpec) (containerd.Container, error)
 	GetContainer(id string) (containerd.Container, error)
@@ -86,14 +88,26 @@ type Client interface {
 
 func NewClient(ctx context.Context, logger *slog.Logger, socket string) Client {
 	return &client{
-		ctx:        ctx,
-		logger:     logger,
-		socket:     socket,
-		namespace:  namespaces.Default,
-		cgroups:    make(map[string]*cgroup2.Manager),
-		containers: make(map[string]containerd.Container),
-		tasks:      make(map[string]containerd.Task),
+		ctx:               ctx,
+		logger:            logger,
+		socket:            socket,
+		namespace:         namespaces.Default,
+		cgroups:           make(map[string]*cgroup2.Manager),
+		containers:        make(map[string]containerd.Container),
+		tasks:             make(map[string]containerd.Task),
+		secretsStagingDir: DefaultSecretsStagingDir,
 	}
+}
+
+// SetSecretsStagingDir overrides the host directory under which per-container
+// secret files are staged before bind-mounting. Falls back to
+// DefaultSecretsStagingDir when dir is empty.
+func (c *client) SetSecretsStagingDir(dir string) {
+	if dir == "" {
+		c.secretsStagingDir = DefaultSecretsStagingDir
+		return
+	}
+	c.secretsStagingDir = dir
 }
 
 // verifyConnection checks if the containerd client connection is still valid

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -491,7 +491,7 @@ func (c *client) CreateContainerFromSpec(
 	if containerdID == "" {
 		containerdID = containerSpec.ID
 	}
-	resolved, err := resolveSecrets(containerdID, containerSpec.Secrets, c.secretsStagingDir)
+	resolved, err := resolveSecrets(containerdID, containerSpec.Secrets, DefaultSecretsStagingDir)
 	if err != nil {
 		c.logger.ErrorContext(
 			c.ctx,

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -483,6 +483,32 @@ func (c *client) CreateContainerFromSpec(
 
 	cellID := containerSpec.CellName
 
+	// Resolve declared secrets before building the OCI spec. Env entries are
+	// appended to containerSpec.Env (containerd stores these in its own
+	// runtime spec, not in kukeon metadata); file-mounted secrets are staged
+	// on the host at 0400 and added as read-only bind mounts.
+	containerdID := containerSpec.ContainerdID
+	if containerdID == "" {
+		containerdID = containerSpec.ID
+	}
+	resolved, err := resolveSecrets(containerdID, containerSpec.Secrets, c.secretsStagingDir)
+	if err != nil {
+		c.logger.ErrorContext(
+			c.ctx,
+			"failed to resolve container secrets",
+			"id", containerSpec.ID,
+			"cell", cellID,
+			"err", formatError(err),
+		)
+		return nil, fmt.Errorf("failed to resolve secrets: %w", err)
+	}
+	if len(resolved.EnvAdds) > 0 {
+		containerSpec.Env = append(containerSpec.Env, resolved.EnvAdds...)
+	}
+	if len(resolved.MountAdds) > 0 {
+		containerSpec.Volumes = append(containerSpec.Volumes, resolved.MountAdds...)
+	}
+
 	// Convert to ctr.ContainerSpec using BuildContainerSpec
 	ctrSpec := BuildContainerSpec(containerSpec)
 

--- a/internal/ctr/secrets.go
+++ b/internal/ctr/secrets.go
@@ -1,0 +1,182 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// DefaultSecretsStagingDir is the host directory the daemon uses to stage
+// file-mounted secrets before bind-mounting them into containers. The
+// directory lives under /run so contents are ephemeral across reboots on
+// typical deployments.
+const DefaultSecretsStagingDir = "/run/kukeon/secrets"
+
+// secretFileMode is the mode applied to staged secret files that are bind-
+// mounted into containers. Fixed at 0400 per the Container-secret contract.
+const secretFileMode os.FileMode = 0o400
+
+// resolvedSecrets captures the side effects produced by resolveSecrets —
+// environment-variable entries ("NAME=value") to append to the container env
+// and bind mounts that expose file-mounted secrets at their declared mount
+// path.
+type resolvedSecrets struct {
+	EnvAdds   []string
+	MountAdds []intmodel.VolumeMount
+}
+
+// resolveSecrets reads each declared ContainerSecret from its host source
+// (file or env var) and returns env-var strings plus bind mounts for file
+// mode. Resolved values never appear in the returned strings beyond the env
+// entries themselves; callers must not log EnvAdds.
+//
+// stagingDir is the host directory under which per-container secret files
+// are written (mode 0400). The directory is created on demand.
+func resolveSecrets(
+	containerdID string,
+	secrets []intmodel.ContainerSecret,
+	stagingDir string,
+) (resolvedSecrets, error) {
+	var out resolvedSecrets
+	if len(secrets) == 0 {
+		return out, nil
+	}
+	if strings.TrimSpace(stagingDir) == "" {
+		stagingDir = DefaultSecretsStagingDir
+	}
+
+	var perContainerDir string
+	for i, s := range secrets {
+		name := strings.TrimSpace(s.Name)
+		fromFile := strings.TrimSpace(s.FromFile)
+		fromEnv := strings.TrimSpace(s.FromEnv)
+		mountPath := strings.TrimSpace(s.MountPath)
+
+		if name == "" {
+			return resolvedSecrets{}, fmt.Errorf("%w (secrets[%d])", errdefs.ErrSecretNameRequired, i)
+		}
+		switch {
+		case fromFile == "" && fromEnv == "":
+			return resolvedSecrets{}, fmt.Errorf(
+				"%w (secrets[%d] %q)", errdefs.ErrSecretSourceRequired, i, name,
+			)
+		case fromFile != "" && fromEnv != "":
+			return resolvedSecrets{}, fmt.Errorf(
+				"%w (secrets[%d] %q)", errdefs.ErrSecretMultipleSources, i, name,
+			)
+		}
+		if mountPath != "" && !filepath.IsAbs(mountPath) {
+			return resolvedSecrets{}, fmt.Errorf(
+				"%w (secrets[%d] %q mountPath %q)",
+				errdefs.ErrSecretMountPathNotAbsolute, i, name, mountPath,
+			)
+		}
+
+		value, err := readSecretValue(fromFile, fromEnv, name)
+		if err != nil {
+			return resolvedSecrets{}, err
+		}
+
+		if mountPath == "" {
+			out.EnvAdds = append(out.EnvAdds, name+"="+value)
+			continue
+		}
+
+		if perContainerDir == "" {
+			perContainerDir = filepath.Join(stagingDir, containerdID)
+			if mkErr := os.MkdirAll(perContainerDir, 0o700); mkErr != nil {
+				return resolvedSecrets{}, fmt.Errorf(
+					"%w (secrets[%d] %q): %w",
+					errdefs.ErrSecretStagingFailed, i, name, mkErr,
+				)
+			}
+		}
+
+		stagedPath := filepath.Join(perContainerDir, name)
+		if writeErr := writeSecretFile(stagedPath, value); writeErr != nil {
+			return resolvedSecrets{}, fmt.Errorf(
+				"%w (secrets[%d] %q): %w",
+				errdefs.ErrSecretStagingFailed, i, name, writeErr,
+			)
+		}
+
+		out.MountAdds = append(out.MountAdds, intmodel.VolumeMount{
+			Source:   stagedPath,
+			Target:   mountPath,
+			ReadOnly: true,
+		})
+	}
+
+	return out, nil
+}
+
+func readSecretValue(fromFile, fromEnv, name string) (string, error) {
+	if fromFile != "" {
+		data, err := os.ReadFile(fromFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf(
+					"%w (secret %q path %q)",
+					errdefs.ErrSecretFromFileNotFound, name, fromFile,
+				)
+			}
+			return "", fmt.Errorf("failed to read secret %q from %q: %w", name, fromFile, err)
+		}
+		return string(data), nil
+	}
+	value, ok := os.LookupEnv(fromEnv)
+	if !ok {
+		return "", fmt.Errorf(
+			"%w (secret %q env %q)",
+			errdefs.ErrSecretFromEnvNotSet, name, fromEnv,
+		)
+	}
+	return value, nil
+}
+
+// writeSecretFile writes the secret value atomically with 0400 perms so the
+// final file is never briefly world-readable. The caller is responsible for
+// the parent directory's creation and permissions.
+func writeSecretFile(path, value string) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".secret-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Best-effort cleanup if rename didn't succeed.
+		_ = os.Remove(tmpPath)
+	}()
+	if _, writeErr := tmp.WriteString(value); writeErr != nil {
+		_ = tmp.Close()
+		return writeErr
+	}
+	if chmodErr := tmp.Chmod(secretFileMode); chmodErr != nil {
+		_ = tmp.Close()
+		return chmodErr
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		return closeErr
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/ctr/secrets_test.go
+++ b/internal/ctr/secrets_test.go
@@ -1,0 +1,234 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+func TestResolveSecretsFromFileEnvInjection(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "anthropic.key")
+	if err := os.WriteFile(secretPath, []byte("sk-ant-xyz"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	secrets := []intmodel.ContainerSecret{
+		{Name: "ANTHROPIC_API_KEY", FromFile: secretPath},
+	}
+
+	got, err := resolveSecrets("cntr-1", secrets, filepath.Join(dir, "staging"))
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+	if len(got.MountAdds) != 0 {
+		t.Fatalf("expected no mount adds, got %d", len(got.MountAdds))
+	}
+	if len(got.EnvAdds) != 1 || got.EnvAdds[0] != "ANTHROPIC_API_KEY=sk-ant-xyz" {
+		t.Fatalf("unexpected env adds: %#v", got.EnvAdds)
+	}
+}
+
+func TestResolveSecretsFromEnvInjection(t *testing.T) {
+	t.Setenv("KUKEON_TEST_SCOPED_TOKEN", "ghp_scoped") // not parallel: t.Setenv forbids it
+
+	secrets := []intmodel.ContainerSecret{
+		{Name: "GITHUB_TOKEN", FromEnv: "KUKEON_TEST_SCOPED_TOKEN"},
+	}
+
+	got, err := resolveSecrets("cntr-2", secrets, t.TempDir())
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+	if len(got.EnvAdds) != 1 || got.EnvAdds[0] != "GITHUB_TOKEN=ghp_scoped" {
+		t.Fatalf("unexpected env adds: %#v", got.EnvAdds)
+	}
+}
+
+func TestResolveSecretsFileMountMode(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := t.TempDir()
+	stagingDir := t.TempDir()
+	sourcePath := filepath.Join(sourceDir, "tls.crt")
+	if err := os.WriteFile(sourcePath, []byte("-----BEGIN CERT-----"), 0o600); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	secrets := []intmodel.ContainerSecret{
+		{
+			Name:      "tls.crt",
+			FromFile:  sourcePath,
+			MountPath: "/etc/secrets/tls.crt",
+		},
+	}
+
+	got, err := resolveSecrets("cntr-3", secrets, stagingDir)
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+	if len(got.EnvAdds) != 0 {
+		t.Fatalf("expected no env adds, got %#v", got.EnvAdds)
+	}
+	if len(got.MountAdds) != 1 {
+		t.Fatalf("expected 1 mount add, got %d", len(got.MountAdds))
+	}
+	mount := got.MountAdds[0]
+	wantSource := filepath.Join(stagingDir, "cntr-3", "tls.crt")
+	if mount.Source != wantSource {
+		t.Fatalf("mount source = %q want %q", mount.Source, wantSource)
+	}
+	if mount.Target != "/etc/secrets/tls.crt" {
+		t.Fatalf("mount target = %q", mount.Target)
+	}
+	if !mount.ReadOnly {
+		t.Fatalf("mount should be read-only")
+	}
+
+	info, err := os.Stat(wantSource)
+	if err != nil {
+		t.Fatalf("stat staged file: %v", err)
+	}
+	if info.Mode().Perm() != 0o400 {
+		t.Fatalf("staged file perms = %o want 0400", info.Mode().Perm())
+	}
+	data, err := os.ReadFile(wantSource)
+	if err != nil {
+		t.Fatalf("read staged file: %v", err)
+	}
+	if string(data) != "-----BEGIN CERT-----" {
+		t.Fatalf("staged contents = %q", data)
+	}
+}
+
+func TestResolveSecretsMissingFileErrors(t *testing.T) {
+	t.Parallel()
+
+	secrets := []intmodel.ContainerSecret{
+		{Name: "MISSING", FromFile: "/nonexistent/path/secret"},
+	}
+
+	_, err := resolveSecrets("cntr-4", secrets, t.TempDir())
+	if err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+	if !errors.Is(err, errdefs.ErrSecretFromFileNotFound) {
+		t.Fatalf("want ErrSecretFromFileNotFound, got %v", err)
+	}
+}
+
+func TestResolveSecretsMissingEnvErrors(t *testing.T) {
+	t.Parallel()
+
+	// Ensure the env var is not set.
+	_ = os.Unsetenv("KUKEON_TEST_MISSING_SECRET_VAR")
+
+	secrets := []intmodel.ContainerSecret{
+		{Name: "MISSING", FromEnv: "KUKEON_TEST_MISSING_SECRET_VAR"},
+	}
+
+	_, err := resolveSecrets("cntr-5", secrets, t.TempDir())
+	if err == nil {
+		t.Fatalf("expected error for missing env var")
+	}
+	if !errors.Is(err, errdefs.ErrSecretFromEnvNotSet) {
+		t.Fatalf("want ErrSecretFromEnvNotSet, got %v", err)
+	}
+}
+
+func TestResolveSecretsRejectsMultipleSources(t *testing.T) {
+	t.Parallel()
+
+	secrets := []intmodel.ContainerSecret{
+		{Name: "BOTH", FromFile: "/tmp/x", FromEnv: "Y"},
+	}
+
+	_, err := resolveSecrets("cntr-6", secrets, t.TempDir())
+	if !errors.Is(err, errdefs.ErrSecretMultipleSources) {
+		t.Fatalf("want ErrSecretMultipleSources, got %v", err)
+	}
+}
+
+func TestResolveSecretsRejectsMissingSource(t *testing.T) {
+	t.Parallel()
+
+	secrets := []intmodel.ContainerSecret{{Name: "NOSRC"}}
+
+	_, err := resolveSecrets("cntr-7", secrets, t.TempDir())
+	if !errors.Is(err, errdefs.ErrSecretSourceRequired) {
+		t.Fatalf("want ErrSecretSourceRequired, got %v", err)
+	}
+}
+
+func TestResolveSecretsRejectsRelativeMountPath(t *testing.T) {
+	t.Parallel()
+
+	secrets := []intmodel.ContainerSecret{
+		{Name: "X", FromEnv: "HOME", MountPath: "relative/path"},
+	}
+
+	_, err := resolveSecrets("cntr-8", secrets, t.TempDir())
+	if !errors.Is(err, errdefs.ErrSecretMountPathNotAbsolute) {
+		t.Fatalf("want ErrSecretMountPathNotAbsolute, got %v", err)
+	}
+}
+
+func TestResolveSecretsEmptySliceIsNoop(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveSecrets("cntr-9", nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.EnvAdds) != 0 || len(got.MountAdds) != 0 {
+		t.Fatalf("expected empty result, got %#v", got)
+	}
+}
+
+func TestResolveSecretsMixesEnvAndMountModes(t *testing.T) {
+	sourceDir := t.TempDir()
+	stagingDir := t.TempDir()
+	certPath := filepath.Join(sourceDir, "tls.crt")
+	if err := os.WriteFile(certPath, []byte("cert-bytes"), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	t.Setenv("KUKEON_TEST_API_KEY", "api-value")
+
+	secrets := []intmodel.ContainerSecret{
+		{Name: "API_KEY", FromEnv: "KUKEON_TEST_API_KEY"},
+		{Name: "tls.crt", FromFile: certPath, MountPath: "/run/secrets/tls.crt"},
+	}
+
+	got, err := resolveSecrets("cntr-10", secrets, stagingDir)
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+	if len(got.EnvAdds) != 1 || got.EnvAdds[0] != "API_KEY=api-value" {
+		t.Fatalf("env adds = %#v", got.EnvAdds)
+	}
+	if len(got.MountAdds) != 1 || got.MountAdds[0].Target != "/run/secrets/tls.crt" {
+		t.Fatalf("mount adds = %#v", got.MountAdds)
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -112,4 +112,14 @@ var (
 
 	ErrBridgeNameTooLong = errors.New("bridge name exceeds Linux IFNAMSIZ limit")
 	ErrCNIPluginNotFound = errors.New("cni plugin not found")
+
+	// Secret-related errors.
+
+	ErrSecretNameRequired        = errors.New("secret name is required")
+	ErrSecretSourceRequired      = errors.New("secret requires exactly one of fromFile or fromEnv")
+	ErrSecretMultipleSources     = errors.New("secret must not set both fromFile and fromEnv")
+	ErrSecretMountPathNotAbsolute = errors.New("secret mountPath must be an absolute container path")
+	ErrSecretFromFileNotFound    = errors.New("secret fromFile path does not exist on the host")
+	ErrSecretFromEnvNotSet       = errors.New("secret fromEnv env var is not set on the daemon host")
+	ErrSecretStagingFailed       = errors.New("failed to stage secret file for mount")
 )

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -52,8 +52,20 @@ type ContainerSpec struct {
 	SecurityOpts           []string
 	Tmpfs                  []ContainerTmpfsMount
 	Resources              *ContainerResources
+	Secrets                []ContainerSecret
 	CNIConfigPath          string
 	RestartPolicy          string
+}
+
+// ContainerSecret references a credential resolved by the daemon at apply
+// time. Only the reference is persisted in the hub; the resolved value lives
+// only in the OCI runtime spec (for env injection) or in the staged secret
+// file (for mount mode).
+type ContainerSecret struct {
+	Name      string
+	FromFile  string
+	FromEnv   string
+	MountPath string
 }
 
 // VolumeMount is a bind mount of a host path into a container.

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -54,8 +54,21 @@ type ContainerSpec struct {
 	SecurityOpts           []string               `json:"securityOpts,omitempty"           yaml:"securityOpts,omitempty"`
 	Tmpfs                  []ContainerTmpfsMount  `json:"tmpfs,omitempty"                  yaml:"tmpfs,omitempty"`
 	Resources              *ContainerResources    `json:"resources,omitempty"              yaml:"resources,omitempty"`
+	Secrets                []ContainerSecret      `json:"secrets,omitempty"                yaml:"secrets,omitempty"`
 	CNIConfigPath          string                 `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
 	RestartPolicy          string                 `json:"restartPolicy"                    yaml:"restartPolicy"`
+}
+
+// ContainerSecret references a credential that the daemon resolves at apply
+// time and injects into the container — either as an environment variable
+// (default) or as a read-only file when MountPath is set. Only the reference
+// is persisted; the resolved value is never written to status, metadata, or
+// logs.
+type ContainerSecret struct {
+	Name      string `json:"name"                yaml:"name"`
+	FromFile  string `json:"fromFile,omitempty"  yaml:"fromFile,omitempty"`
+	FromEnv   string `json:"fromEnv,omitempty"   yaml:"fromEnv,omitempty"`
+	MountPath string `json:"mountPath,omitempty" yaml:"mountPath,omitempty"`
 }
 
 // VolumeMount is a bind mount of a host path into a container.
@@ -194,6 +207,7 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 	out.Spec.Networks = cloneSlice(out.Spec.Networks)
 	out.Spec.NetworksAliases = cloneSlice(out.Spec.NetworksAliases)
 	out.Spec.SecurityOpts = cloneSlice(out.Spec.SecurityOpts)
+	out.Spec.Secrets = cloneSecrets(out.Spec.Secrets)
 
 	if out.Spec.Capabilities != nil {
 		caps := *out.Spec.Capabilities
@@ -235,6 +249,16 @@ func cloneVolumeMounts(in []VolumeMount) []VolumeMount {
 	}
 
 	out := make([]VolumeMount, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneSecrets(in []ContainerSecret) []ContainerSecret {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]ContainerSecret, len(in))
 	copy(out, in)
 	return out
 }


### PR DESCRIPTION
## Summary
- Adds `spec.secrets` to Container so credentials flow by reference, not by value: `fromFile` reads a path on the daemon host at apply time, `fromEnv` reads an env var on the daemon host. Values are injected as env vars by default, or mounted read-only at 0400 when `mountPath` is set.
- Only the reference (name / source / mountPath) lives in the internal model, YAML, status, and logs — resolved values are never persisted there. File-mount staging goes to `/run/kukeon/secrets/<containerdId>/<name>` with owner-only perms.
- Validation (missing source, both sources, missing name, relative mountPath) runs at apply time with clear errdefs; resolution of a missing file / unset env var also errors loudly with sentinels callers can match.

Why this shape: the proposal §4.6 wants credentials that are safe to commit in manifests. Keeping the value out of the hub/YAML surface is the single invariant that makes the reference model work; everything else (mount mode, staging path, 0400) is contract detail. External broker integration / rotation / session-scoped minting stay out of scope per the issue.

## Test plan
- [x] `go test ./internal/apply/parser/... ./internal/apischeme/... ./internal/ctr/ -run TestResolveSecrets`
- [x] `go build ./...` and `go vet ./...` clean
- [x] `make test` — passes except for two pre-existing failures in `internal/ctr/container_utils_test.go` (`TestDefaultRootContainerSpec`, `TestBuildRootContainerSpec`) introduced by 594f789: the test file expects `registry.eminwux.com/busybox:latest` but `DefaultRootContainerImage` in `container_utils.go` still says `docker.io/library/busybox:latest`. Unrelated to this change; flagged for separate fix.
- [x] Project CLAUDE.md smoke test: rebuild binaries, reload `kukeon-local:dev`, `sudo ./kuke init` succeeds, daemon/no-daemon `get realms` return identical output.

Closes #47