### PR TITLE
feat: add kuke doctor cgroups pre-flight before dev-init

### DIFF
--- a/cmd/kuke/doctor/cgroups/cgroups.go
+++ b/cmd/kuke/doctor/cgroups/cgroups.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cgroups implements `kuke doctor cgroups`: a pre-flight that
+// classifies the host root cgroup's controller availability against the
+// set kukeon's cell-creation path will require, with actionable output
+// for the contributor running `make dev-init`.
+package cgroups
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/cgroupcheck"
+	"github.com/spf13/cobra"
+)
+
+// NewCgroupsCmd builds the `kuke doctor cgroups` subcommand.
+func NewCgroupsCmd() *cobra.Command {
+	var (
+		root    string
+		nested  bool
+		probe   bool
+		verbose bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "cgroups",
+		Short: "Verify host cgroup-v2 controller delegation before kuke init",
+		Long: "Pre-flight that compares the host root cgroup's available + delegated\n" +
+			"controllers against the set kukeon will enable on the kukeond\n" +
+			"bootstrap cell. Distinguishes \"kernel does not support\" from \"parent\n" +
+			"did not delegate\" so the remediation suggestion is always correct.\n\n" +
+			"Exit code 0: every required controller is enabled (or was enabled by\n" +
+			"the optional --probe write). Non-zero: at least one controller is\n" +
+			"missing or the host root cgroup could not be read.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDoctor(cmd.OutOrStdout(), cmd.ErrOrStderr(), root, nested, probe, verbose)
+		},
+		// A failed pre-flight is a host-environment problem, not a CLI
+		// usage error — the structured remediation is the message we
+		// want the operator to read; cobra's auto-printed Usage block
+		// after an error would only bury it.
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().StringVar(&root, "root", cgroupcheck.DefaultHostRoot(),
+		"path to the cgroup-v2 root (default: "+cgroupcheck.DefaultHostRoot()+")")
+	cmd.Flags().BoolVar(&nested, "nested-cgroup-runtime", false,
+		"check the controller set required when the kukeond cell opts into NestedCgroupRuntime")
+	cmd.Flags().BoolVar(&probe, "probe", false,
+		"attempt a +<ctrl> write to cgroup.subtree_control for missing controllers; "+
+			"disambiguates the cgroup-namespace trap. Idempotent — leaves the host in a strictly better state on success.")
+	cmd.Flags().BoolVar(&verbose, "verbose-status", false,
+		"print per-controller status even when the pre-flight passes")
+
+	return cmd
+}
+
+func runDoctor(stdout, stderr io.Writer, root string, nested, probe, verbose bool) error {
+	required, err := resolveRequired(root, nested)
+	if err != nil {
+		return err
+	}
+
+	var prober cgroupcheck.Prober
+	if probe {
+		prober = cgroupcheck.DefaultProber
+	}
+
+	res, err := cgroupcheck.Check(root, required, prober)
+	if err != nil {
+		return fmt.Errorf("cgroup pre-flight: %w", err)
+	}
+
+	if res.OK() {
+		// Silence on success keeps the dev-init.sh tail clean — only
+		// surface details when --verbose-status is set.
+		if verbose {
+			printStatus(stdout, res)
+		}
+		return nil
+	}
+
+	printStatus(stderr, res)
+	fmt.Fprint(stderr, "\n")
+	fmt.Fprint(stderr, cgroupcheck.FormatRemediation(res))
+	return fmt.Errorf("cgroup pre-flight: missing controllers at %s",
+		filepath.Join(root, "cgroup.subtree_control"))
+}
+
+// resolveRequired returns the controller set the pre-flight must verify.
+// nested=true reads the host-advertised set live, mirroring how
+// EnableCellAllSubtreeControllers will behave at cell-creation time —
+// this is the "no second source of truth" guarantee #324 calls for.
+func resolveRequired(root string, nested bool) ([]string, error) {
+	if !nested {
+		return cgroupcheck.RequiredForKukeond(false, nil), nil
+	}
+	advertised, err := cgroupcheck.HostAdvertised(root)
+	if err != nil {
+		return nil, fmt.Errorf("cgroup pre-flight: %w", err)
+	}
+	return cgroupcheck.RequiredForKukeond(true, advertised), nil
+}
+
+func printStatus(w io.Writer, res cgroupcheck.Result) {
+	fmt.Fprintf(w, "host root: %s\n", res.HostRoot)
+	fmt.Fprintf(w, "required:  %s\n", joinControllers(res.Required))
+	for _, c := range res.Required {
+		fmt.Fprintf(w, "  %s: %s\n", c, res.Status[c])
+	}
+}
+
+func joinControllers(in []string) string {
+	if len(in) == 0 {
+		return "(none)"
+	}
+	return strings.Join(in, ", ")
+}

