### PR TITLE
feat: render kuketty log-file fields in terminal spec (phase 3)

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -478,7 +478,7 @@ func convertContainerTtyToInternal(in *ext.ContainerTty) *intmodel.ContainerTty 
 	if in.IsEmpty() {
 		return nil
 	}
-	out := &intmodel.ContainerTty{Prompt: in.Prompt}
+	out := &intmodel.ContainerTty{Prompt: in.Prompt, LogFile: in.LogFile}
 	if len(in.OnInit) > 0 {
 		out.OnInit = make([]intmodel.TtyStage, len(in.OnInit))
 		for i, s := range in.OnInit {
@@ -494,7 +494,7 @@ func buildContainerTtyExternalFromInternal(in *intmodel.ContainerTty) *ext.Conta
 	if in.IsEmpty() {
 		return nil
 	}
-	out := &ext.ContainerTty{Prompt: in.Prompt}
+	out := &ext.ContainerTty{Prompt: in.Prompt, LogFile: in.LogFile}
 	if len(in.OnInit) > 0 {
 		out.OnInit = make([]ext.TtyStage, len(in.OnInit))
 		for i, s := range in.OnInit {

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -1131,6 +1131,7 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 					{Script: "git pull"},
 					{Script: "claude"},
 				},
+				LogFile: "/run/kukeon/tty/log",
 			},
 		},
 	}
@@ -1143,6 +1144,9 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 	}
 	if internal.Spec.Tty.Prompt != input.Spec.Tty.Prompt {
 		t.Errorf("internal prompt = %q, want %q", internal.Spec.Tty.Prompt, input.Spec.Tty.Prompt)
+	}
+	if internal.Spec.Tty.LogFile != input.Spec.Tty.LogFile {
+		t.Errorf("internal logFile = %q, want %q", internal.Spec.Tty.LogFile, input.Spec.Tty.LogFile)
 	}
 	if len(internal.Spec.Tty.OnInit) != 2 ||
 		internal.Spec.Tty.OnInit[0].Script != "git pull" ||
