### PR TITLE
fix: pre-create attachable tty capture/log files at 0640 for kukeon group

### DIFF
--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -42,6 +43,18 @@ const attachableTTYDirRootMode os.FileMode = os.ModeSetgid | 0o0750
 // runPath). In that mode there is no group to delegate access to, so the
 // directory stays owner-only (0700).
 const attachableTTYDirNoGroupMode os.FileMode = 0o0700
+
+// attachableLogFileMode is the mode pre-applied to the per-container sbsh
+// capture and log files when the kukeon group GID is configured. 0640 =
+// rw for owner (the resolved container uid) + r for group (the kukeon
+// group), no world. Pre-creating the inodes at this mode before sbsh
+// runs forces sbsh's later `OpenFile(O_CREATE|...)` (which only sets the
+// mode on a fresh inode) to inherit the host-readable layout instead of
+// sbsh's hard-coded 0o600 owner-only default — that default blocks
+// non-root members of the kukeon group from tailing peer cells via
+// `kuke log`, even though the surrounding tty/ directory is already
+// group-traversable. Issue #366.
+const attachableLogFileMode os.FileMode = 0o0640
 
 // attachableTTYDirInitialPerms returns the (mode, gid) tuple to apply to a
 // freshly-prepared per-container tty directory before the workload
@@ -200,6 +213,55 @@ func (r *Exec) attachablePostCreateChown(namespace string, spec intmodel.Contain
 		// the file; this branch is the legacy attachable contract.
 	default:
 		return fmt.Errorf("chown %q to (uid=%d, gid=%d): %w", profilePath, uid, gid, chownErr)
+	}
+
+	if err := attachableEnsureLogFiles(ttyDir, int(uid), gid); err != nil {
+		return err
+	}
+	return nil
+}
+
+// attachableEnsureLogFiles pre-creates the per-container sbsh capture and
+// log files inside ttyDir at mode 0640 owned by (uid, gid) — the resolved
+// container uid and the kukeon group GID — so the in-container sbsh
+// process's later `OpenFile(O_CREATE|...)` finds existing inodes and
+// inherits the host-readable mode rather than sbsh's hard-coded 0o600
+// owner-only default. Without this pre-create a non-root host operator in
+// the kukeon group cannot tail peer cells via `kuke log` (issue #366),
+// even though the surrounding tty/ directory is already group-traversable.
+//
+// Idempotent: re-applies mode and ownership on every call so a daemon
+// restart that re-enters the start path tightens or relaxes pre-existing
+// inodes from a prior run uniformly.
+//
+// A no-op when gid is 0 — there is no kukeon group on the host, the
+// surrounding tty/ directory is already 0o0700 root-only by
+// attachableTTYDirInitialPerms, and widening these files to 0640 would
+// only change owner-rw to owner-rw + group-r-with-no-group-membership.
+// Skipping the pre-create in that branch preserves the legacy
+// 0o600 owner-only contract sbsh already produces.
+func attachableEnsureLogFiles(ttyDir string, uid, gid int) error {
+	if gid <= 0 {
+		return nil
+	}
+	for _, name := range []string{
+		consts.KukeonContainerCaptureFile,
+		consts.KukeonContainerLogFile,
+	} {
+		path := filepath.Join(ttyDir, name)
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, attachableLogFileMode)
+		if err != nil {
+			return fmt.Errorf("create %q: %w", path, err)
+		}
+		if cerr := f.Close(); cerr != nil {
+			return fmt.Errorf("close %q: %w", path, cerr)
+		}
+		if err := os.Chmod(path, attachableLogFileMode); err != nil {
+			return fmt.Errorf("chmod %q to %#o: %w", path, attachableLogFileMode, err)
+		}
+		if err := os.Chown(path, uid, gid); err != nil {
+			return fmt.Errorf("chown %q to (uid=%d, gid=%d): %w", path, uid, gid, err)
+		}
 	}
 	return nil
 }

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -21,7 +21,10 @@ package runner
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/eminwux/kukeon/internal/consts"
 )
 
 // TestAttachableTTYDirInitialPerms locks the (mode, gid) tuple for the per-
