### PR TITLE
refactor: drop unreachable RootContainerID guard in validateExplicitRootHostNetwork

### DIFF
--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -63,9 +63,6 @@ func cellWantsHostNetworkRoot(cell intmodel.Cell) bool {
 // root would silently lose its host-network intent (peers join the root's
 // netns via JoinContainerNamespaces).
 func validateExplicitRootHostNetwork(cell intmodel.Cell, rootSpec intmodel.ContainerSpec) error {
-	if cell.Spec.RootContainerID == "" {
-		return nil
-	}
 	if cellWantsHostNetworkRoot(cell) && !rootSpec.HostNetwork {
 		return fmt.Errorf(
 			"%w: rootContainerId %q",

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -129,14 +129,6 @@ func TestValidateExplicitRootHostNetwork(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "no explicit root — auto-default branch handles propagation",
-			cell: intmodel.Cell{Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{
-				{ID: "a", HostNetwork: true},
-			}}},
-			rootSpec: intmodel.ContainerSpec{},
-			wantErr:  false,
-		},
-		{
 			name: "explicit root, no peer wants host-network",
 			cell: intmodel.Cell{Spec: intmodel.CellSpec{
 				RootContainerID: "c2",


### PR DESCRIPTION
## Summary
- The leading `if cell.Spec.RootContainerID == "" { return nil }` in `validateExplicitRootHostNetwork` (`internal/controller/runner/start.go:65-77`) was unreachable in production: the only caller in `internal/controller/runner/provision.go:1798-1818` already gates on `cell.Spec.RootContainerID != ""` before invoking the helper. Removing it lets the next reader see the helper for what it is — a check tied to the explicit-root branch, not a general-purpose helper safe to call from anywhere.
- Drops the matching `"no explicit root — auto-default branch handles propagation"` test case in `start_test.go`, which was the only path exercising the now-removed guard. The four remaining cases continue to cover both pass and reject paths for the explicit-root branch.

## Notable judgment calls
- Took the **drop** option (rather than the alternative of adding a defensive-callability comment) because the helper's docstring already names its scope as "for cells using explicit rootContainerId" — keeping a guard for hypothetical other callers contradicts that docstring and invites the misread the issue warns about.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make test` (full unit suite; `internal/controller/runner` passes including the trimmed `TestValidateExplicitRootHostNetwork`)
- [x] `go test -c -o /dev/null ./e2e` (e2e compile-check)
- N/A: kukeond rebuild + `kuke init` + daemon-parity smoke — change is in pure validation logic, does not touch the build path, daemon, or anything under `/opt/kukeon`.

Closes #127