### PR TITLE
fix: name per-container breaking fields in DiffCell so apply errors stop printing []

### DIFF
--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -407,6 +407,15 @@ func DiffCell(desired, actual intmodel.Cell) CellDiffResult {
 				result.HasChanges = true
 				if containerDiff.ChangeType == ChangeTypeBreaking {
 					result.ChangeType = ChangeTypeBreaking
+					// Qualify per-container breaking fields with the container ID
+					// so the cell-level error message in reconcile.go names them
+					// instead of printing an empty `[]`.
+					for _, field := range containerDiff.BreakingChanges {
+						result.BreakingChanges = append(
+							result.BreakingChanges,
+							fmt.Sprintf("containers[%s].%s", id, field),
+						)
+					}
 				} else if result.ChangeType == ChangeTypeNone {
 					result.ChangeType = containerDiff.ChangeType
 				}

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -293,3 +293,53 @@ func TestDiffCell_SynthesizedRoot_NoChange(t *testing.T) {
 		t.Error("synthesized root must not flag RootContainerChanged on re-apply")
 	}
 }
+
+// TestDiffCell_NonRootContainerBreaking_NamesField pins issue #469: when a
+// breaking change is rooted in a non-root container (e.g. image bump),
+// DiffCell must propagate the field name into the cell-level
+// BreakingChanges slice qualified by container ID. Otherwise the
+// reconcile-side error formatter ("cell %q has breaking changes: %v") prints
+// an empty `[]` and the operator has no way to tell what was rejected.
+func TestDiffCell_NonRootContainerBreaking_NamesField(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "nginx:1.27"},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "nginx:1.25"},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Fatalf("expected breaking change, got %v", diff.ChangeType)
+	}
+	want := "containers[web].image"
+	found := false
+	for _, f := range diff.BreakingChanges {
+		if f == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected cell-level BreakingChanges to include %q, got %v", want, diff.BreakingChanges)
+	}
+}


### PR DESCRIPTION
## Summary

- Before this fix, `kuke apply -f` against a cell with a structurally-breaking change rooted in a *non-root* container (e.g. a child container `image` bump) printed `cell "<name>" has breaking changes: []. Delete the cell and recreate it with the new spec` — empty `[]`, no signal to the operator about which field was rejected.
- Root cause: in `internal/controller/apply/diff.go`, `DiffCell` aggregates per-container breaking field names into `result.Containers[i].BreakingChanges` (lines 391–422) and bumps `result.ChangeType` to `ChangeTypeBreaking`, but never copies them up into the cell-level `result.BreakingChanges` slice. `reconcile.go:367–373` then prints that empty cell-level slice.
- Pure messaging fix: when a per-container update is classified as breaking, also append each field name into the cell-level slice, qualified with the container ID (e.g. `containers[web].image`). No semantic change to which diffs are accepted vs refused.

## Test plan

- [x] `make test` — full unit suite green, including the new `TestDiffCell_NonRootContainerBreaking_NamesField` covering a non-root container `image` change and asserting `containers[<id>].image` lands in `BreakingChanges`.
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `pre-commit run --files internal/controller/apply/diff.go internal/controller/apply/diff_test.go` — clean (go fmt, golangci-lint, addlicense, etc.).
- [ ] `make dev-init` smoke — not run; this change is confined to `internal/controller/apply/diff.go` and does not touch the build path, the daemon, or anything under `/opt/kukeon` (per `CLAUDE.md`'s "When a change touches the build path, the daemon, or anything under `/opt/kukeon`" criterion the smoke is not required).

Closes #469