### PR TITLE
fix: stamp lifecycle on CNI-conf regen direct WriteMetadata in ensureSpaceCNIConfig

### DIFF
--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -265,6 +265,11 @@ func (r *Exec) ensureSpaceCNIConfig(space intmodel.Space) (intmodel.Space, error
 		}
 		// Preserve any internal-only fields that might have been set
 		updatedSpace.Status.CgroupPath = space.Status.CgroupPath
+		// This path bypasses UpdateSpaceMetadata (CNIConfigPath would be
+		// dropped through the internal-model conversion), so apply the
+		// same lifecycle-timestamp invariants here — otherwise UpdatedAt
+		// would not advance on this persist. See #419, #418.
+		stampSpaceLifecycle(&updatedSpace, r.nowUTC())
 		// UpdateSpaceMetadata will convert to external, but CNIConfigPath is not in internal model
 		// So we need to ensure it's preserved. Since UpdateSpaceMetadata converts internal->external,
 		// and CNIConfigPath is not in internal, we need to handle this differently.


### PR DESCRIPTION
## Summary
- `ensureSpaceCNIConfig` regenerates a space's CNI conflist when the spec's `CNIConfigPath` drifts and persists the rebuilt `spaceDoc` via a direct `metadata.WriteMetadata` call — bypassing `UpdateSpaceMetadata` (the CNIConfigPath field would otherwise be dropped through the internal-model conversion). That bypass also skipped `stampSpaceLifecycle`, so the centralized "`UpdatedAt` is bumped on every persist" invariant from #418's PR body did not hold on this one path.
- Adds a `stampSpaceLifecycle(&updatedSpace, r.nowUTC())` call right before the `BuildSpaceExternalFromInternal` so the timestamp is part of the external doc that gets written to disk. Matches the suggested fix in #419 verbatim. No restructuring of the surrounding CNIConfigPath workaround.

## Notes for reviewer
- The stamp goes on `updatedSpace` (the internal model) before the external build, mirroring how `UpdateSpaceMetadata` itself stamps (`internal/controller/runner/metadata.go:107`). `CreatedAt` / `ReadyAt` set-once semantics survive: this is a re-persist of an already-Ready space, so the carry from disk preserves the existing timestamps; only `UpdatedAt` advances.
- Stamp is applied even when the regen-only branch wrote the conflist but the spec was already in sync — the branch is gated by `specUpdated := spaceDoc.Spec.CNIConfigPath != confPath`, so we only stamp on the persist path, not on read-only conflist regen.
- `updatedSpace.Status.State == intmodel.SpaceStateReady` would set `ReadyAt` on first-ever persist via this branch — but practically that branch only fires on already-provisioned spaces, so `ReadyAt` carries from the previous persist. No on-disk migration needed; the carry was already covered by `carrySpaceLifecycle` on the refresh path.

## Test plan
- [x] `make test` — all packages pass.
- [x] `go vet ./...` clean; `gofmt -l internal/ pkg/ cmd/` produces no diff.
- [x] `pre-commit run --files internal/controller/runner/provision.go` — all hooks (trim/EOF/go-fmt/go-mod-tidy/golangci-lint/addlicense) passed.
- [x] `make dev-init` rebuilds and re-bootstraps the local kukeond image; daemon-parity tail produces the documented `NAME / NAMESPACE / STATE / CGROUP` two-row layout (both `kuke get realms` and `--no-daemon` views match) and the `kuke attach smoke` step exits cleanly.

Closes #419