### PR TITLE
fix: honor kukeond --flag over YAML when dispatched on leaf subcommand

### DIFF
--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -155,23 +155,44 @@ func bindEnvVars() {
 // without it, `viper.Set` would override viper's env binding and silently
 // invert env > YAML.
 func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurationSpec) {
-	flags := cmd.PersistentFlags()
-	if spec.Socket != "" && !flags.Changed("socket") && !envSet(config.KUKEOND_SOCKET) {
+	if spec.Socket != "" && !flagChanged(cmd, "socket") && !envSet(config.KUKEOND_SOCKET) {
 		viper.Set(config.KUKEOND_SOCKET.ViperKey, spec.Socket)
 	}
-	if spec.SocketGID != 0 && !flags.Changed("socket-gid") && !envSet(config.KUKEOND_SOCKET_GID) {
+	if spec.SocketGID != 0 && !flagChanged(cmd, "socket-gid") && !envSet(config.KUKEOND_SOCKET_GID) {
 		viper.Set(config.KUKEOND_SOCKET_GID.ViperKey, spec.SocketGID)
 	}
-	if spec.RunPath != "" && !flags.Changed("run-path") && !envSet(config.KUKEON_ROOT_RUN_PATH) {
+	if spec.RunPath != "" && !flagChanged(cmd, "run-path") && !envSet(config.KUKEON_ROOT_RUN_PATH) {
 		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, spec.RunPath)
 	}
-	if spec.ContainerdSocket != "" && !flags.Changed("containerd-socket") &&
+	if spec.ContainerdSocket != "" && !flagChanged(cmd, "containerd-socket") &&
 		!envSet(config.KUKEON_ROOT_CONTAINERD_SOCKET) {
 		viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, spec.ContainerdSocket)
 	}
-	if spec.LogLevel != "" && !flags.Changed("log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
+	if spec.LogLevel != "" && !flagChanged(cmd, "log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
 	}
+}
+
+// flagChanged reports whether `--<name>` was explicitly set on the command
+// line. cobra invokes PersistentPreRunE on the leaf subcommand, but kukeond's
+// persistent flags (socket, run-path, etc.) are defined on the root. On the
+// leaf, cmd.PersistentFlags() returns only the leaf's local persistent flag
+// set — it does not include parents' persistent flags — so a direct
+// `cmd.PersistentFlags().Changed("socket")` lookup misses and returns false
+// even when the operator passed `--socket`. cobra merges parent persistent
+// flags into the leaf's cmd.Flags() before PersistentPreRunE runs, so the
+// merged set is the production-correct read; the local PersistentFlags
+// fallback keeps the helper correct in unit tests that pass the root cmd
+// directly without going through Execute. Mirrors the same-named helper in
+// cmd/kuke/kuke.go.
+func flagChanged(cmd *cobra.Command, name string) bool {
+	if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+		return true
+	}
+	if f := cmd.PersistentFlags().Lookup(name); f != nil && f.Changed {
+		return true
+	}
+	return false
 }
 
 // envSet reports whether the OS env var backing v is present (any value,

--- a/cmd/kukeond/kukeond_test.go
+++ b/cmd/kukeond/kukeond_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/eminwux/kukeon/cmd/config"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
@@ -92,6 +93,82 @@ func TestApplyServerConfigurationFlagOverridesConfig(t *testing.T) {
 
 	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon/from-flag.sock" {
 		t.Errorf("Socket flag override lost: got %q, want %q", got, "/run/kukeon/from-flag.sock")
+	}
+}
+
+// TestApplyServerConfigurationFlagOverridesConfigViaExecute is the regression
+// guard for issue #210. cobra invokes PersistentPreRunE on the leaf
+// subcommand, but kukeond's persistent flags live on the root; before the
+// fix, applyServerConfiguration read cmd.PersistentFlags() on the leaf,
+// which does not include the parent's persistent flags, so the flag-changed
+// guard never fired and YAML silently overrode `--socket`. This test drives
+// the full cobra dispatch (cmd.Execute with the "serve" leaf path) so the
+// production code path is exercised — the sibling test above passes the
+// root cmd directly and would not catch this regression.
+func TestApplyServerConfigurationFlagOverridesConfigViaExecute(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "kukeond.yaml")
+	yamlBody := []byte(`apiVersion: v1beta1
+kind: ServerConfiguration
+metadata:
+  name: default
+spec:
+  socket: /run/kukeon/from-config.sock
+  socketGID: 4242
+  runPath: /opt/kukeon-from-config
+  containerdSocket: /run/containerd/from-config.sock
+  logLevel: warn
+`)
+	if err := os.WriteFile(cfgPath, yamlBody, 0o600); err != nil {
+		t.Fatalf("write tmp ServerConfiguration: %v", err)
+	}
+
+	cmd, err := NewKukeondCmd()
+	if err != nil {
+		t.Fatalf("NewKukeondCmd() error = %v", err)
+	}
+	// Stub the serve leaf's RunE so Execute does not start the daemon.
+	// PersistentPreRunE still fires — that is the production path that
+	// dispatches applyServerConfiguration with cmd = leaf.
+	for _, sub := range cmd.Commands() {
+		if sub.Use == "serve" {
+			sub.RunE = func(*cobra.Command, []string) error { return nil }
+		}
+	}
+
+	cmd.SetArgs([]string{
+		"serve",
+		"--configuration", cfgPath,
+		"--socket", "/run/kukeon/from-flag.sock",
+		"--socket-gid", "1234",
+		"--run-path", "/opt/kukeon-from-flag",
+		"--containerd-socket", "/run/containerd/from-flag.sock",
+		"--log-level", "debug",
+	})
+	if execErr := cmd.Execute(); execErr != nil {
+		t.Fatalf("cmd.Execute() error = %v", execErr)
+	}
+
+	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon/from-flag.sock" {
+		t.Errorf("Socket flag override lost via leaf-cmd dispatch: got %q, want %q",
+			got, "/run/kukeon/from-flag.sock")
+	}
+	if got := viper.GetInt(config.KUKEOND_SOCKET_GID.ViperKey); got != 1234 {
+		t.Errorf("SocketGID flag override lost via leaf-cmd dispatch: got %d, want %d", got, 1234)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey); got != "/opt/kukeon-from-flag" {
+		t.Errorf("RunPath flag override lost via leaf-cmd dispatch: got %q, want %q",
+			got, "/opt/kukeon-from-flag")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey); got != "/run/containerd/from-flag.sock" {
+		t.Errorf("ContainerdSocket flag override lost via leaf-cmd dispatch: got %q, want %q",
+			got, "/run/containerd/from-flag.sock")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "debug" {
+		t.Errorf("LogLevel flag override lost via leaf-cmd dispatch: got %q, want %q", got, "debug")
 	}
 }
 


