### PR TITLE
feat(api+cli): CellProfile kind + kuke run -p

### DIFF
--- a/cmd/config/autocomplete.go
+++ b/cmd/config/autocomplete.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/cellprofile"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/spf13/cobra"
@@ -459,6 +460,29 @@ func CompleteContainerNames(cmd *cobra.Command, args []string, toComplete string
 		}
 	}
 
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// CompleteProfileNames provides shell completion for `-p/--profile` by listing
+// every CellProfile under the active profiles directory ($KUKE_PROFILES_DIR or
+// $HOME/.kuke/profiles.d). Errors swallow to an empty list — a fresh shell with
+// no profiles directory should not surface a noisy completion error.
+func CompleteProfileNames(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	dir, err := cellprofile.ResolveDir()
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+	profiles, err := cellprofile.List(dir)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+	names := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		name := p.Metadata.Name
+		if toComplete == "" || strings.HasPrefix(name, toComplete) {
+			names = append(names, name)
+		}
+	}
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -351,6 +351,8 @@ var (
 	KUKE_RUN_ATTACH = DefineKV("KUKE_RUN_ATTACH", "kuke/run/attach")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_CONTAINER = DefineKV("KUKE_RUN_CONTAINER", "kuke/run/container")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_PROFILE = DefineKV("KUKE_RUN_PROFILE", "kuke/run/profile")
 
 	// Attach command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -14,11 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package run implements the `kuke run -f <file>` verb: parse a single-cell
-// YAML doc, idempotently create-and-start the cell, and report the same
-// outcome other lifecycle verbs print. Phase 2a adds -a/--attach so the
-// same invocation can drop the operator into the cell's attachable
-// terminal; -p (profile) lands in phase 2b.
+// Package run implements the `kuke run` verb. The original `-f <file>` form
+// (phase 1c) parses a single-cell YAML doc and idempotently create-and-starts
+// the cell. Phase 2a added `-a/--attach` so the same invocation can drop the
+// operator into the cell's attachable terminal. Phase 2b adds `-p/--profile`,
+// which materializes a CellDoc from a per-user CellProfile under
+// $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR) and then walks the same
+// create+start[+attach] path.
 package run
 
 import (
@@ -31,6 +33,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/config"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/cellprofile"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -41,23 +44,37 @@ import (
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
-// NewRunCmd builds the `kuke run` cobra command. Phase 1c implemented
-// `-f/--file`; phase 2a adds `-a/--attach` and `--container`; `-p/--profile`
-// (#D) extends this scaffold.
+// NewRunCmd builds the `kuke run` cobra command. `-f` reads a single-cell
+// YAML doc; `-p` reads a per-user CellProfile and materializes the same
+// CellDoc shape. Exactly one of the two is required. `-a` then drops the
+// operator into the cell's attachable terminal once the cell is up.
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "run -f <file>",
-		Short:         "Create and start a single cell from a YAML file",
-		Long:          "Create and start a single cell from a YAML file or stdin. Conceptually `kuke apply -f` (single-cell) plus `kuke start cell`, but refuses to update a divergent on-disk spec.",
-		Args:          cobra.NoArgs,
+		Use:   "run (-f <file> | -p <profile> [<cell-name>])",
+		Short: "Create and start a single cell from a YAML file or a profile",
+		Long: "Create and start a single cell from a YAML file or stdin (-f), " +
+			"or from a per-user profile under $HOME/.kuke/profiles.d/<name>.yaml (-p). " +
+			"Conceptually `kuke apply -f` (single-cell) plus `kuke start cell`, but refuses " +
+			"to update a divergent on-disk spec. With -p, the optional positional argument " +
+			"overrides the materialized cell name.",
+		// MaximumNArgs(1) leaves room for the optional cell-name override
+		// `kuke run -p <profile> <cell-name>`. The handler rejects the arg
+		// when -p is not in use, so the -f form behaves as before.
+		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE:          runRun,
 	}
 
-	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin)")
+	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin); mutually exclusive with -p")
 	_ = viper.BindPFlag(config.KUKE_RUN_FILE.ViperKey, cmd.Flags().Lookup("file"))
-	_ = cmd.MarkFlagRequired("file")
+
+	cmd.Flags().StringP("profile", "p", "",
+		"Cell profile name to load from $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR); mutually exclusive with -f")
+	_ = viper.BindPFlag(config.KUKE_RUN_PROFILE.ViperKey, cmd.Flags().Lookup("profile"))
+
+	cmd.MarkFlagsMutuallyExclusive("file", "profile")
+	cmd.MarkFlagsOneRequired("file", "profile")
 
 	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
 	_ = viper.BindPFlag(config.KUKE_RUN_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
@@ -79,52 +96,65 @@ func NewRunCmd() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("profile", config.CompleteProfileNames)
 
 	return cmd
 }
 
