### PR TITLE
fix: stamp CellProfileName + EtcHosts/EtcHostname paths in StartContainer recreate

### DIFF
--- a/internal/controller/runner/cell_etc_files.go
+++ b/internal/controller/runner/cell_etc_files.go
@@ -142,6 +142,21 @@ func stampEtcFilePathsOnContainerSpec(spec *intmodel.ContainerSpec, hostnamePath
 	}
 }
 
+// stampContainerRecreateRuntimeFields applies the runtime-only field stamps
+// that the single-container StartContainer recreate path needs before
+// invoking BuildContainerSpec via CreateContainerFromSpec. Mirrors the
+// cell-wide stampCellEtcFilePathsOnContainers + stampCellProfileNameOnContainers
+// pair the StartCell / ensureCellContainers paths run, but per-spec since
+// the recreate path holds a local container-spec pointer. Without this,
+// `kuke start container` drops the recreated container's /etc/hosts +
+// /etc/hostname bind-mounts and KUKEON_CELL_PROFILE_NAME env entry. Issue
+// #354.
+func (r *Exec) stampContainerRecreateRuntimeFields(spec *intmodel.ContainerSpec, cell *intmodel.Cell) {
+	hostnamePath, hostsPath, suppressHosts := r.cellEtcFilePaths(cell)
+	stampEtcFilePathsOnContainerSpec(spec, hostnamePath, hostsPath, suppressHosts)
+	stampCellProfileNameOnContainerSpec(spec, cell)
+}
+
 // renderCellEtcFilesPreCNI writes the per-cell /etc/hostname and an initial
 // /etc/hosts (localhost block only, no cell IP) so the bind-mount sources
 // exist before runc creates any container in the cell. Idempotent — every

--- a/internal/controller/runner/cell_etc_files_test.go
+++ b/internal/controller/runner/cell_etc_files_test.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eminwux/kukeon/internal/cellprofile"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	utilfs "github.com/eminwux/kukeon/internal/util/fs"
 )
@@ -63,7 +64,13 @@ func TestEnsureCellEtcFilesExistPreCNI_PreservesIPLine(t *testing.T) {
 	if err := r.renderCellEtcFilesPreCNI(cell); err != nil {
 		t.Fatalf("seed pre-CNI render: %v", err)
 	}
-	hostsPath := utilfs.CellEtcHostsPath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+	hostsPath := utilfs.CellEtcHostsPath(
+		runPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
 	withIP := etcHostsLocalhostBlock + "10.22.0.5\tkukeond\n"
 	if err := os.WriteFile(hostsPath, []byte(withIP), 0o644); err != nil {
 		t.Fatalf("seed /etc/hosts with IP: %v", err)
@@ -101,8 +108,20 @@ func TestEnsureCellEtcFilesExistPreCNI_FillsInMissingFiles(t *testing.T) {
 		t.Fatalf("ensureCellEtcFilesExistPreCNI: %v", err)
 	}
 
-	hostnamePath := utilfs.CellEtcHostnamePath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
-	hostsPath := utilfs.CellEtcHostsPath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+	hostnamePath := utilfs.CellEtcHostnamePath(
+		runPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
+	hostsPath := utilfs.CellEtcHostsPath(
+		runPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
 
 	hn, err := os.ReadFile(hostnamePath)
 	if err != nil {
@@ -121,6 +140,131 @@ func TestEnsureCellEtcFilesExistPreCNI_FillsInMissingFiles(t *testing.T) {
 	}
 }
 
+// TestStampContainerRecreateRuntimeFields is the regression guard for
+// issue #354: the StartContainer single-container recreate path was the
+// only BuildContainerSpec call site that did not apply the per-cell
+// /etc/hosts + /etc/hostname bind-mount stamps or the CellProfileName
+// runtime stamp. The helper bundles both per-spec stamps so the recreate
+// path produces a spec consistent with every other recreate path.
+func TestStampContainerRecreateRuntimeFields(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+	cell := &intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name:   "work-cell",
+			Labels: map[string]string{cellprofile.LabelProfile: "kukeon-pr"},
+		},
+		Spec: intmodel.CellSpec{
+			RealmName:       "default",
+			SpaceName:       "team-a",
+			StackName:       "web",
+			RootContainerID: "root",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work"},
+			},
+		},
+	}
+	work := &cell.Spec.Containers[1]
+
+	r.stampContainerRecreateRuntimeFields(work, cell)
+
+	wantHostname := utilfs.CellEtcHostnamePath(
+		runPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
+	wantHosts := utilfs.CellEtcHostsPath(
+		runPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
+	if work.EtcHostnamePath != wantHostname {
+		t.Errorf("EtcHostnamePath = %q, want %q", work.EtcHostnamePath, wantHostname)
+	}
+	if work.EtcHostsPath != wantHosts {
+		t.Errorf("EtcHostsPath = %q, want %q", work.EtcHostsPath, wantHosts)
+	}
+	if work.CellProfileName != "kukeon-pr" {
+		t.Errorf("CellProfileName = %q, want %q", work.CellProfileName, "kukeon-pr")
+	}
+}
+
+// TestStampContainerRecreateRuntimeFields_HostNetworkSuppressesHosts pins the
+// host-network carve-out for the recreate path: a host-network cell still
+// gets /etc/hostname but must leave EtcHostsPath empty so the host's
+// /etc/hosts remains authoritative — same rule the cell-wide stamp applies.
+func TestStampContainerRecreateRuntimeFields_HostNetworkSuppressesHosts(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+	cell := &intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "kukeond"},
+		Spec: intmodel.CellSpec{
+			RealmName:       "kuke-system",
+			SpaceName:       "kukeon",
+			StackName:       "kukeon",
+			RootContainerID: "kukeond",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "kukeond", Root: true, HostNetwork: true},
+				{ID: "sidecar"},
+			},
+		},
+	}
+	side := &cell.Spec.Containers[1]
+
+	r.stampContainerRecreateRuntimeFields(side, cell)
+
+	wantHostname := utilfs.CellEtcHostnamePath(
+		runPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
+	if side.EtcHostnamePath != wantHostname {
+		t.Errorf("EtcHostnamePath = %q, want %q", side.EtcHostnamePath, wantHostname)
+	}
+	if side.EtcHostsPath != "" {
+		t.Errorf("EtcHostsPath = %q, want empty (host-network suppresses /etc/hosts)", side.EtcHostsPath)
+	}
+}
+
+// TestStampContainerRecreateRuntimeFields_NoProfileLabel covers a plain
+// CellDoc-sourced cell: no profile label means CellProfileName stays empty
+// so kukeonDefaultEnv emits no KUKEON_CELL_PROFILE_NAME entry — the
+// downstream BuildContainerSpec test in ctr already pins that env mapping.
+func TestStampContainerRecreateRuntimeFields_NoProfileLabel(t *testing.T) {
+	runPath := t.TempDir()
+	r := newProvisionTestExec(t, runPath, false)
+	cell := &intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "plain"},
+		Spec: intmodel.CellSpec{
+			RealmName:       "default",
+			SpaceName:       "team-a",
+			StackName:       "web",
+			RootContainerID: "root",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work"},
+			},
+		},
+	}
+	work := &cell.Spec.Containers[1]
+
+	r.stampContainerRecreateRuntimeFields(work, cell)
+
+	if work.CellProfileName != "" {
+		t.Errorf("CellProfileName = %q, want empty (no profile label on cell)", work.CellProfileName)
+	}
+	if work.EtcHostnamePath == "" {
+		t.Errorf("EtcHostnamePath empty; etc-files stamp should still apply when no profile label")
+	}
+}
+
 // TestEnsureCellEtcFilesExistPreCNI_HostNetworkSkipsHosts confirms the
 // host-network carve-out: the kukeond cell's root runs HostNetwork=true,
 // so /etc/hosts must not be rendered (the host's /etc/hosts is the right
