### PR TITLE
fix: drop redundant required-flag guards in kuke log runLog

### DIFF
--- a/cmd/kuke/log/log.go
+++ b/cmd/kuke/log/log.go
@@ -128,15 +128,6 @@ func runLog(cmd *cobra.Command, args []string) error {
 	if cell == "" {
 		return fmt.Errorf("%w (positional cell)", errdefs.ErrCellNameRequired)
 	}
-	if realm == "" {
-		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
-	}
-	if space == "" {
-		return fmt.Errorf("%w (--space)", errdefs.ErrSpaceNameRequired)
-	}
-	if stack == "" {
-		return fmt.Errorf("%w (--stack)", errdefs.ErrStackNameRequired)
-	}
 
 	client, err := resolveClient(cmd)
 	if err != nil {

--- a/cmd/kuke/log/log_test.go
+++ b/cmd/kuke/log/log_test.go
@@ -451,53 +451,6 @@ func TestLog_RejectsCellFlag(t *testing.T) {
 	}
 }
 
-func TestLog_MissingFlags(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
-	cases := []struct {
-		name    string
-		args    []string
-		wantErr error
-	}{
-		{
-			name:    "explicit empty realm",
-			args:    []string{"--realm", "", "--space", "s1", "--stack", "st1", "c1"},
-			wantErr: errdefs.ErrRealmNameRequired,
-		},
-		{
-			name:    "explicit empty space",
-			args:    []string{"--realm", "r1", "--space", "", "--stack", "st1", "c1"},
-			wantErr: errdefs.ErrSpaceNameRequired,
-		},
-		{
-			name:    "explicit empty stack",
-			args:    []string{"--realm", "r1", "--space", "s1", "--stack", "", "c1"},
-			wantErr: errdefs.ErrStackNameRequired,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Reset clears viper's defaults set by DefineKV at package
-			// init so an explicit `--realm ""` resolves to the empty
-			// string and trips the runtime guard. t.Setenv keeps the
-			// env-var path quiet too, in case the dev box exports a
-			// KUKE_LOG_*.
-			viper.Reset()
-			t.Setenv("KUKE_LOG_REALM", "")
-			t.Setenv("KUKE_LOG_SPACE", "")
-			t.Setenv("KUKE_LOG_STACK", "")
-
-			cmd, _ := newCmdWithCtx(t, &fakeClient{}, &tailCapture{})
-			cmd.SetArgs(tc.args)
-
-			err := cmd.Execute()
-			if !errors.Is(err, tc.wantErr) {
-				t.Fatalf("error %v does not unwrap to %v", err, tc.wantErr)
-			}
-		})
-	}
-}
-
 // TestLog_MissingCellArg covers the cobra arg-count guard: omitting the
 // positional <cell> exits before runLog ever runs, surfacing a
 // usage-style error rather than ErrCellNameRequired.


### PR DESCRIPTION
## Summary

- Most of issue #465's acceptance criteria already landed in PR #477 (positional `<cell>` arg + `--realm`/`--space`/`--stack` defaults wired to `consts.KukeonDefault*Name`, plus the matching `docs/site/cli/kuke-log.md` revert). This finishes the cleanup tail the issue called for: dropping the `Err{Realm,Space,Stack}NameRequired` empty-string guards in `runLog`, which were dead for the common no-flag case and only fired on an explicit `--realm ""` (etc.). The daemon's name-resolution path is the appropriate boundary for that edge.
- `TestLog_MissingFlags` (the table that asserted those three guards) is removed as a consequence; the `--cell` required check stays and `TestLog_MissingCellArg` continues to cover the positional-arg-omitted path.
- `kuke attach`'s identical guards are intentionally left in place — issue #465 narrows scope to `kuke log`, and a wider sweep across CLI verbs is explicitly out of scope per the issue body.

## Test plan

- [x] `go test ./cmd/kuke/log/...` — green.
- [x] `make test` (== `go test $(go list ./... | grep -v /e2e)`) — green.
- [x] `go vet ./...` — clean.
- [x] `go build ./...` — clean.
- [x] `pre-commit run --files cmd/kuke/log/log.go cmd/kuke/log/log_test.go` — all hooks pass (go fmt, golangci-lint, addlicense, end-of-files, trailing-whitespace).
- [ ] `make dev-init` smoke — not re-run for this change; the diff is a CLI-layer guard removal that touches no build path, daemon, or `/opt/kukeon` write path. `TestLog_PositionalCell_DefaultsRealmSpaceStack` (already landed in #477) covers the user-visible `sudo kuke log <cell>` default-hierarchy contract.

Closes #465