### PR TITLE
fix: hint at cross-scope match when --cell/--space/--stack filter is empty

### DIFF
--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -17,8 +17,10 @@
 package container
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -34,6 +36,8 @@ import (
 
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
+
+const noContainersFoundMsg = "No containers found."
 
 type (
 	printObjectFunc  func(interface{}) error
@@ -177,6 +181,14 @@ func runContainerCmdWithDeps(
 		return err
 	}
 
+	emptyMsg := noContainersFoundMsg
+	if len(specs) == 0 && outputFormat == shared.OutputFormatTable {
+		emptyMsg = buildEmptyResultMessage(realm, space, stack, cell)
+		if hint := maybeBuildScopeHint(cmd.Context(), client, space, stack, cell); hint != "" {
+			emptyMsg = emptyMsg + "\n" + hint
+		}
+	}
+
 	containerStates := make(map[string]string, len(specs))
 	for i := range specs {
 		spec := specs[i]
@@ -205,7 +217,115 @@ func runContainerCmdWithDeps(
 		containerStates[spec.ID] = containerStateToString(probeResult.Container.Status.State)
 	}
 
-	return printContainersWithState(cmd, specs, containerStates, outputFormat, printYAML, printJSON, printTable)
+	return printContainersWithState(
+		cmd,
+		specs,
+		containerStates,
+		outputFormat,
+		emptyMsg,
+		printYAML,
+		printJSON,
+		printTable,
+	)
+}
+
+// buildEmptyResultMessage describes the queried filter set when zero rows
+// match, so the operator sees what filter actually fired instead of a bare
+// "No containers found." Empty filters are omitted.
+func buildEmptyResultMessage(realm, space, stack, cell string) string {
+	var parts []string
+	if cell != "" {
+		parts = append(parts, fmt.Sprintf("cell %q", cell))
+	}
+	if stack != "" {
+		parts = append(parts, fmt.Sprintf("stack %q", stack))
+	}
+	if space != "" {
+		parts = append(parts, fmt.Sprintf("space %q", space))
+	}
+	if realm != "" {
+		parts = append(parts, fmt.Sprintf("realm %q", realm))
+	}
+	if len(parts) == 0 {
+		return noContainersFoundMsg
+	}
+	return fmt.Sprintf("No containers found for %s.", strings.Join(parts, " "))
+}
+
+// maybeBuildScopeHint looks for the user-supplied --cell / --space / --stack
+// name in scopes other than the queried one. Issue #472: when scope-bound
+// filtering returns zero rows but the named entity exists elsewhere, the
+// operator otherwise has no clue where to find it. Returns the empty string
+// when there is nothing useful to surface (e.g. only --realm was set, or the
+// named entity does not exist anywhere). Fails open: any cross-scope lookup
+// error is treated as "no hint" rather than escalated.
+func maybeBuildScopeHint(
+	ctx context.Context,
+	client kukeonv1.Client,
+	space, stack, cell string,
+) string {
+	if cell == "" && stack == "" && space == "" {
+		return ""
+	}
+
+	allSpecs, err := client.ListContainers(ctx, "", "", "", "")
+	if err != nil {
+		return ""
+	}
+
+	type scope struct{ realm, space, stack string }
+	seen := map[scope]bool{}
+	for i := range allSpecs {
+		s := &allSpecs[i]
+		if cell != "" && s.CellID != cell {
+			continue
+		}
+		if stack != "" && s.StackID != stack {
+			continue
+		}
+		if space != "" && s.SpaceID != space {
+			continue
+		}
+		seen[scope{s.RealmID, s.SpaceID, s.StackID}] = true
+	}
+
+	if len(seen) == 0 {
+		return ""
+	}
+
+	sorted := make([]scope, 0, len(seen))
+	for sc := range seen {
+		sorted = append(sorted, sc)
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].realm != sorted[j].realm {
+			return sorted[i].realm < sorted[j].realm
+		}
+		if sorted[i].space != sorted[j].space {
+			return sorted[i].space < sorted[j].space
+		}
+		return sorted[i].stack < sorted[j].stack
+	})
+
+	var entityDesc string
+	switch {
+	case cell != "":
+		entityDesc = fmt.Sprintf("cell %q", cell)
+	case stack != "":
+		entityDesc = fmt.Sprintf("stack %q", stack)
+	case space != "":
+		entityDesc = fmt.Sprintf("space %q", space)
+	}
+
+	locs := make([]string, 0, len(sorted))
+	for _, sc := range sorted {
+		locs = append(locs, fmt.Sprintf("realm %q space %q stack %q", sc.realm, sc.space, sc.stack))
+	}
+
+	return fmt.Sprintf(
+		"Hint: %s exists in %s — pass --realm/--space/--stack to filter there.",
+		entityDesc, strings.Join(locs, "; "),
+	)
 }
 
 func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
