### PR TITLE
test: use containerd namespace for e2e attach task verify

### DIFF
--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/util/fs"
 )
 
@@ -152,9 +153,10 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 		t.Fatalf("get cell ID: %v", err)
 	}
 	containerdID := fmt.Sprintf("%s_%s_%s_%s", spaceName, stackName, cellID, "work")
-	if !verifyContainerTaskIsRunning(t, realmName, containerdID) {
+	realmNamespace := consts.RealmNamespace(realmName)
+	if !verifyContainerTaskIsRunning(t, realmNamespace, containerdID) {
 		t.Fatalf("container task %q in namespace %q is not RUNNING after detach",
-			containerdID, realmName)
+			containerdID, realmNamespace)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `TestKuke_AttachDetach_KeepsTaskRunning` was passing the realm name (e.g. `e-r-6e`) to `verifyContainerTaskIsRunning`, but the helper greps `ctr --namespace <ns> task ls` and the containerd namespace is the realm name plus `.kukeon.io` (per `internal/consts.RealmNamespace`). The assertion therefore looked up the wrong namespace, found nothing, and fired post-detach even though the workload was running. The bug was masked on `main` until #422 because `stageHostSbsh` `t.Skip`'d the test when `sbsh` was missing from `PATH`; once that gate was removed in phase 5, the latent issue surfaced.
- Fix calls `consts.RealmNamespace(realmName)` at the single call site and reuses the value in the `t.Fatalf` message so the diagnostic matches what was actually queried. Mirrors the pattern used by every other e2e helper that interrogates containerd by realm.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test`
- [x] `KUKEON_E2E_IMAGE=docker.io/library/kukeon-local:e2e KUKEON_E2E_IMAGE_DOCKER_NAME=kukeon-local:e2e E2E_BIN_DIR=$(pwd) go test -v -count=1 -run TestKuke_AttachDetach_KeepsTaskRunning ./e2e` — passes in 13.7s
- [ ] Full `make test-e2e` not re-run — orthogonal pre-existing ordering issues (`/run/kukeon/kukeond.sock` failures, `TestKuke_Init_VerifyState` container-conflict) exist on this host; the targeted test is the AC.

Closes #424