### PR TITLE
fix: route cell root-container/start rows through non-cgroup helpers

### DIFF
--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -669,14 +669,14 @@ func printCellActions(cmd *cobra.Command, section controller.CellSection, image 
 		section.CellCgroupExistsPost,
 		section.CellCgroupCreated,
 	)
-	printCgroupAction(
+	printContainerAction(
 		cmd,
 		"cell root container",
 		section.CellRootContainerExistsPre,
 		section.CellRootContainerExistsPost,
 		section.CellRootContainerCreated,
 	)
-	printCgroupAction(
+	printStartAction(
 		cmd,
 		"cell containers",
 		section.CellStartedPre,
@@ -720,6 +720,36 @@ func printCgroupAction(cmd *cobra.Command, label string, existedPre bool, exists
 			cmd.Println(fmt.Sprintf("    - %s cgroup: missing (was previously present)", label))
 		} else {
 			cmd.Println(fmt.Sprintf("    - %s cgroup: missing", label))
+		}
+	}
+}
+
+func printContainerAction(cmd *cobra.Command, label string, existedPre bool, existsPost bool, created bool) {
+	switch {
+	case created:
+		cmd.Println(fmt.Sprintf("    - %s: created", label))
+	case existsPost:
+		cmd.Println(fmt.Sprintf("    - %s: already existed", label))
+	default:
+		if existedPre {
+			cmd.Println(fmt.Sprintf("    - %s: missing (was previously present)", label))
+		} else {
+			cmd.Println(fmt.Sprintf("    - %s: missing", label))
+		}
+	}
+}
+
+func printStartAction(cmd *cobra.Command, label string, startedPre bool, startedPost bool, started bool) {
+	switch {
+	case started:
+		cmd.Println(fmt.Sprintf("    - %s: started", label))
+	case startedPost:
+		cmd.Println(fmt.Sprintf("    - %s: already running", label))
+	default:
+		if startedPre {
+			cmd.Println(fmt.Sprintf("    - %s: stopped (was previously running)", label))
+		} else {
+			cmd.Println(fmt.Sprintf("    - %s: not running", label))
 		}
 	}
 }

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -73,6 +73,12 @@ func printDirAction(cmd *cobra.Command, label string, path string, created bool,
 //go:linkname printCgroupAction github.com/eminwux/kukeon/cmd/kuke/init.printCgroupAction
 func printCgroupAction(cmd *cobra.Command, label string, existedPre bool, existsPost bool, created bool)
 
+//go:linkname printContainerAction github.com/eminwux/kukeon/cmd/kuke/init.printContainerAction
+func printContainerAction(cmd *cobra.Command, label string, existedPre bool, existsPost bool, created bool)
+
+//go:linkname printStartAction github.com/eminwux/kukeon/cmd/kuke/init.printStartAction
+func printStartAction(cmd *cobra.Command, label string, startedPre bool, startedPost bool, started bool)
+
 //go:linkname runInit github.com/eminwux/kukeon/cmd/kuke/init.runInit
 func runInit(cmd *cobra.Command, args []string) error
 
@@ -124,6 +130,14 @@ func PrintDirAction(cmd *cobra.Command, label, path string, created, existsPost 
 
 func PrintCgroupAction(cmd *cobra.Command, label string, existedPre, existsPost, created bool) {
 	printCgroupAction(cmd, label, existedPre, existsPost, created)
+}
+
+func PrintContainerAction(cmd *cobra.Command, label string, existedPre, existsPost, created bool) {
+	printContainerAction(cmd, label, existedPre, existsPost, created)
+}
+
+func PrintStartAction(cmd *cobra.Command, label string, startedPre, startedPost, started bool) {
+	printStartAction(cmd, label, startedPre, startedPost, started)
 }
 
 func RunInit(cmd *cobra.Command) error {
@@ -446,8 +460,8 @@ func TestPrintCellActions(t *testing.T) {
 			expected: []string{
 				"- cell \"kukeond\": created (image ghcr.io/eminwux/kukeon:v1.0.0)",
 				"- cell cgroup: created",
-				"- cell root container cgroup: created",
-				"- cell containers cgroup: created",
+				"- cell root container: created",
+				"- cell containers: started",
 			},
 		},
 		{
@@ -466,8 +480,8 @@ func TestPrintCellActions(t *testing.T) {
 			expected: []string{
 				"- cell \"kukeond\": already existed",
 				"- cell cgroup: already existed",
-				"- cell root container cgroup: already existed",
-				"- cell containers cgroup: already existed",
+				"- cell root container: already existed",
+				"- cell containers: already running",
 			},
 		},
 		{
@@ -603,6 +617,104 @@ func TestPrintCgroupAction(t *testing.T) {
 			got := buf.String()
 			if !strings.Contains(got, tc.want) {
 				t.Fatalf("output %q missing %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrintContainerAction(t *testing.T) {
+	testCases := []struct {
+		name       string
+		label      string
+		existedPre bool
+		existsPost bool
+		created    bool
+		want       string
+	}{
+		{
+			name:    "created",
+			label:   "cell root container",
+			created: true,
+			want:    "- cell root container: created",
+		},
+		{
+			name:       "exists",
+			label:      "cell root container",
+			existsPost: true,
+			want:       "- cell root container: already existed",
+		},
+		{
+			name:       "missing-with-history",
+			label:      "cell root container",
+			existedPre: true,
+			want:       "- cell root container: missing (was previously present)",
+		},
+		{
+			name:  "missing",
+			label: "cell root container",
+			want:  "- cell root container: missing",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, buf := newOutputCommand()
+			PrintContainerAction(cmd, tc.label, tc.existedPre, tc.existsPost, tc.created)
+			got := buf.String()
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("output %q missing %q", got, tc.want)
+			}
+			if strings.Contains(got, "cgroup") {
+				t.Fatalf("output %q must not contain \"cgroup\"", got)
+			}
+		})
+	}
+}
+
+func TestPrintStartAction(t *testing.T) {
+	testCases := []struct {
+		name        string
+		label       string
+		startedPre  bool
+		startedPost bool
+		started     bool
+		want        string
+	}{
+		{
+			name:    "started",
+			label:   "cell containers",
+			started: true,
+			want:    "- cell containers: started",
+		},
+		{
+			name:        "already-running",
+			label:       "cell containers",
+			startedPost: true,
+			want:        "- cell containers: already running",
+		},
+		{
+			name:       "stopped-with-history",
+			label:      "cell containers",
+			startedPre: true,
+			want:       "- cell containers: stopped (was previously running)",
+		},
+		{
+			name:  "not-running",
+			label: "cell containers",
+			want:  "- cell containers: not running",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd, buf := newOutputCommand()
+			PrintStartAction(cmd, tc.label, tc.startedPre, tc.startedPost, tc.started)
+			got := buf.String()
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("output %q missing %q", got, tc.want)
+			}
+			if strings.Contains(got, "cgroup") {
+				t.Fatalf("output %q must not contain \"cgroup\"", got)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- The `cell root container cgroup` and `cell containers cgroup` rows under each cell in `kuke init` output were misleading: only the first row (cell cgroup) corresponds to a real cgroup. The next two report root-container existence and cell-started state — no separate cgroups exist there.
- Splits `printCgroupAction` into two siblings: `printContainerAction` (for root-container existence) and `printStartAction` (for start/stop transitions). Updates `printCellActions` and tests to match.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/kuke/init/...`
- [x] `make test`
- [x] `pre-commit run --files cmd/kuke/init/init.go cmd/kuke/init/init_test.go`
- [ ] `make dev-init` smoke — change is purely display-string in `cmd/kuke/init/init.go`; does not touch the daemon, build path, or anything under `/opt/kukeon`, so the daemon-parity guard does not apply.

## Notes for reviewer
- Per dev role rules (no `CLAUDE.md` edits in a code-fix PR), the `CLAUDE.md` "Manual phases" #4 expected-tail block (lines 79-81) still quotes the old `cgroup` strings. Filing a separate `docs:` follow-up issue with the verbatim proposed wording so pm can pick it up via `/pick-doc`. URL added in a comment on this PR after creation.

Closes #313