### PR TITLE
feat: kuke attach takes cell as positional arg, defaults realm/space/stack

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -388,8 +388,6 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_ATTACH_STACK = DefineKV("KUKE_ATTACH_STACK", "kuke/attach/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_ATTACH_CELL = DefineKV("KUKE_ATTACH_CELL", "kuke/attach/cell")
-	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_ATTACH_CONTAINER = DefineKV("KUKE_ATTACH_CONTAINER", "kuke/attach/container")
 
 	// Log command variables.

--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/eminwux/kukeon/cmd/config"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -56,43 +57,44 @@ type runFn func(ctx context.Context, opts attach.Options) error
 // NewAttachCmd builds the `kuke attach` cobra command.
 func NewAttachCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "attach",
+		Use:           "attach <cell>",
 		Aliases:       []string{"att"},
 		Short:         "Attach to an Attachable container's sbsh terminal",
-		Args:          cobra.NoArgs,
+		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE:          runAttach,
 	}
 
-	cmd.Flags().String("realm", "", "Realm that owns the cell")
+	cmd.Flags().String("realm", consts.KukeonDefaultRealmName, "Realm that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_ATTACH_REALM.ViperKey, cmd.Flags().Lookup("realm"))
-	cmd.Flags().String("space", "", "Space that owns the cell")
+	cmd.Flags().String("space", consts.KukeonDefaultSpaceName, "Space that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_ATTACH_SPACE.ViperKey, cmd.Flags().Lookup("space"))
-	cmd.Flags().String("stack", "", "Stack that owns the cell")
+	cmd.Flags().String("stack", consts.KukeonDefaultStackName, "Stack that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_ATTACH_STACK.ViperKey, cmd.Flags().Lookup("stack"))
-	cmd.Flags().String("cell", "", "Cell to attach into")
-	_ = viper.BindPFlag(config.KUKE_ATTACH_CELL.ViperKey, cmd.Flags().Lookup("cell"))
 	cmd.Flags().String("container", "",
 		"Container within the cell to attach to (omit to auto-pick the only non-root attachable)")
 	_ = viper.BindPFlag(config.KUKE_ATTACH_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
 
+	cmd.ValidArgsFunction = config.CompleteCellNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
-	_ = cmd.RegisterFlagCompletionFunc("cell", config.CompleteCellNames)
 	_ = cmd.RegisterFlagCompletionFunc("container", config.CompleteContainerNames)
 
 	return cmd
 }
 
-func runAttach(cmd *cobra.Command, _ []string) error {
+func runAttach(cmd *cobra.Command, args []string) error {
+	cell := strings.TrimSpace(args[0])
 	realm := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_REALM.ViperKey))
 	space := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_SPACE.ViperKey))
 	stack := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_STACK.ViperKey))
-	cell := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_CELL.ViperKey))
 	container := strings.TrimSpace(viper.GetString(config.KUKE_ATTACH_CONTAINER.ViperKey))
 
+	if cell == "" {
+		return fmt.Errorf("%w (positional cell)", errdefs.ErrCellNameRequired)
+	}
 	if realm == "" {
 		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
 	}
@@ -101,9 +103,6 @@ func runAttach(cmd *cobra.Command, _ []string) error {
 	}
 	if stack == "" {
 		return fmt.Errorf("%w (--stack)", errdefs.ErrStackNameRequired)
-	}
-	if cell == "" {
-		return fmt.Errorf("%w (--cell)", errdefs.ErrCellNameRequired)
 	}
 
 	client, err := resolveClient(cmd)

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -125,7 +125,7 @@ func TestAttach_SingleNonRootAttachable_Succeeds(t *testing.T) {
 	run := &runCapture{}
 	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "c1",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -136,6 +136,74 @@ func TestAttach_SingleNonRootAttachable_Succeeds(t *testing.T) {
 	}
 	if run.opts.SocketPath != testHostSocket {
 		t.Errorf("Options.SocketPath = %q, want %q", run.opts.SocketPath, testHostSocket)
+	}
+}
+
+// TestAttach_PositionalCell_DefaultsRealmSpaceStack covers the issue-#373
+// contract: `kuke attach <cell>` (no realm/space/stack flags) targets the
+// user-default hierarchy `default/default/default`. The runtime resolves
+// realm/space/stack from the flag defaults wired into NewAttachCmd.
+func TestAttach_PositionalCell_DefaultsRealmSpaceStack(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var gotRealm, gotSpace, gotStack, gotCell string
+	fc := &fakeClient{
+		listContainersFn: func(realm, space, stack, cell string) ([]v1beta1.ContainerSpec, error) {
+			gotRealm, gotSpace, gotStack, gotCell = realm, space, stack, cell
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work", Attachable: true},
+			}, nil
+		},
+		attachContainerFn: func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			if got := doc.Spec.RealmID; got != "default" {
+				t.Errorf("doc.Spec.RealmID = %q, want %q", got, "default")
+			}
+			if got := doc.Spec.SpaceID; got != "default" {
+				t.Errorf("doc.Spec.SpaceID = %q, want %q", got, "default")
+			}
+			if got := doc.Spec.StackID; got != "default" {
+				t.Errorf("doc.Spec.StackID = %q, want %q", got, "default")
+			}
+			if got := doc.Spec.CellID; got != "hello" {
+				t.Errorf("doc.Spec.CellID = %q, want %q", got, "hello")
+			}
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
+	cmd.SetArgs([]string{"hello"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if gotRealm != "default" || gotSpace != "default" || gotStack != "default" || gotCell != "hello" {
+		t.Errorf("ListContainers called with (%q, %q, %q, %q), want (default, default, default, hello)",
+			gotRealm, gotSpace, gotStack, gotCell)
+	}
+	if run.calls != 1 {
+		t.Fatalf("attach.Run called %d times, want 1", run.calls)
+	}
+}
+
+// TestAttach_RejectsCellFlag locks in the breaking change: the legacy
+// `--cell` flag was removed in favor of the positional arg. The cobra
+// parser must reject `--cell` rather than silently accepting it.
+func TestAttach_RejectsCellFlag(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd := newCmdWithCtx(t, &fakeClient{}, &runCapture{})
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute returned nil, want unknown-flag error")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("error %q does not mention unknown flag", err.Error())
 	}
 }
 
@@ -154,7 +222,7 @@ func TestAttach_AmbiguousCandidates_ErrorsWithList(t *testing.T) {
 	run := &runCapture{}
 	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "c1",
 	})
 
 	err := cmd.Execute()
