### PR TITLE
fix: chown attachable tty dir to kukeon group + container uid (#258)

### DIFF
--- a/cmd/kukeond/serve.go
+++ b/cmd/kukeond/serve.go
@@ -86,6 +86,13 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		Controller: controller.Options{
 			RunPath:          runPath,
 			ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+			// Forward the kukeon group GID into the runner so per-container
+			// Attachable tty directories created by daemon-mediated apply/start
+			// inherit the same group-traversal layout `kuke init` applies to
+			// /opt/kukeon. Without this the runner sees KukeonGroupGID=0 and
+			// falls back to 0700 root-only — regressing #258 repro A under the
+			// daemon path even when --socket-gid was set.
+			KukeondSocketGID: socketGID,
 		},
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -104,6 +104,7 @@ func NewControllerExec(ctx context.Context, logger *slog.Logger, opts Options) *
 			ContainerdSocket:   opts.ContainerdSocket,
 			RunPath:            opts.RunPath,
 			ForceRegenerateCNI: opts.ForceRegenerateCNI,
+			KukeonGroupGID:     opts.KukeondSocketGID,
 		}),
 	}
 }

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -25,6 +25,38 @@ import (
 	"github.com/eminwux/kukeon/internal/util/fs"
 )
 
+// attachableTTYDirRootMode is the mode applied to the per-container tty
+// directory while it is still root-owned (host-side and group-owned by the
+// kukeon group). 02750 = setgid + rwx for owner + r-x for group + no world
+// access, matching the rest of /opt/kukeon set up by `kuke init` so members
+// of the kukeon group can traverse without world access. The setgid bit
+// makes future siblings (sbsh socket, log, capture) inherit the kukeon
+// group automatically.
+const attachableTTYDirRootMode os.FileMode = os.ModeSetgid | 0o0750
+
+// attachableTTYDirNoGroupMode is the legacy fallback when the kukeon group
+// GID is not configured (e.g., older `kuke init` runs that never invoked
+// sysuser.EnsureUserGroup, or `--no-daemon` smoke tests under a tmp
+// runPath). In that mode there is no group to delegate access to, so the
+// directory stays owner-only (0700).
+const attachableTTYDirNoGroupMode os.FileMode = 0o0700
+
+// attachableTTYDirInitialPerms returns the (mode, gid) tuple to apply to a
+// freshly-prepared per-container tty directory before the workload
+// container starts. When kukeonGroupGID is non-zero, the directory is
+// group-traversable for members of the kukeon group (matches `kuke init`'s
+// /opt/kukeon layout); when it is zero, the directory stays root-only.
+//
+// The owner is set to root in both cases — the post-create step resets it
+// to the resolved container uid once containerd has parsed the image's
+// USER directive (#258 repro B).
+func attachableTTYDirInitialPerms(kukeonGroupGID int) (os.FileMode, int) {
+	if kukeonGroupGID > 0 {
+		return attachableTTYDirRootMode, kukeonGroupGID
+	}
+	return attachableTTYDirNoGroupMode, 0
+}
+
 // attachableBuildOpts returns the ctr.BuildOption slice to pass to
 // CreateContainerFromSpec for a given container spec. When Attachable=false
 // the slice is empty and the call is a no-op. When Attachable=true the
@@ -33,6 +65,13 @@ import (
 // resolves the sbsh binary path keyed off the *image* arch, not the host
 // arch — a cross-arch image running under emulation would otherwise pick a
 // binary the in-container ELF interpreter cannot run.
+//
+// The directory is created with mode 02750 owned by root:kukeon group when
+// the kukeon group GID is configured, so non-root operators in the kukeon
+// group can dial the host-side socket via the same group-traversal path
+// `kuke init` sets up on /opt/kukeon. The owner is corrected to the
+// container's resolved uid by attachablePostCreateChown after
+// CreateContainerFromSpec runs.
 func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOption, error) {
 	if !spec.Attachable {
 		return nil, nil
@@ -43,10 +82,19 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName,
 		spec.ID,
 	)
-	// 0700 so only the daemon (root) can reach the socket from the host
-	// side. Documented in the issue's "Socket security threat model".
-	if err := os.MkdirAll(ttyDir, 0o700); err != nil {
+	if err := os.MkdirAll(ttyDir, 0o0700); err != nil {
 		return nil, err
+	}
+	// MkdirAll leaves any pre-existing directory's mode intact and a fresh
+	// dir's mode is filtered by umask, so apply the desired mode explicitly.
+	mode, gid := attachableTTYDirInitialPerms(r.opts.KukeonGroupGID)
+	if err := os.Chmod(ttyDir, mode); err != nil {
+		return nil, fmt.Errorf("chmod %q to %v: %w", ttyDir, mode, err)
+	}
+	if gid > 0 {
+		if err := os.Chown(ttyDir, 0, gid); err != nil {
+			return nil, fmt.Errorf("chown %q to root:%d: %w", ttyDir, gid, err)
+		}
 	}
 
 	binaryPath, err := r.ctrClient.ResolveSbshCachePath(spec.Image, r.opts.RunPath)
@@ -68,4 +116,50 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 			UseProfile:     useProfile,
 		}),
 	}, nil