@@ -134,8 +278,20 @@ func TestEnsureCellEtcFilesExistPreCNI_HostNetworkSkipsHosts(t *testing.T) {
 		t.Fatalf("ensureCellEtcFilesExistPreCNI: %v", err)
 	}
 
-	hostnamePath := utilfs.CellEtcHostnamePath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
-	hostsPath := utilfs.CellEtcHostsPath(runPath, cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+	hostnamePath := utilfs.CellEtcHostnamePath(
+		runPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
+	hostsPath := utilfs.CellEtcHostsPath(
+		runPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
 
 	if _, err := os.Stat(hostnamePath); err != nil {
 		t.Errorf("/etc/hostname should exist on host-network cells: %v", err)

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -974,6 +974,15 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	// before BuildContainerSpec runs in the destructive recreate below.
 	foundContainerSpec.NestedCgroupRuntime = cell.Spec.NestedCgroupRuntime
 
+	// EtcHostsPath / EtcHostnamePath and CellProfileName: runtime-only
+	// stamps the cell-wide StartCell / ensureCellContainers paths apply via
+	// stampCellEtcFilePathsOnContainers + stampCellProfileNameOnContainers.
+	// The single-container StartContainer recreate path holds a local spec
+	// pointer instead, so use the per-spec variants to match. Without these,
+	// the recreated container drops its /etc/hosts + /etc/hostname
+	// bind-mounts and the KUKEON_CELL_PROFILE_NAME env var. Issue #354.
+	r.stampContainerRecreateRuntimeFields(foundContainerSpec, &cell)
+
 	// Past the idempotent recreate-prep: any subsequent error means we
 	// crashed mid-provisioning, so arm the defer to flip the cell to
 	// Failed (issue #407).


### PR DESCRIPTION
## Summary
- The single-container `StartContainer` recreate path (`kuke start container`) was the only `BuildContainerSpec` / `CreateContainerFromSpec` call site that did not apply the per-cell `/etc/hosts` + `/etc/hostname` bind-mount stamps or the `CellProfileName` runtime stamp. Workloads recreated through this path silently lost `KUKEON_CELL_PROFILE_NAME` and the cell's `/etc/hosts` + `/etc/hostname` bind-mounts.
- Bundles the two per-spec stamps into a new `r.stampContainerRecreateRuntimeFields(spec, cell)` helper next to the existing per-cell stamp methods in `cell_etc_files.go`, and calls it from `StartContainer` immediately before `CreateContainerFromSpec` — mirroring the per-spec pair already used on the `StartCell` root-recreate path at `start.go:411-413`.

## Test plan
- [x] `make test` — full unit suite (incl. new `TestStampContainerRecreateRuntimeFields*` cases covering profile-labelled, no-profile, and host-network-suppresses-hosts).
- [x] `pre-commit run --files <touched>` — gofmt, go-mod-tidy, golangci-lint, addlicense clean.
- [ ] `make e2e` — not run; bug-fix path is covered by the new unit tests and the destructive smoke would not catch this regression class (no existing `kuke start container` step). Reviewer can run if desired.

Closes #354