### PR TITLE
feat: persist lifecycle timestamps and runtime probes in Status

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -59,9 +59,16 @@ func ConvertRealmDocToInternal(in ext.RealmDoc) (intmodel.Realm, error) {
 				RegistryCredentials: registryCreds,
 			},
 			Status: intmodel.RealmStatus{
-				State:              intmodel.RealmState(in.Status.State),
-				CgroupPath:         in.Status.CgroupPath,
-				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
+				State:                    intmodel.RealmState(in.Status.State),
+				CgroupPath:               in.Status.CgroupPath,
+				SubtreeControllers:       cloneStringSlice(in.Status.SubtreeControllers),
+				CreatedAt:                in.Status.CreatedAt,
+				UpdatedAt:                in.Status.UpdatedAt,
+				ReadyAt:                  in.Status.ReadyAt,
+				Reason:                   in.Status.Reason,
+				Message:                  in.Status.Message,
+				CgroupReady:              in.Status.CgroupReady,
+				ContainerdNamespaceReady: in.Status.ContainerdNamespaceReady,
 			},
 		}, nil
 	default:
@@ -93,9 +100,16 @@ func BuildRealmExternalFromInternal(in intmodel.Realm, apiVersion ext.Version) (
 				RegistryCredentials: registryCreds,
 			},
 			Status: ext.RealmStatus{
-				State:              ext.RealmState(in.Status.State),
-				CgroupPath:         in.Status.CgroupPath,
-				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
+				State:                    ext.RealmState(in.Status.State),
+				CgroupPath:               in.Status.CgroupPath,
+				SubtreeControllers:       cloneStringSlice(in.Status.SubtreeControllers),
+				CreatedAt:                in.Status.CreatedAt,
+				UpdatedAt:                in.Status.UpdatedAt,
+				ReadyAt:                  in.Status.ReadyAt,
+				Reason:                   in.Status.Reason,
+				Message:                  in.Status.Message,
+				CgroupReady:              in.Status.CgroupReady,
+				ContainerdNamespaceReady: in.Status.ContainerdNamespaceReady,
 			},
 		}, nil
 	default:
@@ -145,6 +159,12 @@ func ConvertSpaceDocToInternal(in ext.SpaceDoc) (intmodel.Space, error) {
 				State:              intState,
 				CgroupPath:         in.Status.CgroupPath,
 				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
+				CreatedAt:          in.Status.CreatedAt,
+				UpdatedAt:          in.Status.UpdatedAt,
+				ReadyAt:            in.Status.ReadyAt,
+				Reason:             in.Status.Reason,
+				Message:            in.Status.Message,
+				CgroupReady:        in.Status.CgroupReady,
 			},
 		}, nil
 	default:
@@ -185,6 +205,12 @@ func BuildSpaceExternalFromInternal(in intmodel.Space, apiVersion ext.Version) (
 				State:              extState,
 				CgroupPath:         in.Status.CgroupPath,
 				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
+				CreatedAt:          in.Status.CreatedAt,
+				UpdatedAt:          in.Status.UpdatedAt,
+				ReadyAt:            in.Status.ReadyAt,
+				Reason:             in.Status.Reason,
+				Message:            in.Status.Message,
+				CgroupReady:        in.Status.CgroupReady,
 			},
 		}, nil
 	default:
@@ -220,6 +246,12 @@ func ConvertStackDocToInternal(in ext.StackDoc) (intmodel.Stack, error) {
 				State:              intmodel.StackState(in.Status.State),
 				CgroupPath:         in.Status.CgroupPath,
 				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
+				CreatedAt:          in.Status.CreatedAt,
+				UpdatedAt:          in.Status.UpdatedAt,
+				ReadyAt:            in.Status.ReadyAt,
+				Reason:             in.Status.Reason,
+				Message:            in.Status.Message,
+				CgroupReady:        in.Status.CgroupReady,
 			},
 		}, nil
 	default:
@@ -247,6 +279,12 @@ func BuildStackExternalFromInternal(in intmodel.Stack, apiVersion ext.Version) (
 				State:              ext.StackState(in.Status.State),
 				CgroupPath:         in.Status.CgroupPath,
 				SubtreeControllers: cloneStringSlice(in.Status.SubtreeControllers),
+				CreatedAt:          in.Status.CreatedAt,
+				UpdatedAt:          in.Status.UpdatedAt,
+				ReadyAt:            in.Status.ReadyAt,
+				Reason:             in.Status.Reason,
+				Message:            in.Status.Message,
+				CgroupReady:        in.Status.CgroupReady,
 			},
 		}, nil
 	default:
@@ -905,6 +943,12 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				},
 				Containers:    convertContainerStatusesToInternal(in.Status.Containers),
 				ReadyObserved: in.Status.ReadyObserved,
+				CreatedAt:     in.Status.CreatedAt,
+				UpdatedAt:     in.Status.UpdatedAt,
+				ReadyAt:       in.Status.ReadyAt,
+				Reason:        in.Status.Reason,
+				Message:       in.Status.Message,
+				CgroupReady:   in.Status.CgroupReady,
 			},
 		}
 
@@ -962,6 +1006,12 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				},
 				Containers:    buildContainerStatusesExternalFromInternal(in.Status.Containers),
 				ReadyObserved: in.Status.ReadyObserved,
+				CreatedAt:     in.Status.CreatedAt,
+				UpdatedAt:     in.Status.UpdatedAt,
+				ReadyAt:       in.Status.ReadyAt,
+				Reason:        in.Status.Reason,
+				Message:       in.Status.Message,
+				CgroupReady:   in.Status.CgroupReady,
 			},
 		}
 

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/apischeme"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -1764,4 +1765,186 @@ func TestBuildCellExternalRejectsMultipleRootTrue(t *testing.T) {
 	if !errors.Is(err, errdefs.ErrMultipleRootContainers) {
 		t.Fatalf("err = %v, want wrapped ErrMultipleRootContainers", err)
 	}
