### PR TITLE
feat(cli): add kuke log to tail sbsh capture file

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -370,6 +370,21 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_ATTACH_CONTAINER = DefineKV("KUKE_ATTACH_CONTAINER", "kuke/attach/container")
 
+	// Log command variables.
+
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_LOG_REALM = DefineKV("KUKE_LOG_REALM", "kuke/log/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_LOG_SPACE = DefineKV("KUKE_LOG_SPACE", "kuke/log/space", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_LOG_STACK = DefineKV("KUKE_LOG_STACK", "kuke/log/stack", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_LOG_CELL = DefineKV("KUKE_LOG_CELL", "kuke/log/cell")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_LOG_CONTAINER = DefineKV("KUKE_LOG_CONTAINER", "kuke/log/container")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_LOG_NO_FOLLOW = DefineKV("KUKE_LOG_NO_FOLLOW", "kuke/log/no-follow", "false")
+
 	// Stop command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_STOP_CELL_REALM = DefineKV("KUKE_STOP_CELL_REALM", "kuke/stop/cell/realm", "default")

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -33,6 +33,7 @@ import (
 	getcmd "github.com/eminwux/kukeon/cmd/kuke/get"
 	initcmd "github.com/eminwux/kukeon/cmd/kuke/init"
 	killcmd "github.com/eminwux/kukeon/cmd/kuke/kill"
+	logcmd "github.com/eminwux/kukeon/cmd/kuke/log"
 	purgecmd "github.com/eminwux/kukeon/cmd/kuke/purge"
 	refreshcmd "github.com/eminwux/kukeon/cmd/kuke/refresh"
 	runcmd "github.com/eminwux/kukeon/cmd/kuke/run"
@@ -131,6 +132,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(refreshcmd.NewRefreshCmd())
 	rootCmd.AddCommand(runcmd.NewRunCmd())
 	rootCmd.AddCommand(attachcmd.NewAttachCmd())
+	rootCmd.AddCommand(logcmd.NewLogCmd())
 	rootCmd.AddCommand(autocompletecmd.NewAutocompleteCmd())
 	rootCmd.AddCommand(uninstallcmd.NewUninstallCmd())
 	rootCmd.AddCommand(version.NewVersionCmd())

--- a/cmd/kuke/log/export_test.go
+++ b/cmd/kuke/log/export_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+// TailFn is the test-visible alias of the unexported tailFn type. Tests
+// build values of this type and store them under MockTailKey to bypass
+// the real follow loop, which would block on a real file.
+type TailFn = tailFn

--- a/cmd/kuke/log/log.go
+++ b/cmd/kuke/log/log.go
@@ -1,0 +1,268 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package log implements the `kuke log` subcommand. It mirrors `kuke
+// attach`'s flag/arg shape but instead of opening an interactive sbsh
+// session it tails the per-container sbsh capture file. Bytes never
+// traverse the daemon RPC: the daemon validates the Attachable gate and
+// returns the host path of the capture file; this subcommand opens that
+// path directly.
+package log
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey injects a kukeonv1.Client via context for tests.
+type MockControllerKey struct{}
+
+// MockTailKey injects a tailFn via context for tests, so the real follow
+// loop (which would block on a real file) can be bypassed.
+type MockTailKey struct{}
+
+// tailFn opens path and copies its contents to out, then either returns
+// when ctx is cancelled (default follow mode) or returns immediately
+// after the first dump (noFollow). Real implementation: tailFile.
+type tailFn func(ctx context.Context, path string, out io.Writer, noFollow bool) error
+
+// pollInterval is how long the follow loop waits between EOF reads.
+// Polling is intentional: avoiding fsnotify keeps the dependency surface
+// small and behaves correctly for sbsh's append-only capture file.
+const pollInterval = 200 * time.Millisecond
+
+// NewLogCmd builds the `kuke log` cobra command.
+func NewLogCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "log",
+		Aliases:       []string{"logs"},
+		Short:         "Tail the sbsh capture file of an Attachable container",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runLog,
+	}
+
+	cmd.Flags().String("realm", "", "Realm that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_LOG_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Space that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_LOG_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Stack that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_LOG_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+	cmd.Flags().String("cell", "", "Cell whose container's capture file to tail")
+	_ = viper.BindPFlag(config.KUKE_LOG_CELL.ViperKey, cmd.Flags().Lookup("cell"))
+	cmd.Flags().String("container", "",
+		"Container within the cell to read (omit to auto-pick the only non-root attachable)")
+	_ = viper.BindPFlag(config.KUKE_LOG_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
+	cmd.Flags().Bool("no-follow", false, "Dump current capture file contents and exit (do not follow)")
+	_ = viper.BindPFlag(config.KUKE_LOG_NO_FOLLOW.ViperKey, cmd.Flags().Lookup("no-follow"))
+
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("cell", config.CompleteCellNames)
+	_ = cmd.RegisterFlagCompletionFunc("container", config.CompleteContainerNames)
+
+	return cmd
+}
+
+func runLog(cmd *cobra.Command, _ []string) error {
+	realm := strings.TrimSpace(viper.GetString(config.KUKE_LOG_REALM.ViperKey))
+	space := strings.TrimSpace(viper.GetString(config.KUKE_LOG_SPACE.ViperKey))
+	stack := strings.TrimSpace(viper.GetString(config.KUKE_LOG_STACK.ViperKey))
+	cell := strings.TrimSpace(viper.GetString(config.KUKE_LOG_CELL.ViperKey))
+	container := strings.TrimSpace(viper.GetString(config.KUKE_LOG_CONTAINER.ViperKey))
+	noFollow := viper.GetBool(config.KUKE_LOG_NO_FOLLOW.ViperKey)
+
+	if realm == "" {
+		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+	}
+	if space == "" {
+		return fmt.Errorf("%w (--space)", errdefs.ErrSpaceNameRequired)
+	}
+	if stack == "" {
+		return fmt.Errorf("%w (--stack)", errdefs.ErrStackNameRequired)
+	}
+	if cell == "" {
+		return fmt.Errorf("%w (--cell)", errdefs.ErrCellNameRequired)
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if container == "" {
+		container, err = pickAttachableContainer(cmd.Context(), client, realm, space, stack, cell)
+		if err != nil {
+			return err
+		}
+	}
+
+	doc := buildContainerDoc(container, realm, space, stack, cell)
+	result, err := client.LogContainer(cmd.Context(), doc)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrAttachNotSupported) {
+			return fmt.Errorf("container %q in cell %q is not attachable: %w", container, cell, err)
+		}
+		if errors.Is(err, errdefs.ErrContainerNotFound) {
+			return fmt.Errorf("container %q not found in cell %q", container, cell)
+		}
+		return err
+	}
+	if result.HostCapturePath == "" {
+		return fmt.Errorf("daemon returned empty HostCapturePath for container %q", container)
+	}
+
+	tail := resolveTail(cmd)
+	if tailErr := tail(cmd.Context(), result.HostCapturePath, cmd.OutOrStdout(), noFollow); tailErr != nil {
+		if errors.Is(tailErr, os.ErrNotExist) {
+			return fmt.Errorf(
+				"cell %q container %q has no capture file at %s",
+				cell, container, result.HostCapturePath,
+			)
+		}
+		return tailErr
+	}
+	return nil
+}
+
+// tailFile opens path and streams its bytes to out. With noFollow it
+// dumps the current contents and returns. Otherwise it dumps and then
+// polls for new bytes until ctx is cancelled (SIGINT/SIGTERM). On
+// cancellation it returns nil so `kuke log` exits 0 — the user
+// pressing Ctrl+C is a benign session end, not a failure.
+func tailFile(ctx context.Context, path string, out io.Writer, noFollow bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, copyErr := io.Copy(out, f); copyErr != nil {
+		return copyErr
+	}
+	if noFollow {
+		return nil
+	}
+
+	// Install a local cancel scope tied to SIGINT/SIGTERM so Ctrl+C
+	// during follow drains the goroutine cleanly. We chain off the
+	// caller's ctx so an upstream cancellation still wins.
+	followCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-followCtx.Done():
+			return nil
+		case <-ticker.C:
+			// io.Copy from the same file handle resumes at the
+			// previous offset; sbsh appends to the capture file so
+			// any new bytes since the last copy are now between EOF
+			// and the new write boundary.
+			if _, copyErr := io.Copy(out, f); copyErr != nil {
+				return copyErr
+			}
+		}
+	}
+}
+
+// pickAttachableContainer enumerates the cell's containers and returns the
+// single non-root attachable one. Same shape and semantics as the
+// `kuke attach` picker — both subcommands target the same container set.
+func pickAttachableContainer(
+	ctx context.Context,
+	client kukeonv1.Client,
+	realm, space, stack, cell string,
+) (string, error) {
+	specs, err := client.ListContainers(ctx, realm, space, stack, cell)
+	if err != nil {
+		return "", err
+	}
+
+	candidates := make([]string, 0, len(specs))
+	for i := range specs {
+		spec := specs[i]
+		if spec.Root || !spec.Attachable {
+			continue
+		}
+		candidates = append(candidates, spec.ID)
+	}
+	sort.Strings(candidates)
+
+	switch len(candidates) {
+	case 0:
+		return "", fmt.Errorf("%w (cell %q)", errdefs.ErrAttachNoCandidate, cell)
+	case 1:
+		return candidates[0], nil
+	default:
+		return "", fmt.Errorf("%w (cell %q): candidates: %s",
+			errdefs.ErrAttachAmbiguous, cell, strings.Join(candidates, ", "))
+	}
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.ClientFromCmd(cmd)
+}
+
+func resolveTail(cmd *cobra.Command) tailFn {
+	if mock, ok := cmd.Context().Value(MockTailKey{}).(tailFn); ok {
+		return mock
+	}
+	return tailFile
+}
+
+func buildContainerDoc(name, realm, space, stack, cell string) v1beta1.ContainerDoc {
+	return v1beta1.ContainerDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindContainer,
+		Metadata: v1beta1.ContainerMetadata{
+			Name:   name,
+			Labels: make(map[string]string),
+		},
+		Spec: v1beta1.ContainerSpec{
+			ID:      name,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+			CellID:  cell,
+		},
+	}
+}

