### PR TITLE
chore: drop --no-daemon from kuke image load in CLAUDE.md smoke section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ To run individual phases by hand — e.g. while debugging a single phase — inv
 
    ```bash
    docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
-   sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system --no-daemon
+   sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system
    sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
    ```
 


### PR DESCRIPTION
## Summary
Aligns the project `CLAUDE.md` "Local smoke test → Manual phases" step 3 with PR #551, which retired `--no-daemon` on `kuke image *` subcommands (they are daemon-independent by design — #217 category 3).

The flag still parses on `kuke image load` as a silent no-op (the persistent root flag is workload-command-scoped until #222 ships), but the smoke example was misleading: a contributor following manual phase 3 would conclude `--no-daemon` is meaningful for `image load`, which #551 explicitly retired.

## Diff
One line. The only literal `--no-daemon` reference on a `kuke image` invocation in the file. The line-56 `kuke get realms --no-daemon` daemon-parity check is unaffected (workload-command lane, tracked under #222).

## Test plan
- [x] `grep -n -- "--no-daemon" CLAUDE.md` returns only line 56 (the daemon-parity check) after the change.
- [x] No code or test changes.

Closes #552