### PR TITLE
fix: keep cell alive on clean detach under run -a --rm

### DIFF
--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -135,36 +135,16 @@ func runAttach(cmd *cobra.Command, _ []string) error {
 	}
 
 	run := resolveRun(cmd)
-	if runErr := run(cmd.Context(), attach.Options{
+	runErr := run(cmd.Context(), attach.Options{
 		SocketPath: result.HostSocketPath,
 		Stdin:      os.Stdin,
 		Stdout:     os.Stdout,
 		Stderr:     os.Stderr,
-	}); runErr != nil && !isCleanDetach(runErr) {
+	})
+	if runErr != nil && !kukeshared.IsCleanAttachExit(runErr) {
 		return runErr
 	}
 	return nil
-}
-
-// isCleanDetach reports whether err returned by the in-process attach
-// loop describes a normal session end rather than an unrecoverable
-// failure. The Ctrl+] Ctrl+] detach filter inside sbsh's pkg/attach
-// triggers a controller-level Detach RPC; the embedded read/write
-// goroutines then exit cleanly, but their teardown is reported as the
-// error "close requested: read/write routines exited" — sbsh does not
-// expose a sentinel for either layer in its public pkg/errors. The
-// remote terminal closing the connection (workload exited, peer hung
-// up) ends up on the same path, which from `kuke attach`'s perspective
-// is also a benign session end. Surface a clean exit code 0 in those
-// cases; any other failure (socket missing, RPC error, context done)
-// arrives without this signature and still bubbles up.
-func isCleanDetach(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "close requested") &&
-		strings.Contains(msg, "read/write routines exited")
 }
 
 // pickAttachableContainer enumerates the cell's containers and returns the

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -19,6 +19,7 @@ package attach_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -278,12 +279,12 @@ func TestAttach_ExplicitContainer_Attachable_Succeeds(t *testing.T) {
 	}
 }
 
-// TestAttach_RunReturnsCleanDetachError covers the regression from #147:
-// when the user presses Ctrl+] Ctrl+], sbsh's controller fires the
-// Detach RPC and the embedded read/write copy goroutines exit, but that
-// teardown surfaces as "close requested: read/write routines exited"
-// from pkg/attach.Run. The wrapper must recognise that signature as a
-// benign session end and return nil so `kuke attach` exits 0.
+// TestAttach_RunReturnsCleanDetachError covers the regression from
+// #147: when the user presses Ctrl+] Ctrl+], sbsh's controller fires
+// the Detach RPC and pkg/attach.Run returns attach.ErrDetached
+// (sbsh#192, available since sbsh v0.10.1). The wrapper must recognise
+// the public sentinel as a benign session end and return nil so `kuke
+// attach` exits 0.
 func TestAttach_RunReturnsCleanDetachError(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
@@ -292,7 +293,7 @@ func TestAttach_RunReturnsCleanDetachError(t *testing.T) {
 			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
 		},
 	}
-	cleanDetachErr := errors.New("close requested: read/write routines exited")
+	cleanDetachErr := fmt.Errorf("wrapped by harness: %w", sbshattach.ErrDetached)
 	run := &runReturning{err: cleanDetachErr}
 	cmd := newCmdWithCtx(t, fc, nil)
 	cmd.SetContext(context.WithValue(cmd.Context(), attachcmd.MockRunKey{}, attachcmd.RunFn(run.fn)))
