### PR TITLE
refactor: extract setCellCgroupPath helper to dedupe six runner sites

### DIFF
--- a/internal/controller/runner/cell_cgroup_path.go
+++ b/internal/controller/runner/cell_cgroup_path.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import intmodel "github.com/eminwux/kukeon/internal/modelhub"
+
+// setCellCgroupPath fills CellCgroupPath on a single container spec from
+// cell.Status.CgroupPath. CellCgroupPath is a runtime-only injection (not
+// persisted with the cell document), so every BuildContainerSpec /
+// BuildRootContainerSpec call site must populate it from the live cell right
+// before the build — otherwise the OCI Linux.CgroupsPath falls back to the
+// runc-shim default and the cell-rooted placement from issue #312 silently
+// regresses. The runtime-only nature is what made the six prior copies easy
+// to add but hard to keep in sync (issue #317): missing a site doesn't break
+// compile, only the actual cgroup placement at runtime.
+//
+// No-op when spec is nil, cell is nil, or spec.CellCgroupPath is already
+// populated (idempotent across repeat runs from the same cell).
+func setCellCgroupPath(spec *intmodel.ContainerSpec, cell *intmodel.Cell) {
+	if spec == nil || cell == nil || spec.CellCgroupPath != "" {
+		return
+	}
+	spec.CellCgroupPath = cell.Status.CgroupPath
+}

--- a/internal/controller/runner/cell_cgroup_path_test.go
+++ b/internal/controller/runner/cell_cgroup_path_test.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestSetCellCgroupPath asserts the helper copies cell.Status.CgroupPath
+// into spec.CellCgroupPath when the spec field is empty.
+func TestSetCellCgroupPath(t *testing.T) {
+	spec := &intmodel.ContainerSpec{}
+	cell := &intmodel.Cell{Status: intmodel.CellStatus{CgroupPath: "/kukeon/default/space/stack/cell"}}
+
+	setCellCgroupPath(spec, cell)
+
+	if got := spec.CellCgroupPath; got != "/kukeon/default/space/stack/cell" {
+		t.Errorf("spec.CellCgroupPath = %q, want %q", got, "/kukeon/default/space/stack/cell")
+	}
+}
+
+// TestSetCellCgroupPath_DoesNotOverwrite verifies the helper leaves a
+// pre-populated CellCgroupPath alone so a caller that already injected a
+// value (e.g., a test fixture) is not stomped.
+func TestSetCellCgroupPath_DoesNotOverwrite(t *testing.T) {
+	spec := &intmodel.ContainerSpec{CellCgroupPath: "/preset/path"}
+	cell := &intmodel.Cell{Status: intmodel.CellStatus{CgroupPath: "/kukeon/default/space/stack/cell"}}
+
+	setCellCgroupPath(spec, cell)
+
+	if got := spec.CellCgroupPath; got != "/preset/path" {
+		t.Errorf("spec.CellCgroupPath = %q, want %q (preset value must not be overwritten)", got, "/preset/path")
+	}
+}
+
+// TestSetCellCgroupPath_NilSafe locks in the nil-spec and nil-cell guards so
+// the helper is safe to drop in across the six runner sites without each
+// caller having to repeat a defensive nil check.
+func TestSetCellCgroupPath_NilSafe(t *testing.T) {
+	setCellCgroupPath(nil, &intmodel.Cell{Status: intmodel.CellStatus{CgroupPath: "/x"}})
+
+	spec := &intmodel.ContainerSpec{}
+	setCellCgroupPath(spec, nil)
+	if got := spec.CellCgroupPath; got != "" {
+		t.Errorf("spec.CellCgroupPath = %q, want empty (nil cell should be a no-op)", got)
+	}
+}
+
+// TestSetCellCgroupPath_EmptyStatusPath asserts that a cell that has not yet
+// populated Status.CgroupPath (e.g., a not-yet-provisioned cell) leaves the
+// spec field empty — matching the pre-refactor inline behavior, which also
+// only ever wrote whatever cell.Status.CgroupPath held at call time.
+func TestSetCellCgroupPath_EmptyStatusPath(t *testing.T) {
+	spec := &intmodel.ContainerSpec{}
+	cell := &intmodel.Cell{}
+
+	setCellCgroupPath(spec, cell)
+
+	if got := spec.CellCgroupPath; got != "" {
+		t.Errorf("spec.CellCgroupPath = %q, want empty (cell has no status.cgroupPath)", got)
+	}
+}

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1438,12 +1438,6 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		cell.Spec.RootContainerID = rootContainerBaseID
 	}
 
-	// Cell-rooted cgroup placement for every container task. cell.Status.CgroupPath
-	// is populated by createCellCgroup before this runs (and preserved through
-	// recreate paths via desired.Status.CgroupPath = existing.Status.CgroupPath),
-	// so it's safe to read here. See issue #312.
-	cellCgroupPath := cell.Status.CgroupPath
-
 	// Per-cell /etc/hostname and initial /etc/hosts (no IP yet — CNI ADD runs
 	// during StartCell and rewrites /etc/hosts with the assigned cell IP).
 	// Files must exist before runc consumes the OCI bind-mount entries below,
@@ -1480,9 +1474,11 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		if containerSpec.CNIConfigPath == "" {
 			containerSpec.CNIConfigPath = cniConfigPath
 		}
