### PR TITLE
fix: extend RequireRoot gate to kuke daemon start/stop/kill/restart/logs

### DIFF
--- a/cmd/kuke/daemon/kill/kill.go
+++ b/cmd/kuke/daemon/kill/kill.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -62,6 +63,10 @@ func runKill(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
 		return errdefs.ErrLoggerNotFound
+	}
+
+	if err := kukshared.RequireRoot("kuke daemon kill"); err != nil {
+		return err
 	}
 
 	client := resolveClient(cmd, logger)

--- a/cmd/kuke/daemon/kill/kill_test.go
+++ b/cmd/kuke/daemon/kill/kill_test.go
@@ -22,15 +22,30 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
 	kill "github.com/eminwux/kukeon/cmd/kuke/daemon/kill"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// TestMain mocks the shared euid lookup to euid=0 for every test in this
+// package so the fail-fast root gate in runKill does not short-circuit the
+// existing fakes-driven coverage when CI runs as a non-root user
+// (ubuntu-latest defaults to UID 1001). The dedicated non-root case overrides
+// this with its own SetGeteuidForTesting call.
+func TestMain(m *testing.M) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 func TestDaemonKill(t *testing.T) {
 	tests := []struct {
@@ -170,6 +185,37 @@ func TestDaemonKill(t *testing.T) {
 				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
 			}
 		})
+	}
+}
+
+// TestDaemonKill_NonRootIsRejected confirms the fail-fast UID gate rejects
+// non-root invocations before any side effect (cell lookup, in-process
+// controller construction). Symmetric with the same guard on `kuke daemon
+// reset` and the rest of the daemon-lifecycle verbs (#463).
+func TestDaemonKill_NonRootIsRejected(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+
+	cmd := kill.NewKillCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, logger))
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("kuke daemon kill returned nil under euid=1000, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("kuke daemon kill error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke daemon kill") {
+		t.Errorf("error does not name the subcommand: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sudo") {
+		t.Errorf("error does not suggest sudo: %v", err)
 	}
 }
 

--- a/cmd/kuke/daemon/logs/logs.go
+++ b/cmd/kuke/daemon/logs/logs.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/eminwux/kukeon/cmd/config"
 	logcmd "github.com/eminwux/kukeon/cmd/kuke/log"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -81,6 +82,10 @@ func runLogs(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
 		return errdefs.ErrLoggerNotFound
+	}
+
+	if err := kukshared.RequireRoot("kuke daemon logs"); err != nil {
+		return err
 	}
 
 	follow := viper.GetBool(config.KUKE_DAEMON_LOGS_FOLLOW.ViperKey)

--- a/cmd/kuke/daemon/logs/logs_test.go
+++ b/cmd/kuke/daemon/logs/logs_test.go
@@ -30,6 +30,7 @@ import (
 
 	logscmd "github.com/eminwux/kukeon/cmd/kuke/daemon/logs"
 	logcmd "github.com/eminwux/kukeon/cmd/kuke/log"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -38,6 +39,18 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+// TestMain mocks the shared euid lookup to euid=0 for every test in this
+// package so the fail-fast root gate in runLogs does not short-circuit the
+// existing fakes-driven coverage when CI runs as a non-root user
+// (ubuntu-latest defaults to UID 1001). The dedicated non-root case overrides
+// this with its own SetGeteuidForTesting call.
+func TestMain(m *testing.M) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 const kukeondHostLogPath = "/opt/kukeon/kuke-system/kukeon/kukeon/kukeond/kukeond/log"
 
@@ -394,6 +407,38 @@ func TestDaemonLogs_CapturePathFallback(t *testing.T) {
 	}
 	if got := out.String(); got != "from-capture" {
 		t.Errorf("stdout = %q, want %q", got, "from-capture")
+	}
+}
+
+// TestDaemonLogs_NonRootIsRejected confirms the fail-fast UID gate rejects
+// non-root invocations before any side effect (cell lookup, in-process
+// controller construction). Symmetric with the same guard on `kuke daemon
+// reset` and the rest of the daemon-lifecycle verbs (#463).
+func TestDaemonLogs_NonRootIsRejected(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+	viper.Reset()
+
+	cmd := logscmd.NewLogsCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, logger))
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("kuke daemon logs returned nil under euid=1000, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("kuke daemon logs error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke daemon logs") {
+		t.Errorf("error does not name the subcommand: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sudo") {
+		t.Errorf("error does not suggest sudo: %v", err)
 	}
 }
 

