### PR TITLE
fix: pre-flight containerd reachability in kuke init

### DIFF
--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -45,6 +45,12 @@ const (
 	kukeondReadyTimeout = 30 * time.Second
 	kukeondReadyTick    = 200 * time.Millisecond
 
+	// defaultContainerdSocket is the conventional path of a standalone
+	// containerd's gRPC socket. Used as the fallback when no socket is
+	// configured (matches the containerd library's own default and the
+	// pre-flight in scripts/dev-init.sh).
+	defaultContainerdSocket = "/run/containerd/containerd.sock"
+
 	// File modes applied by `kuke init` so the kukeon group can reach the
 	// runtime/socket without world access. Writes under /opt/kukeon still
 	// require root and go through the daemon.
@@ -243,6 +249,29 @@ func resolveKukeondImage() string {
 	return fmt.Sprintf("%s:%s", repo, tag)
 }
 
+// preflightContainerdSocket fails fast when the configured containerd socket
+// does not exist or is not a socket file. Without this check, RunInit can
+// reach the controller bootstrap and silently succeed against an unreachable
+// socket — runner.ExistsRealmContainerdNamespace deliberately returns
+// (false, nil) on a missing socket for test ergonomics, which lets the
+// "namespace missing, create it" path proceed through downstream no-ops.
+func preflightContainerdSocket(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf(
+			"%w: %s — start containerd before re-running `kuke init`: %w",
+			errdefs.ErrConnectContainerd, path, err,
+		)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf(
+			"%w: %s is not a socket file — verify containerd is running and the path is correct",
+			errdefs.ErrConnectContainerd, path,
+		)
+	}
+	return nil
+}
+
 // installForwardAdmission installs the kukeon-owned FORWARD admission chain
 // so cells reach the network on hosts where `iptables -P FORWARD DROP` is
 // the default (Docker, firewalld, ufw, hardened distros). Idempotent —
@@ -322,6 +351,14 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		runPath = config.DefaultRunPath()
 	}
 
+	containerdSocket := viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey)
+	if containerdSocket == "" {
+		containerdSocket = defaultContainerdSocket
+	}
+	if err = preflightContainerdSocket(containerdSocket); err != nil {
+		return err
+	}
+
 	if mismatchErr := instance.VerifyOrWrite(
 		runPath,
 		viper.GetString(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey),
@@ -349,7 +386,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 
 	opts := controller.Options{
 		RunPath:              runPath,
-		ContainerdSocket:     viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+		ContainerdSocket:     containerdSocket,
 		KukeondImage:         image,
 		KukeondSocket:        socketPath,
 		KukeondSocketGID:     ensure.GID,

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -736,18 +736,32 @@ func TestRunInitErrors(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "controller failure",
+			name: "unreachable containerd socket",
 			setup: func(t *testing.T, cmd *cobra.Command) {
 				t.Cleanup(viper.Reset)
 				tmp := t.TempDir()
 				viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, tmp)
 				viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, filepath.Join(tmp, "missing.sock"))
+				// Point at a non-existent ServerConfiguration so Load
+				// returns an empty doc and applyServerConfiguration does
+				// not override the bogus socket above with whatever lives
+				// in /etc/kukeon/kukeond.yaml on the test host.
+				viper.Set(
+					config.KUKE_INIT_SERVER_CONFIGURATION.ViperKey,
+					filepath.Join(tmp, "missing.yaml"),
+				)
+				// Re-seed package-init defaults that an earlier
+				// t.Cleanup(viper.Reset) in this package will have
+				// wiped — consts.ConfigureRuntime rejects empty values.
+				viper.Set(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey, config.KUKEON_ROOT_NAMESPACE_SUFFIX.Default)
+				viper.Set(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey, config.KUKEON_ROOT_CGROUP_ROOT.Default)
 				logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 				ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 				cmd.SetContext(ctx)
 				cmd.SetOut(&bytes.Buffer{})
 				cmd.SetErr(&bytes.Buffer{})
 			},
+			wantErr:     errdefs.ErrConnectContainerd,
 			expectError: true,
 		},
 	}
@@ -768,9 +782,6 @@ func TestRunInitErrors(t *testing.T) {
 			}
 			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
 				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
-			}
-			if tc.name == "controller failure" && (err == nil || errors.Is(err, errdefs.ErrLoggerNotFound)) {
-				t.Fatalf("controller failure case should propagate controller error, got %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- `kuke init` could silently succeed against an unreachable containerd socket because `runner.ExistsRealmContainerdNamespace` deliberately returns `(false, nil)` when the socket is missing (test ergonomics), letting the "namespace missing → create it" path proceed through downstream no-ops. This mirrors the script-level pre-flight already in `scripts/dev-init.sh` (PR #388) inside `runInit` itself, so the daemon path fails fast with a clear `ErrConnectContainerd`-wrapped error instead.
- Tightens `TestRunInitErrors/controller_failure` (renamed to `unreachable_containerd_socket`) to assert specifically `errors.Is(err, errdefs.ErrConnectContainerd)`. The old assertion (`err != nil && !ErrLoggerNotFound`) passed by accident on hosts where an earlier step happened to fail (e.g., missing `iptables` binary) while still allowing the production hole to ship. The test setup now also points `KUKE_INIT_SERVER_CONFIGURATION` at a non-existent file so `applyServerConfiguration` does not silently overwrite the bogus socket with whatever lives in `/etc/kukeon/kukeond.yaml` on the test host, and re-seeds the namespace/cgroup defaults that an earlier `viper.Reset` in the package wipes.

## Test plan
- [x] `make test` — full unit suite green.
- [x] `pre-commit run --files cmd/kuke/init/init.go cmd/kuke/init/init_test.go` — all hooks pass (go fmt, go-mod-tidy, golangci-lint, addlicense, …).
- [x] `make dev-init` — daemon-parity check matches the expected output (both `kuke get realms` and `--no-daemon` show the two-realm Ready table); the pre-flight is a transparent no-op on a healthy host.
- [x] `go test -run TestRunInitErrors/unreachable_containerd_socket ./cmd/kuke/init/... -v` — exercises the new pre-flight path with the bogus socket and confirms `errdefs.ErrConnectContainerd` propagates.

Closes #391