### PR TITLE
feat: expose KUKEON_* identity env vars to container processes

### DIFF
--- a/internal/controller/runner/cell_profile_stamp.go
+++ b/internal/controller/runner/cell_profile_stamp.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"github.com/eminwux/kukeon/internal/cellprofile"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// stampCellProfileNameOnContainers fills CellProfileName on every container
+// in the cell from cell.Metadata.Labels[cellprofile.LabelProfile] (the label
+// Materialize stamps when a cell is generated from a CellProfile). No-op when
+// the label is absent — cells created from a plain CellDoc carry no profile
+// identity. Mirrors the runtime-only stamping shape of
+// stampCellEtcFilePathsOnContainers / CellCgroupPath: BuildContainerSpec /
+// BuildRootContainerSpec read the field, but it is not part of the persisted
+// container document. Issue #351.
+func stampCellProfileNameOnContainers(cell *intmodel.Cell) {
+	if cell == nil {
+		return
+	}
+	name := cellProfileNameFromCell(cell)
+	if name == "" {
+		return
+	}
+	for i := range cell.Spec.Containers {
+		if cell.Spec.Containers[i].CellProfileName == "" {
+			cell.Spec.Containers[i].CellProfileName = name
+		}
+	}
+}
+
+// stampCellProfileNameOnContainerSpec is the per-container counterpart for
+// call sites that hold a local container spec value (e.g. the root spec
+// built fresh by ensureCellRootContainerSpec on the StartCell recreate path)
+// and need it to carry the same CellProfileName the cell-wide stamp would
+// apply. No-op when the cell carries no profile label.
+func stampCellProfileNameOnContainerSpec(spec *intmodel.ContainerSpec, cell *intmodel.Cell) {
+	if spec == nil || spec.CellProfileName != "" {
+		return
+	}
+	spec.CellProfileName = cellProfileNameFromCell(cell)
+}
+
+func cellProfileNameFromCell(cell *intmodel.Cell) string {
+	if cell == nil || cell.Metadata.Labels == nil {
+		return ""
+	}
+	return cell.Metadata.Labels[cellprofile.LabelProfile]
+}

