### PR TITLE
feat: add kuke daemon reset

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -432,4 +432,10 @@ var (
 	KUKE_DAEMON_STOP_TIMEOUT = DefineKV("KUKE_DAEMON_STOP_TIMEOUT", "kuke/daemon/stop/timeout", "10s")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DAEMON_RESTART_TIMEOUT = DefineKV("KUKE_DAEMON_RESTART_TIMEOUT", "kuke/daemon/restart/timeout", "10s")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DAEMON_RESET_TIMEOUT = DefineKV("KUKE_DAEMON_RESET_TIMEOUT", "kuke/daemon/reset/timeout", "10s")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DAEMON_RESET_PURGE_SYSTEM = DefineKV(
+		"KUKE_DAEMON_RESET_PURGE_SYSTEM", "kuke/daemon/reset/purgeSystem", "false",
+	)
 )

--- a/cmd/kuke/daemon/daemon.go
+++ b/cmd/kuke/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	killcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/kill"
+	resetcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/reset"
 	restartcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/restart"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/start"
 	stopcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/stop"
@@ -53,6 +54,7 @@ func NewDaemonCmd() *cobra.Command {
 		stopcmd.NewStopCmd(),
 		killcmd.NewKillCmd(),
 		restartcmd.NewRestartCmd(),
+		resetcmd.NewResetCmd(),
 	)
 
 	return cmd
@@ -60,7 +62,7 @@ func NewDaemonCmd() *cobra.Command {
 
 // completeDaemonSubcommands provides shell completion for daemon subcommand names.
 func completeDaemonSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"start", "stop", "kill", "restart"}
+	subcommands := []string{"start", "stop", "kill", "restart", "reset"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/daemon/daemon_test.go
+++ b/cmd/kuke/daemon/daemon_test.go
@@ -84,6 +84,21 @@ func TestDaemonCmd_HasRestartSubcommand(t *testing.T) {
 	}
 }
 
