### PR TITLE
fix: mount cgroup2 inside NestedCgroupRuntime cells

### DIFF
--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1450,6 +1450,15 @@ func (r *Exec) applyCellContainerDefaults(cell *intmodel.Cell) error {
 	}
 	for i := range cell.Spec.Containers {
 		intmodel.ApplySpaceDefaultsToContainer(parentSpace, &cell.Spec.Containers[i])
+		// Propagate the cell-level NestedCgroupRuntime opt-in (#314) to
+		// every container so BuildContainerSpec can pair the private
+		// cgroup-ns with a /sys/fs/cgroup mount over the delegated
+		// subtree (#322). The flag is a per-cell decision because the
+		// host-side subtree-controller delegation in
+		// EnableCellAllSubtreeControllers is itself per-cell — a
+		// container cannot opt out individually without breaking the
+		// inner runtime that #318 enabled.
+		cell.Spec.Containers[i].NestedCgroupRuntime = cell.Spec.NestedCgroupRuntime
 	}
 	return nil
 }
@@ -1983,6 +1992,15 @@ func (r *Exec) ensureCellRootContainerSpec(cell intmodel.Cell) (intmodel.Contain
 		// (issue #96) so the daemon's CNI/iptables work lands in host scope.
 		rootSpec.HostNetwork = cellWantsHostNetworkRoot(cell)
 	}
+
+	// Propagate NestedCgroupRuntime from the cell to the root spec so a
+	// user-supplied or default-generated root container in a
+	// NestedCgroupRuntime cell gets the same /sys/fs/cgroup wiring as
+	// the rest of the cell's containers (#322). Mirrors the
+	// applyCellContainerDefaults loop for non-root containers; needed
+	// here because DefaultRootContainerSpec returns a freshly built
+	// spec that never passes through that loop.
+	rootSpec.NestedCgroupRuntime = cell.Spec.NestedCgroupRuntime
 
 	// Ensure required fields are set
 	rootSpec.Root = true

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -587,6 +587,17 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 			containerSpec.CellCgroupPath = internalCell.Status.CgroupPath
 		}
 
+		// NestedCgroupRuntime: runtime-only injection — same shape as
+		// CellCgroupPath. The per-container field is not persisted (see
+		// modelhub.ContainerSpec.NestedCgroupRuntime contract), so the
+		// reload-via-GetCell that StartCell does above strips the value
+		// that applyCellContainerDefaults set at create time. Repopulate
+		// from cell.Spec.NestedCgroupRuntime here, otherwise
+		// BuildContainerSpec skips the cgroup2 mount on the destructive
+		// recreate and #322 re-emerges for non-root containers after a
+		// daemon restart.
+		containerSpec.NestedCgroupRuntime = internalCell.Spec.NestedCgroupRuntime
+
 		// Recreate container fresh
 		attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds)
 		if attachErr != nil {
@@ -821,6 +832,13 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 	if foundContainerSpec.CellCgroupPath == "" {
 		foundContainerSpec.CellCgroupPath = cell.Status.CgroupPath
 	}
+
+	// NestedCgroupRuntime: runtime-only injection — see the matching block
+	// in StartCell. The per-container field is not persisted, so a cell
+	// loaded post-restart drops the value that applyCellContainerDefaults
+	// set at create time; repopulate from cell.Spec.NestedCgroupRuntime
+	// before BuildContainerSpec runs in the destructive recreate below.
+	foundContainerSpec.NestedCgroupRuntime = cell.Spec.NestedCgroupRuntime
 
 	// Recreate container fresh
 	attachOpts, attachErr := r.attachableBuildOpts(namespace, *foundContainerSpec, creds)

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -128,6 +128,16 @@ func BuildRootContainerSpec(
 		}))
 	}
 
+	// NestedCgroupRuntime mount: mirrors the BuildContainerSpec path so a
+	// non-default root container in a NestedCgroupRuntime cell still gets
+	// /sys/fs/cgroup populated from its delegated subtree (issue #322). The
+	// kukeond cell's own root sets HostCgroup=true and is exempted by the
+	// guard; the daemon already gets cgroup2 visibility via the bootstrap
+	// bind-mount path in internal/controller/bootstrap.go.
+	if rootSpec.NestedCgroupRuntime && !rootSpec.HostCgroup {
+		specOpts = append(specOpts, oci.WithMounts([]runtimespec.Mount{nestedCgroupMount()}))
+	}
+
 	// Bind mounts and security/isolation fields share the same translators as
 	// BuildContainerSpec so a user-supplied root container (RootContainerID)
 	// keeps its Volumes, User, Capabilities, SecurityOpts, Tmpfs, and

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -287,6 +287,19 @@ func BuildContainerSpec(
 		}))
 	}
 
