### PR TITLE
build: gofmt + prettier sweep to clear pre-commit --all-files drift

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -9,9 +9,9 @@ on:
     branches:
       - main
     paths:
-      - 'docs/site/**'
-      - 'mkdocs.yml'
-      - '.github/workflows/mkdocs.yaml'
+      - "docs/site/**"
+      - "mkdocs.yml"
+      - ".github/workflows/mkdocs.yaml"
   workflow_dispatch:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -357,11 +357,13 @@ func CompleteResourceNames(cmd *cobra.Command, args []string, toComplete string)
 ```
 
 The function parameters are:
+
 - `cmd`: The Cobra command being completed
 - `args`: Already provided arguments
 - `toComplete`: The prefix string the user has typed (for filtering)
 
 The return values are:
+
 - `[]string`: List of completion suggestions
 - `cobra.ShellCompDirective`: Directive controlling completion behavior (typically `cobra.ShellCompDirectiveNoFileComp`)
 
@@ -541,6 +543,7 @@ func TestCompleteRealmNames(t *testing.T) {
 ### 3. Test Scenarios
 
 Tests MUST cover:
+
 - Success cases with multiple resources
 - Empty list scenarios
 - Prefix filtering
@@ -731,6 +734,7 @@ This file demonstrates:
 **Why:** The create realm command is used to create new realms, so there are no existing realms to autocomplete. Users should type the realm name explicitly.
 
 **Implementation:**
+
 - Do NOT register `ValidArgsFunction` for the create realm command
 - The test `TestNewRealmCmd_AutocompleteRegistration` should verify that `ValidArgsFunction` is `nil`
 
@@ -907,6 +911,7 @@ This document establishes the **mandatory process** for verifying test consisten
 ## Purpose
 
 Regular verification of test consistency helps:
+
 - Identify missing tests across command groups
 - Ensure all commands follow the same testing patterns
 - Maintain consistent test coverage across similar command types
@@ -930,12 +935,15 @@ The verification process consists of six systematic steps:
 **Objective:** Create a complete inventory of all command files and their corresponding test files.
 
 **Actions:**
+
 1. Search for all command constructor functions:
+
    ```bash
    grep -r "^func New.*Cmd(" cmd/kuke --include="*.go" | grep -v "_test.go"
    ```
 
 2. Search for all test files:
+
    ```bash
    find cmd/kuke -name "*_test.go" -type f
    ```
@@ -945,6 +953,7 @@ The verification process consists of six systematic steps:
    - Note any commands without test files
 
 **Expected Output:**
+
 - List of all command files (e.g., `cmd/kuke/create/realm/realm.go`)
 - List of all test files (e.g., `cmd/kuke/create/realm/realm_test.go`)
 - Mapping between commands and their test files
@@ -954,7 +963,9 @@ The verification process consists of six systematic steps:
 **Objective:** Extract and categorize all test function names from each test file.
 
 **Actions:**
+
 1. Search for all test functions:
+
    ```bash
    grep -r "^func Test" cmd/kuke --include="*_test.go"
    ```
@@ -970,6 +981,7 @@ The verification process consists of six systematic steps:
    - **Other Tests**: Helper tests, utility tests, etc.
 
 **Expected Output:**
+
 - Complete list of test functions per file
 - Categorization of each test function by type
 - Identification of test function naming patterns
@@ -979,6 +991,7 @@ The verification process consists of six systematic steps:
 **Objective:** Create matrices showing which test types each command has or is missing.
 
 **Actions:**
+
 1. **For Parent Commands** (create, delete, get, start, stop, purge, kill):
    - Create a matrix with columns: Command, Metadata, Subcommands, Autocomplete, Persistent Flags, Viper Bindings
    - Mark each cell as ✅ (present) or ❌ (missing)
@@ -993,6 +1006,7 @@ The verification process consists of six systematic steps:
    - Note that they may have different expected test types
 
 **Expected Output:**
+
 - Parent commands test coverage matrix
 - Resource commands test coverage matrices (one per operation)
 - Special commands documentation
@@ -1002,6 +1016,7 @@ The verification process consists of six systematic steps:
 **Objective:** Determine which commands follow consistent patterns and identify outliers.
 
 **Actions:**
+
 1. **Group Commands by Type:**
    - Parent commands (create, delete, get, start, stop, purge, kill)
    - Resource commands by operation (create/realm, delete/realm, get/realm, etc.)
@@ -1018,6 +1033,7 @@ The verification process consists of six systematic steps:
    - Commands with unusual test structures
 
 **Expected Output:**
+
 - List of consistent patterns (e.g., "All start/stop resource commands have identical test patterns")
 - List of inconsistent patterns (e.g., "Some get commands missing execution tests")
 - Identification of outliers
@@ -1027,6 +1043,7 @@ The verification process consists of six systematic steps:
 **Objective:** Organize commands into consistency groups based on test coverage completeness.
 
 **Actions:**
+
 1. **Group 1: Fully Consistent Commands**
    - Commands that have all expected test types for their category
    - Mark as "Complete" in the matrix
@@ -1046,6 +1063,7 @@ The verification process consists of six systematic steps:
    - Document their unique patterns and why they differ
 
 **Expected Output:**
+
 - Commands grouped by consistency level
 - Summary of what makes each group consistent or inconsistent
 - Count of commands in each group
@@ -1055,6 +1073,7 @@ The verification process consists of six systematic steps:
 **Objective:** Create a comprehensive report documenting findings and recommendations.
 
 **Actions:**
+
 1. **Create Summary Section:**
    - Overall assessment of test coverage
    - Statistics (e.g., "X% of commands have complete coverage")
@@ -1081,6 +1100,7 @@ The verification process consists of six systematic steps:
    - Note any naming/style differences
 
 **Expected Output:**
+
 - Comprehensive markdown report (e.g., `TESTING_CONSISTENCY_REPORT.md`)
 - Clear recommendations prioritized by importance
 - Actionable items for improving test consistency
@@ -1090,6 +1110,7 @@ The verification process consists of six systematic steps:
 ### Parent Commands
 
 All parent commands (create, delete, get, start, stop, purge) should have:
+
 - ✅ `TestNew<Command>CmdMetadata` or `TestNew<Command>Cmd` (structure test)
 - ✅ `TestNew<Command>CmdRegistersSubcommands` (subcommand registration)
 - ✅ `TestNew<Command>Cmd_AutocompleteRegistration` (autocomplete for subcommands)
@@ -1101,6 +1122,7 @@ All parent commands (create, delete, get, start, stop, purge) should have:
 ### Resource Commands - Create
 
 All create resource commands should have:
+
 - ✅ `TestNew<Resource>Cmd` or `TestNew<Resource>CmdRunE` (structure/execution)
 - ✅ `TestNew<Resource>CmdRunE` (execution test)
 - ✅ `TestPrint<Resource>Result` (output formatting)
@@ -1111,6 +1133,7 @@ All create resource commands should have:
 ### Resource Commands - Delete
 
 All delete resource commands should have:
+
 - ✅ `TestNew<Resource>Cmd` (structure test, optional)
 - ✅ `TestNew<Resource>CmdRunE` (execution test)
 - ✅ `TestNew<Resource>Cmd_AutocompleteRegistration` (autocomplete)
@@ -1118,6 +1141,7 @@ All delete resource commands should have:
 ### Resource Commands - Get
 
 All get resource commands should have:
+
 - ✅ `TestNew<Resource>Cmd` (structure test, optional)
 - ✅ `TestNew<Resource>CmdRunE` (execution test)
 - ✅ `TestPrint<Resource>` and/or `TestPrint<Resources>` (output formatting)
@@ -1126,12 +1150,14 @@ All get resource commands should have:
 ### Resource Commands - Start/Stop
 
 All start/stop resource commands should have:
+
 - ✅ `TestNew<Resource>CmdRunE` (execution test)
 - ✅ `TestNew<Resource>Cmd_AutocompleteRegistration` (autocomplete)
 
 ### Resource Commands - Purge
 
 All purge resource commands should have:
+
 - ✅ `TestNew<Resource>Cmd` (structure test)
 - ✅ `TestNew<Resource>CmdRunE` (execution test)
 - ✅ `TestNew<Resource>Cmd_AutocompleteRegistration` (autocomplete)
@@ -1181,6 +1207,7 @@ When performing test consistency verification, ensure:
 ## Frequency
 
 This verification process should be performed:
+
 - **After major refactoring** of command structure
 - **Before releases** to ensure test quality
 - **When adding new command types** to ensure consistency
@@ -1249,6 +1276,7 @@ type RealmStatus struct {
 ```
 
 **Characteristics:**
+
 - No version information
 - Stable structure across API versions
 - Used by all internal business logic
