### PR TITLE
docs: refresh AttachContainerResult.HostSocketPath comment for tty/socket bind path

### DIFF
--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -543,10 +543,11 @@ type AttachContainerReply struct {
 // client needs to drive the sbsh terminal. Bytes never traverse this RPC —
 // the client opens HostSocketPath directly.
 type AttachContainerResult struct {
-	// HostSocketPath is the host path of the per-container sbsh control
-	// socket bind-mounted into the container at /run/sbsh.socket. Returned
-	// only when the target container has Attachable=true; otherwise the
-	// daemon errors with ErrAttachNotSupported.
+	// HostSocketPath is the host path of the per-container sbsh terminal
+	// socket. Inside the container the same inode is reachable at
+	// /run/kukeon/tty/socket via the tty directory bind mount. Returned only
+	// when the target container has Attachable=true; otherwise the daemon
+	// errors with ErrAttachNotSupported.
 	HostSocketPath string
 }
 


### PR DESCRIPTION
## Summary
- The doc on `AttachContainerResult.HostSocketPath` still claimed the in-container path was `/run/sbsh.socket`, which is the legacy single-file mount that PR #77 removed. The current bind is the directory `/run/kukeon/tty` with `socket` as an entry inside (`internal/ctr/attachable.go:40`, `internal/consts/consts.go:35`, `internal/util/fs/metadata.go:95`), so the in-container path is `/run/kukeon/tty/socket`. Refresh the comment to match.
- Pure doc-comment edit — no behavioral change.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test`

Closes #78