### PR TITLE
refactor: invert kuke run attach default — drop -a, add -d/--detach

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -362,7 +362,7 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_STACK = DefineKV("KUKE_RUN_STACK", "kuke/run/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_RUN_ATTACH = DefineKV("KUKE_RUN_ATTACH", "kuke/run/attach")
+	KUKE_RUN_DETACH = DefineKV("KUKE_RUN_DETACH", "kuke/run/detach")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_CONTAINER = DefineKV("KUKE_RUN_CONTAINER", "kuke/run/container")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/run/attach.go
+++ b/cmd/kuke/run/attach.go
@@ -40,8 +40,8 @@ type MockRunKey struct{}
 // detach / context cancel and any unrecoverable controller error otherwise.
 type runFn func(ctx context.Context, opts attach.Options) error
 
-// pickAttachTarget resolves the container `kuke run -a` should attach to,
-// applying the documented precedence:
+// pickAttachTarget resolves the container the post-start attach should
+// connect to, applying the documented precedence:
 //
 //  1. explicit --container flag, when set
 //  2. cell.tty.default, when the spec sets it
@@ -85,7 +85,7 @@ func pickAttachTarget(spec v1beta1.CellSpec, cellName, explicit string) (string,
 	}
 
 	return "", fmt.Errorf(
-		"%w (cell %q); declare 'attachable: true' on one container or omit -a",
+		"%w (cell %q); declare 'attachable: true' on one container or pass -d/--detach",
 		errdefs.ErrAttachNoCandidate, cellName,
 	)
 }
