### PR TITLE
fix: align attachable wrapper with renamed sbsh terminal flags

### DIFF
--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -90,21 +90,25 @@ func stageHostSbsh(t *testing.T, runPath string) {
 	}
 }
 
-// requireSbshHasPostMergeFlags ensures the host sbsh carries the flag set
-// the wrapper injected at #69 assumes (post sbsh#153, which added
-// `--capture-file` to the `sbsh terminal` subcommand). Without this guard a
-// stale sbsh on PATH manifests as `unknown flag: ...` deep inside the work
-// container's task, surfaced here only as a `waitForSocket` timeout — hard
-// to attribute. Skipping with a named cause saves the dig.
+// requireSbshHasPostMergeFlags ensures the host sbsh carries every flag the
+// in-container wrapper (`internal/ctr/attachable.go`) injects into the
+// workload's argv. Without this guard a stale or newer-renamed sbsh on PATH
+// manifests as `unknown flag: ...` deep inside the work container's task,
+// surfaced here only as a `waitForSocket` timeout — hard to attribute.
+// Skipping with a named cause saves the dig.
 func requireSbshHasPostMergeFlags(t *testing.T, hostSbsh string) {
 	t.Helper()
 	out, err := exec.Command(hostSbsh, "terminal", "--help").CombinedOutput()
 	if err != nil {
 		t.Fatalf("sbsh terminal --help failed: %v\noutput:\n%s", err, out)
 	}
-	if !strings.Contains(string(out), "--capture-file") {
-		t.Skipf("host sbsh %q lacks `sbsh terminal --capture-file` (sbsh#153); "+
-			"upgrade sbsh on PATH and retry", hostSbsh)
+	help := string(out)
+	for _, flag := range []string{"--socket", "--capture-file", "--log-file"} {
+		if !strings.Contains(help, flag) {
+			t.Skipf("host sbsh %q lacks `sbsh terminal %s`; "+
+				"upgrade or downgrade sbsh on PATH to a build whose `terminal` "+
+				"subcommand carries every wrapper flag and retry", hostSbsh, flag)
+		}
 	}
 }
 

--- a/internal/ctr/attachable.go
+++ b/internal/ctr/attachable.go
@@ -122,9 +122,9 @@ func withAttachableArgsWrap() oci.SpecOpts {
 			AttachableBinaryPath,
 			AttachableSubcommand,
 			"--run-path", AttachableTTYDir,
-			"--terminal-socket", AttachableSocketPath,
+			"--socket", AttachableSocketPath,
 			"--capture-file", AttachableCapturePath,
-			"--terminal-logfile", AttachableLogfilePath,
+			"--log-file", AttachableLogfilePath,
 			"--",
 		}
 		s.Process.Args = append(wrapped, original...)

--- a/internal/ctr/attachable_test.go
+++ b/internal/ctr/attachable_test.go
@@ -192,9 +192,9 @@ func TestBuildContainerSpec_AttachableTrue_MountsAndArgsWrap(t *testing.T) {
 				ctr.AttachableBinaryPath,
 				ctr.AttachableSubcommand,
 				"--run-path", ctr.AttachableTTYDir,
-				"--terminal-socket", ctr.AttachableSocketPath,
+				"--socket", ctr.AttachableSocketPath,
 				"--capture-file", ctr.AttachableCapturePath,
-				"--terminal-logfile", ctr.AttachableLogfilePath,
+				"--log-file", ctr.AttachableLogfilePath,
 				"--",
 			}
 			if len(spec.Process.Args) < len(wantPrefix) {
@@ -235,9 +235,9 @@ func TestBuildContainerSpec_AttachableTrue_EmptyImageArgs(t *testing.T) {
 		ctr.AttachableBinaryPath,
 		ctr.AttachableSubcommand,
 		"--run-path", ctr.AttachableTTYDir,
-		"--terminal-socket", ctr.AttachableSocketPath,
+		"--socket", ctr.AttachableSocketPath,
 		"--capture-file", ctr.AttachableCapturePath,
-		"--terminal-logfile", ctr.AttachableLogfilePath,
+		"--log-file", ctr.AttachableLogfilePath,
 		"--",
 	}
 	if !reflect.DeepEqual(spec.Process.Args, want) {


### PR DESCRIPTION
## Summary

- The Attachable wrapper in `internal/ctr/attachable.go` injected `--terminal-socket` and `--terminal-logfile` into the workload's argv. Current `sbsh terminal` accepts `--socket` and `--log-file` instead — `--terminal-*` are unknown flags. The wrapped `sbsh terminal` exited with `unknown flag: --terminal-socket` before binding the control socket, so the per-container `tty/socket` inode never appeared on the host bind-mount source. `e2e/e2e_kuke_attach_test.go::waitForSocket` (10s grace) timed out without anything to attribute the failure to. Repro and root-cause analysis live in #116; verified by running the wrapped command directly under the host sbsh.
- The pre-flight `requireSbshHasPostMergeFlags` only checked for `--capture-file`, so a renamed sbsh on PATH passed the guard. Tightened it to assert every flag the wrapper depends on (`--socket`, `--capture-file`, `--log-file`); a host build that lacks any one of them now `t.Skip`s with a named cause instead of timing out 10s deep into the test.
- Unit-test expectations in `internal/ctr/attachable_test.go` updated to match the new wrapped argv prefix.

## Notable judgment calls

- Kept `requireSbshHasPostMergeFlags` as a `t.Skip` (not a `t.Fatal`). The function's whole point is to bail loudly when the host sbsh and the in-container wrapper drift apart; failing the suite would punish an operator running locally with a different sbsh build, which is a real expected case.
- This PR fixes the `waitForSocket` symptom #116 was filed for. After this PR, `TestKuke_AttachDetach_KeepsTaskRunning` advances past Step 3 and now fails at Step 4 with `Error: no terminal identifier provided; terminal name or ID must be specified` from the on-host `sb attach` invocation in `cmd/kuke/attach`. That is a separate sbsh-CLI evolution bug (the current `sb attach` requires `--name` or `--id` even when `--socket` is passed) on the very codepath PR #115 (open) is replacing with `pkg/attach.Run`; out of scope here.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` — all unit packages green
- [x] `go test ./internal/ctr/...` — both `TestBuildContainerSpec_AttachableTrue_*` cases assert the new wrapped argv prefix
- [x] pre-commit (`go fmt`, `go-mod-tidy`, `golangci-lint`, `addlicense`) — green
- [x] `sudo env "PATH=/usr/local/go/bin:\$PATH" HOME=\$HOME make e2e` — `TestKuke_AttachDetach_KeepsTaskRunning` no longer fails at `waitForSocket`; advances to Step 4. Other e2e failures (daemon-socket connect errors, `TestKuke_Init_VerifyState` "container already exists") reproduce identically on `origin/main` via `git worktree add /tmp/kukeon-main-check origin/main`, so they are pre-existing infra/state issues unrelated to this fix.

Closes #116