### PR TITLE
feat(cli): add kuke run --rm to auto-delete cell on task exit

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -355,6 +355,8 @@ var (
 	KUKE_RUN_CONTAINER = DefineKV("KUKE_RUN_CONTAINER", "kuke/run/container")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_PROFILE = DefineKV("KUKE_RUN_PROFILE", "kuke/run/profile")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_RM = DefineKV("KUKE_RUN_RM", "kuke/run/rm")
 
 	// Attach command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -89,6 +89,11 @@ func NewRunCmd() *cobra.Command {
 	cmd.Flags().String("container", "",
 		"Container to attach to (only valid with -a; must be attachable)")
 	_ = viper.BindPFlag(config.KUKE_RUN_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
+	cmd.Flags().Bool("rm", false,
+		"Best-effort delete the cell after the root container's task exits "+
+			"(any rc). Daemon-mode only — incompatible with --no-daemon. "+
+			"A daemon crash between task-exit and delete may leave an orphan.")
+	_ = viper.BindPFlag(config.KUKE_RUN_RM.ViperKey, cmd.Flags().Lookup("rm"))
 
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
@@ -107,6 +112,7 @@ type runFlags struct {
 	output        string
 	doAttach      bool
 	containerFlag string
+	autoDelete    bool
 }
 
 func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
@@ -115,6 +121,7 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		profileName:   strings.TrimSpace(viper.GetString(config.KUKE_RUN_PROFILE.ViperKey)),
 		doAttach:      viper.GetBool(config.KUKE_RUN_ATTACH.ViperKey),
 		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
+		autoDelete:    viper.GetBool(config.KUKE_RUN_RM.ViperKey),
 	}
 
 	output, err := cmd.Flags().GetString("output")
@@ -135,6 +142,12 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		// parse. Reject the combination so callers pick one mode.
 		return runFlags{}, errors.New("--output is incompatible with -a/--attach")
 	}
+	if flags.autoDelete && viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey) {
+		// --rm needs a long-lived process to watch the root task and trigger
+		// cleanup. The --no-daemon CLI exits as soon as create+start returns,
+		// so the watcher would never run.
+		return runFlags{}, errors.New("--rm is incompatible with --no-daemon")
+	}
 	return flags, nil
 }
 
@@ -150,6 +163,14 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	resolveCellLocation(&cellDoc)
+
+	if flags.autoDelete {
+		// The flag is the imperative knob; it always wins over a missing/false
+		// spec.autoDelete in the manifest. We never clear an explicit `true`
+		// in the YAML even without --rm — that's a declarative intent the
+		// operator wrote and the daemon should honor.
+		cellDoc.Spec.AutoDelete = true
+	}
 
 	if validateErr := validateResolvedCell(cellDoc); validateErr != nil {
 		return validateErr

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1258,6 +1258,128 @@ func TestRun_FromProfile_Attach_HeadlineFlow(t *testing.T) {
 	}
 }
 
