### PR TITLE
refactor: render kuketty TerminalDoc from cell fields via sbsh v0.11.2 inline builder

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -679,9 +679,7 @@ func containerTtysEqual(a, b *v1beta1.ContainerTty) bool {
 		return false
 	}
 	if a.Prompt != b.Prompt ||
-		a.LogFile != b.LogFile ||
-		a.Profile != b.Profile ||
-		a.ProfilesDir != b.ProfilesDir {
+		a.LogFile != b.LogFile {
 		return false
 	}
 	if len(a.OnInit) != len(b.OnInit) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.11.1
+	github.com/eminwux/sbsh v0.11.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.11.1 h1:iUGNvfDoP8UMfYPWyd0Yv7OAx9C/TRJUEk+rDxlvuYc=
-github.com/eminwux/sbsh v0.11.1/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
+github.com/eminwux/sbsh v0.11.2 h1:/JnQl7IeCbugePX+tHQ/kC1iTb7hCtezzZsC5ZQheQY=
+github.com/eminwux/sbsh v0.11.2/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -517,10 +517,8 @@ func convertContainerTtyToInternal(in *ext.ContainerTty) *intmodel.ContainerTty 
 		return nil
 	}
 	out := &intmodel.ContainerTty{
-		Prompt:      in.Prompt,
-		LogFile:     in.LogFile,
-		Profile:     in.Profile,
-		ProfilesDir: in.ProfilesDir,
+		Prompt:  in.Prompt,
+		LogFile: in.LogFile,
 	}
 	if len(in.OnInit) > 0 {
 		out.OnInit = make([]intmodel.TtyStage, len(in.OnInit))
@@ -538,10 +536,8 @@ func buildContainerTtyExternalFromInternal(in *intmodel.ContainerTty) *ext.Conta
 		return nil
 	}
 	out := &ext.ContainerTty{
-		Prompt:      in.Prompt,
-		LogFile:     in.LogFile,
-		Profile:     in.Profile,
-		ProfilesDir: in.ProfilesDir,
+		Prompt:  in.Prompt,
+		LogFile: in.LogFile,
 	}
 	if len(in.OnInit) > 0 {
 		out.OnInit = make([]ext.TtyStage, len(in.OnInit))

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -1132,9 +1132,7 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 					{Script: "git pull"},
 					{Script: "claude"},
 				},
-				LogFile:     "/run/kukeon/tty/log",
-				Profile:     "claude",
-				ProfilesDir: "/opt/kukeon/profiles",
+				LogFile: "/run/kukeon/tty/log",
 			},
 		},
 	}
@@ -1150,12 +1148,6 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 	}
 	if internal.Spec.Tty.LogFile != input.Spec.Tty.LogFile {
 		t.Errorf("internal logFile = %q, want %q", internal.Spec.Tty.LogFile, input.Spec.Tty.LogFile)
-	}
-	if internal.Spec.Tty.Profile != input.Spec.Tty.Profile {
-		t.Errorf("internal profile = %q, want %q", internal.Spec.Tty.Profile, input.Spec.Tty.Profile)
-	}
-	if internal.Spec.Tty.ProfilesDir != input.Spec.Tty.ProfilesDir {
-		t.Errorf("internal profilesDir = %q, want %q", internal.Spec.Tty.ProfilesDir, input.Spec.Tty.ProfilesDir)
 	}
 	if len(internal.Spec.Tty.OnInit) != 2 ||
 		internal.Spec.Tty.OnInit[0].Script != "git pull" ||
