### PR TITLE
fix: aggregate DeleteCell container errors and reconcile orphans by name

### DIFF
--- a/internal/controller/runner/delete_cell.go
+++ b/internal/controller/runner/delete_cell.go
@@ -72,6 +72,7 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 	if err != nil {
 		return fmt.Errorf("failed to get realm: %w", err)
 	}
+	namespace := internalRealm.Spec.Namespace
 
 	cellSpaceName := internalCell.Spec.SpaceName
 	cellStackName := internalCell.Spec.StackName
@@ -95,128 +96,80 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 		networkName, _ = r.getSpaceNetworkName(space)
 	}
 
-	// Delete all containers in the cell (workload + root)
-	for _, containerSpec := range internalCell.Spec.Containers {
-		containerSpaceName := containerSpec.SpaceName
-		if strings.TrimSpace(containerSpaceName) == "" {
-			containerSpaceName = cellSpaceName
-		}
-		containerStackName := containerSpec.StackName
-		if strings.TrimSpace(containerStackName) == "" {
-			containerStackName = cellStackName
-		}
-		containerCellName := containerSpec.CellName
-		if strings.TrimSpace(containerCellName) == "" {
-			containerCellName = cellID
-		}
+	// Aggregate container-deletion failures rather than swallow them. Issue
+	// #371: a single warn-and-continue on a non-NotFound DeleteContainer
+	// error used to slip past the metadata-removal step, leaving an orphan
+	// containerd container behind while the controller declared the cell
+	// gone. The next `kuke init` then collided on the surviving ID.
+	var deleteErrors []error
 
-		// Use ContainerdID from spec
+	// Workload containers tracked on the cell spec.
+	for _, containerSpec := range internalCell.Spec.Containers {
 		containerID := containerSpec.ContainerdID
 		if containerID == "" {
+			// A partial init can persist the cell document before the
+			// runner has filled in ContainerdID. Don't silently skip —
+			// the name-based scan below will catch any container that
+			// was already created in containerd.
 			r.logger.WarnContext(
 				r.ctx,
-				"container has empty ContainerdID, skipping",
-				"container",
-				containerSpec.ID,
+				"container has empty ContainerdID; relying on name-based orphan scan",
+				"container", containerSpec.ID,
 			)
 			continue
 		}
-
-		// Get netns path and purge CNI before stopping/deleting
-		netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, containerID)
-		_ = r.purgeCNIForContainer(containerID, netnsPath, networkName)
-
-		// Use container name with UUID for containerd operations
-		// Stop and delete the container
-		_, err = r.ctrClient.StopContainer(internalRealm.Spec.Namespace, containerID, ctr.StopContainerOptions{})
-		if err != nil {
-			// Check if container/task doesn't exist - this is idempotent (already stopped/deleted)
-			if errors.Is(err, errdefs.ErrContainerNotFound) || errors.Is(err, errdefs.ErrTaskNotFound) {
-				r.logger.DebugContext(
-					r.ctx,
-					"container or task already stopped/deleted, continuing",
-					"container",
-					containerID,
-				)
-			} else {
-				r.logger.WarnContext(
-					r.ctx,
-					"failed to stop container, continuing with deletion",
-					"container",
-					containerID,
-					"error",
-					err,
-				)
-			}
-		}
-
-		err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, containerID, ctr.ContainerDeleteOptions{
-			SnapshotCleanup: true,
-		})
-		if err != nil {
-			// Check if container doesn't exist - this is idempotent (already deleted)
-			if errors.Is(err, errdefs.ErrContainerNotFound) {
-				r.logger.DebugContext(r.ctx, "container already deleted", "container", containerID)
-				// Continue with other containers
-			} else {
-				r.logger.WarnContext(r.ctx, "failed to delete container", "container", containerID, "error", err)
-				// Continue with other containers
-			}
+		if delErr := r.stopAndDeleteContainer(namespace, containerID, networkName, false); delErr != nil {
+			deleteErrors = append(deleteErrors,
+				fmt.Errorf("delete container %q: %w", containerID, delErr))
 		}
 	}
 
