### PR TITLE
fix: serialize state enums as string labels in yaml/json

### DIFF
--- a/pkg/api/model/v1beta1/realm.go
+++ b/pkg/api/model/v1beta1/realm.go
@@ -48,7 +48,7 @@ type RegistryCredentials struct {
 }
 
 type RealmStatus struct {
-	State      RealmState `json:"state"`
+	State      RealmState `json:"state"                              yaml:"state"`
 	CgroupPath string     `json:"cgroupPath,omitempty"         yaml:"cgroupPath,omitempty"`
 	// SubtreeControllers is the cgroup-v2 controller set actually
 	// delegated on this realm's own cgroup.subtree_control after the

--- a/pkg/api/model/v1beta1/state_marshal.go
+++ b/pkg/api/model/v1beta1/state_marshal.go
@@ -1,0 +1,355 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+// JSON/YAML marshaling for the *State enum types. The serializers emit the
+// human-readable label (`Ready`, `Pending`, …) instead of the raw int form
+// that the encoding/json and gopkg.in/yaml.v3 defaults would produce.
+// Unmarshal accepts both forms — string is canonical going forward, int is
+// retained for one release so older on-disk metadata.json files persisted by
+// pre-fix daemons still round-trip through `kuke get -o yaml | kuke apply`.
+// Issue #474.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+// yamlIntTag is the auto-resolved gopkg.in/yaml.v3 tag for an unquoted
+// integer scalar — the legacy on-disk encoding for state fields the
+// UnmarshalYAML methods accept for back-compat.
+const yamlIntTag = "!!int"
+
+// --- RealmState ---
+
+func (s RealmState) MarshalJSON() ([]byte, error) {
+	return json.Marshal((&s).String())
+}
+
+func (s RealmState) MarshalYAML() (interface{}, error) {
+	return (&s).String(), nil
+}
+
+func (s *RealmState) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		return parseRealmState(str, s)
+	}
+	var i int
+	if err := json.Unmarshal(data, &i); err != nil {
+		return fmt.Errorf("realm state: expected string or int, got %s", string(data))
+	}
+	return assignRealmStateInt(i, s)
+}
+
+func (s *RealmState) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("realm state: expected scalar, got %v", node.Kind)
+	}
+	if node.Tag == yamlIntTag {
+		i, err := strconv.Atoi(node.Value)
+		if err != nil {
+			return fmt.Errorf("realm state: %w", err)
+		}
+		return assignRealmStateInt(i, s)
+	}
+	return parseRealmState(node.Value, s)
+}
+
+func parseRealmState(in string, out *RealmState) error {
+	switch in {
+	case StatePendingStr:
+		*out = RealmStatePending
+	case StateCreatingStr:
+		*out = RealmStateCreating
+	case StateReadyStr:
+		*out = RealmStateReady
+	case StateDeletingStr:
+		*out = RealmStateDeleting
+	case StateFailedStr:
+		*out = RealmStateFailed
+	case StateUnknownStr:
+		*out = RealmStateUnknown
+	default:
+		return fmt.Errorf("realm state: unknown label %q", in)
+	}
+	return nil
+}
+
+func assignRealmStateInt(i int, out *RealmState) error {
+	v := RealmState(i)
+	if v < RealmStatePending || v > RealmStateUnknown {
+		return fmt.Errorf("realm state: int %d out of range", i)
+	}
+	*out = v
+	return nil
+}
+
+// --- SpaceState ---
+
+func (s SpaceState) MarshalJSON() ([]byte, error) {
+	return json.Marshal((&s).String())
+}
+
+func (s SpaceState) MarshalYAML() (interface{}, error) {
+	return (&s).String(), nil
+}
+
+func (s *SpaceState) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		return parseSpaceState(str, s)
+	}
+	var i int
+	if err := json.Unmarshal(data, &i); err != nil {
+		return fmt.Errorf("space state: expected string or int, got %s", string(data))
+	}
+	return assignSpaceStateInt(i, s)
+}
+
+func (s *SpaceState) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("space state: expected scalar, got %v", node.Kind)
+	}
+	if node.Tag == yamlIntTag {
+		i, err := strconv.Atoi(node.Value)
+		if err != nil {
+			return fmt.Errorf("space state: %w", err)
+		}
+		return assignSpaceStateInt(i, s)
+	}
+	return parseSpaceState(node.Value, s)
+}
+
+func parseSpaceState(in string, out *SpaceState) error {
+	switch in {
+	case StatePendingStr:
+		*out = SpaceStatePending
+	case StateReadyStr:
+		*out = SpaceStateReady
+	case StateFailedStr:
+		*out = SpaceStateFailed
+	case StateUnknownStr:
+		*out = SpaceStateUnknown
+	default:
+		return fmt.Errorf("space state: unknown label %q", in)
+	}
+	return nil
+}
+
+func assignSpaceStateInt(i int, out *SpaceState) error {
+	v := SpaceState(i)
+	if v < SpaceStatePending || v > SpaceStateUnknown {
+		return fmt.Errorf("space state: int %d out of range", i)
+	}
+	*out = v
+	return nil
+}
+
+// --- StackState ---
+
+func (s StackState) MarshalJSON() ([]byte, error) {
+	return json.Marshal((&s).String())
+}
+
+func (s StackState) MarshalYAML() (interface{}, error) {
+	return (&s).String(), nil
+}
+
+func (s *StackState) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		return parseStackState(str, s)
+	}
+	var i int
+	if err := json.Unmarshal(data, &i); err != nil {
+		return fmt.Errorf("stack state: expected string or int, got %s", string(data))
+	}
+	return assignStackStateInt(i, s)
+}
+
+func (s *StackState) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("stack state: expected scalar, got %v", node.Kind)
+	}
+	if node.Tag == yamlIntTag {
+		i, err := strconv.Atoi(node.Value)
+		if err != nil {
+			return fmt.Errorf("stack state: %w", err)
+		}
+		return assignStackStateInt(i, s)
+	}
+	return parseStackState(node.Value, s)
+}
+
+func parseStackState(in string, out *StackState) error {
+	switch in {
+	case StatePendingStr:
+		*out = StackStatePending
+	case StateReadyStr:
+		*out = StackStateReady
+	case StateFailedStr:
+		*out = StackStateFailed
+	case StateUnknownStr:
+		*out = StackStateUnknown
+	default:
+		return fmt.Errorf("stack state: unknown label %q", in)
+	}
+	return nil
+}
+
+func assignStackStateInt(i int, out *StackState) error {
+	v := StackState(i)
+	if v < StackStatePending || v > StackStateUnknown {
+		return fmt.Errorf("stack state: int %d out of range", i)
+	}
+	*out = v
+	return nil
+}
+
+// --- CellState ---
+
+func (s CellState) MarshalJSON() ([]byte, error) {
+	return json.Marshal((&s).String())
+}
+
+func (s CellState) MarshalYAML() (interface{}, error) {
+	return (&s).String(), nil
+}
+
+func (s *CellState) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		return parseCellState(str, s)
+	}
+	var i int
+	if err := json.Unmarshal(data, &i); err != nil {
+		return fmt.Errorf("cell state: expected string or int, got %s", string(data))
+	}
+	return assignCellStateInt(i, s)
+}
+
+func (s *CellState) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("cell state: expected scalar, got %v", node.Kind)
+	}
+	if node.Tag == yamlIntTag {
+		i, err := strconv.Atoi(node.Value)
+		if err != nil {
+			return fmt.Errorf("cell state: %w", err)
+		}
+		return assignCellStateInt(i, s)
+	}
+	return parseCellState(node.Value, s)
+}
+
+func parseCellState(in string, out *CellState) error {
+	switch in {
+	case StatePendingStr:
+		*out = CellStatePending
+	case StateReadyStr:
+		*out = CellStateReady
+	case StateStoppedStr:
+		*out = CellStateStopped
+	case StateFailedStr:
+		*out = CellStateFailed
+	case StateUnknownStr:
+		*out = CellStateUnknown
+	default:
+		return fmt.Errorf("cell state: unknown label %q", in)
+	}
+	return nil
+}
+
+func assignCellStateInt(i int, out *CellState) error {
+	v := CellState(i)
+	if v < CellStatePending || v > CellStateUnknown {
+		return fmt.Errorf("cell state: int %d out of range", i)
+	}
+	*out = v
+	return nil
+}
+
+// --- ContainerState ---
+
+func (s ContainerState) MarshalJSON() ([]byte, error) {
+	return json.Marshal((&s).String())
+}
+
+func (s ContainerState) MarshalYAML() (interface{}, error) {
+	return (&s).String(), nil
+}
+
+func (s *ContainerState) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		return parseContainerState(str, s)
+	}
+	var i int
+	if err := json.Unmarshal(data, &i); err != nil {
+		return fmt.Errorf("container state: expected string or int, got %s", string(data))
+	}
+	return assignContainerStateInt(i, s)
+}
+
+func (s *ContainerState) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.ScalarNode {
+		return fmt.Errorf("container state: expected scalar, got %v", node.Kind)
+	}
+	if node.Tag == yamlIntTag {
+		i, err := strconv.Atoi(node.Value)
+		if err != nil {
+			return fmt.Errorf("container state: %w", err)
+		}
+		return assignContainerStateInt(i, s)
+	}
+	return parseContainerState(node.Value, s)
+}
+
+func parseContainerState(in string, out *ContainerState) error {
+	switch in {
+	case StatePendingStr:
+		*out = ContainerStatePending
+	case StateReadyStr:
+		*out = ContainerStateReady
+	case StateStoppedStr:
+		*out = ContainerStateStopped
+	case StatePausedStr:
+		*out = ContainerStatePaused
+	case StatePausingStr:
+		*out = ContainerStatePausing
+	case StateFailedStr:
+		*out = ContainerStateFailed
+	case StateUnknownStr:
+		*out = ContainerStateUnknown
+	default:
+		return fmt.Errorf("container state: unknown label %q", in)
+	}
+	return nil
+}
+
+func assignContainerStateInt(i int, out *ContainerState) error {
+	v := ContainerState(i)
+	if v < ContainerStatePending || v > ContainerStateUnknown {
+		return fmt.Errorf("container state: int %d out of range", i)
+	}
+	*out = v
+	return nil
+}

