### PR TITLE
feat(kukeond): introduce ServerConfiguration kind and --configuration flag

### DIFF
--- a/cmd/config/defaults.go
+++ b/cmd/config/defaults.go
@@ -63,12 +63,10 @@ func DefaultProfilesFile() string {
 	return filepath.Join(base, ".kukeon", "profiles.yaml")
 }
 
-func DefaultConfigFile() string {
-	base, err := os.UserHomeDir()
-	if err != nil {
-		// fallback to tmp if home dir cannot be determined
-		base = "tmp"
-	}
-
-	return filepath.Join(base, ".kukeon", "config.yaml")
+// DefaultServerConfigurationFile is the on-disk path the kukeond daemon and
+// `kuke init` read when the user does not pass `--configuration` or
+// `--server-configuration`. An absent file is not an error — the daemon
+// falls back to its hardcoded defaults.
+func DefaultServerConfigurationFile() string {
+	return filepath.Join("/", "etc", "kukeon", "kukeond.yaml")
 }

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -93,8 +93,6 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEON_ROOT_RUN_PATH = DefineKV("KUKEON_RUN_PATH", "kukeon/runPath")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKEON_ROOT_CONFIG_FILE = DefineKV("KUKEON_CONFIG_FILE", "kukeon/configFile")
-	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEON_ROOT_LOG_LEVEL = DefineKV("KUKEON_LOG_LEVEL", "kukeon/logLevel", "info")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEON_ROOT_CONTAINERD_SOCKET = DefineKV("KUKEON_CONTAINERD_SOCKET", "kukeon/containerd.socket")
@@ -107,6 +105,10 @@ var (
 	KUKEOND_SOCKET = DefineKV("KUKEOND_SOCKET", "kukeond/socket", "/run/kukeon/kukeond.sock")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEOND_SOCKET_GID = DefineKV("KUKEOND_SOCKET_GID", "kukeond/socketGID", "0")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKEOND_CONFIGURATION = DefineKV(
+		"KUKEOND_CONFIGURATION", "kukeond/configuration", "/etc/kukeon/kukeond.yaml",
+	)
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_INIT_REALM = DefineKV("KUKE_INIT_REALM", "kuke/init/realm")
@@ -114,6 +116,10 @@ var (
 	KUKE_INIT_SPACE = DefineKV("KUKE_INIT_SPACE", "kuke/init/space")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_INIT_KUKEOND_IMAGE = DefineKV("KUKE_INIT_KUKEOND_IMAGE", "kuke/init/kukeondImage")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_INIT_SERVER_CONFIGURATION = DefineKV(
+		"KUKE_INIT_SERVER_CONFIGURATION", "kuke/init/serverConfiguration", "/etc/kukeon/kukeond.yaml",
+	)
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_INIT_NO_WAIT = DefineKV("KUKE_INIT_NO_WAIT", "kuke/init/noWait", "false")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -151,26 +151,37 @@ func setPersistentFlags(_ *cobra.Command) error {
 }
 
 // applyServerConfiguration layers the loaded ServerConfiguration on top of
-// viper for fields the operator did not explicitly set on the command line.
-// Flag-changed values win so a one-off `--kukeond-image` keeps overriding
-// the on-disk document.
+// viper for fields the operator did not explicitly set on the command line
+// or via environment. Order of precedence: explicit `--flag` > env >
+// ServerConfiguration > flag default. Flag-changed values win so a one-off
+// `--kukeond-image` keeps overriding the on-disk document; env-set values
+// win because `viper.Set` would otherwise override viper's env binding.
 func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurationSpec) {
 	flags := cmd.Flags()
-	if spec.Socket != "" {
+	if spec.Socket != "" && !envSet(config.KUKEOND_SOCKET) {
 		viper.Set(config.KUKEOND_SOCKET.ViperKey, spec.Socket)
 	}
-	if spec.RunPath != "" && !flags.Changed("run-path") {
+	if spec.RunPath != "" && !flags.Changed("run-path") && !envSet(config.KUKEON_ROOT_RUN_PATH) {
 		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, spec.RunPath)
 	}
-	if spec.ContainerdSocket != "" && !flags.Changed("containerd-socket") {
+	if spec.ContainerdSocket != "" && !flags.Changed("containerd-socket") &&
+		!envSet(config.KUKEON_ROOT_CONTAINERD_SOCKET) {
 		viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, spec.ContainerdSocket)
 	}
-	if spec.LogLevel != "" && !flags.Changed("log-level") {
+	if spec.LogLevel != "" && !flags.Changed("log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
 	}
-	if spec.KukeondImage != "" && !flags.Changed("kukeond-image") {
+	if spec.KukeondImage != "" && !flags.Changed("kukeond-image") &&
+		!envSet(config.KUKE_INIT_KUKEOND_IMAGE) {
 		viper.Set(config.KUKE_INIT_KUKEOND_IMAGE.ViperKey, spec.KukeondImage)
 	}
+}
+
+// envSet reports whether the OS env var backing v is present (any value,
+// including empty string, counts as set — same semantics as viper's BindEnv).
+func envSet(v config.Var) bool {
+	_, ok := os.LookupEnv(v.EnvVar())
+	return ok
 }
 
 // resolveKukeondImage returns the kukeond container image to provision.

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -31,8 +31,10 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/serverconfig"
 	"github.com/eminwux/kukeon/internal/sysuser"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -128,11 +130,47 @@ func setFlags(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("failed to bind flag: %w", err)
 	}
+
+	cmd.Flags().String(
+		"server-configuration", config.KUKE_INIT_SERVER_CONFIGURATION.Default,
+		"Path to a ServerConfiguration YAML to seed the daemon with; "+
+			"absent file uses hardcoded defaults",
+	)
+	err = viper.BindPFlag(
+		config.KUKE_INIT_SERVER_CONFIGURATION.ViperKey,
+		cmd.Flags().Lookup("server-configuration"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to bind flag: %w", err)
+	}
 	return nil
 }
 
 func setPersistentFlags(_ *cobra.Command) error {
 	return nil
+}
+
+// applyServerConfiguration layers the loaded ServerConfiguration on top of
+// viper for fields the operator did not explicitly set on the command line.
+// Flag-changed values win so a one-off `--kukeond-image` keeps overriding
+// the on-disk document.
+func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurationSpec) {
+	flags := cmd.Flags()
+	if spec.Socket != "" {
+		viper.Set(config.KUKEOND_SOCKET.ViperKey, spec.Socket)
+	}
+	if spec.RunPath != "" && !flags.Changed("run-path") {
+		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, spec.RunPath)
+	}
+	if spec.ContainerdSocket != "" && !flags.Changed("containerd-socket") {
+		viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, spec.ContainerdSocket)
+	}
+	if spec.LogLevel != "" && !flags.Changed("log-level") {
+		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
+	}
+	if spec.KukeondImage != "" && !flags.Changed("kukeond-image") {
+		viper.Set(config.KUKE_INIT_KUKEOND_IMAGE.ViperKey, spec.KukeondImage)
+	}
 }
 
 // resolveKukeondImage returns the kukeond container image to provision.
@@ -163,6 +201,16 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return errdefs.ErrLoggerNotFound
 	}
 
+	serverConfigPath := viper.GetString(config.KUKE_INIT_SERVER_CONFIGURATION.ViperKey)
+	if serverConfigPath == "" {
+		serverConfigPath = config.DefaultServerConfigurationFile()
+	}
+	serverDoc, err := serverconfig.Load(serverConfigPath)
+	if err != nil {
+		return fmt.Errorf("load server configuration: %w", err)
+	}
+	applyServerConfiguration(cmd, serverDoc.Spec)
+
 	socketPath := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
 	if socketPath == "" {
 		socketPath = config.KUKEOND_SOCKET.Default
@@ -189,12 +237,13 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	}
 
 	opts := controller.Options{
-		RunPath:            runPath,
-		ContainerdSocket:   viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
-		KukeondImage:       image,
-		KukeondSocket:      socketPath,
-		KukeondSocketGID:   ensure.GID,
-		ForceRegenerateCNI: viper.GetBool(config.KUKE_INIT_FORCE_REGENERATE_CNI.ViperKey),
+		RunPath:              runPath,
+		ContainerdSocket:     viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+		KukeondImage:         image,
+		KukeondSocket:        socketPath,
+		KukeondSocketGID:     ensure.GID,
+		KukeondConfiguration: serverConfigPath,
+		ForceRegenerateCNI:   viper.GetBool(config.KUKE_INIT_FORCE_REGENERATE_CNI.ViperKey),
 	}
 
 	logger.DebugContext(cmd.Context(), "running init", "opts", opts)

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -18,11 +18,9 @@ package kuke
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	applycmd "github.com/eminwux/kukeon/cmd/kuke/apply"
@@ -156,12 +154,6 @@ func SetPersistentLoggingFlags(rootCmd *cobra.Command) error {
 		return err
 	}
 
-	rootCmd.PersistentFlags().
-		String("config", "/etc/kukeon/config.yaml", "config file (default is /etc/kukeon/config.yaml)")
-	if err := viper.BindPFlag(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, rootCmd.PersistentFlags().Lookup("config")); err != nil {
-		return err
-	}
-
 	rootCmd.PersistentFlags().String("containerd-socket", "/run/containerd/containerd.sock", "containerd socket file")
 	if err := viper.BindPFlag(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, rootCmd.PersistentFlags().Lookup("containerd-socket")); err != nil {
 		return err
@@ -212,40 +204,14 @@ func (r *realConfigLoader) LoadConfig() error {
 }
 
 func loadConfig() error {
-	var configFile string
-	if viper.GetString(config.KUKEON_ROOT_CONFIG_FILE.ViperKey) == "" {
-		configFile = config.DefaultConfigFile()
-		viper.SetConfigName("config")
-		viper.SetConfigType("yaml")
-		// Add the directory containing the config file
-		viper.AddConfigPath(filepath.Dir(configFile))
-	}
-	_ = config.KUKEON_ROOT_CONFIG_FILE.BindEnv()
-
-	if err := config.KUKEON_ROOT_CONFIG_FILE.Set(configFile); err != nil {
-		return fmt.Errorf("%w: failed to set config file: %w", errdefs.ErrConfig, err)
-	}
-
-	var runPath string
-	runPath = viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
-	if runPath == "" {
-		runPath = config.DefaultRunPath()
-		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, runPath)
-	}
 	_ = config.KUKEON_ROOT_RUN_PATH.BindEnv()
+	if viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey) == "" {
+		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, config.DefaultRunPath())
+	}
 
 	_ = config.KUKEON_ROOT_LOG_LEVEL.BindEnv()
