### PR TITLE
fix(uninstall): surface residual namespace and force-drain orphaned tasks

### DIFF
--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -84,7 +84,7 @@ type fakeRunner struct {
 	ExistsCgroupFn func(doc any) (bool, error)
 
 	// Purge methods
-	PurgeRealmFn     func(realm intmodel.Realm) error
+	PurgeRealmFn     func(realm intmodel.Realm) (bool, error)
 	PurgeSpaceFn     func(space intmodel.Space) error
 	PurgeStackFn     func(stack intmodel.Stack) error
 	PurgeCellFn      func(cell intmodel.Cell) error
@@ -380,11 +380,11 @@ func (f *fakeRunner) ExistsCgroup(doc any) (bool, error) {
 
 // Purge methods
 
-func (f *fakeRunner) PurgeRealm(realm intmodel.Realm) error {
+func (f *fakeRunner) PurgeRealm(realm intmodel.Realm) (bool, error) {
 	if f.PurgeRealmFn != nil {
 		return f.PurgeRealmFn(realm)
 	}
-	return errors.New("unexpected call to PurgeRealm")
+	return false, errors.New("unexpected call to PurgeRealm")
 }
 
 func (f *fakeRunner) PurgeSpace(space intmodel.Space) error {

--- a/internal/controller/purge_realm.go
+++ b/internal/controller/purge_realm.go
@@ -28,13 +28,14 @@ import (
 
 // PurgeRealmResult reports what was purged during realm purging.
 type PurgeRealmResult struct {
-	Realm          intmodel.Realm
-	RealmDeleted   bool     // Whether realm deletion succeeded
-	PurgeSucceeded bool     // Whether comprehensive purge succeeded
-	Force          bool     // Force flag that was used
-	Cascade        bool     // Cascade flag that was used
-	Deleted        []string // Resources that were deleted (standard cleanup)
-	Purged         []string // Additional resources purged (CNI, orphaned containers, etc.)
+	Realm            intmodel.Realm
+	RealmDeleted     bool     // Whether realm deletion succeeded
+	PurgeSucceeded   bool     // Whether comprehensive purge succeeded
+	NamespaceRemoved bool     // Whether the containerd namespace was actually removed
+	Force            bool     // Force flag that was used
+	Cascade          bool     // Cascade flag that was used
+	Deleted          []string // Resources that were deleted (standard cleanup)
+	Purged           []string // Additional resources purged (CNI, orphaned containers, etc.)
 }
 
 // PurgeRealm purges a realm with comprehensive cleanup. If cascade is true, purges all spaces first.
@@ -107,7 +108,9 @@ func (b *Exec) PurgeRealm(realm intmodel.Realm, force, cascade bool) (PurgeRealm
 	}
 
 	// Call private cascade method (handles cascade deletion, standard delete, and comprehensive purge)
-	if err = b.purgeRealmCascade(internalRealm, force, cascade, metadataExists); err != nil {
+	namespaceRemoved, err := b.purgeRealmCascade(internalRealm, force, cascade, metadataExists)
+	result.NamespaceRemoved = namespaceRemoved
+	if err != nil {
 		result.Purged = append(result.Purged, fmt.Sprintf("purge-error:%v", err))
 		result.PurgeSucceeded = false
 		// If metadata exists and delete failed, mark as not deleted
@@ -131,30 +134,31 @@ func (b *Exec) PurgeRealm(realm intmodel.Realm, force, cascade bool) (PurgeRealm
 }
 
 // purgeRealmCascade handles cascade deletion and purging logic using runner methods directly.
-// It returns an error if deletion/purging fails, but does not return result types.
-// metadataExists indicates whether realm metadata exists (affects cascade and delete operations).
-func (b *Exec) purgeRealmCascade(realm intmodel.Realm, force, cascade, metadataExists bool) error {
+// It returns whether the containerd namespace was actually removed and an
+// error if deletion/purging failed. metadataExists indicates whether realm
+// metadata exists (affects cascade and delete operations).
+func (b *Exec) purgeRealmCascade(realm intmodel.Realm, force, cascade, metadataExists bool) (bool, error) {
 	realmName := strings.TrimSpace(realm.Metadata.Name)
 
 	// If cascade is true, list and purge child resources (spaces) recursively (only if metadata exists)
 	if cascade && metadataExists {
 		spaces, err := b.runner.ListSpaces(realmName)
 		if err != nil {
-			return fmt.Errorf("failed to list spaces: %w", err)
+			return false, fmt.Errorf("failed to list spaces: %w", err)
 		}
 		for _, space := range spaces {
 			if err = b.purgeSpaceCascade(space, force, cascade); err != nil {
-				return fmt.Errorf("failed to purge space %q: %w", space.Metadata.Name, err)
+				return false, fmt.Errorf("failed to purge space %q: %w", space.Metadata.Name, err)
 			}
 		}
 	} else if !force && metadataExists {
 		// Validate no child resources exist (only if metadata exists)
 		spaces, err := b.runner.ListSpaces(realmName)
 		if err != nil {
-			return fmt.Errorf("failed to list spaces: %w", err)
+			return false, fmt.Errorf("failed to list spaces: %w", err)
 		}
 		if len(spaces) > 0 {
-			return fmt.Errorf("%w: realm %q has %d space(s). Use --cascade to purge them or --force to skip validation",
+			return false, fmt.Errorf("%w: realm %q has %d space(s). Use --cascade to purge them or --force to skip validation",
 				errdefs.ErrResourceHasDependencies, realmName, len(spaces))
 		}
 	}
@@ -183,12 +187,16 @@ func (b *Exec) purgeRealmCascade(realm intmodel.Realm, force, cascade, metadataE
 		}
 	}
 
-	// Perform comprehensive purge via runner (works even without metadata)
-	if purgeErr := b.runner.PurgeRealm(realm); purgeErr != nil {
+	// Perform comprehensive purge via runner (works even without metadata).
+	// Note: namespaceRemoved is the load-bearing signal — even when purgeErr
+	// is nil, a residual namespace surfaces here so callers can render
+	// "namespace not empty" instead of a misleading "purged" outcome.
+	namespaceRemoved, purgeErr := b.runner.PurgeRealm(realm)
+	if purgeErr != nil {
 		if deleteErr != nil {
-			return fmt.Errorf("%w; runner purge also failed: %w", deleteErr, purgeErr)
+			return namespaceRemoved, fmt.Errorf("%w; runner purge also failed: %w", deleteErr, purgeErr)
 		}
-		return purgeErr
+		return namespaceRemoved, purgeErr
 	}
-	return nil
+	return namespaceRemoved, nil
 }

--- a/internal/controller/purge_realm_test.go
+++ b/internal/controller/purge_realm_test.go
@@ -66,8 +66,8 @@ func TestPurgeRealm_SuccessfulPurgeWithMetadata(t *testing.T) {
 					return nil
 				}
 				// Mock comprehensive purge
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return nil
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -127,8 +127,8 @@ func TestPurgeRealm_SuccessfulPurgeWithMetadata(t *testing.T) {
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return nil
 				}
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return nil
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -205,8 +205,8 @@ func TestPurgeRealm_SuccessfulPurgeWithoutMetadata(t *testing.T) {
 					return false, nil
 				}
 				// PurgeRealm is called even without metadata
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return nil
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -329,8 +329,8 @@ func TestPurgeRealm_CascadePurge(t *testing.T) {
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return nil
 				}
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return nil
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -423,8 +423,8 @@ func TestPurgeRealm_ForcePurge(t *testing.T) {
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return nil
 				}
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return nil
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -532,11 +532,11 @@ func TestPurgeRealm_DefaultNamespace(t *testing.T) {
 					}
 					return false, nil
 				}
-				f.PurgeRealmFn = func(realm intmodel.Realm) error {
+				f.PurgeRealmFn = func(realm intmodel.Realm) (bool, error) {
 					if realm.Spec.Namespace != wantNs {
 						t.Errorf("expected namespace to be %q, got %q", wantNs, realm.Spec.Namespace)
 					}
-					return nil
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -559,11 +559,11 @@ func TestPurgeRealm_DefaultNamespace(t *testing.T) {
 				f.ExistsRealmContainerdNamespaceFn = func(_ string) (bool, error) {
 					return false, nil
 				}
-				f.PurgeRealmFn = func(realm intmodel.Realm) error {
+				f.PurgeRealmFn = func(realm intmodel.Realm) (bool, error) {
 					if realm.Spec.Namespace != wantNs {
 						t.Errorf("expected namespace to be %q, got %q", wantNs, realm.Spec.Namespace)
 					}
-					return nil
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -588,11 +588,11 @@ func TestPurgeRealm_DefaultNamespace(t *testing.T) {
 					}
 					return false, nil
 				}
-				f.PurgeRealmFn = func(realm intmodel.Realm) error {
+				f.PurgeRealmFn = func(realm intmodel.Realm) (bool, error) {
 					if realm.Spec.Namespace != "custom-namespace" {
 						t.Errorf("expected namespace to be 'custom-namespace', got %q", realm.Spec.Namespace)
 					}
-					return nil
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -751,8 +751,8 @@ func TestPurgeRealm_GetRealmErrors(t *testing.T) {
 				f.ExistsRealmContainerdNamespaceFn = func(_ string) (bool, error) {
 					return false, nil
 				}
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return nil
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return true, nil
 				}
 			},
 			wantErr: false,
@@ -955,8 +955,8 @@ func TestPurgeRealm_RunnerErrors(t *testing.T) {
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return errors.New("deletion failed")
 				}
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return errors.New("purge failed")
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return false, errors.New("purge failed")
 				}
 			},
 			wantErr:     true,
@@ -985,8 +985,8 @@ func TestPurgeRealm_RunnerErrors(t *testing.T) {
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return nil
 				}
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return errors.New("purge failed")
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return false, errors.New("purge failed")
 				}
 			},
 			wantErr: true,
@@ -1190,8 +1190,8 @@ func TestPurgeRealm_ResultConstruction(t *testing.T) {
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return nil
 				}
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return nil
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -1250,8 +1250,8 @@ func TestPurgeRealm_ResultConstruction(t *testing.T) {
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return nil
 				}
-				f.PurgeRealmFn = func(_ intmodel.Realm) error {
-					return errors.New("purge failed")
+				f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+					return false, errors.New("purge failed")
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -1341,11 +1341,11 @@ func TestPurgeRealm_NameTrimming(t *testing.T) {
 					}
 					return nil
 				}
-				f.PurgeRealmFn = func(realm intmodel.Realm) error {
+				f.PurgeRealmFn = func(realm intmodel.Realm) (bool, error) {
 					if realm.Metadata.Name != "test-realm" {
-						return errors.New("unexpected realm name")
+						return false, errors.New("unexpected realm name")
 					}
-					return nil
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -1379,11 +1379,11 @@ func TestPurgeRealm_NameTrimming(t *testing.T) {
 				f.DeleteRealmFn = func(_ intmodel.Realm) error {
 					return nil
 				}
-				f.PurgeRealmFn = func(realm intmodel.Realm) error {
+				f.PurgeRealmFn = func(realm intmodel.Realm) (bool, error) {
 					if realm.Spec.Namespace != "test-namespace" {
-						return errors.New("unexpected namespace")
+						return false, errors.New("unexpected namespace")
 					}
-					return nil
+					return true, nil
 				}
 			},
 			wantResult: func(t *testing.T, result controller.PurgeRealmResult) {
@@ -1453,9 +1453,9 @@ func TestPurgeRealm_DeleteCascadeFailsButPurgeSucceeds(t *testing.T) {
 		return errors.New("namespace must be empty, still has snapshots on overlayfs snapshotter")
 	}
 	purgeCalled := false
-	mockRunner.PurgeRealmFn = func(_ intmodel.Realm) error {
+	mockRunner.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
 		purgeCalled = true
-		return nil
+		return true, nil
 	}
 
 	ctrl := setupTestController(t, mockRunner)

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -614,9 +614,13 @@ func (r *Exec) processOrphanedContainers(ctx context.Context, containers []strin
 	r.logger.InfoContext(ctx, "processing orphaned containers for deletion", "count", len(containers))
 	for i, containerID := range containers {
 		r.logger.DebugContext(ctx, "processing container", "index", i+1, "total", len(containers), "id", containerID)
-		// Try to delete container
+		// Force-stop: realm/space teardown is destructive by intent. Default
+		// SIGTERM with a 10s grace period leaves SIGKILL on the table for any
+		// stuck task, and a still-running task pins its snapshot mount —
+		// blocking CleanupNamespaceResources and the subsequent
+		// DeleteNamespace with "namespace not empty".
 		r.logger.DebugContext(ctx, "stopping container", "id", containerID)
-		_, _ = r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{})
+		_, _ = r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{Force: true})
 		r.logger.DebugContext(ctx, "deleting container", "id", containerID)
 		_ = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,

--- a/internal/controller/runner/purge_realm.go
+++ b/internal/controller/runner/purge_realm.go
@@ -29,18 +29,27 @@ import (
 	"github.com/eminwux/kukeon/internal/util/fs"
 )
 
-// PurgeRealm performs comprehensive cleanup of a realm, including all child resources, CNI resources, and orphaned containers.
-func (r *Exec) PurgeRealm(realm intmodel.Realm) error {
+// PurgeRealm performs comprehensive cleanup of a realm, including all child
+// resources, CNI resources, and orphaned containers.
+//
+// Returns (namespaceRemoved, err). namespaceRemoved is true iff the
+// containerd namespace was actually removed (or was already gone). err is
+// non-nil only for fatal precondition failures (missing name, GetRealm error,
+// containerd connect error) or when DeleteNamespace itself failed — it is the
+// load-bearing piece of "purge". Best-effort cleanups (cgroup removal, CNI
+// teardown, orphaned-container drain) log warnings and do not surface as err
+// so a fully-cleaned namespace is never reported as a failed purge.
+func (r *Exec) PurgeRealm(realm intmodel.Realm) (bool, error) {
 	realmName := strings.TrimSpace(realm.Metadata.Name)
 	if realmName == "" {
-		return errdefs.ErrRealmNameRequired
+		return false, errdefs.ErrRealmNameRequired
 	}
 
 	// Get realm via internal model to ensure metadata accuracy (if available)
 	// Note: DeleteRealm is handled at the controller level, this function focuses on comprehensive cleanup
 	internalRealm, err := r.GetRealm(realm)
 	if err != nil && !errors.Is(err, errdefs.ErrRealmNotFound) {
-		return fmt.Errorf("%w: %w", errdefs.ErrGetRealm, err)
+		return false, fmt.Errorf("%w: %w", errdefs.ErrGetRealm, err)
 	}
 
 	// Use internalRealm if available, otherwise use provided realm as fallback
@@ -51,7 +60,7 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) error {
 	}
 
 	if err = r.ensureClientConnected(); err != nil {
-		return fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+		return false, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
 	// List ALL containers in namespace (even orphaned ones)
@@ -108,8 +117,15 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) error {
 		// Continue with namespace deletion attempt anyway
 	}
 
-	// Delete containerd namespace as part of comprehensive cleanup
+	// Delete containerd namespace as part of comprehensive cleanup. This is
+	// the load-bearing step of a purge — surface its failure to the caller
+	// so a leftover namespace renders as "FAILED" in the uninstall report
+	// instead of a bogus "purged".
+	namespaceRemoved := true
+	var nsErr error
 	if err = r.ctrClient.DeleteNamespace(realmForOps.Spec.Namespace); err != nil {
+		namespaceRemoved = false
+		nsErr = fmt.Errorf("failed to delete containerd namespace %q: %w", realmForOps.Spec.Namespace, err)
 		r.logger.WarnContext(
 			r.ctx,
 			"failed to delete containerd namespace",
@@ -118,7 +134,8 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) error {
 			"error",
 			err,
 		)
-		// Continue with other cleanup
+		// Continue with other cleanup so a single failure does not strand
+		// metadata/cgroup state on disk.
 	}
 
 	// Remove all metadata directories for realm and children
@@ -140,5 +157,5 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) error {
 		// Continue with cleanup even if cgroup deletion fails
 	}
 
-	return nil
+	return namespaceRemoved, nsErr
 }

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -77,7 +77,7 @@ type Runner interface {
 
 	ExistsCgroup(doc any) (bool, error)
 
-	PurgeRealm(realm intmodel.Realm) error
+	PurgeRealm(realm intmodel.Realm) (namespaceRemoved bool, err error)
 	PurgeSpace(space intmodel.Space) error
 	PurgeStack(stack intmodel.Stack) error
 	PurgeCell(cell intmodel.Cell) error

--- a/internal/controller/uninstall.go
+++ b/internal/controller/uninstall.go
@@ -57,11 +57,18 @@ type UninstallOptions struct {
 }
 
 // RealmPurgeOutcome reports the result of purging a single realm.
+//
+// Purged is the high-level "did the cleanup function complete without a
+// fatal error" flag; NamespaceRemoved is the narrower "did the containerd
+// namespace actually get removed" signal — the residual-namespace bug from
+// issue #193 is the case where Purged was true but NamespaceRemoved was
+// false, leaving the caller with a misleading "purged" report.
 type RealmPurgeOutcome struct {
-	Name      string
-	Namespace string
-	Purged    bool
-	Err       error
+	Name             string
+	Namespace        string
+	Purged           bool
+	NamespaceRemoved bool
+	Err              error
 }
 
 // UninstallReport summarizes what Uninstall did.
@@ -138,7 +145,9 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 			Name:      realm.Metadata.Name,
 			Namespace: realm.Spec.Namespace,
 		}
-		if _, err := b.PurgeRealm(realm, true, true); err != nil {
+		result, err := b.PurgeRealm(realm, true, true)
+		outcome.NamespaceRemoved = result.NamespaceRemoved
+		if err != nil {
 			outcome.Err = err
 			recordErr(fmt.Errorf("purge realm %q: %w", realm.Metadata.Name, err))
 		} else {

--- a/internal/controller/uninstall_test.go
+++ b/internal/controller/uninstall_test.go
@@ -47,7 +47,7 @@ func uninstallNoopRunner(extraRealms []intmodel.Realm) *fakeRunner {
 		return nil, nil
 	}
 	f.DeleteRealmFn = func(_ intmodel.Realm) error { return nil }
-	f.PurgeRealmFn = func(_ intmodel.Realm) error { return nil }
+	f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) { return true, nil }
 	return f
 }
 
@@ -64,9 +64,9 @@ func TestUninstall_PurgesWellKnownRealmsAndCleansFilesystem(t *testing.T) {
 
 	purged := map[string]string{} // name -> namespace
 	f := uninstallNoopRunner(nil)
-	f.PurgeRealmFn = func(r intmodel.Realm) error {
+	f.PurgeRealmFn = func(r intmodel.Realm) (bool, error) {
 		purged[r.Metadata.Name] = r.Spec.Namespace
-		return nil
+		return true, nil
 	}
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
@@ -144,9 +144,9 @@ func TestUninstall_MergesListedRealmsWithWellKnown(t *testing.T) {
 	f := uninstallNoopRunner([]intmodel.Realm{custom})
 
 	purgedNames := []string{}
-	f.PurgeRealmFn = func(r intmodel.Realm) error {
+	f.PurgeRealmFn = func(r intmodel.Realm) (bool, error) {
 		purgedNames = append(purgedNames, r.Metadata.Name)
-		return nil
+		return true, nil
 	}
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
@@ -178,11 +178,11 @@ func TestUninstall_PurgeFailureIsRecordedButCleanupContinues(t *testing.T) {
 
 	f := uninstallNoopRunner(nil)
 	failure := errors.New("synthetic purge failure")
-	f.PurgeRealmFn = func(r intmodel.Realm) error {
+	f.PurgeRealmFn = func(r intmodel.Realm) (bool, error) {
 		if r.Metadata.Name == consts.KukeSystemRealmName {
-			return failure
+			return false, failure
 		}
-		return nil
+		return true, nil
 	}
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
@@ -202,16 +202,48 @@ func TestUninstall_PurgeFailureIsRecordedButCleanupContinues(t *testing.T) {
 		t.Errorf("run path not removed after a realm purge failure (expected best-effort cleanup)")
 	}
 	// And the failing realm's outcome must be in the report so callers can
-	// surface what went wrong.
+	// surface what went wrong. NamespaceRemoved must be false so the renderer
+	// can flag the residual namespace from issue #193 instead of misreporting
+	// "purged".
 	var foundFailure bool
 	for _, outcome := range report.Realms {
-		if outcome.Name == consts.KukeSystemRealmName && outcome.Err != nil {
-			foundFailure = true
-			break
+		if outcome.Name != consts.KukeSystemRealmName {
+			continue
 		}
+		if outcome.Err == nil {
+			t.Errorf("expected failing realm to carry its err; got outcome=%+v", outcome)
+		}
+		if outcome.Purged {
+			t.Errorf("failing realm must not be marked Purged=true; got %+v", outcome)
+		}
+		if outcome.NamespaceRemoved {
+			t.Errorf("failing realm must report NamespaceRemoved=false (namespace survived); got %+v", outcome)
+		}
+		foundFailure = true
+		break
 	}
 	if !foundFailure {
 		t.Errorf("expected failing realm to be reported with its error; got %+v", report.Realms)
+	}
+
+	// The well-known "default" realm purged successfully — its outcome must
+	// be the converse: Purged + NamespaceRemoved both true.
+	var foundOK bool
+	for _, outcome := range report.Realms {
+		if outcome.Name != consts.KukeonDefaultRealmName {
+			continue
+		}
+		if !outcome.Purged || !outcome.NamespaceRemoved || outcome.Err != nil {
+			t.Errorf(
+				"successful realm outcome should be {Purged:true, NamespaceRemoved:true, Err:nil}; got %+v",
+				outcome,
+			)
+		}
+		foundOK = true
+		break
+	}
+	if !foundOK {
+		t.Errorf("expected successful default realm in report; got %+v", report.Realms)
 	}
 }
 

--- a/internal/ctr/namespaces.go
+++ b/internal/ctr/namespaces.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 
 	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/opencontainers/go-digest"
@@ -352,6 +353,29 @@ func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error 
 				// Continue with other blobs
 			} else {
 				c.logger.DebugContext(c.ctx, "deleted blob", "namespace", namespace, "digest", dgst.String())
+			}
+		}
+	}
+
+	// Release any remaining leases. A pinned lease keeps content/snapshot
+	// references alive and blocks NamespaceService.Delete with "namespace not
+	// empty"; the image-pull path (image.go) creates per-pull leases and
+	// deletes them on success, but leases owned by orphaned operations or
+	// older kukeond versions can persist and must be cleared synchronously.
+	c.logger.DebugContext(c.ctx, "cleaning up leases", "namespace", namespace)
+	leaseManager := c.cClient.LeasesService()
+	existingLeases, err := leaseManager.List(nsCtx)
+	if err != nil {
+		c.logger.WarnContext(c.ctx, "failed to list leases", "namespace", namespace, "error", err)
+	} else {
+		c.logger.DebugContext(c.ctx, "found leases", "namespace", namespace, "count", len(existingLeases))
+		for _, lease := range existingLeases {
+			c.logger.DebugContext(c.ctx, "deleting lease", "namespace", namespace, "lease", lease.ID)
+			if deleteErr := leaseManager.Delete(nsCtx, lease, leases.SynchronousDelete); deleteErr != nil {
+				c.logger.WarnContext(c.ctx, "failed to delete lease", "namespace", namespace, "lease", lease.ID, "error", deleteErr)
+				// Continue with other leases
+			} else {
+				c.logger.DebugContext(c.ctx, "deleted lease", "namespace", namespace, "lease", lease.ID)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Stop swallowing `DeleteNamespace` failures in `runner.PurgeRealm` — return `(namespaceRemoved bool, err error)` so the uninstall reporter can render `FAILED: ...` instead of a misleading `purged` when the containerd namespace actually survived.
- Force-stop orphaned containers during the realm-purge drain (`StopContainerOptions{Force: true}`). The default SIGTERM-with-grace path leaves SIGKILL on the table, so a stuck task pinned its snapshot mount and blocked `DeleteNamespace` with "namespace not empty" — exactly the residue the issue describes.
- Enumerate and synchronously release leftover containerd leases inside `CleanupNamespaceResources` before the namespace delete attempt, since a pinned lease keeps content/snapshot references alive across the cleanup pass.
- Propagate a new `NamespaceRemoved bool` through `controller.PurgeRealmResult` and `controller.RealmPurgeOutcome` so callers can distinguish "we ran cleanup without a fatal error" from "the namespace was actually removed."

## Notable judgment calls
- The public `kukeonv1.PurgeRealmResult` (over the daemon RPC) was left unchanged — issue #193 is about the uninstall report, not the API surface. Adding a field there would extend scope past the bug.
- `processOrphanedContainers` always force-stops now, not just on the metadata-missing fallback path. A purge is destructive by intent in both branches, and the same residual-task class can pin snapshots in either case; opting into Force unconditionally is strictly safer and avoids a flag plumbing exercise.
- Existing snapshot/blob/image cleanup is best-effort (warn-and-continue); the new lease cleanup follows the same shape so a single bad lease doesn't strand the rest of the namespace teardown.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes
- [x] `TestUninstall_PurgeFailureIsRecordedButCleanupContinues` extended to assert `NamespaceRemoved=false` on the failing realm and `{Purged, NamespaceRemoved}=true` on the successful one — locks in the new contract.
- [ ] Live repro from the issue (`rm -rf /opt/kukeon` + populated `kuke-system.kukeon.io` namespace, then `kuke uninstall`) — not run; this host already had a kukeond cell I did not want to clobber to reproduce the exact bug-state, and the daemon-parity smoke check in `kukeon/CLAUDE.md` covers `kuke init`, not the uninstall residue path. The unit test exercises the propagation; an end-to-end repro is a worthwhile manual follow-up.

Closes #193