### PR TITLE
refactor: extract container picker to cmd/kuke/shared.PickContainer

### DIFF
--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
@@ -112,7 +111,10 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	defer func() { _ = client.Close() }()
 
 	if container == "" {
-		container, err = pickAttachableContainer(cmd.Context(), client, realm, space, stack, cell)
+		container, err = kukeshared.PickContainer(cmd.Context(), client, realm, space, stack, cell,
+			func(spec v1beta1.ContainerSpec) bool {
+				return !spec.Root && spec.Attachable
+			})
 		if err != nil {
 			return err
 		}
@@ -144,41 +146,6 @@ func runAttach(cmd *cobra.Command, args []string) error {
 		return runErr
 	}
 	return nil
-}
-
-// pickAttachableContainer enumerates the cell's containers and returns the
-// single non-root attachable one. Errors with ErrAttachNoCandidate when
-// none exist and ErrAttachAmbiguous (with the candidate list) when more
-// than one exist.
-func pickAttachableContainer(
-	ctx context.Context,
-	client kukeonv1.Client,
-	realm, space, stack, cell string,
-) (string, error) {
-	specs, err := client.ListContainers(ctx, realm, space, stack, cell)
-	if err != nil {
-		return "", err
-	}
-
-	candidates := make([]string, 0, len(specs))
-	for i := range specs {
-		spec := specs[i]
-		if spec.Root || !spec.Attachable {
-			continue
-		}
-		candidates = append(candidates, spec.ID)
-	}
-	sort.Strings(candidates)
-
-	switch len(candidates) {
-	case 0:
-		return "", fmt.Errorf("%w (cell %q)", errdefs.ErrAttachNoCandidate, cell)
-	case 1:
-		return candidates[0], nil
-	default:
-		return "", fmt.Errorf("%w (cell %q): candidates: %s",
-			errdefs.ErrAttachAmbiguous, cell, strings.Join(candidates, ", "))
-	}
 }
 
 func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {

--- a/cmd/kuke/log/log.go
+++ b/cmd/kuke/log/log.go
@@ -40,7 +40,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -148,7 +147,13 @@ func runLog(cmd *cobra.Command, _ []string) error {
 	defer func() { _ = client.Close() }()
 
 	if container == "" {
-		container, err = pickLogContainer(cmd.Context(), client, realm, space, stack, cell)
+		container, err = kukeshared.PickContainer(cmd.Context(), client, realm, space, stack, cell,
+			func(spec v1beta1.ContainerSpec) bool {
+				// `kuke log` accepts non-Attachable too — sbsh-capture
+				// for Attachable containers, cio.LogFile for the rest
+				// (e.g. kukeond). Only the root container is excluded.
+				return !spec.Root
+			})
 		if err != nil {
 			return err
 		}
@@ -227,42 +232,6 @@ func tailFile(ctx context.Context, path string, out io.Writer, follow bool) erro
 				return copyErr
 			}
 		}
-	}
-}
-
-// pickLogContainer enumerates the cell's containers and returns the single
-// non-root one — Attachable or not, since `kuke log` is meaningful for both
-// IO models (sbsh-capture for Attachable, cio.LogFile for non-Attachable).
-// This is the diff vs the `kuke attach` picker, which still requires
-// Attachable=true.
-func pickLogContainer(
-	ctx context.Context,
-	client kukeonv1.Client,
-	realm, space, stack, cell string,
-) (string, error) {
-	specs, err := client.ListContainers(ctx, realm, space, stack, cell)
-	if err != nil {
-		return "", err
-	}
-
-	candidates := make([]string, 0, len(specs))
-	for i := range specs {
-		spec := specs[i]
-		if spec.Root {
-			continue
-		}
-		candidates = append(candidates, spec.ID)
-	}
-	sort.Strings(candidates)
-
-	switch len(candidates) {
-	case 0:
-		return "", fmt.Errorf("%w (cell %q)", errdefs.ErrAttachNoCandidate, cell)
-	case 1:
-		return candidates[0], nil
-	default:
-		return "", fmt.Errorf("%w (cell %q): candidates: %s",
-			errdefs.ErrAttachAmbiguous, cell, strings.Join(candidates, ", "))
 	}
 }
 

