### PR TITLE
fix: wire cell cgroup path through container OCI spec

### DIFF
--- a/e2e/e2e_kuke_cell_test.go
+++ b/e2e/e2e_kuke_cell_test.go
@@ -206,6 +206,18 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 	if !verifyRootContainerTaskExists(t, realmNamespace, rootContainerID) {
 		t.Fatalf("root container task %q not found in containerd namespace %q", rootContainerID, realmNamespace)
 	}
+
+	// Step 12: Verify the root container task PID lands in the cell cgroup,
+	// not the runc-shim default placement under the containerd namespace
+	// cgroup. This is the regression check for issue #312 — without the
+	// Linux.CgroupsPath wiring, <cell>/<containerd-id>/cgroup.procs is
+	// missing and cell-level resource accounting is impossible.
+	if !verifyContainerTaskInCellCgroup(t, cell.Status.CgroupPath, rootContainerID) {
+		t.Fatalf(
+			"root container task %q not found under cell cgroup %q (issue #312)",
+			rootContainerID, cell.Status.CgroupPath,
+		)
+	}
 }
 
 // TestKuke_DeleteCell_VerifyState tests cell deletion with state-based verification.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -243,6 +243,39 @@ func verifyContainerdNamespace(t *testing.T, namespace string) bool {
 	return strings.Contains(output, namespace)
 }
 
+// verifyContainerTaskInCellCgroup checks that a container's task cgroup is
+// nested under its cell cgroup and contains at least one PID. The on-disk
+// expectation is <mountpoint>/<cellGroup>/<containerdID>/cgroup.procs with a
+// non-empty body — i.e. runc honored Linux.CgroupsPath set by
+// BuildContainerSpec from cell.Status.CgroupPath. Issue #312: without that
+// wiring, the per-task cgroup is created elsewhere (under the containerd
+// namespace cgroup) and the path checked here doesn't exist.
+func verifyContainerTaskInCellCgroup(t *testing.T, cellGroup, containerdID string) bool {
+	t.Helper()
+
+	if cellGroup == "" || containerdID == "" {
+		return false
+	}
+
+	mountpoint := consts.CgroupFilesystemPath
+	relativeCell := strings.TrimPrefix(cellGroup, "/")
+	taskCgroup := filepath.Join(mountpoint, relativeCell, containerdID)
+
+	procsPath := filepath.Join(taskCgroup, "cgroup.procs")
+	data, err := os.ReadFile(procsPath)
+	if err != nil {
+		t.Logf("read %s: %v", procsPath, err)
+		return false
+	}
+	pids := strings.Fields(string(data))
+	if len(pids) == 0 {
+		t.Logf("cell-rooted task cgroup %s exists but cgroup.procs is empty", taskCgroup)
+		return false
+	}
+	t.Logf("verified container task PIDs %v under cell cgroup %s", pids, taskCgroup)
+	return true
+}
+
 // verifyCgroupPathExists verifies cgroup path exists in filesystem.
 func verifyCgroupPathExists(t *testing.T, cgroupPath string) bool {
 	t.Helper()

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1067,6 +1067,15 @@ func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, error) {
 		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateCellCgroup, createErr)
 	}
 
+	// Enable the cell-level resource controllers in the cgroup tree before
+	// any container task lands inside the cell. Without this, container
+	// task cgroups nested under <cell>/<containerd-id> have no controllers
+	// available and cell-level UpdateCgroup limits are decorative — exactly
+	// what issue #312 reports.
+	if subtreeErr := r.ctrClient.EnableCellSubtreeControllers(spec.Group, spec.Mountpoint, cellResourceControllers()); subtreeErr != nil {
+		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateCellCgroup, subtreeErr)
+	}
+
 	r.logger.InfoContext(
 		r.ctx,
 		"created cell cgroup",
@@ -1076,6 +1085,15 @@ func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, error) {
 		cgroupPath,
 	)
 	return cgroupPath, nil
