### PR TITLE
refactor: consolidate inline cellEtcFilePaths+stamp triples onto stampContainerRecreateRuntimeFields

### DIFF
--- a/internal/controller/runner/cell_etc_files.go
+++ b/internal/controller/runner/cell_etc_files.go
@@ -143,14 +143,15 @@ func stampEtcFilePathsOnContainerSpec(spec *intmodel.ContainerSpec, hostnamePath
 }
 
 // stampContainerRecreateRuntimeFields applies the runtime-only field stamps
-// that the single-container StartContainer recreate path needs before
-// invoking BuildContainerSpec via CreateContainerFromSpec. Mirrors the
-// cell-wide stampCellEtcFilePathsOnContainers + stampCellProfileNameOnContainers
-// pair the StartCell / ensureCellContainers paths run, but per-spec since
-// the recreate path holds a local container-spec pointer. Without this,
-// `kuke start container` drops the recreated container's /etc/hosts +
-// /etc/hostname bind-mounts and KUKEON_CELL_PROFILE_NAME env entry. Issue
-// #354.
+// that single-container and root-container build paths need before invoking
+// BuildContainerSpec / BuildRootContainerSpec on a local container-spec
+// pointer. Mirrors the cell-wide stampCellEtcFilePathsOnContainers +
+// stampCellProfileNameOnContainers pair the cell-wide paths run, but
+// per-spec for call sites that hold a local container-spec value (the
+// StartContainer recreate path of issue #354, the StartCell root-recreate
+// path, and the ensureCellContainers root-creation path). Without this,
+// the recreated/created container drops its /etc/hosts + /etc/hostname
+// bind-mounts and KUKEON_CELL_PROFILE_NAME env entry.
 func (r *Exec) stampContainerRecreateRuntimeFields(spec *intmodel.ContainerSpec, cell *intmodel.Cell) {
 	hostnamePath, hostsPath, suppressHosts := r.cellEtcFilePaths(cell)
 	stampEtcFilePathsOnContainerSpec(spec, hostnamePath, hostsPath, suppressHosts)

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1783,9 +1783,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		if etcErr := r.renderCellEtcFilesPreCNI(cell); etcErr != nil {
 			return nil, fmt.Errorf("render cell etc files: %w", etcErr)
 		}
-		hnPath, hPath, suppress := r.cellEtcFilePaths(cell)
-		stampEtcFilePathsOnContainerSpec(&rootContainerSpec, hnPath, hPath, suppress)
-		stampCellProfileNameOnContainerSpec(&rootContainerSpec, cell)
+		r.stampContainerRecreateRuntimeFields(&rootContainerSpec, cell)
 
 		rootLabels := buildRootContainerLabels(*cell)
 		containerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels, r.daemonDefaultBuildOpts()...)

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -472,9 +472,7 @@ func (r *Exec) StartCell(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
 	if etcErr := r.renderCellEtcFilesPreCNI(&internalCell); etcErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("render cell etc files: %w", etcErr)
 	}
-	hnPath, hPath, suppressHosts := r.cellEtcFilePaths(&internalCell)
-	stampEtcFilePathsOnContainerSpec(&rootContainerSpec, hnPath, hPath, suppressHosts)
-	stampCellProfileNameOnContainerSpec(&rootContainerSpec, &internalCell)
+	r.stampContainerRecreateRuntimeFields(&rootContainerSpec, &internalCell)
 
 	rootLabels := buildRootContainerLabels(internalCell)
 	ctrContainerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels, r.daemonDefaultBuildOpts()...)


### PR DESCRIPTION
## Summary
- Fold the inline `cellEtcFilePaths` + `stampEtcFilePathsOnContainerSpec` + `stampCellProfileNameOnContainerSpec` triple at `start.go` (StartCell root-recreate) and `provision.go` (ensureCellContainers root-creation) onto the existing `stampContainerRecreateRuntimeFields` helper, so a future fourth runtime stamp or a change in stamp ordering lands in one place instead of three.
- Helper renamed mentally only — kept the existing `stampContainerRecreateRuntimeFields` name per the issue's explicit consolidation target. Updated the godoc to reflect the broader applicability (single-container recreate + root-recreate + root-creation paths) since the strict "recreate" framing no longer fits the provision call site.

## Test plan
- [x] `make test` — full unit suite green.
- [x] `go vet ./...` — clean.
- [x] `make dev-init` — daemon parity check shows the expected two-realm output; `kuke attach` smoke exited cleanly. The helper's runtime stamps still reach the root container on the fresh-init path.

Closes #488