@@ -87,5 +90,123 @@ func TestAttachableTTYDirRootMode_SetsSGIDBit(t *testing.T) {
 	}
 	if attachableTTYDirRootMode.Perm() != 0o0750 {
 		t.Errorf("attachableTTYDirRootMode perm bits = %#o, want 0o750", attachableTTYDirRootMode.Perm())
+	}
+}
+
+// nonZeroTestGID returns a gid suitable for the
+// attachableEnsureLogFiles tests. The helper short-circuits when gid<=0
+// (the legacy fallback path), so a process whose primary gid is 0 (the
+// CI image runs the suite as root) needs a positive gid plumbed in
+// explicitly. Non-root processes carry a non-zero gid already and use
+// it directly so os.Chown does not EPERM.
+func nonZeroTestGID() int {
+	if gid := os.Getgid(); gid != 0 {
+		return gid
+	}
+	// As root we can chown to any gid; pick 1 (typically `daemon`) — the
+	// numeric value does not matter to the helper, only that it is
+	// positive.
+	return 1
+}
+
+// TestAttachableEnsureLogFiles_PreCreatesAt0640 locks the regression fix
+// for issue #366: when a kukeon group GID is configured, the per-container
+// capture and log files must be pre-created at 0640 so sbsh's later
+// `OpenFile(O_CREATE|...)` inside the container inherits the host-
+// readable mode instead of dropping back to 0o600 owner-only — which had
+// blocked non-root kukeon-group operators from tailing peer cells.
+func TestAttachableEnsureLogFiles_PreCreatesAt0640(t *testing.T) {
+	ttyDir := t.TempDir()
+	if err := attachableEnsureLogFiles(ttyDir, os.Getuid(), nonZeroTestGID()); err != nil {
+		t.Fatalf("attachableEnsureLogFiles: %v", err)
+	}
+	for _, name := range []string{
+		consts.KukeonContainerCaptureFile,
+		consts.KukeonContainerLogFile,
+	} {
+		path := filepath.Join(ttyDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %q: %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != 0o640 {
+			t.Errorf("%s mode = %#o, want 0o640", name, got)
+		}
+	}
+}
+
+// TestAttachableEnsureLogFiles_ReappliesModeOnPreExisting covers the
+// daemon-restart path: a prior run left capture/log inodes at the legacy
+// 0o600, and the new pre-create helper must tighten them up so the
+// regression doesn't survive a restart.
+func TestAttachableEnsureLogFiles_ReappliesModeOnPreExisting(t *testing.T) {
+	ttyDir := t.TempDir()
+	for _, name := range []string{
+		consts.KukeonContainerCaptureFile,
+		consts.KukeonContainerLogFile,
+	} {
+		path := filepath.Join(ttyDir, name)
+		if err := os.WriteFile(path, []byte("stale"), 0o600); err != nil {
+			t.Fatalf("seed %q: %v", path, err)
+		}
+	}
+	if err := attachableEnsureLogFiles(ttyDir, os.Getuid(), nonZeroTestGID()); err != nil {
+		t.Fatalf("attachableEnsureLogFiles: %v", err)
+	}
+	for _, name := range []string{
+		consts.KukeonContainerCaptureFile,
+		consts.KukeonContainerLogFile,
+	} {
+		path := filepath.Join(ttyDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %q: %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != 0o640 {
+			t.Errorf("%s mode = %#o, want 0o640", name, got)
+		}
+		// Pre-existing content must survive — sbsh's later append must not
+		// observe a truncated transcript.
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %q: %v", path, err)
+		}
+		if string(data) != "stale" {
+			t.Errorf("%s content = %q, want %q (pre-create must not truncate)", name, data, "stale")
+		}
+	}
+}
+
+// TestAttachableEnsureLogFiles_NoGroupGIDIsNoOp covers the legacy fallback
+// path: when the kukeon group GID is unset (e.g., older `kuke init` runs
+// or `--no-daemon` smoke tests), the helper does nothing and leaves
+// sbsh's hard-coded 0o600 default in effect — matching the surrounding
+// tty/ directory's 0o0700 root-only mode in the same branch. Widening the
+// files would not buy anything (no group exists to grant access to) and
+// would change the legacy contract.
+func TestAttachableEnsureLogFiles_NoGroupGIDIsNoOp(t *testing.T) {
+	ttyDir := t.TempDir()
+	if err := attachableEnsureLogFiles(ttyDir, os.Getuid(), 0); err != nil {
+		t.Fatalf("attachableEnsureLogFiles: %v", err)
+	}
+	for _, name := range []string{
+		consts.KukeonContainerCaptureFile,
+		consts.KukeonContainerLogFile,
+	} {
+		path := filepath.Join(ttyDir, name)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("%s exists with err=%v; want IsNotExist (helper must skip when gid=0)", name, err)
+		}
+	}
+}
+
+// TestAttachableLogFileMode_Is0640 belt-and-braces guard for the constant
+// itself: a future refactor that loosens it to 0o660 (group-writable)
+// would let the host-side kukeon group append to the in-container
+// transcript, which is not the behaviour the issue asks for; tightening
+// it back to 0o600 reintroduces the regression.
+func TestAttachableLogFileMode_Is0640(t *testing.T) {
+	if attachableLogFileMode != 0o0640 {
+		t.Errorf("attachableLogFileMode = %#o, want 0o0640", attachableLogFileMode)
 	}
 }


