### PR TITLE
fix: flip cell to Failed with Reason/Message on CreateCell/Start* errors

### DIFF
--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1078,53 +1078,74 @@ func cellSpaceBridgeName(cell intmodel.Cell) (string, error) {
 }
 
 func (r *Exec) provisionNewCell(cell intmodel.Cell) (intmodel.Cell, error) {
-	// Update cell metadata
-	if err := r.UpdateCellMetadata(cell); err != nil {
-		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, err)
+	// The inner closure owns the actual provisioning work. The outer
+	// function captures provisionStarted via closure and, on any error
+	// past the stub write, flips the on-disk record to Failed with a
+	// Reason and Message so `kuke get cell -o yaml` shows the operator
+	// the failing stage instead of a derived Stopped (issue #504).
+	// A pre-stub UpdateCellMetadata failure leaves no metadata file to
+	// stamp Failed onto, so provisionStarted stays false and the helper
+	// is skipped. Closure pattern (instead of a named retErr + defer
+	// like StartCell / StartContainer) keeps the new code lint-clean
+	// against nonamedreturns.
+	var provisionStarted bool
+	out, err := func() (intmodel.Cell, error) {
+		// Update cell metadata
+		if err := r.UpdateCellMetadata(cell); err != nil {
+			return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, err)
+		}
+
+		// Past the stub write: any subsequent error must flip the
+		// on-disk record to Failed.
+		provisionStarted = true
+
+		// Create cell cgroup
+		cgroupPath, subtreeControllers, err := r.createCellCgroup(cell)
+		if err != nil {
+			return intmodel.Cell{}, err
+		}
+
+		// Update internal model with cgroup path and effective subtree
+		// controllers (issue #328 — surfaces the result of
+		// enableCellControllers so operators can confirm the cell-level
+		// delegation from `kuke get cells -o yaml`).
+		cell.Status.CgroupPath = cgroupPath
+		cell.Status.SubtreeControllers = subtreeControllers
+
+		// Persist the host-side bridge this cell's space lands on.
+		// Computing it here (instead of the read path) keeps the cell
+		// self-describing for debug tooling and survives daemon
+		// restarts because the cell metadata file is rewritten in
+		// UpdateCellMetadata below.
+		if bridge, brErr := cellSpaceBridgeName(cell); brErr == nil {
+			cell.Status.Network.BridgeName = bridge
+		} else {
+			// Bridge name is best-effort metadata; failing to derive
+			// it must not block provisioning (the cell can still come
+			// up — the iface is created by CNI from the conflist
+			// regardless of what we record here).
+			r.logger.WarnContext(r.ctx, "could not derive cell bridge name",
+				"cell", cell.Metadata.Name, "error", brErr)
+		}
+
+		// Create pause container and all containers for the cell
+		if _, err = r.createCellContainers(&cell); err != nil {
+			return intmodel.Cell{}, err
+		}
+
+		markCellReady(&cell)
+
+		// Update cell metadata
+		if err = r.UpdateCellMetadata(cell); err != nil {
+			return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, err)
+		}
+
+		return cell, nil
+	}()
+	if err != nil && provisionStarted {
+		r.markCellFailed(cell, "CreateCellFailed", err)
 	}
