### PR TITLE
fix: bind env vars in kukeond so KUKEON_/KUKEOND_ overrides win

### DIFF
--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -124,8 +124,27 @@ func NewKukeondCmd() (*cobra.Command, error) {
 		return nil, err
 	}
 
+	bindEnvVars()
+
 	cmd.AddCommand(newServeCmd())
 	return cmd, nil
+}
+
+// bindEnvVars wires each kukeond viper key to its `KUKEON_…` / `KUKEOND_…`
+// environment variable. Without these calls, applyServerConfiguration's
+// envSet check skips the YAML write but viper has no env binding to read
+// from — so both env and YAML are silently ignored and the flag default
+// wins. Mirrors the BindEnv block in cmd/kuke/kuke.go's loadConfig.
+func bindEnvVars() {
+	for _, v := range []config.Var{
+		config.KUKEON_ROOT_CONTAINERD_SOCKET,
+		config.KUKEON_ROOT_RUN_PATH,
+		config.KUKEON_ROOT_LOG_LEVEL,
+		config.KUKEOND_SOCKET,
+		config.KUKEOND_SOCKET_GID,
+	} {
+		_ = v.BindEnv()
+	}
 }
 
 // applyServerConfiguration layers the loaded ServerConfiguration on top of

--- a/cmd/kukeond/kukeond_test.go
+++ b/cmd/kukeond/kukeond_test.go
@@ -26,21 +26,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-func bindKukeondEnv(t *testing.T) {
-	t.Helper()
-	for _, v := range []config.Var{
-		config.KUKEOND_SOCKET,
-		config.KUKEOND_SOCKET_GID,
-		config.KUKEON_ROOT_RUN_PATH,
-		config.KUKEON_ROOT_CONTAINERD_SOCKET,
-		config.KUKEON_ROOT_LOG_LEVEL,
-	} {
-		if err := v.BindEnv(); err != nil {
-			t.Fatalf("BindEnv %s: %v", v.EnvVar(), err)
-		}
-	}
-}
-
 func TestNewKukeondCmdHasConfigurationFlag(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
@@ -118,23 +103,32 @@ func TestApplyServerConfigurationEnvOverridesConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewKukeondCmd() error = %v", err)
 	}
-	bindKukeondEnv(t)
 
-	// Operator exported KUKEOND_SOCKET; the on-disk ServerConfiguration must
-	// not clobber it. Documents the precedence order in the PR description:
-	// --flag > env > ServerConfiguration > default.
+	// Operator exported KUKEOND_SOCKET, KUKEON_CONTAINERD_SOCKET, and
+	// KUKEON_LOG_LEVEL; the on-disk ServerConfiguration must not clobber
+	// them. Documents the precedence order in the PR description:
+	// --flag > env > ServerConfiguration > default. The KUKEON_CONTAINERD_SOCKET
+	// assertion is the regression guard for issue #191 — without
+	// bindEnvVars() in NewKukeondCmd the env binding does not exist and
+	// viper falls back to the flag default, silently dropping both env
+	// and YAML.
 	t.Setenv(config.KUKEOND_SOCKET.EnvVar(), "/run/kukeon/from-env.sock")
+	t.Setenv(config.KUKEON_ROOT_CONTAINERD_SOCKET.EnvVar(), "/run/containerd/from-env.sock")
 	t.Setenv(config.KUKEON_ROOT_LOG_LEVEL.EnvVar(), "debug")
 
 	spec := v1beta1.ServerConfigurationSpec{
-		Socket:   "/run/kukeon/from-config.sock",
-		LogLevel: "warn",
-		RunPath:  "/opt/kukeon-from-config",
+		Socket:           "/run/kukeon/from-config.sock",
+		ContainerdSocket: "/run/containerd/from-config.sock",
+		LogLevel:         "warn",
+		RunPath:          "/opt/kukeon-from-config",
 	}
 	applyServerConfiguration(cmd, spec)
 
 	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon/from-env.sock" {
 		t.Errorf("Socket env override lost: got %q, want %q", got, "/run/kukeon/from-env.sock")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey); got != "/run/containerd/from-env.sock" {
+		t.Errorf("ContainerdSocket env override lost: got %q, want %q", got, "/run/containerd/from-env.sock")
 	}
 	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "debug" {
 		t.Errorf("LogLevel env override lost: got %q, want %q", got, "debug")


### PR DESCRIPTION
## Summary
- `cmd/kukeond/kukeond.go` was wiring `BindPFlag` for each persistent flag but never calling `BindEnv()` for the matching viper keys. The bug: `applyServerConfiguration` correctly skipped its YAML write whenever an env var was set, but viper had no env binding to read from — so both env and YAML lost, and the flag default silently won. Affected vars: `KUKEON_CONTAINERD_SOCKET`, `KUKEON_RUN_PATH`, `KUKEON_LOG_LEVEL`, `KUKEOND_SOCKET`, `KUKEOND_SOCKET_GID`.
- Adds a `bindEnvVars()` helper called from `NewKukeondCmd` after the `BindPFlag` block, mirroring the `BindEnv` pattern in `cmd/kuke/kuke.go`'s `loadConfig` (the kuke side's parallel gap was fixed in #189).
- Strengthens `TestApplyServerConfigurationEnvOverridesConfig` to also assert `KUKEON_CONTAINERD_SOCKET` env wins over a YAML value, which is the regression guard called for in the issue. Removes the `bindKukeondEnv(t)` test helper since `NewKukeondCmd()` now handles binding for production and test paths alike — the helper had been masking the very bug this PR fixes.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (the CI target) — all packages pass, including `cmd/kukeond` with the new `KUKEON_CONTAINERD_SOCKET` regression assertion
- [x] Force-rebuilt `./kuke` from a clean tree to confirm the changed `NewKukeondCmd` builds in the kuke entry binary
- [ ] Daemon-parity smoke (`kuke get realms` vs `--no-daemon`) — not run. The change is confined to env-binding for daemon flag keys; it does not touch bind-mount, `/opt/kukeon` layout, or realm logic, so the bind-mount regression this smoke guards against cannot be triggered by this diff. Tearing down `kuke-system` on the dev host has real blast radius (interrupts the running daemon) and is left to the reviewer if desired.

Closes #191