### PR TITLE
docs: correct misleading HostCgroup comment in StartContainer relocate gate

### DIFF
--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -137,9 +137,10 @@ func (c *client) StartContainer(
 	// requires before any inner runtime (kuke init, dockerd, podman, an
 	// inner containerd) can widen subtree_control for non-thread-aware
 	// controllers like memory or io. Gated on the OCI spec carrying a
-	// non-empty Linux.CgroupsPath: the kukeon cell-container path always
-	// sets it via cellCgroupsPath, and HostCgroup containers leave it empty
-	// to share the host hierarchy through the kukeond bind mount.
+	// non-empty Linux.CgroupsPath: cellCgroupsPath sets it whenever the
+	// container's CellCgroupPath is non-empty (cell containers, including
+	// HostCgroup ones whose CellCgroupPath is filled from cell.Status), and
+	// leaves it empty for raw containerd / non-cell containers.
 	if relocateErr := c.relocateContainerTaskToLeaf(nsCtx, container); relocateErr != nil {
 		c.logger.WarnContext(c.ctx,
 			"failed to relocate container task to _payload leaf",
@@ -154,7 +155,9 @@ func (c *client) StartContainer(
 // relocateContainerTaskToLeaf moves the just-started container's PIDs into
 // a _payload leaf cgroup under its OCI Linux.CgroupsPath. See StartContainer
 // for the rationale (issue #336 scenario A). Returns nil when the container
-// has no CgroupsPath set (HostCgroup or non-cell containers).
+// has no CgroupsPath set — raw containerd / non-cell containers whose
+// CellCgroupPath is empty. Cell containers with HostCgroup=true still relocate
+// because cellCgroupsPath fills Linux.CgroupsPath from their CellCgroupPath.
 func (c *client) relocateContainerTaskToLeaf(nsCtx context.Context, container containerd.Container) error {
 	ociSpec, err := container.Spec(nsCtx)
 	if err != nil {


### PR DESCRIPTION
## Summary
- The comments at \`internal/ctr/container.go:140-142\` and \`:157\` claimed HostCgroup containers leave \`Linux.CgroupsPath\` empty — actively wrong. \`cellCgroupsPath\` (\`spec.go:323\`, \`container_utils.go:174\`) keys on \`CellCgroupPath\` being non-empty, not on \`HostCgroup\`, so a HostCgroup root container whose \`CellCgroupPath\` is filled from \`cell.Status.CgroupPath\` still gets a \`Linux.CgroupsPath\` and still relocates to \`_payload\` (the live behavior #340 verified for \`kukeon_kukeon_kukeond_root\`).
- Reworded both sites to describe the real gate: relocation is gated on \`CellCgroupPath\` being non-empty; the no-op path is raw containerd / non-cell containers, not HostCgroup ones. Doc-comment on \`relocateContainerTaskToLeaf\` now explicitly names the HostCgroup-still-relocates case so a future debugger doesn't get the wrong mental model.
- Pure comment edit — no executable code, test, or behavior change. Tagging \`ready-to-merge\` per CLAUDE.md's trivial-edit shortcut.

## Test plan
- [x] \`go build ./...\`
- [x] \`make test\` (full package suite — \`internal/ctr\` and all others pass)
- [x] \`pre-commit run --files internal/ctr/container.go\` (go fmt / golangci-lint / addlicense clean)
- [ ] \`make dev-init\` — not run; pure comment edit produces a byte-identical binary (Go strips comments at compile time), so the daemon read path and \`/opt/kukeon\` are untouched. The CLAUDE.md smoke-test trigger does not apply.

Closes #341