-		if containerSpec.CellCgroupPath == "" {
-			containerSpec.CellCgroupPath = cellCgroupPath
-		}
+		// Cell-rooted cgroup placement for every container task. cell.Status.CgroupPath
+		// is populated by createCellCgroup before this runs (and preserved through
+		// recreate paths via desired.Status.CgroupPath = existing.Status.CgroupPath),
+		// so it's safe to read here. See issue #312.
+		setCellCgroupPath(&containerSpec, cell)
 		cell.Spec.Containers[i] = containerSpec
 
 		var createdContainer containerd.Container
@@ -1745,9 +1741,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		// Cell-rooted cgroup placement for the root container task (issue
 		// #312). Mirrors the wiring in createCellContainers and the regular-
 		// container loop below.
-		if rootContainerSpec.CellCgroupPath == "" {
-			rootContainerSpec.CellCgroupPath = cell.Status.CgroupPath
-		}
+		setCellCgroupPath(&rootContainerSpec, cell)
 
 		// Determine root container ID for RootContainerID field (use base name from ID field)
 		rootContainerBaseID := rootContainerSpec.ID
@@ -1901,10 +1895,8 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		// Cell-rooted cgroup placement (issue #312). Mirrors the equivalent
 		// fill-in for createCellContainers; only takes effect when the cell
 		// has been provisioned and its Status.CgroupPath is populated.
-		if containerSpec.CellCgroupPath == "" {
-			containerSpec.CellCgroupPath = cell.Status.CgroupPath
-			cell.Spec.Containers[i] = containerSpec
-		}
+		setCellCgroupPath(&containerSpec, cell)
+		cell.Spec.Containers[i] = containerSpec
 
 		// Build containerd ID using hierarchical format for containerd operations
 		// Store it in ContainerdID field, keep base name in ID field

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -428,14 +428,11 @@ func (r *Exec) StartCell(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to get root container spec: %w", err)
 	}
 
-	// CellCgroupPath is a runtime-only injection (not persisted with the cell
-	// document), so every BuildContainerSpec/BuildRootContainerSpec call site
-	// must populate it from cell.Status.CgroupPath right before the build —
-	// otherwise the destructive recreate done by StartCell here resets the
-	// container's OCI Linux.CgroupsPath to the runc-shim default. Issue #312.
-	if rootContainerSpec.CellCgroupPath == "" {
-		rootContainerSpec.CellCgroupPath = internalCell.Status.CgroupPath
-	}
+	// CellCgroupPath: runtime-only injection — see setCellCgroupPath docs.
+	// The destructive recreate done by StartCell here would otherwise reset
+	// the container's OCI Linux.CgroupsPath to the runc-shim default
+	// (issue #312).
+	setCellCgroupPath(&rootContainerSpec, &internalCell)
 
 	// Per-cell /etc/hostname / initial /etc/hosts — render before the root's
 	// OCI spec is built so the bind-mount sources exist when runc consumes
@@ -745,9 +742,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
 
 		// CellCgroupPath: runtime-only injection — see the comment at the
 		// root-container recreate above. Issue #312.
-		if containerSpec.CellCgroupPath == "" {
-			containerSpec.CellCgroupPath = internalCell.Status.CgroupPath
-		}
+		setCellCgroupPath(&containerSpec, &internalCell)
 
 		// NestedCgroupRuntime: runtime-only injection — same shape as
 		// CellCgroupPath. The per-container field is not persisted (see
@@ -1002,9 +997,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 
 	// CellCgroupPath: runtime-only injection — fill from cell.Status.CgroupPath
 	// so the recreated container task lands under <cell>/<id>. Issue #312.
-	if foundContainerSpec.CellCgroupPath == "" {
-		foundContainerSpec.CellCgroupPath = cell.Status.CgroupPath
-	}
+	setCellCgroupPath(foundContainerSpec, &cell)
 
 	// NestedCgroupRuntime: runtime-only injection — see the matching block
 	// in StartCell. The per-container field is not persisted, so a cell


### PR DESCRIPTION
## Summary
- Six call sites in `internal/controller/runner/{provision,start}.go` all carried the same `if spec.CellCgroupPath == "" { spec.CellCgroupPath = cell.Status.CgroupPath }` shape — adding a new `BuildContainerSpec` / `BuildRootContainerSpec` site and forgetting the fill is a silent runtime regression (issue #312 already burned the smoke test once on a missed `start.go` site).
- Extract `setCellCgroupPath(spec *intmodel.ContainerSpec, cell *intmodel.Cell)` into `internal/controller/runner/cell_cgroup_path.go`. Helper is nil-safe and idempotent (no-op when the spec field is already populated), so the call sites collapse to one line each.
- Unit tests in `cell_cgroup_path_test.go` lock in the four contracts: copy-when-empty, do-not-overwrite, nil-safe (spec or cell), and empty-status-path → empty (preserves the pre-refactor "fill from the live cell" semantics).
- Removed the now-unused `cellCgroupPath` local at `provision.go:1445`; the runtime-justification comment moves down to the helper call. The other five sites keep their existing issue-#312 context comments.

## Test plan
- [x] `go build ./...`
- [x] `make test` (full package suite; new `TestSetCellCgroupPath*` pass, no regressions)
- [x] `pre-commit run --files internal/controller/runner/{provision,start,cell_cgroup_path,cell_cgroup_path_test}.go`
- [x] `make dev-init` — daemon-parity check matches expected `default` / `kuke-system` Ready output, and the kukeond cell containers land under `/sys/fs/cgroup/kukeon/kuke-system/kukeon/kukeon/kukeond/{kukeon_kukeon_kukeond_root,kukeon_kukeon_kukeond_kukeond}` confirming the runtime-only injection still works post-refactor
- [x] `kuke attach` smoke tail of `make dev-init` exits cleanly

Closes #317