### PR TITLE
feat: add kuke image load for realm-scoped image import

### DIFF
--- a/cmd/kuke/image/image.go
+++ b/cmd/kuke/image/image.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package image hosts the `kuke image` parent command and its subcommands.
+// Phase 1 ships `load` only; `get` and `delete` arrive in #211 and #212.
+package image
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewImageCmd builds the `kuke image` parent command and registers its
+// subcommands. Persistent flags on the root kuke command are inherited
+// automatically.
+func NewImageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Manage container images in a realm's containerd namespace",
+		Run: func(cmd *cobra.Command, _ []string) {
+			_ = cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(NewLoadCmd())
+
+	return cmd
+}

--- a/cmd/kuke/image/load.go
+++ b/cmd/kuke/image/load.go
@@ -1,0 +1,166 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	"github.com/spf13/cobra"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewLoadCmd builds the `kuke image load` subcommand. Either a positional
+// tarball path or `--from-docker <ref>` is required; passing both is a usage
+// error.
+func NewLoadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "load [tarball | -]",
+		Short:         "Import an OCI/docker image tarball into a realm's containerd namespace",
+		Long:          "Import an OCI/docker image tarball into the containerd namespace mapped to --realm. Pass a tarball path, '-' for stdin, or --from-docker <ref> to shell out to `docker save`.",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			realm, err := cmd.Flags().GetString("realm")
+			if err != nil {
+				return err
+			}
+			realm = strings.TrimSpace(realm)
+			if realm == "" {
+				return errdefs.ErrRealmNameRequired
+			}
+
+			fromDocker, err := cmd.Flags().GetString("from-docker")
+			if err != nil {
+				return err
+			}
+			fromDocker = strings.TrimSpace(fromDocker)
+
+			tarball, err := readTarball(cmd, args, fromDocker)
+			if err != nil {
+				return err
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			result, err := client.LoadImage(cmd.Context(), realm, tarball)
+			if err != nil {
+				return err
+			}
+
+			printLoadResult(cmd, result)
+			return nil
+		},
+	}
+
+	cmd.Flags().String("realm", consts.KukeonDefaultRealmName, "Target realm; the image lands in <realm>.kukeon.io")
+	cmd.Flags().
+		String("from-docker", "", "Image reference to pipe in via `docker save <ref>` (mutually exclusive with the positional tarball)")
+
+	return cmd
+}
+
+// readTarball resolves the tarball bytes from one of three sources:
+// positional path, '-' for stdin, or --from-docker shelling out to
+// `docker save`. Exactly one source must be supplied.
+func readTarball(cmd *cobra.Command, args []string, fromDocker string) ([]byte, error) {
+	hasPositional := len(args) > 0 && args[0] != ""
+
+	switch {
+	case fromDocker != "" && hasPositional:
+		return nil, errors.New("pass either a tarball path or --from-docker, not both")
+	case fromDocker == "" && !hasPositional:
+		return nil, errors.New("a tarball path, '-' for stdin, or --from-docker <ref> is required")
+	case fromDocker != "":
+		return readFromDocker(cmd, fromDocker)
+	}
+
+	if args[0] == "-" {
+		tarball, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tarball from stdin: %w", err)
+		}
+		if len(tarball) == 0 {
+			return nil, errdefs.ErrTarballRequired
+		}
+		return tarball, nil
+	}
+
+	reader, cleanup, err := kukshared.ReadFileOrStdin(args[0])
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cleanup() }()
+
+	tarball, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read tarball: %w", err)
+	}
+	if len(tarball) == 0 {
+		return nil, errdefs.ErrTarballRequired
+	}
+	return tarball, nil
+}
+
+// readFromDocker shells out to `docker save <ref>` and captures the produced
+// tarball. Stderr is forwarded to the cobra command's err writer so docker's
+// own error messages reach the operator (e.g., "Error response from daemon:
+// reference does not exist").
+func readFromDocker(cmd *cobra.Command, ref string) ([]byte, error) {
+	dockerCmd := exec.CommandContext(cmd.Context(), "docker", "save", ref)
+	dockerCmd.Stderr = cmd.ErrOrStderr()
+	out, err := dockerCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker save %s: %w", ref, err)
+	}
+	if len(out) == 0 {
+		return nil, errdefs.ErrTarballRequired
+	}
+	return out, nil
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukshared.ClientFromCmd(cmd)
+}
+
+func printLoadResult(cmd *cobra.Command, result kukeonv1.LoadImageResult) {
+	if len(result.Images) == 0 {
+		cmd.Printf("loaded 0 images into realm %q (namespace %q)\n", result.Realm, result.Namespace)
+		return
+	}
+	cmd.Printf("loaded %d image(s) into realm %q (namespace %q):\n", len(result.Images), result.Realm, result.Namespace)
+	for _, name := range result.Images {
+		cmd.Printf("  - %s\n", name)
+	}
+}