+}
+
+// cellResourceControllers names the cgroup-v2 controllers kukeon enables on a
+// cell's subtree so per-container cgroups inherit them and UpdateCgroup at
+// the cell level becomes effective. The set is filtered against the host
+// root's cgroup.controllers at apply time, so passing a controller missing
+// from a particular kernel build (e.g. "io" without blk-cgroup) is safe.
+func cellResourceControllers() []string {
+	return []string{"cpu", "memory", "io", "pids"}
 }
 
 func (r *Exec) ensureCellCgroup(cell intmodel.Cell) (intmodel.Cell, error) {
@@ -1130,6 +1148,15 @@ func (r *Exec) ensureCellCgroup(cell intmodel.Cell) (intmodel.Cell, error) {
 	if cellDoc.Status.CgroupPath != "" {
 		if err := r.UpdateCellMetadata(cell); err != nil {
 			return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, err)
+		}
+		// Idempotent re-toggle of cell subtree controllers after every
+		// ensure-pass — covers daemon restart against pre-existing cells
+		// provisioned before issue #312 was fixed (and is a no-op on
+		// already-enabled subtrees).
+		if subtreeErr := r.ctrClient.EnableCellSubtreeControllers(cellDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint(), cellResourceControllers()); subtreeErr != nil {
+			r.logger.WarnContext(r.ctx,
+				"failed to enable cell subtree controllers on ensure-path",
+				"cell", cell.Metadata.Name, "error", subtreeErr)
 		}
 	}
 
@@ -1240,6 +1267,12 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		cell.Spec.RootContainerID = rootContainerBaseID
 	}
 
+	// Cell-rooted cgroup placement for every container task. cell.Status.CgroupPath
+	// is populated by createCellCgroup before this runs (and preserved through
+	// recreate paths via desired.Status.CgroupPath = existing.Status.CgroupPath),
+	// so it's safe to read here. See issue #312.
+	cellCgroupPath := cell.Status.CgroupPath
+
 	// Track root container for return value
 	var rootContainer containerd.Container
 
@@ -1265,6 +1298,9 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		}
 		if containerSpec.CNIConfigPath == "" {
 			containerSpec.CNIConfigPath = cniConfigPath
+		}
+		if containerSpec.CellCgroupPath == "" {
+			containerSpec.CellCgroupPath = cellCgroupPath
 		}
 		cell.Spec.Containers[i] = containerSpec
 
@@ -1516,6 +1552,13 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 			return nil, err
 		}
 
+		// Cell-rooted cgroup placement for the root container task (issue
+		// #312). Mirrors the wiring in createCellContainers and the regular-
+		// container loop below.
+		if rootContainerSpec.CellCgroupPath == "" {
+			rootContainerSpec.CellCgroupPath = cell.Status.CgroupPath
+		}
+
 		// Determine root container ID for RootContainerID field (use base name from ID field)
 		rootContainerBaseID := rootContainerSpec.ID
 
@@ -1636,6 +1679,13 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		}
 		if containerSpec.StackName == "" {
 			containerSpec.StackName = stackName
+		}
+		// Cell-rooted cgroup placement (issue #312). Mirrors the equivalent
+		// fill-in for createCellContainers; only takes effect when the cell
+		// has been provisioned and its Status.CgroupPath is populated.
+		if containerSpec.CellCgroupPath == "" {
+			containerSpec.CellCgroupPath = cell.Status.CgroupPath
+			cell.Spec.Containers[i] = containerSpec
 		}
 
 		// Build containerd ID using hierarchical format for containerd operations

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -318,6 +318,15 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to get root container spec: %w", err)
 	}
 
+	// CellCgroupPath is a runtime-only injection (not persisted with the cell
+	// document), so every BuildContainerSpec/BuildRootContainerSpec call site
+	// must populate it from cell.Status.CgroupPath right before the build —
+	// otherwise the destructive recreate done by StartCell here resets the
+	// container's OCI Linux.CgroupsPath to the runc-shim default. Issue #312.
+	if rootContainerSpec.CellCgroupPath == "" {
+		rootContainerSpec.CellCgroupPath = internalCell.Status.CgroupPath
+	}
+
 	rootLabels := buildRootContainerLabels(internalCell)
 	ctrContainerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
 
