### PR TITLE
fix: bind-mount /sys/fs/cgroup into kukeond container

### DIFF
--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -413,7 +413,11 @@ func (b *Exec) bootstrapStack(section *StackSection, realmName, spaceName, stack
 // passed via --run-path so that kukeond reads/writes the same metadata store
 // that kuke uses in --no-daemon mode. The host containerd socket directory is
 // also bind-mounted and --containerd-socket is forwarded so kukeond can reach
-// the same containerd daemon as kuke does on the host.
+// the same containerd daemon as kuke does on the host. The host cgroup2
+// hierarchy at /sys/fs/cgroup is bind-mounted so kukeond can create the
+// realm/space/stack/cell cgroup tree for user workloads — without it, the
+// daemon container only sees a fresh read-only sysfs and cgroup creation
+// returns ENOENT.
 func kukeondCellDoc(image, socketPath, runPath, containerdSocket string) *v1beta1.CellDoc {
 	args := []string{"serve", "--socket", socketPath}
 	if runPath != "" {
@@ -426,6 +430,7 @@ func kukeondCellDoc(image, socketPath, runPath, containerdSocket string) *v1beta
 	sockDir := socketDir(socketPath)
 	volumes := []v1beta1.VolumeMount{
 		{Source: sockDir, Target: sockDir},
+		{Source: "/sys/fs/cgroup", Target: "/sys/fs/cgroup"},
 	}
 	if runPath != "" && runPath != sockDir {
 		volumes = append(volumes, v1beta1.VolumeMount{Source: runPath, Target: runPath})

--- a/internal/controller/bootstrap_test.go
+++ b/internal/controller/bootstrap_test.go
@@ -1,0 +1,102 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"testing"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestKukeondCellDocVolumes(t *testing.T) {
+	tests := []struct {
+		name             string
+		image            string
+		socketPath       string
+		runPath          string
+		containerdSocket string
+		want             []v1beta1.VolumeMount
+	}{
+		{
+			name:             "all-distinct-dirs",
+			image:            "docker.io/library/kukeon:dev",
+			socketPath:       "/run/kukeon/kukeond.sock",
+			runPath:          "/opt/kukeon",
+			containerdSocket: "/run/containerd/containerd.sock",
+			want: []v1beta1.VolumeMount{
+				{Source: "/run/kukeon", Target: "/run/kukeon"},
+				{Source: "/sys/fs/cgroup", Target: "/sys/fs/cgroup"},
+				{Source: "/opt/kukeon", Target: "/opt/kukeon"},
+				{Source: "/run/containerd", Target: "/run/containerd"},
+			},
+		},
+		{
+			name:       "no-runpath-no-containerd",
+			image:      "docker.io/library/kukeon:dev",
+			socketPath: "/run/kukeon/kukeond.sock",
+			want: []v1beta1.VolumeMount{
+				{Source: "/run/kukeon", Target: "/run/kukeon"},
+				{Source: "/sys/fs/cgroup", Target: "/sys/fs/cgroup"},
+			},
+		},
+		{
+			name:             "containerd-socket-collides-with-sockdir",
+			image:            "docker.io/library/kukeon:dev",
+			socketPath:       "/run/kukeon/kukeond.sock",
+			runPath:          "/opt/kukeon",
+			containerdSocket: "/run/kukeon/containerd.sock",
+			want: []v1beta1.VolumeMount{
+				{Source: "/run/kukeon", Target: "/run/kukeon"},
+				{Source: "/sys/fs/cgroup", Target: "/sys/fs/cgroup"},
+				{Source: "/opt/kukeon", Target: "/opt/kukeon"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := kukeondCellDoc(tc.image, tc.socketPath, tc.runPath, tc.containerdSocket)
+			if len(doc.Spec.Containers) != 1 {
+				t.Fatalf("expected 1 container, got %d", len(doc.Spec.Containers))
+			}
+			got := doc.Spec.Containers[0].Volumes
+			if len(got) != len(tc.want) {
+				t.Fatalf("volumes length: got %d, want %d (got=%+v)", len(got), len(tc.want), got)
+			}
+			for i, w := range tc.want {
+				if got[i] != w {
+					t.Errorf("volumes[%d]: got %+v, want %+v", i, got[i], w)
+				}
+			}
+
+			// Cgroup hierarchy mount must always be present so kukeond can
+			// create realm/space/stack/cell cgroups for user workloads.
+			var hasCgroup bool
+			for _, v := range got {
+				if v.Source == "/sys/fs/cgroup" && v.Target == "/sys/fs/cgroup" {
+					hasCgroup = true
+					break
+				}
+			}
+			if !hasCgroup {
+				t.Errorf("missing /sys/fs/cgroup bind mount in volumes: %+v", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- The kukeond container's OCI spec only had a fresh read-only sysfs at `/sys` and no bind of the host cgroup2 hierarchy. Cell creation routed through the daemon failed with `mkdir /sys/fs/cgroup/kukeon: no such file or directory` because the daemon's view of `/sys/fs/cgroup` was empty.
- `kuke init` and `kuke apply --no-daemon` were unaffected because both run in-process on the host before/around the daemon — which is why the regression was masked until a non-bootstrap `kuke apply` went through the daemon.
- Fix: add `/sys/fs/cgroup` to the volumes slice in `kukeondCellDoc`. `buildBindMounts` already produces an `rbind` mount, which captures cgroup2 submounts cleanly. The container is privileged and runs in the host cgroup namespace, so the daemon now has full read/write of the host hierarchy.
- Added `internal/controller/bootstrap_test.go` covering the volumes layout (all-distinct, run-path-omitted, containerd-collides-with-sockdir) and explicitly asserting the `/sys/fs/cgroup` bind is always present.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make test` — full unit suite passes
- [x] Smoke test from `CLAUDE.md` end-to-end: tear down the existing `kuke-system/kukeon/kukeon/kukeond` cell, rebuild `kuke`, `docker build` + `ctr images import` of `kukeon-local:dev`, `kuke init --kukeond-image docker.io/library/kukeon-local:dev` — daemon comes up Ready
- [x] Daemon-parity check: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` produce identical output
- [x] Daemon container mount check: `ctr container info kukeon_kukeon_kukeond_kukeond` now shows **four** bind mounts including `/sys/fs/cgroup → /sys/fs/cgroup` (rbind, rw)
- [x] Bug repro: `sudo ./kuke apply -f docs/examples/hello-world.yaml` (no `--no-daemon`) now creates the cell cgroup successfully — `/sys/fs/cgroup/kukeon/default/default/default/hello-world` is present on the host. (The pull then failed with an unrelated DNS timeout in this environment, but the cgroup-creation step that the issue blocked on is past.)

Closes #83