--- a/internal/controller/runner/cell_profile_stamp_test.go
+++ b/internal/controller/runner/cell_profile_stamp_test.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cellprofile"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestStampCellProfileNameOnContainers asserts the helper copies the
+// cell's kukeon.io/profile label into every container's CellProfileName
+// while leaving already-populated entries alone (the stamp is idempotent
+// across repeat runs from the same cell).
+func TestStampCellProfileNameOnContainers(t *testing.T) {
+	cell := &intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name:   "kukeon-pr-a4aaab",
+			Labels: map[string]string{cellprofile.LabelProfile: "kukeon-pr"},
+		},
+		Spec: intmodel.CellSpec{
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root"},
+				{ID: "work"},
+				{ID: "preset", CellProfileName: "preset-value"},
+			},
+		},
+	}
+
+	stampCellProfileNameOnContainers(cell)
+
+	if got := cell.Spec.Containers[0].CellProfileName; got != "kukeon-pr" {
+		t.Errorf("Containers[root].CellProfileName = %q, want %q", got, "kukeon-pr")
+	}
+	if got := cell.Spec.Containers[1].CellProfileName; got != "kukeon-pr" {
+		t.Errorf("Containers[work].CellProfileName = %q, want %q", got, "kukeon-pr")
+	}
+	if got := cell.Spec.Containers[2].CellProfileName; got != "preset-value" {
+		t.Errorf(
+			"Containers[preset].CellProfileName = %q, want %q (preset value should not be overwritten)",
+			got,
+			"preset-value",
+		)
+	}
+}
+
+// TestStampCellProfileNameOnContainers_NoLabel verifies that cells created
+// from a plain CellDoc (no profile label) leave CellProfileName empty so
+// kukeonDefaultEnv emits no KUKEON_CELL_PROFILE_NAME entry.
+func TestStampCellProfileNameOnContainers_NoLabel(t *testing.T) {
+	cell := &intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "plain-cell"},
+		Spec: intmodel.CellSpec{
+			Containers: []intmodel.ContainerSpec{{ID: "work"}},
+		},
+	}
+
+	stampCellProfileNameOnContainers(cell)
+
+	if got := cell.Spec.Containers[0].CellProfileName; got != "" {
+		t.Errorf("Containers[work].CellProfileName = %q, want empty (no profile label on cell)", got)
+	}
+}
+
+// TestStampCellProfileNameOnContainers_NilSafe locks in the nil-cell
+// guard — every runtime-injection helper in the runner is called on
+// possibly-nil cells in error paths.
+func TestStampCellProfileNameOnContainers_NilSafe(_ *testing.T) {
+	stampCellProfileNameOnContainers(nil) // must not panic
+}
+
+// TestStampCellProfileNameOnContainerSpec covers the per-container
+// counterpart used by the StartCell-recreate paths that hold a local root
+// container spec.
+func TestStampCellProfileNameOnContainerSpec(t *testing.T) {
+	cell := &intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Labels: map[string]string{cellprofile.LabelProfile: "kukeon-pr"},
+		},
+	}
+	root := &intmodel.ContainerSpec{ID: "root"}
+	stampCellProfileNameOnContainerSpec(root, cell)
+	if root.CellProfileName != "kukeon-pr" {
+		t.Errorf("rootSpec.CellProfileName = %q, want %q", root.CellProfileName, "kukeon-pr")
+	}
+
+	preset := &intmodel.ContainerSpec{ID: "root", CellProfileName: "preset"}
+	stampCellProfileNameOnContainerSpec(preset, cell)
+	if preset.CellProfileName != "preset" {
+		t.Errorf("preset spec was overwritten: %q, want %q", preset.CellProfileName, "preset")
+	}
+
+	// Nil cell or nil spec: must be a no-op.
+	stampCellProfileNameOnContainerSpec(nil, cell)
+	stampCellProfileNameOnContainerSpec(&intmodel.ContainerSpec{}, nil)
+}

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1431,6 +1431,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, fmt.Errorf("render cell etc files: %w", err)
 	}
 	r.stampCellEtcFilePathsOnContainers(cell)
+	stampCellProfileNameOnContainers(cell)
 
 	// Track root container for return value
 	var rootContainer containerd.Container
@@ -1763,6 +1764,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		}
 		hnPath, hPath, suppress := r.cellEtcFilePaths(cell)
 		stampEtcFilePathsOnContainerSpec(&rootContainerSpec, hnPath, hPath, suppress)
+		stampCellProfileNameOnContainerSpec(&rootContainerSpec, cell)
 
 		rootLabels := buildRootContainerLabels(*cell)
 		containerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
@@ -1811,6 +1813,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, fmt.Errorf("ensure cell etc files: %w", etcErr)
 	}
 	r.stampCellEtcFilePathsOnContainers(cell)
+	stampCellProfileNameOnContainers(cell)
 
 	// Log how many containers we're about to process
 	containerCountFields := appendCellLogFields([]any{"cell", cellID}, cellID, cellName)

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -340,6 +340,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	}
 	hnPath, hPath, suppressHosts := r.cellEtcFilePaths(&internalCell)
 	stampEtcFilePathsOnContainerSpec(&rootContainerSpec, hnPath, hPath, suppressHosts)
+	stampCellProfileNameOnContainerSpec(&rootContainerSpec, &internalCell)
 
 	rootLabels := buildRootContainerLabels(internalCell)
 	ctrContainerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels)
@@ -582,6 +583,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		}
 	}
 	r.stampCellEtcFilePathsOnContainers(&internalCell)
