### PR TITLE
fix: uninstall daemon-stop reads PID file from runPath; gate cleanup on namespace removal

### DIFF
--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -147,8 +147,17 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	)
 
 	socketDir := resolveSocketDir(cmd)
-	for _, name := range []string{"kukeond.sock", "kukeond.pid"} {
-		path := filepath.Join(socketDir, name)
+	runPath := resolveRunPath(cmd)
+	// kukeond.sock lives under the socket dir (/run/kukeon); kukeond.pid is
+	// written under the run path (/opt/kukeon) by cmd/kukeond/serve.go. The
+	// two diverge — pinning kukeond.pid to the socket dir was the silent #287
+	// no-op that left the daemon-stop step in `kuke uninstall` looking at the
+	// wrong path.
+	transientFiles := []string{
+		filepath.Join(socketDir, "kukeond.sock"),
+		filepath.Join(runPath, "kukeond.pid"),
+	}
+	for _, path := range transientFiles {
 		removed, removeErr := removeFileIfExists(path)
 		if removeErr != nil {
 			return fmt.Errorf("remove %q: %w", path, removeErr)
@@ -159,7 +168,6 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	}
 
 	if purgeSystem {
-		runPath := resolveRunPath(cmd)
 		systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
 		removed, removeErr := removeDirIfExists(systemDir)
 		if removeErr != nil {

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -251,14 +251,20 @@ func TestDaemonReset(t *testing.T) {
 }
 
 // TestDaemonReset_RemovesSocketAndPidFiles confirms the cleanup step actually
-// removes /run/kukeon/kukeond.{sock,pid} (or the per-test override) when both
-// files are present.
+// removes /run/kukeon/kukeond.sock and /opt/kukeon/kukeond.pid (or the
+// per-test overrides) when both files are present.
+//
+// kukeond.sock lives under the socket dir (KUKEOND_SOCKET's parent) while
+// kukeond.pid is written under the run path by cmd/kukeond/serve.go — pinning
+// the pid removal to the socket dir was the silent #287 no-op that left the
+// daemon-stop step in `kuke uninstall` looking at the wrong path.
 func TestDaemonReset_RemovesSocketAndPidFiles(t *testing.T) {
 	withFreshViper(t)
 
 	socketDir := t.TempDir()
+	runPath := t.TempDir()
 	sockPath := filepath.Join(socketDir, "kukeond.sock")
-	pidPath := filepath.Join(socketDir, "kukeond.pid")
+	pidPath := filepath.Join(runPath, "kukeond.pid")
 	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
 		t.Fatalf("seed sock file: %v", err)
 	}
@@ -288,7 +294,7 @@ func TestDaemonReset_RemovesSocketAndPidFiles(t *testing.T) {
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, socketDir)
-	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
 	cmd.SetContext(ctx)
 	cmd.SetArgs(nil)
 

--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -63,6 +63,14 @@ This is the global counterpart to "kuke purge" (which is per-resource). It:
   3. Removes the configured run path (default /opt/kukeon) recursively.
   4. Removes the kukeon system user and group (no-op if absent).
 
+If any realm fails to drop its containerd namespace, steps 2-4 are skipped:
+tearing out /opt/kukeon while a residual namespace is still pinning overlay
+mounts on disk would strand the next "kuke init" with stale containerd state.
+The report flags every dir/account row as "skipped (realm purge failed)" so
+the half-cleaned host is visible without scrolling to the trailing error.
+Resolve the realm-purge failure (often: stop the live daemon, remove the
+residual containerd namespace by hand) and re-run the command.
+
 The /usr/local/bin/kuke binary and the kukeond symlink are NOT removed —
 uninstalling runtime state is not the same as uninstalling the binary.
 
@@ -174,6 +182,14 @@ func printReport(cmd *cobra.Command, report controller.UninstallReport) {
 			fmt.Fprintf(out, "  - realm %q (namespace %q): purged\n", r.Name, r.Namespace)
 		}
 	}
+	if report.CleanupSkipped {
+		fmt.Fprintf(out, "  - %s: %s\n", report.SocketDir, outcomeSkipped)
+		fmt.Fprintf(out, "  - %s: %s\n", report.RunPath, outcomeSkipped)
+		fmt.Fprintf(out, "  - user %q: %s\n", report.UserName, outcomeSkipped)
+		fmt.Fprintf(out, "  - group %q: %s\n", report.GroupName, outcomeSkipped)
+		fmt.Fprintln(out, "  filesystem + user/group cleanup skipped: residual containerd namespace prevented teardown")
+		return
+	}
 	fmt.Fprintf(out, "  - %s: %s\n", report.SocketDir, dirOutcome(report.SocketDirExists, report.SocketDirRemove))
 	fmt.Fprintf(out, "  - %s: %s\n", report.RunPath, dirOutcome(report.RunPathExists, report.RunPathRemove))
 	fmt.Fprintf(out, "  - user %q: %s\n", report.UserName, accountOutcome(report.UserExisted, report.UserRemoved))
@@ -183,6 +199,11 @@ func printReport(cmd *cobra.Command, report controller.UninstallReport) {
 // outcomeAbsent labels every "we didn't find the resource" branch in the
 // uninstall report so the operator sees the same word in every section.
 const outcomeAbsent = "absent"
+
+// outcomeSkipped labels filesystem + user/group rows when the half-cleaned
+// host gate (issue #287) blocks teardown because a realm failed to drop its
+// containerd namespace.
+const outcomeSkipped = "skipped (realm purge failed)"
 
 func daemonOutcome(d controller.DaemonStopReport) string {
 	switch {

--- a/cmd/kuke/uninstall/uninstall_test.go
+++ b/cmd/kuke/uninstall/uninstall_test.go
@@ -318,5 +318,53 @@ func TestUninstall_DefaultRunPathFromConfig(t *testing.T) {
 	}
 }
 
+// TestUninstall_CleanupSkippedRendersSkipMarker pins the half-cleaned-host
+// rendering from issue #287: when the controller reports CleanupSkipped, the
+// CLI must replace each filesystem/account row with the skip marker rather
+// than misreporting "absent" or "removed". This is the operator-facing tell
+// that a residual containerd namespace blocked teardown.
+func TestUninstall_CleanupSkippedRendersSkipMarker(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stepErr := errors.New("synthetic purge failure")
+	stub := &stubController{
+		uninstallFn: func(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+			return controller.UninstallReport{
+				Realms: []controller.RealmPurgeOutcome{
+					{Name: "kuke-system", Namespace: "kuke-system.kukeon.io", Err: stepErr},
+				},
+				CleanupSkipped: true,
+				SocketDir:      opts.SocketDir,
+				RunPath:        "/opt/kukeon",
+				UserName:       "kukeon",
+				GroupName:      "kukeon",
+			}, stepErr
+		},
+	}
+
+	out, err := runCmd(t, stub, "", "--yes")
+	if err == nil {
+		t.Fatalf("expected error to propagate; got nil. output:\n%s", out)
+	}
+
+	wantMarkers := []string{
+		"skipped (realm purge failed)",
+		"filesystem + user/group cleanup skipped",
+	}
+	for _, want := range wantMarkers {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"removed", "absent"} {
+		// Defensive: if the renderer falls back to dirOutcome/accountOutcome
+		// on a CleanupSkipped report, it'll mislabel the rows. The skip
+		// marker must replace those entirely.
+		if strings.Contains(out, ": "+unwanted) {
+			t.Errorf("CleanupSkipped report unexpectedly rendered %q line; got:\n%s", unwanted, out)
+		}
+	}
+}
+
 // Compile-time assertion: stubController must satisfy controller.Controller.
 var _ controller.Controller = (*stubController)(nil)

--- a/internal/controller/uninstall.go
+++ b/internal/controller/uninstall.go
@@ -88,9 +88,16 @@ type RealmPurgeOutcome struct {
 }
 
 // UninstallReport summarizes what Uninstall did.
+//
+// CleanupSkipped is true when the filesystem + user/group teardown steps were
+// skipped because at least one realm failed to drop its containerd namespace.
+// Tearing out /opt/kukeon while a residual namespace is still pinning overlay
+// mounts on disk left a half-cleaned host where the next `kuke init` had to
+// coexist with stale containerd state — see issue #287.
 type UninstallReport struct {
 	Daemon          DaemonStopReport
 	Realms          []RealmPurgeOutcome
+	CleanupSkipped  bool
 	SocketDir       string
 	SocketDirExists bool
 	SocketDirRemove bool
@@ -125,6 +132,12 @@ type UninstallReport struct {
 //  3. RemoveAll on the run path (typically /opt/kukeon).
 //  4. Remove the kukeon system user and group (no-op if absent).
 //
+// Steps 2–4 are gated on every realm reporting NamespaceRemoved=true. When at
+// least one realm fails to drop its containerd namespace, the report's
+// CleanupSkipped flag is set and the filesystem + user/group teardown is left
+// for a follow-up run — see issue #287 for the half-cleaned-host failure
+// mode this prevents.
+//
 // Any step's error is recorded in the report. The first non-nil step error
 // is returned so callers can surface "uninstall failed at step X" without
 // dropping subsequent best-effort cleanup.
@@ -155,11 +168,14 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 	// Step 0: stop the live kukeond daemon. Do this before realm enumeration
 	// so the controller's containerd client is not racing the daemon when
 	// PurgeRealm starts draining the kuke-system namespace.
+	//
+	// The default PID-file path mirrors cmd/kukeond/serve.go's write path —
+	// kukeond writes its PID to <runPath>/kukeond.pid, so reading from any
+	// other location turns this step into a silent no-op (the #287 regression
+	// the daemon-stop step from #195 was supposed to prevent).
 	pidFile := opts.KukeondPIDFile
-	if pidFile == "" && opts.SocketDir != "" {
-		// Default to <socketDir>/kukeond.pid so callers that pre-populate
-		// SocketDir (the CLI does) get the daemon-stop wired up automatically.
-		pidFile = filepath.Join(opts.SocketDir, "kukeond.pid")
+	if pidFile == "" && b.opts.RunPath != "" {
+		pidFile = filepath.Join(b.opts.RunPath, "kukeond.pid")
 	}
 	if pidFile != "" {
 		stopper := opts.DaemonStopper
@@ -201,6 +217,7 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 		)
 	}
 
+	allNamespacesRemoved := true
 	for _, realm := range realms {
 		outcome := RealmPurgeOutcome{
 			Name:      realm.Metadata.Name,
@@ -214,7 +231,21 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 		} else {
 			outcome.Purged = true
 		}
+		if !outcome.NamespaceRemoved {
+			allNamespacesRemoved = false
+		}
 		report.Realms = append(report.Realms, outcome)
+	}
+
+	// Half-cleaned-host gate (issue #287): if any realm failed to drop its
+	// containerd namespace, leave /run/kukeon, /opt/kukeon, and the kukeon
+	// system user/group intact. Tearing those out while overlay snapshots in
+	// the residual namespace are still pinning files on disk strands the next
+	// `kuke init` with stale containerd state — and worse, can rip the bind
+	// mounts out from under a still-live daemon.
+	if !allNamespacesRemoved {
+		report.CleanupSkipped = true
+		return report, firstErr
 	}
 
 	// Step 2: tear down /run/kukeon.

--- a/internal/controller/uninstall_test.go
+++ b/internal/controller/uninstall_test.go
@@ -172,11 +172,22 @@ func TestUninstall_MergesListedRealmsWithWellKnown(t *testing.T) {
 	}
 }
 
-func TestUninstall_PurgeFailureIsRecordedButCleanupContinues(t *testing.T) {
+// TestUninstall_PurgeFailureGatesFilesystemCleanup pins the half-cleaned-host
+// gate from issue #287: when at least one realm fails to drop its containerd
+// namespace, /run/kukeon, /opt/kukeon, and the kukeon system user/group must
+// be left intact so the host stays internally consistent. Tearing them out
+// while overlay snapshots in the residual namespace are still pinning files
+// on disk strands the next `kuke init` with stale containerd state.
+func TestUninstall_PurgeFailureGatesFilesystemCleanup(t *testing.T) {
 	tmpRunPath := t.TempDir()
 	tmpSocketDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmpRunPath, "marker"), []byte("x"), 0o644); err != nil {
+	runMarker := filepath.Join(tmpRunPath, "marker")
+	if err := os.WriteFile(runMarker, []byte("x"), 0o644); err != nil {
 		t.Fatalf("seed run path: %v", err)
+	}
+	socketMarker := filepath.Join(tmpSocketDir, "marker")
+	if err := os.WriteFile(socketMarker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed socket dir: %v", err)
 	}
 
 	f := uninstallNoopRunner(nil)
@@ -200,11 +211,22 @@ func TestUninstall_PurgeFailureIsRecordedButCleanupContinues(t *testing.T) {
 		t.Errorf("error %q does not mention failing realm %q", err, consts.KukeSystemRealmName)
 	}
 
-	// The cleanup steps must still have run despite the realm failure.
-	if !report.RunPathRemove {
-		t.Errorf("run path not removed after a realm purge failure (expected best-effort cleanup)")
+	if !report.CleanupSkipped {
+		t.Errorf("CleanupSkipped=false on a host with a failed realm purge; expected gate to fire")
 	}
-	// And the failing realm's outcome must be in the report so callers can
+	if report.RunPathRemove {
+		t.Errorf("run path was removed after a realm purge failure; expected gate to skip teardown")
+	}
+	if report.SocketDirRemove {
+		t.Errorf("socket dir was removed after a realm purge failure; expected gate to skip teardown")
+	}
+	if _, statErr := os.Stat(runMarker); statErr != nil {
+		t.Errorf("run-path marker missing — gate failed to preserve /opt/kukeon: %v", statErr)
+	}
+	if _, statErr := os.Stat(socketMarker); statErr != nil {
+		t.Errorf("socket-dir marker missing — gate failed to preserve /run/kukeon: %v", statErr)
+	}
+	// The failing realm's outcome must be in the report so callers can
 	// surface what went wrong. NamespaceRemoved must be false so the renderer
 	// can flag the residual namespace from issue #193 instead of misreporting
 	// "purged".
@@ -273,7 +295,10 @@ func TestUninstall_DaemonStopStep_PIDPresent(t *testing.T) {
 	tmpRunPath := t.TempDir()
 	tmpSocketDir := t.TempDir()
 
-	pidFilePath := filepath.Join(tmpSocketDir, "kukeond.pid")
+	// Match the production write path (cmd/kukeond/serve.go:99): kukeond
+	// writes its PID to <runPath>/kukeond.pid. Putting the seed file under
+	// the socket dir is the #287 misconfiguration this test must not pin.
+	pidFilePath := filepath.Join(tmpRunPath, "kukeond.pid")
 	if err := os.WriteFile(pidFilePath, []byte("12345\n"), 0o644); err != nil {
 		t.Fatalf("seed pid file: %v", err)
 	}
@@ -467,5 +492,51 @@ func TestUninstall_SuffixEnumeratorPurgesKukeonNamespacesOnly(t *testing.T) {
 	}
 	if _, leaked := purgedNames["moby"]; leaked {
 		t.Errorf("moby was purged — non-kukeon namespaces must be filtered out; purged=%v", purgedNames)
+	}
+}
+
+// TestUninstall_DefaultPIDFileResolvesToRunPath pins the controller's default
+// PID-file path against the production write path in cmd/kukeond/serve.go.
+//
+// Issue #287: the daemon-stop step from #195 was a silent no-op because
+// Uninstall defaulted KukeondPIDFile to <socketDir>/kukeond.pid while kukeond
+// itself writes <runPath>/kukeond.pid. This test guards against either side
+// drifting again — it asserts the path the controller hands the stopper is
+// exactly filepath.Join(opts.RunPath, "kukeond.pid").
+func TestUninstall_DefaultPIDFileResolvesToRunPath(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+
+	wantPIDFile := filepath.Join(tmpRunPath, "kukeond.pid")
+	var gotPIDFile string
+	stopper := func(_ context.Context, gotPidFile string, _ time.Duration) (controller.DaemonStopReport, error) {
+		gotPIDFile = gotPidFile
+		return controller.DaemonStopReport{PIDFile: gotPidFile}, nil
+	}
+
+	f := uninstallNoopRunner(nil)
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	if _, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		DaemonStopper: stopper,
+		// KukeondPIDFile deliberately empty — the whole point is to exercise
+		// the controller's default-resolution path.
+		SkipUserGroup: true,
+	}); err != nil {
+		t.Fatalf("Uninstall returned error: %v", err)
+	}
+
+	if gotPIDFile != wantPIDFile {
+		t.Errorf(
+			"default PID-file path mismatch:\n  controller passed: %q\n  cmd/kukeond/serve.go writes: <runPath>/kukeond.pid -> %q",
+			gotPIDFile,
+			wantPIDFile,
+		)
+	}
+	if filepath.Dir(gotPIDFile) == tmpSocketDir {
+		t.Errorf(
+			"controller defaulted PID file under socket dir %q — that is the #287 regression",
+			tmpSocketDir,
+		)
 	}
 }


### PR DESCRIPTION
## Summary
- `controller.Uninstall` now defaults `KukeondPIDFile` to `<runPath>/kukeond.pid` (matching `cmd/kukeond/serve.go:99`); the prior `<socketDir>/kukeond.pid` default made the daemon-stop step from #195 a silent no-op so realm purge raced the live daemon and failed with `namespace must be empty, but it still has snapshots on overlayfs`.
- `kuke daemon reset` now removes `kukeond.pid` from runPath (was: socketDir) so the dev-loop teardown matches the production write path.
- Added a half-cleaned-host gate: when at least one realm reports `NamespaceRemoved=false`, steps 2–4 (remove `/run/kukeon`, remove run path, drop user/group) are skipped and `report.CleanupSkipped=true`. The CLI renders each gated row as `skipped (realm purge failed)` and prints a one-line explainer so the failure mode is visible without scrolling to the trailing error.

## Test plan
- [x] `make test` — full project unit + table-test suite (~75 packages)
- [x] `pre-commit run --files <changed>` — gofmt + golangci-lint + addlicense clean
- [x] `go test ./internal/controller/ -run TestUninstall -v` — 8 tests pass, including the new `TestUninstall_DefaultPIDFileResolvesToRunPath` regression and the renamed `TestUninstall_PurgeFailureGatesFilesystemCleanup`
- [x] `go test ./cmd/kuke/uninstall/... ./cmd/kuke/daemon/reset/... -v` — uninstall + reset suites pass; new `TestUninstall_CleanupSkippedRendersSkipMarker` covers the CLI rendering
- [x] `make kuke && ./kuke uninstall --help` — long description carries the new gating paragraph
- [x] Manual repro confirmation: `ls /opt/kukeon/` on this host shows `kukeond.pid` (matching the issue's described symptom — pre-fix `kuke uninstall` reads `/run/kukeon/kukeond.pid` and finds nothing)
- [ ] `make dev-init` end-to-end smoke — **deferred to reviewer's clean host.** This dev host has an active kukeond cell with workloads in `/opt/kukeon/{default,kuke-system}` that the smoke playbook would tear down; running it here would disrupt unrelated state. The `make test` target above is the same suite CI runs.

## Notes
- A docs follow-up to add a `Recovering from a failed kuke uninstall` sub-section to `kukeon/CLAUDE.md` is filed as #356 (verbatim wording included), per the role rule against editing project `CLAUDE.md` from a code-fix PR.
- The renamed test (`TestUninstall_PurgeFailureIsRecordedButCleanupContinues` → `TestUninstall_PurgeFailureGatesFilesystemCleanup`) reflects the new behavior: cleanup no longer continues — it gates. The old name pinned a broken behavior.

Closes #287