### PR TITLE
feat: add kuke daemon kill

### DIFF
--- a/cmd/kuke/daemon/daemon.go
+++ b/cmd/kuke/daemon/daemon.go
@@ -15,7 +15,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package daemon hosts the `kuke daemon` subcommand group, which exposes
-// daemon-lifecycle verbs (start, and later stop/kill/restart/reset). These
+// daemon-lifecycle verbs (start, stop, kill, and later restart/reset). These
 // commands operate on kukeond itself and therefore run in-process — they
 // cannot route through the daemon they are managing.
 package daemon
@@ -23,6 +23,7 @@ package daemon
 import (
 	"strings"
 
+	killcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/kill"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/start"
 	stopcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/stop"
 	"github.com/spf13/cobra"
@@ -49,6 +50,7 @@ func NewDaemonCmd() *cobra.Command {
 	cmd.AddCommand(
 		startcmd.NewStartCmd(),
 		stopcmd.NewStopCmd(),
+		killcmd.NewKillCmd(),
 	)
 
 	return cmd
@@ -56,7 +58,7 @@ func NewDaemonCmd() *cobra.Command {
 
 // completeDaemonSubcommands provides shell completion for daemon subcommand names.
 func completeDaemonSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"start", "stop"}
+	subcommands := []string{"start", "stop", "kill"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/daemon/daemon_test.go
+++ b/cmd/kuke/daemon/daemon_test.go
@@ -54,6 +54,21 @@ func TestDaemonCmd_HasStopSubcommand(t *testing.T) {
 	}
 }
 
+func TestDaemonCmd_HasKillSubcommand(t *testing.T) {
+	cmd := daemon.NewDaemonCmd()
+
+	var found bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "kill" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected `kuke daemon` to register a `kill` subcommand")
+	}
+}
+
 func TestDaemonCmd_HelpRunsWithoutArgs(t *testing.T) {
 	cmd := daemon.NewDaemonCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/kuke/daemon/kill/kill.go
+++ b/cmd/kuke/daemon/kill/kill.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kill implements `kuke daemon kill`, the immediate-SIGKILL escape
+// hatch for the kukeond cell. The command runs in-process — kukeond cannot
+// relay its own teardown — and skips the SIGTERM grace path entirely.
+package kill
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/client/local"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
+// context so unit tests can exercise runKill without a real controller.
+type MockClientKey struct{}
+
+// NewKillCmd builds the `kuke daemon kill` cobra command.
+func NewKillCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kill",
+		Short: "Immediately SIGKILL the kukeond daemon cell",
+		Long: "Force-kill the kukeond cell with no grace period.\n\n" +
+			"This is the escape hatch for a hung or unresponsive daemon — use " +
+			"`kuke daemon stop` for the graceful path. " +
+			"Idempotent: succeeds with a clear message when the daemon is already stopped.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runKill,
+	}
+
+	return cmd
+}
+
+func runKill(cmd *cobra.Command, _ []string) error {
+	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+	if !ok || logger == nil {
+		return errdefs.ErrLoggerNotFound
+	}
+
+	client := resolveClient(cmd, logger)
+	defer func() { _ = client.Close() }()
+
+	doc := kukeondCellDoc()
+
+	getRes, err := client.GetCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("inspect kukeond cell: %w", err)
+	}
+	if !getRes.MetadataExists {
+		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
+	}
+
+	if !isCellRunning(getRes.Cell) {
+		cmd.Printf(
+			"kukeond is already stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	}
+
+	killRes, err := client.KillCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("kill kukeond cell: %w", err)
+	}
+	if !killRes.Killed {
+		return errors.New("kill kukeond cell: controller reported no change")
+	}
+
+	cmd.Printf(
+		"kukeond force-killed (cell %q in realm %q)\n",
+		consts.KukeSystemCellName, consts.KukeSystemRealmName,
+	)
+	return nil
+}
+
+// kukeondCellDoc builds the lookup CellDoc for the system kukeond cell. The
+// names are fixed by `kuke init` and centralised in internal/consts.
+func kukeondCellDoc() v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   consts.KukeSystemCellName,
+			Labels: map[string]string{},
+		},
+		Spec: v1beta1.CellSpec{
+			ID:      consts.KukeSystemCellName,
+			RealmID: consts.KukeSystemRealmName,
+			SpaceID: consts.KukeSystemSpaceName,
+			StackID: consts.KukeSystemStackName,
+		},
+	}
+}
+
+// isCellRunning treats the cell as live if any container reports Ready, or if
+// the persisted cell state is Ready. Mirrors the check in `kuke daemon start`
+// and `kuke daemon stop` so all three verbs agree on what "running" means.
+func isCellRunning(cell v1beta1.CellDoc) bool {
+	for _, c := range cell.Status.Containers {
+		if c.State == v1beta1.ContainerStateReady {
+			return true
+		}
+	}
+	return cell.Status.State == v1beta1.CellStateReady
+}
+
+// resolveClient returns the kukeonv1.Client used by runKill. Tests inject a
+// fake via MockClientKey; production always builds an in-process client —
+// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
+// through the daemon is impossible by definition.
+func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
+	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+		return mockClient
+	}
+	opts := controller.Options{
+		RunPath:          viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	}
+	return local.New(cmd.Context(), logger, opts)
+}

