### PR TITLE
fix: bind KUKE_INIT_* env vars in cmd/kuke/init

### DIFF
--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -92,7 +92,28 @@ func setupInitCmd(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to set persistent flags: %w", err)
 	}
 
+	bindEnvVars()
 	return nil
+}
+
+// bindEnvVars wires each kuke-init viper key to its `KUKE_INIT_*`
+// environment variable. Without these calls applyServerConfiguration's
+// envSet check skips the YAML write yet viper has no env binding to read
+// the value back from — so the operator-exported value is recognised as
+// a gate but its content is silently dropped, leaving the flag default
+// to win. Mirrors the BindEnv block in cmd/kukeond/kukeond.go's
+// bindEnvVars and the KUKEON_* binds in cmd/kuke/kuke.go's loadConfig.
+func bindEnvVars() {
+	for _, v := range []config.Var{
+		config.KUKE_INIT_REALM,
+		config.KUKE_INIT_SPACE,
+		config.KUKE_INIT_KUKEOND_IMAGE,
+		config.KUKE_INIT_NO_WAIT,
+		config.KUKE_INIT_FORCE_REGENERATE_CNI,
+		config.KUKE_INIT_SERVER_CONFIGURATION,
+	} {
+		_ = v.BindEnv()
+	}
 }
 
 func setFlags(cmd *cobra.Command) error {

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -28,6 +28,7 @@ import (
 	"unsafe"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke"
 	initpkg "github.com/eminwux/kukeon/cmd/kuke/init"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/controller"
@@ -802,30 +803,31 @@ func TestRunInitErrors(t *testing.T) {
 // init-specific knobs (KUKE_INIT_KUKEOND_IMAGE, KUKEON_RUN_PATH) so a future
 // change to applyServerConfiguration in init.go cannot regress the env
 // branch while the kukeond sibling test stays green.
+//
+// Issue #399 regression guard: the env bindings are wired exclusively via
+// the production code path — kuke.LoadConfig() for the shared KUKEON_*
+// keys and NewInitCmd() (which calls init's bindEnvVars()) for the
+// KUKE_INIT_* keys. Removing either call from production drops the
+// env binding for the corresponding key, this test fails, and the
+// silent-env-drop bug is caught before it ships.
 func TestApplyServerConfigurationEnvOverridesConfig(t *testing.T) {
 	t.Cleanup(viper.Reset)
 	viper.Reset()
 
+	// Set env before kuke.LoadConfig so the BindEnv'd lookup returns the
+	// env value and loadConfig's empty-default seeding (viper.Set of
+	// DefaultRunPath when KUKEON_RUN_PATH reads empty) does not stamp
+	// the runtime default on top of the env binding.
+	t.Setenv(config.KUKE_INIT_KUKEOND_IMAGE.EnvVar(), "ghcr.io/eminwux/kukeon:from-env")
+	t.Setenv(config.KUKEON_ROOT_RUN_PATH.EnvVar(), "/opt/kukeon-from-env")
+
+	if err := kuke.LoadConfig(); err != nil {
+		t.Fatalf("kuke.LoadConfig: %v", err)
+	}
 	cmd := initpkg.NewInitCmd()
 	if cmd == nil {
 		t.Fatal("NewInitCmd() returned nil")
 	}
-
-	// NewKukeondCmd wires its env bindings via bindEnvVars(); NewInitCmd
-	// defers env binding to kuke.go's loadConfig, which only registers the
-	// shared keys. Bind the init-specific keys explicitly so viper.Get
-	// reflects the env value once t.Setenv fires.
-	if err := config.KUKE_INIT_KUKEOND_IMAGE.BindEnv(); err != nil {
-		t.Fatalf("BindEnv KUKE_INIT_KUKEOND_IMAGE: %v", err)
-	}
-	if err := config.KUKEON_ROOT_RUN_PATH.BindEnv(); err != nil {
-		t.Fatalf("BindEnv KUKEON_ROOT_RUN_PATH: %v", err)
-	}
-
-	// Operator exported KUKE_INIT_KUKEOND_IMAGE and KUKEON_RUN_PATH; the
-	// on-disk ServerConfiguration must not clobber them.
-	t.Setenv(config.KUKE_INIT_KUKEOND_IMAGE.EnvVar(), "ghcr.io/eminwux/kukeon:from-env")
-	t.Setenv(config.KUKEON_ROOT_RUN_PATH.EnvVar(), "/opt/kukeon-from-env")
 
 	spec := v1beta1.ServerConfigurationSpec{
 		KukeondImage: "ghcr.io/eminwux/kukeon:from-config",


### PR DESCRIPTION
## Summary
- `cmd/kuke/init` declared `KUKE_INIT_KUKEOND_IMAGE` (and siblings) with `viper.BindPFlag` but never called `viper.BindEnv` — so `applyServerConfiguration` saw `envSet` and skipped the YAML write while downstream `viper.GetString` returned `""` because no env binding existed, silently dropping the operator-exported value. Same bug class as closed #190 / sibling #191.
- Add a `bindEnvVars()` in `cmd/kuke/init/init.go` mirroring `cmd/kukeond/kukeond.go`'s; called from `setupInitCmd` so every `KUKE_INIT_*` viper key is wired to its env var.
- Simplify `TestApplyServerConfigurationEnvOverridesConfig` to remove the explicit per-test `BindEnv` calls. The test now uses `kuke.LoadConfig()` for the shared `KUKEON_*` keys and `NewInitCmd()` (which now calls `bindEnvVars()`) for the `KUKE_INIT_*` keys — proving env binding is wired end-to-end via the production code path.

## Test plan
- [x] `go test ./cmd/kuke/init/... -run TestApplyServerConfigurationEnvOverridesConfig -v` (passes)
- [x] Reproduced the issue's `TestReproduceKukeondImageEnvIgnored` against the fixed branch with the new production binding path — env value now wins.
- [x] `make test` (full suite, all packages pass)
- [x] `pre-commit run --files cmd/kuke/init/init.go cmd/kuke/init/init_test.go` (all hooks pass)
- [x] `make dev-init` — daemon-parity tail shows both `kuke get realms` and `kuke get realms --no-daemon` listing `default` and `kuke-system` Ready.

Closes #399