### PR TITLE
feat: add kuke image delete for realm-scoped image removal

### DIFF
--- a/cmd/kuke/image/delete.go
+++ b/cmd/kuke/image/delete.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package image
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/spf13/cobra"
+)
+
+// NewDeleteCmd builds the `kuke image delete` subcommand. The positional
+// ref is required; not-found is surfaced with a friendly message that still
+// unwraps to errdefs.ErrImageNotFound for callers using errors.Is.
+func NewDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "delete <ref>",
+		Aliases:       []string{"rm", "remove"},
+		Short:         "Remove an image from a realm's containerd namespace",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			realm, err := cmd.Flags().GetString("realm")
+			if err != nil {
+				return err
+			}
+			realm = strings.TrimSpace(realm)
+			if realm == "" {
+				return errdefs.ErrRealmNameRequired
+			}
+
+			ref := strings.TrimSpace(args[0])
+			if ref == "" {
+				return errdefs.ErrImageNotFound
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			res, err := client.DeleteImage(cmd.Context(), realm, ref)
+			if err != nil {
+				if errors.Is(err, errdefs.ErrImageNotFound) {
+					return fmt.Errorf("image %q not found in realm %q: %w", ref, realm, errdefs.ErrImageNotFound)
+				}
+				return err
+			}
+
+			cmd.Printf("deleted image %q from realm %q (namespace %q)\n", res.Ref, res.Realm, res.Namespace)
+			return nil
+		},
+	}
+
+	cmd.Flags().String("realm", consts.KukeonDefaultRealmName, "Target realm; the lookup runs in <realm>.kukeon.io")
+
+	return cmd
+}

