### PR TITLE
fix: pre-stamp Failed before KillCell to close markCellFailed --rm race

### DIFF
--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -165,13 +165,20 @@ func truncateFailureMessage(cause error) string {
 // (issue #407 for the Start*-stage paths; issue #504 for the CreateCell-stage
 // path). The cleanup itself is:
 //
+//   - reload from metadata and stamp State=Failed plus Status.Reason /
+//     Status.Message *before* KillCell runs, so the on-disk state is sticky
+//     from the start of the cleanup (issue #409). cellStateIsSticky(Failed)
+//     short-circuits ReconcileCell, so any reconcile tick that lands during
+//     KillCell — including the one tripped by `--rm`'s AutoDelete + a cell
+//     that already reached Ready — observes Failed and refuses to reap the
+//     cell.
 //   - best-effort KillCell on the cell so any container that did start (e.g.,
 //     the root container) is torn down — the cell holds no running processes
-//     once it enters Failed;
-//   - reload from metadata so we overwrite KillCell's own Stopped-write, then
-//     stamp State=Failed plus Status.Reason / Status.Message so `kuke get
-//     cell -o yaml` shows the operator the failing stage and the wrapped
-//     cause, and persist via UpdateCellMetadata.
+//     once it enters Failed. KillCell internally writes CellStateStopped at
+//     the end of its run, briefly re-exposing the pre-#409 race window;
+//   - reload again and re-stamp State=Failed + Reason + Message so the
+//     operator-facing breadcrumb survives KillCell's Stopped-write. `kuke get
+//     cell -o yaml` then shows the failing stage and the wrapped cause.
 //
 // The original startup error is returned unmodified by the caller; this helper
 // only writes the new state so the reconciler can later observe it as terminal
@@ -184,6 +191,27 @@ func truncateFailureMessage(cause error) string {
 // on it without parsing the human-readable Message.
 func (r *Exec) markCellFailed(cell intmodel.Cell, reason string, cause error) {
 	cellName := strings.TrimSpace(cell.Metadata.Name)
+	message := truncateFailureMessage(cause)
+
+	// Pre-kill Failed stamp (issue #409). Reload first so we don't overwrite
+	// any concurrent updates from earlier in the failure path, then mutate to
+	// Failed and persist before invoking KillCell.
+	if pre, preErr := r.GetCell(cell); preErr == nil {
+		cell = pre
+	} else {
+		r.logger.DebugContext(r.ctx,
+			"failed to reload cell metadata before pre-kill Failed stamp",
+			"cell", cellName, "error", preErr.Error())
+	}
+	cell.Status.State = intmodel.CellStateFailed
+	cell.Status.Reason = reason
+	cell.Status.Message = message
+	if preStampErr := r.UpdateCellMetadata(cell); preStampErr != nil {
+		r.logger.WarnContext(r.ctx,
+			"failed to pre-stamp Failed state before killing cell",
+			"cell", cellName, "cause", cause.Error(), "error", preStampErr.Error())
+	}
+
 	if _, killErr := r.KillCell(cell); killErr != nil {
 		r.logger.WarnContext(r.ctx,
 			"failed to kill siblings while transitioning cell to Failed",
@@ -201,7 +229,7 @@ func (r *Exec) markCellFailed(cell intmodel.Cell, reason string, cause error) {
 
 	cell.Status.State = intmodel.CellStateFailed
 	cell.Status.Reason = reason
-	cell.Status.Message = truncateFailureMessage(cause)
+	cell.Status.Message = message
 	if updErr := r.UpdateCellMetadata(cell); updErr != nil {
 		r.logger.WarnContext(r.ctx,
 			"failed to persist Failed state after cell startup failure",

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -19,9 +19,13 @@
 package runner
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -517,5 +521,79 @@ func TestMarkCellFailed_PreservesFieldsAcrossRefreshCarry(t *testing.T) {
 	}
 	if newStatus.Message != "createCellContainers: image not found" {
 		t.Errorf("carryCellLifecycle dropped Message: got %q", newStatus.Message)
+	}
+}
+
+// TestMarkCellFailed_PreStampsBeforeKillCell pins the issue #409 ordering:
+// markCellFailed must persist State=Failed *before* calling KillCell. Without
+// the pre-stamp, the on-disk state stays at its pre-failure value (e.g.
+// Ready) until KillCell's own PopulateAndPersistCellContainerStatuses writes
+// Stopped near the end of its run; on an AutoDelete + ReadyObserved cell a
+// reconcile tick that lands in that window would trip shouldAutoDeleteCell
+// and reap the cell before the post-kill Failed-stamp lands.
+//
+// We probe the ordering by counting UpdateCellMetadata calls during the
+// helper's run. nowFn is bumped once per persist via stampCellLifecycle, so
+// the call counter is a direct proxy for "how many UpdateCellMetadata writes
+// happened". KillCell errors out at ensureClientConnected in the unit-test
+// harness (no real containerd socket) so KillCell's own persist is skipped
+// — that leaves the counter as a clean probe for pre-stamp + post-kill
+// restamp.
+//
+// One write means the pre-stamp regressed (only the post-kill restamp ran).
+// Two writes means both the pre-stamp and the post-kill restamp ran, which
+// is the fixed contract.
+func TestMarkCellFailed_PreStampsBeforeKillCell(t *testing.T) {
+	base := time.Date(2026, 5, 14, 12, 0, 0, 0, time.UTC)
+	var callCount int64
+	runPath := t.TempDir()
+	r := &Exec{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:   Options{RunPath: runPath},
+		nowFn: func() time.Time {
+			n := atomic.AddInt64(&callCount, 1)
+			return base.Add(time.Duration(n) * time.Second)
+		},
+	}
+
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "c-prekill"},
+		Spec: intmodel.CellSpec{
+			ID:         "c-prekill",
+			RealmName:  "default",
+			SpaceName:  "default",
+			StackName:  "default",
+			AutoDelete: true,
+			Containers: []intmodel.ContainerSpec{},
+		},
+		Status: intmodel.CellStatus{
+			State:         intmodel.CellStateReady,
+			ReadyObserved: true,
+		},
+	}
+	if err := r.UpdateCellMetadata(cell); err != nil {
+		t.Fatalf("UpdateCellMetadata seed: %v", err)
+	}
+	seed := atomic.LoadInt64(&callCount)
+
+	r.markCellFailed(cell, "StartContainerFailed", errors.New("createContainer: boom"))
+
+	got, err := r.GetCell(cell)
+	if err != nil {
+		t.Fatalf("GetCell: %v", err)
+	}
+	if got.Status.State != intmodel.CellStateFailed {
+		t.Errorf("Status.State = %v, want Failed", got.Status.State)
+	}
+	if !got.Status.ReadyObserved {
+		t.Errorf("Status.ReadyObserved = false, want true (one-way latch preserved across Failed transition)")
+	}
+
+	if delta := atomic.LoadInt64(&callCount) - seed; delta != 2 {
+		t.Errorf(
+			"UpdateCellMetadata writes during markCellFailed = %d, want 2 (pre-stamp + post-kill restamp). Issue #409.",
+			delta,
+		)
 	}
 }


### PR DESCRIPTION
## Summary
- `markCellFailed` now reloads + writes `State=Failed` *before* calling `KillCell`, then re-stamps `Failed` after the post-kill reload. The pre-kill write makes the on-disk state sticky (`cellStateIsSticky(Failed)`) for the duration of `KillCell`, so a reconcile tick that lands on an `AutoDelete=true` cell that previously reached Ready no longer trips `shouldAutoDeleteCell` and reaps the cell before the operator-facing `Failed` breadcrumb persists. Issue #409.
- The race window does not fully vanish — `KillCell`'s own `PopulateAndPersistCellContainerStatuses` writes `CellStateStopped` at the end of its run, so the window from that write to the helper's post-kill restamp remains. The fix matches the issue body's suggested approach: narrow the window dramatically by making the disk state sticky from the start, with the post-kill restamp closing the residual gap. Fully eliminating the window would require a deeper refactor of `KillCell`'s state-write contract and was out of scope here.

## Test plan
- [x] `make test` — passes (the `internal/controller/runner` package picks up the new `TestMarkCellFailed_PreStampsBeforeKillCell` regression test, which counts `UpdateCellMetadata` calls via the `nowFn` clock probe; verified the test fails on the pre-fix code by stashing the `start.go` change and re-running).
- [x] `pre-commit run --files internal/controller/runner/start.go internal/controller/runner/start_test.go` — passed.
- [x] `make dev-init` smoke — daemon-parity check (`kuke get realms` with and without `--no-daemon`) renders the expected two-realm Ready table; attach smoke against a kuketty-wrapped cell exits cleanly.

Closes #409