@@ -572,6 +581,12 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 			)
 		}
 
+		// CellCgroupPath: runtime-only injection — see the comment at the
+		// root-container recreate above. Issue #312.
+		if containerSpec.CellCgroupPath == "" {
+			containerSpec.CellCgroupPath = internalCell.Status.CgroupPath
+		}
+
 		// Recreate container fresh
 		attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds)
 		if attachErr != nil {
@@ -799,6 +814,12 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 			"failed to delete existing container, continuing with recreation",
 			fields...,
 		)
+	}
+
+	// CellCgroupPath: runtime-only injection — fill from cell.Status.CgroupPath
+	// so the recreated container task lands under <cell>/<id>. Issue #312.
+	if foundContainerSpec.CellCgroupPath == "" {
+		foundContainerSpec.CellCgroupPath = cell.Status.CgroupPath
 	}
 
 	// Recreate container fresh

--- a/internal/ctr/cgroups.go
+++ b/internal/ctr/cgroups.go
@@ -19,6 +19,7 @@ package ctr
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,6 +129,93 @@ func (c *client) AddProcessToCgroup(group, mountpoint string, pid int) error {
 		return err
 	}
 	return manager.AddProc(uint64(pid))
+}
+
+// EnableCellSubtreeControllers writes "+<ctrl>" to every ancestor's
+// cgroup.subtree_control file (root → cell parent) AND to the cell's own
+// cgroup.subtree_control. The library's Manager.ToggleControllers handles the
+// ancestor walk by design but skips the cell itself ("the leaf does not need
+// it") — for kukeon the cell is *not* a leaf, since runc nests per-container
+// task cgroups under it (issue #312), so the cell's own subtree_control must
+// also be populated for those children to inherit the controllers.
+//
+// Filters the requested set against what the host root cgroup advertises so
+// callers can pass the desired superset without worrying about kernel
+// configuration variance (e.g. the io controller is missing on hosts without
+// blk-cgroup compiled in).
+func (c *client) EnableCellSubtreeControllers(group, mountpoint string, controllers []string) error {
+	if err := validateGroupPath(group); err != nil {
+		return err
+	}
+	if len(controllers) == 0 {
+		return nil
+	}
+
+	mp := c.effectiveMountpoint(mountpoint)
+	available, err := readRootControllers(mp)
+	if err != nil {
+		return fmt.Errorf("read root cgroup.controllers: %w", err)
+	}
+	enable := intersectControllers(controllers, available)
+	if len(enable) == 0 {
+		return nil
+	}
+
+	manager, err := c.managerFor(group, mp)
+	if err != nil {
+		return err
+	}
+	if toggleErr := manager.ToggleControllers(enable, cgroup2.Enable); toggleErr != nil {
+		return fmt.Errorf("enable controllers in cell ancestors: %w", toggleErr)
+	}
+
+	cellPath := filepath.Join(mp, strings.TrimPrefix(group, "/"))
+	if writeErr := writeSubtreeEnable(filepath.Join(cellPath, "cgroup.subtree_control"), enable); writeErr != nil {
+		return fmt.Errorf("enable controllers in cell subtree_control: %w", writeErr)
+	}
+
+	c.logger.InfoContext(c.ctx, "enabled cell cgroup controllers",
+		"group", group, "mountpoint", mp, "controllers", enable)
+	return nil
+}
+
+func readRootControllers(mountpoint string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(mountpoint, "cgroup.controllers"))
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(string(data)), nil
+}
+
+func intersectControllers(want, have []string) []string {
+	haveSet := make(map[string]struct{}, len(have))
+	for _, h := range have {
+		haveSet[h] = struct{}{}
+	}
+	out := make([]string, 0, len(want))
+	for _, w := range want {
+		if _, ok := haveSet[w]; ok {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func writeSubtreeEnable(path string, controllers []string) error {
+	parts := make([]string, len(controllers))
+	for i, c := range controllers {
+		parts[i] = "+" + c
+	}
+	// Mirror cgroup2.Manager.writeSubtreeControl: O_WRONLY without O_TRUNC.
+	// cgroupfs files don't honor truncation; the write itself is interpreted
+	// additively (kernel applies "+cpu -io" line-by-line).
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(strings.Join(parts, " "))
+	return err
 }
 
 // DeleteCgroup removes the cgroup. It will fail if processes are still attached.

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -62,6 +62,13 @@ type Client interface {
 	NewCgroup(spec CgroupSpec) (*cgroup2.Manager, error)
 	LoadCgroup(group string, mountpoint string) (*cgroup2.Manager, error)
 	DeleteCgroup(group, mountpoint string) error
+	// EnableCellSubtreeControllers enables the named cgroup-v2 controllers in
+	// the cell cgroup's own subtree_control AND in every ancestor's
+	// subtree_control up to the unified cgroup mount, so child cgroups (the
+	// per-container task cgroups runc creates under Linux.CgroupsPath)
+	// inherit the controllers and cell-level resource accounting / limits
+	// become effective. Issue #312.
+	EnableCellSubtreeControllers(group, mountpoint string, controllers []string) error
 	CreateContainerFromSpec(namespace string, spec intmodel.ContainerSpec, creds []RegistryCredentials, opts ...BuildOption) (containerd.Container, error)
 
 	CreateContainer(namespace string, spec ContainerSpec, creds []RegistryCredentials) (containerd.Container, error)

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -136,6 +136,13 @@ func BuildRootContainerSpec(
 		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
 
+	// Linux.CgroupsPath: same cell-rooted placement as BuildContainerSpec so
+	// the root container task lands inside the cell's cgroup subtree rather
+	// than the runc-shim default (issue #312).
+	if cgPath := cellCgroupsPath(rootSpec.CellCgroupPath, containerdID); cgPath != "" {
+		specOpts = append(specOpts, oci.WithCgroup(cgPath))
+	}
+
 	specOpts = append(specOpts, securitySpecOpts(rootSpec)...)
 
 	rootLabels := copyLabels(labels)

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -290,6 +291,15 @@ func BuildContainerSpec(
 		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
 
+	// Linux.CgroupsPath: place the container task inside the cell's cgroup
+	// subtree so cell-level resource accounting and limits actually constrain
+	// it. Without this, containerd's runc-shim default places the task under
+	// /<containerd-namespace>/<id>/, leaving the kukeon cgroup hierarchy
+	// decorative (issue #312).
+	if cgPath := cellCgroupsPath(containerSpec.CellCgroupPath, containerdID); cgPath != "" {
+		specOpts = append(specOpts, oci.WithCgroup(cgPath))
+	}
+
 	specOpts = append(specOpts, securitySpecOpts(containerSpec)...)
 
 	// Attachable wrapping is appended last so the args-wrap runs after any
@@ -310,6 +320,18 @@ func BuildContainerSpec(
 		SpecOpts:      specOpts,
 		CNIConfigPath: containerSpec.CNIConfigPath,
 	}
+}
+
+// cellCgroupsPath returns the absolute OCI Linux.CgroupsPath for a container
+// nested under its cell's cgroup, or "" when either the cell cgroup path or
+// the containerd id is missing (in which case the runc-shim default placement
+// applies). The returned path is absolute so runc treats it as a path under
+// the unified cgroup mount rather than as a systemd slice triple.
+func cellCgroupsPath(cellCgroupPath, containerdID string) string {
+	if cellCgroupPath == "" || containerdID == "" {
+		return ""
+	}
+	return filepath.Join(cellCgroupPath, containerdID)
 }
 
 // buildBindMounts translates ContainerSpec.Volumes into OCI bind mounts.

--- a/internal/ctr/spec_test.go
+++ b/internal/ctr/spec_test.go
@@ -726,6 +726,125 @@ func TestBuildRootContainerSpec_HostCgroup(t *testing.T) {
 	}
 }
 
+// TestBuildContainerSpec_CgroupsPath verifies that BuildContainerSpec emits an
+// OCI Linux.CgroupsPath rooted at <CellCgroupPath>/<containerd-id> when the
+// caller plumbs a non-empty cell cgroup path through the model spec, and
+// leaves it untouched (runc-shim default placement) otherwise. Issue #312:
+// without this, container task cgroups land outside the kukeon cgroup tree
+// and cell-level resource accounting is impossible.
+func TestBuildContainerSpec_CgroupsPath(t *testing.T) {
+	tests := []struct {
+		name           string
+		cellCgroupPath string
+		containerdID   string
+		fallbackID     string
+		wantCgroups    string
+	}{
+		{
+			name:           "cell cgroup path joins containerd id",
+			cellCgroupPath: "/kukeon/r/s/st/c",
+			containerdID:   "s_st_c_app",
+			wantCgroups:    "/kukeon/r/s/st/c/s_st_c_app",
+		},
+		{
+			name:           "cell cgroup path falls back to base id when containerd id empty",
+			cellCgroupPath: "/kukeon/r/s/st/c",
+			fallbackID:     "app",
+			wantCgroups:    "/kukeon/r/s/st/c/app",
+		},
+		{
+			name:        "no cell cgroup path leaves cgroups path untouched",
+			fallbackID:  "app",
+			wantCgroups: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ctr.BuildContainerSpec(intmodel.ContainerSpec{
+				ID:             tt.fallbackID,
+				ContainerdID:   tt.containerdID,
+				Image:          "registry.eminwux.com/busybox:latest",
+				CellCgroupPath: tt.cellCgroupPath,
+				CellName:       "c", SpaceName: "s", RealmName: "r", StackName: "st",
+			})
+
+			ociSpec := &runtimespec.Spec{
+				Process: &runtimespec.Process{},
+				Linux:   &runtimespec.Linux{},
+			}
+			for _, opt := range spec.SpecOpts {
+				if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+					t.Fatalf("apply SpecOpts: %v", err)
+				}
+			}
+
+			if ociSpec.Linux.CgroupsPath != tt.wantCgroups {
+				t.Errorf("Linux.CgroupsPath = %q, want %q",
+					ociSpec.Linux.CgroupsPath, tt.wantCgroups)
+			}
+		})
+	}
+}
+
+// TestBuildRootContainerSpec_CgroupsPath mirrors
+// TestBuildContainerSpec_CgroupsPath for the root-container builder. The
+// root container is the cell's first task and must land under the cell
+// cgroup just like the regular containers do.
+func TestBuildRootContainerSpec_CgroupsPath(t *testing.T) {
+	tests := []struct {
+		name           string
+		cellCgroupPath string
+		containerdID   string
+		fallbackID     string
+		wantCgroups    string
+	}{
+		{
+			name:           "cell cgroup path joins containerd id",
+			cellCgroupPath: "/kukeon/r/s/st/c",
+			containerdID:   "s_st_c_root",
+			wantCgroups:    "/kukeon/r/s/st/c/s_st_c_root",
+		},
+		{
+			name:           "cell cgroup path falls back to base id when containerd id empty",
+			cellCgroupPath: "/kukeon/r/s/st/c",
+			fallbackID:     "root",
+			wantCgroups:    "/kukeon/r/s/st/c/root",
+		},
+		{
+			name:         "no cell cgroup path leaves cgroups path untouched",
+			containerdID: "s_st_c_root",
+			wantCgroups:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ctr.BuildRootContainerSpec(intmodel.ContainerSpec{
+				ID:             tt.fallbackID,
+				ContainerdID:   tt.containerdID,
+				Image:          "registry.eminwux.com/busybox:latest",
+				CellCgroupPath: tt.cellCgroupPath,
+			}, nil)
+
+			ociSpec := &runtimespec.Spec{
+				Process: &runtimespec.Process{},
+				Linux:   &runtimespec.Linux{},
+			}
+			for _, opt := range spec.SpecOpts {
+				if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+					t.Fatalf("apply SpecOpts: %v", err)
+				}
+			}
+
+			if ociSpec.Linux.CgroupsPath != tt.wantCgroups {
+				t.Errorf("Linux.CgroupsPath = %q, want %q",
+					ociSpec.Linux.CgroupsPath, tt.wantCgroups)
+			}
+		})
+	}
+}
+
 // TestBuildRootContainerSpec_HostNetwork is the same assertion as
 // TestBuildContainerSpec_HostNetwork but for the root-container builder used
 // by the runner for the kukeond cell.

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -61,6 +61,13 @@ type ContainerSpec struct {
 	RestartPolicy          string
 	Attachable             bool
 	Tty                    *ContainerTty
+	// CellCgroupPath is the absolute cgroup path of the parent cell (mirrors
+	// Cell.Status.CgroupPath). When set, BuildContainerSpec emits an OCI
+	// Linux.CgroupsPath rooted at <CellCgroupPath>/<containerd-id> so the
+	// container task lands inside the cell's cgroup subtree instead of
+	// containerd's runc-shim default placement. Populated by the runner at
+	// container-create time; not part of the persisted cell document.
+	CellCgroupPath string
 }
 
 // ContainerTty mirrors the v1beta1 ContainerTty payload. See the v1beta1


