### PR TITLE
fix: bind-mount /var/lib/containerd into kukeond container so daemon can unpack images

### DIFF
--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -417,7 +417,12 @@ func (b *Exec) bootstrapStack(section *StackSection, realmName, spaceName, stack
 // hierarchy at /sys/fs/cgroup is bind-mounted so kukeond can create the
 // realm/space/stack/cell cgroup tree for user workloads — without it, the
 // daemon container only sees a fresh read-only sysfs and cgroup creation
-// returns ENOENT.
+// returns ENOENT. The host containerd data root at /var/lib/containerd is
+// bind-mounted as well: kukeond performs in-process overlay mounts during
+// container creation (image unpack, image-config resolution) that reference
+// snapshot lowerdirs under that tree, and the mount syscalls execute in the
+// daemon container's mount namespace — without the bind-mount the kernel
+// returns ENOENT on the host paths.
 func kukeondCellDoc(image, socketPath, runPath, containerdSocket string) *v1beta1.CellDoc {
 	args := []string{"serve", "--socket", socketPath}
 	if runPath != "" {
@@ -431,6 +436,7 @@ func kukeondCellDoc(image, socketPath, runPath, containerdSocket string) *v1beta
 	volumes := []v1beta1.VolumeMount{
 		{Source: sockDir, Target: sockDir},
 		{Source: "/sys/fs/cgroup", Target: "/sys/fs/cgroup"},
+		{Source: "/var/lib/containerd", Target: "/var/lib/containerd"},
 	}
 	if runPath != "" && runPath != sockDir {
 		volumes = append(volumes, v1beta1.VolumeMount{Source: runPath, Target: runPath})

--- a/internal/controller/bootstrap_test.go
+++ b/internal/controller/bootstrap_test.go
@@ -42,6 +42,7 @@ func TestKukeondCellDocVolumes(t *testing.T) {
 			want: []v1beta1.VolumeMount{
 				{Source: "/run/kukeon", Target: "/run/kukeon"},
 				{Source: "/sys/fs/cgroup", Target: "/sys/fs/cgroup"},
+				{Source: "/var/lib/containerd", Target: "/var/lib/containerd"},
 				{Source: "/opt/kukeon", Target: "/opt/kukeon"},
 				{Source: "/run/containerd", Target: "/run/containerd"},
 			},
@@ -53,6 +54,7 @@ func TestKukeondCellDocVolumes(t *testing.T) {
 			want: []v1beta1.VolumeMount{
 				{Source: "/run/kukeon", Target: "/run/kukeon"},
 				{Source: "/sys/fs/cgroup", Target: "/sys/fs/cgroup"},
+				{Source: "/var/lib/containerd", Target: "/var/lib/containerd"},
 			},
 		},
 		{
@@ -64,6 +66,7 @@ func TestKukeondCellDocVolumes(t *testing.T) {
 			want: []v1beta1.VolumeMount{
 				{Source: "/run/kukeon", Target: "/run/kukeon"},
 				{Source: "/sys/fs/cgroup", Target: "/sys/fs/cgroup"},
+				{Source: "/var/lib/containerd", Target: "/var/lib/containerd"},
 				{Source: "/opt/kukeon", Target: "/opt/kukeon"},
 			},
 		},
@@ -96,6 +99,20 @@ func TestKukeondCellDocVolumes(t *testing.T) {
 			}
 			if !hasCgroup {
 				t.Errorf("missing /sys/fs/cgroup bind mount in volumes: %+v", got)
+			}
+
+			// Containerd data root must always be present so kukeond's in-process
+			// overlay mounts during cell creation (image unpack, image-config
+			// resolution) can resolve snapshot lowerdirs that live on the host.
+			var hasContainerdData bool
+			for _, v := range got {
+				if v.Source == "/var/lib/containerd" && v.Target == "/var/lib/containerd" {
+					hasContainerdData = true
+					break
+				}
+			}
+			if !hasContainerdData {
+				t.Errorf("missing /var/lib/containerd bind mount in volumes: %+v", got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Daemon-mode `kuke apply` failed at container creation with `failed to mount … lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/<N>/fs … no such file or directory` because kukeond's image-unpack and image-config-resolution paths perform in-process overlay mounts referencing host snapshot lowerdirs, but `/var/lib/containerd` was not bind-mounted into the daemon container's mount namespace.
- Adds `/var/lib/containerd` (host → container, same path) to the `volumes` slice in `internal/controller/bootstrap.go` alongside `/sys/fs/cgroup`. Same shape as #85.
- Updates the `kukeondCellDoc` doc comment to explain why the new mount is required.
- Updates `bootstrap_test.go`: adjusts the three table cases to reflect the new ordering and adds an always-present assertion on `/var/lib/containerd` mirroring the existing `/sys/fs/cgroup` guard.

## Notable judgment calls
- Hardcoded `/var/lib/containerd` rather than deriving from a `--containerd-data-root` flag. Matches the existing static `/sys/fs/cgroup` mount and the issue's suggested fix. If someone later runs containerd with a non-default `root`, that becomes a follow-up.
- Per project memory, `CLAUDE.md` updates are not bundled into code-fix PRs. The issue's suggested-fix bullets that touch `CLAUDE.md` (the "Two bind mounts expected" inspection note + adding a daemon-parity smoke-test entry) are deferred to a separate `docs:` issue/PR — filing that follow-up issue immediately so the proposal isn't lost when this PR merges.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes (controller package includes the updated `TestKukeondCellDocVolumes`)
- [x] Project smoke test from `CLAUDE.md`: tear down kukeond, rebuild `kuke`+`kukeond`+`kukeon-local:dev`, import to ctr, `sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev` → succeeds; `sudo ctr -n kuke-system.kukeon.io container info kukeon_kukeon_kukeond_kukeond` shows the new bind mount; daemon-parity check (`sudo ./kuke get realms` vs `--no-daemon`) returns identical output
- [x] Issue repro: `sudo ./kuke apply -f docs/examples/hello-world.yaml` no longer fails at the snapshotter-overlay mount — containers and snapshots are created in `kukeon.io`. (A subsequent CNI-bridge-plugin failure is unrelated host setup.)

Closes #91