### PR TITLE
fix: derive cell state from non-root container tasks

### DIFF
--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -341,54 +341,82 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 // ReconcileCell is the daemon-side counterpart to RefreshCell. Where
 // RefreshCell derives cell.Status.State from cgroup existence alone (so
 // `kuke refresh` keeps its current shape), ReconcileCell additionally
-// considers the root container's task state — which is what flips a Ready
-// cell to Stopped when an operator runs `ctr task kill` outside of kukeon.
+// considers container task state — which is what flips a Ready cell to
+// Stopped when an operator runs `ctr task kill` outside of kukeon, or
+// when the cell's non-root workloads have all exited.
 //
-// State derivation:
+// State derivation (see deriveCellState):
 //   - cgroup check error or cgroup absent → Unknown
-//   - cgroup present, no root container in spec → Ready (cgroup-only cell)
-//   - cgroup present, root container task running/created/paused → Ready
-//   - cgroup present, root container missing in containerd or task
-//     stopped/unknown → Stopped
+//   - cgroup present, no non-root container in spec (kukeond-style or
+//     cgroup-only cell) → derived from the root container's task state
+//     (the legacy behavior; root *is* the workload here)
+//   - cgroup present, at least one non-root container in spec → derived
+//     from the union of non-root container task states (Ready if any
+//     non-root is active; Stopped if every non-root is Stopped/Failed/
+//     non-existent; Unknown if any non-root reads back Unknown — the
+//     defensive read-side check that pairs with #301)
 //
-// Container statuses are also re-populated so callers (and `kuke get cell`)
-// see up-to-date per-container state.
+// Container statuses are populated up front so the derivation reads
+// them straight from the snapshot instead of re-querying containerd
+// (and so `kuke get cell` sees the same per-container view the
+// reconciler decided on).
 //
-// AutoDelete: when Spec.AutoDelete is set and the freshly derived state is
-// Stopped or Failed, the reconciler kills + deletes the cell instead of
-// persisting the state transition. This subsumes the per-cell `kuke run
-// --rm` watcher (#161 unblocks the move): a single, restart-resilient
-// ticker is enough, no goroutine-per-cell, and an AutoDelete cell created
-// before a daemon restart still gets cleaned up on the next tick after
-// the daemon is back. Errors during kill/delete are returned to the
-// caller so the loop's per-pass `Errors` slice records them and the cell
-// is preserved for retry on the next tick (best-effort, like the watcher
-// it replaces).
+// Wind-down side-effects: when the derivation flips to Stopped/Failed
+// and the cell has at least one non-root container in spec and the
+// root container task is still running, the reconciler kills the cell
+// so the root container shell stops too. Two flavors:
+//
+//   - AutoDelete=true: autoDeleteCell runs (KillCell + DeleteCell) and
+//     the cell metadata is removed. Subsumes the per-cell
+//     `kuke run --rm` watcher.
+//   - AutoDelete=false: windDownCell runs (KillCell only). The cell
+//     metadata is preserved in Stopped state for the operator to
+//     `kuke delete` explicitly — a long-lived `sleep infinity` root
+//     does not get to hold the cell open after every workload has
+//     exited.
+//
+// Both flavors are gated by the ReadyObserved latch so an in-flight
+// CreateCell (cgroup created, non-root containers not yet registered
+// → derivation reads Stopped from "container does not exist") is not
+// reaped before it ever reached Ready.
+//
+// Errors during kill/delete are returned to the caller so the loop's
+// per-pass `Errors` slice records them and the cell is preserved for
+// retry on the next tick (best-effort, like the watcher it replaces).
 func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcome, error) {
 	originalStatus := cell.Status
-	newState := intmodel.CellStateUnknown
 
 	cgroupExists, cgroupErr := r.ExistsCgroup(cell)
-	switch {
-	case cgroupErr != nil:
+	if cgroupErr != nil {
 		r.logger.DebugContext(r.ctx, "failed to check cell cgroup",
 			"cell", cell.Metadata.Name, "error", cgroupErr)
-	case !cgroupExists:
-		newState = intmodel.CellStateUnknown
-	default:
-		newState = r.deriveCellStateFromRootContainer(cell)
 	}
 
+	// Populate container statuses up front so the non-root-driven
+	// derivation can read them from the snapshot. The root container
+	// path also benefits — populate already queried it, so a single
+	// pass of GetContainerState calls covers both the per-container
+	// status array and the cell-state derivation.
 	if err := r.populateCellContainerStatuses(&cell); err != nil {
 		r.logger.DebugContext(r.ctx, "populate container statuses failed",
 			"cell", cell.Metadata.Name, "error", err)
 	}
+
+	newState := intmodel.CellStateUnknown
+	if cgroupErr == nil && cgroupExists {
+		newState = r.deriveCellState(cell)
+	}
+
 	cell.Status.State = newState
 	cell.Status.ReadyObserved = latchReadyObserved(
 		originalStatus.ReadyObserved, originalStatus.State, newState)
 
 	if shouldAutoDeleteCell(cell.Spec.AutoDelete, newState, cell.Status.ReadyObserved) {
 		return r.autoDeleteCell(cell)
+	}
+
+	if shouldWindDownCell(cell, newState) {
+		return r.windDownCell(cell)
 	}
 
 	updated := false
@@ -408,6 +436,32 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 		}
 	}
 	return cell, ReconcileOutcome{Updated: updated}, nil
