### PR TITLE
fix: cell hostname is cell name with managed /etc/hosts and /etc/hostname

### DIFF
--- a/internal/cni/container.go
+++ b/internal/cni/container.go
@@ -18,20 +18,70 @@ package cni
 
 import (
 	"context"
+	"net"
 
 	libcni "github.com/containernetworking/cni/libcni"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	current "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/eminwux/kukeon/internal/errdefs"
 )
 
-// AddContainerToNetwork adds a container to the CNI network.
-func (m *Manager) AddContainerToNetwork(ctx context.Context, containerID, netnsPath string) error {
+// AddContainerToNetwork adds a container to the CNI network and returns the
+// container's IPv4 address as assigned by IPAM, or nil when no IPv4 address
+// was returned (e.g. IPv6-only networks). The IP is the one the runner
+// renders into the cell's /etc/hosts so tools that resolve the container's
+// own hostname work without DNS-lookup timeouts (issue #345).
+func (m *Manager) AddContainerToNetwork(ctx context.Context, containerID, netnsPath string) (net.IP, error) {
 	if m.netConf == nil {
-		return errdefs.ErrNetworkConfigNotLoaded
+		return nil, errdefs.ErrNetworkConfigNotLoaded
 	}
 
 	rt := buildRuntimeConf(containerID, netnsPath)
-	_, err := m.cniConf.AddNetworkList(ctx, m.netConf, rt)
-	return translateCNIError(err, m.netConf.Name, bridgeNameFromNetConf(m.netConf))
+	rawResult, err := m.cniConf.AddNetworkList(ctx, m.netConf, rt)
+	if err != nil {
+		return nil, translateCNIError(err, m.netConf.Name, bridgeNameFromNetConf(m.netConf))
+	}
+	return firstIPv4FromResult(rawResult), nil
+}
+
+// CachedIPv4ForContainer returns the IPv4 address libcni cached for the
+// given containerID under the manager's current network config, or nil when
+// no usable IPv4 entry is cached. Used by the runner on the idempotent-skip
+// path (ErrCNIVethExists) — when AddContainerToNetwork failed because veth
+// setup already ran, the IPAM allocation persisted in the cache and is the
+// authoritative source for the cell IP without re-issuing CNI ADD.
+func (m *Manager) CachedIPv4ForContainer(containerID, netnsPath string) net.IP {
+	if m.netConf == nil {
+		return nil
+	}
+	rt := buildRuntimeConf(containerID, netnsPath)
+	rawResult, err := m.cniConf.GetNetworkListCachedResult(m.netConf, rt)
+	if err != nil || rawResult == nil {
+		return nil
+	}
+	return firstIPv4FromResult(rawResult)
+}
+
+// firstIPv4FromResult extracts the first IPv4 address from a CNI result,
+// converting through the libcni current schema so callers can stay agnostic
+// of which CNI version the bridge plugin emits.
+func firstIPv4FromResult(rawResult cnitypes.Result) net.IP {
+	if rawResult == nil {
+		return nil
+	}
+	res, err := current.NewResultFromResult(rawResult)
+	if err != nil || res == nil {
+		return nil
+	}
+	for _, ipc := range res.IPs {
+		if ipc == nil {
+			continue
+		}
+		if v4 := ipc.Address.IP.To4(); v4 != nil {
+			return v4
+		}
+	}
+	return nil
 }
 
 // DelContainerFromNetwork removes a container from the CNI network.

--- a/internal/cni/container_test.go
+++ b/internal/cni/container_test.go
@@ -59,13 +59,16 @@ func TestManager_AddContainerToNetwork(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mgr := tt.setup(t)
-			err := mgr.AddContainerToNetwork(context.Background(), tt.containerID, tt.netnsPath)
+			ip, err := mgr.AddContainerToNetwork(context.Background(), tt.containerID, tt.netnsPath)
 
 			if tt.wantErr != nil {
 				if err == nil {
 					t.Errorf("AddContainerToNetwork() error = nil, want %v", tt.wantErr)
 				} else if !errors.Is(err, tt.wantErr) {
 					t.Errorf("AddContainerToNetwork() error = %v, want %v", err, tt.wantErr)
+				}
+				if ip != nil {
+					t.Errorf("AddContainerToNetwork() ip = %v, want nil on error", ip)
 				}
 			} else {
 				if err != nil {

--- a/internal/cni/network_test.go
+++ b/internal/cni/network_test.go
@@ -106,7 +106,7 @@ func TestManager_LoadNetworkConfigList(t *testing.T) {
 				// Verify config was loaded by trying to use it
 				// We can't directly access netConf, but we can verify it's loaded
 				// by checking that AddContainerToNetwork doesn't return ErrNetworkConfigNotLoaded
-				err := mgr.AddContainerToNetwork(context.Background(), "test-container", "/proc/123/ns/net")
+				_, err := mgr.AddContainerToNetwork(context.Background(), "test-container", "/proc/123/ns/net")
 				if err != nil && !errors.Is(err, errdefs.ErrNetworkConfigNotLoaded) {
 					// Config is loaded (error is from libcni, not from missing config)
 					return

--- a/internal/controller/runner/cell_etc_files.go
+++ b/internal/controller/runner/cell_etc_files.go
@@ -170,6 +170,41 @@ func (r *Exec) renderCellEtcFilesPreCNI(cell *intmodel.Cell) error {
 	return renderCellEtcHosts(hostsPath, cellName, nil)
 }
 
+// ensureCellEtcFilesExistPreCNI guarantees the per-cell /etc/hostname and
+// /etc/hosts source files exist without rewriting them when they already
+// do. Use this on call paths where a prior StartCell may have rendered
+// /etc/hosts with the cell IP — an unconditional pre-CNI re-render would
+// truncate the IP line and regress the DNS-lookup fix issue #345 ships.
+// First-creation paths still call renderCellEtcFilesPreCNI directly.
+func (r *Exec) ensureCellEtcFilesExistPreCNI(cell *intmodel.Cell) error {
+	if cell == nil {
+		return nil
+	}
+	hostnamePath, hostsPath, suppressHosts := r.cellEtcFilePaths(cell)
+	if hostnamePath == "" {
+		return nil
+	}
+	cellName := strings.TrimSpace(cell.Metadata.Name)
+	if _, err := os.Stat(hostnamePath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("stat %s: %w", hostnamePath, err)
+		}
+		if rerr := renderCellEtcHostname(hostnamePath, cellName); rerr != nil {
+			return rerr
+		}
+	}
+	if suppressHosts {
+		return nil
+	}
+	if _, err := os.Stat(hostsPath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("stat %s: %w", hostsPath, err)
+		}
+		return renderCellEtcHosts(hostsPath, cellName, nil)
+	}
+	return nil
+}
+
 // renderCellEtcHostsWithIP rewrites the cell's /etc/hosts to include the
 // CNI-assigned cell IP. Called from StartCell after AddContainerToNetwork
 // succeeds (or returns the cached IP on the idempotent-veth-exists path).

--- a/internal/controller/runner/cell_etc_files.go
+++ b/internal/controller/runner/cell_etc_files.go
@@ -1,0 +1,213 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	utilfs "github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// etcHostsLocalhostBlock is the static localhost block kukeond emits at the
+// top of every per-cell /etc/hosts. Mirrors the block Docker, Kubernetes
+// kubelet, and containerd's nerdctl render — the IPv4 loopback first, then
+// the IPv6 loopback aliases tools like `getent hosts localhost` rely on.
+const etcHostsLocalhostBlock = `127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::	ip6-localnet
+ff00::	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+`
+
+// renderCellEtcHostname writes the cell name plus a trailing newline to the
+// given path, atomically replacing whatever was there. The bind-mount in the
+// container's OCI spec resolves to the destination path's inode at mount
+// time, so an in-place rewrite (truncate + write) is what propagates an
+// updated cell-name to running containers.
+func renderCellEtcHostname(path, cellName string) error {
+	cellName = strings.TrimSpace(cellName)
+	if cellName == "" {
+		return fmt.Errorf("cell name is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create cell metadata dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(cellName+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// renderCellEtcHosts writes the localhost block plus an optional
+// "<cellIP>\t<cellName>" line. cellIP may be nil — used at cell-create time
+// before CNI ADD has assigned an address; the post-CNI render replaces the
+// file with the IP populated. Truncate-on-write so the inode the container's
+// bind-mount resolves to keeps reflecting the latest content.
+func renderCellEtcHosts(path, cellName string, cellIP net.IP) error {
+	cellName = strings.TrimSpace(cellName)
+	if cellName == "" {
+		return fmt.Errorf("cell name is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create cell metadata dir: %w", err)
+	}
+	var b strings.Builder
+	b.WriteString(etcHostsLocalhostBlock)
+	if cellIP != nil {
+		b.WriteString(cellIP.String())
+		b.WriteByte('\t')
+		b.WriteString(cellName)
+		b.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// cellEtcFilePaths returns the per-cell /etc/hostname and /etc/hosts host
+// source paths and a suppressHosts flag set when the cell's root container
+// runs with HostNetwork=true (the kukeond carve-out). Returns zero values
+// when the cell's identity fields are incomplete so callers can no-op
+// safely.
+func (r *Exec) cellEtcFilePaths(cell *intmodel.Cell) (hostnamePath, hostsPath string, suppressHosts bool) {
+	if cell == nil {
+		return "", "", false
+	}
+	cellName := strings.TrimSpace(cell.Metadata.Name)
+	realmName := strings.TrimSpace(cell.Spec.RealmName)
+	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
+	stackName := strings.TrimSpace(cell.Spec.StackName)
+	if cellName == "" || realmName == "" || spaceName == "" || stackName == "" {
+		return "", "", false
+	}
+	hostnamePath = utilfs.CellEtcHostnamePath(r.opts.RunPath, realmName, spaceName, stackName, cellName)
+	hostsPath = utilfs.CellEtcHostsPath(r.opts.RunPath, realmName, spaceName, stackName, cellName)
+	suppressHosts = cellRootHostNetwork(cell)
+	return hostnamePath, hostsPath, suppressHosts
+}
+
+// stampCellEtcFilePathsOnContainers fills EtcHostnamePath and EtcHostsPath
+// on every container spec in the cell so BuildContainerSpec /
+// BuildRootContainerSpec emit the bind-mounts. /etc/hosts is suppressed for
+// host-network cells (root container with HostNetwork=true) — the host's
+// /etc/hosts is the authoritative view in that mode and overriding it would
+// hide host-side aliases the daemon depends on. /etc/hostname is set
+// unconditionally so `cat /etc/hostname` agrees with the UTS hostname for
+// every container in the cell.
+func (r *Exec) stampCellEtcFilePathsOnContainers(cell *intmodel.Cell) {
+	hostnamePath, hostsPath, suppressHosts := r.cellEtcFilePaths(cell)
+	if hostnamePath == "" {
+		return
+	}
+	for i := range cell.Spec.Containers {
+		stampEtcFilePathsOnContainerSpec(&cell.Spec.Containers[i], hostnamePath, hostsPath, suppressHosts)
+	}
+}
+
+// stampEtcFilePathsOnContainerSpec is the per-container counterpart to
+// stampCellEtcFilePathsOnContainers — used by call sites that hold a local
+// container spec value (e.g. a root spec built fresh by
+// ensureCellRootContainerSpec) and need it to carry the same bind-mount
+// paths the cell-wide stamp would apply.
+func stampEtcFilePathsOnContainerSpec(spec *intmodel.ContainerSpec, hostnamePath, hostsPath string, suppressHosts bool) {
+	if spec == nil || hostnamePath == "" {
+		return
+	}
+	spec.EtcHostnamePath = hostnamePath
+	if suppressHosts {
+		spec.EtcHostsPath = ""
+	} else {
+		spec.EtcHostsPath = hostsPath
+	}
+}
+
+// renderCellEtcFilesPreCNI writes the per-cell /etc/hostname and an initial
+// /etc/hosts (localhost block only, no cell IP) so the bind-mount sources
+// exist before runc creates any container in the cell. Idempotent — every
+// CreateCell / StartCell / EnsureCellContainers tick calls this so a
+// rebooted host or a daemon restart finds the files in place.
+func (r *Exec) renderCellEtcFilesPreCNI(cell *intmodel.Cell) error {
+	if cell == nil {
+		return nil
+	}
+	cellName := strings.TrimSpace(cell.Metadata.Name)
+	realmName := strings.TrimSpace(cell.Spec.RealmName)
+	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
+	stackName := strings.TrimSpace(cell.Spec.StackName)
+	if cellName == "" || realmName == "" || spaceName == "" || stackName == "" {
+		return nil
+	}
+	hostnamePath := utilfs.CellEtcHostnamePath(r.opts.RunPath, realmName, spaceName, stackName, cellName)
+	hostsPath := utilfs.CellEtcHostsPath(r.opts.RunPath, realmName, spaceName, stackName, cellName)
+	if err := renderCellEtcHostname(hostnamePath, cellName); err != nil {
+		return err
+	}
+	if cellRootHostNetwork(cell) {
+		// Host-network cells use the host's /etc/hosts; nothing to render.
+		return nil
+	}
+	return renderCellEtcHosts(hostsPath, cellName, nil)
+}
+
+// renderCellEtcHostsWithIP rewrites the cell's /etc/hosts to include the
+// CNI-assigned cell IP. Called from StartCell after AddContainerToNetwork
+// succeeds (or returns the cached IP on the idempotent-veth-exists path).
+// No-op for host-network cells.
+func (r *Exec) renderCellEtcHostsWithIP(cell *intmodel.Cell, cellIP net.IP) error {
+	if cell == nil || cellIP == nil {
+		return nil
+	}
+	cellName := strings.TrimSpace(cell.Metadata.Name)
+	realmName := strings.TrimSpace(cell.Spec.RealmName)
+	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
+	stackName := strings.TrimSpace(cell.Spec.StackName)
+	if cellName == "" || realmName == "" || spaceName == "" || stackName == "" {
+		return nil
+	}
+	if cellRootHostNetwork(cell) {
+		return nil
+	}
+	hostsPath := utilfs.CellEtcHostsPath(r.opts.RunPath, realmName, spaceName, stackName, cellName)
+	return renderCellEtcHosts(hostsPath, cellName, cellIP)
+}
+
+// cellRootHostNetwork reports whether the cell's root container runs with
+// HostNetwork=true — the kukeond carve-out where /etc/hosts injection is
+// inappropriate. Looks up the root via Spec.RootContainerID and falls back
+// to scanning Containers for a Root=true entry when the field is unset.
+func cellRootHostNetwork(cell *intmodel.Cell) bool {
+	if cell == nil {
+		return false
+	}
+	rootID := strings.TrimSpace(cell.Spec.RootContainerID)
+	for _, c := range cell.Spec.Containers {
+		if rootID != "" && c.ID == rootID {
+			return c.HostNetwork
+		}
+		if rootID == "" && c.Root {
+			return c.HostNetwork
+		}
+	}
+	return false
+}

--- a/internal/controller/runner/cell_etc_files_test.go
+++ b/internal/controller/runner/cell_etc_files_test.go
@@ -1,0 +1,146 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests exercise private methods on *Exec
+package runner
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	utilfs "github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// newCellForEtcFilesTest builds a minimally-populated Cell suitable for
+// exercising the cell_etc_files helpers. The container layout is what
+// cellRootHostNetwork inspects to decide whether /etc/hosts should be
+// suppressed.
+func newCellForEtcFilesTest(rootHostNetwork bool) *intmodel.Cell {
+	return &intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "kukeond"},
+		Spec: intmodel.CellSpec{
+			RealmName:       "kuke-system",
+			SpaceName:       "kukeon",
+			StackName:       "kukeon",
+			RootContainerID: "kukeond",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "kukeond", Root: true, HostNetwork: rootHostNetwork},
+			},
+		},
+	}
+}
+
+// TestEnsureCellEtcFilesExistPreCNI_PreservesIPLine is the regression guard
+// for the /etc/hosts clobber bug the reviewer flagged on PR #352: a prior
+// StartCell tick has already rewritten /etc/hosts with the CNI-assigned IP
+// line, and a subsequent ensureCellContainers tick (driven by update_cell
+// or update_container on a running cell) must not truncate that file back
+// to the localhost-only block — doing so regresses the DNS-lookup fix
+// issue #345 ships.
+func TestEnsureCellEtcFilesExistPreCNI_PreservesIPLine(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+	cell := newCellForEtcFilesTest(false)
+
+	// Simulate the post-StartCell state: /etc/hosts has the cell IP line.
+	if err := r.renderCellEtcFilesPreCNI(cell); err != nil {
+		t.Fatalf("seed pre-CNI render: %v", err)
+	}
+	hostsPath := utilfs.CellEtcHostsPath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+	withIP := etcHostsLocalhostBlock + "10.22.0.5\tkukeond\n"
+	if err := os.WriteFile(hostsPath, []byte(withIP), 0o644); err != nil {
+		t.Fatalf("seed /etc/hosts with IP: %v", err)
+	}
+
+	// The fix: ensure-only path must not rewrite content when the file
+	// already exists.
+	if err := r.ensureCellEtcFilesExistPreCNI(cell); err != nil {
+		t.Fatalf("ensureCellEtcFilesExistPreCNI: %v", err)
+	}
+
+	got, err := os.ReadFile(hostsPath)
+	if err != nil {
+		t.Fatalf("read /etc/hosts: %v", err)
+	}
+	if string(got) != withIP {
+		t.Errorf("/etc/hosts was clobbered by ensure helper:\n--- got ---\n%s\n--- want ---\n%s", got, withIP)
+	}
+	if !strings.Contains(string(got), "10.22.0.5\tkukeond") {
+		t.Errorf("/etc/hosts lost cell IP entry after ensure: %q", got)
+	}
+}
+
+// TestEnsureCellEtcFilesExistPreCNI_FillsInMissingFiles verifies the helper
+// still creates the per-cell source files when they are absent — the
+// existing-root branch can race a stale or partial prior run that left a
+// file missing, and the bind-mount source must exist before the OCI specs
+// reference it.
+func TestEnsureCellEtcFilesExistPreCNI_FillsInMissingFiles(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+	cell := newCellForEtcFilesTest(false)
+
+	if err := r.ensureCellEtcFilesExistPreCNI(cell); err != nil {
+		t.Fatalf("ensureCellEtcFilesExistPreCNI: %v", err)
+	}
+
+	hostnamePath := utilfs.CellEtcHostnamePath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+	hostsPath := utilfs.CellEtcHostsPath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+
+	hn, err := os.ReadFile(hostnamePath)
+	if err != nil {
+		t.Fatalf("read /etc/hostname: %v", err)
+	}
+	if string(hn) != "kukeond\n" {
+		t.Errorf("/etc/hostname = %q, want %q", hn, "kukeond\n")
+	}
+
+	hosts, err := os.ReadFile(hostsPath)
+	if err != nil {
+		t.Fatalf("read /etc/hosts: %v", err)
+	}
+	if string(hosts) != etcHostsLocalhostBlock {
+		t.Errorf("/etc/hosts = %q, want pre-CNI localhost block", hosts)
+	}
+}
+
+// TestEnsureCellEtcFilesExistPreCNI_HostNetworkSkipsHosts confirms the
+// host-network carve-out: the kukeond cell's root runs HostNetwork=true,
+// so /etc/hosts must not be rendered (the host's /etc/hosts is the right
+// view) — but /etc/hostname is still produced.
+func TestEnsureCellEtcFilesExistPreCNI_HostNetworkSkipsHosts(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+	cell := newCellForEtcFilesTest(true)
+
+	if err := r.ensureCellEtcFilesExistPreCNI(cell); err != nil {
+		t.Fatalf("ensureCellEtcFilesExistPreCNI: %v", err)
+	}
+
+	hostnamePath := utilfs.CellEtcHostnamePath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+	hostsPath := utilfs.CellEtcHostsPath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+
+	if _, err := os.Stat(hostnamePath); err != nil {
+		t.Errorf("/etc/hostname should exist on host-network cells: %v", err)
+	}
+	if _, err := os.Stat(hostsPath); !os.IsNotExist(err) {
+		t.Errorf("/etc/hosts should be suppressed on host-network cells; stat err = %v", err)
+	}
+}

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1423,6 +1423,15 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 	// so it's safe to read here. See issue #312.
 	cellCgroupPath := cell.Status.CgroupPath
 
+	// Per-cell /etc/hostname and initial /etc/hosts (no IP yet — CNI ADD runs
+	// during StartCell and rewrites /etc/hosts with the assigned cell IP).
+	// Files must exist before runc consumes the OCI bind-mount entries below,
+	// so render them up front. Issue #345.
+	if err := r.renderCellEtcFilesPreCNI(cell); err != nil {
+		return nil, fmt.Errorf("render cell etc files: %w", err)
+	}
+	r.stampCellEtcFilePathsOnContainers(cell)
+
 	// Track root container for return value
 	var rootContainer containerd.Container
 
@@ -1742,6 +1751,19 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 			cell.Spec.RootContainerID = rootContainerBaseID
 		}
 
+		// Per-cell /etc/hostname and initial /etc/hosts (issue #345). Render
+		// before BuildRootContainerSpec so the bind-mount sources exist when
+		// runc creates the root container, and stamp the source paths onto
+		// rootContainerSpec so the OCI spec emits the bind-mount entries.
+		// The cell-wide stamp (after the if/else below) reaches non-root
+		// containers; the root needs the per-spec stamp because the local
+		// rootContainerSpec value is what feeds BuildRootContainerSpec here.
+		if etcErr := r.renderCellEtcFilesPreCNI(cell); etcErr != nil {
+			return nil, fmt.Errorf("render cell etc files: %w", etcErr)
+		}
+		hnPath, hPath, suppress := r.cellEtcFilePaths(cell)
+		stampEtcFilePathsOnContainerSpec(&rootContainerSpec, hnPath, hPath, suppress)
+
 		rootLabels := buildRootContainerLabels(*cell)
 		containerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
 
@@ -1776,6 +1798,17 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 			ensuredFields...,
 		)
 	}
+
+	// Per-cell /etc/hostname / /etc/hosts: ensure the source files exist and
+	// every non-root container in cell.Spec.Containers carries the bind-mount
+	// path before the loop below builds OCI specs. Idempotent on the
+	// existing-root branch (re-renders the same content) and a fill-in for
+	// the no-root branch where the root spec was just stamped above. Issue
+	// #345.
+	if etcErr := r.renderCellEtcFilesPreCNI(cell); etcErr != nil {
+		return nil, fmt.Errorf("render cell etc files: %w", etcErr)
+	}
+	r.stampCellEtcFilePathsOnContainers(cell)
 
 	// Log how many containers we're about to process
 	containerCountFields := appendCellLogFields([]any{"cell", cellID}, cellID, cellName)

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1801,12 +1801,14 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 
 	// Per-cell /etc/hostname / /etc/hosts: ensure the source files exist and
 	// every non-root container in cell.Spec.Containers carries the bind-mount
-	// path before the loop below builds OCI specs. Idempotent on the
-	// existing-root branch (re-renders the same content) and a fill-in for
-	// the no-root branch where the root spec was just stamped above. Issue
-	// #345.
-	if etcErr := r.renderCellEtcFilesPreCNI(cell); etcErr != nil {
-		return nil, fmt.Errorf("render cell etc files: %w", etcErr)
+	// path before the loop below builds OCI specs. On the existing-root
+	// branch the cell IP may already be rendered into /etc/hosts by a prior
+	// StartCell; use the existence-only helper so update_cell /
+	// update_container ticks don't truncate the IP line back to localhost-
+	// only. The no-root branch's pre-CNI render above remains the source of
+	// content for fresh cells. Issue #345.
+	if etcErr := r.ensureCellEtcFilesExistPreCNI(cell); etcErr != nil {
+		return nil, fmt.Errorf("ensure cell etc files: %w", etcErr)
 	}
 	r.stampCellEtcFilePathsOnContainers(cell)
 

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -19,6 +19,7 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -327,6 +328,19 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		rootContainerSpec.CellCgroupPath = internalCell.Status.CgroupPath
 	}
 
+	// Per-cell /etc/hostname / initial /etc/hosts — render before the root's
+	// OCI spec is built so the bind-mount sources exist when runc consumes
+	// them, and stamp source paths onto rootContainerSpec so the OCI spec
+	// emits the bind-mount entries (issue #345). The cell-wide stamp below
+	// the CNI-attach block reaches non-root containers; the root needs the
+	// per-spec stamp because the local rootContainerSpec value is what feeds
+	// BuildRootContainerSpec on this fresh-recreate path.
+	if etcErr := r.renderCellEtcFilesPreCNI(&internalCell); etcErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("render cell etc files: %w", etcErr)
+	}
+	hnPath, hPath, suppressHosts := r.cellEtcFilePaths(&internalCell)
+	stampEtcFilePathsOnContainerSpec(&rootContainerSpec, hnPath, hPath, suppressHosts)
+
 	rootLabels := buildRootContainerLabels(internalCell)
 	ctrContainerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
 
@@ -373,6 +387,12 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		IPC: fmt.Sprintf("/proc/%d/ns/ipc", rootPID),
 		UTS: fmt.Sprintf("/proc/%d/ns/uts", rootPID),
 	}