-	// Delete root container
+	// Root container.
 	rootContainerID, err := naming.BuildRootContainerdID(cellSpaceName, cellStackName, cellID)
 	if err != nil {
 		return fmt.Errorf("failed to build root container containerd ID: %w", err)
 	}
+	if delErr := r.stopAndDeleteContainer(namespace, rootContainerID, networkName, true); delErr != nil {
+		deleteErrors = append(deleteErrors,
+			fmt.Errorf("delete root container %q: %w", rootContainerID, delErr))
+	}
 
-	// Comprehensive CNI cleanup for root container before stopping/deleting
-	netnsPath, _ := r.getContainerNetnsPath(internalRealm.Spec.Namespace, rootContainerID)
-	_ = r.purgeCNIForContainer(rootContainerID, netnsPath, networkName)
-
-	_, err = r.ctrClient.StopContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.StopContainerOptions{Force: true})
-	if err != nil {
-		// Check if container/task doesn't exist - this is idempotent (already stopped/deleted)
-		if errors.Is(err, errdefs.ErrContainerNotFound) || errors.Is(err, errdefs.ErrTaskNotFound) {
-			r.logger.DebugContext(
-				r.ctx,
-				"root container or task already stopped/deleted, continuing",
-				"container",
-				rootContainerID,
-			)
-		} else {
-			r.logger.WarnContext(
-				r.ctx,
-				"failed to stop root container, continuing with deletion",
-				"container",
-				rootContainerID,
-				"error",
-				err,
-			)
+	// Belt-and-suspenders: enumerate every containerd container in the realm
+	// namespace whose ID matches `<space>_<stack>_<cell>_*` and tear it down
+	// too. Catches the partial-init case where the cell spec was persisted
+	// with an empty ContainerdID, and the rare race where a non-NotFound
+	// DeleteContainer error above leaves a survivor we then mop up here.
+	namePrefix := fmt.Sprintf("%s_%s_%s_", cellSpaceName, cellStackName, cellID)
+	orphans, scanErr := r.findOrphanContainerIDs(namespace, namePrefix)
+	if scanErr != nil {
+		deleteErrors = append(deleteErrors,
+			fmt.Errorf("scan orphan containers with prefix %q: %w", namePrefix, scanErr))
+	}
+	for _, orphanID := range orphans {
+		r.logger.InfoContext(
+			r.ctx,
+			"reconciling orphan container left by partial init or prior failed delete",
+			"container", orphanID,
+			"namespace", namespace,
+		)
+		if delErr := r.stopAndDeleteContainer(namespace, orphanID, networkName, true); delErr != nil {
+			deleteErrors = append(deleteErrors,
+				fmt.Errorf("delete orphan container %q: %w", orphanID, delErr))
 		}
 	}
 
-	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.ContainerDeleteOptions{
-		SnapshotCleanup: true,
-	})
-	if err != nil {
-		// Check if container doesn't exist - this is idempotent (already deleted)
-		if errors.Is(err, errdefs.ErrContainerNotFound) {
-			r.logger.DebugContext(r.ctx, "root container already deleted", "container", rootContainerID)
-			// Continue with cgroup and metadata deletion
-		} else {
-			r.logger.WarnContext(r.ctx, "failed to delete root container", "container", rootContainerID, "error", err)
-			// Continue with cgroup and metadata deletion
-		}
-	}
-
-	// Always run comprehensive CNI cleanup after root container deletion as a safety net
-	// This ensures IPAM allocations are cleaned up even if earlier cleanup succeeded or failed
-	// Clear netns path since container is now deleted
-	netnsPath = ""
+	// Always run comprehensive CNI cleanup after root container deletion as a safety net.
+	// This ensures IPAM allocations are cleaned up even if earlier cleanup succeeded or failed.
 	if networkName != "" {
-		_ = r.purgeCNIForContainer(rootContainerID, netnsPath, networkName)
+		_ = r.purgeCNIForContainer(rootContainerID, "", networkName)
+	}
+
+	// If any container-tier failure remains, refuse to remove the cell
+	// cgroup or metadata: leaving the metadata file in place is what makes
+	// the next `kuke daemon reset` find the cell document and retry the
+	// teardown instead of declaring success on a still-broken host.
+	if len(deleteErrors) > 0 {
+		return fmt.Errorf("%w: %w", errdefs.ErrDeleteCell, errors.Join(deleteErrors...))
 	}
 
 	// Delete cell cgroup
@@ -258,4 +211,70 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 	_ = os.RemoveAll(metadataRunPath)
 
 	return nil
+}
+
+// stopAndDeleteContainer purges CNI state, stops the task (best effort), then
+// deletes the containerd container. Stop failures are logged but not surfaced
+// — they don't gate delete. Delete is the gate: a non-NotFound error is
+// returned so the caller can refuse to remove cell metadata while an orphan
+// container still owns the containerd ID we'd re-derive on the next init.
+//
+// force selects SIGKILL escalation on the stop step (root containers and
+// orphans use force=true; workload containers preserve the historical
+// SIGTERM-only default).
+func (r *Exec) stopAndDeleteContainer(namespace, containerID, networkName string, force bool) error {
+	netnsPath, _ := r.getContainerNetnsPath(namespace, containerID)
+	_ = r.purgeCNIForContainer(containerID, netnsPath, networkName)
+
+	if _, stopErr := r.ctrClient.StopContainer(
+		namespace, containerID, ctr.StopContainerOptions{Force: force},
+	); stopErr != nil {
+		if errors.Is(stopErr, errdefs.ErrContainerNotFound) ||
+			errors.Is(stopErr, errdefs.ErrTaskNotFound) {
+			r.logger.DebugContext(
+				r.ctx,
+				"container or task already stopped/deleted, continuing",
+				"container", containerID,
+			)
+		} else {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to stop container, continuing with deletion",
+				"container", containerID,
+				"error", stopErr,
+			)
+		}
+	}
+
+	delErr := r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
+		SnapshotCleanup: true,
+	})
+	if delErr == nil {
+		return nil
+	}
+	if errors.Is(delErr, errdefs.ErrContainerNotFound) {
+		r.logger.DebugContext(r.ctx, "container already deleted", "container", containerID)
+		return nil
+	}
+	return delErr
+}
+
+// findOrphanContainerIDs returns every container in namespace whose ID begins
+// with namePrefix. The prefix `<space>_<stack>_<cell>_` matches both the
+// `<...>_root` root container and every `<...>_<containerName>` workload
+// container produced by naming.BuildContainerdID / BuildRootContainerdID, so
+// a single scan covers both partial-init leftovers and prior-reset survivors.
+func (r *Exec) findOrphanContainerIDs(namespace, namePrefix string) ([]string, error) {
+	containers, err := r.ctrClient.ListContainers(namespace)
+	if err != nil {
+		return nil, err
+	}
+	var orphans []string
+	for _, c := range containers {
+		id := c.ID()
+		if strings.HasPrefix(id, namePrefix) {
+			orphans = append(orphans, id)
+		}
+	}
+	return orphans, nil
 }

