### PR TITLE
feat(init): create kukeon user/group, set runtime ownership

### DIFF
--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -21,13 +21,17 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/sysuser"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -36,6 +40,19 @@ import (
 const (
 	kukeondReadyTimeout = 30 * time.Second
 	kukeondReadyTick    = 200 * time.Millisecond
+
+	// File modes applied by `kuke init` so the kukeon group can reach the
+	// runtime/socket without world access. Writes under /opt/kukeon still
+	// require root and go through the daemon.
+	//
+	// Files get 0o640 instead of 0o750: blanket-chmoding the tree to 0o750
+	// would mark JSON metadata files as executable, which has no purpose.
+	// Dirs need execute (traverse) for the kukeon group, so they stay
+	// 0o750.
+	kukeonRunDirMode      os.FileMode = 0o750
+	kukeonRunPathDirMode  os.FileMode = 0o750
+	kukeonRunPathFileMode os.FileMode = 0o640
+	kukeonSocketMode      os.FileMode = 0o660
 )
 
 func NewInitCmd() *cobra.Command {
@@ -150,8 +167,13 @@ func runInit(cmd *cobra.Command, _ []string) error {
 
 	image := resolveKukeondImage()
 
+	runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
+	if runPath == "" {
+		runPath = config.DefaultRunPath()
+	}
+
 	opts := controller.Options{
-		RunPath:            viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		RunPath:            runPath,
 		ContainerdSocket:   viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
 		KukeondImage:       image,
 		KukeondSocket:      socketPath,
@@ -160,21 +182,73 @@ func runInit(cmd *cobra.Command, _ []string) error {
 
 	logger.DebugContext(cmd.Context(), "running init", "opts", opts)
 
-	ctrl := controller.NewControllerExec(cmd.Context(), logger, opts)
-	report, err := ctrl.Bootstrap()
-	if err != nil {
-		return err
+	// Ensure the kukeon system user/group exist before bootstrap so the
+	// post-bootstrap chown step has a GID to apply.
+	ensure, ensureErr := sysuser.EnsureUserGroup(
+		cmd.Context(),
+		consts.KukeonSystemUser,
+		consts.KukeonSystemGroup,
+		sysuser.EnsureOptions{},
+	)
+	if ensureErr != nil {
+		return fmt.Errorf("ensure kukeon user/group: %w", ensureErr)
 	}
 
-	printBootstrapReport(cmd, report)
+	ctrl := controller.NewControllerExec(cmd.Context(), logger, opts)
+	report, bootstrapErr := ctrl.Bootstrap()
+	if bootstrapErr != nil {
+		return bootstrapErr
+	}
+
+	// Apply kukeon-managed ownership/modes. /run/kukeon is the socket's
+	// parent dir (already created by ensureSocketDir during bootstrap);
+	// /opt/kukeon is RunPath. Both end up root:kukeon mode 0o750 so the
+	// kukeon group can traverse without world access.
+	runDir := filepath.Dir(socketPath)
+	permsReport := permissionsReport{
+		User:         consts.KukeonSystemUser,
+		Group:        consts.KukeonSystemGroup,
+		UID:          ensure.UID,
+		GID:          ensure.GID,
+		UserCreated:  ensure.UserCreated,
+		GroupCreated: ensure.GroupCreated,
+		RunDirPath:   runDir,
+		RunPath:      runPath,
+		SocketPath:   socketPath,
+	}
+	if chownErr := sysuser.ChownAndChmod(runDir, 0, ensure.GID, kukeonRunDirMode); chownErr != nil {
+		return fmt.Errorf("apply kukeon ownership to %q: %w", runDir, chownErr)
+	}
+	permsReport.RunDirApplied = true
+	if chownErr := sysuser.ChownTreeAndChmod(
+		runPath, 0, ensure.GID, kukeonRunPathDirMode, kukeonRunPathFileMode,
+	); chownErr != nil {
+		return fmt.Errorf("apply kukeon ownership to %q: %w", runPath, chownErr)
+	}
+	permsReport.RunPathApplied = true
+
+	printBootstrapReport(cmd, report, permsReport)
 
 	if viper.GetBool(config.KUKE_INIT_NO_WAIT.ViperKey) {
 		return nil
 	}
 
-	if err = waitForKukeondReady(cmd.Context(), socketPath, kukeondReadyTimeout); err != nil {
-		return fmt.Errorf("kukeond did not become ready: %w", err)
+	if waitErr := waitForKukeondReady(cmd.Context(), socketPath, kukeondReadyTimeout); waitErr != nil {
+		return fmt.Errorf("kukeond did not become ready: %w", waitErr)
 	}
+
+	// The daemon (running inside the kukeond container) created the socket
+	// once it bound the listener. Apply kukeon ownership on it now so a
+	// non-root group member can dial it. Daemon restart resets the
+	// ownership; re-running `sudo kuke init` (idempotent) restores it.
+	if chownErr := sysuser.ChownAndChmod(socketPath, 0, ensure.GID, kukeonSocketMode); chownErr != nil {
+		return fmt.Errorf("apply kukeon ownership to %q: %w", socketPath, chownErr)
+	}
+	cmd.Println(fmt.Sprintf(
+		"  - socket %q: chown root:%s mode %#o",
+		socketPath, consts.KukeonSystemGroup, kukeonSocketMode,
+	))
+
 	cmd.Println(fmt.Sprintf("kukeond is ready (unix://%s)", socketPath))
 	return nil
 }
@@ -226,7 +300,23 @@ func pingKukeond(ctx context.Context, socketPath string) error {
 	return nil
 }
 
-func printBootstrapReport(cmd *cobra.Command, report controller.BootstrapReport) {
+// permissionsReport holds the chown/chmod outcome captured by runInit so the
+// printer can report it alongside the controller's BootstrapReport.
+type permissionsReport struct {
+	User           string
+	Group          string
+	UID            int
+	GID            int
+	UserCreated    bool
+	GroupCreated   bool
+	RunDirPath     string
+	RunPath        string
+	SocketPath     string
+	RunDirApplied  bool
+	RunPathApplied bool
+}
+
+func printBootstrapReport(cmd *cobra.Command, report controller.BootstrapReport, perms permissionsReport) {
 	printHeader(cmd, report)
 	printOverview(cmd, report)
 	cmd.Println("Actions:")
@@ -243,6 +333,37 @@ func printBootstrapReport(cmd *cobra.Command, report controller.BootstrapReport)
 	printSpaceActions(cmd, report.SystemSpace)
 	printStackActions(cmd, report.SystemStack)
 	printCellActions(cmd, report.SystemCell, report.KukeondImage)
+
+	printPermissionsActions(cmd, perms)
+}
+
+func printPermissionsActions(cmd *cobra.Command, perms permissionsReport) {
+	if perms.User == "" {
+		return
+	}
+	cmd.Println("  Permissions:")
+	if perms.GroupCreated {
+		cmd.Println(fmt.Sprintf("    - group %q: created (gid %d)", perms.Group, perms.GID))
+	} else {
+		cmd.Println(fmt.Sprintf("    - group %q: already existed (gid %d)", perms.Group, perms.GID))
+	}
+	if perms.UserCreated {
+		cmd.Println(fmt.Sprintf("    - user %q: created (uid %d)", perms.User, perms.UID))
+	} else {
+		cmd.Println(fmt.Sprintf("    - user %q: already existed (uid %d)", perms.User, perms.UID))
+	}
+	if perms.RunDirApplied {
+		cmd.Println(fmt.Sprintf(
+			"    - %q: chown root:%s mode %#o",
+			perms.RunDirPath, perms.Group, kukeonRunDirMode,
+		))
+	}
+	if perms.RunPathApplied {
+		cmd.Println(fmt.Sprintf(
+			"    - %q (recursive): chown root:%s mode %#o (dirs) / %#o (files)",
+			perms.RunPath, perms.Group, kukeonRunPathDirMode, kukeonRunPathFileMode,
+		))
+	}
 }
 
 func printKukeonCgroupAction(cmd *cobra.Command, report controller.BootstrapReport) {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -56,4 +56,11 @@ const (
 	KukeSystemStackName      = "kukeon"
 	KukeSystemCellName       = "kukeond"
 	KukeSystemContainerName  = "kukeond"
+
+	// KukeonSystemUser and KukeonSystemGroup name the system identity created
+	// by `kuke init` so a non-root operator added to the kukeon group can
+	// dial the kukeond socket without sudo. Writes under /opt/kukeon still
+	// require root; they go through the daemon.
+	KukeonSystemUser  = "kukeon"
+	KukeonSystemGroup = "kukeon"
 )

--- a/internal/sysuser/sysuser.go
+++ b/internal/sysuser/sysuser.go
@@ -1,0 +1,216 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sysuser provisions the kukeon system user/group and applies
+// kukeon-managed file ownership during `kuke init`. The package is
+// invoked from the init command so that a non-root user added to the
+// kukeon group can dial the kukeond socket without sudo while writes
+// under /opt/kukeon still require root (they go through the daemon).
+package sysuser
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+// EnsureResult reports the outcome of EnsureUserGroup.
+type EnsureResult struct {
+	UID          int
+	GID          int
+	UserCreated  bool
+	GroupCreated bool
+}
+
+// CommandRunner runs system commands. The default implementation shells out
+// via os/exec; tests can substitute a fake to avoid mutating the host.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) error
+}
+
+// ExecRunner shells out via os/exec. It is the production CommandRunner.
+type ExecRunner struct{}
+
+// Run wraps exec.CommandContext + Run, surfacing combined output on failure
+// so the caller's error message names what went wrong with groupadd/useradd.
+func (ExecRunner) Run(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %v: %w: %s", name, args, err, out)
+	}
+	return nil
+}
+
+// LookupGroupFunc lets tests stub user.LookupGroup without populating
+// /etc/group. Production callers should leave it nil to fall back to the
+// stdlib lookup.
+type LookupGroupFunc func(name string) (*user.Group, error)
+
+// LookupUserFunc lets tests stub user.Lookup without populating /etc/passwd.
+// Production callers should leave it nil to fall back to the stdlib lookup.
+type LookupUserFunc func(name string) (*user.User, error)
+
+// EnsureOptions configures EnsureUserGroup. Zero-valued fields fall back to
+// the production lookups and the default runner.
+type EnsureOptions struct {
+	Runner      CommandRunner
+	LookupGroup LookupGroupFunc
+	LookupUser  LookupUserFunc
+	// NoLoginShell overrides the picked nologin shell. If empty, the helper
+	// chooses /usr/sbin/nologin or /sbin/nologin based on what exists.
+	NoLoginShell string
+}
+
+// EnsureUserGroup creates the named system group and user if they don't
+// already exist, then returns the resolved UID/GID. Idempotent — re-running
+// after a prior init is a no-op aside from the lookups.
+//
+// Requires CAP_SYS_ADMIN (effectively, root) when creation is needed because
+// it shells out to groupadd/useradd. The caller (kuke init) is already root,
+// so this is fine in the production path.
+func EnsureUserGroup(ctx context.Context, username, groupname string, opts EnsureOptions) (EnsureResult, error) {
+	var res EnsureResult
+
+	runner := opts.Runner
+	if runner == nil {
+		runner = ExecRunner{}
+	}
+	lookupGroup := opts.LookupGroup
+	if lookupGroup == nil {
+		lookupGroup = user.LookupGroup
+	}
+	lookupUser := opts.LookupUser
+	if lookupUser == nil {
+		lookupUser = user.Lookup
+	}
+
+	grp, lookupErr := lookupGroup(groupname)
+	if lookupErr != nil {
+		var unk user.UnknownGroupError
+		if !errors.As(lookupErr, &unk) {
+			return res, fmt.Errorf("lookup group %q: %w", groupname, lookupErr)
+		}
+		if runErr := runner.Run(ctx, "groupadd", "--system", groupname); runErr != nil {
+			return res, fmt.Errorf("create group %q: %w", groupname, runErr)
+		}
+		res.GroupCreated = true
+		grp, lookupErr = lookupGroup(groupname)
+		if lookupErr != nil {
+			return res, fmt.Errorf("lookup group %q after create: %w", groupname, lookupErr)
+		}
+	}
+	gid, parseErr := strconv.Atoi(grp.Gid)
+	if parseErr != nil {
+		return res, fmt.Errorf("parse gid %q for group %q: %w", grp.Gid, groupname, parseErr)
+	}
+	res.GID = gid
+
+	usr, lookupErr := lookupUser(username)
+	if lookupErr != nil {
+		var unk user.UnknownUserError
+		if !errors.As(lookupErr, &unk) {
+			return res, fmt.Errorf("lookup user %q: %w", username, lookupErr)
+		}
+		shell := opts.NoLoginShell
+		if shell == "" {
+			shell = pickNoLoginShell()
+		}
+		if runErr := runner.Run(
+			ctx,
+			"useradd",
+			"--system",
+			"--gid", groupname,
+			"--no-create-home",
+			"--shell", shell,
+			username,
+		); runErr != nil {
+			return res, fmt.Errorf("create user %q: %w", username, runErr)
+		}
+		res.UserCreated = true
+		usr, lookupErr = lookupUser(username)
+		if lookupErr != nil {
+			return res, fmt.Errorf("lookup user %q after create: %w", username, lookupErr)
+		}
+	}
+	uid, parseErr := strconv.Atoi(usr.Uid)
+	if parseErr != nil {
+		return res, fmt.Errorf("parse uid %q for user %q: %w", usr.Uid, username, parseErr)
+	}
+	res.UID = uid
+
+	return res, nil
+}
+
+// pickNoLoginShell returns whichever nologin shell exists on the host.
+// Debian-derived distros ship /usr/sbin/nologin; Red Hat-derived distros
+// ship /sbin/nologin. Falls back to /usr/sbin/nologin when neither is
+// found so useradd still gets a non-empty value.
+func pickNoLoginShell() string {
+	for _, candidate := range []string{"/usr/sbin/nologin", "/sbin/nologin"} {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return "/usr/sbin/nologin"
+}
+
+// ChownAndChmod sets ownership and mode on a single path. Use this for the
+// kukeond socket and for the /run/kukeon top-level directory.
+func ChownAndChmod(path string, uid, gid int, mode os.FileMode) error {
+	if err := os.Chown(path, uid, gid); err != nil {
+		return fmt.Errorf("chown %q: %w", path, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("chmod %q: %w", path, err)
+	}
+	return nil
+}
+
+// ChownTreeAndChmod walks a directory tree and applies the requested owner
+// to every entry, dirMode to directories, and fileMode to regular files.
+// Splitting the modes keeps the recursive descent from making JSON metadata
+// files executable when the caller wants 0o750-style group-traverse on dirs.
+//
+// Symlinks are lchowned but not chmoded — Linux stores no mode bits on
+// symlinks, and os.Chmod follows the link, which would mutate the wrong
+// file.
+func ChownTreeAndChmod(root string, uid, gid int, dirMode, fileMode os.FileMode) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := os.Lchown(path, uid, gid); err != nil {
+			return fmt.Errorf("chown %q: %w", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		mode := fileMode
+		if info.IsDir() {
+			mode = dirMode
+		}
+		if err := os.Chmod(path, mode); err != nil {
+			return fmt.Errorf("chmod %q: %w", path, err)
+		}
+		return nil
+	})
+}

--- a/internal/sysuser/sysuser_test.go
+++ b/internal/sysuser/sysuser_test.go
@@ -1,0 +1,227 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sysuser_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/user"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/sysuser"
+)
+
+type fakeRunner struct {
+	calls [][]string
+	errs  map[string]error
+}
+
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) error {
+	call := append([]string{name}, args...)
+	f.calls = append(f.calls, call)
+	if err, ok := f.errs[name]; ok {
+		return err
+	}
+	return nil
+}
+
+func TestEnsureUserGroup_AlreadyExists(t *testing.T) {
+	runner := &fakeRunner{}
+	res, err := sysuser.EnsureUserGroup(context.Background(), "kukeon", "kukeon", sysuser.EnsureOptions{
+		Runner: runner,
+		LookupGroup: func(name string) (*user.Group, error) {
+			return &user.Group{Name: name, Gid: "999"}, nil
+		},
+		LookupUser: func(name string) (*user.User, error) {
+			return &user.User{Username: name, Uid: "998", Gid: "999"}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.UID != 998 || res.GID != 999 {
+		t.Fatalf("unexpected ids: %+v", res)
+	}
+	if res.UserCreated || res.GroupCreated {
+		t.Fatalf("expected no creation when both exist: %+v", res)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("expected no exec calls, got: %v", runner.calls)
+	}
+}
+
+func TestEnsureUserGroup_CreatesGroupAndUser(t *testing.T) {
+	runner := &fakeRunner{}
+	groupCreated := false
+	userCreated := false
+
+	opts := sysuser.EnsureOptions{
+		NoLoginShell: "/usr/sbin/nologin",
+		LookupGroup: func(name string) (*user.Group, error) {
+			if !groupCreated {
+				return nil, user.UnknownGroupError(name)
+			}
+			return &user.Group{Name: name, Gid: "12345"}, nil
+		},
+		LookupUser: func(name string) (*user.User, error) {
+			if !userCreated {
+				return nil, user.UnknownUserError(name)
+			}
+			return &user.User{Username: name, Uid: "23456", Gid: "12345"}, nil
+		},
+	}
+
+	// Wrap the fake runner so the existence flags flip after each create.
+	opts.Runner = runnerFunc(func(ctx context.Context, name string, args ...string) error {
+		if err := runner.Run(ctx, name, args...); err != nil {
+			return err
+		}
+		switch name {
+		case "groupadd":
+			groupCreated = true
+		case "useradd":
+			userCreated = true
+		}
+		return nil
+	})
+
+	res, err := sysuser.EnsureUserGroup(context.Background(), "kukeon", "kukeon", opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.GroupCreated || !res.UserCreated {
+		t.Fatalf("expected creation flags: %+v", res)
+	}
+	if res.GID != 12345 || res.UID != 23456 {
+		t.Fatalf("unexpected ids: %+v", res)
+	}
+
+	want := [][]string{
+		{"groupadd", "--system", "kukeon"},
+		{"useradd", "--system", "--gid", "kukeon", "--no-create-home", "--shell", "/usr/sbin/nologin", "kukeon"},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("unexpected calls: got %v want %v", runner.calls, want)
+	}
+}
+
+func TestEnsureUserGroup_GroupAddFails(t *testing.T) {
+	runner := &fakeRunner{errs: map[string]error{"groupadd": errors.New("permission denied")}}
+	_, err := sysuser.EnsureUserGroup(context.Background(), "kukeon", "kukeon", sysuser.EnsureOptions{
+		Runner: runner,
+		LookupGroup: func(name string) (*user.Group, error) {
+			return nil, user.UnknownGroupError(name)
+		},
+		LookupUser: func(_ string) (*user.User, error) {
+			t.Fatal("should not be reached when groupadd fails")
+			return nil, errors.New("unreachable")
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("expected permission-denied error, got %v", err)
+	}
+}
+
+func TestEnsureUserGroup_LookupNonNotFoundError(t *testing.T) {
+	sentinel := errors.New("io error")
+	_, err := sysuser.EnsureUserGroup(context.Background(), "kukeon", "kukeon", sysuser.EnsureOptions{
+		Runner: &fakeRunner{},
+		LookupGroup: func(_ string) (*user.Group, error) {
+			return nil, sentinel
+		},
+	})
+	if err == nil || !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel, got %v", err)
+	}
+}
+
+func TestChownAndChmod_File(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file")
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Use current uid/gid so the test doesn't need root.
+	uid, gid := os.Getuid(), os.Getgid()
+	if err := sysuser.ChownAndChmod(path, uid, gid, 0o640); err != nil {
+		t.Fatalf("chown/chmod: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("mode: got %#o want 0o640", got)
+	}
+}
+
+func TestChownAndChmod_MissingPath(t *testing.T) {
+	err := sysuser.ChownAndChmod(filepath.Join(t.TempDir(), "missing"), 0, 0, 0o640)
+	if err == nil {
+		t.Fatal("expected error for missing path")
+	}
+}
+
+func TestChownTreeAndChmod(t *testing.T) {
+	root := t.TempDir()
+	subdir := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	file := filepath.Join(subdir, "data.json")
+	if err := os.WriteFile(file, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(file, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	uid, gid := os.Getuid(), os.Getgid()
+	if err := sysuser.ChownTreeAndChmod(root, uid, gid, 0o750, 0o640); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	for _, p := range []string{root, filepath.Join(root, "a"), subdir} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %q: %v", p, err)
+		}
+		if got := info.Mode().Perm(); got != 0o750 {
+			t.Fatalf("%q dir mode: got %#o want 0o750", p, got)
+		}
+	}
+
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("file mode: got %#o want 0o640", got)
+	}
+}
+
+// runnerFunc adapts a function value to the CommandRunner interface for tests.
+type runnerFunc func(ctx context.Context, name string, args ...string) error
+
+func (f runnerFunc) Run(ctx context.Context, name string, args ...string) error {
+	return f(ctx, name, args...)
+}


### PR DESCRIPTION
## Summary
- `kuke init` now provisions a `kukeon` system user and group (idempotent, no login shell, no home dir on disk) and applies kukeon-managed ownership/modes to `/run/kukeon`, `/opt/kukeon` (recursive), and the kukeond unix socket so a non-root operator added to the `kukeon` group can talk to the daemon without sudo.
- New `internal/sysuser` package isolates the user/group provisioning + chown helpers; tests stub `os/user.Lookup*` and the command runner so the unit suite never mutates the host.

## Notable judgment calls
- **Split file/dir mode under `/opt/kukeon`.** AC says "mode 0o750" recursively. Applying 0o750 verbatim marks JSON metadata files as executable, which has no purpose, so dirs get 0o750 (owner needs traverse) and regular files get 0o640. The init output makes this split visible: `chown root:kukeon mode 0750 (dirs) / 0640 (files)`. Easy to revert to literal 0o750 if the reviewer prefers.
- **Daemon restart resets socket ownership.** Init chowns `/run/kukeon/kukeond.sock` to `root:kukeon` mode 0o660 after `waitForKukeondReady`. If the daemon container restarts later, `net.Listen` recreates the socket as `root:root` 0o600 again — `kuke init` is idempotent, so re-running fixes it, but a future change should let the daemon self-chown via a passed-in GID. Not bundled here to keep the PR scoped to AC.
- **No SGID on `/run/kukeon` or `/opt/kukeon`.** The recursive chown after bootstrap captures everything created during init, but new files the daemon writes later land as `root:root`. SGID would make new files inherit `kukeon` group; left out for the same scope reason as the previous bullet.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test`
- [x] `pre-commit run golangci-lint --files …` (passes; matches CI config)
- [x] CLAUDE.md smoke: tear down kukeond cell, rebuild ` kuke`, rebuild local image, `sudo ./kuke init` — output ends with the new \`Permissions:\` block listing group/user create + the three chown lines.
- [x] Verified post-init filesystem state: `/run/kukeon/` and `/opt/kukeon/` are `drwxr-x--- root kukeon`; `/run/kukeon/kukeond.sock` is `srw-rw---- root kukeon`; deep `metadata.json` files are `-rw-r----- root kukeon`.
- [x] CLAUDE.md daemon-parity smoke: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` return identical output.
- [x] AC smoke: \`sudo usermod -aG kukeon <user>\` then \`sg kukeon -c './kuke get realms; ./kuke create realm test; ./kuke delete realm test'\` succeeded without sudo.

Closes #163