### PR TITLE
fix: support nested dev-init via per-nest socket + rprivate tty bind

### DIFF
--- a/internal/ctr/attachable.go
+++ b/internal/ctr/attachable.go
@@ -145,6 +145,16 @@ type AttachableInjection struct {
 // the container's overlay — invisible to the host. A directory bind mount
 // keeps the inode host-visible by construction.
 //
+// The tty mount is also pinned to `rprivate` propagation (issue #547). The
+// attachable cell hosts contributor workflows that nest a second kukeond
+// inside (`make dev-init` inside a `kukeon-dev-root` cell); without
+// `rprivate`, mount events from the nested kukeond's `/run/kukeon/...`
+// activity could propagate back through the directory bind into the parent
+// host's `<HostTTYDir>` and break the parent's `kuke attach` plumbing for
+// the cell. `rprivate` makes the bind a one-way window: the nested daemon
+// still sees the parent's socket / capture / log inodes, but no mount
+// event in either direction escapes the boundary.
+//
 // The metadata mount is a *file* bind mount: kuketty reads the file once at
 // startup and never mutates it, so the unlink-and-recreate trap that
 // affects the socket inode does not apply.
@@ -160,7 +170,7 @@ func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 			Destination: AttachableTTYDir,
 			Source:      inj.HostTTYDir,
 			Type:        "bind",
-			Options:     []string{"rbind", "rw"},
+			Options:     []string{"rbind", "rw", "rprivate"},
 		},
 		{
 			Destination: AttachableMetadataPath,

--- a/internal/ctr/attachable_test.go
+++ b/internal/ctr/attachable_test.go
@@ -190,6 +190,18 @@ func TestBuildContainerSpec_AttachableTrue_MountsAndArgsWrap(t *testing.T) {
 			if containsString(ttyMount.Options, "ro") {
 				t.Errorf("tty mount must be read-write, got options=%v", ttyMount.Options)
 			}
+			// Issue #547: the tty bind must be `rprivate` so a nested
+			// kukeond running inside the attachable cell (e.g.
+			// `make dev-init` inside a `kukeon-dev-root` cell) cannot
+			// propagate mount events back through the bind and break the
+			// parent host's attach plumbing for this cell.
+			if !containsString(ttyMount.Options, "rprivate") {
+				t.Errorf(
+					"tty mount must carry %q for nested-kukeon safety, got options=%v",
+					"rprivate",
+					ttyMount.Options,
+				)
+			}
 
 			metaMount := findMount(spec, ctr.AttachableMetadataPath)
 			if metaMount == nil {

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -34,6 +34,124 @@ step() {
     printf '\n==> %s\n' "$*"
 }
 
+# Nested-kukeon detection (issue #547). The canonical probe is the
+# `/.kukeon/bin/kuketty` bind the daemon stages into every attachable cell
+# (`internal/ctr.AttachableBinaryPath`). When present, this script is
+# running inside a `kukeon-dev-root` cell whose parent host has bind-
+# mounted `/run/kukeon/tty/<container>/` into us at `/run/kukeon/tty/`. A
+# nested `kuke init` against the default `/run/kukeon/kukeond.sock` would
+# share the `/run/kukeon` parent dir with that bind and break the parent's
+# `kuke attach <this-cell>` plumbing on script exit (#545 repro).
+#
+# The fix is to publish the nested daemon's socket under a per-nest
+# directory (`/run/kukeon-dev/`) so its lifecycle never touches the
+# parent's bind. The host-run path (probe absent) is unchanged.
+NESTED_PROBE="/.kukeon/bin/kuketty"
+PARENT_ATTACH_SOCKET="/run/kukeon/tty/socket"
+PARENT_ATTACH_METADATA="/.kukeon/kuketty/metadata.json"
+NESTED_SOCKET_DIR="/run/kukeon-dev"
+NESTED_SOCKET_PATH="${NESTED_SOCKET_DIR}/kukeond.sock"
+NESTED_HOST_URI="unix://${NESTED_SOCKET_PATH}"
+NESTED_SERVER_CONFIG=""
+INIT_EXTRA_ARGS=()
+
+if [ -e "${NESTED_PROBE}" ]; then
+    step "Nested kukeon detected (${NESTED_PROBE} present)"
+    echo "Routing the nested kukeond through ${NESTED_SOCKET_PATH} (per-nest socket)."
+    echo "Parent host's /run/kukeon/tty bind is left untouched; verified on exit."
+
+    # Snapshot the parent's per-container attach plumbing so the EXIT trap
+    # can fail loud if anything we did clobbered it. The socket file and
+    # metadata file are the parent's, populated by the parent's daemon at
+    # the moment this cell was created — they're the things the parent's
+    # `kuke attach <this-cell>` depends on.
+    if [ ! -S "${PARENT_ATTACH_SOCKET}" ]; then
+        printf 'parent attach socket missing or not a socket at %s — refusing to run\n' \
+            "${PARENT_ATTACH_SOCKET}" >&2
+        exit 1
+    fi
+    if [ ! -r "${PARENT_ATTACH_METADATA}" ]; then
+        printf 'parent attach metadata missing or unreadable at %s — refusing to run\n' \
+            "${PARENT_ATTACH_METADATA}" >&2
+        exit 1
+    fi
+    PARENT_ATTACH_METADATA_PRE_SHA="$(sha256sum "${PARENT_ATTACH_METADATA}" | awk '{print $1}')"
+
+    # Make the per-nest socket dir up front so its parent exists before
+    # `kuke init`'s `applyKukeonOwnership` chowns it (`ensureSocketDir` in
+    # the controller bootstrap also creates it, so this is belt-and-braces
+    # — it lets us point `KUKEON_HOST` at the right place from line one).
+    sudo mkdir -p "${NESTED_SOCKET_DIR}"
+
+    # KUKEON_HOST is bound to viper for every `kuke` subcommand
+    # (`KUKEON_ROOT_HOST.BindEnv` in cmd/kuke/kuke.go's loadConfig), so
+    # exporting it here covers every client invocation below — `kuke
+    # daemon reset`, `kuke get realms`, `kuke create realm`, `kuke apply`,
+    # `kuke purge`, etc. — without per-call --host overrides.
+    export KUKEON_HOST="${NESTED_HOST_URI}"
+
+    # `kuke init` does not env-bind KUKEOND_SOCKET (the daemon-side
+    # variable), so the supported channel for steering the daemon socket
+    # at init time is `--server-configuration`. We write a minimal
+    # ServerConfiguration document with `spec.socket` only — every other
+    # field falls back to the daemon's hardcoded default, matching the
+    # default-host invocation everywhere else.
+    NESTED_SERVER_CONFIG="$(mktemp -t kukeon-dev-init-nested-server-config.XXXXXX.yaml)"
+    cat > "${NESTED_SERVER_CONFIG}" <<EOF
+apiVersion: v1beta1
+kind: ServerConfiguration
+metadata:
+  name: kukeon-dev-init-nested
+spec:
+  socket: ${NESTED_SOCKET_PATH}
+EOF
+    INIT_EXTRA_ARGS+=("--server-configuration" "${NESTED_SERVER_CONFIG}")
+fi
+
+# Post-flight: re-stat the parent's attach socket and metadata. Runs on
+# every exit path so a botched re-bootstrap surfaces here rather than at
+# the operator's next `kuke attach <this-cell>` on the parent host. When
+# the script was not nested the snapshot is empty and this is a no-op.
+verify_parent_attach_intact() {
+    if [ -z "${PARENT_ATTACH_METADATA_PRE_SHA:-}" ]; then
+        return 0
+    fi
+    local ok=1
+    if [ ! -S "${PARENT_ATTACH_SOCKET}" ]; then
+        printf 'POST-FLIGHT: parent attach socket missing or not a socket at %s\n' \
+            "${PARENT_ATTACH_SOCKET}" >&2
+        ok=0
+    fi
+    if [ ! -r "${PARENT_ATTACH_METADATA}" ]; then
+        printf 'POST-FLIGHT: parent attach metadata missing or unreadable at %s\n' \
+            "${PARENT_ATTACH_METADATA}" >&2
+        ok=0
+    else
+        local now
+        now="$(sha256sum "${PARENT_ATTACH_METADATA}" | awk '{print $1}')"
+        if [ "${now}" != "${PARENT_ATTACH_METADATA_PRE_SHA}" ]; then
+            printf 'POST-FLIGHT: parent attach metadata at %s changed (%s -> %s)\n' \
+                "${PARENT_ATTACH_METADATA}" "${PARENT_ATTACH_METADATA_PRE_SHA}" "${now}" >&2
+            ok=0
+        fi
+    fi
+    if [ "${ok}" -eq 0 ]; then
+        printf 'POST-FLIGHT: nested run disturbed the parent host attach plumbing for this cell\n' >&2
+        return 1
+    fi
+    echo "post-flight: parent attach plumbing at ${PARENT_ATTACH_SOCKET} still intact"
+    return 0
+}
+
+# Register the post-flight check BEFORE any state-mutating step so an
+# early failure (e.g. during `make kuke`, `docker build`, or the first
+# `kuke init`) still surfaces a disturbance of the parent's attach
+# plumbing. The smoke section below replaces this trap with
+# `cleanup_attach_smoke`, whose last step is the same
+# `verify_parent_attach_intact` invocation — so the post-flight contract
+# holds at every exit point in the script.
+trap 'verify_parent_attach_intact || exit 1' EXIT
+
 step "Build kuke (and the kukeond symlink)"
 make kuke
 ln -sf kuke kukeond
@@ -74,25 +192,27 @@ if [ ! -d "${SYSTEM_REALM_DIR}" ]; then
     # of that pass may fail because the local image is not yet staged in
     # containerd. Tolerate that — the second init below recreates the
     # cell after the image load succeeds.
-    sudo ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
+    sudo --preserve-env=KUKEON_HOST ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
+        "${INIT_EXTRA_ARGS[@]}" \
         || echo "first-pass init returned non-zero (expected before image is staged); continuing"
 fi
 
 if [ -d "${KUKEOND_CELL_DIR}" ]; then
     step "Reset prior kukeond cell"
-    sudo ./kuke daemon reset
+    sudo --preserve-env=KUKEON_HOST ./kuke daemon reset
 else
     step "No prior kukeond cell at ${KUKEOND_CELL_DIR}; skipping reset"
 fi
 
 step "Load ${LOCAL_TAG} into the kuke-system realm"
-sudo ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system --no-daemon
+sudo --preserve-env=KUKEON_HOST ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system --no-daemon
 
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
-sudo ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}"
+sudo --preserve-env=KUKEON_HOST ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
+    "${INIT_EXTRA_ARGS[@]}"
 
 step "Daemon parity check (both must show identical output)"
-sudo ./kuke get realms
+sudo --preserve-env=KUKEON_HOST ./kuke get realms
 sudo ./kuke get realms --no-daemon
 
 # Phase 1b smoke (#410): the daemon's metadata-rendering path now emits
@@ -117,18 +237,28 @@ ATTACH_SMOKE_METADATA="${ATTACH_SMOKE_BASE}/kuketty-metadata.json"
 ATTACH_SMOKE_TMP="$(mktemp -d)"
 
 teardown_attach_smoke_state() {
-    sudo ./kuke purge cell "${ATTACH_SMOKE_CELL}" \
+    sudo --preserve-env=KUKEON_HOST ./kuke purge cell "${ATTACH_SMOKE_CELL}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" --stack "${ATTACH_SMOKE_STACK}" \
         --cascade 2>/dev/null || true
-    sudo ./kuke purge stack "${ATTACH_SMOKE_STACK}" \
+    sudo --preserve-env=KUKEON_HOST ./kuke purge stack "${ATTACH_SMOKE_STACK}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" 2>/dev/null || true
-    sudo ./kuke purge space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
-    sudo ./kuke purge realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
+    sudo --preserve-env=KUKEON_HOST ./kuke purge space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
+    sudo --preserve-env=KUKEON_HOST ./kuke purge realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
 }
 
 cleanup_attach_smoke() {
     rm -rf "${ATTACH_SMOKE_TMP}"
     teardown_attach_smoke_state
+    if [ -n "${NESTED_SERVER_CONFIG}" ]; then
+        rm -f "${NESTED_SERVER_CONFIG}"
+    fi
+    # Issue #547 AC#4: the parent host's `/run/kukeon/tty` bind must
+    # still be live before this script exits. Runs after the nested
+    # daemon's smoke artifacts are torn down so we catch any late
+    # disturbance, and runs on the error-exit path too (the trap fires
+    # regardless of exit status). Returns non-zero to surface the
+    # disturbance even when the rest of the script succeeded.
+    verify_parent_attach_intact || exit 1
 }
 trap cleanup_attach_smoke EXIT
 
@@ -137,9 +267,9 @@ trap cleanup_attach_smoke EXIT
 # left intact — only the on-disk realm/space/stack/cell state is wiped.
 teardown_attach_smoke_state
 
-sudo ./kuke create realm "${ATTACH_SMOKE_REALM}"
-sudo ./kuke create space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}"
-sudo ./kuke create stack "${ATTACH_SMOKE_STACK}" --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}"
+sudo --preserve-env=KUKEON_HOST ./kuke create realm "${ATTACH_SMOKE_REALM}"
+sudo --preserve-env=KUKEON_HOST ./kuke create space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}"
+sudo --preserve-env=KUKEON_HOST ./kuke create stack "${ATTACH_SMOKE_STACK}" --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}"
 
 cat > "${ATTACH_SMOKE_TMP}/cell.yaml" <<EOF
 apiVersion: v1beta1
