### PR TITLE
feat: explicit cgroup-controller delegation at each realm/space/stack level

### DIFF
--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -714,6 +714,13 @@ func (r *Exec) ensureSpaceCgroup(space intmodel.Space) (intmodel.Space, error) {
 		if err := r.UpdateSpaceMetadata(space); err != nil {
 			return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateSpaceMetadata, err)
 		}
+		// Idempotent re-toggle of the space's subtree controllers — see the
+		// matching realm ensure-path note for the rationale (issue #327).
+		if subtreeErr := r.enableAncestorSubtreeControllers(spaceDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
+			r.logger.WarnContext(r.ctx,
+				"failed to enable space subtree controllers on ensure-path",
+				"space", space.Metadata.Name, "error", subtreeErr)
+		}
 	}
 
 	return space, nil
@@ -755,6 +762,13 @@ func (r *Exec) createSpaceCgroup(space intmodel.Space) (string, error) {
 		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateSpaceCgroup, createErr)
 	}
 
+	// Delegate the kukeon resource subset on the space's own subtree_control
+	// so an empty space (no descendant stack/cell yet) still carries the
+	// controllers — issue #327.
+	if subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint); subtreeErr != nil {
+		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateSpaceCgroup, subtreeErr)
+	}
+
 	r.logger.InfoContext(
 		r.ctx,
 		"created space cgroup",
@@ -787,6 +801,15 @@ func (r *Exec) createRealmCgroup(realm intmodel.Realm) (string, error) {
 	cgroupPath, createErr := r.createCgroupInternal(spec)
 	if createErr != nil {
 		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateRealmCgroup, createErr)
+	}
+
+	// Delegate the kukeon resource subset on the realm's own subtree_control
+	// so an empty realm (no descendant space/stack/cell yet) still carries
+	// the controllers — issue #327. Mirrors the cell-level call site below
+	// so each level explicitly populates its own subtree instead of
+	// relying on the first cell's ancestor walk to widen everything.
+	if subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint); subtreeErr != nil {
+		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateRealmCgroup, subtreeErr)
 	}
 
 	r.logger.InfoContext(
@@ -844,6 +867,16 @@ func (r *Exec) ensureRealmCgroup(realm intmodel.Realm) (intmodel.Realm, error) {
 	if realmDoc.Status.CgroupPath != "" {
 		if err := r.UpdateRealmMetadata(realm); err != nil {
 			return intmodel.Realm{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateRealmMetadata, err)
+		}
+		// Idempotent re-toggle of the realm's subtree controllers on every
+		// ensure-pass — covers daemon restart against pre-#327 realms whose
+		// subtree_control was only populated as a side effect of the first
+		// cell. No-op on already-delegated subtrees. Log + continue on
+		// failure to mirror the cell ensure-path pattern.
+		if subtreeErr := r.enableAncestorSubtreeControllers(realmDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
+			r.logger.WarnContext(r.ctx,
+				"failed to enable realm subtree controllers on ensure-path",
+				"realm", realm.Metadata.Name, "error", subtreeErr)
 		}
 	} else {
 		// If cgroup path is still empty after ensureCgroupInternal, log warning
@@ -914,6 +947,13 @@ func (r *Exec) createStackCgroup(stack intmodel.Stack) (string, error) {
 		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateStackCgroup, createErr)
 	}
 
+	// Delegate the kukeon resource subset on the stack's own subtree_control
+	// so an empty stack (no descendant cell yet) still carries the
+	// controllers — issue #327.
+	if subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint); subtreeErr != nil {
+		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateStackCgroup, subtreeErr)
+	}
+
 	r.logger.InfoContext(
 		r.ctx,
 		"created stack cgroup",
@@ -973,6 +1013,13 @@ func (r *Exec) ensureStackCgroup(stack intmodel.Stack) (intmodel.Stack, error) {
 	if stackDoc.Status.CgroupPath != "" {
 		if err := r.UpdateStackMetadata(stack); err != nil {
 			return intmodel.Stack{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateStackMetadata, err)
+		}
+		// Idempotent re-toggle of the stack's subtree controllers — see the
+		// matching realm ensure-path note for the rationale (issue #327).
+		if subtreeErr := r.enableAncestorSubtreeControllers(stackDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
+			r.logger.WarnContext(r.ctx,
+				"failed to enable stack subtree controllers on ensure-path",
+				"stack", stack.Metadata.Name, "error", subtreeErr)
 		}
 	}
 
@@ -1104,6 +1151,19 @@ func (r *Exec) enableCellControllers(cell intmodel.Cell, group, mountpoint strin
 		return r.ctrClient.EnableCellAllSubtreeControllers(group, mountpoint)
 	}
 	return r.ctrClient.EnableCellSubtreeControllers(group, mountpoint, cgroupcheck.CellResourceControllers())
+}
+
+// enableAncestorSubtreeControllers delegates the kukeon resource subset on
+// a non-cell level (realm, space, stack) so the level's subtree_control is
+// populated independently of the first cell that lands under it. Without
+// this, an empty realm/space/stack carries no controllers — the cell-level
+// ToggleControllers walk only widens ancestors when a cell is created
+// (issue #327). Returning the underlying error lets callers in create-
+// paths fail hard while ensure-pass call sites can choose to log + continue
+// (matching the cell ensure-path pattern).
+func (r *Exec) enableAncestorSubtreeControllers(group, mountpoint string) error {
+	_, err := r.ctrClient.EnsureSubtreeControllers(group, mountpoint, cgroupcheck.CellResourceControllers())
+	return err
 }
 
 func (r *Exec) ensureCellCgroup(cell intmodel.Cell) (intmodel.Cell, error) {

--- a/internal/controller/runner/provision_subtree_test.go
+++ b/internal/controller/runner/provision_subtree_test.go
@@ -1,0 +1,380 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests exercise private create-cgroup helpers on *Exec
+package runner
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	cgroup2 "github.com/containerd/cgroups/v2/cgroup2"
+	apitypes "github.com/containerd/containerd/api/types"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/cgroupcheck"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/metadata"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// subtreeRecorderClient is a minimal ctr.Client stub for the per-level
+// delegation test (issue #327). It records EnsureSubtreeControllers calls
+// and returns success for the few methods exercised by the create paths
+// (Connect, GetCgroupMountpoint, GetCurrentCgroupPath, NewCgroup); every
+// other interface method panics so that an inadvertent code path change
+// gets caught loudly instead of silently passing through a no-op stub.
+type subtreeRecorderClient struct {
+	mountpoint        string
+	currentCgroupPath string
+	ensureCalls       []ensureSubtreeCall
+}
+
+type ensureSubtreeCall struct {
+	group       string
+	mountpoint  string
+	controllers []string
+}
+
+func (c *subtreeRecorderClient) Connect() error { return nil }
+func (c *subtreeRecorderClient) Close() error   { return nil }
+
+func (c *subtreeRecorderClient) GetCgroupMountpoint() string { return c.mountpoint }
+func (c *subtreeRecorderClient) GetCurrentCgroupPath() (string, error) {
+	return c.currentCgroupPath, nil
+}
+
+// NewCgroup returns a (nil, nil) pair: the create-cgroup paths under test
+// discard the returned manager and the cgroup2.Manager type has unexported
+// fields, so a non-nil sentinel is impossible to construct from outside the
+// containerd cgroups package. Callers in this package only check the error.
+//
+//nolint:nilnil // see comment above; (nil, nil) is the only valid stub here
+func (c *subtreeRecorderClient) NewCgroup(_ ctr.CgroupSpec) (*cgroup2.Manager, error) {
+	return nil, nil
+}
+
+func (c *subtreeRecorderClient) EnsureSubtreeControllers(
+	group, mountpoint string,
+	controllers []string,
+) ([]string, error) {
+	c.ensureCalls = append(c.ensureCalls, ensureSubtreeCall{
+		group:       group,
+		mountpoint:  mountpoint,
+		controllers: append([]string(nil), controllers...),
+	})
+	return controllers, nil
+}
+
+// All other methods panic — calling them from a per-level cgroup-create
+// test would mean the path under test grew an unexpected dependency, and
+// we want the failure surfaced immediately.
+func (c *subtreeRecorderClient) CreateNamespace(string) error { panic("unexpected") }
+func (c *subtreeRecorderClient) DeleteNamespace(string) error { panic("unexpected") }
+func (c *subtreeRecorderClient) ListNamespaces() ([]string, error) {
+	panic("unexpected")
+}
+func (c *subtreeRecorderClient) GetNamespace(string) (string, error)  { panic("unexpected") }
+func (c *subtreeRecorderClient) ExistsNamespace(string) (bool, error) { panic("unexpected") }
+func (c *subtreeRecorderClient) CleanupNamespaceResources(string, string) error {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) CgroupPath(string, string) (string, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) LoadCgroup(string, string) (*cgroup2.Manager, error) {
+	panic("unexpected")
+}
+func (c *subtreeRecorderClient) DeleteCgroup(string, string) error { panic("unexpected") }
+func (c *subtreeRecorderClient) EnableCellSubtreeControllers(string, string, []string) error {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) EnableCellAllSubtreeControllers(string, string) error {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) CreateContainerFromSpec(
+	string, intmodel.ContainerSpec, []ctr.RegistryCredentials, ...ctr.BuildOption,
+) (containerd.Container, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) CreateContainer(
+	string, ctr.ContainerSpec, []ctr.RegistryCredentials,
+) (containerd.Container, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) GetContainer(string, string) (containerd.Container, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) ListContainers(string, ...string) ([]containerd.Container, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) ExistsContainer(string, string) (bool, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) DeleteContainer(string, string, ctr.ContainerDeleteOptions) error {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) StartContainer(
+	string, ctr.ContainerSpec, ctr.TaskSpec,
+) (containerd.Task, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) StopContainer(
+	string, string, ctr.StopContainerOptions,
+) (*containerd.ExitStatus, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) TaskStatus(string, string) (containerd.Status, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) TaskMetrics(string, string) (*apitypes.Metric, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) ResolveSbshCachePath(
+	string, string, string, []ctr.RegistryCredentials,
+) (string, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) ContainerProcessUID(string, containerd.Container) (uint32, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) LoadImage(string, io.Reader) ([]string, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) ListImages(string) ([]ctr.ImageInfo, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) GetImage(string, string) (ctr.ImageInfo, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) DeleteImage(string, string) error {
+	panic("unexpected")
+}
+
+// Compile-time: the stub satisfies the full Client surface.
+var _ ctr.Client = (*subtreeRecorderClient)(nil)
+
+// newSubtreeTestExec builds a minimal *Exec backed by subtreeRecorderClient.
+// The currentCgroupPath is fixed at consts.KukeonCgroupRoot to mirror the
+// real GetCurrentCgroupPath, so spec.Group ends up rooted at /kukeon/...
+// just like the production path.
+func newSubtreeTestExec(t *testing.T, fake *subtreeRecorderClient) *Exec {
+	t.Helper()
+	return &Exec{
+		ctx:       context.Background(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctrClient: fake,
+		opts:      Options{RunPath: t.TempDir()},
+	}
+}
+
+// seedRealmMetadata writes a minimal realm metadata file under r.opts.RunPath
+// so r.GetRealm finds it. createSpaceCgroup looks up the parent realm only
+// to log its name; nothing structural beyond name+namespace is needed.
+func seedRealmMetadata(t *testing.T, r *Exec, realmName string) {
+	t.Helper()
+	doc := v1beta1.RealmDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindRealm,
+		Metadata:   v1beta1.RealmMetadata{Name: realmName},
+		Spec:       v1beta1.RealmSpec{Namespace: realmName + ".kukeon.io"},
+	}
+	path := fs.RealmMetadataPath(r.opts.RunPath, realmName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir realm metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write realm metadata: %v", err)
+	}
+}
+
+// TestEnableAncestorSubtreeControllersPassesResourceSubset pins the
+// invariant that every realm/space/stack create path delegates exactly the
+// kukeon resource subset (cgroupcheck.CellResourceControllers) — the same
+// set the doctor pre-flight expects on the host root. Issue #327.
+func TestEnableAncestorSubtreeControllersPassesResourceSubset(t *testing.T) {
+	fake := &subtreeRecorderClient{mountpoint: "/sys/fs/cgroup"}
+	r := newSubtreeTestExec(t, fake)
+
+	if err := r.enableAncestorSubtreeControllers("/kukeon/foo", "/sys/fs/cgroup"); err != nil {
+		t.Fatalf("enableAncestorSubtreeControllers() unexpected error: %v", err)
+	}
+	if len(fake.ensureCalls) != 1 {
+		t.Fatalf("EnsureSubtreeControllers call count = %d, want 1", len(fake.ensureCalls))
+	}
+	got := fake.ensureCalls[0]
+	if got.group != "/kukeon/foo" {
+		t.Errorf("EnsureSubtreeControllers group = %q, want %q", got.group, "/kukeon/foo")
+	}
+	if got.mountpoint != "/sys/fs/cgroup" {
+		t.Errorf("EnsureSubtreeControllers mountpoint = %q, want %q", got.mountpoint, "/sys/fs/cgroup")
+	}
+	if want := cgroupcheck.CellResourceControllers(); !reflect.DeepEqual(got.controllers, want) {
+		t.Errorf("EnsureSubtreeControllers controllers = %v, want %v", got.controllers, want)
+	}
+}
+
+// TestCreateRealmCgroupEmptyRealmDelegates pins the AC1 invariant from
+// issue #327: creating an empty realm — no descendant space/stack/cell —
+// must still populate the realm's own cgroup.subtree_control with the
+// kukeon resource subset. Pre-#327 the realm subtree was empty until the
+// first cell landed; this test fails if that regression returns.
+func TestCreateRealmCgroupEmptyRealmDelegates(t *testing.T) {
+	fake := &subtreeRecorderClient{
+		mountpoint:        "/sys/fs/cgroup",
+		currentCgroupPath: consts.KukeonCgroupRoot,
+	}
+	r := newSubtreeTestExec(t, fake)
+
+	if _, err := r.createRealmCgroup(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: "empty"},
+		Spec:     intmodel.RealmSpec{Namespace: "empty.kukeon.io"},
+	}); err != nil {
+		t.Fatalf("createRealmCgroup() unexpected error: %v", err)
+	}
+
+	if len(fake.ensureCalls) != 1 {
+		t.Fatalf("EnsureSubtreeControllers call count = %d, want 1 (empty-realm path)", len(fake.ensureCalls))
+	}
+	got := fake.ensureCalls[0]
+	wantGroup := consts.KukeonCgroupRoot + "/empty"
+	if got.group != wantGroup {
+		t.Errorf("empty-realm subtree-control target group = %q, want %q", got.group, wantGroup)
+	}
+	if want := cgroupcheck.CellResourceControllers(); !reflect.DeepEqual(got.controllers, want) {
+		t.Errorf("empty-realm subtree-control controllers = %v, want %v", got.controllers, want)
+	}
+}
+
+// TestCreateLevelCgroupsDelegateSubtreeControllers verifies that each
+// non-cell level (realm, space, stack) calls EnsureSubtreeControllers on
+// its own cgroup with the kukeon resource subset right after creating it.
+// Without these per-level call sites an empty realm/space/stack carries no
+// controllers in subtree_control until the first descendant cell triggers
+// the cell-level ancestor walk — issue #327.
+func TestCreateLevelCgroupsDelegateSubtreeControllers(t *testing.T) {
+	cases := []struct {
+		name      string
+		seed      func(t *testing.T, r *Exec)
+		call      func(r *Exec) (string, error)
+		wantGroup string
+	}{
+		{
+			name: "realm",
+			call: func(r *Exec) (string, error) {
+				return r.createRealmCgroup(intmodel.Realm{
+					Metadata: intmodel.RealmMetadata{Name: "alpha"},
+					Spec:     intmodel.RealmSpec{Namespace: "alpha.kukeon.io"},
+				})
+			},
+			wantGroup: consts.KukeonCgroupRoot + "/alpha",
+		},
+		{
+			name: "space",
+			seed: func(t *testing.T, r *Exec) {
+				// createSpaceCgroup looks up the parent realm via GetRealm
+				// (only to log its name); seed the realm metadata so the
+				// lookup succeeds in the unit-test sandbox.
+				seedRealmMetadata(t, r, "alpha")
+			},
+			call: func(r *Exec) (string, error) {
+				return r.createSpaceCgroup(intmodel.Space{
+					Metadata: intmodel.SpaceMetadata{Name: "beta"},
+					Spec:     intmodel.SpaceSpec{RealmName: "alpha"},
+				})
+			},
+			wantGroup: consts.KukeonCgroupRoot + "/alpha/beta",
+		},
+		{
+			name: "stack",
+			call: func(r *Exec) (string, error) {
+				return r.createStackCgroup(intmodel.Stack{
+					Metadata: intmodel.StackMetadata{Name: "gamma"},
+					Spec:     intmodel.StackSpec{RealmName: "alpha", SpaceName: "beta"},
+				})
+			},
+			wantGroup: consts.KukeonCgroupRoot + "/alpha/beta/gamma",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &subtreeRecorderClient{
+				mountpoint:        "/sys/fs/cgroup",
+				currentCgroupPath: consts.KukeonCgroupRoot,
+			}
+			r := newSubtreeTestExec(t, fake)
+			if tc.seed != nil {
+				tc.seed(t, r)
+			}
+
+			gotPath, err := tc.call(r)
+			if err != nil {
+				t.Fatalf("%s create path unexpected error: %v", tc.name, err)
+			}
+			if gotPath != tc.wantGroup {
+				t.Errorf("%s cgroup path = %q, want %q", tc.name, gotPath, tc.wantGroup)
+			}
+			if len(fake.ensureCalls) != 1 {
+				t.Fatalf(
+					"%s EnsureSubtreeControllers call count = %d, want 1 (got: %+v)",
+					tc.name, len(fake.ensureCalls), fake.ensureCalls,
+				)
+			}
+			got := fake.ensureCalls[0]
+			if got.group != tc.wantGroup {
+				t.Errorf("%s EnsureSubtreeControllers group = %q, want %q",
+					tc.name, got.group, tc.wantGroup)
+			}
+			if got.mountpoint != "/sys/fs/cgroup" {
+				t.Errorf("%s EnsureSubtreeControllers mountpoint = %q, want %q",
+					tc.name, got.mountpoint, "/sys/fs/cgroup")
+			}
+			if want := cgroupcheck.CellResourceControllers(); !reflect.DeepEqual(got.controllers, want) {
+				t.Errorf("%s EnsureSubtreeControllers controllers = %v, want %v",
+					tc.name, got.controllers, want)
+			}
+		})
+	}
+}