+}
+
+// windDownCell is the non-AutoDelete counterpart to autoDeleteCell:
+// when a cell's non-root workloads have all exited, kill the cell
+// (KillCell handles the root task plus CNI detach plus cleanup) so
+// the root container shell does not zombie. Cell metadata is left
+// in place — the operator runs `kuke delete cell` explicitly when
+// they are done with it. KillCell already populates and persists
+// container statuses, so the caller need not double-write metadata.
+//
+// KillCell is best-effort and idempotent (workload containers that
+// are already gone are no-ops); errors surface so the next reconcile
+// pass retries.
+func (r *Exec) windDownCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcome, error) {
+	r.logger.InfoContext(r.ctx, "reconcile: winding down cell after non-root workloads exited",
+		"cell", cell.Metadata.Name,
+		"realm", cell.Spec.RealmName,
+		"space", cell.Spec.SpaceName,
+		"stack", cell.Spec.StackName,
+		"state", cell.Status.State)
+
+	updatedCell, err := r.KillCell(cell)
+	if err != nil {
+		return cell, ReconcileOutcome{}, fmt.Errorf("wind-down: kill cell: %w", err)
+	}
+	return updatedCell, ReconcileOutcome{Updated: true}, nil
 }
 
 // autoDeleteCell runs the kill+delete sequence the per-cell watcher used
@@ -472,6 +526,61 @@ func shouldAutoDeleteCell(autoDelete bool, newState intmodel.CellState, readyObs
 	return autoDelete && cellStateAutoDeleteTriggers(newState) && readyObserved
 }
 
+// shouldWindDownCell decides whether the reconciler should kill the
+// cell (root container + leftover plumbing) because its non-root
+// workloads have all exited. Same trigger states + ReadyObserved gate
+// as shouldAutoDeleteCell, plus two extra preconditions:
+//
+//   - At least one non-root container in spec. Without this, the cell
+//     is kukeond-style — the root *is* the workload, and killing it
+//     because "the workload is gone" would be circular. Those cells
+//     stay in their derived state and the operator stops them
+//     explicitly via `kuke daemon stop` / `kuke daemon reset`.
+//   - The root container task is still running. Once the root is dead
+//     there is nothing to wind down; firing again would be a wasted
+//     KillCell on every subsequent tick. Read from the freshly
+//     populated container statuses so this check costs no extra
+//     containerd round-trip.
+func shouldWindDownCell(cell intmodel.Cell, newState intmodel.CellState) bool {
+	if !cellStateAutoDeleteTriggers(newState) || !cell.Status.ReadyObserved {
+		return false
+	}
+	if !hasNonRootContainerSpec(cell.Spec.Containers) {
+		return false
+	}
+	rootSpec := findRootContainerSpec(cell)
+	if rootSpec == nil {
+		return false
+	}
+	return rootContainerStillRunning(rootSpec.ID, cell.Status.Containers)
+}
+
+// rootContainerStillRunning answers the "is the root task still
+// alive" question by consulting the snapshot
+// populateCellContainerStatuses just wrote. Returns false when the
+// root status is missing (populate skipped or partial — be
+// conservative and don't fire the wind-down kill on incomplete
+// data).
+func rootContainerStillRunning(rootID string, statuses []intmodel.ContainerStatus) bool {
+	for i := range statuses {
+		if statuses[i].ID != rootID {
+			continue
+		}
+		switch statuses[i].State {
+		case intmodel.ContainerStateReady,
+			intmodel.ContainerStatePending,
+			intmodel.ContainerStatePaused,
+			intmodel.ContainerStatePausing:
+			return true
+		case intmodel.ContainerStateStopped,
+			intmodel.ContainerStateFailed,
+			intmodel.ContainerStateUnknown:
+			return false
+		}
+	}
+	return false
+}
+
 // markCellReady stamps a synchronous Ready transition: state and the
 // ReadyObserved latch must close together. Without the eager latch
 // close, a KillCell that races the first reconciler tick (e.g. `kuke
