### PR TITLE
fix: preserve ErrContainerNotFound sentinel in kuke log / get container / daemon logs wraps

### DIFF
--- a/cmd/kuke/daemon/logs/logs.go
+++ b/cmd/kuke/daemon/logs/logs.go
@@ -110,8 +110,8 @@ func runLogs(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		if errors.Is(err, errdefs.ErrContainerNotFound) {
 			return fmt.Errorf(
-				"kukeond container %q not found in cell %q",
-				consts.KukeSystemContainerName, consts.KukeSystemCellName,
+				"kukeond container %q not found in cell %q: %w",
+				consts.KukeSystemContainerName, consts.KukeSystemCellName, err,
 			)
 		}
 		return fmt.Errorf("resolve kukeond log path: %w", err)

--- a/cmd/kuke/daemon/logs/logs_test.go
+++ b/cmd/kuke/daemon/logs/logs_test.go
@@ -297,6 +297,32 @@ func TestDaemonLogs_ContainerNotFound_NamedTarget(t *testing.T) {
 	}
 }
 
+// TestDaemonLogs_ContainerNotFound_SurfacesSentinel locks in the
+// ErrContainerNotFound branch's %w wrap: when LogContainer's RPC reports
+// the kukeond container doesn't exist, `kuke daemon logs` must propagate
+// the sentinel so upstream callers can still errors.Is it. Distinct from
+// TestDaemonLogs_ContainerNotFound_NamedTarget above, which only asserts
+// the human-readable message — they share the same fake but exercise the
+// two contracts (message + sentinel) independently.
+func TestDaemonLogs_ContainerNotFound_SurfacesSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{Cell: readyCell(), MetadataExists: true}, nil
+		},
+		logContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			return kukeonv1.LogContainerResult{}, errdefs.ErrContainerNotFound
+		},
+	}
+	cmd, _ := newCmd(t, fc, &tailCapture{})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrContainerNotFound) {
+		t.Fatalf("error %v does not unwrap to ErrContainerNotFound", err)
+	}
+}
+
 func TestDaemonLogs_MissingLogFile_NamesTheCause(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -164,7 +164,7 @@ func runContainerCmdWithDeps(
 		result, err := client.GetContainer(cmd.Context(), doc)
 		if err != nil {
 			if errors.Is(err, errdefs.ErrContainerNotFound) {
-				return fmt.Errorf("container %q not found", name)
+				return fmt.Errorf("container %q not found: %w", name, err)
 			}
 			return err
 		}

--- a/cmd/kuke/get/container/container_test.go
+++ b/cmd/kuke/get/container/container_test.go
@@ -308,6 +308,39 @@ func TestNewContainerCmd(t *testing.T) {
 	}
 }
 
+// TestGetContainer_NotFound_SurfacesSentinel locks in the
+// ErrContainerNotFound branch's %w wrap: when GetContainer's RPC reports
+// the named container doesn't exist, `kuke get container <name>` must
+// propagate the sentinel so upstream callers can still errors.Is it.
+func TestGetContainer_NotFound_SurfacesSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.GetContainerResult, error) {
+			return kukeonv1.GetContainerResult{}, errdefs.ErrContainerNotFound
+		},
+	}
+	cmd := container.NewContainerCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, container.MockControllerKey{}, kukeonv1.Client(fc))
+	cmd.SetContext(ctx)
+	_ = cmd.Flags().Set("realm", "r1")
+	_ = cmd.Flags().Set("space", "s1")
+	_ = cmd.Flags().Set("stack", "st1")
+	_ = cmd.Flags().Set("cell", "ce1")
+	cmd.SetArgs([]string{"missing"})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrContainerNotFound) {
+		t.Fatalf("error %v does not unwrap to ErrContainerNotFound", err)
+	}
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/log/log.go
+++ b/cmd/kuke/log/log.go
@@ -152,7 +152,7 @@ func runLog(cmd *cobra.Command, args []string) error {
 	result, err := client.LogContainer(cmd.Context(), doc)
 	if err != nil {
 		if errors.Is(err, errdefs.ErrContainerNotFound) {
-			return fmt.Errorf("container %q not found in cell %q", container, cell)
+			return fmt.Errorf("container %q not found in cell %q: %w", container, cell, err)
 		}
 		return err
 	}

--- a/cmd/kuke/log/log_test.go
+++ b/cmd/kuke/log/log_test.go
@@ -469,6 +469,34 @@ func TestLog_MissingCellArg(t *testing.T) {
 	}
 }
 
+// TestLog_ContainerNotFound_SurfacesSentinel locks in the
+// ErrContainerNotFound branch's %w wrap: when LogContainer's RPC reports
+// the named container doesn't exist, `kuke log` must propagate the
+// sentinel so upstream callers can still errors.Is it.
+func TestLog_ContainerNotFound_SurfacesSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		logContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.LogContainerResult, error) {
+			return kukeonv1.LogContainerResult{}, errdefs.ErrContainerNotFound
+		},
+	}
+	tail := &tailCapture{}
+	cmd, _ := newCmdWithCtx(t, fc, tail)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "ghost", "c1",
+	})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrContainerNotFound) {
+		t.Fatalf("error %v does not unwrap to ErrContainerNotFound", err)
+	}
+	if tail.calls != 0 {
+		t.Errorf("tail called %d times on missing target, want 0", tail.calls)
+	}
+}
+
 // TestTailFile_DefaultDumpsAndReturns exercises the real tailFile (not
 // the mock) to lock in the dump-and-exit semantics that the default
 // (no `-f`) `kuke log` invocation relies on.


### PR DESCRIPTION
## Summary
- Three call sites caught `errdefs.ErrContainerNotFound` and returned a fresh `fmt.Errorf` without `%w`, dropping the sentinel for upstream `errors.Is` checks — same shape PR #395 fixed for `kuke attach` / `kuke run` attach.
- `cmd/kuke/log/log.go:155` (`kuke log`), `cmd/kuke/get/container/container.go:167` (`kuke get container <name>`), and `cmd/kuke/daemon/logs/logs.go:112` (`kuke daemon logs`) now append `: %w` and pass the original `err`, matching the adjacent wrapped branches in each file.
- Each call site gets a new `errors.Is` test (`Test*_NotFound_SurfacesSentinel` / `TestDaemonLogs_ContainerNotFound_SurfacesSentinel`). Existing string-message tests stay as-is so the human-readable error wording remains pinned alongside the sentinel propagation.

## Test plan
- [x] `go build ./...`
- [x] `make test` (full package suite — new sentinel tests pass; the existing string-based not-found tests still pin the human-readable wording)
- [x] `pre-commit run --files cmd/kuke/daemon/logs/logs.go cmd/kuke/daemon/logs/logs_test.go cmd/kuke/get/container/container.go cmd/kuke/get/container/container_test.go cmd/kuke/log/log.go cmd/kuke/log/log_test.go` (go-fmt / go-mod-tidy / golangci-lint / addlicense clean)
- [ ] `make dev-init` — not run; pure CLI-side error-wrap formatting in `kuke log` / `kuke get container` / `kuke daemon logs`. No build path, no daemon code, nothing the daemon reads, nothing under `/opt/kukeon`. Same reasoning as PR #395's smoke-test skip.

Closes #396