### PR TITLE
build: add install-dev Makefile target to symlink dev binaries onto PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ KUKEON_DOCKER_IMAGE := $(KUKEON_REGISTRY)/$(KUKEON_IMAGE_NAME):$(KUKEON_IMAGE_TA
 # --kukeond-image is not passed. Release pipeline overrides via env.
 KUKEON_IMAGE_REPO ?= ghcr.io/eminwux/kukeon
 
+# Directory `install-dev` symlinks the dev binaries into. Override for
+# rootless / non-standard PATH layouts (e.g. INSTALL_PREFIX=$HOME/.local/bin).
+INSTALL_PREFIX ?= /usr/local/bin
+
 LDFLAGS := -s -w \
 	-X $(MODULE)/cmd/config.Version=$(KUKEON_VERSION) \
 	-X $(MODULE)/cmd/config.KukeondImageRepo=$(KUKEON_IMAGE_REPO)
@@ -95,3 +99,18 @@ tag:
 .PHONY: dev-init
 dev-init:
 	./scripts/dev-init.sh
+
+# install-dev symlinks the in-tree dev binaries into INSTALL_PREFIX so
+# contributors can invoke `kuke` / `kukeond` from anywhere on the host after
+# `make dev-init`. Symlinks (not copies) so subsequent `make kuke` rebuilds
+# are picked up automatically — a stale hard copy is exactly the footgun a
+# dev workflow can't afford. argv[0] dispatch resolves `kukeond` to the
+# daemon entrypoint because the basename of the exec path is `kukeond`.
+.PHONY: install-dev uninstall-dev
+install-dev: kuke
+	ln -sf kuke kukeond
+	sudo ln -sf $(CURDIR)/kuke $(INSTALL_PREFIX)/kuke
+	sudo ln -sf $(CURDIR)/kuke $(INSTALL_PREFIX)/kukeond
+
+uninstall-dev:
+	sudo rm -f $(INSTALL_PREFIX)/kuke $(INSTALL_PREFIX)/kukeond

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -32,6 +32,9 @@ step "Build kuke (and the kukeond symlink)"
 make kuke
 ln -sf kuke kukeond
 
+step "Install dev symlinks on PATH (make install-dev)"
+make install-dev
+
 # Pre-flight: catch missing host cgroup-v2 controller delegation BEFORE the
 # multi-minute docker build runs (issue #324). On a fully-delegated host
 # this is silent; on a misconfigured host (e.g. cgroup namespace whose


### PR DESCRIPTION
## Summary
- After `make dev-init` the freshly built `./kuke` and `./kukeond` binaries sit only in the source dir, so every contributor command has to be `./kuke …` from the repo root or absolute-pathed. The new `install-dev` target symlinks `kuke` and `kukeond` into `$(INSTALL_PREFIX)` (default `/usr/local/bin`) so the natural `sudo kuke get realms` works from anywhere.
- Symlinks (not hard copies) so the next `make kuke` is picked up automatically — a stale copy would silently run the previous binary, exactly the footgun a dev workflow can't afford. `kukeond` is a parallel symlink to the same source binary; argv[0] basename dispatch resolves it to the daemon entrypoint.
- `make dev-init` auto-invokes `install-dev` so the existing one-shot flow lands the symlinks too. `ln -sf` makes the install idempotent across re-runs; `make uninstall-dev` removes both symlinks.
- The CLAUDE.md note the issue suggested (host symlinks update the *CLI* path, but the *daemon* still ships from the `kuke-system/.../kukeond` cell so daemon updates still require `make dev-init`'s image rebuild + reload) belongs in `<project>/CLAUDE.md`, which is filed as a separate `docs:` follow-up per the role split.

## Test plan
- [x] `go build ./...`
- [x] `make test` — all packages pass
- [x] `make dev-init` end-to-end on a fresh host: daemon-parity check shows both `default` and `kuke-system` `Ready`
- [x] After `make dev-init`, `which kuke` → `/usr/local/bin/kuke`, `which kukeond` → `/usr/local/bin/kukeond`, both symlinks pointing at `/root/kukeon/kuke`
- [x] `sudo kuke --help` shows the client CLI; `sudo kukeond --help` shows the daemon CLI (argv[0] dispatch intact)
- [x] `make install-dev` re-run after a successful install is idempotent (no errors, no duplicate symlinks); `make uninstall-dev` removes both; `make install-dev` recreates them
- [ ] `pre-commit run --files Makefile scripts/dev-init.sh` — `pre-commit` binary not installed on this dev host (only `Makefile` + `scripts/dev-init.sh` changed; manually verified no trailing whitespace and trailing newlines present)

Closes #294