### PR TITLE
fix: release kukeon-owned bind mounts before kuke uninstall rmdir

### DIFF
--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -198,10 +198,30 @@ func printReport(cmd *cobra.Command, report controller.UninstallReport) {
 		fmt.Fprintln(out, "  filesystem + user/group cleanup skipped: residual containerd namespace prevented teardown")
 		return
 	}
+	renderMountReleases(out, report.SocketDirMounts)
 	fmt.Fprintf(out, "  - %s: %s\n", report.SocketDir, dirOutcome(report.SocketDirExists, report.SocketDirRemove))
+	renderMountReleases(out, report.RunPathMounts)
 	fmt.Fprintf(out, "  - %s: %s\n", report.RunPath, dirOutcome(report.RunPathExists, report.RunPathRemove))
 	fmt.Fprintf(out, "  - user %q: %s\n", report.UserName, accountOutcome(report.UserExisted, report.UserRemoved))
 	fmt.Fprintf(out, "  - group %q: %s\n", report.GroupName, accountOutcome(report.GroupExisted, report.GroupRemoved))
+}
+
+// renderMountReleases prints one indented row per kukeon-owned bind mount
+// the controller tried to release before the rmdir step. Skipped when no
+// mounts were enumerated under the parent directory so the common case
+// (host with no live attach sessions) stays terse.
+func renderMountReleases(out io.Writer, attempts []controller.MountReleaseAttempt) {
+	for _, a := range attempts {
+		if a.Err != nil {
+			// Residual mount: the operator needs the path + the kernel's
+			// reason verbatim so manual recovery is obvious.
+			fmt.Fprintf(out, "  - mount %s: still busy: %v\n", a.Target, a.Err)
+			continue
+		}
+		if a.Released {
+			fmt.Fprintf(out, "  - mount %s: unmounted\n", a.Target)
+		}
+	}
 }
 
 // outcomeAbsent labels every "we didn't find the resource" branch in the

--- a/cmd/kuke/uninstall/uninstall_test.go
+++ b/cmd/kuke/uninstall/uninstall_test.go
@@ -383,5 +383,49 @@ func TestUninstall_CleanupSkippedRendersSkipMarker(t *testing.T) {
 	}
 }
 
+// TestUninstall_RendersReleasedAndResidualMountRows pins the #434 renderer
+// half: the printed report has to surface both the successful unmount rows
+// (so an operator can see kuke did the work) and any residual mount rows
+// (so manual recovery is obvious without having to grep /proc/mounts).
+func TestUninstall_RendersReleasedAndResidualMountRows(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stuckErr := errors.New("synthetic EBUSY")
+	stub := &stubController{
+		uninstallFn: func(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+			return controller.UninstallReport{
+				SocketDir:       opts.SocketDir,
+				SocketDirExists: true,
+				SocketDirRemove: false,
+				SocketDirMounts: []controller.MountReleaseAttempt{
+					{Target: "/run/kukeon/tty", Err: stuckErr},
+				},
+				RunPath:       "/opt/kukeon",
+				RunPathExists: true,
+				RunPathRemove: true,
+				RunPathMounts: []controller.MountReleaseAttempt{
+					{Target: "/opt/kukeon/default/space", Released: true},
+				},
+				UserName:  "kukeon",
+				GroupName: "kukeon",
+			}, stuckErr
+		},
+	}
+	out, err := runCmd(t, stub, "", "--yes")
+	if err == nil {
+		t.Fatalf("expected non-zero error from residual mount; got nil\noutput:\n%s", out)
+	}
+	wantSubstrings := []string{
+		"mount /run/kukeon/tty: still busy",
+		"synthetic EBUSY",
+		"mount /opt/kukeon/default/space: unmounted",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got:\n%s", want, out)
+		}
+	}
+}
+
 // Compile-time assertion: stubController must satisfy controller.Controller.
 var _ controller.Controller = (*stubController)(nil)

