### PR TITLE
feat(api): add tty section on attachable containers + cell.tty.default (#139)

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -261,6 +261,9 @@ func NormalizeStack(req ext.StackDoc) (intmodel.Stack, ext.Version, error) {
 func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, error) {
 	switch in.APIVersion {
 	case VersionV1Beta1, "": // default/empty treated as v1beta1
+		if err := validateContainerTty(in.Spec); err != nil {
+			return intmodel.Container{}, err
+		}
 		return intmodel.Container{
 			Metadata: intmodel.ContainerMetadata{
 				Name:   in.Metadata.Name,
@@ -295,6 +298,7 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
 				Attachable:             in.Spec.Attachable,
+				Tty:                    convertContainerTtyToInternal(in.Spec.Tty),
 			},
 			Status: intmodel.ContainerStatus{
 				Name:         in.Status.Name,
@@ -353,6 +357,7 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
 				Attachable:             in.Spec.Attachable,
+				Tty:                    buildContainerTtyExternalFromInternal(in.Spec.Tty),
 			},
 			Status: ext.ContainerStatus{
 				Name:         in.Status.Name,
@@ -414,6 +419,7 @@ func convertContainerSpecToInternal(in ext.ContainerSpec) intmodel.ContainerSpec
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
 		Attachable:             in.Attachable,
+		Tty:                    convertContainerTtyToInternal(in.Tty),
 	}
 }
 
@@ -450,7 +456,97 @@ func BuildContainerSpecExternalFromInternal(in intmodel.ContainerSpec) ext.Conta
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
 		Attachable:             in.Attachable,
+		Tty:                    buildContainerTtyExternalFromInternal(in.Tty),
 	}
+}
+
+// convertContainerTtyToInternal converts an external ContainerTty payload to
+// the internal modelhub mirror. Returns nil for a nil or zero-value input so
+// downstream callers can use the ContainerTty.IsEmpty contract.
+func convertContainerTtyToInternal(in *ext.ContainerTty) *intmodel.ContainerTty {
+	if in.IsEmpty() {
+		return nil
+	}
+	out := &intmodel.ContainerTty{Prompt: in.Prompt}
+	if len(in.OnInit) > 0 {
+		out.OnInit = make([]intmodel.TtyStage, len(in.OnInit))
+		for i, s := range in.OnInit {
+			out.OnInit[i] = intmodel.TtyStage{Script: s.Script}
+		}
+	}
+	return out
+}
+
+// buildContainerTtyExternalFromInternal is the inverse of
+// convertContainerTtyToInternal.
+func buildContainerTtyExternalFromInternal(in *intmodel.ContainerTty) *ext.ContainerTty {
+	if in.IsEmpty() {
+		return nil
+	}
+	out := &ext.ContainerTty{Prompt: in.Prompt}
+	if len(in.OnInit) > 0 {
+		out.OnInit = make([]ext.TtyStage, len(in.OnInit))
+		for i, s := range in.OnInit {
+			out.OnInit[i] = ext.TtyStage{Script: s.Script}
+		}
+	}
+	return out
+}
+
+// convertCellTtyToInternal converts an external CellTty payload to the
+// internal modelhub mirror. Returns nil when the block is absent or only
+// contains zero-value fields.
+func convertCellTtyToInternal(in *ext.CellTty) *intmodel.CellTty {
+	if in == nil || in.Default == "" {
+		return nil
+	}
+	return &intmodel.CellTty{Default: in.Default}
+}
+
+// buildCellTtyExternalFromInternal is the inverse of convertCellTtyToInternal.
+func buildCellTtyExternalFromInternal(in *intmodel.CellTty) *ext.CellTty {
+	if in == nil || in.Default == "" {
+		return nil
+	}
+	return &ext.CellTty{Default: in.Default}
+}
+
+// validateContainerTty enforces the AC that any tty field set on a
+// container with Attachable=false is a validation error. The tty block
+// is config that only takes effect when Attachable=true (the capability
+// gate); silently dropping it on a non-attachable container would let a
+// future apply silently ignore configured prompts/onInit scripts.
+func validateContainerTty(spec ext.ContainerSpec) error {
+	if spec.Attachable {
+		return nil
+	}
+	if spec.Tty.IsEmpty() {
+		return nil
+	}
+	return fmt.Errorf("container %q: tty fields require attachable: true", spec.ID)
+}
+
+// validateCellTty enforces the AC that CellTty.Default names an existing
+// attachable container in the same cell (or is empty).
+func validateCellTty(spec ext.CellSpec) error {
+	if spec.Tty == nil || spec.Tty.Default == "" {
+		return nil
+	}
+	for _, c := range spec.Containers {
+		if c.ID == spec.Tty.Default {
+			if !c.Attachable {
+				return fmt.Errorf(
+					"cell tty.default %q references container that is not attachable",
+					spec.Tty.Default,
+				)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"cell tty.default %q does not match any container in this cell",
+		spec.Tty.Default,
+	)
 }
 
 func convertCapabilitiesToInternal(in *ext.ContainerCapabilities) *intmodel.ContainerCapabilities {
@@ -693,6 +789,14 @@ func buildContainerStatusesExternalFromInternal(in []intmodel.ContainerStatus) [
 func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 	switch in.APIVersion {
 	case VersionV1Beta1, "": // default/empty treated as v1beta1
+		for _, c := range in.Spec.Containers {
+			if err := validateContainerTty(c); err != nil {
+				return intmodel.Cell{}, err
+			}
+		}
+		if err := validateCellTty(in.Spec); err != nil {
+			return intmodel.Cell{}, err
+		}
 		cell := intmodel.Cell{
 			Metadata: intmodel.CellMetadata{
 				Name:   in.Metadata.Name,
@@ -704,6 +808,7 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				SpaceName:       in.Spec.SpaceID,
 				StackName:       in.Spec.StackID,
 				RootContainerID: in.Spec.RootContainerID,
+				Tty:             convertCellTtyToInternal(in.Spec.Tty),
 			},
 			Status: intmodel.CellStatus{
 				State:      intmodel.CellState(in.Status.State),
@@ -758,6 +863,7 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				SpaceID:         in.Spec.SpaceName,
 				StackID:         in.Spec.StackName,
 				RootContainerID: in.Spec.RootContainerID,
+				Tty:             buildCellTtyExternalFromInternal(in.Spec.Tty),
 			},
 			Status: ext.CellStatus{
 				State:      ext.CellState(in.Status.State),

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -717,6 +717,285 @@ func TestContainerAttachableRoundTrips(t *testing.T) {
 	}
 }
 
+// TestContainerTtyRoundTripV1Beta1 covers the AC that a populated tty block
+// on an attachable container survives ConvertContainerDocToInternal +
+// BuildContainerExternalFromInternal with no fields dropped.
+func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "c"},
+		Spec: ext.ContainerSpec{
+			ID:      "c",
+			RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+			Image:      "alpine:latest",
+			Attachable: true,
+			Tty: &ext.ContainerTty{
+				Prompt: `"\[\e[1;36m\]claude \u@\h\[\e[0m\]:\w\$ "`,
+				OnInit: []ext.TtyStage{
+					{Script: "git pull"},
+					{Script: "claude"},
+				},
+			},
+		},
+	}
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	if internal.Spec.Tty == nil {
+		t.Fatalf("internal.Spec.Tty = nil, want populated")
+	}
+	if internal.Spec.Tty.Prompt != input.Spec.Tty.Prompt {
+		t.Errorf("internal prompt = %q, want %q", internal.Spec.Tty.Prompt, input.Spec.Tty.Prompt)
+	}
+	if len(internal.Spec.Tty.OnInit) != 2 ||
+		internal.Spec.Tty.OnInit[0].Script != "git pull" ||
+		internal.Spec.Tty.OnInit[1].Script != "claude" {
+		t.Errorf("internal onInit = %+v, want [git pull, claude]", internal.Spec.Tty.OnInit)
+	}
+	out, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	if out.Spec.Tty == nil {
+		t.Fatalf("round-trip dropped tty block: %+v", out.Spec)
+	}
+	if out.Spec.Tty.Prompt != input.Spec.Tty.Prompt {
+		t.Errorf("round-trip prompt = %q, want %q", out.Spec.Tty.Prompt, input.Spec.Tty.Prompt)
+	}
+	if len(out.Spec.Tty.OnInit) != len(input.Spec.Tty.OnInit) {
+		t.Fatalf("round-trip onInit len = %d, want %d", len(out.Spec.Tty.OnInit), len(input.Spec.Tty.OnInit))
+	}
+	for i, s := range input.Spec.Tty.OnInit {
+		if out.Spec.Tty.OnInit[i].Script != s.Script {
+			t.Errorf("round-trip onInit[%d] = %q, want %q", i, out.Spec.Tty.OnInit[i].Script, s.Script)
+		}
+	}
+}
+
+// TestCellTtyRoundTripV1Beta1 covers the AC that a populated cell-level tty
+// block round-trips intact, with cell.tty.default referencing an attachable
+// container that exists in the same cell.
+func TestCellTtyRoundTripV1Beta1(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "cell-tty"},
+		Spec: ext.CellSpec{
+			ID:      "cell-tty",
+			RealmID: "r", SpaceID: "s", StackID: "st",
+			Tty: &ext.CellTty{Default: "work"},
+			Containers: []ext.ContainerSpec{
+				{
+					ID:         "work",
+					RealmID:    "r",
+					SpaceID:    "s",
+					StackID:    "st",
+					CellID:     "cell-tty",
+					Image:      "alpine:latest",
+					Attachable: true,
+					Tty: &ext.ContainerTty{
+						Prompt: `"\u@\h:\w\$ "`,
+						OnInit: []ext.TtyStage{{Script: "echo hi"}},
+					},
+				},
+			},
+		},
+	}
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if internal.Spec.Tty == nil || internal.Spec.Tty.Default != "work" {
+		t.Fatalf("internal cell tty = %+v, want default=work", internal.Spec.Tty)
+	}
+	if len(internal.Spec.Containers) != 1 || internal.Spec.Containers[0].Tty == nil {
+		t.Fatalf("internal nested container tty dropped: %+v", internal.Spec.Containers)
+	}
+	if internal.Spec.Containers[0].Tty.Prompt == "" ||
+		len(internal.Spec.Containers[0].Tty.OnInit) != 1 {
+		t.Errorf("internal nested container tty fields wrong: %+v", internal.Spec.Containers[0].Tty)
+	}
+	out, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if out.Spec.Tty == nil || out.Spec.Tty.Default != "work" {
+		t.Fatalf("round-trip cell tty = %+v, want default=work", out.Spec.Tty)
+	}
+	if len(out.Spec.Containers) != 1 || out.Spec.Containers[0].Tty == nil ||
+		out.Spec.Containers[0].Tty.Prompt != input.Spec.Containers[0].Tty.Prompt {
+		t.Fatalf("round-trip nested container tty did not survive: %+v", out.Spec.Containers[0].Tty)
+	}
+}
+
+// TestCellTtyZeroBlockOmittedOnRoundTrip confirms an absent cell.tty does
+// not turn into an empty `tty: {}` block on the output side. Distinguishes
+// the user-supplied "block omitted" case from "block present but empty".
+func TestCellTtyZeroBlockOmittedOnRoundTrip(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "cell"},
+		Spec: ext.CellSpec{
+			ID:      "cell",
+			RealmID: "r", SpaceID: "s", StackID: "st",
+		},
+	}
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if internal.Spec.Tty != nil {
+		t.Errorf("internal cell tty = %+v, want nil for absent block", internal.Spec.Tty)
+	}
+	out, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if out.Spec.Tty != nil {
+		t.Errorf("round-trip injected cell tty = %+v, want nil", out.Spec.Tty)
+	}
+}
+
+// TestContainerTtyRejectedWithoutAttachable enforces the AC that any tty
+// field set with attachable=false is a validation error.
+func TestContainerTtyRejectedWithoutAttachable(t *testing.T) {
+	cases := []struct {
+		name string
+		tty  *ext.ContainerTty
+	}{
+		{"prompt only", &ext.ContainerTty{Prompt: `"\u\$ "`}},
+		{"onInit only", &ext.ContainerTty{OnInit: []ext.TtyStage{{Script: "echo"}}}},
+		{"both set", &ext.ContainerTty{
+			Prompt: `"\u\$ "`,
+			OnInit: []ext.TtyStage{{Script: "echo"}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := ext.ContainerDoc{
+				APIVersion: ext.APIVersionV1Beta1,
+				Kind:       ext.KindContainer,
+				Metadata:   ext.ContainerMetadata{Name: "c"},
+				Spec: ext.ContainerSpec{
+					ID:      "c",
+					RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+					Image:      "alpine:latest",
+					Attachable: false,
+					Tty:        tc.tty,
+				},
+			}
+			if _, _, err := apischeme.NormalizeContainer(input); err == nil {
+				t.Fatalf("NormalizeContainer accepted tty with attachable=false; want error")
+			}
+		})
+	}
+}
+
+// TestContainerTtyEmptyBlockAcceptedWithoutAttachable confirms that an
+// explicitly empty tty block (`tty: {}`) on a non-attachable container is
+// equivalent to omitting the block — the validator must not reject it.
+func TestContainerTtyEmptyBlockAcceptedWithoutAttachable(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "c"},
+		Spec: ext.ContainerSpec{
+			ID:      "c",
+			RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+			Image:      "alpine:latest",
+			Attachable: false,
+			Tty:        &ext.ContainerTty{},
+		},
+	}
+	if _, _, err := apischeme.NormalizeContainer(input); err != nil {
+		t.Fatalf("NormalizeContainer rejected empty tty block: %v", err)
+	}
+}
+
+// TestCellTtyDefaultValidation enforces the AC that CellTty.Default must
+// reference an existing attachable container in the same cell. Three cases:
+// missing reference, non-attachable reference, valid reference.
+func TestCellTtyDefaultValidation(t *testing.T) {
+	makeCell := func(defaultName string, containers []ext.ContainerSpec) ext.CellDoc {
+		return ext.CellDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindCell,
+			Metadata:   ext.CellMetadata{Name: "cell"},
+			Spec: ext.CellSpec{
+				ID:      "cell",
+				RealmID: "r", SpaceID: "s", StackID: "st",
+				Tty:        &ext.CellTty{Default: defaultName},
+				Containers: containers,
+			},
+		}
+	}
+
+	t.Run("default refs missing container", func(t *testing.T) {
+		doc := makeCell("ghost", []ext.ContainerSpec{
+			{ID: "work", Image: "alpine:latest", Attachable: true},
+		})
+		if _, _, err := apischeme.NormalizeCell(doc); err == nil {
+			t.Fatalf("NormalizeCell accepted unknown tty.default; want error")
+		}
+	})
+
+	t.Run("default refs non-attachable container", func(t *testing.T) {
+		doc := makeCell("plain", []ext.ContainerSpec{
+			{ID: "plain", Image: "alpine:latest", Attachable: false},
+		})
+		if _, _, err := apischeme.NormalizeCell(doc); err == nil {
+			t.Fatalf("NormalizeCell accepted tty.default on non-attachable; want error")
+		}
+	})
+
+	t.Run("default refs attachable container", func(t *testing.T) {
+		doc := makeCell("work", []ext.ContainerSpec{
+			{ID: "work", Image: "alpine:latest", Attachable: true},
+		})
+		if _, _, err := apischeme.NormalizeCell(doc); err != nil {
+			t.Fatalf("NormalizeCell rejected valid tty.default: %v", err)
+		}
+	})
+
+	t.Run("default empty is allowed", func(t *testing.T) {
+		doc := makeCell("", []ext.ContainerSpec{
+			{ID: "work", Image: "alpine:latest", Attachable: true},
+		})
+		if _, _, err := apischeme.NormalizeCell(doc); err != nil {
+			t.Fatalf("NormalizeCell rejected empty tty.default: %v", err)
+		}
+	})
+}
+
+// TestCellRejectsNestedContainerTtyWithoutAttachable confirms the
+// per-container validation also fires for containers carried inside a
+// CellSpec (not just a standalone ContainerDoc).
+func TestCellRejectsNestedContainerTtyWithoutAttachable(t *testing.T) {
+	doc := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "cell"},
+		Spec: ext.CellSpec{
+			ID:      "cell",
+			RealmID: "r", SpaceID: "s", StackID: "st",
+			Containers: []ext.ContainerSpec{
+				{
+					ID:         "broken",
+					Image:      "alpine:latest",
+					Attachable: false,
+					Tty:        &ext.ContainerTty{Prompt: `"\u\$ "`},
+				},
+			},
+		},
+	}
+	if _, _, err := apischeme.NormalizeCell(doc); err == nil {
+		t.Fatalf("NormalizeCell accepted nested tty with attachable=false; want error")
+	}
+}
+
 // TestContainerSecretYAMLNeverLeaksValues ensures that a round-trip through
 // the external doc + YAML marshal path only serializes the reference fields,
 // never a resolved secret value. The internal model has no value field, so a

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -54,10 +54,18 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 		return nil, fmt.Errorf("resolve sbsh cache path for %q: %w", spec.Image, err)
 	}
 