+func TestRun_RmFlag_SetsAutoDeleteOnSpec(t *testing.T) {
+	// `kuke run --rm -f cell.yaml` must surface AutoDelete=true on the
+	// CellDoc the daemon receives, in both attached and detached modes.
+	// The daemon side (KukeonV1Service.CreateCell) reads that bool to
+	// install the auto-delete watcher.
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "--rm"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !fc.createDoc.Spec.AutoDelete {
+		t.Errorf("CreateCell received AutoDelete=false; --rm must set it true")
+	}
+}
+
+func TestRun_NoRmFlag_LeavesAutoDeleteFalse(t *testing.T) {
+	// Default is opt-in — without --rm, the daemon must not see AutoDelete
+	// flipped on. Guards against accidental regression where the CLI
+	// always sets the bool.
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createDoc.Spec.AutoDelete {
+		t.Errorf("CreateCell received AutoDelete=true without --rm; default must be false")
+	}
+}
+
+func TestRun_RmFlag_RejectsNoDaemon(t *testing.T) {
+	// --rm needs a long-lived process to watch the root task. The --no-daemon
+	// CLI returns immediately after CreateCell, so the watcher would never
+	// run. Reject the combo at flag-parse — before any cell is mutated.
+	t.Cleanup(viper.Reset)
+	// The real --no-daemon flag is registered on rootCmd; in this run-only
+	// fixture we only have the run subcommand, so flip the underlying viper
+	// key directly. Either path lands the same bool in viper.
+	viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, true)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "--rm"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--rm is incompatible with --no-daemon") {
+		t.Fatalf("err=%v want '--rm is incompatible with --no-daemon'", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (must reject before mutating)", fc.createCalls)
+	}
+}
+
+func TestRun_RmFlag_FromYAMLAlreadySet_StillHonored(t *testing.T) {
+	// A YAML manifest with `autoDelete: true` already in the spec must be
+	// honored even without --rm — the spec is the declarative source of
+	// truth and the CLI should not silently strip the bit.
+	t.Cleanup(viper.Reset)
+
+	const yamlWithAutoDelete = `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: my-cell
+spec:
+  id: my-cell
+  realmId: my-realm
+  spaceId: my-space
+  stackId: my-stack
+  autoDelete: true
+  containers:
+    - id: root
+      root: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+`
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, yamlWithAutoDelete)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !fc.createDoc.Spec.AutoDelete {
+		t.Errorf("CreateCell received AutoDelete=false; YAML autoDelete:true must survive when --rm is absent")
+	}
+}
+
+func TestNewRunCmd_RmFlagRegistered(t *testing.T) {
+	cmd := runcmd.NewRunCmd()
+	rmFlag := cmd.Flags().Lookup("rm")
+	if rmFlag == nil {
+		t.Fatal("expected --rm flag")
+	}
+	if rmFlag.Value.Type() != "bool" {
+		t.Errorf("--rm type=%q want bool", rmFlag.Value.Type())
+	}
+	if def := rmFlag.DefValue; def != "false" {
+		t.Errorf("--rm default=%q want false", def)
+	}
+}
+
 func TestPickLocation_DefaultsViaConfigKV(t *testing.T) {
 	// Sanity-check that the run command's KV defaults still resolve to "default"
 	// when viper is reset (mirrors session-default behavior on a fresh shell).

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -809,6 +809,7 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				StackName:       in.Spec.StackID,
 				RootContainerID: in.Spec.RootContainerID,
 				Tty:             convertCellTtyToInternal(in.Spec.Tty),
+				AutoDelete:      in.Spec.AutoDelete,
 			},
 			Status: intmodel.CellStatus{
 				State:      intmodel.CellState(in.Status.State),
@@ -867,6 +868,7 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				StackID:         in.Spec.StackName,
 				RootContainerID: in.Spec.RootContainerID,
 				Tty:             buildCellTtyExternalFromInternal(in.Spec.Tty),
+				AutoDelete:      in.Spec.AutoDelete,
 			},
 			Status: ext.CellStatus{
 				State:      ext.CellState(in.Status.State),

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -437,6 +437,78 @@ func TestCellRoundTripV1Beta1_NetworkBridgeName(t *testing.T) {
 	}
 }
 
