### PR TITLE
fix: kill cell on attach loop return under -a --rm

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -90,11 +90,15 @@ func NewRunCmd() *cobra.Command {
 		"Container to attach to (only valid with -a; must be attachable)")
 	_ = viper.BindPFlag(config.KUKE_RUN_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
 	cmd.Flags().Bool("rm", false,
-		"Best-effort delete the cell after the root container's task exits "+
-			"(any rc). Daemon-mode only — incompatible with --no-daemon. "+
-			"Cleanup runs from kukeond's reconcile loop, so latency is "+
-			"bounded by the reconcile interval rather than firing the "+
-			"instant the task exits.")
+		"Best-effort delete the cell after it is no longer needed "+
+			"(any rc). Without -a, the trigger is the root container's "+
+			"task exit. With -a, the trigger is the attach loop "+
+			"returning (clean detach, exit, or error) — the CLI then "+
+			"sends KillCell so a long-lived root (e.g. `sleep infinity`) "+
+			"does not pin the cell. Daemon-mode only — incompatible "+
+			"with --no-daemon. Cleanup runs from kukeond's reconcile "+
+			"loop, so latency is bounded by the reconcile interval "+
+			"rather than firing the instant the trigger fires.")
 	_ = viper.BindPFlag(config.KUKE_RUN_RM.ViperKey, cmd.Flags().Lookup("rm"))
 
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -222,9 +226,40 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return printErr
 	}
 	if flags.doAttach {
-		return attachAfterRun(cmd, client, cellDoc, flags.containerFlag)
+		attachErr := attachAfterRun(cmd, client, cellDoc, flags.containerFlag)
+		if flags.autoDelete {
+			// With -a --rm, the operator's "I'm done" signal is the
+			// attach loop returning, not the root container exiting.
+			// When the attach target is a peer of a long-lived root
+			// (`sleep infinity` is the standard idiom), the root task
+			// never exits on its own and the reconciler's auto-delete
+			// trigger never fires. Send KillCell here so the root
+			// task is SIGKILL'd and the next reconcile pass reaps the
+			// cell. Best-effort per the --rm contract: a cleanup
+			// failure does not override attachErr.
+			autoDeleteAfterAttach(cmd, client, cellDoc)
+		}
+		return attachErr
 	}
 	return nil
+}
+
+// autoDeleteAfterAttach drives the -a --rm cleanup path. KillCell is
+// idempotent — if the attach target was the root and the user typed
+// `exit`, the root task is already gone and KillCell just confirms it;
+// the kill+delete sequence in autoDeleteCell tolerates a missing task.
+// A KillCell failure (daemon down, RPC error, cell already gone) is
+// reported but not returned: the operator has detached, --rm is
+// best-effort, and the daemon's reconciler still owns final cleanup.
+func autoDeleteAfterAttach(cmd *cobra.Command, client kukeonv1.Client, doc v1beta1.CellDoc) {
+	if _, err := client.KillCell(cmd.Context(), doc); err != nil {
+		if errors.Is(err, errdefs.ErrCellNotFound) {
+			return
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"kuke run: --rm cleanup: failed to kill cell %q: %v\n",
+			doc.Metadata.Name, err)
+	}
 }
 
 // attachAfterRun resolves the post-start attach target per the documented

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -209,7 +209,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 				return printErr
 			}
 			if flags.doAttach {
-				return attachAfterRun(cmd, client, cellDoc, flags.containerFlag)
+				return attachAndMaybeAutoDelete(cmd, client, cellDoc, flags)
 			}
 			return nil
 		}
@@ -226,22 +226,35 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return printErr
 	}
 	if flags.doAttach {
-		attachErr := attachAfterRun(cmd, client, cellDoc, flags.containerFlag)
-		if flags.autoDelete {
-			// With -a --rm, the operator's "I'm done" signal is the
-			// attach loop returning, not the root container exiting.
-			// When the attach target is a peer of a long-lived root
-			// (`sleep infinity` is the standard idiom), the root task
-			// never exits on its own and the reconciler's auto-delete
-			// trigger never fires. Send KillCell here so the root
-			// task is SIGKILL'd and the next reconcile pass reaps the
-			// cell. Best-effort per the --rm contract: a cleanup
-			// failure does not override attachErr.
-			autoDeleteAfterAttach(cmd, client, cellDoc)
-		}
-		return attachErr
+		return attachAndMaybeAutoDelete(cmd, client, cellDoc, flags)
 	}
 	return nil
