### PR TITLE
fix: preserve canonical *.kukeon.io labels through UpdateCell etc.

### DIFF
--- a/internal/controller/runner/labels.go
+++ b/internal/controller/runner/labels.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import "strings"
+
+// managedLabelSuffix is the trailing key segment used by every
+// controller-injected canonical label (`realm.kukeon.io`, `space.kukeon.io`,
+// `stack.kukeon.io`, `cell.kukeon.io`). Kept in sync with the same suffix
+// hardcoded in `internal/controller/apply/diff.go::filterManagedLabels`.
+const managedLabelSuffix = ".kukeon.io"
+
+// mergeManagedLabels returns the label map an Update* runner should write back
+// onto the persisted resource: every key from `desired` wins, plus any
+// controller-managed `*.kukeon.io` key already in `existing` that `desired`
+// did not author.
+//
+// The create-time injection in `internal/controller/create_{realm,space,stack,cell}.go`
+// adds the canonical labels with "if not exists" semantics, so an explicit
+// user-authored `*.kukeon.io` value in `desired` still wins (AC #3 of issue
+// #455). User-authored non-managed labels are unchanged: present in `desired`
+// → kept; absent in `desired` → dropped.
+func mergeManagedLabels(existing, desired map[string]string) map[string]string {
+	if len(existing) == 0 && len(desired) == 0 {
+		return desired
+	}
+	out := make(map[string]string, len(desired)+len(existing))
+	for k, v := range desired {
+		out[k] = v
+	}
+	for k, v := range existing {
+		if !strings.HasSuffix(k, managedLabelSuffix) {
+			continue
+		}
+		if _, authored := out[k]; authored {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/internal/controller/runner/labels_test.go
+++ b/internal/controller/runner/labels_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeManagedLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing map[string]string
+		desired  map[string]string
+		want     map[string]string
+	}{
+		{
+			// AC #1: canonical *.kukeon.io labels survive an Update* call
+			// against a desired doc that authors one user label.
+			name: "preserves canonical labels when desired omits them",
+			existing: map[string]string{
+				"realm.kukeon.io": "default",
+				"space.kukeon.io": "default",
+				"stack.kukeon.io": "default",
+				"cell.kukeon.io":  "hello-world",
+			},
+			desired: map[string]string{
+				"env": "prod",
+			},
+			want: map[string]string{
+				"realm.kukeon.io": "default",
+				"space.kukeon.io": "default",
+				"stack.kukeon.io": "default",
+				"cell.kukeon.io":  "hello-world",
+				"env":             "prod",
+			},
+		},
+		{
+			// AC #2: user-authored labels still follow the existing
+			// "desired is authoritative" rule. An existing non-managed key
+			// the user dropped from `desired` is removed.
+			name: "user-authored labels follow desired (removal still works)",
+			existing: map[string]string{
+				"realm.kukeon.io": "default",
+				"old":             "value",
+			},
+			desired: map[string]string{
+				"new": "value",
+			},
+			want: map[string]string{
+				"realm.kukeon.io": "default",
+				"new":             "value",
+			},
+		},
+		{
+			// AC #3: an explicit user-authored *.kukeon.io key wins, mirroring
+			// the create-time "if not exists" semantics in create_cell.go.
+			name: "explicit kukeon.io key in desired wins over existing",
+			existing: map[string]string{
+				"cell.kukeon.io": "from-create",
+			},
+			desired: map[string]string{
+				"cell.kukeon.io": "from-user",
+			},
+			want: map[string]string{
+				"cell.kukeon.io": "from-user",
+			},
+		},
+		{
+			name:     "both empty returns desired (nil)",
+			existing: nil,
+			desired:  nil,
+			want:     nil,
+		},
+		{
+			name:     "empty existing returns desired unchanged",
+			existing: nil,
+			desired:  map[string]string{"env": "prod"},
+			want:     map[string]string{"env": "prod"},
+		},
+		{
+			// Non-`.kukeon.io` keys in `existing` are dropped even when
+			// `desired` is empty — only managed keys survive an omission.
+			name: "non-managed existing keys do not leak when desired is empty",
+			existing: map[string]string{
+				"realm.kukeon.io": "default",
+				"stale":           "value",
+			},
+			desired: map[string]string{},
+			want: map[string]string{
+				"realm.kukeon.io": "default",
+			},
+		},
+		{
+			// Keys that contain `.kukeon.io` mid-string but do not end with
+			// it should not be preserved. The suffix match is intentional
+			// (mirrors the apply-side `filterManagedLabels`).
+			name: "non-suffix kukeon.io substring is not preserved",
+			existing: map[string]string{
+				".kukeon.io.suffix": "not-managed",
+				"realm.kukeon.io":   "default",
+			},
+			desired: map[string]string{},
+			want: map[string]string{
+				"realm.kukeon.io": "default",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeManagedLabels(tt.existing, tt.desired)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeManagedLabels() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/runner/update_cell.go
+++ b/internal/controller/runner/update_cell.go
@@ -38,8 +38,13 @@ func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
 	}
 
-	// Update compatible metadata fields
-	existing.Metadata.Labels = desired.Metadata.Labels
+	// Update compatible metadata fields. Preserve controller-managed
+	// `*.kukeon.io` canonical labels (injected during create_cell.go) when
+	// the user's desired doc omits them — same rule the diff layer applies
+	// via `filterManagedLabels` (issue #437 / PR #454). Without this, a
+	// genuine spec change that legitimately routes through UpdateCell
+	// strips the canonical labels (issue #455).
+	existing.Metadata.Labels = mergeManagedLabels(existing.Metadata.Labels, desired.Metadata.Labels)
 
 	// Build maps of desired and actual containers by ID
 	desiredContainers := make(map[string]*intmodel.ContainerSpec)

--- a/internal/controller/runner/update_realm.go
+++ b/internal/controller/runner/update_realm.go
@@ -33,8 +33,9 @@ func (r *Exec) UpdateRealm(desired intmodel.Realm) (intmodel.Realm, error) {
 		return intmodel.Realm{}, fmt.Errorf("%w: %w", errdefs.ErrGetRealm, err)
 	}
 
-	// Update compatible fields
-	existing.Metadata.Labels = desired.Metadata.Labels
+	// Update compatible fields. Preserve controller-managed `*.kukeon.io`
+	// canonical labels when the user's desired doc omits them (issue #455).
+	existing.Metadata.Labels = mergeManagedLabels(existing.Metadata.Labels, desired.Metadata.Labels)
 	existing.Spec.RegistryCredentials = desired.Spec.RegistryCredentials
 
 	// Update metadata file

--- a/internal/controller/runner/update_space.go
+++ b/internal/controller/runner/update_space.go
@@ -33,8 +33,9 @@ func (r *Exec) UpdateSpace(desired intmodel.Space) (intmodel.Space, error) {
 		return intmodel.Space{}, fmt.Errorf("%w: %w", errdefs.ErrGetSpace, err)
 	}
 
-	// Update compatible fields
-	existing.Metadata.Labels = desired.Metadata.Labels
+	// Update compatible fields. Preserve controller-managed `*.kukeon.io`
+	// canonical labels when the user's desired doc omits them (issue #455).
+	existing.Metadata.Labels = mergeManagedLabels(existing.Metadata.Labels, desired.Metadata.Labels)
 	existing.Spec.Defaults = desired.Spec.Defaults
 	// Note: CNIConfigPath is not updated as it's a breaking change
 

--- a/internal/controller/runner/update_stack.go
+++ b/internal/controller/runner/update_stack.go
@@ -33,8 +33,9 @@ func (r *Exec) UpdateStack(desired intmodel.Stack) (intmodel.Stack, error) {
 		return intmodel.Stack{}, fmt.Errorf("%w: %w", errdefs.ErrGetStack, err)
 	}
 
-	// Update compatible fields
-	existing.Metadata.Labels = desired.Metadata.Labels
+	// Update compatible fields. Preserve controller-managed `*.kukeon.io`
+	// canonical labels when the user's desired doc omits them (issue #455).
+	existing.Metadata.Labels = mergeManagedLabels(existing.Metadata.Labels, desired.Metadata.Labels)
 	if desired.Spec.ID != "" {
 		existing.Spec.ID = desired.Spec.ID
 	}


### PR DESCRIPTION
## Summary

- `internal/controller/runner/update_{cell,realm,space,stack}.go` unconditionally clobbered `existing.Metadata.Labels` with `desired.Metadata.Labels`. Because user YAMLs never author the canonical `*.kukeon.io` keys, every genuine spec change routed through `UpdateCell`/`UpdateRealm`/`UpdateSpace`/`UpdateStack` stripped them. PR #454 worked around the same root cause at the *diff* layer for the idempotent re-apply case; the underlying primitive was still destructive on real updates.
- Add `mergeManagedLabels(existing, desired)` (new `internal/controller/runner/labels.go`): `desired` keys still win, plus any `.kukeon.io`-suffixed key already on the resource that `desired` did not author is carried forward. Mirrors the create-time "if not exists" semantics in `create_cell.go` so an explicit user-authored `cell.kukeon.io` override still wins (AC #3).
- Wire the helper into the four `Update*` runners that hit canonical-label-carrying resources. `UpdateContainer` is not changed: containers carry no controller-injected canonical labels (`KukeonContainerLabelKey` is defined in `internal/consts/consts.go:65` but unused) and `update_container.go` has no `Metadata.Labels = …` clobber site. Symmetry with the issue's "five resources" framing is honored at the helper's API; nothing to wire on the container path until/unless containers start getting canonical labels too.

## Test plan

- [x] `make test` (full unit suite minus e2e) — green, including the new `TestMergeManagedLabels` 7-case table covering AC #1 / #2 / #3 plus suffix-not-substring matching and nil-map edge cases.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `pre-commit run --files <changed>` clean (go-fmt, golangci-lint, addlicense, etc.).
- [x] `make dev-init` — full re-bootstrap loop is green and the daemon-parity check (`kuke get realms` vs `kuke get realms --no-daemon`) prints the expected two-row identical block. Change touches code the daemon reads, per `CLAUDE.md` this guard is required in the test plan.
- [x] Manual repro from the issue body — `kuke run -f docs/examples/hello-world.yaml -d`, then `kuke apply -f` against a copy that adds `labels: { env: prod }`. Post-apply `kuke get cell -o yaml` shows all four canonical `*.kukeon.io` keys preserved plus the user-added `env: prod` — pre-fix, the four canonical keys were gone.
- [ ] `make e2e` — not run; the full e2e suite requires a clean dev host and was not part of the local validation envelope. The smoke above exercises the same daemon-readable code path end-to-end.

Closes #455