### PR TITLE
docs: add step-by-step guide for attaching to a claude-code cell

### DIFF
--- a/docs/site/guides/attach-claude-code.md
+++ b/docs/site/guides/attach-claude-code.md
@@ -1,0 +1,93 @@
+# Attaching to a claude-code cell
+
+This guide takes a freshly-`kuke init`-ed host from zero to an attached
+`claude-code` session in two commands. Apply a single manifest, then attach.
+
+## Prerequisites
+
+- `kuke init` has completed on the host (the `default/default/default`
+  realm/space/stack tuple is in place — that's what `kuke init` provisions).
+- `sbsh` and `sb` are on the host's `$PATH`. `kuke attach` is a thin client
+  that hands the terminal off to `sb` via `syscall.Exec`; bytes never traverse
+  `kukeond`.
+
+If you haven't bootstrapped yet, see [Init and reset](init-and-reset.md).
+
+## 1. Save the manifest
+
+Save the following as `claude-code.yaml`. It declares one Cell with a single
+attachable container running the claude-code image. Because no container is
+explicitly marked `root: true`, the runner provisions a default root container
+to hold the cell's network namespace; the `claude` container runs alongside it
+and is the one `kuke attach` connects to.
+
+```yaml
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: claude-code
+spec:
+  id: claude-code
+  realmId: default
+  spaceId: default
+  stackId: default
+  containers:
+    - id: claude
+      image: docker.io/anthropic/claude-code:latest
+      command: claude
+      attachable: true
+```
+
+The image is treated as self-contained — no API keys, env vars, or volumes are
+declared here. Anything `claude-code` needs to configure itself (auth, model
+selection, workspace) is the image's responsibility.
+
+## 2. Apply it
+
+```bash
+sudo kuke apply -f claude-code.yaml
+```
+
+`apply` creates the cell and starts its containers. Once the command returns,
+the workload task is running and the per-container `sbsh` socket is in place.
+
+## 3. Attach
+
+```bash
+sudo kuke attach \
+    --realm default \
+    --space default \
+    --stack default \
+    --cell claude-code \
+    --container claude
+```
+
+You'll land in the live `claude-code` prompt. Bytes flow PTY → `sb` → the
+container's `sbsh terminal` wrapper → the `claude` process; `kukeond` is not
+in the data path.
+
+`--container claude` is shown for clarity; you can omit it — `kuke attach`
+auto-picks the only non-root attachable container in the cell.
+
+## 4. Detach
+
+Press `Ctrl+]` twice in quick succession (the sbsh detach keystroke). The `sb`
+client exits cleanly, but the `claude` process inside the container keeps
+running. Re-attach later with the same `kuke attach` command and you're back
+at the same session.
+
+## Tear down
+
+When you're done with the cell:
+
+```bash
+sudo kuke delete cell claude-code \
+    --realm default --space default --stack default --cascade
+```
+
+`--cascade` removes every container in the cell along with the cell itself.
+
+## See also
+
+- [Apply manifests](apply-manifests.md) — the full `kuke apply` story.
+- [CLI Reference → kuke](../cli/kuke.md) — every command, every flag.

--- a/docs/site/guides/attach-claude-code.md
+++ b/docs/site/guides/attach-claude-code.md
@@ -7,9 +7,13 @@ This guide takes a freshly-`kuke init`-ed host from zero to an attached
 
 - `kuke init` has completed on the host (the `default/default/default`
   realm/space/stack tuple is in place — that's what `kuke init` provisions).
-- `sbsh` and `sb` are on the host's `$PATH`. `kuke attach` is a thin client
-  that hands the terminal off to `sb` via `syscall.Exec`; bytes never traverse
-  `kukeond`.
+- The on-host `sb` client is on the host's `$PATH`. `kuke attach` is a thin
+  client that hands the terminal off to `sb` via `syscall.Exec`; bytes never
+  traverse `kukeond`.
+- The static `sbsh` binary is staged in the kukeon cache at
+  `/opt/kukeon/cache/sbsh/<arch>/sbsh` (where `<arch>` is the image's GOARCH —
+  `amd64` on a typical Linux host). The runner bind-mounts that file
+  read-only into every Attachable container.
 
 If you haven't bootstrapped yet, see [Init and reset](init-and-reset.md).
 
@@ -45,11 +49,18 @@ selection, workspace) is the image's responsibility.
 ## 2. Apply it
 
 ```bash
-sudo kuke apply -f claude-code.yaml
+sudo kuke apply -f claude-code.yaml --no-daemon
 ```
 
 `apply` creates the cell and starts its containers. Once the command returns,
 the workload task is running and the per-container `sbsh` socket is in place.
+
+`--no-daemon` runs cell creation in-process. It is required today because the
+released `kukeond` image does not yet bind-mount the containerd socket — see
+[Apply manifests](apply-manifests.md) for the broader story.
+The cell's metadata still lands under `/opt/kukeon`, so the daemon picks it up
+the moment it's queried — that's why the next step (`kuke attach`) goes
+through the daemon without any further setup.
 
 ## 3. Attach
 
@@ -82,10 +93,11 @@ When you're done with the cell:
 
 ```bash
 sudo kuke delete cell claude-code \
-    --realm default --space default --stack default --cascade
+    --realm default --space default --stack default --cascade --no-daemon
 ```
 
 `--cascade` removes every container in the cell along with the cell itself.
+`--no-daemon` is paired with the apply path above for the same reason.
 
 ## See also
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - Guides:
       - guides/init-and-reset.md
       - guides/apply-manifests.md
+      - guides/attach-claude-code.md
       - guides/local-dev.md
       - guides/autocomplete.md
       - guides/troubleshooting.md


### PR DESCRIPTION
## Summary
- Adds a copy-pasteable guide that takes a freshly-`kuke init`-ed host from zero to a live `claude-code` prompt: one YAML, one `kuke apply`, one `kuke attach`.
- Wires the new page into the mkdocs nav under **Guides**.
- Calls out `--no-daemon` for cell create/delete (matching the same caveat already documented in `getting-started.md` and `apply-manifests.md`) so the workflow actually completes end-to-end today.
- Names the real prerequisites: `sb` on host `$PATH`, plus the static `sbsh` binary in the kukeon cache (`/opt/kukeon/cache/sbsh/<arch>/sbsh`) — that's what the runner actually bind-mounts.

## Notable judgment calls
- Image used in the manifest: `docker.io/anthropic/claude-code:latest`. Per the issue, the guide treats the image as self-contained (no auth/keys/volumes); reviewer can swap the ref if there's a preferred canonical name.
- The Cell intentionally has no explicit `root: true` container — relying on the runner's default-root provisioning (`internal/controller/runner/provision.go:1810-1820`) keeps the manifest minimal.

## Test plan
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `make test` passes
- [ ] mkdocs CI builds the new page (no broken nav entry)
- [ ] On a freshly-`kuke init`-ed host with `sb` on `$PATH` and an `sbsh` binary staged in the cache, copy/paste the YAML, run `kuke apply -f claude-code.yaml --no-daemon`, then `kuke attach …` — land in a live claude-code prompt.

Closes #80