### PR TITLE
fix: warn-and-skip empty ContainerdID in kill/stop to match delete/purge policy

### DIFF
--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -119,7 +119,13 @@ func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		// Use ContainerdID from spec
 		containerID := containerSpec.ContainerdID
 		if containerID == "" {
-			return intmodel.Cell{}, fmt.Errorf("container %q has empty ContainerdID", containerSpec.ID)
+			r.logger.WarnContext(
+				r.ctx,
+				"container has empty ContainerdID, skipping",
+				"container",
+				containerSpec.ID,
+			)
+			continue
 		}
 
 		// Use container name with UUID for containerd operations
@@ -370,7 +376,13 @@ func (r *Exec) KillContainer(cell intmodel.Cell, containerID string) error {
 	// Use ContainerdID from spec
 	containerdID := foundContainerSpec.ContainerdID
 	if containerdID == "" {
-		return fmt.Errorf("container %q has empty ContainerdID", containerID)
+		r.logger.WarnContext(
+			r.ctx,
+			"container has empty ContainerdID, skipping",
+			"container",
+			containerID,
+		)
+		return nil
 	}
 
 	// Use containerd ID for containerd operations

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -134,7 +134,13 @@ func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		// Use ContainerdID from spec
 		containerID := containerSpec.ContainerdID
 		if containerID == "" {
-			return intmodel.Cell{}, fmt.Errorf("container %q has empty ContainerdID", containerSpec.ID)
+			r.logger.WarnContext(
+				r.ctx,
+				"container has empty ContainerdID, skipping",
+				"container",
+				containerSpec.ID,
+			)
+			continue
 		}
 
 		// Use container name with UUID for containerd operations
@@ -398,7 +404,13 @@ func (r *Exec) StopContainer(cell intmodel.Cell, containerID string) error {
 	// Use ContainerdID from spec
 	containerdID := foundContainerSpec.ContainerdID
 	if containerdID == "" {
-		return fmt.Errorf("container %q has empty ContainerdID", containerID)
+		r.logger.WarnContext(
+			r.ctx,
+			"container has empty ContainerdID, skipping",
+			"container",
+			containerID,
+		)
+		return nil
 	}
 
 	// Use containerd ID for containerd operations


### PR DESCRIPTION
## Summary
- `KillCell`/`StopCell` per-container loops bail out the whole cell with a hard error the first time they hit an empty `ContainerdID`. That state is reachable through any apply that aborts after cell-cgroup creation but before the per-container create step (image pull failure, OCI spec rejection, network setup failure). `delete_cell.go:117-126` and `purge_cell.go:153` already warn-and-skip that case, so the natural `kuke kill && kuke delete` cleanup only works because the user knows to ignore `kill`'s error and run `delete` anyway. Aligns kill/stop with the delete/purge policy: per-cell loops warn-and-`continue`; per-container `KillContainer`/`StopContainer` warn and return `nil` (successful no-op for a never-created container).
- `start.go` is intentionally left as-is per the issue: starting a container that was never created in containerd is a real error, not a recoverable skip.
- Helper extraction from the issue's optional follow-up is deferred — kept the change minimal and mirroring the existing `delete_cell.go` shape verbatim.

## Notable judgment calls
- For the single-container `KillContainer`/`StopContainer` path there's no loop to `continue` in, so I return `nil` after the warn. Matches the spirit of the suggested fix (treat it the way `delete_cell` does) and fits `kuke kill cell` followed by `kuke delete cell` becoming a single error-free workflow when the cell got stuck pre-create.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l` on changed files: clean
- [x] `make test` passes (full suite, including `internal/controller/runner` and `internal/controller`)
- [x] `go test -count=1 ./internal/controller/runner/... ./internal/controller/...` passes without cache

No unit-level regression test added: the changed branches sit after `ensureClientConnected` and `GetRealm` in functions that have no existing unit tests in this package (kill/stop runner code is currently exercised only via integration paths with real containerd, same as `delete_cell.go`'s identical warn-and-skip branch). Adding a fake-`ctr.Client` harness solely to exercise this branch would expand scope well past the minimal fix and is left for the helper-consolidation follow-up the issue notes.

Closes #86