### PR TITLE
feat: install kukeond systemd unit so the daemon survives reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Get kukeon running on a single Linux host in minutes.
 curl -fsSL https://kukeon.io/install.sh | bash
 ```
 
-The installer detects your platform, verifies the prerequisites above (and prints a distro-aware hint on any miss), downloads the latest release, verifies its `sha256` checksum, installs `kuke` + `kukeond` to `/usr/local/bin`, and runs `sudo kuke init` to bring the daemon up. Pass `--check` to run the prereq checks only without touching the system:
+The installer detects your platform, verifies the prerequisites above (and prints a distro-aware hint on any miss), downloads the latest release, verifies its `sha256` checksum, installs `kuke` + `kukeond` to `/usr/local/bin`, runs `sudo kuke init` to bring the daemon up, and (on systemd hosts) installs `/etc/systemd/system/kukeond.service` so kukeond comes back automatically after a host or containerd restart. On systemd-less hosts the unit step is skipped with a notice — bring kukeond up manually after each reboot with `sudo kuke daemon start`. Pass `--check` to run the prereq checks only without touching the system:
 
 ```bash
 curl -fsSL https://kukeon.io/install.sh | bash -s -- --check

--- a/cmd/kuke/uninstall/systemd.go
+++ b/cmd/kuke/uninstall/systemd.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package uninstall
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// SystemdUnitPath is the absolute path of the kukeond systemd unit
+// scripts/install.sh writes. Exported so the test package can match against
+// it without re-spelling the literal.
+const SystemdUnitPath = "/etc/systemd/system/kukeond.service"
+
+// SystemdUnitName is the canonical short name the systemctl verbs accept.
+const SystemdUnitName = "kukeond.service"
+
+// SystemdRemovalReport summarizes what removeKukeondSystemdUnit did. Every
+// field is independently surfaced in the CLI report so the operator can tell
+// which sub-step ran on a partially-supervised host (e.g., systemctl present
+// but the unit was hand-deleted before re-running uninstall).
+type SystemdRemovalReport struct {
+	// Skipped is true when the helper short-circuited without touching the
+	// host (no systemctl in PATH, or no unit file). SkipReason names the
+	// branch so the printed report is self-explanatory.
+	Skipped    bool
+	SkipReason string
+	// UnitPath is the absolute unit file path the helper attempted to
+	// disable; carried in the report so a future change to SystemdUnitPath
+	// does not require chasing the renderer to update its hard-coded text.
+	UnitPath string
+	// Stopped/Disabled/FileRemoved/DaemonReloaded each flip true on success
+	// of the corresponding sub-step. Stop / disable / daemon-reload are
+	// best-effort — the binding step is FileRemoved. The fields are
+	// independent so the renderer can show (e.g.) "stop+disable failed
+	// (no systemd PID 1) but file removed" on partial paths.
+	Stopped        bool
+	Disabled       bool
+	FileRemoved    bool
+	DaemonReloaded bool
+	// Err carries the first non-nil binding-step error so runUninstall can
+	// propagate a non-zero exit. Best-effort sub-steps (stop / disable /
+	// daemon-reload) do not populate Err — their outcomes are visible via
+	// their bool fields. The report is still returned in full on error so
+	// the operator sees what did succeed before the failure.
+	Err error
+}
+
+// SystemdRemover is the contract removeKukeondSystemdUnit and any test
+// substitute satisfy. Injected via MockSystemdRemoverKey so tests need not
+// touch the host's systemctl or /etc/systemd/system.
+type SystemdRemover func(ctx context.Context) SystemdRemovalReport
+
+// MockSystemdRemoverKey injects a SystemdRemover via cmd.Context() for tests
+// in the same package layout as MockControllerKey.
+type MockSystemdRemoverKey struct{}
+
+// removeKukeondSystemdUnit stops, disables, and removes the kukeond systemd
+// unit installed by scripts/install.sh, then runs `systemctl daemon-reload`
+// so subsequent systemctl calls see the absent unit. Idempotent: a host
+// without systemctl in PATH, or one where the unit file is already gone,
+// short-circuits with Skipped=true so `kuke uninstall` is safe to run on
+// dev hosts that bootstrapped via `make dev-init` (issue #541 AC #4).
+//
+// The stop+disable pair runs before realm purge / filesystem teardown
+// because a still-enabled Restart=on-failure unit would race the
+// controller's PID-file-based daemon stop and respawn kukeond mid-uninstall.
+func removeKukeondSystemdUnit(ctx context.Context) SystemdRemovalReport {
+	report := SystemdRemovalReport{UnitPath: SystemdUnitPath}
+
+	if _, err := exec.LookPath("systemctl"); err != nil {
+		report.Skipped = true
+		report.SkipReason = "systemctl not found in PATH"
+		return report
+	}
+	if _, statErr := os.Stat(SystemdUnitPath); statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) {
+			report.Skipped = true
+			report.SkipReason = "unit file absent"
+			return report
+		}
+		report.Err = fmt.Errorf("stat unit %q: %w", SystemdUnitPath, statErr)
+		return report
+	}
+
+	// stop, disable, and daemon-reload are best-effort: their non-zero
+	// exits do not block the uninstall. The binding step is the file
+	// remove — once the unit file is gone, no future `systemctl` call will
+	// find kukeond.service regardless of the prior stop / disable / reload
+	// outcomes. Non-zero exits here are expected on three benign paths:
+	//   1. The unit is already stopped / already disabled (idempotent re-run).
+	//   2. systemctl is present but PID 1 is not systemd (some minimal
+	//      container images ship systemctl as a no-op binary).
+	//   3. The unit was hand-edited / corrupted and systemd refuses to act
+	//      on it; the operator wants the file gone anyway.
+	// Surfacing these as uninstall failures would break the
+	// "uninstall still works on hosts where the unit was never installed"
+	// AC for any of those partial-state paths.
+	if err := exec.CommandContext(ctx, "systemctl", "stop", SystemdUnitName).Run(); err == nil {
+		report.Stopped = true
+	}
+	if err := exec.CommandContext(ctx, "systemctl", "disable", SystemdUnitName).Run(); err == nil {
+		report.Disabled = true
+	}
+
+	if rmErr := os.Remove(SystemdUnitPath); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+		report.Err = fmt.Errorf("remove unit %q: %w", SystemdUnitPath, rmErr)
+		return report
+	}
+	report.FileRemoved = true
+
+	if err := exec.CommandContext(ctx, "systemctl", "daemon-reload").Run(); err == nil {
+		report.DaemonReloaded = true
+	}
+	return report
+}

