### PR TITLE
feat: add kukeond background cell-reconciliation loop

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -111,6 +111,10 @@ var (
 	KUKEOND_CONFIGURATION = DefineKV(
 		"KUKEOND_CONFIGURATION", "kukeond/configuration", "/etc/kukeon/kukeond.yaml",
 	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKEOND_RECONCILE_INTERVAL = DefineKV(
+		"KUKEOND_RECONCILE_INTERVAL", "kukeond/reconcileInterval", "30s",
+	)
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_INIT_REALM = DefineKV("KUKE_INIT_REALM", "kuke/init/realm")

--- a/cmd/kuke/uninstall/uninstall_test.go
+++ b/cmd/kuke/uninstall/uninstall_test.go
@@ -165,6 +165,9 @@ func (s *stubController) PurgeContainer(intmodel.Container) (controller.PurgeCon
 	panic("not used")
 }
 func (s *stubController) RefreshAll() (controller.RefreshResult, error) { panic("not used") }
+func (s *stubController) ReconcileCells() (controller.ReconcileResult, error) {
+	panic("not used")
+}
 
 // runCmd builds the cobra command, plugs in a stub controller and a logger,
 // and feeds the supplied stdin payload. Returns the captured stdout/stderr

--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -124,6 +124,17 @@ func NewKukeondCmd() (*cobra.Command, error) {
 		return nil, err
 	}
 
+	cmd.PersistentFlags().String(
+		"reconcile-interval", config.KUKEOND_RECONCILE_INTERVAL.Default,
+		"Period of the cell-reconciliation loop (Go duration; 0 disables)",
+	)
+	if err := viper.BindPFlag(
+		config.KUKEOND_RECONCILE_INTERVAL.ViperKey,
+		cmd.PersistentFlags().Lookup("reconcile-interval"),
+	); err != nil {
+		return nil, err
+	}
+
 	bindEnvVars()
 
 	cmd.AddCommand(newServeCmd())
@@ -142,6 +153,7 @@ func bindEnvVars() {
 		config.KUKEON_ROOT_LOG_LEVEL,
 		config.KUKEOND_SOCKET,
 		config.KUKEOND_SOCKET_GID,
+		config.KUKEOND_RECONCILE_INTERVAL,
 	} {
 		_ = v.BindEnv()
 	}
@@ -170,6 +182,11 @@ func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurati
 	}
 	if spec.LogLevel != "" && !flagChanged(cmd, "log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
+	}
+	if spec.ReconcileInterval != "" &&
+		!flagChanged(cmd, "reconcile-interval") &&
+		!envSet(config.KUKEOND_RECONCILE_INTERVAL) {
+		viper.Set(config.KUKEOND_RECONCILE_INTERVAL.ViperKey, spec.ReconcileInterval)
 	}
 }
 

--- a/cmd/kukeond/kukeond_test.go
+++ b/cmd/kukeond/kukeond_test.go
@@ -49,11 +49,12 @@ func TestApplyServerConfigurationDefaultsLayered(t *testing.T) {
 	}
 
 	spec := v1beta1.ServerConfigurationSpec{
-		Socket:           "/run/kukeon/from-config.sock",
-		SocketGID:        4242,
-		RunPath:          "/opt/kukeon-from-config",
-		ContainerdSocket: "/run/containerd/from-config.sock",
-		LogLevel:         "warn",
+		Socket:            "/run/kukeon/from-config.sock",
+		SocketGID:         4242,
+		RunPath:           "/opt/kukeon-from-config",
+		ContainerdSocket:  "/run/containerd/from-config.sock",
+		LogLevel:          "warn",
+		ReconcileInterval: "45s",
 	}
 	applyServerConfiguration(cmd, spec)
 
@@ -71,6 +72,9 @@ func TestApplyServerConfigurationDefaultsLayered(t *testing.T) {
 	}
 	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != spec.LogLevel {
 		t.Errorf("LogLevel: got %q, want %q", got, spec.LogLevel)
+	}
+	if got := viper.GetString(config.KUKEOND_RECONCILE_INTERVAL.ViperKey); got != spec.ReconcileInterval {
+		t.Errorf("ReconcileInterval: got %q, want %q", got, spec.ReconcileInterval)
 	}
 }
 

--- a/cmd/kukeond/serve.go
+++ b/cmd/kukeond/serve.go
@@ -17,11 +17,13 @@
 package kukeond
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/internal/controller"
@@ -78,11 +80,14 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		socketMode = socketModeGroupReadable
 	}
 
