### PR TITLE
test(e2e): make --no-daemon explicit in buildKukeRunPathArgs, drop redundant appendNoDaemonRunPath

### DIFF
--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -83,11 +83,11 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// Step 1: provision realm/space/stack as plain create commands so the
 	// remaining apply call exercises the cell path and only the cell path.
 	runReturningBinary(t, nil, kuke,
-		appendNoDaemonRunPath(runPath, "create", "realm", realmName)...)
+		append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)...)
 	runReturningBinary(t, nil, kuke,
-		appendNoDaemonRunPath(runPath, "create", "space", spaceName, "--realm", realmName)...)
+		append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)...)
 	runReturningBinary(t, nil, kuke,
-		appendNoDaemonRunPath(runPath, "create", "stack", stackName,
+		append(buildKukeRunPathArgs(runPath), "create", "stack", stackName,
 			"--realm", realmName, "--space", spaceName)...)
 
 	// Step 2: apply the attachable cell fixture. Auto-starts the workload
@@ -114,7 +114,7 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 
 	// Step 4: drive `kuke attach` over a real PTY and detach.
 	session := startPTY(t, nil, kuke,
-		appendNoDaemonRunPath(runPath,
+		append(buildKukeRunPathArgs(runPath),
 			"attach", cellName,
 			"--realm", realmName,
 			"--space", spaceName,
@@ -180,37 +180,8 @@ func applyAttachableCell(t *testing.T, runPath, realmName, spaceName, stackName,
 		t.Fatalf("write tmp yaml: %v", err)
 	}
 
-	args := appendNoDaemonRunPath(runPath, "apply", "-f", tmpFile)
+	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", tmpFile)
 	runReturningBinary(t, nil, kuke, args...)
-}
-
-// appendNoDaemonRunPath returns the standard `--no-daemon --run-path X`
-// prefix concatenated with the supplied args. Used by the attach scenario so
-// every kuke invocation hits the in-process controller backed by the test's
-// runPath, isolating from any host daemon. The runPath is resolved to an
-// absolute path so OCI bind-mount sources stay valid even when containerd
-// chroot-resolves them from its own work directory.
-func appendNoDaemonRunPath(runPath string, args ...string) []string {
-	abs := absRunPath(runPath)
-	out := make([]string, 0, len(args)+3)
-	out = append(out, "--no-daemon", "--run-path", abs)
-	return append(out, args...)
-}
-
-// absRunPath returns runPath rewritten as an absolute path under the test's
-// working directory if it is not already absolute. Pure path math; nothing
-// on disk is touched.
-func absRunPath(runPath string) string {
-	if filepath.IsAbs(runPath) {
-		return runPath
-	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		// Fallback: pass through as-is. Hard-fails the kuke invocation
-		// downstream with a clear error rather than masking it.
-		return runPath
-	}
-	return filepath.Join(cwd, runPath)
 }
 
 // waitForSocket polls until the per-container kuketty control socket appears
@@ -264,27 +235,27 @@ func verifyContainerTaskIsRunning(t *testing.T, namespace, containerID string) b
 // runPath) and silently no-ops, leaving resources behind.
 func cleanupRealmNoDaemon(t *testing.T, runPath, realmName string) {
 	t.Helper()
-	args := appendNoDaemonRunPath(runPath, "delete", "realm", realmName, "--cascade")
+	args := append(buildKukeRunPathArgs(runPath), "delete", "realm", realmName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
 
 func cleanupSpaceNoDaemon(t *testing.T, runPath, realmName, spaceName string) {
 	t.Helper()
-	args := appendNoDaemonRunPath(runPath, "delete", "space", spaceName,
+	args := append(buildKukeRunPathArgs(runPath), "delete", "space", spaceName,
 		"--realm", realmName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
 
 func cleanupStackNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName string) {
 	t.Helper()
-	args := appendNoDaemonRunPath(runPath, "delete", "stack", stackName,
+	args := append(buildKukeRunPathArgs(runPath), "delete", "stack", stackName,
 		"--realm", realmName, "--space", spaceName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
 
 func cleanupCellNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) {
 	t.Helper()
-	args := appendNoDaemonRunPath(runPath, "delete", "cell", cellName,
+	args := append(buildKukeRunPathArgs(runPath), "delete", "cell", cellName,
 		"--realm", realmName, "--space", spaceName, "--stack", stackName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
@@ -295,7 +266,7 @@ func cleanupCellNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName,
 func getCellIDNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) (string, error) {
 	t.Helper()
 
-	args := appendNoDaemonRunPath(runPath,
+	args := append(buildKukeRunPathArgs(runPath),
 		"get", "cell", cellName,
 		"--realm", realmName, "--space", spaceName, "--stack", stackName,
 		"--output", "json",

--- a/e2e/e2e_kuke_invalid_names_test.go
+++ b/e2e/e2e_kuke_invalid_names_test.go
@@ -43,7 +43,7 @@ func TestKuke_CreateSpace_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := appendNoDaemonRunPath(runPath,
+			args := append(buildKukeRunPathArgs(runPath),
 				"create", "space", tt.spaceName, "--realm", "default")
 			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
 			if exitCode == 0 {
@@ -75,7 +75,7 @@ func TestKuke_CreateStack_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := appendNoDaemonRunPath(runPath,
+			args := append(buildKukeRunPathArgs(runPath),
 				"create", "stack", tt.stackName,
 				"--realm", "default", "--space", "default")
 			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
@@ -108,7 +108,7 @@ func TestKuke_CreateCell_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := appendNoDaemonRunPath(runPath,
+			args := append(buildKukeRunPathArgs(runPath),
 				"create", "cell", tt.cellName,
 				"--realm", "default", "--space", "default", "--stack", "default")
 			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
@@ -141,7 +141,7 @@ func TestKuke_CreateContainer_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := appendNoDaemonRunPath(runPath,
+			args := append(buildKukeRunPathArgs(runPath),
 				"create", "container", tt.containerName,
 				"--realm", "default", "--space", "default",
 				"--stack", "default", "--cell", "default",

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -157,9 +157,21 @@ func deepSocketPathFits(runPath string) bool {
 	return len(runPath)+deepSocketSuffixLen <= consts.KukeonMaxSocketPath
 }
 
-// buildKukeRunPathArgs builds --run-path flag arguments.
+// buildKukeRunPathArgs returns the canonical `--no-daemon --run-path <X>`
+// prefix every e2e invocation must carry. The two flags travel together
+// because the e2e suite has no shared kukeond running on its --run-path:
+// without --no-daemon, kuke would dial the host's daemon socket (whichever
+// /opt/kukeon path it was started against) and read/write someone else's
+// state. Per-test --run-path + in-process controller is the only mode that
+// keeps the suite hermetic on hosts where containerd is up but kukeond is
+// not (the common e2e harness shape).
+//
+// Note: --run-path alone already implies --no-daemon at the CLI layer via
+// applyRunPathImpliesNoDaemon (cmd/kuke/kuke.go), so this prefix is
+// belt-and-suspenders. Spelling both out keeps test source self-
+// documenting and severs the dependency on that promotion.
 func buildKukeRunPathArgs(runPath string) []string {
-	return []string{"--run-path", runPath}
+	return []string{"--no-daemon", "--run-path", runPath}
 }
 
 // loadKukeondImageIntoContainerd stages the local kukeond image into the


### PR DESCRIPTION
## Summary

- Closes #559.
- **Heads-up: the issue's premise is rotted by #555.** Issue #559 was filed at 2026-05-17 14:12 UTC; PR #555 (`fix: promote --no-daemon when --run-path is explicit`) merged ~1 min later at 14:13 UTC. That fix added `applyRunPathImpliesNoDaemon` (`cmd/kuke/kuke.go:340`), which auto-promotes any explicit `--run-path` to `--no-daemon=true`. After #555, every e2e test that uses `buildKukeRunPathArgs(runPath)` already runs in `--no-daemon` mode (via promotion) — the `dial kukeond at /run/kukeon/kukeond.sock: ... no such file or directory` failure mode the issue describes is gone. Verified on this host with no kukeond running: pre-555 the test died on the kukeond socket dial; post-555 it instead dies on the containerd socket dial (which is the host's `kuke create realm` precondition, unrelated to bootstrap mode). The 40/75 failure count from the #554 resize comment was the *symptom*; #555 was the actual fix.
- **What's left is cosmetic.** The suite was "mixed" only in helper shape: `buildKukeRunPathArgs` returned `[--run-path X]` and relied on the implicit promotion; `appendNoDaemonRunPath` returned `[--no-daemon --run-path X, ...args]` explicitly. Same runtime behavior; two helpers. This PR collapses them: `buildKukeRunPathArgs` now returns `[--no-daemon --run-path X]` explicitly (option (a) from the proposal), the two callers of `appendNoDaemonRunPath` are migrated to `append(buildKukeRunPathArgs(runPath), ...)`, and `appendNoDaemonRunPath` + the local `absRunPath` helper are deleted. The runtime-absolutize was load-bearing only for fixture-juggling tests that change cwd; e2e tests always get absolute paths from `t.TempDir()` / `os.MkdirTemp("/tmp", ...)`, so the absolutize was dead in practice — dropping it.
- **No behavior change for daemon-lifecycle tests** (`TestKuke_Init_VerifyState`, `TestKuke_DaemonReset_RoundTrip`): they were already running in `--no-daemon` mode via the same promotion, so making the flag explicit is a no-op for them at runtime. Verified by spot-checking the originally-failing test families.

If the reviewer's read is that the "consistent bootstrap model" deliverable should include something more (e.g. ripping out the `applyRunPathImpliesNoDaemon` promotion now that all callers are explicit, or migrating daemon-lifecycle tests to a different model entirely), happy to expand scope. The narrow interpretation here is "make explicit what was implicit, drop the duplicate helper, no semantic delta."

## Test plan

- [x] `make test` — all packages green on this host.
- [x] `go vet ./...` — clean.
- [x] `go test -count=1 -run xxx ./e2e` — e2e package compiles cleanly with the helper rename.
- [x] `pre-commit run --files <changed files>` — all hooks pass.
- [x] Spot-checked originally-failing families on a host with containerd up (no kukeond): `TestKuke_CreateRealm_VerifyState`, `TestKuke_CreateSpace_VerifyState`, `TestKuke_CreateStack_VerifyState`, `TestKuke_NoRealms`, `TestKuke_NoSpaces`, `TestKuke_NoStacks`, `TestKuke_NoCells`, `TestKuke_NoContainers` — all pass. (Pre-555 these died on `dial kukeond`; with the explicit `--no-daemon` they hit the in-process controller as intended.)
- [x] Spot-checked `TestKuke_CreateSpace_RejectsInvalidNames` (one of the existing explicit-`--no-daemon` callers) to confirm the helper-rename did not regress it.
- [ ] Full `make e2e` not run — this sandbox host doesn't have a kukeond image staging path (docker build + containerd image import flow). The CI test target `make test` runs in CI and passes; the broader e2e harness is gated by `make dev-init` / `make e2e` and is not yet wired into `.github/workflows/test.yaml` (that's the phase-3 follow-up #559 mentions).

Closes #559