+
+	// CNI ADD's IPv4 result, if any. Captured here so the post-attach
+	// /etc/hosts re-render below can read it after the if/else block. nil
+	// for host-network cells (CNI skipped) and on the idempotent-skip path
+	// when the libcni cache lookup also fails. Issue #345.
+	var cellIP net.IP
 
 	// Host-netns root containers (e.g. kukeond) have no per-container veth to
 	// wire up — CNI attach would create a host-side bridge inside the daemon's
@@ -455,7 +475,9 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		}
 
 		netnsPath := namespacePaths.Net
-		if addErr := cniMgr.AddContainerToNetwork(r.ctx, containerID, netnsPath); addErr != nil {
+		var addErr error
+		cellIP, addErr = cniMgr.AddContainerToNetwork(r.ctx, containerID, netnsPath)
+		if addErr != nil {
 			// The bridge plugin's "container veth name … already exists" is
 			// the one genuinely idempotent failure — a prior ADD reached veth
 			// setup before crashing, so eth0 and its IPAM record are intact
@@ -487,6 +509,13 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 					"root container already attached to network, skipping CNI ADD",
 					fields...,
 				)
+				// Idempotent-skip path: the CNI ADD didn't run, so no fresh
+				// result was returned. The IPAM allocation persisted in the
+				// libcni cache from the prior successful run — recover it so
+				// /etc/hosts can still carry the cell IP. Issue #345.
+				if cellIP == nil {
+					cellIP = cniMgr.CachedIPv4ForContainer(containerID, netnsPath)
+				}
 			} else {
 				// Log the actual CNI bin dir value being used (may be empty, which causes the error)
 				// Note: NewManager creates CNI config with this value BEFORE applying defaults,
@@ -532,6 +561,28 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		"started root container",
 		infoFields...,
 	)
