### PR TITLE
fix: bind-mount per-container tty dir for host-visible sbsh socket

### DIFF
--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	testHostSocket = "/opt/kukeon/r1/s1/st1/c1/work/sbsh.io"
+	testHostSocket = "/opt/kukeon/r1/s1/st1/c1/work/tty/socket"
 )
 
 type fakeClient struct {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -23,10 +23,18 @@ const (
 
 	KukeonMetadataFile = "metadata.json"
 
+	// KukeonContainerTTYDir is the basename of the per-container directory
+	// that owns the sbsh terminal socket plus its capture and log siblings.
+	// kukeon bind-mounts this directory (not a single file) into the
+	// container so sbsh's unlink-and-recreate of the socket inode stays
+	// host-visible.
+	KukeonContainerTTYDir = "tty"
+
 	// KukeonContainerSocketFile is the basename of the per-container sbsh
-	// control socket (host side). The container sees the same inode at
-	// /run/sbsh.socket via a bind mount injected by Attachable=true specs.
-	KukeonContainerSocketFile = "sbsh.io"
+	// terminal socket inside KukeonContainerTTYDir. The container sees the
+	// same inode at /run/kukeon/tty/socket via the directory bind mount
+	// injected by Attachable=true specs.
+	KukeonContainerSocketFile = "socket"
 
 	// Label keys shared across the user default hierarchy and the system hierarchy.
 	KukeonRealmLabelKey     = "realm.kukeon.io"

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -28,31 +28,27 @@ import (
 // attachableBuildOpts returns the ctr.BuildOption slice to pass to
 // CreateContainerFromSpec for a given container spec. When Attachable=false
 // the slice is empty and the call is a no-op. When Attachable=true the
-// runner pre-creates the per-container directory (where the sbsh socket
-// will live) and resolves the sbsh binary path keyed off the *image* arch,
-// not the host arch — a cross-arch image running under emulation would
-// otherwise pick a binary the in-container ELF interpreter cannot run.
+// runner pre-creates the per-container tty/ directory (sbsh's bind-mount
+// source — sbsh creates the socket and its capture/log siblings there) and
+// resolves the sbsh binary path keyed off the *image* arch, not the host
+// arch — a cross-arch image running under emulation would otherwise pick a
+// binary the in-container ELF interpreter cannot run.
 func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOption, error) {
 	if !spec.Attachable {
 		return nil, nil
 	}
 
-	dir := fs.ContainerMetadataDir(
+	ttyDir := fs.ContainerTTYDir(
 		r.opts.RunPath,
 		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName,
 		spec.ID,
 	)
 	// 0700 so only the daemon (root) can reach the socket from the host
 	// side. Documented in the issue's "Socket security threat model".
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	if err := os.MkdirAll(ttyDir, 0o700); err != nil {
 		return nil, err
 	}
 
-	socketPath := fs.ContainerSocketPath(
-		r.opts.RunPath,
-		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName,
-		spec.ID,
-	)
 	binaryPath, err := r.ctrClient.ResolveSbshCachePath(spec.Image, r.opts.RunPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolve sbsh cache path for %q: %w", spec.Image, err)
@@ -61,7 +57,7 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 	return []ctr.BuildOption{
 		ctr.WithAttachableInjection(ctr.AttachableInjection{
 			SbshBinaryPath: binaryPath,
-			HostSocketPath: socketPath,
+			HostTTYDir:     ttyDir,
 		}),
 	}, nil
 }

--- a/internal/ctr/attachable.go
+++ b/internal/ctr/attachable.go
@@ -32,10 +32,25 @@ const (
 	// read-only inside the container.
 	AttachableBinaryPath = "/.kukeon/bin/sbsh"
 
-	// AttachableSocketPath is where the per-container sbsh control socket is
-	// bind-mounted inside the container. The host peer lives in the
-	// per-container metadata directory.
-	AttachableSocketPath = "/run/sbsh.socket"
+	// AttachableTTYDir is where the per-container tty directory is
+	// bind-mounted inside the container. sbsh creates and owns the socket,
+	// capture, and log files inside this directory; because it is a
+	// directory bind mount (not a file mount), sbsh's unlink-and-recreate
+	// of the socket inode stays host-visible.
+	AttachableTTYDir = "/run/kukeon/tty"
+
+	// AttachableSocketPath is the in-container path of the sbsh terminal
+	// socket. sbsh listens here; the host peer is the bind-mount source
+	// directory's `socket` entry, which `kuke attach` connects to.
+	AttachableSocketPath = AttachableTTYDir + "/socket"
+
+	// AttachableCapturePath is the in-container path of the sbsh capture
+	// file. Surfacing it to `kuke logs` is a follow-up.
+	AttachableCapturePath = AttachableTTYDir + "/capture"
+
+	// AttachableLogfilePath is the in-container path of the sbsh terminal
+	// log file. Surfacing it to `kuke logs` is a follow-up.
+	AttachableLogfilePath = AttachableTTYDir + "/log"
 
 	// AttachableSubcommand is the sbsh entrypoint subcommand used to wrap
 	// the workload's process. Hard-coded for the foundation slice; the
@@ -52,16 +67,23 @@ type AttachableInjection struct {
 	// bind-mounted RO at AttachableBinaryPath inside the container.
 	SbshBinaryPath string
 
-	// HostSocketPath is the host path of the per-container sbsh control
-	// socket. It will be bind-mounted at AttachableSocketPath inside the
-	// container, and is what `kuke attach` (#66) connects to.
-	HostSocketPath string
+	// HostTTYDir is the host path of the per-container tty directory that
+	// will be bind-mounted at AttachableTTYDir inside the container. The
+	// host-visible socket that `kuke attach` (#66) connects to is the
+	// `socket` entry inside this directory.
+	HostTTYDir string
 }
 
 // withAttachableMounts adds the two bind mounts that make sbsh reachable from
-// inside the container: the static binary (RO) and the per-container control
-// socket (RW). Used as an oci.SpecOpts so it composes with the rest of the
+// inside the container: the static binary (RO) and the per-container tty
+// directory (RW). Used as an oci.SpecOpts so it composes with the rest of the
 // spec build.
+//
+// The tty mount is a *directory* bind mount, not a file mount: sbsh's
+// listener does `os.Remove` + `Listen` on the destination, which under a
+// file bind would unlink the bind dirent and create a fresh socket inode on
+// the container's overlay — invisible to the host. A directory bind mount
+// keeps the inode host-visible by construction.
 func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 	return oci.WithMounts([]runtimespec.Mount{
 		{
@@ -71,18 +93,19 @@ func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 			Options:     []string{"rbind", "ro"},
 		},
 		{
-			Destination: AttachableSocketPath,
-			Source:      inj.HostSocketPath,
+			Destination: AttachableTTYDir,
+			Source:      inj.HostTTYDir,
 			Type:        "bind",
 			Options:     []string{"rbind", "rw"},
 		},
 	})
 }
 
-// withAttachableArgsWrap prepends `sbsh terminal --socket /run/sbsh.socket --`
-// to the container's process.args. It is composed *after* the normal
-// WithProcessArgs (or the image's default ENTRYPOINT/CMD) so the wrapped
-// command line is whatever would have run otherwise.
+// withAttachableArgsWrap prepends the sbsh terminal wrapper, with the
+// per-tty paths inside AttachableTTYDir, to the container's process.args.
+// It is composed *after* the normal WithProcessArgs (or the image's default
+// ENTRYPOINT/CMD) so the wrapped command line is whatever would have run
+// otherwise.
 //
 // OCI semantics: process.args is the merged "ENTRYPOINT + CMD" by the time
 // this opt runs (containerd's WithImageConfigArgs has already resolved image
@@ -98,8 +121,10 @@ func withAttachableArgsWrap() oci.SpecOpts {
 		wrapped := []string{
 			AttachableBinaryPath,
 			AttachableSubcommand,
-			"--socket",
-			AttachableSocketPath,
+			"--run-path", AttachableTTYDir,
+			"--terminal-socket", AttachableSocketPath,
+			"--capture-file", AttachableCapturePath,
+			"--terminal-logfile", AttachableLogfilePath,
 			"--",
 		}
 		s.Process.Args = append(wrapped, original...)

--- a/internal/ctr/attachable_test.go
+++ b/internal/ctr/attachable_test.go
@@ -75,8 +75,8 @@ func TestBuildContainerSpec_AttachableFalseIsByteIdentical(t *testing.T) {
 	if hasMountAt(got, ctr.AttachableBinaryPath) {
 		t.Errorf("Attachable=false produced sbsh binary mount; should not")
 	}
-	if hasMountAt(got, ctr.AttachableSocketPath) {
-		t.Errorf("Attachable=false produced sbsh socket mount; should not")
+	if hasMountAt(got, ctr.AttachableTTYDir) {
+		t.Errorf("Attachable=false produced sbsh tty dir mount; should not")
 	}
 }
 
@@ -134,7 +134,7 @@ func TestBuildContainerSpec_AttachableTrue_MountsAndArgsWrap(t *testing.T) {
 
 	inj := ctr.AttachableInjection{
 		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
-		HostSocketPath: "/opt/kukeon/realm/space/stack/cell/c1/sbsh.io",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
 	}
 
 	for _, tc := range cases {
@@ -163,19 +163,38 @@ func TestBuildContainerSpec_AttachableTrue_MountsAndArgsWrap(t *testing.T) {
 				t.Errorf("binary mount must be read-only, got options=%v", binMount.Options)
 			}
 
-			sockMount := findMount(spec, ctr.AttachableSocketPath)
-			if sockMount == nil {
-				t.Fatalf("expected bind mount at %s, got mounts=%+v", ctr.AttachableSocketPath, spec.Mounts)
+			ttyMount := findMount(spec, ctr.AttachableTTYDir)
+			if ttyMount == nil {
+				t.Fatalf("expected bind mount at %s, got mounts=%+v", ctr.AttachableTTYDir, spec.Mounts)
 			}
-			if sockMount.Source != inj.HostSocketPath {
-				t.Errorf("socket mount source = %q, want %q", sockMount.Source, inj.HostSocketPath)
+			if ttyMount.Source != inj.HostTTYDir {
+				t.Errorf("tty mount source = %q, want %q", ttyMount.Source, inj.HostTTYDir)
+			}
+			if containsString(ttyMount.Options, "ro") {
+				t.Errorf("tty mount must be read-write, got options=%v", ttyMount.Options)
+			}
+			// AC: exactly one rw bind whose source is the tty dir; the
+			// single-file /run/sbsh.socket mount must be gone.
+			if hasMountAt(spec, "/run/sbsh.socket") {
+				t.Errorf("legacy /run/sbsh.socket file mount still present: %+v", spec.Mounts)
+			}
+			ttyMounts := 0
+			for _, m := range spec.Mounts {
+				if m.Destination == ctr.AttachableTTYDir {
+					ttyMounts++
+				}
+			}
+			if ttyMounts != 1 {
+				t.Errorf("expected exactly one mount at %s, got %d", ctr.AttachableTTYDir, ttyMounts)
 			}
 
 			wantPrefix := []string{
 				ctr.AttachableBinaryPath,
 				ctr.AttachableSubcommand,
-				"--socket",
-				ctr.AttachableSocketPath,
+				"--run-path", ctr.AttachableTTYDir,
+				"--terminal-socket", ctr.AttachableSocketPath,
+				"--capture-file", ctr.AttachableCapturePath,
+				"--terminal-logfile", ctr.AttachableLogfilePath,
 				"--",
 			}
 			if len(spec.Process.Args) < len(wantPrefix) {
@@ -208,15 +227,17 @@ func TestBuildContainerSpec_AttachableTrue_EmptyImageArgs(t *testing.T) {
 	}
 	inj := ctr.AttachableInjection{
 		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
-		HostSocketPath: "/opt/kukeon/realm/space/stack/cell/c1/sbsh.io",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
 	}
 	spec := applyBuiltSpecWith(t, in, nil, ctr.WithAttachableInjection(inj))
 
 	want := []string{
 		ctr.AttachableBinaryPath,
 		ctr.AttachableSubcommand,
-		"--socket",
-		ctr.AttachableSocketPath,
+		"--run-path", ctr.AttachableTTYDir,
+		"--terminal-socket", ctr.AttachableSocketPath,
+		"--capture-file", ctr.AttachableCapturePath,
+		"--terminal-logfile", ctr.AttachableLogfilePath,
 		"--",
 	}
 	if !reflect.DeepEqual(spec.Process.Args, want) {

--- a/internal/daemon/attach_rpc_test.go
+++ b/internal/daemon/attach_rpc_test.go
@@ -68,7 +68,7 @@ func TestAttachContainer_Attachable_RPCReturnsSocketPath(t *testing.T) {
 	// When the target is Attachable=true the daemon hands back the host
 	// socket path so the client can open it directly. The RPC layer must
 	// pass that path through verbatim and leave Err nil.
-	const wantSocket = "/opt/kukeon/default/default/default/cellA/work/sbsh.io"
+	const wantSocket = "/opt/kukeon/default/default/default/cellA/work/tty/socket"
 	core := &attachClientFake{result: kukeonv1.AttachContainerResult{HostSocketPath: wantSocket}}
 	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core)
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -130,7 +130,7 @@ var (
 	// ErrAttachNotSupported is returned when an attach request targets a
 	// container that was not created with Attachable=true. The sbsh wrapper
 	// is only injected on opt-in; non-Attachable containers have no
-	// /run/sbsh.socket to connect to.
+	// /run/kukeon/tty/socket to connect to.
 	ErrAttachNotSupported = errors.New("container is not attachable; recreate with attachable=true")
 
 	// ErrAttachAmbiguous is returned by the `kuke attach` candidate picker

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -90,13 +90,24 @@ func ContainerMetadataDir(baseRunPath, realmName, spaceName, stackName, cellName
 	)
 }
 
-// ContainerSocketPath returns the host-side path for a container's sbsh
-// control socket. This is the single source of truth for both the OCI
-// bind-mount source (the container sees it at /run/sbsh.socket) and the
-// host-visible path that `kuke attach` will connect to.
-func ContainerSocketPath(baseRunPath, realmName, spaceName, stackName, cellName, containerName string) string {
+// ContainerTTYDir returns the host-side per-container directory that owns
+// the sbsh terminal socket and its capture/log siblings. It is bind-mounted
+// into the container at /run/kukeon/tty so that sbsh's unlink-and-recreate
+// cycle on the socket inode stays host-visible.
+func ContainerTTYDir(baseRunPath, realmName, spaceName, stackName, cellName, containerName string) string {
 	return filepath.Join(
 		ContainerMetadataDir(baseRunPath, realmName, spaceName, stackName, cellName, containerName),
+		consts.KukeonContainerTTYDir,
+	)
+}
+
+// ContainerSocketPath returns the host-side path for a container's sbsh
+// terminal socket. This is the single source of truth for both the
+// host-visible path that `kuke attach` connects to and the path sbsh listens
+// on inside the container (mediated by the ContainerTTYDir bind mount).
+func ContainerSocketPath(baseRunPath, realmName, spaceName, stackName, cellName, containerName string) string {
+	return filepath.Join(
+		ContainerTTYDir(baseRunPath, realmName, spaceName, stackName, cellName, containerName),
 		consts.KukeonContainerSocketFile,
 	)
 }

--- a/internal/util/fs/metadata_test.go
+++ b/internal/util/fs/metadata_test.go
@@ -26,23 +26,38 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
+func TestContainerTTYDir(t *testing.T) {
+	got := fs.ContainerTTYDir("/opt/kukeon", "realm", "space", "stack", "cell", "c1")
+	want := "/opt/kukeon/realm/space/stack/cell/c1/" + consts.KukeonContainerTTYDir
+	if got != want {
+		t.Errorf("ContainerTTYDir = %q, want %q", got, want)
+	}
+}
+
 func TestContainerSocketPath(t *testing.T) {
 	got := fs.ContainerSocketPath("/opt/kukeon", "realm", "space", "stack", "cell", "c1")
-	want := "/opt/kukeon/realm/space/stack/cell/c1/" + consts.KukeonContainerSocketFile
+	want := "/opt/kukeon/realm/space/stack/cell/c1/" +
+		consts.KukeonContainerTTYDir + "/" + consts.KukeonContainerSocketFile
 	if got != want {
 		t.Errorf("ContainerSocketPath = %q, want %q", got, want)
 	}
 }
 
-func TestContainerMetadataDir_AnchorsContainerSocket(t *testing.T) {
-	// The socket must live under the container's metadata dir, not anywhere
-	// else — `kuke attach` (#66) and the OCI bind-mount source rely on this
-	// being the single source of truth.
+func TestContainerMetadataDir_AnchorsContainerTTYDir(t *testing.T) {
+	// The tty dir (and the socket inside it) must live under the
+	// container's metadata dir, not anywhere else — `kuke attach` (#66)
+	// and the OCI bind-mount source rely on this being the single source
+	// of truth.
 	dir := fs.ContainerMetadataDir("/opt/kukeon", "r", "s", "st", "c", "co")
+	ttyDir := fs.ContainerTTYDir("/opt/kukeon", "r", "s", "st", "c", "co")
+	wantTTY := dir + "/" + consts.KukeonContainerTTYDir
+	if ttyDir != wantTTY {
+		t.Errorf("tty dir = %q, want it under container metadata dir = %q", ttyDir, wantTTY)
+	}
 	sock := fs.ContainerSocketPath("/opt/kukeon", "r", "s", "st", "c", "co")
-	want := dir + "/" + consts.KukeonContainerSocketFile
-	if sock != want {
-		t.Errorf("socket path = %q, want it under container metadata dir = %q", sock, want)
+	wantSock := wantTTY + "/" + consts.KukeonContainerSocketFile
+	if sock != wantSock {
+		t.Errorf("socket path = %q, want it under tty dir = %q", sock, wantSock)
 	}
 }
 

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -58,12 +58,13 @@ type ContainerSpec struct {
 	CNIConfigPath          string                 `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
 	RestartPolicy          string                 `json:"restartPolicy"                    yaml:"restartPolicy"`
 	// Attachable opts the container into sbsh-wrapper injection. When true,
-	// the daemon prepends `sbsh terminal --socket /run/sbsh.socket --` to
+	// the daemon prepends `sbsh terminal --run-path /run/kukeon/tty …` to
 	// process.args, bind-mounts the sbsh binary read-only at /.kukeon/bin/sbsh,
-	// and bind-mounts a per-container Unix socket at /run/sbsh.socket. The
-	// host-visible peer of the socket lives in the per-container metadata dir
-	// and is what `kuke attach` connects to. Default false — no behavior
-	// change for existing specs.
+	// and bind-mounts a per-container tty directory at /run/kukeon/tty (sbsh
+	// owns its socket, capture, and log files inside it). The host-visible
+	// peer of that directory lives in the per-container metadata dir and its
+	// `socket` entry is what `kuke attach` connects to. Default false — no
+	// behavior change for existing specs.
 	Attachable bool `json:"attachable,omitempty" yaml:"attachable,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Replace the `/run/sbsh.socket` single-file bind mount (which `runc` rejects when the source doesn't exist, and which sbsh would unlink to a container-overlay inode anyway) with a directory bind mount of the per-container `tty/` host dir at `/run/kukeon/tty` — sbsh's unlink-and-recreate of the socket inode now stays host-visible by construction.
- Wrap `process.args` with the upstream sbsh terminal flags: `--run-path`, `--terminal-socket`, `--capture-file`, `--terminal-logfile`. sbsh creates and owns those files inside the bind-mounted dir.
- Renames: `consts.KukeonContainerSocketFile` is now `"socket"` (was `"sbsh.io"`), new `consts.KukeonContainerTTYDir = "tty"`, new `fs.ContainerTTYDir` helper, `AttachableInjection.HostSocketPath` → `HostTTYDir`. `fs.ContainerSocketPath` continues to be the single source of truth and now returns `<container>/tty/socket`, so `kuke attach` (#66) is unchanged at the call-site level.
- Runner pre-creates `<container>/tty/` at mode `0700` before container start; `Attachable: false` specs are unchanged (regression guard from #57 still passes).

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make test` (full unit suite, e2e excluded — passes)
- [x] `make release-build` (CI build target — produces linux/amd64 + linux/arm64)
- [x] Smoke test from project CLAUDE.md: tear down → `make kuke` → docker build/import → `sudo ./kuke init` → daemon-parity check (`sudo ./kuke get realms` vs `--no-daemon` returned identical Ready output for `default` and `kuke-system`).
- [ ] e2e `make test-e2e` against an Attachable cell — gated on PR #75 (which also depends on this PR); the AC "host-visible Unix-domain socket appears under `tty/socket`" is exercised end-to-end there.

Closes #74