### PR TITLE
feat: surface Status.SubtreeControllers on realm/space/stack/cell

### DIFF
--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -109,7 +109,8 @@ func NewCellCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printCells(cmd, cells, outputFormat)
+			showControllers, _ := cmd.Flags().GetBool("show-controllers")
+			return printCells(cmd, cells, outputFormat, showControllers)
 		},
 	}
 
@@ -123,6 +124,10 @@ func NewCellCmd() *cobra.Command {
 		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+	cmd.Flags().Bool(
+		"show-controllers", false,
+		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each cell's subtree (issue #328).",
+	)
 
 	cmd.ValidArgsFunction = config.CompleteCellNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -150,7 +155,7 @@ func printCell(cell *v1beta1.CellDoc, format shared.OutputFormat) error {
 	}
 }
 
-func printCells(cmd *cobra.Command, cells []v1beta1.CellDoc, format shared.OutputFormat) error {
+func printCells(cmd *cobra.Command, cells []v1beta1.CellDoc, format shared.OutputFormat, showControllers bool) error {
 	switch format {
 	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cells)
@@ -162,6 +167,9 @@ func printCells(cmd *cobra.Command, cells []v1beta1.CellDoc, format shared.Outpu
 			return nil
 		}
 		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "CGROUP"}
+		if showControllers {
+			headers = append(headers, "CONTROLLERS")
+		}
 		rows := make([][]string, 0, len(cells))
 		for i := range cells {
 			c := &cells[i]
@@ -170,10 +178,11 @@ func printCells(cmd *cobra.Command, cells []v1beta1.CellDoc, format shared.Outpu
 			if cgroup == "" {
 				cgroup = "-"
 			}
-			rows = append(
-				rows,
-				[]string{c.Metadata.Name, c.Spec.RealmID, c.Spec.SpaceID, c.Spec.StackID, state, cgroup},
-			)
+			row := []string{c.Metadata.Name, c.Spec.RealmID, c.Spec.SpaceID, c.Spec.StackID, state, cgroup}
+			if showControllers {
+				row = append(row, shared.FormatControllers(c.Status.SubtreeControllers))
+			}
+			rows = append(rows, row)
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil

--- a/cmd/kuke/get/realm/realm.go
+++ b/cmd/kuke/get/realm/realm.go
@@ -82,7 +82,8 @@ func NewRealmCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printRealms(cmd, realms, outputFormat)
+			showControllers, _ := cmd.Flags().GetBool("show-controllers")
+			return printRealms(cmd, realms, outputFormat, showControllers)
 		},
 	}
 
@@ -90,6 +91,10 @@ func NewRealmCmd() *cobra.Command {
 		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+	cmd.Flags().Bool(
+		"show-controllers", false,
+		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each realm's subtree (issue #328). Off by default to keep the default table the daemon-parity dev-init regression guard expects.",
+	)
 
 	cmd.ValidArgsFunction = config.CompleteRealmNames
 	_ = cmd.RegisterFlagCompletionFunc("output", config.CompleteOutputFormat)
@@ -114,7 +119,12 @@ func printRealm(realm *v1beta1.RealmDoc, format shared.OutputFormat) error {
 	}
 }
 
-func printRealms(cmd *cobra.Command, realms []v1beta1.RealmDoc, format shared.OutputFormat) error {
+func printRealms(
+	cmd *cobra.Command,
+	realms []v1beta1.RealmDoc,
+	format shared.OutputFormat,
+	showControllers bool,
+) error {
 	switch format {
 	case shared.OutputFormatYAML:
 		return shared.PrintYAML(realms)
@@ -126,6 +136,9 @@ func printRealms(cmd *cobra.Command, realms []v1beta1.RealmDoc, format shared.Ou
 			return nil
 		}
 		headers := []string{"NAME", "NAMESPACE", "STATE", "CGROUP"}
+		if showControllers {
+			headers = append(headers, "CONTROLLERS")
+		}
 		rows := make([][]string, 0, len(realms))
 		for i := range realms {
 			r := &realms[i]
@@ -134,7 +147,11 @@ func printRealms(cmd *cobra.Command, realms []v1beta1.RealmDoc, format shared.Ou
 			if cgroup == "" {
 				cgroup = "-"
 			}
-			rows = append(rows, []string{r.Metadata.Name, r.Spec.Namespace, state, cgroup})
+			row := []string{r.Metadata.Name, r.Spec.Namespace, state, cgroup}
+			if showControllers {
+				row = append(row, shared.FormatControllers(r.Status.SubtreeControllers))
+			}
+			rows = append(rows, row)
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil

--- a/cmd/kuke/get/realm/realm_test.go
+++ b/cmd/kuke/get/realm/realm_test.go
@@ -147,6 +147,88 @@ func TestNewRealmCmd_Structure(t *testing.T) {
 	if cmd.Flags().Lookup("output") == nil {
 		t.Fatal("expected output flag")
 	}
+	if cmd.Flags().Lookup("show-controllers") == nil {
+		t.Fatal("expected show-controllers flag (issue #328)")
+	}
+}
+
+// TestNewRealmCmd_ShowControllers pins the issue #328 surfacing rule:
+//
+//   - default `kuke get realms` MUST omit the CONTROLLERS column so the
+//     dev-init daemon-parity tail (NAME NAMESPACE STATE CGROUP) stays
+//     byte-identical to what kukeon's CLAUDE.md regression guard expects.
+//   - `--show-controllers` adds the column with the comma-joined effective
+//     set, falling back to "-" when SubtreeControllers is empty.
+func TestNewRealmCmd_ShowControllers(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func() ([]v1beta1.RealmDoc, error) {
+		return []v1beta1.RealmDoc{
+			{
+				Metadata: v1beta1.RealmMetadata{Name: "default"},
+				Spec:     v1beta1.RealmSpec{Namespace: "default.kukeon.io"},
+				Status: v1beta1.RealmStatus{
+					CgroupPath:         "/kukeon/default",
+					SubtreeControllers: []string{"cpu", "memory", "io", "pids"},
+				},
+			},
+			{
+				Metadata: v1beta1.RealmMetadata{Name: "kuke-system"},
+				Spec:     v1beta1.RealmSpec{Namespace: "kuke-system.kukeon.io"},
+				Status: v1beta1.RealmStatus{
+					CgroupPath: "/kukeon/kuke-system",
+				},
+			},
+		}, nil
+	}
+
+	t.Run("default omits controllers column", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+
+		cmd := realm.NewRealmCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(),
+			realm.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listRealmsFn: listFn}))
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(buf.String(), "CONTROLLERS") {
+			t.Errorf("default output must NOT include CONTROLLERS column "+
+				"(issue #328 dev-init regression guard); got:\n%s", buf.String())
+		}
+	})
+
+	t.Run("flag appends controllers column", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+
+		cmd := realm.NewRealmCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(),
+			realm.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listRealmsFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"--show-controllers"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "CONTROLLERS") {
+			t.Errorf("expected CONTROLLERS column with --show-controllers; got:\n%s", out)
+		}
+		if !strings.Contains(out, "cpu,memory,io,pids") {
+			t.Errorf("expected joined controller list; got:\n%s", out)
+		}
+		// The empty-controllers row renders "-".
+		if !strings.Contains(out, "kuke-system") || !strings.Contains(out, " -") {
+			t.Errorf("expected empty controllers to render as '-'; got:\n%s", out)
+		}
+	})
 }
 
 type fakeClient struct {

--- a/cmd/kuke/get/shared/shared.go
+++ b/cmd/kuke/get/shared/shared.go
@@ -160,6 +160,17 @@ func PrintTable(cmd *cobra.Command, headers []string, rows [][]string) {
 	}
 }
 
+// FormatControllers renders a Status.SubtreeControllers slice for the
+// CONTROLLERS table column emitted by `kuke get <kind> --show-controllers`
+// (issue #328). Empty input renders as "-" so the column never collapses
+// to an unaligned blank cell.
+func FormatControllers(controllers []string) string {
+	if len(controllers) == 0 {
+		return "-"
+	}
+	return strings.Join(controllers, ",")
+}
+
 // ControllerFromCmd reuses the controller helper from create/shared.
 func ControllerFromCmd(cmd *cobra.Command) (*controller.Exec, error) {
 	return createshared.ControllerFromCmd(cmd)

--- a/cmd/kuke/get/space/space.go
+++ b/cmd/kuke/get/space/space.go
@@ -91,7 +91,8 @@ func NewSpaceCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printSpaces(cmd, spaces, outputFormat)
+			showControllers, _ := cmd.Flags().GetBool("show-controllers")
+			return printSpaces(cmd, spaces, outputFormat, showControllers)
 		},
 	}
 
