### PR TITLE
docs: replace ctr images import with kuke image load in smoke test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,7 @@ ln -sf kuke kukeond # kukeond is argv[0]-dispatched from the same binary
 docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
 docker tag kukeon-local:dev docker.io/library/kukeon-local:dev
 
-docker save kukeon-local:dev | \
-    sudo ctr -n kuke-system.kukeon.io images import -
+sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
 
 sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
 ```


### PR DESCRIPTION
## Summary
- Routes step 3 of the local smoke test through `kuke image load --from-docker` (added in #213) instead of piping `docker save` into `sudo ctr -n kuke-system.kukeon.io images import -`. Stops the smoke test from leaking the realm → containerd-namespace mapping that `kuke image load` is meant to abstract away.
- `--no-daemon` is correct here because step 1 just tore the daemon down; the in-process path is the only one available.
- Verification line (`sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local`) is left as-is — it inspects containerd directly, which is still the right end-of-step check.
- Pure docs change. No code touched.

## Test plan
- [x] `make test` (full unit-test suite — what CI runs on PRs) passes locally.
- [ ] Local smoke test (the rebuild + `kuke init` flow) — not re-run for this PR; the change is a pure docs swap to the documented commands and the new line is the same `kuke image load` invocation already covered by #213's tests.

Closes #214