### PR DESCRIPTION
## Summary

- cobra invokes `PersistentPreRunE` on the **leaf** subcommand, but kukeond's persistent flags (`socket`, `socket-gid`, `run-path`, `containerd-socket`, `log-level`) are defined on the root. `applyServerConfiguration` was reading `cmd.PersistentFlags().Changed(name)` on the leaf — that lookup misses parent-defined persistent flags and silently returns `false`, so the YAML value at `spec.<field>` overrode the operator's explicit `--flag`. The advertised precedence (`--flag > env > ServerConfiguration > default`) was effectively `env > ServerConfiguration > --flag > default` for kukeond.
- Switched the flag-changed check to a `flagChanged(cmd, name)` helper that looks up both `cmd.Flags()` (post-merge — what cobra populates on the leaf before `PersistentPreRunE`) and `cmd.PersistentFlags()` (the local set). Mirrors the same-named helper in `cmd/kuke/kuke.go`. Could have inlined per-field, but five callsites in one function plus parity with the kuke-side fix made a helper the lower-blast-radius call.
- Added regression test `TestApplyServerConfigurationFlagOverridesConfigViaExecute` that drives `cmd.SetArgs([]string{"serve", "--configuration", <tmp>, "--socket", ..., ...}) + cmd.Execute()` — i.e. exercises `PersistentPreRunE` through cobra dispatch with `cmd = serve` (leaf), the production code path. Verified the test fails on the unfixed `applyServerConfiguration` for all five spec fields (each silently overridden by YAML).
- Existing `TestApplyServerConfigurationFlagOverridesConfig` left in place — it tests `applyServerConfiguration`'s narrow contract (skip when Changed is set on the persistent flag set directly), which is still valuable as a unit test even though it bypasses cobra dispatch. The new test is the production-path coverage.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` passes
- [x] Counter-check: stashed only the `kukeond.go` fix and re-ran the new test — it failed with the exact bug from #210 (each of `socket`, `socket-gid`, `run-path`, `containerd-socket`, `log-level` silently overridden by YAML).
- [x] Smoke test (rebuild kuke + kukeond image, `kuke init` with `--kukeond-image docker.io/library/kukeon-local:dev`): kukeond comes up at `unix:///run/kukeon/kukeond.sock`, daemon process line shows `--socket /run/kukeon/kukeond.sock --run-path /opt/kukeon --containerd-socket /run/containerd/containerd.sock --socket-gid 986`, daemon-parity check `sudo ./kuke get realms` vs `--no-daemon` returns identical output.

Closes #210