### PR TITLE
feat(config): dump default Server/ClientConfiguration on first run

### DIFF
--- a/cmd/kuke/clientconfig_test.go
+++ b/cmd/kuke/clientconfig_test.go
@@ -214,3 +214,54 @@ spec:
 		t.Errorf("LogLevel: got %q, want %q", got, "warn")
 	}
 }
+
+// TestMaybeWriteClientConfigurationDefaultSkipsCustomPath locks the guard
+// that prevents tests (and operators pointing --configuration at a custom
+// location) from writing to ~/.kuke/kuke.yaml on the host. The path-equality
+// guard is what makes operator-supplied custom paths "opt out" of the
+// default-location dump (per the issue's "Both honor --configuration to opt
+// out of the default location" note).
+func TestMaybeWriteClientConfigurationDefaultSkipsCustomPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+
+	dir := t.TempDir()
+	custom := filepath.Join(dir, "custom-kuke.yaml")
+	maybeWriteClientConfigurationDefault(cmd, custom)
+
+	if _, statErr := os.Stat(custom); !os.IsNotExist(statErr) {
+		t.Fatalf("custom path was written; got Stat err=%v, want IsNotExist", statErr)
+	}
+}
+
+// TestMaybeWriteClientConfigurationDefaultWritesAtDefaultPath proves the
+// happy path: when the resolved path equals the project default, the dump
+// fires and produces a parseable document. We swap $HOME to a TempDir so
+// DefaultClientConfigurationFile() resolves to a sandbox path and the
+// host's real ~/.kuke is untouched.
+func TestMaybeWriteClientConfigurationDefaultWritesAtDefaultPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	t.Setenv("HOME", t.TempDir())
+	defaultPath := config.DefaultClientConfigurationFile()
+	if _, statErr := os.Stat(defaultPath); !os.IsNotExist(statErr) {
+		t.Fatalf("HOME shim is leaky; default path already exists: %v", statErr)
+	}
+
+	viper.Reset()
+	cmd, err := NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v", err)
+	}
+
+	maybeWriteClientConfigurationDefault(cmd, defaultPath)
+
+	if _, statErr := os.Stat(defaultPath); statErr != nil {
+		t.Fatalf("default-path write did not fire: %v", statErr)
+	}
+}

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -252,12 +252,32 @@ func loadClientConfiguration(cmd *cobra.Command) error {
 	if path == "" {
 		path = config.DefaultClientConfigurationFile()
 	}
+	// First-run dump: when the operator did not pick a custom --configuration,
+	// write the commented defaults to the well-known path so a fresh host has a
+	// template to edit. Skipped silently on permission/IO failures — kuke must
+	// still run with hardcoded defaults.
+	maybeWriteClientConfigurationDefault(cmd, path)
 	doc, err := clientconfig.Load(path)
 	if err != nil {
 		return fmt.Errorf("load client configuration: %w", err)
 	}
 	applyClientConfiguration(cmd, doc.Spec)
 	return nil
+}
+
+// maybeWriteClientConfigurationDefault writes the commented default
+// ClientConfiguration when the resolved --configuration path equals the
+// project default. The path-equality guard is the only filter: pointing
+// --configuration at a custom path opts out of the default-location dump
+// (the path won't equal the project default), while pointing it at the
+// default path is a no-op overwrite-guarded by O_EXCL inside WriteDefault.
+// Errors are intentionally swallowed: kuke must still run when $HOME is
+// read-only or the parent directory cannot be created.
+func maybeWriteClientConfigurationDefault(_ *cobra.Command, path string) {
+	if path != config.DefaultClientConfigurationFile() {
+		return
+	}
+	_, _ = clientconfig.WriteDefault(path)
 }
 
 // applyClientConfiguration layers the loaded ClientConfiguration on top of

