### PR TITLE
test: register t.Cleanup in create_realm_test.go so cgroups don't leak

### DIFF
--- a/internal/controller/runner/create_realm_test.go
+++ b/internal/controller/runner/create_realm_test.go
@@ -59,6 +59,21 @@ func setupTestRunner(t *testing.T) (runner.Runner, string) {
 	return r, runPath
 }
 
+// registerRealmCleanup schedules a best-effort DeleteRealm at test end so the
+// kernel cgroup CreateRealm provisions under /sys/fs/cgroup (and the
+// containerd namespace it owns) does not leak across runs. DeleteRealm is
+// idempotent — a missing realm, missing cgroup, and missing namespace all
+// return nil — so this is safe to register before the test decides whether
+// to skip or fail.
+func registerRealmCleanup(t *testing.T, r runner.Runner, realmName string) {
+	t.Helper()
+	t.Cleanup(func() {
+		_ = r.DeleteRealm(intmodel.Realm{
+			Metadata: intmodel.RealmMetadata{Name: realmName},
+		})
+	})
+}
+
 // createRealmMetadata creates a realm metadata file with the specified state.
 func createRealmMetadata(t *testing.T, runPath, realmName, namespace string, state intmodel.RealmState) {
 	t.Helper()
@@ -322,6 +337,7 @@ func TestCreateRealm_LifecycleStateManagement(t *testing.T) {
 			}
 
 			r, runPath := setupTestRunner(t)
+			registerRealmCleanup(t, r, tt.realmName)
 
 			// Use unique namespace per test to avoid collisions
 			// Use a hash of the test name to create a short unique identifier (containerd has 76 char limit)
@@ -510,6 +526,7 @@ func TestProvisionNewRealm_ErrorHandling(t *testing.T) {
 			}
 
 			r, _ := setupTestRunner(t)
+			registerRealmCleanup(t, r, tt.realmName)
 
 			// Use unique namespace per test to avoid collisions
 			uniqueNamespace := tt.namespace
@@ -670,6 +687,7 @@ func TestCreateRealm_StateReconciliation(t *testing.T) {
 			r, runPath := setupTestRunner(t)
 			realmName := "reconcile-realm"
 			namespace := "reconcile-realm-ns"
+			registerRealmCleanup(t, r, realmName)
 
 			// Create realm metadata with initial state
 			createRealmMetadata(t, runPath, realmName, namespace, tt.initialState)
@@ -766,6 +784,7 @@ func TestCreateRealm_NamespacePreSeeded_PersistsReady(t *testing.T) {
 	shortHash := hex.EncodeToString(hash[:])[:8]
 	realmName := "preseed-realm-" + shortHash
 	namespace := "preseed-ns-" + shortHash
+	registerRealmCleanup(t, r, realmName)
 
 	// Pre-seed the containerd namespace via a separate client to mirror the
 	// `ctr -n <ns> images import` flow that triggers the bug in real `kuke init`


### PR DESCRIPTION
## Summary

- Adds a `registerRealmCleanup(t, r, realmName)` sibling helper that schedules `r.DeleteRealm` at test end, then calls it once per subtest in the four integration tests under `internal/controller/runner/create_realm_test.go` flagged in #108: `TestCreateRealm_LifecycleStateManagement`, `TestProvisionNewRealm_ErrorHandling`, `TestCreateRealm_StateReconciliation`, and `TestCreateRealm_NamespacePreSeeded_PersistsReady`.
- `DeleteRealm` is idempotent (missing realm / cgroup / namespace all return nil), so the helper is safe to register before the test decides whether to skip or fail.

## Notable judgment calls

- **Sibling helper, not a `setupTestRunner` arg.** The issue suggested either; a sibling helper keeps the call site to one line per subtest and avoids changing the existing `setupTestRunner` signature (~8 callers in the file). Each subtest registers its own realm name (`tt.realmName`), which the table-driven cases need anyway because each case has a different realm.
- **Reuse `r.DeleteRealm` rather than touching `/sys/fs/cgroup` directly.** It's the production teardown path the runtime already exercises, so the cleanup also exercises the realm-delete code rather than introducing a separate test-only cgroup-removal helper.
- **The "same name different namespace" subtest in `TestCreateRealm_LifecycleStateManagement`.** Its `setup` creates a realm under an OLD namespace before the body re-creates under the NEW namespace; the cleanup uses the realm name and reads back the persisted metadata, so it cleans up the cgroup + the *current* namespace. The OLD namespace can leak in containerd, but since #108 is scoped to cgroup leakage on `/sys/fs/cgroup` and the OLD namespace is hash-suffixed (no cross-run collision), this is left for a separate sweep.

## Pre-existing failures observed during local validation (not caused by this PR)

`TestCreateRealm_LifecycleStateManagement/realm_creation_with_invalid_namespace_-_transitions_to_Failed` and `TestProvisionNewRealm_ErrorHandling/namespace_creation_failure_-_Creating_to_Failed` both fail on `origin/main` independently of this branch (verified via `git worktree add /tmp/kukeon-main-check origin/main`): both expect `CreateRealm` to error on `namespace: ""` but it currently succeeds. These are unrelated to the cgroup-cleanup change in this PR — they are about the same code path *that the cleanup itself relies on to clean up cgroups* — and will be filed as a separate verified bug. The cleanup helper still fires on those failing subtests (verified by inspecting `/sys/fs/cgroup/kukeon/test-realm-5` and `/sys/fs/cgroup/kukeon/fail-ns-realm` after each run — both removed).

## Test plan

- [x] `make test` (unit suite, no integration tag) — clean.
- [x] `go vet ./...` and `go vet -tags=integration ./...` — clean.
- [x] `go build ./...` and `go build -tags=integration ./...` — clean.
- [x] `golangci-lint` (via pre-commit hook) — clean.
- [x] Integration suite (`sudo PATH=$PATH go test -tags=integration -run "TestCreateRealm_LifecycleStateManagement|TestProvisionNewRealm_ErrorHandling|TestCreateRealm_StateReconciliation|TestCreateRealm_NamespacePreSeeded_PersistsReady" -v ./internal/controller/runner/`) — all subtests that were passing on `main` still pass; the two failures listed above also reproduce on `main` (out of scope).
- [x] Cleanup actually fires: ran `TestCreateRealm_LifecycleStateManagement/…invalid_namespace…` and `TestProvisionNewRealm_ErrorHandling/namespace_creation_failure…` standalone, verified `/sys/fs/cgroup/kukeon/test-realm-5` and `/sys/fs/cgroup/kukeon/fail-ns-realm` were removed by test end.
- [ ] Project-CLAUDE.md daemon-parity smoke test — **not run**. This change is test-only (no daemon-path code touched), so the smoke test isn't required by the project CLAUDE.md rule ("If your change touches anything the daemon reads…").

Closes #108