### PR TITLE
fix: kuke log defaults to print-and-exit; add -f/--follow, drop --no-follow

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -405,7 +405,7 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_LOG_CONTAINER = DefineKV("KUKE_LOG_CONTAINER", "kuke/log/container")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_LOG_NO_FOLLOW = DefineKV("KUKE_LOG_NO_FOLLOW", "kuke/log/no-follow", "false")
+	KUKE_LOG_FOLLOW = DefineKV("KUKE_LOG_FOLLOW", "kuke/log/follow", "false")
 
 	// Stop command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/log/log.go
+++ b/cmd/kuke/log/log.go
@@ -16,17 +16,20 @@
 
 // Package log implements the `kuke log` subcommand. It mirrors `kuke
 // attach`'s flag/arg shape but instead of opening an interactive sbsh
-// session it tails the per-container output stream. Bytes never traverse
-// the daemon RPC: the daemon resolves the host path of the relevant
-// stream and this subcommand opens that path directly.
+// session it prints the per-container output stream. By default it
+// dumps the current capture/log file contents and exits; pass
+// `-f`/`--follow` to tail until SIGINT, matching `kubectl logs` /
+// `docker logs` conventions. Bytes never traverse the daemon RPC:
+// the daemon resolves the host path of the relevant stream and this
+// subcommand opens that path directly.
 //
 // Two paths exist depending on the target container's IO model:
 //
 //   - Attachable containers route output through sbsh, which writes a
-//     tty byte stream to HostCapturePath. `kuke log` tails that file.
+//     tty byte stream to HostCapturePath. `kuke log` reads that file.
 //   - Non-Attachable containers (including kukeond) have the containerd
 //     runtime shim write stdout/stderr to HostLogPath via cio.LogFile.
-//     `kuke log` tails that file. This is gap #4 in
+//     `kuke log` reads that file. This is gap #4 in
 //     docs/gaps-2026-04-19.md and was implemented per issue #203.
 package log
 
@@ -59,9 +62,10 @@ type MockControllerKey struct{}
 type MockTailKey struct{}
 
 // tailFn opens path and copies its contents to out, then either returns
-// when ctx is cancelled (default follow mode) or returns immediately
-// after the first dump (noFollow). Real implementation: tailFile.
-type tailFn func(ctx context.Context, path string, out io.Writer, noFollow bool) error
+// immediately after the first dump (follow=false, the default) or keeps
+// streaming new bytes until ctx is cancelled (follow=true). Real
+// implementation: tailFile.
+type tailFn func(ctx context.Context, path string, out io.Writer, follow bool) error
 
 // pollInterval is how long the follow loop waits between EOF reads.
 // Polling is intentional: avoiding fsnotify keeps the dependency surface
@@ -73,7 +77,7 @@ func NewLogCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "log",
 		Aliases:       []string{"logs"},
