### PR TITLE
refactor: replace expect(1) attach smoke with a Go PTY helper

### DIFF
--- a/hack/attach-smoke/main.go
+++ b/hack/attach-smoke/main.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// attach-smoke drives an interactive subprocess attached to a freshly
+// allocated pseudoterminal, then sends sbsh's Ctrl+] Ctrl+] detach
+// sequence and waits for the child to exit. It exists so scripts/dev-init.sh
+// can smoke-test `kuke attach` without an expect(1) prereq; the helper
+// reuses github.com/creack/pty (already a direct dependency).
+//
+// Behaviour mirrors the prior expect block:
+//   - allocate a PTY and spawn the child connected to it
+//   - sleep --connect-grace (default 2s) so the pkg/attach raw-mode
+//     keyboard filter wires up before keystrokes arrive
+//   - write 0x1d 0x1d (Ctrl+] Ctrl+]) to the PTY master
+//   - wait up to --exit-timeout (default 20s) for the child to exit
+//   - exit non-zero on timeout or non-zero child exit; the child's
+//     transcript is always captured to --log
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// detachSequence is the keystroke pair the sbsh client filter recognises
+// as a request to detach (Ctrl+] Ctrl+], adjacent). It matches the
+// constant the e2e suite uses; see e2e/e2e_kuke_attach_test.go.
+var detachSequence = []byte{0x1d, 0x1d}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		logPath      string
+		connectGrace time.Duration
+		exitTimeout  time.Duration
+	)
+	flag.StringVar(&logPath, "log", "", "path to write the child's combined output (required)")
+	flag.DurationVar(&connectGrace, "connect-grace", 2*time.Second,
+		"delay after spawn before sending the detach sequence")
+	flag.DurationVar(&exitTimeout, "exit-timeout", 20*time.Second,
+		"overall deadline for the child to exit after spawn")
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(),
+			"usage: %s --log PATH [--connect-grace D] [--exit-timeout D] -- CMD [ARGS...]\n",
+			os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if logPath == "" {
+		flag.Usage()
+		return errors.New("--log is required")
+	}
+	if flag.NArg() == 0 {
+		flag.Usage()
+		return errors.New("missing CMD to spawn under the PTY")
+	}
+
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return fmt.Errorf("open log %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+
+	args := flag.Args()
+	cmd := exec.Command(args[0], args[1:]...)
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return fmt.Errorf("pty.Start %s: %w", args[0], err)
+	}
+	defer ptmx.Close()
+
+	copyDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(logFile, ptmx)
+		close(copyDone)
+	}()
+
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- cmd.Wait() }()
+
+	var detach <-chan time.Time = time.After(connectGrace)
+	overall := time.After(exitTimeout)
+
+	for {
+		select {
+		case <-detach:
+			detach = nil
+			if _, werr := ptmx.Write(detachSequence); werr != nil {
+				fmt.Fprintf(os.Stderr,
+					"warning: write detach sequence: %v (child may have already exited)\n",
+					werr)
+			}
+		case waitErr := <-waitDone:
+			_ = ptmx.Close()
+			<-copyDone
+			if waitErr != nil {
+				var exitErr *exec.ExitError
+				if errors.As(waitErr, &exitErr) {
+					return fmt.Errorf("child exited with code %d (transcript: %s)",
+						exitErr.ExitCode(), logPath)
+				}
+				return fmt.Errorf("child wait: %w", waitErr)
+			}
+			return nil
+		case <-overall:
+			_ = cmd.Process.Kill()
+			<-waitDone
+			_ = ptmx.Close()
+			<-copyDone
+			return fmt.Errorf("child did not exit within %s (transcript: %s)",
+				exitTimeout, logPath)
+		}
+	}
+}

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -179,30 +179,15 @@ sudo grep -q '"apiVersion": "sbsh/v1beta1"' "${ATTACH_SMOKE_METADATA}" \
 sudo grep -q '"kind": "Terminal"' "${ATTACH_SMOKE_METADATA}" \
     || { printf 'rendered metadata at %s missing kind Terminal\n' "${ATTACH_SMOKE_METADATA}" >&2; exit 1; }
 