@@ -1174,12 +1166,6 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 	}
 	if out.Spec.Tty.LogFile != input.Spec.Tty.LogFile {
 		t.Errorf("round-trip logFile = %q, want %q", out.Spec.Tty.LogFile, input.Spec.Tty.LogFile)
-	}
-	if out.Spec.Tty.Profile != input.Spec.Tty.Profile {
-		t.Errorf("round-trip profile = %q, want %q", out.Spec.Tty.Profile, input.Spec.Tty.Profile)
-	}
-	if out.Spec.Tty.ProfilesDir != input.Spec.Tty.ProfilesDir {
-		t.Errorf("round-trip profilesDir = %q, want %q", out.Spec.Tty.ProfilesDir, input.Spec.Tty.ProfilesDir)
 	}
 	if len(out.Spec.Tty.OnInit) != len(input.Spec.Tty.OnInit) {
 		t.Fatalf("round-trip onInit len = %d, want %d", len(out.Spec.Tty.OnInit), len(input.Spec.Tty.OnInit))
@@ -1286,14 +1272,10 @@ func TestContainerTtyRejectedWithoutAttachable(t *testing.T) {
 		{"prompt only", &ext.ContainerTty{Prompt: `"\u\$ "`}},
 		{"onInit only", &ext.ContainerTty{OnInit: []ext.TtyStage{{Script: "echo"}}}},
 		{"logFile only", &ext.ContainerTty{LogFile: "/run/kukeon/tty/log"}},
-		{"profile only", &ext.ContainerTty{Profile: "claude"}},
-		{"profilesDir only", &ext.ContainerTty{ProfilesDir: "/opt/kukeon/profiles"}},
 		{"all set", &ext.ContainerTty{
-			Prompt:      `"\u\$ "`,
-			OnInit:      []ext.TtyStage{{Script: "echo"}},
-			LogFile:     "/run/kukeon/tty/log",
-			Profile:     "claude",
-			ProfilesDir: "/opt/kukeon/profiles",
+			Prompt:  `"\u\$ "`,
+			OnInit:  []ext.TtyStage{{Script: "echo"}},
+			LogFile: "/run/kukeon/tty/log",
 		}},
 	}
 	for _, tc := range cases {

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -171,47 +171,43 @@ func (r *Exec) attachableBuildOpts(_ string, spec intmodel.ContainerSpec, _ []ct
 // into TerminalSpec.Command / TerminalSpec.CommandArgs via sbsh's
 // builder.WithCommand so the kuketty side spawns the workload via sbsh's
 // terminal runner instead of the wrapper's argv. An empty workloadArgv
-// leaves the builder's profile default in place (sbsh's hardcoded default
-// profile is /bin/bash -i, matching the legacy fallback when the user
-// supplied no command).
+// leaves sbsh's inline-builder default (/bin/bash -i) in place, matching
+// the legacy fallback when the user supplied no command.
 func (r *Exec) writeKukettyMetadata(
 	path string,
 	spec intmodel.ContainerSpec,
 	kukeonGroupGID int,
 	workloadArgv []string,
 ) error {
-	profileConfigured := spec.Tty != nil && spec.Tty.Profile != ""
+	prompt := ""
+	if spec.Tty != nil {
+		prompt = spec.Tty.Prompt
+	}
 	opts := []sbshbuilder.TerminalOption{
 		sbshbuilder.WithSocketFile(ctr.AttachableSocketPath),
 		// Capture file is anchored to the kukeon-controlled per-container
 		// tty dir so `kuke log` (which tails ContainerCapturePath on the
 		// host) and the in-container writer see the same inode through the
 		// directory bind mount. Without an explicit WithCaptureFile, sbsh's
-		// profile builder derives a capture path from runPath + ID that
+		// inline builder derives a capture path from runPath + ID that
 		// would land outside the bind-mount, hiding the transcript from the
 		// host.
 		sbshbuilder.WithCaptureFile(ctr.AttachableCapturePath),
+		// Spec.Prompt + Spec.SetPrompt are stamped from the cell's inline
+		// Tty.Prompt with no profile loader involved (#494): an empty
+		// prompt pairs with DisableSetPrompt(true) so a non-shell workload
+		// (nginx, python) never receives a literal `export PS1=…` on
+		// stdin; a non-empty prompt flips SetPrompt on (sbsh's
+		// `!DisableSetPrompt` rule). Replaces the phase-4 (#290) profile
+		// lane that loaded sbsh TerminalProfile YAML from disk.
+		sbshbuilder.WithPrompt(prompt),
+		sbshbuilder.WithDisableSetPrompt(prompt == ""),
 	}
-	// Phase 4 (#290) wires the cell's Tty.Profile through to sbsh's builder:
-	// when configured, WithProfile selects the TerminalProfile by name and
-	// WithProfilesDir points the loader at the host-side YAML directory.
-	// sbsh's builder stamps Prompt, SetPrompt, and Stages into the rendered
-	// TerminalSpec; no kukeon-side profile interpreter runs.
-	//
-	// When no profile is configured, both builder options are omitted (so
-	// sbsh's no-profile path runs) and DisableSetPrompt stays on — without
-	// it sbsh's hardcoded default would inject `(sbsh-$ID) $PS1` into a
-	// non-shell workload's stdin. ProfilesDir is only honored alongside
-	// Profile: in isolation it would prime sbsh's profile name to "default"
-	// and chase the configured dir for a YAML the operator never asked to
-	// load.
-	if profileConfigured {
-		opts = append(opts, sbshbuilder.WithProfile(spec.Tty.Profile))
-		if spec.Tty.ProfilesDir != "" {
-			opts = append(opts, sbshbuilder.WithProfilesDir(spec.Tty.ProfilesDir))
-		}
-	} else {
-		opts = append(opts, sbshbuilder.WithDisableSetPrompt(true))
+	if spec.Tty != nil && len(spec.Tty.OnInit) > 0 {
+		// Inline OnInit (#494): map the cell's TtyStage{Script} entries to
+		// sbsh's api.ExecStep{Script}. Before this lane existed, OnInit set
+		// on a cell with no profile was silently dropped (#494 problem 1).
+		opts = append(opts, sbshbuilder.WithOnInit(ttyStagesToExecSteps(spec.Tty.OnInit)))
 	}
 	if mode := modeIfGroupSet(kukeonGroupGID, ctr.AttachableSocketMode); mode != "" {
 		opts = append(opts, sbshbuilder.WithSocketMode(mode))
@@ -251,9 +247,9 @@ func (r *Exec) writeKukettyMetadata(
 		return fmt.Errorf("build kuketty terminal spec: %w", err)
 	}
 	if !logFileConfigured {
-		// sbsh's profile builder unconditionally derives a default
-		// LogFile path from runPath + terminalID when the caller
-		// passes no WithLogFile. That default would land at
+		// sbsh's inline builder unconditionally derives a default LogFile
+		// path from runPath + terminalID when the caller passes no
+		// WithLogFile (applyParamDefaults). That default would land at
 		// /run/kukeon/tty/terminals/<id>/log inside the container —
 		// host-visible through the bind mount, but at a location the
 		// daemon does not advertise. Clearing the field lets kuketty's
@@ -289,6 +285,21 @@ func (r *Exec) writeKukettyMetadata(
 		return fmt.Errorf("rename kuketty metadata %q -> %q: %w", tmp, path, err)
 	}
 	return nil
+}
+
+// ttyStagesToExecSteps maps the cell's inline Tty.OnInit entries into
+// sbsh's api.ExecStep slice. Each stage carries only Script today; sbsh's
+// ExecStep also supports Env, but the cell schema does not surface it yet
+// (a future TtyStage knob lands here without touching the renderer).
+func ttyStagesToExecSteps(in []intmodel.TtyStage) []sbshapi.ExecStep {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]sbshapi.ExecStep, len(in))
+	for i, s := range in {
+		out[i] = sbshapi.ExecStep{Script: s.Script}
+	}
+	return out
 }
 
 // kukettyMetadataLabels stamps the cell-context identity on the rendered

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -352,40 +352,52 @@ func TestWriteKukettyMetadata_LogFileSet(t *testing.T) {
 	}
 }
 
-// TestWriteKukettyMetadata_ProfileConfigured locks phase 4 (#290): when
-// the cell's Tty.Profile and Tty.ProfilesDir are set, the renderer hands
-// both to sbsh's builder via WithProfile / WithProfilesDir. sbsh loads the
-// named TerminalProfile YAML, stamps Prompt + onInit Stages into the
-// rendered Spec, and SetPrompt stays true (the daemon's legacy
-// DisableSetPrompt safety belt drops away when a profile is explicitly
-// configured — the operator opted into PS1 rewriting).
-func TestWriteKukettyMetadata_ProfileConfigured(t *testing.T) {
-	const profileYAML = `apiVersion: sbsh/v1beta1
-kind: TerminalProfile
-metadata:
-  name: claude
-spec:
-  runTarget: local
-  shell:
-    cmd: /bin/bash
-    prompt: "\"phase4-prompt $PS1\""
-  stages:
-    onInit:
-      - script: "echo hello"
-      - script: "echo world"
-`
+// TestWriteKukettyMetadata_PromptConfigured locks the inline-Prompt lane
+// (#494): when the cell sets Tty.Prompt, the renderer stamps it onto
+// Spec.Prompt and flips Spec.SetPrompt on via sbsh's WithPrompt +
+// WithDisableSetPrompt(false). No profile YAML is loaded — the renderer
+// uses sbsh's inline BuildTerminalSpec entry point (sbsh v0.11.2 #209).
+// Replaces the pre-#494 phase-4 profile-coupling test that round-tripped a
+// TerminalProfile YAML through sbsh's pkg/discovery loader.
+func TestWriteKukettyMetadata_PromptConfigured(t *testing.T) {
 	r := newTestRunner(t)
-	profilesDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(profilesDir, "claude.yaml"), []byte(profileYAML), 0o644); err != nil {
-		t.Fatalf("write profile yaml: %v", err)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+	const wantPrompt = `"\[\e[1;36m\]claude \u@\h\[\e[0m\]:\w\$ "`
+	spec := intmodel.ContainerSpec{
+		ID:  "c1",
+		Tty: &intmodel.ContainerTty{Prompt: wantPrompt},
 	}
+
+	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
+		t.Fatalf("writeKukettyMetadata: %v", err)
+	}
+	doc := readDoc(t, path)
+	if doc.Spec.Prompt != wantPrompt {
+		t.Errorf("Spec.Prompt = %q, want %q", doc.Spec.Prompt, wantPrompt)
+	}
+	if !doc.Spec.SetPrompt {
+		t.Errorf("Spec.SetPrompt = false, want true (non-empty inline Tty.Prompt flips it on)")
+	}
+}
+
+// TestWriteKukettyMetadata_OnInitConfigured locks the inline-OnInit lane
+// (#494): when the cell sets Tty.OnInit, the renderer forwards each
+// TtyStage.Script to sbsh's WithOnInit as an api.ExecStep, in order, and
+// the rendered Spec.Stages.OnInit carries the same scripts. Closes the
+// pre-#494 silent drop where OnInit set on a cell with no profile was
+// never stamped onto the TerminalDoc (problem 1 in #494's Context).
+func TestWriteKukettyMetadata_OnInitConfigured(t *testing.T) {
+	r := newTestRunner(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kuketty-metadata.json")
 	spec := intmodel.ContainerSpec{
 		ID: "c1",
 		Tty: &intmodel.ContainerTty{
-			Profile:     "claude",
-			ProfilesDir: profilesDir,
+			OnInit: []intmodel.TtyStage{
+				{Script: "echo hello"},
+				{Script: "echo world"},
+			},
 		},
 	}
 
@@ -393,12 +405,6 @@ spec:
 		t.Fatalf("writeKukettyMetadata: %v", err)
 	}
 	doc := readDoc(t, path)
-	if doc.Spec.Prompt != `"phase4-prompt $PS1"` {
-		t.Errorf("Spec.Prompt = %q, want %q", doc.Spec.Prompt, `"phase4-prompt $PS1"`)
-	}
-	if !doc.Spec.SetPrompt {
-		t.Errorf("Spec.SetPrompt = false, want true (profile drives it; daemon's DisableSetPrompt safety belt off)")
-	}
 	if len(doc.Spec.Stages.OnInit) != 2 {
 		t.Fatalf("Spec.Stages.OnInit len = %d, want 2", len(doc.Spec.Stages.OnInit))
 	}
@@ -406,15 +412,20 @@ spec:
 		doc.Spec.Stages.OnInit[1].Script != "echo world" {
 		t.Errorf("Spec.Stages.OnInit = %+v, want [echo hello, echo world]", doc.Spec.Stages.OnInit)
 	}
+	if len(doc.Spec.Stages.PostAttach) != 0 {
+		t.Errorf("Spec.Stages.PostAttach = %+v, want empty (cell did not set it)", doc.Spec.Stages.PostAttach)
+	}
 }
 
-// TestWriteKukettyMetadata_NoProfileKeepsSafeDefault locks AC #3 (#290):
-// when the cell does not configure a profile, the renderer omits the
-// builder's profile options and keeps the DisableSetPrompt safe default,
-// so Spec.SetPrompt stays false and Spec.Stages stays zero — a workload
-// that is not a shell (nginx, python) never receives a literal PS1
-// injection on its stdin.
-func TestWriteKukettyMetadata_NoProfileKeepsSafeDefault(t *testing.T) {
+// TestWriteKukettyMetadata_EmptyTtyKeepsSafeDefault locks the safe-default
+// branch for an unconfigured Tty (#494): no cell-level Prompt or OnInit
+// means Spec.SetPrompt stays false (DisableSetPrompt(true) is forced) and
+// Spec.Stages stays zero. Without the DisableSetPrompt(true) belt, sbsh's
+// inline builder would flip SetPrompt on by default (`SetPrompt =
+// !DisableSetPrompt`), which would inject a literal PS1 onto a non-shell
+// workload's stdin. Same invariant the pre-#494 NoProfileKeepsSafeDefault
+// test enforced, now on the profile-free renderer.
+func TestWriteKukettyMetadata_EmptyTtyKeepsSafeDefault(t *testing.T) {
 	r := newTestRunner(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kuketty-metadata.json")
@@ -425,58 +436,16 @@ func TestWriteKukettyMetadata_NoProfileKeepsSafeDefault(t *testing.T) {
 	}
 	doc := readDoc(t, path)
 	if doc.Spec.SetPrompt {
-		t.Errorf("Spec.SetPrompt = true, want false (no profile → DisableSetPrompt safety belt)")
+		t.Errorf("Spec.SetPrompt = true, want false (no inline Prompt → DisableSetPrompt(true))")
+	}
+	if doc.Spec.Prompt != "" {
+		t.Errorf("Spec.Prompt = %q, want empty (no inline Tty.Prompt)", doc.Spec.Prompt)
 	}
 	if len(doc.Spec.Stages.OnInit) != 0 {
-		t.Errorf("Spec.Stages.OnInit = %+v, want empty (no profile)", doc.Spec.Stages.OnInit)
+		t.Errorf("Spec.Stages.OnInit = %+v, want empty (no inline Tty.OnInit)", doc.Spec.Stages.OnInit)
 	}
 	if len(doc.Spec.Stages.PostAttach) != 0 {
-		t.Errorf("Spec.Stages.PostAttach = %+v, want empty (no profile)", doc.Spec.Stages.PostAttach)
-	}
-}
-
-// TestWriteKukettyMetadata_ProfilesDirIgnoredWithoutProfile locks the
-// guard that ProfilesDir is only honored alongside Profile: when Profile
-// is empty, the renderer omits WithProfilesDir so sbsh's builder cannot
-// chase the configured dir for a "default" YAML the operator never asked
-// to load. SetPrompt stays false; Stages stays zero.
-func TestWriteKukettyMetadata_ProfilesDirIgnoredWithoutProfile(t *testing.T) {
-	// Stage a "default" profile in the dir that would set SetPrompt=true
-	// if sbsh were to load it. The renderer must skip the dir entirely.
-	const defaultYAML = `apiVersion: sbsh/v1beta1
-kind: TerminalProfile
-metadata:
-  name: default
-spec:
-  runTarget: local
-  shell:
-    cmd: /bin/bash
-    prompt: "\"should-not-apply $PS1\""
-  stages:
-    onInit:
-      - script: "echo should-not-run"
-`
-	r := newTestRunner(t)
-	profilesDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(profilesDir, "default.yaml"), []byte(defaultYAML), 0o644); err != nil {
-		t.Fatalf("write default profile: %v", err)
-	}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kuketty-metadata.json")
-	spec := intmodel.ContainerSpec{
-		ID:  "c1",
-		Tty: &intmodel.ContainerTty{ProfilesDir: profilesDir},
-	}
-
-	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
-		t.Fatalf("writeKukettyMetadata: %v", err)
-	}
-	doc := readDoc(t, path)
-	if doc.Spec.SetPrompt {
-		t.Errorf("Spec.SetPrompt = true, want false (ProfilesDir without Profile must not load any profile)")
-	}
-	if len(doc.Spec.Stages.OnInit) != 0 {
-		t.Errorf("Spec.Stages.OnInit = %+v, want empty (no Profile)", doc.Spec.Stages.OnInit)
+		t.Errorf("Spec.Stages.PostAttach = %+v, want empty (no inline Tty.OnInit)", doc.Spec.Stages.PostAttach)
 	}
 }
 

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -105,11 +105,9 @@ type ContainerSpec struct {
 // ContainerTty mirrors the v1beta1 ContainerTty payload. See the v1beta1
 // type for field semantics.
 type ContainerTty struct {
-	Prompt      string
-	OnInit      []TtyStage
-	LogFile     string
-	Profile     string
-	ProfilesDir string
+	Prompt  string
+	OnInit  []TtyStage
+	LogFile string
 }
 
 // TtyStage mirrors the v1beta1 TtyStage payload.
@@ -126,12 +124,6 @@ func (t *ContainerTty) IsEmpty() bool {
 		return false
 	}
 	if t.LogFile != "" {
-		return false
-	}
-	if t.Profile != "" {
-		return false
-	}
-	if t.ProfilesDir != "" {
 		return false
 	}
 	for _, s := range t.OnInit {

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -112,13 +112,21 @@ type ContainerSpec struct {
 
 // ContainerTty carries per-attach shell-UX config that the daemon threads
 // into sbsh terminal on first attach. Has no effect unless Attachable=true.
+//
+// All fields are stamped directly onto the rendered sbsh TerminalSpec via
+// sbsh's inline builder lane (sbsh v0.11.2+, kukeon #494). The pre-#494
+// Profile / ProfilesDir fields that pointed at on-disk TerminalProfile YAML
+// have been removed; cell YAML that still carries those keys is silently
+// ignored by the default YAML decoder.
 type ContainerTty struct {
-	// Prompt is the literal prompt expression sbsh sets in the wrapped
-	// shell, in the same form sbsh's TerminalProfile spec.shell.prompt
-	// accepts (e.g. a quoted PS1-style string).
-	Prompt string `json:"prompt,omitempty"      yaml:"prompt,omitempty"`
-	// OnInit are scripts run once when the wrapped shell starts, in order.
-	OnInit []TtyStage `json:"onInit,omitempty"      yaml:"onInit,omitempty"`
+	// Prompt is the literal prompt expression sbsh stamps onto
+	// TerminalSpec.Prompt and flips SetPrompt on for. Empty leaves
+	// SetPrompt off (sbsh's wrapper skips PS1 injection).
+	Prompt string `json:"prompt,omitempty"  yaml:"prompt,omitempty"`
+	// OnInit are scripts run once when the wrapped shell starts, in
+	// order. Forwarded to TerminalSpec.Stages.OnInit via sbsh's
+	// WithOnInit; an empty slice leaves Stages.OnInit zero.
+	OnInit []TtyStage `json:"onInit,omitempty"  yaml:"onInit,omitempty"`
 	// LogFile is the in-container path where sbsh's runner writes its
 	// runtime/debug log. Empty (the default) means sbsh's runner skips
 	// log-writer setup entirely. Set this to a path inside the kuketty
@@ -129,24 +137,7 @@ type ContainerTty struct {
 	// — the daemon applies its system-wide AttachableLogFileMode and
 	// the kukeon-group GID, gated on the kukeon group being configured
 	// (matches the SocketMode/CaptureMode treatment).
-	LogFile string `json:"logFile,omitempty"     yaml:"logFile,omitempty"`
-	// Profile names the sbsh TerminalProfile (Metadata.Name) the daemon
-	// asks sbsh's builder to resolve when rendering this container's
-	// kuketty TerminalDoc. The profile YAML lives outside kukeon — sbsh's
-	// pkg/discovery loads it from ProfilesDir at OCI-injection time and
-	// stamps Prompt, SetPrompt, and Stages into the rendered Spec.
-	// Empty (the default) means "no profile": the renderer omits the
-	// builder option, Spec.Prompt / Spec.SetPrompt / Spec.Stages stay
-	// zero, and the workload runs without a prompt override or onInit
-	// stages. Phase 4 (#290).
-	Profile string `json:"profile,omitempty"     yaml:"profile,omitempty"`
-	// ProfilesDir is the host-side directory sbsh's builder scans for
-	// TerminalProfile YAML when resolving Profile. Empty means
-	// "use sbsh's default ($HOME/.sbsh/profiles.d/)"; that default is
-	// rarely the right answer on a daemon host with no operator HOME, so
-	// most cells that set Profile also set ProfilesDir to an explicit
-	// host path. Phase 4 (#290).
-	ProfilesDir string `json:"profilesDir,omitempty" yaml:"profilesDir,omitempty"`
+	LogFile string `json:"logFile,omitempty" yaml:"logFile,omitempty"`
 }
 
 // TtyStage is a single onInit script entry. Wrapped in a struct rather than
@@ -167,12 +158,6 @@ func (t *ContainerTty) IsEmpty() bool {
 		return false
 	}
 	if t.LogFile != "" {
-		return false
-	}
-	if t.Profile != "" {
-		return false
-	}
-	if t.ProfilesDir != "" {
 		return false
 	}
 	for _, s := range t.OnInit {


### PR DESCRIPTION
## Summary

- Profile-coupling rip (#494). `internal/controller/runner/attachable.go::writeKukettyMetadata` now renders the kuketty `TerminalDoc` from the in-memory cell `Tty.*` fields via sbsh v0.11.2's inline `BuildTerminalSpec` (the profile-free lane added in `eminwux/sbsh#209`). `WithProfile` / `WithProfilesDir` are gone, the unconditional `WithDisableSetPrompt(true)` safety belt is replaced by per-cell `WithPrompt(spec.Tty.Prompt) + WithDisableSetPrompt(spec.Tty.Prompt == "")`, and `WithOnInit([]api.ExecStep{...})` closes the silent drop where a cell with no profile but a non-empty `Tty.OnInit` produced an empty `Spec.Stages.OnInit`.
- Cell schema trimmed. `Profile` and `ProfilesDir` are deleted from both `intmodel.ContainerTty` and `ext.ContainerTty`, with the matching apischeme converters and `IsEmpty()` branches removed. The default `gopkg.in/yaml.v3` decoder silently drops unknown keys, so cell YAML that still carries `tty.profile:` / `tty.profilesDir:` parses cleanly and the fields are ignored — chosen over the "reject" path per the AC's pick-one-and-document leeway, because the surrounding container API uses non-strict YAML and rejection would force a YAML migration we have no current operators for. Documented in `ContainerTty`'s docstring.
- `cmd/kuke/run/run.go::containerTtysEqual` loses the corresponding `Profile` / `ProfilesDir` field comparisons; otherwise the drift detector would dereference a deleted field. No other call sites in the tree referenced either field.
- Test refresh. The phase-4 attachable_test.go fixtures (`TestWriteKukettyMetadata_ProfileConfigured`, `_NoProfileKeepsSafeDefault`, `_ProfilesDirIgnoredWithoutProfile`) are replaced with three inline-lane tests (`_PromptConfigured`, `_OnInitConfigured`, `_EmptyTtyKeepsSafeDefault`) that lock the new contract: prompt-stamping + SetPrompt flip on `Tty.Prompt`, `Spec.Stages.OnInit` round-trip for inline `Tty.OnInit`, and the safe-default branch that keeps `SetPrompt=false` and `Stages` zero for an unconfigured Tty. `internal/apischeme/scheme_test.go` loses the Profile / ProfilesDir round-trip assertions and the `profile only` / `profilesDir only` reject cases — the dropped fields no longer round-trip.
- `go.mod` bumps `github.com/eminwux/sbsh` from `v0.11.1` to `v0.11.2` (the release that ships `#209`'s `BuildTerminalSpec` inline lane + `WithPrompt` / `WithOnInit` / `WithStages` options).

The comprehensive cell → TerminalDoc mapping test the AC defers to #493 is not added here — that issue tracks the dedicated coverage and is independent of this fix.

## Test plan

- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test $(go list ./... | grep -v /e2e$)` — 80+ packages green including the rewritten `internal/controller/runner` and `internal/apischeme` suites (no regressions in `cmd/kuke/run`, `internal/modelhub`, `pkg/api/model/v1beta1`).
- [x] `pre-commit run --files $(git diff --name-only HEAD~1)` — trim-trailing-whitespace, fix-end-of-files, go-fmt, go-mod-tidy, golangci-lint, addlicense all pass.
- [x] `make dev-init` daemon-parity tail (the CLAUDE.md regression guard) — both `kuke get realms` and `kuke get realms --no-daemon` produce the canonical `default` + `kuke-system` Ready output. PR does touch what the daemon reads (renderer at `writeKukettyMetadata` + cell schema), so the guard was run.
- [ ] `make dev-init`'s follow-on `kuke attach smoke` step — not run to completion. The dev host carries a pre-#349 / pre-#482 stale `kukeond` task that survives `daemon reset` (`stop kukeond cell: failed to stop cell containers: cell "kukeond" has no RootContainerID set`); reproduces identically on `origin/main` with the change stashed, so it is environmental and pre-existing rather than introduced here. Filed as #495 with the proposed dev-init / daemon-reset fix.
- [ ] e2e: cell with inline `Tty.OnInit` produces a workload where the scripts actually run — not run end-to-end for the same reason as above (the smoke that would surface this is blocked by #495 on this host). The unit-level coverage of the renderer (`TestWriteKukettyMetadata_OnInitConfigured` + `TestWriteKukettyMetadata_PromptConfigured`) locks the daemon side of the contract; the in-container side (kuketty server consuming `Spec.Stages.OnInit`) is sbsh's own coverage area, sealed by sbsh v0.11.2's release.

Closes #494
