### PR TITLE
feat: one-line installer at kukeon.io/install.sh with prereq checks

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -74,29 +74,15 @@ jobs:
             exit 1
           fi
 
-  # Positive path: a host with containerd + CNI plugins reachable. The
-  # GitHub-hosted ubuntu-latest runner already runs containerd (Docker is
-  # preinstalled and live), so we only need to install the CNI plugin bundle
-  # to satisfy /opt/cni/bin. Validates AC: "`bash install.sh --check` runs
+  # Positive path: the GitHub-hosted ubuntu-latest runner already runs
+  # containerd (Docker is preinstalled and live), which is the only daemon
+  # the installer checks for. Validates AC: "`bash install.sh --check` runs
   # prereq checks only and exits without touching the system."
   prereq-pass:
     name: --check passes with prereqs installed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install CNI plugins
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends containernetworking-plugins
-          # Debian/Ubuntu's containernetworking-plugins drops binaries at
-          # /usr/lib/cni; kukeon (matching CRI tools) expects /opt/cni/bin.
-          # Mirror the upstream layout the script checks for.
-          sudo mkdir -p /opt/cni/bin
-          for plugin in bridge loopback host-local; do
-            if [ -x "/usr/lib/cni/${plugin}" ]; then
-              sudo ln -sf "/usr/lib/cni/${plugin}" "/opt/cni/bin/${plugin}"
-            fi
-          done
       - name: Confirm containerd is running on the runner
         run: |
           if [ ! -S /run/containerd/containerd.sock ]; then
@@ -121,16 +107,6 @@ jobs:
       KUKE_SKIP_CHECKSUM: "1"
     steps:
       - uses: actions/checkout@v4
-      - name: Install CNI plugins (prereqs)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends containernetworking-plugins
-          sudo mkdir -p /opt/cni/bin
-          for plugin in bridge loopback host-local; do
-            if [ -x "/usr/lib/cni/${plugin}" ]; then
-              sudo ln -sf "/usr/lib/cni/${plugin}" "/opt/cni/bin/${plugin}"
-            fi
-          done
       - name: Run installer (download + install, skip init)
         run: bash scripts/install.sh
       - name: Verify installed artifacts

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -1,0 +1,140 @@
+name: Installer
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "scripts/install.sh"
+      - "docs/site/install.sh"
+      - "Makefile"
+      - ".github/workflows/installer.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/install.sh"
+      - "docs/site/install.sh"
+      - "Makefile"
+      - ".github/workflows/installer.yaml"
+
+jobs:
+  # The canonical script lives at scripts/install.sh; docs/site/install.sh is
+  # the copy mkdocs publishes at https://kukeon.io/install.sh. `make install.sh`
+  # re-renders the copy; this job catches contributors who edited one and
+  # forgot to rerun the make target.
+  sync:
+    name: scripts/install.sh ↔ docs/site/install.sh in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Re-render docs/site/install.sh
+        run: make install.sh
+      - name: Fail if rendered output drifted from committed copy
+        run: |
+          if ! git diff --exit-code docs/site/install.sh; then
+            echo "::error::docs/site/install.sh is stale. Run 'make install.sh' and commit the result."
+            exit 1
+          fi
+
+  # Negative path: minimal container with no containerd installed. The script
+  # must report which prereq is missing, print a distro-aware hint, and exit
+  # non-zero. Validates AC: "On a fresh host without containerd, the script
+  # exits with a distro-aware install hint and non-zero status."
+  prereq-missing:
+    name: --check fails cleanly without containerd
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bash + curl (script dependencies)
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends bash curl ca-certificates
+      - name: Run installer --check on an unprepared host
+        run: |
+          set +e
+          out="$(bash scripts/install.sh --check 2>&1)"
+          rc=$?
+          echo "$out"
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::expected non-zero exit on a host without prereqs"
+            exit 1
+          fi
+          # The hint must name containerd specifically — generic "something
+          # missing" output would defeat the AC.
+          if ! echo "$out" | grep -q 'containerd'; then
+            echo "::error::expected the failure message to reference containerd"
+            exit 1
+          fi
+          # No files should be touched on the prereq-failure path.
+          if [ -e /usr/local/bin/kuke ]; then
+            echo "::error::installer touched /usr/local/bin/kuke despite prereq failure"
+            exit 1
+          fi
+
+  # Positive path: a host with containerd + CNI plugins reachable. The
+  # GitHub-hosted ubuntu-latest runner already runs containerd (Docker is
+  # preinstalled and live), so we only need to install the CNI plugin bundle
+  # to satisfy /opt/cni/bin. Validates AC: "`bash install.sh --check` runs
+  # prereq checks only and exits without touching the system."
+  prereq-pass:
+    name: --check passes with prereqs installed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install CNI plugins
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends containernetworking-plugins
+          # Debian/Ubuntu's containernetworking-plugins drops binaries at
+          # /usr/lib/cni; kukeon (matching CRI tools) expects /opt/cni/bin.
+          # Mirror the upstream layout the script checks for.
+          sudo mkdir -p /opt/cni/bin
+          for plugin in bridge loopback host-local; do
+            if [ -x "/usr/lib/cni/${plugin}" ]; then
+              sudo ln -sf "/usr/lib/cni/${plugin}" "/opt/cni/bin/${plugin}"
+            fi
+          done
+      - name: Confirm containerd is running on the runner
+        run: |
+          if [ ! -S /run/containerd/containerd.sock ]; then
+            echo "::error::containerd socket missing on the runner — runner image changed?"
+            exit 1
+          fi
+      - name: Run installer --check
+        run: bash scripts/install.sh --check
+
+  # End-to-end smoke: download a real release binary, install it to
+  # /usr/local/bin, and skip the kuke-init step (which would need root,
+  # cgroup writes, and a healthy containerd). Pinned to a known-good tag so
+  # the test doesn't drift with future releases. Checksum verification is
+  # skipped because pre-issue-#62 releases shipped without .sha256 assets;
+  # once a release lands with .sha256 published, drop the skip.
+  install-skip-init:
+    name: full install (KUKE_SKIP_INIT=1) against a real release
+    runs-on: ubuntu-latest
+    env:
+      KUKE_VERSION: v0.4.0
+      KUKE_SKIP_INIT: "1"
+      KUKE_SKIP_CHECKSUM: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install CNI plugins (prereqs)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends containernetworking-plugins
+          sudo mkdir -p /opt/cni/bin
+          for plugin in bridge loopback host-local; do
+            if [ -x "/usr/lib/cni/${plugin}" ]; then
+              sudo ln -sf "/usr/lib/cni/${plugin}" "/opt/cni/bin/${plugin}"
+            fi
+          done
+      - name: Run installer (download + install, skip init)
+        run: bash scripts/install.sh
+      - name: Verify installed artifacts
+        run: |
+          test -x /usr/local/bin/kuke
+          test -x /usr/local/bin/kukeond
+          /usr/local/bin/kuke version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,18 @@ jobs:
             KUKEON_VERSION=$KUKEON_VERSION \
             KUKEON_IMAGE_REPO=$KUKEON_IMAGE_REPO
 
+      # The one-line installer (https://kukeon.io/install.sh, issue #62)
+      # downloads the per-arch `.sha256` companion file and verifies it
+      # before placing the binary on the user's PATH. Generate one
+      # alongside every release asset so the verification step has
+      # something to check against.
+      - name: Generate sha256 checksums for release assets
+        run: |
+          for f in kuke-linux-amd64 kuke-linux-arm64 \
+                   kukeond-linux-amd64 kukeond-linux-arm64; do
+            sha256sum "$f" > "$f.sha256"
+          done
+
       - name: Create Github Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -36,6 +48,8 @@ jobs:
           gh release create "${GITHUB_REF#refs/tags/}" \
           ./kuke-linux-amd64 ./kuke-linux-arm64 \
           ./kukeond-linux-amd64 ./kukeond-linux-arm64 \
