### PR TITLE
build: mark kuke and kukeond targets PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ all: clean kill $(BINS)
 .PHONY: release
 release: release-build
 
+.PHONY: kuke kukeond
 kuke:
 	go build \
 	-o kuke \


### PR DESCRIPTION
## Summary
- `make kuke` was a silent no-op when `./kuke` existed because the target had no `.PHONY` and no source-file prerequisites — GNU Make treated it as up-to-date and skipped the recipe. Same shape for `kukeond`.
- This masked stale-binary bugs in `scripts/dev-init.sh`, whose first step is `make kuke`; a stale `./kuke` would survive into later steps and surface as a confusing "unknown command" error in a different phase of the bootstrap.
- Fix matches the issue's suggested approach: declare both targets `.PHONY`, matching how `release`, `test-e2e`, `dev-init`, etc. are already treated. Go's build cache makes the unconditional rebuild fast when nothing changed.

## Test plan
- [x] Reproduced the bug pre-fix style and confirmed the fix: built `./kuke`, backdated its mtime to 2024-01-01, ran `make kuke` — mtime advanced to today (post-fix `make kuke` rebuilds instead of skipping).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (the target CI runs in `.github/workflows/test.yaml`)
- [ ] `make dev-init` not run — requires sudo + containerd + docker; this change only affects whether the Makefile's first step actually rebuilds, which the reproduction above verifies directly.

Closes #277