### PR TITLE
docs: re-baseline manifests/* with v0.4.0 fields and behavior (v0.5.0)

### DIFF
--- a/docs/site/manifests/cell.md
+++ b/docs/site/manifests/cell.md
@@ -60,11 +60,18 @@ This is opt-in because the default subset minimises the controller surface enabl
 
 ## status
 
-| Field        | Type                                               | Description                   |
-| ------------ | -------------------------------------------------- | ----------------------------- |
-| `state`      | `Pending`, `Ready`, `Stopped`, `Failed`, `Unknown` | Lifecycle state               |
-| `cgroupPath` | string                                             | Absolute cgroup path          |
-| `containers` | array of `ContainerStatus`                         | Per-container status snapshot |
+| Field                | Type                                               | Description                                                                                                                                          |
+| -------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `state`              | `Pending`, `Ready`, `Stopped`, `Failed`, `Unknown` | Lifecycle state                                                                                                                                      |
+| `cgroupPath`         | string                                             | Absolute cgroup path                                                                                                                                 |
+| `subtreeControllers` | array of string                                    | Cgroup-v2 controller set actually delegated on this cell's `cgroup.subtree_control` after the host-root filter. For a `nestedCgroupRuntime: true` cell this is the full host-available set; otherwise the kukeon resource subset (`cpu`, `memory`, `io`, `pids`). |
+| `containers`         | array of `ContainerStatus`                         | Per-container status snapshot                                                                                                                        |
+| `createdAt`          | RFC3339 timestamp                                  | Wall-clock time of the first persist for this cell. Set once and never moves.                                                                        |
+| `updatedAt`          | RFC3339 timestamp                                  | Wall-clock time of the most recent persist.                                                                                                          |
+| `readyAt`            | RFC3339 timestamp                                  | Wall-clock time of the first `State==Ready` persist. Set-once.                                                                                       |
+| `reason`             | string                                             | Short reason code summarizing why `state` is in its current value.                                                                                   |
+| `message`            | string                                             | Human-readable detail backing `reason`; especially valuable on `state: Failed`.                                                                      |
+| `cgroupReady`        | bool                                               | Whether `cgroupPath` actually exists on the host filesystem as of the last status write.                                                             |
 
 ## Minimal
 

--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -63,6 +63,7 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 | `networks`        | array of string            | no       | Additional CNI networks to join beyond the cell's default                                                             |
 | `networksAliases` | array of string            | no       | DNS aliases for the container within its CNI networks                                                                 |
 | `privileged`      | bool                       | no       | Run privileged (full capabilities, access to `/dev`, etc.)                                                            |
+| `hostCgroup`      | bool                       | no       | Opt the container into its parent's cgroup namespace (see [Host cgroup mode](#host-cgroup-mode))                      |
 | `secrets`         | array of `ContainerSecret` | no       | Inject credentials resolved by the daemon — never written to status or YAML (see [ContainerSecret](#containersecret)) |
 | `cniConfigPath`   | string                     | no       | Override the CNI config directory for this container                                                                  |
 | `restartPolicy`   | string                     | no       | Restart policy. Reserved — restart semantics are not finalized.                                                       |
@@ -72,13 +73,27 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 
 ### VolumeMount
 
-Each entry in `spec.volumes` is a bind mount of a host path into the container.
+Each entry in `spec.volumes` is a mount attached to the container. The `kind` discriminator selects which OCI mount type the runtime emits.
 
-| Field      | Type   | Required | Description                                                                              |
-| ---------- | ------ | -------- | ---------------------------------------------------------------------------------------- |
-| `source`   | string | yes      | Absolute host path. Must exist at apply time. Named / managed volumes are not supported. |
-| `target`   | string | yes      | Absolute path inside the container                                                       |
-| `readOnly` | bool   | no       | Mount read-only when `true` (writes fail with `EROFS`). Defaults to `false`.             |
+| Field       | Type            | Required           | Description                                                                                                                                                                          |
+| ----------- | --------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `kind`      | `bind`\|`tmpfs` | no                 | Mount type. Empty means `bind` for back-compat with YAML authored before the discriminator existed.                                                                                  |
+| `source`    | string          | yes for `bind`     | Absolute host path. Must exist at apply time. Named / managed volumes are not supported. Must be empty for `kind: tmpfs`.                                                            |
+| `target`    | string          | yes                | Absolute path inside the container                                                                                                                                                   |
+| `readOnly`  | bool            | no                 | Mount read-only when `true` (writes fail with `EROFS`). Defaults to `false`.                                                                                                         |
+| `sizeBytes` | int             | no (`tmpfs` only)  | Tmpfs size in bytes. When non-zero, the standard tmpfs `size=` option is set. Ignored for `bind`.                                                                                    |
+| `mode`      | uint            | no (`tmpfs` only)  | Tmpfs root-directory mode (e.g. `0755`). When non-zero, the standard tmpfs `mode=` option is set. Ignored for `bind`.                                                                |
+
+```yaml
+volumes:
+  - source: /srv/html
+    target: /usr/share/nginx/html
+    readOnly: true
+  - kind: tmpfs
+    target: /tmp
+    sizeBytes: 268435456 # 256 MiB
+    mode: 0755
+```
 
 ### ContainerSecret
 
@@ -105,6 +120,37 @@ secrets:
 ```
 
 File-mount mode stages secrets under `/run/kukeon/secrets/<containerdId>/<name>` on the host, with owner-only read perms, then bind-mounts them read-only into the container. Because containerd persists resolved env vars in its own runtime spec, env-injection mode leaves the value in containerd's state; file-mount mode keeps it only in the tmpfs staging file.
+
+### Managed `/etc/hosts` and `/etc/hostname`
+
+Every container in a cell sees a managed `/etc/hostname` and (unless its cell's root container runs with `hostNetwork: true`) a managed `/etc/hosts`, bind-mounted in by kukeond.
+
+- `/etc/hostname` contains the **cell's** name plus a trailing newline. All containers in the same cell agree on the hostname.
+- `/etc/hosts` carries the standard localhost block plus a `<cellIP>\t<cellName>` line once CNI ADD has assigned the cell's address. The cell IP line is filled in once the cell is reachable; before that, only the localhost block is present.
+
+Host-network cells (cells whose root container is declared with `hostNetwork: true` — the kukeond carve-out) inherit the host's `/etc/hosts` directly; kukeond does not overlay one.
+
+### `KUKEON_*` identity environment variables
+
+Kukeon exports the container's location in the realm/space/stack/cell hierarchy as environment variables visible to the process at startup:
+
+| Variable                  | Value                                                              |
+| ------------------------- | ------------------------------------------------------------------ |
+| `KUKEON_REALM`            | The container's realm name                                         |
+| `KUKEON_SPACE`            | The container's space name                                         |
+| `KUKEON_STACK`            | The container's stack name                                         |
+| `KUKEON_CELL_NAME`        | The container's cell name                                          |
+| `KUKEON_CONTAINER_ID`     | The container's `spec.id`                                          |
+| `KUKEON_CGROUP_PATH`      | Absolute cgroup path of the cell                                   |
+| `KUKEON_CELL_PROFILE_NAME` | Name of the cell profile that materialized the cell, when applicable |
+
+These pairs are appended to the container's effective environment so user-declared `spec.env` entries still take precedence on collision.
+
+### Host cgroup mode
+
+`spec.hostCgroup: true` opts the container into its parent's cgroup namespace — the runtime omits the cgroup `LinuxNamespace` from the OCI spec, and the container sees the host cgroup tree directly instead of seeing its own cgroup as `/`.
+
+Set this only for cells that hosts a nested runtime (containerd, runc, dockerd, an inner `kuke init`) that needs to write cgroups *outside* its own subtree. For ordinary workload containers, leave it `false` (the default). The canonical use case is the kukeond cell in dev-init phase 2.
 
 ## status
 

--- a/docs/site/manifests/overview.md
+++ b/docs/site/manifests/overview.md
@@ -19,6 +19,16 @@ status:
 
 Only `v1beta1` is currently defined. See [Architecture → API versioning](../architecture/api-versioning.md) for how Kukeon decouples the on-wire schema from internal types, which lets new versions coexist when they ship.
 
+## What's new in v0.5.0
+
+The v1beta1 schema picked up several additions since v0.3.0. The biggest ones, by kind:
+
+- **All four levels (realm / space / stack / cell)** now report `status.subtreeControllers` — the cgroup-v2 controller set actually delegated on the resource's own `cgroup.subtree_control` — and a uniform set of lifecycle fields (`createdAt`, `updatedAt`, `readyAt`, `reason`, `message`, `cgroupReady`). See each kind's `status` table.
+- **[Cell](cell.md)** — `spec.nestedCgroupRuntime` opts a cell into full controller delegation for nested runtimes (e.g. an inner kukeond). `spec.rootContainerId` selection rules are spelled out.
+- **[Container](container.md)** — `spec.hostCgroup` opts the container into its parent's cgroup namespace (kukeond-style host-cgroup mode). `spec.volumes[].kind` now discriminates `bind` vs `tmpfs`, with `sizeBytes` and `mode` knobs. Each container in a cell sees a managed `/etc/hosts` / `/etc/hostname` plus `KUKEON_*` identity environment variables.
+
+If you're moving from v0.3.0 or v0.4.0, the per-kind pages below are the source of truth.
+
 ## Kinds
 
 - [Realm](realm.md) — tenant boundary

--- a/docs/site/manifests/realm.md
+++ b/docs/site/manifests/realm.md
@@ -45,10 +45,18 @@ spec:
 
 ## status
 
-| Field        | Type                                                            | Description                             |
-| ------------ | --------------------------------------------------------------- | --------------------------------------- |
-| `state`      | `Pending`, `Creating`, `Ready`, `Deleting`, `Failed`, `Unknown` | Lifecycle state                         |
-| `cgroupPath` | string                                                          | Absolute cgroup path: `/kukeon/<realm>` |
+| Field                      | Type                                                            | Description                                                                                                                                       |
+| -------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `state`                    | `Pending`, `Creating`, `Ready`, `Deleting`, `Failed`, `Unknown` | Lifecycle state                                                                                                                                   |
+| `cgroupPath`               | string                                                          | Absolute cgroup path: `/kukeon/<realm>`                                                                                                           |
+| `subtreeControllers`       | array of string                                                 | Cgroup-v2 controller set actually delegated on this realm's `cgroup.subtree_control` after the host-root filter (e.g. `cpu`, `memory`, `io`, `pids`) |
+| `createdAt`                | RFC3339 timestamp                                               | Wall-clock time of the first persist for this realm. Set once and never moves.                                                                    |
+| `updatedAt`                | RFC3339 timestamp                                               | Wall-clock time of the most recent persist.                                                                                                       |
+| `readyAt`                  | RFC3339 timestamp                                               | Wall-clock time of the first `State==Ready` persist. Set-once: never overwritten on subsequent Ready transitions or flaps.                        |
+| `reason`                   | string                                                          | Short reason code summarizing why `state` is in its current value. Empty when none has been recorded.                                             |
+| `message`                  | string                                                          | Human-readable detail backing `reason`; especially valuable on `state: Failed`.                                                                   |
+| `cgroupReady`              | bool                                                            | Whether `cgroupPath` actually exists on the host filesystem as of the last status write — separates intent from observation.                      |
+| `containerdNamespaceReady` | bool                                                            | Whether the containerd namespace recorded in `spec.namespace` was actually present as of the last status write.                                   |
 
 `status` is populated by Kukeon; anything you set when applying is overwritten on reconcile.
 

--- a/docs/site/manifests/space.md
+++ b/docs/site/manifests/space.md
@@ -100,10 +100,17 @@ Supported fields (each mirrors `ContainerSpec`): `user`, `readOnlyRootFilesystem
 
 ## status
 
-| Field        | Type                                    | Description                                     |
-| ------------ | --------------------------------------- | ----------------------------------------------- |
-| `state`      | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                                 |
-| `cgroupPath` | string                                  | Absolute cgroup path: `/kukeon/<realm>/<space>` |
+| Field                | Type                                    | Description                                                                                                                                          |
+| -------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `state`              | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                                                                                                                                      |
+| `cgroupPath`         | string                                  | Absolute cgroup path: `/kukeon/<realm>/<space>`                                                                                                      |
+| `subtreeControllers` | array of string                         | Cgroup-v2 controller set actually delegated on this space's `cgroup.subtree_control` after the host-root filter (e.g. `cpu`, `memory`, `io`, `pids`) |
+| `createdAt`          | RFC3339 timestamp                       | Wall-clock time of the first persist. Set once and never moves.                                                                                      |
+| `updatedAt`          | RFC3339 timestamp                       | Wall-clock time of the most recent persist.                                                                                                          |
+| `readyAt`            | RFC3339 timestamp                       | Wall-clock time of the first `State==Ready` persist. Set-once.                                                                                       |
+| `reason`             | string                                  | Short reason code summarizing why `state` is in its current value.                                                                                   |
+| `message`            | string                                  | Human-readable detail backing `reason`; especially valuable on `state: Failed`.                                                                      |
+| `cgroupReady`        | bool                                    | Whether `cgroupPath` actually exists on the host filesystem as of the last status write.                                                             |
 
 ## Bridge naming
 

--- a/docs/site/manifests/stack.md
+++ b/docs/site/manifests/stack.md
@@ -30,10 +30,17 @@ Today the stack schema requires both `metadata.name` and `spec.id`, and they sho
 
 ## status
 
-| Field        | Type                                    | Description                                             |
-| ------------ | --------------------------------------- | ------------------------------------------------------- |
-| `state`      | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                                         |
-| `cgroupPath` | string                                  | Absolute cgroup path: `/kukeon/<realm>/<space>/<stack>` |
+| Field                | Type                                    | Description                                                                                                                                          |
+| -------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `state`              | `Pending`, `Ready`, `Failed`, `Unknown` | Lifecycle state                                                                                                                                      |
+| `cgroupPath`         | string                                  | Absolute cgroup path: `/kukeon/<realm>/<space>/<stack>`                                                                                              |
+| `subtreeControllers` | array of string                         | Cgroup-v2 controller set actually delegated on this stack's `cgroup.subtree_control` after the host-root filter (e.g. `cpu`, `memory`, `io`, `pids`) |
+| `createdAt`          | RFC3339 timestamp                       | Wall-clock time of the first persist. Set once and never moves.                                                                                      |
+| `updatedAt`          | RFC3339 timestamp                       | Wall-clock time of the most recent persist.                                                                                                          |
+| `readyAt`            | RFC3339 timestamp                       | Wall-clock time of the first `State==Ready` persist. Set-once.                                                                                       |
+| `reason`             | string                                  | Short reason code summarizing why `state` is in its current value.                                                                                   |
+| `message`            | string                                  | Human-readable detail backing `reason`; especially valuable on `state: Failed`.                                                                      |
+| `cgroupReady`        | bool                                    | Whether `cgroupPath` actually exists on the host filesystem as of the last status write.                                                             |
 
 ## Minimal
 


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #445.
Mode: best-effort — the issue body identified files and sections but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria.

## Files changed
- `docs/site/manifests/overview.md` — `## Supported versions` (new `## What's new in v0.5.0` section after it)
- `docs/site/manifests/realm.md` — `## status` table
- `docs/site/manifests/space.md` — `## status` table
- `docs/site/manifests/stack.md` — `## status` table
- `docs/site/manifests/cell.md` — `## status` table
- `docs/site/manifests/container.md` — `spec` table (added `hostCgroup` row), `### VolumeMount` (added `kind`/`sizeBytes`/`mode`), new `### Managed /etc/hosts and /etc/hostname`, `### KUKEON_* identity environment variables`, and `### Host cgroup mode` sections inserted before `## status`

## Editorial choices
- All four kinds' status tables get the same uniform `subtreeControllers` + `createdAt`/`updatedAt`/`readyAt` + `reason`/`message`/`cgroupReady` rows, in the same column order, matching the shape of the per-field contract documented on `RealmStatus`. Cell's `subtreeControllers` description additionally notes the `nestedCgroupRuntime` branch since that's the only kind where the controller set varies.
- Realm gets the extra `containerdNamespaceReady` row that only `RealmStatus` carries.
- Container `VolumeMount` table was rewritten in place (rather than appended) since the `kind` discriminator changes whether `source` is required; new fields tag `tmpfs only` in the Required column. A short combined `bind` + `tmpfs` YAML example replaces the prose-only description.
- `KUKEON_*` env vars listed in a small table sourced from `kukeonDefaultEnv` in `internal/ctr/spec.go`. Noted the precedence rule (user `spec.env` wins on collision) so readers don't expect a hard override.
- `/etc/hosts` / `/etc/hostname` written as a sibling subsection under `## spec` so it lives next to the container-shape doc; called out the `hostNetwork` carve-out since that's the only path where `/etc/hosts` is not overlaid.
- `hostCgroup` was added as a row in the existing spec table plus a short narrative subsection. Kept the field's "use only for nested runtimes" guidance because the schema's docstring is emphatic on that point.
- Skipped fields outside the AC's scope (`workingDir`, `hostNetwork`, `hostPID`, `attachable`/`tty`, container-level isolation defaults like `user`/`capabilities`/`tmpfs`/`resources`, `cellSpec.autoDelete`/`tty`, `cellStatus.network.bridgeName`/`readyObserved`). These remain undocumented, matching the minimal-change rule.

## Acceptance criteria check
- [x] `cell.md` documents `NestedCgroupRuntime` and `CellSpec.RootContainerID` derivation — already present in the existing file (`### The root container`, `### Nested cgroup runtimes`); diff leaves them intact.
- [x] `container.md` documents `HostCgroup`, `VolumeMount.Kind=tmpfs` (with `sizeBytes`/`mode`), managed `/etc/hosts` / `/etc/hostname`, `KUKEON_*` identity env vars, `Secret{fromFile,fromEnv,mountPath}` — verified `ContainerSecret` already matches v1beta1 (`name`/`fromFile`/`fromEnv`/`mountPath`); other items added.
- [x] All four levels show `Status.SubtreeControllers` and lifecycle timestamps.
- [x] `overview.md` includes a "What's new in v0.5.0" section pointing to the changed kinds.
- [x] No documented fields that don't exist in the current schema — every added row was grounded against `pkg/api/model/v1beta1/*.go`.

Closes #445