### PR TITLE
fix: gate AutoDelete on Ready observation

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -817,7 +817,8 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				Network: intmodel.CellNetworkStatus{
 					BridgeName: in.Status.Network.BridgeName,
 				},
-				Containers: convertContainerStatusesToInternal(in.Status.Containers),
+				Containers:    convertContainerStatusesToInternal(in.Status.Containers),
+				ReadyObserved: in.Status.ReadyObserved,
 			},
 		}
 
@@ -876,7 +877,8 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				Network: ext.CellNetworkStatus{
 					BridgeName: in.Status.Network.BridgeName,
 				},
-				Containers: buildContainerStatusesExternalFromInternal(in.Status.Containers),
+				Containers:    buildContainerStatusesExternalFromInternal(in.Status.Containers),
+				ReadyObserved: in.Status.ReadyObserved,
 			},
 		}
 

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -437,6 +437,59 @@ func TestCellRoundTripV1Beta1_NetworkBridgeName(t *testing.T) {
 	}
 }
 
+// TestCellRoundTripV1Beta1_ReadyObserved covers the persistence side of
+// the AutoDelete Ready-gate from #269: the latch must round-trip
+// external→internal→external so it survives daemon restarts. Without
+// it, a `kuke run --rm` cell that was Ready at shutdown would lose the
+// latch on restart and miss its cleanup tick.
+func TestCellRoundTripV1Beta1_ReadyObserved(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata: ext.CellMetadata{
+			Name:   "cell-rm",
+			Labels: map[string]string{},
+		},
+		Spec: ext.CellSpec{
+			ID:         "cell-id-rm",
+			RealmID:    "realm0",
+			SpaceID:    "space0",
+			StackID:    "stack0",
+			Containers: []ext.ContainerSpec{},
+			AutoDelete: true,
+		},
+		Status: ext.CellStatus{
+			State:         ext.CellStateReady,
+			CgroupPath:    "/sys/fs/cgroup/cell-rm",
+			ReadyObserved: true,
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if !internal.Status.ReadyObserved {
+		t.Errorf("internal ReadyObserved = false, want true")
+	}
+
+	output, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if !output.Status.ReadyObserved {
+		t.Errorf("external ReadyObserved = false, want true")
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if !strings.Contains(string(rendered), "readyObserved: true") {
+		t.Errorf("rendered YAML missing readyObserved entry; got:\n%s", string(rendered))
+	}
+}
+
 // TestCellRoundTripV1Beta1_AutoDelete locks down the AC for `kuke run --rm`:
 // the AutoDelete bool must survive the external→internal→external round-trip
 // and serialize as YAML so a daemon restart can re-read the auto-delete intent

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -384,13 +384,18 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 			"cell", cell.Metadata.Name, "error", err)
 	}
 	cell.Status.State = newState
+	cell.Status.ReadyObserved = latchReadyObserved(
+		originalStatus.ReadyObserved, originalStatus.State, newState)
 
-	if cell.Spec.AutoDelete && cellStateAutoDeleteTriggers(newState) {
+	if shouldAutoDeleteCell(cell.Spec.AutoDelete, newState, cell.Status.ReadyObserved) {
 		return r.autoDeleteCell(cell)
 	}
 
 	updated := false
 	if originalStatus.State != cell.Status.State {
+		updated = true
+	}
+	if originalStatus.ReadyObserved != cell.Status.ReadyObserved {
 		updated = true
 	}
 	if !containerStatusesEqual(originalStatus.Containers, cell.Status.Containers) {
@@ -436,6 +441,35 @@ func (r *Exec) autoDeleteCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutco
 // nuke the cell — wait for the next pass.
 func cellStateAutoDeleteTriggers(s intmodel.CellState) bool {
 	return s == intmodel.CellStateStopped || s == intmodel.CellStateFailed
+}
+
+// latchReadyObserved is the one-way latch the reconciler uses to decide
+// whether a cell has ever been Ready. A cell that has never reached
+// Ready must not be auto-deleted: GetContainerState returns Stopped
+// for a not-yet-existing container (the "container does not exist in
+// containerd" branch in container_state.go), and the reconciler ticking
+// inside the gap between cgroup creation and root-container
+// registration in CreateCell would otherwise reap an in-flight cell.
+//
+// Inputs that latch ReadyObserved true:
+//   - the prior persisted ReadyObserved (the latch survives across
+//     ticks and across daemon restarts via CellStatus serialization),
+//   - newState == Ready (the current observation),
+//   - originalStatus.State == Ready (a synchronous Start persisted
+//     Ready into the cell metadata before this reconciler tick saw it,
+//     even on the first tick after a restart).
+func latchReadyObserved(prior bool, originalState, newState intmodel.CellState) bool {
+	return prior ||
+		newState == intmodel.CellStateReady ||
+		originalState == intmodel.CellStateReady
+}
+
+// shouldAutoDeleteCell returns true when the reconciler should kick off
+// AutoDelete cleanup. The latch (readyObserved) is the gate that
+// prevents an in-flight CreateCell from being reaped before the root
+// container has come up; see latchReadyObserved.
+func shouldAutoDeleteCell(autoDelete bool, newState intmodel.CellState, readyObserved bool) bool {
+	return autoDelete && cellStateAutoDeleteTriggers(newState) && readyObserved
 }
 
 // deriveCellStateFromRootContainer resolves the cell's state from the root

--- a/internal/controller/runner/refresh_test.go
+++ b/internal/controller/runner/refresh_test.go
@@ -48,3 +48,145 @@ func TestCellStateAutoDeleteTriggers(t *testing.T) {
 		}
 	}
 }