--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -64,12 +64,15 @@ func NewUninstallCmd() *cobra.Command {
 const uninstallLongDesc = `Remove all kukeon runtime state from this host.
 
 This is the global counterpart to "kuke purge" (which is per-resource). It:
-  1. Purges every realm with --cascade (drains spaces, stacks, cells,
+  1. Stops, disables, and removes the kukeond systemd unit (no-op on hosts
+     without systemd, or where the unit was never installed). Done first so
+     a Restart=on-failure unit cannot respawn kukeond mid-uninstall.
+  2. Purges every realm with --cascade (drains spaces, stacks, cells,
      containers and their containerd tasks/containers, and deletes the
      containerd namespaces created by kukeon).
-  2. Removes /run/kukeon/ recursively.
-  3. Removes the configured run path (default /opt/kukeon) recursively.
-  4. Removes the kukeon system user and group (no-op if absent).
+  3. Removes /run/kukeon/ recursively.
+  4. Removes the configured run path (default /opt/kukeon) recursively.
+  5. Removes the kukeon system user and group (no-op if absent).
 
 If any realm fails to drop its containerd namespace, steps 2-4 are skipped:
 tearing out /opt/kukeon while a residual namespace is still pinning overlay
@@ -120,6 +123,19 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// systemd unit teardown runs before realm/filesystem teardown per
+	// issue #541 AC #4: leaving Restart=on-failure on the unit while the
+	// controller's PID-file-based daemon-stop step fires would let systemd
+	// respawn kukeond mid-uninstall. Idempotent on hosts where the unit
+	// was never installed (dev hosts via `make dev-init`, systemd-less
+	// distros).
+	systemdRemover := resolveSystemdRemover(cmd)
+	systemdReport := systemdRemover(cmd.Context())
+	printSystemdRemoval(cmd, systemdReport)
+	if systemdReport.Err != nil {
+		return systemdReport.Err
+	}
+
 	ctrl := resolveController(cmd, logger, runPath)
 	defer func() { _ = ctrl.Close() }()
 
@@ -128,6 +144,43 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 	})
 	printReport(cmd, report)
 	return err
+}
+
+// resolveSystemdRemover returns the SystemdRemover used by runUninstall.
+// Tests inject a stub via MockSystemdRemoverKey; production always runs the
+// real systemctl-driven implementation.
+func resolveSystemdRemover(cmd *cobra.Command) SystemdRemover {
+	if mock, ok := cmd.Context().Value(MockSystemdRemoverKey{}).(SystemdRemover); ok {
+		return mock
+	}
+	return removeKukeondSystemdUnit
+}
+
+// printSystemdRemoval renders the SystemdRemovalReport as the first line of
+// the uninstall output so the operator sees the unit-teardown outcome
+// before the realm/filesystem rows. Quiet on the skip path: a host that
+// never had the unit installed (e.g. `make dev-init`) should not emit a
+// systemd row at all, matching the existing report's terse style on the
+// no-daemon path.
+func printSystemdRemoval(cmd *cobra.Command, r SystemdRemovalReport) {
+	out := cmd.OutOrStdout()
+	if r.Skipped {
+		// Quiet skip — no systemd row at all.
+		return
+	}
+	switch {
+	case r.Err != nil:
+		fmt.Fprintf(out, "  - systemd unit %s: failed: %v\n", r.UnitPath, r.Err)
+	case r.Stopped && r.Disabled && r.FileRemoved && r.DaemonReloaded:
+		fmt.Fprintf(out, "  - systemd unit %s: stopped, disabled, removed\n", r.UnitPath)
+	default:
+		// Partial: at least one best-effort sub-step did not succeed. Show
+		// each independently so the operator can tell which (e.g. stop
+		// failed because there's no systemd PID 1 vs. file remove
+		// succeeded — the binding step did its job).
+		fmt.Fprintf(out, "  - systemd unit %s: partial (stop=%t disable=%t remove=%t reload=%t)\n",
+			r.UnitPath, r.Stopped, r.Disabled, r.FileRemoved, r.DaemonReloaded)
+	}
 }
 
 func resolveController(cmd *cobra.Command, logger *slog.Logger, runPath string) controller.Controller {
@@ -144,6 +197,7 @@ func resolveController(cmd *cobra.Command, logger *slog.Logger, runPath string) 
 func confirm(cmd *cobra.Command, runPath, socketDir string) (bool, error) {
 	out := cmd.OutOrStdout()
 	fmt.Fprintln(out, "kuke uninstall will remove ALL kukeon runtime state on this host:")
+	fmt.Fprintln(out, "  - the kukeond systemd unit (stop + disable + remove, if installed)")
 	fmt.Fprintln(out, "  - every realm (cascade), including the kuke-system realm and the kukeond cell")
 	fmt.Fprintln(out, "  - the kukeon containerd namespaces")
 	fmt.Fprintf(out, "  - %s/ (kukeond socket dir)\n", socketDir)

--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -74,7 +74,7 @@ This is the global counterpart to "kuke purge" (which is per-resource). It:
   4. Removes the configured run path (default /opt/kukeon) recursively.
   5. Removes the kukeon system user and group (no-op if absent).
 
-If any realm fails to drop its containerd namespace, steps 2-4 are skipped:
+If any realm fails to drop its containerd namespace, steps 3-5 are skipped:
 tearing out /opt/kukeon while a residual namespace is still pinning overlay
 mounts on disk would strand the next "kuke init" with stale containerd state.
 The report flags every dir/account row as "skipped (realm purge failed)" so

--- a/cmd/kuke/uninstall/uninstall_test.go
+++ b/cmd/kuke/uninstall/uninstall_test.go
@@ -171,10 +171,35 @@ func (s *stubController) ReconcileCells() (controller.ReconcileResult, error) {
 
 // runCmd builds the cobra command, plugs in a stub controller and a logger,
 // and feeds the supplied stdin payload. Returns the captured stdout/stderr
-// buffer so tests can assert on output.
+// buffer so tests can assert on output. A no-op systemd remover is injected
+// by default so tests stay hermetic on hosts that happen to have systemctl
+// and a stale unit file present; tests that need to exercise the systemd
+// teardown rendering call runCmdWithSystemd instead.
 func runCmd(
 	t *testing.T,
 	stub *stubController,
+	stdin string,
+	args ...string,
+) (string, error) {
+	t.Helper()
+	return runCmdWithSystemd(t, stub, skippedSystemdRemover, stdin, args...)
+}
+
+// skippedSystemdRemover stands in for the real removeKukeondSystemdUnit on
+// tests that do not care about the systemd path. Returns Skipped=true so the
+// renderer prints no systemd row, matching the dev-host code path.
+func skippedSystemdRemover(_ context.Context) uninstall.SystemdRemovalReport {
+	return uninstall.SystemdRemovalReport{
+		Skipped:    true,
+		SkipReason: "test stub",
+		UnitPath:   uninstall.SystemdUnitPath,
+	}
+}
+
+func runCmdWithSystemd(
+	t *testing.T,
+	stub *stubController,
+	systemd uninstall.SystemdRemover,
 	stdin string,
 	args ...string,
 ) (string, error) {
@@ -183,6 +208,7 @@ func runCmd(
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 	ctx = context.WithValue(ctx, uninstall.MockControllerKey{}, controller.Controller(stub))
+	ctx = context.WithValue(ctx, uninstall.MockSystemdRemoverKey{}, systemd)
 	cmd.SetContext(ctx)
 
 	out := &bytes.Buffer{}
@@ -424,6 +450,147 @@ func TestUninstall_RendersReleasedAndResidualMountRows(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected output to contain %q; got:\n%s", want, out)
 		}
+	}
+}
+
+// TestUninstall_SystemdUnitRemovedRendersRow pins the issue #541 AC #4
+// rendering: when the systemd remover reports a successful stop+disable+
+// remove, the CLI must emit a unit row above the realm/filesystem rows so
+// the operator sees the host-supervisor teardown happened.
+func TestUninstall_SystemdUnitRemovedRendersRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	ctrlCalled := false
+	stub := &stubController{
+		uninstallFn: func(controller.UninstallOptions) (controller.UninstallReport, error) {
+			ctrlCalled = true
+			return controller.UninstallReport{
+				SocketDir: "/run/kukeon",
+				RunPath:   "/opt/kukeon",
+				UserName:  "kukeon",
+				GroupName: "kukeon",
+			}, nil
+		},
+	}
+	systemd := func(_ context.Context) uninstall.SystemdRemovalReport {
+		return uninstall.SystemdRemovalReport{
+			UnitPath:       uninstall.SystemdUnitPath,
+			Stopped:        true,
+			Disabled:       true,
+			FileRemoved:    true,
+			DaemonReloaded: true,
+		}
+	}
+	out, err := runCmdWithSystemd(t, stub, systemd, "", "--yes")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	if !ctrlCalled {
+		t.Errorf("controller.Uninstall did not fire after successful systemd teardown; output:\n%s", out)
+	}
+	wantRow := "systemd unit " + uninstall.SystemdUnitPath + ": stopped, disabled, removed"
+	if !strings.Contains(out, wantRow) {
+		t.Errorf("expected systemd row %q; got:\n%s", wantRow, out)
+	}
+}
+
+// TestUninstall_SystemdPartialPath pins the renderer's honesty on the
+// "file removed but best-effort sub-steps non-zero" path — e.g., a host
+// where systemctl is present but PID 1 is not systemd. The CLI must show
+// which sub-steps actually succeeded so the operator can verify the unit
+// file is gone without being misled by a "stopped, disabled, removed"
+// claim that did not match reality.
+func TestUninstall_SystemdPartialPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stub := &stubController{
+		uninstallFn: func(controller.UninstallOptions) (controller.UninstallReport, error) {
+			return controller.UninstallReport{
+				SocketDir: "/run/kukeon",
+				RunPath:   "/opt/kukeon",
+				UserName:  "kukeon",
+				GroupName: "kukeon",
+			}, nil
+		},
+	}
+	systemd := func(_ context.Context) uninstall.SystemdRemovalReport {
+		// stop/disable/daemon-reload all failed (no systemd PID 1); file
+		// removed succeeded — the binding step.
+		return uninstall.SystemdRemovalReport{
+			UnitPath:    uninstall.SystemdUnitPath,
+			FileRemoved: true,
+		}
+	}
+	out, err := runCmdWithSystemd(t, stub, systemd, "", "--yes")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	wantSubstr := "partial (stop=false disable=false remove=true reload=false)"
+	if !strings.Contains(out, wantSubstr) {
+		t.Errorf("expected partial row %q; got:\n%s", wantSubstr, out)
+	}
+}
+
+// TestUninstall_SystemdSkippedEmitsNoRow guards the dev-host AC: a host
+// where the unit was never installed (e.g. bootstrapped via `make
+// dev-init`) must produce no systemd row at all so the report stays terse.
+// The controller's realm/filesystem teardown still runs to completion.
+func TestUninstall_SystemdSkippedEmitsNoRow(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stub := &stubController{
+		uninstallFn: func(controller.UninstallOptions) (controller.UninstallReport, error) {
+			return controller.UninstallReport{
+				SocketDir: "/run/kukeon",
+				RunPath:   "/opt/kukeon",
+				UserName:  "kukeon",
+				GroupName: "kukeon",
+			}, nil
+		},
+	}
+	out, err := runCmd(t, stub, "", "--yes")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	if strings.Contains(out, "systemd unit") {
+		t.Errorf("Skipped systemd report unexpectedly rendered a row:\n%s", out)
+	}
+}
+
+// TestUninstall_SystemdFailureShortCircuits pins the ordering invariant:
+// if the systemd remover errors (e.g. daemon-reload fails on a broken PID
+// 1), realm purge / filesystem teardown must not run. Allowing the
+// controller to proceed while the unit is still respawn-eligible would
+// race the daemon-stop step and is the regression #541 AC #4 prevents.
+func TestUninstall_SystemdFailureShortCircuits(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	ctrlCalled := false
+	stub := &stubController{
+		uninstallFn: func(controller.UninstallOptions) (controller.UninstallReport, error) {
+			ctrlCalled = true
+			return controller.UninstallReport{}, nil
+		},
+	}
+	sentinel := errors.New("synthetic daemon-reload failure")
+	systemd := func(_ context.Context) uninstall.SystemdRemovalReport {
+		return uninstall.SystemdRemovalReport{
+			UnitPath:    uninstall.SystemdUnitPath,
+			Stopped:     true,
+			Disabled:    true,
+			FileRemoved: true,
+			Err:         sentinel,
+		}
+	}
+	out, err := runCmdWithSystemd(t, stub, systemd, "", "--yes")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error to propagate; got %v\noutput:\n%s", err, out)
+	}
+	if ctrlCalled {
+		t.Errorf("controller.Uninstall must not fire when systemd teardown failed; output:\n%s", out)
+	}
+	if !strings.Contains(out, "failed:") || !strings.Contains(out, "synthetic daemon-reload failure") {
+		t.Errorf("expected failure row to surface sentinel; got:\n%s", out)
 	}
 }
 

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -67,13 +67,14 @@ sudo kuke uninstall -y       # non-interactive (scripts)
 **Invariants.**
 
 - Without `-y`, the command prints a destructive-action prompt naming every artifact it will remove and waits on stdin. EOF or a non-`yes` answer aborts with non-zero exit and no destructive side effect.
