### PR TITLE
ci: run make test on every pull request

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: make test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run unit tests
+        run: make test

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![status: active](https://img.shields.io/badge/status-active-blue)
 ![state: alpha](https://img.shields.io/badge/state-alpha-orange)
 ![license: apache2](https://img.shields.io/badge/license-Apache%202.0-green)
+[![Test](https://github.com/eminwux/kukeon/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/eminwux/kukeon/actions/workflows/test.yaml)
 
 _Agent-native orchestration. Self-hosted. No walled garden._
 
@@ -237,10 +238,10 @@ Each layer is a real Linux primitive, not an invented abstraction. This structur
 
 Two commands, one binary: kukeon uses hard links to provide different behaviors.
 
-| Command     | Purpose                                          | Run by                |
-| ----------- | ------------------------------------------------ | --------------------- |
-| `kuke`      | Client CLI — talks to the daemon                 | Users                 |
-| `kukeond`   | The daemon process itself                        | Process supervisor    |
+| Command   | Purpose                          | Run by             |
+| --------- | -------------------------------- | ------------------ |
+| `kuke`    | Client CLI — talks to the daemon | Users              |
+| `kukeond` | The daemon process itself        | Process supervisor |
 
 Both are the same binary; behavior is determined by the executable name at runtime.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/test.yaml` that runs `make test` on `ubuntu-latest`. Triggers on pull_request targeting `main` and on push to `main`.
- Uses `actions/setup-go@v5` with `go-version-file: go.mod` so the workflow tracks the Go version declared in the module file (currently 1.24.5). `cache: true` enables setup-go's built-in module + build caching.
- Adds a status badge for the new workflow near the top of `README.md`, alongside the existing status/state/license shields. Per the issue, #73's e2e workflow can get its own badge here once it lands.

## Notable judgment calls

- Workflow triggers on `pull_request` against `main` only (not `pull_request: branches-ignore`). The repo's working policy is "PRs target `main`", so widening the trigger would only spin runners on internal release branches if any ever appeared.
- No explicit `actions/cache` step — `setup-go@v5`'s built-in cache covers the GOPATH module cache and build cache that `make test` (`go test ./...` minus e2e) actually uses, which is what the AC asks for.
- Branch protection is intentionally out of scope per the issue's Notes section.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes (all unit tests green)
- [x] Workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Workflow runs green on `main` after merge — verifiable only post-merge per the AC

Closes #187