@@ -102,6 +103,10 @@ func NewSpaceCmd() *cobra.Command {
 		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+	cmd.Flags().Bool(
+		"show-controllers", false,
+		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each space's subtree (issue #328).",
+	)
 
 	cmd.ValidArgsFunction = config.CompleteSpaceNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -127,7 +132,12 @@ func printSpace(space *v1beta1.SpaceDoc, format shared.OutputFormat) error {
 	}
 }
 
-func printSpaces(cmd *cobra.Command, spaces []v1beta1.SpaceDoc, format shared.OutputFormat) error {
+func printSpaces(
+	cmd *cobra.Command,
+	spaces []v1beta1.SpaceDoc,
+	format shared.OutputFormat,
+	showControllers bool,
+) error {
 	switch format {
 	case shared.OutputFormatYAML:
 		return shared.PrintYAML(spaces)
@@ -139,6 +149,9 @@ func printSpaces(cmd *cobra.Command, spaces []v1beta1.SpaceDoc, format shared.Ou
 			return nil
 		}
 		headers := []string{"NAME", "REALM", "STATE", "CGROUP"}
+		if showControllers {
+			headers = append(headers, "CONTROLLERS")
+		}
 		rows := make([][]string, 0, len(spaces))
 		for i := range spaces {
 			s := &spaces[i]
@@ -147,7 +160,11 @@ func printSpaces(cmd *cobra.Command, spaces []v1beta1.SpaceDoc, format shared.Ou
 			if cgroup == "" {
 				cgroup = "-"
 			}
-			rows = append(rows, []string{s.Metadata.Name, s.Spec.RealmID, state, cgroup})
+			row := []string{s.Metadata.Name, s.Spec.RealmID, state, cgroup}
+			if showControllers {
+				row = append(row, shared.FormatControllers(s.Status.SubtreeControllers))
+			}
+			rows = append(rows, row)
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil

--- a/cmd/kuke/get/stack/stack.go
+++ b/cmd/kuke/get/stack/stack.go
@@ -101,7 +101,8 @@ func NewStackCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return printStacks(cmd, stacks, outputFormat)
+			showControllers, _ := cmd.Flags().GetBool("show-controllers")
+			return printStacks(cmd, stacks, outputFormat, showControllers)
 		},
 	}
 
@@ -113,6 +114,10 @@ func NewStackCmd() *cobra.Command {
 		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+	cmd.Flags().Bool(
+		"show-controllers", false,
+		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each stack's subtree (issue #328).",
+	)
 
 	cmd.ValidArgsFunction = config.CompleteStackNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -139,7 +144,12 @@ func printStack(stack *v1beta1.StackDoc, format shared.OutputFormat) error {
 	}
 }
 
-func printStacks(cmd *cobra.Command, stacks []v1beta1.StackDoc, format shared.OutputFormat) error {
+func printStacks(
+	cmd *cobra.Command,
+	stacks []v1beta1.StackDoc,
+	format shared.OutputFormat,
+	showControllers bool,
+) error {
 	switch format {
 	case shared.OutputFormatYAML:
 		return shared.PrintYAML(stacks)
@@ -151,6 +161,9 @@ func printStacks(cmd *cobra.Command, stacks []v1beta1.StackDoc, format shared.Ou
 			return nil
 		}
 		headers := []string{"NAME", "REALM", "SPACE", "STATE", "CGROUP"}
+		if showControllers {
+			headers = append(headers, "CONTROLLERS")
+		}
 		rows := make([][]string, 0, len(stacks))
 		for i := range stacks {
 			s := &stacks[i]
@@ -159,7 +172,11 @@ func printStacks(cmd *cobra.Command, stacks []v1beta1.StackDoc, format shared.Ou
 			if cgroup == "" {
 				cgroup = "-"
 			}
-			rows = append(rows, []string{s.Metadata.Name, s.Spec.RealmID, s.Spec.SpaceID, state, cgroup})
+			row := []string{s.Metadata.Name, s.Spec.RealmID, s.Spec.SpaceID, state, cgroup}
+			if showControllers {
+				row = append(row, shared.FormatControllers(s.Status.SubtreeControllers))
+			}
+			rows = append(rows, row)
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -58,8 +58,9 @@ func ConvertRealmDocToInternal(in ext.RealmDoc) (intmodel.Realm, error) {
 				RegistryCredentials: registryCreds,
 			},
 			Status: intmodel.RealmStatus{
-				State:      intmodel.RealmState(in.Status.State),
-				CgroupPath: in.Status.CgroupPath,
+				State:              intmodel.RealmState(in.Status.State),
+				CgroupPath:         in.Status.CgroupPath,
+				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
 			},
 		}, nil
 	default:
@@ -91,8 +92,9 @@ func BuildRealmExternalFromInternal(in intmodel.Realm, apiVersion ext.Version) (
 				RegistryCredentials: registryCreds,
 			},
 			Status: ext.RealmStatus{
-				State:      ext.RealmState(in.Status.State),
-				CgroupPath: in.Status.CgroupPath,
+				State:              ext.RealmState(in.Status.State),
+				CgroupPath:         in.Status.CgroupPath,
+				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
 			},
 		}, nil
 	default:
@@ -139,8 +141,9 @@ func ConvertSpaceDocToInternal(in ext.SpaceDoc) (intmodel.Space, error) {
 				Defaults:      convertSpaceDefaultsToInternal(in.Spec.Defaults),
 			},
 			Status: intmodel.SpaceStatus{
-				State:      intState,
-				CgroupPath: in.Status.CgroupPath,
+				State:              intState,
+				CgroupPath:         in.Status.CgroupPath,
+				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
 			},
 		}, nil
 	default:
@@ -178,8 +181,9 @@ func BuildSpaceExternalFromInternal(in intmodel.Space, apiVersion ext.Version) (
 				Defaults:      buildSpaceDefaultsExternalFromInternal(in.Spec.Defaults),
 			},
 			Status: ext.SpaceStatus{
-				State:      extState,
-				CgroupPath: in.Status.CgroupPath,
+				State:              extState,
+				CgroupPath:         in.Status.CgroupPath,
+				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
 			},
 		}, nil
 	default:
@@ -212,8 +216,9 @@ func ConvertStackDocToInternal(in ext.StackDoc) (intmodel.Stack, error) {
 				SpaceName: in.Spec.SpaceID,
 			},
 			Status: intmodel.StackStatus{
-				State:      intmodel.StackState(in.Status.State),
-				CgroupPath: in.Status.CgroupPath,
+				State:              intmodel.StackState(in.Status.State),
+				CgroupPath:         in.Status.CgroupPath,
+				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
 			},
 		}, nil
 	default:
@@ -238,8 +243,9 @@ func BuildStackExternalFromInternal(in intmodel.Stack, apiVersion ext.Version) (
 				SpaceID: in.Spec.SpaceName,
 			},
 			Status: ext.StackStatus{
-				State:      ext.StackState(in.Status.State),
-				CgroupPath: in.Status.CgroupPath,
+				State:              ext.StackState(in.Status.State),
+				CgroupPath:         in.Status.CgroupPath,
+				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
 			},
 		}, nil
 	default:
@@ -707,6 +713,17 @@ func buildSpaceContainerDefaultsExternalFromInternal(in *intmodel.SpaceContainer
 	}
 }
 
+// cloneStringSlice returns a deep copy of in. Used by Status conversions so
+// the external and internal models do not alias the same backing array.
+// Returns nil for nil/empty input so the resulting Status field stays nil
+// and `omitempty`-tagged JSON/YAML emit nothing (issue #328).
+func cloneStringSlice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	return append([]string(nil), in...)
+}
+
 func copyBoolPtr(in *bool) *bool {
 	if in == nil {
 		return nil
@@ -817,8 +834,9 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				NestedCgroupRuntime: in.Spec.NestedCgroupRuntime,
 			},
 			Status: intmodel.CellStatus{
-				State:      intmodel.CellState(in.Status.State),
-				CgroupPath: in.Status.CgroupPath,
+				State:              intmodel.CellState(in.Status.State),
+				CgroupPath:         in.Status.CgroupPath,
+				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
 				Network: intmodel.CellNetworkStatus{
 					BridgeName: in.Status.Network.BridgeName,
 				},
@@ -878,8 +896,9 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				NestedCgroupRuntime: in.Spec.NestedCgroupRuntime,
 			},
 			Status: ext.CellStatus{
-				State:      ext.CellState(in.Status.State),
-				CgroupPath: in.Status.CgroupPath,
+				State:              ext.CellState(in.Status.State),
+				CgroupPath:         in.Status.CgroupPath,
+				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
 				Network: ext.CellNetworkStatus{
 					BridgeName: in.Status.Network.BridgeName,
 				},

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -17,6 +17,7 @@
 package apischeme_test
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1291,4 +1292,143 @@ func TestContainerSecretYAMLNeverLeaksValues(t *testing.T) {
 			t.Fatalf("rendered YAML contains forbidden key %q; full doc:\n%s", forbidden, rendered)
 		}
 	}
+}
+
+// TestSubtreeControllersRoundTripV1Beta1 pins the issue #328 plumbing: the
+// new Status.SubtreeControllers field must round-trip in both directions on
+// realm/space/stack/cell. Covered together because the field has identical
+// semantics on every level.
+func TestSubtreeControllersRoundTripV1Beta1(t *testing.T) {
+	want := []string{"cpu", "memory", "io", "pids"}
+
+	t.Run("realm", func(t *testing.T) {
+		ext2int, err := apischeme.ConvertRealmDocToInternal(ext.RealmDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindRealm,
+			Metadata:   ext.RealmMetadata{Name: "r0"},
+			Status:     ext.RealmStatus{SubtreeControllers: want},
+		})
+		if err != nil {
+			t.Fatalf("ConvertRealmDocToInternal: %v", err)
+		}
+		if !reflect.DeepEqual(ext2int.Status.SubtreeControllers, want) {
+			t.Errorf("ext→int realm SubtreeControllers = %v, want %v",
+				ext2int.Status.SubtreeControllers, want)
+		}
+		out, err := apischeme.BuildRealmExternalFromInternal(ext2int, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildRealmExternalFromInternal: %v", err)
+		}
+		if !reflect.DeepEqual(out.Status.SubtreeControllers, want) {
+			t.Errorf("int→ext realm SubtreeControllers = %v, want %v",
+				out.Status.SubtreeControllers, want)
+		}
+		// Aliasing guard: mutating the converted slice must not bleed into
+		// the source. cloneStringSlice is what enforces this.
+		out.Status.SubtreeControllers[0] = "MUTATED"
+		if ext2int.Status.SubtreeControllers[0] != "cpu" {
+			t.Errorf("realm SubtreeControllers aliased internal slice (got %q)",
+				ext2int.Status.SubtreeControllers[0])
+		}
+	})
+
+	t.Run("space", func(t *testing.T) {
+		ext2int, err := apischeme.ConvertSpaceDocToInternal(ext.SpaceDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindSpace,
+			Metadata:   ext.SpaceMetadata{Name: "s0"},
+			Spec:       ext.SpaceSpec{RealmID: "r0"},
+			Status:     ext.SpaceStatus{SubtreeControllers: want},
+		})
+		if err != nil {
+			t.Fatalf("ConvertSpaceDocToInternal: %v", err)
+		}
+		if !reflect.DeepEqual(ext2int.Status.SubtreeControllers, want) {
+			t.Errorf("ext→int space SubtreeControllers = %v, want %v",
+				ext2int.Status.SubtreeControllers, want)
+		}
+		out, err := apischeme.BuildSpaceExternalFromInternal(ext2int, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildSpaceExternalFromInternal: %v", err)
+		}
+		if !reflect.DeepEqual(out.Status.SubtreeControllers, want) {
+			t.Errorf("int→ext space SubtreeControllers = %v, want %v",
+				out.Status.SubtreeControllers, want)
+		}
+	})
+
+	t.Run("stack", func(t *testing.T) {
+		ext2int, err := apischeme.ConvertStackDocToInternal(ext.StackDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindStack,
+			Metadata:   ext.StackMetadata{Name: "st0"},
+			Spec:       ext.StackSpec{ID: "st0", RealmID: "r0", SpaceID: "s0"},
+			Status:     ext.StackStatus{SubtreeControllers: want},
+		})
+		if err != nil {
+			t.Fatalf("ConvertStackDocToInternal: %v", err)
+		}
+		if !reflect.DeepEqual(ext2int.Status.SubtreeControllers, want) {
+			t.Errorf("ext→int stack SubtreeControllers = %v, want %v",
+				ext2int.Status.SubtreeControllers, want)
+		}
+		out, err := apischeme.BuildStackExternalFromInternal(ext2int, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildStackExternalFromInternal: %v", err)
+		}
+		if !reflect.DeepEqual(out.Status.SubtreeControllers, want) {
+			t.Errorf("int→ext stack SubtreeControllers = %v, want %v",
+				out.Status.SubtreeControllers, want)
+		}
+	})
+
+	t.Run("cell", func(t *testing.T) {
+		ext2int, err := apischeme.ConvertCellDocToInternal(ext.CellDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindCell,
+			Metadata:   ext.CellMetadata{Name: "c0"},
+			Spec:       ext.CellSpec{ID: "c0", RealmID: "r0", SpaceID: "s0", StackID: "st0"},
+			Status:     ext.CellStatus{SubtreeControllers: want},
+		})
+		if err != nil {
+			t.Fatalf("ConvertCellDocToInternal: %v", err)
+		}
+		if !reflect.DeepEqual(ext2int.Status.SubtreeControllers, want) {
+			t.Errorf("ext→int cell SubtreeControllers = %v, want %v",
+				ext2int.Status.SubtreeControllers, want)
+		}
+		out, err := apischeme.BuildCellExternalFromInternal(ext2int, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildCellExternalFromInternal: %v", err)
+		}
+		if !reflect.DeepEqual(out.Status.SubtreeControllers, want) {
+			t.Errorf("int→ext cell SubtreeControllers = %v, want %v",
+				out.Status.SubtreeControllers, want)
+		}
+	})
+
+	// nil-on-empty: an empty-input Status must produce a nil slice in the
+	// converted form so `omitempty` keeps the field out of YAML/JSON.
+	t.Run("empty stays nil", func(t *testing.T) {
+		ext2int, err := apischeme.ConvertRealmDocToInternal(ext.RealmDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindRealm,
+			Metadata:   ext.RealmMetadata{Name: "r0"},
+		})
+		if err != nil {
+			t.Fatalf("ConvertRealmDocToInternal: %v", err)
+		}
+		if ext2int.Status.SubtreeControllers != nil {
+			t.Errorf("empty input produced non-nil internal slice: %v",
+				ext2int.Status.SubtreeControllers)
+		}
+		out, err := apischeme.BuildRealmExternalFromInternal(ext2int, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildRealmExternalFromInternal: %v", err)
+		}
+		if out.Status.SubtreeControllers != nil {
+			t.Errorf("empty input produced non-nil external slice: %v",
+				out.Status.SubtreeControllers)
+		}
+	})
 }

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -79,7 +79,7 @@ func (r *Exec) provisionNewRealm(realm intmodel.Realm) (intmodel.Realm, error) {
 	}
 
 	// Create realm cgroup