--- a/cmd/kuke/daemon/restart/restart.go
+++ b/cmd/kuke/daemon/restart/restart.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -76,6 +77,10 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
 		return errdefs.ErrLoggerNotFound
+	}
+
+	if err := kukshared.RequireRoot("kuke daemon restart"); err != nil {
+		return err
 	}
 
 	timeout := viper.GetDuration(config.KUKE_DAEMON_RESTART_TIMEOUT.ViperKey)

--- a/cmd/kuke/daemon/restart/restart_test.go
+++ b/cmd/kuke/daemon/restart/restart_test.go
@@ -22,18 +22,33 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	restart "github.com/eminwux/kukeon/cmd/kuke/daemon/restart"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/viper"
 )
+
+// TestMain mocks the shared euid lookup to euid=0 for every test in this
+// package so the fail-fast root gate in runRestart does not short-circuit the
+// existing fakes-driven coverage when CI runs as a non-root user
+// (ubuntu-latest defaults to UID 1001). The dedicated non-root case overrides
+// this with its own SetGeteuidForTesting call.
+func TestMain(m *testing.M) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 func TestDaemonRestart(t *testing.T) {
 	tests := []struct {
@@ -458,6 +473,38 @@ func TestDaemonRestart_KillCellErrorIsWrapped(t *testing.T) {
 	}
 	if startCalled.Load() {
 		t.Fatal("StartCell must not run when the stop-phase escalation fails")
+	}
+}
+
+// TestDaemonRestart_NonRootIsRejected confirms the fail-fast UID gate rejects
+// non-root invocations before any side effect (cell lookup, in-process
+// controller construction). Symmetric with the same guard on `kuke daemon
+// reset` and the rest of the daemon-lifecycle verbs (#463).
+func TestDaemonRestart_NonRootIsRejected(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+	viper.Reset()
+
+	cmd := restart.NewRestartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, logger))
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("kuke daemon restart returned nil under euid=1000, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("kuke daemon restart error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke daemon restart") {
+		t.Errorf("error does not name the subcommand: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sudo") {
+		t.Errorf("error does not suggest sudo: %v", err)
 	}
 }
 

--- a/cmd/kuke/daemon/start/start.go
+++ b/cmd/kuke/daemon/start/start.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -62,6 +63,10 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
 		return errdefs.ErrLoggerNotFound
+	}
+
+	if err := kukshared.RequireRoot("kuke daemon start"); err != nil {
+		return err
 	}
 
 	client := resolveClient(cmd, logger)

--- a/cmd/kuke/daemon/start/start_test.go
+++ b/cmd/kuke/daemon/start/start_test.go
@@ -22,15 +22,30 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
 	start "github.com/eminwux/kukeon/cmd/kuke/daemon/start"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// TestMain mocks the shared euid lookup to euid=0 for every test in this
+// package so the fail-fast root gate in runStart does not short-circuit the
+// existing fakes-driven coverage when CI runs as a non-root user
+// (ubuntu-latest defaults to UID 1001). The dedicated non-root case overrides
+// this with its own SetGeteuidForTesting call.
+func TestMain(m *testing.M) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 func TestDaemonStart(t *testing.T) {
 	tests := []struct {
@@ -166,6 +181,37 @@ func TestDaemonStart(t *testing.T) {
 				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
 			}
 		})
+	}
+}
+
+// TestDaemonStart_NonRootIsRejected confirms the fail-fast UID gate rejects
+// non-root invocations before any side effect (cell lookup, in-process
+// controller construction). Symmetric with the same guard on `kuke daemon
+// reset` and the rest of the daemon-lifecycle verbs (#463).
+func TestDaemonStart_NonRootIsRejected(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+
+	cmd := start.NewStartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, logger))
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("kuke daemon start returned nil under euid=1000, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("kuke daemon start error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke daemon start") {
+		t.Errorf("error does not name the subcommand: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sudo") {
+		t.Errorf("error does not suggest sudo: %v", err)
 	}
 }
 

