### PR TITLE
fix: auto-derive RootContainerID from container Root flag in apischeme

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -19,6 +19,7 @@ package apischeme
 import (
 	"fmt"
 
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
@@ -536,6 +537,62 @@ func validateContainerTty(spec ext.ContainerSpec) error {
 	return fmt.Errorf("container %q: tty fields require attachable: true", spec.ID)
 }
 
+// resolveCellRootContainer enforces the rules around CellSpec.RootContainerID
+// and ContainerSpec.Root and returns the resolved root container ID:
+//   - At most one container may carry root: true. Issue #349: a second
+//     root-flagged container would silently lose its Root intent, so it
+//     surfaces as a hard error here.
+//   - If RootContainerID is set, the named container must exist in the
+//     array, and any container marked root: true must be that same one.
+//   - If RootContainerID is empty but exactly one container has
+//     root: true, that container's ID is the resolved root. Callers
+//     building a normalized internal cell should overwrite
+//     spec.RootContainerID with the returned value so downstream code
+//     (runner.ensureCellRootContainerSpec, helpers.findRootContainer,
+//     etc.) sees a self-consistent cell.
+//   - If neither is set, returns "" — the runner builds a default root.
+func resolveCellRootContainer(spec intmodel.CellSpec) (string, error) {
+	var rootMarked []string
+	for _, c := range spec.Containers {
+		if c.Root {
+			rootMarked = append(rootMarked, c.ID)
+		}
+	}
+	if len(rootMarked) > 1 {
+		return "", fmt.Errorf("%w: %v", errdefs.ErrMultipleRootContainers, rootMarked)
+	}
+
+	if spec.RootContainerID != "" {
+		found := false
+		for _, c := range spec.Containers {
+			if c.ID == spec.RootContainerID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return "", fmt.Errorf(
+				"rootContainerId %q not found in containers array",
+				spec.RootContainerID,
+			)
+		}
+		if len(rootMarked) == 1 && rootMarked[0] != spec.RootContainerID {
+			return "", fmt.Errorf(
+				"%w: rootContainerId is %q but container %q has root: true",
+				errdefs.ErrRootContainerMismatch,
+				spec.RootContainerID,
+				rootMarked[0],
+			)
+		}
+		return spec.RootContainerID, nil
+	}
+
+	if len(rootMarked) == 1 {
+		return rootMarked[0], nil
+	}
+	return "", nil
+}
+
 // validateCellTty enforces the AC that CellTty.Default names an existing
 // attachable container in the same cell (or is empty).
 func validateCellTty(spec ext.CellSpec) error {
@@ -857,22 +914,17 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 			cell.Spec.Containers[i] = convertContainerSpecToInternal(extContainer)
 		}
 
-		// Validate that if RootContainerID is set, the container exists in Containers array
-		if cell.Spec.RootContainerID != "" {
-			found := false
-			for _, container := range cell.Spec.Containers {
-				if container.ID == cell.Spec.RootContainerID {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return intmodel.Cell{}, fmt.Errorf(
-					"rootContainerId %q not found in containers array",
-					cell.Spec.RootContainerID,
-				)
-			}
+		// Resolve RootContainerID. Auto-populates the field when a
+		// container in the array carries root: true with no explicit
+		// rootContainerId set, so the runner's explicit-root branch
+		// (and every downstream consumer of cell.Spec.RootContainerID)
+		// sees the user-supplied root spec instead of a default-built
+		// one (issue #349).
+		resolvedRoot, err := resolveCellRootContainer(cell.Spec)
+		if err != nil {
+			return intmodel.Cell{}, err
 		}
+		cell.Spec.RootContainerID = resolvedRoot
 
 		return cell, nil
 	default:
@@ -919,21 +971,14 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 			cell.Spec.Containers[i] = BuildContainerSpecExternalFromInternal(intContainer)
 		}
 
-		// Validate that if RootContainerID is set, the container exists in Containers array
-		if cell.Spec.RootContainerID != "" {
-			found := false
-			for _, container := range cell.Spec.Containers {
-				if container.ID == cell.Spec.RootContainerID {
-					found = true
-					break
-				}
-			}
-			if !found {
-				return ext.CellDoc{}, fmt.Errorf(
-					"rootContainerId %q not found in containers array",
-					cell.Spec.RootContainerID,
-				)
-			}
+		// Defensive validation on the way out: a malformed internal
+		// cell (e.g. constructed without going through ConvertCellDoc-
+		// ToInternal) should not silently round-trip. Reuses the same
+		// rules the inbound path applies; the resolved ID is ignored
+		// because the persisted RootContainerID is the source of truth
+		// for serialization.
+		if _, err := resolveCellRootContainer(in.Spec); err != nil {
+			return ext.CellDoc{}, err
 		}
 
 		return cell, nil

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -17,11 +17,13 @@
 package apischeme_test
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"gopkg.in/yaml.v3"
@@ -1566,4 +1568,200 @@ func TestSubtreeControllersRoundTripV1Beta1(t *testing.T) {
 				out.Status.SubtreeControllers)
 		}
 	})