+func TestDaemonCmd_HasResetSubcommand(t *testing.T) {
+	cmd := daemon.NewDaemonCmd()
+
+	var found bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "reset" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected `kuke daemon` to register a `reset` subcommand")
+	}
+}
+
 func TestDaemonCmd_HelpRunsWithoutArgs(t *testing.T) {
 	cmd := daemon.NewDaemonCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -1,0 +1,328 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package reset implements `kuke daemon reset`, the lightweight dev-loop
+// teardown for the kukeond cell. It composes stop (with the same SIGTERM →
+// SIGKILL escalation as `kuke daemon stop`) plus delete, then clears the
+// transient socket/PID files under /run/kukeon. User-realm data under
+// /opt/kukeon/default/** is left untouched so a subsequent `kuke init` can
+// re-bootstrap without wiping user workloads. `--purge-system` additionally
+// removes /opt/kukeon/kuke-system for a fully clean re-bootstrap.
+package reset
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/client/local"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
+// context so unit tests can exercise runReset without a real controller.
+type MockClientKey struct{}
+
+// MockSocketDirKey overrides the directory containing kukeond.{sock,pid}.
+// Tests use this to point the cleanup step at a tmpdir; production reads the
+// path from KUKEOND_SOCKET viper config.
+type MockSocketDirKey struct{}
+
+// MockRunPathKey overrides the run-path the --purge-system step removes
+// /opt/kukeon/kuke-system from. Tests use this to point at a tmpdir so the
+// cleanup never touches the real /opt/kukeon.
+type MockRunPathKey struct{}
+
+// defaultTimeout matches `kuke daemon stop`'s grace period (#219) so the two
+// verbs agree on how long the SIGTERM phase gets before SIGKILL escalates.
+const defaultTimeout = 10 * time.Second
+
+// NewResetCmd builds the `kuke daemon reset` cobra command.
+func NewResetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset the kukeond daemon cell (stop, delete, clear socket+pid)",
+		Long: "Lightweight dev-loop teardown of the kukeond daemon.\n\n" +
+			"Stops the kukeond cell (SIGTERM, escalating to SIGKILL after --timeout), " +
+			"deletes the cell metadata + cgroups, and clears the transient files " +
+			"/run/kukeon/kukeond.{sock,pid}. User-realm data under " +
+			"/opt/kukeon/default/** is left intact. Re-running `kuke init` after " +
+			"`kuke daemon reset` produces a clean re-bootstrap.\n\n" +
+			"Pass --purge-system to additionally remove /opt/kukeon/kuke-system " +
+			"for a fully clean re-bootstrap. Distinct from `kuke uninstall`, which " +
+			"is the per-host teardown (every realm, the system user/group, and the " +
+			"run path itself).",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runReset,
+	}
+
+	cmd.Flags().Duration(
+		"timeout", defaultTimeout,
+		"Grace period for the stop phase before escalating from SIGTERM to SIGKILL",
+	)
+	_ = viper.BindPFlag(config.KUKE_DAEMON_RESET_TIMEOUT.ViperKey, cmd.Flags().Lookup("timeout"))
+
+	cmd.Flags().Bool(
+		"purge-system", false,
+		"Also remove /opt/kukeon/kuke-system (user-realm data is still preserved)",
+	)
+	_ = viper.BindPFlag(config.KUKE_DAEMON_RESET_PURGE_SYSTEM.ViperKey, cmd.Flags().Lookup("purge-system"))
+
+	return cmd
+}
+
+func runReset(cmd *cobra.Command, _ []string) error {
+	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+	if !ok || logger == nil {
+		return errdefs.ErrLoggerNotFound
+	}
+
+	timeout := viper.GetDuration(config.KUKE_DAEMON_RESET_TIMEOUT.ViperKey)
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	purgeSystem := viper.GetBool(config.KUKE_DAEMON_RESET_PURGE_SYSTEM.ViperKey)
+
+	client := resolveClient(cmd, logger)
+	defer func() { _ = client.Close() }()
+
+	doc := kukeondCellDoc()
+
+	getRes, err := client.GetCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("inspect kukeond cell: %w", err)
+	}
+	if !getRes.MetadataExists {
+		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
+	}
+
+	if isCellRunning(getRes.Cell) {
+		if stopErr := stopPhase(cmd, client, doc, timeout); stopErr != nil {
+			return stopErr
+		}
+	} else {
+		cmd.Printf(
+			"kukeond was already stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+	}
+
+	delRes, err := client.DeleteCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("delete kukeond cell: %w", err)
+	}
+	if !delRes.MetadataDeleted {
+		return errors.New("delete kukeond cell: controller reported no change")
+	}
+	cmd.Printf(
+		"kukeond cell deleted (cell %q in realm %q)\n",
+		consts.KukeSystemCellName, consts.KukeSystemRealmName,
+	)
+
+	socketDir := resolveSocketDir(cmd)
+	for _, name := range []string{"kukeond.sock", "kukeond.pid"} {
+		path := filepath.Join(socketDir, name)
+		removed, removeErr := removeFileIfExists(path)
+		if removeErr != nil {
+			return fmt.Errorf("remove %q: %w", path, removeErr)
+		}
+		if removed {
+			cmd.Printf("removed %s\n", path)
+		}
+	}
+
+	if purgeSystem {
+		runPath := resolveRunPath(cmd)
+		systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+		removed, removeErr := removeDirIfExists(systemDir)
+		if removeErr != nil {
+			return fmt.Errorf("remove %q: %w", systemDir, removeErr)
+		}
+		if removed {
+			cmd.Printf("removed %s\n", systemDir)
+		}
+	}
+
+	return nil
+}
+
+// stopPhase mirrors `kuke daemon stop`: graceful StopCell with SIGTERM →
+// SIGKILL escalation when the grace period expires. Duplicated here rather
+// than imported from the stop package to keep each daemon-lifecycle verb
+// self-contained — start/stop/kill/restart follow the same convention.
+func stopPhase(
+	cmd *cobra.Command,
+	client kukeonv1.Client,
+	doc v1beta1.CellDoc,
+	timeout time.Duration,
+) error {
+	type stopOutcome struct {
+		res kukeonv1.StopCellResult
+		err error
+	}
+	done := make(chan stopOutcome, 1)
+	go func() {
+		res, sErr := client.StopCell(cmd.Context(), doc)
+		done <- stopOutcome{res: res, err: sErr}
+	}()
+
+	select {
+	case out := <-done:
+		if out.err != nil {
+			return fmt.Errorf("stop kukeond cell: %w", out.err)
+		}
+		if !out.res.Stopped {
+			return errors.New("stop kukeond cell: controller reported no change")
+		}
+		cmd.Printf(
+			"kukeond stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	case <-time.After(timeout):
+		killRes, killErr := client.KillCell(cmd.Context(), doc)
+		if killErr != nil {
+			return fmt.Errorf(
+				"kill kukeond cell after %s grace period expired: %w",
+				timeout, killErr,
+			)
+		}
+		if !killRes.Killed {
+			return errors.New("kill kukeond cell: controller reported no change")
+		}
+		cmd.Printf(
+			"kukeond force-killed after %s grace period expired (cell %q in realm %q)\n",
+			timeout, consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	}
+}
+
+// removeFileIfExists removes a single file. Missing-file is a no-op so a
+// re-run of `kuke daemon reset` on a clean tree does not error.
+func removeFileIfExists(path string) (bool, error) {
+	if _, statErr := os.Stat(path); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, statErr
+	}
+	if rmErr := os.Remove(path); rmErr != nil {
+		return false, rmErr
+	}
+	return true, nil
+}
+
+// removeDirIfExists removes a directory tree. Missing-dir is a no-op.
+func removeDirIfExists(path string) (bool, error) {
+	if _, statErr := os.Stat(path); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, statErr
+	}
+	if rmErr := os.RemoveAll(path); rmErr != nil {
+		return false, rmErr
+	}
+	return true, nil
+}
+
+// kukeondCellDoc builds the lookup CellDoc for the system kukeond cell. The
+// names are fixed by `kuke init` and centralised in internal/consts.
+func kukeondCellDoc() v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   consts.KukeSystemCellName,
+			Labels: map[string]string{},
+		},
+		Spec: v1beta1.CellSpec{
+			ID:      consts.KukeSystemCellName,
+			RealmID: consts.KukeSystemRealmName,
+			SpaceID: consts.KukeSystemSpaceName,
+			StackID: consts.KukeSystemStackName,
+		},
+	}
+}
+
+// isCellRunning treats the cell as live if any container reports Ready, or if
+// the persisted cell state is Ready. Mirrors the check used by all other
+// daemon-lifecycle verbs so they agree on what "running" means.
+func isCellRunning(cell v1beta1.CellDoc) bool {
+	for _, c := range cell.Status.Containers {
+		if c.State == v1beta1.ContainerStateReady {
+			return true
+		}
+	}
+	return cell.Status.State == v1beta1.CellStateReady
+}
+
+// resolveClient returns the kukeonv1.Client used by runReset. Tests inject a
+// fake via MockClientKey; production always builds an in-process client —
+// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
+// through the daemon is impossible by definition.
+func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
+	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+		return mockClient
+	}
+	opts := controller.Options{
+		RunPath:          viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	}
+	return local.New(cmd.Context(), logger, opts)
+}
+
+// resolveSocketDir picks the directory holding kukeond.{sock,pid}. Tests
+// inject a tmpdir via MockSocketDirKey; production derives the parent from
+// KUKEOND_SOCKET (default /run/kukeon/kukeond.sock → /run/kukeon).
+func resolveSocketDir(cmd *cobra.Command) string {
+	if dir, ok := cmd.Context().Value(MockSocketDirKey{}).(string); ok && dir != "" {
+		return dir
+	}
+	socketPath := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
+	if socketPath == "" {
+		socketPath = config.KUKEOND_SOCKET.Default
+	}
+	return filepath.Dir(socketPath)
+}
+
+// resolveRunPath picks the run path for the --purge-system step. Tests inject
+// a tmpdir via MockRunPathKey; production reads KUKEON_ROOT_RUN_PATH (default
+// /opt/kukeon).
+func resolveRunPath(cmd *cobra.Command) string {
+	if rp, ok := cmd.Context().Value(MockRunPathKey{}).(string); ok && rp != "" {
+		return rp
+	}
+	runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
+	if runPath == "" {
+		runPath = config.DefaultRunPath()
+	}
+	return runPath
+}

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -1,0 +1,642 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package reset_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	reset "github.com/eminwux/kukeon/cmd/kuke/daemon/reset"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+// TestDaemonReset covers the table of states the verb has to handle: a
+// running daemon (graceful stop+delete), an already-stopped daemon (skip
+// stop, still delete), missing-init guard, and the propagation of GetCell /
+// StopCell / DeleteCell errors.
+func TestDaemonReset(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		fake           *fakeClient
+		wantErr        string
+		wantOutputs    []string
+		wantNotOutputs []string
+	}{
+		{
+			name: "running cell is gracefully stopped, deleted, sock+pid cleared",
+			fake: &fakeClient{
+				getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+				},
+				deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					assertKukeondTarget(t, doc)
+					return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+				},
+			},
+			wantOutputs: []string{
+				`kukeond stopped (cell "kukeond" in realm "kuke-system")`,
+				`kukeond cell deleted (cell "kukeond" in realm "kuke-system")`,
+			},
+		},
+		{
+			name: "already-stopped cell skips stop phase and still deletes",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					t.Fatalf("StopCell must not be called when daemon is already stopped")
+					return kukeonv1.StopCellResult{}, nil
+				},
+				deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+				},
+			},
+			wantOutputs: []string{
+				`kukeond was already stopped (cell "kukeond" in realm "kuke-system")`,
+				`kukeond cell deleted (cell "kukeond" in realm "kuke-system")`,
+			},
+		},
+		{
+			name: "host not initialized",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: "kukeon host is not initialized",
+		},
+		{
+			name: "GetCell error is wrapped",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{}, errors.New("io: read failed")
+				},
+			},
+			wantErr: "inspect kukeond cell:",
+		},
+		{
+			name: "StopCell error is wrapped and delete phase is not reached",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{}, errors.New("runner blew up")
+				},
+				deleteCellFn: func(_ v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					t.Fatalf("DeleteCell must not be called when stop phase fails")
+					return kukeonv1.DeleteCellResult{}, nil
+				},
+			},
+			wantErr: "stop kukeond cell:",
+		},
+		{
+			name: "StopCell reports no change is an error and delete is not reached",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: false}, nil
+				},
+				deleteCellFn: func(_ v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					t.Fatalf("DeleteCell must not be called when stop reports no change")
+					return kukeonv1.DeleteCellResult{}, nil
+				},
+			},
+			wantErr: "controller reported no change",
+		},
+		{
+			name: "DeleteCell error is wrapped",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				deleteCellFn: func(_ v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					return kukeonv1.DeleteCellResult{}, errors.New("runner blew up")
+				},
+			},
+			wantErr: "delete kukeond cell:",
+		},
+		{
+			name: "DeleteCell reports no change is an error",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: false}, nil
+				},
+			},
+			wantErr: "delete kukeond cell: controller reported no change",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFreshViper(t)
+			cmd := reset.NewResetCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+			ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+			cmd.SetContext(ctx)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			out := buf.String()
+			for _, want := range tt.wantOutputs {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\nGot:\n%s", want, out)
+				}
+			}
+			for _, notWant := range tt.wantNotOutputs {
+				if strings.Contains(out, notWant) {
+					t.Errorf("output unexpectedly contained %q\nGot:\n%s", notWant, out)
+				}
+			}
+		})
+	}
+}
+
+// TestDaemonReset_RemovesSocketAndPidFiles confirms the cleanup step actually
+// removes /run/kukeon/kukeond.{sock,pid} (or the per-test override) when both
+// files are present.
+func TestDaemonReset_RemovesSocketAndPidFiles(t *testing.T) {
+	withFreshViper(t)
+
+	socketDir := t.TempDir()
+	sockPath := filepath.Join(socketDir, "kukeond.sock")
+	pidPath := filepath.Join(socketDir, "kukeond.pid")
+	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("seed sock file: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte("12345\n"), 0o600); err != nil {
+		t.Fatalf("seed pid file: %v", err)
+	}
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, socketDir)
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	cmd.SetContext(ctx)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Errorf("kukeond.sock not removed: stat err=%v", err)
+	}
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Errorf("kukeond.pid not removed: stat err=%v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, sockPath) || !strings.Contains(out, pidPath) {
+		t.Errorf("expected output to mention removed sock/pid paths; got:\n%s", out)
+	}
+}
+
+// TestDaemonReset_MissingSockAndPidIsNoOp confirms idempotency: a second
+// `kuke daemon reset` (or one against a partially-cleaned host) does not
+// error when the sock/pid files are already gone.
+func TestDaemonReset_MissingSockAndPidIsNoOp(t *testing.T) {
+	withFreshViper(t)
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	cmd.SetContext(ctx)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error on missing sock/pid: %v", err)
+	}
+	if strings.Contains(buf.String(), "removed") {
+		t.Errorf("did not expect any 'removed' line when files are already gone; got:\n%s", buf.String())
+	}
+}
+
+// TestDaemonReset_PreservesDefaultRealm covers the AC: --purge-system removes
+// /opt/kukeon/kuke-system but never touches /opt/kukeon/default. Both
+// directories are seeded with sentinel files; only the kuke-system tree
+// disappears.
+func TestDaemonReset_PreservesDefaultRealm(t *testing.T) {
+	withFreshViper(t)
+
+	runPath := t.TempDir()
+	defaultDir := filepath.Join(runPath, consts.KukeonDefaultRealmName)
+	systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	if err := os.MkdirAll(defaultDir, 0o750); err != nil {
+		t.Fatalf("mkdir default: %v", err)
+	}
+	if err := os.MkdirAll(systemDir, 0o750); err != nil {
+		t.Fatalf("mkdir kuke-system: %v", err)
+	}
+	defaultMarker := filepath.Join(defaultDir, "user-data.txt")
+	systemMarker := filepath.Join(systemDir, "system-data.txt")
+	if err := os.WriteFile(defaultMarker, []byte("user data"), 0o600); err != nil {
+		t.Fatalf("seed default marker: %v", err)
+	}
+	if err := os.WriteFile(systemMarker, []byte("system data"), 0o600); err != nil {
+		t.Fatalf("seed system marker: %v", err)
+	}
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--purge-system"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(systemDir); !os.IsNotExist(err) {
+		t.Errorf("kuke-system dir was not removed under --purge-system: stat err=%v", err)
+	}
+	if _, err := os.Stat(defaultMarker); err != nil {
+		t.Errorf("default-realm marker must not be touched: stat err=%v", err)
+	}
+	if !strings.Contains(buf.String(), systemDir) {
+		t.Errorf("expected output to mention removed kuke-system dir; got:\n%s", buf.String())
+	}
+}
+
+// TestDaemonReset_NoPurgeSystemKeepsKukeSystem is the negative twin of the
+// preceding test: without --purge-system, the kuke-system tree must be
+// preserved alongside the default realm.
+func TestDaemonReset_NoPurgeSystemKeepsKukeSystem(t *testing.T) {
+	withFreshViper(t)
+
+	runPath := t.TempDir()
+	systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	if err := os.MkdirAll(systemDir, 0o750); err != nil {
+		t.Fatalf("mkdir kuke-system: %v", err)
+	}
+	systemMarker := filepath.Join(systemDir, "system-data.txt")
+	if err := os.WriteFile(systemMarker, []byte("system data"), 0o600); err != nil {
+		t.Fatalf("seed system marker: %v", err)
+	}
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
+	cmd.SetContext(ctx)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(systemMarker); err != nil {
+		t.Errorf("kuke-system marker must be preserved without --purge-system: stat err=%v", err)
+	}
+}
+
+// TestDaemonReset_GracefulTimeoutEscalatesToKill exercises the SIGTERM →
+// SIGKILL escalation path: StopCell blocks past --timeout, KillCell must be
+// invoked, the escalation notice is printed, and DeleteCell still runs.
+func TestDaemonReset_GracefulTimeoutEscalatesToKill(t *testing.T) {
+	withFreshViper(t)
+
+	stopBlocked := make(chan struct{})
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+
+	var killCalled, deleteCalled atomicBool
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			close(stopBlocked)
+			<-releaseStop
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			killCalled.Store(true)
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			deleteCalled.Store(true)
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--timeout", "50ms"})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.Execute() }()
+
+	select {
+	case <-stopBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopCell was not invoked within 2s")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runReset did not return after timeout fired")
+	}
+
+	if !killCalled.Load() {
+		t.Fatal("expected KillCell to be invoked when --timeout fires before StopCell returns")
+	}
+	if !deleteCalled.Load() {
+		t.Fatal("expected DeleteCell to be invoked after escalation completes")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "force-killed after 50ms grace period expired") {
+		t.Errorf("output missing escalation notice; got:\n%s", out)
+	}
+	if !strings.Contains(out, "kukeond cell deleted") {
+		t.Errorf("output missing delete-phase notice; got:\n%s", out)
+	}
+}
+
+// TestDaemonReset_LoggerMissingFromContext confirms the verb refuses to run
+// when the logger context value is absent — same guard the other daemon-
+// lifecycle verbs apply.
+func TestDaemonReset_LoggerMissingFromContext(t *testing.T) {
+	withFreshViper(t)
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "logger not found") {
+		t.Fatalf("expected logger-missing error, got %v", err)
+	}
+}
+
+func assertKukeondTarget(t *testing.T, doc v1beta1.CellDoc) {
+	t.Helper()
+	if doc.Metadata.Name != consts.KukeSystemCellName {
+		t.Errorf("cell name: want %q, got %q", consts.KukeSystemCellName, doc.Metadata.Name)
+	}
+	if doc.Spec.RealmID != consts.KukeSystemRealmName {
+		t.Errorf("realm: want %q, got %q", consts.KukeSystemRealmName, doc.Spec.RealmID)
+	}
+	if doc.Spec.SpaceID != consts.KukeSystemSpaceName {
+		t.Errorf("space: want %q, got %q", consts.KukeSystemSpaceName, doc.Spec.SpaceID)
+	}
+	if doc.Spec.StackID != consts.KukeSystemStackName {
+		t.Errorf("stack: want %q, got %q", consts.KukeSystemStackName, doc.Spec.StackID)
+	}
+}
+
+// withFreshViper resets the viper keys the reset command binds to so prior
+// tests' --timeout / --purge-system values don't leak between runs.
+func withFreshViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+}
+
+type atomicBool struct {
+	mu sync.Mutex
+	v  bool
+}
+
+func (a *atomicBool) Store(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.v = v
+}
+
+func (a *atomicBool) Load() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.v
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getCellFn    func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	stopCellFn   func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
+	killCellFn   func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
+	deleteCellFn func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error)
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errors.New("unexpected GetCell call")
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) StopCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+	if f.stopCellFn == nil {
+		return kukeonv1.StopCellResult{}, errors.New("unexpected StopCell call")
+	}
+	return f.stopCellFn(doc)
+}
+
+func (f *fakeClient) KillCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+	if f.killCellFn == nil {
+		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
+	}
+	return f.killCellFn(doc)
+}
+
+func (f *fakeClient) DeleteCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+	if f.deleteCellFn == nil {
+		return kukeonv1.DeleteCellResult{}, errors.New("unexpected DeleteCell call")
+	}
+	return f.deleteCellFn(doc)
+}

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -17,6 +17,8 @@
 package e2e_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -109,7 +111,7 @@ func TestKuke_Start_Help(t *testing.T) {
 	}
 }
 
