### PR TITLE
feat(init+daemon): SGID kukeon dirs and re-chown socket on daemon restart

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -105,6 +105,8 @@ var (
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEOND_SOCKET = DefineKV("KUKEOND_SOCKET", "kukeond/socket", "/run/kukeon/kukeond.sock")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKEOND_SOCKET_GID = DefineKV("KUKEOND_SOCKET_GID", "kukeond/socketGID", "0")
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_INIT_REALM = DefineKV("KUKE_INIT_REALM", "kuke/init/realm")

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -48,9 +48,12 @@ const (
 	// Files get 0o640 instead of 0o750: blanket-chmoding the tree to 0o750
 	// would mark JSON metadata files as executable, which has no purpose.
 	// Dirs need execute (traverse) for the kukeon group, so they stay
-	// 0o750.
-	kukeonRunDirMode      os.FileMode = 0o750
-	kukeonRunPathDirMode  os.FileMode = 0o750
+	// 0o750. The SGID bit is set on directories (mode 2750) so that files
+	// the daemon writes later (metadata.json, CNI state, etc.) inherit
+	// the kukeon group instead of landing as root:root and breaking
+	// `--no-daemon` reads for non-root operators.
+	kukeonRunDirMode      os.FileMode = os.ModeSetgid | 0o750
+	kukeonRunPathDirMode  os.FileMode = os.ModeSetgid | 0o750
 	kukeonRunPathFileMode os.FileMode = 0o640
 	kukeonSocketMode      os.FileMode = 0o660
 )
@@ -172,18 +175,9 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		runPath = config.DefaultRunPath()
 	}
 
-	opts := controller.Options{
-		RunPath:            runPath,
-		ContainerdSocket:   viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
-		KukeondImage:       image,
-		KukeondSocket:      socketPath,
-		ForceRegenerateCNI: viper.GetBool(config.KUKE_INIT_FORCE_REGENERATE_CNI.ViperKey),
-	}
-
-	logger.DebugContext(cmd.Context(), "running init", "opts", opts)
-
 	// Ensure the kukeon system user/group exist before bootstrap so the
-	// post-bootstrap chown step has a GID to apply.
+	// post-bootstrap chown step has a GID to apply, and so the kukeond cell
+	// is provisioned with --socket-gid pointing at it.
 	ensure, ensureErr := sysuser.EnsureUserGroup(
 		cmd.Context(),
 		consts.KukeonSystemUser,
@@ -193,6 +187,17 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	if ensureErr != nil {
 		return fmt.Errorf("ensure kukeon user/group: %w", ensureErr)
 	}
+
+	opts := controller.Options{
+		RunPath:            runPath,
+		ContainerdSocket:   viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+		KukeondImage:       image,
+		KukeondSocket:      socketPath,
+		KukeondSocketGID:   ensure.GID,
+		ForceRegenerateCNI: viper.GetBool(config.KUKE_INIT_FORCE_REGENERATE_CNI.ViperKey),
+	}
+
+	logger.DebugContext(cmd.Context(), "running init", "opts", opts)
 
 	ctrl := controller.NewControllerExec(cmd.Context(), logger, opts)
 	report, bootstrapErr := ctrl.Bootstrap()
@@ -245,8 +250,8 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("apply kukeon ownership to %q: %w", socketPath, chownErr)
 	}
 	cmd.Println(fmt.Sprintf(
-		"  - socket %q: chown root:%s mode %#o",
-		socketPath, consts.KukeonSystemGroup, kukeonSocketMode,
+		"  - socket %q: chown root:%s mode %s",
+		socketPath, consts.KukeonSystemGroup, formatPosixMode(kukeonSocketMode),
 	))
 
 	cmd.Println(fmt.Sprintf("kukeond is ready (unix://%s)", socketPath))
