### PR TITLE
test: add e2e PTY harness and attach/detach scenario

### DIFF
--- a/cmd/kuke/apply/testdata/attachable-cell.yaml
+++ b/cmd/kuke/apply/testdata/attachable-cell.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: test-cell
+spec:
+  id: test-cell
+  realmId: test-realm
+  spaceId: test-space
+  stackId: test-stack
+  containers:
+    - id: root
+      root: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: work
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+      attachable: true

--- a/e2e/e2e_kuke_apply_test.go
+++ b/e2e/e2e_kuke_apply_test.go
@@ -129,6 +129,7 @@ func TestKukeApply_VerifyTestdataYAMLs(t *testing.T) {
 		"space.yaml",
 		"stack.yaml",
 		"cell.yaml",
+		"attachable-cell.yaml",
 		"multi-resource.yaml",
 	}
 

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -65,6 +65,7 @@ func stageHostSbsh(t *testing.T, runPath string) {
 	if err != nil {
 		t.Skipf("sbsh binary not found on PATH: %v", err)
 	}
+	requireSbshHasPostMergeFlags(t, hostSbsh)
 
 	dstDir := filepath.Join(fullRunPath, ctrpkg.SbshCacheSubdir, runtime.GOARCH)
 	if err = os.MkdirAll(dstDir, 0o755); err != nil {
@@ -86,6 +87,24 @@ func stageHostSbsh(t *testing.T, runPath string) {
 
 	if _, err = io.Copy(out, src); err != nil {
 		t.Fatalf("copy sbsh %q -> %q: %v", hostSbsh, dst, err)
+	}
+}
+
+// requireSbshHasPostMergeFlags ensures the host sbsh carries the flag set
+// the wrapper injected at #69 assumes (post sbsh#153, which added
+// `--capture-file` to the `sbsh terminal` subcommand). Without this guard a
+// stale sbsh on PATH manifests as `unknown flag: ...` deep inside the work
+// container's task, surfaced here only as a `waitForSocket` timeout — hard
+// to attribute. Skipping with a named cause saves the dig.
+func requireSbshHasPostMergeFlags(t *testing.T, hostSbsh string) {
+	t.Helper()
+	out, err := exec.Command(hostSbsh, "terminal", "--help").CombinedOutput()
+	if err != nil {
+		t.Fatalf("sbsh terminal --help failed: %v\noutput:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "--capture-file") {
+		t.Skipf("host sbsh %q lacks `sbsh terminal --capture-file` (sbsh#153); "+
+			"upgrade sbsh on PATH and retry", hostSbsh)
 	}
 }
 

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -1,0 +1,351 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	ctrpkg "github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// sbshDetachSequence is the keystroke pair that the sbsh client filter
+// recognises as a request to detach (Ctrl+] Ctrl+], adjacent). Forwarded
+// verbatim by the test so the on-host `sb attach` filter triggers.
+var sbshDetachSequence = []byte{0x1d, 0x1d}
+
+// attachConnectGrace is how long the test waits between starting `kuke attach`
+// and sending the detach sequence. Long enough for syscall.Exec into `sb` and
+// the unix-socket handshake to complete on a busy CI runner; short enough that
+// a hung scenario surfaces quickly.
+const attachConnectGrace = 2 * time.Second
+
+// attachExitTimeout caps how long the test waits for `kuke attach` to exit
+// after the detach keystroke is sent. A clean detach lands in well under a
+// second; the cap is set so a regression that swallows the keystroke fails
+// loudly instead of hanging the suite.
+const attachExitTimeout = 15 * time.Second
+
+// stageHostSbsh copies the on-host sbsh binary into the per-test sbsh cache
+// at the path the runner will resolve for the workload image. Required
+// because the runner only computes the cache path; populating it is an
+// out-of-band concern (today the test, in production the operator).
+func stageHostSbsh(t *testing.T, runPath string) {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get working dir: %v", err)
+	}
+	fullRunPath := filepath.Join(cwd, runPath)
+
+	hostSbsh, err := exec.LookPath("sbsh")
+	if err != nil {
+		t.Skipf("sbsh binary not found on PATH: %v", err)
+	}
+
+	dstDir := filepath.Join(fullRunPath, ctrpkg.SbshCacheSubdir, runtime.GOARCH)
+	if err = os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatalf("failed to create sbsh cache dir %q: %v", dstDir, err)
+	}
+	dst := filepath.Join(dstDir, ctrpkg.SbshBinaryName)
+
+	src, err := os.Open(hostSbsh)
+	if err != nil {
+		t.Fatalf("open host sbsh %q: %v", hostSbsh, err)
+	}
+	defer func() { _ = src.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		t.Fatalf("open dst sbsh %q: %v", dst, err)
+	}
+	defer func() { _ = out.Close() }()
+
+	if _, err = io.Copy(out, src); err != nil {
+		t.Fatalf("copy sbsh %q -> %q: %v", hostSbsh, dst, err)
+	}
+}
+
+// TestKuke_AttachDetach_KeepsTaskRunning is the phase 2a end-to-end scenario
+// for `kuke attach`: it boots a cell that contains an Attachable container,
+// drives `kuke attach` over a real PTY, sends sbsh's detach keystroke
+// (Ctrl+] Ctrl+]), and verifies that `kuke attach` exits cleanly while the
+// underlying container task remains RUNNING. Requires the host `sbsh` and
+// `sb` binaries on PATH; the test is skipped if either is missing.
+func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("sb"); err != nil {
+		t.Skipf("sb binary not found on PATH (required by `kuke attach`): %v", err)
+	}
+
+	// Setup: isolated runPath, unique resource names, in-process controller
+	// (`--no-daemon`) so the sbsh cache and per-container socket live under
+	// the test's runPath rather than the host daemon's.
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+	stageHostSbsh(t, runPath)
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+	cellName := generateUniqueCellName(t)
+
+	t.Cleanup(func() {
+		cleanupCellNoDaemon(t, runPath, realmName, spaceName, stackName, cellName)
+		cleanupStackNoDaemon(t, runPath, realmName, spaceName, stackName)
+		cleanupSpaceNoDaemon(t, runPath, realmName, spaceName)
+		cleanupRealmNoDaemon(t, runPath, realmName)
+	})
+
+	// Step 1: provision realm/space/stack as plain create commands so the
+	// remaining apply call exercises the cell path and only the cell path.
+	runReturningBinary(t, nil, kuke,
+		appendNoDaemonRunPath(runPath, "create", "realm", realmName)...)
+	runReturningBinary(t, nil, kuke,
+		appendNoDaemonRunPath(runPath, "create", "space", spaceName, "--realm", realmName)...)
+	runReturningBinary(t, nil, kuke,
+		appendNoDaemonRunPath(runPath, "create", "stack", stackName,
+			"--realm", realmName, "--space", spaceName)...)
+
+	// Step 2: apply the attachable cell fixture. Auto-starts the workload
+	// (apply is the path that drives Cell to Ready), so by the time it
+	// returns the container task should be RUNNING. The per-container
+	// sbsh socket appears once #74 lands the directory bind mount that
+	// makes sbsh's listener inode host-visible; this scenario depends on
+	// that and does not pre-create any placeholder file (the old
+	// workaround was broken because sbsh unlinks-and-recreates the
+	// destination, producing a fresh inode invisible to the host).
+	applyAttachableCell(t, runPath, realmName, spaceName, stackName, cellName)
+
+	// Step 3: confirm the per-container sbsh socket is in place. The runner
+	// creates the metadata dir at provision time and sbsh binds the socket
+	// inside the container at task start. If this is missing, `sb attach`
+	// would fail in a way that's hard to attribute, so check explicitly.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get working dir: %v", err)
+	}
+	socketPath := fs.ContainerSocketPath(filepath.Join(cwd, runPath),
+		realmName, spaceName, stackName, cellName, "work")
+	waitForSocket(t, socketPath, 10*time.Second)
+
+	// Step 4: drive `kuke attach` over a real PTY and detach.
+	session := startPTY(t, nil, kuke,
+		appendNoDaemonRunPath(runPath,
+			"attach",
+			"--realm", realmName,
+			"--space", spaceName,
+			"--stack", stackName,
+			"--cell", cellName,
+			"--container", "work",
+		)...)
+	t.Cleanup(session.Close)
+
+	// Wait for sb attach to take over the PTY before sending the keystroke.
+	// Without this grace, the bytes can race the syscall.Exec into sb and
+	// land on the bare `kuke attach` process, which discards them.
+	time.Sleep(attachConnectGrace)
+
+	if err = session.Write(sbshDetachSequence); err != nil {
+		t.Fatalf("write sbsh detach sequence: %v", err)
+	}
+
+	exitCode, output, waitErr := session.Wait(attachExitTimeout)
+	if waitErr != nil && exitCode == -1 {
+		t.Fatalf("kuke attach did not exit cleanly within %s: %v\noutput:\n%s",
+			attachExitTimeout, waitErr, output)
+	}
+	if exitCode != 0 {
+		t.Fatalf("kuke attach exited with code %d (want 0)\noutput:\n%s",
+			exitCode, output)
+	}
+
+	// Step 5: assert the container task is still RUNNING. The detach should
+	// only tear down the sb client; the workload (sleep wrapped by sbsh
+	// terminal) keeps running inside the container.
+	cellID, err := getCellIDNoDaemon(t, runPath, realmName, spaceName, stackName, cellName)
+	if err != nil {
+		t.Fatalf("get cell ID: %v", err)
+	}
+	containerdID := fmt.Sprintf("%s_%s_%s_%s", spaceName, stackName, cellID, "work")
+	if !verifyContainerTaskIsRunning(t, realmName, containerdID) {
+		t.Fatalf("container task %q in namespace %q is not RUNNING after detach",
+			containerdID, realmName)
+	}
+}
+
+// applyAttachableCell substitutes test-side names into the
+// attachable-cell.yaml fixture and runs `kuke apply` against it.
+func applyAttachableCell(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) {
+	t.Helper()
+
+	yamlContent := readTestdataYAML(t, "attachable-cell.yaml")
+	for old, replacement := range map[string]string{
+		"test-realm": realmName,
+		"test-space": spaceName,
+		"test-stack": stackName,
+		"test-cell":  cellName,
+	} {
+		yamlContent = strings.ReplaceAll(yamlContent, old, replacement)
+	}
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "attachable-cell.yaml")
+	if err := os.WriteFile(tmpFile, []byte(yamlContent), 0o644); err != nil {
+		t.Fatalf("write tmp yaml: %v", err)
+	}
+
+	args := appendNoDaemonRunPath(runPath, "apply", "-f", tmpFile)
+	runReturningBinary(t, nil, kuke, args...)
+}
+
+// appendNoDaemonRunPath returns the standard `--no-daemon --run-path X`
+// prefix concatenated with the supplied args. Used by the attach scenario so
+// every kuke invocation hits the in-process controller backed by the test's
+// runPath, isolating from any host daemon. The runPath is resolved to an
+// absolute path so OCI bind-mount sources stay valid even when containerd
+// chroot-resolves them from its own work directory.
+func appendNoDaemonRunPath(runPath string, args ...string) []string {
+	abs := absRunPath(runPath)
+	out := make([]string, 0, len(args)+3)
+	out = append(out, "--no-daemon", "--run-path", abs)
+	return append(out, args...)
+}
+
+// absRunPath returns runPath rewritten as an absolute path under the test's
+// working directory if it is not already absolute. Pure path math; nothing
+// on disk is touched.
+func absRunPath(runPath string) string {
+	if filepath.IsAbs(runPath) {
+		return runPath
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		// Fallback: pass through as-is. Hard-fails the kuke invocation
+		// downstream with a clear error rather than masking it.
+		return runPath
+	}
+	return filepath.Join(cwd, runPath)
+}
+
+// waitForSocket polls until the per-container sbsh control socket appears
+// or the timeout expires. Polling rather than fixed-sleep so a fast machine
+// is not penalised and a stuck task fails with a useful message.
+func waitForSocket(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if info, err := os.Stat(path); err == nil && (info.Mode()&os.ModeSocket) != 0 {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("sbsh socket %q did not appear within %s", path, timeout)
+}
+
+// verifyContainerTaskIsRunning returns true iff `ctr task ls` reports the
+// task in RUNNING state. Distinct from verifyContainerTaskExists, which is
+// satisfied even by STOPPED tasks; the detach scenario specifically needs
+// to assert the workload survived the client disconnect.
+func verifyContainerTaskIsRunning(t *testing.T, namespace, containerID string) bool {
+	t.Helper()
+
+	ctrPath, err := exec.LookPath(ctr)
+	if err != nil {
+		t.Logf("ctr binary not found, skipping task running check")
+		return false
+	}
+
+	cmd := exec.Command(ctrPath, "--namespace", namespace, "task", "ls")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("ctr task ls failed: %v, output: %s", err, out)
+		return false
+	}
+
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, containerID) && strings.Contains(line, "RUNNING") {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanupRealmNoDaemon, cleanupSpaceNoDaemon, cleanupStackNoDaemon, and
+// cleanupCellNoDaemon mirror the existing cleanup helpers but route through
+// `--no-daemon` so they use the same in-process controller as the test
+// itself. Without this the cleanup goes via the host daemon (different
+// runPath) and silently no-ops, leaving resources behind.
+func cleanupRealmNoDaemon(t *testing.T, runPath, realmName string) {
+	t.Helper()
+	args := appendNoDaemonRunPath(runPath, "delete", "realm", realmName, "--cascade")
+	_, _, _ = runBinary(t, nil, kuke, args...)
+}
+
+func cleanupSpaceNoDaemon(t *testing.T, runPath, realmName, spaceName string) {
+	t.Helper()
+	args := appendNoDaemonRunPath(runPath, "delete", "space", spaceName,
+		"--realm", realmName, "--cascade")
+	_, _, _ = runBinary(t, nil, kuke, args...)
+}
+
+func cleanupStackNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName string) {
+	t.Helper()
+	args := appendNoDaemonRunPath(runPath, "delete", "stack", stackName,
+		"--realm", realmName, "--space", spaceName, "--cascade")
+	_, _, _ = runBinary(t, nil, kuke, args...)
+}
+
+func cleanupCellNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) {
+	t.Helper()
+	args := appendNoDaemonRunPath(runPath, "delete", "cell", cellName,
+		"--realm", realmName, "--space", spaceName, "--stack", stackName, "--cascade")
+	_, _, _ = runBinary(t, nil, kuke, args...)
+}
+
+// getCellIDNoDaemon mirrors getCellID but goes through the in-process
+// controller. The realm namespace argument used elsewhere collapses to the
+// realm name when --no-daemon owns the metadata.
+func getCellIDNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) (string, error) {
+	t.Helper()
+
+	args := appendNoDaemonRunPath(runPath,
+		"get", "cell", cellName,
+		"--realm", realmName, "--space", spaceName, "--stack", stackName,
+		"--output", "json",
+	)
+	output := runReturningBinary(t, nil, kuke, args...)
+	cell, err := parseCellJSON(t, output)
+	if err != nil {
+		return "", err
+	}
+	if cell.Spec.ID == "" {
+		return "", fmt.Errorf("cell %q has empty Spec.ID", cellName)
+	}
+	return cell.Spec.ID, nil
+}

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -134,11 +134,11 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// Step 2: apply the attachable cell fixture. Auto-starts the workload
 	// (apply is the path that drives Cell to Ready), so by the time it
 	// returns the container task should be RUNNING. The per-container
