### PR TITLE
fix: keep reconciler progressing past Unknown after host reboot

### DIFF
--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -174,6 +174,24 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 		return state, nil
 	}
 
+	// TaskStatus failed against an existing container: the container record
+	// survived but its task is gone. The headline case is a host reboot
+	// (cgroups + tasks wiped, container records survive in containerd's
+	// boltdb): without this branch the cell-level derivation can never see
+	// past Unknown and the reconciler leaves every previously-Ready cell
+	// stuck (#543). A wrapped ErrTaskNotFound is the "no task" signal
+	// loadTask emits via container.Task() — anything else is treated as a
+	// transient containerd RPC blip and stays Unknown to avoid reaping a
+	// cell on a misread.
+	if errors.Is(taskStatusErr, errdefs.ErrTaskNotFound) {
+		r.logger.InfoContext(r.ctx, "container exists but task is gone; reporting Stopped",
+			"container", containerID,
+			"containerdID", containerdID,
+			"namespace", namespace,
+			"error", taskStatusErr)
+		return intmodel.ContainerStateStopped, nil
+	}
+
 	// TaskStatus failed - return Unknown since we can't determine the state
 	r.logger.InfoContext(r.ctx, "failed to get container state via TaskStatus",
 		"container", containerID,

--- a/internal/controller/runner/container_state_test.go
+++ b/internal/controller/runner/container_state_test.go
@@ -1,0 +1,290 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.GetContainerState and ReconcileCell against an in-package ctr.Client fake
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cgroup2 "github.com/containerd/cgroups/v2/cgroup2"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/metadata"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// containerStateCell mimics the shape ReconcileCell + GetContainerState
+// expect: a workload cell with one non-root container carrying an
+// explicit ContainerdID so the runner skips the build-from-naming branch
+// the test fake can't satisfy.
+func containerStateCell(realm, space, stack, cellName, containerID, containerdID string) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			ID:        cellName,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+			Containers: []intmodel.ContainerSpec{
+				{
+					ID:           containerID,
+					ContainerdID: containerdID,
+					Root:         true,
+				},
+			},
+		},
+	}
+}
+
+// TestGetContainerState_TaskNotFound_ReturnsStopped is the headline #543
+// Layer 2 fix: a container record that survives a host reboot (containerd's
+// boltdb keeps the container entry, the task is gone with the cgroup) must
+// read back as Stopped, not Unknown. Without this, the cell-level derivation
+// can never transition past Unknown — cellStateAutoDeleteTriggers and
+// shouldWindDownCell both exclude Unknown by design — and the reconciler
+// leaves every previously-Ready cell stuck.
+func TestGetContainerState_TaskNotFound_ReturnsStopped(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{}, fmt.Errorf("%w: %w", errdefs.ErrTaskNotFound, errors.New("task: not found"))
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+
+	state, err := r.GetContainerState(cell, containerID)
+	if err != nil {
+		t.Fatalf("GetContainerState: unexpected error: %v", err)
+	}
+	if state != intmodel.ContainerStateStopped {
+		t.Errorf(
+			"GetContainerState = %v, want Stopped (container exists, task gone is the post-reboot signature #543)",
+			state,
+		)
+	}
+}
+
+// TestGetContainerState_ContainerGoneAlsoStopped sanity-checks the existing
+// pre-fix path: a container that's been removed from containerd entirely
+// (operator ran `ctr -n <ns> containers rm` between boots) reads back as
+// Stopped via the "container does not exist" branch. The Layer 2 fix added
+// in #543 must not regress this case — both paths land at Stopped so the
+// cell-level derivation reaches a terminal state either way.
+func TestGetContainerState_ContainerGoneAlsoStopped(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return false, nil },
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+
+	state, err := r.GetContainerState(cell, containerID)
+	if err != nil {
+		t.Fatalf("GetContainerState: unexpected error: %v", err)
+	}
+	if state != intmodel.ContainerStateStopped {
+		t.Errorf(
+			"GetContainerState = %v, want Stopped (container fully gone branch — sanity check the existing path isn't regressed)",
+			state,
+		)
+	}
+}
+
+// TestGetContainerState_TransientErrorStaysUnknown locks down the narrowing
+// the Layer 2 fix performs: a TaskStatus failure that is NOT wrapped with
+// ErrTaskNotFound must stay Unknown so a transient containerd RPC blip
+// cannot flip a healthy cell to Stopped (and trigger AutoDelete /
+// wind-down on the next reconcile pass).
+func TestGetContainerState_TransientErrorStaysUnknown(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{}, errors.New("containerd: rpc transport closed")
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+
+	state, err := r.GetContainerState(cell, containerID)
+	if err != nil {
+		t.Fatalf("GetContainerState: unexpected error: %v", err)
+	}
+	if state != intmodel.ContainerStateUnknown {
+		t.Errorf(
+			"GetContainerState = %v, want Unknown (transient RPC errors without ErrTaskNotFound must NOT flip to Stopped — defensive against #301-class hiccups)",
+			state,
+		)
+	}
+}
+
+// TestReconcileCell_PostReboot_TransitionsToStopped is the headline #543
+// end-to-end: a cell that was Ready before a host reboot (latch already
+// closed, containerd container records survive) must transition to
+// Stopped within one reconcile pass once the daemon comes back, even
+// though the cgroup is gone (tmpfs-backed cgroups don't persist across
+// reboot). Without the Layer 1 fix (drop the cgroup-existence gate
+// around deriveCellState) AND the Layer 2 fix (TaskStatus failing with
+// ErrTaskNotFound after ExistsContainer succeeded ⇒ Stopped, not
+// Unknown), the cell stays parked at Unknown and the operator must
+// manually `kuke purge cell <name>` for each orphan.
+func TestReconcileCell_PostReboot_TransitionsToStopped(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	rootID := "root"
+	workloadID := "workload"
+	rootContainerdID := space + "_" + stack + "_" + cellName + "_" + rootID
+	workloadContainerdID := space + "_" + stack + "_" + cellName + "_" + workloadID
+
+	fake := &deleteCellFakeClient{
+		// Cgroup absent: the tmpfs-backed /sys/fs/cgroup/kukeon/... tree
+		// is wiped on reboot and not recreated until the daemon
+		// rebuilds it.
+		loadCgroupFn: func(string, string) (*cgroup2.Manager, error) {
+			return nil, errors.New("cgroup path does not exist")
+		},
+		// Containerd container records survive the reboot — both root and
+		// non-root.
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		// Tasks are gone — the kernel side wiped them with the cgroup,
+		// but the boltdb-side container entries persist.
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{}, fmt.Errorf("%w: %w", errdefs.ErrTaskNotFound, errors.New("task: not found"))
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	seedPostRebootCell(t, r, realm, space, stack, cellName, rootID, workloadID, rootContainerdID, workloadContainerdID)
+
+	// Build the cell the way the reconcile loop would — load it back so
+	// the test exercises the same code path daemon does on first tick
+	// after restart.
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			ID:        cellName,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+			Containers: []intmodel.ContainerSpec{
+				{ID: rootID, ContainerdID: rootContainerdID, Root: true},
+				{ID: workloadID, ContainerdID: workloadContainerdID, Root: false},
+			},
+		},
+		Status: intmodel.CellStatus{
+			State:         intmodel.CellStateReady,
+			ReadyObserved: true,
+		},
+	}
+
+	updatedCell, outcome, err := r.ReconcileCell(cell)
+	if err != nil {
+		t.Fatalf("ReconcileCell: unexpected error: %v", err)
+	}
+	if !outcome.Updated {
+		t.Errorf(
+			"ReconcileCell outcome.Updated = false; want true (post-reboot state transition Ready → Stopped must be reported as an update)",
+		)
+	}
+	if updatedCell.Status.State != intmodel.CellStateStopped {
+		t.Errorf(
+			"ReconcileCell cell.Status.State = %v, want Stopped (post-reboot cells must transition out of Unknown so cellStateAutoDeleteTriggers and shouldWindDownCell become eligible)",
+			updatedCell.Status.State,
+		)
+	}
+	if !updatedCell.Status.ReadyObserved {
+		t.Errorf(
+			"ReconcileCell cell.Status.ReadyObserved = false; want true (the ReadyObserved latch must survive a reboot — it's the AutoDelete gate)",
+		)
+	}
+}
+
+// seedPostRebootCell writes a cell metadata doc shaped like the on-disk
+// snapshot left by a clean shutdown / reboot: state Ready, ReadyObserved
+// true (the latch persisted), and both root + workload containers carrying
+// explicit ContainerdIDs so the reconcile path can look them up.
+func seedPostRebootCell(
+	t *testing.T,
+	r *Exec,
+	realm, space, stack, cellName, rootID, workloadID, rootContainerdID, workloadContainerdID string,
+) {
+	t.Helper()
+	doc := v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: cellName},
+		Spec: v1beta1.CellSpec{
+			ID:      cellName,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:           rootID,
+					ContainerdID: rootContainerdID,
+					RealmID:      realm,
+					SpaceID:      space,
+					StackID:      stack,
+					CellID:       cellName,
+					Image:        "alpine:latest",
+					Root:         true,
+				},
+				{
+					ID:           workloadID,
+					ContainerdID: workloadContainerdID,
+					RealmID:      realm,
+					SpaceID:      space,
+					StackID:      stack,
+					CellID:       cellName,
+					Image:        "nginx:latest",
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{
+			State:         v1beta1.CellStateReady,
+			ReadyObserved: true,
+		},
+	}
+	path := fs.CellMetadataPath(r.opts.RunPath, realm, space, stack, cellName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir cell metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write cell metadata: %v", err)
+	}
+}

