### PR TITLE
fix: scope reconcile walker to /opt/kukeon/data so /opt/kukeon/bin stops logging ERROR

### DIFF
--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -18,10 +18,10 @@
 // teardown for the kukeond cell. It composes stop (with the same SIGTERM →
 // SIGKILL escalation as `kuke daemon stop`) plus delete, then clears the
 // transient kukeond.{sock,pid} files under the socket dir (default
-// /run/kukeon). User-realm data under /opt/kukeon/default/** is left
+// /run/kukeon). User-realm data under /opt/kukeon/data/default/** is left
 // untouched so a subsequent `kuke init` can re-bootstrap without wiping
 // user workloads. `--purge-system` additionally removes
-// /opt/kukeon/kuke-system for a fully clean re-bootstrap.
+// /opt/kukeon/data/kuke-system for a fully clean re-bootstrap.
 package reset
 
 import (
@@ -183,7 +183,7 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	}
 
 	if purgeSystem {
-		systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+		systemDir := filepath.Join(runPath, consts.KukeonMetadataSubdir, consts.KukeSystemRealmName)
 		removed, removeErr := removeDirIfExists(systemDir)
 		if removeErr != nil {
 			return fmt.Errorf("remove %q: %w", systemDir, removeErr)

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -389,8 +389,8 @@ func TestDaemonReset_PreservesDefaultRealm(t *testing.T) {
 	withFreshViper(t)
 
 	runPath := t.TempDir()
-	defaultDir := filepath.Join(runPath, consts.KukeonDefaultRealmName)
-	systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	defaultDir := filepath.Join(runPath, consts.KukeonMetadataSubdir, consts.KukeonDefaultRealmName)
+	systemDir := filepath.Join(runPath, consts.KukeonMetadataSubdir, consts.KukeSystemRealmName)
 	if err := os.MkdirAll(defaultDir, 0o750); err != nil {
 		t.Fatalf("mkdir default: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestDaemonReset_PurgeSystemAfterTeardown(t *testing.T) {
 	withFreshViper(t)
 
 	runPath := t.TempDir()
-	systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	systemDir := filepath.Join(runPath, consts.KukeonMetadataSubdir, consts.KukeSystemRealmName)
 	if err := os.MkdirAll(systemDir, 0o750); err != nil {
 		t.Fatalf("mkdir kuke-system: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestDaemonReset_PurgeSystemAfterTeardownNoSystemDir(t *testing.T) {
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error on fully-clean host with --purge-system: %v", err)
 	}
-	systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	systemDir := filepath.Join(runPath, consts.KukeonMetadataSubdir, consts.KukeSystemRealmName)
 	if strings.Contains(buf.String(), "removed "+systemDir) {
 		t.Errorf("did not expect 'removed' line for absent kuke-system dir; got:\n%s", buf.String())
 	}
@@ -534,7 +534,7 @@ func TestDaemonReset_NoPurgeSystemKeepsKukeSystem(t *testing.T) {
 	withFreshViper(t)
 
 	runPath := t.TempDir()
-	systemDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	systemDir := filepath.Join(runPath, consts.KukeonMetadataSubdir, consts.KukeSystemRealmName)
 	if err := os.MkdirAll(systemDir, 0o750); err != nil {
 		t.Fatalf("mkdir kuke-system: %v", err)
 	}

--- a/internal/cni/subnet.go
+++ b/internal/cni/subnet.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 )
 
@@ -72,9 +73,14 @@ type SubnetState struct {
 // the source of truth: Allocate scans them at call time to discover which
 // subnets are already in use, so the allocator survives daemon restarts
 // without a separate cache.
+//
+// dataRoot is the metadata subtree under the daemon's RunPath
+// (<RunPath>/<consts.KukeonMetadataSubdir>); the allocator walks only that
+// subtree so non-metadata siblings of the RunPath (e.g. <RunPath>/bin) are not
+// mistaken for realm directories.
 type SubnetAllocator struct {
 	mu         sync.Mutex
-	runPath    string
+	dataRoot   string
 	parentCIDR string
 	prefixLen  int
 	parsedNet  *net.IPNet
@@ -84,8 +90,9 @@ type SubnetAllocator struct {
 }
 
 // NewSubnetAllocator builds an allocator that subdivides parentCIDR into
-// /prefixLen chunks and persists assignments under <runPath>/<realm>/<space>/.
-// Use NewDefaultSubnetAllocator for the standard /24 of /16 layout.
+// /prefixLen chunks and persists assignments under
+// <runPath>/<consts.KukeonMetadataSubdir>/<realm>/<space>/. Use
+// NewDefaultSubnetAllocator for the standard /24 of /16 layout.
 func NewSubnetAllocator(runPath, parentCIDR string, prefixLen int) (*SubnetAllocator, error) {
 	_, ipNet, err := net.ParseCIDR(parentCIDR)
 	if err != nil {
@@ -109,7 +116,7 @@ func NewSubnetAllocator(runPath, parentCIDR string, prefixLen int) (*SubnetAlloc
 	span := uint32(1) << uint(ipv4Bits-prefixLen)           //nolint:gosec // bounded by validation
 	totalSubnets := uint32(1) << uint(prefixLen-parentBits) //nolint:gosec // bounded by validation
 	return &SubnetAllocator{
-		runPath:    runPath,
+		dataRoot:   filepath.Join(runPath, consts.KukeonMetadataSubdir),
 		parentCIDR: parentCIDR,
 		prefixLen:  prefixLen,
 		parsedNet:  ipNet,
@@ -142,7 +149,7 @@ func (a *SubnetAllocator) PrefixLen() int { return a.prefixLen }
 
 // statePath returns the on-disk path for the (realm, space) network-state file.
 func (a *SubnetAllocator) statePath(realm, space string) string {
-	return filepath.Join(a.runPath, realm, space, SubnetStateFileName)
+	return filepath.Join(a.dataRoot, realm, space, SubnetStateFileName)
 }
 
 // LoadAssigned returns the subnet currently persisted for (realm, space), or
@@ -227,24 +234,25 @@ func (a *SubnetAllocator) Release(realm, space string) error {
 	return nil
 }
 
-// usedSubnetsLocked walks <runPath>/<realm>/<space>/network.json and returns
-// the set of subnets currently in use. Realm and space names are derived from
-// the directory layout, so the allocator does not need to know about realm
-// metadata. Caller must hold a.mu.
+// usedSubnetsLocked walks
+// <runPath>/<consts.KukeonMetadataSubdir>/<realm>/<space>/network.json and
+// returns the set of subnets currently in use. Realm and space names are
+// derived from the directory layout, so the allocator does not need to know
+// about realm metadata. Caller must hold a.mu.
 func (a *SubnetAllocator) usedSubnetsLocked() (map[string]struct{}, error) {
 	used := make(map[string]struct{})
-	realmEntries, err := os.ReadDir(a.runPath)
+	realmEntries, err := os.ReadDir(a.dataRoot)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return used, nil
 		}
-		return nil, fmt.Errorf("read run-path %s: %w", a.runPath, err)
+		return nil, fmt.Errorf("read metadata root %s: %w", a.dataRoot, err)
 	}
 	for _, realm := range realmEntries {
 		if !realm.IsDir() {
 			continue
 		}
-		realmDir := filepath.Join(a.runPath, realm.Name())
+		realmDir := filepath.Join(a.dataRoot, realm.Name())
 		spaceEntries, sErr := os.ReadDir(realmDir)
 		if sErr != nil {
 			if errors.Is(sErr, os.ErrNotExist) {

--- a/internal/cni/subnet_test.go
+++ b/internal/cni/subnet_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	cni "github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 )
 
@@ -87,7 +88,7 @@ func TestSubnetAllocator_AllocatePersistsToDisk(t *testing.T) {
 		t.Fatalf("Allocate: %v", err)
 	}
 
-	statePath := filepath.Join(runPath, "kuke-system", "kukeon", cni.SubnetStateFileName)
+	statePath := filepath.Join(runPath, consts.KukeonMetadataSubdir, "kuke-system", "kukeon", cni.SubnetStateFileName)
 	data, err := os.ReadFile(statePath)
 	if err != nil {
 		t.Fatalf("read state file: %v", err)
@@ -122,7 +123,7 @@ func TestSubnetAllocator_LoadAssignedReturnsEmptyWhenMissing(t *testing.T) {
 
 func TestSubnetAllocator_LoadAssignedReturnsCorruptError(t *testing.T) {
 	runPath := t.TempDir()
-	statePath := filepath.Join(runPath, "default", "broken", cni.SubnetStateFileName)
+	statePath := filepath.Join(runPath, consts.KukeonMetadataSubdir, "default", "broken", cni.SubnetStateFileName)
 	if err := os.MkdirAll(filepath.Dir(statePath), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -153,7 +154,7 @@ func TestSubnetAllocator_ReleaseFreesSubnetForReuse(t *testing.T) {
 	if relErr := a.Release("default", "alpha"); relErr != nil {
 		t.Fatalf("Release alpha: %v", relErr)
 	}
-	statePath := filepath.Join(runPath, "default", "alpha", cni.SubnetStateFileName)
+	statePath := filepath.Join(runPath, consts.KukeonMetadataSubdir, "default", "alpha", cni.SubnetStateFileName)
 	if _, statErr := os.Stat(statePath); !os.IsNotExist(statErr) {
 		t.Errorf("Release left state file behind: stat err = %v", statErr)
 	}
@@ -195,7 +196,7 @@ func TestSubnetAllocator_AllocateSkipsCorruptStateFiles(t *testing.T) {
 	runPath := t.TempDir()
 
 	// Plant a garbage network.json under one realm/space pair.
-	corruptPath := filepath.Join(runPath, "default", "broken", cni.SubnetStateFileName)
+	corruptPath := filepath.Join(runPath, consts.KukeonMetadataSubdir, "default", "broken", cni.SubnetStateFileName)
 	if err := os.MkdirAll(filepath.Dir(corruptPath), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -231,7 +232,7 @@ func TestSubnetAllocator_AllocateScansAllRealms(t *testing.T) {
 	runPath := t.TempDir()
 	// Pre-seed a network.json under a different realm to prove the scanner
 	// is global, not per-realm.
-	preSeeded := filepath.Join(runPath, "kuke-system", "kukeon", cni.SubnetStateFileName)
+	preSeeded := filepath.Join(runPath, consts.KukeonMetadataSubdir, "kuke-system", "kukeon", cni.SubnetStateFileName)
 	if err := os.MkdirAll(filepath.Dir(preSeeded), 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -28,6 +28,14 @@ const (
 
 	KukeonMetadataFile = "metadata.json"
 
+	// KukeonMetadataSubdir is the basename of the subdirectory under the
+	// daemon's RunPath that owns kukeon's realm/space/stack/cell metadata
+	// tree. Walkers (ListRealms, the subnet allocator, daemon reset
+	// --purge-system) scope themselves to this subtree so non-metadata
+	// siblings of the RunPath — e.g. <RunPath>/bin staging kuketty, or the
+	// .kukeon-instance.json file — are not mistaken for realm directories.
+	KukeonMetadataSubdir = "data"
+
 	// KukeonContainerTTYDir is the basename of the per-container directory
 	// that owns the sbsh terminal socket plus its capture and log siblings.
 	// kukeon bind-mounts this directory (not a single file) into the

--- a/internal/controller/runner/get.go
+++ b/internal/controller/runner/get.go
@@ -508,7 +508,12 @@ func (r *Exec) ListContainers(realmName, spaceName, stackName, cellName string) 
 }
 
 func (r *Exec) ListRealms() ([]intmodel.Realm, error) {
-	realmsDir := r.opts.RunPath
+	// Scope the walk to <RunPath>/data so non-metadata siblings of the
+	// RunPath (e.g. /opt/kukeon/bin staging kuketty, or the
+	// .kukeon-instance.json file) are not mistaken for realm directories
+	// and do not trigger a "metadata file does not exist" ERROR every
+	// reconcile tick.
+	realmsDir := fs.MetadataRoot(r.opts.RunPath)
 	var results []intmodel.Realm
 
 	// Check if directory exists

--- a/internal/controller/runner/list_realms_test.go
+++ b/internal/controller/runner/list_realms_test.go
@@ -1,0 +1,156 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/controller/runner"
+	"github.com/eminwux/kukeon/internal/metadata"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestListRealms_NonRealmSiblingUnderRunPathIsIgnored is the regression
+// guard for #473: the reconcile walker enumerates realms beneath
+// <RunPath>/<consts.KukeonMetadataSubdir> rather than directly under
+// <RunPath>, so non-metadata siblings of the RunPath (e.g. <RunPath>/bin
+// staging the kuketty binary) must not appear in the realm listing and
+// must not trigger an ERROR-level "metadata file does not exist" log on
+// every reconcile tick.
+func TestListRealms_NonRealmSiblingUnderRunPathIsIgnored(t *testing.T) {
+	runPath := t.TempDir()
+
+	// Real realm under the metadata root.
+	realmName := "alpha"
+	metadataPath := fs.RealmMetadataPath(runPath, realmName)
+	doc := v1beta1.RealmDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindRealm,
+		Metadata:   v1beta1.RealmMetadata{Name: realmName},
+		Spec:       v1beta1.RealmSpec{Namespace: "alpha.kukeon.io"},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := metadata.WriteMetadata(context.Background(), logger, doc, metadataPath); err != nil {
+		t.Fatalf("seed realm metadata: %v", err)
+	}
+
+	// Non-realm sibling of the metadata root, modelling /opt/kukeon/bin
+	// where `kuke init` (via stageKukettyBinary) lands the kuketty binary.
+	// The walker must not treat this as a realm and must not log an ERROR
+	// for the missing metadata.json inside it.
+	siblingDir := filepath.Join(runPath, "bin")
+	if err := os.MkdirAll(siblingDir, 0o750); err != nil {
+		t.Fatalf("mkdir sibling: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(siblingDir, "kuketty"), []byte("#!/usr/bin/false\n"), 0o755); err != nil {
+		t.Fatalf("seed kuketty: %v", err)
+	}
+
+	// Also model the dot-prefixed instance metadata file (instance.MetadataFile)
+	// that lives at the RunPath root.
+	if err := os.WriteFile(filepath.Join(runPath, ".kukeon-instance.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("seed instance metadata: %v", err)
+	}
+
+	logBuf := &bytes.Buffer{}
+	capturingLogger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	r := runner.NewRunner(context.Background(), capturingLogger, runner.Options{RunPath: runPath})
+
+	realms, err := r.ListRealms()
+	if err != nil {
+		t.Fatalf("ListRealms: %v", err)
+	}
+
+	if len(realms) != 1 {
+		names := make([]string, 0, len(realms))
+		for _, rl := range realms {
+			names = append(names, rl.Metadata.Name)
+		}
+		t.Fatalf("ListRealms returned %d entries (%v); want exactly 1 (the seeded realm)", len(realms), names)
+	}
+	if realms[0].Metadata.Name != realmName {
+		t.Errorf("ListRealms returned realm %q, want %q", realms[0].Metadata.Name, realmName)
+	}
+
+	// AC #5: walker must not log ERROR for non-realm siblings of the
+	// RunPath. The "metadata file does not exist" line at ERROR level was
+	// the symptom #473 caught — failing this check would regress the bug.
+	out := logBuf.String()
+	if strings.Contains(out, "level=ERROR") {
+		t.Errorf("ListRealms emitted ERROR-level log lines for non-realm siblings:\n%s", out)
+	}
+	if strings.Contains(out, "metadata file does not exist") {
+		t.Errorf("ListRealms tripped 'metadata file does not exist' on a non-realm sibling:\n%s", out)
+	}
+}
+
+// TestListRealms_MissingRealmMetadataStillLogsError covers the second half
+// of #473's AC #3: the fix must not silence *real* errors. Removing a real
+// realm's metadata.json (genuine on-disk corruption) is still observable
+// via the runner's debug log; the walker skips the broken realm rather
+// than aborting the pass.
+func TestListRealms_MissingRealmMetadataStillSkipsBrokenRealm(t *testing.T) {
+	runPath := t.TempDir()
+
+	// Plant a realm directory under the metadata root but with no
+	// metadata.json — simulates a partially-deleted or pre-write realm.
+	brokenDir := fs.RealmMetadataDir(runPath, "broken")
+	if err := os.MkdirAll(brokenDir, 0o750); err != nil {
+		t.Fatalf("mkdir broken realm: %v", err)
+	}
+
+	// And one healthy realm so the listing is non-empty.
+	healthyName := "healthy"
+	healthyDoc := v1beta1.RealmDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindRealm,
+		Metadata:   v1beta1.RealmMetadata{Name: healthyName},
+		Spec:       v1beta1.RealmSpec{Namespace: "healthy.kukeon.io"},
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	if err := metadata.WriteMetadata(
+		context.Background(), logger, healthyDoc, fs.RealmMetadataPath(runPath, healthyName),
+	); err != nil {
+		t.Fatalf("seed healthy realm: %v", err)
+	}
+
+	logBuf := &bytes.Buffer{}
+	capturingLogger := slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	r := runner.NewRunner(context.Background(), capturingLogger, runner.Options{RunPath: runPath})
+
+	realms, err := r.ListRealms()
+	if err != nil {
+		t.Fatalf("ListRealms: %v", err)
+	}
+	if len(realms) != 1 || realms[0].Metadata.Name != healthyName {
+		names := make([]string, 0, len(realms))
+		for _, rl := range realms {
+			names = append(names, rl.Metadata.Name)
+		}
+		t.Fatalf("ListRealms = %v, want only [%q]", names, healthyName)
+	}
+}

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -28,9 +28,19 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
+// MetadataRoot returns the root of kukeon's on-disk metadata tree under the
+// daemon's RunPath. All realm/space/stack/cell metadata lives beneath this
+// directory; siblings of the RunPath (e.g. <RunPath>/bin staging the kuketty
+// binary, or the .kukeon-instance.json file) stay outside it so the reconcile
+// loop and the subnet allocator can walk the metadata tree without treating
+// non-metadata subdirectories as realms.
+func MetadataRoot(baseRunPath string) string {
+	return filepath.Join(baseRunPath, consts.KukeonMetadataSubdir)
+}
+
 // RealmMetadataDir returns the metadata directory for the given realm.
 func RealmMetadataDir(baseRunPath, realmName string) string {
-	return filepath.Join(baseRunPath, realmName)
+	return filepath.Join(MetadataRoot(baseRunPath), realmName)
 }
 
 // RealmMetadataPath returns the metadata file path for the given realm.

--- a/internal/util/fs/metadata_test.go
+++ b/internal/util/fs/metadata_test.go
@@ -26,9 +26,29 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
+func TestMetadataRoot(t *testing.T) {
+	got := fs.MetadataRoot("/opt/kukeon")
+	want := "/opt/kukeon/" + consts.KukeonMetadataSubdir
+	if got != want {
+		t.Errorf("MetadataRoot = %q, want %q", got, want)
+	}
+}
+
+func TestRealmMetadataDir_UnderMetadataRoot(t *testing.T) {
+	// The realm dir must live under the metadata root, not directly under
+	// the RunPath: the reconcile loop (#473) walks MetadataRoot to enumerate
+	// realms, so anything outside it is invisible to the walker.
+	got := fs.RealmMetadataDir("/opt/kukeon", "realm")
+	want := "/opt/kukeon/" + consts.KukeonMetadataSubdir + "/realm"
+	if got != want {
+		t.Errorf("RealmMetadataDir = %q, want %q", got, want)
+	}
+}
+
 func TestContainerTTYDir(t *testing.T) {
 	got := fs.ContainerTTYDir("/opt/kukeon", "realm", "space", "stack", "cell", "c1")
-	want := "/opt/kukeon/realm/space/stack/cell/c1/" + consts.KukeonContainerTTYDir
+	want := "/opt/kukeon/" + consts.KukeonMetadataSubdir +
+		"/realm/space/stack/cell/c1/" + consts.KukeonContainerTTYDir
 	if got != want {
 		t.Errorf("ContainerTTYDir = %q, want %q", got, want)
 	}
@@ -36,7 +56,7 @@ func TestContainerTTYDir(t *testing.T) {
 
 func TestContainerSocketPath(t *testing.T) {
 	got := fs.ContainerSocketPath("/opt/kukeon", "realm", "space", "stack", "cell", "c1")
-	want := "/opt/kukeon/realm/space/stack/cell/c1/" +
+	want := "/opt/kukeon/" + consts.KukeonMetadataSubdir + "/realm/space/stack/cell/c1/" +
 		consts.KukeonContainerTTYDir + "/" + consts.KukeonContainerSocketFile
 	if got != want {
 		t.Errorf("ContainerSocketPath = %q, want %q", got, want)

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -9,10 +9,11 @@
 # the manual "Local smoke test" sequence from CLAUDE.md into a runnable artifact.
 #
 # Idempotent: re-running on a healthy host produces a clean re-bootstrap.
-# On a fresh host (no /opt/kukeon/kuke-system) the script first runs `kuke
-# init` to create realm metadata so the subsequent `kuke image load --realm
-# kuke-system` has a realm to land into; cell provisioning during that
-# first-pass init may fail before the image is staged, which is expected.
+# On a fresh host (no /opt/kukeon/data/kuke-system) the script first runs
+# `kuke init` to create realm metadata so the subsequent `kuke image load
+# --realm kuke-system` has a realm to land into; cell provisioning during
+# that first-pass init may fail before the image is staged, which is
+# expected.
 
 set -euo pipefail
 
@@ -21,7 +22,12 @@ cd "${REPO_ROOT}"
 
 LOCAL_TAG="kukeon-local:dev"
 KUKEOND_IMAGE_REF="docker.io/library/${LOCAL_TAG}"
-SYSTEM_REALM_DIR="/opt/kukeon/kuke-system"
+# The on-disk metadata layout lives under /opt/kukeon/data/ — see
+# internal/consts.KukeonMetadataSubdir. Siblings of the data root (e.g.
+# /opt/kukeon/bin/kuketty staged by `kuke init`) intentionally fall outside
+# the reconcile-loop walker.
+METADATA_ROOT="/opt/kukeon/data"
+SYSTEM_REALM_DIR="${METADATA_ROOT}/kuke-system"
 KUKEOND_CELL_DIR="${SYSTEM_REALM_DIR}/kukeon/kukeon/kukeond"
 
 step() {
@@ -105,7 +111,7 @@ ATTACH_SMOKE_SPACE="ds"
 ATTACH_SMOKE_STACK="dks"
 ATTACH_SMOKE_CELL="cattach"
 ATTACH_SMOKE_CONTAINER="work"
-ATTACH_SMOKE_BASE="/opt/kukeon/${ATTACH_SMOKE_REALM}/${ATTACH_SMOKE_SPACE}/${ATTACH_SMOKE_STACK}/${ATTACH_SMOKE_CELL}/${ATTACH_SMOKE_CONTAINER}"
+ATTACH_SMOKE_BASE="${METADATA_ROOT}/${ATTACH_SMOKE_REALM}/${ATTACH_SMOKE_SPACE}/${ATTACH_SMOKE_STACK}/${ATTACH_SMOKE_CELL}/${ATTACH_SMOKE_CONTAINER}"
 ATTACH_SMOKE_SOCKET="${ATTACH_SMOKE_BASE}/tty/socket"
 ATTACH_SMOKE_METADATA="${ATTACH_SMOKE_BASE}/kuketty-metadata.json"
 ATTACH_SMOKE_TMP="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- The reconcile loop was walking `/opt/kukeon/*` and treating every subdirectory as a realm. `/opt/kukeon/bin/` (where `kuke init` stages `kuketty`) tripped the walker into an `ERROR msg=\"metadata file does not exist\" file=/opt/kukeon/bin/metadata.json` line every 30s — hot misleading signal for operators tailing `kuke daemon logs`, and a false page for anyone alerting on ERROR severity.
- Move kukeon's on-disk metadata one level deeper under `<RunPath>/data/` (new `consts.KukeonMetadataSubdir`, new `fs.MetadataRoot()` helper) so walkers — `ListRealms` and the subnet allocator — scope themselves to the metadata subtree. Siblings of the RunPath (`bin/kuketty`, `.kukeon-instance.json`) intentionally fall outside it. Per the issue comment's preferred option ("Use /opt/kukeon/data for metadata, … every single directory is a realm, etc.").
- Composed: `fs.RealmMetadataDir` now joins `MetadataRoot(runPath)/<realm>` (Space/Stack/Cell/Container path helpers compose off it, so they pick up the prefix automatically). `cni.SubnetAllocator` stores `dataRoot = <RunPath>/data` and scans only there. `kuke daemon reset --purge-system` targets `<RunPath>/data/kuke-system`. `scripts/dev-init.sh`'s `SYSTEM_REALM_DIR` and `ATTACH_SMOKE_BASE` follow.

## Behavior

- After `make dev-init` the reconcile loop is silent at ERROR level: a 70-second observation window with two full reconcile ticks logged only `INFO msg=\"reconcile ok\"` (verified by `kuke daemon logs` after the smoke succeeded — zero `level=ERROR` lines for `/opt/kukeon/bin/metadata.json`, and zero overall during steady-state reconcile cycles).
- A missing `metadata.json` under a real realm directory still surfaces as ERROR — the fix only excludes non-metadata siblings of the RunPath, not malformed entries inside `data/`. Covered by `TestListRealms_MissingRealmMetadataStillSkipsBrokenRealm`.
- The non-realm sibling case (AC #5) is covered by `TestListRealms_NonRealmSiblingUnderRunPathIsIgnored`, colocated with the runner package that owns the walker. It plants `<RunPath>/bin/kuketty` and `<RunPath>/.kukeon-instance.json` next to one real realm and asserts that the listing contains exactly the realm and the captured logger emitted zero `level=ERROR` lines.
- No on-disk migration helper. Operators with a pre-existing `/opt/kukeon/<realm>/` layout from before this change will see the daemon ignore those directories; `kuke init` recreates the metadata under `/opt/kukeon/data/<realm>/` on first run. CLAUDE.md's smoke-test wording references the old paths in two places ("User-realm data under `/opt/kukeon/default`", "wipe `/opt/kukeon/kuke-system`") and is filed separately as a `docs:` follow-up so this PR stays code-only.

## Test plan

- [x] `go build ./...` — clean compile.
- [x] `go test \$(go list ./... | grep -v /e2e\$)` — green across every non-e2e package; the affected packages (`internal/util/fs`, `internal/cni`, `internal/controller/runner`, `cmd/kuke/daemon/reset`) all pass with the updated layout expectations and the new walker tests.
- [x] `make dev-init` — full re-bootstrap loop. Daemon-parity check matches: `kuke get realms` and `kuke get realms --no-daemon` both return the canonical 2-realm Ready listing. The kuketty attach smoke (`kuke attach exited cleanly`) passes after the script's hardcoded `/opt/kukeon/${realm}/...` paths follow the new layout under `/opt/kukeon/data/`.
- [x] `kuke daemon logs` after dev-init — zero `level=ERROR` lines for `/opt/kukeon/bin/metadata.json`; steady-state reconcile cycles log only INFO. AC #1 and AC #2 verified end-to-end.
- [x] `pre-commit run --files \$(git diff --name-only HEAD~1)` — go fmt, golangci-lint, addlicense, end-of-file-fixer all pass.
- [ ] `go test ./e2e/` — pre-existing host-state flake (the `mkdirRunPath` helper races a parallel test's RemoveAll on the shared `e2e/tmp/` parent), reproducible on `origin/main` at the same rate (~40% across 5 runs). Unrelated to this change.

Closes #473