+	stampCellProfileNameOnContainers(&internalCell)
 	cellSpec = internalCell.Spec
 
 	// Start all containers defined in the CellDoc

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -114,8 +114,11 @@ func BuildRootContainerSpec(
 		specOpts = append(specOpts, oci.WithProcessCwd(rootSpec.WorkingDir))
 	}
 
-	if len(rootSpec.Env) > 0 {
-		specOpts = append(specOpts, oci.WithEnv(rootSpec.Env))
+	// KUKEON_* identity vars (issue #351) are merged with the user-supplied
+	// rootSpec.Env on the same rules as BuildContainerSpec: user entries win
+	// on key collisions, empty cell-context fields contribute nothing.
+	if env := kukeonContainerEnv(rootSpec); len(env) > 0 {
+		specOpts = append(specOpts, oci.WithEnv(env))
 	}
 
 	if rootSpec.Privileged {

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -255,9 +255,12 @@ func BuildContainerSpec(
 		specOpts = append(specOpts, oci.WithProcessCwd(containerSpec.WorkingDir))
 	}
 
-	// Set environment variables
-	if len(containerSpec.Env) > 0 {
-		specOpts = append(specOpts, oci.WithEnv(containerSpec.Env))
+	// Set environment variables. KUKEON_* identity vars (issue #351) are
+	// merged with the user-supplied containerSpec.Env, with user entries
+	// taking precedence on key collisions so an explicit override in a
+	// CellProfile still wins.
+	if env := kukeonContainerEnv(containerSpec); len(env) > 0 {
+		specOpts = append(specOpts, oci.WithEnv(env))
 	}
 
 	// Set privileged mode if specified
@@ -383,6 +386,66 @@ func nestedCgroupMount() runtimespec.Mount {
 		Type:        "cgroup",
 		Options:     []string{"rw", "nosuid", "noexec", "nodev"},
 	}
+}
+
+// kukeonContainerEnv builds the final container env: a set of KUKEON_*
+// identity vars derived from the container spec's cell-context fields,
+// merged with the user-supplied spec.Env. User entries override defaults on
+// key collisions; empty cell-context fields produce no entry. Order in the
+// returned slice is: surviving defaults in canonical order, then user
+// entries in their declared order. The merge is done here (rather than
+// trusting oci.WithEnv) because containerd's replaceOrAppendEnvValues
+// dedupes only against keys already present in spec.Process.Env when WithEnv
+// runs, so two entries with the same key inside a single overrides slice
+// would both end up in the final env. Issue #351.
+func kukeonContainerEnv(spec intmodel.ContainerSpec) []string {
+	defaults := kukeonDefaultEnv(spec)
+	switch {
+	case len(spec.Env) == 0:
+		return defaults
+	case len(defaults) == 0:
+		return spec.Env
+	}
+	userKeys := make(map[string]struct{}, len(spec.Env))
+	for _, kv := range spec.Env {
+		k, _, _ := strings.Cut(kv, "=")
+		userKeys[k] = struct{}{}
+	}
+	out := make([]string, 0, len(defaults)+len(spec.Env))
+	for _, kv := range defaults {
+		k, _, _ := strings.Cut(kv, "=")
+		if _, ok := userKeys[k]; ok {
+			continue
+		}
+		out = append(out, kv)
+	}
+	out = append(out, spec.Env...)
+	return out
+}
+
+// kukeonDefaultEnv returns the KUKEON_* identity entries that describe the
+// container's cell context. Each field contributes one entry only when set;
+// the order is profile → cell → container ID → realm/space/stack →
+// cgroup-path so `env | grep KUKEON_` reads top-down from the broadest
+// identity to the narrowest. Issue #351.
+func kukeonDefaultEnv(spec intmodel.ContainerSpec) []string {
+	pairs := []struct{ key, value string }{
+		{"KUKEON_CELL_PROFILE_NAME", spec.CellProfileName},
+		{"KUKEON_CELL_NAME", spec.CellName},
+		{"KUKEON_CONTAINER_ID", spec.ID},
+		{"KUKEON_REALM", spec.RealmName},
+		{"KUKEON_SPACE", spec.SpaceName},
+		{"KUKEON_STACK", spec.StackName},
+		{"KUKEON_CGROUP_PATH", spec.CellCgroupPath},
+	}
+	out := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		if p.value == "" {
+			continue
+		}
+		out = append(out, p.key+"="+p.value)
+	}
+	return out
 }
 
 // cellCgroupsPath returns the absolute OCI Linux.CgroupsPath for a container

--- a/internal/ctr/spec_kukeon_env_test.go
+++ b/internal/ctr/spec_kukeon_env_test.go
@@ -1,0 +1,267 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	ctr "github.com/eminwux/kukeon/internal/ctr"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// applyBuiltRootSpec is the BuildRootContainerSpec counterpart of
+// applyBuiltSpec — composes the SpecOpts produced by the root-container
+// builder into an empty runtime spec so tests can assert on the resulting
+// OCI Process.Env without touching containerd.
+func applyBuiltRootSpec(t *testing.T, in intmodel.ContainerSpec) *runtimespec.Spec {
+	t.Helper()
+	spec := &runtimespec.Spec{
+		Process: &runtimespec.Process{},
+		Linux:   &runtimespec.Linux{},
+	}
+	built := ctr.BuildRootContainerSpec(in, nil)
+	for _, opt := range built.SpecOpts {
+		if err := opt(context.Background(), nil, nil, spec); err != nil {
+			t.Fatalf("SpecOpts returned error: %v", err)
+		}
+	}
+	return spec
+}
+
+func envMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, kv := range env {
+		k, v, _ := strings.Cut(kv, "=")
+		out[k] = v
+	}
+	return out
+}
+
+func envKeyOccurrences(env []string, key string) int {
+	n := 0
+	for _, kv := range env {
+		k, _, _ := strings.Cut(kv, "=")
+		if k == key {
+			n++
+		}
+	}
+	return n
+}
+
+// TestBuildContainerSpec_KukeonEnv asserts that BuildContainerSpec emits the
+// KUKEON_* identity entries for every populated cell-context field on
+// ContainerSpec, with KUKEON_CELL_PROFILE_NAME tracking the runner-stamped
+// CellProfileName. Issue #351.
+func TestBuildContainerSpec_KukeonEnv(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:              "work",
+		Image:           "registry.eminwux.com/busybox:latest",
+		CellName:        "kukeon-pr-a4aaab",
+		RealmName:       "default",
+		SpaceName:       "default",
+		StackName:       "default",
+		CellCgroupPath:  "/kukeon/default/default/default/kukeon-pr-a4aaab",
+		CellProfileName: "kukeon-pr",
+	})
+
+	want := map[string]string{
+		"KUKEON_CELL_PROFILE_NAME": "kukeon-pr",
+		"KUKEON_CELL_NAME":         "kukeon-pr-a4aaab",
+		"KUKEON_CONTAINER_ID":      "work",
+		"KUKEON_REALM":             "default",
+		"KUKEON_SPACE":             "default",
+		"KUKEON_STACK":             "default",
+		"KUKEON_CGROUP_PATH":       "/kukeon/default/default/default/kukeon-pr-a4aaab",
+	}
+	got := envMap(spec.Process.Env)
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Process.Env[%q] = %q, want %q (full env: %v)", k, got[k], v, spec.Process.Env)
+		}
+	}
+}
+
+// TestBuildContainerSpec_KukeonEnv_SkipsEmptyFields locks in that an empty
+// cell-context field produces no corresponding KUKEON_* entry — so test specs
+// and edge cases that omit, say, CellProfileName or CellCgroupPath don't
+// leak `KUKEON_CELL_PROFILE_NAME=` empty-value entries into the container.
+func TestBuildContainerSpec_KukeonEnv_SkipsEmptyFields(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:        "work",
+		Image:     "registry.eminwux.com/busybox:latest",
+		CellName:  "cell-1",
+		RealmName: "realm-1",
+		SpaceName: "space-1",
+		StackName: "stack-1",
+		// CellProfileName and CellCgroupPath intentionally empty.
+	})
+
+	got := envMap(spec.Process.Env)
+	if _, ok := got["KUKEON_CELL_PROFILE_NAME"]; ok {
+		t.Errorf("KUKEON_CELL_PROFILE_NAME present with empty CellProfileName: %q", got["KUKEON_CELL_PROFILE_NAME"])
+	}
+	if _, ok := got["KUKEON_CGROUP_PATH"]; ok {
+		t.Errorf("KUKEON_CGROUP_PATH present with empty CellCgroupPath: %q", got["KUKEON_CGROUP_PATH"])
+	}
+	// The other vars must still be present so the partial-population case
+	// is useful (a cell created without a profile still surfaces its own
+	// realm/space/stack/cell name to the workload).
+	for _, k := range []string{"KUKEON_CELL_NAME", "KUKEON_CONTAINER_ID", "KUKEON_REALM", "KUKEON_SPACE", "KUKEON_STACK"} {
+		if _, ok := got[k]; !ok {
+			t.Errorf("Process.Env missing %q (full env: %v)", k, spec.Process.Env)
+		}
+	}
+}
+
+// TestBuildContainerSpec_KukeonEnv_UserEnvWinsOnCollision asserts the
+// override rule the issue calls out: a user-supplied entry in
+// containerSpec.Env with the same key as a KUKEON_* default takes precedence
+// in the final OCI Process.Env, and no duplicate KUKEON_* entry is left
+// behind. Issue #351.
+func TestBuildContainerSpec_KukeonEnv_UserEnvWinsOnCollision(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:              "work",
+		Image:           "registry.eminwux.com/busybox:latest",
+		CellName:        "cell-1",
+		RealmName:       "realm-1",
+		SpaceName:       "space-1",
+		StackName:       "stack-1",
+		CellProfileName: "profile-1",
+		// User explicitly overrides one of the KUKEON_* defaults plus
+		// declares an unrelated AGENT_NAME var.
+		Env: []string{
+			"KUKEON_CELL_NAME=user-override",
+			"AGENT_NAME=kukeon-pr",
+		},
+	})
+
+	got := envMap(spec.Process.Env)
+	if got["KUKEON_CELL_NAME"] != "user-override" {
+		t.Errorf("KUKEON_CELL_NAME = %q, want %q (user override should win)", got["KUKEON_CELL_NAME"], "user-override")
+	}
+	if got["AGENT_NAME"] != "kukeon-pr" {
+		t.Errorf("AGENT_NAME = %q, want %q", got["AGENT_NAME"], "kukeon-pr")
+	}
+	if got["KUKEON_CELL_PROFILE_NAME"] != "profile-1" {
+		t.Errorf(
+			"KUKEON_CELL_PROFILE_NAME = %q, want %q (untouched default)",
+			got["KUKEON_CELL_PROFILE_NAME"],
+			"profile-1",
+		)
+	}
+	// No duplicate entries — the merge happens before oci.WithEnv so two
+	// entries with the same key never reach replaceOrAppendEnvValues.
+	if n := envKeyOccurrences(spec.Process.Env, "KUKEON_CELL_NAME"); n != 1 {
+		keys := make([]string, 0, len(spec.Process.Env))
+		for _, kv := range spec.Process.Env {
+			k, _, _ := strings.Cut(kv, "=")
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		t.Errorf("KUKEON_CELL_NAME appeared %d times, want 1 (keys: %v)", n, keys)
+	}
+}
+
+// TestBuildContainerSpec_KukeonEnv_NoFieldsNoEntries locks the empty case:
+// a ContainerSpec without any cell-context fields and no user env produces
+// no Env entries — so legacy unit tests that build minimal specs don't gain
+// surprise environment leaks.
+func TestBuildContainerSpec_KukeonEnv_NoFieldsNoEntries(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		// Only ID is set. ID alone produces KUKEON_CONTAINER_ID, which is
+		// the documented behaviour, but no other vars and no leaked
+		// empty-value entries.
+		ID:    "c1",
+		Image: "registry.eminwux.com/busybox:latest",
+	})
+	got := envMap(spec.Process.Env)
+	if got["KUKEON_CONTAINER_ID"] != "c1" {
+		t.Errorf("KUKEON_CONTAINER_ID = %q, want %q", got["KUKEON_CONTAINER_ID"], "c1")
+	}
+	for _, k := range []string{
+		"KUKEON_CELL_PROFILE_NAME",
+		"KUKEON_CELL_NAME",
+		"KUKEON_REALM",
+		"KUKEON_SPACE",
+		"KUKEON_STACK",
+		"KUKEON_CGROUP_PATH",
+	} {
+		if _, ok := got[k]; ok {
+			t.Errorf("Process.Env carries %q with empty source field: %q", k, got[k])
+		}
+	}
+}
+
+// TestBuildRootContainerSpec_KukeonEnv mirrors the BuildContainerSpec
+// coverage on the root-container builder so the kukeond cell and any
+// user-supplied root container also receive KUKEON_* identity vars.
+// Issue #351.
+func TestBuildRootContainerSpec_KukeonEnv(t *testing.T) {
+	spec := applyBuiltRootSpec(t, intmodel.ContainerSpec{
+		ID:              "root",
+		Root:            true,
+		Image:           "registry.eminwux.com/busybox:latest",
+		CellName:        "kukeon-pr-a4aaab",
+		RealmName:       "default",
+		SpaceName:       "default",
+		StackName:       "default",
+		CellCgroupPath:  "/kukeon/default/default/default/kukeon-pr-a4aaab",
+		CellProfileName: "kukeon-pr",
+	})
+
+	want := map[string]string{
+		"KUKEON_CELL_PROFILE_NAME": "kukeon-pr",
+		"KUKEON_CELL_NAME":         "kukeon-pr-a4aaab",
+		"KUKEON_CONTAINER_ID":      "root",
+		"KUKEON_REALM":             "default",
+		"KUKEON_SPACE":             "default",
+		"KUKEON_STACK":             "default",
+		"KUKEON_CGROUP_PATH":       "/kukeon/default/default/default/kukeon-pr-a4aaab",
+	}
+	got := envMap(spec.Process.Env)
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Process.Env[%q] = %q, want %q (full env: %v)", k, got[k], v, spec.Process.Env)
+		}
+	}
+}
+
+// TestBuildRootContainerSpec_KukeonEnv_UserEnvWinsOnCollision mirrors the
+// override semantics on the root builder.
+func TestBuildRootContainerSpec_KukeonEnv_UserEnvWinsOnCollision(t *testing.T) {
+	spec := applyBuiltRootSpec(t, intmodel.ContainerSpec{
+		ID:        "root",
+		Root:      true,
+		Image:     "registry.eminwux.com/busybox:latest",
+		CellName:  "cell-1",
+		RealmName: "realm-1",
+		SpaceName: "space-1",
+		StackName: "stack-1",
+		Env:       []string{"KUKEON_CELL_NAME=root-override"},
+	})
+	got := envMap(spec.Process.Env)
+	if got["KUKEON_CELL_NAME"] != "root-override" {
+		t.Errorf("KUKEON_CELL_NAME = %q, want %q", got["KUKEON_CELL_NAME"], "root-override")
+	}
+	if n := envKeyOccurrences(spec.Process.Env, "KUKEON_CELL_NAME"); n != 1 {
+		t.Errorf("KUKEON_CELL_NAME appeared %d times, want 1 (env: %v)", n, spec.Process.Env)
+	}
+}

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -90,6 +90,16 @@ type ContainerSpec struct {
 	// Empty disables the bind-mount. Same lifecycle and storage location as
 	// EtcHostsPath; not part of the persisted document.
 	EtcHostnamePath string
+	// CellProfileName is the metadata.name of the CellProfile this container's
+	// cell was materialized from (mirrors cell.Metadata.Labels
+	// [cellprofile.LabelProfile]). When non-empty, BuildContainerSpec /
+	// BuildRootContainerSpec emit it as KUKEON_CELL_PROFILE_NAME on the
+	// container's OCI Process.Env so workloads can read their own profile
+	// identity without relying on profile authors to hardcode it. Empty when
+	// the cell was created from a plain CellDoc rather than a CellProfile.
+	// Populated by the runner at container-create time; not part of the
+	// persisted document. Issue #351.
+	CellProfileName string
 }
 
 // ContainerTty mirrors the v1beta1 ContainerTty payload. See the v1beta1


