### PR TITLE
docs: re-baseline cli/* against current command surface (v0.5.0)

### DIFF
--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -11,18 +11,25 @@ Both are hard-linked to the same binary on install. Running `kuke` enters the cl
 
 ## kuke subcommands
 
-| Command                        | What it does                                                      |
-| ------------------------------ | ----------------------------------------------------------------- |
-| `kuke init`                    | Bootstrap or reconcile a host                                     |
-| `kuke apply`                   | Apply resource definitions from YAML (multi-document supported)   |
-| `kuke get`                     | List or describe resources (realm, space, stack, cell, container) |
-| `kuke create`                  | Create a single resource imperatively                             |
-| `kuke delete`                  | Delete a resource                                                 |
-| `kuke start` / `stop` / `kill` | Lifecycle operations on cells and containers                      |
-| `kuke purge`                   | Delete with aggressive cleanup of residual state                  |
-| `kuke refresh`                 | Reconcile `.status` from live state without touching `.spec`      |
-| `kuke autocomplete`            | Emit a shell completion script                                    |
-| `kuke version`                 | Print the version                                                 |
+| Command                        | What it does                                                          |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `kuke init`                    | Bootstrap or reconcile a host                                         |
+| `kuke doctor`                  | Host pre-flight checks (cgroup-v2 delegation) before `kuke init`      |
+| `kuke apply`                   | Apply resource definitions from YAML (multi-document supported)       |
+| `kuke run`                     | Create and start a single cell from a file or per-user profile        |
+| `kuke get`                     | List or describe resources (realm, space, stack, cell, container)     |
+| `kuke create`                  | Create a single resource imperatively                                 |
+| `kuke delete`                  | Delete a resource                                                     |
+| `kuke start` / `stop` / `kill` | Lifecycle operations on cells and containers                          |
+| `kuke purge`                   | Delete with aggressive cleanup of residual state                      |
+| `kuke refresh`                 | Reconcile `.status` from live state without touching `.spec`          |
+| `kuke log`                     | Print a container's stdout/stderr (use `-f` to follow)                |
+| `kuke attach`                  | Attach to an Attachable container's `sbsh` terminal                   |
+| `kuke image`                   | Manage container images in a realm's containerd namespace             |
+| `kuke daemon`                  | Manage the `kukeond` daemon cell lifecycle                            |
+| `kuke uninstall`               | Remove all kukeon runtime state from this host                        |
+| `kuke autocomplete`            | Emit a shell completion script                                        |
+| `kuke version`                 | Print the version                                                     |
 
 ## Global flags
 
@@ -31,9 +38,9 @@ Every `kuke` subcommand inherits these persistent flags from the root command:
 | Flag                  | Default                           | What it does                                         |
 | --------------------- | --------------------------------- | ---------------------------------------------------- |
 | `--run-path`          | `/opt/kukeon`                     | Where Kukeon stores realm/space/stack/cell state     |
-| `--config`            | `/etc/kukeon/config.yaml`         | Config file path                                     |
+| `--configuration`     | `$HOME/.kuke/kuke.yaml`           | ClientConfiguration YAML; absent file uses defaults  |
 | `--containerd-socket` | `/run/containerd/containerd.sock` | Containerd socket                                    |
-| `--host`              | `unix:///run/kukeon/kukeond.sock` | Daemon endpoint (unix:// or ssh://)                  |
+| `--host`              | `unix:///run/kukeon/kukeond.sock` | Daemon endpoint (`unix://` or `ssh://`)              |
 | `--no-daemon`         | `false`                           | Bypass the daemon and run in-process (requires root) |
 | `--verbose`, `-v`     | `false`                           | Enable verbose logging on stderr                     |
 | `--log-level`         | `info`                            | Log level (`debug`, `info`, `warn`, `error`)         |
@@ -63,13 +70,20 @@ The positional argument is the resource's own name; the flags specify where in t
 
 - [kuke (root)](kuke.md)
 - [kuke init](kuke-init.md)
+- [kuke doctor](kuke-doctor.md)
 - [kuke get](kuke-get.md)
 - [kuke create](kuke-create.md)
 - [kuke apply](kuke-apply.md)
+- [kuke run](kuke-run.md)
 - [kuke delete](kuke-delete.md)
 - [kuke start / stop / kill](kuke-lifecycle.md)
 - [kuke purge](kuke-purge.md)
 - [kuke refresh](kuke-refresh.md)
+- [kuke log](kuke-log.md)
+- [kuke attach](kuke-attach.md)
+- [kuke image](kuke-image.md)
+- [kuke daemon](kuke-daemon.md)
+- [kuke uninstall](kuke-uninstall.md)
 - [kuke autocomplete](kuke-autocomplete.md)
 - [kuke version](kuke-version.md)
 - [kukeond](kukeond.md)

--- a/docs/site/cli/kuke-apply.md
+++ b/docs/site/cli/kuke-apply.md
@@ -65,7 +65,7 @@ kind: Space
 metadata:
   name: blog
 spec:
-  realmId: main
+  realmId: default
 ---
 apiVersion: v1beta1
 kind: Stack
@@ -73,7 +73,7 @@ metadata:
   name: wordpress
 spec:
   id: wordpress
-  realmId: main
+  realmId: default
   spaceId: blog
 EOF
 
@@ -81,17 +81,8 @@ EOF
 sudo kuke apply -f cell.yaml -o json
 ```
 
-## The `--no-daemon` caveat
-
-Today, cell creation has to run with `--no-daemon` because the released daemon image doesn't bind-mount the containerd socket. Until that ships, use:
-
-```bash
-sudo kuke apply -f cell.yaml --no-daemon
-```
-
-See [Client and daemon](../concepts/client-and-daemon.md).
-
 ## Related
 
+- [kuke run](kuke-run.md) — create + start a single cell in one shot
 - [Applying manifests](../guides/apply-manifests.md) — the longer guide
 - [Manifest Reference](../manifests/overview.md) — every field explained

--- a/docs/site/cli/kuke-attach.md
+++ b/docs/site/cli/kuke-attach.md
@@ -1,0 +1,49 @@
+# kuke attach
+
+Attach to an Attachable container's `sbsh` terminal.
+
+```
+kuke attach <cell> [flags]
+kuke att    <cell> [flags]      # alias
+```
+
+`<cell>` is a positional argument. `--realm`, `--space`, and `--stack` all default to `default`, so for a cell in the default location you only need the cell name.
+
+## Flags
+
+| Flag          | Default     | Description                                                              |
+| ------------- | ----------- | ------------------------------------------------------------------------ |
+| `--container` | (auto-pick) | Container within the cell to attach to (omit to auto-pick the only non-root attachable) |
+| `--realm`     | `default`   | Realm that owns the cell                                                 |
+| `--space`     | `default`   | Space that owns the cell                                                 |
+| `--stack`     | `default`   | Stack that owns the cell                                                 |
+
+Plus all [global flags](kuke.md).
+
+## Container selection
+
+If the cell has exactly one non-root attachable container, `--container` can be omitted. Otherwise, pass `--container` explicitly. Containers must be marked attachable in the cell spec to be a valid target.
+
+## Detaching
+
+Press `^]^]` (two consecutive `Ctrl-]` keystrokes) to detach cleanly. The cell keeps running and you can re-attach later with the same command.
+
+If the workload exits or the peer hangs up, the attach loop exits and the CLI returns to your shell.
+
+## Examples
+
+```bash
+# Attach to a cell in the default location
+sudo kuke attach myshell
+
+# Attach to a cell in a non-default location
+sudo kuke attach wp --realm default --space blog --stack wordpress
+
+# Explicit container in a multi-container cell
+sudo kuke attach web --container debug
+```
+
+## Related
+
+- [kuke run](kuke-run.md) — create + start a cell and attach in one step
+- [kuke log](kuke-log.md) — one-way log stream instead of an interactive terminal

--- a/docs/site/cli/kuke-create.md
+++ b/docs/site/cli/kuke-create.md
@@ -15,13 +15,13 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also 
 kuke create realm [NAME] [--namespace <ns>]
 ```
 
-| Flag          | Default      | Description                        |
-| ------------- | ------------ | ---------------------------------- |
-| `--namespace` | (realm name) | Containerd namespace for the realm |
+| Flag          | Default                       | Description                        |
+| ------------- | ----------------------------- | ---------------------------------- |
+| `--namespace` | `<realm>.kukeon.io` (derived) | Containerd namespace for the realm |
 
 ```bash
 sudo kuke create realm mytenant
-sudo kuke create realm mytenant --namespace kukeon-mytenant
+sudo kuke create realm mytenant --namespace mytenant.kukeon.io
 ```
 
 ## kuke create space
@@ -35,7 +35,7 @@ kuke create space [NAME] --realm <realm>
 | `--realm` | `default` | Realm that will own the space |
 
 ```bash
-sudo kuke create space blog --realm main
+sudo kuke create space blog --realm default
 ```
 
 ## kuke create stack
@@ -50,7 +50,7 @@ kuke create stack [NAME] --realm <realm> --space <space>
 | `--space` | `default` | Space that owns the stack |
 
 ```bash
-sudo kuke create stack wordpress --realm main --space blog
+sudo kuke create stack wordpress --realm default --space blog
 ```
 
 ## kuke create cell
@@ -65,10 +65,10 @@ kuke create cell [NAME] --realm <r> --space <s> --stack <t>
 | `--space` | `default` | Space that owns the cell |
 | `--stack` | `default` | Stack that owns the cell |
 
-`create cell` creates an empty cell (no containers). Use [`kuke apply`](kuke-apply.md) with a manifest to create a cell with its containers in one step.
+`create cell` creates an empty cell (no containers). Use [`kuke apply`](kuke-apply.md) with a manifest to create a cell with its containers in one step, or [`kuke run`](kuke-run.md) for a one-shot create+start.
 
 ```bash
-sudo kuke create cell web --realm main --space blog --stack wordpress
+sudo kuke create cell web --realm default --space blog --stack wordpress
 ```
 
 ## kuke create container
@@ -79,35 +79,44 @@ Adds a container to an existing cell.
 kuke create container [NAME] --cell <cell> [--realm <r> --space <s> --stack <t>] [container flags]
 ```
 
-| Flag                | Default                           | Description                                      |
-| ------------------- | --------------------------------- | ------------------------------------------------ |
-| `--realm`           | `default`                         | Realm of the parent cell                         |
-| `--space`           | `default`                         | Space of the parent cell                         |
-| `--stack`           | `default`                         | Stack of the parent cell                         |
-| `--cell`            | _(required)_                      | Cell that owns the container                     |
-| `--image`           | `docker.io/library/debian:latest` | Container image                                  |
-| `--command`         | (empty)                           | Command to run                                   |
-| `--args`            | (empty, repeatable)               | Arguments                                        |
-| `--env`             | (empty, repeatable)               | `KEY=VALUE` env var                              |
-| `--port`            | (empty, repeatable)               | Port mapping                                     |
-| `--volume`          | (empty, repeatable)               | Volume mount                                     |
-| `--network`         | (empty, repeatable)               | Network to join                                  |
-| `--network-alias`   | (empty, repeatable)               | Network alias                                    |
-| `--privileged`      | `false`                           | Run privileged                                   |
-| `--root`            | `false`                           | Mark this container as the cell's root container |
-| `--cni-config-path` | (empty)                           | Override CNI config dir for this container       |
-| `--restart-policy`  | (empty)                           | Restart policy                                   |
-| `--label`           | (empty, repeatable)               | `KEY=VALUE` label                                |
+| Flag                 | Default                           | Description                                                  |
+| -------------------- | --------------------------------- | ------------------------------------------------------------ |
+| `--realm`            | `default`                         | Realm of the parent cell                                     |
+| `--space`            | `default`                         | Space of the parent cell                                     |
+| `--stack`            | `default`                         | Stack of the parent cell                                     |
+| `--cell`             | _(required)_                      | Cell that owns the container                                 |
+| `--image`            | `docker.io/library/debian:latest` | Container image                                              |
+| `--command`          | (empty)                           | Command to run                                               |
+| `--args`             | (empty, repeatable)               | Arguments                                                    |
+| `--env`              | (empty, repeatable)               | `KEY=VALUE` env var                                          |
+| `--port`             | (empty, repeatable)               | Port mapping                                                 |
+| `--volume`           | (empty, repeatable)               | Volume mount                                                 |
+| `--tmpfs`            | (empty, repeatable)               | Tmpfs mount, `path[:opts]` (e.g. `/tmp:size=64m`)            |
+| `--network`          | (empty, repeatable)               | Network to join                                              |
+| `--network-alias`    | (empty, repeatable)               | Network alias                                                |
+| `--user`             | (empty)                           | Run as `UID[:GID]` (e.g. `1000:1000`)                        |
+| `--privileged`       | `false`                           | Run privileged                                               |
+| `--read-only`        | `false`                           | Mount the root filesystem read-only                          |
+| `--root`             | `false`                           | Mark this container as the cell's root container             |
+| `--cap-add`          | (empty, repeatable)               | Linux capability to add (e.g. `NET_ADMIN`)                   |
+| `--cap-drop`         | (empty, repeatable)               | Linux capability to drop (e.g. `ALL` or `NET_ADMIN`)         |
+| `--security-opt`     | (empty, repeatable)               | Security option (e.g. `no-new-privileges`, `seccomp=unconfined`) |
+| `--cpu-shares`       | `0`                               | Relative CPU weight (cgroup `cpu.shares`)                    |
+| `--memory`           | (empty)                           | Hard memory limit (bytes, or with suffix `k`/`m`/`g`)        |
+| `--pids-limit`       | `0`                               | Maximum number of PIDs (0 leaves unset)                      |
+| `--cni-config-path`  | (empty)                           | Override CNI config dir for this container                   |
+| `--restart-policy`   | (empty)                           | Restart policy for the container                             |
+| `--label`            | (empty, repeatable)               | `KEY=VALUE` label                                            |
 
 ```bash
 sudo kuke create container nginx \
-    --cell web --realm main --space blog --stack wordpress \
+    --cell web --realm default --space blog --stack wordpress \
     --image docker.io/library/nginx:alpine \
     --root
 ```
 
 !!! warning "The `--image` default"
-If you don't pass `--image`, Kukeon uses `docker.io/library/debian:latest`. Always pass `--image` explicitly when you care what runs.
+    If you don't pass `--image`, Kukeon uses `docker.io/library/debian:latest`. Always pass `--image` explicitly when you care what runs.
 
 ## Imperative vs. declarative
 
@@ -116,4 +125,5 @@ If you don't pass `--image`, Kukeon uses `docker.io/library/debian:latest`. Alwa
 ## Related
 
 - [kuke apply](kuke-apply.md) — declarative alternative
+- [kuke run](kuke-run.md) — create + start a single cell in one shot
 - [Manifest Reference](../manifests/overview.md) — the schema for each resource

--- a/docs/site/cli/kuke-daemon.md
+++ b/docs/site/cli/kuke-daemon.md
@@ -1,0 +1,103 @@
+# kuke daemon
+
+Manage the `kukeond` daemon cell lifecycle.
+
+```
+kuke daemon [command]
+```
+
+These commands act on the `kukeond` cell provisioned by `kuke init` (`kuke-system / kukeon / kukeon / kukeond`). They run **in-process** because the daemon they manage may not be running at the time the command is invoked.
+
+## Subcommands
+
+| Command              | What it does                                                              |
+| -------------------- | ------------------------------------------------------------------------- |
+| `kuke daemon start`  | Start the kukeond daemon cell                                             |
+| `kuke daemon stop`   | Gracefully stop the kukeond cell (SIGTERM, escalating to SIGKILL)         |
+| `kuke daemon kill`   | Immediately SIGKILL the kukeond daemon cell                               |
+| `kuke daemon restart`| Stop then start the kukeond daemon cell                                   |
+| `kuke daemon reset`  | Stop, delete metadata + cgroups, clear `/run/kukeon/kukeond.{sock,pid}`   |
+| `kuke daemon logs`   | Print the kukeond daemon's stdout/stderr (use `-f` to follow)             |
+
+All subcommands are idempotent: they succeed with a clear message when the daemon is already in the requested state.
+
+## kuke daemon start
+
+Bring up the existing `kukeond` cell provisioned by `kuke init`. Returns success when the daemon is already running. Errors when the host has not been initialized — run `kuke init` first.
+
+## kuke daemon stop
+
+Send SIGTERM and wait up to `--timeout` (default 10s) for the daemon to exit; if the grace period expires, escalate to SIGKILL.
+
+| Flag        | Default | Description                                                |
+| ----------- | ------- | ---------------------------------------------------------- |
+| `--timeout` | `10s`   | Grace period before escalating from SIGTERM to SIGKILL     |
+
+## kuke daemon kill
+
+Force-kill the kukeond cell with no grace period. This is the escape hatch for a hung or unresponsive daemon — use `kuke daemon stop` for the graceful path.
+
+## kuke daemon restart
+
+Compose `kuke daemon stop` and `kuke daemon start` into a single verb. When the daemon is already stopped, the stop phase is skipped and the start phase still runs.
+
+| Flag        | Default | Description                                                          |
+| ----------- | ------- | -------------------------------------------------------------------- |
+| `--timeout` | `10s`   | Grace period for the stop phase before escalating from SIGTERM to SIGKILL |
+
+## kuke daemon reset
+
+Lightweight dev-loop teardown of the kukeond daemon. Stops the cell (with the same SIGTERM → SIGKILL escalation as `daemon stop`), deletes the cell metadata + cgroups, and clears the transient files `/run/kukeon/kukeond.{sock,pid}`. User-realm data under `/opt/kukeon/default/**` is left intact, so re-running `kuke init` after `kuke daemon reset` produces a clean re-bootstrap.
+
+Always runs as root: it touches `/sys/fs/cgroup`, containerd namespaces, and `/opt/kukeon`. Fails fast with a clear remediation if you forget `sudo`.
+
+Distinct from [`kuke uninstall`](kuke-uninstall.md), which is the per-host teardown (every realm, the kukeon system user/group, and the run path itself).
+
+| Flag             | Default | Description                                                              |
+| ---------------- | ------- | ------------------------------------------------------------------------ |
+| `--purge-system` | `false` | Also remove `/opt/kukeon/kuke-system` (user-realm data is still preserved) |
+| `--timeout`      | `10s`   | Grace period for the stop phase before escalating from SIGTERM to SIGKILL |
+
+## kuke daemon logs
+
+Print the `kukeond` container's stdout/stderr stream. Shortcut for `kuke log --realm kuke-system --space kukeon --stack kukeon --cell kukeond` — the coordinates are static and filled in for you.
+
+```
+kuke daemon logs [-f]
+kuke daemon log  [-f]      # alias
+```
+
+By default the current contents are printed and the command exits; pass `-f`/`--follow` to tail until SIGINT.
+
+| Flag             | Default | Description                                                  |
+| ---------------- | ------- | ------------------------------------------------------------ |
+| `--follow`, `-f` | `false` | Tail until SIGINT instead of printing current contents and exiting |
+
+## Examples
+
+```bash
+# Bring the daemon back after a host reboot
+sudo kuke daemon start
+
+# Graceful restart after editing /etc/kukeon/kukeond.yaml
+sudo kuke daemon restart
+
+# Force-kill an unresponsive daemon
+sudo kuke daemon kill
+
+# Dev loop: blow away the daemon cell and re-init
+sudo kuke daemon reset
+sudo kuke init --kukeond-image docker.io/library/kukeon-local:dev
+
+# Wipe /opt/kukeon/kuke-system too (user-realm data stays)
+sudo kuke daemon reset --purge-system
+
+# Tail the daemon log live
+sudo kuke daemon logs -f
+```
+
+## Related
+
+- [kuke init](kuke-init.md) — provisions the daemon cell that `kuke daemon …` manages
+- [kuke uninstall](kuke-uninstall.md) — full-host teardown; the next step up from `daemon reset --purge-system`
+- [kukeond](kukeond.md) — the daemon binary itself

--- a/docs/site/cli/kuke-delete.md
+++ b/docs/site/cli/kuke-delete.md
@@ -5,6 +5,7 @@ Delete a resource. Can be called per-resource (`kuke delete realm foo`) or again
 ```
 kuke delete <resource> <name> [--cascade] [--force] [scope flags]
 kuke delete -f <file>
+kuke d      <resource> <name> ...                                # alias
 ```
 
 ## Persistent flags (inherited by every subcommand)
@@ -62,13 +63,13 @@ kuke delete container <name> --realm <r> --space <s> --stack <t> --cell <c>
 
 ```bash
 # Delete an empty cell
-sudo kuke delete cell web --realm main --space blog --stack wordpress
+sudo kuke delete cell web --realm default --space blog --stack wordpress
 
-# Cascade-delete an entire realm (all spaces, stacks, cells, containers)
+# Cascade-delete an entire user realm (all spaces, stacks, cells, containers)
 sudo kuke delete realm mytenant --cascade
 
 # Force-delete a container that's stuck in an unknown state
-sudo kuke delete container stuck --cell web --realm main --space blog --stack wordpress --force
+sudo kuke delete container stuck --cell web --realm default --space blog --stack wordpress --force
 
 # Delete every resource listed in a manifest
 sudo kuke delete -f site.yaml
@@ -82,4 +83,5 @@ sudo kuke delete -f site.yaml
 ## Related
 
 - [kuke purge](kuke-purge.md) — more aggressive variant
+- [kuke uninstall](kuke-uninstall.md) — full-host teardown (every realm, system user/group, run path)
 - [Init and reset](../guides/init-and-reset.md) — full-host reset workflows

--- a/docs/site/cli/kuke-doctor.md
+++ b/docs/site/cli/kuke-doctor.md
@@ -1,0 +1,77 @@
+# kuke doctor
+
+Host pre-flight checks before `kuke init`. These checks read the host environment (cgroup hierarchy, controller delegation, …) and fail fast with an actionable remediation when the host would otherwise produce a cryptic mid-bootstrap error.
+
+```
+kuke doctor [command]
+```
+
+## Subcommands
+
+| Command              | What it checks                                                       |
+| -------------------- | -------------------------------------------------------------------- |
+| `kuke doctor cgroups` | cgroup-v2 controller delegation, on the host root or any sub-tree   |
+
+## kuke doctor cgroups
+
+```
+kuke doctor cgroups [name] [flags]
+```
+
+Compares the cgroup's available + delegated controllers against the set kukeon will enable on the `kukeond` bootstrap cell. Distinguishes "kernel does not support" from "parent did not delegate" so the remediation suggestion is always correct.
+
+By default it probes any controller missing from `cgroup.subtree_control` with a `+<ctrl>` write so the cgroup-namespace trap (advertised but not delegated, write returns `EOPNOTSUPP`) is distinguished from "merely needs the operator to enable it". The probe is idempotent on healthy hosts and harmless on trapped ones; pass `--no-probe` to keep the pre-flight strictly read-only.
+
+The `--probe` write requires root; `kuke doctor cgroups --probe` fails fast with a clear message if you forget `sudo`.
+
+### Flags
+
+| Flag                        | Default            | Description                                                                                                                                                                                       |
+| --------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--scope`                   | (empty)            | Verify a sub-tree instead of the host root: `realm`, `space`, `stack`, or `cell`. Resolves the named object's `Status.CgroupPath` via the daemon and runs the controller-set check on that path. |
+| `--realm`                   | (empty)            | Realm name (required for `--scope space`/`stack`/`cell`)                                                                                                                                          |
+| `--space`                   | (empty)            | Space name (required for `--scope stack`/`cell`)                                                                                                                                                  |
+| `--stack`                   | (empty)            | Stack name (required for `--scope cell`)                                                                                                                                                          |
+| `--root`                    | `/sys/fs/cgroup`   | Path to the cgroup-v2 root                                                                                                                                                                        |
+| `--probe`                   | `true`             | Attempt a `+<ctrl>` write to `cgroup.subtree_control` for missing controllers; disambiguates the cgroup-namespace trap                                                                            |
+| `--no-probe`                | `false`            | Keep the pre-flight strictly read-only. Wins over `--probe` when both are set.                                                                                                                    |
+| `--nested-cgroup-runtime`   | `false`            | Check the controller set required when the kukeond cell opts into `NestedCgroupRuntime`                                                                                                           |
+| `--verbose-status`          | `false`            | Print per-controller status even when the pre-flight passes                                                                                                                                       |
+
+Plus all [global flags](kuke.md).
+
+### Exit codes
+
+- `0` — every required controller is enabled (or was enabled by the probe write).
+- non-zero — at least one controller is missing, the cgroup directory could not be read, or `--probe` was used without root.
+
+### Examples
+
+```bash
+# Host-root pre-flight, with the default +ctrl probe write
+sudo kuke doctor cgroups
+
+# Read-only check; useful in CI before you have root
+kuke doctor cgroups --no-probe
+
+# Diagnose a mid-tree delegation gap inside a specific realm
+sudo kuke doctor cgroups --scope realm --realm default
+
+# Drill all the way down to a single cell's subtree
+sudo kuke doctor cgroups --scope cell --realm default --space default --stack default web
+
+# Print per-controller status even when the check passes
+sudo kuke doctor cgroups --verbose-status
+
+# Check the alternate controller set used by NestedCgroupRuntime cells
+sudo kuke doctor cgroups --nested-cgroup-runtime
+```
+
+## When to run
+
+Run `kuke doctor cgroups` once before the first `kuke init` on a new host. If the daemon later fails to start a cell with a "controller not available" error, run `--scope` against the parent realm/space/stack to find the level where delegation breaks.
+
+## Related
+
+- [kuke init](kuke-init.md) — what doctor pre-flights for
+- [Concepts → Cgroups](../concepts/cgroups.md) — the controller model

--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -11,9 +11,10 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also 
 
 ## Common flags
 
-| Flag             | Description                                                                                      |
-| ---------------- | ------------------------------------------------------------------------------------------------ |
-| `--output`, `-o` | Output format: `yaml`, `json`, `table`. Default: `table` for list, `yaml` for a single resource. |
+| Flag                 | Description                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| `--output`, `-o`     | Output format: `yaml`, `json`, `table`. Default: `table` for list, `yaml` for a single resource.  |
+| `--show-controllers` | Append a `CONTROLLERS` column listing the cgroup-v2 controllers delegated on the subject's subtree. Off by default to keep the dev-init parity check stable. |
 
 Plus all [global flags](kuke.md) — most importantly `--no-daemon`.
 
@@ -37,26 +38,30 @@ All scope flags default to `default`. See the [realm default note](commands.md#c
 - **Single** (positional arg): returns the one matching resource. Default output is YAML.
 
 ```bash
-# Table of realms
+# Table of realms — the dev-init parity check expects this exact shape
 sudo kuke get realms
-NAME           NAMESPACE       STATE    CGROUP
-main           kukeon-main     Running  /kukeon/main
-kukeon-system  kukeon-system   Running  /kukeon/kukeon-system
+NAME         NAMESPACE              STATE  CGROUP
+-----------  ---------------------  -----  -------------------
+default      default.kukeon.io      Ready  /kukeon/default
+kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
 
 # Single realm as YAML
-sudo kuke get realm main -o yaml
+sudo kuke get realm default -o yaml
 
 # Single realm as JSON
-sudo kuke get realm main -o json
+sudo kuke get realm default -o json
 
-# Spaces in a non-default realm
-sudo kuke get spaces --realm main
+# Spaces in the default realm
+sudo kuke get spaces --realm default
 
 # Cells in a specific stack
-sudo kuke get cells --realm main --space default --stack default
+sudo kuke get cells --realm default --space default --stack default
 
-# All containers in the cell
-sudo kuke get containers --realm main --space default --stack default --cell hello-world
+# All containers in a cell
+sudo kuke get containers --realm default --space default --stack default --cell hello-world
+
+# Show which cgroup controllers are delegated to every realm
+sudo kuke get realms --show-controllers
 ```
 
 ## `get` vs `refresh`

--- a/docs/site/cli/kuke-image.md
+++ b/docs/site/cli/kuke-image.md
@@ -1,0 +1,96 @@
+# kuke image
+
+Manage container images in a realm's containerd namespace.
+
+```
+kuke image [command]
+```
+
+Every realm maps to its own containerd namespace (`<realm>.kukeon.io`). `kuke image` lists, loads, and deletes images inside that namespace. The default realm is `default` (containerd namespace `default.kukeon.io`); pass `--realm kuke-system` to operate on the system realm where the `kukeond` image lives.
+
+## Subcommands
+
+| Command            | What it does                                                        |
+| ------------------ | ------------------------------------------------------------------- |
+| `kuke image load`  | Import an OCI/docker image tarball into a realm's containerd namespace |
+| `kuke image get`   | List or describe images in a realm's containerd namespace            |
+| `kuke image delete`| Remove an image from a realm's containerd namespace                  |
+
+## kuke image load
+
+```
+kuke image load [tarball | -] [flags]
+```
+
+Import an OCI/docker image tarball into the containerd namespace mapped to `--realm`. Pass a tarball path, `-` for stdin, or `--from-docker <ref>` to shell out to `docker save`.
+
+`kuke image load --no-daemon` (the bootstrap path used by `kuke init`) requires root; it fails fast with a clear remediation if you forget `sudo`.
+
+| Flag            | Default   | Description                                                                                       |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------- |
+| `--from-docker` | (empty)   | Image reference to pipe in via `docker save <ref>` (mutually exclusive with the positional tarball) |
+| `--realm`       | `default` | Target realm; the image lands in `<realm>.kukeon.io`                                              |
+
+### Examples
+
+```bash
+# Load a saved tarball into the default realm
+sudo kuke image load my-image.tar
+
+# Pipe a docker-build into kuke-system for a local kukeond image
+sudo kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
+
+# Stdin
+docker save myimage:latest | sudo kuke image load -
+```
+
+## kuke image get
+
+```
+kuke image get [ref] [flags]
+kuke image ls  [ref] [flags]      # alias
+```
+
+| Flag             | Default   | Description                                                                                       |
+| ---------------- | --------- | ------------------------------------------------------------------------------------------------- |
+| `--realm`        | `default` | Target realm; the lookup runs in `<realm>.kukeon.io`                                              |
+| `--output`, `-o` | (auto)    | Output format (`yaml`, `json`, `table`). Default: `table` for list, `yaml` for a single resource. |
+
+### Examples
+
+```bash
+# List images in the default realm
+sudo kuke image get
+
+# List images in the system realm (where the kukeond image lives)
+sudo kuke image get --realm kuke-system
+
+# Describe a single image as YAML
+sudo kuke image get docker.io/library/nginx:alpine -o yaml
+```
+
+## kuke image delete
+
+```
+kuke image delete <ref> [flags]
+kuke image rm     <ref> [flags]      # alias
+```
+
+| Flag      | Default   | Description                                          |
+| --------- | --------- | ---------------------------------------------------- |
+| `--realm` | `default` | Target realm; the lookup runs in `<realm>.kukeon.io` |
+
+### Examples
+
+```bash
+# Remove an image from the default realm
+sudo kuke image delete docker.io/library/nginx:alpine
+
+# Remove an image from kuke-system
+sudo kuke image delete docker.io/library/kukeon-local:dev --realm kuke-system
+```
+
+## Related
+
+- [kuke init](kuke-init.md) — uses `kuke image load --from-docker --no-daemon` in the local-dev bootstrap path
+- [Local development](../guides/local-dev.md) — first-time bootstrap with a local image

--- a/docs/site/cli/kuke-init.md
+++ b/docs/site/cli/kuke-init.md
@@ -1,38 +1,51 @@
 # kuke init
 
-Bootstrap or reconcile a host. Creates the default user realm, the system realm, the kukeon cgroup root, the CNI config directory, and the `kukeond` cell. Starts the daemon and waits for it to respond.
+Bootstrap or reconcile a host. Creates the kukeon cgroup root, the CNI config directory, both default realms (`default` and `kuke-system`) and their default space/stack, and the `kukeond` cell. Starts the daemon and waits for it to respond.
 
 ```
 kuke init [flags]
 ```
 
-Always runs as root: it touches `/sys/fs/cgroup`, containerd namespaces, `/opt/kukeon`, and CNI dirs.
+Always runs as root: it touches `/sys/fs/cgroup`, containerd namespaces, `/opt/kukeon`, and CNI dirs. `kuke init` fails fast with a clear remediation if you forget `sudo`.
 
 ## Flags
 
-| Flag                     | Default                            | Description                                                                                                                                                   |
-| ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--realm`                | `default`                          | Name of the default user realm                                                                                                                                |
-| `--space`                | `default`                          | Name of the default space inside the user realm                                                                                                               |
-| `--kukeond-image`        | `ghcr.io/eminwux/kukeon:<version>` | Image to run the daemon cell. See [image resolution](#image-resolution).                                                                                      |
-| `--no-wait`              | `false`                            | Don't wait for the daemon socket after bootstrap                                                                                                              |
-| `--force-regenerate-cni` | `false`                            | Rewrite every space's CNI conflist even if it exists. See [Troubleshooting](../guides/troubleshooting.md#kuke-init-fails-with-numerical-result-out-of-range). |
+| Flag                              | Default                            | Description                                                                                                                                                   |
+| --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--realm`                         | `default`                          | Name of the default user realm                                                                                                                                |
+| `--space`                         | `default`                          | Name of the default space inside the user realm                                                                                                               |
+| `--kukeond-image`                 | `ghcr.io/eminwux/kukeon:<version>` | Image to run the daemon cell. See [image resolution](#image-resolution).                                                                                      |
+| `--server-configuration`          | `/etc/kukeon/kukeond.yaml`         | `ServerConfiguration` YAML to seed the daemon with; absent file uses hardcoded defaults                                                                       |
+| `--cgroup-root`                   | `/kukeon`                          | Cgroup root under which all realms / spaces / stacks / cells live                                                                                             |
+| `--containerd-namespace-suffix`   | `kukeon.io`                        | Suffix appended to every realm name to form its containerd namespace (`default` → `default.kukeon.io`)                                                        |
+| `--no-wait`                       | `false`                            | Don't wait for the daemon socket after bootstrap                                                                                                              |
+| `--force-regenerate-cni`          | `false`                            | Rewrite every space's CNI conflist even if it exists. See [Troubleshooting](../guides/troubleshooting.md#kuke-init-fails-with-numerical-result-out-of-range). |
 
 Plus all [global flags](kuke.md).
 
 ## What it does
 
-1. Creates `/sys/fs/cgroup/kukeon` if missing.
+1. Creates `/sys/fs/cgroup/kukeon` if missing (or the directory matching `--cgroup-root`).
 2. Creates `/etc/cni/net.d` and `/opt/cni/bin` if missing.
-3. Creates the user realm (`--realm`, default `default`): containerd namespace, cgroup, metadata.
-4. Creates the default space (`--space`, default `default`): CNI conflist, bridge, cgroup, metadata.
-5. Creates the default stack (`default`): cgroup, metadata.
-6. Creates the system realm (`kukeon-system`): containerd namespace, cgroup, metadata.
-7. Creates the system space and stack inside `kukeon-system`.
-8. Creates the `kukeond` cell and its root container using `--kukeond-image`.
-9. Starts the daemon's root container; waits up to 30s for the socket to accept a `Ping` RPC (skipped when `--no-wait` is set).
+3. Creates the user realm (`--realm`, default `default`): containerd namespace `<realm>.kukeon.io`, cgroup, metadata. The realm is left empty so `kuke purge --cascade` on it can never take down the daemon.
+4. Creates the default space (`--space`, default `default`) inside the user realm: CNI conflist, bridge, cgroup, metadata.
+5. Creates the default stack (`default`) inside the default space: cgroup, metadata.
+6. Creates the system realm `kuke-system` (containerd namespace `kuke-system.kukeon.io`), plus its `kukeon` space and `kukeon` stack.
+7. Creates the `kukeond` cell inside `kuke-system / kukeon / kukeon` and its root container using `--kukeond-image`.
+8. Starts the daemon's root container; waits up to 30s for the socket to accept a `Ping` RPC (skipped when `--no-wait` is set). The socket is `chown`ed to the `kukeon` system group with mode 0660 so members of that group can dial it.
 
 Everything is idempotent. Re-running `init` on a bootstrapped host reports `already existed` for the parts it finds on disk. Use `--force-regenerate-cni` to explicitly rewrite the CNI conflist.
+
+## The two default realms
+
+`kuke init` provisions **two** realms, each mapped to its own containerd namespace:
+
+| Realm         | Containerd namespace    | Purpose                                                      |
+| ------------- | ----------------------- | ------------------------------------------------------------ |
+| `default`     | `default.kukeon.io`     | User workloads. Created empty so `kuke create …` has a home. |
+| `kuke-system` | `kuke-system.kukeon.io` | System workloads owned by kukeon itself.                     |
+
+The `kukeond` daemon runs as a container inside the cell `kuke-system / kukeon / kukeon / kukeond`. The `default` realm is deliberately left user-owned so `kuke purge --cascade` on it can never take down the daemon.
 
 ## Image resolution
 
@@ -41,7 +54,7 @@ Everything is idempotent. Re-running `init` on a bootstrapped host reports `alre
 - Release builds: `ghcr.io/eminwux/kukeon:<version>` where `<version>` is the semver tag.
 - Dev builds (no tag or non-`v`-prefixed version): `ghcr.io/eminwux/kukeon:latest`.
 
-For local iteration, pass `--kukeond-image docker.io/library/kukeon-local:dev` or whatever tag you built.
+For local iteration, pre-load a local image with [`kuke image load --from-docker`](kuke-image.md) and pass `--kukeond-image docker.io/library/kukeon-local:dev` or whatever tag you built.
 
 ## Examples
 
@@ -60,6 +73,10 @@ sudo kuke init --force-regenerate-cni
 
 # Bootstrap without waiting for the daemon to come up
 sudo kuke init --no-wait
+
+# Run host pre-flight before initializing
+sudo kuke doctor cgroups
+sudo kuke init
 ```
 
 ## Output
@@ -68,5 +85,7 @@ sudo kuke init --no-wait
 
 ## Related
 
+- [kuke doctor](kuke-doctor.md) — host pre-flight checks before `kuke init`
+- [kuke daemon](kuke-daemon.md) — lifecycle verbs for the `kukeond` cell after bootstrap
 - [Init and reset](../guides/init-and-reset.md) — teardown, re-init, and reset workflows
 - [Local development](../guides/local-dev.md) — first-time bootstrap with a local image

--- a/docs/site/cli/kuke-lifecycle.md
+++ b/docs/site/cli/kuke-lifecycle.md
@@ -42,7 +42,7 @@ kuke kill container  <name> --realm <r> --space <s> --stack <t> --cell <c>
 
 Aliases: `kuke kill` → `kuke k`.
 
-Sends SIGKILL. Useful when a container is unresponsive, or when tearing down the daemon (`kuke kill cell kukeond …`).
+Sends SIGKILL. Useful when a container is unresponsive. For the daemon itself, prefer the dedicated [`kuke daemon kill`](kuke-daemon.md) shortcut — it knows the daemon's static coordinates.
 
 ## Common flags
 
@@ -61,13 +61,13 @@ Plus all [global flags](kuke.md).
 
 ```bash
 # Start a cell
-sudo kuke start cell web --realm main --space blog --stack wordpress
+sudo kuke start cell web --realm default --space blog --stack wordpress
 
 # Graceful stop
-sudo kuke stop cell web --realm main --space blog --stack wordpress
+sudo kuke stop cell web --realm default --space blog --stack wordpress
 
-# Force-kill (useful for the daemon cell itself)
-sudo kuke kill cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+# Force-kill an unresponsive container
+sudo kuke kill container stuck --cell web --realm default --space blog --stack wordpress
 ```
 
 ## Exit semantics
@@ -76,3 +76,8 @@ sudo kuke kill cell kukeond --realm kukeon-system --space kukeon --stack kukeon 
 - Exit non-zero: the daemon couldn't find the resource, the resource is in a state that doesn't allow the transition, or the underlying containerd/runtime call failed.
 
 After `stop`/`kill`, the resource is in `Stopped` state. `start` moves it to `Ready`. See [Cell](../concepts/cell.md#lifecycle) and [Container](../concepts/container.md#lifecycle) for the full state tables.
+
+## Related
+
+- [kuke run](kuke-run.md) — create + start a cell from a file or profile
+- [kuke daemon](kuke-daemon.md) — start/stop/restart/kill the `kukeond` daemon cell

--- a/docs/site/cli/kuke-log.md
+++ b/docs/site/cli/kuke-log.md
@@ -3,22 +3,22 @@
 Print a container's stdout/stderr stream.
 
 ```
-kuke log  --cell <cell> [flags]
-kuke logs --cell <cell> [flags]      # alias
+kuke log  --realm <realm> --space <space> --stack <stack> --cell <cell> [flags]
+kuke logs --realm <realm> --space <space> --stack <stack> --cell <cell> [flags]      # alias
 ```
 
 By default, `kuke log` prints the current contents of the capture file and exits. Pass `-f`/`--follow` to tail until SIGINT.
 
 ## Flags
 
-| Flag          | Default     | Description                                                                              |
-| ------------- | ----------- | ---------------------------------------------------------------------------------------- |
-| `--cell`      | _(required)_| Cell whose container's capture file to tail                                              |
-| `--container` | (auto-pick) | Container within the cell to read (omit to auto-pick the only non-root container)        |
-| `--realm`     | `default`   | Realm that owns the cell                                                                 |
-| `--space`     | `default`   | Space that owns the cell                                                                 |
-| `--stack`     | `default`   | Stack that owns the cell                                                                 |
-| `--follow`, `-f` | `false` | Tail the file until SIGINT instead of printing current contents and exiting              |
+| Flag             | Default      | Description                                                                       |
+| ---------------- | ------------ | --------------------------------------------------------------------------------- |
+| `--cell`         | _(required)_ | Cell whose container's capture file to tail                                       |
+| `--container`    | (auto-pick)  | Container within the cell to read (omit to auto-pick the only non-root container) |
+| `--realm`        | _(required)_ | Realm that owns the cell                                                          |
+| `--space`        | _(required)_ | Space that owns the cell                                                          |
+| `--stack`        | _(required)_ | Stack that owns the cell                                                          |
+| `--follow`, `-f` | `false`      | Tail the file until SIGINT instead of printing current contents and exiting       |
 
 Plus all [global flags](kuke.md).
 
@@ -28,20 +28,22 @@ Plus all [global flags](kuke.md).
 
 Container selection: if the cell has exactly one non-root container, `--container` can be omitted. Otherwise, pass `--container` explicitly.
 
+`--realm`, `--space`, and `--stack` are all required — `kuke log` does not assume `default` for any of them. Pass each explicitly even when targeting the default realm/space/stack. (Note: `kuke attach` defaults these three to `default`; the two commands diverge here.)
+
 ## Examples
 
 ```bash
 # Print and exit
-sudo kuke log --cell web
+sudo kuke log --realm default --space default --stack default --cell web
 
 # Follow until Ctrl-C
-sudo kuke log --cell web -f
+sudo kuke log --realm default --space default --stack default --cell web -f
 
 # Explicit container in a multi-container cell
-sudo kuke log --cell web --container nginx -f
+sudo kuke log --realm default --space default --stack default --cell web --container nginx -f
 
 # Non-default realm/space/stack
-sudo kuke log --cell wp --realm default --space blog --stack wordpress
+sudo kuke log --realm default --space blog --stack wordpress --cell wp
 ```
 
 ## kuke log vs. kuke daemon logs

--- a/docs/site/cli/kuke-log.md
+++ b/docs/site/cli/kuke-log.md
@@ -1,0 +1,54 @@
+# kuke log
+
+Print a container's stdout/stderr stream.
+
+```
+kuke log  --cell <cell> [flags]
+kuke logs --cell <cell> [flags]      # alias
+```
+
+By default, `kuke log` prints the current contents of the capture file and exits. Pass `-f`/`--follow` to tail until SIGINT.
+
+## Flags
+
+| Flag          | Default     | Description                                                                              |
+| ------------- | ----------- | ---------------------------------------------------------------------------------------- |
+| `--cell`      | _(required)_| Cell whose container's capture file to tail                                              |
+| `--container` | (auto-pick) | Container within the cell to read (omit to auto-pick the only non-root container)        |
+| `--realm`     | `default`   | Realm that owns the cell                                                                 |
+| `--space`     | `default`   | Space that owns the cell                                                                 |
+| `--stack`     | `default`   | Stack that owns the cell                                                                 |
+| `--follow`, `-f` | `false` | Tail the file until SIGINT instead of printing current contents and exiting              |
+
+Plus all [global flags](kuke.md).
+
+## Behavior
+
+`kuke log` reads the on-disk capture file maintained by the daemon for each container's stdout/stderr. Without `-f`, it prints what's there and exits — useful for scripting and for checking on a container that has already terminated. With `-f`, it tails the file until you SIGINT (Ctrl-C) the command.
+
+Container selection: if the cell has exactly one non-root container, `--container` can be omitted. Otherwise, pass `--container` explicitly.
+
+## Examples
+
+```bash
+# Print and exit
+sudo kuke log --cell web
+
+# Follow until Ctrl-C
+sudo kuke log --cell web -f
+
+# Explicit container in a multi-container cell
+sudo kuke log --cell web --container nginx -f
+
+# Non-default realm/space/stack
+sudo kuke log --cell wp --realm default --space blog --stack wordpress
+```
+
+## kuke log vs. kuke daemon logs
+
+`kuke log` is for any user-workload container. To read the `kukeond` daemon's own logs without typing out the static `kuke-system / kukeon / kukeon / kukeond` coordinates, use [`kuke daemon logs`](kuke-daemon.md) — it's a thin wrapper around `kuke log` with the realm/space/stack/cell pre-filled.
+
+## Related
+
+- [kuke daemon logs](kuke-daemon.md) — shortcut for the daemon's own log stream
+- [kuke attach](kuke-attach.md) — interactive `sbsh` terminal instead of a one-way log stream

--- a/docs/site/cli/kuke-purge.md
+++ b/docs/site/cli/kuke-purge.md
@@ -4,6 +4,7 @@ More aggressive variant of [`kuke delete`](kuke-delete.md). Removes metadata, re
 
 ```
 kuke purge <resource> <name> [--cascade] [--force] [scope flags]
+kuke p     <resource> <name> ...                                # alias
 ```
 
 Resources: `realm`, `space`, `stack`, `cell`, `container`.
@@ -22,11 +23,11 @@ Plus all [global flags](kuke.md).
 Shape and flags are identical to the equivalent `delete` subcommands:
 
 ```
-kuke purge realm     <name>                                 [--cascade] [--force]
-kuke purge space     <name> --realm <r>                     [--cascade] [--force]
-kuke purge stack     <name> --realm <r> --space <s>         [--cascade] [--force]
-kuke purge cell      <name> --realm <r> --space <s> --stack <t>  [--cascade] [--force]
-kuke purge container <name> --realm <r> --space <s> --stack <t> --cell <c> [--force]
+kuke purge realm     <name>                                              [--cascade] [--force]
+kuke purge space     <name> --realm <r>                                  [--cascade] [--force]
+kuke purge stack     <name> --realm <r> --space <s>                      [--cascade] [--force]
+kuke purge cell      <name> --realm <r> --space <s> --stack <t>          [--cascade] [--force]
+kuke purge container <name> --realm <r> --space <s> --stack <t> --cell <c>           [--force]
 ```
 
 ## When to use purge vs. delete
@@ -43,24 +44,38 @@ kuke purge container <name> --realm <r> --space <s> --stack <t> --cell <c> [--fo
 - CNI networks are torn down via the bridge plugin even when the metadata is inconsistent.
 - Conflist files are unlinked from disk.
 
+## Safe by design: purging the user realm
+
+`kuke purge --cascade` on the `default` (user) realm is **safe**: the daemon lives in `kuke-system / kukeon / kukeon / kukeond`, so the user-realm cascade can never take down the daemon. To wipe `default` and immediately reuse the host:
+
+```bash
+sudo kuke purge realm default --cascade --force
+sudo kuke create realm default
+sudo kuke create space  default --realm default
+sudo kuke create stack  default --realm default --space default
+```
+
 ## Examples
 
 ```bash
-# Purge a realm that delete wouldn't tear down
+# Purge a user realm that delete wouldn't tear down
 sudo kuke purge realm mytenant --cascade --force
 
 # Nuke a broken cell
-sudo kuke purge cell stuck --realm main --space default --stack default --cascade --force
+sudo kuke purge cell stuck --realm default --space default --stack default --cascade --force
 
 # Clean up a container that's been orphaned
-sudo kuke purge container ghost --cell web --realm main --space blog --stack wordpress --force
+sudo kuke purge container ghost --cell web --realm default --space blog --stack wordpress --force
 ```
 
 ## Caution
 
 `purge` is destructive and makes "best effort" its primary operating mode. It will keep going past errors that would halt `delete`. Use it when you're prepared to lose state that you didn't explicitly back up.
 
+For a full-host teardown (every realm, the kukeon system user/group, and `/opt/kukeon` itself), use [`kuke uninstall`](kuke-uninstall.md).
+
 ## Related
 
 - [kuke delete](kuke-delete.md) — the safer variant
+- [kuke uninstall](kuke-uninstall.md) — per-host teardown wrapping `purge --cascade`
 - [Init and reset → Full host wipe](../guides/init-and-reset.md#full-host-wipe) — uses `purge --cascade --force` in the nuclear path

--- a/docs/site/cli/kuke-refresh.md
+++ b/docs/site/cli/kuke-refresh.md
@@ -26,8 +26,8 @@ A summary of what was inspected and what was updated:
 
 ```
 $ sudo kuke refresh
-Inspected 3 realms, 5 spaces, 6 stacks, 8 cells, 12 containers.
-Updated 2 resources.
+Inspected 2 realms, 2 spaces, 2 stacks, 1 cells, 1 containers.
+Updated 0 resources.
 ```
 
 ## When it's a no-op
@@ -43,5 +43,5 @@ So a typical "what's actually happening right now" workflow is:
 
 ```bash
 sudo kuke refresh
-sudo kuke get cells --realm main --space default --stack default
+sudo kuke get cells --realm default --space default --stack default
 ```

--- a/docs/site/cli/kuke-run.md
+++ b/docs/site/cli/kuke-run.md
@@ -1,0 +1,90 @@
+# kuke run
+
+Create and start a single cell from a YAML file or stdin (`-f`), or from a per-user profile under `$HOME/.kuke/profiles.d/<name>.yaml` (`-p`). Conceptually `kuke apply -f` (single-cell) plus `kuke start cell`, but refuses to update a divergent on-disk spec.
+
+```
+kuke run (-f <file> | -p <profile>) [flags]
+```
+
+To re-attach to an existing cell, use [`kuke attach <cell>`](kuke-attach.md).
+
+## Flags
+
+| Flag                | Default                   | Description                                                                                                                                                          |
+| ------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--file`, `-f`      | _(one of `-f`/`-p`)_      | YAML to read (path or `-` for stdin); mutually exclusive with `-p`                                                                                                   |
+| `--profile`, `-p`   | _(one of `-f`/`-p`)_      | Cell profile name to load from `$HOME/.kuke/profiles.d` (or `$KUKE_PROFILES_DIR`); mutually exclusive with `-f`                                                      |
+| `--name`            | `<metadata.name>-<6hex>`  | Override the materialized cell name. Only valid with `-p`; rejected with `-f`, where `metadata.name` is the cell name verbatim                                       |
+| `--param`           | (empty, repeatable)       | Profile parameter override as `KEY=VALUE`. Only valid with `-p`. Each `KEY` must be declared in `spec.parameters[]`. Wins over the default and over `--param-file`.   |
+| `--param-file`      | (empty)                   | File of `KEY=VALUE` lines whose values seed profile parameters; one per line, `#` starts a comment. Same declaration rules as `--param`. CLI `--param` wins on dups. |
+| `--detach`, `-d`    | `false`                   | Return immediately after start without attaching                                                                                                                     |
+| `--container`       | (auto-pick)               | Container to attach to (attach mode only; rejected with `-d`). Precedence: `--container` > `cell.tty.default` > first attachable                                     |
+| `--rm`              | `false`                   | Best-effort delete the cell after it's no longer needed (any rc). See [Cleanup with `--rm`](#cleanup-with---rm).                                                     |
+| `--realm`           | (from manifest)           | Realm that owns the cell (overrides `spec.realmId` only when the doc is empty)                                                                                       |
+| `--space`           | (from manifest)           | Space that owns the cell                                                                                                                                             |
+| `--stack`           | (from manifest)           | Stack that owns the cell                                                                                                                                             |
+| `--output`, `-o`    | (human-readable)          | Output format: `json`, `yaml`                                                                                                                                        |
+
+Plus all [global flags](kuke.md).
+
+## Attach vs. detach
+
+By default, `kuke run` attaches to the cell's attachable container after start. Precedence for which container to attach to:
+
+1. `--container <name>` if set.
+2. The container marked `tty.default: true` in the cell spec.
+3. The single non-root attachable container, when there's exactly one.
+
+Pass `-d`/`--detach` to return immediately without attaching. `--container` is rejected together with `-d`.
+
+A clean `^]^]` detach exits the CLI but leaves the cell running so you can re-attach later with [`kuke attach`](kuke-attach.md).
+
+## Profiles
+
+Profiles are YAML files under `$HOME/.kuke/profiles.d/<name>.yaml` (or `$KUKE_PROFILES_DIR`). A profile is a cell spec template with declared `spec.parameters[]`. Each invocation materializes one cell with a unique name (`<metadata.name>-<6hex>` by default; override with `--name`).
+
+Parameters are resolved in this order, last-write-wins per key:
+
+1. The parameter's `default` in the profile.
+2. Values from `--param-file <path>`.
+3. Values from each `--param KEY=VALUE` on the CLI.
+
+Keys not declared in `spec.parameters[]` are rejected.
+
+## Cleanup with `--rm`
+
+`--rm` best-effort deletes the cell after it's no longer needed (any return code). Daemon-mode only — incompatible with `--no-daemon`. Cleanup runs from `kukeond`'s reconcile loop, so latency is bounded by the reconcile interval rather than firing the instant the trigger fires.
+
+Triggers:
+
+- With `-d`/`--detach`: the root container's task exits.
+- In the default attach mode: the attach loop exits because the workload terminated, the peer hung up, or an unrecoverable controller error fired — the CLI then sends `KillCell` so a long-lived root (e.g. `sleep infinity`) doesn't pin the cell.
+- A clean `^]^]` detach is **not** a trigger: the cell stays alive so the operator can re-attach later (parity with `kuke attach`).
+
+## Examples
+
+```bash
+# Run a one-shot cell from a file, attached
+sudo kuke run -f hello.yaml
+
+# Run detached from a profile
+kuke run -p shell --detach
+
+# Materialize a profile with overridden parameters
+kuke run -p shell --param IMAGE=alpine:latest --param CMD="/bin/sh"
+
+# Use a parameter file, with one CLI override winning on the same key
+kuke run -p shell --param-file ./shell.env --param IMAGE=alpine:edge
+
+# Pin the materialized cell name
+kuke run -p shell --name my-shell --detach
+
+# One-shot job that cleans itself up after the workload exits
+kuke run -p batch --rm
+```
+
+## Related
+
+- [kuke apply](kuke-apply.md) — declarative path; supports multi-document manifests
+- [kuke attach](kuke-attach.md) — attach to an already-running cell
+- [kuke create cell](kuke-create.md#kuke-create-cell) — imperative cell creation without a manifest

--- a/docs/site/cli/kuke-uninstall.md
+++ b/docs/site/cli/kuke-uninstall.md
@@ -1,0 +1,62 @@
+# kuke uninstall
+
+Remove all kukeon runtime state from this host.
+
+```
+kuke uninstall [flags]
+```
+
+This is the global counterpart to [`kuke purge`](kuke-purge.md) (which is per-resource). It:
+
+1. Purges every realm with `--cascade` — drains spaces, stacks, cells, containers and their containerd tasks/containers, and deletes the containerd namespaces created by kukeon.
+2. Removes `/run/kukeon/` recursively.
+3. Removes the configured run path (default `/opt/kukeon`) recursively.
+4. Removes the kukeon system user and group (no-op if absent).
+
+The `/usr/local/bin/kuke` binary and the `kukeond` symlink are **not** removed — uninstalling runtime state is not the same as uninstalling the binary.
+
+## Flags
+
+| Flag         | Default | Description                                                          |
+| ------------ | ------- | -------------------------------------------------------------------- |
+| `--yes`, `-y`| `false` | Skip the interactive confirmation prompt (use this in scripts)       |
+
+Plus all [global flags](kuke.md).
+
+## Behavior
+
+By default, `kuke uninstall` asks for interactive confirmation before doing anything. Pass `--yes`/`-y` to skip the prompt.
+
+If any realm fails to drop its containerd namespace, steps 2–4 are **skipped**: tearing out `/opt/kukeon` while a residual namespace is still pinning overlay mounts on disk would strand the next `kuke init` with stale containerd state. The report flags every dir/account row as `skipped (realm purge failed)` so the half-cleaned host is visible without scrolling to the trailing error.
+
+Resolve the realm-purge failure (often: stop the live daemon, remove the residual containerd namespace by hand) and re-run the command.
+
+## Exit codes
+
+- `0` — every step succeeded (or was already in the target state).
+- non-zero — at least one step failed. Check the report for which row was flagged.
+
+## Examples
+
+```bash
+# Interactive teardown
+sudo kuke uninstall
+
+# Scripted teardown
+sudo kuke uninstall --yes
+```
+
+## uninstall vs. daemon reset vs. purge
+
+| Command                                          | Scope                                                                 |
+| ------------------------------------------------ | --------------------------------------------------------------------- |
+| [`kuke daemon reset`](kuke-daemon.md)            | Only the `kukeond` cell + `/run/kukeon`. User-realm data preserved.   |
+| [`kuke daemon reset --purge-system`](kuke-daemon.md) | The above plus `/opt/kukeon/kuke-system`. User-realm data preserved. |
+| [`kuke purge realm <r> --cascade`](kuke-purge.md) | A single realm and its subtree. Daemon stays up.                      |
+| `kuke uninstall`                                 | Every realm, every namespace, `/run/kukeon`, `/opt/kukeon`, user/group. |
+
+## Related
+
+- [kuke purge](kuke-purge.md) — per-resource aggressive cleanup
+- [kuke daemon reset](kuke-daemon.md) — dev-loop reset of just the daemon cell
+- [Init and reset](../guides/init-and-reset.md) — full reset workflows

--- a/docs/site/cli/kuke-version.md
+++ b/docs/site/cli/kuke-version.md
@@ -12,7 +12,7 @@ A single line containing the version string:
 
 ```
 $ kuke version
-v0.1.0
+v0.5.0
 ```
 
 For release builds, this is the semver tag. For dev builds, it's whatever `VERSION` was passed at build time (often `v0.0.0-dev` or empty).

--- a/docs/site/cli/kuke.md
+++ b/docs/site/cli/kuke.md
@@ -12,11 +12,11 @@ These flags apply to every `kuke` subcommand. Defaults are shown in parentheses.
 
 ### `--run-path` (`/opt/kukeon`)
 
-Where Kukeon stores on-disk metadata for realms, spaces, stacks, cells, and containers. Must be writable by the process running `kuke` (typically root).
+Where Kukeon stores on-disk metadata for realms, spaces, stacks, cells, and containers. Must be writable by the process running `kuke` — typically root, or a member of the `kukeon` group when talking to the daemon over its group-readable socket.
 
-### `--config` (`/etc/kukeon/config.yaml`)
+### `--configuration` (`$HOME/.kuke/kuke.yaml`)
 
-Path to the configuration file. If the file doesn't exist, Kukeon falls back to command-line flags and environment variables only — a missing config file is not fatal.
+Path to a `ClientConfiguration` YAML. If the file doesn't exist, Kukeon falls back to command-line flags, environment variables, and hardcoded defaults — a missing config file is not fatal.
 
 ### `--containerd-socket` (`/run/containerd/containerd.sock`)
 
@@ -28,9 +28,9 @@ The daemon endpoint. Today only the `unix://` scheme is supported. The `ssh://us
 
 ### `--no-daemon` (`false`)
 
-Bypass `kukeond` and run the operation in-process. Requires root: the client now directly touches containerd, CNI, cgroups.
+Bypass `kukeond` and run the operation in-process. Requires root: the client now directly touches containerd, CNI, and cgroups.
 
-Use when the daemon is stopped, when bootstrapping (`kuke init`), or when working around the current limitation that the released daemon image doesn't bind-mount `/run/containerd/containerd.sock`.
+Use when the daemon is stopped, when bootstrapping (`kuke init` and `kuke image load --no-daemon` both run this path), or while debugging.
 
 Don't run two `--no-daemon` commands at the same time — they'll race on the same on-disk state.
 
@@ -44,7 +44,7 @@ One of `debug`, `info`, `warn`, `error`. Controls log verbosity when `--verbose`
 
 ## Environment variables
 
-Every flag also has a corresponding `KUKEON_*` environment variable (check via `--help` on a subcommand, or see `cmd/config/env.go`). Flags beat env vars beat the config file beats built-in defaults.
+Every flag also has a corresponding `KUKE_*` environment variable (check via `--help` on a subcommand, or see `cmd/config/env.go`). Flags beat env vars beat the config file beats built-in defaults.
 
 ## Examples
 

--- a/docs/site/cli/kukeond.md
+++ b/docs/site/cli/kukeond.md
@@ -8,12 +8,17 @@ kukeond serve [flags]
 
 ## Persistent flags
 
-| Flag                  | Default                           | Description                                                         |
-| --------------------- | --------------------------------- | ------------------------------------------------------------------- |
-| `--run-path`          | `/opt/kukeon`                     | Where the daemon reads/writes persistent state (shared with `kuke`) |
-| `--containerd-socket` | `/run/containerd/containerd.sock` | Path to the containerd socket                                       |
-| `--socket`            | `/run/kukeon/kukeond.sock`        | Unix socket the daemon listens on                                   |
-| `--log-level`         | `info`                            | Log level: `debug`, `info`, `warn`, `error`                         |
+| Flag                              | Default                           | Description                                                                                                          |
+| --------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `--socket`                        | `/run/kukeon/kukeond.sock`        | Unix socket the daemon listens on                                                                                    |
+| `--socket-gid`                    | `0`                               | Group ID to chown the listener socket to (mode 0660 with group). Set by `kuke init` to the `kukeon` GID.             |
+| `--run-path`                      | `/opt/kukeon`                     | Where the daemon reads/writes persistent state (shared with `kuke`)                                                  |
+| `--containerd-socket`             | `/run/containerd/containerd.sock` | Path to the containerd socket                                                                                        |
+| `--configuration`                 | `/etc/kukeon/kukeond.yaml`        | `ServerConfiguration` YAML; absent file uses hardcoded defaults                                                      |
+| `--cgroup-root`                   | `/kukeon`                         | Cgroup root under which all realms / spaces / stacks / cells live                                                    |
+| `--containerd-namespace-suffix`   | `kukeon.io`                       | Suffix appended to every realm name to form its containerd namespace                                                 |
+| `--reconcile-interval`            | `30s`                             | Period of the cell-reconciliation loop (Go duration; `0` disables)                                                   |
+| `--log-level`                     | `info`                            | Log level: `debug`, `info`, `warn`, `error`                                                                          |
 
 `kukeond`'s `--run-path` matches `kuke`'s default — both binaries share the same `/opt/kukeon` tree. The socket and pid files live under `/run/kukeon` and are controlled by `--socket` independently.
 
@@ -23,7 +28,7 @@ kukeond serve [flags]
 kukeond serve
 ```
 
-Runs the daemon in the foreground. Listens on `--socket`, writes a pid file at `<run-path>/kukeond.pid`, and serves the `kukeonv1` API until it receives SIGINT or SIGTERM.
+Runs the daemon in the foreground. Listens on `--socket`, writes a pid file at `/run/kukeon/kukeond.pid`, and serves the `kukeonv1` API until it receives SIGINT or SIGTERM.
 
 On shutdown it closes the listener, removes the pid file, and drains in-flight requests on a best-effort basis.
 
@@ -38,4 +43,4 @@ This runs the daemon on the host directly. In the normal path, `kuke init` creat
 ## Signals
 
 - `SIGINT`, `SIGTERM` — clean shutdown.
-- `SIGKILL` — hard kill; leaves the socket and pid file behind. Clean up with `sudo rm -f /run/kukeon/kukeond.{sock,pid}` before restarting.
+- `SIGKILL` — hard kill; leaves the socket and pid file behind. Clean up with `sudo rm -f /run/kukeon/kukeond.{sock,pid}` before restarting (or use [`kuke daemon reset`](kuke-daemon.md)).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,13 +93,20 @@ nav:
       - cli/commands.md
       - cli/kuke.md
       - cli/kuke-init.md
+      - cli/kuke-doctor.md
       - cli/kuke-get.md
       - cli/kuke-create.md
       - cli/kuke-apply.md
+      - cli/kuke-run.md
       - cli/kuke-delete.md
       - cli/kuke-lifecycle.md
       - cli/kuke-purge.md
       - cli/kuke-refresh.md
+      - cli/kuke-log.md
+      - cli/kuke-attach.md
+      - cli/kuke-image.md
+      - cli/kuke-daemon.md
+      - cli/kuke-uninstall.md
       - cli/kuke-autocomplete.md
       - cli/kuke-version.md
       - cli/kukeond.md


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #444.
Mode: best-effort — the issue body identified files, sections, and a long list of drift items (`-a` on `run`, `--no-follow` on `log`, missing pages for `run`/`log`/`attach`/`doctor`/`daemon`/`uninstall`/`image`, stale `--config` flag, `main`/`kukeon-system` examples) but did not provide paste-ready Before/After wording, so each page was authored against the current `kuke <verb> --help` output to match the Proposal and Acceptance criteria.

## Files changed

Existing pages re-baselined against current `--help` output:

- `docs/site/cli/commands.md` — `--config` → `--configuration`, default path → `$HOME/.kuke/kuke.yaml`, added new verbs (`run`, `log`, `attach`, `image`, `daemon`, `uninstall`, `doctor`) to the subcommand table and "Full reference" list, kept the global flags + `--no-daemon` prerequisites prose verbatim.
- `docs/site/cli/kuke.md` — replaced the `--config` section with `--configuration`, refreshed the `--no-daemon` blurb to mention the still-supported in-process paths (`kuke init`, `kuke image load --no-daemon`).
- `docs/site/cli/kuke-init.md` — flag table now lists `--cgroup-root`, `--containerd-namespace-suffix`, `--server-configuration`; "What it does" walks through both default realms (`default`, `kuke-system`) and the `kukeond` cell coordinates; added a "two default realms" table matching `CLAUDE.md`; image-resolution note now references `kuke image load --from-docker` for the local-dev path; cross-links to `kuke doctor` and `kuke daemon`.
- `docs/site/cli/kuke-get.md` — added the `--show-controllers` column flag; updated all examples to the current realms (`default`, `kuke-system`) and the dev-init parity output shape from CLAUDE.md.
- `docs/site/cli/kuke-create.md` — `kuke create container` flag table refreshed against current `--help` (added `--tmpfs`, `--user`, `--read-only`, `--cap-add`, `--cap-drop`, `--security-opt`, `--cpu-shares`, `--memory`, `--pids-limit`); realm-namespace default note rewritten as `<realm>.kukeon.io`; examples retargeted to the `default` realm; cross-link to `kuke run` added.
- `docs/site/cli/kuke-apply.md` — dropped the stale "today, cell creation has to run with `--no-daemon`" caveat (no longer true — the daemon image bind-mounts containerd); retargeted multi-doc example to `realmId: default`.
- `docs/site/cli/kuke-delete.md` — refreshed examples to the current realms; cross-link to `kuke uninstall`.
- `docs/site/cli/kuke-lifecycle.md` — refreshed examples; removed the "use this for the daemon cell" line that hand-typed the static daemon coordinates in favor of pointing readers at `kuke daemon kill`.
- `docs/site/cli/kuke-purge.md` — added a "safe by design: purging the user realm" subsection matching the CLAUDE.md invariant; updated examples; cross-link to `kuke uninstall`.
- `docs/site/cli/kuke-refresh.md` — refreshed example output and the workflow example.
- `docs/site/cli/kuke-version.md` — bumped the example to `v0.5.0`.
- `docs/site/cli/kukeond.md` — flag table now matches current `kukeond --help`: added `--socket-gid`, `--reconcile-interval`, `--cgroup-root`, `--containerd-namespace-suffix`, `--configuration`; pid file path corrected to `/run/kukeon/kukeond.pid`; SIGKILL cleanup note now also points to `kuke daemon reset`.

New pages:

- `docs/site/cli/kuke-run.md` — current flag set including `--param`/`--param-file`, attach/detach precedence, `--rm` cleanup semantics, profile resolution order.
- `docs/site/cli/kuke-log.md` — current default (print-and-exit), `-f`/`--follow` documented; cross-link to `kuke daemon logs`.
- `docs/site/cli/kuke-attach.md` — cell-as-positional shape, realm/space/stack default to `default`, `^]^]` detach.
- `docs/site/cli/kuke-doctor.md` — `kuke doctor cgroups` subcommand surface including `--scope realm|space|stack|cell`, `--probe`/`--no-probe`, `--root`, `--nested-cgroup-runtime`, `--verbose-status`; mentions the `sudo` fail-fast on `--probe`.
- `docs/site/cli/kuke-daemon.md` — `start`/`stop`/`kill`/`restart`/`reset`/`logs` with their flags; documents the in-process execution model and the SIGTERM → SIGKILL escalation; cross-link to `kuke uninstall`.
- `docs/site/cli/kuke-uninstall.md` — interactive default + `--yes`/`-y`, the half-cleaned-host skip rule, comparison table against `kuke daemon reset` / `kuke purge`.
- `docs/site/cli/kuke-image.md` — `load`/`get`/`delete` (with aliases `ls`/`rm`), `--from-docker`, `--realm` defaulting to `default`, the `kuke-system` realm for the kukeond image; `kuke image load --no-daemon` root requirement.

`mkdocs.yml` — added the seven new pages to the CLI Reference nav.

Did **not** create `kuke-status.md` — issue AC qualifies on \"if #202 has landed\"; #202 is still OPEN.

## Editorial choices

- Stayed with the existing voice and structure of each page (concise, table-driven flag reference, `## Examples`, `## Related` block at the end) — preferred re-baselining each existing page in place over a wholesale rewrite. New pages follow the same template so the CLI Reference reads as one piece.
- Where a single help string was dense (e.g. `kuke run --rm`), split it into a flag-table one-liner plus a dedicated subsection explaining the triggers, rather than dumping the full help string into the table cell.
- Pulled the daemon-cell coordinates (`kuke-system / kukeon / kukeon / kukeond`) and the two-default-realms table from `CLAUDE.md` since several new pages need them and the existing docs already say so in passing.
- Removed the \"today, cell creation has to run with `--no-daemon`\" admonition from `kuke-apply.md` — the released `kukeond` image bind-mounts containerd via the daemon's bundled CNI/state setup, and the current Quick Start (rewritten in #458) does cells through the daemon. Keeping the admonition would have contradicted the v0.5.0 README.
- Added cross-links between every new and existing page so the CLI Reference forms a connected graph (e.g. `kuke run` ↔ `kuke attach` ↔ `kuke log`, `kuke daemon` ↔ `kuke uninstall` ↔ `kuke purge`).

## Acceptance criteria check

- [x] Every existing `cli/*.md` page matches current `kuke <verb> --help` output, including flag names, defaults, and examples — verified each page's flag table against fresh `--help` capture from a `make kuke` build of `main`.
- [x] Missing verbs covered: `run`, `log`, `attach`, `doctor`, `daemon`, `uninstall`, `image` — all seven new pages created and wired into `mkdocs.yml` and `commands.md`. `status` skipped because #202 is still open (per the AC's conditional).
- [x] `commands.md` index lists every current top-level verb — refreshed both the subcommand table and the \"Full reference\" links.
- [x] No references to `-a` on `run`, `--no-follow` on `log`, or other dropped flags — greps for `-a` (on run), `--no-follow`, `--config ` (the stale flag name), `/etc/kukeon/config.yaml`, and `kukeon-main`/`kukeon-system` all return clean.
- [x] Examples use current realm/namespace names — all examples now use `default` and `kuke-system`; realm-namespace defaults documented as `<realm>.kukeon.io`.

Closes #444