### PR TITLE
fix: switch bash autocomplete to cobra V2 to route every tab through __complete

### DIFF
--- a/cmd/kuke/autocomplete/autocomplete.go
+++ b/cmd/kuke/autocomplete/autocomplete.go
@@ -50,7 +50,10 @@ func newBashCmd() *cobra.Command {
 			if rootCmd == nil {
 				return errors.New("failed to get root command")
 			}
-			return rootCmd.GenBashCompletion(os.Stdout)
+			// V2 routes every tab through `kuke __complete` and omits the
+			// inlined flag arrays V1 ships; matches zsh/fish behavior and
+			// avoids stale-script shadowing across re-installs (#375).
+			return rootCmd.GenBashCompletionV2(os.Stdout, true)
 		},
 	}
 }

--- a/cmd/kuke/autocomplete/autocomplete_test.go
+++ b/cmd/kuke/autocomplete/autocomplete_test.go
@@ -82,59 +82,39 @@ func TestAutocompleteBash(t *testing.T) {
 	autocompleteCmd := autocomplete.NewAutocompleteCmd()
 	rootCmd.AddCommand(autocompleteCmd)
 
-	// Get bash subcommand
-	bashCmd, _, err := rootCmd.Find([]string{"autocomplete", "bash"})
-	if err != nil {
-		t.Fatalf("Failed to find bash subcommand: %v", err)
-	}
-
-	// Capture stdout
-	var buf bytes.Buffer
+	// Capture stdout — the bash RunE writes the generated script there.
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	// Execute command in goroutine
 	errChan := make(chan error, 1)
 	go func() {
-		bashCmd.SetOutput(&buf)
-		bashCmd.SetContext(ctx)
-		bashCmd.SetArgs([]string{})
-		err := bashCmd.Execute()
+		rootCmd.SetArgs([]string{"autocomplete", "bash"})
+		errChan <- rootCmd.Execute()
 		w.Close()
-		errChan <- err
 	}()
 
-	// Read output
 	var output bytes.Buffer
-	_, readErr := output.ReadFrom(r)
-	if readErr != nil {
+	if _, readErr := output.ReadFrom(r); readErr != nil {
 		t.Fatalf("Failed to read from pipe: %v", readErr)
 	}
 	r.Close()
-
-	// Restore stdout
 	os.Stdout = oldStdout
 
-	// Wait for command to complete
-	execErr := <-errChan
-	if execErr != nil {
+	if execErr := <-errChan; execErr != nil {
 		t.Fatalf("Execute() error = %v, want nil", execErr)
 	}
 
-	// Verify output contains bash completion script markers
+	// Verify output is the cobra V2 bash completion: it routes every tab
+	// through __complete via __kuke_get_completion_results, instead of the
+	// V1 __kuke_handle_go_custom_completion dispatcher that ships inlined
+	// flag arrays. Guards against a silent revert to V1 (#375).
 	outputStr := output.String()
-	if !strings.Contains(outputStr, "complete") && !strings.Contains(outputStr, "_kuke") {
-		// Bash completion scripts typically contain these markers
-		// But we'll just verify we got some output
-		if len(outputStr) == 0 {
-			t.Error("Expected non-empty output from bash completion generation")
-		}
+	if !strings.Contains(outputStr, "__kuke_get_completion_results") {
+		t.Errorf("bash completion is not cobra V2 (missing __kuke_get_completion_results marker)")
 	}
-
-	// Verify output is not empty
-	if len(outputStr) == 0 {
-		t.Error("Bash completion script output is empty")
+	if strings.Contains(outputStr, "__kuke_handle_go_custom_completion") {
+		t.Errorf("bash completion still contains V1 dispatcher __kuke_handle_go_custom_completion")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `kuke autocomplete bash` now emits `GenBashCompletionV2` instead of V1. V2 ships a tiny dispatcher that routes every tab through `kuke __complete`; V1 ships ~3500 lines of inlined per-command flag arrays plus a `__kuke_handle_go_custom_completion` shim. The inlined arrays are the shadowing surface — a stale `/etc/bash_completion.d/kuke` left from a prior install (the install path the issue's repro uses) keeps loading old flag tables even after `sudo tee` overwrites the file, because bash-completion lazy-loads the script per shell. V2 has no inlined arrays to go stale, and matches the dispatch model zsh/fish already use.
- Direct dynamic check (`kuke __complete run -p ""`) was already returning live results in both V1 and V2 — so the daemon-side completer at `cmd/config/autocomplete.go:466-487` is not the bug. The bug is the bash-side dispatcher's shape, not the Go side.
- Generated-script size drops from 3564 to 426 lines.

## Test plan

- [x] `go test ./cmd/kuke/autocomplete/...` — passes; new V2-marker assertion replaces the prior `len > 0` check, which the old test was satisfying with root-help text because `bashCmd.Execute()` was not actually routing through the bash subcommand.
- [x] `make test` — full unit suite passes.
- [x] AC #1 (add yaml → appears without re-source): sourced the generated V2 script in a fresh bash, simulated tab on `kuke run -p <TAB>`, added a second yaml under `$KUKE_PROFILES_DIR`, repeated the same tab without re-sourcing → both profiles listed.
- [x] AC #2 (remove yaml → disappears without re-source): removed the first yaml, repeated tab → only the remaining profile listed.
- [x] AC #3 (`$KUKE_PROFILES_DIR` override honored per-tab): switched the env var to a different dir with a third yaml, repeated tab → only the third profile listed.
- [x] Same checks against `--profile=` and `--profile <space>` long forms — both update live, no asymmetry with `-p`.
- [x] `pre-commit run --files cmd/kuke/autocomplete/autocomplete.go cmd/kuke/autocomplete/autocomplete_test.go` — passes.
- [ ] `make dev-init` smoke — not run; this PR touches only `cmd/kuke/autocomplete/`, which is not on the daemon read path or the `/opt/kukeon` write path the daemon-parity guard catches.

## Notes for reviewer

- I narrowed the `TestAutocompleteBash` body alongside the fix because the old test asserted only `len(output) > 0` and was passing on the root command's help text (`bashCmd.Execute()` with an empty `SetArgs` falls back to help) — it had been silently dead for a while. The new test asserts the V2 dispatcher marker `__kuke_get_completion_results` is present and the V1 dispatcher `__kuke_handle_go_custom_completion` is absent, so a future revert is caught. `TestAutocompleteZsh` and `TestAutocompleteFish` have the same dead-test pattern but I left them alone — out of scope for this fix.
- `GenBashCompletionV2(os.Stdout, true)` — `true` keeps descriptions on tab (parity with zsh/fish).

Closes #375