### PR TITLE
docs: refresh faq.md, vision.md, index.md status for v0.5.0 beta

### DIFF
--- a/docs/site/faq.md
+++ b/docs/site/faq.md
@@ -19,7 +19,7 @@ Scale, resiliency, and multi-node concerns are deliberately out of scope.
 
 ## Can I run Kukeon and Docker on the same host?
 
-Yes. Kukeon uses its own containerd namespaces (`kukeon-<realm>`). Docker uses `moby`. The two never see each other's containers.
+Yes. Kukeon uses its own containerd namespaces (`<realm>.kukeon.io` — `default.kukeon.io` and `kuke-system.kukeon.io` after `kuke init`). Docker uses `moby`. The two never see each other's containers.
 
 ## Can I run Kukeon without the daemon?
 
@@ -47,15 +47,33 @@ Not yet. One is on the roadmap. The `kukeonv1` API that the CLI uses is stable e
 
 ## Where does Kukeon write files on the host?
 
-See [Architecture → Storage layout](architecture/storage-layout.md). The short list: `/opt/kukeon`, `/run/kukeon`, `/sys/fs/cgroup/kukeon`, `/etc/cni/net.d/*.conflist`, containerd's own store (via namespaces `kukeon-<realm>`).
+See [Architecture → Storage layout](architecture/storage-layout.md). The short list: `/opt/kukeon`, `/run/kukeon`, `/sys/fs/cgroup/kukeon`, `/etc/cni/net.d/*.conflist`, containerd's own store (via namespaces `<realm>.kukeon.io`).
 
 ## Can I run multiple kukeon daemons on the same host?
 
-Not supported. The daemon assumes sole ownership of `/run/kukeon/kukeond.sock`, `/opt/kukeon`, and the `kukeon-*` containerd namespaces. Running two would race on all three.
+Not supported. The daemon assumes sole ownership of `/run/kukeon/kukeond.sock`, `/opt/kukeon`, and the `*.kukeon.io` containerd namespaces. Running two would race on all three.
 
 ## Is Kukeon production ready?
 
