### PR TITLE
fix: make kuke uninstall exit non-zero on non-yes confirmation answer

### DIFF
--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -18,6 +18,7 @@ package uninstall
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -30,6 +31,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+// ErrAborted is returned when the interactive confirmation prompt receives
+// any answer other than "yes"/"y". It signals a clean abort to cobra so the
+// process exits non-zero, matching the documented invariant in
+// docs/cli-use-cases.md § "Full per-host teardown" (EOF or non-`yes` answer
+// aborts with non-zero exit and no destructive side effect).
+var ErrAborted = errors.New("uninstall aborted")
 
 // MockControllerKey injects a mock controller via cmd.Context() for tests.
 type MockControllerKey struct{}
@@ -108,7 +116,7 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 		}
 		if !confirmed {
 			cmd.Println("Aborted.")
-			return nil
+			return ErrAborted
 		}
 	}
 

--- a/cmd/kuke/uninstall/uninstall_test.go
+++ b/cmd/kuke/uninstall/uninstall_test.go
@@ -226,25 +226,42 @@ func TestUninstall_YesFlagSkipsPrompt(t *testing.T) {
 	}
 }
 
-func TestUninstall_PromptAbortsOnNo(t *testing.T) {
+// TestUninstall_PromptAbortsNonYes pins the docs/cli-use-cases.md invariant
+// that any non-"yes" answer (including "no", "n", and an empty line) aborts
+// with non-zero exit and no destructive side effect, matching the EOF path.
+// Issue #433 — tooling that gates on the documented "non-zero on abort"
+// contract was silently treating a "no" answer as success.
+func TestUninstall_PromptAbortsNonYes(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
-	called := false
-	stub := &stubController{
-		uninstallFn: func(controller.UninstallOptions) (controller.UninstallReport, error) {
-			called = true
-			return controller.UninstallReport{}, nil
-		},
+	answers := []struct {
+		name  string
+		stdin string
+	}{
+		{"no", "no\n"},
+		{"n", "n\n"},
+		{"empty line", "\n"},
 	}
-	out, err := runCmd(t, stub, "no\n")
-	if err != nil {
-		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
-	}
-	if called {
-		t.Errorf("expected Uninstall not to fire after 'no' answer; output:\n%s", out)
-	}
-	if !strings.Contains(out, "Aborted.") {
-		t.Errorf("expected aborted message; got:\n%s", out)
+	for _, tc := range answers {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			stub := &stubController{
+				uninstallFn: func(controller.UninstallOptions) (controller.UninstallReport, error) {
+					called = true
+					return controller.UninstallReport{}, nil
+				},
+			}
+			out, err := runCmd(t, stub, tc.stdin)
+			if !errors.Is(err, uninstall.ErrAborted) {
+				t.Fatalf("expected ErrAborted, got %v; output:\n%s", err, out)
+			}
+			if called {
+				t.Errorf("expected Uninstall not to fire after %q answer; output:\n%s", tc.name, out)
+			}
+			if !strings.Contains(out, "Aborted.") {
+				t.Errorf("expected aborted message; got:\n%s", out)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- `kuke uninstall` (no `-y`) was answering `no`/`n`/empty with `Aborted.` and exit **0**, silently breaking the documented `docs/cli-use-cases.md` invariant ("EOF or a non-`yes` answer aborts with non-zero exit and no destructive side effect"). CI guards / wrapper scripts gating on the abort exit code were treating those answers as success.
- Return a new `ErrAborted` sentinel from `runUninstall` when the prompt rejects the answer, so cobra exits non-zero (matching the existing EOF path). `Aborted.` stays on stdout per the issue's "user-facing message can stay; only the exit code needs to change" call.
- `--yes` and `yes`/`y` paths are unchanged.

## Test plan
- [x] `make test` — passes; `cmd/kuke/uninstall` adds a `TestUninstall_PromptAbortsNonYes` table-test pinning the new exit-code contract for `no`, `n`, and empty-line answers.
- [x] `gofmt -l` clean on changed files.
- [x] Manual verification against built `./kuke`:
  - `echo "no"  | ./kuke uninstall` → `Aborted.` + `Error: uninstall aborted` + `exit=1`.
  - `echo "n"   | ./kuke uninstall` → `Aborted.` + `Error: uninstall aborted` + `exit=1`.
  - `echo ""    | ./kuke uninstall` → `Aborted.` + `Error: uninstall aborted` + `exit=1`.
  - `echo -n "" | ./kuke uninstall` (EOF, regression check) → `Error: read confirmation: EOF` + `exit=1` (unchanged).
- [ ] `pre-commit run` / `golangci-lint` — neither tool installed on the dev host; both run in CI. `gofmt -l` was used as a local proxy.

## Notes for the reviewer
- Cobra prints an additional `Error: uninstall aborted` line after the `Aborted.` user message. The mild duplication mirrors the existing EOF path (`Aborted.`-less but `Error: read confirmation: EOF`); silencing it would require flipping `SilenceErrors: true` on the command, which the rest of the project deliberately leaves `false` (e.g. `cmd/kuke/daemon/stop/stop.go:60`). Kept the convention; happy to change if you'd rather suppress the trailing line.
- `ErrAborted` is local to the `uninstall` package — it's the only interactive yes/no prompt in the CLI today (`Are you sure?` is grep-unique to `uninstall.go`), so it doesn't yet belong in `internal/errdefs`.

Closes #433