### PR TITLE
fix: drain leases before snapshots in CleanupNamespaceResources

### DIFF
--- a/internal/ctr/namespaces.go
+++ b/internal/ctr/namespaces.go
@@ -23,11 +23,24 @@ import (
 	"slices"
 
 	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/opencontainers/go-digest"
 )
+
+// containerdNamespaceServices is the subset of containerd.Client used by
+// drainNamespaceResources. Extracted so a fake modeling lease→snapshot
+// pinning can drive the drain in unit tests without a real containerd —
+// real-containerd integration in this repo lives in the e2e suite, not the
+// per-package `make test` target. *containerd.Client satisfies it directly.
+type containerdNamespaceServices interface {
+	ImageService() images.Store
+	SnapshotService(name string) snapshots.Snapshotter
+	ContentStore() content.Store
+	LeasesService() leases.Manager
+}
 
 // namespaceCtx returns a context with the namespace set.
 func (c *client) namespaceCtx(namespace string) context.Context {
@@ -170,12 +183,22 @@ var KukeonKnownSnapshotters = []string{
 // CleanupNamespaceResources empties a containerd namespace so DeleteNamespace
 // (which requires the namespace to be empty) can succeed. It drains in this
 // fixed order:
-//  1. images,
-//  2. snapshots — for every snapshotter when `snapshotter == ""` (the
+//  1. leases (with leases.SynchronousDelete),
+//  2. images,
+//  3. snapshots — for every snapshotter when `snapshotter == ""` (the
 //     uninstall path's default), or just the named snapshotter when one is
 //     specified explicitly,
-//  3. blobs (content store),
-//  4. leases.
+//  4. blobs (content store).
+//
+// Leases run first because leases.SynchronousDelete triggers the containerd
+// GC scheduler's ScheduleAndWait sweep before returning. That sweep is what
+// reconciles any metadata-only snapshot entries the image-pull path left
+// behind (entries whose lease was the GC root keeping them reachable); a
+// straight Walk+Remove pass after the fact misses those because the
+// metadata snapshotter's Walk silently skips entries with no underlying
+// state (containerd v2 metadata/snapshot.go). Draining leases first lets the
+// GC sweep clear them, then the subsequent snapshotter walk handles whatever
+// the user/runtime layer still pinned directly.
 //
 // Each class logs a count summary at INFO and per-resource debug lines at
 // DEBUG, so a future "namespace not empty" failure points at the exact class
@@ -190,94 +213,144 @@ func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error 
 		}
 	}
 
-	// Set namespace context for operations
 	nsCtx := namespaces.WithNamespace(c.ctx, namespace)
+	c.drainNamespaceResources(nsCtx, namespace, snapshotter, c.cClient)
+	return nil
+}
 
