### PR TITLE
fix: switch e2e run paths to t.TempDir() to drop shared tmp/ race

### DIFF
--- a/e2e/e2e_kuke_apply_test.go
+++ b/e2e/e2e_kuke_apply_test.go
@@ -239,7 +239,6 @@ func TestKukeApply_Realm_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 
 	// Cleanup: Delete realm
@@ -316,7 +315,6 @@ func TestKukeApply_Space_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 
@@ -396,7 +394,6 @@ func TestKukeApply_Stack_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -489,7 +486,6 @@ func TestKukeApply_Cell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -638,7 +634,6 @@ func TestKukeApply_MultiResource_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -104,11 +104,7 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// creates the metadata dir at provision time and sbsh binds the socket
 	// inside the container at task start. If this is missing, pkg/attach
 	// would fail in a way that's hard to attribute, so check explicitly.
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	socketPath := fs.ContainerSocketPath(filepath.Join(cwd, runPath),
+	socketPath := fs.ContainerSocketPath(runPath,
 		realmName, spaceName, stackName, cellName, "work")
 	waitForSocket(t, socketPath, 10*time.Second)
 
@@ -130,7 +126,7 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// triggering a clean exit.
 	time.Sleep(attachConnectGrace)
 
-	if err = session.Write(sbshDetachSequence); err != nil {
+	if err := session.Write(sbshDetachSequence); err != nil {
 		t.Fatalf("write sbsh detach sequence: %v", err)
 	}
 

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -67,7 +67,6 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// (`--no-daemon`) so the per-container socket lives under the test's
 	// runPath rather than the host daemon's.
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)

--- a/e2e/e2e_kuke_cell_test.go
+++ b/e2e/e2e_kuke_cell_test.go
@@ -51,7 +51,6 @@ func TestKuke_NoCells(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "get", "cell", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
@@ -72,7 +71,6 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -226,7 +224,6 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -419,7 +416,6 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -574,7 +570,6 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -741,7 +736,6 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -908,7 +902,6 @@ func TestKuke_PurgeCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)

--- a/e2e/e2e_kuke_container_test.go
+++ b/e2e/e2e_kuke_container_test.go
@@ -50,7 +50,6 @@ func TestKuke_NoContainers(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "get", "container", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
@@ -71,7 +70,6 @@ func TestKuke_CreateContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -184,7 +182,6 @@ func TestKuke_DeleteContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -333,7 +330,6 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -499,7 +495,6 @@ func TestKuke_StopContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -639,7 +634,6 @@ func TestKuke_KillContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -780,7 +774,6 @@ func TestKuke_PurgeContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)

--- a/e2e/e2e_kuke_delete_f_test.go
+++ b/e2e/e2e_kuke_delete_f_test.go
@@ -30,7 +30,6 @@ func TestKukeDeleteF_Realm(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 
@@ -101,7 +100,6 @@ func TestKukeDeleteF_MultiResource(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := "delete-space-" + strings.TrimPrefix(realmName, "e-r-")
@@ -189,7 +187,6 @@ func TestKukeDeleteF_Cascade(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := "delete-cascade-space-" + strings.TrimPrefix(realmName, "e-r-")
@@ -270,7 +267,6 @@ func TestKukeDeleteF_Idempotent(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 
@@ -400,7 +396,6 @@ func TestDeleteF_Realm_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	namespace := realmName + "-ns"
@@ -480,7 +475,6 @@ func TestDeleteF_Space_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
@@ -565,7 +559,6 @@ func TestDeleteF_Stack_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
@@ -659,7 +652,6 @@ func TestDeleteF_Cell_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
@@ -799,7 +791,6 @@ func TestDeleteF_Container_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)

--- a/e2e/e2e_kuke_invalid_names_test.go
+++ b/e2e/e2e_kuke_invalid_names_test.go
@@ -31,7 +31,6 @@ func TestKuke_CreateSpace_RejectsInvalidNames(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	tests := []struct {
 		name      string
@@ -64,7 +63,6 @@ func TestKuke_CreateStack_RejectsInvalidNames(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	tests := []struct {
 		name      string
@@ -98,7 +96,6 @@ func TestKuke_CreateCell_RejectsInvalidNames(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	tests := []struct {
 		name     string
@@ -132,7 +129,6 @@ func TestKuke_CreateContainer_RejectsInvalidNames(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	tests := []struct {
 		name          string

--- a/e2e/e2e_kuke_realm_test.go
+++ b/e2e/e2e_kuke_realm_test.go
@@ -42,14 +42,8 @@ func generateUniqueRealmName(t *testing.T) string {
 func verifyRealmMetadataExists(t *testing.T, runPath, realmName string) bool {
 	t.Helper()
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	fullRunPath := filepath.Join(cwd, runPath)
-
-	metadataPath := fs.RealmMetadataPath(fullRunPath, realmName)
-	_, err = os.Stat(metadataPath)
+	metadataPath := fs.RealmMetadataPath(runPath, realmName)
+	_, err := os.Stat(metadataPath)
 	return err == nil
 }
 
@@ -133,7 +127,6 @@ func TestKuke_NoRealms(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "get", "realm", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
@@ -180,7 +173,6 @@ func TestKuke_CreateRealm_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 
 	// Cleanup: Delete realm
@@ -257,7 +249,6 @@ func TestKuke_DeleteRealm_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 
 	// Cleanup: Safety net (realm should already be deleted, but ensure cleanup if test fails partway)
@@ -349,7 +340,6 @@ func TestKuke_PurgeRealm_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 
 	// Cleanup: Safety net (realm should already be purged, but ensure cleanup if test fails partway)

--- a/e2e/e2e_kuke_space_test.go
+++ b/e2e/e2e_kuke_space_test.go
@@ -39,7 +39,6 @@ func TestKuke_NoSpaces(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "get", "space", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
@@ -60,7 +59,6 @@ func TestKuke_CreateSpace_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 
@@ -136,7 +134,6 @@ func TestKuke_DeleteSpace_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 
@@ -233,7 +230,6 @@ func TestKuke_PurgeSpace_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 

--- a/e2e/e2e_kuke_stack_test.go
+++ b/e2e/e2e_kuke_stack_test.go
@@ -48,7 +48,6 @@ func TestKuke_NoStacks(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "get", "stack", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
@@ -69,7 +68,6 @@ func TestKuke_CreateStack_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -166,7 +164,6 @@ func TestKuke_DeleteStack_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -297,7 +294,6 @@ func TestKuke_PurgeStack_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -146,7 +146,6 @@ func TestKuke_DaemonStart_Uninitialized(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "daemon", "start")
 	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
@@ -170,7 +169,6 @@ func TestKuke_DaemonStop_Uninitialized(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "daemon", "stop")
 	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
@@ -193,7 +191,6 @@ func TestKuke_DaemonKill_Uninitialized(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "daemon", "kill")
 	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
@@ -218,7 +215,6 @@ func TestKuke_DaemonRestart_Uninitialized(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "daemon", "restart")
 	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
@@ -258,7 +254,6 @@ func TestKuke_DaemonReset_Uninitialized(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	args := append(buildKukeRunPathArgs(runPath), "daemon", "reset")
 	exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
@@ -303,15 +298,9 @@ func TestKuke_DaemonReset_Flags(t *testing.T) {
 // host-level state init touches.
 func TestKuke_DaemonReset_RoundTrip(t *testing.T) {
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	fullRunPath := filepath.Join(cwd, runPath)
-	defaultRealmDir := filepath.Join(fullRunPath, consts.KukeonDefaultRealmName)
-	systemRealmDir := filepath.Join(fullRunPath, consts.KukeSystemRealmName)
+	defaultRealmDir := filepath.Join(runPath, consts.KukeonDefaultRealmName)
+	systemRealmDir := filepath.Join(runPath, consts.KukeSystemRealmName)
 
 	t.Cleanup(func() {
 		// Best-effort host-level cleanup: a final reset --purge-system if the
@@ -453,7 +442,6 @@ func TestKuke_Init_VerifyState(t *testing.T) {
 
 	// Setup: Use a fresh, isolated run path
 	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
 
 	// Step 0: Purge resources created by init in reverse dependency order
 	// (cleanup from previous runs that may have left orphaned containerd containers)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -110,46 +109,16 @@ func runBinary(t *testing.T, env []string, command string, args ...string) (int,
 	return exitCode, []byte(stdoutBuf.String()), []byte(stderrBuf.String())
 }
 
-// getRandomRunPath generates a temporary run path for test isolation.
+// getRandomRunPath returns a unique, absolute run path for the test, backed
+// by t.TempDir(). The directory is created up front and removed automatically
+// when the test ends, so callers do not need a separate create-or-cleanup
+// step. Each call returns its own path, which avoids contention on a shared
+// parent directory (issue #491: MkdirAll on a shared parent races
+// concurrent t.Cleanup RemoveAll from sibling parallel tests, surfacing as
+// ENOENT on the new leaf).
 func getRandomRunPath(t *testing.T) string {
 	t.Helper()
-	// Use timestamp-based ID for uniqueness
-	timestamp := time.Now().UnixNano()
-	rndDir := fmt.Sprintf("e-%d", timestamp)
-	fullDir := path.Join("tmp", rndDir)
-	return fullDir
-}
-
-// mkdirRunPath creates the temporary run path directory.
-func mkdirRunPath(t *testing.T, fullDir string) {
-	t.Helper()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	fullDir = filepath.Join(cwd, fullDir)
-	if err = os.MkdirAll(fullDir, 0o755); err != nil {
-		t.Fatalf("could not create dir %s: %v", fullDir, err)
-	}
-
-	// Register cleanup to remove the tmp directory after test
-	t.Cleanup(func() {
-		if removeErr := os.RemoveAll(fullDir); removeErr != nil {
-			t.Logf("failed to cleanup tmp directory %q: %v", fullDir, removeErr)
-		}
-
-		// Also remove parent tmp directory if it's empty
-		tmpDir := filepath.Dir(fullDir)
-		if tmpDir != "" && filepath.Base(tmpDir) == "tmp" {
-			entries, readErr := os.ReadDir(tmpDir)
-			if readErr == nil && len(entries) == 0 {
-				// tmp directory is empty, remove it
-				if removeErr := os.Remove(tmpDir); removeErr != nil {
-					t.Logf("failed to cleanup parent tmp directory %q: %v", tmpDir, removeErr)
-				}
-			}
-		}
-	})
+	return t.TempDir()
 }
 
 // buildKukeRunPathArgs builds --run-path flag arguments.
@@ -318,13 +287,7 @@ func generateUniqueSpaceName(t *testing.T) string {
 func verifySpaceCNIConfigExists(t *testing.T, runPath, realmName, spaceName string) bool {
 	t.Helper()
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	fullRunPath := filepath.Join(cwd, runPath)
-
-	confPath, err := fs.SpaceNetworkConfigPath(fullRunPath, realmName, spaceName)
+	confPath, err := fs.SpaceNetworkConfigPath(runPath, realmName, spaceName)
 	if err != nil {
 		t.Logf("failed to build CNI config path: %v", err)
 		return false
@@ -338,14 +301,8 @@ func verifySpaceCNIConfigExists(t *testing.T, runPath, realmName, spaceName stri
 func verifySpaceMetadataExists(t *testing.T, runPath, realmName, spaceName string) bool {
 	t.Helper()
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	fullRunPath := filepath.Join(cwd, runPath)
-
-	metadataPath := fs.SpaceMetadataPath(fullRunPath, realmName, spaceName)
-	_, err = os.Stat(metadataPath)
+	metadataPath := fs.SpaceMetadataPath(runPath, realmName, spaceName)
+	_, err := os.Stat(metadataPath)
 	return err == nil
 }
 
@@ -427,14 +384,8 @@ func generateUniqueStackName(t *testing.T) string {
 func verifyStackMetadataExists(t *testing.T, runPath, realmName, spaceName, stackName string) bool {
 	t.Helper()
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	fullRunPath := filepath.Join(cwd, runPath)
-
-	metadataPath := fs.StackMetadataPath(fullRunPath, realmName, spaceName, stackName)
-	_, err = os.Stat(metadataPath)
+	metadataPath := fs.StackMetadataPath(runPath, realmName, spaceName, stackName)
+	_, err := os.Stat(metadataPath)
 	return err == nil
 }
 
@@ -545,14 +496,8 @@ func generateUniqueContainerName(t *testing.T) string {
 func verifyCellMetadataExists(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) bool {
 	t.Helper()
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	fullRunPath := filepath.Join(cwd, runPath)
-
-	metadataPath := fs.CellMetadataPath(fullRunPath, realmName, spaceName, stackName, cellName)
-	_, err = os.Stat(metadataPath)
+	metadataPath := fs.CellMetadataPath(runPath, realmName, spaceName, stackName, cellName)
+	_, err := os.Stat(metadataPath)
 	return err == nil
 }
 


### PR DESCRIPTION
## Summary

- The e2e harness handed every test a unique-suffix path under a shared `e2e/tmp/` parent and created it with `os.MkdirAll`. Under `t.Parallel()`, a sibling test's `t.Cleanup` `os.RemoveAll(tmp/e-X)` could race a peer's `os.MkdirAll(tmp/e-Y)` for the same parent inode, surfacing as `ENOENT` on the *new* leaf — ~40% failure rate on local re-runs, deterministically green only with `-run <single>`. Per the issue's preferred option, replace the bespoke helper with `t.TempDir()`: each test gets its own absolute path under `os.TempDir()`, `testing` registers per-test cleanup, and the shared-parent contention disappears.
- `getRandomRunPath` now returns `t.TempDir()` (absolute path, auto-cleaned). `mkdirRunPath` is removed — the directory already exists when the helper returns, so the call-site pair (`getRandomRunPath` + `mkdirRunPath`) collapses to one line. Six verifier helpers (`verifySpaceCNIConfigExists`, `verifySpaceMetadataExists`, `verifyStackMetadataExists`, `verifyCellMetadataExists`, `verifyRealmMetadataExists`, and the inline join in `TestKuke_DaemonReset_RoundTrip`) previously prepended `cwd` to a relative `runPath`; with `runPath` now absolute, the `filepath.Join(cwd, runPath)` becomes wrong (`filepath.Join("/work", "/tmp/x")` → `/work/tmp/x`), so those wraps are dropped and the helpers pass `runPath` straight to the `fs` builders. `appendNoDaemonRunPath` / `absRunPath` (attach test) already handle absolute paths via `filepath.IsAbs`, so no change there.

## Test plan

- [x] `go build ./...` — clean compile.
- [x] `go test $(go list ./... | grep -v /e2e$)` — full non-e2e sweep green (60+ packages including `internal/cni`, `internal/controller/runner`, `internal/ctr`, `cmd/...`). No regressions.
- [x] `for i in 1 2 3 4 5; do go test -count=1 -timeout 300s ./e2e/ 2>&1 | tail -8; done` — five consecutive full e2e runs on this dev host: zero `could not create dir … no such file or directory` failures (the exact race the issue reports). The bare-`grep -iE "could not create dir|mkdir.*no such file"` over the same 5 runs returns no matches. Remaining e2e failures on this host are environmental (no kukeond daemon, no kuketty binary staged) — verified to reproduce identically on `origin/main` with the change stashed (`TestKuke_NoRealms` fails on both with the same `dial unix /run/kukeon/kukeond.sock: connect: no such file or directory`), so they are pre-existing and unrelated.
- [x] `pre-commit run --files \$(git diff --name-only HEAD~1)` — trim-trailing-whitespace, fix-end-of-files, go-fmt, go-mod-tidy, golangci-lint, addlicense all pass.
- [ ] `make dev-init` — not run. This PR is e2e-test-only; it does not touch what the daemon reads (`/opt/kukeon` layout, walker, metadata files, CNI configs) or the build path. CLAUDE.md's daemon-parity guard is scoped to changes the daemon observes — none apply here.

Closes #491