### PR TITLE
fix(cli): panic on uninstall flag-bind failure instead of returning nil

### DIFF
--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -44,7 +44,11 @@ func NewUninstallCmd() *cobra.Command {
 	}
 
 	if err := setupUninstallCmd(cmd); err != nil {
-		return nil
+		// setupUninstallCmd only fails if viper.BindPFlag is handed a nil
+		// flag — unreachable by construction here. Panic surfaces a future
+		// flag-rename or typo at startup instead of letting nil flow into
+		// cobra.AddCommand and crash the root command registration.
+		panic(fmt.Sprintf("kukeon: uninstall command misconfigured: %v", err))
 	}
 	return cmd
 }


### PR DESCRIPTION
## Summary
- `cmd/kuke/uninstall/uninstall.go:46` previously swallowed any `setupUninstallCmd` error and returned a `nil` `*cobra.Command`. The caller in `cmd/kuke/kuke.go:141` passes that straight into `cobra.AddCommand`, which then panics inside cobra (it dereferences `cmd.Name()`), turning a setup bug into an opaque crash deep in command registration.
- Replace the silent `return nil` with `panic(fmt.Sprintf("kukeon: uninstall command misconfigured: %v", err))`. This matches the existing "unreachable by construction" pattern in `internal/cni/subnet.go:131` for `NewDefaultSubnetAllocator`. A future flag rename / typo now fails at startup with a clear message naming the offender, rather than at root-command registration.
- Function signature unchanged, so no caller updates needed.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes (uninstall package + full unit suite)
- [ ] Daemon-parity smoke test (`sudo ./kuke get realms` vs `--no-daemon`) — not run; this PR does not touch `/opt/kukeon` paths, the daemon, or anything the daemon-parity check guards. Pure CLI command-construction wiring.

Closes #172