### PR TITLE
feat: accept in-place image/command/args updates on non-root containers (phase 2)

### DIFF
--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -401,8 +401,13 @@ func DiffCell(desired, actual intmodel.Cell) CellDiffResult {
 				Action: "add",
 			})
 		} else {
-			// Container to update
-			containerDiff := diffContainerSpec(desiredContainer, actualContainer)
+			// Container to update. Non-root container — image/command/args
+			// are classified as in-place updateable (Compatible) here so
+			// UpdateCell stops, removes, recreates, and starts the affected
+			// child container instead of refusing the diff. The root
+			// container's image/command/args bypass diffContainerSpec via
+			// rootContainerSpecChanged above and stay on the recreate path.
+			containerDiff := diffContainerSpec(desiredContainer, actualContainer, false)
 			if containerDiff.HasChanges {
 				result.HasChanges = true
 				if containerDiff.ChangeType == ChangeTypeBreaking {
@@ -484,8 +489,12 @@ func DiffContainer(desired, actual intmodel.Container) DiffResult {
 		result.Details["metadata.labels"] = labelsChangedMsg
 	}
 
-	// Diff container spec
-	specDiff := diffContainerSpec(&desired.Spec, &actual.Spec)
+	// Diff container spec. Pass desired.Spec.Root so a root container under
+	// the single-container reconcile path keeps the existing
+	// breaking-change classification for image/command/args (cell-level
+	// callers always pass false because only non-root children flow
+	// through DiffCell's container loop).
+	specDiff := diffContainerSpec(&desired.Spec, &actual.Spec, desired.Spec.Root)
 	if specDiff.HasChanges {
 		result.HasChanges = true
 		if specDiff.ChangeType == ChangeTypeBreaking {
@@ -504,31 +513,41 @@ func DiffContainer(desired, actual intmodel.Container) DiffResult {
 }
 
 // diffContainerSpec compares two container specs.
-func diffContainerSpec(desired, actual *intmodel.ContainerSpec) DiffResult {
+//
+// `rootContainer` controls whether image/command/args changes are
+// classified as breaking. Root containers cannot be updated in place — the
+// runner's StartCell path bakes the root spec into namespace setup, so any
+// change to image/command/args has to flow through RecreateCell. Non-root
+// containers can be stopped, removed, recreated, and started under the
+// existing cell namespaces; UpdateCell already implements that recreate
+// dance (the apply layer just needs to stop refusing the diff). Issue
+// #485.
+//
+// which needs a per-field diff branch. Splitting into smaller helpers per
+// field group (env/ports/volumes, privileged/user/readonly,
+// capabilities/securityOpts/tmpfs/resources) would obscure the spec-vs-spec
+// shape readers reach for when adding a new field. The image/command/args
+// trio already lives in recordImageCmdArgsChange because those three share
+// the only non-trivial classification branch (root vs. non-root).
+//
+//nolint:funlen // The container spec is a flat list of ~12 fields, each of
+func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bool) DiffResult {
 	result := DiffResult{
 		Details: make(map[string]string),
 	}
 
-	// Breaking changes: image, command, args
 	if desired.Image != actual.Image {
-		result.HasChanges = true
-		result.ChangeType = ChangeTypeBreaking
-		result.BreakingChanges = append(result.BreakingChanges, "image")
-		result.Details["image"] = fmt.Sprintf("image changed from %q to %q", actual.Image, desired.Image)
+		recordImageCmdArgsChange(&result, rootContainer, "image",
+			fmt.Sprintf("image changed from %q to %q", actual.Image, desired.Image))
 	}
 
 	if desired.Command != actual.Command {
-		result.HasChanges = true
-		result.ChangeType = ChangeTypeBreaking
-		result.BreakingChanges = append(result.BreakingChanges, "command")
-		result.Details["command"] = fmt.Sprintf("command changed from %q to %q", actual.Command, desired.Command)
+		recordImageCmdArgsChange(&result, rootContainer, "command",
+			fmt.Sprintf("command changed from %q to %q", actual.Command, desired.Command))
 	}
 
 	if !slicesEqual(desired.Args, actual.Args) {
-		result.HasChanges = true
-		result.ChangeType = ChangeTypeBreaking
-		result.BreakingChanges = append(result.BreakingChanges, "args")
-		result.Details["args"] = "args changed"
+		recordImageCmdArgsChange(&result, rootContainer, "args", "args changed")
 	}
 
 	// Compatible changes: env, ports, volumes, etc.
@@ -631,6 +650,24 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec) DiffResult {
 	}
 
 	return result
+}
+
+// recordImageCmdArgsChange routes an image/command/args diff into either
+// BreakingChanges (root container) or ChangedFields (non-root, in-place
+// updateable). Lives outside diffContainerSpec so the latter stays within
+// funlen's statement budget. Issue #485.
+func recordImageCmdArgsChange(result *DiffResult, rootContainer bool, field, detail string) {
+	result.HasChanges = true
+	if rootContainer {
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, field)
+	} else {
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, field)
+	}
+	result.Details[field] = detail
 }
 
 func capabilitiesEqual(a, b *intmodel.ContainerCapabilities) bool {

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -294,13 +294,14 @@ func TestDiffCell_SynthesizedRoot_NoChange(t *testing.T) {
 	}
 }
 
-// TestDiffCell_NonRootContainerBreaking_NamesField pins issue #469: when a
-// breaking change is rooted in a non-root container (e.g. image bump),
-// DiffCell must propagate the field name into the cell-level
-// BreakingChanges slice qualified by container ID. Otherwise the
-// reconcile-side error formatter ("cell %q has breaking changes: %v") prints
-// an empty `[]` and the operator has no way to tell what was rejected.
-func TestDiffCell_NonRootContainerBreaking_NamesField(t *testing.T) {
+// TestDiffCell_NonRootContainerImage_InPlaceUpdate pins issue #485: a
+// non-root container `image` change must NOT classify as breaking — the
+// runner's UpdateCell path stops, removes, recreates, and starts the
+// affected child in place. Otherwise the apply layer refuses the diff and
+// the docs/cli-use-cases.md "apply updates a divergent existing cell"
+// claim stays gapped (phase 1 #469 only fixed the empty-`[]` formatter on
+// the refusal message; this is the divergent-update use case itself).
+func TestDiffCell_NonRootContainerImage_InPlaceUpdate(t *testing.T) {
 	desired := intmodel.Cell{
 		Metadata: intmodel.CellMetadata{Name: "hello-world"},
 		Spec: intmodel.CellSpec{
@@ -328,18 +329,182 @@ func TestDiffCell_NonRootContainerBreaking_NamesField(t *testing.T) {
 	}
 
 	diff := apply.DiffCell(desired, actual)
-	if diff.ChangeType != apply.ChangeTypeBreaking {
-		t.Fatalf("expected breaking change, got %v", diff.ChangeType)
+	if !diff.HasChanges {
+		t.Fatal("expected changes")
 	}
-	want := "containers[web].image"
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible (in-place updateable) change, got %v", diff.ChangeType)
+	}
+	if len(diff.BreakingChanges) != 0 {
+		t.Errorf("non-root image bump must not populate BreakingChanges, got %v", diff.BreakingChanges)
+	}
+	if len(diff.Containers) != 1 {
+		t.Fatalf("expected one ContainerDiff entry, got %d", len(diff.Containers))
+	}
+	cd := diff.Containers[0]
+	if cd.Name != "web" || cd.Action != "update" {
+		t.Errorf("expected web update, got %+v", cd)
+	}
+	if len(cd.BreakingChanges) != 0 {
+		t.Errorf("per-container BreakingChanges must be empty, got %v", cd.BreakingChanges)
+	}
+	foundImage := false
+	for _, f := range cd.ChangedFields {
+		if f == "image" {
+			foundImage = true
+			break
+		}
+	}
+	if !foundImage {
+		t.Errorf("expected ContainerDiff.ChangedFields to include %q, got %v", "image", cd.ChangedFields)
+	}
+}
+
+// TestDiffCell_NonRootContainerCommandArgs_InPlaceUpdate covers AC2 of
+// issue #485: `command` and `args` changes on non-root containers travel
+// the same in-place updateable path as `image`.
+func TestDiffCell_NonRootContainerCommandArgs_InPlaceUpdate(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "nginx:1.27", Command: "/new/cmd", Args: []string{"--new"}},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "nginx:1.27", Command: "/old/cmd", Args: []string{"--old"}},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible change for command/args bump, got %v", diff.ChangeType)
+	}
+	if len(diff.BreakingChanges) != 0 {
+		t.Errorf("non-root command/args bump must not populate BreakingChanges, got %v", diff.BreakingChanges)
+	}
+	if len(diff.Containers) != 1 {
+		t.Fatalf("expected one ContainerDiff entry, got %d", len(diff.Containers))
+	}
+	cd := diff.Containers[0]
+	wantFields := map[string]bool{"command": false, "args": false}
+	for _, f := range cd.ChangedFields {
+		if _, ok := wantFields[f]; ok {
+			wantFields[f] = true
+		}
+	}
+	for f, seen := range wantFields {
+		if !seen {
+			t.Errorf("expected ContainerDiff.ChangedFields to include %q, got %v", f, cd.ChangedFields)
+		}
+	}
+}
+
+// TestDiffCell_RootContainerImage_StillBreaking pins AC4 of issue #485:
+// even after the non-root reclassification, root-container image changes
+// stay on the existing RecreateCell path so the cell-wide network/CNI
+// recreate dance is preserved.
+func TestDiffCell_RootContainerImage_StillBreaking(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:1.36"},
+			},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:1.35"},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.RootContainerChanged {
+		t.Fatal("expected RootContainerChanged=true for root image bump")
+	}
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Errorf("expected breaking change for root image bump, got %v", diff.ChangeType)
+	}
+}
+
+// TestDiffContainer_RootStillBreaking ensures the single-container
+// reconcile path (ReconcileContainer) keeps the breaking-change
+// classification for root containers — the rootContainer flag flows
+// through diffContainerSpec via desired.Spec.Root.
+func TestDiffContainer_RootStillBreaking(t *testing.T) {
+	desired := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "root"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "root",
+			Root:      true,
+			RealmName: "default", SpaceName: "default", StackName: "default", CellName: "hello-world",
+			Image: "busybox:1.36",
+		},
+	}
+	actual := desired
+	actual.Spec.Image = "busybox:1.35"
+
+	diff := apply.DiffContainer(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Fatalf("expected breaking change for root image bump, got %v", diff.ChangeType)
+	}
 	found := false
 	for _, f := range diff.BreakingChanges {
-		if f == want {
+		if f == "image" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected cell-level BreakingChanges to include %q, got %v", want, diff.BreakingChanges)
+		t.Errorf("expected BreakingChanges to include image, got %v", diff.BreakingChanges)
+	}
+}
+
+// TestDiffContainer_NonRootInPlace mirrors the cell-level reclassification
+// at the single-container reconcile path: a non-root image bump must
+// surface as Compatible.
+func TestDiffContainer_NonRootInPlace(t *testing.T) {
+	desired := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "web"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "web",
+			RealmName: "default", SpaceName: "default", StackName: "default", CellName: "hello-world",
+			Image: "nginx:1.27",
+		},
+	}
+	actual := desired
+	actual.Spec.Image = "nginx:1.25"
+
+	diff := apply.DiffContainer(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible change for non-root image bump, got %v", diff.ChangeType)
+	}
+	if len(diff.BreakingChanges) != 0 {
+		t.Errorf("non-root image bump must not populate BreakingChanges, got %v", diff.BreakingChanges)
 	}
 }

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -19,6 +19,7 @@ package apply
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/eminwux/kukeon/internal/controller/runner"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -383,13 +384,27 @@ func ReconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, err
 	result.Changes = diff.ChangedFields
 	result.Details = diff.Details
 