+	// NestedCgroupRuntime: pair the private cgroup-ns with a cgroup2 mount
+	// so an inner runtime (dockerd, podman, an inner containerd, systemd)
+	// can read the controller list that #318's EnableCellAllSubtreeControllers
+	// just delegated host-side. Without this, /sys/fs/cgroup is an empty
+	// mountpoint inside the cell and dockerd's "Devices cgroup isn't
+	// mounted" probe aborts (issue #322). Gated on !HostCgroup because a
+	// HostCgroup cell already shares the host's cgroup hierarchy through
+	// kukeond's own bind-mount path; emitting a private cgroup mount on
+	// top would shadow it.
+	if containerSpec.NestedCgroupRuntime && !containerSpec.HostCgroup {
+		specOpts = append(specOpts, oci.WithMounts([]runtimespec.Mount{nestedCgroupMount()}))
+	}
+
 	if mounts := buildBindMounts(containerSpec.Volumes); len(mounts) > 0 {
 		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
@@ -319,6 +332,21 @@ func BuildContainerSpec(
 		Labels:        labels,
 		SpecOpts:      specOpts,
 		CNIConfigPath: containerSpec.CNIConfigPath,
+	}
+}
+
+// nestedCgroupMount returns the OCI Mount entry that exposes the cell's
+// delegated cgroup2 subtree at /sys/fs/cgroup inside the container. runc
+// resolves a Type:"cgroup" entry under a private cgroup-ns to the calling
+// process's cgroup root, which is exactly the scope #318's host-side
+// subtree-controller delegation prepared. Options match what systemd and
+// dockerd write for cgroup2 mounts.
+func nestedCgroupMount() runtimespec.Mount {
+	return runtimespec.Mount{
+		Destination: "/sys/fs/cgroup",
+		Source:      "cgroup",
+		Type:        "cgroup",
+		Options:     []string{"rw", "nosuid", "noexec", "nodev"},
 	}
 }
 

