### PR TITLE
fix: filter runner-synthesized state from kuke run/apply divergence

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -517,6 +517,15 @@ func pickLocation(fromDoc string, kv *config.Var) string {
 // cell as divergent on the very next `kuke run -f` invocation. Per the AC, a
 // genuine spec rewrite — adding/removing containers, swapping the root, moving
 // realm/space/stack — must route through `kuke apply -f` instead.
+//
+// Root containers are filtered out of the count/id-set comparison on both
+// sides. The runner synthesizes a root container during create if the YAML
+// omitted one (`docs/examples/hello-world.yaml` is the canonical case), so a
+// raw count comparison would treat every re-run of an existing file as
+// divergent (actual=root+web, desired=web) and route the operator to
+// `kuke apply -f` even though nothing changed. Comparing only the
+// user-supplied (non-root) entries restores the idempotent path while still
+// catching real adds/removes/renames among the user containers.
 func divergedFields(actual, desired v1beta1.CellSpec) []string {
 	var diffs []string
 
@@ -533,19 +542,23 @@ func divergedFields(actual, desired v1beta1.CellSpec) []string {
 	if len(actual.Containers) == 0 {
 		return diffs
 	}
-	if len(actual.Containers) != len(desired.Containers) {
+
+	actualUser := nonRootContainers(actual.Containers)
+	desiredUser := nonRootContainers(desired.Containers)
+
+	if len(actualUser) != len(desiredUser) {
 		diffs = append(diffs, fmt.Sprintf(
 			"spec.containers (count: actual=%d, desired=%d)",
-			len(actual.Containers), len(desired.Containers),
+			len(actualUser), len(desiredUser),
 		))
 		return diffs
 	}
 
-	desiredByID := make(map[string]v1beta1.ContainerSpec, len(desired.Containers))
-	for _, c := range desired.Containers {
+	desiredByID := make(map[string]v1beta1.ContainerSpec, len(desiredUser))
+	for _, c := range desiredUser {
 		desiredByID[c.ID] = c
 	}
-	for _, ac := range actual.Containers {
+	for _, ac := range actualUser {
 		dc, ok := desiredByID[ac.ID]
 		if !ok {
 			diffs = append(diffs, fmt.Sprintf("spec.containers[%q] (missing in file)", ac.ID))
@@ -556,6 +569,19 @@ func divergedFields(actual, desired v1beta1.CellSpec) []string {
 		}
 	}
 	return diffs
+}
+
+// nonRootContainers returns the user-supplied subset of cs — entries where
+// Root is false. Used to exclude the runner-synthesized root from divergence
+// comparison; see divergedFields.
+func nonRootContainers(cs []v1beta1.ContainerSpec) []v1beta1.ContainerSpec {
+	out := make([]v1beta1.ContainerSpec, 0, len(cs))
+	for _, c := range cs {
+		if !c.Root {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -84,6 +84,27 @@ spec:
         - "3600"
 `
 
+// cellYAMLUserContainersOnly mirrors docs/examples/hello-world.yaml: the user
+// declares only their workload container(s), and relies on the runner to
+// synthesize the root container during create. Used by the same-file re-run
+// regression below (issue #437).
+const cellYAMLUserContainersOnly = `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: my-cell
+spec:
+  id: my-cell
+  realmId: my-realm
+  spaceId: my-space
+  stackId: my-stack
+  containers:
+    - id: web
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+`
+
 const multiDocYAML = validCellYAML + "\n---\n" + validCellYAML
 
 const realmDocYAML = `apiVersion: v1beta1
@@ -487,6 +508,97 @@ func TestRun_ExistingCell_MatchingSpec_NotReady_StillEnsures(t *testing.T) {
 	}
 	if fc.createCalls != 1 {
 		t.Fatalf("CreateCell calls=%d want 1 (must ensure+start when not Ready)", fc.createCalls)
+	}
+}
+
+// TestRun_ExistingCell_SynthesizedRoot_DoesNotDiverge covers the same-file
+// re-run path for a YAML that omits an explicit root container (the canonical
+// case — `docs/examples/hello-world.yaml`). The on-disk cell carries the
+// runner-synthesized root entry; a naive count comparison would treat actual=2
+// vs desired=1 as divergent and refuse the re-run with `spec.containers
+// (count: actual=2, desired=1)`. Per issue #437, the divergence check must
+// exclude the synthesized root on both sides so the idempotent path works.
+func TestRun_ExistingCell_SynthesizedRoot_DoesNotDiverge(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "web", Image: "registry.eminwux.com/busybox:latest"},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                existing,
+				MetadataExists:      true,
+				CgroupExists:        true,
+				RootContainerExists: true,
+			}, nil
+		},
+	}
+	cmd, out := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, cellYAMLUserContainersOnly), "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned %v, want nil (re-run of same file must succeed)", err)
+	}
+	if fc.createCalls != 0 {
+		t.Fatalf("CreateCell calls=%d want 0 (short-circuit on matching spec + Ready)", fc.createCalls)
+	}
+	if !strings.Contains(out.String(), "  - metadata: already existed") {
+		t.Errorf("output missing 'already existed' marker:\n%s", out.String())
+	}
+}
+
+// TestRun_ExistingCell_SynthesizedRoot_RealDivergenceStillCaught makes sure
+// the issue #437 fix did not over-narrow: when the user adds a new container
+// to the YAML between runs, the refusal must still fire and name the
+// diverging field (count delta among user containers, not the synthesized
+// root).
+func TestRun_ExistingCell_SynthesizedRoot_RealDivergenceStillCaught(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// On-disk: synthesized root + the original "web" container.
+	// YAML in cellYAMLUserContainersOnly: only "web".
+	// Real divergence: on-disk has an additional user container "extra".
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "web", Image: "registry.eminwux.com/busybox:latest"},
+				{ID: "extra", Image: "registry.eminwux.com/busybox:latest"},
+			},
+		},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{Cell: existing, MetadataExists: true}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, cellYAMLUserContainersOnly), "-d"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want divergence error for real user-container delta")
+	}
+	if !strings.Contains(err.Error(), "kuke apply -f") {
+		t.Errorf("err=%q does not refer the operator to `kuke apply -f`", err)
+	}
+	if !strings.Contains(err.Error(), "actual=2, desired=1") {
+		t.Errorf("err=%q should report user-container counts excluding the synthesized root, got count delta", err)
 	}
 }
 

