### PR TITLE
fix: doctor cgroups warns on internal-process trap when runtime self-heals

### DIFF
--- a/cmd/kuke/doctor/cgroups/cgroups.go
+++ b/cmd/kuke/doctor/cgroups/cgroups.go
@@ -168,6 +168,25 @@ func runDoctor(cmd *cobra.Command, root string, nested, probe, verbose bool, tar
 	return runCheck(cmd.OutOrStdout(), cmd.ErrOrStderr(), scopedRoot, nested, probe, verbose, target.label())
 }
 
+// activeProber is the cgroupcheck.Prober runCheck uses when --probe is
+// set. Indirected via a package var so unit tests can simulate the EBUSY
+// no-internal-process trap without writing to a real cgroupfs.
+//
+//nolint:gochecknoglobals // test seam for the production prober
+var activeProber = cgroupcheck.DefaultProber
+
+// selfHealGate reports whether the host fingerprint matches the case
+// applySubtreeControllers (internal/ctr) self-heals via its defensive
+// __bootstrap drain (PR #340) — both clauses (cgroup-namespace root and
+// the mountpoint root being populated) must hold. Indirected so unit
+// tests can simulate matching/non-matching hosts without touching
+// /proc/self/cgroup.
+//
+//nolint:gochecknoglobals // test seam for the cgroup-ns fingerprint check
+var selfHealGate = func(root string) bool {
+	return cgroupcheck.IsCgroupNsRoot() && cgroupcheck.IsHostRootPopulated(root)
+}
+
 // runCheck is the shared pre-flight body used by both the host-root and
 // --scope paths. scopeLabel is empty for the host-root path; non-empty
 // labels are printed as a "scope: ..." header so operators can tell which
@@ -181,7 +200,7 @@ func runCheck(stdout, stderr io.Writer, root string, nested, probe, verbose bool
 
 	var prober cgroupcheck.Prober
 	if probe {
-		prober = cgroupcheck.DefaultProber
+		prober = activeProber
 	}
 
 	res, err := cgroupcheck.Check(root, required, prober)
@@ -196,6 +215,27 @@ func runCheck(stdout, stderr io.Writer, root string, nested, probe, verbose bool
 			printScope(stdout, scopeLabel)
 			printStatus(stdout, res)
 		}
+		return nil
+	}
+
+	// Self-heal downgrade: when the only unresolved class is the EBUSY
+	// no-internal-process trap AND the host fingerprint matches what
+	// applySubtreeControllers (internal/ctr) drains via its defensive
+	// __bootstrap leaf (PR #340), `kuke init` would proceed anyway. Surface
+	// the diagnostic so the operator sees what is about to happen, but
+	// exit 0 so dev-init.sh proceeds. Restricted to the unscoped host-root
+	// path because the runtime drain only operates on the mountpoint root,
+	// not on a deeper scoped cgroup — a scoped EBUSY still requires
+	// operator action.
+	if scopeLabel == "" && res.OnlyInternalProcess() && selfHealGate(root) {
+		printScope(stderr, scopeLabel)
+		printStatus(stderr, res)
+		fmt.Fprint(stderr, "\n")
+		fmt.Fprint(stderr, cgroupcheck.FormatRemediation(res))
+		fmt.Fprint(stderr, "\nnote: the runtime will drain the cgroup-namespace root into a "+
+			"__bootstrap leaf\nbefore widening cgroup.subtree_control "+
+			"(internal/ctr applySubtreeControllers,\nPR #340). this is "+
+			"informational; `kuke init` will proceed.\n")
 		return nil
 	}
 

--- a/cmd/kuke/doctor/cgroups/cgroups_test.go
+++ b/cmd/kuke/doctor/cgroups/cgroups_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
 	cgroupscmd "github.com/eminwux/kukeon/cmd/kuke/doctor/cgroups"
@@ -225,6 +226,168 @@ func TestCgroupsCmdNoSuchRoot(t *testing.T) {
 		t.Errorf("error message = %q, want it to mention 'cgroup pre-flight'", err.Error())
 	}
 	_ = stderr