--- a/internal/ctr/spec_test.go
+++ b/internal/ctr/spec_test.go
@@ -18,6 +18,7 @@ package ctr_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -724,6 +725,173 @@ func TestBuildRootContainerSpec_HostCgroup(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildContainerSpec_NestedCgroupRuntimeMount asserts that
+// BuildContainerSpec emits the cgroup2 mount at /sys/fs/cgroup exactly when
+// NestedCgroupRuntime is set and HostCgroup is not — pairing the in-cell
+// mount with the host-side subtree-controller delegation #318 added. Without
+// this, an inner runtime (dockerd, podman) inside a NestedCgroupRuntime cell
+// sees /sys/fs/cgroup as an empty mountpoint and aborts (#322). The unset
+// and HostCgroup-true cases must leave the mount list byte-identical to the
+// pre-#322 output so cells that don't opt in keep their existing OCI spec.
+func TestBuildContainerSpec_NestedCgroupRuntimeMount(t *testing.T) {
+	tests := []struct {
+		name      string
+		nested    bool
+		hostCG    bool
+		wantMount bool
+	}{
+		{name: "nested true and host cgroup false emits mount", nested: true, hostCG: false, wantMount: true},
+		{name: "nested false and host cgroup false omits mount", nested: false, hostCG: false, wantMount: false},
+		{name: "nested true and host cgroup true omits mount", nested: true, hostCG: true, wantMount: false},
+		{name: "nested zero values omit mount", wantMount: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ctr.BuildContainerSpec(intmodel.ContainerSpec{
+				ID:                  "test-id",
+				Image:               "registry.eminwux.com/busybox:latest",
+				NestedCgroupRuntime: tt.nested,
+				HostCgroup:          tt.hostCG,
+				CellName:            "c", SpaceName: "s", RealmName: "r", StackName: "st",
+			})
+
+			ociSpec := &runtimespec.Spec{
+				Process: &runtimespec.Process{},
+				Linux:   &runtimespec.Linux{},
+			}
+			for _, opt := range spec.SpecOpts {
+				if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+					t.Fatalf("apply SpecOpts: %v", err)
+				}
+			}
+
+			var got *runtimespec.Mount
+			for i, m := range ociSpec.Mounts {
+				if m.Destination == "/sys/fs/cgroup" {
+					got = &ociSpec.Mounts[i]
+					break
+				}
+			}
+			if tt.wantMount {
+				if got == nil {
+					t.Fatalf("/sys/fs/cgroup mount missing; mounts=%+v", ociSpec.Mounts)
+				}
+				if got.Type != "cgroup" {
+					t.Errorf("mount.Type = %q, want %q", got.Type, "cgroup")
+				}
+				if got.Source != "cgroup" {
+					t.Errorf("mount.Source = %q, want %q", got.Source, "cgroup")
+				}
+				wantOpts := []string{"rw", "nosuid", "noexec", "nodev"}
+				if len(got.Options) != len(wantOpts) {
+					t.Fatalf("mount.Options = %v, want %v", got.Options, wantOpts)
+				}
+				for i, want := range wantOpts {
+					if got.Options[i] != want {
+						t.Errorf("mount.Options[%d] = %q, want %q", i, got.Options[i], want)
+					}
+				}
+			} else if got != nil {
+				t.Errorf("unexpected /sys/fs/cgroup mount on opt-out spec: %+v", *got)
+			}
+		})
+	}
+}
+
+// TestBuildContainerSpec_NestedCgroupRuntimeOffByteIdentical pins the
+// pre-#322 mount-list output for the opt-out path: a ContainerSpec with
+// NestedCgroupRuntime=false must produce the same Mounts slice as one with
+// the field omitted entirely. The byte-identical guarantee matters because
+// every existing cell on existing hosts is opt-out, and a stray cgroup2
+// entry would alter every running container's OCI spec on first reconcile
+// after the upgrade.
+func TestBuildContainerSpec_NestedCgroupRuntimeOffByteIdentical(t *testing.T) {
+	base := intmodel.ContainerSpec{
+		ID:       "test-id",
+		Image:    "registry.eminwux.com/busybox:latest",
+		CellName: "c", SpaceName: "s", RealmName: "r", StackName: "st",
+	}
+	want := mountListAfterApply(t, ctr.BuildContainerSpec(base))
+
+	off := base
+	off.NestedCgroupRuntime = false
+	got := mountListAfterApply(t, ctr.BuildContainerSpec(off))
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mount list diverged on opt-out path:\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// TestBuildRootContainerSpec_NestedCgroupRuntimeMount mirrors
+// TestBuildContainerSpec_NestedCgroupRuntimeMount for the root-container
+// builder. A user-supplied root in a NestedCgroupRuntime cell must get the
+// same /sys/fs/cgroup wiring; the kukeond cell's HostCgroup=true root is
+// exempted by the same guard.
+func TestBuildRootContainerSpec_NestedCgroupRuntimeMount(t *testing.T) {
+	tests := []struct {
+		name      string
+		nested    bool
+		hostCG    bool
+		wantMount bool
+	}{
+		{name: "nested true and host cgroup false emits mount", nested: true, hostCG: false, wantMount: true},
+		{name: "nested false and host cgroup false omits mount", nested: false, hostCG: false, wantMount: false},
+		{name: "nested true and host cgroup true omits mount", nested: true, hostCG: true, wantMount: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ctr.BuildRootContainerSpec(intmodel.ContainerSpec{
+				ID:                  "root",
+				ContainerdID:        "root-id",
+				Image:               "registry.eminwux.com/busybox:latest",
+				NestedCgroupRuntime: tt.nested,
+				HostCgroup:          tt.hostCG,
+			}, nil)
+
+			ociSpec := &runtimespec.Spec{
+				Process: &runtimespec.Process{},
+				Linux:   &runtimespec.Linux{},
+			}
+			for _, opt := range spec.SpecOpts {
+				if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+					t.Fatalf("apply SpecOpts: %v", err)
+				}
+			}
+
+			var hasMount bool
+			for _, m := range ociSpec.Mounts {
+				if m.Destination == "/sys/fs/cgroup" && m.Type == "cgroup" {
+					hasMount = true
+					break
+				}
+			}
+			if hasMount != tt.wantMount {
+				t.Errorf("/sys/fs/cgroup cgroup mount present = %v, want %v (mounts=%+v)",
+					hasMount, tt.wantMount, ociSpec.Mounts)
+			}
+		})
+	}
+}
+
+// mountListAfterApply runs the spec's SpecOpts against an empty OCI spec and
+// returns the resulting Mounts slice. Used by the byte-identical guard above
+// to compare the pre-#322 mount layout against the opt-out path.
+func mountListAfterApply(t *testing.T, spec ctr.ContainerSpec) []runtimespec.Mount {
+	t.Helper()
+	ociSpec := &runtimespec.Spec{
+		Process: &runtimespec.Process{},
+		Linux:   &runtimespec.Linux{},
+	}
+	for _, opt := range spec.SpecOpts {
+		if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+			t.Fatalf("apply SpecOpts: %v", err)
+		}
+	}
+	return ociSpec.Mounts
 }
 
 // TestBuildContainerSpec_CgroupsPath verifies that BuildContainerSpec emits an

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -30,26 +30,36 @@ type ContainerMetadata struct {
 }
 
 type ContainerSpec struct {
-	ID                     string
-	ContainerdID           string
-	RealmName              string
-	SpaceName              string
-	StackName              string
-	CellName               string
-	Root                   bool
-	Image                  string
-	Command                string
-	Args                   []string
-	WorkingDir             string
-	Env                    []string
-	Ports                  []string
-	Volumes                []VolumeMount
-	Networks               []string
-	NetworksAliases        []string
-	Privileged             bool
-	HostNetwork            bool
-	HostPID                bool
-	HostCgroup             bool
+	ID              string
+	ContainerdID    string
+	RealmName       string
+	SpaceName       string
+	StackName       string
+	CellName        string
+	Root            bool
+	Image           string
+	Command         string
+	Args            []string
+	WorkingDir      string
+	Env             []string
+	Ports           []string
+	Volumes         []VolumeMount
+	Networks        []string
+	NetworksAliases []string
+	Privileged      bool
+	HostNetwork     bool
+	HostPID         bool
+	HostCgroup      bool
+	// NestedCgroupRuntime mirrors the parent cell's
+	// CellSpec.NestedCgroupRuntime opt-in (issue #314). When true and
+	// !HostCgroup, BuildContainerSpec/BuildRootContainerSpec append a
+	// cgroup2 mount at /sys/fs/cgroup so an inner runtime (dockerd,
+	// podman, an inner containerd) can read the controller set that
+	// the controller delegated host-side via
+	// EnableCellAllSubtreeControllers (#318). Propagated by the runner
+	// from cell.Spec.NestedCgroupRuntime at every BuildContainerSpec
+	// call site; not part of the persisted container document.
+	NestedCgroupRuntime    bool
 	User                   string
 	ReadOnlyRootFilesystem bool
 	Capabilities           *ContainerCapabilities


### PR DESCRIPTION
## Summary
- #318 added the host-side half of `nestedCgroupRuntime: true` (`EnableCellAllSubtreeControllers` writes the full cgroup-v2 controller set into the cell's host-side `cgroup.subtree_control`), but the in-cell mount half was never wired up. With cgroup-ns private and no cgroup2 mount, an inner runtime (dockerd, podman, an inner containerd) inside the cell sees `/sys/fs/cgroup` as an empty mountpoint and aborts ("Devices cgroup isn't mounted"). Closes #322.
- Adds `NestedCgroupRuntime` to `intmodel.ContainerSpec` and propagates `cell.Spec.NestedCgroupRuntime` to every container at `applyCellContainerDefaults` and `ensureCellRootContainerSpec`. `BuildContainerSpec` and `BuildRootContainerSpec` then emit an OCI `cgroup2` mount at `/sys/fs/cgroup` exactly when `NestedCgroupRuntime && !HostCgroup`. `HostCgroup=true` cells (kukeond) already get cgroup2 visibility via the bootstrap bind-mount path and are unaffected.
- The per-container `NestedCgroupRuntime` field is runtime-only (not part of the persisted container document, same shape as `CellCgroupPath`), so `StartCell`'s non-root container loop and `StartContainer` re-inject it from `cell.Spec.NestedCgroupRuntime` before `BuildContainerSpec` runs in the destructive recreate. Without this, the value `applyCellContainerDefaults` set at create time gets stripped on the post-restart `GetCell` reload and #322 re-emerges for non-root containers after a daemon restart.
- Opt-out path (the default) is byte-identical to pre-#322 — pinned by `TestBuildContainerSpec_NestedCgroupRuntimeOffByteIdentical`. Existing cells on existing hosts see no OCI-spec change after upgrade.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full unit suite, all packages green)
- [x] `go test ./internal/ctr/... -run "Cgroup|NestedCgroup" -v` — new tests pass: `TestBuildContainerSpec_NestedCgroupRuntimeMount`, `TestBuildContainerSpec_NestedCgroupRuntimeOffByteIdentical`, `TestBuildRootContainerSpec_NestedCgroupRuntimeMount`
- [x] `make dev-init` — daemon-parity check returns the expected two-realm output (regression guard for the bind-mount path; this change touches `BuildContainerSpec` which the daemon reads)
- [x] Daemon-restart smoke for a `nestedCgroupRuntime: true` cell with a non-root container: applied the cell, confirmed `/sys/fs/cgroup` cgroup mount in the worker container's OCI spec, then `kuke stop cell` + `kuke start cell` (which exercises `StartCell` with the freshly-loaded-from-storage cell). After the restart the OCI spec still carries the mount and `cat /proc/<pid>/mountinfo` shows the `cgroup2` filesystem mounted at `/sys/fs/cgroup` rooted at the cell's delegated subtree (`/kukeon/default/default/default/nested-smoke/...`). Locks down the regression the latest commit fixes.
- [x] `pre-commit run` on staged files (golangci-lint, go fmt, go-mod-tidy, addlicense — all green)

Closes #322