### PR TITLE
feat: add kuke image get for realm-scoped image listing

### DIFF
--- a/cmd/kuke/image/get.go
+++ b/cmd/kuke/image/get.go
@@ -1,0 +1,156 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	getshared "github.com/eminwux/kukeon/cmd/kuke/get/shared"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	"github.com/spf13/cobra"
+)
+
+// NewGetCmd builds the `kuke image get` subcommand. With no positional, it
+// lists every image in the realm; with a positional ref, it describes that
+// one image. The output format follows the rest of `kuke get …`: yaml/json
+// for single resources, table/yaml/json for lists.
+func NewGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "get [ref]",
+		Aliases:       []string{"ls", "list"},
+		Short:         "List or describe images in a realm's containerd namespace",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			realm, err := cmd.Flags().GetString("realm")
+			if err != nil {
+				return err
+			}
+			realm = strings.TrimSpace(realm)
+			if realm == "" {
+				return errdefs.ErrRealmNameRequired
+			}
+
+			outputFormat, err := getshared.ParseOutputFormat(cmd)
+			if err != nil {
+				return err
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			if len(args) > 0 && strings.TrimSpace(args[0]) != "" {
+				ref := strings.TrimSpace(args[0])
+				getRes, getErr := client.GetImage(cmd.Context(), realm, ref)
+				if getErr != nil {
+					if errors.Is(getErr, errdefs.ErrImageNotFound) {
+						return fmt.Errorf("image %q not found in realm %q: %w", ref, realm, errdefs.ErrImageNotFound)
+					}
+					return getErr
+				}
+				return printImage(getRes.Image, outputFormat)
+			}
+
+			listRes, listErr := client.ListImages(cmd.Context(), realm)
+			if listErr != nil {
+				return listErr
+			}
+			return printImages(cmd, realm, listRes, outputFormat)
+		},
+	}
+
+	cmd.Flags().String("realm", consts.KukeonDefaultRealmName, "Target realm; the lookup runs in <realm>.kukeon.io")
+	cmd.Flags().
+		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+
+	return cmd
+}
+
+func printImage(img kukeonv1.ImageInfo, format getshared.OutputFormat) error {
+	switch format {
+	case getshared.OutputFormatJSON:
+		return getshared.PrintJSON(img)
+	case getshared.OutputFormatYAML, getshared.OutputFormatTable:
+		return getshared.PrintYAML(img)
+	default:
+		return getshared.PrintYAML(img)
+	}
+}
+
+func printImages(
+	cmd *cobra.Command,
+	realm string,
+	result kukeonv1.ListImagesResult,
+	format getshared.OutputFormat,
+) error {
+	switch format {
+	case getshared.OutputFormatYAML:
+		return getshared.PrintYAML(result)
+	case getshared.OutputFormatJSON:
+		return getshared.PrintJSON(result)
+	case getshared.OutputFormatTable:
+		if len(result.Images) == 0 {
+			cmd.Printf("No images found in realm %q.\n", realm)
+			return nil
+		}
+		headers := []string{"NAME", "SIZE", "CREATED"}
+		rows := make([][]string, 0, len(result.Images))
+		for _, img := range result.Images {
+			rows = append(rows, []string{img.Name, formatSize(img.Size), formatCreated(img)})
+		}
+		getshared.PrintTable(cmd, headers, rows)
+		return nil
+	default:
+		return getshared.PrintYAML(result)
+	}
+}
+
+// formatSize renders a size in human-friendly bytes; -1 surfaces as "-" so
+// the operator sees a missing value rather than a misleading "0 B".
+func formatSize(size int64) string {
+	if size < 0 {
+		return "-"
+	}
+	const unit = 1024
+	if size < unit {
+		return fmt.Sprintf("%d B", size)
+	}
+	div, exp := int64(unit), 0
+	for n := size / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(size)/float64(div), "KMGTPE"[exp])
+}
+
+// formatCreated renders the image's creation time as RFC3339 in UTC. A zero
+// time surfaces as "-" because containerd does not always populate it for
+// images imported from `docker save` tarballs.
+func formatCreated(img kukeonv1.ImageInfo) string {
+	if img.CreatedAt.IsZero() {
+		return "-"
+	}
+	return img.CreatedAt.UTC().Format("2006-01-02T15:04:05Z")
+}

