### PR TITLE
test: fix misleading env var name in ParseOutputFormat test fatalf

### DIFF
--- a/cmd/kuke/get/shared/shared_test.go
+++ b/cmd/kuke/get/shared/shared_test.go
@@ -114,7 +114,7 @@ func TestParseOutputFormat(t *testing.T) {
 
 func TestParseOutputFormatEnvAndFlagPrecedence(t *testing.T) {
 	if err := config.KUKE_GET_OUTPUT.BindEnv(); err != nil {
-		t.Fatalf("bind KUKEON_GET_OUTPUT: %v", err)
+		t.Fatalf("bind KUKE_GET_OUTPUT: %v", err)
 	}
 
 	tests := []struct {


### PR DESCRIPTION
## Summary
- The `t.Fatalf` message in `TestParseOutputFormatEnvAndFlagPrecedence` references `KUKEON_GET_OUTPUT`, but the env var actually bound by `config.KUKE_GET_OUTPUT.BindEnv()` is `KUKE_GET_OUTPUT`. Anyone debugging a `BindEnv` failure would grep for the wrong name. Fix the message to match.

## Test plan
- [x] `make test` (full unit-test suite — CI's `make test` job)
- [x] `pre-commit run --files cmd/kuke/get/shared/shared_test.go`
- [ ] smoke test (`make dev-init`) — not run; the change is a string in a `t.Fatalf`, not touching the build path, daemon, or anything under `/opt/kukeon`

Closes #229