### PR TITLE
feat: env-bind KUKEOND_SOCKET on kuke CLI to match daemon-side reach

### DIFF
--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -238,6 +238,9 @@ func loadConfig() error {
 	_ = config.KUKEON_ROOT_HOST.BindEnv()
 	_ = config.KUKEON_ROOT_CONTAINERD_SOCKET.BindEnv()
 
+	_ = config.KUKEOND_SOCKET.BindEnv()
+	_ = config.KUKEOND_SOCKET_GID.BindEnv()
+
 	_ = config.KUKEON_ROOT_RUN_PATH.BindEnv()
 	if viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey) == "" {
 		viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, config.DefaultRunPath())

--- a/cmd/kuke/kuke_test.go
+++ b/cmd/kuke/kuke_test.go
@@ -284,6 +284,31 @@ func TestLoadConfigPreservesExplicitValues(t *testing.T) {
 	}
 }
 
+// TestLoadConfigBindsKukeondSocketEnv locks down the env binding for
+// KUKEOND_SOCKET / KUKEOND_SOCKET_GID added to mirror the daemon-side
+// binds (cmd/kukeond/kukeond.go:bindEnvVars). Without these, `kuke init`'s
+// applyServerConfiguration env-gate at cmd/kuke/init/init.go:216 sees the
+// env var, skips the YAML write, but viper has no binding to read it back
+// — so the resolved socket path silently falls through to the default and
+// `kuke daemon reset`'s resolveSocketDir cleans the wrong directory.
+func TestLoadConfigBindsKukeondSocketEnv(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	t.Setenv(config.KUKEOND_SOCKET.EnvVar(), "/run/kukeon-dev/kukeond.sock")
+	t.Setenv(config.KUKEOND_SOCKET_GID.EnvVar(), "1234")
+
+	viper.Reset()
+	if err := kuke.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	if got := viper.GetString(config.KUKEOND_SOCKET.ViperKey); got != "/run/kukeon-dev/kukeond.sock" {
+		t.Errorf("KUKEOND_SOCKET: got %q, want %q", got, "/run/kukeon-dev/kukeond.sock")
+	}
+	if got := viper.GetString(config.KUKEOND_SOCKET_GID.ViperKey); got != "1234" {
+		t.Errorf("KUKEOND_SOCKET_GID: got %q, want %q", got, "1234")
+	}
+}
+
 func TestNewKukeCmdRun(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -52,8 +52,6 @@ PARENT_ATTACH_METADATA="/.kukeon/kuketty/metadata.json"
 NESTED_SOCKET_DIR="/run/kukeon-dev"
 NESTED_SOCKET_PATH="${NESTED_SOCKET_DIR}/kukeond.sock"
 NESTED_HOST_URI="unix://${NESTED_SOCKET_PATH}"
-NESTED_SERVER_CONFIG=""
-INIT_EXTRA_ARGS=()
 
 if [ -e "${NESTED_PROBE}" ]; then
     step "Nested kukeon detected (${NESTED_PROBE} present)"
@@ -90,22 +88,12 @@ if [ -e "${NESTED_PROBE}" ]; then
     # `kuke purge`, etc. — without per-call --host overrides.
     export KUKEON_HOST="${NESTED_HOST_URI}"
 
-    # `kuke init` does not env-bind KUKEOND_SOCKET (the daemon-side
-    # variable), so the supported channel for steering the daemon socket
-    # at init time is `--server-configuration`. We write a minimal
-    # ServerConfiguration document with `spec.socket` only — every other
-    # field falls back to the daemon's hardcoded default, matching the
-    # default-host invocation everywhere else.
-    NESTED_SERVER_CONFIG="$(mktemp -t kukeon-dev-init-nested-server-config.XXXXXX.yaml)"
-    cat > "${NESTED_SERVER_CONFIG}" <<EOF
-apiVersion: v1beta1
-kind: ServerConfiguration
-metadata:
-  name: kukeon-dev-init-nested
-spec:
-  socket: ${NESTED_SOCKET_PATH}
-EOF
-    INIT_EXTRA_ARGS+=("--server-configuration" "${NESTED_SERVER_CONFIG}")
+    # KUKEOND_SOCKET steers the daemon-side socket path read by `kuke
+    # init` (when seeding the kukeond cell's serve args) and `kuke daemon
+    # reset` (when resolving which kukeond.{sock,pid} to clean up). Both
+    # paths read it through viper via `KUKEOND_SOCKET.BindEnv` in
+    # cmd/kuke/kuke.go's loadConfig, so exporting it here is sufficient.
+    export KUKEOND_SOCKET="${NESTED_SOCKET_PATH}"
 fi
 
 # Post-flight: re-stat the parent's attach socket and metadata. Runs on
@@ -192,14 +180,13 @@ if [ ! -d "${SYSTEM_REALM_DIR}" ]; then
     # of that pass may fail because the local image is not yet staged in
     # containerd. Tolerate that — the second init below recreates the
     # cell after the image load succeeds.
-    sudo --preserve-env=KUKEON_HOST ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
-        "${INIT_EXTRA_ARGS[@]}" \
+    sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
         || echo "first-pass init returned non-zero (expected before image is staged); continuing"
 fi
 
 if [ -d "${KUKEOND_CELL_DIR}" ]; then
     step "Reset prior kukeond cell"
-    sudo --preserve-env=KUKEON_HOST ./kuke daemon reset
+    sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke daemon reset
 else
     step "No prior kukeond cell at ${KUKEOND_CELL_DIR}; skipping reset"
 fi
@@ -208,8 +195,7 @@ step "Load ${LOCAL_TAG} into the kuke-system realm"
 sudo --preserve-env=KUKEON_HOST ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system --no-daemon
 
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
-sudo --preserve-env=KUKEON_HOST ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
-    "${INIT_EXTRA_ARGS[@]}"
+sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}"
 
 step "Daemon parity check (both must show identical output)"
 sudo --preserve-env=KUKEON_HOST ./kuke get realms
