### PR TITLE
fix: drain cell PIDs to _payload leaf for subtree_control widening

### DIFF
--- a/internal/controller/runner/provision_subtree_test.go
+++ b/internal/controller/runner/provision_subtree_test.go
@@ -118,6 +118,10 @@ func (c *subtreeRecorderClient) EnableCellAllSubtreeControllers(string, string) 
 	panic("unexpected")
 }
 
+func (c *subtreeRecorderClient) RelocateProcessesToLeaf(string, string, string) error {
+	panic("unexpected")
+}
+
 func (c *subtreeRecorderClient) CreateContainerFromSpec(
 	string, intmodel.ContainerSpec, []ctr.RegistryCredentials, ...ctr.BuildOption,
 ) (containerd.Container, error) {

--- a/internal/ctr/cgroups.go
+++ b/internal/ctr/cgroups.go
@@ -17,6 +17,7 @@
 package ctr
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -29,6 +30,13 @@ import (
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 )
+
+// bootstrapLeafName is the leaf cgroup the defensive drain in
+// applySubtreeControllers relocates the cgroup-namespace root's processes
+// into when widening subtree_control would otherwise hit the no-internal-
+// process rule. Kept distinct from _payload (the cell-startup leaf) so
+// post-mortem inspection of /sys/fs/cgroup can tell the two layers apart.
+const bootstrapLeafName = "__bootstrap"
 
 // TODO(eminwux): add cgroup integration tests once CI exposes a writable cgroup v2 hierarchy.
 
@@ -131,6 +139,52 @@ func (c *client) AddProcessToCgroup(group, mountpoint string, pid int) error {
 	return manager.AddProc(uint64(pid))
 }
 
+// RelocateProcessesToLeaf drains every PID currently in <group>/cgroup.procs
+// into a freshly-mkdir'd leaf cgroup at <group>/<leaf>. Used by both the
+// cell-startup structural fix and the applySubtreeControllers defensive
+// drain to satisfy cgroup-v2's no-internal-process rule before the kernel
+// is asked to enable a non-thread-aware controller in <group>'s
+// subtree_control. Idempotent: re-running on an already-drained group is a
+// no-op (mkdir tolerates existing leaf, the procs read returns no PIDs).
+//
+// The leaf scope inherits the parent's controllers via the parent's
+// subtree_control walk that runs after the drain, so resource accounting
+// applied at <group> still constrains the leaf — the relocation moves
+// where PIDs live in the cgroup tree, not which limits apply to them.
+func (c *client) RelocateProcessesToLeaf(group, mountpoint, leaf string) error {
+	if err := validateGroupPath(group); err != nil {
+		return err
+	}
+	if leaf == "" || strings.ContainsAny(leaf, "/") || leaf == "." || leaf == ".." {
+		return errdefs.ErrInvalidLeafName
+	}
+
+	mp := c.effectiveMountpoint(mountpoint)
+	groupPath := filepath.Join(mp, strings.TrimPrefix(group, "/"))
+	leafPath := filepath.Join(groupPath, leaf)
+
+	if err := os.Mkdir(leafPath, 0o750); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("create leaf cgroup %s: %w", leafPath, err)
+	}
+
+	pids, err := readCgroupProcs(filepath.Join(groupPath, "cgroup.procs"))
+	if err != nil {
+		return fmt.Errorf("read cgroup.procs in %s: %w", groupPath, err)
+	}
+	if len(pids) == 0 {
+		return nil
+	}
+
+	leafProcs := filepath.Join(leafPath, "cgroup.procs")
+	if writeErr := writeCgroupProcs(leafProcs, pids); writeErr != nil {
+		return fmt.Errorf("write cgroup.procs in %s: %w", leafPath, writeErr)
+	}
+
+	c.logger.InfoContext(c.ctx, "relocated processes to leaf cgroup",
+		"group", group, "leaf", leaf, "pids", len(pids))
+	return nil
+}
+
 // EnsureSubtreeControllers writes "+<ctrl>" to every ancestor's
 // cgroup.subtree_control file (root → group's parent) AND to the group's own
 // cgroup.subtree_control. The library's Manager.ToggleControllers handles the
@@ -218,6 +272,21 @@ func (c *client) applySubtreeControllers(group, mountpoint string, enable []stri
 		return nil
 	}
 
