### PR TITLE
fix: tear down CNI bridge link on space/realm delete and purge

### DIFF
--- a/internal/cni/bridge.go
+++ b/internal/cni/bridge.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// BridgeRunner deletes a kernel bridge link by name. Implementations must be
+// idempotent: deleting an already-absent bridge is success, not an error.
+type BridgeRunner interface {
+	DeleteBridge(ctx context.Context, name string) error
+}
+
+// IPBridgeRunner shells out to the host `ip` binary to delete bridge links.
+// It mirrors the iproute2 invocation used by the standard CNI bridge plugin
+// at create time, so the create/teardown contract stays symmetric.
+type IPBridgeRunner struct{}
+
+// DeleteBridge runs `ip link delete <name> type bridge`. It treats the
+// "Cannot find device" error as success, so callers can invoke it without
+// first probing for the bridge.
+func (IPBridgeRunner) DeleteBridge(ctx context.Context, name string) error {
+	if name == "" {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "ip", "link", "delete", name, "type", "bridge")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	msg := strings.TrimSpace(string(out))
+	if strings.Contains(strings.ToLower(msg), "cannot find device") {
+		return nil
+	}
+	return fmt.Errorf("ip link delete %s: %w: %s", name, err, msg)
+}
+
+// TeardownNetwork removes the CNI network for networkName end-to-end: it reads
+// the bridge name from the conflist, removes the conflist file, and deletes
+// the kernel bridge link. The bridge name is read **before** the conflist is
+// removed so that a transient failure between steps still leaves enough state
+// to retry from. If configPath is empty the manager's default location is used.
+//
+// Each step is idempotent — a missing conflist, a conflist with no bridge
+// plugin, an empty `bridge` field, or an already-absent bridge are all treated
+// as success — so callers can invoke it on partially-cleaned-up state without
+// special-casing.
+func (m *Manager) TeardownNetwork(
+	ctx context.Context, runner BridgeRunner, networkName, configPath string,
+) error {
+	if networkName == "" {
+		return errors.New("network name is required")
+	}
+	if runner == nil {
+		runner = IPBridgeRunner{}
+	}
+	if configPath == "" {
+		configPath = filepath.Join(m.conf.CniConfigDir, networkName+".conflist")
+	}
+
+	bridge, readErr := m.ReadBridgeName(configPath)
+	if readErr != nil &&
+		!errors.Is(readErr, errdefs.ErrNetworkNotFound) &&
+		!errors.Is(readErr, errdefs.ErrBridgePluginMissing) {
+		return fmt.Errorf("read bridge name: %w", readErr)
+	}
+
+	if delErr := m.DeleteNetwork(networkName, configPath); delErr != nil {
+		return delErr
+	}
+
+	if bridge == "" {
+		return nil
+	}
+	return runner.DeleteBridge(ctx, bridge)
+}

