### PR TITLE
refactor: retire --no-daemon from kuke image commands per #226

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ sudo usermod -aG kukeon $USER
 kuke get realms
 ```
 
-Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, and any command run with the `--no-daemon` flag.
+Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), and any command run with the `--no-daemon` flag.
 
 ### Autocomplete
 

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -665,8 +665,7 @@ func TestDaemonReset_GracefulTimeoutEscalatesToKill(t *testing.T) {
 // TestDaemonReset_NonRootIsRejected confirms the fail-fast UID gate rejects
 // non-root invocations before any side effect (cell lookup, sock/pid file
 // removal, --purge-system rm -rf). Symmetric with the same guard on
-// `kuke init`, `kuke image load --no-daemon`, and `kuke doctor cgroups
-// --probe`.
+// `kuke init`, `kuke image load`, and `kuke doctor cgroups --probe`.
 func TestDaemonReset_NonRootIsRejected(t *testing.T) {
 	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
 	t.Cleanup(restore)

--- a/cmd/kuke/image/delete.go
+++ b/cmd/kuke/image/delete.go
@@ -52,10 +52,7 @@ func NewDeleteCmd() *cobra.Command {
 				return errdefs.ErrImageNotFound
 			}
 
-			client, err := resolveClient(cmd)
-			if err != nil {
-				return err
-			}
+			client := resolveClient(cmd)
 			defer func() { _ = client.Close() }()
 
 			res, err := client.DeleteImage(cmd.Context(), realm, ref)

--- a/cmd/kuke/image/delete_test.go
+++ b/cmd/kuke/image/delete_test.go
@@ -134,7 +134,7 @@ func runDelete(t *testing.T, fake *fakeDeleteClient, args []string) (string, err
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, image.MockControllerKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, image.MockControllerKey{}, image.Client(fake))
 	cmd.SetContext(ctx)
 	cmd.SetArgs(args)
 	err := cmd.Execute()
@@ -142,9 +142,21 @@ func runDelete(t *testing.T, fake *fakeDeleteClient, args []string) (string, err
 }
 
 type fakeDeleteClient struct {
-	kukeonv1.FakeClient
-
 	deleteImageFn func(realm, ref string) (kukeonv1.DeleteImageResult, error)
+}
+
+func (f *fakeDeleteClient) Close() error { return nil }
+
+func (f *fakeDeleteClient) LoadImage(context.Context, string, []byte) (kukeonv1.LoadImageResult, error) {
+	return kukeonv1.LoadImageResult{}, errors.New("unexpected LoadImage call")
+}
+
+func (f *fakeDeleteClient) ListImages(context.Context, string) (kukeonv1.ListImagesResult, error) {
+	return kukeonv1.ListImagesResult{}, errors.New("unexpected ListImages call")
+}
+
+func (f *fakeDeleteClient) GetImage(context.Context, string, string) (kukeonv1.GetImageResult, error) {
+	return kukeonv1.GetImageResult{}, errors.New("unexpected GetImage call")
 }
 
 func (f *fakeDeleteClient) DeleteImage(_ context.Context, realm, ref string) (kukeonv1.DeleteImageResult, error) {

--- a/cmd/kuke/image/get.go
+++ b/cmd/kuke/image/get.go
@@ -55,10 +55,7 @@ func NewGetCmd() *cobra.Command {
 				return err
 			}
 
-			client, err := resolveClient(cmd)
-			if err != nil {
-				return err
-			}
+			client := resolveClient(cmd)
 			defer func() { _ = client.Close() }()
 
 			if len(args) > 0 && strings.TrimSpace(args[0]) != "" {

--- a/cmd/kuke/image/get_test.go
+++ b/cmd/kuke/image/get_test.go
@@ -159,7 +159,7 @@ func runGet(t *testing.T, fake *fakeImageClient, args []string) (string, error) 
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, image.MockControllerKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, image.MockControllerKey{}, image.Client(fake))
 	cmd.SetContext(ctx)
 	cmd.SetArgs(args)
 	err := cmd.Execute()
@@ -167,10 +167,14 @@ func runGet(t *testing.T, fake *fakeImageClient, args []string) (string, error) 
 }
 
 type fakeImageClient struct {
-	kukeonv1.FakeClient
-
 	listImagesFn func(realm string) (kukeonv1.ListImagesResult, error)
 	getImageFn   func(realm, ref string) (kukeonv1.GetImageResult, error)
+}
+
+func (f *fakeImageClient) Close() error { return nil }
+
+func (f *fakeImageClient) LoadImage(context.Context, string, []byte) (kukeonv1.LoadImageResult, error) {
+	return kukeonv1.LoadImageResult{}, errors.New("unexpected LoadImage call")
 }
 
 func (f *fakeImageClient) ListImages(_ context.Context, realm string) (kukeonv1.ListImagesResult, error) {
@@ -185,4 +189,8 @@ func (f *fakeImageClient) GetImage(_ context.Context, realm, ref string) (kukeon
 		return kukeonv1.GetImageResult{}, errors.New("unexpected GetImage call")
 	}
 	return f.getImageFn(realm, ref)
+}
+
+func (f *fakeImageClient) DeleteImage(context.Context, string, string) (kukeonv1.DeleteImageResult, error) {
+	return kukeonv1.DeleteImageResult{}, errors.New("unexpected DeleteImage call")
 }

--- a/cmd/kuke/image/image.go
+++ b/cmd/kuke/image/image.go
@@ -16,11 +16,71 @@
 
 // Package image hosts the `kuke image` parent command and its subcommands:
 // `load` (#200), `get` (#211), and `delete` (#212).
+//
+// `kuke image *` is the canonical example of the "daemon-independent,
+// in-process by design" command category captured in #217: every subcommand
+// wraps containerd's image API directly. Whether `kukeond` is running has
+// no effect on their semantics — they manipulate containerd content, not
+// `/opt/kukeon/<realm>/` state — so they always construct a local
+// in-process Client. The root persistent `--no-daemon` flag is ignored
+// here (#226).
 package image
 
 import (
+	"context"
+	"io"
+	"log/slog"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/client/local"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+// MockControllerKey injects a mock Client via context for tests. Shared by
+// every `kuke image *` subcommand so a single per-test fake can wire up
+// load/get/delete behavior together.
+type MockControllerKey struct{}
+
+// Client is the narrow surface every `kuke image *` subcommand uses. It is
+// satisfied by `*local.Client` (the in-process containerd-backed client)
+// and by per-test fakes injected via MockControllerKey. There is no RPC
+// implementation by design — see the package doc.
+type Client interface {
+	io.Closer
+
+	LoadImage(ctx context.Context, realm string, tarball []byte) (kukeonv1.LoadImageResult, error)
+	ListImages(ctx context.Context, realm string) (kukeonv1.ListImagesResult, error)
+	GetImage(ctx context.Context, realm, ref string) (kukeonv1.GetImageResult, error)
+	DeleteImage(ctx context.Context, realm, ref string) (kukeonv1.DeleteImageResult, error)
+}
+
+// resolveClient returns the Client every `kuke image *` subcommand uses.
+// Tests inject a fake via MockControllerKey; otherwise the result is a
+// fresh in-process local.Client wired to the root persistent --run-path
+// and --containerd-socket flags. The root persistent --no-daemon flag is
+// not consulted — image commands are in-process by design (#226).
+//
+// The logger fallback (a discard handler when LoggerFromCmd cannot find one
+// in the command context) makes this safe to call in tests that drive the
+// cobra cmd directly without seeding `types.CtxLogger`. There is no error
+// return because every branch produces a usable Client.
+func resolveClient(cmd *cobra.Command) Client {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(Client); ok {
+		return mockClient
+	}
+	logger, err := kukshared.LoggerFromCmd(cmd)
+	if err != nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return local.New(cmd.Context(), logger, controller.Options{
+		RunPath:          viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	})
+}
 
 // NewImageCmd builds the `kuke image` parent command and registers its
 // subcommands. Persistent flags on the root kuke command are inherited

--- a/cmd/kuke/image/load.go
+++ b/cmd/kuke/image/load.go
@@ -23,17 +23,12 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/eminwux/kukeon/cmd/config"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
-
-// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
-type MockControllerKey struct{}
 
 // NewLoadCmd builds the `kuke image load` subcommand. Either a positional
 // tarball path or `--from-docker <ref>` is required; passing both is a usage
@@ -47,14 +42,15 @@ func NewLoadCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// --no-daemon writes directly under /opt/kukeon/<realm>/…,
-			// which is root:kukeon after `kuke init`. Daemon-routed loads
-			// (the default) round-trip through kukeond and stay fine for
-			// `kukeon`-group rootless clients.
-			if viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey) {
-				if err := kukshared.RequireRoot("kuke image load --no-daemon"); err != nil {
-					return err
-				}
+			// `kuke image load` writes directly to containerd's content
+			// store as the in-process client; the containerd socket is
+			// root-only on a stock host. Fail fast under non-root euid
+			// with a friendly message rather than letting containerd
+			// surface an opaque EACCES later. The root persistent
+			// `--no-daemon` flag is ignored — load is in-process by
+			// design (#226).
+			if err := kukshared.RequireRoot("kuke image load"); err != nil {
+				return err
 			}
 
 			realm, err := cmd.Flags().GetString("realm")
@@ -77,10 +73,7 @@ func NewLoadCmd() *cobra.Command {
 				return err
 			}
 
-			client, err := resolveClient(cmd)
-			if err != nil {
-				return err
-			}
+			client := resolveClient(cmd)
 			defer func() { _ = client.Close() }()
 
 			result, err := client.LoadImage(cmd.Context(), realm, tarball)
@@ -157,13 +150,6 @@ func readFromDocker(cmd *cobra.Command, ref string) ([]byte, error) {
 		return nil, errdefs.ErrTarballRequired
 	}
 	return out, nil
-}
-
-func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
-	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
-		return mockClient, nil
-	}
-	return kukshared.ClientFromCmd(cmd)
 }
 
 func printLoadResult(cmd *cobra.Command, result kukeonv1.LoadImageResult) {

--- a/cmd/kuke/image/load_test.go
+++ b/cmd/kuke/image/load_test.go
@@ -27,16 +27,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eminwux/kukeon/cmd/config"
 	image "github.com/eminwux/kukeon/cmd/kuke/image"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
-	"github.com/spf13/viper"
 )
 
 func TestLoadCmd_FromFileDefaultRealm(t *testing.T) {
+	withRootEuid(t)
+
 	dir := t.TempDir()
 	tarPath := filepath.Join(dir, "img.tar")
 	want := []byte("oci-tarball-bytes")
@@ -74,6 +74,8 @@ func TestLoadCmd_FromFileDefaultRealm(t *testing.T) {
 }
 
 func TestLoadCmd_FromStdinExplicitRealm(t *testing.T) {
+	withRootEuid(t)
+
 	want := []byte("stdin-tarball")
 
 	var gotRealm string
@@ -98,6 +100,8 @@ func TestLoadCmd_FromStdinExplicitRealm(t *testing.T) {
 }
 
 func TestLoadCmd_FromDockerAndPositionalAreMutuallyExclusive(t *testing.T) {
+	withRootEuid(t)
+
 	fake := &fakeClient{
 		loadImageFn: func(string, []byte) (kukeonv1.LoadImageResult, error) {
 			t.Fatal("client should not be invoked")
@@ -115,6 +119,8 @@ func TestLoadCmd_FromDockerAndPositionalAreMutuallyExclusive(t *testing.T) {
 }
 
 func TestLoadCmd_NoSourceIsAnError(t *testing.T) {
+	withRootEuid(t)
+
 	fake := &fakeClient{}
 	_, err := runLoad(t, fake, nil)
 	if err == nil {
@@ -126,6 +132,8 @@ func TestLoadCmd_NoSourceIsAnError(t *testing.T) {
 }
 
 func TestLoadCmd_ClientErrorPropagates(t *testing.T) {
+	withRootEuid(t)
+
 	dir := t.TempDir()
 	tarPath := filepath.Join(dir, "img.tar")
 	if err := os.WriteFile(tarPath, []byte("x"), 0o600); err != nil {
@@ -143,14 +151,12 @@ func TestLoadCmd_ClientErrorPropagates(t *testing.T) {
 	}
 }
 
-// TestLoadCmd_NoDaemonRequiresRoot pins the fail-fast UID gate that fires
-// only when --no-daemon (KUKEON_NO_DAEMON=true) is set. The daemon-routed
-// default path stays unrestricted so `kukeon`-group rootless clients keep
-// working — that is covered by every other test in this file, none of which
-// set the flag.
-func TestLoadCmd_NoDaemonRequiresRoot(t *testing.T) {
-	t.Cleanup(viper.Reset)
-	viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, true)
+// TestLoadCmd_RequiresRoot pins the unconditional UID gate that fires on
+// every invocation (no longer tied to --no-daemon, since image commands are
+// in-process by design per #226). The gate is the friendly fail-fast that
+// keeps non-root operators from hitting an opaque EACCES later in the
+// containerd write path.
+func TestLoadCmd_RequiresRoot(t *testing.T) {
 	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
 	t.Cleanup(restore)
 
@@ -169,17 +175,25 @@ func TestLoadCmd_NoDaemonRequiresRoot(t *testing.T) {
 
 	_, err := runLoad(t, fake, []string{tarPath})
 	if err == nil {
-		t.Fatal("kuke image load --no-daemon returned nil under euid=1000, want ErrMustRunAsRoot")
+		t.Fatal("kuke image load returned nil under euid=1000, want ErrMustRunAsRoot")
 	}
 	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
 		t.Fatalf("error does not wrap ErrMustRunAsRoot: %v", err)
 	}
-	if !strings.Contains(err.Error(), "kuke image load --no-daemon") {
+	if !strings.Contains(err.Error(), "kuke image load") {
 		t.Errorf("error does not name the subcommand: %v", err)
 	}
 }
 
 // --- helpers ---
+
+// withRootEuid stubs the euid probe so the RequireRoot gate at the top of
+// every image-write subcommand passes under any test runner UID.
+func withRootEuid(t *testing.T) {
+	t.Helper()
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	t.Cleanup(restore)
+}
 
 func runLoad(t *testing.T, fake *fakeClient, args []string) (string, error) {
 	t.Helper()
@@ -198,7 +212,7 @@ func runLoadWithStdin(t *testing.T, fake *fakeClient, args []string, stdin io.Re
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, image.MockControllerKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, image.MockControllerKey{}, image.Client(fake))
 	cmd.SetContext(ctx)
 	cmd.SetArgs(args)
 	err := cmd.Execute()
@@ -206,14 +220,26 @@ func runLoadWithStdin(t *testing.T, fake *fakeClient, args []string, stdin io.Re
 }
 
 type fakeClient struct {
-	kukeonv1.FakeClient
-
 	loadImageFn func(realm string, tarball []byte) (kukeonv1.LoadImageResult, error)
 }
+
+func (f *fakeClient) Close() error { return nil }
 
 func (f *fakeClient) LoadImage(_ context.Context, realm string, tarball []byte) (kukeonv1.LoadImageResult, error) {
 	if f.loadImageFn == nil {
 		return kukeonv1.LoadImageResult{}, errors.New("unexpected LoadImage call")
 	}
 	return f.loadImageFn(realm, tarball)
+}
+
+func (f *fakeClient) ListImages(context.Context, string) (kukeonv1.ListImagesResult, error) {
+	return kukeonv1.ListImagesResult{}, errors.New("unexpected ListImages call")
+}
+
+func (f *fakeClient) GetImage(context.Context, string, string) (kukeonv1.GetImageResult, error) {
+	return kukeonv1.GetImageResult{}, errors.New("unexpected GetImage call")
+}
+
+func (f *fakeClient) DeleteImage(context.Context, string, string) (kukeonv1.DeleteImageResult, error) {
+	return kukeonv1.DeleteImageResult{}, errors.New("unexpected DeleteImage call")
 }

--- a/cmd/kuke/shared/root.go
+++ b/cmd/kuke/shared/root.go
@@ -41,8 +41,8 @@ func SetGeteuidForTesting(f func() int) func() {
 }
 
 // RequireRoot is the fail-fast UID gate used by direct-write subcommands
-// (kuke init, kuke daemon reset, kuke image load --no-daemon, kuke doctor
-// cgroups --probe). When the effective UID is non-zero it returns an error
+// (kuke init, kuke daemon reset, kuke image load, kuke doctor cgroups
+// --probe). When the effective UID is non-zero it returns an error
 // wrapping errdefs.ErrMustRunAsRoot that names the subcommand and suggests
 // re-running under `sudo`, so operators see a clear cause instead of a
 // confusing "operation not permitted" several phases in. Daemon-routed

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -230,7 +230,9 @@ sudo kuke image delete --realm default <ref>                    # alias: rm, rem
 - `--from-docker <ref>` shells out to `docker save`; if the docker daemon is unreachable or the ref is unknown, the command exits non-zero with the docker error surfaced (e.g. `No such image`).
 - `kuke image get --realm <r>` exits 0 even when the namespace is empty; the CLI prints a "No images found in realm" line rather than failing.
 - `kuke image delete --realm <r> <missing-ref>` exits non-zero with an `image not found` message that names the realm and ref.
-- The dev-loop pattern is `kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon` so the image is in place before `kuke init` brings up the daemon. The `--no-daemon` flag is required here because the daemon is not yet running.
+- `kuke image *` is daemon-independent by design (#217, #226): every subcommand wraps containerd's image API directly in-process and ignores the root persistent `--no-daemon` flag. There is no "with daemon" mode — the daemon does not serve image RPCs.
+- `kuke image load` writes to containerd's content store and must run as root; it fails fast with a friendly `must run as root` error under non-root euid rather than letting containerd surface an opaque EACCES later. `kuke image get` and `kuke image delete` do not impose their own UID gate — they fail with whatever containerd returns if the socket is unreachable.
+- The dev-loop pattern is `sudo kuke image load --from-docker kukeon-local:dev --realm kuke-system`; the image lands in containerd before `kuke init` brings up the daemon, which is fine because image operations never go through `kukeond`.
 
 ## Workload lifecycle
 

--- a/docs/site/cli/kuke-image.md
+++ b/docs/site/cli/kuke-image.md
@@ -10,11 +10,11 @@ Every realm maps to its own containerd namespace (`<realm>.kukeon.io`). `kuke im
 
 ## Subcommands
 
-| Command            | What it does                                                        |
-| ------------------ | ------------------------------------------------------------------- |
-| `kuke image load`  | Import an OCI/docker image tarball into a realm's containerd namespace |
-| `kuke image get`   | List or describe images in a realm's containerd namespace            |
-| `kuke image delete`| Remove an image from a realm's containerd namespace                  |
+| Command             | What it does                                                           |
+| ------------------- | ---------------------------------------------------------------------- |
+| `kuke image load`   | Import an OCI/docker image tarball into a realm's containerd namespace |
+| `kuke image get`    | List or describe images in a realm's containerd namespace              |
+| `kuke image delete` | Remove an image from a realm's containerd namespace                    |
 
 ## kuke image load
 
@@ -24,12 +24,12 @@ kuke image load [tarball | -] [flags]
 
 Import an OCI/docker image tarball into the containerd namespace mapped to `--realm`. Pass a tarball path, `-` for stdin, or `--from-docker <ref>` to shell out to `docker save`.
 
-`kuke image load --no-daemon` (the bootstrap path used by `kuke init`) requires root; it fails fast with a clear remediation if you forget `sudo`.
+`kuke image *` is daemon-independent by design: every subcommand wraps containerd's image API directly in-process and ignores the root persistent `--no-daemon` flag — there is no "with daemon" mode for images. `kuke image load` always requires root because it writes to containerd's content store; it fails fast with a clear remediation if you forget `sudo`.
 
-| Flag            | Default   | Description                                                                                       |
-| --------------- | --------- | ------------------------------------------------------------------------------------------------- |
+| Flag            | Default   | Description                                                                                         |
+| --------------- | --------- | --------------------------------------------------------------------------------------------------- |
 | `--from-docker` | (empty)   | Image reference to pipe in via `docker save <ref>` (mutually exclusive with the positional tarball) |
-| `--realm`       | `default` | Target realm; the image lands in `<realm>.kukeon.io`                                              |
+| `--realm`       | `default` | Target realm; the image lands in `<realm>.kukeon.io`                                                |
 
 ### Examples
 
@@ -38,7 +38,7 @@ Import an OCI/docker image tarball into the containerd namespace mapped to `--re
 sudo kuke image load my-image.tar
 
 # Pipe a docker-build into kuke-system for a local kukeond image
-sudo kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
+sudo kuke image load --from-docker kukeon-local:dev --realm kuke-system
 
 # Stdin
 docker save myimage:latest | sudo kuke image load -
@@ -92,5 +92,5 @@ sudo kuke image delete docker.io/library/kukeon-local:dev --realm kuke-system
 
 ## Related
 
-- [kuke init](kuke-init.md) — uses `kuke image load --from-docker --no-daemon` in the local-dev bootstrap path
+- [kuke init](kuke-init.md) — uses `kuke image load --from-docker` in the local-dev bootstrap path
 - [Local development](../guides/local-dev.md) — first-time bootstrap with a local image

--- a/docs/site/cli/kuke.md
+++ b/docs/site/cli/kuke.md
@@ -30,7 +30,7 @@ The daemon endpoint. Today only the `unix://` scheme is supported. The `ssh://us
 
 Bypass `kukeond` and run the operation in-process. Requires root: the client now directly touches containerd, CNI, and cgroups.
 
-Use when the daemon is stopped, when bootstrapping (`kuke init` and `kuke image load --no-daemon` both run this path), or while debugging.
+Use when the daemon is stopped, when bootstrapping (`kuke init` runs this path), or while debugging. `kuke image *` is daemon-independent by design and is always in-process regardless of `--no-daemon`.
 
 Don't run two `--no-daemon` commands at the same time — they'll race on the same on-disk state.
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -63,7 +63,7 @@ sudo usermod -aG kukeon $USER
 # Log out and back in (or run `newgrp kukeon`) so the group takes effect.
 ```
 
-The rest of this guide assumes you have done that. If you skip this step, prepend `sudo` to every `kuke` command below. Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`, and any command run with `--no-daemon`.
+The rest of this guide assumes you have done that. If you skip this step, prepend `sudo` to every `kuke` command below. Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), `kuke doctor cgroups --probe`, and any command run with `--no-daemon`.
 
 ## 5. Verify with `kuke get`
 

--- a/docs/site/guides/init-and-reset.md
+++ b/docs/site/guides/init-and-reset.md
@@ -4,9 +4,9 @@ This guide covers the operations you'll run most often when bootstrapping, itera
 
 `kuke init` provisions **two** realms, each mapped to its own containerd namespace:
 
-| Realm         | Containerd namespace    | Purpose                                                                          |
-| ------------- | ----------------------- | -------------------------------------------------------------------------------- |
-| `default`     | `default.kukeon.io`     | User workloads. Created empty so `kuke create …` has a home.                     |
+| Realm         | Containerd namespace    | Purpose                                                                             |
+| ------------- | ----------------------- | ----------------------------------------------------------------------------------- |
+| `default`     | `default.kukeon.io`     | User workloads. Created empty so `kuke create …` has a home.                        |
 | `kuke-system` | `kuke-system.kukeon.io` | System workloads owned by kukeon itself (the `kukeond` daemon runs as a cell here). |
 
 The daemon lives at `kuke-system / kukeon / kukeon / kukeond` (realm / space / stack / cell). The `default` realm is deliberately left user-owned so `kuke purge --cascade` on it can never take down the daemon.
@@ -67,11 +67,11 @@ Rebuild and re-init:
 ```bash
 make kuke
 docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
-sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
+sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system
 sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
 ```
 
-`--no-daemon` on `kuke image load` is required here because the daemon is not yet running — the in-process controller talks to containerd directly. See [Local development](local-dev.md) for the full dev loop, which is wrapped end-to-end as `make dev-init`.
+`kuke image load` is daemon-independent by design — it always wraps containerd directly in-process — so the daemon does not need to be running to stage the bootstrap image. See [Local development](local-dev.md) for the full dev loop, which is wrapped end-to-end as `make dev-init`.
 
 ## Wipe a realm
 

--- a/docs/site/guides/local-dev.md
+++ b/docs/site/guides/local-dev.md
@@ -36,15 +36,15 @@ User data under `/opt/kukeon/default/**` is untouched across iterations; only th
 
 ## Make targets
 
-| Target              | What it does                                                                                                                  |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `make kuke`         | Build the `kuke` binary (same binary is dispatched as `kukeond` via `argv[0]`)                                                |
-| `make install-dev`  | Symlink the in-tree `kuke` and `kukeond` binaries into `$(INSTALL_PREFIX)` (default `/usr/local/bin`). Idempotent (`ln -sf`). |
-| `make uninstall-dev`| Remove both symlinks from `$(INSTALL_PREFIX)`.                                                                                |
-| `make dev-init`     | The full canonical loop above. Auto-invokes `install-dev` so `sudo kuke …` works from any directory.                          |
-| `make test`         | Run the Go unit test suite                                                                                                    |
-| `make e2e`          | Run end-to-end tests against a real containerd (requires root)                                                                |
-| `make lint`         | Run `golangci-lint` with the repo's config                                                                                    |
+| Target               | What it does                                                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `make kuke`          | Build the `kuke` binary (same binary is dispatched as `kukeond` via `argv[0]`)                                                |
+| `make install-dev`   | Symlink the in-tree `kuke` and `kukeond` binaries into `$(INSTALL_PREFIX)` (default `/usr/local/bin`). Idempotent (`ln -sf`). |
+| `make uninstall-dev` | Remove both symlinks from `$(INSTALL_PREFIX)`.                                                                                |
+| `make dev-init`      | The full canonical loop above. Auto-invokes `install-dev` so `sudo kuke …` works from any directory.                          |
+| `make test`          | Run the Go unit test suite                                                                                                    |
+| `make e2e`           | Run end-to-end tests against a real containerd (requires root)                                                                |
+| `make lint`          | Run `golangci-lint` with the repo's config                                                                                    |
 
 Override `INSTALL_PREFIX` for non-standard PATH layouts: `make install-dev INSTALL_PREFIX=$HOME/.local/bin`.
 
@@ -74,11 +74,11 @@ To run individual phases by hand — typically while debugging a single phase:
 
    ```bash
    docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
-   sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
+   sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system
    sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
    ```
 
-   `--no-daemon` is required because the daemon is not yet running.
+   `kuke image *` is daemon-independent by design — it always wraps containerd directly in-process — so this command works whether `kukeond` is running or not.
 
 4. **Run `kuke init`.**
 

--- a/docs/site/guides/troubleshooting.md
+++ b/docs/site/guides/troubleshooting.md
@@ -19,7 +19,7 @@ sudo usermod -aG kukeon $USER
 # Log out and back in so the new group membership is picked up.
 ```
 
-After logging back in, `id -nG | grep kukeon` should show the group. Daemon-routed commands now work without `sudo`. Commands that mutate the host (`kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`) still require root regardless.
+After logging back in, `id -nG | grep kukeon` should show the group. Daemon-routed commands now work without `sudo`. Commands that mutate the host (`kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), `kuke doctor cgroups --probe`) still require root regardless.
 
 ## `kuke doctor cgroups` exits non-zero
 
@@ -33,13 +33,13 @@ host cgroup pre-flight: 1 controller missing on /sys/fs/cgroup
 
 **What it means.** `kuke doctor cgroups` compares the cgroup's available + delegated controllers against the set `kukeon init` will enable on the `kukeond` bootstrap cell, then classifies each gap:
 
-| Status                 | Why it appears                                                                                                    | What to do                                                                                                |
-| ---------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `kernel-missing`       | The kernel was built without the named controller.                                                                | Rebuild the kernel with the controller compiled in, or switch hosts.                                      |
-| `needs-delegation`     | The controller is advertised in `cgroup.controllers` but not in `cgroup.subtree_control`. Operator can fix it.    | Run the `echo +<ctrl> \| sudo tee …` line the doctor prints.                                              |
-| `not-delegated`        | Probe write returned `EOPNOTSUPP`: the cgroup-namespace trap (advertised but not delegated by the parent).        | Escalate to whoever owns the parent cgroup — your own write cannot fix this.                              |
-| `threaded-subtree`     | Probe write returned `EOPNOTSUPP` and the target cgroup is `domain threaded` / `threaded`.                        | Domain-only controllers (memory, io, …) cannot be enabled in a threaded subtree; adjust the cgroup.type.  |
-| `internal-process`     | Probe write returned `EBUSY`: the cgroup-v2 no-internal-process rule (the cgroup holds processes).                | Move processes to a child cgroup, or accept thread-aware-only enablement at this scope.                   |
+| Status             | Why it appears                                                                                                 | What to do                                                                                               |
+| ------------------ | -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `kernel-missing`   | The kernel was built without the named controller.                                                             | Rebuild the kernel with the controller compiled in, or switch hosts.                                     |
+| `needs-delegation` | The controller is advertised in `cgroup.controllers` but not in `cgroup.subtree_control`. Operator can fix it. | Run the `echo +<ctrl> \| sudo tee …` line the doctor prints.                                             |
+| `not-delegated`    | Probe write returned `EOPNOTSUPP`: the cgroup-namespace trap (advertised but not delegated by the parent).     | Escalate to whoever owns the parent cgroup — your own write cannot fix this.                             |
+| `threaded-subtree` | Probe write returned `EOPNOTSUPP` and the target cgroup is `domain threaded` / `threaded`.                     | Domain-only controllers (memory, io, …) cannot be enabled in a threaded subtree; adjust the cgroup.type. |
+| `internal-process` | Probe write returned `EBUSY`: the cgroup-v2 no-internal-process rule (the cgroup holds processes).             | Move processes to a child cgroup, or accept thread-aware-only enablement at this scope.                  |
 
 `--probe` is the default — it disambiguates `not-delegated` and `threaded-subtree` from `needs-delegation`. Pass `--no-probe` for a strictly read-only check (useful in CI before you have root); the trap classifications won't fire.
 
@@ -119,7 +119,7 @@ sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon
 **Fix.** Use `kuke image load --from-docker` so the right namespace is created and populated in one step:
 
 ```bash
-sudo kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
+sudo kuke image load --from-docker kukeon-local:dev --realm kuke-system
 ```
 
 If you load with `ctr` directly, the target namespace must exist or `ctr images import` silently no-ops. Use `kuke image load` to avoid that footgun.

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -88,7 +88,7 @@ sudo usermod -aG kukeon $USER
 kuke get realms
 ```
 
-Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`, and any command run with the `--no-daemon` flag.
+Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), `kuke doctor cgroups --probe`, and any command run with the `--no-daemon` flag.
 
 ## Host supervisor
 

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -72,7 +72,7 @@ At minimum Kukeon needs `bridge`, `host-local`, `loopback`, and `portmap`.
 
 Two paths exist, depending on whether the command goes through `kukeond` or bypasses it:
 
-- **Direct host writes need root.** `kuke init`, `kuke daemon reset`, `kuke image load --no-daemon`, `kuke doctor cgroups --probe`, and anything else run with `--no-daemon` touch cgroups, netlink, containerd, or `/opt/kukeon` directly. Run them with `sudo`; otherwise they fail fast with a clear "must run as root" error before touching anything.
+- **Direct host writes need root.** `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), `kuke doctor cgroups --probe`, and anything else run with `--no-daemon` touch cgroups, netlink, containerd, or `/opt/kukeon` directly. Run them with `sudo`; otherwise they fail fast with a clear "must run as root" error before touching anything.
 - **Daemon-routed commands do not need root.** `kuke init` provisions a system `kukeon` group and sets the daemon socket at `/run/kukeon/kukeond.sock` to mode `0660 root:kukeon`. Adding a user to that group (`sudo usermod -aG kukeon $USER`, then re-login) is enough for `kuke get`, `kuke create`, `kuke apply`, `kuke delete`, `kuke log`, and `kuke attach` to work without `sudo`. Writes under `/opt/kukeon` still require root, but they go through the daemon.
 
 See [Getting Started → Daily use without sudo](../getting-started.md#daily-use-without-sudo) for the post-init steps.

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -15,8 +15,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package local provides an in-process kukeonv1.Client backed by a
-// controller.Exec. Used by the CLI in --no-daemon mode and by the daemon
-// itself when servicing RPC calls.
+// controller.Exec. Used by the CLI in --no-daemon mode (workload commands
+// per #222), by the `kuke image *` subcommands as the always-in-process
+// path (#226), and by the daemon itself when servicing RPC calls.
 package local
 
 import (

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -367,44 +367,6 @@ func (s *KukeonV1Service) ApplyDocuments(args *kukeonv1.ApplyDocumentsArgs, repl
 	return nil
 }
 
-// ---- Image ----
-
-func (s *KukeonV1Service) LoadImage(args *kukeonv1.LoadImageArgs, reply *kukeonv1.LoadImageReply) error {
-	result, err := s.core.LoadImage(s.ctx, args.Realm, args.Tarball)
-	reply.Result = result
-	reply.Err = kukeonv1.ToAPIError(err)
-	if err != nil {
-		s.logger.DebugContext(s.ctx, "LoadImage returned error", "error", err)
-	}
-	return nil
-}
-
-func (s *KukeonV1Service) ListImages(args *kukeonv1.ListImagesArgs, reply *kukeonv1.ListImagesReply) error {
-	result, err := s.core.ListImages(s.ctx, args.Realm)
-	reply.Result = result
-	reply.Err = kukeonv1.ToAPIError(err)
-	if err != nil {
-		s.logger.DebugContext(s.ctx, "ListImages returned error", "error", err)
-	}
-	return nil
-}
-
-func (s *KukeonV1Service) GetImage(args *kukeonv1.GetImageArgs, reply *kukeonv1.GetImageReply) error {
-	result, err := s.core.GetImage(s.ctx, args.Realm, args.Ref)
-	reply.Result = result
-	reply.Err = kukeonv1.ToAPIError(err)
-	if err != nil {
-		s.logger.DebugContext(s.ctx, "GetImage returned error", "error", err)
-	}
-	return nil
-}
-
-func (s *KukeonV1Service) DeleteImage(args *kukeonv1.DeleteImageArgs, reply *kukeonv1.DeleteImageReply) error {
-	result, err := s.core.DeleteImage(s.ctx, args.Realm, args.Ref)
-	reply.Result = result
-	reply.Err = kukeonv1.ToAPIError(err)
-	if err != nil {
-		s.logger.DebugContext(s.ctx, "DeleteImage returned error", "error", err)
-	}
-	return nil
-}
+// Image methods (LoadImage / ListImages / GetImage / DeleteImage) are
+// intentionally not served over RPC — `kuke image *` is daemon-independent
+// by design (#226). The CLI constructs a local in-process client directly.

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -272,9 +272,9 @@ var (
 	ErrSecretStagingFailed        = errors.New("failed to stage secret file for mount")
 
 	// ErrMustRunAsRoot is returned by direct-write subcommands (kuke init,
-	// kuke daemon reset, kuke image load --no-daemon, kuke doctor cgroups
-	// --probe) when invoked with a non-zero effective UID. Wrapped errors
-	// must name the subcommand and suggest `sudo`. Daemon-routed verbs
+	// kuke daemon reset, kuke image load, kuke doctor cgroups --probe)
+	// when invoked with a non-zero effective UID. Wrapped errors must
+	// name the subcommand and suggest `sudo`. Daemon-routed verbs
 	// (kuke get, kuke create, kuke apply, kuke delete, …) do not gate on
 	// this — those are the supported `kukeon`-group rootless-client path.
 	ErrMustRunAsRoot = errors.New("command must run as root")

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -85,22 +85,12 @@ type Client interface {
 	RefreshAll(ctx context.Context) (RefreshAllResult, error)
 	ApplyDocuments(ctx context.Context, rawYAML []byte) (ApplyDocumentsResult, error)
 
-	// LoadImage imports an OCI/docker image tarball into the named realm's
-	// containerd namespace. The tarball ships in-band; see LoadImageArgs.
-	LoadImage(ctx context.Context, realm string, tarball []byte) (LoadImageResult, error)
-
-	// ListImages enumerates images in the named realm's containerd
-	// namespace.
-	ListImages(ctx context.Context, realm string) (ListImagesResult, error)
-
-	// GetImage returns metadata for the named image ref in the named
-	// realm. errdefs.ErrImageNotFound is returned when the ref is absent.
-	GetImage(ctx context.Context, realm, ref string) (GetImageResult, error)
-
-	// DeleteImage removes the named image ref from the named realm's
-	// containerd namespace. errdefs.ErrImageNotFound is returned when
-	// the ref does not exist.
-	DeleteImage(ctx context.Context, realm, ref string) (DeleteImageResult, error)
+	// NOTE: image operations (LoadImage / ListImages / GetImage /
+	// DeleteImage) are intentionally NOT on this interface. They are
+	// daemon-independent by design (#226) and live on the in-process
+	// client (`*local.Client`) only — see the `cmd/kuke/image` package's
+	// `Client` interface, which the image subcommands use directly. The
+	// RPC daemon does not serve image methods.
 
 	Ping(ctx context.Context) error
 }
@@ -193,10 +183,6 @@ const (
 
 	MethodRefreshAll     = ServiceName + ".RefreshAll"
 	MethodApplyDocuments = ServiceName + ".ApplyDocuments"
-	MethodLoadImage      = ServiceName + ".LoadImage"
-	MethodListImages     = ServiceName + ".ListImages"
-	MethodGetImage       = ServiceName + ".GetImage"
-	MethodDeleteImage    = ServiceName + ".DeleteImage"
 
 	MethodPing = ServiceName + ".Ping"
 )

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -177,22 +177,6 @@ func (FakeClient) ApplyDocuments(context.Context, []byte) (ApplyDocumentsResult,
 	return ApplyDocumentsResult{}, ErrUnexpectedCall
 }
 
-func (FakeClient) LoadImage(context.Context, string, []byte) (LoadImageResult, error) {
-	return LoadImageResult{}, ErrUnexpectedCall
-}
-
-func (FakeClient) ListImages(context.Context, string) (ListImagesResult, error) {
-	return ListImagesResult{}, ErrUnexpectedCall
-}
-
-func (FakeClient) GetImage(context.Context, string, string) (GetImageResult, error) {
-	return GetImageResult{}, ErrUnexpectedCall
-}
-
-func (FakeClient) DeleteImage(context.Context, string, string) (DeleteImageResult, error) {
-	return DeleteImageResult{}, ErrUnexpectedCall
-}
-
 func (FakeClient) Ping(context.Context) error {
 	return ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -621,58 +621,6 @@ func (c *UnixClient) ApplyDocuments(ctx context.Context, rawYAML []byte) (ApplyD
 	return reply.Result, nil
 }
 
-// LoadImage implements Client.
-func (c *UnixClient) LoadImage(ctx context.Context, realm string, tarball []byte) (LoadImageResult, error) {
-	args := &LoadImageArgs{Realm: realm, Tarball: tarball}
-	reply := &LoadImageReply{}
-	if err := c.call(ctx, MethodLoadImage, args, reply); err != nil {
-		return LoadImageResult{}, err
-	}
-	if reply.Err != nil {
-		return reply.Result, FromAPIError(reply.Err)
-	}
-	return reply.Result, nil
-}
-
-// ListImages implements Client.
-func (c *UnixClient) ListImages(ctx context.Context, realm string) (ListImagesResult, error) {
-	args := &ListImagesArgs{Realm: realm}
-	reply := &ListImagesReply{}
-	if err := c.call(ctx, MethodListImages, args, reply); err != nil {
-		return ListImagesResult{}, err
-	}
-	if reply.Err != nil {
-		return reply.Result, FromAPIError(reply.Err)
-	}
-	return reply.Result, nil
-}
-
-// GetImage implements Client.
-func (c *UnixClient) GetImage(ctx context.Context, realm, ref string) (GetImageResult, error) {
-	args := &GetImageArgs{Realm: realm, Ref: ref}
-	reply := &GetImageReply{}
-	if err := c.call(ctx, MethodGetImage, args, reply); err != nil {
-		return GetImageResult{}, err
-	}
-	if reply.Err != nil {
-		return reply.Result, FromAPIError(reply.Err)
-	}
-	return reply.Result, nil
-}
-
-// DeleteImage implements Client.
-func (c *UnixClient) DeleteImage(ctx context.Context, realm, ref string) (DeleteImageResult, error) {
-	args := &DeleteImageArgs{Realm: realm, Ref: ref}
-	reply := &DeleteImageReply{}
-	if err := c.call(ctx, MethodDeleteImage, args, reply); err != nil {
-		return DeleteImageResult{}, err
-	}
-	if reply.Err != nil {
-		return reply.Result, FromAPIError(reply.Err)
-	}
-	return reply.Result, nil
-}
-
 // Ping implements Client.
 func (c *UnixClient) Ping(ctx context.Context) error {
 	args := &PingArgs{}

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -655,31 +655,25 @@ type ApplyResourceResult struct {
 }
 
 // ---- Image ----
+//
+// Image result types live here (and not on the RPC interface) so the in-
+// process `*local.Client` returned by the daemon-independent `kuke image *`
+// path (#226) can keep using a wire-compatible shape without depending on
+// internal/controller. The Args/Reply wire envelopes were retired with the
+// RPC handlers — the daemon does not serve image methods.
 
-// LoadImageArgs carries an OCI/docker image tarball plus the target realm.
-// The tarball ships as a byte slice (mirroring ApplyDocumentsArgs.RawYAML);
-// phase 1 sizes are bounded by the dev loop (≈100MB), so JSON-RPC roundtrip
-// cost is acceptable. Larger payloads will move to a streaming endpoint when
-// the multi-host story arrives.
-type LoadImageArgs struct {
-	Realm   string
-	Tarball []byte
-}
-
-type LoadImageReply struct {
-	Result LoadImageResult
-	Err    *APIError
-}
-
+// LoadImageResult reports the outcome of a `kuke image load` import: the
+// realm/namespace it landed in and the canonical image refs containerd
+// recorded.
 type LoadImageResult struct {
 	Realm     string
 	Namespace string
 	Images    []string
 }
 
-// ImageInfo is the wire view of one containerd image. Size is best-effort:
-// the daemon emits -1 when containerd cannot resolve the size locally so the
-// CLI can render "-" rather than "0 B".
+// ImageInfo is the rendered view of one containerd image. Size is best-
+// effort: -1 is emitted when containerd cannot resolve the size locally so
+// the CLI renders "-" rather than "0 B".
 type ImageInfo struct {
 	Name      string
 	Size      int64
@@ -687,17 +681,6 @@ type ImageInfo struct {
 	Digest    string
 	MediaType string
 	Labels    map[string]string
-}
-
-// ListImagesArgs is the wire request for ListImages.
-type ListImagesArgs struct {
-	Realm string
-}
-
-// ListImagesReply is the wire response for ListImages.
-type ListImagesReply struct {
-	Result ListImagesResult
-	Err    *APIError
 }
 
 // ListImagesResult lists the images present in a realm's containerd
@@ -708,35 +691,11 @@ type ListImagesResult struct {
 	Images    []ImageInfo
 }
 
-// GetImageArgs is the wire request for GetImage.
-type GetImageArgs struct {
-	Realm string
-	Ref   string
-}
-
-// GetImageReply is the wire response for GetImage.
-type GetImageReply struct {
-	Result GetImageResult
-	Err    *APIError
-}
-
 // GetImageResult carries the metadata of one named image in a realm.
 type GetImageResult struct {
 	Realm     string
 	Namespace string
 	Image     ImageInfo
-}
-
-// DeleteImageArgs is the wire request for DeleteImage.
-type DeleteImageArgs struct {
-	Realm string
-	Ref   string
-}
-
-// DeleteImageReply is the wire response for DeleteImage.
-type DeleteImageReply struct {
-	Result DeleteImageResult
-	Err    *APIError
 }
 
 // DeleteImageResult reports the outcome of a `kuke image delete` removal.

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -192,7 +192,9 @@ else
 fi
 
 step "Load ${LOCAL_TAG} into the kuke-system realm"
-sudo --preserve-env=KUKEON_HOST ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system --no-daemon
+# `kuke image load` is in-process by design (#226); --no-daemon is not
+# passed because the flag is a no-op for image subcommands.
+sudo --preserve-env=KUKEON_HOST ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system
 
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
 sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}"


### PR DESCRIPTION
## Summary

- `kuke image *` is daemon-independent by design (#217 category 3): every subcommand wraps containerd's image API directly in-process. The root persistent `--no-daemon` flag was meaningless on this path — it surfaced as user-visible noise and ambiguity about which mode actually ran. This PR makes the in-process path the only path and retires the vestigial daemon-routed code.
- The CLI image commands (`load`/`get`/`delete`) no longer consult `viper.GetBool(KUKEON_ROOT_NO_DAEMON)`. A new `cmd/kuke/image.Client` interface (just the four image methods + `io.Closer`) replaces `kukeonv1.Client` at the call sites; the in-process `*local.Client` satisfies it, and per-test fakes implement the same narrow surface. `MockControllerKey` moved out of `load.go` into `image.go` so all three subcommands share it.
- `kuke image load`'s UID gate is now unconditional (was conditional on `--no-daemon`). Since the command always writes to containerd's content store, fail-fast under non-root euid keeps the friendly "must run as root" remediation and avoids the opaque EACCES that would otherwise surface from the containerd write.
- The "vestigial daemon-routed code path" called out by the AC is the RPC layer: removed `LoadImage`/`ListImages`/`GetImage`/`DeleteImage` from the `kukeonv1.Client` interface, from the `UnixClient` RPC client, from the `KukeonV1Service` daemon handlers, from `FakeClient`, and the corresponding `MethodLoadImage`/`MethodListImages`/`MethodGetImage`/`MethodDeleteImage` constants plus `*Args`/`*Reply` wire envelopes. The result types (`LoadImageResult`/`ListImagesResult`/`GetImageResult`/`DeleteImageResult`/`ImageInfo`) stay in `pkg/api/kukeonv1` as the shared data shape between `*local.Client` and the CLI.
- `scripts/dev-init.sh` drops the now-redundant `--no-daemon` from its `kuke image load --from-docker` invocation. Docs that named `kuke image load --no-daemon` as a privileged command are reworded to `kuke image load` plus a one-line note that `--no-daemon` is ignored on image subcommands. See "Reinterpreted scope" below for the doc lane I deliberately did not touch.

## Reinterpreted scope (per CLAUDE.md "premise-rotted but inferable" rule)

- The issue body's Proposal enumerates `kuke image save`, `kuke image load`, `kuke image get`. There is no `save` subcommand — the package ships `load`/`get`/`delete`. The Acceptance Criteria says "all `kuke image *` cobra definitions", which is the canonical reading I followed: the change covers `load`/`get`/`delete`.
- `--no-daemon` is a persistent root flag, not bound per-image-subcommand. AC#1's "removed from all `kuke image *` cobra definitions" therefore means "image subcommands no longer act on `--no-daemon`" — not "drop the cobra flag definition", which would break workload commands that still consult the flag pending #222.
- `<project>/CLAUDE.md` still names `kuke image load --no-daemon` in the bootstrap-smoke section. Per CLAUDE.md hard rule "No \`CLAUDE.md\` edits in a code-fix PR", I am filing a separate \`chore:\` + \`enhancement\` follow-up issue to align it. The PR ships with that one known doc drift.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` green (full unit suite passes; image-package tests updated to use the narrow `image.Client` fakes)
- [x] `pre-commit run --files $(git diff --name-only HEAD)` green (golangci-lint, prettier, addlicense, go fmt, go-mod-tidy)
- [x] `make dev-init` smoke green end-to-end, including the daemon-parity check (both `kuke get realms` and `kuke get realms --no-daemon` produce identical output) and the `kuke image load --from-docker kukeon-local:dev --realm kuke-system` step now running without `--no-daemon`
- [x] Literal-flag-string grep: `grep -rn '"--no-daemon"' --include='*.go' --include='*.sh'` only matches `e2e/e2e_kuke_attach_test.go` (workload command, intentional — flag still exists at the root for non-image consumers)
- [ ] `make e2e` — not run locally; the e2e suite needs the host-level kuketty/network plumbing and is the CI's lane. The `make dev-init` smoke covered the realm + image-load + bootstrap path end-to-end on this host.

Closes #226