### PR TITLE
feat(naming): validate space/stack/cell/container names

### DIFF
--- a/e2e/e2e_kuke_invalid_names_test.go
+++ b/e2e/e2e_kuke_invalid_names_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestKuke_CreateSpace_RejectsInvalidNames covers the AC for #180: invalid
+// space names ("_" or "/") must be rejected end-to-end with a non-zero exit
+// code and a clear error message that names the offending input. Run via the
+// in-process controller (--no-daemon) so the test is self-contained — the
+// validator is wired at both controller and runner boundaries, so the same
+// rejection fires either way.
+func TestKuke_CreateSpace_RejectsInvalidNames(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	tests := []struct {
+		name      string
+		spaceName string
+	}{
+		{name: "underscore in space name", spaceName: "bad_space"},
+		{name: "slash in space name", spaceName: "bad/space"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args := appendNoDaemonRunPath(runPath,
+				"create", "space", tt.spaceName, "--realm", "default")
+			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
+			if exitCode == 0 {
+				t.Fatalf("expected non-zero exit rejecting space name %q", tt.spaceName)
+			}
+			combined := string(stderr)
+			if !strings.Contains(combined, "space") || !strings.Contains(combined, tt.spaceName) {
+				t.Errorf("expected error mentioning kind=space and name %q, got:\n%s", tt.spaceName, combined)
+			}
+		})
+	}
+}
+
+// TestKuke_CreateStack_RejectsInvalidNames covers the AC for #180: invalid
+// stack names must be rejected end-to-end.
+func TestKuke_CreateStack_RejectsInvalidNames(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	tests := []struct {
+		name      string
+		stackName string
+	}{
+		{name: "underscore in stack name", stackName: "bad_stack"},
+		{name: "slash in stack name", stackName: "bad/stack"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args := appendNoDaemonRunPath(runPath,
+				"create", "stack", tt.stackName,
+				"--realm", "default", "--space", "default")
+			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
+			if exitCode == 0 {
+				t.Fatalf("expected non-zero exit rejecting stack name %q", tt.stackName)
+			}
+			combined := string(stderr)
+			if !strings.Contains(combined, "stack") || !strings.Contains(combined, tt.stackName) {
+				t.Errorf("expected error mentioning kind=stack and name %q, got:\n%s", tt.stackName, combined)
+			}
+		})
+	}
+}
+
+// TestKuke_CreateCell_RejectsInvalidNames covers the AC for #180: invalid
+// cell names must be rejected end-to-end.
+func TestKuke_CreateCell_RejectsInvalidNames(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	tests := []struct {
+		name     string
+		cellName string
+	}{
+		{name: "underscore in cell name", cellName: "bad_cell"},
+		{name: "slash in cell name", cellName: "bad/cell"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args := appendNoDaemonRunPath(runPath,
+				"create", "cell", tt.cellName,
+				"--realm", "default", "--space", "default", "--stack", "default")
+			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
+			if exitCode == 0 {
+				t.Fatalf("expected non-zero exit rejecting cell name %q", tt.cellName)
+			}
+			combined := string(stderr)
+			if !strings.Contains(combined, "cell") || !strings.Contains(combined, tt.cellName) {
+				t.Errorf("expected error mentioning kind=cell and name %q, got:\n%s", tt.cellName, combined)
+			}
+		})
+	}
+}
+
+// TestKuke_CreateContainer_RejectsInvalidNames covers the AC for #180:
+// invalid container names must be rejected end-to-end.
+func TestKuke_CreateContainer_RejectsInvalidNames(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	tests := []struct {
+		name          string
+		containerName string
+	}{
+		{name: "underscore in container name", containerName: "bad_container"},
+		{name: "slash in container name", containerName: "bad/container"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args := appendNoDaemonRunPath(runPath,
+				"create", "container", tt.containerName,
+				"--realm", "default", "--space", "default",
+				"--stack", "default", "--cell", "default",
+				"--image", "registry.eminwux.com/library/alpine:3.19")
+			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
+			if exitCode == 0 {
+				t.Fatalf("expected non-zero exit rejecting container name %q", tt.containerName)
+			}
+			combined := string(stderr)
+			if !strings.Contains(combined, "container") || !strings.Contains(combined, tt.containerName) {
+				t.Errorf("expected error mentioning kind=container and name %q, got:\n%s", tt.containerName, combined)
+			}
+		})
+	}
+}

