### PR TITLE
docs: update Manual phases #4 expected tail to drop misleading cgroup suffix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,8 @@ To run individual phases by hand — e.g. while debugging a single phase — inv
    ```
        - cell "kukeond": created (image docker.io/library/kukeon-local:dev)
        - cell cgroup: created
-       - cell root container cgroup: created
-       - cell containers cgroup: created
+       - cell root container: created
+       - cell containers: started
    kukeond is ready (unix:///run/kukeon/kukeond.sock)
    ```
 


### PR DESCRIPTION
## Summary
Verbatim documentation update applied from issue #365.
Mode: verbatim.

## Spec from issue
- File: `CLAUDE.md`
- Section: `## Local smoke test → Manual phases (fallback)` step 4, the "Expected tail" fenced block under "Run `kuke init`"
- Replaced the two `- cell root container cgroup: created` / `- cell containers cgroup: created` lines with `- cell root container: created` / `- cell containers: started` to match the new strings PR #364 routes through `printContainerAction` / `printStartAction`.

## Diff vs spec
- [x] Each applied hunk matches the issue's "After" wording character-for-character.

Closes #365