### PR TITLE
fix: reject cell hostNetwork peer with non-host explicit rootContainerId

### DIFF
--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1811,6 +1811,11 @@ func (r *Exec) ensureCellRootContainerSpec(cell intmodel.Cell) (intmodel.Contain
 				cell.Spec.RootContainerID,
 			)
 		}
+		// Reject the misalignment instead of silently overriding the
+		// user-provided root spec — see validateExplicitRootHostNetwork.
+		if err := validateExplicitRootHostNetwork(cell, rootSpec); err != nil {
+			return intmodel.ContainerSpec{}, err
+		}
 	} else {
 		// Create default root container spec
 		// Pass containerdID to set ContainerdID field, ID will be set to "root"

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -54,6 +54,28 @@ func cellWantsHostNetworkRoot(cell intmodel.Cell) bool {
 	return false
 }
 
+// validateExplicitRootHostNetwork enforces, for cells using explicit
+// rootContainerId, that the chosen root has HostNetwork=true whenever any
+// peer container has HostNetwork=true. The auto-default-root branch in
+// ensureCellRootContainerSpec already propagates host-network onto the
+// generated root, but the explicit-root branch reads the user's spec
+// verbatim — so a peer with HostNetwork=true alongside an explicit non-host
+// root would silently lose its host-network intent (peers join the root's
+// netns via JoinContainerNamespaces).
+func validateExplicitRootHostNetwork(cell intmodel.Cell, rootSpec intmodel.ContainerSpec) error {
+	if cell.Spec.RootContainerID == "" {
+		return nil
+	}
+	if cellWantsHostNetworkRoot(cell) && !rootSpec.HostNetwork {
+		return fmt.Errorf(
+			"%w: rootContainerId %q",
+			internalerrdefs.ErrExplicitRootHostNetworkMismatch,
+			cell.Spec.RootContainerID,
+		)
+	}
+	return nil
+}
+
 // StartCell starts the root container and all containers defined in the CellDoc.
 // The root container is started first, then all containers in doc.Spec.Containers are started.
 func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -19,8 +19,10 @@
 package runner
 
 import (
+	"errors"
 	"testing"
 
+	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
@@ -109,6 +111,85 @@ func TestCellWantsHostNetworkRoot(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := cellWantsHostNetworkRoot(tt.cell); got != tt.want {
 				t.Errorf("cellWantsHostNetworkRoot() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateExplicitRootHostNetwork covers the explicit-root branch's
+// host-network alignment guard from issue #103. Without it, a peer with
+// HostNetwork=true alongside an explicit non-host root would silently lose
+// its host-network intent — peers join the root's netns via
+// JoinContainerNamespaces, so the root owns the decision.
+func TestValidateExplicitRootHostNetwork(t *testing.T) {
+	tests := []struct {
+		name     string
+		cell     intmodel.Cell
+		rootSpec intmodel.ContainerSpec
+		wantErr  bool
+	}{
+		{
+			name: "no explicit root — auto-default branch handles propagation",
+			cell: intmodel.Cell{Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{
+				{ID: "a", HostNetwork: true},
+			}}},
+			rootSpec: intmodel.ContainerSpec{},
+			wantErr:  false,
+		},
+		{
+			name: "explicit root, no peer wants host-network",
+			cell: intmodel.Cell{Spec: intmodel.CellSpec{
+				RootContainerID: "c2",
+				Containers: []intmodel.ContainerSpec{
+					{ID: "c1"}, {ID: "c2"},
+				},
+			}},
+			rootSpec: intmodel.ContainerSpec{ID: "c2"},
+			wantErr:  false,
+		},
+		{
+			name: "explicit root host-network, peers default — fine, peers join host netns",
+			cell: intmodel.Cell{Spec: intmodel.CellSpec{
+				RootContainerID: "c2",
+				Containers: []intmodel.ContainerSpec{
+					{ID: "c1"}, {ID: "c2", HostNetwork: true},
+				},
+			}},
+			rootSpec: intmodel.ContainerSpec{ID: "c2", HostNetwork: true},
+			wantErr:  false,
+		},
+		{
+			name: "explicit root host-network, peer also host-network — aligned",
+			cell: intmodel.Cell{Spec: intmodel.CellSpec{
+				RootContainerID: "c2",
+				Containers: []intmodel.ContainerSpec{
+					{ID: "c1", HostNetwork: true}, {ID: "c2", HostNetwork: true},
+				},
+			}},
+			rootSpec: intmodel.ContainerSpec{ID: "c2", HostNetwork: true},
+			wantErr:  false,
+		},
+		{
+			name: "peer wants host-network but explicit root does not — reject",
+			cell: intmodel.Cell{Spec: intmodel.CellSpec{
+				RootContainerID: "c2",
+				Containers: []intmodel.ContainerSpec{
+					{ID: "c1", HostNetwork: true}, {ID: "c2"},
+				},
+			}},
+			rootSpec: intmodel.ContainerSpec{ID: "c2"},
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExplicitRootHostNetwork(tt.cell, tt.rootSpec)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateExplicitRootHostNetwork() err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && !errors.Is(err, internalerrdefs.ErrExplicitRootHostNetworkMismatch) {
+				t.Errorf("err = %v, want wrapped ErrExplicitRootHostNetworkMismatch", err)
 			}
 		})
 	}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -67,6 +67,14 @@ var (
 	ErrCreateCell              = errors.New("failed to create cell")
 	ErrCreateRootContainer     = errors.New("failed to create root container")
 	ErrNetworkConfigNotLoaded  = errors.New("network config not loaded")
+	// ErrExplicitRootHostNetworkMismatch fires when a cell pins its root via
+	// rootContainerId but the chosen root has HostNetwork=false while at
+	// least one peer container has HostNetwork=true. Because peers join the
+	// root's netns via JoinContainerNamespaces, a per-container-netns root
+	// would silently swallow the peer's host-network intent.
+	ErrExplicitRootHostNetworkMismatch = errors.New(
+		"explicit rootContainerId must have hostNetwork: true when any cell container has hostNetwork: true",
+	)
 	ErrCellNameRequired        = errors.New("cell name is required")
 	ErrContainerNameRequired   = errors.New("container name is required")
 	ErrInvalidImage            = errors.New("invalid image reference")


### PR DESCRIPTION
## Summary
- `internal/controller/runner/provision.go:1798-1813` previously accepted a cell with `rootContainerId` pointing at a non-host-network root even when peer containers had `hostNetwork: true`. Because peers join the root's netns via `JoinContainerNamespaces`, the peer's host-network intent would be silently dropped — the foot-gun called out in #103.
- The auto-default-root branch (`provision.go:1825-1831`) already propagates host-network onto its generated root via `cellWantsHostNetworkRoot`, but the explicit-root branch reads the user's spec verbatim, so the symmetric path was missing.
- Picked **option 1 (validation reject)** from the issue rather than option 2 (silent propagation): the explicit-root case has user-authored container specs, and silently flipping `c2.HostNetwork` from false to true overrides what the user wrote. Lower blast-radius default — surface the misalignment via a sentinel error, force the user to align the spec.

## Implementation
- New sentinel `ErrExplicitRootHostNetworkMismatch` in `internal/errdefs/errdefs.go` per the project convention against bare `errors.New` in package code for reusable concepts.
- New helper `validateExplicitRootHostNetwork(cell, rootSpec)` next to `cellWantsHostNetworkRoot` in `internal/controller/runner/start.go`.
- Helper called from `ensureCellRootContainerSpec` after the explicit-root lookup in `provision.go`.
- Five-case table-driven unit test in `start_test.go` covering: no-explicit-root pass-through, explicit-root with no peer host-network, explicit-host-network root with default peers, fully-aligned host-network root + peer, and the rejected misalignment.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`make test\`
- [x] \`go vet ./e2e/...\` + \`go test -count=1 -run NONE ./e2e/...\` (e2e package compiles)

(Smoke test \`kuke init\` not run — change is confined to cell-provision validation; \`/opt/kukeon\` layout and the daemon-parity \`kuke get realms\` views are untouched.)

Closes #103