### PR TITLE
feat: add space egress policy with iptables enforcement

### DIFF
--- a/docs/site/manifests/space.md
+++ b/docs/site/manifests/space.md
@@ -9,6 +9,14 @@ metadata:
 spec:
   realmId: main
   cniConfigPath: /etc/cni/net.d
+  network:
+    egress:
+      default: deny
+      allow:
+        - host: api.anthropic.com
+          ports: [443]
+        - cidr: 10.0.0.0/8
+          ports: [5432]
 status:
   state: Ready
   cgroupPath: /kukeon/main/default
@@ -25,6 +33,31 @@ The realm that owns this space. Matches the realm's `metadata.name`.
 ### `spec.cniConfigPath` (string, optional)
 
 Directory where Kukeon writes this space's CNI conflist. Defaults to the system CNI config directory (`/etc/cni/net.d`). Override when you want per-space conflist isolation.
+
+### `spec.network.egress` (object, optional)
+
+Constrains outbound traffic leaving the space's bridge. When omitted, traffic is unconstrained — matching the pre-`v1beta1` behavior.
+
+| Field     | Type                              | Description                                                                 |
+|-----------|-----------------------------------|-----------------------------------------------------------------------------|
+| `default` | `allow` \| `deny`                 | Fallthrough action when no `allow` rule matches. Required when `egress` is set. |
+| `allow`   | list of allow rules               | Permitted destinations. Each entry sets exactly one of `host` or `cidr`.    |
+
+Each allow rule:
+
+| Field   | Type          | Description                                                                          |
+|---------|---------------|--------------------------------------------------------------------------------------|
+| `host`  | string        | DNS name. Resolved to IPv4 addresses by the daemon at apply time.                    |
+| `cidr`  | string        | IPv4 CIDR. Enforced literally via iptables.                                          |
+| `ports` | list of ints  | TCP destination ports (1–65535). Empty means "any protocol and any port on this destination". |
+
+**Enforcement.** When the policy is non-trivial (either `default: deny`, or `default: allow` with at least one allow rule), the daemon materializes it as a per-space chain in the iptables `filter` table named `KUKE-EGR-<hash>`, fed from a shared `KUKEON-EGRESS` chain hooked into `FORWARD`. Existing connections are preserved via a `RELATED,ESTABLISHED` short-circuit, so reply traffic for outbound flows initiated before a policy is applied is unaffected. The enforcement is bridge-scoped (`-i <bridge>`), so a single misconfigured space cannot affect traffic from other spaces in the same realm.
+
+**Hostname caveat (design path a).** Hostnames are resolved to IPs once, at apply time, and the resolved IPs are written into iptables. If the target service publishes a new IP after the policy is applied, the rule will not cover it until you re-apply the space (for example, `kuke apply -f space.yaml`). Services behind large, frequently rotating CDNs are not a good fit for hostname rules in this release — prefer a CIDR rule if you control the upstream, or accept occasional 5xxs and re-apply on a schedule. A transparent egress proxy would address this, and is tracked as a separate primitive (out of scope for this issue).
+
+**Observability.** When a space is deleted, the daemon logs the terminal DROP counter (packets + bytes) for its chain, tagged with the `kukeon:<realm>:<space>` comment. Operators can also inspect counters on a running policy at any time with `iptables -L KUKE-EGR-<hash> -n -v -x` or filter across all spaces with `iptables -S | grep kukeon:`.
+
+**Minimum-viable scope.** When a rule specifies `ports`, enforcement is TCP-only; UDP and ICMP fall through to `default` for that destination. When `ports` is omitted, the rule matches any IP traffic to the destination. IPv6 addresses returned by DNS are ignored — the rules are IPv4-only. These gaps are tracked as follow-ups.
 
 ### `spec.defaults.container` (object, optional)
 

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -135,6 +135,7 @@ func ConvertSpaceDocToInternal(in ext.SpaceDoc) (intmodel.Space, error) {
 			Spec: intmodel.SpaceSpec{
 				RealmName:     in.Spec.RealmID,
 				CNIConfigPath: in.Spec.CNIConfigPath,
+				Network:       convertSpaceNetworkToInternal(in.Spec.Network),
 				Defaults:      convertSpaceDefaultsToInternal(in.Spec.Defaults),
 			},
 			Status: intmodel.SpaceStatus{
@@ -173,6 +174,7 @@ func BuildSpaceExternalFromInternal(in intmodel.Space, apiVersion ext.Version) (
 			Spec: ext.SpaceSpec{
 				RealmID:       in.Spec.RealmName,
 				CNIConfigPath: in.Spec.CNIConfigPath,
+				Network:       buildSpaceNetworkExternalFromInternal(in.Spec.Network),
 				Defaults:      buildSpaceDefaultsExternalFromInternal(in.Spec.Defaults),
 			},
 			Status: ext.SpaceStatus{
@@ -788,4 +790,50 @@ func NormalizeCell(req ext.CellDoc) (intmodel.Cell, ext.Version, error) {
 		return intmodel.Cell{}, "", err
 	}
 	return internal, version, nil
+}
+
+func convertSpaceNetworkToInternal(in *ext.SpaceNetwork) *intmodel.SpaceNetwork {
+	if in == nil {
+		return nil
+	}
+	out := &intmodel.SpaceNetwork{}
+	if in.Egress != nil {
+		allow := make([]intmodel.EgressAllowRule, len(in.Egress.Allow))
+		for i, r := range in.Egress.Allow {
+			ports := append([]int(nil), r.Ports...)
+			allow[i] = intmodel.EgressAllowRule{
+				Host:  r.Host,
+				CIDR:  r.CIDR,
+				Ports: ports,
+			}
+		}
+		out.Egress = &intmodel.EgressPolicy{
+			Default: intmodel.EgressDefault(in.Egress.Default),
+			Allow:   allow,
+		}
+	}
+	return out
+}
+
+func buildSpaceNetworkExternalFromInternal(in *intmodel.SpaceNetwork) *ext.SpaceNetwork {
+	if in == nil {
+		return nil
+	}
+	out := &ext.SpaceNetwork{}
+	if in.Egress != nil {
+		allow := make([]ext.EgressAllowRule, len(in.Egress.Allow))
+		for i, r := range in.Egress.Allow {
+			ports := append([]int(nil), r.Ports...)
+			allow[i] = ext.EgressAllowRule{
+				Host:  r.Host,
+				CIDR:  r.CIDR,
+				Ports: ports,
+			}
+		}
+		out.Egress = &ext.EgressPolicy{
+			Default: ext.EgressDefault(in.Egress.Default),
+			Allow:   allow,
+		}
+	}
+	return out
 }

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -255,6 +255,81 @@ func TestStackRoundTripV1Beta1(t *testing.T) {
 	}
 }
 
+func TestSpaceEgressPolicyRoundTripV1Beta1(t *testing.T) {
+	input := ext.SpaceDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindSpace,
+		Metadata:   ext.SpaceMetadata{Name: "agents"},
+		Spec: ext.SpaceSpec{
+			RealmID: "main",
+			Network: &ext.SpaceNetwork{
+				Egress: &ext.EgressPolicy{
+					Default: ext.EgressDefaultDeny,
+					Allow: []ext.EgressAllowRule{
+						{Host: "api.anthropic.com", Ports: []int{443}},
+						{CIDR: "10.0.0.0/8", Ports: []int{5432}},
+					},
+				},
+			},
+		},
+	}
+	internal, version, err := apischeme.NormalizeSpace(input)
+	if err != nil {
+		t.Fatalf("NormalizeSpace: %v", err)
+	}
+	if version != ext.APIVersionV1Beta1 {
+		t.Fatalf("unexpected version: %s", version)
+	}
+	if internal.Spec.Network == nil || internal.Spec.Network.Egress == nil {
+		t.Fatalf("egress dropped in conversion: %+v", internal.Spec)
+	}
+	eg := internal.Spec.Network.Egress
+	if string(eg.Default) != string(ext.EgressDefaultDeny) {
+		t.Fatalf("default not preserved: %q", eg.Default)
+	}
+	if len(eg.Allow) != 2 {
+		t.Fatalf("allow rule count: got %d, want 2", len(eg.Allow))
+	}
+	if eg.Allow[0].Host != "api.anthropic.com" || len(eg.Allow[0].Ports) != 1 || eg.Allow[0].Ports[0] != 443 {
+		t.Fatalf("host rule not preserved: %+v", eg.Allow[0])
+	}
+
+	// Round-trip back to external.
+	out, err := apischeme.BuildSpaceExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildSpaceExternalFromInternal: %v", err)
+	}
+	if out.Spec.Network == nil || out.Spec.Network.Egress == nil {
+		t.Fatalf("egress dropped on reverse conversion: %+v", out.Spec)
+	}
+	if len(out.Spec.Network.Egress.Allow) != 2 {
+		t.Fatalf("allow rules lost on reverse conversion: %+v", out.Spec.Network.Egress)
+	}
+	// Confirm the YAML round-trip: re-serializing shouldn't blow up on
+	// the new nested struct.
+	if _, err = yaml.Marshal(out); err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+}
+
+func TestSpaceEgressNilFieldsOmittedInYAML(t *testing.T) {
+	// Minimal space with no network/egress — YAML must not render a
+	// "network: null" line or expose the Egress pointer.
+	input := ext.SpaceDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindSpace,
+		Metadata:   ext.SpaceMetadata{Name: "blog"},
+		Spec:       ext.SpaceSpec{RealmID: "main"},
+	}
+	b, err := yaml.Marshal(input)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if strings.Contains(string(b), "network:") {
+		t.Fatalf("network field must be omitted when nil; got:\n%s", string(b))
+	}
+}
+
 func TestCellRoundTripV1Beta1(t *testing.T) {
 	input := ext.CellDoc{
 		APIVersion: ext.APIVersionV1Beta1,

--- a/internal/controller/runner/delete_space.go
+++ b/internal/controller/runner/delete_space.go
@@ -89,6 +89,14 @@ func (r *Exec) DeleteSpace(space intmodel.Space) error {
 		}
 	}
 
+	// Remove egress policy (iptables chain + dispatch) before tearing
+	// down the bridge itself. Idempotent: safe when no policy was ever
+	// applied.
+	if policyErr := r.removeSpaceEgressPolicy(internalSpace); policyErr != nil {
+		r.logger.WarnContext(r.ctx, "failed to remove space egress policy", "error", policyErr)
+		// Continue teardown even if policy removal fails.
+	}
+
 	// Delete CNI network config and perform comprehensive CNI cleanup
 	var networkName string
 	networkName, err = naming.BuildSpaceNetworkName(realmName, internalSpace.Metadata.Name)

--- a/internal/controller/runner/egress.go
+++ b/internal/controller/runner/egress.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+
+	"github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/netpolicy"
+	"github.com/eminwux/kukeon/internal/util/naming"
+)
+
+// applySpaceEgressPolicy realizes space.Spec.Network.Egress on the host
+// firewall. It is a no-op when the space has no egress policy or when the
+// policy effectively matches current behavior (default=allow with no
+// allowlist entries).
+func (r *Exec) applySpaceEgressPolicy(space intmodel.Space) error {
+	if space.Spec.Network == nil || space.Spec.Network.Egress == nil {
+		return nil
+	}
+	networkName, err := naming.BuildSpaceNetworkName(space.Spec.RealmName, space.Metadata.Name)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)
+	}
+	bridge := cni.SafeBridgeName(networkName)
+
+	policy, err := netpolicy.FromInternal(
+		space.Spec.RealmName, space.Metadata.Name, bridge, space.Spec.Network.Egress,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)
+	}
+	if policy == nil {
+		return nil
+	}
+	if err = policy.Resolve(r.ctx, nil); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)
+	}
+	return r.netPolicyEnforcer().Apply(r.ctx, policy)
+}
+
+// removeSpaceEgressPolicy tears down any policy previously installed for
+// this space. Idempotent; safe to call on spaces that never had a policy.
+func (r *Exec) removeSpaceEgressPolicy(space intmodel.Space) error {
+	return r.netPolicyEnforcer().Remove(r.ctx, space.Spec.RealmName, space.Metadata.Name)
+}

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -158,6 +158,13 @@ func (r *Exec) provisionNewSpace(space intmodel.Space) (intmodel.Space, error) {
 	space.Status.CgroupPath = cgroupPath
 	space.Status.State = intmodel.SpaceStateReady
 
+	// Realize egress policy on the host firewall. iptables rules are safe
+	// to install before the bridge exists — they will match nothing until
+	// the CNI plugin brings the bridge up for the first container.
+	if policyErr := r.applySpaceEgressPolicy(space); policyErr != nil {
+		return intmodel.Space{}, policyErr
+	}
+
 	// Update space metadata
 	if updateErr := r.UpdateSpaceMetadata(space); updateErr != nil {
 		return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateSpaceMetadata, updateErr)
@@ -266,6 +273,12 @@ func (r *Exec) ensureSpaceCNIConfig(space intmodel.Space) (intmodel.Space, error
 		"conf",
 		confPath,
 	)
+	// Re-apply egress policy on every Ensure so a daemon restart (or a
+	// manual `kuke apply` with a changed policy) converges the host
+	// firewall to the spec. iptables rules are idempotent via ensureRule.
+	if policyErr := r.applySpaceEgressPolicy(space); policyErr != nil {
+		return intmodel.Space{}, policyErr
+	}
 	return space, nil
 }
 

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/ctr"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/netpolicy"
 )
 
 type Runner interface {
@@ -99,6 +100,11 @@ type Exec struct {
 	ctrClient ctr.Client
 
 	cniConf *cni.Conf
+
+	// netPolicy applies and removes space egress policies on the host
+	// firewall. nil behaves as a NoopEnforcer so unit tests and read-only
+	// clients never touch iptables.
+	netPolicy netpolicy.Enforcer
 }
 
 type Options struct {
@@ -113,11 +119,21 @@ type Options struct {
 
 func NewRunner(ctx context.Context, logger *slog.Logger, opts Options) Runner {
 	return &Exec{
-		ctx:     ctx,
-		logger:  logger,
-		opts:    opts,
-		cniConf: &opts.CniConf,
+		ctx:       ctx,
+		logger:    logger,
+		opts:      opts,
+		cniConf:   &opts.CniConf,
+		netPolicy: netpolicy.NewIptablesEnforcer(logger),
 	}
+}
+
+// netPolicyEnforcer returns the configured enforcer or a no-op when the
+// runner was built without one (e.g., minimal test fixtures).
+func (r *Exec) netPolicyEnforcer() netpolicy.Enforcer {
+	if r.netPolicy == nil {
+		return netpolicy.NoopEnforcer{}
+	}
+	return r.netPolicy
 }
 
 func (r *Exec) BootstrapCNI(cfgDir, cacheDir, binDir string) (cni.BootstrapReport, error) {

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -113,6 +113,18 @@ var (
 	ErrBridgeNameTooLong = errors.New("bridge name exceeds Linux IFNAMSIZ limit")
 	ErrCNIPluginNotFound = errors.New("cni plugin not found")
 
+	// Network-policy-related errors.
+
+	ErrEgressRuleTargetRequired = errors.New("egress allow rule requires exactly one of host or cidr")
+	ErrEgressRuleTargetConflict = errors.New("egress allow rule must not set both host and cidr")
+	ErrEgressInvalidCIDR        = errors.New("egress allow rule cidr is not a valid CIDR")
+	ErrEgressInvalidHost        = errors.New("egress allow rule host is not a valid dns name")
+	ErrEgressInvalidPort        = errors.New("egress allow rule port must be within [1, 65535]")
+	ErrEgressInvalidDefault     = errors.New("egress default must be 'allow' or 'deny'")
+	ErrEgressHostResolution     = errors.New("failed to resolve egress allow rule host")
+	ErrEgressApply              = errors.New("failed to apply egress policy")
+	ErrEgressRemove             = errors.New("failed to remove egress policy")
+
 	// Secret-related errors.
 
 	ErrSecretNameRequired        = errors.New("secret name is required")

--- a/internal/modelhub/space.go
+++ b/internal/modelhub/space.go
@@ -30,7 +30,37 @@ type SpaceMetadata struct {
 type SpaceSpec struct {
 	RealmName     string
 	CNIConfigPath string
+	Network       *SpaceNetwork
 	Defaults      *SpaceDefaults
+}
+
+// SpaceNetwork groups network-scoped policy applied to the space bridge.
+type SpaceNetwork struct {
+	Egress *EgressPolicy
+}
+
+// EgressPolicy constrains outbound traffic leaving the space bridge. nil
+// means unconstrained; EgressDefaultAllow with no allow rules matches the
+// same unconstrained behavior.
+type EgressPolicy struct {
+	Default EgressDefault
+	Allow   []EgressAllowRule
+}
+
+// EgressDefault is the fallthrough action when no allowlist rule matches.
+type EgressDefault string
+
+const (
+	EgressDefaultAllow EgressDefault = "allow"
+	EgressDefaultDeny  EgressDefault = "deny"
+)
+
+// EgressAllowRule describes a single permitted destination. Exactly one of
+// Host or CIDR must be set. Empty Ports means "any port on this destination".
+type EgressAllowRule struct {
+	Host  string
+	CIDR  string
+	Ports []int
 }
 
 // SpaceDefaults declares default values inherited by resources inside the

--- a/internal/netpolicy/enforcer.go
+++ b/internal/netpolicy/enforcer.go
@@ -1,0 +1,297 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package netpolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// Enforcer applies and removes per-space egress policies on the host
+// firewall. The interface is narrow so tests and `--no-daemon` paths can
+// substitute a no-op implementation.
+type Enforcer interface {
+	// Apply installs the policy idempotently. A nil policy is a no-op.
+	Apply(ctx context.Context, p *Policy) error
+	// Remove tears down the policy for the given realm+space. It is safe
+	// to call when no policy was installed.
+	Remove(ctx context.Context, realmName, spaceName string) error
+}
+
+// NoopEnforcer satisfies Enforcer without touching the host firewall. It is
+// the safe default for test fixtures and for code paths that must never
+// mutate iptables (e.g., `--no-daemon` read-only clients).
+type NoopEnforcer struct{}
+
+func (NoopEnforcer) Apply(_ context.Context, _ *Policy) error         { return nil }
+func (NoopEnforcer) Remove(_ context.Context, _, _ string) error      { return nil }
+
+// CommandRunner executes an iptables invocation and returns its combined
+// stdout+stderr. Tests inject a fake to capture invocations and return
+// canned output for read-only calls like "-S" or "-L".
+type CommandRunner interface {
+	Run(ctx context.Context, args ...string) ([]byte, error)
+}
+
+type execRunner struct {
+	binary string
+}
+
+func (e *execRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, e.binary, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("iptables %s: %w: %s",
+			strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+// IptablesEnforcer invokes the iptables command to realize policies.
+type IptablesEnforcer struct {
+	runner CommandRunner
+	logger *slog.Logger
+}
+
+// NewIptablesEnforcer returns an enforcer that shells out to the iptables
+// binary on PATH. Logger is required and should be the daemon-scoped slog.
+func NewIptablesEnforcer(logger *slog.Logger) *IptablesEnforcer {
+	return &IptablesEnforcer{
+		runner: &execRunner{binary: "iptables"},
+		logger: logger,
+	}
+}
+
+// NewIptablesEnforcerWithRunner is the test-hook constructor.
+func NewIptablesEnforcerWithRunner(logger *slog.Logger, runner CommandRunner) *IptablesEnforcer {
+	return &IptablesEnforcer{runner: runner, logger: logger}
+}
+
+// Apply creates/flushes the per-space chain, loads the rules, and wires the
+// dispatch jump from the master chain. A nil policy is a no-op.
+func (e *IptablesEnforcer) Apply(ctx context.Context, p *Policy) error {
+	if p == nil {
+		return nil
+	}
+	if err := e.ensureMasterChain(ctx); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)
+	}
+	chain := p.ChainName()
+
+	if err := e.ensureChain(ctx, chain); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)
+	}
+	if _, err := e.runner.Run(ctx, "-F", chain); err != nil {
+		return fmt.Errorf("%w: flush %s: %w", errdefs.ErrEgressApply, chain, err)
+	}
+
+	for _, rule := range BuildRules(p) {
+		if _, err := e.runner.Run(ctx, ruleArgs(rule)...); err != nil {
+			return fmt.Errorf("%w: %w", errdefs.ErrEgressApply, err)
+		}
+	}
+
+	dispatch := DispatchRule(p)
+	if err := e.ensureRule(ctx, dispatch); err != nil {
+		return fmt.Errorf("%w: dispatch: %w", errdefs.ErrEgressApply, err)
+	}
+
+	e.logger.InfoContext(ctx, "applied egress policy",
+		"realm", p.RealmName,
+		"space", p.SpaceName,
+		"bridge", p.Bridge,
+		"chain", chain,
+		"default", string(p.Default),
+		"allow_count", len(p.Allow),
+	)
+	return nil
+}
+
+// Remove deletes every dispatch rule targeting the per-space chain, then
+// flushes and deletes the chain itself. Idempotent.
+func (e *IptablesEnforcer) Remove(ctx context.Context, realmName, spaceName string) error {
+	chain := chainName(realmName, spaceName)
+
+	e.logDropCounter(ctx, chain, realmName, spaceName)
+
+	if err := e.deleteJumpsToChain(ctx, chain); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrEgressRemove, err)
+	}
+
+	if _, err := e.runner.Run(ctx, "-F", chain); err != nil {
+		e.logger.DebugContext(ctx, "flush chain (likely absent)", "chain", chain, "err", err)
+	}
+	if _, err := e.runner.Run(ctx, "-X", chain); err != nil {
+		e.logger.DebugContext(ctx, "delete chain (likely absent)", "chain", chain, "err", err)
+	}
+	return nil
+}
+
+func (e *IptablesEnforcer) ensureMasterChain(ctx context.Context) error {
+	if err := e.ensureChain(ctx, MasterChainName); err != nil {
+		return err
+	}
+	if _, err := e.runner.Run(ctx, "-C", "FORWARD", "-j", MasterChainName); err == nil {
+		return nil
+	}
+	_, err := e.runner.Run(ctx, "-I", "FORWARD", "1", "-j", MasterChainName)
+	return err
+}
+
+func (e *IptablesEnforcer) ensureChain(ctx context.Context, chain string) error {
+	if _, err := e.runner.Run(ctx, "-L", chain, "-n"); err == nil {
+		return nil
+	}
+	_, err := e.runner.Run(ctx, "-N", chain)
+	return err
+}
+
+func (e *IptablesEnforcer) ensureRule(ctx context.Context, r Rule) error {
+	check := append([]string{"-C", r.Chain}, r.Args...)
+	if _, err := e.runner.Run(ctx, check...); err == nil {
+		return nil
+	}
+	_, err := e.runner.Run(ctx, ruleArgs(r)...)
+	return err
+}
+
+// deleteJumpsToChain enumerates FORWARD/KUKEON-EGRESS rules and deletes
+// every entry that jumps to the given per-space chain. It tolerates a
+// missing master chain (treats it as nothing to remove).
+func (e *IptablesEnforcer) deleteJumpsToChain(ctx context.Context, chain string) error {
+	out, err := e.runner.Run(ctx, "-S", MasterChainName)
+	if err != nil {
+		// Master chain likely absent — nothing to remove.
+		return nil
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "-A "+MasterChainName+" ") {
+			continue
+		}
+		if !strings.Contains(line, " -j "+chain) {
+			continue
+		}
+		args, parseErr := parseRuleLine(line)
+		if parseErr != nil {
+			return parseErr
+		}
+		if len(args) == 0 || args[0] != "-A" {
+			continue
+		}
+		delArgs := append([]string{"-D"}, args[1:]...)
+		if _, delErr := e.runner.Run(ctx, delArgs...); delErr != nil {
+			return delErr
+		}
+	}
+	return nil
+}
+
+func (e *IptablesEnforcer) logDropCounter(ctx context.Context, chain, realmName, spaceName string) {
+	out, err := e.runner.Run(ctx, "-L", chain, "-n", "-v", "-x")
+	if err != nil {
+		return
+	}
+	packets, bytes, ok := parseDropCounter(string(out))
+	if !ok {
+		return
+	}
+	e.logger.InfoContext(ctx, "egress policy drop counter",
+		"realm", realmName,
+		"space", spaceName,
+		"chain", chain,
+		"drop_packets", packets,
+		"drop_bytes", bytes,
+	)
+}
+
+// parseDropCounter finds the terminal DROP row in `iptables -L <chain> -n -v -x`
+// output and returns its (packets, bytes) counters. Returns ok=false on any
+// format surprise.
+func parseDropCounter(output string) (uint64, uint64, bool) {
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		if fields[2] != "DROP" {
+			continue
+		}
+		packets, err := strconv.ParseUint(fields[0], 10, 64)
+		if err != nil {
+			continue
+		}
+		bytes, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		return packets, bytes, true
+	}
+	return 0, 0, false
+}
+
+// ruleArgs flattens a Rule into an iptables argument vector.
+func ruleArgs(r Rule) []string {
+	opFields := strings.Fields(r.Op)
+	out := make([]string, 0, len(opFields)+1+len(r.Args))
+	out = append(out, opFields...)
+	out = append(out, r.Chain)
+	out = append(out, r.Args...)
+	return out
+}
+
+// parseRuleLine splits an "-A <chain> ..." line from `iptables -S` into its
+// argument vector. Double-quoted substrings (iptables emits --comment values
+// in quotes when they contain spaces) are preserved as a single arg with the
+// quotes stripped.
+func parseRuleLine(line string) ([]string, error) {
+	var (
+		out     []string
+		cur     strings.Builder
+		inQuote bool
+	)
+	flush := func() {
+		if cur.Len() == 0 {
+			return
+		}
+		out = append(out, cur.String())
+		cur.Reset()
+	}
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case c == '"':
+			inQuote = !inQuote
+		case c == ' ' && !inQuote:
+			flush()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	flush()
+	if inQuote {
+		return nil, errors.New("unterminated quote in iptables -S line")
+	}
+	return out, nil
+}

