### PR TITLE
docs: rewrite README Quick Start against current behavior (v0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ See **[docs/site/vision.md](docs/site/vision.md)** for the full "Kukeon for AI A
 
 ## Status
 
-Kukeon is pre-v1 and under active development. The agent-native story is usable once Session (#46) and Interactive UC2 (#57) ship; P0 primitives (Container volumes, security fields, scoped secrets, network policy) are landed.
+Kukeon is in **v0.5.0 beta**. The operator surface — realms, spaces, stacks, cells, containers, the daemon, `kuke init` / `apply` / `get` / `attach` / `log`, the one-line installer, and v0.4.0 manifest fields — is shipping and usable today. "Beta" means what's released works reliably; "pre-v1" means SemVer API stability isn't promised yet — minor releases can still introduce breaking changes to manifests, CLI verbs, and daemon semantics.
+
+Still pre-v1, gated by:
+
+- **Agent-native primitives** — Session (#46) and Interactive UC2 (#57) are the gate for the agent-native story.
+- **Schema rework** — crew-layers absorption into `CellBlueprint` / `CellConfig` / `Secret` (#423) is a breaking change.
+- **Daemon-only verbs** — `--no-daemon` retirement (#217) is mid-flight; the CLI surface is still moving.
+- **Reconciler-driven lifecycle** — convergent create/delete (#224) changes runtime semantics.
+
+References:
 
 - Umbrella: #48
-- P1 anchors: #46, #57
+- v0.5.0 release tracker: #440
 - Library substrate (sbsh): sbsh#118 ✅
 
 ## Quick Start
@@ -45,6 +54,10 @@ curl -fsSL https://kukeon.io/install.sh | bash -s -- --check
 After install completes you should see the daemon's realm/space/stack hierarchy provisioned and `kukeond` listening on its unix socket:
 
 ```text
+Realm: default (namespace: default.kukeon.io)
+System realm: kuke-system (namespace: kuke-system.kukeon.io)
+Run path: /opt/kukeon
+...
 kukeond is ready (unix:///run/kukeon/kukeond.sock)
 ```
 
@@ -58,7 +71,7 @@ export OS=linux        # Options: linux
 export ARCH=amd64      # Options: amd64, arm64
 
 # Install kuke (the CLI also dispatches as kukeond based on argv[0])
-curl -L -o kuke https://github.com/eminwux/kukeon/releases/download/v0.1.0/kuke-${OS}-${ARCH} && \
+curl -L -o kuke https://github.com/eminwux/kukeon/releases/download/v0.5.0/kuke-${OS}-${ARCH} && \
 chmod +x kuke && \
 sudo install -m 0755 kuke /usr/local/bin/kuke && \
 sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
@@ -88,6 +101,8 @@ EOF
 ```
 
 `kuke autocomplete zsh` and `kuke autocomplete fish` are also supported.
+
+Completions are dynamic: every tab dispatches through `kuke __complete`, so newly added profiles, realms, and cells (and `$KUKE_PROFILES_DIR` overrides) are picked up on the next tab without re-sourcing the script.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Best-effort documentation update applied from issue #441.
Mode: best-effort — the issue body identifies the file and sections plus clear acceptance criteria, but does not provide paste-ready Before/After wording. Wording was authored to match the issue's Proposal and Acceptance criteria.

## Files changed

- `README.md` — `## Status`, `## Quick Start` (`### Install`, `#### Manual install`, `### Autocomplete`).

## Editorial choices

- **Status section** — rewrote as "v0.5.0 beta" with a brief gloss on what beta means (works reliably, but pre-v1 → SemVer API stability not promised) and a bulleted list of pre-v1 blockers (#46/#57 agent-native; #423 schema rework; #217 daemon-only verbs; #224 reconciler lifecycle), drawn from #440's "Why beta, not v1.0" section. Replaced "P1 anchors: #46, #57" with "v0.5.0 release tracker: #440" since #46/#57 are now surfaced in the gating list above.
- **Quick Start `kuke init` sample** — expanded from one line to four to surface the realm/namespace lines `printOverview` actually prints (`cmd/kuke/init/init.go:636-645`). Added a `...` elision line to make clear the bootstrap log is omitted between the overview and the final ready line.
- **Manual install URL** — bumped `v0.1.0` → `v0.5.0` per AC #1. This URL will 404 until #440 cuts the v0.5.0 tag; matched the AC's literal wording on the assumption this PR lands in the v0.5.0 prep window. If the timing is a concern, swap to `v0.4.0` (current latest) is a one-character edit.
- **Autocomplete** — left the `source <(kuke autocomplete bash)` snippet alone (V2 ships the same command surface) and added a one-line note describing the user-visible V2 benefit: dynamic dispatch through `kuke __complete`, so newly added profiles/realms/cells are picked up on the next tab without re-sourcing. Sourced from the #380 PR's test plan (the three live-update ACs).

## Acceptance criteria check

- [x] AC #1 — README install command resolves to the v0.5.0 release asset (not v0.1.0). Bumped on line 74; resolves once #440 tags v0.5.0.
- [x] AC #2 — Sample `kuke init` output matches current daemon output: socket path `/run/kukeon/kukeond.sock`, realms `default` (`default.kukeon.io`) and `kuke-system` (`kuke-system.kukeon.io`). All three present in the expanded sample (lines 57-61).
- [x] AC #3 — Primary install path is the one-line installer (#62); manual install is a fallback section. Already in place from prior work — no edit needed.
- [x] AC #4 — Daily-use-without-sudo note added. Already landed via #457 (merged before this PR branched) — no edit needed.
- [x] AC #5 — Status section reads "v0.5.0 beta" with a clear list of what beta means and what's still pre-v1.
- [x] AC #6 — Autocomplete snippet reflects cobra V2 behavior. Snippet is unchanged (V2 didn't alter the user-facing command); added a note describing the V2-only dynamic-dispatch behavior.
- [ ] AC #7 — Badge `state: alpha` → `state: beta`. **Deferred** per the issue's explicit parenthetical "(apply when v0.5.0 cuts)" — this should land in the release-cut PR (Track 4 of #440), not here.

## Notes for reviewer

- Out-of-scope realm/namespace staleness in `## Usage Examples` (`kukeon-default`, `kukeon-system`, `Running` → should be `default.kukeon.io`, `kuke-system.kukeon.io`, `Ready`) and in `## Understanding kukeon Commands` (line 282 says "`kukeon-system` realm" — should be `kuke-system`) was left alone. AC #2 narrows to "Sample `kuke init` output", and this issue's Proposal scopes the rewrite to Quick Start. The broader fix belongs in the Track 3 `docs(site): re-baseline` issues or a dedicated docs follow-up.

Closes #441