### PR TITLE
fix(runner): make StartCell idempotent on already-running cells

### DIFF
--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -73,6 +73,40 @@ func validateExplicitRootHostNetwork(cell intmodel.Cell, rootSpec intmodel.Conta
 	return nil
 }
 
+// cellTasksAllRunningFn is StartCell's idempotency guard, decoupled from
+// any specific containerd client so it can be unit-tested without a live
+// runtime. statusFn is called once for the root containerd ID and once
+// per non-root container; the cell is considered already running only if
+// every call returns containerd.Running. Issue #149: without this guard,
+// CreateCell→StartCell on an already-Ready cell tears the running root
+// container down and re-runs CNI ADD against its recreated peer, which
+// host-local IPAM rejects as a duplicate allocation under the same
+// container ID (we never ran CNI DEL on the teardown path).
+func cellTasksAllRunningFn(
+	cell intmodel.Cell,
+	rootContainerdID string,
+	statusFn func(id string) (containerd.Status, error),
+) bool {
+	rootStatus, err := statusFn(rootContainerdID)
+	if err != nil || rootStatus.Status != containerd.Running {
+		return false
+	}
+	for _, c := range cell.Spec.Containers {
+		if c.Root {
+			continue
+		}
+		cid := strings.TrimSpace(c.ContainerdID)
+		if cid == "" {
+			return false
+		}
+		s, statusErr := statusFn(cid)
+		if statusErr != nil || s.Status != containerd.Running {
+			return false
+		}
+	}
+	return true
+}
+
 // StartCell starts the root container and all containers defined in the CellDoc.
 // The root container is started first, then all containers in doc.Spec.Containers are started.
 func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
@@ -160,6 +194,30 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	containerID, err := naming.BuildRootContainerdID(spaceID, stackID, cellID)
 	if err != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to build root container containerd ID: %w", err)