-		Short:         "Tail a container's stdout/stderr stream",
+		Short:         "Print a container's stdout/stderr stream (use -f to follow)",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -91,8 +95,8 @@ func NewLogCmd() *cobra.Command {
 	cmd.Flags().String("container", "",
 		"Container within the cell to read (omit to auto-pick the only non-root container)")
 	_ = viper.BindPFlag(config.KUKE_LOG_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
-	cmd.Flags().Bool("no-follow", false, "Dump current capture file contents and exit (do not follow)")
-	_ = viper.BindPFlag(config.KUKE_LOG_NO_FOLLOW.ViperKey, cmd.Flags().Lookup("no-follow"))
+	cmd.Flags().BoolP("follow", "f", false, "Tail the file until SIGINT instead of printing current contents and exiting")
+	_ = viper.BindPFlag(config.KUKE_LOG_FOLLOW.ViperKey, cmd.Flags().Lookup("follow"))
 
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
@@ -109,7 +113,7 @@ func runLog(cmd *cobra.Command, _ []string) error {
 	stack := strings.TrimSpace(viper.GetString(config.KUKE_LOG_STACK.ViperKey))
 	cell := strings.TrimSpace(viper.GetString(config.KUKE_LOG_CELL.ViperKey))
 	container := strings.TrimSpace(viper.GetString(config.KUKE_LOG_CONTAINER.ViperKey))
-	noFollow := viper.GetBool(config.KUKE_LOG_NO_FOLLOW.ViperKey)
+	follow := viper.GetBool(config.KUKE_LOG_FOLLOW.ViperKey)
 
 	if realm == "" {
 		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
@@ -154,7 +158,7 @@ func runLog(cmd *cobra.Command, _ []string) error {
 	}
 
 	tail := resolveTail(cmd)
-	if tailErr := tail(cmd.Context(), streamPath, cmd.OutOrStdout(), noFollow); tailErr != nil {
+	if tailErr := tail(cmd.Context(), streamPath, cmd.OutOrStdout(), follow); tailErr != nil {
 		if errors.Is(tailErr, os.ErrNotExist) {
 			return fmt.Errorf(
 				"cell %q container %q has no log file at %s (the runtime shim has not opened it yet — try again after the container produces output)",
@@ -168,12 +172,13 @@ func runLog(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// tailFile opens path and streams its bytes to out. With noFollow it
-// dumps the current contents and returns. Otherwise it dumps and then
-// polls for new bytes until ctx is cancelled (SIGINT/SIGTERM). On
-// cancellation it returns nil so `kuke log` exits 0 — the user
-// pressing Ctrl+C is a benign session end, not a failure.
-func tailFile(ctx context.Context, path string, out io.Writer, noFollow bool) error {
+// tailFile opens path and streams its bytes to out. With follow=false
+// (the default for `kuke log`) it dumps the current contents and
+// returns. With follow=true it dumps and then polls for new bytes until
+// ctx is cancelled (SIGINT/SIGTERM). On cancellation it returns nil so
+// `kuke log -f` exits 0 — the user pressing Ctrl+C is a benign session
+// end, not a failure.
+func tailFile(ctx context.Context, path string, out io.Writer, follow bool) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -183,7 +188,7 @@ func tailFile(ctx context.Context, path string, out io.Writer, noFollow bool) er
 	if _, copyErr := io.Copy(out, f); copyErr != nil {
 		return copyErr
 	}
-	if noFollow {
+	if !follow {
 		return nil
 	}
 

--- a/cmd/kuke/log/log_test.go
+++ b/cmd/kuke/log/log_test.go
@@ -65,24 +65,25 @@ func (f *fakeClient) LogContainer(
 	return f.logContainerFn(doc)
 }
 
-// tailCapture records the (path, noFollow) it was called with and copies
+// tailCapture records the (path, follow) it was called with and copies
 // configured bytes to the writer so callers can assert on stdout.
 type tailCapture struct {
-	calls    int
-	path     string
-	noFollow bool
-	payload  []byte
-	err      error
+	calls   int
+	path    string
+	follow  bool
+	payload []byte
+	err     error
 	// blockUntilCancel makes the tail block on ctx.Done() before
 	// returning, modeling the real follow loop. When false the call
-	// returns immediately after writing payload (modeling --no-follow).
+	// returns immediately after writing payload (modeling the default
+	// dump-and-exit mode).
 	blockUntilCancel bool
 }
 
-func (t *tailCapture) fn(ctx context.Context, path string, out io.Writer, noFollow bool) error {
+func (t *tailCapture) fn(ctx context.Context, path string, out io.Writer, follow bool) error {
 	t.calls++
 	t.path = path
-	t.noFollow = noFollow
+	t.follow = follow
 	if t.payload != nil {
 		if _, err := out.Write(t.payload); err != nil {
 			return err
@@ -117,7 +118,7 @@ func newCmdWithCtx(t *testing.T, fc *fakeClient, tail *tailCapture) (*cobra.Comm
 	return cmd, out
 }
 
-func TestLog_NoFollow_DumpsCaptureAndExits(t *testing.T) {
+func TestLog_DefaultDumpsCaptureAndExits(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
 	fc := &fakeClient{
@@ -132,7 +133,7 @@ func TestLog_NoFollow_DumpsCaptureAndExits(t *testing.T) {
 	cmd, out := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work", "--no-follow",
+		"--container", "work",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -141,8 +142,8 @@ func TestLog_NoFollow_DumpsCaptureAndExits(t *testing.T) {
 	if tail.calls != 1 {
 		t.Fatalf("tail called %d times, want 1", tail.calls)
 	}
-	if !tail.noFollow {
-		t.Errorf("noFollow flag = false, want true")
+	if tail.follow {
+		t.Errorf("follow flag = true, want false (default dump-and-exit)")
 	}
 	if tail.path != testHostCapture {
 		t.Errorf("tail path = %q, want %q", tail.path, testHostCapture)
@@ -168,7 +169,7 @@ func TestLog_Follow_CancelsCleanlyOnCtxDone(t *testing.T) {
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work",
+		"--container", "work", "--follow",
 	})
 
 	var wg sync.WaitGroup
@@ -192,8 +193,8 @@ func TestLog_Follow_CancelsCleanlyOnCtxDone(t *testing.T) {
 	if tail.calls != 1 {
 		t.Fatalf("tail called %d times, want 1", tail.calls)
 	}
-	if tail.noFollow {
-		t.Errorf("noFollow flag = true, want false (follow mode)")
+	if !tail.follow {
+		t.Errorf("follow flag = false, want true")
 	}
 	if got := out.String(); got != "seed" {
 		t.Errorf("stdout = %q, want %q", got, "seed")
@@ -212,7 +213,7 @@ func TestLog_MissingCaptureFile_WrapsWithCellAndContainer(t *testing.T) {
 	cmd, _ := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work", "--no-follow",
+		"--container", "work",
 	})
 
 	err := cmd.Execute()
@@ -299,7 +300,7 @@ func TestLog_NonAttachable_TailsHostLogPath(t *testing.T) {
 	cmd, out := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "side", "--no-follow",
+		"--container", "side",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -372,7 +373,6 @@ func TestLog_AutoPicksLoneNonAttachable(t *testing.T) {
 	cmd, _ := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
 		"--realm", "kuke-system", "--space", "kukeon", "--stack", "kukeon", "--cell", "kukeond",
-		"--no-follow",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -431,10 +431,10 @@ func TestLog_MissingFlags(t *testing.T) {
 	}
 }
 
-// TestTailFile_NoFollow_DumpsAndReturns exercises the real tailFile
-// (not the mock) to lock in the dump-and-exit semantics required by the
-// --no-follow path.
-func TestTailFile_NoFollow_DumpsAndReturns(t *testing.T) {
+// TestTailFile_DefaultDumpsAndReturns exercises the real tailFile (not
+// the mock) to lock in the dump-and-exit semantics that the default
+// (no `-f`) `kuke log` invocation relies on.
+func TestTailFile_DefaultDumpsAndReturns(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "capture")
 	want := "hello sbsh\n"
@@ -457,7 +457,7 @@ func TestTailFile_NoFollow_DumpsAndReturns(t *testing.T) {
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{
 		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work", "--no-follow",
+		"--container", "work",
 	})
 	t.Cleanup(viper.Reset)
 


### PR DESCRIPTION
## Summary
- `kuke log <cell>` was following by default with a `--no-follow` opt-out — flipped to the `kubectl logs` / `docker logs` convention so default = print-and-exit and `-f`/`--follow` = tail until SIGINT.
- `--no-follow` removed cleanly (renamed `KUKE_LOG_NO_FOLLOW` → `KUKE_LOG_FOLLOW`). Pre-v1, no deprecation window — the flag was added only on the prior PR and has no in-the-wild operators to break.
- Updated package docstring, `Short` help text, `tailFile` doc, and unit tests to reflect the new default semantics.

## Test plan
- [x] `make test` — full unit test suite passes (the package's own tests cover the default-print-and-exit path via `TestLog_DefaultDumpsCaptureAndExits` / `TestTailFile_DefaultDumpsAndReturns` and the `-f` follow path via `TestLog_Follow_CancelsCleanlyOnCtxDone`).
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean on touched files.
- [ ] `pre-commit run --files …` — neither `pre-commit` nor `golangci-lint` is installed on the dev host (`which pre-commit` and `which golangci-lint` both return nothing). Gofmt/vet/go-build/go-mod-tidy ran clean as a substitute; CI will exercise the full hook set.
- [ ] `make dev-init` smoke — not run; this change touches only the `kuke log` CLI surface and does not affect the daemon bootstrap or `/opt/kukeon` layout the dev-init regression guard covers.

Closes #376