--- a/internal/cni/bridge_test.go
+++ b/internal/cni/bridge_test.go
@@ -1,0 +1,237 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cni_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cni "github.com/eminwux/kukeon/internal/cni"
+)
+
+// fakeBridgeRunner records DeleteBridge invocations and lets tests assert on
+// the call sequence. notFoundOn names a bridge for which the runner returns
+// an "already-absent" success — it never returns an error so the helper sees
+// the same idempotent contract as the real IPBridgeRunner does for missing
+// links.
+type fakeBridgeRunner struct {
+	calls       []string
+	notFoundOn  string
+	failOn      string
+	failWithErr error
+}
+
+func (f *fakeBridgeRunner) DeleteBridge(_ context.Context, name string) error {
+	f.calls = append(f.calls, name)
+	if f.failOn != "" && name == f.failOn {
+		return f.failWithErr
+	}
+	// notFoundOn drains to nil — idempotent absent-bridge case.
+	_ = f.notFoundOn
+	return nil
+}
+
+func writeConflist(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("failed to write conflist: %v", err)
+	}
+	return path
+}
+
+const bridgeConflist = `{
+  "cniVersion": "0.4.0",
+  "name": "default-foo",
+  "plugins": [
+    {"type": "bridge", "bridge": "kuke-s-deadbeef"},
+    {"type": "loopback"}
+  ]
+}`
+
+const noBridgeConflist = `{
+  "cniVersion": "0.4.0",
+  "name": "default-bar",
+  "plugins": [{"type": "loopback"}]
+}`
+
+func TestManager_TeardownNetwork_BridgePresent(t *testing.T) {
+	dir := t.TempDir()
+	confPath := writeConflist(t, dir, "default-foo.conflist", bridgeConflist)
+
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	runner := &fakeBridgeRunner{}
+	if err = mgr.TeardownNetwork(context.Background(), runner, "default-foo", confPath); err != nil {
+		t.Fatalf("TeardownNetwork() error = %v, want nil", err)
+	}
+
+	if _, statErr := os.Stat(confPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("conflist still present after teardown: %v", statErr)
+	}
+	if got, want := runner.calls, []string{"kuke-s-deadbeef"}; !equalStrings(got, want) {
+		t.Errorf("DeleteBridge calls = %v, want %v", got, want)
+	}
+}
+
+func TestManager_TeardownNetwork_BridgeAlreadyAbsent(t *testing.T) {
+	dir := t.TempDir()
+	confPath := writeConflist(t, dir, "default-foo.conflist", bridgeConflist)
+
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	// Runner returns nil (treats as absent) — TeardownNetwork must propagate
+	// that as success, not error.
+	runner := &fakeBridgeRunner{notFoundOn: "kuke-s-deadbeef"}
+	if err = mgr.TeardownNetwork(context.Background(), runner, "default-foo", confPath); err != nil {
+		t.Fatalf("TeardownNetwork() error = %v, want nil (absent bridge is idempotent)", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Errorf("DeleteBridge call count = %d, want 1", len(runner.calls))
+	}
+}
+
+func TestManager_TeardownNetwork_ConflistMissing(t *testing.T) {
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "default-foo.conflist")
+
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	runner := &fakeBridgeRunner{}
+	if err = mgr.TeardownNetwork(context.Background(), runner, "default-foo", missing); err != nil {
+		t.Fatalf("TeardownNetwork() error = %v, want nil (missing conflist is idempotent)", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("DeleteBridge calls = %v, want none (no bridge to delete)", runner.calls)
+	}
+}
+
+func TestManager_TeardownNetwork_ConflistNoBridgePlugin(t *testing.T) {
+	dir := t.TempDir()
+	confPath := writeConflist(t, dir, "default-bar.conflist", noBridgeConflist)
+
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	runner := &fakeBridgeRunner{}
+	if err = mgr.TeardownNetwork(context.Background(), runner, "default-bar", confPath); err != nil {
+		t.Fatalf("TeardownNetwork() error = %v, want nil (no bridge plugin is idempotent)", err)
+	}
+	if _, statErr := os.Stat(confPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("conflist still present after teardown: %v", statErr)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("DeleteBridge calls = %v, want none (no bridge plugin)", runner.calls)
+	}
+}
+
+func TestManager_TeardownNetwork_DefaultsConfigPathFromName(t *testing.T) {
+	dir := t.TempDir()
+	confPath := writeConflist(t, dir, "default-foo.conflist", bridgeConflist)
+
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+
+	runner := &fakeBridgeRunner{}
+	// Empty configPath → manager derives <CniConfigDir>/<name>.conflist.
+	if err = mgr.TeardownNetwork(context.Background(), runner, "default-foo", ""); err != nil {
+		t.Fatalf("TeardownNetwork() error = %v, want nil", err)
+	}
+	if _, statErr := os.Stat(confPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("conflist still present after teardown via default path: %v", statErr)
+	}
+	if got, want := runner.calls, []string{"kuke-s-deadbeef"}; !equalStrings(got, want) {
+		t.Errorf("DeleteBridge calls = %v, want %v", got, want)
+	}
+}
+
+func TestManager_TeardownNetwork_EmptyNetworkName(t *testing.T) {
+	dir := t.TempDir()
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+	if err = mgr.TeardownNetwork(context.Background(), nil, "", ""); err == nil {
+		t.Fatal("TeardownNetwork(\"\") error = nil, want error")
+	}
+}
+
+func TestManager_TeardownNetwork_MalformedConflistErrors(t *testing.T) {
+	dir := t.TempDir()
+	confPath := writeConflist(t, dir, "default-foo.conflist", "not json")
+
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+	runner := &fakeBridgeRunner{}
+	if err = mgr.TeardownNetwork(context.Background(), runner, "default-foo", confPath); err == nil {
+		t.Fatal("TeardownNetwork() error = nil on malformed JSON, want error")
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("DeleteBridge called despite malformed conflist: %v", runner.calls)
+	}
+	// Conflist must remain so the operator can inspect/repair.
+	if _, statErr := os.Stat(confPath); statErr != nil {
+		t.Errorf("conflist removed despite parse error: %v", statErr)
+	}
+}
+
+func TestManager_TeardownNetwork_NilRunnerDefaults(t *testing.T) {
+	// Helper must not panic when caller passes nil; it falls back to
+	// IPBridgeRunner. With a no-bridge conflist there is no link to delete,
+	// so the IPBridgeRunner path is never exercised — exactly what we want
+	// for a unit test that doesn't shell out to ip(8).
+	dir := t.TempDir()
+	confPath := writeConflist(t, dir, "default-bar.conflist", noBridgeConflist)
+
+	mgr, err := cni.NewManager("", dir, "")
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+	if err = mgr.TeardownNetwork(context.Background(), nil, "default-bar", confPath); err != nil {
+		t.Fatalf("TeardownNetwork(nil runner) error = %v, want nil", err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/runner/delete_realm.go
+++ b/internal/controller/runner/delete_realm.go
@@ -86,7 +86,13 @@ func (r *Exec) DeleteRealm(realm intmodel.Realm) error {
 		r.processOrphanedContainers(r.ctx, containers)
 	}
 
-	// Purge all CNI networks for this realm
+	// Tear down each conflist + bridge link for this realm. Driven from
+	// CniConfigDir because that is the source of truth for which bridges
+	// were created — IPAM dirs under CNINetworksDir can be missing if a
+	// space's containers never started.
+	r.teardownRealmCNI(internalRealm.Metadata.Name)
+
+	// Purge IPAM/cache state for any leftover networks the realm owned.
 	// Network names follow the pattern: {realmName}-{spaceName}
 	// Scan /var/lib/cni/networks/ for all networks starting with realm name
 	cniNetworksDir := cni.CNINetworksDir

--- a/internal/controller/runner/delete_space.go
+++ b/internal/controller/runner/delete_space.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -97,28 +96,17 @@ func (r *Exec) DeleteSpace(space intmodel.Space) error {
 		// Continue teardown even if policy removal fails.
 	}
 
-	// Delete CNI network config and perform comprehensive CNI cleanup
+	// Delete CNI network config (and the bridge link it references) and
+	// perform comprehensive CNI cleanup.
 	var networkName string
 	networkName, err = naming.BuildSpaceNetworkName(realmName, internalSpace.Metadata.Name)
 	if err != nil {
 		r.logger.WarnContext(r.ctx, "failed to build network name, skipping CNI config deletion", "error", err)
 	} else {
-		var confPath string
-		confPath, err = r.resolveSpaceCNIConfigPath(realmName, internalSpace.Metadata.Name)
-		if err == nil {
-			var mgr *cni.Manager
-			mgr, err = cni.NewManager(
-				r.cniConf.CniBinDir,
-				r.cniConf.CniConfigDir,
-				r.cniConf.CniCacheDir,
-			)
-			if err == nil {
-				if err = mgr.DeleteNetwork(networkName, confPath); err != nil {
-					r.logger.WarnContext(r.ctx, "failed to delete CNI network config", "network", networkName, "error", err)
-					// Continue with comprehensive cleanup
-				}
-			}
-		}
+		confPath, _ := r.resolveSpaceCNIConfigPath(realmName, internalSpace.Metadata.Name)
+		// teardownSpaceCNI reads the bridge name from confPath BEFORE removing
+		// the conflist, then deletes the bridge link. Safe when confPath is "".
+		r.teardownSpaceCNI(networkName, confPath)
 		// Perform comprehensive CNI network cleanup (IPAM, cache entries, network directory)
 		_ = r.purgeCNIForNetwork(networkName)
 	}

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
 	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
@@ -188,6 +189,72 @@ func containsExactContainerID(content, containerID string) bool {
 	}
 
 	return matched
+}
+
+// teardownSpaceCNI runs the conflist+bridge teardown for a single network.
+// It is best-effort: failures are logged but do not propagate so callers can
+// continue with other cleanup steps. configPath may be empty; the cni.Manager
+// derives the default location from networkName.
+func (r *Exec) teardownSpaceCNI(networkName, configPath string) {
+	if networkName == "" {
+		return
+	}
+	mgr, err := cni.NewManager(r.cniConf.CniBinDir, r.cniConf.CniConfigDir, r.cniConf.CniCacheDir)
+	if err != nil {
+		r.logger.WarnContext(r.ctx, "failed to create CNI manager for teardown", "network", networkName, "error", err)
+		return
+	}
+	if err = mgr.TeardownNetwork(r.ctx, cni.IPBridgeRunner{}, networkName, configPath); err != nil {
+		r.logger.WarnContext(r.ctx, "failed to teardown CNI network", "network", networkName, "error", err)
+	}
+}
+
+// teardownRealmCNI enumerates each space directory under <RunPath>/<realm>/
+// and tears its network down (conflist + bridge link). The conflist is the
+// source of truth for the bridge name, so this is the only enumeration that
+// reliably finds every leaked bridge. Best-effort: per-entry failures are
+// logged and skipped.
+func (r *Exec) teardownRealmCNI(realmName string) {
+	if realmName == "" {
+		return
+	}
+	realmDir := fs.RealmMetadataDir(r.opts.RunPath, realmName)
+	entries, err := os.ReadDir(realmDir)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			r.logger.WarnContext(r.ctx, "failed to read realm metadata dir", "dir", realmDir, "error", err)
+		}
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		spaceName := entry.Name()
+		confPath, perr := fs.SpaceNetworkConfigPath(r.opts.RunPath, realmName, spaceName)
+		if perr != nil {
+			continue
+		}
+		if _, statErr := os.Stat(confPath); statErr != nil {
+			// No conflist (and therefore no bridge) for this space dir.
+			continue
+		}
+		networkName, nerr := naming.BuildSpaceNetworkName(realmName, spaceName)
+		if nerr != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to derive network name",
+				"realm",
+				realmName,
+				"space",
+				spaceName,
+				"error",
+				nerr,
+			)
+			continue
+		}
+		r.teardownSpaceCNI(networkName, confPath)
+	}
 }
 
 // purgeCNIForNetwork removes all CNI-related resources for an entire network.