-- With `-y`, exit code 0 on success. Side effect: every realm purged with `--cascade`; `/run/kukeon` and the configured run path (default `/opt/kukeon`) removed; the `kukeon` system user/group removed if present.
+- With `-y`, exit code 0 on success. Side effect: the `kukeond` systemd unit (if installed) is stopped, disabled, and removed; every realm purged with `--cascade`; `/run/kukeon` and the configured run path (default `/opt/kukeon`) removed; the `kukeon` system user/group removed if present.
 - The binary at `/usr/local/bin/kuke` and the `kukeond` symlink are **never** removed — uninstalling runtime state is not the same as uninstalling the binary.
+- The systemd-unit teardown is a no-op (silent, no row in the report) on hosts where `systemctl` is absent or `/etc/systemd/system/kukeond.service` was never installed (e.g. `make dev-init` hosts).
 - If any realm fails to drop its containerd namespace, the subsequent dir/account removal is **skipped** (not silently best-effort) and the report flags each skipped row. Exit code is non-zero so automation can branch on it.
 
 **Recovering from a failed `kuke uninstall`.**
 
-`kuke uninstall` tears down kukeon runtime state in this order: (0) stop the kukeond daemon, (1) purge every realm, (2) remove `/run/kukeon`, (3) remove the configured run path (default `/opt/kukeon`), (4) remove the kukeon system user and group.
+`kuke uninstall` tears down kukeon runtime state in this order: (-1) stop+disable+remove the `kukeond` systemd unit (so a `Restart=on-failure` unit cannot respawn the daemon mid-uninstall), (0) stop the kukeond daemon, (1) purge every realm, (2) remove `/run/kukeon`, (3) remove the configured run path (default `/opt/kukeon`), (4) remove the kukeon system user and group.
 
 Steps 2–4 are gated on every realm reporting `NamespaceRemoved=true`. If any realm fails to drop its containerd namespace, the report renders each filesystem/account row as `skipped (realm purge failed)` and prints
 

