### PR TITLE
docs: add Claude Code example image, cell, profile, and guide

### DIFF
--- a/docs/examples/claude-code/Dockerfile
+++ b/docs/examples/claude-code/Dockerfile
@@ -1,0 +1,63 @@
+# Claude Code image used by the run-claude-code guide.
+#
+# Derived verbatim from eminwux/crew images/claude/Dockerfile so the example
+# tracks what is actually running at fleet scale. The companion guide at
+# docs/site/guides/run-claude-code.md explains which pieces are kukeon-cell
+# essentials (Node + the npm package, the `claude` user) versus crew-fleet
+# extras carried over for parity (gh, git signing tooling, golang, jq/yq,
+# the `kukeon` gid 988 stanza). Trim freely for your own image — the bits
+# the guide's smoke path needs are Node, the `@anthropic-ai/claude-code`
+# package, and the non-root `claude` user.
+
+FROM debian:trixie-slim
+
+ARG CLAUDE_CODE_VERSION=latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        nodejs \
+        npm \
+        make \
+        pre-commit \
+        ssh \
+        golang \
+        jq \
+        yq \
+        gettext-base \
+ && install -m 0755 -d /etc/apt/keyrings \
+ && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
+ && rm -rf /var/lib/apt/lists/*
+
+# Non-root claude user. The `kukeon` gid 988 stanza matches the host
+# containerd-socket group on crew's fleet hosts; on a freshly-`kuke init`-ed
+# host you don't need it for the smoke path in the companion guide. Left in
+# verbatim so this Dockerfile stays usable on a fleet host without edits —
+# the guide explains the tradeoff and how to drop it when you don't.
+RUN useradd --create-home --shell /bin/bash claude \
+ && groupadd -g 988 kukeon \
+ && usermod -aG kukeon claude
+
+USER claude
+WORKDIR /home/claude
+
+ENV NPM_CONFIG_PREFIX=/home/claude/.npm-global
+ENV PATH=/home/claude/.npm-global/bin:$PATH
+
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+ && npm cache clean --force \
+ && echo 'export NPM_CONFIG_PREFIX=$HOME/.npm-global' >> /home/claude/.bashrc \
+ && echo 'export PATH=$HOME/.npm-global/bin:$PATH' >> /home/claude/.bashrc
+
+CMD ["sleep", "infinity"]

--- a/docs/examples/claude-code/cell.yaml
+++ b/docs/examples/claude-code/cell.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: claude-code
+spec:
+  id: claude-code
+  realmId: default
+  spaceId: default
+  stackId: default
+  tty:
+    default: work
+  containers:
+    - id: root
+      root: true
+      image: docker.io/library/busybox:latest
+      command: sleep
+      args:
+        - "infinity"
+    - id: work
+      attachable: true
+      image: docker.io/library/claude-code:latest
+      command: /bin/bash
+      workingDir: /home/claude
+      tty:
+        prompt: "claude> "

--- a/docs/examples/claude-code/profile.yaml
+++ b/docs/examples/claude-code/profile.yaml
@@ -1,0 +1,54 @@
+# CellProfile for one-shot Claude Code prompts.
+#
+# Install at $HOME/.kuke/profiles.d/claude-code.yaml (or set
+# $KUKE_PROFILES_DIR), then invoke with:
+#
+#   sudo kuke run -p claude-code \
+#       --param PROMPT="explain the kukeon architecture in one sentence" --rm
+#
+# `kuke run -p` materializes a CellDoc named `claude-code-<6hex>` from this
+# template, substitutes ${IMAGE} / ${PROMPT}, and attaches to the `work`
+# container. The onInit script runs `claude --print "${PROMPT}"` once and
+# exits, so the attach loop closes and `--rm` reclaims the cell.
+#
+# Derived from eminwux/crew agents/pm/profiles/pm.yaml; the SSH bind, GPG
+# signing env, and agents/project-repo clone scripts have been stripped so
+# the first-time reader sees only the Claude-Code-specific shape. See the
+# companion guide at docs/site/guides/run-claude-code.md for the full
+# agent-runner reference.
+apiVersion: v1beta1
+kind: CellProfile
+metadata:
+  name: claude-code
+spec:
+  realm: default
+  space: default
+  stack: default
+  parameters:
+    - name: IMAGE
+      description: "Claude Code image reference"
+      default: docker.io/library/claude-code:latest
+    - name: PROMPT
+      description: "Prompt passed to `claude --print`"
+      required: true
+  cell:
+    autoDelete: true
+    tty:
+      default: work
+    containers:
+      - id: root
+        root: true
+        image: docker.io/library/busybox:latest
+        command: sleep
+        args:
+          - "infinity"
+      - id: work
+        attachable: true
+        image: ${IMAGE}
+        command: /bin/bash
+        workingDir: /home/claude
+        tty:
+          prompt: "claude> "
+          onInit:
+            - script: |
+                claude --print "${PROMPT}" && exit

--- a/docs/site/guides/run-claude-code.md
+++ b/docs/site/guides/run-claude-code.md
@@ -1,0 +1,133 @@
+# Run Claude Code in a kukeon cell
+
+This guide walks a freshly-`kuke init`-ed host from zero to a live Claude Code prompt running inside a kukeon cell — first as a long-lived Attachable `Cell`, then as a parametrized `CellProfile` you can drive with `kuke run -p` for one-shot prompts.
+
+[Claude Code](https://docs.claude.com/en/docs/claude-code/overview) is named in the [Vision](../vision.md) as the canonical agent workload kukeon's isolation primitives are measured against. The companion artifacts under [`docs/examples/claude-code/`](https://github.com/eminwux/kukeon/tree/main/docs/examples/claude-code) are the smallest end-to-end shape: an image, a Cell, and a CellProfile.
+
+The example does **not** bake API keys into the image and does not configure auth — bring your own per the upstream [setup docs](https://docs.claude.com/en/docs/claude-code/setup). For the full agent-runner shape (SSH bind, signed commits, agents/project-repo clones), see [`eminwux/crew`](https://github.com/eminwux/crew) — this guide is derived from `crew/images/claude/Dockerfile` and `crew/agents/pm/profiles/pm.yaml` with that plumbing stripped out.
+
+## Prerequisites
+
+- A host that has been bootstrapped with [`kuke init`](init-and-reset.md). `kuke get realms` shows both `default` and `kuke-system` Ready.
+- A local Docker (or `nerdctl build`) install for building the image.
+- A copy of the three files under `docs/examples/claude-code/`:
+  - [`Dockerfile`](https://github.com/eminwux/kukeon/blob/main/docs/examples/claude-code/Dockerfile)
+  - [`cell.yaml`](https://github.com/eminwux/kukeon/blob/main/docs/examples/claude-code/cell.yaml)
+  - [`profile.yaml`](https://github.com/eminwux/kukeon/blob/main/docs/examples/claude-code/profile.yaml)
+
+## Step 1 — Build the image
+
+The example `Dockerfile` is the upstream `crew` image verbatim. It installs `nodejs` + `npm` + the `@anthropic-ai/claude-code` package as a non-root `claude` user on `debian:trixie-slim`:
+
+```bash
+cd docs/examples/claude-code
+docker build -t claude-code:latest .
+```
+
+`nerdctl build -t claude-code:latest .` works the same way if you don't run Docker.
+
+### What's in the upstream image that the smoke path doesn't need
+
+The crew Dockerfile carries a handful of fleet-runner extras the Claude Code smoke does not exercise; they are kept verbatim so this Dockerfile remains drop-in usable on a crew-style host:
+
+- **`golang`, `gh`, `pre-commit`, `gnupg`, `ssh`, `jq`, `yq`, `make`, `gettext-base`** — the toolchain crew's `/dispatch` agents need to clone repos, sign commits, and run pre-commit. The smoke in this guide does not invoke any of them; trim them if you want a leaner image.
+- **`groupadd -g 988 kukeon` / `usermod -aG kukeon claude`** — fleet-specific. On crew's hosts gid 988 matches the host containerd socket group, so the `claude` user inside the cell can talk to a host-mounted socket. On a freshly-`kuke init`-ed host you do not bind-mount the containerd socket into the cell, so the supplementary group is inert. Leave it in if you ever expect to bind the socket; drop it for a strictly-Claude-Code image.
+
+The smoke path needs only `nodejs`, `npm`, the `@anthropic-ai/claude-code` package, and the non-root `claude` user.
+
+## Step 2 — Load the image into the `default` realm
+
+Every realm maps to its own containerd namespace ([Containerd namespaces](../concepts/containerd-namespaces.md)). User workloads live in `default.kukeon.io`, so the cell's image has to be loaded into that namespace before `kuke apply` / `kuke run` can pull it:
+
+```bash
+sudo kuke image load --from-docker claude-code:latest
+```
+
+`--realm default` is the default, so it can be omitted. Verify:
+
+```bash
+sudo kuke image get | grep claude-code
+```
+
+If you don't run Docker, use the `nerdctl save … | sudo kuke image load -` form documented in [`kuke image`](../cli/kuke-image.md).
+
+## Step 3 — Apply and attach the Cell
+
+`cell.yaml` is a single Attachable `Cell` with two containers: a `busybox` root keeping the cell alive (`sleep infinity`) and a `work` container running the Claude Code image, marked `attachable: true` so `kuke attach` can connect a TTY to it.
+
+```bash
+sudo kuke apply -f docs/examples/claude-code/cell.yaml
+```
+
+`kuke apply` creates the cell. If you hit a daemon issue, [retry under `--no-daemon`](apply-manifests.md#--no-daemon-caveat).
+
+Then connect a terminal to the `work` container:
+
+```bash
+sudo kuke attach claude-code
+```
+
+You should land at a `claude> ` prompt inside the cell. From there, run `claude` to enter the upstream Claude Code REPL (you'll need to complete the upstream auth flow the first time — the example does not pre-bake an API key).
+
+Press `^]^]` (two consecutive `Ctrl-]` keystrokes) to detach cleanly. The cell keeps running; re-attach later with the same command.
+
+### Tear-down
+
+```bash
+sudo kuke delete cell claude-code --cascade --no-daemon
+```
+
+`--cascade` removes the cell's containers in the same call. The `--no-daemon` flag is the same caveat as in `kuke apply` — see [Applying manifests](apply-manifests.md#--no-daemon-caveat).
+
+### Optional: persist `~/.claude` across restarts
+
+The smoke path above keeps Claude Code's per-user state inside the cell's overlay. To survive `kuke delete cell` + re-apply, bind-mount a host directory under the `work` container:
+
+```yaml
+- id: work
+  attachable: true
+  image: docker.io/library/claude-code:latest
+  command: /bin/bash
+  workingDir: /home/claude
+  volumes:
+    - source: /var/lib/claude-code/state
+      target: /home/claude/.claude
+  tty:
+    prompt: "claude> "
+```
+
+This is optional — the smoke flow above does not need it.
+
+## Step 4 — One-shot prompts via a `CellProfile`
+
+For "fire one prompt, tear the cell down on exit" jobs, install the example profile and drive it with `kuke run -p`. A [CellProfile](apply-manifests.md#parameterized-cell-profiles) is a per-user reusable cell template loaded from `$HOME/.kuke/profiles.d/<name>.yaml` (or `$KUKE_PROFILES_DIR`).
+
+```bash
+mkdir -p ~/.kuke/profiles.d
+cp docs/examples/claude-code/profile.yaml ~/.kuke/profiles.d/claude-code.yaml
+```
+
+The profile declares two parameters: `IMAGE` (defaults to `docker.io/library/claude-code:latest`) and `PROMPT` (required). Its `tty.onInit` runs `claude --print "${PROMPT}" && exit`, so the attach loop closes after the prompt's reply prints. `spec.cell.autoDelete: true` then deletes the materialized cell — no `--rm` flag required.
+
+Run it:
+
+```bash
+sudo kuke run -p claude-code \
+    --param PROMPT="explain the kukeon architecture in one sentence"
+```
+
+`kuke run -p` materializes a cell named `claude-code-<6hex>`, attaches to the `work` container, runs the onInit script, prints Claude Code's reply, and exits. Override `IMAGE` to pin a tag:
+
+```bash
+sudo kuke run -p claude-code \
+    --param IMAGE=docker.io/library/claude-code:2026-05-14 \
+    --param PROMPT="…"
+```
+
+See [`kuke run`](../cli/kuke-run.md) for the full flag surface, including `--name`, `--param-file`, and the `-d`/`--detach` mode.
+
+## Where to go next
+
+- **The full crew agent-runner shape.** [`eminwux/crew`](https://github.com/eminwux/crew) — SSH bind, GPG-signed commits, agents-repo clone, project-repo clone, the orchestrator that dispatches per-call cells. Two layers up from this guide.
+- **Cell teardown verbs.** [`docs/cli-use-cases.md`](https://github.com/eminwux/kukeon/blob/main/docs/cli-use-cases.md) — the full operator workflow reference, including `stop` / `kill` / `delete` / `purge --cascade` for cells.
+- **Manifest reference.** [Applying manifests](apply-manifests.md) — multi-doc manifests, the `--no-daemon` caveat, profile parameter resolution order.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
   - Guides:
       - guides/init-and-reset.md
       - guides/apply-manifests.md
+      - guides/run-claude-code.md
       - guides/local-dev.md
       - guides/autocomplete.md
       - guides/troubleshooting.md


### PR DESCRIPTION
## Summary

- Adds `docs/examples/claude-code/{Dockerfile,cell.yaml,profile.yaml}` plus a new top-level guide at `docs/site/guides/run-claude-code.md` (wired into `mkdocs.yml`) so a freshly-`kuke init`-ed user can build the image, load it into the `default` realm, apply an Attachable `Cell`, and drive one-shot prompts through a parametrized `CellProfile`.
- Per user instruction during pickup ("do not change dockerfiles because they work, you can add comments"), the `Dockerfile` is the upstream `crew/images/claude/Dockerfile` verbatim with only added explanatory comments. The fleet-specific pieces the issue body called out (extra toolchain, `gid 988` stanza) are documented in a "what's in the upstream image that the smoke path doesn't need" section of the guide instead of being stripped from the file — so the Dockerfile stays drop-in usable on a crew-style host and the reader sees the tradeoff explained.
- `profile.yaml` is the `crew/agents/pm/profiles/pm.yaml` shape stripped of SSH/GPG/agents-repo plumbing: two parameters (`IMAGE` default + `PROMPT` required), an Attachable `work` container with a `tty.onInit` that runs `claude --print "${PROMPT}" && exit`, and `spec.cell.autoDelete: true` so the cell reclaims after the attach loop closes.
- `cell.yaml` is the long-lived Attachable shape: busybox root + Claude Code `work` container, no volumes (the guide describes `~/.claude` bind-mount as an optional add-on).

## Test plan

- [x] `make test` — full unit suite green (no Go changes; sanity).
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `pre-commit run --files docs/examples/claude-code/Dockerfile docs/examples/claude-code/cell.yaml docs/examples/claude-code/profile.yaml docs/site/guides/run-claude-code.md mkdocs.yml` — passed (trailing-whitespace, end-of-file-fixer, check-yaml, prettier, etc.).
- [ ] `make dev-init` smoke — not run; this change is docs/examples only and does not touch the build path, the daemon, or anything under `/opt/kukeon` (per `CLAUDE.md`'s criterion the smoke is not required).
- [ ] End-to-end guide walkthrough on a `kuke init`-ed host — not run; the dev container this PR was authored in does not have a working `kuke init` against a host containerd, and the guide's value is the reader's first run on their own host. Deferring to reviewer.

Closes #481