--- a/internal/controller/runner/delete_cell_test.go
+++ b/internal/controller/runner/delete_cell_test.go
@@ -44,10 +44,15 @@ import (
 // tests. Methods unused by DeleteCell return zero values rather than panic so
 // adding a new code path through ctr.Client doesn't require revisiting this
 // fake — the controller-level error assertions catch unintended behavior.
+// Also reused by container_state / reconcile tests that need ExistsContainer
+// + TaskStatus hooks (the post-reboot reproduction in #543).
 type deleteCellFakeClient struct {
 	deleteContainerFn func(namespace, id string, opts ctr.ContainerDeleteOptions) error
 	stopContainerFn   func(namespace, id string, opts ctr.StopContainerOptions) (*containerd.ExitStatus, error)
 	listContainersFn  func(namespace string, filters ...string) ([]containerd.Container, error)
+	existsContainerFn func(namespace, id string) (bool, error)
+	taskStatusFn      func(namespace, id string) (containerd.Status, error)
+	loadCgroupFn      func(group, mountpoint string) (*cgroup2.Manager, error)
 }
 
 func (c *deleteCellFakeClient) Connect() error { return nil }
@@ -72,7 +77,10 @@ func (c *deleteCellFakeClient) NewCgroup(ctr.CgroupSpec) (*cgroup2.Manager, erro
 	return nil, nil
 }
 
-func (c *deleteCellFakeClient) LoadCgroup(string, string) (*cgroup2.Manager, error) {
+func (c *deleteCellFakeClient) LoadCgroup(group, mountpoint string) (*cgroup2.Manager, error) {
+	if c.loadCgroupFn != nil {
+		return c.loadCgroupFn(group, mountpoint)
+	}
 	//nolint:nilnil // same as NewCgroup
 	return nil, nil
 }
@@ -116,7 +124,10 @@ func (c *deleteCellFakeClient) ListContainers(namespace string, filters ...strin
 	return nil, nil
 }
 
-func (c *deleteCellFakeClient) ExistsContainer(string, string) (bool, error) {
+func (c *deleteCellFakeClient) ExistsContainer(namespace, id string) (bool, error) {
+	if c.existsContainerFn != nil {
+		return c.existsContainerFn(namespace, id)
+	}
 	return false, nil
 }
 
@@ -143,7 +154,10 @@ func (c *deleteCellFakeClient) StopContainer(
 	return nil, errdefs.ErrTaskNotFound
 }
 
-func (c *deleteCellFakeClient) TaskStatus(string, string) (containerd.Status, error) {
+func (c *deleteCellFakeClient) TaskStatus(namespace, id string) (containerd.Status, error) {
+	if c.taskStatusFn != nil {
+		return c.taskStatusFn(namespace, id)
+	}
 	return containerd.Status{}, nil
 }
 

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -244,28 +244,51 @@ func carryStackLifecycle(orig intmodel.StackStatus, next *intmodel.StackStatus) 
 
 // RefreshCell refreshes the status of a cell and its containers.
 // Returns the updated cell, number of containers updated, and any error.
+//
+// Mirrors the container-aware derivation ReconcileCell does (#543): the
+// post-reboot scenario (cgroup wiped, container records survive, tasks
+// gone) must transition cells out of Unknown so `kuke refresh` surfaces
+// the same Cells / Containers updates the reconcile loop does. Pure
+// "cgroup-only" cell-state derivation would re-park them at Unknown.
 func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 	originalStatus := cell.Status
+	originalContainerStatuses := append(
+		[]intmodel.ContainerStatus(nil), originalStatus.Containers...)
+
 	newStatus := intmodel.CellStatus{
 		State:      intmodel.CellStateUnknown, // Default to Unknown - will be updated if checks succeed
 		CgroupPath: originalStatus.CgroupPath,
 	}
 
-	// Check cgroup existence
+	// Check cgroup existence. Used to set CgroupReady and to guard the
+	// derivation pass below — when the filesystem check itself errors we
+	// have no positive observation either way and stay at Unknown.
 	cgroupExists, err := r.ExistsCgroup(cell)
-	switch {
-	case err != nil:
+	if err != nil {
 		r.logger.DebugContext(r.ctx, "failed to check cell cgroup", "cell", cell.Metadata.Name, "error", err)
-		// If check fails, state remains Unknown (already set)
-	case cgroupExists:
-		newStatus.State = intmodel.CellStateReady
+	} else if cgroupExists {
 		newStatus.CgroupReady = true
-	default:
-		// Cgroup doesn't exist - cell is unknown
-		newStatus.State = intmodel.CellStateUnknown
 	}
 
 	carryCellLifecycle(originalStatus, &newStatus)
+
+	// Populate container statuses so derivation reads from a fresh
+	// snapshot and so containersUpdated reflects per-container state
+	// changes (the post-reboot Unknown → Stopped transition that the
+	// AC #3 calls out for `kuke refresh`).
+	if populateErr := r.populateCellContainerStatuses(&cell); populateErr != nil {
+		r.logger.DebugContext(r.ctx, "populate container statuses failed",
+			"cell", cell.Metadata.Name, "error", populateErr)
+	}
+	newStatus.Containers = cell.Status.Containers
+
+	// Derive cell state from the container snapshot when the cgroup
+	// check didn't error. CreateCell-race protection comes from
+	// latchReadyObserved below — a cell that has never been observed
+	// Ready cannot be reaped regardless of what derivation reads back.
+	if err == nil {
+		newStatus.State = r.deriveCellState(cell)
+	}
 
 	// Run ReadyObserved through the same one-way latch ReconcileCell uses.
 	// Without this, `kuke refresh` racing a synchronous Ready write would
@@ -291,12 +314,23 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 		}
 	}
 
+	// Surface per-container state transitions to the operator: any
+	// container whose snapshot State differs from the persisted record
+	// counts toward containersUpdated, so `kuke refresh` lists them
+	// under the Containers: line. Without this, refreshContainerStatus
+	// alone only fires the counter on a missing-ContainerdID fill-in.
+	if !containerStatusesEqual(originalContainerStatuses, newStatus.Containers) {
+		containersUpdated += countContainerStatusChanges(
+			originalContainerStatuses, newStatus.Containers)
+	}
+
 	// Update cell metadata if status changed or containers were updated
 	cellUpdated := false
 	if newStatus.State != originalStatus.State ||
 		newStatus.CgroupPath != originalStatus.CgroupPath ||
 		newStatus.CgroupReady != originalStatus.CgroupReady ||
-		newStatus.ReadyObserved != originalStatus.ReadyObserved {
+		newStatus.ReadyObserved != originalStatus.ReadyObserved ||
+		!containerStatusesEqual(originalContainerStatuses, newStatus.Containers) {
 		cell.Status = newStatus
 		cellUpdated = true
 	}
@@ -309,6 +343,24 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 	}
 
 	return cell, containersUpdated, nil
+}
+
+// countContainerStatusChanges counts containers whose State differs
+// from the persisted record (or are newly present). Used by RefreshCell
+// to size the Containers: line in `kuke refresh` summaries.
+func countContainerStatusChanges(orig, next []intmodel.ContainerStatus) int {
+	prevByID := make(map[string]intmodel.ContainerState, len(orig))
+	for i := range orig {
+		prevByID[orig[i].ID] = orig[i].State
+	}
+	changed := 0
+	for i := range next {
+		prev, existed := prevByID[next[i].ID]
+		if !existed || prev != next[i].State {
+			changed++
+		}
+	}
+	return changed
 }
 
 // carryCellLifecycle is the Cell counterpart of carryRealmLifecycle.
@@ -493,7 +545,7 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 		return cell, ReconcileOutcome{Updated: updated}, nil
 	}
 
-	cgroupExists, cgroupErr := r.ExistsCgroup(cell)
+	_, cgroupErr := r.ExistsCgroup(cell)
 	if cgroupErr != nil {
 		r.logger.DebugContext(r.ctx, "failed to check cell cgroup",
 			"cell", cell.Metadata.Name, "error", cgroupErr)
@@ -509,8 +561,18 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 			"cell", cell.Metadata.Name, "error", err)
 	}
 
