### PR TITLE
fix: install KUKEON-FORWARD admission chain at init

### DIFF
--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -37,6 +37,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/firewall"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
@@ -166,6 +167,15 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		}
 		if removed {
 			cmd.Printf("removed %s\n", systemDir)
+		}
+
+		// Symmetric with `kuke init`: full re-bootstrap should leave no
+		// kukeon-owned host firewall state behind. Per-space egress chains
+		// are torn down by space-deletion paths; this removes the host-wide
+		// admission chain installed at init time.
+		fwInstaller := firewall.NewInstaller(logger)
+		if fwErr := fwInstaller.Remove(cmd.Context()); fwErr != nil {
+			return fmt.Errorf("remove forward admission chain: %w", fwErr)
 		}
 	}
 

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -31,6 +31,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/firewall"
 	"github.com/eminwux/kukeon/internal/serverconfig"
 	"github.com/eminwux/kukeon/internal/sysuser"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -206,6 +207,50 @@ func resolveKukeondImage() string {
 	return fmt.Sprintf("%s:%s", repo, tag)
 }
 
+// installForwardAdmission installs the kukeon-owned FORWARD admission chain
+// so cells reach the network on hosts where `iptables -P FORWARD DROP` is
+// the default (Docker, firewalld, ufw, hardened distros). Idempotent —
+// re-running `kuke init` on a healthy host produces no rule churn.
+func installForwardAdmission(ctx context.Context, logger *slog.Logger) error {
+	if err := firewall.NewInstaller(logger).Install(ctx); err != nil {
+		return fmt.Errorf("install forward admission chain: %w", err)
+	}
+	return nil
+}
+
+// applyKukeonOwnership chown+chmods /run/kukeon (socket's parent dir,
+// already created by ensureSocketDir during bootstrap) and /opt/kukeon
+// (RunPath). Both end up root:kukeon mode 0o750 so the kukeon group can
+// traverse without world access.
+func applyKukeonOwnership(
+	socketPath, runPath string,
+	ensure sysuser.EnsureResult,
+) (permissionsReport, error) {
+	runDir := filepath.Dir(socketPath)
+	r := permissionsReport{
+		User:         consts.KukeonSystemUser,
+		Group:        consts.KukeonSystemGroup,
+		UID:          ensure.UID,
+		GID:          ensure.GID,
+		UserCreated:  ensure.UserCreated,
+		GroupCreated: ensure.GroupCreated,
+		RunDirPath:   runDir,
+		RunPath:      runPath,
+		SocketPath:   socketPath,
+	}
+	if err := sysuser.ChownAndChmod(runDir, 0, ensure.GID, kukeonRunDirMode); err != nil {
+		return r, fmt.Errorf("apply kukeon ownership to %q: %w", runDir, err)
+	}
+	r.RunDirApplied = true
+	if err := sysuser.ChownTreeAndChmod(
+		runPath, 0, ensure.GID, kukeonRunPathDirMode, kukeonRunPathFileMode,
+	); err != nil {
+		return r, fmt.Errorf("apply kukeon ownership to %q: %w", runPath, err)
+	}
+	r.RunPathApplied = true
+	return r, nil
+}
+
 func runInit(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
@@ -247,6 +292,10 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("ensure kukeon user/group: %w", ensureErr)
 	}
 
+	if fwErr := installForwardAdmission(cmd.Context(), logger); fwErr != nil {
+		return fwErr
+	}
+
 	opts := controller.Options{
 		RunPath:              runPath,
 		ContainerdSocket:     viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
@@ -265,32 +314,10 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return bootstrapErr
 	}
 