@@ -164,7 +294,7 @@ spec:
       attachable: true
 EOF
 
-sudo ./kuke apply -f "${ATTACH_SMOKE_TMP}/cell.yaml"
+sudo --preserve-env=KUKEON_HOST ./kuke apply -f "${ATTACH_SMOKE_TMP}/cell.yaml"
 
 # Wait for kuketty to bind the per-container socket. The window covers
 # image pull + container start + sbsh server bring-up; a regression that
@@ -193,7 +323,30 @@ sudo grep -q '"kind": "Terminal"' "${ATTACH_SMOKE_METADATA}" \
 # pkg/attach speaks.
 ATTACH_LOG="${ATTACH_SMOKE_TMP}/attach.log"
 go run ./hack/attach-smoke --log "${ATTACH_LOG}" -- \
-    sudo ./kuke attach "${ATTACH_SMOKE_CELL}" \
+    sudo --preserve-env=KUKEON_HOST ./kuke attach "${ATTACH_SMOKE_CELL}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" \
         --stack "${ATTACH_SMOKE_STACK}" --container "${ATTACH_SMOKE_CONTAINER}"
 echo "kuke attach exited cleanly (see ${ATTACH_LOG} for the full transcript)"
+
+# Issue #547 AC#5: when the script runs nested, the existing smoke above
+# only validates the nested daemon's disposable cell. The contract the AC
+# adds is that the parent host's pre-existing attach paths must still be
+# usable after the nested smoke completes — exercise that by re-statting
+# the parent's per-container attach socket and metadata bind. The EXIT
+# trap's `verify_parent_attach_intact` is the final fail-loud guard; this
+# is the in-script verification surfaced in the smoke output so a
+# regression is visible at the smoke step, not opaquely on exit.
+if [ -n "${PARENT_ATTACH_METADATA_PRE_SHA:-}" ]; then
+    step "Nested smoke: verify parent host attach plumbing still live"
+    if [ ! -S "${PARENT_ATTACH_SOCKET}" ]; then
+        printf 'parent attach socket missing at %s after nested smoke\n' \
+            "${PARENT_ATTACH_SOCKET}" >&2
+        exit 1
+    fi
+    if ! sudo test -r "${PARENT_ATTACH_METADATA}"; then
+        printf 'parent attach metadata unreadable at %s after nested smoke\n' \
+            "${PARENT_ATTACH_METADATA}" >&2
+        exit 1
+    fi
+    echo "parent attach socket ${PARENT_ATTACH_SOCKET} still a socket; metadata still readable"
+fi