+}
+
+// TestCgroupsCmdSelfHealDowngradeOnInternalProcess: when the only
+// unresolved class is the EBUSY no-internal-process trap (i.e. what
+// applySubtreeControllers's defensive __bootstrap drain self-heals at
+// `kuke init` time, PR #340) AND the host fingerprint matches both
+// defensive-drain clauses, the pre-flight surfaces the diagnostic on
+// stderr but exits 0 so dev-init.sh proceeds. This is the issue #342
+// repro: stop the doctor from rejecting hosts the runtime would heal.
+func TestCgroupsCmdSelfHealDowngradeOnInternalProcess(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+	// Inject a prober that returns EBUSY for memory/io (the
+	// no-internal-process trap) so the result lands in
+	// StatusInternalProcess for those controllers.
+	restoreProber := cgroupscmd.SetActiveProberForTest(func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EBUSY
+		}
+		return nil
+	})
+	defer restoreProber()
+	// Force the gate to match (production reads /proc/self/cgroup +
+	// cgroup.events; tests inject directly).
+	restoreGate := cgroupscmd.SetSelfHealGateForTest(func(string) bool { return true })
+	defer restoreGate()
+
+	stdout, stderr, err := runCmd(t, "--root", root)
+	if err != nil {
+		t.Fatalf("self-heal Execute() error = %v\nstdout=%q\nstderr=%q", err, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("self-heal stdout = %q, want empty (all output goes to stderr)", stdout)
+	}
+	// Diagnostic is still surfaced — operators must see what is about
+	// to happen.
+	for _, want := range []string{
+		"internal-process",
+		"no-internal-process rule",
+		"memory, io",
+		"applySubtreeControllers",
+		"__bootstrap",
+		"`kuke init` will proceed",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("self-heal stderr missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestCgroupsCmdSelfHealNoDowngradeWithoutGate: if the
+// no-internal-process trap fires but the host fingerprint does NOT
+// match (gate returns false), the runtime drain would also not run, so
+// the pre-flight must remain fatal. Pins the gate as load-bearing —
+// without both clauses holding, the downgrade can't fire.
+func TestCgroupsCmdSelfHealNoDowngradeWithoutGate(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+	restoreProber := cgroupscmd.SetActiveProberForTest(func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EBUSY
+		}
+		return nil
+	})
+	defer restoreProber()
+	restoreGate := cgroupscmd.SetSelfHealGateForTest(func(string) bool { return false })
+	defer restoreGate()
+
+	_, stderr, err := runCmd(t, "--root", root)
+	if err == nil {
+		t.Fatal("Execute() error = nil with EBUSY trap and gate=false, want fatal")
+	}
+	for _, want := range []string{"internal-process", "no-internal-process rule"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+	// The "self-heal" note must NOT be printed when the gate is false —
+	// the operator would otherwise be told `kuke init` will proceed
+	// when in fact it would EBUSY.
+	if strings.Contains(stderr, "`kuke init` will proceed") {
+		t.Errorf("self-heal note printed despite gate=false:\n%s", stderr)
+	}
+}
+
+// TestCgroupsCmdSelfHealNoDowngradeOnMixedClasses: the downgrade only
+// fires when EVERY unresolved controller is StatusInternalProcess. When
+// one controller is internal-process and another is kernel-missing,
+// the runtime drain cannot rescue the second, so the pre-flight must
+// remain fatal. Pins the OnlyInternalProcess boundary so a future
+// change can't silently downgrade mixed-class failures.
+func TestCgroupsCmdSelfHealNoDowngradeOnMixedClasses(t *testing.T) {
+	// memory advertised, io NOT advertised → io stays
+	// StatusKernelMissing regardless of probe; memory EBUSYs to
+	// StatusInternalProcess. Mixed → must remain fatal even with the
+	// gate matching.
+	root := writeFakeCgroup(t,
+		"cpuset cpu memory pids",
+		"cpu pids",
+	)
+	restoreProber := cgroupscmd.SetActiveProberForTest(func(_, ctrl string) error {
+		if ctrl == "memory" {
+			return syscall.EBUSY
+		}
+		return nil
+	})
+	defer restoreProber()
+	restoreGate := cgroupscmd.SetSelfHealGateForTest(func(string) bool { return true })
+	defer restoreGate()
+
+	_, stderr, err := runCmd(t, "--root", root)
+	if err == nil {
+		t.Fatal("Execute() error = nil on mixed internal-process + kernel-missing, want fatal")
+	}
+	if !strings.Contains(stderr, "kernel does not support") {
+		t.Errorf("stderr missing kernel-missing stanza on mixed-class failure:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "`kuke init` will proceed") {
+		t.Errorf("self-heal note printed despite kernel-missing controllers in the same result:\n%s", stderr)
+	}
+}
+
+// TestCgroupsCmdSelfHealNoDowngradeOnScoped: --scope paths probe a
+// sub-tree, not the cgroup-namespace mountpoint root. The runtime
+// drain in applySubtreeControllers only operates on the mountpoint
+// root, so a scoped EBUSY is genuinely operator-actionable and must
+// stay fatal even when the gate matches.
+func TestCgroupsCmdSelfHealNoDowngradeOnScoped(t *testing.T) {
+	root := t.TempDir()
+	writeFakeCgroupAt(t, root,
+		"cpuset cpu io memory pids",
+		"cpu memory io pids",
+	)
+	realmCg := "/kukeon/default"
+	writeFakeCgroupAt(t, filepath.Join(root, realmCg),
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+	restoreProber := cgroupscmd.SetActiveProberForTest(func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EBUSY
+		}
+		return nil
+	})
+	defer restoreProber()
+	restoreGate := cgroupscmd.SetSelfHealGateForTest(func(string) bool { return true })
+	defer restoreGate()
+
+	client := &fakeScopedClient{realmExists: true, realmCgroupPath: realmCg}
+	_, stderr, err := runCmdWithClient(t, client,
+		"--scope", "realm", "default", "--root", root,
+	)
+	if err == nil {
+		t.Fatal("scope=realm Execute() error = nil with EBUSY at scoped path, want fatal")
+	}
+	if strings.Contains(stderr, "`kuke init` will proceed") {
+		t.Errorf("self-heal note printed for scoped pre-flight (runtime drain does not heal scoped EBUSY):\n%s", stderr)
+	}
 }
 
 // fakeScopedClient embeds FakeClient so only the Get* methods relevant to

--- a/cmd/kuke/doctor/cgroups/export_test.go
+++ b/cmd/kuke/doctor/cgroups/export_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroups
+
+import "github.com/eminwux/kukeon/internal/cgroupcheck"
+
+// SetActiveProberForTest swaps the prober runCheck uses when --probe is
+// set and returns a restore closure. Used by unit tests that need to
+// simulate EBUSY (the no-internal-process trap) without writing to a
+// real cgroupfs.
+func SetActiveProberForTest(fn cgroupcheck.Prober) func() {
+	prev := activeProber
+	activeProber = fn
+	return func() { activeProber = prev }
+}
+
+// SetSelfHealGateForTest swaps the self-heal fingerprint gate and returns
+// a restore closure. Used by unit tests to simulate matching/non-matching
+// hosts without reaching /proc/self/cgroup.
+func SetSelfHealGateForTest(fn func(string) bool) func() {
+	prev := selfHealGate
+	selfHealGate = fn
+	return func() { selfHealGate = prev }
+}

--- a/internal/cgroupcheck/cgroupcheck.go
+++ b/internal/cgroupcheck/cgroupcheck.go
@@ -164,6 +164,28 @@ func (r Result) Unresolved() []string {
 	return out
 }
 
+// OnlyInternalProcess reports whether every unresolved required controller
+// failed with StatusInternalProcess. Used by `kuke doctor cgroups` to
+// recognize the case where the applySubtreeControllers defensive
+// __bootstrap drain (internal/ctr, PR #340) self-heals the
+// no-internal-process EBUSY at `kuke init` time — the doctor's pre-flight
+// can surface the diagnostic but does not need to abort, since the runtime
+// would have proceeded anyway. Returns false when the result is fully
+// resolved or when any non-internal-process class still blocks (those
+// require operator action the runtime drain cannot supply).
+func (r Result) OnlyInternalProcess() bool {
+	unresolved := r.Unresolved()
+	if len(unresolved) == 0 {
+		return false
+	}
+	for _, c := range unresolved {
+		if r.Status[c] != StatusInternalProcess {
+			return false
+		}
+	}
+	return true
+}
+
 // ByStatus groups Required controllers by their classification, returning
 // only statuses that have at least one entry. Slice order within each
 // group matches Required.
@@ -408,6 +430,44 @@ func FormatRemediation(r Result) string {
 		b.WriteString("  escalate to the host / container runtime above this shell.\n")
 	}
 	return b.String()
+}
+
+// IsCgroupNsRoot reports whether /proc/self/cgroup pins the calling
+// process at its cgroup namespace's unified-hierarchy root ("0::/"). One
+// half of the fingerprint applySubtreeControllers (internal/ctr) uses to
+// gate its defensive __bootstrap drain — exposed here so the doctor's
+// pre-flight can apply the same gate without depending on internal/ctr.
+// A read failure or any path past "/" returns false so callers fall
+// through to the conservative "this is a hard failure" path.
+func IsCgroupNsRoot() bool {
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if strings.TrimSpace(line) == "0::/" {
+			return true
+		}
+	}
+	return false
+}
+
+// IsHostRootPopulated reports whether <hostRoot>/cgroup.events shows
+// "populated 1", i.e. the root cgroup contains processes that the
+// no-internal-process rule would EBUSY on a subtree_control widening.
+// The other half of applySubtreeControllers's defensive-drain gate. A
+// missing file or any read failure returns false (conservative).
+func IsHostRootPopulated(hostRoot string) bool {
+	data, err := os.ReadFile(filepath.Join(hostRoot, "cgroup.events"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if strings.TrimSpace(line) == "populated 1" {
+			return true
+		}
+	}
+	return false
 }
 
 // HostAdvertised returns the controller names in <hostRoot>/cgroup.controllers,

--- a/internal/cgroupcheck/cgroupcheck_test.go
+++ b/internal/cgroupcheck/cgroupcheck_test.go
@@ -530,6 +530,118 @@ func TestCheckUnresolvedOrderMatchesRequired(t *testing.T) {
 // land "+<ctrl>" verbatim — cgroupfs interprets the line additively, so
 // the prober must not pad with newlines or other framing that would
 // change semantics on a real subtree_control file.
+// TestOnlyInternalProcessAllStatusInternalProcess: every unresolved
+// controller is StatusInternalProcess → the doctor's self-heal downgrade
+// can fire. Pins the all-EBUSY case dev-init.sh hits on a
+// NestedCgroupRuntime sandbox.
+func TestOnlyInternalProcessAllStatusInternalProcess(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+	probe := func(_, ctrl string) error {
+		if ctrl == "memory" || ctrl == "io" {
+			return syscall.EBUSY
+		}
+		return nil
+	}
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !res.OnlyInternalProcess() {
+		t.Fatalf("OnlyInternalProcess() = false on all-EBUSY result; unresolved=%v", res.Unresolved())
+	}
+}
+
+// TestOnlyInternalProcessMixedReturnsFalse: when at least one unresolved
+// controller is not StatusInternalProcess (e.g. kernel-missing), the
+// runtime drain cannot self-heal it; the doctor must keep the failure
+// fatal. Pins the boundary so a future change can't silently downgrade
+// mixed-class failures.
+func TestOnlyInternalProcessMixedReturnsFalse(t *testing.T) {
+	// memory missing from cgroup.controllers (kernel-missing) AND io
+	// EBUSY on probe (internal-process). Mixed class → must return false.
+	root := writeCgroupFiles(t,
+		"cpuset cpu io pids",
+		"cpu pids",
+	)
+	probe := func(_, ctrl string) error {
+		if ctrl == "io" {
+			return syscall.EBUSY
+		}
+		return nil
+	}
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), probe)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if res.OnlyInternalProcess() {
+		t.Fatalf("OnlyInternalProcess() = true on mixed-class result; unresolved=%v", res.Unresolved())
+	}
+}
+
+// TestOnlyInternalProcessFullyResolvedReturnsFalse: a result with no
+// unresolved controllers is not "only internal-process" — there's
+// nothing to downgrade. Otherwise the doctor's downgrade branch could
+// fire on a happy-path result and emit a misleading warning.
+func TestOnlyInternalProcessFullyResolvedReturnsFalse(t *testing.T) {
+	root := writeCgroupFiles(t,
+		"cpuset cpu io memory pids",
+		"cpu memory io pids",
+	)
+	res, err := cgroupcheck.Check(root, cgroupcheck.CellResourceControllers(), nil)
+	if err != nil {
+		t.Fatalf("Check() unexpected error: %v", err)
+	}
+	if !res.OK() {
+		t.Fatalf("Check() OK=false on fully-enabled host; unresolved=%v", res.Unresolved())
+	}
+	if res.OnlyInternalProcess() {
+		t.Errorf("OnlyInternalProcess() = true on OK result; want false")
+	}
+}
+
+// TestIsHostRootPopulatedReadsCgroupEvents: the populated half of the
+// self-heal fingerprint reads <hostRoot>/cgroup.events and keys on the
+// "populated 1" line. Pins both the file location and the exact line
+// match so a future format change in the kernel surface (or a bad
+// refactor) trips the test instead of silently breaking the gate.
+func TestIsHostRootPopulatedReadsCgroupEvents(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"populated-1", "populated 1\nfrozen 0\n", true},
+		{"populated-0", "populated 0\nfrozen 0\n", false},
+		{"missing-key", "frozen 0\n", false},
+		{"empty-file", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "cgroup.events"), []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("seed cgroup.events: %v", err)
+			}
+			if got := cgroupcheck.IsHostRootPopulated(dir); got != tc.want {
+				t.Errorf("IsHostRootPopulated(%q) = %v, want %v\ncontent=%q", dir, got, tc.want, tc.content)
+			}
+		})
+	}
+}
+
+// TestIsHostRootPopulatedMissingFileReturnsFalse: a missing
+// cgroup.events (e.g. a non-cgroupfs path) must not error — the
+// conservative-fallback contract returns false so the doctor's
+// self-heal branch does not fire on a path that isn't even a cgroup.
+func TestIsHostRootPopulatedMissingFileReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	if got := cgroupcheck.IsHostRootPopulated(dir); got != false {
+		t.Errorf("IsHostRootPopulated on missing file = %v, want false", got)
+	}
+}
+
 func TestDefaultProberWritesPlusController(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "cgroup.subtree_control")


