### PR TITLE
fix: classify domain-only EOPNOTSUPP in threaded subtree as threaded-subtree

### DIFF
--- a/internal/cgroupcheck/cgroupcheck.go
+++ b/internal/cgroupcheck/cgroupcheck.go
@@ -70,6 +70,14 @@ const (
 	// cgroup-namespace trap: cgroup.controllers advertises kernel support
 	// but the namespace's actual parent never delegated the controller.
 	StatusNotDelegated
+	// StatusThreadedSubtree — the probe write returned EOPNOTSUPP and
+	// cgroup.type at this scope is "domain threaded" or "threaded", so the
+	// kernel forbids enabling domain-only controllers (memory, io, ...) in
+	// this subtree_control regardless of delegation. Distinct from
+	// StatusNotDelegated because escalating to the parent runtime will not
+	// help — the fix lives at the threaded descendant or in this cgroup's
+	// own cgroup.type.
+	StatusThreadedSubtree
 	// StatusNeedsDelegation — listed in cgroup.controllers, missing from
 	// cgroup.subtree_control, and we did not probe (or probing wasn't
 	// permitted). The fix is "+<ctrl>" to cgroup.subtree_control, but the
@@ -93,6 +101,8 @@ func (s Status) String() string {
 		return "kernel-missing"
 	case StatusNotDelegated:
 		return "not-delegated"
+	case StatusThreadedSubtree:
+		return "threaded-subtree"
 	case StatusNeedsDelegation:
 		return "needs-delegation"
 	case StatusEnabledByProbe:
@@ -134,6 +144,7 @@ func (r Result) Unresolved() []string {
 			// Good terminal state.
 		case StatusKernelMissing,
 			StatusNotDelegated,
+			StatusThreadedSubtree,
 			StatusNeedsDelegation,
 			StatusPermissionDenied:
 			out = append(out, c)
@@ -233,22 +244,28 @@ func Check(hostRoot string, required []string, probe Prober) (Result, error) {
 			}
 			perr := probe(hostRoot, c)
 			res.ProbeErr[c] = perr
-			res.Status[c] = classifyProbeErr(perr)
+			res.Status[c] = classifyProbeErr(hostRoot, c, perr)
 		}
 	}
 	return res, nil
 }
 
 // classifyProbeErr maps the result of a probe write to a Status. The