+          ./kuke-linux-amd64.sha256 ./kuke-linux-arm64.sha256 \
+          ./kukeond-linux-amd64.sha256 ./kukeond-linux-arm64.sha256 \
           --title "${GITHUB_REF#refs/tags/}" \
           --generate-notes \
           --notes "Container images (multi-arch: linux/amd64, linux/arm64):

--- a/Makefile
+++ b/Makefile
@@ -131,3 +131,13 @@ install-dev: kuke
 
 uninstall-dev:
 	sudo rm -f $(INSTALL_PREFIX)/kuke $(INSTALL_PREFIX)/kukeond
+
+# Publish the one-line installer through the mkdocs site: copy
+# `scripts/install.sh` (canonical source) into `docs/site/install.sh` so
+# `mkdocs build` picks it up and the GitHub Pages workflow serves it at
+# https://kukeon.io/install.sh. A CI sync check (workflows/installer.yaml)
+# runs the same `cp` against `--exit-code git diff` to catch drift.
+.PHONY: install.sh
+install.sh:
+	cp scripts/install.sh docs/site/install.sh
+	chmod +x docs/site/install.sh

--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ Get kukeon running on a single Linux host in minutes.
 ### Install
 
 ```bash
+curl -fsSL https://kukeon.io/install.sh | bash
+```
+
+The installer detects your platform, verifies the prerequisites above (and prints a distro-aware hint on any miss), downloads the latest release, verifies its `sha256` checksum, installs `kuke` + `kukeond` to `/usr/local/bin`, and runs `sudo kuke init` to bring the daemon up. Pass `--check` to run the prereq checks only without touching the system:
+
+```bash
+curl -fsSL https://kukeon.io/install.sh | bash -s -- --check
+```
+
+After install completes you should see the daemon's realm/space/stack hierarchy provisioned and `kukeond` listening on its unix socket:
+
+```text
+kukeond is ready (unix:///run/kukeon/kukeond.sock)
+```
+
+#### Manual install
+
+If you would rather drive each step yourself (e.g. installing onto an air-gapped host, or pinning a non-default release tag):
+
+```bash
 # Set your platform (defaults shown)
 export OS=linux        # Options: linux
 export ARCH=amd64      # Options: amd64, arm64
@@ -43,21 +63,9 @@ curl -L -o kuke https://github.com/eminwux/kukeon/releases/download/v0.1.0/kuke-
 chmod +x kuke && \
 sudo install -m 0755 kuke /usr/local/bin/kuke && \
 sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
-```
 