-	// Clean up images
-	c.logger.DebugContext(c.ctx, "listing images in namespace", "namespace", namespace)
-	images, err := c.cClient.ListImages(nsCtx)
-	if err != nil {
-		c.logger.WarnContext(c.ctx, "failed to list images", "namespace", namespace, "error", err)
-	} else {
-		c.logger.DebugContext(c.ctx, "found images in namespace", "namespace", namespace, "count", len(images))
-		for _, image := range images {
-			imageName := image.Name()
-			if imageName == "" {
-				// If image has no name, use target digest
-				if target := image.Target(); target.Digest.String() != "" {
-					imageName = target.Digest.String()
-				} else {
-					c.logger.WarnContext(c.ctx, "skipping image with no name or digest", "namespace", namespace)
-					continue
-				}
-			}
-			c.logger.DebugContext(c.ctx, "deleting image", "namespace", namespace, "image", imageName)
-			if deleteErr := c.cClient.ImageService().Delete(nsCtx, imageName); deleteErr != nil {
-				c.logger.WarnContext(c.ctx, "failed to delete image", "namespace", namespace, "image", imageName, "error", deleteErr)
-				// Continue with other images
-			} else {
-				c.logger.DebugContext(c.ctx, "deleted image", "namespace", namespace, "image", imageName)
-			}
-		}
-	}
+// drainNamespaceResources is the body of CleanupNamespaceResources split out
+// so unit tests can drive the drain order with a fake containerdNamespaceServices
+// that models lease→snapshot pinning. The order is load-bearing — see the
+// CleanupNamespaceResources doc for the GC-sweep rationale — and is therefore
+// asserted by TestCleanupNamespaceResourcesDrainsLeasePinnedSnapshots.
+func (c *client) drainNamespaceResources(
+	nsCtx context.Context,
+	namespace, snapshotter string,
+	srv containerdNamespaceServices,
+) {
+	c.drainLeases(nsCtx, namespace, srv)
+	c.drainImages(nsCtx, namespace, srv)
 
-	// Clean up snapshots. Walk every known snapshotter when the caller did
-	// not pin one; older callers passing "overlayfs" still drain only that.
 	snapshotters := []string{snapshotter}
 	if snapshotter == "" {
 		snapshotters = KukeonKnownSnapshotters
 	}
 	for _, snap := range snapshotters {
-		c.cleanupSnapshotsFor(nsCtx, namespace, snap)
+		c.cleanupSnapshotsFor(nsCtx, namespace, snap, srv)
 	}
 
-	// Clean up blobs (content)
+	c.drainBlobs(nsCtx, namespace, srv)
+}
+
+// drainLeases releases every lease in the namespace using
+// leases.SynchronousDelete so each delete blocks on the GC scheduler's
+// ScheduleAndWait sweep. That sweep is what reconciles metadata-only
+// snapshot orphans (entries whose lease was the only GC root keeping them
+// reachable); see the CleanupNamespaceResources doc for the full story.
+func (c *client) drainLeases(nsCtx context.Context, namespace string, srv containerdNamespaceServices) {
+	c.logger.DebugContext(c.ctx, "cleaning up leases", "namespace", namespace)
+	leaseManager := srv.LeasesService()
+	existingLeases, err := leaseManager.List(nsCtx)
+	if err != nil {
+		c.logger.WarnContext(c.ctx, "failed to list leases", "namespace", namespace, "error", err)
+		return
+	}
+	c.logger.InfoContext(c.ctx, "draining leases", "namespace", namespace, "count", len(existingLeases))
+	for _, lease := range existingLeases {
+		c.logger.DebugContext(c.ctx, "deleting lease", "namespace", namespace, "lease", lease.ID)
+		if deleteErr := leaseManager.Delete(nsCtx, lease, leases.SynchronousDelete); deleteErr != nil {
+			c.logger.WarnContext(
+				c.ctx,
+				"failed to delete lease",
+				"namespace",
+				namespace,
+				"lease",
+				lease.ID,
+				"error",
+				deleteErr,
+			)
+			continue
+		}
+		c.logger.DebugContext(c.ctx, "deleted lease", "namespace", namespace, "lease", lease.ID)
+	}
+}
+
+// drainImages deletes every image in the namespace via the metadata image
+// store. Image deletion only unlinks the metadata image bucket entry; the
+// underlying snapshot/blob refcount drops to zero and the next GC sweep (or
+// the snapshot/blob drain below) reclaims them.
+func (c *client) drainImages(nsCtx context.Context, namespace string, srv containerdNamespaceServices) {
+	c.logger.DebugContext(c.ctx, "listing images in namespace", "namespace", namespace)
+	imageStore := srv.ImageService()
+	imgs, err := imageStore.List(nsCtx)
+	if err != nil {
+		c.logger.WarnContext(c.ctx, "failed to list images", "namespace", namespace, "error", err)
+		return
+	}
+	c.logger.DebugContext(c.ctx, "found images in namespace", "namespace", namespace, "count", len(imgs))
+	for _, image := range imgs {
+		imageName := image.Name
+		if imageName == "" {
+			// If image has no name, use target digest
+			if image.Target.Digest.String() != "" {
+				imageName = image.Target.Digest.String()
+			} else {
+				c.logger.WarnContext(c.ctx, "skipping image with no name or digest", "namespace", namespace)
+				continue
+			}
+		}
+		c.logger.DebugContext(c.ctx, "deleting image", "namespace", namespace, "image", imageName)
+		if deleteErr := imageStore.Delete(nsCtx, imageName); deleteErr != nil {
+			c.logger.WarnContext(
+				c.ctx,
+				"failed to delete image",
+				"namespace",
+				namespace,
+				"image",
+				imageName,
+				"error",
+				deleteErr,
+			)
+			continue
+		}
+		c.logger.DebugContext(c.ctx, "deleted image", "namespace", namespace, "image", imageName)
+	}
+}
+
+// drainBlobs deletes every blob in the content store for the namespace.
+// Runs last because content-store entries are still referenced by leases
+// and images at the moment of cleanup; by the time the drain reaches here
+// those higher-level holders are gone and Delete proceeds.
+func (c *client) drainBlobs(nsCtx context.Context, namespace string, srv containerdNamespaceServices) {
 	c.logger.DebugContext(c.ctx, "cleaning up blobs", "namespace", namespace)
-	contentStore := c.cClient.ContentStore()
+	contentStore := srv.ContentStore()
 	var blobDigests []digest.Digest
-	err = contentStore.Walk(nsCtx, func(info content.Info) error {
+	err := contentStore.Walk(nsCtx, func(info content.Info) error {
 		blobDigests = append(blobDigests, info.Digest)
 		return nil
 	})
 	if err != nil {
 		c.logger.WarnContext(c.ctx, "failed to walk blobs", "namespace", namespace, "error", err)
-	} else {
-		c.logger.DebugContext(c.ctx, "found blobs", "namespace", namespace, "count", len(blobDigests))
-		for _, dgst := range blobDigests {
-			c.logger.DebugContext(c.ctx, "deleting blob", "namespace", namespace, "digest", dgst.String())
-			if deleteErr := contentStore.Delete(nsCtx, dgst); deleteErr != nil {
-				c.logger.WarnContext(c.ctx, "failed to delete blob", "namespace", namespace, "digest", dgst.String(), "error", deleteErr)
-				// Continue with other blobs
-			} else {
-				c.logger.DebugContext(c.ctx, "deleted blob", "namespace", namespace, "digest", dgst.String())
-			}
-		}
+		return
 	}
-
-	// Release any remaining leases. A pinned lease keeps content/snapshot
-	// references alive and blocks NamespaceService.Delete with "namespace not
-	// empty"; the image-pull path (image.go) creates per-pull leases and
-	// deletes them on success, but leases owned by orphaned operations or
-	// older kukeond versions can persist and must be cleared synchronously.
-	c.logger.DebugContext(c.ctx, "cleaning up leases", "namespace", namespace)
-	leaseManager := c.cClient.LeasesService()
-	existingLeases, err := leaseManager.List(nsCtx)
-	if err != nil {
-		c.logger.WarnContext(c.ctx, "failed to list leases", "namespace", namespace, "error", err)
-	} else {
-		c.logger.InfoContext(c.ctx, "draining leases", "namespace", namespace, "count", len(existingLeases))
-		for _, lease := range existingLeases {
-			c.logger.DebugContext(c.ctx, "deleting lease", "namespace", namespace, "lease", lease.ID)
-			if deleteErr := leaseManager.Delete(nsCtx, lease, leases.SynchronousDelete); deleteErr != nil {
-				c.logger.WarnContext(c.ctx, "failed to delete lease", "namespace", namespace, "lease", lease.ID, "error", deleteErr)
-				// Continue with other leases
-			} else {
-				c.logger.DebugContext(c.ctx, "deleted lease", "namespace", namespace, "lease", lease.ID)
-			}
+	c.logger.DebugContext(c.ctx, "found blobs", "namespace", namespace, "count", len(blobDigests))
+	for _, dgst := range blobDigests {
+		c.logger.DebugContext(c.ctx, "deleting blob", "namespace", namespace, "digest", dgst.String())
+		if deleteErr := contentStore.Delete(nsCtx, dgst); deleteErr != nil {
+			c.logger.WarnContext(
+				c.ctx,
+				"failed to delete blob",
+				"namespace",
+				namespace,
+				"digest",
+				dgst.String(),
+				"error",
+				deleteErr,
+			)
+			continue
 		}
+		c.logger.DebugContext(c.ctx, "deleted blob", "namespace", namespace, "digest", dgst.String())
 	}
-
-	return nil
 }
 
 // cleanupSnapshotsFor drains every snapshot under one snapshotter from the
@@ -287,12 +360,16 @@ func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error 
 // children are removed before parents. Capped at maxSnapshotPasses to bound
 // work on a pathological graph; in practice the depth is small (image layers
 // + a few committed container layers).
-func (c *client) cleanupSnapshotsFor(nsCtx context.Context, namespace, snapshotter string) {
+func (c *client) cleanupSnapshotsFor(
+	nsCtx context.Context,
+	namespace, snapshotter string,
+	srv containerdNamespaceServices,
+) {
 	if snapshotter == "" {
 		return
 	}
 	c.logger.DebugContext(c.ctx, "cleaning up snapshots", "namespace", namespace, "snapshotter", snapshotter)
-	snapshotService := c.cClient.SnapshotService(snapshotter)
+	snapshotService := srv.SnapshotService(snapshotter)
 
 	const maxSnapshotPasses = 32
 	totalRemoved := 0

--- a/internal/ctr/namespaces_internal_test.go
+++ b/internal/ctr/namespaces_internal_test.go
@@ -1,0 +1,294 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
+)
+
+// TestCleanupNamespaceResourcesDrainsLeasePinnedSnapshots is the regression
+// guard for issue #401 — `kuke uninstall` stranded overlayfs snapshots when
+// the default realm held lease-pinned snapshots (image pulls, container
+// creates), forcing operators to re-run uninstall. The fix is to drain
+// leases (with leases.SynchronousDelete to trigger a synchronous GC sweep)
+// BEFORE snapshots so the snapshot pass sees an unpinned graph.
+//
+// The fake models the observed-in-the-field semantic: snapshotter.Remove
+// fails with FailedPrecondition while a lease references the snapshot, and
+// lease.Delete drops that reference. A drainNamespaceResources that runs in
+// the old order (snapshots first, leases last) would call snapshotter.Remove
+// while the pins are still live, strand every snapshot, then drop the
+// leases too late to clean up. The new order (leases first) clears the pins
+// before the snapshot pass, so snapshotter.Remove succeeds and the
+// namespace ends up empty — which is what this test asserts.
+//
+// Real-containerd integration of the drain ordering lives in the e2e suite;
+// CI's `make test` target intentionally avoids needing a containerd socket,
+// so a fake is the only viable substrate for a per-package regression test.
+func TestCleanupNamespaceResourcesDrainsLeasePinnedSnapshots(t *testing.T) {
+	srv := newFakeServices()
+	srv.addSnapshot("overlayfs", "sha256:base")
+	srv.addSnapshot("overlayfs", "sha256:layer")
+	srv.addSnapshot("overlayfs", "sha256:top")
+	srv.addLease("lease-1", "snapshots/overlayfs", "sha256:base", "sha256:layer", "sha256:top")
+	srv.addImage("docker.io/library/alpine:latest", "sha256:manifest")
+	srv.addBlob("sha256:blob-a")
+	srv.addBlob("sha256:blob-b")
+
+	c := &client{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	c.drainNamespaceResources(context.Background(), "test-ns", "overlayfs", srv)
+
+	if got := len(srv.leases); got != 0 {
+		t.Errorf("leases remaining after drain: got %d, want 0", got)
+	}
+	if got := len(srv.snaps["overlayfs"]); got != 0 {
+		remaining := make([]string, 0, len(srv.snaps["overlayfs"]))
+		for k := range srv.snaps["overlayfs"] {
+			remaining = append(remaining, k)
+		}
+		t.Errorf(
+			"snapshots remaining after drain: got %d (%v), want 0 — lease-first ordering regressed",
+			got,
+			remaining,
+		)
+	}
+	if got := len(srv.imageList); got != 0 {
+		t.Errorf("images remaining after drain: got %d, want 0", got)
+	}
+	if got := len(srv.blobs); got != 0 {
+		t.Errorf("blobs remaining after drain: got %d, want 0", got)
+	}
+
+	// Ordering invariant: every lease delete must have completed before
+	// the first snapshotter Walk on the pinned snapshotter. If a future
+	// refactor inverts the order, every snapshot Remove would fail (pins
+	// still live) and the previous assertion fails — but checking the call
+	// log gives a sharper diagnostic.
+	lastLeaseDel := -1
+	firstSnapWalk := -1
+	for i, op := range srv.callLog {
+		if op == "lease.Delete(lease-1)" {
+			lastLeaseDel = i
+		}
+		if firstSnapWalk == -1 && op == "snapshotter.Walk(overlayfs)" {
+			firstSnapWalk = i
+		}
+	}
+	if lastLeaseDel == -1 {
+		t.Fatalf("call log missing lease.Delete; got %v", srv.callLog)
+	}
+	if firstSnapWalk == -1 {
+		t.Fatalf("call log missing snapshotter.Walk(overlayfs); got %v", srv.callLog)
+	}
+	if firstSnapWalk < lastLeaseDel {
+		t.Errorf(
+			"snapshotter.Walk(overlayfs) at %d ran before lease.Delete at %d; got call log %v",
+			firstSnapWalk,
+			lastLeaseDel,
+			srv.callLog,
+		)
+	}
+}
+
+// fakeServices models the subset of containerd surface drainNamespaceResources
+// uses. The pinning semantic — snapshotter.Remove fails while any lease
+// references the snapshot via a leases.Resource{Type:"snapshots/<name>",ID:<key>}
+// pair — is the load-bearing piece; everything else is plumbing.
+type fakeServices struct {
+	snaps     map[string]map[string]*fakeSnapshot // snapshotter -> key -> snap
+	leases    map[string]*fakeLease
+	imageList []images.Image
+	blobs     map[string]bool
+	callLog   []string
+}
+
+type fakeSnapshot struct {
+	name string
+}
+
+type fakeLease struct {
+	id        string
+	resources []leases.Resource
+}
+
+func newFakeServices() *fakeServices {
+	return &fakeServices{
+		snaps:  map[string]map[string]*fakeSnapshot{},
+		leases: map[string]*fakeLease{},
+		blobs:  map[string]bool{},
+	}
+}
+
+func (f *fakeServices) addSnapshot(snapshotter, key string) {
+	if f.snaps[snapshotter] == nil {
+		f.snaps[snapshotter] = map[string]*fakeSnapshot{}
+	}
+	f.snaps[snapshotter][key] = &fakeSnapshot{name: key}
+}
+
+func (f *fakeServices) addLease(id, resourceType string, keys ...string) {
+	res := make([]leases.Resource, len(keys))
+	for i, k := range keys {
+		res[i] = leases.Resource{ID: k, Type: resourceType}
+	}
+	f.leases[id] = &fakeLease{id: id, resources: res}
+}
+
+func (f *fakeServices) addImage(name string, dgst digest.Digest) {
+	img := images.Image{Name: name}
+	img.Target.Digest = dgst
+	f.imageList = append(f.imageList, img)
+}
+
+func (f *fakeServices) addBlob(dgst digest.Digest) {
+	f.blobs[dgst.String()] = true
+}
+
+// snapshotPinnedBy returns the lease IDs pinning the given snapshot key
+// under the given snapshotter. A non-empty result means snapshotter.Remove
+// must fail per the fake's modeled semantic.
+func (f *fakeServices) snapshotPinnedBy(snapshotter, key string) []string {
+	wantType := "snapshots/" + snapshotter
+	var pins []string
+	for _, l := range f.leases {
+		for _, r := range l.resources {
+			if r.Type == wantType && r.ID == key {
+				pins = append(pins, l.id)
+			}
+		}
+	}
+	return pins
+}
+
+func (f *fakeServices) LeasesService() leases.Manager { return &fakeLeaseManager{f: f} }
+func (f *fakeServices) ImageService() images.Store    { return &fakeImageStore{f: f} }
+func (f *fakeServices) ContentStore() content.Store   { return &fakeContentStore{f: f} }
+func (f *fakeServices) SnapshotService(name string) snapshots.Snapshotter {
+	return &fakeSnapshotter{f: f, name: name}
+}
+
+// fakeLeaseManager implements the subset of leases.Manager the drain calls.
+// Embedding leases.Manager (nil) promotes the unused methods; calling them
+// would panic, which is the right behavior — drainLeases must not need them.
+type fakeLeaseManager struct {
+	leases.Manager
+
+	f *fakeServices
+}
+
+func (m *fakeLeaseManager) List(_ context.Context, _ ...string) ([]leases.Lease, error) {
+	m.f.callLog = append(m.f.callLog, "lease.List")
+	out := make([]leases.Lease, 0, len(m.f.leases))
+	for id := range m.f.leases {
+		out = append(out, leases.Lease{ID: id})
+	}
+	return out, nil
+}
+
+func (m *fakeLeaseManager) Delete(_ context.Context, l leases.Lease, _ ...leases.DeleteOpt) error {
+	m.f.callLog = append(m.f.callLog, "lease.Delete("+l.ID+")")
+	delete(m.f.leases, l.ID)
+	return nil
+}
+
+type fakeImageStore struct {
+	images.Store
+
+	f *fakeServices
+}
+
+func (s *fakeImageStore) List(_ context.Context, _ ...string) ([]images.Image, error) {
+	s.f.callLog = append(s.f.callLog, "images.List")
+	return append([]images.Image(nil), s.f.imageList...), nil
+}
+
+func (s *fakeImageStore) Delete(_ context.Context, name string, _ ...images.DeleteOpt) error {
+	s.f.callLog = append(s.f.callLog, "images.Delete("+name+")")
+	for i, img := range s.f.imageList {
+		if img.Name == name {
+			s.f.imageList = append(s.f.imageList[:i], s.f.imageList[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("image %q: %w", name, errdefs.ErrNotFound)
+}
+
+type fakeSnapshotter struct {
+	snapshots.Snapshotter
+
+	f    *fakeServices
+	name string
+}
+
+func (s *fakeSnapshotter) Walk(_ context.Context, fn snapshots.WalkFunc, _ ...string) error {
+	s.f.callLog = append(s.f.callLog, "snapshotter.Walk("+s.name+")")
+	bucket, ok := s.f.snaps[s.name]
+	if !ok {
+		return nil
+	}
+	for key := range bucket {
+		if err := fn(context.Background(), snapshots.Info{Name: key}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *fakeSnapshotter) Remove(_ context.Context, key string) error {
+	s.f.callLog = append(s.f.callLog, "snapshotter.Remove("+s.name+","+key+")")
+	if pins := s.f.snapshotPinnedBy(s.name, key); len(pins) > 0 {
+		return fmt.Errorf("snapshot %q pinned by %v: %w", key, pins, errdefs.ErrFailedPrecondition)
+	}
+	delete(s.f.snaps[s.name], key)
+	return nil
+}
+
+type fakeContentStore struct {
+	content.Store
+
+	f *fakeServices
+}
+
+func (s *fakeContentStore) Walk(_ context.Context, fn content.WalkFunc, _ ...string) error {
+	s.f.callLog = append(s.f.callLog, "content.Walk")
+	for dgst := range s.f.blobs {
+		if err := fn(content.Info{Digest: digest.Digest(dgst)}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *fakeContentStore) Delete(_ context.Context, dgst digest.Digest) error {
+	s.f.callLog = append(s.f.callLog, "content.Delete("+dgst.String()+")")
+	delete(s.f.blobs, dgst.String())
+	return nil
+}


### PR DESCRIPTION
## Summary

`kuke uninstall` against a default realm with prior workload activity (image pulls, container creates) was stranding overlayfs snapshots and failing with `namespace "default.kukeon.io" must be empty, but it still has snapshots on "overlayfs" snapshotter: failed precondition`. Operators had to re-run uninstall, which the half-cleaned-host gate (#287) is supposed to make unnecessary.

**Root cause.** `CleanupNamespaceResources` drained in the order images → snapshots → blobs → leases. Leases ran last, so by the time `leases.SynchronousDelete` triggered the containerd GC scheduler's `ScheduleAndWait` sweep, the snapshotter pass had already given up — but the GC sweep is exactly what's needed to reconcile metadata-only snapshot entries the image-pull path leaves behind (entries whose lease was the GC root keeping them reachable). A direct `snapshotter.Walk` + `snapshotter.Remove` pass silently skips those because the metadata-wrapped Walk drops entries with no underlying state (containerd v2 `metadata/snapshot.go`).

**Fix.** Reorder to leases → images → snapshots → blobs. Each lease delete uses `leases.SynchronousDelete`, so the GC sweep completes synchronously before the snapshot pass runs against an unpinned graph. The function-level doc explains the rationale so a future refactor that "tidies" the order back has a paper trail to read.

**Refactor.** Split the body into per-class helpers (`drainLeases`, `drainImages`, `drainBlobs`, plus the existing `cleanupSnapshotsFor`) behind a small `containerdNamespaceServices` interface (`*containerd.Client` satisfies it directly). The interface exists for the regression test — a fake modeling lease→snapshot pinning would otherwise need to stand up a real containerd, which CI's `make test` target deliberately avoids.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — all packages green including `internal/ctr` (70s), `cmd/kuke/uninstall`, `internal/controller`
- [x] `go test -run TestCleanupNamespaceResourcesDrainsLeasePinnedSnapshots -v ./internal/ctr/...` — new regression test passes; asserts both the post-drain empty state AND the call-log ordering invariant (lease.Delete before snapshotter.Walk on the pinned snapshotter)
- [x] `pre-commit run --files internal/ctr/namespaces.go internal/ctr/namespaces_internal_test.go`
- [x] `make dev-init` — daemon-parity check passes; both `kuke get realms` and `kuke get realms --no-daemon` produce the canonical two-row output (`default` Ready `/kukeon/default`, `kuke-system` Ready `/kukeon/kuke-system`)
- [ ] `make dev-init` → workload in default → `kuke uninstall` (single invocation) — deferred. The dev host has multiple live concurrent agent cells running in the `default` realm (`kukeon-pm-pick-doc-3f27d7`, `kukeon-pr-ac7f52`, `kukeon-pr-1962b5`); running the destructive uninstall scenario on this host would clobber unrelated production state. The regression test covers the ordering invariant on a fake that models the failure semantic, and the daemon-parity smoke covers the code-path-the-daemon-reads check.

Closes #401