### PR TITLE
feat(cli): add kuke uninstall to remove all kukeon state

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -382,6 +382,9 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_STOP_CONTAINER_CELL = DefineKV("KUKE_STOP_CONTAINER_CELL", "kuke/stop/container/cell")
 
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_UNINSTALL_YES = DefineKV("KUKE_UNINSTALL_YES", "kuke/uninstall/yes", "false")
+
 	// Kill command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_KILL_CELL_REALM = DefineKV("KUKE_KILL_CELL_REALM", "kuke/kill/cell/realm", "default")

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -38,6 +38,7 @@ import (
 	runcmd "github.com/eminwux/kukeon/cmd/kuke/run"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/start"
 	stopcmd "github.com/eminwux/kukeon/cmd/kuke/stop"
+	uninstallcmd "github.com/eminwux/kukeon/cmd/kuke/uninstall"
 	"github.com/eminwux/kukeon/cmd/kuke/version"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -131,6 +132,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(runcmd.NewRunCmd())
 	rootCmd.AddCommand(attachcmd.NewAttachCmd())
 	rootCmd.AddCommand(autocompletecmd.NewAutocompleteCmd())
+	rootCmd.AddCommand(uninstallcmd.NewUninstallCmd())
 	rootCmd.AddCommand(version.NewVersionCmd())
 
 	// Persistent flags

--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -1,0 +1,210 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package uninstall
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey injects a mock controller via cmd.Context() for tests.
+type MockControllerKey struct{}
+
+func NewUninstallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "uninstall",
+		Short:        "Remove all kukeon runtime state from this host",
+		Long:         uninstallLongDesc,
+		RunE:         runUninstall,
+		SilenceUsage: true,
+	}
+
+	if err := setupUninstallCmd(cmd); err != nil {
+		return nil
+	}
+	return cmd
+}
+
+const uninstallLongDesc = `Remove all kukeon runtime state from this host.
+
+This is the global counterpart to "kuke purge" (which is per-resource). It:
+  1. Purges every realm with --cascade (drains spaces, stacks, cells,
+     containers and their containerd tasks/containers, and deletes the
+     containerd namespaces created by kukeon).
+  2. Removes /run/kukeon/ recursively.
+  3. Removes the configured run path (default /opt/kukeon) recursively.
+  4. Removes the kukeon system user and group (no-op if absent).
+
+The /usr/local/bin/kuke binary and the kukeond symlink are NOT removed —
+uninstalling runtime state is not the same as uninstalling the binary.
+
+By default the command asks for interactive confirmation. Pass --yes/-y to
+skip the prompt (use this in scripts).`
+
+func setupUninstallCmd(cmd *cobra.Command) error {
+	cmd.Flags().BoolP("yes", "y", false, "Skip the interactive confirmation prompt")
+	if err := viper.BindPFlag(config.KUKE_UNINSTALL_YES.ViperKey, cmd.Flags().Lookup("yes")); err != nil {
+		return fmt.Errorf("failed to bind flag: %w", err)
+	}
+	return nil
+}
+
+func runUninstall(cmd *cobra.Command, _ []string) error {
+	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+	if !ok || logger == nil {
+		return errdefs.ErrLoggerNotFound
+	}
+
+	socketPath := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
+	if socketPath == "" {
+		socketPath = config.KUKEOND_SOCKET.Default
+	}
+	socketDir := socketDir(socketPath)
+	runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
+	if runPath == "" {
+		runPath = config.DefaultRunPath()
+	}
+
+	if !viper.GetBool(config.KUKE_UNINSTALL_YES.ViperKey) {
+		confirmed, err := confirm(cmd, runPath, socketDir)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			cmd.Println("Aborted.")
+			return nil
+		}
+	}
+
+	ctrl := resolveController(cmd, logger, runPath)
+	defer func() { _ = ctrl.Close() }()
+
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir: socketDir,
+	})
+	printReport(cmd, report)
+	return err
+}
+
+func resolveController(cmd *cobra.Command, logger *slog.Logger, runPath string) controller.Controller {
+	if mock, ok := cmd.Context().Value(MockControllerKey{}).(controller.Controller); ok {
+		return mock
+	}
+	opts := controller.Options{
+		RunPath:          runPath,
+		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	}
+	return controller.NewControllerExec(cmd.Context(), logger, opts)
+}
+
+func confirm(cmd *cobra.Command, runPath, socketDir string) (bool, error) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "kuke uninstall will remove ALL kukeon runtime state on this host:")
+	fmt.Fprintln(out, "  - every realm (cascade), including the kuke-system realm and the kukeond cell")
+	fmt.Fprintln(out, "  - the kukeon containerd namespaces")
+	fmt.Fprintf(out, "  - %s/ (kukeond socket dir)\n", socketDir)
+	fmt.Fprintf(out, "  - %s/ (run path)\n", runPath)
+	fmt.Fprintln(out, "  - the kukeon system user and group (if present)")
+	fmt.Fprintln(out)
+
+	in := cmd.InOrStdin()
+	for {
+		fmt.Fprint(out, "Are you sure? (yes/no) ")
+		line, err := readLine(in)
+		if err != nil {
+			return false, fmt.Errorf("read confirmation: %w", err)
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "yes", "y":
+			return true, nil
+		case "no", "n", "":
+			return false, nil
+		}
+	}
+}
+
+func readLine(r io.Reader) (string, error) {
+	br := bufio.NewReader(r)
+	line, err := br.ReadString('\n')
+	if err != nil && (line == "" || err != io.EOF) {
+		return line, err
+	}
+	return line, nil
+}
+
+func printReport(cmd *cobra.Command, report controller.UninstallReport) {
+	out := cmd.OutOrStdout()
+	fmt.Fprintln(out, "kuke uninstall:")
+	for _, r := range report.Realms {
+		switch {
+		case r.Err != nil:
+			fmt.Fprintf(out, "  - realm %q (namespace %q): FAILED: %v\n", r.Name, r.Namespace, r.Err)
+		case r.Purged:
+			fmt.Fprintf(out, "  - realm %q (namespace %q): purged\n", r.Name, r.Namespace)
+		}
+	}
+	fmt.Fprintf(out, "  - %s: %s\n", report.SocketDir, dirOutcome(report.SocketDirExists, report.SocketDirRemove))
+	fmt.Fprintf(out, "  - %s: %s\n", report.RunPath, dirOutcome(report.RunPathExists, report.RunPathRemove))
+	fmt.Fprintf(out, "  - user %q: %s\n", report.UserName, accountOutcome(report.UserExisted, report.UserRemoved))
+	fmt.Fprintf(out, "  - group %q: %s\n", report.GroupName, accountOutcome(report.GroupExisted, report.GroupRemoved))
+}
+
+func dirOutcome(existed, removed bool) string {
+	switch {
+	case removed:
+		return "removed"
+	case existed:
+		return "remove failed"
+	default:
+		return "absent"
+	}
+}
+
+func accountOutcome(existed, removed bool) string {
+	switch {
+	case removed:
+		return "removed"
+	case existed:
+		return "remove failed"
+	default:
+		return "absent"
+	}
+}
+
+// socketDir mirrors the helper in controller/bootstrap.go so the CLI does
+// not need to reach into that package just to derive the socket parent.
+func socketDir(socketPath string) string {
+	for i := len(socketPath) - 1; i >= 0; i-- {
+		if socketPath[i] == '/' {
+			if i == 0 {
+				return "/"
+			}
+			return socketPath[:i]
+		}
+	}
+	return "/run/kukeon"
+}

