### PR TITLE
test: lock comprehensive cell→TerminalDoc mapping and fix EnvInherit drop

### DIFF
--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -202,6 +202,21 @@ func (r *Exec) writeKukettyMetadata(
 		// lane that loaded sbsh TerminalProfile YAML from disk.
 		sbshbuilder.WithPrompt(prompt),
 		sbshbuilder.WithDisableSetPrompt(prompt == ""),
+		// Spec.EnvInherit=true tells sbsh's terminal runner to forward
+		// kuketty's os.Environ() (which is the container's OCI Process.Env
+		// — user-supplied containerSpec.Env merged with kukeon's KUKEON_*
+		// identity vars at ctr.BuildContainerSpec) to the workload child.
+		// Without it, sbsh's runner spawns the workload with only HOME +
+		// SBSH_* set (sbsh@v0.11.2/internal/terminal/terminalrunner/
+		// terminal.go:54) — every user env entry and every KUKEON_* entry
+		// gets stripped at the kuketty → workload boundary. Pre-#494 the
+		// profile lane's no-profile fallback defaulted EnvInherit=true
+		// (sbsh@v0.11.1/internal/profile/profile.go:454), so the inline-
+		// builder migration silently regressed env passthrough — this
+		// option restores the kukeon contract that the OCI Process.Env IS
+		// the workload's env. Pinned by the comprehensive renderer test in
+		// attachable_test.go so a future refactor cannot drop it.
+		sbshbuilder.WithEnvInherit(true),
 	}
 	if spec.Tty != nil && len(spec.Tty.OnInit) > 0 {
 		// Inline OnInit (#494): map the cell's TtyStage{Script} entries to

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/ctr"
@@ -163,7 +164,12 @@ func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
 	}
 	wantArgs := []string{"-c", "echo hello"}
 	if len(doc.Spec.CommandArgs) != len(wantArgs) {
-		t.Fatalf("Spec.CommandArgs len = %d, want %d (full=%v)", len(doc.Spec.CommandArgs), len(wantArgs), doc.Spec.CommandArgs)
+		t.Fatalf(
+			"Spec.CommandArgs len = %d, want %d (full=%v)",
+			len(doc.Spec.CommandArgs),
+			len(wantArgs),
+			doc.Spec.CommandArgs,
+		)
 	}
 	for i, want := range wantArgs {
 		if doc.Spec.CommandArgs[i] != want {
@@ -349,6 +355,202 @@ func TestWriteKukettyMetadata_LogFileSet(t *testing.T) {
 				t.Errorf("Spec.LogFileGID = %v, want nil", doc.Spec.LogFileGID)
 			}
 		})