--- a/cmd/kuke/image/delete_test.go
+++ b/cmd/kuke/image/delete_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package image_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	image "github.com/eminwux/kukeon/cmd/kuke/image"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+)
+
+func TestDeleteCmd_DefaultRealmSuccess(t *testing.T) {
+	var gotRealm, gotRef string
+	fake := &fakeDeleteClient{
+		deleteImageFn: func(realm, ref string) (kukeonv1.DeleteImageResult, error) {
+			gotRealm = realm
+			gotRef = ref
+			return kukeonv1.DeleteImageResult{
+				Realm:     realm,
+				Namespace: realm + ".kukeon.io",
+				Ref:       ref,
+			}, nil
+		},
+	}
+
+	out, err := runDelete(t, fake, []string{"docker.io/library/alpine:3.20"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotRealm != "default" {
+		t.Errorf("realm = %q, want default", gotRealm)
+	}
+	if gotRef != "docker.io/library/alpine:3.20" {
+		t.Errorf("ref = %q, want docker.io/library/alpine:3.20", gotRef)
+	}
+	if !strings.Contains(out, "deleted image") || !strings.Contains(out, "docker.io/library/alpine:3.20") {
+		t.Errorf("output missing confirmation; got: %s", out)
+	}
+	if !strings.Contains(out, "default.kukeon.io") {
+		t.Errorf("output missing namespace; got: %s", out)
+	}
+}
+
+func TestDeleteCmd_ExplicitRealm(t *testing.T) {
+	var gotRealm string
+	fake := &fakeDeleteClient{
+		deleteImageFn: func(realm, ref string) (kukeonv1.DeleteImageResult, error) {
+			gotRealm = realm
+			return kukeonv1.DeleteImageResult{Realm: realm, Namespace: realm + ".kukeon.io", Ref: ref}, nil
+		},
+	}
+
+	if _, err := runDelete(t, fake, []string{"foo", "--realm", "kuke-system"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotRealm != "kuke-system" {
+		t.Errorf("realm = %q, want kuke-system", gotRealm)
+	}
+}
+
+func TestDeleteCmd_NotFoundIsFriendly(t *testing.T) {
+	fake := &fakeDeleteClient{
+		deleteImageFn: func(string, string) (kukeonv1.DeleteImageResult, error) {
+			return kukeonv1.DeleteImageResult{}, errdefs.ErrImageNotFound
+		},
+	}
+
+	_, err := runDelete(t, fake, []string{"docker.io/library/missing:1"})
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrImageNotFound) {
+		t.Errorf("error not wrapping ErrImageNotFound: %v", err)
+	}
+	if !strings.Contains(err.Error(), `image "docker.io/library/missing:1" not found in realm "default"`) {
+		t.Errorf("error = %q, want friendly not-found message", err.Error())
+	}
+}
+
+func TestDeleteCmd_ClientErrorPropagates(t *testing.T) {
+	fake := &fakeDeleteClient{
+		deleteImageFn: func(string, string) (kukeonv1.DeleteImageResult, error) {
+			return kukeonv1.DeleteImageResult{}, errors.New("boom")
+		},
+	}
+	if _, err := runDelete(t, fake, []string{"alpine"}); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected client error to propagate, got %v", err)
+	}
+}
+
+func TestDeleteCmd_RequiresRef(t *testing.T) {
+	fake := &fakeDeleteClient{
+		deleteImageFn: func(string, string) (kukeonv1.DeleteImageResult, error) {
+			t.Fatal("client should not be invoked without a positional ref")
+			return kukeonv1.DeleteImageResult{}, nil
+		},
+	}
+	_, err := runDelete(t, fake, nil)
+	if err == nil {
+		t.Fatal("expected missing-arg error, got nil")
+	}
+}
+
+// --- helpers ---
+
+func runDelete(t *testing.T, fake *fakeDeleteClient, args []string) (string, error) {
+	t.Helper()
+	cmd := image.NewDeleteCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, image.MockControllerKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+type fakeDeleteClient struct {
+	kukeonv1.FakeClient
+
+	deleteImageFn func(realm, ref string) (kukeonv1.DeleteImageResult, error)
+}
+
+func (f *fakeDeleteClient) DeleteImage(_ context.Context, realm, ref string) (kukeonv1.DeleteImageResult, error) {
+	if f.deleteImageFn == nil {
+		return kukeonv1.DeleteImageResult{}, errors.New("unexpected DeleteImage call")
+	}
+	return f.deleteImageFn(realm, ref)
+}

--- a/cmd/kuke/image/image.go
+++ b/cmd/kuke/image/image.go
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package image hosts the `kuke image` parent command and its subcommands.
-// Phase 2 ships `load` and `get`; `delete` arrives in #212.
+// Package image hosts the `kuke image` parent command and its subcommands:
+// `load` (#200), `get` (#211), and `delete` (#212).
 package image
 
 import (
@@ -36,6 +36,7 @@ func NewImageCmd() *cobra.Command {
 
 	cmd.AddCommand(NewLoadCmd())
 	cmd.AddCommand(NewGetCmd())
+	cmd.AddCommand(NewDeleteCmd())
 
 	return cmd
 }

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -915,6 +915,21 @@ func (c *Client) GetImage(_ context.Context, realm, ref string) (kukeonv1.GetIma
 	}, nil
 }
 
+// DeleteImage removes the named image ref from the realm's containerd
+// namespace. errdefs.ErrImageNotFound is propagated unchanged so the wire
+// layer can emit the matching APIError Kind.
+func (c *Client) DeleteImage(_ context.Context, realm, ref string) (kukeonv1.DeleteImageResult, error) {
+	res, err := c.ctrl.DeleteImage(realm, ref)
+	if err != nil {
+		return kukeonv1.DeleteImageResult{}, err
+	}
+	return kukeonv1.DeleteImageResult{
+		Realm:     res.Realm,
+		Namespace: res.Namespace,
+		Ref:       res.Ref,
+	}, nil
+}
+
 func controllerImageToWire(img controller.ImageInfo) kukeonv1.ImageInfo {
 	return kukeonv1.ImageInfo{
 		Name:      img.Name,

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -114,9 +114,10 @@ type fakeRunner struct {
 	RefreshCellFn  func(cell intmodel.Cell) (intmodel.Cell, int, error)
 
 	// Image methods
-	LoadImageFn  func(namespace string, reader io.Reader) ([]string, error)
-	ListImagesFn func(namespace string) ([]ctr.ImageInfo, error)
-	GetImageFn   func(namespace, ref string) (ctr.ImageInfo, error)
+	LoadImageFn   func(namespace string, reader io.Reader) ([]string, error)
+	ListImagesFn  func(namespace string) ([]ctr.ImageInfo, error)
+	GetImageFn    func(namespace, ref string) (ctr.ImageInfo, error)
+	DeleteImageFn func(namespace, ref string) error
 }
 
 // Realm methods
@@ -558,6 +559,13 @@ func (f *fakeRunner) GetImage(namespace, ref string) (ctr.ImageInfo, error) {
 		return f.GetImageFn(namespace, ref)
 	}
 	return ctr.ImageInfo{}, errors.New("unexpected call to GetImage")
+}
+
+func (f *fakeRunner) DeleteImage(namespace, ref string) error {
+	if f.DeleteImageFn != nil {
+		return f.DeleteImageFn(namespace, ref)
+	}
+	return errors.New("unexpected call to DeleteImage")
 }
 
 // Test helper functions

--- a/internal/controller/image.go
+++ b/internal/controller/image.go
@@ -55,6 +55,13 @@ type GetImageResult struct {
 	Image     ImageInfo
 }
 
+// DeleteImageResult reports the outcome of a `kuke image delete` removal.
+type DeleteImageResult struct {
+	Realm     string
+	Namespace string
+	Ref       string
+}
+
 // ListImages enumerates images in the realm's containerd namespace. The
 // realm is validated up-front so callers see ErrRealmNotFound before any
 // containerd round-trip; the namespace mapping mirrors LoadImage.
@@ -128,6 +135,45 @@ func (b *Exec) GetImage(realm, ref string) (GetImageResult, error) {
 	res.Realm = realmName
 	res.Namespace = namespace
 	res.Image = ctrImageToControllerImage(img)
+	return res, nil
+}
+
+// DeleteImage removes the named image ref from the realm's containerd
+// namespace. errdefs.ErrImageNotFound is propagated unchanged so callers
+// (CLI, RPC) can map it to a clean "image not found" message.
+func (b *Exec) DeleteImage(realm, ref string) (DeleteImageResult, error) {
+	var res DeleteImageResult
+
+	realmName := strings.TrimSpace(realm)
+	if realmName == "" {
+		return res, errdefs.ErrRealmNameRequired
+	}
+	imageRef := strings.TrimSpace(ref)
+	if imageRef == "" {
+		return res, errdefs.ErrImageNotFound
+	}
+
+	lookup := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: realmName},
+	}
+	if _, err := b.runner.GetRealm(lookup); err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			return res, fmt.Errorf("%w: %s", errdefs.ErrRealmNotFound, realmName)
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetRealm, err)
+	}
+
+	namespace := consts.RealmNamespace(realmName)
+	if err := b.runner.DeleteImage(namespace, imageRef); err != nil {
+		if errors.Is(err, errdefs.ErrImageNotFound) {
+			return res, err
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrDeleteImage, err)
+	}
+
+	res.Realm = realmName
+	res.Namespace = namespace
+	res.Ref = imageRef
 	return res, nil
 }
 

