### PR TITLE
fix: default empty namespace to realm name in runner.provisionNewRealm

### DIFF
--- a/internal/controller/runner/create_realm_test.go
+++ b/internal/controller/runner/create_realm_test.go
@@ -212,15 +212,15 @@ func TestCreateRealm_LifecycleStateManagement(t *testing.T) {
 			description:             "When a realm exists in Failed state, it should remain in Failed state (no automatic recovery)",
 		},
 		{
-			name:                    "realm creation with invalid namespace - transitions to Failed",
+			name:                    "realm creation with empty namespace - defaults to realm name and reaches Ready",
 			realmName:               "test-realm-5",
-			namespace:               "", // Empty namespace will cause failure
+			namespace:               "", // Empty namespace defaults to realm name at the runner layer
 			setup:                   nil,
-			wantState:               intmodel.RealmStateFailed,
-			wantErr:                 true,
-			verifyStateInMetadata:   true, // Check that Failed state was persisted
-			skipIfContainerdMissing: false,
-			description:             "When namespace creation fails, realm should transition to Failed state",
+			wantState:               intmodel.RealmStateReady,
+			wantErr:                 false,
+			verifyStateInMetadata:   true,
+			skipIfContainerdMissing: true,
+			description:             "When namespace is empty, runner.CreateRealm defaults Spec.Namespace to the realm name (matching controller-layer defaulting in internal/controller/create_realm.go) so reconcile-style stub realms still provision successfully.",
 		},
 		{
 			name:      "realm creation with duplicate namespace - handles gracefully",
@@ -507,13 +507,13 @@ func TestProvisionNewRealm_ErrorHandling(t *testing.T) {
 			description:             "Successful realm creation should transition from Creating to Ready",
 		},
 		{
-			name:                    "namespace creation failure - Creating to Failed",
+			name:                    "empty namespace - defaults to realm name and reaches Ready",
 			realmName:               "fail-ns-realm",
-			namespace:               "", // Empty namespace will cause failure
-			wantState:               intmodel.RealmStateFailed,
-			wantErr:                 true,
-			skipIfContainerdMissing: false,
-			description:             "When namespace creation fails, realm should be marked as Failed",
+			namespace:               "", // Empty namespace defaults to realm name at the runner layer
+			wantState:               intmodel.RealmStateReady,
+			wantErr:                 false,
+			skipIfContainerdMissing: true,
+			description:             "When namespace is empty, runner.CreateRealm defaults Spec.Namespace to the realm name; the realm provisions successfully rather than parking as Failed.",
 		},
 	}
 

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -56,7 +56,7 @@ func (r *Exec) provisionNewRealm(realm intmodel.Realm) (intmodel.Realm, error) {
 	// silently colocating every "naked" realm. Mirror the controller's
 	// behavior here so both layers converge on the same safe default.
 	if strings.TrimSpace(realm.Spec.Namespace) == "" {
-		realm.Spec.Namespace = realm.Metadata.Name
+		realm.Spec.Namespace = strings.TrimSpace(realm.Metadata.Name)
 	}
 
 	// Update realm metadata with Creating state

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -47,6 +47,18 @@ type ensureCgroupParams struct {
 }
 
 func (r *Exec) provisionNewRealm(realm intmodel.Realm) (intmodel.Realm, error) {
+	// Default empty Spec.Namespace to the realm name so the runner-layer
+	// API behaves symmetrically with the controller layer's defaulting
+	// (internal/controller/create_realm.go:57-62). Without this, callers
+	// that go straight to the runner — notably ReconcileSpace's "ensure
+	// parent realm exists" stub at internal/controller/apply/reconcile.go
+	// — would create a containerd namespace under the empty string,
+	// silently colocating every "naked" realm. Mirror the controller's
+	// behavior here so both layers converge on the same safe default.
+	if strings.TrimSpace(realm.Spec.Namespace) == "" {
+		realm.Spec.Namespace = realm.Metadata.Name
+	}
+
 	// Update realm metadata with Creating state
 	if err := r.UpdateRealmMetadata(realm); err != nil {
 		return intmodel.Realm{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateRealmMetadata, err)


### PR DESCRIPTION
## Summary

- `runner.(*Exec).provisionNewRealm` now defaults `realm.Spec.Namespace` to `realm.Metadata.Name` when the input namespace is empty (or whitespace-only), making the runner-layer behavior match the controller-layer defaulting at `internal/controller/create_realm.go:57-62`.
- Without this, `internal/controller/apply/reconcile.go:105` (and the two other parent-realm-stub call sites in the same file) was creating realms with `Spec.Namespace == ""`, which made `provisionNewRealm` happily call `containerd.CreateNamespace("")` — silently colocating every "naked" realm in containerd's empty namespace.
- Updates the two integration test cases that asserted the *opposite* behavior (`test-realm-5`, `fail-ns-realm`) to match the new contract: empty namespace → defaults to realm name → state Ready.

## Notable judgment calls

- **Defaulting, not erroring (option 2 from #136's body, not the "Suggested fix" option 1).** While writing the fix I traced `runner.CreateRealm` callers and found `apply/reconcile.go` constructs parent-realm stubs with `Metadata.Name` only — no namespace. Erroring on empty namespace at the runner layer would break `kuke apply` against any manifest whose space references a not-yet-created parent realm. Defaulting matches what production already relies on, what the controller already does, and is the lower-blast-radius half of the asymmetry-fix the bug body lists. Reviewer can push back if the project would rather see strict validation propagated upward (controller stops defaulting, reconcile sets the namespace explicitly, runner errors), but that's an architectural change on top of a `bug` fix and out of scope for this PR.
- **Integration tests get rewritten in place rather than removed.** The two cases were aspirational ("if you pass empty namespace, realm should fail to provision") — under the new contract that's wrong, but the test slots are still useful for asserting the *defaulting* behavior, so they keep their realm names and become positive cases.
- **`provisionNewRealm`, not `runner.CreateRealm`.** The defaulting only matters for the new-realm path; the existing-realm path already pulls the persisted namespace via `GetRealm` before calling `EnsureRealm`. Putting the default at the bottom of the call chain (`provisionNewRealm`) keeps the contract local to where the namespace is first written to disk.

## Test plan

- [x] `make test` (unit suite) — clean.
- [x] `go vet ./...` — clean.
- [x] `go build ./...` — clean.
- [x] `golangci-lint` (via pre-commit hook) — clean.
- [x] Integration suite (`sudo PATH=$PATH go test -tags=integration -run "TestCreateRealm_LifecycleStateManagement|TestProvisionNewRealm_ErrorHandling|TestCreateRealm_StateReconciliation|TestCreateRealm_NamespacePreSeeded_PersistsReady" -v ./internal/controller/runner/`) — all subtests pass, including the two previously-failing empty-namespace cases (renamed to reflect their new "defaults to realm name and reaches Ready" expectation).
- [ ] Project-CLAUDE.md daemon-parity smoke test — **not run**. This host has an active production `kukeond` running a live `default-default` cell with a `claude-code` task, and the playbook's teardown step would interrupt that workload. The change touches the daemon path (the runner is the daemon), so reviewer should run the full smoke on a clean host before merging.

Closes #136