--- a/internal/controller/create_cell.go
+++ b/internal/controller/create_cell.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 // CreateCellResult reports reconciliation outcomes for a cell.
@@ -67,6 +68,10 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 	if name == "" {
 		return res, errdefs.ErrCellNameRequired
 	}
+	if err := naming.ValidateHierarchyName("cell", name); err != nil {
+		return res, err
+	}
+	cell.Metadata.Name = name
 	realm := strings.TrimSpace(cell.Spec.RealmName)
 	if realm == "" {
 		return res, errdefs.ErrRealmNameRequired
@@ -78,6 +83,20 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 	stack := strings.TrimSpace(cell.Spec.StackName)
 	if stack == "" {
 		return res, errdefs.ErrStackNameRequired
+	}
+
+	// Validate container names embedded in the cell spec so a malformed
+	// container ID is rejected at the cell-create boundary, before
+	// provisionNewCell would build a containerd ID with an embedded "_".
+	for i := range cell.Spec.Containers {
+		id := strings.TrimSpace(cell.Spec.Containers[i].ID)
+		if id == "" {
+			return res, errdefs.ErrContainerNameRequired
+		}
+		if err := naming.ValidateHierarchyName("container", id); err != nil {
+			return res, err
+		}
+		cell.Spec.Containers[i].ID = id
 	}
 
 	// Ensure default labels are set

--- a/internal/controller/create_cell_test.go
+++ b/internal/controller/create_cell_test.go
@@ -474,7 +474,7 @@ func TestCreateCell_ContainerOutcomes(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "empty container ID is skipped in outcomes",
+			name: "empty container ID is rejected at the cell-create boundary",
 			cell: intmodel.Cell{
 				Metadata: intmodel.CellMetadata{
 					Name: "test-cell",
@@ -485,36 +485,23 @@ func TestCreateCell_ContainerOutcomes(t *testing.T) {
 					StackName: "test-stack",
 					Containers: []intmodel.ContainerSpec{
 						{ID: "container1", Image: "image1"},
-						{ID: "", Image: "image2"}, // empty ID should be skipped
+						{ID: "", Image: "image2"},
 						{ID: "container3", Image: "image3"},
 					},
 				},
 			},
 			setupRunner: func(f *fakeRunner) {
 				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
-					return intmodel.Cell{}, errdefs.ErrCellNotFound
-				}
-				createdCell := buildTestCell("test-cell", "test-realm", "test-space", "test-stack")
-				createdCell.Spec.Containers = []intmodel.ContainerSpec{
-					{ID: "container1", Image: "image1"},
-					{ID: "", Image: "image2"},
-					{ID: "container3", Image: "image3"},
+					t.Fatal("GetCell called despite empty container ID — validation should run first")
+					return intmodel.Cell{}, nil
 				}
 				f.CreateCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
-					return createdCell, nil
-				}
-				f.StartCellFn = func(cell intmodel.Cell) (intmodel.Cell, error) {
-					cell.Status.State = intmodel.CellStateReady
-					return cell, nil
+					t.Fatal("CreateCell called despite empty container ID — validation should run first")
+					return intmodel.Cell{}, nil
 				}
 			},
-			wantResult: func(t *testing.T, result controller.CreateCellResult) {
-				// Only container1 and container3 should be in outcomes (empty ID skipped)
-				if len(result.Containers) != 2 {
-					t.Errorf("expected 2 container outcomes (empty ID skipped), got %d", len(result.Containers))
-				}
-			},
-			wantErr: false,
+			wantResult: nil,
+			wantErr:    true,
 		},
 	}
 