@@ -354,16 +359,36 @@ func printPermissionsActions(cmd *cobra.Command, perms permissionsReport) {
 	}
 	if perms.RunDirApplied {
 		cmd.Println(fmt.Sprintf(
-			"    - %q: chown root:%s mode %#o",
-			perms.RunDirPath, perms.Group, kukeonRunDirMode,
+			"    - %q: chown root:%s mode %s",
+			perms.RunDirPath, perms.Group, formatPosixMode(kukeonRunDirMode),
 		))
 	}
 	if perms.RunPathApplied {
 		cmd.Println(fmt.Sprintf(
-			"    - %q (recursive): chown root:%s mode %#o (dirs) / %#o (files)",
-			perms.RunPath, perms.Group, kukeonRunPathDirMode, kukeonRunPathFileMode,
+			"    - %q (recursive): chown root:%s mode %s (dirs) / %s (files)",
+			perms.RunPath, perms.Group,
+			formatPosixMode(kukeonRunPathDirMode),
+			formatPosixMode(kukeonRunPathFileMode),
 		))
 	}
+}
+
+// formatPosixMode renders an os.FileMode as the on-disk POSIX octal mode
+// (including SUID/SGID/sticky bits), matching what `stat`/`ls -l` show.
+// Go's %#o on a FileMode prints internal flag bits like ModeSetgid (0x400000)
+// instead of the syscall-level 02750, which is unreadable in init output.
+func formatPosixMode(m os.FileMode) string {
+	val := uint32(m.Perm())
+	if m&os.ModeSetuid != 0 {
+		val |= 0o4000
+	}
+	if m&os.ModeSetgid != 0 {
+		val |= 0o2000
+	}
+	if m&os.ModeSticky != 0 {
+		val |= 0o1000
+	}
+	return fmt.Sprintf("0o%04o", val)
 }
 
 func printKukeonCgroupAction(cmd *cobra.Command, report controller.BootstrapReport) {

--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -66,6 +66,19 @@ func NewKukeondCmd() (*cobra.Command, error) {
 		return nil, err
 	}
 
+	cmd.PersistentFlags().Int(
+		"socket-gid", 0,
+		"Group ID to chown the listener socket to (mode 0o660 with group). "+
+			"Set by `kuke init` to the kukeon GID so non-root group members "+
+			"can dial the daemon after a kukeond restart.",
+	)
+	if err := viper.BindPFlag(
+		config.KUKEOND_SOCKET_GID.ViperKey,
+		cmd.PersistentFlags().Lookup("socket-gid"),
+	); err != nil {
+		return nil, err
+	}
+
 	cmd.PersistentFlags().String(
 		"log-level", "info",
 		"Log level (debug, info, warn, error)",

--- a/cmd/kukeond/serve.go
+++ b/cmd/kukeond/serve.go
@@ -31,6 +31,15 @@ import (
 	"github.com/spf13/viper"
 )
 
+// Socket modes applied to the kukeond unix listener. The narrow mode is the
+// fallback when no SocketGID was passed (root-only access); the group-readable
+// mode is used when init plumbed a kukeon GID through `--socket-gid` so a
+// non-root operator in the kukeon group can dial the daemon after restart.
+const (
+	socketModeRootOnly      os.FileMode = 0o600
+	socketModeGroupReadable os.FileMode = 0o660
+)
+
 func newServeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "serve",
@@ -63,9 +72,16 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		runPath = config.DefaultRunPath()
 	}
 
+	socketGID := viper.GetInt(config.KUKEOND_SOCKET_GID.ViperKey)
+	socketMode := socketModeRootOnly
+	if socketGID > 0 {
+		socketMode = socketModeGroupReadable
+	}
+
 	opts := daemon.Options{
 		SocketPath: socketPath,
-		SocketMode: 0o600,
+		SocketMode: socketMode,
+		SocketGID:  socketGID,
 		PIDFile:    filepath.Join(runPath, "kukeond.pid"),
 		Controller: controller.Options{
 			RunPath:          runPath,

--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/eminwux/kukeon/internal/apischeme"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -429,13 +430,16 @@ func (b *Exec) bootstrapStack(section *StackSection, realmName, spaceName, stack
 // don't allocate the same IP twice; /opt/cni/cache holds the CNI invocation
 // cache that gives DEL stable arguments — a mismatch leaks veths and IPs
 // across daemon restarts.
-func kukeondCellDoc(image, socketPath, runPath, containerdSocket string) *v1beta1.CellDoc {
+func kukeondCellDoc(image, socketPath, runPath, containerdSocket string, socketGID int) *v1beta1.CellDoc {
 	args := []string{"serve", "--socket", socketPath}
 	if runPath != "" {
 		args = append(args, "--run-path", runPath)
 	}
 	if containerdSocket != "" {
 		args = append(args, "--containerd-socket", containerdSocket)
+	}
+	if socketGID > 0 {
+		args = append(args, "--socket-gid", strconv.Itoa(socketGID))
 	}
 
 	sockDir := socketDir(socketPath)

--- a/internal/controller/bootstrap_test.go
+++ b/internal/controller/bootstrap_test.go
@@ -19,6 +19,7 @@
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -83,7 +84,7 @@ func TestKukeondCellDocVolumes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := kukeondCellDoc(tc.image, tc.socketPath, tc.runPath, tc.containerdSocket)
+			doc := kukeondCellDoc(tc.image, tc.socketPath, tc.runPath, tc.containerdSocket, 0)
 			if len(doc.Spec.Containers) != 1 {
 				t.Fatalf("expected 1 container, got %d", len(doc.Spec.Containers))
 			}
@@ -178,6 +179,55 @@ func TestKukeondCellDocVolumes(t *testing.T) {
 			// and the user-cell network attach fails (issue #105).
 			if !doc.Spec.Containers[0].HostPID {
 				t.Errorf("kukeond container must have HostPID=true")
+			}
+		})
+	}
+}
+
+// TestKukeondCellDocSocketGIDArg guards the wire that lets kukeond restart
+// re-apply socket ownership without re-running kuke init: the cell args must
+// include `--socket-gid <gid>` whenever a kukeon GID is plumbed through.
+func TestKukeondCellDocSocketGIDArg(t *testing.T) {
+	tests := []struct {
+		name          string
+		gid           int
+		wantSocketGID bool
+		wantValue     string
+	}{
+		{name: "zero-omits-flag", gid: 0, wantSocketGID: false},
+		{name: "non-zero-emits-flag", gid: 1234, wantSocketGID: true, wantValue: "1234"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := kukeondCellDoc(
+				"docker.io/library/kukeon:dev",
+				"/run/kukeon/kukeond.sock",
+				"/opt/kukeon",
+				"/run/containerd/containerd.sock",
+				tc.gid,
+			)
+			args := doc.Spec.Containers[0].Args
+			joined := strings.Join(args, " ")
+			has := strings.Contains(joined, "--socket-gid")
+			if has != tc.wantSocketGID {
+				t.Fatalf("--socket-gid presence: got %v want %v (args=%v)", has, tc.wantSocketGID, args)
+			}
+			if !tc.wantSocketGID {
+				return
+			}
+			// Find the flag's value and confirm it matches.
+			for i, a := range args {
+				if a != "--socket-gid" {
+					continue
+				}
+				if i+1 >= len(args) {
+					t.Fatalf("--socket-gid has no value (args=%v)", args)
+				}
+				if args[i+1] != tc.wantValue {
+					t.Errorf("--socket-gid value: got %q want %q", args[i+1], tc.wantValue)
+				}
+				return
 			}
 		})
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -80,6 +80,10 @@ type Options struct {
 	// KukeondSocket is the unix socket path kukeond serves on. Used by bootstrap
 	// to build the bind-mount for the system cell.
 	KukeondSocket string
+	// KukeondSocketGID, when non-zero, is passed to the kukeond cell as
+	// --socket-gid <gid> so the daemon can chown its listener socket on every
+	// restart. Set by `kuke init` to the kukeon group's numeric GID.
+	KukeondSocketGID int
 	// ForceRegenerateCNI forces bootstrap to rewrite space conflists even when
 	// they already exist with the expected bridge name. Surfaces via
 	// `kuke init --force-regenerate-cni`.
@@ -192,6 +196,7 @@ func (b *Exec) Bootstrap() (BootstrapReport, error) {
 			b.opts.KukeondSocket,
 			b.opts.RunPath,
 			b.opts.ContainerdSocket,
+			b.opts.KukeondSocketGID,
 		)
 		if err = b.bootstrapCell(&report.SystemCell, cellDoc); err != nil {
 			return report, err

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -42,6 +42,11 @@ type Options struct {
 	SocketPath string
 	// SocketMode is the file mode applied to the socket after creation.
 	SocketMode os.FileMode
+	// SocketGID, when non-zero, is the group the listener socket is chowned
+	// to (uid stays root) so non-root members of that group can dial the
+	// daemon. Set by `kuke init` to the kukeon GID. Each Serve re-applies
+	// this so a daemon restart does not lose group access.
+	SocketGID int
 	// PIDFile, when non-empty, is written on Serve and removed on Stop.
 	PIDFile string
 	// Controller is forwarded to controller.NewControllerExec.
@@ -89,6 +94,16 @@ func (s *Server) Serve() error {
 	listener, err := net.Listen("unix", s.opts.SocketPath)
 	if err != nil {
 		return fmt.Errorf("listen on %s: %w", s.opts.SocketPath, err)
+	}
+	if s.opts.SocketGID > 0 {
+		if chownErr := os.Chown(s.opts.SocketPath, 0, s.opts.SocketGID); chownErr != nil {
+			s.logger.WarnContext(s.ctx,
+				"chown socket to kukeon group failed; non-root operators will need sudo",
+				"socket", s.opts.SocketPath,
+				"gid", s.opts.SocketGID,
+				"error", chownErr,
+			)
+		}
 	}
 	if err := os.Chmod(s.opts.SocketPath, s.opts.SocketMode); err != nil {
 		_ = listener.Close()

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1,0 +1,131 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestServeChownsSocketToSocketGID guards the regression that motivated #173:
+// a kukeond restart must self-apply the socket group/mode so a non-root
+// operator does not lose access until kuke init is re-run.
+func TestServeChownsSocketToSocketGID(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "kukeond.sock")
+
+	// Use the test process's own GID so the chown succeeds without root.
+	gid := os.Getgid()
+
+	srv := NewServer(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), Options{
+		SocketPath: socketPath,
+		SocketMode: 0o660,
+		SocketGID:  gid,
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	t.Cleanup(func() {
+		_ = srv.Stop()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Serve did not return after Stop")
+		}
+	})
+
+	// Wait for the socket to exist.
+	deadline := time.Now().Add(2 * time.Second)
+	var info os.FileInfo
+	for {
+		var err error
+		info, err = os.Stat(socketPath)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat socket: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket did not appear within deadline")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("syscall.Stat_t not available on this platform")
+	}
+	if int(stat.Gid) != gid {
+		t.Errorf("socket gid: got %d want %d", stat.Gid, gid)
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Errorf("socket mode: got %#o want 0o660", got)
+	}
+}
+
+// TestServeWithoutSocketGIDLeavesGroupUnchanged confirms the chown step is
+// gated on SocketGID > 0 — without a kukeon group provisioned, kukeond must
+// fall back to root:root mode 0o600 instead of erroring out.
+func TestServeWithoutSocketGIDLeavesGroupUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "kukeond.sock")
+
+	srv := NewServer(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), Options{
+		SocketPath: socketPath,
+		SocketMode: 0o600,
+	})
+
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	t.Cleanup(func() {
+		_ = srv.Stop()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Serve did not return after Stop")
+		}
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	var info os.FileInfo
+	for {
+		var err error
+		info, err = os.Stat(socketPath)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat socket: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket did not appear within deadline")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("socket mode: got %#o want 0o600", got)
+	}
+}

--- a/internal/sysuser/sysuser_test.go
+++ b/internal/sysuser/sysuser_test.go
@@ -219,6 +219,48 @@ func TestChownTreeAndChmod(t *testing.T) {
 	}
 }
 
+// TestChownTreeAndChmod_SGIDBit confirms the SGID bit on dirMode survives
+// the recursive walk. `kuke init` relies on this so daemon-written files
+// later inherit the kukeon group instead of falling back to root:root.
+func TestChownTreeAndChmod_SGIDBit(t *testing.T) {
+	root := t.TempDir()
+	subdir := filepath.Join(root, "sub")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	file := filepath.Join(subdir, "data.json")
+	if err := os.WriteFile(file, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	uid, gid := os.Getuid(), os.Getgid()
+	dirMode := os.ModeSetgid | os.FileMode(0o750)
+	if err := sysuser.ChownTreeAndChmod(root, uid, gid, dirMode, 0o640); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	for _, p := range []string{root, subdir} {
+		info, err := os.Stat(p)
+		if err != nil {
+			t.Fatalf("stat %q: %v", p, err)
+		}
+		if info.Mode()&os.ModeSetgid == 0 {
+			t.Errorf("%q: SGID bit not set (mode=%v)", p, info.Mode())
+		}
+		if got := info.Mode().Perm(); got != 0o750 {
+			t.Errorf("%q: perm bits got %#o want 0o750", p, got)
+		}
+	}
+
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if info.Mode()&os.ModeSetgid != 0 {
+		t.Errorf("file should not carry SGID: mode=%v", info.Mode())
+	}
+}
+
 // runnerFunc adapts a function value to the CommandRunner interface for tests.
 type runnerFunc func(ctx context.Context, name string, args ...string) error
 


### PR DESCRIPTION
## Summary
- Plumbs the kukeon GID through to `kukeond serve` via a new `--socket-gid` flag (set by `kuke init` from the resolved GID). After `net.Listen`, the daemon `chown`s the socket to `root:<kukeon-gid>` and uses mode `0o660`, so a kukeond restart no longer resets it to `root:root 0o600`. Failure to chown is a warn-and-continue (group missing on dev hosts is not fatal).
- Sets the SGID bit on `/run/kukeon` and `/opt/kukeon` (mode `2750`) during the existing recursive walk in init, so files the daemon writes later (`metadata.json`, CNI state) inherit the `kukeon` group instead of falling back to `root:root` and breaking `--no-daemon` reads for non-root operators.
- Closes the two carve-outs called out in #167's PR description for #163.

## Notable judgment calls
- `--socket-gid` is an explicit numeric flag rather than having kukeond resolve `kukeon` via `user.LookupGroup` inside its container. The daemon image does not necessarily ship `/etc/group` with a `kukeon` entry, and a numeric GID matches what already lives on the host's bind-mounted state — keeping the contract numeric avoids divergence between init and serve.
- Mode constants: `kukeonRunDirMode` and `kukeonRunPathDirMode` use `os.ModeSetgid | 0o750` rather than the bare `0o2750`. Go's `os.Chmod` reads SGID from `os.ModeSetgid`, not from raw mode bits — `0o2750` would silently be applied as `0o0750`. A small `formatPosixMode` helper renders init's permission report as the on-disk POSIX octal (e.g. `0o2750`), since `%#o` on a Go `FileMode` would print internal flag bits like `0x400000`.
- CLAUDE.md update is filed as separate docs follow-up #175 per `agents/dev/CLAUDE.md`'s rule that project CLAUDE.md edits cannot be bundled into a code-fix PR.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes
- [x] New unit coverage:
  - `internal/daemon/server_test.go` — `Serve` chowns socket to `SocketGID` and applies mode `0o660`; without `SocketGID` the socket stays `0o600`.
  - `internal/controller/bootstrap_test.go` — `kukeondCellDoc` emits `--socket-gid <gid>` only when GID > 0.
  - `internal/sysuser/sysuser_test.go` — `ChownTreeAndChmod` propagates SGID on dirs and leaves regular files unaffected.
- [x] Local end-to-end smoke (per project `CLAUDE.md`):
  - Tear down kukeond cell, rebuild `kuke`/`kukeond`, rebuild and import `kukeon-local:dev`, run `sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev`. Init reports `mode 0o2750 (dirs) / 0o0640 (files)` for `/opt/kukeon` and `mode 0o0660` for the socket.
  - `stat -c '%A %U:%G %a' /run/kukeon /run/kukeon/kukeond.sock /opt/kukeon /opt/kukeon/default` confirms `drwxr-s---` (SGID) on dirs, `srw-rw----` `root:kukeon 660` on the socket.
  - Daemon-parity check: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` return identical output.
  - Daemon-restart check: `kuke stop cell kukeond ... && kuke start cell kukeond ... --no-daemon`. After restart, `stat` still reports `root:kukeon 660`; `ps -ef | grep kukeond` shows the daemon launched with `--socket-gid 986`.
  - Non-root group member dial: as `inwx` (in the `kukeon` group), `./kuke get realms` succeeds without sudo.
  - SGID inheritance: `sudo ./kuke create realm sgid-smoke` followed by `stat /opt/kukeon/sgid-smoke/metadata.json` shows `root:kukeon`.

Closes #173

Filed as a separate docs follow-up: #175 (CLAUDE.md smoke section update for the new daemon-restart and group-inheritance checks).