### PR TITLE
feat: inherit Space spec.defaults.container into contained containers

### DIFF
--- a/docs/site/manifests/space.md
+++ b/docs/site/manifests/space.md
@@ -26,6 +26,45 @@ The realm that owns this space. Matches the realm's `metadata.name`.
 
 Directory where Kukeon writes this space's CNI conflist. Defaults to the system CNI config directory (`/etc/cni/net.d`). Override when you want per-space conflist isolation.
 
+### `spec.defaults.container` (object, optional)
+
+Default values inherited by every container created inside the space unless the container's own spec overrides the field. The space exists to declare the isolation envelope once — `spec.defaults.container` is how that envelope flows into every container.
+
+```yaml
+apiVersion: v1beta1
+kind: Space
+metadata:
+  name: agent-sandbox
+spec:
+  realmId: agents
+  defaults:
+    container:
+      user: "1000:1000"
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]
+        add: ["NET_BIND_SERVICE"]
+      securityOpts: ["no-new-privileges"]
+      tmpfs:
+        - path: /tmp
+          sizeBytes: 268435456   # 256 MiB
+      resources:
+        memoryLimitBytes: 4294967296   # 4 GiB
+        pidsLimit: 512
+```
+
+Supported fields (each mirrors `ContainerSpec`): `user`, `readOnlyRootFilesystem`, `capabilities`, `securityOpts`, `tmpfs`, `resources`.
+
+**Precedence** (highest wins):
+
+1. Container `spec.*` — explicit per-container values
+2. Space `spec.defaults.container.*` — envelope defaults
+3. Kukeon built-in defaults — the runtime fallback (no user, capabilities as delivered by the image, etc.)
+
+**Shallow inheritance.** A container that sets a field replaces the space default for that field in full; nested slices and pointer structs are not deep-merged. For example, a container that declares `capabilities.drop: ["CAP_NET_RAW"]` replaces the space's `capabilities` entirely — the space's `add: [NET_BIND_SERVICE]` does **not** carry through. If you want layered changes, re-declare the full effective value on the container.
+
+**Effective config.** The merge runs at the point the container is created or updated, so the post-merge (effective) configuration is what gets persisted. `kuke get container <name> -o yaml` shows the merged values directly — no separate `status.effectiveConfig` block is needed.
+
 ## status
 
 | Field         | Type                           | Description                                            |

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -135,6 +135,7 @@ func ConvertSpaceDocToInternal(in ext.SpaceDoc) (intmodel.Space, error) {
 			Spec: intmodel.SpaceSpec{
 				RealmName:     in.Spec.RealmID,
 				CNIConfigPath: in.Spec.CNIConfigPath,
+				Defaults:      convertSpaceDefaultsToInternal(in.Spec.Defaults),
 			},
 			Status: intmodel.SpaceStatus{
 				State:      intState,
@@ -172,6 +173,7 @@ func BuildSpaceExternalFromInternal(in intmodel.Space, apiVersion ext.Version) (
 			Spec: ext.SpaceSpec{
 				RealmID:       in.Spec.RealmName,
 				CNIConfigPath: in.Spec.CNIConfigPath,
+				Defaults:      buildSpaceDefaultsExternalFromInternal(in.Spec.Defaults),
 			},
 			Status: ext.SpaceStatus{
 				State:      extState,
@@ -539,6 +541,60 @@ func buildSecretsExternalFromInternal(in []intmodel.ContainerSecret) []ext.Conta
 		}
 	}
 	return out
+}
+
+func convertSpaceDefaultsToInternal(in *ext.SpaceDefaults) *intmodel.SpaceDefaults {
+	if in == nil {
+		return nil
+	}
+	return &intmodel.SpaceDefaults{
+		Container: convertSpaceContainerDefaultsToInternal(in.Container),
+	}
+}
+
+func buildSpaceDefaultsExternalFromInternal(in *intmodel.SpaceDefaults) *ext.SpaceDefaults {
+	if in == nil {
+		return nil
+	}
+	return &ext.SpaceDefaults{
+		Container: buildSpaceContainerDefaultsExternalFromInternal(in.Container),
+	}
+}
+
+func convertSpaceContainerDefaultsToInternal(in *ext.SpaceContainerDefaults) *intmodel.SpaceContainerDefaults {
+	if in == nil {
+		return nil
+	}
+	return &intmodel.SpaceContainerDefaults{
+		User:                   in.User,
+		ReadOnlyRootFilesystem: copyBoolPtr(in.ReadOnlyRootFilesystem),
+		Capabilities:           convertCapabilitiesToInternal(in.Capabilities),
+		SecurityOpts:           in.SecurityOpts,
+		Tmpfs:                  convertTmpfsMountsToInternal(in.Tmpfs),
+		Resources:              convertResourcesToInternal(in.Resources),
+	}
+}
+
+func buildSpaceContainerDefaultsExternalFromInternal(in *intmodel.SpaceContainerDefaults) *ext.SpaceContainerDefaults {
+	if in == nil {
+		return nil
+	}
+	return &ext.SpaceContainerDefaults{
+		User:                   in.User,
+		ReadOnlyRootFilesystem: copyBoolPtr(in.ReadOnlyRootFilesystem),
+		Capabilities:           buildCapabilitiesExternalFromInternal(in.Capabilities),
+		SecurityOpts:           in.SecurityOpts,
+		Tmpfs:                  buildTmpfsMountsExternalFromInternal(in.Tmpfs),
+		Resources:              buildResourcesExternalFromInternal(in.Resources),
+	}
+}
+
+func copyBoolPtr(in *bool) *bool {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
 }
 
 func volumeMountsToInternal(in []ext.VolumeMount) []intmodel.VolumeMount {

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -110,6 +110,105 @@ func TestSpaceRoundTripV1Beta1(t *testing.T) {
 	}
 }
 
+// TestSpaceDefaultsRoundTripV1Beta1 verifies that spec.defaults.container
+// survives NormalizeSpace → BuildSpaceExternalFromInternal with all nested
+// fields (user, readOnly, caps, securityOpts, tmpfs, resources) intact.
+func TestSpaceDefaultsRoundTripV1Beta1(t *testing.T) {
+	roTrue := true
+	memLimit := int64(4 * 1024 * 1024 * 1024)
+	input := ext.SpaceDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindSpace,
+		Metadata:   ext.SpaceMetadata{Name: "agent-sandbox"},
+		Spec: ext.SpaceSpec{
+			RealmID: "agents",
+			Defaults: &ext.SpaceDefaults{
+				Container: &ext.SpaceContainerDefaults{
+					User:                   "1000:1000",
+					ReadOnlyRootFilesystem: &roTrue,
+					Capabilities: &ext.ContainerCapabilities{
+						Drop: []string{"ALL"},
+						Add:  []string{"NET_BIND_SERVICE"},
+					},
+					SecurityOpts: []string{"no-new-privileges"},
+					Tmpfs: []ext.ContainerTmpfsMount{
+						{Path: "/tmp", SizeBytes: 64 * 1024 * 1024},
+					},
+					Resources: &ext.ContainerResources{
+						MemoryLimitBytes: &memLimit,
+					},
+				},
+			},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeSpace(input)
+	if err != nil {
+		t.Fatalf("NormalizeSpace failed: %v", err)
+	}
+	if internal.Spec.Defaults == nil || internal.Spec.Defaults.Container == nil {
+		t.Fatalf("internal Defaults.Container is nil after NormalizeSpace: %+v", internal.Spec.Defaults)
+	}
+	intContainer := internal.Spec.Defaults.Container
+	if intContainer.User != "1000:1000" {
+		t.Errorf("internal User = %q, want 1000:1000", intContainer.User)
+	}
+	if intContainer.ReadOnlyRootFilesystem == nil || !*intContainer.ReadOnlyRootFilesystem {
+		t.Errorf("internal ReadOnlyRootFilesystem = %v, want *true", intContainer.ReadOnlyRootFilesystem)
+	}
+	if intContainer.Capabilities == nil ||
+		len(intContainer.Capabilities.Drop) != 1 || intContainer.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("internal Capabilities.Drop = %+v, want [ALL]", intContainer.Capabilities)
+	}
+	if len(intContainer.SecurityOpts) != 1 || intContainer.SecurityOpts[0] != "no-new-privileges" {
+		t.Errorf("internal SecurityOpts = %v", intContainer.SecurityOpts)
+	}
+	if len(intContainer.Tmpfs) != 1 || intContainer.Tmpfs[0].Path != "/tmp" {
+		t.Errorf("internal Tmpfs = %+v", intContainer.Tmpfs)
+	}
+	if intContainer.Resources == nil || intContainer.Resources.MemoryLimitBytes == nil ||
+		*intContainer.Resources.MemoryLimitBytes != memLimit {
+		t.Errorf("internal Resources = %+v, want MemoryLimit=4GiB", intContainer.Resources)
+	}
+
+	output, err := apischeme.BuildSpaceExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildSpaceExternalFromInternal failed: %v", err)
+	}
+	if output.Spec.Defaults == nil || output.Spec.Defaults.Container == nil {
+		t.Fatalf("external Defaults.Container is nil after round trip: %+v", output.Spec.Defaults)
+	}
+	extContainer := output.Spec.Defaults.Container
+	if extContainer.User != "1000:1000" {
+		t.Errorf("external User = %q, want 1000:1000", extContainer.User)
+	}
+	if extContainer.ReadOnlyRootFilesystem == nil || !*extContainer.ReadOnlyRootFilesystem {
+		t.Errorf("external ReadOnlyRootFilesystem not round-tripped: %v", extContainer.ReadOnlyRootFilesystem)
+	}
+	if extContainer.Capabilities == nil ||
+		len(extContainer.Capabilities.Drop) != 1 || extContainer.Capabilities.Drop[0] != "ALL" ||
+		len(extContainer.Capabilities.Add) != 1 || extContainer.Capabilities.Add[0] != "NET_BIND_SERVICE" {
+		t.Errorf("external Capabilities not round-tripped: %+v", extContainer.Capabilities)
+	}
+
+	// YAML round trip — ensures the tags decode / encode correctly.
+	encoded, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal failed: %v", err)
+	}
+	var decoded ext.SpaceDoc
+	if err = yaml.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("yaml.Unmarshal failed: %v\nyaml:\n%s", err, encoded)
+	}
+	if decoded.Spec.Defaults == nil || decoded.Spec.Defaults.Container == nil ||
+		decoded.Spec.Defaults.Container.User != "1000:1000" {
+		t.Errorf("YAML round trip lost Defaults.Container: decoded=%+v", decoded.Spec.Defaults)
+	}
+	if !strings.Contains(string(encoded), "defaults:") {
+		t.Errorf("YAML missing defaults block: %s", encoded)
+	}
+}
+
 func TestStackRoundTripV1Beta1(t *testing.T) {
 	input := ext.StackDoc{
 		APIVersion: ext.APIVersionV1Beta1,

--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -177,6 +177,19 @@ func DiffSpace(desired, actual intmodel.Space) DiffResult {
 		result.Details["metadata.labels"] = labelsChangedMsg
 	}
 
+	// Compatible changes: spec.defaults.container. Inheritance is computed
+	// at container-create/update time, so changing defaults is non-breaking
+	// for already-running containers — only new or updated containers pick
+	// up the new envelope.
+	if !spaceDefaultsEqual(desired.Spec.Defaults, actual.Spec.Defaults) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "spec.defaults.container")
+		result.Details["spec.defaults.container"] = "container defaults changed"
+	}
+
 	return result
 }
 
