### PR TITLE
fix: kuke run -f refuses on-disk spec divergent from file

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -587,7 +587,8 @@ func divergedFields(actual, desired v1beta1.CellSpec) []string {
 // fill in or normalize at create/start time (so a fresh cell never
 // false-flags on the next `kuke run -f` of the same file): image, command,
 // args, workingDir, env, ports, volumes, networks, networksAliases,
-// privileged, hostNetwork, hostPID, hostCgroup, attachable, restartPolicy.
+// privileged, hostNetwork, hostPID, hostCgroup, attachable, restartPolicy,
+// secrets, tty.
 // Fields that inherit from `space.spec.defaults.container` (see
 // internal/modelhub.ApplySpaceDefaultsToContainer) are deliberately
 // excluded — their on-disk value is post-merge while the YAML side is
@@ -639,7 +640,59 @@ func divergedContainerFields(actual, desired v1beta1.ContainerSpec) []string {
 	if actual.RestartPolicy != desired.RestartPolicy {
 		fields = append(fields, "restartPolicy")
 	}
+	if !containerSecretsEqual(actual.Secrets, desired.Secrets) {
+		fields = append(fields, "secrets")
+	}
+	if !containerTtysEqual(actual.Tty, desired.Tty) {
+		fields = append(fields, "tty")
+	}
 	return fields
+}
+
+// containerSecretsEqual compares two ContainerSecret slices field-by-field.
+// nil and empty are treated as equal so YAML that omits secrets does not
+// register as drift against on-disk metadata that persisted it as nil.
+// ContainerSecret carries only scalar string fields, so a direct == on each
+// element is enough.
+func containerSecretsEqual(a, b []v1beta1.ContainerSecret) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// containerTtysEqual compares two ContainerTty pointers. Empty values on
+// either side are treated as equal because
+// internal/apischeme.convertContainerTtyToInternal normalizes an IsEmpty
+// input to nil at persistence: on-disk Tty=nil and a YAML carrying an
+// otherwise-empty &ContainerTty{} must not register as drift.
+func containerTtysEqual(a, b *v1beta1.ContainerTty) bool {
+	if a.IsEmpty() && b.IsEmpty() {
+		return true
+	}
+	if a.IsEmpty() != b.IsEmpty() {
+		return false
+	}
+	if a.Prompt != b.Prompt ||
+		a.LogFile != b.LogFile ||
+		a.Profile != b.Profile ||
+		a.ProfilesDir != b.ProfilesDir {
+		return false
+	}
+	if len(a.OnInit) != len(b.OnInit) {
+		return false
+	}
+	for i := range a.OnInit {
+		if a.OnInit[i] != b.OnInit[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // stringSlicesEqual reports whether two []string carry the same elements

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -508,15 +508,14 @@ func pickLocation(fromDoc string, kv *config.Var) string {
 	return strings.TrimSpace(kv.ValueOrDefault())
 }
 
-// divergedFields names the structural fields where the on-disk cell disagrees
-// with the file. We deliberately stop at structural identity (container count,
-// container id set, root container id, cell location) and do NOT compare
-// images/args/env: the runner normalizes container images on create
-// (auto-default root rewrites e.g. user-supplied image to docker.io/library/
-// busybox:latest), so a deep field-by-field diff would flag a freshly-created
-// cell as divergent on the very next `kuke run -f` invocation. Per the AC, a
-// genuine spec rewrite — adding/removing containers, swapping the root, moving
-// realm/space/stack — must route through `kuke apply -f` instead.
+// divergedFields names the fields where the on-disk cell disagrees with the
+// file. The check covers structural identity (container count, container id
+// set, cell location) and the operator-controlled per-container fields the
+// runner does NOT rewrite at create time (image, command, args, env, ports,
+// volumes, networks, host-namespace opts, privileged, attachable,
+// restartPolicy, workingDir). Per the AC for issue #468, a genuine spec
+// rewrite — including an image swap — must route through `kuke apply -f`
+// instead of silently no-opping under `kuke run -f`.
 //
 // Root containers are filtered out of the count/id-set comparison on both
 // sides. The runner synthesizes a root container during create if the YAML
@@ -526,6 +525,15 @@ func pickLocation(fromDoc string, kv *config.Var) string {
 // `kuke apply -f` even though nothing changed. Comparing only the
 // user-supplied (non-root) entries restores the idempotent path while still
 // catching real adds/removes/renames among the user containers.
+//
+// Fields filled in by the runner from `space.spec.defaults.container`
+// (user, readOnlyRootFilesystem, capabilities, securityOpts, tmpfs,
+// resources) are deliberately excluded from the per-container check: a
+// YAML that omits them would be filled in on create and then compare
+// non-equal on the next `run` against the same file, false-flagging the
+// idempotent path. Those fields still drive divergence detection on
+// `kuke apply -f`, which has the on-disk + post-merge view; `run` stops
+// at the user-authored surface.
 func divergedFields(actual, desired v1beta1.CellSpec) []string {
 	var diffs []string
 
@@ -567,8 +575,102 @@ func divergedFields(actual, desired v1beta1.CellSpec) []string {
 		if ac.Root != dc.Root {
 			diffs = append(diffs, fmt.Sprintf("spec.containers[%q].root", ac.ID))
 		}
+		for _, field := range divergedContainerFields(ac, dc) {
+			diffs = append(diffs, fmt.Sprintf("spec.containers[%q].%s", ac.ID, field))
+		}
 	}
 	return diffs
+}
+
+// divergedContainerFields returns the user-authored container fields where
+// actual disagrees with desired. Restricted to fields the runner does NOT
+// fill in or normalize at create/start time (so a fresh cell never
+// false-flags on the next `kuke run -f` of the same file): image, command,
+// args, workingDir, env, ports, volumes, networks, networksAliases,
+// privileged, hostNetwork, hostPID, hostCgroup, attachable, restartPolicy.
+// Fields that inherit from `space.spec.defaults.container` (see
+// internal/modelhub.ApplySpaceDefaultsToContainer) are deliberately
+// excluded — their on-disk value is post-merge while the YAML side is
+// pre-merge, so comparing them would always trip on a default-using YAML.
+func divergedContainerFields(actual, desired v1beta1.ContainerSpec) []string {
+	var fields []string
+	if actual.Image != desired.Image {
+		fields = append(fields, "image")
+	}
+	if actual.Command != desired.Command {
+		fields = append(fields, "command")
+	}
+	if !stringSlicesEqual(actual.Args, desired.Args) {
+		fields = append(fields, "args")
+	}
+	if actual.WorkingDir != desired.WorkingDir {
+		fields = append(fields, "workingDir")
+	}
+	if !stringSlicesEqual(actual.Env, desired.Env) {
+		fields = append(fields, "env")
+	}
+	if !stringSlicesEqual(actual.Ports, desired.Ports) {
+		fields = append(fields, "ports")
+	}
+	if !volumeMountsEqual(actual.Volumes, desired.Volumes) {
+		fields = append(fields, "volumes")
+	}
+	if !stringSlicesEqual(actual.Networks, desired.Networks) {
+		fields = append(fields, "networks")
+	}
+	if !stringSlicesEqual(actual.NetworksAliases, desired.NetworksAliases) {
+		fields = append(fields, "networksAliases")
+	}
+	if actual.Privileged != desired.Privileged {
+		fields = append(fields, "privileged")
+	}
+	if actual.HostNetwork != desired.HostNetwork {
+		fields = append(fields, "hostNetwork")
+	}
+	if actual.HostPID != desired.HostPID {
+		fields = append(fields, "hostPID")
+	}
+	if actual.HostCgroup != desired.HostCgroup {
+		fields = append(fields, "hostCgroup")
+	}
+	if actual.Attachable != desired.Attachable {
+		fields = append(fields, "attachable")
+	}
+	if actual.RestartPolicy != desired.RestartPolicy {
+		fields = append(fields, "restartPolicy")
+	}
+	return fields
+}
+
+// stringSlicesEqual reports whether two []string carry the same elements
+// in the same order. nil and empty are treated as equal so YAML that
+// omits an optional list does not register as drift against on-disk
+// metadata that persisted it as an empty array.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// volumeMountsEqual compares two VolumeMount slices field-by-field. The
+// VolumeMount struct has no slice/map fields, so a direct == on each
+// element is enough.
+func volumeMountsEqual(a, b []v1beta1.VolumeMount) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // nonRootContainers returns the user-supplied subset of cs — entries where

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -431,8 +431,19 @@ func TestRun_ExistingCell_MatchingSpec_AlreadyReady_ShortCircuits(t *testing.T) 
 			SpaceID: "my-space",
 			StackID: "my-stack",
 			Containers: []v1beta1.ContainerSpec{
-				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
 			},
 		},
 		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
@@ -474,8 +485,19 @@ func TestRun_ExistingCell_MatchingSpec_NotReady_StillEnsures(t *testing.T) {
 			SpaceID: "my-space",
 			StackID: "my-stack",
 			Containers: []v1beta1.ContainerSpec{
-				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
 			},
 		},
 		Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
@@ -528,8 +550,19 @@ func TestRun_ExistingCell_SynthesizedRoot_DoesNotDiverge(t *testing.T) {
 			SpaceID: "my-space",
 			StackID: "my-stack",
 			Containers: []v1beta1.ContainerSpec{
-				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "web", Image: "registry.eminwux.com/busybox:latest"},
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "web",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
 			},
 		},
 		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
@@ -607,9 +640,7 @@ func TestRun_ExistingCell_DivergingContainerSet_RefusesAndPointsToApply(t *testi
 
 	// On-disk cell has an extra container the file does not declare. This is
 	// the structural drift (container set / count) the AC routes through
-	// `kuke apply -f`. We deliberately do NOT compare container images/env —
-	// the runner rewrites those during create, so a deep diff would flag a
-	// fresh cell as divergent on the next run.
+	// `kuke apply -f`.
 	existing := v1beta1.CellDoc{
 		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
 		Spec: v1beta1.CellSpec{
@@ -617,9 +648,25 @@ func TestRun_ExistingCell_DivergingContainerSet_RefusesAndPointsToApply(t *testi
 			SpaceID: "my-space",
 			StackID: "my-stack",
 			Containers: []v1beta1.ContainerSpec{
-				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "work", Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "extra", Image: "registry.eminwux.com/busybox:latest"},
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "extra",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
 			},
 		},
 	}
@@ -640,6 +687,71 @@ func TestRun_ExistingCell_DivergingContainerSet_RefusesAndPointsToApply(t *testi
 	}
 	if !strings.Contains(err.Error(), "spec.containers (count:") {
 		t.Errorf("err=%q does not name the diverging field", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (must not mutate on divergence)", fc.createCalls)
+	}
+}
+
+// TestRun_ExistingCell_DivergingContainerImage_RefusesAndPointsToApply covers
+// the issue #468 case: on-disk cell has the same container set as the file
+// but the user-supplied container's image differs (busybox:latest on disk
+// vs busybox:musl in the file). `kuke run -f` must refuse with the
+// diverging-spec error and not mutate the cell, matching the
+// `docs/cli-use-cases.md` invariant for `kuke run -f` against a divergent
+// on-disk spec.
+func TestRun_ExistingCell_DivergingContainerImage_RefusesAndPointsToApply(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:musl",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                existing,
+				MetadataExists:      true,
+				CgroupExists:        true,
+				RootContainerExists: true,
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want divergence error for image change")
+	}
+	if !strings.Contains(err.Error(), `cell "my-cell" exists with diverging spec`) {
+		t.Errorf("err=%q does not contain the diverging-spec phrase naming the cell", err)
+	}
+	if !strings.Contains(err.Error(), "kuke apply -f") {
+		t.Errorf("err=%q does not refer the operator to `kuke apply -f`", err)
+	}
+	if !strings.Contains(err.Error(), `spec.containers["work"].image`) {
+		t.Errorf("err=%q does not name the diverging image field on the user container", err)
 	}
 	if fc.createCalls != 0 {
 		t.Errorf("CreateCell calls=%d want 0 (must not mutate on divergence)", fc.createCalls)
@@ -1149,9 +1261,27 @@ func TestRun_Attach_AlreadyReady_ShortCircuitThenAttaches(t *testing.T) {
 			StackID: "my-stack",
 			Tty:     &v1beta1.CellTty{Default: "claude"},
 			Containers: []v1beta1.ContainerSpec{
-				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "shell", Attachable: true, Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "claude", Attachable: true, Image: "registry.eminwux.com/busybox:latest"},
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:         "shell",
+					Attachable: true,
+					Image:      "registry.eminwux.com/busybox:latest",
+					Command:    "sleep",
+					Args:       []string{"3600"},
+				},
+				{
+					ID:         "claude",
+					Attachable: true,
+					Image:      "registry.eminwux.com/busybox:latest",
+					Command:    "sleep",
+					Args:       []string{"3600"},
+				},
 			},
 		},
 		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
@@ -1770,9 +1900,27 @@ func TestRun_RmAttach_AlreadyReady_StillKillsCellOnPeerClosed(t *testing.T) {
 			StackID: "my-stack",
 			Tty:     &v1beta1.CellTty{Default: "claude"},
 			Containers: []v1beta1.ContainerSpec{
-				{ID: "root", Root: true, Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "shell", Attachable: true, Image: "registry.eminwux.com/busybox:latest"},
-				{ID: "claude", Attachable: true, Image: "registry.eminwux.com/busybox:latest"},
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:         "shell",
+					Attachable: true,
+					Image:      "registry.eminwux.com/busybox:latest",
+					Command:    "sleep",
+					Args:       []string{"3600"},
+				},
+				{
+					ID:         "claude",
+					Attachable: true,
+					Image:      "registry.eminwux.com/busybox:latest",
+					Command:    "sleep",
+					Args:       []string{"3600"},
+				},
 			},
 		},
 		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -758,6 +758,147 @@ func TestRun_ExistingCell_DivergingContainerImage_RefusesAndPointsToApply(t *tes
 	}
 }
 
+// TestRun_ExistingCell_DivergingContainerSecrets_RefusesAndPointsToApply
+// exercises the secrets branch of divergedContainerFields. Secrets is
+// user-authored, persisted to disk unchanged (apischeme round-trips it
+// verbatim), and not filled in from `space.spec.defaults.container` — so
+// the same no-op-on-drift failure mode that #468 closes for image applies.
+func TestRun_ExistingCell_DivergingContainerSecrets_RefusesAndPointsToApply(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+					Secrets: []v1beta1.ContainerSecret{
+						{Name: "db-pass", FromFile: "/etc/kukeon/secrets/db-pass"},
+					},
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                existing,
+				MetadataExists:      true,
+				CgroupExists:        true,
+				RootContainerExists: true,
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want divergence error for secrets change")
+	}
+	if !strings.Contains(err.Error(), `cell "my-cell" exists with diverging spec`) {
+		t.Errorf("err=%q does not contain the diverging-spec phrase naming the cell", err)
+	}
+	if !strings.Contains(err.Error(), "kuke apply -f") {
+		t.Errorf("err=%q does not refer the operator to `kuke apply -f`", err)
+	}
+	if !strings.Contains(err.Error(), `spec.containers["work"].secrets`) {
+		t.Errorf("err=%q does not name the diverging secrets field on the user container", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (must not mutate on divergence)", fc.createCalls)
+	}
+}
+
+// TestRun_ExistingCell_DivergingContainerTty_RefusesAndPointsToApply
+// exercises the tty branch of divergedContainerFields. ContainerTty is
+// user-authored shell-UX config the daemon persists verbatim and never
+// fills in from space defaults, so a drift here would silently skip the
+// configured prompt/profile/onInit on `kuke run -f` re-runs.
+func TestRun_ExistingCell_DivergingContainerTty_RefusesAndPointsToApply(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Tty:     &v1beta1.CellTty{Default: "claude"},
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:         "shell",
+					Attachable: true,
+					Image:      "registry.eminwux.com/busybox:latest",
+					Command:    "sleep",
+					Args:       []string{"3600"},
+				},
+				{
+					ID:         "claude",
+					Attachable: true,
+					Image:      "registry.eminwux.com/busybox:latest",
+					Command:    "sleep",
+					Args:       []string{"3600"},
+					Tty: &v1beta1.ContainerTty{
+						Prompt: `claude> `,
+					},
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                existing,
+				MetadataExists:      true,
+				CgroupExists:        true,
+				RootContainerExists: true,
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML), "-d"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want divergence error for tty change")
+	}
+	if !strings.Contains(err.Error(), `cell "my-cell" exists with diverging spec`) {
+		t.Errorf("err=%q does not contain the diverging-spec phrase naming the cell", err)
+	}
+	if !strings.Contains(err.Error(), "kuke apply -f") {
+		t.Errorf("err=%q does not refer the operator to `kuke apply -f`", err)
+	}
+	if !strings.Contains(err.Error(), `spec.containers["claude"].tty`) {
+		t.Errorf("err=%q does not name the diverging tty field on the user container", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (must not mutate on divergence)", fc.createCalls)
+	}
+}
+
 func TestRun_OutputJSON(t *testing.T) {
 	t.Cleanup(viper.Reset)
 


### PR DESCRIPTION
## Summary

- `kuke run -f` previously only diffed structural identity (container count, container id set, root flag, cell location) against the on-disk metadata, so a divergent **container image** — the headline case in #468 — slipped through and the CLI silently no-opped with exit 0. The `docs/cli-use-cases.md` invariants require refusal with a non-zero exit and a pointer to `kuke apply -f`.
- Extends `divergedFields` to also compare per-container user-authored fields the runner does NOT rewrite at create time: `image`, `command`, `args`, `workingDir`, `env`, `ports`, `volumes`, `networks`, `networksAliases`, `privileged`, `hostNetwork`, `hostPID`, `hostCgroup`, `attachable`, `restartPolicy`, `secrets`, `tty`.
- Deliberately excludes fields inherited from `space.spec.defaults.container` (user, readOnlyRootFilesystem, capabilities, securityOpts, tmpfs, resources). Their on-disk value is post-merge while the YAML side is pre-merge, so comparing them would false-flag a default-using YAML on every re-run.
- Updates fixtures in the existing idempotent / matching-spec / synthesized-root tests so they reflect what an on-disk cell created from the YAML actually looks like (command/args persisted, not stripped).
- Adds `TestRun_ExistingCell_DivergingContainerImage_RefusesAndPointsToApply` covering the bug from the issue body verbatim (busybox:latest on disk vs busybox:musl in file), plus matching regression tests for `secrets` and `tty` divergence.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/kuke/run/...` — new divergent-image/secrets/tty tests plus updated fixtures all pass
- [x] `make test` — full unit suite green
- [x] `pre-commit run --files cmd/kuke/run/run.go cmd/kuke/run/run_test.go` — all hooks pass (golangci-lint, gofmt, addlicense, etc.)
- [ ] \`make dev-init\` — not run; change is purely in \`cmd/kuke/run/\` and does not touch the build path, the daemon, or \`/opt/kukeon\`, so the daemon-parity smoke test is out of scope per \`CLAUDE.md\`.

Closes #468