### PR TITLE
fix: treat sbsh clean-detach error as exit 0 in kuke attach

### DIFF
--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -135,12 +135,36 @@ func runAttach(cmd *cobra.Command, _ []string) error {
 	}
 
 	run := resolveRun(cmd)
-	return run(cmd.Context(), attach.Options{
+	if runErr := run(cmd.Context(), attach.Options{
 		SocketPath: result.HostSocketPath,
 		Stdin:      os.Stdin,
 		Stdout:     os.Stdout,
 		Stderr:     os.Stderr,
-	})
+	}); runErr != nil && !isCleanDetach(runErr) {
+		return runErr
+	}
+	return nil
+}
+
+// isCleanDetach reports whether err returned by the in-process attach
+// loop describes a normal session end rather than an unrecoverable
+// failure. The Ctrl+] Ctrl+] detach filter inside sbsh's pkg/attach
+// triggers a controller-level Detach RPC; the embedded read/write
+// goroutines then exit cleanly, but their teardown is reported as the
+// error "close requested: read/write routines exited" — sbsh does not
+// expose a sentinel for either layer in its public pkg/errors. The
+// remote terminal closing the connection (workload exited, peer hung
+// up) ends up on the same path, which from `kuke attach`'s perspective
+// is also a benign session end. Surface a clean exit code 0 in those
+// cases; any other failure (socket missing, RPC error, context done)
+// arrives without this signature and still bubbles up.
+func isCleanDetach(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "close requested") &&
+		strings.Contains(msg, "read/write routines exited")
 }
 
 // pickAttachableContainer enumerates the cell's containers and returns the

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -75,6 +75,18 @@ func (r *runCapture) fn(_ context.Context, opts sbshattach.Options) error {
 	return nil
 }
 
+// runReturning is the mirror of runCapture for tests that want pkg/attach.Run
+// to return a specific error (rather than the clean-detach default).
+type runReturning struct {
+	calls int
+	err   error
+}
+
+func (r *runReturning) fn(_ context.Context, _ sbshattach.Options) error {
+	r.calls++
+	return r.err
+}
+
 func newCmdWithCtx(t *testing.T, fc *fakeClient, run *runCapture) *cobra.Command {
 	t.Helper()
 
@@ -263,6 +275,66 @@ func TestAttach_ExplicitContainer_Attachable_Succeeds(t *testing.T) {
 	}
 	if run.opts.SocketPath != testHostSocket {
 		t.Errorf("Options.SocketPath = %q, want %q", run.opts.SocketPath, testHostSocket)
+	}
+}
+
+// TestAttach_RunReturnsCleanDetachError covers the regression from #147:
+// when the user presses Ctrl+] Ctrl+], sbsh's controller fires the
+// Detach RPC and the embedded read/write copy goroutines exit, but that
+// teardown surfaces as "close requested: read/write routines exited"
+// from pkg/attach.Run. The wrapper must recognise that signature as a
+// benign session end and return nil so `kuke attach` exits 0.
+func TestAttach_RunReturnsCleanDetachError(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	cleanDetachErr := errors.New("close requested: read/write routines exited")
+	run := &runReturning{err: cleanDetachErr}
+	cmd := newCmdWithCtx(t, fc, nil)
+	cmd.SetContext(context.WithValue(cmd.Context(), attachcmd.MockRunKey{}, attachcmd.RunFn(run.fn)))
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "work",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned %v on clean-detach error, want nil", err)
+	}
+	if run.calls != 1 {
+		t.Fatalf("attach.Run called %d times, want 1", run.calls)
+	}
+}
+
+// TestAttach_RunReturnsRealError ensures that any pkg/attach.Run error
+// not matching the clean-detach signature still bubbles up — the wrapper
+// must not swallow real failures like socket-not-found or RPC errors.
+func TestAttach_RunReturnsRealError(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	bootErr := errors.New("wait on ready: dial unix: connection refused")
+	run := &runReturning{err: bootErr}
+	cmd := newCmdWithCtx(t, fc, nil)
+	cmd.SetContext(context.WithValue(cmd.Context(), attachcmd.MockRunKey{}, attachcmd.RunFn(run.fn)))
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "work",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute returned nil on real error, want %v", bootErr)
+	}
+	if !errors.Is(err, bootErr) {
+		t.Fatalf("error %v does not unwrap to bootErr", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `kuke attach` was exiting 1 after a successful Ctrl+] Ctrl+] detach, surfacing `Error: close requested: read/write routines exited` even though the workload kept running. The `pkg/attach` detach filter already fired and printed `Detached`, but the embedded read/write goroutines tearing down then surfaced as a non-nil error from `pkg/attach.Run` and bubbled to the cobra runner.
- Wrap that single return in `cmd/kuke/attach/attach.go:runAttach` with an `isCleanDetach(err)` check that recognises the `close requested: ...read/write routines exited` signature emitted by sbsh's controller after the detach RPC fires (or the remote terminal closes the connection from its side). Other failures — context-done, RPC errors, socket missing, wait-on-ready — arrive without that pair of substrings and still bubble up unchanged, so this only suppresses benign session-end signals.

## Notable judgment calls
- **String match on the wrapper side, not a sentinel.** The relevant errors live behind `github.com/eminwux/sbsh/internal/errdefs` and the inner `errors.New("read/write routines exited")` is constructed inline in sbsh's `clientrunner/io.go`. Neither is exported via sbsh's public `pkg/errors`, so an `errors.Is` branch is not available against either layer. The matched substrings are stable in sbsh v0.8.0 and the suppression is conservative (both have to be present), so a real failure outside this clean-detach path still surfaces. A follow-up upstream sentinel would let this collapse to one line — left for a separate PR rather than bundled here.
- **Treat any `close requested: …read/write routines exited` as benign**, not just the user-keystroke case. The same goroutine-teardown path fires when the remote workload exits or the peer hangs up; from `kuke attach`'s perspective those are also clean session ends and exit 0 is the correct UX, matching what e.g. `ssh` returns when the remote shell exits cleanly.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes (the project's CI test target — CI does not run e2e)
- [x] `go test ./cmd/kuke/attach/... -race -count=1` — new `TestAttach_RunReturnsCleanDetachError` covers the regression (exit 0 when `pkg/attach.Run` returns the matching error) and `TestAttach_RunReturnsRealError` pins the negative case (a non-matching error still bubbles via `errors.Is`)
- [x] Pre-commit hooks pass (golangci-lint, addlicense, go fmt, go-mod-tidy)
- [ ] **End-to-end `TestKuke_AttachDetach_KeepsTaskRunning` rerun** — the e2e harness needs sudo + a fresh kukeond image build + a real PTY (`go test … ./e2e -count=1` under root); not feasible from this non-interactive session. The unit tests cover the seam and the failure mode is fully reproduced from sbsh's source: `pkg/attach.Run` -> `errdefs.ErrCloseReq` wrap -> the inline `errors.New("read/write routines exited")`. Reviewer should run the original repro on a live host; this also closes out the open re-run TODO in #119.

Closes #147