-	logLevel := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey)
-	if logLevel == "" {
+	if viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey) == "" {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, "info")
-	}
-
-	if err := viper.ReadInConfig(); err != nil {
-		// File not found is OK if ENV is set
-		var configFileNotFoundError viper.ConfigFileNotFoundError
-		if !errors.As(err, &configFileNotFoundError) {
-			return fmt.Errorf("%w: %w", errdefs.ErrConfig, err)
-		}
 	}
 
 	return nil

--- a/cmd/kuke/kuke_test.go
+++ b/cmd/kuke/kuke_test.go
@@ -21,8 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -61,7 +59,6 @@ func TestNewKukeCmd(t *testing.T) {
 		t.Errorf("Short mismatch: got %q, want %q", cmd.Short, "Kukeon is a tool for managing Kukeon entities")
 	}
 
-	// Verify subcommands are added
 	expectedSubcommands := []string{"init", "create", "get", "delete", "start", "stop", "kill", "purge", "version"}
 	for _, subcmdName := range expectedSubcommands {
 		subcmd := cmd.Commands()
@@ -85,99 +82,26 @@ func TestNewKukeCmdPersistentPreRunE(t *testing.T) {
 		name        string
 		verbose     bool
 		logLevel    string
-		configSetup func() error
 		loader      kuke.ConfigLoader
 		wantErr     bool
 		wantErrMsg  string
 		checkLogger bool
 	}{
+		{name: "verbose disabled", verbose: false, checkLogger: false},
+		{name: "verbose enabled with default log level", verbose: true, checkLogger: true},
+		{name: "verbose enabled with debug log level", verbose: true, logLevel: "debug", checkLogger: true},
+		{name: "verbose enabled with info log level", verbose: true, logLevel: "info", checkLogger: true},
+		{name: "verbose enabled with warn log level", verbose: true, logLevel: "warn", checkLogger: true},
+		{name: "verbose enabled with error log level", verbose: true, logLevel: "error", checkLogger: true},
 		{
-			name:     "verbose disabled",
-			verbose:  false,
-			logLevel: "",
-			configSetup: func() error {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				return nil
-			},
-			loader:      nil, // Use real loader
-			wantErr:     false,
-			checkLogger: false,
-		},
-		{
-			name:     "verbose enabled with default log level",
-			verbose:  true,
-			logLevel: "",
-			configSetup: func() error {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				return nil
-			},
-			loader:      nil, // Use real loader
-			wantErr:     false,
-			checkLogger: true,
-		},
-		{
-			name:     "verbose enabled with debug log level",
-			verbose:  true,
-			logLevel: "debug",
-			configSetup: func() error {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				return nil
-			},
-			loader:      nil, // Use real loader
-			wantErr:     false,
-			checkLogger: true,
-		},
-		{
-			name:     "verbose enabled with info log level",
-			verbose:  true,
-			logLevel: "info",
-			configSetup: func() error {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				return nil
-			},
-			loader:      nil, // Use real loader
-			wantErr:     false,
-			checkLogger: true,
-		},
-		{
-			name:     "verbose enabled with warn log level",
-			verbose:  true,
-			logLevel: "warn",
-			configSetup: func() error {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				return nil
-			},
-			loader:      nil, // Use real loader
-			wantErr:     false,
-			checkLogger: true,
-		},
-		{
-			name:     "verbose enabled with error log level",
-			verbose:  true,
-			logLevel: "error",
-			configSetup: func() error {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				return nil
-			},
-			loader:      nil, // Use real loader
-			wantErr:     false,
-			checkLogger: true,
-		},
-		{
-			name:     "config loading error",
-			verbose:  false,
-			logLevel: "",
-			configSetup: func() error {
-				return nil
-			},
+			name: "config loading error",
 			loader: &fakeConfigLoader{
 				loadConfigFn: func() error {
 					return fmt.Errorf("config error: %w", errdefs.ErrConfig)
 				},
 			},
-			wantErr:     true,
-			wantErrMsg:  "config error",
-			checkLogger: false,
+			wantErr:    true,
+			wantErrMsg: "config error",
 		},
 	}
 
@@ -189,19 +113,12 @@ func TestNewKukeCmdPersistentPreRunE(t *testing.T) {
 				viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, tt.logLevel)
 			}
 
-			if tt.configSetup != nil {
-				if err := tt.configSetup(); err != nil {
-					t.Fatalf("configSetup() error = %v", err)
-				}
-			}
-
 			cmd, err := kuke.NewKukeCmd()
 			if err != nil {
 				t.Fatalf("NewKukeCmd() error = %v", err)
 			}
 
 			ctx := context.Background()
-			// Inject mock config loader via context if provided
 			if tt.loader != nil {
 				ctx = context.WithValue(ctx, kuke.MockConfigLoaderKey{}, tt.loader)
 			}
@@ -223,19 +140,16 @@ func TestNewKukeCmdPersistentPreRunE(t *testing.T) {
 				t.Fatalf("PersistentPreRunE() error = %v, want nil", err)
 			}
 
+			logger := cmd.Context().Value(types.CtxLogger)
 			if tt.checkLogger {
-				logger := cmd.Context().Value(types.CtxLogger)
 				if logger == nil {
 					t.Error("logger not found in context when verbose is enabled")
 				}
 				if _, ok := logger.(*slog.Logger); !ok {
 					t.Errorf("logger type mismatch: got %T, want *slog.Logger", logger)
 				}
-			} else {
-				logger := cmd.Context().Value(types.CtxLogger)
-				if logger != nil {
-					t.Error("logger found in context when verbose is disabled")
-				}
+			} else if logger != nil {
+				t.Error("logger found in context when verbose is disabled")
 			}
 		})
 	}
@@ -250,7 +164,6 @@ func TestSetupKukeCmd(t *testing.T) {
 		t.Fatalf("setupKukeCmd() error = %v, want nil", err)
 	}
 
-	// Verify subcommands are added
 	expectedSubcommands := []string{"init", "create", "get", "delete", "start", "stop", "kill", "purge", "version"}
 	commands := rootCmd.Commands()
 	commandMap := make(map[string]bool)
@@ -264,87 +177,65 @@ func TestSetupKukeCmd(t *testing.T) {
 		}
 	}
 
-	// Verify persistent flags exist
-	persistentFlags := []string{"run-path", "config", "containerd-socket", "verbose", "log-level"}
+	persistentFlags := []string{"run-path", "containerd-socket", "verbose", "log-level"}
 	for _, flagName := range persistentFlags {
 		flag := rootCmd.PersistentFlags().Lookup(flagName)
 		if flag == nil {
 			t.Errorf("persistent flag %q not found", flagName)
 		}
 	}