--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -41,6 +41,12 @@ func NewKukeondCmd() (*cobra.Command, error) {
 			if path == "" {
 				path = config.DefaultServerConfigurationFile()
 			}
+			// First-run dump: when the operator did not pick a custom
+			// --configuration, write the commented defaults to the well-known
+			// path so a fresh host has a template to edit. Skipped silently
+			// on permission/IO failures — the daemon must still start with
+			// hardcoded defaults.
+			maybeWriteServerConfigurationDefault(cmd, path)
 			doc, err := serverconfig.Load(path)
 			if err != nil {
 				return fmt.Errorf("load server configuration: %w", err)
@@ -154,4 +160,22 @@ func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurati
 func envSet(v config.Var) bool {
 	_, ok := os.LookupEnv(v.EnvVar())
 	return ok
+}
+
+// maybeWriteServerConfigurationDefault writes the commented default
+// ServerConfiguration when the resolved --configuration path equals the
+// project default. The path-equality guard is the only filter: pointing
+// --configuration at a custom path opts out of the default-location dump
+// (the path won't equal the project default), while pointing it at the
+// default path is a no-op overwrite-guarded by O_EXCL inside WriteDefault.
+// This shape lets `kuke init` — which always plumbs --configuration
+// /etc/kukeon/kukeond.yaml into the kukeond cell — still produce a fresh
+// host's template on first boot. Errors are intentionally swallowed: a
+// read-only /etc or unwritable parent dir must not block the daemon from
+// starting on the in-binary defaults.
+func maybeWriteServerConfigurationDefault(_ *cobra.Command, path string) {
+	if path != config.DefaultServerConfigurationFile() {
+		return
+	}
+	_, _ = serverconfig.WriteDefault(path)
 }

--- a/cmd/kukeond/kukeond_test.go
+++ b/cmd/kukeond/kukeond_test.go
@@ -17,6 +17,8 @@
 package kukeond
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/eminwux/kukeon/cmd/config"
@@ -158,5 +160,28 @@ func TestApplyServerConfigurationEmptyFieldsLeaveViperUntouched(t *testing.T) {
 
 	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon/preexisting.sock" {
 		t.Errorf("empty spec must not overwrite existing viper value: got %q", got)
+	}
+}
+
+// TestMaybeWriteServerConfigurationDefaultSkipsCustomPath locks the guard
+// that prevents tests (and operators pointing --configuration at a custom
+// location) from writing to /etc/kukeon/kukeond.yaml on the host. The
+// path-equality guard is what makes operator-supplied custom paths opt out
+// of the default-location dump (per the issue's "Both honor --configuration
+// to opt out of the default location" note).
+func TestMaybeWriteServerConfigurationDefaultSkipsCustomPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	viper.Reset()
+	cmd, err := NewKukeondCmd()
+	if err != nil {
+		t.Fatalf("NewKukeondCmd() error = %v", err)
+	}
+
+	dir := t.TempDir()
+	custom := filepath.Join(dir, "custom-kukeond.yaml")
+	maybeWriteServerConfigurationDefault(cmd, custom)
+	if _, statErr := os.Stat(custom); !os.IsNotExist(statErr) {
+		t.Fatalf("custom path was written; got Stat err=%v, want IsNotExist", statErr)
 	}
 }

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -61,4 +62,61 @@ func Load(path string) (*v1beta1.ClientConfigurationDoc, error) {
 		)
 	}
 	return &doc, nil