--- a/internal/controller/runner/delete_cell_test.go
+++ b/internal/controller/runner/delete_cell_test.go
@@ -1,0 +1,430 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.DeleteCell against an in-package ctr.Client fake
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cgroup2 "github.com/containerd/cgroups/v2/cgroup2"
+	apitypes "github.com/containerd/containerd/api/types"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/metadata"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// deleteCellFakeClient is a near-empty ctr.Client used to drive DeleteCell
+// tests. Methods unused by DeleteCell return zero values rather than panic so
+// adding a new code path through ctr.Client doesn't require revisiting this
+// fake — the controller-level error assertions catch unintended behavior.
+type deleteCellFakeClient struct {
+	deleteContainerFn func(namespace, id string, opts ctr.ContainerDeleteOptions) error
+	stopContainerFn   func(namespace, id string, opts ctr.StopContainerOptions) (*containerd.ExitStatus, error)
+	listContainersFn  func(namespace string, filters ...string) ([]containerd.Container, error)
+}
+
+func (c *deleteCellFakeClient) Connect() error { return nil }
+func (c *deleteCellFakeClient) Close() error   { return nil }
+
+func (c *deleteCellFakeClient) CreateNamespace(string) error { return nil }
+func (c *deleteCellFakeClient) DeleteNamespace(string) error { return nil }
+func (c *deleteCellFakeClient) ListNamespaces() ([]string, error) {
+	return nil, nil
+}
+func (c *deleteCellFakeClient) GetNamespace(string) (string, error)  { return "", nil }
+func (c *deleteCellFakeClient) ExistsNamespace(string) (bool, error) { return false, nil }
+func (c *deleteCellFakeClient) CleanupNamespaceResources(string, string) error {
+	return nil
+}
+
+func (c *deleteCellFakeClient) GetCgroupMountpoint() string               { return "" }
+func (c *deleteCellFakeClient) GetCurrentCgroupPath() (string, error)     { return "", nil }
+func (c *deleteCellFakeClient) CgroupPath(string, string) (string, error) { return "", nil }
+func (c *deleteCellFakeClient) NewCgroup(ctr.CgroupSpec) (*cgroup2.Manager, error) {
+	//nolint:nilnil // cgroup2.Manager has unexported fields; the test path discards the value
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) LoadCgroup(string, string) (*cgroup2.Manager, error) {
+	//nolint:nilnil // same as NewCgroup
+	return nil, nil
+}
+func (c *deleteCellFakeClient) DeleteCgroup(string, string) error { return nil }
+func (c *deleteCellFakeClient) EnsureSubtreeControllers(string, string, []string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) EnableCellSubtreeControllers(string, string, []string) ([]string, error) {
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) EnableCellAllSubtreeControllers(string, string) ([]string, error) {
+	return nil, nil
+}
+func (c *deleteCellFakeClient) RelocateProcessesToLeaf(string, string, string) error { return nil }
+
+func (c *deleteCellFakeClient) CreateContainerFromSpec(
+	string, intmodel.ContainerSpec, []ctr.RegistryCredentials, ...ctr.BuildOption,
+) (containerd.Container, error) {
+	//nolint:nilnil // not invoked by DeleteCell; present only to satisfy ctr.Client
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) CreateContainer(
+	string, ctr.ContainerSpec, []ctr.RegistryCredentials,
+) (containerd.Container, error) {
+	//nolint:nilnil // same as CreateContainerFromSpec
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) GetContainer(string, string) (containerd.Container, error) {
+	return nil, errdefs.ErrContainerNotFound
+}
+
+func (c *deleteCellFakeClient) ListContainers(namespace string, filters ...string) ([]containerd.Container, error) {
+	if c.listContainersFn != nil {
+		return c.listContainersFn(namespace, filters...)
+	}
+
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) ExistsContainer(string, string) (bool, error) {
+	return false, nil
+}
+
+func (c *deleteCellFakeClient) DeleteContainer(namespace, id string, opts ctr.ContainerDeleteOptions) error {
+	if c.deleteContainerFn != nil {
+		return c.deleteContainerFn(namespace, id, opts)
+	}
+	return nil
+}
+
+func (c *deleteCellFakeClient) StartContainer(
+	string, ctr.ContainerSpec, ctr.TaskSpec,
+) (containerd.Task, error) {
+	//nolint:nilnil // not invoked by DeleteCell; present only to satisfy ctr.Client
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) StopContainer(
+	namespace, id string, opts ctr.StopContainerOptions,
+) (*containerd.ExitStatus, error) {
+	if c.stopContainerFn != nil {
+		return c.stopContainerFn(namespace, id, opts)
+	}
+	return nil, errdefs.ErrTaskNotFound
+}
+
+func (c *deleteCellFakeClient) TaskStatus(string, string) (containerd.Status, error) {
+	return containerd.Status{}, nil
+}
+
+func (c *deleteCellFakeClient) TaskMetrics(string, string) (*apitypes.Metric, error) {
+	//nolint:nilnil // not invoked by DeleteCell; present only to satisfy ctr.Client
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) ResolveSbshCachePath(
+	string, string, string, []ctr.RegistryCredentials,
+) (string, error) {
+	return "", nil
+}
+
+func (c *deleteCellFakeClient) ContainerProcessUID(string, containerd.Container) (uint32, error) {
+	return 0, nil
+}
+
+func (c *deleteCellFakeClient) LoadImage(string, io.Reader) ([]string, error) {
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) ListImages(string) ([]ctr.ImageInfo, error) {
+	return nil, nil
+}
+
+func (c *deleteCellFakeClient) GetImage(string, string) (ctr.ImageInfo, error) {
+	return ctr.ImageInfo{}, nil
+}
+func (c *deleteCellFakeClient) DeleteImage(string, string) error { return nil }
+
+var _ ctr.Client = (*deleteCellFakeClient)(nil)
+
+// newDeleteCellTestExec builds a *Exec wired to the fake ctr.Client and an
+// isolated RunPath under t.TempDir(). The realm + cell metadata seeded by
+// the per-test helpers below live under that path so GetCell / GetRealm read
+// off the same tmpdir DeleteCell would later try to remove.
+func newDeleteCellTestExec(t *testing.T, fake *deleteCellFakeClient) *Exec {
+	t.Helper()
+	cniCacheDir := t.TempDir()
+	return &Exec{
+		ctx:       context.Background(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctrClient: fake,
+		opts:      Options{RunPath: t.TempDir()},
+		// cniConf is dereferenced by purgeCNIForContainer's cache-cleanup
+		// path even when networkName is empty; point it at a per-test
+		// tmpdir so the glob no-ops instead of nil-panicking.
+		cniConf: &cni.Conf{CniCacheDir: cniCacheDir},
+	}
+}
+
+func seedDeleteCellRealm(t *testing.T, r *Exec, realmName string) {
+	t.Helper()
+	doc := v1beta1.RealmDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindRealm,
+		Metadata:   v1beta1.RealmMetadata{Name: realmName},
+		Spec:       v1beta1.RealmSpec{Namespace: realmName + ".kukeon.io"},
+	}
+	path := fs.RealmMetadataPath(r.opts.RunPath, realmName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir realm metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write realm metadata: %v", err)
+	}
+}
+
+// seedDeleteCellCell writes a minimal cell metadata doc with one workload
+// container carrying an explicit ContainerdID, so DeleteCell's workload loop
+// has something concrete to call DeleteContainer with.
+func seedDeleteCellCell(t *testing.T, r *Exec, realm, space, stack, cellName string) string {
+	t.Helper()
+	containerdID := space + "_" + stack + "_" + cellName + "_workload"
+	doc := v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: cellName},
+		Spec: v1beta1.CellSpec{
+			ID:      cellName,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:           "workload",
+					ContainerdID: containerdID,
+					RealmID:      realm,
+					SpaceID:      space,
+					StackID:      stack,
+					CellID:       cellName,
+					Image:        "alpine:latest",
+				},
+			},
+		},
+	}
+	path := fs.CellMetadataPath(r.opts.RunPath, realm, space, stack, cellName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir cell metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write cell metadata: %v", err)
+	}
+	return path
+}
+
+// TestDeleteCell_PreservesMetadataOnDeleteContainerFailure is the regression
+// guard for issue #371. A non-NotFound DeleteContainer failure used to be
+// warn-and-continue: the cell metadata file got removed and `ctr containers
+// ls` still showed the orphan, so the next `kuke init` collided on the
+// surviving containerd ID with no way for `kuke daemon reset` to recover.
+// The new contract: DeleteCell aggregates per-container failures, returns
+// them wrapped under ErrDeleteCell, and leaves the metadata file in place so
+// the next reset call finds the cell and retries the teardown.
+func TestDeleteCell_PreservesMetadataOnDeleteContainerFailure(t *testing.T) {
+	realm, space, stack, cellName := "kuke-system", "kukeon", "kukeon", "kukeond"
+	workloadID := space + "_" + stack + "_" + cellName + "_workload"
+
+	fake := &deleteCellFakeClient{
+		deleteContainerFn: func(_, id string, _ ctr.ContainerDeleteOptions) error {
+			if id == workloadID {
+				return errors.New("container already exists")
+			}
+			return nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	metadataPath := seedDeleteCellCell(t, r, realm, space, stack, cellName)
+
+	cell := buildDeleteCellRequest(realm, space, stack, cellName)
+	err := r.DeleteCell(cell)
+	if err == nil {
+		t.Fatal("DeleteCell: want non-nil error when DeleteContainer fails with non-NotFound, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrDeleteCell) {
+		t.Errorf(
+			"DeleteCell error must wrap ErrDeleteCell so the reset CLI flips its `kukeond cell deleted` line to a failure surface; got %v",
+			err,
+		)
+	}
+	if _, statErr := os.Stat(metadataPath); statErr != nil {
+		t.Errorf(
+			"cell metadata must remain on disk when container deletion failed, so the next `kuke daemon reset` can retry; stat err=%v",
+			statErr,
+		)
+	}
+}
+
+// TestDeleteCell_ReconcilesOrphanFromEmptyContainerdID covers the second
+// contributor named in issue #371: a partial init can persist the cell
+// document before the runner has filled in ContainerdID. Pre-fix DeleteCell
+// silently `continue`d past the empty-ID entry and removed metadata, leaving
+// the containerd-side container behind. The name-based orphan scan must now
+// pick it up via the `<space>_<stack>_<cell>_*` prefix and tear it down.
+func TestDeleteCell_ReconcilesOrphanFromEmptyContainerdID(t *testing.T) {
+	realm, space, stack, cellName := "kuke-system", "kukeon", "kukeon", "kukeond"
+	orphanID := space + "_" + stack + "_" + cellName + "_kukeond"
+
+	var deletedIDs []string
+	fake := &deleteCellFakeClient{
+		deleteContainerFn: func(_, id string, _ ctr.ContainerDeleteOptions) error {
+			deletedIDs = append(deletedIDs, id)
+			return nil
+		},
+		listContainersFn: func(string, ...string) ([]containerd.Container, error) {
+			return []containerd.Container{stubContainer{id: orphanID}}, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	// Seed a cell whose only container has an empty ContainerdID — the
+	// repro for the partial-init case the issue calls out. The workload
+	// loop must skip it (no ID), the name-based scan must catch it.
+	doc := v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: cellName},
+		Spec: v1beta1.CellSpec{
+			ID:      cellName,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "kukeond",
+					RealmID: realm,
+					SpaceID: space,
+					StackID: stack,
+					CellID:  cellName,
+					Image:   "alpine:latest",
+				},
+			},
+		},
+	}
+	cellMetadataPath := fs.CellMetadataPath(r.opts.RunPath, realm, space, stack, cellName)
+	if err := os.MkdirAll(filepath.Dir(cellMetadataPath), 0o755); err != nil {
+		t.Fatalf("mkdir cell metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, cellMetadataPath); err != nil {
+		t.Fatalf("write cell metadata: %v", err)
+	}
+
+	if err := r.DeleteCell(buildDeleteCellRequest(realm, space, stack, cellName)); err != nil {
+		t.Fatalf("DeleteCell: unexpected error: %v", err)
+	}
+
+	var foundOrphan bool
+	for _, id := range deletedIDs {
+		if id == orphanID {
+			foundOrphan = true
+			break
+		}
+	}
+	if !foundOrphan {
+		t.Errorf("orphan container %q was not deleted; DeleteContainer was called for %v", orphanID, deletedIDs)
+	}
+	if _, statErr := os.Stat(cellMetadataPath); !os.IsNotExist(statErr) {
+		t.Errorf("cell metadata should be removed on full success; stat err=%v", statErr)
+	}
+}
+
+// TestFindOrphanContainerIDs locks the prefix-filter behavior the orphan
+// scan relies on. The prefix is `<space>_<stack>_<cell>_` and must match
+// both `_root` and `_<workload>` IDs while excluding unrelated containers
+// that happen to share part of the namespace.
+func TestFindOrphanContainerIDs(t *testing.T) {
+	fake := &deleteCellFakeClient{
+		listContainersFn: func(string, ...string) ([]containerd.Container, error) {
+			return []containerd.Container{
+				stubContainer{id: "kukeon_kukeon_kukeond_root"},
+				stubContainer{id: "kukeon_kukeon_kukeond_kukeond"},
+				stubContainer{id: "kukeon_kukeon_other_root"},
+				stubContainer{id: "unrelated_id"},
+			}, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+
+	got, err := r.findOrphanContainerIDs("kuke-system.kukeon.io", "kukeon_kukeon_kukeond_")
+	if err != nil {
+		t.Fatalf("findOrphanContainerIDs: unexpected error: %v", err)
+	}
+	want := map[string]bool{
+		"kukeon_kukeon_kukeond_root":    true,
+		"kukeon_kukeon_kukeond_kukeond": true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("findOrphanContainerIDs returned %d IDs, want %d; got=%v", len(got), len(want), got)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("findOrphanContainerIDs returned unexpected ID %q (not under the cell prefix)", id)
+		}
+	}
+}
+
+// stubContainer is a minimal containerd.Container that only carries an ID.
+// The orphan scan reads .ID() and nothing else, so every other method is
+// satisfied by the embedded interface (calls panic at runtime, which is
+// what we want if the scan grows new dependencies without test coverage).
+type stubContainer struct {
+	containerd.Container
+
+	id string
+}
+
+func (c stubContainer) ID() string { return c.id }
+
+// buildDeleteCellRequest mirrors the intmodel.Cell shape the controller
+// hands to runner.DeleteCell — only the lookup keys are populated.
+func buildDeleteCellRequest(realm, space, stack, cellName string) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			ID:        cellName,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- DeleteCell now treats non-NotFound DeleteContainer failures as fatal: per-container errors are aggregated, wrapped in `errdefs.ErrDeleteCell`, and returned instead of swallowed — so the metadata file stays on disk and the next `kuke daemon reset` finds the cell and retries the teardown.
- Adds a `<space>_<stack>_<cell>_*` name-based orphan scan in the realm's containerd namespace, covering the partial-init case where the cell spec was persisted with an empty `ContainerdID` (the workload loop used to silently `continue` past that spec, leaving the container in containerd while the metadata was removed).
- Restructured the per-container stop+delete into a `stopAndDeleteContainer` helper so the workload loop, root container, and orphan scan share the same gate. Cgroup and metadata removal now run only after every container call returns NotFound or success — partial container-tier failures no longer half-tear-down the cell.

## Test plan
- [x] `go test ./internal/controller/runner/ ./internal/controller/ ./cmd/kuke/daemon/reset/` (passes; new `TestDeleteCell_PreservesMetadataOnDeleteContainerFailure`, `TestDeleteCell_ReconcilesOrphanFromEmptyContainerdID`, `TestFindOrphanContainerIDs`)
- [x] `make test` (full suite, all packages green)
- [x] `make dev-init` smoke (daemon-parity tail matches expected output for both `kuke get realms` and `--no-daemon`)
- [x] Live orphan repro: ran `sudo ./kuke init`, manually created an extra container `kukeon_kukeon_kukeond_orphan` in `kuke-system.kukeon.io` via `ctr containers create`, ran `sudo ./kuke daemon reset`, confirmed `ctr containers ls` is empty post-reset — the orphan was reconciled by the new name-based scan exactly as #371's "belt-and-suspenders" suggested fix described.

Closes #371