-	// Add container change details
+	// Add container change details. The update branch surfaces the changed
+	// fields so `kuke apply -f` of an image bump reports
+	// `container "web" updated: image` instead of an opaque
+	// `container "web" updated` — the issue-#485 per-component summary the
+	// docs/cli-use-cases.md "apply updates a divergent existing cell" claim
+	// promises.
 	for _, containerDiff := range diff.Containers {
 		switch containerDiff.Action {
 		case "add":
 			result.Changes = append(result.Changes, fmt.Sprintf("container %q added", containerDiff.Name))
 		case "update":
-			result.Changes = append(result.Changes, fmt.Sprintf("container %q updated", containerDiff.Name))
+			fields := append([]string{}, containerDiff.ChangedFields...)
+			fields = append(fields, containerDiff.BreakingChanges...)
+			if len(fields) > 0 {
+				result.Changes = append(
+					result.Changes,
+					fmt.Sprintf("container %q updated: %s", containerDiff.Name, strings.Join(fields, ", ")),
+				)
+			} else {
+				result.Changes = append(result.Changes, fmt.Sprintf("container %q updated", containerDiff.Name))
+			}
 		}
 	}
 	for _, orphan := range diff.Orphans {

--- a/internal/controller/runner/update_cell.go
+++ b/internal/controller/runner/update_cell.go
@@ -153,6 +153,14 @@ func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		// scan Containers for the root see it.
 		newContainers = append(newContainers, *preservedRoot)
 	}
