### PR TITLE
fix: persist kuke-system realm as Ready when its containerd namespace pre-exists

### DIFF
--- a/internal/controller/runner/create_realm_test.go
+++ b/internal/controller/runner/create_realm_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/controller/runner"
+	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/metadata"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -744,5 +745,78 @@ func TestCreateRealm_StateReconciliation(t *testing.T) {
 				t.Logf("Test case: %s", tt.description)
 			}
 		})
+	}
+}
+
+// TestCreateRealm_NamespacePreSeeded_PersistsReady reproduces issue #94: when the
+// containerd namespace already exists at provisionNewRealm time (the real-world
+// trigger is `ctr -n kuke-system.kukeon.io images import` seeding the namespace
+// before `kuke init` runs), CreateRealm must still drive the realm to Ready with
+// a populated cgroupPath persisted to metadata.json — not park it as Failed with
+// an empty cgroupPath, which is what users see as `kuke get realms` reporting
+// the daemon's own home realm as Failed.
+func TestCreateRealm_NamespacePreSeeded_PersistsReady(t *testing.T) {
+	if _, err := os.Stat("/run/containerd/containerd.sock"); os.IsNotExist(err) {
+		t.Skip("containerd socket not available, skipping test")
+	}
+
+	r, _ := setupTestRunner(t)
+
+	hash := sha256.Sum256([]byte(t.Name()))
+	shortHash := hex.EncodeToString(hash[:])[:8]
+	realmName := "preseed-realm-" + shortHash
+	namespace := "preseed-ns-" + shortHash
+
+	// Pre-seed the containerd namespace via a separate client to mirror the
+	// `ctr -n <ns> images import` flow that triggers the bug in real `kuke init`
+	// runs.
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	preSeedClient := ctr.NewClient(ctx, logger, "/run/containerd/containerd.sock")
+	if err := preSeedClient.Connect(); err != nil {
+		t.Skipf("cannot connect to containerd: %v", err)
+	}
+	t.Cleanup(func() { _ = preSeedClient.Close() })
+	if err := preSeedClient.CreateNamespace(namespace); err != nil {
+		t.Fatalf("pre-seed namespace: %v", err)
+	}
+	t.Cleanup(func() { _ = preSeedClient.DeleteNamespace(namespace) })
+
+	realm := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{
+			Name: realmName,
+			Labels: map[string]string{
+				"kukeon.io/realm": namespace,
+			},
+		},
+		Spec: intmodel.RealmSpec{Namespace: namespace},
+	}
+
+	result, err := r.CreateRealm(realm)
+	if err != nil {
+		t.Fatalf("CreateRealm() unexpected error: %v", err)
+	}
+
+	if result.Status.State != intmodel.RealmStateReady {
+		t.Errorf("CreateRealm() in-memory state = %v, want Ready", result.Status.State)
+	}
+	if result.Status.CgroupPath == "" {
+		t.Error("CreateRealm() in-memory cgroupPath is empty, want non-empty")
+	}
+
+	// Persisted metadata is what `kuke get realms` reads — the bug surfaces
+	// because that is left half-written. Read it back via GetRealm to make sure
+	// the on-disk state agrees with the in-memory result.
+	persisted, getErr := r.GetRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: realmName},
+	})
+	if getErr != nil {
+		t.Fatalf("GetRealm() failed: %v", getErr)
+	}
+	if persisted.Status.State != intmodel.RealmStateReady {
+		t.Errorf("persisted state = %v, want Ready", persisted.Status.State)
+	}
+	if persisted.Status.CgroupPath == "" {
+		t.Error("persisted cgroupPath is empty, want non-empty")
 	}
 }

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -52,8 +52,13 @@ func (r *Exec) provisionNewRealm(realm intmodel.Realm) (intmodel.Realm, error) {
 		return intmodel.Realm{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateRealmMetadata, err)
 	}
 
-	// Create realm namespace
-	if err := r.createRealmContainerdNamespace(realm); err != nil {
+	// Create realm namespace. A pre-existing containerd namespace is benign on the
+	// idempotent kuke init path — kuke-system.kukeon.io is routinely seeded by
+	// `ctr -n kuke-system.kukeon.io images import` before init runs. Treat it as
+	// a no-op so we still proceed to cgroup creation and the Ready transition,
+	// matching the symmetry of ensureRealmContainerdNamespace.
+	if err := r.createRealmContainerdNamespace(realm); err != nil &&
+		!errors.Is(err, errdefs.ErrNamespaceAlreadyExists) {
 		// Set state to Failed and update metadata before returning error
 		realm.Status.State = intmodel.RealmStateFailed
 		_ = r.UpdateRealmMetadata(realm) // Best effort to save failed state


### PR DESCRIPTION
## Summary
- `provisionNewRealm` (`internal/controller/runner/provision.go:49`) bailed with `state=Failed` and an empty `cgroupPath` whenever `createRealmContainerdNamespace` returned `ErrNamespaceAlreadyExists` — even though the controller layer (`internal/controller/create_realm.go:87`) already treats that error as benign for `kuke init`'s idempotent re-run path. The result was that on every fresh `kuke init` where `ctr -n kuke-system.kukeon.io images import` had pre-seeded the namespace (i.e., the standard documented bootstrap), the daemon's own home realm was persisted as `Failed`, which `kuke get realms` reported back to the user and which broke any tooling gating on `STATE=Ready`.
- Fix: in `provisionNewRealm`, treat `ErrNamespaceAlreadyExists` from `createRealmContainerdNamespace` the same way `ensureRealmContainerdNamespace` already treats existing namespaces — log and continue. The cgroup is then created and the realm transitions to `Ready` with `cgroupPath` populated, matching the per-issue suggested-fix shape.
- Adds an integration regression test (`TestCreateRealm_NamespacePreSeeded_PersistsReady`) that pre-creates the containerd namespace via a separate `ctr.Client` (mirroring the real `ctr -n <ns> images import` flow) and asserts the persisted metadata ends up `Ready` with non-empty `cgroupPath`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes
- [x] Smoke test from `CLAUDE.md` (rebuild kukeon-local:dev, import into `kuke-system.kukeon.io`, `kuke init`, then `kuke get realms` vs `kuke get realms --no-daemon`) — both paths report the kuke-system realm as `Ready` with `/kukeon/kuke-system` cgroup, identical byte-for-byte.
- [x] Bug-trigger reproduction: with the containerd namespace pre-existing and `/opt/kukeon/kuke-system/metadata.json` deleted (the conditions that make `runner.GetRealm` take the provisionNewRealm branch), re-run `kuke init` — system hierarchy now reports `realm cgroup: created` (was `missing` before fix), and `metadata.json` persists `state: 2` (Ready) with `cgroupPath: "/kukeon/kuke-system"` (was `state: 4` (Failed) with no `cgroupPath` before fix).

Closes #94