### PR TITLE
fix: make kuke daemon reset idempotent when cell metadata is already gone

### DIFF
--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -119,32 +119,39 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("inspect kukeond cell: %w", err)
 	}
-	if !getRes.MetadataExists {
-		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
-	}
-
-	if isCellRunning(getRes.Cell) {
-		if stopErr := stopPhase(cmd, client, doc, timeout); stopErr != nil {
-			return stopErr
+	if getRes.MetadataExists {
+		if isCellRunning(getRes.Cell) {
+			if stopErr := stopPhase(cmd, client, doc, timeout); stopErr != nil {
+				return stopErr
+			}
+		} else {
+			cmd.Printf(
+				"kukeond was already stopped (cell %q in realm %q)\n",
+				consts.KukeSystemCellName, consts.KukeSystemRealmName,
+			)
 		}
-	} else {
+
+		delRes, err := client.DeleteCell(cmd.Context(), doc)
+		if err != nil {
+			return fmt.Errorf("delete kukeond cell: %w", err)
+		}
+		if !delRes.MetadataDeleted {
+			return errors.New("delete kukeond cell: controller reported no change")
+		}
 		cmd.Printf(
-			"kukeond was already stopped (cell %q in realm %q)\n",
+			"kukeond cell deleted (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+	} else {
+		// Teardown verbs are idempotent — a second `kuke daemon reset` after
+		// the cell metadata is already gone should still finish the remaining
+		// transient-file / --purge-system steps and exit 0, rather than reuse
+		// the "host not initialized" sentinel that gates read/write verbs.
+		cmd.Printf(
+			"kukeond cell already torn down (cell %q in realm %q)\n",
 			consts.KukeSystemCellName, consts.KukeSystemRealmName,
 		)
 	}
-
-	delRes, err := client.DeleteCell(cmd.Context(), doc)
-	if err != nil {
-		return fmt.Errorf("delete kukeond cell: %w", err)
-	}
-	if !delRes.MetadataDeleted {
-		return errors.New("delete kukeond cell: controller reported no change")
-	}
-	cmd.Printf(
-		"kukeond cell deleted (cell %q in realm %q)\n",
-		consts.KukeSystemCellName, consts.KukeSystemRealmName,
-	)
 
 	socketDir := resolveSocketDir(cmd)
 	runPath := resolveRunPath(cmd)

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -106,13 +106,27 @@ func TestDaemonReset(t *testing.T) {
 			},
 		},
 		{
-			name: "host not initialized",
+			name: "missing cell metadata is idempotent (already torn down)",
 			fake: &fakeClient{
 				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 					return kukeonv1.GetCellResult{MetadataExists: false}, nil
 				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					t.Fatalf("StopCell must not be called when metadata is already gone")
+					return kukeonv1.StopCellResult{}, nil
+				},
+				deleteCellFn: func(_ v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					t.Fatalf("DeleteCell must not be called when metadata is already gone")
+					return kukeonv1.DeleteCellResult{}, nil
+				},
 			},
-			wantErr: "kukeon host is not initialized",
+			wantOutputs: []string{
+				`kukeond cell already torn down (cell "kukeond" in realm "kuke-system")`,
+			},
+			wantNotOutputs: []string{
+				`kukeond cell deleted`,
+				`kukeond stopped`,
+			},
 		},
 		{
 			name: "GetCell error is wrapped",
@@ -414,6 +428,87 @@ func TestDaemonReset_PreservesDefaultRealm(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), systemDir) {
 		t.Errorf("expected output to mention removed kuke-system dir; got:\n%s", buf.String())
+	}
+}
+
+// TestDaemonReset_PurgeSystemAfterTeardown covers the AC: a second
+// `kuke daemon reset --purge-system` on an already-reset host (cell metadata
+// missing) still removes /opt/kukeon/kuke-system and exits 0.
+func TestDaemonReset_PurgeSystemAfterTeardown(t *testing.T) {
+	withFreshViper(t)
+
+	runPath := t.TempDir()
+	systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	if err := os.MkdirAll(systemDir, 0o750); err != nil {
+		t.Fatalf("mkdir kuke-system: %v", err)
+	}
+	systemMarker := filepath.Join(systemDir, "system-data.txt")
+	if err := os.WriteFile(systemMarker, []byte("system data"), 0o600); err != nil {
+		t.Fatalf("seed system marker: %v", err)
+	}
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{MetadataExists: false}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--purge-system"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error on already-reset host with --purge-system: %v", err)
+	}
+	if _, err := os.Stat(systemDir); !os.IsNotExist(err) {
+		t.Errorf("kuke-system dir must be removed even when cell metadata is already gone: stat err=%v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "already torn down") {
+		t.Errorf("expected output to mention idempotent already-torn-down notice; got:\n%s", out)
+	}
+}
+
+// TestDaemonReset_PurgeSystemAfterTeardownNoSystemDir confirms that the
+// `--purge-system` step is also idempotent when /opt/kukeon/kuke-system is
+// already absent: no error, no "removed" line for the system dir.
+func TestDaemonReset_PurgeSystemAfterTeardownNoSystemDir(t *testing.T) {
+	withFreshViper(t)
+
+	runPath := t.TempDir()
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{MetadataExists: false}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--purge-system"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error on fully-clean host with --purge-system: %v", err)
+	}
+	systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	if strings.Contains(buf.String(), "removed "+systemDir) {
+		t.Errorf("did not expect 'removed' line for absent kuke-system dir; got:\n%s", buf.String())
 	}
 }
 

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -250,9 +250,10 @@ func TestKuke_DaemonRestart_TimeoutFlag(t *testing.T) {
 	}
 }
 