--- a/cmd/kuke/image/load_test.go
+++ b/cmd/kuke/image/load_test.go
@@ -1,0 +1,179 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package image_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	image "github.com/eminwux/kukeon/cmd/kuke/image"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+)
+
+func TestLoadCmd_FromFileDefaultRealm(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "img.tar")
+	want := []byte("oci-tarball-bytes")
+	if err := os.WriteFile(tarPath, want, 0o600); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+
+	var gotRealm string
+	var gotBytes []byte
+	fake := &fakeClient{
+		loadImageFn: func(realm string, tarball []byte) (kukeonv1.LoadImageResult, error) {
+			gotRealm = realm
+			gotBytes = tarball
+			return kukeonv1.LoadImageResult{
+				Realm:     realm,
+				Namespace: realm + ".kukeon.io",
+				Images:    []string{"docker.io/library/foo:bar"},
+			}, nil
+		},
+	}
+
+	out, err := runLoad(t, fake, []string{tarPath})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotRealm != "default" {
+		t.Errorf("realm = %q, want default", gotRealm)
+	}
+	if !bytes.Equal(gotBytes, want) {
+		t.Errorf("client received %d bytes, want %d", len(gotBytes), len(want))
+	}
+	if !strings.Contains(out, "docker.io/library/foo:bar") {
+		t.Errorf("output missing image name; got: %s", out)
+	}
+}
+
+func TestLoadCmd_FromStdinExplicitRealm(t *testing.T) {
+	want := []byte("stdin-tarball")
+
+	var gotRealm string
+	var gotBytes []byte
+	fake := &fakeClient{
+		loadImageFn: func(realm string, tarball []byte) (kukeonv1.LoadImageResult, error) {
+			gotRealm = realm
+			gotBytes = tarball
+			return kukeonv1.LoadImageResult{Realm: realm, Namespace: "kuke-system.kukeon.io"}, nil
+		},
+	}
+
+	if _, err := runLoadWithStdin(t, fake, []string{"-", "--realm", "kuke-system"}, bytes.NewReader(want)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotRealm != "kuke-system" {
+		t.Errorf("realm = %q, want kuke-system", gotRealm)
+	}
+	if !bytes.Equal(gotBytes, want) {
+		t.Errorf("client received %d bytes, want %d", len(gotBytes), len(want))
+	}
+}
+
+func TestLoadCmd_FromDockerAndPositionalAreMutuallyExclusive(t *testing.T) {
+	fake := &fakeClient{
+		loadImageFn: func(string, []byte) (kukeonv1.LoadImageResult, error) {
+			t.Fatal("client should not be invoked")
+			return kukeonv1.LoadImageResult{}, nil
+		},
+	}
+
+	_, err := runLoad(t, fake, []string{"foo.tar", "--from-docker", "kukeon-local:dev"})
+	if err == nil {
+		t.Fatal("expected mutually-exclusive error, got nil")
+	}
+	if !strings.Contains(err.Error(), "either a tarball path or --from-docker") {
+		t.Errorf("error = %q, want mutually-exclusive message", err.Error())
+	}
+}
+
+func TestLoadCmd_NoSourceIsAnError(t *testing.T) {
+	fake := &fakeClient{}
+	_, err := runLoad(t, fake, nil)
+	if err == nil {
+		t.Fatal("expected missing-source error, got nil")
+	}
+	if !strings.Contains(err.Error(), "is required") {
+		t.Errorf("error = %q, want missing-source message", err.Error())
+	}
+}
+
+func TestLoadCmd_ClientErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "img.tar")
+	if err := os.WriteFile(tarPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+
+	fake := &fakeClient{
+		loadImageFn: func(string, []byte) (kukeonv1.LoadImageResult, error) {
+			return kukeonv1.LoadImageResult{}, errors.New("boom")
+		},
+	}
+
+	if _, err := runLoad(t, fake, []string{tarPath}); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected client error to propagate, got %v", err)
+	}
+}
+
+// --- helpers ---
+
+func runLoad(t *testing.T, fake *fakeClient, args []string) (string, error) {
+	t.Helper()
+	return runLoadWithStdin(t, fake, args, nil)
+}
+
+func runLoadWithStdin(t *testing.T, fake *fakeClient, args []string, stdin io.Reader) (string, error) {
+	t.Helper()
+	cmd := image.NewLoadCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	if stdin != nil {
+		cmd.SetIn(stdin)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, image.MockControllerKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	loadImageFn func(realm string, tarball []byte) (kukeonv1.LoadImageResult, error)
+}
+
+func (f *fakeClient) LoadImage(_ context.Context, realm string, tarball []byte) (kukeonv1.LoadImageResult, error) {
+	if f.loadImageFn == nil {
+		return kukeonv1.LoadImageResult{}, errors.New("unexpected LoadImage call")
+	}
+	return f.loadImageFn(realm, tarball)
+}

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -29,6 +29,7 @@ import (
 	createcmd "github.com/eminwux/kukeon/cmd/kuke/create"
 	deletecmd "github.com/eminwux/kukeon/cmd/kuke/delete"
 	getcmd "github.com/eminwux/kukeon/cmd/kuke/get"
+	imagecmd "github.com/eminwux/kukeon/cmd/kuke/image"
 	initcmd "github.com/eminwux/kukeon/cmd/kuke/init"
 	killcmd "github.com/eminwux/kukeon/cmd/kuke/kill"
 	logcmd "github.com/eminwux/kukeon/cmd/kuke/log"
@@ -138,6 +139,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(attachcmd.NewAttachCmd())
 	rootCmd.AddCommand(logcmd.NewLogCmd())
 	rootCmd.AddCommand(autocompletecmd.NewAutocompleteCmd())
+	rootCmd.AddCommand(imagecmd.NewImageCmd())
 	rootCmd.AddCommand(uninstallcmd.NewUninstallCmd())
 	rootCmd.AddCommand(version.NewVersionCmd())
 

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -860,6 +860,26 @@ func formatValidationErrors(validationErrors []*parser.ValidationError) error {
 	return fmt.Errorf("validation failed:\n  %s", strings.Join(msgs, "\n  "))
 }
 
+// ---- Image ----
+
+// LoadImage imports an OCI/docker image tarball into the realm's containerd
+// namespace. The byte slice is wrapped in a bytes.Reader so the controller
+// can stream it through to containerd's Import API.
+func (c *Client) LoadImage(_ context.Context, realm string, tarball []byte) (kukeonv1.LoadImageResult, error) {
+	if len(tarball) == 0 {
+		return kukeonv1.LoadImageResult{}, errdefs.ErrTarballRequired
+	}
+	res, err := c.ctrl.LoadImage(realm, bytes.NewReader(tarball))
+	if err != nil {
+		return kukeonv1.LoadImageResult{}, err
+	}
+	return kukeonv1.LoadImageResult{
+		Realm:     res.Realm,
+		Namespace: res.Namespace,
+		Images:    res.Images,
+	}, nil
+}
+
 // ---- Attach ----
 
 // AttachContainer enforces the Attachable gate and resolves the host-side

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -111,6 +111,9 @@ type fakeRunner struct {
 	RefreshSpaceFn func(space intmodel.Space) (intmodel.Space, bool, error)
 	RefreshStackFn func(stack intmodel.Stack) (intmodel.Stack, bool, error)
 	RefreshCellFn  func(cell intmodel.Cell) (intmodel.Cell, int, error)
+
+	// Image methods
+	LoadImageFn func(namespace string, reader io.Reader) ([]string, error)
 }
 
 // Realm methods
@@ -531,6 +534,13 @@ func (f *fakeRunner) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error)
 		return f.RefreshCellFn(cell)
 	}
 	return intmodel.Cell{}, 0, errors.New("unexpected call to RefreshCell")
