### PR TITLE
fix: classify EBUSY probe write as internal-process, not namespace trap

### DIFF
--- a/internal/cgroupcheck/cgroupcheck.go
+++ b/internal/cgroupcheck/cgroupcheck.go
@@ -78,6 +78,14 @@ const (
 	// help — the fix lives at the threaded descendant or in this cgroup's
 	// own cgroup.type.
 	StatusThreadedSubtree
+	// StatusInternalProcess — the probe write returned EBUSY because this
+	// cgroup contains processes in its own cgroup.procs. Cgroup-v2's
+	// no-internal-process rule forbids enabling non-thread-aware
+	// controllers in subtree_control on a non-leaf cgroup that hosts
+	// processes. Distinct from StatusNotDelegated because the parent did
+	// delegate; the fix is to move the processes to a child cgroup (or
+	// accept that only thread-aware controllers can land here).
+	StatusInternalProcess
 	// StatusNeedsDelegation — listed in cgroup.controllers, missing from
 	// cgroup.subtree_control, and we did not probe (or probing wasn't
 	// permitted). The fix is "+<ctrl>" to cgroup.subtree_control, but the
@@ -103,6 +111,8 @@ func (s Status) String() string {
 		return "not-delegated"
 	case StatusThreadedSubtree:
 		return "threaded-subtree"
+	case StatusInternalProcess:
+		return "internal-process"
 	case StatusNeedsDelegation:
 		return "needs-delegation"
 	case StatusEnabledByProbe:
@@ -145,6 +155,7 @@ func (r Result) Unresolved() []string {
 		case StatusKernelMissing,
 			StatusNotDelegated,
 			StatusThreadedSubtree,
+			StatusInternalProcess,
 			StatusNeedsDelegation,
 			StatusPermissionDenied:
 			out = append(out, c)
@@ -251,12 +262,14 @@ func Check(hostRoot string, required []string, probe Prober) (Result, error) {
 }
 
 // classifyProbeErr maps the result of a probe write to a Status. The
-// distinction between StatusNotDelegated, StatusThreadedSubtree, and
-// StatusPermissionDenied is the whole point of probing — getting it right
-// keeps the remediation suggestion correct. EOPNOTSUPP on a domain-only
-// controller in a "domain threaded" / "threaded" cgroup is the
-// threaded-subtree trap, not the cgroup-namespace trap; reading
-// cgroup.type at hostRoot is what disambiguates them.
+// distinction between StatusNotDelegated, StatusThreadedSubtree,
+// StatusInternalProcess, and StatusPermissionDenied is the whole point of
+// probing — getting it right keeps the remediation suggestion correct.
+// EOPNOTSUPP on a domain-only controller in a "domain threaded" /
+// "threaded" cgroup is the threaded-subtree trap, not the
+// cgroup-namespace trap; reading cgroup.type at hostRoot is what
+// disambiguates them. EBUSY is the no-internal-process rule firing on a
+// non-leaf cgroup that contains processes, which has its own remediation.
 func classifyProbeErr(hostRoot, controller string, err error) Status {
 	if err == nil {
 		return StatusEnabledByProbe
@@ -267,6 +280,8 @@ func classifyProbeErr(hostRoot, controller string, err error) Status {
 			return StatusThreadedSubtree
 		}
 		return StatusNotDelegated
+	case errors.Is(err, syscall.EBUSY):
+		return StatusInternalProcess
 	case errors.Is(err, syscall.EACCES), errors.Is(err, syscall.EPERM):
 		return StatusPermissionDenied
 	}
@@ -342,6 +357,15 @@ func FormatRemediation(r Result) string {
 		b.WriteString("    descendant that promoted this cgroup, or change this scope's\n")
 		b.WriteString("    cgroup.type back to \"domain\" before retrying.\n")
 	}
+	if g, ok := groups[StatusInternalProcess]; ok {
+		fmt.Fprintf(&b, "\n  no-internal-process rule (cgroup contains processes): %s\n", strings.Join(g, ", "))
+		b.WriteString("    cgroup-v2 forbids enabling non-thread-aware controllers in\n")
+		b.WriteString("    cgroup.subtree_control on a non-leaf cgroup that hosts\n")
+		b.WriteString("    processes in its own cgroup.procs. the parent did delegate;\n")
+		b.WriteString("    escalating to the parent runtime will not help. move the\n")
+		b.WriteString("    processes to a child cgroup, or accept that only thread-aware\n")
+		b.WriteString("    controllers (cpu, pids) can be enabled at this scope.\n")
+	}
 	if g, ok := groups[StatusKernelMissing]; ok {
 		fmt.Fprintf(&b, "\n  kernel does not support: %s\n", strings.Join(g, ", "))
 		b.WriteString("    the running kernel was built without these controllers, or\n")
@@ -365,10 +389,14 @@ func FormatRemediation(r Result) string {
 	for _, c := range unresolved {
 		// "kernel-missing" controllers cannot be enabled by an operator
 		// write; "threaded-subtree" controllers will EOPNOTSUPP on the
-		// same +<ctrl> write the fix suggests. Omit both from the fix
-		// line so the suggestion is correct — the threaded-subtree
-		// stanza above already explains the right remediation.
-		if r.Status[c] == StatusKernelMissing || r.Status[c] == StatusThreadedSubtree {
+		// same +<ctrl> write the fix suggests; "internal-process"
+		// controllers will EBUSY again until the operator first moves
+		// the contained processes out. Omit all three from the fix line
+		// so the suggestion is correct — each class's stanza above
+		// already explains the right remediation.
+		if r.Status[c] == StatusKernelMissing ||
+			r.Status[c] == StatusThreadedSubtree ||
+			r.Status[c] == StatusInternalProcess {
 			continue
 		}
 		parts = append(parts, "+"+c)

--- a/internal/cgroupcheck/cgroupcheck_test.go
+++ b/internal/cgroupcheck/cgroupcheck_test.go
@@ -407,6 +407,75 @@ func TestStatusThreadedSubtreeString(t *testing.T) {
 	}
 }
 
+// TestStatusInternalProcessString pins the human-readable label for the
+// EBUSY (no-internal-process) class. Same reason as the threaded-subtree
+// pinning: downstream greps key on the label string.
+func TestStatusInternalProcessString(t *testing.T) {
+	if got, want := cgroupcheck.StatusInternalProcess.String(), "internal-process"; got != want {
+		t.Errorf("StatusInternalProcess.String() = %q, want %q", got, want)
+	}
+}
+
+// TestCheckProbeEBUSY: the no-internal-process trap from issue #335. The
+// kernel returns EBUSY when subtree_control is asked to enable
+// non-thread-aware controllers on a non-leaf cgroup that contains
+// processes in its own cgroup.procs. The classifier must report
+// StatusInternalProcess — not StatusNotDelegated. The remediation must
+// name the no-internal-process rule, must not advertise the misleading
+// "escalate to the parent runtime" footer for the affected controllers
+// (the +<ctrl> tee fix line excludes them), and must not surface the
+// cgroup-namespace trap stanza.
+func TestCheckProbeEBUSY(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	probe := func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EBUSY
+		}
+		return nil
+	}
+
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	for _, c := range []string{"memory", "io"} {
+		if got, want := res.Status[c], cgroupcheck.StatusInternalProcess; got != want {
+			t.Errorf("Status[%q] = %v, want %v", c, got, want)
+		}
+	}
+	if res.OK() {
+		t.Fatal("Check() OK=true after EBUSY probe failures")
+	}
+
+	msg := cgroupcheck.FormatRemediation(res)
+	for _, want := range []string{
+		"no-internal-process rule",
+		"memory, io",
+		"move the",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("FormatRemediation missing %q:\n%s", want, msg)
+		}
+	}
+	// The internal-process fix is not "+<ctrl> | sudo tee" — those writes
+	// will EBUSY again until the operator first moves the contained
+	// processes out. The fix line must omit the affected controllers so
+	// the suggestion stays correct.
+	if strings.Contains(msg, "+memory") || strings.Contains(msg, "+io") {
+		t.Errorf("FormatRemediation suggests +memory/+io tee fix for internal-process controllers:\n%s", msg)
+	}
+	// And the internal-process class must not be misclassified as the
+	// namespace trap, which would lead the operator to escalate
+	// pointlessly to the host/container runtime.
+	if strings.Contains(msg, "cgroup-namespace trap") {
+		t.Errorf("FormatRemediation surfaces cgroup-namespace trap stanza for internal-process-only failures:\n%s", msg)
+	}
+}
+
 func TestCheckProbePermissionDenied(t *testing.T) {
 	root := writeCgroupFiles(t,
 		"cpuset cpu io memory pids",


### PR DESCRIPTION
## Summary

- `kuke doctor cgroups --probe` returned `EBUSY` from the kernel when a non-leaf cgroup hosting processes (e.g. a cell `_work`) is asked to enable a non-thread-aware controller — the cgroup-v2 no-internal-process rule. The classifier dropped through to the `StatusNotDelegated` fallback, so operators saw the cgroup-namespace-trap stanza ("escalate to the parent runtime") which does not address the actual precondition.
- Add `StatusInternalProcess` and branch `EBUSY` in `classifyProbeErr` to it. New `FormatRemediation` stanza names the no-internal-process rule and points the operator at moving processes to a child cgroup (or accepting thread-aware-only enablement at this scope).
- Internal-process controllers are excluded from the `+<ctrl> | sudo tee` fix line for the same reason `StatusKernelMissing` and `StatusThreadedSubtree` already are: the suggested write would EBUSY again until the precondition is fixed.
- Optional augmentation in the issue (surface `cgroup.procs` count alongside the result) is intentionally skipped as the lower-blast-radius default — the new stanza names the precondition explicitly, and a follow-up can wire the count if it proves useful.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cgroupcheck/... ./cmd/kuke/doctor/cgroups/...`
- [x] `make test` (full suite)
- [x] `pre-commit run` on staged files
- [ ] `make dev-init` smoke — change is contained to in-memory classifier logic for `kuke doctor cgroups`; daemon path / cell bootstrap untouched, so the dev-init smoke is not load-bearing for this fix.

Closes #335