### PR DESCRIPTION
## Summary

- Adds `CellCgroupPath` to `intmodel.ContainerSpec` (runtime-only) and emits `Linux.CgroupsPath = <CellCgroupPath>/<containerd-id>` from both `BuildContainerSpec` and `BuildRootContainerSpec`, so container task cgroups land *under* the cell cgroup instead of the runc-shim default (`/<containerd-namespace>/<id>`).
- Wires `cell.Status.CgroupPath` into every BuildContainerSpec / BuildRootContainerSpec call site: `provisionNewCell`, `EnsureCell`, `StartCell`, `StartContainer`. Two-pass init (`createCellContainers` + later `StartCell` destructive recreate) means both code paths must populate the field; missing the start.go sites was the silent regression caught by the smoke test.
- Enables `cpu`/`memory`/`io`/`pids` controllers on the cell's own `cgroup.subtree_control` during `createCellCgroup` (and warn-only in `ensureCellCgroup`). The `containerd/cgroups` v2 library's `ToggleControllers` walks ancestors but skips the leaf — for kukeon the cell is *not* a leaf because runc nests per-container cgroups beneath it, so the cell's own subtree_control must also be populated. Filters the requested set against root `cgroup.controllers` so callers can pass the desired superset without minding kernel-config variance.
- Adds new `Client.EnableCellSubtreeControllers(group, mountpoint, controllers)` interface method + `client` impl in `internal/ctr/cgroups.go`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full unit-test suite green, including new `TestBuildContainerSpec_CgroupsPath` and `TestBuildRootContainerSpec_CgroupsPath` cases in `internal/ctr/spec_test.go`.
- [x] `pre-commit run` on the changed file set — gofmt, go-mod-tidy, golangci-lint, addlicense all pass.
- [x] `make dev-init` smoke — daemon-parity check passes; `sudo ctr -n kuke-system.kukeon.io container info kukeon_kukeon_kukeond_kukeond` now reports `Spec.linux.cgroupsPath = /kukeon/kuke-system/kukeon/kukeon/kukeond/kukeon_kukeon_kukeond_kukeond` (was `/kuke-system.kukeon.io/kukeon_kukeon_kukeond_kukeond` — the runc-shim default). `/sys/fs/cgroup/kukeon/kuke-system/kukeon/kukeon/kukeond/` now contains the expected child cgroup directory and full controller files (cpu.*, memory.*, io.*, pids.*).
- [ ] Extended e2e `TestKuke_CreateCell_VerifyState` (Step 12 + helper `verifyContainerTaskInCellCgroup` in `e2e/e2e_test.go`) — not run on this host; reviewer to run the e2e suite in the standard environment.

Closes #312