### PR TITLE
fix: doctor cgroups probes by default to avoid suggesting EOPNOTSUPP fix

### DIFF
--- a/cmd/kuke/doctor/cgroups/cgroups.go
+++ b/cmd/kuke/doctor/cgroups/cgroups.go
@@ -54,6 +54,7 @@ func NewCgroupsCmd() *cobra.Command {
 		root    string
 		nested  bool
 		probe   bool
+		noProbe bool
 		verbose bool
 
 		scope string
@@ -74,9 +75,15 @@ func NewCgroupsCmd() *cobra.Command {
 			"against that directory instead of the host root — useful for\n" +
 			"diagnosing mid-tree delegation gaps when a workload below a given\n" +
 			"level fails to start.\n\n" +
+			"By default, the pre-flight probes any controller missing from\n" +
+			"cgroup.subtree_control with a +<ctrl> write so the cgroup-namespace\n" +
+			"trap (advertised but not delegated, write returns EOPNOTSUPP) is\n" +
+			"distinguished from \"merely needs the operator to enable it\". The\n" +
+			"probe is idempotent on healthy hosts and harmless on trapped ones;\n" +
+			"pass --no-probe to keep the pre-flight strictly read-only.\n\n" +
 			"Exit code 0: every required controller is enabled (or was enabled by\n" +
-			"the optional --probe write). Non-zero: at least one controller is\n" +
-			"missing or the cgroup directory could not be read.",
+			"the probe write). Non-zero: at least one controller is missing or the\n" +
+			"cgroup directory could not be read.",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			target := scopedTarget{
@@ -88,7 +95,10 @@ func NewCgroupsCmd() *cobra.Command {
 			if len(args) > 0 {
 				target.name = strings.TrimSpace(args[0])
 			}
-			return runDoctor(cmd, root, nested, probe, verbose, target)
+			// --no-probe always wins over --probe so an explicit opt-out
+			// is unambiguous regardless of flag ordering.
+			effectiveProbe := probe && !noProbe
+			return runDoctor(cmd, root, nested, effectiveProbe, verbose, target)
 		},
 		// A failed pre-flight is a host-environment problem, not a CLI
 		// usage error — the structured remediation is the message we
@@ -101,9 +111,14 @@ func NewCgroupsCmd() *cobra.Command {
 		"path to the cgroup-v2 root (default: "+cgroupcheck.DefaultHostRoot()+")")
 	cmd.Flags().BoolVar(&nested, "nested-cgroup-runtime", false,
 		"check the controller set required when the kukeond cell opts into NestedCgroupRuntime")
-	cmd.Flags().BoolVar(&probe, "probe", false,
+	cmd.Flags().BoolVar(&probe, "probe", true,
 		"attempt a +<ctrl> write to cgroup.subtree_control for missing controllers; "+
-			"disambiguates the cgroup-namespace trap. Idempotent — leaves the host in a strictly better state on success.")
+			"disambiguates the cgroup-namespace trap (default true). Idempotent — leaves the host in a "+
+			"strictly better state on success. Pass --no-probe to keep the pre-flight read-only.")
+	cmd.Flags().BoolVar(&noProbe, "no-probe", false,
+		"opt out of the +<ctrl> probe write; the pre-flight stays strictly read-only and "+
+			"missing-but-advertised controllers are reported as needs-delegation without "+
+			"distinguishing the cgroup-namespace trap. Wins over --probe when both are set.")
 	cmd.Flags().BoolVar(&verbose, "verbose-status", false,
 		"print per-controller status even when the pre-flight passes")
 	cmd.Flags().StringVar(&scope, "scope", "",

--- a/cmd/kuke/doctor/cgroups/cgroups_test.go
+++ b/cmd/kuke/doctor/cgroups/cgroups_test.go
@@ -98,18 +98,21 @@ func TestCgroupsCmdHappyPath(t *testing.T) {
 	}
 }
 
-// TestCgroupsCmdMissingFails: when memory + io are missing from
-// subtree_control, the command exits non-zero and the stderr remediation
-// names them and the canonical fix.
-func TestCgroupsCmdMissingFails(t *testing.T) {
+// TestCgroupsCmdMissingFailsNoProbe: with --no-probe, when memory + io are
+// missing from subtree_control, the command exits non-zero and the stderr
+// remediation names them and the canonical fix. Pinning --no-probe rather
+// than the bare default keeps the assertion stable now that probing is
+// the default behavior — the tempdir-backed subtree_control would otherwise
+// accept the +<ctrl> writes and the pre-flight would pass.
+func TestCgroupsCmdMissingFailsNoProbe(t *testing.T) {
 	root := writeFakeCgroup(t,
 		"cpuset cpu io memory pids",
 		"cpu pids",
 	)
 
-	_, stderr, err := runCmd(t, "--root", root)
+	_, stderr, err := runCmd(t, "--root", root, "--no-probe")
 	if err == nil {
-		t.Fatal("Execute() error = nil for host missing memory + io, want error")
+		t.Fatal("Execute() error = nil for host missing memory + io with --no-probe, want error")
 	}
 
 	for _, want := range []string{"memory", "io", "cgroup.subtree_control"} {
@@ -119,11 +122,34 @@ func TestCgroupsCmdMissingFails(t *testing.T) {
 	}
 }
 
+// TestCgroupsCmdProbesByDefault: a bare `kuke doctor cgroups` (no --probe,
+// no --no-probe) must probe by default — that is the fix #333 calls for.
+// On the tempdir-backed fake cgroup the +<ctrl> writes succeed, so missing
+// controllers end up StatusEnabledByProbe and the pre-flight exits 0.
+// This pins the new default so a future regression that re-disables probe
+// fails the test instead of silently regressing the user-visible behavior.
+func TestCgroupsCmdProbesByDefault(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	stdout, stderr, err := runCmd(t, "--root", root)
+	if err != nil {
+		t.Fatalf("default-probe Execute() error = %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("default-probe stdout = %q, want empty (silence on probe success)", stdout)
+	}
+}
+
 // TestCgroupsCmdProbeRecoversOnPlainFile: --probe writes "+<ctrl>" to the
 // fake subtree_control file. After the write the controllers are present
 // in the file and a re-read inside cgroupcheck classifies them as
 // EnabledByProbe → command returns success. Exercises the same probe
-// path dev-init.sh uses on a misconfigured host.
+// path dev-init.sh uses on a misconfigured host. Pinning the explicit
+// --probe form keeps the dev-init.sh callsite contractually covered even
+// after probe-by-default became the new default.
 func TestCgroupsCmdProbeRecoversOnPlainFile(t *testing.T) {
 	root := writeFakeCgroup(t,
 		"cpuset cpu io memory pids",
@@ -133,6 +159,28 @@ func TestCgroupsCmdProbeRecoversOnPlainFile(t *testing.T) {
 	stdout, stderr, err := runCmd(t, "--root", root, "--probe")
 	if err != nil {
 		t.Fatalf("probe-recover Execute() error = %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+}
+
+// TestCgroupsCmdNoProbeWinsOverProbe: when both --probe and --no-probe are
+// passed, --no-probe wins and the pre-flight stays read-only. Pins the
+// "explicit opt-out is unambiguous regardless of flag ordering" contract
+// so a future change can't silently re-enable probing for an operator who
+// asked for read-only.
+func TestCgroupsCmdNoProbeWinsOverProbe(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	_, stderr, err := runCmd(t, "--root", root, "--probe", "--no-probe")
+	if err == nil {
+		t.Fatal("Execute() error = nil with --probe --no-probe and missing controllers, want error")
+	}
+	for _, want := range []string{"memory", "io"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q under --probe --no-probe:\n%s", want, stderr)
+		}
 	}
 }
 
@@ -156,7 +204,7 @@ func TestCgroupsCmdNestedFailsOnPartialSubtree(t *testing.T) {
 	full := "cpuset cpu io memory hugetlb pids rdma misc"
 	root := writeFakeCgroup(t, full, "cpu memory io pids")
 
-	_, stderr, err := runCmd(t, "--root", root, "--nested-cgroup-runtime")
+	_, stderr, err := runCmd(t, "--root", root, "--nested-cgroup-runtime", "--no-probe")
 	if err == nil {
 		t.Fatal("nested partial-subtree Execute() error = nil, want error")
 	}
@@ -328,7 +376,7 @@ func TestCgroupsCmdScopeFailsOnGap(t *testing.T) {
 	client := &fakeScopedClient{realmExists: true, realmCgroupPath: realmCg}
 
 	_, stderr, err := runCmdWithClient(t, client,
-		"--scope", "realm", "default", "--root", root,
+		"--scope", "realm", "default", "--root", root, "--no-probe",
 	)
 	if err == nil {
 		t.Fatal("scope=realm gap Execute() error = nil, want error")


### PR DESCRIPTION
## Summary

- `kuke doctor cgroups` previously deferred the `+<ctrl>` probe write to `--probe`, so a bare invocation on a cgroup-namespace-trapped host (controllers advertised in `cgroup.controllers` but never delegated by the parent) classified the controllers as `needs-delegation` and suggested a `tee` fix that returns `Operation not supported` when the user actually pasted it.
- Flip the default to **probe-on**, idempotent on healthy hosts and harmless on trapped ones. Add a `--no-probe` opt-out for the rare strictly-read-only case. The trap stanza already in `FormatRemediation` is now reached for every user, not just those who happened to pass `--probe`.
- Backwards-compatible with the existing `dev-init.sh --probe` callsite — the flag stays accepted; default just changed from `false` to `true`. `--no-probe` always wins over `--probe` so an explicit opt-out is unambiguous regardless of flag ordering.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full unit-test sweep CI runs
- [x] `go test ./cmd/kuke/doctor/cgroups/... ./internal/cgroupcheck/...` — affected packages
- [x] New tests: `TestCgroupsCmdProbesByDefault` (pins probe-on default), `TestCgroupsCmdNoProbeWinsOverProbe` (pins opt-out semantics). Existing `TestCgroupsCmdMissingFails` renamed to `TestCgroupsCmdMissingFailsNoProbe` and pinned to `--no-probe`; `TestCgroupsCmdNestedFailsOnPartialSubtree` and `TestCgroupsCmdScopeFailsOnGap` updated likewise so they keep asserting the read-only failure path.
- [x] Live-host smoke: `sudo ./kuke doctor cgroups`, `--no-probe`, `--probe`, and `--verbose-status` — all exit 0 on a fully-delegated host. Help text shows `--probe (default true)` and the new `--no-probe` flag with the documented opt-out behavior.
- [ ] `make dev-init` — not run; the change is purely client-side CLI default-flip in `kuke doctor cgroups` and does not touch the daemon, the build path, or `/opt/kukeon`. The `dev-init.sh --probe` callsite is contractually covered by `TestCgroupsCmdProbeRecoversOnPlainFile`.

Closes #333