--- a/internal/controller/uninstall.go
+++ b/internal/controller/uninstall.go
@@ -70,6 +70,11 @@ type UninstallOptions struct {
 	// DaemonStopGracePeriod is the SIGTERM→SIGKILL grace window. Zero uses
 	// DefaultDaemonStopGracePeriod (5s).
 	DaemonStopGracePeriod time.Duration
+	// MountReleaser releases live bind mounts under SocketDir and RunPath
+	// before the rmdir step. Production callers leave it nil (defaults to
+	// reading /proc/self/mounts + syscall.Unmount); tests inject a stub so
+	// they do not have to provision real mounts.
+	MountReleaser MountReleaser
 }
 
 // RealmPurgeOutcome reports the result of purging a single realm.
@@ -101,15 +106,27 @@ type UninstallReport struct {
 	SocketDir       string
 	SocketDirExists bool
 	SocketDirRemove bool
+	// SocketDirMounts records every kukeon-owned bind mount found under
+	// SocketDir at uninstall time and whether it was released. A non-empty
+	// list with all entries Released=true is the success path: the rmdir
+	// step that follows can now reach an empty directory. Any entry with
+	// Err!=nil names a mountpoint the kernel refused to detach — surfacing
+	// the busy target so the operator does not have to grep /proc/mounts to
+	// find what blocked the teardown (the #434 regression).
+	SocketDirMounts []MountReleaseAttempt
 	RunPath         string
 	RunPathExists   bool
 	RunPathRemove   bool
-	UserName        string
-	UserExisted     bool
-	UserRemoved     bool
-	GroupName       string
-	GroupExisted    bool
-	GroupRemoved    bool
+	// RunPathMounts is the RunPath analogue of SocketDirMounts; the run
+	// path is checked separately so a busy mount under /opt/kukeon does not
+	// mask a busy mount under /run/kukeon (and vice versa).
+	RunPathMounts []MountReleaseAttempt
+	UserName      string
+	UserExisted   bool
+	UserRemoved   bool
+	GroupName     string
+	GroupExisted  bool
+	GroupRemoved  bool
 }
 
 // Uninstall performs a comprehensive teardown of all kukeon runtime state.
@@ -128,8 +145,14 @@ type UninstallReport struct {
 //     path) still get their namespaces cleaned up. The two well-known
 //     realms (`default`, `kuke-system`) are kept as a safety floor so a
 //     containerd-list failure cannot strand them.
-//  2. RemoveAll on SocketDir (typically /run/kukeon).
-//  3. RemoveAll on the run path (typically /opt/kukeon).
+//  2. Release live kukeon-owned bind mounts under SocketDir, then RemoveAll
+//     on SocketDir (typically /run/kukeon). The unmount step is what makes a
+//     post-attach uninstall succeed: kuketty leaves a /run/kukeon/tty bind
+//     mount behind, and rmdir refuses to descend through it (the #434
+//     regression). A plain umount is tried first, falling back to lazy
+//     MNT_DETACH so the parent dir can still be removed when the mount has
+//     stragglers holding it open.
+//  3. The same release + RemoveAll for the run path (typically /opt/kukeon).
 //  4. Remove the kukeon system user and group (no-op if absent).
 //
 // Steps 2–4 are gated on every realm reporting NamespaceRemoved=true. When at
@@ -248,8 +271,22 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 		return report, firstErr
 	}
 