--- a/internal/controller/runner/purge_realm.go
+++ b/internal/controller/runner/purge_realm.go
@@ -64,7 +64,13 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) error {
 		r.processOrphanedContainers(r.ctx, containers)
 	}
 
-	// Purge all CNI networks for this realm
+	// Tear down each conflist + bridge link for this realm. Driven from
+	// CniConfigDir because that is the source of truth for which bridges
+	// were created — IPAM dirs under CNINetworksDir can be missing if a
+	// space's containers never started.
+	r.teardownRealmCNI(realmForOps.Metadata.Name)
+
+	// Purge IPAM/cache state for any leftover networks the realm owned.
 	// Network names follow the pattern: {realmName}-{spaceName}
 	// Scan /var/lib/cni/networks/ for all networks starting with realm name
 	cniNetworksDir := cni.CNINetworksDir

--- a/internal/controller/runner/purge_space.go
+++ b/internal/controller/runner/purge_space.go
@@ -69,12 +69,16 @@ func (r *Exec) PurgeSpace(space intmodel.Space) error {
 		return nil
 	}
 
-	// Get network name
+	// Get network name and tear down conflist + bridge link, then purge
+	// the rest of the CNI state. DeleteSpace above already attempted the
+	// teardown, but it can be skipped on prior failure paths — call again
+	// idempotently so purge always converges.
 	var networkName string
 	if !spaceNotFound {
 		networkName, err = r.getSpaceNetworkName(internalSpace)
 		if err == nil {
-			// Purge entire network
+			r.teardownSpaceCNI(networkName, "")
+			// Purge IPAM and cache state for the network.
 			_ = r.purgeCNIForNetwork(networkName)
 		}
 	}