@@ -1265,6 +1293,7 @@ func NormalizeRealm(req ext.RealmDoc) (intmodel.Realm, ext.Version, error)
 ```
 
 **Pattern for Each Resource:**
+
 - `Convert*DocToInternal` - External → Internal (handles version switching)
 - `Build*ExternalFromInternal` - Internal → External (for specified version)
 - `Normalize*` - External → Internal with version defaulting
@@ -1289,6 +1318,7 @@ external, err := apischeme.BuildRealmExternalFromInternal(internal, version)
 ### 1. All Resources MUST Have ModelHub Types
 
 **Required Files:**
+
 - `internal/modelhub/realm.go` ✅
 - `internal/modelhub/space.go` ✅
 - `internal/modelhub/stack.go` ❌ (missing)
@@ -1296,6 +1326,7 @@ external, err := apischeme.BuildRealmExternalFromInternal(internal, version)
 - `internal/modelhub/container.go` ❌ (missing)
 
 **Pattern:**
+
 ```go
 type <Resource> struct {
     Metadata <Resource>Metadata
@@ -1307,11 +1338,13 @@ type <Resource> struct {
 ### 2. All Resources MUST Have Apischeme Conversions
 
 **Required Functions (per resource):**
+
 - `Convert<Resource>DocToInternal(ext.<Resource>Doc) -> (intmodel.<Resource>, error)`
 - `Build<Resource>ExternalFromInternal(intmodel.<Resource>, ext.Version) -> (ext.<Resource>Doc, error)`
 - `Normalize<Resource>(ext.<Resource>Doc) -> (intmodel.<Resource>, ext.Version, error)`
 
 **Version Handling:**
+
 - Switch statements to handle different API versions
 - Default empty version to latest supported version
 - Return error for unsupported versions
@@ -1319,17 +1352,19 @@ type <Resource> struct {
 ### 3. Controllers MUST Use Internal Types
 
 **Controller Methods Should:**
+
 - Accept internal types as parameters (or convert at entry)
 - Return internal types (or convert at exit)
 - Work with modelhub types throughout business logic
 
 **Example:**
+
 ```go
 // GOOD: Controller works with internal types
 func (r *Exec) CreateRealm(internal intmodel.Realm) (*v1beta1.RealmDoc, error) {
     // Work with internal type
     internal.Status.State = intmodel.RealmStateCreating
-    
+
     // Convert at boundary
     version := apischeme.VersionV1Beta1
     external, err := apischeme.BuildRealmExternalFromInternal(internal, version)
@@ -1347,11 +1382,13 @@ func (r *Exec) CreateRealm(doc *v1beta1.RealmDoc) (*v1beta1.RealmDoc, error) {
 ### 4. Utility Functions MUST Use Internal Types
 
 **Utility Functions Should:**
+
 - Accept internal types as parameters
 - Work with modelhub types
 - Not import `pkg/api` packages
 
 **Example:**
+
 ```go
 // GOOD: Utility uses internal types
 func BuildSpaceNetworkName(internal intmodel.Space) (string, error) {
@@ -1371,6 +1408,7 @@ func BuildSpaceNetworkName(doc *v1beta1.SpaceDoc) (string, error) {
 ### ✅ ALLOWED Imports
 
 **Only `internal/apischeme` can import `pkg/api`:**
+
 - `internal/apischeme/scheme.go` ✅ (conversion layer)
 - `internal/apischeme/scheme_test.go` ✅ (test file)
 
@@ -1379,6 +1417,7 @@ func BuildSpaceNetworkName(doc *v1beta1.SpaceDoc) (string, error) {
 ### ❌ PROHIBITED Imports
 
 **These patterns are violations:**
+
 ```go
 // BAD: Direct import in controller
 import v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -1392,6 +1431,7 @@ import v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 ### ⚠️ SPECIAL CASES
 
 **Daemon API (`pkg/api/apidaemon`):**
+
 - `internal/daemon` importing `pkg/api/apidaemon` is currently acceptable
 - This is a control API, not a resource API
 - Less likely to require versioning
@@ -1407,13 +1447,13 @@ import v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 func Test<Resource>RoundTripV1Beta1(t *testing.T) {
     // External → Internal
     internal, version, err := apischeme.Normalize<Resource>(externalInput)
-    
+
     // Modify internal (simulate controller logic)
     internal.Status.State = intmodel.<Resource>StateReady
-    
+
     // Internal → External
     external, err := apischeme.Build<Resource>ExternalFromInternal(internal, version)
-    
+
     // Validate round-trip
     // ...
 }
@@ -1422,6 +1462,7 @@ func Test<Resource>RoundTripV1Beta1(t *testing.T) {
 ### 2. Version Support Tests
 
 **Test all supported versions:**
+
 - Test conversion for each API version
 - Test error handling for unsupported versions
 - Test version defaulting (empty version)
@@ -1429,6 +1470,7 @@ func Test<Resource>RoundTripV1Beta1(t *testing.T) {
 ### 3. Field Mapping Tests
 
 **Test field name differences:**
+
 - External uses `RealmID`, internal uses `RealmName`
 - Test that conversions handle field name mappings correctly
 - Test that all fields are preserved through conversion
@@ -1444,12 +1486,15 @@ This section documents the **mandatory process** for validating apischeme and mo
 **Objective:** Identify all resource types and their modelhub/apischeme coverage.
 
 **Actions:**
+
 1. List all `*Doc` types in `pkg/api/model/v1beta1/`:
+
    ```bash
    grep -r "^type.*Doc struct" pkg/api/model/v1beta1
    ```
 
 2. Check for corresponding modelhub types:
+
    ```bash
    find internal/modelhub -name "*.go" -type f
    ```
@@ -1460,6 +1505,7 @@ This section documents the **mandatory process** for validating apischeme and mo
    ```
 
 **Expected Output:**
+
 - Complete list of resource types in pkg/api
 - Coverage matrix showing which resources have modelhub types
 - Coverage matrix showing which resources have apischeme conversions
@@ -1469,7 +1515,9 @@ This section documents the **mandatory process** for validating apischeme and mo
 **Objective:** Identify all direct imports from `internal/` to `pkg/api`.
 
 **Actions:**
+
 1. Search for all `pkg/api` imports in `internal/`:
+
    ```bash
    grep -r "pkg/api" internal/ --include="*.go"
    ```
@@ -1486,6 +1534,7 @@ This section documents the **mandatory process** for validating apischeme and mo
    - Field access
 
 **Expected Output:**
+
 - Complete list of import violations
 - Categorized by package and purpose
 - Identification of acceptable vs. problematic imports
@@ -1495,6 +1544,7 @@ This section documents the **mandatory process** for validating apischeme and mo
 **Objective:** Verify conversion functions are complete and correct.
 
 **Actions:**
+
 1. Check for all three conversion functions per resource:
    - `Convert*DocToInternal`
    - `Build*ExternalFromInternal`
@@ -1511,6 +1561,7 @@ This section documents the **mandatory process** for validating apischeme and mo
    - Error cases are covered
 
 **Expected Output:**
+
 - List of complete conversion patterns
 - List of missing conversion functions
 - Test coverage assessment
@@ -1520,12 +1571,15 @@ This section documents the **mandatory process** for validating apischeme and mo
 **Objective:** Determine how controllers use conversions vs. direct API types.
 
 **Actions:**
+
 1. Search for apischeme usage in controllers:
+
    ```bash
    grep -r "apischeme\\.(Normalize|Convert|Build)" internal/controller
    ```
 
 2. Search for direct pkg/api usage:
+
    ```bash
    grep -r "v1beta1\\." internal/controller
    ```
@@ -1536,6 +1590,7 @@ This section documents the **mandatory process** for validating apischeme and mo
    - Where controllers bypass conversions
 
 **Expected Output:**
+
 - List of controllers using apischeme correctly
 - List of controllers bypassing conversions
 - Identification of conversion boundaries
@@ -1545,7 +1600,9 @@ This section documents the **mandatory process** for validating apischeme and mo
 **Objective:** Assess readiness for multiple API versions.
 
 **Actions:**
+
 1. Check supported versions:
+
    ```bash
    grep -r "VersionV1Beta1\\|VersionV1\\|VersionV1Beta2" internal/apischeme
    ```
@@ -1561,6 +1618,7 @@ This section documents the **mandatory process** for validating apischeme and mo
    - Storage layer is version-aware
 
 **Expected Output:**
+
 - Current version support status
 - Multi-version readiness assessment
 - Gaps in version handling
@@ -1570,6 +1628,7 @@ This section documents the **mandatory process** for validating apischeme and mo
 **Objective:** Create comprehensive report documenting findings.
 
 **Actions:**
+
 1. **Create Summary Section:**
    - Overall decoupling status
    - Coverage statistics
@@ -1591,6 +1650,7 @@ This section documents the **mandatory process** for validating apischeme and mo
    - Provide examples for missing resources
 
 **Expected Output:**
+
 - Comprehensive markdown report (`API_SCHEME_VALIDATION_REPORT.md`)
 - Prioritized recommendations
 - Actionable items for achieving full decoupling
@@ -1637,22 +1697,27 @@ The validation report should be saved as `API_SCHEME_VALIDATION_REPORT.md` in th
 ### Reference Implementation: Realm/Space
 
 **ModelHub Types:**
+
 - `internal/modelhub/realm.go` - Complete Realm type
 - `internal/modelhub/space.go` - Complete Space type
 
 **Apischeme Conversions:**
+
 - `internal/apischeme/scheme.go` - Complete conversion functions
 
 **Usage Pattern:**
+
 - `internal/controller/runner/runner.go:134` - `CreateRealm` uses apischeme
 - `internal/controller/runner/runner.go:419` - `CreateSpace` uses apischeme
 
 **Test Coverage:**
+
 - `internal/apischeme/scheme_test.go` - Round-trip test for Realm
 
 ### Missing Implementation: Stack, Cell, Container
 
 **Required Actions:**
+
 1. Create modelhub types (`internal/modelhub/stack.go`, etc.)
 2. Implement apischeme conversions
 3. Add round-trip tests

--- a/docs/gaps-2026-04-19.md
+++ b/docs/gaps-2026-04-19.md
@@ -19,7 +19,7 @@ Items below are ordered by the pain they caused in that flow.
 
 ---
 
-## 1. `kuke init` does not self-heal stale on-disk config *(correctness bug)* — **DONE 2026-04-20**
+## 1. `kuke init` does not self-heal stale on-disk config _(correctness bug)_ — **DONE 2026-04-20**
 
 **Symptom.** After merging `SafeBridgeName` (commit `6a46bc4`), re-running
 `kuke init` on a host with a pre-fix conflist fails at
@@ -35,6 +35,7 @@ numerical result out of range`.
 to hosts that already have state on disk.
 
 **Resolution.**
+
 - `cni.Manager.ReadBridgeName` (`internal/cni/network.go`) parses an existing
   conflist and returns the bridge-plugin's `bridge` field, with sentinel
   errors `errdefs.ErrNetworkNotFound` and `errdefs.ErrBridgePluginMissing`.
@@ -75,6 +76,7 @@ sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
 Anyone iterating on `kukeond` hits this every rebuild.
 
 **Proposed fix.** Add `kuke reset` (or `kuke down`). Semantics:
+
 - Stop + delete the `kuke-system/kukeon/kukeon/kukeond` cell.
 - Remove `/run/kukeon/kukeond.{sock,pid}`.
 - Leave `/opt/kukeon/default/**` untouched (user realm data).
@@ -102,6 +104,7 @@ into `kukeon.io` (default realm) by mistake and wonder why `kuke init`
 can't find the image.
 
 **Proposed fix.** `kuke image load <tarball-or-docker-ref> --realm <name>`.
+
 - Default `--realm` to `kuke-system` for `kukeond` images.
 - Accept either a `docker save` tarball path, `-` for stdin, or a local
   docker reference (shell out to `docker save` internally).
@@ -135,6 +138,7 @@ which isn't readable without root + digging).
 the CLI is new, the daemon is old. Nothing tells you.
 
 **Proposed fix.**
+
 - `kuke version` prints the CLI version + build info.
 - When `--no-daemon` is absent, also query the daemon's `/version` endpoint
   and print its version alongside. Warn on mismatch.
@@ -149,6 +153,7 @@ the CLI is new, the daemon is old. Nothing tells you.
 ## 6. No `kuke doctor` / preflight
 
 **Symptom.** The class of problems I hit are all detectable ahead of time:
+
 - Stale conflist with oversized bridge name.
 - Missing kukeond image in the system namespace.
 - Orphaned sockets in `/run/kukeon/`.
@@ -204,6 +209,7 @@ This is the actual regression guard for the run-path bind-mount bug — and
 it runs only when a human remembers to run it.
 
 **Proposed fix.** `kuke selftest` (or extend `kuke doctor`) that:
+
 - Runs every `kuke get <resource>` both ways and diffs.
 - Fails on any divergence with a pointer to which resource disagrees.
 - Optional: also verify the kukeond container's mount spec includes
@@ -217,13 +223,13 @@ it runs only when a human remembers to run it.
 
 If picking up one at a time, I'd tackle them in this order:
 
-| Order | Item | Why first |
-| ----- | --------------------------------------------- | ---------------------------------------------------------- |
-| 1     | ~~#1 Self-heal stale conflist~~ (done)        | Latent correctness bug; silently breaks re-init across fix commits. |
-| 2     | #7 Translate raw netlink errors               | Cheap; makes #1-class bugs self-diagnosing going forward.  |
-| 3     | #2 `kuke reset`                               | Removes the biggest daily papercut for anyone hacking on kukeond. |
-| 4     | #6 `kuke doctor`                              | Central place to land preflight checks as they're written. |
-| 5     | #3 `kuke image load`                          | Removes the second-biggest papercut in the dev loop.       |
-| 6     | #5 `kuke version` w/ client-daemon check      | Prevents the "forgot to reimport image" foot-gun.          |
-| 7     | #4 `kuke logs`                                | Needed once users start debugging their own cells.         |
-| 8     | #8 `kuke ping` + #9 `kuke selftest`           | Polish; both fit naturally under `doctor`.                 |
+| Order | Item                                     | Why first                                                           |
+| ----- | ---------------------------------------- | ------------------------------------------------------------------- |
+| 1     | ~~#1 Self-heal stale conflist~~ (done)   | Latent correctness bug; silently breaks re-init across fix commits. |
+| 2     | #7 Translate raw netlink errors          | Cheap; makes #1-class bugs self-diagnosing going forward.           |
+| 3     | #2 `kuke reset`                          | Removes the biggest daily papercut for anyone hacking on kukeond.   |
+| 4     | #6 `kuke doctor`                         | Central place to land preflight checks as they're written.          |
+| 5     | #3 `kuke image load`                     | Removes the second-biggest papercut in the dev loop.                |
+| 6     | #5 `kuke version` w/ client-daemon check | Prevents the "forgot to reimport image" foot-gun.                   |
+| 7     | #4 `kuke logs`                           | Needed once users start debugging their own cells.                  |
+| 8     | #8 `kuke ping` + #9 `kuke selftest`      | Polish; both fit naturally under `doctor`.                          |

--- a/docs/site/architecture/storage-layout.md
+++ b/docs/site/architecture/storage-layout.md
@@ -89,13 +89,13 @@ If you want to inspect what Kukeon pushed into containerd, use `ctr -n kukeon-<r
 
 ## What gets cleaned up, and when
 
-| Operation                       | Removes                                                                 |
-|---------------------------------|-------------------------------------------------------------------------|
-| `kuke delete realm --cascade`   | The realm subtree under the run path, cgroups, CNI conflists           |
-| `kuke delete space --cascade`   | The space subtree, cgroups, CNI conflist                                |
-| `kuke delete cell --cascade`    | The cell subtree, cgroups, containerd containers                        |
-| `kuke purge <resource>`         | Same as delete but more aggressive: force-removes residual state        |
-| Reboot                          | `/run/kukeon/*` disappears (tmpfs). `/opt/kukeon/*` persists.           |
+| Operation                     | Removes                                                          |
+| ----------------------------- | ---------------------------------------------------------------- |
+| `kuke delete realm --cascade` | The realm subtree under the run path, cgroups, CNI conflists     |
+| `kuke delete space --cascade` | The space subtree, cgroups, CNI conflist                         |
+| `kuke delete cell --cascade`  | The cell subtree, cgroups, containerd containers                 |
+| `kuke purge <resource>`       | Same as delete but more aggressive: force-removes residual state |
+| Reboot                        | `/run/kukeon/*` disappears (tmpfs). `/opt/kukeon/*` persists.    |
 
 `--no-daemon` versions of the same commands do exactly the same thing on disk — they just run in-process instead of going through the socket.
 

--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -2,41 +2,41 @@
 
 Kukeon ships a single binary that behaves as one of two commands depending on the executable name.
 
-| Command   | Purpose                                   | Used by                |
-|-----------|-------------------------------------------|------------------------|
-| `kuke`    | Client CLI (talks to the daemon)          | Users                  |
-| `kukeond` | The daemon process itself                 | Process supervisor     |
+| Command   | Purpose                          | Used by            |
+| --------- | -------------------------------- | ------------------ |
+| `kuke`    | Client CLI (talks to the daemon) | Users              |
+| `kukeond` | The daemon process itself        | Process supervisor |
 
 Both are hard-linked to the same binary on install. Running `kuke` enters the client tree; running `kukeond` enters the daemon tree. See [Architecture → Process Model](../architecture/process-model.md).
 
 ## kuke subcommands
 
-| Command                   | What it does                                                      |
-|---------------------------|-------------------------------------------------------------------|
-| `kuke init`               | Bootstrap or reconcile a host                                     |
-| `kuke apply`              | Apply resource definitions from YAML (multi-document supported)   |
-| `kuke get`                | List or describe resources (realm, space, stack, cell, container) |
-| `kuke create`             | Create a single resource imperatively                             |
-| `kuke delete`             | Delete a resource                                                 |
-| `kuke start` / `stop` / `kill` | Lifecycle operations on cells and containers                 |
-| `kuke purge`              | Delete with aggressive cleanup of residual state                  |
-| `kuke refresh`            | Reconcile `.status` from live state without touching `.spec`      |
-| `kuke autocomplete`       | Emit a shell completion script                                    |
-| `kuke version`            | Print the version                                                 |
+| Command                        | What it does                                                      |
+| ------------------------------ | ----------------------------------------------------------------- |
+| `kuke init`                    | Bootstrap or reconcile a host                                     |
+| `kuke apply`                   | Apply resource definitions from YAML (multi-document supported)   |
+| `kuke get`                     | List or describe resources (realm, space, stack, cell, container) |
+| `kuke create`                  | Create a single resource imperatively                             |
+| `kuke delete`                  | Delete a resource                                                 |
+| `kuke start` / `stop` / `kill` | Lifecycle operations on cells and containers                      |
+| `kuke purge`                   | Delete with aggressive cleanup of residual state                  |
+| `kuke refresh`                 | Reconcile `.status` from live state without touching `.spec`      |
+| `kuke autocomplete`            | Emit a shell completion script                                    |
+| `kuke version`                 | Print the version                                                 |
 
 ## Global flags
 
 Every `kuke` subcommand inherits these persistent flags from the root command:
 
-| Flag                    | Default                              | What it does                                               |
-|-------------------------|--------------------------------------|------------------------------------------------------------|
-| `--run-path`            | `/opt/kukeon`                        | Where Kukeon stores realm/space/stack/cell state           |
-| `--config`              | `/etc/kukeon/config.yaml`            | Config file path                                           |
-| `--containerd-socket`   | `/run/containerd/containerd.sock`    | Containerd socket                                          |
-| `--host`                | `unix:///run/kukeon/kukeond.sock`    | Daemon endpoint (unix:// or ssh://)                        |
-| `--no-daemon`           | `false`                              | Bypass the daemon and run in-process (requires root)       |
-| `--verbose`, `-v`       | `false`                              | Enable verbose logging on stderr                           |
-| `--log-level`           | `info`                               | Log level (`debug`, `info`, `warn`, `error`)               |
+| Flag                  | Default                           | What it does                                         |
+| --------------------- | --------------------------------- | ---------------------------------------------------- |
+| `--run-path`          | `/opt/kukeon`                     | Where Kukeon stores realm/space/stack/cell state     |
+| `--config`            | `/etc/kukeon/config.yaml`         | Config file path                                     |
+| `--containerd-socket` | `/run/containerd/containerd.sock` | Containerd socket                                    |
+| `--host`              | `unix:///run/kukeon/kukeond.sock` | Daemon endpoint (unix:// or ssh://)                  |
+| `--no-daemon`         | `false`                           | Bypass the daemon and run in-process (requires root) |
+| `--verbose`, `-v`     | `false`                           | Enable verbose logging on stderr                     |
+| `--log-level`         | `info`                            | Log level (`debug`, `info`, `warn`, `error`)         |
 
 ## Convention: positional arg + flags
 

--- a/docs/site/cli/kuke-apply.md
+++ b/docs/site/cli/kuke-apply.md
@@ -8,10 +8,10 @@ kuke apply -f <file> [-o json|yaml]
 
 ## Flags
 
-| Flag                | Default | Description                                                     |
-|---------------------|---------|-----------------------------------------------------------------|
-| `--file`, `-f`      | _(required)_ | Path to a YAML file, or `-` for stdin                      |
-| `--output`, `-o`    | _(empty)_    | Output format: `json`, `yaml`. Default: human-readable.    |
+| Flag             | Default      | Description                                             |
+| ---------------- | ------------ | ------------------------------------------------------- |
+| `--file`, `-f`   | _(required)_ | Path to a YAML file, or `-` for stdin                   |
+| `--output`, `-o` | _(empty)_    | Output format: `json`, `yaml`. Default: human-readable. |
 
 Plus all [global flags](kuke.md).
 

--- a/docs/site/cli/kuke-create.md
+++ b/docs/site/cli/kuke-create.md
@@ -15,9 +15,9 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also 
 kuke create realm [NAME] [--namespace <ns>]
 ```
 
-| Flag            | Default        | Description                                                 |
-|-----------------|----------------|-------------------------------------------------------------|
-| `--namespace`   | (realm name)   | Containerd namespace for the realm                          |
+| Flag          | Default      | Description                        |
+| ------------- | ------------ | ---------------------------------- |
+| `--namespace` | (realm name) | Containerd namespace for the realm |
 
 ```bash
 sudo kuke create realm mytenant
@@ -30,9 +30,9 @@ sudo kuke create realm mytenant --namespace kukeon-mytenant
 kuke create space [NAME] --realm <realm>
 ```
 
-| Flag        | Default    | Description                              |
-|-------------|------------|------------------------------------------|
-| `--realm`   | `default`  | Realm that will own the space            |
+| Flag      | Default   | Description                   |
+| --------- | --------- | ----------------------------- |
+| `--realm` | `default` | Realm that will own the space |
 
 ```bash
 sudo kuke create space blog --realm main
@@ -44,10 +44,10 @@ sudo kuke create space blog --realm main
 kuke create stack [NAME] --realm <realm> --space <space>
 ```
 
-| Flag        | Default    | Description                              |
-|-------------|------------|------------------------------------------|
-| `--realm`   | `default`  | Realm that owns the stack                |
-| `--space`   | `default`  | Space that owns the stack                |
+| Flag      | Default   | Description               |
+| --------- | --------- | ------------------------- |
+| `--realm` | `default` | Realm that owns the stack |
+| `--space` | `default` | Space that owns the stack |
 
 ```bash
 sudo kuke create stack wordpress --realm main --space blog
@@ -59,11 +59,11 @@ sudo kuke create stack wordpress --realm main --space blog
 kuke create cell [NAME] --realm <r> --space <s> --stack <t>
 ```
 
-| Flag        | Default    | Description                              |
-|-------------|------------|------------------------------------------|
-| `--realm`   | `default`  | Realm that owns the cell                 |
-| `--space`   | `default`  | Space that owns the cell                 |
-| `--stack`   | `default`  | Stack that owns the cell                 |
+| Flag      | Default   | Description              |
+| --------- | --------- | ------------------------ |
+| `--realm` | `default` | Realm that owns the cell |
+| `--space` | `default` | Space that owns the cell |
+| `--stack` | `default` | Stack that owns the cell |
 
 `create cell` creates an empty cell (no containers). Use [`kuke apply`](kuke-apply.md) with a manifest to create a cell with its containers in one step.
 
@@ -79,25 +79,25 @@ Adds a container to an existing cell.
 kuke create container [NAME] --cell <cell> [--realm <r> --space <s> --stack <t>] [container flags]
 ```
 
-| Flag                 | Default                               | Description                                                 |
-|----------------------|---------------------------------------|-------------------------------------------------------------|
-| `--realm`            | `default`                             | Realm of the parent cell                                    |
-| `--space`            | `default`                             | Space of the parent cell                                    |
-| `--stack`            | `default`                             | Stack of the parent cell                                    |
-| `--cell`             | _(required)_                          | Cell that owns the container                                |
-| `--image`            | `docker.io/library/debian:latest`     | Container image                                             |
-| `--command`          | (empty)                               | Command to run                                              |
-| `--args`             | (empty, repeatable)                   | Arguments                                                   |
-| `--env`              | (empty, repeatable)                   | `KEY=VALUE` env var                                         |
-| `--port`             | (empty, repeatable)                   | Port mapping                                                |
-| `--volume`           | (empty, repeatable)                   | Volume mount                                                |
-| `--network`          | (empty, repeatable)                   | Network to join                                             |
-| `--network-alias`    | (empty, repeatable)                   | Network alias                                               |
-| `--privileged`       | `false`                               | Run privileged                                              |
-| `--root`             | `false`                               | Mark this container as the cell's root container            |
-| `--cni-config-path`  | (empty)                               | Override CNI config dir for this container                  |
-| `--restart-policy`   | (empty)                               | Restart policy                                              |
-| `--label`            | (empty, repeatable)                   | `KEY=VALUE` label                                           |
+| Flag                | Default                           | Description                                      |
+| ------------------- | --------------------------------- | ------------------------------------------------ |
+| `--realm`           | `default`                         | Realm of the parent cell                         |
+| `--space`           | `default`                         | Space of the parent cell                         |
+| `--stack`           | `default`                         | Stack of the parent cell                         |
+| `--cell`            | _(required)_                      | Cell that owns the container                     |
+| `--image`           | `docker.io/library/debian:latest` | Container image                                  |
+| `--command`         | (empty)                           | Command to run                                   |
+| `--args`            | (empty, repeatable)               | Arguments                                        |
+| `--env`             | (empty, repeatable)               | `KEY=VALUE` env var                              |
+| `--port`            | (empty, repeatable)               | Port mapping                                     |
+| `--volume`          | (empty, repeatable)               | Volume mount                                     |
+| `--network`         | (empty, repeatable)               | Network to join                                  |
+| `--network-alias`   | (empty, repeatable)               | Network alias                                    |
+| `--privileged`      | `false`                           | Run privileged                                   |
+| `--root`            | `false`                           | Mark this container as the cell's root container |
+| `--cni-config-path` | (empty)                           | Override CNI config dir for this container       |
+| `--restart-policy`  | (empty)                           | Restart policy                                   |
+| `--label`           | (empty, repeatable)               | `KEY=VALUE` label                                |
 
 ```bash
 sudo kuke create container nginx \
@@ -107,7 +107,7 @@ sudo kuke create container nginx \
 ```
 
 !!! warning "The `--image` default"
-    If you don't pass `--image`, Kukeon uses `docker.io/library/debian:latest`. Always pass `--image` explicitly when you care what runs.
+If you don't pass `--image`, Kukeon uses `docker.io/library/debian:latest`. Always pass `--image` explicitly when you care what runs.
 
 ## Imperative vs. declarative
 

--- a/docs/site/cli/kuke-delete.md
+++ b/docs/site/cli/kuke-delete.md
@@ -9,12 +9,12 @@ kuke delete -f <file>
 
 ## Persistent flags (inherited by every subcommand)
 
-| Flag         | Default | Description                                                                            |
-|--------------|---------|----------------------------------------------------------------------------------------|
-| `--cascade`  | `false` | Recursively delete child resources (realm → spaces → stacks → cells; not containers)   |
-| `--force`    | `false` | Skip validation; attempt deletion anyway                                               |
-| `--file`, `-f` | (empty) | Delete the resources listed in a YAML file                                           |
-| `--output`, `-o` | (empty) | Output format: `json`, `yaml`                                                      |
+| Flag             | Default | Description                                                                          |
+| ---------------- | ------- | ------------------------------------------------------------------------------------ |
+| `--cascade`      | `false` | Recursively delete child resources (realm → spaces → stacks → cells; not containers) |
+| `--force`        | `false` | Skip validation; attempt deletion anyway                                             |
+| `--file`, `-f`   | (empty) | Delete the resources listed in a YAML file                                           |
+| `--output`, `-o` | (empty) | Output format: `json`, `yaml`                                                        |
 
 Plus all [global flags](kuke.md).
 

--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -11,9 +11,9 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also 
 
 ## Common flags
 
-| Flag             | Description                                                                                           |
-|------------------|-------------------------------------------------------------------------------------------------------|
-| `--output`, `-o` | Output format: `yaml`, `json`, `table`. Default: `table` for list, `yaml` for a single resource.     |
+| Flag             | Description                                                                                      |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| `--output`, `-o` | Output format: `yaml`, `json`, `table`. Default: `table` for list, `yaml` for a single resource. |
 
 Plus all [global flags](kuke.md) — most importantly `--no-daemon`.
 
@@ -21,13 +21,13 @@ Plus all [global flags](kuke.md) — most importantly `--no-daemon`.
 
 Each subcommand takes the flags that scope the query:
 
-| Subcommand          | Scope flags                                    |
-|---------------------|-----------------------------------------------|
-| `get realm [name]`   | none (realms are top-level)                   |
-| `get space [name]`   | `--realm` (default `default`)                 |
-| `get stack [name]`   | `--realm`, `--space`                          |
-| `get cell [name]`    | `--realm`, `--space`, `--stack`               |
-| `get container [name]` | `--realm`, `--space`, `--stack`, `--cell`  |
+| Subcommand             | Scope flags                               |
+| ---------------------- | ----------------------------------------- |
+| `get realm [name]`     | none (realms are top-level)               |
+| `get space [name]`     | `--realm` (default `default`)             |
+| `get stack [name]`     | `--realm`, `--space`                      |
+| `get cell [name]`      | `--realm`, `--space`, `--stack`           |
+| `get container [name]` | `--realm`, `--space`, `--stack`, `--cell` |
 
 All scope flags default to `default`. See the [realm default note](commands.md#convention-positional-arg--flags).
 

--- a/docs/site/cli/kuke-init.md
+++ b/docs/site/cli/kuke-init.md
@@ -10,13 +10,13 @@ Always runs as root: it touches `/sys/fs/cgroup`, containerd namespaces, `/opt/k
 
 ## Flags
 
-| Flag                      | Default                             | Description                                                                                 |
-|---------------------------|-------------------------------------|---------------------------------------------------------------------------------------------|
-| `--realm`                 | `default`                           | Name of the default user realm                                                              |
-| `--space`                 | `default`                           | Name of the default space inside the user realm                                             |
-| `--kukeond-image`         | `ghcr.io/eminwux/kukeon:<version>`  | Image to run the daemon cell. See [image resolution](#image-resolution).                    |
-| `--no-wait`               | `false`                             | Don't wait for the daemon socket after bootstrap                                            |
-| `--force-regenerate-cni`  | `false`                             | Rewrite every space's CNI conflist even if it exists. See [Troubleshooting](../guides/troubleshooting.md#kuke-init-fails-with-numerical-result-out-of-range). |
+| Flag                     | Default                            | Description                                                                                                                                                   |
+| ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--realm`                | `default`                          | Name of the default user realm                                                                                                                                |
+| `--space`                | `default`                          | Name of the default space inside the user realm                                                                                                               |
+| `--kukeond-image`        | `ghcr.io/eminwux/kukeon:<version>` | Image to run the daemon cell. See [image resolution](#image-resolution).                                                                                      |
+| `--no-wait`              | `false`                            | Don't wait for the daemon socket after bootstrap                                                                                                              |
+| `--force-regenerate-cni` | `false`                            | Rewrite every space's CNI conflist even if it exists. See [Troubleshooting](../guides/troubleshooting.md#kuke-init-fails-with-numerical-result-out-of-range). |
 
 Plus all [global flags](kuke.md).
 

--- a/docs/site/cli/kuke-lifecycle.md
+++ b/docs/site/cli/kuke-lifecycle.md
@@ -2,11 +2,11 @@
 
 Runtime lifecycle for cells and containers. These commands don't touch metadata — they operate on the containerd task under the resource.
 
-| Command      | Signal             | What it does                                                  |
-|--------------|--------------------|---------------------------------------------------------------|
-| `kuke start` | (create/start task)| Launch the container(s); no-op if already running             |
-| `kuke stop`  | `SIGTERM`          | Request graceful shutdown; container exits on its own terms   |
-| `kuke kill`  | `SIGKILL`          | Immediate termination; no graceful shutdown window            |
+| Command      | Signal              | What it does                                                |
+| ------------ | ------------------- | ----------------------------------------------------------- |
+| `kuke start` | (create/start task) | Launch the container(s); no-op if already running           |
+| `kuke stop`  | `SIGTERM`           | Request graceful shutdown; container exits on its own terms |
+| `kuke kill`  | `SIGKILL`           | Immediate termination; no graceful shutdown window          |
 
 All three take the same shape: `<verb> cell|container <name> <scope flags>`.
 
@@ -48,12 +48,12 @@ Sends SIGKILL. Useful when a container is unresponsive, or when tearing down the
 
 All three verbs share the same scope flags:
 
-| Flag       | Default    | Scope                 |
-|------------|-----------|-----------------------|
-| `--realm`  | `default` | Required for cell/container |
-| `--space`  | `default` | Required for cell/container |
-| `--stack`  | `default` | Required for cell/container |
-| `--cell`   | _(required for `container`)_ | Parent cell |
+| Flag      | Default                      | Scope                       |
+| --------- | ---------------------------- | --------------------------- |
+| `--realm` | `default`                    | Required for cell/container |
+| `--space` | `default`                    | Required for cell/container |
+| `--stack` | `default`                    | Required for cell/container |
+| `--cell`  | _(required for `container`)_ | Parent cell                 |
 
 Plus all [global flags](kuke.md).
 

--- a/docs/site/cli/kuke-purge.md
+++ b/docs/site/cli/kuke-purge.md
@@ -10,10 +10,10 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`.
 
 ## Persistent flags
 
-| Flag        | Default | Description                                                          |
-|-------------|---------|----------------------------------------------------------------------|
-| `--cascade` | `false` | Recursively purge children (does not apply to containers)            |
-| `--force`   | `false` | Skip validation; attempt purge regardless of current state           |
+| Flag        | Default | Description                                                |
+| ----------- | ------- | ---------------------------------------------------------- |
+| `--cascade` | `false` | Recursively purge children (does not apply to containers)  |
+| `--force`   | `false` | Skip validation; attempt purge regardless of current state |
 
 Plus all [global flags](kuke.md).
 

--- a/docs/site/cli/kukeond.md
+++ b/docs/site/cli/kukeond.md
@@ -8,12 +8,12 @@ kukeond serve [flags]
 
 ## Persistent flags
 
-| Flag                    | Default                             | Description                                                                       |
-|-------------------------|-------------------------------------|-----------------------------------------------------------------------------------|
-| `--run-path`            | `/opt/kukeon`                       | Where the daemon reads/writes persistent state (shared with `kuke`)               |
-| `--containerd-socket`   | `/run/containerd/containerd.sock`   | Path to the containerd socket                                                     |
-| `--socket`              | `/run/kukeon/kukeond.sock`          | Unix socket the daemon listens on                                                 |
-| `--log-level`           | `info`                              | Log level: `debug`, `info`, `warn`, `error`                                       |
+| Flag                  | Default                           | Description                                                         |
+| --------------------- | --------------------------------- | ------------------------------------------------------------------- |
+| `--run-path`          | `/opt/kukeon`                     | Where the daemon reads/writes persistent state (shared with `kuke`) |
+| `--containerd-socket` | `/run/containerd/containerd.sock` | Path to the containerd socket                                       |
+| `--socket`            | `/run/kukeon/kukeond.sock`        | Unix socket the daemon listens on                                   |
+| `--log-level`         | `info`                            | Log level: `debug`, `info`, `warn`, `error`                         |
 
 `kukeond`'s `--run-path` matches `kuke`'s default — both binaries share the same `/opt/kukeon` tree. The socket and pid files live under `/run/kukeon` and are controlled by `--socket` independently.
 

--- a/docs/site/concepts/cell.md
+++ b/docs/site/concepts/cell.md
@@ -28,7 +28,7 @@ spec:
   containers:
     - id: nginx
       image: docker.io/library/nginx:alpine
-      root: true                 # owns the network namespace
+      root: true # owns the network namespace
     - id: sidecar
       image: docker.io/library/busybox:latest
       command: /bin/sh
@@ -53,13 +53,13 @@ See [Manifest Reference → Cell](../manifests/cell.md) for the full schema.
 
 ## Lifecycle
 
-| State        | What it means                                                   |
-|--------------|-----------------------------------------------------------------|
-| `Pending`    | Cell metadata exists; containers not yet created                |
-| `Ready`      | Root container is running; non-root containers are running      |
-| `Stopped`    | All containers have exited                                      |
-| `Failed`     | The root container failed to start or exited unexpectedly       |
-| `Unknown`    | The daemon can't determine the state (e.g., containerd offline) |
+| State     | What it means                                                   |
+| --------- | --------------------------------------------------------------- |
+| `Pending` | Cell metadata exists; containers not yet created                |
+| `Ready`   | Root container is running; non-root containers are running      |
+| `Stopped` | All containers have exited                                      |
+| `Failed`  | The root container failed to start or exited unexpectedly       |
+| `Unknown` | The daemon can't determine the state (e.g., containerd offline) |
 
 ## Operations
 

--- a/docs/site/concepts/container.md
+++ b/docs/site/concepts/container.md
@@ -60,15 +60,15 @@ See [Manifest Reference → Container](../manifests/container.md) for the comple
 
 ## Lifecycle
 
-| State      | What it means                                                     |
-|------------|-------------------------------------------------------------------|
-| `Pending`  | Container metadata exists; containerd container not yet created   |
-| `Ready`    | Task is running                                                   |
-| `Stopped`  | Task has exited                                                   |
-| `Paused`   | Task is paused (cgroup-frozen)                                    |
-| `Pausing`  | Task is in the process of being paused                            |
-| `Failed`   | Task exited non-zero or was signalled                             |
-| `Unknown`  | Daemon can't determine state                                      |
+| State     | What it means                                                   |
+| --------- | --------------------------------------------------------------- |
+| `Pending` | Container metadata exists; containerd container not yet created |
+| `Ready`   | Task is running                                                 |
+| `Stopped` | Task has exited                                                 |
+| `Paused`  | Task is paused (cgroup-frozen)                                  |
+| `Pausing` | Task is in the process of being paused                          |
+| `Failed`  | Task exited non-zero or was signalled                           |
+| `Unknown` | Daemon can't determine state                                    |
 
 ## Operations
 
@@ -91,7 +91,7 @@ sudo kuke delete container side --cell hello-world \
 ```
 
 !!! note "`--image` default"
-    `kuke create container` defaults `--image` to `docker.io/library/debian:latest` when none is provided. Always pass `--image` explicitly if you care which image runs.
+`kuke create container` defaults `--image` to `docker.io/library/debian:latest` when none is provided. Always pass `--image` explicitly if you care which image runs.
 
 ## Related concepts
 

--- a/docs/site/concepts/containerd-namespaces.md
+++ b/docs/site/concepts/containerd-namespaces.md
@@ -4,10 +4,10 @@ Kukeon doesn't run its own container runtime. It drives [containerd](https://con
 
 ## The mapping
 
-| Realm           | containerd namespace      |
-|-----------------|---------------------------|
-| `main`          | `kukeon-main`             |
-| `kukeon-system` | `kukeon-system`           |
+| Realm           | containerd namespace                                  |
+| --------------- | ----------------------------------------------------- |
+| `main`          | `kukeon-main`                                         |
+| `kukeon-system` | `kukeon-system`                                       |
 | `mytenant`      | `kukeon-mytenant` (or whatever `spec.namespace` says) |
 
 By default, each realm's namespace is `kukeon-<realm-name>`. The realm manifest can override this via `spec.namespace`.

--- a/docs/site/concepts/overview.md
+++ b/docs/site/concepts/overview.md
@@ -9,23 +9,23 @@ flowchart LR
 
 Each layer maps to a concrete Linux primitive. There are no hidden layers and no "virtual" concepts that only exist inside the daemon.
 
-| Layer       | Linux primitive                                | What it gives you                   |
-|-------------|------------------------------------------------|-------------------------------------|
-| [Realm](realm.md)     | containerd namespace                           | Tenant boundary                     |
-| [Space](space.md)     | CNI network + cgroup subtree                   | Network and resource isolation      |
-| [Stack](stack.md)     | cgroup subtree                                 | Logical grouping within a space     |
-| [Cell](cell.md)       | Network namespace (one root container owns it) | Pod-like co-location                |
-| [Container](container.md) | OCI container via containerd              | The actual workload                 |
+| Layer                     | Linux primitive                                | What it gives you               |
+| ------------------------- | ---------------------------------------------- | ------------------------------- |
+| [Realm](realm.md)         | containerd namespace                           | Tenant boundary                 |
+| [Space](space.md)         | CNI network + cgroup subtree                   | Network and resource isolation  |
+| [Stack](stack.md)         | cgroup subtree                                 | Logical grouping within a space |
+| [Cell](cell.md)           | Network namespace (one root container owns it) | Pod-like co-location            |
+| [Container](container.md) | OCI container via containerd                   | The actual workload             |
 
 ## Why five layers?
 
 Docker has one layer (the container). Kubernetes has many (namespaces, workloads, services, ingress, nodes, pods). Kukeon sits between: enough layers to carve real isolation boundaries on a single host, but few enough that each one has a single, clear job.
 
-- **Realm** answers *whose containers are these?* — one realm per tenant, environment, or user.
-- **Space** answers *what can they talk to?* — each space is one CNI bridge, one IP range, one cgroup subtree for quotas.
-- **Stack** answers *which cells are part of the same deployment?* — groups related cells together for lifecycle operations.
-- **Cell** answers *which containers share a network namespace?* — like a Kubernetes pod, one unit of co-located containers.
-- **Container** answers *what is actually running?* — a plain OCI container.
+- **Realm** answers _whose containers are these?_ — one realm per tenant, environment, or user.
+- **Space** answers _what can they talk to?_ — each space is one CNI bridge, one IP range, one cgroup subtree for quotas.
+- **Stack** answers _which cells are part of the same deployment?_ — groups related cells together for lifecycle operations.
+- **Cell** answers _which containers share a network namespace?_ — like a Kubernetes pod, one unit of co-located containers.
+- **Container** answers _what is actually running?_ — a plain OCI container.
 
 ## A worked example
 

--- a/docs/site/concepts/realm.md
+++ b/docs/site/concepts/realm.md
@@ -20,7 +20,7 @@ metadata:
   labels: {}
 spec:
   namespace: kukeon-main
-  registryCredentials: []   # optional, per-registry
+  registryCredentials: [] # optional, per-registry
 ```
 
 The full schema is in [Manifest Reference → Realm](../manifests/realm.md).

--- a/docs/site/concepts/space.md
+++ b/docs/site/concepts/space.md
@@ -20,7 +20,7 @@ metadata:
   name: default
 spec:
   realmId: main
-  cniConfigPath: /etc/cni/net.d   # optional; defaults to system CNI dir
+  cniConfigPath: /etc/cni/net.d # optional; defaults to system CNI dir
 ```
 
 The full schema is in [Manifest Reference → Space](../manifests/space.md).

--- a/docs/site/concepts/system-realm.md
+++ b/docs/site/concepts/system-realm.md
@@ -54,7 +54,7 @@ sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
 See [Guides → Init and reset](../guides/init-and-reset.md) for the full teardown-and-bootstrap loop.
 
 !!! note "Older layouts"
-    On earlier versions of Kukeon, the system realm used `kuke-system.kukeon.io` as the containerd namespace. `kuke-system` and `kukeon-system` refer to the same concept depending on which version you bootstrapped the host with.
+On earlier versions of Kukeon, the system realm used `kuke-system.kukeon.io` as the containerd namespace. `kuke-system` and `kukeon-system` refer to the same concept depending on which version you bootstrapped the host with.
 
 ## Related concepts
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -117,7 +117,7 @@ sudo kuke apply -f docs/examples/hello-world.yaml --no-daemon
 ```
 
 !!! info "Why `--no-daemon` here"
-    The released `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`, so cell creation currently must run in-process via `--no-daemon`. This will change in a future release.
+The released `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`, so cell creation currently must run in-process via `--no-daemon`. This will change in a future release.
 
 Confirm the cell is ready, find its IP on the default-default bridge, and curl it:
 

--- a/docs/site/guides/autocomplete.md
+++ b/docs/site/guides/autocomplete.md
@@ -27,7 +27,7 @@ EOF
 ```
 
 !!! note "zsh `compinit`"
-    If your zsh setup doesn't already call `compinit`, you may need to add `autoload -U compinit && compinit` before the `source` line.
+If your zsh setup doesn't already call `compinit`, you may need to add `autoload -U compinit && compinit` before the `source` line.
 
 ## fish
 

--- a/docs/site/guides/local-dev.md
+++ b/docs/site/guides/local-dev.md
@@ -55,12 +55,12 @@ sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
 
 ## Make targets
 
-| Target         | What it does                                                 |
-|----------------|--------------------------------------------------------------|
-| `make kuke`    | Build the `kuke` binary (same binary is used as `kukeond`)    |
-| `make test`    | Run the Go unit test suite                                   |
-| `make e2e`     | Run end-to-end tests against a real containerd (requires root)|
-| `make lint`    | Run `golangci-lint` with the repo's config                   |
+| Target      | What it does                                                   |
+| ----------- | -------------------------------------------------------------- |
+| `make kuke` | Build the `kuke` binary (same binary is used as `kukeond`)     |
+| `make test` | Run the Go unit test suite                                     |
+| `make e2e`  | Run end-to-end tests against a real containerd (requires root) |
+| `make lint` | Run `golangci-lint` with the repo's config                     |
 
 ## Running without the daemon
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -9,7 +9,7 @@ _Agent-native orchestration. Self-hosted. No walled garden._
 Your agent's context, state, and workspace live on **your** machines — not behind a SaaS login. Kukeon is a containerd-native runtime for AI agents on any Linux host: your cloud VM, your homelab, your laptop. Declarative sessions with bounded lifetime, PTY-attached workloads, and clean teardown — all on infrastructure you control.
 
 !!! warning "Alpha software"
-    This project is under active development and not production ready. Interfaces and APIs may change.
+This project is under active development and not production ready. Interfaces and APIs may change.
 
 `kukeond` is a small daemon over containerd + CNI + cgroups. `kuke` is the CLI. Agent-native primitives — `Session`, `Interactive` containers, scoped secrets, default-deny networking — are declared in YAML and reconciled on a single host.
 

--- a/docs/site/install/build-from-source.md
+++ b/docs/site/install/build-from-source.md
@@ -38,7 +38,7 @@ sudo ./kuke get realms
 `kuke init` bootstraps a `kukeond` cell from a container image. For iterating locally, you can build the image, load it into the right containerd namespace, and point `init` at it.
 
 !!! warning "Namespace must exist before `ctr images import`"
-    `ctr images import` needs the target namespace to already exist; otherwise the import succeeds silently but nothing lands in the namespace, and the next `kuke init` will fail to find the image.
+`ctr images import` needs the target namespace to already exist; otherwise the import succeeds silently but nothing lands in the namespace, and the next `kuke init` will fail to find the image.
 
 ```bash
 # 1. Create the kuke-system containerd namespace (either by running kuke init

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -70,13 +70,13 @@ Running `kuke get` for read-only queries over the daemon socket does not require
 
 ## Disk paths kukeon touches
 
-| Path | Purpose |
-|------|---------|
-| `/opt/kukeon` | Default run path. Stores per-realm/space/stack metadata and runtime state. Configurable via `--run-path`. |
-| `/run/kukeon/kukeond.sock` | Default daemon socket. Configurable via `--socket` (kukeond) and `--host` (kuke). |
-| `/run/kukeon/kukeond.pid` | Daemon PID file. |
-| `/etc/cni/net.d` | Generated CNI conflists for each space. |
-| `/sys/fs/cgroup/kukeon/...` | Kukeon's cgroup subtree. |
+| Path                        | Purpose                                                                                                   |
+| --------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `/opt/kukeon`               | Default run path. Stores per-realm/space/stack metadata and runtime state. Configurable via `--run-path`. |
+| `/run/kukeon/kukeond.sock`  | Default daemon socket. Configurable via `--socket` (kukeond) and `--host` (kuke).                         |
+| `/run/kukeon/kukeond.pid`   | Daemon PID file.                                                                                          |
+| `/etc/cni/net.d`            | Generated CNI conflists for each space.                                                                   |
+| `/sys/fs/cgroup/kukeon/...` | Kukeon's cgroup subtree.                                                                                  |
 
 Nothing is written outside those paths without an explicit flag.
 

--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -45,51 +45,51 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 
 ## spec
 
-| Field              | Type             | Required | Description                                                                             |
-|--------------------|------------------|----------|-----------------------------------------------------------------------------------------|
-| `id`               | string           | yes      | Container identifier (matches `metadata.name`)                                          |
-| `containerdId`     | string           | no       | Populated by Kukeon with the containerd-level container id                              |
-| `realmId`          | string           | yes      | Realm that owns the container                                                           |
-| `spaceId`          | string           | yes      | Space that owns the container                                                           |
-| `stackId`          | string           | yes      | Stack that owns the container                                                           |
-| `cellId`           | string           | yes      | Cell that owns the container                                                            |
-| `root`             | bool             | no       | Mark this as the cell's root container (owns the network namespace)                     |
-| `image`            | string           | yes      | OCI image reference. Kukeon passes this to containerd's image pull.                     |
-| `command`          | string           | no       | Command to run. If omitted, the image's `ENTRYPOINT` is used.                           |
-| `args`             | array of string  | no       | Arguments. Combined with `command`.                                                     |
-| `env`              | array of string  | no       | `KEY=VALUE` environment variables                                                       |
-| `ports`            | array of string  | no       | Reserved — port mapping semantics are not finalized                                     |
-| `volumes`          | array of `VolumeMount` | no | Bind-mount host paths into the container (see [VolumeMount](#volumemount))            |
-| `networks`         | array of string  | no       | Additional CNI networks to join beyond the cell's default                               |
-| `networksAliases`  | array of string  | no       | DNS aliases for the container within its CNI networks                                   |
-| `privileged`       | bool             | no       | Run privileged (full capabilities, access to `/dev`, etc.)                              |
-| `secrets`          | array of `ContainerSecret` | no | Inject credentials resolved by the daemon — never written to status or YAML (see [ContainerSecret](#containersecret)) |
-| `cniConfigPath`    | string           | no       | Override the CNI config directory for this container                                    |
-| `restartPolicy`    | string           | no       | Restart policy. Reserved — restart semantics are not finalized.                         |
+| Field             | Type                       | Required | Description                                                                                                           |
+| ----------------- | -------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `id`              | string                     | yes      | Container identifier (matches `metadata.name`)                                                                        |
+| `containerdId`    | string                     | no       | Populated by Kukeon with the containerd-level container id                                                            |
+| `realmId`         | string                     | yes      | Realm that owns the container                                                                                         |
+| `spaceId`         | string                     | yes      | Space that owns the container                                                                                         |
+| `stackId`         | string                     | yes      | Stack that owns the container                                                                                         |
+| `cellId`          | string                     | yes      | Cell that owns the container                                                                                          |
+| `root`            | bool                       | no       | Mark this as the cell's root container (owns the network namespace)                                                   |
+| `image`           | string                     | yes      | OCI image reference. Kukeon passes this to containerd's image pull.                                                   |
+| `command`         | string                     | no       | Command to run. If omitted, the image's `ENTRYPOINT` is used.                                                         |
+| `args`            | array of string            | no       | Arguments. Combined with `command`.                                                                                   |
+| `env`             | array of string            | no       | `KEY=VALUE` environment variables                                                                                     |
+| `ports`           | array of string            | no       | Reserved — port mapping semantics are not finalized                                                                   |
+| `volumes`         | array of `VolumeMount`     | no       | Bind-mount host paths into the container (see [VolumeMount](#volumemount))                                            |
+| `networks`        | array of string            | no       | Additional CNI networks to join beyond the cell's default                                                             |
+| `networksAliases` | array of string            | no       | DNS aliases for the container within its CNI networks                                                                 |
+| `privileged`      | bool                       | no       | Run privileged (full capabilities, access to `/dev`, etc.)                                                            |
+| `secrets`         | array of `ContainerSecret` | no       | Inject credentials resolved by the daemon — never written to status or YAML (see [ContainerSecret](#containersecret)) |
+| `cniConfigPath`   | string                     | no       | Override the CNI config directory for this container                                                                  |
+| `restartPolicy`   | string                     | no       | Restart policy. Reserved — restart semantics are not finalized.                                                       |
 
 !!! warning "Fields marked reserved"
-    `ports` and `restartPolicy` are accepted by the schema today but their semantics are still being designed. Values round-trip (you can read back what you applied), but the controller does not act on them. See [ROADMAP.md](https://github.com/eminwux/kukeon/blob/main/ROADMAP.md) for the backlog.
+`ports` and `restartPolicy` are accepted by the schema today but their semantics are still being designed. Values round-trip (you can read back what you applied), but the controller does not act on them. See [ROADMAP.md](https://github.com/eminwux/kukeon/blob/main/ROADMAP.md) for the backlog.
 
 ### VolumeMount
 
 Each entry in `spec.volumes` is a bind mount of a host path into the container.
 
-| Field      | Type   | Required | Description                                                                 |
-|------------|--------|----------|-----------------------------------------------------------------------------|
+| Field      | Type   | Required | Description                                                                              |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------------------------- |
 | `source`   | string | yes      | Absolute host path. Must exist at apply time. Named / managed volumes are not supported. |
-| `target`   | string | yes      | Absolute path inside the container                                          |
-| `readOnly` | bool   | no       | Mount read-only when `true` (writes fail with `EROFS`). Defaults to `false`. |
+| `target`   | string | yes      | Absolute path inside the container                                                       |
+| `readOnly` | bool   | no       | Mount read-only when `true` (writes fail with `EROFS`). Defaults to `false`.             |
 
 ### ContainerSecret
 
 Each entry in `spec.secrets` references a credential the daemon resolves at apply time. Only the reference is persisted — the resolved value never appears in `kuke get -o yaml`, in object status, or in daemon logs.
 
-| Field        | Type   | Required | Description                                                                                                |
-|--------------|--------|----------|------------------------------------------------------------------------------------------------------------|
-| `name`       | string | yes      | Environment-variable name (default mode) or basename of the mounted secret file when `mountPath` is set    |
-| `fromFile`   | string | one of required | Absolute host path the daemon reads at apply time. Missing files produce a clear error.             |
-| `fromEnv`    | string | one of required | Name of an environment variable set on the daemon host. Missing env vars produce a clear error.     |
-| `mountPath`  | string | no       | Absolute path inside the container. When set, the secret is staged with mode `0400` and bind-mounted read-only instead of being injected as an env var. |
+| Field       | Type   | Required        | Description                                                                                                                                             |
+| ----------- | ------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | string | yes             | Environment-variable name (default mode) or basename of the mounted secret file when `mountPath` is set                                                 |
+| `fromFile`  | string | one of required | Absolute host path the daemon reads at apply time. Missing files produce a clear error.                                                                 |
+| `fromEnv`   | string | one of required | Name of an environment variable set on the daemon host. Missing env vars produce a clear error.                                                         |
+| `mountPath` | string | no              | Absolute path inside the container. When set, the secret is staged with mode `0400` and bind-mounted read-only instead of being injected as an env var. |
 
 Exactly one of `fromFile` / `fromEnv` must be set. Example:
 
@@ -108,17 +108,17 @@ File-mount mode stages secrets under `/run/kukeon/secrets/<containerdId>/<name>`
 
 ## status
 
-| Field         | Type                                                                             | Description                                |
-|---------------|----------------------------------------------------------------------------------|--------------------------------------------|
-| `name`        | string                                                                           | Matches `metadata.name`                    |
-| `id`          | string                                                                           | Containerd container id                    |
-| `state`       | `Pending`, `Ready`, `Stopped`, `Paused`, `Pausing`, `Failed`, `Unknown`          | Lifecycle state                            |
-| `restartCount`| int                                                                              | Times the container has restarted          |
-| `restartTime` | RFC3339 timestamp                                                                | Last restart                               |
-| `startTime`   | RFC3339 timestamp                                                                | Current (or last) start                    |
-| `finishTime`  | RFC3339 timestamp                                                                | When the task exited (zero-value if still running) |
-| `exitCode`    | int                                                                              | Exit code of the last run (0 if still running) |
-| `exitSignal`  | string                                                                           | Signal that terminated the task, if any    |
+| Field          | Type                                                                    | Description                                        |
+| -------------- | ----------------------------------------------------------------------- | -------------------------------------------------- |
+| `name`         | string                                                                  | Matches `metadata.name`                            |
+| `id`           | string                                                                  | Containerd container id                            |
+| `state`        | `Pending`, `Ready`, `Stopped`, `Paused`, `Pausing`, `Failed`, `Unknown` | Lifecycle state                                    |
+| `restartCount` | int                                                                     | Times the container has restarted                  |
+| `restartTime`  | RFC3339 timestamp                                                       | Last restart                                       |
+| `startTime`    | RFC3339 timestamp                                                       | Current (or last) start                            |
+| `finishTime`   | RFC3339 timestamp                                                       | When the task exited (zero-value if still running) |
+| `exitCode`     | int                                                                     | Exit code of the last run (0 if still running)     |
+| `exitSignal`   | string                                                                  | Signal that terminated the task, if any            |
 
 ## Minimal (embedded in a cell)
 

--- a/docs/site/manifests/realm.md
+++ b/docs/site/manifests/realm.md
@@ -29,10 +29,10 @@ The containerd namespace this realm uses for its images, containers, and tasks. 
 
 Authentication for image registries. Scoped to the realm — two realms can use different credentials for the same registry.
 
-| Field           | Type   | Required | Description                                                                                     |
-|-----------------|--------|----------|-------------------------------------------------------------------------------------------------|
-| `username`      | string | yes      | Registry username                                                                              |
-| `password`      | string | yes      | Registry password or token                                                                     |
+| Field           | Type   | Required | Description                                                                                                 |
+| --------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `username`      | string | yes      | Registry username                                                                                           |
+| `password`      | string | yes      | Registry password or token                                                                                  |
 | `serverAddress` | string | no       | Registry server (e.g., `docker.io`, `ghcr.io`). If omitted, applies to the registry in the image reference. |
 
 ```yaml
@@ -45,10 +45,10 @@ spec:
 
 ## status
 
-| Field         | Type                              | Description                                             |
-|---------------|-----------------------------------|---------------------------------------------------------|
-| `state`       | `Pending`, `Creating`, `Ready`, `Deleting`, `Failed`, `Unknown` | Lifecycle state |
-| `cgroupPath`  | string                            | Absolute cgroup path: `/kukeon/<realm>`                 |
+| Field        | Type                                                            | Description                             |
+| ------------ | --------------------------------------------------------------- | --------------------------------------- |
+| `state`      | `Pending`, `Creating`, `Ready`, `Deleting`, `Failed`, `Unknown` | Lifecycle state                         |
+| `cgroupPath` | string                                                          | Absolute cgroup path: `/kukeon/<realm>` |
 
 `status` is populated by Kukeon; anything you set when applying is overwritten on reconcile.
 

--- a/docs/site/manifests/space.md
+++ b/docs/site/manifests/space.md
@@ -38,18 +38,18 @@ Directory where Kukeon writes this space's CNI conflist. Defaults to the system 
 
 Constrains outbound traffic leaving the space's bridge. When omitted, traffic is unconstrained — matching the pre-`v1beta1` behavior.
 
-| Field     | Type                              | Description                                                                 |
-|-----------|-----------------------------------|-----------------------------------------------------------------------------|
-| `default` | `allow` \| `deny`                 | Fallthrough action when no `allow` rule matches. Required when `egress` is set. |
-| `allow`   | list of allow rules               | Permitted destinations. Each entry sets exactly one of `host` or `cidr`.    |
+| Field     | Type                | Description                                                                     |
+| --------- | ------------------- | ------------------------------------------------------------------------------- |
+| `default` | `allow` \| `deny`   | Fallthrough action when no `allow` rule matches. Required when `egress` is set. |
+| `allow`   | list of allow rules | Permitted destinations. Each entry sets exactly one of `host` or `cidr`.        |
 
 Each allow rule:
 
-| Field   | Type          | Description                                                                          |
-|---------|---------------|--------------------------------------------------------------------------------------|
-| `host`  | string        | DNS name. Resolved to IPv4 addresses by the daemon at apply time.                    |
-| `cidr`  | string        | IPv4 CIDR. Enforced literally via iptables.                                          |
-| `ports` | list of ints  | TCP destination ports (1–65535). Empty means "any protocol and any port on this destination". |
+| Field   | Type         | Description                                                                                   |
+| ------- | ------------ | --------------------------------------------------------------------------------------------- |
+| `host`  | string       | DNS name. Resolved to IPv4 addresses by the daemon at apply time.                             |
+| `cidr`  | string       | IPv4 CIDR. Enforced literally via iptables.                                                   |
+| `ports` | list of ints | TCP destination ports (1–65535). Empty means "any protocol and any port on this destination". |
 
 **Enforcement.** When the policy is non-trivial (either `default: deny`, or `default: allow` with at least one allow rule), the daemon materializes it as a per-space chain in the iptables `filter` table named `KUKE-EGR-<hash>`, fed from a shared `KUKEON-EGRESS` chain hooked into `FORWARD`. Existing connections are preserved via a `RELATED,ESTABLISHED` short-circuit, so reply traffic for outbound flows initiated before a policy is applied is unaffected. The enforcement is bridge-scoped (`-i <bridge>`), so a single misconfigured space cannot affect traffic from other spaces in the same realm.
 
@@ -80,9 +80,9 @@ spec:
       securityOpts: ["no-new-privileges"]
       tmpfs:
         - path: /tmp
-          sizeBytes: 268435456   # 256 MiB
+          sizeBytes: 268435456 # 256 MiB
       resources:
-        memoryLimitBytes: 4294967296   # 4 GiB
+        memoryLimitBytes: 4294967296 # 4 GiB
         pidsLimit: 512
 ```
 
@@ -100,10 +100,10 @@ Supported fields (each mirrors `ContainerSpec`): `user`, `readOnlyRootFilesystem
 
 ## status
 
-| Field         | Type                           | Description                                            |
-|---------------|--------------------------------|--------------------------------------------------------|
-| `state`       | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                               |
-| `cgroupPath`  | string                         | Absolute cgroup path: `/kukeon/<realm>/<space>`        |
+| Field        | Type                                    | Description                                     |
+| ------------ | --------------------------------------- | ----------------------------------------------- |
+| `state`      | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                                 |
+| `cgroupPath` | string                                  | Absolute cgroup path: `/kukeon/<realm>/<space>` |
 
 ## Bridge naming
 

--- a/docs/site/manifests/stack.md
+++ b/docs/site/manifests/stack.md
@@ -19,21 +19,21 @@ See [Concepts → Stack](../concepts/stack.md) for what a stack is.
 
 ## spec
 
-| Field       | Type   | Required | Description                                 |
-|-------------|--------|----------|---------------------------------------------|
-| `id`        | string | yes      | Stack identifier (matches `metadata.name`)  |
-| `realmId`   | string | yes      | Realm that owns the stack                   |
-| `spaceId`   | string | yes      | Space that owns the stack                   |
+| Field     | Type   | Required | Description                                |
+| --------- | ------ | -------- | ------------------------------------------ |
+| `id`      | string | yes      | Stack identifier (matches `metadata.name`) |
+| `realmId` | string | yes      | Realm that owns the stack                  |
+| `spaceId` | string | yes      | Space that owns the stack                  |
 
 !!! note "`id` vs. `metadata.name`"
-    Today the stack schema requires both `metadata.name` and `spec.id`, and they should be the same value. The duplication is historical and will be removed in a future version.
+Today the stack schema requires both `metadata.name` and `spec.id`, and they should be the same value. The duplication is historical and will be removed in a future version.
 
 ## status
 
-| Field         | Type                           | Description                                                 |
-|---------------|--------------------------------|-------------------------------------------------------------|
-| `state`       | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                                    |
-| `cgroupPath`  | string                         | Absolute cgroup path: `/kukeon/<realm>/<space>/<stack>`     |
+| Field        | Type                                    | Description                                             |
+| ------------ | --------------------------------------- | ------------------------------------------------------- |
+| `state`      | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                                         |
+| `cgroupPath` | string                                  | Absolute cgroup path: `/kukeon/<realm>/<space>/<stack>` |
 
 ## Minimal
 

--- a/docs/site/tutorials/first-stack.md
+++ b/docs/site/tutorials/first-stack.md
@@ -100,7 +100,7 @@ sudo ctr -n kukeon-default tasks attach client_wget
 You should see nginx's default HTML stream by every 5 seconds. Press `Ctrl-C` to detach from the task without killing it.
 
 !!! note "Reaching `web` by name"
-    In this example `wget http://web` works because the space's bridge has a resolver, and the `web` cell's root container registers itself by name. If your space has DNS turned off, you can replace the URL with the cell IP (find it via `kuke get cells --realm default --space tutorial --stack demo -o yaml` and look under `status.containers[].ip`).
+In this example `wget http://web` works because the space's bridge has a resolver, and the `web` cell's root container registers itself by name. If your space has DNS turned off, you can replace the URL with the cell IP (find it via `kuke get cells --realm default --space tutorial --stack demo -o yaml` and look under `status.containers[].ip`).
 
 ## 5. Tear it down
 

--- a/docs/site/tutorials/hello-world.md
+++ b/docs/site/tutorials/hello-world.md
@@ -79,7 +79,7 @@ curl http://${CELL_IP}:8080/
 You should see the HTML from the manifest.
 
 !!! note "Containerd namespace"
-    In the default bootstrap, the containerd namespace for `realm=default` is `kukeon-default`. If your realm is named differently, replace the namespace accordingly. Older layouts used `kukeon.io` as the default namespace.
+In the default bootstrap, the containerd namespace for `realm=default` is `kukeon-default`. If your realm is named differently, replace the namespace accordingly. Older layouts used `kukeon.io` as the default namespace.
 
 ## 5. Tear down
 

--- a/docs/site/vision.md
+++ b/docs/site/vision.md
@@ -32,7 +32,7 @@ What's missing is not in the bones. It's in the fields.
 
 ## 2. The agent threat model, briefly
 
-Traditional container workloads are *adversarial on the outside, trusted on the inside*. The orchestrator defends a trusted service from hostile network traffic.
+Traditional container workloads are _adversarial on the outside, trusted on the inside_. The orchestrator defends a trusted service from hostile network traffic.
 
 Agent workloads invert this. The API endpoint is trusted (you deployed the key). The code running inside the container is not — not because the model is malicious, but because:
 
@@ -102,17 +102,17 @@ Bind mounts are the base case. Named volumes can wait. What matters is that `sou
 
 **Proposal.** Add the following fields to Container `spec`, each with safe defaults:
 
-| Field | Type | Default | Purpose |
-|---|---|---|---|
-| `user` | `"uid:gid"` | image default | Run as non-root |
-| `readOnlyRootFilesystem` | bool | `false` (for compat), `true` recommended | Lock rootfs |
-| `capabilities.drop` | `[]string` | `[]` | Drop Linux capabilities |
-| `capabilities.add` | `[]string` | `[]` | Add Linux capabilities (rarely needed) |
-| `securityOpts` | `[]string` | `[]` | Passthrough for `no-new-privileges`, seccomp profiles |
-| `tmpfs` | `[]{path, sizeBytes, options}` | `[]` | tmpfs mounts for ephemeral scratch |
-| `resources.memoryLimitBytes` | int | unset | Hard memory ceiling |
-| `resources.cpuShares` | int | unset | CPU weight |
-| `resources.pidsLimit` | int | unset | Prevent fork bombs |
+| Field                        | Type                           | Default                                  | Purpose                                               |
+| ---------------------------- | ------------------------------ | ---------------------------------------- | ----------------------------------------------------- |
+| `user`                       | `"uid:gid"`                    | image default                            | Run as non-root                                       |
+| `readOnlyRootFilesystem`     | bool                           | `false` (for compat), `true` recommended | Lock rootfs                                           |
+| `capabilities.drop`          | `[]string`                     | `[]`                                     | Drop Linux capabilities                               |
+| `capabilities.add`           | `[]string`                     | `[]`                                     | Add Linux capabilities (rarely needed)                |
+| `securityOpts`               | `[]string`                     | `[]`                                     | Passthrough for `no-new-privileges`, seccomp profiles |
+| `tmpfs`                      | `[]{path, sizeBytes, options}` | `[]`                                     | tmpfs mounts for ephemeral scratch                    |
+| `resources.memoryLimitBytes` | int                            | unset                                    | Hard memory ceiling                                   |
+| `resources.cpuShares`        | int                            | unset                                    | CPU weight                                            |
+| `resources.pidsLimit`        | int                            | unset                                    | Prevent fork bombs                                    |
 
 This is the minimum to express what `docker run --user X --read-only --cap-drop=ALL --security-opt=no-new-privileges --tmpfs=/tmp --memory=4g --pids-limit=512` expresses today. Without these, kukeon is strictly less expressive than compose for untrusted workloads.
 
@@ -120,7 +120,7 @@ This is the minimum to express what `docker run --user X --read-only --cap-drop=
 
 ### 4.3 `P1` — Isolation-envelope inheritance from Space
 
-**Problem.** If every Container in a Space needs the same cap drops, the same user, the same resource ceilings, repeating that per-container in YAML is error-prone. More importantly, it misses the point of the Space-as-envelope design — the Space exists *because* isolation should be declared once.
+**Problem.** If every Container in a Space needs the same cap drops, the same user, the same resource ceilings, repeating that per-container in YAML is error-prone. More importantly, it misses the point of the Space-as-envelope design — the Space exists _because_ isolation should be declared once.
 
 **Proposal.** Add a `spec.defaults` block on Space that is inherited by every Container in the Space unless overridden:
 
@@ -139,7 +139,7 @@ spec:
         drop: ["ALL"]
       securityOpts: ["no-new-privileges"]
       resources:
-        memoryLimitBytes: 4294967296   # 4 GiB
+        memoryLimitBytes: 4294967296 # 4 GiB
         pidsLimit: 512
       tmpfs:
         - { path: /tmp, sizeBytes: 268435456 }
@@ -147,7 +147,7 @@ spec:
 
 Per-container values override Space defaults; Space defaults override kukeon built-ins. Inheritance is shallow (no deep-merge surprises).
 
-**Why this is P1.** This is the move that turns kukeon from "compose with a hierarchy" into "compose where the hierarchy means something." Isolation posture becomes a property of *where* a container lives, not a property every author has to remember to set.
+**Why this is P1.** This is the move that turns kukeon from "compose with a hierarchy" into "compose where the hierarchy means something." Isolation posture becomes a property of _where_ a container lives, not a property every author has to remember to set.
 
 ### 4.4 `P1` — Network policy on Space
 
@@ -160,7 +160,7 @@ spec:
   realmId: agents
   network:
     egress:
-      default: deny           # or allow
+      default: deny # or allow
       allow:
         - host: api.anthropic.com
           ports: [443]
@@ -212,7 +212,7 @@ This primitive is what makes "ephemeral by default" the easy path. It also gives
 
 ### 4.6 `P1` — Scoped credential injection
 
-**Problem.** Today, credentials are passed via `env: ["ANTHROPIC_API_KEY=..."]`, which puts the secret in the manifest, in logs, and in `kuke get -o yaml` output. For agents, this is the wrong ergonomics *and* the wrong security posture.
+**Problem.** Today, credentials are passed via `env: ["ANTHROPIC_API_KEY=..."]`, which puts the secret in the manifest, in logs, and in `kuke get -o yaml` output. For agents, this is the wrong ergonomics _and_ the wrong security posture.
 
 **Proposal.** Add a `secrets` field on Container (or inherited from Space/Session) that references credentials by source, not by value:
 
@@ -221,7 +221,7 @@ secrets:
   - name: ANTHROPIC_API_KEY
     fromFile: /etc/kukeon/secrets/anthropic.key
   - name: GITHUB_TOKEN
-    fromEnv: GITHUB_TOKEN_SCOPED     # on the host, set by a wrapper
+    fromEnv: GITHUB_TOKEN_SCOPED # on the host, set by a wrapper
 ```
 
 Values are mounted into the container's environment or as files, never written into status or persisted in audit logs. The manifest is safe to commit.
@@ -255,7 +255,7 @@ When a budget is exceeded, the Session is terminated (not warned). The enforceme
 
 ### 4.8 `P2` — Causal audit trail
 
-**Problem.** "The blast radius is controlled" is a verifiable claim only if, after the Session ends, you can answer *exactly* what the agent did: what it read, what it wrote, where it connected, what commands it ran. Container logs don't cut it — they're unstructured and disappear with the container.
+**Problem.** "The blast radius is controlled" is a verifiable claim only if, after the Session ends, you can answer _exactly_ what the agent did: what it read, what it wrote, where it connected, what commands it ran. Container logs don't cut it — they're unstructured and disappear with the container.
 
 **Proposal.** The daemon writes a per-Session append-only audit log to a location the Session itself cannot write to:
 
@@ -351,7 +351,7 @@ spec:
   stackId: claude-code
   lifetime: { wallClock: 30m, idleTimeout: 5m }
   onEnd:
-    persist: [ { volume: /workspace/out } ]
+    persist: [{ volume: /workspace/out }]
 ---
 apiVersion: v1beta1
 kind: Cell
@@ -366,9 +366,16 @@ spec:
       command: claude
       args: ["--dangerously-skip-permissions"]
       volumes:
-        - { source: /home/alice/src/my-project, target: /workspace, readOnly: false }
+        - {
+            source: /home/alice/src/my-project,
+            target: /workspace,
+            readOnly: false,
+          }
       secrets:
-        - { name: ANTHROPIC_API_KEY, fromFile: /etc/kukeon/secrets/anthropic.key }
+        - {
+            name: ANTHROPIC_API_KEY,
+            fromFile: /etc/kukeon/secrets/anthropic.key,
+          }
 ```
 
 One file, one `kuke apply`, one Session, one `kuke delete` when done. The agent has a workspace, an egress-restricted network, a scoped credential, a hard deadline, and no access to anything on the host outside the declared workspace. That's the bar.
@@ -380,7 +387,7 @@ One file, one `kuke apply`, one Session, one `kuke delete` when done. The agent 
 A reasonable order of operations for the project:
 
 1. **Land `P0` first** (volumes, container security fields). This unblocks the compose-parity story and makes kukeon usable for any untrusted workload, agent or otherwise.
-2. **Then `P1`** (Space defaults, network policy, Session kind, scoped credentials). This is the stretch that makes kukeon *better than* compose for the agent case specifically.
+2. **Then `P1`** (Space defaults, network policy, Session kind, scoped credentials). This is the stretch that makes kukeon _better than_ compose for the agent case specifically.
 3. **Finally `P2`** (budgets, audit, approval gates). This is where the agent-native category bet is made — opt-in, ambitious, and optional for the project's homelab/VPS user base.
 
 `P0` is a few weeks of well-scoped work against an existing schema. `P1` is a quarter of design-heavy work but introduces no new architecture. `P2` is a project of its own and can wait until there's demand to justify it.

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -228,4 +228,3 @@ func (b *Exec) Close() error {
 func (b *Exec) RunPath() string {
 	return b.opts.RunPath
 }
-

--- a/internal/modelhub/merge_test.go
+++ b/internal/modelhub/merge_test.go
@@ -23,7 +23,7 @@ import (
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
-func ptrBool(v bool) *bool   { return &v }
+func ptrBool(v bool) *bool    { return &v }
 func ptrInt64(v int64) *int64 { return &v }
 
 func spaceWithContainerDefaults(d *intmodel.SpaceContainerDefaults) intmodel.Space {

--- a/internal/netpolicy/enforcer.go
+++ b/internal/netpolicy/enforcer.go
@@ -44,8 +44,8 @@ type Enforcer interface {
 // mutate iptables (e.g., `--no-daemon` read-only clients).
 type NoopEnforcer struct{}
 
-func (NoopEnforcer) Apply(_ context.Context, _ *Policy) error         { return nil }
-func (NoopEnforcer) Remove(_ context.Context, _, _ string) error      { return nil }
+func (NoopEnforcer) Apply(_ context.Context, _ *Policy) error    { return nil }
+func (NoopEnforcer) Remove(_ context.Context, _, _ string) error { return nil }
 
 // CommandRunner executes an iptables invocation and returns its combined
 // stdout+stderr. Tests inject a fake to capture invocations and return

--- a/internal/netpolicy/rules.go
+++ b/internal/netpolicy/rules.go
@@ -152,4 +152,3 @@ func DispatchRule(p *Policy) Rule {
 		},
 	}
 }
-


### PR DESCRIPTION
## Summary

- Runs `gofmt -w` on the four Go files flagged by `gofmt -l .` on clean `main` (alignment in `internal/modelhub/merge_test.go` + `internal/netpolicy/enforcer.go`; trailing-newline drift in `internal/controller/controller.go` + `internal/netpolicy/rules.go`).
- Runs `prettier --write` over `docs/site/**`, `docs/gaps-2026-04-19.md`, `AGENTS.md`, and `.github/workflows/mkdocs.yaml` (~33 files) — the same set the pre-commit `prettier` hook reformats on `--all-files`.
- All diffs are purely cosmetic (alignment, blank-line-after-list-intro, double-quoted YAML strings); no behavior change.

## Why

Dev's PR-creation contract requires `pre-commit run` to be clean before commit. On `main`, `pre-commit run --all-files` was auto-modifying ~37 files outside any change set, forcing devs to either bundle cosmetic cleanup into feature PRs (violates the no-unrelated-cleanups rule) or `git restore` the drift and re-run with `--files <touched>`. This PR clears the drift in one focused commit so the next dev sees a clean tree.

## Notes

- The `check-yaml` pre-commit hook still fails after this PR — but on two unrelated files I did not touch (`cmd/kuke/apply/testdata/multi-resource.yaml` for multi-document YAML, `mkdocs.yml` for a Python-tagged YAML constructor). Verified pre-existing on `origin/main`. Out of scope for a format-drift cleanup; should be a separate issue if it needs fixing.
- Pre-commit's `gofmt` only flagged 2 of the 4 Go files in its output (`merge_test.go`, `enforcer.go`). The other two (`controller.go`, `rules.go`) are the trailing-newline cases and were caught by the `end-of-file-fixer` hook that runs ahead of `go-fmt` in the chain — both still in scope and reformatted to match the issue's expected file list.

## Test plan

- [x] `gofmt -l .` — empty after fix
- [x] `pre-commit run --all-files` — `go-fmt`, `prettier`, and `addlicense` all `Passed`; only pre-existing `check-yaml` failures remain (verified pre-existing via `git stash` against `main`)
- [x] `make test` — full unit + table-test suite green (~30 packages)
- [ ] `make dev-init` end-to-end smoke — not run; this PR touches only formatting (Go files: alignment + trailing newline; doc files: prettier whitespace), no daemon/runtime/build-path code that the smoke playbook would exercise. The `make test` target above is the same suite CI runs.

Closes #308