### PR TITLE
refactor: drop dead errors.As branch in cgroupcheck.readControllers

### DIFF
--- a/internal/cgroupcheck/cgroupcheck.go
+++ b/internal/cgroupcheck/cgroupcheck.go
@@ -32,7 +32,6 @@ package cgroupcheck
 import (
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -489,13 +488,6 @@ func HostAdvertised(hostRoot string) ([]string, error) {
 func readControllers(path string) ([]string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		// Return a more actionable error for the common "kuke doctor
-		// cgroups" misuse where the operator pointed --root at something
-		// that isn't a cgroup-v2 hierarchy.
-		var pathErr *fs.PathError
-		if errors.As(err, &pathErr) {
-			return nil, err
-		}
 		return nil, err
 	}
 	out := strings.Fields(string(data))


### PR DESCRIPTION
## Summary
- Both arms of the `errors.As(err, &pathErr)` check at `internal/cgroupcheck/cgroupcheck.go:489` returned `nil, err` identically — the branch had no runtime effect, and the comment promised a "more actionable error" that was never synthesized. Dropped the dead branch + misleading comment (lower-blast-radius of the two resolutions the issue offered).
- `io/fs` was only used by that branch — dropped the import. `errors` stays (still used by the `errors.Is` calls at lines 300, 305, 307 in the probe-error classifier).
- Behaviorally a no-op: `readControllers` still returns `nil, err` on `os.ReadFile` failure, and the two `Check()` call sites at lines 248 and 252 still wrap with `fmt.Errorf("read %s: %w", path, err)` so the path appears in the operator-facing error.

## Test plan
- [x] `go build ./...`
- [x] `make test` (full package suite — `internal/cgroupcheck` passes; no regressions elsewhere)
- [x] `pre-commit run --files internal/cgroupcheck/cgroupcheck.go` (go fmt / golangci-lint / addlicense clean)
- [ ] `make dev-init` — not run; this PR is a pure dead-code removal in `internal/cgroupcheck` (the daemon read path uses only `cgroupcheck.CellResourceControllers()`, a constant slice — `readControllers`/`Check()` are reached exclusively via `cmd/kuke/doctor/cgroups`). The CLAUDE.md smoke-test trigger ("anything the daemon reads") does not apply.

Closes #326