### PR TITLE
fix: close ReadyObserved latch eagerly on synchronous Ready writes

### DIFF
--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1025,8 +1025,7 @@ func (r *Exec) provisionNewCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, err
 	}
 
-	// Update cell state in internal model
-	cell.Status.State = intmodel.CellStateReady
+	markCellReady(&cell)
 
 	// Update cell metadata
 	if err = r.UpdateCellMetadata(cell); err != nil {

--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -148,8 +148,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to recreate cell containers: %w", err)
 	}
 
-	// Update cell state
-	desired.Status.State = intmodel.CellStateReady
+	markCellReady(&desired)
 
 	// Update metadata
 	if updateErr := r.UpdateCellMetadata(desired); updateErr != nil {

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -472,6 +472,18 @@ func shouldAutoDeleteCell(autoDelete bool, newState intmodel.CellState, readyObs
 	return autoDelete && cellStateAutoDeleteTriggers(newState) && readyObserved
 }
 
+// markCellReady stamps a synchronous Ready transition: state and the
+// ReadyObserved latch must close together. Without the eager latch
+// close, a KillCell that races the first reconciler tick (e.g. `kuke
+// run -a --rm` exiting attach within the reconcile interval) flips
+// persisted state Ready → Stopped before any reconciler observation,
+// leaving readyObserved=false on disk; subsequent ticks then see
+// originalState=Stopped and shouldAutoDeleteCell never fires.
+func markCellReady(cell *intmodel.Cell) {
+	cell.Status.State = intmodel.CellStateReady
+	cell.Status.ReadyObserved = true
+}
+
 // deriveCellStateFromRootContainer resolves the cell's state from the root
 // container's task. Returns Ready when no root container is configured (a
 // cgroup-only cell counts as Ready by cgroup existence).

--- a/internal/controller/runner/refresh_test.go
+++ b/internal/controller/runner/refresh_test.go
@@ -123,6 +123,65 @@ func TestLatchReadyObserved(t *testing.T) {
 	}
 }
 
+// TestMarkCellReady is the eager-latch contract synchronous Ready
+// writers (provisionNewCell, StartCell idempotent skip, StartCell
+// happy path, StartContainer, RecreateCell) all rely on. State and
+// ReadyObserved must close together — without that, a KillCell that
+// races the first reconciler tick (e.g. `kuke run -a --rm` exiting
+// attach inside the reconcile interval) flips persisted state Ready
+// → Stopped before any reconciler observation, leaving
+// readyObserved=false on disk. Subsequent ticks then see
+// originalState=Stopped, latchReadyObserved returns false, and
+// shouldAutoDeleteCell never fires (regression #275).
+func TestMarkCellReady(t *testing.T) {
+	cell := intmodel.Cell{Status: intmodel.CellStatus{
+		State:         intmodel.CellStatePending,
+		ReadyObserved: false,
+	}}
+	markCellReady(&cell)
+	if cell.Status.State != intmodel.CellStateReady {
+		t.Errorf("State = %v, want Ready", cell.Status.State)
+	}
+	if !cell.Status.ReadyObserved {
+		t.Errorf("ReadyObserved = false, want true")
+	}
+}
+
+// TestAutoDeleteSurvivesKillCellRace is the end-to-end invariant for
+// #275: after a synchronous Ready write followed by a synchronous
+// KillCell that flips state to Stopped (without touching the latch),
+// the persisted ReadyObserved must still be true so the next
+// reconciler tick gates AutoDelete on. Models the on-disk handoff
+// between the runner's synchronous writes and the reconciler's
+// shouldAutoDeleteCell predicate.
+func TestAutoDeleteSurvivesKillCellRace(t *testing.T) {
+	cell := intmodel.Cell{Status: intmodel.CellStatus{
+		State:         intmodel.CellStatePending,
+		ReadyObserved: false,
+	}}
+
+	// Runner writes Ready synchronously (StartCell happy path).
+	markCellReady(&cell)
+
+	// Synchronous KillCell flips state to Stopped without touching
+	// the latch — this is the persisted state the reconciler reads
+	// on its first tick after the race.
+	cell.Status.State = intmodel.CellStateStopped
+
+	persisted := cell.Status
+
+	// Reconciler tick: derive newState=Stopped from a not-yet-existing
+	// containerd task, run the latch over the persisted snapshot.
+	newState := intmodel.CellStateStopped
+	latched := latchReadyObserved(persisted.ReadyObserved, persisted.State, newState)
+	if !latched {
+		t.Fatalf("latchReadyObserved = false; AutoDelete gate would never fire")
+	}
+	if !shouldAutoDeleteCell(true, newState, latched) {
+		t.Errorf("shouldAutoDeleteCell = false; cell would be stranded in Stopped")
+	}
+}
+
 // TestShouldAutoDeleteCell is the complete gate guarding AutoDelete
 // cleanup: AutoDelete=true AND newState is a trigger (Stopped/Failed)
 // AND the ReadyObserved latch is set. The Ready-gate row is the

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -225,7 +225,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	// refuses as a duplicate allocation (we never run CNI DEL when we
 	// delete the old container, so the reservation persists).
 	if cellTasksAllRunningFn(internalCell, containerID, r.ctrClient.TaskStatus) {
-		internalCell.Status.State = intmodel.CellStateReady
+		markCellReady(&internalCell)
 		if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
 			r.logger.WarnContext(r.ctx, "failed to populate container statuses after idempotent StartCell skip",
 				"cell", cellName,
@@ -636,8 +636,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		)
 	}
 