--- a/cmd/kuke/image/get_test.go
+++ b/cmd/kuke/image/get_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package image_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	image "github.com/eminwux/kukeon/cmd/kuke/image"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+)
+
+func TestGetCmd_ListDefaultRealmTable(t *testing.T) {
+	created := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	var gotRealm string
+	fake := &fakeImageClient{
+		listImagesFn: func(realm string) (kukeonv1.ListImagesResult, error) {
+			gotRealm = realm
+			return kukeonv1.ListImagesResult{
+				Realm:     realm,
+				Namespace: realm + ".kukeon.io",
+				Images: []kukeonv1.ImageInfo{
+					{Name: "docker.io/library/alpine:3.20", Size: 4_500_000, CreatedAt: created},
+					{Name: "registry.eminwux.com/kukeon-local:dev", Size: -1},
+				},
+			}, nil
+		},
+	}
+
+	out, err := runGet(t, fake, nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotRealm != "default" {
+		t.Errorf("realm = %q, want default", gotRealm)
+	}
+	if !strings.Contains(out, "docker.io/library/alpine:3.20") {
+		t.Errorf("table missing first image; got: %s", out)
+	}
+	if !strings.Contains(out, "4.3 MiB") {
+		t.Errorf("table missing humanized size; got: %s", out)
+	}
+	if !strings.Contains(out, "2026-04-29T12:00:00Z") {
+		t.Errorf("table missing created timestamp; got: %s", out)
+	}
+	// Image with Size=-1 should render as "-" rather than "0 B".
+	if strings.Contains(out, "0 B") {
+		t.Errorf("missing-size image rendered as 0 B; got: %s", out)
+	}
+	if !strings.Contains(out, "-\n") && !strings.Contains(out, "- ") {
+		t.Errorf("missing-size image did not render as '-'; got: %s", out)
+	}
+}
+
+func TestGetCmd_ListEmptyRealm(t *testing.T) {
+	fake := &fakeImageClient{
+		listImagesFn: func(realm string) (kukeonv1.ListImagesResult, error) {
+			return kukeonv1.ListImagesResult{Realm: realm, Namespace: realm + ".kukeon.io"}, nil
+		},
+	}
+	out, err := runGet(t, fake, []string{"--realm", "kuke-system"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, `No images found in realm "kuke-system"`) {
+		t.Errorf("missing empty-realm message; got: %s", out)
+	}
+}
+
+func TestGetCmd_DescribeSingleImageRoutesToGetImage(t *testing.T) {
+	var gotRealm, gotRef string
+	fake := &fakeImageClient{
+		getImageFn: func(realm, ref string) (kukeonv1.GetImageResult, error) {
+			gotRealm = realm
+			gotRef = ref
+			return kukeonv1.GetImageResult{
+				Realm:     realm,
+				Namespace: realm + ".kukeon.io",
+				Image:     kukeonv1.ImageInfo{Name: ref, Size: 4_500_000, Digest: "sha256:abcd"},
+			}, nil
+		},
+		listImagesFn: func(string) (kukeonv1.ListImagesResult, error) {
+			t.Fatal("ListImages should not be called when a positional ref is supplied")
+			return kukeonv1.ListImagesResult{}, nil
+		},
+	}
+
+	if _, err := runGet(t, fake, []string{"docker.io/library/alpine:3.20"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotRealm != "default" {
+		t.Errorf("realm = %q, want default", gotRealm)
+	}
+	if gotRef != "docker.io/library/alpine:3.20" {
+		t.Errorf("ref = %q, want docker.io/library/alpine:3.20", gotRef)
+	}
+}
+
+func TestGetCmd_NotFoundIsFriendly(t *testing.T) {
+	fake := &fakeImageClient{
+		getImageFn: func(string, string) (kukeonv1.GetImageResult, error) {
+			return kukeonv1.GetImageResult{}, errdefs.ErrImageNotFound
+		},
+	}
+
+	_, err := runGet(t, fake, []string{"docker.io/library/missing:1"})
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrImageNotFound) {
+		t.Errorf("error not wrapping ErrImageNotFound: %v", err)
+	}
+	if !strings.Contains(err.Error(), `image "docker.io/library/missing:1" not found in realm "default"`) {
+		t.Errorf("error = %q, want friendly not-found message", err.Error())
+	}
+}
+
+func TestGetCmd_ClientErrorPropagates(t *testing.T) {
+	fake := &fakeImageClient{
+		listImagesFn: func(string) (kukeonv1.ListImagesResult, error) {
+			return kukeonv1.ListImagesResult{}, errors.New("boom")
+		},
+	}
+	if _, err := runGet(t, fake, nil); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected client error to propagate, got %v", err)
+	}
+}
+
+// --- helpers ---
+
+func runGet(t *testing.T, fake *fakeImageClient, args []string) (string, error) {
+	t.Helper()
+	cmd := image.NewGetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, image.MockControllerKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+type fakeImageClient struct {
+	kukeonv1.FakeClient
+
+	listImagesFn func(realm string) (kukeonv1.ListImagesResult, error)
+	getImageFn   func(realm, ref string) (kukeonv1.GetImageResult, error)
+}
+
+func (f *fakeImageClient) ListImages(_ context.Context, realm string) (kukeonv1.ListImagesResult, error) {
+	if f.listImagesFn == nil {
+		return kukeonv1.ListImagesResult{}, errors.New("unexpected ListImages call")
+	}
+	return f.listImagesFn(realm)
+}
+
+func (f *fakeImageClient) GetImage(_ context.Context, realm, ref string) (kukeonv1.GetImageResult, error) {
+	if f.getImageFn == nil {
+		return kukeonv1.GetImageResult{}, errors.New("unexpected GetImage call")
+	}
+	return f.getImageFn(realm, ref)
+}

--- a/cmd/kuke/image/image.go
+++ b/cmd/kuke/image/image.go
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package image hosts the `kuke image` parent command and its subcommands.
-// Phase 1 ships `load` only; `get` and `delete` arrive in #211 and #212.
+// Phase 2 ships `load` and `get`; `delete` arrives in #212.
 package image
 
 import (
@@ -35,6 +35,7 @@ func NewImageCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewLoadCmd())
+	cmd.AddCommand(NewGetCmd())
 
 	return cmd
 }

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -880,6 +880,52 @@ func (c *Client) LoadImage(_ context.Context, realm string, tarball []byte) (kuk
 	}, nil
 }
 
+// ListImages enumerates images in the realm's containerd namespace. The
+// realm is validated by the controller layer; this wrapper only re-encodes
+// the controller's ImageInfo onto the wire type so callers never import
+// the controller package.
+func (c *Client) ListImages(_ context.Context, realm string) (kukeonv1.ListImagesResult, error) {
+	res, err := c.ctrl.ListImages(realm)
+	if err != nil {
+		return kukeonv1.ListImagesResult{}, err
+	}
+	out := kukeonv1.ListImagesResult{
+		Realm:     res.Realm,
+		Namespace: res.Namespace,
+		Images:    make([]kukeonv1.ImageInfo, 0, len(res.Images)),
+	}
+	for _, img := range res.Images {
+		out.Images = append(out.Images, controllerImageToWire(img))
+	}
+	return out, nil
+}
+
+// GetImage returns metadata for the named image ref in the realm.
+// errdefs.ErrImageNotFound is propagated unchanged so the wire layer can
+// emit the matching APIError Kind.
+func (c *Client) GetImage(_ context.Context, realm, ref string) (kukeonv1.GetImageResult, error) {
+	res, err := c.ctrl.GetImage(realm, ref)
+	if err != nil {
+		return kukeonv1.GetImageResult{}, err
+	}
+	return kukeonv1.GetImageResult{
+		Realm:     res.Realm,
+		Namespace: res.Namespace,
+		Image:     controllerImageToWire(res.Image),
+	}, nil
+}
+
+func controllerImageToWire(img controller.ImageInfo) kukeonv1.ImageInfo {
+	return kukeonv1.ImageInfo{
+		Name:      img.Name,
+		Size:      img.Size,
+		CreatedAt: img.CreatedAt,
+		Digest:    img.Digest,
+		MediaType: img.MediaType,
+		Labels:    img.Labels,
+	}
+}
+
 // ---- Attach ----
 
 // AttachContainer enforces the Attachable gate and resolves the host-side

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/controller/runner"
+	"github.com/eminwux/kukeon/internal/ctr"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
@@ -113,7 +114,9 @@ type fakeRunner struct {
 	RefreshCellFn  func(cell intmodel.Cell) (intmodel.Cell, int, error)
 
 	// Image methods
-	LoadImageFn func(namespace string, reader io.Reader) ([]string, error)
+	LoadImageFn  func(namespace string, reader io.Reader) ([]string, error)
+	ListImagesFn func(namespace string) ([]ctr.ImageInfo, error)
+	GetImageFn   func(namespace, ref string) (ctr.ImageInfo, error)
 }
 
 // Realm methods
@@ -541,6 +544,20 @@ func (f *fakeRunner) LoadImage(namespace string, reader io.Reader) ([]string, er
 		return f.LoadImageFn(namespace, reader)
 	}
 	return nil, errors.New("unexpected call to LoadImage")
+}
+
+func (f *fakeRunner) ListImages(namespace string) ([]ctr.ImageInfo, error) {
+	if f.ListImagesFn != nil {
+		return f.ListImagesFn(namespace)
+	}
+	return nil, errors.New("unexpected call to ListImages")
+}
+
+func (f *fakeRunner) GetImage(namespace, ref string) (ctr.ImageInfo, error) {
+	if f.GetImageFn != nil {
+		return f.GetImageFn(namespace, ref)
+	}
+	return ctr.ImageInfo{}, errors.New("unexpected call to GetImage")
 }
 
 // Test helper functions