--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -18,6 +18,7 @@ package apply
 
 import (
 	"fmt"
+	"strings"
 
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
@@ -318,8 +319,15 @@ func DiffCell(desired, actual intmodel.Cell) CellDiffResult {
 		return result
 	}
 
-	// Compatible changes: labels
-	if !mapsEqual(desired.Metadata.Labels, actual.Metadata.Labels) {
+	// Compatible changes: labels. The runner injects canonical
+	// `*.kukeon.io` keys (cell.kukeon.io, realm.kukeon.io, …) on
+	// CreateCell — these are controller-managed, not user-authored, and
+	// must not be compared against an empty `desired.Metadata.Labels`
+	// (issue #437 AC #3). Without this filter, every `kuke apply -f` of a
+	// label-free YAML against an existing cell reports
+	// `metadata.labels changed`, falls through to UpdateCell, and
+	// clobbers the canonical labels with the user's empty map.
+	if !userLabelsEqual(desired.Metadata.Labels, actual.Metadata.Labels) {
 		result.HasChanges = true
 		if result.ChangeType == ChangeTypeNone {
 			result.ChangeType = ChangeTypeCompatible
@@ -350,12 +358,15 @@ func DiffCell(desired, actual intmodel.Cell) CellDiffResult {
 		result.BreakingChanges = append(result.BreakingChanges, "spec.rootContainer")
 		result.RootContainerDetails["rootContainer"] = "root container added"
 	case desiredRoot == nil && actualRoot != nil:
-		// Root container removed
-		result.HasChanges = true
-		result.ChangeType = ChangeTypeBreaking
-		result.RootContainerChanged = true
-		result.BreakingChanges = append(result.BreakingChanges, "spec.rootContainer")
-		result.RootContainerDetails["rootContainer"] = "root container removed"
+		// The YAML omitted a root container and the runner synthesized one
+		// during create (see `internal/controller/runner/provision.go`'s
+		// `ensureCellRootContainerSpec` path — every cell ends up with a
+		// `Root: true` entry whether or not the user authored one). Treating
+		// the synthesized root as a "removal" caused `kuke apply -f` of an
+		// unchanged file to report `Cell <name>: updated\n  - root
+		// container recreated` and trip RecreateCell. The synthesized root
+		// is an implementation detail of cell creation, not a user-authored
+		// field the apply layer should drift-detect on; skip it.
 	}
 
 	// Diff child containers
@@ -735,6 +746,32 @@ func boolPtrEqual(a, b *bool) bool {
 }
 
 // Helper functions
+
+// userLabelsEqual compares the user-authored subset of two label maps,
+// filtering out controller-managed keys (anything with the `.kukeon.io`
+// suffix — `cell.kukeon.io`, `realm.kukeon.io`, …, injected during cell
+// creation). Used by DiffCell so the runner-managed canonical labels do
+// not register as drift on a same-file re-apply (issue #437).
+func userLabelsEqual(desired, actual map[string]string) bool {
+	return mapsEqual(filterManagedLabels(desired), filterManagedLabels(actual))
+}
+
+// filterManagedLabels returns a copy of m with controller-managed keys
+// removed. A key is considered managed when its full name ends with
+// `.kukeon.io` — the suffix every controller-injected label uses.
+func filterManagedLabels(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return m
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		if strings.HasSuffix(k, ".kukeon.io") {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
 
 func mapsEqual(a, b map[string]string) bool {
 	if len(a) != len(b) {

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -139,3 +139,157 @@ func TestDiffCell_RootContainerChanged(t *testing.T) {
 		t.Errorf("expected breaking change, got %v", diff.ChangeType)
 	}
 }
+
+// TestDiffCell_ManagedLabels_NoChange covers the apply-side label leak called
+// out in issue #437. The runner injects canonical labels (cell.kukeon.io,
+// realm.kukeon.io, …) on CreateCell. A user YAML that omits labels must not
+// be reported as a `metadata.labels changed` drift on the same-file re-apply
+// — otherwise apply reports `updated` on the unchanged file and falls through
+// to UpdateCell which clobbers the canonical labels with the user's empty
+// map.
+func TestDiffCell_ManagedLabels_NoChange(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "web", Image: "busybox:latest"},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name: "hello-world",
+			Labels: map[string]string{
+				"cell.kukeon.io":  "hello-world",
+				"realm.kukeon.io": "default",
+				"space.kukeon.io": "default",
+				"stack.kukeon.io": "default",
+			},
+		},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "busybox:latest"},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if diff.HasChanges {
+		t.Errorf("expected no changes when actual carries only controller-managed labels, got: %+v", diff)
+	}
+}
+
+// TestDiffCell_UserLabels_StillDetectsDrift makes sure the managed-label
+// filter does not over-narrow: a real user-authored label change must still
+// register as drift.
+func TestDiffCell_UserLabels_StillDetectsDrift(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name:   "hello-world",
+			Labels: map[string]string{"env": "prod"},
+		},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "web", Image: "busybox:latest"},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name: "hello-world",
+			Labels: map[string]string{
+				"cell.kukeon.io": "hello-world",
+				"env":            "staging",
+			},
+		},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "busybox:latest"},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Error("expected drift on user-authored label change")
+	}
+	found := false
+	for _, f := range diff.ChangedFields {
+		if f == "metadata.labels" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected metadata.labels in ChangedFields, got %v", diff.ChangedFields)
+	}
+}
+
+// TestDiffCell_SynthesizedRoot_NoChange exercises the same-file re-apply path
+// for a YAML that omits a root container (the canonical case —
+// docs/examples/hello-world.yaml). The runner synthesizes a root entry during
+// create, so the on-disk Containers slice picks up a `Root: true` element the
+// user never authored. DiffCell must not treat that synthesized root as a
+// removal — doing so trips RecreateCell and produces the spurious
+// `Cell <name>: updated\n  - root container recreated` output on every
+// idempotent re-apply (issue #437).
+func TestDiffCell_SynthesizedRoot_NoChange(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{
+					ID:    "web",
+					Image: "busybox:latest",
+				},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{
+					ID:    "root",
+					Root:  true,
+					Image: "busybox:latest",
+				},
+				{
+					ID:    "web",
+					Image: "busybox:latest",
+				},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if diff.HasChanges {
+		t.Errorf("expected no changes for same-file re-apply, got changes: %+v", diff)
+	}
+	if diff.RootContainerChanged {
+		t.Error("synthesized root must not flag RootContainerChanged on re-apply")
+	}
+}

