### PR TITLE
feat(realm+cni): validate realm names and use k-{hash} for all bridge names

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -813,6 +813,9 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 			Status: intmodel.CellStatus{
 				State:      intmodel.CellState(in.Status.State),
 				CgroupPath: in.Status.CgroupPath,
+				Network: intmodel.CellNetworkStatus{
+					BridgeName: in.Status.Network.BridgeName,
+				},
 				Containers: convertContainerStatusesToInternal(in.Status.Containers),
 			},
 		}
@@ -868,6 +871,9 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 			Status: ext.CellStatus{
 				State:      ext.CellState(in.Status.State),
 				CgroupPath: in.Status.CgroupPath,
+				Network: ext.CellNetworkStatus{
+					BridgeName: in.Status.Network.BridgeName,
+				},
 				Containers: buildContainerStatusesExternalFromInternal(in.Status.Containers),
 			},
 		}

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -380,6 +380,63 @@ func TestCellRoundTripV1Beta1(t *testing.T) {
 	}
 }
 
+// TestCellRoundTripV1Beta1_NetworkBridgeName covers AC for #168: the cell
+// status persists Network.BridgeName through the external→internal→external
+// round-trip so daemon restarts can recover the iface mapping from the
+// cell metadata file alone.
+func TestCellRoundTripV1Beta1_NetworkBridgeName(t *testing.T) {
+	const wantBridge = "k-1a2b3c4d"
+
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata: ext.CellMetadata{
+			Name:   "cell-net",
+			Labels: map[string]string{},
+		},
+		Spec: ext.CellSpec{
+			ID:         "cell-id-net",
+			RealmID:    "realm0",
+			SpaceID:    "space0",
+			StackID:    "stack0",
+			Containers: []ext.ContainerSpec{},
+		},
+		Status: ext.CellStatus{
+			State:      ext.CellStateReady,
+			CgroupPath: "/sys/fs/cgroup/cell-net",
+			Network: ext.CellNetworkStatus{
+				BridgeName: wantBridge,
+			},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if internal.Status.Network.BridgeName != wantBridge {
+		t.Errorf("internal bridge = %q, want %q", internal.Status.Network.BridgeName, wantBridge)
+	}
+
+	output, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if output.Status.Network.BridgeName != wantBridge {
+		t.Errorf("external bridge = %q, want %q", output.Status.Network.BridgeName, wantBridge)
+	}
+
+	// The YAML rendering must include the bridgeName line so `kuke get
+	// cell -o yaml` surfaces it for operators.
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if !strings.Contains(string(rendered), "bridgeName: "+wantBridge) {
+		t.Errorf("rendered YAML missing bridgeName entry; got:\n%s", string(rendered))
+	}
+}
+
 func TestContainerRoundTripV1Beta1(t *testing.T) {
 	input := ext.ContainerDoc{
 		APIVersion: ext.APIVersionV1Beta1,

--- a/internal/cni/config.go
+++ b/internal/cni/config.go
@@ -19,7 +19,6 @@ package cni
 import (
 	"encoding/json"
 	"hash/fnv"
-	"strings"
 )
 
 // maxBridgeNameLen is the Linux IFNAMSIZ-1 limit for network interface names.
@@ -49,31 +48,29 @@ func NewCNINetworkConfigWithSubnet(name, subnetCIDR string) NetworkConfig {
 }
 
 // SafeBridgeName derives a Linux-legal bridge device name from a CNI network
-// name. Names within the IFNAMSIZ limit pass through unchanged; longer ones
-// are deterministically truncated to a 6-char prefix plus an 8-hex-char FNV-1a
-// suffix (total 15 chars) to preserve readability while staying unique.
-// The empty string is preserved so callers can detect "unset".
+// name. The output is always "k-{8-hex FNV-1a hash}" (10 chars, well under
+// IFNAMSIZ-1=15) regardless of input length, so the bridge name never depends
+// on user-controlled realm/space lengths or charset. Same input → same hash;
+// the empty string is preserved so callers can detect "unset".
 func SafeBridgeName(name string) string {
-	if len(name) <= maxBridgeNameLen {
-		return name
+	if name == "" {
+		return ""
 	}
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(name))
-	sum := h.Sum32()
-	prefix := strings.ReplaceAll(name[:6], "/", "-")
-	return prefixHashBridgeName(prefix, sum)
+	return hashBridgeName(h.Sum32())
 }
 
-func prefixHashBridgeName(prefix string, sum uint32) string {
+func hashBridgeName(sum uint32) string {
 	const (
 		hexLen     = 8
 		bitsPerHex = 4
 		hexMask    = 0xf
 		hex        = "0123456789abcdef"
+		prefix     = "k-"
 	)
-	buf := make([]byte, 0, len(prefix)+1+hexLen)
+	buf := make([]byte, 0, len(prefix)+hexLen)
 	buf = append(buf, prefix...)
-	buf = append(buf, '-')
 	for i := hexLen - 1; i >= 0; i-- {
 		buf = append(buf, hex[(sum>>(uint(i)*bitsPerHex))&hexMask])
 	}

--- a/internal/cni/config_test.go
+++ b/internal/cni/config_test.go
@@ -31,9 +31,9 @@ func TestNewCNINetworkConfig(t *testing.T) {
 		wantSubnet  string
 	}{
 		{
-			name:        "success with name provided",
+			name:        "short name is hashed to k-{8hex}",
 			networkName: "test-network",
-			wantBridge:  "test-network",
+			wantBridge:  cni.SafeBridgeName("test-network"),
 			wantSubnet:  "10.88.0.0/16",
 		},
 		{
@@ -43,7 +43,7 @@ func TestNewCNINetworkConfig(t *testing.T) {
 			wantSubnet:  "10.88.0.0/16",
 		},
 		{
-			name:        "long name is truncated to IFNAMSIZ-safe bridge",
+			name:        "long name is hashed to k-{8hex}",
 			networkName: "kuke-system-kukeon",
 			wantBridge:  cni.SafeBridgeName("kuke-system-kukeon"),
 			wantSubnet:  "10.88.0.0/16",
@@ -71,14 +71,14 @@ func TestNewCNINetworkConfig(t *testing.T) {
 
 func TestSafeBridgeName(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    string
-		wantLen  int
-		wantSame bool
+		name      string
+		input     string
+		wantLen   int
+		wantEmpty bool
 	}{
-		{name: "empty", input: "", wantLen: 0, wantSame: true},
-		{name: "short passes through", input: "default-default", wantLen: 15, wantSame: true},
-		{name: "long is truncated to 15", input: "kuke-system-kukeon", wantLen: 15, wantSame: false},
+		{name: "empty stays empty", input: "", wantLen: 0, wantEmpty: true},
+		{name: "short input is hashed", input: "default-default", wantLen: 10},
+		{name: "long input is hashed", input: "kuke-system-kukeon", wantLen: 10},
 	}
 
 	for _, tt := range tests {
@@ -87,16 +87,49 @@ func TestSafeBridgeName(t *testing.T) {
 			if len(got) != tt.wantLen {
 				t.Errorf("SafeBridgeName(%q) length = %d, want %d (got %q)", tt.input, len(got), tt.wantLen, got)
 			}
-			if tt.wantSame && got != tt.input {
-				t.Errorf("SafeBridgeName(%q) = %q, want unchanged", tt.input, got)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("SafeBridgeName(%q) = %q, want empty", tt.input, got)
+				}
+				return
 			}
-			if !tt.wantSame && tt.input != "" && got == tt.input {
-				t.Errorf("SafeBridgeName(%q) unchanged, want truncated", tt.input)
+			if got[:2] != "k-" {
+				t.Errorf("SafeBridgeName(%q) = %q, want k-{hash} prefix", tt.input, got)
 			}
 			if cni.SafeBridgeName(tt.input) != got {
 				t.Errorf("SafeBridgeName is not deterministic for %q", tt.input)
 			}
 		})
+	}
+}
+
+// TestSafeBridgeName_Determinism documents the determinism contract: same
+// realm/space → same hash, regardless of length or charset. Locks the rule
+// the issue calls out: "bridge-name determinism (same realm/space → same
+// hash)".
+func TestSafeBridgeName_Determinism(t *testing.T) {
+	cases := []string{
+		"default-alpha",
+		"kuke-system-kukeon",
+		"some-very-long-realm-name-foo-bar-baz",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			a := cni.SafeBridgeName(in)
+			b := cni.SafeBridgeName(in)
+			if a != b {
+				t.Errorf("SafeBridgeName(%q) non-deterministic: %q vs %q", in, a, b)
+			}
+			if got := len(a); got != 10 {
+				t.Errorf("SafeBridgeName(%q) length = %d, want 10 (got %q)", in, got, a)
+			}
+		})
+	}
+	// Different inputs should generally hash to different outputs (this is
+	// not a collision-resistance proof — just a sanity check that we are
+	// not constant-folding to a single bucket).
+	if cni.SafeBridgeName("default-alpha") == cni.SafeBridgeName("default-beta") {
+		t.Errorf("two different network names hash to the same bridge — generator regressed")
 	}
 }
 

--- a/internal/cni/errors.go
+++ b/internal/cni/errors.go
@@ -45,7 +45,7 @@ func translateCNIError(err error, networkName, bridge string) error {
 	// other ERANGE causes (e.g. route table overflow) are left untranslated.
 	if strings.Contains(msg, "numerical result out of range") && len(bridge) > maxBridgeNameLen {
 		return fmt.Errorf(
-			"%w: bridge %q is %d chars, max %d (IFNAMSIZ-1); SafeBridgeName was expected to truncate — file a bug: %w",
+			"%w: bridge %q is %d chars, max %d (IFNAMSIZ-1); SafeBridgeName was expected to hash — file a bug: %w",
 			errdefs.ErrBridgeNameTooLong, bridge, len(bridge), maxBridgeNameLen, err,
 		)
 	}

--- a/internal/cni/network.go
+++ b/internal/cni/network.go
@@ -184,8 +184,9 @@ func (m *Manager) CreateNetworkWithConfig(cfg NetworkConfig) (string, error) {
 	if bridge == "" {
 		bridge = defaultBridgeName
 	}
-	// Defense-in-depth: SafeBridgeName is supposed to truncate, but a caller
-	// bypassing it (or a future bug there) would otherwise write a conflist
+	// Defense-in-depth: SafeBridgeName is supposed to keep the bridge under
+	// IFNAMSIZ (it always emits k-{8hex} = 10 chars), but a caller that
+	// bypasses it (or a future bug there) would otherwise write a conflist
 	// that fails at bridge-create time with netlink ERANGE — a far less
 	// diagnosable error than this one.
 	if len(bridge) > maxBridgeNameLen {

--- a/internal/controller/create_realm.go
+++ b/internal/controller/create_realm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 // CreateRealmResult reports the reconciliation outcomes for a realm.
@@ -51,9 +52,10 @@ func (b *Exec) CreateRealm(realm intmodel.Realm) (CreateRealmResult, error) {
 	var res CreateRealmResult
 
 	name := strings.TrimSpace(realm.Metadata.Name)
-	if name == "" {
-		return res, errdefs.ErrRealmNameRequired
+	if err := naming.ValidateRealmName(name); err != nil {
+		return res, err
 	}
+	realm.Metadata.Name = name
 	namespace := strings.TrimSpace(realm.Spec.Namespace)
 	if namespace == "" {
 		namespace = consts.RealmNamespace(name)

--- a/internal/controller/create_realm_test.go
+++ b/internal/controller/create_realm_test.go
@@ -329,6 +329,50 @@ func TestCreateRealm_ValidationErrors(t *testing.T) {
 	}
 }
 
+// TestCreateRealm_RejectsInvalidCharacters covers the AC for #168: realm
+// names containing "_" or "/" must be rejected at the controller boundary
+// before any runner state mutation. The fakeRunner deliberately fails the
+// test if the create path was reached.
+func TestCreateRealm_RejectsInvalidCharacters(t *testing.T) {
+	tests := []struct {
+		name      string
+		realmName string
+	}{
+		{name: "underscore in realm name", realmName: "team_alpha"},
+		{name: "slash in realm name", realmName: "team/alpha"},
+		{name: "underscore alone", realmName: "_"},
+		{name: "slash alone", realmName: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRunner := &fakeRunner{
+				GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+					t.Fatal("GetRealm called despite invalid name — validation should run first")
+					return intmodel.Realm{}, nil
+				},
+				CreateRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+					t.Fatal("CreateRealm called despite invalid name — validation should run first")
+					return intmodel.Realm{}, nil
+				},
+			}
+
+			ctrl := setupTestController(t, mockRunner)
+			realm := intmodel.Realm{
+				Metadata: intmodel.RealmMetadata{Name: tt.realmName},
+			}
+
+			_, err := ctrl.CreateRealm(realm)
+			if err == nil {
+				t.Fatalf("expected error rejecting %q, got nil", tt.realmName)
+			}
+			if !errors.Is(err, errdefs.ErrInvalidRealmName) {
+				t.Errorf("expected ErrInvalidRealmName, got %v", err)
+			}
+		})
+	}
+}
+
 func TestCreateRealm_DefaultNamespace(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/controller/runner/create_cell.go
+++ b/internal/controller/runner/create_cell.go
@@ -146,6 +146,18 @@ func (r *Exec) EnsureCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, ensureErr
 	}
 
+	// Backfill the bridge name on cells that pre-date the field. Same
+	// best-effort posture as in provisionNewCell: if we cannot derive it,
+	// leave the field empty rather than fail the ensure.
+	if ensuredCell.Status.Network.BridgeName == "" {
+		if bridge, brErr := cellSpaceBridgeName(ensuredCell); brErr == nil {
+			ensuredCell.Status.Network.BridgeName = bridge
+		} else {
+			r.logger.WarnContext(r.ctx, "could not derive cell bridge name on ensure",
+				"cell", ensuredCell.Metadata.Name, "error", brErr)
+		}
+	}
+
 	// Update metadata to persist the containers
 	if err := r.UpdateCellMetadata(ensuredCell); err != nil {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, err)

--- a/internal/controller/runner/create_realm.go
+++ b/internal/controller/runner/create_realm.go
@@ -22,10 +22,15 @@ import (
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 func (r *Exec) CreateRealm(realm intmodel.Realm) (intmodel.Realm, error) {
 	r.logger.Debug("run-path", "run-path", r.opts.RunPath)
+
+	if err := naming.ValidateRealmName(realm.Metadata.Name); err != nil {
+		return intmodel.Realm{}, err
+	}
 
 	// Get existing realm (returns internal model)
 	existingRealm, err := r.GetRealm(realm)

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -978,6 +978,17 @@ func (r *Exec) ensureStackCgroup(stack intmodel.Stack) (intmodel.Stack, error) {
 	return stack, nil
 }
 
+// cellSpaceBridgeName returns the host-side bridge interface name for the
+// cell's space. Returns an error if the realm or space is missing on the
+// cell spec — callers treat that as best-effort and log/continue.
+func cellSpaceBridgeName(cell intmodel.Cell) (string, error) {
+	networkName, err := naming.BuildSpaceNetworkName(cell.Spec.RealmName, cell.Spec.SpaceName)
+	if err != nil {
+		return "", err
+	}
+	return cni.SafeBridgeName(networkName), nil
+}
+
 func (r *Exec) provisionNewCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	// Update cell metadata
 	if err := r.UpdateCellMetadata(cell); err != nil {
@@ -992,6 +1003,21 @@ func (r *Exec) provisionNewCell(cell intmodel.Cell) (intmodel.Cell, error) {
 
 	// Update internal model with cgroup path
 	cell.Status.CgroupPath = cgroupPath
+
+	// Persist the host-side bridge this cell's space lands on. Computing it
+	// here (instead of the read path) keeps the cell self-describing for
+	// debug tooling and survives daemon restarts because the cell metadata
+	// file is rewritten in UpdateCellMetadata below.
+	if bridge, brErr := cellSpaceBridgeName(cell); brErr == nil {
+		cell.Status.Network.BridgeName = bridge
+	} else {
+		// Bridge name is best-effort metadata; failing to derive it must
+		// not block provisioning (the cell can still come up — the iface
+		// is created by CNI from the conflist regardless of what we
+		// record here).
+		r.logger.WarnContext(r.ctx, "could not derive cell bridge name",
+			"cell", cell.Metadata.Name, "error", brErr)
+	}
 
 	// Create pause container and all containers for the cell
 	_, err = r.createCellContainers(&cell)

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -52,6 +52,7 @@ var (
 	ErrSpaceDocRequired       = errors.New("space document is required")
 	ErrSpaceNameRequired      = errors.New("space name is required")
 	ErrRealmNameRequired      = errors.New("realm name is required")
+	ErrInvalidRealmName       = errors.New("realm name is invalid")
 	ErrUpdateSpaceMetadata    = errors.New("failed to update space metadata")
 	ErrCreateSpace            = errors.New("failed to create space")
 	ErrCreateSpaceCgroup      = errors.New("failed to create space cgroup")

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -46,7 +46,17 @@ type CellTty struct {
 type CellStatus struct {
 	State      CellState
 	CgroupPath string
+	Network    CellNetworkStatus
 	Containers []ContainerStatus
+}
+
+// CellNetworkStatus records the network endpoints the cell is attached to.
+// BridgeName is the host-side Linux bridge derived via cni.SafeBridgeName
+// from the cell's space network — persisting it lets `kuke describe`/
+// `kuke get cell -o yaml` recover the human→iface mapping without
+// recomputing the hash.
+type CellNetworkStatus struct {
+	BridgeName string
 }
 
 type CellState int

--- a/internal/util/naming/realmname.go
+++ b/internal/util/naming/realmname.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package naming
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// ValidateRealmName rejects realm names that would corrupt downstream
+// resources. Two characters are blocked today:
+//
+//   - "_" collides with the containerd container-ID separator
+//     ({space}_{stack}_{cell}_{container}) and would break the parser
+//     that splits IDs back into hierarchy components.
+//   - "/" injects extra path components into the cgroup path
+//     (/kukeon/{realm}/{space}/...).
+//
+// Empty names are also rejected for callers that want a single entrypoint;
+// callers that need a separate "required" error should keep using
+// errdefs.ErrRealmNameRequired before invoking this.
+func ValidateRealmName(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return errdefs.ErrRealmNameRequired
+	}
+	if strings.ContainsAny(trimmed, "_/") {
+		return fmt.Errorf("%w: %q contains disallowed character (must not contain '_' or '/')",
+			errdefs.ErrInvalidRealmName, trimmed)
+	}
+	return nil
+}

--- a/internal/util/naming/realmname_test.go
+++ b/internal/util/naming/realmname_test.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package naming_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/util/naming"
+)
+
+func TestValidateRealmName(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   error
+		wantValid bool
+	}{
+		{name: "default realm legal", input: "default", wantValid: true},
+		{name: "kuke-system legal", input: "kuke-system", wantValid: true},
+		{name: "alphanumeric and dash legal", input: "team-alpha-1", wantValid: true},
+		{name: "empty rejected", input: "", wantErr: errdefs.ErrRealmNameRequired},
+		{name: "whitespace-only rejected", input: "   ", wantErr: errdefs.ErrRealmNameRequired},
+		{
+			name:    "underscore rejected (containerd ID parser collision)",
+			input:   "team_alpha",
+			wantErr: errdefs.ErrInvalidRealmName,
+		},
+		{
+			name:    "underscore in middle rejected",
+			input:   "a_b",
+			wantErr: errdefs.ErrInvalidRealmName,
+		},
+		{
+			name:    "slash rejected (cgroup path injection)",
+			input:   "team/alpha",
+			wantErr: errdefs.ErrInvalidRealmName,
+		},
+		{
+			name:    "leading slash rejected",
+			input:   "/team",
+			wantErr: errdefs.ErrInvalidRealmName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := naming.ValidateRealmName(tt.input)
+			if tt.wantValid {
+				if err != nil {
+					t.Errorf("ValidateRealmName(%q) = %v, want nil", tt.input, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("ValidateRealmName(%q) = nil, want error %v", tt.input, tt.wantErr)
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("ValidateRealmName(%q) = %v, want errors.Is(_, %v)", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -49,9 +49,18 @@ type CellTty struct {
 }
 
 type CellStatus struct {
-	State      CellState         `json:"state"      yaml:"state"`
-	CgroupPath string            `json:"cgroupPath" yaml:"cgroupPath"`
-	Containers []ContainerStatus `json:"containers" yaml:"containers"`
+	State      CellState         `json:"state"             yaml:"state"`
+	CgroupPath string            `json:"cgroupPath"        yaml:"cgroupPath"`
+	Network    CellNetworkStatus `json:"network,omitempty" yaml:"network,omitempty"`
+	Containers []ContainerStatus `json:"containers"        yaml:"containers"`
+}
+
+// CellNetworkStatus exposes the host-side bridge a cell is attached to.
+// Populated by the runner during cell provisioning so describe/get -o yaml
+// surfaces the iface name without recomputing the hash. Always emitted in
+// the canonical k-{8hex} form (see cni.SafeBridgeName).
+type CellNetworkStatus struct {
+	BridgeName string `json:"bridgeName,omitempty" yaml:"bridgeName,omitempty"`
 }
 
 type CellState int
@@ -101,6 +110,7 @@ func NewCellDoc(from *CellDoc) *CellDoc {
 			Status: CellStatus{
 				State:      CellStateUnknown,
 				CgroupPath: "",
+				Network:    CellNetworkStatus{},
 				Containers: []ContainerStatus{},
 			},
 		}


### PR DESCRIPTION
## Summary
- Add `ValidateRealmName(string) error` (`internal/util/naming/realmname.go`) that rejects `_` (collides with the containerd ID separator) and `/` (injects extra cgroup path components). Wire it into both controller-level `Exec.CreateRealm` and runner-level `Runner.CreateRealm` so every realm-creation path (CLI, daemon RPC, apply reconcile, init bootstrap) trips the same gate.
- Replace the conditional truncation in `cni.SafeBridgeName` with an unconditional `k-{8-hex FNV-1a}` (10 chars). Bridge names no longer depend on user-controlled realm/space lengths or charset; the empty-string case is preserved so callers can detect "unset". Defensive >15-char check at `internal/cni/network.go:191` is preserved.
- Persist `Status.Network.BridgeName` on every cell via a new `CellNetworkStatus` type at both internal (`internal/modelhub/cell.go`) and external (`pkg/api/model/v1beta1/cell.go`) layers; populated during `provisionNewCell` and backfilled on `EnsureCell` so old metadata files self-heal on next ensure cycle. `kuke get cell -o yaml` surfaces the `network.bridgeName` line directly from the persisted metadata, no recomputation.

Closes #168

## Notable judgment calls
- `Network.BridgeName` is populated best-effort: if `BuildSpaceNetworkName` fails (missing realm/space on the cell spec), provisioning still succeeds — the iface is created from the conflist regardless of what we record on the status.
- `Network.BridgeName` is a single string today (the cell joins one space, ergo one bridge). If a future change attaches a cell to multiple bridges, this becomes a slice — keeping it as a struct (`CellNetworkStatus`) leaves room.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full unit + integration excluding e2e)
- [x] New unit tests:
  - `internal/util/naming/realmname_test.go` — `_`/`/` rejection, empty/whitespace handling
  - `internal/controller/create_realm_test.go::TestCreateRealm_RejectsInvalidCharacters` — controller-layer rejection without runner mutation
  - `internal/cni/config_test.go::TestSafeBridgeName_Determinism` — same input → same hash, different inputs differ
  - `internal/apischeme/scheme_test.go::TestCellRoundTripV1Beta1_NetworkBridgeName` — Status.Network.BridgeName round-trips through ext→internal→ext and renders in YAML
- [x] Project smoke test (CLAUDE.md): tear down kukeond cell, rebuild, re-import image, `kuke init`, daemon-parity check (`kuke get realms` ≡ `kuke get realms --no-daemon`)
- [x] End-to-end realm rejection via daemon: `sudo kuke create realm bad_name` → `Error: realm name is invalid: "bad_name" contains disallowed character...`; same for `bad/name`
- [x] End-to-end bridge persistence: re-init produced `bridge: k-082023b5` in `/opt/kukeon/kuke-system/kukeon/network.conflist` and `status.network.bridgeName: k-082023b5` in the kukeond cell metadata; `kuke get cell kukeond ... -o yaml` surfaces the same value