### PR TITLE
fix: route kuke get output format through viper so KUKE_GET_OUTPUT env wins

### DIFF
--- a/cmd/kuke/get/shared/shared.go
+++ b/cmd/kuke/get/shared/shared.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/eminwux/kukeon/cmd/config"
 	createshared "github.com/eminwux/kukeon/cmd/kuke/create/shared"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/spf13/cobra"
@@ -49,17 +50,25 @@ const (
 	OutputFormatTable OutputFormat = "table"
 )
 
-// ParseOutputFormat parses and validates the --output flag from the command.
+// ParseOutputFormat resolves the output format using kuke's standard
+// precedence: explicit `--output`/`-o` flag > KUKEON_GET_OUTPUT env (and
+// any other source viper has bound to `kuke/get/output`) > table default.
+// Each `kuke get <kind>` subcommand binds its own `--output` flag to the
+// shared viper key at construction time, but viper only retains the last
+// binding for a given key; reading the active command's flag directly
+// keeps the flag working for every subcommand and lets viper handle the
+// env/config fall-throughs.
 func ParseOutputFormat(cmd *cobra.Command) (OutputFormat, error) {
-	output, err := cmd.Flags().GetString("output")
-	if err != nil {
-		return OutputFormatTable, err
+	output := ""
+	if cmd != nil && cmd.Flags().Changed("output") {
+		var err error
+		output, err = cmd.Flags().GetString("output")
+		if err != nil {
+			return OutputFormatTable, err
+		}
 	}
 	if output == "" {
-		output, _ = cmd.Flags().GetString("o")
-	}
-	if output == "" {
-		return OutputFormatTable, nil
+		output = viper.GetString(config.KUKE_GET_OUTPUT.ViperKey)
 	}
 
 	trimmed := strings.TrimSpace(output)

--- a/cmd/kuke/get/shared/shared_test.go
+++ b/cmd/kuke/get/shared/shared_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -67,16 +68,6 @@ func TestParseOutputFormat(t *testing.T) {
 			wantFormat: shared.OutputFormatJSON,
 		},
 		{
-			name:       "short flag -o",
-			flags:      map[string]string{"o": "yaml"},
-			wantFormat: shared.OutputFormatYAML,
-		},
-		{
-			name:       "output flag takes precedence over -o",
-			flags:      map[string]string{"output": "json", "o": "yaml"},
-			wantFormat: shared.OutputFormatJSON,
-		},
-		{
 			name:    "invalid format",
 			flags:   map[string]string{"output": "xml"},
 			wantErr: "invalid output format",
@@ -91,8 +82,7 @@ func TestParseOutputFormat(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{Use: "test"}
-			cmd.Flags().String("output", "", "Output format")
-			cmd.Flags().StringP("o", "o", "", "Output format (short)")
+			cmd.Flags().StringP("output", "o", "", "Output format")
 
 			for name, value := range tt.flags {
 				if err := cmd.Flags().Set(name, value); err != nil {
@@ -112,6 +102,73 @@ func TestParseOutputFormat(t *testing.T) {
 				return
 			}
 
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if format != tt.wantFormat {
+				t.Errorf("expected format %q, got %q", tt.wantFormat, format)
+			}
+		})
+	}
+}
+
+func TestParseOutputFormatEnvAndFlagPrecedence(t *testing.T) {
+	if err := config.KUKE_GET_OUTPUT.BindEnv(); err != nil {
+		t.Fatalf("bind KUKEON_GET_OUTPUT: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		env        string
+		setEnv     bool
+		flag       string // empty means flag not set
+		wantFormat shared.OutputFormat
+	}{
+		{
+			name:       "env yaml is honored when flag unset",
+			env:        "yaml",
+			setEnv:     true,
+			wantFormat: shared.OutputFormatYAML,
+		},
+		{
+			name:       "env json is honored when flag unset",
+			env:        "json",
+			setEnv:     true,
+			wantFormat: shared.OutputFormatJSON,
+		},
+		{
+			name:       "explicit flag overrides env",
+			env:        "yaml",
+			setEnv:     true,
+			flag:       "json",
+			wantFormat: shared.OutputFormatJSON,
+		},
+		{
+			name:       "default table when neither set",
+			wantFormat: shared.OutputFormatTable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Always seed the env via t.Setenv so the test always restores
+			// the prior value on exit, regardless of CI shell state.
+			t.Setenv(config.KUKE_GET_OUTPUT.Key, tt.env)
+			if !tt.setEnv {
+				if err := os.Unsetenv(config.KUKE_GET_OUTPUT.Key); err != nil {
+					t.Fatalf("unset env: %v", err)
+				}
+			}
+
+			cmd := &cobra.Command{Use: "test"}
+			cmd.Flags().StringP("output", "o", "", "Output format")
+			if tt.flag != "" {
+				if err := cmd.Flags().Set("output", tt.flag); err != nil {
+					t.Fatalf("set flag: %v", err)
+				}
+			}
+
+			format, err := shared.ParseOutputFormat(cmd)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -236,6 +236,8 @@ func loadConfig() error {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, "info")
 	}
 
+	_ = config.KUKE_GET_OUTPUT.BindEnv()
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- \`ParseOutputFormat\` now reads via viper for the env/config fall-through, while still consulting the active subcommand's \`--output\` flag directly so the flag works for every \`kuke get <kind>\`. Reading viper alone does not work because each \`get\` sibling binds the same \`kuke/get/output\` key during construction and viper retains only the last binding (\`v.pflags[key] = flag\`), so \`viper.GetString\` would only see the last-bound subcommand's flag.
- \`loadConfig\` now calls \`config.KUKE_GET_OUTPUT.BindEnv()\` so viper actually consults the env variable. Without this, the suggested fix would still be a silent no-op for env vars.
- Issue #190's repro snippet writes \`KUKEON_GET_OUTPUT=yaml\` but the var is named \`KUKE_GET_OUTPUT\` (per \`cmd/config/env.go:269\`, sibling to \`KUKE_GET_REALM_NAME\`, etc.). The fix wires the actual var, not the typo.
- Precedence: explicit \`--output\`/\`-o\` flag > \`KUKE_GET_OUTPUT\` env > table default. \`ClientConfiguration.spec.output\` plumbing remains the follow-up to #160 the issue mentions.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`make test\` passes (all unit tests including the new \`TestParseOutputFormatEnvAndFlagPrecedence\`)
- [x] Built \`./kuke\` and verified env path: \`KUKE_GET_OUTPUT=yaml ./kuke get realms --no-daemon\` prints YAML; \`KUKE_GET_OUTPUT=yaml ./kuke get realms --no-daemon --output table\` prints table (flag overrides env); plain \`./kuke get realms --no-daemon\` prints table (default).
- [x] Daemon-parity sanity: \`sudo ./kuke get realms\` and \`sudo ./kuke get realms --no-daemon\` produce identical table output; \`KUKE_GET_OUTPUT=yaml sudo -E ./kuke get realms\` prints YAML through the daemon.
- [ ] Full smoke test (rebuild kukeond image + \`kuke init\`) — skipped: this fix is purely client-side output parsing, the daemon read path is untouched.

Closes #190