### PR DESCRIPTION
## Summary

- Issue #342 picked Fix 2 (downgrade fatal to warning, leave doctor read-only). On a `NestedCgroupRuntime` dev cell where the cgroup-namespace root carries processes, `kuke doctor cgroups --probe` writes EBUSY at the mountpoint root, classifies it as `StatusInternalProcess`, and exits non-zero — even though `applySubtreeControllers`'s defensive `__bootstrap` drain (PR #340) would self-heal the same condition at `kuke init` time. Net effect: `make dev-init` aborts at the pre-flight before the runtime gets a chance to fix it.
- The fix recognizes the layer mismatch: when **every** unresolved required controller is `StatusInternalProcess` AND the host fingerprint matches both defensive-drain clauses (`/proc/self/cgroup == 0::/` and the mountpoint root's `cgroup.events` shows `populated 1`), the doctor still surfaces the diagnostic on stderr — operators see what's about to happen — but exits 0 so dev-init.sh proceeds. Restricted to the unscoped host-root path because the runtime drain only operates on the mountpoint root, not on a deeper scoped cgroup.
- Doctor stays read-only (no `RelocateProcessesToLeaf` from the pre-flight). Mixed-class failures (e.g. `internal-process` + `kernel-missing`) stay fatal — the runtime drain cannot rescue the second class.
- New helpers `cgroupcheck.IsCgroupNsRoot()` and `cgroupcheck.IsHostRootPopulated(hostRoot)` mirror the gate clauses `internal/ctr.maybeDrainCgroupNsRoot` reads at runtime; kept as a duplicate of the (private) ctr versions to avoid pulling internal/ctr into the doctor's import graph for a six-line file read.
- Test seams `activeProber` and `selfHealGate` are package vars (with `//nolint:gochecknoglobals` matching the repo's existing convention) so unit tests can simulate the EBUSY trap and a matching/non-matching fingerprint without writing to a real cgroupfs or `/proc/self/cgroup`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full suite, all packages green
- [x] `make dev-init` — daemon parity check matches the expected `default` + `kuke-system` realm/cgroup output (this host doesn't reproduce the NestedCgroupRuntime fingerprint, so the new branch is a no-op here; unit tests cover the new path comprehensively)
- [x] `pre-commit run` on changed files
- [x] New unit tests added: `Result.OnlyInternalProcess` boundaries (all-EBUSY, mixed, fully resolved); `IsHostRootPopulated` reads `cgroup.events` correctly across populated-1, populated-0, missing key, empty file, missing file; doctor cmd `SelfHealDowngradeOnInternalProcess` (warning + exit 0), `SelfHealNoDowngradeWithoutGate` (still fatal), `SelfHealNoDowngradeOnMixedClasses` (still fatal), `SelfHealNoDowngradeOnScoped` (still fatal — runtime drain doesn't apply at scoped paths)

Closes #342