@@ -1426,6 +1413,104 @@ func TestCreateCell_NameTrimming(t *testing.T) {
 
 			if tt.wantResult != nil {
 				tt.wantResult(t, result)
+			}
+		})
+	}
+}
+
+// TestCreateCell_RejectsInvalidCharacters covers the AC for #180: cell
+// names containing "_" or "/" must be rejected at the controller boundary
+// before any runner state mutation. The fakeRunner deliberately fails the
+// test if the create path was reached.
+func TestCreateCell_RejectsInvalidCharacters(t *testing.T) {
+	tests := []struct {
+		name     string
+		cellName string
+	}{
+		{name: "underscore in cell name", cellName: "my_cell"},
+		{name: "slash in cell name", cellName: "my/cell"},
+		{name: "underscore alone", cellName: "_"},
+		{name: "slash alone", cellName: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRunner := &fakeRunner{
+				GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+					t.Fatal("GetCell called despite invalid name — validation should run first")
+					return intmodel.Cell{}, nil
+				},
+				CreateCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+					t.Fatal("CreateCell called despite invalid name — validation should run first")
+					return intmodel.Cell{}, nil
+				},
+			}
+
+			ctrl := setupTestController(t, mockRunner)
+			cell := intmodel.Cell{
+				Metadata: intmodel.CellMetadata{Name: tt.cellName},
+				Spec: intmodel.CellSpec{
+					RealmName: "valid-realm",
+					SpaceName: "valid-space",
+					StackName: "valid-stack",
+				},
+			}
+
+			_, err := ctrl.CreateCell(cell)
+			if err == nil {
+				t.Fatalf("expected error rejecting %q, got nil", tt.cellName)
+			}
+			if !errors.Is(err, errdefs.ErrInvalidName) {
+				t.Errorf("expected ErrInvalidName, got %v", err)
+			}
+		})
+	}
+}
+
+// TestCreateCell_RejectsInvalidContainerCharacters covers the AC for #180:
+// container IDs embedded in a cell spec must also be rejected at the
+// controller boundary before any runner state mutation.
+func TestCreateCell_RejectsInvalidContainerCharacters(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerName string
+	}{
+		{name: "underscore in container ID", containerName: "my_container"},
+		{name: "slash in container ID", containerName: "my/container"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRunner := &fakeRunner{
+				GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+					t.Fatal("GetCell called despite invalid container ID — validation should run first")
+					return intmodel.Cell{}, nil
+				},
+				CreateCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+					t.Fatal("CreateCell called despite invalid container ID — validation should run first")
+					return intmodel.Cell{}, nil
+				},
+			}
+
+			ctrl := setupTestController(t, mockRunner)
+			cell := intmodel.Cell{
+				Metadata: intmodel.CellMetadata{Name: "valid-cell"},
+				Spec: intmodel.CellSpec{
+					RealmName: "valid-realm",
+					SpaceName: "valid-space",
+					StackName: "valid-stack",
+					Containers: []intmodel.ContainerSpec{
+						{ID: tt.containerName, Image: "docker.io/library/alpine:3.19"},
+					},
+				},
+			}
+
+			_, err := ctrl.CreateCell(cell)
+			if err == nil {
+				t.Fatalf("expected error rejecting container %q, got nil", tt.containerName)
+			}
+			if !errors.Is(err, errdefs.ErrInvalidName) {
+				t.Errorf("expected ErrInvalidName, got %v", err)
 			}
 		})
 	}

--- a/internal/controller/create_container.go
+++ b/internal/controller/create_container.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 // CreateContainerResult reports reconciliation outcomes for container creation within a cell.
@@ -49,8 +50,14 @@ func (b *Exec) CreateContainer(container intmodel.Container) (CreateContainerRes
 	if containerName == "" {
 		return res, errdefs.ErrContainerNameRequired
 	}
+	if err := naming.ValidateHierarchyName("container", containerName); err != nil {
+		return res, err
+	}
+	container.Metadata.Name = containerName
 	if strings.TrimSpace(container.Spec.ID) == "" {
 		container.Spec.ID = containerName
+	} else {
+		container.Spec.ID = strings.TrimSpace(container.Spec.ID)
 	}
 
 	realm := strings.TrimSpace(container.Spec.RealmName)

--- a/internal/controller/create_container_test.go
+++ b/internal/controller/create_container_test.go
@@ -1497,3 +1497,54 @@ func TestCreateContainer_ContainerObjectConstruction(t *testing.T) {
 		})
 	}
 }
