### PR TITLE
feat: add kuke daemon restart

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -430,4 +430,6 @@ var (
 
 	//nolint:revive,gochecknoglobals,staticcheck // daemon command variables
 	KUKE_DAEMON_STOP_TIMEOUT = DefineKV("KUKE_DAEMON_STOP_TIMEOUT", "kuke/daemon/stop/timeout", "10s")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DAEMON_RESTART_TIMEOUT = DefineKV("KUKE_DAEMON_RESTART_TIMEOUT", "kuke/daemon/restart/timeout", "10s")
 )

--- a/cmd/kuke/daemon/daemon.go
+++ b/cmd/kuke/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	killcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/kill"
+	restartcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/restart"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/start"
 	stopcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/stop"
 	"github.com/spf13/cobra"
@@ -51,6 +52,7 @@ func NewDaemonCmd() *cobra.Command {
 		startcmd.NewStartCmd(),
 		stopcmd.NewStopCmd(),
 		killcmd.NewKillCmd(),
+		restartcmd.NewRestartCmd(),
 	)
 
 	return cmd
@@ -58,7 +60,7 @@ func NewDaemonCmd() *cobra.Command {
 
 // completeDaemonSubcommands provides shell completion for daemon subcommand names.
 func completeDaemonSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"start", "stop", "kill"}
+	subcommands := []string{"start", "stop", "kill", "restart"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/daemon/daemon_test.go
+++ b/cmd/kuke/daemon/daemon_test.go
@@ -69,6 +69,21 @@ func TestDaemonCmd_HasKillSubcommand(t *testing.T) {
 	}
 }
 