### PR DESCRIPTION
## Summary
- Adds `cni.Manager.TeardownNetwork(ctx, runner, networkName, configPath)` (in `internal/cni/bridge.go`) — reads the bridge name from the conflist BEFORE removing the conflist, then deletes the kernel bridge link via `ip link delete`. Each step is idempotent: missing conflist, no bridge plugin, empty bridge field, and already-absent bridge are all treated as success.
- Wires the helper through two runner-layer wrappers in `helpers.go`: `teardownSpaceCNI` (single space) and `teardownRealmCNI` (enumerates `<RunPath>/<realm>/*/network.conflist` and tears each down).
- Hooks both into all four runner paths called out in the issue: `delete_space`, `delete_realm`, `purge_space`, `purge_realm`. The bridge teardown runs before the existing IPAM/cache cleanup so a partial failure leaves enough state to retry from.

## Notable judgment calls
- **Bridge enumeration source.** Issue suggested `r.cniConf.CniConfigDir` for realm-level enumeration, but kukeon writes per-space conflists to `<RunPath>/<realm>/<space>/network.conflist` (via `fs.SpaceNetworkConfigPath`), not to the global CNI config dir. `teardownRealmCNI` enumerates the run path so it actually finds the conflists in both daemon and `--no-daemon` modes.
- **`os/exec` over a netlink Go library.** Mirrors the iptables enforcer pattern already in `internal/netpolicy/enforcer.go` rather than introducing `vishvananda/netlink` as a new direct dep. The `BridgeRunner` interface keeps the unit tests off the host's `ip` binary.
- **Idempotent error matching.** `IPBridgeRunner.DeleteBridge` treats the literal iproute2 error `Cannot find device` as success — verified against `iproute2-6.4.0` on the smoke-test host. Other failures still propagate.

