### PR TITLE
feat: drive kuke attach in-process via sbsh/pkg/attach

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -347,8 +347,6 @@ var (
 	KUKE_ATTACH_CELL = DefineKV("KUKE_ATTACH_CELL", "kuke/attach/cell")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_ATTACH_CONTAINER = DefineKV("KUKE_ATTACH_CONTAINER", "kuke/attach/container")
-	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_ATTACH_SB_BINARY = DefineKV("KUKE_ATTACH_SB_BINARY", "kuke/attach/sbBinary", "sb")
 
 	// Stop command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -16,9 +16,9 @@
 
 // Package attach implements the `kuke attach` thin sbsh client subcommand.
 // The daemon validates the target's Attachable gate and returns the host
-// path of the per-container sbsh control socket; this subcommand opens the
-// socket via the on-host `sb` binary using syscall.Exec, so TTY/signal
-// handling falls through to sb directly. Bytes never traverse kukeond's
+// path of the per-container sbsh control socket; this subcommand drives
+// the interactive attach loop in-process via sbsh's pkg/attach library,
+// so kuke needs no on-host `sb` binary. Bytes never traverse kukeond's
 // RPC.
 package attach
 
@@ -27,16 +27,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"sort"
 	"strings"
-	"syscall"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/eminwux/sbsh/pkg/attach"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -44,14 +43,15 @@ import (
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
-// MockExecKey is used to inject a mock execFn via context in tests, so the
-// real syscall.Exec (which would replace the test binary) is bypassed.
-type MockExecKey struct{}
+// MockRunKey is used to inject a mock runFn via context in tests, so the
+// real pkg/attach.Run (which would open a TTY and connect to a real
+// control socket) is bypassed.
+type MockRunKey struct{}
 
-// execFn replaces the running process with the named binary, à la syscall.Exec.
-// Returning an error means the exec call itself failed; on success the
-// function does not return.
-type execFn func(argv0 string, argv []string, envv []string) error
+// runFn drives the in-process sbsh attach loop. Returns nil on a clean
+// detach / context cancel and any unrecoverable controller error
+// otherwise.
+type runFn func(ctx context.Context, opts attach.Options) error
 
 // NewAttachCmd builds the `kuke attach` cobra command.
 func NewAttachCmd() *cobra.Command {
@@ -76,9 +76,6 @@ func NewAttachCmd() *cobra.Command {
 	cmd.Flags().String("container", "",
 		"Container within the cell to attach to (omit to auto-pick the only non-root attachable)")
 	_ = viper.BindPFlag(config.KUKE_ATTACH_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
-	cmd.Flags().String("sb-binary", config.KUKE_ATTACH_SB_BINARY.Default,
-		"Path to the on-host sb client binary (looked up on $PATH if not absolute)")
-	_ = viper.BindPFlag(config.KUKE_ATTACH_SB_BINARY.ViperKey, cmd.Flags().Lookup("sb-binary"))
 
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
@@ -95,7 +92,6 @@ func runAttach(cmd *cobra.Command, _ []string) error {
 	stack := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_STACK.ViperKey))
 	cell := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_CELL.ViperKey))
 	container := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_CONTAINER.ViperKey))
-	sbBinary := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_SB_BINARY.ViperKey))
 
 	if realm == "" {
 		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
@@ -108,9 +104,6 @@ func runAttach(cmd *cobra.Command, _ []string) error {
 	}
 	if cell == "" {
 		return fmt.Errorf("%w (--cell)", errdefs.ErrCellNameRequired)
-	}
-	if sbBinary == "" {
-		sbBinary = config.KUKE_ATTACH_SB_BINARY.Default
 	}
 
 	client, err := resolveClient(cmd)
@@ -141,15 +134,13 @@ func runAttach(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("daemon returned empty HostSocketPath for container %q", container)
 	}
 
-	sbPath, err := resolveSbBinary(sbBinary)
-	if err != nil {
-		return err
-	}
-
-	exe := resolveExec(cmd)
-	argv := []string{sbPath, "attach", "--socket", result.HostSocketPath}
-	// On success exe replaces the current process and never returns.
-	return exe(sbPath, argv, os.Environ())
+	run := resolveRun(cmd)
+	return run(cmd.Context(), attach.Options{
+		SocketPath: result.HostSocketPath,
+		Stdin:      os.Stdin,
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
+	})
 }
 
 // pickAttachableContainer enumerates the cell's containers and returns the
