### PR TITLE
build: add install-dev to symlink dev binaries onto PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ BINS = kuke kukeond
 OS = linux
 ARCHS = amd64 arm64
 
+# Where install-dev / uninstall-dev manage the host PATH symlinks. Contributors
+# can override (e.g. INSTALL_PREFIX=$HOME/.local/bin) when /usr/local/bin is
+# read-only or sudo-gated.
+INSTALL_PREFIX ?= /usr/local/bin
+
 
 all: clean kill $(BINS)
 
@@ -95,3 +100,17 @@ tag:
 .PHONY: dev-init
 dev-init:
 	./scripts/dev-init.sh
+
+# Symlink the freshly built dev binaries onto a PATH directory so contributors
+# can invoke `kuke` and `kukeond` directly after `make dev-init`. Symlink (not
+# copy) so the next `make kuke` is picked up automatically — a hard copy would
+# silently leave the previous build on PATH until the contributor remembers to
+# re-install. argv[0] dispatch follows the basename of the path used to exec,
+# so two parallel symlinks both pointing at the source binary work cleanly.
+.PHONY: install-dev uninstall-dev
+install-dev: kuke
+	sudo ln -sf $(CURDIR)/kuke $(INSTALL_PREFIX)/kuke
+	sudo ln -sf $(CURDIR)/kuke $(INSTALL_PREFIX)/kukeond
+
+uninstall-dev:
+	sudo rm -f $(INSTALL_PREFIX)/kuke $(INSTALL_PREFIX)/kukeond

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -71,6 +71,11 @@ sudo ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system --no-dae
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
 sudo ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}"
 
+step "Install kuke and kukeond on PATH (symlinks into INSTALL_PREFIX)"
+# `ln -sf` is idempotent — re-runs replace an existing symlink with an
+# identical one, so repeated `make dev-init` invocations stay clean.
+make install-dev
+
 step "Daemon parity check (both must show identical output)"
 sudo ./kuke get realms
 sudo ./kuke get realms --no-daemon


### PR DESCRIPTION
## Summary
- After `make dev-init`, contributors had to run `./kuke` from the source dir (or absolute path) — neither `kuke` nor `kukeond` was reachable through `PATH`, breaking the natural "I just ran an init script, now I can use the tool" expectation and diverging from how every doc and CLAUDE.md example reads.
- Adds opt-in `install-dev` / `uninstall-dev` Makefile targets that symlink `./kuke` and `./kukeond` into `INSTALL_PREFIX` (default `/usr/local/bin`), and wires `make dev-init` to invoke `install-dev` so the bootstrap leaves the host with both binaries reachable on `PATH`.
- Symlink (not copy) so the next `make kuke` is picked up automatically — a hard copy would silently leave the previous build on `PATH` until the contributor remembered to re-install. argv[0] dispatch follows the basename of the path used to exec, so two parallel symlinks both pointing at the source binary work cleanly.
- `INSTALL_PREFIX` is an overridable Make var so contributors can target a non-sudo path (e.g. `INSTALL_PREFIX=$HOME/.local/bin make install-dev`).
- `dev-init.sh` calls `make install-dev` unconditionally — `ln -sf` is itself idempotent, so re-runs replace the symlink with an identical one and stay clean.
- Project `CLAUDE.md` note about the host-CLI vs daemon-image distinction is deferred to follow-up issue #384 (per the dev role rule that bars `CLAUDE.md` edits in code-fix PRs).

## Test plan
- [x] `make test` (full project test target) — passed.
- [x] `make dev-init` end-to-end on this host — daemon-parity table renders the expected two `Ready` rows for both `kuke get realms` and `kuke get realms --no-daemon`.
- [x] `which kuke` → `/usr/local/bin/kuke`, `which kukeond` → `/usr/local/bin/kukeond` after `make dev-init`; both resolve via symlink to `/root/kukeon/kuke`.
- [x] argv[0] dispatch: `kuke --help` prints the client CLI ("Kukeon is a tool for managing Kukeon entities"); `kukeond --help` prints the daemon CLI ("Kukeon daemon: hosts the kukeonv1 API over a unix socket").
- [x] Idempotency: re-running `make install-dev` on a host that already has the symlinks produces no errors and no duplicate symlinks (target/source unchanged).
- [x] `make uninstall-dev` removes both symlinks; a subsequent `make install-dev` recreates them.
- [ ] `pre-commit run` — pre-commit binary is not installed on this dev host (`command -v pre-commit` returns nothing, `pip` also unavailable). Diff is two text files (Makefile, shell script) with no formatter-eligible content; deferred to CI.

Closes #294