### PR TITLE
fix: pre-flight containerd reachability in dev-init.sh

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -46,6 +46,17 @@ make install-dev
 step "Pre-flight: host cgroup controller delegation"
 sudo ./kuke doctor cgroups --probe
 
+# Pre-flight: catch a missing standalone containerd BEFORE the multi-minute
+# docker build, and BEFORE the first-pass `kuke init` below whose tolerate-
+# non-zero (image-not-staged) would otherwise swallow the connection-timeout
+# error and surface a misleading downstream "realm not found: kuke-system"
+# at image load (issue #344).
+step "Pre-flight: containerd reachability"
+if [ ! -S /run/containerd/containerd.sock ]; then
+    printf 'containerd is not running at /run/containerd/containerd.sock — start it before re-running\n' >&2
+    exit 1
+fi
+
 step "Build local kukeond image (${LOCAL_TAG})"
 docker build --build-arg VERSION=v0.0.0-dev -t "${LOCAL_TAG}" .
 


### PR DESCRIPTION
## Summary
- The first-pass `kuke init` in `scripts/dev-init.sh` tolerates a non-zero exit because the local kukeond image is not yet staged in containerd. That tolerate also swallows a containerd-unreachable error, so a host with `/run/containerd/containerd.sock` missing fails minutes later at `kuke image load` with the misleading `realm not found: kuke-system`.
- Adds a pre-flight reachability probe alongside the existing cgroup pre-flight. Fails fast with the named-socket message before the multi-minute `docker build` runs; silent on a healthy host.

## Test plan
- [x] `bash -n scripts/dev-init.sh`
- [x] Manual exercise of both branches: silent when `/run/containerd/containerd.sock` is a socket, exits 1 with the named-socket message when absent
- [x] `make test`
- [x] `go build ./...`, `go vet ./...`
- [x] `make dev-init` runs to the daemon parity-check tail (both `kuke get realms` and `--no-daemon` produce identical output) on a host with containerd up

Closes #344