-	cgroupPath, err := r.createRealmCgroup(realm)
+	cgroupPath, subtreeControllers, err := r.createRealmCgroup(realm)
 	if err != nil {
 		// Set state to Failed and update metadata before returning error
 		realm.Status.State = intmodel.RealmStateFailed
@@ -87,8 +87,9 @@ func (r *Exec) provisionNewRealm(realm intmodel.Realm) (intmodel.Realm, error) {
 		return intmodel.Realm{}, err
 	}
 
-	// Update CgroupPath and state in internal model
+	// Update CgroupPath, SubtreeControllers (issue #328), and state in internal model
 	realm.Status.CgroupPath = cgroupPath
+	realm.Status.SubtreeControllers = subtreeControllers
 	realm.Status.State = intmodel.RealmStateReady
 
 	// Always update metadata after cgroup creation to ensure CgroupPath is saved
@@ -167,13 +168,14 @@ func (r *Exec) provisionNewSpace(space intmodel.Space) (intmodel.Space, error) {
 	space.Spec.CNIConfigPath = cniConfigPath
 
 	// Create space cgroup
-	cgroupPath, createErr := r.createSpaceCgroup(space)
+	cgroupPath, subtreeControllers, createErr := r.createSpaceCgroup(space)
 	if createErr != nil {
 		return intmodel.Space{}, createErr
 	}
 
-	// Update CgroupPath and state in internal model
+	// Update CgroupPath, SubtreeControllers (issue #328), and state in internal model
 	space.Status.CgroupPath = cgroupPath
+	space.Status.SubtreeControllers = subtreeControllers
 	space.Status.State = intmodel.SpaceStateReady
 
 	// Realize egress policy on the host firewall. iptables rules are safe
@@ -716,20 +718,31 @@ func (r *Exec) ensureSpaceCgroup(space intmodel.Space) (intmodel.Space, error) {
 		}
 		// Idempotent re-toggle of the space's subtree controllers — see the
 		// matching realm ensure-path note for the rationale (issue #327).
-		if subtreeErr := r.enableAncestorSubtreeControllers(spaceDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
+		// Persist the effective set so SpaceStatus.SubtreeControllers
+		// reflects the live host-filtered set after every ensure-pass
+		// (issue #328). On error skip the persist — the warn-and-continue
+		// pattern matches the cell ensure path and avoids overwriting a
+		// previously-correct value with stale data.
+		if subtreeControllers, subtreeErr := r.enableAncestorSubtreeControllers(
+			spaceDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
 			r.logger.WarnContext(r.ctx,
 				"failed to enable space subtree controllers on ensure-path",
 				"space", space.Metadata.Name, "error", subtreeErr)
+		} else if !equalStringSlices(space.Status.SubtreeControllers, subtreeControllers) {
+			space.Status.SubtreeControllers = subtreeControllers
+			if metaErr := r.UpdateSpaceMetadata(space); metaErr != nil {
+				return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateSpaceMetadata, metaErr)
+			}
 		}
 	}
 
 	return space, nil
 }
 
