### PR TITLE
feat: plumb capture/log mode+gid through AttachableInjection for kukeon-group log access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.10.1
+	github.com/eminwux/sbsh v0.10.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.10.1 h1:uJY2XTHbz1bsYic3LPuu69t4/NtPW2gaIA+OflJOrfo=
-github.com/eminwux/sbsh v0.10.1/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
+github.com/eminwux/sbsh v0.10.2 h1:rqWDbl343evHUZ/hbIW2SxpZvo0vab3c3/Y8I5OUANI=
+github.com/eminwux/sbsh v0.10.2/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -133,6 +133,12 @@ func (r *Exec) attachableBuildOpts(namespace string, spec intmodel.ContainerSpec
 			// host-side traversal layout `kuke init` sets up on /opt/kukeon.
 			// Zero falls back to sbsh's hard-coded 0600 owner-only default.
 			SocketGID: r.opts.KukeonGroupGID,
+			// Same group plumbed for the capture transcript and log file so
+			// `kuke log` from a non-root kukeon-group operator can read the
+			// 0640 root:kukeon files sbsh writes inside ttyDir. Zero falls
+			// back to sbsh's hard-coded 0600 owner-only default.
+			CaptureGID: r.opts.KukeonGroupGID,
+			LogFileGID: r.opts.KukeonGroupGID,
 		}),
 	}, nil
 }

--- a/internal/ctr/attachable.go
+++ b/internal/ctr/attachable.go
@@ -80,6 +80,18 @@ const (
 	// Available since sbsh v0.10.0; older sbsh binaries reject the flag and
 	// the wrapper omits it when the kukeon group GID is unset.
 	AttachableSocketMode = "0660"
+
+	// AttachableCaptureMode and AttachableLogFileMode are the octal modes
+	// passed to `sbsh terminal --capture-mode` / `--log-file-mode` when the
+	// corresponding GID is configured. 0640 = rw for owner (the container
+	// uid) + r for group (the kukeon group), no world. 0640 — not 0660 —
+	// because the host-side group only needs to tail the transcript via
+	// `kuke log`; the in-container sbsh process does the writes.
+	//
+	// Available since sbsh v0.10.2; older sbsh binaries reject the flags
+	// and the wrapper omits them when the corresponding GID is unset.
+	AttachableCaptureMode = "0640"
+	AttachableLogFileMode = "0640"
 )
 
 // AttachableInjection carries the host-side paths needed to wrap a container's
@@ -115,6 +127,26 @@ type AttachableInjection struct {
 	// container; the staged binary at /.kukeon/bin/sbsh must support the
 	// `--socket-mode` and `--socket-gid` flags.
 	SocketGID int
+
+	// CaptureGID and LogFileGID, when non-zero, are the numeric GIDs of
+	// the kukeon system group on the host. The wrapper emits `sbsh terminal
+	// --capture-mode AttachableCaptureMode --capture-gid <CaptureGID>` and
+	// `--log-file-mode AttachableLogFileMode --log-file-gid <LogFileGID>`
+	// so the per-container capture transcript and log file are created
+	// with mode 0640 owned by the kukeon group, matching the socket and
+	// parent tty/ layout — without these flags sbsh's default 0o600
+	// owner-only files are unreadable to non-root kukeon-group operators
+	// invoking `kuke log` from the host.
+	//
+	// In practice both will be the same GID (the kukeon group GID) for
+	// now, but separate fields keep the API parallel to SocketGID and
+	// leave room for divergent group choices later. Zero (the default)
+	// preserves sbsh's hard-coded 0o600 owner-only behavior. Requires
+	// sbsh v0.10.2 or later inside the container; the staged binary at
+	// /.kukeon/bin/sbsh must support the `--capture-mode`, `--capture-gid`,
+	// `--log-file-mode`, and `--log-file-gid` flags.
+	CaptureGID int
+	LogFileGID int
 }
 
 // withAttachableMounts adds the two bind mounts that make sbsh reachable from
