### PR TITLE
docs: document nested vs. bare-host socket modes in make dev-init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,20 +36,7 @@ When a change touches the build path, the daemon, or anything under `/opt/kukeon
 
 A failure in either daemon surfaces as a confusing error several phases into the script — `dial unix /var/run/docker.sock: connect: no such file or directory` for docker, or `failed to connect to containerd: ... dial unix:///run/containerd/containerd.sock: timeout` for containerd. Bring both up before invoking `make dev-init` to skip the rabbit hole.
 
-### Nested vs. bare host: where the kukeond socket lands
-
-`scripts/dev-init.sh` runs in one of two modes, picked automatically at the top of the script by probing for `/.kukeon/bin/kuketty` — the canonical bind the daemon stages into every attachable cell (see `internal/ctr.AttachableBinaryPath`):
-
-| Mode                                  | Probe                          | Host socket                    | How it's steered                                                                                                    |
-| ------------------------------------- | ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **Bare host** (probe absent)          | `/.kukeon/bin/kuketty` missing | `/run/kukeon/kukeond.sock`     | Daemon's compiled-in default; no env vars exported.                                                                 |
-| **Nested in a kukeon-dev-root cell**  | `/.kukeon/bin/kuketty` present | `/run/kukeon-dev/kukeond.sock` | Script exports `KUKEON_HOST=unix:///run/kukeon-dev/kukeond.sock` and `KUKEOND_SOCKET=/run/kukeon-dev/kukeond.sock`. |
-
-`KUKEON_HOST` is read via viper in `cmd/kuke/kuke.go`'s `loadConfig` and steers every `kuke` client call. `KUKEOND_SOCKET` steers the daemon-side serve args `kuke init` seeds for the kukeond cell *and* the cleanup path in `kuke daemon reset`. Both flow into sudo'd children via `--preserve-env=KUKEON_HOST,KUKEOND_SOCKET` on every relevant invocation in the script.
-
-The nested-mode redirect exists because the parent daemon bind-mounts `/run/kukeon/tty/<container>/` into the nested cell at `/run/kukeon/tty/`. A nested daemon publishing under `/run/kukeon/` would share that parent directory and break the host's `kuke attach <this-cell>` plumbing on script exit (issues #547, #545). Publishing under `/run/kukeon-dev/` keeps the two lifecycles disjoint. The script's `EXIT` trap (`verify_parent_attach_intact`) sha256-snapshots the parent's `/.kukeon/kuketty/metadata.json` up front and re-checks it on every exit path, so a botched re-bootstrap fails loud here rather than at the operator's next `kuke attach`.
-
-The source of truth for the probe and env-var contract is `scripts/dev-init.sh` lines 38-97.
+When run from inside a `kukeon-dev-root` cell (the canonical agent workflow), `make dev-init` automatically redirects the kukeond socket to `/run/kukeon-dev/` so it doesn't clobber the parent host's `kuke attach` plumbing — see [`docs/dev-init.md`](docs/dev-init.md) for the full bare-host vs. nested-mode contract.
 
 ### One-shot: `make dev-init`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,21 @@ When a change touches the build path, the daemon, or anything under `/opt/kukeon
 
 A failure in either daemon surfaces as a confusing error several phases into the script — `dial unix /var/run/docker.sock: connect: no such file or directory` for docker, or `failed to connect to containerd: ... dial unix:///run/containerd/containerd.sock: timeout` for containerd. Bring both up before invoking `make dev-init` to skip the rabbit hole.
 