## Test plan
- [x] `go test ./internal/cni/...` — six new unit tests cover the issue's three required cases (bridge present → deleted, bridge already absent → no error, conflist missing → no error) plus default-config-path derivation, no-bridge-plugin conflist, malformed-JSON error, empty network name, and nil-runner fallback.
- [x] `make test` — full unit suite green.
- [x] `go vet ./...` — clean.
- [x] Manual end-to-end on host (kuke `--no-daemon`, fresh runtime state, manually pre-created bridge links matching the conflists' `bridge` field):
  - `kuke delete space <s> --realm <r>` → conflist removed, bridge `defaul-b6be7a43` confirmed gone via `ip link show` (exit 1).
  - `kuke purge space <s> --realm <r>` → bridge `defaul-5acf354b` confirmed gone.
  - `kuke delete realm <r> --cascade` → bridge `del-test-sp-a` confirmed gone.
  - `kuke purge realm <r> --cascade --force` → bridges `leak-t-7e253bbc` and `leak-t-81254075` (two child spaces) both confirmed gone.
- [ ] `make e2e` — not run; e2e suite needs a running kukeond daemon and root socket access on the host, neither available in this session. Same skip behavior as on `origin/main`.
- [ ] `kuke init` smoke test from `CLAUDE.md` — not re-run; the diff only touches delete/purge runner paths, which the smoke test (init + `get realms` daemon parity) does not exercise.

Note: pre-existing leaked bridges on hosts already affected by the bug (where conflists were already deleted by old `delete space`) cannot be recovered by this change — the workaround `ip link delete` loop in the issue body is still needed once for those. The fix prevents further accumulation.

Closes #87