### PR TITLE
feat: parameterized cell profiles via --param/--name/--param-file

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -375,6 +375,10 @@ var (
 	KUKE_RUN_PROFILE = DefineKV("KUKE_RUN_PROFILE", "kuke/run/profile")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_RM = DefineKV("KUKE_RUN_RM", "kuke/run/rm")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_NAME = DefineKV("KUKE_RUN_NAME", "kuke/run/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_PARAM_FILE = DefineKV("KUKE_RUN_PARAM_FILE", "kuke/run/param-file")
 
 	// Attach command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
@@ -71,6 +72,22 @@ func NewRunCmd() *cobra.Command {
 	cmd.Flags().StringP("profile", "p", "",
 		"Cell profile name to load from $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR); mutually exclusive with -f")
 	_ = viper.BindPFlag(config.KUKE_RUN_PROFILE.ViperKey, cmd.Flags().Lookup("profile"))
+
+	cmd.Flags().String("name", "",
+		"Override the materialized cell name (default: <metadata.name>-<6hex>). "+
+			"Only valid with -p; rejected with -f, where metadata.name is the cell name verbatim.")
+	_ = viper.BindPFlag(config.KUKE_RUN_NAME.ViperKey, cmd.Flags().Lookup("name"))
+
+	cmd.Flags().StringArray("param", nil,
+		"Profile parameter override as KEY=VALUE; repeatable. Only valid with -p. "+
+			"Each KEY must be declared in spec.parameters[]. Wins over the parameter's "+
+			"default and over --param-file when both set the same key.")
+
+	cmd.Flags().String("param-file", "",
+		"File of KEY=VALUE lines whose values seed profile parameters; one per line, "+
+			"`#` starts a comment. Same declaration rules as --param. CLI --param wins on "+
+			"duplicate keys.")
+	_ = viper.BindPFlag(config.KUKE_RUN_PARAM_FILE.ViperKey, cmd.Flags().Lookup("param-file"))
 
 	cmd.MarkFlagsMutuallyExclusive("file", "profile")
 	cmd.MarkFlagsOneRequired("file", "profile")
@@ -126,6 +143,9 @@ type runFlags struct {
 	detach        bool
 	containerFlag string
 	autoDelete    bool
+	nameOverride  string
+	paramArgs     []string
+	paramFile     string
 }
 
 func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
@@ -135,7 +155,15 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		detach:        viper.GetBool(config.KUKE_RUN_DETACH.ViperKey),
 		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
 		autoDelete:    viper.GetBool(config.KUKE_RUN_RM.ViperKey),
+		nameOverride:  strings.TrimSpace(viper.GetString(config.KUKE_RUN_NAME.ViperKey)),
+		paramFile:     strings.TrimSpace(viper.GetString(config.KUKE_RUN_PARAM_FILE.ViperKey)),
 	}
+
+	paramArgs, err := cmd.Flags().GetStringArray("param")
+	if err != nil {
+		return runFlags{}, err
+	}
+	flags.paramArgs = paramArgs
 
 	output, err := cmd.Flags().GetString("output")
 	if err != nil {
@@ -162,6 +190,21 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		// so the watcher would never run.
 		return runFlags{}, errors.New("--rm is incompatible with --no-daemon")
 	}
+	if flags.file != "" {
+		// --name, --param, --param-file are profile-only knobs (per issue
+		// #355). With -f the file's metadata.name is authoritative and the
+		// substitution surface doesn't apply, so reject the combination
+		// rather than silently dropping the flag.
+		if flags.nameOverride != "" {
+			return runFlags{}, errors.New("--name is only valid with -p/--profile")
+		}
+		if len(flags.paramArgs) > 0 {
+			return runFlags{}, errors.New("--param is only valid with -p/--profile")
+		}
+		if flags.paramFile != "" {
+			return runFlags{}, errors.New("--param-file is only valid with -p/--profile")
+		}
+	}
 	return flags, nil
 }
 
@@ -171,7 +214,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cellDoc, err := loadCellDoc(flags.file, flags.profileName)
+	cellDoc, err := loadCellDoc(flags)
 	if err != nil {
 		return err
 	}
@@ -313,14 +356,15 @@ func attachAfterRun(
 	return runAttachLoop(cmd, client, doc, target)
 }
 
-// loadCellDoc dispatches to the file or profile loader. Exactly one of file or
-// profileName is non-empty (the cobra mutex enforces it before the handler
-// runs).
-func loadCellDoc(file, profileName string) (v1beta1.CellDoc, error) {
-	if profileName != "" {
-		return loadFromProfile(profileName)
+// loadCellDoc dispatches to the file or profile loader. Exactly one of
+// flags.file or flags.profileName is non-empty (the cobra mutex enforces
+// this before the handler runs); --name and --param* are profile-only and
+// already rejected against -f in parseRunFlags.
+func loadCellDoc(flags runFlags) (v1beta1.CellDoc, error) {
+	if flags.profileName != "" {
+		return loadFromProfile(flags)
 	}
-	return loadFromFile(file)
+	return loadFromFile(flags.file)
 }
 
 // loadFromFile preserves the phase-1c -f path: read the file (or stdin),
@@ -340,19 +384,59 @@ func loadFromFile(file string) (v1beta1.CellDoc, error) {
 }
 
 // loadFromProfile resolves the active profiles directory, loads the named
-// profile, and materializes its CellSpec body into a CellDoc. The cell name
-// is `<prefix>-<6hex>` — prefix defaults to metadata.name and is overridden
-// by spec.prefix — so every invocation produces a fresh cell.
-func loadFromProfile(profileName string) (v1beta1.CellDoc, error) {
+// profile with `${KEY}` references substituted, and materializes its CellSpec
+// body into a CellDoc. By default the cell name is `<prefix>-<6hex>` (prefix
+// = spec.prefix or metadata.name); --name overrides it verbatim so callers
+// like the orchestrator can pin a deterministic name.
+//
+// Parameter resolution order matches the spec for issue #355:
+//  1. --param-file lines (lowest)
+//  2. --param flags (override the file on duplicate keys)
+//  3. spec.parameters[].default
+//  4. os.Getenv(KEY) — drawn from kuke's process env
+//  5. error if the parameter is required and still unset
+//
+// We thread os.LookupEnv as the env source because today profiles are
+// loaded by the kuke CLI (a one-shot process), so kuke's env IS the
+// substitution surface the spec calls "the kukeond process, not the
+// caller". A future move to daemon-side profile loading would swap this
+// for the daemon's env without changing the resolution order.
+func loadFromProfile(flags runFlags) (v1beta1.CellDoc, error) {
 	dir, err := cellprofile.ResolveDir()
 	if err != nil {
 		return v1beta1.CellDoc{}, err
 	}
-	profile, err := cellprofile.Load(dir, profileName)
+
+	cliParams, err := buildParamMap(flags)
 	if err != nil {
 		return v1beta1.CellDoc{}, err
 	}
-	return cellprofile.Materialize(profile)
+
+	profile, err := cellprofile.LoadResolved(dir, flags.profileName, cliParams, os.LookupEnv)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	return cellprofile.MaterializeWithName(profile, flags.nameOverride)
+}
+
+// buildParamMap layers --param flags on top of --param-file contents.
+// Empty result is a valid input for LoadResolved (the profile may have all
+// defaults). The function is split out so the run-time errors for malformed
+// files / KEY=VALUE strings stay close to the call site.
+func buildParamMap(flags runFlags) (map[string]string, error) {
+	var fileParams map[string]string
+	if flags.paramFile != "" {
+		fp, err := cellprofile.ParseParamFile(flags.paramFile)
+		if err != nil {
+			return nil, err
+		}
+		fileParams = fp
+	}
+	cliParams, err := cellprofile.ParseParamArgs(flags.paramArgs)
+	if err != nil {
+		return nil, err
+	}
+	return cellprofile.MergeParams(fileParams, cliParams), nil
 }
 
 // parseSingleCellDoc parses raw YAML and returns the single-doc Cell. It errors

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1702,6 +1703,233 @@ func TestNewRunCmd_RmFlagRegistered(t *testing.T) {
 	}
 	if def := rmFlag.DefValue; def != "false" {
 		t.Errorf("--rm default=%q want false", def)
+	}
+}
+
+// paramProfileYAML is the issue #355 example with three required parameters
+// and two defaults. Used to exercise the --param / --param-file / --name
+// path end-to-end through `kuke run`.
+const paramProfileYAML = `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: dev
+spec:
+  realm: default
+  space: agents
+  stack: claude
+  parameters:
+    - name: PROMPT
+      required: true
+    - name: PROJECT_REPO
+      required: true
+    - name: PROJECT_DIR
+      required: true
+    - name: AGENTS_REPO
+      default: "eminwux/agents"
+    - name: CLAUDE_IMAGE
+      default: "registry.eminwux.com/claude:latest"
+  cell:
+    containers:
+      - id: work
+        attachable: true
+        image: ${CLAUDE_IMAGE}
+        env:
+          - PROMPT=${PROMPT}
+          - PROJECT_REPO=${PROJECT_REPO}
+          - PROJECT_DIR=${PROJECT_DIR}
+          - AGENTS_REPO=${AGENTS_REPO}
+`
+
+func writeParamProfile(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dev.yaml")
+	if err := os.WriteFile(path, []byte(paramProfileYAML), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	t.Setenv("KUKE_PROFILES_DIR", dir)
+}
+
+func TestRun_FromProfile_WithParams_Substitutes(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeParamProfile(t)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{
+		"-p", "dev", "-d",
+		"--name", "crew-dev-354",
+		"--param", "PROMPT=/pick-issue 354",
+		"--param", "PROJECT_REPO=https://github.com/eminwux/crew",
+		"--param", "PROJECT_DIR=crew",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if got := fc.createDoc.Metadata.Name; got != "crew-dev-354" {
+		t.Errorf("cell name=%q want crew-dev-354 (--name override)", got)
+	}
+	if got := fc.createDoc.Spec.ID; got != "crew-dev-354" {
+		t.Errorf("spec.id=%q want crew-dev-354", got)
+	}
+
+	c := fc.createDoc.Spec.Containers[0]
+	if c.Image != "registry.eminwux.com/claude:latest" {
+		t.Errorf("image=%q want registry.eminwux.com/claude:latest (default substituted)", c.Image)
+	}
+	wantEnv := []string{
+		"PROMPT=/pick-issue 354",
+		"PROJECT_REPO=https://github.com/eminwux/crew",
+		"PROJECT_DIR=crew",
+		"AGENTS_REPO=eminwux/agents",
+	}
+	if !reflect.DeepEqual(c.Env, wantEnv) {
+		t.Errorf("env=%v\nwant %v", c.Env, wantEnv)
+	}
+}
+
+func TestRun_FromProfile_WithParamFile(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeParamProfile(t)
+
+	paramFile := filepath.Join(t.TempDir(), "dev.params")
+	body := "# issue 355 example\n" +
+		"PROMPT=/pick-issue 354\n" +
+		"PROJECT_REPO=https://github.com/eminwux/crew\n" +
+		"PROJECT_DIR=crew\n"
+	if err := os.WriteFile(paramFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write param file: %v", err)
+	}
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-p", "dev", "-d", "--param-file", paramFile})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.createDoc.Spec.Containers[0].Env[0]; got != "PROMPT=/pick-issue 354" {
+		t.Errorf("env[0]=%q want PROMPT=/pick-issue 354", got)
+	}
+}
+
+func TestRun_FromProfile_ParamFlagBeatsParamFile(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeParamProfile(t)
+
+	paramFile := filepath.Join(t.TempDir(), "dev.params")
+	body := "PROMPT=from-file\nPROJECT_REPO=x\nPROJECT_DIR=x\n"
+	if err := os.WriteFile(paramFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	// CLI --param targets the same key the file sets — flag wins (later-binding).
+	cmd.SetArgs([]string{
+		"-p", "dev", "-d",
+		"--param-file", paramFile,
+		"--param", "PROMPT=from-flag",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.createDoc.Spec.Containers[0].Env[0]; got != "PROMPT=from-flag" {
+		t.Errorf("env[0]=%q want PROMPT=from-flag (CLI --param wins over file)", got)
+	}
+}
+
+func TestRun_FromProfile_RequiredMissing_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeParamProfile(t)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-p", "dev", "-d"})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "PROMPT") {
+		t.Errorf("err %q must name a missing required parameter", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell called %d times; want 0 (substitution must error before RPC)", fc.createCalls)
+	}
+}
+
+func TestRun_FromProfile_UndeclaredParam_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	writeParamProfile(t)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{
+		"-p", "dev", "-d",
+		"--param", "PROMPT=x",
+		"--param", "PROJECT_REPO=x",
+		"--param", "PROJECT_DIR=x",
+		"--param", "TYPO=oops",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "TYPO") {
+		t.Errorf("err %q must name the undeclared --param key", err)
+	}
+}
+
+func TestRun_FileMode_RejectsParamFlags(t *testing.T) {
+	// --name, --param, --param-file are profile-only knobs. With -f the file's
+	// metadata.name is authoritative and substitution doesn't apply, so the
+	// CLI rejects the combination rather than silently dropping the flag.
+	cases := []struct {
+		name string
+		flag []string
+		want string
+	}{
+		{"name", []string{"--name", "x"}, "--name is only valid"},
+		{"param", []string{"--param", "K=V"}, "--param is only valid"},
+		{"param-file", []string{"--param-file", "/tmp/whatever"}, "--param-file is only valid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			fc := &fakeClient{}
+			cmd, _ := newCmd(t, fc)
+			args := []string{"-f", writeTempYAML(t, validCellYAML), "-d"}
+			args = append(args, tc.flag...)
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute returned nil; want error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err %q must contain %q", err, tc.want)
+			}
+			if fc.createCalls != 0 {
+				t.Errorf("CreateCell called; flag rejection must short-circuit before RPC")
+			}
+		})
 	}
 }
 

--- a/internal/cellprofile/cellprofile.go
+++ b/internal/cellprofile/cellprofile.go
@@ -22,7 +22,6 @@ package cellprofile
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -73,41 +72,70 @@ func ResolveDir() (string, error) {
 // is the convenient case but not authoritative, so two profiles can share a
 // directory regardless of how they were named on disk.
 //
+// `${KEY}` references in the body remain literal — substitution is a `kuke
+// run -p`-time concern. Use LoadResolved when the caller has --param values
+// to apply.
+//
 // Wraps errdefs.ErrProfileNotFound when the name does not resolve, including
 // the directory in the error so the operator knows where to drop the file.
 func Load(dir, name string) (*v1beta1.CellProfileDoc, error) {
+	profile, _, err := locate(dir, name)
+	return profile, err
+}
+
+// locate is the shared core for Load and LoadResolved: resolve the named
+// profile to a file, parse it, and return both the typed profile and the raw
+// yaml.Node tree. The node lets LoadResolved substitute scalars in the same
+// document tree the caller will eventually decode against — bypassing a YAML
+// → struct → YAML round-trip that would lose comments and re-quote scalars.
+func locate(dir, name string) (*v1beta1.CellProfileDoc, *yaml.Node, error) {
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return nil, fmt.Errorf("%w: empty name", errdefs.ErrProfileInvalid)
+		return nil, nil, fmt.Errorf("%w: empty name", errdefs.ErrProfileInvalid)
 	}
 
 	for _, ext := range []string{".yaml", ".yml"} {
 		candidate := filepath.Join(dir, name+ext)
 		if _, statErr := os.Stat(candidate); statErr == nil {
-			profile, err := loadFile(candidate)
+			profile, node, err := loadFile(candidate)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if matchesName(profile, name) {
-				return profile, nil
+				return profile, node, nil
 			}
 		}
 	}
 
-	profiles, err := List(dir)
+	// Fallback: basename did not match. Scan the directory and return the
+	// first parseable profile whose metadata.name equals `name`. We re-read
+	// the matching file so the caller gets a fresh node tree (List discards
+	// nodes by design).
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		if errors.Is(err, errdefs.ErrProfileNotFound) {
-			return nil, fmt.Errorf("profile %q not found in %s: %w", name, dir, errdefs.ErrProfileNotFound)
+		if os.IsNotExist(err) {
+			return nil, nil, fmt.Errorf("profile %q not found in %s: %w", name, dir, errdefs.ErrProfileNotFound)
 		}
-		return nil, err
+		return nil, nil, fmt.Errorf("read profiles dir %q: %w", dir, err)
 	}
-	for _, p := range profiles {
-		if p.Metadata.Name == name {
-			out := p
-			return &out, nil
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		filename := e.Name()
+		if !strings.HasSuffix(filename, ".yaml") && !strings.HasSuffix(filename, ".yml") {
+			continue
+		}
+		path := filepath.Join(dir, filename)
+		profile, node, loadErr := loadFile(path)
+		if loadErr != nil {
+			continue
+		}
+		if profile.Metadata.Name == name {
+			return profile, node, nil
 		}
 	}
-	return nil, fmt.Errorf("profile %q not found in %s: %w", name, dir, errdefs.ErrProfileNotFound)
+	return nil, nil, fmt.Errorf("profile %q not found in %s: %w", name, dir, errdefs.ErrProfileNotFound)
 }
 
 // List returns every parseable CellProfile in dir, sorted by metadata.name.
@@ -132,7 +160,7 @@ func List(dir string) ([]v1beta1.CellProfileDoc, error) {
 		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
 			continue
 		}
-		profile, loadErr := loadFile(filepath.Join(dir, name))
+		profile, _, loadErr := loadFile(filepath.Join(dir, name))
 		if loadErr != nil {
 			continue
 		}
@@ -144,34 +172,46 @@ func List(dir string) ([]v1beta1.CellProfileDoc, error) {
 	return out, nil
 }
 
-func loadFile(path string) (*v1beta1.CellProfileDoc, error) {
+// loadFile parses a single profile YAML and returns both the typed profile
+// and the underlying yaml.Node tree. The node is needed by LoadResolved to
+// substitute `${KEY}` references in scalar values without round-tripping
+// through marshal/unmarshal. Validation runs here so any caller (Load,
+// LoadResolved, the List fallback) gets the same shape rejections.
+func loadFile(path string) (*v1beta1.CellProfileDoc, *yaml.Node, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read profile %q: %w", path, err)
+		return nil, nil, fmt.Errorf("read profile %q: %w", path, err)
+	}
+	var node yaml.Node
+	if unmarshalErr := yaml.Unmarshal(raw, &node); unmarshalErr != nil {
+		return nil, nil, fmt.Errorf("parse profile %q: %w: %w", path, errdefs.ErrProfileInvalid, unmarshalErr)
 	}
 	var profile v1beta1.CellProfileDoc
-	if unmarshalErr := yaml.Unmarshal(raw, &profile); unmarshalErr != nil {
-		return nil, fmt.Errorf("parse profile %q: %w: %w", path, errdefs.ErrProfileInvalid, unmarshalErr)
+	if decodeErr := node.Decode(&profile); decodeErr != nil {
+		return nil, nil, fmt.Errorf("parse profile %q: %w: %w", path, errdefs.ErrProfileInvalid, decodeErr)
 	}
 	if profile.Kind != v1beta1.KindCellProfile {
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"profile %q has kind %q, want %q: %w",
 			path, profile.Kind, v1beta1.KindCellProfile, errdefs.ErrProfileInvalid,
 		)
 	}
 	if strings.TrimSpace(profile.Metadata.Name) == "" {
-		return nil, fmt.Errorf("profile %q: metadata.name is required: %w", path, errdefs.ErrProfileInvalid)
+		return nil, nil, fmt.Errorf("profile %q: metadata.name is required: %w", path, errdefs.ErrProfileInvalid)
 	}
 	if strings.TrimSpace(profile.Spec.Cell.ID) != "" {
 		// Every materialized cell gets a generated `<prefix>-<6hex>` name; a
 		// hardcoded spec.cell.id would silently produce N cells sharing one ID.
 		// Reject loudly so the operator removes the stray field instead.
-		return nil, fmt.Errorf(
+		return nil, nil, fmt.Errorf(
 			"profile %q: spec.cell.id must not be set on a CellProfile: %w",
 			path, errdefs.ErrProfileInvalid,
 		)
 	}
-	return &profile, nil
+	if validateErr := validateParameters(&profile, &node, path); validateErr != nil {
+		return nil, nil, validateErr
+	}
+	return &profile, &node, nil
 }
 
 func matchesName(profile *v1beta1.CellProfileDoc, name string) bool {
@@ -188,7 +228,17 @@ func matchesName(profile *v1beta1.CellProfileDoc, name string) bool {
 // kukeon.io/profile=<metadata.name> label so the set of cells materialized
 // from a profile is queryable via `kuke get cells -l`.
 func Materialize(profile *v1beta1.CellProfileDoc) (v1beta1.CellDoc, error) {
-	cellName, err := resolveCellName(profile)
+	return MaterializeWithName(profile, "")
+}
+
+// MaterializeWithName is Materialize with an explicit cell-name override —
+// used by `kuke run -p ... --name <override>`. When nameOverride is non-empty
+// (after trim) it replaces the generated `<prefix>-<6hex>` name verbatim, so
+// callers can give the cell a deterministic identity (e.g., the orchestrator
+// dispatching `crew-dev-354` so it can later attach by name). When empty,
+// behavior matches Materialize.
+func MaterializeWithName(profile *v1beta1.CellProfileDoc, nameOverride string) (v1beta1.CellDoc, error) {
+	cellName, err := resolveCellName(profile, nameOverride)
 	if err != nil {
 		return v1beta1.CellDoc{}, err
 	}
@@ -210,7 +260,10 @@ func Materialize(profile *v1beta1.CellProfileDoc) (v1beta1.CellDoc, error) {
 	}, nil
 }
 
-func resolveCellName(profile *v1beta1.CellProfileDoc) (string, error) {
+func resolveCellName(profile *v1beta1.CellProfileDoc, nameOverride string) (string, error) {
+	if override := strings.TrimSpace(nameOverride); override != "" {
+		return override, nil
+	}
 	prefix := strings.TrimSpace(profile.Spec.Prefix)
 	if prefix == "" {
 		prefix = profile.Metadata.Name

--- a/internal/cellprofile/params.go
+++ b/internal/cellprofile/params.go
@@ -1,0 +1,407 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellprofile
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// paramRefRE matches `${KEY}` substitution references in profile scalars.
+// KEY must start with a letter or underscore and contain only letters,
+// digits, and underscores — the same shape POSIX shells use, so existing
+// envsubst-style profiles port over without re-quoting.
+var paramRefRE = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// paramNameRE is the same alphabet used to validate `--param KEY=...` and
+// `--param-file` keys. Kept aligned with paramRefRE so a key that survives
+// CLI parsing is guaranteed to match a `${KEY}` reference shape.
+var paramNameRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// LoadResolved is Load + parameter substitution. Resolution order per
+// declared parameter: cliParams[k] > parameters[k].default > lookupEnv(k).
+// When lookupEnv is nil the env fallback is skipped — useful for tests and
+// for callers that want to keep substitution narrow (e.g., a daemon that
+// must not draw from the user's shell).
+//
+// Returns errdefs.ErrProfileInvalid wrapped when:
+//   - the profile body references `${KEY}` for a KEY not declared in
+//     spec.parameters[] (typo at install time);
+//   - cliParams contains a key not declared in spec.parameters[] (typo at
+//     call time);
+//   - a parameter declared `required: true` resolves to no value.
+//
+// Empty string is a valid resolved value: only "unset" — every provider
+// declines — triggers the required-vs-default decision.
+func LoadResolved(
+	dir, name string,
+	cliParams map[string]string,
+	lookupEnv func(string) (string, bool),
+) (*v1beta1.CellProfileDoc, error) {
+	profile, node, err := locate(dir, name)
+	if err != nil {
+		return nil, err
+	}
+	return resolve(profile, node, cliParams, lookupEnv)
+}
+
+// resolve is the lower-level half of LoadResolved: given an already-parsed
+// profile and its yaml.Node tree, validate cliParams, build the value map,
+// substitute scalars in a clone of the node tree, and decode the result.
+//
+// The clone is deliberate: callers that want to replay resolution against a
+// different cliParams map (tests do this) need the input tree to stay
+// untouched. The cost is one round-trip through yaml.Marshal/Unmarshal per
+// resolution — negligible given profile sizes.
+func resolve(
+	profile *v1beta1.CellProfileDoc,
+	node *yaml.Node,
+	cliParams map[string]string,
+	lookupEnv func(string) (string, bool),
+) (*v1beta1.CellProfileDoc, error) {
+	declared := make(map[string]v1beta1.CellProfileParameter, len(profile.Spec.Parameters))
+	for _, p := range profile.Spec.Parameters {
+		declared[p.Name] = p
+	}
+
+	for k := range cliParams {
+		if _, ok := declared[k]; !ok {
+			return nil, fmt.Errorf(
+				"profile %q: --param %q is not declared in spec.parameters[]: %w",
+				profile.Metadata.Name, k, errdefs.ErrProfileInvalid,
+			)
+		}
+	}
+
+	values := make(map[string]string, len(declared))
+	for _, p := range profile.Spec.Parameters {
+		if v, ok := cliParams[p.Name]; ok {
+			values[p.Name] = v
+			continue
+		}
+		if p.Default != nil {
+			values[p.Name] = *p.Default
+			continue
+		}
+		if lookupEnv != nil {
+			if v, ok := lookupEnv(p.Name); ok {
+				values[p.Name] = v
+				continue
+			}
+		}
+		if p.Required {
+			return nil, fmt.Errorf(
+				"profile %q: required parameter %q is not set "+
+					"(provide --param %s=... or declare a spec.parameters[].default): %w",
+				profile.Metadata.Name, p.Name, p.Name, errdefs.ErrProfileInvalid,
+			)
+		}
+		// Unset, not required: substitute with empty string. Matches
+		// `envsubst` behavior for unset env vars and the proposal's
+		// "empty string is a valid value" rule — declared but unused
+		// params drop out cleanly instead of leaving a literal `${KEY}`
+		// in the materialized cell.
+		values[p.Name] = ""
+	}
+
+	resolved := cloneNode(node)
+	substituteScalars(resolved, values)
+
+	var out v1beta1.CellProfileDoc
+	if err := resolved.Decode(&out); err != nil {
+		return nil, fmt.Errorf(
+			"profile %q: re-decode after parameter substitution: %w: %w",
+			profile.Metadata.Name, errdefs.ErrProfileInvalid, err,
+		)
+	}
+	return &out, nil
+}
+
+// validateParameters runs the at-load-time parameter checks: every
+// declared name must be unique and lexically valid; every `${KEY}` reference
+// in scalar values must point at a declared parameter. Called from loadFile
+// so any caller (Load, LoadResolved, the List fallback) gets the same
+// rejection rather than re-implementing the check.
+func validateParameters(profile *v1beta1.CellProfileDoc, node *yaml.Node, path string) error {
+	declared := make(map[string]struct{}, len(profile.Spec.Parameters))
+	for _, p := range profile.Spec.Parameters {
+		if !paramNameRE.MatchString(p.Name) {
+			return fmt.Errorf(
+				"profile %q: parameter name %q must match [A-Za-z_][A-Za-z0-9_]*: %w",
+				path, p.Name, errdefs.ErrProfileInvalid,
+			)
+		}
+		if _, dup := declared[p.Name]; dup {
+			return fmt.Errorf(
+				"profile %q: parameter %q is declared twice in spec.parameters[]: %w",
+				path, p.Name, errdefs.ErrProfileInvalid,
+			)
+		}
+		declared[p.Name] = struct{}{}
+	}
+
+	// Skip ref scanning under the spec.parameters block itself — `default`
+	// values legitimately contain literal `${...}`-shaped text on profiles
+	// that proxy substitutions through to a downstream tool. The reference
+	// check is meant to catch typos in the cell body, not double-quote the
+	// declarations.
+	for _, ref := range referencedParamsInBody(node) {
+		if _, ok := declared[ref]; !ok {
+			return fmt.Errorf(
+				"profile %q: references undeclared parameter %q "+
+					"(declare it in spec.parameters[] to fix): %w",
+				path, ref, errdefs.ErrProfileInvalid,
+			)
+		}
+	}
+	return nil
+}
+
+// referencedParamsInBody returns the unique set of `${KEY}` references in
+// the profile's scalar values, EXCLUDING the spec.parameters declaration
+// block. Document order is preserved so error messages name the first
+// offender the operator sees when they scroll through the file.
+func referencedParamsInBody(node *yaml.Node) []string {
+	body := bodyForRefScan(node)
+	if body == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	walkScalars(body, func(s *yaml.Node) {
+		for _, m := range paramRefRE.FindAllStringSubmatch(s.Value, -1) {
+			k := m[1]
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			out = append(out, k)
+		}
+	})
+	return out
+}
+
+// bodyForRefScan returns a yaml.Node that mirrors the input but with the
+// spec.parameters subtree spliced out. We intentionally do NOT mutate the
+// input — the caller still needs the original tree for substitution against
+// the entire profile (parameters block included, so any `${OTHER}` chain
+// declared inside a default still resolves).
+func bodyForRefScan(node *yaml.Node) *yaml.Node {
+	clone := cloneNode(node)
+	if clone == nil {
+		return nil
+	}
+	root := clone
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		root = root.Content[0]
+	}
+	if root.Kind != yaml.MappingNode {
+		return clone
+	}
+	specNode := mappingValue(root, "spec")
+	if specNode == nil || specNode.Kind != yaml.MappingNode {
+		return clone
+	}
+	// Drop the parameters mapping entry from the spec mapping content.
+	out := make([]*yaml.Node, 0, len(specNode.Content))
+	for i := 0; i+1 < len(specNode.Content); i += 2 {
+		key := specNode.Content[i]
+		if key.Kind == yaml.ScalarNode && key.Value == "parameters" {
+			continue
+		}
+		out = append(out, specNode.Content[i], specNode.Content[i+1])
+	}
+	specNode.Content = out
+	return clone
+}
+
+func mappingValue(m *yaml.Node, key string) *yaml.Node {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// substituteScalars rewrites every `${KEY}` occurrence inside scalar values
+// with values[KEY]. Mapping keys are not rewritten (per the proposal). Keys
+// not present in values are left as literal `${KEY}` — callers must validate
+// references first.
+func substituteScalars(node *yaml.Node, values map[string]string) {
+	walkScalars(node, func(s *yaml.Node) {
+		if !strings.Contains(s.Value, "${") {
+			return
+		}
+		s.Value = paramRefRE.ReplaceAllStringFunc(s.Value, func(match string) string {
+			k := paramRefRE.FindStringSubmatch(match)[1]
+			if v, ok := values[k]; ok {
+				return v
+			}
+			return match
+		})
+		// Clear the resolved type tag: the post-substitution value may no
+		// longer match the pre-substitution shape (e.g., `${PORT}` typed as
+		// !!int when PORT="8080" must stay a string after `${PORT}-foo`
+		// substitutes to `8080-foo`). Style is preserved so quoting hints
+		// (DoubleQuoted, Literal block) flow through.
+		s.Tag = ""
+	})
+}
+
+// walkScalars traverses the YAML node tree, invoking f on every scalar value
+// node — but NOT on mapping keys. Aliases are not followed: callers that
+// rely on anchor/alias references must substitute on the anchored node only.
+func walkScalars(n *yaml.Node, f func(*yaml.Node)) {
+	if n == nil {
+		return
+	}
+	switch n.Kind {
+	case yaml.DocumentNode:
+		for _, c := range n.Content {
+			walkScalars(c, f)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			walkScalars(n.Content[i+1], f)
+		}
+	case yaml.SequenceNode:
+		for _, c := range n.Content {
+			walkScalars(c, f)
+		}
+	case yaml.ScalarNode:
+		f(n)
+	case yaml.AliasNode:
+		// No-op: aliases share state with the anchor; substituting via the
+		// alias would double-mutate the underlying node.
+	}
+}
+
+// cloneNode returns a deep copy of n so substitutions don't mutate the input.
+// yaml.v3 doesn't expose a clone primitive — round-tripping through bytes is
+// the simplest faithful copy and stays within the bounds of a profile-sized
+// document. On marshal/unmarshal failure we fall back to the input pointer:
+// the caller still gets a working tree, just one shared with the source.
+func cloneNode(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	raw, err := yaml.Marshal(n)
+	if err != nil {
+		return n
+	}
+	var out yaml.Node
+	if uerr := yaml.Unmarshal(raw, &out); uerr != nil {
+		return n
+	}
+	return &out
+}
+
+// ParseParamArgs validates a slice of `KEY=VALUE` strings (from --param) and
+// returns the equivalent map. Empty values are allowed (`KEY=` → "");
+// missing `=` errors. Duplicate keys: last occurrence wins, matching `docker
+// run -e` semantics.
+func ParseParamArgs(args []string) (map[string]string, error) {
+	out := make(map[string]string, len(args))
+	for _, arg := range args {
+		k, v, ok := splitKV(arg)
+		if !ok {
+			return nil, fmt.Errorf(
+				"invalid --param %q: want KEY=VALUE: %w",
+				arg, errdefs.ErrProfileInvalid,
+			)
+		}
+		if !paramNameRE.MatchString(k) {
+			return nil, fmt.Errorf(
+				"invalid --param %q: KEY must match [A-Za-z_][A-Za-z0-9_]*: %w",
+				arg, errdefs.ErrProfileInvalid,
+			)
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// ParseParamFile reads path and parses it as a list of `KEY=VALUE` lines.
+// Blank lines and lines whose first non-whitespace character is `#` are
+// skipped (POSIX-ish comment shape). Same KEY=VALUE rules as ParseParamArgs.
+//
+// Values are taken verbatim after the first `=` — no quote stripping, no
+// shell expansion. Callers that need shell semantics should pre-render their
+// own file. Trailing CR is stripped so files written on Windows host editors
+// still parse cleanly.
+func ParseParamFile(path string) (map[string]string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --param-file %q: %w", path, err)
+	}
+	out := make(map[string]string)
+	for i, line := range strings.Split(string(raw), "\n") {
+		line = strings.TrimRight(line, "\r")
+		trim := strings.TrimSpace(line)
+		if trim == "" || strings.HasPrefix(trim, "#") {
+			continue
+		}
+		k, v, ok := splitKV(line)
+		if !ok {
+			return nil, fmt.Errorf(
+				"%s:%d: invalid line %q: want KEY=VALUE: %w",
+				path, i+1, line, errdefs.ErrProfileInvalid,
+			)
+		}
+		if !paramNameRE.MatchString(k) {
+			return nil, fmt.Errorf(
+				"%s:%d: invalid KEY %q: must match [A-Za-z_][A-Za-z0-9_]*: %w",
+				path, i+1, k, errdefs.ErrProfileInvalid,
+			)
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// MergeParams returns the union of base and overrides, with overrides
+// winning on duplicate keys. Used by `kuke run` to layer --param on top of
+// --param-file (CLI flag is later-binding than the file).
+func MergeParams(base, overrides map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(overrides))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overrides {
+		out[k] = v
+	}
+	return out
+}
+
+func splitKV(s string) (string, string, bool) {
+	eq := strings.IndexByte(s, '=')
+	if eq < 0 {
+		return "", "", false
+	}
+	return strings.TrimSpace(s[:eq]), s[eq+1:], true
+}

--- a/internal/cellprofile/params_test.go
+++ b/internal/cellprofile/params_test.go
@@ -1,0 +1,554 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellprofile_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cellprofile"
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+const paramProfile = `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: dev
+spec:
+  parameters:
+    - name: PROMPT
+      description: "Slash command passed to claude --print"
+      required: true
+    - name: PROJECT_REPO
+      description: "Git URL of the target project"
+      required: true
+    - name: PROJECT_DIR
+      description: "Short dirname for the project clone"
+      required: true
+    - name: AGENTS_REPO
+      description: "owner/repo of the agents repo"
+      default: "eminwux/agents"
+    - name: CLAUDE_IMAGE
+      description: "Container image tag for the worker"
+      default: "registry.eminwux.com/claude:latest"
+  cell:
+    containers:
+      - id: work
+        image: ${CLAUDE_IMAGE}
+        env:
+          - PROMPT=${PROMPT}
+          - PROJECT_REPO=${PROJECT_REPO}
+          - PROJECT_DIR=${PROJECT_DIR}
+          - AGENTS_REPO=${AGENTS_REPO}
+`
+
+// noEnv is the env-fallback callers pass when they want to disable env
+// lookup entirely — substitution then comes from --param + defaults only.
+func noEnv(string) (string, bool) { return "", false }
+
+func TestLoadResolved_RequiredParamsViaCLI(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "dev.yaml", paramProfile)
+
+	cli := map[string]string{
+		"PROMPT":       "/pick-issue 354",
+		"PROJECT_REPO": "https://github.com/eminwux/crew",
+		"PROJECT_DIR":  "crew",
+	}
+
+	got, err := cellprofile.LoadResolved(dir, "dev", cli, noEnv)
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+
+	if len(got.Spec.Cell.Containers) != 1 {
+		t.Fatalf("containers=%d want 1", len(got.Spec.Cell.Containers))
+	}
+	c := got.Spec.Cell.Containers[0]
+	if c.Image != "registry.eminwux.com/claude:latest" {
+		t.Errorf("image=%q want default substituted", c.Image)
+	}
+	wantEnv := []string{
+		"PROMPT=/pick-issue 354",
+		"PROJECT_REPO=https://github.com/eminwux/crew",
+		"PROJECT_DIR=crew",
+		"AGENTS_REPO=eminwux/agents",
+	}
+	if !reflect.DeepEqual(c.Env, wantEnv) {
+		t.Errorf("env=%v\nwant %v", c.Env, wantEnv)
+	}
+}
+
+func TestLoadResolved_CLIBeatsDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "dev.yaml", paramProfile)
+
+	got, err := cellprofile.LoadResolved(dir, "dev", map[string]string{
+		"PROMPT":       "test",
+		"PROJECT_REPO": "test",
+		"PROJECT_DIR":  "test",
+		"AGENTS_REPO":  "override/agents",
+	}, noEnv)
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+	if got.Spec.Cell.Containers[0].Env[3] != "AGENTS_REPO=override/agents" {
+		t.Errorf("env[3]=%q want AGENTS_REPO=override/agents (CLI override wins over default)",
+			got.Spec.Cell.Containers[0].Env[3])
+	}
+}
+
+func TestLoadResolved_EnvFallback(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "dev.yaml", paramProfile)
+
+	env := map[string]string{
+		"PROMPT":       "from-env",
+		"PROJECT_REPO": "env://repo",
+		"PROJECT_DIR":  "envdir",
+	}
+	lookup := func(k string) (string, bool) {
+		v, ok := env[k]
+		return v, ok
+	}
+
+	got, err := cellprofile.LoadResolved(dir, "dev", nil, lookup)
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+	if got.Spec.Cell.Containers[0].Env[0] != "PROMPT=from-env" {
+		t.Errorf("env[0]=%q want PROMPT=from-env (env fallback)",
+			got.Spec.Cell.Containers[0].Env[0])
+	}
+}
+
+func TestLoadResolved_DefaultBeatsEnv(t *testing.T) {
+	// Defaults are declared in the profile and must win over the env fallback —
+	// otherwise a stray env var on the host would silently shadow what the
+	// profile author wrote down.
+	dir := t.TempDir()
+	writeProfile(t, dir, "dev.yaml", paramProfile)
+
+	env := map[string]string{"AGENTS_REPO": "from-env/agents"}
+	got, err := cellprofile.LoadResolved(dir, "dev", map[string]string{
+		"PROMPT":       "x",
+		"PROJECT_REPO": "x",
+		"PROJECT_DIR":  "x",
+	}, func(k string) (string, bool) {
+		v, ok := env[k]
+		return v, ok
+	})
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+	if got.Spec.Cell.Containers[0].Env[3] != "AGENTS_REPO=eminwux/agents" {
+		t.Errorf("env[3]=%q want AGENTS_REPO=eminwux/agents (default beats env)",
+			got.Spec.Cell.Containers[0].Env[3])
+	}
+}
+
+func TestLoadResolved_RequiredMissing_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "dev.yaml", paramProfile)
+
+	_, err := cellprofile.LoadResolved(dir, "dev", nil, noEnv)
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "PROMPT") {
+		t.Errorf("err %q must name the missing required parameter", err)
+	}
+}
+
+func TestLoadResolved_UndeclaredCLIParam_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "dev.yaml", paramProfile)
+
+	_, err := cellprofile.LoadResolved(dir, "dev", map[string]string{
+		"PROMPT":       "x",
+		"PROJECT_REPO": "x",
+		"PROJECT_DIR":  "x",
+		"NOT_A_PARAM":  "oops",
+	}, noEnv)
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "NOT_A_PARAM") {
+		t.Errorf("err %q must name the undeclared --param key", err)
+	}
+}
+
+func TestLoad_UndeclaredReference_Errors(t *testing.T) {
+	// Refs to undeclared params are caught at install time so a typo doesn't
+	// silently leave a literal `${KEY}` in the rendered cell at runtime.
+	dir := t.TempDir()
+	writeProfile(t, dir, "bad.yaml", `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: bad
+spec:
+  parameters:
+    - name: GOOD
+      default: "ok"
+  cell:
+    containers:
+      - id: work
+        image: ${TYPO}
+`)
+
+	_, err := cellprofile.Load(dir, "bad")
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "TYPO") {
+		t.Errorf("err %q must name the undeclared reference", err)
+	}
+}
+
+func TestLoad_DuplicateParameter_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "dup.yaml", `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: dup
+spec:
+  parameters:
+    - name: KEY
+      default: "a"
+    - name: KEY
+      default: "b"
+  cell:
+    containers:
+      - id: work
+        image: registry.eminwux.com/busybox:latest
+`)
+
+	_, err := cellprofile.Load(dir, "dup")
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+	if !strings.Contains(err.Error(), "KEY") {
+		t.Errorf("err %q must name the duplicated parameter", err)
+	}
+}
+
+func TestLoad_InvalidParameterName_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "bad.yaml", `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: bad
+spec:
+  parameters:
+    - name: "1NOT-VALID"
+  cell:
+    containers:
+      - id: work
+        image: registry.eminwux.com/busybox:latest
+`)
+
+	_, err := cellprofile.Load(dir, "bad")
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+}
+
+func TestLoadResolved_EmptyStringIsValidValue(t *testing.T) {
+	// Empty strings are a valid resolved value and must not trigger the
+	// required/default fallback — they're how callers say "explicitly
+	// nothing here." Distinct from "unset" (no provider returns a value).
+	dir := t.TempDir()
+	writeProfile(t, dir, "p.yaml", `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: p
+spec:
+  parameters:
+    - name: NOTE
+      required: true
+  cell:
+    containers:
+      - id: work
+        image: registry.eminwux.com/busybox:latest
+        env:
+          - NOTE=${NOTE}
+`)
+
+	got, err := cellprofile.LoadResolved(dir, "p", map[string]string{"NOTE": ""}, noEnv)
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+	if got.Spec.Cell.Containers[0].Env[0] != "NOTE=" {
+		t.Errorf("env[0]=%q want NOTE= (empty string is a valid value)",
+			got.Spec.Cell.Containers[0].Env[0])
+	}
+}
+
+func TestLoadResolved_NonRequiredUnset_SubstitutesEmpty(t *testing.T) {
+	// A declared, referenced, non-required parameter with no provider
+	// resolves to "" — matching `envsubst` behavior. Profiles that need
+	// "literal ${KEY}" should escape via shell/templating layer above.
+	dir := t.TempDir()
+	writeProfile(t, dir, "p.yaml", `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: p
+spec:
+  parameters:
+    - name: NOTE
+  cell:
+    containers:
+      - id: work
+        image: registry.eminwux.com/busybox:latest
+        env:
+          - NOTE=${NOTE}
+`)
+
+	got, err := cellprofile.LoadResolved(dir, "p", nil, noEnv)
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+	if got.Spec.Cell.Containers[0].Env[0] != "NOTE=" {
+		t.Errorf("env[0]=%q want NOTE= (unset non-required → empty)",
+			got.Spec.Cell.Containers[0].Env[0])
+	}
+}
+
+func TestLoadResolved_NoParameters_NoOp(t *testing.T) {
+	// Profiles without parameters[] keep working — the new substitution path
+	// is a no-op for them. This is the migration safety net the proposal
+	// promises ("No breaking change").
+	dir := t.TempDir()
+	writeProfile(t, dir, "claude-cell.yaml", claudeProfile)
+
+	got, err := cellprofile.LoadResolved(dir, "claude-cell", nil, noEnv)
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+	if got.Metadata.Name != "claude-cell" {
+		t.Errorf("metadata.name=%q want claude-cell", got.Metadata.Name)
+	}
+	if len(got.Spec.Cell.Containers) != 2 {
+		t.Errorf("containers=%d want 2", len(got.Spec.Cell.Containers))
+	}
+}
+
+func TestLoadResolved_PartialReferences(t *testing.T) {
+	// Substitution must work mid-string (not only when ${KEY} is the entire
+	// value) — this is the common case for image tags and env values.
+	dir := t.TempDir()
+	writeProfile(t, dir, "p.yaml", `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: p
+spec:
+  parameters:
+    - name: TAG
+      required: true
+  cell:
+    containers:
+      - id: work
+        image: registry.eminwux.com/busybox:${TAG}-stable
+`)
+
+	got, err := cellprofile.LoadResolved(dir, "p",
+		map[string]string{"TAG": "1.36"}, noEnv)
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+	if got.Spec.Cell.Containers[0].Image != "registry.eminwux.com/busybox:1.36-stable" {
+		t.Errorf("image=%q want registry.eminwux.com/busybox:1.36-stable",
+			got.Spec.Cell.Containers[0].Image)
+	}
+}
+
+func TestLoadResolved_ParametersBlockExempted(t *testing.T) {
+	// Defaults that contain `${VAR}`-shaped text (e.g., a profile that
+	// proxies its substitutions through to a downstream tool) must not
+	// trigger the "undeclared reference" check. The validator scans the
+	// cell body, not the parameter declarations.
+	dir := t.TempDir()
+	writeProfile(t, dir, "p.yaml", `apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: p
+spec:
+  parameters:
+    - name: SHELL_LIT
+      default: "${HOME}/bin"
+  cell:
+    containers:
+      - id: work
+        image: registry.eminwux.com/busybox:latest
+        env:
+          - SHELL_LIT=${SHELL_LIT}
+`)
+
+	got, err := cellprofile.LoadResolved(dir, "p", nil, noEnv)
+	if err != nil {
+		t.Fatalf("LoadResolved: %v", err)
+	}
+	if got.Spec.Cell.Containers[0].Env[0] != "SHELL_LIT=${HOME}/bin" {
+		t.Errorf("env[0]=%q want SHELL_LIT=${HOME}/bin (literal default flows through)",
+			got.Spec.Cell.Containers[0].Env[0])
+	}
+}
+
+func TestParseParamArgs_HappyPath(t *testing.T) {
+	got, err := cellprofile.ParseParamArgs([]string{
+		"A=alpha",
+		"B=value with spaces",
+		"C=",
+		"D=has=equals",
+	})
+	if err != nil {
+		t.Fatalf("ParseParamArgs: %v", err)
+	}
+	want := map[string]string{
+		"A": "alpha",
+		"B": "value with spaces",
+		"C": "",
+		"D": "has=equals",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestParseParamArgs_MissingEquals_Errors(t *testing.T) {
+	_, err := cellprofile.ParseParamArgs([]string{"NOEQ"})
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+}
+
+func TestParseParamArgs_InvalidName_Errors(t *testing.T) {
+	_, err := cellprofile.ParseParamArgs([]string{"1BAD=x"})
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+}
+
+func TestParseParamFile_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.params")
+	body := "# leading comment\n" +
+		"\n" +
+		"  # indented comment\n" +
+		"A=alpha\n" +
+		"B=value with spaces\n" +
+		"C=\n" +
+		"D=has=equals\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := cellprofile.ParseParamFile(path)
+	if err != nil {
+		t.Fatalf("ParseParamFile: %v", err)
+	}
+	want := map[string]string{
+		"A": "alpha",
+		"B": "value with spaces",
+		"C": "",
+		"D": "has=equals",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestParseParamFile_BadLine_Errors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.params")
+	if err := os.WriteFile(path, []byte("OK=1\nBAD-LINE\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := cellprofile.ParseParamFile(path)
+	if !errors.Is(err, errdefs.ErrProfileInvalid) {
+		t.Fatalf("err=%v want ErrProfileInvalid", err)
+	}
+	if !strings.Contains(err.Error(), ":2:") {
+		t.Errorf("err %q must name the offending line number", err)
+	}
+}
+
+func TestMergeParams_OverridesWin(t *testing.T) {
+	got := cellprofile.MergeParams(
+		map[string]string{"A": "from-base", "B": "kept"},
+		map[string]string{"A": "from-override", "C": "added"},
+	)
+	want := map[string]string{
+		"A": "from-override",
+		"B": "kept",
+		"C": "added",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v want %v", got, want)
+	}
+}
+
+func TestMaterializeWithName_OverridesGenerated(t *testing.T) {
+	dir := t.TempDir()
+	writeProfile(t, dir, "claude-cell.yaml", claudeProfile)
+
+	profile, err := cellprofile.Load(dir, "claude-cell")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	got, err := cellprofile.MaterializeWithName(profile, "pinned-name-1")
+	if err != nil {
+		t.Fatalf("MaterializeWithName: %v", err)
+	}
+	if got.Metadata.Name != "pinned-name-1" {
+		t.Errorf("name=%q want pinned-name-1 (no suffix)", got.Metadata.Name)
+	}
+	if got.Spec.ID != "pinned-name-1" {
+		t.Errorf("spec.id=%q want pinned-name-1 (mirrors metadata.name)", got.Spec.ID)
+	}
+	// Profile-of-origin label still flows through under the override.
+	if got.Metadata.Labels[cellprofile.LabelProfile] != "claude-cell" {
+		t.Errorf("profile label=%q want claude-cell",
+			got.Metadata.Labels[cellprofile.LabelProfile])
+	}
+}
+
+func TestMaterializeWithName_EmptyFallsBackToGenerated(t *testing.T) {
+	// Empty/whitespace nameOverride must behave exactly like Materialize —
+	// the override path is opt-in, and a blank --name on the CLI must not
+	// silently produce a cell named "".
+	dir := t.TempDir()
+	writeProfile(t, dir, "claude-cell.yaml", claudeProfile)
+
+	profile, err := cellprofile.Load(dir, "claude-cell")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	got, err := cellprofile.MaterializeWithName(profile, "  ")
+	if err != nil {
+		t.Fatalf("MaterializeWithName: %v", err)
+	}
+	if !strings.HasPrefix(got.Metadata.Name, "claude-cell-") {
+		t.Errorf("name=%q want generated <claude-cell>-<6hex>", got.Metadata.Name)
+	}
+}

--- a/pkg/api/model/v1beta1/cellprofile.go
+++ b/pkg/api/model/v1beta1/cellprofile.go
@@ -40,10 +40,30 @@ type CellProfileMetadata struct {
 // names; when unset, the prefix defaults to metadata.name. Every Materialize
 // call appends a `-<6hex>` suffix so each invocation produces a fresh cell —
 // CellProfile is always a template. Use the Cell kind for singleton workloads.
+//
+// Parameters declares the `${KEY}` substitution variables the profile body
+// references. `kuke run -p` resolves each declared parameter against the
+// caller's --param map, the parameter's Default, and (when permitted) the
+// kuke process's env, in that order. Profiles fail to load when the body
+// references a key that is not declared here, so typos surface at install
+// time rather than as a runtime mystery.
 type CellProfileSpec struct {
-	Realm  string   `json:"realm,omitempty"  yaml:"realm,omitempty"`
-	Space  string   `json:"space,omitempty"  yaml:"space,omitempty"`
-	Stack  string   `json:"stack,omitempty"  yaml:"stack,omitempty"`
-	Prefix string   `json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	Cell   CellSpec `json:"cell"             yaml:"cell"`
+	Realm      string                 `json:"realm,omitempty"      yaml:"realm,omitempty"`
+	Space      string                 `json:"space,omitempty"      yaml:"space,omitempty"`
+	Stack      string                 `json:"stack,omitempty"      yaml:"stack,omitempty"`
+	Prefix     string                 `json:"prefix,omitempty"     yaml:"prefix,omitempty"`
+	Parameters []CellProfileParameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Cell       CellSpec               `json:"cell"                 yaml:"cell"`
+}
+
+// CellProfileParameter declares one substitution variable used by the
+// profile body. Default is a pointer so YAML/JSON can distinguish "no
+// default" (nil) from an explicit empty default (""). The substitution
+// engine treats them differently: a missing default falls through to the
+// env-var lookup, while an explicit empty default short-circuits there.
+type CellProfileParameter struct {
+	Name        string  `json:"name"                  yaml:"name"`
+	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Default     *string `json:"default,omitempty"     yaml:"default,omitempty"`
+	Required    bool    `json:"required,omitempty"    yaml:"required,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Adds `spec.parameters[]` to `CellProfile` (name + description + optional default + required), so a profile can declare its variable inputs alongside its body.
- Wires three new flags on `kuke run -p`: `--name <override>` (replaces the auto-generated `<prefix>-<6hex>` cell name), `--param KEY=VALUE` (repeatable), and `--param-file <file>` (KEY=VALUE per line, `#` comments). All three are rejected when combined with `-f`.
- Implements `${KEY}` substitution over the loaded YAML node tree. Resolution order per key: CLI `--param` > `--param-file` > parameter's `default` > process env (`os.LookupEnv` on the kuke binary's env) > error if `required: true`. Non-required, referenced, unset → empty string (envsubst-compatible). Substitution operates on scalar *values* only — keys are never touched, and `spec.parameters[]` defaults are exempt from the undeclared-ref scan so `default: \"\${VAR}\"` is a literal default, not a recursive reference.
- Validation: at load, undeclared `${KEY}` refs in the body fail with `ErrProfileInvalid`; duplicate / invalid parameter names fail. At call, undeclared `--param` keys fail.
- Backward-compatible: profiles without `spec.parameters` and without `${...}` refs go through the original `Load`/`Materialize` path unchanged.

### Non-obvious calls (please push back if wrong)

- The issue spec says "process env (the kukeond process, not the caller)", but profiles are a client-side artifact loaded by the `kuke` CLI before anything reaches the daemon. Interpreted as the `kuke` binary's process env (`os.LookupEnv`); the substituted body is what gets sent to kukeond.
- Non-required + unset substitutes to empty string rather than leaving the literal `\${KEY}`, matching shell `envsubst`. Required + unset still errors.
- `--name` / `--param` / `--param-file` are rejected with `-f` (file mode is not a profile and has no parameter declarations).
- `--param` wins over `--param-file` (later-binding) when both supply the same key.

## Test plan

- [x] `make test` (full suite green; new tests in `internal/cellprofile/params_test.go` and `cmd/kuke/run/run_test.go`)
- [x] `pre-commit run --files <changed>` (go fmt / golangci-lint / addlicense / go-mod-tidy clean)
- [x] `go vet ./...` and `go build ./...` clean
- [x] `make dev-init` end-to-end smoke — ran on the PR branch; daemon parity check identical for `kuke get realms` and `kuke get realms --no-daemon`.

Closes #355