### PR TITLE
feat: wire cell profile to sbsh builder (phase 4)

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -516,7 +516,12 @@ func convertContainerTtyToInternal(in *ext.ContainerTty) *intmodel.ContainerTty 
 	if in.IsEmpty() {
 		return nil
 	}
-	out := &intmodel.ContainerTty{Prompt: in.Prompt, LogFile: in.LogFile}
+	out := &intmodel.ContainerTty{
+		Prompt:      in.Prompt,
+		LogFile:     in.LogFile,
+		Profile:     in.Profile,
+		ProfilesDir: in.ProfilesDir,
+	}
 	if len(in.OnInit) > 0 {
 		out.OnInit = make([]intmodel.TtyStage, len(in.OnInit))
 		for i, s := range in.OnInit {
@@ -532,7 +537,12 @@ func buildContainerTtyExternalFromInternal(in *intmodel.ContainerTty) *ext.Conta
 	if in.IsEmpty() {
 		return nil
 	}
-	out := &ext.ContainerTty{Prompt: in.Prompt, LogFile: in.LogFile}
+	out := &ext.ContainerTty{
+		Prompt:      in.Prompt,
+		LogFile:     in.LogFile,
+		Profile:     in.Profile,
+		ProfilesDir: in.ProfilesDir,
+	}
 	if len(in.OnInit) > 0 {
 		out.OnInit = make([]ext.TtyStage, len(in.OnInit))
 		for i, s := range in.OnInit {

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -1132,7 +1132,9 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 					{Script: "git pull"},
 					{Script: "claude"},
 				},
-				LogFile: "/run/kukeon/tty/log",
+				LogFile:     "/run/kukeon/tty/log",
+				Profile:     "claude",
+				ProfilesDir: "/opt/kukeon/profiles",
 			},
 		},
 	}
@@ -1148,6 +1150,12 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 	}
 	if internal.Spec.Tty.LogFile != input.Spec.Tty.LogFile {
 		t.Errorf("internal logFile = %q, want %q", internal.Spec.Tty.LogFile, input.Spec.Tty.LogFile)
+	}
+	if internal.Spec.Tty.Profile != input.Spec.Tty.Profile {
+		t.Errorf("internal profile = %q, want %q", internal.Spec.Tty.Profile, input.Spec.Tty.Profile)
+	}
+	if internal.Spec.Tty.ProfilesDir != input.Spec.Tty.ProfilesDir {
+		t.Errorf("internal profilesDir = %q, want %q", internal.Spec.Tty.ProfilesDir, input.Spec.Tty.ProfilesDir)
 	}
 	if len(internal.Spec.Tty.OnInit) != 2 ||
 		internal.Spec.Tty.OnInit[0].Script != "git pull" ||