--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -334,6 +334,74 @@ do_install() {
     else
         $SUDO kuke init
     fi
+
+    install_systemd_unit
+}
+
+# --- systemd unit ------------------------------------------------------------
+# Drops /etc/systemd/system/kukeond.service so the daemon survives host and
+# containerd restarts (issue #541). Without it, nothing brings kukeond back
+# after a reboot — containerd does not restart tasks across its own restart
+# and there is no host-level supervisor on the kuke side. The unit invokes
+# `kuke daemon start` (the in-process verb, idempotent against an already-
+# running daemon) ordered after containerd.service so the daemon's
+# containerd client always has a socket to talk to.
+#
+# Skipped on systemd-less hosts (dev containers, minimal images) with a
+# visible notice — the operator falls back to running `sudo kuke daemon start`
+# manually after each reboot. Re-running install.sh on a host that already
+# has the unit installed overwrites it and runs daemon-reload, so a version
+# bump that changes the unit contents picks up cleanly.
+SYSTEMD_UNIT_PATH="/etc/systemd/system/kukeond.service"
+
+install_systemd_unit() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        step "Configuring host supervisor"
+        warn "systemd not detected — skipping kukeond.service unit install."
+        printf '    On systemd-less hosts, bring kukeond up after each reboot with:\n' >&2
+        printf '      sudo kuke daemon start\n' >&2
+        return 0
+    fi
+    step "Installing kukeond.service systemd unit"
+    # Write through a tmpfile + atomic install so a concurrent systemd read of
+    # /etc/systemd/system never sees a half-written unit. `install -m 0644`
+    # mirrors the perms systemd-supplied units ship with.
+    local unit_tmp
+    unit_tmp="$(mktemp -t kukeond.service.XXXXXX)"
+    cat >"$unit_tmp" <<EOF
+[Unit]
+Description=kukeon daemon (kukeond)
+Documentation=https://kukeon.io
+After=containerd.service
+Requires=containerd.service
+
+[Service]
+# Type=oneshot + RemainAfterExit=yes: \`kuke daemon start\` is an in-process
+# verb that brings the kukeond cell up via containerd and then exits;
+# containerd supervises the kukeond container once it is running. The unit
+# stays "active" so \`systemctl status kukeond\` reports the bootstrap as
+# the supervised state, and Restart=on-failure retries the bootstrap if it
+# loses a race with containerd.service coming up.
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=${KUKE_INSTALL_PREFIX}/kuke daemon start
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    $SUDO install -m 0644 "$unit_tmp" "$SYSTEMD_UNIT_PATH"
+    rm -f "$unit_tmp"
+    $SUDO systemctl daemon-reload
+    # `enable --now` is idempotent when the daemon is already running (the
+    # oneshot ExecStart calls `kuke daemon start`, which itself returns
+    # success when the kukeond cell is up). On a fresh host where `kuke
+    # init` just ran, the daemon is already live and this call is a no-op
+    # start + a real enable; on a re-run after `systemctl disable`, this is
+    # the path that re-enables the unit.
+    $SUDO systemctl enable --now kukeond.service
+    ok "installed and enabled ${SYSTEMD_UNIT_PATH}"
 }
 
 # --- Next steps --------------------------------------------------------------

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -16,6 +16,7 @@ The installer:
 2. Verifies cgroups v2 is mounted and `/run/containerd/containerd.sock` is responsive. On any miss it prints a distro-aware hint and exits non-zero without touching the system.
 3. Downloads the latest release binary from GitHub, verifies its `.sha256` checksum, installs it to `/usr/local/bin/kuke`, and hard-links `kukeond` next to it.
 4. Runs `sudo kuke init` to bring up the daemon. Skipped on a host that already has a healthy `kukeond` listening on `/run/kukeon/kukeond.sock`.