+	useProfile := !spec.Tty.IsEmpty()
+	if useProfile {
+		if err = writeSbshProfile(ttyDir, spec); err != nil {
+			return nil, err
+		}
+	}
+
 	return []ctr.BuildOption{
 		ctr.WithAttachableInjection(ctr.AttachableInjection{
 			SbshBinaryPath: binaryPath,
 			HostTTYDir:     ttyDir,
+			UseProfile:     useProfile,
 		}),
 	}, nil
 }

--- a/internal/controller/runner/sbsh_profile.go
+++ b/internal/controller/runner/sbsh_profile.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/eminwux/kukeon/internal/ctr"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"gopkg.in/yaml.v3"
+)
+
+// sbshProfileDoc mirrors the subset of the sbsh TerminalProfile YAML schema
+// the daemon writes for an attachable container. Only fields driven by the
+// container-level tty block live here; the rest are sbsh's own defaults.
+type sbshProfileDoc struct {
+	APIVersion string             `yaml:"apiVersion"`
+	Kind       string             `yaml:"kind"`
+	Metadata   sbshProfileMeta    `yaml:"metadata"`
+	Spec       sbshProfileSpecDoc `yaml:"spec"`
+}
+
+type sbshProfileMeta struct {
+	Name string `yaml:"name"`
+}
+
+type sbshProfileSpecDoc struct {
+	Shell  sbshProfileShell   `yaml:"shell,omitempty"`
+	Stages *sbshProfileStages `yaml:"stages,omitempty"`
+}
+
+type sbshProfileShell struct {
+	// Cmd is required by sbsh's profile validator. Populated from the
+	// container's command (with a /bin/sh fallback when the container
+	// inherits its command from the image's ENTRYPOINT/CMD).
+	Cmd string `yaml:"cmd"`
+	// CmdArgs carries the container's args alongside Cmd; sbsh executes
+	// `Cmd CmdArgs...` under the profile-driven shell wrapper.
+	CmdArgs []string `yaml:"cmdArgs,omitempty"`
+	// InheritEnv tells sbsh to inherit the parent process's env, which is
+	// the container's OCI-injected env — so the profile does not have to
+	// duplicate ContainerSpec.Env.
+	InheritEnv bool `yaml:"inheritEnv,omitempty"`
+	// Prompt is the literal prompt expression sbsh sets in the wrapped shell.
+	Prompt string `yaml:"prompt,omitempty"`
+}
+
+// fallbackShellCmd is the shell binary the daemon writes into shell.cmd
+// when ContainerSpec.Command is empty (image-default ENTRYPOINT/CMD).
+// The same binary is present in busybox, alpine, debian, and ubuntu — the
+// images used in the smoke and e2e tests.
+const fallbackShellCmd = "/bin/sh"
+
+type sbshProfileStages struct {
+	OnInit []sbshProfileStage `yaml:"onInit,omitempty"`
+}
+
+type sbshProfileStage struct {
+	Script string `yaml:"script,omitempty"`
+}
+
+// writeSbshProfile renders the container's tty config plus the inherited
+// command/args as an sbsh TerminalProfile YAML and writes it to
+// <dir>/<ctr.AttachableProfileFile>. Returns nil without touching the
+// filesystem when the container's tty block is empty (the caller must
+// not pass UseProfile=true in that case).
+//
+// sbsh's profile validator requires `shell.cmd` — even when the post-`--`
+// workload would supply it — so the daemon mirrors ContainerSpec.Command
+// (and Args) into shell.cmd/cmdArgs, and falls back to /bin/sh for the
+// image-inherited-command case. inheritEnv is set so the container's
+// OCI-injected env flows through without the profile duplicating it.
+//
+// The file is written 0600 because it lives inside the per-container tty
+// dir, which is daemon-private (0700); keeping the inner file similarly
+// tight guards against a future loosening of the parent dir.
+func writeSbshProfile(dir string, spec intmodel.ContainerSpec) error {
+	if spec.Tty.IsEmpty() {
+		return nil
+	}
+	cmd := spec.Command
+	cmdArgs := append([]string(nil), spec.Args...)
+	if cmd == "" {
+		cmd = fallbackShellCmd
+		cmdArgs = nil
+	}
+	doc := sbshProfileDoc{
+		APIVersion: "sbsh/v1beta1",
+		Kind:       "TerminalProfile",
+		Metadata:   sbshProfileMeta{Name: ctr.AttachableProfileName},
+		Spec: sbshProfileSpecDoc{
+			Shell: sbshProfileShell{
+				Cmd:        cmd,
+				CmdArgs:    cmdArgs,
+				InheritEnv: true,
+				Prompt:     spec.Tty.Prompt,
+			},
+		},
+	}
+	if len(spec.Tty.OnInit) > 0 {
+		stages := make([]sbshProfileStage, 0, len(spec.Tty.OnInit))
+		for _, s := range spec.Tty.OnInit {
+			if s.Script == "" {
+				continue
+			}
+			stages = append(stages, sbshProfileStage{Script: s.Script})
+		}
+		if len(stages) > 0 {
+			doc.Spec.Stages = &sbshProfileStages{OnInit: stages}
+		}
+	}
+	data, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal sbsh profile: %w", err)
+	}
+	path := filepath.Join(dir, ctr.AttachableProfileFile)
+	if err = os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write sbsh profile %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/controller/runner/sbsh_profile_test.go
+++ b/internal/controller/runner/sbsh_profile_test.go
@@ -1,0 +1,184 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises private writeSbshProfile.
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/ctr"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"gopkg.in/yaml.v3"
+)
+
+func TestWriteSbshProfile_NilOrEmptySkipsWrite(t *testing.T) {
+	cases := []struct {
+		name string
+		tty  *intmodel.ContainerTty
+	}{
+		{"nil", nil},
+		{"empty struct", &intmodel.ContainerTty{}},
+		{"only blank scripts", &intmodel.ContainerTty{
+			OnInit: []intmodel.TtyStage{{Script: ""}, {Script: ""}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			spec := intmodel.ContainerSpec{Command: "/bin/bash", Tty: tc.tty}
+			if err := writeSbshProfile(dir, spec); err != nil {
+				t.Fatalf("writeSbshProfile: %v", err)
+			}
+			path := filepath.Join(dir, ctr.AttachableProfileFile)
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("expected no profile file at %s, got err=%v", path, err)
+			}
+		})
+	}
+}
+
+func TestWriteSbshProfile_RendersTerminalProfileYAML(t *testing.T) {
+	dir := t.TempDir()
+	spec := intmodel.ContainerSpec{
+		Command: "/bin/bash",
+		Args:    []string{"-l"},
+		Tty: &intmodel.ContainerTty{
+			Prompt: `"\[\e[1;36m\]claude \u@\h\[\e[0m\]:\w\$ "`,
+			OnInit: []intmodel.TtyStage{
+				{Script: "git pull"},
+				{Script: "claude"},
+			},
+		},
+	}
+	if err := writeSbshProfile(dir, spec); err != nil {
+		t.Fatalf("writeSbshProfile: %v", err)
+	}
+
+	path := filepath.Join(dir, ctr.AttachableProfileFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat profile: %v", err)
+	}
+	// The file lives inside a 0700 daemon-private dir; keep the inner
+	// file at 0600 so a future loosening of the parent does not silently
+	// expose the script body.
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("profile mode = %#o, want 0600", mode)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+
+	var parsed sbshProfileDoc
+	if err = yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal profile: %v\n%s", err, string(data))
+	}
+	if parsed.APIVersion != "sbsh/v1beta1" || parsed.Kind != "TerminalProfile" {
+		t.Errorf("apiVersion/kind = %q/%q, want sbsh/v1beta1 / TerminalProfile",
+			parsed.APIVersion, parsed.Kind)
+	}
+	if parsed.Metadata.Name != ctr.AttachableProfileName {
+		t.Errorf("metadata.name = %q, want %q", parsed.Metadata.Name, ctr.AttachableProfileName)
+	}
+	if parsed.Spec.Shell.Cmd != spec.Command {
+		t.Errorf("spec.shell.cmd = %q, want %q", parsed.Spec.Shell.Cmd, spec.Command)
+	}
+	if len(parsed.Spec.Shell.CmdArgs) != 1 || parsed.Spec.Shell.CmdArgs[0] != "-l" {
+		t.Errorf("spec.shell.cmdArgs = %+v, want [-l]", parsed.Spec.Shell.CmdArgs)
+	}
+	if !parsed.Spec.Shell.InheritEnv {
+		t.Errorf("spec.shell.inheritEnv = false, want true")
+	}
+	if parsed.Spec.Shell.Prompt != spec.Tty.Prompt {
+		t.Errorf("spec.shell.prompt = %q, want %q", parsed.Spec.Shell.Prompt, spec.Tty.Prompt)
+	}
+	if parsed.Spec.Stages == nil || len(parsed.Spec.Stages.OnInit) != 2 {
+		t.Fatalf("spec.stages = %+v, want 2 onInit entries", parsed.Spec.Stages)
+	}
+	if parsed.Spec.Stages.OnInit[0].Script != "git pull" ||
+		parsed.Spec.Stages.OnInit[1].Script != "claude" {
+		t.Errorf("onInit scripts = %+v, want [git pull, claude]", parsed.Spec.Stages.OnInit)
+	}
+}
+
+// TestWriteSbshProfile_EmptyCommandFallsBackToShell covers the case where
+// the container inherits its command from the image's ENTRYPOINT/CMD —
+// sbsh's profile validator still requires shell.cmd, so the daemon
+// substitutes /bin/sh rather than emit an unloadable profile.
+func TestWriteSbshProfile_EmptyCommandFallsBackToShell(t *testing.T) {
+	dir := t.TempDir()
+	spec := intmodel.ContainerSpec{
+		// Command and Args intentionally unset — image-default path.
+		Tty: &intmodel.ContainerTty{Prompt: `"\u\$ "`},
+	}
+	if err := writeSbshProfile(dir, spec); err != nil {
+		t.Fatalf("writeSbshProfile: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ctr.AttachableProfileFile))
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	var parsed sbshProfileDoc
+	if err = yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Spec.Shell.Cmd != fallbackShellCmd {
+		t.Errorf("fallback shell.cmd = %q, want %q", parsed.Spec.Shell.Cmd, fallbackShellCmd)
+	}
+	if len(parsed.Spec.Shell.CmdArgs) != 0 {
+		t.Errorf("fallback shell.cmdArgs = %+v, want empty", parsed.Spec.Shell.CmdArgs)
+	}
+}
+
+func TestWriteSbshProfile_DropsBlankScripts(t *testing.T) {
+	dir := t.TempDir()
+	spec := intmodel.ContainerSpec{
+		Command: "/bin/bash",
+		Tty: &intmodel.ContainerTty{
+			Prompt: `"\u\$ "`,
+			OnInit: []intmodel.TtyStage{
+				{Script: ""},
+				{Script: "echo hi"},
+				{Script: "  "}, // not stripped — caller-supplied whitespace is preserved
+			},
+		},
+	}
+	if err := writeSbshProfile(dir, spec); err != nil {
+		t.Fatalf("writeSbshProfile: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ctr.AttachableProfileFile))
+	if err != nil {
+		t.Fatalf("read profile: %v", err)
+	}
+	var parsed sbshProfileDoc
+	if err = yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Spec.Stages == nil || len(parsed.Spec.Stages.OnInit) != 2 {
+		t.Fatalf("expected 2 stages after dropping empty, got %+v", parsed.Spec.Stages)
+	}
+	if parsed.Spec.Stages.OnInit[0].Script != "echo hi" ||
+		parsed.Spec.Stages.OnInit[1].Script != "  " {
+		t.Errorf("unexpected stages: %+v", parsed.Spec.Stages.OnInit)
+	}
+}

--- a/internal/ctr/attachable.go
+++ b/internal/ctr/attachable.go
@@ -56,6 +56,21 @@ const (
 	// the workload's process. Hard-coded for the foundation slice; the
 	// resolver in #67 will not change it.
 	AttachableSubcommand = "terminal"
+
+	// AttachableProfileFile is the basename of the sbsh TerminalProfile YAML
+	// the daemon writes into the per-container tty directory when a
+	// container declares a tty block. The host pre-writes the file in the
+	// bind-mount source so it appears at AttachableProfilePath inside the
+	// container.
+	AttachableProfileFile = "profile.yaml"
+
+	// AttachableProfilePath is the in-container path of the generated sbsh
+	// TerminalProfile YAML.
+	AttachableProfilePath = AttachableTTYDir + "/" + AttachableProfileFile
+
+	// AttachableProfileName is the profile.metadata.name written into the
+	// generated TerminalProfile and passed to `sbsh terminal --profile`.
+	AttachableProfileName = "kukeon"
 )
 
 // AttachableInjection carries the host-side paths needed to wrap a container's
@@ -72,6 +87,13 @@ type AttachableInjection struct {
 	// host-visible socket that `kuke attach` (#66) connects to is the
 	// `socket` entry inside this directory.
 	HostTTYDir string
+
+	// UseProfile, when true, instructs the wrapper to append
+	// `--profiles-dir AttachableTTYDir --profile AttachableProfileName` to
+	// the sbsh terminal invocation. The runner is responsible for writing
+	// the profile YAML to <HostTTYDir>/AttachableProfileFile before the
+	// container starts; the wrapper itself never touches the filesystem.
+	UseProfile bool
 }
 
 // withAttachableMounts adds the two bind mounts that make sbsh reachable from
@@ -107,26 +129,41 @@ func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 // ENTRYPOINT/CMD) so the wrapped command line is whatever would have run
 // otherwise.
 //
+// When useProfile is true, the wrapper additionally points sbsh at the
+// per-container profile YAML the runner pre-wrote into HostTTYDir, so
+// the generated prompt and onInit scripts take effect on first attach.
+// Profile flags are global on `sbsh`, so they sit before the `terminal`
+// subcommand — sbsh reports `unknown flag` if --profiles-dir/--profile are
+// passed after `terminal`.
+//
 // OCI semantics: process.args is the merged "ENTRYPOINT + CMD" by the time
 // this opt runs (containerd's WithImageConfigArgs has already resolved image
 // defaults and any user override of either). We just wrap the result, which
 // is what Kubernetes failed to do correctly for years and what this issue
 // explicitly tests.
-func withAttachableArgsWrap() oci.SpecOpts {
+func withAttachableArgsWrap(useProfile bool) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
 		if s.Process == nil {
 			s.Process = &runtimespec.Process{}
 		}
 		original := append([]string(nil), s.Process.Args...)
-		wrapped := []string{
-			AttachableBinaryPath,
-			AttachableSubcommand,
+		wrapped := []string{AttachableBinaryPath}
+		if useProfile {
+			wrapped = append(wrapped,
+				"--profiles-dir", AttachableTTYDir,
+			)
+		}
+		wrapped = append(wrapped, AttachableSubcommand)
+		if useProfile {
+			wrapped = append(wrapped, "--profile", AttachableProfileName)
+		}
+		wrapped = append(wrapped,
 			"--run-path", AttachableTTYDir,
 			"--socket", AttachableSocketPath,
 			"--capture-file", AttachableCapturePath,
 			"--log-file", AttachableLogfilePath,
 			"--",
-		}
+		)
 		s.Process.Args = append(wrapped, original...)
 		return nil
 	}

--- a/internal/ctr/attachable.go
+++ b/internal/ctr/attachable.go
@@ -60,13 +60,9 @@ const (
 	// AttachableProfileFile is the basename of the sbsh TerminalProfile YAML
 	// the daemon writes into the per-container tty directory when a
 	// container declares a tty block. The host pre-writes the file in the
-	// bind-mount source so it appears at AttachableProfilePath inside the
-	// container.
+	// bind-mount source so it appears under AttachableTTYDir inside the
+	// container, where sbsh resolves it via --profiles-dir + --profile.
 	AttachableProfileFile = "profile.yaml"
-
-	// AttachableProfilePath is the in-container path of the generated sbsh
-	// TerminalProfile YAML.
-	AttachableProfilePath = AttachableTTYDir + "/" + AttachableProfileFile
 
 	// AttachableProfileName is the profile.metadata.name written into the
 	// generated TerminalProfile and passed to `sbsh terminal --profile`.
@@ -132,9 +128,10 @@ func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 // When useProfile is true, the wrapper additionally points sbsh at the
 // per-container profile YAML the runner pre-wrote into HostTTYDir, so
 // the generated prompt and onInit scripts take effect on first attach.
-// Profile flags are global on `sbsh`, so they sit before the `terminal`
-// subcommand — sbsh reports `unknown flag` if --profiles-dir/--profile are
-// passed after `terminal`.
+// `--profiles-dir` is a global flag on `sbsh` and must precede the
+// `terminal` subcommand; `--profile` is a per-subcommand flag on
+// `terminal` and must follow it. Swapping either placement makes sbsh
+// reject the invocation with `unknown flag`.
 //
 // OCI semantics: process.args is the merged "ENTRYPOINT + CMD" by the time
 // this opt runs (containerd's WithImageConfigArgs has already resolved image

--- a/internal/ctr/attachable_test.go
+++ b/internal/ctr/attachable_test.go
@@ -212,6 +212,74 @@ func TestBuildContainerSpec_AttachableTrue_MountsAndArgsWrap(t *testing.T) {
 	}
 }
 
+// TestBuildContainerSpec_AttachableTrue_ProfileFlagsInjected covers the
+// wrapper change for #139: when AttachableInjection.UseProfile is set, the
+// generated args carry `--profiles-dir <ttydir>` before the `terminal`
+// subcommand and `--profile <name>` immediately after it. Profile flags
+// are sbsh global flags, so positioning matters — `sbsh terminal
+// --profiles-dir …` would surface as `unknown flag` deep inside the
+// container task.
+func TestBuildContainerSpec_AttachableTrue_ProfileFlagsInjected(t *testing.T) {
+	in := intmodel.ContainerSpec{
+		ID:         "c1",
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Attachable: true,
+	}
+	inj := ctr.AttachableInjection{
+		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
+		UseProfile:     true,
+	}
+	spec := applyBuiltSpecWith(t, in, []string{"/bin/sh"}, ctr.WithAttachableInjection(inj))
+
+	want := []string{
+		ctr.AttachableBinaryPath,
+		"--profiles-dir", ctr.AttachableTTYDir,
+		ctr.AttachableSubcommand,
+		"--profile", ctr.AttachableProfileName,
+		"--run-path", ctr.AttachableTTYDir,
+		"--socket", ctr.AttachableSocketPath,
+		"--capture-file", ctr.AttachableCapturePath,
+		"--log-file", ctr.AttachableLogfilePath,
+		"--",
+		"/bin/sh",
+	}
+	if !reflect.DeepEqual(spec.Process.Args, want) {
+		t.Fatalf("Process.Args = %v\nwant %v", spec.Process.Args, want)
+	}
+}
+
+// TestBuildContainerSpec_AttachableTrue_NoProfileWhenUnset confirms the
+// wrapper does NOT inject --profiles-dir / --profile when UseProfile is
+// false — the legacy contract for attachable containers without a tty
+// block must stay byte-identical.
+func TestBuildContainerSpec_AttachableTrue_NoProfileWhenUnset(t *testing.T) {
+	in := intmodel.ContainerSpec{
+		ID:         "c1",
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Attachable: true,
+	}
+	inj := ctr.AttachableInjection{
+		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
+	}
+	spec := applyBuiltSpecWith(t, in, []string{"/bin/sh"}, ctr.WithAttachableInjection(inj))
+
+	for _, arg := range spec.Process.Args {
+		if arg == "--profiles-dir" || arg == "--profile" {
+			t.Fatalf("expected no profile flags when UseProfile=false, got %v", spec.Process.Args)
+		}
+	}
+}
+
 func TestBuildContainerSpec_AttachableTrue_EmptyImageArgs(t *testing.T) {
 	// An image whose ENTRYPOINT+CMD resolves to nothing (uncommon but valid)
 	// must still produce a wrapped args list — the wrapper prefix on its own,

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -260,7 +260,7 @@ func BuildContainerSpec(
 		specOpts = append(
 			specOpts,
 			withAttachableMounts(opts.attachable),
-			withAttachableArgsWrap(),
+			withAttachableArgsWrap(opts.attachable.UseProfile),
 		)
 	}
 

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -33,7 +33,14 @@ type CellSpec struct {
 	SpaceName       string
 	StackName       string
 	RootContainerID string
+	Tty             *CellTty
 	Containers      []ContainerSpec
+}
+
+// CellTty mirrors the v1beta1 CellTty payload. See the v1beta1 type for
+// field semantics.
+type CellTty struct {
+	Default string
 }
 
 type CellStatus struct {

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -59,6 +59,35 @@ type ContainerSpec struct {
 	CNIConfigPath          string
 	RestartPolicy          string
 	Attachable             bool
+	Tty                    *ContainerTty
+}
+
+// ContainerTty mirrors the v1beta1 ContainerTty payload. See the v1beta1
+// type for field semantics.
+type ContainerTty struct {
+	Prompt string
+	OnInit []TtyStage
+}
+
+// TtyStage mirrors the v1beta1 TtyStage payload.
+type TtyStage struct {
+	Script string
+}
+
+// IsEmpty reports whether the tty block carries no user-supplied config.
+func (t *ContainerTty) IsEmpty() bool {
+	if t == nil {
+		return true
+	}
+	if t.Prompt != "" {
+		return false
+	}
+	for _, s := range t.OnInit {
+		if s.Script != "" {
+			return false
+		}
+	}
+	return true
 }
 
 // ContainerSecret references a credential resolved by the daemon at apply

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -35,7 +35,17 @@ type CellSpec struct {
 	SpaceID         string          `json:"spaceId"                   yaml:"spaceId"`
 	StackID         string          `json:"stackId"                   yaml:"stackId"`
 	RootContainerID string          `json:"rootContainerId,omitempty" yaml:"rootContainerId,omitempty"`
+	Tty             *CellTty        `json:"tty,omitempty"             yaml:"tty,omitempty"`
 	Containers      []ContainerSpec `json:"containers"                yaml:"containers"`
+}
+
+// CellTty is cell-level tty/attach config. Kept intentionally minimal: only
+// fields the container or container-level tty cannot express belong here.
+type CellTty struct {
+	// Default names the attachable container `kuke run -a` (phase 2a)
+	// selects when no --container flag is given. Must reference an
+	// existing container in this cell whose Attachable=true (or be empty).
+	Default string `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
 type CellStatus struct {

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -86,7 +86,49 @@ type ContainerSpec struct {
 	// peer of that directory lives in the per-container metadata dir and its
 	// `socket` entry is what `kuke attach` connects to. Default false — no
 	// behavior change for existing specs.
-	Attachable bool `json:"attachable,omitempty" yaml:"attachable,omitempty"`
+	Attachable bool `json:"attachable,omitempty"             yaml:"attachable,omitempty"`
+	// Tty configures shell-UX (prompt, init scripts) for the sbsh wrapper
+	// when Attachable=true. The container model already owns command, args,
+	// workingDir, and env, so Tty intentionally only adds layers the
+	// container model can't express. Setting any tty field with
+	// Attachable=false is a validation error.
+	Tty *ContainerTty `json:"tty,omitempty"                    yaml:"tty,omitempty"`
+}
+
+// ContainerTty carries per-attach shell-UX config that the daemon threads
+// into sbsh terminal on first attach. Has no effect unless Attachable=true.
+type ContainerTty struct {
+	// Prompt is the literal prompt expression sbsh sets in the wrapped
+	// shell, in the same form sbsh's TerminalProfile spec.shell.prompt
+	// accepts (e.g. a quoted PS1-style string).
+	Prompt string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
+	// OnInit are scripts run once when the wrapped shell starts, in order.
+	OnInit []TtyStage `json:"onInit,omitempty" yaml:"onInit,omitempty"`
+}
+
+// TtyStage is a single onInit script entry. Wrapped in a struct rather than
+// a bare string so future stage knobs (timeout, runOn, etc.) can land
+// without breaking the YAML shape.
+type TtyStage struct {
+	Script string `json:"script,omitempty" yaml:"script,omitempty"`
+}
+
+// IsEmpty reports whether the tty block carries no user-supplied config —
+// i.e. equivalent to omitting the block entirely. Used by validation to
+// distinguish "explicitly empty" from "any field set".
+func (t *ContainerTty) IsEmpty() bool {
+	if t == nil {
+		return true
+	}
+	if t.Prompt != "" {
+		return false
+	}
+	for _, s := range t.OnInit {
+		if s.Script != "" {
+			return false
+		}
+	}
+	return true
 }
 
 // ContainerSecret references a credential that the daemon resolves at apply


### PR DESCRIPTION
## Summary
- Adds `ContainerSpec.Tty` (`prompt`, `onInit[].script`) and `CellSpec.Tty.Default` to v1beta1, with the matching internal-modelhub mirrors and round-trip plumbing in `apischeme`.
- Validates `tty` fields require `attachable: true`, and that `cell.tty.default` references an existing attachable container in the same cell (or is empty).
- Threads prompt + onInit through to `sbsh terminal` by writing a per-container TerminalProfile YAML into the bind-mounted tty dir and pointing sbsh at it via `--profiles-dir <ttydir>` (global, before `terminal`) and `--profile kukeon` (per-subcommand, after `terminal`).
- Mirrors `ContainerSpec.Command`/`Args` into the profile's `shell.cmd`/`cmdArgs` and sets `inheritEnv: true` — sbsh's profile validator requires `shell.cmd`, and using the profile path silently drops post-`--` workload args. Falls back to `/bin/sh` when the container inherits its command from the image's ENTRYPOINT/CMD.

## Test plan
- [x] `go vet ./...` — clean
- [x] `make test` — all packages pass
- [x] `make e2e` — `TestKuke_AttachDetach_KeepsTaskRunning` fails on this branch **and on `origin/main`** with `kuke attach exited with code 1 (want 0)` from sbsh's read/write loop teardown — pre-existing, not caused by this change. Other cell-state e2es require root for `/run/kukeon/kukeond.sock` and pass identically against the new daemon (parity with main confirmed by re-running on stashed state).
- [x] Smoke test per CLAUDE.md (kukeond rebuild + `kuke init` + apply + parity):
  - Tear down + rebuild + image import + `kuke init` succeeds.
  - `kuke get realms` and `kuke get realms --no-daemon` byte-identical.
  - `kuke get cells` and `kuke get cells --no-daemon` byte-identical (parity check).
- [x] AC smoke: applied an attachable cell carrying a tty block:
  ```yaml
  spec:
    tty:
      default: work
    containers:
      - id: work
        image: registry.eminwux.com/busybox:latest
        command: /bin/sh
        attachable: true
        tty:
          prompt: '"\[\e[1;36m\]kuke139 \u@\h\[\e[0m\]:\w\$ "'
          onInit:
            - script: echo "kuke139 onInit fired" > /tmp/kuke139.flag
  ```
  - The container task came up `RUNNING`, the daemon-written `/run/kukeon/tty/profile.yaml` had the expected shape, and the sbsh capture file showed `export PS1="\[\e[1;36m\]kuke139 \u@\h\[\e[0m\]:\w\$ "` followed by the colorized `kuke139 root@…` prompt.
  - `ctr tasks exec … cat /tmp/kuke139.flag` returned `kuke139 onInit fired`, confirming the init script ran.

## AC checklist
- [x] `ContainerSpec.Tty` with `Prompt` and `OnInit` only.
- [x] `CellSpec.Tty.Default` defined; validated against attachable containers in the same cell (or empty).
- [x] Validation error when any `tty` field is set with `attachable: false` (covered by unit + nested-in-cell tests).
- [x] Daemon's sbsh-wrapper injection threads `prompt` and `onInit` through to sbsh terminal.
- [x] `apply -f` round-trips a populated `tty` block (no fields dropped).
- [x] Smoke test: attach showed configured prompt + init script ran (verified via capture + flag file).
- [x] Daemon-parity check: `kuke get cells` identical with and without `--no-daemon`.

## Notes
- Profile vs flags: I considered a flag-based approach (`--prompt`, `--on-init`) but sbsh exposes neither — its closest hooks are the global `--profiles-dir` + per-command `--profile` (or `-f` for an inline JSON spec). The profile route lets the issue's `spec.shell.prompt` / `spec.stages.onInit[].script` shape land verbatim, and is what `~/.sbsh/profiles.d/` already uses upstream.
- Post-`--` workload positioning: kept for compatibility with non-tty attachable containers; sbsh ignores it when `--profile` is found, so the wrapper preserves the original args in argv without changing semantics.

Closes #139