@@ -482,6 +591,100 @@ func shouldAutoDeleteCell(autoDelete bool, newState intmodel.CellState, readyObs
 func markCellReady(cell *intmodel.Cell) {
 	cell.Status.State = intmodel.CellStateReady
 	cell.Status.ReadyObserved = true
+}
+
+// deriveCellState dispatches between the two derivation strategies
+// the reconciler supports. See ReconcileCell's contract comment for
+// the full state-machine description.
+//
+// kukeond-style cells (kuke-system / kukeon / kukeon / kukeond) and
+// cgroup-only cells have no non-root container in spec, so they fall
+// through to the legacy root-only derivation — without that fallback
+// the kukeond cell would have no signal to derive its state from
+// (its root *is* the workload, and there are no non-root entries to
+// union over). User-workload cells with at least one non-root
+// container in spec take the new derivation, which makes the cell
+// follow its workloads' lifecycle: a long-lived `sleep infinity`
+// root no longer holds the cell open after every workload has
+// exited.
+func (r *Exec) deriveCellState(cell intmodel.Cell) intmodel.CellState {
+	if !hasNonRootContainerSpec(cell.Spec.Containers) {
+		return r.deriveCellStateFromRootContainer(cell)
+	}
+	return deriveCellStateFromNonRootContainerStatuses(cell.Spec.Containers, cell.Status.Containers)
+}
+
+// deriveCellStateFromNonRootContainerStatuses unions the non-root
+// container task states the populate pass just snapshotted. Pure
+// (no containerd I/O) so it is straightforward to test.
+//
+// The "any non-root reads back Unknown ⇒ cell Unknown" branch is the
+// defensive read-side check that pairs with #301 — a transient
+// containerd hiccup or namespace-race-induced misread on a workload
+// container must not flip the cell to Stopped and trigger the
+// wind-down KillCell. Wait for the next reconcile pass to settle.
+//
+// "Container does not exist in containerd" is mapped to
+// ContainerStateStopped by GetContainerState, so a non-root workload
+// that exited and was reaped naturally counts toward "all stopped"
+// here.
+func deriveCellStateFromNonRootContainerStatuses(
+	specs []intmodel.ContainerSpec,
+	statuses []intmodel.ContainerStatus,
+) intmodel.CellState {
+	nonRootIDs := make(map[string]struct{}, len(specs))
+	for i := range specs {
+		if !specs[i].Root {
+			nonRootIDs[specs[i].ID] = struct{}{}
+		}
+	}
+
+	seen := 0
+	anyActive := false
+	anyUnknown := false
+	for i := range statuses {
+		if _, ok := nonRootIDs[statuses[i].ID]; !ok {
+			continue
+		}
+		seen++
+		switch statuses[i].State {
+		case intmodel.ContainerStateReady,
+			intmodel.ContainerStatePending,
+			intmodel.ContainerStatePaused,
+			intmodel.ContainerStatePausing:
+			anyActive = true
+		case intmodel.ContainerStateUnknown:
+			anyUnknown = true
+		case intmodel.ContainerStateStopped, intmodel.ContainerStateFailed:
+			// terminal — does not contribute to active.
+		}
+	}
+
+	if seen < len(nonRootIDs) {
+		// populate skipped or didn't reach every non-root spec — be
+		// defensive and stay Unknown so a partial-populate failure
+		// can't reap a healthy cell.
+		return intmodel.CellStateUnknown
+	}
+	if anyActive {
+		return intmodel.CellStateReady
+	}
+	if anyUnknown {
+		return intmodel.CellStateUnknown
+	}
+	return intmodel.CellStateStopped
+}
+
+// hasNonRootContainerSpec reports whether the cell has at least one
+// non-root container in spec — i.e. whether the new union-of-non-root
+// derivation applies.
+func hasNonRootContainerSpec(specs []intmodel.ContainerSpec) bool {
+	for i := range specs {
+		if !specs[i].Root {
+			return true
+		}
+	}
+	return false
 }
 
 // deriveCellStateFromRootContainer resolves the cell's state from the root

--- a/internal/controller/runner/refresh_test.go
+++ b/internal/controller/runner/refresh_test.go
@@ -249,3 +249,360 @@ func TestShouldAutoDeleteCell(t *testing.T) {
 		})
 	}
 }
