### PR TITLE
feat: add kuke daemon stop

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -427,4 +427,7 @@ var (
 	KUKE_KILL_CONTAINER_STACK = DefineKV("KUKE_KILL_CONTAINER_STACK", "kuke/kill/container/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_KILL_CONTAINER_CELL = DefineKV("KUKE_KILL_CONTAINER_CELL", "kuke/kill/container/cell")
+
+	//nolint:revive,gochecknoglobals,staticcheck // daemon command variables
+	KUKE_DAEMON_STOP_TIMEOUT = DefineKV("KUKE_DAEMON_STOP_TIMEOUT", "kuke/daemon/stop/timeout", "10s")
 )

--- a/cmd/kuke/daemon/daemon.go
+++ b/cmd/kuke/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/start"
+	stopcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/stop"
 	"github.com/spf13/cobra"
 )
 
@@ -47,6 +48,7 @@ func NewDaemonCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		startcmd.NewStartCmd(),
+		stopcmd.NewStopCmd(),
 	)
 
 	return cmd
@@ -54,7 +56,7 @@ func NewDaemonCmd() *cobra.Command {
 
 // completeDaemonSubcommands provides shell completion for daemon subcommand names.
 func completeDaemonSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"start"}
+	subcommands := []string{"start", "stop"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/daemon/daemon_test.go
+++ b/cmd/kuke/daemon/daemon_test.go
@@ -39,6 +39,21 @@ func TestDaemonCmd_HasStartSubcommand(t *testing.T) {
 	}
 }
 
+func TestDaemonCmd_HasStopSubcommand(t *testing.T) {
+	cmd := daemon.NewDaemonCmd()
+
+	var found bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "stop" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected `kuke daemon` to register a `stop` subcommand")
+	}
+}
+
 func TestDaemonCmd_HelpRunsWithoutArgs(t *testing.T) {
 	cmd := daemon.NewDaemonCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/kuke/daemon/stop/stop.go
+++ b/cmd/kuke/daemon/stop/stop.go
@@ -1,0 +1,195 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package stop implements `kuke daemon stop`, which gracefully shuts down the
+// kukeond cell. The command runs in-process — kukeond cannot relay its own
+// shutdown — and escalates to a force-kill if the graceful path does not
+// complete within the configured grace period.
+package stop
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/client/local"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
+// context so unit tests can exercise runStop without a real controller.
+type MockClientKey struct{}
+
+// defaultTimeout matches the issue spec (#219): 10s graceful grace period
+// before SIGKILL escalation.
+const defaultTimeout = 10 * time.Second
+
+// NewStopCmd builds the `kuke daemon stop` cobra command.
+func NewStopCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the kukeond daemon cell",
+		Long: "Gracefully shut down the kukeond cell.\n\n" +
+			"Sends SIGTERM and waits up to --timeout (default 10s) for the daemon " +
+			"to exit; if the grace period expires, escalates to SIGKILL. " +
+			"Idempotent: succeeds with a clear message when the daemon is already stopped.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runStop,
+	}
+
+	cmd.Flags().Duration(
+		"timeout", defaultTimeout,
+		"Grace period before escalating from SIGTERM to SIGKILL",
+	)
+	_ = viper.BindPFlag(config.KUKE_DAEMON_STOP_TIMEOUT.ViperKey, cmd.Flags().Lookup("timeout"))
+
+	return cmd
+}
+
+func runStop(cmd *cobra.Command, _ []string) error {
+	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+	if !ok || logger == nil {
+		return errdefs.ErrLoggerNotFound
+	}
+
+	timeout := viper.GetDuration(config.KUKE_DAEMON_STOP_TIMEOUT.ViperKey)
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
+	client := resolveClient(cmd, logger)
+	defer func() { _ = client.Close() }()
+
+	doc := kukeondCellDoc()
+
+	getRes, err := client.GetCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("inspect kukeond cell: %w", err)
+	}
+	if !getRes.MetadataExists {
+		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
+	}
+
+	if !isCellRunning(getRes.Cell) {
+		cmd.Printf(
+			"kukeond is already stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	}
+
+	type stopOutcome struct {
+		res kukeonv1.StopCellResult
+		err error
+	}
+	done := make(chan stopOutcome, 1)
+	go func() {
+		res, sErr := client.StopCell(cmd.Context(), doc)
+		done <- stopOutcome{res: res, err: sErr}
+	}()
+
+	select {
+	case out := <-done:
+		if out.err != nil {
+			return fmt.Errorf("stop kukeond cell: %w", out.err)
+		}
+		if !out.res.Stopped {
+			return errors.New("stop kukeond cell: controller reported no change")
+		}
+		cmd.Printf(
+			"kukeond stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	case <-time.After(timeout):
+		// Graceful path did not complete within the grace period — escalate.
+		// The in-flight StopCell may still be running; the underlying containerd
+		// task will be torn down by KillCell regardless, and the goroutine exits
+		// cleanly when its call returns.
+		killRes, killErr := client.KillCell(cmd.Context(), doc)
+		if killErr != nil {
+			return fmt.Errorf(
+				"kill kukeond cell after %s grace period expired: %w",
+				timeout, killErr,
+			)
+		}
+		if !killRes.Killed {
+			return errors.New("kill kukeond cell: controller reported no change")
+		}
+		cmd.Printf(
+			"kukeond force-killed after %s grace period expired (cell %q in realm %q)\n",
+			timeout, consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	}
+}
+
+// kukeondCellDoc builds the lookup CellDoc for the system kukeond cell. The
+// names are fixed by `kuke init` and centralised in internal/consts.
+func kukeondCellDoc() v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   consts.KukeSystemCellName,
+			Labels: map[string]string{},
+		},
+		Spec: v1beta1.CellSpec{
+			ID:      consts.KukeSystemCellName,
+			RealmID: consts.KukeSystemRealmName,
+			SpaceID: consts.KukeSystemSpaceName,
+			StackID: consts.KukeSystemStackName,
+		},
+	}
+}
+
+// isCellRunning treats the cell as live if any container reports Ready, or if
+// the persisted cell state is Ready. This mirrors the running-check used by
+// `kuke daemon start` so the two verbs agree on what "running" means.
+func isCellRunning(cell v1beta1.CellDoc) bool {
+	for _, c := range cell.Status.Containers {
+		if c.State == v1beta1.ContainerStateReady {
+			return true
+		}
+	}
+	return cell.Status.State == v1beta1.CellStateReady
+}
+
+// resolveClient returns the kukeonv1.Client used by runStop. Tests inject a
+// fake via MockClientKey; production always builds an in-process client —
+// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
+// through the daemon is impossible by definition.
+func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
+	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+		return mockClient
+	}
+	opts := controller.Options{
+		RunPath:          viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	}
+	return local.New(cmd.Context(), logger, opts)
+}