+}
+
+// attachAndMaybeAutoDelete drives the attach loop and, under -a --rm, fires
+// KillCell once the loop returns. Both the create-and-start path and the
+// already-Ready idempotent short-circuit funnel through here so re-running
+// `kuke run -a --rm` against an up cell still gets cleanup on detach
+// (issue #265 regression: the original fix only patched the create path).
+//
+// With -a --rm, the operator's "I'm done" signal is the attach loop
+// returning, not the root container exiting. When the attach target is a
+// peer of a long-lived root (`sleep infinity` is the standard idiom), the
+// root task never exits on its own and the reconciler's auto-delete trigger
+// never fires. KillCell here SIGKILL's the root task so the next reconcile
+// pass reaps the cell. Best-effort per the --rm contract: a cleanup failure
+// does not override attachErr.
+func attachAndMaybeAutoDelete(
+	cmd *cobra.Command,
+	client kukeonv1.Client,
+	doc v1beta1.CellDoc,
+	flags runFlags,
+) error {
+	attachErr := attachAfterRun(cmd, client, doc, flags.containerFlag)
+	if flags.autoDelete {
+		autoDeleteAfterAttach(cmd, client, doc)
+	}
+	return attachErr
 }
 
 // autoDeleteAfterAttach drives the -a --rm cleanup path. KillCell is

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -108,12 +108,15 @@ type fakeClient struct {
 	getCellFn         func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
 	createCellFn      func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
 	attachContainerFn func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error)
+	killCellFn        func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
 
 	getCalls    int
 	createCalls int
 	attachCalls int
+	killCalls   int
 	createDoc   v1beta1.CellDoc
 	attachDoc   v1beta1.ContainerDoc
+	killDoc     v1beta1.CellDoc
 }
 
 func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
@@ -145,17 +148,41 @@ func (f *fakeClient) AttachContainer(
 	return f.attachContainerFn(doc)
 }
 
