### PR TITLE
docs(site): re-baseline install/ and getting-started against v0.5.0

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide walks you through installing Kukeon on a Linux host, bootstrapping the runtime, and running a simple cell.
+This guide walks you through installing Kukeon (v0.5.0 beta) on a Linux host, bootstrapping the runtime, and running a simple cell.
 
 ## 1. Check prerequisites
 
@@ -9,73 +9,90 @@ Kukeon needs:
 - Linux with cgroups v2
 - [containerd](https://containerd.io/) running at `/run/containerd/containerd.sock`
 
-See [Installation → Prerequisites](install/prerequisites.md) for details and quick install commands for each dependency.
+See [Installation → Prerequisites](install/prerequisites.md) for the full check (including `kuke doctor cgroups` to verify controller delegation) and quick install commands for each dependency.
 
 ## 2. Install kuke
 
-```bash
-export OS=linux
-export ARCH=amd64
+The one-line installer detects your platform, verifies the prereqs above, downloads the latest release binary with checksum verification, installs `kuke` + `kukeond` to `/usr/local/bin`, and runs `sudo kuke init` to bring the daemon up:
 
-curl -L -o kuke https://github.com/eminwux/kukeon/releases/download/v0.1.0/kuke-${OS}-${ARCH} && \
-  chmod +x kuke && \
-  sudo install -m 0755 kuke /usr/local/bin/kuke && \
-  sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
+```bash
+curl -fsSL https://kukeon.io/install.sh | bash
 ```
 
-A single binary ships both the CLI (`kuke`) and the daemon (`kukeond`). Kukeon dispatches to one or the other based on the executable name, so the hard link above is required. See [Architecture → Process Model](architecture/process-model.md) for the details.
+Pass `--check` to run the prereq checks only without touching the system. See [Install on Linux](install/install-linux.md) for the manual install path and the env vars the installer honors (`KUKE_VERSION`, `KUKE_INSTALL_PREFIX`, etc.).
+
+A single binary ships both the CLI (`kuke`) and the daemon (`kukeond`). Kukeon dispatches to one or the other based on the executable name, so the installer hard-links them next to each other. See [Architecture → Process Model](architecture/process-model.md) for the details.
 
 ## 3. Bootstrap the runtime
 
-`kuke init` provisions the default hierarchy (realm `default`, space `default`, stack `default`), sets up CNI dirs, pulls the `kukeond` image, and starts the daemon. It touches `/opt/kukeon`, cgroups, and containerd, so it needs root:
+If you used the one-line installer, `kuke init` already ran. If you installed manually, run it now:
 
 ```bash
-$ sudo kuke init
+sudo kuke init
+```
+
+`kuke init` provisions the two default realms (`default` for user workloads, `kuke-system` for the `kukeond` daemon cell), sets up CNI dirs, pulls the `kukeond` image into the `kuke-system` realm's containerd namespace, and starts the daemon. It touches `/opt/kukeon`, cgroups, and containerd, so it needs root.
+
+Expected tail of the output:
+
+```
 Initialized Kukeon runtime
-Realm: default (namespace: kukeon-default)
-System realm: kukeon-system (namespace: kukeon-system)
+Realm: default (namespace: default.kukeon.io)
+System realm: kuke-system (namespace: kuke-system.kukeon.io)
 Run path: /opt/kukeon
-Kukeond image: ghcr.io/eminwux/kukeon:v0.1.0
+Kukeond image: ghcr.io/eminwux/kukeon:v0.5.0
 Actions:
-    - kukeon root cgroup: created
-  - CNI config dir "/etc/cni/net.d": created
-  - CNI bin dir "/opt/cni/bin": already existed
-  Default hierarchy:
-    - realm "default": created
-    - containerd namespace "kukeon-default": created
-    - space "default": created
-    - network "default": created
-    - stack "default": created
+  ...
   System hierarchy:
-    - realm "kukeon-system": created
-    - cell "kukeond": created (image ghcr.io/eminwux/kukeon:v0.1.0)
-kukeond is ready (unix:///opt/kukeon/run/kukeond.sock)
+    - realm "kuke-system": created
+    - cell "kukeond": created (image ghcr.io/eminwux/kukeon:v0.5.0)
+    - cell cgroup: created
+    - cell root container: created
+    - cell containers: started
+kukeond is ready (unix:///run/kukeon/kukeond.sock)
 ```
 
-`init` is idempotent. Re-running it reconciles on-disk state; items that already exist are reported as `already existed`.
+`init` is idempotent. Re-running it reconciles on-disk state; items that already exist are reported as `already existed`, and on a healthy host the header reads `Kukeon runtime already initialized`.
 
-## 4. Verify with `kuke get`
+## 4. Daily use without sudo
 
-List the realms, spaces, and stacks that `kuke init` just created:
+`kuke init` provisions a system `kukeon` group and sets the daemon socket at `/run/kukeon/kukeond.sock` to mode `0660 root:kukeon`. Add yourself to the group so daemon-routed commands don't need `sudo`:
 
 ```bash
-$ sudo kuke get realms
-NAME           NAMESPACE         STATE    CGROUP
-default        kukeon-default    Running  /kukeon/default
-kukeon-system  kukeon-system     Running  /kukeon/kukeon-system
-
-$ sudo kuke get spaces
-NAME     REALM    STATE    CGROUP
-default  default  Running  /kukeon/default/default
-
-$ sudo kuke get stacks
-NAME     REALM    SPACE    STATE    CGROUP
-default  default  default  Running  /kukeon/default/default/default
+sudo usermod -aG kukeon $USER
+# Log out and back in (or run `newgrp kukeon`) so the group takes effect.
 ```
 
-Add `-o yaml` or `-o json` for full resource details. All of `--realm`, `--space`, and `--stack` default to `default`, so the fresh-install hierarchy is reachable without any flags.
+The rest of this guide assumes you have done that. If you skip this step, prepend `sudo` to every `kuke` command below. Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`, and any command run with `--no-daemon`.
 
-## 5. Run a hello-world cell
+## 5. Verify with `kuke get`
+
+List the realms `kuke init` just created:
+
+```bash
+$ kuke get realms
+NAME         NAMESPACE              STATE  CGROUP
+default      default.kukeon.io      Ready  /kukeon/default
+kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+```
+
+`default` is your user-workload realm — `kuke create`, `kuke apply`, etc. land here when no `--realm` flag is given. `kuke-system` is reserved for Kukeon itself; the `kukeond` daemon runs as a cell inside `kuke-system / kukeon / kukeon / kukeond` (realm / space / stack / cell).
+
+Spaces and stacks are only auto-created under `kuke-system` — the user-facing `default` realm is empty so `kuke purge --cascade default` cannot take the daemon down:
+
+```bash
+$ kuke get spaces --realm kuke-system
+NAME    REALM        STATE  CGROUP
+kukeon  kuke-system  Ready  /kukeon/kuke-system/kukeon
+
+$ kuke get stacks --realm kuke-system --space kukeon
+NAME    REALM        SPACE   STATE  CGROUP
+kukeon  kuke-system  kukeon  Ready  /kukeon/kuke-system/kukeon/kukeon
+```
+
+Add `-o yaml` or `-o json` for full resource details.
+
+## 6. Run a hello-world cell
 
 A minimal example that brings up a single container serving a static HTML page with busybox httpd ships in the repo at [`docs/examples/hello-world.yaml`](https://github.com/eminwux/kukeon/blob/main/docs/examples/hello-world.yaml):
 
@@ -116,14 +133,14 @@ sudo kuke apply -f docs/examples/hello-world.yaml --no-daemon
 ```
 
 !!! info "Why `--no-daemon` here"
-The released `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`, so cell creation currently must run in-process via `--no-daemon`. This will change in a future release.
+The released `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`, so cell creation currently must run in-process via `--no-daemon`. This will change in a future release; see issue #217 for the daemon-only verb track.
 
 Confirm the cell is ready, find its IP on the default-default bridge, and curl it:
 
 ```bash
-sudo kuke get cells --realm default --space default --stack default
+kuke get cells --realm default --space default --stack default
 
-ROOT_PID=$(sudo ctr -n kukeon.io task ls | awk '/hello-world_root/ {print $2}')
+ROOT_PID=$(sudo ctr -n default.kukeon.io task ls | awk '/hello-world_root/ {print $2}')
 CELL_IP=$(sudo nsenter -t "${ROOT_PID}" -n ip -4 -o addr show eth0 | awk '{print $4}' | cut -d/ -f1)
 curl http://${CELL_IP}:8080/
 ```
@@ -135,7 +152,7 @@ sudo kuke delete cell hello-world \
     --realm default --space default --stack default --cascade --no-daemon
 ```
 
-## 6. Enable shell autocomplete
+## 7. Enable shell autocomplete
 
 ```bash
 cat >> ~/.bashrc <<EOF

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -1,19 +1,56 @@
 # Install on Linux
 
-Kukeon ships a single static binary per platform. The same binary behaves as `kuke` (the CLI) or `kukeond` (the daemon) depending on the name it is invoked under. You install the binary once and create a hard link for the second name.
+Kukeon (v0.5.0 beta) ships a single static binary per platform. The same binary behaves as `kuke` (the CLI) or `kukeond` (the daemon) depending on the name it is invoked under: you install the binary once and create a hard link for the second name. The one-line installer below does both for you.
 
-## From a release
+Before installing, confirm cgroups v2 and containerd are in place — see [Prerequisites](prerequisites.md). The installer also checks them and exits with a distro-aware hint on any miss.
+
+## One-line install (recommended)
+
+```bash
+curl -fsSL https://kukeon.io/install.sh | bash
+```
+
+The installer:
+
+1. Detects your platform (`linux/amd64` or `linux/arm64`) and refuses anything else.
+2. Verifies cgroups v2 is mounted and `/run/containerd/containerd.sock` is responsive. On any miss it prints a distro-aware hint and exits non-zero without touching the system.
+3. Downloads the latest release binary from GitHub, verifies its `.sha256` checksum, installs it to `/usr/local/bin/kuke`, and hard-links `kukeond` next to it.
+4. Runs `sudo kuke init` to bring up the daemon. Skipped on a host that already has a healthy `kukeond` listening on `/run/kukeon/kukeond.sock`.
+
+Pass `--check` to run the prereq checks only without touching the system:
+
+```bash
+curl -fsSL https://kukeon.io/install.sh | bash -s -- --check
+```
+
+Environment overrides the installer honors:
+
+| Variable               | Purpose                                                          |
+| ---------------------- | ---------------------------------------------------------------- |
+| `KUKE_VERSION`         | Pin a specific release tag (default: resolve latest via GitHub). |
+| `KUKE_REPO`            | GitHub repo path for forks (default: `eminwux/kukeon`).          |
+| `KUKE_INSTALL_PREFIX`  | Install dir (default: `/usr/local/bin`).                         |
+| `KUKE_SKIP_INIT=1`     | Skip the post-install `kuke init` step.                          |
+| `KUKE_SKIP_CHECKSUM=1` | Skip `.sha256` verification (not recommended).                   |
+
+## Manual install (fallback)
+
+If you would rather drive each step yourself — e.g. installing onto an air-gapped host, pinning a non-default release tag, or scripting the install into an image build — the steps the one-liner runs are:
 
 ```bash
 # Pick your platform
 export OS=linux             # Options: linux
 export ARCH=amd64           # Options: amd64, arm64
+export KUKE_VERSION=v0.5.0  # Or the release you want to pin
 
-# Download, install, and link
-curl -L -o kuke https://github.com/eminwux/kukeon/releases/download/v0.1.0/kuke-${OS}-${ARCH}
+# Download, install, and hard-link
+curl -L -o kuke "https://github.com/eminwux/kukeon/releases/download/${KUKE_VERSION}/kuke-${OS}-${ARCH}"
 chmod +x kuke
 sudo install -m 0755 kuke /usr/local/bin/kuke
 sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
+
+# Bring up the daemon
+sudo kuke init
 ```
 
 The hard link is required: `main.go` dispatches to `kuke` or `kukeond` by looking at `argv[0]` (see [Architecture → Process Model](../architecture/process-model.md)). Running `kuke kukeond …` does **not** enter the daemon tree.
@@ -22,31 +59,48 @@ The hard link is required: `main.go` dispatches to `kuke` or `kukeond` by lookin
 
 ```bash
 $ kuke version
-v0.1.0
+v0.5.0
 
 $ kukeond --help
 Kukeon daemon: hosts the kukeonv1 API over a unix socket
 ...
 ```
 
-## Uninstall
+`kuke init` should have left the daemon listening on `/run/kukeon/kukeond.sock` and the canonical two-realm hierarchy provisioned:
 
 ```bash
+$ sudo kuke get realms
+NAME         NAMESPACE              STATE  CGROUP
+default      default.kukeon.io      Ready  /kukeon/default
+kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+```
+
+`default` is the user-workload realm — `kuke create …` lands here by default. `kuke-system` is owned by Kukeon itself and hosts the `kukeond` daemon cell.
+
+## Daily use without sudo
+
+`kuke init` provisions a system `kukeon` group and sets the kukeond socket to mode `0660 root:kukeon`. Add yourself to the group so daemon-routed commands (`kuke get`, `kuke create`, `kuke apply`, `kuke delete`, `kuke log`, `kuke attach`) don't need `sudo`:
+
+```bash
+sudo usermod -aG kukeon $USER
+# Log out and back in (or run `newgrp kukeon`) so the group takes effect, then:
+kuke get realms
+```
+
+Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`, and any command run with the `--no-daemon` flag.
+
+## Uninstall
+
+`kuke uninstall` removes all kukeon runtime state from the host — stops and deletes the `kukeond` cell, clears `/run/kukeon`, and wipes `/opt/kukeon` and the kukeon-generated CNI conflists. It prompts for interactive confirmation by default; pass `-y` to skip the prompt in scripts:
+
+```bash
+sudo kuke uninstall -y
 sudo rm -f /usr/local/bin/kuke /usr/local/bin/kukeond
 ```
 
-If you want to wipe runtime state too, stop anything still running and remove the run path:
-
-```bash
-sudo kuke kill cell kukeond --realm kuke-system --space kukeon --stack kukeon --no-daemon || true
-sudo kuke delete cell kukeond --realm kuke-system --space kukeon --stack kukeon --no-daemon || true
-sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
-sudo rm -rf /opt/kukeon
-```
-
-The `/etc/cni/net.d/*.conflist` files Kukeon generated can be removed too if you are not using CNI for anything else; if other tools on the host use CNI, inspect the files first.
+`uninstall` only touches CNI conflists Kukeon itself generated; other files under `/etc/cni/net.d` are left alone. If you want to remove the `kukeon` system group too, finish with `sudo groupdel kukeon`.
 
 ## Next
 
-- [Getting Started](../getting-started.md) — bootstrap the runtime
+- [Getting Started](../getting-started.md) — bring up a hello-world cell
 - [Build from source](build-from-source.md) — compile `kuke` / `kukeond` from a local checkout

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -1,11 +1,13 @@
 # Prerequisites
 
-Kukeon runs on a single Linux host and relies on two things being present before you install the binary:
+Kukeon (v0.5.0 beta) runs on a single Linux host and relies on two things being present before you install the binary:
 
 1. A kernel with **cgroups v2** enabled
 2. A running **containerd** daemon
 
 CNI plugins are bundled inside the `kukeond` container image, so the standard daemon-mediated install path does **not** need them on the host. If you plan to use the transitional `--no-daemon` flag for some operations, see the [`--no-daemon` host-CNI note below](#cni-plugins-for---no-daemon-only).
+
+The [one-line installer](install-linux.md) checks both prereqs for you before touching the system; the notes below cover the same checks for operators driving the install manually or debugging a failed installer run.
 
 ## Linux with cgroups v2
 
@@ -19,6 +21,14 @@ cgroup2 on /sys/fs/cgroup type cgroup2 (...)
 ```
 
 If you see `cgroup` (v1) instead, enable the unified hierarchy with `systemd.unified_cgroup_hierarchy=1` on the kernel command line and reboot.
+
+Once cgroups v2 is mounted, run the pre-flight to confirm the host's root cgroup delegates the controllers Kukeon needs (`cpu`, `memory`, `pids`, `io`):
+
+```bash
+sudo kuke doctor cgroups
+```
+
+The check passes silently when delegation is healthy and prints a per-controller diff when it isn't. Pass `--probe` to additionally attempt a write to `/sys/fs/cgroup/cgroup.subtree_control` — useful when you suspect that `+memory` or `+pids` are present in `cgroup.controllers` but blocked from delegation by a parent slice.
 
 ## containerd
 
@@ -39,7 +49,7 @@ sudo systemctl enable --now containerd
 sudo ctr version
 ```
 
-Kukeon uses its own containerd namespaces (one per realm: `kukeon-<realm>`). It does not interfere with existing containerd namespaces used by Docker, nerdctl, or other tools.
+Kukeon uses its own containerd namespaces (one per realm: `<realm>.kukeon.io`). `kuke init` provisions two by default — `default.kukeon.io` for user workloads and `kuke-system.kukeon.io` for the `kukeond` daemon. Kukeon does not interfere with existing containerd namespaces used by Docker, nerdctl, or other tools.
 
 ## CNI plugins (for `--no-daemon` only)
 
@@ -60,9 +70,12 @@ At minimum Kukeon needs `bridge`, `host-local`, `loopback`, and `portmap`.
 
 ## Root / privileges
 
-`kuke init`, `kuke apply`, and any command touching cgroups, netlink, or containerd namespaces needs root (or equivalent capabilities: `CAP_SYS_ADMIN`, `CAP_NET_ADMIN`, access to the containerd socket, write access to `/sys/fs/cgroup` and `/opt/kukeon`). For now, the working assumption is "run as root" (`sudo kuke ...`).
+Two paths exist, depending on whether the command goes through `kukeond` or bypasses it:
 
-Running `kuke get` for read-only queries over the daemon socket does not require root, as long as the user can read the socket at `/run/kukeon/kukeond.sock`.
+- **Direct host writes need root.** `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`, and anything else run with `--no-daemon` touch cgroups, netlink, containerd, or `/opt/kukeon` directly. Run them with `sudo`; otherwise they fail fast with a clear "must run as root" error before touching anything.
+- **Daemon-routed commands do not need root.** `kuke init` provisions a system `kukeon` group and sets the daemon socket at `/run/kukeon/kukeond.sock` to mode `0660 root:kukeon`. Adding a user to that group (`sudo usermod -aG kukeon $USER`, then re-login) is enough for `kuke get`, `kuke create`, `kuke apply`, `kuke delete`, `kuke log`, and `kuke attach` to work without `sudo`. Writes under `/opt/kukeon` still require root, but they go through the daemon.
+
+See [Getting Started → Daily use without sudo](../getting-started.md#daily-use-without-sudo) for the post-init steps.
 
 ## Disk paths kukeon touches
 


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #443.
Mode: best-effort — the issue body identified files and the drift items to fix but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria.

## Files changed
- `docs/site/install/prerequisites.md` — surgical edits: added `kuke doctor cgroups` pre-flight ref, fixed containerd-namespace naming (`kukeon-<realm>` → `<realm>.kukeon.io` with explicit `default.kukeon.io` / `kuke-system.kukeon.io` callout), expanded "Root / privileges" to cover the daemon-routed vs. direct-host split and the post-init `kukeon`-group path, and noted v0.5.0 beta at the top with a pointer to the one-line installer.
- `docs/site/install/install-linux.md` — full restructure: one-line installer (`curl … | bash`) is now the primary "From a release" path; manual install moved to a "fallback" section pinned to `v0.5.0` with the env vars the installer honors; new "Daily use without sudo" subsection documents the `usermod -aG kukeon` flow; uninstall stanza replaced with `sudo kuke uninstall -y` instead of the legacy `--no-daemon` stop/delete dance.
- `docs/site/getting-started.md` — rewrote the bootstrap walkthrough: install step points at the one-line installer (manual via cross-link), `kuke init` example output corrected to the canonical v0.5.0 form (`default` / `default.kukeon.io`, `kuke-system` / `kuke-system.kukeon.io`, `Run path: /opt/kukeon`, `kukeond is ready (unix:///run/kukeon/kukeond.sock)`), `kuke get realms` table updated to the v0.5.0 `Ready` state + dotted namespaces matching `internal/consts/consts.go`, new "Daily use without sudo" step inserted before the verification step (the rest of the guide drops the `sudo` prefix accordingly), `ctr -n kukeon.io` corrected to `ctr -n default.kukeon.io` in the hello-world IP-lookup, and the `--no-daemon` apply note now links the daemon-only verb track to issue #217.

## Editorial choices
- Chose to surface the v0.5.0 beta status with a single sentence at the top of each page (rather than a banner) — same shape the README uses, keeps the docs voice consistent.
- Kept the hello-world section's `--no-daemon` apply with the existing rationale (`kukeond` image does not yet bind-mount `/run/containerd/containerd.sock`) — that's still accurate per `CLAUDE.md` (the bind-mount regression-guard lists only `/run/kukeon` and `/opt/kukeon`), so the docs match shipping behavior.
- Step numbering in `getting-started.md` grew from 6 to 7 to accommodate the new "Daily use without sudo" step before `kuke get`; downstream step numbers shifted by one.
- In `install-linux.md`, used a table for the `KUKE_*` env vars (matches the installer's own `--help` shape and the prerequisites.md "Disk paths" table convention).
- Uninstall now references `kuke uninstall` directly instead of the manual stop/delete sequence; appended `sudo rm -f /usr/local/bin/{kuke,kukeond}` so the user still has the binary-removal step, and a one-liner for `groupdel kukeon` as an optional cleanup.

## Acceptance criteria check
- [x] `docs/site/install/prerequisites.md` lists exact prereqs verified on Ubuntu 24.04: cgroups v2, standalone containerd, CNI plugins — preserved + augmented with `kuke doctor cgroups`.
- [x] `docs/site/install/install-linux.md` documents one-line installer (#62) as primary path; manual fallback matches current command surface.
- [x] `docs/site/getting-started.md` walkthrough — written to succeed on a fresh host; `kuke init` output, realm/namespace names, socket path, and `kuke get realms` output all match the shipping v0.5.0 behavior captured in `internal/consts/consts.go` and `CLAUDE.md`'s daemon-parity regression guard.
- [x] Realm/namespace names match `internal/consts/consts.go` — `default` / `default.kukeon.io` and `kuke-system` / `kuke-system.kukeon.io` everywhere.
- [x] Beta status called out where appropriate — top of each of the three pages.

Closes #443