-	// sbsh socket appears once #74 lands the directory bind mount that
-	// makes sbsh's listener inode host-visible; this scenario depends on
-	// that and does not pre-create any placeholder file (the old
-	// workaround was broken because sbsh unlinks-and-recreates the
-	// destination, producing a fresh inode invisible to the host).
+	// sbsh socket appears thanks to #77's per-container tty/ directory bind
+	// mount, which makes sbsh's listener inode host-visible. This scenario
+	// does not pre-create any placeholder socket file (the old workaround
+	// was broken because sbsh unlinks-and-recreates the destination,
+	// producing a fresh inode invisible to the host).
 	applyAttachableCell(t, runPath, realmName, spaceName, stackName, cellName)
 
 	// Step 3: confirm the per-container sbsh socket is in place. The runner

--- a/e2e/e2e_pty_test.go
+++ b/e2e/e2e_pty_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// ptySession runs a binary attached to a freshly allocated pseudoterminal.
+// Stdin/stdout/stderr of the child are wired to the PTY slave; the test
+// drives the child by calling Write (master side) and reads captured
+// output via the Wait return value or Output. Exists for end-to-end
+// scenarios that need to drive interactive subcommands like `kuke attach`,
+// where CombinedOutput-style helpers cannot deliver detach keystrokes.
+type ptySession struct {
+	t        *testing.T
+	cmd      *exec.Cmd
+	pty      *os.File
+	waitDone chan error
+
+	mu  sync.Mutex
+	out bytes.Buffer
+}
+
+// startPTY launches a binary inside a fresh PTY and returns a session handle.
+// If the binary is missing, the test is skipped to match the convention used
+// by runReturningBinary. The caller MUST eventually call Wait or Close to
+// reap the child and release the PTY.
+func startPTY(t *testing.T, env []string, command string, args ...string) *ptySession {
+	t.Helper()
+
+	dir := os.Getenv("E2E_BIN_DIR")
+	if dir == "" {
+		dir = ".."
+	}
+	bin := filepath.Join(dir, command)
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Skipf("binary %s not found, skipping", bin)
+	}
+
+	cmd := exec.Command(bin, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty.Start %s: %v", bin, err)
+	}
+
+	s := &ptySession{
+		t:        t,
+		cmd:      cmd,
+		pty:      ptmx,
+		waitDone: make(chan error, 1),
+	}
+
+	// Drain master into the buffer so the child does not block on a full
+	// pipe. Returns when the slave side is closed (child has exited or we
+	// closed the PTY ourselves).
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := ptmx.Read(buf)
+			if n > 0 {
+				s.mu.Lock()
+				s.out.Write(buf[:n])
+				s.mu.Unlock()
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		s.waitDone <- cmd.Wait()
+	}()
+
+	return s
+}
+
+// Write sends raw bytes to the PTY master so they arrive on the child's
+// stdin as if typed by a user.
+func (s *ptySession) Write(p []byte) error {
+	s.t.Helper()
+	_, err := s.pty.Write(p)
+	return err
+}
+
+// Wait blocks until the child exits or the timeout expires. Returns the
+// exit code (0 on success, -1 if the timeout fires or the child died of
+// a signal), the captured output up to that point, and any wait error.
+func (s *ptySession) Wait(timeout time.Duration) (int, []byte, error) {
+	s.t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case waitErr := <-s.waitDone:
+		_ = s.pty.Close()
+		exitCode := 0
+		if waitErr != nil {
+			var exitErr *exec.ExitError
+			if errors.As(waitErr, &exitErr) {
+				exitCode = exitErr.ExitCode()
+			} else {
+				exitCode = -1
+			}
+		}
+		return exitCode, s.snapshotOutput(), waitErr
+	case <-timer.C:
+		return -1, s.snapshotOutput(), fmt.Errorf("pty session %s did not exit within %s",
+			filepath.Base(s.cmd.Path), timeout)
+	}
+}
+
+// Close kills the child if it has not exited and releases the PTY. Safe to
+// call after Wait. The drain goroutine returns shortly afterwards.
+func (s *ptySession) Close() {
+	s.t.Helper()
+	if s.cmd != nil && s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+	}
+	_ = s.pty.Close()
+}
+
+// snapshotOutput returns a copy of the output captured so far.
+func (s *ptySession) snapshotOutput() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.out.Bytes()...)
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
+	github.com/creack/pty v1.1.24
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/containernetworking/cni v1.3.0/go.mod h1:Bs8glZjjFfGPHMw6hQu82RUgEPNG
 github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
 github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/cyphar/filepath-securejoin v0.6.0 h1:BtGB77njd6SVO6VztOHfPxKitJvd/VPT+OFBFMOi1Is=
 github.com/cyphar/filepath-securejoin v0.6.0/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- Adds a reusable PTY harness under `e2e/` (`startPTY`, `Write`, `Wait`, `Close`) so e2e tests can drive interactive subprocesses like `kuke attach`. Backed by `github.com/creack/pty` (test-side dep only).