-
-	// Create cell cgroup
-	cgroupPath, subtreeControllers, err := r.createCellCgroup(cell)
-	if err != nil {
-		return intmodel.Cell{}, err
-	}
-
-	// Update internal model with cgroup path and effective subtree
-	// controllers (issue #328 — surfaces the result of enableCellControllers
-	// so operators can confirm the cell-level delegation from `kuke get
-	// cells -o yaml`).
-	cell.Status.CgroupPath = cgroupPath
-	cell.Status.SubtreeControllers = subtreeControllers
-
-	// Persist the host-side bridge this cell's space lands on. Computing it
-	// here (instead of the read path) keeps the cell self-describing for
-	// debug tooling and survives daemon restarts because the cell metadata
-	// file is rewritten in UpdateCellMetadata below.
-	if bridge, brErr := cellSpaceBridgeName(cell); brErr == nil {
-		cell.Status.Network.BridgeName = bridge
-	} else {
-		// Bridge name is best-effort metadata; failing to derive it must
-		// not block provisioning (the cell can still come up — the iface
-		// is created by CNI from the conflist regardless of what we
-		// record here).
-		r.logger.WarnContext(r.ctx, "could not derive cell bridge name",
-			"cell", cell.Metadata.Name, "error", brErr)
-	}
-
-	// Create pause container and all containers for the cell
-	_, err = r.createCellContainers(&cell)
-	if err != nil {
-		return intmodel.Cell{}, err
-	}
-
-	markCellReady(&cell)
-
-	// Update cell metadata
-	if err = r.UpdateCellMetadata(cell); err != nil {
-		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, err)
-	}
-
-	return cell, nil
+	return out, err
 }
 
 func (r *Exec) createCellCgroup(cell intmodel.Cell) (string, []string, error) {

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -130,22 +130,59 @@ func cellTasksAllRunningFn(
 	return true
 }
 
-// markCellFailedAfterStartupFailure transitions the cell to the terminal
-// CellStateFailed state (issue #407) when a non-validation, containerd-touching
-// step in StartCell / StartContainer returns an error. The cleanup itself is:
+// maxFailureMessageLen caps Status.Message so a long, multi-line wrap from
+// `fmt.Errorf("%w: %w", …)` chains doesn't blow up `kuke get cell -o yaml`.
+// 256 bytes is comfortably wider than any error sentinel string in the repo
+// while still rendering as a single readable line.
+const maxFailureMessageLen = 256
+
+// truncateFailureMessage flattens cause's text into the single-line, bounded
+// form Status.Message expects: newlines/tabs collapsed to spaces, trimmed of
+// runs of whitespace, and capped at maxFailureMessageLen with a trailing
+// "..." indicator. Returns "" when cause is nil so callers don't need to
+// pre-guard.
+func truncateFailureMessage(cause error) string {
+	if cause == nil {
+		return ""
+	}
+	msg := cause.Error()
+	// Collapse any control-ish whitespace to a single space so the message
+	// always renders on one YAML/JSON line.
+	msg = strings.ReplaceAll(msg, "\n", " ")
+	msg = strings.ReplaceAll(msg, "\r", " ")
+	msg = strings.ReplaceAll(msg, "\t", " ")
+	msg = strings.Join(strings.Fields(msg), " ")
+	if len(msg) > maxFailureMessageLen {
+		// Truncate on a valid UTF-8 boundary so a multi-byte rune isn't
+		// split. Error strings are dominantly ASCII but registry tags
+		// and image refs can carry non-ASCII content.
+		msg = strings.ToValidUTF8(msg[:maxFailureMessageLen-3], "") + "..."
+	}
+	return msg
+}
+
+// markCellFailed transitions the cell to the terminal CellStateFailed state
+// (issue #407 for the Start*-stage paths; issue #504 for the CreateCell-stage
+// path). The cleanup itself is:
 //
 //   - best-effort KillCell on the cell so any container that did start (e.g.,
 //     the root container) is torn down — the cell holds no running processes
 //     once it enters Failed;
 //   - reload from metadata so we overwrite KillCell's own Stopped-write, then
-//     stamp Failed and persist via UpdateCellMetadata.
+//     stamp State=Failed plus Status.Reason / Status.Message so `kuke get
+//     cell -o yaml` shows the operator the failing stage and the wrapped
+//     cause, and persist via UpdateCellMetadata.
 //
 // The original startup error is returned unmodified by the caller; this helper
 // only writes the new state so the reconciler can later observe it as terminal
 // (cellStateAutoDeleteTriggers excludes Failed, and ReconcileCell treats
 // originalState==Failed as sticky). Errors from the kill/persist sub-steps are
 // logged at WARN — propagating them would mask the original startup cause.
-func (r *Exec) markCellFailedAfterStartupFailure(cell intmodel.Cell, cause error) {
+//
+// reason is a stable PascalCase label (e.g. "CreateCellFailed",
+// "StartCellFailed", "StartContainerFailed") so machine consumers can switch
+// on it without parsing the human-readable Message.
+func (r *Exec) markCellFailed(cell intmodel.Cell, reason string, cause error) {
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if _, killErr := r.KillCell(cell); killErr != nil {
 		r.logger.WarnContext(r.ctx,
@@ -163,6 +200,8 @@ func (r *Exec) markCellFailedAfterStartupFailure(cell intmodel.Cell, cause error
 	}
 
 	cell.Status.State = intmodel.CellStateFailed
+	cell.Status.Reason = reason
+	cell.Status.Message = truncateFailureMessage(cause)
 	if updErr := r.UpdateCellMetadata(cell); updErr != nil {
 		r.logger.WarnContext(r.ctx,
 			"failed to persist Failed state after cell startup failure",
@@ -171,7 +210,7 @@ func (r *Exec) markCellFailedAfterStartupFailure(cell intmodel.Cell, cause error
 	}
 	r.logger.InfoContext(r.ctx,
 		"cell transitioned to Failed after startup failure",
-		"cell", cellName, "cause", cause.Error())
+		"cell", cellName, "reason", reason, "cause", cause.Error())
 }
 
 // StartCell starts the root container and all containers defined in the CellDoc.
@@ -194,7 +233,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
 	cellForCleanup := cell
 	defer func() {
 		if retErr != nil && provisionStarted {
-			r.markCellFailedAfterStartupFailure(cellForCleanup, retErr)
+			r.markCellFailed(cellForCleanup, "StartCellFailed", retErr)
 		}
 	}()
 	cellName := strings.TrimSpace(cell.Metadata.Name)
@@ -812,7 +851,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	cellForCleanup := cell
 	defer func() {
 		if retErr != nil && provisionStarted {
-			r.markCellFailedAfterStartupFailure(cellForCleanup, retErr)
+			r.markCellFailed(cellForCleanup, "StartContainerFailed", retErr)
 		}
 	}()
 	containerID = strings.TrimSpace(containerID)

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -21,7 +21,9 @@ package runner
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
@@ -298,5 +300,222 @@ func TestCellTasksAllRunningFn(t *testing.T) {
 				t.Errorf("cellTasksAllRunningFn() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestTruncateFailureMessage pins the single-line + length-bounded contract
+// markCellFailed relies on for Status.Message: long, multi-line wrapped
+// `fmt.Errorf("%w: %w", …)` chains must end up as a single, capped string
+// so `kuke get cell -o yaml` stays human-readable (issue #504).
+func TestTruncateFailureMessage(t *testing.T) {
+	t.Run("nil_cause_returns_empty", func(t *testing.T) {
+		if got := truncateFailureMessage(nil); got != "" {
+			t.Errorf("truncateFailureMessage(nil) = %q, want \"\"", got)
+		}
+	})
+
+	t.Run("newlines_collapsed_to_space", func(t *testing.T) {
+		err := errors.New("first line\nsecond line\twith tab")
+		got := truncateFailureMessage(err)
+		if strings.ContainsAny(got, "\n\r\t") {
+			t.Errorf("truncateFailureMessage left control whitespace in %q", got)
+		}
+		if got != "first line second line with tab" {
+			t.Errorf("truncateFailureMessage() = %q, want collapsed", got)
+		}
+	})
+
+	t.Run("long_cause_is_truncated_with_indicator", func(t *testing.T) {
+		long := strings.Repeat("a", maxFailureMessageLen+50)
+		got := truncateFailureMessage(errors.New(long))
+		if len(got) > maxFailureMessageLen {
+			t.Errorf("truncateFailureMessage returned %d bytes, want ≤ %d", len(got), maxFailureMessageLen)
+		}
+		if !strings.HasSuffix(got, "...") {
+			t.Errorf("truncated message %q missing trailing ellipsis indicator", got[len(got)-10:])
+		}
+	})
+
+	t.Run("short_cause_kept_verbatim", func(t *testing.T) {
+		err := fmt.Errorf("pull image: %w", errors.New("connection refused"))
+		got := truncateFailureMessage(err)
+		if got != "pull image: connection refused" {
+			t.Errorf("truncateFailureMessage() = %q, want verbatim", got)
+		}
+	})
+}
+
+// TestMarkCellFailed_PersistsReasonAndMessage verifies the helper writes
+// State=Failed, Status.Reason, and Status.Message onto the on-disk cell
+// document. Without this, the operator-facing reason for the failure stays
+// trapped in daemon logs and `kuke get cell -o yaml` shows a derived
+// Stopped (or worse, a Failed cell with empty Reason/Message). Issue #504.
+//
+// The helper internally invokes KillCell, which requires containerd
+// connectivity the unit test does not have — KillCell's error is logged at
+// WARN and swallowed by markCellFailed, so the persist step still runs.
+// The test is deliberately not asserting on KillCell behavior.
+func TestMarkCellFailed_PersistsReasonAndMessage(t *testing.T) {
+	t0 := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		reason      string
+		cause       error
+		wantMessage string
+	}{
+		{
+			name:        "create_cell_failed",
+			reason:      "CreateCellFailed",
+			cause:       fmt.Errorf("createCellContainers: %w", errors.New("image pull: connection refused")),
+			wantMessage: "createCellContainers: image pull: connection refused",
+		},
+		{
+			name:        "start_cell_failed",
+			reason:      "StartCellFailed",
+			cause:       fmt.Errorf("failed to attach root container: %w", errors.New("cni: bridge plugin missing")),
+			wantMessage: "failed to attach root container: cni: bridge plugin missing",
+		},
+		{
+			name:        "start_container_failed",
+			reason:      "StartContainerFailed",
+			cause:       errors.New("failed to start container worker: containerd: task already exists"),
+			wantMessage: "failed to start container worker: containerd: task already exists",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runPath := t.TempDir()
+			r := newMetadataTestExec(t, runPath, t0)
+			cell := intmodel.Cell{
+				Metadata: intmodel.CellMetadata{Name: "c-" + tt.name},
+				Spec: intmodel.CellSpec{
+					ID:         "c-" + tt.name,
+					RealmName:  "default",
+					SpaceName:  "default",
+					StackName:  "default",
+					Containers: []intmodel.ContainerSpec{},
+				},
+				Status: intmodel.CellStatus{
+					State: intmodel.CellStatePending,
+				},
+			}
+			if err := r.UpdateCellMetadata(cell); err != nil {
+				t.Fatalf("UpdateCellMetadata (stub write): %v", err)
+			}
+
+			r.markCellFailed(cell, tt.reason, tt.cause)
+
+			got, err := r.GetCell(cell)
+			if err != nil {
+				t.Fatalf("GetCell: %v", err)
+			}
+			if got.Status.State != intmodel.CellStateFailed {
+				t.Errorf("Status.State = %v, want Failed", got.Status.State)
+			}
+			if got.Status.Reason != tt.reason {
+				t.Errorf("Status.Reason = %q, want %q", got.Status.Reason, tt.reason)
+			}
+			if got.Status.Message != tt.wantMessage {
+				t.Errorf("Status.Message = %q, want %q", got.Status.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+// TestMarkCellFailed_LongCauseIsTruncated covers a real-world repro: a
+// chain of wrapped errors from CNI / IPAM / containerd can balloon past a
+// few hundred bytes. The Message field must stay capped + single-line on
+// disk so YAML emit doesn't bury the rest of `kuke get cell -o yaml`
+// output. Issue #504.
+func TestMarkCellFailed_LongCauseIsTruncated(t *testing.T) {
+	t0 := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, t0)
+
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "c-long"},
+		Spec: intmodel.CellSpec{
+			ID:         "c-long",
+			RealmName:  "default",
+			SpaceName:  "default",
+			StackName:  "default",
+			Containers: []intmodel.ContainerSpec{},
+		},
+		Status: intmodel.CellStatus{State: intmodel.CellStatePending},
+	}
+	if err := r.UpdateCellMetadata(cell); err != nil {
+		t.Fatalf("UpdateCellMetadata: %v", err)
+	}
+
+	cause := errors.New(strings.Repeat("x", maxFailureMessageLen*2))
+	r.markCellFailed(cell, "CreateCellFailed", cause)
+
+	got, err := r.GetCell(cell)
+	if err != nil {
+		t.Fatalf("GetCell: %v", err)
+	}
+	if got.Status.State != intmodel.CellStateFailed {
+		t.Errorf("Status.State = %v, want Failed", got.Status.State)
+	}
+	if got.Status.Reason != "CreateCellFailed" {
+		t.Errorf("Status.Reason = %q, want CreateCellFailed", got.Status.Reason)
+	}
+	if len(got.Status.Message) > maxFailureMessageLen {
+		t.Errorf("Status.Message length = %d, want ≤ %d", len(got.Status.Message), maxFailureMessageLen)
+	}
+	if !strings.HasSuffix(got.Status.Message, "...") {
+		t.Errorf(
+			"Status.Message missing truncation indicator: tail=%q",
+			got.Status.Message[len(got.Status.Message)-10:],
+		)
+	}
+}
+
+// TestMarkCellFailed_PreservesFieldsAcrossRefreshCarry guards the
+// reason/message carry on the refresh path. `carryCellLifecycle` already
+// copies Reason+Message from originalStatus to newStatus, but a regression
+// that wires a Failed-state writer in front of a refresh tick that drops
+// the field would leave the operator-facing breadcrumb empty after one
+// reconciler pass. The test simulates the carry by manually invoking
+// the helper and then mimicking the refresh-path `newStatus :=` reset.
+// Issue #504 acceptance criterion #4.
+func TestMarkCellFailed_PreservesFieldsAcrossRefreshCarry(t *testing.T) {
+	t0 := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, t0)
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "c-carry"},
+		Spec: intmodel.CellSpec{
+			ID:         "c-carry",
+			RealmName:  "default",
+			SpaceName:  "default",
+			StackName:  "default",
+			Containers: []intmodel.ContainerSpec{},
+		},
+		Status: intmodel.CellStatus{State: intmodel.CellStatePending},
+	}
+	if err := r.UpdateCellMetadata(cell); err != nil {
+		t.Fatalf("UpdateCellMetadata: %v", err)
+	}
+
+	r.markCellFailed(cell, "CreateCellFailed", errors.New("createCellContainers: image not found"))
+
+	got, err := r.GetCell(cell)
+	if err != nil {
+		t.Fatalf("GetCell: %v", err)
+	}
+
+	// Simulate a refresh tick: refresh builds newStatus from scratch then
+	// calls carryCellLifecycle to keep set-once fields. If the carry ever
+	// stops copying Reason/Message, this assert catches it.
+	newStatus := intmodel.CellStatus{State: intmodel.CellStateFailed}
+	carryCellLifecycle(got.Status, &newStatus)
+	if newStatus.Reason != "CreateCellFailed" {
+		t.Errorf("carryCellLifecycle dropped Reason: got %q", newStatus.Reason)
+	}
+	if newStatus.Message != "createCellContainers: image not found" {
+		t.Errorf("carryCellLifecycle dropped Message: got %q", newStatus.Message)
 	}
 }


### PR DESCRIPTION
## Summary

- A cell that fails during \`CreateCell\` (e.g. \`createCellContainers\` returns a registry/pull error) now ends up on disk as \`state: Failed\`, with \`status.reason\` = \`CreateCellFailed\` and \`status.message\` = the wrapped cause — instead of the derived \`Stopped\` with empty fields the operator was seeing per issue #504. \`StartCell\` and \`StartContainer\` failures (issue #407 path) likewise populate \`reason\` (\`StartCellFailed\` / \`StartContainerFailed\`) and \`message\`, closing Gap 2 in the same writer.
- The Failed transition on the CreateCell path is wired into \`provisionNewCell\` via an inner-closure pattern with a \`provisionStarted\` gate armed right after the line-1082 stub write — a pre-stub \`UpdateCellMetadata\` failure leaves no metadata file to stamp Failed onto, so the helper is skipped. Closure was used (instead of a named \`retErr\` + defer like StartCell / StartContainer) because \`nonamedreturns\` is enabled for new code via \`golangci-lint --new-from-rev HEAD\`; the existing two functions are grandfathered.
- The existing \`markCellFailedAfterStartupFailure\` helper was renamed to \`markCellFailed\` and now also writes \`Status.Reason\` (caller-supplied stable label) plus \`Status.Message\` via the new \`truncateFailureMessage\` helper: collapses control whitespace to spaces, joins runs, caps at 256 bytes with a \`...\` indicator, and trims on a valid UTF-8 boundary so registry refs with non-ASCII characters don't render as broken runes in YAML.
- Because \`Failed\` is already sticky (\`cellStateIsSticky\`) and excluded from \`cellStateAutoDeleteTriggers\`, an \`autoDelete: true\` cell that fails during create now stays as \`Failed\` until the operator runs \`kuke delete cell\` — AC #5. The existing \`carryCellLifecycle\` already copies Reason/Message through the refresh path, so the new writes survive subsequent reconciler ticks (AC #4); a regression test asserts the carry remains in place.

## Test plan

- [x] \`go test ./...\` (full unit suite green, including the four new tests in \`internal/controller/runner/start_test.go\`: \`TestTruncateFailureMessage\`, \`TestMarkCellFailed_PersistsReasonAndMessage\`, \`TestMarkCellFailed_LongCauseIsTruncated\`, \`TestMarkCellFailed_PreservesFieldsAcrossRefreshCarry\`)
- [x] \`make test\` green
- [x] \`go vet ./...\` clean
- [x] \`pre-commit run --files internal/controller/runner/{provision,start,start_test}.go\` clean (go fmt, golangci-lint, addlicense, etc.)
- [x] \`make dev-init\` smoke test passes, daemon-parity check matches the regression guard for both \`kuke get realms\` and \`kuke get realms --no-daemon\`
- [x] Manual end-to-end repro of AC #1 / #2 / #3 — \`kuke run -f /tmp/bad-cell.yaml -d\` against a profile pointing at \`registry.invalid/does-not-exist:latest\` produces:

  \`\`\`
  status:
    state: Failed
    reason: CreateCellFailed
    message: 'failed to create container default_default_failtest_worker: failed to create container from spec: failed to pull image registry.invalid/does-not-exist:latest: failed to resolve reference ... He...'
  \`\`\`

  Truncated at 256 bytes with the \`...\` indicator, single-line.
- [x] Manual AC #5 verification — same repro with \`autoDelete: true\` on the spec: the cell stays as \`Failed\` after 3s (no auto-delete fired), purged manually with \`kuke purge cell --cascade\`.

Closes #504