### PR TITLE
feat: render kuketty capture-file fields in terminal spec (phase 2)

### DIFF
--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -182,6 +182,14 @@ func (r *Exec) writeKukettyMetadata(
 ) error {
 	opts := []sbshbuilder.TerminalOption{
 		sbshbuilder.WithSocketFile(ctr.AttachableSocketPath),
+		// Capture file is anchored to the kukeon-controlled per-container
+		// tty dir so `kuke log` (which tails ContainerCapturePath on the
+		// host) and the in-container writer see the same inode through the
+		// directory bind mount. Without an explicit WithCaptureFile, sbsh's
+		// profile builder derives a capture path from runPath + ID that
+		// would land outside the bind-mount, hiding the transcript from the
+		// host.
+		sbshbuilder.WithCaptureFile(ctr.AttachableCapturePath),
 		// DisableSetPrompt: phase 4 (#290) wires the cell's Tty.Prompt
 		// through to sbsh's PS1 rewriting; until then, leave the
 		// workload's PS1 alone — writing the default `(sbsh-$ID) $PS1`
@@ -189,11 +197,15 @@ func (r *Exec) writeKukettyMetadata(
 		// literal text into its stdin.
 		sbshbuilder.WithDisableSetPrompt(true),
 	}
-	if mode := socketModeIfGroupSet(kukeonGroupGID, ctr.AttachableSocketMode); mode != "" {
+	if mode := modeIfGroupSet(kukeonGroupGID, ctr.AttachableSocketMode); mode != "" {
 		opts = append(opts, sbshbuilder.WithSocketMode(mode))
+	}
+	if mode := modeIfGroupSet(kukeonGroupGID, ctr.AttachableCaptureMode); mode != "" {
+		opts = append(opts, sbshbuilder.WithCaptureMode(mode))
 	}
 	if kukeonGroupGID > 0 {
 		opts = append(opts, sbshbuilder.WithSocketGID(kukeonGroupGID))
+		opts = append(opts, sbshbuilder.WithCaptureGID(kukeonGroupGID))
 	}
 	if len(workloadArgv) > 0 {
 		opts = append(opts, sbshbuilder.WithCommand(workloadArgv))
@@ -256,11 +268,12 @@ func kukettyMetadataLabels(spec intmodel.ContainerSpec) map[string]string {
 	return out
 }
 
-// socketModeIfGroupSet returns the octal-mode string only when the kukeon
+// modeIfGroupSet returns the octal-mode string only when the kukeon
 // group GID is configured; otherwise empty so kuketty applies the OS-default
-// (umask-clipped) mode — matching the legacy 0o600-owner-only fallback the
-// sbsh wrapper had when no kukeon group existed.
-func socketModeIfGroupSet(gid int, mode string) string {
+// (umask-clipped) mode on the per-terminal inode the mode applies to
+// (socket, capture file, log file). Matches the legacy 0o600-owner-only
+// fallback the sbsh wrapper had when no kukeon group existed.
+func modeIfGroupSet(gid int, mode string) string {
 	if gid > 0 {
 		return mode
 	}

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -106,6 +106,12 @@ func TestAttachableTTYDirRootMode_SetsSGIDBit(t *testing.T) {
 // discriminator (api.APIVersionV1Beta1 + api.KindTerminal), and the
 // resolved workload argv lands in Spec.Command / Spec.CommandArgs (no
 // trailing argv on the OCI side).
+//
+// Phase 2 (#288) extends the same case to cover the capture-file fields:
+// CaptureFile is anchored to the per-container tty dir so `kuke log` and
+// sbsh's in-container writer see the same inode through the bind mount,
+// and CaptureMode/CaptureGID mirror the socket pattern (gated on kukeon
+// group configured).
 func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
 	r := newTestRunner(t)
 	dir := t.TempDir()
@@ -173,6 +179,19 @@ func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
 	if doc.Spec.SocketGID == nil || *doc.Spec.SocketGID != kukeonGID {
 		t.Errorf("Spec.SocketGID = %v, want pointer to %d", doc.Spec.SocketGID, kukeonGID)
 	}
+	// Capture fields (phase 2 #288): path is anchored on the kukeon-
+	// controlled in-container tty dir so the host-side ContainerCapturePath
+	// `kuke log` tails resolves to the same inode through the bind mount;
+	// mode + gid mirror the socket pattern.
+	if doc.Spec.CaptureFile != ctr.AttachableCapturePath {
+		t.Errorf("Spec.CaptureFile = %q, want %q", doc.Spec.CaptureFile, ctr.AttachableCapturePath)
+	}
+	if doc.Spec.CaptureMode.Perm() != 0o640 {
+		t.Errorf("Spec.CaptureMode = %v, want perm 0640", doc.Spec.CaptureMode)
+	}
+	if doc.Spec.CaptureGID == nil || *doc.Spec.CaptureGID != kukeonGID {
+		t.Errorf("Spec.CaptureGID = %v, want pointer to %d", doc.Spec.CaptureGID, kukeonGID)
+	}
 	// SetPrompt off in phase 1b: arbitrary workloads (nginx, python)
 	// would receive a literal `export PS1=…` injection into stdin
 	// otherwise. Phase 4 (#290) wires Tty.Prompt through the builder.
@@ -195,6 +214,12 @@ func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
 // is set on the spec so the sbsh server leaves the OS-default
 // (umask-clipped) permissions on the socket inode — matching the sbsh
 // wrapper's behavior on a host with no kukeon group.
+//
+// Phase 2 (#288) extends the same case to cover the capture-file fields:
+// CaptureFile is still anchored to the kukeon-controlled per-container tty
+// dir so `kuke log` resolves to the same inode regardless of group config;
+// CaptureMode + CaptureGID stay zero so sbsh's runner falls through to its
+// OS-default mode and leaves the group unchanged.
 func TestWriteKukettyMetadata_NoKukeonGroup(t *testing.T) {
 	r := newTestRunner(t)
 	dir := t.TempDir()
@@ -210,6 +235,19 @@ func TestWriteKukettyMetadata_NoKukeonGroup(t *testing.T) {
 	}
 	if doc.Spec.SocketGID != nil {
 		t.Errorf("Spec.SocketGID = %v, want nil (no kukeon group)", doc.Spec.SocketGID)
+	}
+	// CaptureFile is set regardless of group config: kuketty must write
+	// the transcript at the kukeon-controlled bind-mount path so `kuke log`
+	// keeps tailing the host-side peer of the same inode. Mode + GID stay
+	// zero so sbsh's runner defaults apply.
+	if doc.Spec.CaptureFile != ctr.AttachableCapturePath {
+		t.Errorf("Spec.CaptureFile = %q, want %q", doc.Spec.CaptureFile, ctr.AttachableCapturePath)
+	}
+	if doc.Spec.CaptureMode.Perm() != 0 {
+		t.Errorf("Spec.CaptureMode perm = %#o, want 0 (no kukeon group)", doc.Spec.CaptureMode.Perm())
+	}
+	if doc.Spec.CaptureGID != nil {
+		t.Errorf("Spec.CaptureGID = %v, want nil (no kukeon group)", doc.Spec.CaptureGID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Phase 2 of the kuketty cutover (#288). Renders `Spec.CaptureFile`, `Spec.CaptureMode`, and `Spec.CaptureGID` on the kukeond-built `TerminalDoc` so sbsh's runner inside kuketty writes the per-container capture transcript at the kukeon-controlled `/run/kukeon/tty/capture` path with the kukeon-group ownership the existing socket fields already apply.
- `CaptureFile` is anchored to `ctr.AttachableCapturePath` unconditionally for Attachable containers — without this, sbsh's profile builder would derive the path from `runPath + ID` and land outside the directory bind mount, hiding the transcript from the host (`kuke log` tails `ContainerCapturePath`, the host-side peer of the same inode).
- `CaptureMode` (`ctr.AttachableCaptureMode`, `0640`) and `CaptureGID` (`kukeonGroupGID`) are gated on the kukeon group being configured, mirroring the existing socket pattern in `writeKukettyMetadata`. With no kukeon group, both stay zero so sbsh's runner falls through to its OS-default mode and leaves the group unchanged — matching the legacy 0o600 fallback.
- Renames the now-shared helper `socketModeIfGroupSet` → `modeIfGroupSet` (single in-package caller, signature unchanged) so the capture mode reuses the same gating idiom without a misleading socket-specific name.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full unit suite passes; `internal/controller/runner` tests cover the populated and zero-config capture paths via extended `TestWriteKukettyMetadata_KukeonGroupSet` / `TestWriteKukettyMetadata_NoKukeonGroup` (assertions for `Spec.CaptureFile`, `Spec.CaptureMode`, `Spec.CaptureGID`).
- [x] `pre-commit run --files internal/controller/runner/attachable.go internal/controller/runner/attachable_test.go` — go-fmt, go-mod-tidy, golangci-lint, addlicense all pass.
- [x] `make dev-init` — full re-bootstrap, daemon-parity check, and `kuke attach` smoke against a kuketty-wrapped cell all green.
- [ ] `make test-e2e` — not run on the dev host (docker + containerd bring-up required, kuke attach smoke covered via `make dev-init` end-to-end).

Closes #288