### PR TITLE
fix: warn in kuke doctor cgroups on no-swap and no userspace OOM hosts

### DIFF
--- a/cmd/kuke/doctor/cgroups/cgroups.go
+++ b/cmd/kuke/doctor/cgroups/cgroups.go
@@ -218,6 +218,16 @@ func runCheck(stdout, stderr io.Writer, root string, nested, probe, verbose bool
 		return fmt.Errorf("cgroup pre-flight: %w", err)
 	}
 
+	// Host-level probes only fire on the unscoped host-root path —
+	// per-realm/space/stack/cell scopes inspect a sub-tree, not the host
+	// environment, so the host warnings would be misleading there. Deferred
+	// so they reach the operator regardless of which exit branch the
+	// cgroup-check result lands in (silent success, self-heal downgrade,
+	// or fatal failure).
+	if scopeLabel == "" {
+		defer runHostProbes(stderr)
+	}
+
 	if res.OK() {
 		// Silence on success keeps the dev-init.sh tail clean — only
 		// surface details when --verbose-status is set.

--- a/cmd/kuke/doctor/cgroups/cgroups_test.go
+++ b/cmd/kuke/doctor/cgroups/cgroups_test.go
@@ -33,17 +33,24 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
-// TestMain mocks the shared euid lookup to euid=0 for every test in this
-// package. The new fail-fast root gate on --probe would otherwise
+// TestMain mocks the shared euid lookup to euid=0 and neutralizes the
+// host-environment probes (swap + userspace OOM guard) for every test in
+// this package. The fail-fast root gate on --probe would otherwise
 // short-circuit every default-probe and --probe test under non-root CI
 // runners (ubuntu-latest defaults to UID 1001), even though their fake
-// cgroupfs lives under t.TempDir() and never needs real root. Individual
-// cases that exercise the non-root rejection override this with their own
-// SetGeteuidForTesting call.
+// cgroupfs lives under t.TempDir() and never needs real root. The host
+// probes default to no-op returns so existing tests do not depend on the
+// runner's actual /proc/swaps or running-process set; individual probe
+// tests below override these with their own SetHostProbesForTest call.
 func TestMain(m *testing.M) {
-	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	restoreEuid := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	restoreProbes := cgroupscmd.SetHostProbesForTest(
+		func() string { return "" },
+		func() string { return "" },
+	)
 	code := m.Run()
-	restore()
+	restoreProbes()
+	restoreEuid()
 	os.Exit(code)
 }
 

--- a/cmd/kuke/doctor/cgroups/export_test.go
+++ b/cmd/kuke/doctor/cgroups/export_test.go
@@ -36,3 +36,33 @@ func SetSelfHealGateForTest(fn func(string) bool) func() {
 	selfHealGate = fn
 	return func() { selfHealGate = prev }
 }
+
+// SetHostProbesForTest swaps both host probes and returns a restore closure.
+// TestMain calls this to neutralize the production /proc readers so the
+// existing test corpus does not depend on the runner's actual swap or
+// userspace-OOM configuration; individual tests call it again locally to
+// simulate specific bad-config hosts. Either argument may be nil to leave
+// that probe untouched.
+func SetHostProbesForTest(swap, oom func() string) func() {
+	prevSwap, prevOOM := probeSwap, probeUserspaceOOM
+	if swap != nil {
+		probeSwap = swap
+	}
+	if oom != nil {
+		probeUserspaceOOM = oom
+	}
+	return func() {
+		probeSwap = prevSwap
+		probeUserspaceOOM = prevOOM
+	}
+}
+
+// ProbeSwapAtForTest exposes the path-parameterized swap probe so unit
+// tests can exercise its file-parsing branches against a tmpdir-backed
+// fake /proc/swaps.
+func ProbeSwapAtForTest(path string) string { return probeSwapAt(path) }
+
+// ProbeUserspaceOOMAtForTest exposes the path-parameterized OOM-guard
+// probe so unit tests can exercise its /proc-walking logic against a
+// tmpdir-backed fake /proc populated with synthetic <pid>/comm files.
+func ProbeUserspaceOOMAtForTest(procDir string) string { return probeUserspaceOOMAt(procDir) }

--- a/cmd/kuke/doctor/cgroups/host_probes.go
+++ b/cmd/kuke/doctor/cgroups/host_probes.go
@@ -103,6 +103,9 @@ func defaultProbeUserspaceOOM() string {
 // sandboxed environment without /proc silently skips the check rather
 // than emitting a false-positive warning.
 func probeUserspaceOOMAt(procDir string) string {
+	if _, err := os.Stat(procDir); err != nil {
+		return ""
+	}
 	for _, name := range []string{"systemd-oomd", "earlyoom", "oomd"} {
 		if processRunningAt(procDir, name) {
 			return ""

--- a/cmd/kuke/doctor/cgroups/host_probes.go
+++ b/cmd/kuke/doctor/cgroups/host_probes.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroups
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// hostProbe reports a host-environment risk that interacts with cgroup-v2
+// memory accounting: a non-empty return is a high-severity warning the
+// operator should see; an empty return means "this risk does not apply".
+//
+// Probes are advisory — they never change the exit code (per the
+// 2026-05-15 incident author's directive on issue #532: warnings only,
+// never fail). The point is to flag hosts that are one cgroup-unlimited
+// container away from a hard wedge so the operator decides what to do,
+// not to refuse work.
+type hostProbe func() string
+
+// probeSwap is the swap-availability probe runCheck calls on the unscoped
+// host-root path. Indirected via a package var so unit tests can simulate
+// hosts with/without swap without mounting a fake /proc.
+//
+//nolint:gochecknoglobals // test seam for the production swap probe
+var probeSwap hostProbe = defaultProbeSwap
+
+// probeUserspaceOOM is the userspace-OOM-guard probe runCheck calls on the
+// unscoped host-root path. Indirected via a package var so unit tests can
+// simulate matching/non-matching hosts.
+//
+//nolint:gochecknoglobals // test seam for the production OOM-guard probe
+var probeUserspaceOOM hostProbe = defaultProbeUserspaceOOM
+
+// runHostProbes invokes both host probes and writes any non-empty warning
+// lines to w prefixed with "warning:" so operators can scan severity at a
+// glance. Called only from the unscoped host-root path in runCheck —
+// scoped probes (--scope realm|space|stack|cell) inspect a sub-tree, not
+// the host environment, so the host warnings would be misleading there.
+func runHostProbes(w io.Writer) {
+	for _, msg := range []string{probeSwap(), probeUserspaceOOM()} {
+		if msg == "" {
+			continue
+		}
+		fmt.Fprintf(w, "warning: %s\n", msg)
+	}
+}
+
+// defaultProbeSwap reads /proc/swaps and returns a warning when no swap is
+// configured. Wraps probeSwapAt so the on-disk path is overridable in
+// tests via the export_test.go hooks.
+func defaultProbeSwap() string {
+	return probeSwapAt("/proc/swaps")
+}
+
+// probeSwapAt is the path-parameterized core of defaultProbeSwap. /proc/swaps
+// always emits a header line (`Filename Type Size Used Priority`) even when
+// no swap is configured; an empty swap-config has only that header. An
+// unreadable file is treated as "cannot tell" rather than a warning so the
+// probe stays silent on platforms that do not expose /proc/swaps.
+func probeSwapAt(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) <= 1 {
+		return "host has no swap (/proc/swaps shows only the header line); on no-swap, no-userspace-OOM hosts a single cgroup-unlimited container can wedge the kernel before any userspace OOM kills it (see kuke daemon --default-memory-limit-bytes for a daemon-side fallback)"
+	}
+	return ""
+}
+
+// defaultProbeUserspaceOOM reports a warning when no known userspace OOM
+// guard (systemd-oomd, earlyoom, oomd) is running. Wraps
+// probeUserspaceOOMAt so the on-disk /proc directory is overridable in
+// tests via the export_test.go hooks.
+func defaultProbeUserspaceOOM() string {
+	return probeUserspaceOOMAt("/proc")
+}
+
+// probeUserspaceOOMAt is the path-parameterized core of
+// defaultProbeUserspaceOOM. Walks /proc directly instead of shelling out
+// to systemctl/pgrep so the probe stays dependency-free and works on
+// minimal hosts. Returns empty when /proc itself is unreadable so a
+// sandboxed environment without /proc silently skips the check rather
+// than emitting a false-positive warning.
+func probeUserspaceOOMAt(procDir string) string {
+	for _, name := range []string{"systemd-oomd", "earlyoom", "oomd"} {
+		if processRunningAt(procDir, name) {
+			return ""
+		}
+	}
+	return "host has no userspace OOM guard (systemd-oomd / earlyoom / oomd); the in-kernel OOM killer alone may not act before journald, sshd, or other host-critical services degrade on a memory-pressure event"
+}
+
+// processRunningAt reports whether any process under procDir has the given
+// comm. /proc/<pid>/comm is the kernel-truncated 15-char base name, which
+// matches all three guard names above (longest is "systemd-oomd" = 12
+// chars). Returns false on any read error along the way.
+func processRunningAt(procDir, name string) bool {
+	entries, readErr := os.ReadDir(procDir)
+	if readErr != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, atoiErr := strconv.Atoi(e.Name()); atoiErr != nil {
+			continue
+		}
+		comm, commErr := os.ReadFile(filepath.Join(procDir, e.Name(), "comm"))
+		if commErr != nil {
+			continue
+		}
+		if strings.TrimSpace(string(comm)) == name {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/kuke/doctor/cgroups/host_probes_test.go
+++ b/cmd/kuke/doctor/cgroups/host_probes_test.go
@@ -1,0 +1,324 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cgroups_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cgroupscmd "github.com/eminwux/kukeon/cmd/kuke/doctor/cgroups"
+)
+
+// TestCgroupsCmdHostProbeSwapMissingWarns: when /proc/swaps shows no swap,
+// the unscoped pre-flight emits a high-severity warning to stderr but the
+// exit code is unchanged. Pins the "warnings only, never fail" contract
+// the 2026-05-15 incident author asked for in the issue #532 comment.
+func TestCgroupsCmdHostProbeSwapMissingWarns(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	restore := cgroupscmd.SetHostProbesForTest(
+		func() string { return "host has no swap" },
+		func() string { return "" },
+	)
+	defer restore()
+
+	stdout, stderr, err := runCmd(t, "--root", root)
+	if err != nil {
+		t.Fatalf(
+			"Execute() error = %v on healthy cgroups + missing swap (warnings must not fail):\nstdout=%q\nstderr=%q",
+			err,
+			stdout,
+			stderr,
+		)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty (host warnings go to stderr only)", stdout)
+	}
+	if !strings.Contains(stderr, "warning:") {
+		t.Errorf("stderr missing 'warning:' prefix on no-swap host:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "no swap") {
+		t.Errorf("stderr missing swap warning text:\n%s", stderr)
+	}
+}
+
+// TestCgroupsCmdHostProbeOOMMissingWarns: when no userspace OOM guard is
+// running, the unscoped pre-flight emits a high-severity warning to
+// stderr but the exit code is unchanged.
+func TestCgroupsCmdHostProbeOOMMissingWarns(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	restore := cgroupscmd.SetHostProbesForTest(
+		func() string { return "" },
+		func() string { return "host has no userspace OOM guard" },
+	)
+	defer restore()
+
+	_, stderr, err := runCmd(t, "--root", root)
+	if err != nil {
+		t.Fatalf("Execute() error = %v on healthy cgroups + missing OOM guard (warnings must not fail):\nstderr=%q",
+			err, stderr)
+	}
+	if !strings.Contains(stderr, "warning:") {
+		t.Errorf("stderr missing 'warning:' prefix on no-OOM host:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "userspace OOM") {
+		t.Errorf("stderr missing OOM-guard warning text:\n%s", stderr)
+	}
+}
+
+// TestCgroupsCmdHostProbesBothMissingWarnsBoth: when both probes fire,
+// both warning lines appear independently — the doctor surfaces each
+// risk on its own line so the operator sees the full picture rather
+// than a collapsed combined verdict.
+func TestCgroupsCmdHostProbesBothMissingWarnsBoth(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	restore := cgroupscmd.SetHostProbesForTest(
+		func() string { return "host has no swap" },
+		func() string { return "host has no userspace OOM guard" },
+	)
+	defer restore()
+
+	_, stderr, err := runCmd(t, "--root", root)
+	if err != nil {
+		t.Fatalf("Execute() error = %v with both host warnings (warnings must never fail):\nstderr=%q",
+			err, stderr)
+	}
+	if got := strings.Count(stderr, "warning:"); got != 2 {
+		t.Errorf("expected 2 'warning:' lines, got %d:\n%s", got, stderr)
+	}
+	for _, want := range []string{"no swap", "userspace OOM"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestCgroupsCmdHostProbesAllGreen: when both host probes return empty
+// (swap present + OOM guard active), the unscoped pre-flight stays
+// silent on stderr — preserves the dev-init.sh tail-clean rule the
+// project CLAUDE.md regression guard depends on.
+func TestCgroupsCmdHostProbesAllGreen(t *testing.T) {
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	// TestMain already neutralizes the probes to "", but pin it again
+	// locally so this test reads as self-contained.
+	restore := cgroupscmd.SetHostProbesForTest(
+		func() string { return "" },
+		func() string { return "" },
+	)
+	defer restore()
+
+	stdout, stderr, err := runCmd(t, "--root", root)
+	if err != nil {
+		t.Fatalf("Execute() error = %v on all-green host:\nstdout=%q\nstderr=%q",
+			err, stdout, stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want empty on healthy host", stdout)
+	}
+	if strings.Contains(stderr, "warning:") {
+		t.Errorf("stderr contains warning on all-green host (host probes leaked):\n%s", stderr)
+	}
+}
+
+// TestCgroupsCmdHostProbesScopedSkipped: the host probes never run on the
+// --scope realm|space|stack|cell paths because the host environment does
+// not depend on which sub-tree the operator is inspecting. Pins this
+// scoping so a future change can't accidentally start emitting host
+// warnings for every scoped invocation.
+func TestCgroupsCmdHostProbesScopedSkipped(t *testing.T) {
+	root := t.TempDir()
+	writeFakeCgroupAt(t, root,
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	realmCg := "/kukeon/default"
+	writeFakeCgroupAt(t, filepath.Join(root, realmCg),
+		"cpuset cpu io memory hugetlb pids rdma misc",
+		"cpu memory io pids",
+	)
+	// Both probes WOULD warn loudly if invoked — the test asserts they
+	// are NOT invoked on the scoped path.
+	restore := cgroupscmd.SetHostProbesForTest(
+		func() string { return "host has no swap" },
+		func() string { return "host has no userspace OOM guard" },
+	)
+	defer restore()
+
+	client := &fakeScopedClient{realmExists: true, realmCgroupPath: realmCg}
+
+	_, stderr, err := runCmdWithClient(t, client,
+		"--scope", "realm", "default", "--root", root,
+	)
+	if err != nil {
+		t.Fatalf("scope=realm Execute() error = %v on healthy scoped path:\nstderr=%q",
+			err, stderr)
+	}
+	if strings.Contains(stderr, "warning:") {
+		t.Errorf("scoped pre-flight emitted host warning (probes must only fire on the unscoped host-root path):\n%s",
+			stderr)
+	}
+}
+
+// TestCgroupsCmdHostProbesFireOnFailure: when the cgroup pre-flight
+// itself fails AND the host probes warn, the operator must see both —
+// the host warnings are advisory and orthogonal to the cgroup-controller
+// failure. Pins the defer-runHostProbes contract so a future refactor
+// can't quietly drop warnings on the failing branch.
+func TestCgroupsCmdHostProbesFireOnFailure(t *testing.T) {
+	// Missing memory + io from subtree_control → cgroup pre-flight fails.
+	root := writeFakeCgroup(t,
+		"cpuset cpu io memory pids",
+		"cpu pids",
+	)
+	restore := cgroupscmd.SetHostProbesForTest(
+		func() string { return "host has no swap" },
+		func() string { return "host has no userspace OOM guard" },
+	)
+	defer restore()
+
+	_, stderr, err := runCmd(t, "--root", root, "--no-probe")
+	if err == nil {
+		t.Fatal("Execute() error = nil with missing memory + io, want cgroup pre-flight failure")
+	}
+	if !strings.Contains(stderr, "warning:") {
+		t.Errorf("stderr missing host warnings on the failing cgroup branch:\n%s", stderr)
+	}
+	// Cgroup-failure remediation must still appear — host warnings are
+	// additive, not a replacement for the cgroup-controller diagnosis.
+	for _, want := range []string{"memory", "io", "cgroup.subtree_control"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing cgroup-remediation token %q on failing branch:\n%s", want, stderr)
+		}
+	}
+}
+
+// TestProbeSwapAt covers the file-parsing branches of the swap probe
+// directly against synthetic /proc/swaps files in t.TempDir(): unreadable
+// (silent), header-only (warns), and header + entry (silent).
+func TestProbeSwapAt(t *testing.T) {
+	tmp := t.TempDir()
+
+	missing := filepath.Join(tmp, "absent")
+	if got := cgroupscmd.ProbeSwapAtForTest(missing); got != "" {
+		t.Errorf("missing /proc/swaps: got %q, want empty (silent fallback)", got)
+	}
+
+	headerOnly := filepath.Join(tmp, "header-only")
+	if err := os.WriteFile(headerOnly, []byte("Filename                                Type            Size            Used            Priority\n"), 0o644); err != nil {
+		t.Fatalf("write header-only: %v", err)
+	}
+	if got := cgroupscmd.ProbeSwapAtForTest(headerOnly); !strings.Contains(got, "no swap") {
+		t.Errorf("header-only /proc/swaps: got %q, want a 'no swap' warning", got)
+	}
+
+	withEntry := filepath.Join(tmp, "with-entry")
+	body := "Filename                                Type            Size            Used            Priority\n" +
+		"/dev/zram0                              partition       2097148         0               100\n"
+	if err := os.WriteFile(withEntry, []byte(body), 0o644); err != nil {
+		t.Fatalf("write with-entry: %v", err)
+	}
+	if got := cgroupscmd.ProbeSwapAtForTest(withEntry); got != "" {
+		t.Errorf("/proc/swaps with one entry: got %q, want empty (swap present)", got)
+	}
+}
+
+// TestProbeUserspaceOOMAt covers the /proc-walking branches of the OOM
+// probe directly against a synthetic /proc tree in t.TempDir(): empty
+// (warns), with one of the recognized comms (silent), and with an
+// unrecognized comm (warns). Each <pid>/comm carries the kernel's
+// trailing newline so the test reflects the real /proc shape.
+func TestProbeUserspaceOOMAt(t *testing.T) {
+	cases := []struct {
+		name     string
+		setup    func(procDir string)
+		wantWarn bool
+	}{
+		{
+			name:     "empty proc",
+			setup:    func(string) {},
+			wantWarn: true,
+		},
+		{
+			name: "systemd-oomd present",
+			setup: func(procDir string) {
+				writeFakeProcessAt(t, procDir, "42", "systemd-oomd")
+			},
+			wantWarn: false,
+		},
+		{
+			name: "earlyoom present",
+			setup: func(procDir string) {
+				writeFakeProcessAt(t, procDir, "100", "earlyoom")
+			},
+			wantWarn: false,
+		},
+		{
+			name: "oomd present",
+			setup: func(procDir string) {
+				writeFakeProcessAt(t, procDir, "200", "oomd")
+			},
+			wantWarn: false,
+		},
+		{
+			name: "unrelated process only",
+			setup: func(procDir string) {
+				writeFakeProcessAt(t, procDir, "1", "init")
+			},
+			wantWarn: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			procDir := t.TempDir()
+			tc.setup(procDir)
+			got := cgroupscmd.ProbeUserspaceOOMAtForTest(procDir)
+			if tc.wantWarn && got == "" {
+				t.Errorf("expected warning, got empty")
+			}
+			if !tc.wantWarn && got != "" {
+				t.Errorf("expected no warning, got %q", got)
+			}
+		})
+	}
+}
+
+// writeFakeProcessAt materializes <procDir>/<pid>/comm with the given
+// command name plus the trailing newline the kernel always writes, so
+// processRunningAt's TrimSpace logic reflects the real /proc shape.
+func writeFakeProcessAt(t *testing.T, procDir, pid, comm string) {
+	t.Helper()
+	dir := filepath.Join(procDir, pid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "comm"), []byte(comm+"\n"), 0o644); err != nil {
+		t.Fatalf("write comm for pid %s: %v", pid, err)
+	}
+}

--- a/cmd/kuke/doctor/cgroups/host_probes_test.go
+++ b/cmd/kuke/doctor/cgroups/host_probes_test.go
@@ -266,6 +266,15 @@ func TestProbeUserspaceOOMAt(t *testing.T) {
 			wantWarn: true,
 		},
 		{
+			name: "missing procDir",
+			setup: func(procDir string) {
+				if err := os.RemoveAll(procDir); err != nil {
+					t.Fatalf("remove procDir: %v", err)
+				}
+			},
+			wantWarn: false,
+		},
+		{
 			name: "systemd-oomd present",
 			setup: func(procDir string) {
 				writeFakeProcessAt(t, procDir, "42", "systemd-oomd")


### PR DESCRIPTION
## Summary
- Extends `kuke doctor cgroups` with two new host-environment probes that flag the configuration the 2026-05-15 kukeon-dev incident named: hosts with no swap, and hosts with no userspace OOM guard (`systemd-oomd` / `earlyoom` / `oomd`). On either gap the unscoped pre-flight prints a `warning: …` line to stderr explaining the risk and pointing the operator at the daemon-side fallback (`kuke daemon --default-memory-limit-bytes`, the companion fix in #533).
- Both probes are advisory: they never change the exit code, per the issue #532 author's directive *"DO NOT make the process fail, only high severity warnings"*. The probes are scoped to the unscoped host-root path only — `--scope realm|space|stack|cell` skips them because the host environment does not depend on which sub-tree the operator is inspecting.
- New file `cmd/kuke/doctor/cgroups/host_probes.go` with two package-level probe vars (`probeSwap`, `probeUserspaceOOM`) and path-parameterized cores (`probeSwapAt`, `probeUserspaceOOMAt`) so unit tests can exercise the file-parsing and `/proc`-walking branches without touching real system state. The OOM-guard probe walks `/proc` directly instead of shelling out to `systemctl` / `pgrep` so the doctor stays dependency-free on minimal hosts.
- `runCheck` defers `runHostProbes(stderr)` once on the unscoped path — guarantees the warnings reach the operator regardless of which exit branch fires (silent success, self-heal downgrade, or fatal failure). On all-green hosts the probes return empty strings, preserving the dev-init.sh tail-clean rule the project CLAUDE.md regression guard depends on.

## Behavior preserved
- Exit codes are unchanged on every existing branch — warnings are additive output, never a failure escalation. The "silent on success" contract for the dev-init.sh tail still holds when both probes return empty.
- The `--scope` paths are untouched: scoped pre-flights inspect a sub-tree, not the host environment, so they continue to emit only their cgroup-status output.

## Implementation calls worth flagging
- The original AC point 3 ("If both checks fail AND the daemon-default memory cap is not set on `kukeond`, the doctor should fail-not-warn") is dropped: the issue's sole comment from the author overrides it with *"DO NOT make the process fail, only high severity warnings"*. The two probes therefore emit independent warning lines instead of a combined fail-or-warn verdict, and the doctor never reads kukeond config — which also keeps this PR independent of the open #533 daemon-default-memory-cap landing.
- Both probes default to silent on read errors (unreadable `/proc/swaps`, missing `/proc`) rather than emitting false-positive warnings on platforms that don't expose those interfaces — same conservative posture the existing self-heal gate uses.
- Tests use the same `Set…ForTest` package-var-swap pattern as the existing `SetActiveProberForTest` / `SetSelfHealGateForTest` hooks, plus two `*AtForTest` direct-call exposures so the file-parsing and `/proc`-walking branches can be unit-tested against `t.TempDir()`-backed synthetic fixtures.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test \$(go list ./... | grep -v /e2e) -count=1 -timeout 600s` — full unit suite passes; the new tests in `cmd/kuke/doctor/cgroups/host_probes_test.go` (probe combinations, scoped-path skip, fire-on-failure, direct probe-function unit coverage) all pass alongside the existing cgroups corpus
- [x] `pre-commit run --files \$(git diff --name-only origin/main..HEAD)` — addlicense, golangci-lint (govet shadow check among others), go-fmt, go-mod-tidy, end-of-file, trailing-whitespace all pass
- [ ] `make e2e` — **deferred** to the reviewer's environment: this dev session runs inside a kuke-managed container (`/run/kukeon/tty`, `/.kukeon/bin/kuketty`, `/.kukeon/kuketty/metadata.json` are visible mounts) and a prior session that drove `make e2e` from inside this same wrapper broke the outer host with overlay-on-overlay IO and leaked CNI bridges. Per the role playbook's "verification step can't safely run on the current host" section, the e2e check needs a clean host. The change is to a doctor pre-flight (advisory output only, no exit-code change), so the existing e2e suite should be unaffected.
- [ ] `make dev-init` daemon-parity smoke (project CLAUDE.md §Local smoke test) — same defer + same reason. The diff does not touch the daemon path or anything under `/opt/kukeon`, so the parity check should be unaffected, but reviewer should run it on a clean host before merge to confirm.

## New tests
- `cmd/kuke/doctor/cgroups/host_probes_test.go` — six end-to-end command tests + two direct probe-function tests:
  - `TestCgroupsCmdHostProbeSwapMissingWarns` / `TestCgroupsCmdHostProbeOOMMissingWarns` — each probe in isolation emits a `warning:` line on stderr without changing exit code.
  - `TestCgroupsCmdHostProbesBothMissingWarnsBoth` — both probes fire produce two independent warning lines (no collapsed verdict).
  - `TestCgroupsCmdHostProbesAllGreen` — both probes empty → silent on stderr (preserves dev-init.sh tail-clean rule).
  - `TestCgroupsCmdHostProbesScopedSkipped` — `--scope realm` never triggers the host probes even when both would warn loudly.
  - `TestCgroupsCmdHostProbesFireOnFailure` — host warnings still emit when the cgroup pre-flight itself fails (the defer-runHostProbes contract).
  - `TestProbeSwapAt` — direct unit coverage of the `/proc/swaps` parser: missing file (silent), header-only (warns), header + entry (silent).
  - `TestProbeUserspaceOOMAt` — direct unit coverage of the `/proc`-walker against a synthetic process tree: empty `/proc` (warns), each of `systemd-oomd` / `earlyoom` / `oomd` present (silent), unrelated process only (warns).
- `TestMain` in the existing `cgroups_test.go` neutralizes the production probes to no-op returns so the existing test corpus does not depend on the runner's actual `/proc/swaps` or running-process set; new probe tests opt back in locally.

Closes #532