### PR TITLE
test: include --run-path in requireSbshHasPostMergeFlags pre-flight

### DIFF
--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -103,7 +103,7 @@ func requireSbshHasPostMergeFlags(t *testing.T, hostSbsh string) {
 		t.Fatalf("sbsh terminal --help failed: %v\noutput:\n%s", err, out)
 	}
 	help := string(out)
-	for _, flag := range []string{"--socket", "--capture-file", "--log-file"} {
+	for _, flag := range []string{"--run-path", "--socket", "--capture-file", "--log-file"} {
 		if !strings.Contains(help, flag) {
 			t.Skipf("host sbsh %q lacks `sbsh terminal %s`; "+
 				"upgrade or downgrade sbsh on PATH to a build whose `terminal` "+


### PR DESCRIPTION
## Summary
- The pre-flight in `e2e/e2e_kuke_attach_test.go:106` only checked three of the four flags `withAttachableArgsWrap` injects (`internal/ctr/attachable.go:121-128`), but its doc comment claims it covers "every flag the in-container wrapper injects". `--run-path` was missing — an independent rename of that flag in sbsh would have slipped past the guard and resurfaced as a `waitForSocket` timeout, the exact failure mode this skip is designed to attribute up front.
- Add `--run-path` to the slice (placed first to match the wrapper's own argv order).

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`make test\`
- [x] \`go vet ./e2e/...\` + \`go test -count=1 -run NONE ./e2e/...\` (e2e package compiles)

Closes #120