-# PTY-driven `kuke attach` smoke. `expect` allocates a TTY (pkg/attach
-# requires one) and times out under 20s. The detach sequence is the same
-# Ctrl+] Ctrl+] sbsh registers — a clean exit confirms the kuketty server
-# is serving the JSON-RPC + SCM_RIGHTS protocol pkg/attach speaks.
-if ! command -v expect >/dev/null 2>&1; then
-    printf 'expect(1) not on PATH; install `expect` (apt: expect, rpm: expect) to run the kuke attach smoke\n' >&2
-    exit 1
-fi
-
+# PTY-driven `kuke attach` smoke. hack/attach-smoke allocates a TTY
+# (pkg/attach requires one), waits for pkg/attach's raw-mode keyboard
+# filter to wire up, sends the Ctrl+] Ctrl+] detach sequence sbsh
+# registers, and enforces a 20s overall deadline. A clean exit confirms
+# the kuketty server is serving the JSON-RPC + SCM_RIGHTS protocol
+# pkg/attach speaks.
 ATTACH_LOG="${ATTACH_SMOKE_TMP}/attach.log"
-expect <<EOF >"${ATTACH_LOG}" 2>&1
-set timeout 20
-spawn sudo ./kuke attach ${ATTACH_SMOKE_CELL} --realm ${ATTACH_SMOKE_REALM} --space ${ATTACH_SMOKE_SPACE} --stack ${ATTACH_SMOKE_STACK} --container ${ATTACH_SMOKE_CONTAINER}
-# Give pkg/attach time to wire its raw-mode keyboard filter before sending
-# the detach sequence — the filter is what recognizes ^]^] as detach
-# rather than forwarding the bytes verbatim.
-sleep 2
-send "\035\035"
-expect eof
-catch wait result
-set exitcode [lindex \$result 3]
-if {\$exitcode != 0} {
-    puts "kuke attach exited with code \$exitcode"
-    exit \$exitcode
-}
-EOF
+go run ./hack/attach-smoke --log "${ATTACH_LOG}" -- \
+    sudo ./kuke attach "${ATTACH_SMOKE_CELL}" \
+        --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" \
+        --stack "${ATTACH_SMOKE_STACK}" --container "${ATTACH_SMOKE_CONTAINER}"
 echo "kuke attach exited cleanly (see ${ATTACH_LOG} for the full transcript)"


### PR DESCRIPTION
## Summary

- `scripts/dev-init.sh` required `expect(1)` solely to drive the final `kuke attach` smoke; an unobvious prereq that fails contributor first-runs several minutes in. `github.com/creack/pty` is already a direct dependency, so a small Go helper replaces the Tcl block with no new toolchain footprint.
- New `hack/attach-smoke/main.go` allocates a PTY, spawns an arbitrary command attached to it, waits a configurable connect-grace, sends sbsh's `\x1d\x1d` detach sequence, enforces an overall deadline, and writes the child's transcript to `--log`. Defaults (`2s` connect-grace, `20s` exit-timeout) match the prior expect block. Detach sequence is hardcoded to match the e2e suite's `sbshDetachSequence`.
- Helper is invoked via `go run ./hack/attach-smoke` so no extra make target / build artifact is needed; the `kuke` build path stays untouched.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — full unit suite green (includes the new `hack/attach-smoke` module; `[no test files]`, builds clean)
- [x] Helper self-tests — verified exit-code propagation (`exit 42` → rc 42), timeout path (sleep 5 with 3s deadline → "child did not exit within 3s"), and detach-sequence write (`^]^]` present in transcript)
- [x] `make dev-init` — full re-bootstrap green on a host without `expect` installed; daemon-parity tail matches CLAUDE.md, attach smoke prints `kuke attach exited cleanly (...)`

Closes #428