### PR TITLE
fix: remove shared mutable namespace from ctr client to fix race condition

### DIFF
--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -111,7 +111,7 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 		}
 	}
 
-	binaryPath, err := r.ctrClient.ResolveSbshCachePath(spec.Image, r.opts.RunPath)
+	binaryPath, err := r.ctrClient.ResolveSbshCachePath(spec.RealmName, spec.Image, r.opts.RunPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolve sbsh cache path for %q: %w", spec.Image, err)
 	}
@@ -150,7 +150,7 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 // Group ownership and mode are preserved (the dir was already chmod'd to
 // 02750 root:kukeon by attachableBuildOpts), so kukeon-group members on
 // the host keep traverse access to the socket.
-func (r *Exec) attachablePostCreateChown(spec intmodel.ContainerSpec) error {
+func (r *Exec) attachablePostCreateChown(namespace string, spec intmodel.ContainerSpec) error {
 	if !spec.Attachable {
 		return nil
 	}
@@ -159,7 +159,7 @@ func (r *Exec) attachablePostCreateChown(spec intmodel.ContainerSpec) error {
 	if containerdID == "" {
 		containerdID = spec.ID
 	}
-	container, err := r.ctrClient.GetContainer(containerdID)
+	container, err := r.ctrClient.GetContainer(namespace, containerdID)
 	if err != nil {
 		return fmt.Errorf("get container %q: %w", containerdID, err)
 	}

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -164,7 +164,7 @@ func (r *Exec) attachablePostCreateChown(namespace string, spec intmodel.Contain
 		return fmt.Errorf("get container %q: %w", containerdID, err)
 	}
 
-	uid, err := r.ctrClient.ContainerProcessUID(container)
+	uid, err := r.ctrClient.ContainerProcessUID(namespace, container)
 	if err != nil {
 		return fmt.Errorf("resolve process uid for %q: %w", containerdID, err)
 	}

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -74,7 +74,7 @@ func attachableTTYDirInitialPerms(kukeonGroupGID int) (os.FileMode, int) {
 // `kuke init` sets up on /opt/kukeon. The owner is corrected to the
 // container's resolved uid by attachablePostCreateChown after
 // CreateContainerFromSpec runs.
-func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOption, error) {
+func (r *Exec) attachableBuildOpts(namespace string, spec intmodel.ContainerSpec) ([]ctr.BuildOption, error) {
 	if !spec.Attachable {
 		return nil, nil
 	}
@@ -111,7 +111,7 @@ func (r *Exec) attachableBuildOpts(spec intmodel.ContainerSpec) ([]ctr.BuildOpti
 		}
 	}
 
-	binaryPath, err := r.ctrClient.ResolveSbshCachePath(spec.RealmName, spec.Image, r.opts.RunPath)
+	binaryPath, err := r.ctrClient.ResolveSbshCachePath(namespace, spec.Image, r.opts.RunPath)
 	if err != nil {
 		return nil, fmt.Errorf("resolve sbsh cache path for %q: %w", spec.Image, err)
 	}

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -74,7 +74,7 @@ func attachableTTYDirInitialPerms(kukeonGroupGID int) (os.FileMode, int) {
 // `kuke init` sets up on /opt/kukeon. The owner is corrected to the
 // container's resolved uid by attachablePostCreateChown after
 // CreateContainerFromSpec runs.
-func (r *Exec) attachableBuildOpts(namespace string, spec intmodel.ContainerSpec) ([]ctr.BuildOption, error) {
+func (r *Exec) attachableBuildOpts(namespace string, spec intmodel.ContainerSpec, creds []ctr.RegistryCredentials) ([]ctr.BuildOption, error) {
 	if !spec.Attachable {
 		return nil, nil
 	}
@@ -111,7 +111,7 @@ func (r *Exec) attachableBuildOpts(namespace string, spec intmodel.ContainerSpec
 		}
 	}
 
-	binaryPath, err := r.ctrClient.ResolveSbshCachePath(namespace, spec.Image, r.opts.RunPath)
+	binaryPath, err := r.ctrClient.ResolveSbshCachePath(namespace, spec.Image, r.opts.RunPath, creds)
 	if err != nil {
 		return nil, fmt.Errorf("resolve sbsh cache path for %q: %w", spec.Image, err)
 	}

--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -87,14 +87,6 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"namespace", namespace)
 	}
 
-	// Set namespace for containerd operations
-	if r.ctrClient != nil {
-		r.ctrClient.SetNamespace(namespace)
-		r.logger.DebugContext(r.ctx, "set containerd namespace",
-			"namespace", namespace,
-			"realm", realmName)
-	}
-
 	// Find container in cell spec to get ContainerdID
 	var foundContainerSpec *intmodel.ContainerSpec
 	for i := range cell.Spec.Containers {
@@ -150,7 +142,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 		"namespace", namespace)
 
 	// Check if container exists in containerd
-	containerExists, err := r.ExistsContainer(containerdID)
+	containerExists, err := r.ctrClient.ExistsContainer(namespace, containerdID)
 	if err != nil {
 		r.logger.InfoContext(r.ctx, "failed to check container existence",
 			"container", containerID,
@@ -169,7 +161,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 	}
 
 	// Get container state using TaskStatus from ctr package
-	taskStatus, taskStatusErr := r.ctrClient.TaskStatus(containerdID)
+	taskStatus, taskStatusErr := r.ctrClient.TaskStatus(namespace, containerdID)
 	if taskStatusErr == nil {
 		// TaskStatus succeeded - convert and return
 		state := ctr.ConvertContainerdStatusToContainerState(taskStatus)

--- a/internal/controller/runner/delete_cell.go
+++ b/internal/controller/runner/delete_cell.go
@@ -73,9 +73,6 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 		return fmt.Errorf("failed to get realm: %w", err)
 	}
 
-	// Set namespace to realm namespace
-	r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 	cellSpaceName := internalCell.Spec.SpaceName
 	cellStackName := internalCell.Spec.StackName
 	cellID := internalCell.Spec.ID
@@ -126,12 +123,12 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 		}
 
 		// Get netns path and purge CNI before stopping/deleting
-		netnsPath, _ := r.getContainerNetnsPath(containerID)
+		netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, containerID)
 		_ = r.purgeCNIForContainer(containerID, netnsPath, networkName)
 
 		// Use container name with UUID for containerd operations
 		// Stop and delete the container
-		_, err = r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{})
+		_, err = r.ctrClient.StopContainer(internalRealm.Spec.Namespace, containerID, ctr.StopContainerOptions{})
 		if err != nil {
 			// Check if container/task doesn't exist - this is idempotent (already stopped/deleted)
 			if errors.Is(err, errdefs.ErrContainerNotFound) || errors.Is(err, errdefs.ErrTaskNotFound) {
@@ -153,7 +150,7 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 			}
 		}
 
-		err = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
+		err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
 		})
 		if err != nil {
@@ -175,10 +172,10 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 	}
 
 	// Comprehensive CNI cleanup for root container before stopping/deleting
-	netnsPath, _ := r.getContainerNetnsPath(rootContainerID)
+	netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, rootContainerID)
 	_ = r.purgeCNIForContainer(rootContainerID, netnsPath, networkName)
 
-	_, err = r.ctrClient.StopContainer(rootContainerID, ctr.StopContainerOptions{Force: true})
+	_, err = r.ctrClient.StopContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.StopContainerOptions{Force: true})
 	if err != nil {
 		// Check if container/task doesn't exist - this is idempotent (already stopped/deleted)
 		if errors.Is(err, errdefs.ErrContainerNotFound) || errors.Is(err, errdefs.ErrTaskNotFound) {
@@ -200,7 +197,7 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 		}
 	}
 
