### PR TITLE
feat(kuke): introduce ClientConfiguration kind and --configuration flag

### DIFF
--- a/cmd/config/defaults.go
+++ b/cmd/config/defaults.go
@@ -70,3 +70,15 @@ func DefaultProfilesFile() string {
 func DefaultServerConfigurationFile() string {
 	return filepath.Join("/", "etc", "kukeon", "kukeond.yaml")
 }
+
+// DefaultClientConfigurationFile is the on-disk path the `kuke` client reads
+// when the user does not pass `--configuration`. An absent file is not an
+// error — the client falls back to its hardcoded defaults.
+func DefaultClientConfigurationFile() string {
+	base, err := os.UserHomeDir()
+	if err != nil {
+		// fallback to tmp if home dir cannot be determined
+		base = "tmp"
+	}
+	return filepath.Join(base, ".kuke", "kuke.yaml")
+}

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -100,6 +100,8 @@ var (
 	KUKEON_ROOT_HOST = DefineKV("KUKEON_HOST", "kukeon/host", "unix:///run/kukeon/kukeond.sock")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEON_ROOT_NO_DAEMON = DefineKV("KUKEON_NO_DAEMON", "kukeon/noDaemon", "false")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CONFIGURATION = DefineKV("KUKE_CONFIGURATION", "kuke/configuration")
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEOND_SOCKET = DefineKV("KUKEOND_SOCKET", "kukeond/socket", "/run/kukeon/kukeond.sock")

--- a/cmd/kuke/clientconfig_test.go
+++ b/cmd/kuke/clientconfig_test.go
@@ -1,0 +1,216 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuke
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+func bindKukeEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []config.Var{
+		config.KUKEON_ROOT_HOST,
+		config.KUKEON_ROOT_RUN_PATH,
+		config.KUKEON_ROOT_CONTAINERD_SOCKET,
+		config.KUKEON_ROOT_LOG_LEVEL,
+	} {
+		if err := v.BindEnv(); err != nil {
+			t.Fatalf("BindEnv %s: %v", v.EnvVar(), err)
+		}
+	}
+}
+
+func TestNewKukeCmdHasConfigurationFlag(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+	if flag := cmd.PersistentFlags().Lookup("configuration"); flag == nil {
+		t.Fatal("--configuration persistent flag not found")
+	}
+}
+
+func TestApplyClientConfigurationDefaultsLayered(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+
+	spec := v1beta1.ClientConfigurationSpec{
+		Host:             "unix:///tmp/from-config.sock",
+		RunPath:          "/opt/kukeon-from-config",
+		ContainerdSocket: "/run/containerd/from-config.sock",
+		LogLevel:         "warn",
+	}
+	applyClientConfiguration(cmd, spec)
+
+	if got := viper.GetString(config.KUKEON_ROOT_HOST.ViperKey); got != spec.Host {
+		t.Errorf("Host: got %q, want %q", got, spec.Host)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey); got != spec.RunPath {
+		t.Errorf("RunPath: got %q, want %q", got, spec.RunPath)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey); got != spec.ContainerdSocket {
+		t.Errorf("ContainerdSocket: got %q, want %q", got, spec.ContainerdSocket)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != spec.LogLevel {
+		t.Errorf("LogLevel: got %q, want %q", got, spec.LogLevel)
+	}
+}
+
+func TestApplyClientConfigurationFlagOverridesConfig(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+	// Operator passed --host on the command line; the config file's value
+	// must not clobber it.
+	if setErr := cmd.PersistentFlags().Set("host", "unix:///tmp/from-flag.sock"); setErr != nil {
+		t.Fatalf("set --host: %v", setErr)
+	}
+
+	spec := v1beta1.ClientConfigurationSpec{Host: "unix:///tmp/from-config.sock"}
+	applyClientConfiguration(cmd, spec)
+
+	if got := viper.GetString(config.KUKEON_ROOT_HOST.ViperKey); got != "unix:///tmp/from-flag.sock" {
+		t.Errorf("Host flag override lost: got %q, want %q", got, "unix:///tmp/from-flag.sock")
+	}
+}
+
+func TestApplyClientConfigurationEnvOverridesConfig(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+	bindKukeEnv(t)
+
+	// Operator exported KUKEON_HOST and KUKEON_LOG_LEVEL; the on-disk
+	// ClientConfiguration must not clobber them. Locks the precedence
+	// documented on applyClientConfiguration: --flag > env >
+	// ClientConfiguration > default. The mirror of this guard exists for
+	// applyServerConfiguration in cmd/kukeond/kukeond_test.go; keep both
+	// in lock-step.
+	t.Setenv(config.KUKEON_ROOT_HOST.EnvVar(), "unix:///tmp/from-env.sock")
+	t.Setenv(config.KUKEON_ROOT_LOG_LEVEL.EnvVar(), "debug")
+
+	spec := v1beta1.ClientConfigurationSpec{
+		Host:     "unix:///tmp/from-config.sock",
+		LogLevel: "warn",
+		RunPath:  "/opt/kukeon-from-config",
+	}
+	applyClientConfiguration(cmd, spec)
+
+	if got := viper.GetString(config.KUKEON_ROOT_HOST.ViperKey); got != "unix:///tmp/from-env.sock" {
+		t.Errorf("Host env override lost: got %q, want %q", got, "unix:///tmp/from-env.sock")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "debug" {
+		t.Errorf("LogLevel env override lost: got %q, want %q", got, "debug")
+	}
+	// Field with no env var set still picks up the ClientConfiguration value —
+	// the env check is per-field, not all-or-nothing.
+	if got := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey); got != "/opt/kukeon-from-config" {
+		t.Errorf("RunPath: got %q, want %q", got, "/opt/kukeon-from-config")
+	}
+}
+
+func TestApplyClientConfigurationEmptyFieldsLeaveViperUntouched(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+	viper.Set(config.KUKEON_ROOT_HOST.ViperKey, "unix:///tmp/preexisting.sock")
+
+	applyClientConfiguration(cmd, v1beta1.ClientConfigurationSpec{})
+
+	if got := viper.GetString(config.KUKEON_ROOT_HOST.ViperKey); got != "unix:///tmp/preexisting.sock" {
+		t.Errorf("empty spec must not overwrite existing viper value: got %q", got)
+	}
+}
+
+func TestLoadClientConfigurationAbsentFileNoError(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+
+	// Point --configuration at a path that does not exist; loader returns
+	// a zero-value doc and applyClientConfiguration leaves viper untouched.
+	missing := filepath.Join(t.TempDir(), "missing.yaml")
+	viper.Set(config.KUKE_CONFIGURATION.ViperKey, missing)
+
+	if loadErr := loadClientConfiguration(cmd); loadErr != nil {
+		t.Fatalf("loadClientConfiguration() unexpected error for absent file: %v", loadErr)
+	}
+}
+
+func TestLoadClientConfigurationSeedsViper(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuke.yaml")
+	content := `apiVersion: v1beta1
+kind: ClientConfiguration
+metadata:
+  name: default
+spec:
+  host: unix:///tmp/from-config.sock
+  logLevel: warn
+`
+	if writeErr := os.WriteFile(path, []byte(content), 0o644); writeErr != nil {
+		t.Fatalf("WriteFile: %v", writeErr)
+	}
+	viper.Set(config.KUKE_CONFIGURATION.ViperKey, path)
+
+	if loadErr := loadClientConfiguration(cmd); loadErr != nil {
+		t.Fatalf("loadClientConfiguration() error = %v", loadErr)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_HOST.ViperKey); got != "unix:///tmp/from-config.sock" {
+		t.Errorf("Host: got %q, want %q", got, "unix:///tmp/from-config.sock")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "warn" {
+		t.Errorf("LogLevel: got %q, want %q", got, "warn")
+	}
+}

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -40,8 +40,10 @@ import (
 	uninstallcmd "github.com/eminwux/kukeon/cmd/kuke/uninstall"
 	"github.com/eminwux/kukeon/cmd/kuke/version"
 	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/clientconfig"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/logging"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -58,6 +60,10 @@ func NewKukeCmd() (*cobra.Command, error) {
 		Use:   "kuke",
 		Short: "Kukeon is a tool for managing Kukeon entities",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			if err := loadClientConfiguration(cmd); err != nil {
+				return err
+			}
+
 			var logger *slog.Logger
 			if viper.GetBool(config.KUKEON_ROOT_VERBOSE.ViperKey) {
 				logLevel := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey)
@@ -149,6 +155,17 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 }
 
 func SetPersistentLoggingFlags(rootCmd *cobra.Command) error {
+	rootCmd.PersistentFlags().String(
+		"configuration", config.DefaultClientConfigurationFile(),
+		"Path to a ClientConfiguration YAML; absent file uses hardcoded defaults",
+	)
+	if err := viper.BindPFlag(
+		config.KUKE_CONFIGURATION.ViperKey,
+		rootCmd.PersistentFlags().Lookup("configuration"),
+	); err != nil {
+		return err
+	}
+
 	rootCmd.PersistentFlags().String("run-path", "/opt/kukeon", "Run path for the kukeon runtime")
 	if err := viper.BindPFlag(config.KUKEON_ROOT_RUN_PATH.ViperKey, rootCmd.PersistentFlags().Lookup("run-path")); err != nil {
 		return err
@@ -220,4 +237,67 @@ func loadConfig() error {
 // LoadConfig is a public wrapper for backward compatibility.
 func LoadConfig() error {
 	return loadConfig()
+}
+
+// loadClientConfiguration reads the ClientConfiguration document at
+// `--configuration` (default `~/.kuke/kuke.yaml`) and layers its values onto
+// viper for fields the operator did not set explicitly. Called from the root
+// PersistentPreRunE so every subcommand sees the seeded defaults before
+// reading viper.
+func loadClientConfiguration(cmd *cobra.Command) error {
+	path := viper.GetString(config.KUKE_CONFIGURATION.ViperKey)
+	if path == "" {
+		path = config.DefaultClientConfigurationFile()
+	}
+	doc, err := clientconfig.Load(path)
+	if err != nil {
+		return fmt.Errorf("load client configuration: %w", err)
+	}
+	applyClientConfiguration(cmd, doc.Spec)
+	return nil
+}
+
+// applyClientConfiguration layers the loaded ClientConfiguration on top of
+// viper for fields the operator did not explicitly set on the command line
+// or via environment. Order of precedence: explicit `--flag` > env >
+// ClientConfiguration > flag default. The flag check skips fields whose
+// `--flag` was changed; the env check skips fields whose env var is set —
+// without it, `viper.Set` would override viper's env binding and silently
+// invert env > YAML.
+func applyClientConfiguration(cmd *cobra.Command, spec v1beta1.ClientConfigurationSpec) {
+	if spec.Host != "" && !flagChanged(cmd, "host") && !envSet(config.KUKEON_ROOT_HOST) {
+		viper.Set(config.KUKEON_ROOT_HOST.ViperKey, spec.Host)
+	}
+	if spec.RunPath != "" && !flagChanged(cmd, "run-path") && !envSet(config.KUKEON_ROOT_RUN_PATH) {
+		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, spec.RunPath)
+	}
+	if spec.ContainerdSocket != "" && !flagChanged(cmd, "containerd-socket") &&
+		!envSet(config.KUKEON_ROOT_CONTAINERD_SOCKET) {
+		viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, spec.ContainerdSocket)
+	}
+	if spec.LogLevel != "" && !flagChanged(cmd, "log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
+		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
+	}
+}
+
+// flagChanged checks both the local and persistent flag sets so the helper
+// is correct in tests (where cmd is the root and persistent flags are not
+// yet merged into cmd.Flags()) and in production (where cmd is the leaf
+// subcommand and the merged set already contains the parent's persistent
+// flags).
+func flagChanged(cmd *cobra.Command, name string) bool {
+	if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+		return true
+	}
+	if f := cmd.PersistentFlags().Lookup(name); f != nil && f.Changed {
+		return true
+	}
+	return false
+}
+
+// envSet reports whether the OS env var backing v is present (any value,
+// including empty string, counts as set — same semantics as viper's BindEnv).
+func envSet(v config.Var) bool {
+	_, ok := os.LookupEnv(v.EnvVar())
+	return ok
 }

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -221,6 +221,9 @@ func (r *realConfigLoader) LoadConfig() error {
 }
 
 func loadConfig() error {
+	_ = config.KUKEON_ROOT_HOST.BindEnv()
+	_ = config.KUKEON_ROOT_CONTAINERD_SOCKET.BindEnv()
+
 	_ = config.KUKEON_ROOT_RUN_PATH.BindEnv()
 	if viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey) == "" {
 		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, config.DefaultRunPath())

--- a/docs/kuke.yaml
+++ b/docs/kuke.yaml
@@ -1,0 +1,24 @@
+# kuke ClientConfiguration example.
+#
+# Drop this file at ~/.kuke/kuke.yaml (the default --configuration path)
+# to seed the kuke client's defaults, or pass `kuke --configuration <path>`
+# explicitly. Each spec field is optional: an absent value falls back to
+# the client's hardcoded default. Explicit `--host`, `--log-level`, etc.
+# on the command line and matching env vars (`KUKEON_HOST`, …) still
+# override values from this document — precedence is
+# `--flag > env > ClientConfiguration > default`.
+apiVersion: v1beta1
+kind: ClientConfiguration
+metadata:
+  name: default
+spec:
+  # Daemon endpoint kuke dials by default. Use a `unix://` URL for a
+  # local daemon socket or `ssh://user@host` to reach a remote kukeond.
+  host: unix:///run/kukeon/kukeond.sock
+  # kukeon runtime root used by `--no-daemon` operations that read
+  # /opt/kukeon directly instead of going through kukeond.
+  runPath: /opt/kukeon
+  # Containerd socket `--no-daemon` operations connect to.
+  containerdSocket: /run/containerd/containerd.sock
+  # Client log level when `--verbose` is on (debug, info, warn, error).
+  logLevel: info

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package clientconfig loads a kuke ClientConfiguration document from disk.
+// Used by `kuke --configuration` to feed defaults into viper before any
+// subcommand runs. An absent file returns a zero-value document so the
+// caller can fall back to its existing defaults without an error.
+package clientconfig
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// Load reads path and returns the parsed ClientConfiguration. When the file
+// does not exist, returns a zero-value document and no error — the absent
+// case is normal (callers fall back to hardcoded defaults). Any other read
+// or parse failure is wrapped with errdefs.ErrClientConfigurationInvalid.
+func Load(path string) (*v1beta1.ClientConfigurationDoc, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &v1beta1.ClientConfigurationDoc{}, nil
+		}
+		return nil, fmt.Errorf(
+			"read client configuration %q: %w: %w",
+			path, errdefs.ErrClientConfigurationInvalid, err,
+		)
+	}
+
+	var doc v1beta1.ClientConfigurationDoc
+	if unmarshalErr := yaml.Unmarshal(raw, &doc); unmarshalErr != nil {
+		return nil, fmt.Errorf(
+			"parse client configuration %q: %w: %w",
+			path, errdefs.ErrClientConfigurationInvalid, unmarshalErr,
+		)
+	}
+	if doc.Kind != "" && doc.Kind != v1beta1.KindClientConfiguration {
+		return nil, fmt.Errorf(
+			"client configuration %q has kind %q, want %q: %w",
+			path, doc.Kind, v1beta1.KindClientConfiguration,
+			errdefs.ErrClientConfigurationInvalid,
+		)
+	}
+	return &doc, nil
+}

--- a/internal/clientconfig/clientconfig_test.go
+++ b/internal/clientconfig/clientconfig_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientconfig
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestLoadAbsentFileReturnsZeroDoc(t *testing.T) {
+	doc, err := Load(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("Load() returned nil doc, want zero-value")
+	}
+	if doc.Kind != "" || doc.Spec.Host != "" || doc.Spec.LogLevel != "" {
+		t.Fatalf("Load() returned non-zero doc for absent file: %+v", doc)
+	}
+}
+
+func TestLoadValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuke.yaml")
+	content := `apiVersion: v1beta1
+kind: ClientConfiguration
+metadata:
+  name: default
+spec:
+  host: unix:///tmp/kuke-test.sock
+  runPath: /opt/kukeon-test
+  containerdSocket: /run/containerd/test.sock
+  logLevel: debug
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	doc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if doc.Kind != v1beta1.KindClientConfiguration {
+		t.Errorf("Kind: got %q, want %q", doc.Kind, v1beta1.KindClientConfiguration)
+	}
+	if doc.Spec.Host != "unix:///tmp/kuke-test.sock" {
+		t.Errorf("Host: got %q", doc.Spec.Host)
+	}
+	if doc.Spec.RunPath != "/opt/kukeon-test" {
+		t.Errorf("RunPath: got %q", doc.Spec.RunPath)
+	}
+	if doc.Spec.ContainerdSocket != "/run/containerd/test.sock" {
+		t.Errorf("ContainerdSocket: got %q", doc.Spec.ContainerdSocket)
+	}
+	if doc.Spec.LogLevel != "debug" {
+		t.Errorf("LogLevel: got %q", doc.Spec.LogLevel)
+	}
+}
+
+func TestLoadWrongKindRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuke.yaml")
+	content := `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: nope
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load() expected error for wrong kind, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrClientConfigurationInvalid) {
+		t.Errorf("Load() error = %v, want wrapping ErrClientConfigurationInvalid", err)
+	}
+}
+
+func TestLoadMalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuke.yaml")
+	// Mapping value where a string is expected.
+	content := `apiVersion: v1beta1
+kind: ClientConfiguration
+spec:
+  host:
+    nested: bad
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("Load() expected error for malformed YAML, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrClientConfigurationInvalid) {
+		t.Errorf("Load() error = %v, want wrapping ErrClientConfigurationInvalid", err)
+	}
+}
+
+func TestLoadEmptyKindAccepted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuke.yaml")
+	content := `spec:
+  host: unix:///tmp/kuke-test.sock
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	doc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if doc.Spec.Host != "unix:///tmp/kuke-test.sock" {
+		t.Errorf("Host: got %q", doc.Spec.Host)
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -173,6 +173,10 @@ var (
 	// YAML fails to parse or violates the schema (wrong kind, etc.).
 	ErrServerConfigurationInvalid = errors.New("server configuration is invalid")
 
+	// ErrClientConfigurationInvalid is returned when a ClientConfiguration
+	// YAML fails to parse or violates the schema (wrong kind, etc.).
+	ErrClientConfigurationInvalid = errors.New("client configuration is invalid")
+
 	// Secret-related errors.
 
 	ErrSecretNameRequired         = errors.New("secret name is required")

--- a/pkg/api/model/v1beta1/clientconfiguration.go
+++ b/pkg/api/model/v1beta1/clientconfiguration.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+// ClientConfigurationDoc is the kuke-side configuration document. It is
+// loaded by the `kuke` cobra root via `kuke --configuration <path>` (default
+// `~/.kuke/kuke.yaml`) and seeds defaults for client-only settings such as
+// the daemon endpoint and the default output format. It is not a server-side
+// resource: `kuke apply` rejects it.
+type ClientConfigurationDoc struct {
+	APIVersion Version                     `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind                        `json:"kind"       yaml:"kind"`
+	Metadata   ClientConfigurationMetadata `json:"metadata"   yaml:"metadata"`
+	Spec       ClientConfigurationSpec     `json:"spec"       yaml:"spec"`
+}
+
+type ClientConfigurationMetadata struct {
+	Name   string            `json:"name"             yaml:"name"`
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// ClientConfigurationSpec carries kuke-only settings. Each field is optional:
+// an absent or empty value falls back to the client's hardcoded default.
+// Explicit command-line flags (`--host`, `--log-level`, …) and matching env
+// vars (`KUKEON_HOST`, `KUKEON_LOG_LEVEL`, …) still take precedence over
+// values loaded from this document.
+type ClientConfigurationSpec struct {
+	// Host is the kukeond endpoint kuke dials by default
+	// (`unix:///run/kukeon/kukeond.sock` or `ssh://user@host`).
+	Host string `json:"host,omitempty"             yaml:"host,omitempty"`
+	// RunPath is the kukeon runtime root used by `--no-daemon` operations
+	// that read /opt/kukeon directly instead of going through kukeond.
+	RunPath string `json:"runPath,omitempty"          yaml:"runPath,omitempty"`
+	// ContainerdSocket is the containerd unix socket `--no-daemon`
+	// operations connect to.
+	ContainerdSocket string `json:"containerdSocket,omitempty" yaml:"containerdSocket,omitempty"`
+	// LogLevel is the client log level when `--verbose` is on
+	// (debug, info, warn, error).
+	LogLevel string `json:"logLevel,omitempty"         yaml:"logLevel,omitempty"`
+}

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -42,6 +42,11 @@ const (
 	// `kuke init --server-configuration`). Not a server-side resource —
 	// `kuke apply` rejects it.
 	KindServerConfiguration Kind = "ServerConfiguration"
+	// KindClientConfiguration identifies the kuke client's configuration
+	// document loaded via `kuke --configuration` (default
+	// `~/.kuke/kuke.yaml`). Not a server-side resource — `kuke apply`
+	// rejects it.
+	KindClientConfiguration Kind = "ClientConfiguration"
 )
 
 // Common printable state strings.


### PR DESCRIPTION
## Summary
- Add `ClientConfiguration` (apiVersion `v1beta1`) kind for kuke client-side defaults — daemon endpoint, run path, containerd socket, log level. Mirrors PR #185's `ServerConfiguration` shape.
- Add `--configuration` persistent flag on the `kuke` cobra root (default `~/.kuke/kuke.yaml`); absent file is not an error and falls back to hardcoded defaults.
- PreRunE seeds viper from the YAML, but only for fields not already supplied by `--flag` or env var. Precedence: `--flag > env > ClientConfiguration > default`.
- `kuke apply` rejects this kind (it falls through to `ErrUnknownKind` in the parser, same as `ServerConfiguration`) — it is a client-side document, not a server resource.

## Non-obvious calls
- **apiVersion is `v1beta1`, not `kukeon.io/v1beta1`** — the issue body suggests the latter, but every existing kind in this repo uses bare `v1beta1` (see `Version` const in `pkg/api/model/v1beta1/consts.go`). Following the precedent set by PR #185.
- **Initial spec fields are kuke-only settings**: `host`, `runPath`, `containerdSocket`, `logLevel`. The issue notes the exact list is settled in code review — happy to add/remove fields per reviewer feedback.
- **`output` was considered but trimmed.** The `kuke get …` printer reads `cmd.Flags().GetString("output")` directly (`cmd/kuke/get/shared/shared.go:54`) and bypasses viper entirely. Wiring `output: yaml` from YAML through viper would silently no-op, which violates the project rule of not shipping non-functional features. Happy to file a follow-up to retrofit the printer to read via viper if reviewer wants `output` in the next iteration.
- **`flagChanged` helper checks both `cmd.Flags()` and `cmd.PersistentFlags()`.** This differs from `cmd/kukeond/kukeond.go`'s pattern (which only checks persistent flags). The kuke root has subcommand-level flags merged in at Execute time, and depending on which command path is being executed, a flag may live in either set during PreRunE; checking both is the safe read. The test `TestApplyClientConfigurationFlagOverridesConfig` would have caught this if I'd used the kukeond pattern verbatim.
- **Env-over-YAML test ships from day one.** PR #185's reviewer flagged that the equivalent test was missing for `cmd/kuke/init/init.go`'s structurally identical path; that gap is closed here in `TestApplyClientConfigurationEnvOverridesConfig`.

## Test plan
- [x] `make test` — all packages green, including new `internal/clientconfig` and `cmd/kuke` tests.
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] Smoke test per project CLAUDE.md: `kuke init` rebuild + daemon-parity check (`kuke get realms` vs `--no-daemon`) — identical output. Daemon path untouched by this PR; smoke run was a regression-guard sanity check.
- [x] Manual: created `~/.kuke/kuke.yaml` with non-default `host`, ran `kuke get realms`, observed daemon connection attempt to the configured socket. With `KUKEON_HOST` exported, env wins over YAML. With `--host` on CLI, flag wins over env.

Closes #160