+func TestDaemonCmd_HasRestartSubcommand(t *testing.T) {
+	cmd := daemon.NewDaemonCmd()
+
+	var found bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "restart" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected `kuke daemon` to register a `restart` subcommand")
+	}
+}
+
 func TestDaemonCmd_HelpRunsWithoutArgs(t *testing.T) {
 	cmd := daemon.NewDaemonCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/kuke/daemon/restart/restart.go
+++ b/cmd/kuke/daemon/restart/restart.go
@@ -1,0 +1,221 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package restart implements `kuke daemon restart`, which is the composed
+// stop-then-start lifecycle verb for the kukeond cell. It runs in-process for
+// the same reason `kuke daemon stop`/`start` do — kukeond cannot relay its own
+// teardown — and forwards `--timeout` to the stop phase's grace period.
+package restart
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/client/local"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
+// context so unit tests can exercise runRestart without a real controller.
+type MockClientKey struct{}
+
+// defaultTimeout matches `kuke daemon stop`'s grace period (#219) so the two
+// verbs agree on how long the SIGTERM phase gets before SIGKILL escalates.
+const defaultTimeout = 10 * time.Second
+
+// NewRestartCmd builds the `kuke daemon restart` cobra command.
+func NewRestartCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restart",
+		Short: "Restart the kukeond daemon cell (stop, then start)",
+		Long: "Compose `kuke daemon stop` and `kuke daemon start` into a single verb.\n\n" +
+			"Sends SIGTERM and waits up to --timeout (default 10s) for the daemon " +
+			"to exit; if the grace period expires, escalates to SIGKILL. Once the " +
+			"cell is stopped, brings it back up. " +
+			"Idempotent: when the daemon is already stopped, the stop phase is " +
+			"skipped and the start phase still runs.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runRestart,
+	}
+
+	cmd.Flags().Duration(
+		"timeout", defaultTimeout,
+		"Grace period for the stop phase before escalating from SIGTERM to SIGKILL",
+	)
+	_ = viper.BindPFlag(config.KUKE_DAEMON_RESTART_TIMEOUT.ViperKey, cmd.Flags().Lookup("timeout"))
+
+	return cmd
+}
+
+func runRestart(cmd *cobra.Command, _ []string) error {
+	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+	if !ok || logger == nil {
+		return errdefs.ErrLoggerNotFound
+	}
+
+	timeout := viper.GetDuration(config.KUKE_DAEMON_RESTART_TIMEOUT.ViperKey)
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
+	client := resolveClient(cmd, logger)
+	defer func() { _ = client.Close() }()
+
+	doc := kukeondCellDoc()
+
+	getRes, err := client.GetCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("inspect kukeond cell: %w", err)
+	}
+	if !getRes.MetadataExists {
+		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
+	}
+
+	if isCellRunning(getRes.Cell) {
+		if stopErr := stopPhase(cmd, client, doc, timeout); stopErr != nil {
+			return stopErr
+		}
+	} else {
+		cmd.Printf(
+			"kukeond was already stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+	}
+
+	startRes, err := client.StartCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("start kukeond cell: %w", err)
+	}
+	if !startRes.Started {
+		return errors.New("start kukeond cell: controller reported no change")
+	}
+
+	cmd.Printf(
+		"kukeond started (cell %q in realm %q)\n",
+		consts.KukeSystemCellName, consts.KukeSystemRealmName,
+	)
+	return nil
+}
+
+// stopPhase mirrors `kuke daemon stop`: graceful StopCell with SIGTERM →
+// SIGKILL escalation when the grace period expires. Duplicated here rather
+// than imported from the stop package to keep each daemon-lifecycle verb
+// self-contained — start/stop/kill follow the same convention.
+func stopPhase(
+	cmd *cobra.Command,
+	client kukeonv1.Client,
+	doc v1beta1.CellDoc,
+	timeout time.Duration,
+) error {
+	type stopOutcome struct {
+		res kukeonv1.StopCellResult
+		err error
+	}
+	done := make(chan stopOutcome, 1)
+	go func() {
+		res, sErr := client.StopCell(cmd.Context(), doc)
+		done <- stopOutcome{res: res, err: sErr}
+	}()
+
+	select {
+	case out := <-done:
+		if out.err != nil {
+			return fmt.Errorf("stop kukeond cell: %w", out.err)
+		}
+		if !out.res.Stopped {
+			return errors.New("stop kukeond cell: controller reported no change")
+		}
+		cmd.Printf(
+			"kukeond stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	case <-time.After(timeout):
+		killRes, killErr := client.KillCell(cmd.Context(), doc)
+		if killErr != nil {
+			return fmt.Errorf(
+				"kill kukeond cell after %s grace period expired: %w",
+				timeout, killErr,
+			)
+		}
+		if !killRes.Killed {
+			return errors.New("kill kukeond cell: controller reported no change")
+		}
+		cmd.Printf(
+			"kukeond force-killed after %s grace period expired (cell %q in realm %q)\n",
+			timeout, consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	}
+}
+
+// kukeondCellDoc builds the lookup CellDoc for the system kukeond cell. The
+// names are fixed by `kuke init` and centralised in internal/consts.
+func kukeondCellDoc() v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   consts.KukeSystemCellName,
+			Labels: map[string]string{},
+		},
+		Spec: v1beta1.CellSpec{
+			ID:      consts.KukeSystemCellName,
+			RealmID: consts.KukeSystemRealmName,
+			SpaceID: consts.KukeSystemSpaceName,
+			StackID: consts.KukeSystemStackName,
+		},
+	}
+}
+
+// isCellRunning treats the cell as live if any container reports Ready, or if
+// the persisted cell state is Ready. Mirrors the check in `kuke daemon
+// start`/`stop`/`kill` so all four verbs agree on what "running" means.
+func isCellRunning(cell v1beta1.CellDoc) bool {
+	for _, c := range cell.Status.Containers {
+		if c.State == v1beta1.ContainerStateReady {
+			return true
+		}
+	}
+	return cell.Status.State == v1beta1.CellStateReady
+}
+
+// resolveClient returns the kukeonv1.Client used by runRestart. Tests inject a
+// fake via MockClientKey; production always builds an in-process client —
+// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
+// through the daemon is impossible by definition.
+func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
+	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+		return mockClient
+	}
+	opts := controller.Options{
+		RunPath:          viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	}
+	return local.New(cmd.Context(), logger, opts)
+}