--- a/cmd/kuke/uninstall/uninstall_test.go
+++ b/cmd/kuke/uninstall/uninstall_test.go
@@ -1,0 +1,319 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package uninstall_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/uninstall"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/controller"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/spf13/viper"
+)
+
+// stubController implements controller.Controller; only Uninstall and Close
+// are exercised here. The rest panic so a stray call shows up loudly.
+type stubController struct {
+	uninstallFn func(controller.UninstallOptions) (controller.UninstallReport, error)
+	closed      bool
+}
+
+func (s *stubController) Uninstall(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+	return s.uninstallFn(opts)
+}
+
+func (s *stubController) Close() error {
+	s.closed = true
+	return nil
+}
+
+// Unused interface methods — panic on call so tests fail fast on accidental
+// reach-through. Keep this list aligned with controller.Controller.
+func (s *stubController) Bootstrap() (controller.BootstrapReport, error) { panic("not used") }
+
+func (s *stubController) CreateRealm(intmodel.Realm) (controller.CreateRealmResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) CreateSpace(intmodel.Space) (controller.CreateSpaceResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) CreateStack(intmodel.Stack) (controller.CreateStackResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) CreateCell(intmodel.Cell) (controller.CreateCellResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) CreateContainer(intmodel.Container) (controller.CreateContainerResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) DeleteRealm(intmodel.Realm, bool, bool) (controller.DeleteRealmResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) DeleteSpace(intmodel.Space, bool, bool) (controller.DeleteSpaceResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) DeleteStack(intmodel.Stack, bool, bool) (controller.DeleteStackResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) DeleteCell(intmodel.Cell) (controller.DeleteCellResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) DeleteContainer(intmodel.Container) (controller.DeleteContainerResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) GetRealm(intmodel.Realm) (controller.GetRealmResult, error) {
+	panic("not used")
+}
+func (s *stubController) ListRealms() ([]intmodel.Realm, error) { panic("not used") }
+func (s *stubController) GetSpace(intmodel.Space) (controller.GetSpaceResult, error) {
+	panic("not used")
+}
+func (s *stubController) ListSpaces(string) ([]intmodel.Space, error) { panic("not used") }
+func (s *stubController) GetStack(intmodel.Stack) (controller.GetStackResult, error) {
+	panic("not used")
+}
+func (s *stubController) ListStacks(string, string) ([]intmodel.Stack, error) { panic("not used") }
+func (s *stubController) GetCell(intmodel.Cell) (controller.GetCellResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) ListCells(string, string, string) ([]intmodel.Cell, error) {
+	panic("not used")
+}
+
+func (s *stubController) GetContainer(intmodel.Container) (controller.GetContainerResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) ListContainers(string, string, string, string) ([]intmodel.ContainerSpec, error) {
+	panic("not used")
+}
+
+func (s *stubController) StartCell(intmodel.Cell) (controller.StartCellResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) StartContainer(intmodel.Container) (controller.StartContainerResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) StopCell(intmodel.Cell) (controller.StopCellResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) StopContainer(intmodel.Container) (controller.StopContainerResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) KillCell(intmodel.Cell) (controller.KillCellResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) KillContainer(intmodel.Container) (controller.KillContainerResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) PurgeRealm(intmodel.Realm, bool, bool) (controller.PurgeRealmResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) PurgeSpace(intmodel.Space, bool, bool) (controller.PurgeSpaceResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) PurgeStack(intmodel.Stack, bool, bool) (controller.PurgeStackResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) PurgeCell(intmodel.Cell, bool, bool) (controller.PurgeCellResult, error) {
+	panic("not used")
+}
+
+func (s *stubController) PurgeContainer(intmodel.Container) (controller.PurgeContainerResult, error) {
+	panic("not used")
+}
+func (s *stubController) RefreshAll() (controller.RefreshResult, error) { panic("not used") }
+
+// runCmd builds the cobra command, plugs in a stub controller and a logger,
+// and feeds the supplied stdin payload. Returns the captured stdout/stderr
+// buffer so tests can assert on output.
+func runCmd(
+	t *testing.T,
+	stub *stubController,
+	stdin string,
+	args ...string,
+) (string, error) {
+	t.Helper()
+	cmd := uninstall.NewUninstallCmd()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, uninstall.MockControllerKey{}, controller.Controller(stub))
+	cmd.SetContext(ctx)
+
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestUninstall_YesFlagSkipsPrompt(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	called := false
+	stub := &stubController{
+		uninstallFn: func(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+			called = true
+			return controller.UninstallReport{
+				SocketDir: opts.SocketDir,
+				RunPath:   "/opt/kukeon",
+				UserName:  "kukeon",
+				GroupName: "kukeon",
+			}, nil
+		},
+	}
+
+	// stdin is empty: if the prompt fires, ReadString hits io.EOF and the
+	// command returns an error, so seeing a clean exit + Uninstall called
+	// is proof the --yes path skipped it.
+	out, err := runCmd(t, stub, "", "--yes")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	if !called {
+		t.Errorf("Uninstall was not invoked; output:\n%s", out)
+	}
+	if strings.Contains(out, "Are you sure?") {
+		t.Errorf("--yes still triggered the confirmation prompt:\n%s", out)
+	}
+}
+
+func TestUninstall_PromptAbortsOnNo(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	called := false
+	stub := &stubController{
+		uninstallFn: func(controller.UninstallOptions) (controller.UninstallReport, error) {
+			called = true
+			return controller.UninstallReport{}, nil
+		},
+	}
+	out, err := runCmd(t, stub, "no\n")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	if called {
+		t.Errorf("expected Uninstall not to fire after 'no' answer; output:\n%s", out)
+	}
+	if !strings.Contains(out, "Aborted.") {
+		t.Errorf("expected aborted message; got:\n%s", out)
+	}
+}
+
+func TestUninstall_PromptAcceptsYes(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	called := false
+	stub := &stubController{
+		uninstallFn: func(controller.UninstallOptions) (controller.UninstallReport, error) {
+			called = true
+			return controller.UninstallReport{}, nil
+		},
+	}
+	out, err := runCmd(t, stub, "yes\n")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	if !called {
+		t.Errorf("expected Uninstall to fire after 'yes' answer; output:\n%s", out)
+	}
+}
+
+func TestUninstall_AbortsStepError(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stepErr := errors.New("synthetic")
+	stub := &stubController{
+		uninstallFn: func(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+			return controller.UninstallReport{
+				Realms: []controller.RealmPurgeOutcome{
+					{Name: "kuke-system", Namespace: "kuke-system.kukeon.io", Err: stepErr},
+				},
+				SocketDir: opts.SocketDir,
+				RunPath:   "/opt/kukeon",
+				UserName:  "kukeon",
+				GroupName: "kukeon",
+			}, stepErr
+		},
+	}
+
+	out, err := runCmd(t, stub, "", "--yes")
+	if err == nil {
+		t.Fatalf("expected error to propagate; got nil. output:\n%s", out)
+	}
+	if !strings.Contains(out, "FAILED") {
+		t.Errorf("expected failure marker in report; got:\n%s", out)
+	}
+}
+
+func TestUninstall_DefaultRunPathFromConfig(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "/var/lib/kukeon-test")
+
+	gotRunPath := ""
+	stub := &stubController{
+		uninstallFn: func(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+			// The CLI doesn't pass RunPath through opts (it's on the
+			// controller's Options); we capture it via SocketDir, which
+			// is supplied. Indirectly verify by inspecting what the
+			// command derives for confirmation output instead.
+			_ = opts
+			return controller.UninstallReport{RunPath: "/var/lib/kukeon-test"}, nil
+		},
+	}
+	out, _ := runCmd(t, stub, "", "--yes")
+	if strings.Contains(out, "/var/lib/kukeon-test") {
+		gotRunPath = "/var/lib/kukeon-test"
+	}
+	if gotRunPath == "" {
+		t.Errorf("expected report to surface configured run path; got:\n%s", out)
+	}
+}
+
+// Compile-time assertion: stubController must satisfy controller.Controller.
+var _ controller.Controller = (*stubController)(nil)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -59,6 +59,7 @@ type Controller interface {
 	PurgeCell(cell intmodel.Cell, force, cascade bool) (PurgeCellResult, error)
 	PurgeContainer(container intmodel.Container) (PurgeContainerResult, error)
 	RefreshAll() (RefreshResult, error)
+	Uninstall(opts UninstallOptions) (UninstallReport, error)
 	Close() error
 }
 