+}
+
+// TestCellRootContainerIDAutoDerivedFromRootFlag covers issue #349: a Cell
+// whose YAML places root: true on a container in spec.containers[] but does
+// not set spec.rootContainerId must have RootContainerID auto-populated by
+// normalization. Without this, the runner's empty-RootContainerID branch in
+// ensureCellRootContainerSpec builds a default root spec and the user's
+// declared volumes (and any other container fields) silently disappear.
+func TestCellRootContainerIDAutoDerivedFromRootFlag(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "tmpfs-smoke"},
+		Spec: ext.CellSpec{
+			ID:      "tmpfs-smoke",
+			RealmID: "default",
+			SpaceID: "default",
+			StackID: "default",
+			Containers: []ext.ContainerSpec{
+				{
+					ID:    "root",
+					Root:  true,
+					Image: "registry.eminwux.com/busybox:latest",
+					Volumes: []ext.VolumeMount{
+						{Kind: "tmpfs", Target: "/var/lib/cache", SizeBytes: 16 * 1024 * 1024},
+					},
+				},
+			},
+		},
+	}
+
+	internal, _, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if got, want := internal.Spec.RootContainerID, "root"; got != want {
+		t.Fatalf("RootContainerID = %q, want %q (auto-derive from Root:true)", got, want)
+	}
+	if len(internal.Spec.Containers) != 1 {
+		t.Fatalf("containers len = %d, want 1", len(internal.Spec.Containers))
+	}
+	c := internal.Spec.Containers[0]
+	if !c.Root {
+		t.Errorf("Root flag dropped from container after normalize")
+	}
+	if len(c.Volumes) != 1 || c.Volumes[0].Target != "/var/lib/cache" {
+		t.Errorf("user volume dropped during normalize: %+v", c.Volumes)
+	}
+}
+
+// TestCellRootContainerIDLeftEmptyWhenNoRootFlag confirms the auto-derive
+// path is opt-in: a cell with no rootContainerId and no container marked
+// root: true keeps RootContainerID empty so the runner builds a default
+// root spec. This matches the kuke-system / system-realm pattern.
+func TestCellRootContainerIDLeftEmptyWhenNoRootFlag(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "no-root"},
+		Spec: ext.CellSpec{
+			ID:      "no-root",
+			RealmID: "default",
+			SpaceID: "default",
+			StackID: "default",
+			Containers: []ext.ContainerSpec{
+				{ID: "worker", Image: "registry.eminwux.com/busybox:latest"},
+			},
+		},
+	}
+
+	internal, _, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if internal.Spec.RootContainerID != "" {
+		t.Fatalf("RootContainerID = %q, want \"\"", internal.Spec.RootContainerID)
+	}
+}
+
+// TestCellRejectsMultipleRootTrueContainers asserts the multi-Root rule
+// from #349: at most one container in a cell may have root: true.
+// Otherwise either the second one's Root intent silently drops or we
+// pick a winner the user did not name — both are foot-guns.
+func TestCellRejectsMultipleRootTrueContainers(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "two-roots"},
+		Spec: ext.CellSpec{
+			ID:      "two-roots",
+			RealmID: "default",
+			SpaceID: "default",
+			StackID: "default",
+			Containers: []ext.ContainerSpec{
+				{ID: "a", Root: true, Image: "img"},
+				{ID: "b", Root: true, Image: "img"},
+			},
+		},
+	}
+
+	_, _, err := apischeme.NormalizeCell(input)
+	if err == nil {
+		t.Fatalf("NormalizeCell: want error, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrMultipleRootContainers) {
+		t.Fatalf("err = %v, want wrapped ErrMultipleRootContainers", err)
+	}
+}
+
+// TestCellRejectsRootContainerIDMismatch asserts the explicit/Root-flag
+// agreement rule: if rootContainerId is set and a different container
+// carries root: true, that's a misconfiguration the user must resolve.
+// The Root-flagged peer would otherwise silently end up as a non-root
+// container.
+func TestCellRejectsRootContainerIDMismatch(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "mismatch"},
+		Spec: ext.CellSpec{
+			ID:              "mismatch",
+			RealmID:         "default",
+			SpaceID:         "default",
+			StackID:         "default",
+			RootContainerID: "a",
+			Containers: []ext.ContainerSpec{
+				{ID: "a", Image: "img"},
+				{ID: "b", Root: true, Image: "img"},
+			},
+		},
+	}
+
+	_, _, err := apischeme.NormalizeCell(input)
+	if err == nil {
+		t.Fatalf("NormalizeCell: want error, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrRootContainerMismatch) {
+		t.Fatalf("err = %v, want wrapped ErrRootContainerMismatch", err)
+	}
+}
+
+// TestCellRootContainerIDAndRootFlagAgree confirms the no-op case:
+// rootContainerId set and the named container also carries root: true
+// is accepted (the explicit branch's existing happy path).
+func TestCellRootContainerIDAndRootFlagAgree(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "agree"},
+		Spec: ext.CellSpec{
+			ID:              "agree",
+			RealmID:         "default",
+			SpaceID:         "default",
+			StackID:         "default",
+			RootContainerID: "root",
+			Containers: []ext.ContainerSpec{
+				{ID: "root", Root: true, Image: "img"},
+				{ID: "worker", Image: "img"},
+			},
+		},
+	}
+
+	internal, _, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if internal.Spec.RootContainerID != "root" {
+		t.Fatalf("RootContainerID = %q, want %q", internal.Spec.RootContainerID, "root")
+	}
+}
+
+// TestBuildCellExternalRejectsMultipleRootTrue covers the defensive
+// validation on the outbound path: a malformed internal cell that
+// carries two Root:true containers must not silently round-trip out.
+func TestBuildCellExternalRejectsMultipleRootTrue(t *testing.T) {
+	internal := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "two-roots"},
+		Spec: intmodel.CellSpec{
+			ID:        "two-roots",
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "a", Root: true, Image: "img"},
+				{ID: "b", Root: true, Image: "img"},
+			},
+		},
+	}
+
+	_, err := apischeme.BuildCellExternalFromInternal(internal, ext.APIVersionV1Beta1)
+	if err == nil {
+		t.Fatalf("BuildCellExternalFromInternal: want error, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrMultipleRootContainers) {
+		t.Fatalf("err = %v, want wrapped ErrMultipleRootContainers", err)
+	}
 }

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -79,6 +79,21 @@ var (
 	ErrExplicitRootHostNetworkMismatch = errors.New(
 		"explicit rootContainerId must have hostNetwork: true when any cell container has hostNetwork: true",
 	)
+	// ErrMultipleRootContainers fires when more than one container in a cell
+	// has root: true. Only one container can be the cell's root; any extras
+	// would either silently lose their Root intent or contradict an explicit
+	// rootContainerId. Surfaced by apischeme normalization so the user sees
+	// a hard error at apply time instead of a silent drop downstream.
+	ErrMultipleRootContainers = errors.New(
+		"only one container in a cell may have root: true",
+	)
+	// ErrRootContainerMismatch fires when rootContainerId is set on a cell
+	// but a different container in the array carries root: true. The
+	// Root-flagged container would otherwise silently end up as a non-root
+	// peer; a hard error forces the user to pick one canonical root.
+	ErrRootContainerMismatch = errors.New(
+		"rootContainerId disagrees with container marked root: true",
+	)
 	ErrCellNameRequired        = errors.New("cell name is required")
 	ErrContainerNameRequired   = errors.New("container name is required")
 	ErrInvalidName             = errors.New("name is invalid")


### PR DESCRIPTION
## Summary

- A Cell whose YAML places `root: true` on a container in `spec.containers[]` but does not set `spec.rootContainerId` was silently dropping the user's container fields (volumes, env, command, etc.). The runner's `ensureCellRootContainerSpec` only consulted the container array when `RootContainerID != ""` and otherwise unconditionally generated a fresh default root spec — the user-marked container was re-merged into the array but only the *default-built* fields fed `BuildRootContainerSpec`.
- Fix at the API normalization boundary (`apischeme.ConvertCellDocToInternal`) so every entry point — apply, bootstrap, on-disk rehydrate (`runner.read`) — produces a self-consistent cell. A new `resolveCellRootContainer` helper auto-populates `RootContainerID` from a sole `Root: true` container, rejects multiple `Root: true` containers, and rejects a `RootContainerID`/`Root: true` mismatch. Two new sentinels in `internal/errdefs` (`ErrMultipleRootContainers`, `ErrRootContainerMismatch`) match the project's shared-sentinel convention.
- Picked option (2) from the issue ("normalize at the API boundary") over option (1) ("fix the runner branch") so the persisted internal cell stays consistent for every downstream reader (`update_cell.go`, `helpers.findRootContainer`, `refresh.go`, `get.go`, `cell_etc_files.go`). Bootstrap's `kukeondCellDoc` doesn't use `Root: true`, so the auto-default-root path for the kuke-system cell is structurally unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` — full unit suite green, including new `internal/apischeme` cases:
  - auto-derive populates `RootContainerID` from a single `Root: true` container, with volumes preserved
  - empty `RootContainerID` + zero `Root: true` containers stays empty (preserves the kuke-system / default-root path)
  - two `Root: true` containers errors with wrapped `ErrMultipleRootContainers`
  - `RootContainerID` set + a *different* `Root: true` container errors with wrapped `ErrRootContainerMismatch`
  - `RootContainerID` set + matching `Root: true` accepted
  - `BuildCellExternalFromInternal` rejects a malformed internal cell with two `Root: true` containers (defensive outbound validation)
- [ ] `make dev-init` smoke — could not run on this dev host: the docker build for the local kukeond image fails inside the dev container with `mount source: "overlay" ... err: invalid argument` from buildkit's nested overlayfs cachemount. The change is purely in apischeme normalization with no impact on the build path or the daemon binary; bootstrap doesn't use `Root: true`, so the daemon-parity check is structurally unaffected.

Closes #349