### PR DESCRIPTION
## Summary

- Adds `kukeonContainerEnv` / `kukeonDefaultEnv` helpers in `internal/ctr/spec.go` that emit `KUKEON_CELL_PROFILE_NAME`, `KUKEON_CELL_NAME`, `KUKEON_CONTAINER_ID`, `KUKEON_REALM`, `KUKEON_SPACE`, `KUKEON_STACK`, and `KUKEON_CGROUP_PATH` from the container's existing cell-context fields. `BuildContainerSpec` and `BuildRootContainerSpec` route their `oci.WithEnv` call through the merge so user-supplied `containerSpec.Env` entries override defaults on key collisions and duplicate entries never reach `replaceOrAppendEnvValues`.
- Plumbs the profile name through a new runtime-only `ContainerSpec.CellProfileName` field (mirrors `CellCgroupPath`'s lifecycle — populated by the runner, not persisted) sourced from `cell.Metadata.Labels[cellprofile.LabelProfile]`. Cells materialized from a `CellProfile` get the var; cells created from a plain `CellDoc` skip it.
- Stamps the field at every BuildContainerSpec/BuildRootContainerSpec call site that already injects `CellCgroupPath` or etc-file paths: `provision.go` (CreateCell + ensureCellContainers root recreate), `start.go` (StartCell root + non-root recreates).

## Why

Profiles today hardcode `AGENT_NAME=<cell name>` in the env block, which drifts from `metadata.name` and silently mismatches over time. All seven values are already known to `kukeond` at container-create time — this is an env merge, not new plumbing.

## Test plan

- [x] `make test` — full unit suite
- [x] `pre-commit run --all-files` — lint/format
- [x] `make dev-init` — daemon-parity check passes; both `kuke get realms` and `kuke get realms --no-daemon` show identical output (the bind-mount regression guard from CLAUDE.md)
- [x] Live verification: `sudo ctr -n kuke-system.kukeon.io container info kukeon_kukeon_kukeond_kukeond` confirms the kukeond container's OCI Process.Env carries `KUKEON_CELL_NAME=kukeond`, `KUKEON_REALM=kuke-system`, `KUKEON_SPACE=kukeon`, `KUKEON_STACK=kukeon`, `KUKEON_CONTAINER_ID=kukeond`, `KUKEON_CGROUP_PATH=/kukeon/kuke-system/kukeon/kukeon/kukeond`. `KUKEON_CELL_PROFILE_NAME` is correctly absent because kukeond is not materialized from a CellProfile.
- [x] New unit tests in `internal/ctr/spec_kukeon_env_test.go` cover: full population, empty-field skipping, user-env-wins-on-collision, no-duplicate-entries, root-builder parity. New tests in `internal/controller/runner/cell_profile_stamp_test.go` cover the stamp helper (label present, label absent, nil-safety, preset-not-overwritten, per-spec variant).

Closes #351