--- a/internal/ctr/cgroups.go
+++ b/internal/ctr/cgroups.go
@@ -131,33 +131,55 @@ func (c *client) AddProcessToCgroup(group, mountpoint string, pid int) error {
 	return manager.AddProc(uint64(pid))
 }
 
-// EnableCellSubtreeControllers writes "+<ctrl>" to every ancestor's
-// cgroup.subtree_control file (root → cell parent) AND to the cell's own
+// EnsureSubtreeControllers writes "+<ctrl>" to every ancestor's
+// cgroup.subtree_control file (root → group's parent) AND to the group's own
 // cgroup.subtree_control. The library's Manager.ToggleControllers handles the
-// ancestor walk by design but skips the cell itself ("the leaf does not need
-// it") — for kukeon the cell is *not* a leaf, since runc nests per-container
-// task cgroups under it (issue #312), so the cell's own subtree_control must
+// ancestor walk by design but skips the group itself ("the leaf does not need
+// it") — for kukeon, every level (realm, space, stack, cell) is *not* a leaf,
+// since each has descendants nested under it (issue #327, generalising the
+// cell-only case from issue #312), so the group's own subtree_control must
 // also be populated for those children to inherit the controllers.
 //
 // Filters the requested set against what the host root cgroup advertises so
 // callers can pass the desired superset without worrying about kernel
 // configuration variance (e.g. the io controller is missing on hosts without