+	// recreatedIDs collects non-root container IDs whose image/command/args
+	// changed under the breaking-spec branch below. ensureCellContainers
+	// recreates the containerd container with the new spec (pulling the new
+	// image), but does not start it; the start happens further down via
+	// r.StartContainer once metadata has been persisted, so a successful
+	// apply leaves the recreated child running and the cell Ready. Issue
+	// #485.
+	var recreatedIDs []string
 	for _, desiredContainer := range desired.Spec.Containers {
 		if actualContainer, exists := actualContainers[desiredContainer.ID]; exists {
 			// Container exists, preserve containerd ID but update spec
@@ -202,6 +210,7 @@ func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 				}
 				// Clear containerd ID so it will be recreated
 				desiredContainer.ContainerdID = ""
+				recreatedIDs = append(recreatedIDs, desiredContainer.ID)
 			}
 		}
 		// Ensure container has proper parent references
@@ -249,6 +258,21 @@ func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	// Update metadata
 	if updateErr := r.UpdateCellMetadata(existing); updateErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, updateErr)
+	}
+
+	// Start non-root containers that were recreated above. ensureCellContainers
+	// pulled the new image and built a fresh containerd container, but did not
+	// start it; without this loop a `kuke apply -f` that bumps a non-root
+	// container's image leaves the recreated child in the Created state and
+	// the reconciler drives the cell back out of Ready. r.StartContainer is
+	// idempotent (delete + create + start) so the second create-call here is
+	// harmless — the freshly-pulled snapshot is reused. Issue #485.
+	for _, id := range recreatedIDs {
+		started, startErr := r.StartContainer(existing, id)
+		if startErr != nil {
+			return intmodel.Cell{}, fmt.Errorf("failed to start recreated container %q: %w", id, startErr)
+		}
+		existing = started
 	}
 
 	return existing, nil


