### PR TITLE
feat: tmpfs volume kind on ContainerSpec.Volumes

### DIFF
--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -142,7 +142,7 @@ func BuildRootContainerSpec(
 	// BuildContainerSpec so a user-supplied root container (RootContainerID)
 	// keeps its Volumes, User, Capabilities, SecurityOpts, Tmpfs, and
 	// Resources instead of having them silently dropped.
-	if mounts := buildBindMounts(rootSpec.Volumes); len(mounts) > 0 {
+	if mounts := buildVolumeMounts(rootSpec.Volumes); len(mounts) > 0 {
 		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
 

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -300,7 +300,7 @@ func BuildContainerSpec(
 		specOpts = append(specOpts, oci.WithMounts([]runtimespec.Mount{nestedCgroupMount()}))
 	}
 
-	if mounts := buildBindMounts(containerSpec.Volumes); len(mounts) > 0 {
+	if mounts := buildVolumeMounts(containerSpec.Volumes); len(mounts) > 0 {
 		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
 
@@ -362,31 +362,80 @@ func cellCgroupsPath(cellCgroupPath, containerdID string) string {
 	return filepath.Join(cellCgroupPath, containerdID)
 }
 
-// buildBindMounts translates ContainerSpec.Volumes into OCI bind mounts.
-// Entries are expected to be already validated (absolute source/target).
-func buildBindMounts(volumes []intmodel.VolumeMount) []runtimespec.Mount {
+// buildVolumeMounts translates ContainerSpec.Volumes into OCI mounts. The
+// VolumeMount.Kind discriminator selects the emitted mount type: empty or
+// VolumeKindBind produces a host bind mount (Source → Target), VolumeKindTmpfs
+// produces an in-memory tmpfs mount at Target with the runtime's standard
+// tmpfs Source. Entries are expected to be already validated (absolute paths
+// for the bind kind; absolute Target for the tmpfs kind). Unknown kinds are
+// skipped silently — validation belongs upstream.
+func buildVolumeMounts(volumes []intmodel.VolumeMount) []runtimespec.Mount {
 	if len(volumes) == 0 {
 		return nil
 	}
 	mounts := make([]runtimespec.Mount, 0, len(volumes))
 	for _, v := range volumes {
-		if v.Source == "" || v.Target == "" {
-			continue
+		switch v.Kind {
+		case intmodel.VolumeKindTmpfs:
+			if m, ok := tmpfsVolumeMount(v); ok {
+				mounts = append(mounts, m)
+			}
+		case "", intmodel.VolumeKindBind:
+			if m, ok := bindVolumeMount(v); ok {
+				mounts = append(mounts, m)
+			}
 		}
-		options := []string{"rbind"}
-		if v.ReadOnly {
-			options = append(options, "ro")
-		} else {
-			options = append(options, "rw")
-		}
-		mounts = append(mounts, runtimespec.Mount{
-			Destination: v.Target,
-			Source:      v.Source,
-			Type:        "bind",
-			Options:     options,
-		})
 	}
 	return mounts
+}
+
+// bindVolumeMount renders a bind-kind VolumeMount as an OCI Mount. Returns
+// (zero, false) when Source or Target is empty so the caller can skip the
+// entry — matching the historical buildBindMounts skip rule.
+func bindVolumeMount(v intmodel.VolumeMount) (runtimespec.Mount, bool) {
+	if v.Source == "" || v.Target == "" {
+		return runtimespec.Mount{}, false
+	}
+	options := []string{"rbind"}
+	if v.ReadOnly {
+		options = append(options, "ro")
+	} else {
+		options = append(options, "rw")
+	}
+	return runtimespec.Mount{
+		Destination: v.Target,
+		Source:      v.Source,
+		Type:        "bind",
+		Options:     options,
+	}, true
+}
+
+// tmpfsVolumeMount renders a tmpfs-kind VolumeMount as an OCI Mount. Returns
+// (zero, false) when Target is empty. SizeBytes and Mode emit the standard
+// tmpfs size= / mode= options when set; ReadOnly maps to ro/rw last in the
+// option list.
+func tmpfsVolumeMount(v intmodel.VolumeMount) (runtimespec.Mount, bool) {
+	if v.Target == "" {
+		return runtimespec.Mount{}, false
+	}
+	options := make([]string, 0)
+	if v.SizeBytes > 0 {
+		options = append(options, "size="+strconv.FormatInt(v.SizeBytes, 10))
+	}
+	if v.Mode != 0 {
+		options = append(options, fmt.Sprintf("mode=%04o", v.Mode))
+	}
+	if v.ReadOnly {
+		options = append(options, "ro")
+	} else {
+		options = append(options, "rw")
+	}
+	return runtimespec.Mount{
+		Destination: v.Target,
+		Source:      "tmpfs",
+		Type:        "tmpfs",
+		Options:     options,
+	}, true
 }
 
 // securitySpecOpts translates the security/isolation fields on the internal

--- a/internal/ctr/volumes_test.go
+++ b/internal/ctr/volumes_test.go
@@ -17,12 +17,14 @@
 package ctr
 
 import (
+	"reflect"
 	"testing"
 
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func TestBuildBindMounts(t *testing.T) {
+func TestBuildVolumeMounts_Bind(t *testing.T) {
 	tests := []struct {
 		name    string
 		in      []intmodel.VolumeMount
@@ -52,6 +54,12 @@ func TestBuildBindMounts(t *testing.T) {
 			wantRO:  []bool{false, true},
 		},
 		{
+			name:    "explicit bind kind matches default",
+			in:      []intmodel.VolumeMount{{Kind: intmodel.VolumeKindBind, Source: "/a", Target: "/b"}},
+			wantLen: 1,
+			wantRO:  []bool{false},
+		},
+		{
 			name:    "skip empty source",
 			in:      []intmodel.VolumeMount{{Source: "", Target: "/b"}},
 			wantLen: 0,
@@ -65,7 +73,7 @@ func TestBuildBindMounts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildBindMounts(tt.in)
+			got := buildVolumeMounts(tt.in)
 			if len(got) != tt.wantLen {
 				t.Fatalf("len = %d, want %d", len(got), tt.wantLen)
 			}
@@ -104,5 +112,141 @@ func TestBuildBindMounts(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestBuildVolumeMounts_BindParity locks the all-bind output to today's exact
+// runtimespec.Mount shape so unrelated callers (kukeond cell spec, attachable
+// wrapping, secret-injected mounts) keep their byte-identical OCI mounts after
+// the tmpfs branch landed. Acceptance criterion from issue #309.
+func TestBuildVolumeMounts_BindParity(t *testing.T) {
+	in := []intmodel.VolumeMount{
+		{Source: "/host/run", Target: "/run/kukeon"},
+		{Source: "/host/opt", Target: "/opt/kukeon", ReadOnly: true},
+	}
+	want := []runtimespec.Mount{
+		{
+			Destination: "/run/kukeon",
+			Source:      "/host/run",
+			Type:        "bind",
+			Options:     []string{"rbind", "rw"},
+		},
+		{
+			Destination: "/opt/kukeon",
+			Source:      "/host/opt",
+			Type:        "bind",
+			Options:     []string{"rbind", "ro"},
+		},
+	}
+	got := buildVolumeMounts(in)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildVolumeMounts(bind list) = %+v, want %+v", got, want)
+	}
+}
+
+func TestBuildVolumeMounts_Tmpfs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   intmodel.VolumeMount
+		want runtimespec.Mount
+		skip bool
+	}{
+		{
+			name: "minimal",
+			in:   intmodel.VolumeMount{Kind: intmodel.VolumeKindTmpfs, Target: "/var/lib/containerd"},
+			want: runtimespec.Mount{
+				Destination: "/var/lib/containerd",
+				Source:      "tmpfs",
+				Type:        "tmpfs",
+				Options:     []string{"rw"},
+			},
+		},
+		{
+			name: "size and mode",
+			in: intmodel.VolumeMount{
+				Kind:      intmodel.VolumeKindTmpfs,
+				Target:    "/scratch",
+				SizeBytes: 1 << 30, // 1 GiB
+				Mode:      0o755,
+			},
+			want: runtimespec.Mount{
+				Destination: "/scratch",
+				Source:      "tmpfs",
+				Type:        "tmpfs",
+				Options:     []string{"size=1073741824", "mode=0755", "rw"},
+			},
+		},
+		{
+			name: "read-only",
+			in: intmodel.VolumeMount{
+				Kind:     intmodel.VolumeKindTmpfs,
+				Target:   "/cache",
+				ReadOnly: true,
+			},
+			want: runtimespec.Mount{
+				Destination: "/cache",
+				Source:      "tmpfs",
+				Type:        "tmpfs",
+				Options:     []string{"ro"},
+			},
+		},
+		{
+			name: "skip empty target",
+			in:   intmodel.VolumeMount{Kind: intmodel.VolumeKindTmpfs, Target: ""},
+			skip: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildVolumeMounts([]intmodel.VolumeMount{tt.in})
+			if tt.skip {
+				if len(got) != 0 {
+					t.Fatalf("expected entry to be skipped, got %+v", got)
+				}
+				return
+			}
+			if len(got) != 1 {
+				t.Fatalf("len = %d, want 1", len(got))
+			}
+			if !reflect.DeepEqual(got[0], tt.want) {
+				t.Fatalf("got %+v, want %+v", got[0], tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildVolumeMounts_Mixed verifies that a list mixing bind and tmpfs
+// entries preserves declaration order and emits each kind's expected OCI
+// shape independently.
+func TestBuildVolumeMounts_Mixed(t *testing.T) {
+	in := []intmodel.VolumeMount{
+		{Source: "/host/run", Target: "/run/kukeon"},
+		{Kind: intmodel.VolumeKindTmpfs, Target: "/var/lib/containerd", SizeBytes: 512 << 20},
+		{Source: "/host/opt", Target: "/opt/kukeon", ReadOnly: true},
+	}
+	want := []runtimespec.Mount{
+		{
+			Destination: "/run/kukeon",
+			Source:      "/host/run",
+			Type:        "bind",
+			Options:     []string{"rbind", "rw"},
+		},
+		{
+			Destination: "/var/lib/containerd",
+			Source:      "tmpfs",
+			Type:        "tmpfs",
+			Options:     []string{"size=536870912", "rw"},
+		},
+		{
+			Destination: "/opt/kukeon",
+			Source:      "/host/opt",
+			Type:        "bind",
+			Options:     []string{"rbind", "ro"},
+		},
+	}
+	got := buildVolumeMounts(in)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildVolumeMounts(mixed) = %+v, want %+v", got, want)
 	}
 }

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -119,11 +119,36 @@ type ContainerSecret struct {
 	MountPath string
 }
 
-// VolumeMount is a bind mount of a host path into a container.
+// VolumeKind discriminates between the supported VolumeMount kinds. An empty
+// value is treated as VolumeKindBind so existing call sites that build a
+// VolumeMount without a Kind keep their bind-mount semantics.
+type VolumeKind string
+
+const (
+	// VolumeKindBind is a host bind mount. Source and Target are required.
+	VolumeKindBind VolumeKind = "bind"
+	// VolumeKindTmpfs is an in-memory tmpfs mount. Only Target is required;
+	// Source is implicit ("tmpfs"). SizeBytes and Mode tune the standard
+	// tmpfs size= and mode= options when non-zero.
+	VolumeKindTmpfs VolumeKind = "tmpfs"
+)
+
+// VolumeMount is a mount entry attached to a container. The Kind discriminator
+// selects the OCI mount type the runtime emits: bind (host path → container
+// path) or tmpfs (in-memory directory). Empty Kind means bind for back-compat
+// with call sites that predate the discriminator.
 type VolumeMount struct {
+	Kind     VolumeKind
 	Source   string
 	Target   string
 	ReadOnly bool
+	// SizeBytes is the tmpfs size= option in bytes. Only honored when
+	// Kind == VolumeKindTmpfs; zero leaves the kernel default.
+	SizeBytes int64
+	// Mode is the tmpfs mode= option as a 4-digit octal value (e.g. 0755).
+	// Only honored when Kind == VolumeKindTmpfs; zero leaves the kernel
+	// default (01777).
+	Mode uint32
 }
 
 // ContainerCapabilities groups Linux capability deltas applied relative to the


### PR DESCRIPTION
## Summary

- `ContainerSpec.Volumes` only carried bind mounts; cells that need an in-memory directory (e.g. an inner containerd snapshotter root that would otherwise hit nested-overlay restrictions) had no spec-side way to declare it.
- Add a `Kind` discriminator on `intmodel.VolumeMount` plus optional `SizeBytes` / `Mode` fields. `Kind=""` and `Kind="bind"` keep existing semantics; `Kind="tmpfs"` produces an OCI `Mount{Type:"tmpfs", Source:"tmpfs", Destination:Target, Options:[size=…, mode=…, rw|ro]}` entry.
- Rename `buildBindMounts` → `buildVolumeMounts` and dispatch on `Kind`. Both internal callers (`spec.go`, `container_utils.go`) updated; existing call sites that do not opt in are byte-identical (asserted by `TestBuildVolumeMounts_BindParity`).
- CLI surface, `v1beta1.VolumeMount`, the apischeme converter, and `validateVolumes` are deliberately untouched per the issue's "out of scope" — the model + builder land first; CLI and validation wiring follow once consumers exist.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full unit suite — `internal/ctr`, `internal/modelhub`, controllers, CLI cmd)
- [x] `go test ./internal/ctr/ -run 'TestBuildVolumeMounts'` covering bind, bind-parity (byte-identical), tmpfs (minimal / size+mode / read-only / skip-empty-target), and bind+tmpfs mixed ordering
- [x] `make dev-init` smoke — daemon-parity tail matches the regression guard exactly:
  ```
  default      default.kukeon.io      Ready  /kukeon/default
  kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
  ```
- [x] `pre-commit run` on staged files (gofmt, golangci-lint, addlicense, …)

Closes #309