--- a/cmd/kuke/daemon/stop/stop_test.go
+++ b/cmd/kuke/daemon/stop/stop_test.go
@@ -1,0 +1,390 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stop_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	stop "github.com/eminwux/kukeon/cmd/kuke/daemon/stop"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+func TestDaemonStop(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		fake       *fakeClient
+		wantErr    string
+		wantOutput string
+	}{
+		{
+			name: "running cell is gracefully stopped",
+			fake: &fakeClient{
+				getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+				},
+				killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+					t.Fatalf("KillCell must not be called when graceful stop succeeds")
+					return kukeonv1.KillCellResult{}, nil
+				},
+			},
+			wantOutput: `kukeond stopped (cell "kukeond" in realm "kuke-system")`,
+		},
+		{
+			name: "already-stopped cell is a no-op",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					t.Fatalf("StopCell must not be called when daemon is already stopped")
+					return kukeonv1.StopCellResult{}, nil
+				},
+			},
+			wantOutput: `kukeond is already stopped (cell "kukeond" in realm "kuke-system")`,
+		},
+		{
+			name: "host not initialized",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: "kukeon host is not initialized",
+		},
+		{
+			name: "GetCell error is wrapped",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{}, errors.New("io: read failed")
+				},
+			},
+			wantErr: "inspect kukeond cell:",
+		},
+		{
+			name: "StopCell error is wrapped",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{}, errors.New("runner blew up")
+				},
+			},
+			wantErr: "stop kukeond cell:",
+		},
+		{
+			name: "StopCell reports no change is an error",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: false}, nil
+				},
+			},
+			wantErr: "controller reported no change",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFreshViper(t)
+			cmd := stop.NewStopCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, stop.MockClientKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+// TestDaemonStop_GracefulTimeoutEscalatesToKill exercises the SIGTERM →
+// SIGKILL escalation path by having the fake StopCell block past the user's
+// --timeout. KillCell must be invoked, and the output must mention the
+// expired grace period.
+func TestDaemonStop_GracefulTimeoutEscalatesToKill(t *testing.T) {
+	withFreshViper(t)
+
+	stopBlocked := make(chan struct{})
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+
+	var killCalled atomicBool
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			close(stopBlocked)
+			<-releaseStop
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			killCalled.Store(true)
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+	}
+
+	cmd := stop.NewStopCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, stop.MockClientKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--timeout", "50ms"})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.Execute() }()
+
+	select {
+	case <-stopBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopCell was not invoked within 2s")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runStop did not return after timeout fired")
+	}
+
+	if !killCalled.Load() {
+		t.Fatal("expected KillCell to be invoked when --timeout fires before StopCell returns")
+	}
+	if !strings.Contains(buf.String(), "force-killed after 50ms grace period expired") {
+		t.Errorf("output missing escalation notice; got:\n%s", buf.String())
+	}
+}
+
+// TestDaemonStop_KillCellErrorIsWrapped covers the failure mode where the
+// graceful timeout fires, escalation runs, and KillCell itself errors.
+func TestDaemonStop_KillCellErrorIsWrapped(t *testing.T) {
+	withFreshViper(t)
+
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			<-releaseStop
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{}, errors.New("ctrd unreachable")
+		},
+	}
+
+	cmd := stop.NewStopCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, stop.MockClientKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--timeout", "20ms"})
+
+	err := cmd.Execute()
+	if err == nil ||
+		!strings.Contains(err.Error(), "kill kukeond cell after") ||
+		!strings.Contains(err.Error(), "20ms grace period expired") {
+		t.Fatalf("expected wrapped kill error mentioning grace period, got %v", err)
+	}
+}
+
+func TestDaemonStop_LoggerMissingFromContext(t *testing.T) {
+	withFreshViper(t)
+	cmd := stop.NewStopCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "logger not found") {
+		t.Fatalf("expected logger-missing error, got %v", err)
+	}
+}
+
+func assertKukeondTarget(t *testing.T, doc v1beta1.CellDoc) {
+	t.Helper()
+	if doc.Metadata.Name != consts.KukeSystemCellName {
+		t.Errorf("cell name: want %q, got %q", consts.KukeSystemCellName, doc.Metadata.Name)
+	}
+	if doc.Spec.RealmID != consts.KukeSystemRealmName {
+		t.Errorf("realm: want %q, got %q", consts.KukeSystemRealmName, doc.Spec.RealmID)
+	}
+	if doc.Spec.SpaceID != consts.KukeSystemSpaceName {
+		t.Errorf("space: want %q, got %q", consts.KukeSystemSpaceName, doc.Spec.SpaceID)
+	}
+	if doc.Spec.StackID != consts.KukeSystemStackName {
+		t.Errorf("stack: want %q, got %q", consts.KukeSystemStackName, doc.Spec.StackID)
+	}
+}
+
+// withFreshViper resets the viper key the stop command binds to, so prior
+// tests' --timeout values don't leak between table-driven runs.
+func withFreshViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+}
+
+type atomicBool struct {
+	mu sync.Mutex
+	v  bool
+}
+
+func (a *atomicBool) Store(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.v = v
+}
+
+func (a *atomicBool) Load() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.v
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getCellFn  func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	stopCellFn func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
+	killCellFn func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errors.New("unexpected GetCell call")
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) StopCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+	if f.stopCellFn == nil {
+		return kukeonv1.StopCellResult{}, errors.New("unexpected StopCell call")
+	}
+	return f.stopCellFn(doc)
+}
+
+func (f *fakeClient) KillCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+	if f.killCellFn == nil {
+		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
+	}
+	return f.killCellFn(doc)
+}

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -109,7 +109,7 @@ func TestKuke_Start_Help(t *testing.T) {
 	}
 }
 