--- a/internal/controller/uninstall.go
+++ b/internal/controller/uninstall.go
@@ -1,0 +1,285 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// UserGroupRemover removes a system user and group from the host. The real
+// implementation shells out to userdel/groupdel; tests inject a stub.
+type UserGroupRemover func(ctx context.Context, user, group string) (UserGroupRemovalReport, error)
+
+// UserGroupRemovalReport mirrors the user/group fields on UninstallReport
+// without forcing the implementation to know the report type's layout.
+type UserGroupRemovalReport struct {
+	UserExisted  bool
+	UserRemoved  bool
+	GroupExisted bool
+	GroupRemoved bool
+}
+
+// UninstallOptions configures Uninstall.
+type UninstallOptions struct {
+	// SocketDir is the parent directory of the kukeond unix socket
+	// (typically /run/kukeon). Removed recursively when non-empty.
+	SocketDir string
+	// SystemUser/SystemGroup are the names of the kukeon system user and
+	// group to remove. Defaults to "kukeon"/"kukeon" when empty.
+	SystemUser  string
+	SystemGroup string
+	// SkipUserGroup skips userdel/groupdel. Set in tests where touching
+	// the host's /etc/passwd is undesirable.
+	SkipUserGroup bool
+	// UserGroupRemover overrides the default userdel/groupdel routine.
+	// Tests inject a stub; production callers leave it nil.
+	UserGroupRemover UserGroupRemover
+}
+
+// RealmPurgeOutcome reports the result of purging a single realm.
+type RealmPurgeOutcome struct {
+	Name      string
+	Namespace string
+	Purged    bool
+	Err       error
+}
+
+// UninstallReport summarizes what Uninstall did.
+type UninstallReport struct {
+	Realms          []RealmPurgeOutcome
+	SocketDir       string
+	SocketDirExists bool
+	SocketDirRemove bool
+	RunPath         string
+	RunPathExists   bool
+	RunPathRemove   bool
+	UserName        string
+	UserExisted     bool
+	UserRemoved     bool
+	GroupName       string
+	GroupExisted    bool
+	GroupRemoved    bool
+}
+
+// Uninstall performs a comprehensive teardown of all kukeon runtime state.
+// Steps (in order):
+//  1. Purge every realm with --cascade --force (drains spaces/stacks/cells/
+//     containers + tasks; the kukeond cell living inside `kuke-system` is
+//     killed and deleted as part of that cascade). Both well-known realms
+//     (`default`, `kuke-system`) are purged unconditionally so containerd
+//     namespaces left behind by an earlier partial uninstall are cleaned up
+//     even when on-disk metadata is already gone.
+//  2. RemoveAll on SocketDir (typically /run/kukeon).
+//  3. RemoveAll on the run path (typically /opt/kukeon).
+//  4. Remove the kukeon system user and group (no-op if absent).
+//
+// Any step's error is recorded in the report. The first non-nil step error
+// is returned so callers can surface "uninstall failed at step X" without
+// dropping subsequent best-effort cleanup.
+func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
+	report := UninstallReport{
+		SocketDir: opts.SocketDir,
+		RunPath:   b.opts.RunPath,
+	}
+
+	user := opts.SystemUser
+	if user == "" {
+		user = "kukeon"
+	}
+	group := opts.SystemGroup
+	if group == "" {
+		group = "kukeon"
+	}
+	report.UserName = user
+	report.GroupName = group
+
+	var firstErr error
+	recordErr := func(err error) {
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	// Step 1: enumerate realms and purge each.
+	realms, listErr := b.collectRealmsForUninstall()
+	if listErr != nil {
+		// If listing fails we still attempt the well-known realms — partial
+		// uninstall cleanup must not be blocked by a stale metadata read.
+		b.logger.WarnContext(
+			b.ctx,
+			"uninstall: failed to list realms; proceeding with well-known realms only",
+			"error",
+			listErr,
+		)
+	}
+
+	for _, realm := range realms {
+		outcome := RealmPurgeOutcome{
+			Name:      realm.Metadata.Name,
+			Namespace: realm.Spec.Namespace,
+		}
+		if _, err := b.PurgeRealm(realm, true, true); err != nil {
+			outcome.Err = err
+			recordErr(fmt.Errorf("purge realm %q: %w", realm.Metadata.Name, err))
+		} else {
+			outcome.Purged = true
+		}
+		report.Realms = append(report.Realms, outcome)
+	}
+
+	// Step 2: tear down /run/kukeon.
+	if opts.SocketDir != "" {
+		exists, removed, err := removePathIfExists(opts.SocketDir)
+		report.SocketDirExists = exists
+		report.SocketDirRemove = removed
+		if err != nil {
+			recordErr(fmt.Errorf("remove socket dir %q: %w", opts.SocketDir, err))
+		}
+	}
+
+	// Step 3: tear down /opt/kukeon.
+	if b.opts.RunPath != "" {
+		exists, removed, err := removePathIfExists(b.opts.RunPath)
+		report.RunPathExists = exists
+		report.RunPathRemove = removed
+		if err != nil {
+			recordErr(fmt.Errorf("remove run path %q: %w", b.opts.RunPath, err))
+		}
+	}
+
+	// Step 4: drop the kukeon system user/group.
+	if !opts.SkipUserGroup {
+		remover := opts.UserGroupRemover
+		if remover == nil {
+			remover = removeSystemUserGroup
+		}
+		userReport, err := remover(b.ctx, user, group)
+		report.UserExisted = userReport.UserExisted
+		report.UserRemoved = userReport.UserRemoved
+		report.GroupExisted = userReport.GroupExisted
+		report.GroupRemoved = userReport.GroupRemoved
+		if err != nil {
+			recordErr(fmt.Errorf("remove user/group: %w", err))
+		}
+	}
+
+	return report, firstErr
+}
+
+// collectRealmsForUninstall returns every realm that should be purged,
+// merging on-disk metadata with the two well-known kukeon realms (so a
+// partial uninstall whose metadata was already wiped still cleans up
+// containerd namespaces by name).
+func (b *Exec) collectRealmsForUninstall() ([]intmodel.Realm, error) {
+	wellKnown := []intmodel.Realm{
+		{
+			Metadata: intmodel.RealmMetadata{Name: consts.KukeonDefaultRealmName},
+			Spec:     intmodel.RealmSpec{Namespace: consts.KukeonDefaultRealmNamespace},
+		},
+		{
+			Metadata: intmodel.RealmMetadata{Name: consts.KukeSystemRealmName},
+			Spec:     intmodel.RealmSpec{Namespace: consts.KukeSystemRealmNamespace},
+		},
+	}
+
+	listed, err := b.runner.ListRealms()
+	if err != nil {
+		return wellKnown, err
+	}
+
+	seen := make(map[string]struct{}, len(listed)+len(wellKnown))
+	out := make([]intmodel.Realm, 0, len(listed)+len(wellKnown))
+	for _, realm := range listed {
+		seen[realm.Metadata.Name] = struct{}{}
+		out = append(out, realm)
+	}
+	for _, realm := range wellKnown {
+		if _, ok := seen[realm.Metadata.Name]; ok {
+			continue
+		}
+		out = append(out, realm)
+	}
+	return out, nil
+}
+
+// removePathIfExists is a thin wrapper around os.RemoveAll that reports
+// whether the path was present before removal. It treats os.IsNotExist as
+// "already gone" so a re-run of `kuke uninstall` on a clean machine is a
+// no-op rather than an error.
+func removePathIfExists(path string) (bool, bool, error) {
+	if _, statErr := os.Stat(path); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, false, nil
+		}
+		return false, false, statErr
+	}
+	if rmErr := os.RemoveAll(path); rmErr != nil {
+		return true, false, rmErr
+	}
+	return true, true, nil
+}
+
+// removeSystemUserGroup invokes userdel/groupdel for the kukeon system
+// account. Both lookups go through `id`/`getent` so the function is a
+// pure no-op on hosts where the account never existed (matches the
+// "no-op if absent" acceptance criterion). userdel runs before groupdel
+// so the primary group can be removed once the user is gone.
+func removeSystemUserGroup(ctx context.Context, user, group string) (UserGroupRemovalReport, error) {
+	var report UserGroupRemovalReport
+
+	report.UserExisted = lookupUser(ctx, user)
+	if report.UserExisted {
+		if delErr := exec.CommandContext(ctx, "userdel", user).Run(); delErr != nil {
+			// userdel returns 6 ("specified user doesn't exist") if the
+			// account vanished between lookup and delete — treat that as
+			// idempotent success.
+			if lookupUser(ctx, user) {
+				return report, fmt.Errorf("userdel %q: %w", user, delErr)
+			}
+			report.UserRemoved = true
+		} else {
+			report.UserRemoved = true
+		}
+	}
+
+	report.GroupExisted = lookupGroup(ctx, group)
+	if report.GroupExisted {
+		if delErr := exec.CommandContext(ctx, "groupdel", group).Run(); delErr != nil {
+			if lookupGroup(ctx, group) {
+				return report, fmt.Errorf("groupdel %q: %w", group, delErr)
+			}
+			report.GroupRemoved = true
+		} else {
+			report.GroupRemoved = true
+		}
+	}
+	return report, nil
+}
+
+func lookupUser(ctx context.Context, name string) bool {
+	return exec.CommandContext(ctx, "id", "-u", name).Run() == nil
+}
+
+func lookupGroup(ctx context.Context, name string) bool {
+	return exec.CommandContext(ctx, "getent", "group", name).Run() == nil
+}