+	}
+
+	// Idempotency guard (issue #149): if every container's task is already
+	// running, the cell is up. Skip the destructive teardown-and-recreate
+	// cycle below; otherwise we'd kill the running root, recreate it, and
+	// re-run CNI ADD against the same container ID — which host-local IPAM
+	// refuses as a duplicate allocation (we never run CNI DEL when we
+	// delete the old container, so the reservation persists).
+	if cellTasksAllRunningFn(internalCell, containerID, r.ctrClient.TaskStatus) {
+		internalCell.Status.State = intmodel.CellStateReady
+		if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
+			r.logger.WarnContext(r.ctx, "failed to populate container statuses after idempotent StartCell skip",
+				"cell", cellName,
+				"error", err)
+			// best-effort, fall through with the Ready state we already set
+		}
+		skipFields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+		skipFields = append(skipFields, "space", spaceID, "realm", realmID)
+		r.logger.InfoContext(
+			r.ctx,
+			"cell tasks already running, StartCell is a no-op",
+			skipFields...,
+		)
+		return internalCell, nil
 	}
 
 	// Check if container exists and clean it up

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -20,8 +20,10 @@ package runner
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
@@ -182,6 +184,118 @@ func TestValidateExplicitRootHostNetwork(t *testing.T) {
 			}
 			if tt.wantErr && !errors.Is(err, internalerrdefs.ErrExplicitRootHostNetworkMismatch) {
 				t.Errorf("err = %v, want wrapped ErrExplicitRootHostNetworkMismatch", err)
+			}
+		})
+	}
+}
+
+// TestCellTasksAllRunningFn pins the StartCell idempotency guard from
+// issue #149: only every-task-running yields a no-op skip. Anything else
+// — root not running, root status error, a non-root in any non-Running
+// state, a non-root with an empty ContainerdID — has to fall through to
+// the destructive teardown-and-recreate path so a wedged cell can still
+// recover.
+func TestCellTasksAllRunningFn(t *testing.T) {
+	const rootID = "space_stack_cell_root"
+
+	statusOf := func(states map[string]containerd.ProcessStatus) func(string) (containerd.Status, error) {
+		return func(id string) (containerd.Status, error) {
+			s, ok := states[id]
+			if !ok {
+				return containerd.Status{}, fmt.Errorf("no task for %q", id)
+			}
+			return containerd.Status{Status: s}, nil
+		}
+	}
+
+	cellWithPeers := func(peers ...intmodel.ContainerSpec) intmodel.Cell {
+		return intmodel.Cell{Spec: intmodel.CellSpec{Containers: peers}}
+	}
+
+	tests := []struct {
+		name string
+		cell intmodel.Cell
+		fn   func(string) (containerd.Status, error)
+		want bool
+	}{
+		{
+			name: "root running, no non-root containers — already up",
+			cell: intmodel.Cell{},
+			fn:   statusOf(map[string]containerd.ProcessStatus{rootID: containerd.Running}),
+			want: true,
+		},
+		{
+			name: "root running and all non-roots running — already up",
+			cell: cellWithPeers(
+				intmodel.ContainerSpec{ID: "a", ContainerdID: "cid_a"},
+				intmodel.ContainerSpec{ID: "b", ContainerdID: "cid_b"},
+			),
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID:  containerd.Running,
+				"cid_a": containerd.Running,
+				"cid_b": containerd.Running,
+			}),
+			want: true,
+		},
+		{
+			name: "explicit-root entry in Containers list is skipped",
+			cell: cellWithPeers(
+				intmodel.ContainerSpec{ID: "root", Root: true, ContainerdID: "ignored"},
+				intmodel.ContainerSpec{ID: "a", ContainerdID: "cid_a"},
+			),
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID:  containerd.Running,
+				"cid_a": containerd.Running,
+			}),
+			want: true,
+		},
+		{
+			name: "root TaskStatus errors — not up",
+			cell: intmodel.Cell{},
+			fn:   statusOf(map[string]containerd.ProcessStatus{}),
+			want: false,
+		},
+		{
+			name: "root stopped — not up",
+			cell: intmodel.Cell{},
+			fn:   statusOf(map[string]containerd.ProcessStatus{rootID: containerd.Stopped}),
+			want: false,
+		},
+		{
+			name: "root running, one non-root stopped — not up",
+			cell: cellWithPeers(
+				intmodel.ContainerSpec{ID: "a", ContainerdID: "cid_a"},
+				intmodel.ContainerSpec{ID: "b", ContainerdID: "cid_b"},
+			),
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID:  containerd.Running,
+				"cid_a": containerd.Running,
+				"cid_b": containerd.Stopped,
+			}),
+			want: false,
+		},
+		{
+			name: "non-root has empty ContainerdID — not up",
+			cell: cellWithPeers(
+				intmodel.ContainerSpec{ID: "a", ContainerdID: ""},
+			),
+			fn:   statusOf(map[string]containerd.ProcessStatus{rootID: containerd.Running}),
+			want: false,
+		},
+		{
+			name: "non-root TaskStatus errors — not up",
+			cell: cellWithPeers(
+				intmodel.ContainerSpec{ID: "a", ContainerdID: "cid_a"},
+			),
+			fn:   statusOf(map[string]containerd.ProcessStatus{rootID: containerd.Running}),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cellTasksAllRunningFn(tt.cell, rootID, tt.fn); got != tt.want {
+				t.Errorf("cellTasksAllRunningFn() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `controller.Exec.CreateCell` calls `runner.EnsureCell` followed by an unconditional `runner.StartCell`. When `EnsureCell` returned an already-Ready cell, `StartCell` would tear down the running root container, recreate it with the same containerd ID, then re-run CNI ADD — which host-local IPAM rejects (`10.88.0.10 has been allocated to ..., duplicate allocation is not allowed`) because we never run CNI DEL on the teardown path, so the reservation persists.
- Add an idempotency guard at the top of `StartCell`: if the root container's task and every declared non-root container's task are already in `containerd.Running`, refresh container statuses, mark the cell `Ready`, and return — skip the destructive teardown-and-recreate cycle entirely.
- Decision pinned in tests: the guard is intentionally strict ("every task running"); a wedged cell with a stopped peer or a missing task still falls through to the destructive recovery path so `kuke create cell` can still bring a partially-broken cell back. See the new `TestCellTasksAllRunningFn` cases.

## Notable judgment calls
- `cellTasksAllRunningFn` takes a status closure rather than calling `r.ctrClient.TaskStatus` directly — keeps the decision logic unit-testable without standing up a containerd fake. The wiring in `StartCell` passes `r.ctrClient.TaskStatus` as the closure.
- The guard explicitly does **not** trust the persisted `cell.Status.State` (which could be stale across daemon restarts); it asks containerd for the live task status.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test \$(go list ./... | grep -v /e2e)` passes (full unit suite)
- [x] CLAUDE.md smoke test: rebuild `kuke`/`kukeond`, rebuild + import `kukeon-local:dev`, tear down and re-`kuke init`. Daemon-parity check (`kuke get realms` vs `kuke get realms --no-daemon`) is identical.
- [x] Reproduce #149 directly: two consecutive `sudo ./kuke create cell smoke --realm default --space default --stack default` calls. Before this PR the second one returned the duplicate-allocation error from the issue; now both succeed (second prints `metadata: already existed`, `containers: started`) and the root task PID is unchanged across the second call (`ctr -n kukeon.io tasks ls` confirms RUNNING with the same PID).

Closes #149