--- a/cmd/kuke/shared/pick_container.go
+++ b/cmd/kuke/shared/pick_container.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// PickContainer enumerates the cell's containers via client.ListContainers
+// and returns the single container ID for which include returns true.
+//
+// `kuke attach` and `kuke log` both need to resolve the implicit container
+// when the operator omits --container; the two disagree on which specs to
+// keep — `kuke attach` requires Attachable=true, `kuke log` accepts
+// non-Attachable too — but the enumeration / sort / error semantics are
+// identical and live here so a future change to one subcommand cannot
+// drift the other.
+//
+// Callers pass include and decide for themselves whether to exclude
+// Spec.Root (both current callers do).
+//
+// Errors:
+//   - errdefs.ErrAttachNoCandidate (wrapped with cell) when no spec
+//     passes include.
+//   - errdefs.ErrAttachAmbiguous (wrapped with cell + sorted candidate
+//     list) when more than one passes.
+func PickContainer(
+	ctx context.Context,
+	client kukeonv1.Client,
+	realm, space, stack, cell string,
+	include func(v1beta1.ContainerSpec) bool,
+) (string, error) {
+	specs, err := client.ListContainers(ctx, realm, space, stack, cell)
+	if err != nil {
+		return "", err
+	}
+
+	candidates := make([]string, 0, len(specs))
+	for i := range specs {
+		spec := specs[i]
+		if !include(spec) {
+			continue
+		}
+		candidates = append(candidates, spec.ID)
+	}
+	sort.Strings(candidates)
+
+	switch len(candidates) {
+	case 0:
+		return "", fmt.Errorf("%w (cell %q)", errdefs.ErrAttachNoCandidate, cell)
+	case 1:
+		return candidates[0], nil
+	default:
+		return "", fmt.Errorf("%w (cell %q): candidates: %s",
+			errdefs.ErrAttachAmbiguous, cell, strings.Join(candidates, ", "))
+	}
+}

--- a/cmd/kuke/shared/pick_container_test.go
+++ b/cmd/kuke/shared/pick_container_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+type fakeListClient struct {
+	kukeonv1.FakeClient
+
+	specs []v1beta1.ContainerSpec
+	err   error
+}
+
+func (f *fakeListClient) ListContainers(
+	_ context.Context,
+	_, _, _, _ string,
+) ([]v1beta1.ContainerSpec, error) {
+	return f.specs, f.err
+}
+
+// nonRootAttachable mirrors the `kuke attach` filter.
+func nonRootAttachable(spec v1beta1.ContainerSpec) bool {
+	return !spec.Root && spec.Attachable
+}
+
+// nonRoot mirrors the `kuke log` filter (Attachable accepted too).
+func nonRoot(spec v1beta1.ContainerSpec) bool {
+	return !spec.Root
+}
+
+func TestPickContainer_SingleAttachable(t *testing.T) {
+	fc := &fakeListClient{specs: []v1beta1.ContainerSpec{
+		{ID: "root", Root: true},
+		{ID: "shell", Attachable: true},
+	}}
+	got, err := kukeshared.PickContainer(context.Background(), fc, "r", "s", "st", "c1", nonRootAttachable)
+	if err != nil {
+		t.Fatalf("PickContainer: %v", err)
+	}
+	if got != "shell" {
+		t.Errorf("got %q, want %q", got, "shell")
+	}
+}
+
+func TestPickContainer_NoCandidate_WrapsSentinel(t *testing.T) {
+	fc := &fakeListClient{specs: []v1beta1.ContainerSpec{
+		{ID: "root", Root: true},
+	}}
+	_, err := kukeshared.PickContainer(context.Background(), fc, "r", "s", "st", "c1", nonRootAttachable)
+	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
+		t.Fatalf("err=%v, want wraps ErrAttachNoCandidate", err)
+	}
+	if !strings.Contains(err.Error(), `"c1"`) {
+		t.Errorf("err=%q missing cell name", err)
+	}
+}
+
+func TestPickContainer_Ambiguous_WrapsSentinelWithSortedList(t *testing.T) {
+	fc := &fakeListClient{specs: []v1beta1.ContainerSpec{
+		{ID: "shell", Attachable: true},
+		{ID: "claude", Attachable: true},
+	}}
+	_, err := kukeshared.PickContainer(context.Background(), fc, "r", "s", "st", "c1", nonRootAttachable)
+	if !errors.Is(err, errdefs.ErrAttachAmbiguous) {
+		t.Fatalf("err=%v, want wraps ErrAttachAmbiguous", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "claude, shell") {
+		t.Errorf("err=%q missing sorted candidate list", got)
+	}
+}
+
+// TestPickContainer_AttachableFilterRejectsNonAttachable locks in the
+// `kuke attach` filter shape: even though the cell has a single non-root
+// container, it is non-Attachable and must surface as ErrAttachNoCandidate
+// rather than being auto-picked.
+func TestPickContainer_AttachableFilterRejectsNonAttachable(t *testing.T) {
+	fc := &fakeListClient{specs: []v1beta1.ContainerSpec{
+		{ID: "root", Root: true},
+		{ID: "daemon"},
+	}}
+	_, err := kukeshared.PickContainer(context.Background(), fc, "r", "s", "st", "c1", nonRootAttachable)
+	if !errors.Is(err, errdefs.ErrAttachNoCandidate) {
+		t.Fatalf("err=%v, want ErrAttachNoCandidate (non-Attachable must be filtered out for attach)", err)
+	}
+}
+
+// TestPickContainer_LogFilterAcceptsNonAttachable locks in the `kuke log`
+// filter shape: a lone non-Attachable container is auto-picked because
+// `kuke log` is meaningful for non-sbsh IO too (e.g. kukeond's cio.LogFile).
+func TestPickContainer_LogFilterAcceptsNonAttachable(t *testing.T) {
+	fc := &fakeListClient{specs: []v1beta1.ContainerSpec{
+		{ID: "root", Root: true},
+		{ID: "daemon"},
+	}}
+	got, err := kukeshared.PickContainer(context.Background(), fc, "r", "s", "st", "c1", nonRoot)
+	if err != nil {
+		t.Fatalf("PickContainer: %v", err)
+	}
+	if got != "daemon" {
+		t.Errorf("got %q, want %q", got, "daemon")
+	}
+}
+
+func TestPickContainer_ListContainersError_PropagatesUnwrapped(t *testing.T) {
+	sentinel := errors.New("rpc dropped")
+	fc := &fakeListClient{err: sentinel}
+	_, err := kukeshared.PickContainer(context.Background(), fc, "r", "s", "st", "c1", nonRoot)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err=%v, want wraps sentinel %v", err, sentinel)
+	}
+}