@@ -662,6 +675,56 @@ func resourcesAreZero(r *intmodel.ContainerResources) bool {
 }
 
 func int64PtrEqual(a, b *int64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// spaceDefaultsEqual reports whether two *SpaceDefaults describe the same
+// inherited envelope. A nil pointer is treated as equal to an empty defaults
+// block so that adding or clearing an explicitly-empty `spec.defaults` does
+// not register as a change.
+func spaceDefaultsEqual(a, b *intmodel.SpaceDefaults) bool {
+	ac := spaceDefaultsContainer(a)
+	bc := spaceDefaultsContainer(b)
+	if ac == nil && bc == nil {
+		return true
+	}
+	if ac == nil || bc == nil {
+		return spaceContainerDefaultsIsZero(ac) && spaceContainerDefaultsIsZero(bc)
+	}
+	return ac.User == bc.User &&
+		boolPtrEqual(ac.ReadOnlyRootFilesystem, bc.ReadOnlyRootFilesystem) &&
+		capabilitiesEqual(ac.Capabilities, bc.Capabilities) &&
+		slicesEqual(ac.SecurityOpts, bc.SecurityOpts) &&
+		tmpfsEqual(ac.Tmpfs, bc.Tmpfs) &&
+		resourcesEqual(ac.Resources, bc.Resources)
+}
+
+func spaceDefaultsContainer(d *intmodel.SpaceDefaults) *intmodel.SpaceContainerDefaults {
+	if d == nil {
+		return nil
+	}
+	return d.Container
+}
+
+func spaceContainerDefaultsIsZero(c *intmodel.SpaceContainerDefaults) bool {
+	if c == nil {
+		return true
+	}
+	return c.User == "" &&
+		c.ReadOnlyRootFilesystem == nil &&
+		c.Capabilities == nil &&
+		len(c.SecurityOpts) == 0 &&
+		len(c.Tmpfs) == 0 &&
+		c.Resources == nil
+}
+
+func boolPtrEqual(a, b *bool) bool {
 	if a == nil && b == nil {
 		return true
 	}

--- a/internal/controller/runner/create_container.go
+++ b/internal/controller/runner/create_container.go
@@ -26,6 +26,11 @@ import (
 
 // CreateContainer creates a container in an existing cell by merging the container spec
 // into the cell's containers list. The cell must already exist.
+//
+// Inheritance of spec.defaults.container from the parent Space happens in
+// ensureCellContainers, which is the single choke point every creation and
+// update path traverses — so the post-merge (effective) configuration is
+// what gets persisted and what `kuke get container -o yaml` displays.
 func (r *Exec) CreateContainer(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error) {
 	// Get existing cell (returns internal model)
 	existingCell, err := r.GetCell(cell)

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1069,6 +1069,10 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, errdefs.ErrStackNameRequired
 	}
 
+	if err := r.applyCellContainerDefaults(cell); err != nil {
+		return nil, err
+	}
+
 	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmName, spaceName)
 	if cniErr != nil {
 		return nil, fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
@@ -1273,6 +1277,27 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 	return rootContainer, nil
 }
 
+// applyCellContainerDefaults loads the parent Space for the cell and merges
+// its spec.defaults.container into every container in the cell. The merge
+// runs in place and is idempotent — containers that already carry the
+// defaults are unchanged. This is the single entry point that every
+// container-creating flow (CreateCell, UpdateCell, CreateContainer,
+// UpdateContainer) funnels through.
+func (r *Exec) applyCellContainerDefaults(cell *intmodel.Cell) error {
+	spaceLookup := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: cell.Spec.SpaceName},
+		Spec:     intmodel.SpaceSpec{RealmName: cell.Spec.RealmName},
+	}
+	parentSpace, err := r.GetSpace(spaceLookup)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrGetSpace, err)
+	}
+	for i := range cell.Spec.Containers {
+		intmodel.ApplySpaceDefaultsToContainer(parentSpace, &cell.Spec.Containers[i])
+	}
+	return nil
+}
+
 // ensureCellContainers ensures the root container and all containers defined in the CellDoc exist.
 // The root container is ensured first, then all containers in doc.Spec.Containers are ensured.
 // If any container doesn't exist, it is created. Returns the root container or an error.