--- a/cmd/kuke/daemon/restart/restart_test.go
+++ b/cmd/kuke/daemon/restart/restart_test.go
@@ -1,0 +1,554 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package restart_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	restart "github.com/eminwux/kukeon/cmd/kuke/daemon/restart"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+func TestDaemonRestart(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		fake           *fakeClient
+		wantErr        string
+		wantOutputs    []string
+		wantNotOutputs []string
+	}{
+		{
+			name: "running cell is gracefully stopped then started",
+			fake: &fakeClient{
+				getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+				},
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+				},
+				killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+					t.Fatalf("KillCell must not be called when graceful stop succeeds")
+					return kukeonv1.KillCellResult{}, nil
+				},
+			},
+			wantOutputs: []string{
+				`kukeond stopped (cell "kukeond" in realm "kuke-system")`,
+				`kukeond started (cell "kukeond" in realm "kuke-system")`,
+			},
+		},
+		{
+			name: "already-stopped cell skips stop phase and starts",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					t.Fatalf("StopCell must not be called when daemon is already stopped")
+					return kukeonv1.StopCellResult{}, nil
+				},
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+				},
+			},
+			wantOutputs: []string{
+				`kukeond was already stopped (cell "kukeond" in realm "kuke-system")`,
+				`kukeond started (cell "kukeond" in realm "kuke-system")`,
+			},
+		},
+		{
+			name: "host not initialized",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: "kukeon host is not initialized",
+		},
+		{
+			name: "GetCell error is wrapped",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{}, errors.New("io: read failed")
+				},
+			},
+			wantErr: "inspect kukeond cell:",
+		},
+		{
+			name: "StopCell error is wrapped and start phase is not reached",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{}, errors.New("runner blew up")
+				},
+				startCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					t.Fatalf("StartCell must not be called when stop phase fails")
+					return kukeonv1.StartCellResult{}, nil
+				},
+			},
+			wantErr: "stop kukeond cell:",
+		},
+		{
+			name: "StopCell reports no change is an error and start is not reached",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: false}, nil
+				},
+				startCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					t.Fatalf("StartCell must not be called when stop phase reports no change")
+					return kukeonv1.StartCellResult{}, nil
+				},
+			},
+			wantErr: "controller reported no change",
+		},
+		{
+			name: "StartCell error after successful stop is wrapped",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+				},
+				startCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{}, errors.New("runner blew up")
+				},
+			},
+			wantErr: "start kukeond cell:",
+		},
+		{
+			name: "StartCell reports no change is an error",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc, Started: false}, nil
+				},
+			},
+			wantErr: "start kukeond cell: controller reported no change",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFreshViper(t)
+			cmd := restart.NewRestartCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, restart.MockClientKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			out := buf.String()
+			for _, want := range tt.wantOutputs {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\nGot:\n%s", want, out)
+				}
+			}
+			for _, notWant := range tt.wantNotOutputs {
+				if strings.Contains(out, notWant) {
+					t.Errorf("output unexpectedly contained %q\nGot:\n%s", notWant, out)
+				}
+			}
+		})
+	}
+}
+
+// TestDaemonRestart_GracefulTimeoutEscalatesToKillThenStarts exercises the
+// SIGTERM → SIGKILL escalation path inside the stop phase: StopCell blocks
+// past --timeout, KillCell must be invoked, the escalation notice is printed,
+// and the start phase still runs to completion.
+func TestDaemonRestart_GracefulTimeoutEscalatesToKillThenStarts(t *testing.T) {
+	withFreshViper(t)
+
+	stopBlocked := make(chan struct{})
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+
+	var killCalled, startCalled atomicBool
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			close(stopBlocked)
+			<-releaseStop
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			killCalled.Store(true)
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			startCalled.Store(true)
+			return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+		},
+	}
+
+	cmd := restart.NewRestartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, restart.MockClientKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--timeout", "50ms"})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.Execute() }()
+
+	select {
+	case <-stopBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopCell was not invoked within 2s")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runRestart did not return after timeout fired")
+	}
+
+	if !killCalled.Load() {
+		t.Fatal("expected KillCell to be invoked when --timeout fires before StopCell returns")
+	}
+	if !startCalled.Load() {
+		t.Fatal("expected StartCell to be invoked after escalation completes")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "force-killed after 50ms grace period expired") {
+		t.Errorf("output missing escalation notice; got:\n%s", out)
+	}
+	if !strings.Contains(out, "kukeond started") {
+		t.Errorf("output missing start phase notice; got:\n%s", out)
+	}
+}
+
+// TestDaemonRestart_TimeoutOverridesDefault confirms the --timeout flag
+// reaches the stop phase rather than the 10s default. Setting --timeout=20ms
+// against a blocking StopCell must escalate within milliseconds, not seconds —
+// this is the regression guard for "AC: --timeout overrides stop's grace
+// period".
+func TestDaemonRestart_TimeoutOverridesDefault(t *testing.T) {
+	withFreshViper(t)
+
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			<-releaseStop
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+		},
+	}
+
+	cmd := restart.NewRestartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, restart.MockClientKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--timeout", "20ms"})
+
+	start := time.Now()
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// Generous upper bound: the override must escalate well below the 10s default.
+	if elapsed > 2*time.Second {
+		t.Fatalf("restart took %s — --timeout=20ms did not override the default", elapsed)
+	}
+	if !strings.Contains(buf.String(), "20ms grace period expired") {
+		t.Errorf("output should mention the 20ms grace period; got:\n%s", buf.String())
+	}
+}
+
+// TestDaemonRestart_KillCellErrorIsWrapped covers the failure mode where the
+// graceful timeout fires, escalation runs, and KillCell itself errors — the
+// start phase must not run, and the error must mention the expired grace
+// period.
+func TestDaemonRestart_KillCellErrorIsWrapped(t *testing.T) {
+	withFreshViper(t)
+
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+
+	var startCalled atomicBool
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			<-releaseStop
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{}, errors.New("ctrd unreachable")
+		},
+		startCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			startCalled.Store(true)
+			return kukeonv1.StartCellResult{}, nil
+		},
+	}
+
+	cmd := restart.NewRestartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, restart.MockClientKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--timeout", "20ms"})
+
+	err := cmd.Execute()
+	if err == nil ||
+		!strings.Contains(err.Error(), "kill kukeond cell after") ||
+		!strings.Contains(err.Error(), "20ms grace period expired") {
+		t.Fatalf("expected wrapped kill error mentioning grace period, got %v", err)
+	}
+	if startCalled.Load() {
+		t.Fatal("StartCell must not run when the stop-phase escalation fails")
+	}
+}
+
+func TestDaemonRestart_LoggerMissingFromContext(t *testing.T) {
+	withFreshViper(t)
+	cmd := restart.NewRestartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "logger not found") {
+		t.Fatalf("expected logger-missing error, got %v", err)
+	}
+}
+
+func assertKukeondTarget(t *testing.T, doc v1beta1.CellDoc) {
+	t.Helper()
+	if doc.Metadata.Name != consts.KukeSystemCellName {
+		t.Errorf("cell name: want %q, got %q", consts.KukeSystemCellName, doc.Metadata.Name)
+	}
+	if doc.Spec.RealmID != consts.KukeSystemRealmName {
+		t.Errorf("realm: want %q, got %q", consts.KukeSystemRealmName, doc.Spec.RealmID)
+	}
+	if doc.Spec.SpaceID != consts.KukeSystemSpaceName {
+		t.Errorf("space: want %q, got %q", consts.KukeSystemSpaceName, doc.Spec.SpaceID)
+	}
+	if doc.Spec.StackID != consts.KukeSystemStackName {
+		t.Errorf("stack: want %q, got %q", consts.KukeSystemStackName, doc.Spec.StackID)
+	}
+}
+
+// withFreshViper resets the viper key the restart command binds to, so prior
+// tests' --timeout values don't leak between table-driven runs.
+func withFreshViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+}
+
+type atomicBool struct {
+	mu sync.Mutex
+	v  bool
+}
+
+func (a *atomicBool) Store(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.v = v
+}
+
+func (a *atomicBool) Load() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.v
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getCellFn   func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	stopCellFn  func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
+	killCellFn  func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
+	startCellFn func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errors.New("unexpected GetCell call")
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) StopCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+	if f.stopCellFn == nil {
+		return kukeonv1.StopCellResult{}, errors.New("unexpected StopCell call")
+	}
+	return f.stopCellFn(doc)
+}
+
+func (f *fakeClient) KillCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+	if f.killCellFn == nil {
+		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
+	}
+	return f.killCellFn(doc)
+}
+
+func (f *fakeClient) StartCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+	if f.startCellFn == nil {
+		return kukeonv1.StartCellResult{}, errors.New("unexpected StartCell call")
+	}
+	return f.startCellFn(doc)
+}

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -205,6 +205,47 @@ func TestKuke_DaemonKill_Uninitialized(t *testing.T) {
 	}
 }
 