-	// Update cell state in internal model
-	internalCell.Status.State = intmodel.CellStateReady
+	markCellReady(&internalCell)
 
 	// Populate container statuses after starting cell and persist them
 	if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
@@ -897,8 +896,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 		return intmodel.Cell{}, fmt.Errorf("failed to retrieve cell after starting container: %w", err)
 	}
 
-	// Update cell state in internal model
-	updatedCell.Status.State = intmodel.CellStateReady
+	markCellReady(&updatedCell)
 
 	// Populate container statuses after starting cell and persist them
 	if err = r.PopulateAndPersistCellContainerStatuses(&updatedCell); err != nil {


### PR DESCRIPTION
## Summary
- Close the `ReadyObserved` latch alongside every synchronous `state=Ready` write so `KillCell` racing the first reconciler tick can no longer strand a `--rm` cell in `Stopped`.
- Centralized the invariant in a `markCellReady(*Cell)` helper next to `latchReadyObserved` in `refresh.go`. Five call sites (`provisionNewCell`, two `StartCell` paths, `StartContainer`, `RecreateCell`) now go through the helper instead of writing only `Status.State`.
- Added two unit tests: `TestMarkCellReady` pins the helper contract; `TestAutoDeleteSurvivesKillCellRace` models the on-disk handoff between the synchronous Ready write, a racing `KillCell`, and the reconciler's `shouldAutoDeleteCell` predicate.
- Took the broader fix from the issue's "Suggested fix" rather than the alt one-liner in `KillCell`: the latch's intent is "the runner has just observed Ready," so closing it next to each Ready write is semantically faithful and also covers any future caller that flips state to `Stopped` without going through `KillCell`. Caught a 5th synchronous Ready write in `RecreateCell` that the issue did not list — same race shape, applied the same fix.

## Test plan
- [x] `make test` — full unit suite green.
- [x] `go build ./...` and `go vet ./...` — clean.
- [x] `make dev-init` — daemon-parity tail matches the regression guard from `CLAUDE.md` (both `kuke get realms` and `kuke get realms --no-daemon` show `default Ready` and `kuke-system Ready`).
- [x] End-to-end repro from the issue: `kuke run -a --rm -f repro-275.yaml --container work` with attach exiting in <5s. Pre-write metadata showed `state=2 (Stopped)` and `readyObserved=true` (the new invariant on disk); after one reconcile interval the cell directory `/opt/kukeon/default/default/default/repro-275` was reaped and `kuke get cells` was clean. Pre-fix, the same repro left `readyObserved=false` and the cell stuck in `Stopped` indefinitely (verified by inspecting the orphan `kukeon-dev-cb9290` cell from the issue's repro session before purging it).

Closes #275