### PR TITLE
docs: fix default realm namespace in daemon-parity sample

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ The daemon-parity tail of the output (the regression guard) must read:
 ```
 NAME         NAMESPACE              STATE  CGROUP
 -----------  ---------------------  -----  -------------------
-default      kukeon.io              Ready  /kukeon/default
+default      default.kukeon.io      Ready  /kukeon/default
 kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
 ```
 


### PR DESCRIPTION
## Summary
- Fix the daemon-parity regression-guard sample in `CLAUDE.md` to show `default.kukeon.io` for the `default` realm. The canonical mapping in `internal/consts/consts.go` (`RealmNamespace` always appends `RealmNamespaceSuffix = ".kukeon.io"`) produces `default.kukeon.io`, and `make dev-init` confirms both `kuke get realms` and `kuke get realms --no-daemon` print that. The old sample (`kukeon.io`) would either fail the regression guard on a healthy host or get treated as a regression — making the guard unenforceable.

## Scope note (AC #2 deviation)
- AC #2 of #268 claims the upper "two default realms" table at `CLAUDE.md:17` already correctly says `default.kukeon.io`. It does not — that row also reads `kukeon.io`, the same factual bug as the regression-guard sample. Per AC #2's explicit "no edit needed there; this issue is only the regression-guard sample" scope directive, I left that table untouched. Reviewer can push back to expand scope; otherwise I'll file a separate `docs:` follow-up via `/reflect`.

## Test plan
- [x] `make dev-init` — daemon-parity tail prints the updated table verbatim:
  ```
  NAME         NAMESPACE              STATE  CGROUP
  -----------  ---------------------  -----  -------------------
  default      default.kukeon.io      Ready  /kukeon/default
  kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
  ```
- No code paths touched — `go build`/`go vet`/`make test` not run (docs-only change).

Closes #268