@@ -165,6 +197,13 @@ func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 // kukeon-group operators on the host even when the parent tty/ directory
 // is group-traversable. Both flags require sbsh v0.10.0 or later.
 //
+// When inj.CaptureGID > 0 or inj.LogFileGID > 0, the wrapper additionally
+// passes `--capture-mode 0640 --capture-gid <CaptureGID>` and
+// `--log-file-mode 0640 --log-file-gid <LogFileGID>` so the per-container
+// capture transcript and log file land as 0640 owned by the kukeon group,
+// allowing `kuke log` from a non-root kukeon-group operator to read them.
+// These flags require sbsh v0.10.2 or later.
+//
 // OCI semantics: process.args is the merged "ENTRYPOINT + CMD" by the time
 // this opt runs (containerd's WithImageConfigArgs has already resolved image
 // defaults and any user override of either). We just wrap the result, which
@@ -196,6 +235,18 @@ func withAttachableArgsWrap(inj AttachableInjection) oci.SpecOpts {
 			wrapped = append(wrapped,
 				"--socket-mode", AttachableSocketMode,
 				"--socket-gid", strconv.Itoa(inj.SocketGID),
+			)
+		}
+		if inj.CaptureGID > 0 {
+			wrapped = append(wrapped,
+				"--capture-mode", AttachableCaptureMode,
+				"--capture-gid", strconv.Itoa(inj.CaptureGID),
+			)
+		}
+		if inj.LogFileGID > 0 {
+			wrapped = append(wrapped,
+				"--log-file-mode", AttachableLogFileMode,
+				"--log-file-gid", strconv.Itoa(inj.LogFileGID),
 			)
 		}
 		wrapped = append(wrapped, "--")

--- a/internal/ctr/attachable_test.go
+++ b/internal/ctr/attachable_test.go
@@ -384,6 +384,136 @@ func TestBuildContainerSpec_AttachableTrue_NoSocketFlagsWhenGIDUnset(t *testing.
 	}
 }
 