+// TestCellRoundTripV1Beta1_AutoDelete locks down the AC for `kuke run --rm`:
+// the AutoDelete bool must survive the external→internal→external round-trip
+// and serialize as YAML so a daemon restart can re-read the auto-delete intent
+// from the cell metadata file (the future #161 reconciliation loop's hook).
+func TestCellRoundTripV1Beta1_AutoDelete(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata: ext.CellMetadata{
+			Name:   "cell-rm",
+			Labels: map[string]string{},
+		},
+		Spec: ext.CellSpec{
+			ID:         "cell-id-rm",
+			RealmID:    "realm0",
+			SpaceID:    "space0",
+			StackID:    "stack0",
+			AutoDelete: true,
+			Containers: []ext.ContainerSpec{},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if !internal.Spec.AutoDelete {
+		t.Errorf("internal AutoDelete = false, want true after Normalize")
+	}
+
+	output, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if !output.Spec.AutoDelete {
+		t.Errorf("external AutoDelete = false, want true after Build")
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if !strings.Contains(string(rendered), "autoDelete: true") {
+		t.Errorf("rendered YAML missing autoDelete entry; got:\n%s", string(rendered))
+	}
+}
+
+// TestCellRoundTripV1Beta1_AutoDeleteOmitted ensures the field stays omitted
+// from the YAML when unset — keeps existing manifests visually clean.
+func TestCellRoundTripV1Beta1_AutoDeleteOmitted(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "cell-noop"},
+		Spec: ext.CellSpec{
+			ID:         "cell-id-noop",
+			RealmID:    "realm0",
+			SpaceID:    "space0",
+			StackID:    "stack0",
+			Containers: []ext.ContainerSpec{},
+		},
+	}
+
+	rendered, err := yaml.Marshal(input)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if strings.Contains(string(rendered), "autoDelete:") {
+		t.Errorf("autoDelete must be omitted when false; got:\n%s", string(rendered))
+	}
+}
+
 func TestContainerRoundTripV1Beta1(t *testing.T) {
 	input := ext.ContainerDoc{
 		APIVersion: ext.APIVersionV1Beta1,

--- a/internal/client/local/autodelete.go
+++ b/internal/client/local/autodelete.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// WatchCellAutoDelete spawns a background goroutine that waits for the
+// cell's root containerd task to exit, then best-effort kills and deletes
+// the cell. Returns immediately — the wait happens in the goroutine.
+//
+// Cleanup is scoped to the cell only; it never cascades to stack/space/realm.
+// Best-effort: if any step (Wait, Kill, Delete) fails it is logged and the
+// goroutine exits, leaving the cell behind for the operator (or the future
+// reconciliation loop in #161) to sweep up.
+//
+// Lifetime is bound to bgCtx — when bgCtx is cancelled (daemon shutdown),
+// the wait is abandoned and no cleanup runs. The caller (the daemon) owns
+// passing a long-lived context; the CLI's --no-daemon path would tie the
+// watcher to a short-lived process, so `--rm --no-daemon` is rejected at
+// the flag layer.
+func (c *Client) WatchCellAutoDelete(
+	bgCtx context.Context,
+	logger *slog.Logger,
+	doc v1beta1.CellDoc,
+) error {
+	internal, _, err := apischeme.NormalizeCell(doc)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+
+	exitChan, err := c.ctrl.WaitCellRootTaskExit(bgCtx, internal)
+	if err != nil {
+		return fmt.Errorf("install --rm watcher: %w", err)
+	}
+
+	go c.runAutoDeleteWatcher(bgCtx, logger, doc, exitChan)
+	return nil
+}
+
+func (c *Client) runAutoDeleteWatcher(
+	bgCtx context.Context,
+	logger *slog.Logger,
+	doc v1beta1.CellDoc,
+	exitChan <-chan containerd.ExitStatus,
+) {
+	cellLog := []any{
+		"cell", doc.Metadata.Name,
+		"realm", doc.Spec.RealmID,
+		"space", doc.Spec.SpaceID,
+		"stack", doc.Spec.StackID,
+	}
+
+	select {
+	case <-bgCtx.Done():
+		logger.InfoContext(bgCtx, "--rm watcher cancelled before task exit", cellLog...)
+		return
+	case exit, ok := <-exitChan:
+		if !ok {
+			logger.WarnContext(bgCtx, "--rm watcher: exit channel closed without status", cellLog...)
+			return
+		}
+		fields := append([]any{"exit_code", exit.ExitCode()}, cellLog...)
+		logger.InfoContext(bgCtx, "--rm watcher: root task exited, cleaning up cell", fields...)
+	}
+
+	// Defensive kill: the task may already be gone, but other peers in the
+	// cell could still be running. KillCell is idempotent on already-stopped
+	// containers and bounds the time DeleteCell needs to acquire its locks.
+	if _, killErr := c.KillCell(bgCtx, doc); killErr != nil {
+		logger.WarnContext(bgCtx, "--rm watcher: KillCell failed, continuing to delete",
+			append([]any{"error", killErr}, cellLog...)...)
+	}
+
+	if _, delErr := c.DeleteCell(bgCtx, doc); delErr != nil {
+		logger.ErrorContext(bgCtx, "--rm watcher: DeleteCell failed; cell may be orphaned",
+			append([]any{"error", delErr}, cellLog...)...)
+		return
+	}
+
+	logger.InfoContext(bgCtx, "--rm watcher: cell auto-deleted", cellLog...)
+}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log/slog"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller/runner"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -217,4 +218,14 @@ func (b *Exec) Close() error {
 // per-container sbsh socket via fs.ContainerSocketPath.
 func (b *Exec) RunPath() string {
 	return b.opts.RunPath
+}
+
+// WaitCellRootTaskExit forwards to the runner. Surfaced so the daemon's
+// auto-delete watcher (`kuke run --rm`) can take a wait channel against
+// the cell's root containerd task without reaching into the runner directly.
+func (b *Exec) WaitCellRootTaskExit(
+	ctx context.Context,
+	cell intmodel.Cell,
+) (<-chan containerd.ExitStatus, error) {
+	return b.runner.WaitCellRootTaskExit(ctx, cell)
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"testing"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
@@ -437,6 +438,15 @@ func (f *fakeRunner) Close() error {
 		return f.CloseFn()
 	}
 	return nil
+}
+
+// WaitCellRootTaskExit is unused by controller_test scenarios; no test
+// installs an FX yet, so a stable "unexpected call" stub is enough.
+func (f *fakeRunner) WaitCellRootTaskExit(
+	_ context.Context,
+	_ intmodel.Cell,
+) (<-chan containerd.ExitStatus, error) {
+	return nil, errors.New("unexpected call to WaitCellRootTaskExit")
 }
 
 // Apply

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log/slog"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/ctr"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -88,6 +89,8 @@ type Runner interface {
 	RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error)
 
 	GetContainerState(cell intmodel.Cell, containerID string) (intmodel.ContainerState, error)
+
+	WaitCellRootTaskExit(ctx context.Context, cell intmodel.Cell) (<-chan containerd.ExitStatus, error)
 
 	Close() error
 }

--- a/internal/controller/runner/wait.go
+++ b/internal/controller/runner/wait.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
+)
+
+// WaitCellRootTaskExit returns a channel that fires when the cell's root
+// container task exits. The runner switches the ctr client into the realm's
+// containerd namespace before calling task.Wait so the channel is bound to
+// the right task. Used by the daemon's `kuke run --rm` watcher; the channel
+// emits exactly once and the caller is responsible for any cleanup.
+func (r *Exec) WaitCellRootTaskExit(ctx context.Context, cell intmodel.Cell) (<-chan containerd.ExitStatus, error) {
+	cellName := strings.TrimSpace(cell.Metadata.Name)
+	if cellName == "" {
+		return nil, internalerrdefs.ErrCellNameRequired
+	}
+	realmName := strings.TrimSpace(cell.Spec.RealmName)
+	if realmName == "" {
+		return nil, internalerrdefs.ErrRealmNameRequired
+	}
+	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
+	if spaceName == "" {
+		return nil, internalerrdefs.ErrSpaceNameRequired
+	}
+	stackName := strings.TrimSpace(cell.Spec.StackName)
+	if stackName == "" {
+		return nil, internalerrdefs.ErrStackNameRequired
+	}
+	cellID := strings.TrimSpace(cell.Spec.ID)
+	if cellID == "" {
+		cellID = cellName
+	}
+
+	if err := r.ensureClientConnected(); err != nil {
+		return nil, fmt.Errorf("%w: %w", internalerrdefs.ErrConnectContainerd, err)
+	}
+
+	internalRealm, err := r.GetRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: realmName},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get realm %q: %w", realmName, err)
+	}
+	namespace := internalRealm.Spec.Namespace
+	if namespace == "" {
+		return nil, fmt.Errorf("realm %q has no namespace", realmName)
+	}
+	r.ctrClient.SetNamespace(namespace)
+
+	rootContainerdID, err := naming.BuildRootContainerdID(spaceName, stackName, cellID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build root containerd ID: %w", err)
+	}
+
+	exitChan, err := r.ctrClient.WaitTaskExit(ctx, rootContainerdID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for root task %s: %w", rootContainerdID, err)
+	}
+	return exitChan, nil
+}

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -82,6 +82,7 @@ type Client interface {
 
 	TaskStatus(id string) (containerd.Status, error)
 	TaskMetrics(id string) (*apitypes.Metric, error)
+	WaitTaskExit(ctx context.Context, id string) (<-chan containerd.ExitStatus, error)
 
 	ResolveSbshCachePath(imageRef, baseRunPath string) (string, error)
 }