+5. Installs `/etc/systemd/system/kukeond.service` and runs `systemctl enable --now kukeond.service` so the daemon comes back automatically after a host or containerd restart. Skipped with a notice on systemd-less hosts — bring kukeond up manually with `sudo kuke daemon start` after each reboot in that case.
 
 Pass `--check` to run the prereq checks only without touching the system:
 
@@ -89,9 +90,19 @@ kuke get realms
 
 Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`, and any command run with the `--no-daemon` flag.
 
+## Host supervisor
+
+On systemd hosts the installer drops `/etc/systemd/system/kukeond.service`, ordered `After=containerd.service` / `Requires=containerd.service`. The unit's `ExecStart` is `kuke daemon start`, which is idempotent against an already-running daemon, and `Restart=on-failure` retries the bring-up if the daemon's cell cannot reach a starting containerd on first try. After a `systemctl reboot` the unit re-bootstraps the daemon without operator intervention.
+
+If your host has no systemd (some minimal container images, dev sandboxes), the installer prints a notice and skips the unit. Bring kukeond up manually after each reboot:
+
+```bash
+sudo kuke daemon start
+```
+
 ## Uninstall
 
-`kuke uninstall` removes all kukeon runtime state from the host — stops and deletes the `kukeond` cell, clears `/run/kukeon`, and wipes `/opt/kukeon` and the kukeon-generated CNI conflists. It prompts for interactive confirmation by default; pass `-y` to skip the prompt in scripts:
+`kuke uninstall` removes all kukeon runtime state from the host — stops, disables, and removes the `kukeond` systemd unit (if installed), then stops and deletes the `kukeond` cell, clears `/run/kukeon`, and wipes `/opt/kukeon` and the kukeon-generated CNI conflists. It prompts for interactive confirmation by default; pass `-y` to skip the prompt in scripts:
 
 ```bash
 sudo kuke uninstall -y

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -334,6 +334,74 @@ do_install() {
     else
         $SUDO kuke init
     fi
+
+    install_systemd_unit
+}
+
+# --- systemd unit ------------------------------------------------------------
+# Drops /etc/systemd/system/kukeond.service so the daemon survives host and
+# containerd restarts (issue #541). Without it, nothing brings kukeond back
+# after a reboot — containerd does not restart tasks across its own restart
+# and there is no host-level supervisor on the kuke side. The unit invokes
+# `kuke daemon start` (the in-process verb, idempotent against an already-
+# running daemon) ordered after containerd.service so the daemon's
+# containerd client always has a socket to talk to.
+#
+# Skipped on systemd-less hosts (dev containers, minimal images) with a
+# visible notice — the operator falls back to running `sudo kuke daemon start`
+# manually after each reboot. Re-running install.sh on a host that already
+# has the unit installed overwrites it and runs daemon-reload, so a version
+# bump that changes the unit contents picks up cleanly.
+SYSTEMD_UNIT_PATH="/etc/systemd/system/kukeond.service"
+
+install_systemd_unit() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        step "Configuring host supervisor"
+        warn "systemd not detected — skipping kukeond.service unit install."
+        printf '    On systemd-less hosts, bring kukeond up after each reboot with:\n' >&2
+        printf '      sudo kuke daemon start\n' >&2
+        return 0
+    fi
+    step "Installing kukeond.service systemd unit"
+    # Write through a tmpfile + atomic install so a concurrent systemd read of
+    # /etc/systemd/system never sees a half-written unit. `install -m 0644`
+    # mirrors the perms systemd-supplied units ship with.
+    local unit_tmp
+    unit_tmp="$(mktemp -t kukeond.service.XXXXXX)"
+    cat >"$unit_tmp" <<EOF
+[Unit]
+Description=kukeon daemon (kukeond)
+Documentation=https://kukeon.io
+After=containerd.service
+Requires=containerd.service
+
+[Service]
+# Type=oneshot + RemainAfterExit=yes: \`kuke daemon start\` is an in-process
+# verb that brings the kukeond cell up via containerd and then exits;
+# containerd supervises the kukeond container once it is running. The unit
+# stays "active" so \`systemctl status kukeond\` reports the bootstrap as
+# the supervised state, and Restart=on-failure retries the bootstrap if it
+# loses a race with containerd.service coming up.
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=${KUKE_INSTALL_PREFIX}/kuke daemon start
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    $SUDO install -m 0644 "$unit_tmp" "$SYSTEMD_UNIT_PATH"
+    rm -f "$unit_tmp"
+    $SUDO systemctl daemon-reload
+    # `enable --now` is idempotent when the daemon is already running (the
+    # oneshot ExecStart calls `kuke daemon start`, which itself returns
+    # success when the kukeond cell is up). On a fresh host where `kuke
+    # init` just ran, the daemon is already live and this call is a no-op
+    # start + a real enable; on a re-run after `systemctl disable`, this is
+    # the path that re-enables the unit.
+    $SUDO systemctl enable --now kukeond.service
+    ok "installed and enabled ${SYSTEMD_UNIT_PATH}"
 }
 
 # --- Next steps --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Issue #541: nothing brought kukeond back after a host or containerd restart. containerd does not restart tasks across its own restart, and the kuke side had no host-level supervisor — operators had to run `kuke daemon start` after every reboot.