@@ -108,18 +108,17 @@ func formatAttachableList(spec v1beta1.CellSpec) string {
 
 // runAttachLoop resolves the per-container sbsh control socket via the
 // daemon's AttachContainer RPC and drives the in-process attach loop.
-// Returns the tri-state used by the -a --rm cleanup decision in
+// Returns the tri-state used by the --rm cleanup decision in
 // attachAndMaybeAutoDelete:
 //
 //   - detached=true,  err=nil — operator pressed ^]^] (or peer issued
 //     a Detach RPC). Cell must stay alive.
 //   - detached=false, err=nil — peer dropped the connection (workload
-//     exited / hung up). Surface exit 0; -a --rm fires KillCell so a
+//     exited / hung up). Surface exit 0; --rm fires KillCell so a
 //     long-lived root does not pin the cell.
 //   - detached=false, err≠nil — pre-attach setup error or unrecoverable
-//     controller error. Surface to the user; -a --rm still fires
-//     KillCell because a half-detached session would otherwise leak
-//     the cell.
+//     controller error. Surface to the user; --rm still fires KillCell
+//     because a half-detached session would otherwise leak the cell.
 func runAttachLoop(
 	cmd *cobra.Command,
 	client kukeonv1.Client,

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -14,13 +14,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package run implements the `kuke run` verb. The original `-f <file>` form
-// (phase 1c) parses a single-cell YAML doc and idempotently create-and-starts
-// the cell. Phase 2a added `-a/--attach` so the same invocation can drop the
-// operator into the cell's attachable terminal. Phase 2b adds `-p/--profile`,
-// which materializes a CellDoc from a per-user CellProfile under
-// $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR) and then walks the same
-// create+start[+attach] path.
+// Package run implements the `kuke run` verb. The `-f <file>` form parses a
+// single-cell YAML doc and idempotently create-and-starts the cell; the
+// `-p/--profile` form materializes a CellDoc from a per-user CellProfile under
+// $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR) and walks the same path.
+//
+// `kuke run` attaches to the cell's attachable container by default, matching
+// `docker run` and `kubectl run -it`. Pass `-d/--detach` to return immediately
+// after start without attaching.
 package run
 
 import (
@@ -46,8 +47,9 @@ type MockControllerKey struct{}
 
 // NewRunCmd builds the `kuke run` cobra command. `-f` reads a single-cell
 // YAML doc; `-p` reads a per-user CellProfile and materializes the same
-// CellDoc shape. Exactly one of the two is required. `-a` then drops the
-// operator into the cell's attachable terminal once the cell is up.
+// CellDoc shape. Exactly one of the two is required. By default, after the
+// cell starts the CLI drops the operator into the cell's attachable terminal;
+// `-d/--detach` opts out of the post-start attach.
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run (-f <file> | -p <profile>)",
@@ -83,25 +85,27 @@ func NewRunCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Stack that owns the cell (overrides spec.stackId only when the doc is empty)")
 	_ = viper.BindPFlag(config.KUKE_RUN_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 
-	cmd.Flags().BoolP("attach", "a", false,
-		"After start, attach to the cell's attachable container (precedence: --container > cell.tty.default > first attachable)")
-	_ = viper.BindPFlag(config.KUKE_RUN_ATTACH.ViperKey, cmd.Flags().Lookup("attach"))
+	cmd.Flags().BoolP("detach", "d", false,
+		"Return immediately after start without attaching (default: attach to the cell's "+
+			"attachable container, precedence --container > cell.tty.default > first attachable)")
+	_ = viper.BindPFlag(config.KUKE_RUN_DETACH.ViperKey, cmd.Flags().Lookup("detach"))
 	cmd.Flags().String("container", "",
-		"Container to attach to (only valid with -a; must be attachable)")
+		"Container to attach to (only valid in attach mode; rejected with -d/--detach; must be attachable)")
 	_ = viper.BindPFlag(config.KUKE_RUN_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
 	cmd.Flags().Bool("rm", false,
 		"Best-effort delete the cell after it is no longer needed "+
-			"(any rc). Without -a, the trigger is the root container's "+
-			"task exit. With -a, the trigger is the attach loop exiting "+
-			"because the workload terminated, the peer hung up, or an "+
-			"unrecoverable controller error fired — the CLI then sends "+
-			"KillCell so a long-lived root (e.g. `sleep infinity`) does "+
-			"not pin the cell. A clean ^]^] detach is NOT a trigger: the "+
-			"cell stays alive so the operator can re-attach later "+
-			"(parity with `kuke attach`). Daemon-mode only — incompatible "+
-			"with --no-daemon. Cleanup runs from kukeond's reconcile "+
-			"loop, so latency is bounded by the reconcile interval "+
-			"rather than firing the instant the trigger fires.")
+			"(any rc). With -d/--detach, the trigger is the root "+
+			"container's task exit. In the default attach mode, the "+
+			"trigger is the attach loop exiting because the workload "+
+			"terminated, the peer hung up, or an unrecoverable "+
+			"controller error fired — the CLI then sends KillCell so a "+
+			"long-lived root (e.g. `sleep infinity`) does not pin the "+
+			"cell. A clean ^]^] detach is NOT a trigger: the cell stays "+
+			"alive so the operator can re-attach later (parity with "+
+			"`kuke attach`). Daemon-mode only — incompatible with "+
+			"--no-daemon. Cleanup runs from kukeond's reconcile loop, "+
+			"so latency is bounded by the reconcile interval rather "+
+			"than firing the instant the trigger fires.")
 	_ = viper.BindPFlag(config.KUKE_RUN_RM.ViperKey, cmd.Flags().Lookup("rm"))
 
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -119,7 +123,7 @@ type runFlags struct {
 	file          string
 	profileName   string
 	output        string
-	doAttach      bool
+	detach        bool
 	containerFlag string
 	autoDelete    bool
 }
@@ -128,7 +132,7 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 	flags := runFlags{
 		file:          strings.TrimSpace(viper.GetString(config.KUKE_RUN_FILE.ViperKey)),
 		profileName:   strings.TrimSpace(viper.GetString(config.KUKE_RUN_PROFILE.ViperKey)),
-		doAttach:      viper.GetBool(config.KUKE_RUN_ATTACH.ViperKey),
+		detach:        viper.GetBool(config.KUKE_RUN_DETACH.ViperKey),
 		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
 		autoDelete:    viper.GetBool(config.KUKE_RUN_RM.ViperKey),
 	}
@@ -142,14 +146,15 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		return runFlags{}, fmt.Errorf("invalid --output %q: want json or yaml", flags.output)
 	}
 
-	if !flags.doAttach && flags.containerFlag != "" {
-		return runFlags{}, errors.New("--container is only valid together with -a/--attach")
+	if flags.detach && flags.containerFlag != "" {
+		return runFlags{}, errors.New("--container is incompatible with -d/--detach")
 	}
-	if flags.doAttach && flags.output != "" {
-		// -a hands the terminal to sbsh; mixing structured -o output with an
-		// interactive attach loop produces garbled output that nothing can
-		// parse. Reject the combination so callers pick one mode.
-		return runFlags{}, errors.New("--output is incompatible with -a/--attach")
+	if !flags.detach && flags.output != "" {
+		// The default attach mode hands the terminal to sbsh; mixing
+		// structured -o output with an interactive attach loop produces
+		// garbled output that nothing can parse. Reject the combination
+		// so callers pick one mode.
+		return runFlags{}, errors.New("--output is incompatible with attach mode (pass -d/--detach)")
 	}
 	if flags.autoDelete && viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey) {
 		// --rm needs a long-lived process to watch the root task and trigger
@@ -211,7 +216,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 			if printErr := printRunResult(cmd, noOpResultFromGet(pre), flags.output); printErr != nil {
 				return printErr
 			}
-			if flags.doAttach {
+			if !flags.detach {
 				return attachAndMaybeAutoDelete(cmd, client, cellDoc, flags)
 			}
 			return nil
@@ -228,21 +233,21 @@ func runRun(cmd *cobra.Command, args []string) error {
 	if printErr := printRunResult(cmd, result, flags.output); printErr != nil {
 		return printErr
 	}
-	if flags.doAttach {
+	if !flags.detach {
 		return attachAndMaybeAutoDelete(cmd, client, cellDoc, flags)
 	}
 	return nil
 }
 
-// attachAndMaybeAutoDelete drives the attach loop and, under -a --rm,
-// fires KillCell once the loop returns — but only if the loop exited
-// because the workload ended (peer hangup, shell exit, controller
-// error). A clean ^]^] detach (issue #279) leaves the cell alive so the
-// operator can re-attach later, matching `kuke attach`'s exit-0
-// semantics.
+// attachAndMaybeAutoDelete drives the attach loop and, under --rm in
+// the default attach mode, fires KillCell once the loop returns — but
+// only if the loop exited because the workload ended (peer hangup,
+// shell exit, controller error). A clean ^]^] detach (issue #279)
+// leaves the cell alive so the operator can re-attach later, matching
+// `kuke attach`'s exit-0 semantics.
 //
 // Both the create-and-start path and the already-Ready idempotent
-// short-circuit funnel through here so re-running `kuke run -a --rm`
+// short-circuit funnel through here so re-running `kuke run --rm`
 // against an up cell still gets cleanup on workload exit (issue #265
 // regression: the original fix only patched the create path).
 //
@@ -265,7 +270,7 @@ func attachAndMaybeAutoDelete(
 	return attachErr
 }
 
-// autoDeleteAfterAttach drives the -a --rm cleanup path. KillCell is
+// autoDeleteAfterAttach drives the --rm cleanup path under attach mode. KillCell is
 // idempotent — if the attach target was the root and the user typed
 // `exit`, the root task is already gone and KillCell just confirms it;
 // the kill+delete sequence in autoDeleteCell tolerates a missing task.

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -245,7 +245,7 @@ func TestRun_FromFile_CreatesAndStarts(t *testing.T) {
 		},
 	}
 	cmd, out := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -289,6 +289,7 @@ func TestRun_FlagFallback_WhenDocOmitsLocation(t *testing.T) {
 	cmd, _ := newCmd(t, fc)
 	cmd.SetArgs([]string{
 		"-f", writeTempYAML(t, cellYAMLNoLocation),
+		"-d",
 		"--realm", "flag-realm",
 		"--space", "flag-space",
 		"--stack", "flag-stack",
@@ -317,7 +318,7 @@ func TestRun_DefaultLocation_WhenDocAndFlagsOmit(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, cellYAMLNoLocation)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, cellYAMLNoLocation), "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -344,6 +345,7 @@ func TestRun_DocLocationWinsOverFlag(t *testing.T) {
 	cmd, _ := newCmd(t, fc)
 	cmd.SetArgs([]string{
 		"-f", writeTempYAML(t, validCellYAML),
+		"-d",
 		"--realm", "ignored", "--space", "ignored", "--stack", "ignored",
 	})
 
@@ -360,7 +362,7 @@ func TestRun_MultiDoc_Errors(t *testing.T) {
 
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, multiDocYAML)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, multiDocYAML), "-d"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -379,7 +381,7 @@ func TestRun_NonCellKind_Errors(t *testing.T) {
 
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, realmDocYAML)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, realmDocYAML), "-d"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -424,7 +426,7 @@ func TestRun_ExistingCell_MatchingSpec_AlreadyReady_ShortCircuits(t *testing.T) 
 		},
 	}
 	cmd, out := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -477,7 +479,7 @@ func TestRun_ExistingCell_MatchingSpec_NotReady_StillEnsures(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -514,7 +516,7 @@ func TestRun_ExistingCell_DivergingContainerSet_RefusesAndPointsToApply(t *testi
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -540,7 +542,7 @@ func TestRun_OutputJSON(t *testing.T) {
 		},
 	}
 	cmd, out := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-o", "json"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "-o", "json"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -567,7 +569,7 @@ func TestRun_OutputYAML(t *testing.T) {
 		},
 	}
 	cmd, out := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-o", "yaml"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "-o", "yaml"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -590,7 +592,7 @@ func TestRun_InvalidOutput_Errors(t *testing.T) {
 
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-o", "table"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "-o", "table"})
 
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "invalid --output") {
@@ -824,7 +826,7 @@ func TestRun_Attach_AfterCreate_UsesTtyDefault(t *testing.T) {
 	}
 	run := &runCapture{}
 	cmd, _ := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -857,7 +859,7 @@ func TestRun_Attach_AfterCreate_FirstAttachableWhenNoDefault(t *testing.T) {
 	}
 	run := &runCapture{}
 	cmd, _ := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableNoDefaultYAML), "-a"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableNoDefaultYAML)})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -880,7 +882,7 @@ func TestRun_Attach_AfterCreate_ExplicitContainerWinsOverDefault(t *testing.T) {
 	cmd, _ := newCmdWithRun(t, fc, run)
 	cmd.SetArgs([]string{
 		"-f", writeTempYAML(t, attachableCellYAML),
-		"-a", "--container", "shell",
+		"--container", "shell",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -894,11 +896,12 @@ func TestRun_Attach_AfterCreate_ExplicitContainerWinsOverDefault(t *testing.T) {
 func TestRun_Attach_NoCandidate_Errors_NoMutationOnAttach(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
-	// validCellYAML has no attachable containers — -a must fail with the
-	// explicit ErrAttachNoCandidate without driving the attach loop. The
-	// CreateCell ran already (fail-late after start is the documented UX);
-	// the cell is left Ready and the operator can re-run with --container or
-	// fix the spec.
+	// validCellYAML has no attachable containers — the default attach
+	// mode must fail with the explicit ErrAttachNoCandidate without
+	// driving the attach loop. The CreateCell ran already (fail-late
+	// after start is the documented UX); the cell is left Ready and
+	// the operator can re-run with --container, fix the spec, or pass
+	// -d/--detach.
 	fc := &fakeClient{
 		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
 			return successCreateResult(doc), nil
@@ -906,7 +909,7 @@ func TestRun_Attach_NoCandidate_Errors_NoMutationOnAttach(t *testing.T) {
 	}
 	run := &runCapture{}
 	cmd, _ := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-a"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
 
 	err := cmd.Execute()
 	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
@@ -932,7 +935,7 @@ func TestRun_Attach_BadContainerFlag_Errors(t *testing.T) {
 	cmd, out := newCmdWithRun(t, fc, run)
 	cmd.SetArgs([]string{
 		"-f", writeTempYAML(t, attachableCellYAML),
-		"-a", "--container", "ghost",
+		"--container", "ghost",
 	})
 
 	err := cmd.Execute()
@@ -950,19 +953,22 @@ func TestRun_Attach_BadContainerFlag_Errors(t *testing.T) {
 	}
 }
 
-func TestRun_Attach_ContainerWithoutAttachFlag_Errors(t *testing.T) {
+func TestRun_Attach_ContainerWithDetachFlag_Errors(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
+	// --container only makes sense in the default attach mode; combining
+	// it with -d/--detach is a contradiction and must be rejected before
+	// any cell is mutated.
 	fc := &fakeClient{}
 	cmd, _ := newCmdWithRun(t, fc, &runCapture{})
 	cmd.SetArgs([]string{
 		"-f", writeTempYAML(t, attachableCellYAML),
-		"--container", "shell",
+		"-d", "--container", "shell",
 	})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--container is only valid") {
-		t.Fatalf("err=%v want '--container is only valid' guard", err)
+	if err == nil || !strings.Contains(err.Error(), "--container is incompatible") {
+		t.Fatalf("err=%v want '--container is incompatible with -d/--detach' guard", err)
 	}
 	if fc.createCalls != 0 {
 		t.Errorf("CreateCell calls=%d want 0 (must reject before mutating)", fc.createCalls)
@@ -976,7 +982,7 @@ func TestRun_Attach_OutputFlag_Errors(t *testing.T) {
 	cmd, _ := newCmdWithRun(t, fc, &runCapture{})
 	cmd.SetArgs([]string{
 		"-f", writeTempYAML(t, attachableCellYAML),
-		"-a", "-o", "json",
+		"-o", "json",
 	})
 
 	err := cmd.Execute()
@@ -1019,7 +1025,7 @@ func TestRun_Attach_AlreadyReady_ShortCircuitThenAttaches(t *testing.T) {
 	}
 	run := &runCapture{}
 	cmd, _ := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1038,11 +1044,11 @@ func TestRun_Attach_AlreadyReady_ShortCircuitThenAttaches(t *testing.T) {
 	}
 }
 
-func TestNewRunCmd_AttachFlagRegistered(t *testing.T) {
+func TestNewRunCmd_DetachFlagRegistered(t *testing.T) {
 	cmd := runcmd.NewRunCmd()
-	attachFlag := cmd.Flags().Lookup("attach")
-	if attachFlag == nil || attachFlag.Shorthand != "a" {
-		t.Errorf("expected -a/--attach flag, got %+v", attachFlag)
+	detachFlag := cmd.Flags().Lookup("detach")
+	if detachFlag == nil || detachFlag.Shorthand != "d" {
+		t.Errorf("expected -d/--detach flag, got %+v", detachFlag)
 	}
 	if got := cmd.Flags().Lookup("container"); got == nil {
 		t.Errorf("expected --container flag")
@@ -1101,7 +1107,7 @@ func TestRun_FromProfile_CreatesAndStarts(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-p", "claude-cell"})
+	cmd.SetArgs([]string{"-p", "claude-cell", "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1160,7 +1166,7 @@ spec:
 			},
 		}
 		cmd, _ := newCmd(t, fc)
-		cmd.SetArgs([]string{"-p", "claude"})
+		cmd.SetArgs([]string{"-p", "claude", "-d"})
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute #%d: %v", i, err)
 		}
@@ -1191,7 +1197,7 @@ func TestRun_FromProfile_LocationFlagsOverride(t *testing.T) {
 	// The materialized profile sets realm/space/stack already; --realm/--space/--stack
 	// flags must NOT override values the profile already provides — the same
 	// "doc wins over flag" rule that -f obeys.
-	cmd.SetArgs([]string{"-p", "claude-cell", "--realm", "x", "--space", "y", "--stack", "z"})
+	cmd.SetArgs([]string{"-p", "claude-cell", "-d", "--realm", "x", "--space", "y", "--stack", "z"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1207,7 +1213,7 @@ func TestRun_FromProfile_UnknownProfile_Errors(t *testing.T) {
 
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-p", "ghost"})
+	cmd.SetArgs([]string{"-p", "ghost", "-d"})
 
 	err := cmd.Execute()
 	if !errors.Is(err, errdefs.ErrProfileNotFound) {
@@ -1227,7 +1233,7 @@ func TestRun_FromProfile_FileAndProfile_MutuallyExclusive(t *testing.T) {
 
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-p", "claude-cell"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-p", "claude-cell", "-d"})
 
 	err := cmd.Execute()
 	// MarkFlagsMutuallyExclusive emits "if any flags in the group [file profile]
@@ -1248,7 +1254,7 @@ func TestRun_RejectsPositionalArgs(t *testing.T) {
 
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "my-cell"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "my-cell"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -1263,9 +1269,9 @@ func TestRun_FromProfile_Attach_HeadlineFlow(t *testing.T) {
 	t.Cleanup(viper.Reset)
 	writeTempProfile(t)
 
-	// Headline flow from the issue: `kuke run -p claude-cell -a` materializes
+	// Headline flow from the issue: `kuke run -p claude-cell` materializes
 	// the profile, creates+starts the cell, then attaches to cell.tty.default
-	// (the `work` container).
+	// (the `work` container) by default.
 	fc := &fakeClient{
 		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
 			return successCreateResult(doc), nil
@@ -1274,7 +1280,7 @@ func TestRun_FromProfile_Attach_HeadlineFlow(t *testing.T) {
 	}
 	run := &runCapture{}
 	cmd, _ := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-p", "claude-cell", "-a"})
+	cmd.SetArgs([]string{"-p", "claude-cell"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1294,10 +1300,10 @@ func TestRun_FromProfile_Attach_HeadlineFlow(t *testing.T) {
 }
 
 func TestRun_RmFlag_SetsAutoDeleteOnSpec(t *testing.T) {
-	// `kuke run --rm -f cell.yaml` must surface AutoDelete=true on the
-	// CellDoc the daemon receives, in both attached and detached modes.
-	// The daemon side (KukeonV1Service.CreateCell) reads that bool to
-	// install the auto-delete watcher.
+	// `kuke run -d --rm -f cell.yaml` must surface AutoDelete=true on
+	// the CellDoc the daemon receives, in both attached and detached
+	// modes. The daemon side (KukeonV1Service.CreateCell) reads that
+	// bool to install the auto-delete watcher.
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
@@ -1306,7 +1312,7 @@ func TestRun_RmFlag_SetsAutoDeleteOnSpec(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "--rm"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1328,7 +1334,7 @@ func TestRun_NoRmFlag_LeavesAutoDeleteFalse(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1350,7 +1356,7 @@ func TestRun_RmFlag_RejectsNoDaemon(t *testing.T) {
 
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "--rm"})
 
 	err := cmd.Execute()
 	if err == nil || !strings.Contains(err.Error(), "--rm is incompatible with --no-daemon") {
@@ -1391,7 +1397,7 @@ spec:
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, yamlWithAutoDelete)})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, yamlWithAutoDelete), "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1402,10 +1408,11 @@ spec:
 }
 
 func TestRun_RmAttach_KeepsCellAliveOnCleanDetach(t *testing.T) {
-	// Issue #279: a clean ^]^] detach must NOT trigger the -a --rm
-	// KillCell. The operator may want to re-attach later — same
-	// semantics as `kuke attach`. Only workload-end signals (peer
-	// hangup, shell exit, controller error) should fire cleanup.
+	// Issue #279: a clean ^]^] detach must NOT trigger the --rm
+	// KillCell under the default attach mode. The operator may want
+	// to re-attach later — same semantics as `kuke attach`. Only
+	// workload-end signals (peer hangup, shell exit, controller
+	// error) should fire cleanup.
 	//
 	// Inject attach.ErrDetached as the attach-loop result; that is
 	// what sbsh v0.10.1 returns when the in-band detach keystroke
@@ -1425,7 +1432,7 @@ func TestRun_RmAttach_KeepsCellAliveOnCleanDetach(t *testing.T) {
 		err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrDetached),
 	}
 	cmd, _ := newCmdWithRunFn(t, fc, run.fn)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "--rm"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v (clean detach must surface as exit 0)", err)
@@ -1442,12 +1449,13 @@ func TestRun_RmAttach_KeepsCellAliveOnCleanDetach(t *testing.T) {
 }
 
 func TestRun_RmAttach_KillsCellOnPeerClosed(t *testing.T) {
-	// Issue #265: with -a --rm and a long-lived root (`sleep infinity`)
-	// peering an attachable container, the root task never exits when
-	// the workload terminates on the peer side, so the reconciler's
-	// auto-delete trigger never fires. The CLI must call KillCell when
-	// the attach loop returns peer-closed so the daemon's reconciler
-	// reaps the cell on the next tick.
+	// Issue #265: with --rm in the default attach mode and a
+	// long-lived root (`sleep infinity`) peering an attachable
+	// container, the root task never exits when the workload
+	// terminates on the peer side, so the reconciler's auto-delete
+	// trigger never fires. The CLI must call KillCell when the attach
+	// loop returns peer-closed so the daemon's reconciler reaps the
+	// cell on the next tick.
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
@@ -1463,7 +1471,7 @@ func TestRun_RmAttach_KillsCellOnPeerClosed(t *testing.T) {
 		err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed),
 	}
 	cmd, _ := newCmdWithRunFn(t, fc, run.fn)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "--rm"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v (peer-closed must surface as exit 0 — workload ended)", err)
@@ -1504,7 +1512,7 @@ func TestRun_RmAttach_KillsCellEvenWhenAttachLoopErrors(t *testing.T) {
 	}
 	run := &runErrorCapture{err: attachLoopErr}
 	cmd, _ := newCmdWithRunFn(t, fc, run.fn)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "--rm"})
 
 	if err := cmd.Execute(); !errors.Is(err, attachLoopErr) {
 		t.Fatalf("Execute err=%v want attachLoopErr (must surface to caller)", err)
@@ -1533,7 +1541,7 @@ func TestRun_RmAttach_KillCellFailureDoesNotMaskAttachExit(t *testing.T) {
 	}
 	run := &runCapture{err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed)}
 	cmd, buf := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "--rm"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v (KillCell failure on workload-end must not surface as a run error)", err)
@@ -1566,7 +1574,7 @@ func TestRun_RmAttach_KillCellNotFound_Silent(t *testing.T) {
 	}
 	run := &runCapture{err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed)}
 	cmd, buf := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "--rm"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1576,12 +1584,13 @@ func TestRun_RmAttach_KillCellNotFound_Silent(t *testing.T) {
 	}
 }
 
-func TestRun_RmNoAttach_DoesNotCallKillCell(t *testing.T) {
-	// Without -a, --rm preserves its original semantics: the daemon's
-	// reconciler watches the root task and reaps when it exits. The CLI
-	// must not pre-empt that path with a KillCell — that would break
-	// `kuke run --rm -f cell.yaml` for a long-running workload that the
-	// operator wants left running until it exits on its own.
+func TestRun_RmDetach_DoesNotCallKillCell(t *testing.T) {
+	// With -d/--detach, --rm preserves its original semantics: the
+	// daemon's reconciler watches the root task and reaps when it
+	// exits. The CLI must not pre-empt that path with a KillCell —
+	// that would break `kuke run -d --rm -f cell.yaml` for a
+	// long-running workload that the operator wants left running
+	// until it exits on its own.
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
@@ -1590,22 +1599,22 @@ func TestRun_RmNoAttach_DoesNotCallKillCell(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "--rm"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if fc.killCalls != 0 {
-		t.Errorf("KillCell calls=%d want 0 (no -a means the reconciler owns cleanup)", fc.killCalls)
+		t.Errorf("KillCell calls=%d want 0 (-d means the reconciler owns cleanup)", fc.killCalls)
 	}
 }
 
 func TestRun_RmAttach_AlreadyReady_StillKillsCellOnPeerClosed(t *testing.T) {
-	// Idempotent branch regression guard: re-running `kuke run -a --rm`
+	// Idempotent branch regression guard: re-running `kuke run --rm`
 	// against an already-Ready cell with matching spec must still fire
 	// KillCell when the attach loop reports workload-end (peer hangup
 	// here). Otherwise a user with a dangling cell from a pre-fix
-	// invocation cannot recover via -a --rm, reproducing the original
+	// invocation cannot recover via --rm, reproducing the original
 	// #265 symptom.
 	t.Cleanup(viper.Reset)
 
@@ -1640,7 +1649,7 @@ func TestRun_RmAttach_AlreadyReady_StillKillsCellOnPeerClosed(t *testing.T) {
 	}
 	run := &runCapture{err: fmt.Errorf("wrapped by harness: %w", sbshattach.ErrPeerClosed)}
 	cmd, _ := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a", "--rm"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "--rm"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -1660,8 +1669,8 @@ func TestRun_RmAttach_AlreadyReady_StillKillsCellOnPeerClosed(t *testing.T) {
 }
 
 func TestRun_AttachNoRm_DoesNotCallKillCell(t *testing.T) {
-	// Defensive guard: -a alone must not engage cleanup. KillCell only
-	// fires when --rm is also set.
+	// Defensive guard: the default attach mode alone must not engage
+	// cleanup. KillCell only fires when --rm is also set.
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
@@ -1672,13 +1681,13 @@ func TestRun_AttachNoRm_DoesNotCallKillCell(t *testing.T) {
 	}
 	run := &runCapture{}
 	cmd, _ := newCmdWithRun(t, fc, run)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-a"})
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	if fc.killCalls != 0 {
-		t.Errorf("KillCell calls=%d want 0 (-a without --rm must not clean up)", fc.killCalls)
+		t.Errorf("KillCell calls=%d want 0 (attach without --rm must not clean up)", fc.killCalls)
 	}
 }
 

--- a/cmd/kuke/shared/attach_exit.go
+++ b/cmd/kuke/shared/attach_exit.go
@@ -23,26 +23,26 @@ import (
 )
 
 // AttachExit classifies how an in-process sbsh attach loop ended.
-// `kuke attach` and `kuke run -a` both drive the same loop and need to
-// branch on the same three outcomes.
+// `kuke attach` and the default-attach branch of `kuke run` both drive
+// the same loop and need to branch on the same three outcomes.
 type AttachExit int
 
 const (
 	// AttachExitDetached signals a clean ^]^] (or peer-issued Detach
-	// RPC). The remote terminal is still alive and `kuke run -a --rm`
+	// RPC). The remote terminal is still alive and `kuke run --rm`
 	// must NOT kill the cell — the operator may want to re-attach.
 	AttachExitDetached AttachExit = iota
 
 	// AttachExitPeerClosed signals the remote terminal dropped the
 	// connection (workload exited, peer hung up). From the user's
 	// perspective the session ended cleanly (exit 0), but `kuke run
-	// -a --rm` should fire KillCell so a long-lived root (e.g.
+	// --rm` should fire KillCell so a long-lived root (e.g.
 	// `sleep infinity`) does not pin the cell.
 	AttachExitPeerClosed
 
 	// AttachExitError signals an unrecoverable controller error
 	// (control socket lost, RPC failure, context cancel, …). The
-	// caller surfaces the error to the user and `kuke run -a --rm`
+	// caller surfaces the error to the user and `kuke run --rm`
 	// fires KillCell so a half-detached session does not leak the
 	// cell.
 	AttachExitError
@@ -62,7 +62,7 @@ func ClassifyAttachExit(err error) AttachExit {
 	case err == nil:
 		// pkg/attach.Run already collapses context-canceled to nil; we
 		// treat a nil return as "operator ended the session cleanly",
-		// which for `kuke run -a --rm` means "leave the cell alive" —
+		// which for `kuke run --rm` means "leave the cell alive" —
 		// same semantics as ErrDetached.
 		return AttachExitDetached
 	case errors.Is(err, attach.ErrDetached):

--- a/internal/controller/runner/refresh_test.go
+++ b/internal/controller/runner/refresh_test.go
@@ -127,7 +127,7 @@ func TestLatchReadyObserved(t *testing.T) {
 // writers (provisionNewCell, StartCell idempotent skip, StartCell
 // happy path, StartContainer, RecreateCell) all rely on. State and
 // ReadyObserved must close together — without that, a KillCell that
-// races the first reconciler tick (e.g. `kuke run -a --rm` exiting
+// races the first reconciler tick (e.g. `kuke run --rm` exiting
 // attach inside the reconcile interval) flips persisted state Ready
 // → Stopped before any reconciler observation, leaving
 // readyObserved=false on disk. Subsequent ticks then see

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -51,9 +51,10 @@ type CellSpec struct {
 // CellTty is cell-level tty/attach config. Kept intentionally minimal: only
 // fields the container or container-level tty cannot express belong here.
 type CellTty struct {
-	// Default names the attachable container `kuke run -a` (phase 2a)
-	// selects when no --container flag is given. Must reference an
-	// existing container in this cell whose Attachable=true (or be empty).
+	// Default names the attachable container the post-start attach
+	// (`kuke run`'s default mode) selects when no --container flag is
+	// given. Must reference an existing container in this cell whose
+	// Attachable=true (or be empty).
 	Default string `json:"default,omitempty" yaml:"default,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- Flip `kuke run` so the post-start attach is the default and `-d/--detach` is the opt-out — matches `docker run` and `kubectl run -it`, removes the recurring context-switch friction.
- Drop `-a/--attach` outright (no deprecation alias); pre-1.0 CLI, one breaking change is cleaner than carrying both flags.
- Rename viper key `KUKE_RUN_ATTACH` → `KUKE_RUN_DETACH` and invert validation: `--container` rejected with `-d`, `--output` rejected without `-d`.

BREAKING: `kuke run -f <file>` (or `-p <profile>`) now attaches by default; pass `-d/--detach` to keep the previous detached behavior. The `-a/--attach` flag is removed.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/kuke/run/...` passes (test cases inverted; `-a` dropped from attach cases, `-d` added to detached cases, new `TestRun_Attach_ContainerWithDetachFlag_Errors` and renamed `TestNewRunCmd_DetachFlagRegistered` / `TestRun_RmDetach_DoesNotCallKillCell`)
- [x] `make test` (full unit/integration suite excluding e2e) all packages pass
- [x] `make dev-init` daemon-parity check passes (both `kuke get realms` and `kuke get realms --no-daemon` print the documented `default` + `kuke-system` Ready table)
- [x] Manual smoke `sudo ./kuke run -f /tmp/cell.yaml -d` returns immediately after start (rc=0, no terminal handover)
- [x] Manual smoke `sudo ./kuke run -f /tmp/cell.yaml </dev/null` (no flags) drops into the sbsh attach loop (`To detach, press ^] twice` banner printed; loop exits when stdin EOFs)
- [x] Manual smoke `sudo ./kuke run -f /tmp/cell.yaml -d --container work` rejected with `--container is incompatible with -d/--detach`
- [x] `sudo ./kuke run -f cell.yaml -a` rejected as unknown shorthand flag (no deprecation alias)

## Acceptance criteria
- [x] `cmd/kuke/run/run.go` registers `-d/--detach` and removes `-a/--attach`; viper key renamed `KUKE_RUN_ATTACH` → `KUKE_RUN_DETACH` in `cmd/config/env.go`.
- [x] `parseRunFlags` field renamed `doAttach` → `detach`; `runRun` and the already-Ready short-circuit invert their checks (`flags.doAttach` → `!flags.detach`).
- [x] Validation rules inverted: `--container` rejected only when `-d` set; `--output` rejected only when `-d` not set; `--rm` + `--no-daemon` rule unchanged.
- [x] Package doc and `--rm` long help rewritten to describe attach-as-default and `-d` as opt-out. Surrounding doc comments in `attach.go`, `cmd/kuke/shared/attach_exit.go`, `pkg/api/model/v1beta1/cell.go`, and `internal/controller/runner/refresh_test.go` updated to drop now-stale `kuke run -a` references.
- [x] `cmd/kuke/run/run_test.go` updated: `-a` flag-presence assertion now checks `-d/--detach`; attach-driven cases drop `-a` (attach is default), detached cases add `-d`, and `--container` validation test rewritten to assert the new `-d` + `--container` rejection.
- [x] Smoke check above.

Closes #283