### PR TITLE
docs: refresh 'sbsh socket' wording in attach e2e to 'kuketty socket'

### DIFF
--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -93,14 +93,14 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// Step 2: apply the attachable cell fixture. Auto-starts the workload
 	// (apply is the path that drives Cell to Ready), so by the time it
 	// returns the container task should be RUNNING. The per-container
-	// sbsh socket appears thanks to #77's per-container tty/ directory bind
+	// kuketty socket appears thanks to #77's per-container tty/ directory bind
 	// mount, which makes sbsh's listener inode host-visible. This scenario
 	// does not pre-create any placeholder socket file (the old workaround
 	// was broken because sbsh unlinks-and-recreates the destination,
 	// producing a fresh inode invisible to the host).
 	applyAttachableCell(t, runPath, realmName, spaceName, stackName, cellName)
 
-	// Step 3: confirm the per-container sbsh socket is in place. The runner
+	// Step 3: confirm the per-container kuketty socket is in place. The runner
 	// creates the metadata dir at provision time and sbsh binds the socket
 	// inside the container at task start. If this is missing, pkg/attach
 	// would fail in a way that's hard to attribute, so check explicitly.
@@ -209,7 +209,7 @@ func absRunPath(runPath string) string {
 	return filepath.Join(cwd, runPath)
 }
 
-// waitForSocket polls until the per-container sbsh control socket appears
+// waitForSocket polls until the per-container kuketty control socket appears
 // or the timeout expires. Polling rather than fixed-sleep so a fast machine
 // is not penalised and a stuck task fails with a useful message.
 func waitForSocket(t *testing.T, path string, timeout time.Duration) {
@@ -222,7 +222,7 @@ func waitForSocket(t *testing.T, path string, timeout time.Duration) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	t.Fatalf("sbsh socket %q did not appear within %s", path, timeout)
+	t.Fatalf("kuketty socket %q did not appear within %s", path, timeout)
 }
 
 // verifyContainerTaskIsRunning returns true iff `ctr task ls` reports the


### PR DESCRIPTION
## Summary
- Resumes the parked re-run of `TestKuke_AttachDetach_KeepsTaskRunning` from #119. The premise (`waitForSocket` timeout on the sbsh-era socket) is stale: the kuketty phases (#413/#415/#417/#420) landed and the socket now appears as expected; the failure has moved to a host-side `connect: invalid argument` on the long temp-dir path. That distinct failure is captured by **#521** ("kuke attach fails with 'connect: invalid argument' on long runPaths (SUN_PATH overflow)") — out of scope for this PR.
- Delivers the wording-refresh half of #119's "as part of either outcome" note: the literal `sbsh socket` / `sbsh control socket` phrases in `e2e/e2e_kuke_attach_test.go` (the per-container socket producer is now kuketty) are renamed at the four matching sites (two `Step 2/3` comments, the `waitForSocket` docstring, and the `t.Fatalf` message). Other `sbsh` mentions in the file refer to the underlying `pkg/attach` / `pkg/terminal` library that kuketty wraps and stay accurate.

## Test plan
- [x] `make test` — full unit-test suite (the CI target per `.github/workflows/test.yaml`) passes locally
- [x] `pre-commit run --files e2e/e2e_kuke_attach_test.go` — all hooks green (go fmt, golangci-lint, addlicense, trailing-whitespace, …)
- [x] `grep -n 'sbsh socket\|sbsh control socket' e2e/e2e_kuke_attach_test.go` — no remaining matches
- [ ] `make e2e TestKuke_AttachDetach_KeepsTaskRunning` — still fails with `connect: invalid argument` on `origin/main` (verified pre-PR). The SUN_PATH overflow root cause is filed as #521; this PR does not attempt to fix it.

Closes #119
References #521