### PR TITLE
test: trim verbose runCapture doc to match terse-comment style

### DIFF
--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -63,9 +63,7 @@ func (f *fakeClient) AttachContainer(
 }
 
 // runCapture records the Options passed to pkg/attach.Run and returns
-// nil so the test treats the call as a clean detach. The real Run would
-// open the user's TTY and connect to a control socket; bypassing it
-// keeps the test hermetic.
+// nil so the test treats the call as a clean detach.
 type runCapture struct {
 	calls int
 	opts  sbshattach.Options


### PR DESCRIPTION
## Summary
- Trims the second sentence of the `runCapture` doc comment in `cmd/kuke/attach/attach_test.go` so it matches the terse-comment style of surrounding test helpers. Surfaced during review of #115; the first sentence already carries the load.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make test` (full unit suite, all green)
- [ ] e2e / smoke — not run; comment-only change with no code-path or daemon impact

Closes #118