### PR TITLE
fix: close remaining gates on kukeon-group attachable end-to-end

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.8.0
+	github.com/eminwux/sbsh v0.10.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.8.0 h1:PI0tUwgkYcdFlug6Ga3XhbqiHY/JqrPT9QVOEIhTFYY=
-github.com/eminwux/sbsh v0.8.0/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
+github.com/eminwux/sbsh v0.10.0 h1:4mNa7UQPmveVS0v5mesnF4RmB1RojV+kPTr50LpcJBI=
+github.com/eminwux/sbsh v0.10.0/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -17,8 +17,10 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/eminwux/kukeon/internal/ctr"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -82,16 +84,28 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName,
 		spec.ID,
 	)
-	if err := os.MkdirAll(ttyDir, 0o0700); err != nil {
+	mode, gid := attachableTTYDirInitialPerms(r.opts.KukeonGroupGID)
+	if err := os.MkdirAll(ttyDir, mode); err != nil {
 		return nil, err
 	}
 	// MkdirAll leaves any pre-existing directory's mode intact and a fresh
-	// dir's mode is filtered by umask, so apply the desired mode explicitly.
-	mode, gid := attachableTTYDirInitialPerms(r.opts.KukeonGroupGID)
+	// dir's mode is filtered by umask, so apply the desired mode explicitly
+	// to both the leaf tty/ dir and its per-container parent. The parent
+	// holds the future per-container metadata.json and is the dir host-side
+	// kuke attach has to traverse to reach the socket inside tty/; a
+	// pre-existing 0o2700 from a daemon predating this fix would otherwise
+	// leave it unreachable to kukeon-group operators.
+	containerDir := filepath.Dir(ttyDir)
+	if err := os.Chmod(containerDir, mode); err != nil {
+		return nil, fmt.Errorf("chmod %q to %v: %w", containerDir, mode, err)
+	}
 	if err := os.Chmod(ttyDir, mode); err != nil {
 		return nil, fmt.Errorf("chmod %q to %v: %w", ttyDir, mode, err)
 	}
 	if gid > 0 {
+		if err := os.Chown(containerDir, 0, gid); err != nil {
+			return nil, fmt.Errorf("chown %q to root:%d: %w", containerDir, gid, err)
+		}
 		if err := os.Chown(ttyDir, 0, gid); err != nil {
 			return nil, fmt.Errorf("chown %q to root:%d: %w", ttyDir, gid, err)
 		}
@@ -114,6 +128,11 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 			SbshBinaryPath: binaryPath,
 			HostTTYDir:     ttyDir,
 			UseProfile:     useProfile,
+			// Plumb the kukeon group GID so the in-container sbsh wrapper
+			// creates the control socket as 0660 root:kukeon — matching the
+			// host-side traversal layout `kuke init` sets up on /opt/kukeon.
+			// Zero falls back to sbsh's hard-coded 0600 owner-only default.
+			SocketGID: r.opts.KukeonGroupGID,
 		}),
 	}, nil
 }
@@ -160,6 +179,27 @@ func (r *Exec) attachablePostCreateChown(spec intmodel.ContainerSpec) error {
 	gid := r.opts.KukeonGroupGID
 	if chownErr := os.Chown(ttyDir, int(uid), gid); chownErr != nil {
 		return fmt.Errorf("chown %q to (uid=%d, gid=%d): %w", ttyDir, uid, gid, chownErr)
+	}
+	// Chown the per-container profile.yaml the runner pre-wrote inside
+	// ttyDir so the in-container sbsh wrapper (running as the resolved
+	// container uid) can open it. The file was created at 0o600 owned by
+	// the daemon (root); without this chown sbsh's profile loader fails
+	// with "permission denied", returns no profiles, and exits with
+	// "Failed to build terminal spec" before ever calling Listen — and the
+	// host-side socket inode the kukeon-group operator needs is never
+	// created. The chmod stays 0o600: the container uid is now the file
+	// owner, so it can read; group=kukeon is preserved by the parent
+	// dir's setgid bit so a future host-side reader path stays consistent.
+	profilePath := filepath.Join(ttyDir, ctr.AttachableProfileFile)
+	switch chownErr := os.Chown(profilePath, int(uid), gid); {
+	case chownErr == nil:
+	case errors.Is(chownErr, os.ErrNotExist):
+		// Container declared no tty block: the runner skipped writing
+		// profile.yaml and there is nothing to chown. The wrapper also
+		// runs without --profile in that case, so sbsh does not look for
+		// the file; this branch is the legacy attachable contract.
+	default:
+		return fmt.Errorf("chown %q to (uid=%d, gid=%d): %w", profilePath, uid, gid, chownErr)
 	}
 	return nil
 }