-// TestKuke_DaemonReset_Uninitialized verifies that `kuke daemon reset` fails
-// with the same friendly "host not initialized" message as the other daemon-
-// lifecycle verbs when the run-path has no kukeond cell metadata.
+// TestKuke_DaemonReset_Uninitialized verifies that `kuke daemon reset` is
+// idempotent on a host with no kukeond cell metadata: exit 0 with an
+// "already torn down" notice rather than the "host not initialized" sentinel
+// reserved for read/write verbs.
 func TestKuke_DaemonReset_Uninitialized(t *testing.T) {
 	t.Parallel()
 
@@ -261,15 +262,15 @@ func TestKuke_DaemonReset_Uninitialized(t *testing.T) {
 
 	args := append(buildKukeRunPathArgs(runPath), "daemon", "reset")
 	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
-	if exitCode == 0 {
+	if exitCode != 0 {
 		t.Fatalf(
-			"expected non-zero exit code on uninitialized host; stdout=%s stderr=%s",
-			string(stdout), string(stderr),
+			"expected exit 0 on uninitialized host (idempotent teardown); code=%d stdout=%s stderr=%s",
+			exitCode, string(stdout), string(stderr),
 		)
 	}
 	combined := string(stdout) + string(stderr)
-	if !strings.Contains(combined, "kuke init") {
-		t.Fatalf("expected error to mention `kuke init`, got: %s", combined)
+	if !strings.Contains(combined, "already torn down") {
+		t.Fatalf("expected output to mention 'already torn down', got: %s", combined)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Teardown verbs should not reuse the read/write "host not initialized" sentinel. `kuke daemon reset` (and `--purge-system`) now exit 0 with an "already torn down" notice when the kukeond cell metadata is missing, restoring the `docs/cli-use-cases.md` § "Lightweight teardown (dev loop)" invariant *"Idempotent: re-running on a host with no daemon succeeds."*
- The transient-file cleanup (`/run/kukeon/kukeond.{sock,pid}`) and `--purge-system` removal of `/opt/kukeon/kuke-system` still run on the already-reset path so a half-cleaned host can be finished off with a second invocation rather than left wedged.

## Test plan
- [x] `go test ./cmd/kuke/daemon/reset/...` (added: `missing cell metadata is idempotent (already torn down)`, `TestDaemonReset_PurgeSystemAfterTeardown`, `TestDaemonReset_PurgeSystemAfterTeardownNoSystemDir`; updated `TestKuke_DaemonReset_Uninitialized` e2e to expect exit 0 + "already torn down").
- [x] `make test` — full unit suite green.
- [x] Manual reproduction of the issue scenario on a live host (after `make dev-init`):
  ```
  $ sudo ./kuke daemon reset
  kukeond stopped (cell "kukeond" in realm "kuke-system")
  kukeond cell deleted (cell "kukeond" in realm "kuke-system")
  exit=0
  $ sudo ./kuke daemon reset
  kukeond cell already torn down (cell "kukeond" in realm "kuke-system")
  exit=0
  $ sudo ./kuke daemon reset --purge-system
  kukeond cell already torn down (cell "kukeond" in realm "kuke-system")
  removed /opt/kukeon/kuke-system
  exit=0
  ```
- [x] `make dev-init` smoke (CLAUDE.md regression guard) — daemon-parity check passes; both `kuke get realms` and `kuke get realms --no-daemon` produce the canonical two-realm table.
- [x] `go test -v -run TestKuke_DaemonReset ./e2e/...` — `TestKuke_DaemonReset_Uninitialized` and `TestKuke_DaemonReset_Flags` pass; `TestKuke_DaemonReset_RoundTrip` skipped (requires `make e2e` to build the local kukeond image — same skip the test already documents).

Closes #432