### PR TITLE
feat: fail-fast root check across kuke init / daemon reset / image load --no-daemon / doctor cgroups --probe

### DIFF
--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -102,6 +103,10 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
 		return errdefs.ErrLoggerNotFound
+	}
+
+	if err := kukshared.RequireRoot("kuke daemon reset"); err != nil {
+		return err
 	}
 
 	timeout := viper.GetDuration(config.KUKE_DAEMON_RESET_TIMEOUT.ViperKey)

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -30,12 +30,26 @@ import (
 	"time"
 
 	reset "github.com/eminwux/kukeon/cmd/kuke/daemon/reset"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/viper"
 )
+
+// TestMain mocks the shared euid lookup to euid=0 for every test in this
+// package so the new fail-fast root gate in runReset does not short-circuit
+// the existing fakes-driven coverage when CI runs as a non-root user
+// (ubuntu-latest defaults to UID 1001). Individual cases that exercise the
+// non-root path override this with their own SetGeteuidForTesting call.
+func TestMain(m *testing.M) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 // TestDaemonReset covers the table of states the verb has to handle: a
 // running daemon (graceful stop+delete), an already-stopped daemon (skip
@@ -644,6 +658,39 @@ func TestDaemonReset_GracefulTimeoutEscalatesToKill(t *testing.T) {
 	}
 	if !strings.Contains(out, "kukeond cell deleted") {
 		t.Errorf("output missing delete-phase notice; got:\n%s", out)
+	}
+}
+
+// TestDaemonReset_NonRootIsRejected confirms the fail-fast UID gate rejects
+// non-root invocations before any side effect (cell lookup, sock/pid file
+// removal, --purge-system rm -rf). Symmetric with the same guard on
+// `kuke init`, `kuke image load --no-daemon`, and `kuke doctor cgroups
+// --probe`.
+func TestDaemonReset_NonRootIsRejected(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+	withFreshViper(t)
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, logger))
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("kuke daemon reset returned nil under euid=1000, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("kuke daemon reset error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke daemon reset") {
+		t.Errorf("error does not name the subcommand: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sudo") {
+		t.Errorf("error does not suggest sudo: %v", err)
 	}
 }
 

--- a/cmd/kuke/doctor/cgroups/cgroups.go
+++ b/cmd/kuke/doctor/cgroups/cgroups.go
@@ -98,6 +98,16 @@ func NewCgroupsCmd() *cobra.Command {
 			// --no-probe always wins over --probe so an explicit opt-out
 			// is unambiguous regardless of flag ordering.
 			effectiveProbe := probe && !noProbe
+			// The probe writes "+<ctrl>" to cgroup.subtree_control, which
+			// is root-only on a real cgroup-v2 root. Fail fast with a
+			// named cause so operators see "must run as root" instead of
+			// a confusing EACCES inside cgroupcheck.Probe. The read-only
+			// --no-probe path stays unrestricted.
+			if effectiveProbe {
+				if err := shared.RequireRoot("kuke doctor cgroups --probe"); err != nil {
+					return err
+				}
+			}
 			return runDoctor(cmd, root, nested, effectiveProbe, verbose, target)
 		},
 		// A failed pre-flight is a host-environment problem, not a CLI

