### PR TITLE
fix: promote --no-daemon when --run-path is explicit, unblocking nested e2e

### DIFF
--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -112,6 +112,8 @@ func NewKukeCmd() (*cobra.Command, error) {
 				}
 				return fmt.Errorf("%w: %w", errdefs.ErrConfig, err)
 			}
+
+			applyRunPathImpliesNoDaemon(cmd)
 			return nil
 		},
 		Run: func(cmd *cobra.Command, _ []string) {
@@ -319,6 +321,27 @@ func applyClientConfiguration(cmd *cobra.Command, spec v1beta1.ClientConfigurati
 	}
 	if spec.LogLevel != "" && !flagChanged(cmd, "log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
+	}
+}
+
+// applyRunPathImpliesNoDaemon promotes an explicit `--run-path` (flag or
+// `KUKEON_RUN_PATH` env) into `--no-daemon=true` when the operator did not
+// set `--no-daemon` themselves. The daemon ignores the client's run-path
+// (it serves whatever path it was started with), so the only way for a
+// caller-supplied `--run-path` to take effect is in-process. Without this
+// promotion, passing `--run-path /tmp/foo` silently dials the default
+// daemon socket and reads/writes someone else's run-path — the failure
+// mode that broke 40/75 e2e tests under per-test `--run-path` isolation.
+//
+// YAML-configured run-path does not trip this promotion: contributors
+// with a non-default ClientConfiguration shouldn't have their daemon
+// access silently disabled. Flag/env are explicit per-invocation intent;
+// YAML is ambient configuration.
+func applyRunPathImpliesNoDaemon(cmd *cobra.Command) {
+	runPathExplicit := flagChanged(cmd, "run-path") || envSet(config.KUKEON_ROOT_RUN_PATH)
+	noDaemonExplicit := flagChanged(cmd, "no-daemon") || envSet(config.KUKEON_ROOT_NO_DAEMON)
+	if runPathExplicit && !noDaemonExplicit {
+		viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, true)
 	}
 }
 

--- a/cmd/kuke/kuke_test.go
+++ b/cmd/kuke/kuke_test.go
@@ -465,3 +465,87 @@ func TestNewKukeCmdStreams(t *testing.T) {
 		t.Errorf("ErrOrStderr() not wired to os.Stderr: got %T", got)
 	}
 }
+
+// TestRunPathImpliesNoDaemon locks down the issue #554 fix: explicit
+// `--run-path` (flag or env) promotes `--no-daemon` to true, but only when
+// `--no-daemon` itself was not set. The daemon ignores the client's
+// run-path, so a caller passing `--run-path` and reaching a daemon dial
+// would silently read/write the daemon's path instead — the failure mode
+// that broke 40/75 e2e tests under per-test `--run-path` isolation.
+func TestRunPathImpliesNoDaemon(t *testing.T) {
+	tests := []struct {
+		name            string
+		setFlag         bool   // --run-path on the command line
+		setEnv          string // KUKEON_RUN_PATH in env ("" = unset)
+		setNoDaemonFlag bool   // --no-daemon on the command line (=false)
+		setNoDaemonEnv  string // KUKEON_NO_DAEMON in env ("" = unset)
+		wantNoDaemon    bool
+	}{
+		{
+			name:         "neither set leaves no-daemon at default",
+			wantNoDaemon: false,
+		},
+		{
+			name:         "run-path flag promotes no-daemon",
+			setFlag:      true,
+			wantNoDaemon: true,
+		},
+		{
+			name:         "run-path env promotes no-daemon",
+			setEnv:       "/tmp/foo",
+			wantNoDaemon: true,
+		},
+		{
+			name:            "explicit --no-daemon=false blocks promotion",
+			setFlag:         true,
+			setNoDaemonFlag: true,
+			wantNoDaemon:    false,
+		},
+		{
+			name:           "KUKEON_NO_DAEMON=false blocks promotion",
+			setFlag:        true,
+			setNoDaemonEnv: "false",
+			wantNoDaemon:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			viper.Reset()
+
+			if tc.setEnv != "" {
+				t.Setenv(config.KUKEON_ROOT_RUN_PATH.EnvVar(), tc.setEnv)
+			}
+			if tc.setNoDaemonEnv != "" {
+				t.Setenv(config.KUKEON_ROOT_NO_DAEMON.EnvVar(), tc.setNoDaemonEnv)
+			}
+
+			cmd, err := kuke.NewKukeCmd()
+			if err != nil {
+				t.Fatalf("NewKukeCmd() error = %v", err)
+			}
+
+			if tc.setFlag {
+				if setErr := cmd.PersistentFlags().Set("run-path", "/tmp/from-flag"); setErr != nil {
+					t.Fatalf("set --run-path: %v", setErr)
+				}
+			}
+			if tc.setNoDaemonFlag {
+				if setErr := cmd.PersistentFlags().Set("no-daemon", "false"); setErr != nil {
+					t.Fatalf("set --no-daemon: %v", setErr)
+				}
+			}
+
+			cmd.SetContext(context.Background())
+			if preErr := cmd.PersistentPreRunE(cmd, []string{}); preErr != nil {
+				t.Fatalf("PersistentPreRunE: %v", preErr)
+			}
+
+			got := viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey)
+			if got != tc.wantNoDaemon {
+				t.Errorf("KUKEON_NO_DAEMON: got %v, want %v", got, tc.wantNoDaemon)
+			}
+		})
+	}
+}

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/util/fs"
 )
 
 // TestKuke_Help tests kuke help command.