@@ -1166,6 +1174,12 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 	}
 	if out.Spec.Tty.LogFile != input.Spec.Tty.LogFile {
 		t.Errorf("round-trip logFile = %q, want %q", out.Spec.Tty.LogFile, input.Spec.Tty.LogFile)
+	}
+	if out.Spec.Tty.Profile != input.Spec.Tty.Profile {
+		t.Errorf("round-trip profile = %q, want %q", out.Spec.Tty.Profile, input.Spec.Tty.Profile)
+	}
+	if out.Spec.Tty.ProfilesDir != input.Spec.Tty.ProfilesDir {
+		t.Errorf("round-trip profilesDir = %q, want %q", out.Spec.Tty.ProfilesDir, input.Spec.Tty.ProfilesDir)
 	}
 	if len(out.Spec.Tty.OnInit) != len(input.Spec.Tty.OnInit) {
 		t.Fatalf("round-trip onInit len = %d, want %d", len(out.Spec.Tty.OnInit), len(input.Spec.Tty.OnInit))
@@ -1272,10 +1286,14 @@ func TestContainerTtyRejectedWithoutAttachable(t *testing.T) {
 		{"prompt only", &ext.ContainerTty{Prompt: `"\u\$ "`}},
 		{"onInit only", &ext.ContainerTty{OnInit: []ext.TtyStage{{Script: "echo"}}}},
 		{"logFile only", &ext.ContainerTty{LogFile: "/run/kukeon/tty/log"}},
+		{"profile only", &ext.ContainerTty{Profile: "claude"}},
+		{"profilesDir only", &ext.ContainerTty{ProfilesDir: "/opt/kukeon/profiles"}},
 		{"all set", &ext.ContainerTty{
-			Prompt:  `"\u\$ "`,
-			OnInit:  []ext.TtyStage{{Script: "echo"}},
-			LogFile: "/run/kukeon/tty/log",
+			Prompt:      `"\u\$ "`,
+			OnInit:      []ext.TtyStage{{Script: "echo"}},
+			LogFile:     "/run/kukeon/tty/log",
+			Profile:     "claude",
+			ProfilesDir: "/opt/kukeon/profiles",
 		}},
 	}
 	for _, tc := range cases {

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -180,6 +180,7 @@ func (r *Exec) writeKukettyMetadata(
 	kukeonGroupGID int,
 	workloadArgv []string,
 ) error {
+	profileConfigured := spec.Tty != nil && spec.Tty.Profile != ""
 	opts := []sbshbuilder.TerminalOption{
 		sbshbuilder.WithSocketFile(ctr.AttachableSocketPath),
 		// Capture file is anchored to the kukeon-controlled per-container
@@ -190,12 +191,27 @@ func (r *Exec) writeKukettyMetadata(
 		// would land outside the bind-mount, hiding the transcript from the
 		// host.
 		sbshbuilder.WithCaptureFile(ctr.AttachableCapturePath),
-		// DisableSetPrompt: phase 4 (#290) wires the cell's Tty.Prompt
-		// through to sbsh's PS1 rewriting; until then, leave the
-		// workload's PS1 alone — writing the default `(sbsh-$ID) $PS1`
-		// export into a non-shell workload (nginx, python) would inject
-		// literal text into its stdin.
-		sbshbuilder.WithDisableSetPrompt(true),
+	}
+	// Phase 4 (#290) wires the cell's Tty.Profile through to sbsh's builder:
+	// when configured, WithProfile selects the TerminalProfile by name and
+	// WithProfilesDir points the loader at the host-side YAML directory.
+	// sbsh's builder stamps Prompt, SetPrompt, and Stages into the rendered
+	// TerminalSpec; no kukeon-side profile interpreter runs.
+	//
+	// When no profile is configured, both builder options are omitted (so
+	// sbsh's no-profile path runs) and DisableSetPrompt stays on — without
+	// it sbsh's hardcoded default would inject `(sbsh-$ID) $PS1` into a
+	// non-shell workload's stdin. ProfilesDir is only honored alongside
+	// Profile: in isolation it would prime sbsh's profile name to "default"
+	// and chase the configured dir for a YAML the operator never asked to
+	// load.
+	if profileConfigured {
+		opts = append(opts, sbshbuilder.WithProfile(spec.Tty.Profile))
+		if spec.Tty.ProfilesDir != "" {
+			opts = append(opts, sbshbuilder.WithProfilesDir(spec.Tty.ProfilesDir))
+		}
+	} else {
+		opts = append(opts, sbshbuilder.WithDisableSetPrompt(true))
 	}
 	if mode := modeIfGroupSet(kukeonGroupGID, ctr.AttachableSocketMode); mode != "" {
 		opts = append(opts, sbshbuilder.WithSocketMode(mode))

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -352,6 +352,134 @@ func TestWriteKukettyMetadata_LogFileSet(t *testing.T) {
 	}
 }
 
+// TestWriteKukettyMetadata_ProfileConfigured locks phase 4 (#290): when
+// the cell's Tty.Profile and Tty.ProfilesDir are set, the renderer hands
+// both to sbsh's builder via WithProfile / WithProfilesDir. sbsh loads the
+// named TerminalProfile YAML, stamps Prompt + onInit Stages into the
+// rendered Spec, and SetPrompt stays true (the daemon's legacy
+// DisableSetPrompt safety belt drops away when a profile is explicitly
+// configured — the operator opted into PS1 rewriting).
+func TestWriteKukettyMetadata_ProfileConfigured(t *testing.T) {
+	const profileYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: claude
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+    prompt: "\"phase4-prompt $PS1\""
+  stages:
+    onInit:
+      - script: "echo hello"
+      - script: "echo world"
+`
+	r := newTestRunner(t)
+	profilesDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(profilesDir, "claude.yaml"), []byte(profileYAML), 0o644); err != nil {
+		t.Fatalf("write profile yaml: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+	spec := intmodel.ContainerSpec{
+		ID: "c1",
+		Tty: &intmodel.ContainerTty{
+			Profile:     "claude",
+			ProfilesDir: profilesDir,
+		},
+	}
+
+	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
+		t.Fatalf("writeKukettyMetadata: %v", err)
+	}
+	doc := readDoc(t, path)
+	if doc.Spec.Prompt != `"phase4-prompt $PS1"` {
+		t.Errorf("Spec.Prompt = %q, want %q", doc.Spec.Prompt, `"phase4-prompt $PS1"`)
+	}
+	if !doc.Spec.SetPrompt {
+		t.Errorf("Spec.SetPrompt = false, want true (profile drives it; daemon's DisableSetPrompt safety belt off)")
+	}
+	if len(doc.Spec.Stages.OnInit) != 2 {
+		t.Fatalf("Spec.Stages.OnInit len = %d, want 2", len(doc.Spec.Stages.OnInit))
+	}
+	if doc.Spec.Stages.OnInit[0].Script != "echo hello" ||
+		doc.Spec.Stages.OnInit[1].Script != "echo world" {
+		t.Errorf("Spec.Stages.OnInit = %+v, want [echo hello, echo world]", doc.Spec.Stages.OnInit)
+	}
+}
+
+// TestWriteKukettyMetadata_NoProfileKeepsSafeDefault locks AC #3 (#290):
+// when the cell does not configure a profile, the renderer omits the
+// builder's profile options and keeps the DisableSetPrompt safe default,
+// so Spec.SetPrompt stays false and Spec.Stages stays zero — a workload
+// that is not a shell (nginx, python) never receives a literal PS1
+// injection on its stdin.
+func TestWriteKukettyMetadata_NoProfileKeepsSafeDefault(t *testing.T) {
+	r := newTestRunner(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+	spec := intmodel.ContainerSpec{ID: "c1"}
+
+	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
+		t.Fatalf("writeKukettyMetadata: %v", err)
+	}
+	doc := readDoc(t, path)
+	if doc.Spec.SetPrompt {
+		t.Errorf("Spec.SetPrompt = true, want false (no profile → DisableSetPrompt safety belt)")
+	}
+	if len(doc.Spec.Stages.OnInit) != 0 {
+		t.Errorf("Spec.Stages.OnInit = %+v, want empty (no profile)", doc.Spec.Stages.OnInit)
+	}
+	if len(doc.Spec.Stages.PostAttach) != 0 {
+		t.Errorf("Spec.Stages.PostAttach = %+v, want empty (no profile)", doc.Spec.Stages.PostAttach)
+	}
+}
+
+// TestWriteKukettyMetadata_ProfilesDirIgnoredWithoutProfile locks the
+// guard that ProfilesDir is only honored alongside Profile: when Profile
+// is empty, the renderer omits WithProfilesDir so sbsh's builder cannot
+// chase the configured dir for a "default" YAML the operator never asked
+// to load. SetPrompt stays false; Stages stays zero.
+func TestWriteKukettyMetadata_ProfilesDirIgnoredWithoutProfile(t *testing.T) {
+	// Stage a "default" profile in the dir that would set SetPrompt=true
+	// if sbsh were to load it. The renderer must skip the dir entirely.
+	const defaultYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: default
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+    prompt: "\"should-not-apply $PS1\""
+  stages:
+    onInit:
+      - script: "echo should-not-run"
+`
+	r := newTestRunner(t)
+	profilesDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(profilesDir, "default.yaml"), []byte(defaultYAML), 0o644); err != nil {
+		t.Fatalf("write default profile: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+	spec := intmodel.ContainerSpec{
+		ID:  "c1",
+		Tty: &intmodel.ContainerTty{ProfilesDir: profilesDir},
+	}
+
+	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
+		t.Fatalf("writeKukettyMetadata: %v", err)
+	}
+	doc := readDoc(t, path)
+	if doc.Spec.SetPrompt {
+		t.Errorf("Spec.SetPrompt = true, want false (ProfilesDir without Profile must not load any profile)")
+	}
+	if len(doc.Spec.Stages.OnInit) != 0 {
+		t.Errorf("Spec.Stages.OnInit = %+v, want empty (no Profile)", doc.Spec.Stages.OnInit)
+	}
+}
+
 // TestWriteKukettyMetadata_EmptyWorkloadFallsBackToBuilderDefault: when
 // the OCI args-wrap captures an empty Process.Args (image with no
 // ENTRYPOINT/CMD and no user override), the renderer leaves Spec.Command

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -105,9 +105,11 @@ type ContainerSpec struct {
 // ContainerTty mirrors the v1beta1 ContainerTty payload. See the v1beta1
 // type for field semantics.
 type ContainerTty struct {
-	Prompt  string
-	OnInit  []TtyStage
-	LogFile string
+	Prompt      string
+	OnInit      []TtyStage
+	LogFile     string
+	Profile     string
+	ProfilesDir string
 }
 
 // TtyStage mirrors the v1beta1 TtyStage payload.
@@ -124,6 +126,12 @@ func (t *ContainerTty) IsEmpty() bool {
 		return false
 	}
 	if t.LogFile != "" {
+		return false
+	}
+	if t.Profile != "" {
+		return false
+	}
+	if t.ProfilesDir != "" {
 		return false
 	}
 	for _, s := range t.OnInit {

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -116,9 +116,9 @@ type ContainerTty struct {
 	// Prompt is the literal prompt expression sbsh sets in the wrapped
 	// shell, in the same form sbsh's TerminalProfile spec.shell.prompt
 	// accepts (e.g. a quoted PS1-style string).
-	Prompt string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
+	Prompt string `json:"prompt,omitempty"      yaml:"prompt,omitempty"`
 	// OnInit are scripts run once when the wrapped shell starts, in order.
-	OnInit []TtyStage `json:"onInit,omitempty" yaml:"onInit,omitempty"`
+	OnInit []TtyStage `json:"onInit,omitempty"      yaml:"onInit,omitempty"`
 	// LogFile is the in-container path where sbsh's runner writes its
 	// runtime/debug log. Empty (the default) means sbsh's runner skips
 	// log-writer setup entirely. Set this to a path inside the kuketty
@@ -129,7 +129,24 @@ type ContainerTty struct {
 	// — the daemon applies its system-wide AttachableLogFileMode and
 	// the kukeon-group GID, gated on the kukeon group being configured
 	// (matches the SocketMode/CaptureMode treatment).
-	LogFile string `json:"logFile,omitempty" yaml:"logFile,omitempty"`
+	LogFile string `json:"logFile,omitempty"     yaml:"logFile,omitempty"`
+	// Profile names the sbsh TerminalProfile (Metadata.Name) the daemon
+	// asks sbsh's builder to resolve when rendering this container's
+	// kuketty TerminalDoc. The profile YAML lives outside kukeon — sbsh's
+	// pkg/discovery loads it from ProfilesDir at OCI-injection time and
+	// stamps Prompt, SetPrompt, and Stages into the rendered Spec.
+	// Empty (the default) means "no profile": the renderer omits the
+	// builder option, Spec.Prompt / Spec.SetPrompt / Spec.Stages stay
+	// zero, and the workload runs without a prompt override or onInit
+	// stages. Phase 4 (#290).
+	Profile string `json:"profile,omitempty"     yaml:"profile,omitempty"`
+	// ProfilesDir is the host-side directory sbsh's builder scans for
+	// TerminalProfile YAML when resolving Profile. Empty means
+	// "use sbsh's default ($HOME/.sbsh/profiles.d/)"; that default is
+	// rarely the right answer on a daemon host with no operator HOME, so
+	// most cells that set Profile also set ProfilesDir to an explicit
+	// host path. Phase 4 (#290).
+	ProfilesDir string `json:"profilesDir,omitempty" yaml:"profilesDir,omitempty"`
 }
 
 // TtyStage is a single onInit script entry. Wrapped in a struct rather than
@@ -150,6 +167,12 @@ func (t *ContainerTty) IsEmpty() bool {
 		return false
 	}
 	if t.LogFile != "" {
+		return false
+	}
+	if t.Profile != "" {
+		return false
+	}
+	if t.ProfilesDir != "" {
 		return false
 	}
 	for _, s := range t.OnInit {


### PR DESCRIPTION
## Summary
- Plumb a sbsh `TerminalProfile` (name + host-side profiles dir) end-to-end from `ContainerTty` into the per-container kuketty `TerminalDoc` via `pkg/builder.BuildTerminalSpec(WithProfile(...), WithProfilesDir(...))`. sbsh's loader and builder do the YAML resolution; kukeon keeps no profile interpreter.
- Drop the unconditional `WithDisableSetPrompt(true)` safety belt **only when** a profile is configured, so the profile's `Prompt` / `Stages` / `SetPrompt=true` actually take effect. The no-profile path keeps the legacy `DisableSetPrompt` default so a non-shell workload (nginx, python) never receives a literal `export PS1=…` on its stdin.
- `ProfilesDir` is only honored alongside `Profile` — in isolation sbsh's builder would default the profile name to `"default"` and chase the configured dir for a YAML the operator never asked to load. Matches the issue's "builder options are omitted" wording for the no-profile path.

## Notes
- AC #3 mentions `Spec.Prompt` staying zero in the no-profile path. sbsh's hardcoded default profile (the fallback when `discovery.FindProfileByNameInDir` returns nothing) populates `Spec.Prompt` with its own `"(sbsh-$SBSH_TERM_ID) $PS1"` string — kukeon cannot suppress that without writing the profile interpreter the issue explicitly forbids. The AC's intent (workload PS1 not modified) holds because `Spec.SetPrompt=false` keeps the runner from applying that prompt at all. Spec.SetPrompt and Spec.Stages do stay zero. Flagging for the reviewer in case the literal "Prompt zero" wording is load-bearing.
- Schema lives on `ContainerTty` next to `LogFile` rather than `CellTty`, matching the existing per-attach shell-UX pattern. Validation already rejects any tty field with `Attachable=false`; extended the test matrix to cover the two new fields.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (no FAIL across the suite; touched packages: apischeme, controller/runner, modelhub, pkg/api/model/v1beta1)
- [x] `make dev-init` — daemon parity check passes, kuketty-wrapped cell attach smoke exits cleanly
- [x] `pre-commit run --files <changed>` (golangci-lint auto-formatted struct tags on first pass, clean on second)

Closes #290