--- a/internal/controller/image.go
+++ b/internal/controller/image.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// ImageInfo is the controller-layer view of a containerd image. The fields
+// are a re-export of internal/ctr's ImageInfo so transports above the
+// controller never need to import the ctr package.
+type ImageInfo struct {
+	Name      string
+	Size      int64
+	CreatedAt time.Time
+	Digest    string
+	MediaType string
+	Labels    map[string]string
+}
+
+// ListImagesResult reports the images present in a realm's containerd
+// namespace.
+type ListImagesResult struct {
+	Realm     string
+	Namespace string
+	Images    []ImageInfo
+}
+
+// GetImageResult reports the metadata of one named image in a realm.
+type GetImageResult struct {
+	Realm     string
+	Namespace string
+	Image     ImageInfo
+}
+
+// ListImages enumerates images in the realm's containerd namespace. The
+// realm is validated up-front so callers see ErrRealmNotFound before any
+// containerd round-trip; the namespace mapping mirrors LoadImage.
+func (b *Exec) ListImages(realm string) (ListImagesResult, error) {
+	var res ListImagesResult
+
+	realmName := strings.TrimSpace(realm)
+	if realmName == "" {
+		return res, errdefs.ErrRealmNameRequired
+	}
+
+	lookup := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: realmName},
+	}
+	if _, err := b.runner.GetRealm(lookup); err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			return res, fmt.Errorf("%w: %s", errdefs.ErrRealmNotFound, realmName)
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetRealm, err)
+	}
+
+	namespace := consts.RealmNamespace(realmName)
+	imgs, err := b.runner.ListImages(namespace)
+	if err != nil {
+		return res, fmt.Errorf("%w: %w", errdefs.ErrListImages, err)
+	}
+
+	res.Realm = realmName
+	res.Namespace = namespace
+	res.Images = make([]ImageInfo, 0, len(imgs))
+	for _, img := range imgs {
+		res.Images = append(res.Images, ctrImageToControllerImage(img))
+	}
+	return res, nil
+}
+
+// GetImage returns metadata for the named image ref in the realm's
+// containerd namespace. errdefs.ErrImageNotFound is propagated unchanged
+// so callers (CLI, RPC) can map it to a clean "image not found" message.
+func (b *Exec) GetImage(realm, ref string) (GetImageResult, error) {
+	var res GetImageResult
+
+	realmName := strings.TrimSpace(realm)
+	if realmName == "" {
+		return res, errdefs.ErrRealmNameRequired
+	}
+	imageRef := strings.TrimSpace(ref)
+	if imageRef == "" {
+		return res, errdefs.ErrImageNotFound
+	}
+
+	lookup := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: realmName},
+	}
+	if _, err := b.runner.GetRealm(lookup); err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			return res, fmt.Errorf("%w: %s", errdefs.ErrRealmNotFound, realmName)
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetRealm, err)
+	}
+
+	namespace := consts.RealmNamespace(realmName)
+	img, err := b.runner.GetImage(namespace, imageRef)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrImageNotFound) {
+			return res, err
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetImage, err)
+	}
+
+	res.Realm = realmName
+	res.Namespace = namespace
+	res.Image = ctrImageToControllerImage(img)
+	return res, nil
+}
+
+func ctrImageToControllerImage(img ctr.ImageInfo) ImageInfo {
+	return ImageInfo{
+		Name:      img.Name,
+		Size:      img.Size,
+		CreatedAt: img.CreatedAt,
+		Digest:    img.Digest,
+		MediaType: img.MediaType,
+		Labels:    img.Labels,
+	}
+}