-func (r *Exec) createSpaceCgroup(space intmodel.Space) (string, error) {
+func (r *Exec) createSpaceCgroup(space intmodel.Space) (string, []string, error) {
 	// Extract realm name from space and validate
 	if space.Spec.RealmName == "" {
-		return "", errdefs.ErrRealmNameRequired
+		return "", nil, errdefs.ErrRealmNameRequired
 	}
 
 	// Fetch the realm internally for DefaultSpaceSpec
@@ -740,33 +753,36 @@ func (r *Exec) createSpaceCgroup(space intmodel.Space) (string, error) {
 	}
 	internalRealm, err := r.GetRealm(lookupRealm)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	spec := ctr.DefaultSpaceSpec(space)
 
 	// Ensure client is initialized and connected
 	if err = r.ensureClientConnected(); err != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
 	// Build the cgroup path
 	spec, _, err = r.buildCgroupPath(spec)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	// Create the cgroup
 	cgroupPath, createErr := r.createCgroupInternal(spec)
 	if createErr != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateSpaceCgroup, createErr)
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrCreateSpaceCgroup, createErr)
 	}
 
 	// Delegate the kukeon resource subset on the space's own subtree_control
 	// so an empty space (no descendant stack/cell yet) still carries the
-	// controllers — issue #327.
-	if subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint); subtreeErr != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateSpaceCgroup, subtreeErr)
+	// controllers — issue #327. The returned effective set bubbles back up
+	// so the caller can persist it on SpaceStatus.SubtreeControllers
+	// (issue #328).
+	subtreeControllers, subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint)
+	if subtreeErr != nil {
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrCreateSpaceCgroup, subtreeErr)
 	}
 
 	r.logger.InfoContext(
@@ -779,37 +795,40 @@ func (r *Exec) createSpaceCgroup(space intmodel.Space) (string, error) {
 		"path",
 		cgroupPath,
 	)
-	return cgroupPath, nil
+	return cgroupPath, subtreeControllers, nil
 }
 
-func (r *Exec) createRealmCgroup(realm intmodel.Realm) (string, error) {
+func (r *Exec) createRealmCgroup(realm intmodel.Realm) (string, []string, error) {
 	spec := ctr.DefaultRealmSpec(realm)
 
 	// Ensure client is initialized and connected
 	if err := r.ensureClientConnected(); err != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
 	// Build the cgroup path
 	var err error
 	spec, _, err = r.buildCgroupPath(spec)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	// Create the cgroup
 	cgroupPath, createErr := r.createCgroupInternal(spec)
 	if createErr != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateRealmCgroup, createErr)
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrCreateRealmCgroup, createErr)
 	}
 
 	// Delegate the kukeon resource subset on the realm's own subtree_control
 	// so an empty realm (no descendant space/stack/cell yet) still carries
 	// the controllers — issue #327. Mirrors the cell-level call site below
 	// so each level explicitly populates its own subtree instead of
-	// relying on the first cell's ancestor walk to widen everything.
-	if subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint); subtreeErr != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateRealmCgroup, subtreeErr)
+	// relying on the first cell's ancestor walk to widen everything. The
+	// returned effective set bubbles back up so the caller can persist it
+	// on RealmStatus.SubtreeControllers (issue #328).
+	subtreeControllers, subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint)
+	if subtreeErr != nil {
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrCreateRealmCgroup, subtreeErr)
 	}
 
 	r.logger.InfoContext(
@@ -820,7 +839,7 @@ func (r *Exec) createRealmCgroup(realm intmodel.Realm) (string, error) {
 		"path",
 		cgroupPath,
 	)
-	return cgroupPath, nil
+	return cgroupPath, subtreeControllers, nil
 }
 
 func (r *Exec) ensureRealmCgroup(realm intmodel.Realm) (intmodel.Realm, error) {
@@ -872,11 +891,19 @@ func (r *Exec) ensureRealmCgroup(realm intmodel.Realm) (intmodel.Realm, error) {
 		// ensure-pass — covers daemon restart against pre-#327 realms whose
 		// subtree_control was only populated as a side effect of the first
 		// cell. No-op on already-delegated subtrees. Log + continue on
-		// failure to mirror the cell ensure-path pattern.
-		if subtreeErr := r.enableAncestorSubtreeControllers(realmDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
+		// failure to mirror the cell ensure-path pattern. Persist the
+		// effective set so RealmStatus.SubtreeControllers reflects the
+		// live host-filtered set after every ensure-pass (issue #328).
+		if subtreeControllers, subtreeErr := r.enableAncestorSubtreeControllers(
+			realmDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
 			r.logger.WarnContext(r.ctx,
 				"failed to enable realm subtree controllers on ensure-path",
 				"realm", realm.Metadata.Name, "error", subtreeErr)
+		} else if !equalStringSlices(realm.Status.SubtreeControllers, subtreeControllers) {
+			realm.Status.SubtreeControllers = subtreeControllers
+			if metaErr := r.UpdateRealmMetadata(realm); metaErr != nil {
+				return intmodel.Realm{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateRealmMetadata, metaErr)
+			}
 		}
 	} else {
 		// If cgroup path is still empty after ensureCgroupInternal, log warning
@@ -901,13 +928,14 @@ func (r *Exec) provisionNewStack(stack intmodel.Stack) (intmodel.Stack, error) {
 	}
 
 	// Create stack cgroup
-	cgroupPath, err := r.createStackCgroup(stack)
+	cgroupPath, subtreeControllers, err := r.createStackCgroup(stack)
 	if err != nil {
 		return intmodel.Stack{}, err
 	}
 
-	// Update CgroupPath and state in internal model
+	// Update CgroupPath, SubtreeControllers (issue #328), and state in internal model
 	stack.Status.CgroupPath = cgroupPath
+	stack.Status.SubtreeControllers = subtreeControllers
 	stack.Status.State = intmodel.StackStateReady
 
 	// Update stack metadata
@@ -918,40 +946,43 @@ func (r *Exec) provisionNewStack(stack intmodel.Stack) (intmodel.Stack, error) {
 	return stack, nil
 }
 
-func (r *Exec) createStackCgroup(stack intmodel.Stack) (string, error) {
+func (r *Exec) createStackCgroup(stack intmodel.Stack) (string, []string, error) {
 	// Extract realm and space names from stack and validate
 	if stack.Spec.RealmName == "" {
-		return "", errdefs.ErrRealmNameRequired
+		return "", nil, errdefs.ErrRealmNameRequired
 	}
 	if stack.Spec.SpaceName == "" {
-		return "", errdefs.ErrSpaceNameRequired
+		return "", nil, errdefs.ErrSpaceNameRequired
 	}
 
 	spec := ctr.DefaultStackSpec(stack)
 
 	// Ensure client is initialized and connected
 	if err := r.ensureClientConnected(); err != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
 	// Build the cgroup path
 	var err error
 	spec, _, err = r.buildCgroupPath(spec)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	// Create the cgroup
 	cgroupPath, createErr := r.createCgroupInternal(spec)
 	if createErr != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateStackCgroup, createErr)
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrCreateStackCgroup, createErr)
 	}
 
 	// Delegate the kukeon resource subset on the stack's own subtree_control
 	// so an empty stack (no descendant cell yet) still carries the
-	// controllers — issue #327.
-	if subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint); subtreeErr != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateStackCgroup, subtreeErr)
+	// controllers — issue #327. The returned effective set bubbles back up
+	// so the caller can persist it on StackStatus.SubtreeControllers
+	// (issue #328).
+	subtreeControllers, subtreeErr := r.enableAncestorSubtreeControllers(spec.Group, spec.Mountpoint)
+	if subtreeErr != nil {
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrCreateStackCgroup, subtreeErr)
 	}
 
 	r.logger.InfoContext(
@@ -962,7 +993,7 @@ func (r *Exec) createStackCgroup(stack intmodel.Stack) (string, error) {
 		"path",
 		cgroupPath,
 	)
-	return cgroupPath, nil
+	return cgroupPath, subtreeControllers, nil
 }
 
 func (r *Exec) ensureStackCgroup(stack intmodel.Stack) (intmodel.Stack, error) {
@@ -1016,10 +1047,19 @@ func (r *Exec) ensureStackCgroup(stack intmodel.Stack) (intmodel.Stack, error) {
 		}
 		// Idempotent re-toggle of the stack's subtree controllers — see the
 		// matching realm ensure-path note for the rationale (issue #327).
-		if subtreeErr := r.enableAncestorSubtreeControllers(stackDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
+		// Persist the effective set so StackStatus.SubtreeControllers
+		// reflects the live host-filtered set after every ensure-pass
+		// (issue #328).
+		if subtreeControllers, subtreeErr := r.enableAncestorSubtreeControllers(
+			stackDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
 			r.logger.WarnContext(r.ctx,
 				"failed to enable stack subtree controllers on ensure-path",
 				"stack", stack.Metadata.Name, "error", subtreeErr)
+		} else if !equalStringSlices(stack.Status.SubtreeControllers, subtreeControllers) {
+			stack.Status.SubtreeControllers = subtreeControllers
+			if metaErr := r.UpdateStackMetadata(stack); metaErr != nil {
+				return intmodel.Stack{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateStackMetadata, metaErr)
+			}
 		}
 	}
 
@@ -1044,13 +1084,17 @@ func (r *Exec) provisionNewCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	}
 
 	// Create cell cgroup