+
+	if rootCmd.PersistentFlags().Lookup("config") != nil {
+		t.Errorf("persistent flag %q must not be present (removed in favor of `kukeond --configuration`)", "config")
+	}
 }
 
 func TestSetPersistentLoggingFlags(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
-	tests := []struct {
-		name    string
-		rootCmd *cobra.Command
-		wantErr bool
-	}{
-		{
-			name:    "success",
-			rootCmd: &cobra.Command{Use: "test"},
-			wantErr: false,
-		},
+	rootCmd := &cobra.Command{Use: "test"}
+	if err := kuke.SetPersistentLoggingFlags(rootCmd); err != nil {
+		t.Fatalf("SetPersistentLoggingFlags() error = %v, want nil", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := kuke.SetPersistentLoggingFlags(tt.rootCmd)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("setPersistentLoggingFlags() error = %v, wantErr %v", err, tt.wantErr)
+	expectedFlags := []struct {
+		name         string
+		viperKey     string
+		defaultValue string
+	}{
+		{"run-path", config.KUKEON_ROOT_RUN_PATH.ViperKey, "/opt/kukeon"},
+		{
+			"containerd-socket",
+			config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey,
+			"/run/containerd/containerd.sock",
+		},
+		{"verbose", config.KUKEON_ROOT_VERBOSE.ViperKey, "false"},
+		{"log-level", config.KUKEON_ROOT_LOG_LEVEL.ViperKey, ""},
+	}
+
+	for _, flag := range expectedFlags {
+		f := rootCmd.PersistentFlags().Lookup(flag.name)
+		if f == nil {
+			t.Errorf("flag %q not found", flag.name)
+			continue
+		}
+
+		if flag.name == "verbose" {
+			if err := rootCmd.PersistentFlags().Set(flag.name, "true"); err != nil {
+				t.Fatalf("failed to set flag %q: %v", flag.name, err)
 			}
-
-			if !tt.wantErr {
-				// Verify all flags are defined
-				expectedFlags := []struct {
-					name         string
-					viperKey     string
-					defaultValue string
-				}{
-					{"run-path", config.KUKEON_ROOT_RUN_PATH.ViperKey, "/opt/kukeon"},
-					{"config", config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "/etc/kukeon/config.yaml"},
-					{
-						"containerd-socket",
-						config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey,
-						"/run/containerd/containerd.sock",
-					},
-					{"verbose", config.KUKEON_ROOT_VERBOSE.ViperKey, "false"},
-					{"log-level", config.KUKEON_ROOT_LOG_LEVEL.ViperKey, ""},
-				}
-
-				for _, flag := range expectedFlags {
-					f := tt.rootCmd.PersistentFlags().Lookup(flag.name)
-					if f == nil {
-						t.Errorf("flag %q not found", flag.name)
-						continue
-					}
-
-					// Test viper binding
-					if flag.name == "verbose" {
-						err = tt.rootCmd.PersistentFlags().Set(flag.name, "true")
-						if err != nil {
-							t.Fatalf("failed to set flag %q: %v", flag.name, err)
-						}
-						got := viper.GetBool(flag.viperKey)
-						if !got {
-							t.Errorf("viper binding mismatch for %q: got %v, want true", flag.name, got)
-						}
-					} else {
-						testValue := "test-value"
-						err = tt.rootCmd.PersistentFlags().Set(flag.name, testValue)
-						if err != nil {
-							t.Fatalf("failed to set flag %q: %v", flag.name, err)
-						}
-						got := viper.GetString(flag.viperKey)
-						if got != testValue {
-							t.Errorf("viper binding mismatch for %q: got %q, want %q", flag.name, got, testValue)
-						}
-					}
-				}
+			if !viper.GetBool(flag.viperKey) {
+				t.Errorf("viper binding mismatch for %q: got false, want true", flag.name)
 			}
-		})
+		} else {
+			testValue := "test-value"
+			if err := rootCmd.PersistentFlags().Set(flag.name, testValue); err != nil {
+				t.Fatalf("failed to set flag %q: %v", flag.name, err)
+			}
+			if got := viper.GetString(flag.viperKey); got != testValue {
+				t.Errorf("viper binding mismatch for %q: got %q, want %q", flag.name, got, testValue)
+			}
+		}
 	}
 }
 
@@ -352,158 +243,43 @@ func TestSetFlags(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
 	rootCmd := &cobra.Command{Use: "test"}
-	err := kuke.SetFlags(rootCmd)
-	if err != nil {
+	if err := kuke.SetFlags(rootCmd); err != nil {
 		t.Errorf("setFlags() error = %v, want nil", err)
 	}
 }
 
-func TestLoadConfig(t *testing.T) {
+func TestLoadConfigDefaults(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
-	tests := []struct {
-		name          string
-		setup         func(t *testing.T) (string, error)
-		cleanup       func(string) error
-		wantErr       bool
-		wantErrMsg    string
-		checkRunPath  bool
-		checkLogLevel bool
-	}{
-		{
-			name: "empty config file uses default",
-			setup: func(_ *testing.T) (string, error) {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "")
-				return "", nil
-			},
-			cleanup:       func(string) error { return nil },
-			wantErr:       false,
-			checkRunPath:  true,
-			checkLogLevel: true,
-		},
-		{
-			name: "set config file is used",
-			setup: func(t *testing.T) (string, error) {
-				tmpDir := t.TempDir()
-				configFile := filepath.Join(tmpDir, "config.yaml")
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, configFile)
-				viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "/custom/run/path")
-				return tmpDir, nil
-			},
-			cleanup:       func(string) error { return nil },
-			wantErr:       false,
-			checkRunPath:  true,
-			checkLogLevel: true,
-		},
-		{
-			name: "config file not found is acceptable",
-			setup: func(_ *testing.T) (string, error) {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "/nonexistent/path/config.yaml")
-				viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "")
-				return "", nil
-			},
-			cleanup:       func(string) error { return nil },
-			wantErr:       false,
-			checkRunPath:  true,
-			checkLogLevel: true,
-		},
-		{
-			name: "valid config file with yaml content",
-			setup: func(t *testing.T) (string, error) {
-				tmpDir := t.TempDir()
-				configFile := filepath.Join(tmpDir, "config.yaml")
-				configContent := `kukeon:
-  runPath: /custom/run/path
-  logLevel: debug
-`
-				if err := os.WriteFile(configFile, []byte(configContent), 0o644); err != nil {
-					return "", err
-				}
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, configFile)
-				viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "")
-				return tmpDir, nil
-			},
-			cleanup:       func(string) error { return nil },
-			wantErr:       false,
-			checkRunPath:  true,
-			checkLogLevel: true,
-		},
-		{
-			name: "run path from viper",
-			setup: func(_ *testing.T) (string, error) {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "/custom/run/path")
-				return "", nil
-			},
-			cleanup:       func(string) error { return nil },
-			wantErr:       false,
-			checkRunPath:  true,
-			checkLogLevel: true,
-		},
-		{
-			name: "log level default is set",
-			setup: func(_ *testing.T) (string, error) {
-				viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-				viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "")
-				viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, "")
-				return "", nil
-			},
-			cleanup:       func(string) error { return nil },
-			wantErr:       false,
-			checkRunPath:  true,
-			checkLogLevel: true,
-		},
+	viper.Reset()
+	if err := kuke.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			viper.Reset()
+	if got := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey); got == "" {
+		t.Error("LoadConfig did not set a default run path")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got == "" {
+		t.Error("LoadConfig did not set a default log level")
+	}
+}
 
-			tmpDir, err := tt.setup(t)
-			if err != nil {
-				t.Fatalf("setup() error = %v", err)
-			}
-			defer func() {
-				if cleanupErr := tt.cleanup(tmpDir); cleanupErr != nil {
-					t.Logf("cleanup() error = %v", cleanupErr)
-				}
-			}()
+func TestLoadConfigPreservesExplicitValues(t *testing.T) {
+	t.Cleanup(viper.Reset)
 
-			err = kuke.LoadConfig()
+	viper.Reset()
+	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "/custom/run/path")
+	viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, "debug")
 
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("LoadConfig() error = nil, want error containing %q", tt.wantErrMsg)
-				}
-				if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
-					t.Fatalf("LoadConfig() error = %q, want error containing %q", err.Error(), tt.wantErrMsg)
-				}
-				return
-			}
+	if err := kuke.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
 
-			if err != nil {
-				t.Fatalf("LoadConfig() error = %v, want nil", err)
-			}
-
-			if tt.checkRunPath {
-				runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
-				if runPath == "" {
-					t.Error("run path is empty after LoadConfig")
-				}
-			}
-
-			if tt.checkLogLevel {
-				logLevel := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey)
-				if logLevel == "" {
-					// Check if default was set
-					logLevel = config.KUKEON_ROOT_LOG_LEVEL.ValueOrDefault()
-				}
-				if logLevel == "" {
-					t.Error("log level is empty after LoadConfig")
-				}
-			}
-		})
+	if got := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey); got != "/custom/run/path" {
+		t.Errorf("RunPath: got %q, want %q", got, "/custom/run/path")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "debug" {
+		t.Errorf("LogLevel: got %q, want %q", got, "debug")
 	}
 }
 
