### PR TITLE
feat: add kuke attach thin sbsh client subcommand

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -336,6 +336,20 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_START_CONTAINER_CELL = DefineKV("KUKE_START_CONTAINER_CELL", "kuke/start/container/cell")
 
+	// Attach command variables
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_ATTACH_REALM = DefineKV("KUKE_ATTACH_REALM", "kuke/attach/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_ATTACH_SPACE = DefineKV("KUKE_ATTACH_SPACE", "kuke/attach/space", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_ATTACH_STACK = DefineKV("KUKE_ATTACH_STACK", "kuke/attach/stack", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_ATTACH_CELL = DefineKV("KUKE_ATTACH_CELL", "kuke/attach/cell")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_ATTACH_CONTAINER = DefineKV("KUKE_ATTACH_CONTAINER", "kuke/attach/container")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_ATTACH_SB_BINARY = DefineKV("KUKE_ATTACH_SB_BINARY", "kuke/attach/sbBinary", "sb")
+
 	// Stop command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_STOP_CELL_REALM = DefineKV("KUKE_STOP_CELL_REALM", "kuke/stop/cell/realm", "default")

--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -1,0 +1,234 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package attach implements the `kuke attach` thin sbsh client subcommand.
+// The daemon validates the target's Attachable gate and returns the host
+// path of the per-container sbsh control socket; this subcommand opens the
+// socket via the on-host `sb` binary using syscall.Exec, so TTY/signal
+// handling falls through to sb directly. Bytes never traverse kukeond's
+// RPC.
+package attach
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// MockExecKey is used to inject a mock execFn via context in tests, so the
+// real syscall.Exec (which would replace the test binary) is bypassed.
+type MockExecKey struct{}
+
+// execFn replaces the running process with the named binary, à la syscall.Exec.
+// Returning an error means the exec call itself failed; on success the
+// function does not return.
+type execFn func(argv0 string, argv []string, envv []string) error
+
+// NewAttachCmd builds the `kuke attach` cobra command.
+func NewAttachCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "attach",
+		Aliases:       []string{"att"},
+		Short:         "Attach to an Attachable container's sbsh terminal",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runAttach,
+	}
+
+	cmd.Flags().String("realm", "", "Realm that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_ATTACH_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Space that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_ATTACH_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Stack that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_ATTACH_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+	cmd.Flags().String("cell", "", "Cell to attach into")
+	_ = viper.BindPFlag(config.KUKE_ATTACH_CELL.ViperKey, cmd.Flags().Lookup("cell"))
+	cmd.Flags().String("container", "",
+		"Container within the cell to attach to (omit to auto-pick the only non-root attachable)")
+	_ = viper.BindPFlag(config.KUKE_ATTACH_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
+	cmd.Flags().String("sb-binary", config.KUKE_ATTACH_SB_BINARY.Default,
+		"Path to the on-host sb client binary (looked up on $PATH if not absolute)")
+	_ = viper.BindPFlag(config.KUKE_ATTACH_SB_BINARY.ViperKey, cmd.Flags().Lookup("sb-binary"))
+
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("cell", config.CompleteCellNames)
+	_ = cmd.RegisterFlagCompletionFunc("container", config.CompleteContainerNames)
+
+	return cmd
+}
+
+func runAttach(cmd *cobra.Command, _ []string) error {
+	realm := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_REALM.ViperKey))
+	space := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_SPACE.ViperKey))
+	stack := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_STACK.ViperKey))
+	cell := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_CELL.ViperKey))
+	container := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_CONTAINER.ViperKey))
+	sbBinary := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_SB_BINARY.ViperKey))
+
+	if realm == "" {
+		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+	}
+	if space == "" {
+		return fmt.Errorf("%w (--space)", errdefs.ErrSpaceNameRequired)
+	}
+	if stack == "" {
+		return fmt.Errorf("%w (--stack)", errdefs.ErrStackNameRequired)
+	}
+	if cell == "" {
+		return fmt.Errorf("%w (--cell)", errdefs.ErrCellNameRequired)
+	}
+	if sbBinary == "" {
+		sbBinary = config.KUKE_ATTACH_SB_BINARY.Default
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if container == "" {
+		container, err = pickAttachableContainer(cmd.Context(), client, realm, space, stack, cell)
+		if err != nil {
+			return err
+		}
+	}
+
+	doc := buildContainerDoc(container, realm, space, stack, cell)
+	result, err := client.AttachContainer(cmd.Context(), doc)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrAttachNotSupported) {
+			return fmt.Errorf("container %q in cell %q is not attachable: %w", container, cell, err)
+		}
+		if errors.Is(err, errdefs.ErrContainerNotFound) {
+			return fmt.Errorf("container %q not found in cell %q", container, cell)
+		}
+		return err
+	}
+	if result.HostSocketPath == "" {
+		return fmt.Errorf("daemon returned empty HostSocketPath for container %q", container)
+	}
+
+	sbPath, err := resolveSbBinary(sbBinary)
+	if err != nil {
+		return err
+	}
+
+	exe := resolveExec(cmd)
+	argv := []string{sbPath, "attach", "--socket", result.HostSocketPath}
+	// On success exe replaces the current process and never returns.
+	return exe(sbPath, argv, os.Environ())
+}
+
+// pickAttachableContainer enumerates the cell's containers and returns the
+// single non-root attachable one. Errors with ErrAttachNoCandidate when
+// none exist and ErrAttachAmbiguous (with the candidate list) when more
+// than one exist.
+func pickAttachableContainer(
+	ctx context.Context,
+	client kukeonv1.Client,
+	realm, space, stack, cell string,
+) (string, error) {
+	specs, err := client.ListContainers(ctx, realm, space, stack, cell)
+	if err != nil {
+		return "", err
+	}
+
+	candidates := make([]string, 0, len(specs))
+	for i := range specs {
+		spec := specs[i]
+		if spec.Root || !spec.Attachable {
+			continue
+		}
+		candidates = append(candidates, spec.ID)
+	}
+	sort.Strings(candidates)
+
+	switch len(candidates) {
+	case 0:
+		return "", fmt.Errorf("%w (cell %q)", errdefs.ErrAttachNoCandidate, cell)
+	case 1:
+		return candidates[0], nil
+	default:
+		return "", fmt.Errorf("%w (cell %q): candidates: %s",
+			errdefs.ErrAttachAmbiguous, cell, strings.Join(candidates, ", "))
+	}
+}
+
+// resolveSbBinary returns the absolute path of the sb client binary. If the
+// caller supplied an absolute path it is used verbatim; otherwise the name
+// is looked up on $PATH so operators can drop a binary anywhere.
+func resolveSbBinary(name string) (string, error) {
+	if strings.ContainsRune(name, os.PathSeparator) {
+		return name, nil
+	}
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return "", fmt.Errorf("locate sb client binary %q on PATH: %w", name, err)
+	}
+	return path, nil
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.ClientFromCmd(cmd)
+}
+
+func resolveExec(cmd *cobra.Command) execFn {
+	if mock, ok := cmd.Context().Value(MockExecKey{}).(execFn); ok {
+		return mock
+	}
+	return syscall.Exec
+}
+
+func buildContainerDoc(name, realm, space, stack, cell string) v1beta1.ContainerDoc {
+	return v1beta1.ContainerDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindContainer,
+		Metadata: v1beta1.ContainerMetadata{
+			Name:   name,
+			Labels: make(map[string]string),
+		},
+		Spec: v1beta1.ContainerSpec{
+			ID:      name,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+			CellID:  cell,
+		},
+	}
+}

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -1,0 +1,391 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package attach_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	attachcmd "github.com/eminwux/kukeon/cmd/kuke/attach"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	testHostSocket = "/opt/kukeon/r1/s1/st1/c1/work/sbsh.io"
+)
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	listContainersFn  func(realm, space, stack, cell string) ([]v1beta1.ContainerSpec, error)
+	attachContainerFn func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error)
+}
+
+func (f *fakeClient) ListContainers(
+	_ context.Context,
+	realm, space, stack, cell string,
+) ([]v1beta1.ContainerSpec, error) {
+	if f.listContainersFn == nil {
+		return nil, errors.New("unexpected ListContainers call")
+	}
+	return f.listContainersFn(realm, space, stack, cell)
+}
+
+func (f *fakeClient) AttachContainer(
+	_ context.Context,
+	doc v1beta1.ContainerDoc,
+) (kukeonv1.AttachContainerResult, error) {
+	if f.attachContainerFn == nil {
+		return kukeonv1.AttachContainerResult{}, errors.New("unexpected AttachContainer call")
+	}
+	return f.attachContainerFn(doc)
+}
+
+// execCapture records the argv passed to syscall.Exec and returns nil so the
+// test treats the call as success (the real syscall.Exec never returns on
+// success, so nil is the in-test analogue).
+type execCapture struct {
+	calls int
+	argv0 string
+	argv  []string
+}
+
+func (e *execCapture) fn(argv0 string, argv []string, _ []string) error {
+	e.calls++
+	e.argv0 = argv0
+	e.argv = argv
+	return nil
+}
+
+func newCmdWithCtx(t *testing.T, fc *fakeClient, exec *execCapture) *cobra.Command {
+	t.Helper()
+
+	cmd := attachcmd.NewAttachCmd()
+	ctx := context.Background()
+	if fc != nil {
+		ctx = context.WithValue(ctx, attachcmd.MockControllerKey{}, kukeonv1.Client(fc))
+	}
+	if exec != nil {
+		ctx = context.WithValue(ctx, attachcmd.MockExecKey{}, attachcmd.ExecFn(exec.fn))
+	}
+	cmd.SetContext(ctx)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	return cmd
+}
+
+func TestAttach_SingleNonRootAttachable_Succeeds(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Attachable: false},
+				{ID: "work", Attachable: true},
+			}, nil
+		},
+		attachContainerFn: func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			if got := doc.Metadata.Name; got != "work" {
+				t.Errorf("AttachContainer called with name %q, want %q", got, "work")
+			}
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	exec := &execCapture{}
+	cmd := newCmdWithCtx(t, fc, exec)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--sb-binary", "/usr/local/bin/sb",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if exec.calls != 1 {
+		t.Fatalf("exec called %d times, want 1", exec.calls)
+	}
+	wantArgv := []string{"/usr/local/bin/sb", "attach", "--socket", testHostSocket}
+	if !strSliceEq(exec.argv, wantArgv) {
+		t.Errorf("argv = %v, want %v", exec.argv, wantArgv)
+	}
+	if exec.argv0 != "/usr/local/bin/sb" {
+		t.Errorf("argv0 = %q, want %q", exec.argv0, "/usr/local/bin/sb")
+	}
+}
+
+func TestAttach_AmbiguousCandidates_ErrorsWithList(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "shell", Attachable: true},
+				{ID: "claude", Attachable: true},
+			}, nil
+		},
+	}
+	exec := &execCapture{}
+	cmd := newCmdWithCtx(t, fc, exec)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--sb-binary", "/usr/local/bin/sb",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute returned nil, want ErrAttachAmbiguous")
+	}
+	if !errors.Is(err, errdefs.ErrAttachAmbiguous) {
+		t.Fatalf("error %v does not unwrap to ErrAttachAmbiguous", err)
+	}
+	// The candidate list must be sorted and present in the error message so
+	// the operator can re-run with --container.
+	if got := err.Error(); !strings.Contains(got, "claude, shell") {
+		t.Errorf("error message %q missing sorted candidate list", got)
+	}
+	if exec.calls != 0 {
+		t.Errorf("exec called %d times on ambiguous picker, want 0", exec.calls)
+	}
+}
+
+func TestAttach_NoCandidate_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				// non-attachable workload doesn't count
+				{ID: "side", Attachable: false},
+			}, nil
+		},
+	}
+	exec := &execCapture{}
+	cmd := newCmdWithCtx(t, fc, exec)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--sb-binary", "/usr/local/bin/sb",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
+		t.Fatalf("error %v does not unwrap to ErrAttachNoCandidate", err)
+	}
+	if exec.calls != 0 {
+		t.Errorf("exec called %d times on empty picker, want 0", exec.calls)
+	}
+}
+
+func TestAttach_RootContainerExcludedFromAutoPick(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// A root container with Attachable=true must NOT be picked: the issue
+	// excludes the root container from the auto-pick set explicitly.
+	fc := &fakeClient{
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Attachable: true},
+			}, nil
+		},
+	}
+	exec := &execCapture{}
+	cmd := newCmdWithCtx(t, fc, exec)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--sb-binary", "/usr/local/bin/sb",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
+		t.Fatalf("error %v does not unwrap to ErrAttachNoCandidate (root must be excluded from auto-pick)", err)
+	}
+}
+
+func TestAttach_ExplicitContainer_NotAttachable_SurfacesSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		// ListContainers must not be called when --container is explicit.
+		attachContainerFn: func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			if got := doc.Metadata.Name; got != "side" {
+				t.Errorf("AttachContainer called with name %q, want %q", got, "side")
+			}
+			return kukeonv1.AttachContainerResult{}, errdefs.ErrAttachNotSupported
+		},
+	}
+	exec := &execCapture{}
+	cmd := newCmdWithCtx(t, fc, exec)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "side",
+		"--sb-binary", "/usr/local/bin/sb",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachNotSupported) {
+		t.Fatalf("error %v does not unwrap to ErrAttachNotSupported", err)
+	}
+	if exec.calls != 0 {
+		t.Errorf("exec called %d times on non-attachable target, want 0", exec.calls)
+	}
+}
+
+func TestAttach_ExplicitContainer_Attachable_Succeeds(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	exec := &execCapture{}
+	cmd := newCmdWithCtx(t, fc, exec)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "shell",
+		"--sb-binary", "/usr/local/bin/sb",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if exec.calls != 1 {
+		t.Fatalf("exec called %d times, want 1", exec.calls)
+	}
+	wantArgv := []string{"/usr/local/bin/sb", "attach", "--socket", testHostSocket}
+	if !strSliceEq(exec.argv, wantArgv) {
+		t.Errorf("argv = %v, want %v", exec.argv, wantArgv)
+	}
+}
+
+func TestAttach_MissingFlags(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr error
+	}{
+		{
+			name:    "missing realm",
+			args:    []string{"--space", "s1", "--stack", "st1", "--cell", "c1"},
+			wantErr: errdefs.ErrRealmNameRequired,
+		},
+		{
+			name:    "missing space",
+			args:    []string{"--realm", "r1", "--stack", "st1", "--cell", "c1"},
+			wantErr: errdefs.ErrSpaceNameRequired,
+		},
+		{
+			name:    "missing stack",
+			args:    []string{"--realm", "r1", "--space", "s1", "--cell", "c1"},
+			wantErr: errdefs.ErrStackNameRequired,
+		},
+		{
+			name:    "missing cell",
+			args:    []string{"--realm", "r1", "--space", "s1", "--stack", "st1"},
+			wantErr: errdefs.ErrCellNameRequired,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset clears viper's defaults set by DefineKV at package
+			// init ("default" for realm/space/stack), so any flag the
+			// case omits resolves to the empty string and trips the
+			// missing-flag guard. t.Setenv keeps the env-var path
+			// quiet too, in case the dev box exports a KUKE_ATTACH_*.
+			viper.Reset()
+			t.Setenv("KUKE_ATTACH_REALM", "")
+			t.Setenv("KUKE_ATTACH_SPACE", "")
+			t.Setenv("KUKE_ATTACH_STACK", "")
+			t.Setenv("KUKE_ATTACH_CELL", "")
+
+			cmd := newCmdWithCtx(t, &fakeClient{}, &execCapture{})
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error %v does not unwrap to %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveSbBinary_AbsolutePath_PassesThrough(t *testing.T) {
+	got, err := attachcmd.ResolveSbBinaryForTest("/opt/sb/bin/sb")
+	if err != nil {
+		t.Fatalf("ResolveSbBinary returned error: %v", err)
+	}
+	if got != "/opt/sb/bin/sb" {
+		t.Errorf("ResolveSbBinary = %q, want %q", got, "/opt/sb/bin/sb")
+	}
+}
+
+func TestResolveSbBinary_PathLookup_FindsBinaryOnPATH(t *testing.T) {
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "sb-test")
+	// Create an empty executable file. exec.LookPath only checks for the
+	// executable bit, so we don't need real content.
+	if err := writeExecutable(binPath); err != nil {
+		t.Fatalf("create test binary: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := attachcmd.ResolveSbBinaryForTest("sb-test")
+	if err != nil {
+		t.Fatalf("ResolveSbBinary returned error: %v", err)
+	}
+	if got != binPath {
+		t.Errorf("ResolveSbBinary = %q, want %q", got, binPath)
+	}
+}
+
+func TestResolveSbBinary_PathLookup_MissingBinary_Errors(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if _, err := attachcmd.ResolveSbBinaryForTest("definitely-not-on-path"); err == nil {
+		t.Fatal("ResolveSbBinary returned nil, want error for missing binary")
+	}
+}
+
+func strSliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func writeExecutable(path string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/cmd/kuke/attach/export_test.go
+++ b/cmd/kuke/attach/export_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package attach
+
+// ExecFn is the test-visible alias of the unexported execFn type. Tests
+// build values of this type and store them under MockExecKey to bypass
+// the real syscall.Exec, which would replace the test binary on success.
+type ExecFn = execFn
+
+// ResolveSbBinaryForTest exposes resolveSbBinary to the external _test
+// package so the PATH-lookup vs absolute-path branches can be exercised
+// without going through the full cobra entry point.
+func ResolveSbBinaryForTest(name string) (string, error) {
+	return resolveSbBinary(name)
+}

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/eminwux/kukeon/cmd/config"
 	applycmd "github.com/eminwux/kukeon/cmd/kuke/apply"
+	attachcmd "github.com/eminwux/kukeon/cmd/kuke/attach"
 	autocompletecmd "github.com/eminwux/kukeon/cmd/kuke/autocomplete"
 	createcmd "github.com/eminwux/kukeon/cmd/kuke/create"
 	deletecmd "github.com/eminwux/kukeon/cmd/kuke/delete"
@@ -126,6 +127,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(killcmd.NewKillCmd())
 	rootCmd.AddCommand(purgecmd.NewPurgeCmd())
 	rootCmd.AddCommand(refreshcmd.NewRefreshCmd())
+	rootCmd.AddCommand(attachcmd.NewAttachCmd())
 	rootCmd.AddCommand(autocompletecmd.NewAutocompleteCmd())
 	rootCmd.AddCommand(version.NewVersionCmd())
 

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -861,12 +861,10 @@ func formatValidationErrors(validationErrors []*parser.ValidationError) error {
 
 // ---- Attach ----
 
-// AttachContainer is the in-process placeholder for the attach endpoint
-// shipped in #57. It enforces the Attachable gate at the API boundary by
-// looking up the target container and refusing the request when its
-// Attachable field is false. The full sbsh-client logic lands in #66; until
-// then this method always returns ErrAttachNotImplemented for permitted
-// targets so callers fail fast with a recognizable sentinel.
+// AttachContainer enforces the Attachable gate and resolves the host-side
+// sbsh control-socket path. Bytes never traverse this RPC — the caller
+// (`kuke attach`) opens HostSocketPath directly and runs the sbsh client
+// loop against it.
 func (c *Client) AttachContainer(_ context.Context, doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
 	internal, _, err := apischeme.NormalizeContainer(doc)
 	if err != nil {
@@ -882,7 +880,16 @@ func (c *Client) AttachContainer(_ context.Context, doc v1beta1.ContainerDoc) (k
 	if !res.Container.Spec.Attachable {
 		return kukeonv1.AttachContainerResult{}, errdefs.ErrAttachNotSupported
 	}
-	return kukeonv1.AttachContainerResult{}, errdefs.ErrAttachNotImplemented
+	return kukeonv1.AttachContainerResult{
+		HostSocketPath: fs.ContainerSocketPath(
+			c.ctrl.RunPath(),
+			res.Container.Spec.RealmName,
+			res.Container.Spec.SpaceName,
+			res.Container.Spec.StackName,
+			res.Container.Spec.CellName,
+			res.Container.Spec.ID,
+		),
+	}, nil
 }
 
 // ---- Ping ----

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -201,3 +201,11 @@ func (b *Exec) Bootstrap() (BootstrapReport, error) {
 func (b *Exec) Close() error {
 	return b.runner.Close()
 }
+
+// RunPath returns the configured kukeon run path. Surfaced for callers that
+// need to derive host paths from the same root the controller writes to —
+// notably the in-process AttachContainer endpoint, which resolves the
+// per-container sbsh socket via fs.ContainerSocketPath.
+func (b *Exec) RunPath() string {
+	return b.opts.RunPath
+}

--- a/internal/daemon/attach_rpc_test.go
+++ b/internal/daemon/attach_rpc_test.go
@@ -64,12 +64,12 @@ func TestAttachContainer_NotAttachable_RPCSurfacesSentinel(t *testing.T) {
 	}
 }
 
-func TestAttachContainer_Attachable_PlaceholderReturnsNotImplemented(t *testing.T) {
-	// When the target *is* Attachable=true the placeholder must still fail
-	// fast — the actual sbsh-bridge client lands in #66. The sentinel must
-	// be ErrAttachNotImplemented (not ErrAttachNotSupported), so a future
-	// `kuke attach` client can branch on it.
-	core := &attachClientFake{err: errdefs.ErrAttachNotImplemented}
+func TestAttachContainer_Attachable_RPCReturnsSocketPath(t *testing.T) {
+	// When the target is Attachable=true the daemon hands back the host
+	// socket path so the client can open it directly. The RPC layer must
+	// pass that path through verbatim and leave Err nil.
+	const wantSocket = "/opt/kukeon/default/default/default/cellA/work/sbsh.io"
+	core := &attachClientFake{result: kukeonv1.AttachContainerResult{HostSocketPath: wantSocket}}
 	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core)
 
 	args := &kukeonv1.AttachContainerArgs{Doc: v1beta1.ContainerDoc{}}
@@ -77,15 +77,11 @@ func TestAttachContainer_Attachable_PlaceholderReturnsNotImplemented(t *testing.
 	if err := svc.AttachContainer(args, reply); err != nil {
 		t.Fatalf("AttachContainer returned transport error: %v", err)
 	}
-	if reply.Err == nil {
-		t.Fatalf("expected wire-level Err to be populated, got nil")
+	if reply.Err != nil {
+		t.Fatalf("expected wire-level Err to be nil, got %v", kukeonv1.FromAPIError(reply.Err))
 	}
-	wireErr := kukeonv1.FromAPIError(reply.Err)
-	if !errors.Is(wireErr, errdefs.ErrAttachNotImplemented) {
-		t.Errorf("wire error %q does not unwrap to ErrAttachNotImplemented", wireErr)
-	}
-	if errors.Is(wireErr, errdefs.ErrAttachNotSupported) {
-		t.Errorf("attachable=true target must not produce ErrAttachNotSupported")
+	if reply.Result.HostSocketPath != wantSocket {
+		t.Errorf("HostSocketPath = %q, want %q", reply.Result.HostSocketPath, wantSocket)
 	}
 }
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -133,11 +133,16 @@ var (
 	// /run/sbsh.socket to connect to.
 	ErrAttachNotSupported = errors.New("container is not attachable; recreate with attachable=true")
 
-	// ErrAttachNotImplemented is returned by the daemon-side placeholder
-	// endpoint shipped in #57. The full sbsh-client implementation lands in
-	// #66; until then the endpoint exists only to enforce the Attachable
-	// gate so that misuse fails fast at the API boundary.
-	ErrAttachNotImplemented = errors.New("attach client not implemented yet (see kukeon#66)")
+	// ErrAttachAmbiguous is returned by the `kuke attach` candidate picker
+	// when --container is omitted and the target cell has more than one
+	// non-root attachable container. The error message lists the candidates
+	// so the operator can re-run with --container.
+	ErrAttachAmbiguous = errors.New("multiple attachable containers in cell; specify --container")
+
+	// ErrAttachNoCandidate is returned by the `kuke attach` candidate
+	// picker when --container is omitted and the target cell has zero
+	// non-root attachable containers.
+	ErrAttachNoCandidate = errors.New("no attachable container in cell")
 
 	// Secret-related errors.
 

--- a/pkg/api/kukeonv1/errmap.go
+++ b/pkg/api/kukeonv1/errmap.go
@@ -58,7 +58,6 @@ var kindToSentinel = map[string]error{
 	"ContainerExists":         errdefs.ErrContainerExists,
 	"ConversionFailed":        errdefs.ErrConversionFailed,
 	"AttachNotSupported":      errdefs.ErrAttachNotSupported,
-	"AttachNotImplemented":    errdefs.ErrAttachNotImplemented,
 }
 
 // sentinelToKind is the reverse lookup, populated lazily.

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -530,8 +530,6 @@ type PurgeContainerResult struct {
 // ---- Attach ----
 
 // AttachContainerArgs identifies the target container for an attach request.
-// The full client (#66) will add session-shape fields; this shape is the
-// minimum the placeholder endpoint needs to enforce the Attachable gate.
 type AttachContainerArgs struct {
 	Doc v1beta1.ContainerDoc
 }
@@ -541,10 +539,16 @@ type AttachContainerReply struct {
 	Err    *APIError
 }
 
-// AttachContainerResult is intentionally empty in #57. The fields the client
-// in #66 will populate (host socket path, terminal mode, etc.) live behind
-// the placeholder until that PR.
-type AttachContainerResult struct{}
+// AttachContainerResult carries the host-side coordinates the `kuke attach`
+// client needs to drive the sbsh terminal. Bytes never traverse this RPC —
+// the client opens HostSocketPath directly.
+type AttachContainerResult struct {
+	// HostSocketPath is the host path of the per-container sbsh control
+	// socket bind-mounted into the container at /run/sbsh.socket. Returned
+	// only when the target container has Attachable=true; otherwise the
+	// daemon errors with ErrAttachNotSupported.
+	HostSocketPath string
+}
 
 // ---- Refresh ----
 


### PR DESCRIPTION
## Summary

Phase-1 slice of #66 — the `kuke attach` thin client and the daemon-side socket-path resolution it needs. Filed under [#66 (resize-issue)](https://github.com/eminwux/kukeon/issues/66) because the issue's E2E + sbsh-Go-module ACs make it too broad for a single PR; PM to file phase-2 from the resize comment.

- Promotes the daemon's `AttachContainer` placeholder from `ErrAttachNotImplemented` to a real endpoint that validates the Attachable gate and returns `HostSocketPath` (resolved via `fs.ContainerSocketPath` against `controller.Exec.RunPath()`).
- Adds `cmd/kuke/attach/`: a top-level cobra subcommand that resolves the candidate container (auto-pick when one non-root attachable exists, error with sorted list when ambiguous, exclude root from the auto-pick set), then `syscall.Exec`s the on-host `sb` client against the resolved socket — bytes never traverse kukeond's RPC.
- Drops the now-unused `ErrAttachNotImplemented` sentinel and its errmap entry; adds `ErrAttachAmbiguous` and `ErrAttachNoCandidate` for the picker.

## Deferred to phase-2 (per resize-issue comment on #66)

- E2E under `e2e/` covering attach / detach / reattach (needs new PTY harness, attachable shell-workload image, scripted detach-keystroke driver — none exist in repo today).
- Optionally swap `syscall.Exec` for `sbsh/pkg/spawn.NewClient` once managed lifecycle is wanted. The issue body's claim that sbsh exposes a Go-module client TTY loop didn't match upstream — sbsh#120 is a server-side PID-1 change, not a client export — so the thin-client design is exec-based.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `make test` — all unit packages pass, including new `cmd/kuke/attach/` suite (single-attachable auto-pick, ambiguous list, no-candidate, root-excluded-from-auto-pick, explicit `--container` not-attachable surfaces sentinel, missing `--realm/--space/--stack/--cell` checks, sb-binary absolute vs PATH-lookup) and the updated `internal/daemon/attach_rpc_test.go` (Attachable=true now returns `HostSocketPath` over the wire; Attachable=false still surfaces `ErrAttachNotSupported`).
- [x] Daemon-parity check from CLAUDE.md after rebuild + `kuke init` against the new image: `kuke get realms` and `kuke get realms --no-daemon` produce identical output.
- [x] `kuke attach --realm default --space default --stack default --cell ghost --container nope` returns the same `cell not found` error via daemon and `--no-daemon`.
- [ ] Phase-2 E2E (deferred — see resize-issue comment on #66).

`make test-e2e` has pre-existing socket/permission failures on `origin/main` (verified via worktree on `2339792`); not introduced by this change.

Refs #66