### PR TITLE
docs: document docker + standalone containerd prerequisites for make dev-init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,15 @@ The `kukeond` daemon runs inside the **`kuke-system`** realm — specifically as
 
 When a change touches the build path, the daemon, or anything under `/opt/kukeon`, run this end-to-end before opening a PR.
 
+### Prerequisites
+
+`make dev-init` requires two daemons to be running on the host:
+
+- **Docker daemon** — used to build the local `kukeon-local:dev` image. Start with `service docker start` (or `systemctl start docker`).
+- **Standalone containerd** at `/run/containerd/containerd.sock` — used by `kuke image load` and `kuke init`. This is _not_ the docker-private containerd at `/var/run/docker/containerd/containerd.toml`; `pgrep containerd` may show that one even when the system socket is missing. If `ls /run/containerd/containerd.sock` returns no such file, start it with `service containerd start` (or `systemctl start containerd`). On hosts with no init script and no systemd (e.g., the agent dev container), launch the binary directly: `containerd > /tmp/containerd.log 2>&1 &`.
+
+A failure in either daemon surfaces as a confusing error several phases into the script — `dial unix /var/run/docker.sock: connect: no such file or directory` for docker, or `failed to connect to containerd: ... dial unix:///run/containerd/containerd.sock: timeout` for containerd. Bring both up before invoking `make dev-init` to skip the rabbit hole.
+
 ### One-shot: `make dev-init`
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a `### Prerequisites` subsection at the top of "Local smoke test: rebuild and re-run `kuke init`" in `/CLAUDE.md`, naming the docker daemon and the standalone containerd at `/run/containerd/containerd.sock` as required, with start commands (service/systemctl plus a bare-binary fallback) and the actual error strings each missing daemon produces several phases into `make dev-init`.
- Calls out the docker-private containerd at `/var/run/docker/containerd/containerd.toml` so the next operator doesn't get fooled by `pgrep containerd` showing a process that doesn't satisfy the system-socket dependency.
- Pure CLAUDE.md edit — no code, no other section of CLAUDE.md changed; smoke-test body, parity check, and manual phases all stay as-is. Wording follows the issue verbatim modulo prettier's `*not*` → `_not_` italic-emphasis normalization.

## Test plan
- [x] `npx prettier@4.0.0-alpha.8 --check CLAUDE.md` — passes.
- [x] `make test` — full Go suite green (no code touched, but the project's CI test target still ran clean).
- [ ] `make dev-init` smoke — not run; the change is markdown-only and does not touch the build path, the daemon, or anything under `/opt/kukeon`, so the daemon-parity regression guard does not apply per CLAUDE.md.

Closes #372