+}
+
+// defaultDocument is the commented YAML written by WriteDefault on first
+// kuke invocation. Every spec field is present with its in-binary default and
+// a header comment explaining its purpose so the operator can tweak the file
+// without consulting source. The string round-trips through Load.
+const defaultDocument = `# kuke ClientConfiguration — auto-generated default.
+# kuke reads this file via --configuration (default ~/.kuke/kuke.yaml).
+# Precedence: explicit --flag > KUKEON_* env > this file > hardcoded default.
+# Existing files are never overwritten; delete this file to regenerate.
+apiVersion: v1beta1
+kind: ClientConfiguration
+metadata:
+  name: default
+spec:
+  # kukeond endpoint kuke dials by default.
+  # Examples: unix:///run/kukeon/kukeond.sock, ssh://user@host
+  # Default: unix:///run/kukeon/kukeond.sock
+  host: unix:///run/kukeon/kukeond.sock
+
+  # Kukeon runtime root used by --no-daemon operations that read /opt/kukeon
+  # directly instead of going through kukeond.
+  # Default: /opt/kukeon
+  runPath: /opt/kukeon
+
+  # Containerd unix socket --no-daemon operations connect to.
+  # Default: /run/containerd/containerd.sock
+  containerdSocket: /run/containerd/containerd.sock
+
+  # Client log level when --verbose is on (debug, info, warn, error).
+  # Default: info
+  logLevel: info
+`
+
+// WriteDefault writes the commented default ClientConfiguration to path when
+// the file is absent. Returns true only when this call created the file; an
+// existing file (any contents) is left untouched, satisfying the "first-write
+// only" rule. Creates the parent directory if missing. Any other failure is
+// returned wrapped.
+func WriteDefault(path string) (bool, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return false, fmt.Errorf("create parent directory for %q: %w", path, err)
+	}
+	// O_EXCL closes the TOCTOU race between Stat and Create — two concurrent
+	// kuke invocations can't both believe they wrote the file.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("create %q: %w", path, err)
+	}
+	defer f.Close()
+	if _, writeErr := f.WriteString(defaultDocument); writeErr != nil {
+		return false, fmt.Errorf("write %q: %w", path, writeErr)
+	}
+	return true, nil
 }

--- a/internal/clientconfig/clientconfig_test.go
+++ b/internal/clientconfig/clientconfig_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -137,5 +138,89 @@ func TestLoadEmptyKindAccepted(t *testing.T) {
 	}
 	if doc.Spec.Host != "unix:///tmp/kuke-test.sock" {
 		t.Errorf("Host: got %q", doc.Spec.Host)
+	}
+}
+
+func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
+	dir := t.TempDir()
+	// Nested parent directory exercises the MkdirAll branch.
+	path := filepath.Join(dir, "a", "b", "kuke.yaml")
+
+	wrote, err := WriteDefault(path)
+	if err != nil {
+		t.Fatalf("WriteDefault: %v", err)
+	}
+	if !wrote {
+		t.Fatal("WriteDefault returned wrote=false on a fresh path")
+	}
+
+	// Round-trip: the freshly written file must parse cleanly through Load
+	// and surface every documented default. AC: "Generated YAML round-trips
+	// through the loader without errors."
+	doc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() round-trip: %v", err)
+	}
+	if doc.Kind != v1beta1.KindClientConfiguration {
+		t.Errorf("Kind: got %q, want %q", doc.Kind, v1beta1.KindClientConfiguration)
+	}
+	if doc.APIVersion != v1beta1.APIVersionV1Beta1 {
+		t.Errorf("APIVersion: got %q, want %q", doc.APIVersion, v1beta1.APIVersionV1Beta1)
+	}
+	if doc.Spec.Host != "unix:///run/kukeon/kukeond.sock" {
+		t.Errorf("Spec.Host: got %q", doc.Spec.Host)
+	}
+	if doc.Spec.RunPath != "/opt/kukeon" {
+		t.Errorf("Spec.RunPath: got %q", doc.Spec.RunPath)
+	}
+	if doc.Spec.ContainerdSocket != "/run/containerd/containerd.sock" {
+		t.Errorf("Spec.ContainerdSocket: got %q", doc.Spec.ContainerdSocket)
+	}
+	if doc.Spec.LogLevel != "info" {
+		t.Errorf("Spec.LogLevel: got %q", doc.Spec.LogLevel)
+	}
+
+	// AC: "Header comment explains each field's purpose and default."
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	rawStr := string(raw)
+	if !strings.Contains(rawStr, "# kuke ClientConfiguration") {
+		t.Errorf("missing header comment block")
+	}
+	for _, marker := range []string{
+		"# Default: unix:///run/kukeon/kukeond.sock",
+		"# Default: /opt/kukeon",
+		"# Default: /run/containerd/containerd.sock",
+		"# Default: info",
+	} {
+		if !strings.Contains(rawStr, marker) {
+			t.Errorf("missing per-field default marker %q in dumped YAML", marker)
+		}
+	}
+}
+
+func TestWriteDefaultLeavesExistingFileUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuke.yaml")
+	preexisting := []byte("# operator-edited file\nkind: ClientConfiguration\n")
+	if err := os.WriteFile(path, preexisting, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	wrote, err := WriteDefault(path)
+	if err != nil {
+		t.Fatalf("WriteDefault: %v", err)
+	}
+	if wrote {
+		t.Fatal("WriteDefault overwrote an existing file (wrote=true)")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after WriteDefault: %v", err)
+	}
+	if string(got) != string(preexisting) {
+		t.Errorf("file contents changed:\n got: %q\nwant: %q", got, preexisting)
 	}
 }

