### PR TITLE
feat: add scripts/dev-init.sh + make dev-init for local re-bootstrap loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,7 @@ test-e2e: kuke
 tag:
 	git tag -s v$(KUKEON_VERSION) -m "Release version $(KUKEON_VERSION)"
 	git push origin v$(KUKEON_VERSION)
+
+.PHONY: dev-init
+dev-init:
+	./scripts/dev-init.sh

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2025 Emiliano Spinella (eminwux)
+# SPDX-License-Identifier: Apache-2.0
+#
+# dev-init.sh — local kukeond build + load + init loop for contributors.
+#
+# Composes existing primitives end-to-end so a `kuke init` runs against the
+# locally built kukeond image instead of the registry-resolved default. Lifts
+# the manual "Local smoke test" sequence from CLAUDE.md into a runnable artifact.
+#
+# Idempotent: re-running on a healthy host produces a clean re-bootstrap.
+# On a fresh host (no /opt/kukeon/kuke-system) the script first runs `kuke
+# init` to create realm metadata so the subsequent `kuke image load --realm
+# kuke-system` has a realm to land into; cell provisioning during that
+# first-pass init may fail before the image is staged, which is expected.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+LOCAL_TAG="kukeon-local:dev"
+KUKEOND_IMAGE_REF="docker.io/library/${LOCAL_TAG}"
+SYSTEM_REALM_DIR="/opt/kukeon/kuke-system"
+KUKEOND_CELL_DIR="${SYSTEM_REALM_DIR}/kukeon/kukeon/kukeond"
+
+step() {
+    printf '\n==> %s\n' "$*"
+}
+
+step "Build kuke (and the kukeond symlink)"
+make kuke
+ln -sf kuke kukeond
+
+step "Build local kukeond image (${LOCAL_TAG})"
+docker build --build-arg VERSION=v0.0.0-dev -t "${LOCAL_TAG}" .
+
+if [ ! -d "${SYSTEM_REALM_DIR}" ]; then
+    step "First-time bootstrap: run kuke init to create realm metadata"
+    # The kuke-system realm must exist before `kuke image load --realm
+    # kuke-system` will accept the load. On a fresh host that realm is
+    # created by kuke init's bootstrap pass; cell provisioning at the end
+    # of that pass may fail because the local image is not yet staged in
+    # containerd. Tolerate that — the second init below recreates the
+    # cell after the image load succeeds.
+    sudo ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
+        || echo "first-pass init returned non-zero (expected before image is staged); continuing"
+fi
+
+if [ -d "${KUKEOND_CELL_DIR}" ]; then
+    step "Reset prior kukeond cell"
+    sudo ./kuke daemon reset
+else
+    step "No prior kukeond cell at ${KUKEOND_CELL_DIR}; skipping reset"
+fi
+
+step "Load ${LOCAL_TAG} into the kuke-system realm"
+sudo ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system --no-daemon
+
+step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
+sudo ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}"
+
+step "Daemon parity check (both must show identical output)"
+sudo ./kuke get realms
+sudo ./kuke get realms --no-daemon


### PR DESCRIPTION
## Summary
- Adds `scripts/dev-init.sh`, the runnable artifact that lifts CLAUDE.md's "Local smoke test: rebuild and re-run `kuke init`" prose into one executable. Composes `make kuke` + `kukeond` symlink, `docker build` of `kukeon-local:dev`, `kuke daemon reset` of the prior cell (post-#199/#240), `kuke image load --from-docker` into the `kuke-system` realm, `kuke init --kukeond-image docker.io/library/kukeon-local:dev`, and the daemon-parity check (`kuke get realms` vs. `--no-daemon`).
- Adds `make dev-init` as the canonical entry point, matching the contributor-facing UX the issue calls for.
- Idempotent: re-running on a healthy host produces a clean re-bootstrap. The fresh-host path runs `kuke init` once first to create realm metadata so the subsequent `kuke image load --realm kuke-system` has a realm to land into; that first-pass init may fail at cell provisioning before the local image is staged, which the script tolerates and recovers from on the second init pass.
- Uses `set -euo pipefail` and prints the active phase before each step (the AC's print-the-step-it's-running requirement).

## Implementation notes
- Keeps `--no-daemon` on `kuke image load` per the issue — #226 (drop `--no-daemon` from image commands) is still open. The flag drops cleanly in a follow-up once that lands.
- Hardcodes `LOCAL_TAG=kukeon-local:dev` and `KUKEOND_IMAGE_REF=docker.io/library/kukeon-local:dev` to match the existing CLAUDE.md smoke test exactly. Contributors who need to override these can edit the script — no flag surface added since the script targets a single audience (local dev re-iterate loop).
- The cell-presence check (`[ -d /opt/kukeon/kuke-system/kukeon/kukeon/kukeond ]`) is the precondition for `kuke daemon reset`, since reset errors out with "kukeon host is not initialized" when cell metadata is missing. Skipping reset on a partially-initialized host (realm metadata present, cell metadata absent — e.g. a first-pass init that failed at cell provisioning) keeps `set -e` behaviour intact while still letting the next image-load + init steps complete.
- Plain `kuke daemon reset` (no `--purge-system`) is intentional: the next step (`kuke image load --realm kuke-system`) needs the kuke-system realm metadata to remain. `--purge-system` would wipe it and the load would fail with `ErrRealmNotFound`.
- CNI-bridge cleanup is **not** included in the script — that's #87's territory and belongs in `kuke daemon reset` / `kuke delete realm`, not in the dev script (matches the issue's "Notes" call-out).

## CLAUDE.md update deferred
- AC #6 ("CLAUDE.md 'Local smoke test' section is replaced with a pointer to `make dev-init`") is **not** in this PR. Per `agents/dev/CLAUDE.md`, project-`CLAUDE.md` updates do not bundle into a code-fix PR. Filed as kukeon#244 (`docs:`, `documentation` label, `priority:B`) with the verbatim proposed wording so the next picker can copy-paste it.

## Test plan
- [x] `bash -n scripts/dev-init.sh` (syntax check passes)
- [x] `chmod +x scripts/dev-init.sh` (script is executable)
- [x] `make -n dev-init` (target dispatches to the script)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (all unit tests pass)
- [ ] End-to-end run of `make dev-init` on a real host — this dev sandbox lacks `sudo`/`docker`/`ctr`/writable `/run/kukeon` (the same containerd-write limitation that affected #240's round-trip e2e). Reviewer / CI exercises the full flow; the script's primitives are each covered by their own unit + e2e tests landed in earlier PRs (#216, #213, #240).
- [ ] Manual idempotency check on a healthy host (re-run `make dev-init` twice, confirm second run produces the same daemon-parity tail) — same sandbox limitation.

Closes #232