### PR TITLE
docs: fix misleading KUKEON_GET_OUTPUT reference in ParseOutputFormat docstring

### DIFF
--- a/cmd/kuke/get/shared/shared.go
+++ b/cmd/kuke/get/shared/shared.go
@@ -51,7 +51,7 @@ const (
 )
 
 // ParseOutputFormat resolves the output format using kuke's standard
-// precedence: explicit `--output`/`-o` flag > KUKEON_GET_OUTPUT env (and
+// precedence: explicit `--output`/`-o` flag > KUKE_GET_OUTPUT env (and
 // any other source viper has bound to `kuke/get/output`) > table default.
 // Each `kuke get <kind>` subcommand binds its own `--output` flag to the
 // shared viper key at construction time, but viper only retains the last


### PR DESCRIPTION
## Summary
- The `ParseOutputFormat` docstring at `cmd/kuke/get/shared/shared.go:54` referenced `KUKEON_GET_OUTPUT`, but the env var bound by `config.KUKE_GET_OUTPUT.BindEnv()` (see `cmd/config/env.go:283`) is actually `KUKE_GET_OUTPUT`. Anyone reading the precedence rule to understand the public contract would look for an env that doesn't exist.
- One-line docstring edit; no behavior change.

## Test plan
- [x] `make test` — full suite green.
- [x] `pre-commit run --files cmd/kuke/get/shared/shared.go` — all hooks pass (go fmt, golangci-lint, addlicense, etc.).
- [x] `grep -rn KUKEON_GET_OUTPUT` — zero remaining references in the tree after this edit.

Closes #510