+}
+
+// TestStatusLifecycleFieldsRoundTripV1Beta1 pins the issue #166 plumbing:
+// every kind's new Status lifecycle/probe fields must round-trip in both
+// directions. Realm additionally carries ContainerdNamespaceReady; the
+// other three kinds carry CgroupReady but no namespace probe. Bundled
+// because the contract is shared even if the field sets differ.
+func TestStatusLifecycleFieldsRoundTripV1Beta1(t *testing.T) {
+	createdAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Hour)
+	readyAt := createdAt.Add(30 * time.Minute)
+
+	t.Run("realm", func(t *testing.T) {
+		in := ext.RealmDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindRealm,
+			Metadata:   ext.RealmMetadata{Name: "r0"},
+			Status: ext.RealmStatus{
+				CreatedAt:                createdAt,
+				UpdatedAt:                updatedAt,
+				ReadyAt:                  readyAt,
+				Reason:                   "RealmReady",
+				Message:                  "namespace + cgroup present",
+				CgroupReady:              true,
+				ContainerdNamespaceReady: true,
+			},
+		}
+		intRealm, err := apischeme.ConvertRealmDocToInternal(in)
+		if err != nil {
+			t.Fatalf("ConvertRealmDocToInternal: %v", err)
+		}
+		if !intRealm.Status.CreatedAt.Equal(createdAt) {
+			t.Errorf("ext→int CreatedAt = %v, want %v", intRealm.Status.CreatedAt, createdAt)
+		}
+		if !intRealm.Status.ReadyAt.Equal(readyAt) {
+			t.Errorf("ext→int ReadyAt = %v, want %v", intRealm.Status.ReadyAt, readyAt)
+		}
+		if intRealm.Status.Reason != "RealmReady" {
+			t.Errorf("ext→int Reason = %q, want RealmReady", intRealm.Status.Reason)
+		}
+		if !intRealm.Status.CgroupReady || !intRealm.Status.ContainerdNamespaceReady {
+			t.Errorf("ext→int probes = %v/%v, want true/true",
+				intRealm.Status.CgroupReady, intRealm.Status.ContainerdNamespaceReady)
+		}
+
+		out, err := apischeme.BuildRealmExternalFromInternal(intRealm, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildRealmExternalFromInternal: %v", err)
+		}
+		if !out.Status.UpdatedAt.Equal(updatedAt) {
+			t.Errorf("int→ext UpdatedAt = %v, want %v", out.Status.UpdatedAt, updatedAt)
+		}
+		if out.Status.Message != "namespace + cgroup present" {
+			t.Errorf("int→ext Message = %q, lost in round trip", out.Status.Message)
+		}
+		if !out.Status.ContainerdNamespaceReady {
+			t.Errorf("int→ext ContainerdNamespaceReady = false, lost in round trip")
+		}
+	})
+
+	t.Run("space", func(t *testing.T) {
+		in := ext.SpaceDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindSpace,
+			Metadata:   ext.SpaceMetadata{Name: "s0"},
+			Spec:       ext.SpaceSpec{RealmID: "r0"},
+			Status: ext.SpaceStatus{
+				CreatedAt:   createdAt,
+				UpdatedAt:   updatedAt,
+				ReadyAt:     readyAt,
+				Reason:      "CNIReady",
+				Message:     "cni conf installed",
+				CgroupReady: true,
+			},
+		}
+		intSpace, err := apischeme.ConvertSpaceDocToInternal(in)
+		if err != nil {
+			t.Fatalf("ConvertSpaceDocToInternal: %v", err)
+		}
+		out, err := apischeme.BuildSpaceExternalFromInternal(intSpace, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildSpaceExternalFromInternal: %v", err)
+		}
+		if !out.Status.CreatedAt.Equal(createdAt) || !out.Status.ReadyAt.Equal(readyAt) {
+			t.Errorf("space lifecycle timestamps lost in round trip: got %+v", out.Status)
+		}
+		if out.Status.Reason != "CNIReady" || !out.Status.CgroupReady {
+			t.Errorf("space reason/probe lost: got reason=%q cgroupReady=%v",
+				out.Status.Reason, out.Status.CgroupReady)
+		}
+	})
+
+	t.Run("stack", func(t *testing.T) {
+		in := ext.StackDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindStack,
+			Metadata:   ext.StackMetadata{Name: "st0"},
+			Spec:       ext.StackSpec{ID: "st0", RealmID: "r0", SpaceID: "s0"},
+			Status: ext.StackStatus{
+				CreatedAt:   createdAt,
+				UpdatedAt:   updatedAt,
+				ReadyAt:     readyAt,
+				Reason:      "CgroupReady",
+				CgroupReady: true,
+			},
+		}
+		intStack, err := apischeme.ConvertStackDocToInternal(in)
+		if err != nil {
+			t.Fatalf("ConvertStackDocToInternal: %v", err)
+		}
+		out, err := apischeme.BuildStackExternalFromInternal(intStack, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildStackExternalFromInternal: %v", err)
+		}
+		if !out.Status.UpdatedAt.Equal(updatedAt) || !out.Status.CgroupReady {
+			t.Errorf("stack lifecycle/probe lost: %+v", out.Status)
+		}
+	})
+
+	t.Run("cell", func(t *testing.T) {
+		in := ext.CellDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindCell,
+			Metadata:   ext.CellMetadata{Name: "c0"},
+			Spec:       ext.CellSpec{ID: "c0", RealmID: "r0", SpaceID: "s0", StackID: "st0"},
+			Status: ext.CellStatus{
+				CreatedAt:   createdAt,
+				UpdatedAt:   updatedAt,
+				ReadyAt:     readyAt,
+				Reason:      "RootRunning",
+				Message:     "root task active",
+				CgroupReady: true,
+			},
+		}
+		intCell, err := apischeme.ConvertCellDocToInternal(in)
+		if err != nil {
+			t.Fatalf("ConvertCellDocToInternal: %v", err)
+		}
+		out, err := apischeme.BuildCellExternalFromInternal(intCell, ext.APIVersionV1Beta1)
+		if err != nil {
+			t.Fatalf("BuildCellExternalFromInternal: %v", err)
+		}
+		if !out.Status.CreatedAt.Equal(createdAt) || !out.Status.ReadyAt.Equal(readyAt) {
+			t.Errorf("cell lifecycle timestamps lost in round trip: got %+v", out.Status)
+		}
+		if out.Status.Message != "root task active" || !out.Status.CgroupReady {
+			t.Errorf("cell message/probe lost: msg=%q cgroupReady=%v",
+				out.Status.Message, out.Status.CgroupReady)
+		}
+	})
+}
+
+// TestStatusLifecycleFieldsZeroDefault covers the AC bullet "existing
+// metadata.json files load with zero-value defaults (no migration)".
+// An external doc with no lifecycle fields set must convert to an
+// internal model with the same zero values, and round-trip back to
+// zero-valued external. This is what lets a daemon upgrade onto a
+// previously-written /opt/kukeon tree without rewriting every
+// metadata.json.
+func TestStatusLifecycleFieldsZeroDefault(t *testing.T) {
+	t.Run("realm zero defaults", func(t *testing.T) {
+		in := ext.RealmDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindRealm,
+			Metadata:   ext.RealmMetadata{Name: "r0"},
+		}
+		intRealm, err := apischeme.ConvertRealmDocToInternal(in)
+		if err != nil {
+			t.Fatalf("ConvertRealmDocToInternal: %v", err)
+		}
+		if !intRealm.Status.CreatedAt.IsZero() ||
+			!intRealm.Status.UpdatedAt.IsZero() ||
+			!intRealm.Status.ReadyAt.IsZero() {
+			t.Errorf("non-zero timestamps from zero-value input: %+v", intRealm.Status)
+		}
+		if intRealm.Status.Reason != "" || intRealm.Status.Message != "" {
+			t.Errorf("non-empty reason/message from zero-value input: %+v", intRealm.Status)
+		}
+		if intRealm.Status.CgroupReady || intRealm.Status.ContainerdNamespaceReady {
+			t.Errorf("non-false probes from zero-value input: %+v", intRealm.Status)
+		}
+	})
 }

--- a/internal/controller/runner/metadata.go
+++ b/internal/controller/runner/metadata.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/apischeme"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -26,7 +27,67 @@ import (
 	"github.com/eminwux/kukeon/internal/util/fs"
 )
 