+
+	// Re-render the cell's /etc/hosts now that CNI assigned the cell IP. The
+	// container's bind-mount points to this file's inode, so an in-place
+	// rewrite (truncate + write) propagates the new content to the running
+	// root container without a remount. cellIP is nil for host-network cells
+	// or if the IPAM cache was unreadable on the idempotent-skip path; the
+	// renderer no-ops in either case. Stamp source paths onto every non-root
+	// containerSpec next so the bind-mount entries make it onto their OCI
+	// specs as the loop below recreates them. Issue #345.
+	if cellIP != nil {
+		if etcErr := r.renderCellEtcHostsWithIP(&internalCell, cellIP); etcErr != nil {
+			r.logger.WarnContext(r.ctx,
+				"failed to re-render cell /etc/hosts with cell IP",
+				"cell", cellName, "cellIP", cellIP.String(), "err", etcErr.Error())
+			// best-effort — non-fatal: pre-CNI render already produced a
+			// valid file with the localhost block, which is enough for
+			// non-self-resolution use cases. Surface as a warning so it's
+			// visible without breaking StartCell.
+		}
+	}
+	r.stampCellEtcFilePathsOnContainers(&internalCell)
+	cellSpec = internalCell.Spec
 
 	// Start all containers defined in the CellDoc
 	for _, containerSpec := range cellSpec.Containers {

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -83,8 +83,27 @@ func BuildRootContainerSpec(
 		oci.WithDefaultPathEnv,
 	}
 
-	if containerdID != "" {
-		specOpts = append(specOpts, oci.WithHostname(containerdID))
+	// Hostname identifies the cell, not the hierarchical containerd ID. All
+	// containers in the cell share this root's UTS namespace via
+	// JoinContainerNamespaces, so the cell-name hostname is what `hostname`
+	// returns for every container. Falls back to the containerd ID only when
+	// the runner failed to populate CellName (defensive — every CreateCell /
+	// StartCell path stamps it). Issue #345.
+	hostname := strings.TrimSpace(rootSpec.CellName)
+	if hostname == "" {
+		hostname = containerdID
+	}
+	if hostname != "" {
+		specOpts = append(specOpts, oci.WithHostname(hostname))
+	}
+
+	// Per-cell /etc/hostname and /etc/hosts bind-mounts (issue #345). The
+	// runner renders both files under the cell's metadata directory before
+	// invoking this builder; an empty path here means the bind-mount is
+	// disabled (e.g. host-network root containers like kukeond, where the
+	// host's /etc/hosts is the right view).
+	if mounts := etcFileBindMounts(rootSpec.EtcHostsPath, rootSpec.EtcHostnamePath); len(mounts) > 0 {
+		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
 
 	if processArgs := buildRootProcessArgs(rootSpec); len(processArgs) > 0 {

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -224,9 +224,17 @@ func BuildContainerSpec(
 		oci.WithDefaultPathEnv,
 	}
 
-	// Set hostname to containerd ID if not empty
-	if containerdID != "" {
-		specOpts = append(specOpts, oci.WithHostname(containerdID))
+	// Hostname is set on the root container only; non-root containers inherit
+	// it via the shared UTS namespace established by JoinContainerNamespaces.
+	// See BuildRootContainerSpec for the WithHostname call site (issue #345).
+
+	// Per-cell /etc/hostname and /etc/hosts bind-mounts (issue #345). The host
+	// source files are rendered by the runner under the cell's metadata
+	// directory and reflect the cell name (and, for /etc/hosts, the CNI-
+	// assigned cell IP) so tools that resolve the container's own hostname
+	// (sudo, getent) work without timing out on DNS.
+	if mounts := etcFileBindMounts(containerSpec.EtcHostsPath, containerSpec.EtcHostnamePath); len(mounts) > 0 {
+		specOpts = append(specOpts, oci.WithMounts(mounts))
 	}
 
 	// Set command and args
@@ -333,6 +341,33 @@ func BuildContainerSpec(
 		SpecOpts:      specOpts,
 		CNIConfigPath: containerSpec.CNIConfigPath,
 	}
+}
+
+// etcFileBindMounts returns OCI bind-mount entries for the per-cell
+// /etc/hosts and /etc/hostname files, skipping each entry whose host source
+// path is empty. Both files are bind-mounted read-only because containers
+// have no business mutating identity files the runtime owns; the runner
+// re-renders the source on every cell start so updated content propagates
+// through the bind without remounting (issue #345).
+func etcFileBindMounts(hostsPath, hostnamePath string) []runtimespec.Mount {
+	var mounts []runtimespec.Mount
+	if hostsPath != "" {
+		mounts = append(mounts, runtimespec.Mount{
+			Destination: "/etc/hosts",
+			Source:      hostsPath,
+			Type:        "bind",
+			Options:     []string{"rbind", "ro"},
+		})
+	}
+	if hostnamePath != "" {
+		mounts = append(mounts, runtimespec.Mount{
+			Destination: "/etc/hostname",
+			Source:      hostnamePath,
+			Type:        "bind",
+			Options:     []string{"rbind", "ro"},
+		})
+	}
+	return mounts
 }
 
 // nestedCgroupMount returns the OCI Mount entry that exposes the cell's

--- a/internal/ctr/spec_test.go
+++ b/internal/ctr/spec_test.go
@@ -1013,6 +1013,283 @@ func TestBuildRootContainerSpec_CgroupsPath(t *testing.T) {
 	}
 }
 
+// TestBuildRootContainerSpec_Hostname pins the hostname-on-root contract
+// from issue #345: the cell's root container's UTS hostname must be the
+// cell name (so `hostname` returns `kuke-app` instead of the hierarchical
+// containerd id `default_default_kuke-app_root`), and a missing CellName
+// falls back defensively to the containerd id so a misrouted spec still
+// produces a usable hostname instead of an empty one. All non-root
+// containers in the cell join this UTS namespace and inherit the value.
+func TestBuildRootContainerSpec_Hostname(t *testing.T) {
+	tests := []struct {
+		name         string
+		cellName     string
+		containerdID string
+		wantHostname string
+	}{
+		{name: "cell name sets hostname", cellName: "kuke-app", containerdID: "s_st_kuke-app_root", wantHostname: "kuke-app"},
+		{name: "empty cell name falls back to containerd id", cellName: "", containerdID: "s_st_kuke-app_root", wantHostname: "s_st_kuke-app_root"},
+		{name: "whitespace cell name treated as empty", cellName: "   ", containerdID: "s_st_kuke-app_root", wantHostname: "s_st_kuke-app_root"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ctr.BuildRootContainerSpec(intmodel.ContainerSpec{
+				ID:           "root",
+				ContainerdID: tt.containerdID,
+				Image:        "registry.eminwux.com/busybox:latest",
+				CellName:     tt.cellName,
+			}, nil)
+
+			ociSpec := &runtimespec.Spec{
+				Process: &runtimespec.Process{},
+				Linux:   &runtimespec.Linux{},
+			}
+			for _, opt := range spec.SpecOpts {
+				if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+					t.Fatalf("apply SpecOpts: %v", err)
+				}
+			}
+
+			if ociSpec.Hostname != tt.wantHostname {
+				t.Errorf("Hostname = %q, want %q", ociSpec.Hostname, tt.wantHostname)
+			}
+		})
+	}
+}
+
+// TestBuildContainerSpec_NoHostname pins the inverse half of issue #345:
+// non-root containers must not call oci.WithHostname. They share the root's
+// UTS namespace via JoinContainerNamespaces, so any hostname set on the
+// per-container spec would be overwritten at run-time anyway — but worse,
+// containerd persists the spec's Hostname in the on-disk container metadata
+// and a stray non-empty value there confuses tooling that inspects it. The
+// test asserts ociSpec.Hostname is whatever the prebuilt spec started with
+// (empty in this fixture), regardless of the model spec's identity fields.
+func TestBuildContainerSpec_NoHostname(t *testing.T) {
+	spec := ctr.BuildContainerSpec(intmodel.ContainerSpec{
+		ID:           "user-app",
+		ContainerdID: "s_st_kuke-app_user-app",
+		Image:        "registry.eminwux.com/busybox:latest",
+		CellName:     "kuke-app",
+		SpaceName:    "s",
+		RealmName:    "r",
+		StackName:    "st",
+	})
+
+	ociSpec := &runtimespec.Spec{
+		Process: &runtimespec.Process{},
+		Linux:   &runtimespec.Linux{},
+	}
+	for _, opt := range spec.SpecOpts {
+		if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+			t.Fatalf("apply SpecOpts: %v", err)
+		}
+	}
+
+	if ociSpec.Hostname != "" {
+		t.Errorf("Hostname = %q, want empty (non-root must not set hostname)", ociSpec.Hostname)
+	}
+}
+
+// TestBuildContainerSpec_EtcFileBindMounts pins the bind-mount half of issue
+// #345: when EtcHostsPath / EtcHostnamePath are stamped on the model spec,
+// BuildContainerSpec must emit two bind entries (Destination /etc/hosts and
+// /etc/hostname), each pointing at the supplied host source path with rbind
+// + ro options. Empty paths must produce no entry — that path is the host-
+// network carve-out where the host's /etc/hosts is the right view.
+func TestBuildContainerSpec_EtcFileBindMounts(t *testing.T) {
+	tests := []struct {
+		name            string
+		hostsPath       string
+		hostnamePath    string
+		wantHosts       bool
+		wantHostname    bool
+		wantHostsSrc    string
+		wantHostnameSrc string
+	}{
+		{
+			name:            "both paths set emits both bind mounts",
+			hostsPath:       "/run/kukeon/r/s/st/c/etc-hosts",
+			hostnamePath:    "/run/kukeon/r/s/st/c/etc-hostname",
+			wantHosts:       true,
+			wantHostname:    true,
+			wantHostsSrc:    "/run/kukeon/r/s/st/c/etc-hosts",
+			wantHostnameSrc: "/run/kukeon/r/s/st/c/etc-hostname",
+		},
+		{
+			name:            "only hostname path set emits hostname mount only",
+			hostsPath:       "",
+			hostnamePath:    "/run/kukeon/r/s/st/c/etc-hostname",
+			wantHosts:       false,
+			wantHostname:    true,
+			wantHostnameSrc: "/run/kukeon/r/s/st/c/etc-hostname",
+		},
+		{
+			name:         "both paths empty emits no etc bind mounts",
+			hostsPath:    "",
+			hostnamePath: "",
+			wantHosts:    false,
+			wantHostname: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ctr.BuildContainerSpec(intmodel.ContainerSpec{
+				ID:              "user-app",
+				ContainerdID:    "s_st_c_user-app",
+				Image:           "registry.eminwux.com/busybox:latest",
+				EtcHostsPath:    tt.hostsPath,
+				EtcHostnamePath: tt.hostnamePath,
+				CellName:        "c", SpaceName: "s", RealmName: "r", StackName: "st",
+			})
+
+			ociSpec := &runtimespec.Spec{
+				Process: &runtimespec.Process{},
+				Linux:   &runtimespec.Linux{},
+			}
+			for _, opt := range spec.SpecOpts {
+				if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+					t.Fatalf("apply SpecOpts: %v", err)
+				}
+			}
+
+			assertEtcBindMounts(t, ociSpec.Mounts, tt.wantHosts, tt.wantHostname,
+				tt.wantHostsSrc, tt.wantHostnameSrc)
+		})
+	}
+}
+
+// TestBuildRootContainerSpec_EtcFileBindMounts mirrors the non-root test for
+// the root-container builder. The runner stamps the same host source paths
+// on the root spec; a regression in either builder would partially break the
+// cell — the root and its siblings would disagree on what `/etc/hosts`
+// resolves to.
+func TestBuildRootContainerSpec_EtcFileBindMounts(t *testing.T) {
+	tests := []struct {
+		name            string
+		hostsPath       string
+		hostnamePath    string
+		wantHosts       bool
+		wantHostname    bool
+		wantHostsSrc    string
+		wantHostnameSrc string
+	}{
+		{
+			name:            "both paths set emits both bind mounts",
+			hostsPath:       "/run/kukeon/r/s/st/c/etc-hosts",
+			hostnamePath:    "/run/kukeon/r/s/st/c/etc-hostname",
+			wantHosts:       true,
+			wantHostname:    true,
+			wantHostsSrc:    "/run/kukeon/r/s/st/c/etc-hosts",
+			wantHostnameSrc: "/run/kukeon/r/s/st/c/etc-hostname",
+		},
+		{
+			name:            "host-network root keeps hostname mount only",
+			hostsPath:       "",
+			hostnamePath:    "/run/kukeon/r/s/st/c/etc-hostname",
+			wantHosts:       false,
+			wantHostname:    true,
+			wantHostnameSrc: "/run/kukeon/r/s/st/c/etc-hostname",
+		},
+		{
+			name:         "both paths empty emits no etc bind mounts",
+			hostsPath:    "",
+			hostnamePath: "",
+			wantHosts:    false,
+			wantHostname: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ctr.BuildRootContainerSpec(intmodel.ContainerSpec{
+				ID:              "root",
+				ContainerdID:    "s_st_c_root",
+				Image:           "registry.eminwux.com/busybox:latest",
+				CellName:        "c",
+				EtcHostsPath:    tt.hostsPath,
+				EtcHostnamePath: tt.hostnamePath,
+			}, nil)
+
+			ociSpec := &runtimespec.Spec{
+				Process: &runtimespec.Process{},
+				Linux:   &runtimespec.Linux{},
+			}
+			for _, opt := range spec.SpecOpts {
+				if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+					t.Fatalf("apply SpecOpts: %v", err)
+				}
+			}
+
+			assertEtcBindMounts(t, ociSpec.Mounts, tt.wantHosts, tt.wantHostname,
+				tt.wantHostsSrc, tt.wantHostnameSrc)
+		})
+	}
+}
+
+// assertEtcBindMounts verifies that the given OCI Mounts slice contains (or
+// omits) /etc/hosts and /etc/hostname bind entries with the expected source
+// paths and rbind/ro options.
+func assertEtcBindMounts(
+	t *testing.T,
+	mounts []runtimespec.Mount,
+	wantHosts, wantHostname bool,
+	wantHostsSrc, wantHostnameSrc string,
+) {
+	t.Helper()
+	var hostsM, hostnameM *runtimespec.Mount
+	for i := range mounts {
+		switch mounts[i].Destination {
+		case "/etc/hosts":
+			hostsM = &mounts[i]
+		case "/etc/hostname":
+			hostnameM = &mounts[i]
+		}
+	}
+
+	if wantHosts {
+		if hostsM == nil {
+			t.Fatalf("/etc/hosts bind mount missing; mounts=%+v", mounts)
+		}
+		if hostsM.Source != wantHostsSrc {
+			t.Errorf("/etc/hosts source = %q, want %q", hostsM.Source, wantHostsSrc)
+		}
+		if hostsM.Type != "bind" {
+			t.Errorf("/etc/hosts type = %q, want %q", hostsM.Type, "bind")
+		}
+		if !containsString(hostsM.Options, "rbind") {
+			t.Errorf("/etc/hosts options = %v, want contains rbind", hostsM.Options)
+		}
+		if !containsString(hostsM.Options, "ro") {
+			t.Errorf("/etc/hosts options = %v, want contains ro", hostsM.Options)
+		}
+	} else if hostsM != nil {
+		t.Errorf("unexpected /etc/hosts bind mount: %+v", *hostsM)
+	}
+
+	if wantHostname {
+		if hostnameM == nil {
+			t.Fatalf("/etc/hostname bind mount missing; mounts=%+v", mounts)
+		}
+		if hostnameM.Source != wantHostnameSrc {
+			t.Errorf("/etc/hostname source = %q, want %q", hostnameM.Source, wantHostnameSrc)
+		}
+		if hostnameM.Type != "bind" {
+			t.Errorf("/etc/hostname type = %q, want %q", hostnameM.Type, "bind")
+		}
+		if !containsString(hostnameM.Options, "rbind") {
+			t.Errorf("/etc/hostname options = %v, want contains rbind", hostnameM.Options)
+		}
+		if !containsString(hostnameM.Options, "ro") {
+			t.Errorf("/etc/hostname options = %v, want contains ro", hostnameM.Options)
+		}
+	} else if hostnameM != nil {
+		t.Errorf("unexpected /etc/hostname bind mount: %+v", *hostnameM)
+	}
+}
+
 // TestBuildRootContainerSpec_HostNetwork is the same assertion as
 // TestBuildContainerSpec_HostNetwork but for the root-container builder used
 // by the runner for the kukeond cell.

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -78,6 +78,18 @@ type ContainerSpec struct {
 	// containerd's runc-shim default placement. Populated by the runner at
 	// container-create time; not part of the persisted cell document.
 	CellCgroupPath string
+	// EtcHostsPath is the host-side path of a kukeond-rendered /etc/hosts file
+	// to bind-mount at /etc/hosts inside the container. Empty disables the
+	// bind-mount, leaving the image's /etc/hosts in place. Mirrors Docker's
+	// per-container hosts pattern; the source file lives under the cell's
+	// metadata directory so cell teardown cleans it up. Populated by the
+	// runner at container-create time; not part of the persisted document.
+	EtcHostsPath string
+	// EtcHostnamePath is the host-side path of a kukeond-rendered /etc/hostname
+	// file (cell name) to bind-mount at /etc/hostname inside the container.
+	// Empty disables the bind-mount. Same lifecycle and storage location as
+	// EtcHostsPath; not part of the persisted document.
+	EtcHostnamePath string
 }
 
 // ContainerTty mirrors the v1beta1 ContainerTty payload. See the v1beta1

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -80,6 +80,26 @@ func CellMetadataPath(baseRunPath, realmName, spaceName, stackName, cellName str
 	)
 }
 