+}
+
+func (f *fakeRunner) LoadImage(namespace string, reader io.Reader) ([]string, error) {
+	if f.LoadImageFn != nil {
+		return f.LoadImageFn(namespace, reader)
+	}
+	return nil, errors.New("unexpected call to LoadImage")
 }
 
 // Test helper functions

--- a/internal/controller/load_image.go
+++ b/internal/controller/load_image.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// LoadImageResult reports the outcome of a `kuke image load` import.
+type LoadImageResult struct {
+	Realm     string
+	Namespace string
+	Images    []string
+}
+
+// LoadImage imports an OCI/docker image tarball into the realm's containerd
+// namespace. The realm name is mapped to a containerd namespace via
+// consts.RealmNamespace, the same source of truth used by `kuke init` and
+// every other realm operation.
+func (b *Exec) LoadImage(realm string, reader io.Reader) (LoadImageResult, error) {
+	var res LoadImageResult
+
+	realmName := strings.TrimSpace(realm)
+	if realmName == "" {
+		return res, errdefs.ErrRealmNameRequired
+	}
+	if reader == nil {
+		return res, errdefs.ErrTarballRequired
+	}
+
+	lookup := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: realmName},
+	}
+	if _, err := b.runner.GetRealm(lookup); err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			return res, fmt.Errorf("%w: %s", errdefs.ErrRealmNotFound, realmName)
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetRealm, err)
+	}
+
+	namespace := consts.RealmNamespace(realmName)
+	images, err := b.runner.LoadImage(namespace, reader)
+	if err != nil {
+		return res, fmt.Errorf("%w: %w", errdefs.ErrLoadImage, err)
+	}
+
+	res.Realm = realmName
+	res.Namespace = namespace
+	res.Images = images
+	return res, nil
+}