+// TestBuildContainerSpec_AttachableTrue_CaptureLogFlagsEmittedWithGID covers
+// the kukeon-group `kuke log` end-to-end fix (#369): when CaptureGID and
+// LogFileGID are non-zero, the wrapper appends `--capture-mode 0640
+// --capture-gid <gid>` and `--log-file-mode 0640 --log-file-gid <gid>` to
+// the `sbsh terminal` invocation, immediately before the `--` workload
+// separator. Without these flags sbsh's capture transcript and log file
+// land at 0o600 owner-only and are unreadable to non-root members of the
+// kukeon group on the host even when the parent tty/ directory is
+// group-traversable.
+func TestBuildContainerSpec_AttachableTrue_CaptureLogFlagsEmittedWithGID(t *testing.T) {
+	in := intmodel.ContainerSpec{
+		ID:         "c1",
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Attachable: true,
+	}
+	inj := ctr.AttachableInjection{
+		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
+		SocketGID:      986,
+		CaptureGID:     986,
+		LogFileGID:     986,
+	}
+	spec := applyBuiltSpecWith(t, in, []string{"/bin/sh"}, ctr.WithAttachableInjection(inj))
+
+	want := []string{
+		ctr.AttachableBinaryPath,
+		ctr.AttachableSubcommand,
+		"--run-path", ctr.AttachableTTYDir,
+		"--socket", ctr.AttachableSocketPath,
+		"--capture-file", ctr.AttachableCapturePath,
+		"--log-file", ctr.AttachableLogfilePath,
+		"--socket-mode", ctr.AttachableSocketMode,
+		"--socket-gid", "986",
+		"--capture-mode", ctr.AttachableCaptureMode,
+		"--capture-gid", "986",
+		"--log-file-mode", ctr.AttachableLogFileMode,
+		"--log-file-gid", "986",
+		"--",
+		"/bin/sh",
+	}
+	if !reflect.DeepEqual(spec.Process.Args, want) {
+		t.Fatalf("Process.Args = %v\nwant %v", spec.Process.Args, want)
+	}
+}
+
+// TestBuildContainerSpec_AttachableTrue_NoCaptureLogFlagsWhenGIDsUnset locks
+// the legacy fallback: with no kukeon group GID configured (CaptureGID = 0
+// and LogFileGID = 0) the wrapper omits the capture/log mode and gid flags
+// so sbsh applies its hard-coded 0o600 owner-only default. Mirrors the
+// socket-flag guard — we must not invoke flags introduced in sbsh v0.10.2
+// against an older staged binary.
+func TestBuildContainerSpec_AttachableTrue_NoCaptureLogFlagsWhenGIDsUnset(t *testing.T) {
+	in := intmodel.ContainerSpec{
+		ID:         "c1",
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Attachable: true,
+	}
+	inj := ctr.AttachableInjection{
+		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
+	}
+	spec := applyBuiltSpecWith(t, in, []string{"/bin/sh"}, ctr.WithAttachableInjection(inj))
+
+	for _, arg := range spec.Process.Args {
+		switch arg {
+		case "--capture-mode", "--capture-gid", "--log-file-mode", "--log-file-gid":
+			t.Fatalf("expected no capture/log flags when CaptureGID=0 and LogFileGID=0, got %v", spec.Process.Args)
+		}
+	}
+}
+
+// TestBuildContainerSpec_AttachableTrue_CaptureAndLogFlagsIndependent
+// confirms CaptureGID and LogFileGID are independently gated — setting one
+// must not emit the other's flags. Future callers may legitimately diverge
+// the two GIDs (e.g., capture readable to a broader audit group) and the
+// wrapper must respect that.
+func TestBuildContainerSpec_AttachableTrue_CaptureAndLogFlagsIndependent(t *testing.T) {
+	in := intmodel.ContainerSpec{
+		ID:         "c1",
+		Image:      "registry.eminwux.com/busybox:latest",
+		CellName:   "cell",
+		SpaceName:  "space",
+		RealmName:  "realm",
+		StackName:  "stack",
+		Attachable: true,
+	}
+
+	captureOnly := ctr.AttachableInjection{
+		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
+		CaptureGID:     986,
+	}
+	spec := applyBuiltSpecWith(t, in, []string{"/bin/sh"}, ctr.WithAttachableInjection(captureOnly))
+	hasFlag := func(args []string, flag string) bool {
+		for _, a := range args {
+			if a == flag {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasFlag(spec.Process.Args, "--capture-mode") || !hasFlag(spec.Process.Args, "--capture-gid") {
+		t.Fatalf("CaptureGID set: expected --capture-mode and --capture-gid, got %v", spec.Process.Args)
+	}
+	if hasFlag(spec.Process.Args, "--log-file-mode") || hasFlag(spec.Process.Args, "--log-file-gid") {
+		t.Fatalf("CaptureGID set, LogFileGID unset: expected no log-file flags, got %v", spec.Process.Args)
+	}
+
+	logOnly := ctr.AttachableInjection{
+		SbshBinaryPath: "/opt/kukeon/cache/sbsh/amd64/sbsh",
+		HostTTYDir:     "/opt/kukeon/realm/space/stack/cell/c1/tty",
+		LogFileGID:     986,
+	}
+	spec = applyBuiltSpecWith(t, in, []string{"/bin/sh"}, ctr.WithAttachableInjection(logOnly))
+	if !hasFlag(spec.Process.Args, "--log-file-mode") || !hasFlag(spec.Process.Args, "--log-file-gid") {
+		t.Fatalf("LogFileGID set: expected --log-file-mode and --log-file-gid, got %v", spec.Process.Args)
+	}
+	if hasFlag(spec.Process.Args, "--capture-mode") || hasFlag(spec.Process.Args, "--capture-gid") {
+		t.Fatalf("LogFileGID set, CaptureGID unset: expected no capture flags, got %v", spec.Process.Args)
+	}
+}
+
 func findMount(spec *runtimespec.Spec, dest string) *runtimespec.Mount {
 	for i := range spec.Mounts {
 		if spec.Mounts[i].Destination == dest {


### PR DESCRIPTION
## Summary

- Per-container sbsh capture and log files inside `<ttyDir>/` landed `0o600` owned by the container uid because sbsh's hard-coded default opens them owner-only — the surrounding `tty/` dir is `02750 root:kukeon` and the control socket is `0660 root:kukeon` (post-#260), but the capture/log siblings stayed root-only, so a non-root operator in the `kukeon` group got EACCES when tailing peer cells via `kuke log`.
- Fixed by extending `AttachableInjection` with `CaptureGID` and `LogFileGID` fields paralleling `SocketGID`, and having `withAttachableArgsWrap` plumb `--capture-mode 0640 --capture-gid <gid>` and `--log-file-mode 0640 --log-file-gid <gid>` to `sbsh terminal` so sbsh applies the mode and chown after open. Same plumbing point and dependency-injection structure as the socket fix — the capture/log files are siblings of the socket, share the kukeon-group read requirement, and now go through the same single mechanism. Replaces PR #368's host-side pre-create approach, which fragmented the contract: a future sbsh that adds `O_TRUNC` or unlinks-and-recreates would silently regress that fix without any test catching it.
- 0640 (not 0660) because the host-side group only needs to read the captured PTY transcript; the in-container sbsh process does the writes. Mirrors the issue's proposal verbatim.
- `attachableBuildOpts` populates both new fields from `r.opts.KukeonGroupGID`. Zero falls back to sbsh's hard-coded `0o600` owner-only default — matching the legacy contract for hosts without `sysuser.EnsureUserGroup` and the older socket fallback.
- Bumps `github.com/eminwux/sbsh` to `v0.10.2` in `go.mod`/`go.sum` — the version that ships the `--capture-mode/--capture-gid` and `--log-file-mode/--log-file-gid` flags (eminwux/sbsh#200). The staged binary at `/.kukeon/bin/sbsh` must be v0.10.2 or later for the new flags to take effect; older sbsh binaries reject the flags and the wrapper omits them when the corresponding GID is zero.
- AC bullet about removing PR #368's `attachableEnsureLogFiles` is structurally a no-op: PR #368 was closed without merging, so `main` already lacks the helper — verified via `grep -rn "attachableEnsureLogFiles" --include='*.go'` returning no matches.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` — full unit suite green, including new `internal/ctr/attachable_test.go` cases:
  - wrapper appends `--capture-mode 0640 --capture-gid <gid>` and `--log-file-mode 0640 --log-file-gid <gid>` when both GIDs are non-zero, in the slot immediately before `--`
  - legacy fallback: with both GIDs unset the wrapper omits all four capture/log flags so sbsh applies its hard-coded `0o600` default (also guards against invoking sbsh-v0.10.2-only flags against an older staged binary)
  - independent gating: setting `CaptureGID` alone emits only the capture flags; setting `LogFileGID` alone emits only the log-file flags
- [ ] `make dev-init` smoke — could not run on this dev host: the docker build for the local kukeond image fails inside the dev container with `mount source: "overlay" ... err: invalid argument` from buildkit's nested overlayfs cachemount. Same environmental failure documented on PRs #367 and #368. The change is purely additive on the wrapper-arg path with no impact on the build path or the daemon's `/opt/kukeon` view; bootstrap doesn't use Attachable/sbsh, so the daemon-parity check is structurally unaffected.
- [ ] End-to-end `kuke log` smoke from a non-root kukeon-group operator — could not run on this dev host because (a) the local kukeond image build is blocked by the same overlay-on-overlay docker error above, and (b) the cached sbsh binary at `/opt/kukeon/cache/sbsh/<arch>/sbsh` would need to be updated to v0.10.2 on this host. Reviewer's environment will exercise this.

Closes #369