### PR TITLE
fix: build and import local kukeond image in e2e harness so init does not pull non-existent registry tag from dirty trees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,24 @@ kill:
 test:
 	go test $(shell go list ./... | grep -v /e2e)
 
+# Tag the e2e suite uses to refer to the local kukeond image. The e2e harness
+# imports it into containerd's kuke-system namespace before running `kuke init`,
+# so the test does not depend on a published registry tag matching `git
+# describe`.
+KUKEON_E2E_IMAGE_DOCKER_NAME ?= kukeon-local:e2e
+KUKEON_E2E_IMAGE ?= docker.io/library/$(KUKEON_E2E_IMAGE_DOCKER_NAME)
+
 e2e: test-e2e
 .PHONY: test-e2e
 test-e2e: kuke
+	@echo "Building local kukeond image $(KUKEON_E2E_IMAGE_DOCKER_NAME) for e2e"
+	docker build --build-arg VERSION=v0.0.0-e2e -t $(KUKEON_E2E_IMAGE_DOCKER_NAME) .
 	@echo "Running e2e tests using binaries in project root"
-	HOME=$(HOME) PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH) E2E_BIN_DIR=$(CURDIR) go test -v ./e2e
+	HOME=$(HOME) PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH) \
+		E2E_BIN_DIR=$(CURDIR) \
+		KUKEON_E2E_IMAGE=$(KUKEON_E2E_IMAGE) \
+		KUKEON_E2E_IMAGE_DOCKER_NAME=$(KUKEON_E2E_IMAGE_DOCKER_NAME) \
+		go test -v ./e2e
 
 tag:
 	git tag -s v$(KUKEON_VERSION) -m "Release version $(KUKEON_VERSION)"

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -243,8 +243,14 @@ func TestKuke_Init_VerifyState(t *testing.T) {
 		cleanupRealm(t, runPath, "default")
 	})
 
+	// Step 0.5: Stage the local kukeond image into containerd's kuke-system
+	// namespace. The Step 0 purge above wipes any prior image, and dev builds
+	// from a dirty/untagged tree resolve to a registry tag that doesn't exist,
+	// so init would fail on image pull without this.
+	kukeondImage := loadKukeondImageIntoContainerd(t)
+
 	// Step 1: Run init command
-	args := append(buildKukeRunPathArgs(runPath), "init")
+	args := append(buildKukeRunPathArgs(runPath), "init", "--kukeond-image", kukeondImage)
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Verify bootstrap report output contains expected content

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -157,6 +157,66 @@ func buildKukeRunPathArgs(runPath string) []string {
 	return []string{"--run-path", runPath}
 }
 
+// loadKukeondImageIntoContainerd stages the local kukeond image into the
+// kuke-system containerd namespace and returns the fully-qualified image
+// reference to pass via `kuke init --kukeond-image`. It skips the test when
+// the harness env vars are unset (running `go test ./e2e` without the
+// `make e2e` wrapper) or when `docker` / `ctr` aren't on PATH. `kuke init`
+// otherwise resolves the kukeond image from `git describe` output, which
+// fails on dirty/untagged dev trees because that ref does not exist in any
+// registry.
+func loadKukeondImageIntoContainerd(t *testing.T) string {
+	t.Helper()
+
+	image := os.Getenv("KUKEON_E2E_IMAGE")
+	dockerName := os.Getenv("KUKEON_E2E_IMAGE_DOCKER_NAME")
+	if image == "" || dockerName == "" {
+		t.Skip(
+			"KUKEON_E2E_IMAGE / KUKEON_E2E_IMAGE_DOCKER_NAME unset; " +
+				"run via 'make e2e' (which builds the local kukeond image) " +
+				"or set both env vars manually",
+		)
+	}
+
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil {
+		t.Skipf("docker binary not found, skipping kukeond image staging: %v", err)
+	}
+	ctrPath, err := exec.LookPath(ctr)
+	if err != nil {
+		t.Skipf("ctr binary not found, skipping kukeond image staging: %v", err)
+	}
+
+	tarPath := filepath.Join(t.TempDir(), "kukeond.tar")
+
+	saveCtx, saveCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer saveCancel()
+	saveCmd := exec.CommandContext(saveCtx, dockerPath, "save", "-o", tarPath, dockerName)
+	if out, saveErr := saveCmd.CombinedOutput(); saveErr != nil {
+		t.Fatalf(
+			"docker save %q failed: %v\noutput:\n%s\n"+
+				"hint: 'make e2e' builds this image; if running go test directly, build it first",
+			dockerName, saveErr, string(out),
+		)
+	}
+
+	importCtx, importCancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer importCancel()
+	importCmd := exec.CommandContext(
+		importCtx, ctrPath,
+		"--namespace", consts.KukeSystemRealmNamespace,
+		"images", "import", tarPath,
+	)
+	if out, importErr := importCmd.CombinedOutput(); importErr != nil {
+		t.Fatalf(
+			"ctr -n %s images import %q failed: %v\noutput:\n%s",
+			consts.KukeSystemRealmNamespace, tarPath, importErr, string(out),
+		)
+	}
+
+	return image
+}
+
 // verifyContainerdNamespace verifies containerd namespace exists by running ctr ns ls.
 func verifyContainerdNamespace(t *testing.T, namespace string) bool {
 	t.Helper()


### PR DESCRIPTION
## Summary
- `TestKuke_Init_VerifyState` ran `kuke init` without `--kukeond-image`, so the daemon fell back to `ghcr.io/eminwux/kukeon:<git-describe>`. Any dirty or untagged dev tree resolves to a tag the registry never received (e.g. `v0.2.4-1-g462f83a-dirty`), and the test fails with `failed to resolve reference … not found`.
- `make test-e2e` now builds a deterministic-tagged `kukeon-local:e2e` image (mirroring the smoke-test recipe in `CLAUDE.md`) and exports `KUKEON_E2E_IMAGE` / `KUKEON_E2E_IMAGE_DOCKER_NAME` to the test process.
- The test reads those env vars, `docker save`s the image, `ctr -n kuke-system.kukeon.io images import`s it after Step 0 purge (which would otherwise wipe it), then passes the resolved ref via `--kukeond-image`. If the env vars or `docker`/`ctr` are unavailable (someone running `go test ./e2e` directly), the test skips with a hint rather than failing.

## Notable judgment calls
- Image name: `kukeon-local:e2e` (not the `kukeon-local:dev` used in the smoke-test) so a developer's interactive smoke-test image and the e2e harness's image don't trample each other.
- Kept the existing Step 0 purge — it cleans up residual state from prior runs. Image staging is moved to a new Step 0.5 so it lands after the purge wipes the namespace and before init needs it.
- Test does the `docker save | ctr import` itself rather than the Makefile pre-loading the image: the Step 0 purge of `realm kuke-system` deletes the namespace and its images, so a Makefile-time import wouldn't survive.

## Test plan
- [ ] `go build ./...` clean
- [ ] `go vet ./...` clean
- [ ] `make test` passes
- [ ] On a deliberately dirty tree (`touch foo && make kuke && make kuke`), run `sudo env "PATH=/usr/local/go/bin:\$PATH" HOME=\$HOME make e2e` — `TestKuke_Init_VerifyState` now passes instead of failing on a `ghcr.io/eminwux/kukeon:v…-dirty: not found` pull.
- [ ] `go test ./e2e -run TestKuke_Init_VerifyState` (no env, no Makefile) reports SKIP with the env-var hint rather than failing.

Closes #98