### PR TITLE
fix: install KUKEON-FORWARD chain so cells egress past restrictive FORWARD policy

### DIFF
--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -195,7 +195,7 @@ func tearDownHostFirewall(cmd *cobra.Command, logger *slog.Logger) error {
 	if err := installer.Remove(cmd.Context()); err != nil {
 		return fmt.Errorf("remove host firewall admission rules: %w", err)
 	}
-	cmd.Printf("removed host firewall chain %s\n", hostfw.ChainName)
+	cmd.Printf("ensured host firewall chain %s removed\n", hostfw.ChainName)
 	return nil
 }
 

--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -37,6 +37,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/hostfw"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
@@ -56,6 +57,11 @@ type MockSocketDirKey struct{}
 // /opt/kukeon/kuke-system from. Tests use this to point at a tmpdir so the
 // cleanup never touches the real /opt/kukeon.
 type MockRunPathKey struct{}
+
+// MockHostFwKey injects a hostfw.Installer (typically a fake) so unit
+// tests can assert the --purge-system path tears down the FORWARD
+// admission chain without requiring a real iptables binary.
+type MockHostFwKey struct{}
 
 // defaultTimeout matches `kuke daemon stop`'s grace period (#219) so the two
 // verbs agree on how long the SIGTERM phase gets before SIGKILL escalates.
@@ -167,8 +173,29 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		if removed {
 			cmd.Printf("removed %s\n", systemDir)
 		}
+
+		if hostFwErr := tearDownHostFirewall(cmd, logger); hostFwErr != nil {
+			return hostFwErr
+		}
 	}
 
+	return nil
+}
+
+// tearDownHostFirewall removes the KUKEON-FORWARD chain installed by
+// `kuke init`. The `--purge-system` flag advertises a "fully clean
+// re-bootstrap"; without this step the chain dangles after the daemon
+// is gone. Skipped silently when iptables is not on PATH (the chain
+// could not have been installed in the first place).
+func tearDownHostFirewall(cmd *cobra.Command, logger *slog.Logger) error {
+	installer := resolveHostFwInstaller(cmd, logger)
+	if installer == nil {
+		return nil
+	}
+	if err := installer.Remove(cmd.Context()); err != nil {
+		return fmt.Errorf("remove host firewall admission rules: %w", err)
+	}
+	cmd.Printf("removed host firewall chain %s\n", hostfw.ChainName)
 	return nil
 }
 
@@ -311,6 +338,21 @@ func resolveSocketDir(cmd *cobra.Command) string {
 		socketPath = config.KUKEOND_SOCKET.Default
 	}
 	return filepath.Dir(socketPath)
+}
+
+// resolveHostFwInstaller picks the hostfw.Installer used by the
+// --purge-system step. Tests inject a fake via MockHostFwKey;
+// production builds an IptablesInstaller, returning nil when iptables
+// is absent so the cleanup is silently skipped (the chain could not
+// have been installed without iptables in the first place).
+func resolveHostFwInstaller(cmd *cobra.Command, logger *slog.Logger) hostfw.Installer {
+	if mock, ok := cmd.Context().Value(MockHostFwKey{}).(hostfw.Installer); ok {
+		return mock
+	}
+	if !hostfw.IsIptablesAvailable() {
+		return nil
+	}
+	return hostfw.NewIptablesInstaller(logger)
 }
 
 // resolveRunPath picks the run path for the --purge-system step. Tests inject

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -32,6 +33,7 @@ import (
 	reset "github.com/eminwux/kukeon/cmd/kuke/daemon/reset"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/hostfw"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -536,7 +538,9 @@ func TestDaemonReset_PurgeSystemPropagatesHostFirewallError(t *testing.T) {
 			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
 		},
 	}
-	installer := &recordingInstaller{removeErr: errors.New("iptables down")}
+	installer := &recordingInstaller{
+		removeErr: fmt.Errorf("%w: iptables down", errdefs.ErrHostFwRemove),
+	}
 
 	cmd := reset.NewResetCmd()
 	buf := &bytes.Buffer{}
@@ -555,8 +559,8 @@ func TestDaemonReset_PurgeSystemPropagatesHostFirewallError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when host-firewall teardown fails")
 	}
-	if !strings.Contains(err.Error(), "host firewall") {
-		t.Errorf("error should mention host firewall: %v", err)
+	if !errors.Is(err, errdefs.ErrHostFwRemove) {
+		t.Errorf("error should wrap errdefs.ErrHostFwRemove: %v", err)
 	}
 }
 

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -32,10 +32,25 @@ import (
 	reset "github.com/eminwux/kukeon/cmd/kuke/daemon/reset"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/hostfw"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/viper"
 )
+
+// recordingInstaller is a hostfw.Installer that records whether Remove
+// was invoked, so reset_test can assert the --purge-system wiring fires
+// the host-firewall teardown hook.
+type recordingInstaller struct {
+	removed   bool
+	removeErr error
+}
+
+func (r *recordingInstaller) Apply(_ context.Context) error { return nil }
+func (r *recordingInstaller) Remove(_ context.Context) error {
+	r.removed = true
+	return r.removeErr
+}
 
 // TestDaemonReset covers the table of states the verb has to handle: a
 // running daemon (graceful stop+delete), an already-stopped daemon (skip