- `scripts/install.sh` (and the synced `docs/site/install.sh`) now drops `/etc/systemd/system/kukeond.service` ordered `After=containerd.service` / `Requires=containerd.service`, then `systemctl daemon-reload` + `systemctl enable --now kukeond.service`. The unit's `ExecStart` is `${KUKE_INSTALL_PREFIX}/kuke daemon start` (the in-process verb at `cmd/kuke/daemon/start/start.go`, idempotent against an already-running daemon, no `--no-daemon`). On systemd-less hosts the installer prints a notice and skips — operators fall back to manual `sudo kuke daemon start` per reboot.
- Unit shape: `Type=oneshot` + `RemainAfterExit=yes` to make the AC-required `Restart=on-failure` (with `RestartSec=5s`) meaningful around an in-process verb that exits after bringing the kukeond cell up — containerd supervises the kukeond container thereafter.
- `kuke uninstall` (new `cmd/kuke/uninstall/systemd.go`, wired into `runUninstall` before `ctrl.Uninstall`) stops, disables, and removes the unit, then `systemctl daemon-reload`, ahead of realm / filesystem teardown so a `Restart=on-failure` unit cannot respawn kukeond mid-uninstall. Stop / disable / daemon-reload are best-effort (no-op on hosts where systemctl is missing or PID 1 is not systemd); the file remove is the binding step. Idempotent: silent skip when no systemctl in PATH or no unit file (covers `make dev-init` hosts and partial-state re-runs).
- Tests injected via a new `MockSystemdRemoverKey` context key in the same pattern as `MockControllerKey`. Existing tests inject a no-op stub by default so they stay hermetic on hosts that happen to have systemctl present.
- Docs: README + `docs/site/install/install-linux.md` describe the host-supervisor model and the systemd-less manual fallback; `docs/cli-use-cases.md`'s "Full per-host teardown" section restates the uninstall ordering with the new step.

