### PR TITLE
feat: hint kukeon-group remediation on kukeond socket EACCES dial

### DIFF
--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -18,11 +18,14 @@ package kukeonv1
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"sync"
+	"syscall"
 	"time"
 
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -50,6 +53,22 @@ func WithDialTimeout(d time.Duration) UnixOption {
 	return func(c *UnixClient) { c.dialTimeout = d }
 }
 
+// wrapDialError converts a unix-socket dial error into a user-facing error.
+// EACCES on the kukeond socket almost always means the caller is not a member
+// of the `kukeon` group — surface the remediation instead of a raw syscall
+// error. Other failure modes (socket missing, daemon down, timeout) pass
+// through unchanged so their existing messages are preserved.
+func wrapDialError(sockPath string, err error) error {
+	if errors.Is(err, syscall.EACCES) || errors.Is(err, fs.ErrPermission) {
+		return fmt.Errorf(
+			"dial kukeond at %s: permission denied — add yourself to the kukeon group "+
+				"(sudo usermod -aG kukeon $USER), then log out and back in: %w",
+			sockPath, err,
+		)
+	}
+	return fmt.Errorf("dial kukeond at %s: %w", sockPath, err)
+}
+
 // NewUnixClient returns a ctx-aware Client that dials the given unix socket
 // path on first use and reuses the connection for subsequent calls.
 func NewUnixClient(sockPath string, opts ...UnixOption) *UnixClient {
@@ -69,7 +88,7 @@ func (c *UnixClient) ensureConn(ctx context.Context) error {
 	d := net.Dialer{Timeout: c.dialTimeout}
 	conn, err := d.DialContext(ctx, "unix", c.sockPath)
 	if err != nil {
-		return fmt.Errorf("dial kukeond at %s: %w", c.sockPath, err)
+		return wrapDialError(c.sockPath, err)
 	}
 	c.conn = conn
 	c.rpcc = rpc.NewClientWithCodec(jsonrpc.NewClientCodec(conn))

--- a/pkg/api/kukeonv1/rpcclient_internal_test.go
+++ b/pkg/api/kukeonv1/rpcclient_internal_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kukeonv1
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+const testSockPath = "/run/kukeon/kukeond.sock"
+
+// TestWrapDialErrorBareEACCES verifies the EACCES branch adds the usermod
+// remediation hint and preserves the underlying error for errors.Is.
+func TestWrapDialErrorBareEACCES(t *testing.T) {
+	got := wrapDialError(testSockPath, syscall.EACCES)
+	if got == nil {
+		t.Fatal("wrapDialError returned nil for non-nil input")
+	}
+	msg := got.Error()
+	if !strings.Contains(msg, "usermod -aG kukeon $USER") {
+		t.Errorf("missing usermod hint in error: %q", msg)
+	}
+	if !strings.Contains(msg, testSockPath) {
+		t.Errorf("socket path not in error: %q", msg)
+	}
+	if !errors.Is(got, syscall.EACCES) {
+		t.Error("errors.Is(got, syscall.EACCES) = false, want true")
+	}
+}
+
+// TestWrapDialErrorEACCESBuriedInOpError verifies the hint still fires when
+// EACCES is wrapped in the *net.OpError + *os.SyscallError shape that
+// net.Dialer.DialContext actually returns.
+func TestWrapDialErrorEACCESBuriedInOpError(t *testing.T) {
+	dialErr := &net.OpError{
+		Op:  "dial",
+		Net: "unix",
+		Err: &os.SyscallError{Syscall: "connect", Err: syscall.EACCES},
+	}
+	got := wrapDialError(testSockPath, dialErr)
+	if !strings.Contains(got.Error(), "usermod -aG kukeon $USER") {
+		t.Errorf("missing usermod hint when EACCES is wrapped: %q", got.Error())
+	}
+	if !errors.Is(got, syscall.EACCES) {
+		t.Error("errors.Is(got, syscall.EACCES) = false through OpError, want true")
+	}
+}
+
+// TestWrapDialErrorFsPermission verifies the hint also fires for the
+// portable fs.ErrPermission sentinel.
+func TestWrapDialErrorFsPermission(t *testing.T) {
+	got := wrapDialError(testSockPath, fs.ErrPermission)
+	if !strings.Contains(got.Error(), "usermod -aG kukeon $USER") {
+		t.Errorf("missing usermod hint for fs.ErrPermission: %q", got.Error())
+	}
+}
+
+// TestWrapDialErrorOtherErrorUnchanged verifies non-permission errors keep
+// their existing wrap and do not receive the usermod hint.
+func TestWrapDialErrorOtherErrorUnchanged(t *testing.T) {
+	cases := []error{
+		syscall.ECONNREFUSED, // daemon not running
+		syscall.ENOENT,       // socket missing
+		errors.New("i/o timeout"),
+	}
+	for _, c := range cases {
+		got := wrapDialError(testSockPath, c)
+		msg := got.Error()
+		if strings.Contains(msg, "usermod") {
+			t.Errorf("non-permission error gained usermod hint: input=%v, got=%q", c, msg)
+		}
+		if !strings.Contains(msg, "dial kukeond at "+testSockPath) {
+			t.Errorf("standard wrap prefix missing: %q", msg)
+		}
+		if !errors.Is(got, c) {
+			t.Errorf("underlying error not preserved for %v", c)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Wrap the EACCES branch of `UnixClient.ensureConn` with the `sudo usermod -aG kukeon $USER` remediation so a non-`kukeon`-group caller dialing `/run/kukeon/kukeond.sock` sees the fix, not a raw transport error.
- Detection uses `errors.Is(err, syscall.EACCES) || errors.Is(err, fs.ErrPermission)`, which fires both on the bare syscall and on the `*net.OpError{*os.SyscallError{syscall.EACCES}}` shape `net.Dialer.DialContext` actually returns.
- Other dial errors (`ECONNREFUSED`, `ENOENT`, timeouts) keep their existing `dial kukeond at %s: %w` wrap unchanged.

## Notes
- Logic lives in an unexported `wrapDialError` helper next to `ensureConn` so unit tests can exercise it directly without standing up a permission-restricted socket. No new sentinel exported — the issue calls that out as optional and there are no callers needing to branch.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/api/kukeonv1/...`
- [x] `make test` (full suite, e2e excluded per Makefile target)
- [x] `pre-commit run --files pkg/api/kukeonv1/rpcclient.go pkg/api/kukeonv1/rpcclient_internal_test.go`
- [ ] `make dev-init` smoke — not run; change is confined to the client-side transport wrap and does not touch the daemon, `/opt/kukeon`, or build path.

Closes #406