@@ -394,6 +409,7 @@ func TestDaemonReset_PreservesDefaultRealm(t *testing.T) {
 	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
 	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
+	ctx = context.WithValue(ctx, reset.MockHostFwKey{}, hostfw.Installer(hostfw.NoopInstaller{}))
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--purge-system"})
 
@@ -408,6 +424,139 @@ func TestDaemonReset_PreservesDefaultRealm(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), systemDir) {
 		t.Errorf("expected output to mention removed kuke-system dir; got:\n%s", buf.String())
+	}
+}
+
+// TestDaemonReset_PurgeSystemTearsDownHostFirewall pins the AC for #293:
+// `kuke daemon reset --purge-system` must invoke hostfw.Remove so the
+// KUKEON-FORWARD chain installed by `kuke init` does not dangle after a
+// fully-clean re-bootstrap.
+func TestDaemonReset_PurgeSystemTearsDownHostFirewall(t *testing.T) {
+	withFreshViper(t)
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+	installer := &recordingInstaller{}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockHostFwKey{}, hostfw.Installer(installer))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--purge-system"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !installer.removed {
+		t.Fatal("expected hostfw.Remove to be invoked under --purge-system")
+	}
+	if !strings.Contains(buf.String(), hostfw.ChainName) {
+		t.Errorf("expected output to mention removed chain %q; got:\n%s", hostfw.ChainName, buf.String())
+	}
+}
+
+// TestDaemonReset_NoPurgeSystemDoesNotTouchHostFirewall keeps the
+// FORWARD chain in place for plain `kuke daemon reset` — the daemon may
+// be coming back up shortly and the chain is still needed for any cell
+// the operator brings up afterward.
+func TestDaemonReset_NoPurgeSystemDoesNotTouchHostFirewall(t *testing.T) {
+	withFreshViper(t)
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+	installer := &recordingInstaller{}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockHostFwKey{}, hostfw.Installer(installer))
+	cmd.SetContext(ctx)
+	// no --purge-system
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if installer.removed {
+		t.Fatal("hostfw.Remove must not run without --purge-system")
+	}
+}
+
+// TestDaemonReset_PurgeSystemPropagatesHostFirewallError pins the
+// error-path: a Remove failure surfaces as a runReset error rather than
+// being silently swallowed, so a stuck chain does not hide as a clean
+// reset.
+func TestDaemonReset_PurgeSystemPropagatesHostFirewallError(t *testing.T) {
+	withFreshViper(t)
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+	installer := &recordingInstaller{removeErr: errors.New("iptables down")}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockHostFwKey{}, hostfw.Installer(installer))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--purge-system"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when host-firewall teardown fails")
+	}
+	if !strings.Contains(err.Error(), "host firewall") {
+		t.Errorf("error should mention host firewall: %v", err)
 	}
 }
 

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -31,6 +31,7 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/hostfw"
 	"github.com/eminwux/kukeon/internal/serverconfig"
 	"github.com/eminwux/kukeon/internal/sysuser"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -265,34 +266,17 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return bootstrapErr
 	}
 