-func runRun(cmd *cobra.Command, _ []string) error {
-	file, err := cmd.Flags().GetString("file")
-	if err != nil {
-		return err
+// runFlags is the validated bundle of flag values runRun consumes after
+// argument validation. Splitting it out keeps runRun under the funlen limit
+// while preserving the original control flow.
+type runFlags struct {
+	file             string
+	profileName      string
+	cellNameOverride string
+	output           string
+	doAttach         bool
+	containerFlag    string
+}
+
+func parseRunFlags(cmd *cobra.Command, args []string) (runFlags, error) {
+	flags := runFlags{
+		file:          strings.TrimSpace(viper.GetString(config.KUKE_RUN_FILE.ViperKey)),
+		profileName:   strings.TrimSpace(viper.GetString(config.KUKE_RUN_PROFILE.ViperKey)),
+		doAttach:      viper.GetBool(config.KUKE_RUN_ATTACH.ViperKey),
+		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
 	}
-	if strings.TrimSpace(file) == "" {
-		return errors.New("file flag is required (use -f <file> or -f - for stdin)")
+	if len(args) == 1 {
+		flags.cellNameOverride = strings.TrimSpace(args[0])
+	}
+	if flags.cellNameOverride != "" && flags.profileName == "" {
+		return runFlags{}, errors.New("positional <cell-name> argument is only valid together with -p/--profile")
 	}
 
 	output, err := cmd.Flags().GetString("output")
 	if err != nil {
-		return err
+		return runFlags{}, err
 	}
-	output = strings.TrimSpace(output)
-	if output != "" && output != "json" && output != "yaml" {
-		return fmt.Errorf("invalid --output %q: want json or yaml", output)
+	flags.output = strings.TrimSpace(output)
+	if flags.output != "" && flags.output != "json" && flags.output != "yaml" {
+		return runFlags{}, fmt.Errorf("invalid --output %q: want json or yaml", flags.output)
 	}
 
-	doAttach := viper.GetBool(config.KUKE_RUN_ATTACH.ViperKey)
-	containerFlag := strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey))
-	if !doAttach && containerFlag != "" {
-		return errors.New("--container is only valid together with -a/--attach")
+	if !flags.doAttach && flags.containerFlag != "" {
+		return runFlags{}, errors.New("--container is only valid together with -a/--attach")
 	}
-	if doAttach && output != "" {
+	if flags.doAttach && flags.output != "" {
 		// -a hands the terminal to sbsh; mixing structured -o output with an
 		// interactive attach loop produces garbled output that nothing can
 		// parse. Reject the combination so callers pick one mode.
-		return errors.New("--output is incompatible with -a/--attach")
+		return runFlags{}, errors.New("--output is incompatible with -a/--attach")
 	}
+	return flags, nil
+}
 
-	reader, cleanup, err := kukshared.ReadFileOrStdin(file)
+func runRun(cmd *cobra.Command, args []string) error {
+	flags, err := parseRunFlags(cmd, args)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = cleanup() }()
 
-	rawYAML, err := io.ReadAll(reader)
-	if err != nil {
-		return fmt.Errorf("failed to read input: %w", err)
-	}
-
-	cellDoc, err := parseSingleCellDoc(rawYAML)
+	cellDoc, err := loadCellDoc(flags.file, flags.profileName, flags.cellNameOverride)
 	if err != nil {
 		return err
 	}
@@ -158,11 +188,11 @@ func runRun(cmd *cobra.Command, _ []string) error {
 		// bridge plugin rejects with `duplicate allocation`. Pre-existing
 		// daemon bug, surfaced here because the AC requires idempotency.
 		if pre.Cell.Status.State == v1beta1.CellStateReady {
-			if printErr := printRunResult(cmd, noOpResultFromGet(pre), output); printErr != nil {
+			if printErr := printRunResult(cmd, noOpResultFromGet(pre), flags.output); printErr != nil {
 				return printErr
 			}
-			if doAttach {
-				return attachAfterRun(cmd, client, cellDoc, containerFlag)
+			if flags.doAttach {
+				return attachAfterRun(cmd, client, cellDoc, flags.containerFlag)
 			}
 			return nil
 		}
@@ -175,11 +205,11 @@ func runRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if printErr := printRunResult(cmd, result, output); printErr != nil {
+	if printErr := printRunResult(cmd, result, flags.output); printErr != nil {
 		return printErr
 	}
-	if doAttach {
-		return attachAfterRun(cmd, client, cellDoc, containerFlag)
+	if flags.doAttach {
+		return attachAfterRun(cmd, client, cellDoc, flags.containerFlag)
 	}
 	return nil
 }
@@ -200,6 +230,48 @@ func attachAfterRun(
 		return err
 	}
 	return runAttachLoop(cmd, client, doc, target)
+}
+
+// loadCellDoc dispatches to the file or profile loader. Exactly one of file or
+// profileName is non-empty (the cobra mutex enforces it before the handler
+// runs). cellNameOverride is honored only on the profile path.
+func loadCellDoc(file, profileName, cellNameOverride string) (v1beta1.CellDoc, error) {
+	if profileName != "" {
+		return loadFromProfile(profileName, cellNameOverride)
+	}
+	return loadFromFile(file)
+}
+
+// loadFromFile preserves the phase-1c -f path: read the file (or stdin),
+// parse the single Cell document, and return it.
+func loadFromFile(file string) (v1beta1.CellDoc, error) {
+	reader, cleanup, err := kukshared.ReadFileOrStdin(file)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	defer func() { _ = cleanup() }()
+
+	rawYAML, err := io.ReadAll(reader)
+	if err != nil {
+		return v1beta1.CellDoc{}, fmt.Errorf("failed to read input: %w", err)
+	}
+	return parseSingleCellDoc(rawYAML)
+}
+
+// loadFromProfile resolves the active profiles directory, loads the named
+// profile, and materializes its CellSpec body into a CellDoc. The cell name
+// defaults to the profile metadata.name; cellNameOverride wins when set
+// (positional arg on `kuke run -p <profile> <cell-name>`).
+func loadFromProfile(profileName, cellNameOverride string) (v1beta1.CellDoc, error) {
+	dir, err := cellprofile.ResolveDir()
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	profile, err := cellprofile.Load(dir, profileName)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	return cellprofile.Materialize(profile, cellNameOverride), nil
 }
 
 // parseSingleCellDoc parses raw YAML and returns the single-doc Cell. It errors

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -564,7 +564,7 @@ func TestRun_InvalidOutput_Errors(t *testing.T) {
 	}
 }
 
-func TestRun_MissingFile_Errors(t *testing.T) {
+func TestRun_MissingFileAndProfile_Errors(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{}
@@ -572,8 +572,11 @@ func TestRun_MissingFile_Errors(t *testing.T) {
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "required flag") {
-		t.Fatalf("err=%v want missing-flag error", err)
+	// MarkFlagsOneRequired produces "at least one of the flags in the group
+	// [file profile] is required" — match on the stable phrase rather than
+	// the exact wording so a cobra phrasing change doesn't break the test.
+	if err == nil || !strings.Contains(err.Error(), "[file profile]") {
+		t.Fatalf("err=%v want one-of error naming both flags", err)
 	}
 }
 
@@ -584,10 +587,13 @@ func TestNewRunCmd_AutocompleteRegistration(t *testing.T) {
 			t.Errorf("expected %q flag to exist", flag)
 		}
 	}
-	// File flag is required and short-aliased.
 	fileFlag := cmd.Flags().Lookup("file")
 	if fileFlag == nil || fileFlag.Shorthand != "f" {
 		t.Errorf("expected -f/--file flag, got %+v", fileFlag)
+	}
+	profileFlag := cmd.Flags().Lookup("profile")
+	if profileFlag == nil || profileFlag.Shorthand != "p" {
+		t.Errorf("expected -p/--profile flag, got %+v", profileFlag)
 	}
 	outputFlag := cmd.Flags().Lookup("output")
 	if outputFlag == nil || outputFlag.Shorthand != "o" {
@@ -1003,6 +1009,210 @@ func TestNewRunCmd_AttachFlagRegistered(t *testing.T) {
 	}
 	if got := cmd.Flags().Lookup("container"); got == nil {
 		t.Errorf("expected --container flag")
+	}
+}
+
+// claudeProfileYAML is the headline -p example from issue #142: a per-user
+// profile that opts a `work` container into attach + tty.default. Drives the
+// `-p -a` round-trip tests below.
+const claudeProfileYAML = `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: claude-cell
+spec:
+  realm: default
+  space: agents
+  stack: claude
+  cell:
+    tty:
+      default: work
+    containers:
+      - id: root
+        root: true
+        image: registry.eminwux.com/busybox:latest
+        command: sleep
+        args:
+          - "3600"
+      - id: work
+        attachable: true
+        image: registry.eminwux.com/busybox:latest
+        command: /bin/sh
+`
+
+// writeTempProfile drops the headline claudeProfileYAML in a t.TempDir as
+// `claude-cell.yaml` and points KUKE_PROFILES_DIR at it. The filename + content
+// are hard-coded because every -p test in this file targets the same headline
+// profile from issue #142; tests that exercise the metadata.name fallback or
+// alternative shapes live in the cellprofile package itself.
+func writeTempProfile(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude-cell.yaml")
+	if err := os.WriteFile(path, []byte(claudeProfileYAML), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	t.Setenv("KUKE_PROFILES_DIR", dir)
+}
+
+func TestRun_FromProfile_CreatesAndStarts(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeTempProfile(t)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-p", "claude-cell"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 1 {
+		t.Fatalf("CreateCell calls=%d want 1", fc.createCalls)
+	}
+	if got := fc.createDoc.Metadata.Name; got != "claude-cell" {
+		t.Errorf("cell name=%q want claude-cell (default to profile name)", got)
+	}
+	if got := fc.createDoc.Spec.RealmID; got != "default" {
+		t.Errorf("RealmID=%q want default", got)
+	}
+	if got := fc.createDoc.Spec.SpaceID; got != "agents" {
+		t.Errorf("SpaceID=%q want agents", got)
+	}
+	if got := fc.createDoc.Spec.StackID; got != "claude" {
+		t.Errorf("StackID=%q want claude", got)
+	}
+}
+
+func TestRun_FromProfile_PositionalCellNameOverride(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeTempProfile(t)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-p", "claude-cell", "my-cell"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.createDoc.Metadata.Name; got != "my-cell" {
+		t.Errorf("cell name=%q want my-cell (positional override)", got)
+	}
+}
+
+func TestRun_FromProfile_LocationFlagsOverride(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeTempProfile(t)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	// The materialized profile sets realm/space/stack already; --realm/--space/--stack
+	// flags must NOT override values the profile already provides — the same
+	// "doc wins over flag" rule that -f obeys.
+	cmd.SetArgs([]string{"-p", "claude-cell", "--realm", "x", "--space", "y", "--stack", "z"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.createDoc.Spec.RealmID; got != "default" {
+		t.Errorf("RealmID=%q want default (profile must beat --realm)", got)
+	}
+}
+
+func TestRun_FromProfile_UnknownProfile_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeTempProfile(t)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-p", "ghost"})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrProfileNotFound) {
+		t.Fatalf("err=%v want ErrProfileNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("err %q must name the profile", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0", fc.createCalls)
+	}
+}
+
+func TestRun_FromProfile_FileAndProfile_MutuallyExclusive(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeTempProfile(t)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-p", "claude-cell"})
+
+	err := cmd.Execute()
+	// MarkFlagsMutuallyExclusive emits "if any flags in the group [file profile]
+	// are set none of the others can be" — match on the [file profile] phrase
+	// rather than wording so cobra rephrasing doesn't break the test.
+	if err == nil || !strings.Contains(err.Error(), "[file profile]") {
+		t.Fatalf("err=%v want mutually-exclusive guard naming both flags", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0", fc.createCalls)
+	}
+}
+
+func TestRun_PositionalArg_WithoutProfile_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "my-cell"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "positional <cell-name>") {
+		t.Fatalf("err=%v want positional-arg guard", err)
+	}
+}
+
+func TestRun_FromProfile_Attach_HeadlineFlow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeTempProfile(t)
+
+	// Headline flow from the issue: `kuke run -p claude-cell -a` materializes
+	// the profile, creates+starts the cell, then attaches to cell.tty.default
+	// (the `work` container).
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-p", "claude-cell", "-a"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 1 {
+		t.Fatalf("CreateCell calls=%d want 1", fc.createCalls)
+	}
+	if fc.attachCalls != 1 {
+		t.Fatalf("AttachContainer calls=%d want 1", fc.attachCalls)
+	}
+	if got := fc.attachDoc.Metadata.Name; got != "work" {
+		t.Errorf("attach target=%q want work (cell.tty.default)", got)
+	}
+	if run.calls != 1 {
+		t.Errorf("attach loop calls=%d want 1", run.calls)
 	}
 }
 

--- a/internal/cellprofile/cellprofile.go
+++ b/internal/cellprofile/cellprofile.go
@@ -1,0 +1,198 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cellprofile loads per-user CellProfile templates from
+// $HOME/.kuke/profiles.d/*.yaml (or $KUKE_PROFILES_DIR) and materializes them
+// into CellDocs that `kuke run -p` then drives along the same path as `-f`.
+package cellprofile
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// EnvProfilesDir is the env var that overrides the default user profiles
+// directory. Picked up by ResolveDir; takes precedence over $HOME/.kuke/profiles.d.
+const EnvProfilesDir = "KUKE_PROFILES_DIR"
+
+// DefaultDirSuffix is appended to $HOME when KUKE_PROFILES_DIR is unset.
+// Matches sbsh's `~/.sbsh/profiles.d` layout.
+const DefaultDirSuffix = ".kuke/profiles.d"
+
+// ResolveDir returns the active profiles directory: $KUKE_PROFILES_DIR if set,
+// otherwise $HOME/.kuke/profiles.d. The directory is not required to exist —
+// callers either tolerate ENOENT (List) or surface ProfileNotFound (Load).
+func ResolveDir() (string, error) {
+	if dir := strings.TrimSpace(os.Getenv(EnvProfilesDir)); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, DefaultDirSuffix), nil
+}
+
+// Load reads $dir/<name>.yaml (or its .yml sibling) and returns the parsed
+// profile. When neither exists, it falls back to scanning every *.yaml /
+// *.yml file in the directory and matching on metadata.name — the file basename
+// is the convenient case but not authoritative, so two profiles can share a
+// directory regardless of how they were named on disk.
+//
+// Wraps errdefs.ErrProfileNotFound when the name does not resolve, including
+// the directory in the error so the operator knows where to drop the file.
+func Load(dir, name string) (*v1beta1.CellProfileDoc, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: empty name", errdefs.ErrProfileInvalid)
+	}
+
+	for _, ext := range []string{".yaml", ".yml"} {
+		candidate := filepath.Join(dir, name+ext)
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			profile, err := loadFile(candidate)
+			if err != nil {
+				return nil, err
+			}
+			if matchesName(profile, name) {
+				return profile, nil
+			}
+		}
+	}
+
+	profiles, err := List(dir)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrProfileNotFound) {
+			return nil, fmt.Errorf("profile %q not found in %s: %w", name, dir, errdefs.ErrProfileNotFound)
+		}
+		return nil, err
+	}
+	for _, p := range profiles {
+		if p.Metadata.Name == name {
+			out := p
+			return &out, nil
+		}
+	}
+	return nil, fmt.Errorf("profile %q not found in %s: %w", name, dir, errdefs.ErrProfileNotFound)
+}
+
+// List returns every parseable CellProfile in dir, sorted by metadata.name.
+// Used by both the `-p` autocomplete handler and the fallback name lookup in
+// Load. Files that fail to parse are skipped silently — the operator finds
+// out via Load when they actually try to use the broken profile.
+func List(dir string) ([]v1beta1.CellProfileDoc, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read profiles dir %q: %w", dir, err)
+	}
+
+	out := make([]v1beta1.CellProfileDoc, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			continue
+		}
+		profile, loadErr := loadFile(filepath.Join(dir, name))
+		if loadErr != nil {
+			continue
+		}
+		out = append(out, *profile)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Metadata.Name < out[j].Metadata.Name
+	})
+	return out, nil
+}
+
+func loadFile(path string) (*v1beta1.CellProfileDoc, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read profile %q: %w", path, err)
+	}
+	var profile v1beta1.CellProfileDoc
+	if unmarshalErr := yaml.Unmarshal(raw, &profile); unmarshalErr != nil {
+		return nil, fmt.Errorf("parse profile %q: %w: %w", path, errdefs.ErrProfileInvalid, unmarshalErr)
+	}
+	if profile.Kind != v1beta1.KindCellProfile {
+		return nil, fmt.Errorf(
+			"profile %q has kind %q, want %q: %w",
+			path, profile.Kind, v1beta1.KindCellProfile, errdefs.ErrProfileInvalid,
+		)
+	}
+	if strings.TrimSpace(profile.Metadata.Name) == "" {
+		return nil, fmt.Errorf("profile %q: metadata.name is required: %w", path, errdefs.ErrProfileInvalid)
+	}
+	return &profile, nil
+}
+
+func matchesName(profile *v1beta1.CellProfileDoc, name string) bool {
+	return profile != nil && profile.Metadata.Name == name
+}
+
+// Materialize converts a CellProfile into a CellDoc suitable for the same
+// path `kuke run -f` drives. The cell name comes from cellNameOverride if
+// non-empty, else the profile's metadata.name; the realm/space/stack triple
+// is taken from the profile spec verbatim (callers layer --realm/--space/--stack
+// flag overrides separately, mirroring the existing -f resolution).
+func Materialize(profile *v1beta1.CellProfileDoc, cellNameOverride string) v1beta1.CellDoc {
+	cellName := strings.TrimSpace(cellNameOverride)
+	if cellName == "" {
+		cellName = profile.Metadata.Name
+	}
+
+	spec := profile.Spec.Cell
+	spec.RealmID = strings.TrimSpace(profile.Spec.Realm)
+	spec.SpaceID = strings.TrimSpace(profile.Spec.Space)
+	spec.StackID = strings.TrimSpace(profile.Spec.Stack)
+	if strings.TrimSpace(spec.ID) == "" {
+		spec.ID = cellName
+	}
+
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   cellName,
+			Labels: cloneLabels(profile.Metadata.Labels),
+		},
+		Spec: spec,
+	}
+}
+
+func cloneLabels(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/cellprofile/cellprofile_test.go
+++ b/internal/cellprofile/cellprofile_test.go
@@ -1,0 +1,232 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellprofile_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cellprofile"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+const claudeProfile = `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: claude-cell
+spec:
+  realm: default
+  space: agents
+  stack: claude
+  cell:
+    tty:
+      default: work
+    containers:
+      - id: root
+        root: true
+        image: registry.eminwux.com/busybox:latest
+        command: sleep
+        args:
+          - "3600"
+      - id: work
+        attachable: true
+        image: registry.eminwux.com/claude-runner:latest
+        command: /bin/bash
+        workingDir: /workspace
+`
+
+func writeProfile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write profile %q: %v", path, err)
+	}
+}
+
+func TestLoad_ByFilename(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "claude-cell.yaml", claudeProfile)
+
+	got, err := cellprofile.Load(dir, "claude-cell")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Metadata.Name != "claude-cell" {
+		t.Errorf("metadata.name=%q want claude-cell", got.Metadata.Name)
+	}
+	if got.Spec.Realm != "default" {
+		t.Errorf("spec.realm=%q want default", got.Spec.Realm)
+	}
+	if got.Spec.Cell.Tty == nil || got.Spec.Cell.Tty.Default != "work" {
+		t.Errorf("cell.tty.default not preserved: %+v", got.Spec.Cell.Tty)
+	}
+	if len(got.Spec.Cell.Containers) != 2 {
+		t.Errorf("containers=%d want 2", len(got.Spec.Cell.Containers))
+	}
+}
+
+func TestLoad_ByMetadataName_FilenameMismatch(t *testing.T) {
+	// File named differently than metadata.name. Profile is still findable
+	// because the fallback scan keys on metadata.name.
+	dir := t.TempDir()
+	writeProfile(t, dir, "renamed.yaml", claudeProfile)
+
+	got, err := cellprofile.Load(dir, "claude-cell")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Metadata.Name != "claude-cell" {
+		t.Errorf("metadata.name=%q want claude-cell", got.Metadata.Name)
+	}
+}
+
+func TestLoad_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := cellprofile.Load(dir, "missing")
+	if !errors.Is(err, errdefs.ErrProfileNotFound) {
+		t.Fatalf("err=%v want ErrProfileNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "missing") || !strings.Contains(err.Error(), dir) {
+		t.Errorf("err %q must name profile and dir", err)
+	}
+}
+
+func TestLoad_DirMissing_NotFound(t *testing.T) {
+	// ENOENT on the dir resolves to a profile-not-found error, not a hard
+	// filesystem failure: a fresh user with no profiles.d/ should hit the
+	// same error path as someone who has the dir but no matching file.
+	dir := filepath.Join(t.TempDir(), "absent")
+	_, err := cellprofile.Load(dir, "claude-cell")
+	if !errors.Is(err, errdefs.ErrProfileNotFound) {
+		t.Fatalf("err=%v want ErrProfileNotFound", err)
+	}
+}
+
+func TestLoad_WrongKind_Rejected(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "bad.yaml", `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: bad
+`)
+	_, err := cellprofile.Load(dir, "bad")
+	if err == nil {
+		t.Fatal("Load returned nil, want ErrProfileInvalid (or NotFound after fallthrough)")
+	}
+}
+
+func TestList_SkipsBrokenAndNonYAML(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "claude-cell.yaml", claudeProfile)
+	writeProfile(t, dir, "junk.yaml", "not: [valid")
+	writeProfile(t, dir, "readme.txt", "ignored")
+	if err := os.MkdirAll(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+
+	profiles, err := cellprofile.List(dir)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(profiles) != 1 || profiles[0].Metadata.Name != "claude-cell" {
+		t.Errorf("got %+v, want exactly [claude-cell]", profiles)
+	}
+}
+
+func TestResolveDir_EnvOverride(t *testing.T) {
+	t.Setenv(cellprofile.EnvProfilesDir, "/tmp/custom-profiles")
+	dir, err := cellprofile.ResolveDir()
+	if err != nil {
+		t.Fatalf("ResolveDir: %v", err)
+	}
+	if dir != "/tmp/custom-profiles" {
+		t.Errorf("dir=%q want /tmp/custom-profiles", dir)
+	}
+}
+
+func TestResolveDir_DefaultsUnderHome(t *testing.T) {
+	t.Setenv(cellprofile.EnvProfilesDir, "")
+	t.Setenv("HOME", "/tmp/fake-home")
+	dir, err := cellprofile.ResolveDir()
+	if err != nil {
+		t.Fatalf("ResolveDir: %v", err)
+	}
+	want := filepath.Join("/tmp/fake-home", cellprofile.DefaultDirSuffix)
+	if dir != want {
+		t.Errorf("dir=%q want %q", dir, want)
+	}
+}
+
+func TestMaterialize_DefaultName(t *testing.T) {
+	profile := &v1beta1.CellProfileDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellProfile,
+		Metadata:   v1beta1.CellProfileMetadata{Name: "claude-cell"},
+		Spec: v1beta1.CellProfileSpec{
+			Realm: "default",
+			Space: "agents",
+			Stack: "claude",
+			Cell: v1beta1.CellSpec{
+				Containers: []v1beta1.ContainerSpec{
+					{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+				},
+			},
+		},
+	}
+
+	doc := cellprofile.Materialize(profile, "")
+
+	if doc.Metadata.Name != "claude-cell" {
+		t.Errorf("metadata.name=%q want claude-cell (default to profile name)", doc.Metadata.Name)
+	}
+	if doc.Kind != v1beta1.KindCell || doc.APIVersion != v1beta1.APIVersionV1Beta1 {
+		t.Errorf("apiVersion/kind=%q/%q want v1beta1/Cell", doc.APIVersion, doc.Kind)
+	}
+	if doc.Spec.RealmID != "default" || doc.Spec.SpaceID != "agents" || doc.Spec.StackID != "claude" {
+		t.Errorf("location=%q/%q/%q want default/agents/claude",
+			doc.Spec.RealmID, doc.Spec.SpaceID, doc.Spec.StackID)
+	}
+	if doc.Spec.ID != "claude-cell" {
+		t.Errorf("spec.id=%q want claude-cell (defaulted from cell name)", doc.Spec.ID)
+	}
+}
+
+func TestMaterialize_NameOverride(t *testing.T) {
+	profile := &v1beta1.CellProfileDoc{
+		Metadata: v1beta1.CellProfileMetadata{Name: "claude-cell"},
+		Spec: v1beta1.CellProfileSpec{
+			Cell: v1beta1.CellSpec{
+				Containers: []v1beta1.ContainerSpec{
+					{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+				},
+			},
+		},
+	}
+
+	doc := cellprofile.Materialize(profile, "my-cell")
+
+	if doc.Metadata.Name != "my-cell" {
+		t.Errorf("metadata.name=%q want my-cell (positional override)", doc.Metadata.Name)
+	}
+	if doc.Spec.ID != "my-cell" {
+		t.Errorf("spec.id=%q want my-cell (override propagates)", doc.Spec.ID)
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -155,6 +155,18 @@ var (
 	// non-root attachable containers.
 	ErrAttachNoCandidate = errors.New("no attachable container in cell")
 
+	// Profile-related errors.
+
+	// ErrProfileNotFound is returned when `kuke run -p <name>` cannot find
+	// a CellProfile under the active profiles directory. Wrapped errors
+	// must name the profile and the directory searched so the operator
+	// knows which file to drop.
+	ErrProfileNotFound = errors.New("profile not found")
+
+	// ErrProfileInvalid is returned when a CellProfile YAML fails to parse
+	// or violates the schema (missing kind, missing metadata.name, etc.).
+	ErrProfileInvalid = errors.New("profile is invalid")
+
 	// Secret-related errors.
 
 	ErrSecretNameRequired         = errors.New("secret name is required")

--- a/pkg/api/model/v1beta1/cellprofile.go
+++ b/pkg/api/model/v1beta1/cellprofile.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+// CellProfileDoc is a per-user reusable cell template loaded from
+// $HOME/.kuke/profiles.d/<name>.yaml (or $KUKE_PROFILES_DIR). It is never sent
+// to the daemon: `kuke run -p` materializes a CellDoc from it locally and
+// proceeds along the same `-f` path.
+type CellProfileDoc struct {
+	APIVersion Version             `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind                `json:"kind"       yaml:"kind"`
+	Metadata   CellProfileMetadata `json:"metadata"   yaml:"metadata"`
+	Spec       CellProfileSpec     `json:"spec"       yaml:"spec"`
+}
+
+type CellProfileMetadata struct {
+	Name   string            `json:"name"             yaml:"name"`
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// CellProfileSpec carries the location triple (realm/space/stack) plus a
+// CellSpec body. The location uses the user-facing names rather than internal
+// IDs so a profile is portable between hosts.
+type CellProfileSpec struct {
+	Realm string   `json:"realm,omitempty" yaml:"realm,omitempty"`
+	Space string   `json:"space,omitempty" yaml:"space,omitempty"`
+	Stack string   `json:"stack,omitempty" yaml:"stack,omitempty"`
+	Cell  CellSpec `json:"cell"            yaml:"cell"`
+}

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -33,6 +33,10 @@ const (
 	KindSpace Kind = "Space"
 	// KindStack identifies stack documents.
 	KindStack Kind = "Stack"
+	// KindCellProfile identifies per-user cell-template documents loaded by
+	// `kuke run -p`. Profiles are not server-side resources — `kuke apply`
+	// rejects them.
+	KindCellProfile Kind = "CellProfile"
 )
 
 // Common printable state strings.


### PR DESCRIPTION
## Summary
- Adds `kind: CellProfile` under `pkg/api/model/v1beta1/` (parallel to existing kinds), with apiVersion / Kind / Metadata / Spec where Spec carries `realm` / `space` / `stack` plus a `cell:` body that's a CellSpec verbatim.
- Adds `internal/cellprofile/` — a per-user loader that reads `$HOME/.kuke/profiles.d/*.yaml` (configurable via `KUKE_PROFILES_DIR`), scans by filename then falls back to `metadata.name`, and materializes a CellProfile into a CellDoc that walks the same path as `kuke run -f`.
- Wires `kuke run -p <profile> [<cell-name>]`: positional arg overrides the materialized cell name (defaults to `metadata.name`); `--realm`/`--space`/`--stack` flags layer over an unset profile location, matching the existing `-f` "doc wins" rule; bash/zsh autocomplete on `-p` lists profile names; `-f` and `-p` are mutually exclusive (cobra `MarkFlagsMutuallyExclusive` + `MarkFlagsOneRequired`); unknown profiles return `profile "<name>" not found in <dir>` wrapping `errdefs.ErrProfileNotFound`.
- Live smoke (per AC): dropped a profile, ran `kuke run -p smoke-cell smoke-test` against the in-flight daemon — cell created and started; second invocation reports the idempotent already-existed path; `kuke run -p ghost` returns the spec'd not-found message; `kuke run -p smoke-cell -f /tmp/x` rejects with the cobra mutex.

## Notable judgment calls
- Profile spec uses user-facing `realm` / `space` / `stack` strings (not `realmId`/`spaceId`/`stackId`), so a profile is portable between hosts; materialization rewrites them onto `CellSpec.RealmID`/`SpaceID`/`StackID`.
- `cmd/kuke/apply` is intentionally untouched: `CellProfile` is a per-user-only kind (issue says system-wide is a possible follow-up), so `kuke apply -f` rejecting it via the existing `ErrUnknownKind` path is the desired UX rather than a regression.
- Loader's `List()` silently skips unparseable files; the operator only finds out when they actually try to use a broken profile via `Load()`. Tracking-not-failing keeps autocomplete clean when one stale file in `profiles.d/` would otherwise blank the completion list.
- Refactored `runRun` to extract `parseRunFlags` into a `runFlags` struct — kept the original control flow but split the validation block out so the function clears the lint funlen threshold after adding `-p`.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes (including new `internal/cellprofile` and `cmd/kuke/run` `-p` cases)
- [x] golangci-lint pre-commit hook passes
- [x] Live smoke: `kuke run -p smoke-cell smoke-test` round-trip against the running daemon — create succeeds first time, idempotent on re-run; `-p ghost` returns the spec'd not-found error; `-f` + `-p` rejected with the mutex error
- [x] Daemon-parity sanity (`kuke get realms` vs `kuke get realms --no-daemon`) returned identical output — though this PR is purely client-side so the parity check isn't load-bearing here
- [ ] Live `-p -a` round-trip (drop into the attached terminal) — not run interactively in this session; mock-attached test `TestRun_FromProfile_Attach_HeadlineFlow` exercises the full materialize → create → AttachContainer → attach loop chain

Closes #142