@@ -522,50 +298,8 @@ func TestNewKukeCmdRun(t *testing.T) {
 	cmd.SetArgs([]string{})
 	cmd.Run(cmd, []string{})
 
-	output := outBuf.String()
-	if !strings.Contains(output, "kuke") {
-		t.Errorf("Run() output missing 'kuke'. Got: %q", output)
-	}
-}
-
-func TestNewKukeCmdWithConfigError(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	// This test verifies that setupKukeCmd errors are properly handled
-	// Since setupKukeCmd doesn't currently return errors in normal cases,
-	// we'll test the error path by ensuring the function handles nil subcommands
-	// (though this shouldn't happen in practice)
-
-	cmd, err := kuke.NewKukeCmd()
-	if err != nil {
-		t.Fatalf("NewKukeCmd() error = %v, want nil", err)
-	}
-
-	if cmd == nil {
-		t.Fatal("NewKukeCmd() returned nil command")
-	}
-}
-
-func TestPersistentPreRunEWithConfigError(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	cmd, err := kuke.NewKukeCmd()
-	if err != nil {
-		t.Fatalf("NewKukeCmd() error = %v", err)
-	}
-
-	// Set up a scenario where LoadConfig might fail
-	// We'll use an invalid config file that causes a non-ConfigFileNotFoundError
-	// This is hard to simulate, so we'll test the file not found case which is acceptable
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "/nonexistent/path/config.yaml")
-	viper.Set(config.KUKEON_ROOT_VERBOSE.ViperKey, false)
-
-	ctx := context.Background()
-	cmd.SetContext(ctx)
-
-	err = cmd.PersistentPreRunE(cmd, []string{})
-	if err != nil {
-		t.Fatalf("PersistentPreRunE() error = %v, want nil (file not found is acceptable)", err)
+	if !strings.Contains(outBuf.String(), "kuke") {
+		t.Errorf("Run() output missing 'kuke'. Got: %q", outBuf.String())
 	}
 }
 
@@ -579,131 +313,28 @@ func TestPersistentPreRunELoggerContext(t *testing.T) {
 
 	viper.Set(config.KUKEON_ROOT_VERBOSE.ViperKey, true)
 	viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, "debug")
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
 
 	ctx := context.Background()
 	cmd.SetContext(ctx)
 
-	err = cmd.PersistentPreRunE(cmd, []string{})
-	if err != nil {
+	if err = cmd.PersistentPreRunE(cmd, []string{}); err != nil {
 		t.Fatalf("PersistentPreRunE() error = %v, want nil", err)
 	}
 
-	// Verify logger is in context
-	logger := cmd.Context().Value(types.CtxLogger)
-	if logger == nil {
+	if logger := cmd.Context().Value(types.CtxLogger); logger == nil {
 		t.Fatal("logger not found in context")
-	}
-	if _, ok := logger.(*slog.Logger); !ok {
+	} else if _, ok := logger.(*slog.Logger); !ok {
 		t.Errorf("logger type mismatch: got %T, want *slog.Logger", logger)
 	}
-
-	// Verify levelVar is in context
-	levelVar := cmd.Context().Value(types.CtxLevelVar)
-	if levelVar == nil {
+	if levelVar := cmd.Context().Value(types.CtxLevelVar); levelVar == nil {
 		t.Fatal("levelVar not found in context")
 	}
-
-	// Verify handler is in context
-	handler := cmd.Context().Value(types.CtxHandler)
-	if handler == nil {
+	if handler := cmd.Context().Value(types.CtxHandler); handler == nil {
 		t.Fatal("handler not found in context")
 	}
 }
 
-func TestLoadConfigEnvironmentBinding(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	// Test that environment variables are bound
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "")
-
-	err := kuke.LoadConfig()
-	if err != nil {
-		t.Fatalf("LoadConfig() error = %v, want nil", err)
-	}
-
-	// Verify environment binding was attempted (we can't easily test the actual binding
-	// without setting environment variables, but we can verify the function completes)
-}
-
-func TestSetPersistentLoggingFlagsViperBinding(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	rootCmd := &cobra.Command{Use: "test"}
-	err := kuke.SetPersistentLoggingFlags(rootCmd)
-	if err != nil {
-		t.Fatalf("SetPersistentLoggingFlags() error = %v, want nil", err)
-	}
-
-	// Test that flags are bound to viper by setting values and checking viper
-	testCases := []struct {
-		flagName  string
-		flagValue string
-		viperKey  string
-	}{
-		{"run-path", "/test/run/path", config.KUKEON_ROOT_RUN_PATH.ViperKey},
-		{"config", "/test/config.yaml", config.KUKEON_ROOT_CONFIG_FILE.ViperKey},
-		{"containerd-socket", "/test/containerd.sock", config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey},
-		{"log-level", "debug", config.KUKEON_ROOT_LOG_LEVEL.ViperKey},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.flagName, func(t *testing.T) {
-			setErr := rootCmd.PersistentFlags().Set(tc.flagName, tc.flagValue)
-			if setErr != nil {
-				t.Fatalf("failed to set flag %q: %v", tc.flagName, setErr)
-			}
-			got := viper.GetString(tc.viperKey)
-			if got != tc.flagValue {
-				t.Errorf("viper binding mismatch: got %q, want %q", got, tc.flagValue)
-			}
-		})
-	}
-
-	// Test verbose flag separately (it's a bool)
-	err = rootCmd.PersistentFlags().Set("verbose", "true")
-	if err != nil {
-		t.Fatalf("failed to set verbose flag: %v", err)
-	}
-	got := viper.GetBool(config.KUKEON_ROOT_VERBOSE.ViperKey)
-	if !got {
-		t.Errorf("viper binding mismatch for verbose: got %v, want true", got)
-	}
-}
-
-func TestLoadConfigWithValidYAML(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	tmpDir := t.TempDir()
-
-	configFile := filepath.Join(tmpDir, "config.yaml")
-	configContent := `kukeon:
-  runPath: /test/run/path
-  logLevel: warn
-  containerd:
-    socket: /test/containerd.sock
-`
-	var err error
-	err = os.WriteFile(configFile, []byte(configContent), 0o644)
-	if err != nil {
-		t.Fatalf("failed to write config file: %v", err)
-	}
-
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, configFile)
-	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "")
-
-	err = kuke.LoadConfig()
-	if err != nil {
-		t.Fatalf("LoadConfig() error = %v, want nil", err)
-	}
-
-	// Verify config was read (viper should have the values)
-	// Note: The actual structure depends on how viper is configured
-	// We mainly verify that ReadInConfig didn't fail
-}
-
-func TestPersistentPreRunEWithLoggerDebugCall(t *testing.T) {
+func TestPersistentPreRunEConfigErrorWrapping(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
 	cmd, err := kuke.NewKukeCmd()
@@ -711,31 +342,22 @@ func TestPersistentPreRunEWithLoggerDebugCall(t *testing.T) {
 		t.Fatalf("NewKukeCmd() error = %v", err)
 	}
 
-	viper.Set(config.KUKEON_ROOT_VERBOSE.ViperKey, true)
-	viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, "debug")
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
+	loader := &fakeConfigLoader{
+		loadConfigFn: func() error {
+			return fmt.Errorf("synthetic load error: %w", errdefs.ErrConfig)
+		},
+	}
 
-	// Capture stderr to verify debug logging
-	oldStderr := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), kuke.MockConfigLoaderKey{}, kuke.ConfigLoader(loader))
 	cmd.SetContext(ctx)
 
 	err = cmd.PersistentPreRunE(cmd, []string{})