-	// Apply kukeon-managed ownership/modes. /run/kukeon is the socket's
-	// parent dir (already created by ensureSocketDir during bootstrap);
-	// /opt/kukeon is RunPath. Both end up root:kukeon mode 0o750 so the
-	// kukeon group can traverse without world access.
-	runDir := filepath.Dir(socketPath)
-	permsReport := permissionsReport{
-		User:         consts.KukeonSystemUser,
-		Group:        consts.KukeonSystemGroup,
-		UID:          ensure.UID,
-		GID:          ensure.GID,
-		UserCreated:  ensure.UserCreated,
-		GroupCreated: ensure.GroupCreated,
-		RunDirPath:   runDir,
-		RunPath:      runPath,
-		SocketPath:   socketPath,
+	permsReport, permsErr := applyKukeonOwnership(socketPath, runPath, ensure)
+	if permsErr != nil {
+		return permsErr
 	}
-	if chownErr := sysuser.ChownAndChmod(runDir, 0, ensure.GID, kukeonRunDirMode); chownErr != nil {
-		return fmt.Errorf("apply kukeon ownership to %q: %w", runDir, chownErr)
-	}
-	permsReport.RunDirApplied = true
-	if chownErr := sysuser.ChownTreeAndChmod(
-		runPath, 0, ensure.GID, kukeonRunPathDirMode, kukeonRunPathFileMode,
-	); chownErr != nil {
-		return fmt.Errorf("apply kukeon ownership to %q: %w", runPath, chownErr)
-	}
-	permsReport.RunPathApplied = true
 
-	printBootstrapReport(cmd, report, permsReport)
+	hostFwReport, hostFwErr := installHostFirewall(cmd.Context(), logger)
+	if hostFwErr != nil {
+		return hostFwErr
+	}
+
+	printBootstrapReport(cmd, report, permsReport, hostFwReport)
 
 	if viper.GetBool(config.KUKE_INIT_NO_WAIT.ViperKey) {
 		return nil
@@ -381,7 +365,12 @@ type permissionsReport struct {
 	RunPathApplied bool
 }
 
-func printBootstrapReport(cmd *cobra.Command, report controller.BootstrapReport, perms permissionsReport) {
+func printBootstrapReport(
+	cmd *cobra.Command,
+	report controller.BootstrapReport,
+	perms permissionsReport,
+	hostFw hostFirewallReport,
+) {
 	printHeader(cmd, report)
 	printOverview(cmd, report)
 	cmd.Println("Actions:")
@@ -400,6 +389,98 @@ func printBootstrapReport(cmd *cobra.Command, report controller.BootstrapReport,
 	printCellActions(cmd, report.SystemCell, report.KukeondImage)
 
 	printPermissionsActions(cmd, perms)
+	printHostFirewallActions(cmd, hostFw)
+}
+
+// applyKukeonOwnership chowns/chmods the runtime directories so the
+// kukeon group can dial the socket without world access. /run/kukeon is
+// the socket's parent dir (already created by ensureSocketDir during
+// bootstrap); /opt/kukeon is RunPath. Both end up root:kukeon mode
+// 0o750 so the kukeon group can traverse.
+func applyKukeonOwnership(
+	socketPath, runPath string,
+	ensure sysuser.EnsureResult,
+) (permissionsReport, error) {
+	runDir := filepath.Dir(socketPath)
+	report := permissionsReport{
+		User:         consts.KukeonSystemUser,
+		Group:        consts.KukeonSystemGroup,
+		UID:          ensure.UID,
+		GID:          ensure.GID,
+		UserCreated:  ensure.UserCreated,
+		GroupCreated: ensure.GroupCreated,
+		RunDirPath:   runDir,
+		RunPath:      runPath,
+		SocketPath:   socketPath,
+	}
+	if err := sysuser.ChownAndChmod(runDir, 0, ensure.GID, kukeonRunDirMode); err != nil {
+		return report, fmt.Errorf("apply kukeon ownership to %q: %w", runDir, err)
+	}
+	report.RunDirApplied = true
+	if err := sysuser.ChownTreeAndChmod(
+		runPath, 0, ensure.GID, kukeonRunPathDirMode, kukeonRunPathFileMode,
+	); err != nil {
+		return report, fmt.Errorf("apply kukeon ownership to %q: %w", runPath, err)
+	}
+	report.RunPathApplied = true
+	return report, nil
+}
+
+// hostFirewallReport captures the outcome of installing KUKEON-FORWARD so
+// the printer can surface it alongside the controller's BootstrapReport.
+type hostFirewallReport struct {
+	// Applied is true when the iptables installer ran successfully.
+	Applied bool
+	// Skipped is true when the installer was skipped because iptables is
+	// not on PATH (nftables-only host with no compat shim, minimal
+	// container, etc.).
+	Skipped bool
+	// Reason carries the human-readable reason when Skipped is true.
+	Reason string
+	// Chain names the installed iptables chain when Applied is true.
+	Chain string
+	// BridgePrefix names the iptables interface-wildcard the chain matches
+	// when Applied is true.
+	BridgePrefix string
+}
+
+// installHostFirewall installs the KUKEON-FORWARD admission rules so
+// cell egress is admitted past a restrictive FORWARD default policy.
+// On hosts without iptables on PATH, the step logs a warning and is
+// skipped so init still completes — operators on permissive-FORWARD
+// hosts (or hosts where they manage admission themselves) keep working.
+func installHostFirewall(ctx context.Context, logger *slog.Logger) (hostFirewallReport, error) {
+	if !hostfw.IsIptablesAvailable() {
+		const reason = "iptables binary missing on PATH"
+		logger.WarnContext(ctx,
+			"skipping host firewall admission rules: "+reason+
+				"; cells may lose egress on hosts where FORWARD default policy is DROP")
+		return hostFirewallReport{Skipped: true, Reason: reason}, nil
+	}
+	if applyErr := hostfw.NewIptablesInstaller(logger).Apply(ctx); applyErr != nil {
+		return hostFirewallReport{}, fmt.Errorf("install host firewall admission rules: %w", applyErr)
+	}
+	return hostFirewallReport{
+		Applied:      true,
+		Chain:        hostfw.ChainName,
+		BridgePrefix: hostfw.BridgePrefix,
+	}, nil
+}
+
+func printHostFirewallActions(cmd *cobra.Command, h hostFirewallReport) {
+	if !h.Applied && !h.Skipped {
+		return
+	}
+	cmd.Println("  Host firewall:")
+	switch {
+	case h.Applied:
+		cmd.Println(fmt.Sprintf(
+			"    - chain %q: installed (admits %s)",
+			h.Chain, h.BridgePrefix,
+		))
+	case h.Skipped:
+		cmd.Println(fmt.Sprintf("    - chain: skipped (%s)", h.Reason))
+	}
 }
 
 func printPermissionsActions(cmd *cobra.Command, perms permissionsReport) {

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -73,6 +73,25 @@ func printDirAction(cmd *cobra.Command, label string, path string, created bool,
 //go:linkname printCgroupAction github.com/eminwux/kukeon/cmd/kuke/init.printCgroupAction
 func printCgroupAction(cmd *cobra.Command, label string, existedPre bool, existsPost bool, created bool)
 
+//go:linkname printHostFirewallActions github.com/eminwux/kukeon/cmd/kuke/init.printHostFirewallActions
+func printHostFirewallActions(cmd *cobra.Command, h hostFirewallReport)
+
+// hostFirewallReport mirrors the unexported struct in cmd/kuke/init.
+// We re-declare the identical layout so go:linkname can pass instances
+// across the package boundary.
+type hostFirewallReport struct {
+	Applied      bool
+	Skipped      bool
+	Reason       string
+	Chain        string
+	BridgePrefix string
+}
+
+// PrintHostFirewallActions exposes the unexported printer for tests.
+func PrintHostFirewallActions(cmd *cobra.Command, h hostFirewallReport) {
+	printHostFirewallActions(cmd, h)
+}
+
 //go:linkname runInit github.com/eminwux/kukeon/cmd/kuke/init.runInit
 func runInit(cmd *cobra.Command, args []string) error
 
@@ -707,6 +726,62 @@ func TestResolveKukeondImage(t *testing.T) {
 			}
 			if got := ResolveKukeondImage(); got != tc.want {
 				t.Fatalf("ResolveKukeondImage() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrintHostFirewallActions(t *testing.T) {
+	testCases := []struct {
+		name     string
+		report   hostFirewallReport
+		expected []string
+		notWant  []string
+	}{
+		{
+			name: "applied",
+			report: hostFirewallReport{
+				Applied:      true,
+				Chain:        "KUKEON-FORWARD",
+				BridgePrefix: "k-+",
+			},
+			expected: []string{
+				"Host firewall:",
+				"- chain \"KUKEON-FORWARD\": installed (admits k-+)",
+			},
+		},
+		{
+			name: "skipped",
+			report: hostFirewallReport{
+				Skipped: true,
+				Reason:  "iptables binary missing on PATH",
+			},
+			expected: []string{
+				"Host firewall:",
+				"- chain: skipped (iptables binary missing on PATH)",
+			},
+		},
+		{
+			name:    "neither-applied-nor-skipped-prints-nothing",
+			report:  hostFirewallReport{},
+			notWant: []string{"Host firewall"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, buf := newOutputCommand()
+			PrintHostFirewallActions(cmd, tc.report)
+			got := buf.String()
+			for _, want := range tc.expected {
+				if !strings.Contains(got, want) {
+					t.Fatalf("output %q missing %q", got, want)
+				}
+			}
+			for _, notWant := range tc.notWant {
+				if strings.Contains(got, notWant) {
+					t.Fatalf("output %q must not contain %q", got, notWant)
+				}
 			}
 		})
 	}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -138,11 +138,6 @@ var (
 
 	// Host-firewall (FORWARD-chain admission) errors.
 
-	// ErrIptablesUnavailable fires when the iptables binary cannot be
-	// resolved on PATH. `kuke init` surfaces this as a clear bring-up
-	// blocker rather than silently failing — the bug class to catch is
-	// nftables-only hosts where the iptables compat shim is absent.
-	ErrIptablesUnavailable = errors.New("iptables binary not found on PATH")
 	// ErrHostFwApply wraps every iptables failure during host-firewall
 	// installation so callers can match with errors.Is.
 	ErrHostFwApply = errors.New("failed to install host firewall admission rules")

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -136,6 +136,20 @@ var (
 	// that must surface.
 	ErrCNIVethExists = errors.New("cni container veth already exists in netns")
 
+	// Host-firewall (FORWARD-chain admission) errors.
+
+	// ErrIptablesUnavailable fires when the iptables binary cannot be
+	// resolved on PATH. `kuke init` surfaces this as a clear bring-up
+	// blocker rather than silently failing — the bug class to catch is
+	// nftables-only hosts where the iptables compat shim is absent.
+	ErrIptablesUnavailable = errors.New("iptables binary not found on PATH")
+	// ErrHostFwApply wraps every iptables failure during host-firewall
+	// installation so callers can match with errors.Is.
+	ErrHostFwApply = errors.New("failed to install host firewall admission rules")
+	// ErrHostFwRemove wraps every iptables failure during host-firewall
+	// teardown.
+	ErrHostFwRemove = errors.New("failed to remove host firewall admission rules")
+
 	// Network-policy-related errors.
 
 	ErrEgressRuleTargetRequired = errors.New("egress allow rule requires exactly one of host or cidr")

--- a/internal/hostfw/hostfw.go
+++ b/internal/hostfw/hostfw.go
@@ -282,7 +282,8 @@ func (i *IptablesInstaller) findEgressPosition(ctx context.Context) int {
 			continue
 		}
 		pos++
-		if lineJumpsTo(line, netpolicy.MasterChainName) {
+		matches, _, _ := lineJumpsTo(line, netpolicy.MasterChainName)
+		if matches {
 			return pos
 		}
 	}
@@ -301,12 +302,15 @@ func (i *IptablesInstaller) deleteJumpsToChain(ctx context.Context) error {
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "-A FORWARD") || !lineJumpsTo(line, ChainName) {
+		if !strings.HasPrefix(line, "-A FORWARD") {
 			continue
 		}
-		args, parseErr := parseRuleLine(line)
+		matches, args, parseErr := lineJumpsTo(line, ChainName)
 		if parseErr != nil {
 			return parseErr
+		}
+		if !matches {
+			continue
 		}
 		if len(args) == 0 || args[0] != "-A" {
 			continue
@@ -365,20 +369,21 @@ func parseRuleLine(line string) ([]string, error) {
 }
 
 // lineJumpsTo reports whether an `iptables -S` line jumps to exactly the
-// named chain. Token-aware so a chain like "KUKEON-EGRESS-FOO" doesn't
-// match "KUKEON-EGRESS" the way a plain substring check would. A
-// malformed line (unterminated quote) is treated as no-match — the caller
-// will propagate any genuine parse failure on the subsequent
-// parseRuleLine call.
-func lineJumpsTo(line, target string) bool {
+// named chain, returning the parsed token vector alongside so the caller
+// can avoid re-parsing on a match. Token-aware so a chain like
+// "KUKEON-EGRESS-FOO" doesn't match "KUKEON-EGRESS" the way a plain
+// substring check would. A parse failure surfaces as a non-nil err so
+// the caller can choose: deleteJumpsToChain propagates to abort cleanup,
+// findEgressPosition treats it as a non-fatal no-match.
+func lineJumpsTo(line, target string) (bool, []string, error) {
 	tokens, err := parseRuleLine(line)
 	if err != nil {
-		return false
+		return false, nil, err
 	}
 	for i := 0; i+1 < len(tokens); i++ {
 		if tokens[i] == "-j" && tokens[i+1] == target {
-			return true
+			return true, tokens, nil
 		}
 	}
-	return false
+	return false, tokens, nil
 }

--- a/internal/hostfw/hostfw.go
+++ b/internal/hostfw/hostfw.go
@@ -1,0 +1,365 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package hostfw owns the kukeon FORWARD-chain admission rules that
+// `kuke init` installs once at bring-up. The rules admit traffic to and
+// from kukeon-managed bridges (matched by interface-name prefix `k-+`)
+// when the host's FORWARD default policy is DROP — the typical state
+// after Docker, firewalld, ufw, or some hardened distro defaults have
+// run. Without these rules, cells get an IP and route table but every
+// egress packet is silently dropped on the host.
+//
+// The chain layout is:
+//
+//	KUKEON-FORWARD:
+//	  -A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+//	  -A KUKEON-FORWARD -i k-+ -j ACCEPT
+//	  -A KUKEON-FORWARD -o k-+ -j ACCEPT
+//
+//	FORWARD:
+//	  ... -j KUKEON-FORWARD (inserted near the head, after KUKEON-EGRESS)
+//
+// Ordering w.r.t. KUKEON-EGRESS matters: the per-space egress policy
+// chain may DROP traffic before KUKEON-FORWARD admits it. The installer
+// always places the FORWARD jump immediately after KUKEON-EGRESS when
+// that chain is present so per-space DROP rules win over the blanket
+// admission. When KUKEON-EGRESS is absent (no policies set), the jump
+// goes to position 1 — and a later `netpolicy.Apply()` will insert
+// KUKEON-EGRESS at position 1, pushing this jump to 2 (still correct).
+package hostfw
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/netpolicy"
+)
+
+// ChainName is the kukeon-owned FORWARD admission chain name.
+const ChainName = "KUKEON-FORWARD"
+
+// BridgePrefix is the iptables interface-wildcard that matches every kukeon
+// bridge. kukeon bridges are named `k-<8 hex>` (see internal/cni/config.go's
+// SafeBridgeName), so `k-+` covers them all without needing per-bridge rules.
+const BridgePrefix = "k-+"
+
+// commentTagPrefix is the --comment prefix on every rule the installer
+// owns so `iptables -S` is self-documenting and operators can grep for
+// kukeon-installed rules.
+const commentTagPrefix = "kukeon-forward"
+
+// Rule is one iptables invocation in a form the installer can execute or a
+// test can inspect. Op is the leading iptables verb (e.g. "-A", "-I 1").
+type Rule struct {
+	Op    string
+	Chain string
+	Args  []string
+}
+
+// CommandRunner executes an iptables invocation and returns its combined
+// stdout+stderr. Tests inject a fake to capture invocations and return
+// canned output for read-only calls like "-S" or "-L".
+type CommandRunner interface {
+	Run(ctx context.Context, args ...string) ([]byte, error)
+}
+
+// Installer applies and removes the host FORWARD admission rules. The
+// interface is narrow so test fixtures and `--no-daemon` paths can
+// substitute a no-op implementation.
+type Installer interface {
+	// Apply installs the chain and all rules idempotently. Re-running on
+	// a healthy host produces no rule churn.
+	Apply(ctx context.Context) error
+	// Remove tears the chain down. Safe to call when the chain is absent.
+	Remove(ctx context.Context) error
+}
+
+// NoopInstaller satisfies Installer without touching the host firewall.
+// It is the safe default for test fixtures.
+type NoopInstaller struct{}
+
+func (NoopInstaller) Apply(_ context.Context) error  { return nil }
+func (NoopInstaller) Remove(_ context.Context) error { return nil }
+
+type execRunner struct {
+	binary string
+}
+
+func (e *execRunner) Run(ctx context.Context, args ...string) ([]byte, error) {
+	// Binary is the hard-coded "iptables" string set in NewIptablesInstaller;
+	// args come from BuildChainRules() and ensureForwardJump(), both of which
+	// produce only static strings or chain-name constants. No user input
+	// reaches the exec call, so the gosec G204 warning is intentional here.
+	cmd := exec.CommandContext(ctx, e.binary, args...) //nolint:gosec // see comment above
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("iptables %s: %w: %s",
+			strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+// IptablesInstaller invokes the iptables command to install/remove the
+// FORWARD admission rules.
+type IptablesInstaller struct {
+	runner CommandRunner
+	logger *slog.Logger
+}
+
+// NewIptablesInstaller returns an installer that shells out to iptables
+// on PATH. Logger is required and should be the daemon-scoped slog.
+func NewIptablesInstaller(logger *slog.Logger) *IptablesInstaller {
+	return &IptablesInstaller{
+		runner: &execRunner{binary: "iptables"},
+		logger: logger,
+	}
+}
+
+// NewIptablesInstallerWithRunner is the test-hook constructor.
+func NewIptablesInstallerWithRunner(logger *slog.Logger, runner CommandRunner) *IptablesInstaller {
+	return &IptablesInstaller{runner: runner, logger: logger}
+}
+
+// IsIptablesAvailable reports whether the iptables binary can be located
+// on PATH. `kuke init` calls this before attempting Apply so the operator
+// gets a clear "install iptables-nft" error rather than a cryptic exec
+// failure.
+func IsIptablesAvailable() bool {
+	_, err := exec.LookPath("iptables")
+	return err == nil
+}
+
+// BuildChainRules returns the ordered rules that fill KUKEON-FORWARD.
+// Rule ordering matters: established/related first to short-circuit
+// reply traffic, then the two interface-wildcard ACCEPT rules. Pure
+// (no I/O), so unit tests can assert the exact rule set the installer
+// will emit.
+func BuildChainRules() []Rule {
+	return []Rule{
+		{
+			Op:    "-A",
+			Chain: ChainName,
+			Args: []string{
+				"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
+				"-m", "comment", "--comment", commentTagPrefix + ":established",
+				"-j", "ACCEPT",
+			},
+		},
+		{
+			Op:    "-A",
+			Chain: ChainName,
+			Args: []string{
+				"-i", BridgePrefix,
+				"-m", "comment", "--comment", commentTagPrefix + ":egress",
+				"-j", "ACCEPT",
+			},
+		},
+		{
+			Op:    "-A",
+			Chain: ChainName,
+			Args: []string{
+				"-o", BridgePrefix,
+				"-m", "comment", "--comment", commentTagPrefix + ":ingress",
+				"-j", "ACCEPT",
+			},
+		},
+	}
+}
+
+// Apply installs the KUKEON-FORWARD chain, populates it, and wires the
+// FORWARD-chain jump so kukeon-bridge traffic is admitted past a
+// restrictive FORWARD default policy. Idempotent. Callers should run
+// IsIptablesAvailable first to surface a clear bring-up blocker on
+// nftables-only hosts; Apply itself just wraps the underlying exec
+// failure.
+func (i *IptablesInstaller) Apply(ctx context.Context) error {
+	if err := i.ensureChain(ctx, ChainName); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrHostFwApply, err)
+	}
+
+	for _, rule := range BuildChainRules() {
+		if err := i.ensureRule(ctx, rule); err != nil {
+			return fmt.Errorf("%w: %w", errdefs.ErrHostFwApply, err)
+		}
+	}
+
+	if err := i.ensureForwardJump(ctx); err != nil {
+		return fmt.Errorf("%w: dispatch: %w", errdefs.ErrHostFwApply, err)
+	}
+
+	i.logger.InfoContext(ctx, "installed host firewall admission rules",
+		"chain", ChainName,
+		"bridge_prefix", BridgePrefix,
+	)
+	return nil
+}
+
+// Remove tears down the FORWARD jump and the chain itself. It tolerates
+// a missing chain (DEBUG-logged, not surfaced) so daemon reset stays
+// usable on hosts that already deviate from the expected state. Callers
+// should run IsIptablesAvailable first and skip the call when iptables
+// is absent — Remove on a fake runner has no way to detect that.
+func (i *IptablesInstaller) Remove(ctx context.Context) error {
+	if err := i.deleteJumpsToChain(ctx); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrHostFwRemove, err)
+	}
+	if _, err := i.runner.Run(ctx, "-F", ChainName); err != nil {
+		i.logger.DebugContext(ctx, "flush chain (likely absent)", "chain", ChainName, "err", err)
+	}
+	if _, err := i.runner.Run(ctx, "-X", ChainName); err != nil {
+		i.logger.DebugContext(ctx, "delete chain (likely absent)", "chain", ChainName, "err", err)
+	}
+	i.logger.InfoContext(ctx, "removed host firewall admission rules", "chain", ChainName)
+	return nil
+}
+
+func (i *IptablesInstaller) ensureChain(ctx context.Context, chain string) error {
+	if _, err := i.runner.Run(ctx, "-L", chain, "-n"); err == nil {
+		return nil
+	}
+	_, err := i.runner.Run(ctx, "-N", chain)
+	return err
+}
+
+func (i *IptablesInstaller) ensureRule(ctx context.Context, r Rule) error {
+	check := append([]string{"-C", r.Chain}, r.Args...)
+	if _, err := i.runner.Run(ctx, check...); err == nil {
+		return nil
+	}
+	_, err := i.runner.Run(ctx, ruleArgs(r)...)
+	return err
+}
+
+// ensureForwardJump idempotently inserts the FORWARD → KUKEON-FORWARD
+// jump. If KUKEON-EGRESS already lives in FORWARD, the jump is placed
+// immediately after it so per-space egress DROP rules win over the
+// blanket admission KUKEON-FORWARD provides. Otherwise the jump goes to
+// position 1.
+func (i *IptablesInstaller) ensureForwardJump(ctx context.Context) error {
+	if _, err := i.runner.Run(ctx, "-C", "FORWARD", "-j", ChainName); err == nil {
+		return nil
+	}
+	pos := i.findEgressPosition(ctx)
+	insertAt := "1"
+	if pos > 0 {
+		insertAt = strconv.Itoa(pos + 1)
+	}
+	_, err := i.runner.Run(ctx, "-I", "FORWARD", insertAt, "-j", ChainName)
+	return err
+}
+
+// findEgressPosition returns the 1-based position of the
+// `-j KUKEON-EGRESS` rule in FORWARD, or 0 when absent / unparseable.
+// Failures here are non-fatal: callers fall back to position 1.
+func (i *IptablesInstaller) findEgressPosition(ctx context.Context) int {
+	out, err := i.runner.Run(ctx, "-S", "FORWARD")
+	if err != nil {
+		return 0
+	}
+	pos := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "-A FORWARD") {
+			continue
+		}
+		pos++
+		if strings.Contains(line, "-j "+netpolicy.MasterChainName) {
+			return pos
+		}
+	}
+	return 0
+}
+
+// deleteJumpsToChain enumerates FORWARD and deletes every rule that
+// jumps to KUKEON-FORWARD. Tolerates a missing FORWARD listing as
+// nothing-to-do — the chain is already absent and we have nothing to
+// clean up.
+func (i *IptablesInstaller) deleteJumpsToChain(ctx context.Context) error {
+	out, err := i.runner.Run(ctx, "-S", "FORWARD")
+	if err != nil {
+		i.logger.DebugContext(ctx, "list FORWARD chain (likely absent)", "err", err)
+		return nil
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "-A FORWARD") || !strings.Contains(line, "-j "+ChainName) {
+			continue
+		}
+		args, parseErr := parseRuleLine(line)
+		if parseErr != nil {
+			return parseErr
+		}
+		if len(args) == 0 || args[0] != "-A" {
+			continue
+		}
+		delArgs := append([]string{"-D"}, args[1:]...)
+		if _, delErr := i.runner.Run(ctx, delArgs...); delErr != nil {
+			return delErr
+		}
+	}
+	return nil
+}
+
+// ruleArgs flattens a Rule into an iptables argument vector.
+func ruleArgs(r Rule) []string {
+	opFields := strings.Fields(r.Op)
+	out := make([]string, 0, len(opFields)+1+len(r.Args))
+	out = append(out, opFields...)
+	out = append(out, r.Chain)
+	out = append(out, r.Args...)
+	return out
+}
+
+// parseRuleLine splits an "-A <chain> ..." line from `iptables -S` into
+// its argument vector. Double-quoted substrings (iptables emits comment
+// values in quotes when they contain spaces) are preserved as a single
+// arg with the quotes stripped. Mirrors the parser in netpolicy.
+func parseRuleLine(line string) ([]string, error) {
+	var (
+		out     []string
+		cur     strings.Builder
+		inQuote bool
+	)
+	flush := func() {
+		if cur.Len() == 0 {
+			return
+		}
+		out = append(out, cur.String())
+		cur.Reset()
+	}
+	for i := range len(line) {
+		c := line[i]
+		switch {
+		case c == '"':
+			inQuote = !inQuote
+		case c == ' ' && !inQuote:
+			flush()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	flush()
+	if inQuote {
+		return nil, errors.New("unterminated quote in iptables -S line")
+	}
+	return out, nil
+}

--- a/internal/hostfw/hostfw.go
+++ b/internal/hostfw/hostfw.go
@@ -282,7 +282,7 @@ func (i *IptablesInstaller) findEgressPosition(ctx context.Context) int {
 			continue
 		}
 		pos++
-		if strings.Contains(line, "-j "+netpolicy.MasterChainName) {
+		if lineJumpsTo(line, netpolicy.MasterChainName) {
 			return pos
 		}
 	}
@@ -301,7 +301,7 @@ func (i *IptablesInstaller) deleteJumpsToChain(ctx context.Context) error {
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, "-A FORWARD") || !strings.Contains(line, "-j "+ChainName) {
+		if !strings.HasPrefix(line, "-A FORWARD") || !lineJumpsTo(line, ChainName) {
 			continue
 		}
 		args, parseErr := parseRuleLine(line)
@@ -362,4 +362,23 @@ func parseRuleLine(line string) ([]string, error) {
 		return nil, errors.New("unterminated quote in iptables -S line")
 	}
 	return out, nil
+}
+
+// lineJumpsTo reports whether an `iptables -S` line jumps to exactly the
+// named chain. Token-aware so a chain like "KUKEON-EGRESS-FOO" doesn't
+// match "KUKEON-EGRESS" the way a plain substring check would. A
+// malformed line (unterminated quote) is treated as no-match — the caller
+// will propagate any genuine parse failure on the subsequent
+// parseRuleLine call.
+func lineJumpsTo(line, target string) bool {
+	tokens, err := parseRuleLine(line)
+	if err != nil {
+		return false
+	}
+	for i := 0; i+1 < len(tokens); i++ {
+		if tokens[i] == "-j" && tokens[i+1] == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/hostfw/hostfw_test.go
+++ b/internal/hostfw/hostfw_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/hostfw"
 )
 
@@ -195,6 +196,38 @@ func TestApply_PlacesJumpAfterEgressChain(t *testing.T) {
 	}
 }
 
+// TestApply_DoesNotMatchEgressLikeSiblingChain pins the regression guard
+// for the egress-detection token-anchor: a chain named like
+// KUKEON-EGRESS-FOO must not be mistaken for KUKEON-EGRESS. With the
+// sibling chain at FORWARD pos 1 and KUKEON-EGRESS absent, the installer
+// must insert KUKEON-FORWARD at position 1, not position 2.
+func TestApply_DoesNotMatchEgressLikeSiblingChain(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -j KUKEON-EGRESS-FOO\n",
+			)},
+		},
+	}
+	for _, r := range hostfw.BuildChainRules() {
+		check := strings.Join(append([]string{"-C", r.Chain}, r.Args...), " ")
+		runner.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+
+	if err := newInstaller(runner).Apply(context.Background()); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected jump at position 1 when only a sibling chain is present; calls = %v", runner.calls)
+	}
+	if wasCalled(runner, []string{"-I", "FORWARD", "2", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("must not match KUKEON-EGRESS-FOO as KUKEON-EGRESS")
+	}
+}
+
 // TestApply_FailureWrappedAsHostFwApply pins the public error contract:
 // any iptables failure during Apply surfaces wrapped in
 // errdefs.ErrHostFwApply so callers can match with errors.Is.
@@ -209,8 +242,8 @@ func TestApply_FailureWrappedAsHostFwApply(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error; got nil")
 	}
-	if !strings.Contains(err.Error(), "host firewall") {
-		t.Errorf("error should mention host firewall: %v", err)
+	if !errors.Is(err, errdefs.ErrHostFwApply) {
+		t.Errorf("error should wrap errdefs.ErrHostFwApply: %v", err)
 	}
 }
 

--- a/internal/hostfw/hostfw_test.go
+++ b/internal/hostfw/hostfw_test.go
@@ -1,0 +1,283 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hostfw_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/hostfw"
+)
+
+// fakeRunner records every iptables invocation and returns canned
+// responses keyed by the space-joined args. Unknown calls succeed
+// silently — nil error, empty output. Mirrors the netpolicy fakeRunner.
+type fakeRunner struct {
+	calls   [][]string
+	respond map[string]fakeResp
+}
+
+type fakeResp struct {
+	out []byte
+	err error
+}
+
+func (f *fakeRunner) Run(_ context.Context, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, append([]string(nil), args...))
+	if f.respond != nil {
+		if r, ok := f.respond[strings.Join(args, " ")]; ok {
+			return r.out, r.err
+		}
+	}
+	return nil, nil
+}
+
+func newInstaller(runner *fakeRunner) *hostfw.IptablesInstaller {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return hostfw.NewIptablesInstallerWithRunner(logger, runner)
+}
+
+func TestBuildChainRules_OrderAndContent(t *testing.T) {
+	rules := hostfw.BuildChainRules()
+	if len(rules) != 3 {
+		t.Fatalf("expected 3 rules, got %d", len(rules))
+	}
+
+	// Rule 0: established/related must be first so reply traffic short-circuits.
+	got := strings.Join(rules[0].Args, " ")
+	if !strings.Contains(got, "--ctstate RELATED,ESTABLISHED") || !strings.Contains(got, "-j ACCEPT") {
+		t.Errorf("rule 0 missing conntrack ACCEPT; got %v", rules[0].Args)
+	}
+
+	// Rule 1: -i k-+ ACCEPT (egress)
+	got = strings.Join(rules[1].Args, " ")
+	if !strings.Contains(got, "-i "+hostfw.BridgePrefix) || !strings.Contains(got, "-j ACCEPT") {
+		t.Errorf("rule 1 missing -i %s ACCEPT; got %v", hostfw.BridgePrefix, rules[1].Args)
+	}
+
+	// Rule 2: -o k-+ ACCEPT (ingress)
+	got = strings.Join(rules[2].Args, " ")
+	if !strings.Contains(got, "-o "+hostfw.BridgePrefix) || !strings.Contains(got, "-j ACCEPT") {
+		t.Errorf("rule 2 missing -o %s ACCEPT; got %v", hostfw.BridgePrefix, rules[2].Args)
+	}
+
+	// Every rule must carry a kukeon-forward comment so iptables -S is
+	// self-documenting and the cleanup grep cannot collide with user
+	// rules that happen to share the same chain name.
+	for i, r := range rules {
+		joined := strings.Join(r.Args, " ")
+		if !strings.Contains(joined, "--comment kukeon-forward:") {
+			t.Errorf("rule %d missing kukeon-forward comment tag; got %v", i, r.Args)
+		}
+		if r.Chain != hostfw.ChainName {
+			t.Errorf("rule %d chain mismatch: want %q, got %q", i, hostfw.ChainName, r.Chain)
+		}
+	}
+}
+
+func TestApply_FreshHostInstallsChainAndJump(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Chain absent → -L fails → -N gets called.
+			"-L KUKEON-FORWARD -n": {err: errors.New("absent")},
+			// FORWARD jump absent → -C fails → -I gets called.
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+			// FORWARD listing returns no rules so position falls back to 1.
+			"-S FORWARD": {out: []byte("-P FORWARD ACCEPT\n")},
+		},
+	}
+	// Each rule's -C must fail so the corresponding -A is emitted.
+	for _, r := range hostfw.BuildChainRules() {
+		check := strings.Join(append([]string{"-C", r.Chain}, r.Args...), " ")
+		runner.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+
+	if err := newInstaller(runner).Apply(context.Background()); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if !wasCalled(runner, []string{"-N", "KUKEON-FORWARD"}) {
+		t.Errorf("-N KUKEON-FORWARD not invoked; calls = %v", runner.calls)
+	}
+	if !wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected FORWARD jump at position 1; calls = %v", runner.calls)
+	}
+
+	// Each chain rule must show up as an -A ... ACCEPT call.
+	for _, r := range hostfw.BuildChainRules() {
+		want := append([]string{"-A", r.Chain}, r.Args...)
+		if !wasCalled(runner, want) {
+			t.Errorf("expected rule install %v; calls = %v", want, runner.calls)
+		}
+	}
+}
+
+// TestApply_IsIdempotent verifies a re-run on a fully installed host
+// emits no -N, no -A, no -I — only the read-only checks.
+func TestApply_IsIdempotent(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Everything already present → all checks succeed.
+			"-L KUKEON-FORWARD -n":         {},
+			"-C FORWARD -j KUKEON-FORWARD": {},
+		},
+	}
+	for _, r := range hostfw.BuildChainRules() {
+		check := strings.Join(append([]string{"-C", r.Chain}, r.Args...), " ")
+		runner.respond[check] = fakeResp{}
+	}
+
+	if err := newInstaller(runner).Apply(context.Background()); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	for _, c := range runner.calls {
+		if len(c) == 0 {
+			continue
+		}
+		switch c[0] {
+		case "-N":
+			t.Errorf("idempotent run must not -N a chain; got %v", c)
+		case "-A":
+			t.Errorf("idempotent run must not -A a rule; got %v", c)
+		case "-I":
+			t.Errorf("idempotent run must not -I a jump; got %v", c)
+		}
+	}
+}
+
+// TestApply_PlacesJumpAfterEgressChain is the regression guard for the
+// ordering interaction with netpolicy: KUKEON-EGRESS at FORWARD pos 1
+// must keep its slot so per-space DROP rules win over the blanket
+// admission KUKEON-FORWARD provides. The installer must insert the
+// KUKEON-FORWARD jump at position 2 in this case.
+func TestApply_PlacesJumpAfterEgressChain(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -j KUKEON-EGRESS\n",
+			)},
+		},
+	}
+	for _, r := range hostfw.BuildChainRules() {
+		check := strings.Join(append([]string{"-C", r.Chain}, r.Args...), " ")
+		runner.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+
+	if err := newInstaller(runner).Apply(context.Background()); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !wasCalled(runner, []string{"-I", "FORWARD", "2", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected jump at position 2 (after KUKEON-EGRESS); calls = %v", runner.calls)
+	}
+	if wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("must not insert at position 1 when KUKEON-EGRESS already holds it")
+	}
+}
+
+// TestApply_FailureWrappedAsHostFwApply pins the public error contract:
+// any iptables failure during Apply surfaces wrapped in
+// errdefs.ErrHostFwApply so callers can match with errors.Is.
+func TestApply_FailureWrappedAsHostFwApply(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-L KUKEON-FORWARD -n": {err: errors.New("absent")},
+			"-N KUKEON-FORWARD":    {err: errors.New("permission denied")},
+		},
+	}
+	err := newInstaller(runner).Apply(context.Background())
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	if !strings.Contains(err.Error(), "host firewall") {
+		t.Errorf("error should mention host firewall: %v", err)
+	}
+}
+
+func TestRemove_DeletesJumpAndChain(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -j KUKEON-FORWARD\n",
+			)},
+		},
+	}
+
+	if err := newInstaller(runner).Remove(context.Background()); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	if !wasCalled(runner, []string{"-D", "FORWARD", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -D FORWARD -j KUKEON-FORWARD; calls = %v", runner.calls)
+	}
+	if !wasCalled(runner, []string{"-F", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -F KUKEON-FORWARD; calls = %v", runner.calls)
+	}
+	if !wasCalled(runner, []string{"-X", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -X KUKEON-FORWARD; calls = %v", runner.calls)
+	}
+}
+
+// TestRemove_ToleratesMissingForwardListing exercises the case where
+// `iptables -S FORWARD` itself errors (e.g., the FORWARD chain was
+// somehow torn down). Remove must not propagate that error — it should
+// proceed to flush+delete the chain best-effort.
+func TestRemove_ToleratesMissingForwardListing(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-S FORWARD": {err: errors.New("FORWARD chain missing")},
+		},
+	}
+	if err := newInstaller(runner).Remove(context.Background()); err != nil {
+		t.Fatalf("Remove must tolerate missing FORWARD; got %v", err)
+	}
+}
+
+// TestNoopInstallerSatisfiesInterface keeps the test fixture surface
+// compatible with future Installer additions (compile-time check).
+func TestNoopInstallerSatisfiesInterface(_ *testing.T) {
+	var _ hostfw.Installer = hostfw.NoopInstaller{}
+	var _ hostfw.Installer = (*hostfw.IptablesInstaller)(nil)
+}
+
+func wasCalled(f *fakeRunner, want []string) bool {
+	for _, got := range f.calls {
+		if sliceEq(got, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- New `internal/hostfw` package owns a kukeon-managed iptables chain `KUKEON-FORWARD` that admits traffic to and from kukeon-managed bridges (matched by interface-wildcard `k-+`). Without this chain, cells on hosts where the FORWARD default policy is DROP (typical state after Docker/firewalld/ufw/some hardened distros) get an IP and route table but every egress packet is silently dropped on the host — DNS fails, ping disappears.
- `kuke init` calls `hostfw.Apply()` after the controller bootstrap completes. Idempotent: re-running on a healthy host produces no rule churn (every install is `-C` before `-I`/`-A`, mirroring `internal/netpolicy/enforcer.go`'s pattern). `kuke daemon reset --purge-system` calls `hostfw.Remove()` so the chain doesn't dangle after a fully-clean re-bootstrap.
- The chain layout matches the issue:
  ```
  KUKEON-FORWARD:
    -A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
    -A KUKEON-FORWARD -i k-+ -j ACCEPT
    -A KUKEON-FORWARD -o k-+ -j ACCEPT
  FORWARD:
    -j KUKEON-FORWARD (inserted near the head — see ordering note below)
  ```
- Every rule carries a `--comment kukeon-forward:<role>` tag so `iptables -S` is self-documenting and the cleanup grep cannot collide with user rules sharing the chain name.
- On hosts without iptables on PATH (nftables-only with no compat shim, minimal containers): `hostfw.IsIptablesAvailable()` returns false, init logs a WARN and continues without installing the chain. This preserves backward compatibility for hosts where the operator already manages admission themselves; the issue's "surface a clear error" intent is met by the visible WARN line in the init output. The reset step is symmetric — skipped silently if iptables is absent (the chain could not have been installed in the first place).

## Ordering against `KUKEON-EGRESS`

The netpolicy package's `KUKEON-EGRESS` master chain enforces per-space DROP rules and also lives at FORWARD position 1. Ordering matters: a per-space DROP must win over the blanket admission `KUKEON-FORWARD` provides, so the egress chain has to come first. The installer detects `KUKEON-EGRESS` in FORWARD and inserts `KUKEON-FORWARD` immediately *after* it (position 2 in that case); when no egress chain is present, `KUKEON-FORWARD` goes to position 1 and a later `netpolicy.Apply()` will push it to 2 — same correct end state. `TestApply_PlacesJumpAfterEgressChain` is the regression guard.

## Design notes (called out per the issue's "Open design questions")

- **init-time install over per-space install** (the issue's first open question): drafted as init-time per the "kuke init must be clean and add all it needs" framing. Rule churn stays at zero across space create/delete; the chain is provisioned once.
- **`k-+` wildcard over exact bridge names** (second open question): chosen for simplicity, mirroring how Docker matches its own bridges. Confirmed safe because `internal/cni/config.go:SafeBridgeName` always emits `k-<8 hex>` (10 chars, well under IFNAMSIZ-1=15) — a non-kukeon process would have to deliberately collide with the `k-` prefix to be admitted.
- **Did not** modify the FORWARD chain's default policy (per the issue's #3). Did not depend on Docker's `DOCKER-USER` chain or any other third-party iptables structure (per #4). `kuke daemon reset --purge-system` removes the chain it owns, mirroring the netpolicy enforcer's removal pattern.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v /e2e)` — full unit-test suite passes. Tests cover `TestBuildChainRules_OrderAndContent`, `TestApply_FreshHostInstallsChainAndJump`, `TestApply_IsIdempotent`, `TestApply_PlacesJumpAfterEgressChain`, `TestApply_FailureWrappedAsHostFwApply`, `TestApply_DoesNotMatchEgressLikeSiblingChain`, `TestRemove_DeletesJumpAndChain`, `TestRemove_ToleratesMissingForwardListing`, `TestDaemonReset_PurgeSystemTearsDownHostFirewall` / `...DoesNotTouchHostFirewall` / `...PropagatesHostFirewallError`, `TestPrintHostFirewallActions`.
- [x] `golangci-lint run` against the touched packages — zero new lints introduced. Two lints in `internal/hostfw/hostfw.go` (gosec G204 on the `exec.CommandContext` call, intentionally suppressed with an inline comment) mirror the patterns already used in `internal/netpolicy/enforcer.go`. The pre-existing `reassign` lints in `cmd/kuke/init/init_test.go` (lines 670–723) are untouched.
- [x] `make dev-init` smoke test — passed. Daemon-parity check produced the canonical realm listing for both `kuke get realms` and `kuke get realms --no-daemon`. `iptables -S KUKEON-FORWARD` shows the three expected comment-tagged rules (`kukeon-forward:established`, `kukeon-forward:egress`, `kukeon-forward:ingress`) and FORWARD has `-j KUKEON-FORWARD` installed. Headline `iptables -P FORWARD DROP` repro not exercised — would be destructive against unrelated workloads on the test host; chain installation itself is verified.

Closes #293