### PR TITLE
test: skip cni bootstrap defaults subtest when /opt/cni isn't writable

### DIFF
--- a/internal/cni/bootstrap_test.go
+++ b/internal/cni/bootstrap_test.go
@@ -69,7 +69,22 @@ func TestBootstrapCNI(t *testing.T) {
 		},
 		{
 			name: "success with empty directories (uses defaults)",
-			setup: func(_ *testing.T, _ string) (string, string, string) {
+			setup: func(t *testing.T, _ string) (string, string, string) {
+				// This subtest exercises the production-default path —
+				// BootstrapCNI("","","") resolves to /opt/cni/{net.d,cache,bin},
+				// so it cannot be substituted with a tempdir without losing
+				// the tripwire. Skip on hosts where /opt/cni isn't writable
+				// (typical of non-root `go test` runs); under root or in
+				// privileged CI the subtest still runs.
+				if err := os.MkdirAll("/opt/cni", 0o750); err != nil {
+					t.Skipf("skip: /opt/cni not creatable by current user: %v", err)
+				}
+				probe, err := os.CreateTemp("/opt/cni", ".bootstrap-probe-*")
+				if err != nil {
+					t.Skipf("skip: /opt/cni not writable by current user: %v", err)
+				}
+				probe.Close()
+				_ = os.Remove(probe.Name())
 				return "", "", ""
 			},
 			wantReport: func(t *testing.T, report cni.BootstrapReport) {


### PR DESCRIPTION
## Summary
- `TestBootstrapCNI/success_with_empty_directories_(uses_defaults)` was unrunnable on any unprivileged host because `BootstrapCNI(\"\",\"\",\"\")` resolves to the hardcoded `/opt/cni/{net.d,cache,bin}` defaults and then `mkdir`s them — a tempdir substitution would defeat the purpose of the subtest (asserting the production-default path).
- Added a `t.Skip` guard at the top of the subtest using a writability probe (try `MkdirAll(/opt/cni)` then `CreateTemp` inside it). On root or privileged CI the tripwire still fires; on unprivileged dev/CI the subtest silently skips. Matches issue #264 Option 1, the lower-blast-radius fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cni/... -v -run TestBootstrapCNI` as unprivileged user — defaults subtest now `SKIP`, all others `PASS`
- [x] `sudo go test ./internal/cni/... -v -run "TestBootstrapCNI/success_with_empty_directories"` as root — subtest still `PASS` (tripwire preserved)
- [x] `make test` — all packages pass
- [ ] `make dev-init` — not run; this PR is test-file-only and does not touch the daemon, build path, or anything under `/opt/kukeon`

Closes #264