--- a/internal/netpolicy/enforcer_test.go
+++ b/internal/netpolicy/enforcer_test.go
@@ -1,0 +1,246 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package netpolicy_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/netpolicy"
+)
+
+// fakeRunner records every iptables invocation and returns canned responses
+// keyed by the first few args. Unknown calls succeed silently.
+type fakeRunner struct {
+	calls [][]string
+	// respond maps a space-joined prefix of args to (stdout, err).
+	respond map[string]fakeResp
+}
+
+type fakeResp struct {
+	out []byte
+	err error
+}
+
+func (f *fakeRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, append([]string(nil), args...))
+	key := strings.Join(args, " ")
+	if f.respond != nil {
+		if r, ok := f.respond[key]; ok {
+			return r.out, r.err
+		}
+	}
+	return nil, nil
+}
+
+func newEnforcer(runner *fakeRunner) *netpolicy.IptablesEnforcer {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return netpolicy.NewIptablesEnforcerWithRunner(logger, runner)
+}
+
+func TestEnforcer_ApplyNilIsNoop(t *testing.T) {
+	runner := &fakeRunner{}
+	e := newEnforcer(runner)
+	if err := e.Apply(context.Background(), nil); err != nil {
+		t.Fatalf("nil Apply: %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("nil Apply must not invoke iptables; got %v", runner.calls)
+	}
+}
+
+func TestEnforcer_ApplyEmitsExpectedSequence(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Make -C and -L succeed where we want to skip the creation step.
+			"-C FORWARD -j KUKEON-EGRESS": {err: errors.New("absent")},
+			"-L KUKEON-EGRESS -n":         {err: errors.New("absent")},
+		},
+	}
+	e := newEnforcer(runner)
+
+	p, err := netpolicy.FromInternal("main", "blog", "br0", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{CIDR: "10.0.0.0/8", Ports: []int{5432}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("FromInternal: %v", err)
+	}
+	// Make the per-space chain appear absent so -N gets called.
+	runner.respond["-L "+p.ChainName()+" -n"] = fakeResp{err: errors.New("absent")}
+
+	if err = e.Apply(context.Background(), p); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if !wasCalled(runner, []string{"-N", "KUKEON-EGRESS"}) {
+		t.Errorf("expected -N KUKEON-EGRESS; calls = %v", runner.calls)
+	}
+	if !wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-EGRESS"}) {
+		t.Errorf("expected FORWARD jump to KUKEON-EGRESS; calls = %v", runner.calls)
+	}
+	if !wasCalled(runner, []string{"-N", p.ChainName()}) {
+		t.Errorf("expected -N %s; calls = %v", p.ChainName(), runner.calls)
+	}
+	if !wasCalled(runner, []string{"-F", p.ChainName()}) {
+		t.Errorf("expected -F %s (flush); calls = %v", p.ChainName(), runner.calls)
+	}
+
+	// Must include a DROP rule with the policy comment tag.
+	foundDrop := false
+	for _, c := range runner.calls {
+		joined := strings.Join(c, " ")
+		if strings.HasPrefix(joined, "-A "+p.ChainName()) && strings.Contains(joined, "-j DROP") {
+			foundDrop = true
+			break
+		}
+	}
+	if !foundDrop {
+		t.Errorf("expected terminal DROP rule; calls = %v", runner.calls)
+	}
+}
+
+func TestEnforcer_ApplyIsIdempotentWhenMasterExists(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Simulate master chain + FORWARD jump already present.
+			"-L KUKEON-EGRESS -n":         {}, // nil err means "exists"
+			"-C FORWARD -j KUKEON-EGRESS": {},
+		},
+	}
+	e := newEnforcer(runner)
+
+	p, _ := netpolicy.FromInternal("main", "blog", "br0", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	runner.respond["-L "+p.ChainName()+" -n"] = fakeResp{} // per-space chain exists too
+	// Dispatch rule absent so we get one -A.
+	dispatchCheckKey := "-C KUKEON-EGRESS -i br0 -m comment --comment kukeon:main:blog:dispatch -j " + p.ChainName()
+	runner.respond[dispatchCheckKey] = fakeResp{err: errors.New("absent")}
+
+	if err := e.Apply(context.Background(), p); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// -N KUKEON-EGRESS must NOT be invoked since -L succeeded.
+	if wasCalled(runner, []string{"-N", "KUKEON-EGRESS"}) {
+		t.Errorf("must not re-create existing master chain")
+	}
+	// -I FORWARD jump also must not be re-inserted.
+	if wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-EGRESS"}) {
+		t.Errorf("must not re-insert FORWARD jump when -C succeeds")
+	}
+	// Dispatch append should have occurred.
+	if !wasCalled(runner, []string{"-A", "KUKEON-EGRESS", "-i", "br0", "-m", "comment",
+		"--comment", "kukeon:main:blog:dispatch", "-j", p.ChainName()}) {
+		t.Errorf("expected dispatch -A; calls = %v", runner.calls)
+	}
+}
+
+func TestEnforcer_RemoveFlushesAndDeletes(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// No dispatch rules — master list empty.
+			"-S KUKEON-EGRESS": {out: []byte("-N KUKEON-EGRESS\n")},
+		},
+	}
+	e := newEnforcer(runner)
+	if err := e.Remove(context.Background(), "main", "blog"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	chain := chainFor("main", "blog")
+	if !wasCalled(runner, []string{"-F", chain}) {
+		t.Errorf("expected -F %s; calls = %v", chain, runner.calls)
+	}
+	if !wasCalled(runner, []string{"-X", chain}) {
+		t.Errorf("expected -X %s; calls = %v", chain, runner.calls)
+	}
+}
+
+func TestEnforcer_RemoveDeletesDispatchRules(t *testing.T) {
+	// Build a Policy so we can get the chain name the enforcer will use.
+	p, _ := netpolicy.FromInternal("main", "blog", "br0", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	chain := p.ChainName()
+
+	// iptables -S output containing one matching rule.
+	listOut := "-N KUKEON-EGRESS\n" +
+		"-A KUKEON-EGRESS -i br0 -m comment --comment \"kukeon:main:blog:dispatch\" -j " + chain + "\n"
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-S KUKEON-EGRESS": {out: []byte(listOut)},
+		},
+	}
+	e := newEnforcer(runner)
+	if err := e.Remove(context.Background(), "main", "blog"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	// Must emit a -D with the args from the -A line.
+	foundDelete := false
+	for _, c := range runner.calls {
+		joined := strings.Join(c, " ")
+		if strings.HasPrefix(joined, "-D KUKEON-EGRESS") && strings.Contains(joined, "-j "+chain) {
+			foundDelete = true
+			break
+		}
+	}
+	if !foundDelete {
+		t.Errorf("expected -D dispatch rule; calls = %v", runner.calls)
+	}
+}
+
+func TestNoopEnforcerMatchesInterface(t *testing.T) {
+	var _ netpolicy.Enforcer = netpolicy.NoopEnforcer{}
+	var _ netpolicy.Enforcer = (*netpolicy.IptablesEnforcer)(nil)
+}
+
+// chainFor mirrors netpolicy.chainName for test-side lookups. The function
+// is unexported in the package; we reuse FromInternal to reach ChainName.
+func chainFor(realm, space string) string {
+	p, _ := netpolicy.FromInternal(realm, space, "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	return p.ChainName()
+}
+
+func wasCalled(f *fakeRunner, want []string) bool {
+	for _, got := range f.calls {
+		if sliceEq(got, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/netpolicy/policy.go
+++ b/internal/netpolicy/policy.go
@@ -1,0 +1,193 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package netpolicy renders space-level egress policies into iptables rules
+// and applies them on the host firewall. The public surface is:
+//
+//   - Policy: an already-validated policy-for-a-space, derived from a Space's
+//     intmodel.EgressPolicy.
+//   - BuildRules: pure rule generator — no I/O, no iptables invocations.
+//   - Enforcer: interface for applying/removing rules on the host.
+//   - IptablesEnforcer: concrete enforcer that shells out to iptables.
+//
+// Design choice (per issue #45): host entries are resolved to IPs at apply
+// time. The resolved IPs are embedded in iptables rules, so hostname-based
+// entries do not reflect DNS changes until the space is re-applied. See the
+// Space manifest docs for the operator-visible caveat.
+package netpolicy
+
+import (
+	"fmt"
+	"hash/fnv"
+	"net"
+	"sort"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// Policy is the validated, per-space egress policy ready for rule generation.
+// Use FromInternal to build one from the internal Space model.
+type Policy struct {
+	// Bridge is the Linux bridge device name (as written in the CNI
+	// conflist) that the policy guards.
+	Bridge string
+	// RealmName and SpaceName identify the space for chain naming and log
+	// tagging.
+	RealmName string
+	SpaceName string
+	// Default is the fallthrough action when no Allow rule matches.
+	Default intmodel.EgressDefault
+	// Allow is the list of validated allowlist entries.
+	Allow []ResolvedRule
+}
+
+// ResolvedRule is a single allowlist entry where Host (if any) has already
+// been resolved to IPs. Callers constructing Policy by hand must fill either
+// CIDR or IPs (the resolver populates IPs from a Host lookup).
+type ResolvedRule struct {
+	// OriginalHost is the user-supplied host, kept so rule comments can
+	// name the DNS origin. Empty when the rule came from a CIDR entry.
+	OriginalHost string
+	// CIDR is set when the rule was supplied as a literal CIDR.
+	CIDR string
+	// IPs is the list of IPs the rule targets. When CIDR is set, IPs is
+	// empty and CIDR is used as the iptables -d target.
+	IPs []net.IP
+	// Ports is the list of TCP destination ports. Empty means "any port".
+	Ports []int
+}
+
+// FromInternal validates an internal EgressPolicy and returns an intermediate
+// Policy with hosts *not yet resolved*. Call Resolve to populate IPs.
+//
+// Returns (nil, nil) when egress is effectively a no-op: either the policy
+// pointer is nil, or Default=allow with no Allow entries. Callers treat a nil
+// result as "nothing to enforce".
+func FromInternal(realmName, spaceName, bridge string, in *intmodel.EgressPolicy) (*Policy, error) {
+	if in == nil {
+		return nil, nil
+	}
+	def, err := normalizeDefault(in.Default)
+	if err != nil {
+		return nil, err
+	}
+	if def == intmodel.EgressDefaultAllow && len(in.Allow) == 0 {
+		return nil, nil
+	}
+	rules := make([]ResolvedRule, 0, len(in.Allow))
+	for i, r := range in.Allow {
+		rule, vErr := validateAllowRule(r)
+		if vErr != nil {
+			return nil, fmt.Errorf("egress allow rule %d: %w", i, vErr)
+		}
+		rules = append(rules, rule)
+	}
+	return &Policy{
+		Bridge:    bridge,
+		RealmName: realmName,
+		SpaceName: spaceName,
+		Default:   def,
+		Allow:     rules,
+	}, nil
+}
+
+func normalizeDefault(d intmodel.EgressDefault) (intmodel.EgressDefault, error) {
+	switch strings.ToLower(strings.TrimSpace(string(d))) {
+	case "", string(intmodel.EgressDefaultAllow):
+		return intmodel.EgressDefaultAllow, nil
+	case string(intmodel.EgressDefaultDeny):
+		return intmodel.EgressDefaultDeny, nil
+	default:
+		return "", errdefs.ErrEgressInvalidDefault
+	}
+}
+
+func validateAllowRule(r intmodel.EgressAllowRule) (ResolvedRule, error) {
+	host := strings.TrimSpace(r.Host)
+	cidr := strings.TrimSpace(r.CIDR)
+	switch {
+	case host == "" && cidr == "":
+		return ResolvedRule{}, errdefs.ErrEgressRuleTargetRequired
+	case host != "" && cidr != "":
+		return ResolvedRule{}, errdefs.ErrEgressRuleTargetConflict
+	}
+	if cidr != "" {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return ResolvedRule{}, fmt.Errorf("%w: %q: %w", errdefs.ErrEgressInvalidCIDR, cidr, err)
+		}
+	}
+	if host != "" && !isLikelyDNSName(host) {
+		return ResolvedRule{}, fmt.Errorf("%w: %q", errdefs.ErrEgressInvalidHost, host)
+	}
+	ports := make([]int, 0, len(r.Ports))
+	seen := make(map[int]struct{}, len(r.Ports))
+	for _, p := range r.Ports {
+		if p < 1 || p > 65535 {
+			return ResolvedRule{}, fmt.Errorf("%w: %d", errdefs.ErrEgressInvalidPort, p)
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		ports = append(ports, p)
+	}
+	sort.Ints(ports)
+	return ResolvedRule{
+		OriginalHost: host,
+		CIDR:         cidr,
+		Ports:        ports,
+	}, nil
+}
+
+// isLikelyDNSName is a loose syntactic check that rejects obvious garbage
+// (spaces, empty labels, leading/trailing dots) without trying to reimplement
+// the full RFC 1035 grammar. The authoritative check happens at Resolve time.
+func isLikelyDNSName(s string) bool {
+	if s == "" || strings.ContainsAny(s, " \t/") {
+		return false
+	}
+	if strings.HasPrefix(s, ".") || strings.HasSuffix(s, ".") {
+		return false
+	}
+	for _, label := range strings.Split(s, ".") {
+		if label == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// ChainName returns the deterministic iptables chain name for this policy.
+// Format: "KUKE-EGR-<8-hex-fnv>". The FNV-1a hash of "<realm>/<space>" keeps
+// the name short enough for any iptables version while avoiding collisions
+// across spaces in different realms.
+func (p *Policy) ChainName() string {
+	return chainName(p.RealmName, p.SpaceName)
+}
+
+func chainName(realmName, spaceName string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(realmName + "/" + spaceName))
+	return fmt.Sprintf("KUKE-EGR-%08x", h.Sum32())
+}
+
+// CommentTag returns the short identifier embedded in every rule's
+// --comment argument so operators can grep iptables output by space.
+func (p *Policy) CommentTag() string {
+	return fmt.Sprintf("kukeon:%s:%s", p.RealmName, p.SpaceName)
+}

--- a/internal/netpolicy/policy_test.go
+++ b/internal/netpolicy/policy_test.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package netpolicy_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/netpolicy"
+)
+
+func TestFromInternal_NilAndEffectivelyAllow(t *testing.T) {
+	p, err := netpolicy.FromInternal("r", "s", "br", nil)
+	if err != nil || p != nil {
+		t.Fatalf("nil policy expected nil,nil; got %v, %v", p, err)
+	}
+
+	p, err = netpolicy.FromInternal("r", "s", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultAllow,
+	})
+	if err != nil || p != nil {
+		t.Fatalf("default=allow + no allow rules expected nil policy; got %+v, %v", p, err)
+	}
+}
+
+func TestFromInternal_DenyMinimum(t *testing.T) {
+	p, err := netpolicy.FromInternal("main", "blog", "main-blog", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p == nil {
+		t.Fatalf("expected non-nil policy")
+	}
+	if p.Default != intmodel.EgressDefaultDeny {
+		t.Fatalf("default: got %q, want deny", p.Default)
+	}
+	if p.Bridge != "main-blog" {
+		t.Fatalf("bridge: got %q, want main-blog", p.Bridge)
+	}
+}
+
+func TestFromInternal_InvalidDefault(t *testing.T) {
+	_, err := netpolicy.FromInternal("r", "s", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefault("maybe"),
+	})
+	if !errors.Is(err, errdefs.ErrEgressInvalidDefault) {
+		t.Fatalf("expected ErrEgressInvalidDefault, got %v", err)
+	}
+}
+
+func TestFromInternal_RuleValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		rule    intmodel.EgressAllowRule
+		wantErr error
+	}{
+		{"empty", intmodel.EgressAllowRule{}, errdefs.ErrEgressRuleTargetRequired},
+		{"both set", intmodel.EgressAllowRule{Host: "example.com", CIDR: "10.0.0.0/8"}, errdefs.ErrEgressRuleTargetConflict},
+		{"bad cidr", intmodel.EgressAllowRule{CIDR: "not-a-cidr"}, errdefs.ErrEgressInvalidCIDR},
+		{"bad host", intmodel.EgressAllowRule{Host: "has spaces.com"}, errdefs.ErrEgressInvalidHost},
+		{"bad port low", intmodel.EgressAllowRule{CIDR: "10.0.0.0/8", Ports: []int{0}}, errdefs.ErrEgressInvalidPort},
+		{"bad port high", intmodel.EgressAllowRule{CIDR: "10.0.0.0/8", Ports: []int{70000}}, errdefs.ErrEgressInvalidPort},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := netpolicy.FromInternal("r", "s", "br", &intmodel.EgressPolicy{
+				Default: intmodel.EgressDefaultDeny,
+				Allow:   []intmodel.EgressAllowRule{tc.rule},
+			})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestFromInternal_PortsDedupedAndSorted(t *testing.T) {
+	p, err := netpolicy.FromInternal("r", "s", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{CIDR: "10.0.0.0/8", Ports: []int{443, 80, 443, 22}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(p.Allow) != 1 {
+		t.Fatalf("expected 1 allow rule, got %d", len(p.Allow))
+	}
+	got := p.Allow[0].Ports
+	want := []int{22, 80, 443}
+	if len(got) != len(want) {
+		t.Fatalf("ports: got %v, want %v", got, want)
+	}
+	for i, p := range want {
+		if got[i] != p {
+			t.Fatalf("ports[%d]: got %d, want %d", i, got[i], p)
+		}
+	}
+}
+
+func TestChainNameStableAndScoped(t *testing.T) {
+	p1, _ := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	p2, _ := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	p3, _ := netpolicy.FromInternal("main", "shop", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	p4, _ := netpolicy.FromInternal("dev", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+
+	if p1.ChainName() != p2.ChainName() {
+		t.Fatalf("chain must be stable across identical inputs: %s vs %s", p1.ChainName(), p2.ChainName())
+	}
+	if p1.ChainName() == p3.ChainName() {
+		t.Fatalf("chain must differ across spaces in same realm")
+	}
+	if p1.ChainName() == p4.ChainName() {
+		t.Fatalf("chain must differ across realms with same space name")
+	}
+	if !strings.HasPrefix(p1.ChainName(), "KUKE-EGR-") {
+		t.Fatalf("chain prefix: got %q", p1.ChainName())
+	}
+	if len(p1.ChainName()) > 20 {
+		t.Fatalf("chain name too long for iptables: %q (%d chars)", p1.ChainName(), len(p1.ChainName()))
+	}
+}

--- a/internal/netpolicy/resolver.go
+++ b/internal/netpolicy/resolver.go
@@ -1,0 +1,91 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package netpolicy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// HostResolver resolves a hostname to its IP addresses at policy-apply time.
+// The interface is explicit so tests can substitute deterministic lookups.
+type HostResolver interface {
+	LookupIP(ctx context.Context, host string) ([]net.IP, error)
+}
+
+// NetHostResolver uses net.DefaultResolver. IPv6 addresses are filtered out
+// because the iptables applier only emits IPv4 rules today; IPv6 support is
+// out of scope for the MVP.
+type NetHostResolver struct{}
+
+func (NetHostResolver) LookupIP(ctx context.Context, host string) ([]net.IP, error) {
+	addrs, err := net.DefaultResolver.LookupIP(ctx, "ip4", host)
+	if err != nil {
+		return nil, err
+	}
+	return addrs, nil
+}
+
+// Resolve expands every Allow rule that uses a Host into a rule populated
+// with IPs. CIDR-based rules are passed through unchanged. A host that
+// resolves to zero IPv4 addresses is a fatal error so operators don't
+// silently end up with a deny-only policy.
+func (p *Policy) Resolve(ctx context.Context, resolver HostResolver) error {
+	if resolver == nil {
+		resolver = NetHostResolver{}
+	}
+	for i := range p.Allow {
+		rule := &p.Allow[i]
+		if rule.OriginalHost == "" {
+			continue
+		}
+		ips, err := resolver.LookupIP(ctx, rule.OriginalHost)
+		if err != nil {
+			return fmt.Errorf("%w: %q: %w", errdefs.ErrEgressHostResolution, rule.OriginalHost, err)
+		}
+		ips = dedupAndSortIPs(ips)
+		if len(ips) == 0 {
+			return fmt.Errorf("%w: %q resolved to no IPv4 addresses",
+				errdefs.ErrEgressHostResolution, rule.OriginalHost)
+		}
+		rule.IPs = ips
+	}
+	return nil
+}
+
+func dedupAndSortIPs(in []net.IP) []net.IP {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]net.IP, 0, len(in))
+	for _, ip := range in {
+		v4 := ip.To4()
+		if v4 == nil {
+			continue
+		}
+		key := v4.String()
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, v4)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].String() < out[j].String() })
+	return out
+}

--- a/internal/netpolicy/resolver_test.go
+++ b/internal/netpolicy/resolver_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package netpolicy_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/netpolicy"
+)
+
+type stubResolver struct {
+	table map[string][]net.IP
+	err   error
+}
+
+func (s stubResolver) LookupIP(_ context.Context, host string) ([]net.IP, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.table[host], nil
+}
+
+func TestResolve_PopulatesHostIPs(t *testing.T) {
+	p, err := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{Host: "api.example.com", Ports: []int{443}},
+			{CIDR: "10.0.0.0/8", Ports: []int{5432}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	resolver := stubResolver{
+		table: map[string][]net.IP{
+			"api.example.com": {net.ParseIP("192.0.2.10"), net.ParseIP("192.0.2.11")},
+		},
+	}
+	if err = p.Resolve(context.Background(), resolver); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := len(p.Allow[0].IPs); got != 2 {
+		t.Fatalf("host rule: got %d IPs, want 2", got)
+	}
+	// CIDR rule untouched.
+	if p.Allow[1].CIDR != "10.0.0.0/8" {
+		t.Fatalf("cidr rule mutated: %+v", p.Allow[1])
+	}
+	if len(p.Allow[1].IPs) != 0 {
+		t.Fatalf("cidr rule must not get IPs: %+v", p.Allow[1])
+	}
+}
+
+func TestResolve_EmptyResultIsFatal(t *testing.T) {
+	p, _ := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{Host: "nothing.example.com", Ports: []int{443}},
+		},
+	})
+	resolver := stubResolver{table: map[string][]net.IP{}}
+	err := p.Resolve(context.Background(), resolver)
+	if !errors.Is(err, errdefs.ErrEgressHostResolution) {
+		t.Fatalf("want ErrEgressHostResolution, got %v", err)
+	}
+}
+
+func TestResolve_FiltersV6AndDedups(t *testing.T) {
+	p, _ := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{Host: "example.com", Ports: []int{443}},
+		},
+	})
+	resolver := stubResolver{
+		table: map[string][]net.IP{
+			"example.com": {
+				net.ParseIP("2001:db8::1"), // IPv6 — filtered
+				net.ParseIP("192.0.2.10"),
+				net.ParseIP("192.0.2.10"), // dup
+			},
+		},
+	}
+	if err := p.Resolve(context.Background(), resolver); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := len(p.Allow[0].IPs); got != 1 {
+		t.Fatalf("after filter+dedup want 1 IP, got %d: %+v", got, p.Allow[0].IPs)
+	}
+	if p.Allow[0].IPs[0].String() != "192.0.2.10" {
+		t.Fatalf("wrong IP kept: %s", p.Allow[0].IPs[0])
+	}
+}