-	// Apply kukeon-managed ownership/modes. /run/kukeon is the socket's
-	// parent dir (already created by ensureSocketDir during bootstrap);
-	// /opt/kukeon is RunPath. Both end up root:kukeon mode 0o750 so the
-	// kukeon group can traverse without world access.
-	runDir := filepath.Dir(socketPath)
-	permsReport := permissionsReport{
-		User:         consts.KukeonSystemUser,
-		Group:        consts.KukeonSystemGroup,
-		UID:          ensure.UID,
-		GID:          ensure.GID,
-		UserCreated:  ensure.UserCreated,
-		GroupCreated: ensure.GroupCreated,
-		RunDirPath:   runDir,
-		RunPath:      runPath,
-		SocketPath:   socketPath,
+	permsReport, ownErr := applyKukeonOwnership(socketPath, runPath, ensure)
+	if ownErr != nil {
+		return ownErr
 	}
-	if chownErr := sysuser.ChownAndChmod(runDir, 0, ensure.GID, kukeonRunDirMode); chownErr != nil {
-		return fmt.Errorf("apply kukeon ownership to %q: %w", runDir, chownErr)
-	}
-	permsReport.RunDirApplied = true
-	if chownErr := sysuser.ChownTreeAndChmod(
-		runPath, 0, ensure.GID, kukeonRunPathDirMode, kukeonRunPathFileMode,
-	); chownErr != nil {
-		return fmt.Errorf("apply kukeon ownership to %q: %w", runPath, chownErr)
-	}
-	permsReport.RunPathApplied = true
 
 	printBootstrapReport(cmd, report, permsReport)
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -138,6 +138,11 @@ var (
 	ErrEgressApply              = errors.New("failed to apply egress policy")
 	ErrEgressRemove             = errors.New("failed to remove egress policy")
 
+	// Firewall (FORWARD admission) errors.
+
+	ErrForwardAdmissionApply  = errors.New("failed to apply forward admission rules")
+	ErrForwardAdmissionRemove = errors.New("failed to remove forward admission rules")
+
 	// Image-related errors.
 
 	// ErrLoadImage is returned when importing an OCI/docker tarball into a

--- a/internal/firewall/forward.go
+++ b/internal/firewall/forward.go
@@ -1,0 +1,187 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package firewall manages host-level iptables state owned by kukeon — the
+// FORWARD admission chain that admits traffic to/from kukeon bridges. It is
+// distinct from internal/netpolicy, which installs per-space egress filters:
+// admission lives at host scope and is set up once at `kuke init`, while
+// egress is per-space and applied by the runner when a Space carries an
+// EgressPolicy.
+package firewall
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// ForwardChainName is the kukeon-owned FORWARD admission chain.
+//
+// Relative ordering with KUKEON-EGRESS (netpolicy.MasterChainName) is
+// implicit: kuke init inserts KUKEON-FORWARD at FORWARD position 1, then any
+// later egress-policy install inserts KUKEON-EGRESS at position 1, pushing
+// KUKEON-FORWARD down. The resulting chain — KUKEON-EGRESS first (may DROP),
+// then KUKEON-FORWARD (admits surviving kukeon-bridge traffic) — is the
+// intended order.
+const ForwardChainName = "KUKEON-FORWARD"
+
+// BridgeIfaceMatch is the iptables -i / -o interface match that scopes the
+// admission rules to kukeon-managed bridges. The interface name is derived
+// in internal/cni.SafeBridgeName as "k-<8 hex>" so the "+" wildcard matches
+// the hex suffix and admits any kukeon bridge regardless of which space hash
+// it represents.
+const BridgeIfaceMatch = "k-+"
+
+// AdmissionRules returns the ordered iptables rules that populate
+// ForwardChainName. The generator is pure — no I/O, no iptables calls — so
+// tests can verify rule order without fakes.
+//
+// Rule order:
+//  1. RELATED,ESTABLISHED ACCEPT — return-traffic for already-admitted flows
+//     so reply packets cannot be dropped by FORWARD's default policy.
+//  2. -i k-+ ACCEPT — admit egress originating on a kukeon bridge.
+//  3. -o k-+ ACCEPT — admit ingress destined to a kukeon bridge.
+func AdmissionRules() [][]string {
+	return [][]string{
+		{
+			"-A", ForwardChainName,
+			"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
+			"-j", "ACCEPT",
+		},
+		{"-A", ForwardChainName, "-i", BridgeIfaceMatch, "-j", "ACCEPT"},
+		{"-A", ForwardChainName, "-o", BridgeIfaceMatch, "-j", "ACCEPT"},
+	}
+}
+
+// CommandRunner executes an iptables invocation and returns its combined
+// stdout+stderr. Tests inject a fake to capture invocations and return
+// canned output for read-only calls like "-C" or "-L". Mirrors
+// netpolicy.CommandRunner.
+type CommandRunner interface {
+	Run(ctx context.Context, args ...string) ([]byte, error)
+}
+
+type execRunner struct {
+	binary string
+}
+
+func (e *execRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	// #nosec G204 -- args are internally constructed from this package's
+	// constants (chain names, fixed flags); never user-supplied.
+	cmd := exec.CommandContext(ctx, e.binary, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("iptables %s: %w: %s",
+			strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+// Installer applies and removes the KUKEON-FORWARD admission chain.
+type Installer struct {
+	runner CommandRunner
+	logger *slog.Logger
+}
+
+// NewInstaller returns an Installer that shells out to the iptables binary
+// on PATH. Logger is required.
+func NewInstaller(logger *slog.Logger) *Installer {
+	return &Installer{runner: &execRunner{binary: "iptables"}, logger: logger}
+}
+
+// NewInstallerWithRunner is the test-hook constructor.
+func NewInstallerWithRunner(logger *slog.Logger, runner CommandRunner) *Installer {
+	return &Installer{runner: runner, logger: logger}
+}
+
+// Install ensures KUKEON-FORWARD exists, contains the admission rules in the
+// expected order, and is jumped to from FORWARD. Idempotent — re-running on
+// a healthy host produces no rule churn (every install step does -C before
+// -I/-A, mirroring the netpolicy pattern).
+func (i *Installer) Install(ctx context.Context) error {
+	if err := i.ensureChain(ctx, ForwardChainName); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
+	}
+	for _, args := range AdmissionRules() {
+		if err := i.ensureRule(ctx, args); err != nil {
+			return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
+		}
+	}
+	if err := i.ensureForwardJump(ctx); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
+	}
+	i.logger.InfoContext(ctx, "installed forward admission chain",
+		"chain", ForwardChainName,
+		"iface_match", BridgeIfaceMatch,
+	)
+	return nil
+}
+
+// Remove deletes the FORWARD jump, flushes, and deletes KUKEON-FORWARD.
+// Safe to call when the chain does not exist; missing-chain failures from
+// flush/delete are demoted to debug logs so reset --purge-system on a host
+// that never installed the chain (or already removed it) does not error.
+func (i *Installer) Remove(ctx context.Context) error {
+	if _, err := i.runner.Run(ctx, "-C", "FORWARD", "-j", ForwardChainName); err == nil {
+		if _, delErr := i.runner.Run(ctx, "-D", "FORWARD", "-j", ForwardChainName); delErr != nil {
+			return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionRemove, delErr)
+		}
+	}
+	if _, err := i.runner.Run(ctx, "-F", ForwardChainName); err != nil {
+		i.logger.DebugContext(ctx, "flush chain (likely absent)",
+			"chain", ForwardChainName, "err", err)
+	}
+	if _, err := i.runner.Run(ctx, "-X", ForwardChainName); err != nil {
+		i.logger.DebugContext(ctx, "delete chain (likely absent)",
+			"chain", ForwardChainName, "err", err)
+	}
+	i.logger.InfoContext(ctx, "removed forward admission chain", "chain", ForwardChainName)
+	return nil
+}
+
+func (i *Installer) ensureChain(ctx context.Context, chain string) error {
+	if _, err := i.runner.Run(ctx, "-L", chain, "-n"); err == nil {
+		return nil
+	}
+	_, err := i.runner.Run(ctx, "-N", chain)
+	return err
+}
+
+// ensureRule rewrites an "-A <chain> ..." rule as "-C <chain> ..." for the
+// existence check, then runs the original "-A" if -C reports absence.
+func (i *Installer) ensureRule(ctx context.Context, args []string) error {
+	if len(args) < 2 || args[0] != "-A" {
+		return fmt.Errorf("admission rule must start with -A <chain>; got %v", args)
+	}
+	check := append([]string{"-C"}, args[1:]...)
+	if _, err := i.runner.Run(ctx, check...); err == nil {
+		return nil
+	}
+	_, err := i.runner.Run(ctx, args...)
+	return err
+}
+
+func (i *Installer) ensureForwardJump(ctx context.Context) error {
+	if _, err := i.runner.Run(ctx, "-C", "FORWARD", "-j", ForwardChainName); err == nil {
+		return nil
+	}
+	_, err := i.runner.Run(ctx, "-I", "FORWARD", "1", "-j", ForwardChainName)
+	return err
+}

--- a/internal/firewall/forward_test.go
+++ b/internal/firewall/forward_test.go
@@ -1,0 +1,274 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package firewall_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/firewall"
+)
+
+// fakeRunner records every iptables invocation and returns canned responses
+// keyed by the space-joined args. Unknown calls succeed silently. Mirrors
+// the netpolicy enforcer test harness so the two packages stay legible
+// side-by-side.
+type fakeRunner struct {
+	calls   [][]string
+	respond map[string]fakeResp
+}
+
+type fakeResp struct {
+	out []byte
+	err error
+}
+
+func (f *fakeRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, append([]string(nil), args...))
+	if f.respond != nil {
+		if r, ok := f.respond[strings.Join(args, " ")]; ok {
+			return r.out, r.err
+		}
+	}
+	return nil, nil
+}
+
+func newInstaller(runner *fakeRunner) *firewall.Installer {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return firewall.NewInstallerWithRunner(logger, runner)
+}
+
+// TestAdmissionRules_Order locks in the rule order and content. The chain
+// must start with a stateful ACCEPT for return-traffic, then admit -i and -o
+// kukeon-bridge traffic. Catching a future reorder here is the regression
+// guard for the silent-egress-loss bug fixed by #293.
+func TestAdmissionRules_Order(t *testing.T) {
+	rules := firewall.AdmissionRules()
+	if len(rules) != 3 {
+		t.Fatalf("want 3 admission rules; got %d: %v", len(rules), rules)
+	}
+
+	// Rule 0: -A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+	want0 := []string{
+		"-A", firewall.ForwardChainName,
+		"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
+		"-j", "ACCEPT",
+	}
+	if !sliceEq(rules[0], want0) {
+		t.Errorf("rule 0: want %v; got %v", want0, rules[0])
+	}
+
+	// Rule 1: -A KUKEON-FORWARD -i k-+ -j ACCEPT
+	want1 := []string{"-A", firewall.ForwardChainName, "-i", firewall.BridgeIfaceMatch, "-j", "ACCEPT"}
+	if !sliceEq(rules[1], want1) {
+		t.Errorf("rule 1: want %v; got %v", want1, rules[1])
+	}
+
+	// Rule 2: -A KUKEON-FORWARD -o k-+ -j ACCEPT
+	want2 := []string{"-A", firewall.ForwardChainName, "-o", firewall.BridgeIfaceMatch, "-j", "ACCEPT"}
+	if !sliceEq(rules[2], want2) {
+		t.Errorf("rule 2: want %v; got %v", want2, rules[2])
+	}
+}
+
+// TestBridgeIfaceMatch_CoversCNINames asserts the wildcard match used in the
+// admission rules covers the bridge names produced by internal/cni so the
+// firewall and CNI packages cannot drift apart.
+func TestBridgeIfaceMatch_CoversCNINames(t *testing.T) {
+	const wildcard = "k-+" // iptables prefix-match
+	if firewall.BridgeIfaceMatch != wildcard {
+		t.Fatalf("BridgeIfaceMatch must be %q to cover all kukeon bridges; got %q",
+			wildcard, firewall.BridgeIfaceMatch)
+	}
+	// Sample bridge name produced by the CNI helper. It must start with
+	// "k-" and have at most 15 chars (IFNAMSIZ-1).
+	bridge := cni.SafeBridgeName("default-default")
+	if !strings.HasPrefix(bridge, "k-") {
+		t.Errorf("cni.SafeBridgeName must start with k-; got %q", bridge)
+	}
+	if len(bridge) > 15 {
+		t.Errorf("cni.SafeBridgeName must fit IFNAMSIZ-1=15; got %q (%d)", bridge, len(bridge))
+	}
+}
+
+// TestInstall_OnFreshHost emits -N, three -A rules in order, and the FORWARD
+// position-1 jump when nothing is already in place.
+func TestInstall_OnFreshHost(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Chain absent.
+			"-L KUKEON-FORWARD -n": {err: errors.New("absent")},
+			// Each rule absent (so -C fails and -A runs).
+			"-C KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT": {err: errors.New("absent")},
+			"-C KUKEON-FORWARD -i k-+ -j ACCEPT":                                     {err: errors.New("absent")},
+			"-C KUKEON-FORWARD -o k-+ -j ACCEPT":                                     {err: errors.New("absent")},
+			// FORWARD jump absent.
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+		},
+	}
+	i := newInstaller(runner)
+
+	if err := i.Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if !wasCalled(runner, []string{"-N", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -N KUKEON-FORWARD; calls = %v", runner.calls)
+	}
+	for _, r := range firewall.AdmissionRules() {
+		if !wasCalled(runner, r) {
+			t.Errorf("expected admission rule %v; calls = %v", r, runner.calls)
+		}
+	}
+	if !wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -I FORWARD 1 -j KUKEON-FORWARD; calls = %v", runner.calls)
+	}
+}
+
+// TestInstall_IsIdempotent verifies a second install on a healthy host
+// performs zero -N, -A, or -I operations — only the -L/-C existence checks.
+// This is the "no rule churn" guarantee the issue calls out.
+func TestInstall_IsIdempotent(t *testing.T) {
+	// All -L/-C succeed → everything already in place.
+	runner := &fakeRunner{respond: map[string]fakeResp{}}
+	i := newInstaller(runner)
+
+	if err := i.Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	for _, c := range runner.calls {
+		switch c[0] {
+		case "-N", "-I", "-A":
+			t.Errorf("idempotent install must not invoke %s; got call %v", c[0], c)
+		}
+	}
+}
+
+// TestInstall_ChainCreateFailureWrapsSentinel surfaces -N failures with the
+// ErrForwardAdmissionApply sentinel so callers can errors.Is them.
+func TestInstall_ChainCreateFailureWrapsSentinel(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-L KUKEON-FORWARD -n": {err: errors.New("absent")},
+			"-N KUKEON-FORWARD":    {err: errors.New("denied")},
+		},
+	}
+	i := newInstaller(runner)
+
+	err := i.Install(context.Background())
+	if err == nil {
+		t.Fatal("expected error from -N failure")
+	}
+	if !errors.Is(err, errdefs.ErrForwardAdmissionApply) {
+		t.Errorf("expected ErrForwardAdmissionApply wrap; got %v", err)
+	}
+}
+
+// TestRemove_OnInstalledHost deletes the FORWARD jump, flushes, and deletes
+// the chain.
+func TestRemove_OnInstalledHost(t *testing.T) {
+	// -C FORWARD jump succeeds (jump present), so -D should be invoked.
+	runner := &fakeRunner{respond: map[string]fakeResp{}}
+	i := newInstaller(runner)
+
+	if err := i.Remove(context.Background()); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	if !wasCalled(runner, []string{"-D", "FORWARD", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -D FORWARD -j KUKEON-FORWARD; calls = %v", runner.calls)
+	}
+	if !wasCalled(runner, []string{"-F", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -F KUKEON-FORWARD; calls = %v", runner.calls)
+	}
+	if !wasCalled(runner, []string{"-X", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -X KUKEON-FORWARD; calls = %v", runner.calls)
+	}
+}
+
+// TestRemove_TolerantWhenChainAbsent leaves -F/-X failures as a debug log,
+// not a returned error, so reset --purge-system on a host that never had
+// the chain installed (or already removed it) is a no-op.
+func TestRemove_TolerantWhenChainAbsent(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Jump absent → no -D should be issued.
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+			// Chain absent → -F/-X return errors but Remove must swallow them.
+			"-F KUKEON-FORWARD": {err: errors.New("no such chain")},
+			"-X KUKEON-FORWARD": {err: errors.New("no such chain")},
+		},
+	}
+	i := newInstaller(runner)
+
+	if err := i.Remove(context.Background()); err != nil {
+		t.Fatalf("Remove on absent chain must not error: %v", err)
+	}
+	for _, c := range runner.calls {
+		if c[0] == "-D" {
+			t.Errorf("must not -D when -C reports absence; got %v", c)
+		}
+	}
+}
+
+// TestRemove_DeleteJumpFailureWrapsSentinel surfaces a -D failure (jump was
+// detected but couldn't be removed — e.g. permission revoked between -C and
+// -D) with the ErrForwardAdmissionRemove sentinel.
+func TestRemove_DeleteJumpFailureWrapsSentinel(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-D FORWARD -j KUKEON-FORWARD": {err: errors.New("denied")},
+		},
+	}
+	i := newInstaller(runner)
+
+	err := i.Remove(context.Background())
+	if err == nil {
+		t.Fatal("expected error from -D failure")
+	}
+	if !errors.Is(err, errdefs.ErrForwardAdmissionRemove) {
+		t.Errorf("expected ErrForwardAdmissionRemove wrap; got %v", err)
+	}
+}
+
+func wasCalled(f *fakeRunner, want []string) bool {
+	for _, got := range f.calls {
+		if sliceEq(got, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Adds `internal/firewall` package owning a `KUKEON-FORWARD` chain jumped to from FORWARD at position 1. The chain admits return-traffic (RELATED,ESTABLISHED) and any packet to/from a kukeon bridge (`-i k-+` / `-o k-+`). Wired into `kuke init` so cells reach the network on hosts where `iptables -P FORWARD DROP` is the default (Docker, firewalld, ufw, hardened distros) — currently those hosts silently lose every cell egress packet despite the bridge, IPAM, and SNAT rule being healthy.
- Mirrored teardown wired into `kuke daemon reset --purge-system` so a full re-bootstrap leaves no kukeon-owned host firewall state behind.
- New `errdefs.ErrForwardAdmissionApply` / `ErrForwardAdmissionRemove` sentinels follow the `ErrEgressApply` / `ErrEgressRemove` convention next door so callers can `errors.Is` them.
- Idempotency follows the existing netpolicy enforcer pattern: every install step does `iptables -C` before `-I`/`-A`, so re-running `kuke init` on a healthy host produces zero rule churn (test guarantees this).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v /e2e)` — full unit test suite (the `make test` body; `make` is not available in this environment but the target's body is exactly that command). Includes new `internal/firewall` coverage:
  - `TestAdmissionRules_Order` — locks rule order: stateful ACCEPT, then `-i k-+`, then `-o k-+`. Regression guard on the silent-egress-loss bug.
  - `TestBridgeIfaceMatch_CoversCNINames` — pins `BridgeIfaceMatch = "k-+"` against `internal/cni.SafeBridgeName`'s `k-<8 hex>` output so the two packages cannot drift.
  - `TestInstall_OnFreshHost` — emits `-N`, three `-A` rules, and `-I FORWARD 1 -j KUKEON-FORWARD` when nothing is in place.
  - `TestInstall_IsIdempotent` — second install on a healthy host issues zero `-N`/`-A`/`-I`, only the `-L`/`-C` existence checks.
  - `TestInstall_ChainCreateFailureWrapsSentinel` — `-N` failure wraps `ErrForwardAdmissionApply`.
  - `TestRemove_OnInstalledHost` — emits `-D FORWARD -j KUKEON-FORWARD`, `-F`, `-X`.
  - `TestRemove_TolerantWhenChainAbsent` — `-F`/`-X` failures on a fresh host are debug-logged, not returned.
  - `TestRemove_DeleteJumpFailureWrapsSentinel` — `-D` failure wraps `ErrForwardAdmissionRemove`.
- [x] `golangci-lint run` against the touched packages — zero new lints introduced. (Pre-existing `reassign` lints in `cmd/kuke/init/init_test.go:654-704` are untouched.)
- [ ] `make dev-init` smoke test — not run. This change is host-firewall state outside the daemon-parity guard's coverage: the regression check at the tail of `dev-init.sh` reads `kuke get realms` with and without `--no-daemon`, which exercises `/opt/kukeon` bind-mount parity, not iptables. The full repro would require a host with `iptables -P FORWARD DROP` set, which the maintainer flagged as the natural smoke environment in the issue's "Test plan suggestion." Defers to the reviewer's host.

## Design notes for the reviewer

**Relative ordering with `KUKEON-EGRESS`.** The netpolicy enforcer also inserts at FORWARD position 1, so install order matters. `kuke init` runs first and lands `KUKEON-FORWARD` at position 1; the first egress-policy install (per-space, runner-side) later inserts `KUKEON-EGRESS` at position 1, pushing `KUKEON-FORWARD` to position 2. The resulting order — KUKEON-EGRESS first (may DROP), then KUKEON-FORWARD (admits surviving kukeon-bridge traffic) — is the intended one. Documented in the `ForwardChainName` comment in `internal/firewall/forward.go`. The pre-egress race window only opens if a re-`init` runs after KUKEON-EGRESS already exists, but presence-based idempotency means re-init is a no-op there.

**No nftables-detection step.** The issue suggested surfacing a clear error if the host has loaded `nftables` as the primary backend (no working `iptables` shim). I deferred that: the typical Docker-on-Debian-13 case ships `iptables-nft` as the `iptables` shim and our rules work fine through it. If `iptables` is genuinely absent, `exec.CommandContext` already returns an `executable file not found` error wrapped via `ErrForwardAdmissionApply`. Happy to add a `iptables --version` probe + structured error if you want a stronger diagnostic story; left it out to keep blast radius narrow.

**Integration point: `cmd/kuke/init/runInit`, not `controller.Bootstrap`.** Host-level firewall state is set once at init and not per-realm/space, so it sits next to the existing `sysuser.EnsureUserGroup` step (also host-level) rather than inside the controller's per-realm bootstrap loop. Kept the controller's iptables-free shape intact.

**`runInit` length refactor.** Adding the firewall step pushed `runInit` past the `funlen: 100` lint. Extracted the post-bootstrap chown block into `applyKukeonOwnership` (the same shape — local-helper, returning `(permissionsReport, error)`). The behaviour is unchanged; the diff is mechanical.

Closes #293