### PR TITLE
test: rewrite zsh/fish autocomplete tests to exercise their RunE

### DIFF
--- a/cmd/kuke/autocomplete/autocomplete_test.go
+++ b/cmd/kuke/autocomplete/autocomplete_test.go
@@ -134,59 +134,40 @@ func TestAutocompleteZsh(t *testing.T) {
 	autocompleteCmd := autocomplete.NewAutocompleteCmd()
 	rootCmd.AddCommand(autocompleteCmd)
 
-	// Get zsh subcommand
-	zshCmd, _, err := rootCmd.Find([]string{"autocomplete", "zsh"})
-	if err != nil {
-		t.Fatalf("Failed to find zsh subcommand: %v", err)
-	}
-
-	// Capture stdout
-	var buf bytes.Buffer
+	// Capture stdout — the zsh RunE writes the generated script there.
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	// Execute command in goroutine
 	errChan := make(chan error, 1)
 	go func() {
-		zshCmd.SetOutput(&buf)
-		zshCmd.SetContext(ctx)
-		zshCmd.SetArgs([]string{})
-		err := zshCmd.Execute()
+		rootCmd.SetArgs([]string{"autocomplete", "zsh"})
+		errChan <- rootCmd.Execute()
 		w.Close()
-		errChan <- err
 	}()
 
-	// Read output
 	var output bytes.Buffer
-	_, readErr := output.ReadFrom(r)
-	if readErr != nil {
+	if _, readErr := output.ReadFrom(r); readErr != nil {
 		t.Fatalf("Failed to read from pipe: %v", readErr)
 	}
 	r.Close()
-
-	// Restore stdout
 	os.Stdout = oldStdout
 
-	// Wait for command to complete
-	execErr := <-errChan
-	if execErr != nil {
+	if execErr := <-errChan; execErr != nil {
 		t.Fatalf("Execute() error = %v, want nil", execErr)
 	}
 
-	// Verify output contains zsh completion script markers
+	// Guard against silent regression to a code path that returns root help
+	// (which contains neither marker) instead of running GenZshCompletion.
+	// `#compdef kuke` is the cobra zsh header; `__complete` is the V2
+	// request-dispatch verb that proves the script drives `kuke __complete`
+	// at runtime — the same hot path the bash V2 test guards.
 	outputStr := output.String()
-	if !strings.Contains(outputStr, "compdef") && !strings.Contains(outputStr, "#compdef") {
-		// Zsh completion scripts typically contain these markers
-		// But we'll just verify we got some output
-		if len(outputStr) == 0 {
-			t.Error("Expected non-empty output from zsh completion generation")
-		}
+	if !strings.Contains(outputStr, "#compdef kuke") {
+		t.Errorf("zsh completion missing #compdef header (got %d bytes)", len(outputStr))
 	}
-
-	// Verify output is not empty
-	if len(outputStr) == 0 {
-		t.Error("Zsh completion script output is empty")
+	if !strings.Contains(outputStr, "__complete") {
+		t.Errorf("zsh completion missing __complete V2 dispatch verb")
 	}
 }
 
@@ -206,59 +187,40 @@ func TestAutocompleteFish(t *testing.T) {
 	autocompleteCmd := autocomplete.NewAutocompleteCmd()
 	rootCmd.AddCommand(autocompleteCmd)
 
-	// Get fish subcommand
-	fishCmd, _, err := rootCmd.Find([]string{"autocomplete", "fish"})
-	if err != nil {
-		t.Fatalf("Failed to find fish subcommand: %v", err)
-	}
-
-	// Capture stdout
-	var buf bytes.Buffer
+	// Capture stdout — the fish RunE writes the generated script there.
 	oldStdout := os.Stdout
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	// Execute command in goroutine
 	errChan := make(chan error, 1)
 	go func() {
-		fishCmd.SetOutput(&buf)
-		fishCmd.SetContext(ctx)
-		fishCmd.SetArgs([]string{})
-		err := fishCmd.Execute()
+		rootCmd.SetArgs([]string{"autocomplete", "fish"})
+		errChan <- rootCmd.Execute()
 		w.Close()
-		errChan <- err
 	}()
 
-	// Read output
 	var output bytes.Buffer
-	_, readErr := output.ReadFrom(r)
-	if readErr != nil {
+	if _, readErr := output.ReadFrom(r); readErr != nil {
 		t.Fatalf("Failed to read from pipe: %v", readErr)
 	}
 	r.Close()
-
-	// Restore stdout
 	os.Stdout = oldStdout
 
-	// Wait for command to complete
-	execErr := <-errChan
-	if execErr != nil {
+	if execErr := <-errChan; execErr != nil {
 		t.Fatalf("Execute() error = %v, want nil", execErr)
 	}
 
-	// Verify output contains fish completion script markers
+	// Guard against silent regression to a code path that returns root help
+	// (whose body contains the substring `complete` from the autocomplete
+	// Short description) instead of running GenFishCompletion. `complete -c
+	// kuke` is the per-arg dispatch fish needs; `__kuke_perform_completion`
+	// is the function that drives `kuke __complete` from the running shell.
 	outputStr := output.String()
-	if !strings.Contains(outputStr, "complete") {
-		// Fish completion scripts typically contain "complete" commands
-		// But we'll just verify we got some output
-		if len(outputStr) == 0 {
-			t.Error("Expected non-empty output from fish completion generation")
-		}
+	if !strings.Contains(outputStr, "complete -c kuke") {
+		t.Errorf("fish completion missing `complete -c kuke` dispatch (got %d bytes)", len(outputStr))
 	}
-
-	// Verify output is not empty
-	if len(outputStr) == 0 {
-		t.Error("Fish completion script output is empty")
+	if !strings.Contains(outputStr, "__kuke_perform_completion") {
+		t.Errorf("fish completion missing __kuke_perform_completion dispatcher")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `TestAutocompleteZsh` / `TestAutocompleteFish` previously drove the subcommand with `subCmd.SetArgs([]string{})` + `subCmd.Execute()`, which falls back to root help instead of running `GenZshCompletion` / `GenFishCompletion`. The assertions then passed against help output: zsh's empty-output fallback never fired, and fish's `strings.Contains(out, "complete")` matched help text because the autocomplete root's `Short` description contains "completion script".
- Mirrors the rewrite #380 applied to `TestAutocompleteBash`: route through `rootCmd.SetArgs([]string{"autocomplete", "<shell>"})` + `rootCmd.Execute()`, capture stdout (the RunE writes to `os.Stdout`), and assert on markers the real script must contain (so help output cannot satisfy them).
- Zsh markers: `#compdef kuke` (script header) and `__complete` (V2 dispatch verb — same V2 hot-path the bash test guards). Fish markers: `complete -c kuke` (per-arg dispatch) and `__kuke_perform_completion` (request-dispatch function). Verified all four substrings are absent from `kuke help` / `kuke --help` output, so a regression that returns help would now fail the assertions.

This is a test-only change; only `cmd/kuke/autocomplete/autocomplete_test.go` is modified. The daemon and `/opt/kukeon` are untouched, so the `make dev-init` daemon-parity smoke is not required.

Note: #382 describes the same fix as #381 (filed independently after the same review) and the change here satisfies its acceptance criteria as well, but per the dev role I'm only closing the bug-labeled issue and leaving #382 for pm to dedupe.

## Test plan
- [x] `go test ./cmd/kuke/autocomplete/... -run TestAutocomplete -v` — all five pass
- [x] `make test` — full suite green
- [x] `go vet ./...`, `go build ./...`
- [x] `pre-commit run --files cmd/kuke/autocomplete/autocomplete_test.go`
- [ ] `make dev-init` — not run; change is test-only and does not touch the daemon, build path, or `/opt/kukeon`

Closes #381