--- a/internal/netpolicy/rules.go
+++ b/internal/netpolicy/rules.go
@@ -1,0 +1,155 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package netpolicy
+
+import (
+	"fmt"
+	"strconv"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// MasterChainName is the top-level FORWARD dispatch chain that holds one
+// "jump to per-space chain" entry per space with an active policy. It is
+// shared across all spaces; the per-space chain names differ.
+const MasterChainName = "KUKEON-EGRESS"
+
+// Rule represents a single iptables command in a form the applier can
+// execute or a test can compare. It is chain-qualified ("-A <chain>" or
+// "-I <chain> 1") plus arguments.
+type Rule struct {
+	// Op is "-A" (append), "-I 1" (insert at head), etc.
+	Op string
+	// Chain is the target chain for Op.
+	Chain string
+	// Args is the remaining iptables argument list.
+	Args []string
+}
+
+// BuildRules returns the ordered iptables rules that implement Policy on the
+// per-space chain. The caller is responsible for ensuring the chain exists
+// (flushed) and for wiring the dispatch jump from the master chain.
+//
+// Rule ordering matters:
+//  1. Return on RELATED/ESTABLISHED so reply traffic is never dropped.
+//  2. Each allowlist entry emits one or more RETURN rules.
+//  3. Final action: DROP (when Default=deny) or RETURN (when Default=allow).
+//
+// The generator is pure: no I/O, no iptables invocations.
+func BuildRules(p *Policy) []Rule {
+	chain := p.ChainName()
+	tag := p.CommentTag()
+	rules := make([]Rule, 0, 2+len(p.Allow)+1)
+
+	rules = append(rules, Rule{
+		Op:    "-A",
+		Chain: chain,
+		Args: []string{
+			"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
+			"-m", "comment", "--comment", tag + ":established",
+			"-j", "RETURN",
+		},
+	})
+
+	for i, r := range p.Allow {
+		rules = append(rules, buildAllowRules(chain, tag, i, r)...)
+	}
+
+	terminal := Rule{
+		Op:    "-A",
+		Chain: chain,
+		Args: []string{
+			"-m", "comment", "--comment", tag + ":default",
+		},
+	}
+	if p.Default == intmodel.EgressDefaultDeny {
+		terminal.Args = append(terminal.Args, "-j", "DROP")
+	} else {
+		terminal.Args = append(terminal.Args, "-j", "RETURN")
+	}
+	rules = append(rules, terminal)
+
+	return rules
+}
+
+func buildAllowRules(chain, tag string, idx int, r ResolvedRule) []Rule {
+	targets := make([]string, 0)
+	if r.CIDR != "" {
+		targets = append(targets, r.CIDR)
+	} else {
+		for _, ip := range r.IPs {
+			targets = append(targets, ip.String()+"/32")
+		}
+	}
+
+	ruleCap := len(targets)
+	if len(r.Ports) > 0 {
+		ruleCap *= len(r.Ports)
+	}
+	out := make([]Rule, 0, ruleCap)
+	for _, dst := range targets {
+		if len(r.Ports) == 0 {
+			out = append(out, Rule{
+				Op:    "-A",
+				Chain: chain,
+				Args: []string{
+					"-d", dst,
+					"-m", "comment", "--comment", tag + ":" + allowComment(idx, r),
+					"-j", "RETURN",
+				},
+			})
+			continue
+		}
+		for _, port := range r.Ports {
+			out = append(out, Rule{
+				Op:    "-A",
+				Chain: chain,
+				Args: []string{
+					"-d", dst,
+					"-p", "tcp",
+					"--dport", strconv.Itoa(port),
+					"-m", "comment", "--comment", tag + ":" + allowComment(idx, r),
+					"-j", "RETURN",
+				},
+			})
+		}
+	}
+	return out
+}
+
+func allowComment(idx int, r ResolvedRule) string {
+	if r.OriginalHost != "" {
+		return fmt.Sprintf("allow[%d]:host=%s", idx, r.OriginalHost)
+	}
+	return fmt.Sprintf("allow[%d]:cidr=%s", idx, r.CIDR)
+}
+
+// DispatchRule returns the single "-A <master> -i <bridge> -j <per-space>"
+// rule that funnels bridge-sourced traffic into the per-space chain. It is
+// emitted on Apply and removed on Remove.
+func DispatchRule(p *Policy) Rule {
+	return Rule{
+		Op:    "-A",
+		Chain: MasterChainName,
+		Args: []string{
+			"-i", p.Bridge,
+			"-m", "comment", "--comment", p.CommentTag() + ":dispatch",
+			"-j", p.ChainName(),
+		},
+	}
+}
+

--- a/internal/netpolicy/rules_test.go
+++ b/internal/netpolicy/rules_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package netpolicy_test
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/netpolicy"
+)
+
+func TestBuildRules_DenyDefaultHasTerminalDrop(t *testing.T) {
+	p, err := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rules := netpolicy.BuildRules(p)
+	if len(rules) < 2 {
+		t.Fatalf("expected at least 2 rules (conntrack + default), got %d", len(rules))
+	}
+
+	last := rules[len(rules)-1]
+	joined := strings.Join(last.Args, " ")
+	if !strings.Contains(joined, "-j DROP") {
+		t.Fatalf("deny default must terminate in DROP; terminal = %q", joined)
+	}
+	if !strings.Contains(joined, ":default") {
+		t.Fatalf("terminal rule must carry :default comment; got %q", joined)
+	}
+
+	first := rules[0]
+	firstJoined := strings.Join(first.Args, " ")
+	if !strings.Contains(firstJoined, "RELATED,ESTABLISHED") {
+		t.Fatalf("first rule must allow RELATED,ESTABLISHED; got %q", firstJoined)
+	}
+	if !strings.Contains(firstJoined, "-j RETURN") {
+		t.Fatalf("first rule must RETURN; got %q", firstJoined)
+	}
+}
+
+func TestBuildRules_AllowDefaultHasTerminalReturn(t *testing.T) {
+	// An explicit allow default with at least one allow rule (otherwise
+	// FromInternal collapses to nil).
+	p, err := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultAllow,
+		Allow: []intmodel.EgressAllowRule{
+			{CIDR: "10.0.0.0/8", Ports: []int{5432}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rules := netpolicy.BuildRules(p)
+	last := rules[len(rules)-1]
+	joined := strings.Join(last.Args, " ")
+	if !strings.Contains(joined, "-j RETURN") {
+		t.Fatalf("allow default must terminate in RETURN; got %q", joined)
+	}
+}
+
+func TestBuildRules_CIDRAllowExpandsByPort(t *testing.T) {
+	p, err := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{CIDR: "10.0.0.0/8", Ports: []int{443, 5432}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rules := netpolicy.BuildRules(p)
+	// conntrack + 2 port rules + terminal = 4
+	if len(rules) != 4 {
+		t.Fatalf("expected 4 rules, got %d: %+v", len(rules), rules)
+	}
+	// Rules 1 and 2 should target the CIDR with distinct dports.
+	for i, idx := range []int{1, 2} {
+		joined := strings.Join(rules[idx].Args, " ")
+		if !strings.Contains(joined, "-d 10.0.0.0/8") {
+			t.Errorf("rule %d: missing -d 10.0.0.0/8: %q", i, joined)
+		}
+		if !strings.Contains(joined, "-p tcp") {
+			t.Errorf("rule %d: missing -p tcp: %q", i, joined)
+		}
+		if !strings.Contains(joined, "--dport") {
+			t.Errorf("rule %d: missing --dport: %q", i, joined)
+		}
+		if !strings.Contains(joined, "-j RETURN") {
+			t.Errorf("rule %d: missing -j RETURN: %q", i, joined)
+		}
+	}
+}
+
+func TestBuildRules_HostAllowUsesResolvedIPs(t *testing.T) {
+	p, err := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{Host: "api.example.com", Ports: []int{443}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Stub resolver returning two IPs.
+	p.Allow[0].IPs = []net.IP{net.ParseIP("192.0.2.10"), net.ParseIP("192.0.2.11")}
+
+	rules := netpolicy.BuildRules(p)
+	// conntrack + 2 per-IP rules + terminal = 4
+	if len(rules) != 4 {
+		t.Fatalf("expected 4 rules, got %d", len(rules))
+	}
+	found10, found11 := false, false
+	for _, r := range rules[1:3] {
+		joined := strings.Join(r.Args, " ")
+		if strings.Contains(joined, "-d 192.0.2.10/32") {
+			found10 = true
+		}
+		if strings.Contains(joined, "-d 192.0.2.11/32") {
+			found11 = true
+		}
+		if !strings.Contains(joined, "host=api.example.com") {
+			t.Errorf("allow rule missing host comment: %q", joined)
+		}
+	}
+	if !found10 || !found11 {
+		t.Fatalf("both resolved IPs must appear; found10=%v found11=%v", found10, found11)
+	}
+}
+
+func TestBuildRules_NoPortsMeansAnyDest(t *testing.T) {
+	p, err := netpolicy.FromInternal("main", "blog", "br", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+		Allow: []intmodel.EgressAllowRule{
+			{CIDR: "172.16.0.0/12"}, // no ports
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rules := netpolicy.BuildRules(p)
+	// conntrack + 1 allow rule + terminal = 3
+	if len(rules) != 3 {
+		t.Fatalf("expected 3 rules, got %d", len(rules))
+	}
+	joined := strings.Join(rules[1].Args, " ")
+	if strings.Contains(joined, "-p tcp") || strings.Contains(joined, "--dport") {
+		t.Fatalf("no-ports rule must not constrain protocol/port; got %q", joined)
+	}
+	if !strings.Contains(joined, "-d 172.16.0.0/12") {
+		t.Fatalf("missing -d target: %q", joined)
+	}
+}
+
+func TestDispatchRule(t *testing.T) {
+	p, _ := netpolicy.FromInternal("main", "blog", "main-blog", &intmodel.EgressPolicy{
+		Default: intmodel.EgressDefaultDeny,
+	})
+	d := netpolicy.DispatchRule(p)
+	if d.Chain != netpolicy.MasterChainName {
+		t.Fatalf("dispatch chain: got %q, want %q", d.Chain, netpolicy.MasterChainName)
+	}
+	joined := strings.Join(d.Args, " ")
+	if !strings.Contains(joined, "-i main-blog") {
+		t.Fatalf("dispatch must match bridge -i; got %q", joined)
+	}
+	if !strings.Contains(joined, "-j "+p.ChainName()) {
+		t.Fatalf("dispatch must jump to per-space chain; got %q", joined)
+	}
+}

--- a/pkg/api/model/v1beta1/space.go
+++ b/pkg/api/model/v1beta1/space.go
@@ -32,7 +32,43 @@ type SpaceMetadata struct {
 type SpaceSpec struct {
 	RealmID       string         `json:"realmId"                 yaml:"realmId"`
 	CNIConfigPath string         `json:"cniConfigPath,omitempty" yaml:"cniConfigPath,omitempty"`
+	Network       *SpaceNetwork  `json:"network,omitempty"       yaml:"network,omitempty"`
 	Defaults      *SpaceDefaults `json:"defaults,omitempty"      yaml:"defaults,omitempty"`
+}
+
+// SpaceNetwork groups network-scoped policy applied to the space bridge.
+type SpaceNetwork struct {
+	Egress *EgressPolicy `json:"egress,omitempty" yaml:"egress,omitempty"`
+}
+
+// EgressPolicy constrains outbound traffic leaving the space bridge toward the
+// host or external networks. When nil, traffic is unconstrained (current
+// behavior). An explicit Default=allow with no Allow rules also matches
+// current behavior.
+type EgressPolicy struct {
+	Default EgressDefault     `json:"default"         yaml:"default"`
+	Allow   []EgressAllowRule `json:"allow,omitempty" yaml:"allow,omitempty"`
+}
+
+// EgressDefault is the fallthrough action when no allowlist rule matches.
+type EgressDefault string
+
+const (
+	EgressDefaultAllow EgressDefault = "allow"
+	EgressDefaultDeny  EgressDefault = "deny"
+)
+
+// EgressAllowRule describes a single permitted destination. Exactly one of
+// Host or CIDR must be set. Ports, when non-empty, constrains to those TCP
+// destination ports; empty Ports means "any port on this destination".
+//
+// Host entries are resolved to IPs by the daemon at apply time; the resulting
+// iptables rules reflect the IPs known at that moment. See the Space manifest
+// docs for the TTL caveat.
+type EgressAllowRule struct {
+	Host  string `json:"host,omitempty"  yaml:"host,omitempty"`
+	CIDR  string `json:"cidr,omitempty"  yaml:"cidr,omitempty"`
+	Ports []int  `json:"ports,omitempty" yaml:"ports,omitempty"`
 }
 
 // SpaceDefaults declares default values that Kukeon inherits into resources


### PR DESCRIPTION
## Summary

- Extend `spec.network.egress` on Space with `default: allow|deny` + host/CIDR allowlist so untrusted workloads (notably agents) cannot exfiltrate to arbitrary destinations by default.
- Pick **design path (a)** for hostname rules from the issue: resolve to IPv4 at apply time and embed IPs into iptables. An egress proxy is left for a follow-up primitive.
- Per-space `KUKE-EGR-<hash>` chain dispatched from a shared `KUKEON-EGRESS` chain hooked into `FORWARD`, matched on the space bridge (`-i <bridge>`). RELATED/ESTABLISHED short-circuit preserves reply traffic.
- New `internal/netpolicy` package isolates pure rule generation from the iptables exec, with a test-hook runner. The runner `Exec` grows a `netpolicy.Enforcer` field that defaults to a `NoopEnforcer` when unset — existing runner tests need no changes.
- Observability (AC #5): terminal DROP is comment-tagged `kukeon:<realm>:<space>:default`; drop counter logged at space teardown. Operators can grep live state via `iptables -S | grep kukeon:`.

## Test plan

- [x] `make test` — all prior passing tests still green; pre-existing `internal/ctr` failures (unrelated default-image-registry mismatch) reproduce on `origin/main` and are out of scope
- [x] `go vet ./...`
- [x] `go build ./...` and `make kuke`
- [x] New unit tests exercise rule generation (`BuildRules`, `DispatchRule`), validation (bad CIDR/host/port, default=allow collapse), host resolver (v6 filtering, empty-result fatal, dedup), and the enforcer's iptables invocation sequence via a fake runner (apply/idempotent-apply/remove with dispatch cleanup)
- [x] apischeme round-trip covers the new `network.egress` field and confirms `network: null` is omitted when unset
- [ ] **Local smoke test from CLAUDE.md §5 (daemon-parity check)** — requires root/containerd; not run in this session. The next reviewer-triggered workflow or the maintainer should exercise `sudo ./kuke get realms` vs `--no-daemon` after re-applying a Space with an egress policy, and confirm `sudo iptables -S KUKEON-EGRESS` lists the dispatch rule and `sudo iptables -L KUKE-EGR-<hash> -n -v -x` shows the policy rules with counters

Closes #45