--- a/internal/controller/runner/update_cell.go
+++ b/internal/controller/runner/update_cell.go
@@ -59,9 +59,41 @@ func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		}
 	}
 
+	// Whether the desired side authored a root container. When the user YAML
+	// omits one (docs/examples/hello-world.yaml is the canonical case), the
+	// runner synthesized a root during create and the apply layer's diff
+	// already treats it as implementation detail (see
+	// `internal/controller/apply/diff.go`). UpdateCell must mirror that:
+	// preserve the actual root container in place, do not treat it as an
+	// orphan, and do not clear `Spec.RootContainerID` from the cell. Without
+	// this, every `kuke apply -f` of an unchanged file (issue #437) errored
+	// with "root container ... cannot be removed".
+	desiredHasRoot := false
+	for _, c := range desired.Spec.Containers {
+		if c.Root {
+			desiredHasRoot = true
+			break
+		}
+	}
+	var preservedRoot *intmodel.ContainerSpec
+	if !desiredHasRoot {
+		for i := range existing.Spec.Containers {
+			if existing.Spec.Containers[i].Root {
+				preservedRoot = &existing.Spec.Containers[i]
+				break
+			}
+		}
+	}
+
 	// Handle orphan containers (in actual but not in desired)
 	for id := range actualContainers {
 		if _, exists := desiredContainers[id]; !exists {
+			if actualContainers[id].Root && preservedRoot != nil {
+				// Runner-synthesized root: the user YAML omitted it, so the
+				// orphan check would otherwise refuse the update. Leave it
+				// alone (handled by the newContainers prepend below).
+				continue
+			}
 			// Root container cannot be removed from the cell
 			if actualContainers[id].Root {
 				return intmodel.Cell{}, fmt.Errorf(
@@ -109,7 +141,13 @@ func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 
 	// Update existing cell's containers list to match desired
 	// Preserve root container and existing containerd IDs where possible
-	newContainers := make([]intmodel.ContainerSpec, 0, len(desired.Spec.Containers))
+	newContainers := make([]intmodel.ContainerSpec, 0, len(desired.Spec.Containers)+1)
+	if preservedRoot != nil {
+		// Keep the synthesized root in front of the user-authored containers
+		// so RootContainerID still resolves and runner/refresh paths that
+		// scan Containers for the root see it.
+		newContainers = append(newContainers, *preservedRoot)
+	}
 	for _, desiredContainer := range desired.Spec.Containers {
 		if actualContainer, exists := actualContainers[desiredContainer.ID]; exists {
 			// Container exists, preserve containerd ID but update spec
@@ -182,7 +220,16 @@ func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 
 	// Update cell with new containers list
 	existing.Spec.Containers = newContainers
-	existing.Spec.RootContainerID = desired.Spec.RootContainerID
+	if preservedRoot != nil && desired.Spec.RootContainerID == "" {
+		// User YAML omitted the root container; preserve the existing
+		// RootContainerID so subsequent runner lookups still resolve.
+		// existing.Spec.RootContainerID is already set, so this is a no-op
+		// in the happy path — the explicit guard exists so a future
+		// refactor that clears existing.Spec.RootContainerID up-front does
+		// not silently drop it.
+	} else {
+		existing.Spec.RootContainerID = desired.Spec.RootContainerID
+	}
 
 	// Ensure all containers exist (will create missing ones, update existing ones)
 	if connectErr := r.ensureClientConnected(); connectErr != nil {


### PR DESCRIPTION
## Summary

- \`kuke run -f docs/examples/hello-world.yaml -d\` re-run against the cell it just created refused with a phantom \`spec.containers (count: actual=2, desired=1)\` error. The on-disk side counted the runner-synthesized root container (\`Root: true\`) toward \`spec.containers\` while the user YAML (which omits the root) did not. Fixed by excluding \`Root: true\` entries from the count/id-set comparison on both sides in \`divergedFields\` — same pattern \`internal/controller/apply/diff.go\` already uses for child-container diffs.
- \`kuke apply -f\` against the same unchanged file reported \`Cell <name>: updated\\n  - root container recreated\` because \`DiffCell\` hit \`desiredRoot == nil && actualRoot != nil\` and tripped \`RecreateCell\`. Fixed by treating the synthesized root as implementation detail (the runner always produces one) rather than as a removed user field.
- Removing the recreate path exposed two adjacent bugs in the same idempotent flow that had been masked by it: \`UpdateCell\` refused to remove the root from desired (it never should — runner synthesizes it), and \`DiffCell\`'s labels comparison flagged drift between the user's empty \`Labels\` and the canonical \`*.kukeon.io\` set the runner injected on create. Both are runner-managed state, same principle as the root container. \`UpdateCell\` now preserves the synthesized root through orphan detection and the rebuild loop; \`DiffCell\` filters \`*.kukeon.io\`-suffixed keys from the label comparison (canonical keys are controller-owned, not user-authored).

## Test plan

- [x] \`make test\` — all unit tests pass.
- [x] \`make dev-init\` — daemon parity check passes (the trailing \`kuke attach\` smoke step fails on \`registry.eminwux.com\` DNS in this dev container, unrelated to the diff).
- [x] \`sudo ./kuke run -f docs/examples/hello-world.yaml -d\` twice against the same cell: first run creates, second run returns exit 0 and reports \`already existed\` (AC #1).
- [x] Real-divergence variant (YAML with an added user container) still trips \`spec.containers (count: actual=1, desired=2)\` and points to \`kuke apply -f\` (AC #2).
- [x] \`sudo ./kuke apply -f docs/examples/hello-world.yaml\` against the existing cell reports \`Cell hello-world: unchanged\`. Repeated invocations also report \`unchanged\` (AC #3).
- [x] Post-apply \`kuke get cell hello-world -o yaml\` confirms the canonical \`cell.kukeon.io / realm.kukeon.io / space.kukeon.io / stack.kukeon.io\` labels are preserved (no clobber).
- [x] New unit tests:
  - \`cmd/kuke/run/run_test.go\`: \`TestRun_ExistingCell_SynthesizedRoot_DoesNotDiverge\`, \`TestRun_ExistingCell_SynthesizedRoot_RealDivergenceStillCaught\`.
  - \`internal/controller/apply/diff_test.go\`: \`TestDiffCell_SynthesizedRoot_NoChange\`, \`TestDiffCell_ManagedLabels_NoChange\`, \`TestDiffCell_UserLabels_StillDetectsDrift\`.
- [ ] \`make e2e\` — not run (e2e harness wants a clean host and times out on this dev container's external image pulls; unit + dev-init smoke cover the changed paths).

## Notes

- The label-filter change goes slightly beyond the strict "root-container-count comparison" framing in the issue's "Out of scope" section, but AC #3 explicitly requires \`apply -f\` to report \`unchanged\` on a same-file re-apply. Without filtering the runner-managed canonical labels, the diff still fires \`metadata.labels changed\`, falls through to \`UpdateCell\`, and (pre-fix) clobbers the canonical labels with the user's empty map. Treating \`*.kukeon.io\`-suffixed keys as controller-managed is the smallest surgical change that satisfies the AC and is the same principle the existing apply-side child-container diff already applies to \`Root: true\` entries.
- A genuine spec change that triggers \`UpdateCell\` still overwrites \`existing.Metadata.Labels\` with \`desired.Metadata.Labels\` (\`update_cell.go:42\`), which can drop the canonical labels in the genuine-update path. Out of scope per the issue; filing a follow-up.

Closes #437