-	if err != nil {
-		t.Fatalf("PersistentPreRunE() error = %v, want nil", err)
+	if err == nil {
+		t.Fatalf("PersistentPreRunE() error = nil, want error wrapping ErrConfig")
 	}
-
-	// Restore stderr
-	w.Close()
-	os.Stderr = oldStderr
-
-	// Read captured output (we don't assert on it, just verify it doesn't crash)
-	output := make([]byte, 1024)
-	_, _ = r.Read(output)
-	r.Close()
+	if !errors.Is(err, errdefs.ErrConfig) {
+		t.Errorf("PersistentPreRunE() error = %v, want error wrapping %v", err, errdefs.ErrConfig)
+	}
 }
 
 func TestNewKukeCmdSubcommandStructure(t *testing.T) {
@@ -751,7 +373,6 @@ func TestNewKukeCmdSubcommandStructure(t *testing.T) {
 		t.Fatal("no subcommands found")
 	}
 
-	// Verify each subcommand is a valid cobra.Command
 	for _, subcmd := range commands {
 		if subcmd == nil {
 			t.Error("found nil subcommand")
@@ -763,100 +384,39 @@ func TestNewKukeCmdSubcommandStructure(t *testing.T) {
 	}
 }
 
-func TestLoadConfigDefaultConfigFile(t *testing.T) {
+func TestSetPersistentLoggingFlagsViperBinding(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "")
-
-	err := kuke.LoadConfig()
-	if err != nil {
-		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	rootCmd := &cobra.Command{Use: "test"}
+	if err := kuke.SetPersistentLoggingFlags(rootCmd); err != nil {
+		t.Fatalf("SetPersistentLoggingFlags() error = %v, want nil", err)
 	}
 
-	// Verify that default config file path was set
-	// The actual path depends on DefaultConfigFile() implementation
-	// We mainly verify the function completes without error
-}
-
-func TestLoadConfigDefaultRunPath(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "")
-
-	err := kuke.LoadConfig()
-	if err != nil {
-		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	testCases := []struct {
+		flagName  string
+		flagValue string
+		viperKey  string
+	}{
+		{"run-path", "/test/run/path", config.KUKEON_ROOT_RUN_PATH.ViperKey},
+		{"containerd-socket", "/test/containerd.sock", config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey},
+		{"log-level", "debug", config.KUKEON_ROOT_LOG_LEVEL.ViperKey},
 	}
 
-	// Verify that default run path was set
-	runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
-	if runPath == "" {
-		t.Error("run path is empty after LoadConfig with empty viper value")
+	for _, tc := range testCases {
+		t.Run(tc.flagName, func(t *testing.T) {
+			if err := rootCmd.PersistentFlags().Set(tc.flagName, tc.flagValue); err != nil {
+				t.Fatalf("failed to set flag %q: %v", tc.flagName, err)
+			}
+			if got := viper.GetString(tc.viperKey); got != tc.flagValue {
+				t.Errorf("viper binding mismatch: got %q, want %q", got, tc.flagValue)
+			}
+		})
 	}
 
-	// Check that it matches the default
-	defaultRunPath := config.DefaultRunPath()
-	// The run path might be set via environment or default, so we just verify it's not empty
-	if runPath == "" && defaultRunPath != "" {
-		t.Errorf("run path not set to default: got %q, want non-empty", runPath)
+	if err := rootCmd.PersistentFlags().Set("verbose", "true"); err != nil {
+		t.Fatalf("failed to set verbose flag: %v", err)
 	}
-}
-
-func TestPersistentPreRunEConfigErrorWrapping(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	cmd, err := kuke.NewKukeCmd()
-	if err != nil {
-		t.Fatalf("NewKukeCmd() error = %v", err)
-	}
-
-	viper.Set(config.KUKEON_ROOT_VERBOSE.ViperKey, false)
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-
-	// Create a scenario where LoadConfig would fail
-	// Since LoadConfig handles ConfigFileNotFoundError gracefully,
-	// we need to test a different error scenario
-	// For now, we'll test that the error wrapping works correctly
-	// by ensuring the function properly handles errors
-
-	ctx := context.Background()
-	cmd.SetContext(ctx)
-
-	err = cmd.PersistentPreRunE(cmd, []string{})
-	if err != nil {
-		// Check that error is wrapped with ErrConfig
-		if !errors.Is(err, errdefs.ErrConfig) {
-			t.Errorf("PersistentPreRunE() error = %v, want error wrapping %v", err, errdefs.ErrConfig)
-		}
-	}
-}
-
-// Helper function to create a test command with logger.
-func TestPersistentPreRunEWithNilLogger(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	cmd, err := kuke.NewKukeCmd()
-	if err != nil {
-		t.Fatalf("NewKukeCmd() error = %v", err)
-	}
-
-	viper.Set(config.KUKEON_ROOT_VERBOSE.ViperKey, false)
-	viper.Set(config.KUKEON_ROOT_CONFIG_FILE.ViperKey, "")
-
-	ctx := context.Background()
-	cmd.SetContext(ctx)
-
-	// When verbose is false, logger should be nil
-	err = cmd.PersistentPreRunE(cmd, []string{})
-	if err != nil {
-		t.Fatalf("PersistentPreRunE() error = %v, want nil", err)
-	}
-
-	// Verify logger is not set when verbose is false
-	logger := cmd.Context().Value(types.CtxLogger)
-	if logger != nil {
-		t.Error("logger found in context when verbose is disabled")
+	if !viper.GetBool(config.KUKEON_ROOT_VERBOSE.ViperKey) {
+		t.Errorf("viper binding mismatch for verbose: got false, want true")
 	}
 }

--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -20,6 +20,7 @@ package kukeond
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/internal/serverconfig"
@@ -122,25 +123,35 @@ func NewKukeondCmd() (*cobra.Command, error) {
 }
 
 // applyServerConfiguration layers the loaded ServerConfiguration on top of
-// viper for fields the operator did not explicitly set on the command line.
-// Order of precedence: explicit `--flag` > env > ServerConfiguration > flag
-// default. Skipping fields whose flag was changed lets the operator keep
-// per-invocation overrides without editing the on-disk document.
+// viper for fields the operator did not explicitly set on the command line
+// or via environment. Order of precedence: explicit `--flag` > env >
+// ServerConfiguration > flag default. The flag check skips fields whose
+// `--flag` was changed; the env check skips fields whose env var is set —
+// without it, `viper.Set` would override viper's env binding and silently
+// invert env > YAML.
 func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurationSpec) {
 	flags := cmd.PersistentFlags()
-	if spec.Socket != "" && !flags.Changed("socket") {
+	if spec.Socket != "" && !flags.Changed("socket") && !envSet(config.KUKEOND_SOCKET) {
 		viper.Set(config.KUKEOND_SOCKET.ViperKey, spec.Socket)
 	}
-	if spec.SocketGID != 0 && !flags.Changed("socket-gid") {
+	if spec.SocketGID != 0 && !flags.Changed("socket-gid") && !envSet(config.KUKEOND_SOCKET_GID) {
 		viper.Set(config.KUKEOND_SOCKET_GID.ViperKey, spec.SocketGID)
 	}
-	if spec.RunPath != "" && !flags.Changed("run-path") {
+	if spec.RunPath != "" && !flags.Changed("run-path") && !envSet(config.KUKEON_ROOT_RUN_PATH) {
 		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, spec.RunPath)
 	}
-	if spec.ContainerdSocket != "" && !flags.Changed("containerd-socket") {
+	if spec.ContainerdSocket != "" && !flags.Changed("containerd-socket") &&
+		!envSet(config.KUKEON_ROOT_CONTAINERD_SOCKET) {
 		viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, spec.ContainerdSocket)
 	}
-	if spec.LogLevel != "" && !flags.Changed("log-level") {
+	if spec.LogLevel != "" && !flags.Changed("log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
 	}
+}
+
+// envSet reports whether the OS env var backing v is present (any value,
+// including empty string, counts as set — same semantics as viper's BindEnv).
+func envSet(v config.Var) bool {
+	_, ok := os.LookupEnv(v.EnvVar())
+	return ok
 }

--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -19,7 +19,11 @@
 package kukeond
 
 import (
+	"fmt"
+
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/internal/serverconfig"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -31,6 +35,29 @@ func NewKukeondCmd() (*cobra.Command, error) {
 		Short:         "Kukeon daemon: hosts the kukeonv1 API over a unix socket",
 		SilenceUsage:  true,
 		SilenceErrors: false,
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			path := viper.GetString(config.KUKEOND_CONFIGURATION.ViperKey)
+			if path == "" {
+				path = config.DefaultServerConfigurationFile()
+			}
+			doc, err := serverconfig.Load(path)
+			if err != nil {
+				return fmt.Errorf("load server configuration: %w", err)
+			}
+			applyServerConfiguration(cmd, doc.Spec)
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().String(
+		"configuration", config.KUKEOND_CONFIGURATION.Default,
+		"Path to a ServerConfiguration YAML; absent file uses hardcoded defaults",
+	)
+	if err := viper.BindPFlag(
+		config.KUKEOND_CONFIGURATION.ViperKey,
+		cmd.PersistentFlags().Lookup("configuration"),
+	); err != nil {
+		return nil, err
 	}
 
 	cmd.PersistentFlags().String(
@@ -92,4 +119,28 @@ func NewKukeondCmd() (*cobra.Command, error) {
 
 	cmd.AddCommand(newServeCmd())
 	return cmd, nil
+}
+
+// applyServerConfiguration layers the loaded ServerConfiguration on top of
+// viper for fields the operator did not explicitly set on the command line.
+// Order of precedence: explicit `--flag` > env > ServerConfiguration > flag
+// default. Skipping fields whose flag was changed lets the operator keep
+// per-invocation overrides without editing the on-disk document.
+func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurationSpec) {
+	flags := cmd.PersistentFlags()
+	if spec.Socket != "" && !flags.Changed("socket") {
+		viper.Set(config.KUKEOND_SOCKET.ViperKey, spec.Socket)
+	}
+	if spec.SocketGID != 0 && !flags.Changed("socket-gid") {
+		viper.Set(config.KUKEOND_SOCKET_GID.ViperKey, spec.SocketGID)
+	}
+	if spec.RunPath != "" && !flags.Changed("run-path") {
+		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, spec.RunPath)
+	}
+	if spec.ContainerdSocket != "" && !flags.Changed("containerd-socket") {
+		viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, spec.ContainerdSocket)
+	}
+	if spec.LogLevel != "" && !flags.Changed("log-level") {
+		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
+	}
 }

--- a/cmd/kukeond/kukeond_test.go
+++ b/cmd/kukeond/kukeond_test.go
@@ -24,6 +24,21 @@ import (
 	"github.com/spf13/viper"
 )
 
+func bindKukeondEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []config.Var{
+		config.KUKEOND_SOCKET,
+		config.KUKEOND_SOCKET_GID,
+		config.KUKEON_ROOT_RUN_PATH,
+		config.KUKEON_ROOT_CONTAINERD_SOCKET,
+		config.KUKEON_ROOT_LOG_LEVEL,
+	} {
+		if err := v.BindEnv(); err != nil {
+			t.Fatalf("BindEnv %s: %v", v.EnvVar(), err)
+		}
+	}
+}
+
 func TestNewKukeondCmdHasConfigurationFlag(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
@@ -90,6 +105,42 @@ func TestApplyServerConfigurationFlagOverridesConfig(t *testing.T) {
 
 	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon/from-flag.sock" {
 		t.Errorf("Socket flag override lost: got %q, want %q", got, "/run/kukeon/from-flag.sock")
+	}
+}
+
+func TestApplyServerConfigurationEnvOverridesConfig(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeondCmd()
+	if err != nil {
+		t.Fatalf("NewKukeondCmd() error = %v", err)
+	}
+	bindKukeondEnv(t)
+
+	// Operator exported KUKEOND_SOCKET; the on-disk ServerConfiguration must
+	// not clobber it. Documents the precedence order in the PR description:
+	// --flag > env > ServerConfiguration > default.
+	t.Setenv(config.KUKEOND_SOCKET.EnvVar(), "/run/kukeon/from-env.sock")
+	t.Setenv(config.KUKEON_ROOT_LOG_LEVEL.EnvVar(), "debug")
+
+	spec := v1beta1.ServerConfigurationSpec{
+		Socket:   "/run/kukeon/from-config.sock",
+		LogLevel: "warn",
+		RunPath:  "/opt/kukeon-from-config",
+	}
+	applyServerConfiguration(cmd, spec)
+
+	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon/from-env.sock" {
+		t.Errorf("Socket env override lost: got %q, want %q", got, "/run/kukeon/from-env.sock")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "debug" {
+		t.Errorf("LogLevel env override lost: got %q, want %q", got, "debug")
+	}
+	// Field with no env var set still picks up the ServerConfiguration value —
+	// the env check is per-field, not all-or-nothing.
+	if got := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey); got != "/opt/kukeon-from-config" {
+		t.Errorf("RunPath: got %q, want %q", got, "/opt/kukeon-from-config")
 	}
 }
 

--- a/cmd/kukeond/kukeond_test.go
+++ b/cmd/kukeond/kukeond_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kukeond
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+func TestNewKukeondCmdHasConfigurationFlag(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd, err := NewKukeondCmd()
+	if err != nil {
+		t.Fatalf("NewKukeondCmd() error = %v", err)
+	}
+	if flag := cmd.PersistentFlags().Lookup("configuration"); flag == nil {
+		t.Fatal("--configuration persistent flag not found")
+	}
+}
+
+func TestApplyServerConfigurationDefaultsLayered(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeondCmd()
+	if err != nil {
+		t.Fatalf("NewKukeondCmd() error = %v", err)
+	}
+
+	spec := v1beta1.ServerConfigurationSpec{
+		Socket:           "/run/kukeon/from-config.sock",
+		SocketGID:        4242,
+		RunPath:          "/opt/kukeon-from-config",
+		ContainerdSocket: "/run/containerd/from-config.sock",
+		LogLevel:         "warn",
+	}
+	applyServerConfiguration(cmd, spec)
+
+	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != spec.Socket {
+		t.Errorf("Socket: got %q, want %q", got, spec.Socket)
+	}
+	if got := viper.GetInt(config.KUKEOND_SOCKET_GID.ViperKey); got != spec.SocketGID {
+		t.Errorf("SocketGID: got %d, want %d", got, spec.SocketGID)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey); got != spec.RunPath {
+		t.Errorf("RunPath: got %q, want %q", got, spec.RunPath)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey); got != spec.ContainerdSocket {
+		t.Errorf("ContainerdSocket: got %q, want %q", got, spec.ContainerdSocket)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != spec.LogLevel {
+		t.Errorf("LogLevel: got %q, want %q", got, spec.LogLevel)
+	}
+}
+
+func TestApplyServerConfigurationFlagOverridesConfig(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeondCmd()
+	if err != nil {
+		t.Fatalf("NewKukeondCmd() error = %v", err)
+	}
+	// Operator passed --socket on the command line; the config file's value
+	// must not clobber it.
+	if setErr := cmd.PersistentFlags().Set("socket", "/run/kukeon/from-flag.sock"); setErr != nil {
+		t.Fatalf("set --socket: %v", setErr)
+	}
+
+	spec := v1beta1.ServerConfigurationSpec{Socket: "/run/kukeon/from-config.sock"}
+	applyServerConfiguration(cmd, spec)
+
+	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon/from-flag.sock" {
+		t.Errorf("Socket flag override lost: got %q, want %q", got, "/run/kukeon/from-flag.sock")
+	}
+}
+
+func TestApplyServerConfigurationEmptyFieldsLeaveViperUntouched(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeondCmd()
+	if err != nil {
+		t.Fatalf("NewKukeondCmd() error = %v", err)
+	}
+	viper.Set(config.KUKEOND_SOCKET.ViperKey, "/run/kukeon/preexisting.sock")
+
+	applyServerConfiguration(cmd, v1beta1.ServerConfigurationSpec{})
+
+	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon/preexisting.sock" {
+		t.Errorf("empty spec must not overwrite existing viper value: got %q", got)
+	}
+}

--- a/docs/kukeond.yaml
+++ b/docs/kukeond.yaml
@@ -1,0 +1,28 @@
+# kukeond ServerConfiguration example.
+#
+# Drop this file at /etc/kukeon/kukeond.yaml (the default --configuration path)
+# to seed the daemon's defaults, or pass --configuration <path> explicitly.
+# Each spec field is optional: an absent value falls back to the daemon's
+# hardcoded default. Explicit `--socket`, `--run-path`, etc. on the command
+# line still override values from this document.
+apiVersion: v1beta1
+kind: ServerConfiguration
+metadata:
+  name: default
+spec:
+  # Unix socket the daemon listens on.
+  socket: /run/kukeon/kukeond.sock
+  # Numeric GID to chown the listener socket to (mode 0o660 with group).
+  # 0 means root-only access. `kuke init` plumbs the kukeon group's GID
+  # in here automatically; only set this manually if you provision the
+  # group yourself.
+  socketGID: 0
+  # kukeon runtime root.
+  runPath: /opt/kukeon
+  # Containerd socket the daemon connects to.
+  containerdSocket: /run/containerd/containerd.sock
+  # Daemon log level: debug, info, warn, error.
+  logLevel: info
+  # Container image `kuke init` provisions for the kukeond system cell.
+  # Read by `kuke init --server-configuration` only; the daemon ignores it.
+  kukeondImage: ghcr.io/eminwux/kukeon:latest

--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -430,8 +430,19 @@ func (b *Exec) bootstrapStack(section *StackSection, realmName, spaceName, stack
 // don't allocate the same IP twice; /opt/cni/cache holds the CNI invocation
 // cache that gives DEL stable arguments — a mismatch leaks veths and IPs
 // across daemon restarts.
-func kukeondCellDoc(image, socketPath, runPath, containerdSocket string, socketGID int) *v1beta1.CellDoc {
+func kukeondCellDoc(
+	image, socketPath, runPath, containerdSocket string,
+	socketGID int,
+	configurationPath string,
+) *v1beta1.CellDoc {
 	args := []string{"serve", "--socket", socketPath}
+	// `kukeond` (the cobra root) processes --configuration in PersistentPreRunE,
+	// so the flag must come before the `serve` subcommand on the cell args. Cobra
+	// is permissive about positional ordering, but listing the persistent flag
+	// first matches what the operator types on the host shell.
+	if configurationPath != "" {
+		args = append([]string{"--configuration", configurationPath}, args...)
+	}
 	if runPath != "" {
 		args = append(args, "--run-path", runPath)
 	}
@@ -458,6 +469,12 @@ func kukeondCellDoc(image, socketPath, runPath, containerdSocket string, socketG
 		ctrdDir := socketDir(containerdSocket)
 		if ctrdDir != sockDir && ctrdDir != runPath {
 			volumes = append(volumes, v1beta1.VolumeMount{Source: ctrdDir, Target: ctrdDir})
+		}
+	}
+	if configurationPath != "" {
+		cfgDir := socketDir(configurationPath)
+		if !volumeContainsTarget(volumes, cfgDir) {
+			volumes = append(volumes, v1beta1.VolumeMount{Source: cfgDir, Target: cfgDir})
 		}
 	}
 
@@ -539,6 +556,33 @@ func ensureCNIStateDir() error {
 	// idempotent across upgrades.
 	if err := os.Chmod("/var/lib/cni", 0o750); err != nil {
 		return fmt.Errorf("chmod CNI state dir %q: %w", "/var/lib/cni", err)
+	}
+	return nil
+}
+
+// volumeContainsTarget reports whether vols already binds-into target. Used to
+// dedupe overlapping bind-mounts (e.g. /etc/kukeon being the same as another
+// path that the runtime already exposes to the daemon container).
+func volumeContainsTarget(vols []v1beta1.VolumeMount, target string) bool {
+	for _, v := range vols {
+		if v.Target == target {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureServerConfigurationDir creates the parent dir of the ServerConfiguration
+// path so the kukeond cell's bind-mount has a source. The file itself is
+// optional — kukeond's loader treats an absent file as "use defaults" — but
+// the directory must exist for the bind-mount to succeed.
+func ensureServerConfigurationDir(configurationPath string) error {
+	if configurationPath == "" {
+		return nil
+	}
+	dir := socketDir(configurationPath)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create server configuration dir %q: %w", dir, err)
 	}
 	return nil
 }

--- a/internal/controller/bootstrap_test.go
+++ b/internal/controller/bootstrap_test.go
@@ -84,7 +84,7 @@ func TestKukeondCellDocVolumes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := kukeondCellDoc(tc.image, tc.socketPath, tc.runPath, tc.containerdSocket, 0)
+			doc := kukeondCellDoc(tc.image, tc.socketPath, tc.runPath, tc.containerdSocket, 0, "")
 			if len(doc.Spec.Containers) != 1 {
 				t.Fatalf("expected 1 container, got %d", len(doc.Spec.Containers))
 			}
@@ -184,6 +184,69 @@ func TestKukeondCellDocVolumes(t *testing.T) {
 	}
 }
 
+// TestKukeondCellDocConfigurationArg guards the wire that lets kukeond
+// re-read its ServerConfiguration on every restart: the cell args must
+// include `--configuration <path>` and the path's parent directory must
+// be bind-mounted into the cell so the daemon can read the file.
+func TestKukeondCellDocConfigurationArg(t *testing.T) {
+	tests := []struct {
+		name              string
+		configurationPath string
+		wantArg           bool
+		wantVolumeSource  string
+	}{
+		{name: "empty-omits-flag", configurationPath: "", wantArg: false},
+		{
+			name:              "default-path",
+			configurationPath: "/etc/kukeon/kukeond.yaml",
+			wantArg:           true,
+			wantVolumeSource:  "/etc/kukeon",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := kukeondCellDoc(
+				"docker.io/library/kukeon:dev",
+				"/run/kukeon/kukeond.sock",
+				"/opt/kukeon",
+				"/run/containerd/containerd.sock",
+				0,
+				tc.configurationPath,
+			)
+			args := doc.Spec.Containers[0].Args
+			joined := strings.Join(args, " ")
+			has := strings.Contains(joined, "--configuration")
+			if has != tc.wantArg {
+				t.Fatalf("--configuration presence: got %v want %v (args=%v)", has, tc.wantArg, args)
+			}
+			if !tc.wantArg {
+				return
+			}
+			for i, a := range args {
+				if a != "--configuration" {
+					continue
+				}
+				if i+1 >= len(args) || args[i+1] != tc.configurationPath {
+					t.Errorf("--configuration value: got %v want %q", args, tc.configurationPath)
+				}
+				break
+			}
+			var hasVolume bool
+			for _, v := range doc.Spec.Containers[0].Volumes {
+				if v.Source == tc.wantVolumeSource && v.Target == tc.wantVolumeSource {
+					hasVolume = true
+					break
+				}
+			}
+			if !hasVolume {
+				t.Errorf("missing %q bind-mount in volumes: %+v",
+					tc.wantVolumeSource, doc.Spec.Containers[0].Volumes)
+			}
+		})
+	}
+}
+
 // TestKukeondCellDocSocketGIDArg guards the wire that lets kukeond restart
 // re-apply socket ownership without re-running kuke init: the cell args must
 // include `--socket-gid <gid>` whenever a kukeon GID is plumbed through.
@@ -206,6 +269,7 @@ func TestKukeondCellDocSocketGIDArg(t *testing.T) {
 				"/opt/kukeon",
 				"/run/containerd/containerd.sock",
 				tc.gid,
+				"",
 			)
 			args := doc.Spec.Containers[0].Args
 			joined := strings.Join(args, " ")

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -85,6 +85,10 @@ type Options struct {
 	// --socket-gid <gid> so the daemon can chown its listener socket on every
 	// restart. Set by `kuke init` to the kukeon group's numeric GID.
 	KukeondSocketGID int
+	// KukeondConfiguration, when set, is passed to the kukeond cell as
+	// --configuration <path> and bind-mounted into the cell so the daemon
+	// re-reads the same ServerConfiguration on every restart.
+	KukeondConfiguration string
 	// ForceRegenerateCNI forces bootstrap to rewrite space conflists even when
 	// they already exist with the expected bridge name. Surfaces via
 	// `kuke init --force-regenerate-cni`.
@@ -192,12 +196,16 @@ func (b *Exec) Bootstrap() (BootstrapReport, error) {
 		if err = ensureCNIStateDir(); err != nil {
 			return report, err
 		}
+		if err = ensureServerConfigurationDir(b.opts.KukeondConfiguration); err != nil {
+			return report, err
+		}
 		cellDoc := kukeondCellDoc(
 			b.opts.KukeondImage,
 			b.opts.KukeondSocket,
 			b.opts.RunPath,
 			b.opts.ContainerdSocket,
 			b.opts.KukeondSocketGID,
+			b.opts.KukeondConfiguration,
 		)
 		if err = b.bootstrapCell(&report.SystemCell, cellDoc); err != nil {
 			return report, err

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -169,6 +169,10 @@ var (
 	// or violates the schema (missing kind, missing metadata.name, etc.).
 	ErrProfileInvalid = errors.New("profile is invalid")
 
+	// ErrServerConfigurationInvalid is returned when a ServerConfiguration
+	// YAML fails to parse or violates the schema (wrong kind, etc.).
+	ErrServerConfigurationInvalid = errors.New("server configuration is invalid")
+
 	// Secret-related errors.
 
 	ErrSecretNameRequired         = errors.New("secret name is required")

--- a/internal/serverconfig/serverconfig.go
+++ b/internal/serverconfig/serverconfig.go
@@ -1,0 +1,65 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package serverconfig loads a kukeond ServerConfiguration document from
+// disk. Used by `kukeond --configuration` (daemon root command) and
+// `kuke init --server-configuration` to feed defaults into viper before
+// the daemon starts. An absent file returns a zero-value document so the
+// caller can fall back to its existing defaults without an error.
+package serverconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// Load reads path and returns the parsed ServerConfiguration. When the file
+// does not exist, returns a zero-value document and no error — the absent
+// case is normal (callers fall back to hardcoded defaults). Any other read
+// or parse failure is wrapped with errdefs.ErrServerConfigurationInvalid.
+func Load(path string) (*v1beta1.ServerConfigurationDoc, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &v1beta1.ServerConfigurationDoc{}, nil
+		}
+		return nil, fmt.Errorf(
+			"read server configuration %q: %w: %w",
+			path, errdefs.ErrServerConfigurationInvalid, err,
+		)
+	}
+
+	var doc v1beta1.ServerConfigurationDoc
+	if unmarshalErr := yaml.Unmarshal(raw, &doc); unmarshalErr != nil {
+		return nil, fmt.Errorf(
+			"parse server configuration %q: %w: %w",
+			path, errdefs.ErrServerConfigurationInvalid, unmarshalErr,
+		)
+	}
+	if doc.Kind != "" && doc.Kind != v1beta1.KindServerConfiguration {
+		return nil, fmt.Errorf(
+			"server configuration %q has kind %q, want %q: %w",
+			path, doc.Kind, v1beta1.KindServerConfiguration,
+			errdefs.ErrServerConfigurationInvalid,
+		)
+	}
+	return &doc, nil
+}

--- a/internal/serverconfig/serverconfig_test.go
+++ b/internal/serverconfig/serverconfig_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package serverconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestLoadAbsentFileReturnsZeroDoc(t *testing.T) {
+	doc, err := Load(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("Load() returned nil doc, want zero-value")
+	}
+	if doc.Kind != "" || doc.Spec.Socket != "" || doc.Spec.RunPath != "" {
+		t.Fatalf("Load() returned non-zero doc for absent file: %+v", doc)
+	}
+}
+
+func TestLoadValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kukeond.yaml")
+	content := `apiVersion: v1beta1
+kind: ServerConfiguration
+metadata:
+  name: default
+spec:
+  socket: /run/kukeon/test.sock
+  socketGID: 1000
+  runPath: /opt/kukeon-test
+  containerdSocket: /run/containerd/test.sock
+  logLevel: debug
+  kukeondImage: docker.io/library/kukeon:test
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	doc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if doc.Kind != v1beta1.KindServerConfiguration {
+		t.Errorf("Kind: got %q, want %q", doc.Kind, v1beta1.KindServerConfiguration)
+	}
+	if doc.Spec.Socket != "/run/kukeon/test.sock" {
+		t.Errorf("Socket: got %q", doc.Spec.Socket)
+	}
+	if doc.Spec.SocketGID != 1000 {
+		t.Errorf("SocketGID: got %d, want 1000", doc.Spec.SocketGID)
+	}
+	if doc.Spec.RunPath != "/opt/kukeon-test" {
+		t.Errorf("RunPath: got %q", doc.Spec.RunPath)
+	}
+	if doc.Spec.ContainerdSocket != "/run/containerd/test.sock" {
+		t.Errorf("ContainerdSocket: got %q", doc.Spec.ContainerdSocket)
+	}
+	if doc.Spec.LogLevel != "debug" {
+		t.Errorf("LogLevel: got %q", doc.Spec.LogLevel)
+	}
+	if doc.Spec.KukeondImage != "docker.io/library/kukeon:test" {
+		t.Errorf("KukeondImage: got %q", doc.Spec.KukeondImage)
+	}
+}
+
+func TestLoadWrongKindRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kukeond.yaml")
+	content := `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: nope
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load() expected error for wrong kind, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrServerConfigurationInvalid) {
+		t.Errorf("Load() error = %v, want wrapping ErrServerConfigurationInvalid", err)
+	}
+}
+
+func TestLoadMalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kukeond.yaml")
+	// Mapping value where a string is expected.
+	content := `apiVersion: v1beta1
+kind: ServerConfiguration
+spec:
+  socket:
+    nested: bad
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load() expected error for malformed YAML, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrServerConfigurationInvalid) {
+		t.Errorf("Load() error = %v, want wrapping ErrServerConfigurationInvalid", err)
+	}
+}
+
+func TestLoadEmptyKindAccepted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kukeond.yaml")
+	content := `spec:
+  socket: /run/kukeon/test.sock
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	doc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if doc.Spec.Socket != "/run/kukeon/test.sock" {
+		t.Errorf("Socket: got %q", doc.Spec.Socket)
+	}
+}

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -37,6 +37,11 @@ const (
 	// `kuke run -p`. Profiles are not server-side resources — `kuke apply`
 	// rejects them.
 	KindCellProfile Kind = "CellProfile"
+	// KindServerConfiguration identifies the kukeond daemon's configuration
+	// document loaded via `kukeond --configuration` (and consumed by
+	// `kuke init --server-configuration`). Not a server-side resource —
+	// `kuke apply` rejects it.
+	KindServerConfiguration Kind = "ServerConfiguration"
 )
 
 // Common printable state strings.

--- a/pkg/api/model/v1beta1/serverconfiguration.go
+++ b/pkg/api/model/v1beta1/serverconfiguration.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+// ServerConfigurationDoc is the kukeond-side configuration document. It is
+// loaded by the kukeond daemon (via `kukeond --configuration <path>`) and by
+// `kuke init --server-configuration <path>` when bootstrapping the daemon. It
+// is not a server-side resource: `kuke apply` rejects it.
+type ServerConfigurationDoc struct {
+	APIVersion Version                     `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind                        `json:"kind"       yaml:"kind"`
+	Metadata   ServerConfigurationMetadata `json:"metadata"   yaml:"metadata"`
+	Spec       ServerConfigurationSpec     `json:"spec"       yaml:"spec"`
+}
+
+type ServerConfigurationMetadata struct {
+	Name   string            `json:"name"             yaml:"name"`
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// ServerConfigurationSpec carries kukeond-only settings. Each field is
+// optional: an absent or empty value falls back to the daemon's hardcoded
+// default. Explicit command-line flags (`--socket`, `--run-path`, …) still
+// take precedence over values loaded from this document.
+type ServerConfigurationSpec struct {
+	// Socket is the unix socket path the daemon listens on.
+	Socket string `json:"socket,omitempty"           yaml:"socket,omitempty"`
+	// SocketGID is the numeric group ID the daemon chowns its listener
+	// socket to (mode 0o660 with group). Zero means root-only access.
+	SocketGID int `json:"socketGID,omitempty"        yaml:"socketGID,omitempty"`
+	// RunPath is the kukeon runtime root (e.g. /opt/kukeon).
+	RunPath string `json:"runPath,omitempty"          yaml:"runPath,omitempty"`
+	// ContainerdSocket is the path to the containerd unix socket the
+	// daemon connects to.
+	ContainerdSocket string `json:"containerdSocket,omitempty" yaml:"containerdSocket,omitempty"`
+	// LogLevel is the daemon log level (debug, info, warn, error).
+	LogLevel string `json:"logLevel,omitempty"         yaml:"logLevel,omitempty"`
+	// KukeondImage is the container image `kuke init` provisions for the
+	// kukeond system cell. Read by `kuke init` only; the daemon ignores it.
+	KukeondImage string `json:"kukeondImage,omitempty"     yaml:"kukeondImage,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Adds a dedicated `ServerConfiguration` kind so kukeond settings stop riding on the shared `kuke --config` flag — keeps client and daemon config from drifting into each other.
- `kukeond --configuration <path>` (default `/etc/kukeon/kukeond.yaml`) loads the doc in PersistentPreRunE; absent file → defaults, no error.
- `kuke init --server-configuration <path>` reads the same doc, applies values to viper before bootstrap, and plumbs `--configuration` + a bind-mount of the parent dir into the kukeond cell so the daemon re-reads on every restart.
- Removes the `kuke` root `--config` persistent flag (no current users) and the `KUKEON_ROOT_CONFIG_FILE` env/viper var; `loadConfig` collapses to env binding + run-path/log-level defaulting.
- Example `docs/kukeond.yaml` documents every spec field.

## Non-obvious calls

- **apiVersion: `v1beta1`, not `kukeon.io/v1beta1`.** The issue body proposes the `kukeon.io/`-prefixed form, but every other kind in `pkg/api/model/v1beta1/` (Realm, Space, Stack, Cell, Container, CellProfile) uses bare `v1beta1`, and `apischeme.VersionV1Beta1` keys off that literal. Adopting the prefixed form here would either fork apischeme or quietly fail validation. Reviewer can override.
- **Precedence:** explicit `--flag` > env > ServerConfiguration > flag default. Implemented via `cmd.Flags().Changed(<name>)` for the flag layer and `os.LookupEnv` for the env layer — `viper.Set` is skipped when either is in play, so a one-off `--flag` keeps winning and an exported env var overrides the on-disk doc.
- ServerConfiguration is not a server-side resource — `kuke apply` still rejects it, mirroring CellProfile's treatment.

## Test plan

- [x] `make test`
- [x] `go vet ./...` / `go build ./...`
- [x] CLAUDE.md daemon-parity smoke test: tear-down → rebuild → `sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev` → `sudo ./kuke get realms` vs `--no-daemon` (identical)
- [x] Confirmed `/bin/kukeond --configuration /etc/kukeon/kukeond.yaml serve …` is the running cmdline and `/etc/kukeon` is bind-mounted into the kukeond cell
- [x] Re-ran the smoke test with `docs/kukeond.yaml` copied to `/etc/kukeon/kukeond.yaml` — daemon-parity still identical
- [x] Re-ran the daemon-parity smoke test on the fix-up commit (env > YAML precedence) — both views still identical
- [x] Added `TestApplyServerConfigurationEnvOverridesConfig` locking in `--flag > env > ServerConfiguration > default` for kukeond
- [ ] `make e2e` — not run; the e2e suite is heavier than this PR's diff (env binding + cobra flag plumbing) and the daemon-parity smoke test is the regression guard CLAUDE.md names for changes that touch the build path / daemon

Closes #159