### PR TITLE
fix: transition cell to Failed when a container fails to start

### DIFF
--- a/internal/controller/delete_cell_test.go
+++ b/internal/controller/delete_cell_test.go
@@ -192,6 +192,49 @@ func TestDeleteCell_SuccessfulDeletionWithContainers(t *testing.T) {
 	}
 }
 
+// TestDeleteCell_FailedCellDeletesWithoutForce locks down the issue #407
+// contract that `kuke delete cell <name>` accepts a cell in the terminal
+// CellStateFailed state without any --force or extra flag. Stickiness of
+// Failed is enforced by the reconciler (cellStateAutoDeleteTriggers excludes
+// Failed); the operator's explicit delete is the one and only escape hatch.
+func TestDeleteCell_FailedCellDeletesWithoutForce(t *testing.T) {
+	mockRunner := &fakeRunner{}
+	existingCell := buildTestCell("failed-cell", "test-realm", "test-space", "test-stack")
+	existingCell.Status.State = intmodel.CellStateFailed
+	existingCell.Spec.Containers = []intmodel.ContainerSpec{
+		{ID: "work", Image: "alpine:latest"},
+	}
+
+	deleteCalled := false
+	mockRunner.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+		return existingCell, nil
+	}
+	mockRunner.ExistsCgroupFn = func(_ any) (bool, error) {
+		return true, nil
+	}
+	mockRunner.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
+		return true, nil
+	}
+	mockRunner.DeleteCellFn = func(_ intmodel.Cell) error {
+		deleteCalled = true
+		return nil
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	cell := buildTestCell("failed-cell", "test-realm", "test-space", "test-stack")
+
+	result, err := ctrl.DeleteCell(cell)
+	if err != nil {
+		t.Fatalf("DeleteCell on Failed cell returned error: %v", err)
+	}
+	if !deleteCalled {
+		t.Error("runner.DeleteCell was not invoked — controller refused to delete a Failed cell")
+	}
+	if !result.MetadataDeleted {
+		t.Error("expected MetadataDeleted to be true on Failed cell deletion")
+	}
+}
+
 func TestDeleteCell_ValidationErrors(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -381,6 +381,29 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcome, error) {
 	originalStatus := cell.Status
 
+	// CellStateFailed is terminal (issue #407): once a cell has been marked
+	// Failed by a startup-path error in StartCell / StartContainer, the
+	// reconciler must keep the state sticky so a subsequent populate that
+	// reads back "no task" doesn't quietly downgrade Failed to Unknown or
+	// Stopped — and so cellStateAutoDeleteTriggers (which excludes Failed)
+	// cannot be bypassed via a re-derivation tick. Container statuses are
+	// still refreshed below so `kuke get cell -o yaml` shows the latest
+	// per-container view, but the cell-level state is left alone until the
+	// operator runs `kuke delete cell`.
+	if cellStateIsSticky(originalStatus.State) {
+		if err := r.populateCellContainerStatuses(&cell); err != nil {
+			r.logger.DebugContext(r.ctx, "populate container statuses failed",
+				"cell", cell.Metadata.Name, "error", err)
+		}
+		updated := !containerStatusesEqual(originalStatus.Containers, cell.Status.Containers)
+		if updated {
+			if updateErr := r.UpdateCellMetadata(cell); updateErr != nil {
+				return cell, ReconcileOutcome{}, fmt.Errorf("failed to update cell metadata: %w", updateErr)
+			}
+		}
+		return cell, ReconcileOutcome{Updated: updated}, nil
+	}
+
 	cgroupExists, cgroupErr := r.ExistsCgroup(cell)
 	if cgroupErr != nil {
 		r.logger.DebugContext(r.ctx, "failed to check cell cgroup",
@@ -483,13 +506,33 @@ func (r *Exec) autoDeleteCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutco
 	return cell, ReconcileOutcome{Deleted: true}, nil
 }
 
+// cellStateIsSticky reports whether the reconciler must preserve the cell's
+// persisted state instead of re-deriving from cgroup + container task state.
+// Currently a single state qualifies — CellStateFailed (the terminal Error
+// state introduced for issue #407). A Failed cell stays Failed across every
+// reconcile tick until the operator runs `kuke delete cell`, regardless of
+// what containerd reports for its (now-killed) containers. Extracted as a
+// pure function so the stickiness predicate is unit-testable without spinning
+// up a runner + containerd fake.
+func cellStateIsSticky(s intmodel.CellState) bool {
+	return s == intmodel.CellStateFailed
+}
+
 // cellStateAutoDeleteTriggers returns true for the post-reconcile cell
-// states that mean "the root container is no longer running", which is
-// the trigger AutoDelete cares about. Unknown is deliberately excluded:
-// a transient containerd hiccup that flips a cell to Unknown should not
-// nuke the cell — wait for the next pass.
+// states that mean "the root container is no longer running and the cell
+// has run its course successfully", which is the trigger AutoDelete cares
+// about. Excluded states:
+//
+//   - Unknown: a transient containerd hiccup that flips a cell to Unknown
+//     should not nuke the cell — wait for the next pass.
+//   - Failed (issue #407): the terminal Error state is reserved for
+//     startup-path failures and is deliberately sticky. `kuke run --rm`
+//     does not auto-clean a Failed cell — `--rm` only takes effect on a
+//     *successful* run that subsequently exits cleanly (i.e. Stopped).
+//     Preserving the cell on failure keeps the diagnostic surface (spec,
+//     captured logs) intact until the operator runs `kuke delete cell`.
 func cellStateAutoDeleteTriggers(s intmodel.CellState) bool {
-	return s == intmodel.CellStateStopped || s == intmodel.CellStateFailed
+	return s == intmodel.CellStateStopped
 }
 
 // latchReadyObserved is the one-way latch the reconciler uses to decide

--- a/internal/controller/runner/refresh_test.go
+++ b/internal/controller/runner/refresh_test.go
@@ -27,8 +27,10 @@ import (
 
 // TestCellStateAutoDeleteTriggers locks down the predicate the reconciler
 // uses to decide when Spec.AutoDelete=true should kick off cleanup. Stopped
-// and Failed are the only triggers — Unknown is excluded so a transient
-// containerd hiccup doesn't nuke the cell, and the running states stay
+// is the only trigger — Unknown is excluded so a transient containerd
+// hiccup doesn't nuke the cell, Failed is excluded per the issue #407
+// contract (the terminal Error state is sticky and preserves diagnostic
+// surface — `--rm` does not auto-clean it), and the running states stay
 // untouched.
 func TestCellStateAutoDeleteTriggers(t *testing.T) {
 	cases := []struct {
@@ -36,7 +38,7 @@ func TestCellStateAutoDeleteTriggers(t *testing.T) {
 		want  bool
 	}{
 		{intmodel.CellStateStopped, true},
-		{intmodel.CellStateFailed, true},
+		{intmodel.CellStateFailed, false},
 		{intmodel.CellStateReady, false},
 		{intmodel.CellStatePending, false},
 		{intmodel.CellStateUnknown, false},
@@ -204,11 +206,16 @@ func TestShouldAutoDeleteCell(t *testing.T) {
 			want:          true,
 		},
 		{
-			name:          "fires_on_failed_state",
+			// Issue #407: Failed is the terminal Error state and must
+			// NOT trigger AutoDelete. `kuke run --rm` only auto-cleans
+			// on a *successful* run that subsequently exits cleanly;
+			// a startup-path failure preserves the cell so the operator
+			// has a diagnostic surface to inspect.
+			name:          "blocked_on_failed_state_per_issue_407",
 			autoDelete:    true,
 			newState:      intmodel.CellStateFailed,
 			readyObserved: true,
-			want:          true,
+			want:          false,
 		},
 		{
 			name:          "blocked_when_autoDelete_false",
@@ -562,10 +569,14 @@ func TestShouldWindDownCell(t *testing.T) {
 			want:     true,
 		},
 		{
-			name:     "fires_on_failed_state",
+			// Issue #407: Failed cells are already torn down at the
+			// startup-failure transition (markCellFailedAfterStartupFailure
+			// runs KillCell before stamping Failed), so the wind-down
+			// predicate must NOT re-fire on them.
+			name:     "blocked_on_failed_state_per_issue_407",
 			cell:     cell(specsWithWork, rootRunningStatus, true),
 			newState: intmodel.CellStateFailed,
-			want:     true,
+			want:     false,
 		},
 		{
 			name:     "blocked_when_state_not_trigger",
@@ -604,5 +615,29 @@ func TestShouldWindDownCell(t *testing.T) {
 				t.Errorf("shouldWindDownCell(...) = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestCellStateIsSticky locks down the issue-#407 contract that the terminal
+// Error state must be preserved across reconcile ticks. Failed is sticky;
+// every other state is re-derivable. Pairs with the auto-delete/wind-down
+// predicate tests above: together they ensure a Failed cell stays Failed
+// until the operator runs `kuke delete cell`.
+func TestCellStateIsSticky(t *testing.T) {
+	cases := []struct {
+		state intmodel.CellState
+		want  bool
+	}{
+		{intmodel.CellStateFailed, true},
+		{intmodel.CellStateStopped, false},
+		{intmodel.CellStateReady, false},
+		{intmodel.CellStatePending, false},
+		{intmodel.CellStateUnknown, false},
+	}
+	for _, tc := range cases {
+		if got := cellStateIsSticky(tc.state); got != tc.want {
+			t.Errorf("cellStateIsSticky(%v) = %v, want %v",
+				tc.state, got, tc.want)
+		}
 	}
 }

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -130,9 +130,73 @@ func cellTasksAllRunningFn(
 	return true
 }
 
+// markCellFailedAfterStartupFailure transitions the cell to the terminal
+// CellStateFailed state (issue #407) when a non-validation, containerd-touching
+// step in StartCell / StartContainer returns an error. The cleanup itself is:
+//
+//   - best-effort KillCell on the cell so any container that did start (e.g.,
+//     the root container) is torn down — the cell holds no running processes
+//     once it enters Failed;
+//   - reload from metadata so we overwrite KillCell's own Stopped-write, then
+//     stamp Failed and persist via UpdateCellMetadata.
+//
+// The original startup error is returned unmodified by the caller; this helper
+// only writes the new state so the reconciler can later observe it as terminal
+// (cellStateAutoDeleteTriggers excludes Failed, and ReconcileCell treats
+// originalState==Failed as sticky). Errors from the kill/persist sub-steps are
+// logged at WARN — propagating them would mask the original startup cause.
+func (r *Exec) markCellFailedAfterStartupFailure(cell intmodel.Cell, cause error) {
+	cellName := strings.TrimSpace(cell.Metadata.Name)
+	if _, killErr := r.KillCell(cell); killErr != nil {
+		r.logger.WarnContext(r.ctx,
+			"failed to kill siblings while transitioning cell to Failed",
+			"cell", cellName, "cause", cause.Error(), "error", killErr.Error())
+	}
+
+	reloaded, getErr := r.GetCell(cell)
+	if getErr == nil {
+		cell = reloaded
+	} else {
+		r.logger.DebugContext(r.ctx,
+			"failed to reload cell metadata after KillCell while transitioning to Failed",
+			"cell", cellName, "error", getErr.Error())
+	}
+
+	cell.Status.State = intmodel.CellStateFailed
+	if updErr := r.UpdateCellMetadata(cell); updErr != nil {
+		r.logger.WarnContext(r.ctx,
+			"failed to persist Failed state after cell startup failure",
+			"cell", cellName, "cause", cause.Error(), "error", updErr.Error())
+		return
+	}
+	r.logger.InfoContext(r.ctx,
+		"cell transitioned to Failed after startup failure",
+		"cell", cellName, "cause", cause.Error())
+}
+
 // StartCell starts the root container and all containers defined in the CellDoc.
 // The root container is started first, then all containers in doc.Spec.Containers are started.
-func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
+//
+// If a containerd-touching step fails (CreateContainer, StartContainer, CNI
+// attach, attachable chown), the cell is transitioned to CellStateFailed and
+// any containers that did start are killed — issue #407. Errors raised before
+// the provisioning phase (input validation, realm lookup, idempotent-skip
+// path) leave the cell's persisted state alone.
+func (r *Exec) StartCell(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
+	// provisionStarted gates the defer below: only flip the cell to Failed
+	// when we've already entered the destructive recreate path. Validation
+	// errors (missing cell name, missing realm) and the idempotent-skip
+	// return predate this flip and must not stamp Failed onto a healthy
+	// cell. cellForCleanup is captured by the closure and overwritten with
+	// the fully-resolved internalCell after GetCell succeeds so KillCell's
+	// internal GetCell has the realm/space/stack identifiers it needs.
+	var provisionStarted bool
+	cellForCleanup := cell
+	defer func() {
+		if retErr != nil && provisionStarted {
+			r.markCellFailedAfterStartupFailure(cellForCleanup, retErr)
+		}
+	}()
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
 		return intmodel.Cell{}, internalerrdefs.ErrCellNameRequired
@@ -165,6 +229,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	if err != nil {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", internalerrdefs.ErrGetCell, err)
 	}
+	cellForCleanup = internalCell
 
 	cellSpec := internalCell.Spec
 	cellID := cellSpec.ID
@@ -238,6 +303,11 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		)
 		return internalCell, nil
 	}
+
+	// Past the idempotent-skip path: any subsequent error means we crashed
+	// mid-provisioning. Arm the defer above so the cell flips to Failed and
+	// any siblings already started get killed (issue #407).
+	provisionStarted = true
 
 	// Check if container exists and clean it up
 	container, err := r.ctrClient.GetContainer(namespace, containerID)
@@ -732,8 +802,19 @@ func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	return internalCell, nil
 }
 
-// StartContainer starts a specific container in a cell.
-func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.Cell, error) {
+// StartContainer starts a specific container in a cell. Mirrors StartCell's
+// issue-#407 behavior: a containerd-touching failure (CreateContainer,
+// StartContainer, attachable chown) marks the cell as CellStateFailed and
+// kills any siblings the cell still holds, so a single non-root container
+// that cannot be brought up no longer leaves the cell wedged in Unknown.
+func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmodel.Cell, retErr error) {
+	var provisionStarted bool
+	cellForCleanup := cell
+	defer func() {
+		if retErr != nil && provisionStarted {
+			r.markCellFailedAfterStartupFailure(cellForCleanup, retErr)
+		}
+	}()
 	containerID = strings.TrimSpace(containerID)
 	if containerID == "" {
 		return intmodel.Cell{}, errors.New("container ID is required")
@@ -892,6 +973,11 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (intmodel.
 	// set at create time; repopulate from cell.Spec.NestedCgroupRuntime
 	// before BuildContainerSpec runs in the destructive recreate below.
 	foundContainerSpec.NestedCgroupRuntime = cell.Spec.NestedCgroupRuntime
+
+	// Past the idempotent recreate-prep: any subsequent error means we
+	// crashed mid-provisioning, so arm the defer to flip the cell to
+	// Failed (issue #407).
+	provisionStarted = true
 
 	// Recreate container fresh
 	attachOpts, attachErr := r.attachableBuildOpts(namespace, *foundContainerSpec, creds)


### PR DESCRIPTION
## Summary
- A non-root container that fails to create or start (OCI/runc, image pull, CNI, missing bind-mount) used to leave the cell in `Unknown` forever — daemon reconcile never swept it because the auto-delete predicate only fires on `Stopped`, so `Spec`, cgroup, PIDs, and netns stayed pinned indefinitely (issue #407 repro: `kukeon-pr-reviewer-54bb2f`).
- `runner.StartCell` and `runner.StartContainer` now arm a deferred cleanup once they enter the destructive provisioning phase: any error past that point flips the cell to `CellStateFailed`, runs `KillCell` so any sibling that *did* start (e.g. the root) is torn down, then persists the Failed state. The original startup error returns to the caller unmodified.
- The reconciler now treats `CellStateFailed` as sticky (`cellStateIsSticky`): the populate pass still refreshes per-container statuses for `kuke get cell -o yaml`, but the cell-level state is never re-derived. Combined with `cellStateAutoDeleteTriggers` losing its `Failed` entry, `kuke run --rm` will no longer auto-clean a Failed cell — that's a deliberate departure from `docker run --rm` so the diagnostic surface survives until the operator runs `kuke delete cell`. `kuke delete cell` already accepts any state, so no `--force` is needed.

## Test plan
- [x] `make test` — full Go unit/integration suite (pkg `internal/ctr` runs ~70s).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make dev-init` — daemon-parity tail printed both `kuke get realms` and `kuke get realms --no-daemon` showing `default` + `kuke-system` both `Ready` under `/kukeon/...`.
- [x] New / updated unit tests:
  - `TestCellStateIsSticky` — new predicate covers Failed-sticky reconciler behavior.
  - `TestCellStateAutoDeleteTriggers` — pinned Failed → `false` (was `true`).
  - `TestShouldAutoDeleteCell/blocked_on_failed_state_per_issue_407` — Failed no longer triggers `--rm` auto-delete.
  - `TestShouldWindDownCell/blocked_on_failed_state_per_issue_407` — Failed no longer triggers wind-down.
  - `TestDeleteCell_FailedCellDeletesWithoutForce` — controller-level confirmation that the explicit `kuke delete cell` path works on a Failed cell with no extra flag.
- [ ] Integration test that exercises a real `runner.StartCell` failure path through the `ctr.Client` fake — skipped; the helper relies on `r.KillCell`, which in turn does CNI detach + cgroup reads against a live containerd. Pure-predicate coverage above plus the smoke test on `dev-init` cover the wiring; a heavier fake is a separate follow-up if reviewers want it.
- [ ] `pre-commit run` — not run; `pre-commit` binary is not installed on this dev host. CI hooks remain authoritative.

Closes #407