--- a/cmd/kuke/doctor/cgroups/cgroups_test.go
+++ b/cmd/kuke/doctor/cgroups/cgroups_test.go
@@ -19,6 +19,7 @@ package cgroups_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,9 +27,25 @@ import (
 	"testing"
 
 	cgroupscmd "github.com/eminwux/kukeon/cmd/kuke/doctor/cgroups"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// TestMain mocks the shared euid lookup to euid=0 for every test in this
+// package. The new fail-fast root gate on --probe would otherwise
+// short-circuit every default-probe and --probe test under non-root CI
+// runners (ubuntu-latest defaults to UID 1001), even though their fake
+// cgroupfs lives under t.TempDir() and never needs real root. Individual
+// cases that exercise the non-root rejection override this with their own
+// SetGeteuidForTesting call.
+func TestMain(m *testing.M) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 // writeFakeCgroup materializes a directory pretending to be a cgroup-v2
 // root: cgroup.controllers + cgroup.subtree_control with the given
@@ -628,6 +645,50 @@ func TestCgroupsCmdScopeNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ghost") {
 		t.Errorf("error = %q, want it to name the missing realm", err.Error())
+	}
+}
+
+// TestCgroupsCmdProbeRequiresRoot pins the fail-fast UID gate that fires
+// only when probe is effective. The probe writes "+<ctrl>" to
+// cgroup.subtree_control, which is root-only on a real cgroup-v2 root —
+// the gate makes the failure mode "must run as root" instead of an EACCES
+// inside cgroupcheck.Probe. The read-only --no-probe path stays
+// unrestricted, covered by the sibling --no-probe test below.
+func TestCgroupsCmdProbeRequiresRoot(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+
+	_, _, err := runCmd(t, "--root", root, "--probe")
+	if err == nil {
+		t.Fatal("Execute() error = nil under euid=1000 with --probe, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke doctor cgroups --probe") {
+		t.Errorf("error does not name the subcommand: %v", err)
+	}
+}
+
+// TestCgroupsCmdNoProbeBypassesRootGate confirms the read-only --no-probe
+// path stays available to non-root operators — it only reads cgroup files
+// and never writes, so the UID gate must not fire.
+func TestCgroupsCmdNoProbeBypassesRootGate(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+
+	if _, _, err := runCmd(t, "--root", root, "--no-probe"); err != nil {
+		t.Fatalf("--no-probe rejected under euid=1000: %v", err)
 	}
 }
 

--- a/cmd/kuke/image/load.go
+++ b/cmd/kuke/image/load.go
@@ -23,11 +23,13 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/eminwux/kukeon/cmd/config"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
@@ -45,6 +47,16 @@ func NewLoadCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// --no-daemon writes directly under /opt/kukeon/<realm>/…,
+			// which is root:kukeon after `kuke init`. Daemon-routed loads
+			// (the default) round-trip through kukeond and stay fine for
+			// `kukeon`-group rootless clients.
+			if viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey) {
+				if err := kukshared.RequireRoot("kuke image load --no-daemon"); err != nil {
+					return err
+				}
+			}
+
 			realm, err := cmd.Flags().GetString("realm")
 			if err != nil {
 				return err

--- a/cmd/kuke/image/load_test.go
+++ b/cmd/kuke/image/load_test.go
@@ -27,9 +27,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eminwux/kukeon/cmd/config"
 	image "github.com/eminwux/kukeon/cmd/kuke/image"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	"github.com/spf13/viper"
 )
 
 func TestLoadCmd_FromFileDefaultRealm(t *testing.T) {
@@ -136,6 +140,42 @@ func TestLoadCmd_ClientErrorPropagates(t *testing.T) {
 
 	if _, err := runLoad(t, fake, []string{tarPath}); err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected client error to propagate, got %v", err)
+	}
+}
+
+// TestLoadCmd_NoDaemonRequiresRoot pins the fail-fast UID gate that fires
+// only when --no-daemon (KUKEON_NO_DAEMON=true) is set. The daemon-routed
+// default path stays unrestricted so `kukeon`-group rootless clients keep
+// working — that is covered by every other test in this file, none of which
+// set the flag.
+func TestLoadCmd_NoDaemonRequiresRoot(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, true)
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "img.tar")
+	if err := os.WriteFile(tarPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+
+	fake := &fakeClient{
+		loadImageFn: func(string, []byte) (kukeonv1.LoadImageResult, error) {
+			t.Fatal("LoadImage should not be invoked when the root gate fires")
+			return kukeonv1.LoadImageResult{}, nil
+		},
+	}
+
+	_, err := runLoad(t, fake, []string{tarPath})
+	if err == nil {
+		t.Fatal("kuke image load --no-daemon returned nil under euid=1000, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke image load --no-daemon") {
+		t.Errorf("error does not name the subcommand: %v", err)
 	}
 }
 

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
@@ -341,6 +342,10 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
 		return errdefs.ErrLoggerNotFound
+	}
+
+	if err := kukshared.RequireRoot("kuke init"); err != nil {
+		return err
 	}
 
 	serverConfigPath := viper.GetString(config.KUKE_INIT_SERVER_CONFIGURATION.ViperKey)

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke"
 	initpkg "github.com/eminwux/kukeon/cmd/kuke/init"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -749,6 +750,11 @@ func TestRunInitErrors(t *testing.T) {
 			name: "unreachable containerd socket",
 			setup: func(t *testing.T, cmd *cobra.Command) {
 				t.Cleanup(viper.Reset)
+				// The fail-fast root check sits before the containerd
+				// preflight; mock euid=0 so this case still reaches the
+				// containerd path it was written to exercise.
+				restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+				t.Cleanup(restore)
 				tmp := t.TempDir()
 				viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, tmp)
 				viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, filepath.Join(tmp, "missing.sock"))
@@ -772,6 +778,20 @@ func TestRunInitErrors(t *testing.T) {
 				cmd.SetErr(&bytes.Buffer{})
 			},
 			wantErr:     errdefs.ErrConnectContainerd,
+			expectError: true,
+		},
+		{
+			name: "non-root user is rejected",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+				t.Cleanup(restore)
+				logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+				ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+				cmd.SetContext(ctx)
+				cmd.SetOut(&bytes.Buffer{})
+				cmd.SetErr(&bytes.Buffer{})
+			},
+			wantErr:     errdefs.ErrMustRunAsRoot,
 			expectError: true,
 		},
 	}