### PR DESCRIPTION
## Summary

- Make `make dev-init` a first-class workflow inside a `kukeon-dev-root` cell again. The prior refusal gate (PR #546, closed) is replaced with a nested-safe path that supports the contributor workflow by default — no opt-in env var — and verifies the parent host's attach plumbing remains intact when the script exits.
- Same `/.kukeon/bin/kuketty` probe as #546 (`internal/ctr.AttachableBinaryPath`) detects the nested case. When nested, route the daemon socket to `/run/kukeon-dev/kukeond.sock` so the nested kukeond's lifecycle never touches the parent's `/run/kukeon/tty/...` bind: `KUKEON_HOST` is exported so every `kuke` client invocation dials the per-nest socket, and a minimal ServerConfiguration YAML threads `spec.socket` into `kuke init` (the daemon-side `KUKEOND_SOCKET` env var is intentionally not env-bound for the CLI, so `--server-configuration` is the supported channel).
- Defense-in-depth on the parent side: `internal/ctr/attachable.go`'s `withAttachableMounts` now pins the `/run/kukeon/tty` bind to `rprivate` so any nested kukeond's `/run/kukeon` mount events can never propagate back through the bind. New unit assertion in `internal/ctr/attachable_test.go` locks the option down.
- Pre-flight snapshots the parent's `/run/kukeon/tty/socket` and `/.kukeon/kuketty/metadata.json`; an EXIT trap (registered before any state mutation, so it survives early failures during build/init) re-stats them and fails loud if anything moved. The smoke section additionally re-verifies the parent's bind after the disposable-cell smoke completes, surfacing a regression inline rather than opaquely at exit.

## Design notes for the reviewer

- The issue offered three candidate directions (per-nest socket, `rprivate` on the parent bind, post-flight check). This PR layers all three — they compose. The per-nest socket is the structural fix; `rprivate` is a parent-side belt-and-braces that benefits *all* future attachable cells (existing cells must be recreated to pick it up); the post-flight check guards against future regressions in either of the first two.
- `sudo --preserve-env=KUKEON_HOST` is added to every `sudo ./kuke ...` invocation so the export reaches the privileged child. The host-run path (probe absent) is unchanged: `INIT_EXTRA_ARGS` stays empty, `KUKEON_HOST` is not exported, the trap function returns 0 early.
- `kuke daemon reset`'s socket+pid cleanup still uses the default `/run/kukeon` socket dir (its `KUKEOND_SOCKET` viper key has no CLI env binding). In the nested case it no-ops on missing files; the next daemon start handles the stale `/run/kukeon-dev/kukeond.{sock,pid}` via the existing `removeStaleSocket` step in `internal/daemon/server.go:109`, so no script-side cleanup is needed.

## Test plan

- [x] `make test` — full Go unit test suite, all packages pass (including the new `rprivate` assertion in `internal/ctr/attachable_test.go`).
- [x] `go build ./...` and `go vet ./...` — clean.
- [x] `bash -n scripts/dev-init.sh` — syntax OK.
- [x] `pre-commit run --files scripts/dev-init.sh internal/ctr/attachable.go internal/ctr/attachable_test.go` — clean (golangci-lint auto-wrapped one long `t.Errorf`; re-ran clean after).
- [x] End-to-end `bash scripts/dev-init.sh` *inside this nested `kukeon-dev-root` dev container* (started containerd + docker first, then ran the full script). Tail confirms: nested detection fires, daemon listens on `/run/kukeon-dev/kukeond.sock`, `applyKukeonOwnership` chowns `/run/kukeon-dev` (not the parent's `/run/kukeon`), daemon parity check matches, the kuketty-wrapped attach smoke succeeds, AC#5 in-script verification prints `parent attach socket /run/kukeon/tty/socket still a socket; metadata still readable`, EXIT-trap post-flight prints `post-flight: parent attach plumbing at /run/kukeon/tty/socket still intact`.
- [ ] `make dev-init` end-to-end smoke on the *host* (non-nested) — not run; this PR's change keeps the host-run path unchanged (nested detection is a single `[ -e ${NESTED_PROBE} ]` branch), and the dev container is exactly the environment that exercises the new branch. Worth re-running on the parent host pre-merge to confirm the host path still produces the documented daemon-parity tail.

Closes #547