--- a/internal/controller/uninstall_test.go
+++ b/internal/controller/uninstall_test.go
@@ -1,0 +1,227 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/controller"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// uninstallNoopRunner accepts the realm-purge plumbing PurgeRealm calls into
+// without actually doing anything — the goal is to verify Uninstall's flow
+// and reporting, not the runner's purge internals (covered elsewhere).
+func uninstallNoopRunner(extraRealms []intmodel.Realm) *fakeRunner {
+	f := &fakeRunner{}
+	f.ListRealmsFn = func() ([]intmodel.Realm, error) {
+		return extraRealms, nil
+	}
+	f.GetRealmFn = func(r intmodel.Realm) (intmodel.Realm, error) {
+		// Echo the input so PurgeRealm sees a "metadata exists" realm with
+		// the namespace we provided.
+		return r, nil
+	}
+	f.ListSpacesFn = func(_ string) ([]intmodel.Space, error) {
+		return nil, nil
+	}
+	f.DeleteRealmFn = func(_ intmodel.Realm) error { return nil }
+	f.PurgeRealmFn = func(_ intmodel.Realm) error { return nil }
+	return f
+}
+
+func TestUninstall_PurgesWellKnownRealmsAndCleansFilesystem(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+	// Plant a sentinel file inside each so we can prove RemoveAll fired.
+	if err := os.WriteFile(filepath.Join(tmpRunPath, "marker"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed run path: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpSocketDir, "kukeond.sock"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed socket dir: %v", err)
+	}
+
+	purged := map[string]string{} // name -> namespace
+	f := uninstallNoopRunner(nil)
+	f.PurgeRealmFn = func(r intmodel.Realm) error {
+		purged[r.Metadata.Name] = r.Spec.Namespace
+		return nil
+	}
+
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, uninstallErr := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		SkipUserGroup: true,
+	})
+	if uninstallErr != nil {
+		t.Fatalf("Uninstall returned error: %v", uninstallErr)
+	}
+
+	// Both well-known realms must be in the report, with their canonical
+	// containerd namespaces (the whole point of preferring well-known
+	// names over a stale/missing on-disk realm list).
+	if got := purged[consts.KukeonDefaultRealmName]; got != consts.KukeonDefaultRealmNamespace {
+		t.Errorf("default realm purged with namespace %q, want %q", got, consts.KukeonDefaultRealmNamespace)
+	}
+	if got := purged[consts.KukeSystemRealmName]; got != consts.KukeSystemRealmNamespace {
+		t.Errorf("kuke-system realm purged with namespace %q, want %q", got, consts.KukeSystemRealmNamespace)
+	}
+
+	if !report.SocketDirRemove || !report.SocketDirExists {
+		t.Errorf("socket dir not removed: existed=%v removed=%v", report.SocketDirExists, report.SocketDirRemove)
+	}
+	if !report.RunPathRemove || !report.RunPathExists {
+		t.Errorf("run path not removed: existed=%v removed=%v", report.RunPathExists, report.RunPathRemove)
+	}
+	if _, statErr := os.Stat(tmpRunPath); !os.IsNotExist(statErr) {
+		t.Errorf("run path %q still present after uninstall", tmpRunPath)
+	}
+	if _, statErr := os.Stat(tmpSocketDir); !os.IsNotExist(statErr) {
+		t.Errorf("socket dir %q still present after uninstall", tmpSocketDir)
+	}
+}
+
+func TestUninstall_IsIdempotent(t *testing.T) {
+	tmpRunPath := filepath.Join(t.TempDir(), "kukeon-absent")
+	tmpSocketDir := filepath.Join(t.TempDir(), "run-absent")
+
+	f := uninstallNoopRunner(nil)
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+
+	// First run on a never-existed install: must not error, nothing exists
+	// to clean up but the realms still get a defensive purge call.
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		SkipUserGroup: true,
+	})
+	if err != nil {
+		t.Fatalf("first Uninstall errored: %v", err)
+	}
+	if report.SocketDirExists || report.SocketDirRemove {
+		t.Errorf("expected socket dir absent on clean host, got existed=%v removed=%v",
+			report.SocketDirExists, report.SocketDirRemove)
+	}
+	if report.RunPathExists || report.RunPathRemove {
+		t.Errorf("expected run path absent on clean host, got existed=%v removed=%v",
+			report.RunPathExists, report.RunPathRemove)
+	}
+
+	// Re-run: still no error.
+	if _, repeatErr := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		SkipUserGroup: true,
+	}); repeatErr != nil {
+		t.Fatalf("repeat Uninstall errored: %v", repeatErr)
+	}
+}
+
+func TestUninstall_MergesListedRealmsWithWellKnown(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	custom := buildTestRealm("custom", "custom.kukeon.io")
+	f := uninstallNoopRunner([]intmodel.Realm{custom})
+
+	purgedNames := []string{}
+	f.PurgeRealmFn = func(r intmodel.Realm) error {
+		purgedNames = append(purgedNames, r.Metadata.Name)
+		return nil
+	}
+
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	if _, err := ctrl.Uninstall(controller.UninstallOptions{
+		SkipUserGroup: true,
+	}); err != nil {
+		t.Fatalf("Uninstall errored: %v", err)
+	}
+
+	// Listed realm must come first (preserving insertion order), then the
+	// missing well-known realms appended deduplicated.
+	want := []string{"custom", consts.KukeonDefaultRealmName, consts.KukeSystemRealmName}
+	if len(purgedNames) != len(want) {
+		t.Fatalf("purge sequence = %v, want %v", purgedNames, want)
+	}
+	for i := range want {
+		if purgedNames[i] != want[i] {
+			t.Errorf("purge[%d] = %q, want %q", i, purgedNames[i], want[i])
+		}
+	}
+}
+
+func TestUninstall_PurgeFailureIsRecordedButCleanupContinues(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpRunPath, "marker"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed run path: %v", err)
+	}
+
+	f := uninstallNoopRunner(nil)
+	failure := errors.New("synthetic purge failure")
+	f.PurgeRealmFn = func(r intmodel.Realm) error {
+		if r.Metadata.Name == consts.KukeSystemRealmName {
+			return failure
+		}
+		return nil
+	}
+
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		SkipUserGroup: true,
+	})
+	if err == nil {
+		t.Fatalf("expected error from failing realm purge, got nil")
+	}
+	if !strings.Contains(err.Error(), consts.KukeSystemRealmName) {
+		t.Errorf("error %q does not mention failing realm %q", err, consts.KukeSystemRealmName)
+	}
+
+	// The cleanup steps must still have run despite the realm failure.
+	if !report.RunPathRemove {
+		t.Errorf("run path not removed after a realm purge failure (expected best-effort cleanup)")
+	}
+	// And the failing realm's outcome must be in the report so callers can
+	// surface what went wrong.
+	var foundFailure bool
+	for _, outcome := range report.Realms {
+		if outcome.Name == consts.KukeSystemRealmName && outcome.Err != nil {
+			foundFailure = true
+			break
+		}
+	}
+	if !foundFailure {
+		t.Errorf("expected failing realm to be reported with its error; got %+v", report.Realms)
+	}
+}
+
+// setupTestControllerWithRunPath mirrors setupTestController but lets the
+// caller pin a temporary run path so filesystem assertions can target it.
+func setupTestControllerWithRunPath(t *testing.T, mockRunner *fakeRunner, runPath string) *controller.Exec {
+	t.Helper()
+	ctx := setupTestContext(t)
+	logger := setupTestLogger(t)
+	opts := controller.Options{
+		RunPath:          runPath,
+		ContainerdSocket: "/test/containerd.sock",
+	}
+	return controller.NewControllerExecForTesting(ctx, logger, opts, mockRunner)
+}