### PR DESCRIPTION
## Summary

- Closes the gap behind `docs/cli-use-cases.md`'s "apply updates a divergent existing cell" claim for non-root containers. Phase 1 (#469) fixed only the empty-`[]` refusal-message formatter; this phase lets the divergent-update path actually succeed instead of returning a breaking-change error.
- `internal/controller/apply/diff.go`: `diffContainerSpec` now takes a `rootContainer bool`. Non-root containers route `image`/`command`/`args` diffs through `ChangedFields` (Compatible) instead of `BreakingChanges` (Breaking). Root containers stay on the existing classification — root spec changes still bypass `diffContainerSpec` via `rootContainerSpecChanged` and drive `ReconcileCell.RecreateCell`. The single-container reconcile path (`DiffContainer`) reads `desired.Spec.Root` so a root container under that path also keeps the breaking classification.
- `internal/controller/runner/update_cell.go`: the recreate-on-`containerSpecChanged` branch already stops, deletes, and lets `ensureCellContainers` pull the new image and recreate the containerd container. Added a follow-up `r.StartContainer` for each recreated non-root child so the cell ends Ready instead of leaving the recreated container parked in Created.
- `internal/controller/apply/reconcile.go`: the per-component summary now reports `container "<id>" updated: <field, …>` so `kuke apply -f` of an image bump surfaces the changed field, not an opaque `container "<id>" updated` line.

### In-place vs. structurally-breaking partition (per issue Notes #4)

In-place updateable (this PR — non-root only):
- `image`, `command`, `args` — routed through stop + delete + recreate + start in `UpdateCell` + `StartContainer`; the new image is pulled by `r.ctrClient.CreateContainer` during the recreate.

Already compatible (no behavior change):
- `env`, `ports`, `volumes`, `privileged`, `user`, `readOnlyRootFilesystem`, `capabilities`, `securityOpts`, `tmpfs`, `resources`.

Structurally breaking (still refused):
- Cell-level: `metadata.name`, `spec.realmName`, `spec.spaceName`, `spec.stackName`.
- Root container `image`/`command`/`args`: drives `RecreateCell` (the existing cell-wide recreate dance — needed because CNI/netns setup binds to the root spec).

## Test plan

- [x] `make test` — full unit suite, including new `TestDiffCell_NonRootContainerImage_InPlaceUpdate`, `TestDiffCell_NonRootContainerCommandArgs_InPlaceUpdate`, `TestDiffCell_RootContainerImage_StillBreaking`, `TestDiffContainer_RootStillBreaking`, `TestDiffContainer_NonRootInPlace`.
- [x] `make dev-init` — daemon-parity check passes; attach smoke against a kuketty-wrapped cell completes cleanly.
- [ ] `make e2e` — not run (e2e suite needs the heavier docker build + privileged container loop; the smoke `dev-init` exercises the build path and daemon bring-up). Reviewer-environment defer.

The pre-existing `TestDiffCell_NonRootContainerBreaking_NamesField` was rewritten as `TestDiffCell_NonRootContainerImage_InPlaceUpdate` — the issue-#469 invariant it pinned (qualified field name in the cell-level slice) still holds for any future breaking field surfaced by `diffContainerSpec`, but the non-root image bump it used as the example case is no longer breaking by design here.

Closes #485