### PR TITLE
ci(installer): add explicit permissions: contents: read

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -1,5 +1,8 @@
 name: Installer
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Summary
- Closes CodeQL's `actions/missing-workflow-permissions` alerts on `.github/workflows/installer.yaml`'s four jobs in one place. The workflow only checks out the repo and runs scripts, so the minimal least-privilege block is `contents: read`.
- Convention precedent: `mkdocs.yaml` already declares its `permissions:` block at the top level (between `name:` and `on:`), so this matches it stylistically. `release.yaml`'s per-job permissions stay untouched (it needs `packages: write`, `attestations: write`, `id-token: write` only for the release job).

## Test plan
- [x] `pre-commit run --files .github/workflows/installer.yaml` — trim-trailing-whitespace, end-of-file-fixer, check-yaml, prettier all pass
- [x] `make test` — full unit suite passes (no Go code touched, but ran per role playbook)
- [ ] The `Installer` workflow itself — runs in CI on this PR (paths-filter matches `.github/workflows/installer.yaml`), so all four jobs (`sync`, `prereq-missing`, `prereq-pass`, `install-skip-init`) will execute with the new `contents: read` token and confirm the permission is sufficient.

Closes #452