-// distinction between StatusNotDelegated and StatusPermissionDenied is the
-// whole point of probing — getting it right keeps the remediation
-// suggestion correct.
-func classifyProbeErr(err error) Status {
+// distinction between StatusNotDelegated, StatusThreadedSubtree, and
+// StatusPermissionDenied is the whole point of probing — getting it right
+// keeps the remediation suggestion correct. EOPNOTSUPP on a domain-only
+// controller in a "domain threaded" / "threaded" cgroup is the
+// threaded-subtree trap, not the cgroup-namespace trap; reading
+// cgroup.type at hostRoot is what disambiguates them.
+func classifyProbeErr(hostRoot, controller string, err error) Status {
 	if err == nil {
 		return StatusEnabledByProbe
 	}
 	switch {
 	case errors.Is(err, syscall.EOPNOTSUPP), errors.Is(err, syscall.ENOTSUP):
+		if isThreadedSubtreeRoot(hostRoot) && isDomainOnlyController(controller) {
+			return StatusThreadedSubtree
+		}
 		return StatusNotDelegated
 	case errors.Is(err, syscall.EACCES), errors.Is(err, syscall.EPERM):
 		return StatusPermissionDenied
@@ -257,6 +274,41 @@ func classifyProbeErr(err error) Status {
 	// unexpected error: the controller was advertised but the write did
 	// not land, which is the same operator-visible outcome.
 	return StatusNotDelegated
+}
+
+// isDomainOnlyController reports whether a cgroup-v2 controller is
+// forbidden in a threaded subtree's cgroup.subtree_control. The kernel
+// permits only thread-aware controllers (cpu, cpuset, perf_event, pids
+// per cgroup-v2.rst) in a threaded subtree; everything else is
+// domain-only and will EOPNOTSUPP on the +<ctrl> write. Adding to this
+// set without kernel support would silently reclassify a real namespace
+// trap as threaded-subtree, so the list is pinned narrowly.
+func isDomainOnlyController(c string) bool {
+	switch c {
+	case "cpu", "cpuset", "perf_event", "pids":
+		return false
+	}
+	return true
+}
+
+// isThreadedSubtreeRoot reports whether the cgroup at hostRoot is in a
+// threaded state where domain-only controllers cannot be enabled. The
+// kernel exposes two relevant cgroup.type values: "domain threaded" (a
+// domain that has a threaded child, so its subtree_control is restricted
+// to thread-aware controllers) and "threaded" (the cgroup is itself a
+// threaded child). A read failure conservatively returns false so the
+// classifier falls through to the existing namespace-trap diagnosis
+// rather than mislabeling on hosts where cgroup.type is not present.
+func isThreadedSubtreeRoot(hostRoot string) bool {
+	data, err := os.ReadFile(filepath.Join(hostRoot, "cgroup.type"))
+	if err != nil {
+		return false
+	}
+	switch strings.TrimSpace(string(data)) {
+	case "domain threaded", "threaded":
+		return true
+	}
+	return false
 }
 
 // FormatRemediation returns a human-readable, multi-line message describing
@@ -281,6 +333,15 @@ func FormatRemediation(r Result) string {
 		b.WriteString("    them. escalate to the host / container runtime above this\n")
 		b.WriteString("    shell to delegate the missing controllers.\n")
 	}
+	if g, ok := groups[StatusThreadedSubtree]; ok {
+		fmt.Fprintf(&b, "\n  threaded-subtree forbids domain-only controllers: %s\n", strings.Join(g, ", "))
+		b.WriteString("    cgroup.type at this scope is \"domain threaded\" or \"threaded\",\n")
+		b.WriteString("    so the kernel only permits thread-aware controllers (cpu,\n")
+		b.WriteString("    cpuset, perf_event, pids) in this subtree_control. escalating\n")
+		b.WriteString("    to the parent runtime will not help — fix the threaded\n")
+		b.WriteString("    descendant that promoted this cgroup, or change this scope's\n")
+		b.WriteString("    cgroup.type back to \"domain\" before retrying.\n")
+	}
 	if g, ok := groups[StatusKernelMissing]; ok {
 		fmt.Fprintf(&b, "\n  kernel does not support: %s\n", strings.Join(g, ", "))
 		b.WriteString("    the running kernel was built without these controllers, or\n")
@@ -303,8 +364,11 @@ func FormatRemediation(r Result) string {
 	parts := make([]string, 0, len(unresolved))
 	for _, c := range unresolved {
 		// "kernel-missing" controllers cannot be enabled by an operator
-		// write; omit them from the fix line so the suggestion is correct.
-		if r.Status[c] == StatusKernelMissing {
+		// write; "threaded-subtree" controllers will EOPNOTSUPP on the
+		// same +<ctrl> write the fix suggests. Omit both from the fix
+		// line so the suggestion is correct — the threaded-subtree
+		// stanza above already explains the right remediation.
+		if r.Status[c] == StatusKernelMissing || r.Status[c] == StatusThreadedSubtree {
 			continue
 		}
 		parts = append(parts, "+"+c)

--- a/internal/cgroupcheck/cgroupcheck_test.go
+++ b/internal/cgroupcheck/cgroupcheck_test.go
@@ -82,6 +82,15 @@ func writeCgroupFiles(t *testing.T, controllers, subtree string) string {
 	return root
 }
 
+// writeCgroupType seeds a cgroup.type file in an existing fake host root
+// so the threaded-subtree classifier reads the value the test wants.
+func writeCgroupType(t *testing.T, root, value string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, "cgroup.type"), []byte(value+"\n"), 0o644); err != nil {
+		t.Fatalf("write cgroup.type: %v", err)
+	}
+}
+
 func TestCheckAllEnabled(t *testing.T) {
 	root := writeCgroupFiles(t,
 		"cpuset cpu io memory hugetlb pids rdma misc",
@@ -233,6 +242,168 @@ func TestCheckProbeEOPNOTSUPP(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("FormatRemediation missing %q:\n%s", want, msg)
 		}
+	}
+}
+
+// TestCheckProbeThreadedSubtreeDomainOnly: when cgroup.type is "domain
+// threaded" and the probe write returns EOPNOTSUPP for a domain-only
+// controller (memory, io), the classifier must report
+// StatusThreadedSubtree — not StatusNotDelegated. The remediation must
+// name the threaded-subtree case and must not include the misleading
+// "escalate to the parent runtime" footer for the affected controllers
+// (the +<ctrl> tee fix line excludes them).
+func TestCheckProbeThreadedSubtreeDomainOnly(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+	writeCgroupType(t, root, "domain threaded")
+
+	probe := func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EOPNOTSUPP
+		}
+		return nil
+	}
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	for _, c := range []string{"memory", "io"} {
+		if got, want := res.Status[c], cgroupcheck.StatusThreadedSubtree; got != want {
+			t.Errorf("Status[%q] = %v, want %v", c, got, want)
+		}
+	}
+	if res.OK() {
+		t.Fatal("Check() OK=true with threaded-subtree EOPNOTSUPP failures")
+	}
+
+	msg := cgroupcheck.FormatRemediation(res)
+	for _, want := range []string{
+		"threaded-subtree forbids domain-only controllers",
+		"memory, io",
+		`"domain threaded"`,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("FormatRemediation missing %q:\n%s", want, msg)
+		}
+	}
+	// The threaded-subtree fix is not "+<ctrl> | sudo tee" — those
+	// writes will EOPNOTSUPP again. The fix line must omit the
+	// threaded-subtree controllers so the suggestion stays correct.
+	if strings.Contains(msg, "+memory") || strings.Contains(msg, "+io") {
+		t.Errorf("FormatRemediation suggests +memory/+io tee fix for threaded-subtree controllers:\n%s", msg)
+	}
+	// And the threaded-subtree class must not be misclassified as the
+	// namespace trap, which would lead the operator to escalate
+	// pointlessly to the host/container runtime.
+	if strings.Contains(msg, "cgroup-namespace trap") {
+		t.Errorf("FormatRemediation surfaces cgroup-namespace trap stanza for threaded-subtree-only failures:\n%s", msg)
+	}
+}
+
+// TestCheckProbeThreadedTypeAlone: cgroup.type "threaded" (the cgroup is
+// itself a threaded child, not just a domain root with threaded
+// children) is the second value the kernel uses to gate domain-only
+// controllers. Pin the same classification path so a future regression
+// that only handles "domain threaded" still trips this test.
+func TestCheckProbeThreadedTypeAlone(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+	writeCgroupType(t, root, "threaded")
+
+	probe := func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EOPNOTSUPP
+		}
+		return nil
+	}
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	for _, c := range []string{"memory", "io"} {
+		if got, want := res.Status[c], cgroupcheck.StatusThreadedSubtree; got != want {
+			t.Errorf("Status[%q] = %v, want %v under cgroup.type=threaded", c, got, want)
+		}
+	}
+}
+
+// TestCheckProbeThreadedTypeThreadAwareControllerStaysNotDelegated: a
+// thread-aware controller (cpu, pids, ...) failing with EOPNOTSUPP on a
+// "domain threaded" cgroup is a real namespace trap, not the
+// threaded-subtree case — the kernel does allow these in a threaded
+// subtree. Misclassifying here would suppress the correct escalation
+// hint, so pin the boundary.
+func TestCheckProbeThreadedTypeThreadAwareControllerStaysNotDelegated(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"memory io",
+	)
+	writeCgroupType(t, root, "domain threaded")
+
+	probe := func(_, ctrl string) error {
+		if ctrl == "cpu" || ctrl == "pids" {
+			return syscall.EOPNOTSUPP
+		}
+		return nil
+	}
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	for _, c := range []string{"cpu", "pids"} {
+		if got, want := res.Status[c], cgroupcheck.StatusNotDelegated; got != want {
+			t.Errorf("Status[%q] = %v, want %v (thread-aware controller in threaded subtree → namespace trap)",
+				c, got, want)
+		}
+	}
+}
+
+// TestCheckProbeMissingCgroupTypeFallsBackToNotDelegated: the
+// classifier's cgroup.type read must fail soft — when the file is
+// absent (e.g. tempdir-backed fakes that don't set it), an EOPNOTSUPP
+// probe write stays StatusNotDelegated rather than getting reclassified.
+// This pins the conservative-fallback contract so a future "treat
+// missing cgroup.type as threaded" change can't silently break the
+// existing namespace-trap diagnosis on hosts where cgroup.type is
+// genuinely unreadable.
+func TestCheckProbeMissingCgroupTypeFallsBackToNotDelegated(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+	// Deliberately do not write cgroup.type.
+
+	probe := func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EOPNOTSUPP
+		}
+		return nil
+	}
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	for _, c := range []string{"memory", "io"} {
+		if got, want := res.Status[c], cgroupcheck.StatusNotDelegated; got != want {
+			t.Errorf("Status[%q] = %v, want %v with cgroup.type absent", c, got, want)
+		}
+	}
+}
+
+// TestStatusThreadedSubtreeString pins the human-readable label so
+// downstream parsers / dev-init.sh greps that key on the label stay
+// stable.
+func TestStatusThreadedSubtreeString(t *testing.T) {
+	if got, want := cgroupcheck.StatusThreadedSubtree.String(), "threaded-subtree"; got != want {
+		t.Errorf("StatusThreadedSubtree.String() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Doctor's `--probe` mode misdiagnosed EOPNOTSUPP on a `domain threaded` cgroup as the cgroup-namespace trap, sending operators to escalate to the parent runtime when the actual rule is that domain-only controllers (memory, io, ...) are forbidden in a threaded subtree's `subtree_control`.
- Adds `StatusThreadedSubtree` between `StatusNotDelegated` and `StatusNeedsDelegation`. The probe-error classifier now reads `<target>/cgroup.type` on EOPNOTSUPP and switches to the new status when the cgroup is `domain threaded` or `threaded` and the failing controller is not in the kernel's thread-aware set (`cpu, cpuset, perf_event, pids`).
- New `FormatRemediation` stanza explains the threaded-subtree case and points at the threaded descendant / cell `cgroup.type` as the fix instead of the parent runtime. Threaded-subtree controllers are also dropped from the generic `+<ctrl> | sudo tee` fix line — that write would EOPNOTSUPP again.
- The `cgroup.type` read fails soft: missing file → `false`, so the existing namespace-trap diagnosis still fires when no threaded state is present (covered by the existing `TestCheckProbeEOPNOTSUPP` and a new `TestCheckProbeMissingCgroupTypeFallsBackToNotDelegated`). No daemon code consumes the doctor classifier (only `CellResourceControllers()` is shared), so this is a doctor-side change with no behavioral impact on cell creation.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` — all packages pass, including the five new cgroupcheck tests covering `domain threaded` + domain-only → ThreadedSubtree, `threaded` alone, thread-aware controller in threaded subtree → still NotDelegated, missing cgroup.type → fallback, and the `String()` label
- [x] `pre-commit run` on the changed files (golangci-lint, gofmt, addlicense) — passes
- [x] `make dev-init` smoke per project CLAUDE.md (since `dev-init.sh` calls `kuke doctor cgroups --probe` whose code I changed) — daemon-parity tail matches expected output for `default` and `kuke-system` realms

Closes #334