### PR TITLE
fix: latch ReadyObserved in RefreshCell to preserve AutoDelete gate

### DIFF
--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -267,6 +267,14 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 
 	carryCellLifecycle(originalStatus, &newStatus)
 
+	// Run ReadyObserved through the same one-way latch ReconcileCell uses.
+	// Without this, `kuke refresh` racing a synchronous Ready write would
+	// wipe the latched ReadyObserved to false (newStatus is constructed
+	// without it and assigned wholesale below), defeating AutoDelete via
+	// the same mechanism as #275 — see issue #278.
+	newStatus.ReadyObserved = latchReadyObserved(
+		originalStatus.ReadyObserved, originalStatus.State, newStatus.State)
+
 	// Refresh all containers in the cell (always attempt, regardless of cgroup check result)
 	containersUpdated := 0
 	for i := range cell.Spec.Containers {
@@ -287,7 +295,8 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 	cellUpdated := false
 	if newStatus.State != originalStatus.State ||
 		newStatus.CgroupPath != originalStatus.CgroupPath ||
-		newStatus.CgroupReady != originalStatus.CgroupReady {
+		newStatus.CgroupReady != originalStatus.CgroupReady ||
+		newStatus.ReadyObserved != originalStatus.ReadyObserved {
 		cell.Status = newStatus
 		cellUpdated = true
 	}
@@ -303,10 +312,12 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 }
 
 // carryCellLifecycle is the Cell counterpart of carryRealmLifecycle.
-// Network/Containers/ReadyObserved are not carried because the refresh
-// path either rebuilds them (Containers) or leaves them on the live cell
-// struct (Network, ReadyObserved); only the issue #166 fields need an
-// explicit carry from originalStatus to the locally-built newStatus.
+// Network/Containers are not carried because the refresh path either
+// rebuilds them (Containers) or leaves them on the live cell struct
+// (Network). ReadyObserved is handled by the caller via
+// latchReadyObserved — it needs both the original and the freshly
+// derived State to apply the one-way latch, which carryCellLifecycle
+// does not see — so the carry-through happens inline in RefreshCell.
 func carryCellLifecycle(orig intmodel.CellStatus, next *intmodel.CellStatus) {
 	next.CreatedAt = orig.CreatedAt
 	next.ReadyAt = orig.ReadyAt


### PR DESCRIPTION
## Summary
- `RefreshCell` built a fresh `CellStatus` that omitted `ReadyObserved` and assigned it back wholesale, so a `kuke refresh` racing a synchronous Ready write wiped the latched `ReadyObserved` to `false` on disk — defeating `AutoDelete` via the same mechanism as #275.
- Fix runs `ReadyObserved` through `latchReadyObserved` (the same one-way latch `ReconcileCell` uses), so the CLI refresh path can never downgrade the latch.
- Added the `ReadyObserved` delta to the change-detection condition so the latched value is actually persisted when it transitions; corrected the `carryCellLifecycle` doc-comment that falsely claimed `ReadyObserved` is left on the live cell struct.

## Test plan
- [x] `go build ./...`
- [x] `make test` (full package suite, including `TestLatchReadyObserved`, `TestMarkCellReady`, `TestAutoDeleteSurvivesKillCellRace`)
- [x] `make dev-init` end-to-end smoke — daemon parity check + attach smoke clean
- [x] `pre-commit run --files internal/controller/runner/refresh.go`

Closes #278