### PR DESCRIPTION
## Summary

- `kuke attach` and `kuke log` each carried a near-duplicate `pick{Attachable,Log}Container` that enumerated `client.ListContainers`, sorted candidates, and wrapped `ErrAttachNoCandidate` / `ErrAttachAmbiguous` with byte-identical message shapes. The only diff is the inclusion filter — attach requires `Attachable=true`, log accepts non-Attachable too. Lifted the enumeration/sort/error semantics into `kukeshared.PickContainer(ctx, client, …, include func(spec) bool)` so a future change to one subcommand cannot drift the other; each call site now passes its own one-line filter.
- Behavior-preserving: existing `cmd/kuke/attach` and `cmd/kuke/log` integration tests (which exercise the picker via `cmd.Execute()`) continue to pass against the new shared helper. New direct unit tests in `cmd/kuke/shared` lock in (a) the `ErrAttachNoCandidate` / `ErrAttachAmbiguous` sentinel wraps, (b) the sorted candidate list in the ambiguous error, (c) attach's Attachable filter rejecting a lone non-Attachable container, (d) log's filter accepting a lone non-Attachable container, and (e) `ListContainers` errors propagating unwrapped.
- Note vs the issue body's "byte-identical bodies" claim: the two pickers diverged in #203, when `pickLogContainer` dropped the Attachable filter so `kuke log` could surface kukeond's `cio.LogFile`. The issue's stated invariant ("both subcommands target the same attachable container set") is therefore not preserved by the dedup — they target structurally similar sets with different filters. The canonical-semantics goal still holds (one picker, one error shape, one sort), and the filter divergence is now an explicit predicate at each call site rather than a buried `if` inside a near-clone.

## Test plan

- [x] `go test ./cmd/kuke/shared/... ./cmd/kuke/attach/... ./cmd/kuke/log/...`
- [x] `make test`
- [x] `pre-commit run --files cmd/kuke/attach/attach.go cmd/kuke/log/log.go cmd/kuke/shared/pick_container.go cmd/kuke/shared/pick_container_test.go`
- [ ] `make dev-init` smoke test — change is purely CLI-side picker-helper refactor in `kuke attach` / `kuke log`; touches no build path, no daemon code, nothing the daemon reads, and nothing under `/opt/kukeon`, so the daemon-parity regression guard does not apply.

Closes #184