--- a/internal/ctr/task.go
+++ b/internal/ctr/task.go
@@ -17,10 +17,12 @@
 package ctr
 
 import (
+	"context"
 	"fmt"
 
 	apitypes "github.com/containerd/containerd/api/types"
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
@@ -44,6 +46,32 @@ func (c *client) TaskStatus(id string) (containerd.Status, error) {
 	}
 
 	return status, nil
+}
+
+// WaitTaskExit returns a channel that receives the task's ExitStatus once the
+// task exits. The wait is bound to the given ctx — the namespace is taken
+// from the client's current namespace at call time. Used by the daemon's
+// auto-delete watcher (`kuke run --rm`); StopContainer keeps its own private
+// task.Wait call because it needs to react to a kill timeout.
+func (c *client) WaitTaskExit(ctx context.Context, id string) (<-chan containerd.ExitStatus, error) {
+	if id == "" {
+		return nil, errdefs.ErrEmptyContainerID
+	}
+
+	task, err := c.loadTask(id)
+	if err != nil {
+		return nil, err
+	}
+
+	c.namespaceMu.RLock()
+	ns := c.namespace
+	c.namespaceMu.RUnlock()
+
+	exitChan, err := task.Wait(namespaces.WithNamespace(ctx, ns))
+	if err != nil {
+		return nil, fmt.Errorf("failed to wait for task %s: %w", id, err)
+	}
+	return exitChan, nil
 }
 
 // TaskMetrics returns the metrics for a task.

