### PR TITLE
docs: supersede docs/gaps-2026-04-19.md (rolled into #208)

### DIFF
--- a/docs/gaps-2026-04-19.md
+++ b/docs/gaps-2026-04-19.md
@@ -1,5 +1,13 @@
 # Kukeon Operator Gaps — 2026-04-19
 
+> **Superseded by [#208](https://github.com/eminwux/kukeon/issues/208) — historical session snapshot, do not act on this.**
+>
+> All nine friction points captured here have been resolved or rolled into the
+> operator-experience umbrella issue ([#208](https://github.com/eminwux/kukeon/issues/208)),
+> which is the live tracker. This file is retained as a historical artifact
+> (referenced from a few inline code comments) but is no longer load-bearing —
+> read [#208](https://github.com/eminwux/kukeon/issues/208) for current status.
+
 This document captures functionality that was missing or rough when rebuilding
 kukeon from source and running `kuke init` end-to-end. Each gap is written so it
 can be picked up as a standalone implementation task.


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #448.
Mode: best-effort — the issue body identified the target file and presented two acceptable options (delete vs. add a Superseded-by banner) but no paste-ready banner wording, so the banner was authored to match the issue's Proposal and Acceptance criteria.

## Files changed
- `docs/gaps-2026-04-19.md` — added a Superseded-by banner immediately under the H1.

## Editorial choices
- Selected option 2 (banner) rather than the recommended option 1 (delete) because two `.go` files reference this doc inline — `internal/client/local/local.go:982` ("gap #4 in docs/gaps-2026-04-19.md") and `cmd/kuke/log/log.go:33` ("This is gap #4 in docs/gaps-2026-04-19.md and was implemented per issue #203"). Deleting the file would leave dangling references; fixing those would require code edits, which are outside pm's lane. The issue body explicitly lists option 2 as an acceptable AC.
- Banner wording follows the AC's suggested phrasing ("Superseded by #208 — historical session snapshot, do not act on this") verbatim as the headline, then a short paragraph naming #208 as the live tracker and noting the file is retained because of the inline code-comment references.
- Placed the banner immediately under the H1, before the existing intro paragraph, so any reader who lands on the file sees the supersedence before reading the snapshot.

## Acceptance criteria check
- [x] File has an explicit "Superseded by #208 — historical session snapshot, do not act on this" banner at the top.

Closes #448