-	cgroupPath, err := r.createCellCgroup(cell)
+	cgroupPath, subtreeControllers, err := r.createCellCgroup(cell)
 	if err != nil {
 		return intmodel.Cell{}, err
 	}
 
-	// Update internal model with cgroup path
+	// Update internal model with cgroup path and effective subtree
+	// controllers (issue #328 — surfaces the result of enableCellControllers
+	// so operators can confirm the cell-level delegation from `kuke get
+	// cells -o yaml`).
 	cell.Status.CgroupPath = cgroupPath
+	cell.Status.SubtreeControllers = subtreeControllers
 
 	// Persist the host-side bridge this cell's space lands on. Computing it
 	// here (instead of the read path) keeps the cell self-describing for
@@ -1083,36 +1127,36 @@ func (r *Exec) provisionNewCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	return cell, nil
 }
 
-func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, error) {
+func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, []string, error) {
 	// Extract realm, space, and stack names from cell and validate
 	if cell.Spec.RealmName == "" {
-		return "", errdefs.ErrRealmNameRequired
+		return "", nil, errdefs.ErrRealmNameRequired
 	}
 	if cell.Spec.SpaceName == "" {
-		return "", errdefs.ErrSpaceNameRequired
+		return "", nil, errdefs.ErrSpaceNameRequired
 	}
 	if cell.Spec.StackName == "" {
-		return "", errdefs.ErrStackNameRequired
+		return "", nil, errdefs.ErrStackNameRequired
 	}
 
 	spec := ctr.DefaultCellSpec(cell)
 
 	// Ensure client is initialized and connected
 	if err := r.ensureClientConnected(); err != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
 	// Build the cgroup path
 	var err error
 	spec, _, err = r.buildCgroupPath(spec)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	// Create the cgroup
 	cgroupPath, createErr := r.createCgroupInternal(spec)
 	if createErr != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateCellCgroup, createErr)
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrCreateCellCgroup, createErr)
 	}
 
 	// Enable the cell-level resource controllers in the cgroup tree before