+
+// TestLatchReadyObserved pins the one-way latch behavior the reconciler
+// uses to gate Spec.AutoDelete cleanup. The latch must:
+//   - flip to true the first time newState==Ready is observed,
+//   - flip to true when the persisted state is already Ready (covers
+//     the first reconciler tick after a synchronous Start that wrote
+//     Ready before any reconciler observation, including the first
+//     tick after a daemon restart),
+//   - never flip back to false once true (a cell that flapped through
+//     Ready and is now Stopped is still a candidate for AutoDelete),
+//   - stay false in the bug window from #269 — newState==Stopped on a
+//     cell whose persisted state is Pending/Unknown, i.e. the "container
+//     does not exist in containerd yet" branch during CreateCell.
+func TestLatchReadyObserved(t *testing.T) {
+	cases := []struct {
+		name          string
+		prior         bool
+		originalState intmodel.CellState
+		newState      intmodel.CellState
+		want          bool
+	}{
+		{
+			name:          "never_ready_mid_create_stays_false",
+			prior:         false,
+			originalState: intmodel.CellStatePending,
+			newState:      intmodel.CellStateStopped,
+			want:          false,
+		},
+		{
+			name:          "never_ready_unknown_persisted_stays_false",
+			prior:         false,
+			originalState: intmodel.CellStateUnknown,
+			newState:      intmodel.CellStateStopped,
+			want:          false,
+		},
+		{
+			name:          "first_ready_observation_flips_true",
+			prior:         false,
+			originalState: intmodel.CellStatePending,
+			newState:      intmodel.CellStateReady,
+			want:          true,
+		},
+		{
+			name:          "persisted_ready_flips_true_even_when_now_stopped",
+			prior:         false,
+			originalState: intmodel.CellStateReady,
+			newState:      intmodel.CellStateStopped,
+			want:          true,
+		},
+		{
+			name:          "prior_true_stays_true_through_stopped",
+			prior:         true,
+			originalState: intmodel.CellStateStopped,
+			newState:      intmodel.CellStateStopped,
+			want:          true,
+		},
+		{
+			name:          "prior_true_stays_true_through_unknown",
+			prior:         true,
+			originalState: intmodel.CellStateUnknown,
+			newState:      intmodel.CellStateUnknown,
+			want:          true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := latchReadyObserved(tc.prior, tc.originalState, tc.newState)
+			if got != tc.want {
+				t.Errorf("latchReadyObserved(prior=%v, original=%v, new=%v) = %v, want %v",
+					tc.prior, tc.originalState, tc.newState, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldAutoDeleteCell is the complete gate guarding AutoDelete
+// cleanup: AutoDelete=true AND newState is a trigger (Stopped/Failed)
+// AND the ReadyObserved latch is set. The Ready-gate row is the
+// regression #269 calls out — without it, an in-flight CreateCell that
+// has not yet registered its root container resolves to Stopped and the
+// pre-fix code reaped the cell.
+func TestShouldAutoDeleteCell(t *testing.T) {
+	cases := []struct {
+		name          string
+		autoDelete    bool
+		newState      intmodel.CellState
+		readyObserved bool
+		want          bool
+	}{
+		{
+			name:          "fires_when_all_three_satisfied",
+			autoDelete:    true,
+			newState:      intmodel.CellStateStopped,
+			readyObserved: true,
+			want:          true,
+		},
+		{
+			name:          "fires_on_failed_state",
+			autoDelete:    true,
+			newState:      intmodel.CellStateFailed,
+			readyObserved: true,
+			want:          true,
+		},
+		{
+			name:          "blocked_when_autoDelete_false",
+			autoDelete:    false,
+			newState:      intmodel.CellStateStopped,
+			readyObserved: true,
+			want:          false,
+		},
+		{
+			name:          "blocked_when_state_not_trigger",
+			autoDelete:    true,
+			newState:      intmodel.CellStateReady,
+			readyObserved: true,
+			want:          false,
+		},
+		{
+			name:          "blocked_when_state_unknown",
+			autoDelete:    true,
+			newState:      intmodel.CellStateUnknown,
+			readyObserved: true,
+			want:          false,
+		},
+		{
+			name:          "blocked_when_never_ready_regression_269",
+			autoDelete:    true,
+			newState:      intmodel.CellStateStopped,
+			readyObserved: false,
+			want:          false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldAutoDeleteCell(tc.autoDelete, tc.newState, tc.readyObserved)
+			if got != tc.want {
+				t.Errorf("shouldAutoDeleteCell(autoDelete=%v, new=%v, ready=%v) = %v, want %v",
+					tc.autoDelete, tc.newState, tc.readyObserved, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -52,6 +52,16 @@ type CellStatus struct {
 	CgroupPath string
 	Network    CellNetworkStatus
 	Containers []ContainerStatus
+	// ReadyObserved is a one-way latch set the first time the cell has
+	// been observed Ready by ReconcileCell — either via the freshly
+	// derived state or via a persisted Ready state from a prior
+	// observation (or a synchronous Start that wrote Ready before the
+	// reconciler got there). The latch gates Spec.AutoDelete cleanup so
+	// a cell that has never been Ready (e.g. mid-creation, between
+	// cgroup setup and root-container registration, where
+	// GetContainerState reports Stopped for a not-yet-existing
+	// container) cannot be reaped by the reconciler.
+	ReadyObserved bool
 }
 
 // CellNetworkStatus records the network endpoints the cell is attached to.

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -58,10 +58,16 @@ type CellTty struct {
 }
 
 type CellStatus struct {
-	State      CellState         `json:"state"             yaml:"state"`
-	CgroupPath string            `json:"cgroupPath"        yaml:"cgroupPath"`
-	Network    CellNetworkStatus `json:"network,omitempty" yaml:"network,omitempty"`
-	Containers []ContainerStatus `json:"containers"        yaml:"containers"`
+	State      CellState         `json:"state"                   yaml:"state"`
+	CgroupPath string            `json:"cgroupPath"              yaml:"cgroupPath"`
+	Network    CellNetworkStatus `json:"network,omitempty"       yaml:"network,omitempty"`
+	Containers []ContainerStatus `json:"containers"              yaml:"containers"`
+	// ReadyObserved is the persisted form of the one-way latch the
+	// reconciler uses to gate Spec.AutoDelete cleanup. Once a cell has
+	// been observed Ready it stays true across daemon restarts so that
+	// cleanup of a `kuke run --rm` cell that was already Ready at
+	// shutdown still fires on the next tick after restart.
+	ReadyObserved bool `json:"readyObserved,omitempty" yaml:"readyObserved,omitempty"`
 }
 
 // CellNetworkStatus exposes the host-side bridge a cell is attached to.


### PR DESCRIPTION
## Summary
- Gate the daemon reconciler's AutoDelete cleanup on a one-way `ReadyObserved` latch so a cell that has never been observed Ready cannot be reaped from the "container does not exist in containerd yet → Stopped" branch (`internal/controller/runner/container_state.go:168`). Without the latch, a reconciler tick that lands inside the gap between cgroup creation and root-container registration during `CreateCell` resolves the cell to Stopped and `autoDeleteCell` reaps an in-flight cell.
- The latch flips true on either a fresh `Ready` observation, the persisted state already being `Ready` (covers a synchronous `Start` that wrote `Ready` before any reconciler tick — including the first tick after a daemon restart), or the prior persisted latch value (so it survives across ticks and across restarts).
- Persisted via `CellStatus.ReadyObserved` (`json/yaml: readyObserved,omitempty`) so a `kuke run --rm` cell that was already Ready at daemon shutdown still gets cleaned up on the next tick after restart.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full unit suite)
- [x] `go test -run "TestLatchReadyObserved|TestShouldAutoDeleteCell|TestCellStateAutoDeleteTriggers|TestCellRoundTripV1Beta1_ReadyObserved" -v ./internal/apischeme/... ./internal/controller/runner/...` — new pure-function tests for the latch + gate, plus an external↔internal round-trip test for the persisted field
- [x] `make dev-init` — daemon-parity check passes (`kuke get realms` and `kuke get realms --no-daemon` produce identical output)
- [ ] `make e2e` — not run locally; CI will exercise

Closes #269