@@ -1300,6 +1325,10 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 	stackName := cell.Spec.StackName
 	if stackName == "" {
 		return nil, errdefs.ErrStackNameRequired
+	}
+
+	if err := r.applyCellContainerDefaults(cell); err != nil {
+		return nil, err
 	}
 
 	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmName, spaceName)

--- a/internal/controller/runner/update_container.go
+++ b/internal/controller/runner/update_container.go
@@ -107,6 +107,9 @@ func (r *Exec) UpdateContainer(cell intmodel.Cell, desiredContainer intmodel.Con
 		}
 	}
 
+	// spec.defaults.container inheritance is applied in ensureCellContainers,
+	// below, for both the create and recreate-on-breaking-change paths.
+
 	// Update container in cell's containers list
 	if containerIndex >= 0 {
 		// Preserve containerd ID if not cleared

--- a/internal/controller/runner/update_space.go
+++ b/internal/controller/runner/update_space.go
@@ -35,6 +35,7 @@ func (r *Exec) UpdateSpace(desired intmodel.Space) (intmodel.Space, error) {
 
 	// Update compatible fields
 	existing.Metadata.Labels = desired.Metadata.Labels
+	existing.Spec.Defaults = desired.Spec.Defaults
 	// Note: CNIConfigPath is not updated as it's a breaking change
 
 	// Update metadata file

--- a/internal/modelhub/merge.go
+++ b/internal/modelhub/merge.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelhub
+
+// ApplySpaceDefaultsToContainer fills isolation fields on container that are
+// unset (zero value or nil) using the defaults declared on space. Precedence:
+//
+//	container spec > Space defaults > kukeon built-in defaults
+//
+// Inheritance is shallow — overriding a pointer/slice field replaces the Space
+// default outright rather than deep-merging. For example, a Container that
+// sets Capabilities.Drop=["CAP_NET_RAW"] replaces the Space default's Drop
+// list entirely; it does not union with it.
+//
+// The merge is idempotent: calling it twice on the same container yields the
+// same result as calling it once.
+func ApplySpaceDefaultsToContainer(space Space, container *ContainerSpec) {
+	if container == nil || space.Spec.Defaults == nil || space.Spec.Defaults.Container == nil {
+		return
+	}
+	defaults := space.Spec.Defaults.Container
+
+	if container.User == "" {
+		container.User = defaults.User
+	}
+	if !container.ReadOnlyRootFilesystem && defaults.ReadOnlyRootFilesystem != nil {
+		container.ReadOnlyRootFilesystem = *defaults.ReadOnlyRootFilesystem
+	}
+	if container.Capabilities == nil && defaults.Capabilities != nil {
+		container.Capabilities = cloneCapabilities(defaults.Capabilities)
+	}
+	if len(container.SecurityOpts) == 0 && len(defaults.SecurityOpts) > 0 {
+		container.SecurityOpts = append([]string(nil), defaults.SecurityOpts...)
+	}
+	if len(container.Tmpfs) == 0 && len(defaults.Tmpfs) > 0 {
+		container.Tmpfs = cloneTmpfsMounts(defaults.Tmpfs)
+	}
+	if container.Resources == nil && defaults.Resources != nil {
+		container.Resources = cloneResources(defaults.Resources)
+	}
+}
+
+func cloneCapabilities(in *ContainerCapabilities) *ContainerCapabilities {
+	if in == nil {
+		return nil
+	}
+	out := &ContainerCapabilities{
+		Drop: append([]string(nil), in.Drop...),
+		Add:  append([]string(nil), in.Add...),
+	}
+	if len(out.Drop) == 0 {
+		out.Drop = nil
+	}
+	if len(out.Add) == 0 {
+		out.Add = nil
+	}
+	return out
+}
+
+func cloneTmpfsMounts(in []ContainerTmpfsMount) []ContainerTmpfsMount {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ContainerTmpfsMount, len(in))
+	for i, m := range in {
+		opts := append([]string(nil), m.Options...)
+		if len(opts) == 0 {
+			opts = nil
+		}
+		out[i] = ContainerTmpfsMount{
+			Path:      m.Path,
+			SizeBytes: m.SizeBytes,
+			Options:   opts,
+		}
+	}
+	return out
+}
+
+func cloneResources(in *ContainerResources) *ContainerResources {
+	if in == nil {
+		return nil
+	}
+	out := &ContainerResources{}
+	if in.MemoryLimitBytes != nil {
+		v := *in.MemoryLimitBytes
+		out.MemoryLimitBytes = &v
+	}
+	if in.CPUShares != nil {
+		v := *in.CPUShares
+		out.CPUShares = &v
+	}
+	if in.PidsLimit != nil {
+		v := *in.PidsLimit
+		out.PidsLimit = &v
+	}
+	return out
+}

--- a/internal/modelhub/merge_test.go
+++ b/internal/modelhub/merge_test.go
@@ -1,0 +1,256 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelhub_test
+
+import (
+	"reflect"
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+func ptrBool(v bool) *bool   { return &v }
+func ptrInt64(v int64) *int64 { return &v }
+
+func spaceWithContainerDefaults(d *intmodel.SpaceContainerDefaults) intmodel.Space {
+	return intmodel.Space{
+		Spec: intmodel.SpaceSpec{
+			Defaults: &intmodel.SpaceDefaults{Container: d},
+		},
+	}
+}
+
+// TestApplySpaceDefaultsToContainer_FillsEmptyFields covers the common case:
+// a Container that declares nothing beyond its image inherits the full Space
+// envelope (user, readOnly, caps, securityOpts, tmpfs, resources).
+func TestApplySpaceDefaultsToContainer_FillsEmptyFields(t *testing.T) {
+	space := spaceWithContainerDefaults(&intmodel.SpaceContainerDefaults{
+		User:                   "1000:1000",
+		ReadOnlyRootFilesystem: ptrBool(true),
+		Capabilities: &intmodel.ContainerCapabilities{
+			Drop: []string{"ALL"},
+			Add:  []string{"NET_BIND_SERVICE"},
+		},
+		SecurityOpts: []string{"no-new-privileges"},
+		Tmpfs: []intmodel.ContainerTmpfsMount{
+			{Path: "/tmp", SizeBytes: 64 * 1024 * 1024},
+		},
+		Resources: &intmodel.ContainerResources{
+			MemoryLimitBytes: ptrInt64(4 * 1024 * 1024 * 1024),
+			PidsLimit:        ptrInt64(512),
+		},
+	})
+
+	container := intmodel.ContainerSpec{ID: "c1", Image: "busybox:latest"}
+	intmodel.ApplySpaceDefaultsToContainer(space, &container)
+
+	if container.User != "1000:1000" {
+		t.Errorf("User = %q, want 1000:1000", container.User)
+	}
+	if !container.ReadOnlyRootFilesystem {
+		t.Errorf("ReadOnlyRootFilesystem = false, want true")
+	}
+	if container.Capabilities == nil ||
+		!reflect.DeepEqual(container.Capabilities.Drop, []string{"ALL"}) ||
+		!reflect.DeepEqual(container.Capabilities.Add, []string{"NET_BIND_SERVICE"}) {
+		t.Errorf("Capabilities = %+v, want Drop=[ALL] Add=[NET_BIND_SERVICE]", container.Capabilities)
+	}
+	if !reflect.DeepEqual(container.SecurityOpts, []string{"no-new-privileges"}) {
+		t.Errorf("SecurityOpts = %v, want [no-new-privileges]", container.SecurityOpts)
+	}
+	if len(container.Tmpfs) != 1 || container.Tmpfs[0].Path != "/tmp" ||
+		container.Tmpfs[0].SizeBytes != 64*1024*1024 {
+		t.Errorf("Tmpfs = %+v, want single /tmp mount of 64MiB", container.Tmpfs)
+	}
+	if container.Resources == nil ||
+		container.Resources.MemoryLimitBytes == nil || *container.Resources.MemoryLimitBytes != 4*1024*1024*1024 ||
+		container.Resources.PidsLimit == nil || *container.Resources.PidsLimit != 512 {
+		t.Errorf("Resources = %+v, want MemoryLimit=4GiB PidsLimit=512", container.Resources)
+	}
+}
+
+// TestApplySpaceDefaultsToContainer_ContainerValuesWin covers precedence:
+// the Container's explicit values take precedence over Space defaults.
+func TestApplySpaceDefaultsToContainer_ContainerValuesWin(t *testing.T) {
+	space := spaceWithContainerDefaults(&intmodel.SpaceContainerDefaults{
+		User:         "1000:1000",
+		SecurityOpts: []string{"no-new-privileges"},
+		Resources: &intmodel.ContainerResources{
+			MemoryLimitBytes: ptrInt64(4 * 1024 * 1024 * 1024),
+		},
+	})
+
+	container := intmodel.ContainerSpec{
+		ID:           "c1",
+		User:         "2000:2000",
+		SecurityOpts: []string{"seccomp=unconfined"},
+		Resources: &intmodel.ContainerResources{
+			MemoryLimitBytes: ptrInt64(1 * 1024 * 1024 * 1024),
+		},
+	}
+	intmodel.ApplySpaceDefaultsToContainer(space, &container)
+
+	if container.User != "2000:2000" {
+		t.Errorf("User = %q, container-spec value should win", container.User)
+	}
+	if !reflect.DeepEqual(container.SecurityOpts, []string{"seccomp=unconfined"}) {
+		t.Errorf("SecurityOpts = %v, container-spec value should win", container.SecurityOpts)
+	}
+	if container.Resources == nil || container.Resources.MemoryLimitBytes == nil ||
+		*container.Resources.MemoryLimitBytes != 1*1024*1024*1024 {
+		t.Errorf("Resources.MemoryLimitBytes = %+v, container-spec 1GiB should win", container.Resources)
+	}
+}
+
+// TestApplySpaceDefaultsToContainer_OverrideReplacesShallow covers the
+// shallow-merge semantic on pointer / slice fields: a Container that sets
+// Capabilities replaces the Space default entirely — Drop/Add are not
+// merged.
+func TestApplySpaceDefaultsToContainer_OverrideReplacesShallow(t *testing.T) {
+	space := spaceWithContainerDefaults(&intmodel.SpaceContainerDefaults{
+		Capabilities: &intmodel.ContainerCapabilities{
+			Drop: []string{"ALL"},
+			Add:  []string{"NET_BIND_SERVICE"},
+		},
+		Tmpfs: []intmodel.ContainerTmpfsMount{
+			{Path: "/tmp", SizeBytes: 64 * 1024 * 1024},
+			{Path: "/run", SizeBytes: 16 * 1024 * 1024},
+		},
+	})
+
+	container := intmodel.ContainerSpec{
+		ID: "c1",
+		Capabilities: &intmodel.ContainerCapabilities{
+			Drop: []string{"CAP_NET_RAW"},
+		},
+		Tmpfs: []intmodel.ContainerTmpfsMount{
+			{Path: "/var/tmp", SizeBytes: 8 * 1024 * 1024},
+		},
+	}
+	intmodel.ApplySpaceDefaultsToContainer(space, &container)
+
+	// Capabilities replaced — Add from Space must NOT appear.
+	if container.Capabilities == nil {
+		t.Fatalf("Capabilities lost during merge")
+	}
+	if !reflect.DeepEqual(container.Capabilities.Drop, []string{"CAP_NET_RAW"}) {
+		t.Errorf("Capabilities.Drop = %v, container-spec value should replace defaults", container.Capabilities.Drop)
+	}
+	if len(container.Capabilities.Add) != 0 {
+		t.Errorf("Capabilities.Add = %v, expected empty — shallow override must not leak default Add", container.Capabilities.Add)
+	}
+
+	// Tmpfs replaced — the single container-spec entry, not the Space pair.
+	if len(container.Tmpfs) != 1 || container.Tmpfs[0].Path != "/var/tmp" {
+		t.Errorf("Tmpfs = %+v, container-spec value should replace defaults (no append)", container.Tmpfs)
+	}
+}
+
+// TestApplySpaceDefaultsToContainer_NoDefaults covers the nil-defaults case:
+// a Space with no defaults block leaves the container untouched.
+func TestApplySpaceDefaultsToContainer_NoDefaults(t *testing.T) {
+	cases := []struct {
+		name  string
+		space intmodel.Space
+	}{
+		{name: "nil-defaults", space: intmodel.Space{Spec: intmodel.SpaceSpec{Defaults: nil}}},
+		{name: "nil-container", space: intmodel.Space{Spec: intmodel.SpaceSpec{Defaults: &intmodel.SpaceDefaults{}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			container := intmodel.ContainerSpec{ID: "c1", Image: "busybox"}
+			orig := container
+			intmodel.ApplySpaceDefaultsToContainer(tc.space, &container)
+			if !reflect.DeepEqual(container, orig) {
+				t.Errorf("container mutated: got=%+v orig=%+v", container, orig)
+			}
+		})
+	}
+}
+
+// TestApplySpaceDefaultsToContainer_Idempotent verifies calling the merge
+// twice yields the same result as calling it once — important because both
+// CreateContainer and UpdateContainer now invoke the merge, and an update
+// that happens to retrigger create must not compound defaults.
+func TestApplySpaceDefaultsToContainer_Idempotent(t *testing.T) {
+	space := spaceWithContainerDefaults(&intmodel.SpaceContainerDefaults{
+		User: "1000:1000",
+		Capabilities: &intmodel.ContainerCapabilities{
+			Drop: []string{"ALL"},
+			Add:  []string{"NET_BIND_SERVICE"},
+		},
+		SecurityOpts: []string{"no-new-privileges"},
+		Tmpfs: []intmodel.ContainerTmpfsMount{
+			{Path: "/tmp", SizeBytes: 64 * 1024 * 1024},
+		},
+	})
+
+	once := intmodel.ContainerSpec{ID: "c1"}
+	intmodel.ApplySpaceDefaultsToContainer(space, &once)
+
+	twice := once
+	intmodel.ApplySpaceDefaultsToContainer(space, &twice)
+
+	if !reflect.DeepEqual(once, twice) {
+		t.Errorf("merge is not idempotent:\n once=%+v\n twice=%+v", once, twice)
+	}
+}
+
+// TestApplySpaceDefaultsToContainer_NilContainer is a sanity check that a
+// nil container pointer is a no-op rather than a panic.
+func TestApplySpaceDefaultsToContainer_NilContainer(t *testing.T) {
+	space := spaceWithContainerDefaults(&intmodel.SpaceContainerDefaults{User: "1000:1000"})
+	intmodel.ApplySpaceDefaultsToContainer(space, nil)
+}
+
+// TestApplySpaceDefaultsToContainer_DefaultsDeepCopied guards against
+// aliasing — mutating the merged container later must not reach back into
+// the Space defaults object.
+func TestApplySpaceDefaultsToContainer_DefaultsDeepCopied(t *testing.T) {
+	defaults := &intmodel.SpaceContainerDefaults{
+		Capabilities: &intmodel.ContainerCapabilities{Drop: []string{"ALL"}},
+		SecurityOpts: []string{"no-new-privileges"},
+		Tmpfs: []intmodel.ContainerTmpfsMount{
+			{Path: "/tmp", SizeBytes: 64 * 1024 * 1024, Options: []string{"mode=1777"}},
+		},
+		Resources: &intmodel.ContainerResources{MemoryLimitBytes: ptrInt64(1 << 30)},
+	}
+	space := spaceWithContainerDefaults(defaults)
+
+	container := intmodel.ContainerSpec{ID: "c1"}
+	intmodel.ApplySpaceDefaultsToContainer(space, &container)
+
+	// Mutate the merged container's fields.
+	container.Capabilities.Drop[0] = "CAP_NET_RAW"
+	container.SecurityOpts[0] = "seccomp=unconfined"
+	container.Tmpfs[0].Options[0] = "mode=0700"
+	*container.Resources.MemoryLimitBytes = 2 << 30
+
+	// Space defaults should remain unchanged.
+	if defaults.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("Capabilities.Drop leaked: got %q, want ALL", defaults.Capabilities.Drop[0])
+	}
+	if defaults.SecurityOpts[0] != "no-new-privileges" {
+		t.Errorf("SecurityOpts leaked: got %q", defaults.SecurityOpts[0])
+	}
+	if defaults.Tmpfs[0].Options[0] != "mode=1777" {
+		t.Errorf("Tmpfs.Options leaked: got %q", defaults.Tmpfs[0].Options[0])
+	}
+	if *defaults.Resources.MemoryLimitBytes != 1<<30 {
+		t.Errorf("Resources.MemoryLimitBytes leaked: got %d", *defaults.Resources.MemoryLimitBytes)
+	}
+}

--- a/internal/modelhub/space.go
+++ b/internal/modelhub/space.go
@@ -30,6 +30,24 @@ type SpaceMetadata struct {
 type SpaceSpec struct {
 	RealmName     string
 	CNIConfigPath string
+	Defaults      *SpaceDefaults
+}
+
+// SpaceDefaults declares default values inherited by resources inside the
+// Space unless the resource's own spec overrides the field. See the external
+// v1beta1.SpaceDefaults type for user-facing documentation.
+type SpaceDefaults struct {
+	Container *SpaceContainerDefaults
+}
+
+// SpaceContainerDefaults mirrors the isolation fields on ContainerSpec.
+type SpaceContainerDefaults struct {
+	User                   string
+	ReadOnlyRootFilesystem *bool
+	Capabilities           *ContainerCapabilities
+	SecurityOpts           []string
+	Tmpfs                  []ContainerTmpfsMount
+	Resources              *ContainerResources
 }
 
 type SpaceStatus struct {

--- a/pkg/api/model/v1beta1/space.go
+++ b/pkg/api/model/v1beta1/space.go
@@ -30,8 +30,35 @@ type SpaceMetadata struct {
 }
 
 type SpaceSpec struct {
-	RealmID       string `json:"realmId"                 yaml:"realmId"`
-	CNIConfigPath string `json:"cniConfigPath,omitempty" yaml:"cniConfigPath,omitempty"`
+	RealmID       string         `json:"realmId"                 yaml:"realmId"`
+	CNIConfigPath string         `json:"cniConfigPath,omitempty" yaml:"cniConfigPath,omitempty"`
+	Defaults      *SpaceDefaults `json:"defaults,omitempty"      yaml:"defaults,omitempty"`
+}
+
+// SpaceDefaults declares default values that Kukeon inherits into resources
+// created inside the Space unless the resource's own spec overrides the field.
+// It exists so the isolation envelope can be declared once on the Space and
+// reused by every Container that lives in it.
+type SpaceDefaults struct {
+	Container *SpaceContainerDefaults `json:"container,omitempty" yaml:"container,omitempty"`
+}
+
+// SpaceContainerDefaults mirrors the isolation-related fields on ContainerSpec.
+// Each field is applied to a Container only when the Container leaves it empty.
+// Inheritance is shallow: a Container that sets Capabilities replaces the Space
+// default outright — Drop and Add slices are not merged.
+//
+// ReadOnlyRootFilesystem is a *bool so the default can distinguish "not set"
+// from an explicit "false"; Container.Spec.ReadOnlyRootFilesystem is still a
+// plain bool, so a Container cannot opt out of a Space default that enables
+// it.
+type SpaceContainerDefaults struct {
+	User                   string                 `json:"user,omitempty"                   yaml:"user,omitempty"`
+	ReadOnlyRootFilesystem *bool                  `json:"readOnlyRootFilesystem,omitempty" yaml:"readOnlyRootFilesystem,omitempty"`
+	Capabilities           *ContainerCapabilities `json:"capabilities,omitempty"           yaml:"capabilities,omitempty"`
+	SecurityOpts           []string               `json:"securityOpts,omitempty"           yaml:"securityOpts,omitempty"`
+	Tmpfs                  []ContainerTmpfsMount  `json:"tmpfs,omitempty"                  yaml:"tmpfs,omitempty"`
+	Resources              *ContainerResources    `json:"resources,omitempty"              yaml:"resources,omitempty"`
 }
 
 type SpaceStatus struct {


### PR DESCRIPTION
## Summary
- Add `spec.defaults.container` to the Space kind so the isolation envelope (user, readOnlyRootFilesystem, capabilities, securityOpts, tmpfs, resources) is declared once on the Space and inherited by every container that lives in it.
- Run a shallow merge at the single choke point (`applyCellContainerDefaults`, called from both `ensureCellContainers` and `createCellContainers`); precedence is **container spec > Space defaults > kukeon built-ins**. Inheriting a slice/pointer field is a replace, not a deep-merge — a container that sets `capabilities.drop` replaces the Space's `capabilities` entirely rather than layering.
- Persist the merged (effective) config so `kuke get container -o yaml` shows what actually applied — no separate `status.effectiveConfig` is needed. `DiffSpace` / `UpdateSpace` now track the defaults block so applying a modified defaults re-persists the metadata.

Closes #44

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/modelhub/... ./internal/apischeme/... ./internal/controller/...` — new `merge_test.go` covers fill-empty, container-wins, shallow-replace, idempotency, deep-copy; new scheme round-trip test covers the YAML tags.
- [x] `make test` — only pre-existing `registry.eminwux.com` expectations in `internal/ctr/container_utils_test.go` fail (reproduced on `origin/main`, unrelated).
- [x] Smoke test per CLAUDE.md: torn down + rebuilt kukeond image, `kuke init` succeeded, `kuke get realms` and `kuke get realms --no-daemon` returned identical output.
- [x] Applied a Space with every defaults field set and a Cell whose only container declares `image` + `command` — `kuke get container -o yaml` shows all Space defaults merged (user, readOnlyRootFilesystem, capabilities, securityOpts, tmpfs, resources).
- [x] Applied a second Cell whose container overrides `user` and sets `capabilities.drop: [CAP_NET_RAW]` — effective spec keeps the override, drops the Space default's `add`, and still inherits the unset fields (verifies precedence + shallow replace end-to-end).