-// runCapture records the Options passed to the in-process attach loop and
-// returns nil so the test treats the call as a clean detach.
+func (f *fakeClient) KillCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+	f.killCalls++
+	f.killDoc = doc
+	if f.killCellFn == nil {
+		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
+	}
+	return f.killCellFn(doc)
+}
+
+// runCapture records the Options passed to the in-process attach loop. By
+// default returns nil so the test treats the call as a clean detach; set
+// err to inject an attach-loop failure (e.g. control-socket lost).
 type runCapture struct {
 	calls int
 	opts  sbshattach.Options
+	err   error
 }
 
 func (r *runCapture) fn(_ context.Context, opts sbshattach.Options) error {
 	r.calls++
 	r.opts = opts
-	return nil
+	return r.err
+}
+
+// runErrorCapture is a thin wrapper used by tests that only care that the
+// attach loop returned a specific error — it shares the same shape as
+// runCapture so existing newCmdWithRun plumbing works unchanged.
+type runErrorCapture struct {
+	calls int
+	err   error
+}
+
+func (r *runErrorCapture) fn(_ context.Context, _ sbshattach.Options) error {
+	r.calls++
+	return r.err
 }
 
 func newCmd(t *testing.T, fc *fakeClient) (*cobra.Command, *bytes.Buffer) {
@@ -164,6 +191,15 @@ func newCmd(t *testing.T, fc *fakeClient) (*cobra.Command, *bytes.Buffer) {
 }
 
 func newCmdWithRun(t *testing.T, fc *fakeClient, run *runCapture) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	var fn runcmd.RunFn
+	if run != nil {
+		fn = run.fn
+	}
+	return newCmdWithRunFn(t, fc, fn)
+}
+
+func newCmdWithRunFn(t *testing.T, fc *fakeClient, run runcmd.RunFn) (*cobra.Command, *bytes.Buffer) {
 	t.Helper()
 	cmd := runcmd.NewRunCmd()
 	buf := &bytes.Buffer{}
@@ -176,7 +212,7 @@ func newCmdWithRun(t *testing.T, fc *fakeClient, run *runCapture) (*cobra.Comman
 		ctx = context.WithValue(ctx, runcmd.MockControllerKey{}, kukeonv1.Client(fc))
 	}
 	if run != nil {
-		ctx = context.WithValue(ctx, runcmd.MockRunKey{}, runcmd.RunFn(run.fn))
+		ctx = context.WithValue(ctx, runcmd.MockRunKey{}, run)
 	}
 	cmd.SetContext(ctx)
 	return cmd, buf
@@ -1361,6 +1397,183 @@ spec:
 	}
 	if !fc.createDoc.Spec.AutoDelete {
 		t.Errorf("CreateCell received AutoDelete=false; YAML autoDelete:true must survive when --rm is absent")
+	}
+}
+
+func TestRun_RmAttach_KillsCellAfterAttachLoopReturns(t *testing.T) {
+	// Issue #265: with -a --rm and a long-lived root (`sleep infinity`)
+	// peering an attachable container, the root task never exits when
+	// the operator detaches, so the reconciler's auto-delete trigger
+	// never fires. The CLI must call KillCell when the attach loop
+	// returns so the daemon's reconciler reaps the cell on the next
+	// tick.
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+		killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{Killed: true}, nil
+		},
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !fc.createDoc.Spec.AutoDelete {
+		t.Errorf("CreateCell received AutoDelete=false; --rm must set it true")
+	}
+	if run.calls != 1 {
+		t.Fatalf("attach loop calls=%d want 1", run.calls)
+	}
+	if fc.killCalls != 1 {
+		t.Fatalf("KillCell calls=%d want 1 (must fire after attach loop returns)", fc.killCalls)
+	}
+	if got := fc.killDoc.Metadata.Name; got != "my-cell" {
+		t.Errorf("KillCell target=%q want my-cell", got)
+	}
+	if got := fc.killDoc.Spec.RealmID; got != "my-realm" {
+		t.Errorf("KillCell realm=%q want my-realm", got)
+	}
+}
+
+func TestRun_RmAttach_KillsCellEvenWhenAttachLoopErrors(t *testing.T) {
+	// --rm is best-effort cleanup keyed on "the operator is done", which
+	// is true regardless of whether the attach loop returned cleanly or
+	// errored. KillCell must still fire so a peer-shell crash does not
+	// leak the cell.
+	t.Cleanup(viper.Reset)
+
+	attachLoopErr := errors.New("control socket lost")
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+		killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{Killed: true}, nil
+		},
+	}
+	run := &runErrorCapture{err: attachLoopErr}
+	cmd, _ := newCmdWithRunFn(t, fc, run.fn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+
+	if err := cmd.Execute(); !errors.Is(err, attachLoopErr) {
+		t.Fatalf("Execute err=%v want attachLoopErr (must surface to caller)", err)
+	}
+	if fc.killCalls != 1 {
+		t.Errorf("KillCell calls=%d want 1 (must fire even when attach loop errors)", fc.killCalls)
+	}
+}
+
+func TestRun_RmAttach_KillCellFailureDoesNotMaskAttachExit(t *testing.T) {
+	// A KillCell RPC failure is logged to stderr but does not become the
+	// exit error: the operator has already detached, --rm is documented
+	// best-effort, and the daemon's reconciler is the safety net for any
+	// orphaned cell.
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+		killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{}, errors.New("daemon RPC: connection refused")
+		},
+	}
+	run := &runCapture{}
+	cmd, buf := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v (a KillCell failure on a clean detach must not surface as a run error)", err)
+	}
+	if fc.killCalls != 1 {
+		t.Fatalf("KillCell calls=%d want 1", fc.killCalls)
+	}
+	if !strings.Contains(buf.String(), "--rm cleanup: failed to kill cell") {
+		t.Errorf("expected stderr warning about KillCell failure, got:\n%s", buf.String())
+	}
+}
+
+func TestRun_RmAttach_KillCellNotFound_Silent(t *testing.T) {
+	// If the daemon's reconciler raced ahead and already reaped the cell
+	// (e.g. attach target was the root and exiting it triggered the
+	// existing root-task path), KillCell returns ErrCellNotFound. That
+	// is the expected idempotent outcome — no stderr noise.
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+		killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{}, errdefs.ErrCellNotFound
+		},
+	}
+	run := &runCapture{}
+	cmd, buf := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(buf.String(), "--rm cleanup: failed to kill cell") {
+		t.Errorf("ErrCellNotFound must be silent (idempotent), got stderr:\n%s", buf.String())
+	}
+}
+
+func TestRun_RmNoAttach_DoesNotCallKillCell(t *testing.T) {
+	// Without -a, --rm preserves its original semantics: the daemon's
+	// reconciler watches the root task and reaps when it exits. The CLI
+	// must not pre-empt that path with a KillCell — that would break
+	// `kuke run --rm -f cell.yaml` for a long-running workload that the
+	// operator wants left running until it exits on its own.
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "--rm"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.killCalls != 0 {
+		t.Errorf("KillCell calls=%d want 0 (no -a means the reconciler owns cleanup)", fc.killCalls)
+	}
+}
+
+func TestRun_AttachNoRm_DoesNotCallKillCell(t *testing.T) {
+	// Defensive guard: -a alone must not engage cleanup. KillCell only
+	// fires when --rm is also set.
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.killCalls != 0 {
+		t.Errorf("KillCell calls=%d want 0 (-a without --rm must not clean up)", fc.killCalls)
 	}
 }
 

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1554,6 +1554,64 @@ func TestRun_RmNoAttach_DoesNotCallKillCell(t *testing.T) {
 	}
 }
 