--- a/cmd/kuke/daemon/kill/kill_test.go
+++ b/cmd/kuke/daemon/kill/kill_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kill_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	kill "github.com/eminwux/kukeon/cmd/kuke/daemon/kill"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestDaemonKill(t *testing.T) {
+	tests := []struct {
+		name       string
+		fake       *fakeClient
+		wantErr    string
+		wantOutput string
+	}{
+		{
+			name: "running cell is force-killed",
+			fake: &fakeClient{
+				getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+				},
+			},
+			wantOutput: `kukeond force-killed (cell "kukeond" in realm "kuke-system")`,
+		},
+		{
+			name: "already-stopped cell is a no-op",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+					t.Fatalf("KillCell must not be called when daemon is already stopped")
+					return kukeonv1.KillCellResult{}, nil
+				},
+			},
+			wantOutput: `kukeond is already stopped (cell "kukeond" in realm "kuke-system")`,
+		},
+		{
+			name: "host not initialized",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: "kukeon host is not initialized",
+		},
+		{
+			name: "GetCell error is wrapped",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{}, errors.New("io: read failed")
+				},
+			},
+			wantErr: "inspect kukeond cell:",
+		},
+		{
+			name: "KillCell error is wrapped",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+					return kukeonv1.KillCellResult{}, errors.New("ctrd unreachable")
+				},
+			},
+			wantErr: "kill kukeond cell:",
+		},
+		{
+			name: "KillCell reports no change is an error",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+					return kukeonv1.KillCellResult{Cell: doc, Killed: false}, nil
+				},
+			},
+			wantErr: "controller reported no change",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := kill.NewKillCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, kill.MockClientKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+			cmd.SetArgs(nil)
+
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+func TestDaemonKill_LoggerMissingFromContext(t *testing.T) {
+	cmd := kill.NewKillCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "logger not found") {
+		t.Fatalf("expected logger-missing error, got %v", err)
+	}
+}
+
+func assertKukeondTarget(t *testing.T, doc v1beta1.CellDoc) {
+	t.Helper()
+	if doc.Metadata.Name != consts.KukeSystemCellName {
+		t.Errorf("cell name: want %q, got %q", consts.KukeSystemCellName, doc.Metadata.Name)
+	}
+	if doc.Spec.RealmID != consts.KukeSystemRealmName {
+		t.Errorf("realm: want %q, got %q", consts.KukeSystemRealmName, doc.Spec.RealmID)
+	}
+	if doc.Spec.SpaceID != consts.KukeSystemSpaceName {
+		t.Errorf("space: want %q, got %q", consts.KukeSystemSpaceName, doc.Spec.SpaceID)
+	}
+	if doc.Spec.StackID != consts.KukeSystemStackName {
+		t.Errorf("stack: want %q, got %q", consts.KukeSystemStackName, doc.Spec.StackID)
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getCellFn  func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	killCellFn func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errors.New("unexpected GetCell call")
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) KillCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+	if f.killCellFn == nil {
+		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
+	}
+	return f.killCellFn(doc)
+}

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -109,7 +109,7 @@ func TestKuke_Start_Help(t *testing.T) {
 	}
 }
 