@@ -189,7 +257,7 @@ func TestAttach_NoCandidate_Errors(t *testing.T) {
 	run := &runCapture{}
 	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "c1",
 	})
 
 	err := cmd.Execute()
@@ -216,7 +284,7 @@ func TestAttach_RootContainerExcludedFromAutoPick(t *testing.T) {
 	run := &runCapture{}
 	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "c1",
 	})
 
 	err := cmd.Execute()
@@ -240,8 +308,8 @@ func TestAttach_ExplicitContainer_NotAttachable_SurfacesSentinel(t *testing.T) {
 	run := &runCapture{}
 	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "side",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "side", "c1",
 	})
 
 	err := cmd.Execute()
@@ -264,8 +332,8 @@ func TestAttach_ExplicitContainer_Attachable_Succeeds(t *testing.T) {
 	run := &runCapture{}
 	cmd := newCmdWithCtx(t, fc, run)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "shell",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "shell", "c1",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -298,8 +366,8 @@ func TestAttach_RunReturnsCleanDetachError(t *testing.T) {
 	cmd := newCmdWithCtx(t, fc, nil)
 	cmd.SetContext(context.WithValue(cmd.Context(), attachcmd.MockRunKey{}, attachcmd.RunFn(run.fn)))
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -328,8 +396,8 @@ func TestAttach_RunReturnsPeerClosedError(t *testing.T) {
 	cmd := newCmdWithCtx(t, fc, nil)
 	cmd.SetContext(context.WithValue(cmd.Context(), attachcmd.MockRunKey{}, attachcmd.RunFn(run.fn)))
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -356,8 +424,8 @@ func TestAttach_RunReturnsRealError(t *testing.T) {
 	cmd := newCmdWithCtx(t, fc, nil)
 	cmd.SetContext(context.WithValue(cmd.Context(), attachcmd.MockRunKey{}, attachcmd.RunFn(run.fn)))
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1",
 	})
 
 	err := cmd.Execute()
@@ -378,38 +446,32 @@ func TestAttach_MissingFlags(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "missing realm",
-			args:    []string{"--space", "s1", "--stack", "st1", "--cell", "c1"},
+			name:    "explicit empty realm",
+			args:    []string{"--realm", "", "--space", "s1", "--stack", "st1", "c1"},
 			wantErr: errdefs.ErrRealmNameRequired,
 		},
 		{
-			name:    "missing space",
-			args:    []string{"--realm", "r1", "--stack", "st1", "--cell", "c1"},
+			name:    "explicit empty space",
+			args:    []string{"--realm", "r1", "--space", "", "--stack", "st1", "c1"},
 			wantErr: errdefs.ErrSpaceNameRequired,
 		},
 		{
-			name:    "missing stack",
-			args:    []string{"--realm", "r1", "--space", "s1", "--cell", "c1"},
+			name:    "explicit empty stack",
+			args:    []string{"--realm", "r1", "--space", "s1", "--stack", "", "c1"},
 			wantErr: errdefs.ErrStackNameRequired,
-		},
-		{
-			name:    "missing cell",
-			args:    []string{"--realm", "r1", "--space", "s1", "--stack", "st1"},
-			wantErr: errdefs.ErrCellNameRequired,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Reset clears viper's defaults set by DefineKV at package
-			// init ("default" for realm/space/stack), so any flag the
-			// case omits resolves to the empty string and trips the
-			// missing-flag guard. t.Setenv keeps the env-var path
-			// quiet too, in case the dev box exports a KUKE_ATTACH_*.
+			// init so an explicit `--realm ""` resolves to the empty
+			// string and trips the runtime guard. t.Setenv keeps the
+			// env-var path quiet too, in case the dev box exports a
+			// KUKE_ATTACH_*.
 			viper.Reset()
 			t.Setenv("KUKE_ATTACH_REALM", "")
 			t.Setenv("KUKE_ATTACH_SPACE", "")
 			t.Setenv("KUKE_ATTACH_STACK", "")
-			t.Setenv("KUKE_ATTACH_CELL", "")
 
 			cmd := newCmdWithCtx(t, &fakeClient{}, &runCapture{})
 			cmd.SetArgs(tc.args)
@@ -419,5 +481,23 @@ func TestAttach_MissingFlags(t *testing.T) {
 				t.Fatalf("error %v does not unwrap to %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestAttach_MissingCellArg covers the cobra arg-count guard: omitting the
+// positional <cell> exits before runAttach ever runs, surfacing a
+// usage-style error rather than ErrCellNameRequired.
+func TestAttach_MissingCellArg(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd := newCmdWithCtx(t, &fakeClient{}, &runCapture{})
+	cmd.SetArgs([]string{"--realm", "r1", "--space", "s1", "--stack", "st1"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute returned nil, want arg-count error")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Errorf("error %q does not mention arg-count requirement", err.Error())
 	}
 }

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -177,11 +177,10 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// Step 4: drive `kuke attach` over a real PTY and detach.
 	session := startPTY(t, nil, kuke,
 		appendNoDaemonRunPath(runPath,
-			"attach",
+			"attach", cellName,
 			"--realm", realmName,
 			"--space", spaceName,
 			"--stack", stackName,
-			"--cell", cellName,
 			"--container", "work",
 		)...)
 	t.Cleanup(session.Close)


### PR DESCRIPTION
## Summary

- `kuke attach <cell>` is now the primary form: cobra `ExactArgs(1)` consumes the cell name positionally, matching the sibling `kuke start cell <name>` shape (`cmd/kuke/start/cell/cell.go:37-44`).
- `--realm`/`--space`/`--stack` default to `KukeonDefault*Name` (`default`/`default`/`default`) at the flag level, so `kuke attach hello` resolves to `default/default/default/hello` in the user-default hierarchy without flag boilerplate. The runtime guards still fire on explicit `--realm ""` / `--space ""` / `--stack ""`.
- `cmd.ValidArgsFunction = config.CompleteCellNames` wires positional tab-completion against the user-default hierarchy. `CompleteCellNames` already falls back to `realm=default`/`space=default`/`stack=default` when the flags are unset (`cmd/config/autocomplete.go:346-348`).
- **Breaking change — `--cell` flag removed cleanly.** Per the project's "no backwards-compatibility shims" convention (root `CLAUDE.md`), the legacy `--cell` is dropped rather than kept as a hidden alias. The flag was undocumented in `docs/` for `attach` (only sibling commands like `kuke purge container --cell` reference it), `cmd/kuke/run/run.go:62` already documents the new shape (`kuke attach <cell>`), and pre-1.0 status keeps the migration cost low. `KUKE_ATTACH_CELL` env var (`cmd/config/env.go`) is removed alongside it. `TestAttach_RejectsCellFlag` locks the rejection in.

Closes #373.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/kuke/attach/...` — all attach tests pass, including the new `TestAttach_PositionalCell_DefaultsRealmSpaceStack`, `TestAttach_RejectsCellFlag`, `TestAttach_MissingCellArg`, and the updated explicit-empty-flag cases in `TestAttach_MissingFlags`
- [x] `make test` — full unit-test suite green for every package my diff touches; **one pre-existing failure** in `cmd/kuke/init/TestRunInitErrors/controller_failure` reproduces on a stashed clean `origin/main` checkout and is already filed as [#391](https://github.com/eminwux/kukeon/issues/391) — unrelated to this PR (no init code touched), and CI on main is green per recent runs (the bug reproduces locally only)
- [x] `gofmt -l` clean on the three touched files
- [ ] `make dev-init` smoke — not run; this change is CLI-flag-shape only and does not touch the build path, the daemon, or anything under `/opt/kukeon`, so the parity check in the project `CLAUDE.md` is not in scope. Inspected `kuke run`'s help-text reference (`cmd/kuke/run/run.go:62`) which already documents the new `kuke attach <cell>` shape — alignment confirmed by code inspection.

## Notes for reviewer

- I picked the **clean removal** path for `--cell` rather than a deprecation shim, per the issue body's "Pick one and document in the PR" and root `CLAUDE.md`'s "Don't add … backwards-compatibility hacks". If you'd prefer a one-release deprecation alias, I can swap to a hidden `--cell` flag that overrides the positional with a `Deprecated: …` notice on the flag.
- The `KUKE_ATTACH_CELL` env-var key is removed alongside the flag. If anyone in the wild relied on `KUKE_ATTACH_CELL=foo kuke attach`, they'll need to migrate to `kuke attach foo`. Worth a release-note line if there's a `CHANGELOG.md`-style convention I missed.
- Sibling change for `kuke log` is explicitly out of scope per the issue's "Notes" — that's a separate ticket. `kuke log` still requires `--realm/--space/--stack/--cell` after this PR.