- Adds `attachable-cell.yaml` testdata fixture: one root and one `attachable: true` container, both `registry.eminwux.com/busybox` per the test-side image rule.
- Adds `TestKuke_AttachDetach_KeepsTaskRunning`: PTY-driven `kuke attach`, sends sbsh's documented detach keystroke (Ctrl+] Ctrl+]), asserts the attach process exits cleanly, and asserts the underlying container task is still RUNNING via `ctr -n <realm> task ls`.
- The scenario depends on the per-container `tty/` directory bind mount (landed in `main` as #77). It does **not** pre-create any placeholder socket file (the workaround that #77 superseded). Skips if `sb` or `sbsh` is missing on PATH, or if the host `sbsh` predates sbsh#153 (probed via `sbsh terminal --help` for `--capture-file`).

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -c ./e2e` (compile-check)
- [x] `make test` (unit suite, e2e excluded)
- [x] `make release-build` (CI build target)
- [x] Daemon-parity: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` returned identical output (default + kuke-system, both Ready).
- [ ] Full `make test-e2e` end-to-end exercise — gated on #79 *as redesigned post-sbsh#153*. sbsh#153 closed one of the gaps documented in #79 (`--capture-file` now exists on `sbsh terminal`), but the wrapper in `internal/ctr/attachable.go` still passes `--terminal-socket` and `--terminal-logfile` (which `sbsh terminal` exposes as `--socket` and `--log-file`) and uses positional argv after `--` instead of `--command`. Run log on this branch (head `c8677a2`, freshly rebuilt `kuke`): `sbsh socket "<runPath>/.../work/tty/socket" did not appear within 10s` — `ctr task start` on the work container still surfaces `Error: unknown flag: --terminal-socket` from sbsh. Expected to start passing once #79's wrapper fix lands against the post-#153 CLI. The new `requireSbshHasPostMergeFlags` guard skips the test up-front when host sbsh predates #153 so a stale binary fails loudly with a named cause instead of as a `waitForSocket` timeout.

Closes #71