### PR TITLE
fix: refuse make dev-init inside an attachable kukeon cell

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -20,6 +20,39 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
+# Pre-flight: refuse to run inside an attachable kukeon cell (issue #545).
+# The presence of /.kukeon/bin/kuketty (ctr.AttachableBinaryPath) is the
+# canonical "we are inside an attachable cell" probe — the daemon bind-
+# mounts the kuketty binary at this fixed in-container path whenever it
+# provisions an attachable container. Running dev-init in that context
+# provisions a *nested* kukeond whose own bind of /run/kukeon collides
+# with the parent host's /run/kukeon/tty bind, leaving the parent's
+# `kuke attach <this-cell>` unrecoverably broken on exit. Refuse fast,
+# before any state-mutating step (kuke daemon reset, kuke init).
+# KUKEON_DEV_INIT_ALLOW_NESTED=1 is an explicit opt-in for contributors
+# who accept the breakage; the script still warns loudly under override.
+if [ -e "/.kukeon/bin/kuketty" ]; then
+    if [ "${KUKEON_DEV_INIT_ALLOW_NESTED:-0}" != "1" ]; then
+        cat >&2 <<'EOF'
+dev-init.sh: refusing to run — detected /.kukeon/bin/kuketty, which
+means this script is executing inside an attachable kukeon cell.
+Provisioning a nested kukeond clobbers the parent host's /run/kukeon/tty
+bind mount and leaves `kuke attach <this-cell>` from the parent host
+unrecoverably broken (issue #545). The only recovery is
+`kuke purge cell <this-cell>` + recreate from the parent host, which
+kills any running workload inside this cell.
+
+Options:
+  * Run dev-init on the host, not inside an attachable kukeon cell.
+  * To override and accept that the parent host's attach to this cell
+    will break, set KUKEON_DEV_INIT_ALLOW_NESTED=1.
+EOF
+        exit 1
+    fi
+    printf '\n!! KUKEON_DEV_INIT_ALLOW_NESTED=1 — parent host attach to this cell\n' >&2
+    printf '!! will likely break (issue #545). Continuing anyway.\n\n' >&2
+fi
+
 LOCAL_TAG="kukeon-local:dev"
 KUKEOND_IMAGE_REF="docker.io/library/${LOCAL_TAG}"
 # The on-disk metadata layout lives under /opt/kukeon/data/ — see


### PR DESCRIPTION
## Summary

- Add a pre-flight check at the top of `scripts/dev-init.sh` that detects whether the script is running inside an attachable kukeon cell (probe: `/.kukeon/bin/kuketty`, the daemon's `ctr.AttachableBinaryPath` bind-mount destination) and refuses to run.
- `KUKEON_DEV_INIT_ALLOW_NESTED=1` opts in to the prior behavior for contributors who explicitly accept that the parent host's `kuke attach <this-cell>` will break; the script still prints a loud two-line warning under the override.
- The check fires before any state-mutating step (no `make kuke`, no `make install-dev`, no `kuke daemon reset`, no `kuke init`), so the parent's `/run/kukeon/tty` bind mount is never disturbed by an accidental nested invocation.

## Why this approach

Issue #545 enumerated four candidate directions; I went with the first ("refuse to run") because it is the lowest-blast-radius option that satisfies AC #1 ("must not break `kuke attach <that-cell>` from the parent host"). The alternatives — switching the nested kukeond to a per-nest `/run/kukeon-dev/` path, or making the parent's attach bind `rprivate` — are valuable in their own right but require structural daemon work; gating the entry script kills the regression today without touching the controller bootstrap, and the override env var preserves the escape hatch for contributors who explicitly want to keep the prior behavior.

AC #2 is satisfied trivially: when refusal triggers, no step under the script mutates `/run/kukeon` at all. AC #3 (smoke verifies parent's pre-existing attach paths still work when nested) is conditional on the script running nested; under the refuse-to-run default the nested case is short-circuited before the smoke, so the existing smoke (which validates a disposable cell on the host) needs no change. If the issue author prefers the per-nest path scheme as the real fix later, that work would land as a separate PR and would naturally relax the refusal here.

## Test plan

- [x] `make test` — full Go unit test suite, all packages pass.
- [x] `go build ./...` and `go vet ./...` — clean.
- [x] `bash -n scripts/dev-init.sh` — syntax OK.
- [x] `pre-commit run --files scripts/dev-init.sh` — clean.
- [x] Manual: this dev container is itself a `kukeon-dev-root` cell (it has `/.kukeon/bin/kuketty`). Ran `bash scripts/dev-init.sh` → refused with the expected message and `exit 1`. Ran `KUKEON_DEV_INIT_ALLOW_NESTED=1 bash scripts/dev-init.sh` → printed the warning and proceeded into the build step (killed before any `/run/kukeon` mutation).
- [ ] Full `make dev-init` end-to-end smoke on a real host — not run; this PR's diff cannot reach the daemon/bootstrap path it would exercise, and the test host (this dev container) is exactly the environment the new gate refuses.

Closes #545