+}
+
+// attachablePostCreateChown resets the owner of the per-container tty
+// directory to the container's resolved process uid, so a non-root image
+// USER (or an explicit container.user override) can create the sbsh
+// socket and its capture/log siblings inside the bind-mounted dir.
+//
+// A no-op for non-Attachable containers. Called after
+// CreateContainerFromSpec because containerd resolves USER (including
+// usernames like "claude" via the rootfs's /etc/passwd) only when the
+// runtime spec is built — which is during NewContainer, not before.
+//
+// Group ownership and mode are preserved (the dir was already chmod'd to
+// 02750 root:kukeon by attachableBuildOpts), so kukeon-group members on
+// the host keep traverse access to the socket.
+func (r *Exec) attachablePostCreateChown(spec intmodel.ContainerSpec) error {
+	if !spec.Attachable {
+		return nil
+	}
+
+	containerdID := spec.ContainerdID
+	if containerdID == "" {
+		containerdID = spec.ID
+	}
+	container, err := r.ctrClient.GetContainer(containerdID)
+	if err != nil {
+		return fmt.Errorf("get container %q: %w", containerdID, err)
+	}
+
+	uid, err := r.ctrClient.ContainerProcessUID(container)
+	if err != nil {
+		return fmt.Errorf("resolve process uid for %q: %w", containerdID, err)
+	}
+
+	ttyDir := fs.ContainerTTYDir(
+		r.opts.RunPath,
+		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName,
+		spec.ID,
+	)
+	// Group: kukeon group when configured, root otherwise (-1 would also
+	// work but plumbing 0 is consistent with attachableBuildOpts).
+	gid := r.opts.KukeonGroupGID
+	if chownErr := os.Chown(ttyDir, int(uid), gid); chownErr != nil {
+		return fmt.Errorf("chown %q to (uid=%d, gid=%d): %w", ttyDir, uid, gid, chownErr)
+	}
+	return nil
 }

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -1,0 +1,91 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises private attachableTTYDirInitialPerms.
+package runner
+
+import (
+	"os"
+	"testing"
+)
+
+// TestAttachableTTYDirInitialPerms locks the (mode, gid) tuple for the per-
+// container tty directory:
+//
+//   - When the kukeon group GID is configured (>0), the dir is 02750
+//     root:kukeon — same group-traversal layout `kuke init` applies to the
+//     rest of /opt/kukeon. This is the regression fix for #258 repro A,
+//     where 0o700 root-owned blocked non-root members of the kukeon group
+//     from dialing the per-container sbsh socket.
+//   - When the kukeon group GID is unset (0), the dir falls back to 0o700.
+//     Used by `--no-daemon` smoke tests under tmp run-paths and by hosts
+//     that pre-date sysuser.EnsureUserGroup; matches pre-#258 behavior.
+func TestAttachableTTYDirInitialPerms(t *testing.T) {
+	cases := []struct {
+		name     string
+		gid      int
+		wantMode os.FileMode
+		wantGID  int
+	}{
+		{
+			name:     "with kukeon group: 02750 root:kukeon",
+			gid:      986,
+			wantMode: os.ModeSetgid | 0o0750,
+			wantGID:  986,
+		},
+		{
+			name:     "kukeon group unset: legacy 0700 root-only",
+			gid:      0,
+			wantMode: 0o0700,
+			wantGID:  0,
+		},
+		{
+			name:     "negative gid (defensive): treated as unset",
+			gid:      -1,
+			wantMode: 0o0700,
+			wantGID:  0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotMode, gotGID := attachableTTYDirInitialPerms(tc.gid)
+			if gotMode != tc.wantMode {
+				t.Errorf("mode = %v, want %v", gotMode, tc.wantMode)
+			}
+			if gotGID != tc.wantGID {
+				t.Errorf("gid = %d, want %d", gotGID, tc.wantGID)
+			}
+		})
+	}
+}
+
+// TestAttachableTTYDirRootMode_SetsSGIDBit is a belt-and-braces guard for
+// the constant itself: `os.FileMode(0o2750)` does NOT carry os.ModeSetgid
+// (the FileMode flag bits live above the perm bits), so a future refactor
+// that drops the explicit `os.ModeSetgid |` could silently produce a
+// directory without the setgid bit — and sbsh's later-created socket /
+// log / capture siblings would land as root:root instead of inheriting the
+// kukeon group, breaking host-side group access on every restart.
+func TestAttachableTTYDirRootMode_SetsSGIDBit(t *testing.T) {
+	if attachableTTYDirRootMode&os.ModeSetgid == 0 {
+		t.Errorf("attachableTTYDirRootMode = %v missing os.ModeSetgid bit", attachableTTYDirRootMode)
+	}
+	if attachableTTYDirRootMode.Perm() != 0o0750 {
+		t.Errorf("attachableTTYDirRootMode perm bits = %#o, want 0o750", attachableTTYDirRootMode.Perm())
+	}
+}

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1374,6 +1374,11 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				)
 				return nil, fmt.Errorf("failed to create container %s: %w", containerdID, createErr)
 			}