@@ -1121,9 +1165,12 @@ func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, error) {
 	// available and cell-level UpdateCgroup limits are decorative — exactly
 	// what issue #312 reports. Cells with NestedCgroupRuntime opt in to
 	// delegating the full host-available controller set instead of the
-	// resource subset (issue #314).
-	if subtreeErr := r.enableCellControllers(cell, spec.Group, spec.Mountpoint); subtreeErr != nil {
-		return "", fmt.Errorf("%w: %w", errdefs.ErrCreateCellCgroup, subtreeErr)
+	// resource subset (issue #314). The returned effective set bubbles
+	// back up so the caller can persist it on
+	// CellStatus.SubtreeControllers (issue #328).
+	subtreeControllers, subtreeErr := r.enableCellControllers(cell, spec.Group, spec.Mountpoint)
+	if subtreeErr != nil {
+		return "", nil, fmt.Errorf("%w: %w", errdefs.ErrCreateCellCgroup, subtreeErr)
 	}
 
 	r.logger.InfoContext(
@@ -1134,7 +1181,7 @@ func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, error) {
 		"path",
 		cgroupPath,
 	)
-	return cgroupPath, nil
+	return cgroupPath, subtreeControllers, nil
 }
 
 // enableCellControllers picks between the resource-subset and full-set
@@ -1146,7 +1193,11 @@ func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, error) {
 // The resource subset comes from cgroupcheck.CellResourceControllers so
 // the doctor pre-flight (`kuke doctor cgroups`) and the cell-creation
 // path stay in lockstep — issue #324.
-func (r *Exec) enableCellControllers(cell intmodel.Cell, group, mountpoint string) error {
+//
+// Returns the effective controller set actually written (filtered against
+// the host root) so the caller can persist it on
+// CellStatus.SubtreeControllers (issue #328).
+func (r *Exec) enableCellControllers(cell intmodel.Cell, group, mountpoint string) ([]string, error) {
 	if cell.Spec.NestedCgroupRuntime {
 		return r.ctrClient.EnableCellAllSubtreeControllers(group, mountpoint)
 	}
@@ -1158,12 +1209,30 @@ func (r *Exec) enableCellControllers(cell intmodel.Cell, group, mountpoint strin
 // populated independently of the first cell that lands under it. Without
 // this, an empty realm/space/stack carries no controllers — the cell-level
 // ToggleControllers walk only widens ancestors when a cell is created
-// (issue #327). Returning the underlying error lets callers in create-
+// (issue #327). Returns the effective controller set actually written so
+// the caller can persist it on the level's Status.SubtreeControllers
+// (issue #328); returning the underlying error lets callers in create-
 // paths fail hard while ensure-pass call sites can choose to log + continue
 // (matching the cell ensure-path pattern).
-func (r *Exec) enableAncestorSubtreeControllers(group, mountpoint string) error {
-	_, err := r.ctrClient.EnsureSubtreeControllers(group, mountpoint, cgroupcheck.CellResourceControllers())
-	return err
+func (r *Exec) enableAncestorSubtreeControllers(group, mountpoint string) ([]string, error) {
+	return r.ctrClient.EnsureSubtreeControllers(group, mountpoint, cgroupcheck.CellResourceControllers())
+}
+
+// equalStringSlices reports whether two []string values carry the same
+// elements in the same order. Used by the ensure-paths to skip a metadata
+// rewrite when SubtreeControllers is unchanged (issue #328 — the kernel
+// re-toggle is already idempotent; the metadata save costs an fsync, so
+// short-circuit on equality keeps the steady-state ensure pass cheap).
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *Exec) ensureCellCgroup(cell intmodel.Cell) (intmodel.Cell, error) {
@@ -1225,11 +1294,19 @@ func (r *Exec) ensureCellCgroup(cell intmodel.Cell) (intmodel.Cell, error) {
 		// already-enabled subtrees). Cells whose persisted spec carries
 		// NestedCgroupRuntime=true take the full-set delegation path so a
 		// daemon restart re-asserts the same controller set the cell was
-		// provisioned with (issue #314).
-		if subtreeErr := r.enableCellControllers(cell, cellDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
+		// provisioned with (issue #314). Persist the effective set so
+		// CellStatus.SubtreeControllers reflects the live host-filtered set
+		// after every ensure-pass (issue #328).
+		if subtreeControllers, subtreeErr := r.enableCellControllers(
+			cell, cellDoc.Status.CgroupPath, r.ctrClient.GetCgroupMountpoint()); subtreeErr != nil {
 			r.logger.WarnContext(r.ctx,
 				"failed to enable cell subtree controllers on ensure-path",
 				"cell", cell.Metadata.Name, "error", subtreeErr)
+		} else if !equalStringSlices(cell.Status.SubtreeControllers, subtreeControllers) {
+			cell.Status.SubtreeControllers = subtreeControllers
+			if metaErr := r.UpdateCellMetadata(cell); metaErr != nil {
+				return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, metaErr)
+			}
 		}
 	}
 

--- a/internal/controller/runner/provision_subtree_test.go
+++ b/internal/controller/runner/provision_subtree_test.go
@@ -110,11 +110,11 @@ func (c *subtreeRecorderClient) LoadCgroup(string, string) (*cgroup2.Manager, er
 	panic("unexpected")
 }
 func (c *subtreeRecorderClient) DeleteCgroup(string, string) error { panic("unexpected") }
-func (c *subtreeRecorderClient) EnableCellSubtreeControllers(string, string, []string) error {
+func (c *subtreeRecorderClient) EnableCellSubtreeControllers(string, string, []string) ([]string, error) {
 	panic("unexpected")
 }
 
-func (c *subtreeRecorderClient) EnableCellAllSubtreeControllers(string, string) error {
+func (c *subtreeRecorderClient) EnableCellAllSubtreeControllers(string, string) ([]string, error) {
 	panic("unexpected")
 }
 
@@ -232,13 +232,20 @@ func seedRealmMetadata(t *testing.T, r *Exec, realmName string) {
 // TestEnableAncestorSubtreeControllersPassesResourceSubset pins the
 // invariant that every realm/space/stack create path delegates exactly the
 // kukeon resource subset (cgroupcheck.CellResourceControllers) — the same
-// set the doctor pre-flight expects on the host root. Issue #327.
+// set the doctor pre-flight expects on the host root. Issue #327. Also
+// pins that the helper returns the effective set so callers can persist
+// it on Status.SubtreeControllers (issue #328).
 func TestEnableAncestorSubtreeControllersPassesResourceSubset(t *testing.T) {
 	fake := &subtreeRecorderClient{mountpoint: "/sys/fs/cgroup"}
 	r := newSubtreeTestExec(t, fake)
 
-	if err := r.enableAncestorSubtreeControllers("/kukeon/foo", "/sys/fs/cgroup"); err != nil {
+	gotEffective, err := r.enableAncestorSubtreeControllers("/kukeon/foo", "/sys/fs/cgroup")
+	if err != nil {
 		t.Fatalf("enableAncestorSubtreeControllers() unexpected error: %v", err)
+	}
+	if want := cgroupcheck.CellResourceControllers(); !reflect.DeepEqual(gotEffective, want) {
+		t.Errorf("enableAncestorSubtreeControllers() effective = %v, want %v (issue #328)",
+			gotEffective, want)
 	}
 	if len(fake.ensureCalls) != 1 {
 		t.Fatalf("EnsureSubtreeControllers call count = %d, want 1", len(fake.ensureCalls))
@@ -267,7 +274,7 @@ func TestCreateRealmCgroupEmptyRealmDelegates(t *testing.T) {
 	}
 	r := newSubtreeTestExec(t, fake)
 
-	if _, err := r.createRealmCgroup(intmodel.Realm{
+	if _, _, err := r.createRealmCgroup(intmodel.Realm{
 		Metadata: intmodel.RealmMetadata{Name: "empty"},
 		Spec:     intmodel.RealmSpec{Namespace: "empty.kukeon.io"},
 	}); err != nil {
@@ -297,12 +304,12 @@ func TestCreateLevelCgroupsDelegateSubtreeControllers(t *testing.T) {
 	cases := []struct {
 		name      string
 		seed      func(t *testing.T, r *Exec)
-		call      func(r *Exec) (string, error)
+		call      func(r *Exec) (string, []string, error)
 		wantGroup string
 	}{
 		{
 			name: "realm",
-			call: func(r *Exec) (string, error) {
+			call: func(r *Exec) (string, []string, error) {
 				return r.createRealmCgroup(intmodel.Realm{
 					Metadata: intmodel.RealmMetadata{Name: "alpha"},
 					Spec:     intmodel.RealmSpec{Namespace: "alpha.kukeon.io"},
@@ -318,7 +325,7 @@ func TestCreateLevelCgroupsDelegateSubtreeControllers(t *testing.T) {
 				// lookup succeeds in the unit-test sandbox.
 				seedRealmMetadata(t, r, "alpha")
 			},
-			call: func(r *Exec) (string, error) {
+			call: func(r *Exec) (string, []string, error) {
 				return r.createSpaceCgroup(intmodel.Space{
 					Metadata: intmodel.SpaceMetadata{Name: "beta"},
 					Spec:     intmodel.SpaceSpec{RealmName: "alpha"},
@@ -328,7 +335,7 @@ func TestCreateLevelCgroupsDelegateSubtreeControllers(t *testing.T) {
 		},
 		{
 			name: "stack",
-			call: func(r *Exec) (string, error) {
+			call: func(r *Exec) (string, []string, error) {
 				return r.createStackCgroup(intmodel.Stack{
 					Metadata: intmodel.StackMetadata{Name: "gamma"},
 					Spec:     intmodel.StackSpec{RealmName: "alpha", SpaceName: "beta"},
@@ -349,12 +356,19 @@ func TestCreateLevelCgroupsDelegateSubtreeControllers(t *testing.T) {
 				tc.seed(t, r)
 			}
 
-			gotPath, err := tc.call(r)
+			gotPath, gotControllers, err := tc.call(r)
 			if err != nil {
 				t.Fatalf("%s create path unexpected error: %v", tc.name, err)
 			}
 			if gotPath != tc.wantGroup {
 				t.Errorf("%s cgroup path = %q, want %q", tc.name, gotPath, tc.wantGroup)
+			}
+			// Issue #328: every level's create path returns the effective
+			// controller set so the caller can persist it on
+			// Status.SubtreeControllers.
+			if want := cgroupcheck.CellResourceControllers(); !reflect.DeepEqual(gotControllers, want) {
+				t.Errorf("%s create returned controllers = %v, want %v",
+					tc.name, gotControllers, want)
 			}
 			if len(fake.ensureCalls) != 1 {
 				t.Fatalf(

--- a/internal/ctr/cgroups.go
+++ b/internal/ctr/cgroups.go
@@ -176,10 +176,10 @@ func (c *client) EnsureSubtreeControllers(group, mountpoint string, controllers 
 // EnableCellSubtreeControllers is a thin wrapper around
 // EnsureSubtreeControllers for the cell create/ensure call sites that pass
 // the kukeon resource subset (cgroupcheck.CellResourceControllers). Issue
-// #312.
-func (c *client) EnableCellSubtreeControllers(group, mountpoint string, controllers []string) error {
-	_, err := c.EnsureSubtreeControllers(group, mountpoint, controllers)
-	return err
+// #312. Returns the effective set EnsureSubtreeControllers wrote so the
+// runner can stash it on CellStatus.SubtreeControllers (issue #328).
+func (c *client) EnableCellSubtreeControllers(group, mountpoint string, controllers []string) ([]string, error) {
+	return c.EnsureSubtreeControllers(group, mountpoint, controllers)
 }
 
 // EnableCellAllSubtreeControllers is the cell/profile=NestedCgroupRuntime
@@ -193,16 +193,19 @@ func (c *client) EnableCellSubtreeControllers(group, mountpoint string, controll
 // resource subset) is what every kukeon-managed cell wants by default; the
 // "all" variant is the explicit opt-in cells request when they host a
 // nested runtime that needs more than the resource subset.
-func (c *client) EnableCellAllSubtreeControllers(group, mountpoint string) error {
+func (c *client) EnableCellAllSubtreeControllers(group, mountpoint string) ([]string, error) {
 	if err := validateGroupPath(group); err != nil {
-		return err
+		return nil, err
 	}
 	mp := c.effectiveMountpoint(mountpoint)
 	available, err := readRootControllers(mp)
 	if err != nil {
-		return fmt.Errorf("read root cgroup.controllers: %w", err)
+		return nil, fmt.Errorf("read root cgroup.controllers: %w", err)
 	}
-	return c.applySubtreeControllers(group, mp, available)
+	if applyErr := c.applySubtreeControllers(group, mp, available); applyErr != nil {
+		return nil, applyErr
+	}
+	return available, nil
 }
 
 // applySubtreeControllers is the shared body of EnsureSubtreeControllers and

--- a/internal/ctr/cgroups_test.go
+++ b/internal/ctr/cgroups_test.go
@@ -366,13 +366,13 @@ func TestEnsureSubtreeControllersValidation(t *testing.T) {
 func TestEnableCellSubtreeControllersValidation(t *testing.T) {
 	client := setupTestClientForCgroups(t)
 
-	if err := client.EnableCellSubtreeControllers("", "/sys/fs/cgroup", []string{"cpu"}); err == nil {
+	if _, err := client.EnableCellSubtreeControllers("", "/sys/fs/cgroup", []string{"cpu"}); err == nil {
 		t.Error("EnableCellSubtreeControllers(empty group) error = nil, want ErrEmptyGroupPath")
 	} else if !errors.Is(err, errdefs.ErrEmptyGroupPath) {
 		t.Errorf("EnableCellSubtreeControllers(empty group) error = %v, want ErrEmptyGroupPath", err)
 	}
 
-	if err := client.EnableCellSubtreeControllers("/kukeon/test", "/sys/fs/cgroup", []string{"cpu"}); err != nil &&
+	if _, err := client.EnableCellSubtreeControllers("/kukeon/test", "/sys/fs/cgroup", []string{"cpu"}); err != nil &&
 		errors.Is(err, errdefs.ErrEmptyGroupPath) {
 		t.Errorf("EnableCellSubtreeControllers(valid group) unexpected validation error: %v", err)
 	}
@@ -388,7 +388,7 @@ func TestEnableCellSubtreeControllersValidation(t *testing.T) {
 func TestEnableCellAllSubtreeControllersValidation(t *testing.T) {
 	client := setupTestClientForCgroups(t)
 
-	if err := client.EnableCellAllSubtreeControllers("", "/sys/fs/cgroup"); err == nil {
+	if _, err := client.EnableCellAllSubtreeControllers("", "/sys/fs/cgroup"); err == nil {
 		t.Error("EnableCellAllSubtreeControllers(empty group) error = nil, want ErrEmptyGroupPath")
 	} else if !errors.Is(err, errdefs.ErrEmptyGroupPath) {
 		t.Errorf("EnableCellAllSubtreeControllers(empty group) error = %v, want ErrEmptyGroupPath", err)
@@ -397,7 +397,7 @@ func TestEnableCellAllSubtreeControllersValidation(t *testing.T) {
 	// Syntactically valid group: validation must pass; downstream cgroupfs
 	// access then fails in the unit-test sandbox, which is fine — that is
 	// not a validation failure and must not surface ErrEmptyGroupPath.
-	if err := client.EnableCellAllSubtreeControllers("/kukeon/test", "/sys/fs/cgroup"); err != nil &&
+	if _, err := client.EnableCellAllSubtreeControllers("/kukeon/test", "/sys/fs/cgroup"); err != nil &&
 		errors.Is(err, errdefs.ErrEmptyGroupPath) {
 		t.Errorf("EnableCellAllSubtreeControllers(valid group) unexpected validation error: %v", err)
 	}

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -76,16 +76,23 @@ type Client interface {
 	// subtree_control up to the unified cgroup mount, so child cgroups (the
 	// per-container task cgroups runc creates under Linux.CgroupsPath)
 	// inherit the controllers and cell-level resource accounting / limits
-	// become effective. Thin wrapper around EnsureSubtreeControllers kept
-	// for the cell call sites' readability. Issue #312.
-	EnableCellSubtreeControllers(group, mountpoint string, controllers []string) error
+	// become effective. Returns the effective controller set actually
+	// written (the requested set filtered against the host root's
+	// cgroup.controllers) so the runner can persist it on
+	// CellStatus.SubtreeControllers (issue #328). Thin wrapper around
+	// EnsureSubtreeControllers kept for the cell call sites' readability.
+	// Issue #312.
+	EnableCellSubtreeControllers(group, mountpoint string, controllers []string) ([]string, error)
 	// EnableCellAllSubtreeControllers is the cell/profile=NestedCgroupRuntime
 	// counterpart: it delegates the full host-available cgroup-v2 controller
 	// set on the cell's subtree_control (and every ancestor's), rather than
-	// the kukeon resource subset. Used by cells that host an inner cgroup
-	// runtime (an embedded containerd or systemd) which needs to in turn
-	// delegate arbitrary controllers to its own children. Issue #314.
-	EnableCellAllSubtreeControllers(group, mountpoint string) error
+	// the kukeon resource subset. Returns the effective controller set
+	// actually written so the runner can persist it on
+	// CellStatus.SubtreeControllers (issue #328). Used by cells that host
+	// an inner cgroup runtime (an embedded containerd or systemd) which
+	// needs to in turn delegate arbitrary controllers to its own children.
+	// Issue #314.
+	EnableCellAllSubtreeControllers(group, mountpoint string) ([]string, error)
 	CreateContainerFromSpec(namespace string, spec intmodel.ContainerSpec, creds []RegistryCredentials, opts ...BuildOption) (containerd.Container, error)
 
 	CreateContainer(namespace string, spec ContainerSpec, creds []RegistryCredentials) (containerd.Container, error)

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -55,8 +55,15 @@ type CellTty struct {
 type CellStatus struct {
 	State      CellState
 	CgroupPath string
-	Network    CellNetworkStatus
-	Containers []ContainerStatus
+	// SubtreeControllers records the cgroup-v2 controllers actually
+	// delegated on this cell's own cgroup.subtree_control after the
+	// effective filter against the host root's cgroup.controllers
+	// (issue #328). For NestedCgroupRuntime cells this carries the full
+	// host-available set; for ordinary cells it carries the kukeon
+	// resource subset (cgroupcheck.CellResourceControllers).
+	SubtreeControllers []string
+	Network            CellNetworkStatus
+	Containers         []ContainerStatus
 	// ReadyObserved is a one-way latch set the first time the cell has
 	// been observed Ready by ReconcileCell — either via the freshly
 	// derived state or via a persisted Ready state from a prior

--- a/internal/modelhub/realm.go
+++ b/internal/modelhub/realm.go
@@ -46,6 +46,11 @@ type RegistryCredentials struct {
 type RealmStatus struct {
 	State      RealmState
 	CgroupPath string
+	// SubtreeControllers records the cgroup-v2 controllers actually
+	// delegated on this realm's own cgroup.subtree_control after the
+	// effective filter against the host root's cgroup.controllers (issue
+	// #328, surfacing the result of the helper landed by issue #327).
+	SubtreeControllers []string
 }
 
 type RealmState int

--- a/internal/modelhub/space.go
+++ b/internal/modelhub/space.go
@@ -83,6 +83,11 @@ type SpaceContainerDefaults struct {
 type SpaceStatus struct {
 	State      SpaceState
 	CgroupPath string
+	// SubtreeControllers records the cgroup-v2 controllers actually
+	// delegated on this space's own cgroup.subtree_control after the
+	// effective filter against the host root's cgroup.controllers (issue
+	// #328).
+	SubtreeControllers []string
 }
 
 type SpaceState int

--- a/internal/modelhub/stack.go
+++ b/internal/modelhub/stack.go
@@ -36,6 +36,11 @@ type StackSpec struct {
 type StackStatus struct {
 	State      StackState
 	CgroupPath string
+	// SubtreeControllers records the cgroup-v2 controllers actually
+	// delegated on this stack's own cgroup.subtree_control after the
+	// effective filter against the host root's cgroup.controllers (issue
+	// #328).
+	SubtreeControllers []string
 }
 
 type StackState int

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -68,10 +68,16 @@ type CellTty struct {
 }
 
 type CellStatus struct {
-	State      CellState         `json:"state"                   yaml:"state"`
-	CgroupPath string            `json:"cgroupPath"              yaml:"cgroupPath"`
-	Network    CellNetworkStatus `json:"network,omitempty"       yaml:"network,omitempty"`
-	Containers []ContainerStatus `json:"containers"              yaml:"containers"`
+	State      CellState `json:"state"                        yaml:"state"`
+	CgroupPath string    `json:"cgroupPath"                   yaml:"cgroupPath"`
+	// SubtreeControllers is the cgroup-v2 controller set actually
+	// delegated on this cell's own cgroup.subtree_control after the
+	// host-root filter (issue #328). For NestedCgroupRuntime cells this
+	// is the full host-available set; for ordinary cells it's the
+	// kukeon resource subset (cpu/memory/io/pids).
+	SubtreeControllers []string          `json:"subtreeControllers,omitempty" yaml:"subtreeControllers,omitempty"`
+	Network            CellNetworkStatus `json:"network,omitempty"            yaml:"network,omitempty"`
+	Containers         []ContainerStatus `json:"containers"                   yaml:"containers"`
 	// ReadyObserved is the persisted form of the one-way latch the
 	// reconciler uses to gate Spec.AutoDelete cleanup. Once a cell has
 	// been observed Ready it stays true across daemon restarts so that

--- a/pkg/api/model/v1beta1/realm.go
+++ b/pkg/api/model/v1beta1/realm.go
@@ -47,7 +47,11 @@ type RegistryCredentials struct {
 
 type RealmStatus struct {
 	State      RealmState `json:"state"`
-	CgroupPath string     `json:"cgroupPath,omitempty" yaml:"cgroupPath,omitempty"`
+	CgroupPath string     `json:"cgroupPath,omitempty"         yaml:"cgroupPath,omitempty"`
+	// SubtreeControllers is the cgroup-v2 controller set actually
+	// delegated on this realm's own cgroup.subtree_control after the
+	// host-root filter (issue #328).
+	SubtreeControllers []string `json:"subtreeControllers,omitempty" yaml:"subtreeControllers,omitempty"`
 }
 
 type RealmState int

--- a/pkg/api/model/v1beta1/space.go
+++ b/pkg/api/model/v1beta1/space.go
@@ -98,8 +98,12 @@ type SpaceContainerDefaults struct {
 }
 
 type SpaceStatus struct {
-	State      SpaceState `json:"state"                yaml:"state"`
-	CgroupPath string     `json:"cgroupPath,omitempty" yaml:"cgroupPath,omitempty"`
+	State      SpaceState `json:"state"                        yaml:"state"`
+	CgroupPath string     `json:"cgroupPath,omitempty"         yaml:"cgroupPath,omitempty"`
+	// SubtreeControllers is the cgroup-v2 controller set actually
+	// delegated on this space's own cgroup.subtree_control after the
+	// host-root filter (issue #328).
+	SubtreeControllers []string `json:"subtreeControllers,omitempty" yaml:"subtreeControllers,omitempty"`
 }
 
 type SpaceState int

--- a/pkg/api/model/v1beta1/stack.go
+++ b/pkg/api/model/v1beta1/stack.go
@@ -36,8 +36,12 @@ type StackSpec struct {
 }
 
 type StackStatus struct {
-	State      StackState `json:"state"      yaml:"state"`
-	CgroupPath string     `json:"cgroupPath" yaml:"cgroupPath"`
+	State      StackState `json:"state"                        yaml:"state"`
+	CgroupPath string     `json:"cgroupPath"                   yaml:"cgroupPath"`
+	// SubtreeControllers is the cgroup-v2 controller set actually
+	// delegated on this stack's own cgroup.subtree_control after the
+	// host-root filter (issue #328).
+	SubtreeControllers []string `json:"subtreeControllers,omitempty" yaml:"subtreeControllers,omitempty"`
 }
 
 type StackState int


### PR DESCRIPTION
## Summary

- Phase 2 of the per-level cgroup-controller delegation work (depends on the merged Phase 1 #330). Adds the observability layer the operator side needs to confirm what each level actually delegated.
- Threads the effective controller set returned by `EnsureSubtreeControllers` (and the cell wrappers) up through `createXCgroup` and the ensure-pass paths into a new `Status.SubtreeControllers` field on the internal and external `RealmStatus` / `SpaceStatus` / `StackStatus` / `CellStatus` types.
- Cell wrappers (`EnableCellSubtreeControllers`, `EnableCellAllSubtreeControllers`) now return `([]string, error)` so the runner can persist the same value the kernel actually accepted, including for the `NestedCgroupRuntime` full-set path.
- `kuke get realms / spaces / stacks / cells` now accept `--show-controllers` (off by default) to append a `CONTROLLERS` column. `-o yaml` / `-o json` always include the field.

## Notes for the reviewer

- **CLI surface picked the `--show-controllers` flag instead of an always-on column.** The issue lets the implementer pick \"a column or a `--show-controllers` flag, whichever fits the existing table style.\" The flag form is the only one that satisfies AC #4 (`make dev-init` tail unchanged), because the daemon-parity tail in kukeon's CLAUDE.md regression guard is byte-checked as a 4-column `NAME NAMESPACE STATE CGROUP` table — adding a column would break the smoke. A focused unit test pins the rule (default omits CONTROLLERS, `--show-controllers` adds it).
- **Conversion plumbing landed in `internal/apischeme/scheme.go`, not `internal/modelhub/merge.go`.** The issue text says \"extend `internal/modelhub/merge.go` to copy the field on internal↔external conversions; add coverage in `merge_test.go`.\" `merge.go` in modelhub is unrelated — it applies Space defaults onto containers — and the actual int↔ext conversions live in `apischeme/scheme.go`. Coverage is added there as `TestSubtreeControllersRoundTripV1Beta1` (all four kinds, both directions, plus an aliasing guard via the new `cloneStringSlice` helper and a nil-on-empty assertion). Happy to relocate the helper or rename if you prefer a different layout.
- **Ensure-paths persist on diff only.** Each ensure-pass already re-toggles the kernel state idempotently (Phase 1's pattern); I only call `UpdateXMetadata` when the freshly-observed effective set differs from `Status.SubtreeControllers`. Skips an fsync per ensure-pass on the steady state. `equalStringSlices` lives in `provision.go` next to the call sites.

## Test plan

- [x] \`go build ./...\` and \`go vet ./...\` clean.
- [x] \`make test\` (full unit suite) — all packages green.
- [x] \`make dev-init\` — daemon-parity tail still byte-identical to the CLAUDE.md regression text (NAME NAMESPACE STATE CGROUP, both realms Ready). AC #4 verified.
- [x] \`sudo ./kuke get realms --show-controllers\` against the live daemon — CONTROLLERS column shows \`cpu,memory,io,pids\` for both realms.
- [x] \`sudo ./kuke get realm default -o yaml\` — \`status.subtreeControllers\` block emitted with the four controllers.
- [x] \`sudo ./kuke get cells --show-controllers --realm kuke-system --space kukeon --stack kukeon\` — kukeond cell shows \`cpu,memory,io,pids\`.
- [x] \`pre-commit run\` on staged files — Passed (golangci-lint shadow check now clean after renaming the inner-block \`err\` to \`metaErr\` at the four ensure-path sites).
- [ ] \`make e2e\` — not run on the dev host; the e2e harness builds + loads its own image and would interfere with the live kuke-system cell. Reviewer environment, please.

Closes #328