### PR TITLE
fix: tighten ensureCNIStateDir mode to 0o750 to match sibling CNI dirs

### DIFF
--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -526,7 +526,7 @@ func ensureSocketDir(socketPath string) error {
 // other CNI mounts (/opt/cni/net.d and /opt/cni/cache) are already created by
 // the earlier CNI bootstrap step.
 func ensureCNIStateDir() error {
-	if err := os.MkdirAll("/var/lib/cni", 0o755); err != nil {
+	if err := os.MkdirAll("/var/lib/cni", 0o750); err != nil {
 		return fmt.Errorf("create CNI state dir %q: %w", "/var/lib/cni", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- `internal/controller/bootstrap.go:529` created `/var/lib/cni` with `0o755`, but the sibling CNI dirs in `internal/cni/bootstrap.go:53,59,65` (`/opt/cni/net.d`, `/opt/cni/cache`, `/opt/cni/bin`) all use `0o750`. Aligning keeps host-local IPAM state consistent with the rest of the CNI tree and avoids leaving it world-readable.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test`

Closes #101