--- a/internal/serverconfig/serverconfig.go
+++ b/internal/serverconfig/serverconfig.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -62,4 +63,72 @@ func Load(path string) (*v1beta1.ServerConfigurationDoc, error) {
 		)
 	}
 	return &doc, nil
+}
+
+// defaultDocument is the commented YAML written by WriteDefault on first
+// kukeond start. Every spec field is present with its in-binary default and
+// a header comment explaining its purpose so the operator can tweak the file
+// without consulting source. The string round-trips through Load.
+const defaultDocument = `# kukeond ServerConfiguration — auto-generated default.
+# kukeond reads this file via --configuration (default /etc/kukeon/kukeond.yaml).
+# Precedence: explicit --flag > KUKEON_*/KUKEOND_* env > this file > hardcoded default.
+# Existing files are never overwritten; delete this file to regenerate.
+apiVersion: v1beta1
+kind: ServerConfiguration
+metadata:
+  name: default
+spec:
+  # Unix socket path the daemon listens on.
+  # Default: /run/kukeon/kukeond.sock
+  socket: /run/kukeon/kukeond.sock
+
+  # Numeric group ID the daemon chowns its listener socket to (mode 0o660 with
+  # group). Zero means root-only access. ` + "`kuke init`" + ` plumbs the kukeon GID here
+  # so non-root group members can dial the daemon after a kukeond restart.
+  # Default: 0
+  socketGID: 0
+
+  # Kukeon runtime root — the on-disk hierarchy under which realms, spaces,
+  # stacks, and cells live.
+  # Default: /opt/kukeon
+  runPath: /opt/kukeon
+
+  # Path to the containerd unix socket the daemon connects to.
+  # Default: /run/containerd/containerd.sock
+  containerdSocket: /run/containerd/containerd.sock
+
+  # Daemon log level (debug, info, warn, error).
+  # Default: info
+  logLevel: info
+
+  # Container image ` + "`kuke init`" + ` provisions for the kukeond system cell.
+  # Read by ` + "`kuke init`" + ` only; the daemon ignores it. Empty means kuke init
+  # picks the release-matching ghcr.io/eminwux/kukeon image automatically.
+  # Default: ""
+  kukeondImage: ""
+`
+
+// WriteDefault writes the commented default ServerConfiguration to path when
+// the file is absent. Returns true only when this call created the file; an
+// existing file (any contents) is left untouched, satisfying the "first-write
+// only" rule. Creates the parent directory if missing. Any other failure is
+// returned wrapped.
+func WriteDefault(path string) (bool, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return false, fmt.Errorf("create parent directory for %q: %w", path, err)
+	}
+	// O_EXCL closes the TOCTOU race between Stat and Create — two concurrent
+	// kukeond starts can't both believe they wrote the file.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("create %q: %w", path, err)
+	}
+	defer f.Close()
+	if _, writeErr := f.WriteString(defaultDocument); writeErr != nil {
+		return false, fmt.Errorf("write %q: %w", path, writeErr)
+	}
+	return true, nil
 }