+			if chownErr := r.attachablePostCreateChown(containerSpec); chownErr != nil {
+				return nil, fmt.Errorf(
+					"failed to chown attachable tty dir for %s: %w", containerdID, chownErr,
+				)
+			}
 		}
 	}
 
@@ -1821,6 +1826,11 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 					"created container from cell",
 					successFields...,
 				)
+				if chownErr := r.attachablePostCreateChown(containerSpec); chownErr != nil {
+					return nil, fmt.Errorf(
+						"failed to chown attachable tty dir for %s: %w", containerdID, chownErr,
+					)
+				}
 			}
 		} else {
 			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -149,6 +149,12 @@ type Options struct {
 	// even when one is present and its bridge name matches SafeBridgeName. Set by
 	// `kuke init --force-regenerate-cni` as an operator escape hatch.
 	ForceRegenerateCNI bool
+	// KukeonGroupGID, when non-zero, is the numeric GID of the kukeon system
+	// group. The runner uses it to chown the host-side per-container tty
+	// directory created for Attachable containers, so that members of the
+	// kukeon group can reach the per-container sbsh socket via the same
+	// group-traversal path that `kuke init` sets up on /opt/kukeon.
+	KukeonGroupGID int
 }
 
 func NewRunner(ctx context.Context, logger *slog.Logger, opts Options) Runner {

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -603,6 +603,12 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 			fields...,
 		)
 
+		if err = r.attachablePostCreateChown(containerSpec); err != nil {
+			return intmodel.Cell{}, fmt.Errorf(
+				"failed to chown attachable tty dir for %s: %w", ctrContainerID, err,
+			)
+		}
+
 		// Use container name with UUID for containerd operations
 		specWithNamespaces := ctr.JoinContainerNamespaces(
 			ctr.ContainerSpec{ID: ctrContainerID},
@@ -832,6 +838,12 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 		"created container",
 		fields...,
 	)
+
+	if err = r.attachablePostCreateChown(*foundContainerSpec); err != nil {
+		return intmodel.Cell{}, fmt.Errorf(
+			"failed to chown attachable tty dir for %s: %w", containerdID, err,
+		)
+	}
 
 	// Start container with namespace paths
 	specWithNamespaces := ctr.JoinContainerNamespaces(

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -87,6 +87,15 @@ type Client interface {
 
 	ResolveSbshCachePath(imageRef, baseRunPath string) (string, error)
 
+	// ContainerProcessUID returns the resolved process.User.UID from the
+	// given container's OCI runtime spec. Used after CreateContainerFromSpec
+	// to chown the host-side per-container Attachable tty directory to the
+	// runtime uid the container will execute as — which can be non-root
+	// when the image carries a USER directive (or the cell profile sets
+	// container.user). Without this, sbsh inside the container fails to
+	// create its socket/log/capture files in the bind-mounted dir.
+	ContainerProcessUID(container containerd.Container) (uint32, error)
+
 	// LoadImage imports an OCI/docker image tarball into the client's current
 	// containerd namespace and returns the names of the imported images.
 	// Callers set the target namespace via SetNamespace before invoking.

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -130,6 +130,30 @@ func (c *client) applySpecOpts(container containerd.Container, opts []oci.SpecOp
 	return nil
 }
 
+// ContainerProcessUID returns the resolved process.User.UID from the
+// container's OCI runtime spec. The spec carries the post-resolution UID
+// after CreateContainerFromSpec has run — containerd's WithImageConfig
+// (and any caller-supplied WithUser) populates Process.User by parsing the
+// image's USER directive against the rootfs's /etc/passwd, so this returns
+// the actual numeric uid even when the image specified a username like
+// "claude". Returns an error if the spec cannot be loaded or has no
+// Process — both indicate the container was not created or was destroyed
+// between create and this call.
+func (c *client) ContainerProcessUID(container containerd.Container) (uint32, error) {
+	if container == nil {
+		return 0, errors.New("container is nil")
+	}
+	nsCtx := c.namespaceCtx()
+	spec, err := container.Spec(nsCtx)
+	if err != nil {
+		return 0, fmt.Errorf("read container spec: %w", err)
+	}
+	if spec == nil || spec.Process == nil {
+		return 0, errors.New("container spec has no Process")
+	}
+	return spec.Process.User.UID, nil
+}
+
 func withUpdatedSpec(spec *oci.Spec) containerd.UpdateContainerOpts {
 	return func(_ context.Context, _ *containerd.Client, c *containers.Container) error {
 		if spec == nil {


### PR DESCRIPTION
## Summary
- Fix #258: per-container Attachable tty dir was created at 0700 root-owned, blocking both kukeon-group operators (Repro A) and non-root container USER (Repro B) from reaching the host-side sbsh socket.
- Pre-create the tty dir as 02750 root:kukeon when the kukeon group GID is plumbed (matches `kuke init`'s /opt/kukeon layout); fall back to 0700 when it isn't (legacy / `--no-daemon` smoke tests).
- After CreateContainerFromSpec resolves the image's USER directive, chown the tty dir to the container's runtime uid (read from `container.Spec(ctx).Process.User.UID`) so non-root processes can create the socket/log/capture siblings inside the bind-mounted dir.
- Plumb `KukeondSocketGID` from controller through `runner.Options.KukeonGroupGID`, and forward it from `kukeond serve` (this last step was missing — without it the daemon-mediated path silently regressed).

## Test plan
- [x] `make test` — full unit suite passes.
- [x] `make dev-init` — daemon parity check shows identical realm output for both `kuke get realms` and `kuke get realms --no-daemon`.
- [x] Manual Repro A (root-USER attachable busybox via daemon `apply`): tty dir is `drwxr-s--- root:kukeon` mode 02750; socket/log/capture all inherit kukeon group via setgid.
- [x] Manual Repro B (non-root `user: "1234:1234"` attachable busybox): tty dir is `drwxr-s--- 1234:kukeon`; sbsh log inside is owned `1234:kukeon`, proving the non-root in-container process can write the bind-mounted dir.
- [x] New unit tests in `internal/controller/runner/attachable_test.go`: `TestAttachableTTYDirInitialPerms` covers gid=986 / gid=0 / gid=-1; `TestAttachableTTYDirRootMode_SetsSGIDBit` guards the FileMode constant against losing `os.ModeSetgid` on refactor.
- [ ] `make test-e2e` — pre-existing failures unrelated to this change: `TestKuke_AttachDetach_KeepsTaskRunning` (task not RUNNING after detach — fails on origin/main too), `TestKuke_Init_VerifyState` (residual state collision), and the `--run-path tmp/...` cell tests that try to dial the daemon socket without `--no-daemon`. None reproduce on the changed code paths.

Closes #258