-// TestKuke_Daemon_Help tests `kuke daemon -h` and the `start`/`stop`/`kill` subcommand help.
+// TestKuke_Daemon_Help tests `kuke daemon -h` and the `start`/`stop`/`kill`/`reset` subcommand help.
 func TestKuke_Daemon_Help(t *testing.T) {
 	t.Parallel()
 
@@ -122,6 +124,8 @@ func TestKuke_Daemon_Help(t *testing.T) {
 		{"daemon", "stop", "--help"},
 		{"daemon", "kill", "-h"},
 		{"daemon", "kill", "--help"},
+		{"daemon", "reset", "-h"},
+		{"daemon", "reset", "--help"},
 	} {
 		exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
 		if exitCode != 0 {
@@ -243,6 +247,137 @@ func TestKuke_DaemonRestart_TimeoutFlag(t *testing.T) {
 	}
 	if !strings.Contains(string(stdout), "--timeout") {
 		t.Fatalf("expected --timeout in `kuke daemon restart --help`; got:\n%s", string(stdout))
+	}
+}
+
+// TestKuke_DaemonReset_Uninitialized verifies that `kuke daemon reset` fails
+// with the same friendly "host not initialized" message as the other daemon-
+// lifecycle verbs when the run-path has no kukeond cell metadata.
+func TestKuke_DaemonReset_Uninitialized(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	args := append(buildKukeRunPathArgs(runPath), "daemon", "reset")
+	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
+	if exitCode == 0 {
+		t.Fatalf(
+			"expected non-zero exit code on uninitialized host; stdout=%s stderr=%s",
+			string(stdout), string(stderr),
+		)
+	}
+	combined := string(stdout) + string(stderr)
+	if !strings.Contains(combined, "kuke init") {
+		t.Fatalf("expected error to mention `kuke init`, got: %s", combined)
+	}
+}
+
+// TestKuke_DaemonReset_Flags verifies the `--timeout` and `--purge-system`
+// flags are registered on `kuke daemon reset`. Their presence in --help is
+// the minimum guard that the wiring did not regress (#199 AC).
+func TestKuke_DaemonReset_Flags(t *testing.T) {
+	t.Parallel()
+
+	exitCode, stdout, stderr := runBinary(t, nil, kuke, "daemon", "reset", "--help")
+	if exitCode != 0 {
+		t.Fatalf("expected exit 0 from --help, got %d; stderr=%s", exitCode, string(stderr))
+	}
+	out := string(stdout)
+	for _, want := range []string{"--timeout", "--purge-system"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in `kuke daemon reset --help`; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestKuke_DaemonReset_RoundTrip exercises the AC: `kuke init` → `kuke daemon
+// reset --purge-system` → `kuke init` produces a clean re-bootstrap. Skipped
+// without the make-e2e harness env (KUKEON_E2E_IMAGE / docker / ctr); runs in
+// the same environment that TestKuke_Init_VerifyState does.
+//
+// Not run with t.Parallel() so it does not race TestKuke_Init_VerifyState
+// on the shared /run/kukeon socket dir — go test interleaves serial tests
+// between parallel batches, which gives this test exclusive access to the
+// host-level state init touches.
+func TestKuke_DaemonReset_RoundTrip(t *testing.T) {
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("could not get working dir: %v", err)
+	}
+	fullRunPath := filepath.Join(cwd, runPath)
+	defaultRealmDir := filepath.Join(fullRunPath, consts.KukeonDefaultRealmName)
+	systemRealmDir := filepath.Join(fullRunPath, consts.KukeSystemRealmName)
+
+	t.Cleanup(func() {
+		// Best-effort host-level cleanup: a final reset --purge-system if the
+		// test exited mid-flow. Failures here are diagnostic only.
+		args := append(buildKukeRunPathArgs(runPath), "daemon", "reset", "--purge-system")
+		_, _, _ = runBinary(t, nil, kuke, args...)
+
+		cleanupCell(
+			t, runPath,
+			consts.KukeSystemRealmName,
+			consts.KukeSystemSpaceName,
+			consts.KukeSystemStackName,
+			consts.KukeSystemCellName,
+		)
+		cleanupRealm(t, runPath, consts.KukeSystemRealmName)
+		cleanupRealm(t, runPath, consts.KukeonDefaultRealmName)
+	})
+
+	kukeondImage := loadKukeondImageIntoContainerd(t)
+
+	// Step 1: init.
+	args := append(buildKukeRunPathArgs(runPath), "init", "--kukeond-image", kukeondImage)
+	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
+	if exitCode != 0 {
+		t.Fatalf("first init failed: code=%d stdout=%s stderr=%s", exitCode, string(stdout), string(stderr))
+	}
+	if _, statErr := os.Stat(defaultRealmDir); statErr != nil {
+		t.Fatalf("default realm dir missing after init: %v", statErr)
+	}
+	if _, statErr := os.Stat(systemRealmDir); statErr != nil {
+		t.Fatalf("kuke-system realm dir missing after init: %v", statErr)
+	}
+
+	// Seed a sentinel under default so the AC "user-realm data preserved" has
+	// something concrete to check after reset.
+	sentinelPath := filepath.Join(defaultRealmDir, "user-data.sentinel")
+	if writeErr := os.WriteFile(sentinelPath, []byte("preserve-me"), 0o600); writeErr != nil {
+		t.Fatalf("seed default-realm sentinel: %v", writeErr)
+	}
+
+	// Step 2: reset --purge-system.
+	args = append(buildKukeRunPathArgs(runPath), "daemon", "reset", "--purge-system")
+	exitCode, stdout, stderr = runBinary(t, nil, kuke, args...)
+	if exitCode != 0 {
+		t.Fatalf("daemon reset failed: code=%d stdout=%s stderr=%s", exitCode, string(stdout), string(stderr))
+	}
+	if _, statErr := os.Stat(systemRealmDir); !os.IsNotExist(statErr) {
+		t.Fatalf("kuke-system dir was not removed under --purge-system: stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(sentinelPath); statErr != nil {
+		t.Fatalf("default-realm sentinel must be preserved by reset: %v", statErr)
+	}
+
+	// Step 3: init again must produce a clean re-bootstrap.
+	args = append(buildKukeRunPathArgs(runPath), "init", "--kukeond-image", kukeondImage)
+	exitCode, stdout, stderr = runBinary(t, nil, kuke, args...)
+	if exitCode != 0 {
+		t.Fatalf("re-init after reset failed: code=%d stdout=%s stderr=%s", exitCode, string(stdout), string(stderr))
+	}
+	if _, statErr := os.Stat(systemRealmDir); statErr != nil {
+		t.Fatalf("kuke-system realm dir missing after re-init: %v", statErr)
+	}
+	if _, statErr := os.Stat(sentinelPath); statErr != nil {
+		t.Fatalf("default-realm sentinel must still be present after re-init: %v", statErr)
+	}
+	if !strings.Contains(string(stdout), "Initialized Kukeon runtime") {
+		t.Fatalf("re-init output missing bootstrap header; stdout=%s", string(stdout))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `kuke daemon reset`: lightweight dev-loop teardown that stops + deletes the kukeond cell, clears `/run/kukeon/kukeond.{sock,pid}`, and (optionally) removes `/opt/kukeon/kuke-system`. User-realm data under `/opt/kukeon/default/**` is left untouched, so a follow-up `kuke init` produces a clean re-bootstrap.
- Mirrors the existing `kuke daemon stop`/`restart` SIGTERM → SIGKILL escalation via `--timeout` (default 10s); adds `--purge-system` for the additional kuke-system tree removal.
- Composes existing `StopCell` + `DeleteCell` client calls; runs in-process (the daemon being reset cannot relay its own teardown).
- Wired into the `kuke daemon` subcommand group; help text and shell completion updated to include `reset`.

## Implementation notes
- The stop phase is duplicated locally rather than imported from `cmd/kuke/daemon/stop` to keep each daemon-lifecycle verb self-contained — this matches the convention `kuke daemon restart` established (per #239).
- `MockSocketDirKey` / `MockRunPathKey` context overrides let unit tests redirect socket/runpath cleanup at tmpdirs without touching real `/run/kukeon` or `/opt/kukeon`.
- Distinct from `kuke uninstall` (#170): reset is per-daemon-instance, uninstall is per-host.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (all unit tests pass)
- [x] `go test ./cmd/kuke/daemon/...` (table-driven coverage of running cell, already-stopped cell, missing init, GetCell/StopCell/DeleteCell errors, sock+pid removal, idempotent missing-files, default-realm preservation, --purge-system, graceful-timeout SIGKILL escalation, logger-missing guard)
- [x] `go test ./e2e/... -run "TestKuke_Daemon"` (help text, uninitialized-host guard, `--timeout`/`--purge-system` flag presence)
- [ ] `go test ./e2e/...` round-trip (`TestKuke_DaemonReset_RoundTrip`) — requires the make-e2e harness (KUKEON_E2E_IMAGE / docker / ctr / writable /run/kukeon); skipped in plain `go test`. Full local smoke (rebuild + reset + init round-trip) was not run because this dev sandbox lacks containerd write access (a pre-existing limitation also affecting `TestKuke_AttachDetach_KeepsTaskRunning` on `origin/main`). Reviewer / CI should exercise via `make e2e`.

## Notes for reviewer
- Project `CLAUDE.md` currently documents the manual smoke test as `kuke kill cell` + `kuke delete cell` + `rm -f /run/kukeon/kukeond.{sock,pid}`. With `kuke daemon reset` shipped, that block can be replaced with a single `sudo ./kuke daemon reset --purge-system`. Per `agents/dev/CLAUDE.md`, project-`CLAUDE.md` updates do not bundle into a code-fix PR — I will file the docs follow-up issue separately.

Closes #199