--- a/cmd/kuke/doctor/cgroups/cgroups_test.go
+++ b/cmd/kuke/doctor/cgroups/cgroups_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroups_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cgroupscmd "github.com/eminwux/kukeon/cmd/kuke/doctor/cgroups"
+)
+
+// writeFakeCgroup materializes a directory pretending to be a cgroup-v2
+// root: cgroup.controllers + cgroup.subtree_control with the given
+// space-separated controller lists.
+func writeFakeCgroup(t *testing.T, controllers, subtree string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "cgroup.controllers"), []byte(controllers), 0o644); err != nil {
+		t.Fatalf("write cgroup.controllers: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "cgroup.subtree_control"), []byte(subtree), 0o644); err != nil {
+		t.Fatalf("write cgroup.subtree_control: %v", err)
+	}
+	return root
+}
+
+func runCmd(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	cmd := cgroupscmd.NewCgroupsCmd()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+// TestCgroupsCmdHappyPath: when every required controller is enabled, the
+// command exits 0 and prints nothing to stdout. The dev-init.sh tail
+// regression guard relies on this silence.
+func TestCgroupsCmdHappyPath(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+
+	stdout, stderr, err := runCmd(t, "--root", root)
+	if err != nil {
+		t.Fatalf("happy-path Execute() error = %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("happy-path stdout = %q, want empty (silence keeps dev-init.sh tail clean)", stdout)
+	}
+}
+
+// TestCgroupsCmdMissingFails: when memory + io are missing from
+// subtree_control, the command exits non-zero and the stderr remediation
+// names them and the canonical fix.
+func TestCgroupsCmdMissingFails(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	_, stderr, err := runCmd(t, "--root", root)
+	if err == nil {
+		t.Fatal("Execute() error = nil for host missing memory + io, want error")
+	}
+
+	for _, want := range []string{"memory", "io", "cgroup.subtree_control"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestCgroupsCmdProbeRecoversOnPlainFile: --probe writes "+<ctrl>" to the
+// fake subtree_control file. After the write the controllers are present
+// in the file and a re-read inside cgroupcheck classifies them as
+// EnabledByProbe → command returns success. Exercises the same probe
+// path dev-init.sh uses on a misconfigured host.
+func TestCgroupsCmdProbeRecoversOnPlainFile(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	stdout, stderr, err := runCmd(t, "--root", root, "--probe")
+	if err != nil {
+		t.Fatalf("probe-recover Execute() error = %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+}
+
+// TestCgroupsCmdNestedReadsAdvertised: --nested-cgroup-runtime requires
+// the full host-advertised set. Seeding subtree_control with the full
+// set must therefore pass the pre-flight (no second source of truth).
+func TestCgroupsCmdNestedReadsAdvertised(t *testing.T) {
+	full := "cpuset cpu io memory hugetlb pids rdma misc"
+	root := writeFakeCgroup(t, full, full)
+
+	if _, stderr, err := runCmd(t, "--root", root, "--nested-cgroup-runtime"); err != nil {
+		t.Fatalf("nested happy-path failed: %v\nstderr=%q", err, stderr)
+	}
+}
+
+// TestCgroupsCmdNestedFailsOnPartialSubtree: with --nested-cgroup-runtime,
+// any host-advertised controller missing from subtree_control must fail
+// the pre-flight. Confirms the "moving target" handling: when the cell
+// adopts NestedCgroupRuntime the required set widens automatically.
+func TestCgroupsCmdNestedFailsOnPartialSubtree(t *testing.T) {
+	full := "cpuset cpu io memory hugetlb pids rdma misc"
+	root := writeFakeCgroup(t, full, "cpu memory io pids")
+
+	_, stderr, err := runCmd(t, "--root", root, "--nested-cgroup-runtime")
+	if err == nil {
+		t.Fatal("nested partial-subtree Execute() error = nil, want error")
+	}
+	for _, want := range []string{"cpuset", "hugetlb", "rdma", "misc"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q under --nested-cgroup-runtime:\n%s", want, stderr)
+		}
+	}
+}
+
+func TestCgroupsCmdNoSuchRoot(t *testing.T) {
+	bogus := filepath.Join(t.TempDir(), "no-such-root")
+	_, stderr, err := runCmd(t, "--root", bogus)
+	if err == nil {
+		t.Fatal("Execute() error = nil for missing host root, want error")
+	}
+	if !strings.Contains(err.Error(), "cgroup pre-flight") {
+		t.Errorf("error message = %q, want it to mention 'cgroup pre-flight'", err.Error())
+	}
+	_ = stderr
+}

--- a/cmd/kuke/doctor/doctor.go
+++ b/cmd/kuke/doctor/doctor.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package doctor hosts `kuke doctor`, a parent command for host-level
+// pre-flight checks invoked before `kuke init` to surface environmental
+// problems that would otherwise be diagnosed only via cryptic mid-bootstrap
+// failures (e.g., missing cgroup-v2 controller delegation).
+package doctor
+
+import (
+	cgroupscmd "github.com/eminwux/kukeon/cmd/kuke/doctor/cgroups"
+	"github.com/spf13/cobra"
+)
+
+// NewDoctorCmd builds the `kuke doctor` parent command.
+func NewDoctorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Run host pre-flight checks before kuke init",
+		Long: "Run host-level pre-flight checks before `kuke init`.\n\n" +
+			"These checks read the host environment (cgroup hierarchy, controller\n" +
+			"delegation, ...) and fail fast with an actionable remediation when\n" +
+			"the host would otherwise produce a cryptic mid-bootstrap error.",
+		Run: func(cmd *cobra.Command, _ []string) {
+			_ = cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(cgroupscmd.NewCgroupsCmd())
+	return cmd
+}

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -29,6 +29,7 @@ import (
 	createcmd "github.com/eminwux/kukeon/cmd/kuke/create"
 	daemoncmd "github.com/eminwux/kukeon/cmd/kuke/daemon"
 	deletecmd "github.com/eminwux/kukeon/cmd/kuke/delete"
+	doctorcmd "github.com/eminwux/kukeon/cmd/kuke/doctor"
 	getcmd "github.com/eminwux/kukeon/cmd/kuke/get"
 	imagecmd "github.com/eminwux/kukeon/cmd/kuke/image"
 	initcmd "github.com/eminwux/kukeon/cmd/kuke/init"
@@ -132,6 +133,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(daemoncmd.NewDaemonCmd())
 	rootCmd.AddCommand(getcmd.NewGetCmd())
 	rootCmd.AddCommand(deletecmd.NewDeleteCmd())
+	rootCmd.AddCommand(doctorcmd.NewDoctorCmd())
 	rootCmd.AddCommand(startcmd.NewStartCmd())
 	rootCmd.AddCommand(stopcmd.NewStopCmd())
 	rootCmd.AddCommand(killcmd.NewKillCmd())

--- a/internal/cgroupcheck/cgroupcheck.go
+++ b/internal/cgroupcheck/cgroupcheck.go
@@ -1,0 +1,365 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cgroupcheck implements the host-cgroup pre-flight that catches
+// missing or undelegated cgroup-v2 controllers before kukeon's bootstrap
+// path tries (and fails) to enable them. Used by the `kuke doctor cgroups`
+// subcommand and reused as the single source of truth for the cell
+// resource-controller set kukeon enables on every cell's subtree.
+//
+// File-based classification reads <root>/cgroup.controllers (controllers
+// the kernel exposes here) and <root>/cgroup.subtree_control (controllers
+// already enabled into the subtree). A controller missing from
+// subtree_control but present in cgroup.controllers usually only needs a
+// "+<ctrl>" write to subtree_control; in cgroup-namespace contexts, that
+// write can still fail with EOPNOTSUPP because the namespace's parent
+// hasn't delegated the controller. The optional probe write disambiguates.
+package cgroupcheck
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/eminwux/kukeon/internal/consts"
+)
+
+// CellResourceControllers names the cgroup-v2 controllers kukeon enables on
+// a cell's subtree by default so per-container cgroups inherit them and
+// cell-level UpdateCgroup limits are effective. Cells that opt into
+// CellSpec.NestedCgroupRuntime delegate the full host-advertised set
+// instead — see EnableCellAllSubtreeControllers in internal/ctr.
+//
+// Single source of truth: provision.go and the doctor pre-flight both
+// consume this slice; mutating it would silently change the cell-creation
+// path. Returning a fresh copy keeps callers honest.
+func CellResourceControllers() []string {
+	return []string{"cpu", "memory", "io", "pids"}
+}
+
+// Status classifies a single controller's availability at the host root.
+type Status int
+
+const (
+	// StatusEnabled — already listed in cgroup.subtree_control. Nothing to do.
+	StatusEnabled Status = iota
+	// StatusKernelMissing — not listed in cgroup.controllers. Either the
+	// kernel was built without the controller, or the parent in the cgroup
+	// hierarchy hasn't delegated it down to this scope.
+	StatusKernelMissing
+	// StatusNotDelegated — listed in cgroup.controllers but the probe write
+	// to cgroup.subtree_control returned EOPNOTSUPP. Diagnostic of the
+	// cgroup-namespace trap: cgroup.controllers advertises kernel support
+	// but the namespace's actual parent never delegated the controller.
+	StatusNotDelegated
+	// StatusNeedsDelegation — listed in cgroup.controllers, missing from
+	// cgroup.subtree_control, and we did not probe (or probing wasn't
+	// permitted). The fix is "+<ctrl>" to cgroup.subtree_control, but the
+	// pre-flight cannot promise the write will succeed.
+	StatusNeedsDelegation
+	// StatusEnabledByProbe — the probe write succeeded and the controller
+	// is now in cgroup.subtree_control. Idempotent: re-running is a no-op.
+	StatusEnabledByProbe
+	// StatusPermissionDenied — the probe write returned EACCES/EPERM. The
+	// pre-flight cannot tell whether the kernel would accept the write
+	// from a privileged caller; re-run with sudo for a definitive answer.
+	StatusPermissionDenied
+)
+
+// String returns the short label used in human-readable output.
+func (s Status) String() string {
+	switch s {
+	case StatusEnabled:
+		return "enabled"
+	case StatusKernelMissing:
+		return "kernel-missing"
+	case StatusNotDelegated:
+		return "not-delegated"
+	case StatusNeedsDelegation:
+		return "needs-delegation"
+	case StatusEnabledByProbe:
+		return "enabled-by-probe"
+	case StatusPermissionDenied:
+		return "permission-denied"
+	default:
+		return fmt.Sprintf("status(%d)", int(s))
+	}
+}
+
+// Result captures the outcome of a controller-set check, keyed by
+// controller name. Required preserves the caller's input order so the
+// remediation message lists controllers in the same sequence the
+// caller asked about.
+type Result struct {
+	HostRoot string
+	Required []string
+	Status   map[string]Status
+	// ProbeErr records the raw error from each probe attempt, when one
+	// was made. Useful for verbose diagnostics; ignore when reading
+	// Status alone is enough.
+	ProbeErr map[string]error
+}
+
+// OK reports whether every required controller ended in a "good" terminal
+// state — already enabled, or enabled by the probe.
+func (r Result) OK() bool {
+	return len(r.Unresolved()) == 0
+}
+
+// Unresolved returns the required controllers that still need operator
+// attention after the check. Order matches Required.
+func (r Result) Unresolved() []string {
+	out := make([]string, 0, len(r.Required))
+	for _, c := range r.Required {
+		switch r.Status[c] {
+		case StatusEnabled, StatusEnabledByProbe:
+			// Good terminal state.
+		case StatusKernelMissing,
+			StatusNotDelegated,
+			StatusNeedsDelegation,
+			StatusPermissionDenied:
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// ByStatus groups Required controllers by their classification, returning
+// only statuses that have at least one entry. Slice order within each
+// group matches Required.
+func (r Result) ByStatus() map[Status][]string {
+	groups := map[Status][]string{}
+	for _, c := range r.Required {
+		s := r.Status[c]
+		groups[s] = append(groups[s], c)
+	}
+	return groups
+}
+
+// RequiredForKukeond returns the controllers the host root's
+// subtree_control must include for `kuke init` to provision the kukeond
+// cell. When the kukeond cell opts into NestedCgroupRuntime (issue #314),
+// the daemon enables the full host-advertised set on the cell's subtree;
+// the pre-flight then needs every one of those at the root, too.
+// Otherwise the resource subset is enough.
+//
+// hostAdvertised is the set read from <root>/cgroup.controllers; pass
+// only when nested is true (otherwise it is ignored).
+func RequiredForKukeond(nested bool, hostAdvertised []string) []string {
+	if !nested {
+		return CellResourceControllers()
+	}
+	out := make([]string, len(hostAdvertised))
+	copy(out, hostAdvertised)
+	return out
+}
+
+// Prober attempts to enable a controller in <hostRoot>/cgroup.subtree_control
+// and returns a syscall-level error so the caller can distinguish EOPNOTSUPP
+// (parent didn't delegate) from EACCES/EPERM (need root) from kernel
+// errors. Returning nil means the controller is now enabled.
+type Prober func(hostRoot, controller string) error
+
+// DefaultProber writes "+<ctrl>" to <hostRoot>/cgroup.subtree_control
+// using O_WRONLY without O_TRUNC — cgroupfs files do not honor truncation
+// and interpret the write additively, matching the rest of internal/ctr.
+func DefaultProber(hostRoot, controller string) error {
+	path := filepath.Join(hostRoot, "cgroup.subtree_control")
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, werr := f.WriteString("+" + controller); werr != nil {
+		return werr
+	}
+	return nil
+}
+
+// Check classifies each required controller against the host root cgroup at
+// hostRoot (typically /sys/fs/cgroup). When probe is non-nil, controllers
+// missing from subtree_control but present in cgroup.controllers are
+// disambiguated by calling probe — a successful call leaves the host in a
+// strictly better state (controller now enabled), so re-runs are idempotent.
+// Pass probe=nil for a strictly read-only check.
+func Check(hostRoot string, required []string, probe Prober) (Result, error) {
+	advertised, err := readControllers(filepath.Join(hostRoot, "cgroup.controllers"))
+	if err != nil {
+		return Result{}, fmt.Errorf("read %s: %w", filepath.Join(hostRoot, "cgroup.controllers"), err)
+	}
+	enabled, err := readControllers(filepath.Join(hostRoot, "cgroup.subtree_control"))
+	if err != nil {
+		return Result{}, fmt.Errorf("read %s: %w", filepath.Join(hostRoot, "cgroup.subtree_control"), err)
+	}
+
+	advertisedSet := toSet(advertised)
+	enabledSet := toSet(enabled)
+
+	res := Result{
+		HostRoot: hostRoot,
+		Required: append([]string(nil), required...),
+		Status:   make(map[string]Status, len(required)),
+		ProbeErr: map[string]error{},
+	}
+
+	for _, c := range required {
+		switch {
+		case enabledSet[c]:
+			res.Status[c] = StatusEnabled
+		case !advertisedSet[c]:
+			res.Status[c] = StatusKernelMissing
+		default:
+			if probe == nil {
+				res.Status[c] = StatusNeedsDelegation
+				continue
+			}
+			perr := probe(hostRoot, c)
+			res.ProbeErr[c] = perr
+			res.Status[c] = classifyProbeErr(perr)
+		}
+	}
+	return res, nil
+}
+
+// classifyProbeErr maps the result of a probe write to a Status. The
+// distinction between StatusNotDelegated and StatusPermissionDenied is the
+// whole point of probing — getting it right keeps the remediation
+// suggestion correct.
+func classifyProbeErr(err error) Status {
+	if err == nil {
+		return StatusEnabledByProbe
+	}
+	switch {
+	case errors.Is(err, syscall.EOPNOTSUPP), errors.Is(err, syscall.ENOTSUP):
+		return StatusNotDelegated
+	case errors.Is(err, syscall.EACCES), errors.Is(err, syscall.EPERM):
+		return StatusPermissionDenied
+	}
+	// Fall back to the cgroup-ns trap class when the kernel surfaced an
+	// unexpected error: the controller was advertised but the write did
+	// not land, which is the same operator-visible outcome.
+	return StatusNotDelegated
+}
+
+// FormatRemediation returns a human-readable, multi-line message describing
+// the missing controllers and how to fix them. Returns an empty string
+// when r.OK() — callers can print unconditionally.
+func FormatRemediation(r Result) string {
+	if r.OK() {
+		return ""
+	}
+
+	groups := r.ByStatus()
+	unresolved := r.Unresolved()
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "host root cgroup is missing controllers required by kukeond: %s\n",
+		strings.Join(unresolved, ", "))
+
+	if g, ok := groups[StatusNotDelegated]; ok {
+		fmt.Fprintf(&b, "\n  parent did not delegate (cgroup-namespace trap): %s\n", strings.Join(g, ", "))
+		b.WriteString("    the namespace this shell runs in advertises these controllers\n")
+		b.WriteString("    in cgroup.controllers but the actual parent never delegated\n")
+		b.WriteString("    them. escalate to the host / container runtime above this\n")
+		b.WriteString("    shell to delegate the missing controllers.\n")
+	}
+	if g, ok := groups[StatusKernelMissing]; ok {
+		fmt.Fprintf(&b, "\n  kernel does not support: %s\n", strings.Join(g, ", "))
+		b.WriteString("    the running kernel was built without these controllers, or\n")
+		b.WriteString("    this scope's parent has not delegated them and the\n")
+		b.WriteString("    advertised set is already trimmed. rebuild with the matching\n")
+		b.WriteString("    CONFIG_* options or run on a host that exposes them.\n")
+	}
+	if g, ok := groups[StatusNeedsDelegation]; ok {
+		fmt.Fprintf(&b, "\n  not enabled in cgroup.subtree_control: %s\n", strings.Join(g, ", "))
+		b.WriteString("    these controllers are advertised but not yet delegated to\n")
+		b.WriteString("    children. enable them with the fix below.\n")
+	}
+	if g, ok := groups[StatusPermissionDenied]; ok {
+		fmt.Fprintf(&b, "\n  permission denied during probe: %s\n", strings.Join(g, ", "))
+		b.WriteString("    re-run the pre-flight with sudo so the probe write to\n")
+		b.WriteString("    cgroup.subtree_control can succeed.\n")
+	}
+
+	subtree := filepath.Join(r.HostRoot, "cgroup.subtree_control")
+	parts := make([]string, 0, len(unresolved))
+	for _, c := range unresolved {
+		// "kernel-missing" controllers cannot be enabled by an operator
+		// write; omit them from the fix line so the suggestion is correct.
+		if r.Status[c] == StatusKernelMissing {
+			continue
+		}
+		parts = append(parts, "+"+c)
+	}
+	if len(parts) > 0 {
+		fmt.Fprintf(&b, "\n  fix: echo \"%s\" | sudo tee %s\n", strings.Join(parts, " "), subtree)
+		b.WriteString("\n  if that returns \"Operation not supported\", the parent of\n")
+		b.WriteString("  this cgroup namespace did not delegate those controllers —\n")
+		b.WriteString("  escalate to the host / container runtime above this shell.\n")
+	}
+	return b.String()
+}
+
+// HostAdvertised returns the controller names in <hostRoot>/cgroup.controllers,
+// i.e. the set the kernel says can be enabled at this scope. Used by the
+// nested-cgroup-runtime path to derive "the full host-advertised set" without
+// duplicating the file-read logic outside this package.
+func HostAdvertised(hostRoot string) ([]string, error) {
+	path := filepath.Join(hostRoot, "cgroup.controllers")
+	out, err := readControllers(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return out, nil
+}
+
+// readControllers reads a cgroup.controllers / cgroup.subtree_control file
+// and returns the space-separated controller names. Empty file returns
+// an empty slice (not nil) so callers can still compute a set from it.
+func readControllers(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Return a more actionable error for the common "kuke doctor
+		// cgroups" misuse where the operator pointed --root at something
+		// that isn't a cgroup-v2 hierarchy.
+		var pathErr *fs.PathError
+		if errors.As(err, &pathErr) {
+			return nil, err
+		}
+		return nil, err
+	}
+	out := strings.Fields(string(data))
+	sort.Strings(out)
+	return out, nil
+}
+
+func toSet(in []string) map[string]bool {
+	m := make(map[string]bool, len(in))
+	for _, v := range in {
+		m[v] = true
+	}
+	return m
+}
+
+// DefaultHostRoot returns the cgroup-v2 mountpoint kukeon assumes when
+// the caller did not pass --root. Mirrors consts.CgroupFilesystemPath so
+// the pre-flight and the rest of the codebase agree on the same path.
+func DefaultHostRoot() string { return consts.CgroupFilesystemPath }

--- a/internal/cgroupcheck/cgroupcheck_test.go
+++ b/internal/cgroupcheck/cgroupcheck_test.go
@@ -1,0 +1,309 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroupcheck_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cgroupcheck"
+)
+
+// TestCellResourceControllersStable pins the cell resource subset. The
+// controller names ride into the kernel's cgroup.subtree_control writes
+// and into provision.go's enableCellControllers; reordering or renaming
+// here would silently change the cell-creation path on every host.
+func TestCellResourceControllersStable(t *testing.T) {
+	got := cgroupcheck.CellResourceControllers()
+	want := []string{"cpu", "memory", "io", "pids"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("CellResourceControllers() = %v, want %v", got, want)
+	}
+
+	// Defensive copy: mutating the returned slice must not leak back
+	// into the package-level constant.
+	got[0] = "mutated"
+	if cgroupcheck.CellResourceControllers()[0] == "mutated" {
+		t.Fatal("CellResourceControllers must return a fresh slice; caller mutation leaked into the package")
+	}
+}
+
+func TestRequiredForKukeondNotNested(t *testing.T) {
+	got := cgroupcheck.RequiredForKukeond(false, []string{"cpuset", "cpu", "io", "memory", "hugetlb", "pids"})
+	want := cgroupcheck.CellResourceControllers()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RequiredForKukeond(nested=false) = %v, want resource subset %v", got, want)
+	}
+}
+
+func TestRequiredForKukeondNested(t *testing.T) {
+	advertised := []string{"cpuset", "cpu", "io", "memory", "hugetlb", "pids", "rdma", "misc"}
+	got := cgroupcheck.RequiredForKukeond(true, advertised)
+	if !reflect.DeepEqual(got, advertised) {
+		t.Fatalf("RequiredForKukeond(nested=true) = %v, want %v", got, advertised)
+	}
+	got[0] = "mutated"
+	if advertised[0] == "mutated" {
+		t.Fatal("RequiredForKukeond must copy hostAdvertised; caller mutation leaked into the input slice")
+	}
+}
+
+// writeCgroupFiles materializes a fake host root cgroup hierarchy: a
+// directory with cgroup.controllers and cgroup.subtree_control populated
+// from the given strings. Mirrors what /sys/fs/cgroup looks like to
+// readControllers without requiring a real cgroup-v2 mount.
+func writeCgroupFiles(t *testing.T, controllers, subtree string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "cgroup.controllers"), []byte(controllers), 0o644); err != nil {
+		t.Fatalf("write cgroup.controllers: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "cgroup.subtree_control"), []byte(subtree), 0o644); err != nil {
+		t.Fatalf("write cgroup.subtree_control: %v", err)
+	}
+	return root
+}
+
+func TestCheckAllEnabled(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !res.OK() {
+		t.Fatalf("Check() OK=false on fully-enabled host; unresolved=%v", res.Unresolved())
+	}
+	for _, c := range cgroupcheck.CellResourceControllers() {
+		if got, want := res.Status[c], cgroupcheck.StatusEnabled; got != want {
+			t.Errorf("Status[%q] = %v, want %v", c, got, want)
+		}
+	}
+	if msg := cgroupcheck.FormatRemediation(res); msg != "" {
+		t.Errorf("FormatRemediation on OK result = %q, want empty", msg)
+	}
+}
+
+func TestCheckMissingFromSubtreeNoProbe(t *testing.T) {
+	// memory and io are advertised but not yet enabled into subtree_control.
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if res.OK() {
+		t.Fatalf("Check() OK=true with memory/io missing from subtree_control")
+	}
+	for _, c := range []string{"memory", "io"} {
+		if got, want := res.Status[c], cgroupcheck.StatusNeedsDelegation; got != want {
+			t.Errorf("Status[%q] = %v, want %v", c, got, want)
+		}
+	}
+	for _, c := range []string{"cpu", "pids"} {
+		if got, want := res.Status[c], cgroupcheck.StatusEnabled; got != want {
+			t.Errorf("Status[%q] = %v, want %v", c, got, want)
+		}
+	}
+}
+
+func TestCheckKernelMissing(t *testing.T) {
+	// Kernel built without the io controller; cgroup.controllers will
+	// not list it even at the host root.
+	root := writeCgroupFiles(t,
+		"cpuset cpu memory pids",
+		"cpu memory pids",
+	)
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if got, want := res.Status["io"], cgroupcheck.StatusKernelMissing; got != want {
+		t.Errorf("Status[io] = %v, want %v", got, want)
+	}
+	if res.OK() {
+		t.Fatal("Check() OK=true with io missing from cgroup.controllers")
+	}
+	msg := cgroupcheck.FormatRemediation(res)
+	if !strings.Contains(msg, "kernel does not support") {
+		t.Errorf("FormatRemediation missing 'kernel does not support' classification:\n%s", msg)
+	}
+	// The fix line must NOT include +io — operators can't enable a
+	// controller the kernel doesn't expose.
+	if strings.Contains(msg, "+io") {
+		t.Errorf("FormatRemediation suggests `+io` for a kernel-missing controller:\n%s", msg)
+	}
+}
+
+func TestCheckProbeSuccess(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	probedFor := map[string]int{}
+	probe := func(_, ctrl string) error {
+		probedFor[ctrl]++
+		return nil
+	}
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !res.OK() {
+		t.Fatalf("Check() OK=false after successful probe; unresolved=%v", res.Unresolved())
+	}
+	for _, c := range []string{"memory", "io"} {
+		if got, want := res.Status[c], cgroupcheck.StatusEnabledByProbe; got != want {
+			t.Errorf("Status[%q] = %v, want %v", c, got, want)
+		}
+		if probedFor[c] != 1 {
+			t.Errorf("probe called %d times for %q, want exactly once", probedFor[c], c)
+		}
+	}
+	// Already-enabled controllers must not be probed — that would be a
+	// pointless host write on the happy path.
+	for _, c := range []string{"cpu", "pids"} {
+		if probedFor[c] != 0 {
+			t.Errorf("probe called for already-enabled %q (count=%d); should be skipped", c, probedFor[c])
+		}
+	}
+}
+
+func TestCheckProbeEOPNOTSUPP(t *testing.T) {
+	// The cgroup-namespace trap from the issue: cgroup.controllers
+	// advertises memory + io but the actual parent never delegated them,
+	// so the kernel returns EOPNOTSUPP on the write.
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	probe := func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EOPNOTSUPP
+		}
+		return nil
+	}
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	for _, c := range []string{"memory", "io"} {
+		if got, want := res.Status[c], cgroupcheck.StatusNotDelegated; got != want {
+			t.Errorf("Status[%q] = %v, want %v", c, got, want)
+		}
+	}
+	if res.OK() {
+		t.Fatal("Check() OK=true after EOPNOTSUPP probe failures")
+	}
+	msg := cgroupcheck.FormatRemediation(res)
+	for _, want := range []string{
+		"parent did not delegate",
+		"cgroup-namespace trap",
+		"memory, io",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("FormatRemediation missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestCheckProbePermissionDenied(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	probe := func(_, _ string) error { return syscall.EACCES }
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	for _, c := range []string{"memory", "io"} {
+		if got, want := res.Status[c], cgroupcheck.StatusPermissionDenied; got != want {
+			t.Errorf("Status[%q] = %v, want %v", c, got, want)
+		}
+	}
+	if !strings.Contains(cgroupcheck.FormatRemediation(res), "permission denied") {
+		t.Errorf("FormatRemediation missing permission-denied classification:\n%s", cgroupcheck.FormatRemediation(res))
+	}
+}
+
+func TestCheckMissingHostRoot(t *testing.T) {
+	_, err := cgroupcheck.Check(filepath.Join(t.TempDir(), "does-not-exist"),
+		cgroupcheck.CellResourceControllers(), nil)
+	if err == nil {
+		t.Fatal("Check() error = nil for missing host root, want error")
+	}
+}
+
+// TestCheckUnresolvedOrderMatchesRequired pins the order of Unresolved()
+// against the caller-supplied required slice. The remediation message
+// repeats this order; reordering would surprise downstream consumers.
+func TestCheckUnresolvedOrderMatchesRequired(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"",
+	)
+
+	required := []string{"pids", "io", "cpu", "memory"}
+	res, err := cgroupcheck.Check(root, required, nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(res.Unresolved(), required) {
+		t.Fatalf("Unresolved() = %v, want %v (order must match Required)", res.Unresolved(), required)
+	}
+}
+
+// TestDefaultProberWritesPlusController exercises the production prober
+// against an ordinary tempdir file (not a real cgroupfs). The write must
+// land "+<ctrl>" verbatim — cgroupfs interprets the line additively, so
+// the prober must not pad with newlines or other framing that would
+// change semantics on a real subtree_control file.
+func TestDefaultProberWritesPlusController(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "cgroup.subtree_control")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("seed subtree_control: %v", err)
+	}
+	if err := cgroupcheck.DefaultProber(root, "memory"); err != nil {
+		t.Fatalf("DefaultProber error: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "+memory" {
+		t.Errorf("subtree_control after DefaultProber = %q, want %q", string(got), "+memory")
+	}
+}

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -25,6 +25,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/cgroupcheck"
 	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
@@ -1089,25 +1090,20 @@ func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, error) {
 	return cgroupPath, nil
 }
 
-// cellResourceControllers names the cgroup-v2 controllers kukeon enables on a
-// cell's subtree so per-container cgroups inherit them and UpdateCgroup at
-// the cell level becomes effective. The set is filtered against the host
-// root's cgroup.controllers at apply time, so passing a controller missing
-// from a particular kernel build (e.g. "io" without blk-cgroup) is safe.
-func cellResourceControllers() []string {
-	return []string{"cpu", "memory", "io", "pids"}
-}
-
 // enableCellControllers picks between the resource-subset and full-set
 // subtree-control delegation based on cell.Spec.NestedCgroupRuntime, and
 // invokes the matching ctr.Client entry point. The two paths share the
 // same underlying writeSubtreeEnable + ToggleControllers logic; the only
 // difference is which controller set is enabled. Issue #314.
+//
+// The resource subset comes from cgroupcheck.CellResourceControllers so
+// the doctor pre-flight (`kuke doctor cgroups`) and the cell-creation
+// path stay in lockstep — issue #324.
 func (r *Exec) enableCellControllers(cell intmodel.Cell, group, mountpoint string) error {
 	if cell.Spec.NestedCgroupRuntime {
 		return r.ctrClient.EnableCellAllSubtreeControllers(group, mountpoint)
 	}
-	return r.ctrClient.EnableCellSubtreeControllers(group, mountpoint, cellResourceControllers())
+	return r.ctrClient.EnableCellSubtreeControllers(group, mountpoint, cgroupcheck.CellResourceControllers())
 }
 
 func (r *Exec) ensureCellCgroup(cell intmodel.Cell) (intmodel.Cell, error) {

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -32,6 +32,17 @@ step "Build kuke (and the kukeond symlink)"
 make kuke
 ln -sf kuke kukeond
 
+# Pre-flight: catch missing host cgroup-v2 controller delegation BEFORE the
+# multi-minute docker build runs (issue #324). On a fully-delegated host
+# this is silent; on a misconfigured host (e.g. cgroup namespace whose
+# parent only delegated a subset) it fails fast with the missing
+# controllers named and a copy-pasteable remediation. --probe attempts the
+# +<ctrl> write so the EOPNOTSUPP cgroup-namespace trap is distinguished
+# from "kernel does not support". Idempotent on a healthy host (write is
+# a no-op when the controller is already in subtree_control).
+step "Pre-flight: host cgroup controller delegation"
+sudo ./kuke doctor cgroups --probe
+
 step "Build local kukeond image (${LOCAL_TAG})"
 docker build --build-arg VERSION=v0.0.0-dev -t "${LOCAL_TAG}" .
 


### PR DESCRIPTION
## Summary

- New `internal/cgroupcheck` package: file-based classifier (`cgroup.controllers` vs `cgroup.subtree_control`) with optional `+<ctrl>` probe to disambiguate the cgroup-namespace `EOPNOTSUPP` trap from "kernel does not support".
- New `kuke doctor cgroups` subcommand wraps the classifier; silent on a fully-delegated host, fails with a structured remediation otherwise. `--probe`, `--nested-cgroup-runtime`, `--root`, `--verbose-status` flags.
- `scripts/dev-init.sh` invokes `sudo ./kuke doctor cgroups --probe` after the kuke build and before the multi-minute `docker build`, so contributors see the missing-controller remediation before paying the build cost.
- Single source of truth: `internal/controller/runner/provision.go` now consumes `cgroupcheck.CellResourceControllers()`; the resource-subset list lives in one place. When the kukeond cell adopts `NestedCgroupRuntime`, callers flip `--nested-cgroup-runtime` and the required set widens to the full host-advertised set automatically (read live from `cgroup.controllers`).
- `SilenceUsage: true` on the cgroups command — a failed pre-flight is a host issue, not a CLI usage error; cobra's auto-printed Usage block would only bury the remediation.

## Test plan

- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v /e2e)` — all green; new package and command tests cover happy path, EOPNOTSUPP probe, kernel-missing, permission-denied, nested mode, missing host root, ordering, and the canonical fix line.
- [x] `make dev-init` end-to-end on this host — daemon-parity tail matches the CLAUDE.md regression guard (both `kuke get realms` and `kuke get realms --no-daemon` produce identical output); pre-flight step is silent on the happy path.
- [x] Manual fault injection (`/tmp/cgrp-fake`): seeded with missing memory + io → command exits 1 with `host root cgroup is missing controllers required by kukeond: memory, io` + `fix: echo "+memory +io" | sudo tee …` lines. Repeated with `io` absent from `cgroup.controllers` → "kernel does not support" classification, `+io` correctly omitted from the fix line. `--probe` on the missing-but-advertised case → exits 0.
- [x] `pre-commit run --all-files` — only my changed files (other repo files have pre-existing prettier/check-yaml drift, reverted).

## Acceptance criteria

- [x] `make dev-init` on a host missing required controllers fails before the docker build with a single clear message naming exactly which controllers are missing and the command to enable them.
- [x] Passes silently on a fully-delegated host; `kuke get realms` / `kuke get realms --no-daemon` regression-guard output unchanged.
- [x] Distinguishes "parent did not delegate" from "kernel does not support" so the remediation suggestion is always correct.
- [x] When the kukeond cell adopts `NestedCgroupRuntime`, the required set switches to the full host-advertised set without a second source of truth — derived from `cgroupcheck.CellResourceControllers` + a live read of `cgroup.controllers` via `cgroupcheck.HostAdvertised`.
- [x] Unit tests for the controller-set comparison logic — `internal/cgroupcheck/cgroupcheck_test.go`.

Closes #324