@@ -299,8 +300,13 @@ func TestKuke_DaemonReset_Flags(t *testing.T) {
 func TestKuke_DaemonReset_RoundTrip(t *testing.T) {
 	runPath := getRandomRunPath(t)
 
-	defaultRealmDir := filepath.Join(runPath, consts.KukeonDefaultRealmName)
-	systemRealmDir := filepath.Join(runPath, consts.KukeSystemRealmName)
+	// PR #489 (2026-05-14) moved the on-disk layout to <runPath>/data/<realm>
+	// via fs.MetadataRoot; the prior <runPath>/<realm> form silently passes
+	// "must not exist" negative checks but always fails the positive stats
+	// after `kuke init` populates the real path. Route through the helper
+	// so a future layout change cannot drift the assertion silently.
+	defaultRealmDir := fs.RealmMetadataDir(runPath, consts.KukeonDefaultRealmName)
+	systemRealmDir := fs.RealmMetadataDir(runPath, consts.KukeSystemRealmName)
 
 	t.Cleanup(func() {
 		// Best-effort host-level cleanup: a final reset --purge-system if the


### PR DESCRIPTION
## Summary

- The daemon ignores the client's `--run-path` (it serves whatever path it was started with), so any test that passes `--run-path <tempdir>` for per-test isolation and reaches a daemon dial silently reads/writes someone else's run-path. In the nested-dev-cell case that surfaces as 40/75 e2e tests failing.
- Wire option (b) from #554's finding #3 at the CLI layer: in the root `PersistentPreRunE`, after the YAML+env merge, promote an explicit `--run-path` (flag or `KUKEON_RUN_PATH` env) into `--no-daemon=true` when the operator did not set `--no-daemon` themselves. YAML-configured run-path is deliberately *not* a trigger — contributors with a non-default `ClientConfiguration` shouldn't have their daemon access silently disabled. Flag/env are explicit per-invocation intent; YAML is ambient configuration.
- Drive-by: fix the on-disk path layout in `TestKuke_DaemonReset_RoundTrip` — PR #489 (2026-05-14) moved the layout to `<runPath>/data/<realm>` via `fs.MetadataRoot`, but this test still joined `<runPath>/<realm>` directly. The negative ("must not exist") checks silently pass for both layouts; the positive ("must exist") checks after `kuke init` always failed under the new layout. Route through `fs.RealmMetadataDir` so a future layout change can't drift the assertion silently.

## Test plan

- [x] `go test ./cmd/kuke/ -run TestRunPathImpliesNoDaemon -v` — 5 sub-cases pass (neither set, run-path flag promotes, run-path env promotes, explicit `--no-daemon=false` blocks, `KUKEON_NO_DAEMON=false` blocks).
- [x] `make test` — full unit suite passes.
- [x] `make e2e` nested in a kuke-dev cell: **73/75 pass** (up from a 35/75 baseline before this change).
  - `TestKuke_Init_VerifyState` fails on a `busybox:latest` containerd image pull: `dial tcp: lookup registry-1.docker.io on 1.0.0.1:53: read udp ...: i/o timeout` — same env class as #554's listed obstacle #1 (cgo resolver workaround), unrelated to the `--no-daemon` change.
  - `TestKuke_CreateCell_VerifyState` fails on the positive `verifyCgroupPathExists` check at `e2e/e2e_kuke_cell_test.go:166`. The two sibling tests with identical setup (`TestKuke_DeleteCell_VerifyState`, `TestKuke_PurgeCell_VerifyState`) run in the same parallel batch and pass the same positive check — strongly suggests a flake in cgroup-creation timing under parallel load rather than a regression from this change.

## Deferred from this PR (per #554's ACs)

This PR lands option (b) only — the central fix for the failing-nested-e2e symptom #554 was filed to validate. The remaining AC items are out of scope here:

- **Docs (`docs/site/install/build-from-source.md:88-89`, `docs/site/guides/local-dev.md:46`):** The "disposable host" framing should drop once `make e2e` runs cleanly nested. The 73/75 result is a large step toward that but the two residual failures need triage first.
- **Nested kukeon-dev socket integration for `make e2e`:** The user's instruction was to *plan* it; the Makefile + nested-aware test helper change is a separate, reviewable diff. Per the analysis here, setting `KUKEOND_SOCKET=/run/kukeon-dev/kukeond.sock` in the e2e Makefile target would conflict with the parent dev cell's daemon at the same path. The clean design needs a third per-e2e-run socket path (or a `--run-path`-derived socket override in `kuke init`) and belongs in a focused follow-up.

I'll file the follow-up issues after this PR opens so the lineage stays visible after #554 auto-closes.

Closes #554