--- a/internal/controller/image_test.go
+++ b/internal/controller/image_test.go
@@ -1,0 +1,208 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+func TestListImages_Success(t *testing.T) {
+	wantNS := consts.RealmNamespace("default")
+	created := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+
+	var gotNS string
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", wantNS), nil
+		},
+		ListImagesFn: func(ns string) ([]ctr.ImageInfo, error) {
+			gotNS = ns
+			return []ctr.ImageInfo{
+				{Name: "docker.io/library/alpine:3.20", Size: 4_500_000, CreatedAt: created, Digest: "sha256:abc"},
+			}, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ListImages("default")
+	if err != nil {
+		t.Fatalf("ListImages returned error: %v", err)
+	}
+	if gotNS != wantNS {
+		t.Errorf("runner saw namespace %q, want %q", gotNS, wantNS)
+	}
+	if res.Realm != "default" {
+		t.Errorf("Realm = %q, want default", res.Realm)
+	}
+	if len(res.Images) != 1 || res.Images[0].Name != "docker.io/library/alpine:3.20" {
+		t.Errorf("unexpected images: %+v", res.Images)
+	}
+	if res.Images[0].CreatedAt != created {
+		t.Errorf("CreatedAt = %v, want %v", res.Images[0].CreatedAt, created)
+	}
+}
+
+func TestListImages_RealmNotFound(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errdefs.ErrRealmNotFound
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.ListImages("ghost")
+	if !errors.Is(err, errdefs.ErrRealmNotFound) {
+		t.Fatalf("expected ErrRealmNotFound, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error should name the missing realm; got %q", err.Error())
+	}
+}
+
+func TestListImages_EmptyRealm(t *testing.T) {
+	mock := &fakeRunner{}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.ListImages("   ")
+	if !errors.Is(err, errdefs.ErrRealmNameRequired) {
+		t.Fatalf("expected ErrRealmNameRequired, got %v", err)
+	}
+}
+
+func TestListImages_RunnerErrorIsWrapped(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", ""), nil
+		},
+		ListImagesFn: func(string) ([]ctr.ImageInfo, error) {
+			return nil, errors.New("containerd unreachable")
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.ListImages("default")
+	if !errors.Is(err, errdefs.ErrListImages) {
+		t.Fatalf("expected ErrListImages wrapper, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "containerd unreachable") {
+		t.Errorf("inner error should be preserved; got %q", err.Error())
+	}
+}
+
+func TestGetImage_Success(t *testing.T) {
+	wantNS := consts.RealmNamespace("default")
+
+	var gotNS, gotRef string
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", wantNS), nil
+		},
+		GetImageFn: func(ns, ref string) (ctr.ImageInfo, error) {
+			gotNS = ns
+			gotRef = ref
+			return ctr.ImageInfo{Name: ref, Size: 1234, Digest: "sha256:abc"}, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.GetImage("default", "docker.io/library/alpine:3.20")
+	if err != nil {
+		t.Fatalf("GetImage returned error: %v", err)
+	}
+	if gotNS != wantNS {
+		t.Errorf("runner saw namespace %q, want %q", gotNS, wantNS)
+	}
+	if gotRef != "docker.io/library/alpine:3.20" {
+		t.Errorf("runner saw ref %q, want docker.io/library/alpine:3.20", gotRef)
+	}
+	if res.Image.Name != "docker.io/library/alpine:3.20" {
+		t.Errorf("Image.Name = %q, want docker.io/library/alpine:3.20", res.Image.Name)
+	}
+}
+
+func TestGetImage_NotFoundIsPassedThrough(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", ""), nil
+		},
+		GetImageFn: func(string, string) (ctr.ImageInfo, error) {
+			return ctr.ImageInfo{}, errdefs.ErrImageNotFound
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.GetImage("default", "docker.io/library/missing:1")
+	if !errors.Is(err, errdefs.ErrImageNotFound) {
+		t.Fatalf("expected ErrImageNotFound, got %v", err)
+	}
+}
+
+func TestGetImage_RealmNotFound(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errdefs.ErrRealmNotFound
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.GetImage("ghost", "alpine")
+	if !errors.Is(err, errdefs.ErrRealmNotFound) {
+		t.Fatalf("expected ErrRealmNotFound, got %v", err)
+	}
+}
+
+func TestGetImage_EmptyRealm(t *testing.T) {
+	mock := &fakeRunner{}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.GetImage("   ", "alpine")
+	if !errors.Is(err, errdefs.ErrRealmNameRequired) {
+		t.Fatalf("expected ErrRealmNameRequired, got %v", err)
+	}
+}
+
+func TestGetImage_EmptyRefIsNotFound(t *testing.T) {
+	mock := &fakeRunner{}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.GetImage("default", "  ")
+	if !errors.Is(err, errdefs.ErrImageNotFound) {
+		t.Fatalf("expected ErrImageNotFound, got %v", err)
+	}
+}
+
+func TestGetImage_RunnerErrorIsWrapped(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", ""), nil
+		},
+		GetImageFn: func(string, string) (ctr.ImageInfo, error) {
+			return ctr.ImageInfo{}, errors.New("containerd unreachable")
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.GetImage("default", "alpine")
+	if !errors.Is(err, errdefs.ErrGetImage) {
+		t.Fatalf("expected ErrGetImage wrapper, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "containerd unreachable") {
+		t.Errorf("inner error should be preserved; got %q", err.Error())
+	}
+}

--- a/internal/controller/runner/image.go
+++ b/internal/controller/runner/image.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// ListImages enumerates images in the given containerd namespace. The
+// caller (controller) is responsible for resolving the realm to a
+// namespace and ensuring the realm exists; this method only routes the
+// call onto a connected containerd client.
+func (r *Exec) ListImages(namespace string) ([]ctr.ImageInfo, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return nil, errdefs.ErrCheckNamespaceExists
+	}
+	if err := r.ensureClientConnected(); err != nil {
+		return nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+	r.ctrClient.SetNamespace(namespace)
+	return r.ctrClient.ListImages()
+}
+
+// GetImage returns metadata for the named image ref in the given
+// containerd namespace. errdefs.ErrImageNotFound is propagated unchanged
+// so callers can use errors.Is for not-found detection.
+func (r *Exec) GetImage(namespace, ref string) (ctr.ImageInfo, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return ctr.ImageInfo{}, errdefs.ErrCheckNamespaceExists
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ctr.ImageInfo{}, errdefs.ErrImageNotFound
+	}
+	if err := r.ensureClientConnected(); err != nil {
+		return ctr.ImageInfo{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+	r.ctrClient.SetNamespace(namespace)
+	return r.ctrClient.GetImage(ref)
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -102,6 +102,14 @@ type Runner interface {
 	// containerd namespace and returns the names of the imported images.
 	LoadImage(namespace string, reader io.Reader) ([]string, error)
 
+	// ListImages enumerates images in the given containerd namespace.
+	ListImages(namespace string) ([]ctr.ImageInfo, error)
+
+	// GetImage returns metadata for the named image ref in the given
+	// containerd namespace. Returns errdefs.ErrImageNotFound when the
+	// ref is absent.
+	GetImage(namespace, ref string) (ctr.ImageInfo, error)
+
 	Close() error
 }
 

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -91,6 +91,16 @@ type Client interface {
 	// containerd namespace and returns the names of the imported images.
 	// Callers set the target namespace via SetNamespace before invoking.
 	LoadImage(reader io.Reader) ([]string, error)
+
+	// ListImages enumerates images in the client's current containerd
+	// namespace. Callers set the target namespace via SetNamespace before
+	// invoking.
+	ListImages() ([]ImageInfo, error)
+
+	// GetImage returns metadata for the named image ref in the client's
+	// current containerd namespace. Returns errdefs.ErrImageNotFound if
+	// the ref is absent.
+	GetImage(ref string) (ImageInfo, error)
 }
 
 func NewClient(ctx context.Context, logger *slog.Logger, socket string) Client {

--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -23,8 +23,23 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
+	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
 )
+
+// ImageInfo is the ctr-layer view of a containerd image. The fields are the
+// common subset surfaced to operators by `kuke image get`; downstream layers
+// re-encode this onto their own wire types so the ctr package does not leak
+// into pkg/api.
+type ImageInfo struct {
+	Name      string
+	Size      int64
+	CreatedAt time.Time
+	Digest    string
+	MediaType string
+	Labels    map[string]string
+}
 
 // ensureImageUnpacked ensures that an image is unpacked for the given snapshotter.
 // If the image is not unpacked, it will be unpacked. Returns an error if unpacking fails.
@@ -173,4 +188,93 @@ func (c *client) LoadImage(reader io.Reader) ([]string, error) {
 	}
 	c.logger.DebugContext(c.ctx, "imported image tarball", "namespace", c.Namespace(), "images", names)
 	return names, nil
+}
+
+// ListImages enumerates images in the client's current containerd namespace.
+// Size is best-effort: when containerd cannot resolve an image's size (e.g.
+// because content is missing locally), the entry is still surfaced with
+// Size=-1 so listing degrades gracefully instead of failing the whole call.
+func (c *client) ListImages() ([]ImageInfo, error) {
+	nsCtx := c.namespaceCtx()
+
+	imgs, err := c.cClient.ListImages(nsCtx)
+	if err != nil {
+		c.logger.ErrorContext(
+			c.ctx,
+			"failed to list images",
+			"namespace",
+			c.Namespace(),
+			"err",
+			formatError(err),
+		)
+		return nil, fmt.Errorf("%w: %w", internalerrdefs.ErrListImages, err)
+	}
+
+	out := make([]ImageInfo, 0, len(imgs))
+	for _, img := range imgs {
+		out = append(out, c.imageToInfo(img))
+	}
+	return out, nil
+}
+
+// GetImage returns metadata for the named image ref in the client's current
+// containerd namespace. Returns errdefs.ErrImageNotFound (the kukeon
+// sentinel) when containerd reports the ref absent so upper layers can map
+// to a clean error message.
+func (c *client) GetImage(ref string) (ImageInfo, error) {
+	nsCtx := c.namespaceCtx()
+
+	img, err := c.cClient.GetImage(nsCtx, ref)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return ImageInfo{}, fmt.Errorf("%w: %s", internalerrdefs.ErrImageNotFound, ref)
+		}
+		c.logger.ErrorContext(
+			c.ctx,
+			"failed to get image",
+			"namespace",
+			c.Namespace(),
+			"ref",
+			ref,
+			"err",
+			formatError(err),
+		)
+		return ImageInfo{}, fmt.Errorf("%w: %w", internalerrdefs.ErrGetImage, err)
+	}
+	return c.imageToInfo(img), nil
+}
+
+// imageToInfo extracts the ImageInfo subset from a containerd Image. Size is
+// resolved via the platform-default Size() helper; failure leaves Size=-1
+// rather than aborting because partial-content tarballs are common with
+// `docker save` (see LoadImage's WithSkipMissing rationale).
+func (c *client) imageToInfo(img containerd.Image) ImageInfo {
+	nsCtx := c.namespaceCtx()
+	meta := img.Metadata()
+	target := img.Target()
+
+	size := int64(-1)
+	if s, err := img.Size(nsCtx); err == nil {
+		size = s
+	} else {
+		c.logger.DebugContext(
+			c.ctx,
+			"failed to resolve image size",
+			"namespace",
+			c.Namespace(),
+			"image",
+			img.Name(),
+			"err",
+			formatError(err),
+		)
+	}
+
+	return ImageInfo{
+		Name:      img.Name(),
+		Size:      size,
+		CreatedAt: meta.CreatedAt,
+		Digest:    target.Digest.String(),
+		MediaType: target.MediaType,
+		Labels:    meta.Labels,
+	}
 }

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -401,3 +401,23 @@ func (s *KukeonV1Service) LoadImage(args *kukeonv1.LoadImageArgs, reply *kukeonv
 	}
 	return nil
 }
