### PR TITLE
fix: include hostNetwork value in CNI-skip log line

### DIFF
--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -295,7 +295,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	// dance for them.
 	if !rootContainerWantsCNI(rootContainerSpec) {
 		skipFields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-		skipFields = append(skipFields, "space", spaceID, "realm", realmID, "pid", rootPID)
+		skipFields = append(skipFields, "space", spaceID, "realm", realmID, "pid", rootPID, "hostNetwork", rootContainerSpec.HostNetwork)
 		r.logger.InfoContext(
 			r.ctx,
 			"skipping CNI attach for host-network root container",


### PR DESCRIPTION
## Summary
- Append `hostNetwork=<bool>` to the `skipFields` slice on the CNI-skip branch in `internal/controller/runner/start.go` so the log line is self-documenting if `rootContainerWantsCNI` later grows additional skip reasons.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test`
- [ ] `make e2e` — not run; this is a one-field log addition with no behavioral change, so e2e adds no signal beyond the unit suite.
- [ ] `kuke init` smoke / daemon-parity check — not run; the change does not touch the build path, daemon serving logic, or anything the daemon reads from `/opt/kukeon`.

Closes #104