--- a/internal/daemon/attach_rpc_test.go
+++ b/internal/daemon/attach_rpc_test.go
@@ -48,7 +48,7 @@ func (a *attachClientFake) AttachContainer(
 
 func TestAttachContainer_NotAttachable_RPCSurfacesSentinel(t *testing.T) {
 	core := &attachClientFake{err: errdefs.ErrAttachNotSupported}
-	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core)
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, nil)
 
 	args := &kukeonv1.AttachContainerArgs{Doc: v1beta1.ContainerDoc{}}
 	reply := &kukeonv1.AttachContainerReply{}
@@ -70,7 +70,7 @@ func TestAttachContainer_Attachable_RPCReturnsSocketPath(t *testing.T) {
 	// pass that path through verbatim and leave Err nil.
 	const wantSocket = "/opt/kukeon/default/default/default/cellA/work/tty/socket"
 	core := &attachClientFake{result: kukeonv1.AttachContainerResult{HostSocketPath: wantSocket}}
-	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core)
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, nil)
 
 	args := &kukeonv1.AttachContainerArgs{Doc: v1beta1.ContainerDoc{}}
 	reply := &kukeonv1.AttachContainerReply{}

--- a/internal/daemon/autodelete_rpc_test.go
+++ b/internal/daemon/autodelete_rpc_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/daemon"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// createCellClientFake stubs CreateCell so the auto-delete tests can drive
+// the result path independently of the real controller. All other methods
+// fall through to FakeClient's ErrUnexpectedCall — the launcher should
+// never call into them in the cases under test, since cleanup happens
+// inside the watcher goroutine which uses the real *local.Client in prod.
+type createCellClientFake struct {
+	kukeonv1.FakeClient
+
+	result kukeonv1.CreateCellResult
+	err    error
+}
+
+func (f *createCellClientFake) CreateCell(
+	context.Context,
+	v1beta1.CellDoc,
+) (kukeonv1.CreateCellResult, error) {
+	return f.result, f.err
+}
+
+// recordingLauncher captures every call site the service routes into the
+// auto-delete path. The test compares Calls against the expected count for
+// each scenario.
+type recordingLauncher struct {
+	calls atomic.Int32
+	docs  []v1beta1.CellDoc
+}
+
+func (r *recordingLauncher) launch(_ context.Context, doc v1beta1.CellDoc) error {
+	r.calls.Add(1)
+	r.docs = append(r.docs, doc)
+	return nil
+}
+
+func TestCreateCell_AutoDelete_LaunchesWatcherWhenStarted(t *testing.T) {
+	core := &createCellClientFake{
+		result: kukeonv1.CreateCellResult{
+			Cell:    v1beta1.CellDoc{Metadata: v1beta1.CellMetadata{Name: "my-cell"}},
+			Started: true,
+			Created: true,
+		},
+	}
+	launcher := &recordingLauncher{}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, launcher.launch)
+
+	args := &kukeonv1.CreateCellArgs{
+		Doc: v1beta1.CellDoc{
+			Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+			Spec:     v1beta1.CellSpec{AutoDelete: true},
+		},
+	}
+	reply := &kukeonv1.CreateCellReply{}
+	if err := svc.CreateCell(args, reply); err != nil {
+		t.Fatalf("CreateCell transport error: %v", err)
+	}
+	if got := launcher.calls.Load(); got != 1 {
+		t.Errorf("launcher calls=%d want 1", got)
+	}
+	if len(launcher.docs) != 1 || launcher.docs[0].Metadata.Name != "my-cell" {
+		t.Errorf("launcher received unexpected doc: %+v", launcher.docs)
+	}
+}
+
+func TestCreateCell_AutoDelete_NoLaunchWhenAutoDeleteFalse(t *testing.T) {
+	// Without AutoDelete on the spec, the launcher must not fire even
+	// when the cell was successfully started — the bit is opt-in.
+	core := &createCellClientFake{
+		result: kukeonv1.CreateCellResult{Started: true},
+	}
+	launcher := &recordingLauncher{}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, launcher.launch)
+
+	args := &kukeonv1.CreateCellArgs{
+		Doc: v1beta1.CellDoc{Spec: v1beta1.CellSpec{AutoDelete: false}},
+	}
+	reply := &kukeonv1.CreateCellReply{}
+	if err := svc.CreateCell(args, reply); err != nil {
+		t.Fatalf("CreateCell transport error: %v", err)
+	}
+	if got := launcher.calls.Load(); got != 0 {
+		t.Errorf("launcher calls=%d want 0 when AutoDelete=false", got)
+	}
+}
+
+func TestCreateCell_AutoDelete_NoLaunchWhenNotStarted(t *testing.T) {
+	// An idempotent CreateCell that returns Started=false (cell already
+	// running, no transition) must not install a fresh watcher — that
+	// would race against a watcher installed on the original CreateCell.
+	core := &createCellClientFake{
+		result: kukeonv1.CreateCellResult{Started: false},
+	}
+	launcher := &recordingLauncher{}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, launcher.launch)
+
+	args := &kukeonv1.CreateCellArgs{
+		Doc: v1beta1.CellDoc{Spec: v1beta1.CellSpec{AutoDelete: true}},
+	}
+	reply := &kukeonv1.CreateCellReply{}
+	if err := svc.CreateCell(args, reply); err != nil {
+		t.Fatalf("CreateCell transport error: %v", err)
+	}
+	if got := launcher.calls.Load(); got != 0 {
+		t.Errorf("launcher calls=%d want 0 when Started=false", got)
+	}
+}
+
+func TestCreateCell_AutoDelete_NoLaunchOnError(t *testing.T) {
+	// When CreateCell itself fails, the launcher must not run — there's
+	// nothing to watch and the error path already returns.
+	core := &createCellClientFake{err: errors.New("boom")}
+	launcher := &recordingLauncher{}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, launcher.launch)
+
+	args := &kukeonv1.CreateCellArgs{
+		Doc: v1beta1.CellDoc{Spec: v1beta1.CellSpec{AutoDelete: true}},
+	}
+	reply := &kukeonv1.CreateCellReply{}
+	if err := svc.CreateCell(args, reply); err != nil {
+		t.Fatalf("CreateCell transport error: %v", err)
+	}
+	if reply.Err == nil {
+		t.Errorf("expected reply.Err set on failure, got nil")
+	}
+	if got := launcher.calls.Load(); got != 0 {
+		t.Errorf("launcher calls=%d want 0 on CreateCell failure", got)
+	}
+}
+
+func TestCreateCell_AutoDelete_NilLauncherTolerated(t *testing.T) {
+	// Constructed with a nil launcher (older callers, or tests without
+	// the wiring), CreateCell must still complete successfully even
+	// when AutoDelete is set — the watcher is genuinely optional.
+	core := &createCellClientFake{
+		result: kukeonv1.CreateCellResult{Started: true},
+	}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, nil)
+
+	args := &kukeonv1.CreateCellArgs{
+		Doc: v1beta1.CellDoc{Spec: v1beta1.CellSpec{AutoDelete: true}},
+	}
+	reply := &kukeonv1.CreateCellReply{}
+	if err := svc.CreateCell(args, reply); err != nil {
+		t.Fatalf("CreateCell transport error: %v", err)
+	}
+	if reply.Err != nil {
+		t.Errorf("reply.Err=%v want nil with nil launcher", reply.Err)
+	}
+}

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -22,21 +22,42 @@ import (
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// AutoDeleteLauncher installs a background watcher that deletes the cell
+// after its root containerd task exits. Called from CreateCell when the
+// resulting cell has Spec.AutoDelete=true (i.e., the operator passed
+// `kuke run --rm`). Returning an error logs and proceeds — auto-delete is
+// best-effort by design.
+type AutoDeleteLauncher func(ctx context.Context, doc v1beta1.CellDoc) error
 
 // KukeonV1Service implements the net/rpc server methods for the KukeonV1
 // service. Each method always returns nil to net/rpc and carries structured
 // errors inside the Reply envelope so errdefs sentinels survive the wire.
 type KukeonV1Service struct {
-	ctx    context.Context
-	logger *slog.Logger
-	core   kukeonv1.Client
+	ctx                context.Context
+	logger             *slog.Logger
+	core               kukeonv1.Client
+	autoDeleteLauncher AutoDeleteLauncher
 }
 
 // NewKukeonV1Service constructs a service bound to the given kukeon Client.
-// The service borrows the client; the caller owns its lifecycle.
-func NewKukeonV1Service(ctx context.Context, logger *slog.Logger, core kukeonv1.Client) *KukeonV1Service {
-	return &KukeonV1Service{ctx: ctx, logger: logger, core: core}
+// The service borrows the client; the caller owns its lifecycle. If
+// autoDeleteLauncher is non-nil, CreateCell consults it for cells whose
+// resulting spec asks for auto-delete.
+func NewKukeonV1Service(
+	ctx context.Context,
+	logger *slog.Logger,
+	core kukeonv1.Client,
+	autoDeleteLauncher AutoDeleteLauncher,
+) *KukeonV1Service {
+	return &KukeonV1Service{
+		ctx:                ctx,
+		logger:             logger,
+		core:               core,
+		autoDeleteLauncher: autoDeleteLauncher,
+	}
 }
 
 // CreateRealm is the net/rpc method for KukeonV1.CreateRealm.
@@ -74,12 +95,29 @@ func (s *KukeonV1Service) CreateStack(args *kukeonv1.CreateStackArgs, reply *kuk
 
 // CreateCell is the net/rpc method for KukeonV1.CreateCell. net/rpc requires
 // exported pointer-to-struct args and reply plus a single error return.
+//
+// When the request asks for auto-delete (`kuke run --rm` set Spec.AutoDelete)
+// and the cell was started, the service kicks off a best-effort watcher
+// goroutine that waits for the root task to exit and then kills+deletes the
+// cell. The watcher is owned by the daemon (s.ctx); a daemon crash before
+// task exit leaves an orphan, matching the documented behavior.
 func (s *KukeonV1Service) CreateCell(args *kukeonv1.CreateCellArgs, reply *kukeonv1.CreateCellReply) error {
 	result, err := s.core.CreateCell(s.ctx, args.Doc)
 	reply.Result = result
 	reply.Err = kukeonv1.ToAPIError(err)
 	if err != nil {
 		s.logger.DebugContext(s.ctx, "CreateCell returned error", "error", err)
+		return nil
+	}
+
+	if s.autoDeleteLauncher != nil && args.Doc.Spec.AutoDelete && result.Started {
+		if launchErr := s.autoDeleteLauncher(s.ctx, args.Doc); launchErr != nil {
+			s.logger.WarnContext(s.ctx, "failed to install --rm watcher; cell will not auto-delete",
+				"cell", args.Doc.Metadata.Name,
+				"realm", args.Doc.Spec.RealmID,
+				"error", launchErr,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 // Options configures a Server.
@@ -120,7 +121,7 @@ func (s *Server) Serve() error {
 	}
 
 	s.rpc = rpc.NewServer()
-	svc := NewKukeonV1Service(s.ctx, s.logger, s.core)
+	svc := NewKukeonV1Service(s.ctx, s.logger, s.core, s.autoDeleteLauncher())
 	if err := s.rpc.RegisterName(kukeonv1.ServiceName, svc); err != nil {
 		_ = listener.Close()
 		return fmt.Errorf("register rpc service: %w", err)
@@ -198,6 +199,19 @@ func (s *Server) removeStaleSocket() error {
 		return nil
 	}
 	return fmt.Errorf("remove stale socket: %w", err)
+}
+
+// autoDeleteLauncher returns the AutoDeleteLauncher that the RPC service
+// hands a CellDoc to when it sees Spec.AutoDelete=true on a successful
+// CreateCell. The launcher delegates to *local.Client.WatchCellAutoDelete,
+// which spawns the wait-and-cleanup goroutine bound to the daemon context.
+func (s *Server) autoDeleteLauncher() AutoDeleteLauncher {
+	return func(_ context.Context, doc v1beta1.CellDoc) error {
+		// Always pass the daemon's context (s.ctx) — not the per-RPC ctx,
+		// which is cancelled when the CreateCell call returns. The watcher
+		// must outlive the RPC.
+		return s.core.WatchCellAutoDelete(s.ctx, s.logger, doc)
+	}
 }
 
 func (s *Server) writePIDFile() error {

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -35,6 +35,10 @@ type CellSpec struct {
 	RootContainerID string
 	Tty             *CellTty
 	Containers      []ContainerSpec
+	// AutoDelete mirrors v1beta1.CellSpec.AutoDelete. See that type for
+	// semantics; the field is round-tripped through cell metadata so the
+	// daemon can re-derive the auto-delete intent after a restart.
+	AutoDelete bool
 }
 
 // CellTty mirrors the v1beta1 CellTty payload. See the v1beta1 type for

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -37,6 +37,12 @@ type CellSpec struct {
 	RootContainerID string          `json:"rootContainerId,omitempty" yaml:"rootContainerId,omitempty"`
 	Tty             *CellTty        `json:"tty,omitempty"             yaml:"tty,omitempty"`
 	Containers      []ContainerSpec `json:"containers"                yaml:"containers"`
+	// AutoDelete asks kukeond to delete this cell best-effort after its root
+	// container's task exits (any rc). Set by `kuke run --rm`. Cleanup is
+	// scoped to the cell only — never cascades to stack/space/realm. Best-
+	// effort: a daemon crash between task-exit and delete-completion leaves
+	// an orphan that #161's reconciliation loop will eventually sweep.
+	AutoDelete bool `json:"autoDelete,omitempty"      yaml:"autoDelete,omitempty"`
 }
 
 // CellTty is cell-level tty/attach config. Kept intentionally minimal: only


### PR DESCRIPTION
## Summary
- Add `--rm` boolean flag on `kuke run`. When set, kukeond marks the cell with `Spec.AutoDelete=true` and best-effort kills + deletes the cell after the root container's task exits (any rc).
- Persist `AutoDelete` on the cell spec (not in-memory) so a future reconciliation loop (#161) can re-derive intent after a daemon restart. Round-trip wiring: external `v1beta1.CellSpec` ↔ internal `CellSpec` ↔ on-disk JSON/YAML.
- Watcher lives daemon-side: `Server` injects an `AutoDeleteLauncher` closure into the RPC service; `CreateCell` fires it once when `result.Started == true && doc.Spec.AutoDelete`. The launcher dispatches a goroutine that blocks on `WaitCellRootTaskExit` (new method on `controller`/`runner`/`ctr.Client`) and then calls `KillCell` + `DeleteCell` best-effort.
- Reject `--rm --no-daemon` at the CLI: the watcher needs a long-lived process and `--no-daemon` exits as soon as the RPC returns.
- Cell-scoped only — never cascades to stack/space/realm. Best-effort: a daemon crash between task-exit and delete-completion leaves an orphan that #161's reconciler will sweep.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — all packages green; new tests in `cmd/kuke/run`, `internal/apischeme`, and `internal/daemon` cover flag wiring, round-trip, and launcher firing rules
- [x] `kuke init --kukeond-image docker.io/library/kukeon-local:dev` smoke + daemon-parity check (`kuke get realms` vs `--no-daemon`) — identical output
- [x] End-to-end detached `--rm`: cell auto-deletes within ~3s of `ctr tasks kill -s SIGKILL`
- [x] Negative: cell created without `--rm` survives a task kill (opt-in confirmed)
- [x] CLI rejection: `kuke run -f manifest.yaml --rm --no-daemon` errors with "--rm is incompatible with --no-daemon"
- [ ] Attached-mode (`-a`) live exercise — not separately run; the daemon-side watcher is mode-agnostic and the detached path exercises the same code.

Closes #162