### PR TITLE
feat: kuke doctor cgroups --scope realm|space|stack|cell

### DIFF
--- a/cmd/kuke/doctor/cgroups/cgroups.go
+++ b/cmd/kuke/doctor/cgroups/cgroups.go
@@ -21,13 +21,31 @@
 package cgroups
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 
+	"github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/cgroupcheck"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in
+// tests of the `--scope realm|space|stack|cell` paths. Mirrors the same
+// pattern used by `cmd/kuke/get/...` subcommands so test setup is uniform.
+type MockControllerKey struct{}
+
+// scope kinds accepted by the --scope flag.
+const (
+	scopeRealm = "realm"
+	scopeSpace = "space"
+	scopeStack = "stack"
+	scopeCell  = "cell"
 )
 
 // NewCgroupsCmd builds the `kuke doctor cgroups` subcommand.
@@ -37,20 +55,40 @@ func NewCgroupsCmd() *cobra.Command {
 		nested  bool
 		probe   bool
 		verbose bool
+
+		scope string
+		realm string
+		space string
+		stack string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "cgroups",
+		Use:   "cgroups [name]",
 		Short: "Verify host cgroup-v2 controller delegation before kuke init",
 		Long: "Pre-flight that compares the host root cgroup's available + delegated\n" +
 			"controllers against the set kukeon will enable on the kukeond\n" +
 			"bootstrap cell. Distinguishes \"kernel does not support\" from \"parent\n" +
 			"did not delegate\" so the remediation suggestion is always correct.\n\n" +
+			"With --scope realm|space|stack|cell <name>, resolves the named\n" +
+			"object's Status.CgroupPath via the daemon and runs the same check\n" +
+			"against that directory instead of the host root — useful for\n" +
+			"diagnosing mid-tree delegation gaps when a workload below a given\n" +
+			"level fails to start.\n\n" +
 			"Exit code 0: every required controller is enabled (or was enabled by\n" +
 			"the optional --probe write). Non-zero: at least one controller is\n" +
-			"missing or the host root cgroup could not be read.",
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runDoctor(cmd.OutOrStdout(), cmd.ErrOrStderr(), root, nested, probe, verbose)
+			"missing or the cgroup directory could not be read.",
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := scopedTarget{
+				kind:  strings.TrimSpace(scope),
+				realm: strings.TrimSpace(realm),
+				space: strings.TrimSpace(space),
+				stack: strings.TrimSpace(stack),
+			}
+			if len(args) > 0 {
+				target.name = strings.TrimSpace(args[0])
+			}
+			return runDoctor(cmd, root, nested, probe, verbose, target)
 		},
 		// A failed pre-flight is a host-environment problem, not a CLI
 		// usage error — the structured remediation is the message we
@@ -68,11 +106,59 @@ func NewCgroupsCmd() *cobra.Command {
 			"disambiguates the cgroup-namespace trap. Idempotent — leaves the host in a strictly better state on success.")
 	cmd.Flags().BoolVar(&verbose, "verbose-status", false,
 		"print per-controller status even when the pre-flight passes")
+	cmd.Flags().StringVar(&scope, "scope", "",
+		"verify a sub-tree instead of the host root: 'realm', 'space', 'stack', or 'cell'. "+
+			"When set, resolves the named object's Status.CgroupPath via the daemon and "+
+			"runs the controller-set check against that directory. "+
+			"Empty (default) keeps the unchanged host-root behavior.")
+	cmd.Flags().StringVar(&realm, "realm", "",
+		"realm name (required for --scope space|stack|cell)")
+	cmd.Flags().StringVar(&space, "space", "",
+		"space name (required for --scope stack|cell)")
+	cmd.Flags().StringVar(&stack, "stack", "",
+		"stack name (required for --scope cell)")
 
 	return cmd
 }
 
