### PR TITLE
build: pass --allow-multiple-documents --unsafe to pre-commit check-yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: ["--allow-multiple-documents", "--unsafe"]
         exclude: ^examples/profiles/local\.yaml$
       - id: check-json
       - id: check-toml


### PR DESCRIPTION
## Summary
- `pre-commit run --all-files` was non-zero on a clean `main` because `check-yaml` rejected the multi-doc `cmd/kuke/apply/testdata/multi-resource.yaml` and `mkdocs.yml`'s `!!python/name:` Material-for-MkDocs constructor — both legitimate uses the safe-loader default cannot accept (#361, #362).
- Add `args: ["--allow-multiple-documents", "--unsafe"]` to the existing `check-yaml` hook. `--unsafe` makes the hook parse via `yaml.parse` (token-level, no constructor resolution), so it still validates structure without requiring `pymdownx`. The existing `^examples/profiles/local\.yaml$` exclude is left untouched.

## Test plan
- [x] `pre-commit run check-yaml --all-files` → `Passed`
- [x] `pre-commit run --files .pre-commit-config.yaml` → all applicable hooks pass (yaml/json/toml/whitespace/prettier)
- [ ] `make test` — not run (out of scope: this PR only edits `.pre-commit-config.yaml`, no Go code touched)

Closes #361
Closes #362