### PR TITLE
fix: purge realm cleans up snapshots in a single pass

### DIFF
--- a/internal/controller/purge_realm.go
+++ b/internal/controller/purge_realm.go
@@ -158,13 +158,36 @@ func (b *Exec) purgeRealmCascade(realm intmodel.Realm, force, cascade, metadataE
 		}
 	}
 
-	// Perform standard delete first (only if metadata exists, as deleteRealmCascade requires metadata)
+	// Perform standard delete first (only if metadata exists, as deleteRealmCascade requires metadata).
+	// If it fails (e.g. DeleteNamespace can't remove a namespace whose snapshots
+	// are still pinned by a live task), still fall through to runner.PurgeRealm
+	// so the comprehensive cleanup runs in a single pass — runner.PurgeRealm
+	// is idempotent and goes further (orphaned containers, CNI tear-down, etc.),
+	// so a single failed deleteRealmCascade should not strand the user with a
+	// half-cleaned realm that requires re-running the command. If runner.PurgeRealm
+	// later succeeds, the realm is fully gone and the original delete error is
+	// no longer load-bearing — log it and treat the operation as a success.
+	var deleteErr error
 	if metadataExists {
 		if err := b.deleteRealmCascade(realm, force, cascade); err != nil {
-			return fmt.Errorf("failed to delete realm: %w", err)
+			deleteErr = fmt.Errorf("failed to delete realm: %w", err)
+			b.logger.WarnContext(
+				b.ctx,
+				"deleteRealmCascade failed; falling through to runner.PurgeRealm",
+				"realm",
+				realmName,
+				"error",
+				err,
+			)
 		}
 	}
 
 	// Perform comprehensive purge via runner (works even without metadata)
-	return b.runner.PurgeRealm(realm)
+	if purgeErr := b.runner.PurgeRealm(realm); purgeErr != nil {
+		if deleteErr != nil {
+			return fmt.Errorf("%w; runner purge also failed: %w", deleteErr, purgeErr)
+		}
+		return purgeErr
+	}
+	return nil
 }

--- a/internal/controller/purge_realm_test.go
+++ b/internal/controller/purge_realm_test.go
@@ -924,7 +924,10 @@ func TestPurgeRealm_RunnerErrors(t *testing.T) {
 			errContains: "failed to purge space",
 		},
 		{
-			name:      "deleteRealmCascade error",
+			// deleteRealmCascade fails AND runner.PurgeRealm also fails — both errors are
+			// surfaced. (The single-failure case where runner.PurgeRealm recovers is
+			// covered separately in TestPurgeRealm_DeleteCascadeFailsButPurgeSucceeds.)
+			name:      "deleteRealmCascade error, purge also fails",
 			realmName: "test-realm",
 			namespace: "test-namespace",
 			force:     false,
@@ -945,6 +948,9 @@ func TestPurgeRealm_RunnerErrors(t *testing.T) {
 				}
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return errors.New("deletion failed")
+				}
+				f.PurgeRealmFn = func(_ intmodel.Realm) error {
+					return errors.New("purge failed")
 				}
 			},
 			wantErr:     true,
@@ -1413,5 +1419,50 @@ func TestPurgeRealm_NameTrimming(t *testing.T) {
 				tt.wantResult(t, result)
 			}
 		})