+	// Run derivation whenever the filesystem check succeeded, even when the
+	// cgroup is absent — a missing cgroup with surviving containerd
+	// containers and no tasks is the post-reboot signature (#543), and
+	// staying at Unknown there bypasses cellStateAutoDeleteTriggers /
+	// shouldWindDownCell forever. The cgroupErr != nil path still parks at
+	// Unknown because we have no positive observation of either side.
+	// The CreateCell-race protection that used to come from the cgroup
+	// gate is now carried entirely by latchReadyObserved: a cell that has
+	// never been observed Ready cannot be reaped, regardless of what
+	// derivation reads back.
 	newState := intmodel.CellStateUnknown
-	if cgroupErr == nil && cgroupExists {
+	if cgroupErr == nil {
 		newState = r.deriveCellState(cell)
 	}
 


### PR DESCRIPTION
## Summary

- **Layer 2 (`internal/controller/runner/container_state.go`):** `GetContainerState` now classifies the post-reboot signature — `ExistsContainer == true` but `TaskStatus` returns a wrapped `errdefs.ErrTaskNotFound` — as `ContainerStateStopped` instead of `Unknown`. Without this, the cell-level derivation can never see past Unknown (both `cellStateAutoDeleteTriggers` and `shouldWindDownCell` exclude Unknown by design) and the reconciler leaves every previously-Ready cell stuck after the host comes back. Any other `TaskStatus` failure still maps to `Unknown` so a transient RPC blip can't flip a healthy cell to Stopped.
- **Layer 1 (`internal/controller/runner/refresh.go`):** Dropped the `cgroupExists` short-circuit in `ReconcileCell` that was forcing `Unknown` whenever the cgroup tree was missing. The tmpfs-backed `/sys/fs/cgroup/kukeon/...` hierarchy doesn't survive reboot, so this gate kept Layer 2 from ever firing. `CgroupReady` is still recorded from the cgroup probe, but the state derivation now runs as long as the probe didn't error.
- **`RefreshCell` parity:** Aligned `RefreshCell` with `ReconcileCell` so `kuke refresh` surfaces the same Ready→Stopped transition for the AC's `Cells/Containers` change summary — populates container statuses, derives state via `deriveCellState`, applies `latchReadyObserved`, and tracks per-container state diffs via the new `countContainerStatusChanges` helper.
- **Latch invariant preserved:** A never-Ready cell still cannot be reaped — `ReadyObserved` is a one-way latch gated on a derived `Ready`, and Layer 2 only converts `task gone + container present` to `Stopped`; the CreateCell-race protection from #275/#278 is untouched.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/controller/runner/...` — all four new tests pass (`TestGetContainerState_TaskNotFound_ReturnsStopped`, `TestGetContainerState_ContainerGoneAlsoStopped`, `TestGetContainerState_TransientErrorStaysUnknown`, `TestReconcileCell_PostReboot_TransitionsToStopped`)
- [x] `make test` — full suite green
- [x] `pre-commit run --files <changed>` — go fmt / golangci-lint / addlicense all pass
- [ ] `make dev-init` smoke (daemon-parity bind-mount regression) — user rejected the tool call this session. The diff is pure reconciler-derivation logic in `internal/controller/runner/`; it does not touch the daemon bootstrap path, bind mounts, `/opt/kukeon` layout, or anything `make dev-init` is designed to catch. Reviewer please re-run on a clean host if there's any doubt.

Closes #543