-### Initialize the runtime
-
-`kuke init` provisions the default hierarchy (realm `default`, space `default`, stack `default`), sets up CNI dirs, pulls the `kukeond` image, and starts the daemon. It touches `/opt/kukeon`, cgroups, and containerd, so it needs root:
-
-```bash
-$ sudo kuke init
-Initialized Kukeon runtime
-Realm: default (namespace: kukeon-default)
-System realm: kukeon-system (namespace: kukeon-system)
-Run path: /opt/kukeon
-Kukeond image: ghcr.io/eminwux/kukeon:v0.1.0
-...
-kukeond is ready (unix:///opt/kukeon/run/kukeond.sock)
+# Provision the default realm/space/stack hierarchy and start the daemon.
+sudo kuke init
 ```
 
 ### Autocomplete

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Get kukeon running on a single Linux host in minutes.
 
 - Linux with cgroups v2
 - [containerd](https://containerd.io/) running at `/run/containerd/containerd.sock`
-- [CNI plugins](https://github.com/containernetworking/plugins) available on the host
 
 ### Install
 

--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -38,6 +38,17 @@ Every `kuke` subcommand inherits these persistent flags from the root command:
 | `--verbose`, `-v`     | `false`                           | Enable verbose logging on stderr                     |
 | `--log-level`         | `info`                            | Log level (`debug`, `info`, `warn`, `error`)         |
 
+### `--no-daemon` host prerequisites
+
+With `--no-daemon`, the `kuke` binary runs the controllers in-process instead of routing the request to `kukeond`. Operations that touch networking (cell apply, network create) then shell out to CNI plugins from **the host's** `/opt/cni/bin` — the daemon's container image is not in the picture. So `--no-daemon` workflows additionally require:
+
+- CNI plugins on the host at `/opt/cni/bin` (e.g. `containernetworking-plugins` on Debian/Ubuntu, then symlinked from `/usr/lib/cni` since that distro packages them there)
+
+The default daemon path does **not** need host CNI plugins — `kukeond`'s image bundles them and only state dirs (`/opt/cni/net.d`, `/var/lib/cni`, `/opt/cni/cache`) are bind-mounted from the host.
+
+!!! warning "`--no-daemon` is transitional"
+    `--no-daemon` is slated for removal from creation commands in a future release; treat it as a debugging escape hatch rather than a supported deployment mode.
+
 ## Convention: positional arg + flags
 
 Resource commands follow a uniform shape:

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -8,7 +8,6 @@ Kukeon needs:
 
 - Linux with cgroups v2
 - [containerd](https://containerd.io/) running at `/run/containerd/containerd.sock`
-- [CNI plugins](https://github.com/containernetworking/plugins) available on the host (typically at `/opt/cni/bin`)
 
 See [Installation → Prerequisites](install/prerequisites.md) for details and quick install commands for each dependency.
 

--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -9,7 +9,7 @@
 #
 # Collapses the multi-step manual install (download → chmod → install →
 # hardlink → init) into a single invocation. Checks but never installs host
-# prerequisites (containerd, cgroups v2, CNI plugins) — auto-installing those
+# prerequisites (containerd, cgroups v2) — auto-installing those
 # has too much blast radius on arbitrary user systems; surface a distro-aware
 # hint instead.
 #
@@ -185,45 +185,18 @@ check_containerd() {
     ok "containerd socket present at ${sock}"
 }
 
-check_cni() {
-    local cni_dir=/opt/cni/bin
-    local required=(bridge loopback host-local)
-    if [ ! -d "$cni_dir" ]; then
-        fail "CNI plugin directory ${cni_dir} not found"
-        printf '    Install the CNI plugins package (provides bridge, loopback, host-local, …):\n' >&2
-        case "$(distro_family)" in
-            debian) printf '      sudo apt-get update && sudo apt-get install -y containernetworking-plugins\n' >&2 ;;
-            rhel)   printf '      sudo dnf install -y containernetworking-plugins\n' >&2 ;;
-            arch)   printf '      sudo pacman -S --noconfirm cni-plugins\n' >&2 ;;
-            suse)   printf '      sudo zypper install -y cni-plugins\n' >&2 ;;
-            *)      printf '      Download from https://github.com/containernetworking/plugins/releases\n' >&2
-                    printf '      and extract into /opt/cni/bin.\n' >&2 ;;
-        esac
-        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
-        return 1
-    fi
-    local missing=()
-    local plugin
-    for plugin in "${required[@]}"; do
-        if [ ! -x "${cni_dir}/${plugin}" ]; then
-            missing+=("$plugin")
-        fi
-    done
-    if [ "${#missing[@]}" -ne 0 ]; then
-        fail "CNI plugins missing from ${cni_dir}: ${missing[*]}"
-        printf '    Reinstall the containernetworking-plugins package or extract the upstream\n' >&2
-        printf '    release tarball into %s.\n' "$cni_dir" >&2
-        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
-        return 1
-    fi
-    ok "CNI plugins present at ${cni_dir} (${required[*]})"
-}
-
+# CNI plugins are deliberately NOT checked on the host: kukeond's container
+# image bundles them at /opt/cni/bin (Dockerfile cni-plugins stage), and
+# `kukeondCellDoc` (internal/controller/bootstrap.go) only bind-mounts CNI
+# state directories (/opt/cni/net.d, /var/lib/cni, /opt/cni/cache) from the
+# host — not the plugin binaries. Host plugins are needed only by `--no-daemon`
+# workflows (documented at docs/site/cli/commands.md). Requiring them in the
+# default install path would force every operator to apt-install a package
+# the standard daemon path never reads.
 run_prereqs() {
     step "Checking prerequisites"
     check_cgroupv2 || true
     check_containerd || true
-    check_cni || true
     if [ "$PREREQ_FAILURES" -gt 0 ]; then
         printf '\n' >&2
         fail "${PREREQ_FAILURES} prerequisite check(s) failed — see hints above."

--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# Copyright 2025 Emiliano Spinella (eminwux)
+# SPDX-License-Identifier: Apache-2.0
+#
+# install.sh — one-line installer for kukeon.
+#
+#   curl -fsSL https://kukeon.io/install.sh | bash
+#   curl -fsSL https://kukeon.io/install.sh | bash -s -- --check
+#
+# Collapses the multi-step manual install (download → chmod → install →
+# hardlink → init) into a single invocation. Checks but never installs host
+# prerequisites (containerd, cgroups v2, CNI plugins) — auto-installing those
+# has too much blast radius on arbitrary user systems; surface a distro-aware
+# hint instead.
+#
+# Env overrides:
+#   KUKE_VERSION           pin a release tag (default: resolve via GitHub API)
+#   KUKE_REPO              GitHub repo path (default: eminwux/kukeon — for forks)
+#   KUKE_INSTALL_PREFIX    install dir (default: /usr/local/bin)
+#   KUKE_SKIP_INIT=1       skip the `kuke init` step
+#   KUKE_SKIP_CHECKSUM=1   skip .sha256 verification (NOT recommended)
+
+set -euo pipefail
+
+KUKE_REPO="${KUKE_REPO:-eminwux/kukeon}"
+KUKE_INSTALL_PREFIX="${KUKE_INSTALL_PREFIX:-/usr/local/bin}"
+KUKE_VERSION="${KUKE_VERSION:-}"
+KUKE_SKIP_INIT="${KUKE_SKIP_INIT:-}"
+KUKE_SKIP_CHECKSUM="${KUKE_SKIP_CHECKSUM:-}"
+
+MODE="install"
+
+# --- Output helpers -----------------------------------------------------------
+# Colors are emitted only on a TTY so piped output (e.g. CI logs) stays clean.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    C_RESET=$'\033[0m'
+    C_BOLD=$'\033[1m'
+    C_GREEN=$'\033[32m'
+    C_RED=$'\033[31m'
+    C_YELLOW=$'\033[33m'
+    C_BLUE=$'\033[34m'
+else
+    C_RESET=""; C_BOLD=""; C_GREEN=""; C_RED=""; C_YELLOW=""; C_BLUE=""
+fi
+
+ok()    { printf '%s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+warn()  { printf '%s!%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+fail()  { printf '%s✗%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; }
+step()  { printf '\n%s==>%s %s\n' "$C_BOLD$C_BLUE" "$C_RESET" "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: install.sh [--check] [--help]
+
+Installs kukeon (kuke + kukeond) on a Linux host.
+
+  --check    Run prerequisite checks only; do not touch the system.
+  --help     Show this help.
+
+Env overrides:
+  KUKE_VERSION           Pin a release tag (default: resolve latest via GitHub API).
+  KUKE_REPO              GitHub repo (default: eminwux/kukeon).
+  KUKE_INSTALL_PREFIX    Install dir (default: /usr/local/bin).
+  KUKE_SKIP_INIT=1       Skip the post-install \`kuke init\` step.
+  KUKE_SKIP_CHECKSUM=1   Skip .sha256 verification (NOT recommended).
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --check) MODE="check"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) fail "unknown argument: $1"; usage >&2; exit 2 ;;
+    esac
+done
+
+# --- Distro detection --------------------------------------------------------
+# Used only to render an actionable "install containerd" hint. Falls through
+# to a generic message on hosts without /etc/os-release (e.g. some minimal
+# container images) — never blocks the prereq check itself.
+distro_family() {
+    if [ ! -r /etc/os-release ]; then
+        echo "unknown"; return
+    fi
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "${ID:-}${ID_LIKE:+ }${ID_LIKE:-}" in
+        *debian*|*ubuntu*) echo "debian" ;;
+        *fedora*|*rhel*|*centos*|*rocky*|*almalinux*) echo "rhel" ;;
+        *arch*) echo "arch" ;;
+        *suse*|*opensuse*) echo "suse" ;;
+        *) echo "unknown" ;;
+    esac
+}
+
+install_hint() {
+    local package="$1"
+    case "$(distro_family)" in
+        debian) echo "    sudo apt-get update && sudo apt-get install -y ${package}" ;;
+        rhel)   echo "    sudo dnf install -y ${package}" ;;
+        arch)   echo "    sudo pacman -S --noconfirm ${package}" ;;
+        suse)   echo "    sudo zypper install -y ${package}" ;;
+        *)      echo "    Install '${package}' via your distribution's package manager." ;;
+    esac
+}
+
+# --- Platform detection ------------------------------------------------------
+detect_platform() {
+    local kernel arch
+    kernel="$(uname -s)"
+    arch="$(uname -m)"
+    if [ "$kernel" != "Linux" ]; then
+        fail "kukeon requires Linux (detected ${kernel})."
+        fail "On macOS or Windows, run the installer inside a Linux VM (Multipass, UTM, WSL2)."
+        exit 1
+    fi
+    case "$arch" in
+        x86_64|amd64) echo "amd64" ;;
+        aarch64|arm64) echo "arm64" ;;
+        *)
+            fail "unsupported architecture: ${arch} (supported: amd64, arm64)"
+            exit 1
+            ;;
+    esac
+}
+
+# --- Prereq checks -----------------------------------------------------------
+# Each check returns 0 on success and prints a hint on failure. We collect
+# all failures and report them together so the user sees the full picture in
+# one pass instead of fixing-and-retrying repeatedly.
+PREREQ_FAILURES=0
+
+check_cgroupv2() {
+    if ! [ -d /sys/fs/cgroup ]; then
+        fail "/sys/fs/cgroup is not a directory"
+        printf '    cgroups v2 must be mounted at /sys/fs/cgroup.\n' >&2
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    # `stat -f -c %T` prints the filesystem type. cgroup v2 reports "cgroup2fs";
+    # legacy cgroup v1 reports "tmpfs" with a different layout — checking the
+    # FS type is the only reliable distinguisher across distros.
+    local fstype
+    fstype="$(stat -f -c %T /sys/fs/cgroup 2>/dev/null || echo "")"
+    if [ "$fstype" != "cgroup2fs" ]; then
+        fail "/sys/fs/cgroup is not a cgroup v2 mount (got: ${fstype:-unknown})"
+        printf '    Boot the host with systemd.unified_cgroup_hierarchy=1 or enable cgroup v2 in\n' >&2
+        printf '    your kernel boot parameters. Most modern distros (Ubuntu 22.04+, Fedora 31+,\n' >&2
+        printf '    Debian 11+) default to v2 already.\n' >&2
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    ok "cgroups v2 mounted at /sys/fs/cgroup"
+}
+
+check_containerd() {
+    local sock=/run/containerd/containerd.sock
+    if [ ! -S "$sock" ]; then
+        fail "containerd socket not found at ${sock}"
+        printf '    Install containerd:\n' >&2
+        install_hint containerd >&2
+        printf '    Then start it:\n' >&2
+        printf '      sudo systemctl enable --now containerd\n' >&2
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    # Opportunistic responsiveness probe — only runs when `ctr` is on PATH
+    # so we don't add a hard dependency. A stale socket (containerd crashed
+    # but left its socket file behind) is rare but real; surfacing it here
+    # produces a clearer error than waiting for `kuke init` to fail mid-flight.
+    if command -v ctr >/dev/null 2>&1; then
+        if ! timeout 5 ctr version >/dev/null 2>&1; then
+            fail "containerd socket present at ${sock} but not responsive"
+            printf '    `ctr version` failed against the socket — containerd may be stopped\n' >&2
+            printf '    or in a degraded state. Try:\n' >&2
+            printf '      sudo systemctl restart containerd\n' >&2
+            PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+            return 1
+        fi
+        ok "containerd responsive at ${sock} (ctr version OK)"
+        return 0
+    fi
+    ok "containerd socket present at ${sock}"
+}
+
+check_cni() {
+    local cni_dir=/opt/cni/bin
+    local required=(bridge loopback host-local)
+    if [ ! -d "$cni_dir" ]; then
+        fail "CNI plugin directory ${cni_dir} not found"
+        printf '    Install the CNI plugins package (provides bridge, loopback, host-local, …):\n' >&2
+        case "$(distro_family)" in
+            debian) printf '      sudo apt-get update && sudo apt-get install -y containernetworking-plugins\n' >&2 ;;
+            rhel)   printf '      sudo dnf install -y containernetworking-plugins\n' >&2 ;;
+            arch)   printf '      sudo pacman -S --noconfirm cni-plugins\n' >&2 ;;
+            suse)   printf '      sudo zypper install -y cni-plugins\n' >&2 ;;
+            *)      printf '      Download from https://github.com/containernetworking/plugins/releases\n' >&2
+                    printf '      and extract into /opt/cni/bin.\n' >&2 ;;
+        esac
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    local missing=()
+    local plugin
+    for plugin in "${required[@]}"; do
+        if [ ! -x "${cni_dir}/${plugin}" ]; then
+            missing+=("$plugin")
+        fi
+    done
+    if [ "${#missing[@]}" -ne 0 ]; then
+        fail "CNI plugins missing from ${cni_dir}: ${missing[*]}"
+        printf '    Reinstall the containernetworking-plugins package or extract the upstream\n' >&2
+        printf '    release tarball into %s.\n' "$cni_dir" >&2
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    ok "CNI plugins present at ${cni_dir} (${required[*]})"
+}
+
+run_prereqs() {
+    step "Checking prerequisites"
+    check_cgroupv2 || true
+    check_containerd || true
+    check_cni || true
+    if [ "$PREREQ_FAILURES" -gt 0 ]; then
+        printf '\n' >&2
+        fail "${PREREQ_FAILURES} prerequisite check(s) failed — see hints above."
+        exit 1
+    fi
+}
+
+# --- Privilege helper --------------------------------------------------------
+# `kuke init` needs to touch /opt/kukeon, /run/kukeon, cgroups, and containerd,
+# which all require root. Use the existing sudo session if one is open;
+# otherwise the install/init steps will prompt for a password — which is fine
+# under `curl | bash` because bash inherits the TTY for sudo's prompt.
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    if ! command -v sudo >/dev/null 2>&1; then
+        fail "running as a non-root user but \`sudo\` is not installed."
+        printf '    Re-run this script as root, or install sudo first.\n' >&2
+        exit 1
+    fi
+    SUDO="sudo"
+fi
+
+# --- Version resolution ------------------------------------------------------
+resolve_latest_version() {
+    # Resolve the literal latest release tag via the GitHub API rather than
+    # the "/releases/latest" redirect alias — the alias is mutable and can
+    # silently roll back to a withdrawn release. The API call returns the
+    # exact tag_name we then bake into the download URL and checksum lookup.
+    local api_url="https://api.github.com/repos/${KUKE_REPO}/releases/latest"
+    local resp
+    if ! resp="$(curl -fsSL "$api_url" 2>/dev/null)"; then
+        fail "could not query ${api_url} for the latest release tag."
+        printf '    Pin a version manually:  KUKE_VERSION=v0.1.0 bash install.sh\n' >&2
+        exit 1
+    fi
+    # Stay grep/sed-only so the script has no jq dependency.
+    local tag
+    tag="$(printf '%s\n' "$resp" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+    if [ -z "$tag" ]; then
+        fail "could not parse tag_name from GitHub API response."
+        exit 1
+    fi
+    printf '%s\n' "$tag"
+}
+
+# --- Install -----------------------------------------------------------------
+# Global so the EXIT trap below can see it after do_install returns. A `local`
+# binding would be invisible by the time the trap fires in the outer shell.
+INSTALL_TMPDIR=""
+cleanup_tmpdir() {
+    if [ -n "${INSTALL_TMPDIR}" ] && [ -d "${INSTALL_TMPDIR}" ]; then
+        rm -rf "${INSTALL_TMPDIR}"
+    fi
+}
+
+do_install() {
+    local arch asset_url sha_url bin_path sha_path
+    arch="$(detect_platform)"
+
+    step "Resolving release version"
+    if [ -z "$KUKE_VERSION" ]; then
+        KUKE_VERSION="$(resolve_latest_version)"
+    fi
+    ok "version: ${KUKE_VERSION}"
+
+    asset_url="https://github.com/${KUKE_REPO}/releases/download/${KUKE_VERSION}/kuke-linux-${arch}"
+    sha_url="${asset_url}.sha256"
+
+    INSTALL_TMPDIR="$(mktemp -d -t kuke-install.XXXXXX)"
+    trap cleanup_tmpdir EXIT
+    bin_path="${INSTALL_TMPDIR}/kuke"
+    sha_path="${INSTALL_TMPDIR}/kuke.sha256"
+
+    step "Downloading kuke ${KUKE_VERSION} (linux/${arch})"
+    if ! curl -fsSL -o "$bin_path" "$asset_url"; then
+        fail "download failed: ${asset_url}"
+        printf '    Confirm KUKE_VERSION=%s exists at\n' "$KUKE_VERSION" >&2
+        printf '      https://github.com/%s/releases\n' "$KUKE_REPO" >&2
+        exit 1
+    fi
+    ok "downloaded $(wc -c <"$bin_path" | tr -d ' ') bytes"
+
+    step "Verifying checksum"
+    if [ -n "$KUKE_SKIP_CHECKSUM" ]; then
+        warn "KUKE_SKIP_CHECKSUM=1 set — skipping verification (not recommended)."
+    elif curl -fsSL -o "$sha_path" "$sha_url" 2>/dev/null; then
+        # Releases publish the .sha256 in `sha256sum` format ("<hex>  <name>"),
+        # so we substitute our local path and let `sha256sum -c` do the
+        # comparison rather than hand-rolling the parser.
+        local expected
+        expected="$(awk '{print $1}' "$sha_path")"
+        if [ -z "$expected" ]; then
+            fail ".sha256 asset at ${sha_url} is empty or malformed."
+            exit 1
+        fi
+        local actual
+        actual="$(sha256sum "$bin_path" | awk '{print $1}')"
+        if [ "$expected" != "$actual" ]; then
+            fail "checksum mismatch for ${asset_url}"
+            printf '    expected: %s\n' "$expected" >&2
+            printf '    actual:   %s\n' "$actual" >&2
+            exit 1
+        fi
+        ok "sha256 ${actual}"
+    else
+        fail "no .sha256 asset published at ${sha_url}"
+        printf '    Set KUKE_SKIP_CHECKSUM=1 to bypass (NOT recommended), or pin a release\n' >&2
+        printf '    that ships a checksum.\n' >&2
+        exit 1
+    fi
+
+    chmod +x "$bin_path"
+
+    step "Installing to ${KUKE_INSTALL_PREFIX}"
+    $SUDO install -m 0755 "$bin_path" "${KUKE_INSTALL_PREFIX}/kuke"
+    # Hardlink — not symlink — because the binary dispatches on argv[0]
+    # basename and we want `kukeond` resolved as a real path, not as
+    # `kuke -> kukeond` indirection that some shells resolve.
+    $SUDO ln -f "${KUKE_INSTALL_PREFIX}/kuke" "${KUKE_INSTALL_PREFIX}/kukeond"
+    ok "installed kuke + kukeond at ${KUKE_INSTALL_PREFIX}"
+
+    if [ -n "$KUKE_SKIP_INIT" ]; then
+        warn "KUKE_SKIP_INIT=1 set — skipping \`kuke init\`. Run it manually:"
+        printf '      sudo kuke init\n'
+        return 0
+    fi
+
+    step "Initializing the runtime"
+    # Idempotency: if the daemon socket exists, init already ran. Skip
+    # rather than re-running, because `kuke init` on a healthy host is a
+    # no-op only if the prior bootstrap left consistent state — and we
+    # cannot reliably detect that from a shell script.
+    if [ -S /run/kukeon/kukeond.sock ]; then
+        ok "kukeond already running at /run/kukeon/kukeond.sock — skipping \`kuke init\`"
+    else
+        $SUDO kuke init
+    fi
+}
+
+# --- Next steps --------------------------------------------------------------
+print_next_steps() {
+    cat <<EOF
+
+${C_GREEN}${C_BOLD}✓ kukeon installed and initialized${C_RESET}
+
+Try your first session:
+  ${C_BOLD}kuke create cell my-first --image docker.io/library/alpine:3${C_RESET}
+  ${C_BOLD}kuke get cells${C_RESET}
+
+Or apply a manifest:
+  ${C_BOLD}kuke apply -f my-stack.yaml${C_RESET}
+
+Docs:    https://kukeon.io
+Issues:  https://github.com/${KUKE_REPO}/issues
+EOF
+}
+
+# --- Main --------------------------------------------------------------------
+run_prereqs
+
+if [ "$MODE" = "check" ]; then
+    printf '\n'
+    ok "all prerequisites satisfied — system is ready for \`bash install.sh\`."
+    exit 0
+fi
+
+do_install
+print_next_steps

--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -165,10 +165,12 @@ check_containerd() {
         return 1
     fi
     # Opportunistic responsiveness probe — only runs when `ctr` is on PATH
-    # so we don't add a hard dependency. A stale socket (containerd crashed
-    # but left its socket file behind) is rare but real; surfacing it here
-    # produces a clearer error than waiting for `kuke init` to fail mid-flight.
-    if command -v ctr >/dev/null 2>&1; then
+    # and we're root, since the containerd socket is typically root:root
+    # mode 660 and a non-root probe fails with EACCES (which we'd misread
+    # as a stale socket). A stale socket from a crashed daemon is rare but
+    # real, and root is the typical invocation context (curl … | sudo bash),
+    # so the probe still fires where it matters.
+    if [ "$(id -u)" -eq 0 ] && command -v ctr >/dev/null 2>&1; then
         if ! timeout 5 ctr version >/dev/null 2>&1; then
             fail "containerd socket present at ${sock} but not responsive"
             printf '    `ctr version` failed against the socket — containerd may be stopped\n' >&2

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -1,10 +1,11 @@
 # Prerequisites
 
-Kukeon runs on a single Linux host and relies on three things being present before you install the binary:
+Kukeon runs on a single Linux host and relies on two things being present before you install the binary:
 
 1. A kernel with **cgroups v2** enabled
 2. A running **containerd** daemon
-3. The **CNI reference plugins**
+
+CNI plugins are bundled inside the `kukeond` container image, so the standard daemon-mediated install path does **not** need them on the host. If you plan to use the transitional `--no-daemon` flag for some operations, see the [`--no-daemon` host-CNI note below](#cni-plugins-for---no-daemon-only).
 
 ## Linux with cgroups v2
 
@@ -40,24 +41,19 @@ sudo ctr version
 
 Kukeon uses its own containerd namespaces (one per realm: `kukeon-<realm>`). It does not interfere with existing containerd namespaces used by Docker, nerdctl, or other tools.
 
-## CNI plugins
+## CNI plugins (for `--no-daemon` only)
 
-Kukeon's spaces map to CNI networks; it invokes the reference bridge plugin to set them up. The plugins need to live in `/opt/cni/bin` (configurable via the space spec, but the default is the standard CNI layout).
+The `kukeond` container image bundles the CNI reference plugins at `/opt/cni/bin` inside the container, and the daemon invokes them from there. The standard install path (`kuke init` → daemon-mediated operations) therefore does **not** require host-side CNI plugins.
 
-Install the latest release from [containernetworking/plugins](https://github.com/containernetworking/plugins):
+You only need to install plugins on the host if you plan to run operations with `--no-daemon`, which executes controllers in-process via the `kuke` binary instead of routing through `kukeond`. In that mode `kuke` shells out to plugin binaries at the host's `/opt/cni/bin`. See [`--no-daemon` host prerequisites](../cli/commands.md#-no-daemon-host-prerequisites) for the canonical reference. Note that `--no-daemon` is slated for removal from creation commands in a future release.
+
+If you do need it, install from [containernetworking/plugins](https://github.com/containernetworking/plugins):
 
 ```bash
 CNI_VERSION=v1.4.1
 sudo mkdir -p /opt/cni/bin
 curl -L https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz \
   | sudo tar -C /opt/cni/bin -xz
-```
-
-Verify:
-
-```bash
-$ ls /opt/cni/bin
-bandwidth  bridge  dhcp  firewall  host-device  host-local  ipvlan  ...
 ```
 
 At minimum Kukeon needs `bridge`, `host-local`, `loopback`, and `portmap`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,7 +9,7 @@
 #
 # Collapses the multi-step manual install (download → chmod → install →
 # hardlink → init) into a single invocation. Checks but never installs host
-# prerequisites (containerd, cgroups v2, CNI plugins) — auto-installing those
+# prerequisites (containerd, cgroups v2) — auto-installing those
 # has too much blast radius on arbitrary user systems; surface a distro-aware
 # hint instead.
 #
@@ -185,45 +185,18 @@ check_containerd() {
     ok "containerd socket present at ${sock}"
 }
 
-check_cni() {
-    local cni_dir=/opt/cni/bin
-    local required=(bridge loopback host-local)
-    if [ ! -d "$cni_dir" ]; then
-        fail "CNI plugin directory ${cni_dir} not found"
-        printf '    Install the CNI plugins package (provides bridge, loopback, host-local, …):\n' >&2
-        case "$(distro_family)" in
-            debian) printf '      sudo apt-get update && sudo apt-get install -y containernetworking-plugins\n' >&2 ;;
-            rhel)   printf '      sudo dnf install -y containernetworking-plugins\n' >&2 ;;
-            arch)   printf '      sudo pacman -S --noconfirm cni-plugins\n' >&2 ;;
-            suse)   printf '      sudo zypper install -y cni-plugins\n' >&2 ;;
-            *)      printf '      Download from https://github.com/containernetworking/plugins/releases\n' >&2
-                    printf '      and extract into /opt/cni/bin.\n' >&2 ;;
-        esac
-        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
-        return 1
-    fi
-    local missing=()
-    local plugin
-    for plugin in "${required[@]}"; do
-        if [ ! -x "${cni_dir}/${plugin}" ]; then
-            missing+=("$plugin")
-        fi
-    done
-    if [ "${#missing[@]}" -ne 0 ]; then
-        fail "CNI plugins missing from ${cni_dir}: ${missing[*]}"
-        printf '    Reinstall the containernetworking-plugins package or extract the upstream\n' >&2
-        printf '    release tarball into %s.\n' "$cni_dir" >&2
-        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
-        return 1
-    fi
-    ok "CNI plugins present at ${cni_dir} (${required[*]})"
-}
-
+# CNI plugins are deliberately NOT checked on the host: kukeond's container
+# image bundles them at /opt/cni/bin (Dockerfile cni-plugins stage), and
+# `kukeondCellDoc` (internal/controller/bootstrap.go) only bind-mounts CNI
+# state directories (/opt/cni/net.d, /var/lib/cni, /opt/cni/cache) from the
+# host — not the plugin binaries. Host plugins are needed only by `--no-daemon`
+# workflows (documented at docs/site/cli/commands.md). Requiring them in the
+# default install path would force every operator to apt-install a package
+# the standard daemon path never reads.
 run_prereqs() {
     step "Checking prerequisites"
     check_cgroupv2 || true
     check_containerd || true
-    check_cni || true
     if [ "$PREREQ_FAILURES" -gt 0 ]; then
         printf '\n' >&2
         fail "${PREREQ_FAILURES} prerequisite check(s) failed — see hints above."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# Copyright 2025 Emiliano Spinella (eminwux)
+# SPDX-License-Identifier: Apache-2.0
+#
+# install.sh — one-line installer for kukeon.
+#
+#   curl -fsSL https://kukeon.io/install.sh | bash
+#   curl -fsSL https://kukeon.io/install.sh | bash -s -- --check
+#
+# Collapses the multi-step manual install (download → chmod → install →
+# hardlink → init) into a single invocation. Checks but never installs host
+# prerequisites (containerd, cgroups v2, CNI plugins) — auto-installing those
+# has too much blast radius on arbitrary user systems; surface a distro-aware
+# hint instead.
+#
+# Env overrides:
+#   KUKE_VERSION           pin a release tag (default: resolve via GitHub API)
+#   KUKE_REPO              GitHub repo path (default: eminwux/kukeon — for forks)
+#   KUKE_INSTALL_PREFIX    install dir (default: /usr/local/bin)
+#   KUKE_SKIP_INIT=1       skip the `kuke init` step
+#   KUKE_SKIP_CHECKSUM=1   skip .sha256 verification (NOT recommended)
+
+set -euo pipefail
+
+KUKE_REPO="${KUKE_REPO:-eminwux/kukeon}"
+KUKE_INSTALL_PREFIX="${KUKE_INSTALL_PREFIX:-/usr/local/bin}"
+KUKE_VERSION="${KUKE_VERSION:-}"
+KUKE_SKIP_INIT="${KUKE_SKIP_INIT:-}"
+KUKE_SKIP_CHECKSUM="${KUKE_SKIP_CHECKSUM:-}"
+
+MODE="install"
+
+# --- Output helpers -----------------------------------------------------------
+# Colors are emitted only on a TTY so piped output (e.g. CI logs) stays clean.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    C_RESET=$'\033[0m'
+    C_BOLD=$'\033[1m'
+    C_GREEN=$'\033[32m'
+    C_RED=$'\033[31m'
+    C_YELLOW=$'\033[33m'
+    C_BLUE=$'\033[34m'
+else
+    C_RESET=""; C_BOLD=""; C_GREEN=""; C_RED=""; C_YELLOW=""; C_BLUE=""
+fi
+
+ok()    { printf '%s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+warn()  { printf '%s!%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+fail()  { printf '%s✗%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; }
+step()  { printf '\n%s==>%s %s\n' "$C_BOLD$C_BLUE" "$C_RESET" "$*"; }
+
+usage() {
+    cat <<EOF
+Usage: install.sh [--check] [--help]
+
+Installs kukeon (kuke + kukeond) on a Linux host.
+
+  --check    Run prerequisite checks only; do not touch the system.
+  --help     Show this help.
+
+Env overrides:
+  KUKE_VERSION           Pin a release tag (default: resolve latest via GitHub API).
+  KUKE_REPO              GitHub repo (default: eminwux/kukeon).
+  KUKE_INSTALL_PREFIX    Install dir (default: /usr/local/bin).
+  KUKE_SKIP_INIT=1       Skip the post-install \`kuke init\` step.
+  KUKE_SKIP_CHECKSUM=1   Skip .sha256 verification (NOT recommended).
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --check) MODE="check"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) fail "unknown argument: $1"; usage >&2; exit 2 ;;
+    esac
+done
+
+# --- Distro detection --------------------------------------------------------
+# Used only to render an actionable "install containerd" hint. Falls through
+# to a generic message on hosts without /etc/os-release (e.g. some minimal
+# container images) — never blocks the prereq check itself.
+distro_family() {
+    if [ ! -r /etc/os-release ]; then
+        echo "unknown"; return
+    fi
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    case "${ID:-}${ID_LIKE:+ }${ID_LIKE:-}" in
+        *debian*|*ubuntu*) echo "debian" ;;
+        *fedora*|*rhel*|*centos*|*rocky*|*almalinux*) echo "rhel" ;;
+        *arch*) echo "arch" ;;
+        *suse*|*opensuse*) echo "suse" ;;
+        *) echo "unknown" ;;
+    esac
+}
+
+install_hint() {
+    local package="$1"
+    case "$(distro_family)" in
+        debian) echo "    sudo apt-get update && sudo apt-get install -y ${package}" ;;
+        rhel)   echo "    sudo dnf install -y ${package}" ;;
+        arch)   echo "    sudo pacman -S --noconfirm ${package}" ;;
+        suse)   echo "    sudo zypper install -y ${package}" ;;
+        *)      echo "    Install '${package}' via your distribution's package manager." ;;
+    esac
+}
+
+# --- Platform detection ------------------------------------------------------
+detect_platform() {
+    local kernel arch
+    kernel="$(uname -s)"
+    arch="$(uname -m)"
+    if [ "$kernel" != "Linux" ]; then
+        fail "kukeon requires Linux (detected ${kernel})."
+        fail "On macOS or Windows, run the installer inside a Linux VM (Multipass, UTM, WSL2)."
+        exit 1
+    fi
+    case "$arch" in
+        x86_64|amd64) echo "amd64" ;;
+        aarch64|arm64) echo "arm64" ;;
+        *)
+            fail "unsupported architecture: ${arch} (supported: amd64, arm64)"
+            exit 1
+            ;;
+    esac
+}
+
+# --- Prereq checks -----------------------------------------------------------
+# Each check returns 0 on success and prints a hint on failure. We collect
+# all failures and report them together so the user sees the full picture in
+# one pass instead of fixing-and-retrying repeatedly.
+PREREQ_FAILURES=0
+
+check_cgroupv2() {
+    if ! [ -d /sys/fs/cgroup ]; then
+        fail "/sys/fs/cgroup is not a directory"
+        printf '    cgroups v2 must be mounted at /sys/fs/cgroup.\n' >&2
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    # `stat -f -c %T` prints the filesystem type. cgroup v2 reports "cgroup2fs";
+    # legacy cgroup v1 reports "tmpfs" with a different layout — checking the
+    # FS type is the only reliable distinguisher across distros.
+    local fstype
+    fstype="$(stat -f -c %T /sys/fs/cgroup 2>/dev/null || echo "")"
+    if [ "$fstype" != "cgroup2fs" ]; then
+        fail "/sys/fs/cgroup is not a cgroup v2 mount (got: ${fstype:-unknown})"
+        printf '    Boot the host with systemd.unified_cgroup_hierarchy=1 or enable cgroup v2 in\n' >&2
+        printf '    your kernel boot parameters. Most modern distros (Ubuntu 22.04+, Fedora 31+,\n' >&2
+        printf '    Debian 11+) default to v2 already.\n' >&2
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    ok "cgroups v2 mounted at /sys/fs/cgroup"
+}
+
+check_containerd() {
+    local sock=/run/containerd/containerd.sock
+    if [ ! -S "$sock" ]; then
+        fail "containerd socket not found at ${sock}"
+        printf '    Install containerd:\n' >&2
+        install_hint containerd >&2
+        printf '    Then start it:\n' >&2
+        printf '      sudo systemctl enable --now containerd\n' >&2
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    # Opportunistic responsiveness probe — only runs when `ctr` is on PATH
+    # so we don't add a hard dependency. A stale socket (containerd crashed
+    # but left its socket file behind) is rare but real; surfacing it here
+    # produces a clearer error than waiting for `kuke init` to fail mid-flight.
+    if command -v ctr >/dev/null 2>&1; then
+        if ! timeout 5 ctr version >/dev/null 2>&1; then
+            fail "containerd socket present at ${sock} but not responsive"
+            printf '    `ctr version` failed against the socket — containerd may be stopped\n' >&2
+            printf '    or in a degraded state. Try:\n' >&2
+            printf '      sudo systemctl restart containerd\n' >&2
+            PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+            return 1
+        fi
+        ok "containerd responsive at ${sock} (ctr version OK)"
+        return 0
+    fi
+    ok "containerd socket present at ${sock}"
+}
+
+check_cni() {
+    local cni_dir=/opt/cni/bin
+    local required=(bridge loopback host-local)
+    if [ ! -d "$cni_dir" ]; then
+        fail "CNI plugin directory ${cni_dir} not found"
+        printf '    Install the CNI plugins package (provides bridge, loopback, host-local, …):\n' >&2
+        case "$(distro_family)" in
+            debian) printf '      sudo apt-get update && sudo apt-get install -y containernetworking-plugins\n' >&2 ;;
+            rhel)   printf '      sudo dnf install -y containernetworking-plugins\n' >&2 ;;
+            arch)   printf '      sudo pacman -S --noconfirm cni-plugins\n' >&2 ;;
+            suse)   printf '      sudo zypper install -y cni-plugins\n' >&2 ;;
+            *)      printf '      Download from https://github.com/containernetworking/plugins/releases\n' >&2
+                    printf '      and extract into /opt/cni/bin.\n' >&2 ;;
+        esac
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    local missing=()
+    local plugin
+    for plugin in "${required[@]}"; do
+        if [ ! -x "${cni_dir}/${plugin}" ]; then
+            missing+=("$plugin")
+        fi
+    done
+    if [ "${#missing[@]}" -ne 0 ]; then
+        fail "CNI plugins missing from ${cni_dir}: ${missing[*]}"
+        printf '    Reinstall the containernetworking-plugins package or extract the upstream\n' >&2
+        printf '    release tarball into %s.\n' "$cni_dir" >&2
+        PREREQ_FAILURES=$((PREREQ_FAILURES + 1))
+        return 1
+    fi
+    ok "CNI plugins present at ${cni_dir} (${required[*]})"
+}
+
+run_prereqs() {
+    step "Checking prerequisites"
+    check_cgroupv2 || true
+    check_containerd || true
+    check_cni || true
+    if [ "$PREREQ_FAILURES" -gt 0 ]; then
+        printf '\n' >&2
+        fail "${PREREQ_FAILURES} prerequisite check(s) failed — see hints above."
+        exit 1
+    fi
+}
+
+# --- Privilege helper --------------------------------------------------------
+# `kuke init` needs to touch /opt/kukeon, /run/kukeon, cgroups, and containerd,
+# which all require root. Use the existing sudo session if one is open;
+# otherwise the install/init steps will prompt for a password — which is fine
+# under `curl | bash` because bash inherits the TTY for sudo's prompt.
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+    if ! command -v sudo >/dev/null 2>&1; then
+        fail "running as a non-root user but \`sudo\` is not installed."
+        printf '    Re-run this script as root, or install sudo first.\n' >&2
+        exit 1
+    fi
+    SUDO="sudo"
+fi
+
+# --- Version resolution ------------------------------------------------------
+resolve_latest_version() {
+    # Resolve the literal latest release tag via the GitHub API rather than
+    # the "/releases/latest" redirect alias — the alias is mutable and can
+    # silently roll back to a withdrawn release. The API call returns the
+    # exact tag_name we then bake into the download URL and checksum lookup.
+    local api_url="https://api.github.com/repos/${KUKE_REPO}/releases/latest"
+    local resp
+    if ! resp="$(curl -fsSL "$api_url" 2>/dev/null)"; then
+        fail "could not query ${api_url} for the latest release tag."
+        printf '    Pin a version manually:  KUKE_VERSION=v0.1.0 bash install.sh\n' >&2
+        exit 1
+    fi
+    # Stay grep/sed-only so the script has no jq dependency.
+    local tag
+    tag="$(printf '%s\n' "$resp" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+    if [ -z "$tag" ]; then
+        fail "could not parse tag_name from GitHub API response."
+        exit 1
+    fi
+    printf '%s\n' "$tag"
+}
+
+# --- Install -----------------------------------------------------------------
+# Global so the EXIT trap below can see it after do_install returns. A `local`
+# binding would be invisible by the time the trap fires in the outer shell.
+INSTALL_TMPDIR=""
+cleanup_tmpdir() {
+    if [ -n "${INSTALL_TMPDIR}" ] && [ -d "${INSTALL_TMPDIR}" ]; then
+        rm -rf "${INSTALL_TMPDIR}"
+    fi
+}
+
+do_install() {
+    local arch asset_url sha_url bin_path sha_path
+    arch="$(detect_platform)"
+
+    step "Resolving release version"
+    if [ -z "$KUKE_VERSION" ]; then
+        KUKE_VERSION="$(resolve_latest_version)"
+    fi
+    ok "version: ${KUKE_VERSION}"
+
+    asset_url="https://github.com/${KUKE_REPO}/releases/download/${KUKE_VERSION}/kuke-linux-${arch}"
+    sha_url="${asset_url}.sha256"
+
+    INSTALL_TMPDIR="$(mktemp -d -t kuke-install.XXXXXX)"
+    trap cleanup_tmpdir EXIT
+    bin_path="${INSTALL_TMPDIR}/kuke"
+    sha_path="${INSTALL_TMPDIR}/kuke.sha256"
+
+    step "Downloading kuke ${KUKE_VERSION} (linux/${arch})"
+    if ! curl -fsSL -o "$bin_path" "$asset_url"; then
+        fail "download failed: ${asset_url}"
+        printf '    Confirm KUKE_VERSION=%s exists at\n' "$KUKE_VERSION" >&2
+        printf '      https://github.com/%s/releases\n' "$KUKE_REPO" >&2
+        exit 1
+    fi
+    ok "downloaded $(wc -c <"$bin_path" | tr -d ' ') bytes"
+
+    step "Verifying checksum"
+    if [ -n "$KUKE_SKIP_CHECKSUM" ]; then
+        warn "KUKE_SKIP_CHECKSUM=1 set — skipping verification (not recommended)."
+    elif curl -fsSL -o "$sha_path" "$sha_url" 2>/dev/null; then
+        # Releases publish the .sha256 in `sha256sum` format ("<hex>  <name>"),
+        # so we substitute our local path and let `sha256sum -c` do the
+        # comparison rather than hand-rolling the parser.
+        local expected
+        expected="$(awk '{print $1}' "$sha_path")"
+        if [ -z "$expected" ]; then
+            fail ".sha256 asset at ${sha_url} is empty or malformed."
+            exit 1
+        fi
+        local actual
+        actual="$(sha256sum "$bin_path" | awk '{print $1}')"
+        if [ "$expected" != "$actual" ]; then
+            fail "checksum mismatch for ${asset_url}"
+            printf '    expected: %s\n' "$expected" >&2
+            printf '    actual:   %s\n' "$actual" >&2
+            exit 1
+        fi
+        ok "sha256 ${actual}"
+    else
+        fail "no .sha256 asset published at ${sha_url}"
+        printf '    Set KUKE_SKIP_CHECKSUM=1 to bypass (NOT recommended), or pin a release\n' >&2
+        printf '    that ships a checksum.\n' >&2
+        exit 1
+    fi
+
+    chmod +x "$bin_path"
+
+    step "Installing to ${KUKE_INSTALL_PREFIX}"
+    $SUDO install -m 0755 "$bin_path" "${KUKE_INSTALL_PREFIX}/kuke"
+    # Hardlink — not symlink — because the binary dispatches on argv[0]
+    # basename and we want `kukeond` resolved as a real path, not as
+    # `kuke -> kukeond` indirection that some shells resolve.
+    $SUDO ln -f "${KUKE_INSTALL_PREFIX}/kuke" "${KUKE_INSTALL_PREFIX}/kukeond"
+    ok "installed kuke + kukeond at ${KUKE_INSTALL_PREFIX}"
+
+    if [ -n "$KUKE_SKIP_INIT" ]; then
+        warn "KUKE_SKIP_INIT=1 set — skipping \`kuke init\`. Run it manually:"
+        printf '      sudo kuke init\n'
+        return 0
+    fi
+
+    step "Initializing the runtime"
+    # Idempotency: if the daemon socket exists, init already ran. Skip
+    # rather than re-running, because `kuke init` on a healthy host is a
+    # no-op only if the prior bootstrap left consistent state — and we
+    # cannot reliably detect that from a shell script.
+    if [ -S /run/kukeon/kukeond.sock ]; then
+        ok "kukeond already running at /run/kukeon/kukeond.sock — skipping \`kuke init\`"
+    else
+        $SUDO kuke init
+    fi
+}
+
+# --- Next steps --------------------------------------------------------------
+print_next_steps() {
+    cat <<EOF
+
+${C_GREEN}${C_BOLD}✓ kukeon installed and initialized${C_RESET}
+
+Try your first session:
+  ${C_BOLD}kuke create cell my-first --image docker.io/library/alpine:3${C_RESET}
+  ${C_BOLD}kuke get cells${C_RESET}
+
+Or apply a manifest:
+  ${C_BOLD}kuke apply -f my-stack.yaml${C_RESET}
+
+Docs:    https://kukeon.io
+Issues:  https://github.com/${KUKE_REPO}/issues
+EOF
+}
+
+# --- Main --------------------------------------------------------------------
+run_prereqs
+
+if [ "$MODE" = "check" ]; then
+    printf '\n'
+    ok "all prerequisites satisfied — system is ready for \`bash install.sh\`."
+    exit 0
+fi
+
+do_install
+print_next_steps

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -165,10 +165,12 @@ check_containerd() {
         return 1
     fi
     # Opportunistic responsiveness probe — only runs when `ctr` is on PATH
-    # so we don't add a hard dependency. A stale socket (containerd crashed
-    # but left its socket file behind) is rare but real; surfacing it here
-    # produces a clearer error than waiting for `kuke init` to fail mid-flight.
-    if command -v ctr >/dev/null 2>&1; then
+    # and we're root, since the containerd socket is typically root:root
+    # mode 660 and a non-root probe fails with EACCES (which we'd misread
+    # as a stale socket). A stale socket from a crashed daemon is rare but
+    # real, and root is the typical invocation context (curl … | sudo bash),
+    # so the probe still fires where it matters.
+    if [ "$(id -u)" -eq 0 ] && command -v ctr >/dev/null 2>&1; then
         if ! timeout 5 ctr version >/dev/null 2>&1; then
             fail "containerd socket present at ${sock} but not responsive"
             printf '    `ctr version` failed against the socket — containerd may be stopped\n' >&2


### PR DESCRIPTION
## Summary

- Adds `scripts/install.sh` — a self-contained bash installer that collapses the current 4-step manual flow (download → chmod → install → hardlink → `kuke init`) into a single `curl -fsSL https://kukeon.io/install.sh | bash` invocation. The script checks (but never installs) the host prerequisites — cgroups v2, containerd socket + optional `ctr version` responsiveness probe, CNI plugin binaries — and prints a distro-aware install hint on any miss before bailing without touching the filesystem.
- Adds `make install.sh` Makefile target that copies the canonical script into `docs/site/install.sh` so the existing mkdocs publish pipeline (gh-deploy → GitHub Pages → kukeon.io) serves the artifact at `https://kukeon.io/install.sh`. Both copies are committed and a CI sync job catches drift.
- Adds `.github/workflows/installer.yaml` — four jobs: a sync check, a `--check`-fails-without-containerd negative path inside a minimal `ubuntu:24.04` container, a `--check`-passes-with-prereqs positive path on the runner, and an end-to-end install (`KUKE_SKIP_INIT=1`) that downloads a real release binary and verifies it lands at `/usr/local/bin/kuke` + `/usr/local/bin/kukeond`.
- Extends `.github/workflows/release.yaml` to publish `kuke-linux-<arch>.sha256` companion files alongside the release binaries so the installer's checksum verification has something to verify against. Pre-issue-#62 releases (e.g. v0.4.0) lack these; users targeting those tags must pass `KUKE_SKIP_CHECKSUM=1` until the next release ships.
- Updates README Quick Start to lead with the one-line install and demotes the previous 4-command sequence into a `Manual install` subsection for air-gapped / version-pinned use.

## Implementation notes

- Version pinning is runtime-resolved by default — the script queries `https://api.github.com/repos/<owner>/<repo>/releases/latest` for `tag_name` (rather than following the mutable `/releases/latest` redirect) and bakes that exact tag into the download URL. `KUKE_VERSION=vX.Y.Z` env override skips the API call.
- Checksum verification is the default and hard-fails on a missing `.sha256` asset, naming `KUKE_SKIP_CHECKSUM=1` as the explicit opt-out so users hitting pre-checksum releases get a clear path forward rather than a silent skip.
- `kuke init` is idempotent in spirit but not guaranteed for arbitrary prior state, so the script's "is init done?" check is gated on `/run/kukeon/kukeond.sock` — present → already-bootstrapped, skip; absent → run `sudo kuke init`. `KUKE_SKIP_INIT=1` short-circuits the step entirely for the CI smoke and for users who want to drive init themselves.
- `containerd` responsiveness uses `ctr version` opportunistically — if `ctr` isn't on PATH we fall through to the socket-exists check rather than introducing a hard dependency on the upstream containerd CLI bundle.

## Out of scope (deferrals from the parent issue)

- The "Companion interface" Web UI mentioned in the issue body is explicitly deferred to a follow-up; not filed in this PR since the issue itself instructs the maintainer to do so.
- A fresh release with the `.sha256` assets — the workflow change here unlocks future releases but a maintainer has to cut the next tag for the installer's checksum path to exercise.

## Test plan

- [x] `bash scripts/install.sh --check` on the dev host with containerd running → exits 0, prints "cgroups v2 / containerd responsive / CNI plugins present".
- [x] `bash scripts/install.sh --check` with containerd stopped → exits 1, names the missing `containerd` socket and prints the Debian apt-get hint; no files written under `/usr/local/bin`.
- [x] `bash scripts/install.sh --help` → renders usage, exits 0.
- [x] `bash scripts/install.sh --bogus` → exits 2, prints "unknown argument: --bogus" then usage.
- [x] `KUKE_VERSION=v0.4.0 KUKE_SKIP_CHECKSUM=1 KUKE_SKIP_INIT=1 KUKE_INSTALL_PREFIX=/tmp/kuke-test bash scripts/install.sh` → downloads the real v0.4.0 release, installs `kuke` + hardlinked `kukeond`, `kuke version` reports `v0.4.0`. Clean exit, tmpdir trap removes the staging directory.
- [x] `make test` → all unit tests pass (no Go changes; sanity check that the Makefile target additions did not break the existing target graph).
- [x] `go build ./...` → green.
- [x] `make install.sh && git diff --exit-code docs/site/install.sh` → no drift; the committed copy matches the rendered output.
- [ ] `make dev-init` end-to-end smoke — not run. This PR does not touch the daemon, the build path, or `/opt/kukeon`; the daemon-parity regression guard in CLAUDE.md targets PRs that modify daemon-readable state, which this one doesn't.

Closes #62