--- a/internal/controller/load_image_test.go
+++ b/internal/controller/load_image_test.go
@@ -1,0 +1,153 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+func TestLoadImage_Success(t *testing.T) {
+	tarball := []byte("fake-tarball-bytes")
+	wantNS := consts.RealmNamespace("kuke-system")
+
+	var gotNS string
+	var gotBytes []byte
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("kuke-system", wantNS), nil
+		},
+		LoadImageFn: func(ns string, r io.Reader) ([]string, error) {
+			gotNS = ns
+			b, err := io.ReadAll(r)
+			if err != nil {
+				return nil, err
+			}
+			gotBytes = b
+			return []string{"docker.io/library/kukeon-local:dev"}, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.LoadImage("kuke-system", bytes.NewReader(tarball))
+	if err != nil {
+		t.Fatalf("LoadImage returned error: %v", err)
+	}
+
+	if res.Realm != "kuke-system" {
+		t.Errorf("Realm = %q, want %q", res.Realm, "kuke-system")
+	}
+	if res.Namespace != wantNS {
+		t.Errorf("Namespace = %q, want %q", res.Namespace, wantNS)
+	}
+	if len(res.Images) != 1 || res.Images[0] != "docker.io/library/kukeon-local:dev" {
+		t.Errorf("Images = %v, want [docker.io/library/kukeon-local:dev]", res.Images)
+	}
+	if gotNS != wantNS {
+		t.Errorf("runner received namespace %q, want %q", gotNS, wantNS)
+	}
+	if !bytes.Equal(gotBytes, tarball) {
+		t.Errorf("runner received %d bytes, want %d", len(gotBytes), len(tarball))
+	}
+}
+
+func TestLoadImage_DefaultRealmMappedToDefaultNamespace(t *testing.T) {
+	wantNS := consts.RealmNamespace(consts.KukeonDefaultRealmName)
+
+	var gotNS string
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm(consts.KukeonDefaultRealmName, wantNS), nil
+		},
+		LoadImageFn: func(ns string, _ io.Reader) ([]string, error) {
+			gotNS = ns
+			return []string{"foo"}, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	if _, err := ctrl.LoadImage(consts.KukeonDefaultRealmName, bytes.NewReader([]byte("x"))); err != nil {
+		t.Fatalf("LoadImage returned error: %v", err)
+	}
+	if gotNS != wantNS {
+		t.Errorf("runner saw namespace %q, want %q", gotNS, wantNS)
+	}
+}
+
+func TestLoadImage_RealmNotFound(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errdefs.ErrRealmNotFound
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.LoadImage("ghost", bytes.NewReader([]byte("x")))
+	if !errors.Is(err, errdefs.ErrRealmNotFound) {
+		t.Fatalf("expected ErrRealmNotFound, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error message should name the missing realm; got %q", err.Error())
+	}
+}
+
+func TestLoadImage_EmptyRealm(t *testing.T) {
+	mock := &fakeRunner{}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.LoadImage("   ", bytes.NewReader([]byte("x")))
+	if !errors.Is(err, errdefs.ErrRealmNameRequired) {
+		t.Fatalf("expected ErrRealmNameRequired, got %v", err)
+	}
+}
+
+func TestLoadImage_NilReader(t *testing.T) {
+	mock := &fakeRunner{}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.LoadImage("default", nil)
+	if !errors.Is(err, errdefs.ErrTarballRequired) {
+		t.Fatalf("expected ErrTarballRequired, got %v", err)
+	}
+}
+
+func TestLoadImage_RunnerErrorIsWrapped(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", ""), nil
+		},
+		LoadImageFn: func(_ string, _ io.Reader) ([]string, error) {
+			return nil, errors.New("containerd unreachable")
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.LoadImage("default", bytes.NewReader([]byte("x")))
+	if !errors.Is(err, errdefs.ErrLoadImage) {
+		t.Fatalf("expected ErrLoadImage wrapper, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "containerd unreachable") {
+		t.Errorf("inner error should be preserved; got %q", err.Error())
+	}
+}

--- a/internal/controller/runner/load_image.go
+++ b/internal/controller/runner/load_image.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// LoadImage imports an OCI/docker image tarball into the given containerd
+// namespace and returns the names of the imported images. The caller is
+// responsible for ensuring the namespace exists; the controller layer
+// validates the realm before invoking this method.
+func (r *Exec) LoadImage(namespace string, reader io.Reader) ([]string, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return nil, errdefs.ErrCheckNamespaceExists
+	}
+	if err := r.ensureClientConnected(); err != nil {
+		return nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+	r.ctrClient.SetNamespace(namespace)
+	return r.ctrClient.LoadImage(reader)
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"context"
+	"io"
 	"log/slog"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -96,6 +97,10 @@ type Runner interface {
 	GetContainerState(cell intmodel.Cell, containerID string) (intmodel.ContainerState, error)
 
 	WaitCellRootTaskExit(ctx context.Context, cell intmodel.Cell) (<-chan containerd.ExitStatus, error)
+
+	// LoadImage imports an OCI/docker image tarball into the given
+	// containerd namespace and returns the names of the imported images.
+	LoadImage(namespace string, reader io.Reader) ([]string, error)
 
 	Close() error
 }

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"sync"
 
@@ -85,6 +86,11 @@ type Client interface {
 	WaitTaskExit(ctx context.Context, id string) (<-chan containerd.ExitStatus, error)
 
 	ResolveSbshCachePath(imageRef, baseRunPath string) (string, error)
+
+	// LoadImage imports an OCI/docker image tarball into the client's current
+	// containerd namespace and returns the names of the imported images.
+	// Callers set the target namespace via SetNamespace before invoking.
+	LoadImage(reader io.Reader) ([]string, error)
 }
 
 func NewClient(ctx context.Context, logger *slog.Logger, socket string) Client {

--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -18,6 +18,7 @@ package ctr
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -139,4 +140,37 @@ func (c *client) pullImage(imageRef string) (containerd.Image, error) {
 	}
 
 	return image, nil
+}
+
+// LoadImage imports an OCI/docker image tarball into the client's current
+// containerd namespace and returns the names of the imported images. The
+// caller sets the target namespace via SetNamespace; namespaceCtx() then
+// scopes the import to that namespace.
+//
+// WithSkipMissing() mirrors `ctr images import`'s tolerance: multi-arch
+// tarballs produced by `docker save` reference platform-specific blobs the
+// docker daemon does not always include. Skipping missing blobs lets the
+// host-arch manifest land while ignoring the others.
+func (c *client) LoadImage(reader io.Reader) ([]string, error) {
+	nsCtx := c.namespaceCtx()
+
+	imgs, err := c.cClient.Import(nsCtx, reader, containerd.WithSkipMissing())
+	if err != nil {
+		c.logger.ErrorContext(
+			c.ctx,
+			"failed to import image tarball",
+			"namespace",
+			c.Namespace(),
+			"err",
+			formatError(err),
+		)
+		return nil, fmt.Errorf("failed to import image tarball: %w", err)
+	}
+
+	names := make([]string, 0, len(imgs))
+	for _, img := range imgs {
+		names = append(names, img.Name)
+	}
+	c.logger.DebugContext(c.ctx, "imported image tarball", "namespace", c.Namespace(), "images", names)
+	return names, nil
 }

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -389,3 +389,15 @@ func (s *KukeonV1Service) ApplyDocuments(args *kukeonv1.ApplyDocumentsArgs, repl
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil
 }
+
+// ---- Image ----
+
+func (s *KukeonV1Service) LoadImage(args *kukeonv1.LoadImageArgs, reply *kukeonv1.LoadImageReply) error {
+	result, err := s.core.LoadImage(s.ctx, args.Realm, args.Tarball)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	if err != nil {
+		s.logger.DebugContext(s.ctx, "LoadImage returned error", "error", err)
+	}
+	return nil
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -138,6 +138,18 @@ var (
 	ErrEgressApply              = errors.New("failed to apply egress policy")
 	ErrEgressRemove             = errors.New("failed to remove egress policy")
 
+	// Image-related errors.
+
+	// ErrLoadImage is returned when importing an OCI/docker tarball into a
+	// realm's containerd namespace fails. Wrapped with the underlying
+	// containerd error so callers can inspect the cause.
+	ErrLoadImage = errors.New("failed to load image")
+
+	// ErrTarballRequired is returned when `kuke image load` receives an
+	// empty tarball (the file was empty, stdin was closed without bytes,
+	// or `docker save` produced no output).
+	ErrTarballRequired = errors.New("image tarball is required")
+
 	// Attach-related errors.
 
 	// ErrAttachNotSupported is returned when an attach request targets a

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -85,6 +85,10 @@ type Client interface {
 	RefreshAll(ctx context.Context) (RefreshAllResult, error)
 	ApplyDocuments(ctx context.Context, rawYAML []byte) (ApplyDocumentsResult, error)
 
+	// LoadImage imports an OCI/docker image tarball into the named realm's
+	// containerd namespace. The tarball ships in-band; see LoadImageArgs.
+	LoadImage(ctx context.Context, realm string, tarball []byte) (LoadImageResult, error)
+
 	Ping(ctx context.Context) error
 }
 
@@ -176,6 +180,7 @@ const (
 
 	MethodRefreshAll     = ServiceName + ".RefreshAll"
 	MethodApplyDocuments = ServiceName + ".ApplyDocuments"
+	MethodLoadImage      = ServiceName + ".LoadImage"
 
 	MethodPing = ServiceName + ".Ping"
 )

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -177,6 +177,10 @@ func (FakeClient) ApplyDocuments(context.Context, []byte) (ApplyDocumentsResult,
 	return ApplyDocumentsResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) LoadImage(context.Context, string, []byte) (LoadImageResult, error) {
+	return LoadImageResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) Ping(context.Context) error {
 	return ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -602,6 +602,19 @@ func (c *UnixClient) ApplyDocuments(ctx context.Context, rawYAML []byte) (ApplyD
 	return reply.Result, nil
 }
 
+// LoadImage implements Client.
+func (c *UnixClient) LoadImage(ctx context.Context, realm string, tarball []byte) (LoadImageResult, error) {
+	args := &LoadImageArgs{Realm: realm, Tarball: tarball}
+	reply := &LoadImageReply{}
+	if err := c.call(ctx, MethodLoadImage, args, reply); err != nil {
+		return LoadImageResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // Ping implements Client.
 func (c *UnixClient) Ping(ctx context.Context) error {
 	args := &PingArgs{}

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -639,3 +639,26 @@ type ApplyResourceResult struct {
 	Changes []string
 	Details map[string]string
 }
+
+// ---- Image ----
+
+// LoadImageArgs carries an OCI/docker image tarball plus the target realm.
+// The tarball ships as a byte slice (mirroring ApplyDocumentsArgs.RawYAML);
+// phase 1 sizes are bounded by the dev loop (≈100MB), so JSON-RPC roundtrip
+// cost is acceptable. Larger payloads will move to a streaming endpoint when
+// the multi-host story arrives.
+type LoadImageArgs struct {
+	Realm   string
+	Tarball []byte
+}
+
+type LoadImageReply struct {
+	Result LoadImageResult
+	Err    *APIError
+}
+
+type LoadImageResult struct {
+	Realm     string
+	Namespace string
+	Images    []string
+}


### PR DESCRIPTION
## Summary
- Phase 1 of `kuke image load`: imports an OCI/docker tarball into the containerd namespace mapped to a realm via the existing daemon RPC plumbing, replacing the manual `docker save | sudo ctr -n <ns> images import -` step in the local smoke test.
- Adds the full vertical slice — `kukeonv1.LoadImageArgs/Reply/Result` over the unix-socket RPC, `controller.Exec.LoadImage` (validates realm + tarball, maps realm to namespace via `consts.RealmNamespace`), `runner.Exec.LoadImage`, and `ctr.client.LoadImage` (uses `containerd.WithSkipMissing()` to mirror `ctr images import` ergonomics for multi-arch tarballs from `docker save`).
- CLI accepts a positional tarball path, `-` for stdin (read from `cmd.InOrStdin()` so tests can inject without touching `os.Stdin`), or `--from-docker <ref>` (shells out to `docker save` on the CLI side, so the daemon host doesn't need docker installed); positional and `--from-docker` are mutually exclusive.
- New error sentinels `ErrLoadImage` and `ErrTarballRequired` in `internal/errdefs/`.

The CLAUDE.md smoke-section update will travel as a separate `docs:` follow-up issue per the project's hard rule against bundling CLAUDE.md edits into a code-fix PR.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make test` — all packages PASS
- [x] End-to-end smoke: tore down `kuke-system` cell, rebuilt `kuke` and the local docker image, then `sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon` (in-process), `sudo ./kuke init` (re-bootstrap daemon), `sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system` (over unix socket), `docker save busybox | sudo ./kuke image load - --realm default` (stdin + multi-arch via daemon).
- [x] Daemon-parity check: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` produced identical output.

Closes #200