@@ -1158,6 +1162,9 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 	}
 	if out.Spec.Tty.Prompt != input.Spec.Tty.Prompt {
 		t.Errorf("round-trip prompt = %q, want %q", out.Spec.Tty.Prompt, input.Spec.Tty.Prompt)
+	}
+	if out.Spec.Tty.LogFile != input.Spec.Tty.LogFile {
+		t.Errorf("round-trip logFile = %q, want %q", out.Spec.Tty.LogFile, input.Spec.Tty.LogFile)
 	}
 	if len(out.Spec.Tty.OnInit) != len(input.Spec.Tty.OnInit) {
 		t.Fatalf("round-trip onInit len = %d, want %d", len(out.Spec.Tty.OnInit), len(input.Spec.Tty.OnInit))
@@ -1263,9 +1270,11 @@ func TestContainerTtyRejectedWithoutAttachable(t *testing.T) {
 	}{
 		{"prompt only", &ext.ContainerTty{Prompt: `"\u\$ "`}},
 		{"onInit only", &ext.ContainerTty{OnInit: []ext.TtyStage{{Script: "echo"}}}},
-		{"both set", &ext.ContainerTty{
-			Prompt: `"\u\$ "`,
-			OnInit: []ext.TtyStage{{Script: "echo"}},
+		{"logFile only", &ext.ContainerTty{LogFile: "/run/kukeon/tty/log"}},
+		{"all set", &ext.ContainerTty{
+			Prompt:  `"\u\$ "`,
+			OnInit:  []ext.TtyStage{{Script: "echo"}},
+			LogFile: "/run/kukeon/tty/log",
 		}},
 	}
 	for _, tc := range cases {

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -207,6 +207,25 @@ func (r *Exec) writeKukettyMetadata(
 		opts = append(opts, sbshbuilder.WithSocketGID(kukeonGroupGID))
 		opts = append(opts, sbshbuilder.WithCaptureGID(kukeonGroupGID))
 	}
+	// Log file is opt-in per-container via Tty.LogFile (phase 3 #289):
+	// when set, the daemon passes the path verbatim plus the kukeon-
+	// group-derived mode/GID (matches socket/capture treatment); when
+	// unset, the daemon clears sbsh-builder's auto-derived default
+	// after BuildTerminalSpec so the rendered Spec.LogFile stays zero.
+	// Empty Spec.LogFile is the contract kuketty's openTerminalLogger
+	// (cmd/kuketty/main.go) and sbsh's runner.applyLogFilePerms both
+	// honor as "no log file configured" — so a workload without
+	// Tty.LogFile produces no log writer setup end-to-end.
+	logFileConfigured := spec.Tty != nil && spec.Tty.LogFile != ""
+	if logFileConfigured {
+		opts = append(opts, sbshbuilder.WithLogFile(spec.Tty.LogFile))
+		if mode := modeIfGroupSet(kukeonGroupGID, ctr.AttachableLogFileMode); mode != "" {
+			opts = append(opts, sbshbuilder.WithLogFileMode(mode))
+		}
+		if kukeonGroupGID > 0 {
+			opts = append(opts, sbshbuilder.WithLogFileGID(kukeonGroupGID))
+		}
+	}
 	if len(workloadArgv) > 0 {
 		opts = append(opts, sbshbuilder.WithCommand(workloadArgv))
 	}
@@ -214,6 +233,21 @@ func (r *Exec) writeKukettyMetadata(
 	terminalSpec, err := sbshbuilder.BuildTerminalSpec(r.ctx, r.logger, ctr.AttachableTTYDir, opts...)
 	if err != nil {
 		return fmt.Errorf("build kuketty terminal spec: %w", err)
+	}
+	if !logFileConfigured {
+		// sbsh's profile builder unconditionally derives a default
+		// LogFile path from runPath + terminalID when the caller
+		// passes no WithLogFile. That default would land at
+		// /run/kukeon/tty/terminals/<id>/log inside the container —
+		// host-visible through the bind mount, but at a location the
+		// daemon does not advertise. Clearing the field lets kuketty's
+		// openTerminalLogger fall through to a discard logger and
+		// keeps sbsh's runner.applyLogFilePerms a no-op, so a cell
+		// without Tty.LogFile produces no log file at all (issue
+		// #289 AC #2).
+		terminalSpec.LogFile = ""
+		terminalSpec.LogFileMode = 0
+		terminalSpec.LogFileGID = nil
 	}
 
 	doc := sbshapi.TerminalDoc{

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -192,6 +192,19 @@ func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
 	if doc.Spec.CaptureGID == nil || *doc.Spec.CaptureGID != kukeonGID {
 		t.Errorf("Spec.CaptureGID = %v, want pointer to %d", doc.Spec.CaptureGID, kukeonGID)
 	}
+	// Log fields (phase 3 #289) stay zero when the spec carries no
+	// Tty.LogFile, even with the kukeon group configured: the log writer
+	// is opt-in per-container and a kukeon-group-configured host must
+	// not silently start writing sbsh's runtime log on every workload.
+	if doc.Spec.LogFile != "" {
+		t.Errorf("Spec.LogFile = %q, want empty (no Tty.LogFile)", doc.Spec.LogFile)
+	}
+	if doc.Spec.LogFileMode.Perm() != 0 {
+		t.Errorf("Spec.LogFileMode perm = %#o, want 0 (no Tty.LogFile)", doc.Spec.LogFileMode.Perm())
+	}
+	if doc.Spec.LogFileGID != nil {
+		t.Errorf("Spec.LogFileGID = %v, want nil (no Tty.LogFile)", doc.Spec.LogFileGID)
+	}
 	// SetPrompt off in phase 1b: arbitrary workloads (nginx, python)
 	// would receive a literal `export PS1=…` injection into stdin
 	// otherwise. Phase 4 (#290) wires Tty.Prompt through the builder.
@@ -248,6 +261,94 @@ func TestWriteKukettyMetadata_NoKukeonGroup(t *testing.T) {
 	}
 	if doc.Spec.CaptureGID != nil {
 		t.Errorf("Spec.CaptureGID = %v, want nil (no kukeon group)", doc.Spec.CaptureGID)
+	}
+	// Log fields (phase 3 #289) stay zero with no Tty.LogFile and no
+	// kukeon group — the same opt-in invariant as the group-set case.
+	if doc.Spec.LogFile != "" {
+		t.Errorf("Spec.LogFile = %q, want empty (no Tty.LogFile)", doc.Spec.LogFile)
+	}
+	if doc.Spec.LogFileMode.Perm() != 0 {
+		t.Errorf("Spec.LogFileMode perm = %#o, want 0 (no Tty.LogFile)", doc.Spec.LogFileMode.Perm())
+	}
+	if doc.Spec.LogFileGID != nil {
+		t.Errorf("Spec.LogFileGID = %v, want nil (no Tty.LogFile)", doc.Spec.LogFileGID)
+	}
+}
+
+// TestWriteKukettyMetadata_LogFileSet locks phase 3 (#289) rendering when
+// the cell's container-tty config opts into the sbsh runner log writer:
+// Spec.LogFile carries the user-supplied path verbatim (no daemon-side
+// path rewriting — operators choose where it lands); LogFileMode and
+// LogFileGID mirror the socket/capture treatment, gated on the kukeon
+// group being configured. The two subcases fix the exhaustive matrix
+// against silent regressions.
+func TestWriteKukettyMetadata_LogFileSet(t *testing.T) {
+	cases := []struct {
+		name        string
+		kukeonGID   int
+		wantMode    os.FileMode
+		wantGIDPtr  bool
+		wantGIDVal  int
+		logFilePath string
+	}{
+		{
+			// Kukeon group configured: mode + gid filled in so a
+			// non-root operator in the kukeon group can read the log.
+			name:        "kukeon group set: mode+gid populated",
+			kukeonGID:   986,
+			wantMode:    0o640,
+			wantGIDPtr:  true,
+			wantGIDVal:  986,
+			logFilePath: ctr.AttachableLogfilePath,
+		},
+		{
+			// No kukeon group: mode+gid stay zero so sbsh's runner
+			// applies its OS-default umask-clipped permissions and
+			// leaves the group untouched (matches socket/capture).
+			name:        "no kukeon group: mode+gid stay zero",
+			kukeonGID:   0,
+			wantMode:    0,
+			wantGIDPtr:  false,
+			logFilePath: ctr.AttachableLogfilePath,
+		},
+		{
+			// User-supplied path outside the bind-mount: passed
+			// through verbatim. The operator owns the choice;
+			// the daemon does not rewrite or anchor it.
+			name:        "non-bind-mount path passed through verbatim",
+			kukeonGID:   986,
+			wantMode:    0o640,
+			wantGIDPtr:  true,
+			wantGIDVal:  986,
+			logFilePath: "/var/log/sbsh.log",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newTestRunner(t)
+			dir := t.TempDir()
+			path := filepath.Join(dir, "kuketty-metadata.json")
+			spec := intmodel.ContainerSpec{
+				ID:  "c1",
+				Tty: &intmodel.ContainerTty{LogFile: tc.logFilePath},
+			}
+			if err := r.writeKukettyMetadata(path, spec, tc.kukeonGID, []string{"/bin/sh"}); err != nil {
+				t.Fatalf("writeKukettyMetadata: %v", err)
+			}
+			doc := readDoc(t, path)
+			if doc.Spec.LogFile != tc.logFilePath {
+				t.Errorf("Spec.LogFile = %q, want %q", doc.Spec.LogFile, tc.logFilePath)
+			}
+			if doc.Spec.LogFileMode.Perm() != tc.wantMode {
+				t.Errorf("Spec.LogFileMode perm = %#o, want %#o", doc.Spec.LogFileMode.Perm(), tc.wantMode)
+			}
+			switch {
+			case tc.wantGIDPtr && (doc.Spec.LogFileGID == nil || *doc.Spec.LogFileGID != tc.wantGIDVal):
+				t.Errorf("Spec.LogFileGID = %v, want pointer to %d", doc.Spec.LogFileGID, tc.wantGIDVal)
+			case !tc.wantGIDPtr && doc.Spec.LogFileGID != nil:
+				t.Errorf("Spec.LogFileGID = %v, want nil", doc.Spec.LogFileGID)
+			}
+		})
 	}
 }
 

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -105,8 +105,9 @@ type ContainerSpec struct {
 // ContainerTty mirrors the v1beta1 ContainerTty payload. See the v1beta1
 // type for field semantics.
 type ContainerTty struct {
-	Prompt string
-	OnInit []TtyStage
+	Prompt  string
+	OnInit  []TtyStage
+	LogFile string
 }
 
 // TtyStage mirrors the v1beta1 TtyStage payload.
@@ -120,6 +121,9 @@ func (t *ContainerTty) IsEmpty() bool {
 		return true
 	}
 	if t.Prompt != "" {
+		return false
+	}
+	if t.LogFile != "" {
 		return false
 	}
 	for _, s := range t.OnInit {

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -119,6 +119,17 @@ type ContainerTty struct {
 	Prompt string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
 	// OnInit are scripts run once when the wrapped shell starts, in order.
 	OnInit []TtyStage `json:"onInit,omitempty" yaml:"onInit,omitempty"`
+	// LogFile is the in-container path where sbsh's runner writes its
+	// runtime/debug log. Empty (the default) means sbsh's runner skips
+	// log-writer setup entirely. Set this to a path inside the kuketty
+	// tty bind mount (e.g. "/run/kukeon/tty/log") if the operator wants
+	// the log file host-visible through the directory bind mount; any
+	// other in-container path is accepted and just stays inside the
+	// container's overlay. Mode and GID are not user-configurable here
+	// — the daemon applies its system-wide AttachableLogFileMode and
+	// the kukeon-group GID, gated on the kukeon group being configured
+	// (matches the SocketMode/CaptureMode treatment).
+	LogFile string `json:"logFile,omitempty" yaml:"logFile,omitempty"`
 }
 
 // TtyStage is a single onInit script entry. Wrapped in a struct rather than
@@ -136,6 +147,9 @@ func (t *ContainerTty) IsEmpty() bool {
 		return true
 	}
 	if t.Prompt != "" {
+		return false
+	}
+	if t.LogFile != "" {
 		return false
 	}
 	for _, s := range t.OnInit {


### PR DESCRIPTION
## Summary
- Phase 3 of #165: kukeond-side rendering of the sbsh runner log-file fields on the bind-mounted `TerminalDoc.Spec`. Adds `Tty.LogFile` to `ContainerTty` (external + internal), threads it through apischeme conversion + validation, and plumbs it into `writeKukettyMetadata` so an opt-in cell carries `LogFile`/`LogFileMode`/`LogFileGID` on the rendered spec.
- When `Tty.LogFile` is unset, the renderer zeros sbsh-builder's auto-derived `LogFile` default (and the mode/GID) on the resulting spec so kuketty's `openTerminalLogger` (cmd/kuketty/main.go:194) falls through to a discard logger and sbsh's `runner.applyLogFilePerms` no-ops — no log writer setup end-to-end. Without that post-step the rendered field would carry sbsh's `runPath/terminals/<id>/log` derivation regardless of operator intent (smoke output captured this on the first iteration).
- Mode + GID mirror the existing socket/capture treatment (`AttachableLogFileMode = 0o640`, kukeon-group GID), gated on the kukeon group being configured. Out of scope: profile rendering — phase 4 (#290).

## Design call (please push back if wrong)
- `LogFile` is the only new knob exposed on `ContainerTty`; `LogFileMode` and `LogFileGID` reuse the system-wide `AttachableLogFileMode` constant + the daemon's resolved kukeon-group GID, matching socket/capture. Rationale: the host's kukeon group is the daemon's concern, not the cell author's, so the per-cell surface stays minimal. If the AC ("optional mode/GID") meant per-cell knobs for those too, happy to add.

## Test plan
- [x] `go build ./...` (clean)
- [x] `go vet ./...` (clean)
- [x] `make test` — full unit suite, including the new `TestWriteKukettyMetadata_LogFileSet` matrix (kukeon-group set / unset / non-bind-mount path) and the extended `TestContainerTtyRoundTripV1Beta1` + `TestContainerTtyRejectedWithoutAttachable` coverage for the new field
- [x] `gofmt -l` clean on changed files
- [x] `make dev-init` — full daemon parity check + `kuke attach` smoke against a kuketty-wrapped cell exited cleanly (verifies the empty-`LogFile` path on a real container)
- [ ] `make test-e2e` — not run; the `e2e/` suite exercises broader attach/cell scenarios but the change is locked by the smoke above plus the unit matrix; reviewer can re-run on a clean host if desired

Closes #289