### PR TITLE
feat(realm): standardize containerd namespace to <realm>.kukeon.io

### DIFF
--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -255,7 +255,7 @@ func TestPrintRealmActions(t *testing.T) {
 			name: "created",
 			section: controller.RealmSection{
 				RealmName:                          "default",
-				RealmContainerdNamespace:           "kukeon.io",
+				RealmContainerdNamespace:           "default.kukeon.io",
 				RealmCreated:                       true,
 				RealmContainerdNamespaceCreated:    true,
 				RealmCgroupCreated:                 true,
@@ -264,7 +264,7 @@ func TestPrintRealmActions(t *testing.T) {
 			},
 			expected: []string{
 				"- realm \"default\": created",
-				"- containerd namespace \"kukeon.io\": created",
+				"- containerd namespace \"default.kukeon.io\": created",
 				"- realm cgroup: created",
 			},
 		},
@@ -272,7 +272,7 @@ func TestPrintRealmActions(t *testing.T) {
 			name: "already-existed",
 			section: controller.RealmSection{
 				RealmName:                          "default",
-				RealmContainerdNamespace:           "kukeon.io",
+				RealmContainerdNamespace:           "default.kukeon.io",
 				RealmCgroupExistsPre:               true,
 				RealmCgroupExistsPost:              true,
 				RealmContainerdNamespaceExistsPre:  true,
@@ -282,7 +282,7 @@ func TestPrintRealmActions(t *testing.T) {
 			},
 			expected: []string{
 				"- realm \"default\": already existed",
-				"- containerd namespace \"kukeon.io\": already existed",
+				"- containerd namespace \"default.kukeon.io\": already existed",
 				"- realm cgroup: already existed",
 			},
 		},

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -288,7 +288,7 @@ func TestKuke_Init_VerifyState(t *testing.T) {
 	}
 
 	// Step 4: Verify containerd namespace exists
-	namespace := "kukeon.io"
+	namespace := consts.RealmNamespace(consts.KukeonDefaultRealmName)
 	if !verifyContainerdNamespace(t, namespace) {
 		t.Fatalf("containerd namespace %q not found after init", namespace)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -204,13 +204,13 @@ func loadKukeondImageIntoContainerd(t *testing.T) string {
 	defer importCancel()
 	importCmd := exec.CommandContext(
 		importCtx, ctrPath,
-		"--namespace", consts.KukeSystemRealmNamespace,
+		"--namespace", consts.RealmNamespace(consts.KukeSystemRealmName),
 		"images", "import", tarPath,
 	)
 	if out, importErr := importCmd.CombinedOutput(); importErr != nil {
 		t.Fatalf(
 			"ctr -n %s images import %q failed: %v\noutput:\n%s",
-			consts.KukeSystemRealmNamespace, tarPath, importErr, string(out),
+			consts.RealmNamespace(consts.KukeSystemRealmName), tarPath, importErr, string(out),
 		)
 	}
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -44,18 +44,20 @@ const (
 	KukeonContainerLabelKey = "container.kukeon.io"
 
 	// Default user hierarchy created by `kuke init` for user workloads.
-	KukeonDefaultRealmName      = "default"
-	KukeonDefaultRealmNamespace = "kukeon.io"
-	KukeonDefaultSpaceName      = "default"
-	KukeonDefaultStackName      = "default"
+	KukeonDefaultRealmName = "default"
+	KukeonDefaultSpaceName = "default"
+	KukeonDefaultStackName = "default"
 
 	// System hierarchy created by `kuke init` for the kukeond daemon.
-	KukeSystemRealmName      = "kuke-system"
-	KukeSystemRealmNamespace = "kuke-system.kukeon.io"
-	KukeSystemSpaceName      = "kukeon"
-	KukeSystemStackName      = "kukeon"
-	KukeSystemCellName       = "kukeond"
-	KukeSystemContainerName  = "kukeond"
+	KukeSystemRealmName     = "kuke-system"
+	KukeSystemSpaceName     = "kukeon"
+	KukeSystemStackName     = "kukeon"
+	KukeSystemCellName      = "kukeond"
+	KukeSystemContainerName = "kukeond"
+
+	// realmNamespaceSuffix is the suffix appended to every realm name to form
+	// its containerd namespace. See RealmNamespace.
+	realmNamespaceSuffix = ".kukeon.io"
 
 	// KukeonSystemUser and KukeonSystemGroup name the system identity created
 	// by `kuke init` so a non-root operator added to the kukeon group can
@@ -64,3 +66,11 @@ const (
 	KukeonSystemUser  = "kukeon"
 	KukeonSystemGroup = "kukeon"
 )
+
+// RealmNamespace returns the containerd namespace for a realm: <realm>.kukeon.io.
+// This is the only place in the codebase that appends the .kukeon.io suffix to a
+// realm name; all bootstrap and user-realm code paths route through it so the
+// mapping stays consistent.
+func RealmNamespace(realm string) string {
+	return realm + realmNamespaceSuffix
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -134,7 +134,7 @@ func (b *Exec) Bootstrap() (BootstrapReport, error) {
 	if err = b.bootstrapRealm(
 		&report.DefaultRealm,
 		consts.KukeonDefaultRealmName,
-		consts.KukeonDefaultRealmNamespace,
+		consts.RealmNamespace(consts.KukeonDefaultRealmName),
 	); err != nil {
 		return report, err
 	}
@@ -158,7 +158,7 @@ func (b *Exec) Bootstrap() (BootstrapReport, error) {
 	if err = b.bootstrapRealm(
 		&report.SystemRealm,
 		consts.KukeSystemRealmName,
-		consts.KukeSystemRealmNamespace,
+		consts.RealmNamespace(consts.KukeSystemRealmName),
 	); err != nil {
 		return report, err
 	}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -543,9 +543,11 @@ func setupTestController(t *testing.T, mockRunner runner.Runner) *controller.Exe
 // Resource builder helpers
 
 // buildTestRealm creates a test realm with the specified name and namespace.
+// An empty namespace argument is filled with consts.RealmNamespace(name) so
+// fixtures stay in sync with the controller-layer default in CreateRealm/PurgeRealm.
 func buildTestRealm(name, namespace string) intmodel.Realm {
 	if namespace == "" {
-		namespace = name
+		namespace = consts.RealmNamespace(name)
 	}
 	return intmodel.Realm{
 		Metadata: intmodel.RealmMetadata{

--- a/internal/controller/create_realm.go
+++ b/internal/controller/create_realm.go
@@ -56,7 +56,7 @@ func (b *Exec) CreateRealm(realm intmodel.Realm) (CreateRealmResult, error) {
 	}
 	namespace := strings.TrimSpace(realm.Spec.Namespace)
 	if namespace == "" {
-		namespace = name
+		namespace = consts.RealmNamespace(name)
 		// Update realm with default namespace
 		realm.Spec.Namespace = namespace
 	}

--- a/internal/controller/create_realm_test.go
+++ b/internal/controller/create_realm_test.go
@@ -338,7 +338,7 @@ func TestCreateRealm_DefaultNamespace(t *testing.T) {
 		wantResult  func(t *testing.T, result controller.CreateRealmResult)
 	}{
 		{
-			name:      "empty namespace defaults to realm name",
+			name:      "empty namespace defaults to <realm>.kukeon.io",
 			realmName: "test-realm",
 			namespace: "",
 			setupRunner: func(f *fakeRunner) {
@@ -346,22 +346,20 @@ func TestCreateRealm_DefaultNamespace(t *testing.T) {
 					return intmodel.Realm{}, errdefs.ErrRealmNotFound
 				}
 				f.CreateRealmFn = func(realm intmodel.Realm) (intmodel.Realm, error) {
-					// Verify namespace was set to realm name
-					if realm.Spec.Namespace != "test-realm" {
-						return intmodel.Realm{}, errors.New("namespace not set to realm name")
+					// Verify namespace was derived from the realm name via consts.RealmNamespace.
+					if realm.Spec.Namespace != consts.RealmNamespace("test-realm") {
+						return intmodel.Realm{}, errors.New("namespace not derived from realm name")
 					}
-					return buildTestRealm("test-realm", "test-realm"), nil
+					return buildTestRealm("test-realm", consts.RealmNamespace("test-realm")), nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.CreateRealmResult) {
-				if result.Realm.Spec.Namespace != "test-realm" {
-					t.Errorf("expected namespace to be 'test-realm', got %q", result.Realm.Spec.Namespace)
+				wantNs := consts.RealmNamespace("test-realm")
+				if result.Realm.Spec.Namespace != wantNs {
+					t.Errorf("expected namespace to be %q, got %q", wantNs, result.Realm.Spec.Namespace)
 				}
-				if result.Realm.Metadata.Labels[consts.KukeonRealmLabelKey] != "test-realm" {
-					t.Errorf(
-						"expected label to be 'test-realm', got %q",
-						result.Realm.Metadata.Labels[consts.KukeonRealmLabelKey],
-					)
+				if got := result.Realm.Metadata.Labels[consts.KukeonRealmLabelKey]; got != wantNs {
+					t.Errorf("expected label to be %q, got %q", wantNs, got)
 				}
 			},
 		},

--- a/internal/controller/get_realm.go
+++ b/internal/controller/get_realm.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
@@ -44,7 +45,7 @@ func (b *Exec) GetRealm(realm intmodel.Realm) (GetRealmResult, error) {
 
 	namespace := strings.TrimSpace(realm.Spec.Namespace)
 	if namespace == "" {
-		namespace = name
+		namespace = consts.RealmNamespace(name)
 	}
 
 	// Build lookup realm for runner

--- a/internal/controller/get_realm_test.go
+++ b/internal/controller/get_realm_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -191,12 +192,12 @@ func TestGetRealm_DefaultNamespace(t *testing.T) {
 		setupRunner       func(*fakeRunner, string)
 	}{
 		{
-			name:              "empty namespace defaults to realm name",
+			name:              "empty namespace defaults to <realm>.kukeon.io",
 			realmName:         "test-realm",
 			namespace:         "",
-			expectedNamespace: "test-realm",
+			expectedNamespace: consts.RealmNamespace("test-realm"),
 			setupRunner: func(f *fakeRunner, expectedNs string) {
-				realm := buildTestRealm("test-realm", "test-realm")
+				realm := buildTestRealm("test-realm", expectedNs)
 				f.GetRealmFn = func(_ intmodel.Realm) (intmodel.Realm, error) {
 					return realm, nil
 				}
@@ -212,12 +213,12 @@ func TestGetRealm_DefaultNamespace(t *testing.T) {
 			},
 		},
 		{
-			name:              "whitespace namespace defaults to realm name",
+			name:              "whitespace namespace defaults to <realm>.kukeon.io",
 			realmName:         "test-realm",
 			namespace:         "   ",
-			expectedNamespace: "test-realm",
+			expectedNamespace: consts.RealmNamespace("test-realm"),
 			setupRunner: func(f *fakeRunner, expectedNs string) {
-				realm := buildTestRealm("test-realm", "test-realm")
+				realm := buildTestRealm("test-realm", expectedNs)
 				f.GetRealmFn = func(_ intmodel.Realm) (intmodel.Realm, error) {
 					return realm, nil
 				}

--- a/internal/controller/purge_realm.go
+++ b/internal/controller/purge_realm.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
@@ -46,10 +47,10 @@ func (b *Exec) PurgeRealm(realm intmodel.Realm, force, cascade bool) (PurgeRealm
 		return result, errdefs.ErrRealmNameRequired
 	}
 
-	// Default namespace to realm name if not set (matching CreateRealm behavior)
+	// Default namespace to <name>.kukeon.io if not set (matching CreateRealm behavior)
 	namespace := strings.TrimSpace(realm.Spec.Namespace)
 	if namespace == "" {
-		namespace = name
+		namespace = consts.RealmNamespace(name)
 		realm.Spec.Namespace = namespace
 	}
 

--- a/internal/controller/purge_realm_test.go
+++ b/internal/controller/purge_realm_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -232,10 +233,11 @@ func TestPurgeRealm_SuccessfulPurgeWithoutMetadata(t *testing.T) {
 				if result.Realm.Metadata.Name != "test-realm" {
 					t.Errorf("expected realm name to be 'test-realm', got %q", result.Realm.Metadata.Name)
 				}
-				if result.Realm.Spec.Namespace != "test-realm" {
+				wantNs := consts.RealmNamespace("test-realm")
+				if result.Realm.Spec.Namespace != wantNs {
 					t.Errorf(
-						"expected namespace to default to realm name 'test-realm', got %q",
-						result.Realm.Spec.Namespace,
+						"expected namespace to default to %q, got %q",
+						wantNs, result.Realm.Spec.Namespace,
 					)
 				}
 				if result.Realm.Status.State != intmodel.RealmStateUnknown {
@@ -516,38 +518,41 @@ func TestPurgeRealm_DefaultNamespace(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name:      "empty namespace defaults to realm name",
+			name:      "empty namespace defaults to <realm>.kukeon.io",
 			realmName: "test-realm",
 			namespace: "",
 			setupRunner: func(f *fakeRunner) {
+				wantNs := consts.RealmNamespace("test-realm")
 				f.GetRealmFn = func(_ intmodel.Realm) (intmodel.Realm, error) {
 					return intmodel.Realm{}, errdefs.ErrRealmNotFound
 				}
 				f.ExistsRealmContainerdNamespaceFn = func(namespace string) (bool, error) {
-					if namespace != "test-realm" {
-						t.Errorf("expected namespace to be 'test-realm', got %q", namespace)
+					if namespace != wantNs {
+						t.Errorf("expected namespace to be %q, got %q", wantNs, namespace)
 					}
 					return false, nil
 				}
 				f.PurgeRealmFn = func(realm intmodel.Realm) error {
-					if realm.Spec.Namespace != "test-realm" {
-						t.Errorf("expected namespace to be 'test-realm', got %q", realm.Spec.Namespace)
+					if realm.Spec.Namespace != wantNs {
+						t.Errorf("expected namespace to be %q, got %q", wantNs, realm.Spec.Namespace)
 					}
 					return nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
-				if result.Realm.Spec.Namespace != "test-realm" {
-					t.Errorf("expected namespace to default to 'test-realm', got %q", result.Realm.Spec.Namespace)
+				wantNs := consts.RealmNamespace("test-realm")
+				if result.Realm.Spec.Namespace != wantNs {
+					t.Errorf("expected namespace to default to %q, got %q", wantNs, result.Realm.Spec.Namespace)
 				}
 			},
 			wantErr: false,
 		},
 		{
-			name:      "whitespace namespace defaults to realm name",
+			name:      "whitespace namespace defaults to <realm>.kukeon.io",
 			realmName: "test-realm",
 			namespace: "   ",
 			setupRunner: func(f *fakeRunner) {
+				wantNs := consts.RealmNamespace("test-realm")
 				f.GetRealmFn = func(_ intmodel.Realm) (intmodel.Realm, error) {
 					return intmodel.Realm{}, errdefs.ErrRealmNotFound
 				}
@@ -555,15 +560,16 @@ func TestPurgeRealm_DefaultNamespace(t *testing.T) {
 					return false, nil
 				}
 				f.PurgeRealmFn = func(realm intmodel.Realm) error {
-					if realm.Spec.Namespace != "test-realm" {
-						t.Errorf("expected namespace to be 'test-realm', got %q", realm.Spec.Namespace)
+					if realm.Spec.Namespace != wantNs {
+						t.Errorf("expected namespace to be %q, got %q", wantNs, realm.Spec.Namespace)
 					}
 					return nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
-				if result.Realm.Spec.Namespace != "test-realm" {
-					t.Errorf("expected namespace to default to 'test-realm', got %q", result.Realm.Spec.Namespace)
+				wantNs := consts.RealmNamespace("test-realm")
+				if result.Realm.Spec.Namespace != wantNs {
+					t.Errorf("expected namespace to default to %q, got %q", wantNs, result.Realm.Spec.Namespace)
 				}
 			},
 			wantErr: false,

--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -79,9 +80,9 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 
 	namespace := internalRealm.Spec.Namespace
 	if namespace == "" {
-		// Fallback to realm name if namespace is not set
-		namespace = realmName
-		r.logger.DebugContext(r.ctx, "realm has no namespace, using realm name as fallback",
+		// Fallback to <realm>.kukeon.io if namespace is not set
+		namespace = consts.RealmNamespace(realmName)
+		r.logger.DebugContext(r.ctx, "realm has no namespace, deriving from realm name",
 			"realm", realmName,
 			"namespace", namespace)
 	}

--- a/internal/controller/runner/create_realm_test.go
+++ b/internal/controller/runner/create_realm_test.go
@@ -212,15 +212,15 @@ func TestCreateRealm_LifecycleStateManagement(t *testing.T) {
 			description:             "When a realm exists in Failed state, it should remain in Failed state (no automatic recovery)",
 		},
 		{
-			name:                    "realm creation with empty namespace - defaults to realm name and reaches Ready",
+			name:                    "realm creation with empty namespace - defaults to <realm>.kukeon.io and reaches Ready",
 			realmName:               "test-realm-5",
-			namespace:               "", // Empty namespace defaults to realm name at the runner layer
+			namespace:               "", // Empty namespace defaults to <realm>.kukeon.io at the runner layer
 			setup:                   nil,
 			wantState:               intmodel.RealmStateReady,
 			wantErr:                 false,
 			verifyStateInMetadata:   true,
 			skipIfContainerdMissing: true,
-			description:             "When namespace is empty, runner.CreateRealm defaults Spec.Namespace to the realm name (matching controller-layer defaulting in internal/controller/create_realm.go) so reconcile-style stub realms still provision successfully.",
+			description:             "When namespace is empty, runner.CreateRealm defaults Spec.Namespace to consts.RealmNamespace(name) (matching controller-layer defaulting in internal/controller/create_realm.go) so reconcile-style stub realms still provision successfully.",
 		},
 		{
 			name:      "realm creation with duplicate namespace - handles gracefully",
@@ -507,13 +507,13 @@ func TestProvisionNewRealm_ErrorHandling(t *testing.T) {
 			description:             "Successful realm creation should transition from Creating to Ready",
 		},
 		{
-			name:                    "empty namespace - defaults to realm name and reaches Ready",
+			name:                    "empty namespace - defaults to <realm>.kukeon.io and reaches Ready",
 			realmName:               "fail-ns-realm",
-			namespace:               "", // Empty namespace defaults to realm name at the runner layer
+			namespace:               "", // Empty namespace defaults to <realm>.kukeon.io at the runner layer
 			wantState:               intmodel.RealmStateReady,
 			wantErr:                 false,
 			skipIfContainerdMissing: true,
-			description:             "When namespace is empty, runner.CreateRealm defaults Spec.Namespace to the realm name; the realm provisions successfully rather than parking as Failed.",
+			description:             "When namespace is empty, runner.CreateRealm defaults Spec.Namespace to consts.RealmNamespace(name); the realm provisions successfully rather than parking as Failed.",
 		},
 	}
 

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -47,7 +47,7 @@ type ensureCgroupParams struct {
 }
 
 func (r *Exec) provisionNewRealm(realm intmodel.Realm) (intmodel.Realm, error) {
-	// Default empty Spec.Namespace to the realm name so the runner-layer
+	// Default empty Spec.Namespace to <realm>.kukeon.io so the runner-layer
 	// API behaves symmetrically with the controller layer's defaulting
 	// (internal/controller/create_realm.go:57-62). Without this, callers
 	// that go straight to the runner — notably ReconcileSpace's "ensure
@@ -56,7 +56,7 @@ func (r *Exec) provisionNewRealm(realm intmodel.Realm) (intmodel.Realm, error) {
 	// silently colocating every "naked" realm. Mirror the controller's
 	// behavior here so both layers converge on the same safe default.
 	if strings.TrimSpace(realm.Spec.Namespace) == "" {
-		realm.Spec.Namespace = strings.TrimSpace(realm.Metadata.Name)
+		realm.Spec.Namespace = consts.RealmNamespace(strings.TrimSpace(realm.Metadata.Name))
 	}
 
 	// Update realm metadata with Creating state

--- a/internal/controller/uninstall.go
+++ b/internal/controller/uninstall.go
@@ -194,11 +194,11 @@ func (b *Exec) collectRealmsForUninstall() ([]intmodel.Realm, error) {
 	wellKnown := []intmodel.Realm{
 		{
 			Metadata: intmodel.RealmMetadata{Name: consts.KukeonDefaultRealmName},
-			Spec:     intmodel.RealmSpec{Namespace: consts.KukeonDefaultRealmNamespace},
+			Spec:     intmodel.RealmSpec{Namespace: consts.RealmNamespace(consts.KukeonDefaultRealmName)},
 		},
 		{
 			Metadata: intmodel.RealmMetadata{Name: consts.KukeSystemRealmName},
-			Spec:     intmodel.RealmSpec{Namespace: consts.KukeSystemRealmNamespace},
+			Spec:     intmodel.RealmSpec{Namespace: consts.RealmNamespace(consts.KukeSystemRealmName)},
 		},
 	}
 

--- a/internal/controller/uninstall_test.go
+++ b/internal/controller/uninstall_test.go
@@ -81,11 +81,13 @@ func TestUninstall_PurgesWellKnownRealmsAndCleansFilesystem(t *testing.T) {
 	// Both well-known realms must be in the report, with their canonical
 	// containerd namespaces (the whole point of preferring well-known
 	// names over a stale/missing on-disk realm list).
-	if got := purged[consts.KukeonDefaultRealmName]; got != consts.KukeonDefaultRealmNamespace {
-		t.Errorf("default realm purged with namespace %q, want %q", got, consts.KukeonDefaultRealmNamespace)
+	wantDefaultNs := consts.RealmNamespace(consts.KukeonDefaultRealmName)
+	if got := purged[consts.KukeonDefaultRealmName]; got != wantDefaultNs {
+		t.Errorf("default realm purged with namespace %q, want %q", got, wantDefaultNs)
 	}
-	if got := purged[consts.KukeSystemRealmName]; got != consts.KukeSystemRealmNamespace {
-		t.Errorf("kuke-system realm purged with namespace %q, want %q", got, consts.KukeSystemRealmNamespace)
+	wantSystemNs := consts.RealmNamespace(consts.KukeSystemRealmName)
+	if got := purged[consts.KukeSystemRealmName]; got != wantSystemNs {
+		t.Errorf("kuke-system realm purged with namespace %q, want %q", got, wantSystemNs)
 	}
 
 	if !report.SocketDirRemove || !report.SocketDirExists {


### PR DESCRIPTION
## Summary

- Adds `consts.RealmNamespace(realm string) string` — the single helper that appends `.kukeon.io` to a realm name. Every realm-name → containerd-namespace derivation in the codebase now routes through it (bootstrap, user-realm create/purge/get, runner-layer fallbacks).
- Drops the per-realm namespace constants (`KukeonDefaultRealmNamespace`, `KukeSystemRealmNamespace`) — bootstrap now derives them from `consts.RealmNamespace(KukeonDefaultRealmName)` / `consts.RealmNamespace(KukeSystemRealmName)`.
- `default` realm now resolves to `default.kukeon.io` (was `kukeon.io`).
- `kuke create realm foo` now produces containerd namespace `foo.kukeon.io` (was bare `foo`).

## Notable judgment calls

- The two existing constants are removed rather than kept as derived literals: Go does not allow `const` to call a function, so leaving them as constants would have meant either making them `var`s (mutable, surprising) or repeating the suffix string. Removing them and routing call sites through the helper is the cleanest enforcement of the AC's "only place .kukeon.io is appended" requirement.
- Test fixtures: `buildTestRealm(name, "")` now defaults the namespace to `consts.RealmNamespace(name)`. Tests that explicitly pass a namespace are unchanged. This keeps test fixtures aligned with the controller-layer default so `*_DefaultNamespace` tests still cover the production path.
- The on-disk path layout under `/opt/kukeon/<realm-name>/...` continues to use the bare realm name (not the namespace). The namespace is the containerd-side identifier; the disk path is the kukeon-side identifier. They diverge intentionally.
- Per the dev role's "AC mixes a code fix with `<project>/CLAUDE.md` changes" rule, the smoke-output bullet in CLAUDE.md is filed as a separate `docs:` follow-up issue rather than bundled here. See #177.
- Per the issue's Notes, #168 (realm-name validation) lands later. This PR does not introduce a new risk: today user-realm names already flow into containerd verbatim, so `foo_bar` → `foo_bar.kukeon.io` is no worse than the existing `foo_bar` → `foo_bar` mapping, and the AC is independent of validation.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes (full unit suite incl. `internal/controller/...`, `cmd/kuke/...`, runner-layer)
- [x] Local end-to-end smoke per project `CLAUDE.md`:
  - Tear down kukeond cell + `kuke purge realm default kuke-system --cascade --force --no-daemon` to clear stale `kukeon.io` namespace.
  - Rebuild `kuke`/`kukeond`, rebuild and import `kukeon-local:dev`, run `sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev`. Init prints `containerd namespace "default.kukeon.io": created` (was `"kukeon.io"`).
  - Daemon-parity check: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` return identical output, with `default` mapped to `default.kukeon.io` and `kuke-system` to `kuke-system.kukeon.io`.
- [x] User-realm path: `sudo ./kuke create realm test-userrealm` reports `(namespace "test-userrealm.kukeon.io")`; `kuke get realms` confirms; `kuke purge realm test-userrealm --cascade --force` cleans up.

Closes #169

Filed as a separate docs follow-up: #177 (CLAUDE.md smoke section update for the new `default.kukeon.io` namespace).