### PR TITLE
build: add kuketty to test-e2e prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ KUKEON_E2E_IMAGE ?= docker.io/library/$(KUKEON_E2E_IMAGE_DOCKER_NAME)
 
 e2e: test-e2e
 .PHONY: test-e2e
-test-e2e: kuke
+test-e2e: kuke kuketty
 	@echo "Building local kukeond image $(KUKEON_E2E_IMAGE_DOCKER_NAME) for e2e"
 	docker build --build-arg VERSION=v0.0.0-e2e -t $(KUKEON_E2E_IMAGE_DOCKER_NAME) .
 	@echo "Running e2e tests using binaries in project root"


### PR DESCRIPTION
## Summary
- `make e2e` from a clean tree fails with `kuketty binary not found` because `test-e2e` only declared `kuke` as a prerequisite. The e2e harness runs `kuke --no-daemon`, and `resolveKukettyBinary` looks for a sibling `./kuketty` next to the running executable — that sibling has to exist before the test starts.
- Adds `kuketty` to the `test-e2e` prerequisite list so `make e2e` builds both binaries the harness expects. The `clean` target already removes `kuke kukeond kuketty` together, so teardown symmetry is preserved.

## Test plan
- [x] `make test` — all unit tests pass
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make -n test-e2e` — dry-run shows both `go build -o kuke ./cmd/` and `go build -o kuketty ./cmd/kuketty/` run before the docker build + `go test ./e2e` invocation
- [ ] `make e2e TestKuke_AttachDetach_KeepsTaskRunning` — not run end-to-end. The originally failing test then hits the separate SUN_PATH overflow tracked by #521; that's out of scope for this PR per the issue body. The Makefile prereq fix is verified by `make -n` and is a one-line declarative change.

Closes #527