### PR TITLE
fix: chmod /var/lib/cni after MkdirAll so mode tightening applies on upgrade

### DIFF
--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -529,6 +529,13 @@ func ensureCNIStateDir() error {
 	if err := os.MkdirAll("/var/lib/cni", 0o750); err != nil {
 		return fmt.Errorf("create CNI state dir %q: %w", "/var/lib/cni", err)
 	}
+	// MkdirAll is a no-op when the dir already exists, so on upgrade from a
+	// prior install (or co-existing CNI installer) that left /var/lib/cni at
+	// 0o755, the mode would stay loose. Chmod here makes the tightening
+	// idempotent across upgrades.
+	if err := os.Chmod("/var/lib/cni", 0o750); err != nil {
+		return fmt.Errorf("chmod CNI state dir %q: %w", "/var/lib/cni", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `ensureCNIStateDir` calls `os.MkdirAll("/var/lib/cni", 0o750)` (added in #122). `MkdirAll` is a no-op when the directory already exists, so on hosts where `/var/lib/cni` was previously created at `0o755` (prior install, or another CNI installer), the mode tightening from #122 silently doesn't apply on upgrade.
- Add `os.Chmod("/var/lib/cni", 0o750)` after the `MkdirAll` so the tightening is idempotent across upgrades, matching what a cleanly-bootstrapped host already gets.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test`
- [ ] `make e2e` — not run; this is a one-line idempotence fix for a chmod-on-upgrade gap and the e2e harness bootstraps from a clean host where `MkdirAll` already lands the mode at `0o750`. e2e adds no signal beyond the unit suite for this case.
- [ ] `kuke init` smoke / daemon-parity check — not run; the change does not touch the build path, daemon serving logic, the bind-mount layout, or anything the daemon reads from `/opt/kukeon`. It only adds a chmod on `/var/lib/cni` (a host path the bootstrap creates before the daemon starts).

Closes #123