--- a/internal/serverconfig/serverconfig_test.go
+++ b/internal/serverconfig/serverconfig_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -145,5 +146,97 @@ func TestLoadEmptyKindAccepted(t *testing.T) {
 	}
 	if doc.Spec.Socket != "/run/kukeon/test.sock" {
 		t.Errorf("Socket: got %q", doc.Spec.Socket)
+	}
+}
+
+func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
+	dir := t.TempDir()
+	// Nested parent directory exercises the MkdirAll branch.
+	path := filepath.Join(dir, "a", "b", "kukeond.yaml")
+
+	wrote, err := WriteDefault(path)
+	if err != nil {
+		t.Fatalf("WriteDefault: %v", err)
+	}
+	if !wrote {
+		t.Fatal("WriteDefault returned wrote=false on a fresh path")
+	}
+
+	// Round-trip: the freshly written file must parse cleanly through Load
+	// and surface every documented default. AC: "Generated YAML round-trips
+	// through the loader without errors."
+	doc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() round-trip: %v", err)
+	}
+	if doc.Kind != v1beta1.KindServerConfiguration {
+		t.Errorf("Kind: got %q, want %q", doc.Kind, v1beta1.KindServerConfiguration)
+	}
+	if doc.APIVersion != v1beta1.APIVersionV1Beta1 {
+		t.Errorf("APIVersion: got %q, want %q", doc.APIVersion, v1beta1.APIVersionV1Beta1)
+	}
+	if doc.Spec.Socket != "/run/kukeon/kukeond.sock" {
+		t.Errorf("Spec.Socket: got %q", doc.Spec.Socket)
+	}
+	if doc.Spec.SocketGID != 0 {
+		t.Errorf("Spec.SocketGID: got %d, want 0", doc.Spec.SocketGID)
+	}
+	if doc.Spec.RunPath != "/opt/kukeon" {
+		t.Errorf("Spec.RunPath: got %q", doc.Spec.RunPath)
+	}
+	if doc.Spec.ContainerdSocket != "/run/containerd/containerd.sock" {
+		t.Errorf("Spec.ContainerdSocket: got %q", doc.Spec.ContainerdSocket)
+	}
+	if doc.Spec.LogLevel != "info" {
+		t.Errorf("Spec.LogLevel: got %q", doc.Spec.LogLevel)
+	}
+	if doc.Spec.KukeondImage != "" {
+		t.Errorf("Spec.KukeondImage: got %q, want empty (kuke init resolves at runtime)", doc.Spec.KukeondImage)
+	}
+
+	// AC: "Header comment explains each field's purpose and default."
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	rawStr := string(raw)
+	if !strings.Contains(rawStr, "# kukeond ServerConfiguration") {
+		t.Errorf("missing header comment block")
+	}
+	for _, marker := range []string{
+		"# Default: /run/kukeon/kukeond.sock",
+		"# Default: 0",
+		"# Default: /opt/kukeon",
+		"# Default: /run/containerd/containerd.sock",
+		"# Default: info",
+		`# Default: ""`,
+	} {
+		if !strings.Contains(rawStr, marker) {
+			t.Errorf("missing per-field default marker %q in dumped YAML", marker)
+		}
+	}
+}
+
+func TestWriteDefaultLeavesExistingFileUntouched(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kukeond.yaml")
+	preexisting := []byte("# operator-edited file\nkind: ServerConfiguration\n")
+	if err := os.WriteFile(path, preexisting, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	wrote, err := WriteDefault(path)
+	if err != nil {
+		t.Fatalf("WriteDefault: %v", err)
+	}
+	if wrote {
+		t.Fatal("WriteDefault overwrote an existing file (wrote=true)")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after WriteDefault: %v", err)
+	}
+	if string(got) != string(preexisting) {
+		t.Errorf("file contents changed:\n got: %q\nwant: %q", got, preexisting)
 	}
 }


### PR DESCRIPTION
## Summary
- On first invocation, `kukeond serve` writes a fully-populated default `ServerConfiguration` YAML to `/etc/kukeon/kukeond.yaml` (every field present with header comments naming purpose + default).
- On first invocation, `kuke <any>` writes a fully-populated default `ClientConfiguration` YAML to `~/.kuke/kuke.yaml` (existing project default kept intact — see judgment call below).
- Existing files at the default path are never overwritten — `O_CREATE|O_EXCL` plus a parent `MkdirAll` close the TOCTOU race; an `os.ErrExist` returns `wrote=false, err=nil`.
- Errors during the dump are intentionally swallowed in the wiring helpers: a read-only `/etc` or `$HOME` must not block the daemon or client from running on hardcoded defaults.
- Unit tests cover the three behaviors directly (round-trip via `Load`, no-overwrite, custom-path skip) and the CLI-wiring tests cover the path-equality guard + the happy default-path write under a sandboxed `$HOME`.

## Notable judgment calls
- **Guard semantics — path-equality only, no flag-changed check.** Reading AC #4 literally ("skipped when `--configuration` is set") would silence the dump when `kuke init` plumbs `--configuration /etc/kukeon/kukeond.yaml` into the kukeond cell — which would defeat AC #1 on a fresh `kuke init`. The issue's Notes section says "Both honor `--configuration` to opt out of the default location," so I read AC #4 as "opt out when pointing at a custom path" and implemented that with a single `path == DefaultXxxFile()` check. Pointing `--configuration` at a custom path opts out cleanly; pointing it at the default path is a no-op overwrite-guarded by `O_EXCL`. Reviewer can swap to a strict literal reading by adding the flag-changed check back, but that path requires a parallel `kuke init` hook to satisfy AC #1.
- **ClientConfiguration default path kept at `~/.kuke/kuke.yaml`** (the existing project default), not the issue body's `~/.config/kukeon/kuke.yaml`. The existing default is what the loader already reads and what the existing tests target; switching it would be a behavior change unrelated to first-run dumping. Reviewer can ask for the path swap as a separate concern.
- **Cobra leaf flag-Changed pitfall.** Empirical probe confirmed `cmd.PersistentFlags().Changed` returns false on the leaf subcommand because parent persistent flags aren't on the leaf's set; `cmd.Flags().Changed` returns true after merge. Mentioning this because the existing kukeond `applyServerConfiguration`'s `flags.Changed` checks (cmd/kukeond/kukeond.go:133) may have the same latent issue (unrelated to this PR — flagging for a follow-up).
- **YAML emission via hand-written templated string** (not yaml.v3 `Node` with `HeadComment`). Hand-rolling keeps the field-level comments exactly readable in source, lets `kukeondImage: ""` survive omitempty, and is simple to round-trip-test.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes
- [x] golangci-lint passes (gosec G301/G302 → 0o750 dirs, 0o600 files; nonamedreturns; govet shadow)
- [x] **Smoke test per `CLAUDE.md` (touches the daemon)** — torn down `kuke-system/kukeon/kukeon/kukeond`, removed dumped configs, rebuilt `./kuke` and the local kukeond image, ran `sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev`; both `/etc/kukeon/kukeond.yaml` and `/root/.kuke/kuke.yaml` were dumped with the expected content. Confirmed a second invocation does NOT update mtime (no overwrite).
- [x] **Daemon-parity check** — `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` produced identical output.

Closes #204