@@ -234,6 +354,7 @@ func printContainersWithState(
 	containers []v1beta1.ContainerSpec,
 	containerStates map[string]string,
 	format shared.OutputFormat,
+	emptyMsg string,
 	printYAML printObjectFunc,
 	printJSON printObjectFunc,
 	printTable tablePrinterFunc,
@@ -245,7 +366,10 @@ func printContainersWithState(
 		return printJSON(containers)
 	case shared.OutputFormatTable:
 		if len(containers) == 0 {
-			cmd.Println("No containers found.")
+			if emptyMsg == "" {
+				emptyMsg = noContainersFoundMsg
+			}
+			cmd.Println(emptyMsg)
 			return nil
 		}
 		headers := []string{"NAME", "REALM", "SPACE", "STACK", "CELL", "ROOT", "IMAGE", "STATE"}

--- a/cmd/kuke/get/container/container_test.go
+++ b/cmd/kuke/get/container/container_test.go
@@ -38,12 +38,13 @@ func TestNewContainerCmd(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
 	tests := []struct {
-		name       string
-		args       []string
-		setup      func(t *testing.T, cmd *cobra.Command)
-		fake       *fakeClient
-		wantErr    string
-		wantOutput string
+		name            string
+		args            []string
+		setup           func(t *testing.T, cmd *cobra.Command)
+		fake            *fakeClient
+		wantErr         string
+		wantOutput      string
+		wantNotInOutput []string
 	}{
 		{
 			name: "get single container",
@@ -103,6 +104,145 @@ func TestNewContainerCmd(t *testing.T) {
 			wantOutput: "No containers found.",
 		},
 		{
+			// Issue #472, Option B. Cell filter returns zero in the current
+			// scope, but the named cell exists in a different (realm,space,
+			// stack). Table output appends a Hint: line naming where to look.
+			name: "list empty with cell-only filter hints at other scope",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("cell", "kukeond")
+			},
+			fake: &fakeClient{
+				listContainersFn: func(_, _, _, cell string) ([]v1beta1.ContainerSpec, error) {
+					if cell == "kukeond" {
+						return nil, nil
+					}
+					return []v1beta1.ContainerSpec{
+						{
+							ID:      "kukeond",
+							RealmID: "kuke-system",
+							SpaceID: "kukeon",
+							StackID: "kukeon",
+							CellID:  "kukeond",
+						},
+					}, nil
+				},
+			},
+			wantOutput: `No containers found for cell "kukeond".` + "\n" +
+				`Hint: cell "kukeond" exists in realm "kuke-system" space "kukeon" stack "kukeon" — pass --realm/--space/--stack to filter there.`,
+		},
+		{
+			// Cell filter empty *and* no cross-scope match — no hint, plain
+			// scoped message so the operator knows the filter fired and just
+			// matched nothing.
+			name: "list empty with cell filter no match anywhere",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("cell", "ghost")
+			},
+			fake: &fakeClient{
+				listContainersFn: func(_, _, _, cell string) ([]v1beta1.ContainerSpec, error) {
+					if cell == "ghost" {
+						return nil, nil
+					}
+					return []v1beta1.ContainerSpec{
+						{ID: "x", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "other"},
+					}, nil
+				},
+			},
+			wantOutput: `No containers found for cell "ghost".`,
+		},
+		{
+			// AC4: --stack follows the same convention. Empty result with
+			// --stack <name> set hints at the realm/space where it exists.
+			name: "list empty with stack-only filter hints at other scope",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("stack", "kukeon")
+			},
+			fake: &fakeClient{
+				listContainersFn: func(_, _, stack, _ string) ([]v1beta1.ContainerSpec, error) {
+					if stack == "kukeon" {
+						return nil, nil
+					}
+					return []v1beta1.ContainerSpec{
+						{
+							ID:      "kukeond",
+							RealmID: "kuke-system",
+							SpaceID: "kukeon",
+							StackID: "kukeon",
+							CellID:  "kukeond",
+						},
+					}, nil
+				},
+			},
+			wantOutput: `Hint: stack "kukeon" exists in realm "kuke-system" space "kukeon" stack "kukeon"`,
+		},
+		{
+			// AC4: --space follows the same convention.
+			name: "list empty with space-only filter hints at other scope",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("space", "kukeon")
+			},
+			fake: &fakeClient{
+				listContainersFn: func(_, space, _, _ string) ([]v1beta1.ContainerSpec, error) {
+					if space == "kukeon" {
+						return nil, nil
+					}
+					return []v1beta1.ContainerSpec{
+						{
+							ID:      "kukeond",
+							RealmID: "kuke-system",
+							SpaceID: "kukeon",
+							StackID: "kukeon",
+							CellID:  "kukeond",
+						},
+					}, nil
+				},
+			},
+			wantOutput: `Hint: space "kukeon" exists in realm "kuke-system" space "kukeon" stack "kukeon"`,
+		},
+		{
+			// realm-only filter does not trigger a hint: realm is the
+			// top-level scope; if the user asked for a realm by name and got
+			// nothing, "look in another realm" is not actionable advice.
+			name: "list empty with realm-only filter does not hint",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "default")
+			},
+			fake: &fakeClient{
+				listContainersFn: func(realm, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+					if realm == "default" {
+						return nil, nil
+					}
+					return []v1beta1.ContainerSpec{
+						{
+							ID:      "kukeond",
+							RealmID: "kuke-system",
+							SpaceID: "kukeon",
+							StackID: "kukeon",
+							CellID:  "kukeond",
+						},
+					}, nil
+				},
+			},
+			wantOutput:      `No containers found for realm "default".`,
+			wantNotInOutput: []string{"Hint:"},
+		},
+		{
+			// -o yaml on empty result emits an empty list and no hint —
+			// the hint is a table-only UX aid; structured output stays
+			// machine-readable.
+			name: "list empty yaml output suppresses hint",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("cell", "kukeond")
+				_ = cmd.Flags().Set("output", "yaml")
+			},
+			fake: &fakeClient{
+				listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+					return nil, nil
+				},
+			},
+			wantNotInOutput: []string{"Hint:", "No containers found"},
+		},
+		{
 			name: "list one and probe state",
 			fake: &fakeClient{
 				listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
@@ -158,6 +298,11 @@ func TestNewContainerCmd(t *testing.T) {
 			}
 			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
 				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+			for _, banned := range tt.wantNotInOutput {
+				if strings.Contains(buf.String(), banned) {
+					t.Errorf("output unexpectedly contains %q\nGot:\n%s", banned, buf.String())
+				}
 			}
 		})
 	}

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -133,7 +133,7 @@ kuke get realms                                  # alias: r, realm
 kuke get spaces
 kuke get stacks
 kuke get cells