@@ -187,20 +178,6 @@ func pickAttachableContainer(
 	}
 }
 
-// resolveSbBinary returns the absolute path of the sb client binary. If the
-// caller supplied an absolute path it is used verbatim; otherwise the name
-// is looked up on $PATH so operators can drop a binary anywhere.
-func resolveSbBinary(name string) (string, error) {
-	if strings.ContainsRune(name, os.PathSeparator) {
-		return name, nil
-	}
-	path, err := exec.LookPath(name)
-	if err != nil {
-		return "", fmt.Errorf("locate sb client binary %q on PATH: %w", name, err)
-	}
-	return path, nil
-}
-
 func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
@@ -208,11 +185,11 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
-func resolveExec(cmd *cobra.Command) execFn {
-	if mock, ok := cmd.Context().Value(MockExecKey{}).(execFn); ok {
+func resolveRun(cmd *cobra.Command) runFn {
+	if mock, ok := cmd.Context().Value(MockRunKey{}).(runFn); ok {
 		return mock
 	}
-	return syscall.Exec
+	return attach.Run
 }
 
 func buildContainerDoc(name, realm, space, stack, cell string) v1beta1.ContainerDoc {

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -19,8 +19,6 @@ package attach_test
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -28,6 +26,7 @@ import (
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	sbshattach "github.com/eminwux/sbsh/pkg/attach"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -63,23 +62,22 @@ func (f *fakeClient) AttachContainer(
 	return f.attachContainerFn(doc)
 }
 
-// execCapture records the argv passed to syscall.Exec and returns nil so the
-// test treats the call as success (the real syscall.Exec never returns on
-// success, so nil is the in-test analogue).
-type execCapture struct {
+// runCapture records the Options passed to pkg/attach.Run and returns
+// nil so the test treats the call as a clean detach. The real Run would
+// open the user's TTY and connect to a control socket; bypassing it
+// keeps the test hermetic.
+type runCapture struct {
 	calls int
-	argv0 string
-	argv  []string
+	opts  sbshattach.Options
 }
 
-func (e *execCapture) fn(argv0 string, argv []string, _ []string) error {
-	e.calls++
-	e.argv0 = argv0
-	e.argv = argv
+func (r *runCapture) fn(_ context.Context, opts sbshattach.Options) error {
+	r.calls++
+	r.opts = opts
 	return nil
 }
 
-func newCmdWithCtx(t *testing.T, fc *fakeClient, exec *execCapture) *cobra.Command {
+func newCmdWithCtx(t *testing.T, fc *fakeClient, run *runCapture) *cobra.Command {
 	t.Helper()
 
 	cmd := attachcmd.NewAttachCmd()
@@ -87,8 +85,8 @@ func newCmdWithCtx(t *testing.T, fc *fakeClient, exec *execCapture) *cobra.Comma
 	if fc != nil {
 		ctx = context.WithValue(ctx, attachcmd.MockControllerKey{}, kukeonv1.Client(fc))
 	}
-	if exec != nil {
-		ctx = context.WithValue(ctx, attachcmd.MockExecKey{}, attachcmd.ExecFn(exec.fn))
+	if run != nil {
+		ctx = context.WithValue(ctx, attachcmd.MockRunKey{}, attachcmd.RunFn(run.fn))
 	}
 	cmd.SetContext(ctx)
 	cmd.SilenceErrors = true
@@ -113,25 +111,20 @@ func TestAttach_SingleNonRootAttachable_Succeeds(t *testing.T) {
 			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
 		},
 	}
-	exec := &execCapture{}
-	cmd := newCmdWithCtx(t, fc, exec)
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--sb-binary", "/usr/local/bin/sb",
 	})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if exec.calls != 1 {
-		t.Fatalf("exec called %d times, want 1", exec.calls)
+	if run.calls != 1 {
+		t.Fatalf("attach.Run called %d times, want 1", run.calls)
 	}
-	wantArgv := []string{"/usr/local/bin/sb", "attach", "--socket", testHostSocket}
-	if !strSliceEq(exec.argv, wantArgv) {
-		t.Errorf("argv = %v, want %v", exec.argv, wantArgv)
-	}
-	if exec.argv0 != "/usr/local/bin/sb" {
-		t.Errorf("argv0 = %q, want %q", exec.argv0, "/usr/local/bin/sb")
+	if run.opts.SocketPath != testHostSocket {
+		t.Errorf("Options.SocketPath = %q, want %q", run.opts.SocketPath, testHostSocket)
 	}
 }
 
@@ -147,11 +140,10 @@ func TestAttach_AmbiguousCandidates_ErrorsWithList(t *testing.T) {
 			}, nil
 		},
 	}
-	exec := &execCapture{}
-	cmd := newCmdWithCtx(t, fc, exec)
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--sb-binary", "/usr/local/bin/sb",
 	})
 
 	err := cmd.Execute()
@@ -166,8 +158,8 @@ func TestAttach_AmbiguousCandidates_ErrorsWithList(t *testing.T) {
 	if got := err.Error(); !strings.Contains(got, "claude, shell") {
 		t.Errorf("error message %q missing sorted candidate list", got)
 	}
-	if exec.calls != 0 {
-		t.Errorf("exec called %d times on ambiguous picker, want 0", exec.calls)
+	if run.calls != 0 {
+		t.Errorf("attach.Run called %d times on ambiguous picker, want 0", run.calls)
 	}
 }
 
@@ -183,19 +175,18 @@ func TestAttach_NoCandidate_Errors(t *testing.T) {
 			}, nil
 		},
 	}
-	exec := &execCapture{}
-	cmd := newCmdWithCtx(t, fc, exec)
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--sb-binary", "/usr/local/bin/sb",
 	})
 
 	err := cmd.Execute()
 	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
 		t.Fatalf("error %v does not unwrap to ErrAttachNoCandidate", err)
 	}