+
+// TestHasNonRootContainerSpec is the kukeond-fallback gate: cells with no
+// non-root container in spec (kuke-system / kukeon / kukeon / kukeond and
+// other supervised cells, or cgroup-only cells) must NOT take the new
+// non-root-driven derivation. The sentinel keeps that contract.
+func TestHasNonRootContainerSpec(t *testing.T) {
+	cases := []struct {
+		name  string
+		specs []intmodel.ContainerSpec
+		want  bool
+	}{
+		{name: "empty", specs: nil, want: false},
+		{
+			name:  "only_root",
+			specs: []intmodel.ContainerSpec{{ID: "kukeond", Root: true}},
+			want:  false,
+		},
+		{
+			name: "root_plus_workload",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work", Root: false},
+			},
+			want: true,
+		},
+		{
+			name:  "only_workload",
+			specs: []intmodel.ContainerSpec{{ID: "work", Root: false}},
+			want:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasNonRootContainerSpec(tc.specs); got != tc.want {
+				t.Errorf("hasNonRootContainerSpec(%+v) = %v, want %v", tc.specs, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDeriveCellStateFromNonRootContainerStatuses pins the union-of-non-root
+// derivation introduced for #302. Five invariants:
+//   - Any non-root in an active state ⇒ Ready (the cell is hosting work).
+//   - Every non-root in a terminal state (Stopped/Failed/non-existent which
+//     GetContainerState maps to Stopped) ⇒ Stopped (cell shell is no longer
+//     hosting any workload — the wind-down trigger).
+//   - Any non-root reading back Unknown blocks the Stopped derivation: a
+//     transient containerd hiccup or namespace-race misread (#301) on a
+//     workload container must not flip the cell to Stopped and reap a
+//     healthy host.
+//   - Root containers in cell.Status.Containers are ignored — the whole
+//     point of this derivation is that the root is no longer the lifecycle
+//     anchor for cells that have non-root workloads.
+//   - When populate skipped or didn't reach every non-root spec (seen <
+//     expected), the derivation stays Unknown rather than declaring
+//     Stopped on a partial snapshot.
+func TestDeriveCellStateFromNonRootContainerStatuses(t *testing.T) {
+	cases := []struct {
+		name     string
+		specs    []intmodel.ContainerSpec
+		statuses []intmodel.ContainerStatus
+		want     intmodel.CellState
+	}{
+		{
+			name: "any_active_workload_keeps_cell_ready",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work-a", Root: false},
+				{ID: "work-b", Root: false},
+			},
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work-a", State: intmodel.ContainerStateStopped},
+				{ID: "work-b", State: intmodel.ContainerStateReady},
+			},
+			want: intmodel.CellStateReady,
+		},
+		{
+			name: "all_workloads_stopped_winds_cell_to_stopped",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work-a", Root: false},
+				{ID: "work-b", Root: false},
+			},
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work-a", State: intmodel.ContainerStateStopped},
+				{ID: "work-b", State: intmodel.ContainerStateStopped},
+			},
+			want: intmodel.CellStateStopped,
+		},
+		{
+			name: "all_workloads_failed_also_stopped",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work", Root: false},
+			},
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work", State: intmodel.ContainerStateFailed},
+			},
+			want: intmodel.CellStateStopped,
+		},
+		{
+			name: "workload_reads_back_unknown_blocks_stopped_defensive_against_301",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work-a", Root: false},
+				{ID: "work-b", Root: false},
+			},
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work-a", State: intmodel.ContainerStateStopped},
+				{ID: "work-b", State: intmodel.ContainerStateUnknown},
+			},
+			want: intmodel.CellStateUnknown,
+		},
+		{
+			name: "running_root_is_ignored_when_workloads_are_all_stopped",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work", Root: false},
+			},
+			statuses: []intmodel.ContainerStatus{
+				// Root is still Ready (long-lived sleep infinity) — but
+				// the workload is gone. This is the headline #302 case:
+				// the long-lived root must NOT keep the cell open after
+				// every workload exited.
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work", State: intmodel.ContainerStateStopped},
+			},
+			want: intmodel.CellStateStopped,
+		},
+		{
+			name: "pending_workload_is_active",
+			specs: []intmodel.ContainerSpec{
+				{ID: "work", Root: false},
+			},
+			statuses: []intmodel.ContainerStatus{
+				{ID: "work", State: intmodel.ContainerStatePending},
+			},
+			want: intmodel.CellStateReady,
+		},
+		{
+			name: "paused_workload_is_active",
+			specs: []intmodel.ContainerSpec{
+				{ID: "work", Root: false},
+			},
+			statuses: []intmodel.ContainerStatus{
+				{ID: "work", State: intmodel.ContainerStatePaused},
+			},
+			want: intmodel.CellStateReady,
+		},
+		{
+			name: "missing_workload_status_is_treated_as_unknown_not_stopped",
+			specs: []intmodel.ContainerSpec{
+				{ID: "work-a", Root: false},
+				{ID: "work-b", Root: false},
+			},
+			// populate didn't write a status entry for work-b — defensive
+			// path: don't reap on a partial snapshot.
+			statuses: []intmodel.ContainerStatus{
+				{ID: "work-a", State: intmodel.ContainerStateStopped},
+			},
+			want: intmodel.CellStateUnknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveCellStateFromNonRootContainerStatuses(tc.specs, tc.statuses)
+			if got != tc.want {
+				t.Errorf("deriveCellStateFromNonRootContainerStatuses(...) = %v, want %v",
+					got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRootContainerStillRunning pins the snapshot read used by the
+// wind-down gate. The wind-down kill is a no-op on every subsequent
+// tick once the root task is dead, so this read is the cheap guard
+// that keeps shouldWindDownCell from firing again. Missing-status
+// reads false (the snapshot didn't see the root — be conservative
+// and skip the kill).
+func TestRootContainerStillRunning(t *testing.T) {
+	cases := []struct {
+		name     string
+		rootID   string
+		statuses []intmodel.ContainerStatus
+		want     bool
+	}{
+		{
+			name:   "ready_root_still_running",
+			rootID: "root",
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+			},
+			want: true,
+		},
+		{
+			name:   "pending_root_still_running",
+			rootID: "root",
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStatePending},
+			},
+			want: true,
+		},
+		{
+			name:   "paused_root_still_running",
+			rootID: "root",
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStatePaused},
+			},
+			want: true,
+		},
+		{
+			name:   "stopped_root_not_running",
+			rootID: "root",
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateStopped},
+			},
+			want: false,
+		},
+		{
+			name:   "failed_root_not_running",
+			rootID: "root",
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateFailed},
+			},
+			want: false,
+		},
+		{
+			name:   "unknown_root_not_running",
+			rootID: "root",
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateUnknown},
+			},
+			want: false,
+		},
+		{
+			name:     "missing_root_status_not_running",
+			rootID:   "root",
+			statuses: []intmodel.ContainerStatus{{ID: "work", State: intmodel.ContainerStateReady}},
+			want:     false,
+		},
+		{
+			name:     "empty_status_not_running",
+			rootID:   "root",
+			statuses: nil,
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rootContainerStillRunning(tc.rootID, tc.statuses); got != tc.want {
+				t.Errorf("rootContainerStillRunning(%q, %+v) = %v, want %v",
+					tc.rootID, tc.statuses, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestShouldWindDownCell pins the gate the reconciler uses to decide
+// whether to KillCell a non-AutoDelete cell whose workloads have all
+// exited. The gate must be:
+//   - Same trigger states (Stopped/Failed only) as shouldAutoDeleteCell.
+//   - ReadyObserved latch must be set (mirrors the CreateCell-protection
+//     behavior of shouldAutoDeleteCell — a cell that never reached
+//     Ready must not be reaped, regression #269).
+//   - hasNonRootContainerSpec must be true. This is the kukeond
+//     fallback: kukeond-style cells (root *is* the workload) keep
+//     their legacy lifecycle and the operator stops them via
+//     `kuke daemon stop`.
+//   - The root container task must still be running. Once the root is
+//     dead the kill becomes a wasted tick-after-tick KillCell call.
+func TestShouldWindDownCell(t *testing.T) {
+	rootRunningStatus := []intmodel.ContainerStatus{
+		{ID: "root", State: intmodel.ContainerStateReady},
+		{ID: "work", State: intmodel.ContainerStateStopped},
+	}
+	rootDeadStatus := []intmodel.ContainerStatus{
+		{ID: "root", State: intmodel.ContainerStateStopped},
+		{ID: "work", State: intmodel.ContainerStateStopped},
+	}
+	specsWithWork := []intmodel.ContainerSpec{
+		{ID: "root", Root: true},
+		{ID: "work", Root: false},
+	}
+	specsRootOnly := []intmodel.ContainerSpec{{ID: "root", Root: true}}
+
+	cell := func(specs []intmodel.ContainerSpec, statuses []intmodel.ContainerStatus, ready bool) intmodel.Cell {
+		return intmodel.Cell{
+			Spec: intmodel.CellSpec{Containers: specs},
+			Status: intmodel.CellStatus{
+				ReadyObserved: ready,
+				Containers:    statuses,
+			},
+		}
+	}
+
+	cases := []struct {
+		name     string
+		cell     intmodel.Cell
+		newState intmodel.CellState
+		want     bool
+	}{
+		{
+			name:     "fires_when_all_three_satisfied",
+			cell:     cell(specsWithWork, rootRunningStatus, true),
+			newState: intmodel.CellStateStopped,
+			want:     true,
+		},
+		{
+			name:     "fires_on_failed_state",
+			cell:     cell(specsWithWork, rootRunningStatus, true),
+			newState: intmodel.CellStateFailed,
+			want:     true,
+		},
+		{
+			name:     "blocked_when_state_not_trigger",
+			cell:     cell(specsWithWork, rootRunningStatus, true),
+			newState: intmodel.CellStateReady,
+			want:     false,
+		},
+		{
+			name:     "blocked_when_state_unknown",
+			cell:     cell(specsWithWork, rootRunningStatus, true),
+			newState: intmodel.CellStateUnknown,
+			want:     false,
+		},
+		{
+			name:     "blocked_when_never_ready",
+			cell:     cell(specsWithWork, rootRunningStatus, false),
+			newState: intmodel.CellStateStopped,
+			want:     false,
+		},
+		{
+			name:     "blocked_for_kukeond_style_cell_root_only",
+			cell:     cell(specsRootOnly, []intmodel.ContainerStatus{{ID: "root", State: intmodel.ContainerStateReady}}, true),
+			newState: intmodel.CellStateStopped,
+			want:     false,
+		},
+		{
+			name:     "blocked_when_root_already_dead_idempotency_guard",
+			cell:     cell(specsWithWork, rootDeadStatus, true),
+			newState: intmodel.CellStateStopped,
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldWindDownCell(tc.cell, tc.newState); got != tc.want {
+				t.Errorf("shouldWindDownCell(...) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #302. The reconciler's cell-state derivation now follows the cell's non-root workloads instead of just the root container, so a long-lived `sleep infinity` root no longer holds the cell open after every workload has exited (and `--rm` cleanup actually fires for those cells).

**Before:** `internal/controller/runner/refresh.go`'s `deriveCellStateFromRootContainer` was the sole input to cell state inside `ReconcileCell`. Stopping every non-root task in a cell that has a long-lived root left the cell stuck `Ready` indefinitely — root keeps running, autodelete never triggers, operator has to `kuke kill` manually.

**After:** `deriveCellState` dispatches:
- Cells with **no** non-root container in spec (kukeond-style supervised cells, cgroup-only cells) → fall through to the legacy root-only derivation. Confirmed by the `blocked_for_kukeond_style_cell_root_only` test case — the kukeond cell does not get unintended wind-down.
- Cells with **at least one** non-root container in spec → derive from the union of non-root container task states (Ready if any non-root is active; Stopped if every non-root is Stopped/Failed/non-existent; Unknown if any non-root reads back Unknown — defensive read-side check that pairs with the still-open #301).

When the new derivation flips Stopped/Failed and the root container task is still running:
- `AutoDelete=true` → existing `autoDeleteCell` path (`KillCell` + `DeleteCell`).
- `AutoDelete=false` → new `windDownCell` path (`KillCell` only — cell metadata preserved for explicit `kuke delete cell`, but the root container shell stops so it does not zombie).

Both flavors stay gated by the `ReadyObserved` latch (regression #269), so an in-flight `CreateCell` is never reaped before the cell ever reached Ready.

## Design notes called out in the issue's AC

- **`ReadyObserved` latch shape preserved.** No changes to `latchReadyObserved`; the new wind-down gate uses the same latch via `shouldWindDownCell`. Existing `TestLatchReadyObserved` and `TestAutoDeleteSurvivesKillCellRace` pass unchanged.
- **#301 interaction defensively handled.** `deriveCellStateFromNonRootContainerStatuses` returns `Unknown` (not `Stopped`) when any non-root status reads back `Unknown` — covered by `workload_reads_back_unknown_blocks_stopped_defensive_against_301`. Partial-populate snapshots (seen < expected) also stay Unknown via `missing_workload_status_is_treated_as_unknown_not_stopped`. The wind-down `KillCell` will not fire on a transient containerd hiccup or a #301-induced misread.
- **kukeond cell preserved.** `hasNonRootContainerSpec` is the dispatch gate; its `only_root` test case pins the kukeond fallback. The kukeond cell (`kuke-system / kukeon / kukeon / kukeond`) has only a root container in spec, so `deriveCellState` reduces to the existing `deriveCellStateFromRootContainer`. `shouldWindDownCell` also blocks on the same gate, so no wind-down `KillCell` for kukeond either.
- **Idempotency.** `shouldWindDownCell` consults `rootContainerStillRunning` against the freshly populated status snapshot, so once the root is dead the gate stops firing — no wasted `KillCell` per tick.

## Implementation notes the reviewer might push back on

- **Populate-then-derive ordering swap.** `populateCellContainerStatuses` now runs before state derivation (was after) so the non-root derivation can read from the snapshot instead of re-querying containerd N times. Net containerd round-trips are unchanged — the previous flow queried the root once for derivation plus once for populate; the new flow queries each non-root once for populate plus zero for derivation. Behavior parity for the kukeond fallback path: `deriveCellStateFromRootContainer` still queries the root directly (same as before), which means a redundant root query on that path; chose simplicity over a third specialization, since kukeond-style cells are the small fraction of host cells.
- **`windDownCell` calls `KillCell` (not a narrower "kill root only" helper).** `KillCell` already handles workload-container kills (idempotent — they are gone, this is the trigger condition), CNI detach, root container deletion, and final CNI cleanup. A targeted "kill root task only" would have to duplicate the CNI detach/cleanup logic to leave the cell sane. Reviewer can push back if a lighter-touch helper is preferred.
- **Pre-existing lints unchanged.** Two `golangci-lint` hits in `refresh.go` (the `updated := false` QF1007 and the `deriveCellStateFromRootContainer` switch's missing-`ContainerStateUnknown`-in-exhaustive-switch) are pre-existing on `main` — line numbers shifted but the lints are not introduced by this PR. CLAUDE.md "no unrelated cleanups in feature PRs" applies.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test $(go list ./... | grep -v /e2e)` — full unit-test suite passes (matches `make test`). New tests in `internal/controller/runner/refresh_test.go`:
  - `TestHasNonRootContainerSpec` — pins the kukeond-fallback dispatch gate (empty / only root / root+work / only work).
  - `TestDeriveCellStateFromNonRootContainerStatuses` — pins the union-of-non-root derivation, with the headline #302 case (`running_root_is_ignored_when_workloads_are_all_stopped`) plus #301-defense and partial-populate-defense cases.
  - `TestRootContainerStillRunning` — pins the snapshot read used by the wind-down gate so the kill is idempotent across ticks.
  - `TestShouldWindDownCell` — pins the four-condition gate (trigger state, ReadyObserved, hasNonRoot, root-still-running), with the kukeond fallback and idempotency cases.
- [x] `golangci-lint run ./internal/controller/runner/` — only pre-existing lints (see implementation notes); no new lints introduced.
- [x] `make dev-init` smoke test — re-run on the updated dev sandbox after dependencies + cgroup + overlay constraints were lifted. Daemon-parity tail produced the expected output (both `kuke get realms` and `kuke get realms --no-daemon` match):
  ```
  default      default.kukeon.io      Ready  /kukeon/default
  kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
  ```
  Bonus end-to-end check (the issue's headline repro) deferred to reviewer's environment — not on the original AC checklist; the daemon-parity guard above is the regression check CLAUDE.md mandates.

Closes #302