@@ -249,9 +235,6 @@ teardown_attach_smoke_state() {
 cleanup_attach_smoke() {
     rm -rf "${ATTACH_SMOKE_TMP}"
     teardown_attach_smoke_state
-    if [ -n "${NESTED_SERVER_CONFIG}" ]; then
-        rm -f "${NESTED_SERVER_CONFIG}"
-    fi
     # Issue #547 AC#4: the parent host's `/run/kukeon/tty` bind must
     # still be live before this script exits. Runs after the nested
     # daemon's smoke artifacts are torn down so we catch any late


### PR DESCRIPTION
## Summary

- Add `KUKEOND_SOCKET.BindEnv()` + `KUKEOND_SOCKET_GID.BindEnv()` to `cmd/kuke/kuke.go:loadConfig` so every `kuke` subcommand reads the daemon-side socket env consistently with how `kukeond serve` reads it. Closes the gap called out in `cmd/kuke/init/init.go:216`'s `!envSet(config.KUKEOND_SOCKET)` gate (which previously was half-wired: the env-presence gate fired but the value never landed in viper, so the default silently won).
- Simplify the `scripts/dev-init.sh` nested branch (AC#5): drop the `--server-configuration` YAML workaround and the `NESTED_SERVER_CONFIG` / `INIT_EXTRA_ARGS` plumbing in favor of a plain `export KUKEOND_SOCKET="${NESTED_SOCKET_PATH}"`. Add `KUKEOND_SOCKET` to `--preserve-env=` on the two sudo invocations that read it (`kuke init`, `kuke daemon reset`).

## Design notes for the reviewer

- **Test location.** The AC suggested adding the unit test in `cmd/kuke/init/init_test.go` or `cmd/kuke/daemon/reset/reset_test.go`. I placed it in `cmd/kuke/kuke_test.go` (where the binding actually lives — `TestLoadConfigBindsKukeondSocketEnv`) because verifying through `init` / `reset` would need an import cycle to invoke `kuke.LoadConfig`, and a test that calls `config.KUKEOND_SOCKET.BindEnv()` directly in the consumer package would not regress when `loadConfig` stops calling it. The new test sets both env vars, runs `LoadConfig`, and asserts viper resolves the env values — which is the precise regression guard. Push back if you'd rather see it duplicated downstream.

## Test plan

- [x] `make test` — full Go test suite, all green (CI-parity target per repo Makefile `test:`).
- [x] `go build ./...` — compile clean.
- [x] `go vet ./...` — clean.
- [x] New unit test: `go test ./cmd/kuke/ -run TestLoadConfigBindsKukeondSocketEnv -v` → PASS.
- [x] `make dev-init` smoke (nested branch, since this dev host is itself a nested kukeon — `/.kukeon/bin/kuketty` probe present). End-to-end run exercised the new env path: bootstrap log line `kukeond is ready (unix:///run/kukeon-dev/kukeond.sock)` and `socket "/run/kukeon-dev/kukeond.sock": chown root:kukeon mode 0o0660` both confirm the daemon was steered through `KUKEOND_SOCKET=` rather than the YAML workaround. Daemon parity check (both `kuke get realms` and `--no-daemon` produced the canonical two-row output). `kuke attach` smoke against a kuketty-wrapped cell passed, and the post-flight check confirmed the parent host's `/run/kukeon/tty/socket` plumbing was undisturbed.

## Acceptance criteria

- [x] `KUKEOND_SOCKET` and `KUKEOND_SOCKET_GID` are env-bound in `cmd/kuke/kuke.go:loadConfig`.
- [x] `KUKEOND_SOCKET=/run/kukeon-dev/kukeond.sock sudo --preserve-env=KUKEOND_SOCKET ./kuke init …` resolves `socketPath` to `/run/kukeon-dev/kukeond.sock`. Verified via dev-init nested smoke — bootstrap output shows `kukeond is ready (unix:///run/kukeon-dev/kukeond.sock)` and the chown applies to the per-env path.
- [x] `KUKEOND_SOCKET=… sudo --preserve-env=KUKEOND_SOCKET ./kuke daemon reset` removes `kukeond.{sock,pid}` from the per-env dir. Verified via dev-init nested smoke — `==> Reset prior kukeond cell` succeeded against `/run/kukeon-dev/`.
- [x] Unit test locking the binding down (`TestLoadConfigBindsKukeondSocketEnv` in `cmd/kuke/kuke_test.go`).
- [x] Optional `scripts/dev-init.sh` cleanup: nested branch now uses `export KUKEOND_SOCKET=` instead of the `--server-configuration` YAML.

Closes #549