+	reconcileInterval := parseReconcileInterval(logger, cmd.Context())
+
 	opts := daemon.Options{
-		SocketPath: socketPath,
-		SocketMode: socketMode,
-		SocketGID:  socketGID,
-		PIDFile:    filepath.Join(runPath, "kukeond.pid"),
+		SocketPath:        socketPath,
+		SocketMode:        socketMode,
+		SocketGID:         socketGID,
+		PIDFile:           filepath.Join(runPath, "kukeond.pid"),
+		ReconcileInterval: reconcileInterval,
 		Controller: controller.Options{
 			RunPath:          runPath,
 			ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
@@ -118,4 +123,26 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	}
 	logger.InfoContext(cmd.Context(), "kukeond stopped")
 	return nil
+}
+
+// parseReconcileInterval reads the resolved reconcile-interval string out of
+// viper and parses it as a Go time.Duration. An empty value or a parse
+// failure logs a warning and falls back to the in-binary default so a typo
+// in the YAML never blocks the daemon from starting. A zero or negative
+// duration disables the loop on purpose — Server.startReconcileLoop honors
+// that and emits a "reconcile loop disabled" line.
+func parseReconcileInterval(logger *slog.Logger, ctx context.Context) time.Duration {
+	raw := viper.GetString(config.KUKEOND_RECONCILE_INTERVAL.ViperKey)
+	if raw == "" {
+		raw = config.KUKEOND_RECONCILE_INTERVAL.Default
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		fallback, _ := time.ParseDuration(config.KUKEOND_RECONCILE_INTERVAL.Default)
+		logger.WarnContext(ctx,
+			"invalid reconcile-interval; falling back to default",
+			"value", raw, "error", err, "fallback", fallback)
+		return fallback
+	}
+	return d
 }

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -762,6 +762,15 @@ func (c *Client) PurgeContainer(_ context.Context, doc v1beta1.ContainerDoc) (ku
 	}, nil
 }
 