+// CellEtcHostsPath returns the host-side path of the per-cell /etc/hosts file
+// kukeond renders and bind-mounts into every container in the cell. Lives
+// under the cell's metadata directory so cell teardown cleans it up.
+func CellEtcHostsPath(baseRunPath, realmName, spaceName, stackName, cellName string) string {
+	return filepath.Join(
+		CellMetadataDir(baseRunPath, realmName, spaceName, stackName, cellName),
+		"etc-hosts",
+	)
+}
+
+// CellEtcHostnamePath returns the host-side path of the per-cell /etc/hostname
+// file kukeond renders and bind-mounts into every container in the cell.
+// Lives under the cell's metadata directory so cell teardown cleans it up.
+func CellEtcHostnamePath(baseRunPath, realmName, spaceName, stackName, cellName string) string {
+	return filepath.Join(
+		CellMetadataDir(baseRunPath, realmName, spaceName, stackName, cellName),
+		"etc-hostname",
+	)
+}
+
 // ContainerMetadataDir returns the per-container metadata directory inside the
 // owning cell's metadata tree. Used as the host anchor for per-container state
 // such as the sbsh control socket.


### PR DESCRIPTION
## Summary
- Replace the hierarchical containerd id with the cell name as the OCI hostname on the cell's root container, drop the redundant `oci.WithHostname` on every other container so they inherit the value through the shared UTS namespace, and bind-mount per-cell `/etc/hostname` and `/etc/hosts` files into every container so identity-resolving tools (`sudo`, `getent hosts`, `hostname -s`) see the same value the kernel does. Fixes the `sudo: unable to resolve host …` warnings and the multi-second DNS-lookup timeouts inside kuke-system pods.
- The host source files live under each cell's metadata directory at `<runPath>/<realm>/<space>/<stack>/<cell>/{etc-hostname,etc-hosts}` so cell teardown cleans them up. `/etc/hostname` is rendered at cell create-time (no IP needed); `/etc/hosts` is rendered with the localhost block before CNI ADD and re-rendered with the CNI-assigned cell IP after `AddContainerToNetwork` succeeds. The same paths are stamped on every container in the cell so root and non-root agree on the file inode, and the `/etc/hosts` mount is suppressed for `HostNetwork=true` roots (the kukeond carve-out where the host's `/etc/hosts` is the right view).
- `cni.Manager.AddContainerToNetwork` now returns the first IPv4 from the CNI result so the runner can populate the IP line, and a sibling `CachedIPv4ForContainer` reads `libcni`'s IPAM cache for the `ErrCNIVethExists` idempotency path on cell restart.
- Fix-up `cab2aaa`: the second `renderCellEtcFilesPreCNI` call in `ensureCellContainers` (provision.go:1808) was clobbering `/etc/hosts` on every `update_cell`/`update_container` tick of a running cell — the pre-CNI render truncates the file back to the localhost-only block, dropping the cell-IP line that the post-CNI render had written. Replaced with a new `ensureCellEtcFilesExistPreCNI` helper that fills in missing files but never rewrites existing content; the no-root branch's first-creation render is unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full project test suite)
- [x] `internal/ctr` unit tests cover the new contract: hostname is the cell name on root, falls back to containerd-id when CellName is empty, non-root never sets `oci.WithHostname`, and `/etc/hosts` + `/etc/hostname` bind-mount entries appear with `rbind,ro` when `EtcHostsPath`/`EtcHostnamePath` are stamped on the model spec
- [x] `internal/controller/runner/cell_etc_files_test.go` — regression guard for the fix-up: `ensureCellEtcFilesExistPreCNI` preserves an existing `/etc/hosts` that already carries the cell-IP line, fills in missing files when absent, and skips `/etc/hosts` on host-network cells while still producing `/etc/hostname`
- [ ] `make dev-init` smoke test — deferred to reviewer/user's docker-capable host. Dev host has the docker CLI but no running docker daemon (`docker ps` → "dial unix /var/run/docker.sock: connect: no such file or directory"), so the `docker build` phase of `scripts/dev-init.sh` cannot run. The fix-up is also covered by the new unit test above and by the existing `internal/ctr` tests for the bind-mount contract.

Closes #345