### PR TITLE
refactor(cellprofile): drop singleton mode; spec.prefix overrides metadata.name

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -271,8 +271,8 @@ func loadFromFile(file string) (v1beta1.CellDoc, error) {
 
 // loadFromProfile resolves the active profiles directory, loads the named
 // profile, and materializes its CellSpec body into a CellDoc. The cell name
-// is the profile metadata.name when spec.namePrefix is unset, otherwise
-// `<namePrefix>-<6hex>` so each invocation produces a fresh cell.
+// is `<prefix>-<6hex>` — prefix defaults to metadata.name and is overridden
+// by spec.prefix — so every invocation produces a fresh cell.
 func loadFromProfile(profileName string) (v1beta1.CellDoc, error) {
 	dir, err := cellprofile.ResolveDir()
 	if err != nil {

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1072,8 +1072,8 @@ func TestRun_FromProfile_CreatesAndStarts(t *testing.T) {
 	if fc.createCalls != 1 {
 		t.Fatalf("CreateCell calls=%d want 1", fc.createCalls)
 	}
-	if got := fc.createDoc.Metadata.Name; got != "claude-cell" {
-		t.Errorf("cell name=%q want claude-cell (default to profile name)", got)
+	if got := fc.createDoc.Metadata.Name; !strings.HasPrefix(got, "claude-cell-") || len(got) != len("claude-cell-")+6 {
+		t.Errorf("cell name=%q want claude-cell-<6hex> (default prefix from metadata.name)", got)
 	}
 	if got := fc.createDoc.Spec.RealmID; got != "default" {
 		t.Errorf("RealmID=%q want default", got)
@@ -1089,11 +1089,9 @@ func TestRun_FromProfile_CreatesAndStarts(t *testing.T) {
 	}
 }
 
-func TestRun_FromProfile_NamePrefix_GeneratesFreshCell(t *testing.T) {
-	// spec.namePrefix flips the profile from singleton to template: every
-	// invocation must produce a distinct cell name shaped like
-	// `<prefix>-<6hex>`. Drive two invocations and assert both names share
-	// the prefix and differ.
+func TestRun_FromProfile_PrefixOverride_GeneratesFreshCell(t *testing.T) {
+	// spec.prefix overrides the default prefix (metadata.name). Every
+	// invocation must produce a distinct cell name shaped `<prefix>-<6hex>`.
 	t.Cleanup(viper.Reset)
 	dir := t.TempDir()
 	const profileYAML = `apiVersion: v1beta1
@@ -1104,7 +1102,7 @@ spec:
   realm: default
   space: agents
   stack: claude
-  namePrefix: claude
+  prefix: agent
   cell:
     containers:
       - id: work
@@ -1130,15 +1128,15 @@ spec:
 			t.Fatalf("Execute #%d: %v", i, err)
 		}
 		name := fc.createDoc.Metadata.Name
-		if !strings.HasPrefix(name, "claude-") || len(name) != len("claude-")+6 {
-			t.Fatalf("cell name=%q want claude-<6hex>", name)
+		if !strings.HasPrefix(name, "agent-") || len(name) != len("agent-")+6 {
+			t.Fatalf("cell name=%q want agent-<6hex>", name)
 		}
 		if _, dup := names[name]; dup {
 			t.Errorf("name=%q repeated across invocations", name)
 		}
 		names[name] = struct{}{}
 		if got := fc.createDoc.Metadata.Labels["kukeon.io/profile"]; got != "claude" {
-			t.Errorf("labels[kukeon.io/profile]=%q want claude", got)
+			t.Errorf("labels[kukeon.io/profile]=%q want claude (label tracks metadata.name)", got)
 		}
 	}
 }

--- a/internal/cellprofile/cellprofile.go
+++ b/internal/cellprofile/cellprofile.go
@@ -39,9 +39,10 @@ import (
 // can list all instances with `kuke get cells -l kukeon.io/profile=<name>`.
 const LabelProfile = "kukeon.io/profile"
 
-// nameSuffixBytes is the entropy width for namePrefix-generated cell names.
-// 3 bytes → 6 lowercase hex chars; matches K8s `generateName`'s suffix shape
-// closely enough that the names read familiar at a glance.
+// nameSuffixBytes is the entropy width for the suffix appended to every
+// generated cell name. 3 bytes → 6 lowercase hex chars; matches K8s
+// `generateName`'s suffix shape closely enough that the names read familiar
+// at a glance.
 const nameSuffixBytes = 3
 
 // EnvProfilesDir is the env var that overrides the default user profiles
@@ -161,6 +162,15 @@ func loadFile(path string) (*v1beta1.CellProfileDoc, error) {
 	if strings.TrimSpace(profile.Metadata.Name) == "" {
 		return nil, fmt.Errorf("profile %q: metadata.name is required: %w", path, errdefs.ErrProfileInvalid)
 	}
+	if strings.TrimSpace(profile.Spec.Cell.ID) != "" {
+		// Every materialized cell gets a generated `<prefix>-<6hex>` name; a
+		// hardcoded spec.cell.id would silently produce N cells sharing one ID.
+		// Reject loudly so the operator removes the stray field instead.
+		return nil, fmt.Errorf(
+			"profile %q: spec.cell.id must not be set on a CellProfile: %w",
+			path, errdefs.ErrProfileInvalid,
+		)
+	}
 	return &profile, nil
 }
 
@@ -169,14 +179,14 @@ func matchesName(profile *v1beta1.CellProfileDoc, name string) bool {
 }
 
 // Materialize converts a CellProfile into a CellDoc suitable for the same
-// path `kuke run -f` drives. When spec.namePrefix is set the cell name is
-// `<namePrefix>-<6hex>` (a fresh cell on every invocation); otherwise it
-// defaults to the profile's metadata.name and re-running the profile is
-// idempotent against the existing cell. The realm/space/stack triple is taken
-// from the profile spec verbatim — callers layer --realm/--space/--stack flag
-// overrides separately, mirroring the existing -f resolution. Every produced
-// cell also carries the kukeon.io/profile=<metadata.name> label so the set of
-// cells materialized from a profile is queryable via `kuke get cells -l`.
+// path `kuke run -f` drives. CellProfile is always a template: every call
+// returns a cell named `<prefix>-<6hex>`, where prefix is spec.prefix when set
+// and metadata.name otherwise. Singleton workloads belong on the Cell kind.
+// The realm/space/stack triple is taken from the profile spec verbatim —
+// callers layer --realm/--space/--stack flag overrides separately, mirroring
+// the existing -f resolution. Every produced cell also carries the
+// kukeon.io/profile=<metadata.name> label so the set of cells materialized
+// from a profile is queryable via `kuke get cells -l`.
 func Materialize(profile *v1beta1.CellProfileDoc) (v1beta1.CellDoc, error) {
 	cellName, err := resolveCellName(profile)
 	if err != nil {
@@ -187,9 +197,7 @@ func Materialize(profile *v1beta1.CellProfileDoc) (v1beta1.CellDoc, error) {
 	spec.RealmID = strings.TrimSpace(profile.Spec.Realm)
 	spec.SpaceID = strings.TrimSpace(profile.Spec.Space)
 	spec.StackID = strings.TrimSpace(profile.Spec.Stack)
-	if strings.TrimSpace(spec.ID) == "" {
-		spec.ID = cellName
-	}
+	spec.ID = cellName
 
 	return v1beta1.CellDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
@@ -203,9 +211,9 @@ func Materialize(profile *v1beta1.CellProfileDoc) (v1beta1.CellDoc, error) {
 }
 
 func resolveCellName(profile *v1beta1.CellProfileDoc) (string, error) {
-	prefix := strings.TrimSpace(profile.Spec.NamePrefix)
+	prefix := strings.TrimSpace(profile.Spec.Prefix)
 	if prefix == "" {
-		return profile.Metadata.Name, nil
+		prefix = profile.Metadata.Name
 	}
 	suffix, err := randomHexSuffix()
 	if err != nil {

--- a/internal/cellprofile/cellprofile_test.go
+++ b/internal/cellprofile/cellprofile_test.go
@@ -133,6 +133,30 @@ metadata:
 	}
 }
 
+func TestLoad_RejectsCellID(t *testing.T) {
+	// Materialized cell names are always generated, so a hardcoded spec.cell.id
+	// would silently produce N cells sharing one ID. Reject the field at load.
+	dir := t.TempDir()
+	writeProfile(t, dir, "with-id.yaml", `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: with-id
+spec:
+  cell:
+    id: pinned
+    containers:
+      - id: work
+        image: registry.eminwux.com/busybox:latest
+`)
+	_, err := cellprofile.Load(dir, "with-id")
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "spec.cell.id") {
+		t.Errorf("err %q must name spec.cell.id", err)
+	}
+}
+
 func TestList_SkipsBrokenAndNonYAML(t *testing.T) {
 	dir := t.TempDir()
 	writeProfile(t, dir, "claude-cell.yaml", claudeProfile)
@@ -175,7 +199,10 @@ func TestResolveDir_DefaultsUnderHome(t *testing.T) {
 	}
 }
 
-func TestMaterialize_DefaultName(t *testing.T) {
+func TestMaterialize_DefaultPrefix(t *testing.T) {
+	// Without spec.prefix the prefix defaults to metadata.name; the cell name
+	// is `<metadata.name>-<6hex>` and the realm/space/stack triple flows
+	// through verbatim.
 	profile := &v1beta1.CellProfileDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
 		Kind:       v1beta1.KindCellProfile,
@@ -197,8 +224,12 @@ func TestMaterialize_DefaultName(t *testing.T) {
 		t.Fatalf("Materialize: %v", err)
 	}
 
-	if doc.Metadata.Name != "claude-cell" {
-		t.Errorf("metadata.name=%q want claude-cell (default to profile name)", doc.Metadata.Name)
+	if !strings.HasPrefix(doc.Metadata.Name, "claude-cell-") {
+		t.Errorf("metadata.name=%q want prefix claude-cell-", doc.Metadata.Name)
+	}
+	suffix := strings.TrimPrefix(doc.Metadata.Name, "claude-cell-")
+	if len(suffix) != 6 {
+		t.Errorf("suffix=%q len=%d want 6 lowercase hex chars", suffix, len(suffix))
 	}
 	if doc.Kind != v1beta1.KindCell || doc.APIVersion != v1beta1.APIVersionV1Beta1 {
 		t.Errorf("apiVersion/kind=%q/%q want v1beta1/Cell", doc.APIVersion, doc.Kind)
@@ -207,8 +238,8 @@ func TestMaterialize_DefaultName(t *testing.T) {
 		t.Errorf("location=%q/%q/%q want default/agents/claude",
 			doc.Spec.RealmID, doc.Spec.SpaceID, doc.Spec.StackID)
 	}
-	if doc.Spec.ID != "claude-cell" {
-		t.Errorf("spec.id=%q want claude-cell (defaulted from cell name)", doc.Spec.ID)
+	if doc.Spec.ID != doc.Metadata.Name {
+		t.Errorf("spec.id=%q want %q (mirrors generated cell name)", doc.Spec.ID, doc.Metadata.Name)
 	}
 	if got := doc.Metadata.Labels[cellprofile.LabelProfile]; got != "claude-cell" {
 		t.Errorf("labels[%q]=%q want claude-cell (profile-of-origin label)",
@@ -216,39 +247,12 @@ func TestMaterialize_DefaultName(t *testing.T) {
 	}
 }
 
-func TestMaterialize_DefaultName_Idempotent(t *testing.T) {
-	// Without spec.namePrefix the same profile must produce the same cell name
-	// across invocations. This is the singleton path that pairs with the
-	// runner's already-exists idempotency.
+func TestMaterialize_DefaultPrefix_GeneratesUniqueCells(t *testing.T) {
+	// CellProfile is always a template: even without spec.prefix, successive
+	// calls must produce distinct names sharing the metadata.name prefix.
 	profile := &v1beta1.CellProfileDoc{
-		Metadata: v1beta1.CellProfileMetadata{Name: "singleton"},
+		Metadata: v1beta1.CellProfileMetadata{Name: "claude-cell"},
 		Spec: v1beta1.CellProfileSpec{
-			Cell: v1beta1.CellSpec{
-				Containers: []v1beta1.ContainerSpec{
-					{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
-				},
-			},
-		},
-	}
-
-	first, err := cellprofile.Materialize(profile)
-	if err != nil {
-		t.Fatalf("Materialize first: %v", err)
-	}
-	second, err := cellprofile.Materialize(profile)
-	if err != nil {
-		t.Fatalf("Materialize second: %v", err)
-	}
-	if first.Metadata.Name != "singleton" || second.Metadata.Name != "singleton" {
-		t.Fatalf("names=%q/%q want singleton/singleton", first.Metadata.Name, second.Metadata.Name)
-	}
-}
-
-func TestMaterialize_NamePrefix_GeneratesUniqueCells(t *testing.T) {
-	profile := &v1beta1.CellProfileDoc{
-		Metadata: v1beta1.CellProfileMetadata{Name: "claude"},
-		Spec: v1beta1.CellProfileSpec{
-			NamePrefix: "claude",
 			Cell: v1beta1.CellSpec{
 				Containers: []v1beta1.ContainerSpec{
 					{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
@@ -265,10 +269,44 @@ func TestMaterialize_NamePrefix_GeneratesUniqueCells(t *testing.T) {
 			t.Fatalf("Materialize #%d: %v", i, err)
 		}
 		name := doc.Metadata.Name
-		if !strings.HasPrefix(name, "claude-") {
-			t.Errorf("name=%q want prefix claude-", name)
+		if !strings.HasPrefix(name, "claude-cell-") {
+			t.Errorf("name=%q want prefix claude-cell-", name)
 		}
-		suffix := strings.TrimPrefix(name, "claude-")
+		if _, dup := seen[name]; dup {
+			t.Errorf("name=%q repeated across invocations", name)
+		}
+		seen[name] = struct{}{}
+		if got := doc.Metadata.Labels[cellprofile.LabelProfile]; got != "claude-cell" {
+			t.Errorf("labels[%q]=%q want claude-cell", cellprofile.LabelProfile, got)
+		}
+	}
+}
+
+func TestMaterialize_PrefixOverride_GeneratesUniqueCells(t *testing.T) {
+	profile := &v1beta1.CellProfileDoc{
+		Metadata: v1beta1.CellProfileMetadata{Name: "claude"},
+		Spec: v1beta1.CellProfileSpec{
+			Prefix: "agent",
+			Cell: v1beta1.CellSpec{
+				Containers: []v1beta1.ContainerSpec{
+					{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+				},
+			},
+		},
+	}
+
+	const invocations = 3
+	seen := make(map[string]struct{}, invocations)
+	for i := range invocations {
+		doc, err := cellprofile.Materialize(profile)
+		if err != nil {
+			t.Fatalf("Materialize #%d: %v", i, err)
+		}
+		name := doc.Metadata.Name
+		if !strings.HasPrefix(name, "agent-") {
+			t.Errorf("name=%q want prefix agent- (spec.prefix override)", name)
+		}
+		suffix := strings.TrimPrefix(name, "agent-")
 		if len(suffix) != 6 {
 			t.Errorf("suffix=%q len=%d want 6 lowercase hex chars", suffix, len(suffix))
 		}
@@ -281,10 +319,10 @@ func TestMaterialize_NamePrefix_GeneratesUniqueCells(t *testing.T) {
 		}
 		seen[name] = struct{}{}
 		if doc.Spec.ID != name {
-			t.Errorf("spec.id=%q want %q (defaulted from generated name)", doc.Spec.ID, name)
+			t.Errorf("spec.id=%q want %q (mirrors generated cell name)", doc.Spec.ID, name)
 		}
 		if got := doc.Metadata.Labels[cellprofile.LabelProfile]; got != "claude" {
-			t.Errorf("labels[%q]=%q want claude (profile-of-origin survives namePrefix path)",
+			t.Errorf("labels[%q]=%q want claude (profile-of-origin label tracks metadata.name, not prefix)",
 				cellprofile.LabelProfile, got)
 		}
 	}

--- a/pkg/api/model/v1beta1/cellprofile.go
+++ b/pkg/api/model/v1beta1/cellprofile.go
@@ -36,15 +36,14 @@ type CellProfileMetadata struct {
 // CellSpec body. The location uses the user-facing names rather than internal
 // IDs so a profile is portable between hosts.
 //
-// NamePrefix toggles the profile between singleton and template modes:
-// when empty, `kuke run -p` materializes a cell named after metadata.name and
-// the same invocation is idempotent. When set, every invocation generates a
-// fresh `<NamePrefix>-<6hex>` cell so the profile behaves like a template
-// (mirrors K8s `metadata.generateName` and sbsh's "every start is fresh").
+// Prefix is an optional override for the prefix used when generating cell
+// names; when unset, the prefix defaults to metadata.name. Every Materialize
+// call appends a `-<6hex>` suffix so each invocation produces a fresh cell —
+// CellProfile is always a template. Use the Cell kind for singleton workloads.
 type CellProfileSpec struct {
-	Realm      string   `json:"realm,omitempty"      yaml:"realm,omitempty"`
-	Space      string   `json:"space,omitempty"      yaml:"space,omitempty"`
-	Stack      string   `json:"stack,omitempty"      yaml:"stack,omitempty"`
-	NamePrefix string   `json:"namePrefix,omitempty" yaml:"namePrefix,omitempty"`
-	Cell       CellSpec `json:"cell"                 yaml:"cell"`
+	Realm  string   `json:"realm,omitempty"  yaml:"realm,omitempty"`
+	Space  string   `json:"space,omitempty"  yaml:"space,omitempty"`
+	Stack  string   `json:"stack,omitempty"  yaml:"stack,omitempty"`
+	Prefix string   `json:"prefix,omitempty" yaml:"prefix,omitempty"`
+	Cell   CellSpec `json:"cell"             yaml:"cell"`
 }


### PR DESCRIPTION
## Summary
- `CellProfile` is now always a template — every `Materialize` returns `<prefix>-<6hex>`. Prefix is `spec.prefix` if set, otherwise `metadata.name`. The prior singleton mode (idempotent re-attach when `namePrefix` was unset) is gone; the `Cell` kind is what represents singleton workloads.
- Field rename `spec.namePrefix` → `spec.prefix` (YAML/JSON tags follow); doc comment rewritten to drop the singleton/template framing and cast `prefix` as a default-prefix override.
- `loadFile` now rejects profiles with non-empty `spec.cell.id` — that field would otherwise produce N cells sharing one ID once names are always generated. Returns `errdefs.ErrProfileInvalid` with a message naming the field.
- Tests updated for the new shape: `TestMaterialize_DefaultName_Idempotent` removed; new `TestMaterialize_DefaultPrefix_GeneratesUniqueCells` covers default-prefix-from-`metadata.name`; `TestRun_FromProfile_NamePrefix_GeneratesFreshCell` renamed and reshaped for `spec.prefix`. Added `TestLoad_RejectsCellID`.

## Notable judgment calls
- Removed the `if spec.ID == ""` guard around the cell-name assignment in `Materialize` because `loadFile` now rejects non-empty `spec.cell.id` upfront — keeping the guard would imply the field is meaningful, and the issue explicitly wants it surfaced as an invariant rather than silently overwritten.
- `kukeon.io/profile=<metadata.name>` label-of-origin is unchanged and still tracks `metadata.name`, not the (possibly overridden) prefix — operators query by profile identity, not by the string used to generate names.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full unit suite)
- [ ] CLAUDE.md daemon-parity check (`kuke get realms` vs `--no-daemon`) — not run; this PR is client-only (cellprofile materialization happens in-process before any daemon RPC) and touches no daemon-visible code paths or `/opt/kukeon` reads.

## Breaking changes
Acceptable in v1beta1 per the issue:
- Profiles that omitted `namePrefix` and relied on singleton/idempotent behavior now create fresh cells. Migration: rewrite as a `Cell` doc and apply with `kuke run -f`.
- Profiles that set `namePrefix` must rename the field to `prefix`.
- Profiles that set `spec.cell.id` must remove it (now rejected at load).

Closes #197