+
+// TestCreateContainer_RejectsInvalidCharacters covers the AC for #180:
+// container names containing "_" or "/" must be rejected at the controller
+// boundary before any runner state mutation. The fakeRunner deliberately
+// fails the test if the create path was reached.
+func TestCreateContainer_RejectsInvalidCharacters(t *testing.T) {
+	tests := []struct {
+		name          string
+		containerName string
+	}{
+		{name: "underscore in container name", containerName: "my_container"},
+		{name: "slash in container name", containerName: "my/container"},
+		{name: "underscore alone", containerName: "_"},
+		{name: "slash alone", containerName: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRunner := &fakeRunner{
+				GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+					t.Fatal("GetCell called despite invalid container name — validation should run first")
+					return intmodel.Cell{}, nil
+				},
+				CreateContainerFn: func(_ intmodel.Cell, _ intmodel.ContainerSpec) (intmodel.Cell, error) {
+					t.Fatal("CreateContainer called despite invalid container name — validation should run first")
+					return intmodel.Cell{}, nil
+				},
+			}
+
+			ctrl := setupTestController(t, mockRunner)
+			container := intmodel.Container{
+				Metadata: intmodel.ContainerMetadata{Name: tt.containerName},
+				Spec: intmodel.ContainerSpec{
+					RealmName: "valid-realm",
+					SpaceName: "valid-space",
+					StackName: "valid-stack",
+					CellName:  "valid-cell",
+					Image:     "docker.io/library/alpine:3.19",
+				},
+			}
+
+			_, err := ctrl.CreateContainer(container)
+			if err == nil {
+				t.Fatalf("expected error rejecting %q, got nil", tt.containerName)
+			}
+			if !errors.Is(err, errdefs.ErrInvalidName) {
+				t.Errorf("expected ErrInvalidName, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/controller/create_space.go
+++ b/internal/controller/create_space.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 // CreateSpaceResult reports reconciliation outcomes for a space.
@@ -54,6 +55,10 @@ func (b *Exec) CreateSpace(space intmodel.Space) (CreateSpaceResult, error) {
 	if name == "" {
 		return res, errdefs.ErrSpaceNameRequired
 	}
+	if err := naming.ValidateHierarchyName("space", name); err != nil {
+		return res, err
+	}
+	space.Metadata.Name = name
 	realm := strings.TrimSpace(space.Spec.RealmName)
 	if realm == "" {
 		return res, errdefs.ErrRealmNameRequired

--- a/internal/controller/create_space_test.go
+++ b/internal/controller/create_space_test.go
@@ -849,3 +849,48 @@ func TestCreateSpace_NameTrimming(t *testing.T) {
 		})
 	}
 }
+
+// TestCreateSpace_RejectsInvalidCharacters covers the AC for #180: space
+// names containing "_" or "/" must be rejected at the controller boundary
+// before any runner state mutation. The fakeRunner deliberately fails the
+// test if the create path was reached.
+func TestCreateSpace_RejectsInvalidCharacters(t *testing.T) {
+	tests := []struct {
+		name      string
+		spaceName string
+	}{
+		{name: "underscore in space name", spaceName: "my_space"},
+		{name: "slash in space name", spaceName: "my/space"},
+		{name: "underscore alone", spaceName: "_"},
+		{name: "slash alone", spaceName: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRunner := &fakeRunner{
+				GetSpaceFn: func(_ intmodel.Space) (intmodel.Space, error) {
+					t.Fatal("GetSpace called despite invalid name — validation should run first")
+					return intmodel.Space{}, nil
+				},
+				CreateSpaceFn: func(_ intmodel.Space) (intmodel.Space, error) {
+					t.Fatal("CreateSpace called despite invalid name — validation should run first")
+					return intmodel.Space{}, nil
+				},
+			}
+
+			ctrl := setupTestController(t, mockRunner)
+			space := intmodel.Space{
+				Metadata: intmodel.SpaceMetadata{Name: tt.spaceName},
+				Spec:     intmodel.SpaceSpec{RealmName: "valid-realm"},
+			}
+
+			_, err := ctrl.CreateSpace(space)
+			if err == nil {
+				t.Fatalf("expected error rejecting %q, got nil", tt.spaceName)
+			}
+			if !errors.Is(err, errdefs.ErrInvalidName) {
+				t.Errorf("expected ErrInvalidName, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/controller/create_stack.go
+++ b/internal/controller/create_stack.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 // CreateStackResult reports reconciliation outcomes for a stack.
@@ -51,6 +52,10 @@ func (b *Exec) CreateStack(stack intmodel.Stack) (CreateStackResult, error) {
 	if name == "" {
 		return res, errdefs.ErrStackNameRequired
 	}
+	if err := naming.ValidateHierarchyName("stack", name); err != nil {
+		return res, err
+	}
+	stack.Metadata.Name = name
 	realm := strings.TrimSpace(stack.Spec.RealmName)
 	if realm == "" {
 		return res, errdefs.ErrRealmNameRequired

--- a/internal/controller/create_stack_test.go
+++ b/internal/controller/create_stack_test.go
@@ -958,3 +958,51 @@ func TestCreateStack_NameTrimming(t *testing.T) {
 		})
 	}
 }
+
+// TestCreateStack_RejectsInvalidCharacters covers the AC for #180: stack
+// names containing "_" or "/" must be rejected at the controller boundary
+// before any runner state mutation. The fakeRunner deliberately fails the
+// test if the create path was reached.
+func TestCreateStack_RejectsInvalidCharacters(t *testing.T) {
+	tests := []struct {
+		name      string
+		stackName string
+	}{
+		{name: "underscore in stack name", stackName: "my_stack"},
+		{name: "slash in stack name", stackName: "my/stack"},
+		{name: "underscore alone", stackName: "_"},
+		{name: "slash alone", stackName: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRunner := &fakeRunner{
+				GetStackFn: func(_ intmodel.Stack) (intmodel.Stack, error) {
+					t.Fatal("GetStack called despite invalid name — validation should run first")
+					return intmodel.Stack{}, nil
+				},
+				CreateStackFn: func(_ intmodel.Stack) (intmodel.Stack, error) {
+					t.Fatal("CreateStack called despite invalid name — validation should run first")
+					return intmodel.Stack{}, nil
+				},
+			}
+
+			ctrl := setupTestController(t, mockRunner)
+			stack := intmodel.Stack{
+				Metadata: intmodel.StackMetadata{Name: tt.stackName},
+				Spec: intmodel.StackSpec{
+					RealmName: "valid-realm",
+					SpaceName: "valid-space",
+				},
+			}
+
+			_, err := ctrl.CreateStack(stack)
+			if err == nil {
+				t.Fatalf("expected error rejecting %q, got nil", tt.stackName)
+			}
+			if !errors.Is(err, errdefs.ErrInvalidName) {
+				t.Errorf("expected ErrInvalidName, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/controller/runner/create_cell.go
+++ b/internal/controller/runner/create_cell.go
@@ -19,14 +19,32 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 func (r *Exec) CreateCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	if err := r.ensureClientConnected(); err != nil {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+
+	trimmedName := strings.TrimSpace(cell.Metadata.Name)
+	if err := naming.ValidateHierarchyName("cell", trimmedName); err != nil {
+		return intmodel.Cell{}, err
+	}
+	cell.Metadata.Name = trimmedName
+
+	// Validate any container IDs embedded in the cell spec, mirroring the
+	// controller-side check so a malformed container ID is rejected here too.
+	for i := range cell.Spec.Containers {
+		id := strings.TrimSpace(cell.Spec.Containers[i].ID)
+		if err := naming.ValidateHierarchyName("container", id); err != nil {
+			return intmodel.Cell{}, err
+		}
+		cell.Spec.Containers[i].ID = id
 	}
 
 	// Get existing cell (returns internal model)

--- a/internal/controller/runner/create_container.go
+++ b/internal/controller/runner/create_container.go
@@ -19,9 +19,11 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 // CreateContainer creates a container in an existing cell by merging the container spec
@@ -32,6 +34,12 @@ import (
 // update path traverses — so the post-merge (effective) configuration is
 // what gets persisted and what `kuke get container -o yaml` displays.
 func (r *Exec) CreateContainer(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error) {
+	trimmedID := strings.TrimSpace(container.ID)
+	if err := naming.ValidateHierarchyName("container", trimmedID); err != nil {
+		return intmodel.Cell{}, err
+	}
+	container.ID = trimmedID
+
 	// Get existing cell (returns internal model)
 	existingCell, err := r.GetCell(cell)
 	if err != nil {

--- a/internal/controller/runner/create_space.go
+++ b/internal/controller/runner/create_space.go
@@ -19,15 +19,23 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 func (r *Exec) CreateSpace(space intmodel.Space) (intmodel.Space, error) {
 	if err := r.ensureClientConnected(); err != nil {
 		return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
+
+	trimmedName := strings.TrimSpace(space.Metadata.Name)
+	if err := naming.ValidateHierarchyName("space", trimmedName); err != nil {
+		return intmodel.Space{}, err
+	}
+	space.Metadata.Name = trimmedName
 
 	// Get existing space (returns internal model)
 	existingSpace, err := r.GetSpace(space)

--- a/internal/controller/runner/create_stack.go
+++ b/internal/controller/runner/create_stack.go
@@ -19,15 +19,23 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
 func (r *Exec) CreateStack(stack intmodel.Stack) (intmodel.Stack, error) {
 	if err := r.ensureClientConnected(); err != nil {
 		return intmodel.Stack{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
+
+	trimmedName := strings.TrimSpace(stack.Metadata.Name)
+	if err := naming.ValidateHierarchyName("stack", trimmedName); err != nil {
+		return intmodel.Stack{}, err
+	}
+	stack.Metadata.Name = trimmedName
 
 	// Get existing stack (returns internal model)
 	existingStack, err := r.GetStack(stack)

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -81,6 +81,7 @@ var (
 	)
 	ErrCellNameRequired        = errors.New("cell name is required")
 	ErrContainerNameRequired   = errors.New("container name is required")
+	ErrInvalidName             = errors.New("name is invalid")
 	ErrInvalidImage            = errors.New("invalid image reference")
 	ErrDeleteRealm             = errors.New("failed to delete realm")
 	ErrDeleteSpace             = errors.New("failed to delete space")

--- a/internal/util/naming/hierarchyname.go
+++ b/internal/util/naming/hierarchyname.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package naming
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// ValidateHierarchyName rejects space, stack, cell, and container names that
+// would corrupt downstream resources, the same way ValidateRealmName guards
+// realm names. Two characters are blocked:
+//
+//   - "_" collides with the containerd container-ID separator
+//     ({space}_{stack}_{cell}_{container}) built by BuildContainerdID. A name
+//     containing "_" produces an ambiguous ID that the inverse parser cannot
+//     round-trip back to its hierarchy components.
+//   - "/" injects extra path components into the cgroup path
+//     (/kukeon/{realm}/{space}/{stack}/{cell}/...).
+//
+// Empty / whitespace-only names are also rejected so callers have a single
+// entrypoint. Callers that need to surface a "required" error per kind
+// should check emptiness and return their own sentinel before invoking this.
+//
+// The kind argument ("space", "stack", "cell", "container") is included in
+// the error message so the operator knows which input was rejected.
+func ValidateHierarchyName(kind, name string) error {
+	if strings.TrimSpace(kind) == "" {
+		return errors.New("hierarchy kind is required")
+	}
+	trimmed := strings.TrimSpace(name)
+	if trimmed == "" {
+		return fmt.Errorf("%w: %s name is required", errdefs.ErrInvalidName, kind)
+	}
+	if strings.ContainsAny(trimmed, "_/") {
+		return fmt.Errorf("%w: %s name %q contains disallowed character (must not contain '_' or '/')",
+			errdefs.ErrInvalidName, kind, trimmed)
+	}
+	return nil
+}

--- a/internal/util/naming/hierarchyname_test.go
+++ b/internal/util/naming/hierarchyname_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package naming_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/util/naming"
+)
+
+func TestValidateHierarchyName(t *testing.T) {
+	kinds := []string{"space", "stack", "cell", "container"}
+
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   error
+		wantValid bool
+	}{
+		{name: "alphanumeric legal", input: "alpha-1", wantValid: true},
+		{name: "single char legal", input: "a", wantValid: true},
+		{name: "dashes legal", input: "team-alpha-1", wantValid: true},
+		{name: "empty rejected", input: "", wantErr: errdefs.ErrInvalidName},
+		{name: "whitespace-only rejected", input: "   ", wantErr: errdefs.ErrInvalidName},
+		{
+			name:    "underscore rejected (containerd ID parser collision)",
+			input:   "team_alpha",
+			wantErr: errdefs.ErrInvalidName,
+		},
+		{
+			name:    "underscore in middle rejected",
+			input:   "a_b",
+			wantErr: errdefs.ErrInvalidName,
+		},
+		{
+			name:    "underscore alone rejected",
+			input:   "_",
+			wantErr: errdefs.ErrInvalidName,
+		},
+		{
+			name:    "slash rejected (cgroup path injection)",
+			input:   "team/alpha",
+			wantErr: errdefs.ErrInvalidName,
+		},
+		{
+			name:    "leading slash rejected",
+			input:   "/team",
+			wantErr: errdefs.ErrInvalidName,
+		},
+		{
+			name:    "slash alone rejected",
+			input:   "/",
+			wantErr: errdefs.ErrInvalidName,
+		},
+	}
+
+	for _, kind := range kinds {
+		for _, tt := range tests {
+			t.Run(kind+"/"+tt.name, func(t *testing.T) {
+				err := naming.ValidateHierarchyName(kind, tt.input)
+				if tt.wantValid {
+					if err != nil {
+						t.Errorf("ValidateHierarchyName(%q, %q) = %v, want nil", kind, tt.input, err)
+					}
+					return
+				}
+				if err == nil {
+					t.Fatalf("ValidateHierarchyName(%q, %q) = nil, want error %v", kind, tt.input, tt.wantErr)
+				}
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf(
+						"ValidateHierarchyName(%q, %q) = %v, want errors.Is(_, %v)",
+						kind,
+						tt.input,
+						err,
+						tt.wantErr,
+					)
+				}
+				// Error message must name the kind so the operator knows which
+				// input was rejected.
+				if !strings.Contains(err.Error(), kind) {
+					t.Errorf("ValidateHierarchyName(%q, %q) = %q, want error containing kind %q",
+						kind, tt.input, err.Error(), kind)
+				}
+			})
+		}
+	}
+}
+
+func TestValidateHierarchyName_RejectsEmptyKind(t *testing.T) {
+	if err := naming.ValidateHierarchyName("", "foo"); err == nil {
+		t.Fatal("ValidateHierarchyName(\"\", \"foo\") = nil, want error")
+	}
+	if err := naming.ValidateHierarchyName("   ", "foo"); err == nil {
+		t.Fatal("ValidateHierarchyName(\"   \", \"foo\") = nil, want error")
+	}
+}


### PR DESCRIPTION
## Summary
- Extends the realm-name validator pattern (#168/#179) to space, stack, cell, and container names. Rejects `_` (collides with the containerd ID separator `{space}_{stack}_{cell}_{container}`), `/` (would inject cgroup-path components), and empty/whitespace-only names. Uses a generic `errdefs.ErrInvalidName` sentinel; the kind name (`space`/`stack`/`cell`/`container`) is baked into the wrapped error message so the operator knows which input was rejected.
- Wires the validator at both the controller (`Exec.Create*`) and the runner (`r.Create*`) boundaries — defense-in-depth, matching the realm precedent. `runner.CreateCell` also re-validates each embedded `cell.Spec.Containers[].ID` so a malformed nested ID can't slip through. Each entry point trims the input first and mirrors the trimmed value back onto `Metadata.Name` (the documented "trim drift" fix from issue #180), so persisted state matches what was validated.
- Updates the controller-side `TestCreateCell_ContainerOutcomes/empty_container_ID_is_skipped_in_outcomes` case in place: empty container IDs are now rejected at the cell-create boundary instead of silently filtered downstream. The renamed subtest documents the new contract.

## Test plan
- [x] `make test` — full unit suite, all packages green (controller, runner, naming, errdefs paths).
- [x] `go test ./internal/util/naming/...` — table-driven coverage of all 4 kinds, valid + invalid + empty + whitespace cases.
- [x] `go test ./internal/controller/...` — every kind has a `Create*_RejectsInvalidCharacters` unit test driving the controller via a fakeRunner that `t.Fatal`s if the create path is reached, asserting `errors.Is(err, errdefs.ErrInvalidName)`. `create_cell_test.go` also has `TestCreateCell_RejectsInvalidContainerCharacters` for embedded container IDs.
- [x] `go test -tags e2e -run "TestKuke_(CreateSpace|CreateStack|CreateCell|CreateContainer)_RejectsInvalidNames" ./e2e/...` — all 8 e2e cases pass (4 kinds × `_` and `/`). Uses `--no-daemon --run-path X` (in-process controller); defense-in-depth means the validator fires either way.
- [x] `go build ./...` and `go vet ./...` clean.
- [x] Daemon-parity smoke check from project CLAUDE.md: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` produced byte-identical output (8 realms — `default`, `kuke-system`, plus 6 leftover `e-r-*` realms from prior e2e runs). This change doesn't touch the daemon path; the parity check is included because CLAUDE.md asks for it on any change touching what the daemon reads.
- [ ] `make test-e2e` (full suite) — not green locally, but the failures are pre-existing environmental issues unrelated to this change. Verified by stashing this branch's changes, checking out `origin/main`, and reproducing the same failures: `TestKuke_Init_VerifyState` fails with stale containerd containers (`kukeon_kukeon_kukeond_*` left "running" by prior runs), which then takes down the daemon socket and cascades into `dial unix /run/kukeon/kukeond.sock: no such file or directory` failures across the parallel daemon-mode tests. None of the failing tests touch the validator paths exercised by this PR.

Closes #180