+	}
+}
+
+// TestPurgeRealm_DeleteCascadeFailsButPurgeSucceeds covers the regression
+// from #171: deleteRealmCascade fails (e.g. namespace.Delete trips
+// "still has snapshots" because a live task pinned them), and the controller
+// must still call runner.PurgeRealm — runner.PurgeRealm kills orphans and
+// drains snapshots, so a single command leaves the host clean instead of
+// requiring the user to re-run.
+func TestPurgeRealm_DeleteCascadeFailsButPurgeSucceeds(t *testing.T) {
+	mockRunner := &fakeRunner{}
+	existingRealm := buildTestRealm("test-realm", "test-namespace")
+	mockRunner.GetRealmFn = func(_ intmodel.Realm) (intmodel.Realm, error) {
+		return existingRealm, nil
+	}
+	mockRunner.ExistsCgroupFn = func(_ any) (bool, error) {
+		return true, nil
+	}
+	mockRunner.ExistsRealmContainerdNamespaceFn = func(_ string) (bool, error) {
+		return true, nil
+	}
+	mockRunner.ListSpacesFn = func(_ string) ([]intmodel.Space, error) {
+		return []intmodel.Space{}, nil
+	}
+	mockRunner.DeleteRealmFn = func(_ intmodel.Realm) error {
+		return errors.New("namespace must be empty, still has snapshots on overlayfs snapshotter")
+	}
+	purgeCalled := false
+	mockRunner.PurgeRealmFn = func(_ intmodel.Realm) error {
+		purgeCalled = true
+		return nil
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	realm := buildTestRealm("test-realm", "test-namespace")
+
+	result, err := ctrl.PurgeRealm(realm, false, false)
+	if err != nil {
+		t.Fatalf("expected nil error after PurgeRealm recovery, got %v", err)
+	}
+	if !purgeCalled {
+		t.Fatal("expected runner.PurgeRealm to be called even after deleteRealmCascade failed")
+	}
+	if !result.PurgeSucceeded {
+		t.Errorf("expected PurgeSucceeded=true, got %+v", result)
 	}
 }

--- a/internal/controller/runner/delete_realm.go
+++ b/internal/controller/runner/delete_realm.go
@@ -48,18 +48,18 @@ func (r *Exec) DeleteRealm(realm intmodel.Realm) error {
 		return fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
-	// Delete realm cgroup
-	// Use the stored CgroupPath from realm status (includes full hierarchy path)
-	// instead of rebuilding from DefaultRealmSpec which only has the relative path
-	mountpoint := r.ctrClient.GetCgroupMountpoint()
-	cgroupGroup := internalRealm.Status.CgroupPath
-	if cgroupGroup == "" {
-		// Fallback to DefaultRealmSpec if CgroupPath is not set (for backwards compatibility)
-		spec := ctr.DefaultRealmSpec(internalRealm)
-		cgroupGroup = spec.Group
-	}
-	if err = r.ctrClient.DeleteCgroup(cgroupGroup, mountpoint); err != nil {
-		return fmt.Errorf("%w: failed to delete realm cgroup: %w", errdefs.ErrDeleteRealm, err)
+	// Find and clean up orphaned containers FIRST so their tasks are killed and
+	// their committed snapshots released before CleanupNamespaceResources tries
+	// to remove them — otherwise a live task holds the snapshot mount and
+	// snapshotService.Remove silently fails, leaving the namespace non-empty
+	// for the subsequent DeleteNamespace call.
+	r.logger.DebugContext(r.ctx, "starting to find orphaned containers", "namespace", internalRealm.Spec.Namespace)
+	containers, err := r.findOrphanedContainers(internalRealm.Spec.Namespace, "")
+	if err != nil {
+		r.logger.WarnContext(r.ctx, "failed to find orphaned containers", "error", err)
+	} else {
+		r.logger.DebugContext(r.ctx, "found orphaned containers", "count", len(containers))
+		r.processOrphanedContainers(r.ctx, containers)
 	}
 
 	// Clean up all namespace resources (images, snapshots, blobs) before deleting namespace
@@ -76,14 +76,19 @@ func (r *Exec) DeleteRealm(realm intmodel.Realm) error {
 		// Continue with namespace deletion attempt anyway
 	}
 
-	// Find and clean up orphaned containers before deleting namespace
-	r.logger.DebugContext(r.ctx, "starting to find orphaned containers", "namespace", internalRealm.Spec.Namespace)
-	containers, err := r.findOrphanedContainers(internalRealm.Spec.Namespace, "")
-	if err != nil {
-		r.logger.WarnContext(r.ctx, "failed to find orphaned containers", "error", err)
-	} else {
-		r.logger.DebugContext(r.ctx, "found orphaned containers", "count", len(containers))
-		r.processOrphanedContainers(r.ctx, containers)
+	// Delete realm cgroup after task processes are gone (otherwise cgroup
+	// removal fails with EBUSY because PIDs are still attached).
+	// Use the stored CgroupPath from realm status (includes full hierarchy path)
+	// instead of rebuilding from DefaultRealmSpec which only has the relative path
+	mountpoint := r.ctrClient.GetCgroupMountpoint()
+	cgroupGroup := internalRealm.Status.CgroupPath
+	if cgroupGroup == "" {
+		// Fallback to DefaultRealmSpec if CgroupPath is not set (for backwards compatibility)
+		spec := ctr.DefaultRealmSpec(internalRealm)
+		cgroupGroup = spec.Group
+	}
+	if err = r.ctrClient.DeleteCgroup(cgroupGroup, mountpoint); err != nil {
+		return fmt.Errorf("%w: failed to delete realm cgroup: %w", errdefs.ErrDeleteRealm, err)
 	}
 
 	// Tear down each conflist + bridge link for this realm. Driven from

--- a/internal/ctr/namespaces.go
+++ b/internal/ctr/namespaces.go
@@ -235,35 +235,101 @@ func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error 
 	c.logger.DebugContext(c.ctx, "cleaning up snapshots", "namespace", namespace, "snapshotter", snapshotter)
 	snapshotService := c.cClient.SnapshotService(snapshotter)
 
-	// Walk all snapshots and remove them
-	var snapshotKeys []string
-	err = snapshotService.Walk(nsCtx, func(_ context.Context, info snapshots.Info) error {
-		snapshotKeys = append(snapshotKeys, info.Name)
-		return nil
-	})
-	if err != nil {
-		c.logger.WarnContext(
+	// Iteratively remove snapshots until none remain or no progress is made.
+	// Walk order is implementation-defined (boltdb key order), so a single
+	// reverse-order pass cannot guarantee children are removed before parents
+	// when a parent has multiple children. A snapshot with extant children
+	// fails Remove with "must be empty"; on the next pass its children are
+	// gone and it succeeds. Cap iterations to bound work on a pathological
+	// graph; in practice the depth is small (image layers + a few committed
+	// container layers).
+	const maxSnapshotPasses = 32
+	for pass := range maxSnapshotPasses {
+		var snapshotKeys []string
+		err = snapshotService.Walk(nsCtx, func(_ context.Context, info snapshots.Info) error {
+			snapshotKeys = append(snapshotKeys, info.Name)
+			return nil
+		})
+		if err != nil {
+			c.logger.WarnContext(
+				c.ctx,
+				"failed to walk snapshots",
+				"namespace",
+				namespace,
+				"snapshotter",
+				snapshotter,
+				"error",
+				err,
+			)
+			break
+		}
+		if len(snapshotKeys) == 0 {
+			break
+		}
+		c.logger.DebugContext(
 			c.ctx,
-			"failed to walk snapshots",
+			"found snapshots",
 			"namespace",
 			namespace,
 			"snapshotter",
 			snapshotter,
-			"error",
-			err,
+			"count",
+			len(snapshotKeys),
+			"pass",
+			pass,
 		)
-	} else {
-		c.logger.DebugContext(c.ctx, "found snapshots", "namespace", namespace, "snapshotter", snapshotter, "count", len(snapshotKeys))
-		// Delete snapshots in reverse order (children before parents)
+		removedAny := false
 		for i := len(snapshotKeys) - 1; i >= 0; i-- {
 			key := snapshotKeys[i]
-			c.logger.DebugContext(c.ctx, "removing snapshot", "namespace", namespace, "snapshotter", snapshotter, "key", key)
+			c.logger.DebugContext(
+				c.ctx,
+				"removing snapshot",
+				"namespace",
+				namespace,
+				"snapshotter",
+				snapshotter,
+				"key",
+				key,
+			)
 			if removeErr := snapshotService.Remove(nsCtx, key); removeErr != nil {
-				c.logger.WarnContext(c.ctx, "failed to remove snapshot", "namespace", namespace, "snapshotter", snapshotter, "key", key, "error", removeErr)
-				// Continue with other snapshots
-			} else {
-				c.logger.DebugContext(c.ctx, "removed snapshot", "namespace", namespace, "snapshotter", snapshotter, "key", key)
+				c.logger.DebugContext(
+					c.ctx,
+					"snapshot remove deferred",
+					"namespace",
+					namespace,
+					"snapshotter",
+					snapshotter,
+					"key",
+					key,
+					"error",
+					removeErr,
+				)
+				continue
 			}
+			removedAny = true
+			c.logger.DebugContext(
+				c.ctx,
+				"removed snapshot",
+				"namespace",
+				namespace,
+				"snapshotter",
+				snapshotter,
+				"key",
+				key,
+			)
+		}
+		if !removedAny {
+			c.logger.WarnContext(
+				c.ctx,
+				"snapshot cleanup made no progress, giving up",
+				"namespace",
+				namespace,
+				"snapshotter",
+				snapshotter,
+				"remaining",
+				len(snapshotKeys),
+			)
+			break
 		}
 	}
 


### PR DESCRIPTION
## Summary
- `kuke purge realm --cascade --force` (and `kuke uninstall` once #170 lands) used to need a second pass on hosts with active overlayfs snapshots — the first run died with `failed precondition: namespace must be empty, still has snapshots on overlayfs snapshotter`. After this PR it's single-pass.
- Three small fixes converge on the same root cause:
  - **`runner.DeleteRealm` reorder** — orphaned-container handling moved before `CleanupNamespaceResources`, and `DeleteCgroup` moved to the end. A live task pinned its committed snapshot, so cleaning snapshots before killing the task silently failed; matching `runner.PurgeRealm`'s order eliminates that.
  - **`CleanupNamespaceResources` iterates** — snapshotter `Walk` returns boltdb-key order, not topological, so a single reverse pass can't guarantee children-before-parents when a parent has multiple children. Now iterates up to 32 passes (in practice 1–3) until either zero remain or no progress is made on a pass.
  - **`controller.purgeRealmCascade` falls through** — even if `deleteRealmCascade` errors, still call `runner.PurgeRealm`. `runner.PurgeRealm` is idempotent and goes further, so a single command leaves the host clean. If runner-purge then succeeds, the original delete error is no longer load-bearing and the operation reports success.

## Notable judgment calls
- **Pass cap of 32 in `CleanupNamespaceResources`.** Snapshot graphs in this project are shallow (image layers + a few committed container layers), so a real graph clears in 1–3 passes. The cap exists only to bound work on a pathological cycle; raising it has no normal-path impact. Hard-coded rather than configurable to avoid plumbing options through.
- **Recovery hides the `deleteRealm` error.** When `deleteRealmCascade` fails but `runner.PurgeRealm` later succeeds, the operation reports success and the original delete error is logged at WARN, not propagated. Reasoning: the user's intent for `kuke purge --force` is "clean it all up regardless"; surfacing a no-longer-load-bearing error would push them to re-run unnecessarily. Both errors are still surfaced when both fail.
- **Did not touch `runner.PurgeRealm`'s ordering.** Already correct — orphans first, then `CleanupNamespaceResources`. Issue's suggested fix ("walk and remove snapshots in `runner.PurgeRealm` before `namespaces.Delete`") is functionally what `CleanupNamespaceResources` already does; the iteration fix to that helper is the missing piece, and it benefits the `DeleteRealm` path too.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — all packages pass, including new `TestPurgeRealm_DeleteCascadeFailsButPurgeSucceeds` covering the recovery path and the updated existing case where both delete and purge fail.
- [x] `pre-commit run golangci-lint --files <changed>` passes.
- [x] CLAUDE.md smoke (full reproducer of the issue): tear down kukeond cell, rebuild `kuke`, rebuild local image, `sudo ./kuke init`, then `sudo ./kuke purge realm kuke-system --cascade --force --no-daemon` on a host with active overlayfs snapshots — single pass cleans the namespace, snapshots, and `/opt/kukeon/kuke-system/`. Verbose log line `"deleted containerd namespace" namespace=kuke-system.kukeon.io` confirms the regression is fixed.
- [x] CLAUDE.md daemon-parity smoke: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` return identical output before and after the smoke test.

Closes #171