--- a/internal/controller/image_test.go
+++ b/internal/controller/image_test.go
@@ -206,3 +206,109 @@ func TestGetImage_RunnerErrorIsWrapped(t *testing.T) {
 		t.Errorf("inner error should be preserved; got %q", err.Error())
 	}
 }
+
+func TestDeleteImage_Success(t *testing.T) {
+	wantNS := consts.RealmNamespace("default")
+
+	var gotNS, gotRef string
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", wantNS), nil
+		},
+		DeleteImageFn: func(ns, ref string) error {
+			gotNS = ns
+			gotRef = ref
+			return nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.DeleteImage("default", "docker.io/library/alpine:3.20")
+	if err != nil {
+		t.Fatalf("DeleteImage returned error: %v", err)
+	}
+	if gotNS != wantNS {
+		t.Errorf("runner saw namespace %q, want %q", gotNS, wantNS)
+	}
+	if gotRef != "docker.io/library/alpine:3.20" {
+		t.Errorf("runner saw ref %q, want docker.io/library/alpine:3.20", gotRef)
+	}
+	if res.Realm != "default" {
+		t.Errorf("Realm = %q, want default", res.Realm)
+	}
+	if res.Namespace != wantNS {
+		t.Errorf("Namespace = %q, want %q", res.Namespace, wantNS)
+	}
+	if res.Ref != "docker.io/library/alpine:3.20" {
+		t.Errorf("Ref = %q, want docker.io/library/alpine:3.20", res.Ref)
+	}
+}
+
+func TestDeleteImage_NotFoundIsPassedThrough(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", ""), nil
+		},
+		DeleteImageFn: func(string, string) error {
+			return errdefs.ErrImageNotFound
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.DeleteImage("default", "docker.io/library/missing:1")
+	if !errors.Is(err, errdefs.ErrImageNotFound) {
+		t.Fatalf("expected ErrImageNotFound, got %v", err)
+	}
+}
+
+func TestDeleteImage_RealmNotFound(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errdefs.ErrRealmNotFound
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.DeleteImage("ghost", "alpine")
+	if !errors.Is(err, errdefs.ErrRealmNotFound) {
+		t.Fatalf("expected ErrRealmNotFound, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error should name the missing realm; got %q", err.Error())
+	}
+}
+
+func TestDeleteImage_EmptyRealm(t *testing.T) {
+	mock := &fakeRunner{}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.DeleteImage("   ", "alpine")
+	if !errors.Is(err, errdefs.ErrRealmNameRequired) {
+		t.Fatalf("expected ErrRealmNameRequired, got %v", err)
+	}
+}
+
+func TestDeleteImage_EmptyRefIsNotFound(t *testing.T) {
+	mock := &fakeRunner{}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.DeleteImage("default", "  ")
+	if !errors.Is(err, errdefs.ErrImageNotFound) {
+		t.Fatalf("expected ErrImageNotFound, got %v", err)
+	}
+}
+
+func TestDeleteImage_RunnerErrorIsWrapped(t *testing.T) {
+	mock := &fakeRunner{
+		GetRealmFn: func(_ intmodel.Realm) (intmodel.Realm, error) {
+			return buildTestRealm("default", ""), nil
+		},
+		DeleteImageFn: func(string, string) error {
+			return errors.New("containerd unreachable")
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	_, err := ctrl.DeleteImage("default", "alpine")
+	if !errors.Is(err, errdefs.ErrDeleteImage) {
+		t.Fatalf("expected ErrDeleteImage wrapper, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "containerd unreachable") {
+		t.Errorf("inner error should be preserved; got %q", err.Error())
+	}
+}

--- a/internal/controller/runner/image.go
+++ b/internal/controller/runner/image.go
@@ -58,3 +58,22 @@ func (r *Exec) GetImage(namespace, ref string) (ctr.ImageInfo, error) {
 	r.ctrClient.SetNamespace(namespace)
 	return r.ctrClient.GetImage(ref)
 }
+
+// DeleteImage removes the named image ref from the given containerd
+// namespace. errdefs.ErrImageNotFound is propagated unchanged so callers
+// can use errors.Is for not-found detection.
+func (r *Exec) DeleteImage(namespace, ref string) error {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return errdefs.ErrCheckNamespaceExists
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return errdefs.ErrImageNotFound
+	}
+	if err := r.ensureClientConnected(); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+	r.ctrClient.SetNamespace(namespace)
+	return r.ctrClient.DeleteImage(ref)
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -110,6 +110,10 @@ type Runner interface {
 	// ref is absent.
 	GetImage(namespace, ref string) (ctr.ImageInfo, error)
 
+	// DeleteImage removes the named image ref from the given containerd
+	// namespace. Returns errdefs.ErrImageNotFound when the ref is absent.
+	DeleteImage(namespace, ref string) error
+
 	Close() error
 }
 

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -101,6 +101,12 @@ type Client interface {
 	// current containerd namespace. Returns errdefs.ErrImageNotFound if
 	// the ref is absent.
 	GetImage(ref string) (ImageInfo, error)
+
+	// DeleteImage removes the named image ref from the client's current
+	// containerd namespace. Returns errdefs.ErrImageNotFound if the ref
+	// is absent so callers can distinguish missing from operational
+	// failures.
+	DeleteImage(ref string) error
 }
 
 func NewClient(ctx context.Context, logger *slog.Logger, socket string) Client {

--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -244,6 +244,32 @@ func (c *client) GetImage(ref string) (ImageInfo, error) {
 	return c.imageToInfo(img), nil
 }
 
+// DeleteImage removes the named image ref from the client's current
+// containerd namespace. The kukeon ErrImageNotFound sentinel is returned
+// when containerd reports the ref absent so upper layers can map to a
+// clean error message; other errors are wrapped with ErrDeleteImage.
+func (c *client) DeleteImage(ref string) error {
+	nsCtx := c.namespaceCtx()
+
+	if err := c.cClient.ImageService().Delete(nsCtx, ref); err != nil {
+		if errdefs.IsNotFound(err) {
+			return fmt.Errorf("%w: %s", internalerrdefs.ErrImageNotFound, ref)
+		}
+		c.logger.ErrorContext(
+			c.ctx,
+			"failed to delete image",
+			"namespace",
+			c.Namespace(),
+			"ref",
+			ref,
+			"err",
+			formatError(err),
+		)
+		return fmt.Errorf("%w: %w", internalerrdefs.ErrDeleteImage, err)
+	}
+	return nil
+}
+
 // imageToInfo extracts the ImageInfo subset from a containerd Image. Size is
 // resolved via the platform-default Size() helper; failure leaves Size=-1
 // rather than aborting because partial-content tarballs are common with

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -421,3 +421,13 @@ func (s *KukeonV1Service) GetImage(args *kukeonv1.GetImageArgs, reply *kukeonv1.
 	}
 	return nil
 }
+
+func (s *KukeonV1Service) DeleteImage(args *kukeonv1.DeleteImageArgs, reply *kukeonv1.DeleteImageReply) error {
+	result, err := s.core.DeleteImage(s.ctx, args.Realm, args.Ref)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	if err != nil {
+		s.logger.DebugContext(s.ctx, "DeleteImage returned error", "error", err)
+	}
+	return nil
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -163,6 +163,11 @@ var (
 	// enumerating images in a realm's namespace fails.
 	ErrListImages = errors.New("failed to list images")
 
+	// ErrDeleteImage wraps the underlying containerd error when removing
+	// one image from a realm's namespace fails for reasons other than
+	// not-found. Not-found is reported via ErrImageNotFound.
+	ErrDeleteImage = errors.New("failed to delete image")
+
 	// Attach-related errors.
 
 	// ErrAttachNotSupported is returned when an attach request targets a

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -97,6 +97,11 @@ type Client interface {
 	// realm. errdefs.ErrImageNotFound is returned when the ref is absent.
 	GetImage(ctx context.Context, realm, ref string) (GetImageResult, error)
 
+	// DeleteImage removes the named image ref from the named realm's
+	// containerd namespace. errdefs.ErrImageNotFound is returned when
+	// the ref does not exist.
+	DeleteImage(ctx context.Context, realm, ref string) (DeleteImageResult, error)
+
 	Ping(ctx context.Context) error
 }
 
@@ -191,6 +196,7 @@ const (
 	MethodLoadImage      = ServiceName + ".LoadImage"
 	MethodListImages     = ServiceName + ".ListImages"
 	MethodGetImage       = ServiceName + ".GetImage"
+	MethodDeleteImage    = ServiceName + ".DeleteImage"
 
 	MethodPing = ServiceName + ".Ping"
 )

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -189,6 +189,10 @@ func (FakeClient) GetImage(context.Context, string, string) (GetImageResult, err
 	return GetImageResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) DeleteImage(context.Context, string, string) (DeleteImageResult, error) {
+	return DeleteImageResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) Ping(context.Context) error {
 	return ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -641,6 +641,19 @@ func (c *UnixClient) GetImage(ctx context.Context, realm, ref string) (GetImageR
 	return reply.Result, nil
 }
 
+// DeleteImage implements Client.
+func (c *UnixClient) DeleteImage(ctx context.Context, realm, ref string) (DeleteImageResult, error) {
+	args := &DeleteImageArgs{Realm: realm, Ref: ref}
+	reply := &DeleteImageReply{}
+	if err := c.call(ctx, MethodDeleteImage, args, reply); err != nil {
+		return DeleteImageResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // Ping implements Client.
 func (c *UnixClient) Ping(ctx context.Context) error {
 	args := &PingArgs{}

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -716,3 +716,22 @@ type GetImageResult struct {
 	Namespace string
 	Image     ImageInfo
 }
+
+// DeleteImageArgs is the wire request for DeleteImage.
+type DeleteImageArgs struct {
+	Realm string
+	Ref   string
+}
+
+// DeleteImageReply is the wire response for DeleteImage.
+type DeleteImageReply struct {
+	Result DeleteImageResult
+	Err    *APIError
+}
+
+// DeleteImageResult reports the outcome of a `kuke image delete` removal.
+type DeleteImageResult struct {
+	Realm     string
+	Namespace string
+	Ref       string
+}


### PR DESCRIPTION
## Summary
- Adds `kuke image delete <ref> --realm <name>` (phase 3 of #200/#211/#212), removing the named image from the realm's containerd namespace via `ImageService().Delete`.
- Wires the new endpoint top-to-bottom: `ctr.Client.DeleteImage` → runner → controller → `kukeonv1.Client.DeleteImage` (RPC + in-process), with `MethodDeleteImage` on the wire and the daemon `KukeonV1Service.DeleteImage` handler.
- Maps containerd not-found to the existing `errdefs.ErrImageNotFound` sentinel (reused, not duplicated); other failures wrap a new `errdefs.ErrDeleteImage`. The CLI surfaces a friendly `image %q not found in realm %q` message that still unwraps via `errors.Is(err, errdefs.ErrImageNotFound)`.
- Realm name uses `consts.RealmNamespace` like `load`/`get`, keeping the realm→namespace mapping consistent across the `kuke image` family.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes (full unit suite)
- [x] Smoke test per project CLAUDE.md — torn down the existing kukeond cell, rebuilt `kuke`, rebuilt and imported `kukeon-local:dev`, ran `sudo ./kuke init` to a healthy `kukeond is ready`.
- [x] Daemon-parity check: `sudo ./kuke get realms` and `sudo ./kuke get realms --no-daemon` produced identical output (default + kuke-system, both Ready).
- [x] End-to-end: `kuke image load` → `kuke image get` → `kuke image delete` → `kuke image get` (empty) on the `default` realm via the daemon path **and** via `--no-daemon`. Both paths produced identical results, confirming daemon-parity for the new endpoint.
- [x] Error paths: deleting a missing ref returns `image "..." not found in realm "default": image not found` on both paths; bad realm name returns `realm not found: ghost`.

Closes #212