-	if exec.calls != 0 {
-		t.Errorf("exec called %d times on empty picker, want 0", exec.calls)
+	if run.calls != 0 {
+		t.Errorf("attach.Run called %d times on empty picker, want 0", run.calls)
 	}
 }
 
@@ -211,11 +202,10 @@ func TestAttach_RootContainerExcludedFromAutoPick(t *testing.T) {
 			}, nil
 		},
 	}
-	exec := &execCapture{}
-	cmd := newCmdWithCtx(t, fc, exec)
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--sb-binary", "/usr/local/bin/sb",
 	})
 
 	err := cmd.Execute()
@@ -236,20 +226,19 @@ func TestAttach_ExplicitContainer_NotAttachable_SurfacesSentinel(t *testing.T) {
 			return kukeonv1.AttachContainerResult{}, errdefs.ErrAttachNotSupported
 		},
 	}
-	exec := &execCapture{}
-	cmd := newCmdWithCtx(t, fc, exec)
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
 		"--container", "side",
-		"--sb-binary", "/usr/local/bin/sb",
 	})
 
 	err := cmd.Execute()
 	if !errors.Is(err, errdefs.ErrAttachNotSupported) {
 		t.Fatalf("error %v does not unwrap to ErrAttachNotSupported", err)
 	}
-	if exec.calls != 0 {
-		t.Errorf("exec called %d times on non-attachable target, want 0", exec.calls)
+	if run.calls != 0 {
+		t.Errorf("attach.Run called %d times on non-attachable target, want 0", run.calls)
 	}
 }
 
@@ -261,23 +250,21 @@ func TestAttach_ExplicitContainer_Attachable_Succeeds(t *testing.T) {
 			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
 		},
 	}
-	exec := &execCapture{}
-	cmd := newCmdWithCtx(t, fc, exec)
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
 		"--container", "shell",