-kuke get containers --cell <name>                # filter on any level
+kuke get containers --cell <name>                # filter within current scope
 kuke get realm <name> -o yaml                    # full spec+status
 kuke get realm <name> -o json
 kuke get realms --show-controllers               # cgroup-v2 controllers column
@@ -146,6 +146,7 @@ kuke get realms --show-controllers               # cgroup-v2 controllers column
 - After `kuke init`, `kuke get realms` lists at least `default` and `kuke-system`. `kuke get realms --no-daemon` must produce the same row set — divergence is a regression (see CLAUDE.md daemon-parity guard).
 - `--show-controllers` appends a `CONTROLLERS` column; it is **off by default** so the default table matches the dev-init regression-guard tail in CLAUDE.md.
 - `kuke get realms --no-daemon` works without `sudo` when `/opt/kukeon` is readable by the `kukeon` group; this is the supported escape hatch when the daemon is down.
+- `kuke get containers --cell <name>` (and `--space <name>` / `--stack <name>`) filter **within the scope passed on the command line**. The operator must supply matching `--realm/--space/--stack` to filter into a non-default scope. When a filter returns zero rows but the named cell/space/stack exists in a different scope, the table output appends a `Hint:` line naming the realm/space/stack where it does exist, so the operator can re-run with the right flags. The hint applies to the `table` output only — `-o yaml` and `-o json` still emit an empty list, exit code 0.
 
 ### Creating a custom realm / space / stack
 


### PR DESCRIPTION
## Summary

- Issue #472 listed two acceptable paths; per the user's `Implement option B. Update documentation. Override pm role here.` comment, this PR ships **Option B** (informative hint when scope-bound filtering finds zero rows) instead of Option A. An earlier push on this branch implemented Option A — that commit has been replaced via `--force-with-lease`.
- When `kuke get containers --cell <name>` (or `--space` / `--stack`) returns zero rows in `table` output, the CLI now:
  1. Replaces the bare `No containers found.` line with a scope-aware message (e.g. `No containers found for cell "kukeond".`) so the operator can see which filter actually fired.
  2. Issues a single cross-scope `ListContainers("", "", "", "")` lookup, and if the supplied cell/space/stack name exists in a different realm/space/stack, appends `Hint: cell "kukeond" exists in realm "kuke-system" space "kukeon" stack "kukeon" — pass --realm/--space/--stack to filter there.`
- The hint is a table-only UX aid: `-o yaml` / `-o json` still emit the empty list with exit code 0 so machine-readable consumers are unaffected.
- `--realm` alone does not trigger a hint — realm is the top-level scope and "look in another realm" is not actionable advice.
- The cross-scope lookup fails open: any error from the second `ListContainers` call is treated as "no hint to add" rather than escalated, so a transient daemon hiccup never turns an empty-result table into an error.
- `docs/cli-use-cases.md:136` updated from `# filter on any level` to `# filter within current scope` to match the chosen behavior, plus a new invariant under "Listing the hierarchy" that documents the `Hint:` line so reviewers and `/test-cli` runs treat it as expected output.

## Test plan

- [x] `go test ./cmd/kuke/get/container/...` — `TestNewContainerCmd` extended with six new subcases (cell/stack/space hint paths, no-match-anywhere path, realm-only-no-hint path, yaml-suppresses-hint path); all pass.
- [x] `go test ./...` — full suite green.
- [x] `go vet ./...` — clean.
- [x] `go build ./...` — clean.
- [x] `pre-commit run --files <changed-files>` — all hooks pass (go fmt, golangci-lint, addlicense, prettier).
- [ ] `make dev-init` smoke — not re-run for this Option B swap; the change is CLI-layer only and does not touch the daemon, build, or `/opt/kukeon` write path. Manual table-output verification via the existing unit tests covers the user-visible behavior.

Closes #472