-// TestKuke_Daemon_Help tests `kuke daemon -h` and the `start` subcommand help.
+// TestKuke_Daemon_Help tests `kuke daemon -h` and the `start`/`stop` subcommand help.
 func TestKuke_Daemon_Help(t *testing.T) {
 	t.Parallel()
 
@@ -118,6 +118,8 @@ func TestKuke_Daemon_Help(t *testing.T) {
 		{"daemon", "--help"},
 		{"daemon", "start", "-h"},
 		{"daemon", "start", "--help"},
+		{"daemon", "stop", "-h"},
+		{"daemon", "stop", "--help"},
 	} {
 		exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
 		if exitCode != 0 {
@@ -141,6 +143,30 @@ func TestKuke_DaemonStart_Uninitialized(t *testing.T) {
 	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "daemon", "start")
+	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
+	if exitCode == 0 {
+		t.Fatalf(
+			"expected non-zero exit code on uninitialized host; stdout=%s stderr=%s",
+			string(stdout), string(stderr),
+		)
+	}
+	combined := string(stdout) + string(stderr)
+	if !strings.Contains(combined, "kuke init") {
+		t.Fatalf("expected error to mention `kuke init`, got: %s", combined)
+	}
+}
+
+// TestKuke_DaemonStop_Uninitialized verifies that `kuke daemon stop` fails
+// with the same friendly "host not initialized" message as `daemon start` when
+// the run-path has no kukeond cell metadata. Mirrors the start-side guard so
+// regressions in either branch surface immediately.
+func TestKuke_DaemonStop_Uninitialized(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	args := append(buildKukeRunPathArgs(runPath), "daemon", "stop")
 	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
 	if exitCode == 0 {
 		t.Fatalf(


### PR DESCRIPTION
## Summary
- Add `kuke daemon stop`, the second verb in the `kuke daemon` group (umbrella #217). Sends a graceful stop to the kukeond cell, watches it with a configurable `--timeout` (default 10s, also bindable via `KUKE_DAEMON_STOP_TIMEOUT`), and escalates to `KillCell` (SIGKILL) if the graceful path does not complete in time.
- Implicitly in-process: same architectural rationale as `kuke daemon start` — the daemon being shut down cannot relay its own teardown, so the command always builds a `local` client.
- Idempotent: prints `kukeond is already stopped (...)` and returns success when the cell is not running. `kukeon host is not initialized` (with the same `kuke init` directive `start` uses) when no cell metadata exists.
- Done message differs by path: `kukeond stopped (...)` on graceful, `kukeond force-killed after <timeout> grace period expired (...)` on escalation, so operators can tell at a glance whether the daemon honored SIGTERM.

## Test plan
- [x] `make test` (full unit suite, includes new `cmd/kuke/daemon/stop/...` tests covering graceful path, idempotent already-stopped, host-not-initialized, GetCell/StopCell error wrapping, the timeout-escalation path, and the KillCell-error wrapping path on escalation).
- [x] `go vet ./...` clean.
- [x] `go test -run "TestKuke_Daemon_Help|TestKuke_DaemonStart_Uninitialized|TestKuke_DaemonStop_Uninitialized" ./e2e` — help-tree (start + stop) and uninitialized-host e2e tests pass against the built binary.
- [x] Local smoke (host already provisioned):
  - `sudo ./kuke daemon stop` returns `kukeond stopped (...)` in ~5.7s; `ctr -n kuke-system.kukeon.io tasks ls` shows no kukeond task; `/run/kukeon/kukeond.sock` is gone.
  - Re-running `sudo ./kuke daemon stop` returns `kukeond is already stopped (...)` (idempotent).
  - `sudo ./kuke daemon start` brings the daemon back up; `sudo ./kuke daemon stop --timeout 100ms` exits in ~0.7s with `kukeond force-killed after 100ms grace period expired (...)`, exercising the SIGKILL-escalation branch.
  - Daemon-parity check (`sudo ./kuke get realms` vs. `sudo ./kuke get realms --no-daemon`) returns identical output after a fresh start.
- [ ] Full CLAUDE.md re-init smoke test (`kuke kill cell kukeond` → rebuild → `kuke init` → daemon-parity check) — not run because this PR adds a CLI subcommand only and does not touch the bootstrap/init path or anything the daemon reads from `/opt/kukeon`. Mirrors the deferral the `kuke daemon start` PR (#233) used for the same reason.

Closes #219