-// blk-cgroup compiled in).
-func (c *client) EnableCellSubtreeControllers(group, mountpoint string, controllers []string) error {
+// blk-cgroup compiled in). Returns the effective set actually written.
+//
+// The behaviour is idempotent — re-running on an already-delegated subtree
+// is a no-op for the kernel (additive "+ctrl" writes), so callers can use
+// it both on first provision and on every ensure-pass.
+//
+// An empty `controllers` slice short-circuits with (nil, nil): no validation
+// work, no kernel writes. Callers in provision.go always pass
+// cgroupcheck.CellResourceControllers() so this branch only triggers on the
+// degenerate empty-slice input.
+func (c *client) EnsureSubtreeControllers(group, mountpoint string, controllers []string) ([]string, error) {
 	if err := validateGroupPath(group); err != nil {
-		return err
+		return nil, err
 	}
 	if len(controllers) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	mp := c.effectiveMountpoint(mountpoint)
 	available, err := readRootControllers(mp)
 	if err != nil {
-		return fmt.Errorf("read root cgroup.controllers: %w", err)
+		return nil, fmt.Errorf("read root cgroup.controllers: %w", err)
 	}
 	enable := intersectControllers(controllers, available)
-	return c.applyCellSubtreeControllers(group, mp, enable)
+	if applyErr := c.applySubtreeControllers(group, mp, enable); applyErr != nil {
+		return nil, applyErr
+	}
+	return enable, nil
+}
+
+// EnableCellSubtreeControllers is a thin wrapper around
+// EnsureSubtreeControllers for the cell create/ensure call sites that pass
+// the kukeon resource subset (cgroupcheck.CellResourceControllers). Issue
+// #312.
+func (c *client) EnableCellSubtreeControllers(group, mountpoint string, controllers []string) error {
+	_, err := c.EnsureSubtreeControllers(group, mountpoint, controllers)
+	return err
 }
 
 // EnableCellAllSubtreeControllers is the cell/profile=NestedCgroupRuntime
@@ -165,7 +187,7 @@ func (c *client) EnableCellSubtreeControllers(group, mountpoint string, controll
 // the cell's subtree_control (and every ancestor's), so a nested cgroup
 // runtime running inside the cell — e.g. an inner containerd or systemd
 // hosting its own children in sub-cgroups — can in turn delegate any
-// controller it wants.
+// controller it wants. Issue #314.
 //
 // The ordinary cell path (EnableCellSubtreeControllers with the kukeon
 // resource subset) is what every kukeon-managed cell wants by default; the
@@ -180,15 +202,15 @@ func (c *client) EnableCellAllSubtreeControllers(group, mountpoint string) error
 	if err != nil {
 		return fmt.Errorf("read root cgroup.controllers: %w", err)
 	}
-	return c.applyCellSubtreeControllers(group, mp, available)
+	return c.applySubtreeControllers(group, mp, available)
 }
 
-// applyCellSubtreeControllers is the shared body of the two
-// EnableCell*SubtreeControllers entry points. It assumes group has already
-// been validated and that controllers has been pre-filtered against the
-// host root's cgroup.controllers, so every entry is known-supported by the
+// applySubtreeControllers is the shared body of EnsureSubtreeControllers and
+// EnableCellAllSubtreeControllers. It assumes group has already been
+// validated and that controllers has been pre-filtered against the host
+// root's cgroup.controllers, so every entry is known-supported by the
 // running kernel.
-func (c *client) applyCellSubtreeControllers(group, mountpoint string, enable []string) error {
+func (c *client) applySubtreeControllers(group, mountpoint string, enable []string) error {
 	if len(enable) == 0 {
 		return nil
 	}
@@ -198,15 +220,15 @@ func (c *client) applyCellSubtreeControllers(group, mountpoint string, enable []
 		return err
 	}
 	if toggleErr := manager.ToggleControllers(enable, cgroup2.Enable); toggleErr != nil {
-		return fmt.Errorf("enable controllers in cell ancestors: %w", toggleErr)
+		return fmt.Errorf("enable controllers in cgroup ancestors: %w", toggleErr)
 	}
 
-	cellPath := filepath.Join(mountpoint, strings.TrimPrefix(group, "/"))
-	if writeErr := writeSubtreeEnable(filepath.Join(cellPath, "cgroup.subtree_control"), enable); writeErr != nil {
-		return fmt.Errorf("enable controllers in cell subtree_control: %w", writeErr)
+	groupPath := filepath.Join(mountpoint, strings.TrimPrefix(group, "/"))
+	if writeErr := writeSubtreeEnable(filepath.Join(groupPath, "cgroup.subtree_control"), enable); writeErr != nil {
+		return fmt.Errorf("enable controllers in cgroup subtree_control: %w", writeErr)
 	}
 
-	c.logger.InfoContext(c.ctx, "enabled cell cgroup controllers",
+	c.logger.InfoContext(c.ctx, "enabled cgroup subtree controllers",
 		"group", group, "mountpoint", mountpoint, "controllers", enable)
 	return nil
 }

--- a/internal/ctr/cgroups_test.go
+++ b/internal/ctr/cgroups_test.go
@@ -320,6 +320,64 @@ func TestGetCgroupMountpoint(t *testing.T) {
 	}
 }
 
+// TestEnsureSubtreeControllersValidation covers the input-validation
+// surface of the issue-#327 level-agnostic entry point used by every
+// realm/space/stack provision path. Mirrors TestEnableCellAllSubtreeControllersValidation:
+// the empty group path must be rejected with the shared sentinel; an
+// empty controllers slice short-circuits (no validation error, no work);
+// a syntactically valid group with a non-empty controllers list passes
+// validation (the underlying cgroupfs read is then expected to fail in
+// the unit-test environment, which we don't assert on).
+func TestEnsureSubtreeControllersValidation(t *testing.T) {
+	client := setupTestClientForCgroups(t)
+
+	if _, err := client.EnsureSubtreeControllers("", "/sys/fs/cgroup", []string{"cpu"}); err == nil {
+		t.Error("EnsureSubtreeControllers(empty group) error = nil, want ErrEmptyGroupPath")
+	} else if !errors.Is(err, errdefs.ErrEmptyGroupPath) {
+		t.Errorf("EnsureSubtreeControllers(empty group) error = %v, want ErrEmptyGroupPath", err)
+	}
+
+	// Empty controllers list: short-circuit without touching the cgroup
+	// hierarchy. Must not return ErrEmptyGroupPath (group is valid) and
+	// must return a nil effective set.
+	got, err := client.EnsureSubtreeControllers("/kukeon/test", "/sys/fs/cgroup", nil)
+	if err != nil {
+		t.Errorf("EnsureSubtreeControllers(empty controllers) error = %v, want nil", err)
+	}
+	if got != nil {
+		t.Errorf("EnsureSubtreeControllers(empty controllers) effective = %v, want nil", got)
+	}
+
+	// Syntactically valid group + non-empty controllers: validation must
+	// pass; downstream cgroupfs access then fails in the unit-test sandbox,
+	// which is fine — that is not a validation failure and must not
+	// surface ErrEmptyGroupPath.
+	if _, validErr := client.EnsureSubtreeControllers("/kukeon/test", "/sys/fs/cgroup", []string{"cpu"}); validErr != nil &&
+		errors.Is(validErr, errdefs.ErrEmptyGroupPath) {
+		t.Errorf("EnsureSubtreeControllers(valid group) unexpected validation error: %v", validErr)
+	}
+}
+
+// TestEnableCellSubtreeControllersValidation pins the cell-wrapper's
+// validation behaviour after refactoring it onto EnsureSubtreeControllers
+// (issue #327). The semantics — empty group rejected, valid group allowed
+// past validation — must match the pre-refactor behaviour so cell call
+// sites in provision.go keep working unchanged.
+func TestEnableCellSubtreeControllersValidation(t *testing.T) {
+	client := setupTestClientForCgroups(t)
+
+	if err := client.EnableCellSubtreeControllers("", "/sys/fs/cgroup", []string{"cpu"}); err == nil {
+		t.Error("EnableCellSubtreeControllers(empty group) error = nil, want ErrEmptyGroupPath")
+	} else if !errors.Is(err, errdefs.ErrEmptyGroupPath) {
+		t.Errorf("EnableCellSubtreeControllers(empty group) error = %v, want ErrEmptyGroupPath", err)
+	}
+
+	if err := client.EnableCellSubtreeControllers("/kukeon/test", "/sys/fs/cgroup", []string{"cpu"}); err != nil &&
+		errors.Is(err, errdefs.ErrEmptyGroupPath) {
+		t.Errorf("EnableCellSubtreeControllers(valid group) unexpected validation error: %v", err)
+	}
+}
+
 // TestEnableCellAllSubtreeControllersValidation covers the input-validation
 // surface of the issue-#314 NestedCgroupRuntime entry point. The cgroup
 // hierarchy itself isn't writable from a unit test environment, so this

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -62,12 +62,22 @@ type Client interface {
 	NewCgroup(spec CgroupSpec) (*cgroup2.Manager, error)
 	LoadCgroup(group string, mountpoint string) (*cgroup2.Manager, error)
 	DeleteCgroup(group, mountpoint string) error
+	// EnsureSubtreeControllers writes "+<ctrl>" to the named group's own
+	// cgroup.subtree_control AND to every ancestor up to the unified cgroup
+	// mount, so the group's children inherit the controllers. The level-
+	// agnostic primitive used by every realm/space/stack ensure path (issue
+	// #327) and by the cell wrappers below (issues #312, #314). Filters the
+	// requested set against what the host root advertises and returns the
+	// effective set actually written. Idempotent — re-running on an already-
+	// delegated subtree is a no-op.
+	EnsureSubtreeControllers(group, mountpoint string, controllers []string) ([]string, error)
 	// EnableCellSubtreeControllers enables the named cgroup-v2 controllers in
 	// the cell cgroup's own subtree_control AND in every ancestor's
 	// subtree_control up to the unified cgroup mount, so child cgroups (the
 	// per-container task cgroups runc creates under Linux.CgroupsPath)
 	// inherit the controllers and cell-level resource accounting / limits
-	// become effective. Issue #312.
+	// become effective. Thin wrapper around EnsureSubtreeControllers kept
+	// for the cell call sites' readability. Issue #312.
 	EnableCellSubtreeControllers(group, mountpoint string, controllers []string) error
 	// EnableCellAllSubtreeControllers is the cell/profile=NestedCgroupRuntime
 	// counterpart: it delegates the full host-available cgroup-v2 controller


### PR DESCRIPTION
## Summary

- Extracts a level-agnostic `EnsureSubtreeControllers(group, mountpoint, controllers)` in `internal/ctr/cgroups.go` from the cell-only `applyCellSubtreeControllers`. `EnableCellSubtreeControllers` and `EnableCellAllSubtreeControllers` stay as the cell wrappers, so the cell call sites in `provision.go` are unchanged behaviourally.
- Wires the new helper into the realm/space/stack create + ensure paths in `internal/controller/runner/provision.go`. Each level now populates its own `cgroup.subtree_control` with the kukeon resource subset (`cgroupcheck.CellResourceControllers()`) the moment it is provisioned, instead of inheriting it as a side effect of the first cell that lands underneath. Ensure-pass call sites are warning-only on failure to mirror the cell pattern.

This is phase 1 of #327 (correctness only). Phases 2 (`Status.SubtreeControllers` + `kuke get`) and 3 (`kuke doctor cgroups --scope`) are #328 and #329.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full unit suite passes; new tests:
  - `internal/ctr/cgroups_test.go` — `TestEnsureSubtreeControllersValidation`, `TestEnableCellSubtreeControllersValidation` (both new); `TestEnableCellAllSubtreeControllersValidation` still passes (AC4).
  - `internal/controller/runner/provision_subtree_test.go` — `TestEnableAncestorSubtreeControllersPassesResourceSubset`, `TestCreateRealmCgroupEmptyRealmDelegates`, `TestCreateLevelCgroupsDelegateSubtreeControllers/{realm,space,stack}` (per-level delegation paths + empty-realm case).
- [x] `pre-commit run` — clean on the changed Go files.
- [x] `make dev-init` — daemon-parity tail unchanged; both realms `Ready` from both daemon and `--no-daemon` views (AC3, AC5).
- [x] End-to-end empty-realm/space/stack check (AC1, AC2):
  ```
  $ sudo ./kuke create realm test327
  $ sudo cat /sys/fs/cgroup/kukeon/test327/cgroup.subtree_control
  cpu io memory pids
  $ sudo ./kuke create space test327space --realm test327
  $ sudo cat /sys/fs/cgroup/kukeon/test327/test327space/cgroup.subtree_control
  cpu io memory pids
  $ sudo ./kuke create stack test327stack --realm test327 --space test327space
  $ sudo cat /sys/fs/cgroup/kukeon/test327/test327space/test327stack/cgroup.subtree_control
  cpu io memory pids
  ```
  Each empty level carries the resource subset on its own subtree, with no descendant cell required to trigger delegation.

## Notes

- The cell-level call sites at `provision.go:1078` (create) and `:1169` (ensure) are unchanged. The cell still picks between resource-subset and full-set delegation via `enableCellControllers` based on `Spec.NestedCgroupRuntime`.
- The `subtreeRecorderClient` test stub implements all 33 `ctr.Client` methods; only the four touched by the create paths return real values, the rest panic so an inadvertent dependency growth surfaces loudly.

Closes #327