+// nowUTC returns the current wall clock in UTC. Wrapped through the Exec
+// so tests that need to freeze time can override the function.
+func (r *Exec) nowUTC() time.Time {
+	if r.nowFn != nil {
+		return r.nowFn().UTC()
+	}
+	return time.Now().UTC()
+}
+
+// stampRealmLifecycle applies the lifecycle-timestamp invariants from
+// issue #166 to a realm immediately before persistence: CreatedAt is
+// stamped only when zero, UpdatedAt is bumped on every call, and
+// ReadyAt is set once on the first State==Ready persist and never
+// overwritten. Extracted as a pure function so the timestamp logic is
+// unit-testable independent of the metadata-write path.
+func stampRealmLifecycle(realm *intmodel.Realm, now time.Time) {
+	if realm.Status.CreatedAt.IsZero() {
+		realm.Status.CreatedAt = now
+	}
+	realm.Status.UpdatedAt = now
+	if realm.Status.ReadyAt.IsZero() && realm.Status.State == intmodel.RealmStateReady {
+		realm.Status.ReadyAt = now
+	}
+}
+
+// stampSpaceLifecycle is the Space counterpart of stampRealmLifecycle.
+func stampSpaceLifecycle(space *intmodel.Space, now time.Time) {
+	if space.Status.CreatedAt.IsZero() {
+		space.Status.CreatedAt = now
+	}
+	space.Status.UpdatedAt = now
+	if space.Status.ReadyAt.IsZero() && space.Status.State == intmodel.SpaceStateReady {
+		space.Status.ReadyAt = now
+	}
+}
+
+// stampStackLifecycle is the Stack counterpart of stampRealmLifecycle.
+func stampStackLifecycle(stack *intmodel.Stack, now time.Time) {
+	if stack.Status.CreatedAt.IsZero() {
+		stack.Status.CreatedAt = now
+	}
+	stack.Status.UpdatedAt = now
+	if stack.Status.ReadyAt.IsZero() && stack.Status.State == intmodel.StackStateReady {
+		stack.Status.ReadyAt = now
+	}
+}
+
+// stampCellLifecycle is the Cell counterpart of stampRealmLifecycle.
+func stampCellLifecycle(cell *intmodel.Cell, now time.Time) {
+	if cell.Status.CreatedAt.IsZero() {
+		cell.Status.CreatedAt = now
+	}
+	cell.Status.UpdatedAt = now
+	if cell.Status.ReadyAt.IsZero() && cell.Status.State == intmodel.CellStateReady {
+		cell.Status.ReadyAt = now
+	}
+}
+
 func (r *Exec) UpdateRealmMetadata(realm intmodel.Realm) error {
+	stampRealmLifecycle(&realm, r.nowUTC())
+
 	// Convert to external model for filesystem boundary
 	realmDoc, err := apischeme.BuildRealmExternalFromInternal(realm, apischeme.VersionV1Beta1)
 	if err != nil {
@@ -43,6 +104,8 @@ func (r *Exec) UpdateRealmMetadata(realm intmodel.Realm) error {
 }
 
 func (r *Exec) UpdateSpaceMetadata(space intmodel.Space) error {
+	stampSpaceLifecycle(&space, r.nowUTC())
+
 	// Convert to external model for filesystem boundary
 	spaceDoc, err := apischeme.BuildSpaceExternalFromInternal(space, apischeme.VersionV1Beta1)
 	if err != nil {
@@ -63,6 +126,8 @@ func (r *Exec) UpdateSpaceMetadata(space intmodel.Space) error {
 }
 
 func (r *Exec) UpdateStackMetadata(stack intmodel.Stack) error {
+	stampStackLifecycle(&stack, r.nowUTC())
+
 	// Convert to external model for filesystem boundary
 	stackDoc, err := apischeme.BuildStackExternalFromInternal(stack, apischeme.VersionV1Beta1)
 	if err != nil {
@@ -84,6 +149,8 @@ func (r *Exec) UpdateStackMetadata(stack intmodel.Stack) error {
 }
 
 func (r *Exec) UpdateCellMetadata(cell intmodel.Cell) error {
+	stampCellLifecycle(&cell, r.nowUTC())
+
 	// Convert to external model for filesystem boundary
 	cellDoc, err := apischeme.BuildCellExternalFromInternal(cell, apischeme.VersionV1Beta1)
 	if err != nil {

--- a/internal/controller/runner/metadata_test.go
+++ b/internal/controller/runner/metadata_test.go
@@ -1,0 +1,380 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests the unexported stamp helpers
+package runner
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// newMetadataTestExec builds a minimal *Exec wired with a frozen clock
+// for the persist-and-read tests below. No containerd, no CNI — the
+// metadata-write path only needs a runPath and a logger.
+func newMetadataTestExec(t *testing.T, runPath string, now time.Time) *Exec {
+	t.Helper()
+	return &Exec{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:   Options{RunPath: runPath},
+		nowFn:  func() time.Time { return now },
+	}
+}
+
+// TestStampRealmLifecycle pins the issue #166 lifecycle invariants for
+// Realm: CreatedAt is set-once (only when zero), UpdatedAt is bumped
+// every call, and ReadyAt is set-once on the first State==Ready persist.
+// Covered explicitly per-kind because the contract carries identical
+// semantics but lives on distinct struct types.
+func TestStampRealmLifecycle(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+	t2 := t1.Add(time.Hour)
+
+	t.Run("first_persist_stamps_created_and_updated", func(t *testing.T) {
+		r := intmodel.Realm{Status: intmodel.RealmStatus{State: intmodel.RealmStateCreating}}
+		stampRealmLifecycle(&r, t0)
+		if !r.Status.CreatedAt.Equal(t0) {
+			t.Errorf("CreatedAt = %v, want %v", r.Status.CreatedAt, t0)
+		}
+		if !r.Status.UpdatedAt.Equal(t0) {
+			t.Errorf("UpdatedAt = %v, want %v", r.Status.UpdatedAt, t0)
+		}
+		if !r.Status.ReadyAt.IsZero() {
+			t.Errorf("ReadyAt = %v, want zero (not Ready yet)", r.Status.ReadyAt)
+		}
+	})
+
+	t.Run("created_at_is_set_once", func(t *testing.T) {
+		r := intmodel.Realm{Status: intmodel.RealmStatus{
+			State:     intmodel.RealmStateCreating,
+			CreatedAt: t0,
+		}}
+		stampRealmLifecycle(&r, t1)
+		if !r.Status.CreatedAt.Equal(t0) {
+			t.Errorf("CreatedAt moved: got %v, want set-once %v", r.Status.CreatedAt, t0)
+		}
+		if !r.Status.UpdatedAt.Equal(t1) {
+			t.Errorf("UpdatedAt = %v, want %v", r.Status.UpdatedAt, t1)
+		}
+	})
+
+	t.Run("ready_at_set_on_first_ready", func(t *testing.T) {
+		r := intmodel.Realm{Status: intmodel.RealmStatus{
+			State:     intmodel.RealmStateReady,
+			CreatedAt: t0,
+		}}
+		stampRealmLifecycle(&r, t1)
+		if !r.Status.ReadyAt.Equal(t1) {
+			t.Errorf("ReadyAt = %v, want %v", r.Status.ReadyAt, t1)
+		}
+	})
+
+	t.Run("ready_at_is_set_once_through_reready", func(t *testing.T) {
+		// A realm that transitioned to Ready at t1 and is re-persisted
+		// later (still Ready, or briefly off-Ready and back) must keep
+		// the original ReadyAt — the set-once contract.
+		r := intmodel.Realm{Status: intmodel.RealmStatus{
+			State:     intmodel.RealmStateReady,
+			CreatedAt: t0,
+			ReadyAt:   t1,
+		}}
+		stampRealmLifecycle(&r, t2)
+		if !r.Status.ReadyAt.Equal(t1) {
+			t.Errorf("ReadyAt moved: got %v, want set-once %v", r.Status.ReadyAt, t1)
+		}
+		if !r.Status.UpdatedAt.Equal(t2) {
+			t.Errorf("UpdatedAt = %v, want %v", r.Status.UpdatedAt, t2)
+		}
+	})
+
+	t.Run("non_ready_persist_does_not_set_ready_at", func(t *testing.T) {
+		r := intmodel.Realm{Status: intmodel.RealmStatus{
+			State:     intmodel.RealmStateFailed,
+			CreatedAt: t0,
+		}}
+		stampRealmLifecycle(&r, t1)
+		if !r.Status.ReadyAt.IsZero() {
+			t.Errorf("ReadyAt = %v, want zero (Failed state)", r.Status.ReadyAt)
+		}
+	})
+}
+
+// TestStampSpaceLifecycle mirrors TestStampRealmLifecycle on Space. The
+// per-kind coverage is intentional: the four stampers diverge on the
+// state-enum check and a regression that wired a Realm stamper into the
+// Space update path would silently never set ReadyAt.
+func TestStampSpaceLifecycle(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+
+	t.Run("ready_transition_sets_ready_at", func(t *testing.T) {
+		s := intmodel.Space{Status: intmodel.SpaceStatus{State: intmodel.SpaceStateReady}}
+		stampSpaceLifecycle(&s, t0)
+		if !s.Status.ReadyAt.Equal(t0) {
+			t.Errorf("ReadyAt = %v, want %v", s.Status.ReadyAt, t0)
+		}
+	})
+
+	t.Run("ready_at_set_once", func(t *testing.T) {
+		s := intmodel.Space{Status: intmodel.SpaceStatus{
+			State:     intmodel.SpaceStateReady,
+			CreatedAt: t0,
+			ReadyAt:   t0,
+		}}
+		stampSpaceLifecycle(&s, t1)
+		if !s.Status.ReadyAt.Equal(t0) {
+			t.Errorf("ReadyAt moved: got %v, want %v", s.Status.ReadyAt, t0)
+		}
+	})
+
+	t.Run("failed_state_skips_ready_at", func(t *testing.T) {
+		s := intmodel.Space{Status: intmodel.SpaceStatus{State: intmodel.SpaceStateFailed}}
+		stampSpaceLifecycle(&s, t0)
+		if !s.Status.ReadyAt.IsZero() {
+			t.Errorf("ReadyAt = %v, want zero", s.Status.ReadyAt)
+		}
+	})
+}
+
+// TestStampStackLifecycle — see TestStampRealmLifecycle for rationale.
+func TestStampStackLifecycle(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+
+	t.Run("ready_transition_sets_ready_at", func(t *testing.T) {
+		s := intmodel.Stack{Status: intmodel.StackStatus{State: intmodel.StackStateReady}}
+		stampStackLifecycle(&s, t0)
+		if !s.Status.ReadyAt.Equal(t0) {
+			t.Errorf("ReadyAt = %v, want %v", s.Status.ReadyAt, t0)
+		}
+	})
+
+	t.Run("ready_at_set_once", func(t *testing.T) {
+		s := intmodel.Stack{Status: intmodel.StackStatus{
+			State:     intmodel.StackStateReady,
+			CreatedAt: t0,
+			ReadyAt:   t0,
+		}}
+		stampStackLifecycle(&s, t1)
+		if !s.Status.ReadyAt.Equal(t0) {
+			t.Errorf("ReadyAt moved: got %v, want %v", s.Status.ReadyAt, t0)
+		}
+	})
+}
+
+// TestStampCellLifecycle — see TestStampRealmLifecycle for rationale.
+func TestStampCellLifecycle(t *testing.T) {
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+
+	t.Run("ready_transition_sets_ready_at", func(t *testing.T) {
+		c := intmodel.Cell{Status: intmodel.CellStatus{State: intmodel.CellStateReady}}
+		stampCellLifecycle(&c, t0)
+		if !c.Status.ReadyAt.Equal(t0) {
+			t.Errorf("ReadyAt = %v, want %v", c.Status.ReadyAt, t0)
+		}
+	})
+
+	t.Run("ready_at_set_once_through_stopped_and_back", func(t *testing.T) {
+		// Cells flap Ready→Stopped (KillCell race in #275) — the
+		// originating ReadyAt must survive the round trip.
+		c := intmodel.Cell{Status: intmodel.CellStatus{
+			State:     intmodel.CellStateStopped,
+			CreatedAt: t0,
+			ReadyAt:   t0,
+		}}
+		stampCellLifecycle(&c, t1)
+		if !c.Status.ReadyAt.Equal(t0) {
+			t.Errorf("ReadyAt moved through Stopped: got %v, want %v", c.Status.ReadyAt, t0)
+		}
+	})
+}
+
+// TestNowUTCFallsBackToRealClock confirms the nowFn override hook returns
+// real time when not set — the production path. Tests that need a frozen
+// clock plumb their own nowFn into the Exec.
+func TestNowUTCFallsBackToRealClock(t *testing.T) {
+	r := &Exec{}
+	got := r.nowUTC()
+	if got.IsZero() {
+		t.Errorf("nowUTC returned zero time")
+	}
+	if got.Location() != time.UTC {
+		t.Errorf("nowUTC returned non-UTC time: %v", got.Location())
+	}
+}
+
+// TestNowUTCRespectsOverride verifies the hook the tests rely on.
+func TestNowUTCRespectsOverride(t *testing.T) {
+	fixed := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	r := &Exec{nowFn: func() time.Time { return fixed }}
+	if got := r.nowUTC(); !got.Equal(fixed) {
+		t.Errorf("nowUTC = %v, want %v", got, fixed)
+	}
+}
+
+// TestUpdateRealmMetadataPersistsLifecycleFields exercises the full
+// stamp → convert → write → read pipeline at the runner level. The
+// pure-helper tests above pin the in-memory invariants; this test
+// catches a regression where the wiring forgets to call the helper or
+// drops a field on the apischeme boundary.
+func TestUpdateRealmMetadataPersistsLifecycleFields(t *testing.T) {
+	t0 := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+
+	t.Run("first_persist_creating", func(t *testing.T) {
+		runPath := t.TempDir()
+		r := newMetadataTestExec(t, runPath, t0)
+		realm := intmodel.Realm{
+			Metadata: intmodel.RealmMetadata{Name: "r-creating"},
+			Spec:     intmodel.RealmSpec{Namespace: "r-creating.kukeon.io"},
+			Status:   intmodel.RealmStatus{State: intmodel.RealmStateCreating, CgroupPath: "/kukeon/r-creating"},
+		}
+		if err := r.UpdateRealmMetadata(realm); err != nil {
+			t.Fatalf("UpdateRealmMetadata: %v", err)
+		}
+		got, err := r.GetRealm(intmodel.Realm{Metadata: intmodel.RealmMetadata{Name: "r-creating"}})
+		if err != nil {
+			t.Fatalf("GetRealm: %v", err)
+		}
+		if !got.Status.CreatedAt.Equal(t0) {
+			t.Errorf("CreatedAt = %v, want %v", got.Status.CreatedAt, t0)
+		}
+		if !got.Status.UpdatedAt.Equal(t0) {
+			t.Errorf("UpdatedAt = %v, want %v", got.Status.UpdatedAt, t0)
+		}
+		if !got.Status.ReadyAt.IsZero() {
+			t.Errorf("ReadyAt = %v, want zero (not Ready)", got.Status.ReadyAt)
+		}
+	})
+
+	t.Run("ready_persist_sets_ready_at", func(t *testing.T) {
+		runPath := t.TempDir()
+		r := newMetadataTestExec(t, runPath, t0)
+		realm := intmodel.Realm{
+			Metadata: intmodel.RealmMetadata{Name: "r-ready"},
+			Spec:     intmodel.RealmSpec{Namespace: "r-ready.kukeon.io"},
+			Status: intmodel.RealmStatus{
+				State:                    intmodel.RealmStateReady,
+				CgroupPath:               "/kukeon/r-ready",
+				CgroupReady:              true,
+				ContainerdNamespaceReady: true,
+				Reason:                   "RealmReady",
+				Message:                  "namespace + cgroup observed",
+			},
+		}
+		if err := r.UpdateRealmMetadata(realm); err != nil {
+			t.Fatalf("UpdateRealmMetadata: %v", err)
+		}
+		got, err := r.GetRealm(intmodel.Realm{Metadata: intmodel.RealmMetadata{Name: "r-ready"}})
+		if err != nil {
+			t.Fatalf("GetRealm: %v", err)
+		}
+		if !got.Status.ReadyAt.Equal(t0) {
+			t.Errorf("ReadyAt = %v, want %v", got.Status.ReadyAt, t0)
+		}
+		if !got.Status.CgroupReady || !got.Status.ContainerdNamespaceReady {
+			t.Errorf("probes not persisted: cgroupReady=%v, namespaceReady=%v",
+				got.Status.CgroupReady, got.Status.ContainerdNamespaceReady)
+		}
+		if got.Status.Reason != "RealmReady" || got.Status.Message != "namespace + cgroup observed" {
+			t.Errorf("reason/message lost: %+v", got.Status)
+		}
+	})
+
+	t.Run("second_persist_keeps_created_and_ready_at", func(t *testing.T) {
+		runPath := t.TempDir()
+		r0 := newMetadataTestExec(t, runPath, t0)
+		realm := intmodel.Realm{
+			Metadata: intmodel.RealmMetadata{Name: "r-aging"},
+			Spec:     intmodel.RealmSpec{Namespace: "r-aging.kukeon.io"},
+			Status:   intmodel.RealmStatus{State: intmodel.RealmStateReady, CgroupPath: "/kukeon/r-aging"},
+		}
+		if err := r0.UpdateRealmMetadata(realm); err != nil {
+			t.Fatalf("first UpdateRealmMetadata: %v", err)
+		}
+		first, err := r0.GetRealm(intmodel.Realm{Metadata: intmodel.RealmMetadata{Name: "r-aging"}})
+		if err != nil {
+			t.Fatalf("GetRealm after first persist: %v", err)
+		}
+
+		// Second persist: simulate the next reconcile tick — same
+		// realm, advanced clock, still Ready. CreatedAt and ReadyAt
+		// must not move; UpdatedAt must advance to t1.
+		r1 := newMetadataTestExec(t, runPath, t1)
+		if err = r1.UpdateRealmMetadata(first); err != nil {
+			t.Fatalf("second UpdateRealmMetadata: %v", err)
+		}
+		second, err := r1.GetRealm(intmodel.Realm{Metadata: intmodel.RealmMetadata{Name: "r-aging"}})
+		if err != nil {
+			t.Fatalf("GetRealm after second persist: %v", err)
+		}
+		if !second.Status.CreatedAt.Equal(t0) {
+			t.Errorf("CreatedAt moved: got %v, want %v", second.Status.CreatedAt, t0)
+		}
+		if !second.Status.ReadyAt.Equal(t0) {
+			t.Errorf("ReadyAt moved: got %v, want %v", second.Status.ReadyAt, t0)
+		}
+		if !second.Status.UpdatedAt.Equal(t1) {
+			t.Errorf("UpdatedAt = %v, want %v", second.Status.UpdatedAt, t1)
+		}
+	})
+}
+
+// TestCarryRealmLifecycle covers the helper the refresh path uses to
+// carry set-once timestamps + Reason/Message through the locally-built
+// newStatus that drops everything not derived from a probe. Without
+// this carry, every refresh tick would erase CreatedAt/ReadyAt and
+// the next stamping would re-stamp CreatedAt to "now" — losing the
+// set-once invariant on every tick.
+func TestCarryRealmLifecycle(t *testing.T) {
+	t0 := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	orig := intmodel.RealmStatus{
+		CreatedAt: t0,
+		ReadyAt:   t0.Add(time.Minute),
+		UpdatedAt: t0.Add(time.Hour),
+		Reason:    "RealmReady",
+		Message:   "msg",
+	}
+	next := intmodel.RealmStatus{State: intmodel.RealmStateReady}
+	carryRealmLifecycle(orig, &next)
+	if !next.CreatedAt.Equal(orig.CreatedAt) {
+		t.Errorf("CreatedAt not carried: got %v, want %v", next.CreatedAt, orig.CreatedAt)
+	}
+	if !next.ReadyAt.Equal(orig.ReadyAt) {
+		t.Errorf("ReadyAt not carried: got %v, want %v", next.ReadyAt, orig.ReadyAt)
+	}
+	if next.Reason != orig.Reason || next.Message != orig.Message {
+		t.Errorf("reason/message not carried: got reason=%q message=%q",
+			next.Reason, next.Message)
+	}
+	// UpdatedAt is intentionally NOT carried — the stamp helper writes
+	// the fresh value on every persist. Carrying it here would freeze
+	// UpdatedAt at the original value if the post-carry stamp ever got
+	// short-circuited.
+	if next.UpdatedAt.Equal(orig.UpdatedAt) {
+		t.Errorf("UpdatedAt was carried; the stamper would never bump it")
+	}
+}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -38,9 +38,11 @@ func (r *Exec) RefreshRealm(realm intmodel.Realm) (intmodel.Realm, bool, error) 
 	switch {
 	case err != nil:
 		r.logger.DebugContext(r.ctx, "failed to check realm cgroup", "realm", realm.Metadata.Name, "error", err)
-		// If check fails, state remains Unknown (already set)
+		// If check fails, state remains Unknown (already set). CgroupReady stays
+		// false because we have no positive observation.
 	case cgroupExists:
 		newStatus.State = intmodel.RealmStateReady
+		newStatus.CgroupReady = true
 	default:
 		// Cgroup doesn't exist - realm is unknown
 		newStatus.State = intmodel.RealmStateUnknown
@@ -68,15 +70,30 @@ func (r *Exec) RefreshRealm(realm intmodel.Realm) (intmodel.Realm, bool, error) 
 		case namespaceExists && newStatus.State == intmodel.RealmStateReady:
 			// Namespace exists and cgroup exists - realm is ready
 			newStatus.State = intmodel.RealmStateReady
+			newStatus.ContainerdNamespaceReady = true
 		case !namespaceExists && newStatus.State == intmodel.RealmStateReady:
 			// Cgroup exists but namespace doesn't - realm is in inconsistent state
 			newStatus.State = intmodel.RealmStateUnknown
+		case namespaceExists:
+			// Namespace exists but cgroup absent/Unknown above; record the
+			// observation independently so callers can distinguish a missing
+			// cgroup from a missing namespace.
+			newStatus.ContainerdNamespaceReady = true
 		}
 	}
 
-	// Update if status changed
+	// Carry lifecycle timestamps + Reason/Message through unchanged so the
+	// stamping in UpdateRealmMetadata can apply its set-once invariants.
+	// Without this, the locally constructed newStatus would erase CreatedAt
+	// and ReadyAt every time the refresh path writes back.
+	carryRealmLifecycle(originalStatus, &newStatus)
+
+	// Update if anything changed
 	updated := false
-	if newStatus.State != originalStatus.State || newStatus.CgroupPath != originalStatus.CgroupPath {
+	if newStatus.State != originalStatus.State ||
+		newStatus.CgroupPath != originalStatus.CgroupPath ||
+		newStatus.CgroupReady != originalStatus.CgroupReady ||
+		newStatus.ContainerdNamespaceReady != originalStatus.ContainerdNamespaceReady {
 		realm.Status = newStatus
 		if updateErr := r.UpdateRealmMetadata(realm); updateErr != nil {
 			return realm, false, fmt.Errorf("failed to update realm metadata: %w", updateErr)
@@ -85,6 +102,19 @@ func (r *Exec) RefreshRealm(realm intmodel.Realm) (intmodel.Realm, bool, error) 
 	}
 
 	return realm, updated, nil
+}
+
+// carryRealmLifecycle preserves the lifecycle/reason fields the refresh
+// path does not derive from filesystem/containerd checks. CreatedAt and
+// ReadyAt are set-once and must survive the locally-built newStatus;
+// Reason/Message belong to whoever last set them (the reconciler in the
+// future, or a Failed-path writer today). UpdatedAt is intentionally
+// not carried — UpdateRealmMetadata stamps it on every persist.
+func carryRealmLifecycle(orig intmodel.RealmStatus, next *intmodel.RealmStatus) {
+	next.CreatedAt = orig.CreatedAt
+	next.ReadyAt = orig.ReadyAt
+	next.Reason = orig.Reason
+	next.Message = orig.Message
 }
 
 // RefreshSpace refreshes the status of a space by checking CNI config.
@@ -127,15 +157,25 @@ func (r *Exec) RefreshSpace(space intmodel.Space) (intmodel.Space, bool, error) 
 		case cgroupExists && newStatus.State == intmodel.SpaceStateReady:
 			// Both CNI and cgroup exist - space is ready
 			newStatus.State = intmodel.SpaceStateReady
+			newStatus.CgroupReady = true
 		case !cgroupExists && newStatus.State == intmodel.SpaceStateReady:
 			// CNI exists but cgroup doesn't - space is in inconsistent state
 			newStatus.State = intmodel.SpaceStateUnknown
+		case cgroupExists:
+			// Cgroup exists but CNI absent/Unknown above; record the cgroup
+			// observation independently so the field tracks reality, not the
+			// derived State.
+			newStatus.CgroupReady = true
 		}
 	}
 
-	// Update if status changed
+	carrySpaceLifecycle(originalStatus, &newStatus)
+
+	// Update if anything changed
 	updated := false
-	if newStatus.State != originalStatus.State || newStatus.CgroupPath != originalStatus.CgroupPath {
+	if newStatus.State != originalStatus.State ||
+		newStatus.CgroupPath != originalStatus.CgroupPath ||
+		newStatus.CgroupReady != originalStatus.CgroupReady {
 		space.Status = newStatus
 		if updateErr := r.UpdateSpaceMetadata(space); updateErr != nil {
 			return space, false, fmt.Errorf("failed to update space metadata: %w", updateErr)
@@ -144,6 +184,14 @@ func (r *Exec) RefreshSpace(space intmodel.Space) (intmodel.Space, bool, error) 
 	}
 
 	return space, updated, nil
+}
+
+// carrySpaceLifecycle is the Space counterpart of carryRealmLifecycle.
+func carrySpaceLifecycle(orig intmodel.SpaceStatus, next *intmodel.SpaceStatus) {
+	next.CreatedAt = orig.CreatedAt
+	next.ReadyAt = orig.ReadyAt
+	next.Reason = orig.Reason
+	next.Message = orig.Message
 }
 
 // RefreshStack refreshes the status of a stack by checking cgroup.
@@ -163,14 +211,19 @@ func (r *Exec) RefreshStack(stack intmodel.Stack) (intmodel.Stack, bool, error) 
 		// If check fails, state remains Unknown (already set)
 	case cgroupExists:
 		newStatus.State = intmodel.StackStateReady
+		newStatus.CgroupReady = true
 	default:
 		// Cgroup doesn't exist - stack is unknown
 		newStatus.State = intmodel.StackStateUnknown
 	}
 
-	// Update if status changed
+	carryStackLifecycle(originalStatus, &newStatus)
+
+	// Update if anything changed
 	updated := false
-	if newStatus.State != originalStatus.State || newStatus.CgroupPath != originalStatus.CgroupPath {
+	if newStatus.State != originalStatus.State ||
+		newStatus.CgroupPath != originalStatus.CgroupPath ||
+		newStatus.CgroupReady != originalStatus.CgroupReady {
 		stack.Status = newStatus
 		if updateErr := r.UpdateStackMetadata(stack); updateErr != nil {
 			return stack, false, fmt.Errorf("failed to update stack metadata: %w", updateErr)
@@ -179,6 +232,14 @@ func (r *Exec) RefreshStack(stack intmodel.Stack) (intmodel.Stack, bool, error) 
 	}
 
 	return stack, updated, nil
+}
+
+// carryStackLifecycle is the Stack counterpart of carryRealmLifecycle.
+func carryStackLifecycle(orig intmodel.StackStatus, next *intmodel.StackStatus) {
+	next.CreatedAt = orig.CreatedAt
+	next.ReadyAt = orig.ReadyAt
+	next.Reason = orig.Reason
+	next.Message = orig.Message
 }
 
 // RefreshCell refreshes the status of a cell and its containers.
@@ -198,10 +259,13 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 		// If check fails, state remains Unknown (already set)
 	case cgroupExists:
 		newStatus.State = intmodel.CellStateReady
+		newStatus.CgroupReady = true
 	default:
 		// Cgroup doesn't exist - cell is unknown
 		newStatus.State = intmodel.CellStateUnknown
 	}
+
+	carryCellLifecycle(originalStatus, &newStatus)
 
 	// Refresh all containers in the cell (always attempt, regardless of cgroup check result)
 	containersUpdated := 0
@@ -221,7 +285,9 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 
 	// Update cell metadata if status changed or containers were updated
 	cellUpdated := false
-	if newStatus.State != originalStatus.State || newStatus.CgroupPath != originalStatus.CgroupPath {
+	if newStatus.State != originalStatus.State ||
+		newStatus.CgroupPath != originalStatus.CgroupPath ||
+		newStatus.CgroupReady != originalStatus.CgroupReady {
 		cell.Status = newStatus
 		cellUpdated = true
 	}
@@ -234,6 +300,18 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 	}
 
 	return cell, containersUpdated, nil
+}
+
+// carryCellLifecycle is the Cell counterpart of carryRealmLifecycle.
+// Network/Containers/ReadyObserved are not carried because the refresh
+// path either rebuilds them (Containers) or leaves them on the live cell
+// struct (Network, ReadyObserved); only the issue #166 fields need an
+// explicit carry from originalStatus to the locally-built newStatus.
+func carryCellLifecycle(orig intmodel.CellStatus, next *intmodel.CellStatus) {
+	next.CreatedAt = orig.CreatedAt
+	next.ReadyAt = orig.ReadyAt
+	next.Reason = orig.Reason
+	next.Message = orig.Message
 }
 
 // refreshContainerStatus refreshes the status of a container by introspecting containerd.

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/ctr"
@@ -161,6 +162,12 @@ type Exec struct {
 	// firewall. nil behaves as a NoopEnforcer so unit tests and read-only
 	// clients never touch iptables.
 	netPolicy netpolicy.Enforcer
+
+	// nowFn returns the wall clock used for status timestamps (issue
+	// #166). nil falls through to time.Now in nowUTC; tests that need
+	// to freeze the clock override the function via the runner_test
+	// hook (see metadata_test.go).
+	nowFn func() time.Time
 }
 
 type Options struct {

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -16,6 +16,8 @@
 
 package modelhub
 
+import "time"
+
 type Cell struct {
 	Metadata CellMetadata
 	Spec     CellSpec
@@ -74,6 +76,14 @@ type CellStatus struct {
 	// GetContainerState reports Stopped for a not-yet-existing
 	// container) cannot be reaped by the reconciler.
 	ReadyObserved bool
+	// Lifecycle and runtime-health fields (issue #166). See
+	// RealmStatus for the per-field contract.
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	ReadyAt     time.Time
+	Reason      string
+	Message     string
+	CgroupReady bool
 }
 
 // CellNetworkStatus records the network endpoints the cell is attached to.

--- a/internal/modelhub/realm.go
+++ b/internal/modelhub/realm.go
@@ -16,6 +16,8 @@
 
 package modelhub
 
+import "time"
+
 type Realm struct {
 	Metadata RealmMetadata
 	Spec     RealmSpec
@@ -51,6 +53,25 @@ type RealmStatus struct {
 	// effective filter against the host root's cgroup.controllers (issue
 	// #328, surfacing the result of the helper landed by issue #327).
 	SubtreeControllers []string
+	// CreatedAt is the wall-clock time of the first persist. Stamped
+	// only when zero so the value never moves once set (issue #166).
+	CreatedAt time.Time
+	// UpdatedAt is the wall-clock time of the most recent persist.
+	UpdatedAt time.Time
+	// ReadyAt is the wall-clock time of the first State==Ready persist.
+	// Set-once: never overwritten by subsequent Ready transitions.
+	ReadyAt time.Time
+	// Reason is a short reason code summarizing why State is in its
+	// current value. Empty when no reason has been recorded.
+	Reason string
+	// Message is the human-readable detail backing Reason.
+	Message string
+	// CgroupReady reports whether CgroupPath was observed to exist on
+	// the host filesystem as of the last status write.
+	CgroupReady bool
+	// ContainerdNamespaceReady reports whether the realm's containerd
+	// namespace was observed to exist as of the last status write.
+	ContainerdNamespaceReady bool
 }
 
 type RealmState int

--- a/internal/modelhub/space.go
+++ b/internal/modelhub/space.go
@@ -16,6 +16,8 @@
 
 package modelhub
 
+import "time"
+
 type Space struct {
 	Metadata SpaceMetadata
 	Spec     SpaceSpec
@@ -88,6 +90,14 @@ type SpaceStatus struct {
 	// effective filter against the host root's cgroup.controllers (issue
 	// #328).
 	SubtreeControllers []string
+	// Lifecycle and runtime-health fields (issue #166). See
+	// RealmStatus for the per-field contract.
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	ReadyAt     time.Time
+	Reason      string
+	Message     string
+	CgroupReady bool
 }
 
 type SpaceState int

--- a/internal/modelhub/stack.go
+++ b/internal/modelhub/stack.go
@@ -16,6 +16,8 @@
 
 package modelhub
 
+import "time"
+
 type Stack struct {
 	Metadata StackMetadata
 	Spec     StackSpec
@@ -41,6 +43,14 @@ type StackStatus struct {
 	// effective filter against the host root's cgroup.controllers (issue
 	// #328).
 	SubtreeControllers []string
+	// Lifecycle and runtime-health fields (issue #166). See
+	// RealmStatus for the per-field contract.
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	ReadyAt     time.Time
+	Reason      string
+	Message     string
+	CgroupReady bool
 }
 
 type StackState int

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -16,6 +16,8 @@
 
 package v1beta1
 
+import "time"
+
 type CellDoc struct {
 	APIVersion Version      `json:"apiVersion" yaml:"apiVersion"`
 	Kind       Kind         `json:"kind"       yaml:"kind"`
@@ -84,6 +86,14 @@ type CellStatus struct {
 	// cleanup of a `kuke run --rm` cell that was already Ready at
 	// shutdown still fires on the next tick after restart.
 	ReadyObserved bool `json:"readyObserved,omitempty" yaml:"readyObserved,omitempty"`
+	// Lifecycle and runtime-health fields — see RealmStatus for the
+	// per-field contract; the semantics carry across all four kinds.
+	CreatedAt   time.Time `json:"createdAt,omitempty"     yaml:"createdAt,omitempty"`
+	UpdatedAt   time.Time `json:"updatedAt,omitempty"     yaml:"updatedAt,omitempty"`
+	ReadyAt     time.Time `json:"readyAt,omitempty"       yaml:"readyAt,omitempty"`
+	Reason      string    `json:"reason,omitempty"        yaml:"reason,omitempty"`
+	Message     string    `json:"message,omitempty"       yaml:"message,omitempty"`
+	CgroupReady bool      `json:"cgroupReady,omitempty"   yaml:"cgroupReady,omitempty"`
 }
 
 // CellNetworkStatus exposes the host-side bridge a cell is attached to.

--- a/pkg/api/model/v1beta1/realm.go
+++ b/pkg/api/model/v1beta1/realm.go
@@ -16,6 +16,8 @@
 
 package v1beta1
 
+import "time"
+
 type RealmDoc struct {
 	APIVersion Version       `json:"apiVersion" yaml:"apiVersion"`
 	Kind       Kind          `json:"kind"       yaml:"kind"`
@@ -52,6 +54,33 @@ type RealmStatus struct {
 	// delegated on this realm's own cgroup.subtree_control after the
 	// host-root filter (issue #328).
 	SubtreeControllers []string `json:"subtreeControllers,omitempty" yaml:"subtreeControllers,omitempty"`
+	// CreatedAt is the wall-clock time of the first persist for this
+	// realm. Bumped only when zero so the value never moves once set.
+	CreatedAt time.Time `json:"createdAt,omitempty"          yaml:"createdAt,omitempty"`
+	// UpdatedAt is the wall-clock time of the most recent persist.
+	UpdatedAt time.Time `json:"updatedAt,omitempty"          yaml:"updatedAt,omitempty"`
+	// ReadyAt is the wall-clock time of the first State==Ready persist.
+	// Set-once: never overwritten by subsequent Ready transitions or
+	// state flaps, so it serves as an immutable "first reached Ready"
+	// marker.
+	ReadyAt time.Time `json:"readyAt,omitempty"            yaml:"readyAt,omitempty"`
+	// Reason is a short reason code summarizing why State is in its
+	// current value. Empty when no reason has been recorded.
+	Reason string `json:"reason,omitempty"             yaml:"reason,omitempty"`
+	// Message is the human-readable detail backing Reason; especially
+	// valuable on State==Failed where it captures the immediate cause.
+	Message string `json:"message,omitempty"            yaml:"message,omitempty"`
+	// CgroupReady reports whether CgroupPath actually exists on the
+	// host filesystem as of the last status write. The CgroupPath
+	// field records the intent (the path where the cgroup should
+	// live); this re-verifies presence so callers can distinguish
+	// "configured" from "still mounted".
+	CgroupReady bool `json:"cgroupReady,omitempty"        yaml:"cgroupReady,omitempty"`
+	// ContainerdNamespaceReady reports whether the containerd
+	// namespace recorded in Spec.Namespace was actually present as of
+	// the last status write. Like CgroupReady, this separates intent
+	// from observation.
+	ContainerdNamespaceReady bool `json:"containerdNamespaceReady,omitempty" yaml:"containerdNamespaceReady,omitempty"`
 }
 
 type RealmState int

--- a/pkg/api/model/v1beta1/space.go
+++ b/pkg/api/model/v1beta1/space.go
@@ -16,6 +16,8 @@
 
 package v1beta1
 
+import "time"
+
 type SpaceDoc struct {
 	APIVersion Version       `json:"apiVersion" yaml:"apiVersion"`
 	Kind       Kind          `json:"kind"       yaml:"kind"`
@@ -104,6 +106,14 @@ type SpaceStatus struct {
 	// delegated on this space's own cgroup.subtree_control after the
 	// host-root filter (issue #328).
 	SubtreeControllers []string `json:"subtreeControllers,omitempty" yaml:"subtreeControllers,omitempty"`
+	// Lifecycle and runtime-health fields — see RealmStatus for the
+	// per-field contract; the semantics carry across all four kinds.
+	CreatedAt   time.Time `json:"createdAt,omitempty"          yaml:"createdAt,omitempty"`
+	UpdatedAt   time.Time `json:"updatedAt,omitempty"          yaml:"updatedAt,omitempty"`
+	ReadyAt     time.Time `json:"readyAt,omitempty"            yaml:"readyAt,omitempty"`
+	Reason      string    `json:"reason,omitempty"             yaml:"reason,omitempty"`
+	Message     string    `json:"message,omitempty"            yaml:"message,omitempty"`
+	CgroupReady bool      `json:"cgroupReady,omitempty"        yaml:"cgroupReady,omitempty"`
 }
 
 type SpaceState int

--- a/pkg/api/model/v1beta1/stack.go
+++ b/pkg/api/model/v1beta1/stack.go
@@ -16,6 +16,8 @@
 
 package v1beta1
 
+import "time"
+
 type StackDoc struct {
 	APIVersion Version       `json:"apiVersion" yaml:"apiVersion"`
 	Kind       Kind          `json:"kind"       yaml:"kind"`
@@ -42,6 +44,14 @@ type StackStatus struct {
 	// delegated on this stack's own cgroup.subtree_control after the
 	// host-root filter (issue #328).
 	SubtreeControllers []string `json:"subtreeControllers,omitempty" yaml:"subtreeControllers,omitempty"`
+	// Lifecycle and runtime-health fields — see RealmStatus for the
+	// per-field contract; the semantics carry across all four kinds.
+	CreatedAt   time.Time `json:"createdAt,omitempty"          yaml:"createdAt,omitempty"`
+	UpdatedAt   time.Time `json:"updatedAt,omitempty"          yaml:"updatedAt,omitempty"`
+	ReadyAt     time.Time `json:"readyAt,omitempty"            yaml:"readyAt,omitempty"`
+	Reason      string    `json:"reason,omitempty"             yaml:"reason,omitempty"`
+	Message     string    `json:"message,omitempty"            yaml:"message,omitempty"`
+	CgroupReady bool      `json:"cgroupReady,omitempty"        yaml:"cgroupReady,omitempty"`
 }
 
 type StackState int


### PR DESCRIPTION
## Summary
- Adds lifecycle-scoped fields (`CreatedAt`, `UpdatedAt`, `ReadyAt`, `Reason`, `Message`, `CgroupReady`) to `RealmStatus`, `SpaceStatus`, `StackStatus`, `CellStatus`, plus `ContainerdNamespaceReady` on `RealmStatus` only. Lets a `metadata.json` snapshot answer "how old is this, is the cgroup still mounted, and why is the state Failed?" — and gives the future reconciler (#161) somewhere durable to write its observations beyond the `State` enum.
- Timestamp stamping is centralised in the four `UpdateXMetadata` paths. `CreatedAt` is stamped only when zero so the value never moves once set; `UpdatedAt` is bumped on every persist; `ReadyAt` is set once on the first `State==Ready` persist and never overwritten on subsequent Ready transitions or state flaps. Logic is extracted as `stampRealmLifecycle` / `Space` / `Stack` / `Cell` pure helpers so the invariants are unit-testable independent of the metadata-write path.
- Probe fields are populated by the existing refresh path (`RefreshRealm` / `RefreshSpace` / `RefreshStack` / `RefreshCell`). `CgroupReady` is the result of the existing `ExistsCgroup` call; `ContainerdNamespaceReady` is the result of the existing `ExistsRealmContainerdNamespace` call. New `carryXLifecycle` helpers preserve the set-once timestamps and `Reason`/`Message` through the locally-built `newStatus` so the refresh tick does not erase them. The runner gains an `nowFn` override hook so the stamper can be driven from a frozen clock in tests; production callers fall through to `time.Now().UTC()`.
- No on-disk migration: missing fields read as zero values from existing `metadata.json` files (verified with a hand-crafted legacy file). The default `kuke get realms` table is intentionally left unchanged so the daemon-parity regression guard the dev-init smoke check expects keeps passing; new fields are surfaced via the default single-resource view (which is YAML), `-o yaml`, and `-o json`.

## Test plan
- [x] `make test` (the project's named CI target).
- [x] `go vet ./...` clean; `gofmt -l internal/ pkg/ cmd/` produces no diff.
- [x] `make dev-init` rebuilds and re-bootstraps the local kukeond image. The daemon-parity tail produces identical `kuke get realms` / `kuke get realms --no-daemon` output in the documented `NAME / NAMESPACE / STATE / CGROUP` layout. (The script exits non-zero on a later, unrelated `kuke attach` smoke step that needs `expect(1)` to be installed on the host — environmental, predates this change.)
- [x] `kuke get realm default -o yaml` after `make dev-init` shows populated `createdAt` / `updatedAt` / `readyAt` (cell, stack, space and realm verified separately).
- [x] `kuke refresh` followed by `kuke get` shows `cgroupReady: true` and (for the realm) `containerdNamespaceReady: true`. `createdAt` and `readyAt` are unchanged across the refresh; `updatedAt` advanced.
- [x] Hand-crafted legacy `metadata.json` (no lifecycle fields) loads cleanly with zero-value defaults — exercises the no-migration AC.
- [x] Unit tests added: `TestStampRealmLifecycle` / `Space` / `Stack` / `Cell` cover the set-once / bump-on-update invariants; `TestUpdateRealmMetadataPersistsLifecycleFields` exercises the full stamp → convert → write → read pipeline; `TestCarryRealmLifecycle` pins the refresh-path carry; `TestStatusLifecycleFieldsRoundTripV1Beta1` and `TestStatusLifecycleFieldsZeroDefault` cover the apischeme conversions for all four kinds.

Closes #166