### PR TITLE
fix: preserve ErrContainerNotFound sentinel in kuke attach / kuke run attach wraps

### DIFF
--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -125,7 +125,7 @@ func runAttach(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("container %q in cell %q is not attachable: %w", container, cell, err)
 		}
 		if errors.Is(err, errdefs.ErrContainerNotFound) {
-			return fmt.Errorf("container %q not found in cell %q", container, cell)
+			return fmt.Errorf("container %q not found in cell %q: %w", container, cell, err)
 		}
 		return err
 	}

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -321,6 +321,34 @@ func TestAttach_ExplicitContainer_NotAttachable_SurfacesSentinel(t *testing.T) {
 	}
 }
 
+// TestAttach_ExplicitContainer_NotFound_SurfacesSentinel locks in the
+// ErrContainerNotFound branch's %w wrap: when AttachContainer's RPC reports
+// the named container doesn't exist, kuke attach must propagate the
+// sentinel so upstream callers can still errors.Is it.
+func TestAttach_ExplicitContainer_NotFound_SurfacesSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			return kukeonv1.AttachContainerResult{}, errdefs.ErrContainerNotFound
+		},
+	}
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "ghost", "c1",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrContainerNotFound) {
+		t.Fatalf("error %v does not unwrap to ErrContainerNotFound", err)
+	}
+	if run.calls != 0 {
+		t.Errorf("attach.Run called %d times on missing target, want 0", run.calls)
+	}
+}
+
 func TestAttach_ExplicitContainer_Attachable_Succeeds(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/cmd/kuke/run/attach.go
+++ b/cmd/kuke/run/attach.go
@@ -148,8 +148,8 @@ func runAttachLoop(
 				container, doc.Metadata.Name, err)
 		}
 		if errors.Is(err, errdefs.ErrContainerNotFound) {
-			return false, fmt.Errorf("container %q not found in cell %q",
-				container, doc.Metadata.Name)
+			return false, fmt.Errorf("container %q not found in cell %q: %w",
+				container, doc.Metadata.Name, err)
 		}
 		return false, err
 	}

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -954,6 +954,37 @@ func TestRun_Attach_BadContainerFlag_Errors(t *testing.T) {
 	}
 }
 
+// TestRun_Attach_AttachContainer_NotFound_SurfacesSentinel locks in the
+// ErrContainerNotFound branch's %w wrap in runAttachLoop: when the daemon's
+// AttachContainer RPC reports the target container doesn't exist, run must
+// propagate the sentinel so upstream callers can still errors.Is it.
+func TestRun_Attach_AttachContainer_NotFound_SurfacesSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			return kukeonv1.AttachContainerResult{}, errdefs.ErrContainerNotFound
+		},
+	}
+	run := &runCapture{}
+	cmd, _ := newCmdWithRun(t, fc, run)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrContainerNotFound) {
+		t.Fatalf("err=%v want ErrContainerNotFound", err)
+	}
+	if fc.attachCalls != 1 {
+		t.Errorf("AttachContainer calls=%d want 1", fc.attachCalls)
+	}
+	if run.calls != 0 {
+		t.Errorf("attach loop calls=%d want 0", run.calls)
+	}
+}
+
 func TestRun_Attach_ContainerWithDetachFlag_Errors(t *testing.T) {
 	t.Cleanup(viper.Reset)
 


### PR DESCRIPTION
## Summary
- Both `kuke attach` and the post-create attach in `kuke run` dropped the `%w` wrap when `AttachContainer` returned `ErrContainerNotFound`, so upstream `errors.Is` calls could not see the sentinel — diverging from the adjacent `ErrAttachNotSupported` branches which already wrap correctly and from how `delete_cell` and friends expect the sentinel to propagate.
- Re-add `: %w` to both call sites and pass the original `err`.
- Lock the propagation in with two new tests (one per call site) that stub `AttachContainer` to return `ErrContainerNotFound` and assert `errors.Is(err, ErrContainerNotFound)` on the top-level command error.

## Test plan
- [x] `go test ./cmd/kuke/run/... ./cmd/kuke/attach/...`
- [x] `make test`
- [x] `pre-commit run --files cmd/kuke/attach/attach.go cmd/kuke/attach/attach_test.go cmd/kuke/run/attach.go cmd/kuke/run/run_test.go`
- [ ] `make dev-init` smoke test — change is purely CLI-side error-wrap formatting in `kuke attach` and `kuke run`; touches no build path, no daemon code, nothing the daemon reads, and nothing under `/opt/kukeon`, so the daemon-parity regression guard does not apply.

Closes #152