@@ -303,6 +304,36 @@ func TestAttach_RunReturnsCleanDetachError(t *testing.T) {
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute returned %v on clean-detach error, want nil", err)
+	}
+	if run.calls != 1 {
+		t.Fatalf("attach.Run called %d times, want 1", run.calls)
+	}
+}
+
+// TestAttach_RunReturnsPeerClosedError mirrors the clean-detach case for
+// the other benign session-end signal: pkg/attach.Run returns
+// attach.ErrPeerClosed when the remote terminal drops the IO connection
+// (workload exited, peer crashed). For `kuke attach` (a peer attach,
+// not the cell owner), this is also exit 0 — same semantics as detach.
+func TestAttach_RunReturnsPeerClosedError(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	peerClosedErr := fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed)
+	run := &runReturning{err: peerClosedErr}
+	cmd := newCmdWithCtx(t, fc, nil)
+	cmd.SetContext(context.WithValue(cmd.Context(), attachcmd.MockRunKey{}, attachcmd.RunFn(run.fn)))
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--container", "work",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned %v on peer-closed error, want nil", err)
 	}
 	if run.calls != 1 {
 		t.Fatalf("attach.Run called %d times, want 1", run.calls)

--- a/cmd/kuke/run/attach.go
+++ b/cmd/kuke/run/attach.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -107,13 +108,24 @@ func formatAttachableList(spec v1beta1.CellSpec) string {
 
 // runAttachLoop resolves the per-container sbsh control socket via the
 // daemon's AttachContainer RPC and drives the in-process attach loop.
-// Returns nil on clean detach.
+// Returns the tri-state used by the -a --rm cleanup decision in
+// attachAndMaybeAutoDelete:
+//
+//   - detached=true,  err=nil — operator pressed ^]^] (or peer issued
+//     a Detach RPC). Cell must stay alive.
+//   - detached=false, err=nil — peer dropped the connection (workload
+//     exited / hung up). Surface exit 0; -a --rm fires KillCell so a
+//     long-lived root does not pin the cell.
+//   - detached=false, err≠nil — pre-attach setup error or unrecoverable
+//     controller error. Surface to the user; -a --rm still fires
+//     KillCell because a half-detached session would otherwise leak
+//     the cell.
 func runAttachLoop(
 	cmd *cobra.Command,
 	client kukeonv1.Client,
 	doc v1beta1.CellDoc,
 	container string,
-) error {
+) (bool, error) {
 	containerDoc := v1beta1.ContainerDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
 		Kind:       v1beta1.KindContainer,
@@ -133,26 +145,36 @@ func runAttachLoop(
 	result, err := client.AttachContainer(cmd.Context(), containerDoc)
 	if err != nil {
 		if errors.Is(err, errdefs.ErrAttachNotSupported) {
-			return fmt.Errorf("container %q in cell %q is not attachable: %w",
+			return false, fmt.Errorf("container %q in cell %q is not attachable: %w",
 				container, doc.Metadata.Name, err)
 		}
 		if errors.Is(err, errdefs.ErrContainerNotFound) {
-			return fmt.Errorf("container %q not found in cell %q",
+			return false, fmt.Errorf("container %q not found in cell %q",
 				container, doc.Metadata.Name)
 		}
-		return err
+		return false, err
 	}
 	if result.HostSocketPath == "" {
-		return fmt.Errorf("daemon returned empty HostSocketPath for container %q", container)
+		return false, fmt.Errorf("daemon returned empty HostSocketPath for container %q", container)
 	}
 
 	run := resolveRun(cmd)
-	return run(cmd.Context(), attach.Options{
+	runErr := run(cmd.Context(), attach.Options{
 		SocketPath: result.HostSocketPath,
 		Stdin:      os.Stdin,
 		Stdout:     os.Stdout,
 		Stderr:     os.Stderr,
 	})
+	switch kukeshared.ClassifyAttachExit(runErr) {
+	case kukeshared.AttachExitDetached:
+		return true, nil
+	case kukeshared.AttachExitPeerClosed:
+		return false, nil
+	case kukeshared.AttachExitError:
+		return false, runErr
+	default:
+		return false, runErr
+	}
 }
 
 func resolveRun(cmd *cobra.Command) runFn {

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -92,10 +92,13 @@ func NewRunCmd() *cobra.Command {
 	cmd.Flags().Bool("rm", false,
 		"Best-effort delete the cell after it is no longer needed "+
 			"(any rc). Without -a, the trigger is the root container's "+
-			"task exit. With -a, the trigger is the attach loop "+
-			"returning (clean detach, exit, or error) — the CLI then "+
-			"sends KillCell so a long-lived root (e.g. `sleep infinity`) "+
-			"does not pin the cell. Daemon-mode only — incompatible "+
+			"task exit. With -a, the trigger is the attach loop exiting "+
+			"because the workload terminated, the peer hung up, or an "+
+			"unrecoverable controller error fired — the CLI then sends "+
+			"KillCell so a long-lived root (e.g. `sleep infinity`) does "+
+			"not pin the cell. A clean ^]^] detach is NOT a trigger: the "+
+			"cell stays alive so the operator can re-attach later "+
+			"(parity with `kuke attach`). Daemon-mode only — incompatible "+
 			"with --no-daemon. Cleanup runs from kukeond's reconcile "+
 			"loop, so latency is bounded by the reconcile interval "+
 			"rather than firing the instant the trigger fires.")
@@ -231,27 +234,32 @@ func runRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// attachAndMaybeAutoDelete drives the attach loop and, under -a --rm, fires
-// KillCell once the loop returns. Both the create-and-start path and the
-// already-Ready idempotent short-circuit funnel through here so re-running
-// `kuke run -a --rm` against an up cell still gets cleanup on detach
-// (issue #265 regression: the original fix only patched the create path).
+// attachAndMaybeAutoDelete drives the attach loop and, under -a --rm,
+// fires KillCell once the loop returns — but only if the loop exited
+// because the workload ended (peer hangup, shell exit, controller
+// error). A clean ^]^] detach (issue #279) leaves the cell alive so the
+// operator can re-attach later, matching `kuke attach`'s exit-0
+// semantics.
 //
-// With -a --rm, the operator's "I'm done" signal is the attach loop
-// returning, not the root container exiting. When the attach target is a
-// peer of a long-lived root (`sleep infinity` is the standard idiom), the
-// root task never exits on its own and the reconciler's auto-delete trigger
-// never fires. KillCell here SIGKILL's the root task so the next reconcile
-// pass reaps the cell. Best-effort per the --rm contract: a cleanup failure
-// does not override attachErr.
+// Both the create-and-start path and the already-Ready idempotent
+// short-circuit funnel through here so re-running `kuke run -a --rm`
+// against an up cell still gets cleanup on workload exit (issue #265
+// regression: the original fix only patched the create path).
+//
+// When the attach target is a peer of a long-lived root (`sleep
+// infinity` is the standard idiom), the root task never exits on its
+// own and the reconciler's auto-delete trigger never fires. KillCell on
+// the workload-ended path SIGKILL's the root task so the next reconcile
+// pass reaps the cell. Best-effort per the --rm contract: a cleanup
+// failure does not override attachErr.
 func attachAndMaybeAutoDelete(
 	cmd *cobra.Command,
 	client kukeonv1.Client,
 	doc v1beta1.CellDoc,
 	flags runFlags,
 ) error {
-	attachErr := attachAfterRun(cmd, client, doc, flags.containerFlag)
-	if flags.autoDelete {
+	detached, attachErr := attachAfterRun(cmd, client, doc, flags.containerFlag)
+	if flags.autoDelete && !detached {
 		autoDeleteAfterAttach(cmd, client, doc)
 	}
 	return attachErr
@@ -275,20 +283,27 @@ func autoDeleteAfterAttach(cmd *cobra.Command, client kukeonv1.Client, doc v1bet
 	}
 }
 
-// attachAfterRun resolves the post-start attach target per the documented
-// precedence and drives the in-process sbsh attach loop. The selection runs
-// against cellDoc.Spec rather than re-querying the daemon: by this point the
-// resolved doc is what we just told the daemon to create, so the attachable
-// set the user authored is authoritative.
+// attachAfterRun resolves the post-start attach target per the
+// documented precedence and drives the in-process sbsh attach loop.
+// The selection runs against cellDoc.Spec rather than re-querying the
+// daemon: by this point the resolved doc is what we just told the
+// daemon to create, so the attachable set the user authored is
+// authoritative.
+//
+// Returns the (detached, err) tri-state from runAttachLoop. A
+// pre-attach selection failure is reported as (false, err) so
+// attachAndMaybeAutoDelete still fires KillCell — the operator asked
+// for --rm and the cell exists; whether or not the attach loop ever ran
+// does not change that intent.
 func attachAfterRun(
 	cmd *cobra.Command,
 	client kukeonv1.Client,
 	doc v1beta1.CellDoc,
 	containerFlag string,
-) error {
+) (bool, error) {
 	target, err := pickAttachTarget(doc.Spec, doc.Metadata.Name, containerFlag)
 	if err != nil {
-		return err
+		return false, err
 	}
 	return runAttachLoop(cmd, client, doc, target)
 }

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -1400,13 +1401,15 @@ spec:
 	}
 }
 
-func TestRun_RmAttach_KillsCellAfterAttachLoopReturns(t *testing.T) {
-	// Issue #265: with -a --rm and a long-lived root (`sleep infinity`)
-	// peering an attachable container, the root task never exits when
-	// the operator detaches, so the reconciler's auto-delete trigger
-	// never fires. The CLI must call KillCell when the attach loop
-	// returns so the daemon's reconciler reaps the cell on the next
-	// tick.
+func TestRun_RmAttach_KeepsCellAliveOnCleanDetach(t *testing.T) {
+	// Issue #279: a clean ^]^] detach must NOT trigger the -a --rm
+	// KillCell. The operator may want to re-attach later — same
+	// semantics as `kuke attach`. Only workload-end signals (peer
+	// hangup, shell exit, controller error) should fire cleanup.
+	//
+	// Inject attach.ErrDetached as the attach-loop result; that is
+	// what sbsh v0.10.1 returns when the in-band detach keystroke
+	// fires.
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
@@ -1418,12 +1421,52 @@ func TestRun_RmAttach_KillsCellAfterAttachLoopReturns(t *testing.T) {
 			return kukeonv1.KillCellResult{Killed: true}, nil
 		},
 	}
-	run := &runCapture{}
-	cmd, _ := newCmdWithRun(t, fc, run)
+	run := &runErrorCapture{
+		err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrDetached),
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, run.fn)
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
 
 	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v", err)
+		t.Fatalf("Execute: %v (clean detach must surface as exit 0)", err)
+	}
+	if !fc.createDoc.Spec.AutoDelete {
+		t.Errorf("CreateCell received AutoDelete=false; --rm must set it true even when clean detach skips KillCell")
+	}
+	if run.calls != 1 {
+		t.Fatalf("attach loop calls=%d want 1", run.calls)
+	}
+	if fc.killCalls != 0 {
+		t.Fatalf("KillCell calls=%d want 0 (clean detach must leave cell alive for re-attach)", fc.killCalls)
+	}
+}
+
+func TestRun_RmAttach_KillsCellOnPeerClosed(t *testing.T) {
+	// Issue #265: with -a --rm and a long-lived root (`sleep infinity`)
+	// peering an attachable container, the root task never exits when
+	// the workload terminates on the peer side, so the reconciler's
+	// auto-delete trigger never fires. The CLI must call KillCell when
+	// the attach loop returns peer-closed so the daemon's reconciler
+	// reaps the cell on the next tick.
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+		killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{Killed: true}, nil
+		},
+	}
+	run := &runErrorCapture{
+		err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed),
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, run.fn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v (peer-closed must surface as exit 0 — workload ended)", err)
 	}
 	if !fc.createDoc.Spec.AutoDelete {
 		t.Errorf("CreateCell received AutoDelete=false; --rm must set it true")
@@ -1432,7 +1475,7 @@ func TestRun_RmAttach_KillsCellAfterAttachLoopReturns(t *testing.T) {
 		t.Fatalf("attach loop calls=%d want 1", run.calls)
 	}
 	if fc.killCalls != 1 {
-		t.Fatalf("KillCell calls=%d want 1 (must fire after attach loop returns)", fc.killCalls)
+		t.Fatalf("KillCell calls=%d want 1 (peer-closed must trigger cleanup)", fc.killCalls)
 	}
 	if got := fc.killDoc.Metadata.Name; got != "my-cell" {
 		t.Errorf("KillCell target=%q want my-cell", got)
@@ -1472,10 +1515,11 @@ func TestRun_RmAttach_KillsCellEvenWhenAttachLoopErrors(t *testing.T) {
 }
 
 func TestRun_RmAttach_KillCellFailureDoesNotMaskAttachExit(t *testing.T) {
-	// A KillCell RPC failure is logged to stderr but does not become the
-	// exit error: the operator has already detached, --rm is documented
-	// best-effort, and the daemon's reconciler is the safety net for any
-	// orphaned cell.
+	// On the workload-ended path (peer hangup / shell exit), a KillCell
+	// RPC failure is logged to stderr but does not become the exit
+	// error: --rm is documented best-effort and the daemon's reconciler
+	// is the safety net for any orphaned cell. The attach loop result
+	// dictates the run rc.
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
@@ -1487,12 +1531,12 @@ func TestRun_RmAttach_KillCellFailureDoesNotMaskAttachExit(t *testing.T) {
 			return kukeonv1.KillCellResult{}, errors.New("daemon RPC: connection refused")
 		},
 	}
-	run := &runCapture{}
+	run := &runCapture{err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed)}
 	cmd, buf := newCmdWithRun(t, fc, run)
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
 
 	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v (a KillCell failure on a clean detach must not surface as a run error)", err)
+		t.Fatalf("Execute: %v (KillCell failure on workload-end must not surface as a run error)", err)
 	}
 	if fc.killCalls != 1 {
 		t.Fatalf("KillCell calls=%d want 1", fc.killCalls)
@@ -1506,7 +1550,9 @@ func TestRun_RmAttach_KillCellNotFound_Silent(t *testing.T) {
 	// If the daemon's reconciler raced ahead and already reaped the cell
 	// (e.g. attach target was the root and exiting it triggered the
 	// existing root-task path), KillCell returns ErrCellNotFound. That
-	// is the expected idempotent outcome — no stderr noise.
+	// is the expected idempotent outcome — no stderr noise. The attach
+	// loop must report a workload-end exit (peer hangup) so KillCell
+	// fires in the first place under the issue #279 semantics.
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
@@ -1518,7 +1564,7 @@ func TestRun_RmAttach_KillCellNotFound_Silent(t *testing.T) {
 			return kukeonv1.KillCellResult{}, errdefs.ErrCellNotFound
 		},
 	}
-	run := &runCapture{}
+	run := &runCapture{err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed)}
 	cmd, buf := newCmdWithRun(t, fc, run)
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
 
@@ -1554,12 +1600,13 @@ func TestRun_RmNoAttach_DoesNotCallKillCell(t *testing.T) {
 	}
 }
 
-func TestRun_RmAttach_AlreadyReady_StillKillsCellAfterAttachLoopReturns(t *testing.T) {
+func TestRun_RmAttach_AlreadyReady_StillKillsCellOnPeerClosed(t *testing.T) {
 	// Idempotent branch regression guard: re-running `kuke run -a --rm`
 	// against an already-Ready cell with matching spec must still fire
-	// KillCell when the attach loop returns. Otherwise a user with a
-	// dangling cell from a pre-fix invocation cannot recover via -a --rm,
-	// reproducing the original #265 symptom.
+	// KillCell when the attach loop reports workload-end (peer hangup
+	// here). Otherwise a user with a dangling cell from a pre-fix
+	// invocation cannot recover via -a --rm, reproducing the original
+	// #265 symptom.
 	t.Cleanup(viper.Reset)
 
 	existing := v1beta1.CellDoc{
@@ -1591,7 +1638,7 @@ func TestRun_RmAttach_AlreadyReady_StillKillsCellAfterAttachLoopReturns(t *testi
 			return kukeonv1.KillCellResult{Killed: true}, nil
 		},
 	}
-	run := &runCapture{}
+	run := &runCapture{err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed)}
 	cmd, _ := newCmdWithRun(t, fc, run)
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
 

--- a/cmd/kuke/shared/attach_exit.go
+++ b/cmd/kuke/shared/attach_exit.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"errors"
+
+	"github.com/eminwux/sbsh/pkg/attach"
+)
+
+// AttachExit classifies how an in-process sbsh attach loop ended.
+// `kuke attach` and `kuke run -a` both drive the same loop and need to
+// branch on the same three outcomes.
+type AttachExit int
+
+const (
+	// AttachExitDetached signals a clean ^]^] (or peer-issued Detach
+	// RPC). The remote terminal is still alive and `kuke run -a --rm`
+	// must NOT kill the cell — the operator may want to re-attach.
+	AttachExitDetached AttachExit = iota
+
+	// AttachExitPeerClosed signals the remote terminal dropped the
+	// connection (workload exited, peer hung up). From the user's
+	// perspective the session ended cleanly (exit 0), but `kuke run
+	// -a --rm` should fire KillCell so a long-lived root (e.g.
+	// `sleep infinity`) does not pin the cell.
+	AttachExitPeerClosed
+
+	// AttachExitError signals an unrecoverable controller error
+	// (control socket lost, RPC failure, context cancel, …). The
+	// caller surfaces the error to the user and `kuke run -a --rm`
+	// fires KillCell so a half-detached session does not leak the
+	// cell.
+	AttachExitError
+)
+
+// ClassifyAttachExit maps the error returned by
+// `github.com/eminwux/sbsh/pkg/attach`.Run to an AttachExit. nil and
+// detach map to AttachExitDetached / AttachExitPeerClosed respectively;
+// any other non-nil error is AttachExitError.
+//
+// sbsh v0.10.1 made attach.ErrDetached and attach.ErrPeerClosed public
+// (sbsh#192) so embedders can branch on errors.Is rather than the
+// pre-v0.10.1 substring match on "close requested: read/write routines
+// exited".
+func ClassifyAttachExit(err error) AttachExit {
+	switch {
+	case err == nil:
+		// pkg/attach.Run already collapses context-canceled to nil; we
+		// treat a nil return as "operator ended the session cleanly",
+		// which for `kuke run -a --rm` means "leave the cell alive" —
+		// same semantics as ErrDetached.
+		return AttachExitDetached
+	case errors.Is(err, attach.ErrDetached):
+		return AttachExitDetached
+	case errors.Is(err, attach.ErrPeerClosed):
+		return AttachExitPeerClosed
+	default:
+		return AttachExitError
+	}
+}
+
+// IsCleanAttachExit reports whether err describes a benign session end
+// — either a clean detach or a peer-side close. Both map to exit 0
+// from the user's perspective (no error is surfaced to the shell);
+// callers that need to differentiate detach-vs-peer-close (e.g. to
+// decide whether to keep a managed cell alive) should use
+// ClassifyAttachExit instead.
+func IsCleanAttachExit(err error) bool {
+	switch ClassifyAttachExit(err) {
+	case AttachExitDetached, AttachExitPeerClosed:
+		return true
+	case AttachExitError:
+		return false
+	default:
+		return false
+	}
+}

--- a/cmd/kuke/shared/attach_exit_test.go
+++ b/cmd/kuke/shared/attach_exit_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	sbshattach "github.com/eminwux/sbsh/pkg/attach"
+)
+
+func TestClassifyAttachExit(t *testing.T) {
+	cases := []struct {
+		name string
+		in   error
+		want kukeshared.AttachExit
+	}{
+		{
+			name: "nil maps to detached",
+			in:   nil,
+			want: kukeshared.AttachExitDetached,
+		},
+		{
+			name: "ErrDetached is detached",
+			in:   sbshattach.ErrDetached,
+			want: kukeshared.AttachExitDetached,
+		},
+		{
+			name: "wrapped ErrDetached is detached",
+			in:   fmt.Errorf("attach loop exited: %w", sbshattach.ErrDetached),
+			want: kukeshared.AttachExitDetached,
+		},
+		{
+			name: "ErrPeerClosed is peer-closed",
+			in:   sbshattach.ErrPeerClosed,
+			want: kukeshared.AttachExitPeerClosed,
+		},
+		{
+			name: "wrapped ErrPeerClosed is peer-closed",
+			in:   fmt.Errorf("attach loop exited: %w", sbshattach.ErrPeerClosed),
+			want: kukeshared.AttachExitPeerClosed,
+		},
+		{
+			name: "unrelated error is AttachExitError",
+			in:   errors.New("control socket lost"),
+			want: kukeshared.AttachExitError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := kukeshared.ClassifyAttachExit(tc.in); got != tc.want {
+				t.Errorf("ClassifyAttachExit(%v) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsCleanAttachExit(t *testing.T) {
+	cases := []struct {
+		name string
+		in   error
+		want bool
+	}{
+		{name: "nil is clean", in: nil, want: true},
+		{name: "ErrDetached is clean", in: sbshattach.ErrDetached, want: true},
+		{name: "ErrPeerClosed is clean", in: sbshattach.ErrPeerClosed, want: true},
+		{
+			name: "wrapped ErrDetached is clean",
+			in:   fmt.Errorf("attach loop exited: %w", sbshattach.ErrDetached),
+			want: true,
+		},
+		{
+			name: "wrapped ErrPeerClosed is clean",
+			in:   fmt.Errorf("attach loop exited: %w", sbshattach.ErrPeerClosed),
+			want: true,
+		},
+		{
+			name: "unrelated error is not clean",
+			in:   errors.New("dial unix: connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := kukeshared.IsCleanAttachExit(tc.in); got != tc.want {
+				t.Errorf("IsCleanAttachExit(%v) = %t, want %t", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.10.0
+	github.com/eminwux/sbsh v0.10.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.10.0 h1:4mNa7UQPmveVS0v5mesnF4RmB1RojV+kPTr50LpcJBI=
-github.com/eminwux/sbsh v0.10.0/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
+github.com/eminwux/sbsh v0.10.1 h1:uJY2XTHbz1bsYic3LPuu69t4/NtPW2gaIA+OflJOrfo=
+github.com/eminwux/sbsh v0.10.1/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Summary
- Issue #279: `kuke run -a --rm` killed the cell on every clean ^]^] detach, identical to a real workload exit. The kill RPC fired on every attach-loop return because the CLI could not distinguish detach from peer hangup.
- sbsh v0.10.1 ships the public sentinels (`attach.ErrDetached`, `attach.ErrPeerClosed`) the issue's caveat asked for ([sbsh#192](https://github.com/eminwux/sbsh/pull/192)). This PR bumps sbsh to v0.10.1 and switches the classification from the legacy `strings.Contains("close requested")` hack to `errors.Is` against the typed sentinels — no string match remains in either attach path.
- New `cmd/kuke/shared/attach_exit.go` lifts the classifier into one place (`ClassifyAttachExit` / `IsCleanAttachExit`) so `kuke attach` and `kuke run -a` share one source of truth, replacing the per-package `isCleanDetach`.
- `runAttachLoop` now returns `(detached bool, err error)` (issue's suggested tri-state). `attachAndMaybeAutoDelete` gates `KillCell` on `!detached`: clean ^]^] leaves the cell alive (parity with `kuke attach`), peer hangup / shell exit / controller error still fire `KillCell` so a long-lived `sleep infinity` root does not pin the cell.
- `--rm` flag docstring rewritten to reflect the new trigger surface (workload-end, not "any attach-loop return").

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — full suite green (including the regression suite below)
- [x] Pre-commit `golangci-lint` — clean (initial run flagged exhaustive switch on the new `AttachExit` enum; fixed before commit)
- [x] New `TestRun_RmAttach_KeepsCellAliveOnCleanDetach` — drives the mock `runFn` with `attach.ErrDetached` and asserts `KillCell` calls = 0 (encodes the #279 fix; flips the previous `KillsCellAfterAttachLoopReturns` regression-encoder)
- [x] New `TestRun_RmAttach_KillsCellOnPeerClosed` — drives with `attach.ErrPeerClosed`, asserts `KillCell` still fires (preserves #265 cleanup contract for workload-end)
- [x] Existing `TestRun_RmAttach_KillsCellEvenWhenAttachLoopErrors` — unchanged: a non-detach controller error still fires `KillCell`
- [x] `TestRun_RmAttach_AlreadyReady_StillKillsCellOnPeerClosed` — idempotent-Ready branch, peer-closed path still cleans up (was `…AfterAttachLoopReturns`)
- [x] `TestRun_RmAttach_KillCellFailureDoesNotMaskAttachExit` / `…NotFound_Silent` — switched to inject peer-closed so KillCell still fires under the new semantics
- [x] New `TestAttach_RunReturnsPeerClosedError` (sister of the existing detach test) — sentinel-based, asserts `kuke attach` exits 0 on either benign session-end signal
- [x] New `cmd/kuke/shared/attach_exit_test.go` — direct table-test coverage of `ClassifyAttachExit` and `IsCleanAttachExit` (nil, raw sentinels, wrapped sentinels, unrelated err)
- [ ] Interactive repro from the issue (Terminal A `sudo ./kuke run -a --rm -p kukeon-dev`, Terminal B attach + ^]^], Terminal A ^]^]; expect cell still listed in `kuke get cells`) — not run; the bug requires a real TTY and two terminals, which the agent cannot drive. Recommend the human reviewer reproduce before merge.
- [ ] `make dev-init` — not run; the change is CLI-only (`cmd/kuke/run`, `cmd/kuke/attach`, `cmd/kuke/shared`) and does not touch the daemon, the build path, or `/opt/kukeon`, so the daemon-parity regression guard does not apply per `CLAUDE.md`.

Closes #279