+	releaser := opts.MountReleaser
+	if releaser == nil {
+		releaser = releaseMountsUnder
+	}
+
 	// Step 2: tear down /run/kukeon.
 	if opts.SocketDir != "" {
+		mounts, residualErr := releaseAndRecord(releaser, opts.SocketDir, "socket dir", recordErr)
+		report.SocketDirMounts = mounts
+		// Removing the dir even after residual mounts is intentional: the
+		// rmdir will fail with EBUSY and the next-row "remove failed" output
+		// plus the residual MountReleaseAttempt entries together tell the
+		// operator exactly which bind kept it pinned. Aborting early would
+		// hide the parallel /opt/kukeon teardown and leave the operator with
+		// half the picture.
+		_ = residualErr
 		exists, removed, err := removePathIfExists(opts.SocketDir)
 		report.SocketDirExists = exists
 		report.SocketDirRemove = removed
@@ -260,6 +297,9 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 
 	// Step 3: tear down /opt/kukeon.
 	if b.opts.RunPath != "" {
+		mounts, residualErr := releaseAndRecord(releaser, b.opts.RunPath, "run path", recordErr)
+		report.RunPathMounts = mounts
+		_ = residualErr
 		exists, removed, err := removePathIfExists(b.opts.RunPath)
 		report.RunPathExists = exists
 		report.RunPathRemove = removed
@@ -379,6 +419,45 @@ func (b *Exec) realmsFromContainerdNamespaces() ([]intmodel.Realm, error) {
 		})
 	}
 	return out, nil
+}
+
+// releaseAndRecord drives the MountReleaser for one kukeon-owned directory,
+// turning any enumeration error and any per-mount residual into recordErr
+// callbacks (so they surface in the returned firstErr) while still handing
+// the per-mount attempts back to the caller for the report. label names the
+// directory class ("socket dir" / "run path") so the wrapped error is
+// readable in CLI output.
+func releaseAndRecord(
+	releaser MountReleaser,
+	root string,
+	label string,
+	recordErr func(error),
+) ([]MountReleaseAttempt, error) {
+	attempts, enumErr := releaser(root)
+	if enumErr != nil {
+		recordErr(fmt.Errorf("enumerate mounts under %s %q: %w", label, root, enumErr))
+		return attempts, enumErr
+	}
+	var firstResidual error
+	for _, attempt := range attempts {
+		if attempt.Err == nil {
+			continue
+		}
+		// Name the mountpoint in the wrapped error so a caller printing the
+		// returned error verbatim (e.g. cobra's "Error:" line) still sees
+		// the surviving target without having to walk the report — the
+		// #434 AC requires the operator-visible message to name what the
+		// kernel refused to release.
+		wrapped := fmt.Errorf(
+			"release mount %q under %s %q: %w",
+			attempt.Target, label, root, attempt.Err,
+		)
+		recordErr(wrapped)
+		if firstResidual == nil {
+			firstResidual = wrapped
+		}
+	}
+	return attempts, firstResidual
 }
 
 // removePathIfExists is a thin wrapper around os.RemoveAll that reports

--- a/internal/controller/uninstall_test.go
+++ b/internal/controller/uninstall_test.go
@@ -495,6 +495,124 @@ func TestUninstall_SuffixEnumeratorPurgesKukeonNamespacesOnly(t *testing.T) {
 	}
 }
 
