### PR TITLE
docs: README — add 'Daily use without sudo' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
 sudo kuke init
 ```
 
+### Daily use without sudo
+
+`kuke init` provisions a system `kukeon` group and sets the kukeond socket to mode `0660 root:kukeon`. Add yourself to the group so daemon-routed commands (`kuke get`, `kuke create`, `kuke apply`, `kuke delete`, `kuke log`, `kuke attach`) don't need `sudo`:
+
+```bash
+sudo usermod -aG kukeon $USER
+# Log out and back in (or run `newgrp kukeon`) so the group takes effect, then:
+kuke get realms
+```
+
+Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, and any command run with the `--no-daemon` flag.
+
 ### Autocomplete
 
 ```bash


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #405.
Mode: best-effort — the issue body provided paste-ready wording for the new subsection, but its "Before" anchor and section structure no longer match `README.md` (the file's prior `### Initialize the runtime` heading was removed and a `#### Manual install` block was added between the daemon-ready line and `### Autocomplete`). The new subsection content is applied character-for-character; only the insertion anchor was adapted to the current file structure.

User explicitly directed pm to override the prior `stalled` state and apply the change.

## Files changed
- `README.md` — new `### Daily use without sudo` subsection inserted between the `#### Manual install` block and `### Autocomplete`.

## Editorial choices
- Insertion point: placed after the final code fence of the `#### Manual install` block (the `sudo kuke init` line) and before `### Autocomplete`. The issue specified "after `### Initialize the runtime` and before `### Autocomplete`"; since the runtime-initialization steps now live inside `### Install` (primary path) + `#### Manual install` (fallback), the next-best anchor is "after both install paths, before Autocomplete" — preserves the original intent that the section follows runtime initialization.
- Subsection body, headings, and code fence are reproduced verbatim from the issue's "After" snippet — no rewording.

## Acceptance criteria check
- [x] `README.md` contains a new `### Daily use without sudo` subsection placed after the runtime-initialization flow and before `### Autocomplete` — done (anchor adapted to current file structure).
- [x] Content matches the After wording character-for-character — done.
- [x] No other prose in `README.md` is changed — done (single 12-line insertion; no other edits).

Closes #405