### PR DESCRIPTION
## Summary
- Add `kuke uninstall` command that performs a comprehensive teardown of all kukeon runtime state on the host: purges every realm with `--cascade --force` (including the well-known `default` and `kuke-system` realms even if their on-disk metadata is missing, so containerd namespaces left behind by a partial uninstall still get cleaned up), removes `/run/kukeon/`, removes the configured run path (default `/opt/kukeon`), and removes the kukeon system user/group.
- Interactive confirmation by default; `--yes`/`-y` skips the prompt for scripted use. Idempotent — re-running on a clean machine is a no-op rather than an error.
- The `/usr/local/bin/kuke` binary and the `kukeond` symlink are NOT touched (per AC: "uninstalling runtime state is not the same as uninstalling the binary").
- Errors abort the run with the first step's failure but best-effort cleanup continues so a single failed realm purge does not leave `/run/kukeon` and `/opt/kukeon` behind.
- The kukeond cell living inside `kuke-system/kukeon/kukeon/kukeond` is killed and deleted as part of the `kuke-system` realm cascade — no separate "stop daemon" step is needed.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — all packages pass, including new tests in `cmd/kuke/uninstall` (5 tests covering --yes flag, prompt accept/reject, step-error propagation, default run path) and `internal/controller` (4 tests covering well-known realm purge + filesystem cleanup, idempotency on clean host, listed+well-known merge order, partial-failure best-effort cleanup).
- [x] End-to-end smoke on this host: `kuke init` (fresh provision), then `sudo ./kuke uninstall --yes` — purges both realms, removes `/run/kukeon` and `/opt/kukeon`, drops the `kukeon` user/group. Re-running `kuke uninstall --yes` on the now-clean host is a no-op as expected.
- [x] Daemon-parity check (`sudo ./kuke get realms` vs `--no-daemon`) on a fresh `kuke init` — identical output, both realms `Ready`.
- [x] Prompt accept/abort verified by typing `yes`/`no` interactively.

## Notes
- Existing pre-existing quirk surfaced during smoke: on a long-running install with active containerd snapshots in `kuke-system.kukeon.io`, the very first `uninstall --yes` can hit `failed precondition: namespace must be empty, still has snapshots on overlayfs snapshotter` because `PurgeRealm` aborts on `deleteRealmCascade` failure before `runner.PurgeRealm` clears the namespace. A second `kuke uninstall --yes` cleans this up (the command is idempotent by design). Out of scope for this issue — it is the same race that affects `kuke purge realm --cascade`.

Closes #164