### PR TITLE
fix: narrow cni add idempotency check to bridge-veth-exists sentinel

### DIFF
--- a/internal/cni/errors.go
+++ b/internal/cni/errors.go
@@ -61,6 +61,17 @@ func translateCNIError(err error, networkName, bridge string) error {
 		)
 	}
 
+	// Container veth already in the target netns. The bridge plugin emits
+	// "container veth name provided (eth0) already exists" (older versions)
+	// or "container veth name (\"eth0\") peer provided (\"vethXXXX\") already
+	// exists" (>= v1.5). Both share the "container veth name" + "already
+	// exists" pair, which is narrow enough to exclude the unrelated
+	// "file exists" / IPAM "duplicate allocation" / iptables conflicts that
+	// happen to share the looser "already exists" substring.
+	if strings.Contains(msg, "container veth name") && strings.Contains(msg, "already exists") {
+		return fmt.Errorf("%w: %w", errdefs.ErrCNIVethExists, err)
+	}
+
 	return err
 }
 

--- a/internal/cni/errors_test.go
+++ b/internal/cni/errors_test.go
@@ -81,6 +81,66 @@ func TestTranslateCNIError(t *testing.T) {
 			bridge:      "cni0",
 			passthrough: true,
 		},
+		{
+			name: "container veth exists (bridge plugin <v1.5) → ErrCNIVethExists",
+			err: errors.New(
+				`plugin type="bridge" failed (add): container veth name provided (eth0) already exists`,
+			),
+			networkName:  "net",
+			bridge:       "cni0",
+			wantSentinel: errdefs.ErrCNIVethExists,
+			wantSubstr:   "container veth name",
+		},
+		{
+			name: "container veth exists (bridge plugin >=v1.5) → ErrCNIVethExists",
+			err: errors.New(
+				`plugin type="bridge" failed (add): container veth name ("eth0") peer provided ("veth123abc") already exists`,
+			),
+			networkName:  "net",
+			bridge:       "cni0",
+			wantSentinel: errdefs.ErrCNIVethExists,
+			wantSubstr:   "already exists",
+		},
+		{
+			// The original substring check would have swallowed this — it's
+			// the regression the new sentinel exists to prevent. Ensure the
+			// classifier passes it through unchanged so start.go's
+			// errors.Is gate surfaces it as a real failure.
+			name: "IP addr conflict → passthrough (not idempotent)",
+			err: errors.New(
+				`plugin type="bridge" failed (add): failed to add IP addr 10.88.0.5/16 to k-deadbeef: file exists`,
+			),
+			networkName: "net",
+			bridge:      "cni0",
+			passthrough: true,
+		},
+		{
+			name: "IPAM duplicate allocation → passthrough (not idempotent)",
+			err: errors.New(
+				`plugin type="host-local" failed (add): failed to allocate for range 0: 10.88.0.5 has been allocated to abc, duplicate allocation is not allowed`,
+			),
+			networkName: "net",
+			bridge:      "cni0",
+			passthrough: true,
+		},
+		{
+			name: "iptables rule already exists → passthrough (not idempotent)",
+			err: errors.New(
+				`plugin type="portmap" failed (add): running [/usr/sbin/iptables -t nat -N CNI-HOSTPORT-DNAT --wait]: exit status 1: iptables: Chain already exists`,
+			),
+			networkName: "net",
+			bridge:      "cni0",
+			passthrough: true,
+		},
+		{
+			name: "bridge link already exists but not a bridge → passthrough (real failure)",
+			err: errors.New(
+				`plugin type="bridge" failed (add): "kuke0" already exists but is not a bridge`,
+			),
+			networkName: "net",
+			bridge:      "cni0",
+			passthrough: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -451,11 +451,14 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 
 		netnsPath := namespacePaths.Net
 		if addErr := cniMgr.AddContainerToNetwork(r.ctx, containerID, netnsPath); addErr != nil {
-			// Check if the error indicates the container is already attached to the network
-			// This can happen when the task was already running from a previous start
-			errMsg := addErr.Error()
-			if strings.Contains(errMsg, "already exists") {
-				// Container is already attached to the network, log and continue
+			// The bridge plugin's "container veth name … already exists" is
+			// the one genuinely idempotent failure — a prior ADD reached veth
+			// setup before crashing, so eth0 and its IPAM record are intact
+			// and the retry can proceed. Match it via the typed sentinel so
+			// unrelated "already exists" / "file exists" plugin errors (IP
+			// conflicts, route duplicates, IPAM duplicate allocation,
+			// iptables) surface instead of being silently swallowed.
+			if errors.Is(addErr, internalerrdefs.ErrCNIVethExists) {
 				fields = appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 				fields = append(
 					fields,
@@ -467,13 +470,18 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 					cniConfigPath,
 					"netns",
 					netnsPath,
+					"err",
+					addErr.Error(),
 				)
-				r.logger.DebugContext(
+				// INFO so the idempotent-skip is visible without
+				// --log-level debug; the original error message goes in the
+				// "err" field so a real failure misclassified as idempotent
+				// is still traceable.
+				r.logger.InfoContext(
 					r.ctx,
-					"root container already attached to network, skipping",
+					"root container already attached to network, skipping CNI ADD",
 					fields...,
 				)
-				// Continue execution - container is already attached
 			} else {
 				// Log the actual CNI bin dir value being used (may be empty, which causes the error)
 				// Note: NewManager creates CNI config with this value BEFORE applying defaults,

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -125,6 +125,16 @@ var (
 
 	ErrBridgeNameTooLong = errors.New("bridge name exceeds Linux IFNAMSIZ limit")
 	ErrCNIPluginNotFound = errors.New("cni plugin not found")
+	// ErrCNIVethExists fires when CNI ADD reports the container-side veth
+	// (eth0) is already present in the target netns — the bridge plugin's
+	// "container veth name … already exists" path. This is the one genuinely
+	// idempotent failure: the previous ADD reached veth setup before
+	// crashing, so the iface and its IPAM record are intact and a retry can
+	// proceed without re-running attach. All other "already exists" /
+	// "file exists" errors from the plugin chain (IP-addr conflicts, route
+	// duplicates, IPAM duplicate-allocation, iptables) are real failures
+	// that must surface.
+	ErrCNIVethExists = errors.New("cni container veth already exists in netns")
 
 	// Network-policy-related errors.
 


### PR DESCRIPTION
## Summary
- The substring check `strings.Contains(errMsg, "already exists")` in `internal/controller/runner/start.go` was over-broad: any CNI ADD plugin error whose message contained "already exists" was logged at DEBUG and silently treated as idempotent. That bucket includes real failures — bridge-link conflicts (`"kuke0" already exists but is not a bridge`), iptables chain conflicts, and other plugin errors that share the substring — leaving the cell reporting Running with no veth, no bridge, and no surfaced error.
- Adds `errdefs.ErrCNIVethExists`, the one genuinely idempotent case: the bridge plugin's `container veth name … already exists`, which means a prior ADD reached veth setup before crashing and the iface plus its IPAM record are intact. Match it via `errors.Is`, surface every other ADD failure.
- Detection lives in `internal/cni/errors.go:translateCNIError` so it sits next to the other CNI sentinels (`ErrBridgeNameTooLong`, `ErrCNIPluginNotFound`). The substring pair `"container veth name"` + `"already exists"` covers both bridge-plugin wordings — `container veth name provided (eth0) already exists` (<v1.5) and `container veth name ("eth0") peer provided ("vethXXXX") already exists` (>=v1.5).
- Bumps the swallowed-case log from DEBUG to INFO and includes the original error message in the `err` field, per the issue, so the idempotent-skip is visible without `--log-level debug` and a real failure misclassified as idempotent stays traceable.
- Plugin-stderr capture in `internal/cni/container.go` is left for a separate follow-up issue, as the bug report itself suggested.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v /e2e)` — full unit test suite (the equivalent of `make test`; `make` is not available in this environment, but the Makefile target's body is just that command). Includes the new `TestTranslateCNIError` subtests:
  - `container veth exists (bridge plugin <v1.5) → ErrCNIVethExists`
  - `container veth exists (bridge plugin >=v1.5) → ErrCNIVethExists`
  - `IP addr conflict → passthrough` (was previously swallowed — this is the regression guard)
  - `IPAM duplicate allocation → passthrough`
  - `iptables rule already exists → passthrough`
  - `bridge link already exists but not a bridge → passthrough`
- [x] `golangci-lint run` against the touched packages — zero new lints introduced (pre-existing golines/funlen/gocyclo on these files are unchanged).
- [ ] `make dev-init` smoke test — not run. Rationale: this change only modifies the cell-start CNI-attach error-handling path. `kuke init` itself creates `kukeond` as a host-network root container that explicitly skips CNI attach (`!rootContainerWantsCNI(rootContainerSpec)` at `internal/controller/runner/start.go`), so the `dev-init` daemon-parity loop does not exercise the changed code. The change does not touch `/opt/kukeon` disk state or anything the daemon reads, only the error classification on the runner-side ADD path.

## Why a unit test in `internal/cni/errors_test.go` rather than in `internal/controller/runner/`
The issue's test plan suggested a unit test in `internal/controller/runner/` injecting a fake `cniMgr.AddContainerToNetwork`. That requires restructuring `StartCell` to accept an injected CNI manager (currently constructed inline via `cni.NewManager(...)`). After this change, the start-side decision collapses to a single `errors.Is(addErr, errdefs.ErrCNIVethExists)`, which is well-covered by Go semantics — the actual classification logic (where the over-broad substring lived) is now in `translateCNIError`. Testing that classifier with realistic plugin error fixtures gives equivalent coverage at lower blast radius. Happy to expand if a reviewer would rather see a runner-level integration seam.

Closes #292