### PR TITLE
docs: refresh Attachable + Tty docstrings for the kuketty injection path

### DIFF
--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -93,25 +93,30 @@ type ContainerSpec struct {
 	Secrets                []ContainerSecret      `json:"secrets,omitempty"                yaml:"secrets,omitempty"`
 	CNIConfigPath          string                 `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
 	RestartPolicy          string                 `json:"restartPolicy"                    yaml:"restartPolicy"`
-	// Attachable opts the container into sbsh-wrapper injection. When true,
-	// the daemon prepends `sbsh terminal --run-path /run/kukeon/tty …` to
-	// process.args, bind-mounts the sbsh binary read-only at /.kukeon/bin/sbsh,
-	// and bind-mounts a per-container tty directory at /run/kukeon/tty (sbsh
-	// owns its socket, capture, and log files inside it). The host-visible
-	// peer of that directory lives in the per-container metadata dir and its
-	// `socket` entry is what `kuke attach` connects to. Default false — no
-	// behavior change for existing specs.
+	// Attachable opts the container into kuketty-wrapper injection. When
+	// true, the daemon rewrites process.args to a single element
+	// [/.kukeon/bin/kuketty] — no CLI flags, every runtime input flows
+	// through the bind-mounted metadata file — bind-mounts the kuketty
+	// binary read-only at /.kukeon/bin/kuketty, bind-mounts a per-container
+	// tty directory at /run/kukeon/tty (kuketty owns the attach socket
+	// inside it; capture and log files land in later phases), and
+	// bind-mounts the per-container metadata file read-only at
+	// /.kukeon/kuketty/metadata.json (carries the rendered api.TerminalDoc
+	// with the workload argv baked into Spec.Command / Spec.CommandArgs).
+	// The host-visible peer of the tty directory lives in the per-container
+	// metadata dir and its `socket` entry is what `kuke attach` connects
+	// to. Default false — no behavior change for existing specs.
 	Attachable bool `json:"attachable,omitempty"             yaml:"attachable,omitempty"`
-	// Tty configures shell-UX (prompt, init scripts) for the sbsh wrapper
-	// when Attachable=true. The container model already owns command, args,
-	// workingDir, and env, so Tty intentionally only adds layers the
-	// container model can't express. Setting any tty field with
+	// Tty configures shell-UX (prompt, init scripts) for the kuketty
+	// wrapper when Attachable=true. The container model already owns
+	// command, args, workingDir, and env, so Tty intentionally only adds
+	// layers the container model can't express. Setting any tty field with
 	// Attachable=false is a validation error.
 	Tty *ContainerTty `json:"tty,omitempty"                    yaml:"tty,omitempty"`
 }
 
 // ContainerTty carries per-attach shell-UX config that the daemon threads
-// into sbsh terminal on first attach. Has no effect unless Attachable=true.
+// into kuketty on first attach. Has no effect unless Attachable=true.
 //
 // All fields are stamped directly onto the rendered sbsh TerminalSpec via
 // sbsh's inline builder lane (sbsh v0.11.2+, kukeon #494). The pre-#494


### PR DESCRIPTION
## Summary
- Refreshes the `Attachable`, `Tty`, and `ContainerTty` docstrings in `pkg/api/model/v1beta1/container.go` so a YAML / SDK author reading them gets the kuketty injection path documented in `internal/ctr/attachable.go`, not the pre-#411 sbsh-CLI-wrapper picture.
- `Attachable` now describes: process.args **rewritten** to `[/.kukeon/bin/kuketty]` (single element, no CLI flags), kuketty binary bind-mounted RO at `/.kukeon/bin/kuketty`, per-container tty directory at `/run/kukeon/tty`, and the per-container metadata file bind-mounted RO at `/.kukeon/kuketty/metadata.json` carrying the rendered `api.TerminalDoc` (workload argv lives in `Spec.Command` / `Spec.CommandArgs`).
- `Tty` swaps `sbsh wrapper` → `kuketty wrapper`. `ContainerTty` swaps `into sbsh terminal on first attach` → `into kuketty on first attach`. The "stamped onto the rendered sbsh TerminalSpec via sbsh's inline builder lane" sentence stays — kuketty consumes the same sbsh schema via `pkg/terminal/server`, so that line remains accurate.

## Test plan
- [x] `pre-commit run --files pkg/api/model/v1beta1/container.go` — passed (trim trailing whitespace, fix end of files, go fmt, go-mod-tidy, golangci-lint, addlicense).
- [x] `make test` — passed (full non-e2e suite including `pkg/api/model/v1beta1`).
- [ ] `make e2e` / `make dev-init` — not run; pure docstring/comment edit, no behavior change, no daemon-read or build-path surface touched.

Closes #414