## Test plan
- [x] `go build ./...` → clean
- [x] `go vet ./...` → clean
- [x] `go test ./cmd/kuke/uninstall/... -v` → 13 pass including new `TestUninstall_SystemdUnitRemovedRendersRow`, `TestUninstall_SystemdSkippedEmitsNoRow`, `TestUninstall_SystemdPartialPath`, `TestUninstall_SystemdFailureShortCircuits`
- [x] `make test` (project CI target, full unit-test sweep) → all ok, no FAIL
- [x] `make dev-init` (project smoke) → daemon-parity tail produces the canonical two-realm output; AC #5 ("dev-init continues to pass end-to-end") verified
- [x] Manual `sudo ./kuke uninstall -y` on the dev host with **no** systemd unit installed → systemd row absent; rest of the teardown unchanged (verifies the AC #4 "uninstall still works on hosts where the unit was never installed" path)
- [x] Manual `sudo ./kuke uninstall -y` on the dev host with a stub unit file present → file removed; partial-line rendered because PID 1 is not systemd here (verifies the best-effort stop/disable/daemon-reload behavior)
- [x] `pre-commit run --files <changed>` → go fmt, go-mod-tidy, golangci-lint, prettier, addlicense all green
- [ ] AC #6 (`systemctl reboot` → `kuke get realms` shows both realms Ready without operator intervention) — this dev host has no systemd PID 1, so a reboot smoke cannot run locally; the unit's `Type=oneshot` + `Restart=on-failure` + `kuke daemon start` (which is idempotent and errors only when the host has not been `kuke init`-ed) is the design-time argument that it will. Reviewer to verify on a systemd-bootstrapped host.

Closes #541