-No. It's in alpha and the APIs can still change. See [GitHub Issues](https://github.com/eminwux/kukeon/issues?q=is%3Aissue+is%3Aopen+label%3Aplanning) for what's still in flux.
+No. v0.5.0 graduated from alpha to **beta**: the core primitives (Realm, Space, Stack, Cell, Container), `kuke apply` round-trip, attach/log, and the `kukeond` daemon are stable enough for daily homelab and single-host use, but the public API is not frozen and a few in-flight tracks still change semantics. See [GitHub Issues](https://github.com/eminwux/kukeon/issues?q=is%3Aissue+is%3Aopen+label%3Aplanning) for what's still in flux.
+
+## What does beta mean for Kukeon?
+
+Beta is the "ready to use, not yet a SemVer promise" tier between alpha and v1.0:
+
+- **What you get:** the manifest schema (`v1beta1`), the `kuke` CLI surface documented in [CLI Reference](cli/commands.md), and the `kukeond` daemon behavior are intended to keep working as documented. Bugs are fixed forward, not by reshaping verbs.
+- **What you don't get yet:** a deprecation policy. The `v1beta1` API may still gain fields, rename kinds, or absorb new layers (see [#423](https://github.com/eminwux/kukeon/issues/423) for the planned crew-layers reshape) before `v1.0`. Update between minor releases by reading the release notes — assume a non-trivial migration can land in any minor until v1.0.
+- **What changes vs. alpha:** the user-visible flow (`kuke init` → `kuke apply` → `kuke get` → `kuke delete`) is no longer expected to break under you between point releases. Breaking changes go through a beta-deprecation cycle, not a silent rename.
+
+## When is v1.0?
+
+There is no calendar date. v1.0 is gated on closing the in-flight tracks that would otherwise force a breaking v2 a few months later:
+
+- **[#423](https://github.com/eminwux/kukeon/issues/423)** — crew-layers absorption (`CellBlueprint` / `CellConfig` / `Secret` replace today's `CellProfile`). Schema reshape; cannot be SemVer-stable until it lands.
+- **[#217](https://github.com/eminwux/kukeon/issues/217)** — `kuke daemon` subcommand group and `--no-daemon` retirement. CLI surface is still moving; the persistent flag exits the user-facing API at v1.0.
+- **[#224](https://github.com/eminwux/kukeon/issues/224)** — reconciler-driven `create`/`delete` convergence. Changes runtime semantics for create/delete to a desired-state model.
+
+Once those land and the project publishes a compat/deprecation policy, the next tag earns v1.0. The honest progression is **alpha → beta → 1.0**, not "alpha → 1.0 with a breaking change six months later."
 
 ## How do I report a bug or request a feature?
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,15 +1,15 @@
 # kukeon: Run AI agents on your own Linux.
 
 ![status: active](https://img.shields.io/badge/status-active-blue)
-![state: alpha](https://img.shields.io/badge/state-alpha-orange)
+![state: beta](https://img.shields.io/badge/state-beta-yellow)
 ![license: apache2](https://img.shields.io/badge/license-Apache%202.0-green)
 
 _Agent-native orchestration. Self-hosted. No walled garden._
 
 Your agent's context, state, and workspace live on **your** machines — not behind a SaaS login. Kukeon is a containerd-native runtime for AI agents on any Linux host: your cloud VM, your homelab, your laptop. Declarative sessions with bounded lifetime, PTY-attached workloads, and clean teardown — all on infrastructure you control.
 
-!!! warning "Alpha software"
-This project is under active development and not production ready. Interfaces and APIs may change.
+!!! info "v0.5.0 beta — core primitives stable; API not yet frozen"
+The Realm / Space / Stack / Cell / Container hierarchy, `kuke apply`, attach/log, the `kukeond` daemon, and the manifest schema are stable enough for daily homelab and single-host use. Production use is not recommended. Some kinds and flags are still moving — see [Release notes](https://github.com/eminwux/kukeon/releases) and the [v1.0 roadmap](faq.md#when-is-v10).
 
 `kukeond` is a small daemon over containerd + CNI + cgroups. `kuke` is the CLI. Agent-native primitives — `Session`, `Interactive` containers, scoped secrets, default-deny networking — are declared in YAML and reconciled on a single host.
 

--- a/docs/site/vision.md
+++ b/docs/site/vision.md
@@ -401,3 +401,41 @@ Kukeon did not set out to be an agent orchestrator, and it doesn't need to rebra
 The proposal above is a path to take the gap without abandoning the project's stated direction. Most of what's needed is field additions to an existing schema. A few of the items are new kinds. None of them require kukeon to stop being what it already is.
 
 Whether to take the bet is the maintainer's call. This document is written to make the bet legible.
+
+---
+
+## 9. Status as of v0.5.0
+
+The proposal above was written before v0.4.0. Most of P0 and P1 has since shipped; P2 has not been started. This section reconciles each section-4 promise with what's in the tree today so the proposal can be read as a status document rather than a forecast.
+
+| §   | Item                                              | Priority | Status                                    |
+| --- | ------------------------------------------------- | -------- | ----------------------------------------- |
+| 4.1 | Volume mounts on Container                        | P0       | **Shipped** — `v0.4.0`                    |
+| 4.2 | Security fields on Container                      | P0       | **Shipped** — `v0.4.0`                    |
+| 4.3 | Isolation-envelope inheritance from Space         | P1       | **Shipped** — `v0.4.0`                    |
+| 4.4 | Network policy on Space                           | P1       | **Shipped** — `v0.4.0`                    |
+| 4.5 | `Session` kind                                    | P1       | **Deferred** — closed wontfix             |
+| 4.6 | Scoped credential injection                       | P1       | **Shipped** — `v0.4.0`                    |
+| 4.7 | Capability budgets on Session                     | P2       | **Not started**                           |
+| 4.8 | Causal audit trail                                | P2       | **Not started**                           |
+| 4.9 | Approval gates                                    | P2       | **Not started**                           |
+
+### Per-item detail
+
+**4.1 — Volume mounts (P0).** Promoted from reserved to active. The Container spec honors `volumes: [{source, target, readOnly}]` for host bind mounts and `volumes: [{kind: tmpfs, target, sizeBytes, mode}]` for ephemeral scratch. Wired through to the OCI runtime spec at cell-creation time.
+
+**4.2 — Security fields on Container (P0).** All fields proposed in the priority-order table are present and honored: `user`, `readOnlyRootFilesystem`, `capabilities.{add,drop}`, `securityOpts`, `tmpfs`, and `resources.{memoryLimitBytes, cpuShares, pidsLimit}`. Defaults remain backwards-compatible (`readOnlyRootFilesystem: false`); operators opt into tighter posture per-container or per-Space (see 4.3).
+
+**4.3 — Space defaults inheritance (P1).** Space spec exposes `spec.defaults.container` covering the same security/resource/tmpfs surface as 4.2. Inheritance is shallow; per-container values override Space defaults. This is the field that turns Space from "a CNI network" into "the isolation envelope."
+
+**4.4 — Network policy on Space (P1).** Space spec exposes `spec.network.egress` with `default: deny|allow` plus an allowlist of `(host, ports)` or `(cidr, ports)` pairs. Enforcement is iptables/nftables on the space bridge for IP+port rules; hostname-targeted rules are resolved at policy-apply time. The transparent egress proxy mode the proposal outlined as the "honest" path for SNI inspection is not built — HTTPS allowlisting today is by destination IP after DNS resolution, with the proxy path left for a future P2 cycle.
+
+**4.5 — `Session` kind (P1).** [Issue #46](https://github.com/eminwux/kukeon/issues/46) closed as `wontfix`. The original proposal had `Session` carry lifetime, `onEnd.persist`, and budget enforcement in one kind. In practice, lifetime and persist semantics ended up better served by `kuke apply` + explicit teardown plus parameterized cell profiles ([#358](https://github.com/eminwux/kukeon/issues/358), shipped), and the budget/audit/approval pieces (4.7–4.9) are large enough to deserve their own kinds rather than overloading one. A dedicated lifetime/budget primitive may return in a later milestone if demand justifies it.
+
+**4.6 — Scoped credential injection (P1).** Container spec has `secrets: [{name, fromFile|fromEnv, mountPath?}]`. Values are mounted as env vars or files at runtime and never written into status or audit logs. The external-broker integration outlined as the extended (P2-ish) variant is not built; secrets are sourced from the host filesystem or host env today.
+
+**4.7–4.9 — P2 items.** Capability budgets, causal audit trail, and approval gates have no tracking issues open and no code on disk. They were deferred at proposal time as "the agent-native category bet" — opt-in, ambitious, and explicitly optional for kukeon's homelab/VPS user base. Reopening this work is gated on demand from real agent operators using the v0.5.0 substrate.
+
+### What this means for v1.0
+
+The agent-native gate — "give an agent a workspace, an egress-restricted network, a scoped credential, and a non-root sandbox by declaration" — is redeemed in v0.5.0 by the P0+P1-minus-Session set, and the [Section 6 success manifest](#6-what-success-looks-like) shape works today (substituting explicit `kuke apply` + `kuke delete` for the deferred `Session` kind). The remaining gaps to v1.0 are schema/runtime tracks not covered by this proposal — see the [FAQ on v1.0](faq.md#when-is-v10) for the gating issues.


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #447.
Mode: best-effort — the issue body identified files (`docs/site/index.md`, `docs/site/faq.md`, `docs/site/vision.md`) and sections to refresh but did not provide paste-ready Before/After wording, so the rewrites were authored against the Proposal/Acceptance criteria. Claims grounded in `internal/consts/consts.go` (namespace naming), `pkg/api/model/v1beta1/{container,space}.go` and `internal/ctr/spec.go` (which P0/P1 vision items shipped), the closure state of #46/#57, and #440 (v0.5.0 release plan) for the v1.0 gating set (#423, #217, #224).

## Files changed
- `docs/site/index.md` — `state: alpha` badge → `state: beta`; replaced the alpha admonition with a `v0.5.0 beta — core primitives stable; API not yet frozen` info callout linking release notes and the v1.0 roadmap.
- `docs/site/faq.md` — fixed stale `kukeon-<realm>` containerd namespace references to `<realm>.kukeon.io` / `*.kukeon.io` in three places ("Can I run Kukeon and Docker", "Where does Kukeon write files", "Can I run multiple kukeon daemons"); reworked "Is Kukeon production ready?" from alpha to beta with the shipped-substrate framing; added "What does beta mean for Kukeon?" and "When is v1.0?" Q&As that pin the v1.0 gate to #423/#217/#224 per #440.
- `docs/site/vision.md` — appended a "## 9. Status as of v0.5.0" section with a per-item status table for §4.1–4.9 and a paragraph per item reconciling proposal against shipped code. Documents `Session` (#46) as deferred-wontfix with the rationale, leaves §4.7–4.9 (P2) marked not-started, and closes with a "what this means for v1.0" pointer back to the FAQ.

## Editorial choices
- Kept §4.1–4.6's "shipped" verdict pegged to v0.4.0 (the release that brought the bulk of those fields per #440's release notes), not v0.5.0, so the table is a release-history reference rather than a v0.5.0-only snapshot.
- Treated the alpha admonition on `index.md` as in-scope for the "v0.5.0 beta status" AC rather than adding a separate badge above the existing one — the proposal explicitly suggested "a top-of-page status badge / line stating …", which I read as "either form is acceptable; pick one." Replacing the existing alpha block keeps the page tight.
- For the v1.0 FAQ entry, anchored the gating set (#423, #217, #224) verbatim from #440's "Why beta, not v1.0" rationale rather than restating it — this is the explicit upstream decision; pm should not be reinterpreting it.
- Did not touch `vision.md`'s top-matter header ("Status: Proposal / discussion draft" / "Target: post-`v0.1.0`"). The issue Proposal said "append a status section"; rewriting the header would be "while I'm here" scope creep beyond the AC. The new Section 9 carries the v0.5.0 reconciliation; readers see it on the way through.
- §4.5 (`Session`) needed a softer landing than "wontfix, see issue" — added a one-paragraph explanation of *why* (lifetime/persist served better by `kuke apply` + parameterized profiles per #358; budget/audit/approval pieces too large for one kind) so a reader following the proposal's logic isn't left with a dead link.

## Acceptance criteria check
- [x] `index.md` clearly states v0.5.0 beta status — badge flipped and the info callout names "v0.5.0 beta — core primitives stable; API not yet frozen" verbatim.
- [x] `faq.md` answers reflect current command surface and install flow — stale `kukeon-<realm>` namespace claims (three sites) corrected to `<realm>.kukeon.io`; production-ready answer reframed from alpha to beta. (No other FAQ answers contradicted current behavior on review.)
- [x] `faq.md` includes "what does beta mean" and "when is v1.0" entries — both added, with the v1.0 entry pinning the gating issues from #440.
- [x] `vision.md` ends with a "Status as of v0.5.0" section mapping each promise to a tracking issue — Section 9 appended with the table + per-item paragraphs covering §4.1–4.9 and linking #46 / #358 where applicable.

Closes #447