-func runDoctor(stdout, stderr io.Writer, root string, nested, probe, verbose bool) error {
+func runDoctor(cmd *cobra.Command, root string, nested, probe, verbose bool, target scopedTarget) error {
+	if target.kind == "" {
+		// Without --scope, behavior is unchanged from PR #325.
+		if target.name != "" {
+			return fmt.Errorf("positional name %q is only valid with --scope realm|space|stack|cell", target.name)
+		}
+		return runCheck(cmd.OutOrStdout(), cmd.ErrOrStderr(), root, nested, probe, verbose, "")
+	}
+
+	if err := target.validate(); err != nil {
+		return err
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	cgroupPath, err := target.resolveCgroupPath(cmd.Context(), client)
+	if err != nil {
+		return err
+	}
+
+	// Status.CgroupPath is a relative path under the cgroup-v2 mountpoint
+	// (e.g., "/kukeon/default") — join with --root to get the on-disk
+	// path that cgroupcheck.Check reads cgroup.controllers /
+	// cgroup.subtree_control from.
+	scopedRoot := filepath.Join(root, cgroupPath)
+	return runCheck(cmd.OutOrStdout(), cmd.ErrOrStderr(), scopedRoot, nested, probe, verbose, target.label())
+}
+
+// runCheck is the shared pre-flight body used by both the host-root and
+// --scope paths. scopeLabel is empty for the host-root path; non-empty
+// labels are printed as a "scope: ..." header so operators can tell which
+// directory was checked when the failure output looks otherwise identical
+// to the unscoped form.
+func runCheck(stdout, stderr io.Writer, root string, nested, probe, verbose bool, scopeLabel string) error {
 	required, err := resolveRequired(root, nested)
 	if err != nil {
 		return err
@@ -92,11 +178,13 @@ func runDoctor(stdout, stderr io.Writer, root string, nested, probe, verbose boo
 		// Silence on success keeps the dev-init.sh tail clean — only
 		// surface details when --verbose-status is set.
 		if verbose {
+			printScope(stdout, scopeLabel)
 			printStatus(stdout, res)
 		}
 		return nil
 	}
 
+	printScope(stderr, scopeLabel)
 	printStatus(stderr, res)
 	fmt.Fprint(stderr, "\n")
 	fmt.Fprint(stderr, cgroupcheck.FormatRemediation(res))
@@ -107,7 +195,10 @@ func runDoctor(stdout, stderr io.Writer, root string, nested, probe, verbose boo
 // resolveRequired returns the controller set the pre-flight must verify.
 // nested=true reads the host-advertised set live, mirroring how
 // EnableCellAllSubtreeControllers will behave at cell-creation time —
-// this is the "no second source of truth" guarantee #324 calls for.
+// this is the "no second source of truth" guarantee #324 calls for. When
+// the caller is scoped, root is the scoped cgroup directory and the read
+// returns "what this scope advertises", which is exactly the set the
+// caller's children would inherit.
 func resolveRequired(root string, nested bool) ([]string, error) {
 	if !nested {
 		return cgroupcheck.RequiredForKukeond(false, nil), nil
@@ -127,9 +218,164 @@ func printStatus(w io.Writer, res cgroupcheck.Result) {
 	}
 }
 
+func printScope(w io.Writer, label string) {
+	if label == "" {
+		return
+	}
+	fmt.Fprintf(w, "scope: %s\n", label)
+}
+
 func joinControllers(in []string) string {
 	if len(in) == 0 {
 		return "(none)"
 	}
 	return strings.Join(in, ", ")
+}
+
+// scopedTarget identifies the resource whose cgroup is being inspected
+// when --scope is set. Empty kind means "no scope; check the host root".
+type scopedTarget struct {
+	kind  string
+	name  string
+	realm string
+	space string
+	stack string
+}
+
+// validate ensures the parent-context flags appropriate for the scope kind
+// are populated. Mirrors the same parent-flag requirements `kuke get
+// space|stack|cell` enforce so operators do not have to learn a second
+// addressing convention for the doctor.
+func (t scopedTarget) validate() error {
+	if t.name == "" {
+		return fmt.Errorf("--scope %s requires a positional <name> argument", t.kind)
+	}
+	switch t.kind {
+	case scopeRealm:
+		return nil
+	case scopeSpace:
+		if t.realm == "" {
+			return errors.New("--scope space requires --realm")
+		}
+		return nil
+	case scopeStack:
+		if t.realm == "" {
+			return errors.New("--scope stack requires --realm")
+		}
+		if t.space == "" {
+			return errors.New("--scope stack requires --space")
+		}
+		return nil
+	case scopeCell:
+		if t.realm == "" {
+			return errors.New("--scope cell requires --realm")
+		}
+		if t.space == "" {
+			return errors.New("--scope cell requires --space")
+		}
+		if t.stack == "" {
+			return errors.New("--scope cell requires --stack")
+		}
+		return nil
+	default:
+		return fmt.Errorf("--scope must be one of: realm, space, stack, cell (got %q)", t.kind)
+	}
+}
+
+// resolveCgroupPath calls the appropriate kukeonv1 Get method and returns
+// the Status.CgroupPath of the named resource. Returns an error when the
+// daemon does not know the resource or has not yet populated its cgroup —
+// in either case the caller cannot run the scoped pre-flight.
+func (t scopedTarget) resolveCgroupPath(ctx context.Context, c kukeonv1.Client) (string, error) {
+	switch t.kind {
+	case scopeRealm:
+		res, err := c.GetRealm(ctx, v1beta1.RealmDoc{Metadata: v1beta1.RealmMetadata{Name: t.name}})
+		if err != nil {
+			return "", err
+		}
+		if !res.MetadataExists {
+			return "", fmt.Errorf("realm %q not found", t.name)
+		}
+		if res.Realm.Status.CgroupPath == "" {
+			return "", fmt.Errorf("realm %q has no Status.CgroupPath yet", t.name)
+		}
+		return res.Realm.Status.CgroupPath, nil
+	case scopeSpace:
+		res, err := c.GetSpace(ctx, v1beta1.SpaceDoc{
+			Metadata: v1beta1.SpaceMetadata{Name: t.name},
+			Spec:     v1beta1.SpaceSpec{RealmID: t.realm},
+		})
+		if err != nil {
+			return "", err
+		}
+		if !res.MetadataExists {
+			return "", fmt.Errorf("space %q not found in realm %q", t.name, t.realm)
+		}
+		if res.Space.Status.CgroupPath == "" {
+			return "", fmt.Errorf("space %q has no Status.CgroupPath yet", t.name)
+		}
+		return res.Space.Status.CgroupPath, nil
+	case scopeStack:
+		res, err := c.GetStack(ctx, v1beta1.StackDoc{
+			Metadata: v1beta1.StackMetadata{Name: t.name},
+			Spec:     v1beta1.StackSpec{RealmID: t.realm, SpaceID: t.space},
+		})
+		if err != nil {
+			return "", err
+		}
+		if !res.MetadataExists {
+			return "", fmt.Errorf("stack %q not found in realm %q, space %q", t.name, t.realm, t.space)
+		}
+		if res.Stack.Status.CgroupPath == "" {
+			return "", fmt.Errorf("stack %q has no Status.CgroupPath yet", t.name)
+		}
+		return res.Stack.Status.CgroupPath, nil
+	case scopeCell:
+		res, err := c.GetCell(ctx, v1beta1.CellDoc{
+			Metadata: v1beta1.CellMetadata{Name: t.name},
+			Spec: v1beta1.CellSpec{
+				RealmID: t.realm,
+				SpaceID: t.space,
+				StackID: t.stack,
+			},
+		})
+		if err != nil {
+			return "", err
+		}
+		if !res.MetadataExists {
+			return "", fmt.Errorf("cell %q not found in stack %q/%q/%q", t.name, t.realm, t.space, t.stack)
+		}
+		if res.Cell.Status.CgroupPath == "" {
+			return "", fmt.Errorf("cell %q has no Status.CgroupPath yet", t.name)
+		}
+		return res.Cell.Status.CgroupPath, nil
+	}
+	return "", fmt.Errorf("--scope %q not supported", t.kind)
+}
+
+// label is the human-readable scope identifier surfaced as the new
+// "scope:" header line so operators can tell which sub-tree was checked.
+func (t scopedTarget) label() string {
+	switch t.kind {
+	case scopeRealm:
+		return fmt.Sprintf("realm %q", t.name)
+	case scopeSpace:
+		return fmt.Sprintf("space %q in realm %q", t.name, t.realm)
+	case scopeStack:
+		return fmt.Sprintf("stack %q in realm %q, space %q", t.name, t.realm, t.space)
+	case scopeCell:
+		return fmt.Sprintf("cell %q in stack %q/%q/%q", t.name, t.realm, t.space, t.stack)
+	default:
+		return ""
+	}
+}
+
+// resolveClient honors the same MockControllerKey injection convention
+// used by `cmd/kuke/get/...`, then falls through to ClientFromCmd which
+// picks --no-daemon vs RPC dial based on flags.
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mock, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mock, nil
+	}
+	return shared.ClientFromCmd(cmd)
 }

--- a/cmd/kuke/doctor/cgroups/cgroups_test.go
+++ b/cmd/kuke/doctor/cgroups/cgroups_test.go
@@ -18,12 +18,15 @@ package cgroups_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	cgroupscmd "github.com/eminwux/kukeon/cmd/kuke/doctor/cgroups"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 // writeFakeCgroup materializes a directory pretending to be a cgroup-v2
@@ -32,16 +35,35 @@ import (
 func writeFakeCgroup(t *testing.T, controllers, subtree string) string {
 	t.Helper()
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "cgroup.controllers"), []byte(controllers), 0o644); err != nil {
-		t.Fatalf("write cgroup.controllers: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "cgroup.subtree_control"), []byte(subtree), 0o644); err != nil {
-		t.Fatalf("write cgroup.subtree_control: %v", err)
-	}
+	writeFakeCgroupAt(t, root, controllers, subtree)
 	return root
 }
 
+// writeFakeCgroupAt is like writeFakeCgroup but writes at a caller-supplied
+// directory so scoped tests can build a host-root + nested-cgroup-dir
+// hierarchy in a single TempDir.
+func writeFakeCgroupAt(t *testing.T, dir, controllers, subtree string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.controllers"), []byte(controllers), 0o644); err != nil {
+		t.Fatalf("write cgroup.controllers: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.subtree_control"), []byte(subtree), 0o644); err != nil {
+		t.Fatalf("write cgroup.subtree_control: %v", err)
+	}
+}
+
 func runCmd(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	return runCmdWithClient(t, nil, args...)
+}
+
+// runCmdWithClient invokes the cgroups command with an optional fake
+// kukeonv1.Client injected via the MockControllerKey context value. nil
+// client means "no scope; the host-root path is taken".
+func runCmdWithClient(t *testing.T, client kukeonv1.Client, args ...string) (string, string, error) {
 	t.Helper()
 	cmd := cgroupscmd.NewCgroupsCmd()
 	stdout := &bytes.Buffer{}
@@ -49,6 +71,11 @@ func runCmd(t *testing.T, args ...string) (string, string, error) {
 	cmd.SetOut(stdout)
 	cmd.SetErr(stderr)
 	cmd.SetArgs(args)
+	ctx := context.Background()
+	if client != nil {
+		ctx = context.WithValue(ctx, cgroupscmd.MockControllerKey{}, client)
+	}
+	cmd.SetContext(ctx)
 	err := cmd.Execute()
 	return stdout.String(), stderr.String(), err
 }
@@ -150,4 +177,262 @@ func TestCgroupsCmdNoSuchRoot(t *testing.T) {
 		t.Errorf("error message = %q, want it to mention 'cgroup pre-flight'", err.Error())
 	}
 	_ = stderr
+}
+
+// fakeScopedClient embeds FakeClient so only the Get* methods relevant to
+// each --scope test are overridden. CgroupPath is the value the daemon
+// would have populated on Status; tests join it with --root to point the
+// pre-flight at a synthetic cgroup directory.
+type fakeScopedClient struct {
+	kukeonv1.FakeClient
+
+	realmCgroupPath string
+	spaceCgroupPath string
+	stackCgroupPath string
+	cellCgroupPath  string
+
+	// realm/space/stack/cell metadata gates so tests can simulate "not
+	// found" without overriding all four methods.
+	realmExists bool
+	spaceExists bool
+	stackExists bool
+	cellExists  bool
+}
+
+func (f *fakeScopedClient) GetRealm(_ context.Context, doc v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+	out := v1beta1.RealmDoc{
+		Metadata: doc.Metadata,
+		Status:   v1beta1.RealmStatus{CgroupPath: f.realmCgroupPath},
+	}
+	return kukeonv1.GetRealmResult{
+		Realm:          out,
+		MetadataExists: f.realmExists,
+	}, nil
+}
+
+func (f *fakeScopedClient) GetSpace(_ context.Context, doc v1beta1.SpaceDoc) (kukeonv1.GetSpaceResult, error) {
+	out := v1beta1.SpaceDoc{
+		Metadata: doc.Metadata,
+		Spec:     doc.Spec,
+		Status:   v1beta1.SpaceStatus{CgroupPath: f.spaceCgroupPath},
+	}
+	return kukeonv1.GetSpaceResult{
+		Space:          out,
+		MetadataExists: f.spaceExists,
+	}, nil
+}
+
+func (f *fakeScopedClient) GetStack(_ context.Context, doc v1beta1.StackDoc) (kukeonv1.GetStackResult, error) {
+	out := v1beta1.StackDoc{
+		Metadata: doc.Metadata,
+		Spec:     doc.Spec,
+		Status:   v1beta1.StackStatus{CgroupPath: f.stackCgroupPath},
+	}
+	return kukeonv1.GetStackResult{
+		Stack:          out,
+		MetadataExists: f.stackExists,
+	}, nil
+}
+
+func (f *fakeScopedClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	out := v1beta1.CellDoc{
+		Metadata: doc.Metadata,
+		Spec:     doc.Spec,
+		Status:   v1beta1.CellStatus{CgroupPath: f.cellCgroupPath},
+	}
+	return kukeonv1.GetCellResult{
+		Cell:           out,
+		MetadataExists: f.cellExists,
+	}, nil
+}
+
+// TestCgroupsCmdScopeResolvesAndPasses exercises every --scope kind
+// against a synthetic cgroup-v2 hierarchy under one TempDir: the host
+// root has the kukeond resource subset, and each named scope has the
+// same set fully delegated, so the pre-flight must exit 0 for all four
+// scope kinds. This is the resolution-path coverage AC #5 calls for.
+func TestCgroupsCmdScopeResolvesAndPasses(t *testing.T) {
+	root := t.TempDir()
+	// Host-root files keep the unscoped path callable too (defensive —
+	// the scoped path joins root with the cgroup-relative path).
+	writeFakeCgroupAt(t, root,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	// Synthetic per-scope directories. Cell sits under stack sits under
+	// space sits under realm sits under root, mirroring real-world
+	// /sys/fs/cgroup/kukeon/<realm>/<space>/<stack>/<cell> layout.
+	full := "cpuset cpu io memory hugetlb pids rdma misc"
+	enabled := "cpu memory io pids"
+	realmCg := "/kukeon/default"
+	spaceCg := "/kukeon/default/sp"
+	stackCg := "/kukeon/default/sp/st"
+	cellCg := "/kukeon/default/sp/st/ce"
+	for _, p := range []string{realmCg, spaceCg, stackCg, cellCg} {
+		writeFakeCgroupAt(t, filepath.Join(root, p), full, enabled)
+	}
+
+	client := &fakeScopedClient{
+		realmExists: true, realmCgroupPath: realmCg,
+		spaceExists: true, spaceCgroupPath: spaceCg,
+		stackExists: true, stackCgroupPath: stackCg,
+		cellExists: true, cellCgroupPath: cellCg,
+	}
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"realm", []string{"--scope", "realm", "default", "--root", root}},
+		{"space", []string{"--scope", "space", "sp", "--realm", "default", "--root", root}},
+		{"stack", []string{"--scope", "stack", "st", "--realm", "default", "--space", "sp", "--root", root}},
+		{"cell", []string{
+			"--scope", "cell", "ce",
+			"--realm", "default", "--space", "sp", "--stack", "st",
+			"--root", root,
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := runCmdWithClient(t, client, tc.args...)
+			if err != nil {
+				t.Fatalf("scope=%s Execute() error = %v\nstdout=%q\nstderr=%q",
+					tc.name, err, stdout, stderr)
+			}
+			if stdout != "" {
+				t.Errorf("scope=%s stdout = %q, want empty on success", tc.name, stdout)
+			}
+		})
+	}
+}
+
+// TestCgroupsCmdScopeFailsOnGap: with a synthetic gap (memory missing
+// from the realm's cgroup.subtree_control), --scope realm must exit
+// non-zero and the stderr must identify the realm via the new "scope:"
+// header line so the operator can tell which sub-tree failed. This is
+// the gap-exit coverage AC #5 calls for.
+func TestCgroupsCmdScopeFailsOnGap(t *testing.T) {
+	root := t.TempDir()
+	writeFakeCgroupAt(t, root,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	realmCg := "/kukeon/default"
+	// Gap: memory + io present in cgroup.controllers but not delegated
+	// onto subtree_control at the realm level.
+	writeFakeCgroupAt(t, filepath.Join(root, realmCg),
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	client := &fakeScopedClient{realmExists: true, realmCgroupPath: realmCg}
+
+	_, stderr, err := runCmdWithClient(t, client,
+		"--scope", "realm", "default", "--root", root,
+	)
+	if err == nil {
+		t.Fatal("scope=realm gap Execute() error = nil, want error")
+	}
+	for _, want := range []string{`scope: realm "default"`, "memory", "io", "cgroup.subtree_control"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestCgroupsCmdScopeRequiresName: every --scope kind requires a
+// positional <name>. The error must say so and not crash inside the
+// daemon path.
+func TestCgroupsCmdScopeRequiresName(t *testing.T) {
+	client := &fakeScopedClient{}
+	_, _, err := runCmdWithClient(t, client, "--scope", "realm")
+	if err == nil {
+		t.Fatal("Execute() error = nil for --scope realm without name, want error")
+	}
+	if !strings.Contains(err.Error(), "<name>") {
+		t.Errorf("error = %q, want it to mention <name>", err.Error())
+	}
+}
+
+// TestCgroupsCmdScopeRequiresParentFlags: --scope space|stack|cell each
+// require their parent flags. Mirrors the same enforcement in
+// `kuke get space|stack|cell` so operators learn one rule.
+func TestCgroupsCmdScopeRequiresParentFlags(t *testing.T) {
+	client := &fakeScopedClient{}
+	cases := []struct {
+		name    string
+		args    []string
+		wantSub string
+	}{
+		{"space-no-realm", []string{"--scope", "space", "sp"}, "--realm"},
+		{"stack-no-realm", []string{"--scope", "stack", "st", "--space", "sp"}, "--realm"},
+		{"stack-no-space", []string{"--scope", "stack", "st", "--realm", "r"}, "--space"},
+		{"cell-no-realm", []string{"--scope", "cell", "c", "--space", "sp", "--stack", "st"}, "--realm"},
+		{"cell-no-space", []string{"--scope", "cell", "c", "--realm", "r", "--stack", "st"}, "--space"},
+		{"cell-no-stack", []string{"--scope", "cell", "c", "--realm", "r", "--space", "sp"}, "--stack"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := runCmdWithClient(t, client, tc.args...)
+			if err == nil {
+				t.Fatalf("Execute() error = nil for %s, want error", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error = %q, want it to mention %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestCgroupsCmdScopeRejectsUnknownKind: an unknown --scope value must
+// fail with a clear "must be one of" message and not silently fall
+// through to the host-root path.
+func TestCgroupsCmdScopeRejectsUnknownKind(t *testing.T) {
+	client := &fakeScopedClient{}
+	_, _, err := runCmdWithClient(t, client, "--scope", "container", "x")
+	if err == nil {
+		t.Fatal("Execute() error = nil for unknown scope, want error")
+	}
+	if !strings.Contains(err.Error(), "must be one of") {
+		t.Errorf("error = %q, want it to mention 'must be one of'", err.Error())
+	}
+}
+
+// TestCgroupsCmdScopeNotFound: when the daemon does not know the named
+// resource, the scoped pre-flight must surface that (and not crash)
+// before reading any cgroup file.
+func TestCgroupsCmdScopeNotFound(t *testing.T) {
+	root := t.TempDir()
+	writeFakeCgroupAt(t, root,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	client := &fakeScopedClient{realmExists: false}
+
+	_, _, err := runCmdWithClient(t, client,
+		"--scope", "realm", "ghost", "--root", root,
+	)
+	if err == nil {
+		t.Fatal("Execute() error = nil for unknown realm, want error")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Errorf("error = %q, want it to name the missing realm", err.Error())
+	}
+}
+
+// TestCgroupsCmdNameWithoutScope: a positional name without --scope is a
+// usage mistake — surface it cleanly instead of silently ignoring the
+// argument.
+func TestCgroupsCmdNameWithoutScope(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	_, _, err := runCmd(t, "--root", root, "default")
+	if err == nil {
+		t.Fatal("Execute() error = nil for name without --scope, want error")
+	}
+	if !strings.Contains(err.Error(), "--scope") {
+		t.Errorf("error = %q, want it to mention --scope", err.Error())
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `--scope realm|space|stack|cell <name>` to `kuke doctor cgroups`. When set, the command resolves the named object's `Status.CgroupPath` via the daemon and runs the existing `cgroupcheck.Check` against that directory instead of the host root, so operators can diagnose mid-tree delegation gaps without rebuilding the full host-root pre-flight invocation.
- Mirrors the `kuke get realm|space|stack|cell` parent-flag pattern (`--realm`, `--space`, `--stack` plus the positional name), so the addressing convention is the same one operators already know.
- Output mirrors the host-root format with one new `scope: ...` header line that names the sub-tree being checked. Default behavior (no `--scope`) is unchanged from PR #325 — same exit codes, same silence on success, same remediation on failure.
- Failure mode preserved end-to-end: `--scope realm <name>` against a synthetic gap exits non-zero with the same `cgroupcheck.FormatRemediation` output. Resource not found / missing parent flag / unknown scope kind each surface a clean error before any cgroup file is read.
- Test coverage: resolution path for all four scope kinds (table-driven, asserts exit 0 against synthetic populated dirs), gap-exit on a synthetic missing-controller hierarchy, validation errors for missing name / missing parent flags / unknown scope kind / not-found resource / positional-name-without-scope misuse. Daemon access is exercised through a `MockControllerKey{}` context value matching the convention `cmd/kuke/get/...` already uses.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full unit-test target CI runs
- [x] `pre-commit run --files cmd/kuke/doctor/cgroups/cgroups.go cmd/kuke/doctor/cgroups/cgroups_test.go` — go-fmt, golangci-lint, addlicense
- [x] `make dev-init` — daemon-parity tail matches the regression-guard output (`default` + `kuke-system` realms Ready with `/kukeon/...` cgroup paths)
- [x] `sudo ./kuke doctor cgroups` (unchanged host-root path, exit 0 silently)
- [x] `sudo ./kuke doctor cgroups --scope realm default` — exit 0
- [x] `sudo ./kuke doctor cgroups --scope space default --realm default` — exit 0
- [x] `sudo ./kuke doctor cgroups --scope stack default --realm default --space default` — exit 0
- [x] `sudo ./kuke doctor cgroups --scope cell kukeond --realm kuke-system --space kukeon --stack kukeon` — exit 0
- [x] `sudo ./kuke doctor cgroups --scope realm default --verbose-status` — prints `scope: realm "default"` then the per-controller status block
- [x] `sudo ./kuke doctor cgroups --scope realm ghost` — exits 1 with `realm "ghost" not found`
- [x] `sudo ./kuke doctor cgroups --scope cell kukeond` (missing parent flags) — exits 1 with `--scope cell requires --realm`

Closes #329