### PR TITLE
fix(uninstall): stop kukeond before purging kuke-system

### DIFF
--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -163,6 +163,9 @@ func readLine(r io.Reader) (string, error) {
 func printReport(cmd *cobra.Command, report controller.UninstallReport) {
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, "kuke uninstall:")
+	if report.Daemon.PIDFile != "" {
+		fmt.Fprintf(out, "  - kukeond: %s\n", daemonOutcome(report.Daemon))
+	}
 	for _, r := range report.Realms {
 		switch {
 		case r.Err != nil:
@@ -177,6 +180,23 @@ func printReport(cmd *cobra.Command, report controller.UninstallReport) {
 	fmt.Fprintf(out, "  - group %q: %s\n", report.GroupName, accountOutcome(report.GroupExisted, report.GroupRemoved))
 }
 
+// outcomeAbsent labels every "we didn't find the resource" branch in the
+// uninstall report so the operator sees the same word in every section.
+const outcomeAbsent = "absent"
+
+func daemonOutcome(d controller.DaemonStopReport) string {
+	switch {
+	case !d.PIDFilePresent:
+		return outcomeAbsent
+	case d.ForceKilled:
+		return fmt.Sprintf("force-killed (pid %d)", d.PID)
+	case d.Signalled:
+		return fmt.Sprintf("stopped (pid %d)", d.PID)
+	default:
+		return "stale pid file"
+	}
+}
+
 func dirOutcome(existed, removed bool) string {
 	switch {
 	case removed:
@@ -184,7 +204,7 @@ func dirOutcome(existed, removed bool) string {
 	case existed:
 		return "remove failed"
 	default:
-		return "absent"
+		return outcomeAbsent
 	}
 }
 
@@ -195,7 +215,7 @@ func accountOutcome(existed, removed bool) string {
 	case existed:
 		return "remove failed"
 	default:
-		return "absent"
+		return outcomeAbsent
 	}
 }
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -63,9 +63,9 @@ const (
 	KukeSystemCellName      = "kukeond"
 	KukeSystemContainerName = "kukeond"
 
-	// realmNamespaceSuffix is the suffix appended to every realm name to form
-	// its containerd namespace. See RealmNamespace.
-	realmNamespaceSuffix = ".kukeon.io"
+	// RealmNamespaceSuffix is the suffix appended to every realm name to form
+	// its containerd namespace. See RealmNamespace and IsKukeonNamespace.
+	RealmNamespaceSuffix = ".kukeon.io"
 
 	// KukeonSystemUser and KukeonSystemGroup name the system identity created
 	// by `kuke init` so a non-root operator added to the kukeon group can
@@ -80,5 +80,27 @@ const (
 // realm name; all bootstrap and user-realm code paths route through it so the
 // mapping stays consistent.
 func RealmNamespace(realm string) string {
-	return realm + realmNamespaceSuffix
+	return realm + RealmNamespaceSuffix
+}
+
+// IsKukeonNamespace reports whether ns is a containerd namespace owned by
+// kukeon — i.e., one with the canonical .kukeon.io suffix and a non-empty
+// realm prefix. Used by the uninstall path to enumerate kukeon namespaces by
+// suffix so user-created realms whose on-disk metadata was wiped (issue #193's
+// partial-uninstall path) are still purged on a `kuke uninstall`.
+func IsKukeonNamespace(ns string) bool {
+	if len(ns) <= len(RealmNamespaceSuffix) {
+		return false
+	}
+	return ns[len(ns)-len(RealmNamespaceSuffix):] == RealmNamespaceSuffix
+}
+
+// RealmFromNamespace returns the realm name encoded in a containerd namespace
+// (the inverse of RealmNamespace). Returns the empty string when ns does not
+// have the kukeon suffix or when stripping the suffix would leave nothing.
+func RealmFromNamespace(ns string) string {
+	if !IsKukeonNamespace(ns) {
+		return ""
+	}
+	return ns[:len(ns)-len(RealmNamespaceSuffix)]
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -41,6 +41,7 @@ type fakeRunner struct {
 	CreateRealmFn                    func(realm intmodel.Realm) (intmodel.Realm, error)
 	EnsureRealmFn                    func(realm intmodel.Realm) (intmodel.Realm, error)
 	ExistsRealmContainerdNamespaceFn func(namespace string) (bool, error)
+	ListContainerdNamespacesFn       func() ([]string, error)
 	DeleteRealmFn                    func(realm intmodel.Realm) error
 
 	// Space methods
@@ -147,6 +148,15 @@ func (f *fakeRunner) ExistsRealmContainerdNamespace(namespace string) (bool, err
 		return f.ExistsRealmContainerdNamespaceFn(namespace)
 	}
 	return false, errors.New("unexpected call to ExistsRealmContainerdNamespace")
+}
+
+func (f *fakeRunner) ListContainerdNamespaces() ([]string, error) {
+	if f.ListContainerdNamespacesFn != nil {
+		return f.ListContainerdNamespacesFn()
+	}
+	// Default to an empty list so tests that don't care about the suffix
+	// enumerator (the dominant case) don't have to install a stub.
+	return nil, nil
 }
 
 func (f *fakeRunner) DeleteRealm(realm intmodel.Realm) error {

--- a/internal/controller/daemon_stop.go
+++ b/internal/controller/daemon_stop.go
@@ -1,0 +1,154 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// DaemonStopReport summarizes the outcome of the daemon-stop step run at the
+// top of Uninstall.
+//
+// The fields cover the three observable states the operator cares about:
+// (1) was a PID file present at all (PIDFilePresent), (2) was a signal
+// actually delivered (Signalled — false when the PID was already dead by the
+// time we read the file, or the file held garbage), and (3) did the daemon
+// require SIGKILL (ForceKilled) — that is the operator-facing tell that the
+// daemon ignored SIGTERM during the grace window.
+type DaemonStopReport struct {
+	PIDFilePresent bool
+	PIDFile        string
+	PID            int
+	Signalled      bool
+	ForceKilled    bool
+}
+
+// DaemonStopper is the injection point for the daemon-stop step. The default
+// implementation reads the PID file, sends SIGTERM, waits up to gracePeriod
+// for the process to exit, then escalates to SIGKILL. Tests stub this to
+// avoid touching real processes.
+type DaemonStopper func(ctx context.Context, pidFile string, gracePeriod time.Duration) (DaemonStopReport, error)
+
+// DefaultDaemonStopGracePeriod is the SIGTERM-to-SIGKILL grace window. Five
+// seconds matches the issue's "wait up to ~5s" — long enough for a clean
+// JSON-RPC drain on a quiescent daemon, short enough that a wedged daemon
+// does not block uninstall noticeably.
+const DefaultDaemonStopGracePeriod = 5 * time.Second
+
+// daemonStopPollInterval is how often waitForProcessExit polls signal-0.
+// 50ms balances responsiveness (a clean daemon usually exits within one tick)
+// against syscall overhead during the full grace window.
+const daemonStopPollInterval = 50 * time.Millisecond
+
+// stopDaemonByPIDFile is the production DaemonStopper. It treats every error
+// path that resolves to "no live daemon to stop" as success (missing file,
+// unparseable PID, ESRCH on signal) — uninstall is best-effort and a stale
+// PID file must not block the rest of the teardown.
+func stopDaemonByPIDFile(ctx context.Context, pidFile string, gracePeriod time.Duration) (DaemonStopReport, error) {
+	report := DaemonStopReport{PIDFile: pidFile}
+	if pidFile == "" {
+		return report, nil
+	}
+
+	raw, err := os.ReadFile(pidFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Partial-uninstall path from #193: PID file already gone.
+			return report, nil
+		}
+		return report, fmt.Errorf("read pid file %q: %w", pidFile, err)
+	}
+	report.PIDFilePresent = true
+
+	pidStr := strings.TrimSpace(string(raw))
+	pid, parseErr := strconv.Atoi(pidStr)
+	if parseErr != nil {
+		// Garbage in the file — treat as "no live daemon" rather than fail
+		// the whole uninstall. The error itself is uninteresting here; the
+		// PID/Signalled fields on the report communicate "we did nothing".
+		return report, nil //nolint:nilerr // intentional silence: garbage PID is best-effort no-op.
+	}
+	if pid <= 1 {
+		// PID 1 would target init; refuse and no-op.
+		return report, nil
+	}
+	report.PID = pid
+
+	proc, findErr := os.FindProcess(pid)
+	if findErr != nil {
+		// On unix os.FindProcess always succeeds; this branch is defensive.
+		return report, nil //nolint:nilerr // intentional silence: defensive no-op on unreachable error.
+	}
+
+	if signalErr := proc.Signal(syscall.SIGTERM); signalErr != nil {
+		if errors.Is(signalErr, os.ErrProcessDone) || errors.Is(signalErr, syscall.ESRCH) {
+			return report, nil
+		}
+		return report, fmt.Errorf("send SIGTERM to %d: %w", pid, signalErr)
+	}
+	report.Signalled = true
+
+	if waitForProcessExit(ctx, pid, gracePeriod) {
+		return report, nil
+	}
+
+	if killErr := proc.Signal(syscall.SIGKILL); killErr != nil {
+		if errors.Is(killErr, os.ErrProcessDone) || errors.Is(killErr, syscall.ESRCH) {
+			return report, nil
+		}
+		return report, fmt.Errorf("send SIGKILL to %d: %w", pid, killErr)
+	}
+	report.ForceKilled = true
+	// Brief follow-up wait so callers can downstream the assumption that the
+	// daemon is gone before they touch its containers.
+	_ = waitForProcessExit(ctx, pid, gracePeriod)
+	return report, nil
+}
+
+// waitForProcessExit polls signal-0 to detect process exit. signal-0 is the
+// canonical "is this PID still alive?" probe on unix — it returns ESRCH iff
+// the process has been reaped (or is owned by a different user, but uninstall
+// runs as root). Returns true when the process has gone away within timeout.
+func waitForProcessExit(ctx context.Context, pid int, timeout time.Duration) bool {
+	if pid <= 0 {
+		return true
+	}
+	deadline := time.Now().Add(timeout)
+	tick := daemonStopPollInterval
+	for {
+		if err := syscall.Kill(pid, 0); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return true
+			}
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(tick):
+		}
+	}
+}

--- a/internal/controller/daemon_stop_test.go
+++ b/internal/controller/daemon_stop_test.go
@@ -1,0 +1,101 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestStopDaemonByPIDFile_EmptyPath is the trivial case the Uninstall caller
+// can land in if SocketDir is empty: the stopper must short-circuit with no
+// error and an empty report rather than try to read "".
+func TestStopDaemonByPIDFile_EmptyPath(t *testing.T) {
+	report, err := stopDaemonByPIDFile(context.Background(), "", time.Second)
+	if err != nil {
+		t.Fatalf("expected nil error for empty pidFile, got %v", err)
+	}
+	if report.PIDFilePresent {
+		t.Errorf("report.PIDFilePresent=true with empty pidFile; got %+v", report)
+	}
+	if report.Signalled || report.ForceKilled {
+		t.Errorf("nothing should have been signalled with empty pidFile; got %+v", report)
+	}
+}
+
+// TestStopDaemonByPIDFile_MissingFile covers the partial-uninstall path
+// from #193: pidFile is configured but the file is gone. ENOENT is "no live
+// daemon to stop" — must be a clean no-op.
+func TestStopDaemonByPIDFile_MissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "kukeond.pid")
+	report, err := stopDaemonByPIDFile(context.Background(), missing, time.Second)
+	if err != nil {
+		t.Fatalf("expected nil error when pid file is absent, got %v", err)
+	}
+	if report.PIDFilePresent {
+		t.Errorf("report.PIDFilePresent=true for absent file; got %+v", report)
+	}
+	if report.PIDFile != missing {
+		t.Errorf("report.PIDFile=%q, want %q", report.PIDFile, missing)
+	}
+}
+
+// TestStopDaemonByPIDFile_GarbagePID covers operator-corrupted state: a PID
+// file that contains something the daemon would never write. The function
+// must not error (the rest of uninstall has to keep going) and must not have
+// signalled anything.
+func TestStopDaemonByPIDFile_GarbagePID(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "kukeond.pid")
+	if err := os.WriteFile(pidFile, []byte("not-a-number\n"), 0o644); err != nil {
+		t.Fatalf("seed pid file: %v", err)
+	}
+	report, err := stopDaemonByPIDFile(context.Background(), pidFile, time.Second)
+	if err != nil {
+		t.Fatalf("expected nil error for garbage PID, got %v", err)
+	}
+	if !report.PIDFilePresent {
+		t.Errorf("report.PIDFilePresent=false; want true (file existed); got %+v", report)
+	}
+	if report.PID != 0 {
+		t.Errorf("report.PID=%d, want 0 (parse failed)", report.PID)
+	}
+	if report.Signalled {
+		t.Errorf("report.Signalled=true for garbage PID; got %+v", report)
+	}
+}
+
+// TestStopDaemonByPIDFile_RefusesPID1 is the safety guard: even if a corrupted
+// pid file said "1", the stopper must refuse to signal init. This is the
+// "PID <= 1" branch — treated as garbage just like "not-a-number".
+func TestStopDaemonByPIDFile_RefusesPID1(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "kukeond.pid")
+	if err := os.WriteFile(pidFile, []byte("1\n"), 0o644); err != nil {
+		t.Fatalf("seed pid file: %v", err)
+	}
+	report, err := stopDaemonByPIDFile(context.Background(), pidFile, time.Second)
+	if err != nil {
+		t.Fatalf("expected nil error for PID 1, got %v", err)
+	}
+	if report.Signalled {
+		t.Errorf("report.Signalled=true for PID 1; refusal to signal init was bypassed: %+v", report)
+	}
+}