-	err = r.ctrClient.DeleteContainer(rootContainerID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {

--- a/internal/controller/runner/delete_container.go
+++ b/internal/controller/runner/delete_container.go
@@ -73,9 +73,6 @@ func (r *Exec) DeleteContainer(cell intmodel.Cell, containerID string) error {
 		return fmt.Errorf("failed to get realm: %w", err)
 	}
 
-	// Set namespace to realm namespace
-	r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 	// Find container in cell spec by ID (base name)
 	var foundContainerSpec *intmodel.ContainerSpec
 	for i := range cell.Spec.Containers {
@@ -119,11 +116,11 @@ func (r *Exec) DeleteContainer(cell intmodel.Cell, containerID string) error {
 	}
 
 	// Comprehensive CNI cleanup before stopping/deleting
-	netnsPath, _ := r.getContainerNetnsPath(containerdID)
+	netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, containerdID)
 	_ = r.purgeCNIForContainer(containerdID, netnsPath, networkName)
 
 	// Stop the container using containerd ID
-	_, err = r.ctrClient.StopContainer(containerdID, ctr.StopContainerOptions{})
+	_, err = r.ctrClient.StopContainer(internalRealm.Spec.Namespace, containerdID, ctr.StopContainerOptions{})
 	if err != nil {
 		r.logger.WarnContext(
 			r.ctx,
@@ -138,7 +135,7 @@ func (r *Exec) DeleteContainer(cell intmodel.Cell, containerID string) error {
 	}
 
 	// Delete the container from containerd using containerd ID
-	err = r.ctrClient.DeleteContainer(containerdID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, containerdID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {

--- a/internal/controller/runner/delete_realm.go
+++ b/internal/controller/runner/delete_realm.go
@@ -59,7 +59,7 @@ func (r *Exec) DeleteRealm(realm intmodel.Realm) error {
 		r.logger.WarnContext(r.ctx, "failed to find orphaned containers", "error", err)
 	} else {
 		r.logger.DebugContext(r.ctx, "found orphaned containers", "count", len(containers))
-		r.processOrphanedContainers(r.ctx, containers)
+		r.processOrphanedContainers(r.ctx, internalRealm.Spec.Namespace, containers)
 	}
 
 	// Clean up all namespace resources (images, snapshots, blobs) before deleting namespace

--- a/internal/controller/runner/delete_space.go
+++ b/internal/controller/runner/delete_space.go
@@ -73,16 +73,13 @@ func (r *Exec) DeleteSpace(space intmodel.Space) error {
 	if realmErr != nil {
 		r.logger.WarnContext(r.ctx, "failed to get realm for CNI cleanup", "error", realmErr)
 	} else {
-		// Set namespace for container operations
-		r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 		// Find containers by pattern and purge CNI for each
 		pattern := fmt.Sprintf("%s-%s", realmName, internalSpace.Metadata.Name)
 		containers, findErr := r.findContainersByPattern(internalRealm.Spec.Namespace, pattern)
 		if findErr == nil {
 			networkName, _ := r.getSpaceNetworkName(internalSpace)
 			for _, containerID := range containers {
-				netnsPath, _ := r.getContainerNetnsPath(containerID)
+				netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, containerID)
 				_ = r.purgeCNIForContainer(containerID, netnsPath, networkName)
 			}
 		}

--- a/internal/controller/runner/delete_stack.go
+++ b/internal/controller/runner/delete_stack.go
@@ -64,9 +64,6 @@ func (r *Exec) DeleteStack(stack intmodel.Stack) error {
 	}
 	internalRealm, realmErr := r.GetRealm(lookupRealm)
 	if realmErr == nil {
-		// Set namespace for container operations
-		r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 		// Get space for network name
 		lookupSpace := intmodel.Space{
 			Metadata: intmodel.SpaceMetadata{
@@ -90,7 +87,7 @@ func (r *Exec) DeleteStack(stack intmodel.Stack) error {
 			containers, findErr := r.findContainersByPattern(internalRealm.Spec.Namespace, pattern)
 			if findErr == nil {
 				for _, containerID := range containers {
-					netnsPath, _ := r.getContainerNetnsPath(containerID)
+					netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, containerID)
 					_ = r.purgeCNIForContainer(containerID, netnsPath, networkName)
 				}
 			}

--- a/internal/controller/runner/exists.go
+++ b/internal/controller/runner/exists.go
@@ -61,11 +61,11 @@ func (r *Exec) ListContainerdNamespaces() ([]string, error) {
 
 // ExistsContainer checks if a container exists in containerd by its containerd ID.
 // It ensures the client is connected before making the call.
-func (r *Exec) ExistsContainer(containerdID string) (bool, error) {
+func (r *Exec) ExistsContainer(namespace, containerdID string) (bool, error) {
 	if err := r.ensureClientConnected(); err != nil {
 		return false, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
-	return r.ctrClient.ExistsContainer(containerdID)
+	return r.ctrClient.ExistsContainer(namespace, containerdID)
 }
 
 func (r *Exec) ExistsCellRootContainer(cell intmodel.Cell) (bool, error) {
@@ -118,9 +118,6 @@ func (r *Exec) ExistsCellRootContainer(cell intmodel.Cell) (bool, error) {
 		return false, fmt.Errorf("realm %q has no namespace", realmName)
 	}
 
-	// Set namespace to realm namespace
-	r.ctrClient.SetNamespace(namespace)
-
 	// Generate containerd ID with cell identifier for uniqueness
 	containerID, err := naming.BuildRootContainerdID(spaceName, stackName, cellID)
 	if err != nil {
@@ -128,7 +125,7 @@ func (r *Exec) ExistsCellRootContainer(cell intmodel.Cell) (bool, error) {
 	}
 
 	// Check if container exists
-	exists, err := r.ctrClient.ExistsContainer(containerID)
+	exists, err := r.ctrClient.ExistsContainer(namespace, containerID)
 	if err != nil {
 		// Other errors are actual failures
 		return false, fmt.Errorf("failed to check if root container exists: %w", err)

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -640,7 +640,7 @@ func (r *Exec) processOrphanedContainers(ctx context.Context, namespace string, 
 
 		// Get netns and purge CNI
 		r.logger.DebugContext(ctx, "getting container netns path", "id", containerID)
-		netnsPath, _ := r.getContainerNetnsPath(containerID)
+		netnsPath, _ := r.getContainerNetnsPath(namespace, containerID)
 		// Try to determine network name from container ID pattern
 		// Container ID format: realm-space-cell-container
 		parts := strings.Split(containerID, "-")

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -332,22 +332,9 @@ func (r *Exec) findOrphanedContainers(namespace, pattern string) ([]string, erro
 		return nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
-	// Set namespace
-	oldNamespace := r.ctrClient.Namespace()
-	r.logger.DebugContext(
-		r.ctx,
-		"setting namespace for container listing",
-		"namespace",
-		namespace,
-		"old_namespace",
-		oldNamespace,
-	)
-	r.ctrClient.SetNamespace(namespace)
-	defer r.ctrClient.SetNamespace(oldNamespace)
-
 	// List all containers
 	r.logger.DebugContext(r.ctx, "listing containers from containerd", "namespace", namespace, "pattern", pattern)
-	containers, err := r.ctrClient.ListContainers()
+	containers, err := r.ctrClient.ListContainers(namespace)
 	if err != nil {
 		r.logger.ErrorContext(r.ctx, "failed to list containers", "error", err)
 		return nil, fmt.Errorf("failed to list containers: %w", err)
@@ -392,12 +379,12 @@ func (r *Exec) findCNIConfigPath(networkName string) (string, error) {
 }
 
 // getContainerNetnsPath attempts to get the network namespace path for a container.
-func (r *Exec) getContainerNetnsPath(containerID string) (string, error) {
+func (r *Exec) getContainerNetnsPath(namespace, containerID string) (string, error) {
 	if err := r.ensureClientConnected(); err != nil {
 		return "", fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
-	container, err := r.ctrClient.GetContainer(containerID)
+	container, err := r.ctrClient.GetContainer(namespace, containerID)
 	if err != nil {
 		return "", err
 	}
@@ -471,7 +458,7 @@ func (r *Exec) detachRootContainerFromNetwork(
 	rootContainerID, cniConfigPath, namespace, cellID, cellName, spaceID, realmID string,
 ) {
 	var netnsPath string
-	rootContainer, err := r.ctrClient.GetContainer(rootContainerID)
+	rootContainer, err := r.ctrClient.GetContainer(namespace, rootContainerID)
 	if err == nil {
 		nsCtx := namespaces.WithNamespace(r.ctx, namespace)
 		rootTask, taskErr := rootContainer.Task(nsCtx, nil)
@@ -613,7 +600,7 @@ func (r *Exec) getRootContainerContainerdID(cell intmodel.Cell) (string, error) 
 // single stuck container does not strand the rest — but the log line is the
 // only signal the caller has to surface the residual containers in the
 // "namespace not empty" precondition error from DeleteNamespace.
-func (r *Exec) processOrphanedContainers(ctx context.Context, containers []string) {
+func (r *Exec) processOrphanedContainers(ctx context.Context, namespace string, containers []string) {
 	if len(containers) == 0 {
 		return
 	}
@@ -627,7 +614,7 @@ func (r *Exec) processOrphanedContainers(ctx context.Context, containers []strin
 		// blocking CleanupNamespaceResources and the subsequent
 		// DeleteNamespace with "namespace not empty".
 		r.logger.DebugContext(ctx, "stopping container", "id", containerID)
-		if _, stopErr := r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{Force: true}); stopErr != nil {
+		if _, stopErr := r.ctrClient.StopContainer(namespace, containerID, ctr.StopContainerOptions{Force: true}); stopErr != nil {
 			r.logger.WarnContext(
 				ctx,
 				"failed to stop orphaned container; continuing drain",
@@ -638,7 +625,7 @@ func (r *Exec) processOrphanedContainers(ctx context.Context, containers []strin
 			)
 		}
 		r.logger.DebugContext(ctx, "deleting container", "id", containerID)
-		if delErr := r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
+		if delErr := r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
 		}); delErr != nil {
 			r.logger.WarnContext(

--- a/internal/controller/runner/image.go
+++ b/internal/controller/runner/image.go
@@ -36,8 +36,7 @@ func (r *Exec) ListImages(namespace string) ([]ctr.ImageInfo, error) {
 	if err := r.ensureClientConnected(); err != nil {
 		return nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
-	r.ctrClient.SetNamespace(namespace)
-	return r.ctrClient.ListImages()
+	return r.ctrClient.ListImages(namespace)
 }
 
 // GetImage returns metadata for the named image ref in the given
@@ -55,8 +54,7 @@ func (r *Exec) GetImage(namespace, ref string) (ctr.ImageInfo, error) {
 	if err := r.ensureClientConnected(); err != nil {
 		return ctr.ImageInfo{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
-	r.ctrClient.SetNamespace(namespace)
-	return r.ctrClient.GetImage(ref)
+	return r.ctrClient.GetImage(namespace, ref)
 }
 
 // DeleteImage removes the named image ref from the given containerd
@@ -74,6 +72,5 @@ func (r *Exec) DeleteImage(namespace, ref string) error {
 	if err := r.ensureClientConnected(); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
-	r.ctrClient.SetNamespace(namespace)
-	return r.ctrClient.DeleteImage(ref)
+	return r.ctrClient.DeleteImage(namespace, ref)
 }

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -102,9 +102,6 @@ func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to get realm: %w", err)
 	}
 
-	// Set namespace to realm namespace
-	r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 	// Kill all workload containers first
 	for _, containerSpec := range internalCell.Spec.Containers {
 		// Skip root container - it's handled separately afterwards
@@ -129,7 +126,7 @@ func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		// Use container name with UUID for containerd operations
-		err = r.killContainerTask(containerID, internalRealm.Spec.Namespace)
+		err = r.killContainerTask(internalRealm.Spec.Namespace, containerID)
 		if err != nil {
 			// Log warning but continue with other containers
 			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
@@ -152,7 +149,7 @@ func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		)
 
 		// Delete container after killing
-		err = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
+		err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
 		})
 		if err != nil {
@@ -208,7 +205,7 @@ func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	)
 
 	// Kill root container
-	err = r.killContainerTask(rootContainerID, internalRealm.Spec.Namespace)
+	err = r.killContainerTask(internalRealm.Spec.Namespace, rootContainerID)
 	if err != nil {
 		fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
 		fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
@@ -229,7 +226,7 @@ func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	}
 
 	// Delete root container after killing
-	err = r.ctrClient.DeleteContainer(rootContainerID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {
@@ -349,9 +346,6 @@ func (r *Exec) KillContainer(cell intmodel.Cell, containerID string) error {
 		return fmt.Errorf("failed to get realm: %w", err)
 	}
 
-	// Set namespace to realm namespace
-	r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 	// Find container in cell spec by ID (base name)
 	var foundContainerSpec *intmodel.ContainerSpec
 	for i := range cell.Spec.Containers {
@@ -386,7 +380,7 @@ func (r *Exec) KillContainer(cell intmodel.Cell, containerID string) error {
 	}
 
 	// Use containerd ID for containerd operations
-	err = r.killContainerTask(containerdID, internalRealm.Spec.Namespace)
+	err = r.killContainerTask(internalRealm.Spec.Namespace, containerdID)
 	if err != nil {
 		fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
 		fields = append(
@@ -417,7 +411,7 @@ func (r *Exec) KillContainer(cell intmodel.Cell, containerID string) error {
 	)
 
 	// Delete container after killing
-	err = r.ctrClient.DeleteContainer(containerdID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, containerdID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {

--- a/internal/controller/runner/lifecycle.go
+++ b/internal/controller/runner/lifecycle.go
@@ -38,7 +38,7 @@ func (r *Exec) detachRootContainerFromCNI(
 	rootContainerID, cniConfigPath, cellID, cellName, spaceID, realmID, realmNamespace string,
 ) {
 	// Get root container to check if it exists and get its task
-	rootContainer, err := r.ctrClient.GetContainer(rootContainerID)
+	rootContainer, err := r.ctrClient.GetContainer(realmNamespace, rootContainerID)
 	if err == nil {
 		// Container exists, try to get its task to detach from CNI
 		nsCtx := namespaces.WithNamespace(ctrCtx, realmNamespace)
@@ -94,9 +94,9 @@ func (r *Exec) detachRootContainerFromCNI(
 
 // killContainerTask directly kills a container task by sending SIGKILL immediately.
 // This is a helper method used by KillCell and KillContainer.
-func (r *Exec) killContainerTask(containerID, realmNamespace string) error {
+func (r *Exec) killContainerTask(realmNamespace, containerID string) error {
 	// Get the container
-	container, err := r.ctrClient.GetContainer(containerID)
+	container, err := r.ctrClient.GetContainer(realmNamespace, containerID)
 	if err != nil {
 		return fmt.Errorf("failed to get container %s: %w", containerID, err)
 	}

--- a/internal/controller/runner/load_image.go
+++ b/internal/controller/runner/load_image.go
@@ -36,6 +36,5 @@ func (r *Exec) LoadImage(namespace string, reader io.Reader) ([]string, error) {
 	if err := r.ensureClientConnected(); err != nil {
 		return nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
-	r.ctrClient.SetNamespace(namespace)
-	return r.ctrClient.LoadImage(reader)
+	return r.ctrClient.LoadImage(namespace, reader)
 }

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1195,6 +1195,8 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, fmt.Errorf("realm %q has no namespace", realmName)
 	}
 
+	creds := ctr.ConvertRealmCredentials(internalRealm.Spec.RegistryCredentials)
+
 	// Prepare root container: ensure it's in Containers array and RootContainerID is set
 	rootContainerdID, err := naming.BuildRootContainerdID(spaceName, stackName, cellID)
 	if err != nil {
@@ -1286,7 +1288,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 			rootLabels := buildRootContainerLabels(*cell)
 			ctrContainerSpec := ctr.BuildRootContainerSpec(containerSpec, rootLabels)
 
-			createdContainer, createErr = r.ctrClient.CreateContainer(namespace, ctrContainerSpec)
+			createdContainer, createErr = r.ctrClient.CreateContainer(namespace, ctrContainerSpec, creds)
 			if createErr != nil {
 				logFields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
 				logFields = append(
@@ -1337,13 +1339,14 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				cell.Spec.Containers[i] = containerSpec
 			}
 
-			attachOpts, attachErr := r.attachableBuildOpts(containerSpec)
+			attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec)
 			if attachErr != nil {
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
 			_, createErr = r.ctrClient.CreateContainerFromSpec(
 				namespace,
 				containerSpec,
+				creds,
 				attachOpts...,
 			)
 			if createErr != nil {
@@ -1451,6 +1454,8 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, fmt.Errorf("failed to get realm: %w", err)
 	}
 
+	creds := ctr.ConvertRealmCredentials(internalRealm.Spec.RegistryCredentials)
+
 	// Generate containerd ID with cell identifier for uniqueness
 	containerID, err := naming.BuildRootContainerdID(spaceName, stackName, cellID)
 	if err != nil {
@@ -1539,7 +1544,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		containerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
 
 		var createErr error
-		container, createErr = r.ctrClient.CreateContainer(internalRealm.Spec.Namespace, containerSpec)
+		container, createErr = r.ctrClient.CreateContainer(internalRealm.Spec.Namespace, containerSpec, creds)
 		if createErr != nil {
 			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 			fields = append(
@@ -1752,13 +1757,14 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				createSpecFields...,
 			)
 
-			attachOpts, attachErr := r.attachableBuildOpts(containerSpec)
+			attachOpts, attachErr := r.attachableBuildOpts(internalRealm.Spec.Namespace, containerSpec)
 			if attachErr != nil {
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
 			createdContainer, containerCreateErr := r.ctrClient.CreateContainerFromSpec(
 				internalRealm.Spec.Namespace,
 				containerSpec,
+				creds,
 				attachOpts...,
 			)
 			if containerCreateErr != nil {

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1339,7 +1339,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				cell.Spec.Containers[i] = containerSpec
 			}
 
-			attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec)
+			attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds)
 			if attachErr != nil {
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
@@ -1757,7 +1757,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				createSpecFields...,
 			)
 
-			attachOpts, attachErr := r.attachableBuildOpts(internalRealm.Spec.Namespace, containerSpec)
+			attachOpts, attachErr := r.attachableBuildOpts(internalRealm.Spec.Namespace, containerSpec, creds)
 			if attachErr != nil {
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1195,14 +1195,6 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, fmt.Errorf("realm %q has no namespace", realmName)
 	}
 
-	// Set namespace to realm namespace with credentials if available
-	if len(internalRealm.Spec.RegistryCredentials) > 0 {
-		creds := ctr.ConvertRealmCredentials(internalRealm.Spec.RegistryCredentials)
-		r.ctrClient.SetNamespaceWithCredentials(namespace, creds)
-	} else {
-		r.ctrClient.SetNamespace(namespace)
-	}
-
 	// Prepare root container: ensure it's in Containers array and RootContainerID is set
 	rootContainerdID, err := naming.BuildRootContainerdID(spaceName, stackName, cellID)
 	if err != nil {
@@ -1294,7 +1286,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 			rootLabels := buildRootContainerLabels(*cell)
 			ctrContainerSpec := ctr.BuildRootContainerSpec(containerSpec, rootLabels)
 
-			createdContainer, createErr = r.ctrClient.CreateContainer(ctrContainerSpec)
+			createdContainer, createErr = r.ctrClient.CreateContainer(namespace, ctrContainerSpec)
 			if createErr != nil {
 				logFields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
 				logFields = append(
@@ -1350,6 +1342,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
 			_, createErr = r.ctrClient.CreateContainerFromSpec(
+				namespace,
 				containerSpec,
 				attachOpts...,
 			)
@@ -1373,7 +1366,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				)
 				return nil, fmt.Errorf("failed to create container %s: %w", containerdID, createErr)
 			}
-			if chownErr := r.attachablePostCreateChown(containerSpec); chownErr != nil {
+			if chownErr := r.attachablePostCreateChown(namespace, containerSpec); chownErr != nil {
 				return nil, fmt.Errorf(
 					"failed to chown attachable tty dir for %s: %w", containerdID, chownErr,
 				)
@@ -1458,14 +1451,6 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, fmt.Errorf("failed to get realm: %w", err)
 	}
 
-	// Set namespace to realm namespace with credentials if available
-	if len(internalRealm.Spec.RegistryCredentials) > 0 {
-		creds := ctr.ConvertRealmCredentials(internalRealm.Spec.RegistryCredentials)
-		r.ctrClient.SetNamespaceWithCredentials(internalRealm.Spec.Namespace, creds)
-	} else {
-		r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-	}
-
 	// Generate containerd ID with cell identifier for uniqueness
 	containerID, err := naming.BuildRootContainerdID(spaceName, stackName, cellID)
 	if err != nil {
@@ -1476,7 +1461,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 	var container containerd.Container
 
 	// Check if container exists
-	exists, err := r.ExistsContainer(containerID)
+	exists, err := r.ExistsContainer(internalRealm.Spec.Namespace, containerID)
 	if err != nil {
 		fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 		fields = append(fields, "space", spaceName, "realm", realmName, "err", fmt.Sprintf("%v", err))
@@ -1491,7 +1476,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 	if exists {
 		// Container exists, load it but continue to process other containers
 		var loadErr error
-		container, loadErr = r.ctrClient.GetContainer(containerID)
+		container, loadErr = r.ctrClient.GetContainer(internalRealm.Spec.Namespace, containerID)
 		if loadErr != nil {
 			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 			fields = append(fields, "space", spaceName, "realm", realmName, "err", fmt.Sprintf("%v", loadErr))
@@ -1554,7 +1539,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		containerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
 
 		var createErr error
-		container, createErr = r.ctrClient.CreateContainer(containerSpec)
+		container, createErr = r.ctrClient.CreateContainer(internalRealm.Spec.Namespace, containerSpec)
 		if createErr != nil {
 			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 			fields = append(
@@ -1688,7 +1673,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		)
 
 		// Use containerd ID for containerd operations
-		exists, err = r.ExistsContainer(containerdID)
+		exists, err = r.ExistsContainer(internalRealm.Spec.Namespace, containerdID)
 		if err != nil {
 			// Some other error occurred (connection failure, permission error, etc.)
 			fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
@@ -1772,6 +1757,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
 			createdContainer, containerCreateErr := r.ctrClient.CreateContainerFromSpec(
+				internalRealm.Spec.Namespace,
 				containerSpec,
 				attachOpts...,
 			)
@@ -1825,7 +1811,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 					"created container from cell",
 					successFields...,
 				)
-				if chownErr := r.attachablePostCreateChown(containerSpec); chownErr != nil {
+				if chownErr := r.attachablePostCreateChown(internalRealm.Spec.Namespace, containerSpec); chownErr != nil {
 					return nil, fmt.Errorf(
 						"failed to chown attachable tty dir for %s: %w", containerdID, chownErr,
 					)

--- a/internal/controller/runner/purge_cell.go
+++ b/internal/controller/runner/purge_cell.go
@@ -83,10 +83,6 @@ func (r *Exec) PurgeCell(cell intmodel.Cell) error {
 		return nil // Continue anyway
 	}
 
-	// Set namespace
-	r.logger.DebugContext(r.ctx, "setting namespace for cell purge", "namespace", internalRealm.Spec.Namespace)
-	r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 	// Get space for network name
 	lookupSpace := intmodel.Space{
 		Metadata: intmodel.SpaceMetadata{
@@ -163,7 +159,7 @@ func (r *Exec) PurgeCell(cell intmodel.Cell) error {
 					r.logger.DebugContext(r.ctx, "processing container for CNI purge", "index", i+1, "total", len(containerIDs), "id", containerID)
 					// Try to get netns path
 					r.logger.DebugContext(r.ctx, "getting container netns path", "id", containerID)
-					netnsPath, _ := r.getContainerNetnsPath(containerID)
+					netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, containerID)
 					// Purge CNI resources
 					r.logger.DebugContext(r.ctx, "purging CNI resources for container", "id", containerID, "network", networkName)
 					_ = r.purgeCNIForContainer(containerID, netnsPath, networkName)

--- a/internal/controller/runner/purge_container.go
+++ b/internal/controller/runner/purge_container.go
@@ -52,16 +52,14 @@ func (r *Exec) PurgeContainer(realm intmodel.Realm, containerID string) error {
 		return fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
-	r.ctrClient.SetNamespace(namespace)
-
 	// Try to stop and delete container
-	_, _ = r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{})
-	_ = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
+	_, _ = r.ctrClient.StopContainer(namespace, containerID, ctr.StopContainerOptions{})
+	_ = r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 
 	// Get netns path if container is running
-	netnsPath, _ := r.getContainerNetnsPath(containerID)
+	netnsPath, _ := r.getContainerNetnsPath(namespace, containerID)
 
 	// Try to determine network name from container ID
 	parts := strings.Split(containerID, "-")

--- a/internal/controller/runner/purge_realm.go
+++ b/internal/controller/runner/purge_realm.go
@@ -70,7 +70,7 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) (bool, error) {
 		r.logger.WarnContext(r.ctx, "failed to find orphaned containers", "error", err)
 	} else {
 		r.logger.DebugContext(r.ctx, "found orphaned containers", "count", len(containers))
-		r.processOrphanedContainers(r.ctx, containers)
+		r.processOrphanedContainers(r.ctx, realmForOps.Spec.Namespace, containers)
 	}
 
 	// Tear down each conflist + bridge link for this realm. Driven from

--- a/internal/controller/runner/purge_space.go
+++ b/internal/controller/runner/purge_space.go
@@ -85,14 +85,12 @@ func (r *Exec) PurgeSpace(space intmodel.Space) error {
 
 	// Find all containers in space
 	if err = r.ensureClientConnected(); err == nil {
-		r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 		pattern := fmt.Sprintf("%s-%s", spaceForOps.Spec.RealmName, spaceForOps.Metadata.Name)
 		var containers []string
 		containers, err = r.findContainersByPattern(internalRealm.Spec.Namespace, pattern)
 		if err == nil {
 			for _, containerID := range containers {
-				netnsPath, _ := r.getContainerNetnsPath(containerID)
+				netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, containerID)
 				_ = r.purgeCNIForContainer(containerID, netnsPath, networkName)
 			}
 		}

--- a/internal/controller/runner/purge_stack.go
+++ b/internal/controller/runner/purge_stack.go
@@ -87,8 +87,6 @@ func (r *Exec) PurgeStack(stack intmodel.Stack) error {
 
 	// Find all containers in stack
 	if err = r.ensureClientConnected(); err == nil {
-		r.ctrClient.SetNamespace(realmNamespace)
-
 		pattern := fmt.Sprintf(
 			"%s-%s-%s",
 			stackForOps.Spec.RealmName,
@@ -99,7 +97,7 @@ func (r *Exec) PurgeStack(stack intmodel.Stack) error {
 		containers, err = r.findContainersByPattern(realmNamespace, pattern)
 		if err == nil {
 			for _, containerID := range containers {
-				netnsPath, _ := r.getContainerNetnsPath(containerID)
+				netnsPath, _ := r.getContainerNetnsPath(realmNamespace, containerID)
 				_ = r.purgeCNIForContainer(containerID, netnsPath, networkName)
 			}
 		}

--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -72,8 +72,6 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to get realm: %w", err)
 	}
 
-	r.ctrClient.SetNamespace(internalRealm.Spec.Namespace)
-
 	// Delete all containers in the cell
 	for _, containerSpec := range existing.Spec.Containers {
 		containerID := containerSpec.ContainerdID
@@ -82,7 +80,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		// Stop container
-		_, err = r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{})
+		_, err = r.ctrClient.StopContainer(internalRealm.Spec.Namespace, containerID, ctr.StopContainerOptions{})
 		if err != nil {
 			r.logger.WarnContext(
 				r.ctx,
@@ -93,7 +91,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		// Delete container
-		err = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
+		err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
 		})
 		if err != nil {
@@ -112,7 +110,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to build root container containerd ID: %w", err)
 	}
 
-	_, err = r.ctrClient.StopContainer(rootContainerID, ctr.StopContainerOptions{Force: true})
+	_, err = r.ctrClient.StopContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.StopContainerOptions{Force: true})
 	if err != nil {
 		r.logger.WarnContext(
 			r.ctx,
@@ -122,7 +120,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		)
 	}
 
-	err = r.ctrClient.DeleteContainer(rootContainerID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -254,11 +254,6 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 		namespace = internalRealm.Metadata.Name
 	}
 
-	// Set namespace for containerd operations
-	if r.ctrClient != nil {
-		r.ctrClient.SetNamespace(namespace)
-	}
-
 	// Get containerd ID
 	containerdID := containerSpec.ContainerdID
 	if containerdID == "" {
@@ -285,7 +280,7 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 	// Check if container exists in containerd
 	containerExists := false
 	if r.ctrClient != nil {
-		containerExists, err = r.ExistsContainer(containerdID)
+		containerExists, err = r.ExistsContainer(namespace, containerdID)
 		if err != nil {
 			r.logger.DebugContext(r.ctx, "failed to check container existence",
 				"container", containerSpec.ID,
@@ -299,7 +294,7 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 	var taskStatus containerd.Status
 	taskExists := false
 	if containerExists && r.ctrClient != nil {
-		taskStatus, err = r.ctrClient.TaskStatus(containerdID)
+		taskStatus, err = r.ctrClient.TaskStatus(namespace, containerdID)
 		if err != nil {
 			// Task might not exist even if container does
 			r.logger.DebugContext(r.ctx, "failed to get task status",

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -204,14 +204,6 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("realm %q has no namespace", realmID)
 	}
 
-	// Set namespace to realm namespace with credentials if available
-	if internalRealm.Spec.RegistryCredentials != nil {
-		creds := ctr.ConvertRealmCredentials(internalRealm.Spec.RegistryCredentials)
-		r.ctrClient.SetNamespaceWithCredentials(namespace, creds)
-	} else {
-		r.ctrClient.SetNamespace(namespace)
-	}
-
 	// Generate containerd ID with cell identifier for uniqueness
 	containerID, err := naming.BuildRootContainerdID(spaceID, stackID, cellID)
 	if err != nil {
@@ -224,7 +216,9 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	// re-run CNI ADD against the same container ID — which host-local IPAM
 	// refuses as a duplicate allocation (we never run CNI DEL when we
 	// delete the old container, so the reservation persists).
-	if cellTasksAllRunningFn(internalCell, containerID, r.ctrClient.TaskStatus) {
+	if cellTasksAllRunningFn(internalCell, containerID, func(id string) (containerd.Status, error) {
+		return r.ctrClient.TaskStatus(namespace, id)
+	}) {
 		markCellReady(&internalCell)
 		if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
 			r.logger.WarnContext(r.ctx, "failed to populate container statuses after idempotent StartCell skip",
@@ -243,7 +237,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	}
 
 	// Check if container exists and clean it up
-	container, err := r.ctrClient.GetContainer(containerID)
+	container, err := r.ctrClient.GetContainer(namespace, containerID)
 	if err != nil {
 		// Container doesn't exist, will create fresh
 		if errors.Is(err, internalerrdefs.ErrContainerNotFound) {
@@ -283,7 +277,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		// Delete the container to remove stale spec
-		err = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
+		err = r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
 		})
 		if err != nil {
@@ -325,7 +319,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	rootLabels := buildRootContainerLabels(internalCell)
 	ctrContainerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
 
-	_, err = r.ctrClient.CreateContainer(ctrContainerSpec)
+	_, err = r.ctrClient.CreateContainer(namespace, ctrContainerSpec)
 	if err != nil {
 		fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 		fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
@@ -346,7 +340,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	)
 
 	// Start root container
-	rootTask, err := r.ctrClient.StartContainer(ctr.ContainerSpec{ID: containerID}, ctr.TaskSpec{})
+	rootTask, err := r.ctrClient.StartContainer(namespace, ctr.ContainerSpec{ID: containerID}, ctr.TaskSpec{})
 	if err != nil {
 		fields = appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 		fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
@@ -552,7 +546,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 
 		// Delete container if it exists (idempotent - DeleteContainer handles non-existent containers gracefully)
 		// This ensures any stale container specs and tasks are cleaned up before recreation
-		err = r.ctrClient.DeleteContainer(ctrContainerID, ctr.ContainerDeleteOptions{
+		err = r.ctrClient.DeleteContainer(namespace, ctrContainerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
 		})
 		if err != nil {
@@ -581,7 +575,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		if attachErr != nil {
 			return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", ctrContainerID, attachErr)
 		}
-		_, err = r.ctrClient.CreateContainerFromSpec(containerSpec, attachOpts...)
+		_, err = r.ctrClient.CreateContainerFromSpec(namespace, containerSpec, attachOpts...)
 		if err != nil {
 			fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
 			fields = append(
@@ -611,7 +605,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 			fields...,
 		)
 
-		if err = r.attachablePostCreateChown(containerSpec); err != nil {
+		if err = r.attachablePostCreateChown(namespace, containerSpec); err != nil {
 			return intmodel.Cell{}, fmt.Errorf(
 				"failed to chown attachable tty dir for %s: %w", ctrContainerID, err,
 			)
@@ -623,7 +617,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 			namespacePaths,
 		)
 
-		_, err = r.ctrClient.StartContainer(specWithNamespaces, r.containerLogTaskSpec(containerSpec))
+		_, err = r.ctrClient.StartContainer(namespace, specWithNamespaces, r.containerLogTaskSpec(containerSpec))
 		if err != nil {
 			fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
 			fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
@@ -704,14 +698,6 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 		return intmodel.Cell{}, fmt.Errorf("realm %q has no namespace", realmName)
 	}
 
-	// Set namespace to realm namespace with credentials if available
-	if len(internalRealm.Spec.RegistryCredentials) > 0 {
-		creds := ctr.ConvertRealmCredentials(internalRealm.Spec.RegistryCredentials)
-		r.ctrClient.SetNamespaceWithCredentials(namespace, creds)
-	} else {
-		r.ctrClient.SetNamespace(namespace)
-	}
-
 	// Find container in cell spec by ID (base name)
 	var foundContainerSpec *intmodel.ContainerSpec
 	for i := range cell.Spec.Containers {
@@ -746,7 +732,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 	}
 
 	// Get root container's namespace paths
-	rootContainer, err := r.ctrClient.GetContainer(rootContainerID)
+	rootContainer, err := r.ctrClient.GetContainer(namespace, rootContainerID)
 	if err != nil {
 		if errors.Is(err, internalerrdefs.ErrContainerNotFound) {
 			return intmodel.Cell{}, fmt.Errorf(
@@ -787,7 +773,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 
 	// Delete container if it exists (idempotent - DeleteContainer handles non-existent containers gracefully)
 	// This ensures any stale container specs and tasks are cleaned up before recreation
-	err = r.ctrClient.DeleteContainer(containerdID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(namespace, containerdID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {
@@ -816,7 +802,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 	if attachErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", containerID, attachErr)
 	}
-	_, err = r.ctrClient.CreateContainerFromSpec(*foundContainerSpec, attachOpts...)
+	_, err = r.ctrClient.CreateContainerFromSpec(namespace, *foundContainerSpec, attachOpts...)
 	if err != nil {
 		fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
 		fields = append(
@@ -846,7 +832,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 		fields...,
 	)
 
-	if err = r.attachablePostCreateChown(*foundContainerSpec); err != nil {
+	if err = r.attachablePostCreateChown(namespace, *foundContainerSpec); err != nil {
 		return intmodel.Cell{}, fmt.Errorf(
 			"failed to chown attachable tty dir for %s: %w", containerdID, err,
 		)
@@ -858,7 +844,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 		namespacePaths,
 	)
 
-	_, err = r.ctrClient.StartContainer(specWithNamespaces, r.containerLogTaskSpec(*foundContainerSpec))
+	_, err = r.ctrClient.StartContainer(namespace, specWithNamespaces, r.containerLogTaskSpec(*foundContainerSpec))
 	if err != nil {
 		fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
 		fields = append(

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -204,6 +204,8 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("realm %q has no namespace", realmID)
 	}
 
+	creds := ctr.ConvertRealmCredentials(internalRealm.Spec.RegistryCredentials)
+
 	// Generate containerd ID with cell identifier for uniqueness
 	containerID, err := naming.BuildRootContainerdID(spaceID, stackID, cellID)
 	if err != nil {
@@ -319,7 +321,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	rootLabels := buildRootContainerLabels(internalCell)
 	ctrContainerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
 
-	_, err = r.ctrClient.CreateContainer(namespace, ctrContainerSpec)
+	_, err = r.ctrClient.CreateContainer(namespace, ctrContainerSpec, creds)
 	if err != nil {
 		fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 		fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
@@ -571,11 +573,11 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		// Recreate container fresh
-		attachOpts, attachErr := r.attachableBuildOpts(containerSpec)
+		attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec)
 		if attachErr != nil {
 			return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", ctrContainerID, attachErr)
 		}
-		_, err = r.ctrClient.CreateContainerFromSpec(namespace, containerSpec, attachOpts...)
+		_, err = r.ctrClient.CreateContainerFromSpec(namespace, containerSpec, creds, attachOpts...)
 		if err != nil {
 			fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
 			fields = append(
@@ -698,6 +700,8 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 		return intmodel.Cell{}, fmt.Errorf("realm %q has no namespace", realmName)
 	}
 
+	creds := ctr.ConvertRealmCredentials(internalRealm.Spec.RegistryCredentials)
+
 	// Find container in cell spec by ID (base name)
 	var foundContainerSpec *intmodel.ContainerSpec
 	for i := range cell.Spec.Containers {
@@ -798,11 +802,11 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 	}
 
 	// Recreate container fresh
-	attachOpts, attachErr := r.attachableBuildOpts(*foundContainerSpec)
+	attachOpts, attachErr := r.attachableBuildOpts(namespace, *foundContainerSpec)
 	if attachErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", containerID, attachErr)
 	}
-	_, err = r.ctrClient.CreateContainerFromSpec(namespace, *foundContainerSpec, attachOpts...)
+	_, err = r.ctrClient.CreateContainerFromSpec(namespace, *foundContainerSpec, creds, attachOpts...)
 	if err != nil {
 		fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
 		fields = append(

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -573,7 +573,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		// Recreate container fresh
-		attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec)
+		attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds)
 		if attachErr != nil {
 			return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", ctrContainerID, attachErr)
 		}
@@ -802,7 +802,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 	}
 
 	// Recreate container fresh
-	attachOpts, attachErr := r.attachableBuildOpts(namespace, *foundContainerSpec)
+	attachOpts, attachErr := r.attachableBuildOpts(namespace, *foundContainerSpec, creds)
 	if attachErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", containerID, attachErr)
 	}

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -108,9 +108,6 @@ func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("realm %q has no namespace", realmName)
 	}
 
-	// Set namespace to realm namespace
-	r.ctrClient.SetNamespace(namespace)
-
 	// Stop all workload containers first
 	for _, containerSpec := range internalCell.Spec.Containers {
 		// Skip root container - it's handled separately afterwards
@@ -145,7 +142,7 @@ func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 
 		// Use container name with UUID for containerd operations
 		timeout := 5 * time.Second
-		_, err = r.ctrClient.StopContainer(containerID, ctr.StopContainerOptions{
+		_, err = r.ctrClient.StopContainer(namespace, containerID, ctr.StopContainerOptions{
 			Force:   true,
 			Timeout: &timeout,
 		})
@@ -171,7 +168,7 @@ func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		)
 
 		// Delete container after stopping
-		err = r.ctrClient.DeleteContainer(containerID, ctr.ContainerDeleteOptions{
+		err = r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
 			SnapshotCleanup: true,
 		})
 		if err != nil {
@@ -228,7 +225,7 @@ func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 
 	// Stop root container
 	timeout := 5 * time.Second
-	_, err = r.ctrClient.StopContainer(rootContainerID, ctr.StopContainerOptions{
+	_, err = r.ctrClient.StopContainer(namespace, rootContainerID, ctr.StopContainerOptions{
 		Force:   true,
 		Timeout: &timeout,
 	})
@@ -252,7 +249,7 @@ func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	}
 
 	// Delete root container after stopping
-	err = r.ctrClient.DeleteContainer(rootContainerID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(namespace, rootContainerID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {
@@ -377,9 +374,6 @@ func (r *Exec) StopContainer(cell intmodel.Cell, containerID string) error {
 		return fmt.Errorf("realm %q has no namespace", realmName)
 	}
 
-	// Set namespace to realm namespace
-	r.ctrClient.SetNamespace(namespace)
-
 	// Find container in cell spec by ID (base name)
 	var foundContainerSpec *intmodel.ContainerSpec
 	for i := range cell.Spec.Containers {
@@ -415,7 +409,7 @@ func (r *Exec) StopContainer(cell intmodel.Cell, containerID string) error {
 
 	// Use containerd ID for containerd operations
 	timeout := 5 * time.Second
-	_, err = r.ctrClient.StopContainer(containerdID, ctr.StopContainerOptions{
+	_, err = r.ctrClient.StopContainer(namespace, containerdID, ctr.StopContainerOptions{
 		Force:   true,
 		Timeout: &timeout,
 	})
@@ -449,7 +443,7 @@ func (r *Exec) StopContainer(cell intmodel.Cell, containerID string) error {
 	)
 
 	// Delete container after stopping
-	err = r.ctrClient.DeleteContainer(containerdID, ctr.ContainerDeleteOptions{
+	err = r.ctrClient.DeleteContainer(namespace, containerdID, ctr.ContainerDeleteOptions{
 		SnapshotCleanup: true,
 	})
 	if err != nil {

--- a/internal/ctr/cache.go
+++ b/internal/ctr/cache.go
@@ -24,26 +24,32 @@ import (
 	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
 )
 
+// cacheKey returns a unique key for a (namespace, id) pair.
+func cacheKey(namespace, id string) string {
+	return namespace + "/" + id
+}
+
 // storeContainer stores a container in the cache.
-func (c *client) storeContainer(id string, container containerd.Container) {
+func (c *client) storeContainer(namespace, id string, container containerd.Container) {
 	c.containersMu.Lock()
 	defer c.containersMu.Unlock()
 	if c.containers == nil {
 		c.containers = make(map[string]containerd.Container)
 	}
-	c.containers[id] = container
+	c.containers[cacheKey(namespace, id)] = container
 }
 
 // loadContainer loads a container from cache or containerd.
-func (c *client) loadContainer(id string) (containerd.Container, error) {
+func (c *client) loadContainer(namespace, id string) (containerd.Container, error) {
+	key := cacheKey(namespace, id)
 	c.containersMu.RLock()
-	if container, ok := c.containers[id]; ok {
+	if container, ok := c.containers[key]; ok {
 		c.containersMu.RUnlock()
 		return container, nil
 	}
 	c.containersMu.RUnlock()
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 	container, err := c.cClient.LoadContainer(nsCtx, id)
 	if err != nil {
 		// Only wrap "not found" errors with ErrContainerNotFound
@@ -53,57 +59,58 @@ func (c *client) loadContainer(id string) (containerd.Container, error) {
 		}
 		return nil, err
 	}
-	c.storeContainer(id, container)
+	c.storeContainer(namespace, id, container)
 	return container, nil
 }
 
 // dropContainer removes a container from the cache.
-func (c *client) dropContainer(id string) {
+func (c *client) dropContainer(namespace, id string) {
 	c.containersMu.Lock()
 	defer c.containersMu.Unlock()
 	if c.containers != nil {
-		delete(c.containers, id)
+		delete(c.containers, cacheKey(namespace, id))
 	}
 }
 
 // storeTask stores a task in the cache.
-func (c *client) storeTask(id string, task containerd.Task) {
+func (c *client) storeTask(namespace, id string, task containerd.Task) {
 	c.tasksMu.Lock()
 	defer c.tasksMu.Unlock()
 	if c.tasks == nil {
 		c.tasks = make(map[string]containerd.Task)
 	}
-	c.tasks[id] = task
+	c.tasks[cacheKey(namespace, id)] = task
 }
 
 // loadTask loads a task from cache or container.
-func (c *client) loadTask(id string) (containerd.Task, error) {
+func (c *client) loadTask(namespace, id string) (containerd.Task, error) {
+	key := cacheKey(namespace, id)
 	c.tasksMu.RLock()
-	if task, ok := c.tasks[id]; ok {
+	if task, ok := c.tasks[key]; ok {
 		c.tasksMu.RUnlock()
 		return task, nil
 	}
 	c.tasksMu.RUnlock()
 
-	container, err := c.loadContainer(id)
+	container, err := c.loadContainer(namespace, id)
 	if err != nil {
 		return nil, err
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 	task, err := container.Task(nsCtx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", internalerrdefs.ErrTaskNotFound, err)
 	}
-	c.storeTask(id, task)
+	c.storeTask(namespace, id, task)
 	return task, nil
 }
 
 // dropTask removes a task from the cache.
-func (c *client) dropTask(id string) {
+func (c *client) dropTask(namespace, id string) {
 	c.tasksMu.Lock()
 	defer c.tasksMu.Unlock()
 	if c.tasks != nil {
-		delete(c.tasks, id)
+		delete(c.tasks, cacheKey(namespace, id))
 	}
 }

--- a/internal/ctr/cache_test.go
+++ b/internal/ctr/cache_test.go
@@ -40,13 +40,13 @@ func TestStoreContainer(t *testing.T) {
 	// Test that storeContainer initializes the map
 	client.containers = nil
 	// Store nil to test map initialization (nil is valid for interface types)
-	client.storeContainer("test-id", nil)
+	client.storeContainer("test-ns", "test-id", nil)
 	if client.containers == nil {
 		t.Fatal("containers map should be initialized even with nil value")
 	}
 
 	// Verify the value was stored
-	if _, ok := client.containers["test-id"]; !ok {
+	if _, ok := client.containers[cacheKey("test-ns", "test-id")]; !ok {
 		t.Error("container should be stored in cache")
 	}
 }
@@ -56,13 +56,13 @@ func TestStoreContainerInitializesMap(t *testing.T) {
 	client.containers = nil // Simulate uninitialized map
 
 	// Store nil to test map initialization (nil is valid for interface types)
-	client.storeContainer("test-id", nil)
+	client.storeContainer("test-ns", "test-id", nil)
 
 	if client.containers == nil {
 		t.Fatal("containers map should be initialized")
 	}
 
-	if _, ok := client.containers["test-id"]; !ok {
+	if _, ok := client.containers[cacheKey("test-ns", "test-id")]; !ok {
 		t.Error("container should be stored in cache")
 	}
 }
@@ -77,11 +77,11 @@ func TestLoadContainerFromCache(t *testing.T) {
 
 func TestDropContainer(t *testing.T) {
 	client := setupTestClient(t)
-	client.storeContainer("test-id", nil)
+	client.storeContainer("test-ns", "test-id", nil)
 
-	client.dropContainer("test-id")
+	client.dropContainer("test-ns", "test-id")
 
-	if _, ok := client.containers["test-id"]; ok {
+	if _, ok := client.containers[cacheKey("test-ns", "test-id")]; ok {
 		t.Error("container should be removed from cache")
 	}
 }
@@ -90,7 +90,7 @@ func TestDropContainerNilMap(t *testing.T) {
 	client := setupTestClient(t)
 	client.containers = nil // Should not panic
 
-	client.dropContainer("test-id") // Should handle nil map gracefully
+	client.dropContainer("test-ns", "test-id") // Should handle nil map gracefully
 }
 
 func TestStoreTask(t *testing.T) {
@@ -98,13 +98,13 @@ func TestStoreTask(t *testing.T) {
 	// Test that storeTask initializes the map
 	client.tasks = nil
 	// Store nil to test map initialization (nil is valid for interface types)
-	client.storeTask("test-id", nil)
+	client.storeTask("test-ns", "test-id", nil)
 	if client.tasks == nil {
 		t.Fatal("tasks map should be initialized even with nil value")
 	}
 
 	// Verify the value was stored
-	if _, ok := client.tasks["test-id"]; !ok {
+	if _, ok := client.tasks[cacheKey("test-ns", "test-id")]; !ok {
 		t.Error("task should be stored in cache")
 	}
 }
@@ -114,13 +114,13 @@ func TestStoreTaskInitializesMap(t *testing.T) {
 	client.tasks = nil // Simulate uninitialized map
 
 	// Store nil to test map initialization (nil is valid for interface types)
-	client.storeTask("test-id", nil)
+	client.storeTask("test-ns", "test-id", nil)
 
 	if client.tasks == nil {
 		t.Fatal("tasks map should be initialized")
 	}
 
-	if _, ok := client.tasks["test-id"]; !ok {
+	if _, ok := client.tasks[cacheKey("test-ns", "test-id")]; !ok {
 		t.Error("task should be stored in cache")
 	}
 }
@@ -135,11 +135,11 @@ func TestLoadTaskFromCache(t *testing.T) {
 
 func TestDropTask(t *testing.T) {
 	client := setupTestClient(t)
-	client.storeTask("test-id", nil)
+	client.storeTask("test-ns", "test-id", nil)
 
-	client.dropTask("test-id")
+	client.dropTask("test-ns", "test-id")
 
-	if _, ok := client.tasks["test-id"]; ok {
+	if _, ok := client.tasks[cacheKey("test-ns", "test-id")]; ok {
 		t.Error("task should be removed from cache")
 	}
 }
@@ -148,7 +148,7 @@ func TestDropTaskNilMap(t *testing.T) {
 	client := setupTestClient(t)
 	client.tasks = nil // Should not panic
 
-	client.dropTask("test-id") // Should handle nil map gracefully
+	client.dropTask("test-ns", "test-id") // Should handle nil map gracefully
 }
 
 // Test concurrent access to container cache.
@@ -158,11 +158,11 @@ func TestContainerCacheConcurrency(t *testing.T) {
 	// Test concurrent writes
 	done := make(chan bool)
 	go func() {
-		client.storeContainer("test-1", nil)
+		client.storeContainer("test-ns", "test-1", nil)
 		done <- true
 	}()
 	go func() {
-		client.storeContainer("test-2", nil)
+		client.storeContainer("test-ns", "test-2", nil)
 		done <- true
 	}()
 	<-done
@@ -170,7 +170,7 @@ func TestContainerCacheConcurrency(t *testing.T) {
 
 	// Test concurrent writes only (read requires containerd client)
 	go func() {
-		client.storeContainer("test-3", nil)
+		client.storeContainer("test-ns", "test-3", nil)
 		done <- true
 	}()
 	<-done
@@ -188,11 +188,11 @@ func TestTaskCacheConcurrency(t *testing.T) {
 	// Test concurrent writes
 	done := make(chan bool)
 	go func() {
-		client.storeTask("test-1", nil)
+		client.storeTask("test-ns", "test-1", nil)
 		done <- true
 	}()
 	go func() {
-		client.storeTask("test-2", nil)
+		client.storeTask("test-ns", "test-2", nil)
 		done <- true
 	}()
 	<-done
@@ -200,7 +200,7 @@ func TestTaskCacheConcurrency(t *testing.T) {
 
 	// Test concurrent writes only (read requires containerd client)
 	go func() {
-		client.storeTask("test-3", nil)
+		client.storeTask("test-ns", "test-3", nil)
 		done <- true
 	}()
 	<-done

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -27,43 +27,34 @@ import (
 	cgroup2 "github.com/containerd/cgroups/v2/cgroup2"
 	apitypes "github.com/containerd/containerd/api/types"
 	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
 type client struct {
-	ctx                   context.Context
-	logger                *slog.Logger
-	socket                string
-	cClient               *containerd.Client
-	namespace             string
-	namespaceMu           sync.RWMutex
-	registryCredentials   []RegistryCredentials
-	registryCredentialsMu sync.RWMutex
-	cgroups               map[string]*cgroup2.Manager
-	containersMu          sync.RWMutex
-	containers            map[string]containerd.Container
-	tasksMu               sync.RWMutex
-	tasks                 map[string]containerd.Task
-	cgroupMountpointOnce  sync.Once
-	cgroupMountpoint      string
-	cgroupMountpointErr   error
+	ctx                  context.Context
+	logger               *slog.Logger
+	socket               string
+	cClient              *containerd.Client
+	cgroups              map[string]*cgroup2.Manager
+	containersMu         sync.RWMutex
+	containers           map[string]containerd.Container
+	tasksMu              sync.RWMutex
+	tasks                map[string]containerd.Task
+	cgroupMountpointOnce sync.Once
+	cgroupMountpoint     string
+	cgroupMountpointErr  error
 }
 
 type Client interface {
 	Connect() error
 	Close() error
 
-	Namespace() string
 	CreateNamespace(namespace string) error
 	DeleteNamespace(namespace string) error
 	ListNamespaces() ([]string, error)
 	GetNamespace(namespace string) (string, error)
 	ExistsNamespace(namespace string) (bool, error)
-	SetNamespace(namespace string)
-	SetNamespaceWithCredentials(namespace string, creds []RegistryCredentials)
 	CleanupNamespaceResources(namespace, snapshotter string) error
-	GetRegistryCredentials() []RegistryCredentials
 
 	GetCgroupMountpoint() string
 	GetCurrentCgroupPath() (string, error)
@@ -71,20 +62,20 @@ type Client interface {
 	NewCgroup(spec CgroupSpec) (*cgroup2.Manager, error)
 	LoadCgroup(group string, mountpoint string) (*cgroup2.Manager, error)
 	DeleteCgroup(group, mountpoint string) error
-	CreateContainerFromSpec(spec intmodel.ContainerSpec, opts ...BuildOption) (containerd.Container, error)
+	CreateContainerFromSpec(namespace string, spec intmodel.ContainerSpec, opts ...BuildOption) (containerd.Container, error)
 
-	CreateContainer(spec ContainerSpec) (containerd.Container, error)
-	GetContainer(id string) (containerd.Container, error)
-	ListContainers(filters ...string) ([]containerd.Container, error)
-	ExistsContainer(id string) (bool, error)
-	DeleteContainer(id string, opts ContainerDeleteOptions) error
-	StartContainer(spec ContainerSpec, taskSpec TaskSpec) (containerd.Task, error)
-	StopContainer(id string, opts StopContainerOptions) (*containerd.ExitStatus, error)
+	CreateContainer(namespace string, spec ContainerSpec) (containerd.Container, error)
+	GetContainer(namespace, id string) (containerd.Container, error)
+	ListContainers(namespace string, filters ...string) ([]containerd.Container, error)
+	ExistsContainer(namespace, id string) (bool, error)
+	DeleteContainer(namespace, id string, opts ContainerDeleteOptions) error
+	StartContainer(namespace string, spec ContainerSpec, taskSpec TaskSpec) (containerd.Task, error)
+	StopContainer(namespace, id string, opts StopContainerOptions) (*containerd.ExitStatus, error)
 
-	TaskStatus(id string) (containerd.Status, error)
-	TaskMetrics(id string) (*apitypes.Metric, error)
+	TaskStatus(namespace, id string) (containerd.Status, error)
+	TaskMetrics(namespace, id string) (*apitypes.Metric, error)
 
-	ResolveSbshCachePath(imageRef, baseRunPath string) (string, error)
+	ResolveSbshCachePath(namespace, imageRef, baseRunPath string) (string, error)
 
 	// ContainerProcessUID returns the resolved process.User.UID from the
 	// given container's OCI runtime spec. Used after CreateContainerFromSpec
@@ -95,26 +86,23 @@ type Client interface {
 	// create its socket/log/capture files in the bind-mounted dir.
 	ContainerProcessUID(container containerd.Container) (uint32, error)
 
-	// LoadImage imports an OCI/docker image tarball into the client's current
+	// LoadImage imports an OCI/docker image tarball into the specified
 	// containerd namespace and returns the names of the imported images.
-	// Callers set the target namespace via SetNamespace before invoking.
-	LoadImage(reader io.Reader) ([]string, error)
+	LoadImage(namespace string, reader io.Reader) ([]string, error)
 
-	// ListImages enumerates images in the client's current containerd
-	// namespace. Callers set the target namespace via SetNamespace before
-	// invoking.
-	ListImages() ([]ImageInfo, error)
+	// ListImages enumerates images in the specified containerd namespace.
+	ListImages(namespace string) ([]ImageInfo, error)
 
-	// GetImage returns metadata for the named image ref in the client's
-	// current containerd namespace. Returns errdefs.ErrImageNotFound if
+	// GetImage returns metadata for the named image ref in the specified
+	// containerd namespace. Returns errdefs.ErrImageNotFound if
 	// the ref is absent.
-	GetImage(ref string) (ImageInfo, error)
+	GetImage(namespace, ref string) (ImageInfo, error)
 
-	// DeleteImage removes the named image ref from the client's current
+	// DeleteImage removes the named image ref from the specified
 	// containerd namespace. Returns errdefs.ErrImageNotFound if the ref
 	// is absent so callers can distinguish missing from operational
 	// failures.
-	DeleteImage(ref string) error
+	DeleteImage(namespace, ref string) error
 }
 
 func NewClient(ctx context.Context, logger *slog.Logger, socket string) Client {
@@ -122,7 +110,6 @@ func NewClient(ctx context.Context, logger *slog.Logger, socket string) Client {
 		ctx:        ctx,
 		logger:     logger,
 		socket:     socket,
-		namespace:  namespaces.Default,
 		cgroups:    make(map[string]*cgroup2.Manager),
 		containers: make(map[string]containerd.Container),
 		tasks:      make(map[string]containerd.Task),

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -62,9 +62,9 @@ type Client interface {
 	NewCgroup(spec CgroupSpec) (*cgroup2.Manager, error)
 	LoadCgroup(group string, mountpoint string) (*cgroup2.Manager, error)
 	DeleteCgroup(group, mountpoint string) error
-	CreateContainerFromSpec(namespace string, spec intmodel.ContainerSpec, opts ...BuildOption) (containerd.Container, error)
+	CreateContainerFromSpec(namespace string, spec intmodel.ContainerSpec, creds []RegistryCredentials, opts ...BuildOption) (containerd.Container, error)
 
-	CreateContainer(namespace string, spec ContainerSpec) (containerd.Container, error)
+	CreateContainer(namespace string, spec ContainerSpec, creds []RegistryCredentials) (containerd.Container, error)
 	GetContainer(namespace, id string) (containerd.Container, error)
 	ListContainers(namespace string, filters ...string) ([]containerd.Container, error)
 	ExistsContainer(namespace, id string) (bool, error)

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -84,7 +84,7 @@ type Client interface {
 	// when the image carries a USER directive (or the cell profile sets
 	// container.user). Without this, sbsh inside the container fails to
 	// create its socket/log/capture files in the bind-mounted dir.
-	ContainerProcessUID(container containerd.Container) (uint32, error)
+	ContainerProcessUID(namespace string, container containerd.Container) (uint32, error)
 
 	// LoadImage imports an OCI/docker image tarball into the specified
 	// containerd namespace and returns the names of the imported images.

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -75,7 +75,7 @@ type Client interface {
 	TaskStatus(namespace, id string) (containerd.Status, error)
 	TaskMetrics(namespace, id string) (*apitypes.Metric, error)
 
-	ResolveSbshCachePath(namespace, imageRef, baseRunPath string) (string, error)
+	ResolveSbshCachePath(namespace, imageRef, baseRunPath string, creds []RegistryCredentials) (string, error)
 
 	// ContainerProcessUID returns the resolved process.User.UID from the
 	// given container's OCI runtime spec. Used after CreateContainerFromSpec

--- a/internal/ctr/client_test.go
+++ b/internal/ctr/client_test.go
@@ -39,11 +39,6 @@ func TestNewClient(t *testing.T) {
 	if _, ok := client.(ctr.Client); !ok {
 		t.Error("NewClient() should return a Client interface")
 	}
-
-	// Test default namespace
-	if client.Namespace() == "" {
-		t.Error("Client should have a default namespace")
-	}
 }
 
 func TestClientConnect(_ *testing.T) {

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -51,7 +51,7 @@ func (c *client) StartContainer(
 	nsCtx := c.namespaceCtx(namespace)
 
 	if len(containerSpec.SpecOpts) > 0 {
-		if err = c.applySpecOpts(container, containerSpec.SpecOpts); err != nil {
+		if err = c.applySpecOpts(namespace, container, containerSpec.SpecOpts); err != nil {
 			return nil, err
 		}
 	}
@@ -64,7 +64,7 @@ func (c *client) StartContainer(
 		status, err = existingTask.Status(nsCtx)
 		if err == nil && status.Status == containerd.Running {
 			c.logger.WarnContext(c.ctx, "task already running", "id", containerSpec.ID)
-			c.storeTask(containerSpec.ID, existingTask)
+			c.storeTask(namespace, containerSpec.ID, existingTask)
 			return existingTask, nil
 		}
 		// Task exists but is not running (stopped), delete it before creating a new one
@@ -80,7 +80,7 @@ func (c *client) StartContainer(
 				formatError(err),
 			)
 		}
-		c.dropTask(containerSpec.ID)
+		c.dropTask(namespace, containerSpec.ID)
 	}
 
 	// Build IO creator. Selection order:
@@ -128,7 +128,7 @@ func (c *client) StartContainer(
 		return nil, fmt.Errorf("failed to start task: %w", err)
 	}
 
-	c.storeTask(containerSpec.ID, task)
+	c.storeTask(namespace, containerSpec.ID, task)
 	c.logger.InfoContext(c.ctx, "started container", "id", containerSpec.ID, "namespace", namespace)
 	return task, nil
 }
@@ -441,7 +441,7 @@ func (c *client) DeleteContainer(namespace, id string, opts ContainerDeleteOptio
 		} else {
 			c.logger.DebugContext(c.ctx, "deleted task", "id", id)
 		}
-		c.dropTask(id)
+		c.dropTask(namespace, id)
 	} else {
 		c.logger.DebugContext(c.ctx, "no task found for container", "id", id)
 	}

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -284,7 +284,7 @@ func (c *client) StopContainer(
 }
 
 // CreateContainer creates a new container with the provided spec.
-func (c *client) CreateContainer(namespace string, spec ContainerSpec) (containerd.Container, error) {
+func (c *client) CreateContainer(namespace string, spec ContainerSpec, creds []RegistryCredentials) (containerd.Container, error) {
 	if err := validateContainerSpec(spec); err != nil {
 		return nil, err
 	}
@@ -298,8 +298,8 @@ func (c *client) CreateContainer(namespace string, spec ContainerSpec) (containe
 		return nil, internalerrdefs.ErrContainerExists
 	}
 
-	// Pull the image if needed (no registry credentials for basic CreateContainer)
-	image, err := c.pullImage(namespace, spec.Image, nil)
+	// Pull the image if needed
+	image, err := c.pullImage(namespace, spec.Image, creds)
 	if err != nil {
 		return nil, err
 	}
@@ -476,6 +476,7 @@ func (c *client) DeleteContainer(namespace, id string, opts ContainerDeleteOptio
 func (c *client) CreateContainerFromSpec(
 	namespace string,
 	containerSpec intmodel.ContainerSpec,
+	creds []RegistryCredentials,
 	opts ...BuildOption,
 ) (containerd.Container, error) {
 	if containerSpec.ID == "" {
@@ -534,7 +535,7 @@ func (c *client) CreateContainerFromSpec(
 	ctrSpec := BuildContainerSpec(containerSpec, opts...)
 
 	// Create the container
-	container, err := c.CreateContainer(namespace, ctrSpec)
+	container, err := c.CreateContainer(namespace, ctrSpec, creds)
 	if err != nil {
 		c.logger.ErrorContext(
 			c.ctx,

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -35,6 +35,7 @@ import (
 
 // StartContainer creates and starts a task for the container.
 func (c *client) StartContainer(
+	namespace string,
 	containerSpec ContainerSpec,
 	taskSpec TaskSpec,
 ) (containerd.Task, error) {
@@ -42,12 +43,12 @@ func (c *client) StartContainer(
 		return nil, internalerrdefs.ErrEmptyContainerID
 	}
 
-	container, err := c.loadContainer(containerSpec.ID)
+	container, err := c.loadContainer(namespace, containerSpec.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 
 	if len(containerSpec.SpecOpts) > 0 {
 		if err = c.applySpecOpts(container, containerSpec.SpecOpts); err != nil {
@@ -128,12 +129,13 @@ func (c *client) StartContainer(
 	}
 
 	c.storeTask(containerSpec.ID, task)
-	c.logger.InfoContext(c.ctx, "started container", "id", containerSpec.ID)
+	c.logger.InfoContext(c.ctx, "started container", "id", containerSpec.ID, "namespace", namespace)
 	return task, nil
 }
 
 // StopContainer stops a running container task.
 func (c *client) StopContainer(
+	namespace string,
 	id string,
 	opts StopContainerOptions,
 ) (*containerd.ExitStatus, error) {
@@ -141,14 +143,14 @@ func (c *client) StopContainer(
 		return nil, internalerrdefs.ErrEmptyContainerID
 	}
 
-	c.logger.DebugContext(c.ctx, "starting to stop container", "id", id)
-	task, err := c.loadTask(id)
+	c.logger.DebugContext(c.ctx, "starting to stop container", "id", id, "namespace", namespace)
+	task, err := c.loadTask(namespace, id)
 	if err != nil {
 		c.logger.DebugContext(c.ctx, "failed to load task for container", "id", id, "error", err)
 		return nil, err
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 
 	// Check task status
 	c.logger.DebugContext(c.ctx, "checking task status", "id", id)
@@ -247,7 +249,7 @@ func (c *client) StopContainer(
 		}
 	}
 
-	c.logger.InfoContext(c.ctx, "stopped container", "id", id, "exit_code", exitStatus.ExitCode())
+	c.logger.InfoContext(c.ctx, "stopped container", "id", id, "namespace", namespace, "exit_code", exitStatus.ExitCode())
 
 	// Verify task is actually stopped
 	finalStatus, err := task.Status(nsCtx)
@@ -276,18 +278,18 @@ func (c *client) StopContainer(
 	} else {
 		c.logger.DebugContext(c.ctx, "deleted stopped task", "id", id)
 	}
-	c.dropTask(id)
+	c.dropTask(namespace, id)
 
 	return &exitStatus, nil
 }
 
 // CreateContainer creates a new container with the provided spec.
-func (c *client) CreateContainer(spec ContainerSpec) (containerd.Container, error) {
+func (c *client) CreateContainer(namespace string, spec ContainerSpec) (containerd.Container, error) {
 	if err := validateContainerSpec(spec); err != nil {
 		return nil, err
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 
 	// Check if container already exists
 	_, err := c.cClient.LoadContainer(nsCtx, spec.ID)
@@ -296,15 +298,15 @@ func (c *client) CreateContainer(spec ContainerSpec) (containerd.Container, erro
 		return nil, internalerrdefs.ErrContainerExists
 	}
 
-	// Pull the image if needed
-	image, err := c.pullImage(spec.Image)
+	// Pull the image if needed (no registry credentials for basic CreateContainer)
+	image, err := c.pullImage(namespace, spec.Image, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	// Ensure image is unpacked before creating container
 	// Use spec.Snapshotter if provided, otherwise empty string for default snapshotter
-	if err = c.ensureImageUnpacked(image, spec.Snapshotter); err != nil {
+	if err = c.ensureImageUnpacked(namespace, image, spec.Snapshotter); err != nil {
 		return nil, fmt.Errorf("failed to ensure image is unpacked: %w", err)
 	}
 
@@ -353,22 +355,22 @@ func (c *client) CreateContainer(spec ContainerSpec) (containerd.Container, erro
 		return nil, fmt.Errorf("failed to create container: %w", err)
 	}
 
-	c.storeContainer(spec.ID, container)
-	c.logger.InfoContext(c.ctx, "created container", "id", spec.ID, "image", spec.Image)
+	c.storeContainer(namespace, spec.ID, container)
+	c.logger.InfoContext(c.ctx, "created container", "id", spec.ID, "namespace", namespace, "image", spec.Image)
 	return container, nil
 }
 
 // GetContainer retrieves a container by ID.
-func (c *client) GetContainer(id string) (containerd.Container, error) {
+func (c *client) GetContainer(namespace, id string) (containerd.Container, error) {
 	if id == "" {
 		return nil, internalerrdefs.ErrEmptyContainerID
 	}
-	return c.loadContainer(id)
+	return c.loadContainer(namespace, id)
 }
 
 // ListContainers lists all containers matching the provided filters.
-func (c *client) ListContainers(filters ...string) ([]containerd.Container, error) {
-	nsCtx := c.namespaceCtx()
+func (c *client) ListContainers(namespace string, filters ...string) ([]containerd.Container, error) {
+	nsCtx := c.namespaceCtx(namespace)
 
 	containers, err := c.cClient.Containers(nsCtx, filters...)
 	if err != nil {
@@ -378,20 +380,20 @@ func (c *client) ListContainers(filters ...string) ([]containerd.Container, erro
 
 	// Update cache
 	for _, container := range containers {
-		c.storeContainer(container.ID(), container)
+		c.storeContainer(namespace, container.ID(), container)
 	}
 
-	c.logger.DebugContext(c.ctx, "listed containers", "count", len(containers))
+	c.logger.DebugContext(c.ctx, "listed containers", "namespace", namespace, "count", len(containers))
 	return containers, nil
 }
 
 // ExistsContainer checks if a container exists.
-func (c *client) ExistsContainer(id string) (bool, error) {
+func (c *client) ExistsContainer(namespace, id string) (bool, error) {
 	if id == "" {
 		return false, internalerrdefs.ErrEmptyContainerID
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 	_, err := c.cClient.LoadContainer(nsCtx, id)
 	if err != nil {
 		// "Not found" is not an error for Exists - it's a valid result (container doesn't exist)
@@ -407,24 +409,24 @@ func (c *client) ExistsContainer(id string) (bool, error) {
 // DeleteContainer deletes a container.
 // It is idempotent - if the container doesn't exist, it returns nil (treating it as already deleted).
 // It automatically deletes any associated task before deleting the container.
-func (c *client) DeleteContainer(id string, opts ContainerDeleteOptions) error {
+func (c *client) DeleteContainer(namespace, id string, opts ContainerDeleteOptions) error {
 	if id == "" {
 		return internalerrdefs.ErrEmptyContainerID
 	}
 
-	c.logger.DebugContext(c.ctx, "starting to delete container", "id", id, "snapshot_cleanup", opts.SnapshotCleanup)
-	container, err := c.loadContainer(id)
+	c.logger.DebugContext(c.ctx, "starting to delete container", "id", id, "namespace", namespace, "snapshot_cleanup", opts.SnapshotCleanup)
+	container, err := c.loadContainer(namespace, id)
 	if err != nil {
 		// Container doesn't exist - treat as idempotent (already deleted)
 		if errors.Is(err, internalerrdefs.ErrContainerNotFound) {
-			c.logger.DebugContext(c.ctx, "container not found", "id", id)
+			c.logger.DebugContext(c.ctx, "container not found", "id", id, "namespace", namespace)
 			return nil
 		}
-		c.logger.DebugContext(c.ctx, "failed to load container for deletion", "id", id, "error", err)
+		c.logger.DebugContext(c.ctx, "failed to load container for deletion", "id", id, "namespace", namespace, "error", err)
 		return err
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 
 	// Try to get and delete the task if it exists
 	c.logger.DebugContext(c.ctx, "checking for task to delete", "id", id)
@@ -455,16 +457,16 @@ func (c *client) DeleteContainer(id string, opts ContainerDeleteOptions) error {
 	if err != nil {
 		// Check if container was already deleted (race condition)
 		if errdefs.IsNotFound(err) {
-			c.logger.DebugContext(c.ctx, "container not found", "id", id)
-			c.dropContainer(id)
+			c.logger.DebugContext(c.ctx, "container not found", "id", id, "namespace", namespace)
+			c.dropContainer(namespace, id)
 			return nil
 		}
-		c.logger.ErrorContext(c.ctx, "failed to delete container", "id", id, "err", formatError(err))
+		c.logger.ErrorContext(c.ctx, "failed to delete container", "id", id, "namespace", namespace, "err", formatError(err))
 		return fmt.Errorf("failed to delete container: %w", err)
 	}
 
-	c.dropContainer(id)
-	c.logger.InfoContext(c.ctx, "deleted container", "id", id)
+	c.dropContainer(namespace, id)
+	c.logger.InfoContext(c.ctx, "deleted container", "id", id, "namespace", namespace)
 	return nil
 }
 
@@ -472,6 +474,7 @@ func (c *client) DeleteContainer(id string, opts ContainerDeleteOptions) error {
 // Variadic opts forward to BuildContainerSpec — used today only by the
 // runner when it needs to inject host-side paths for an Attachable spec.
 func (c *client) CreateContainerFromSpec(
+	namespace string,
 	containerSpec intmodel.ContainerSpec,
 	opts ...BuildOption,
 ) (containerd.Container, error) {
@@ -531,7 +534,7 @@ func (c *client) CreateContainerFromSpec(
 	ctrSpec := BuildContainerSpec(containerSpec, opts...)
 
 	// Create the container
-	container, err := c.CreateContainer(ctrSpec)
+	container, err := c.CreateContainer(namespace, ctrSpec)
 	if err != nil {
 		c.logger.ErrorContext(
 			c.ctx,
@@ -557,6 +560,8 @@ func (c *client) CreateContainerFromSpec(
 		containerSpec.SpaceName,
 		"realm",
 		containerSpec.RealmName,
+		"namespace",
+		namespace,
 	)
 	return container, nil
 }

--- a/internal/ctr/container_test.go
+++ b/internal/ctr/container_test.go
@@ -98,7 +98,7 @@ func TestCreateContainerValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.CreateContainer("test-ns", tt.spec)
+			_, err := client.CreateContainer("test-ns", tt.spec, nil)
 
 			if tt.wantErr != nil {
 				if err == nil {
@@ -260,7 +260,7 @@ func TestCreateContainerFromSpecValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.CreateContainerFromSpec("test-ns", tt.spec)
+			_, err := client.CreateContainerFromSpec("test-ns", tt.spec, nil)
 
 			if tt.wantErr != nil {
 				if err == nil {

--- a/internal/ctr/container_test.go
+++ b/internal/ctr/container_test.go
@@ -41,7 +41,7 @@ func TestContainerValidation(t *testing.T) {
 	client := setupTestClientForContainer(t)
 
 	// Test GetContainer with empty ID
-	_, err := client.GetContainer("")
+	_, err := client.GetContainer("test-ns", "")
 	if err == nil {
 		t.Error("GetContainer with empty ID should return error")
 	}
@@ -50,7 +50,7 @@ func TestContainerValidation(t *testing.T) {
 	}
 
 	// Test ExistsContainer with empty ID
-	_, err2 := client.ExistsContainer("")
+	_, err2 := client.ExistsContainer("test-ns", "")
 	if err2 == nil {
 		t.Error("ExistsContainer with empty ID should return error")
 	}
@@ -59,7 +59,7 @@ func TestContainerValidation(t *testing.T) {
 	}
 
 	// Test DeleteContainer with empty ID
-	err3 := client.DeleteContainer("", ctr.ContainerDeleteOptions{})
+	err3 := client.DeleteContainer("test-ns", "", ctr.ContainerDeleteOptions{})
 	if err3 == nil {
 		t.Error("DeleteContainer with empty ID should return error")
 	}
@@ -98,7 +98,7 @@ func TestCreateContainerValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.CreateContainer(tt.spec)
+			_, err := client.CreateContainer("test-ns", tt.spec)
 
 			if tt.wantErr != nil {
 				if err == nil {
@@ -135,7 +135,7 @@ func TestStartContainerValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.StartContainer(tt.containerSpec, tt.taskSpec)
+			_, err := client.StartContainer("test-ns", tt.containerSpec, tt.taskSpec)
 
 			if tt.wantErr != nil {
 				if err == nil {
@@ -169,7 +169,7 @@ func TestStopContainerValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.StopContainer(tt.id, tt.opts)
+			_, err := client.StopContainer("test-ns", tt.id, tt.opts)
 
 			if tt.wantErr != nil {
 				if err == nil {
@@ -260,7 +260,7 @@ func TestCreateContainerFromSpecValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.CreateContainerFromSpec(tt.spec)
+			_, err := client.CreateContainerFromSpec("test-ns", tt.spec)
 
 			if tt.wantErr != nil {
 				if err == nil {

--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -43,8 +43,8 @@ type ImageInfo struct {
 
 // ensureImageUnpacked ensures that an image is unpacked for the given snapshotter.
 // If the image is not unpacked, it will be unpacked. Returns an error if unpacking fails.
-func (c *client) ensureImageUnpacked(image containerd.Image, snapshotter string) error {
-	nsCtx := c.namespaceCtx()
+func (c *client) ensureImageUnpacked(namespace string, image containerd.Image, snapshotter string) error {
+	nsCtx := c.namespaceCtx(namespace)
 
 	// Check if image is already unpacked
 	unpacked, err := image.IsUnpacked(nsCtx, snapshotter)
@@ -88,8 +88,8 @@ func (c *client) ensureImageUnpacked(image containerd.Image, snapshotter string)
 
 // pullImage pulls an image from a registry if it's not found locally.
 // Returns the image and any error encountered.
-func (c *client) pullImage(imageRef string) (containerd.Image, error) {
-	nsCtx := c.namespaceCtx()
+func (c *client) pullImage(namespace string, imageRef string, creds []RegistryCredentials) (containerd.Image, error) {
+	nsCtx := c.namespaceCtx(namespace)
 
 	// Try to get the image locally first
 	image, err := c.cClient.GetImage(nsCtx, imageRef)
@@ -138,8 +138,7 @@ func (c *client) pullImage(imageRef string) (containerd.Image, error) {
 		containerd.WithPlatform(platforms.Format(platform)),
 	}
 
-	// Get credentials from client (set when namespace was configured)
-	creds := c.GetRegistryCredentials()
+	// Use credentials passed as parameter
 	if len(creds) > 0 {
 		resolver := buildResolver(creds)
 		pullOpts = append(pullOpts, containerd.WithResolver(resolver))
@@ -157,17 +156,15 @@ func (c *client) pullImage(imageRef string) (containerd.Image, error) {
 	return image, nil
 }
 
-// LoadImage imports an OCI/docker image tarball into the client's current
-// containerd namespace and returns the names of the imported images. The
-// caller sets the target namespace via SetNamespace; namespaceCtx() then
-// scopes the import to that namespace.
+// LoadImage imports an OCI/docker image tarball into the specified
+// containerd namespace and returns the names of the imported images.
 //
 // WithSkipMissing() mirrors `ctr images import`'s tolerance: multi-arch
 // tarballs produced by `docker save` reference platform-specific blobs the
 // docker daemon does not always include. Skipping missing blobs lets the
 // host-arch manifest land while ignoring the others.
-func (c *client) LoadImage(reader io.Reader) ([]string, error) {
-	nsCtx := c.namespaceCtx()
+func (c *client) LoadImage(namespace string, reader io.Reader) ([]string, error) {
+	nsCtx := c.namespaceCtx(namespace)
 
 	imgs, err := c.cClient.Import(nsCtx, reader, containerd.WithSkipMissing())
 	if err != nil {
@@ -175,7 +172,7 @@ func (c *client) LoadImage(reader io.Reader) ([]string, error) {
 			c.ctx,
 			"failed to import image tarball",
 			"namespace",
-			c.Namespace(),
+			namespace,
 			"err",
 			formatError(err),
 		)
@@ -186,16 +183,16 @@ func (c *client) LoadImage(reader io.Reader) ([]string, error) {
 	for _, img := range imgs {
 		names = append(names, img.Name)
 	}
-	c.logger.DebugContext(c.ctx, "imported image tarball", "namespace", c.Namespace(), "images", names)
+	c.logger.DebugContext(c.ctx, "imported image tarball", "namespace", namespace, "images", names)
 	return names, nil
 }
 
-// ListImages enumerates images in the client's current containerd namespace.
+// ListImages enumerates images in the specified containerd namespace.
 // Size is best-effort: when containerd cannot resolve an image's size (e.g.
 // because content is missing locally), the entry is still surfaced with
 // Size=-1 so listing degrades gracefully instead of failing the whole call.
-func (c *client) ListImages() ([]ImageInfo, error) {
-	nsCtx := c.namespaceCtx()
+func (c *client) ListImages(namespace string) ([]ImageInfo, error) {
+	nsCtx := c.namespaceCtx(namespace)
 
 	imgs, err := c.cClient.ListImages(nsCtx)
 	if err != nil {
@@ -203,7 +200,7 @@ func (c *client) ListImages() ([]ImageInfo, error) {
 			c.ctx,
 			"failed to list images",
 			"namespace",
-			c.Namespace(),
+			namespace,
 			"err",
 			formatError(err),
 		)
@@ -212,17 +209,17 @@ func (c *client) ListImages() ([]ImageInfo, error) {
 
 	out := make([]ImageInfo, 0, len(imgs))
 	for _, img := range imgs {
-		out = append(out, c.imageToInfo(img))
+		out = append(out, c.imageToInfo(namespace, img))
 	}
 	return out, nil
 }
 
-// GetImage returns metadata for the named image ref in the client's current
+// GetImage returns metadata for the named image ref in the specified
 // containerd namespace. Returns errdefs.ErrImageNotFound (the kukeon
 // sentinel) when containerd reports the ref absent so upper layers can map
 // to a clean error message.
-func (c *client) GetImage(ref string) (ImageInfo, error) {
-	nsCtx := c.namespaceCtx()
+func (c *client) GetImage(namespace, ref string) (ImageInfo, error) {
+	nsCtx := c.namespaceCtx(namespace)
 
 	img, err := c.cClient.GetImage(nsCtx, ref)
 	if err != nil {
@@ -233,7 +230,7 @@ func (c *client) GetImage(ref string) (ImageInfo, error) {
 			c.ctx,
 			"failed to get image",
 			"namespace",
-			c.Namespace(),
+			namespace,
 			"ref",
 			ref,
 			"err",
@@ -241,15 +238,15 @@ func (c *client) GetImage(ref string) (ImageInfo, error) {
 		)
 		return ImageInfo{}, fmt.Errorf("%w: %w", internalerrdefs.ErrGetImage, err)
 	}
-	return c.imageToInfo(img), nil
+	return c.imageToInfo(namespace, img), nil
 }
 
-// DeleteImage removes the named image ref from the client's current
+// DeleteImage removes the named image ref from the specified
 // containerd namespace. The kukeon ErrImageNotFound sentinel is returned
 // when containerd reports the ref absent so upper layers can map to a
 // clean error message; other errors are wrapped with ErrDeleteImage.
-func (c *client) DeleteImage(ref string) error {
-	nsCtx := c.namespaceCtx()
+func (c *client) DeleteImage(namespace, ref string) error {
+	nsCtx := c.namespaceCtx(namespace)
 
 	if err := c.cClient.ImageService().Delete(nsCtx, ref); err != nil {
 		if errdefs.IsNotFound(err) {
@@ -259,7 +256,7 @@ func (c *client) DeleteImage(ref string) error {
 			c.ctx,
 			"failed to delete image",
 			"namespace",
-			c.Namespace(),
+			namespace,
 			"ref",
 			ref,
 			"err",
@@ -274,8 +271,8 @@ func (c *client) DeleteImage(ref string) error {
 // resolved via the platform-default Size() helper; failure leaves Size=-1
 // rather than aborting because partial-content tarballs are common with
 // `docker save` (see LoadImage's WithSkipMissing rationale).
-func (c *client) imageToInfo(img containerd.Image) ImageInfo {
-	nsCtx := c.namespaceCtx()
+func (c *client) imageToInfo(namespace string, img containerd.Image) ImageInfo {
+	nsCtx := c.namespaceCtx(namespace)
 	meta := img.Metadata()
 	target := img.Target()
 
@@ -287,7 +284,7 @@ func (c *client) imageToInfo(img containerd.Image) ImageInfo {
 			c.ctx,
 			"failed to resolve image size",
 			"namespace",
-			c.Namespace(),
+			namespace,
 			"image",
 			img.Name(),
 			"err",

--- a/internal/ctr/namespaces.go
+++ b/internal/ctr/namespaces.go
@@ -30,51 +30,8 @@ import (
 )
 
 // namespaceCtx returns a context with the namespace set.
-func (c *client) namespaceCtx() context.Context {
-	c.namespaceMu.RLock()
-	defer c.namespaceMu.RUnlock()
-	return namespaces.WithNamespace(c.ctx, c.namespace)
-}
-
-// SetNamespace sets the namespace for subsequent operations.
-// This clears any previously set registry credentials.
-func (c *client) SetNamespace(namespace string) {
-	c.namespaceMu.Lock()
-	defer c.namespaceMu.Unlock()
-	c.namespace = namespace
-	c.logger.DebugContext(c.ctx, "set namespace", "namespace", namespace)
-
-	// Clear credentials when namespace is set without credentials
-	c.registryCredentialsMu.Lock()
-	defer c.registryCredentialsMu.Unlock()
-	c.registryCredentials = nil
-}
-
-// SetNamespaceWithCredentials sets the namespace and associated registry credentials.
-// This should be called when switching to a realm's namespace.
-func (c *client) SetNamespaceWithCredentials(namespace string, creds []RegistryCredentials) {
-	c.namespaceMu.Lock()
-	defer c.namespaceMu.Unlock()
-	c.namespace = namespace
-	c.logger.DebugContext(c.ctx, "set namespace with credentials", "namespace", namespace, "creds_count", len(creds))
-
-	c.registryCredentialsMu.Lock()
-	defer c.registryCredentialsMu.Unlock()
-	c.registryCredentials = creds
-}
-
-// GetRegistryCredentials returns the current registry credentials for the namespace.
-func (c *client) GetRegistryCredentials() []RegistryCredentials {
-	c.registryCredentialsMu.RLock()
-	defer c.registryCredentialsMu.RUnlock()
-	return c.registryCredentials
-}
-
-// Namespace returns the current namespace.
-func (c *client) Namespace() string {
-	c.namespaceMu.RLock()
-	defer c.namespaceMu.RUnlock()
-	return c.namespace
+func (c *client) namespaceCtx(namespace string) context.Context {
+	return namespaces.WithNamespace(c.ctx, namespace)
 }
 
 func (c *client) CreateNamespace(namespace string) error {

--- a/internal/ctr/namespaces_test.go
+++ b/internal/ctr/namespaces_test.go
@@ -33,41 +33,7 @@ func setupTestClientForNamespaces(t *testing.T) ctr.Client {
 	return ctr.NewClient(ctx, logger, "/test/socket")
 }
 
-// TestNamespaceMethods tests the exported namespace methods on Client interface.
-// Full testing requires mocking containerd namespace service and registry credentials.
-func TestNamespaceMethods(t *testing.T) {
-	client := setupTestClientForNamespaces(t)
-
-	// Test GetNamespace - should return default namespace for new client
-	ns := client.Namespace()
-	if ns == "" {
-		t.Error("Namespace should not be empty for new client")
-	}
-
-	// Test SetNamespace
-	client.SetNamespace("test-namespace")
-	if client.Namespace() != "test-namespace" {
-		t.Errorf("Namespace = %q, want %q", client.Namespace(), "test-namespace")
-	}
-
-	// Test SetNamespaceWithCredentials
-	creds := []ctr.RegistryCredentials{
-		{
-			Username:      "user",
-			Password:      "pass",
-			ServerAddress: "docker.io",
-		},
-	}
-	client.SetNamespaceWithCredentials("test-ns", creds)
-	if client.Namespace() != "test-ns" {
-		t.Errorf("Namespace = %q, want %q", client.Namespace(), "test-ns")
-	}
-	gotCreds := client.GetRegistryCredentials()
-	if len(gotCreds) != 1 || gotCreds[0].Username != "user" {
-		t.Errorf("GetRegistryCredentials() = %v, want credentials with username 'user'", gotCreds)
-	}
-}
-
+// TestDeleteNamespaceValidation tests DeleteNamespace input validation.
 func TestDeleteNamespaceValidation(t *testing.T) {
 	client := setupTestClientForNamespaces(t)
 
@@ -113,6 +79,7 @@ func TestDeleteNamespaceValidation(t *testing.T) {
 	}
 }
 
+// TestCleanupNamespaceResourcesValidation tests CleanupNamespaceResources input handling.
 func TestCleanupNamespaceResourcesValidation(t *testing.T) {
 	client := setupTestClientForNamespaces(t)
 
@@ -154,82 +121,5 @@ func TestCleanupNamespaceResourcesValidation(t *testing.T) {
 				t.Logf("CleanupNamespaceResources() error = %v (expected without containerd)", err)
 			}
 		})
-	}
-}
-
-func TestNamespaceStateTransitions(t *testing.T) {
-	client := setupTestClientForNamespaces(t)
-
-	// Test default namespace on creation
-	defaultNs := client.Namespace()
-	if defaultNs == "" {
-		t.Error("Client should have a default namespace on creation")
-	}
-
-	// Test namespace change after SetNamespace
-	newNs := "test-namespace-1"
-	client.SetNamespace(newNs)
-	if client.Namespace() != newNs {
-		t.Errorf("Namespace = %q, want %q after SetNamespace", client.Namespace(), newNs)
-	}
-
-	// Test that credentials are cleared on SetNamespace
-	creds := client.GetRegistryCredentials()
-	if creds != nil && len(creds) > 0 {
-		t.Errorf("GetRegistryCredentials() should return nil/empty after SetNamespace, got %v", creds)
-	}
-
-	// Test SetNamespaceWithCredentials preserves credentials
-	testCreds := []ctr.RegistryCredentials{
-		{
-			Username:      "user1",
-			Password:      "pass1",
-			ServerAddress: "docker.io",
-		},
-		{
-			Username:      "user2",
-			Password:      "pass2",
-			ServerAddress: "registry.example.com",
-		},
-	}
-	nsWithCreds := "test-namespace-2"
-	client.SetNamespaceWithCredentials(nsWithCreds, testCreds)
-
-	if client.Namespace() != nsWithCreds {
-		t.Errorf("Namespace = %q, want %q after SetNamespaceWithCredentials", client.Namespace(), nsWithCreds)
-	}
-
-	gotCreds := client.GetRegistryCredentials()
-	if len(gotCreds) != len(testCreds) {
-		t.Errorf("GetRegistryCredentials() count = %d, want %d", len(gotCreds), len(testCreds))
-	}
-	if len(gotCreds) > 0 {
-		if gotCreds[0].Username != testCreds[0].Username {
-			t.Errorf("GetRegistryCredentials()[0].Username = %q, want %q", gotCreds[0].Username, testCreds[0].Username)
-		}
-		if len(gotCreds) > 1 && gotCreds[1].Username != testCreds[1].Username {
-			t.Errorf("GetRegistryCredentials()[1].Username = %q, want %q", gotCreds[1].Username, testCreds[1].Username)
-		}
-	}
-
-	// Test state consistency - multiple namespace switches
-	client.SetNamespace("test-namespace-3")
-	if client.Namespace() != "test-namespace-3" {
-		t.Errorf("Namespace = %q, want 'test-namespace-3'", client.Namespace())
-	}
-	// Credentials should be cleared again
-	creds = client.GetRegistryCredentials()
-	if creds != nil && len(creds) > 0 {
-		t.Errorf("GetRegistryCredentials() should return nil/empty after SetNamespace, got %v", creds)
-	}
-
-	// Test SetNamespaceWithCredentials again
-	client.SetNamespaceWithCredentials("test-namespace-4", testCreds[:1])
-	if client.Namespace() != "test-namespace-4" {
-		t.Errorf("Namespace = %q, want 'test-namespace-4'", client.Namespace())
-	}
-	gotCreds = client.GetRegistryCredentials()
-	if len(gotCreds) != 1 {
-		t.Errorf("GetRegistryCredentials() count = %d, want 1", len(gotCreds))
 	}
 }

--- a/internal/ctr/sbsh_cache.go
+++ b/internal/ctr/sbsh_cache.go
@@ -58,15 +58,15 @@ func SbshCachePath(baseRunPath, arch string) string {
 // Returns the host path on success; ErrInvalidImage when the image ref is
 // empty or the arch cannot be resolved from the image config; whatever
 // pullImage returns when the pull itself fails.
-func (c *client) ResolveSbshCachePath(imageRef, baseRunPath string) (string, error) {
+func (c *client) ResolveSbshCachePath(namespace, imageRef, baseRunPath string) (string, error) {
 	if imageRef == "" {
 		return "", fmt.Errorf("%w: image ref is empty", errdefs.ErrInvalidImage)
 	}
-	image, err := c.pullImage(imageRef)
+	image, err := c.pullImage(namespace, imageRef, nil)
 	if err != nil {
 		return "", err
 	}
-	arch, err := imageArchitecture(c.namespaceCtx(), image)
+	arch, err := imageArchitecture(c.namespaceCtx(namespace), image)
 	if err != nil {
 		return "", err
 	}

--- a/internal/ctr/sbsh_cache.go
+++ b/internal/ctr/sbsh_cache.go
@@ -58,11 +58,11 @@ func SbshCachePath(baseRunPath, arch string) string {
 // Returns the host path on success; ErrInvalidImage when the image ref is
 // empty or the arch cannot be resolved from the image config; whatever
 // pullImage returns when the pull itself fails.
-func (c *client) ResolveSbshCachePath(namespace, imageRef, baseRunPath string) (string, error) {
+func (c *client) ResolveSbshCachePath(namespace, imageRef, baseRunPath string, creds []RegistryCredentials) (string, error) {
 	if imageRef == "" {
 		return "", fmt.Errorf("%w: image ref is empty", errdefs.ErrInvalidImage)
 	}
-	image, err := c.pullImage(namespace, imageRef, nil)
+	image, err := c.pullImage(namespace, imageRef, creds)
 	if err != nil {
 		return "", err
 	}

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -88,12 +88,12 @@ func withNamespacePathOpt(nsType runtimespec.LinuxNamespaceType, path string) oc
 	}
 }
 
-func (c *client) applySpecOpts(container containerd.Container, opts []oci.SpecOpts) error {
+func (c *client) applySpecOpts(namespace string, container containerd.Container, opts []oci.SpecOpts) error {
 	if len(opts) == 0 {
 		return nil
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 	ociSpec, err := container.Spec(nsCtx)
 	if err != nil {
 		return fmt.Errorf("failed to load container spec: %w", err)
@@ -139,11 +139,11 @@ func (c *client) applySpecOpts(container containerd.Container, opts []oci.SpecOp
 // "claude". Returns an error if the spec cannot be loaded or has no
 // Process — both indicate the container was not created or was destroyed
 // between create and this call.
-func (c *client) ContainerProcessUID(container containerd.Container) (uint32, error) {
+func (c *client) ContainerProcessUID(namespace string, container containerd.Container) (uint32, error) {
 	if container == nil {
 		return 0, errors.New("container is nil")
 	}
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 	spec, err := container.Spec(nsCtx)
 	if err != nil {
 		return 0, fmt.Errorf("read container spec: %w", err)

--- a/internal/ctr/task.go
+++ b/internal/ctr/task.go
@@ -26,20 +26,20 @@ import (
 )
 
 // TaskStatus returns the current status of a task.
-func (c *client) TaskStatus(id string) (containerd.Status, error) {
+func (c *client) TaskStatus(namespace, id string) (containerd.Status, error) {
 	if id == "" {
 		return containerd.Status{}, errdefs.ErrEmptyContainerID
 	}
 
-	task, err := c.loadTask(id)
+	task, err := c.loadTask(namespace, id)
 	if err != nil {
 		return containerd.Status{}, err
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 	status, err := task.Status(nsCtx)
 	if err != nil {
-		c.logger.ErrorContext(c.ctx, "failed to get task status", "id", id, "err", formatError(err))
+		c.logger.ErrorContext(c.ctx, "failed to get task status", "id", id, "namespace", namespace, "err", formatError(err))
 		return containerd.Status{}, fmt.Errorf("failed to get task status: %w", err)
 	}
 
@@ -47,20 +47,20 @@ func (c *client) TaskStatus(id string) (containerd.Status, error) {
 }
 
 // TaskMetrics returns the metrics for a task.
-func (c *client) TaskMetrics(id string) (*apitypes.Metric, error) {
+func (c *client) TaskMetrics(namespace, id string) (*apitypes.Metric, error) {
 	if id == "" {
 		return nil, errdefs.ErrEmptyContainerID
 	}
 
-	task, err := c.loadTask(id)
+	task, err := c.loadTask(namespace, id)
 	if err != nil {
 		return nil, err
 	}
 
-	nsCtx := c.namespaceCtx()
+	nsCtx := c.namespaceCtx(namespace)
 	metrics, err := task.Metrics(nsCtx)
 	if err != nil {
-		c.logger.ErrorContext(c.ctx, "failed to get task metrics", "id", id, "err", formatError(err))
+		c.logger.ErrorContext(c.ctx, "failed to get task metrics", "id", id, "namespace", namespace, "err", formatError(err))
 		return nil, fmt.Errorf("failed to get task metrics: %w", err)
 	}
 

--- a/internal/ctr/task_test.go
+++ b/internal/ctr/task_test.go
@@ -40,7 +40,7 @@ func TestTaskStatusValidation(t *testing.T) {
 	client := setupTestClientForTask(t)
 
 	// Test empty ID validation
-	_, err := client.TaskStatus("")
+	_, err := client.TaskStatus("test-ns", "")
 	if err == nil {
 		t.Error("TaskStatus with empty ID should return error")
 	}
@@ -55,7 +55,7 @@ func TestTaskMetricsValidation(t *testing.T) {
 	client := setupTestClientForTask(t)
 
 	// Test empty ID validation
-	_, err := client.TaskMetrics("")
+	_, err := client.TaskMetrics("test-ns", "")
 	if err == nil {
 		t.Error("TaskMetrics with empty ID should return error")
 	}
@@ -83,7 +83,7 @@ func TestTaskStatusErrorHandling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.TaskStatus(tt.id)
+			_, err := client.TaskStatus("test-ns", tt.id)
 
 			if tt.wantErr != nil {
 				if err == nil {
@@ -115,7 +115,7 @@ func TestTaskMetricsErrorHandling(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.TaskMetrics(tt.id)
+			_, err := client.TaskMetrics("test-ns", tt.id)
 
 			if tt.wantErr != nil {
 				if err == nil {


### PR DESCRIPTION
## Summary

Fixes race condition #301 where shared mutable namespace state in the ctr client caused containers to be mis-reported as Stopped.

**Root cause:** The old API used `SetNamespace(ns)` to set shared state, then methods like `ExistsContainer(id)` would use that namespace. But the reconcile loop continuously toggles namespace between realms, and if its `SetNamespace` lands between an RPC handler's `SetNamespace` and its `ExistsContainer`, the wrong namespace is queried.

**Fix:** Remove all mutable namespace state. Namespace is now passed as an explicit parameter:
- `ExistsContainer(namespace, id)` instead of `SetNamespace(ns); ExistsContainer(id)`
- `TaskStatus(namespace, id)` instead of `SetNamespace(ns); TaskStatus(id)`
- Same pattern for all container, task, and image operations

**Cache fix included:** The cache previously used bare container IDs as keys. Now uses `cacheKey(namespace, id) = \"namespace/id\"` to prevent cross-namespace cache pollution.

## API Changes

Removed from `ctr.Client`:
- `SetNamespace(namespace string)`
- `SetNamespaceWithCredentials(namespace string, creds []RegistryCredentials)`
- `Namespace() string`
- `GetRegistryCredentials() []RegistryCredentials`

Changed signatures (namespace added as first param):
- `CreateContainer(namespace string, spec ContainerSpec, creds []RegistryCredentials)`
- `GetContainer(namespace, id string)`
- `ListContainers(namespace string, filters ...string)`
- `ExistsContainer(namespace, id string)`
- `DeleteContainer(namespace, id string, opts ContainerDeleteOptions)`
- `StartContainer(namespace string, spec ContainerSpec, taskSpec TaskSpec)`
- `StopContainer(namespace, id string, opts StopContainerOptions)`
- `TaskStatus(namespace, id string)`
- `TaskMetrics(namespace, id string)`
- `CreateContainerFromSpec(namespace string, spec intmodel.ContainerSpec, creds []RegistryCredentials, opts ...BuildOption)`
- `LoadImage(namespace string, reader io.Reader)`
- `ListImages(namespace string)`
- `GetImage(namespace, ref string)`
- `DeleteImage(namespace, ref string)`
- `ResolveSbshCachePath(namespace, imageRef, baseRunPath string, creds []RegistryCredentials)`

## Test plan

- [x] All ctr package call sites updated to new API
- [x] All runner package call sites updated (22 files)
- [x] Test files updated to remove tests for removed methods
- [x] `go build ./...` — passed locally
- [x] `go test ./...` — passed locally (e2e tmp dir created first)
- [x] `make dev-init` — passed locally; daemon-parity tail shows both `kuke get realms` and `kuke get realms --no-daemon` printing the expected two-realm output (`default` / `kuke-system`, both Ready, cgroups `/kukeon/default` and `/kukeon/kuke-system`)

The changes are mechanical: namespace that was previously set via SetNamespace is now passed directly to each method call.

Closes #301