### PR TITLE
docs: re-baseline guides/* against current behavior (v0.5.0)

### DIFF
--- a/docs/site/guides/apply-manifests.md
+++ b/docs/site/guides/apply-manifests.md
@@ -109,8 +109,57 @@ sudo kuke apply -f cell.yaml --no-daemon
 
 See [Client and daemon](../concepts/client-and-daemon.md) for the broader story.
 
+## Parameterized cell profiles
+
+`kuke apply -f` consumes a **fixed** manifest — the file you ship is the spec the daemon reconciles to, with no substitution layer in between. When you need the same cell shape with different values per invocation (image tag, command, mount paths), reach for a **cell profile** loaded with `kuke run -p` instead of editing the YAML each time.
+
+A profile lives under `$HOME/.kuke/profiles.d/<name>.yaml` (or `$KUKE_PROFILES_DIR`) and declares its variable inputs alongside the cell spec:
+
+```yaml
+apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: shell
+spec:
+  parameters:
+    - name: IMAGE
+      description: container image to run
+      default: alpine:latest
+    - name: CMD
+      description: command to exec
+      required: true
+  containers:
+    - id: shell
+      image: ${IMAGE}
+      command: ["/bin/sh", "-c", "${CMD}"]
+```
+
+`kuke run -p` materializes one cell with a unique name (`<metadata.name>-<6hex>` by default; override with `--name`) and resolves each `${KEY}` reference in the body. Resolution order, highest first:
+
+1. `--param KEY=VALUE` on the CLI (repeatable)
+2. Values from `--param-file <path>` (one `KEY=VALUE` per line, `#` starts a comment)
+3. The parameter's `default` in the profile
+4. The `kuke` process env (`os.LookupEnv`)
+5. Required + unset → error; non-required + unset → empty string
+
+```bash
+# Use defaults / env / required errors
+kuke run -p shell --param CMD="echo hi"
+
+# Override the image too
+kuke run -p shell --param IMAGE=alpine:edge --param CMD="/bin/sh"
+
+# Load a batch of values from a file, with a CLI override on top
+kuke run -p shell --param-file ./shell.env --param IMAGE=alpine:edge
+```
+
+`--param`, `--param-file`, and `--name` are rejected when combined with `-f` (file mode is not a profile and has no parameter declarations). The substituted body is what reaches the daemon — there is no parameter layer in the manifest API itself.
+
+See [kuke run](../cli/kuke-run.md) for the full flag surface.
+
 ## See also
 
 - [Manifest Reference](../manifests/overview.md) — the full schema of every resource
-- [CLI Reference → apply](../cli/kuke-apply.md) — every flag
+- [CLI Reference → apply](../cli/kuke-apply.md) — every flag on `kuke apply`
+- [CLI Reference → run](../cli/kuke-run.md) — `-f` (file) and `-p` (profile) modes, including parameter handling
 - [Tutorials → Hello-world cell](../tutorials/hello-world.md) — a worked example end-to-end

--- a/docs/site/guides/autocomplete.md
+++ b/docs/site/guides/autocomplete.md
@@ -2,6 +2,8 @@
 
 `kuke` supports shell completion for bash, zsh, and fish. The completion script is generated on the fly by the binary.
 
+All three shells use cobra's V2 dispatcher model: the generated script is small (a few hundred lines) and routes every tab through `kuke __complete` rather than inlining static flag arrays. That avoids the stale-script shadowing footgun where an old `/etc/bash_completion.d/kuke` keeps loading prior-version flag tables after a re-install, and it means a fresh `make kuke` is picked up the next tab without re-sourcing — the dispatcher always calls the live binary.
+
 ## bash
 
 ```bash
@@ -41,11 +43,12 @@ kuke autocomplete fish > ~/.config/fish/completions/kuke.fish
 
 ## What's completed
 
-- **Subcommand names** — `kuke <TAB>` completes to `init`, `get`, `create`, `apply`, `delete`, `start`, `stop`, `kill`, `purge`, `refresh`, `autocomplete`, `version`.
+- **Subcommand names** — `kuke <TAB>` completes against the current command set (`init`, `get`, `create`, `apply`, `run`, `delete`, `start`, `stop`, `kill`, `purge`, `refresh`, `attach`, `log`, `image`, `daemon`, `doctor`, `uninstall`, `autocomplete`, `version`, …). The dispatcher pulls this from the live binary, so a freshly added subcommand shows up the next tab.
 - **Resource names** — `kuke get realm <TAB>`, `kuke delete space <TAB>`, etc. pull live names from the running daemon.
 - **`--realm`, `--space`, `--stack`, `--cell` flags** — complete against the set of resources that match the other flags you've already typed.
+- **Profile names for `kuke run -p`** — `kuke run -p <TAB>` lists `.yaml` files under `$HOME/.kuke/profiles.d` (or `$KUKE_PROFILES_DIR`). Adding or removing a profile reflects on the next tab without re-sourcing.
 
-Completion functions reach out to the daemon to list live resources, so autocomplete on a host where `kukeond` isn't running will return no suggestions (silently). That's expected.
+Completion functions that need realm / space / stack / cell data reach out to the daemon, so autocomplete on a host where `kukeond` isn't running will return no suggestions (silently) for those flags. That's expected. Static completions (subcommands, profile filenames) keep working without the daemon.
 
 ## One exception
 

--- a/docs/site/guides/init-and-reset.md
+++ b/docs/site/guides/init-and-reset.md
@@ -2,6 +2,15 @@
 
 This guide covers the operations you'll run most often when bootstrapping, iterating on, or wiping a Kukeon host.
 
+`kuke init` provisions **two** realms, each mapped to its own containerd namespace:
+
+| Realm         | Containerd namespace    | Purpose                                                                          |
+| ------------- | ----------------------- | -------------------------------------------------------------------------------- |
+| `default`     | `default.kukeon.io`     | User workloads. Created empty so `kuke create …` has a home.                     |
+| `kuke-system` | `kuke-system.kukeon.io` | System workloads owned by kukeon itself (the `kukeond` daemon runs as a cell here). |
+
+The daemon lives at `kuke-system / kukeon / kukeon / kukeond` (realm / space / stack / cell). The `default` realm is deliberately left user-owned so `kuke purge --cascade` on it can never take down the daemon.
+
 ## Fresh bootstrap
 
 On a host that has never run Kukeon:
@@ -14,10 +23,11 @@ That command:
 
 1. Creates the kukeon cgroup root at `/sys/fs/cgroup/kukeon`.
 2. Ensures `/etc/cni/net.d` and `/opt/cni/bin` exist.
-3. Creates the default user realm (`default`, containerd namespace `kukeon-default`) and its default space and stack.
-4. Creates the system realm (`kukeon-system`) and the `kukeond` cell.
-5. Pulls the `kukeond` image.
-6. Starts the daemon; waits up to 30s for the socket to come up (unless you pass `--no-wait`).
+3. Creates the `kukeon` system user/group so the socket can be group-readable.
+4. Creates the `default` user realm (containerd namespace `default.kukeon.io`) and its default space and stack.
+5. Creates the `kuke-system` system realm (containerd namespace `kuke-system.kukeon.io`) and the `kukeond` cell underneath it.
+6. Pulls the `kukeond` image.
+7. Starts the daemon; waits up to 30s for the socket at `/run/kukeon/kukeond.sock` to come up (unless you pass `--no-wait`).
 
 ## Re-init (reconcile)
 
@@ -41,28 +51,27 @@ This rewrites every space's conflist, even the ones that already exist. It does 
 
 ## Tear down the daemon for iteration
 
-When you're hacking on `kukeond` and need to rebuild it, you want to stop the daemon without losing user data:
+When you're hacking on `kukeond` and need to rebuild it, `kuke daemon reset` is the right verb:
 
 ```bash
-sudo kuke kill cell kukeond   --realm kukeon-system --space kukeon --stack kukeon --no-daemon
-sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
-sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+sudo kuke daemon reset                  # preserves /opt/kukeon/default and /opt/kukeon/kuke-system
+sudo kuke daemon reset --purge-system   # additionally wipes /opt/kukeon/kuke-system
 ```
 
-Why `--no-daemon`: the daemon is what's being stopped, so `kuke` has to talk to containerd directly.
+`daemon reset` stops the `kukeond` cell (SIGTERM, escalating to SIGKILL after `--timeout`, default 10s), deletes the cell metadata + cgroups, and clears `/run/kukeon/kukeond.{sock,pid}`. It's idempotent — re-running on a host with no daemon succeeds.
 
-User data under `/opt/kukeon/<realm>/...` (everything outside `kukeon-system`) is untouched.
+`--purge-system` additionally removes `/opt/kukeon/kuke-system` for a fully clean re-bootstrap. Either way, user-realm data under `/opt/kukeon/default/**` is **never** touched — that's the invariant that lets `daemon reset` be safe in a dev loop.
 
 Rebuild and re-init:
 
 ```bash
 make kuke
 docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
-docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
+sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
 sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
 ```
 
-See [Local development](local-dev.md) for the full dev loop.
+`--no-daemon` on `kuke image load` is required here because the daemon is not yet running — the in-process controller talks to containerd directly. See [Local development](local-dev.md) for the full dev loop, which is wrapped end-to-end as `make dev-init`.
 
 ## Wipe a realm
 
@@ -82,31 +91,47 @@ See [Manifest Reference](../manifests/overview.md) and [CLI Reference → delete
 
 ## Full host wipe
 
-Nuclear option: remove every trace of Kukeon from the host. Use this only if you're reinstalling from scratch.
+The "wipe every kukeon-owned thing on this host" verb is `kuke uninstall`:
 
 ```bash
-# 1. Stop the daemon (if running)
-sudo kuke kill cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon || true
-sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon || true
-sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+sudo kuke uninstall          # interactive: prompts for "yes"
+sudo kuke uninstall -y       # non-interactive (scripts)
+```
+
+What it does, in order: stop the daemon, purge every realm with `--cascade` (including `kuke-system`), release kukeon-owned bind mounts under `/run/kukeon`, remove `/run/kukeon` and the configured run path (default `/opt/kukeon`), and remove the `kukeon` system user/group if present.
+
+**Half-cleaned-host gate.** If any realm fails to drop its containerd namespace, the subsequent dir / account removal is **skipped** (not silently best-effort), every skipped row in the report is annotated, and the exit code is non-zero. Tearing out `/opt/kukeon` while a residual namespace is still pinning overlay mounts on disk would strand the next `kuke init` with stale containerd state — the skip is the safe default. Resolve the realm-purge failure (see [Troubleshooting](troubleshooting.md#kuke-uninstall-reports-skipped-realm-purge-failed)) and re-run.
+
+The binary at `/usr/local/bin/kuke` and the `kukeond` symlink are **never** removed — uninstalling runtime state is not the same as uninstalling the binary. Drop the binaries with `make uninstall-dev` (dev installs) or your package manager.
+
+If `kuke uninstall` itself is broken, the equivalent manual sequence is:
+
+```bash
+# 1. Stop the daemon
+sudo kuke daemon reset --purge-system
 
 # 2. Purge every user realm
-for realm in $(sudo kuke get realms -o json --no-daemon | jq -r '.[] | select(.metadata.name != "kukeon-system") | .metadata.name'); do
+for realm in $(sudo kuke get realms -o json --no-daemon | jq -r '.[] | select(.metadata.name != "kuke-system") | .metadata.name'); do
     sudo kuke purge realm "$realm" --cascade --force --no-daemon
 done
 
 # 3. Purge the system realm
-sudo kuke purge realm kukeon-system --cascade --force --no-daemon
+sudo kuke purge realm kuke-system --cascade --force --no-daemon
 
-# 4. Wipe on-disk state and cgroups
-sudo rm -rf /opt/kukeon
+# 4. Release any leftover bind mounts under /run/kukeon
+mount | awk '$3 ~ "^/run/kukeon" {print $3}' | xargs -r sudo umount -l
+
+# 5. Wipe on-disk state and cgroups
+sudo rm -rf /opt/kukeon /run/kukeon
 sudo rm -rf /sys/fs/cgroup/kukeon 2>/dev/null || true
 
-# 5. Wipe generated CNI conflists (careful: skip if you run other CNI apps)
+# 6. Wipe generated CNI conflists (skip if you run other CNI apps on this host)
 sudo rm -f /etc/cni/net.d/*.conflist
 ```
 
 ## Related
 
-- [Local development](local-dev.md) — the full rebuild / reload / re-init loop
-- [Troubleshooting](troubleshooting.md) — what to do when init fails
+- [Local development](local-dev.md) — the full rebuild / reload / re-init loop (wrapped as `make dev-init`)
+- [Troubleshooting](troubleshooting.md) — what to do when init or uninstall fails
+- [kuke daemon](../cli/kuke-daemon.md) — every `daemon` subcommand and flag
+- [kuke uninstall](../cli/kuke-uninstall.md) — flag and invariant reference

--- a/docs/site/guides/local-dev.md
+++ b/docs/site/guides/local-dev.md
@@ -2,73 +2,107 @@
 
 The full rebuild / reload / re-init loop for iterating on `kuke` and `kukeond` from source.
 
-## The loop in one shell
+## Prerequisites
 
-After the first bootstrap, each iteration looks like this:
+`make dev-init` drives two host daemons. Bring both up before you start:
 
-```bash
-# 1. Stop and delete the current kukeond cell (user data is preserved)
-sudo kuke kill cell kukeond   --realm kukeon-system --space kukeon --stack kukeon --no-daemon
-sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
-sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
+- **Docker daemon** — builds the local `kukeon-local:dev` image. Start with `service docker start` (or `systemctl start docker`).
+- **Standalone containerd** at `/run/containerd/containerd.sock` — used by `kuke image load --from-docker` and `kuke init`. This is _not_ the docker-private containerd at `/var/run/docker/containerd/containerd.toml`; `pgrep containerd` may show that one even when the system socket is missing. If `ls /run/containerd/containerd.sock` returns no such file, start it with `service containerd start` (or `systemctl start containerd`). On a host with no init script and no systemd, run the binary directly: `containerd > /tmp/containerd.log 2>&1 &`.
 
-# 2. Rebuild the binary
-make kuke
-ln -sf kuke kukeond
+If either daemon is missing, the failure surfaces several phases into `make dev-init` as a confusing error — `dial unix /var/run/docker.sock: connect: no such file or directory` for docker, or `failed to connect to containerd: ... dial unix:///run/containerd/containerd.sock: timeout` for containerd. Bring both up first to skip the rabbit hole.
 
-# 3. Rebuild the image and load it into the system namespace
-docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
-docker save kukeon-local:dev | \
-    sudo ctr -n kuke-system.kukeon.io images import -
+## The canonical loop: `make dev-init`
 
-# 4. Re-init pointing at the local image
-sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
-```
-
-Everything in `/opt/kukeon/<user-realm>/...` is untouched; only the system cell is replaced.
-
-## First-time bootstrap
-
-On a host with no prior Kukeon state, the containerd namespace `kuke-system.kukeon.io` doesn't exist yet, which means `ctr images import` into it will silently no-op. You have two choices:
-
-**Option A — let `kuke init` create the namespace, then re-init against the local image:**
+After the first bootstrap, each iteration is one command:
 
 ```bash
-# Will fail to pull the default ghcr.io image without network access —
-# that's fine, we only care about the namespace being created.
-sudo ./kuke init || true
-
-# Now the namespace exists; import and re-init.
-docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
-docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
-sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+make dev-init
 ```
 
-**Option B — create the namespace by hand first:**
+`scripts/dev-init.sh` composes the full re-bootstrap: `make kuke` (and the `kukeond` symlink), `make install-dev` (host symlinks under `$(INSTALL_PREFIX)`, default `/usr/local/bin`), the cgroup pre-flight, `docker build` of `kukeon-local:dev`, `kuke daemon reset` of the prior cell, `kuke image load --from-docker` of the freshly built image into the `kuke-system` realm, `kuke init --kukeond-image docker.io/library/kukeon-local:dev`, and a daemon-parity check at the end. It's idempotent — re-running on a healthy host produces a clean re-bootstrap.
 
-```bash
-sudo ctr namespaces create kuke-system.kukeon.io
-docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
-docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
-sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+The parity tail must read:
+
 ```
+NAME         NAMESPACE              STATE  CGROUP
+-----------  ---------------------  -----  -------------------
+default      default.kukeon.io      Ready  /kukeon/default
+kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+```
+
+If only `kuke get realms --no-daemon` returns that table but `kuke get realms` (daemon-routed) does not, the daemon's view of `/opt/kukeon` diverged from the in-process controller — usually a missing bind-mount in the `kukeond` cell spec. See [Troubleshooting → `kuke get` and `kuke get --no-daemon` disagree](troubleshooting.md#kuke-get-and-kuke-get---no-daemon-disagree).
+
+User data under `/opt/kukeon/default/**` is untouched across iterations; only the system cell is replaced.
 
 ## Make targets
 
-| Target      | What it does                                                   |
-| ----------- | -------------------------------------------------------------- |
-| `make kuke` | Build the `kuke` binary (same binary is used as `kukeond`)     |
-| `make test` | Run the Go unit test suite                                     |
-| `make e2e`  | Run end-to-end tests against a real containerd (requires root) |
-| `make lint` | Run `golangci-lint` with the repo's config                     |
+| Target              | What it does                                                                                                                  |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `make kuke`         | Build the `kuke` binary (same binary is dispatched as `kukeond` via `argv[0]`)                                                |
+| `make install-dev`  | Symlink the in-tree `kuke` and `kukeond` binaries into `$(INSTALL_PREFIX)` (default `/usr/local/bin`). Idempotent (`ln -sf`). |
+| `make uninstall-dev`| Remove both symlinks from `$(INSTALL_PREFIX)`.                                                                                |
+| `make dev-init`     | The full canonical loop above. Auto-invokes `install-dev` so `sudo kuke …` works from any directory.                          |
+| `make test`         | Run the Go unit test suite                                                                                                    |
+| `make e2e`          | Run end-to-end tests against a real containerd (requires root)                                                                |
+| `make lint`         | Run `golangci-lint` with the repo's config                                                                                    |
+
+Override `INSTALL_PREFIX` for non-standard PATH layouts: `make install-dev INSTALL_PREFIX=$HOME/.local/bin`.
+
+Because `install-dev` lays down **symlinks** (not copies), the next `make kuke` is picked up automatically — `sudo kuke …` always runs the freshly built binary. The daemon, however, ships from the `kuke-system / kukeon / kukeon / kukeond` cell, so daemon-side changes still need a full `make dev-init` to rebuild the image and reload the cell.
+
+## Manual phases (fallback)
+
+To run individual phases by hand — typically while debugging a single phase:
+
+1. **Tear down the existing daemon cell.**
+
+   ```bash
+   sudo kuke daemon reset                  # preserves /opt/kukeon/default and /opt/kukeon/kuke-system
+   sudo kuke daemon reset --purge-system   # additionally wipes /opt/kukeon/kuke-system
+   ```
+
+   User-realm data under `/opt/kukeon/default` is preserved either way, so `kuke purge --cascade` on `default` can never take down the daemon.
+
+2. **Build the binaries.**
+
+   ```bash
+   make kuke
+   ln -sf kuke kukeond   # kukeond is argv[0]-dispatched from the same binary
+   ```
+
+3. **Build and load the local `kukeond` image.**
+
+   ```bash
+   docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
+   sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
+   sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
+   ```
+
+   `--no-daemon` is required because the daemon is not yet running.
+
+4. **Run `kuke init`.**
+
+   ```bash
+   sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+   ```
+
+   Expected tail:
+
+   ```
+       - cell "kukeond": created (image docker.io/library/kukeon-local:dev)
+       - cell cgroup: created
+       - cell root container: created
+       - cell containers: started
+   kukeond is ready (unix:///run/kukeon/kukeond.sock)
+   ```
 
 ## Running without the daemon
 
-When iterating on controller code you often don't need to put the daemon back up at all. `--no-daemon` runs every `kuke` command in-process against your freshly built binary:
+When iterating on controller code you often don't need the daemon up at all. `--no-daemon` runs every `kuke` command in-process against your freshly built binary:
 
 ```bash
-sudo ./kuke get realms --no-daemon
-sudo ./kuke apply -f my-cell.yaml --no-daemon
+sudo kuke get realms --no-daemon
+sudo kuke apply -f my-cell.yaml --no-daemon
 ```
 
 This is the fastest feedback loop — no image build, no reload, just `make kuke` and go.
@@ -87,14 +121,14 @@ KUKEON_DEBUG_MODE=kukeond dlv exec ./__debug_bin -- serve
 A useful regression check after touching the controller:
 
 ```bash
-# Should be byte-identical
 diff <(sudo kuke get realms -o yaml) \
      <(sudo kuke get realms -o yaml --no-daemon)
 ```
 
-If they diverge, something is wrong with either the `kukeonv1` API surface or the daemon's bind-mount of the run path. See [Troubleshooting](troubleshooting.md).
+The two should be byte-identical. If they diverge, something is wrong with either the `kukeonv1` API surface or the daemon's bind-mount of the run path. See [Troubleshooting](troubleshooting.md).
 
 ## Related
 
 - [Build from source](../install/build-from-source.md) — initial build + image instructions
-- [Init and reset](init-and-reset.md) — teardown variants
+- [Init and reset](init-and-reset.md) — teardown variants and the daemon-reset / uninstall split
+- [Troubleshooting](troubleshooting.md) — common failures during bootstrap and daily use

--- a/docs/site/guides/troubleshooting.md
+++ b/docs/site/guides/troubleshooting.md
@@ -2,6 +2,56 @@
 
 Common failure modes when bootstrapping or operating a Kukeon host, and what to do about them.
 
+## `kuke …` exits with "permission denied" on the kukeond socket
+
+**Symptom.** A non-root invocation of any daemon-routed `kuke` command fails with:
+
+```
+dial kukeond at /run/kukeon/kukeond.sock: permission denied — add yourself to the kukeon group (sudo usermod -aG kukeon $USER), then log out and back in: ...
+```
+
+**What it means.** `kuke init` creates the socket at `/run/kukeon/kukeond.sock` with mode `0660 root:kukeon`, so only members of the `kukeon` system group can dial it without `sudo`. The hint in the error is the fix.
+
+**Fix.**
+
+```bash
+sudo usermod -aG kukeon $USER
+# Log out and back in so the new group membership is picked up.
+```
+
+After logging back in, `id -nG | grep kukeon` should show the group. Daemon-routed commands now work without `sudo`. Commands that mutate the host (`kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`) still require root regardless.
+
+## `kuke doctor cgroups` exits non-zero
+
+**Symptom.** The pre-flight reports a controller is missing or fails the `+<ctrl>` write probe:
+
+```
+$ sudo kuke doctor cgroups
+host cgroup pre-flight: 1 controller missing on /sys/fs/cgroup
+  - memory: needs delegation (parent ran: echo +memory | sudo tee /sys/fs/cgroup/cgroup.subtree_control)
+```
+
+**What it means.** `kuke doctor cgroups` compares the cgroup's available + delegated controllers against the set `kukeon init` will enable on the `kukeond` bootstrap cell, then classifies each gap:
+
+| Status                 | Why it appears                                                                                                    | What to do                                                                                                |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `kernel-missing`       | The kernel was built without the named controller.                                                                | Rebuild the kernel with the controller compiled in, or switch hosts.                                      |
+| `needs-delegation`     | The controller is advertised in `cgroup.controllers` but not in `cgroup.subtree_control`. Operator can fix it.    | Run the `echo +<ctrl> \| sudo tee …` line the doctor prints.                                              |
+| `not-delegated`        | Probe write returned `EOPNOTSUPP`: the cgroup-namespace trap (advertised but not delegated by the parent).        | Escalate to whoever owns the parent cgroup — your own write cannot fix this.                              |
+| `threaded-subtree`     | Probe write returned `EOPNOTSUPP` and the target cgroup is `domain threaded` / `threaded`.                        | Domain-only controllers (memory, io, …) cannot be enabled in a threaded subtree; adjust the cgroup.type.  |
+| `internal-process`     | Probe write returned `EBUSY`: the cgroup-v2 no-internal-process rule (the cgroup holds processes).                | Move processes to a child cgroup, or accept thread-aware-only enablement at this scope.                   |
+
+`--probe` is the default — it disambiguates `not-delegated` and `threaded-subtree` from `needs-delegation`. Pass `--no-probe` for a strictly read-only check (useful in CI before you have root); the trap classifications won't fire.
+
+**Exit codes.**
+
+- `0` — every required controller is enabled (or was enabled by the probe write).
+- non-zero — at least one controller is missing, the cgroup directory could not be read, or `--probe` was used without root.
+
+**Self-heal carve-out.** On a `NestedCgroupRuntime` dev host where the cgroup-namespace root carries processes, the doctor still surfaces the `internal-process` diagnostic on stderr but exits 0 — the `kuke init` runtime drains those processes on its own, so `make dev-init` does not abort at the pre-flight.
+
+See [kuke doctor cgroups](../cli/kuke-doctor.md) for the full flag list.
+
 ## `kuke init` fails with "numerical result out of range"
 
 **Symptom.** On re-init after upgrading Kukeon, a cell attaches to its bridge and fails with:
@@ -66,19 +116,17 @@ sudo ln -f /usr/local/bin/kuke /usr/local/bin/kukeond
 sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon
 ```
 
-If the list is empty and you just imported the image, you probably imported it into the wrong namespace. `ctr images import` **silently no-ops if the target namespace doesn't exist**, so:
+**Fix.** Use `kuke image load --from-docker` so the right namespace is created and populated in one step:
 
 ```bash
-# Create the namespace first
-sudo ctr namespaces create kuke-system.kukeon.io
-
-# Then import
-docker save kukeon-local:dev | sudo ctr -n kuke-system.kukeon.io images import -
+sudo kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
 ```
+
+If you load with `ctr` directly, the target namespace must exist or `ctr images import` silently no-ops. Use `kuke image load` to avoid that footgun.
 
 ## Daemon socket is missing or stale
 
-**Symptom.** `kuke` commands hang or fail with:
+**Symptom.** `kuke` commands fail with:
 
 ```
 dial unix /run/kukeon/kukeond.sock: connect: no such file or directory
@@ -88,7 +136,7 @@ dial unix /run/kukeon/kukeond.sock: connect: no such file or directory
 
 ```bash
 # Is the daemon cell running?
-sudo kuke get cells --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo kuke get cells --realm kuke-system --space kukeon --stack kukeon --no-daemon
 
 # Is the socket actually on disk?
 ls -l /run/kukeon/
@@ -97,15 +145,13 @@ ls -l /run/kukeon/
 **Fix.** If the daemon cell is stopped, start it:
 
 ```bash
-sudo kuke start cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo kuke daemon start
 ```
 
-If the socket exists but nothing responds, the daemon may have died while leaving the socket behind. Remove the stale socket and restart:
+If the socket exists but nothing responds, the daemon died while leaving the socket behind. Reset and re-init:
 
 ```bash
-sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
-sudo kuke kill cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon || true
-sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon || true
+sudo kuke daemon reset
 sudo kuke init
 ```
 
@@ -119,10 +165,46 @@ sudo kuke init
 
 ## `ctr` can see containers that `kuke` doesn't list
 
-`kuke get containers` filters by realm/space/stack/cell. If a container exists in `ctr -n kukeon-<realm>` but doesn't show up in `kuke get containers`, check:
+`kuke get containers` filters by realm/space/stack/cell. If a container exists in `ctr -n <realm>.kukeon.io` but doesn't show up in `kuke get containers`, check:
 
-- The containerd namespace — is it really `kukeon-<realm>` for your realm? `spec.namespace` on the realm manifest can override.
+- The containerd namespace — is it really `<realm>.kukeon.io` for your realm? `spec.namespace` on the realm manifest can override.
 - The resource hierarchy — the container must have `realmId`, `spaceId`, `stackId`, `cellId` set correctly in its metadata. Containers created directly via `ctr` bypass Kukeon's metadata and won't be listed.
+
+## `kuke uninstall` reports `skipped (realm purge failed)`
+
+**Symptom.** `kuke uninstall -y` finishes non-zero, every filesystem / user / group row in the report is annotated `skipped (realm purge failed)`, and `/opt/kukeon` is still on disk.
+
+**What it means.** If any realm fails to drop its containerd namespace, uninstall **deliberately skips** the subsequent dir / account removal steps. Tearing out `/opt/kukeon` while a residual namespace is still pinning overlay mounts on disk would strand the next `kuke init` with stale containerd state. The skip is the safe default — the half-cleaned host is visible without scrolling to the trailing error.
+
+**Fix.** Resolve the realm-purge failure first, then re-run uninstall:
+
+```bash
+# Look at the realm purge error in the uninstall report. Common causes:
+# - a live bind mount under /run/kukeon/<...> (see next section)
+# - a leftover process inside a container that didn't respond to SIGKILL
+# - a stale containerd snapshot the GC hasn't reclaimed
+
+# Once resolved:
+sudo kuke uninstall -y
+```
+
+## `kuke uninstall -y` fails on `/run/kukeon/tty: device or resource busy`
+
+**Symptom.** Uninstall reports `/run/kukeon: remove failed` and exits non-zero with:
+
+```
+Error: remove socket dir "/run/kukeon": unlinkat /run/kukeon/tty: device or resource busy
+```
+
+**What it means.** A `kuke attach`-style smoke or an interactive session left a bind mount under `/run/kukeon/tty/...` pinned to the host. `rmdir /run/kukeon` cannot succeed while a mount lives below it.
+
+**Fix.** Current `kuke uninstall` releases kukeon-owned bind mounts before the `rmdir`, so this should self-resolve. If you're on an older binary, identify and unmount manually:
+
+```bash
+mount | grep kukeon
+sudo umount /run/kukeon/tty            # or `umount -l` if it's still busy
+sudo kuke uninstall -y
+```
 
 ## Leftover state after `delete`
 
@@ -156,6 +238,6 @@ The daemon's log level is set separately via `kukeond --log-level` in the cell s
 
 ## When all else fails
 
-- The full runtime state lives in `/opt/kukeon` (persistent), `/run/kukeon` (tmpfs), `/sys/fs/cgroup/kukeon` (runtime), `/etc/cni/net.d/*.conflist` (cache), and containerd namespaces `kukeon-<realm>`. Those are the only places Kukeon writes state.
+- The full runtime state lives in `/opt/kukeon` (persistent), `/run/kukeon` (tmpfs), `/sys/fs/cgroup/kukeon` (runtime), `/etc/cni/net.d/*.conflist` (cache), and containerd namespaces `<realm>.kukeon.io`. Those are the only places Kukeon writes state.
 - The "nuclear reset" sequence is in [Init and reset → Full host wipe](init-and-reset.md#full-host-wipe).
 - Bug reports and questions welcome at [github.com/eminwux/kukeon/issues](https://github.com/eminwux/kukeon/issues).


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #446.
Mode: best-effort — the issue body identified files and sections (`local-dev.md`, `troubleshooting.md`, `autocomplete.md`, `apply-manifests.md`, `init-and-reset.md`) and the drift points to repair, but did not provide paste-ready Before/After wording. Authored the rewrites against the Proposal/Acceptance criteria, with claims grounded in `Makefile`, `scripts/dev-init.sh`, `internal/consts/consts.go`, `cmd/kuke/{daemon/reset,doctor/cgroups,uninstall,autocomplete}`, `pkg/api/kukeonv1/rpcclient.go`, and `docs/cli-use-cases.md`.

## Files changed
- `docs/site/guides/local-dev.md` — Prerequisites, "The canonical loop: `make dev-init`", Make targets, Manual phases
- `docs/site/guides/troubleshooting.md` — kukeon-group socket dial, doctor cgroups exit conditions, half-cleaned-host uninstall gate, `/run/kukeon/tty` bind-mount gotcha, namespace-name fixes
- `docs/site/guides/autocomplete.md` — cobra V2 dispatcher model note, profile-name completion mention
- `docs/site/guides/apply-manifests.md` — new "Parameterized cell profiles" section pointing at `kuke run -p` with `--param`/`--param-file`
- `docs/site/guides/init-and-reset.md` — realm/namespace name corrections (`default`/`default.kukeon.io`, `kuke-system`/`kuke-system.kukeon.io`), `kuke daemon reset --purge-system`, `kuke uninstall` half-cleaned-host gate, `kuke image load --from-docker` (replaces `docker save | ctr import`)

## Editorial choices
- Re-led each guide with the v0.5.0 canonical verb instead of the v0.3-era manual sequence: `make dev-init` in local-dev.md and `kuke daemon reset` / `kuke uninstall` in init-and-reset.md. The manual sequences are kept as fallback for debugging-a-phase, not as the primary loop, to match how dev-init.sh composes the flow today.
- In troubleshooting.md, formatted the `kuke doctor cgroups` exit conditions as a status-by-status table (`kernel-missing`, `needs-delegation`, `not-delegated`, `threaded-subtree`, `internal-process`) so each AC's classifier (#337/#338/#339/#343) is documented in one place rather than as scattered prose. Escaped the `|` inside the table cell's inline code span so the GitHub markdown renderer doesn't split the row.
- Surfaced the #343 self-heal carve-out as a one-line note under the same section rather than a separate entry — it's a refinement on the `internal-process` classifier, not a distinct failure mode.
- Documented `--param`/`--param-file` in apply-manifests.md as a cross-reference to `kuke run -p` rather than inventing flags on `kuke apply`: parameterized profiles are a feature of `kuke run -p` (#358), and apply-manifests.md's job is to explain the parameters-vs-fixed-manifests split so readers route to the right verb.
- Updated namespace names throughout to match `internal/consts/consts.go` (`default.kukeon.io`, `kuke-system.kukeon.io`) and realm names to `default` / `kuke-system`. Dropped the manual `ctr namespaces create` + `docker save | ctr import` workflow in favor of `kuke image load --from-docker --realm kuke-system --no-daemon`, which is the v0.4.0+ canonical path.

## Acceptance criteria check
- [x] `local-dev.md` documents `make dev-init`, `install-dev`, and the docker + standalone containerd prereqs — done.
- [x] `troubleshooting.md` covers the kukeon-group socket dial error, `kuke doctor cgroups` exit conditions, and the half-cleaned-host uninstall gate — done; also fixed the stale `kukeon-system` realm name and `kukeon-<realm>` namespace references.
- [x] `autocomplete.md` reflects cobra V2 behavior across bash/zsh/fish — done (dispatcher model note, no inlined flag arrays, `kuke __complete` routing).
- [x] `apply-manifests.md` documents parameterized profiles and `--param` / `--param-file` — done (new "Parameterized cell profiles" section cross-linking `kuke run -p`).
- [x] `init-and-reset.md` has correct socket path (`/run/kukeon/kukeond.sock`), namespace names (`default.kukeon.io` / `kuke-system.kukeon.io`), and `--purge-system` flag coverage — done.

Closes #446