--- a/internal/ctr/attachable.go
+++ b/internal/ctr/attachable.go
@@ -18,6 +18,7 @@ package ctr
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -67,6 +68,18 @@ const (
 	// AttachableProfileName is the profile.metadata.name written into the
 	// generated TerminalProfile and passed to `sbsh terminal --profile`.
 	AttachableProfileName = "kukeon"
+
+	// AttachableSocketMode is the octal mode passed to `sbsh terminal
+	// --socket-mode` when SocketGID is configured. 0660 = rw for owner
+	// (the container's runtime uid) + rw for group (the kukeon group), no
+	// world. Combined with `--socket-gid <kukeonGID>` this lets a non-root
+	// member of the kukeon group on the host `connect()` to the per-
+	// container sbsh control socket. Linux requires write permission on a
+	// socket inode to connect — group-readable alone is not enough.
+	//
+	// Available since sbsh v0.10.0; older sbsh binaries reject the flag and
+	// the wrapper omits it when the kukeon group GID is unset.
+	AttachableSocketMode = "0660"
 )
 
 // AttachableInjection carries the host-side paths needed to wrap a container's
@@ -90,6 +103,18 @@ type AttachableInjection struct {
 	// the profile YAML to <HostTTYDir>/AttachableProfileFile before the
 	// container starts; the wrapper itself never touches the filesystem.
 	UseProfile bool
+
+	// SocketGID, when non-zero, is the numeric GID of the kukeon system
+	// group on the host. The wrapper emits `sbsh terminal --socket-mode
+	// AttachableSocketMode --socket-gid <SocketGID>` so the per-container
+	// control socket is created with mode 0660 owned by the kukeon group,
+	// matching the group-traversal layout on the parent tty/ directory and
+	// `/opt/kukeon`. Zero (the default) preserves sbsh's hard-coded 0o600
+	// owner-only behavior — the legacy contract for callers that have no
+	// kukeon group configured. Requires sbsh v0.10.0 or later inside the
+	// container; the staged binary at /.kukeon/bin/sbsh must support the
+	// `--socket-mode` and `--socket-gid` flags.
+	SocketGID int
 }
 
 // withAttachableMounts adds the two bind mounts that make sbsh reachable from
@@ -125,7 +150,7 @@ func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 // ENTRYPOINT/CMD) so the wrapped command line is whatever would have run
 // otherwise.
 //
-// When useProfile is true, the wrapper additionally points sbsh at the
+// When inj.UseProfile is true, the wrapper additionally points sbsh at the
 // per-container profile YAML the runner pre-wrote into HostTTYDir, so
 // the generated prompt and onInit scripts take effect on first attach.
 // `--profiles-dir` is a global flag on `sbsh` and must precede the
@@ -133,25 +158,32 @@ func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 // `terminal` and must follow it. Swapping either placement makes sbsh
 // reject the invocation with `unknown flag`.
 //
+// When inj.SocketGID > 0, the wrapper also passes `--socket-mode 0660
+// --socket-gid <SocketGID>` to `sbsh terminal` so the per-container
+// control socket lands as 0660 owned by the kukeon group — without it,
+// sbsh's default 0o600 root-owned socket is unreachable for non-root
+// kukeon-group operators on the host even when the parent tty/ directory
+// is group-traversable. Both flags require sbsh v0.10.0 or later.
+//
 // OCI semantics: process.args is the merged "ENTRYPOINT + CMD" by the time
 // this opt runs (containerd's WithImageConfigArgs has already resolved image
 // defaults and any user override of either). We just wrap the result, which
 // is what Kubernetes failed to do correctly for years and what this issue
 // explicitly tests.