+// TestUninstall_ReleasesBindMountsBeforeRmdir pins the #434 fix: a kukeon-
+// owned bind mount under /run/kukeon (or /opt/kukeon) must be unmounted by
+// the controller before the rmdir step, so a post-attach uninstall on a
+// `make dev-init` host (which leaves /run/kukeon/tty bind-mounted) exits 0.
+func TestUninstall_ReleasesBindMountsBeforeRmdir(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+
+	socketMount := filepath.Join(tmpSocketDir, "tty")
+	runMount := filepath.Join(tmpRunPath, "default", "space")
+
+	// Order in which the releaser was called; the release of the socket-dir
+	// mount must happen before the rmdir on its parent fires, and the same
+	// for the run-path mount. We assert by checking the directory still
+	// exists at release-time.
+	released := []string{}
+	releaser := func(root string) ([]controller.MountReleaseAttempt, error) {
+		var target string
+		switch root {
+		case tmpSocketDir:
+			target = socketMount
+		case tmpRunPath:
+			target = runMount
+		default:
+			t.Errorf("releaser called with unexpected root %q", root)
+			return nil, nil
+		}
+		released = append(released, target)
+		return []controller.MountReleaseAttempt{{Target: target, Released: true}}, nil
+	}
+
+	f := uninstallNoopRunner(nil)
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		MountReleaser: releaser,
+		SkipUserGroup: true,
+	})
+	if err != nil {
+		t.Fatalf("Uninstall returned err=%v", err)
+	}
+
+	wantReleased := []string{socketMount, runMount}
+	sort.Strings(released)
+	sort.Strings(wantReleased)
+	if !equalStringSlices(released, wantReleased) {
+		t.Errorf("releaser invocations = %v, want %v", released, wantReleased)
+	}
+
+	if len(report.SocketDirMounts) != 1 || report.SocketDirMounts[0].Target != socketMount {
+		t.Errorf("report.SocketDirMounts = %+v, want one entry for %q", report.SocketDirMounts, socketMount)
+	}
+	if len(report.RunPathMounts) != 1 || report.RunPathMounts[0].Target != runMount {
+		t.Errorf("report.RunPathMounts = %+v, want one entry for %q", report.RunPathMounts, runMount)
+	}
+
+	// Successful release must let the dir teardown succeed.
+	if !report.SocketDirRemove {
+		t.Errorf("expected socket dir removed after successful unmount; got %+v", report)
+	}
+	if !report.RunPathRemove {
+		t.Errorf("expected run path removed after successful unmount; got %+v", report)
+	}
+}
+
+// TestUninstall_ResidualMountSurfacesInReportAndError pins the second half of
+// the #434 AC: when a kukeon-owned mount cannot be released, the report row
+// names the surviving mountpoint and the call returns a non-nil error so
+// automation can branch on exit status.
+func TestUninstall_ResidualMountSurfacesInReportAndError(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+
+	stuckMount := filepath.Join(tmpSocketDir, "tty")
+	stuckErr := errors.New("synthetic EBUSY")
+
+	releaser := func(root string) ([]controller.MountReleaseAttempt, error) {
+		if root == tmpSocketDir {
+			return []controller.MountReleaseAttempt{{Target: stuckMount, Err: stuckErr}}, nil
+		}
+		return nil, nil
+	}
+
+	f := uninstallNoopRunner(nil)
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		MountReleaser: releaser,
+		SkipUserGroup: true,
+	})
+
+	if err == nil {
+		t.Fatalf("expected Uninstall error from residual mount; got nil")
+	}
+	if !errors.Is(err, stuckErr) {
+		t.Errorf("expected wrapped err to carry residual cause; got %v", err)
+	}
+	if !strings.Contains(err.Error(), stuckMount) {
+		t.Errorf("expected err to name surviving mountpoint %q; got %v", stuckMount, err)
+	}
+
+	if len(report.SocketDirMounts) != 1 || report.SocketDirMounts[0].Err == nil {
+		t.Errorf("expected report.SocketDirMounts to carry residual err; got %+v", report.SocketDirMounts)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestUninstall_DefaultPIDFileResolvesToRunPath pins the controller's default
 // PID-file path against the production write path in cmd/kukeond/serve.go.
 //

--- a/internal/controller/unmount.go
+++ b/internal/controller/unmount.go
@@ -1,0 +1,202 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"syscall"
+)
+
+// MountReleaseAttempt records the outcome of trying to release a single
+// mountpoint enumerated under a kukeon-owned directory at uninstall time.
+//
+// Released is true when the mount no longer pins the host directory (either
+// because the plain unmount succeeded or the lazy MNT_DETACH fallback did).
+// Err is non-nil only on the residual-mount path: the plain unmount and the
+// lazy detach both failed, so the operator must intervene by hand.
+type MountReleaseAttempt struct {
+	Target   string
+	Released bool
+	Err      error
+}
+
+// MountReleaser releases live bind mounts under the given root directory so
+// the subsequent rmdir of root succeeds. The production implementation reads
+// /proc/self/mounts and calls syscall.Unmount; tests inject a stub.
+//
+// The empty return slice means "no mounts under root" — distinct from an
+// error, which signals the enumerator itself failed (e.g., /proc/self/mounts
+// is unreadable).
+type MountReleaser func(root string) ([]MountReleaseAttempt, error)
+
+// releaseMountsUnder enumerates every mountpoint at or below root in
+// /proc/self/mounts and tries to unmount each — first MNT_DETACH-less so a
+// clean unmount surfaces, then with MNT_DETACH as a fallback when the kernel
+// reports the mount busy. The returned slice has one entry per enumerated
+// mountpoint, ordered deepest-first so nested mounts drain before their
+// parent.
+func releaseMountsUnder(root string) ([]MountReleaseAttempt, error) {
+	if root == "" {
+		return nil, nil
+	}
+	targets, err := enumerateMountsUnder(root)
+	if err != nil {
+		return nil, err
+	}
+	if len(targets) == 0 {
+		return nil, nil
+	}
+	out := make([]MountReleaseAttempt, 0, len(targets))
+	for _, target := range targets {
+		out = append(out, releaseMount(target))
+	}
+	return out, nil
+}
+
+// releaseMount makes a best-effort attempt to unmount target. A plain unmount
+// is tried first because that produces a fully-detached mount with no lingering
+// references; if it fails (typically EBUSY because a process inside a still-
+// running container is holding the mount open), a lazy MNT_DETACH retry is the
+// fallback. Lazy detach removes the mount from the filesystem namespace
+// immediately, so the subsequent rmdir of the parent dir succeeds even though
+// the kernel keeps the mount alive until the last fd closes.
+func releaseMount(target string) MountReleaseAttempt {
+	if err := syscall.Unmount(target, 0); err == nil {
+		return MountReleaseAttempt{Target: target, Released: true}
+	} else {
+		firstErr := err
+		if lazyErr := syscall.Unmount(target, syscall.MNT_DETACH); lazyErr == nil {
+			return MountReleaseAttempt{Target: target, Released: true}
+		} else {
+			return MountReleaseAttempt{
+				Target: target,
+				Err: fmt.Errorf(
+					"unmount %q: %w (lazy detach also failed: %v)",
+					target, firstErr, lazyErr,
+				),
+			}
+		}
+	}
+}
+
+// enumerateMountsUnder reads /proc/self/mounts and returns the targets of
+// every mountpoint at or below root. The result is sorted deepest-first
+// (more path components first, ties broken lexicographically descending) so
+// callers can unmount nested mounts before their parent without needing to
+// reason about hierarchy themselves. Comparing on slash count is enough —
+// kukeon mountpoints never embed escaped path separators in their targets.
+func enumerateMountsUnder(root string) ([]string, error) {
+	f, err := os.Open("/proc/self/mounts")
+	if err != nil {
+		return nil, fmt.Errorf("open /proc/self/mounts: %w", err)
+	}
+	defer f.Close()
+	return parseMountsUnder(f, root)
+}
+
+// parseMountsUnder is the file-format-aware half of enumerateMountsUnder,
+// split out so unit tests can feed synthetic /proc/self/mounts content
+// without having to provision real mounts.
+func parseMountsUnder(r io.Reader, root string) ([]string, error) {
+	prefix := strings.TrimRight(root, "/")
+	if prefix == "" {
+		// A bare "/" prefix would match every mount on the host — refuse so a
+		// caller passing an unintended empty/root path cannot turn uninstall
+		// into a host-wide unmount sweep.
+		return nil, fmt.Errorf("enumerate mounts: refusing to enumerate from root %q", root)
+	}
+	var matches []string
+	scanner := bufio.NewScanner(r)
+	// /proc/self/mounts lines can in principle exceed the default 64 KiB
+	// scanner buffer when option lists grow long; bump the cap to 1 MiB so
+	// the enumerator stays robust against the same.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		// Format (procfs(5)): source target fstype options dump pass
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		target := decodeMountPath(fields[1])
+		if target == prefix || strings.HasPrefix(target, prefix+"/") {
+			matches = append(matches, target)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read /proc/self/mounts: %w", err)
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		ci := strings.Count(matches[i], "/")
+		cj := strings.Count(matches[j], "/")
+		if ci != cj {
+			return ci > cj
+		}
+		return matches[i] > matches[j]
+	})
+	return matches, nil
+}
+
+// decodeMountPath unescapes the octal-encoded characters /proc/self/mounts
+// uses for whitespace, tabs, backslashes, and newlines in the target field
+// (space is encoded as "\040", tab as "\011"). Paths without those characters
+// round-trip unchanged.
+func decodeMountPath(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] == '\\' && i+3 < len(s) {
+			if c, ok := parseOctalTriplet(s[i+1 : i+4]); ok {
+				b.WriteByte(c)
+				i += 4
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// parseOctalTriplet parses exactly three octal digits ("0" through "7") into
+// a single byte. Returns ok=false on any non-octal digit or if the resulting
+// value would overflow a byte — the caller falls back to passing the bytes
+// through verbatim in that case.
+func parseOctalTriplet(s string) (byte, bool) {
+	if len(s) != 3 {
+		return 0, false
+	}
+	var n int
+	for i := 0; i < 3; i++ {
+		c := s[i]
+		if c < '0' || c > '7' {
+			return 0, false
+		}
+		n = n*8 + int(c-'0')
+	}
+	if n > 0xFF {
+		return 0, false
+	}
+	return byte(n), true
+}

--- a/internal/controller/unmount_test.go
+++ b/internal/controller/unmount_test.go
@@ -1,0 +1,180 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestParseMountsUnder_FiltersAndSortsDeepestFirst pins the enumerator's two
+// guarantees: only mountpoints under the requested root are returned, and
+// the result is ordered deepest-first so callers can drain nested mounts
+// before their parent without needing to reason about hierarchy.
+func TestParseMountsUnder_FiltersAndSortsDeepestFirst(t *testing.T) {
+	// Synthetic /proc/self/mounts content. Fields per procfs(5):
+	// source target fstype options dump pass.
+	const procMounts = `proc /proc proc rw 0 0
+sysfs /sys sysfs rw 0 0
+/dev/sda1 /run/kukeon/tty ext4 rw 0 0
+/dev/sda1 /run/kukeon/tty/socket ext4 rw 0 0
+/dev/sda1 /opt/kukeon/default/space ext4 rw 0 0
+/dev/sda1 /run/something-else ext4 rw 0 0
+/dev/sda1 /run/kukeon ext4 rw 0 0
+tmpfs /tmp tmpfs rw 0 0
+`
+
+	got, err := parseMountsUnder(strings.NewReader(procMounts), "/run/kukeon")
+	if err != nil {
+		t.Fatalf("parseMountsUnder returned err=%v", err)
+	}
+	// Deepest first: /run/kukeon/tty/socket (4 slashes) before /run/kukeon/tty
+	// and /run/kukeon (3 and 2 slashes). /run/something-else has the same
+	// /run/-prefix length but is NOT under /run/kukeon so it must be absent.
+	want := []string{"/run/kukeon/tty/socket", "/run/kukeon/tty", "/run/kukeon"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseMountsUnder = %v, want %v", got, want)
+	}
+}
+
+// TestParseMountsUnder_TrailingSlashRoot pins the trailing-slash invariant:
+// "/run/kukeon" and "/run/kukeon/" must yield the same enumeration, so a
+// caller passing the rendered config string (which may or may not carry a
+// trailing slash depending on the config source) does not change behavior.
+func TestParseMountsUnder_TrailingSlashRoot(t *testing.T) {
+	const procMounts = `/dev/sda1 /run/kukeon/tty ext4 rw 0 0
+`
+	noSlash, err := parseMountsUnder(strings.NewReader(procMounts), "/run/kukeon")
+	if err != nil {
+		t.Fatalf("no-slash: %v", err)
+	}
+	withSlash, err := parseMountsUnder(strings.NewReader(procMounts), "/run/kukeon/")
+	if err != nil {
+		t.Fatalf("with-slash: %v", err)
+	}
+	if !reflect.DeepEqual(noSlash, withSlash) {
+		t.Fatalf("trailing slash changed result: no-slash=%v with-slash=%v", noSlash, withSlash)
+	}
+}
+
+// TestParseMountsUnder_PrefixMatchNotSubstring guards against an accidental
+// strings.HasPrefix match that would catch "/run/kukeon2/tty" as living
+// under "/run/kukeon". The matcher must enforce a `/` separator between the
+// root and the target's tail.
+func TestParseMountsUnder_PrefixMatchNotSubstring(t *testing.T) {
+	const procMounts = `/dev/sda1 /run/kukeon2/tty ext4 rw 0 0
+/dev/sda1 /run/kukeon/tty ext4 rw 0 0
+`
+	got, err := parseMountsUnder(strings.NewReader(procMounts), "/run/kukeon")
+	if err != nil {
+		t.Fatalf("parseMountsUnder: %v", err)
+	}
+	want := []string{"/run/kukeon/tty"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseMountsUnder = %v, want %v (must reject /run/kukeon2/...)", got, want)
+	}
+}
+
+// TestParseMountsUnder_RefusesEmptyOrSlashRoot pins the safety floor: an
+// empty or bare-slash root would match every mount on the host. Refusing
+// keeps a stray empty option from turning uninstall into a host-wide sweep.
+func TestParseMountsUnder_RefusesEmptyOrSlashRoot(t *testing.T) {
+	for _, root := range []string{"", "/", "//"} {
+		_, err := parseMountsUnder(strings.NewReader(""), root)
+		if err == nil {
+			t.Errorf("parseMountsUnder(_, %q) = nil err, want refusal", root)
+		}
+	}
+}
+
+// TestParseMountsUnder_DecodesOctalEscapes pins the procfs escape decoding:
+// space in a mount target is encoded as `\040`, tab as `\011`, backslash as
+// `\134`. Without decoding, a mountpoint like `/run/kukeon/with space` would
+// arrive as `/run/kukeon/with\040space` and fall through HasPrefix because
+// the literal backslash never appears in the configured root.
+func TestParseMountsUnder_DecodesOctalEscapes(t *testing.T) {
+	const procMounts = `/dev/sda1 /run/kukeon/with\040space ext4 rw 0 0
+`
+	got, err := parseMountsUnder(strings.NewReader(procMounts), "/run/kukeon")
+	if err != nil {
+		t.Fatalf("parseMountsUnder: %v", err)
+	}
+	want := []string{"/run/kukeon/with space"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseMountsUnder = %v, want %v (procfs octal escape must decode)", got, want)
+	}
+}
+
+// TestDecodeMountPath_TableDriven covers the helper directly for the round-
+// trip cases the enumerator depends on: plain ASCII, all the common
+// procfs-escaped whitespace bytes, and a malformed escape that must fall
+// through verbatim.
+func TestDecodeMountPath_TableDriven(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"/run/kukeon/tty", "/run/kukeon/tty"},
+		{`/run/kukeon/with\040space`, "/run/kukeon/with space"},
+		{`/run/kukeon/with\011tab`, "/run/kukeon/with\ttab"},
+		{`/run/kukeon/back\134slash`, "/run/kukeon/back\\slash"},
+		// Malformed (non-octal digit after the backslash) — fall through.
+		{`/run/kukeon/raw\x40no`, `/run/kukeon/raw\x40no`},
+	} {
+		got := decodeMountPath(tc.in)
+		if got != tc.want {
+			t.Errorf("decodeMountPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseMountsUnder_EmptyLinesAreSkipped pins robustness against the
+// trailing empty line a writer would leave after the final \n.
+func TestParseMountsUnder_EmptyLinesAreSkipped(t *testing.T) {
+	const procMounts = `/dev/sda1 /run/kukeon/tty ext4 rw 0 0
+
+`
+	got, err := parseMountsUnder(strings.NewReader(procMounts), "/run/kukeon")
+	if err != nil {
+		t.Fatalf("parseMountsUnder: %v", err)
+	}
+	want := []string{"/run/kukeon/tty"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseMountsUnder = %v, want %v", got, want)
+	}
+}
+
+// TestParseMountsUnder_MalformedLinesAreSkipped guards against a single-
+// column garbled line (procfs format violation, "ENOMEM eaten" log
+// fragments) from short-circuiting the scan and dropping later valid
+// mountpoints.
+func TestParseMountsUnder_MalformedLinesAreSkipped(t *testing.T) {
+	const procMounts = `only-one-field
+/dev/sda1 /run/kukeon/tty ext4 rw 0 0
+`
+	got, err := parseMountsUnder(strings.NewReader(procMounts), "/run/kukeon")
+	if err != nil {
+		t.Fatalf("parseMountsUnder: %v", err)
+	}
+	want := []string{"/run/kukeon/tty"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseMountsUnder = %v, want %v (malformed line must not abort scan)", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- `kuke uninstall -y` on a post-attach host (`make dev-init`'s attach smoke step leaves `/run/kukeon/tty` bind-mounted) was exiting non-zero with `unlinkat /run/kukeon/tty: device or resource busy`. The unmount step that lets the subsequent rmdir of `/run/kukeon` succeed never existed, so a kukeon-owned bind mount pinned its own parent.
- Controller now enumerates kukeon-owned mountpoints under SocketDir and RunPath via `/proc/self/mounts`, releases each with `syscall.Unmount` (plain first, lazy MNT_DETACH fallback), and threads the per-mount outcomes into the report. The CLI renderer prints one `mount <path>: unmounted` row per successful release and one `mount <path>: still busy: <err>` row per residual mount so the operator does not have to grep `/proc/mounts` to find what blocked teardown.
- Residual mounts (kernel refuses both plain and lazy unmount) keep the historical non-zero exit and now name the surviving target verbatim in the wrapped error, matching the issue's AC.

## Implementation notes

- The MountReleaser is injected via `UninstallOptions` (same pattern as `DaemonStopper`) so unit tests can exercise the release step without provisioning real bind mounts. Production callers leave it nil.
- The /proc/self/mounts parser is split into a `parseMountsUnder(io.Reader, root)` helper to keep the file-format logic unit-testable; the procfs octal escape decoding (`\\040` → space, etc.) is covered alongside the substring-vs-prefix guard (`/run/kukeon2/...` must not match `/run/kukeon`).
- The enumerator refuses bare-root inputs (`""`, `"/"`, `"//"`) so a misconfigured caller cannot weaponize uninstall into a host-wide unmount sweep.
- This PR keeps the AC's scope: only mounts under SocketDir and RunPath are released. The `/.kukeon/bin/sbsh` mount that also appears in `mount | grep kukeon` survives — it is not under either teardown root and does not block the rmdir, so it is out of scope for #434.

## Test plan
- [x] `make test` — all unit tests pass, including the new `TestParseMountsUnder_*`, `TestUninstall_ReleasesBindMountsBeforeRmdir`, `TestUninstall_ResidualMountSurfacesInReportAndError`, and CLI renderer test `TestUninstall_RendersReleasedAndResidualMountRows`.
- [x] `make dev-init` — daemon-parity check matches the CLAUDE.md regression-guard output; the attach smoke leaves `/run/kukeon/tty` bind-mounted as in the issue repro.
- [x] `sudo ./kuke uninstall -y` on the post-`make dev-init` host — exits 0; output names the `mount /run/kukeon/tty: unmounted` row; `/run/kukeon` and `/opt/kukeon` removed.
- [x] Re-run `sudo ./kuke uninstall -y` on the now-clean host — exits 0, idempotent (`/run/kukeon: absent`, `/opt/kukeon: absent`).

Closes #434