--- a/internal/controller/runner/delete_realm.go
+++ b/internal/controller/runner/delete_realm.go
@@ -64,7 +64,8 @@ func (r *Exec) DeleteRealm(realm intmodel.Realm) error {
 
 	// Clean up all namespace resources (images, snapshots, blobs) before deleting namespace
 	// Namespace must be empty before deletion
-	if err = r.ctrClient.CleanupNamespaceResources(internalRealm.Spec.Namespace, "overlayfs"); err != nil {
+	// Pass "" to walk every known snapshotter — see ctr.KukeonKnownSnapshotters.
+	if err = r.ctrClient.CleanupNamespaceResources(internalRealm.Spec.Namespace, ""); err != nil {
 		r.logger.WarnContext(
 			r.ctx,
 			"failed to cleanup namespace resources",

--- a/internal/controller/runner/exists.go
+++ b/internal/controller/runner/exists.go
@@ -45,6 +45,20 @@ func (r *Exec) ExistsRealmContainerdNamespace(namespace string) (bool, error) {
 	return r.ctrClient.ExistsNamespace(namespace)
 }
 
+// ListContainerdNamespaces returns every containerd namespace visible to the
+// runner's client. A missing containerd socket returns an empty list rather
+// than an error so the uninstall path can degrade gracefully on hosts where
+// containerd was never running (or has already been torn down).
+func (r *Exec) ListContainerdNamespaces() ([]string, error) {
+	if _, err := os.Stat(r.opts.ContainerdSocket); os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err := r.ensureClientConnected(); err != nil {
+		return nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+	return r.ctrClient.ListNamespaces()
+}
+
 // ExistsContainer checks if a container exists in containerd by its containerd ID.
 // It ensures the client is connected before making the call.
 func (r *Exec) ExistsContainer(containerdID string) (bool, error) {

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -606,6 +606,13 @@ func (r *Exec) getRootContainerContainerdID(cell intmodel.Cell) (string, error) 
 
 // processOrphanedContainers processes a list of orphaned containers by stopping,
 // deleting them, and purging their CNI resources.
+//
+// Stop/Delete failures are logged at WARN with the container ID and underlying
+// error so an operator can tell which container survived the drain. The drain
+// is best-effort by design — we keep going past per-container failures so a
+// single stuck container does not strand the rest — but the log line is the
+// only signal the caller has to surface the residual containers in the
+// "namespace not empty" precondition error from DeleteNamespace.
 func (r *Exec) processOrphanedContainers(ctx context.Context, containers []string) {
 	if len(containers) == 0 {
 		return
@@ -620,11 +627,29 @@ func (r *Exec) processOrphanedContainers(ctx context.Context, containers []strin
 		// blocking CleanupNamespaceResources and the subsequent
 		// DeleteNamespace with "namespace not empty".
 		r.logger.DebugContext(ctx, "stopping container", "id", containerID)
-		_, _ = r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{Force: true})
+		if _, stopErr := r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{Force: true}); stopErr != nil {
+			r.logger.WarnContext(
+				ctx,
+				"failed to stop orphaned container; continuing drain",
+				"id",
+				containerID,
+				"error",
+				stopErr,
+			)
+		}
 		r.logger.DebugContext(ctx, "deleting container", "id", containerID)
-		_ = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
+		if delErr := r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
-		})
+		}); delErr != nil {
+			r.logger.WarnContext(
+				ctx,
+				"failed to delete orphaned container; continuing drain",
+				"id",
+				containerID,
+				"error",
+				delErr,
+			)
+		}
 
 		// Get netns and purge CNI
 		r.logger.DebugContext(ctx, "getting container netns path", "id", containerID)

--- a/internal/controller/runner/purge_realm.go
+++ b/internal/controller/runner/purge_realm.go
@@ -105,7 +105,10 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) (bool, error) {
 
 	// Clean up all namespace resources (images, snapshots) before deleting namespace
 	// Namespace must be empty before deletion
-	if err = r.ctrClient.CleanupNamespaceResources(realmForOps.Spec.Namespace, "overlayfs"); err != nil {
+	// Pass "" to walk every known snapshotter (overlayfs/native/btrfs/zfs/...);
+	// uninstall on a host that experimented with a non-default snapshotter
+	// must not strand its leftover snapshots and surface "namespace not empty".
+	if err = r.ctrClient.CleanupNamespaceResources(realmForOps.Spec.Namespace, ""); err != nil {
 		r.logger.WarnContext(
 			r.ctx,
 			"failed to cleanup namespace resources",
@@ -125,12 +128,34 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) (bool, error) {
 	var nsErr error
 	if err = r.ctrClient.DeleteNamespace(realmForOps.Spec.Namespace); err != nil {
 		namespaceRemoved = false
-		nsErr = fmt.Errorf("failed to delete containerd namespace %q: %w", realmForOps.Spec.Namespace, err)
+		// Re-list containers in the namespace so the error message names the
+		// specific resources that survived the drain. The generic precondition
+		// "must be empty" message from containerd hides which container is
+		// pinning it; without the IDs an operator cannot tell whether the
+		// orphan-drain misfired (issue #195's symptom) or a different actor
+		// (image, snapshot, lease) is keeping the namespace alive.
+		residual, listErr := r.findOrphanedContainers(realmForOps.Spec.Namespace, "")
+		switch {
+		case listErr != nil:
+			nsErr = fmt.Errorf(
+				"failed to delete containerd namespace %q (re-list of survivors failed: %w): %w",
+				realmForOps.Spec.Namespace, listErr, err,
+			)
+		case len(residual) > 0:
+			nsErr = fmt.Errorf(
+				"failed to delete containerd namespace %q (residual containers: %s): %w",
+				realmForOps.Spec.Namespace, strings.Join(residual, ", "), err,
+			)
+		default:
+			nsErr = fmt.Errorf("failed to delete containerd namespace %q: %w", realmForOps.Spec.Namespace, err)
+		}
 		r.logger.WarnContext(
 			r.ctx,
 			"failed to delete containerd namespace",
 			"namespace",
 			realmForOps.Spec.Namespace,
+			"residual_containers",
+			residual,
 			"error",
 			err,
 		)

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -37,6 +37,11 @@ type Runner interface {
 	EnsureRealm(realm intmodel.Realm) (intmodel.Realm, error)
 	UpdateRealm(realm intmodel.Realm) (intmodel.Realm, error)
 	ExistsRealmContainerdNamespace(namespace string) (bool, error)
+	// ListContainerdNamespaces returns every containerd namespace the
+	// runner's client can see. Surfaced for the uninstall path so it can
+	// enumerate kukeon namespaces by `.kukeon.io` suffix and clean up
+	// user-created realms whose on-disk metadata was already wiped.
+	ListContainerdNamespaces() ([]string, error)
 	DeleteRealm(realm intmodel.Realm) error
 
 	GetSpace(space intmodel.Space) (intmodel.Space, error)

--- a/internal/controller/uninstall.go
+++ b/internal/controller/uninstall.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/consts"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -54,6 +57,19 @@ type UninstallOptions struct {
 	// UserGroupRemover overrides the default userdel/groupdel routine.
 	// Tests inject a stub; production callers leave it nil.
 	UserGroupRemover UserGroupRemover
+	// KukeondPIDFile points at the kukeond PID file. The daemon-stop step
+	// signals the live daemon before any realm purge, so a fight between
+	// the in-process PurgeRealm and the running daemon's containerd session
+	// can never block the namespace delete with "namespace not empty".
+	// Empty disables the daemon-stop step; absent file is a no-op (the
+	// partial-uninstall path from #193).
+	KukeondPIDFile string
+	// DaemonStopper overrides the default PID-file-based stopper. Tests
+	// inject a stub; production callers leave it nil.
+	DaemonStopper DaemonStopper
+	// DaemonStopGracePeriod is the SIGTERM→SIGKILL grace window. Zero uses
+	// DefaultDaemonStopGracePeriod (5s).
+	DaemonStopGracePeriod time.Duration
 }
 
 // RealmPurgeOutcome reports the result of purging a single realm.
@@ -73,6 +89,7 @@ type RealmPurgeOutcome struct {
 
 // UninstallReport summarizes what Uninstall did.
 type UninstallReport struct {
+	Daemon          DaemonStopReport
 	Realms          []RealmPurgeOutcome
 	SocketDir       string
 	SocketDirExists bool
@@ -90,12 +107,20 @@ type UninstallReport struct {
 
 // Uninstall performs a comprehensive teardown of all kukeon runtime state.
 // Steps (in order):
+//  0. Stop the kukeond daemon (SIGTERM, then SIGKILL after a short grace) when
+//     a PID file is present. Doing this before any per-realm purge prevents
+//     the live daemon from racing the in-process containerd cleanup and
+//     pinning containers in `kuke-system.kukeon.io` while we are trying to
+//     drain it.
 //  1. Purge every realm with --cascade --force (drains spaces/stacks/cells/
 //     containers + tasks; the kukeond cell living inside `kuke-system` is
-//     killed and deleted as part of that cascade). Both well-known realms
-//     (`default`, `kuke-system`) are purged unconditionally so containerd
-//     namespaces left behind by an earlier partial uninstall are cleaned up
-//     even when on-disk metadata is already gone.
+//     killed and deleted as part of that cascade). Realms are enumerated by
+//     merging on-disk metadata with the set of containerd namespaces whose
+//     name carries the `.kukeon.io` suffix, so user-created realms whose
+//     metadata was wiped before `kuke uninstall` (the #193 partial-state
+//     path) still get their namespaces cleaned up. The two well-known
+//     realms (`default`, `kuke-system`) are kept as a safety floor so a
+//     containerd-list failure cannot strand them.
 //  2. RemoveAll on SocketDir (typically /run/kukeon).
 //  3. RemoveAll on the run path (typically /opt/kukeon).
 //  4. Remove the kukeon system user and group (no-op if absent).
@@ -124,6 +149,42 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 	recordErr := func(err error) {
 		if err != nil && firstErr == nil {
 			firstErr = err
+		}
+	}
+
+	// Step 0: stop the live kukeond daemon. Do this before realm enumeration
+	// so the controller's containerd client is not racing the daemon when
+	// PurgeRealm starts draining the kuke-system namespace.
+	pidFile := opts.KukeondPIDFile
+	if pidFile == "" && opts.SocketDir != "" {
+		// Default to <socketDir>/kukeond.pid so callers that pre-populate
+		// SocketDir (the CLI does) get the daemon-stop wired up automatically.
+		pidFile = filepath.Join(opts.SocketDir, "kukeond.pid")
+	}
+	if pidFile != "" {
+		stopper := opts.DaemonStopper
+		if stopper == nil {
+			stopper = stopDaemonByPIDFile
+		}
+		grace := opts.DaemonStopGracePeriod
+		if grace <= 0 {
+			grace = DefaultDaemonStopGracePeriod
+		}
+		daemonReport, daemonErr := stopper(b.ctx, pidFile, grace)
+		// Always record what the stopper saw, even on error — the report's
+		// PIDFile/PID/Signalled fields are how the CLI tells the operator
+		// whether the daemon-stop step actually fired.
+		report.Daemon = daemonReport
+		if daemonErr != nil {
+			b.logger.WarnContext(
+				b.ctx,
+				"uninstall: daemon-stop step failed; continuing with realm purge",
+				"pidFile",
+				pidFile,
+				"error",
+				daemonErr,
+			)
+			recordErr(fmt.Errorf("stop kukeond: %w", daemonErr))
 		}
 	}
 
@@ -196,9 +257,19 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 }
 
 // collectRealmsForUninstall returns every realm that should be purged,
-// merging on-disk metadata with the two well-known kukeon realms (so a
-// partial uninstall whose metadata was already wiped still cleans up
-// containerd namespaces by name).
+// merging three sources so a partial-uninstall path (metadata wiped before
+// `kuke uninstall`) still cleans up containerd namespaces:
+//  1. on-disk metadata via runner.ListRealms (the source of truth when present),
+//  2. live containerd namespaces matching `*.kukeon.io` (catches user-created
+//     realms whose metadata is gone — issue #193's partial-state path),
+//  3. the two well-known realms (`default`, `kuke-system`) as a safety floor
+//     so a failed containerd enumeration cannot strand them.
+//
+// The merge is order-stable: on-disk realms first (preserving ListRealms'
+// insertion order), then suffix-enumerated namespaces, then the well-known
+// floor — each de-duplicated against the previous step. Insertion order
+// matters because the renderer prints realms in this order, and operators
+// expect their named realms before "default" and "kuke-system".
 func (b *Exec) collectRealmsForUninstall() ([]intmodel.Realm, error) {
 	wellKnown := []intmodel.Realm{
 		{
@@ -211,22 +282,70 @@ func (b *Exec) collectRealmsForUninstall() ([]intmodel.Realm, error) {
 		},
 	}
 
-	listed, err := b.runner.ListRealms()
-	if err != nil {
-		return wellKnown, err
-	}
+	listed, listErr := b.runner.ListRealms()
 
-	seen := make(map[string]struct{}, len(listed)+len(wellKnown))
-	out := make([]intmodel.Realm, 0, len(listed)+len(wellKnown))
+	// Headroom for suffix-enumerated realms beyond the on-disk + well-known
+	// floor; small fixed reserve avoids an extra growth alloc on the common
+	// case of one or two user-created realms.
+	const suffixEnumeratedSlack = 4
+	seen := make(map[string]struct{}, len(listed)+len(wellKnown)+suffixEnumeratedSlack)
+	out := make([]intmodel.Realm, 0, len(listed)+len(wellKnown)+suffixEnumeratedSlack)
 	for _, realm := range listed {
 		seen[realm.Metadata.Name] = struct{}{}
 		out = append(out, realm)
 	}
+
+	suffixRealms, suffixErr := b.realmsFromContainerdNamespaces()
+	if suffixErr != nil {
+		b.logger.WarnContext(
+			b.ctx,
+			"uninstall: failed to enumerate containerd namespaces by suffix; falling back to well-known realms",
+			"error",
+			suffixErr,
+		)
+	}
+	for _, realm := range suffixRealms {
+		if _, ok := seen[realm.Metadata.Name]; ok {
+			continue
+		}
+		seen[realm.Metadata.Name] = struct{}{}
+		out = append(out, realm)
+	}
+
 	for _, realm := range wellKnown {
 		if _, ok := seen[realm.Metadata.Name]; ok {
 			continue
 		}
 		out = append(out, realm)
+	}
+	return out, listErr
+}
+
+// realmsFromContainerdNamespaces enumerates every containerd namespace and
+// returns realms for those whose name carries the `.kukeon.io` suffix. The
+// runner's containerd client is the single source of truth — non-kukeon
+// namespaces like "default" or "moby" are filtered out so this path cannot
+// accidentally purge a co-tenant's namespace. Returns the list deterministic
+// (sorted) so the report ordering does not flap between runs.
+func (b *Exec) realmsFromContainerdNamespaces() ([]intmodel.Realm, error) {
+	namespaces, err := b.runner.ListContainerdNamespaces()
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(namespaces)
+	out := make([]intmodel.Realm, 0, len(namespaces))
+	for _, ns := range namespaces {
+		if !consts.IsKukeonNamespace(ns) {
+			continue
+		}
+		realmName := consts.RealmFromNamespace(ns)
+		if realmName == "" {
+			continue
+		}
+		out = append(out, intmodel.Realm{
+			Metadata: intmodel.RealmMetadata{Name: realmName},
+			Spec:     intmodel.RealmSpec{Namespace: ns},
+		})
 	}
 	return out, nil
 }

--- a/internal/controller/uninstall_test.go
+++ b/internal/controller/uninstall_test.go
@@ -19,11 +19,14 @@
 package controller_test
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
@@ -258,4 +261,211 @@ func setupTestControllerWithRunPath(t *testing.T, mockRunner *fakeRunner, runPat
 		ContainerdSocket: "/test/containerd.sock",
 	}
 	return controller.NewControllerExecForTesting(ctx, logger, opts, mockRunner)
+}
+
+// TestUninstall_DaemonStopStep_PIDPresent verifies the daemon-stop step from
+// issue #195 fires before the realm-purge loop and surfaces the stub's report
+// verbatim. The whole point of running this step first is that the live
+// daemon's containerd session must be gone before PurgeRealm starts draining
+// `kuke-system.kukeon.io` — otherwise the daemon pins containers we are
+// trying to delete and the namespace delete fails.
+func TestUninstall_DaemonStopStep_PIDPresent(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+
+	pidFilePath := filepath.Join(tmpSocketDir, "kukeond.pid")
+	if err := os.WriteFile(pidFilePath, []byte("12345\n"), 0o644); err != nil {
+		t.Fatalf("seed pid file: %v", err)
+	}
+
+	// Record purge ordering vs. daemon-stop ordering so we can assert the
+	// daemon was signalled before any realm purge ran.
+	var (
+		stopperCalledAt int
+		firstPurgeAt    int
+		callIdx         int
+	)
+
+	stopper := func(_ context.Context, gotPidFile string, gotGrace time.Duration) (controller.DaemonStopReport, error) {
+		callIdx++
+		stopperCalledAt = callIdx
+		if gotPidFile != pidFilePath {
+			t.Errorf("stopper got pidFile %q, want %q", gotPidFile, pidFilePath)
+		}
+		if gotGrace != 250*time.Millisecond {
+			t.Errorf("stopper got grace %v, want %v", gotGrace, 250*time.Millisecond)
+		}
+		return controller.DaemonStopReport{
+			PIDFilePresent: true,
+			PIDFile:        gotPidFile,
+			PID:            12345,
+			Signalled:      true,
+		}, nil
+	}
+
+	f := uninstallNoopRunner(nil)
+	f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) {
+		callIdx++
+		if firstPurgeAt == 0 {
+			firstPurgeAt = callIdx
+		}
+		return true, nil
+	}
+
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:             tmpSocketDir,
+		KukeondPIDFile:        pidFilePath,
+		DaemonStopper:         stopper,
+		DaemonStopGracePeriod: 250 * time.Millisecond,
+		SkipUserGroup:         true,
+	})
+	if err != nil {
+		t.Fatalf("Uninstall returned error: %v", err)
+	}
+
+	if stopperCalledAt == 0 {
+		t.Fatalf("daemon stopper was never called; report.Daemon=%+v", report.Daemon)
+	}
+	if firstPurgeAt == 0 {
+		t.Fatalf("expected at least one PurgeRealm call (well-known realms); report=%+v", report)
+	}
+	if stopperCalledAt >= firstPurgeAt {
+		t.Errorf(
+			"daemon-stop must run before realm purge — stopperCalledAt=%d firstPurgeAt=%d",
+			stopperCalledAt, firstPurgeAt,
+		)
+	}
+
+	if !report.Daemon.PIDFilePresent {
+		t.Errorf("report.Daemon.PIDFilePresent=false, want true; got %+v", report.Daemon)
+	}
+	if report.Daemon.PID != 12345 {
+		t.Errorf("report.Daemon.PID=%d, want 12345", report.Daemon.PID)
+	}
+	if !report.Daemon.Signalled {
+		t.Errorf("report.Daemon.Signalled=false, want true; got %+v", report.Daemon)
+	}
+	if report.Daemon.PIDFile != pidFilePath {
+		t.Errorf("report.Daemon.PIDFile=%q, want %q", report.Daemon.PIDFile, pidFilePath)
+	}
+}
+
+// TestUninstall_DaemonStopStep_PIDAbsent covers the partial-uninstall path
+// from issue #193: the stopper still runs (Uninstall has to ask, since only
+// the stopper can read the PID file), but the report comes back saying no
+// daemon was found. The realm-purge loop must still execute — uninstall on
+// a host with no daemon running must not regress.
+func TestUninstall_DaemonStopStep_PIDAbsent(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+	// Deliberately do NOT create kukeond.pid in tmpSocketDir.
+
+	var stopperCalls int
+	stopper := func(_ context.Context, gotPidFile string, _ time.Duration) (controller.DaemonStopReport, error) {
+		stopperCalls++
+		// PIDFilePresent=false signals "no live daemon to stop" without an error
+		// (matches the production stopper's read-ENOENT branch).
+		return controller.DaemonStopReport{
+			PIDFile:        gotPidFile,
+			PIDFilePresent: false,
+		}, nil
+	}
+
+	purgedNames := []string{}
+	f := uninstallNoopRunner(nil)
+	f.PurgeRealmFn = func(r intmodel.Realm) (bool, error) {
+		purgedNames = append(purgedNames, r.Metadata.Name)
+		return true, nil
+	}
+
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		DaemonStopper: stopper,
+		SkipUserGroup: true,
+	})
+	if err != nil {
+		t.Fatalf("Uninstall returned error: %v", err)
+	}
+
+	if stopperCalls != 1 {
+		t.Errorf("daemon stopper called %d times, want exactly 1", stopperCalls)
+	}
+	if report.Daemon.PIDFilePresent {
+		t.Errorf("report.Daemon.PIDFilePresent=true on a host with no PID file; got %+v", report.Daemon)
+	}
+	if report.Daemon.Signalled {
+		t.Errorf("report.Daemon.Signalled=true with no PID file; got %+v", report.Daemon)
+	}
+	// The well-known realms must still be purged — a stale or missing PID
+	// file must not block subsequent cleanup.
+	if len(purgedNames) == 0 {
+		t.Errorf("realm-purge loop did not run after PID-absent daemon-stop; want at least the well-known realms")
+	}
+}
+
+// TestUninstall_SuffixEnumeratorPurgesKukeonNamespacesOnly is the AC-required
+// suffix-enumeration test from issue #195: a containerd-namespace lister
+// returning a mix of `.kukeon.io` and unrelated namespaces (`moby`) must yield
+// purge calls only for the kukeon-suffixed ones, and never for `moby`.
+//
+// This is the partial-uninstall recovery path (#193): user-created realms
+// whose on-disk metadata was wiped are still cleaned up because containerd
+// is the source of truth for which namespaces actually exist.
+func TestUninstall_SuffixEnumeratorPurgesKukeonNamespacesOnly(t *testing.T) {
+	tmpRunPath := t.TempDir()
+
+	f := uninstallNoopRunner(nil)
+	// ListRealms returns nothing — the on-disk metadata path is empty,
+	// forcing the suffix-enumerator path to be the source of truth.
+	f.ListRealmsFn = func() ([]intmodel.Realm, error) { return nil, nil }
+	f.ListContainerdNamespacesFn = func() ([]string, error) {
+		return []string{
+			"default.kukeon.io",
+			"kuke-system.kukeon.io",
+			"myteam.kukeon.io",
+			"moby",
+		}, nil
+	}
+
+	purgedNames := map[string]string{} // name -> namespace
+	f.PurgeRealmFn = func(r intmodel.Realm) (bool, error) {
+		purgedNames[r.Metadata.Name] = r.Spec.Namespace
+		return true, nil
+	}
+
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	if _, err := ctrl.Uninstall(controller.UninstallOptions{
+		SkipUserGroup: true,
+	}); err != nil {
+		t.Fatalf("Uninstall returned error: %v", err)
+	}
+
+	wantPurged := map[string]string{
+		"default":     "default.kukeon.io",
+		"kuke-system": "kuke-system.kukeon.io",
+		"myteam":      "myteam.kukeon.io",
+	}
+	if len(purgedNames) != len(wantPurged) {
+		// Sort for deterministic error output.
+		got := make([]string, 0, len(purgedNames))
+		for k := range purgedNames {
+			got = append(got, k)
+		}
+		sort.Strings(got)
+		t.Fatalf(
+			"purged realms = %v, want exactly %v (3 .kukeon.io namespaces)",
+			got,
+			[]string{"default", "kuke-system", "myteam"},
+		)
+	}
+	for name, wantNs := range wantPurged {
+		if got := purgedNames[name]; got != wantNs {
+			t.Errorf("realm %q purged with namespace %q, want %q", name, got, wantNs)
+		}
+	}
+	if _, leaked := purgedNames["moby"]; leaked {
+		t.Errorf("moby was purged — non-kukeon namespaces must be filtered out; purged=%v", purgedNames)
+	}
 }

--- a/internal/ctr/namespaces.go
+++ b/internal/ctr/namespaces.go
@@ -187,9 +187,44 @@ func (c *client) GetNamespace(namespace string) (string, error) {
 	return "", nil
 }
 
-// CleanupNamespaceResources removes all images and snapshots from a namespace
-// This must be called before deleting the namespace, as containerd requires
-// namespaces to be empty before deletion.
+// KukeonKnownSnapshotters is the list of containerd snapshotters
+// CleanupNamespaceResources walks when no snapshotter is specified. Stays
+// in sync with the set of snapshotters supported by the kukeond image
+// (overlayfs in production; native is always present as containerd's
+// fallback). Listed in the order they will be drained — overlayfs first
+// because it is the only one populated on a real install, but the others
+// are tried so a host that experimented with btrfs/zfs/etc. still gets a
+// clean uninstall instead of "namespace not empty" surfacing the day after.
+//
+// Listed snapshotters that are not registered in the daemon return errors
+// from snapshotService.Walk; cleanupSnapshotsFor handles those at WARN and
+// keeps walking the rest.
+//
+//nolint:gochecknoglobals // Immutable enumeration; package-level so uninstall callers iterate without re-allocating.
+var KukeonKnownSnapshotters = []string{
+	"overlayfs",
+	"native",
+	"btrfs",
+	"zfs",
+	"devmapper",
+	"blockfile",
+}
+
+// CleanupNamespaceResources empties a containerd namespace so DeleteNamespace
+// (which requires the namespace to be empty) can succeed. It drains in this
+// fixed order:
+//  1. images,
+//  2. snapshots — for every snapshotter when `snapshotter == ""` (the
+//     uninstall path's default), or just the named snapshotter when one is
+//     specified explicitly,
+//  3. blobs (content store),
+//  4. leases.
+//
+// Each class logs a count summary at INFO and per-resource debug lines at
+// DEBUG, so a future "namespace not empty" failure points at the exact class
+// still pinning the namespace. Per-resource failures are logged at WARN and
+// processing continues — the goal is best-effort drain, with the load-bearing
+// signal coming from the caller's subsequent DeleteNamespace check.
 func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error {
 	// Ensure client is connected
 	if c.cClient == nil {
@@ -229,109 +264,14 @@ func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error 
 		}
 	}
 
-	// Clean up snapshots
+	// Clean up snapshots. Walk every known snapshotter when the caller did
+	// not pin one; older callers passing "overlayfs" still drain only that.
+	snapshotters := []string{snapshotter}
 	if snapshotter == "" {
-		snapshotter = "overlayfs" // Default snapshotter
+		snapshotters = KukeonKnownSnapshotters
 	}
-	c.logger.DebugContext(c.ctx, "cleaning up snapshots", "namespace", namespace, "snapshotter", snapshotter)
-	snapshotService := c.cClient.SnapshotService(snapshotter)
-
-	// Iteratively remove snapshots until none remain or no progress is made.
-	// Walk order is implementation-defined (boltdb key order), so a single
-	// reverse-order pass cannot guarantee children are removed before parents
-	// when a parent has multiple children. A snapshot with extant children
-	// fails Remove with "must be empty"; on the next pass its children are
-	// gone and it succeeds. Cap iterations to bound work on a pathological
-	// graph; in practice the depth is small (image layers + a few committed
-	// container layers).
-	const maxSnapshotPasses = 32
-	for pass := range maxSnapshotPasses {
-		var snapshotKeys []string
-		err = snapshotService.Walk(nsCtx, func(_ context.Context, info snapshots.Info) error {
-			snapshotKeys = append(snapshotKeys, info.Name)
-			return nil
-		})
-		if err != nil {
-			c.logger.WarnContext(
-				c.ctx,
-				"failed to walk snapshots",
-				"namespace",
-				namespace,
-				"snapshotter",
-				snapshotter,
-				"error",
-				err,
-			)
-			break
-		}
-		if len(snapshotKeys) == 0 {
-			break
-		}
-		c.logger.DebugContext(
-			c.ctx,
-			"found snapshots",
-			"namespace",
-			namespace,
-			"snapshotter",
-			snapshotter,
-			"count",
-			len(snapshotKeys),
-			"pass",
-			pass,
-		)
-		removedAny := false
-		for i := len(snapshotKeys) - 1; i >= 0; i-- {
-			key := snapshotKeys[i]
-			c.logger.DebugContext(
-				c.ctx,
-				"removing snapshot",
-				"namespace",
-				namespace,
-				"snapshotter",
-				snapshotter,
-				"key",
-				key,
-			)
-			if removeErr := snapshotService.Remove(nsCtx, key); removeErr != nil {
-				c.logger.DebugContext(
-					c.ctx,
-					"snapshot remove deferred",
-					"namespace",
-					namespace,
-					"snapshotter",
-					snapshotter,
-					"key",
-					key,
-					"error",
-					removeErr,
-				)
-				continue
-			}
-			removedAny = true
-			c.logger.DebugContext(
-				c.ctx,
-				"removed snapshot",
-				"namespace",
-				namespace,
-				"snapshotter",
-				snapshotter,
-				"key",
-				key,
-			)
-		}
-		if !removedAny {
-			c.logger.WarnContext(
-				c.ctx,
-				"snapshot cleanup made no progress, giving up",
-				"namespace",
-				namespace,
-				"snapshotter",
-				snapshotter,
-				"remaining",
-				len(snapshotKeys),
-			)
-			break
-		}
+	for _, snap := range snapshotters {
+		c.cleanupSnapshotsFor(nsCtx, namespace, snap)
 	}
 
 	// Clean up blobs (content)
@@ -368,7 +308,7 @@ func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error 
 	if err != nil {
 		c.logger.WarnContext(c.ctx, "failed to list leases", "namespace", namespace, "error", err)
 	} else {
-		c.logger.DebugContext(c.ctx, "found leases", "namespace", namespace, "count", len(existingLeases))
+		c.logger.InfoContext(c.ctx, "draining leases", "namespace", namespace, "count", len(existingLeases))
 		for _, lease := range existingLeases {
 			c.logger.DebugContext(c.ctx, "deleting lease", "namespace", namespace, "lease", lease.ID)
 			if deleteErr := leaseManager.Delete(nsCtx, lease, leases.SynchronousDelete); deleteErr != nil {
@@ -381,4 +321,124 @@ func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error 
 	}
 
 	return nil
+}
+
+// cleanupSnapshotsFor drains every snapshot under one snapshotter from the
+// supplied namespace context. Walks repeatedly so a parent with multiple
+// children clears once each pass — Walk order is implementation-defined
+// (boltdb key order), so a single reverse-order pass cannot guarantee
+// children are removed before parents. Capped at maxSnapshotPasses to bound
+// work on a pathological graph; in practice the depth is small (image layers
+// + a few committed container layers).
+func (c *client) cleanupSnapshotsFor(nsCtx context.Context, namespace, snapshotter string) {
+	if snapshotter == "" {
+		return
+	}
+	c.logger.DebugContext(c.ctx, "cleaning up snapshots", "namespace", namespace, "snapshotter", snapshotter)
+	snapshotService := c.cClient.SnapshotService(snapshotter)
+
+	const maxSnapshotPasses = 32
+	totalRemoved := 0
+	for pass := range maxSnapshotPasses {
+		removed, done := c.cleanupSnapshotPass(nsCtx, snapshotService, namespace, snapshotter, pass)
+		totalRemoved += removed
+		if done {
+			break
+		}
+	}
+	if totalRemoved > 0 {
+		c.logger.InfoContext(
+			c.ctx,
+			"drained snapshots",
+			"namespace",
+			namespace,
+			"snapshotter",
+			snapshotter,
+			"removed",
+			totalRemoved,
+		)
+	}
+}
+
+// cleanupSnapshotPass walks `snapshotter` once, removing as many snapshots as
+// it can in reverse-walk order. Returns the number of snapshots removed in
+// this pass and a `done` flag set when the loop should stop — either because
+// the snapshotter is unregistered, the namespace is empty, or the pass made
+// no forward progress.
+func (c *client) cleanupSnapshotPass(
+	nsCtx context.Context,
+	snapshotService snapshots.Snapshotter,
+	namespace, snapshotter string,
+	pass int,
+) (int, bool) {
+	var snapshotKeys []string
+	walkErr := snapshotService.Walk(nsCtx, func(_ context.Context, info snapshots.Info) error {
+		snapshotKeys = append(snapshotKeys, info.Name)
+		return nil
+	})
+	if walkErr != nil {
+		// Snapshotter not registered (or socket-level error). Common when
+		// iterating KukeonKnownSnapshotters on a host that only has
+		// overlayfs — log at DEBUG so we don't WARN-spam every uninstall.
+		c.logger.DebugContext(
+			c.ctx,
+			"snapshot walk failed; skipping snapshotter",
+			"namespace",
+			namespace,
+			"snapshotter",
+			snapshotter,
+			"error",
+			walkErr,
+		)
+		return 0, true
+	}
+	if len(snapshotKeys) == 0 {
+		return 0, true
+	}
+	c.logger.DebugContext(
+		c.ctx,
+		"found snapshots",
+		"namespace",
+		namespace,
+		"snapshotter",
+		snapshotter,
+		"count",
+		len(snapshotKeys),
+		"pass",
+		pass,
+	)
+	removed := 0
+	for i := len(snapshotKeys) - 1; i >= 0; i-- {
+		key := snapshotKeys[i]
+		if removeErr := snapshotService.Remove(nsCtx, key); removeErr != nil {
+			c.logger.DebugContext(
+				c.ctx,
+				"snapshot remove deferred",
+				"namespace",
+				namespace,
+				"snapshotter",
+				snapshotter,
+				"key",
+				key,
+				"error",
+				removeErr,
+			)
+			continue
+		}
+		removed++
+	}
+	if removed == 0 {
+		c.logger.WarnContext(
+			c.ctx,
+			"snapshot cleanup made no progress, giving up",
+			"namespace",
+			namespace,
+			"snapshotter",
+			snapshotter,
+			"remaining",
+			len(snapshotKeys),
+		)
+		return 0, true
+	}
+	return removed, false
 }


### PR DESCRIPTION
## Summary
- Stop the live kukeond daemon (SIGTERM, then SIGKILL after a 5s grace) at the top of `controller.Uninstall` before any realm purge, so the daemon's containerd session can no longer pin its own cell's containers in `kuke-system.kukeon.io` while the in-process drain is trying to delete them. Gated on a PID file (default `<SocketDir>/kukeond.pid`); absent file is a no-op for the partial-uninstall path from #193. The stopper is injectable via `UninstallOptions.DaemonStopper` so it can be unit-tested without forking processes.
- Surface orphan-drain failures: `processOrphanedContainers` now `WarnContext`-logs every Stop/Delete error with the container ID instead of `_ =`-discarding it, and `runner.PurgeRealm` re-lists residual containers after a failed `DeleteNamespace` and embeds their IDs in the error so the CLI prints which container blocked the namespace delete.
- Exhaustive per-namespace cleanup: `ctr.CleanupNamespaceResources` now walks every snapshotter (`overlayfs`, `native`, `btrfs`, `zfs`, `devmapper`, `blockfile`) when no snapshotter is pinned, so a host that experimented with a non-default snapshotter does not strand its leftover snapshots. Lease drain stays as the final step before `DeleteNamespace`. Unregistered snapshotters log at DEBUG (no WARN-spam on stock hosts).
- Enumerate kukeon namespaces by `.kukeon.io` suffix: `collectRealmsForUninstall` now merges on-disk metadata (when present), the live containerd namespace list filtered by suffix (catches user-created realms whose `/opt/kukeon` was wiped — issue #193's partial-state path), and the two well-known realms as a safety floor when containerd enumeration returns nothing.
- Report layout: `UninstallReport.Daemon` carries the daemon-stop outcome; the CLI prints a new line `- kukeond: <state>` (absent / stopped (pid N) / force-killed (pid N) / stale pid file).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full unit suite, all packages pass.
- [x] New unit tests in `internal/controller/uninstall_test.go`:
  - `TestUninstall_DaemonStopStep_PIDPresent` — injects a stub `DaemonStopper`, asserts it received the configured pidFile + grace and that it ran *before* any `PurgeRealmFn` call (the whole point of step 0).
  - `TestUninstall_DaemonStopStep_PIDAbsent` — stub returns `PIDFilePresent=false`; verifies no error, the realm-purge loop still runs, and `report.Daemon.Signalled=false`.
  - `TestUninstall_SuffixEnumeratorPurgesKukeonNamespacesOnly` — `ListContainerdNamespacesFn` returns `["default.kukeon.io", "kuke-system.kukeon.io", "myteam.kukeon.io", "moby"]`; asserts exactly the three `.kukeon.io` realms get a `PurgeRealm` call and `moby` is filtered out.
- [x] New unit tests in `internal/controller/daemon_stop_test.go` covering the production stopper's no-op branches: empty pidFile, missing file (ENOENT), garbage PID (parse error), and PID 1 (init refusal). All return `nil` error and `Signalled=false`.
- [ ] **Live repro from the AC** (`kuke init` → populated `kuke-system.kukeon.io` → `kuke uninstall --yes` succeeds, `ctr ns ls` no longer shows `kuke-system.kukeon.io`) — not run from the dev environment; needs a host with containerd + the local `kukeon-local:dev` image. Reviewer should run this on a staging host before merge per `kukeon/CLAUDE.md`'s smoke-test policy.
- [ ] **Custom-realm partial-state repro** (`kuke init` + `kuke create realm myteam` + `rm -rf /opt/kukeon` + `kuke uninstall --yes` clears `myteam.kukeon.io`) — same caveat; not run locally.
- [ ] **Daemon-parity smoke check** from `kukeon/CLAUDE.md` (`kuke get realms` vs. `--no-daemon`) — not applicable: this PR does not touch the realm read path the daemon and in-process controller share. Only the uninstall write path changed.

Closes #195