--- a/cmd/kuke/shared/root.go
+++ b/cmd/kuke/shared/root.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// geteuid is indirected via a package var so unit tests can simulate the
+// non-root case without forking under a different UID.
+//
+//nolint:gochecknoglobals // test seam for the production euid lookup
+var geteuid = os.Geteuid
+
+// SetGeteuidForTesting replaces the euid lookup with f and returns a
+// restore function. Intended only for unit tests in dependent packages
+// (cmd/kuke/init, cmd/kuke/daemon/reset, cmd/kuke/doctor/cgroups, …) that
+// drive the gated entrypoints under both root and non-root paths without
+// forking under a different UID. Not for production use.
+func SetGeteuidForTesting(f func() int) func() {
+	prev := geteuid
+	geteuid = f
+	return func() { geteuid = prev }
+}
+
+// RequireRoot is the fail-fast UID gate used by direct-write subcommands
+// (kuke init, kuke daemon reset, kuke image load --no-daemon, kuke doctor
+// cgroups --probe). When the effective UID is non-zero it returns an error
+// wrapping errdefs.ErrMustRunAsRoot that names the subcommand and suggests
+// re-running under `sudo`, so operators see a clear cause instead of a
+// confusing "operation not permitted" several phases in. Daemon-routed
+// verbs (`kuke get`, `kuke create`, `kuke apply`, `kuke delete`, …) must
+// not call this — those are the supported `kukeon`-group rootless-client
+// path.
+func RequireRoot(subcommand string) error {
+	if geteuid() == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: `%s` writes to root-owned paths — re-run with `sudo %s`",
+		errdefs.ErrMustRunAsRoot, subcommand, subcommand,
+	)
+}

--- a/cmd/kuke/shared/root_test.go
+++ b/cmd/kuke/shared/root_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+func TestRequireRoot_AsRoot(t *testing.T) {
+	prev := geteuid
+	t.Cleanup(func() { geteuid = prev })
+	geteuid = func() int { return 0 }
+
+	if err := RequireRoot("kuke init"); err != nil {
+		t.Fatalf("RequireRoot returned error when euid=0: %v", err)
+	}
+}
+
+func TestRequireRoot_NonRoot(t *testing.T) {
+	prev := geteuid
+	t.Cleanup(func() { geteuid = prev })
+	geteuid = func() int { return 1000 }
+
+	err := RequireRoot("kuke init")
+	if err == nil {
+		t.Fatal("RequireRoot returned nil when euid=1000; want error")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("RequireRoot error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "kuke init") {
+		t.Errorf("RequireRoot error does not name the subcommand: %q", msg)
+	}
+	if !strings.Contains(msg, "sudo") {
+		t.Errorf("RequireRoot error does not suggest sudo: %q", msg)
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -260,4 +260,12 @@ var (
 	ErrSecretFromFileNotFound     = errors.New("secret fromFile path does not exist on the host")
 	ErrSecretFromEnvNotSet        = errors.New("secret fromEnv env var is not set on the daemon host")
 	ErrSecretStagingFailed        = errors.New("failed to stage secret file for mount")
+
+	// ErrMustRunAsRoot is returned by direct-write subcommands (kuke init,
+	// kuke daemon reset, kuke image load --no-daemon, kuke doctor cgroups
+	// --probe) when invoked with a non-zero effective UID. Wrapped errors
+	// must name the subcommand and suggest `sudo`. Daemon-routed verbs
+	// (kuke get, kuke create, kuke apply, kuke delete, …) do not gate on
+	// this — those are the supported `kukeon`-group rootless-client path.
+	ErrMustRunAsRoot = errors.New("command must run as root")
 )


### PR DESCRIPTION
## Summary
- New `errdefs.ErrMustRunAsRoot` sentinel + shared `cmd/kuke/shared.RequireRoot(subcommand)` helper that wraps it with a sudo-suggestion error message. Drives a fail-fast UID check at the top of `runInit`, `runReset`, the `kuke image load` RunE (gated on `KUKEON_NO_DAEMON=true`), and the `kuke doctor cgroups` RunE (gated on effective `--probe`). Matches the existing convention `preflightContainerdSocket` set in `cmd/kuke/init/init.go:273` for the containerd-socket pre-flight.
- Daemon-routed verbs (`kuke get`, `kuke create`, `kuke apply`, `kuke delete`, …) are intentionally untouched — those are the supported `kukeon`-group rootless-client path.
- New unit tests cover (root, non-root) for the helper, and the gated entrypoints each grow one explicit non-root rejection case. `kuke doctor cgroups` also gets a sibling test proving `--no-probe` continues to work as non-root. `TestMain` mocks euid=0 across the reset and cgroups packages so the existing fakes-driven coverage keeps passing on the non-root ubuntu-latest CI runner.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full repo test suite passes.
- [x] `make dev-init` — full smoke runs clean; the daemon-parity tail matches the regression-guard expected output from `CLAUDE.md` (both `kuke get realms` and `kuke get realms --no-daemon` produce the canonical two-realm table).
- [x] `pre-commit run --files ...` on the changed set passes (golangci-lint flagged a named-return on the test seam helper, fixed before commit).

Closes #403