### PR TITLE
build: verify cni-plugins tarball checksum before extracting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt update \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/cni/bin \
- && curl -fsSL "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-${TARGETOS}-${TARGETARCH}-${CNI_PLUGINS_VERSION}.tgz" \
-    | tar -xz -C /opt/cni/bin
+ && CNI_PLUGINS_TGZ="cni-plugins-${TARGETOS}-${TARGETARCH}-${CNI_PLUGINS_VERSION}.tgz" \
+ && CNI_PLUGINS_URL="https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/${CNI_PLUGINS_TGZ}" \
+ && curl -fsSL -o "/tmp/${CNI_PLUGINS_TGZ}" "${CNI_PLUGINS_URL}" \
+ && curl -fsSL -o "/tmp/${CNI_PLUGINS_TGZ}.sha256" "${CNI_PLUGINS_URL}.sha256" \
+ && echo "$(awk '{print $1}' /tmp/${CNI_PLUGINS_TGZ}.sha256)  /tmp/${CNI_PLUGINS_TGZ}" | sha256sum -c - \
+ && tar -xz -C /opt/cni/bin -f "/tmp/${CNI_PLUGINS_TGZ}" \
+ && rm -f "/tmp/${CNI_PLUGINS_TGZ}" "/tmp/${CNI_PLUGINS_TGZ}.sha256"
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
## Summary
- The `cni-plugins` build stage in `Dockerfile:33-35` previously piped the upstream tarball straight from `curl` into `tar -xz` with no checksum verification, leaving the daemon image vulnerable to a compromised mirror or a transient download corruption.
- Download both the `.tgz` and the sibling `.tgz.sha256` published in the upstream `containernetworking/plugins` release, run `sha256sum -c` against the tarball before extraction, and clean up the temp files in the same `RUN` so no extra layer remains.
- Hash extraction uses `awk '{print $1}'` plus a re-emitted `sha256sum -c -` line so the verification is robust to either format the upstream may publish (`<hash>` alone or `<hash>  <filename>`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test`
- [x] `docker build --build-arg VERSION=v0.0.0-dev -t kukeon-checksum-test:dev .` — new step prints `cni-plugins-linux-amd64-v1.5.1.tgz: OK` and the build completes.

Closes #102