-// TestKuke_Daemon_Help tests `kuke daemon -h` and the `start`/`stop` subcommand help.
+// TestKuke_Daemon_Help tests `kuke daemon -h` and the `start`/`stop`/`kill` subcommand help.
 func TestKuke_Daemon_Help(t *testing.T) {
 	t.Parallel()
 
@@ -120,6 +120,8 @@ func TestKuke_Daemon_Help(t *testing.T) {
 		{"daemon", "start", "--help"},
 		{"daemon", "stop", "-h"},
 		{"daemon", "stop", "--help"},
+		{"daemon", "kill", "-h"},
+		{"daemon", "kill", "--help"},
 	} {
 		exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
 		if exitCode != 0 {
@@ -167,6 +169,29 @@ func TestKuke_DaemonStop_Uninitialized(t *testing.T) {
 	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "daemon", "stop")
+	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
+	if exitCode == 0 {
+		t.Fatalf(
+			"expected non-zero exit code on uninitialized host; stdout=%s stderr=%s",
+			string(stdout), string(stderr),
+		)
+	}
+	combined := string(stdout) + string(stderr)
+	if !strings.Contains(combined, "kuke init") {
+		t.Fatalf("expected error to mention `kuke init`, got: %s", combined)
+	}
+}
+
+// TestKuke_DaemonKill_Uninitialized verifies that `kuke daemon kill` fails
+// with the same friendly "host not initialized" message as `daemon start`/`stop`
+// when the run-path has no kukeond cell metadata.
+func TestKuke_DaemonKill_Uninitialized(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	args := append(buildKukeRunPathArgs(runPath), "daemon", "kill")
 	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
 	if exitCode == 0 {
 		t.Fatalf(


### PR DESCRIPTION
## Summary
- Add `kuke daemon kill`, the third verb in the `kuke daemon` group (umbrella #217). Sends an immediate SIGKILL to the kukeond cell via `client.KillCell` — no grace period, no SIGTERM. This is the escape hatch for a hung or unresponsive daemon; `kuke daemon stop` remains the graceful path.
- Implicitly in-process: same architectural rationale as the rest of the `kuke daemon` group — the daemon being torn down cannot relay its own teardown, so the command always builds a `local` client.
- Idempotent: prints `kukeond is already stopped (...)` and returns success when the cell is not running. `kukeon host is not initialized` (with the same `kuke init` directive `start`/`stop` use) when no cell metadata exists.
- Done message: `kukeond force-killed (...)` distinguishes the kill verb from the `kukeond stopped (...)` graceful-path message.

## Test plan
- [x] `make test` (full unit suite, includes new `cmd/kuke/daemon/kill/...` tests covering kill path, idempotent already-stopped, host-not-initialized, GetCell/KillCell error wrapping, controller-reported-no-change, and logger-missing-from-context).
- [x] `go vet ./...` clean.
- [x] `go test -run "TestKuke_Daemon_Help|TestKuke_DaemonStart_Uninitialized|TestKuke_DaemonStop_Uninitialized|TestKuke_DaemonKill_Uninitialized" ./e2e` — help-tree (start + stop + kill) and uninitialized-host e2e tests pass against the built binary.
- [x] Manual: `./kuke daemon -h` lists `kill` alongside `start`/`stop`; `./kuke daemon kill -h` renders the kill-specific long help.
- [ ] Local privileged smoke (`sudo ./kuke daemon kill` against a running daemon) — not run because this PR adds a CLI subcommand only and does not touch the bootstrap/init path or anything the daemon reads from `/opt/kukeon`. Mirrors the deferral the `kuke daemon stop` PR (#235) used for the same reason.
- [ ] Full CLAUDE.md re-init smoke test (`kuke kill cell kukeond` → rebuild → `kuke init` → daemon-parity check) — same reason as above; the daemon-parity regression guard fires only on changes that touch what the daemon reads from `/opt/kukeon`.

Closes #220