+// ---- Reconcile ----
+
+// ReconcileCells runs one pass of the daemon-side cell reconciliation loop.
+// Daemon-internal: not surfaced over the kukeonv1 wire — `kuke refresh` is
+// the on-demand, all-resources counterpart that clients use.
+func (c *Client) ReconcileCells() (controller.ReconcileResult, error) {
+	return c.ctrl.ReconcileCells()
+}
+
 // ---- Refresh ----
 
 func (c *Client) RefreshAll(_ context.Context) (kukeonv1.RefreshAllResult, error) {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -60,6 +60,7 @@ type Controller interface {
 	PurgeCell(cell intmodel.Cell, force, cascade bool) (PurgeCellResult, error)
 	PurgeContainer(container intmodel.Container) (PurgeContainerResult, error)
 	RefreshAll() (RefreshResult, error)
+	ReconcileCells() (ReconcileResult, error)
 	Uninstall(opts UninstallOptions) (UninstallReport, error)
 	Close() error
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -108,10 +108,11 @@ type fakeRunner struct {
 	UpdateContainerFn func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
 
 	// Refresh methods
-	RefreshRealmFn func(realm intmodel.Realm) (intmodel.Realm, bool, error)
-	RefreshSpaceFn func(space intmodel.Space) (intmodel.Space, bool, error)
-	RefreshStackFn func(stack intmodel.Stack) (intmodel.Stack, bool, error)
-	RefreshCellFn  func(cell intmodel.Cell) (intmodel.Cell, int, error)
+	RefreshRealmFn  func(realm intmodel.Realm) (intmodel.Realm, bool, error)
+	RefreshSpaceFn  func(space intmodel.Space) (intmodel.Space, bool, error)
+	RefreshStackFn  func(stack intmodel.Stack) (intmodel.Stack, bool, error)
+	RefreshCellFn   func(cell intmodel.Cell) (intmodel.Cell, int, error)
+	ReconcileCellFn func(cell intmodel.Cell) (intmodel.Cell, bool, error)
 
 	// Image methods
 	LoadImageFn   func(namespace string, reader io.Reader) ([]string, error)
@@ -538,6 +539,13 @@ func (f *fakeRunner) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error)
 		return f.RefreshCellFn(cell)
 	}
 	return intmodel.Cell{}, 0, errors.New("unexpected call to RefreshCell")
+}
+
+func (f *fakeRunner) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, bool, error) {
+	if f.ReconcileCellFn != nil {
+		return f.ReconcileCellFn(cell)
+	}
+	return intmodel.Cell{}, false, errors.New("unexpected call to ReconcileCell")
 }
 
 func (f *fakeRunner) LoadImage(namespace string, reader io.Reader) ([]string, error) {

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import "fmt"
+
+// ReconcileResult summarizes a single pass of the daemon's background
+// cell-reconciliation loop. Counts are scoped to cells (v1 of #161 is
+// cell-only); per-pass errors are collected so the loop can keep ticking.
+type ReconcileResult struct {
+	CellsScanned int
+	CellsUpdated int
+	CellsErrored int
+	Errors       []string
+}
+
+// ReconcileCells walks every realm/space/stack and reconciles each cell's
+// status against observed container state. Errors at any level are logged
+// and recorded in Errors; the walk continues so a single bad cell does not
+// silence the rest of the host.
+func (b *Exec) ReconcileCells() (ReconcileResult, error) {
+	result := ReconcileResult{Errors: []string{}}
+
+	realms, err := b.runner.ListRealms()
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("list realms: %v", err))
+		return result, nil
+	}
+
+	for _, realm := range realms {
+		realmName := realm.Metadata.Name
+		spaces, listErr := b.runner.ListSpaces(realmName)
+		if listErr != nil {
+			result.Errors = append(result.Errors,
+				fmt.Sprintf("list spaces in realm %q: %v", realmName, listErr))
+			continue
+		}
+		for _, space := range spaces {
+			spaceName := space.Metadata.Name
+			stacks, stacksErr := b.runner.ListStacks(realmName, spaceName)
+			if stacksErr != nil {
+				result.Errors = append(result.Errors,
+					fmt.Sprintf("list stacks in %s/%s: %v", realmName, spaceName, stacksErr))
+				continue
+			}
+			for _, stack := range stacks {
+				stackName := stack.Metadata.Name
+				cells, cellsErr := b.runner.ListCells(realmName, spaceName, stackName)
+				if cellsErr != nil {
+					result.Errors = append(result.Errors,
+						fmt.Sprintf("list cells in %s/%s/%s: %v",
+							realmName, spaceName, stackName, cellsErr))
+					continue
+				}
+				for _, cell := range cells {
+					result.CellsScanned++
+					_, updated, reconcileErr := b.runner.ReconcileCell(cell)
+					if reconcileErr != nil {
+						result.CellsErrored++
+						result.Errors = append(result.Errors,
+							fmt.Sprintf("reconcile cell %s/%s/%s/%s: %v",
+								realmName, spaceName, stackName,
+								cell.Metadata.Name, reconcileErr))
+						continue
+					}
+					if updated {
+						result.CellsUpdated++
+					}
+				}
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -1,0 +1,182 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+func TestReconcileCells_WalksEveryRealmSpaceStackCell(t *testing.T) {
+	realmA := buildTestRealm("realm-a", "")
+	realmB := buildTestRealm("realm-b", "")
+	spaceA := buildTestSpace("space-a", "realm-a")
+	spaceB := buildTestSpace("space-b", "realm-b")
+	stackA := buildTestStack("stack-a", "realm-a", "space-a")
+	stackB := buildTestStack("stack-b", "realm-b", "space-b")
+	cellA := buildTestCell("cell-a", "realm-a", "space-a", "stack-a")
+	cellB := buildTestCell("cell-b", "realm-b", "space-b", "stack-b")
+
+	var reconcileCalls atomic.Int32
+	mock := &fakeRunner{
+		ListRealmsFn: func() ([]intmodel.Realm, error) {
+			return []intmodel.Realm{realmA, realmB}, nil
+		},
+		ListSpacesFn: func(realm string) ([]intmodel.Space, error) {
+			switch realm {
+			case "realm-a":
+				return []intmodel.Space{spaceA}, nil
+			case "realm-b":
+				return []intmodel.Space{spaceB}, nil
+			}
+			return nil, nil
+		},
+		ListStacksFn: func(realm, space string) ([]intmodel.Stack, error) {
+			switch {
+			case realm == "realm-a" && space == "space-a":
+				return []intmodel.Stack{stackA}, nil
+			case realm == "realm-b" && space == "space-b":
+				return []intmodel.Stack{stackB}, nil
+			}
+			return nil, nil
+		},
+		ListCellsFn: func(realm, space, stack string) ([]intmodel.Cell, error) {
+			switch {
+			case realm == "realm-a" && space == "space-a" && stack == "stack-a":
+				return []intmodel.Cell{cellA}, nil
+			case realm == "realm-b" && space == "space-b" && stack == "stack-b":
+				return []intmodel.Cell{cellB}, nil
+			}
+			return nil, nil
+		},
+		ReconcileCellFn: func(cell intmodel.Cell) (intmodel.Cell, bool, error) {
+			reconcileCalls.Add(1)
+			return cell, true, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileCells()
+	if err != nil {
+		t.Fatalf("ReconcileCells() error = %v", err)
+	}
+	if got := reconcileCalls.Load(); got != 2 {
+		t.Errorf("ReconcileCell calls: got %d, want 2", got)
+	}
+	if res.CellsScanned != 2 {
+		t.Errorf("CellsScanned: got %d, want 2", res.CellsScanned)
+	}
+	if res.CellsUpdated != 2 {
+		t.Errorf("CellsUpdated: got %d, want 2", res.CellsUpdated)
+	}
+	if res.CellsErrored != 0 {
+		t.Errorf("CellsErrored: got %d, want 0", res.CellsErrored)
+	}
+	if len(res.Errors) != 0 {
+		t.Errorf("Errors: got %v, want empty", res.Errors)
+	}
+}
+
+func TestReconcileCells_PerCellErrorDoesNotAbortWalk(t *testing.T) {
+	realm := buildTestRealm("realm-a", "")
+	space := buildTestSpace("space-a", "realm-a")
+	stack := buildTestStack("stack-a", "realm-a", "space-a")
+	good := buildTestCell("good", "realm-a", "space-a", "stack-a")
+	bad := buildTestCell("bad", "realm-a", "space-a", "stack-a")
+
+	var reconcileCalls atomic.Int32
+	mock := &fakeRunner{
+		ListRealmsFn: func() ([]intmodel.Realm, error) { return []intmodel.Realm{realm}, nil },
+		ListSpacesFn: func(string) ([]intmodel.Space, error) { return []intmodel.Space{space}, nil },
+		ListStacksFn: func(string, string) ([]intmodel.Stack, error) {
+			return []intmodel.Stack{stack}, nil
+		},
+		ListCellsFn: func(string, string, string) ([]intmodel.Cell, error) {
+			return []intmodel.Cell{bad, good}, nil
+		},
+		ReconcileCellFn: func(cell intmodel.Cell) (intmodel.Cell, bool, error) {
+			reconcileCalls.Add(1)
+			if cell.Metadata.Name == "bad" {
+				return cell, false, errors.New("synthetic reconcile failure")
+			}
+			return cell, true, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileCells()
+	if err != nil {
+		t.Fatalf("ReconcileCells() error = %v", err)
+	}
+	if got := reconcileCalls.Load(); got != 2 {
+		t.Errorf("ReconcileCell calls: got %d, want 2 (the failing cell must not abort the walk)", got)
+	}
+	if res.CellsScanned != 2 {
+		t.Errorf("CellsScanned: got %d, want 2", res.CellsScanned)
+	}
+	if res.CellsUpdated != 1 {
+		t.Errorf("CellsUpdated: got %d, want 1", res.CellsUpdated)
+	}
+	if res.CellsErrored != 1 {
+		t.Errorf("CellsErrored: got %d, want 1", res.CellsErrored)
+	}
+	if len(res.Errors) != 1 {
+		t.Errorf("Errors: got %v, want 1 entry", res.Errors)
+	}
+	if len(res.Errors) == 1 && !strings.Contains(res.Errors[0], "bad") {
+		t.Errorf("error string should name the failing cell, got %q", res.Errors[0])
+	}
+}
+
+func TestReconcileCells_ListRealmsErrorIsRecorded(t *testing.T) {
+	mock := &fakeRunner{
+		ListRealmsFn: func() ([]intmodel.Realm, error) {
+			return nil, errors.New("containerd unreachable")
+		},
+	}
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileCells()
+	if err != nil {
+		t.Fatalf("ReconcileCells() must not return a hard error on a list-realms failure (loop must keep ticking next pass): %v", err)
+	}
+	if len(res.Errors) != 1 {
+		t.Errorf("Errors: got %v, want 1 entry", res.Errors)
+	}
+	if res.CellsScanned != 0 {
+		t.Errorf("CellsScanned: got %d, want 0", res.CellsScanned)
+	}
+}
+
+func TestReconcileCells_EmptyHostNoOp(t *testing.T) {
+	mock := &fakeRunner{
+		ListRealmsFn: func() ([]intmodel.Realm, error) { return nil, nil },
+	}
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileCells()
+	if err != nil {
+		t.Fatalf("ReconcileCells() error = %v", err)
+	}
+	if res.CellsScanned != 0 || res.CellsUpdated != 0 || res.CellsErrored != 0 {
+		t.Errorf("expected zero counters, got %+v", res)
+	}
+}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -355,11 +355,7 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 // see up-to-date per-container state.
 func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, bool, error) {
 	originalStatus := cell.Status
-	newStatus := intmodel.CellStatus{
-		State:      intmodel.CellStateUnknown,
-		CgroupPath: originalStatus.CgroupPath,
-		Network:    originalStatus.Network,
-	}
+	newState := intmodel.CellStateUnknown
 
 	cgroupExists, cgroupErr := r.ExistsCgroup(cell)
 	switch {
@@ -367,20 +363,19 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, bool, error) {
 		r.logger.DebugContext(r.ctx, "failed to check cell cgroup",
 			"cell", cell.Metadata.Name, "error", cgroupErr)
 	case !cgroupExists:
-		newStatus.State = intmodel.CellStateUnknown
+		newState = intmodel.CellStateUnknown
 	default:
-		newStatus.State = r.deriveCellStateFromRootContainer(cell)
+		newState = r.deriveCellStateFromRootContainer(cell)
 	}
 
 	if err := r.populateCellContainerStatuses(&cell); err != nil {
 		r.logger.DebugContext(r.ctx, "populate container statuses failed",
 			"cell", cell.Metadata.Name, "error", err)
 	}
-	cell.Status.State = newStatus.State
-	cell.Status.CgroupPath = newStatus.CgroupPath
+	cell.Status.State = newState
 
 	updated := false
-	if originalStatus.State != cell.Status.State || originalStatus.CgroupPath != cell.Status.CgroupPath {
+	if originalStatus.State != cell.Status.State {
 		updated = true
 	}
 	if !containerStatusesEqual(originalStatus.Containers, cell.Status.Containers) {

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -337,3 +337,115 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 
 	return updated, nil
 }
+
+// ReconcileCell is the daemon-side counterpart to RefreshCell. Where
+// RefreshCell derives cell.Status.State from cgroup existence alone (so
+// `kuke refresh` keeps its current shape), ReconcileCell additionally
+// considers the root container's task state — which is what flips a Ready
+// cell to Stopped when an operator runs `ctr task kill` outside of kukeon.
+//
+// State derivation:
+//   - cgroup check error or cgroup absent → Unknown
+//   - cgroup present, no root container in spec → Ready (cgroup-only cell)
+//   - cgroup present, root container task running/created/paused → Ready
+//   - cgroup present, root container missing in containerd or task
+//     stopped/unknown → Stopped
+//
+// Container statuses are also re-populated so callers (and `kuke get cell`)
+// see up-to-date per-container state.
+func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, bool, error) {
+	originalStatus := cell.Status
+	newStatus := intmodel.CellStatus{
+		State:      intmodel.CellStateUnknown,
+		CgroupPath: originalStatus.CgroupPath,
+		Network:    originalStatus.Network,
+	}
+
+	cgroupExists, cgroupErr := r.ExistsCgroup(cell)
+	switch {
+	case cgroupErr != nil:
+		r.logger.DebugContext(r.ctx, "failed to check cell cgroup",
+			"cell", cell.Metadata.Name, "error", cgroupErr)
+	case !cgroupExists:
+		newStatus.State = intmodel.CellStateUnknown
+	default:
+		newStatus.State = r.deriveCellStateFromRootContainer(cell)
+	}
+
+	if err := r.populateCellContainerStatuses(&cell); err != nil {
+		r.logger.DebugContext(r.ctx, "populate container statuses failed",
+			"cell", cell.Metadata.Name, "error", err)
+	}
+	cell.Status.State = newStatus.State
+	cell.Status.CgroupPath = newStatus.CgroupPath
+
+	updated := false
+	if originalStatus.State != cell.Status.State || originalStatus.CgroupPath != cell.Status.CgroupPath {
+		updated = true
+	}
+	if !containerStatusesEqual(originalStatus.Containers, cell.Status.Containers) {
+		updated = true
+	}
+
+	if updated {
+		if updateErr := r.UpdateCellMetadata(cell); updateErr != nil {
+			return cell, false, fmt.Errorf("failed to update cell metadata: %w", updateErr)
+		}
+	}
+	return cell, updated, nil
+}
+
+// deriveCellStateFromRootContainer resolves the cell's state from the root
+// container's task. Returns Ready when no root container is configured (a
+// cgroup-only cell counts as Ready by cgroup existence).
+func (r *Exec) deriveCellStateFromRootContainer(cell intmodel.Cell) intmodel.CellState {
+	rootSpec := findRootContainerSpec(cell)
+	if rootSpec == nil {
+		return intmodel.CellStateReady
+	}
+	state, err := r.GetContainerState(cell, rootSpec.ID)
+	if err != nil {
+		r.logger.DebugContext(r.ctx, "reconcile: failed to read root container state",
+			"cell", cell.Metadata.Name, "container", rootSpec.ID, "error", err)
+		return intmodel.CellStateUnknown
+	}
+	switch state {
+	case intmodel.ContainerStateReady,
+		intmodel.ContainerStatePending,
+		intmodel.ContainerStatePaused,
+		intmodel.ContainerStatePausing:
+		return intmodel.CellStateReady
+	case intmodel.ContainerStateStopped, intmodel.ContainerStateFailed:
+		return intmodel.CellStateStopped
+	default:
+		return intmodel.CellStateUnknown
+	}
+}
+
+func findRootContainerSpec(cell intmodel.Cell) *intmodel.ContainerSpec {
+	for i := range cell.Spec.Containers {
+		if cell.Spec.Containers[i].Root {
+			return &cell.Spec.Containers[i]
+		}
+	}
+	if cell.Spec.RootContainerID != "" {
+		for i := range cell.Spec.Containers {
+			if cell.Spec.Containers[i].ID == cell.Spec.RootContainerID {
+				return &cell.Spec.Containers[i]
+			}
+		}
+	}
+	return nil
+}
+
+func containerStatusesEqual(a, b []intmodel.ContainerStatus) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].ID != b[i].ID || a[i].State != b[i].State {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -93,6 +93,11 @@ type Runner interface {
 	RefreshSpace(space intmodel.Space) (intmodel.Space, bool, error)
 	RefreshStack(stack intmodel.Stack) (intmodel.Stack, bool, error)
 	RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error)
+	// ReconcileCell is the daemon-side counterpart to RefreshCell: it
+	// re-derives the cell's status from cgroup + root-container task state
+	// (so a Ready cell whose root task exits externally flips to Stopped).
+	// Returns the updated cell, whether persistence ran, and any error.
+	ReconcileCell(cell intmodel.Cell) (intmodel.Cell, bool, error)
 
 	GetContainerState(cell intmodel.Cell, containerID string) (intmodel.ContainerState, error)
 

--- a/internal/daemon/reconcile_test.go
+++ b/internal/daemon/reconcile_test.go
@@ -106,7 +106,9 @@ func TestServer_ReconcileLoopStopsWithContext(t *testing.T) {
 
 func newTestServer(t *testing.T, interval time.Duration) *Server {
 	t.Helper()
-	return newTestServerWithCtx(t, context.Background(), interval)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return newTestServerWithCtx(t, ctx, interval)
 }
 
 func newTestServerWithCtx(t *testing.T, ctx context.Context, interval time.Duration) *Server {

--- a/internal/daemon/reconcile_test.go
+++ b/internal/daemon/reconcile_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/controller"
+)
+
+// TestServer_ReconcileLoopFires confirms the daemon's background ticker
+// invokes ReconcileCells repeatedly when ReconcileInterval > 0 — the
+// minimum signal that #161 AC #1 is live (kukeond runs a background ticker
+// that, on every tick, reconciles each cell).
+func TestServer_ReconcileLoopFires(t *testing.T) {
+	srv := newTestServer(t, 20*time.Millisecond)
+	var calls atomic.Int32
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		calls.Add(1)
+		return controller.ReconcileResult{CellsScanned: 3}, nil
+	}
+
+	startServer(t, srv)
+	waitForCalls(t, &calls, 2, 2*time.Second)
+}
+
+// TestServer_ReconcileLoopContinuesOnError is AC #5: errors during a pass
+// must be logged and the loop must keep ticking. A single failing pass
+// cannot wedge the loop or take the daemon down.
+func TestServer_ReconcileLoopContinuesOnError(t *testing.T) {
+	srv := newTestServer(t, 20*time.Millisecond)
+	var calls atomic.Int32
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		calls.Add(1)
+		return controller.ReconcileResult{}, errors.New("synthetic failure")
+	}
+
+	startServer(t, srv)
+	waitForCalls(t, &calls, 3, 2*time.Second)
+}
+
+// TestServer_ReconcileLoopDisabledWhenIntervalZero is the explicit opt-out
+// path: a 0 (or negative) ReconcileInterval must keep the loop off so
+// tests, embedded callers, and operators who set --reconcile-interval 0
+// see no background activity.
+func TestServer_ReconcileLoopDisabledWhenIntervalZero(t *testing.T) {
+	srv := newTestServer(t, 0)
+	var calls atomic.Int32
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		calls.Add(1)
+		return controller.ReconcileResult{}, nil
+	}
+
+	startServer(t, srv)
+	time.Sleep(150 * time.Millisecond)
+	if got := calls.Load(); got != 0 {
+		t.Errorf("reconcileFn calls with ReconcileInterval=0: got %d, want 0", got)
+	}
+}
+
+// TestServer_ReconcileLoopStopsWithContext confirms cancellation of the
+// daemon context terminates the loop — required to keep daemon shutdowns
+// fast and to honor the no-leader-election single-instance invariant.
+func TestServer_ReconcileLoopStopsWithContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := newTestServerWithCtx(t, ctx, 20*time.Millisecond)
+	var calls atomic.Int32
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		calls.Add(1)
+		return controller.ReconcileResult{}, nil
+	}
+	startServer(t, srv)
+	waitForCalls(t, &calls, 1, 2*time.Second)
+
+	cancel()
+	preStop := calls.Load()
+	time.Sleep(150 * time.Millisecond)
+	postStop := calls.Load()
+	// Allow up to one in-flight tick after cancel — we require the loop to
+	// settle, not to be perfectly synchronous.
+	if postStop-preStop > 1 {
+		t.Errorf("loop kept ticking after ctx cancel: pre=%d post=%d", preStop, postStop)
+	}
+}
+
+func newTestServer(t *testing.T, interval time.Duration) *Server {
+	t.Helper()
+	return newTestServerWithCtx(t, context.Background(), interval)
+}
+
+func newTestServerWithCtx(t *testing.T, ctx context.Context, interval time.Duration) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "kukeond.sock")
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewServer(ctx, logger, Options{
+		SocketPath:        socketPath,
+		SocketMode:        0o600,
+		ReconcileInterval: interval,
+	})
+}
+
+func startServer(t *testing.T, srv *Server) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	t.Cleanup(func() {
+		_ = srv.Stop()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("Serve did not return after Stop")
+		}
+	})
+}
+
+func waitForCalls(t *testing.T, counter *atomic.Int32, want int32, deadline time.Duration) {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if counter.Load() >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("reconcileFn calls: got %d, want >=%d within %s", counter.Load(), want, deadline)
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/controller"
@@ -50,6 +51,10 @@ type Options struct {
 	SocketGID int
 	// PIDFile, when non-empty, is written on Serve and removed on Stop.
 	PIDFile string
+	// ReconcileInterval is the period of the background cell-reconciliation
+	// loop. Zero or negative disables the loop — useful for tests and for
+	// operators who explicitly opt out via `--reconcile-interval 0`.
+	ReconcileInterval time.Duration
 	// Controller is forwarded to controller.NewControllerExec.
 	Controller controller.Options
 }
@@ -63,6 +68,11 @@ type Server struct {
 	core *local.Client
 	rpc  *rpc.Server
 
+	// reconcileFn is the per-tick callable for the cell-reconciliation loop.
+	// Defaults to core.ReconcileCells; tests in the daemon package overwrite
+	// it before Serve so they exercise the ticker without a real controller.
+	reconcileFn func() (controller.ReconcileResult, error)
+
 	mu       sync.Mutex
 	listener net.Listener
 	closed   bool
@@ -74,12 +84,14 @@ func NewServer(ctx context.Context, logger *slog.Logger, opts Options) *Server {
 		opts.SocketMode = 0o600
 	}
 	core := local.New(ctx, logger, opts.Controller)
-	return &Server{
+	srv := &Server{
 		ctx:    ctx,
 		logger: logger,
 		opts:   opts,
 		core:   core,
 	}
+	srv.reconcileFn = srv.core.ReconcileCells
+	return srv
 }
 
 // Serve opens the listener and accepts connections until Stop is called or
@@ -128,8 +140,67 @@ func (s *Server) Serve() error {
 	}
 
 	s.logger.InfoContext(s.ctx, "kukeond listening", "socket", s.opts.SocketPath)
+	s.startReconcileLoop()
 	s.acceptLoop(listener)
 	return nil
+}
+
+// startReconcileLoop spawns the background cell-reconciliation ticker when
+// ReconcileInterval > 0. Lifetime is bound to s.ctx — daemon shutdown stops
+// the loop. Errors during a pass are logged and the loop continues. One log
+// line per pass: brief on success, detailed on failure (per #161 AC).
+func (s *Server) startReconcileLoop() {
+	if s.opts.ReconcileInterval <= 0 {
+		s.logger.InfoContext(s.ctx, "reconcile loop disabled",
+			"interval", s.opts.ReconcileInterval)
+		return
+	}
+	s.logger.InfoContext(s.ctx, "starting reconcile loop",
+		"interval", s.opts.ReconcileInterval)
+	go s.runReconcileLoop(s.opts.ReconcileInterval)
+}
+
+func (s *Server) runReconcileLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.ctx.Done():
+			s.logger.InfoContext(s.ctx, "reconcile loop stopped")
+			return
+		case <-ticker.C:
+			s.runReconcileOnce()
+		}
+	}
+}
+
+func (s *Server) runReconcileOnce() {
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.ErrorContext(s.ctx, "reconcile pass panicked; loop continues",
+				"panic", r)
+		}
+	}()
+	res, err := s.reconcileFn()
+	switch {
+	case err != nil:
+		s.logger.ErrorContext(s.ctx, "reconcile pass failed",
+			"error", err,
+			"cells_scanned", res.CellsScanned,
+			"cells_updated", res.CellsUpdated,
+			"cells_errored", res.CellsErrored,
+			"errors", res.Errors)
+	case len(res.Errors) > 0:
+		s.logger.WarnContext(s.ctx, "reconcile pass completed with errors",
+			"cells_scanned", res.CellsScanned,
+			"cells_updated", res.CellsUpdated,
+			"cells_errored", res.CellsErrored,
+			"errors", res.Errors)
+	default:
+		s.logger.InfoContext(s.ctx, "reconcile ok",
+			"cells_scanned", res.CellsScanned,
+			"cells_updated", res.CellsUpdated)
+	}
 }
 
 func (s *Server) acceptLoop(listener net.Listener) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -73,6 +73,12 @@ type Server struct {
 	// it before Serve so they exercise the ticker without a real controller.
 	reconcileFn func() (controller.ReconcileResult, error)
 
+	// stopCh is closed by Stop to terminate the reconcile loop independently
+	// of s.ctx; loopWG lets Stop block until the loop exits, so core.Close
+	// never races an in-flight reconcile pass.
+	stopCh chan struct{}
+	loopWG sync.WaitGroup
+
 	mu       sync.Mutex
 	listener net.Listener
 	closed   bool
@@ -89,6 +95,7 @@ func NewServer(ctx context.Context, logger *slog.Logger, opts Options) *Server {
 		logger: logger,
 		opts:   opts,
 		core:   core,
+		stopCh: make(chan struct{}),
 	}
 	srv.reconcileFn = srv.core.ReconcileCells
 	return srv
@@ -157,15 +164,20 @@ func (s *Server) startReconcileLoop() {
 	}
 	s.logger.InfoContext(s.ctx, "starting reconcile loop",
 		"interval", s.opts.ReconcileInterval)
+	s.loopWG.Add(1)
 	go s.runReconcileLoop(s.opts.ReconcileInterval)
 }
 
 func (s *Server) runReconcileLoop(interval time.Duration) {
+	defer s.loopWG.Done()
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-s.ctx.Done():
+			s.logger.InfoContext(s.ctx, "reconcile loop stopped")
+			return
+		case <-s.stopCh:
 			s.logger.InfoContext(s.ctx, "reconcile loop stopped")
 			return
 		case <-ticker.C:
@@ -235,6 +247,12 @@ func (s *Server) Stop() error {
 	listener := s.listener
 	s.listener = nil
 	s.mu.Unlock()
+
+	// Signal the reconcile loop to exit and wait for any in-flight pass to
+	// return before tearing down the controller — otherwise a tick already
+	// inside reconcileFn would race s.core.Close.
+	close(s.stopCh)
+	s.loopWG.Wait()
 
 	var firstErr error
 	if listener != nil {

--- a/internal/serverconfig/serverconfig.go
+++ b/internal/serverconfig/serverconfig.go
@@ -101,6 +101,13 @@ spec:
   # Default: info
   logLevel: info
 
+  # Period of the daemon's background cell-reconciliation loop, expressed as a
+  # Go time.Duration string. The loop walks every cell and re-derives
+  # ` + "`status.state`" + ` against observed container state once per tick. Zero or
+  # negative disables the loop.
+  # Default: 30s
+  reconcileInterval: 30s
+
   # Container image ` + "`kuke init`" + ` provisions for the kukeond system cell.
   # Read by ` + "`kuke init`" + ` only; the daemon ignores it. Empty means kuke init
   # picks the release-matching ghcr.io/eminwux/kukeon image automatically.

--- a/internal/serverconfig/serverconfig_test.go
+++ b/internal/serverconfig/serverconfig_test.go
@@ -86,6 +86,28 @@ spec:
 	}
 }
 
+func TestLoadReconcileInterval(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kukeond.yaml")
+	content := `apiVersion: v1beta1
+kind: ServerConfiguration
+metadata:
+  name: default
+spec:
+  reconcileInterval: 7s
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	doc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if doc.Spec.ReconcileInterval != "7s" {
+		t.Errorf("ReconcileInterval: got %q, want %q", doc.Spec.ReconcileInterval, "7s")
+	}
+}
+
 func TestLoadWrongKindRejected(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kukeond.yaml")
@@ -193,6 +215,9 @@ func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 	if doc.Spec.KukeondImage != "" {
 		t.Errorf("Spec.KukeondImage: got %q, want empty (kuke init resolves at runtime)", doc.Spec.KukeondImage)
 	}
+	if doc.Spec.ReconcileInterval != "30s" {
+		t.Errorf("Spec.ReconcileInterval: got %q, want %q", doc.Spec.ReconcileInterval, "30s")
+	}
 
 	// AC: "Header comment explains each field's purpose and default."
 	raw, err := os.ReadFile(path)
@@ -209,6 +234,7 @@ func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 		"# Default: /opt/kukeon",
 		"# Default: /run/containerd/containerd.sock",
 		"# Default: info",
+		"# Default: 30s",
 		`# Default: ""`,
 	} {
 		if !strings.Contains(rawStr, marker) {

--- a/pkg/api/model/v1beta1/serverconfiguration.go
+++ b/pkg/api/model/v1beta1/serverconfiguration.go
@@ -49,6 +49,11 @@ type ServerConfigurationSpec struct {
 	ContainerdSocket string `json:"containerdSocket,omitempty" yaml:"containerdSocket,omitempty"`
 	// LogLevel is the daemon log level (debug, info, warn, error).
 	LogLevel string `json:"logLevel,omitempty"         yaml:"logLevel,omitempty"`
+	// ReconcileInterval is the period of the daemon's background cell
+	// reconciliation loop, expressed as a Go time.Duration string (e.g.
+	// "30s", "1m"). Empty falls back to the in-binary default. A zero or
+	// negative duration disables the loop.
+	ReconcileInterval string `json:"reconcileInterval,omitempty" yaml:"reconcileInterval,omitempty"`
 	// KukeondImage is the container image `kuke init` provisions for the
 	// kukeond system cell. Read by `kuke init` only; the daemon ignores it.
 	KukeondImage string `json:"kukeondImage,omitempty"     yaml:"kukeondImage,omitempty"`


### PR DESCRIPTION
## Summary
- Adds a periodic, single-goroutine ticker inside `kukeond` that walks every realm/space/stack and re-derives each cell's `status.state` from the observed root-container task — so a cell whose root task is killed externally (e.g. `ctr -n … task kill`) flips from `Ready` to `Stopped` within one tick interval, with no operator `kuke refresh` required.
- Adds a `reconcileInterval` field to `ServerConfiguration` (and a matching `--reconcile-interval` flag / `KUKEOND_RECONCILE_INTERVAL` env), default `30s`. A zero or negative duration disables the loop.
- Layers the new state-from-task derivation into a new `runner.ReconcileCell` so existing `kuke refresh` (which still calls `RefreshCell`) is byte-for-byte unchanged in behavior.

### Design notes (so reviewer can push back)
- The loop lives on `daemon.Server` and is bound to the daemon context — single goroutine, single instance, no leader election (per the issue).
- Errors during a pass are logged once and the loop keeps ticking — a flaky containerd connection cannot wedge reconciliation. One log line per pass: `"reconcile ok"` on success, error/warn variants when something failed.
- `RefreshCell` is intentionally untouched. `ReconcileCell` is its daemon-side counterpart that adds root-container task introspection — keeping AC #7 (kuke refresh unchanged) literal.
- Container statuses are populated as a side effect so `kuke get cell` reflects container state without the operator having to run `kuke refresh`.
- `daemon.Server` got a private `reconcileFn` seam so package-internal tests can drive the ticker without booting a real controller.

## Test plan
- [x] `go test ./internal/controller/... ./internal/daemon/... ./internal/serverconfig/... ./cmd/kukeond/...` — all green (new walk / error-resume / disabled / ctx-cancel / per-pass error coverage).
- [x] `go test $(go list ./... | grep -v /e2e)` — green except for one pre-existing `internal/cni.TestBootstrapCNI` failure on `origin/main` (mkdir /opt/cni: permission denied — sandbox restriction, also reproduces on a clean clone of `origin/main`).
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean for changed files.
- [ ] `make e2e` — not run, sandbox lacks docker + sudo.
- [ ] `make dev-init` smoke test — not run, sandbox lacks `sudo`, `docker`, `containerd`, and the privileged mounts the script needs. The change touches `/run/kukeon`, `/opt/kukeon`, and the daemon read path; this check should be re-run by the reviewer or in CI before merge per the project CLAUDE.md.

Closes #161