+func TestRun_RmAttach_AlreadyReady_StillKillsCellAfterAttachLoopReturns(t *testing.T) {
+	// Idempotent branch regression guard: re-running `kuke run -a --rm`
+	// against an already-Ready cell with matching spec must still fire
+	// KillCell when the attach loop returns. Otherwise a user with a
+	// dangling cell from a pre-fix invocation cannot recover via -a --rm,
+	// reproducing the original #265 symptom.
+	t.Cleanup(viper.Reset)
+
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Tty:     &v1beta1.CellTty{Default: "claude"},
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "shell", Attachable: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "claude", Attachable: true, Image: "registry.eminwux.com/busybox:latest"},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                existing,
+				MetadataExists:      true,
+				CgroupExists:        true,
+				RootContainerExists: true,
+			}, nil
+		},
+		attachContainerFn: attachSuccessFn(),
+		killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{Killed: true}, nil
+		},
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (short-circuit on Ready)", fc.createCalls)
+	}
+	if run.calls != 1 {
+		t.Fatalf("attach loop calls=%d want 1", run.calls)
+	}
+	if fc.killCalls != 1 {
+		t.Fatalf("KillCell calls=%d want 1 (idempotent branch must also fire cleanup)", fc.killCalls)
+	}
+	if got := fc.killDoc.Metadata.Name; got != "my-cell" {
+		t.Errorf("KillCell target=%q want my-cell", got)
+	}
+}
+
 func TestRun_AttachNoRm_DoesNotCallKillCell(t *testing.T) {
 	// Defensive guard: -a alone must not engage cleanup. KillCell only
 	// fires when --rm is also set.


### PR DESCRIPTION
## Summary

- `kuke run -a --rm` left the cell alive forever when the root container was a long-lived sleeper and the operator detached from a peer attachable, because the daemon's auto-delete trigger keys on the *root* task exiting and `sleep infinity` never does. Fix: when both flags are set, the CLI sends `KillCell` once `runAttachLoop` returns, giving the reconciler the Stopped state it needs to reap the cell on the next tick.
- The change is scoped to `cmd/kuke/run/run.go` only — daemon contract and `Spec.AutoDelete` semantics are unchanged. With `--rm` alone (no `-a`), behavior is preserved: the daemon's reconciler still owns cleanup keyed on root-task exit.
- Picked Option B from the issue (smaller, no Spec/RPC schema change) over Option A. Option A would have required threading the attach target through `CreateCell` args and changing the reconciler's auto-delete trigger from "root stopped" to "auto-delete-target stopped" — viable but a much larger blast radius for a UX bug. Filed in the PR body so the reviewer can push back if Option A is preferred.
- `--rm` flag docstring updated to describe the new -a trigger and call out that the no-`-a` path is unchanged.
- Errors from KillCell are best-effort: `ErrCellNotFound` is silent (the daemon may have raced ahead and reaped already), other RPC failures are logged to stderr but do not override the attach exit code.
- Fix-up (3f801c6): the already-Ready idempotent short-circuit now funnels through the same `attachAndMaybeAutoDelete` helper as the create path, so `kuke run -a --rm -f cell.yaml` against an existing Ready cell also fires `KillCell` on detach (reviewer-flagged gap; otherwise users with a cell from a pre-fix run could not recover via -a --rm).

## Test plan

- [x] `go test ./cmd/kuke/run/...` — seven unit tests cover the -a --rm path: KillCell fires on clean detach, on attach-loop error, KillCell failure does not surface as run error, ErrCellNotFound is silent, --rm without -a does not call KillCell, -a without --rm does not call KillCell, and the already-Ready idempotent branch also fires KillCell.
- [x] `make test` — full unit suite green.
- [x] `go vet ./...` — clean.
- [x] `make dev-init` — daemon-parity check passes; both `kuke get realms` and `kuke get realms --no-daemon` produce the matching default + kuke-system table from CLAUDE.md.
- [ ] `make test-e2e` — pre-existing failures on `origin/main` (TestKuke_Init_VerifyState and others fail because the e2e harness assumes a clean host but a kukeond cell from `make dev-init` is already running). Verified the same set fails on baseline without my changes; my change does not regress e2e.

Closes #265