--- a/pkg/api/model/v1beta1/state_marshal_test.go
+++ b/pkg/api/model/v1beta1/state_marshal_test.go
@@ -1,0 +1,261 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestRealmState_MarshalJSON_EmitsString pins the bug-#474 fix for `kuke get
+// realm -o json`. The on-disk integer (`2`) must surface as the human-readable
+// label (`"Ready"`) so operators scripting against the JSON don't have to grep
+// the source for the enum.
+func TestRealmState_MarshalJSON_EmitsString(t *testing.T) {
+	for _, tc := range []struct {
+		in   RealmState
+		want string
+	}{
+		{RealmStatePending, `"Pending"`},
+		{RealmStateCreating, `"Creating"`},
+		{RealmStateReady, `"Ready"`},
+		{RealmStateDeleting, `"Deleting"`},
+		{RealmStateFailed, `"Failed"`},
+		{RealmStateUnknown, `"Unknown"`},
+	} {
+		got, err := json.Marshal(tc.in)
+		if err != nil {
+			t.Fatalf("MarshalJSON(%v) errored: %v", tc.in, err)
+		}
+		if string(got) != tc.want {
+			t.Errorf("MarshalJSON(%v) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRealmState_MarshalYAML_EmitsString(t *testing.T) {
+	doc := RealmDoc{Status: RealmStatus{State: RealmStateReady}}
+	out, err := yaml.Marshal(doc)
+	if err != nil {
+		t.Fatalf("yaml.Marshal errored: %v", err)
+	}
+	if !strings.Contains(string(out), "state: Ready") {
+		t.Errorf("yaml output missing `state: Ready`:\n%s", out)
+	}
+	if strings.Contains(string(out), "state: 2") {
+		t.Errorf("yaml output still has int form:\n%s", out)
+	}
+}
+
+// TestRealmState_UnmarshalJSON_AcceptsBothForms verifies the back-compat aid:
+// daemon-persisted metadata.json from before this fix carries int state and
+// must still parse on a newer daemon. Issue #474 ACs.
+func TestRealmState_UnmarshalJSON_AcceptsBothForms(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want RealmState
+	}{
+		{"string form", `"Ready"`, RealmStateReady},
+		{"int form (legacy)", `2`, RealmStateReady},
+		{"int form pending", `0`, RealmStatePending},
+		{"int form unknown", `5`, RealmStateUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got RealmState
+			if err := json.Unmarshal([]byte(tc.in), &got); err != nil {
+				t.Fatalf("UnmarshalJSON(%s) errored: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("UnmarshalJSON(%s) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRealmState_UnmarshalJSON_Rejects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+	}{
+		{"unknown label", `"PartyTime"`},
+		{"int out of range high", `99`},
+		{"int out of range negative", `-1`},
+		{"not a scalar", `{"x":1}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got RealmState
+			if err := json.Unmarshal([]byte(tc.in), &got); err == nil {
+				t.Errorf("UnmarshalJSON(%s) succeeded with %v, want error", tc.in, got)
+			}
+		})
+	}
+}
+
+func TestRealmState_UnmarshalYAML_AcceptsBothForms(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want RealmState
+	}{
+		{"string form", `Ready`, RealmStateReady},
+		{"string form quoted", `"Ready"`, RealmStateReady},
+		{"int form (legacy)", `2`, RealmStateReady},
+		{"int form pending", `0`, RealmStatePending},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got RealmState
+			if err := yaml.Unmarshal([]byte(tc.in), &got); err != nil {
+				t.Fatalf("UnmarshalYAML(%s) errored: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("UnmarshalYAML(%s) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRealmDoc_RoundTrip is the AC verifying a YAML output piped back through
+// `kuke apply -f` succeeds: marshal a realm, unmarshal it, and confirm the
+// state survives intact (no `state: 2` schema error).
+func TestRealmDoc_RoundTrip(t *testing.T) {
+	in := RealmDoc{
+		APIVersion: APIVersionV1Beta1,
+		Kind:       KindRealm,
+		Metadata:   RealmMetadata{Name: "default"},
+		Spec:       RealmSpec{Namespace: "default.kukeon.io"},
+		Status:     RealmStatus{State: RealmStateReady, CgroupPath: "/kukeon/default"},
+	}
+
+	t.Run("yaml", func(t *testing.T) {
+		out, marshalErr := yaml.Marshal(in)
+		if marshalErr != nil {
+			t.Fatalf("yaml.Marshal: %v", marshalErr)
+		}
+		var back RealmDoc
+		if unmarshalErr := yaml.Unmarshal(out, &back); unmarshalErr != nil {
+			t.Fatalf("yaml.Unmarshal: %v\noutput:\n%s", unmarshalErr, out)
+		}
+		if back.Status.State != RealmStateReady {
+			t.Errorf("round-trip state = %v, want Ready", back.Status.State)
+		}
+	})
+
+	t.Run("json", func(t *testing.T) {
+		out, marshalErr := json.Marshal(in)
+		if marshalErr != nil {
+			t.Fatalf("json.Marshal: %v", marshalErr)
+		}
+		var back RealmDoc
+		if unmarshalErr := json.Unmarshal(out, &back); unmarshalErr != nil {
+			t.Fatalf("json.Unmarshal: %v\noutput: %s", unmarshalErr, out)
+		}
+		if back.Status.State != RealmStateReady {
+			t.Errorf("round-trip state = %v, want Ready", back.Status.State)
+		}
+	})
+}
+
+// The remaining four state types share the same marshal pattern; a per-type
+// "string label round-trips" check is enough to catch a misconfigured switch
+// without re-enumerating every error path.
+
+func TestSpaceState_StringRoundTrip(t *testing.T) {
+	for _, s := range []SpaceState{SpaceStatePending, SpaceStateReady, SpaceStateFailed, SpaceStateUnknown} {
+		out, marshalErr := json.Marshal(s)
+		if marshalErr != nil {
+			t.Fatalf("json.Marshal(%v): %v", s, marshalErr)
+		}
+		var back SpaceState
+		if unmarshalErr := json.Unmarshal(out, &back); unmarshalErr != nil {
+			t.Fatalf("json.Unmarshal(%s): %v", out, unmarshalErr)
+		}
+		if back != s {
+			t.Errorf("round-trip space %v -> %s -> %v", s, out, back)
+		}
+	}
+}
+
+func TestStackState_StringRoundTrip(t *testing.T) {
+	for _, s := range []StackState{StackStatePending, StackStateReady, StackStateFailed, StackStateUnknown} {
+		out, marshalErr := json.Marshal(s)
+		if marshalErr != nil {
+			t.Fatalf("json.Marshal(%v): %v", s, marshalErr)
+		}
+		var back StackState
+		if unmarshalErr := json.Unmarshal(out, &back); unmarshalErr != nil {
+			t.Fatalf("json.Unmarshal(%s): %v", out, unmarshalErr)
+		}
+		if back != s {
+			t.Errorf("round-trip stack %v -> %s -> %v", s, out, back)
+		}
+	}
+}
+
+func TestCellState_StringRoundTrip(t *testing.T) {
+	for _, s := range []CellState{CellStatePending, CellStateReady, CellStateStopped, CellStateFailed, CellStateUnknown} {
+		out, marshalErr := json.Marshal(s)
+		if marshalErr != nil {
+			t.Fatalf("json.Marshal(%v): %v", s, marshalErr)
+		}
+		var back CellState
+		if unmarshalErr := json.Unmarshal(out, &back); unmarshalErr != nil {
+			t.Fatalf("json.Unmarshal(%s): %v", out, unmarshalErr)
+		}
+		if back != s {
+			t.Errorf("round-trip cell %v -> %s -> %v", s, out, back)
+		}
+	}
+}
+
+func TestContainerState_StringRoundTrip(t *testing.T) {
+	for _, s := range []ContainerState{
+		ContainerStatePending, ContainerStateReady, ContainerStateStopped,
+		ContainerStatePaused, ContainerStatePausing, ContainerStateFailed, ContainerStateUnknown,
+	} {
+		out, marshalErr := json.Marshal(s)
+		if marshalErr != nil {
+			t.Fatalf("json.Marshal(%v): %v", s, marshalErr)
+		}
+		var back ContainerState
+		if unmarshalErr := json.Unmarshal(out, &back); unmarshalErr != nil {
+			t.Fatalf("json.Unmarshal(%s): %v", out, unmarshalErr)
+		}
+		if back != s {
+			t.Errorf("round-trip container %v -> %s -> %v", s, out, back)
+		}
+	}
+}
+
+// TestCellState_BackCompat_LegacyIntJSON ensures a daemon reading old
+// metadata.json files (which serialized state as a raw int) still gets the
+// correct enum value back. Critical for in-place upgrades.
+func TestCellState_BackCompat_LegacyIntJSON(t *testing.T) {
+	legacy := []byte(
+		`{"name":"web","id":"abc","state":2,"restartCount":0,"restartTime":"0001-01-01T00:00:00Z","startTime":"0001-01-01T00:00:00Z","finishTime":"0001-01-01T00:00:00Z","exitCode":0,"exitSignal":""}`,
+	)
+	var status ContainerStatus
+	if err := json.Unmarshal(legacy, &status); err != nil {
+		t.Fatalf("Unmarshal legacy int form: %v", err)
+	}
+	if status.State != ContainerStateStopped {
+		t.Errorf("legacy state=2 parsed as %v, want ContainerStateStopped", status.State)
+	}
+}


### PR DESCRIPTION
## Summary

- `kuke get realm|space|stack|cell|container -o yaml|json` now emits `state: Ready` (string) instead of `state: 2` (raw enum int). Operators scripting against the output no longer have to grep the source for the enum.
- All five `*State` types (`RealmState`, `SpaceState`, `StackState`, `CellState`, `ContainerState`) gain `MarshalJSON` / `MarshalYAML` that serialize via the existing `String()` label vocabulary (`Pending`, `Ready`, `Stopped`, …) — the same strings the table renderer uses.
- Symmetric `UnmarshalJSON` / `UnmarshalYAML` accept both the new string form and the legacy int form, so daemon-persisted `metadata.json` files written by pre-fix daemons still parse after upgrade (the daemon's `internal/controller/runner/read.go` path goes through these unmarshals).
- Fixed a missing `yaml:"state"` tag on `RealmStatus.State` surfaced by `musttag` once the new serializer covered the field — the only Status struct in the package without the explicit tag.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full suite green
- [x] `pre-commit run --files <changed-files>` — clean (golangci-lint, addlicense, go fmt all pass)
- [x] New unit tests cover: per-label `Marshal{JSON,YAML}` output, `Unmarshal{JSON,YAML}` accepting both string and legacy int forms, rejecting unknown labels and out-of-range ints, full `RealmDoc` yaml/json round-trip, and a legacy `ContainerStatus{state:2}` JSON parse that round-trips to `ContainerStateStopped`
- [x] `make dev-init` smoke — daemon-parity check passes (both `kuke get realms` and `--no-daemon` show identical `Ready` rows); change touches what the daemon persists/reads, so the smoke is in scope
- [x] Manual verification on the running daemon: `sudo ./kuke get realm default -o yaml` emits `state: Ready`, `-o json` emits `"state": "Ready"`, and `kuke get realm default -o yaml | kuke apply -f` succeeds with `Realm "default": unchanged` (no schema error on the string state — AC's round-trip case)

Closes #474