### PR TITLE
docs: fix realm table default namespace in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Build, test, and smoke-test conventions for anyone — human or agent — workin
 
 | Realm         | Containerd namespace    | Purpose                                                      |
 | ------------- | ----------------------- | ------------------------------------------------------------ |
-| `default`     | `kukeon.io`             | User workloads. Created empty so `kuke create …` has a home. |
+| `default`     | `default.kukeon.io`     | User workloads. Created empty so `kuke create …` has a home. |
 | `kuke-system` | `kuke-system.kukeon.io` | System workloads owned by kukeon itself.                     |
 
 The `kukeond` daemon runs inside the **`kuke-system`** realm — specifically as a container inside the cell `kuke-system / kukeon / kukeon / kukeond` (realm / space / stack / cell). The `default` realm is deliberately left user-owned so `kuke purge --cascade` on it can never take down the daemon.


### PR DESCRIPTION
## Summary
- Line 17 of the realm table listed `kukeon.io` for the `default` realm; canonical mapping in `internal/consts/consts.go` (`RealmNamespace` always appends `.kukeon.io` suffix) yields `default.kukeon.io`.
- PR #272 already fixed the daemon-parity sample at line 39; this PR fixes only the remaining drift at line 17, matching that issue's residual scope.

## Test plan
- [x] `make test` passes locally (full unit suite).
- [ ] `make dev-init` smoke test — not run; pure docs change does not touch the build path, daemon, or `/opt/kukeon`, per CLAUDE.md's smoke-test trigger rule.

Closes #257