### PR TITLE
feat: plumb VolumeMount.Kind=tmpfs to v1beta1, apischeme, and validator

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -739,9 +739,12 @@ func volumeMountsToInternal(in []ext.VolumeMount) []intmodel.VolumeMount {
 	out := make([]intmodel.VolumeMount, len(in))
 	for i, v := range in {
 		out[i] = intmodel.VolumeMount{
-			Source:   v.Source,
-			Target:   v.Target,
-			ReadOnly: v.ReadOnly,
+			Kind:      intmodel.VolumeKind(v.Kind),
+			Source:    v.Source,
+			Target:    v.Target,
+			ReadOnly:  v.ReadOnly,
+			SizeBytes: v.SizeBytes,
+			Mode:      v.Mode,
 		}
 	}
 	return out
@@ -754,9 +757,12 @@ func volumeMountsToExternal(in []intmodel.VolumeMount) []ext.VolumeMount {
 	out := make([]ext.VolumeMount, len(in))
 	for i, v := range in {
 		out[i] = ext.VolumeMount{
-			Source:   v.Source,
-			Target:   v.Target,
-			ReadOnly: v.ReadOnly,
+			Kind:      ext.VolumeKind(v.Kind),
+			Source:    v.Source,
+			Target:    v.Target,
+			ReadOnly:  v.ReadOnly,
+			SizeBytes: v.SizeBytes,
+			Mode:      v.Mode,
 		}
 	}
 	return out

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -707,6 +707,141 @@ func TestContainerRoundTripV1Beta1(t *testing.T) {
 	}
 }
 
+// TestContainerRoundTripVolumeKindTmpfsV1Beta1 pins the tmpfs path on
+// VolumeMount: a YAML author who writes `kind: tmpfs` with size/mode must see
+// those fields survive Normalize → controller → Build with no drops, alongside
+// a plain bind entry (empty Kind preserves bind back-compat).
+func TestContainerRoundTripVolumeKindTmpfsV1Beta1(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata: ext.ContainerMetadata{
+			Name: "container-tmpfs",
+		},
+		Spec: ext.ContainerSpec{
+			ID:      "container-tmpfs",
+			RealmID: "realm0",
+			SpaceID: "space0",
+			StackID: "stack0",
+			CellID:  "cell0",
+			Image:   "alpine:latest",
+			Volumes: []ext.VolumeMount{
+				{Source: "/host/data", Target: "/data"},
+				{
+					Kind:      ext.VolumeKindTmpfs,
+					Target:    "/var/lib/containerd",
+					SizeBytes: 1 << 30,
+					Mode:      0o0755,
+				},
+				{
+					Kind:     ext.VolumeKindBind,
+					Source:   "/host/ro",
+					Target:   "/ro",
+					ReadOnly: true,
+				},
+			},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	if version != ext.APIVersionV1Beta1 {
+		t.Fatalf("unexpected version: %s", version)
+	}
+	if got, want := len(internal.Spec.Volumes), len(input.Spec.Volumes); got != want {
+		t.Fatalf("internal volumes len = %d, want %d", got, want)
+	}
+	if internal.Spec.Volumes[1].Kind != intmodel.VolumeKindTmpfs {
+		t.Errorf("internal volume[1].Kind = %q, want %q",
+			internal.Spec.Volumes[1].Kind, intmodel.VolumeKindTmpfs)
+	}
+	if internal.Spec.Volumes[1].SizeBytes != 1<<30 {
+		t.Errorf("internal volume[1].SizeBytes = %d, want %d",
+			internal.Spec.Volumes[1].SizeBytes, 1<<30)
+	}
+	if internal.Spec.Volumes[1].Mode != 0o0755 {
+		t.Errorf("internal volume[1].Mode = %o, want %o",
+			internal.Spec.Volumes[1].Mode, 0o0755)
+	}
+
+	output, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	if got, want := len(output.Spec.Volumes), len(input.Spec.Volumes); got != want {
+		t.Fatalf("output volumes len = %d, want %d", got, want)
+	}
+	for i, want := range input.Spec.Volumes {
+		if output.Spec.Volumes[i] != want {
+			t.Errorf("volume[%d] = %+v, want %+v",
+				i, output.Spec.Volumes[i], want)
+		}
+	}
+}
+
+// TestCellRoundTripVolumeKindTmpfsV1Beta1 mirrors the standalone Container
+// test for the nested-container path that `apply -f cell.yaml` and the
+// CellProfile materializer travel: a tmpfs entry inside CellSpec.Containers[]
+// must keep Kind / SizeBytes / Mode through Normalize → controller → Build.
+func TestCellRoundTripVolumeKindTmpfsV1Beta1(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "cell-tmpfs"},
+		Spec: ext.CellSpec{
+			ID:      "cell-tmpfs",
+			RealmID: "realm0",
+			SpaceID: "space0",
+			StackID: "stack0",
+			Containers: []ext.ContainerSpec{
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "/bin/sh",
+					Volumes: []ext.VolumeMount{
+						{
+							Kind:      ext.VolumeKindTmpfs,
+							Target:    "/var/lib/containerd",
+							SizeBytes: 512 * 1024 * 1024,
+							Mode:      0o0700,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if len(internal.Spec.Containers) != 1 || len(internal.Spec.Containers[0].Volumes) != 1 {
+		t.Fatalf("internal nested volumes not carried: %+v", internal.Spec.Containers)
+	}
+	got := internal.Spec.Containers[0].Volumes[0]
+	if got.Kind != intmodel.VolumeKindTmpfs ||
+		got.Target != "/var/lib/containerd" ||
+		got.SizeBytes != 512*1024*1024 ||
+		got.Mode != 0o0700 {
+		t.Errorf("internal nested tmpfs mismatch: %+v", got)
+	}
+
+	output, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if len(output.Spec.Containers) != 1 || len(output.Spec.Containers[0].Volumes) != 1 {
+		t.Fatalf("nested volumes did not round-trip: %+v", output.Spec.Containers)
+	}
+	if output.Spec.Containers[0].Volumes[0] != input.Spec.Containers[0].Volumes[0] {
+		t.Errorf("nested volume = %+v, want %+v",
+			output.Spec.Containers[0].Volumes[0],
+			input.Spec.Containers[0].Volumes[0])
+	}
+}
+
 // TestCellRoundTripWorkingDirV1Beta1 covers the nested-ContainerSpec path:
 // `apply -f cell.yaml` lands here (containers live inside CellDoc), so the
 // per-container WorkingDir must survive Normalize → controller → Build with

--- a/internal/controller/create_container.go
+++ b/internal/controller/create_container.go
@@ -273,42 +273,23 @@ func containerSpecExistsInternal(specs []intmodel.ContainerSpec, id string) bool
 	return false
 }
 
-// validateVolumes enforces the bind-mount contract: source and target are
-// required, both must be absolute paths, source must exist on the host, and
-// named / managed volumes (non-absolute source) are rejected.
+// validateVolumes enforces the per-kind volume contract:
+//   - bind (or empty Kind, for back-compat): source and target are required,
+//     both must be absolute paths, source must exist on the host, named /
+//     managed volumes (non-absolute source) are rejected.
+//   - tmpfs: target is required and must be absolute; source must be empty
+//     (tmpfs is in-memory, no host backing); SizeBytes and Mode are accepted
+//     verbatim and the OCI translator validates them downstream.
+//   - any other Kind is rejected with ErrVolumeKindUnknown.
 func validateVolumes(in []intmodel.VolumeMount) ([]intmodel.VolumeMount, error) {
 	if len(in) == 0 {
 		return nil, nil
 	}
 	out := make([]intmodel.VolumeMount, len(in))
 	for i, v := range in {
-		src := strings.TrimSpace(v.Source)
 		dst := strings.TrimSpace(v.Target)
-		if src == "" {
-			return nil, fmt.Errorf("%w (volume[%d])", errdefs.ErrVolumeSourceRequired, i)
-		}
 		if dst == "" {
 			return nil, fmt.Errorf("%w (volume[%d])", errdefs.ErrVolumeTargetRequired, i)
-		}
-		// Named / managed volumes have non-path sources (e.g. "my-vol"). Reject
-		// anything that is not an absolute host path so the user gets a clear
-		// error pointing at the deferred feature rather than a mount failure
-		// buried in containerd logs.
-		if !filepath.IsAbs(src) {
-			if !strings.ContainsRune(src, os.PathSeparator) {
-				return nil, fmt.Errorf(
-					"%w (volume[%d] source %q)",
-					errdefs.ErrVolumeNamedNotSupported,
-					i,
-					src,
-				)
-			}
-			return nil, fmt.Errorf(
-				"%w (volume[%d] source %q)",
-				errdefs.ErrVolumeSourceNotAbsolute,
-				i,
-				src,
-			)
 		}
 		if !filepath.IsAbs(dst) {
 			return nil, fmt.Errorf(
@@ -318,26 +299,80 @@ func validateVolumes(in []intmodel.VolumeMount) ([]intmodel.VolumeMount, error) 
 				dst,
 			)
 		}
-		if _, statErr := os.Stat(src); statErr != nil {
-			if os.IsNotExist(statErr) {
+
+		switch v.Kind {
+		case "", intmodel.VolumeKindBind:
+			src := strings.TrimSpace(v.Source)
+			if src == "" {
+				return nil, fmt.Errorf("%w (volume[%d])", errdefs.ErrVolumeSourceRequired, i)
+			}
+			// Named / managed volumes have non-path sources (e.g. "my-vol").
+			// Reject anything that is not an absolute host path so the user
+			// gets a clear error pointing at the deferred feature rather than
+			// a mount failure buried in containerd logs.
+			if !filepath.IsAbs(src) {
+				if !strings.ContainsRune(src, os.PathSeparator) {
+					return nil, fmt.Errorf(
+						"%w (volume[%d] source %q)",
+						errdefs.ErrVolumeNamedNotSupported,
+						i,
+						src,
+					)
+				}
 				return nil, fmt.Errorf(
 					"%w (volume[%d] source %q)",
-					errdefs.ErrVolumeSourceNotFound,
+					errdefs.ErrVolumeSourceNotAbsolute,
 					i,
 					src,
 				)
 			}
+			if _, statErr := os.Stat(src); statErr != nil {
+				if os.IsNotExist(statErr) {
+					return nil, fmt.Errorf(
+						"%w (volume[%d] source %q)",
+						errdefs.ErrVolumeSourceNotFound,
+						i,
+						src,
+					)
+				}
+				return nil, fmt.Errorf(
+					"failed to stat volume[%d] source %q: %w",
+					i,
+					src,
+					statErr,
+				)
+			}
+			out[i] = intmodel.VolumeMount{
+				Kind:     v.Kind,
+				Source:   src,
+				Target:   dst,
+				ReadOnly: v.ReadOnly,
+			}
+
+		case intmodel.VolumeKindTmpfs:
+			if strings.TrimSpace(v.Source) != "" {
+				return nil, fmt.Errorf(
+					"%w (volume[%d] source %q)",
+					errdefs.ErrVolumeTmpfsSourceForbidden,
+					i,
+					v.Source,
+				)
+			}
+			out[i] = intmodel.VolumeMount{
+				Kind:      intmodel.VolumeKindTmpfs,
+				Target:    dst,
+				ReadOnly:  v.ReadOnly,
+				SizeBytes: v.SizeBytes,
+				Mode:      v.Mode,
+			}
+
+		default:
 			return nil, fmt.Errorf(
-				"failed to stat volume[%d] source %q: %w",
+				"%w (volume[%d] kind %q)",
+				errdefs.ErrVolumeKindUnknown,
 				i,
-				src,
-				statErr,
+				v.Kind,
 			)
-		}
-		out[i] = intmodel.VolumeMount{
-			Source:   src,
-			Target:   dst,
-			ReadOnly: v.ReadOnly,
 		}
 	}
 	return out, nil

--- a/internal/controller/validate_volumes_test.go
+++ b/internal/controller/validate_volumes_test.go
@@ -75,6 +75,57 @@ func TestValidateVolumes(t *testing.T) {
 			in:      []intmodel.VolumeMount{{Source: filepath.Join(tmpDir, "nope"), Target: "/dst"}},
 			wantErr: errdefs.ErrVolumeSourceNotFound,
 		},
+		{
+			name: "explicit bind kind accepted",
+			in: []intmodel.VolumeMount{
+				{Kind: intmodel.VolumeKindBind, Source: existing, Target: "/dst"},
+			},
+		},
+		{
+			name: "tmpfs minimal",
+			in: []intmodel.VolumeMount{
+				{Kind: intmodel.VolumeKindTmpfs, Target: "/run/cache"},
+			},
+		},
+		{
+			name: "tmpfs with size and mode",
+			in: []intmodel.VolumeMount{
+				{
+					Kind:      intmodel.VolumeKindTmpfs,
+					Target:    "/var/lib/containerd",
+					SizeBytes: 1 << 30,
+					Mode:      0o0755,
+				},
+			},
+		},
+		{
+			name: "tmpfs rejects source",
+			in: []intmodel.VolumeMount{
+				{Kind: intmodel.VolumeKindTmpfs, Source: "/host/path", Target: "/dst"},
+			},
+			wantErr: errdefs.ErrVolumeTmpfsSourceForbidden,
+		},
+		{
+			name: "tmpfs requires target",
+			in: []intmodel.VolumeMount{
+				{Kind: intmodel.VolumeKindTmpfs},
+			},
+			wantErr: errdefs.ErrVolumeTargetRequired,
+		},
+		{
+			name: "tmpfs target must be absolute",
+			in: []intmodel.VolumeMount{
+				{Kind: intmodel.VolumeKindTmpfs, Target: "relative"},
+			},
+			wantErr: errdefs.ErrVolumeTargetNotAbsolute,
+		},
+		{
+			name: "unknown kind rejected",
+			in: []intmodel.VolumeMount{
+				{Kind: intmodel.VolumeKind("nfs"), Target: "/dst"},
+			},
+			wantErr: errdefs.ErrVolumeKindUnknown,
+		},
 	}
 
 	for _, tt := range tests {
@@ -105,5 +156,41 @@ func TestValidateVolumes_TrimsWhitespace(t *testing.T) {
 	}
 	if out[0].Source != tmpDir || out[0].Target != "/dst" {
 		t.Errorf("got %+v, expected source=%q target=\"/dst\"", out[0], tmpDir)
+	}
+}
+
+func TestValidateVolumes_PreservesTmpfsFields(t *testing.T) {
+	in := []intmodel.VolumeMount{{
+		Kind:      intmodel.VolumeKindTmpfs,
+		Target:    "/var/lib/containerd",
+		ReadOnly:  true,
+		SizeBytes: 1 << 30,
+		Mode:      0o0755,
+	}}
+	out, err := validateVolumes(in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	got := out[0]
+	if got.Kind != intmodel.VolumeKindTmpfs {
+		t.Errorf("Kind = %q, want %q", got.Kind, intmodel.VolumeKindTmpfs)
+	}
+	if got.Source != "" {
+		t.Errorf("Source = %q, want \"\"", got.Source)
+	}
+	if got.Target != "/var/lib/containerd" {
+		t.Errorf("Target = %q, want \"/var/lib/containerd\"", got.Target)
+	}
+	if !got.ReadOnly {
+		t.Errorf("ReadOnly = false, want true")
+	}
+	if got.SizeBytes != 1<<30 {
+		t.Errorf("SizeBytes = %d, want %d", got.SizeBytes, 1<<30)
+	}
+	if got.Mode != 0o0755 {
+		t.Errorf("Mode = %o, want %o", got.Mode, 0o0755)
 	}
 }

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -121,6 +121,12 @@ var (
 	ErrVolumeNamedNotSupported = errors.New(
 		"named or managed volumes are not supported; use an absolute host path as source",
 	)
+	ErrVolumeKindUnknown = errors.New(
+		"volume kind is not recognized; expected \"\", \"bind\", or \"tmpfs\"",
+	)
+	ErrVolumeTmpfsSourceForbidden = errors.New(
+		"tmpfs volume must not set a source; tmpfs is in-memory and has no host backing",
+	)
 
 	// CNI-related errors.
 

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -158,11 +158,31 @@ type ContainerSecret struct {
 	MountPath string `json:"mountPath,omitempty" yaml:"mountPath,omitempty"`
 }
 
-// VolumeMount is a bind mount of a host path into a container.
+// VolumeKind discriminates between the supported VolumeMount kinds. Mirrors
+// intmodel.VolumeKind. An empty value deserializes as VolumeKindBind so YAML
+// authored before the discriminator existed keeps its bind semantics.
+type VolumeKind string
+
+const (
+	// VolumeKindBind is a host bind mount. Source and Target are required.
+	VolumeKindBind VolumeKind = "bind"
+	// VolumeKindTmpfs is an in-memory tmpfs mount. Only Target is required;
+	// Source must be empty. SizeBytes and Mode tune the standard tmpfs
+	// size= and mode= options when non-zero.
+	VolumeKindTmpfs VolumeKind = "tmpfs"
+)
+
+// VolumeMount is a mount entry attached to a container. The Kind discriminator
+// selects the OCI mount type the runtime emits: bind (host path → container
+// path) or tmpfs (in-memory directory). Empty Kind means bind for back-compat
+// with YAML authored before the discriminator existed.
 type VolumeMount struct {
-	Source   string `json:"source"             yaml:"source"`
-	Target   string `json:"target"             yaml:"target"`
-	ReadOnly bool   `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+	Kind      VolumeKind `json:"kind,omitempty"      yaml:"kind,omitempty"`
+	Source    string     `json:"source,omitempty"    yaml:"source,omitempty"`
+	Target    string     `json:"target"              yaml:"target"`
+	ReadOnly  bool       `json:"readOnly,omitempty"  yaml:"readOnly,omitempty"`
+	SizeBytes int64      `json:"sizeBytes,omitempty" yaml:"sizeBytes,omitempty"`
+	Mode      uint32     `json:"mode,omitempty"      yaml:"mode,omitempty"`
 }
 
 // ContainerCapabilities groups Linux capability deltas applied to the


### PR DESCRIPTION
## Summary
- Extends `pkg/api/model/v1beta1.VolumeMount` with `Kind` (`VolumeKindBind` / `VolumeKindTmpfs` consts), `SizeBytes`, and `Mode`. Empty `Kind` deserializes as bind so every existing YAML round-trips byte-identically.
- Round-trips the new fields through `internal/apischeme.scheme.go` (`volumeMountsToInternal` / `volumeMountsToExternal`).
- Makes `internal/controller.validateVolumes` kind-aware: bind keeps the existing `os.Stat` + absolute-source contract; tmpfs requires an absolute target and rejects any non-empty source; unknown kinds are rejected with a new `errdefs.ErrVolumeKindUnknown`. `errdefs.ErrVolumeTmpfsSourceForbidden` is the tmpfs-specific source error.
- New unit tests in `scheme_test.go` for tmpfs round-trip on both `ContainerSpec` and `CellSpec.Containers[]`, and in `validate_volumes_test.go` for tmpfs accept paths, the rejected-source case, target validation, the unknown-kind reject, and an explicit field-preservation assertion.
- The downstream OCI translator already dispatches on `Kind` (PR #346), so this change closes the gap between user-authored YAML and `internal/ctr/spec.go:buildVolumeMounts`.

`cloneVolumeMounts` already does `copy()` on a value-type slice, so the new fields are preserved automatically — no change needed there.

The design call from issue #347 (keeping `Spec.Tmpfs[]` for one minor release with a deprecation note as a separate follow-up) is unchanged; this PR ships only the v1beta1 / apischeme / validator layer per the AC.

## Test plan
- [x] `make test` (full project unit suite, all packages green)
- [x] `go build ./...` and `go vet ./...`
- [x] `pre-commit run` on the touched files (gofmt, golangci-lint, prettier, addlicense — all green)
- [x] `make dev-init` smoke (daemon-parity output matches the regression guard)
- [x] Smoke check per AC item 7 — applied a Cell with both `kind: tmpfs` (sizeBytes: 16777216, mode: 0o0755) and a bind `readOnly` volume on a non-root container, confirmed the container's containerd OCI spec ships:
  - `{type:"tmpfs", destination:"/var/lib/cache", options:["size=16777216","mode=0755","rw"]}`
  - `{type:"bind", destination:"/host-tmp", source:"/tmp", options:["rbind","ro"]}`

  i.e. the new fields reach `internal/ctr/spec.go:buildVolumeMounts` with `Kind` / `SizeBytes` / `Mode` preserved end-to-end.

Closes #347