### PR TITLE
feat: tail non-Attachable container stdout/stderr via cio.LogFile

### DIFF
--- a/cmd/kuke/log/log.go
+++ b/cmd/kuke/log/log.go
@@ -16,10 +16,18 @@
 
 // Package log implements the `kuke log` subcommand. It mirrors `kuke
 // attach`'s flag/arg shape but instead of opening an interactive sbsh
-// session it tails the per-container sbsh capture file. Bytes never
-// traverse the daemon RPC: the daemon validates the Attachable gate and
-// returns the host path of the capture file; this subcommand opens that
-// path directly.
+// session it tails the per-container output stream. Bytes never traverse
+// the daemon RPC: the daemon resolves the host path of the relevant
+// stream and this subcommand opens that path directly.
+//
+// Two paths exist depending on the target container's IO model:
+//
+//   - Attachable containers route output through sbsh, which writes a
+//     tty byte stream to HostCapturePath. `kuke log` tails that file.
+//   - Non-Attachable containers (including kukeond) have the containerd
+//     runtime shim write stdout/stderr to HostLogPath via cio.LogFile.
+//     `kuke log` tails that file. This is gap #4 in
+//     docs/gaps-2026-04-19.md and was implemented per issue #203.
 package log
 
 import (
@@ -65,7 +73,7 @@ func NewLogCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "log",
 		Aliases:       []string{"logs"},
-		Short:         "Tail the sbsh capture file of an Attachable container",
+		Short:         "Tail a container's stdout/stderr stream",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -81,7 +89,7 @@ func NewLogCmd() *cobra.Command {
 	cmd.Flags().String("cell", "", "Cell whose container's capture file to tail")
 	_ = viper.BindPFlag(config.KUKE_LOG_CELL.ViperKey, cmd.Flags().Lookup("cell"))
 	cmd.Flags().String("container", "",
-		"Container within the cell to read (omit to auto-pick the only non-root attachable)")
+		"Container within the cell to read (omit to auto-pick the only non-root container)")
 	_ = viper.BindPFlag(config.KUKE_LOG_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
 	cmd.Flags().Bool("no-follow", false, "Dump current capture file contents and exit (do not follow)")
 	_ = viper.BindPFlag(config.KUKE_LOG_NO_FOLLOW.ViperKey, cmd.Flags().Lookup("no-follow"))
@@ -123,7 +131,7 @@ func runLog(cmd *cobra.Command, _ []string) error {
 	defer func() { _ = client.Close() }()
 
 	if container == "" {
-		container, err = pickAttachableContainer(cmd.Context(), client, realm, space, stack, cell)
+		container, err = pickLogContainer(cmd.Context(), client, realm, space, stack, cell)
 		if err != nil {
 			return err
 		}
@@ -132,24 +140,27 @@ func runLog(cmd *cobra.Command, _ []string) error {
 	doc := buildContainerDoc(container, realm, space, stack, cell)
 	result, err := client.LogContainer(cmd.Context(), doc)
 	if err != nil {
-		if errors.Is(err, errdefs.ErrAttachNotSupported) {
-			return fmt.Errorf("container %q in cell %q is not attachable: %w", container, cell, err)
-		}
 		if errors.Is(err, errdefs.ErrContainerNotFound) {
 			return fmt.Errorf("container %q not found in cell %q", container, cell)
 		}
 		return err
 	}
-	if result.HostCapturePath == "" {
-		return fmt.Errorf("daemon returned empty HostCapturePath for container %q", container)
+	streamPath := result.HostCapturePath
+	if streamPath == "" {
+		streamPath = result.HostLogPath
+	}
+	if streamPath == "" {
+		return fmt.Errorf("daemon returned no stream path for container %q", container)
 	}
 
 	tail := resolveTail(cmd)
-	if tailErr := tail(cmd.Context(), result.HostCapturePath, cmd.OutOrStdout(), noFollow); tailErr != nil {
+	if tailErr := tail(cmd.Context(), streamPath, cmd.OutOrStdout(), noFollow); tailErr != nil {
 		if errors.Is(tailErr, os.ErrNotExist) {
 			return fmt.Errorf(
-				"cell %q container %q has no capture file at %s",
-				cell, container, result.HostCapturePath,
+				"cell %q container %q has no log file at %s (the runtime shim has not opened it yet — try again after the container produces output)",
+				cell,
+				container,
+				streamPath,
 			)
 		}
 		return tailErr
@@ -201,10 +212,12 @@ func tailFile(ctx context.Context, path string, out io.Writer, noFollow bool) er
 	}
 }
 
-// pickAttachableContainer enumerates the cell's containers and returns the
-// single non-root attachable one. Same shape and semantics as the
-// `kuke attach` picker — both subcommands target the same container set.
-func pickAttachableContainer(
+// pickLogContainer enumerates the cell's containers and returns the single
+// non-root one — Attachable or not, since `kuke log` is meaningful for both
+// IO models (sbsh-capture for Attachable, cio.LogFile for non-Attachable).
+// This is the diff vs the `kuke attach` picker, which still requires
+// Attachable=true.
+func pickLogContainer(
 	ctx context.Context,
 	client kukeonv1.Client,
 	realm, space, stack, cell string,
@@ -217,7 +230,7 @@ func pickAttachableContainer(
 	candidates := make([]string, 0, len(specs))
 	for i := range specs {
 		spec := specs[i]
-		if spec.Root || !spec.Attachable {
+		if spec.Root {
 			continue
 		}
 		candidates = append(candidates, spec.ID)

--- a/cmd/kuke/log/log_test.go
+++ b/cmd/kuke/log/log_test.go
@@ -282,27 +282,104 @@ func TestLog_NoCandidate_Errors(t *testing.T) {
 	}
 }
 
-func TestLog_ExplicitContainer_NotAttachable_SurfacesSentinel(t *testing.T) {
+// TestLog_NonAttachable_TailsHostLogPath locks in the issue-#203 contract:
+// a non-Attachable container is not gated out — the daemon returns
+// HostLogPath (cio.LogFile) and `kuke log` tails it the same way it tails
+// the sbsh capture file for Attachable containers.
+func TestLog_NonAttachable_TailsHostLogPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	const wantPath = "/opt/kukeon/r1/s1/st1/c1/side/log"
+	fc := &fakeClient{
+		logContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			return kukeonv1.LogContainerResult{HostLogPath: wantPath}, nil
+		},
+	}
+	tail := &tailCapture{payload: []byte("daemon-stderr-line\n")}
+	cmd, out := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "side", "--no-follow",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if tail.calls != 1 {
+		t.Fatalf("tail called %d times, want 1", tail.calls)
+	}
+	if tail.path != wantPath {
+		t.Errorf("tail path = %q, want %q", tail.path, wantPath)
+	}
+	if got := out.String(); got != "daemon-stderr-line\n" {
+		t.Errorf("stdout = %q, want %q", got, "daemon-stderr-line\n")
+	}
+}
+
+// TestLog_AmbiguousAcceptsNonAttachable checks the picker fallout from
+// the Attachable filter being dropped (issue #203): a cell with two
+// non-root containers — one Attachable, one not — must surface as
+// ambiguous because both are now valid log targets.
+func TestLog_AmbiguousAcceptsNonAttachable(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
-		logContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
-			return kukeonv1.LogContainerResult{}, errdefs.ErrAttachNotSupported
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "shell", Attachable: true},
+				{ID: "daemon"},
+			}, nil
 		},
 	}
 	tail := &tailCapture{}
 	cmd, _ := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "side",
 	})
 
 	err := cmd.Execute()
-	if !errors.Is(err, errdefs.ErrAttachNotSupported) {
-		t.Fatalf("error %v does not unwrap to ErrAttachNotSupported", err)
+	if !errors.Is(err, errdefs.ErrAttachAmbiguous) {
+		t.Fatalf("error %v does not unwrap to ErrAttachAmbiguous", err)
 	}
-	if tail.calls != 0 {
-		t.Errorf("tail called %d times on non-attachable target, want 0", tail.calls)
+	if got := err.Error(); !strings.Contains(got, "daemon, shell") {
+		t.Errorf("error message %q missing both candidates", got)
+	}
+}
+
+// TestLog_AutoPicksLoneNonAttachable checks the kukeond-cell shape:
+// a cell whose only non-root container is non-Attachable resolves to
+// that container without requiring --container on the command line.
+func TestLog_AutoPicksLoneNonAttachable(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	const wantPath = "/opt/kukeon/kuke-system/kukeon/kukeon/kukeond/kukeond/log"
+	fc := &fakeClient{
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			return []v1beta1.ContainerSpec{
+				{ID: "kukeon-system-root", Root: true},
+				{ID: "kukeond"},
+			}, nil
+		},
+		logContainerFn: func(doc v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			if got := doc.Metadata.Name; got != "kukeond" {
+				t.Errorf("LogContainer called with name %q, want %q", got, "kukeond")
+			}
+			return kukeonv1.LogContainerResult{HostLogPath: wantPath}, nil
+		},
+	}
+	tail := &tailCapture{}
+	cmd, _ := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{
+		"--realm", "kuke-system", "--space", "kukeon", "--stack", "kukeon", "--cell", "kukeond",
+		"--no-follow",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if tail.path != wantPath {
+		t.Errorf("tail path = %q, want %q", tail.path, wantPath)
 	}
 }
 

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -962,18 +962,41 @@ func (c *Client) AttachContainer(_ context.Context, doc v1beta1.ContainerDoc) (k
 
 // ---- Log ----
 
-// LogContainer enforces the Attachable gate and resolves the host-side path
-// of the per-container sbsh capture file. The Attachable gate is the same
-// invariant AttachContainer uses: only sbsh-wrapped containers have a
-// capture file. Bytes never traverse this RPC — the caller (`kuke log`)
-// opens HostCapturePath directly.
+// LogContainer resolves the host-side path of the per-container output
+// stream and returns it via LogContainerResult. The path varies by IO
+// model:
+//
+//   - Attachable containers are sbsh-wrapped, so stdout/stderr land in
+//     the sbsh capture file at HostCapturePath (current behavior).
+//   - Non-Attachable containers (including kukeond) have the runtime
+//     shim write stdout/stderr to HostLogPath via cio.LogFile (gap #4
+//     in docs/gaps-2026-04-19.md). The file is shim-owned; kuke just
+//     hands the path back so `kuke log` can read it.
+//
+// Bytes never traverse this RPC — the caller opens the returned path.
 func (c *Client) LogContainer(_ context.Context, doc v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
-	spec, err := c.resolveAttachable(doc)
+	internal, _, err := apischeme.NormalizeContainer(doc)
+	if err != nil {
+		return kukeonv1.LogContainerResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.GetContainer(internal)
 	if err != nil {
 		return kukeonv1.LogContainerResult{}, err
 	}
+	if !res.ContainerExists {
+		return kukeonv1.LogContainerResult{}, errdefs.ErrContainerNotFound
+	}
+	spec := res.Container.Spec
+	if spec.Attachable {
+		return kukeonv1.LogContainerResult{
+			HostCapturePath: fs.ContainerCapturePath(
+				c.ctrl.RunPath(),
+				spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+			),
+		}, nil
+	}
 	return kukeonv1.LogContainerResult{
-		HostCapturePath: fs.ContainerCapturePath(
+		HostLogPath: fs.ContainerLogPath(
 			c.ctrl.RunPath(),
 			spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
 		),

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -44,6 +44,14 @@ const (
 	// /run/kukeon/tty/capture (see ctr.AttachableCapturePath).
 	KukeonContainerCaptureFile = "capture"
 
+	// KukeonContainerLogFile is the basename of the per-container stdout/
+	// stderr log file written by the containerd runtime shim via cio.LogFile
+	// for non-Attachable containers (Attachable containers route output
+	// through sbsh's capture file instead). The shim is the writer; kuke
+	// only reads it. `kuke log` tails this file when targeting a non-
+	// Attachable container.
+	KukeonContainerLogFile = "log"
+
 	// Label keys shared across the user default hierarchy and the system hierarchy.
 	KukeonRealmLabelKey     = "realm.kukeon.io"
 	KukeonSpaceLabelKey     = "space.kukeon.io"

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -28,8 +28,30 @@ import (
 	"github.com/eminwux/kukeon/internal/ctr"
 	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
 	"github.com/eminwux/kukeon/internal/util/naming"
 )
+
+// containerLogTaskSpec returns a TaskSpec with cio.LogFile IO pointed at the
+// per-container log path for a non-Attachable container. Returns the zero
+// TaskSpec for Attachable containers (sbsh's capture file already covers
+// them) and for Root containers (pause-style — no useful stdout). Bytes flow
+// from the runtime shim into the file; `kuke log` later reads from the same
+// path. Centralised here so all three StartContainer call sites pick up the
+// same policy.
+func (r *Exec) containerLogTaskSpec(spec intmodel.ContainerSpec) ctr.TaskSpec {
+	if spec.Attachable || spec.Root {
+		return ctr.TaskSpec{}
+	}
+	return ctr.TaskSpec{
+		IO: &ctr.TaskIO{
+			LogFilePath: fs.ContainerLogPath(
+				r.opts.RunPath,
+				spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+			),
+		},
+	}
+}
 
 // rootContainerWantsCNI returns true when StartCell should run the CNI attach
 // path for the cell's root container. Host-network containers (kukeond and
@@ -587,7 +609,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 			namespacePaths,
 		)
 
-		_, err = r.ctrClient.StartContainer(specWithNamespaces, ctr.TaskSpec{})
+		_, err = r.ctrClient.StartContainer(specWithNamespaces, r.containerLogTaskSpec(containerSpec))
 		if err != nil {
 			fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
 			fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
@@ -817,7 +839,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 		namespacePaths,
 	)
 
-	_, err = r.ctrClient.StartContainer(specWithNamespaces, ctr.TaskSpec{})
+	_, err = r.ctrClient.StartContainer(specWithNamespaces, r.containerLogTaskSpec(*foundContainerSpec))
 	if err != nil {
 		fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
 		fields = append(

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -80,16 +82,29 @@ func (c *client) StartContainer(
 		c.dropTask(containerSpec.ID)
 	}
 
-	// Build IO creator
+	// Build IO creator. Selection order:
+	//   1. LogFilePath  — cio.LogFile, shim appends stdout+stderr to a host
+	//      file kuke can tail (used for non-Attachable containers including
+	//      kukeond — see internal/util/fs/metadata.go ContainerLogPath).
+	//   2. Terminal     — TTY-attached IO with no streams wired (sbsh later
+	//      claims stdio inside the container).
+	//   3. IO non-nil   — bare IO creator with no streams wired.
+	//   4. default      — cio.NullIO (output discarded).
 	var ioCreator cio.Creator
-	if taskSpec.IO != nil {
-		if taskSpec.IO.Terminal {
-			ioCreator = cio.NewCreator(cio.WithStreams(nil, nil, nil), cio.WithTerminal)
-		} else {
-			ioCreator = cio.NewCreator(cio.WithStreams(nil, nil, nil))
+	switch {
+	case taskSpec.IO != nil && taskSpec.IO.LogFilePath != "":
+		// The shim opens the path on first task write; create the parent
+		// dir up front so that creation fails loudly here rather than
+		// silently inside the shim.
+		if err = os.MkdirAll(filepath.Dir(taskSpec.IO.LogFilePath), 0o750); err != nil {
+			return nil, fmt.Errorf("create container log dir: %w", err)
 		}
-	} else {
-		// Default: no IO streams
+		ioCreator = cio.LogFile(taskSpec.IO.LogFilePath)
+	case taskSpec.IO != nil && taskSpec.IO.Terminal:
+		ioCreator = cio.NewCreator(cio.WithStreams(nil, nil, nil), cio.WithTerminal)
+	case taskSpec.IO != nil:
+		ioCreator = cio.NewCreator(cio.WithStreams(nil, nil, nil))
+	default:
 		ioCreator = cio.NullIO
 	}
 

--- a/internal/ctr/types.go
+++ b/internal/ctr/types.go
@@ -87,6 +87,12 @@ type TaskIO struct {
 	Stderr string
 	// Terminal indicates if the task should have a TTY.
 	Terminal bool
+	// LogFilePath, when set, makes the runtime shim write the task's
+	// stdout and stderr to this host path via cio.LogFile. The shim
+	// opens the file in append mode; if no file exists yet it is
+	// created. Mutually exclusive with Terminal — log files do not
+	// pair with a TTY.
+	LogFilePath string
 }
 
 // ContainerDeleteOptions describes options for deleting a container.

--- a/internal/daemon/log_rpc_test.go
+++ b/internal/daemon/log_rpc_test.go
@@ -45,8 +45,12 @@ func (l *logClientFake) LogContainer(
 	return l.result, l.err
 }
 
-func TestLogContainer_NotAttachable_RPCSurfacesSentinel(t *testing.T) {
-	core := &logClientFake{err: errdefs.ErrAttachNotSupported}
+// TestLogContainer_ContainerNotFound_RPCSurfacesSentinel pins down the
+// daemon RPC layer's pass-through of structured errors from the in-process
+// client. ErrContainerNotFound is the realistic sentinel callers can hit
+// since issue #203 dropped the Attachable gate inside LogContainer.
+func TestLogContainer_ContainerNotFound_RPCSurfacesSentinel(t *testing.T) {
+	core := &logClientFake{err: errdefs.ErrContainerNotFound}
 	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, nil)
 
 	args := &kukeonv1.LogContainerArgs{Doc: v1beta1.ContainerDoc{}}
@@ -58,8 +62,8 @@ func TestLogContainer_NotAttachable_RPCSurfacesSentinel(t *testing.T) {
 		t.Fatalf("expected wire-level Err to be populated, got nil")
 	}
 	wireErr := kukeonv1.FromAPIError(reply.Err)
-	if !errors.Is(wireErr, errdefs.ErrAttachNotSupported) {
-		t.Errorf("wire error %q does not unwrap to ErrAttachNotSupported", wireErr)
+	if !errors.Is(wireErr, errdefs.ErrContainerNotFound) {
+		t.Errorf("wire error %q does not unwrap to ErrContainerNotFound", wireErr)
 	}
 }
 
@@ -78,5 +82,32 @@ func TestLogContainer_Attachable_RPCReturnsCapturePath(t *testing.T) {
 	}
 	if reply.Result.HostCapturePath != wantPath {
 		t.Errorf("HostCapturePath = %q, want %q", reply.Result.HostCapturePath, wantPath)
+	}
+}
+
+// TestLogContainer_NonAttachable_RPCReturnsLogPath pins the wire-level
+// passthrough of HostLogPath added in issue #203 — the field for the
+// containerd-shim cio.LogFile branch.
+func TestLogContainer_NonAttachable_RPCReturnsLogPath(t *testing.T) {
+	const wantPath = "/opt/kukeon/kuke-system/kukeon/kukeon/kukeond/kukeond/log"
+	core := &logClientFake{result: kukeonv1.LogContainerResult{HostLogPath: wantPath}}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core, nil)
+
+	args := &kukeonv1.LogContainerArgs{Doc: v1beta1.ContainerDoc{}}
+	reply := &kukeonv1.LogContainerReply{}
+	if err := svc.LogContainer(args, reply); err != nil {
+		t.Fatalf("LogContainer returned transport error: %v", err)
+	}
+	if reply.Err != nil {
+		t.Fatalf("expected wire-level Err to be nil, got %v", kukeonv1.FromAPIError(reply.Err))
+	}
+	if reply.Result.HostLogPath != wantPath {
+		t.Errorf("HostLogPath = %q, want %q", reply.Result.HostLogPath, wantPath)
+	}
+	if reply.Result.HostCapturePath != "" {
+		t.Errorf(
+			"HostCapturePath = %q, want empty (non-Attachable should not populate it)",
+			reply.Result.HostCapturePath,
+		)
 	}
 }

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -124,6 +124,19 @@ func ContainerCapturePath(baseRunPath, realmName, spaceName, stackName, cellName
 	)
 }
 
+// ContainerLogPath returns the host-side path of the per-container stdout/
+// stderr log file written by the containerd runtime shim via cio.LogFile.
+// Used for non-Attachable containers (kukeond included): the shim opens this
+// path and appends every byte the task writes to stdout or stderr; `kuke log`
+// tails the same path. Attachable containers do not use this file — their
+// output is captured by sbsh into ContainerCapturePath.
+func ContainerLogPath(baseRunPath, realmName, spaceName, stackName, cellName, containerName string) string {
+	return filepath.Join(
+		ContainerMetadataDir(baseRunPath, realmName, spaceName, stackName, cellName, containerName),
+		consts.KukeonContainerLogFile,
+	)
+}
+
 type metadataHeader struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -568,16 +568,26 @@ type LogContainerReply struct {
 }
 
 // LogContainerResult carries the host-side coordinates the `kuke log` client
-// needs to tail the sbsh capture file. Bytes never traverse this RPC — the
-// client opens HostCapturePath directly.
+// needs to read the per-container output stream. Bytes never traverse this
+// RPC — the client opens the returned host path directly.
+//
+// Exactly one of HostCapturePath or HostLogPath is non-empty:
+//
+//   - Attachable containers route stdout/stderr through the sbsh terminal
+//     wrapper, which writes a tty byte stream to HostCapturePath.
+//   - Non-Attachable containers (including kukeond) have the runtime shim
+//     append stdout/stderr to HostLogPath via cio.LogFile.
 type LogContainerResult struct {
 	// HostCapturePath is the host path of the per-container sbsh capture
 	// file. Inside the container the same inode is reachable at
-	// /run/kukeon/tty/capture via the tty directory bind mount. Returned
-	// only when the target container has Attachable=true; otherwise the
-	// daemon errors with ErrAttachNotSupported (non-Attachable containers
-	// have no capture file).
+	// /run/kukeon/tty/capture via the tty directory bind mount. Set only
+	// when the target container has Attachable=true.
 	HostCapturePath string
+
+	// HostLogPath is the host path of the per-container log file written
+	// by the containerd runtime shim (cio.LogFile mode). Set only for
+	// non-Attachable containers; the file is shim-owned, kuke only reads.
+	HostLogPath string
 }
 
 // ---- Refresh ----


### PR DESCRIPTION
## Summary
- `kuke log` now works for both Attachable and non-Attachable containers. Attachable still uses sbsh's capture file (unchanged); non-Attachable uses a host file populated by the containerd shim via `cio.LogFile`.
- Daemon and `--no-daemon` paths produce the same stream via the same `LogContainer` RPC; the response now carries either `HostCapturePath` (Attachable) or `HostLogPath` (non-Attachable), and the CLI tails whichever is set.
- `kukeond` (and any non-root non-Attachable container) is now started with `cio.LogFile(<container metadata dir>/log)` instead of `cio.NullIO`, so stdout/stderr are captured to disk by the shim — no kuke-owned ring, no daemon-side buffering. Root containers stay on `NullIO`.
- Per-container picker for `kuke log` no longer requires `Attachable=true`; it picks the lone non-root container regardless of IO mode.

Implementation note: chose `cio.LogFile` over `Task.Attach` because `ctr tasks attach` kills the task on detach (per repo memory) — the shim-owned log file matches the issue's "containerd already has the bytes; we just expose them" framing without that footgun.

## Test plan
- [x] `make test` (full unit suite) — all packages pass
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `make dev-init` — full re-bootstrap clean; daemon-parity check shows identical output for `kuke get realms` and `kuke get realms --no-daemon`
- [x] `sudo ./kuke log --realm kuke-system --space kukeon --stack kukeon --cell kukeond --no-follow` returns the actual `kukeond` daemon stdout (`time=… level=INFO msg="kukeond listening"…`)

Closes #203