+
+func (s *KukeonV1Service) ListImages(args *kukeonv1.ListImagesArgs, reply *kukeonv1.ListImagesReply) error {
+	result, err := s.core.ListImages(s.ctx, args.Realm)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	if err != nil {
+		s.logger.DebugContext(s.ctx, "ListImages returned error", "error", err)
+	}
+	return nil
+}
+
+func (s *KukeonV1Service) GetImage(args *kukeonv1.GetImageArgs, reply *kukeonv1.GetImageReply) error {
+	result, err := s.core.GetImage(s.ctx, args.Realm, args.Ref)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	if err != nil {
+		s.logger.DebugContext(s.ctx, "GetImage returned error", "error", err)
+	}
+	return nil
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -150,6 +150,19 @@ var (
 	// or `docker save` produced no output).
 	ErrTarballRequired = errors.New("image tarball is required")
 
+	// ErrImageNotFound is returned when a named image ref does not exist
+	// in the target realm's containerd namespace. Surfaces to operators
+	// from `kuke image get <ref>`.
+	ErrImageNotFound = errors.New("image not found")
+
+	// ErrGetImage wraps the underlying containerd error when fetching
+	// one image's metadata fails for reasons other than not-found.
+	ErrGetImage = errors.New("failed to get image")
+
+	// ErrListImages wraps the underlying containerd error when
+	// enumerating images in a realm's namespace fails.
+	ErrListImages = errors.New("failed to list images")
+
 	// Attach-related errors.
 
 	// ErrAttachNotSupported is returned when an attach request targets a

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -89,6 +89,14 @@ type Client interface {
 	// containerd namespace. The tarball ships in-band; see LoadImageArgs.
 	LoadImage(ctx context.Context, realm string, tarball []byte) (LoadImageResult, error)
 
+	// ListImages enumerates images in the named realm's containerd
+	// namespace.
+	ListImages(ctx context.Context, realm string) (ListImagesResult, error)
+
+	// GetImage returns metadata for the named image ref in the named
+	// realm. errdefs.ErrImageNotFound is returned when the ref is absent.
+	GetImage(ctx context.Context, realm, ref string) (GetImageResult, error)
+
 	Ping(ctx context.Context) error
 }
 
@@ -181,6 +189,8 @@ const (
 	MethodRefreshAll     = ServiceName + ".RefreshAll"
 	MethodApplyDocuments = ServiceName + ".ApplyDocuments"
 	MethodLoadImage      = ServiceName + ".LoadImage"
+	MethodListImages     = ServiceName + ".ListImages"
+	MethodGetImage       = ServiceName + ".GetImage"
 
 	MethodPing = ServiceName + ".Ping"
 )

--- a/pkg/api/kukeonv1/errmap.go
+++ b/pkg/api/kukeonv1/errmap.go
@@ -58,6 +58,7 @@ var kindToSentinel = map[string]error{
 	"ContainerExists":         errdefs.ErrContainerExists,
 	"ConversionFailed":        errdefs.ErrConversionFailed,
 	"AttachNotSupported":      errdefs.ErrAttachNotSupported,
+	"ImageNotFound":           errdefs.ErrImageNotFound,
 }
 
 // sentinelToKind is the reverse lookup, populated lazily.

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -181,6 +181,14 @@ func (FakeClient) LoadImage(context.Context, string, []byte) (LoadImageResult, e
 	return LoadImageResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) ListImages(context.Context, string) (ListImagesResult, error) {
+	return ListImagesResult{}, ErrUnexpectedCall
+}
+
+func (FakeClient) GetImage(context.Context, string, string) (GetImageResult, error) {
+	return GetImageResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) Ping(context.Context) error {
 	return ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -615,6 +615,32 @@ func (c *UnixClient) LoadImage(ctx context.Context, realm string, tarball []byte
 	return reply.Result, nil
 }
 
+// ListImages implements Client.
+func (c *UnixClient) ListImages(ctx context.Context, realm string) (ListImagesResult, error) {
+	args := &ListImagesArgs{Realm: realm}
+	reply := &ListImagesReply{}
+	if err := c.call(ctx, MethodListImages, args, reply); err != nil {
+		return ListImagesResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
+// GetImage implements Client.
+func (c *UnixClient) GetImage(ctx context.Context, realm, ref string) (GetImageResult, error) {
+	args := &GetImageArgs{Realm: realm, Ref: ref}
+	reply := &GetImageReply{}
+	if err := c.call(ctx, MethodGetImage, args, reply); err != nil {
+		return GetImageResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // Ping implements Client.
 func (c *UnixClient) Ping(ctx context.Context) error {
 	args := &PingArgs{}

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -16,7 +16,11 @@
 
 package kukeonv1
 
-import v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+import (
+	"time"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
 
 // ---- Realm ----
 
@@ -661,4 +665,54 @@ type LoadImageResult struct {
 	Realm     string
 	Namespace string
 	Images    []string
+}
+
+// ImageInfo is the wire view of one containerd image. Size is best-effort:
+// the daemon emits -1 when containerd cannot resolve the size locally so the
+// CLI can render "-" rather than "0 B".
+type ImageInfo struct {
+	Name      string
+	Size      int64
+	CreatedAt time.Time
+	Digest    string
+	MediaType string
+	Labels    map[string]string
+}
+
+// ListImagesArgs is the wire request for ListImages.
+type ListImagesArgs struct {
+	Realm string
+}
+
+// ListImagesReply is the wire response for ListImages.
+type ListImagesReply struct {
+	Result ListImagesResult
+	Err    *APIError
+}
+
+// ListImagesResult lists the images present in a realm's containerd
+// namespace.
+type ListImagesResult struct {
+	Realm     string
+	Namespace string
+	Images    []ImageInfo
+}
+
+// GetImageArgs is the wire request for GetImage.
+type GetImageArgs struct {
+	Realm string
+	Ref   string
+}
+
+// GetImageReply is the wire response for GetImage.
+type GetImageReply struct {
+	Result GetImageResult
+	Err    *APIError
+}
+
+// GetImageResult carries the metadata of one named image in a realm.
+type GetImageResult struct {
+	Realm     string
+	Namespace string
+	Image     ImageInfo
 }


### PR DESCRIPTION
## Summary
- Adds `kuke image get [ref] --realm <name>` (phase 2 of image management). With no positional, lists every image in the realm's containerd namespace as a NAME / SIZE / CREATED table; with a ref, describes that one image (yaml by default, json/table via `--output`).
- Wires the feature through every layer: `ctr` (`ListImages`/`GetImage` + `ImageInfo`), runner, controller, kukeonv1 wire types + RPC client + RPC handler, and the local in-process `Client` — so daemon and `--no-daemon` paths return identical output (the project CLAUDE.md regression guard).
- Surfaces `errdefs.ErrImageNotFound` when the named ref is absent so callers can `errors.Is` across the wire (registered in `errmap.go` as Kind `"ImageNotFound"`).

## Test plan
- [x] `make test` (full unit-test suite that CI runs) — all packages green
- [x] `go build ./...` — no errors
- [x] `go vet ./...` — clean
- [x] golangci-lint via the pre-commit hook — clean (after fixing exhaustive + shadow warnings)
- [x] Smoke test per project CLAUDE.md: `make kuke`, build/import `kukeon-local:dev`, `kuke kill/delete/init` cycle, `kuke get realms` and `kuke get realms --no-daemon` return identical output, daemon comes up cleanly.
- [x] Daemon-parity check on the new feature: `kuke image get --realm kuke-system` and `kuke image get --realm kuke-system --no-daemon` return identical tables (busybox + kukeon-local:dev with matching sizes + timestamps); `kuke image get docker.io/library/busybox:latest --realm kuke-system` returns identical YAML in both modes; `kuke image get docker.io/library/missing:1 --realm kuke-system` returns identical `image "..." not found in realm "..."` error in both modes; `kuke image get --realm ghost` returns identical `realm not found: ghost` error in both modes.

## Acceptance criteria
- [x] `kuke image get --realm <name>` lists images as NAME / SIZE / CREATED table
- [x] `kuke image get <ref> --realm <name>` describes a single image (yaml by default; `--output json` / `--output table` honored)
- [x] `errdefs.ErrImageNotFound` surfaces when the named ref is absent (preserved via `%w` wrap so `errors.Is` works at the CLI)
- [x] Daemon and `--no-daemon` paths return identical output (parity verified above)
- [x] Phase-1 conventions mirrored: same realm flag default (`consts.KukeonDefaultRealmName`), same controller→runner→ctr layering, same wire-error roundtrip pattern, same colocated test layout

## Notes for the reviewer
- `ImageInfo.Size = -1` when containerd cannot resolve the size (e.g. partial-content tarballs from `docker save` + `WithSkipMissing`). The CLI renders this as `-` in the table rather than a misleading `0 B` — degrading the row gracefully instead of failing the whole listing. The `phase-1 LoadImage` already uses `WithSkipMissing`, so this case is reachable in the same flow.
- `printImage` deliberately defaults table format to YAML for single-resource describes; this matches the existing `kuke get realm <name>` behavior and the `getshared.OutputFormatTable` case is enumerated to satisfy the `exhaustive` linter.
- Ran the smoke test locally with the rebuilt `kukeon-local:dev` image; both `kuke get realms` modes returned identical output (the project CLAUDE.md regression guard) before exercising the new RPCs.

Closes #211