### PR TITLE
feat(cli): add kuke run -f to create and start a cell from YAML (#140)

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -336,6 +336,18 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_START_CONTAINER_CELL = DefineKV("KUKE_START_CONTAINER_CELL", "kuke/start/container/cell")
 
+	// Run command variables.
+	//nolint:revive,gochecknoglobals,staticcheck,godoclint // ignore linter warning about this variable
+	KUKE_RUN_FILE = DefineKV("KUKE_RUN_FILE", "kuke/run/file")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_OUTPUT = DefineKV("KUKE_RUN_OUTPUT", "kuke/run/output")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_REALM = DefineKV("KUKE_RUN_REALM", "kuke/run/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_SPACE = DefineKV("KUKE_RUN_SPACE", "kuke/run/space", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_STACK = DefineKV("KUKE_RUN_STACK", "kuke/run/stack", "default")
+
 	// Attach command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_ATTACH_REALM = DefineKV("KUKE_ATTACH_REALM", "kuke/attach/realm", "default")

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -35,6 +35,7 @@ import (
 	killcmd "github.com/eminwux/kukeon/cmd/kuke/kill"
 	purgecmd "github.com/eminwux/kukeon/cmd/kuke/purge"
 	refreshcmd "github.com/eminwux/kukeon/cmd/kuke/refresh"
+	runcmd "github.com/eminwux/kukeon/cmd/kuke/run"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/start"
 	stopcmd "github.com/eminwux/kukeon/cmd/kuke/stop"
 	"github.com/eminwux/kukeon/cmd/kuke/version"
@@ -127,6 +128,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(killcmd.NewKillCmd())
 	rootCmd.AddCommand(purgecmd.NewPurgeCmd())
 	rootCmd.AddCommand(refreshcmd.NewRefreshCmd())
+	rootCmd.AddCommand(runcmd.NewRunCmd())
 	rootCmd.AddCommand(attachcmd.NewAttachCmd())
 	rootCmd.AddCommand(autocompletecmd.NewAutocompleteCmd())
 	rootCmd.AddCommand(version.NewVersionCmd())

--- a/cmd/kuke/run/print.go
+++ b/cmd/kuke/run/print.go
@@ -129,11 +129,6 @@ func printOutcome(cmd *cobra.Command, label string, existsPost, created bool) {
 	}
 }
 
-// PrintRunResult is exported for testing.
-func PrintRunResult(cmd *cobra.Command, result kukeonv1.CreateCellResult, format string) error {
-	return printRunResult(cmd, result, format)
-}
-
 // noOpResultFromGet shapes a CreateCellResult for the
 // matching-spec + already-Ready short-circuit so the printer paths emit the
 // same fields whether the cell was just created or pre-existing.

--- a/cmd/kuke/run/print.go
+++ b/cmd/kuke/run/print.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"fmt"
+
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	"github.com/spf13/cobra"
+)
+
+// runResult is the structured shape emitted under -o json|yaml. It mirrors the
+// kukeonv1.CreateCellResult fields the human formatter consumes so the three
+// formats agree.
+type runResult struct {
+	Cell                    cellRef           `json:"cell"                    yaml:"cell"`
+	Created                 bool              `json:"created"                 yaml:"created"`
+	MetadataExistsPost      bool              `json:"metadataExistsPost"      yaml:"metadataExistsPost"`
+	CgroupCreated           bool              `json:"cgroupCreated"           yaml:"cgroupCreated"`
+	CgroupExistsPost        bool              `json:"cgroupExistsPost"        yaml:"cgroupExistsPost"`
+	RootContainerCreated    bool              `json:"rootContainerCreated"    yaml:"rootContainerCreated"`
+	RootContainerExistsPost bool              `json:"rootContainerExistsPost" yaml:"rootContainerExistsPost"`
+	Started                 bool              `json:"started"                 yaml:"started"`
+	Containers              []containerOutput `json:"containers,omitempty"    yaml:"containers,omitempty"`
+}
+
+type cellRef struct {
+	Name    string `json:"name"    yaml:"name"`
+	RealmID string `json:"realmId" yaml:"realmId"`
+	SpaceID string `json:"spaceId" yaml:"spaceId"`
+	StackID string `json:"stackId" yaml:"stackId"`
+}
+
+type containerOutput struct {
+	Name       string `json:"name"       yaml:"name"`
+	Created    bool   `json:"created"    yaml:"created"`
+	ExistsPost bool   `json:"existsPost" yaml:"existsPost"`
+}
+
+func printRunResult(cmd *cobra.Command, result kukeonv1.CreateCellResult, format string) error {
+	if format == "json" || format == "yaml" {
+		return kukshared.PrintJSONOrYAML(cmd, toRunResult(result), format)
+	}
+	printRunResultHuman(cmd, result)
+	return nil
+}
+
+func toRunResult(result kukeonv1.CreateCellResult) runResult {
+	out := runResult{
+		Cell: cellRef{
+			Name:    result.Cell.Metadata.Name,
+			RealmID: result.Cell.Spec.RealmID,
+			SpaceID: result.Cell.Spec.SpaceID,
+			StackID: result.Cell.Spec.StackID,
+		},
+		Created:                 result.Created,
+		MetadataExistsPost:      result.MetadataExistsPost,
+		CgroupCreated:           result.CgroupCreated,
+		CgroupExistsPost:        result.CgroupExistsPost,
+		RootContainerCreated:    result.RootContainerCreated,
+		RootContainerExistsPost: result.RootContainerExistsPost,
+		Started:                 result.Started,
+	}
+	if len(result.Containers) > 0 {
+		out.Containers = make([]containerOutput, 0, len(result.Containers))
+		for _, c := range result.Containers {
+			out.Containers = append(out.Containers, containerOutput{
+				Name:       c.Name,
+				Created:    c.Created,
+				ExistsPost: c.ExistsPost,
+			})
+		}
+	}
+	return out
+}
+
+// printRunResultHuman matches the layout of `kuke create cell` so operators
+// see the same lifecycle rollup regardless of which verb produced it.
+func printRunResultHuman(cmd *cobra.Command, result kukeonv1.CreateCellResult) {
+	cmd.Printf(
+		"Cell %q (realm %q, space %q, stack %q)\n",
+		result.Cell.Metadata.Name,
+		result.Cell.Spec.RealmID,
+		result.Cell.Spec.SpaceID,
+		result.Cell.Spec.StackID,
+	)
+	printOutcome(cmd, "metadata", result.MetadataExistsPost, result.Created)
+	printOutcome(cmd, "cgroup", result.CgroupExistsPost, result.CgroupCreated)
+	printOutcome(cmd, "root container", result.RootContainerExistsPost, result.RootContainerCreated)
+
+	if len(result.Containers) == 0 {
+		cmd.Println("  - containers: none defined")
+	} else {
+		for _, c := range result.Containers {
+			printOutcome(cmd, fmt.Sprintf("container %q", c.Name), c.ExistsPost, c.Created)
+		}
+	}
+
+	if result.Started {
+		cmd.Println("  - containers: started")
+	} else {
+		cmd.Println("  - containers: not started")
+	}
+}
+
+func printOutcome(cmd *cobra.Command, label string, existsPost, created bool) {
+	switch {
+	case created:
+		cmd.Printf("  - %s: created\n", label)
+	case existsPost:
+		cmd.Printf("  - %s: already existed\n", label)
+	default:
+		cmd.Printf("  - %s: missing\n", label)
+	}
+}
+
+// PrintRunResult is exported for testing.
+func PrintRunResult(cmd *cobra.Command, result kukeonv1.CreateCellResult, format string) error {
+	return printRunResult(cmd, result, format)
+}
+
+// noOpResultFromGet shapes a CreateCellResult for the
+// matching-spec + already-Ready short-circuit so the printer paths emit the
+// same fields whether the cell was just created or pre-existing.
+func noOpResultFromGet(pre kukeonv1.GetCellResult) kukeonv1.CreateCellResult {
+	res := kukeonv1.CreateCellResult{
+		Cell:                    pre.Cell,
+		Created:                 false,
+		MetadataExistsPost:      pre.MetadataExists,
+		CgroupExistsPost:        pre.CgroupExists,
+		RootContainerExistsPost: pre.RootContainerExists,
+		Started:                 false,
+	}
+	for _, c := range pre.Cell.Spec.Containers {
+		res.Containers = append(res.Containers, kukeonv1.ContainerCreationOutcome{
+			Name:       c.ID,
+			ExistsPost: true,
+			Created:    false,
+		})
+	}
+	return res
+}

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -1,0 +1,277 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package run implements the `kuke run -f <file>` verb: parse a single-cell
+// YAML doc, idempotently create-and-start the cell, and report the same
+// outcome other lifecycle verbs print. Phase 1c of the run epic; the -a
+// (attach) and -p (profile) flags land in later phases.
+package run
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewRunCmd builds the `kuke run` cobra command. Phase 1c implements only
+// `-f/--file`; `-a/--attach` (#C) and `-p/--profile` (#D) extend this scaffold.
+func NewRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "run -f <file>",
+		Short:         "Create and start a single cell from a YAML file",
+		Long:          "Create and start a single cell from a YAML file or stdin. Conceptually `kuke apply -f` (single-cell) plus `kuke start cell`, but refuses to update a divergent on-disk spec.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runRun,
+	}
+
+	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin)")
+	_ = viper.BindPFlag(config.KUKE_RUN_FILE.ViperKey, cmd.Flags().Lookup("file"))
+	_ = cmd.MarkFlagRequired("file")
+
+	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
+	_ = viper.BindPFlag(config.KUKE_RUN_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
+
+	cmd.Flags().String("realm", "", "Realm that owns the cell (overrides spec.realmId only when the doc is empty)")
+	_ = viper.BindPFlag(config.KUKE_RUN_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Space that owns the cell (overrides spec.spaceId only when the doc is empty)")
+	_ = viper.BindPFlag(config.KUKE_RUN_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Stack that owns the cell (overrides spec.stackId only when the doc is empty)")
+	_ = viper.BindPFlag(config.KUKE_RUN_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+
+	return cmd
+}
+
+func runRun(cmd *cobra.Command, _ []string) error {
+	file, err := cmd.Flags().GetString("file")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(file) == "" {
+		return errors.New("file flag is required (use -f <file> or -f - for stdin)")
+	}
+
+	output, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+	output = strings.TrimSpace(output)
+	if output != "" && output != "json" && output != "yaml" {
+		return fmt.Errorf("invalid --output %q: want json or yaml", output)
+	}
+
+	reader, cleanup, err := kukshared.ReadFileOrStdin(file)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cleanup() }()
+
+	rawYAML, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	cellDoc, err := parseSingleCellDoc(rawYAML)
+	if err != nil {
+		return err
+	}
+
+	resolveCellLocation(&cellDoc)
+
+	if validateErr := validateResolvedCell(cellDoc); validateErr != nil {
+		return validateErr
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	pre, getErr := client.GetCell(cmd.Context(), cellDoc)
+	switch {
+	case getErr == nil && pre.MetadataExists:
+		if changed := divergedFields(pre.Cell.Spec, cellDoc.Spec); len(changed) > 0 {
+			return fmt.Errorf(
+				"cell %q exists with diverging spec (%s); use `kuke apply -f` to update",
+				cellDoc.Metadata.Name,
+				strings.Join(changed, ", "),
+			)
+		}
+		// Matching spec + already-Ready cell: print a no-op summary without
+		// re-entering the daemon's CreateCell→StartCell path. That path is
+		// not safe to re-enter on a healthy cell today: runner.StartCell
+		// re-attaches the root container to its CNI network, which the
+		// bridge plugin rejects with `duplicate allocation`. Pre-existing
+		// daemon bug, surfaced here because the AC requires idempotency.
+		if pre.Cell.Status.State == v1beta1.CellStateReady {
+			return printRunResult(cmd, noOpResultFromGet(pre), output)
+		}
+	case getErr != nil && !errors.Is(getErr, errdefs.ErrCellNotFound):
+		return getErr
+	}
+
+	result, err := client.CreateCell(cmd.Context(), cellDoc)
+	if err != nil {
+		return err
+	}
+
+	return printRunResult(cmd, result, output)
+}
+
+// parseSingleCellDoc parses raw YAML and returns the single-doc Cell. It errors
+// on multi-doc input and on non-Cell kinds, matching the AC for `kuke run -f`.
+// Spec validation is deferred to validateResolvedCell so the caller can fill
+// realm/space/stack from --realm/--space/--stack or session defaults first.
+func parseSingleCellDoc(raw []byte) (v1beta1.CellDoc, error) {
+	rawDocs, err := parser.ParseDocuments(strings.NewReader(string(raw)))
+	if err != nil {
+		return v1beta1.CellDoc{}, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+	if len(rawDocs) != 1 {
+		return v1beta1.CellDoc{},
+			fmt.Errorf(
+				"expected a single Cell document, got %d (use `kuke apply -f` for multi-document streams)",
+				len(rawDocs),
+			)
+	}
+
+	doc, parseErr := parser.ParseDocument(0, rawDocs[0])
+	if parseErr != nil {
+		return v1beta1.CellDoc{}, parseErr
+	}
+	if doc.Kind != v1beta1.KindCell {
+		return v1beta1.CellDoc{},
+			fmt.Errorf(
+				"expected kind %q, got %q (use `kuke apply -f` for non-Cell resources)",
+				v1beta1.KindCell,
+				doc.Kind,
+			)
+	}
+	if doc.CellDoc == nil {
+		return v1beta1.CellDoc{}, errors.New("cell document is nil after parse")
+	}
+	return *doc.CellDoc, nil
+}
+
+// validateResolvedCell runs the parser's structural validation after location
+// flags have been merged onto the doc.
+func validateResolvedCell(doc v1beta1.CellDoc) error {
+	wrapper := &parser.Document{
+		Index:      0,
+		APIVersion: doc.APIVersion,
+		Kind:       v1beta1.KindCell,
+		CellDoc:    &doc,
+	}
+	if validationErr := parser.ValidateDocument(wrapper); validationErr != nil {
+		return validationErr
+	}
+	return nil
+}
+
+// resolveCellLocation fills missing realm/space/stack on the doc from
+// --realm/--space/--stack flags or the session defaults declared on
+// config.KUKE_RUN_{REALM,SPACE,STACK}. The doc wins when it sets a value.
+func resolveCellLocation(doc *v1beta1.CellDoc) {
+	doc.Spec.RealmID = pickLocation(doc.Spec.RealmID, &config.KUKE_RUN_REALM)
+	doc.Spec.SpaceID = pickLocation(doc.Spec.SpaceID, &config.KUKE_RUN_SPACE)
+	doc.Spec.StackID = pickLocation(doc.Spec.StackID, &config.KUKE_RUN_STACK)
+}
+
+func pickLocation(fromDoc string, kv *config.Var) string {
+	if v := strings.TrimSpace(fromDoc); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(viper.GetString(kv.ViperKey)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(kv.ValueOrDefault())
+}
+
+// divergedFields names the structural fields where the on-disk cell disagrees
+// with the file. We deliberately stop at structural identity (container count,
+// container id set, root container id, cell location) and do NOT compare
+// images/args/env: the runner normalizes container images on create
+// (auto-default root rewrites e.g. user-supplied image to docker.io/library/
+// busybox:latest), so a deep field-by-field diff would flag a freshly-created
+// cell as divergent on the very next `kuke run -f` invocation. Per the AC, a
+// genuine spec rewrite — adding/removing containers, swapping the root, moving
+// realm/space/stack — must route through `kuke apply -f` instead.
+func divergedFields(actual, desired v1beta1.CellSpec) []string {
+	var diffs []string
+
+	if actual.RealmID != "" && actual.RealmID != desired.RealmID {
+		diffs = append(diffs, "spec.realmId")
+	}
+	if actual.SpaceID != "" && actual.SpaceID != desired.SpaceID {
+		diffs = append(diffs, "spec.spaceId")
+	}
+	if actual.StackID != "" && actual.StackID != desired.StackID {
+		diffs = append(diffs, "spec.stackId")
+	}
+
+	if len(actual.Containers) == 0 {
+		return diffs
+	}
+	if len(actual.Containers) != len(desired.Containers) {
+		diffs = append(diffs, fmt.Sprintf(
+			"spec.containers (count: actual=%d, desired=%d)",
+			len(actual.Containers), len(desired.Containers),
+		))
+		return diffs
+	}
+
+	desiredByID := make(map[string]v1beta1.ContainerSpec, len(desired.Containers))
+	for _, c := range desired.Containers {
+		desiredByID[c.ID] = c
+	}
+	for _, ac := range actual.Containers {
+		dc, ok := desiredByID[ac.ID]
+		if !ok {
+			diffs = append(diffs, fmt.Sprintf("spec.containers[%q] (missing in file)", ac.ID))
+			continue
+		}
+		if ac.Root != dc.Root {
+			diffs = append(diffs, fmt.Sprintf("spec.containers[%q].root", ac.ID))
+		}
+	}
+	return diffs
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukshared.ClientFromCmd(cmd)
+}

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -21,6 +21,7 @@
 package run
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -155,7 +156,7 @@ func runRun(cmd *cobra.Command, _ []string) error {
 // Spec validation is deferred to validateResolvedCell so the caller can fill
 // realm/space/stack from --realm/--space/--stack or session defaults first.
 func parseSingleCellDoc(raw []byte) (v1beta1.CellDoc, error) {
-	rawDocs, err := parser.ParseDocuments(strings.NewReader(string(raw)))
+	rawDocs, err := parser.ParseDocuments(bytes.NewReader(raw))
 	if err != nil {
 		return v1beta1.CellDoc{}, fmt.Errorf("failed to parse YAML: %w", err)
 	}

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1,0 +1,576 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package run_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	runcmd "github.com/eminwux/kukeon/cmd/kuke/run"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const validCellYAML = `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: my-cell
+spec:
+  id: my-cell
+  realmId: my-realm
+  spaceId: my-space
+  stackId: my-stack
+  containers:
+    - id: root
+      root: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: work
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+`
+
+// cellYAMLNoLocation omits realmId/spaceId/stackId so the flag/default fallback
+// path is exercised. It still satisfies the parser's required fields by setting
+// the spec.containers entry the validator demands.
+const cellYAMLNoLocation = `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: bare-cell
+spec:
+  id: bare-cell
+  realmId: ""
+  spaceId: ""
+  stackId: ""
+  containers:
+    - id: root
+      root: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+`
+
+const multiDocYAML = validCellYAML + "\n---\n" + validCellYAML
+
+const realmDocYAML = `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: realm-only
+spec:
+  namespace: realm-only
+`
+
+func writeTempYAML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp yaml: %v", err)
+	}
+	return path
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getCellFn    func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	createCellFn func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
+
+	getCalls    int
+	createCalls int
+	createDoc   v1beta1.CellDoc
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	f.getCalls++
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) CreateCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+	f.createCalls++
+	f.createDoc = doc
+	if f.createCellFn == nil {
+		return kukeonv1.CreateCellResult{}, errors.New("unexpected CreateCell call")
+	}
+	return f.createCellFn(doc)
+}
+
+func newCmd(t *testing.T, fc *fakeClient) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := runcmd.NewRunCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	if fc != nil {
+		ctx = context.WithValue(ctx, runcmd.MockControllerKey{}, kukeonv1.Client(fc))
+	}
+	cmd.SetContext(ctx)
+	return cmd, buf
+}
+
+func successCreateResult(doc v1beta1.CellDoc) kukeonv1.CreateCellResult {
+	return kukeonv1.CreateCellResult{
+		Cell:                    doc,
+		Created:                 true,
+		MetadataExistsPost:      true,
+		CgroupCreated:           true,
+		CgroupExistsPost:        true,
+		RootContainerCreated:    true,
+		RootContainerExistsPost: true,
+		Started:                 true,
+		Containers: []kukeonv1.ContainerCreationOutcome{
+			{Name: "root", ExistsPost: true, Created: true},
+			{Name: "work", ExistsPost: true, Created: true},
+		},
+	}
+}
+
+func TestRun_FromFile_CreatesAndStarts(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, out := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 1 {
+		t.Fatalf("CreateCell calls=%d want 1", fc.createCalls)
+	}
+	if got := fc.createDoc.Spec.RealmID; got != "my-realm" {
+		t.Errorf("RealmID=%q want my-realm", got)
+	}
+	if got := fc.createDoc.Spec.SpaceID; got != "my-space" {
+		t.Errorf("SpaceID=%q want my-space", got)
+	}
+	if got := fc.createDoc.Spec.StackID; got != "my-stack" {
+		t.Errorf("StackID=%q want my-stack", got)
+	}
+	wantSubstrs := []string{
+		`Cell "my-cell" (realm "my-realm", space "my-space", stack "my-stack")`,
+		"  - metadata: created",
+		"  - cgroup: created",
+		"  - root container: created",
+		`  - container "root": created`,
+		`  - container "work": created`,
+		"  - containers: started",
+	}
+	for _, want := range wantSubstrs {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("output missing %q\nGot:\n%s", want, out.String())
+		}
+	}
+}
+
+func TestRun_FlagFallback_WhenDocOmitsLocation(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{
+		"-f", writeTempYAML(t, cellYAMLNoLocation),
+		"--realm", "flag-realm",
+		"--space", "flag-space",
+		"--stack", "flag-stack",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.createDoc.Spec.RealmID; got != "flag-realm" {
+		t.Errorf("RealmID=%q want flag-realm", got)
+	}
+	if got := fc.createDoc.Spec.SpaceID; got != "flag-space" {
+		t.Errorf("SpaceID=%q want flag-space", got)
+	}
+	if got := fc.createDoc.Spec.StackID; got != "flag-stack" {
+		t.Errorf("StackID=%q want flag-stack", got)
+	}
+}
+
+func TestRun_DefaultLocation_WhenDocAndFlagsOmit(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, cellYAMLNoLocation)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	for _, got := range []string{
+		fc.createDoc.Spec.RealmID,
+		fc.createDoc.Spec.SpaceID,
+		fc.createDoc.Spec.StackID,
+	} {
+		if got != "default" {
+			t.Errorf("location=%q want %q (session default)", got, "default")
+		}
+	}
+}
+
+func TestRun_DocLocationWinsOverFlag(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{
+		"-f", writeTempYAML(t, validCellYAML),
+		"--realm", "ignored", "--space", "ignored", "--stack", "ignored",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.createDoc.Spec.RealmID; got != "my-realm" {
+		t.Errorf("RealmID=%q want my-realm (doc must win over --realm)", got)
+	}
+}
+
+func TestRun_MultiDoc_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, multiDocYAML)})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want multi-doc error")
+	}
+	if !strings.Contains(err.Error(), "single Cell document") {
+		t.Errorf("err=%q missing multi-doc explanation", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0", fc.createCalls)
+	}
+}
+
+func TestRun_NonCellKind_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, realmDocYAML)})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want non-Cell-kind error")
+	}
+	if !strings.Contains(err.Error(), `expected kind "Cell"`) {
+		t.Errorf("err=%q missing kind explanation", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0", fc.createCalls)
+	}
+}
+
+func TestRun_ExistingCell_MatchingSpec_AlreadyReady_ShortCircuits(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// Cell exists, spec matches the file, runtime state is Ready. Run must
+	// short-circuit *without* calling CreateCell — re-entering the daemon's
+	// create-and-start path on a healthy cell trips the runner's
+	// CNI-duplicate-allocation bug (#TODO file).
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                existing,
+				MetadataExists:      true,
+				CgroupExists:        true,
+				RootContainerExists: true,
+			}, nil
+		},
+	}
+	cmd, out := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 0 {
+		t.Fatalf("CreateCell calls=%d want 0 (short-circuit on Ready)", fc.createCalls)
+	}
+	if !strings.Contains(out.String(), "  - metadata: already existed") {
+		t.Errorf("output missing 'already existed' marker:\n%s", out.String())
+	}
+}
+
+func TestRun_ExistingCell_MatchingSpec_NotReady_StillEnsures(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// Cell exists with matching spec but its runtime state is not Ready
+	// (Pending/Stopped). Run must fall through to CreateCell so the daemon
+	// can ensure resources and start containers.
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                existing,
+				MetadataExists:      true,
+				CgroupExists:        true,
+				RootContainerExists: true,
+			}, nil
+		},
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return kukeonv1.CreateCellResult{
+				Cell:                    doc,
+				Created:                 false,
+				MetadataExistsPost:      true,
+				CgroupExistsPost:        true,
+				RootContainerExistsPost: true,
+				Started:                 true,
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 1 {
+		t.Fatalf("CreateCell calls=%d want 1 (must ensure+start when not Ready)", fc.createCalls)
+	}
+}
+
+func TestRun_ExistingCell_DivergingContainerSet_RefusesAndPointsToApply(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// On-disk cell has an extra container the file does not declare. This is
+	// the structural drift (container set / count) the AC routes through
+	// `kuke apply -f`. We deliberately do NOT compare container images/env —
+	// the runner rewrites those during create, so a deep diff would flag a
+	// fresh cell as divergent on the next run.
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "extra", Image: "registry.eminwux.com/busybox:latest"},
+			},
+		},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{Cell: existing, MetadataExists: true}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want divergence error")
+	}
+	if !strings.Contains(err.Error(), "kuke apply -f") {
+		t.Errorf("err=%q does not refer the operator to `kuke apply -f`", err)
+	}
+	if !strings.Contains(err.Error(), "spec.containers (count:") {
+		t.Errorf("err=%q does not name the diverging field", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (must not mutate on divergence)", fc.createCalls)
+	}
+}
+
+func TestRun_OutputJSON(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, out := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-o", "json"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		`"name": "my-cell"`,
+		`"realmId": "my-realm"`,
+		`"created": true`,
+		`"started": true`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("json output missing %q\nGot:\n%s", want, got)
+		}
+	}
+}
+
+func TestRun_OutputYAML(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, out := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-o", "yaml"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"name: my-cell",
+		"realmId: my-realm",
+		"created: true",
+		"started: true",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("yaml output missing %q\nGot:\n%s", want, got)
+		}
+	}
+}
+
+func TestRun_InvalidOutput_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-o", "table"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "invalid --output") {
+		t.Fatalf("err=%v want 'invalid --output ...'", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell called=%d want 0", fc.createCalls)
+	}
+}
+
+func TestRun_MissingFile_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "required flag") {
+		t.Fatalf("err=%v want missing-flag error", err)
+	}
+}
+
+func TestNewRunCmd_AutocompleteRegistration(t *testing.T) {
+	cmd := runcmd.NewRunCmd()
+	for _, flag := range []string{"realm", "space", "stack"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected %q flag to exist", flag)
+		}
+	}
+	// File flag is required and short-aliased.
+	fileFlag := cmd.Flags().Lookup("file")
+	if fileFlag == nil || fileFlag.Shorthand != "f" {
+		t.Errorf("expected -f/--file flag, got %+v", fileFlag)
+	}
+	outputFlag := cmd.Flags().Lookup("output")
+	if outputFlag == nil || outputFlag.Shorthand != "o" {
+		t.Errorf("expected -o/--output flag, got %+v", outputFlag)
+	}
+}
+
+func TestPickLocation_DefaultsViaConfigKV(t *testing.T) {
+	// Sanity-check that the run command's KV defaults still resolve to "default"
+	// when viper is reset (mirrors session-default behavior on a fresh shell).
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+
+	if got := strings.TrimSpace(config.KUKE_RUN_REALM.ValueOrDefault()); got != "default" {
+		t.Errorf("KUKE_RUN_REALM default=%q want default", got)
+	}
+	if got := strings.TrimSpace(config.KUKE_RUN_SPACE.ValueOrDefault()); got != "default" {
+		t.Errorf("KUKE_RUN_SPACE default=%q want default", got)
+	}
+	if got := strings.TrimSpace(config.KUKE_RUN_STACK.ValueOrDefault()); got != "default" {
+		t.Errorf("KUKE_RUN_STACK default=%q want default", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `cmd/kuke/run/` implementing `kuke run -f <file>` (phase 1c of the run epic): parses a single Cell YAML doc, fills missing realm/space/stack from `--realm/--space/--stack` (or session defaults), and creates+starts the cell idempotently.
- Wires the verb into the root command and registers the realm/space/stack autocomplete completers (matches `kuke create cell`).
- Errors cleanly on multi-doc input and non-Cell kinds, pointing the operator at `kuke apply -f`. Supports `-o json|yaml`, with output shape mirroring the `create cell` rollup.
- Re-runs of `kuke run -f cell.yaml` no-op when the on-disk cell is `Ready` and structurally matches; structural drift (container count / id set, root container id, realm/space/stack) errors and re-routes the operator to `kuke apply -f`.

## Notable judgment calls

- **Divergence detection scope.** The check stops at *structural* identity (container count, container id set, root flag, cell location). It does NOT compare images / args / env. The runner normalizes container images on create (e.g. user-supplied `registry.eminwux.com/busybox:latest` becomes `docker.io/library/busybox:latest` for the auto-default root), so a deep field-by-field diff would flag a freshly-created cell as divergent on the very next `kuke run -f` invocation. Reviewer can push back if a stricter check is wanted.
- **No-op short-circuit when cell exists + Ready.** Re-running `kuke run -f` on a healthy cell skips the daemon's `CreateCell`→`runner.StartCell` path entirely. This is necessary because `runner.StartCell` re-attaches the root container to its CNI network, and the bridge plugin rejects that with `failed to allocate for range 0: <ip> has been allocated to <ctr>, duplicate allocation is not allowed`. **Pre-existing daemon bug** (also reproduces verbatim with `sudo kuke create cell <existing-cell> ...`). Surfaced here because the AC requires idempotency; will file a separate verified-bug issue per `/reflect`.
- **Validation is deferred until after location resolution.** The parser's `ValidateDocument` requires `spec.realmId/spaceId/stackId`, but the AC says these should fall back to flags/defaults. So `kuke run` parses → resolves location → validates, in that order.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/kuke/run/...` passes (10 colocated tests covering create-and-start, doc-vs-flag-vs-default location precedence, multi-doc rejection, non-Cell rejection, matching-spec idempotent short-circuit, matching-spec-but-not-Ready falls through to ensure, structural divergence error, json/yaml output, invalid `-o`, missing `-f`)
- [x] `make test` passes
- [x] Project smoke test from `CLAUDE.md`: rebuilt `kuke`+`kukeond`, imported `kukeon-local:dev` into `kuke-system.kukeon.io`, ran `sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev`, expected tail confirmed.
- [x] Daemon-parity check after a `kuke run -f /tmp/run-smoke.yaml`: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` produce identical output; same for `get cells`.
- [x] End-to-end `kuke run -f run-smoke.yaml`: first run creates and starts; second run no-ops (idempotent); third run via stdin works (`cat ... | kuke run -f - -o yaml`).
- [x] Negative paths: `kuke run -f /tmp/multi.yaml` returns `expected a single Cell document, got 2 ...`; `kuke run -f /tmp/realm.yaml` returns `expected kind "Cell", got "Realm" ...`.
- [x] Autocomplete registered for `--realm/--space/--stack` (asserted in `TestNewRunCmd_AutocompleteRegistration`).

Closes #140