### PR TITLE
test: cover ensureAttachableSocketSymlink ErrSocketPathTooLong fail-fast

### DIFF
--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -22,15 +22,20 @@ package runner
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
 	sbshapi "github.com/eminwux/sbsh/pkg/api"
 )
 
@@ -702,6 +707,68 @@ func TestStageKukettyBinary_ReusesExisting(t *testing.T) {
 	}
 	if string(data) != "\x7fELF stub" {
 		t.Fatalf("dst contents = %q, want stub (helper re-copied)", data)
+	}
+}
+
+// TestEnsureAttachableSocketSymlink_RefusesOverflow locks the provision-
+// time fail-fast added in #521 AC #2: when the resolved symlink path would
+// exceed consts.KukeonMaxSocketPath bytes, ensureAttachableSocketSymlink
+// must return errdefs.ErrSocketPathTooLong and stage no on-disk state.
+// Without this guard, a future refactor that drops or inverts the length
+// check would silently defer the failure to first `kuke attach`, where it
+// surfaces as an opaque connect(2) ENAMETOOLONG instead of a provision-
+// time error. The existing TestContainerSocketSymlinkPath_FitsSUNPath in
+// internal/util/fs only verifies that normal-shaped inputs stay under the
+// limit — it does not assert that the runner *refuses to provision* when
+// they do not.
+func TestEnsureAttachableSocketSymlink_RefusesOverflow(t *testing.T) {
+	// Pad a real tmp dir so len(runPath)+len("/s/")+16hex exceeds the
+	// budget by one byte. Using a real (existing) base path matters: the
+	// "no on-disk state" assertion below is only meaningful when the
+	// function *could* have created the symlink dir had the fail-fast
+	// regressed.
+	base := t.TempDir()
+	const sep = "/s/"
+	const shortIDLen = 16 // sha256[:8] hex == 16 chars (see containerSocketShortID)
+	padBytes := consts.KukeonMaxSocketPath + 1 - len(base) - len(sep) - shortIDLen
+	if padBytes < 1 {
+		padBytes = 1
+	}
+	runPath := filepath.Join(base, strings.Repeat("a", padBytes))
+	spec := intmodel.ContainerSpec{
+		ID:        "c1",
+		RealmName: "rA",
+		SpaceName: "sB",
+		StackName: "kC",
+		CellName:  "lD",
+	}
+
+	symlinkPath := fs.ContainerSocketSymlinkPath(
+		runPath, spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if len(symlinkPath) <= consts.KukeonMaxSocketPath {
+		t.Fatalf("test setup wrong: symlinkPath len=%d <= limit=%d (path=%q)",
+			len(symlinkPath), consts.KukeonMaxSocketPath, symlinkPath)
+	}
+
+	err := ensureAttachableSocketSymlink(runPath, spec)
+	if !errors.Is(err, errdefs.ErrSocketPathTooLong) {
+		t.Fatalf("err = %v, want errors.Is(_, errdefs.ErrSocketPathTooLong)", err)
+	}
+
+	// On the fail-fast path, no on-disk state should land — neither the
+	// shallow <runPath>/s symlink directory nor the per-container symlink
+	// inode. If a future refactor reorders MkdirAll above the length check
+	// the dir assertion catches it; the symlink-inode assertion guards
+	// against a regression that fires the length check but still proceeds
+	// to os.Symlink after.
+	symlinkDir := fs.ContainerSocketSymlinkDir(runPath)
+	if _, statErr := os.Stat(symlinkDir); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("symlink dir %q exists (stat err = %v), want ErrNotExist — fail-fast must not stage on-disk state",
+			symlinkDir, statErr)
+	}
+	if _, statErr := os.Lstat(symlinkPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("symlink %q exists (lstat err = %v), want ErrNotExist", symlinkPath, statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Issue #534: the provision-time fail-fast added in #521 AC #2 at `internal/controller/runner/attachable.go:596-599` was only asserted by inspection. A future refactor that dropped or inverted the length guard would silently regress the AC and defer the failure to first `kuke attach` (opaque `connect(2)` `ENAMETOOLONG`).
- New unit test `TestEnsureAttachableSocketSymlink_RefusesOverflow` in `internal/controller/runner/attachable_test.go` constructs a contrived `RunPath` (real tmp dir padded so `<runPath>/s/<16hex>` exceeds `consts.KukeonMaxSocketPath` by one byte), calls `ensureAttachableSocketSymlink`, and asserts `errors.Is(err, errdefs.ErrSocketPathTooLong)` plus that no on-disk state was staged (`<runPath>/s` dir absent, symlink inode absent).
- The two on-disk assertions are split so a regression that reorders `MkdirAll` above the length check (dir assertion catches) is distinct from one that fires the length check but still proceeds to `os.Symlink` (symlink assertion catches).

## Test plan
- [x] `go test ./internal/controller/runner/ -run TestEnsureAttachableSocketSymlink_RefusesOverflow -v` → PASS
- [x] `go test ./internal/controller/runner/...` → PASS
- [x] `go vet ./internal/controller/runner/...` → clean
- [x] `make test` (project CI target, full unit-test sweep) → all ok, no FAIL
- [x] `pre-commit run --files internal/controller/runner/attachable_test.go` → all hooks pass (go fmt, go-mod-tidy, golangci-lint, addlicense)
- [ ] `make dev-init` smoke → not required per `CLAUDE.md`: this change touches a single `_test.go` file in one package, not the build path, the daemon, or anything under `/opt/kukeon`.

Closes #534