+### Nested vs. bare host: where the kukeond socket lands
+
+`scripts/dev-init.sh` runs in one of two modes, picked automatically at the top of the script by probing for `/.kukeon/bin/kuketty` — the canonical bind the daemon stages into every attachable cell (see `internal/ctr.AttachableBinaryPath`):
+
+| Mode                                  | Probe                          | Host socket                    | How it's steered                                                                                                    |
+| ------------------------------------- | ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| **Bare host** (probe absent)          | `/.kukeon/bin/kuketty` missing | `/run/kukeon/kukeond.sock`     | Daemon's compiled-in default; no env vars exported.                                                                 |
+| **Nested in a kukeon-dev-root cell**  | `/.kukeon/bin/kuketty` present | `/run/kukeon-dev/kukeond.sock` | Script exports `KUKEON_HOST=unix:///run/kukeon-dev/kukeond.sock` and `KUKEOND_SOCKET=/run/kukeon-dev/kukeond.sock`. |
+
+`KUKEON_HOST` is read via viper in `cmd/kuke/kuke.go`'s `loadConfig` and steers every `kuke` client call. `KUKEOND_SOCKET` steers the daemon-side serve args `kuke init` seeds for the kukeond cell *and* the cleanup path in `kuke daemon reset`. Both flow into sudo'd children via `--preserve-env=KUKEON_HOST,KUKEOND_SOCKET` on every relevant invocation in the script.
+
+The nested-mode redirect exists because the parent daemon bind-mounts `/run/kukeon/tty/<container>/` into the nested cell at `/run/kukeon/tty/`. A nested daemon publishing under `/run/kukeon/` would share that parent directory and break the host's `kuke attach <this-cell>` plumbing on script exit (issues #547, #545). Publishing under `/run/kukeon-dev/` keeps the two lifecycles disjoint. The script's `EXIT` trap (`verify_parent_attach_intact`) sha256-snapshots the parent's `/.kukeon/kuketty/metadata.json` up front and re-checks it on every exit path, so a botched re-bootstrap fails loud here rather than at the operator's next `kuke attach`.
+
+The source of truth for the probe and env-var contract is `scripts/dev-init.sh` lines 38-97.
+
 ### One-shot: `make dev-init`
 
 ```bash

--- a/docs/dev-init.md
+++ b/docs/dev-init.md
@@ -1,0 +1,16 @@
+# `make dev-init`: bare-host vs. nested execution
+
+`scripts/dev-init.sh` (the script `make dev-init` shells out to) runs in one of two modes, picked automatically at the top of the script by probing for `/.kukeon/bin/kuketty` — the canonical bind the daemon stages into every attachable cell (see `internal/ctr.AttachableBinaryPath`):
+
+| Mode                                  | Probe                          | Host socket                    | How it's steered                                                                                                    |
+| ------------------------------------- | ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| **Bare host** (probe absent)          | `/.kukeon/bin/kuketty` missing | `/run/kukeon/kukeond.sock`     | Daemon's compiled-in default; no env vars exported.                                                                 |
+| **Nested in a kukeon-dev-root cell**  | `/.kukeon/bin/kuketty` present | `/run/kukeon-dev/kukeond.sock` | Script exports `KUKEON_HOST=unix:///run/kukeon-dev/kukeond.sock` and `KUKEOND_SOCKET=/run/kukeon-dev/kukeond.sock`. |
+
+`KUKEON_HOST` is read via viper in `cmd/kuke/kuke.go`'s `loadConfig` and steers every `kuke` client call. `KUKEOND_SOCKET` steers the daemon-side serve args `kuke init` seeds for the kukeond cell *and* the cleanup path in `kuke daemon reset`. Both flow into sudo'd children via `--preserve-env=KUKEON_HOST,KUKEOND_SOCKET` on every relevant invocation in the script.
+
+## Why the nested-mode redirect
+
+The parent daemon bind-mounts `/run/kukeon/tty/<container>/` into the nested cell at `/run/kukeon/tty/`. A nested daemon publishing under `/run/kukeon/` would share that parent directory and break the host's `kuke attach <this-cell>` plumbing on script exit (issues #547, #545). Publishing under `/run/kukeon-dev/` keeps the two lifecycles disjoint. The script's `EXIT` trap (`verify_parent_attach_intact`) sha256-snapshots the parent's `/.kukeon/kuketty/metadata.json` up front and re-checks it on every exit path, so a botched re-bootstrap fails loud here rather than at the operator's next `kuke attach`.
+
+The source of truth for the probe and env-var contract is `scripts/dev-init.sh` lines 38-97.


### PR DESCRIPTION
## Summary
Documentation update applied from issue #562, restructured per user feedback mid-PR.
Mode: best-effort (override) — issue #562's verbatim spec called for an inline `### Nested vs. bare host` subsection in CLAUDE.md, but the user directed mid-PR that the details should live in a dedicated doc with only a one-line pointer in CLAUDE.md. The new shape was applied directly under user override of the rescope-first flow.

## Files changed
- `docs/dev-init.md` (new) — full bare-host vs. nested-mode contract: probe, two-mode table, env-var contract (`KUKEON_HOST` / `KUKEOND_SOCKET`), why the nested-mode redirect exists, EXIT trap, source-of-truth pointer to `scripts/dev-init.sh` lines 38-97.
- `CLAUDE.md` — `### Prerequisites` section gains one paragraph naming the nested-mode redirect and linking to `docs/dev-init.md`. The inline subsection added in the prior commit on this branch is reverted.

## Editorial choices
- New doc title: `# \`make dev-init\`: bare-host vs. nested execution` (focused scope; doc can absorb further dev-init coverage over time, mirroring `docs/cli-use-cases.md`).
- CLAUDE.md pointer placement: as a new paragraph in `### Prerequisites` immediately before `### One-shot: \`make dev-init\``, so the reader hits the nested-mode caveat before reading the smoke-test flow.
- Content extracted from #562's verbatim After is preserved character-for-character in `docs/dev-init.md`; only the wrapper (heading hierarchy, opening sentence) is editorial to fit a standalone doc instead of a CLAUDE.md subsection.

## Acceptance criteria check
- [x] Bare-host vs. nested-in-a-kukeon-cell socket-path differentiation is documented (`docs/dev-init.md`).
- [x] Both cases are clearly stated for users and agents (probe, host socket path, env-var contract).
- [x] CLAUDE.md no longer hard-codes the single-mode story (`### Prerequisites` now points to the dual-mode doc).
- [x] Source-of-truth pointer to `scripts/dev-init.sh` lines 38-97 preserved.

Closes #562