### PR TITLE
docs: document kuke uninstall half-cleaned-host gate + recovery in cli-use-cases.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,3 +107,32 @@ sudo ctr -n kuke-system.kukeon.io container info \
 # /bin/kukeond serve --socket /run/kukeon/kukeond.sock --run-path /opt/kukeon
 ps -ef | grep '[k]ukeond serve'
 ```
+
+### Recovering from a failed `kuke uninstall`
+
+`kuke uninstall` tears down kukeon runtime state in this order: (0) stop the
+kukeond daemon, (1) purge every realm, (2) remove `/run/kukeon`, (3) remove
+the configured run path (default `/opt/kukeon`), (4) remove the kukeon
+system user and group.
+
+Steps 2–4 are gated on every realm reporting `NamespaceRemoved=true`. If any
+realm fails to drop its containerd namespace, the report renders each
+filesystem/account row as `skipped (realm purge failed)` and prints
+
+    filesystem + user/group cleanup skipped: residual containerd namespace prevented teardown
+
+This is the half-cleaned-host guard added in #287: tearing out `/opt/kukeon`
+while overlay snapshots in a residual namespace are still pinning files on
+disk would strand the next `kuke init` with stale containerd state and could
+rip the bind mounts out from under a still-live daemon.
+
+To recover:
+
+1. Inspect the residual namespace — e.g. `ctr -n <namespace> snapshots ls`,
+   `ctr -n <namespace> containers ls` — and clean it up by hand or via
+   `ctr namespace remove <namespace>` once the namespace is empty.
+2. Re-run `kuke uninstall --yes`. The realm-purge step will now succeed and
+   the gated cleanup steps (2–4) will run normally.
+
+A successful re-run produces the familiar tail (`/opt/kukeon: removed`,
+`user 'kukeon': removed`, etc.) with no `skipped` lines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,29 +110,4 @@ ps -ef | grep '[k]ukeond serve'
 
 ### Recovering from a failed `kuke uninstall`
 
-`kuke uninstall` tears down kukeon runtime state in this order: (0) stop the
-kukeond daemon, (1) purge every realm, (2) remove `/run/kukeon`, (3) remove
-the configured run path (default `/opt/kukeon`), (4) remove the kukeon
-system user and group.
-
-Steps 2–4 are gated on every realm reporting `NamespaceRemoved=true`. If any
-realm fails to drop its containerd namespace, the report renders each
-filesystem/account row as `skipped (realm purge failed)` and prints
-
-    filesystem + user/group cleanup skipped: residual containerd namespace prevented teardown
-
-This is the half-cleaned-host guard added in #287: tearing out `/opt/kukeon`
-while overlay snapshots in a residual namespace are still pinning files on
-disk would strand the next `kuke init` with stale containerd state and could
-rip the bind mounts out from under a still-live daemon.
-
-To recover:
-
-1. Inspect the residual namespace — e.g. `ctr -n <namespace> snapshots ls`,
-   `ctr -n <namespace> containers ls` — and clean it up by hand or via
-   `ctr namespace remove <namespace>` once the namespace is empty.
-2. Re-run `kuke uninstall --yes`. The realm-purge step will now succeed and
-   the gated cleanup steps (2–4) will run normally.
-
-A successful re-run produces the familiar tail (`/opt/kukeon: removed`,
-`user 'kukeon': removed`, etc.) with no `skipped` lines.
+If `kuke uninstall` reports `skipped (realm purge failed)` and `filesystem + user/group cleanup skipped: residual containerd namespace prevented teardown`, see the **Full per-host teardown** section in [`docs/cli-use-cases.md`](docs/cli-use-cases.md) for the half-cleaned-host gate explanation and the namespace-cleanup + re-run recovery procedure.

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -71,6 +71,23 @@ sudo kuke uninstall -y       # non-interactive (scripts)
 - The binary at `/usr/local/bin/kuke` and the `kukeond` symlink are **never** removed — uninstalling runtime state is not the same as uninstalling the binary.
 - If any realm fails to drop its containerd namespace, the subsequent dir/account removal is **skipped** (not silently best-effort) and the report flags each skipped row. Exit code is non-zero so automation can branch on it.
 
+**Recovering from a failed `kuke uninstall`.**
+
+`kuke uninstall` tears down kukeon runtime state in this order: (0) stop the kukeond daemon, (1) purge every realm, (2) remove `/run/kukeon`, (3) remove the configured run path (default `/opt/kukeon`), (4) remove the kukeon system user and group.
+
+Steps 2–4 are gated on every realm reporting `NamespaceRemoved=true`. If any realm fails to drop its containerd namespace, the report renders each filesystem/account row as `skipped (realm purge failed)` and prints
+
+    filesystem + user/group cleanup skipped: residual containerd namespace prevented teardown
+
+This is the half-cleaned-host guard added in #287: tearing out `/opt/kukeon` while overlay snapshots in a residual namespace are still pinning files on disk would strand the next `kuke init` with stale containerd state and could rip the bind mounts out from under a still-live daemon.
+
+To recover:
+
+1. Inspect the residual namespace — e.g. `ctr -n <namespace> snapshots ls`, `ctr -n <namespace> containers ls` — and clean it up by hand or via `ctr namespace remove <namespace>` once the namespace is empty.
+2. Re-run `kuke uninstall --yes`. The realm-purge step will now succeed and the gated cleanup steps (2–4) will run normally.
+
+A successful re-run produces the familiar tail (`/opt/kukeon: removed`, `user 'kukeon': removed`, etc.) with no `skipped` lines.
+
 ### Pre-flight host checks
 
 **Intent.** Surface host-environment problems with an actionable remediation **before** they fail mid-bootstrap.


### PR DESCRIPTION
## Summary

- Adds a **Recovering from a failed `kuke uninstall`** subsection to the existing `Full per-host teardown` section in `docs/cli-use-cases.md`, documenting the half-cleaned-host gate that ships in `cmd/kuke/uninstall/uninstall.go` (`outcomeSkipped` / `filesystem + user/group cleanup skipped: residual containerd namespace prevented teardown`) and the namespace-cleanup + re-run recovery path.
- Adds a one-line pointer in `CLAUDE.md`'s smoke-test block (after `Inspecting the running daemon`) so an operator hitting the `skipped (realm purge failed)` rendering during a smoke pass is routed to the recovery section without inflating `CLAUDE.md`.

## Notes for reviewer

- Layout change from the original AC of #356 (which named `kukeon/CLAUDE.md` as the target): the recovery body lives in `docs/cli-use-cases.md` and `CLAUDE.md` carries the pointer. Rationale in the linked PR comment. #356's AC will be updated to match this layout.
- The recovery wording is verbatim from #356's "Proposed wording", reformatted to one-paragraph-per-step to match the prose style of the surrounding `Full per-host teardown` section.
- Pure markdown edit to two docs files; no code/tests change. Tagged `ready-to-merge` per the trivial-edit shortcut in `agents/dev/CLAUDE.md`.
- Issue #356 was filed by dev citing #287 as the source of the gate; the gate itself shipped in PR #357. The `#287` reference in the new section matches the existing `outcomeSkipped` doc comment in `cmd/kuke/uninstall/uninstall.go:231–233`.

## Test plan

- [x] `pre-commit run --files CLAUDE.md docs/cli-use-cases.md` — passed (trim trailing whitespace, end-of-files, prettier).
- [ ] `make test` / `make dev-init` — not run; pure markdown edit, no code/test surface touched.

Closes #356