-func withAttachableArgsWrap(useProfile bool) oci.SpecOpts {
+func withAttachableArgsWrap(inj AttachableInjection) oci.SpecOpts {
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
 		if s.Process == nil {
 			s.Process = &runtimespec.Process{}
 		}
 		original := append([]string(nil), s.Process.Args...)
 		wrapped := []string{AttachableBinaryPath}
-		if useProfile {
+		if inj.UseProfile {
 			wrapped = append(wrapped,
 				"--profiles-dir", AttachableTTYDir,
 			)
 		}
 		wrapped = append(wrapped, AttachableSubcommand)
-		if useProfile {
+		if inj.UseProfile {
 			wrapped = append(wrapped, "--profile", AttachableProfileName)
 		}
 		wrapped = append(wrapped,
@@ -159,8 +191,14 @@ func withAttachableArgsWrap(useProfile bool) oci.SpecOpts {
 			"--socket", AttachableSocketPath,
 			"--capture-file", AttachableCapturePath,
 			"--log-file", AttachableLogfilePath,
-			"--",
 		)
+		if inj.SocketGID > 0 {
+			wrapped = append(wrapped,
+				"--socket-mode", AttachableSocketMode,
+				"--socket-gid", strconv.Itoa(inj.SocketGID),
+			)
+		}
+		wrapped = append(wrapped, "--")
 		s.Process.Args = append(wrapped, original...)
 		return nil
 	}

--- a/internal/ctr/attachable_test.go
+++ b/internal/ctr/attachable_test.go
@@ -313,6 +313,77 @@ func TestBuildContainerSpec_AttachableTrue_EmptyImageArgs(t *testing.T) {
 	}
 }
 
+// TestBuildContainerSpec_AttachableTrue_SocketFlagsEmittedWithGID covers the
+// kukeon-group attach end-to-end fix: when AttachableInjection.SocketGID is
+// non-zero, the wrapper appends `--socket-mode 0660 --socket-gid <gid>` to
+// the `sbsh terminal` invocation, immediately before the `--` workload
+// separator. Without these flags sbsh's control socket lands at 0o600
+// root-only and is unreachable to non-root members of the kukeon group on
+// the host even when the parent tty/ directory is group-traversable —
+// Linux requires write permission on the socket inode to connect.
+func TestBuildContainerSpec_AttachableTrue_SocketFlagsEmittedWithGID(t *testing.T) {
+	in := intmodel.ContainerSpec{
+		ID:         "c1",
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Attachable: true,
+	}
+	inj := ctr.AttachableInjection{
+		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
+		SocketGID:      986,
+	}
+	spec := applyBuiltSpecWith(t, in, []string{"/bin/sh"}, ctr.WithAttachableInjection(inj))
+
+	want := []string{
+		ctr.AttachableBinaryPath,
+		ctr.AttachableSubcommand,
+		"--run-path", ctr.AttachableTTYDir,
+		"--socket", ctr.AttachableSocketPath,
+		"--capture-file", ctr.AttachableCapturePath,
+		"--log-file", ctr.AttachableLogfilePath,
+		"--socket-mode", ctr.AttachableSocketMode,
+		"--socket-gid", "986",
+		"--",
+		"/bin/sh",
+	}
+	if !reflect.DeepEqual(spec.Process.Args, want) {
+		t.Fatalf("Process.Args = %v\nwant %v", spec.Process.Args, want)
+	}
+}
+
+// TestBuildContainerSpec_AttachableTrue_NoSocketFlagsWhenGIDUnset locks the
+// legacy fallback: with no kukeon group GID configured (SocketGID = 0) the
+// wrapper omits `--socket-mode` and `--socket-gid` so sbsh applies its
+// hard-coded 0o600 owner-only default — a host without sysuser.EnsureUserGroup
+// has no group to delegate access to, and we must not accidentally invoke
+// flags introduced in sbsh v0.10.0 against an older staged binary either.
+func TestBuildContainerSpec_AttachableTrue_NoSocketFlagsWhenGIDUnset(t *testing.T) {
+	in := intmodel.ContainerSpec{
+		ID:         "c1",
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Attachable: true,
+	}
+	inj := ctr.AttachableInjection{
+		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
+	}
+	spec := applyBuiltSpecWith(t, in, []string{"/bin/sh"}, ctr.WithAttachableInjection(inj))
+
+	for _, arg := range spec.Process.Args {
+		if arg == "--socket-mode" || arg == "--socket-gid" {
+			t.Fatalf("expected no socket flags when SocketGID=0, got %v", spec.Process.Args)
+		}
+	}
+}
+
 func findMount(spec *runtimespec.Spec, dest string) *runtimespec.Mount {
 	for i := range spec.Mounts {
 		if spec.Mounts[i].Destination == dest {

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -284,7 +284,7 @@ func BuildContainerSpec(
 		specOpts = append(
 			specOpts,
 			withAttachableMounts(opts.attachable),
-			withAttachableArgsWrap(opts.attachable.UseProfile),
+			withAttachableArgsWrap(opts.attachable),
 		)
 	}
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -27,6 +27,14 @@ import (
 	"github.com/eminwux/kukeon/internal/errdefs"
 )
 
+// metadataDirMode is the mode applied to the parent directory of a
+// metadata file: setgid + rwx-r-x---. The setgid bit lets newly-created
+// children inherit the kukeon group, matching the `/opt/kukeon` layout
+// `kuke init` sets up via sysuser.ChownTreeAndChmod. Group-traverse +
+// no-world-access keeps the host-side path reachable for kukeon-group
+// operators without exposing it to anyone else.
+const metadataDirMode os.FileMode = os.ModeSetgid | 0o0750
+
 func existsFilePath(filepath string) bool {
 	_, err := os.Stat(filepath)
 	if err == nil {
@@ -52,9 +60,22 @@ func WriteMetadata(ctx context.Context, logger *slog.Logger, metadata any, file 
 		return nil
 	}
 
-	if err := os.MkdirAll(filepath.Dir(file), 0o700); err != nil {
+	parentDir := filepath.Dir(file)
+	if err := os.MkdirAll(parentDir, metadataDirMode); err != nil {
 		logger.ErrorContext(ctx, "failed to write metadata dir", "file", file, "error", err)
 		return fmt.Errorf("mkdir terminal dir: %w", err)
+	}
+	// MkdirAll honors only the rwx permission bits — Linux silently strips
+	// the explicit setgid bit unless it's inherited from the parent (and
+	// /tmp on test hosts has no setgid, breaking the inheritance chain).
+	// Apply it after the fact so a newly-created cell or per-container dir
+	// is host-side traversable for the kukeon group, matching the layout
+	// `kuke init` sets up on /opt/kukeon. Existing dirs are re-chmoded to
+	// the canonical mode — idempotent and self-healing for hosts upgraded
+	// from a daemon that wrote 0o2700 (issue #260 gate 2).
+	if err := os.Chmod(parentDir, metadataDirMode|os.ModeSetgid); err != nil {
+		logger.ErrorContext(ctx, "failed to chmod metadata dir", "dir", parentDir, "error", err)
+		return fmt.Errorf("chmod metadata dir: %w", err)
 	}
 
 	err := writeMetadataFile(ctx, logger, metadata, file)

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/metadata"
+)
+
+// TestWriteMetadata_ParentDirModeIsGroupTraversable locks the dir mode
+// applied to the metadata file's parent: 02750 (setgid + rwx-r-x---) so
+// the kukeon group can traverse newly-created cell and per-container
+// metadata directories on the host. The pre-fix mode was 0700 root-only,
+// which combined with the parent's setgid bit produced 02700 — blocking
+// kukeon-group operators from reaching the per-container sbsh socket even
+// when the leaf tty/ dir itself was group-traversable (issue #260 gate 2).
+//
+// Linux's mkdir(2) silently strips an explicit S_ISGID from `mode` unless
+// the parent directory itself has setgid (and /tmp on test hosts does not),
+// so WriteMetadata applies the bit via an explicit chmod after MkdirAll.
+// Each metadata-write level (realm → space → stack → cell → container)
+// fixes its own immediate parent that way; in production, repeated writes
+// up the tree ensure every intermediate dir ends up group-traversable.
+func TestWriteMetadata_ParentDirModeIsGroupTraversable(t *testing.T) {
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "cell", "metadata.json")
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	doc := struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+	}{APIVersion: "kukeon/v1beta1", Kind: "Cell"}
+
+	if err := metadata.WriteMetadata(context.Background(), logger, doc, target); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	parent := filepath.Join(tmp, "cell")
+	info, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("stat %q: %v", parent, err)
+	}
+	mode := info.Mode()
+	if mode&os.ModeSetgid == 0 {
+		t.Errorf("dir %q mode %v missing setgid bit", parent, mode)
+	}
+	if mode.Perm() != 0o0750 {
+		t.Errorf("dir %q perm bits = %#o, want 0o750", parent, mode.Perm())
+	}
+}
+
+// TestWriteMetadata_ChmodIsIdempotent_OnReuse covers the upgrade path: a
+// host whose pre-#260 daemon left a cell directory at the legacy 0o2700
+// (or 0o700) gets self-healed when the daemon writes the cell metadata
+// again — the chmod runs unconditionally, not just on fresh MkdirAll.
+func TestWriteMetadata_ChmodIsIdempotent_OnReuse(t *testing.T) {
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "cell")
+	if err := os.MkdirAll(parent, 0o0700); err != nil {
+		t.Fatalf("seed MkdirAll: %v", err)
+	}
+	target := filepath.Join(parent, "metadata.json")
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	doc := struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+	}{APIVersion: "kukeon/v1beta1", Kind: "Cell"}
+
+	if err := metadata.WriteMetadata(context.Background(), logger, doc, target); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	info, err := os.Stat(parent)
+	if err != nil {
+		t.Fatalf("stat %q: %v", parent, err)
+	}
+	if info.Mode().Perm() != 0o0750 {
+		t.Errorf("perm bits = %#o, want 0o750 after self-heal", info.Mode().Perm())
+	}
+	if info.Mode()&os.ModeSetgid == 0 {
+		t.Errorf("setgid bit missing after self-heal: mode %v", info.Mode())
+	}
+}


### PR DESCRIPTION
## Summary
- Closes the three permission gates that survived #258 and still blocked `kuke run -a -p claude` for an unprivileged member of the `kukeon` group on `main`.
- **Gate 1 (profile.yaml unreadable to in-container USER):** `attachablePostCreateChown` now also chowns `<tty>/profile.yaml` to the resolved container uid. Mode stays `0o600` — the container's runtime uid is now the file owner, so sbsh's profile loader can open it and reach `Listen()`. Without this, sbsh died with `Failed to build terminal spec` before ever creating the socket inode.
- **Gate 2 (cell + per-container parent dirs at `0o2700`):** `metadata.WriteMetadata`'s `MkdirAll` now uses `0o0750` and explicitly chmods the metadata file's parent to `os.ModeSetgid|0o0750` after the fact (Linux silently strips an explicit `S_ISGID` from `mkdir`'s mode unless inherited from the parent). `attachableBuildOpts` likewise chmods the per-container parent of `tty/` to the same group-traversable mode. Self-healing: existing dirs are re-chmoded on next write.
- **Gate 3 (sbsh socket hard-coded `0o600`):** bumps `github.com/eminwux/sbsh` to `v0.10.0` (which adds `--socket-mode`/`--socket-gid`) and plumbs `SocketGID` through `AttachableInjection` so the wrapper passes `--socket-mode 0660 --socket-gid <kukeonGID>` to `sbsh terminal` whenever `KukeonGroupGID > 0`. Default behavior preserved when GID is unset.
- End-to-end repro from the issue (`kuke run -a -p claude` as user in the `kukeon` group) now reaches the `claude>` prompt; on-disk verifies `<cell>/`, `<cell>/<container>/`, `<container>/tty/` all `drwxr-s---` `root:kukeon` (or `<uid>:kukeon` after the post-create chown), `profile.yaml` `0o600 <uid>:kukeon`, and `socket` `srw-rw---- <uid>:kukeon`.

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] `make test` (full unit suite minus `/e2e`) — green
- [x] New `TestBuildContainerSpec_AttachableTrue_SocketFlagsEmittedWithGID` and `TestBuildContainerSpec_AttachableTrue_NoSocketFlagsWhenGIDUnset` lock the wrapper's flag emission both ways
- [x] New `TestWriteMetadata_ParentDirModeIsGroupTraversable` and `TestWriteMetadata_ChmodIsIdempotent_OnReuse` cover the metadata-dir mode fix on fresh and pre-existing dirs
- [x] `make dev-init` — daemon-parity check passes (both `kuke get realms` and `--no-daemon` produce identical Ready output for `default` and `kuke-system`)
- [x] Manual end-to-end: `kuke run -a -p claude` as `inwx` (uid 1000, in `kukeon` gid 986) reaches the `claude>` prompt; permission denied on the socket connect is gone
- [ ] `make e2e` — not run locally; CI

## Notes
- The staged `/opt/kukeon/cache/sbsh/<arch>/sbsh` binary must be sbsh `v0.10.0` or later for the new flags to be honored. The wrapper omits the flags when `KukeonGroupGID = 0`, so a daemon initialized without `kuke init`'s sysuser bootstrap stays compatible with older sbsh binaries.

Closes #260