### PR TITLE
fix: write kukeond.pid under socket dir to match docs

### DIFF
--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -17,10 +17,11 @@
 // Package reset implements `kuke daemon reset`, the lightweight dev-loop
 // teardown for the kukeond cell. It composes stop (with the same SIGTERM →
 // SIGKILL escalation as `kuke daemon stop`) plus delete, then clears the
-// transient socket/PID files under /run/kukeon. User-realm data under
-// /opt/kukeon/default/** is left untouched so a subsequent `kuke init` can
-// re-bootstrap without wiping user workloads. `--purge-system` additionally
-// removes /opt/kukeon/kuke-system for a fully clean re-bootstrap.
+// transient kukeond.{sock,pid} files under the socket dir (default
+// /run/kukeon). User-realm data under /opt/kukeon/default/** is left
+// untouched so a subsequent `kuke init` can re-bootstrap without wiping
+// user workloads. `--purge-system` additionally removes
+// /opt/kukeon/kuke-system for a fully clean re-bootstrap.
 package reset
 
 import (
@@ -160,14 +161,16 @@ func runReset(cmd *cobra.Command, _ []string) error {
 
 	socketDir := resolveSocketDir(cmd)
 	runPath := resolveRunPath(cmd)
-	// kukeond.sock lives under the socket dir (/run/kukeon); kukeond.pid is
-	// written under the run path (/opt/kukeon) by cmd/kukeond/serve.go. The
-	// two diverge — pinning kukeond.pid to the socket dir was the silent #287
-	// no-op that left the daemon-stop step in `kuke uninstall` looking at the
-	// wrong path.
+	// kukeond.sock and kukeond.pid both live under the socket dir
+	// (default /run/kukeon), matching the storage-layout.md design
+	// ("Sockets and pid files belong in /run"). cmd/kukeond/serve.go
+	// derives the pidfile path from filepath.Dir(--socket) so the two
+	// sides agree regardless of --socket overrides; pinning to runPath
+	// was the silent #287 no-op that left the daemon-stop step in
+	// `kuke uninstall` looking at the wrong path.
 	transientFiles := []string{
 		filepath.Join(socketDir, "kukeond.sock"),
-		filepath.Join(runPath, "kukeond.pid"),
+		filepath.Join(socketDir, "kukeond.pid"),
 	}
 	for _, path := range transientFiles {
 		removed, removeErr := removeFileIfExists(path)

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -279,20 +279,21 @@ func TestDaemonReset(t *testing.T) {
 }
 
 // TestDaemonReset_RemovesSocketAndPidFiles confirms the cleanup step actually
-// removes /run/kukeon/kukeond.sock and /opt/kukeon/kukeond.pid (or the
-// per-test overrides) when both files are present.
+// removes /run/kukeon/kukeond.{sock,pid} (or the per-test overrides) when
+// both files are present.
 //
-// kukeond.sock lives under the socket dir (KUKEOND_SOCKET's parent) while
-// kukeond.pid is written under the run path by cmd/kukeond/serve.go — pinning
-// the pid removal to the socket dir was the silent #287 no-op that left the
-// daemon-stop step in `kuke uninstall` looking at the wrong path.
+// kukeond.sock and kukeond.pid both live under the socket dir (KUKEOND_SOCKET's
+// parent), matching the storage-layout.md design and cmd/kukeond/serve.go's
+// write path (filepath.Dir(--socket) + "kukeond.pid"). Pinning the pid removal
+// to the run path was the silent #287 no-op that left the daemon-stop step in
+// `kuke uninstall` looking at the wrong path.
 func TestDaemonReset_RemovesSocketAndPidFiles(t *testing.T) {
 	withFreshViper(t)
 
 	socketDir := t.TempDir()
 	runPath := t.TempDir()
 	sockPath := filepath.Join(socketDir, "kukeond.sock")
-	pidPath := filepath.Join(runPath, "kukeond.pid")
+	pidPath := filepath.Join(socketDir, "kukeond.pid")
 	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
 		t.Fatalf("seed sock file: %v", err)
 	}

--- a/cmd/kukeond/serve.go
+++ b/cmd/kukeond/serve.go
@@ -96,7 +96,7 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		SocketPath:        socketPath,
 		SocketMode:        socketMode,
 		SocketGID:         socketGID,
-		PIDFile:           filepath.Join(runPath, "kukeond.pid"),
+		PIDFile:           filepath.Join(filepath.Dir(socketPath), "kukeond.pid"),
 		ReconcileInterval: reconcileInterval,
 		Controller: controller.Options{
 			RunPath:          runPath,

--- a/internal/controller/uninstall.go
+++ b/internal/controller/uninstall.go
@@ -193,12 +193,14 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 	// PurgeRealm starts draining the kuke-system namespace.
 	//
 	// The default PID-file path mirrors cmd/kukeond/serve.go's write path —
-	// kukeond writes its PID to <runPath>/kukeond.pid, so reading from any
-	// other location turns this step into a silent no-op (the #287 regression
-	// the daemon-stop step from #195 was supposed to prevent).
+	// kukeond writes its PID to <socketDir>/kukeond.pid (sibling of the
+	// socket, per the storage-layout.md design "Sockets and pid files belong
+	// in /run"). Reading from any other location turns this step into a
+	// silent no-op (the #287 regression the daemon-stop step from #195 was
+	// supposed to prevent).
 	pidFile := opts.KukeondPIDFile
-	if pidFile == "" && b.opts.RunPath != "" {
-		pidFile = filepath.Join(b.opts.RunPath, "kukeond.pid")
+	if pidFile == "" && opts.SocketDir != "" {
+		pidFile = filepath.Join(opts.SocketDir, "kukeond.pid")
 	}
 	if pidFile != "" {
 		stopper := opts.DaemonStopper

--- a/internal/controller/uninstall_test.go
+++ b/internal/controller/uninstall_test.go
@@ -295,10 +295,11 @@ func TestUninstall_DaemonStopStep_PIDPresent(t *testing.T) {
 	tmpRunPath := t.TempDir()
 	tmpSocketDir := t.TempDir()
 
-	// Match the production write path (cmd/kukeond/serve.go:99): kukeond
-	// writes its PID to <runPath>/kukeond.pid. Putting the seed file under
-	// the socket dir is the #287 misconfiguration this test must not pin.
-	pidFilePath := filepath.Join(tmpRunPath, "kukeond.pid")
+	// Match the production write path (cmd/kukeond/serve.go): kukeond
+	// writes its PID to <socketDir>/kukeond.pid (sibling of the socket, per
+	// the storage-layout.md design). Putting the seed file under the run
+	// path is the #287 misconfiguration this test must not pin.
+	pidFilePath := filepath.Join(tmpSocketDir, "kukeond.pid")
 	if err := os.WriteFile(pidFilePath, []byte("12345\n"), 0o644); err != nil {
 		t.Fatalf("seed pid file: %v", err)
 	}
@@ -613,19 +614,22 @@ func equalStringSlices(a, b []string) bool {
 	return true
 }
 
-// TestUninstall_DefaultPIDFileResolvesToRunPath pins the controller's default
-// PID-file path against the production write path in cmd/kukeond/serve.go.
+// TestUninstall_DefaultPIDFileResolvesToSocketDir pins the controller's
+// default PID-file path against the production write path in
+// cmd/kukeond/serve.go.
 //
-// Issue #287: the daemon-stop step from #195 was a silent no-op because
-// Uninstall defaulted KukeondPIDFile to <socketDir>/kukeond.pid while kukeond
-// itself writes <runPath>/kukeond.pid. This test guards against either side
-// drifting again — it asserts the path the controller hands the stopper is
-// exactly filepath.Join(opts.RunPath, "kukeond.pid").
-func TestUninstall_DefaultPIDFileResolvesToRunPath(t *testing.T) {
+// kukeond writes its PID to <socketDir>/kukeond.pid (sibling of the socket),
+// matching the storage-layout.md design "Sockets and pid files belong in
+// /run". Issue #287 was the inverse misalignment — Uninstall used to default
+// to <socketDir>/kukeond.pid while kukeond wrote <runPath>/kukeond.pid; the
+// fix kept the two aligned. This test guards against either side drifting
+// again — it asserts the path the controller hands the stopper is exactly
+// filepath.Join(opts.SocketDir, "kukeond.pid").
+func TestUninstall_DefaultPIDFileResolvesToSocketDir(t *testing.T) {
 	tmpRunPath := t.TempDir()
 	tmpSocketDir := t.TempDir()
 
-	wantPIDFile := filepath.Join(tmpRunPath, "kukeond.pid")
+	wantPIDFile := filepath.Join(tmpSocketDir, "kukeond.pid")
 	var gotPIDFile string
 	stopper := func(_ context.Context, gotPidFile string, _ time.Duration) (controller.DaemonStopReport, error) {
 		gotPIDFile = gotPidFile
@@ -646,15 +650,15 @@ func TestUninstall_DefaultPIDFileResolvesToRunPath(t *testing.T) {
 
 	if gotPIDFile != wantPIDFile {
 		t.Errorf(
-			"default PID-file path mismatch:\n  controller passed: %q\n  cmd/kukeond/serve.go writes: <runPath>/kukeond.pid -> %q",
+			"default PID-file path mismatch:\n  controller passed: %q\n  cmd/kukeond/serve.go writes: <socketDir>/kukeond.pid -> %q",
 			gotPIDFile,
 			wantPIDFile,
 		)
 	}
-	if filepath.Dir(gotPIDFile) == tmpSocketDir {
+	if filepath.Dir(gotPIDFile) == tmpRunPath {
 		t.Errorf(
-			"controller defaulted PID file under socket dir %q — that is the #287 regression",
-			tmpSocketDir,
+			"controller defaulted PID file under run path %q — that is the #287 regression",
+			tmpRunPath,
 		)
 	}
 }


### PR DESCRIPTION
## Summary

- `kukeond serve` now writes `kukeond.pid` under the socket dir (`filepath.Dir(--socket)`, default `/run/kukeon`) instead of under `--run-path` (`/opt/kukeon`). This restores the documented invariant in `docs/cli-use-cases.md` ("Initialize a new host" / "Lightweight teardown") and aligns with the architectural rationale in `docs/site/architecture/storage-layout.md` ("Sockets and pid files belong in `/run`" — `/opt/kukeon` is for persistent state, `/run` is tmpfs).
- `kuke daemon reset` and `controller.Uninstall` were updated symmetrically so the daemon-stop step (`#287`) keeps reading where kukeond writes. Tests `TestUninstall_DefaultPIDFileResolvesToRunPath` → `…ResolvesToSocketDir`, `TestUninstall_DaemonStopStep_PIDPresent`, and `TestDaemonReset_RemovesSocketAndPidFiles` updated to pin the new path.

## Option choice (per `docs/cli-use-cases.md` line 32 ACs)

Picked **Option A — code follows doc** rather than Option B because the architecture-rationale section of `storage-layout.md` already explicitly defines this design, and 7 other doc files (`storage-layout.md`, `process-model.md`, `prerequisites.md`, `system-realm.md`, `build-from-source.md`, `faq.md`, `cli/kukeond.md`) already document `/run/kukeon/kukeond.pid`. Option B would have required contradicting the FHS/tmpfs rationale and updating all 8 files. Code-side blast radius (3 files + 3 tests, no behavioral change visible to operators) is the lower-radius default. Happy to flip to Option B if the reviewer disagrees.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full suite green
- [x] `pre-commit run --files <changed files>` — all hooks pass
- [x] `make dev-init` smoke — fresh re-bootstrap; pidfile lands at `/run/kukeon/kukeond.pid` (was `/opt/kukeon/kukeond.pid`); daemon-parity check shows both realms `Ready` from both `kuke get realms` and `kuke get realms --no-daemon`
- [x] `sudo ./kuke daemon reset` after init — both `/run/kukeon/kukeond.sock` and `/run/kukeon/kukeond.pid` removed (only `tty/` remains under `/run/kukeon`)

Closes #467