### PR TITLE
feat: kuke log <cell> positional arg, default realm/space/stack

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -399,8 +399,6 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_LOG_STACK = DefineKV("KUKE_LOG_STACK", "kuke/log/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_LOG_CELL = DefineKV("KUKE_LOG_CELL", "kuke/log/cell")
-	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_LOG_CONTAINER = DefineKV("KUKE_LOG_CONTAINER", "kuke/log/container")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_LOG_FOLLOW = DefineKV("KUKE_LOG_FOLLOW", "kuke/log/follow", "false")

--- a/cmd/kuke/daemon/logs/logs.go
+++ b/cmd/kuke/daemon/logs/logs.go
@@ -61,7 +61,7 @@ func NewLogsCmd() *cobra.Command {
 		Short:   "Print the kukeond daemon's stdout/stderr (use -f to follow)",
 		Long: "Print the kukeond container's stdout/stderr stream.\n\n" +
 			"Shortcut for `kuke log --realm kuke-system --space kukeon " +
-			"--stack kukeon --cell kukeond`; the coordinates are static and " +
+			"--stack kukeon kukeond`; the coordinates are static and " +
 			"filled in for you. By default the current contents are printed " +
 			"and the command exits; pass -f/--follow to tail until SIGINT.",
 		Args:          cobra.NoArgs,

--- a/cmd/kuke/log/log.go
+++ b/cmd/kuke/log/log.go
@@ -46,6 +46,7 @@ import (
 
 	"github.com/eminwux/kukeon/cmd/config"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -87,46 +88,47 @@ func TailFile(ctx context.Context, path string, out io.Writer, follow bool) erro
 // NewLogCmd builds the `kuke log` cobra command.
 func NewLogCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "log",
+		Use:           "log <cell>",
 		Aliases:       []string{"logs"},
 		Short:         "Print a container's stdout/stderr stream (use -f to follow)",
-		Args:          cobra.NoArgs,
+		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE:          runLog,
 	}
 
-	cmd.Flags().String("realm", "", "Realm that owns the cell")
+	cmd.Flags().String("realm", consts.KukeonDefaultRealmName, "Realm that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_LOG_REALM.ViperKey, cmd.Flags().Lookup("realm"))
-	cmd.Flags().String("space", "", "Space that owns the cell")
+	cmd.Flags().String("space", consts.KukeonDefaultSpaceName, "Space that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_LOG_SPACE.ViperKey, cmd.Flags().Lookup("space"))
-	cmd.Flags().String("stack", "", "Stack that owns the cell")
+	cmd.Flags().String("stack", consts.KukeonDefaultStackName, "Stack that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_LOG_STACK.ViperKey, cmd.Flags().Lookup("stack"))
-	cmd.Flags().String("cell", "", "Cell whose container's capture file to tail")
-	_ = viper.BindPFlag(config.KUKE_LOG_CELL.ViperKey, cmd.Flags().Lookup("cell"))
 	cmd.Flags().String("container", "",
 		"Container within the cell to read (omit to auto-pick the only non-root container)")
 	_ = viper.BindPFlag(config.KUKE_LOG_CONTAINER.ViperKey, cmd.Flags().Lookup("container"))
 	cmd.Flags().BoolP("follow", "f", false, "Tail the file until SIGINT instead of printing current contents and exiting")
 	_ = viper.BindPFlag(config.KUKE_LOG_FOLLOW.ViperKey, cmd.Flags().Lookup("follow"))
 
+	cmd.ValidArgsFunction = config.CompleteCellNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
-	_ = cmd.RegisterFlagCompletionFunc("cell", config.CompleteCellNames)
 	_ = cmd.RegisterFlagCompletionFunc("container", config.CompleteContainerNames)
 
 	return cmd
 }
 
-func runLog(cmd *cobra.Command, _ []string) error {
+func runLog(cmd *cobra.Command, args []string) error {
+	cell := strings.TrimSpace(args[0])
 	realm := strings.TrimSpace(viper.GetString(config.KUKE_LOG_REALM.ViperKey))
 	space := strings.TrimSpace(viper.GetString(config.KUKE_LOG_SPACE.ViperKey))
 	stack := strings.TrimSpace(viper.GetString(config.KUKE_LOG_STACK.ViperKey))
-	cell := strings.TrimSpace(viper.GetString(config.KUKE_LOG_CELL.ViperKey))
 	container := strings.TrimSpace(viper.GetString(config.KUKE_LOG_CONTAINER.ViperKey))
 	follow := viper.GetBool(config.KUKE_LOG_FOLLOW.ViperKey)
 
+	if cell == "" {
+		return fmt.Errorf("%w (positional cell)", errdefs.ErrCellNameRequired)
+	}
 	if realm == "" {
 		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
 	}
@@ -135,9 +137,6 @@ func runLog(cmd *cobra.Command, _ []string) error {
 	}
 	if stack == "" {
 		return fmt.Errorf("%w (--stack)", errdefs.ErrStackNameRequired)
-	}
-	if cell == "" {
-		return fmt.Errorf("%w (--cell)", errdefs.ErrCellNameRequired)
 	}
 
 	client, err := resolveClient(cmd)

--- a/cmd/kuke/log/log_test.go
+++ b/cmd/kuke/log/log_test.go
@@ -132,8 +132,8 @@ func TestLog_DefaultDumpsCaptureAndExits(t *testing.T) {
 	tail := &tailCapture{payload: []byte("captured-bytes")}
 	cmd, out := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -168,8 +168,8 @@ func TestLog_Follow_CancelsCleanlyOnCtxDone(t *testing.T) {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work", "--follow",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1", "--follow",
 	})
 
 	var wg sync.WaitGroup
@@ -212,8 +212,8 @@ func TestLog_MissingCaptureFile_WrapsWithCellAndContainer(t *testing.T) {
 	tail := &tailCapture{err: os.ErrNotExist}
 	cmd, _ := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1",
 	})
 
 	err := cmd.Execute()
@@ -243,7 +243,7 @@ func TestLog_AmbiguousCandidates_ErrorsWithList(t *testing.T) {
 	tail := &tailCapture{}
 	cmd, _ := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "c1",
 	})
 
 	err := cmd.Execute()
@@ -271,7 +271,7 @@ func TestLog_NoCandidate_Errors(t *testing.T) {
 	tail := &tailCapture{}
 	cmd, _ := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "c1",
 	})
 
 	err := cmd.Execute()
@@ -299,8 +299,8 @@ func TestLog_NonAttachable_TailsHostLogPath(t *testing.T) {
 	tail := &tailCapture{payload: []byte("daemon-stderr-line\n")}
 	cmd, out := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "side",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "side", "c1",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -336,7 +336,7 @@ func TestLog_AmbiguousAcceptsNonAttachable(t *testing.T) {
 	tail := &tailCapture{}
 	cmd, _ := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "c1",
 	})
 
 	err := cmd.Execute()
@@ -372,7 +372,7 @@ func TestLog_AutoPicksLoneNonAttachable(t *testing.T) {
 	tail := &tailCapture{}
 	cmd, _ := newCmdWithCtx(t, fc, tail)
 	cmd.SetArgs([]string{
-		"--realm", "kuke-system", "--space", "kukeon", "--stack", "kukeon", "--cell", "kukeond",
+		"--realm", "kuke-system", "--space", "kukeon", "--stack", "kukeon", "kukeond",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -380,6 +380,74 @@ func TestLog_AutoPicksLoneNonAttachable(t *testing.T) {
 	}
 	if tail.path != wantPath {
 		t.Errorf("tail path = %q, want %q", tail.path, wantPath)
+	}
+}
+
+// TestLog_PositionalCell_DefaultsRealmSpaceStack covers the issue-#374
+// contract: `kuke log <cell>` (no realm/space/stack flags) targets the
+// user-default hierarchy `default/default/default`. The runtime resolves
+// realm/space/stack from the flag defaults wired into NewLogCmd.
+func TestLog_PositionalCell_DefaultsRealmSpaceStack(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var gotRealm, gotSpace, gotStack, gotCell string
+	fc := &fakeClient{
+		listContainersFn: func(realm, space, stack, cell string) ([]v1beta1.ContainerSpec, error) {
+			gotRealm, gotSpace, gotStack, gotCell = realm, space, stack, cell
+			return []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work", Attachable: true},
+			}, nil
+		},
+		logContainerFn: func(doc v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			if got := doc.Spec.RealmID; got != "default" {
+				t.Errorf("doc.Spec.RealmID = %q, want %q", got, "default")
+			}
+			if got := doc.Spec.SpaceID; got != "default" {
+				t.Errorf("doc.Spec.SpaceID = %q, want %q", got, "default")
+			}
+			if got := doc.Spec.StackID; got != "default" {
+				t.Errorf("doc.Spec.StackID = %q, want %q", got, "default")
+			}
+			if got := doc.Spec.CellID; got != "hello" {
+				t.Errorf("doc.Spec.CellID = %q, want %q", got, "hello")
+			}
+			return kukeonv1.LogContainerResult{HostCapturePath: testHostCapture}, nil
+		},
+	}
+	tail := &tailCapture{}
+	cmd, _ := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{"hello"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if gotRealm != "default" || gotSpace != "default" || gotStack != "default" || gotCell != "hello" {
+		t.Errorf("ListContainers called with (%q, %q, %q, %q), want (default, default, default, hello)",
+			gotRealm, gotSpace, gotStack, gotCell)
+	}
+	if tail.calls != 1 {
+		t.Fatalf("tail called %d times, want 1", tail.calls)
+	}
+}
+
+// TestLog_RejectsCellFlag locks in the breaking change: the legacy
+// `--cell` flag was removed in favor of the positional arg. The cobra
+// parser must reject `--cell` rather than silently accepting it.
+func TestLog_RejectsCellFlag(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd, _ := newCmdWithCtx(t, &fakeClient{}, &tailCapture{})
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute returned nil, want unknown-flag error")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Errorf("error %q does not mention unknown flag", err.Error())
 	}
 }
 
@@ -392,33 +460,32 @@ func TestLog_MissingFlags(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "missing realm",
-			args:    []string{"--space", "s1", "--stack", "st1", "--cell", "c1"},
+			name:    "explicit empty realm",
+			args:    []string{"--realm", "", "--space", "s1", "--stack", "st1", "c1"},
 			wantErr: errdefs.ErrRealmNameRequired,
 		},
 		{
-			name:    "missing space",
-			args:    []string{"--realm", "r1", "--stack", "st1", "--cell", "c1"},
+			name:    "explicit empty space",
+			args:    []string{"--realm", "r1", "--space", "", "--stack", "st1", "c1"},
 			wantErr: errdefs.ErrSpaceNameRequired,
 		},
 		{
-			name:    "missing stack",
-			args:    []string{"--realm", "r1", "--space", "s1", "--cell", "c1"},
+			name:    "explicit empty stack",
+			args:    []string{"--realm", "r1", "--space", "s1", "--stack", "", "c1"},
 			wantErr: errdefs.ErrStackNameRequired,
-		},
-		{
-			name:    "missing cell",
-			args:    []string{"--realm", "r1", "--space", "s1", "--stack", "st1"},
-			wantErr: errdefs.ErrCellNameRequired,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Reset clears viper's defaults set by DefineKV at package
+			// init so an explicit `--realm ""` resolves to the empty
+			// string and trips the runtime guard. t.Setenv keeps the
+			// env-var path quiet too, in case the dev box exports a
+			// KUKE_LOG_*.
 			viper.Reset()
 			t.Setenv("KUKE_LOG_REALM", "")
 			t.Setenv("KUKE_LOG_SPACE", "")
 			t.Setenv("KUKE_LOG_STACK", "")
-			t.Setenv("KUKE_LOG_CELL", "")
 
 			cmd, _ := newCmdWithCtx(t, &fakeClient{}, &tailCapture{})
 			cmd.SetArgs(tc.args)
@@ -428,6 +495,24 @@ func TestLog_MissingFlags(t *testing.T) {
 				t.Fatalf("error %v does not unwrap to %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestLog_MissingCellArg covers the cobra arg-count guard: omitting the
+// positional <cell> exits before runLog ever runs, surfacing a
+// usage-style error rather than ErrCellNameRequired.
+func TestLog_MissingCellArg(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd, _ := newCmdWithCtx(t, &fakeClient{}, &tailCapture{})
+	cmd.SetArgs([]string{"--realm", "r1", "--space", "s1", "--stack", "st1"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute returned nil, want arg-count error")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Errorf("error %q does not mention arg-count requirement", err.Error())
 	}
 }
 
@@ -456,8 +541,8 @@ func TestTailFile_DefaultDumpsAndReturns(t *testing.T) {
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{
-		"--realm", "r1", "--space", "s1", "--stack", "st1", "--cell", "c1",
-		"--container", "work",
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1",
 	})
 	t.Cleanup(viper.Reset)
 

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -118,7 +118,7 @@ sudo kuke daemon logs -f               # follow until SIGINT
 - `daemon kill` has no grace period; this is the escape hatch for a hung daemon. Use `stop` for the graceful path.
 - `daemon reset` is destructive (cell deletion + socket removal) and described in the Bootstrap & teardown section.
 - After `daemon stop`, daemon-routed commands (anything **without** `--no-daemon`) fail with `dial unix /run/kukeon/kukeond.sock: connect: no such file or directory` and exit non-zero. `--no-daemon` commands still work for the subset of operations the in-process controller supports.
-- `daemon logs` is a typed shortcut for `kuke log --realm kuke-system --space kukeon --stack kukeon --cell kukeond`; the coordinates are wired in. Exit code 0 even when the file is empty.
+- `daemon logs` is a typed shortcut for `kuke log --realm kuke-system --space kukeon --stack kukeon kukeond`; the coordinates are wired in. Exit code 0 even when the file is empty.
 
 ## Realm / space / stack management
 
@@ -270,8 +270,8 @@ sudo kuke apply -f manifest.yaml -o json
 ```bash
 kuke get cell <name> --realm <r> --space <s> --stack <st>
 kuke get container <name> --cell <c> ...
-kuke log --cell <c> --container <con>                  # one-shot
-kuke log --cell <c> --container <con> -f               # follow until SIGINT
+kuke log <cell> --container <con>                      # one-shot
+kuke log <cell> --container <con> -f                   # follow until SIGINT
 kuke attach <cell> --container <con>                   # alias: att
 ```
 

--- a/docs/site/cli/kuke-daemon.md
+++ b/docs/site/cli/kuke-daemon.md
@@ -10,14 +10,14 @@ These commands act on the `kukeond` cell provisioned by `kuke init` (`kuke-syste
 
 ## Subcommands
 
-| Command              | What it does                                                              |
-| -------------------- | ------------------------------------------------------------------------- |
-| `kuke daemon start`  | Start the kukeond daemon cell                                             |
-| `kuke daemon stop`   | Gracefully stop the kukeond cell (SIGTERM, escalating to SIGKILL)         |
-| `kuke daemon kill`   | Immediately SIGKILL the kukeond daemon cell                               |
-| `kuke daemon restart`| Stop then start the kukeond daemon cell                                   |
-| `kuke daemon reset`  | Stop, delete metadata + cgroups, clear `/run/kukeon/kukeond.{sock,pid}`   |
-| `kuke daemon logs`   | Print the kukeond daemon's stdout/stderr (use `-f` to follow)             |
+| Command               | What it does                                                            |
+| --------------------- | ----------------------------------------------------------------------- |
+| `kuke daemon start`   | Start the kukeond daemon cell                                           |
+| `kuke daemon stop`    | Gracefully stop the kukeond cell (SIGTERM, escalating to SIGKILL)       |
+| `kuke daemon kill`    | Immediately SIGKILL the kukeond daemon cell                             |
+| `kuke daemon restart` | Stop then start the kukeond daemon cell                                 |
+| `kuke daemon reset`   | Stop, delete metadata + cgroups, clear `/run/kukeon/kukeond.{sock,pid}` |
+| `kuke daemon logs`    | Print the kukeond daemon's stdout/stderr (use `-f` to follow)           |
 
 All subcommands are idempotent: they succeed with a clear message when the daemon is already in the requested state.
 
@@ -29,9 +29,9 @@ Bring up the existing `kukeond` cell provisioned by `kuke init`. Returns success
 
 Send SIGTERM and wait up to `--timeout` (default 10s) for the daemon to exit; if the grace period expires, escalate to SIGKILL.
 
-| Flag        | Default | Description                                                |
-| ----------- | ------- | ---------------------------------------------------------- |
-| `--timeout` | `10s`   | Grace period before escalating from SIGTERM to SIGKILL     |
+| Flag        | Default | Description                                            |
+| ----------- | ------- | ------------------------------------------------------ |
+| `--timeout` | `10s`   | Grace period before escalating from SIGTERM to SIGKILL |
 
 ## kuke daemon kill
 
@@ -41,8 +41,8 @@ Force-kill the kukeond cell with no grace period. This is the escape hatch for a
 
 Compose `kuke daemon stop` and `kuke daemon start` into a single verb. When the daemon is already stopped, the stop phase is skipped and the start phase still runs.
 
-| Flag        | Default | Description                                                          |
-| ----------- | ------- | -------------------------------------------------------------------- |
+| Flag        | Default | Description                                                               |
+| ----------- | ------- | ------------------------------------------------------------------------- |
 | `--timeout` | `10s`   | Grace period for the stop phase before escalating from SIGTERM to SIGKILL |
 
 ## kuke daemon reset
@@ -53,14 +53,14 @@ Always runs as root: it touches `/sys/fs/cgroup`, containerd namespaces, and `/o
 
 Distinct from [`kuke uninstall`](kuke-uninstall.md), which is the per-host teardown (every realm, the kukeon system user/group, and the run path itself).
 
-| Flag             | Default | Description                                                              |
-| ---------------- | ------- | ------------------------------------------------------------------------ |
+| Flag             | Default | Description                                                                |
+| ---------------- | ------- | -------------------------------------------------------------------------- |
 | `--purge-system` | `false` | Also remove `/opt/kukeon/kuke-system` (user-realm data is still preserved) |
-| `--timeout`      | `10s`   | Grace period for the stop phase before escalating from SIGTERM to SIGKILL |
+| `--timeout`      | `10s`   | Grace period for the stop phase before escalating from SIGTERM to SIGKILL  |
 
 ## kuke daemon logs
 
-Print the `kukeond` container's stdout/stderr stream. Shortcut for `kuke log --realm kuke-system --space kukeon --stack kukeon --cell kukeond` — the coordinates are static and filled in for you.
+Print the `kukeond` container's stdout/stderr stream. Shortcut for `kuke log --realm kuke-system --space kukeon --stack kukeon kukeond` — the coordinates are static and filled in for you.
 
 ```
 kuke daemon logs [-f]
@@ -69,8 +69,8 @@ kuke daemon log  [-f]      # alias
 
 By default the current contents are printed and the command exits; pass `-f`/`--follow` to tail until SIGINT.
 
-| Flag             | Default | Description                                                  |
-| ---------------- | ------- | ------------------------------------------------------------ |
+| Flag             | Default | Description                                                        |
+| ---------------- | ------- | ------------------------------------------------------------------ |
 | `--follow`, `-f` | `false` | Tail until SIGINT instead of printing current contents and exiting |
 
 ## Examples

--- a/docs/site/cli/kuke-log.md
+++ b/docs/site/cli/kuke-log.md
@@ -3,22 +3,23 @@
 Print a container's stdout/stderr stream.
 
 ```
-kuke log  --realm <realm> --space <space> --stack <stack> --cell <cell> [flags]
-kuke logs --realm <realm> --space <space> --stack <stack> --cell <cell> [flags]      # alias
+kuke log  <cell> [flags]
+kuke logs <cell> [flags]      # alias
 ```
+
+`<cell>` is a positional argument. `--realm`, `--space`, and `--stack` all default to `default`, so for a cell in the default location you only need the cell name.
 
 By default, `kuke log` prints the current contents of the capture file and exits. Pass `-f`/`--follow` to tail until SIGINT.
 
 ## Flags
 
-| Flag             | Default      | Description                                                                       |
-| ---------------- | ------------ | --------------------------------------------------------------------------------- |
-| `--cell`         | _(required)_ | Cell whose container's capture file to tail                                       |
-| `--container`    | (auto-pick)  | Container within the cell to read (omit to auto-pick the only non-root container) |
-| `--realm`        | _(required)_ | Realm that owns the cell                                                          |
-| `--space`        | _(required)_ | Space that owns the cell                                                          |
-| `--stack`        | _(required)_ | Stack that owns the cell                                                          |
-| `--follow`, `-f` | `false`      | Tail the file until SIGINT instead of printing current contents and exiting       |
+| Flag             | Default     | Description                                                                       |
+| ---------------- | ----------- | --------------------------------------------------------------------------------- |
+| `--container`    | (auto-pick) | Container within the cell to read (omit to auto-pick the only non-root container) |
+| `--realm`        | `default`   | Realm that owns the cell                                                          |
+| `--space`        | `default`   | Space that owns the cell                                                          |
+| `--stack`        | `default`   | Stack that owns the cell                                                          |
+| `--follow`, `-f` | `false`     | Tail the file until SIGINT instead of printing current contents and exiting       |
 
 Plus all [global flags](kuke.md).
 
@@ -28,22 +29,20 @@ Plus all [global flags](kuke.md).
 
 Container selection: if the cell has exactly one non-root container, `--container` can be omitted. Otherwise, pass `--container` explicitly.
 
-`--realm`, `--space`, and `--stack` are all required — `kuke log` does not assume `default` for any of them. Pass each explicitly even when targeting the default realm/space/stack. (Note: `kuke attach` defaults these three to `default`; the two commands diverge here.)
-
 ## Examples
 
 ```bash
-# Print and exit
-sudo kuke log --realm default --space default --stack default --cell web
+# Print and exit (cell in default/default/default)
+sudo kuke log web
 
 # Follow until Ctrl-C
-sudo kuke log --realm default --space default --stack default --cell web -f
+sudo kuke log web -f
 
 # Explicit container in a multi-container cell
-sudo kuke log --realm default --space default --stack default --cell web --container nginx -f
+sudo kuke log web --container nginx -f
 
 # Non-default realm/space/stack
-sudo kuke log --realm default --space blog --stack wordpress --cell wp
+sudo kuke log wp --realm default --space blog --stack wordpress
 ```
 
 ## kuke log vs. kuke daemon logs


### PR DESCRIPTION
## Summary

- `kuke log` now accepts `<cell>` as a positional argument (mirrors `kuke attach` per issue #373), with `--realm`/`--space`/`--stack` all defaulting to `default`. The common case (cell in `default/default/default`) collapses to `kuke log <cell>` — matches `kubectl logs` / `docker logs`.
- Removed the now-redundant `--cell` flag and its `KUKE_LOG_CELL` viper key. The breaking change is explicit: `kuke log --cell foo` errors with `unknown flag`.
- Tab-completion for the positional arg uses `config.CompleteCellNames`, which already falls back to `default/default/default` when the realm/space/stack flags are unset (`cmd/config/autocomplete.go:346-348`).
- Docs (`docs/cli-use-cases.md`, `docs/site/cli/kuke-log.md`, `docs/site/cli/kuke-daemon.md`) updated to reflect the new shape — included per the issue's "Must include documentation update" instruction.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full suite green
- [x] `pre-commit run --files <changed-files>` — prettier reformatted the markdown tables; re-run clean
- [x] `./kuke log --help` — confirmed positional `<cell>` shape, `default` defaults for realm/space/stack, no `--cell` flag
- [x] New unit tests cover: positional cell with default `default/default/default` fallback; `--cell` flag rejection; `cobra.ExactArgs(1)` arg-count guard
- [ ] `make dev-init` smoke — change is CLI-surface only (no daemon, build, or `/opt/kukeon` writes), so the smoke parity check is not affected

Closes #374