### PR TITLE
feat(cli): kuke run -a / --attach (phase 2a of #141)

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -347,6 +347,10 @@ var (
 	KUKE_RUN_SPACE = DefineKV("KUKE_RUN_SPACE", "kuke/run/space", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_STACK = DefineKV("KUKE_RUN_STACK", "kuke/run/stack", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_ATTACH = DefineKV("KUKE_RUN_ATTACH", "kuke/run/attach")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_CONTAINER = DefineKV("KUKE_RUN_CONTAINER", "kuke/run/container")
 
 	// Attach command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/run/attach.go
+++ b/cmd/kuke/run/attach.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/eminwux/sbsh/pkg/attach"
+	"github.com/spf13/cobra"
+)
+
+// MockRunKey is used to inject a mock runFn via context in tests, so the
+// real pkg/attach.Run (which would open a TTY and connect to a real
+// control socket) is bypassed.
+type MockRunKey struct{}
+
+// runFn drives the in-process sbsh attach loop. Returns nil on a clean
+// detach / context cancel and any unrecoverable controller error otherwise.
+type runFn func(ctx context.Context, opts attach.Options) error
+
+// pickAttachTarget resolves the container `kuke run -a` should attach to,
+// applying the documented precedence:
+//
+//  1. explicit --container flag, when set
+//  2. cell.tty.default, when the spec sets it
+//  3. the first container in declaration order with attachable=true
+//
+// Errors when no candidate exists or the explicit flag names a non-attachable
+// or unknown container; the error message names the attachable containers so
+// the operator can re-run with a valid --container.
+func pickAttachTarget(spec v1beta1.CellSpec, cellName, explicit string) (string, error) {
+	explicit = strings.TrimSpace(explicit)
+	if explicit != "" {
+		for _, c := range spec.Containers {
+			if c.ID == explicit {
+				if !c.Attachable {
+					return "", fmt.Errorf(
+						"container %q in cell %q is not attachable: %w; available attachable containers: %s",
+						explicit, cellName, errdefs.ErrAttachNotSupported,
+						formatAttachableList(spec),
+					)
+				}
+				return c.ID, nil
+			}
+		}
+		return "", fmt.Errorf(
+			"container %q not found in cell %q: %w; available attachable containers: %s",
+			explicit, cellName, errdefs.ErrContainerNotFound,
+			formatAttachableList(spec),
+		)
+	}
+
+	if spec.Tty != nil {
+		if name := strings.TrimSpace(spec.Tty.Default); name != "" {
+			return name, nil
+		}
+	}
+
+	for _, c := range spec.Containers {
+		if c.Attachable {
+			return c.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf(
+		"%w (cell %q); declare 'attachable: true' on one container or omit -a",
+		errdefs.ErrAttachNoCandidate, cellName,
+	)
+}
+
+// formatAttachableList returns a comma-separated list of attachable container
+// IDs in the cell, or "<none>" when there are zero. Used to point operators
+// at a valid --container value when their explicit choice is rejected.
+func formatAttachableList(spec v1beta1.CellSpec) string {
+	names := make([]string, 0, len(spec.Containers))
+	for _, c := range spec.Containers {
+		if c.Attachable {
+			names = append(names, c.ID)
+		}
+	}
+	if len(names) == 0 {
+		return "<none>"
+	}
+	return strings.Join(names, ", ")
+}
+
+// runAttachLoop resolves the per-container sbsh control socket via the
+// daemon's AttachContainer RPC and drives the in-process attach loop.
+// Returns nil on clean detach.
+func runAttachLoop(
+	cmd *cobra.Command,
+	client kukeonv1.Client,
+	doc v1beta1.CellDoc,
+	container string,
+) error {
+	containerDoc := v1beta1.ContainerDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindContainer,
+		Metadata: v1beta1.ContainerMetadata{
+			Name:   container,
+			Labels: make(map[string]string),
+		},
+		Spec: v1beta1.ContainerSpec{
+			ID:      container,
+			RealmID: doc.Spec.RealmID,
+			SpaceID: doc.Spec.SpaceID,
+			StackID: doc.Spec.StackID,
+			CellID:  doc.Metadata.Name,
+		},
+	}
+
+	result, err := client.AttachContainer(cmd.Context(), containerDoc)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrAttachNotSupported) {
+			return fmt.Errorf("container %q in cell %q is not attachable: %w",
+				container, doc.Metadata.Name, err)
+		}
+		if errors.Is(err, errdefs.ErrContainerNotFound) {
+			return fmt.Errorf("container %q not found in cell %q",
+				container, doc.Metadata.Name)
+		}
+		return err
+	}
+	if result.HostSocketPath == "" {
+		return fmt.Errorf("daemon returned empty HostSocketPath for container %q", container)
+	}
+
+	run := resolveRun(cmd)
+	return run(cmd.Context(), attach.Options{
+		SocketPath: result.HostSocketPath,
+		Stdin:      os.Stdin,
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
+	})
+}
+
+func resolveRun(cmd *cobra.Command) runFn {
+	if mock, ok := cmd.Context().Value(MockRunKey{}).(runFn); ok {
+		return mock
+	}
+	return attach.Run
+}

--- a/cmd/kuke/run/export_test.go
+++ b/cmd/kuke/run/export_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// RunFn is the test-visible alias of the unexported runFn type. Tests build
+// values of this type and store them under MockRunKey to bypass the real
+// pkg/attach.Run, which would open the user's TTY and connect to a real
+// control socket.
+type RunFn = runFn
+
+// PickAttachTarget exports the package-private selection helper for tests.
+// Production code reaches the same path through runRun → attachAfterRun.
+func PickAttachTarget(spec v1beta1.CellSpec, cellName, explicit string) (string, error) {
+	return pickAttachTarget(spec, cellName, explicit)
+}

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -16,8 +16,9 @@
 
 // Package run implements the `kuke run -f <file>` verb: parse a single-cell
 // YAML doc, idempotently create-and-start the cell, and report the same
-// outcome other lifecycle verbs print. Phase 1c of the run epic; the -a
-// (attach) and -p (profile) flags land in later phases.
+// outcome other lifecycle verbs print. Phase 2a adds -a/--attach so the
+// same invocation can drop the operator into the cell's attachable
+// terminal; -p (profile) lands in phase 2b.
 package run
 
 import (
@@ -40,8 +41,9 @@ import (
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
-// NewRunCmd builds the `kuke run` cobra command. Phase 1c implements only
-// `-f/--file`; `-a/--attach` (#C) and `-p/--profile` (#D) extend this scaffold.
+// NewRunCmd builds the `kuke run` cobra command. Phase 1c implemented
+// `-f/--file`; phase 2a adds `-a/--attach` and `--container`; `-p/--profile`
+// (#D) extends this scaffold.
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "run -f <file>",
@@ -67,6 +69,13 @@ func NewRunCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Stack that owns the cell (overrides spec.stackId only when the doc is empty)")
 	_ = viper.BindPFlag(config.KUKE_RUN_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 
+	cmd.Flags().BoolP("attach", "a", false,
+		"After start, attach to the cell's attachable container (precedence: --container > cell.tty.default > first attachable)")
+	_ = viper.BindPFlag(config.KUKE_RUN_ATTACH.ViperKey, cmd.Flags().Lookup("attach"))
+	cmd.Flags().String("container", "",
+		"Container to attach to (only valid with -a; must be attachable)")
+	_ = viper.BindPFlag(config.KUKE_RUN_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
+
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
@@ -90,6 +99,18 @@ func runRun(cmd *cobra.Command, _ []string) error {
 	output = strings.TrimSpace(output)
 	if output != "" && output != "json" && output != "yaml" {
 		return fmt.Errorf("invalid --output %q: want json or yaml", output)
+	}
+
+	doAttach := viper.GetBool(config.KUKE_RUN_ATTACH.ViperKey)
+	containerFlag := strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey))
+	if !doAttach && containerFlag != "" {
+		return errors.New("--container is only valid together with -a/--attach")
+	}
+	if doAttach && output != "" {
+		// -a hands the terminal to sbsh; mixing structured -o output with an
+		// interactive attach loop produces garbled output that nothing can
+		// parse. Reject the combination so callers pick one mode.
+		return errors.New("--output is incompatible with -a/--attach")
 	}
 
 	reader, cleanup, err := kukshared.ReadFileOrStdin(file)
@@ -137,7 +158,13 @@ func runRun(cmd *cobra.Command, _ []string) error {
 		// bridge plugin rejects with `duplicate allocation`. Pre-existing
 		// daemon bug, surfaced here because the AC requires idempotency.
 		if pre.Cell.Status.State == v1beta1.CellStateReady {
-			return printRunResult(cmd, noOpResultFromGet(pre), output)
+			if printErr := printRunResult(cmd, noOpResultFromGet(pre), output); printErr != nil {
+				return printErr
+			}
+			if doAttach {
+				return attachAfterRun(cmd, client, cellDoc, containerFlag)
+			}
+			return nil
 		}
 	case getErr != nil && !errors.Is(getErr, errdefs.ErrCellNotFound):
 		return getErr
@@ -148,7 +175,31 @@ func runRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return printRunResult(cmd, result, output)
+	if printErr := printRunResult(cmd, result, output); printErr != nil {
+		return printErr
+	}
+	if doAttach {
+		return attachAfterRun(cmd, client, cellDoc, containerFlag)
+	}
+	return nil
+}
+
+// attachAfterRun resolves the post-start attach target per the documented
+// precedence and drives the in-process sbsh attach loop. The selection runs
+// against cellDoc.Spec rather than re-querying the daemon: by this point the
+// resolved doc is what we just told the daemon to create, so the attachable
+// set the user authored is authoritative.
+func attachAfterRun(
+	cmd *cobra.Command,
+	client kukeonv1.Client,
+	doc v1beta1.CellDoc,
+	containerFlag string,
+) error {
+	target, err := pickAttachTarget(doc.Spec, doc.Metadata.Name, containerFlag)
+	if err != nil {
+		return err
+	}
+	return runAttachLoop(cmd, client, doc, target)
 }
 
 // parseSingleCellDoc parses raw YAML and returns the single-doc Cell. It errors

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	sbshattach "github.com/eminwux/sbsh/pkg/attach"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -104,12 +105,15 @@ func writeTempYAML(t *testing.T, content string) string {
 type fakeClient struct {
 	kukeonv1.FakeClient
 
-	getCellFn    func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
-	createCellFn func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
+	getCellFn         func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	createCellFn      func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
+	attachContainerFn func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error)
 
 	getCalls    int
 	createCalls int
+	attachCalls int
 	createDoc   v1beta1.CellDoc
+	attachDoc   v1beta1.ContainerDoc
 }
 
 func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
@@ -129,7 +133,37 @@ func (f *fakeClient) CreateCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv
 	return f.createCellFn(doc)
 }
 
+func (f *fakeClient) AttachContainer(
+	_ context.Context,
+	doc v1beta1.ContainerDoc,
+) (kukeonv1.AttachContainerResult, error) {
+	f.attachCalls++
+	f.attachDoc = doc
+	if f.attachContainerFn == nil {
+		return kukeonv1.AttachContainerResult{}, errors.New("unexpected AttachContainer call")
+	}
+	return f.attachContainerFn(doc)
+}
+
+// runCapture records the Options passed to the in-process attach loop and
+// returns nil so the test treats the call as a clean detach.
+type runCapture struct {
+	calls int
+	opts  sbshattach.Options
+}
+
+func (r *runCapture) fn(_ context.Context, opts sbshattach.Options) error {
+	r.calls++
+	r.opts = opts
+	return nil
+}
+
 func newCmd(t *testing.T, fc *fakeClient) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	return newCmdWithRun(t, fc, nil)
+}
+
+func newCmdWithRun(t *testing.T, fc *fakeClient, run *runCapture) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 	cmd := runcmd.NewRunCmd()
 	buf := &bytes.Buffer{}
@@ -140,6 +174,9 @@ func newCmd(t *testing.T, fc *fakeClient) (*cobra.Command, *bytes.Buffer) {
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 	if fc != nil {
 		ctx = context.WithValue(ctx, runcmd.MockControllerKey{}, kukeonv1.Client(fc))
+	}
+	if run != nil {
+		ctx = context.WithValue(ctx, runcmd.MockRunKey{}, runcmd.RunFn(run.fn))
 	}
 	cmd.SetContext(ctx)
 	return cmd, buf
@@ -555,6 +592,417 @@ func TestNewRunCmd_AutocompleteRegistration(t *testing.T) {
 	outputFlag := cmd.Flags().Lookup("output")
 	if outputFlag == nil || outputFlag.Shorthand != "o" {
 		t.Errorf("expected -o/--output flag, got %+v", outputFlag)
+	}
+}
+
+// attachableCellYAML declares two attachable containers and pins
+// cell.tty.default to the second one so the precedence-rule tests below can
+// distinguish the explicit-default branch from the first-attachable branch.
+const attachableCellYAML = `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: my-cell
+spec:
+  id: my-cell
+  realmId: my-realm
+  spaceId: my-space
+  stackId: my-stack
+  tty:
+    default: claude
+  containers:
+    - id: root
+      root: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: shell
+      attachable: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: claude
+      attachable: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+`
+
+// attachableNoDefaultYAML omits cell.tty.default so the first-attachable
+// fallback branch fires.
+const attachableNoDefaultYAML = `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: my-cell
+spec:
+  id: my-cell
+  realmId: my-realm
+  spaceId: my-space
+  stackId: my-stack
+  containers:
+    - id: root
+      root: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: shell
+      attachable: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: claude
+      attachable: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+`
+
+const testHostSocket = "/opt/kukeon/r/s/st/c/work/tty/socket"
+
+func attachSuccessFn() func(v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+	return func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+		return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+	}
+}
+
+func TestPickAttachTarget_PrefersExplicitContainer(t *testing.T) {
+	spec := v1beta1.CellSpec{
+		Tty: &v1beta1.CellTty{Default: "claude"},
+		Containers: []v1beta1.ContainerSpec{
+			{ID: "shell", Attachable: true},
+			{ID: "claude", Attachable: true},
+		},
+	}
+	got, err := runcmd.PickAttachTarget(spec, "my-cell", "shell")
+	if err != nil {
+		t.Fatalf("pickAttachTarget: %v", err)
+	}
+	if got != "shell" {
+		t.Errorf("got %q, want %q (--container must beat tty.default)", got, "shell")
+	}
+}
+
+func TestPickAttachTarget_FallsBackToTtyDefault(t *testing.T) {
+	spec := v1beta1.CellSpec{
+		Tty: &v1beta1.CellTty{Default: "claude"},
+		Containers: []v1beta1.ContainerSpec{
+			{ID: "shell", Attachable: true},
+			{ID: "claude", Attachable: true},
+		},
+	}
+	got, err := runcmd.PickAttachTarget(spec, "my-cell", "")
+	if err != nil {
+		t.Fatalf("pickAttachTarget: %v", err)
+	}
+	if got != "claude" {
+		t.Errorf("got %q, want %q (tty.default must beat first-attachable)", got, "claude")
+	}
+}
+
+func TestPickAttachTarget_FallsBackToFirstAttachable(t *testing.T) {
+	spec := v1beta1.CellSpec{
+		Containers: []v1beta1.ContainerSpec{
+			{ID: "root", Root: true},
+			{ID: "shell", Attachable: true},
+			{ID: "claude", Attachable: true},
+		},
+	}
+	got, err := runcmd.PickAttachTarget(spec, "my-cell", "")
+	if err != nil {
+		t.Fatalf("pickAttachTarget: %v", err)
+	}
+	if got != "shell" {
+		t.Errorf("got %q, want %q (first attachable wins, declaration order)", got, "shell")
+	}
+}
+
+func TestPickAttachTarget_NoAttachable_Errors(t *testing.T) {
+	spec := v1beta1.CellSpec{
+		Containers: []v1beta1.ContainerSpec{
+			{ID: "root", Root: true},
+			{ID: "side", Attachable: false},
+		},
+	}
+	_, err := runcmd.PickAttachTarget(spec, "my-cell", "")
+	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
+		t.Fatalf("err=%v want ErrAttachNoCandidate", err)
+	}
+	if !strings.Contains(err.Error(), "attachable: true") {
+		t.Errorf("error %q must guide operator to declare attachable=true", err)
+	}
+}
+
+func TestPickAttachTarget_ExplicitNonAttachable_NamesAttachables(t *testing.T) {
+	spec := v1beta1.CellSpec{
+		Containers: []v1beta1.ContainerSpec{
+			{ID: "root", Root: true},
+			{ID: "side", Attachable: false},
+			{ID: "shell", Attachable: true},
+		},
+	}
+	_, err := runcmd.PickAttachTarget(spec, "my-cell", "side")
+	if !errors.Is(err, errdefs.ErrAttachNotSupported) {
+		t.Fatalf("err=%v want ErrAttachNotSupported", err)
+	}
+	if !strings.Contains(err.Error(), "shell") {
+		t.Errorf("error %q must list available attachables", err)
+	}
+}
+
+func TestPickAttachTarget_ExplicitUnknown_NamesAttachables(t *testing.T) {
+	spec := v1beta1.CellSpec{
+		Containers: []v1beta1.ContainerSpec{
+			{ID: "root", Root: true},
+			{ID: "shell", Attachable: true},
+		},
+	}
+	_, err := runcmd.PickAttachTarget(spec, "my-cell", "ghost")
+	if !errors.Is(err, errdefs.ErrContainerNotFound) {
+		t.Fatalf("err=%v want ErrContainerNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "shell") {
+		t.Errorf("error %q must list available attachables", err)
+	}
+}
+
+func TestRun_Attach_AfterCreate_UsesTtyDefault(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 1 {
+		t.Fatalf("CreateCell calls=%d want 1", fc.createCalls)
+	}
+	if fc.attachCalls != 1 {
+		t.Fatalf("AttachContainer calls=%d want 1", fc.attachCalls)
+	}
+	if got := fc.attachDoc.Metadata.Name; got != "claude" {
+		t.Errorf("AttachContainer target=%q want claude (tty.default)", got)
+	}
+	if run.calls != 1 {
+		t.Fatalf("attach loop calls=%d want 1", run.calls)
+	}
+	if run.opts.SocketPath != testHostSocket {
+		t.Errorf("SocketPath=%q want %q", run.opts.SocketPath, testHostSocket)
+	}
+}
+
+func TestRun_Attach_AfterCreate_FirstAttachableWhenNoDefault(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableNoDefaultYAML), "-a"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.attachDoc.Metadata.Name; got != "shell" {
+		t.Errorf("AttachContainer target=%q want shell (first attachable)", got)
+	}
+}
+
+func TestRun_Attach_AfterCreate_ExplicitContainerWinsOverDefault(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{
+		"-f", writeTempYAML(t, attachableCellYAML),
+		"-a", "--container", "shell",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.attachDoc.Metadata.Name; got != "shell" {
+		t.Errorf("AttachContainer target=%q want shell (--container must beat tty.default)", got)
+	}
+}
+
+func TestRun_Attach_NoCandidate_Errors_NoMutationOnAttach(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// validCellYAML has no attachable containers — -a must fail with the
+	// explicit ErrAttachNoCandidate without driving the attach loop. The
+	// CreateCell ran already (fail-late after start is the documented UX);
+	// the cell is left Ready and the operator can re-run with --container or
+	// fix the spec.
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-a"})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
+		t.Fatalf("err=%v want ErrAttachNoCandidate", err)
+	}
+	if fc.attachCalls != 0 {
+		t.Errorf("AttachContainer calls=%d want 0", fc.attachCalls)
+	}
+	if run.calls != 0 {
+		t.Errorf("attach loop calls=%d want 0", run.calls)
+	}
+}
+
+func TestRun_Attach_BadContainerFlag_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	run := &runCapture{}
+	cmd, out := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{
+		"-f", writeTempYAML(t, attachableCellYAML),
+		"-a", "--container", "ghost",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrContainerNotFound) {
+		t.Fatalf("err=%v want ErrContainerNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "shell") || !strings.Contains(err.Error(), "claude") {
+		t.Errorf("err %q must list attachables (shell, claude); output:\n%s", err, out.String())
+	}
+	if fc.attachCalls != 0 {
+		t.Errorf("AttachContainer calls=%d want 0", fc.attachCalls)
+	}
+	if run.calls != 0 {
+		t.Errorf("attach loop calls=%d want 0", run.calls)
+	}
+}
+
+func TestRun_Attach_ContainerWithoutAttachFlag_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmdWithRun(t, fc, &runCapture{})
+	cmd.SetArgs([]string{
+		"-f", writeTempYAML(t, attachableCellYAML),
+		"--container", "shell",
+	})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--container is only valid") {
+		t.Fatalf("err=%v want '--container is only valid' guard", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (must reject before mutating)", fc.createCalls)
+	}
+}
+
+func TestRun_Attach_OutputFlag_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmdWithRun(t, fc, &runCapture{})
+	cmd.SetArgs([]string{
+		"-f", writeTempYAML(t, attachableCellYAML),
+		"-a", "-o", "json",
+	})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "incompatible") {
+		t.Fatalf("err=%v want incompatibility guard", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0", fc.createCalls)
+	}
+}
+
+func TestRun_Attach_AlreadyReady_ShortCircuitThenAttaches(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Tty:     &v1beta1.CellTty{Default: "claude"},
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "shell", Attachable: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "claude", Attachable: true, Image: "registry.eminwux.com/busybox:latest"},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                existing,
+				MetadataExists:      true,
+				CgroupExists:        true,
+				RootContainerExists: true,
+			}, nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (short-circuit on Ready)", fc.createCalls)
+	}
+	if fc.attachCalls != 1 {
+		t.Fatalf("AttachContainer calls=%d want 1", fc.attachCalls)
+	}
+	if got := fc.attachDoc.Metadata.Name; got != "claude" {
+		t.Errorf("AttachContainer target=%q want claude", got)
+	}
+	if run.calls != 1 {
+		t.Errorf("attach loop calls=%d want 1", run.calls)
+	}
+}
+
+func TestNewRunCmd_AttachFlagRegistered(t *testing.T) {
+	cmd := runcmd.NewRunCmd()
+	attachFlag := cmd.Flags().Lookup("attach")
+	if attachFlag == nil || attachFlag.Shorthand != "a" {
+		t.Errorf("expected -a/--attach flag, got %+v", attachFlag)
+	}
+	if got := cmd.Flags().Lookup("container"); got == nil {
+		t.Errorf("expected --container flag")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `-a/--attach` and `--container` flags to `kuke run`. After the cell reaches Ready (fresh create or already-Ready short-circuit), the in-process sbsh attach loop drives the user into the cell's attachable terminal — no separate `kuke attach` round-trip needed.
- Selection precedence implemented per the AC: `--container <id>` > `cell.tty.default` > first container in declaration order with `attachable: true`.
- Selection runs against the resolved CellDoc (the spec we just told the daemon to create), so a no-attachable / unknown-container / non-attachable error happens before the daemon RPC and names the available attachable containers in the message.
- Two compatibility guards: `--container` without `-a` errors (intent-clarifying), and `-o json|yaml` with `-a` errors (the attach loop hijacks the terminal, so structured output would be unparseable).
- The `cmd/kuke/attach/` package is left untouched: `kuke run -a` reuses sbsh's `pkg/attach.Run` directly via a sibling helper in the run package, and exposes a parallel `MockRunKey` so tests bypass the real TTY.

## Notable judgment calls
- **First-attachable picker does not exclude root.** The AC literally reads "first container in declaration order with `attachable: true`", and the existing scheme validator allows `cell.tty.default` to name a root container as long as it's `attachable: true`. Mirroring that here keeps the two precedence paths consistent. (`kuke attach`'s auto-pick *does* exclude root — that's a separate pre-existing rule for the standalone verb.) Reviewer can call out if the AC should be tightened.
- **Selection runs on `cellDoc.Spec`, not a fresh `ListContainers`.** By the time we attach, the doc is what we told the daemon to create, so it's authoritative for the attachable set; saves an RPC and avoids race windows. The daemon still validates Attachable on `AttachContainer`, so the worst case is a clean error if drift happens.
- **`-o` + `-a` rejected up-front.** Could let JSON print before the attach loop, but the result is garbled / unparseable. Cleaner to make callers pick a mode.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes (full project test target)
- [x] `go test ./cmd/kuke/run/...` covers all selection branches (explicit > tty.default > first-attachable, no-candidate, unknown-container, non-attachable explicit, attach-after-create, attach-after-Ready short-circuit, `--container` without `-a`, `-o` + `-a`)
- [x] Pre-commit hooks pass (golangci-lint, addlicense, go fmt, go-mod-tidy)
- [x] Daemon-parity smoke check: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` return identical output (confirms the rebuilt kuke binary still talks to the running daemon correctly; this PR doesn't touch daemon-read paths)
- [x] `./kuke run --help` shows `-a/--attach` and `--container` flags with the documented precedence in the help text
- [x] Early-validation guards fire before daemon contact: `--container` without `-a` and `-o json` with `-a` both error before any RPC
- [ ] **End-to-end attach round-trip on a live host with sbsh staged** — the in-process sbsh loop opens a TTY and connects to the per-container control socket, so the round-trip needs an interactive terminal and a freshly-`kuke init`-ed host with `sbsh` in the cache. Unit tests cover selection + the AttachContainer wiring; the actual `pkg/attach.Run(opts)` integration is the same one `kuke attach` already uses in production. Reviewer/maintainer should verify on a live host before merge.

Closes #141