+	}
+}
+
+// ttyFieldsCoveredByMapping is the structural half of #493's "every Tty
+// field must map" guard: it enumerates intmodel.ContainerTty via
+// reflection and fails the test when a declared field is missing from
+// mapperedFields, or when mapperedFields carries a stale entry the
+// struct no longer declares. The comprehensive test below supplies the
+// behavioral half (each mapped field has a TerminalDoc.Spec assertion).
+//
+// New fields landing on intmodel.ContainerTty must touch two places to
+// keep the test green:
+//
+//  1. Add the field name to mapperedFields here.
+//  2. Wire it through writeKukettyMetadata and add an assertion to
+//     TestWriteKukettyMetadata_AllTtyFieldsMap.
+//
+// Skipping step 1 fails the structural check; skipping step 2 fails the
+// per-field behavioral check. The pre-#494 silent-drop pattern (Tty.OnInit
+// declared on the schema but never read by the renderer) fails (2).
+func ttyFieldsCoveredByMapping(t *testing.T) {
+	t.Helper()
+	// Local map so the linter's gochecknoglobals rule stays clean and the
+	// list reads as part of the test contract rather than a package
+	// secret. Keep alphabetized.
+	mapperedFields := map[string]struct{}{
+		"LogFile": {},
+		"OnInit":  {},
+		"Prompt":  {},
+	}
+	typ := reflect.TypeOf(intmodel.ContainerTty{})
+	declared := make(map[string]struct{}, typ.NumField())
+	for i := range typ.NumField() {
+		name := typ.Field(i).Name
+		declared[name] = struct{}{}
+		if _, ok := mapperedFields[name]; !ok {
+			t.Errorf(
+				"intmodel.ContainerTty.%s is declared on the cell schema but missing from "+
+					"mapperedFields. Decide whether writeKukettyMetadata should stamp it onto "+
+					"TerminalDoc.Spec; if yes, wire it through and extend "+
+					"TestWriteKukettyMetadata_AllTtyFieldsMap with an assertion; if no, document "+
+					"the deliberate drop in a code comment and still add the field here so the "+
+					"reflect check sees it.",
+				name,
+			)
+		}
+	}
+	for name := range mapperedFields {
+		if _, ok := declared[name]; !ok {
+			t.Errorf(
+				"mapperedFields references %q but intmodel.ContainerTty no longer declares it — "+
+					"drop the stale entry.",
+				name,
+			)
+		}
+	}
+}
+
+// TestWriteKukettyMetadata_AllTtyFieldsMap is the comprehensive renderer
+// guard #493 calls for. It exercises three concentric invariants:
+//
+//  1. Reflective coverage (ttyFieldsCoveredByMapping): every field declared
+//     on intmodel.ContainerTty is listed in mapperedFields. New fields
+//     must touch this file or the test fails.
+//  2. Per-field behavior: each Tty.* knob set on the input has a non-zero
+//     counterpart on the rendered TerminalDoc.Spec. The pre-#494 Tty.OnInit
+//     drop (declared on the schema, never read by the renderer) is the
+//     canonical failure mode this catches.
+//  3. Renderer-default invariants the cell schema does NOT surface but the
+//     renderer is responsible for stamping on every TerminalDoc:
+//     EnvInherit, SocketFile, CaptureFile, RunPath. EnvInherit=true is the
+//     bug fix from #494 that this test pins — without it, sbsh's terminal
+//     runner spawns the workload with HOME + SBSH_* only, stripping the
+//     user-supplied env and the KUKEON_* identity vars the OCI Process.Env
+//     already carries (sbsh@v0.11.2/internal/terminal/terminalrunner/
+//     terminal.go:54). Pre-#494 the profile loader's no-profile fallback
+//     defaulted EnvInherit=true (sbsh@v0.11.1/internal/profile/
+//     profile.go:454), so the inline-builder migration silently regressed
+//     env passthrough.
+//
+// When a new field lands on ContainerTty, this is the test that fails
+// until the renderer is taught to forward it and the mapping list is
+// updated.
+func TestWriteKukettyMetadata_AllTtyFieldsMap(t *testing.T) {
+	ttyFieldsCoveredByMapping(t)
+
+	r := newTestRunner(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+
+	const wantPrompt = `"\u@\h:\w\$ "`
+	wantOnInit := []intmodel.TtyStage{
+		{Script: "echo hello"},
+		{Script: "echo world"},
+	}
+	const wantLogFile = ctr.AttachableLogfilePath
+	const kukeonGID = 986
+	workload := []string{"/bin/sh", "-c", "exec /workload"}
+
+	spec := intmodel.ContainerSpec{
+		ID:         "c1",
+		RealmName:  "rA",
+		SpaceName:  "sB",
+		StackName:  "kC",
+		CellName:   "lD",
+		Attachable: true,
+		Tty: &intmodel.ContainerTty{
+			Prompt:  wantPrompt,
+			OnInit:  wantOnInit,
+			LogFile: wantLogFile,
+		},
+	}
+
+	if err := r.writeKukettyMetadata(path, spec, kukeonGID, workload); err != nil {
+		t.Fatalf("writeKukettyMetadata: %v", err)
+	}
+	doc := readDoc(t, path)
+
+	// Tty.Prompt → Spec.Prompt + Spec.SetPrompt (sbsh's `SetPrompt =
+	// !DisableSetPrompt` rule flips SetPrompt on for a non-empty prompt).
+	if doc.Spec.Prompt != wantPrompt {
+		t.Errorf("Tty.Prompt: Spec.Prompt = %q, want %q", doc.Spec.Prompt, wantPrompt)
+	}
+	if !doc.Spec.SetPrompt {
+		t.Errorf("Tty.Prompt: Spec.SetPrompt = false, want true (non-empty inline prompt)")
+	}
+
+	// Tty.OnInit → Spec.Stages.OnInit. The pre-#494 silent-drop fix: each
+	// TtyStage.Script lands as an api.ExecStep.Script in order. Stages.PostAttach
+	// is not surfaced on the cell schema and must stay zero.
+	if len(doc.Spec.Stages.OnInit) != len(wantOnInit) {
+		t.Fatalf(
+			"Tty.OnInit: Spec.Stages.OnInit len = %d, want %d (full=%+v)",
+			len(doc.Spec.Stages.OnInit), len(wantOnInit), doc.Spec.Stages.OnInit,
+		)
+	}
+	for i, want := range wantOnInit {
+		if doc.Spec.Stages.OnInit[i].Script != want.Script {
+			t.Errorf(
+				"Tty.OnInit[%d]: Spec.Stages.OnInit[%d].Script = %q, want %q",
+				i, i, doc.Spec.Stages.OnInit[i].Script, want.Script,
+			)
+		}
+	}
+	if len(doc.Spec.Stages.PostAttach) != 0 {
+		t.Errorf("Spec.Stages.PostAttach = %+v, want empty (not surfaced on cell schema)", doc.Spec.Stages.PostAttach)
+	}
+
+	// Tty.LogFile → Spec.LogFile (verbatim, no daemon-side rewriting).
+	if doc.Spec.LogFile != wantLogFile {
+		t.Errorf("Tty.LogFile: Spec.LogFile = %q, want %q", doc.Spec.LogFile, wantLogFile)
+	}
+
+	// Renderer-default invariants the cell schema does NOT surface. These
+	// are kukeon-side contracts the renderer must stamp regardless of cell
+	// YAML — a regression in any of them silently changes runtime behavior.
+	if !doc.Spec.EnvInherit {
+		t.Errorf(
+			"Spec.EnvInherit = false, want true. kuketty must forward its os.Environ() " +
+				"(== OCI Process.Env, which contains user env + KUKEON_*) to the workload; " +
+				"without WithEnvInherit(true), sbsh's runner strips everything but HOME + SBSH_* " +
+				"(sbsh@v0.11.2/internal/terminal/terminalrunner/terminal.go:54). #494 regression.",
+		)
+	}
+	if doc.Spec.SocketFile != ctr.AttachableSocketPath {
+		t.Errorf(
+			"Spec.SocketFile = %q, want %q (kukeon-controlled bind-mount path)",
+			doc.Spec.SocketFile,
+			ctr.AttachableSocketPath,
+		)
+	}
+	if doc.Spec.CaptureFile != ctr.AttachableCapturePath {
+		t.Errorf(
+			"Spec.CaptureFile = %q, want %q (kukeon-controlled bind-mount path)",
+			doc.Spec.CaptureFile,
+			ctr.AttachableCapturePath,
+		)
+	}
+	if doc.Spec.RunPath != ctr.AttachableTTYDir {
+		t.Errorf("Spec.RunPath = %q, want %q (sbsh's per-terminal root)", doc.Spec.RunPath, ctr.AttachableTTYDir)
+	}
+
+	// workloadArgv → Spec.Command + Spec.CommandArgs. Sanity-checked here
+	// alongside the Tty assertions because the comprehensive test is the
+	// single place a contributor can read off "what the renderer produces
+	// from a fully-populated input" without chasing per-field tests.
+	if doc.Spec.Command != workload[0] {
+		t.Errorf("workloadArgv: Spec.Command = %q, want %q", doc.Spec.Command, workload[0])
+	}
+	if len(doc.Spec.CommandArgs) != len(workload)-1 {
+		t.Fatalf("workloadArgv: Spec.CommandArgs len = %d, want %d", len(doc.Spec.CommandArgs), len(workload)-1)
+	}
+	for i, want := range workload[1:] {
+		if doc.Spec.CommandArgs[i] != want {
+			t.Errorf("workloadArgv: Spec.CommandArgs[%d] = %q, want %q", i, doc.Spec.CommandArgs[i], want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Closes #493 by adding `TestWriteKukettyMetadata_AllTtyFieldsMap` — a comprehensive renderer test that constructs a `ContainerSpec` with every field on `intmodel.ContainerTty` populated and asserts each lands on `TerminalDoc.Spec`. A reflect-based whitelist (`mapperedFields`) inside `ttyFieldsCoveredByMapping` fails the test when a new `ContainerTty` field lands without being mapped *or* when the renderer drops one silently — the pre-#494 `Tty.OnInit` failure mode this test pattern is designed to catch.
- Pins three renderer-default invariants the cell schema doesn't surface but the renderer is responsible for stamping on every `TerminalDoc`: `SocketFile`, `CaptureFile`, `RunPath`, and **`EnvInherit=true`**. The last one is the load-bearing addition: without it, sbsh's terminal runner (`sbsh@v0.11.2/internal/terminal/terminalrunner/terminal.go:54`) spawns the workload with only `HOME` + `SBSH_*` set, **stripping the user-supplied env and the `KUKEON_*` identity vars** that the OCI `Process.Env` already carries. This is a #494 regression: pre-#494, sbsh's profile loader's no-profile fallback defaulted `EnvInherit: true` (`sbsh@v0.11.1/internal/profile/profile.go:454`) — the inline-builder migration silently lost that default.
- Behavior fix in `internal/controller/runner/attachable.go::writeKukettyMetadata`: adds `sbshbuilder.WithEnvInherit(true)` to the option slice. Bundled into the same PR as #493 because the test is the regression guard for the fix — shipping them separately would let a future renderer refactor re-drop `EnvInherit` undetected.

## Test plan

- [x] `make test` — full unit suite green, including the new `TestWriteKukettyMetadata_AllTtyFieldsMap` and the three pre-existing `TestWriteKukettyMetadata_*` tests.
- [x] `go build ./...` + `go vet ./...` — clean.
- [x] `pre-commit run --files internal/controller/runner/attachable.go internal/controller/runner/attachable_test.go` — clean (`golangci-lint` green after inlining the field-mapper map to satisfy `gochecknoglobals` and using `range typ.NumField()` to satisfy `intrange`).
- [x] Direct end-to-end smoke against `--no-daemon`: launched a cell with `attachable: true` and `env: [FOO=bar, HELLO=world]`, then read `/tmp/workload-env.txt` written by the workload itself. With the fix, the workload now sees `FOO=bar`, `HELLO=world`, every `KUKEON_*` identity var (`KUKEON_CELL_NAME=envatt`, `KUKEON_REALM=default`, etc.), plus `PATH` and the `SBSH_*` markers. Without the `WithEnvInherit(true)` line, only `HOME` + `SBSH_*` + `TERM`/`COLORTERM` survive — the original repro.
- [ ] `make dev-init` daemon-parity smoke — host blocked by #495 (stale pre-#349 daemon predates `RootContainerID`, so `kuke daemon reset` fails before the rebuild step). The `--no-daemon` smoke above exercises the same `writeKukettyMetadata` code path the daemon would run, so the behavior is covered; the daemon-parity tail (which is the part #496 added) is unaffected by this PR (no `/opt/kukeon` schema changes).

Closes #493