### PR DESCRIPTION
## Summary

- The per-container sbsh capture and log files inside `<ttyDir>/` landed mode `0600` because sbsh creates them with that hard-coded default. The surrounding `tty/` directory is already `02750 root:kukeon` (group-traversable) and the sbsh control socket is `0660 root:kukeon` via the existing `--socket-mode` plumbing — but the capture/log siblings stayed root-only, so a non-root operator in the `kukeon` group (orchestrator agent, host tooling) got EACCES when tailing peer cells via `kuke log`.
- Fixed by pre-creating the two files in `attachablePostCreateChown` — the existing post-create hook that already chowns `ttyDir` and `profile.yaml` to the resolved container uid before the task starts. The helper opens `<ttyDir>/{capture,log}` with `O_CREATE|O_WRONLY` (no `O_TRUNC`), then `os.Chmod` to `0640` and `os.Chown` to `(uid, kukeonGID)`. When sbsh later opens the same paths inside the container with `O_CREATE|O_APPEND|O_WRONLY`, the existing inodes are reused and Linux ignores the mode argument — so the host-readable layout sticks across both fresh starts and daemon restarts.
- Skips the pre-create when `KukeonGroupGID == 0` (no kukeon group on the host), preserving the legacy `0o600` owner-only contract that sbsh already produces — the surrounding `tty/` dir is already `0o0700` root-only in that branch by `attachableTTYDirInitialPerms`, so widening the files would not buy anything.
- 0640 chosen over 0660: the kukeon group only needs read access (the captured PTY transcript is for tailing, not writing); 0660 would let the host-side group also append to the in-container transcript, which is not what the issue asks for.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` — full unit suite green, including new `internal/controller/runner` cases:
  - pre-create at 0640 when a kukeon group GID is configured
  - re-apply mode and ownership on pre-existing files (daemon-restart parity), preserving content
  - no-op when GID == 0 (legacy fallback path)
  - constant-locking guard on `attachableLogFileMode == 0o0640`
- [ ] `make dev-init` smoke — could not run on this dev host: the docker build for the local kukeond image fails inside the dev container with `mount source: "overlay" ... err: invalid argument` from buildkit's nested overlayfs cachemount. Same environmental failure documented on the dev host in PR #367. The change is purely in the runner's per-container tty pre-create logic with no impact on the build path or the daemon binary; bootstrap doesn't use Attachable/sbsh, so the daemon-parity check is structurally unaffected.

Closes #366