### PR TITLE
feat(api+cli): add CellProfile.spec.namePrefix and inject profile label

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -50,17 +50,14 @@ type MockControllerKey struct{}
 // operator into the cell's attachable terminal once the cell is up.
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run (-f <file> | -p <profile> [<cell-name>])",
+		Use:   "run (-f <file> | -p <profile>)",
 		Short: "Create and start a single cell from a YAML file or a profile",
 		Long: "Create and start a single cell from a YAML file or stdin (-f), " +
 			"or from a per-user profile under $HOME/.kuke/profiles.d/<name>.yaml (-p). " +
 			"Conceptually `kuke apply -f` (single-cell) plus `kuke start cell`, but refuses " +
-			"to update a divergent on-disk spec. With -p, the optional positional argument " +
-			"overrides the materialized cell name.",
-		// MaximumNArgs(1) leaves room for the optional cell-name override
-		// `kuke run -p <profile> <cell-name>`. The handler rejects the arg
-		// when -p is not in use, so the -f form behaves as before.
-		Args:          cobra.MaximumNArgs(1),
+			"to update a divergent on-disk spec. To re-attach to an existing cell use " +
+			"`kuke attach <cell>`.",
+		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE:          runRun,
@@ -105,26 +102,19 @@ func NewRunCmd() *cobra.Command {
 // argument validation. Splitting it out keeps runRun under the funlen limit
 // while preserving the original control flow.
 type runFlags struct {
-	file             string
-	profileName      string
-	cellNameOverride string
-	output           string
-	doAttach         bool
-	containerFlag    string
+	file          string
+	profileName   string
+	output        string
+	doAttach      bool
+	containerFlag string
 }
 
-func parseRunFlags(cmd *cobra.Command, args []string) (runFlags, error) {
+func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 	flags := runFlags{
 		file:          strings.TrimSpace(viper.GetString(config.KUKE_RUN_FILE.ViperKey)),
 		profileName:   strings.TrimSpace(viper.GetString(config.KUKE_RUN_PROFILE.ViperKey)),
 		doAttach:      viper.GetBool(config.KUKE_RUN_ATTACH.ViperKey),
 		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
-	}
-	if len(args) == 1 {
-		flags.cellNameOverride = strings.TrimSpace(args[0])
-	}
-	if flags.cellNameOverride != "" && flags.profileName == "" {
-		return runFlags{}, errors.New("positional <cell-name> argument is only valid together with -p/--profile")
 	}
 
 	output, err := cmd.Flags().GetString("output")
@@ -154,7 +144,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cellDoc, err := loadCellDoc(flags.file, flags.profileName, flags.cellNameOverride)
+	cellDoc, err := loadCellDoc(flags.file, flags.profileName)
 	if err != nil {
 		return err
 	}
@@ -234,10 +224,10 @@ func attachAfterRun(
 
 // loadCellDoc dispatches to the file or profile loader. Exactly one of file or
 // profileName is non-empty (the cobra mutex enforces it before the handler
-// runs). cellNameOverride is honored only on the profile path.
-func loadCellDoc(file, profileName, cellNameOverride string) (v1beta1.CellDoc, error) {
+// runs).
+func loadCellDoc(file, profileName string) (v1beta1.CellDoc, error) {
 	if profileName != "" {
-		return loadFromProfile(profileName, cellNameOverride)
+		return loadFromProfile(profileName)
 	}
 	return loadFromFile(file)
 }
@@ -260,9 +250,9 @@ func loadFromFile(file string) (v1beta1.CellDoc, error) {
 
 // loadFromProfile resolves the active profiles directory, loads the named
 // profile, and materializes its CellSpec body into a CellDoc. The cell name
-// defaults to the profile metadata.name; cellNameOverride wins when set
-// (positional arg on `kuke run -p <profile> <cell-name>`).
-func loadFromProfile(profileName, cellNameOverride string) (v1beta1.CellDoc, error) {
+// is the profile metadata.name when spec.namePrefix is unset, otherwise
+// `<namePrefix>-<6hex>` so each invocation produces a fresh cell.
+func loadFromProfile(profileName string) (v1beta1.CellDoc, error) {
 	dir, err := cellprofile.ResolveDir()
 	if err != nil {
 		return v1beta1.CellDoc{}, err
@@ -271,7 +261,7 @@ func loadFromProfile(profileName, cellNameOverride string) (v1beta1.CellDoc, err
 	if err != nil {
 		return v1beta1.CellDoc{}, err
 	}
-	return cellprofile.Materialize(profile, cellNameOverride), nil
+	return cellprofile.Materialize(profile)
 }
 
 // parseSingleCellDoc parses raw YAML and returns the single-doc Cell. It errors

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1084,25 +1084,62 @@ func TestRun_FromProfile_CreatesAndStarts(t *testing.T) {
 	if got := fc.createDoc.Spec.StackID; got != "claude" {
 		t.Errorf("StackID=%q want claude", got)
 	}
+	if got := fc.createDoc.Metadata.Labels["kukeon.io/profile"]; got != "claude-cell" {
+		t.Errorf("labels[kukeon.io/profile]=%q want claude-cell", got)
+	}
 }
 
-func TestRun_FromProfile_PositionalCellNameOverride(t *testing.T) {
+func TestRun_FromProfile_NamePrefix_GeneratesFreshCell(t *testing.T) {
+	// spec.namePrefix flips the profile from singleton to template: every
+	// invocation must produce a distinct cell name shaped like
+	// `<prefix>-<6hex>`. Drive two invocations and assert both names share
+	// the prefix and differ.
 	t.Cleanup(viper.Reset)
-	writeTempProfile(t)
-
-	fc := &fakeClient{
-		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-			return successCreateResult(doc), nil
-		},
+	dir := t.TempDir()
+	const profileYAML = `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: claude
+spec:
+  realm: default
+  space: agents
+  stack: claude
+  namePrefix: claude
+  cell:
+    containers:
+      - id: work
+        attachable: true
+        image: registry.eminwux.com/busybox:latest
+        command: /bin/sh
+`
+	if err := os.WriteFile(filepath.Join(dir, "claude.yaml"), []byte(profileYAML), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
 	}
-	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-p", "claude-cell", "my-cell"})
+	t.Setenv("KUKE_PROFILES_DIR", dir)
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if got := fc.createDoc.Metadata.Name; got != "my-cell" {
-		t.Errorf("cell name=%q want my-cell (positional override)", got)
+	names := make(map[string]struct{}, 2)
+	for i := range 2 {
+		fc := &fakeClient{
+			createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+				return successCreateResult(doc), nil
+			},
+		}
+		cmd, _ := newCmd(t, fc)
+		cmd.SetArgs([]string{"-p", "claude"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute #%d: %v", i, err)
+		}
+		name := fc.createDoc.Metadata.Name
+		if !strings.HasPrefix(name, "claude-") || len(name) != len("claude-")+6 {
+			t.Fatalf("cell name=%q want claude-<6hex>", name)
+		}
+		if _, dup := names[name]; dup {
+			t.Errorf("name=%q repeated across invocations", name)
+		}
+		names[name] = struct{}{}
+		if got := fc.createDoc.Metadata.Labels["kukeon.io/profile"]; got != "claude" {
+			t.Errorf("labels[kukeon.io/profile]=%q want claude", got)
+		}
 	}
 }
 
@@ -1169,7 +1206,9 @@ func TestRun_FromProfile_FileAndProfile_MutuallyExclusive(t *testing.T) {
 	}
 }
 
-func TestRun_PositionalArg_WithoutProfile_Errors(t *testing.T) {
+func TestRun_RejectsPositionalArgs(t *testing.T) {
+	// `kuke run` is for creating cells; re-attaching to a known cell is
+	// `kuke attach <cell>`'s job. Cobra's NoArgs guard enforces the split.
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{}
@@ -1177,8 +1216,11 @@ func TestRun_PositionalArg_WithoutProfile_Errors(t *testing.T) {
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "my-cell"})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "positional <cell-name>") {
-		t.Fatalf("err=%v want positional-arg guard", err)
+	if err == nil {
+		t.Fatal("Execute returned nil, want positional-arg rejection")
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 on rejected args", fc.createCalls)
 	}
 }
 

--- a/internal/cellprofile/cellprofile.go
+++ b/internal/cellprofile/cellprofile.go
@@ -20,6 +20,8 @@
 package cellprofile
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -31,6 +33,16 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"gopkg.in/yaml.v3"
 )
+
+// LabelProfile is the cell label that records the CellProfile a cell was
+// materialized from. Set on every cell produced by Materialize so operators
+// can list all instances with `kuke get cells -l kukeon.io/profile=<name>`.
+const LabelProfile = "kukeon.io/profile"
+
+// nameSuffixBytes is the entropy width for namePrefix-generated cell names.
+// 3 bytes → 6 lowercase hex chars; matches K8s `generateName`'s suffix shape
+// closely enough that the names read familiar at a glance.
+const nameSuffixBytes = 3
 
 // EnvProfilesDir is the env var that overrides the default user profiles
 // directory. Picked up by ResolveDir; takes precedence over $HOME/.kuke/profiles.d.
@@ -157,14 +169,18 @@ func matchesName(profile *v1beta1.CellProfileDoc, name string) bool {
 }
 
 // Materialize converts a CellProfile into a CellDoc suitable for the same
-// path `kuke run -f` drives. The cell name comes from cellNameOverride if
-// non-empty, else the profile's metadata.name; the realm/space/stack triple
-// is taken from the profile spec verbatim (callers layer --realm/--space/--stack
-// flag overrides separately, mirroring the existing -f resolution).
-func Materialize(profile *v1beta1.CellProfileDoc, cellNameOverride string) v1beta1.CellDoc {
-	cellName := strings.TrimSpace(cellNameOverride)
-	if cellName == "" {
-		cellName = profile.Metadata.Name
+// path `kuke run -f` drives. When spec.namePrefix is set the cell name is
+// `<namePrefix>-<6hex>` (a fresh cell on every invocation); otherwise it
+// defaults to the profile's metadata.name and re-running the profile is
+// idempotent against the existing cell. The realm/space/stack triple is taken
+// from the profile spec verbatim — callers layer --realm/--space/--stack flag
+// overrides separately, mirroring the existing -f resolution. Every produced
+// cell also carries the kukeon.io/profile=<metadata.name> label so the set of
+// cells materialized from a profile is queryable via `kuke get cells -l`.
+func Materialize(profile *v1beta1.CellProfileDoc) (v1beta1.CellDoc, error) {
+	cellName, err := resolveCellName(profile)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
 	}
 
 	spec := profile.Spec.Cell
@@ -180,19 +196,37 @@ func Materialize(profile *v1beta1.CellProfileDoc, cellNameOverride string) v1bet
 		Kind:       v1beta1.KindCell,
 		Metadata: v1beta1.CellMetadata{
 			Name:   cellName,
-			Labels: cloneLabels(profile.Metadata.Labels),
+			Labels: mergeLabels(profile.Metadata.Labels, LabelProfile, profile.Metadata.Name),
 		},
 		Spec: spec,
-	}
+	}, nil
 }
 
-func cloneLabels(in map[string]string) map[string]string {
-	if len(in) == 0 {
-		return map[string]string{}
+func resolveCellName(profile *v1beta1.CellProfileDoc) (string, error) {
+	prefix := strings.TrimSpace(profile.Spec.NamePrefix)
+	if prefix == "" {
+		return profile.Metadata.Name, nil
 	}
-	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
+	suffix, err := randomHexSuffix()
+	if err != nil {
+		return "", fmt.Errorf("generate name suffix for profile %q: %w", profile.Metadata.Name, err)
 	}
+	return prefix + "-" + suffix, nil
+}
+
+func randomHexSuffix() (string, error) {
+	b := make([]byte, nameSuffixBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func mergeLabels(in map[string]string, k, v string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+	for lk, lv := range in {
+		out[lk] = lv
+	}
+	out[k] = v
 	return out
 }

--- a/internal/cellprofile/cellprofile_test.go
+++ b/internal/cellprofile/cellprofile_test.go
@@ -192,7 +192,10 @@ func TestMaterialize_DefaultName(t *testing.T) {
 		},
 	}
 
-	doc := cellprofile.Materialize(profile, "")
+	doc, err := cellprofile.Materialize(profile)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
 
 	if doc.Metadata.Name != "claude-cell" {
 		t.Errorf("metadata.name=%q want claude-cell (default to profile name)", doc.Metadata.Name)
@@ -207,11 +210,18 @@ func TestMaterialize_DefaultName(t *testing.T) {
 	if doc.Spec.ID != "claude-cell" {
 		t.Errorf("spec.id=%q want claude-cell (defaulted from cell name)", doc.Spec.ID)
 	}
+	if got := doc.Metadata.Labels[cellprofile.LabelProfile]; got != "claude-cell" {
+		t.Errorf("labels[%q]=%q want claude-cell (profile-of-origin label)",
+			cellprofile.LabelProfile, got)
+	}
 }
 
-func TestMaterialize_NameOverride(t *testing.T) {
+func TestMaterialize_DefaultName_Idempotent(t *testing.T) {
+	// Without spec.namePrefix the same profile must produce the same cell name
+	// across invocations. This is the singleton path that pairs with the
+	// runner's already-exists idempotency.
 	profile := &v1beta1.CellProfileDoc{
-		Metadata: v1beta1.CellProfileMetadata{Name: "claude-cell"},
+		Metadata: v1beta1.CellProfileMetadata{Name: "singleton"},
 		Spec: v1beta1.CellProfileSpec{
 			Cell: v1beta1.CellSpec{
 				Containers: []v1beta1.ContainerSpec{
@@ -221,12 +231,101 @@ func TestMaterialize_NameOverride(t *testing.T) {
 		},
 	}
 
-	doc := cellprofile.Materialize(profile, "my-cell")
-
-	if doc.Metadata.Name != "my-cell" {
-		t.Errorf("metadata.name=%q want my-cell (positional override)", doc.Metadata.Name)
+	first, err := cellprofile.Materialize(profile)
+	if err != nil {
+		t.Fatalf("Materialize first: %v", err)
 	}
-	if doc.Spec.ID != "my-cell" {
-		t.Errorf("spec.id=%q want my-cell (override propagates)", doc.Spec.ID)
+	second, err := cellprofile.Materialize(profile)
+	if err != nil {
+		t.Fatalf("Materialize second: %v", err)
+	}
+	if first.Metadata.Name != "singleton" || second.Metadata.Name != "singleton" {
+		t.Fatalf("names=%q/%q want singleton/singleton", first.Metadata.Name, second.Metadata.Name)
+	}
+}
+
+func TestMaterialize_NamePrefix_GeneratesUniqueCells(t *testing.T) {
+	profile := &v1beta1.CellProfileDoc{
+		Metadata: v1beta1.CellProfileMetadata{Name: "claude"},
+		Spec: v1beta1.CellProfileSpec{
+			NamePrefix: "claude",
+			Cell: v1beta1.CellSpec{
+				Containers: []v1beta1.ContainerSpec{
+					{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+				},
+			},
+		},
+	}
+
+	const invocations = 3
+	seen := make(map[string]struct{}, invocations)
+	for i := range invocations {
+		doc, err := cellprofile.Materialize(profile)
+		if err != nil {
+			t.Fatalf("Materialize #%d: %v", i, err)
+		}
+		name := doc.Metadata.Name
+		if !strings.HasPrefix(name, "claude-") {
+			t.Errorf("name=%q want prefix claude-", name)
+		}
+		suffix := strings.TrimPrefix(name, "claude-")
+		if len(suffix) != 6 {
+			t.Errorf("suffix=%q len=%d want 6 lowercase hex chars", suffix, len(suffix))
+		}
+		const hexChars = "0123456789abcdef"
+		if strings.Trim(suffix, hexChars) != "" {
+			t.Errorf("suffix=%q contains non-lowercase-hex bytes", suffix)
+		}
+		if _, dup := seen[name]; dup {
+			t.Errorf("name=%q repeated across invocations (entropy too narrow?)", name)
+		}
+		seen[name] = struct{}{}
+		if doc.Spec.ID != name {
+			t.Errorf("spec.id=%q want %q (defaulted from generated name)", doc.Spec.ID, name)
+		}
+		if got := doc.Metadata.Labels[cellprofile.LabelProfile]; got != "claude" {
+			t.Errorf("labels[%q]=%q want claude (profile-of-origin survives namePrefix path)",
+				cellprofile.LabelProfile, got)
+		}
+	}
+}
+
+func TestMaterialize_LabelsMerged(t *testing.T) {
+	// User-set labels on the profile must survive into the cell, alongside
+	// the system-injected kukeon.io/profile=<name> label. Conflicts on the
+	// reserved key resolve to the system value (the label is identity, not
+	// user-controlled metadata).
+	profile := &v1beta1.CellProfileDoc{
+		Metadata: v1beta1.CellProfileMetadata{
+			Name: "claude",
+			Labels: map[string]string{
+				"team":                   "agents",
+				"owner":                  "ops",
+				cellprofile.LabelProfile: "should-be-overwritten",
+			},
+		},
+		Spec: v1beta1.CellProfileSpec{
+			Cell: v1beta1.CellSpec{
+				Containers: []v1beta1.ContainerSpec{
+					{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+				},
+			},
+		},
+	}
+
+	doc, err := cellprofile.Materialize(profile)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	labels := doc.Metadata.Labels
+	if labels["team"] != "agents" {
+		t.Errorf("labels[team]=%q want agents (user label preserved)", labels["team"])
+	}
+	if labels["owner"] != "ops" {
+		t.Errorf("labels[owner]=%q want ops (user label preserved)", labels["owner"])
+	}
+	if labels[cellprofile.LabelProfile] != "claude" {
+		t.Errorf("labels[%q]=%q want claude (system label wins on conflict)",
+			cellprofile.LabelProfile, labels[cellprofile.LabelProfile])
 	}
 }

--- a/pkg/api/model/v1beta1/cellprofile.go
+++ b/pkg/api/model/v1beta1/cellprofile.go
@@ -35,9 +35,16 @@ type CellProfileMetadata struct {
 // CellProfileSpec carries the location triple (realm/space/stack) plus a
 // CellSpec body. The location uses the user-facing names rather than internal
 // IDs so a profile is portable between hosts.
+//
+// NamePrefix toggles the profile between singleton and template modes:
+// when empty, `kuke run -p` materializes a cell named after metadata.name and
+// the same invocation is idempotent. When set, every invocation generates a
+// fresh `<NamePrefix>-<6hex>` cell so the profile behaves like a template
+// (mirrors K8s `metadata.generateName` and sbsh's "every start is fresh").
 type CellProfileSpec struct {
-	Realm string   `json:"realm,omitempty" yaml:"realm,omitempty"`
-	Space string   `json:"space,omitempty" yaml:"space,omitempty"`
-	Stack string   `json:"stack,omitempty" yaml:"stack,omitempty"`
-	Cell  CellSpec `json:"cell"            yaml:"cell"`
+	Realm      string   `json:"realm,omitempty"      yaml:"realm,omitempty"`
+	Space      string   `json:"space,omitempty"      yaml:"space,omitempty"`
+	Stack      string   `json:"stack,omitempty"      yaml:"stack,omitempty"`
+	NamePrefix string   `json:"namePrefix,omitempty" yaml:"namePrefix,omitempty"`
+	Cell       CellSpec `json:"cell"                 yaml:"cell"`
 }


### PR DESCRIPTION
## Summary
- `CellProfileSpec.NamePrefix` (omitempty) flips a profile from singleton to template: when set, every `kuke run -p` invocation materializes a fresh `<NamePrefix>-<6 lowercase hex>` cell using `crypto/rand`; when unset, the existing `metadata.name` singleton path is preserved.
- Every materialized cell now carries the system label `kukeon.io/profile=<profile metadata.name>`, merged with any user-set labels (the system label wins on conflict on the reserved key). Enables `kuke get cells -l kukeon.io/profile=<name>` to enumerate every instance produced from a profile.
- Drops the positional `<cell-name>` override on `kuke run -p` per the issue's "verb separation" rationale: `kuke run` creates cells, `kuke attach <cell>` re-attaches. Cobra `Args` switches from `MaximumNArgs(1)` to `NoArgs`. The override was one day old (PR #153) with no adoption, the only breaking change here.
- `Materialize` now returns `(CellDoc, error)` so `crypto/rand.Read` failures surface to the caller rather than panic; the cobra handler bubbles them up the same way profile load errors flow today.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full unit suite green (includes the new `TestMaterialize_NamePrefix_GeneratesUniqueCells`, `TestMaterialize_LabelsMerged`, `TestMaterialize_DefaultName_Idempotent`, and `TestRun_FromProfile_NamePrefix_GeneratesFreshCell`).
- [x] gofmt clean on changed files.
- [ ] Local `kuke get realms` vs `--no-daemon` daemon-parity smoke check — change is purely client-side (cellprofile materializer + `kuke run` flag handling, no daemon-visible code paths). The AC asks for it noted in the test plan even when client-side, so this is the explicit acknowledgement that no daemon view changed.

Closes #157