+	// Defensive no-internal-process drain (issue #336 scenario B). When kuke
+	// is invoked from inside a cgroup-namespace whose root cgroup carries
+	// processes (the shell, the kuke binary, anything else spawned by
+	// runc-exec into the cell's container-root cgroup directly), the
+	// ancestor walk below would EBUSY at the cgroup-ns root because
+	// cgroup-v2 forbids enabling non-thread-aware controllers in the
+	// subtree_control of a cgroup that hosts processes. Both clauses are
+	// required: /proc/self/cgroup == 0::/ guards against accidentally
+	// draining systemd's processes on a non-nested host (where the path
+	// shows the systemd slice, not the bare 0::/), and the populated check
+	// avoids the no-op mkdir+read on an empty root.
+	if drainErr := c.maybeDrainCgroupNsRoot(mountpoint); drainErr != nil {
+		return fmt.Errorf("drain cgroup-ns root before subtree_control widening: %w", drainErr)
+	}
+
 	manager, err := c.managerFor(group, mountpoint)
 	if err != nil {
 		return err
@@ -256,6 +325,112 @@ func intersectControllers(want, have []string) []string {
 		}
 	}
 	return out
+}
+
+// readCgroupProcs reads the PIDs from a cgroup.procs file. Empty lines are
+// skipped. Returns nil + nil if the file is empty.
+func readCgroupProcs(path string) ([]int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var pids []int
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var pid int
+		if _, parseErr := fmt.Sscanf(line, "%d", &pid); parseErr != nil {
+			return nil, fmt.Errorf("parse pid %q in %s: %w", line, path, parseErr)
+		}
+		pids = append(pids, pid)
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return nil, scanErr
+	}
+	return pids, nil
+}
+
+// writeCgroupProcs writes each PID into the target cgroup.procs file. The
+// kernel accepts one PID per write; batching them into a single write would
+// be rejected. Failures on individual PIDs are returned immediately so the
+// caller can decide whether the partial state is acceptable.
+func writeCgroupProcs(path string, pids []int) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	for _, pid := range pids {
+		if _, writeErr := fmt.Fprintf(f, "%d\n", pid); writeErr != nil {
+			return fmt.Errorf("write pid %d: %w", pid, writeErr)
+		}
+	}
+	return nil
+}
+
+// maybeDrainCgroupNsRoot drains the cgroup-namespace root cgroup's procs
+// into a __bootstrap leaf when both gating clauses hold:
+//   - /proc/self/cgroup reports 0::/ (we are at the cgroup-ns root, not on
+//     a non-nested host where systemd's slice path would show)
+//   - the mountpoint root cgroup.events shows populated 1 (there are
+//     processes whose presence would EBUSY a subtree_control widening)
+//
+// Either clause failing short-circuits with nil — this is a defensive
+// primitive that must be a no-op on every call site that does not match
+// the cgroup-namespace-trap fingerprint.
+func (c *client) maybeDrainCgroupNsRoot(mountpoint string) error {
+	atRoot, err := procSelfCgroupAtRoot()
+	if err != nil || !atRoot {
+		return err
+	}
+	mp := c.effectiveMountpoint(mountpoint)
+	populated, err := cgroupPopulated(mp)
+	if err != nil || !populated {
+		return err
+	}
+	return c.RelocateProcessesToLeaf("/", mp, bootstrapLeafName)
+}
+
+// procSelfCgroupAtRoot reports whether the calling process's
+// /proc/self/cgroup is the unified-hierarchy root entry "0::/", i.e. the
+// process sits at its cgroup namespace's root. A non-zero hierarchy id or
+// any path past "/" means the process is in a deeper cgroup and the
+// no-internal-process trap does not apply at the mountpoint root.
+func procSelfCgroupAtRoot() (bool, error) {
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return false, fmt.Errorf("read /proc/self/cgroup: %w", err)
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if strings.TrimSpace(line) == "0::/" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// cgroupPopulated reports whether the cgroup at the given path has its
+// "populated 1" flag set in cgroup.events. Returns false (no error) when
+// the file does not exist, so non-cgroupfs paths short-circuit cleanly.
+func cgroupPopulated(cgroupPath string) (bool, error) {
+	data, err := os.ReadFile(filepath.Join(cgroupPath, "cgroup.events"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if strings.TrimSpace(line) == "populated 1" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func writeSubtreeEnable(path string, controllers []string) error {

--- a/internal/ctr/cgroups_relocate_test.go
+++ b/internal/ctr/cgroups_relocate_test.go
@@ -1,0 +1,277 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// newTestClient builds a minimal client that talks to no socket. The
+// cgroup-file primitives operate on plain os.File operations against the
+// caller-supplied mountpoint, so a fake mountpoint under a tmpdir is enough
+// to exercise the relocate / drain logic without a real cgroup-v2 hierarchy.
+func newTestClient(t *testing.T) *client {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return &client{
+		ctx:    context.Background(),
+		logger: logger,
+		socket: "/test/socket",
+	}
+}
+
+func TestRelocateProcessesToLeafValidation(t *testing.T) {
+	c := newTestClient(t)
+
+	if err := c.RelocateProcessesToLeaf("", "/sys/fs/cgroup", "_payload"); !errors.Is(err, errdefs.ErrEmptyGroupPath) {
+		t.Errorf("empty group: got %v, want ErrEmptyGroupPath", err)
+	}
+
+	cases := []string{"", "/", "..", ".", "with/slash", "/leading"}
+	for _, leaf := range cases {
+		err := c.RelocateProcessesToLeaf("/kukeon/test", "/sys/fs/cgroup", leaf)
+		if !errors.Is(err, errdefs.ErrInvalidLeafName) {
+			t.Errorf("leaf %q: got %v, want ErrInvalidLeafName", leaf, err)
+		}
+	}
+}
+
+// writeCgroupTree builds a fake cgroup directory tree for the relocate
+// path. Both the group's cgroup.procs (populated with pids) and the leaf's
+// cgroup.procs (empty) are pre-created — on a real cgroup-v2 mountpoint
+// the kernel auto-creates cgroup.procs when a cgroup directory is mkdir'd,
+// so production code opens it read/write without O_CREATE. The pre-create
+// here keeps the tmpdir simulation faithful to that contract while also
+// covering the mkdir-already-exists branch of the relocate helper.
+func writeCgroupTree(t *testing.T, root, group, leaf string, pids []int) {
+	t.Helper()
+	dir := filepath.Join(root, group)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	procs := filepath.Join(dir, "cgroup.procs")
+	f, err := os.Create(procs)
+	if err != nil {
+		t.Fatalf("create %s: %v", procs, err)
+	}
+	for _, pid := range pids {
+		if _, writeErr := f.WriteString(itoaln(pid)); writeErr != nil {
+			t.Fatalf("write pid %d: %v", pid, writeErr)
+		}
+	}
+	_ = f.Close()
+	if leaf != "" {
+		leafDir := filepath.Join(dir, leaf)
+		if mkErr := os.MkdirAll(leafDir, 0o755); mkErr != nil {
+			t.Fatalf("mkdir leaf %s: %v", leafDir, mkErr)
+		}
+		if writeErr := os.WriteFile(filepath.Join(leafDir, "cgroup.procs"), nil, 0o644); writeErr != nil {
+			t.Fatalf("create leaf procs: %v", writeErr)
+		}
+	}
+}
+
+func itoaln(n int) string {
+	// fmt.Sprintf would pull fmt; small inline implementation keeps the test
+	// helper allocation-free and obvious.
+	if n == 0 {
+		return "0\n"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:]) + "\n"
+}
+
+func readPids(t *testing.T, path string) []int {
+	t.Helper()
+	pids, err := readCgroupProcs(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sort.Ints(pids)
+	return pids
+}
+
+func TestRelocateProcessesToLeafDrains(t *testing.T) {
+	root := t.TempDir()
+	c := newTestClient(t)
+
+	pids := []int{4242, 9999, 12345}
+	writeCgroupTree(t, root, "kukeon/test/cell", "_payload", pids)
+
+	if err := c.RelocateProcessesToLeaf("/kukeon/test/cell", root, "_payload"); err != nil {
+		t.Fatalf("RelocateProcessesToLeaf: %v", err)
+	}
+
+	leafProcs := filepath.Join(root, "kukeon/test/cell/_payload/cgroup.procs")
+	if _, err := os.Stat(filepath.Dir(leafProcs)); err != nil {
+		t.Fatalf("leaf dir missing: %v", err)
+	}
+
+	got := readPids(t, leafProcs)
+	want := []int{4242, 9999, 12345}
+	if len(got) != len(want) {
+		t.Fatalf("leaf pids: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("leaf pids[%d]: got %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestRelocateProcessesToLeafIdempotent(t *testing.T) {
+	root := t.TempDir()
+	c := newTestClient(t)
+
+	writeCgroupTree(t, root, "cell", "_payload", []int{42})
+
+	if err := c.RelocateProcessesToLeaf("/cell", root, "_payload"); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Empty cgroup.procs (the production drain leaves the source readable
+	// but no longer hosting tasks; in the kernel, the write-side would have
+	// moved the PIDs out, so a fresh read returns nothing).
+	if err := os.WriteFile(filepath.Join(root, "cell/cgroup.procs"), nil, 0o644); err != nil {
+		t.Fatalf("truncate source procs: %v", err)
+	}
+
+	if err := c.RelocateProcessesToLeaf("/cell", root, "_payload"); err != nil {
+		t.Fatalf("second call (no-op): %v", err)
+	}
+}
+
+func TestRelocateProcessesToLeafMissingSourceProcs(t *testing.T) {
+	root := t.TempDir()
+	c := newTestClient(t)
+
+	// Mkdir the group dir but do not create cgroup.procs — the relocate
+	// helper should surface the read error so callers see the broken state
+	// instead of silently swallowing it.
+	if err := os.MkdirAll(filepath.Join(root, "cell"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	err := c.RelocateProcessesToLeaf("/cell", root, "_payload")
+	if err == nil {
+		t.Fatal("expected error reading missing cgroup.procs, got nil")
+	}
+}
+
+func TestCgroupPopulated(t *testing.T) {
+	root := t.TempDir()
+
+	// No cgroup.events file → returns false, no error.
+	got, err := cgroupPopulated(root)
+	if err != nil {
+		t.Fatalf("missing events: unexpected err %v", err)
+	}
+	if got {
+		t.Error("missing events: got true, want false")
+	}
+
+	// populated 0 → false.
+	if writeErr := os.WriteFile(filepath.Join(root, "cgroup.events"), []byte("populated 0\nfrozen 0\n"), 0o644); writeErr != nil {
+		t.Fatalf("write events: %v", writeErr)
+	}
+	got, err = cgroupPopulated(root)
+	if err != nil {
+		t.Fatalf("populated 0: unexpected err %v", err)
+	}
+	if got {
+		t.Error("populated 0: got true, want false")
+	}
+
+	// populated 1 → true.
+	if writeErr := os.WriteFile(filepath.Join(root, "cgroup.events"), []byte("populated 1\nfrozen 0\n"), 0o644); writeErr != nil {
+		t.Fatalf("rewrite events: %v", writeErr)
+	}
+	got, err = cgroupPopulated(root)
+	if err != nil {
+		t.Fatalf("populated 1: unexpected err %v", err)
+	}
+	if !got {
+		t.Error("populated 1: got false, want true")
+	}
+}
+
+func TestReadCgroupProcs(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "cgroup.procs")
+
+	// Empty file → no PIDs, no error.
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+	pids, err := readCgroupProcs(path)
+	if err != nil {
+		t.Fatalf("empty read: %v", err)
+	}
+	if len(pids) != 0 {
+		t.Errorf("empty file: got %v, want []", pids)
+	}
+
+	// Mixed content (PIDs, blank lines).
+	if writeErr := os.WriteFile(path, []byte("1\n\n42\n\n\n9001\n"), 0o644); writeErr != nil {
+		t.Fatalf("rewrite: %v", writeErr)
+	}
+	pids, err = readCgroupProcs(path)
+	if err != nil {
+		t.Fatalf("mixed read: %v", err)
+	}
+	want := []int{1, 42, 9001}
+	if len(pids) != len(want) {
+		t.Fatalf("mixed: got %v, want %v", pids, want)
+	}
+	for i := range want {
+		if pids[i] != want[i] {
+			t.Errorf("mixed[%d]: got %d, want %d", i, pids[i], want[i])
+		}
+	}
+
+	// Garbage content surfaces a parse error.
+	if writeErr := os.WriteFile(path, []byte("not-a-pid\n"), 0o644); writeErr != nil {
+		t.Fatalf("write garbage: %v", writeErr)
+	}
+	if _, parseErr := readCgroupProcs(path); parseErr == nil {
+		t.Error("garbage parse: expected error, got nil")
+	}
+}

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -93,6 +93,16 @@ type Client interface {
 	// needs to in turn delegate arbitrary controllers to its own children.
 	// Issue #314.
 	EnableCellAllSubtreeControllers(group, mountpoint string) ([]string, error)
+	// RelocateProcessesToLeaf drains every PID currently in <group>/cgroup.procs
+	// into a freshly-mkdir'd leaf cgroup at <group>/<leaf>. Used to satisfy
+	// cgroup-v2's no-internal-process rule (issue #336): subtree_control
+	// widening for non-thread-aware controllers (memory, io, ...) is rejected
+	// by the kernel when the target cgroup hosts processes directly. The
+	// leaf inherits the parent's controllers via the parent's subtree_control,
+	// so resource accounting at <group> still applies — the PIDs just live
+	// one level deeper. Idempotent: re-running on an already-drained group
+	// is a no-op.
+	RelocateProcessesToLeaf(group, mountpoint, leaf string) error
 	CreateContainerFromSpec(namespace string, spec intmodel.ContainerSpec, creds []RegistryCredentials, opts ...BuildOption) (containerd.Container, error)
 
 	CreateContainer(namespace string, spec ContainerSpec, creds []RegistryCredentials) (containerd.Container, error)

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -128,9 +128,42 @@ func (c *client) StartContainer(
 		return nil, fmt.Errorf("failed to start task: %w", err)
 	}
 
+	// Drain the container's task PID into a _payload leaf cgroup so the
+	// container-root cgroup has no internal processes (issue #336 scenario
+	// A). The cgroup-namespace pin is sticky to the original placement, so
+	// moving the PID into a child after task.Start does not reshape the
+	// inside-cell view of /sys/fs/cgroup — but it does empty the cgroup-ns
+	// root cgroup.procs, which is what cgroup-v2's no-internal-process rule
+	// requires before any inner runtime (kuke init, dockerd, podman, an
+	// inner containerd) can widen subtree_control for non-thread-aware
+	// controllers like memory or io. Gated on the OCI spec carrying a
+	// non-empty Linux.CgroupsPath: the kukeon cell-container path always
+	// sets it via cellCgroupsPath, and HostCgroup containers leave it empty
+	// to share the host hierarchy through the kukeond bind mount.
+	if relocateErr := c.relocateContainerTaskToLeaf(nsCtx, container); relocateErr != nil {
+		c.logger.WarnContext(c.ctx,
+			"failed to relocate container task to _payload leaf",
+			"id", containerSpec.ID, "namespace", namespace, "err", formatError(relocateErr))
+	}
+
 	c.storeTask(namespace, containerSpec.ID, task)
 	c.logger.InfoContext(c.ctx, "started container", "id", containerSpec.ID, "namespace", namespace)
 	return task, nil
+}
+
+// relocateContainerTaskToLeaf moves the just-started container's PIDs into
+// a _payload leaf cgroup under its OCI Linux.CgroupsPath. See StartContainer
+// for the rationale (issue #336 scenario A). Returns nil when the container
+// has no CgroupsPath set (HostCgroup or non-cell containers).
+func (c *client) relocateContainerTaskToLeaf(nsCtx context.Context, container containerd.Container) error {
+	ociSpec, err := container.Spec(nsCtx)
+	if err != nil {
+		return fmt.Errorf("load container spec: %w", err)
+	}
+	if ociSpec.Linux == nil || ociSpec.Linux.CgroupsPath == "" {
+		return nil
+	}
+	return c.RelocateProcessesToLeaf(ociSpec.Linux.CgroupsPath, "", "_payload")
 }
 
 // StopContainer stops a running container task.

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -94,6 +94,7 @@ var (
 
 	ErrEmptyGroupPath   = errors.New("cgroup group path is required")
 	ErrInvalidPID       = errors.New("pid must be greater than zero")
+	ErrInvalidLeafName  = errors.New("cgroup leaf name must be a single non-empty path segment")
 	ErrInvalidCPUWeight = errors.New("cpu weight must be within [1, 10000]")
 	ErrInvalidIOWeight  = errors.New("io weight must be within [1, 1000]")
 	ErrInvalidThrottle  = errors.New("io throttle entries require type, major, minor and rate")


### PR DESCRIPTION
## Summary
- Add `RelocateProcessesToLeaf(group, mountpoint, leaf)` primitive in `internal/ctr/cgroups.go` that mkdir's `<group>/<leaf>` and drains `<group>/cgroup.procs` into it. Idempotent.
- **Scenario A (cell creation, structural):** in `StartContainer`, after `task.Start` returns, look up the OCI spec's `Linux.CgroupsPath` and relocate the container's PIDs into a `_payload` leaf. The cgroup-namespace pin is sticky to the original placement, so moving the PID after task start does not reshape the inside-cell view of `/sys/fs/cgroup` — it just empties the cgroup-ns root `cgroup.procs`, which is what cgroup-v2's no-internal-process rule requires before any inner runtime (`kuke init`, `dockerd`, `podman`, an inner containerd) can widen `subtree_control` for non-thread-aware controllers like memory or io. Relocate failures log a warning and continue, so a kernel that rejects the move never blocks container start.
- **Scenario B (defensive use-site):** in `applySubtreeControllers`, before `manager.ToggleControllers`, gate on `(/proc/self/cgroup == 0::/) AND (mountpoint root cgroup.events shows populated 1)`. Both clauses required: the `0::/` check guards against draining systemd's processes on a non-nested host (where the path shows the systemd slice), and the populated check avoids the no-op mkdir+read on an empty root. If both hold, drain mountpoint root into `__bootstrap` before the toggle.
- Distinct leaf names (`_payload` for cell startup, `__bootstrap` for the defensive drain) keep post-mortem inspection of `/sys/fs/cgroup` able to tell the two layers apart.
- New `errdefs.ErrInvalidLeafName` sentinel for relocate-input validation.

## Non-obvious calls

- The `_payload` relocate fires for any container with a non-empty `Linux.CgroupsPath` — i.e. every kukeon-managed cell container (`HostCgroup` containers leave the field empty and short-circuit). This intentionally drains the kukeond container too: the daemon-parity smoke confirms the daemon stays healthy after the relocation, and the same primitive is what lets a future inner-runtime cell widen `subtree_control`.
- Relocate failure on the cell-startup path is logged + continued, not returned. The cgroup-v2 invariant the relocate satisfies only matters when an inner runtime later tries to widen `subtree_control`; failing the container start over a future-conditional invariant trades a real outage for a hypothetical one. The `_payload` leaf failing to mkdir is also worth surfacing without aborting so `kuke get cells` reflects the actual state.

## Test plan
- [x] `make test` — all package tests green.
- [x] `make dev-init` — full re-bootstrap loop succeeds; daemon-parity check produces the expected identical `default` / `kuke-system` realm rows from both `kuke get realms` and `kuke get realms --no-daemon`.
- [x] Live verification on the kukeond cell: both `kukeon_kukeon_kukeond_kukeond` and `kukeon_kukeon_kukeond_root` container cgroups have `_payload` leaves, the leaves carry the actual PIDs, the parent `cgroup.procs` files are empty, and `echo +memory > .../cgroup.subtree_control` succeeds (it would EBUSY pre-fix).
- [x] Unit tests in `internal/ctr/cgroups_relocate_test.go` exercise input validation, drain semantics on a tmpdir-simulated cgroupfs, idempotent re-runs, error surfacing on missing source `cgroup.procs`, and the `cgroupPopulated` / `readCgroupProcs` helpers.
- [ ] Scenario B nested-`kuke init` smoke (`kuke init` inside a `kukeon-dev-*` cell) — not run; the defensive-drain path is exercised on every kukeond `applySubtreeControllers` call once the gate matches, but the dev host is not currently set up with a nested cell. The deferred follow-up in #336 calls out a nested-cell smoke target.

## Deferred follow-ups (carried over from #336)
- Apply the leaf-scope pattern preventively to every kukeon level (realm/space/stack).
- Make `applySubtreeControllers` fail loud on EBUSY/EOPNOTSUPP after the leaf-scope move with a new `errdefs` sentinel.
- Confirm or rule out the runc-1.3.3 threaded-flip path.

Closes #336