--- a/cmd/kuke/daemon/stop/stop.go
+++ b/cmd/kuke/daemon/stop/stop.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -74,6 +75,10 @@ func runStop(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
 		return errdefs.ErrLoggerNotFound
+	}
+
+	if err := kukshared.RequireRoot("kuke daemon stop"); err != nil {
+		return err
 	}
 
 	timeout := viper.GetDuration(config.KUKE_DAEMON_STOP_TIMEOUT.ViperKey)

--- a/cmd/kuke/daemon/stop/stop_test.go
+++ b/cmd/kuke/daemon/stop/stop_test.go
@@ -22,18 +22,33 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	stop "github.com/eminwux/kukeon/cmd/kuke/daemon/stop"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/viper"
 )
+
+// TestMain mocks the shared euid lookup to euid=0 for every test in this
+// package so the fail-fast root gate in runStop does not short-circuit the
+// existing fakes-driven coverage when CI runs as a non-root user
+// (ubuntu-latest defaults to UID 1001). The dedicated non-root case overrides
+// this with its own SetGeteuidForTesting call.
+func TestMain(m *testing.M) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
 
 func TestDaemonStop(t *testing.T) {
 	tests := []struct {
@@ -302,6 +317,38 @@ func TestDaemonStop_KillCellErrorIsWrapped(t *testing.T) {
 		!strings.Contains(err.Error(), "kill kukeond cell after") ||
 		!strings.Contains(err.Error(), "20ms grace period expired") {
 		t.Fatalf("expected wrapped kill error mentioning grace period, got %v", err)
+	}
+}
+
+// TestDaemonStop_NonRootIsRejected confirms the fail-fast UID gate rejects
+// non-root invocations before any side effect (cell lookup, in-process
+// controller construction). Symmetric with the same guard on `kuke daemon
+// reset` and the rest of the daemon-lifecycle verbs (#463).
+func TestDaemonStop_NonRootIsRejected(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+	viper.Reset()
+
+	cmd := stop.NewStopCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, logger))
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("kuke daemon stop returned nil under euid=1000, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("kuke daemon stop error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke daemon stop") {
+		t.Errorf("error does not name the subcommand: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sudo") {
+		t.Errorf("error does not suggest sudo: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extends the fail-fast UID gate `kukshared.RequireRoot(subcommand)` (introduced in #461) from `kuke daemon reset` to the remaining `kuke daemon` lifecycle verbs: `start`, `stop`, `kill`, `restart`, `logs`. All five use the same in-process direct-containerd path (`local.New()`) as `daemon reset`, so a non-root invocation otherwise surfaces as a confusing containerd EACCES several phases in — exactly the UX problem #461 was written to eliminate.
- Placement mirrors `cmd/kuke/daemon/reset/reset.go:108-111`: after the logger context check, before any viper reads or controller construction. The gate runs in `runX` (not `resolveClient`) so the test-injected `MockClientKey` path continues to bypass the in-process controller for fakes-driven coverage.
- Sibling unit-test cases follow the `reset_test.go` convention: a package-level `TestMain` that swaps `kukshared.SetGeteuidForTesting` to euid=0 so the existing fakes-driven corpus keeps running on non-root CI runners, plus a dedicated `Test…_NonRootIsRejected` that re-installs euid=1000, asserts `errors.Is(err, errdefs.ErrMustRunAsRoot)`, and verifies the error names the subcommand and suggests `sudo`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/kuke/daemon/... -count=1` — all five daemon-verb packages plus reset pass with the new gate and tests.
- [x] `make test` — full unit suite passes (`go test \$(go list ./... | grep -v /e2e)`).
- [x] `pre-commit run --files \$(git diff --name-only HEAD~..HEAD)` — trim-trailing-whitespace, end-of-file-fixer, go-fmt, go-mod-tidy, golangci-lint, addlicense all pass.
- [ ] `make e2e` — deferred to the reviewer's environment: this dev host is a kuke-managed container; a prior session that drove `make e2e` from inside this same wrapper broke the outer host with overlay-on-overlay IO and leaked CNI bridges. The change is to a CLI fail-fast gate (no controller/runtime behavior touched), so the existing e2e suite should be unaffected.
- [ ] `make dev-init` daemon-parity smoke (project CLAUDE.md §Local smoke test) — same defer + same reason. The diff does not touch the daemon path or anything under `/opt/kukeon`, so the parity check should be unaffected, but reviewer should run it on a clean host before merge to confirm.

Closes #463