-		"--sb-binary", "/usr/local/bin/sb",
 	})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if exec.calls != 1 {
-		t.Fatalf("exec called %d times, want 1", exec.calls)
+	if run.calls != 1 {
+		t.Fatalf("attach.Run called %d times, want 1", run.calls)
 	}
-	wantArgv := []string{"/usr/local/bin/sb", "attach", "--socket", testHostSocket}
-	if !strSliceEq(exec.argv, wantArgv) {
-		t.Errorf("argv = %v, want %v", exec.argv, wantArgv)
+	if run.opts.SocketPath != testHostSocket {
+		t.Errorf("Options.SocketPath = %q, want %q", run.opts.SocketPath, testHostSocket)
 	}
 }
 
@@ -323,7 +310,7 @@ func TestAttach_MissingFlags(t *testing.T) {
 			t.Setenv("KUKE_ATTACH_STACK", "")
 			t.Setenv("KUKE_ATTACH_CELL", "")
 
-			cmd := newCmdWithCtx(t, &fakeClient{}, &execCapture{})
+			cmd := newCmdWithCtx(t, &fakeClient{}, &runCapture{})
 			cmd.SetArgs(tc.args)
 
 			err := cmd.Execute()
@@ -332,60 +319,4 @@ func TestAttach_MissingFlags(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestResolveSbBinary_AbsolutePath_PassesThrough(t *testing.T) {
-	got, err := attachcmd.ResolveSbBinaryForTest("/opt/sb/bin/sb")
-	if err != nil {
-		t.Fatalf("ResolveSbBinary returned error: %v", err)
-	}
-	if got != "/opt/sb/bin/sb" {
-		t.Errorf("ResolveSbBinary = %q, want %q", got, "/opt/sb/bin/sb")
-	}
-}
-
-func TestResolveSbBinary_PathLookup_FindsBinaryOnPATH(t *testing.T) {
-	dir := t.TempDir()
-	binPath := filepath.Join(dir, "sb-test")
-	// Create an empty executable file. exec.LookPath only checks for the
-	// executable bit, so we don't need real content.
-	if err := writeExecutable(binPath); err != nil {
-		t.Fatalf("create test binary: %v", err)
-	}
-	t.Setenv("PATH", dir)
-
-	got, err := attachcmd.ResolveSbBinaryForTest("sb-test")
-	if err != nil {
-		t.Fatalf("ResolveSbBinary returned error: %v", err)
-	}
-	if got != binPath {
-		t.Errorf("ResolveSbBinary = %q, want %q", got, binPath)
-	}
-}
-
-func TestResolveSbBinary_PathLookup_MissingBinary_Errors(t *testing.T) {
-	t.Setenv("PATH", t.TempDir())
-	if _, err := attachcmd.ResolveSbBinaryForTest("definitely-not-on-path"); err == nil {
-		t.Fatal("ResolveSbBinary returned nil, want error for missing binary")
-	}
-}
-
-func strSliceEq(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func writeExecutable(path string) error {
-	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o755)
-	if err != nil {
-		return err
-	}
-	return f.Close()
 }

--- a/cmd/kuke/attach/export_test.go
+++ b/cmd/kuke/attach/export_test.go
@@ -16,14 +16,8 @@
 
 package attach
 
-// ExecFn is the test-visible alias of the unexported execFn type. Tests
-// build values of this type and store them under MockExecKey to bypass
-// the real syscall.Exec, which would replace the test binary on success.
-type ExecFn = execFn
-
-// ResolveSbBinaryForTest exposes resolveSbBinary to the external _test
-// package so the PATH-lookup vs absolute-path branches can be exercised
-// without going through the full cobra entry point.
-func ResolveSbBinaryForTest(name string) (string, error) {
-	return resolveSbBinary(name)
-}
+// RunFn is the test-visible alias of the unexported runFn type. Tests
+// build values of this type and store them under MockRunKey to bypass
+// the real pkg/attach.Run, which would open the user's TTY and connect
+// to a real control socket.
+type RunFn = runFn

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -33,13 +33,13 @@ import (
 
 // sbshDetachSequence is the keystroke pair that the sbsh client filter
 // recognises as a request to detach (Ctrl+] Ctrl+], adjacent). Forwarded
-// verbatim by the test so the on-host `sb attach` filter triggers.
+// verbatim by the test so the in-process pkg/attach filter triggers.
 var sbshDetachSequence = []byte{0x1d, 0x1d}
 
 // attachConnectGrace is how long the test waits between starting `kuke attach`
-// and sending the detach sequence. Long enough for syscall.Exec into `sb` and
-// the unix-socket handshake to complete on a busy CI runner; short enough that
-// a hung scenario surfaces quickly.
+// and sending the detach sequence. Long enough for the in-process pkg/attach
+// loop to enter raw mode and complete the unix-socket handshake on a busy CI
+// runner; short enough that a hung scenario surfaces quickly.
 const attachConnectGrace = 2 * time.Second
 
 // attachExitTimeout caps how long the test waits for `kuke attach` to exit
@@ -112,14 +112,12 @@ func requireSbshHasPostMergeFlags(t *testing.T, hostSbsh string) {
 // for `kuke attach`: it boots a cell that contains an Attachable container,
 // drives `kuke attach` over a real PTY, sends sbsh's detach keystroke
 // (Ctrl+] Ctrl+]), and verifies that `kuke attach` exits cleanly while the
-// underlying container task remains RUNNING. Requires the host `sbsh` and
-// `sb` binaries on PATH; the test is skipped if either is missing.
+// underlying container task remains RUNNING. Requires the host `sbsh`
+// binary on PATH (still used to populate the per-container sbsh cache);
+// the test is skipped if it is missing. No on-host `sb` binary is needed
+// — `kuke attach` drives the attach loop in-process via sbsh's pkg/attach.
 func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	t.Parallel()
-
-	if _, err := exec.LookPath("sb"); err != nil {
-		t.Skipf("sb binary not found on PATH (required by `kuke attach`): %v", err)
-	}
 
 	// Setup: isolated runPath, unique resource names, in-process controller
 	// (`--no-daemon`) so the sbsh cache and per-container socket live under
@@ -162,7 +160,7 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 
 	// Step 3: confirm the per-container sbsh socket is in place. The runner
 	// creates the metadata dir at provision time and sbsh binds the socket
-	// inside the container at task start. If this is missing, `sb attach`
+	// inside the container at task start. If this is missing, pkg/attach
 	// would fail in a way that's hard to attribute, so check explicitly.
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -184,9 +182,11 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 		)...)
 	t.Cleanup(session.Close)
 
-	// Wait for sb attach to take over the PTY before sending the keystroke.
-	// Without this grace, the bytes can race the syscall.Exec into sb and
-	// land on the bare `kuke attach` process, which discards them.
+	// Wait for the in-process pkg/attach loop to take over the PTY before
+	// sending the keystroke. Without this grace, the bytes can race
+	// pkg/attach's raw-mode setup and land before its filter is wired up,
+	// in which case the detach sequence is forwarded verbatim instead of
+	// triggering a clean exit.
 	time.Sleep(attachConnectGrace)
 
 	if err = session.Write(sbshDetachSequence); err != nil {
@@ -204,8 +204,8 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	}
 
 	// Step 5: assert the container task is still RUNNING. The detach should
-	// only tear down the sb client; the workload (sleep wrapped by sbsh
-	// terminal) keeps running inside the container.
+	// only tear down the in-process pkg/attach loop; the workload (sleep
+	// wrapped by sbsh terminal) keeps running inside the container.
 	cellID, err := getCellIDNoDaemon(t, runPath, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("get cell ID: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
+	github.com/eminwux/sbsh v0.8.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1
@@ -73,6 +74,7 @@ require (
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/eminwux/sbsh v0.8.0 h1:PI0tUwgkYcdFlug6Ga3XhbqiHY/JqrPT9QVOEIhTFYY=
+github.com/eminwux/sbsh v0.8.0/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -252,6 +254,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.38.0 h1:PQ5pkm/rLO6HnxFR7N2lJHOZX6Kez5Y1gDSJla6jo7Q=
+golang.org/x/term v0.38.0/go.mod h1:bSEAKrOT1W+VSu9TSCMtoGEOUcKxOKgl3LE5QEF/xVg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=


### PR DESCRIPTION
## Summary

- `kuke attach` now drives the interactive sbsh attach loop in-process via `github.com/eminwux/sbsh/pkg/attach.Run` (sbsh v0.8.0, `pkg/attach` from sbsh#155). The `syscall.Exec` hop into the on-host `sb` binary is gone — kuke is one less subprocess and one less binary to ship.
- Drops `--sb-binary`, `KUKE_ATTACH_SB_BINARY`, `resolveSbBinary`, the `execFn` / `MockExecKey` test plumbing, and their unit tests. Replaces them with a single `runFn` / `MockRunKey` seam that swaps in a fake `pkg/attach.Run` for the unit tests; behavioural assertions migrate from "exec'd sb attach with this argv" to "called pkg/attach.Run with this Options.SocketPath".
- `e2e/e2e_kuke_attach_test.go` no longer probes for `sb` on PATH (the in-container `sbsh` requirement is unchanged). Comments updated to reflect that the detach keystroke filter and PTY takeover now happen inside the kuke process.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — all unit packages green
- [x] `go test -v ./cmd/kuke/attach/...` — every attach unit test still passes against the new `pkg/attach.Run` seam
- [x] pre-commit (golangci-lint, go-mod-tidy, addlicense, gofmt) — green
- [ ] `make e2e TestKuke_AttachDetach_KeepsTaskRunning` — fails locally with `sbsh socket … did not appear within 10s` in step 3 (`waitForSocket`), **before** `kuke attach` is invoked. Verified the same failure reproduces on `origin/main` via a clean worktree, so it is a pre-existing host/sbsh setup issue unrelated to this refactor. Reviewer should rerun once the underlying socket-staging issue lands.

Closes #84