### PR TITLE
fix: route cobra cmd.Print* output to stdout instead of stderr

### DIFF
--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -119,6 +119,14 @@ func NewKukeCmd() (*cobra.Command, error) {
 		},
 	}
 
+	// Wire the root to real streams so cobra's cmd.Print* helpers route
+	// non-error output to stdout. Without this, cobra's OutOrStderr() falls
+	// back to os.Stderr and every cmd.Print* in the tree lands on stderr,
+	// breaking `out=$(kuke …)` and `kuke … | xargs …`. Subcommands inherit
+	// these via cobra's getOut/getErr.
+	cmd.SetOut(os.Stdout)
+	cmd.SetErr(os.Stderr)
+
 	if err := SetupKukeCmd(cmd); err != nil {
 		return nil, fmt.Errorf("failed to setup kukeon command: %w", err)
 	}

--- a/cmd/kuke/kuke_test.go
+++ b/cmd/kuke/kuke_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
@@ -418,5 +419,24 @@ func TestSetPersistentLoggingFlagsViperBinding(t *testing.T) {
 	}
 	if !viper.GetBool(config.KUKEON_ROOT_VERBOSE.ViperKey) {
 		t.Errorf("viper binding mismatch for verbose: got false, want true")
+	}
+}
+
+// TestNewKukeCmdStreams guards against cobra's OutOrStderr default — if
+// SetOut/SetErr are dropped from NewKukeCmd, every cmd.Print* call in the
+// subcommand tree silently routes to stderr. Issue #436.
+func TestNewKukeCmdStreams(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd, err := kuke.NewKukeCmd()
+	if err != nil {
+		t.Fatalf("NewKukeCmd() error = %v, want nil", err)
+	}
+
+	if got := cmd.OutOrStdout(); got != os.Stdout {
+		t.Errorf("OutOrStdout() not wired to os.Stdout: got %T", got)
+	}
+	if got := cmd.ErrOrStderr(); got != os.Stderr {
+		t.Errorf("ErrOrStderr() not wired to os.Stderr: got %T", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Wire `cmd.SetOut(os.Stdout)` / `cmd.SetErr(os.Stderr)` once in `cmd/kuke/kuke.go` `NewKukeCmd()`. Cobra propagates these to every subcommand via `getOut`/`getErr`, so the ~145 `cmd.Print*` call sites across `cmd/kuke/` (init, apply, delete, refresh, image, daemon, get table rows, etc.) flip to stdout without per-site edits.
- Without this, `cmd.Print*` falls back to `c.OutOrStderr()` → `os.Stderr`, breaking the Unix contract: `out=$(kuke get realms)` got nothing on stdout while `-o json` did, since the JSON branch writes via `json.NewEncoder(os.Stdout)` directly.
- Existing intentional stderr writes — `cmd/kuke/run/run.go:328` (`--rm` cleanup warning) and `cmd/kuke/image/load.go:139` (docker's own stderr passthrough) — were audited and retained.

## Behavior change for users / CI
Any script that grepped kuke's informational output via `2>&1` (or that only redirected stderr to capture progress) will now see that output on stdout instead. This is the correct Unix behavior, but worth a release-note line.

## Test plan
- [x] `make test` — full unit suite green locally.
- [x] `go build ./...` — clean compile.
- [x] `gofmt -l` and `go vet ./cmd/...` — clean.
- [x] New `TestNewKukeCmdStreams` in `cmd/kuke/kuke_test.go` asserts `cmd.OutOrStdout() == os.Stdout` and `cmd.ErrOrStderr() == os.Stderr` — regression guard against the SetOut/SetErr pair being dropped.
- [x] Smoke: `./kuke get realms --no-daemon` → `No realms found.` on **stdout** (was stderr); `./kuke get realms --no-daemon -o json` → `[]` on **stdout** (regression guard); `./kuke version` → on stdout (no regression); `./kuke daemon stop` error → on **stderr**; unknown command (`./kuke notacommand`) → cobra error on **stderr**; `./kuke --help` and `./kuke init --help` → on stdout.
- [ ] End-to-end `make dev-init` daemon-parity smoke — not run: this change is confined to root cobra stream wiring (`cmd/kuke/kuke.go` constructor) and does not touch the build path, daemon, or anything under `/opt/kukeon`, so the bind-mount regression guard does not apply. Inspecting the daemon's two-realm output is itself just `cmd.Print*` table rendering, which the routing smoke above already exercises.

Closes #436