### PR TITLE
fix: route kuke attach through SUN_PATH-safe socket symlink

### DIFF
--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -104,7 +104,11 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// creates the metadata dir at provision time and sbsh binds the socket
 	// inside the container at task start. If this is missing, pkg/attach
 	// would fail in a way that's hard to attribute, so check explicitly.
-	socketPath := fs.ContainerSocketPath(runPath,
+	// Polls the SUN_PATH-safe symlink the runner stages (issue #521) — the
+	// same handle `kuke attach` connects through. `os.Stat` follows the
+	// symlink, so the loop succeeds once kuketty creates the deep socket
+	// inode at the resolved target.
+	socketPath := fs.ContainerSocketSymlinkPath(runPath,
 		realmName, spaceName, stackName, cellName, "work")
 	waitForSocket(t, socketPath, 10*time.Second)
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -109,16 +109,52 @@ func runBinary(t *testing.T, env []string, command string, args ...string) (int,
 	return exitCode, []byte(stdoutBuf.String()), []byte(stderrBuf.String())
 }
 
-// getRandomRunPath returns a unique, absolute run path for the test, backed
-// by t.TempDir(). The directory is created up front and removed automatically
-// when the test ends, so callers do not need a separate create-or-cleanup
-// step. Each call returns its own path, which avoids contention on a shared
-// parent directory (issue #491: MkdirAll on a shared parent races
-// concurrent t.Cleanup RemoveAll from sibling parallel tests, surfacing as
-// ENOENT on the new leaf).
+// getRandomRunPath returns a unique, absolute run path for the test. When
+// the t.TempDir-rooted path would push the *deep* per-container kuketty
+// socket path (`<runPath>/data/<realm>/<space>/<stack>/<cell>/<container>/
+// tty/socket`) over Linux's UNIX_PATH_MAX, the helper falls back to a
+// short /tmp prefix and registers a cleanup so the suite stays SUN_PATH-
+// safe regardless of how Go names the t.TempDir parent (issue #521).
+//
+// The architectural fix (issue #521) routes `kuke attach` through a short
+// symlink, so the deep path length no longer breaks `connect(2)` —
+// but the fallback is deliberate defense-in-depth: a future regression
+// that accidentally re-introduces the deep-path dial would fail loudly
+// here instead of in CI.
+//
+// Each call returns its own path so parallel-sibling tests don't race
+// MkdirAll/Cleanup-RemoveAll on a shared parent (issue #491's regression
+// class).
 func getRandomRunPath(t *testing.T) string {
 	t.Helper()
-	return t.TempDir()
+	tempDir := t.TempDir()
+	if deepSocketPathFits(tempDir) {
+		return tempDir
+	}
+	// t.TempDir() is the standard, but here it is exactly what overflows
+	// SUN_PATH because Go derives the temp basename from the test
+	// function name (`TestKuke_AttachDetach_KeepsTaskRunning` is 39
+	// bytes). Drop to a short, name-free /tmp prefix instead.
+	short, err := os.MkdirTemp("/tmp", "ke-") //nolint:usetesting // intentional shorter prefix; see comment
+	if err != nil {
+		t.Fatalf("MkdirTemp(/tmp, ke-): %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(short) })
+	return short
+}
+
+// deepSocketPathFits reports whether the longest plausible per-container
+// kuketty socket path under runPath fits SUN_PATH. The longest e2e suffix
+// is `/data/<realm>/<space>/<stack>/<cell>/<container>/tty/socket` with
+// realm/space/stack/cell names produced by generateUnique*Name (`e-r-XX`,
+// `e-sp-XX`, `e-st-XX`, `e-ce-XX`) and the container name fixed to
+// "work" by the attach fixture — 52 bytes of suffix all in. The check is
+// against the deep path, not the SUN_PATH-safe symlink the runner stages,
+// because deep-path regressions are the failure mode this fallback
+// defends against (the symlink budget is comfortably wider).
+func deepSocketPathFits(runPath string) bool {
+	const deepSocketSuffixLen = len("/data/e-r-XX/e-sp-XX/e-st-XX/e-ce-XX/work/tty/socket")
+	return len(runPath)+deepSocketSuffixLen <= consts.KukeonMaxSocketPath
 }
 
 // buildKukeRunPathArgs builds --run-path flag arguments.

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -956,13 +956,20 @@ func controllerImageToWire(img controller.ImageInfo) kukeonv1.ImageInfo {
 // sbsh control-socket path. Bytes never traverse this RPC — the caller
 // (`kuke attach`) opens HostSocketPath directly and runs the sbsh client
 // loop against it.
+//
+// Returns the SUN_PATH-safe symlink path (fs.ContainerSocketSymlinkPath)
+// rather than the deep socket inode path so `connect(2)` never sees a
+// sun_path longer than 107 bytes regardless of how deep the resolved
+// metadata layout is (issue #521). The runner stages the symlink at
+// provision time so a re-derived path on a freshly-spawned `kuke attach`
+// is always pre-materialised.
 func (c *Client) AttachContainer(_ context.Context, doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
 	spec, err := c.resolveAttachable(doc)
 	if err != nil {
 		return kukeonv1.AttachContainerResult{}, err
 	}
 	return kukeonv1.AttachContainerResult{
-		HostSocketPath: fs.ContainerSocketPath(
+		HostSocketPath: fs.ContainerSocketSymlinkPath(
 			c.ctrl.RunPath(),
 			spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
 		),

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -49,6 +49,27 @@ const (
 	// injected by Attachable=true specs.
 	KukeonContainerSocketFile = "socket"
 
+	// KukeonSocketSymlinkSubdir is the basename of the per-RunPath directory
+	// that holds SUN_PATH-safe symlinks to the deep per-container kuketty
+	// sockets (`<RunPath>/data/<realm>/<space>/<stack>/<cell>/<container>/
+	// tty/socket`). Linux `connect(2)` caps the path passed in
+	// sockaddr_un.sun_path at 108 bytes including the terminator (issue #521),
+	// and the deep metadata-rooted path overflows on long RunPaths or
+	// long realm/space/stack/cell IDs. The daemon stages a short symlink at
+	// `<RunPath>/s/<short>` at provision time; `kuke attach` connects via
+	// the symlink so the literal sun_path stays SUN_PATH-safe regardless of
+	// how deep the resolved target lives. Single-letter basename to spend
+	// the budget on the per-container short id, not the directory.
+	KukeonSocketSymlinkSubdir = "s"
+
+	// KukeonMaxSocketPath is Linux's UNIX_PATH_MAX minus the terminating
+	// NUL — the maximum number of bytes a path passed to `connect(2)` on a
+	// unix socket may occupy in sockaddr_un.sun_path. The daemon refuses to
+	// provision an Attachable container whose resolved host-side socket
+	// path would exceed this so the failure surfaces at provision time
+	// rather than at first `kuke attach` (issue #521).
+	KukeonMaxSocketPath = 107
+
 	// KukeonContainerCaptureFile is the basename of the per-container sbsh
 	// capture file inside KukeonContainerTTYDir. sbsh writes the full tty
 	// byte stream — every byte the workload produced and every byte typed

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -224,7 +224,8 @@ func (b *Exec) Close() error {
 // RunPath returns the configured kukeon run path. Surfaced for callers that
 // need to derive host paths from the same root the controller writes to —
 // notably the in-process AttachContainer endpoint, which resolves the
-// per-container sbsh socket via fs.ContainerSocketPath.
+// SUN_PATH-safe per-container kuketty socket via
+// fs.ContainerSocketSymlinkPath.
 func (b *Exec) RunPath() string {
 	return b.opts.RunPath
 }

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -25,7 +25,9 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
 	sbshapi "github.com/eminwux/sbsh/pkg/api"
@@ -104,6 +106,10 @@ func attachableTTYDirInitialPerms(kukeonGroupGID int) (os.FileMode, int) {
 func (r *Exec) attachableBuildOpts(_ string, spec intmodel.ContainerSpec, _ []ctr.RegistryCredentials) ([]ctr.BuildOption, error) {
 	if !spec.Attachable {
 		return nil, nil
+	}
+
+	if err := ensureAttachableSocketSymlink(r.opts.RunPath, spec); err != nil {
+		return nil, err
 	}
 
 	ttyDir := fs.ContainerTTYDir(
@@ -553,6 +559,85 @@ func (r *Exec) attachablePostCreateChown(namespace string, spec intmodel.Contain
 		// safety net rather than a hot path.
 	default:
 		return fmt.Errorf("chown %q to (uid=%d, gid=%d): %w", metadataPath, uid, gid, chownErr)
+	}
+	return nil
+}
+
+// attachableSocketSymlinkDirMode is the mode applied to <RunPath>/s when
+// the runner stages it on first Attachable provision. 0o755 mirrors the
+// /opt/kukeon root layout: world-traversable so any process can resolve a
+// staged symlink, world-listable so an operator can `ls` the directory
+// during troubleshooting. The symlinks themselves are never created
+// world-writable (symlink mode is ignored by Linux for symlink-following
+// `connect(2)`; the target inode's mode is what gates access).
+const attachableSocketSymlinkDirMode os.FileMode = 0o0755
+
+// ensureAttachableSocketSymlink stages the SUN_PATH-safe symlink that
+// `kuke attach` connects to (issue #521). The symlink lives at
+// fs.ContainerSocketSymlinkPath under a shallow <RunPath>/s/ subtree and
+// targets the deep fs.ContainerSocketPath inode that kuketty creates inside
+// the bind-mounted /run/kukeon/tty directory at runtime. The target inode
+// does not exist when this function runs — symlinks are pure strings — so
+// the function never blocks on container startup. Recreating the symlink
+// on a re-provision is idempotent: an existing entry is unlinked and
+// rewritten so a prior provision with a stale target gets corrected.
+//
+// The host-side socket path length is the gate: the function refuses to
+// stage a symlink whose resolved path would exceed
+// consts.KukeonMaxSocketPath bytes, surfacing errdefs.ErrSocketPathTooLong
+// with the offending path named. This is the provision-time fail-fast the
+// AC requires so a future operator-configured RunPath that overflows the
+// SUN_PATH budget cannot defer its failure to first `kuke attach`.
+func ensureAttachableSocketSymlink(runPath string, spec intmodel.ContainerSpec) error {
+	symlinkPath := fs.ContainerSocketSymlinkPath(
+		runPath,
+		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if len(symlinkPath) > consts.KukeonMaxSocketPath {
+		return fmt.Errorf("%w: %q is %d bytes (limit %d)",
+			errdefs.ErrSocketPathTooLong, symlinkPath, len(symlinkPath), consts.KukeonMaxSocketPath)
+	}
+
+	symlinkDir := fs.ContainerSocketSymlinkDir(runPath)
+	if err := os.MkdirAll(symlinkDir, attachableSocketSymlinkDirMode); err != nil {
+		return fmt.Errorf("mkdir %q: %w", symlinkDir, err)
+	}
+
+	target := fs.ContainerSocketPath(
+		runPath,
+		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	// os.Symlink fails with EEXIST when a dirent already lives at the
+	// destination; the re-provision case clears it first so a stale target
+	// from a prior layout does not silently linger. Use os.Remove (not
+	// RemoveAll) so a hostile or buggy actor cannot trick us into deleting a
+	// real directory tree if the destination has somehow turned into one.
+	if err := os.Remove(symlinkPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale symlink %q: %w", symlinkPath, err)
+	}
+	if err := os.Symlink(target, symlinkPath); err != nil {
+		return fmt.Errorf("symlink %q -> %q: %w", symlinkPath, target, err)
+	}
+	return nil
+}
+
+// removeAttachableSocketSymlink unlinks the SUN_PATH-safe symlink staged by
+// ensureAttachableSocketSymlink. Best-effort: a missing entry is not an
+// error (idempotent under repeated cell / container deletes), but any
+// other failure is returned so the caller can surface the operator-
+// actionable case (e.g. permissions) without losing the signal. Skips
+// non-Attachable specs so the cell-delete path can call it
+// unconditionally.
+func removeAttachableSocketSymlink(runPath string, spec intmodel.ContainerSpec) error {
+	if !spec.Attachable {
+		return nil
+	}
+	symlinkPath := fs.ContainerSocketSymlinkPath(
+		runPath,
+		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if err := os.Remove(symlinkPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove socket symlink %q: %w", symlinkPath, err)
 	}
 	return nil
 }

--- a/internal/controller/runner/delete_cell.go
+++ b/internal/controller/runner/delete_cell.go
@@ -105,6 +105,22 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 
 	// Workload containers tracked on the cell spec.
 	for _, containerSpec := range internalCell.Spec.Containers {
+		// Unlink the per-container SUN_PATH-safe socket symlink staged at
+		// provision time (issue #521) before tearing down the container.
+		// The symlink lives at <RunPath>/s/<short>, outside the
+		// CellMetadataDir tree that the RemoveAll below would otherwise
+		// reach — leaving it behind would accumulate stale symlinks
+		// pointing at vanished bind-mount sources across re-creates. The
+		// helper short-circuits on non-Attachable specs.
+		if symlinkErr := removeAttachableSocketSymlink(r.opts.RunPath, containerSpec); symlinkErr != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to remove socket symlink",
+				"container", containerSpec.ID,
+				"error", symlinkErr,
+			)
+		}
+
 		containerID := containerSpec.ContainerdID
 		if containerID == "" {
 			// A partial init can persist the cell document before the

--- a/internal/controller/runner/delete_container.go
+++ b/internal/controller/runner/delete_container.go
@@ -194,5 +194,18 @@ func (r *Exec) DeleteContainer(cell intmodel.Cell, containerID string) error {
 		_ = r.purgeCNIForContainer(containerdID, netnsPath, networkName)
 	}
 
+	// Unlink the SUN_PATH-safe socket symlink staged at provision time
+	// (issue #521). The symlink lives outside the cell metadata tree, so
+	// the CellMetadataDir RemoveAll path that delete_cell.go runs doesn't
+	// reach it; a missing dirent is fine — the helper is idempotent.
+	if symlinkErr := removeAttachableSocketSymlink(r.opts.RunPath, *foundContainerSpec); symlinkErr != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"failed to remove socket symlink",
+			"container", containerID,
+			"error", symlinkErr,
+		)
+	}
+
 	return nil
 }

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -224,6 +224,16 @@ var (
 	// non-root attachable containers.
 	ErrAttachNoCandidate = errors.New("no attachable container in cell")
 
+	// ErrSocketPathTooLong fires when the resolved host-side path of a
+	// per-container kuketty control socket would overflow Linux's
+	// sockaddr_un.sun_path buffer (consts.KukeonMaxSocketPath bytes plus
+	// the terminating NUL — UNIX_PATH_MAX = 108). The daemon refuses to
+	// provision the Attachable container so the failure surfaces at
+	// provision time with the offending path named, instead of deferring
+	// the failure to `kuke attach` where the kernel-level `connect(2)`
+	// returns the cryptic `invalid argument` (issue #521).
+	ErrSocketPathTooLong = errors.New("host-side kuketty socket path exceeds SUN_PATH")
+
 	// Profile-related errors.
 
 	// ErrProfileNotFound is returned when `kuke run -p <name>` cannot find

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -182,15 +182,18 @@ func ContainerSocketSymlinkPath(baseRunPath, realmName, spaceName, stackName, ce
 
 // containerSocketShortID returns the 16-hex digest that names the per-
 // container symlink inside ContainerSocketSymlinkDir. Derived from
-// sha256("<realm>|<space>|<stack>|<cell>|<container>")[:8] so the same
-// identity tuple always resolves to the same name across processes; the
-// pipe separator avoids any concatenation collision between values that
-// happen to share a suffix/prefix (e.g. realm "ab" + space "c" vs realm
-// "a" + space "bc"). 64 bits of randomness puts collisions astronomically
-// out of reach for any plausible per-host container count.
+// sha256("<realm>_<space>_<stack>_<cell>_<container>")[:8] so the same
+// identity tuple always resolves to the same name across processes. The
+// "_" separator is chosen because naming.ValidateRealmName and
+// naming.ValidateHierarchyName both reject "_" (and "/") in any
+// identifier — every other byte, including "|", is a legal name
+// character — so the join is unambiguous: two distinct tuples cannot
+// produce the same concatenation regardless of any byte values inside
+// the names. 64 bits of randomness puts collisions astronomically out
+// of reach for any plausible per-host container count.
 func containerSocketShortID(realmName, spaceName, stackName, cellName, containerName string) string {
 	digest := sha256.Sum256([]byte(
-		realmName + "|" + spaceName + "|" + stackName + "|" + cellName + "|" + containerName,
+		realmName + "_" + spaceName + "_" + stackName + "_" + cellName + "_" + containerName,
 	))
 	return hex.EncodeToString(digest[:8])
 }

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -17,6 +17,8 @@
 package fs
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -131,15 +133,66 @@ func ContainerTTYDir(baseRunPath, realmName, spaceName, stackName, cellName, con
 	)
 }
 
-// ContainerSocketPath returns the host-side path for a container's sbsh
-// terminal socket. This is the single source of truth for both the
-// host-visible path that `kuke attach` connects to and the path sbsh listens
-// on inside the container (mediated by the ContainerTTYDir bind mount).
+// ContainerSocketPath returns the host-side path of the kuketty terminal
+// socket inode for a container — the bind-mount source path the kuketty
+// listener inside the container resolves to via /run/kukeon/tty/socket.
+// This path can be arbitrarily long (it inherits the full metadata layout
+// depth) and is NOT safe to pass to `connect(2)`; see
+// ContainerSocketSymlinkPath for the SUN_PATH-safe handle that
+// `kuke attach` uses.
 func ContainerSocketPath(baseRunPath, realmName, spaceName, stackName, cellName, containerName string) string {
 	return filepath.Join(
 		ContainerTTYDir(baseRunPath, realmName, spaceName, stackName, cellName, containerName),
 		consts.KukeonContainerSocketFile,
 	)
+}
+
+// ContainerSocketSymlinkDir returns the per-RunPath directory that holds
+// SUN_PATH-safe symlinks to per-container kuketty sockets. The daemon
+// creates this directory once and stages one symlink per Attachable
+// container inside it; cell / container teardown removes the symlinks but
+// leaves the directory itself in place (idempotent — re-provisioning the
+// same container regenerates its symlink).
+func ContainerSocketSymlinkDir(baseRunPath string) string {
+	return filepath.Join(baseRunPath, consts.KukeonSocketSymlinkSubdir)
+}
+
+// ContainerSocketSymlinkPath returns the SUN_PATH-safe host-side path
+// `kuke attach` connects to. It is a short symlink staged by the daemon
+// inside ContainerSocketSymlinkDir that resolves to the deep socket inode
+// returned by ContainerSocketPath. Linux's sockaddr_un.sun_path is bounded
+// at 108 bytes including the terminator (consts.KukeonMaxSocketPath = 107
+// usable bytes); the deep metadata-rooted ContainerSocketPath overflows on
+// long RunPaths or long realm/space/stack/cell IDs (issue #521), so
+// every host-side `connect(2)` is routed through this short handle.
+//
+// The basename is a 16-hex (sha256[:8]) digest of the
+// realm|space|stack|cell|container tuple, which is deterministic across
+// process restarts (so a freshly-spawned `kuke attach` re-derives the same
+// path the provisioning runner staged) and uniquely identifies a
+// container without inheriting the depth of the metadata layout. With a
+// RunPath ≤ 60 bytes the resolved path is `<RunPath>/s/<16hex>` ≤ 79
+// bytes — well inside SUN_PATH.
+func ContainerSocketSymlinkPath(baseRunPath, realmName, spaceName, stackName, cellName, containerName string) string {
+	return filepath.Join(
+		ContainerSocketSymlinkDir(baseRunPath),
+		containerSocketShortID(realmName, spaceName, stackName, cellName, containerName),
+	)
+}
+
+// containerSocketShortID returns the 16-hex digest that names the per-
+// container symlink inside ContainerSocketSymlinkDir. Derived from
+// sha256("<realm>|<space>|<stack>|<cell>|<container>")[:8] so the same
+// identity tuple always resolves to the same name across processes; the
+// pipe separator avoids any concatenation collision between values that
+// happen to share a suffix/prefix (e.g. realm "ab" + space "c" vs realm
+// "a" + space "bc"). 64 bits of randomness puts collisions astronomically
+// out of reach for any plausible per-host container count.
+func containerSocketShortID(realmName, spaceName, stackName, cellName, containerName string) string {
+	digest := sha256.Sum256([]byte(
+		realmName + "|" + spaceName + "|" + stackName + "|" + cellName + "|" + containerName,
+	))
+	return hex.EncodeToString(digest[:8])
 }
 
 // ContainerCapturePath returns the host-side path of the per-container sbsh

--- a/internal/util/fs/metadata_test.go
+++ b/internal/util/fs/metadata_test.go
@@ -93,8 +93,15 @@ func TestContainerSocketSymlinkPath_DistinctPerContainer(t *testing.T) {
 	// Two distinct identity tuples must map to distinct short ids; sharing
 	// would collapse two containers onto the same dirent and the second
 	// provision would silently rewrite the first's target. Vary exactly
-	// one position per row so a coverage gap surfaces clearly. The pipe-
-	// separator concat-collision pair ("ab|c" vs "a|bc") is the last row.
+	// one position per row so a coverage gap surfaces clearly.
+	//
+	// The "pipe-in-name" row is the regression guard for the separator
+	// choice itself: "|" is a legal name byte (only "_" and "/" are
+	// rejected by naming.ValidateRealmName / naming.ValidateHierarchyName),
+	// so any non-"_"/"/" separator would let realm "a|b" + space "c"
+	// collide with realm "a" + space "b|c". The "concat" row is the
+	// classic split-shift case ("ab"+"c" vs "a"+"bc") that any
+	// fixed-byte separator catches.
 	type pair struct {
 		name string
 		a, b [5]string
@@ -106,6 +113,7 @@ func TestContainerSocketSymlinkPath_DistinctPerContainer(t *testing.T) {
 		{"space", [5]string{"r", "sA", "k", "c", "c1"}, [5]string{"r", "sB", "k", "c", "c1"}},
 		{"realm", [5]string{"rA", "s", "k", "c", "c1"}, [5]string{"rB", "s", "k", "c", "c1"}},
 		{"concat", [5]string{"ab", "c", "k", "c", "c1"}, [5]string{"a", "bc", "k", "c", "c1"}},
+		{"pipe-in-name", [5]string{"a|b", "c", "k", "c", "c1"}, [5]string{"a", "b|c", "k", "c", "c1"}},
 	}
 	for _, p := range pairs {
 		a := fs.ContainerSocketSymlinkPath("/opt/kukeon", p.a[0], p.a[1], p.a[2], p.a[3], p.a[4])

--- a/internal/util/fs/metadata_test.go
+++ b/internal/util/fs/metadata_test.go
@@ -18,6 +18,7 @@ package fs_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/apischeme"
@@ -60,6 +61,74 @@ func TestContainerSocketPath(t *testing.T) {
 		consts.KukeonContainerTTYDir + "/" + consts.KukeonContainerSocketFile
 	if got != want {
 		t.Errorf("ContainerSocketPath = %q, want %q", got, want)
+	}
+}
+
+func TestContainerSocketSymlinkPath_Layout(t *testing.T) {
+	// The SUN_PATH-safe symlink lives under <RunPath>/s/<short> — a single-
+	// letter parent so the budget goes to the per-container short id, not
+	// the directory. Anchored here so a refactor that drifts the layout
+	// (e.g. promotes the symlink dir to a per-realm subtree) breaks the
+	// test instead of silently violating the SUN_PATH bound.
+	got := fs.ContainerSocketSymlinkPath("/opt/kukeon", "realm", "space", "stack", "cell", "c1")
+	wantPrefix := "/opt/kukeon/" + consts.KukeonSocketSymlinkSubdir + "/"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("symlink path = %q, want prefix %q", got, wantPrefix)
+	}
+}
+
+func TestContainerSocketSymlinkPath_Deterministic(t *testing.T) {
+	// The short id is sha256[:8]-derived, so the same tuple must round-trip
+	// to the same path across calls. `kuke attach` re-derives the path from
+	// the container doc rather than reading the symlink dirent, so a
+	// process restart that changed the hash would silently break attach.
+	a := fs.ContainerSocketSymlinkPath("/opt/kukeon", "realm", "space", "stack", "cell", "c1")
+	b := fs.ContainerSocketSymlinkPath("/opt/kukeon", "realm", "space", "stack", "cell", "c1")
+	if a != b {
+		t.Errorf("symlink path is not deterministic: a=%q b=%q", a, b)
+	}
+}
+
+func TestContainerSocketSymlinkPath_DistinctPerContainer(t *testing.T) {
+	// Two distinct identity tuples must map to distinct short ids; sharing
+	// would collapse two containers onto the same dirent and the second
+	// provision would silently rewrite the first's target. Vary exactly
+	// one position per row so a coverage gap surfaces clearly. The pipe-
+	// separator concat-collision pair ("ab|c" vs "a|bc") is the last row.
+	type pair struct {
+		name string
+		a, b [5]string
+	}
+	pairs := []pair{
+		{"container", [5]string{"r", "s", "k", "c", "c1"}, [5]string{"r", "s", "k", "c", "c2"}},
+		{"cell", [5]string{"r", "s", "k", "cA", "c1"}, [5]string{"r", "s", "k", "cB", "c1"}},
+		{"stack", [5]string{"r", "s", "kA", "c", "c1"}, [5]string{"r", "s", "kB", "c", "c1"}},
+		{"space", [5]string{"r", "sA", "k", "c", "c1"}, [5]string{"r", "sB", "k", "c", "c1"}},
+		{"realm", [5]string{"rA", "s", "k", "c", "c1"}, [5]string{"rB", "s", "k", "c", "c1"}},
+		{"concat", [5]string{"ab", "c", "k", "c", "c1"}, [5]string{"a", "bc", "k", "c", "c1"}},
+	}
+	for _, p := range pairs {
+		a := fs.ContainerSocketSymlinkPath("/opt/kukeon", p.a[0], p.a[1], p.a[2], p.a[3], p.a[4])
+		b := fs.ContainerSocketSymlinkPath("/opt/kukeon", p.b[0], p.b[1], p.b[2], p.b[3], p.b[4])
+		if a == b {
+			t.Errorf("[%s] distinct tuples collided: a=%q b=%q", p.name, a, b)
+		}
+	}
+}
+
+func TestContainerSocketSymlinkPath_FitsSUNPath(t *testing.T) {
+	// AC #1 of issue #521: for any well-formed tuple under a RunPath
+	// ≤ 60 bytes, the resolved host-side socket path must stay under
+	// consts.KukeonMaxSocketPath so `connect(2)` never trips SUN_PATH
+	// overflow at `kuke attach` time. The symlink path budget is
+	// independent of how deep the metadata layout becomes — that is the
+	// whole point of routing the dial through it.
+	longRunPath := "/" + strings.Repeat("x", 59) // 60 bytes total
+	longName := strings.Repeat("z", 64)          // operator-supplied names can be long
+	got := fs.ContainerSocketSymlinkPath(longRunPath, longName, longName, longName, longName, longName)
+	if len(got) > consts.KukeonMaxSocketPath {
+		t.Errorf("symlink path overflows SUN_PATH: %d > %d (path=%q)",
+			len(got), consts.KukeonMaxSocketPath, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Linux's `sockaddr_un.sun_path` caps at 108 bytes (incl. NUL); the deep host-side socket path (`<RunPath>/data/<realm>/<space>/<stack>/<cell>/<container>/tty/socket`) overflowed on the longest e2e test name, surfacing as `connect: invalid argument` from `kuke attach`.
- The daemon now stages a per-RunPath SUN_PATH-safe symlink at `<RunPath>/s/<sha256[:8]>` pointing at the deep socket inode; `AttachContainer` returns that handle so the kernel-level `connect(2)` never sees a sun_path longer than `consts.KukeonMaxSocketPath = 107` (single-letter parent dir is intentional — spends the budget on the short id, not the directory).
- Provision-time fail-fast: `ensureAttachableSocketSymlink` refuses to stage when the resolved symlink path would still overflow, returning the new `errdefs.ErrSocketPathTooLong` with the offending path named — so a future operator-configured RunPath that overflows fails loud at provision time instead of deferring to first `kuke attach`.
- Cleanup wired in `DeleteCell` and `DeleteContainer` so the symlinks under `<RunPath>/s/` don't accumulate as containers come and go (idempotent — missing dirent is fine).
- e2e: `getRandomRunPath` falls back to a short `os.MkdirTemp("/tmp", "ke-")` prefix when `t.TempDir()` would push the *deep* path over `SUN_PATH`. The architectural fix routes attach through the short symlink so this fallback is defense-in-depth: a future regression that re-introduces the deep dial fails loudly here, not in CI.
- Unit tests in `internal/util/fs/metadata_test.go` pin the layout (`<RunPath>/s/<short>`), determinism (sha256-based ID round-trips), distinct-per-container property (incl. the pipe-separator concat-collision pair), and the SUN_PATH budget for a 60-byte RunPath with 64-byte realm/space/stack/cell/container names.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `make test` — full unit suite excluding e2e passes (`pkg/api/...`, `internal/...`, `cmd/...`)
- [x] `pre-commit run --files $(git diff --name-only origin/main..HEAD)` — addlicense, golangci-lint, go-fmt, go-mod-tidy, end-of-file, trailing-whitespace all pass
- [ ] `make e2e TestKuke_AttachDetach_KeepsTaskRunning` (AC #4) — **deferred**: this dev session is itself running inside a kuke-managed container (visible mounts: `/run/kukeon/tty`, `/.kukeon/bin/kuketty`, `/.kukeon/kuketty/metadata.json`). The prior session that attempted to drive e2e from this same environment broke the outer host with connectivity loss and disk IO churn — diagnosis below. Per explicit user direction this session, the e2e + dev-init smoke runs need to happen on a clean host outside the kuketty wrapper. The non-running docker + containerd daemons are NOT the toolchain — both `which docker` and `which containerd` resolve — they are intentionally not being brought up here.
- [ ] `make dev-init` daemon-parity smoke (project CLAUDE.md §Local smoke test) — same defer + reason as `make e2e`. The diff touches `internal/controller/runner/` so the daemon does read this path; the smoke is required by project conventions but cannot safely run from this nested environment.

## Diagnosis of the prior host-break incident (per user request)
The prior dev tick that staged this same diff also attempted the full e2e suite from inside the kuke-managed dev container. Three compounding factors broke the host:

1. **Container-in-container Docker build.** `make test-e2e` first runs `docker build -t kukeon-local:e2e .`, which pulls a full base image and writes a fresh overlay tree to `/var/lib/docker` *inside* the dev container's overlay rootfs. The outer host's overlay-on-overlay shows up as sustained write IO.
2. **Nested containerd with no isolation budget.** The e2e harness brings up a host-side containerd at `/run/containerd/containerd.sock` and stages every cell/container/CNI bridge into it; per-test cleanup runs `t.Cleanup`, but a partial failure (which `TestKuke_AttachDetach_KeepsTaskRunning` did exhibit pre-fix due to this very SUN_PATH bug) leaves CNI bridges, veth pairs, and containerd namespaces dangling. CNI bridge accumulation is what the user observed as "connectivity issues" — each leaked bridge consumes a `/30` and an `iptables` chain in the outer host's view.
3. **No `kuke daemon reset` between attempts.** Re-running the suite without resetting `/opt/kukeon` re-uses any half-staged state from the prior attempt and bind-mounts fresh content over it, producing the high IO observed.

**Mitigation taken this session:** no docker/containerd daemons were brought up. Code review + unit suite + lint were sufficient to validate the fix; e2e is deferred via the `ci-stalled` label below. Future runs from a kuke-wrapped dev environment should either (a) run e2e from outside the wrapper, or (b) gate `make test-e2e` on a `KUKEON_E2E_HOST_OK` env so the wrapped agent fails fast instead of silently churning the outer host. The latter is a candidate `chore:` follow-up worth filing separately if the user agrees.

## Notes on coverage
- AC #1 (path ≤ 107 for any well-formed tuple under a 60-byte RunPath) — `TestContainerSocketSymlinkPath_FitsSUNPath` in `internal/util/fs/metadata_test.go`.
- AC #2 (daemon refuses provisioning with `ErrSocketPathTooLong` when the path would overflow) — `ensureAttachableSocketSymlink` in `internal/controller/runner/attachable.go`; error surfaced via `errdefs.ErrSocketPathTooLong`.
- AC #3 (`getRandomRunPath` produces a SUN_PATH-safe path for the longest test) — `deepSocketPathFits` fallback in `e2e/e2e_test.go`.
- AC #4 (`make e2e TestKuke_AttachDetach_KeepsTaskRunning` passes end-to-end) — deferred per the test plan above; needs verification on a clean host.

Closes #521