--- a/cmd/kuke/log/log_test.go
+++ b/cmd/kuke/log/log_test.go
@@ -1,0 +1,393 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package log_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	logcmd "github.com/eminwux/kukeon/cmd/kuke/log"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const testHostCapture = "/opt/kukeon/r1/s1/st1/c1/work/tty/capture"
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	listContainersFn func(realm, space, stack, cell string) ([]v1beta1.ContainerSpec, error)
+	logContainerFn   func(doc v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error)
+}
+
+func (f *fakeClient) ListContainers(
+	_ context.Context,
+	realm, space, stack, cell string,
+) ([]v1beta1.ContainerSpec, error) {
+	if f.listContainersFn == nil {
+		return nil, errors.New("unexpected ListContainers call")
+	}
+	return f.listContainersFn(realm, space, stack, cell)
+}
+
+func (f *fakeClient) LogContainer(
+	_ context.Context,
+	doc v1beta1.ContainerDoc,
+) (kukeonv1.LogContainerResult, error) {
+	if f.logContainerFn == nil {
+		return kukeonv1.LogContainerResult{}, errors.New("unexpected LogContainer call")
+	}
+	return f.logContainerFn(doc)
+}
+
+// tailCapture records the (path, noFollow) it was called with and copies
+// configured bytes to the writer so callers can assert on stdout.
+type tailCapture struct {
+	calls    int
+	path     string
+	noFollow bool
+	payload  []byte
+	err      error
+	// blockUntilCancel makes the tail block on ctx.Done() before
+	// returning, modeling the real follow loop. When false the call
+	// returns immediately after writing payload (modeling --no-follow).
+	blockUntilCancel bool
+}
+
+func (t *tailCapture) fn(ctx context.Context, path string, out io.Writer, noFollow bool) error {
+	t.calls++
+	t.path = path
+	t.noFollow = noFollow
+	if t.payload != nil {
+		if _, err := out.Write(t.payload); err != nil {
+			return err
+		}
+	}
+	if t.err != nil {
+		return t.err
+	}
+	if t.blockUntilCancel {
+		<-ctx.Done()
+	}
+	return nil
+}
+
+func newCmdWithCtx(t *testing.T, fc *fakeClient, tail *tailCapture) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	cmd := logcmd.NewLogCmd()
+	ctx := context.Background()
+	if fc != nil {
+		ctx = context.WithValue(ctx, logcmd.MockControllerKey{}, kukeonv1.Client(fc))
+	}
+	if tail != nil {
+		ctx = context.WithValue(ctx, logcmd.MockTailKey{}, logcmd.TailFn(tail.fn))
+	}
+	cmd.SetContext(ctx)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	return cmd, out
+}
+
+func TestLog_NoFollow_DumpsCaptureAndExits(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		logContainerFn: func(doc v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			if got := doc.Metadata.Name; got != "work" {
+				t.Errorf("LogContainer called with name %q, want %q", got, "work")
+			}
+			return kukeonv1.LogContainerResult{HostCapturePath: testHostCapture}, nil
+		},
+	}
+	tail := &tailCapture{payload: []byte("captured-bytes")}
+	cmd, out := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "work", "--no-follow",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if tail.calls != 1 {
+		t.Fatalf("tail called %d times, want 1", tail.calls)
+	}
+	if !tail.noFollow {
+		t.Errorf("noFollow flag = false, want true")
+	}
+	if tail.path != testHostCapture {
+		t.Errorf("tail path = %q, want %q", tail.path, testHostCapture)
+	}
+	if got := out.String(); got != "captured-bytes" {
+		t.Errorf("stdout = %q, want %q", got, "captured-bytes")
+	}
+}
+
+func TestLog_Follow_CancelsCleanlyOnCtxDone(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		logContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			return kukeonv1.LogContainerResult{HostCapturePath: testHostCapture}, nil
+		},
+	}
+	tail := &tailCapture{blockUntilCancel: true, payload: []byte("seed")}
+
+	cmd, out := newCmdWithCtx(t, fc, tail)
+	// Override context with one we can cancel to model SIGINT delivery.
+	ctx, cancel := context.WithCancel(cmd.Context())
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "work",
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var execErr error
+	go func() {
+		defer wg.Done()
+		execErr = cmd.Execute()
+	}()
+
+	// Give the goroutine a beat to enter tail.fn before cancelling, so
+	// we exercise the ctx.Done() path in the follow loop rather than
+	// the pre-cancelled fast exit.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	wg.Wait()
+
+	if execErr != nil {
+		t.Fatalf("Execute returned %v on context cancel, want nil", execErr)
+	}
+	if tail.calls != 1 {
+		t.Fatalf("tail called %d times, want 1", tail.calls)
+	}
+	if tail.noFollow {
+		t.Errorf("noFollow flag = true, want false (follow mode)")
+	}
+	if got := out.String(); got != "seed" {
+		t.Errorf("stdout = %q, want %q", got, "seed")
+	}
+}
+
+func TestLog_MissingCaptureFile_WrapsWithCellAndContainer(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		logContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			return kukeonv1.LogContainerResult{HostCapturePath: testHostCapture}, nil
+		},
+	}
+	tail := &tailCapture{err: os.ErrNotExist}
+	cmd, _ := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "work", "--no-follow",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute returned nil, want missing-capture error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"c1", "work", testHostCapture} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestLog_AmbiguousCandidates_ErrorsWithList(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "shell", Attachable: true},
+				{ID: "claude", Attachable: true},
+			}, nil
+		},
+	}
+	tail := &tailCapture{}
+	cmd, _ := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachAmbiguous) {
+		t.Fatalf("error %v does not unwrap to ErrAttachAmbiguous", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "claude, shell") {
+		t.Errorf("error message %q missing sorted candidate list", got)
+	}
+	if tail.calls != 0 {
+		t.Errorf("tail called %d times on ambiguous picker, want 0", tail.calls)
+	}
+}
+
+func TestLog_NoCandidate_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+			}, nil
+		},
+	}
+	tail := &tailCapture{}
+	cmd, _ := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
+		t.Fatalf("error %v does not unwrap to ErrAttachNoCandidate", err)
+	}
+	if tail.calls != 0 {
+		t.Errorf("tail called %d times on empty picker, want 0", tail.calls)
+	}
+}
+
+func TestLog_ExplicitContainer_NotAttachable_SurfacesSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		logContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			return kukeonv1.LogContainerResult{}, errdefs.ErrAttachNotSupported
+		},
+	}
+	tail := &tailCapture{}
+	cmd, _ := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "side",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachNotSupported) {
+		t.Fatalf("error %v does not unwrap to ErrAttachNotSupported", err)
+	}
+	if tail.calls != 0 {
+		t.Errorf("tail called %d times on non-attachable target, want 0", tail.calls)
+	}
+}
+
+func TestLog_MissingFlags(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr error
+	}{
+		{
+			name:    "missing realm",
+			args:    []string{"--space", "s1", "--stack", "st1", "--cell", "c1"},
+			wantErr: errdefs.ErrRealmNameRequired,
+		},
+		{
+			name:    "missing space",
+			args:    []string{"--realm", "r1", "--stack", "st1", "--cell", "c1"},
+			wantErr: errdefs.ErrSpaceNameRequired,
+		},
+		{
+			name:    "missing stack",
+			args:    []string{"--realm", "r1", "--space", "s1", "--cell", "c1"},
+			wantErr: errdefs.ErrStackNameRequired,
+		},
+		{
+			name:    "missing cell",
+			args:    []string{"--realm", "r1", "--space", "s1", "--stack", "st1"},
+			wantErr: errdefs.ErrCellNameRequired,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			t.Setenv("KUKE_LOG_REALM", "")
+			t.Setenv("KUKE_LOG_SPACE", "")
+			t.Setenv("KUKE_LOG_STACK", "")
+			t.Setenv("KUKE_LOG_CELL", "")
+
+			cmd, _ := newCmdWithCtx(t, &fakeClient{}, &tailCapture{})
+			cmd.SetArgs(tc.args)
+
+			err := cmd.Execute()
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error %v does not unwrap to %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestTailFile_NoFollow_DumpsAndReturns exercises the real tailFile
+// (not the mock) to lock in the dump-and-exit semantics required by the
+// --no-follow path.
+func TestTailFile_NoFollow_DumpsAndReturns(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "capture")
+	want := "hello sbsh\n"
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+		t.Fatalf("seed capture: %v", err)
+	}
+
+	out := &bytes.Buffer{}
+	cmd := logcmd.NewLogCmd()
+	fc := &fakeClient{
+		logContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			return kukeonv1.LogContainerResult{HostCapturePath: path}, nil
+		},
+	}
+	ctx := context.WithValue(context.Background(), logcmd.MockControllerKey{}, kukeonv1.Client(fc))
+	cmd.SetContext(ctx)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "work", "--no-follow",
+	})
+	t.Cleanup(viper.Reset)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if got := out.String(); got != want {
+		t.Errorf("stdout = %q, want %q", got, want)
+	}
+}

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -31,6 +31,7 @@ import (
 	"github.com/eminwux/kukeon/internal/apply/parser"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -866,30 +867,60 @@ func formatValidationErrors(validationErrors []*parser.ValidationError) error {
 // (`kuke attach`) opens HostSocketPath directly and runs the sbsh client
 // loop against it.
 func (c *Client) AttachContainer(_ context.Context, doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
-	internal, _, err := apischeme.NormalizeContainer(doc)
-	if err != nil {
-		return kukeonv1.AttachContainerResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
-	}
-	res, err := c.ctrl.GetContainer(internal)
+	spec, err := c.resolveAttachable(doc)
 	if err != nil {
 		return kukeonv1.AttachContainerResult{}, err
-	}
-	if !res.ContainerExists {
-		return kukeonv1.AttachContainerResult{}, errdefs.ErrContainerNotFound
-	}
-	if !res.Container.Spec.Attachable {
-		return kukeonv1.AttachContainerResult{}, errdefs.ErrAttachNotSupported
 	}
 	return kukeonv1.AttachContainerResult{
 		HostSocketPath: fs.ContainerSocketPath(
 			c.ctrl.RunPath(),
-			res.Container.Spec.RealmName,
-			res.Container.Spec.SpaceName,
-			res.Container.Spec.StackName,
-			res.Container.Spec.CellName,
-			res.Container.Spec.ID,
+			spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
 		),
 	}, nil
+}
+
+// ---- Log ----
+
+// LogContainer enforces the Attachable gate and resolves the host-side path
+// of the per-container sbsh capture file. The Attachable gate is the same
+// invariant AttachContainer uses: only sbsh-wrapped containers have a
+// capture file. Bytes never traverse this RPC — the caller (`kuke log`)
+// opens HostCapturePath directly.
+func (c *Client) LogContainer(_ context.Context, doc v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+	spec, err := c.resolveAttachable(doc)
+	if err != nil {
+		return kukeonv1.LogContainerResult{}, err
+	}
+	return kukeonv1.LogContainerResult{
+		HostCapturePath: fs.ContainerCapturePath(
+			c.ctrl.RunPath(),
+			spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+		),
+	}, nil
+}
+
+// resolveAttachable normalizes doc, looks up the container, and returns its
+// internal spec only when Attachable=true. It surfaces ErrConversionFailed
+// for malformed docs, ErrContainerNotFound when the container does not
+// exist, and ErrAttachNotSupported for non-Attachable targets — the
+// invariants both AttachContainer and LogContainer require before handing a
+// host path back to the caller.
+func (c *Client) resolveAttachable(doc v1beta1.ContainerDoc) (intmodel.ContainerSpec, error) {
+	internal, _, err := apischeme.NormalizeContainer(doc)
+	if err != nil {
+		return intmodel.ContainerSpec{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.GetContainer(internal)
+	if err != nil {
+		return intmodel.ContainerSpec{}, err
+	}
+	if !res.ContainerExists {
+		return intmodel.ContainerSpec{}, errdefs.ErrContainerNotFound
+	}
+	if !res.Container.Spec.Attachable {
+		return intmodel.ContainerSpec{}, errdefs.ErrAttachNotSupported
+	}
+	return res.Container.Spec, nil
 }
 
 // ---- Ping ----

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -36,6 +36,14 @@ const (
 	// injected by Attachable=true specs.
 	KukeonContainerSocketFile = "socket"
 
+	// KukeonContainerCaptureFile is the basename of the per-container sbsh
+	// capture file inside KukeonContainerTTYDir. sbsh writes the full tty
+	// byte stream — every byte the workload produced and every byte typed
+	// by an attached operator — into this file. `kuke log` tails the host
+	// path that resolves to the same inode as the in-container path
+	// /run/kukeon/tty/capture (see ctr.AttachableCapturePath).
+	KukeonContainerCaptureFile = "capture"
+
 	// Label keys shared across the user default hierarchy and the system hierarchy.
 	KukeonRealmLabelKey     = "realm.kukeon.io"
 	KukeonSpaceLabelKey     = "space.kukeon.io"

--- a/internal/daemon/log_rpc_test.go
+++ b/internal/daemon/log_rpc_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/daemon"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// logClientFake stubs only the kukeonv1.Client.LogContainer method so the
+// service test exercises the RPC layer without a real controller. All other
+// methods stay at the FakeClient-default ErrUnexpectedCall behavior so a
+// stray call would fail loudly.
+type logClientFake struct {
+	kukeonv1.FakeClient
+
+	result kukeonv1.LogContainerResult
+	err    error
+}
+
+func (l *logClientFake) LogContainer(
+	context.Context,
+	v1beta1.ContainerDoc,
+) (kukeonv1.LogContainerResult, error) {
+	return l.result, l.err
+}
+
+func TestLogContainer_NotAttachable_RPCSurfacesSentinel(t *testing.T) {
+	core := &logClientFake{err: errdefs.ErrAttachNotSupported}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, nil)
+
+	args := &kukeonv1.LogContainerArgs{Doc: v1beta1.ContainerDoc{}}
+	reply := &kukeonv1.LogContainerReply{}
+	if err := svc.LogContainer(args, reply); err != nil {
+		t.Fatalf("LogContainer returned transport error: %v", err)
+	}
+	if reply.Err == nil {
+		t.Fatalf("expected wire-level Err to be populated, got nil")
+	}
+	wireErr := kukeonv1.FromAPIError(reply.Err)
+	if !errors.Is(wireErr, errdefs.ErrAttachNotSupported) {
+		t.Errorf("wire error %q does not unwrap to ErrAttachNotSupported", wireErr)
+	}
+}
+
+func TestLogContainer_Attachable_RPCReturnsCapturePath(t *testing.T) {
+	const wantPath = "/opt/kukeon/default/default/default/cellA/work/tty/capture"
+	core := &logClientFake{result: kukeonv1.LogContainerResult{HostCapturePath: wantPath}}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, nil)
+
+	args := &kukeonv1.LogContainerArgs{Doc: v1beta1.ContainerDoc{}}
+	reply := &kukeonv1.LogContainerReply{}
+	if err := svc.LogContainer(args, reply); err != nil {
+		t.Fatalf("LogContainer returned transport error: %v", err)
+	}
+	if reply.Err != nil {
+		t.Fatalf("expected wire-level Err to be nil, got %v", kukeonv1.FromAPIError(reply.Err))
+	}
+	if reply.Result.HostCapturePath != wantPath {
+		t.Errorf("HostCapturePath = %q, want %q", reply.Result.HostCapturePath, wantPath)
+	}
+}

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -241,6 +241,22 @@ func (s *KukeonV1Service) AttachContainer(
 	return nil
 }
 
+// LogContainer enforces the Attachable gate at the API boundary and returns
+// the host path of the per-container sbsh capture file. Bytes never
+// traverse this RPC — the client tails HostCapturePath directly.
+func (s *KukeonV1Service) LogContainer(
+	args *kukeonv1.LogContainerArgs,
+	reply *kukeonv1.LogContainerReply,
+) error {
+	result, err := s.core.LogContainer(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	if err != nil {
+		s.logger.DebugContext(s.ctx, "LogContainer returned error", "error", err)
+	}
+	return nil
+}
+
 func (s *KukeonV1Service) StopCell(args *kukeonv1.StopCellArgs, reply *kukeonv1.StopCellReply) error {
 	result, err := s.core.StopCell(s.ctx, args.Doc)
 	reply.Result = result

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -112,6 +112,18 @@ func ContainerSocketPath(baseRunPath, realmName, spaceName, stackName, cellName,
 	)
 }
 
+// ContainerCapturePath returns the host-side path of the per-container sbsh
+// capture file. It is the host-visible peer of the in-container path
+// /run/kukeon/tty/capture (ctr.AttachableCapturePath); both resolve to the
+// same inode because the per-container tty directory is bind-mounted into
+// the container. `kuke log` tails this path.
+func ContainerCapturePath(baseRunPath, realmName, spaceName, stackName, cellName, containerName string) string {
+	return filepath.Join(
+		ContainerTTYDir(baseRunPath, realmName, spaceName, stackName, cellName, containerName),
+		consts.KukeonContainerCaptureFile,
+	)
+}
+
 type metadataHeader struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -59,6 +59,12 @@ type Client interface {
 	// validates that the target container has Attachable=true; the
 	// terminal-bridge client lands in #66.
 	AttachContainer(ctx context.Context, doc v1beta1.ContainerDoc) (AttachContainerResult, error)
+	// LogContainer validates that the target container has Attachable=true
+	// and resolves the host-side path of the per-container sbsh capture
+	// file. Bytes never traverse this RPC — the caller (`kuke log`) reads
+	// the file directly. Same Attachable gate as AttachContainer: only
+	// containers wrapped by sbsh have a capture file to surface.
+	LogContainer(ctx context.Context, doc v1beta1.ContainerDoc) (LogContainerResult, error)
 	StopCell(ctx context.Context, doc v1beta1.CellDoc) (StopCellResult, error)
 	StopContainer(ctx context.Context, doc v1beta1.ContainerDoc) (StopContainerResult, error)
 	KillCell(ctx context.Context, doc v1beta1.CellDoc) (KillCellResult, error)
@@ -150,6 +156,7 @@ const (
 	MethodStartCell       = ServiceName + ".StartCell"
 	MethodStartContainer  = ServiceName + ".StartContainer"
 	MethodAttachContainer = ServiceName + ".AttachContainer"
+	MethodLogContainer    = ServiceName + ".LogContainer"
 	MethodStopCell        = ServiceName + ".StopCell"
 	MethodStopContainer   = ServiceName + ".StopContainer"
 	MethodKillCell        = ServiceName + ".KillCell"

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -109,6 +109,10 @@ func (FakeClient) AttachContainer(context.Context, v1beta1.ContainerDoc) (Attach
 	return AttachContainerResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) LogContainer(context.Context, v1beta1.ContainerDoc) (LogContainerResult, error) {
+	return LogContainerResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) StopCell(context.Context, v1beta1.CellDoc) (StopCellResult, error) {
 	return StopCellResult{}, ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -354,6 +354,22 @@ func (c *UnixClient) AttachContainer(
 	return reply.Result, nil
 }
 
+// LogContainer implements Client.
+func (c *UnixClient) LogContainer(
+	ctx context.Context,
+	doc v1beta1.ContainerDoc,
+) (LogContainerResult, error) {
+	args := &LogContainerArgs{Doc: doc}
+	reply := &LogContainerReply{}
+	if err := c.call(ctx, MethodLogContainer, args, reply); err != nil {
+		return LogContainerResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // StopCell implements Client.
 func (c *UnixClient) StopCell(ctx context.Context, doc v1beta1.CellDoc) (StopCellResult, error) {
 	args := &StopCellArgs{Doc: doc}

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -551,6 +551,31 @@ type AttachContainerResult struct {
 	HostSocketPath string
 }
 
+// ---- Log ----
+
+// LogContainerArgs identifies the target container for a log request.
+type LogContainerArgs struct {
+	Doc v1beta1.ContainerDoc
+}
+
+type LogContainerReply struct {
+	Result LogContainerResult
+	Err    *APIError
+}
+
+// LogContainerResult carries the host-side coordinates the `kuke log` client
+// needs to tail the sbsh capture file. Bytes never traverse this RPC — the
+// client opens HostCapturePath directly.
+type LogContainerResult struct {
+	// HostCapturePath is the host path of the per-container sbsh capture
+	// file. Inside the container the same inode is reachable at
+	// /run/kukeon/tty/capture via the tty directory bind mount. Returned
+	// only when the target container has Attachable=true; otherwise the
+	// daemon errors with ErrAttachNotSupported (non-Attachable containers
+	// have no capture file).
+	HostCapturePath string
+}
+
 // ---- Refresh ----
 
 type RefreshAllArgs struct{}


### PR DESCRIPTION
## Summary

- Adds `kuke log` (alias `logs`) — a thin client subcommand that tails the per-container sbsh capture file. Default mode is `tail -f`-like follow; `--no-follow` dumps the current contents and exits 0.
- Mirrors `kuke attach`'s flag/arg shape: `--realm/--space/--stack/--cell/--container` with the same auto-pick of the single non-root attachable when `--container` is omitted, and the same `Attachable=true` gate (non-Attachable containers have no capture file).
- Bytes never traverse the daemon RPC. The new `LogContainer` RPC validates the gate and returns `HostCapturePath`; the client opens that path directly with `os.Open` and streams via `io.Copy` (poll loop @ 200ms in follow mode — keeps the dependency surface tiny vs. fsnotify, and matches sbsh's append-only writes).
- SIGINT/SIGTERM during follow drains cleanly via `signal.NotifyContext`; cancellation returns nil so `kuke log` exits 0 (Ctrl+C is a benign session end).
- Missing capture file errors with `cell %q container %q has no capture file at %s` so the operator can correlate the failure to a specific cell/container.

### Implementation note for the reviewer

The issue body says "positional args" in one place and "mirroring kuke attach" in another. Mirroring `kuke attach` won — same `cobra.NoArgs` + `--container` flag — so the two thin clients stay symmetric and the existing picker semantics carry over.

To suppress a `dupl` lint hit between the new `LogContainer` and existing `AttachContainer` paths in `internal/client/local/local.go`, both methods now share a `resolveAttachable` helper that performs the normalize → `GetContainer` → `Attachable` gate sequence.

## Test plan

- [x] `make test` (full unit suite, including `cmd/kuke/log` and `internal/daemon` log_rpc_test)
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `golangci-lint` (run via repo pre-commit hook)
- [x] Daemon-parity smoke: `kuke get realms` vs `kuke get realms --no-daemon` after `kuke init` rebuild — identical output (`internal/daemon/rpcservice.go` and `internal/client/local/local.go` both touch a daemon-read path)
- [x] `kuke log --help` renders as expected with all five flags + `--no-follow`
- [ ] Live tail against a running attachable container — not exercised on the dev box; covered by unit tests for the dump path, follow-cancels-on-SIGINT path, missing-file path, ambiguous/no-candidate picker paths, and the real `tailFile` against a tempdir capture

Closes #114