### PR TITLE
docs: update CLAUDE.md smoke-test paths to /opt/kukeon/data/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Both `kuke get realms` and `kuke get realms --no-daemon` must produce that outpu
 
 To run individual phases by hand — e.g. while debugging a single phase — invoke them in order:
 
-1. **Tear down the existing runtime.** `sudo ./kuke daemon reset` stops + deletes the prior `kukeond` cell and clears `/run/kukeon/kukeond.{sock,pid}`. User-realm data under `/opt/kukeon/default` is left intact, so `kuke purge --cascade` on `default` can never take down the daemon. Pass `--purge-system` to additionally wipe `/opt/kukeon/kuke-system` for a fully clean re-bootstrap.
+1. **Tear down the existing runtime.** `sudo ./kuke daemon reset` stops + deletes the prior `kukeond` cell and clears `/run/kukeon/kukeond.{sock,pid}`. User-realm data under `/opt/kukeon/data/default` is left intact, so `kuke purge --cascade` on `default` can never take down the daemon. Pass `--purge-system` to additionally wipe `/opt/kukeon/data/kuke-system` for a fully clean re-bootstrap.
 
 2. **Build the binaries.**
 


### PR DESCRIPTION
## Summary
- After PR #489 moved on-disk metadata under `<RunPath>/data/`, the "Tear down the existing runtime" bullet in `CLAUDE.md` still pointed at the pre-#489 paths.
- Update the two path strings on that line so the documented behavior of `kuke daemon reset --purge-system` matches reality.

## Test plan
- [x] `git diff CLAUDE.md` shows only the two path substitutions on the targeted line (`/opt/kukeon/default` → `/opt/kukeon/data/default`; `/opt/kukeon/kuke-system` → `/opt/kukeon/data/kuke-system`).
- [x] `grep -n "opt/kukeon" CLAUDE.md` confirms the bind-mount example (line 101), the RunPath flag (line 107), and the framing sentences (lines 28, 56) remain unchanged — only the smoke-test phase-1 line is touched.
- [x] `pre-commit run --files CLAUDE.md` passes (prettier + whitespace hooks).
- [x] Verified `internal/consts/consts.go` defines `KukeonMetadataSubdir = "data"`, so `/opt/kukeon/data/<realm>` is the post-#489 on-disk layout the docs now match.
- [ ] `make dev-init` regression guard — markdown-only edit, no daemon/runtime touched; smoke is not affected.

Trivial-edit shortcut per `agents/dev/CLAUDE.md` §Trivial-edit shortcut — markdown-text-only change, no executable code or test assertions touched, so opening with `ready-to-merge`.

Closes #490