+// TestKuke_DaemonRestart_Uninitialized verifies that `kuke daemon restart`
+// fails with the same friendly "host not initialized" message as `daemon
+// start`/`stop`/`kill` when the run-path has no kukeond cell metadata. The
+// stop-then-start composition must surface the same precondition as its
+// individual phases.
+func TestKuke_DaemonRestart_Uninitialized(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	args := append(buildKukeRunPathArgs(runPath), "daemon", "restart")
+	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
+	if exitCode == 0 {
+		t.Fatalf(
+			"expected non-zero exit code on uninitialized host; stdout=%s stderr=%s",
+			string(stdout), string(stderr),
+		)
+	}
+	combined := string(stdout) + string(stderr)
+	if !strings.Contains(combined, "kuke init") {
+		t.Fatalf("expected error to mention `kuke init`, got: %s", combined)
+	}
+}
+
+// TestKuke_DaemonRestart_TimeoutFlag verifies the `--timeout` flag is
+// registered on `kuke daemon restart`. The flag is the user-facing override
+// for the stop phase's grace period (#221 AC) — its presence in --help is the
+// minimum guard that the wiring did not regress.
+func TestKuke_DaemonRestart_TimeoutFlag(t *testing.T) {
+	t.Parallel()
+
+	exitCode, stdout, stderr := runBinary(t, nil, kuke, "daemon", "restart", "--help")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 from --help, got %d; stderr=%s", exitCode, string(stderr))
+	}
+	if !strings.Contains(string(stdout), "--timeout") {
+		t.Fatalf("expected --timeout in `kuke daemon restart --help`; got:\n%s", string(stdout))
+	}
+}
+
 // TestKuke_Stop_Help tests kuke stop help.
 func TestKuke_Stop_Help(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Add `kuke daemon restart`, the fourth verb in the `kuke daemon` group (umbrella #217). Composed `kuke daemon stop` → `kuke daemon start`: gracefully stops the kukeond cell with a SIGTERM grace period, escalates to SIGKILL when the deadline expires, then brings the cell back up via `client.StartCell`.
- `--timeout` (default 10s) overrides the stop phase's grace period; same default and semantics as `kuke daemon stop`'s flag, bound to its own viper key (`KUKE_DAEMON_RESTART_TIMEOUT`) so flag state does not leak across the two commands.
- Implicitly in-process: same architectural rationale as the rest of the `kuke daemon` group — the daemon being restarted cannot relay its own teardown.
- Idempotent: when the cell is already stopped, the stop phase is skipped (`kukeond was already stopped (...)`) and the start phase still runs. Same `kukeon host is not initialized` precondition as `start`/`stop`/`kill` when no cell metadata exists.
- Stop-phase logic (StopCell + SIGTERM→SIGKILL escalation via KillCell) is duplicated inside the restart package rather than imported from `daemon/stop`. This matches the existing `start`/`stop`/`kill` convention where each verb is a self-contained file with its own `kukeondCellDoc` / `isCellRunning` / `resolveClient` helpers — extracting a shared helper would be a refactor outside this issue's scope and is intentionally deferred.

## Test plan
- [x] `make test` (full unit suite) — passes; the new `cmd/kuke/daemon/restart/...` tests cover the stop→start happy path, already-stopped skip-stop path, host-not-initialized precondition, GetCell/StopCell/KillCell/StartCell error wrapping, controller-reported-no-change for both phases, the SIGTERM→SIGKILL escalation followed by start, the `--timeout` override (regression guard for AC: "--timeout overrides stop's grace period"), and the logger-missing-from-context branch.
- [x] `go vet ./...` clean.
- [x] `go test -run "TestKuke_Daemon_Help|TestKuke_DaemonStart_Uninitialized|TestKuke_DaemonStop_Uninitialized|TestKuke_DaemonKill_Uninitialized|TestKuke_DaemonRestart_Uninitialized|TestKuke_DaemonRestart_TimeoutFlag" ./e2e` — daemon help-tree (start + stop + kill + restart), uninitialized-host parity for `restart`, and `--timeout` flag-presence guard pass against the built binary.
- [x] Manual: `./kuke daemon -h` lists `restart` alongside `start`/`stop`/`kill`; `./kuke daemon restart -h` renders the restart-specific long help with `--timeout duration` (default 10s).
- [ ] Local privileged smoke (`sudo ./kuke daemon restart` against a running daemon) — not run because this PR adds a CLI subcommand only and does not touch the bootstrap/init path or anything the daemon reads from `/opt/kukeon`. Mirrors the deferral the `kuke daemon kill` PR (#238) and `kuke daemon stop` PR (#235) used for the same reason.
- [ ] Full CLAUDE.md re-init smoke test (`kuke kill cell kukeond` → rebuild → `kuke init` → daemon-parity check) — same reason as above; the daemon-parity regression guard fires only on changes that touch what the daemon reads from `/opt/kukeon`.

Closes #221