### PR TITLE
refactor: retire --no-daemon from workload commands per #222

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Still pre-v1, gated by:
 
 - **Agent-native primitives** — Session (#46) and Interactive UC2 (#57) are the gate for the agent-native story.
 - **Schema rework** — crew-layers absorption into `CellBlueprint` / `CellConfig` / `Secret` (#423) is a breaking change.
-- **Daemon-only verbs** — `--no-daemon` retirement (#217) is mid-flight; the CLI surface is still moving.
+- **Daemon-only verbs** — `--no-daemon` retirement (#217) is mid-flight; the CLI surface is still moving. The flag is already gone from workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get` of non-realm kinds); in-process mode is still reachable via `KUKEON_NO_DAEMON=true` or an explicit `--run-path`.
 - **Reconciler-driven lifecycle** — convergent create/delete (#224) changes runtime semantics.
 
 References:
@@ -90,7 +90,7 @@ sudo usermod -aG kukeon $USER
 kuke get realms
 ```
 
-Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), and any command run with the `--no-daemon` flag.
+Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — every `kuke image *` subcommand runs in-process), `kuke purge` / `kuke uninstall` with `--no-daemon`, and any command run with `KUKEON_NO_DAEMON=true` or an explicit `--run-path`.
 
 ### Autocomplete
 
@@ -184,11 +184,11 @@ spec:
           exec busybox httpd -f -v -p 8080 -h /www
 ```
 
-Apply it and verify the cell is running. Cell creation currently goes in-process (`--no-daemon`) because the `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`:
+Apply it and verify the cell is running. Cell creation currently goes in-process because the `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`; pass `--run-path /opt/kukeon` (or set `KUKEON_NO_DAEMON=true`) to skip the daemon round-trip:
 
 ```bash
 # Create the cell (containers auto-start).
-sudo kuke apply -f docs/examples/hello-world.yaml --no-daemon
+sudo kuke apply -f docs/examples/hello-world.yaml --run-path /opt/kukeon
 
 # Confirm the cell is Ready.
 sudo kuke get cells --realm default --space default --stack default
@@ -203,7 +203,7 @@ Tear it down with:
 
 ```bash
 sudo kuke delete cell hello-world \
-    --realm default --space default --stack default --cascade --no-daemon
+    --realm default --space default --stack default --cascade --run-path /opt/kukeon
 ```
 
 ### Development environment
@@ -241,11 +241,13 @@ To iterate after a change, tear down just the kukeond cell (user data under `/op
 
 ```bash
 sudo kuke kill cell kukeond \
-    --realm kuke-system --space kukeon --stack kukeon --no-daemon
+    --realm kuke-system --space kukeon --stack kukeon --run-path /opt/kukeon
 sudo kuke delete cell kukeond \
-    --realm kuke-system --space kukeon --stack kukeon --no-daemon
+    --realm kuke-system --space kukeon --stack kukeon --run-path /opt/kukeon
 sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
 ```
+
+The `--run-path` promotion runs these commands in-process — required here because the daemon is what's being torn down.
 
 → See [docs/site/guides/local-dev.md](docs/site/guides/local-dev.md) for the full dev loop.
 
@@ -290,7 +292,7 @@ $ sudo kuke apply -f cell.yaml  # Apply a manifest
 $ sudo kuke delete cell mycell --realm ... --cascade
 ```
 
-Everything `kuke` does goes through the daemon by default. Pass `--no-daemon` to run the operation in-process (requires root).
+Everything `kuke` does goes through the daemon by default. Set `KUKEON_NO_DAEMON=true` (or pass `--run-path /opt/kukeon` to trigger the same promotion) to run the operation in-process — required when the daemon is down or being torn down (requires root).
 
 ### `kukeond` — the daemon
 

--- a/cmd/kuke/get/get.go
+++ b/cmd/kuke/get/get.go
@@ -22,6 +22,7 @@ import (
 	cellcmd "github.com/eminwux/kukeon/cmd/kuke/get/cell"
 	containercmd "github.com/eminwux/kukeon/cmd/kuke/get/container"
 	realmcmd "github.com/eminwux/kukeon/cmd/kuke/get/realm"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	spacecmd "github.com/eminwux/kukeon/cmd/kuke/get/space"
 	stackcmd "github.com/eminwux/kukeon/cmd/kuke/get/stack"
 	"github.com/spf13/cobra"
@@ -41,6 +42,14 @@ func NewGetCmd() *cobra.Command {
 	}
 
 	cmd.ValidArgsFunction = completeGetSubcommands
+
+	// `--no-daemon` lives as a persistent flag on the parent `get` cmd so
+	// every `get <kind>` leaf inherits it. The original #222 AC retained the
+	// flag only on `get realm` (for the dev-init parity check); the user
+	// later overrode that to keep it available on every `get` kind because
+	// the in-process escape hatch is just as useful for spaces/stacks/cells
+	// /containers when the daemon is down.
+	kukeshared.RegisterNoDaemonPersistentFlag(cmd)
 
 	cmd.AddCommand(
 		realmcmd.NewRealmCmd(),

--- a/cmd/kuke/get/realm/realm.go
+++ b/cmd/kuke/get/realm/realm.go
@@ -96,11 +96,11 @@ func NewRealmCmd() *cobra.Command {
 		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each realm's subtree (issue #328). Off by default to keep the default table the daemon-parity dev-init regression guard expects.",
 	)
 
-	// `--no-daemon` is retained on `get realm` per #222 ACs to keep the
-	// daemon-parity check (`kuke get realms` vs `kuke get realms
-	// --no-daemon`) the CLAUDE.md `make dev-init` regression guard relies
-	// on. #223 drops it once `kuke status` (#202) absorbs the parity check.
-	kukeshared.RegisterNoDaemonFlag(cmd)
+	// `--no-daemon` is inherited as a persistent flag from the parent `get`
+	// command (registered in cmd/kuke/get/get.go) — every `get <kind>`
+	// keeps the flag per the user override on #222. The CLAUDE.md
+	// `make dev-init` regression guard runs `kuke get realms` vs
+	// `kuke get realms --no-daemon` against that inherited flag.
 
 	cmd.ValidArgsFunction = config.CompleteRealmNames
 	_ = cmd.RegisterFlagCompletionFunc("output", config.CompleteOutputFormat)

--- a/cmd/kuke/get/realm/realm.go
+++ b/cmd/kuke/get/realm/realm.go
@@ -96,6 +96,12 @@ func NewRealmCmd() *cobra.Command {
 		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each realm's subtree (issue #328). Off by default to keep the default table the daemon-parity dev-init regression guard expects.",
 	)
 
+	// `--no-daemon` is retained on `get realm` per #222 ACs to keep the
+	// daemon-parity check (`kuke get realms` vs `kuke get realms
+	// --no-daemon`) the CLAUDE.md `make dev-init` regression guard relies
+	// on. #223 drops it once `kuke status` (#202) absorbs the parity check.
+	kukeshared.RegisterNoDaemonFlag(cmd)
+
 	cmd.ValidArgsFunction = config.CompleteRealmNames
 	_ = cmd.RegisterFlagCompletionFunc("output", config.CompleteOutputFormat)
 	_ = cmd.RegisterFlagCompletionFunc("o", config.CompleteOutputFormat)

--- a/cmd/kuke/image/image.go
+++ b/cmd/kuke/image/image.go
@@ -22,8 +22,8 @@
 // wraps containerd's image API directly. Whether `kukeond` is running has
 // no effect on their semantics — they manipulate containerd content, not
 // `/opt/kukeon/<realm>/` state — so they always construct a local
-// in-process Client. The root persistent `--no-daemon` flag is ignored
-// here (#226).
+// in-process Client. `--no-daemon` is not accepted on these commands —
+// the runtime ignore from #226 became a flag removal in #222.
 package image
 
 import (
@@ -61,8 +61,9 @@ type Client interface {
 // resolveClient returns the Client every `kuke image *` subcommand uses.
 // Tests inject a fake via MockControllerKey; otherwise the result is a
 // fresh in-process local.Client wired to the root persistent --run-path
-// and --containerd-socket flags. The root persistent --no-daemon flag is
-// not consulted — image commands are in-process by design (#226).
+// and --containerd-socket flags. `--no-daemon` is not on image commands
+// after #222; even when set via env, image commands ignore it — they are
+// in-process by design (#226).
 //
 // The logger fallback (a discard handler when LoggerFromCmd cannot find one
 // in the command context) makes this safe to call in tests that drive the

--- a/cmd/kuke/image/load.go
+++ b/cmd/kuke/image/load.go
@@ -46,9 +46,9 @@ func NewLoadCmd() *cobra.Command {
 			// store as the in-process client; the containerd socket is
 			// root-only on a stock host. Fail fast under non-root euid
 			// with a friendly message rather than letting containerd
-			// surface an opaque EACCES later. The root persistent
-			// `--no-daemon` flag is ignored — load is in-process by
-			// design (#226).
+			// surface an opaque EACCES later. `--no-daemon` is not on
+			// image commands after #222 — load is in-process by design
+			// (#226).
 			if err := kukshared.RequireRoot("kuke image load"); err != nil {
 				return err
 			}

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -93,6 +93,12 @@ func setupInitCmd(cmd *cobra.Command) error {
 		return fmt.Errorf("failed to set persistent flags: %w", err)
 	}
 
+	// `--no-daemon` is retained on init per #222 ACs even though init does
+	// not consult the viper key directly — it bootstraps the daemon, it does
+	// not talk to one. The flag stays accepted so existing operator muscle
+	// memory does not break; behavior is unchanged.
+	kukshared.RegisterNoDaemonFlag(cmd)
+
 	bindEnvVars()
 	return nil
 }

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -113,6 +113,7 @@ func NewKukeCmd() (*cobra.Command, error) {
 				return fmt.Errorf("%w: %w", errdefs.ErrConfig, err)
 			}
 
+			rebindNoDaemonViperToLeaf(cmd)
 			applyRunPathImpliesNoDaemon(cmd)
 			return nil
 		},
@@ -200,14 +201,6 @@ func SetPersistentLoggingFlags(rootCmd *cobra.Command) error {
 		return err
 	}
 
-	rootCmd.PersistentFlags().Bool(
-		"no-daemon", false,
-		"bypass kukeond and run operations in-process (requires privileges)",
-	)
-	if err := viper.BindPFlag(config.KUKEON_ROOT_NO_DAEMON.ViperKey, rootCmd.PersistentFlags().Lookup("no-daemon")); err != nil {
-		return err
-	}
-
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose logging")
 	if err := viper.BindPFlag(config.KUKEON_ROOT_VERBOSE.ViperKey, rootCmd.PersistentFlags().Lookup("verbose")); err != nil {
 		return err
@@ -242,6 +235,14 @@ func loadConfig() error {
 
 	_ = config.KUKEOND_SOCKET.BindEnv()
 	_ = config.KUKEOND_SOCKET_GID.BindEnv()
+
+	// `--no-daemon` is no longer a root-persistent flag (#222) — only the
+	// commands that still accept it user-facing register it locally (init,
+	// uninstall, purge, get realm). The env binding is what keeps
+	// `KUKEON_NO_DAEMON=true` reaching viper for callers that never go
+	// through one of those flag instances (e.g. the `--run-path` promotion
+	// path and the `KUKEON_NO_DAEMON=false` envSet check).
+	_ = config.KUKEON_ROOT_NO_DAEMON.BindEnv()
 
 	_ = config.KUKEON_ROOT_RUN_PATH.BindEnv()
 	if viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey) == "" {
@@ -321,6 +322,30 @@ func applyClientConfiguration(cmd *cobra.Command, spec v1beta1.ClientConfigurati
 	}
 	if spec.LogLevel != "" && !flagChanged(cmd, "log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
+	}
+}
+
+// rebindNoDaemonViperToLeaf rebinds the `kukeon/noDaemon` viper key to the
+// `--no-daemon` flag on the leaf cmd being executed, if that cmd has one.
+// Required because #222 demoted `--no-daemon` from a single root-persistent
+// flag to per-command local flags registered on init/uninstall/purge/get
+// realm — viper.BindPFlag has last-bind-wins semantics, so binding at
+// command-tree construction time would leave viper pointing at whichever
+// command happened to register last and silently drop the actual leaf's
+// flag value. Rebinding here, at PreRun time, makes the binding follow the
+// command actually being executed.
+//
+// Cobra merges inherited persistent flags into Flags() before PersistentPreRunE
+// fires, so cmd.Flags().Lookup picks up both local registrations (init's own
+// flag) and persistent ones inherited from a parent (purge's parent flag
+// reaching purge realm). Commands without `--no-daemon` (apply, create, run,
+// attach, delete, kill, get cell/space/stack/container, start, stop, log,
+// refresh, image *, daemon *) get nil from Lookup and viper falls back to
+// the env binding from loadConfig (KUKEON_NO_DAEMON) and the Set override
+// from applyRunPathImpliesNoDaemon below.
+func rebindNoDaemonViperToLeaf(cmd *cobra.Command) {
+	if flag := cmd.Flags().Lookup("no-daemon"); flag != nil {
+		_ = viper.BindPFlag(config.KUKEON_ROOT_NO_DAEMON.ViperKey, flag)
 	}
 }
 

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -237,11 +237,13 @@ func loadConfig() error {
 	_ = config.KUKEOND_SOCKET_GID.BindEnv()
 
 	// `--no-daemon` is no longer a root-persistent flag (#222) — only the
-	// commands that still accept it user-facing register it locally (init,
-	// uninstall, purge, get realm). The env binding is what keeps
-	// `KUKEON_NO_DAEMON=true` reaching viper for callers that never go
-	// through one of those flag instances (e.g. the `--run-path` promotion
-	// path and the `KUKEON_NO_DAEMON=false` envSet check).
+	// commands that still accept it user-facing register it locally: `init`,
+	// `uninstall`, `purge` (persistent on the parent), and the parent `get`
+	// command (persistent — every `get <kind>` inherits it per the user
+	// override on #222). The env binding is what keeps `KUKEON_NO_DAEMON=true`
+	// reaching viper for callers that never go through one of those flag
+	// instances (e.g. the `--run-path` promotion path and the
+	// `KUKEON_NO_DAEMON=false` envSet check).
 	_ = config.KUKEON_ROOT_NO_DAEMON.BindEnv()
 
 	_ = config.KUKEON_ROOT_RUN_PATH.BindEnv()

--- a/cmd/kuke/kuke_test.go
+++ b/cmd/kuke/kuke_test.go
@@ -474,7 +474,7 @@ func TestNewKukeCmdStreams(t *testing.T) {
 // that broke 40/75 e2e tests under per-test `--run-path` isolation.
 //
 // `--no-daemon` is no longer a root-persistent flag (#222) — it only lives
-// on the four retained commands (init, uninstall, purge, get realm). The
+// on the retained commands (init, uninstall, purge, every get <kind>). The
 // flag-set-to-false case drives `kuke init` because that's a representative
 // leaf with the local `--no-daemon` flag; the env-set-to-false case stays
 // on the root since the envSet check in applyRunPathImpliesNoDaemon reads

--- a/cmd/kuke/kuke_test.go
+++ b/cmd/kuke/kuke_test.go
@@ -472,12 +472,19 @@ func TestNewKukeCmdStreams(t *testing.T) {
 // run-path, so a caller passing `--run-path` and reaching a daemon dial
 // would silently read/write the daemon's path instead — the failure mode
 // that broke 40/75 e2e tests under per-test `--run-path` isolation.
+//
+// `--no-daemon` is no longer a root-persistent flag (#222) — it only lives
+// on the four retained commands (init, uninstall, purge, get realm). The
+// flag-set-to-false case drives `kuke init` because that's a representative
+// leaf with the local `--no-daemon` flag; the env-set-to-false case stays
+// on the root since the envSet check in applyRunPathImpliesNoDaemon reads
+// os.LookupEnv directly and doesn't depend on a cobra flag instance.
 func TestRunPathImpliesNoDaemon(t *testing.T) {
 	tests := []struct {
 		name            string
 		setFlag         bool   // --run-path on the command line
 		setEnv          string // KUKEON_RUN_PATH in env ("" = unset)
-		setNoDaemonFlag bool   // --no-daemon on the command line (=false)
+		setNoDaemonFlag bool   // --no-daemon on the leaf cmd (=false)
 		setNoDaemonEnv  string // KUKEON_NO_DAEMON in env ("" = unset)
 		wantNoDaemon    bool
 	}{
@@ -496,7 +503,7 @@ func TestRunPathImpliesNoDaemon(t *testing.T) {
 			wantNoDaemon: true,
 		},
 		{
-			name:            "explicit --no-daemon=false blocks promotion",
+			name:            "explicit --no-daemon=false on leaf blocks promotion",
 			setFlag:         true,
 			setNoDaemonFlag: true,
 			wantNoDaemon:    false,
@@ -526,19 +533,33 @@ func TestRunPathImpliesNoDaemon(t *testing.T) {
 				t.Fatalf("NewKukeCmd() error = %v", err)
 			}
 
+			// Find the leaf, then call ParseFlags so cobra merges the
+			// inherited persistent flag set (--run-path lives on root)
+			// into leaf.Flags(). Without the merge, neither
+			// flagChanged nor rebindNoDaemonViperToLeaf sees --run-path
+			// via cmd.Flags().Lookup, and the env case is the only
+			// path that can be exercised.
+			leaf, _, findErr := cmd.Find([]string{"init"})
+			if findErr != nil {
+				t.Fatalf("find init subcommand: %v", findErr)
+			}
+			if parseErr := leaf.ParseFlags(nil); parseErr != nil {
+				t.Fatalf("parse leaf flags: %v", parseErr)
+			}
+
 			if tc.setFlag {
-				if setErr := cmd.PersistentFlags().Set("run-path", "/tmp/from-flag"); setErr != nil {
-					t.Fatalf("set --run-path: %v", setErr)
+				if setErr := leaf.Flags().Set("run-path", "/tmp/from-flag"); setErr != nil {
+					t.Fatalf("set --run-path on leaf: %v", setErr)
 				}
 			}
 			if tc.setNoDaemonFlag {
-				if setErr := cmd.PersistentFlags().Set("no-daemon", "false"); setErr != nil {
-					t.Fatalf("set --no-daemon: %v", setErr)
+				if setErr := leaf.Flags().Set("no-daemon", "false"); setErr != nil {
+					t.Fatalf("set --no-daemon on leaf: %v", setErr)
 				}
 			}
 
-			cmd.SetContext(context.Background())
-			if preErr := cmd.PersistentPreRunE(cmd, []string{}); preErr != nil {
+			leaf.SetContext(context.Background())
+			if preErr := cmd.PersistentPreRunE(leaf, []string{}); preErr != nil {
 				t.Fatalf("PersistentPreRunE: %v", preErr)
 			}
 

--- a/cmd/kuke/purge/purge.go
+++ b/cmd/kuke/purge/purge.go
@@ -25,6 +25,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/kuke/purge/realm"
 	"github.com/eminwux/kukeon/cmd/kuke/purge/space"
 	"github.com/eminwux/kukeon/cmd/kuke/purge/stack"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -52,6 +53,13 @@ func NewPurgeCmd() *cobra.Command {
 	// Add persistent --force flag
 	cmd.PersistentFlags().Bool("force", false, "Skip validation and attempt purge anyway")
 	_ = viper.BindPFlag(config.KUKE_PURGE_FORCE.ViperKey, cmd.PersistentFlags().Lookup("force"))
+
+	// `--no-daemon` is retained on purge per #222 ACs — every purge
+	// subcommand calls ClientFromCmd, and the in-process branch is the
+	// only path that works when the daemon is down (the canonical
+	// disaster-recovery scenario for purge). Registered as a persistent
+	// flag so realm/space/stack/cell/container all inherit it.
+	kukshared.RegisterNoDaemonPersistentFlag(cmd)
 
 	cmd.AddCommand(
 		realm.NewRealmCmd(),

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -120,7 +120,8 @@ func NewRunCmd() *cobra.Command {
 			"cell. A clean ^]^] detach is NOT a trigger: the cell stays "+
 			"alive so the operator can re-attach later (parity with "+
 			"`kuke attach`). Daemon-mode only — incompatible with "+
-			"--no-daemon. Cleanup runs from kukeond's reconcile loop, "+
+			"in-process mode (KUKEON_NO_DAEMON=true or `--run-path` "+
+			"promotion). Cleanup runs from kukeond's reconcile loop, "+
 			"so latency is bounded by the reconcile interval rather "+
 			"than firing the instant the trigger fires.")
 	_ = viper.BindPFlag(config.KUKE_RUN_RM.ViperKey, cmd.Flags().Lookup("rm"))
@@ -186,9 +187,14 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 	}
 	if flags.autoDelete && viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey) {
 		// --rm needs a long-lived process to watch the root task and trigger
-		// cleanup. The --no-daemon CLI exits as soon as create+start returns,
-		// so the watcher would never run.
-		return runFlags{}, errors.New("--rm is incompatible with --no-daemon")
+		// cleanup. The in-process CLI path exits as soon as create+start
+		// returns, so the watcher would never run. `--no-daemon` is not a
+		// user-facing flag on `kuke run` after #222; the in-process path is
+		// reached via `--run-path` promotion or `KUKEON_NO_DAEMON=true`.
+		return runFlags{}, errors.New(
+			"--rm is incompatible with in-process mode " +
+				"(KUKEON_NO_DAEMON=true or --run-path promotion)",
+		)
 	}
 	if flags.file != "" {
 		// --name, --param, --param-file are profile-only knobs (per issue

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1760,13 +1760,14 @@ func TestRun_NoRmFlag_LeavesAutoDeleteFalse(t *testing.T) {
 }
 
 func TestRun_RmFlag_RejectsNoDaemon(t *testing.T) {
-	// --rm needs a long-lived process to watch the root task. The --no-daemon
+	// --rm needs a long-lived process to watch the root task. The in-process
 	// CLI returns immediately after CreateCell, so the watcher would never
 	// run. Reject the combo at flag-parse — before any cell is mutated.
 	t.Cleanup(viper.Reset)
-	// The real --no-daemon flag is registered on rootCmd; in this run-only
-	// fixture we only have the run subcommand, so flip the underlying viper
-	// key directly. Either path lands the same bool in viper.
+	// `--no-daemon` is not a user-facing flag on `kuke run` after #222;
+	// the in-process path is reached via `--run-path` promotion or
+	// `KUKEON_NO_DAEMON=true`. Flip the underlying viper key directly to
+	// simulate either path.
 	viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, true)
 
 	fc := &fakeClient{}
@@ -1774,8 +1775,8 @@ func TestRun_RmFlag_RejectsNoDaemon(t *testing.T) {
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "--rm"})
 
 	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--rm is incompatible with --no-daemon") {
-		t.Fatalf("err=%v want '--rm is incompatible with --no-daemon'", err)
+	if err == nil || !strings.Contains(err.Error(), "--rm is incompatible with in-process mode") {
+		t.Fatalf("err=%v want '--rm is incompatible with in-process mode'", err)
 	}
 	if fc.createCalls != 0 {
 		t.Errorf("CreateCell calls=%d want 0 (must reject before mutating)", fc.createCalls)

--- a/cmd/kuke/shared/controller.go
+++ b/cmd/kuke/shared/controller.go
@@ -93,8 +93,9 @@ func GetControllerWithMockWrapper[T any](cmd *cobra.Command, mockKey any, wrappe
 
 // ClientFromCmd returns a kukeonv1.Client selected by the
 // `kukeon/noDaemon` viper key, which is fed (in precedence order) by:
-//   - `--no-daemon` on the four commands that still expose it (init,
-//     uninstall, purge, get realm — see #222).
+//   - `--no-daemon` on the commands that still expose it: `init`,
+//     `uninstall`, `purge`, and every `get <kind>` (see #222; the get
+//     kinds were retained per a user override on the original AC).
 //   - `KUKEON_NO_DAEMON=true` env var.
 //   - `applyRunPathImpliesNoDaemon`, which sets the key when `--run-path`
 //     is explicit and `--no-daemon` was not.

--- a/cmd/kuke/shared/controller.go
+++ b/cmd/kuke/shared/controller.go
@@ -91,12 +91,17 @@ func GetControllerWithMockWrapper[T any](cmd *cobra.Command, mockKey any, wrappe
 	return wrapper(realCtrl), nil
 }
 
-// ClientFromCmd returns a kukeonv1.Client selected by flags/env:
-//   - --no-daemon (or KUKEON_NO_DAEMON=true): in-process Client backed by a
-//     fresh controller.Exec. Requires privileges.
-//   - default: JSON-RPC Client dialing KUKEON_HOST (unix:///... today).
+// ClientFromCmd returns a kukeonv1.Client selected by the
+// `kukeon/noDaemon` viper key, which is fed (in precedence order) by:
+//   - `--no-daemon` on the four commands that still expose it (init,
+//     uninstall, purge, get realm — see #222).
+//   - `KUKEON_NO_DAEMON=true` env var.
+//   - `applyRunPathImpliesNoDaemon`, which sets the key when `--run-path`
+//     is explicit and `--no-daemon` was not.
 //
-// The caller owns the returned Client and must Close it.
+// True → in-process Client backed by a fresh controller.Exec (requires
+// privileges). False → JSON-RPC Client dialing KUKEON_HOST (unix:///...
+// today). The caller owns the returned Client and must Close it.
 func ClientFromCmd(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey) {
 		logger, err := LoggerFromCmd(cmd)

--- a/cmd/kuke/shared/no_daemon.go
+++ b/cmd/kuke/shared/no_daemon.go
@@ -19,19 +19,20 @@ package shared
 import "github.com/spf13/cobra"
 
 // noDaemonFlagUsage is the usage string for the `--no-daemon` flag, kept in
-// one place so the four retained registrations stay byte-identical.
+// one place so every retained registration stays byte-identical.
 const noDaemonFlagUsage = "bypass kukeond and run operations in-process (requires privileges)"
 
 // RegisterNoDaemonFlag registers `--no-daemon` as a local flag on cmd.
 //
 // `--no-daemon` used to be a root-persistent flag inherited by every
 // subcommand. #222 demoted it to a per-command opt-in: only the commands that
-// still accept it user-facing (kuke init, kuke uninstall, kuke purge,
-// kuke get realm) call this helper. Daemon-routed workload commands (apply,
-// create, run, attach, delete, kill, get cell/space/stack/container, start,
-// stop, log, refresh) no longer accept the flag at the CLI surface; they
-// still reach the in-process branch via the `--run-path` promotion in
-// applyRunPathImpliesNoDaemon and via `KUKEON_NO_DAEMON=true`.
+// still accept it user-facing (kuke init, kuke uninstall, and — via the
+// persistent variant below — kuke purge and every kuke get <kind>) call this
+// helper or its persistent sibling. Daemon-routed workload commands (apply,
+// create, run, attach, delete, kill, start, stop, log, refresh) no longer
+// accept the flag at the CLI surface; they still reach the in-process branch
+// via the `--run-path` promotion in applyRunPathImpliesNoDaemon and via
+// `KUKEON_NO_DAEMON=true`.
 //
 // Bind to viper at PreRun time, not here — see kuke.go's
 // rebindNoDaemonViperToLeaf for the reason (viper.BindPFlag is
@@ -42,9 +43,9 @@ func RegisterNoDaemonFlag(cmd *cobra.Command) {
 }
 
 // RegisterNoDaemonPersistentFlag registers `--no-daemon` as a persistent
-// flag on cmd. Used by `kuke purge`, where the flag must propagate to every
-// resource subcommand (realm/space/stack/cell/container) without each
-// having to call RegisterNoDaemonFlag individually.
+// flag on cmd. Used by `kuke purge` and `kuke get`, where the flag must
+// propagate to every resource subcommand (realm/space/stack/cell/container)
+// without each having to call RegisterNoDaemonFlag individually.
 func RegisterNoDaemonPersistentFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().Bool("no-daemon", false, noDaemonFlagUsage)
 }

--- a/cmd/kuke/shared/no_daemon.go
+++ b/cmd/kuke/shared/no_daemon.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import "github.com/spf13/cobra"
+
+// noDaemonFlagUsage is the usage string for the `--no-daemon` flag, kept in
+// one place so the four retained registrations stay byte-identical.
+const noDaemonFlagUsage = "bypass kukeond and run operations in-process (requires privileges)"
+
+// RegisterNoDaemonFlag registers `--no-daemon` as a local flag on cmd.
+//
+// `--no-daemon` used to be a root-persistent flag inherited by every
+// subcommand. #222 demoted it to a per-command opt-in: only the commands that
+// still accept it user-facing (kuke init, kuke uninstall, kuke purge,
+// kuke get realm) call this helper. Daemon-routed workload commands (apply,
+// create, run, attach, delete, kill, get cell/space/stack/container, start,
+// stop, log, refresh) no longer accept the flag at the CLI surface; they
+// still reach the in-process branch via the `--run-path` promotion in
+// applyRunPathImpliesNoDaemon and via `KUKEON_NO_DAEMON=true`.
+//
+// Bind to viper at PreRun time, not here — see kuke.go's
+// rebindNoDaemonViperToLeaf for the reason (viper.BindPFlag is
+// last-bind-wins, so binding during setup would have one command's flag
+// silently drive viper for every other command).
+func RegisterNoDaemonFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool("no-daemon", false, noDaemonFlagUsage)
+}
+
+// RegisterNoDaemonPersistentFlag registers `--no-daemon` as a persistent
+// flag on cmd. Used by `kuke purge`, where the flag must propagate to every
+// resource subcommand (realm/space/stack/cell/container) without each
+// having to call RegisterNoDaemonFlag individually.
+func RegisterNoDaemonPersistentFlag(cmd *cobra.Command) {
+	cmd.PersistentFlags().Bool("no-daemon", false, noDaemonFlagUsage)
+}

--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -93,6 +94,13 @@ func setupUninstallCmd(cmd *cobra.Command) error {
 	if err := viper.BindPFlag(config.KUKE_UNINSTALL_YES.ViperKey, cmd.Flags().Lookup("yes")); err != nil {
 		return fmt.Errorf("failed to bind flag: %w", err)
 	}
+
+	// `--no-daemon` is retained on uninstall per #222 ACs. uninstall is
+	// always in-process by construction (it tears down the daemon) — the
+	// flag is accepted as a no-op so existing operator muscle memory does
+	// not break.
+	kukshared.RegisterNoDaemonFlag(cmd)
+
 	return nil
 }
 

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -11,7 +11,7 @@ The companion `<project>/CLAUDE.md` has the build, smoke-test, and daemon-parity
 - "Exit code 0" / "exit code non-zero" — the process exit status. Tooling automation should rely on this rather than scraping stdout.
 - "Side effect: X" — what changes on disk, in containerd, or in the daemon's view after the command completes.
 - "Idempotent" — re-running the command on a healthy host produces success without changing observable state. The CLI distinguishes "already existed" from "created" in the human-readable output but does not change the exit code.
-- "Daemon-mode" / "in-process mode" — `kuke` is a client. By default it dials `unix:///run/kukeon/kukeond.sock`. In in-process mode it runs the controller directly and bypasses the socket; this requires root + a usable `/run/containerd/containerd.sock` and is the only path that works before `kuke init` or while the daemon is stopped. In-process mode is reached via the `--no-daemon` flag on the four commands that still expose it (`init`, `uninstall`, `purge`, `get realm` — per #222), via `KUKEON_NO_DAEMON=true` in the environment, or via an explicit `--run-path` (which auto-promotes to in-process mode).
+- "Daemon-mode" / "in-process mode" — `kuke` is a client. By default it dials `unix:///run/kukeon/kukeond.sock`. In in-process mode it runs the controller directly and bypasses the socket; this requires root + a usable `/run/containerd/containerd.sock` and is the only path that works before `kuke init` or while the daemon is stopped. In-process mode is reached via the `--no-daemon` flag on the commands that still expose it (`init`, `uninstall`, `purge`, every `get <kind>` — per #222; the `get` kinds were retained per a user override on the original AC), via `KUKEON_NO_DAEMON=true` in the environment, or via an explicit `--run-path` (which auto-promotes to in-process mode).
 
 ## Bootstrap & teardown
 
@@ -135,7 +135,7 @@ sudo kuke daemon logs -f               # follow until SIGINT
 - `daemon start` errors when the host has not been `kuke init`-ed yet (no cell to start). Exit code non-zero with a message pointing the operator at `kuke init`.
 - `daemon kill` has no grace period; this is the escape hatch for a hung daemon. Use `stop` for the graceful path.
 - `daemon reset` is destructive (cell deletion + socket removal) and described in the Bootstrap & teardown section.
-- After `daemon stop`, daemon-routed commands (anything **not** explicitly in in-process mode) fail with `dial unix /run/kukeon/kukeond.sock: connect: no such file or directory` and exit non-zero. In-process commands (the four `--no-daemon`-accepting commands, plus anything with `KUKEON_NO_DAEMON=true` or an explicit `--run-path`) still work for the subset of operations the in-process controller supports.
+- After `daemon stop`, daemon-routed commands (anything **not** explicitly in in-process mode) fail with `dial unix /run/kukeon/kukeond.sock: connect: no such file or directory` and exit non-zero. In-process commands (the `--no-daemon`-accepting commands listed above, plus anything with `KUKEON_NO_DAEMON=true` or an explicit `--run-path`) still work for the subset of operations the in-process controller supports.
 - `daemon logs` is a typed shortcut for `kuke log --realm kuke-system --space kukeon --stack kukeon kukeond`; the coordinates are wired in. Exit code 0 even when the file is empty.
 
 ## Realm / space / stack management
@@ -373,7 +373,7 @@ A single command that prints the daemon's view of every realm/space/stack/cell i
 
 ### `--no-daemon` future
 
-The `--no-daemon` flag was removed from daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get cell|space|stack|container`, `start`, `stop`, `log`, `refresh`) by #222 — that workload-command removal is the current state. The flag is still accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (the daemon-parity check, retired by #223 once `kuke status` (#202) absorbs it). The in-process controller path itself stays reachable on workload commands via `KUKEON_NO_DAEMON=true` or the `--run-path` promotion, but is intentionally **not** documented here as a supported general-purpose path — the long-term arc deletes that branch entirely under #566.
+The `--no-daemon` flag was removed from the remaining daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `start`, `stop`, `log`, `refresh`) by #222 — that workload-command removal is the current state. The flag is still accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and every `kuke get <kind>` (the `get` kinds were retained per a user override on the original AC so the in-process escape hatch stays available for every resource lookup, not just `get realm` for the daemon-parity check, retired by #223 once `kuke status` (#202) absorbs it). The in-process controller path itself stays reachable on workload commands via `KUKEON_NO_DAEMON=true` or the `--run-path` promotion, but is intentionally **not** documented here as a supported general-purpose path — the long-term arc deletes that branch entirely under #566.
 
 ## Error & edge paths
 

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -11,7 +11,7 @@ The companion `<project>/CLAUDE.md` has the build, smoke-test, and daemon-parity
 - "Exit code 0" / "exit code non-zero" — the process exit status. Tooling automation should rely on this rather than scraping stdout.
 - "Side effect: X" — what changes on disk, in containerd, or in the daemon's view after the command completes.
 - "Idempotent" — re-running the command on a healthy host produces success without changing observable state. The CLI distinguishes "already existed" from "created" in the human-readable output but does not change the exit code.
-- "Daemon-mode" / "`--no-daemon`" — `kuke` is a client. By default it dials `unix:///run/kukeon/kukeond.sock`. With `--no-daemon` it runs the controller in-process and bypasses the socket; this requires root + a usable `/run/containerd/containerd.sock` and is the only path that works before `kuke init` or while the daemon is stopped.
+- "Daemon-mode" / "in-process mode" — `kuke` is a client. By default it dials `unix:///run/kukeon/kukeond.sock`. In in-process mode it runs the controller directly and bypasses the socket; this requires root + a usable `/run/containerd/containerd.sock` and is the only path that works before `kuke init` or while the daemon is stopped. In-process mode is reached via the `--no-daemon` flag on the four commands that still expose it (`init`, `uninstall`, `purge`, `get realm` — per #222), via `KUKEON_NO_DAEMON=true` in the environment, or via an explicit `--run-path` (which auto-promotes to in-process mode).
 
 ## Bootstrap & teardown
 
@@ -135,7 +135,7 @@ sudo kuke daemon logs -f               # follow until SIGINT
 - `daemon start` errors when the host has not been `kuke init`-ed yet (no cell to start). Exit code non-zero with a message pointing the operator at `kuke init`.
 - `daemon kill` has no grace period; this is the escape hatch for a hung daemon. Use `stop` for the graceful path.
 - `daemon reset` is destructive (cell deletion + socket removal) and described in the Bootstrap & teardown section.
-- After `daemon stop`, daemon-routed commands (anything **without** `--no-daemon`) fail with `dial unix /run/kukeon/kukeond.sock: connect: no such file or directory` and exit non-zero. `--no-daemon` commands still work for the subset of operations the in-process controller supports.
+- After `daemon stop`, daemon-routed commands (anything **not** explicitly in in-process mode) fail with `dial unix /run/kukeon/kukeond.sock: connect: no such file or directory` and exit non-zero. In-process commands (the four `--no-daemon`-accepting commands, plus anything with `KUKEON_NO_DAEMON=true` or an explicit `--run-path`) still work for the subset of operations the in-process controller supports.
 - `daemon logs` is a typed shortcut for `kuke log --realm kuke-system --space kukeon --stack kukeon kukeond`; the coordinates are wired in. Exit code 0 even when the file is empty.
 
 ## Realm / space / stack management
@@ -230,7 +230,7 @@ sudo kuke image delete --realm default <ref>                    # alias: rm, rem
 - `--from-docker <ref>` shells out to `docker save`; if the docker daemon is unreachable or the ref is unknown, the command exits non-zero with the docker error surfaced (e.g. `No such image`).
 - `kuke image get --realm <r>` exits 0 even when the namespace is empty; the CLI prints a "No images found in realm" line rather than failing.
 - `kuke image delete --realm <r> <missing-ref>` exits non-zero with an `image not found` message that names the realm and ref.
-- `kuke image *` is daemon-independent by design (#217, #226): every subcommand wraps containerd's image API directly in-process and ignores the root persistent `--no-daemon` flag. There is no "with daemon" mode — the daemon does not serve image RPCs.
+- `kuke image *` is daemon-independent by design (#217, #226): every subcommand wraps containerd's image API directly in-process. There is no "with daemon" mode — the daemon does not serve image RPCs — and `--no-daemon` is not accepted on image commands after #222.
 - `kuke image load` writes to containerd's content store and must run as root; it fails fast with a friendly `must run as root` error under non-root euid rather than letting containerd surface an opaque EACCES later. `kuke image get` and `kuke image delete` do not impose their own UID gate — they fail with whatever containerd returns if the socket is unreachable.
 - The dev-loop pattern is `sudo kuke image load --from-docker kukeon-local:dev --realm kuke-system`; the image lands in containerd before `kuke init` brings up the daemon, which is fine because image operations never go through `kukeond`.
 
@@ -259,7 +259,7 @@ sudo kuke run -f spec.yaml --rm                             # auto-delete after 
 - Re-running `kuke run -f` against an existing cell whose on-disk spec **diverges** from the file is **refused**, not silently updated. The error message points the operator at `kuke apply -f` for the update path. Exit code non-zero.
 - `-f` and `-p` are mutually exclusive; `--name` is rejected with `-f` (the YAML's `metadata.name` is the cell name verbatim).
 - `--container` is only valid in attach mode; passing both `--container` and `-d/--detach` exits non-zero.
-- `--rm` is daemon-mode only and incompatible with `--no-daemon`. Cleanup latency is bounded by the daemon's reconcile interval (default 30s), not real-time.
+- `--rm` is daemon-mode only and incompatible with in-process mode (`KUKEON_NO_DAEMON=true` or `--run-path` promotion). Cleanup latency is bounded by the daemon's reconcile interval (default 30s), not real-time.
 - A clean `^]^]` detach in attach mode does **not** trigger `--rm` cleanup; the cell stays alive for re-attach. Only workload termination, peer hangup, or an unrecoverable controller error fires cleanup.
 - `kuke run -f /missing.yaml` exits non-zero with a `failed to open file` error.
 - A reference to an unavailable image surfaces the containerd resolver error verbatim (e.g. `pull access denied, repository does not exist or may require authorization`) and exits non-zero; the half-created cell may need `kuke purge cell` to clean up.
@@ -373,7 +373,7 @@ A single command that prints the daemon's view of every realm/space/stack/cell i
 
 ### `--no-daemon` future
 
-The `--no-daemon` flag is the in-process controller path. It is preserved during `kuke init` and `kuke daemon reset` (the daemon may not be running) and is documented as the escape hatch for inspection commands when the daemon is down. Its broader removal as a user-facing flag for daemon-served operations is tracked in issues #222, #223, and #226 — those workflows are intentionally **not** documented here as supported general-purpose paths.
+The `--no-daemon` flag was removed from daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get cell|space|stack|container`, `start`, `stop`, `log`, `refresh`) by #222 — that workload-command removal is the current state. The flag is still accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (the daemon-parity check, retired by #223 once `kuke status` (#202) absorbs it). The in-process controller path itself stays reachable on workload commands via `KUKEON_NO_DAEMON=true` or the `--run-path` promotion, but is intentionally **not** documented here as a supported general-purpose path — the long-term arc deletes that branch entirely under #566.
 
 ## Error & edge paths
 
@@ -385,8 +385,8 @@ These are the negative paths most likely to surface a UX regression. Each is ver
 
 **Invariants.**
 
-- Any daemon-routed command (no `--no-daemon`) exits non-zero with `Error: dial kukeond at /run/kukeon/kukeond.sock: dial unix /run/kukeon/kukeond.sock: connect: no such file or directory`. The path in the message is the resolved socket from flags/config, not a hardcoded constant.
-- `--no-daemon` variants of `kuke get`, `kuke create realm`, etc. continue to work for in-process-controller-supported operations (subject to root + a usable `/run/containerd/containerd.sock`).
+- Any daemon-routed command (no in-process mode) exits non-zero with `Error: dial kukeond at /run/kukeon/kukeond.sock: dial unix /run/kukeon/kukeond.sock: connect: no such file or directory`. The path in the message is the resolved socket from flags/config, not a hardcoded constant.
+- In-process variants — `kuke get realms --no-daemon`, `kuke purge realm --cascade --force --no-daemon`, or any command run with `KUKEON_NO_DAEMON=true` / an explicit `--run-path` — continue to work for in-process-controller-supported operations (subject to root + a usable `/run/containerd/containerd.sock`).
 - `kuke daemon start` (when the host **has** been initialized) brings the socket back. `kuke init` brings it back from scratch.
 
 ### Cascade-purge that would orphan the daemon

--- a/docs/kuke.yaml
+++ b/docs/kuke.yaml
@@ -15,10 +15,11 @@ spec:
   # Daemon endpoint kuke dials by default. Use a `unix://` URL for a
   # local daemon socket or `ssh://user@host` to reach a remote kukeond.
   host: unix:///run/kukeon/kukeond.sock
-  # kukeon runtime root used by `--no-daemon` operations that read
-  # /opt/kukeon directly instead of going through kukeond.
+  # kukeon runtime root used by in-process operations that read
+  # /opt/kukeon directly instead of going through kukeond. An explicit
+  # `--run-path` on the CLI promotes the command into in-process mode.
   runPath: /opt/kukeon
-  # Containerd socket `--no-daemon` operations connect to.
+  # Containerd socket in-process operations connect to.
   containerdSocket: /run/containerd/containerd.sock
   # Client log level when `--verbose` is on (debug, info, warn, error).
   logLevel: info

--- a/docs/site/architecture/overview.md
+++ b/docs/site/architecture/overview.md
@@ -34,7 +34,7 @@ A thin cobra CLI. It:
 - sends `kukeonv1` API requests;
 - formats the response as a table, YAML, or JSON.
 
-The only time `kuke` does real work itself is when it's promoted into in-process mode — by an explicit `--run-path`, by `KUKEON_NO_DAEMON=true`, or (on the remaining flagged commands: `init`, `uninstall`, `purge`, `get realm`) by `--no-daemon`. In that mode it runs the same controller code that `kukeond` would.
+The only time `kuke` does real work itself is when it's promoted into in-process mode — by an explicit `--run-path`, by `KUKEON_NO_DAEMON=true`, or (on the commands that still expose the flag: `init`, `uninstall`, `purge`, every `get <kind>`) by `--no-daemon`. In that mode it runs the same controller code that `kukeond` would.
 
 ## kukeond (daemon)
 

--- a/docs/site/architecture/overview.md
+++ b/docs/site/architecture/overview.md
@@ -10,7 +10,7 @@ flowchart TB
     end
 
     kuke -->|unix socket<br/>kukeonv1 API| kukeond
-    kuke -.->|--no-daemon<br/>in-process| externals
+    kuke -.->|in-process<br/>(--run-path / KUKEON_NO_DAEMON)| externals
 
     kukeond --> externals
 
@@ -34,7 +34,7 @@ A thin cobra CLI. It:
 - sends `kukeonv1` API requests;
 - formats the response as a table, YAML, or JSON.
 
-The only time `kuke` does real work itself is when `--no-daemon` is passed — then it runs the same controller code that `kukeond` would.
+The only time `kuke` does real work itself is when it's promoted into in-process mode — by an explicit `--run-path`, by `KUKEON_NO_DAEMON=true`, or (on the remaining flagged commands: `init`, `uninstall`, `purge`, `get realm`) by `--no-daemon`. In that mode it runs the same controller code that `kukeond` would.
 
 ## kukeond (daemon)
 
@@ -48,7 +48,7 @@ When a client calls `CreateCell`, the daemon orchestrates all three: create the 
 
 ## The controller / reconciler
 
-Both the daemon and `--no-daemon` share the same controller (`internal/controller`). The controller is the single place where "desired state → actual state" logic lives:
+Both the daemon and in-process mode share the same controller (`internal/controller`). The controller is the single place where "desired state → actual state" logic lives:
 
 ```
 apply/refresh request

--- a/docs/site/architecture/process-model.md
+++ b/docs/site/architecture/process-model.md
@@ -30,7 +30,7 @@ default:
 
 - The CLI and the daemon share most of their code (the controller, the apischeme conversion, the error types). Shipping one binary means shipping half the bytes and testing one build.
 - Installers only need to copy one file; the hard link is a one-liner.
-- The CLI can fall back to "be the daemon for one command" (`--no-daemon`) without duplicating any logic.
+- The CLI can fall back to "be the daemon for one command" — in-process mode, reached via an explicit `--run-path` or `KUKEON_NO_DAEMON=true` — without duplicating any logic.
 
 ## The daemon process
 
@@ -49,7 +49,7 @@ The daemon does **not** fork or daemonize itself. When you run `kuke init`, the 
 Every `kuke` invocation is a short-lived process:
 
 1. Parse flags, load config.
-2. If `--no-daemon`, run the operation in-process.
+2. If promoted to in-process mode (explicit `--run-path`, `KUKEON_NO_DAEMON=true`, or one of the commands that still ship `--no-daemon`), run the operation in-process.
 3. Otherwise, dial the daemon socket, send one `kukeonv1` request, print the response, exit.
 
 Clients do not hold persistent connections. Each command opens a new socket, sends, receives, closes. There's no keepalive or session state.

--- a/docs/site/architecture/process-model.md
+++ b/docs/site/architecture/process-model.md
@@ -49,7 +49,7 @@ The daemon does **not** fork or daemonize itself. When you run `kuke init`, the 
 Every `kuke` invocation is a short-lived process:
 
 1. Parse flags, load config.
-2. If promoted to in-process mode (explicit `--run-path`, `KUKEON_NO_DAEMON=true`, or one of the commands that still ship `--no-daemon`), run the operation in-process.
+2. If promoted to in-process mode (explicit `--run-path`, `KUKEON_NO_DAEMON=true`, or `--no-daemon` on one of the commands that still ship it — `init`, `uninstall`, `purge`, every `get <kind>`), run the operation in-process.
 3. Otherwise, dial the daemon socket, send one `kukeonv1` request, print the response, exit.
 
 Clients do not hold persistent connections. Each command opens a new socket, sends, receives, closes. There's no keepalive or session state.

--- a/docs/site/architecture/storage-layout.md
+++ b/docs/site/architecture/storage-layout.md
@@ -97,7 +97,7 @@ If you want to inspect what Kukeon pushed into containerd, use `ctr -n kukeon-<r
 | `kuke purge <resource>`       | Same as delete but more aggressive: force-removes residual state |
 | Reboot                        | `/run/kukeon/*` disappears (tmpfs). `/opt/kukeon/*` persists.    |
 
-In-process runs of the same commands do exactly the same thing on disk — they just skip the socket and execute the controller in-process (reach in-process mode via `--run-path`, `KUKEON_NO_DAEMON=true`, or, on the commands that still ship it, `--no-daemon`).
+In-process runs of the same commands do exactly the same thing on disk — they just skip the socket and execute the controller in-process (reach in-process mode via `--run-path`, `KUKEON_NO_DAEMON=true`, or `--no-daemon` on the commands that still ship it: `init`, `uninstall`, `purge`, every `get <kind>`).
 
 ## Read next
 

--- a/docs/site/architecture/storage-layout.md
+++ b/docs/site/architecture/storage-layout.md
@@ -97,7 +97,7 @@ If you want to inspect what Kukeon pushed into containerd, use `ctr -n kukeon-<r
 | `kuke purge <resource>`       | Same as delete but more aggressive: force-removes residual state |
 | Reboot                        | `/run/kukeon/*` disappears (tmpfs). `/opt/kukeon/*` persists.    |
 
-`--no-daemon` versions of the same commands do exactly the same thing on disk — they just run in-process instead of going through the socket.
+In-process runs of the same commands do exactly the same thing on disk — they just skip the socket and execute the controller in-process (reach in-process mode via `--run-path`, `KUKEON_NO_DAEMON=true`, or, on the commands that still ship it, `--no-daemon`).
 
 ## Read next
 

--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -44,7 +44,7 @@ Every `kuke` subcommand inherits these persistent flags from the root command:
 | `--verbose`, `-v`     | `false`                           | Enable verbose logging on stderr                     |
 | `--log-level`         | `info`                            | Log level (`debug`, `info`, `warn`, `error`)         |
 
-`--no-daemon` is **not** a root-persistent flag — it is only accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (see #222). For daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get cell|space|stack|container`, `start`, `stop`, `log`, `refresh`), the in-process path is reached via `KUKEON_NO_DAEMON=true` or an explicit `--run-path` (which auto-promotes to in-process mode).
+`--no-daemon` is **not** a root-persistent flag — it is only accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and every `kuke get <kind>` (see #222; the `get` kinds were retained per a user override on the original AC). For the remaining daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `start`, `stop`, `log`, `refresh`), the in-process path is reached via `KUKEON_NO_DAEMON=true` or an explicit `--run-path` (which auto-promotes to in-process mode).
 
 ### In-process mode host prerequisites
 

--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -41,20 +41,21 @@ Every `kuke` subcommand inherits these persistent flags from the root command:
 | `--configuration`     | `$HOME/.kuke/kuke.yaml`           | ClientConfiguration YAML; absent file uses defaults  |
 | `--containerd-socket` | `/run/containerd/containerd.sock` | Containerd socket                                    |
 | `--host`              | `unix:///run/kukeon/kukeond.sock` | Daemon endpoint (`unix://` or `ssh://`)              |
-| `--no-daemon`         | `false`                           | Bypass the daemon and run in-process (requires root) |
 | `--verbose`, `-v`     | `false`                           | Enable verbose logging on stderr                     |
 | `--log-level`         | `info`                            | Log level (`debug`, `info`, `warn`, `error`)         |
 
-### `--no-daemon` host prerequisites
+`--no-daemon` is **not** a root-persistent flag — it is only accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (see #222). For daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get cell|space|stack|container`, `start`, `stop`, `log`, `refresh`), the in-process path is reached via `KUKEON_NO_DAEMON=true` or an explicit `--run-path` (which auto-promotes to in-process mode).
 
-With `--no-daemon`, the `kuke` binary runs the controllers in-process instead of routing the request to `kukeond`. Operations that touch networking (cell apply, network create) then shell out to CNI plugins from **the host's** `/opt/cni/bin` — the daemon's container image is not in the picture. So `--no-daemon` workflows additionally require:
+### In-process mode host prerequisites
+
+In in-process mode, the `kuke` binary runs the controllers itself instead of routing the request to `kukeond`. Operations that touch networking (cell apply, network create) then shell out to CNI plugins from **the host's** `/opt/cni/bin` — the daemon's container image is not in the picture. So in-process workflows additionally require:
 
 - CNI plugins on the host at `/opt/cni/bin` (e.g. `containernetworking-plugins` on Debian/Ubuntu, then symlinked from `/usr/lib/cni` since that distro packages them there)
 
 The default daemon path does **not** need host CNI plugins — `kukeond`'s image bundles them and only state dirs (`/opt/cni/net.d`, `/var/lib/cni`, `/opt/cni/cache`) are bind-mounted from the host.
 
-!!! warning "`--no-daemon` is transitional"
-    `--no-daemon` is slated for removal from creation commands in a future release; treat it as a debugging escape hatch rather than a supported deployment mode.
+!!! warning "In-process mode is transitional"
+    `KUKEON_NO_DAEMON=true` / the `--run-path` promotion path is slated for full removal once `ClientFromCmd`'s in-process branch is retired (#566). Treat it as a debugging escape hatch rather than a supported deployment mode.
 
 ## Convention: positional arg + flags
 

--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -16,7 +16,7 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also 
 | `--output`, `-o`     | Output format: `yaml`, `json`, `table`. Default: `table` for list, `yaml` for a single resource.  |
 | `--show-controllers` | Append a `CONTROLLERS` column listing the cgroup-v2 controllers delegated on the subject's subtree. Off by default to keep the dev-init parity check stable. |
 
-Plus all [global flags](kuke.md). To bypass the daemon for a `get` call, set `KUKEON_NO_DAEMON=true` or pass `--run-path /opt/kukeon` (which auto-promotes the command into in-process mode); `kuke get realm` still also accepts the explicit `--no-daemon` flag.
+Plus all [global flags](kuke.md). Every `kuke get <kind>` accepts the explicit `--no-daemon` flag to bypass the daemon (inherited as a persistent flag from the parent `get` command); `KUKEON_NO_DAEMON=true` and `--run-path /opt/kukeon` (which auto-promotes the command into in-process mode) work as well.
 
 ## Hierarchy flags
 

--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -16,7 +16,7 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also 
 | `--output`, `-o`     | Output format: `yaml`, `json`, `table`. Default: `table` for list, `yaml` for a single resource.  |
 | `--show-controllers` | Append a `CONTROLLERS` column listing the cgroup-v2 controllers delegated on the subject's subtree. Off by default to keep the dev-init parity check stable. |
 
-Plus all [global flags](kuke.md) — most importantly `--no-daemon`.
+Plus all [global flags](kuke.md). To bypass the daemon for a `get` call, set `KUKEON_NO_DAEMON=true` or pass `--run-path /opt/kukeon` (which auto-promotes the command into in-process mode); `kuke get realm` still also accepts the explicit `--no-daemon` flag.
 
 ## Hierarchy flags
 

--- a/docs/site/cli/kuke-image.md
+++ b/docs/site/cli/kuke-image.md
@@ -24,7 +24,7 @@ kuke image load [tarball | -] [flags]
 
 Import an OCI/docker image tarball into the containerd namespace mapped to `--realm`. Pass a tarball path, `-` for stdin, or `--from-docker <ref>` to shell out to `docker save`.
 
-`kuke image *` is daemon-independent by design: every subcommand wraps containerd's image API directly in-process and ignores the root persistent `--no-daemon` flag — there is no "with daemon" mode for images. `kuke image load` always requires root because it writes to containerd's content store; it fails fast with a clear remediation if you forget `sudo`.
+`kuke image *` is daemon-independent by design: every subcommand wraps containerd's image API directly in-process — there is no "with daemon" mode for images, and the `--no-daemon` flag is intentionally absent on these commands. `kuke image load` always requires root because it writes to containerd's content store; it fails fast with a clear remediation if you forget `sudo`.
 
 | Flag            | Default   | Description                                                                                         |
 | --------------- | --------- | --------------------------------------------------------------------------------------------------- |

--- a/docs/site/cli/kuke-run.md
+++ b/docs/site/cli/kuke-run.md
@@ -53,7 +53,7 @@ Keys not declared in `spec.parameters[]` are rejected.
 
 ## Cleanup with `--rm`
 
-`--rm` best-effort deletes the cell after it's no longer needed (any return code). Daemon-mode only — incompatible with `--no-daemon`. Cleanup runs from `kukeond`'s reconcile loop, so latency is bounded by the reconcile interval rather than firing the instant the trigger fires.
+`--rm` best-effort deletes the cell after it's no longer needed (any return code). Daemon-mode only — incompatible with in-process mode (set with `KUKEON_NO_DAEMON=true` or by passing `--run-path`, which auto-promotes). Cleanup runs from `kukeond`'s reconcile loop, so latency is bounded by the reconcile interval rather than firing the instant the trigger fires.
 
 Triggers:
 

--- a/docs/site/cli/kuke.md
+++ b/docs/site/cli/kuke.md
@@ -26,11 +26,11 @@ Path to the containerd socket. Only used when running in in-process mode; when t
 
 The daemon endpoint. Today only the `unix://` scheme is supported. The `ssh://user@host` scheme is reserved for a future remote-management feature; don't use it yet.
 
-### `--no-daemon` (only on `init` / `uninstall` / `purge` / `get realm`)
+### `--no-daemon` (only on `init` / `uninstall` / `purge` / `get <kind>`)
 
 Bypass `kukeond` and run the operation in-process. Requires root: the client now directly touches containerd, CNI, and cgroups.
 
-`--no-daemon` is **not** a root-persistent flag — it is only accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (see #222). For daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get cell|space|stack|container`, `start`, `stop`, `log`, `refresh`), reach the in-process path via `KUKEON_NO_DAEMON=true` in the environment or via an explicit `--run-path /path` (which auto-promotes to in-process mode so a caller-supplied run-path is never silently sent to the wrong daemon).
+`--no-daemon` is **not** a root-persistent flag — it is only accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and every `kuke get <kind>` (see #222; the `get` kinds were retained per a user override on the original AC so the in-process escape hatch stays available for every resource lookup, not just `get realm`). For the remaining daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `start`, `stop`, `log`, `refresh`), reach the in-process path via `KUKEON_NO_DAEMON=true` in the environment or via an explicit `--run-path /path` (which auto-promotes to in-process mode so a caller-supplied run-path is never silently sent to the wrong daemon).
 
 `kuke image *` is daemon-independent by design and is always in-process regardless of any of these knobs.
 

--- a/docs/site/cli/kuke.md
+++ b/docs/site/cli/kuke.md
@@ -20,19 +20,21 @@ Path to a `ClientConfiguration` YAML. If the file doesn't exist, Kukeon falls ba
 
 ### `--containerd-socket` (`/run/containerd/containerd.sock`)
 
-Path to the containerd socket. Only used when running in `--no-daemon` mode; when talking to the daemon, containerd is accessed by the daemon, not the client.
+Path to the containerd socket. Only used when running in in-process mode; when talking to the daemon, containerd is accessed by the daemon, not the client.
 
 ### `--host` (`unix:///run/kukeon/kukeond.sock`)
 
 The daemon endpoint. Today only the `unix://` scheme is supported. The `ssh://user@host` scheme is reserved for a future remote-management feature; don't use it yet.
 
-### `--no-daemon` (`false`)
+### `--no-daemon` (only on `init` / `uninstall` / `purge` / `get realm`)
 
 Bypass `kukeond` and run the operation in-process. Requires root: the client now directly touches containerd, CNI, and cgroups.
 
-Use when the daemon is stopped, when bootstrapping (`kuke init` runs this path), or while debugging. `kuke image *` is daemon-independent by design and is always in-process regardless of `--no-daemon`.
+`--no-daemon` is **not** a root-persistent flag — it is only accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (see #222). For daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get cell|space|stack|container`, `start`, `stop`, `log`, `refresh`), reach the in-process path via `KUKEON_NO_DAEMON=true` in the environment or via an explicit `--run-path /path` (which auto-promotes to in-process mode so a caller-supplied run-path is never silently sent to the wrong daemon).
 
-Don't run two `--no-daemon` commands at the same time — they'll race on the same on-disk state.
+`kuke image *` is daemon-independent by design and is always in-process regardless of any of these knobs.
+
+Don't run two in-process commands at the same time — they'll race on the same on-disk state.
 
 ### `--verbose`, `-v` (`false`)
 
@@ -52,8 +54,11 @@ Every flag also has a corresponding `KUKE_*` environment variable (check via `--
 # Talk to a non-default socket
 kuke --host unix:///tmp/kukeond.sock get realms
 
-# Bypass the daemon
-sudo kuke apply -f cell.yaml --no-daemon
+# Bypass the daemon (in-process via env var)
+sudo KUKEON_NO_DAEMON=true kuke apply -f cell.yaml
+
+# Bypass the daemon (in-process via --run-path promotion)
+sudo kuke apply -f cell.yaml --run-path /opt/kukeon
 
 # Verbose debug of a single apply
 sudo kuke apply -f cell.yaml --verbose --log-level debug

--- a/docs/site/concepts/client-and-daemon.md
+++ b/docs/site/concepts/client-and-daemon.md
@@ -28,12 +28,12 @@ It runs as the root container of the `kukeond` cell inside the [system realm](sy
 
 ## In-process mode
 
-`kuke` can bypass the socket and execute the operation in-process. The `--no-daemon` flag used to live on every subcommand; #222 retired it from daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get cell|space|stack|container`, `start`, `stop`, `log`, `refresh`). On those commands the in-process path is now reached via:
+`kuke` can bypass the socket and execute the operation in-process. The `--no-daemon` flag used to live on every subcommand; #222 retired it from the remaining daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `start`, `stop`, `log`, `refresh`). On those commands the in-process path is now reached via:
 
 - `KUKEON_NO_DAEMON=true` in the environment, or
 - an explicit `--run-path /some/path` (which auto-promotes to in-process mode — the daemon ignores client-supplied run-paths, so a caller passing a non-default `--run-path` would otherwise silently read/write the daemon's path instead).
 
-`--no-daemon` itself stays accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (the daemon-parity check), and `kuke image *` is daemon-independent by design (always in-process regardless of any of these knobs).
+`--no-daemon` itself stays accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and every `kuke get <kind>` (the `get` kinds were retained per a user override on the original #222 AC so the in-process escape hatch stays available for every resource lookup, not just `get realm`). `kuke image *` is daemon-independent by design (always in-process regardless of any of these knobs).
 
 ```bash
 # Workload command via env var
@@ -42,8 +42,9 @@ sudo KUKEON_NO_DAEMON=true kuke apply -f cell.yaml
 # Workload command via --run-path promotion
 sudo kuke apply -f cell.yaml --run-path /opt/kukeon
 
-# The four commands that still expose --no-daemon directly
+# Commands that still expose --no-daemon directly
 sudo kuke get realms --no-daemon
+sudo kuke get cells --no-daemon --realm default --space default --stack default
 sudo kuke purge realm myrealm --cascade --force --no-daemon
 ```
 
@@ -70,7 +71,7 @@ Other transports are on the roadmap (`ssh://user@host` is the intended future sh
 
 ## Parity between daemon and in-process
 
-`kuke get realms` and `kuke get realms --no-daemon` should return identical output on a healthy host. Divergence between them is a regression — if you see it, please file a bug. The two paths share the same reconciler and data store; the only difference is who holds the process. This explicit-flag check survives on `kuke get realm` after #222 specifically to keep the daemon-parity guard accessible; #223 retires it once `kuke status` (#202) absorbs the parity contract.
+`kuke get realms` and `kuke get realms --no-daemon` should return identical output on a healthy host. Divergence between them is a regression — if you see it, please file a bug. The two paths share the same reconciler and data store; the only difference is who holds the process. The explicit-flag check survives on every `kuke get <kind>` after #222 (`get realm` is the one the CLAUDE.md dev-init regression guard exercises; the others are available as the same shape of escape hatch); #223 retires `get realm`'s parity-check role once `kuke status` (#202) absorbs the parity contract.
 
 ## Related concepts
 

--- a/docs/site/concepts/client-and-daemon.md
+++ b/docs/site/concepts/client-and-daemon.md
@@ -26,25 +26,37 @@ Kukeon ships as a single binary that behaves as either `kuke` (client CLI) or `k
 
 It runs as the root container of the `kukeond` cell inside the [system realm](system-realm.md), so it's managed by the same primitives as any other workload.
 
-## `--no-daemon`: in-process mode
+## In-process mode
 
-`kuke` has a `--no-daemon` flag that bypasses the socket and executes the operation in-process. When you pass `--no-daemon`, `kuke` becomes the daemon for the duration of the command:
+`kuke` can bypass the socket and execute the operation in-process. The `--no-daemon` flag used to live on every subcommand; #222 retired it from daemon-routed workload commands (`apply`, `create`, `run`, `attach`, `delete`, `kill`, `get cell|space|stack|container`, `start`, `stop`, `log`, `refresh`). On those commands the in-process path is now reached via:
+
+- `KUKEON_NO_DAEMON=true` in the environment, or
+- an explicit `--run-path /some/path` (which auto-promotes to in-process mode — the daemon ignores client-supplied run-paths, so a caller passing a non-default `--run-path` would otherwise silently read/write the daemon's path instead).
+
+`--no-daemon` itself stays accepted on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (the daemon-parity check), and `kuke image *` is daemon-independent by design (always in-process regardless of any of these knobs).
 
 ```bash
-sudo kuke apply -f cell.yaml --no-daemon
+# Workload command via env var
+sudo KUKEON_NO_DAEMON=true kuke apply -f cell.yaml
+
+# Workload command via --run-path promotion
+sudo kuke apply -f cell.yaml --run-path /opt/kukeon
+
+# The four commands that still expose --no-daemon directly
+sudo kuke get realms --no-daemon
+sudo kuke purge realm myrealm --cascade --force --no-daemon
 ```
 
 When to use it:
 
 - **Bootstrapping** — `kuke init` runs in-process by necessity; the daemon isn't up yet.
 - **Daemon is down** — anything that should talk to `kukeond` but can't because the daemon is stopped or being rebuilt.
-- **Current release constraints** — the shipped `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`, so cell creation currently runs `--no-daemon`. This will change in a future release.
 
 Trade-offs:
 
-- `--no-daemon` requires root (it talks directly to containerd, netlink, cgroups).
+- In-process mode requires root (it talks directly to containerd, netlink, cgroups).
 - There's no long-lived state holder, so every command is self-contained.
-- Two `--no-daemon` commands running at the same time will race on the same on-disk state. Don't do it.
+- Two in-process commands running at the same time will race on the same on-disk state. Don't do it.
 
 ## The `--host` flag
 
@@ -58,7 +70,7 @@ Other transports are on the roadmap (`ssh://user@host` is the intended future sh
 
 ## Parity between daemon and in-process
 
-`kuke get <resource>` and `kuke get <resource> --no-daemon` should return identical output on a healthy host. Divergence between them is a regression — if you see it, please file a bug. The two paths share the same reconciler and data store; the only difference is who holds the process.
+`kuke get realms` and `kuke get realms --no-daemon` should return identical output on a healthy host. Divergence between them is a regression — if you see it, please file a bug. The two paths share the same reconciler and data store; the only difference is who holds the process. This explicit-flag check survives on `kuke get realm` after #222 specifically to keep the daemon-parity guard accessible; #223 retires it once `kuke status` (#202) absorbs the parity contract.
 
 ## Related concepts
 

--- a/docs/site/concepts/system-realm.md
+++ b/docs/site/concepts/system-realm.md
@@ -44,12 +44,12 @@ kukeond  kukeon-system    kukeon   kukeon   Ready
 Stopping or restarting the daemon:
 
 ```bash
-sudo kuke kill cell kukeond   --realm kukeon-system --space kukeon --stack kukeon --no-daemon
-sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --no-daemon
+sudo kuke kill cell kukeond   --realm kukeon-system --space kukeon --stack kukeon --run-path /opt/kukeon
+sudo kuke delete cell kukeond --realm kukeon-system --space kukeon --stack kukeon --run-path /opt/kukeon
 sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
 ```
 
-`--no-daemon` is required because the daemon itself is what's being stopped — `kuke` has to talk to containerd directly.
+In-process mode is required because the daemon itself is what's being stopped — `kuke` has to talk to containerd directly. An explicit `--run-path` (or `KUKEON_NO_DAEMON=true`) promotes the command into in-process mode.
 
 See [Guides → Init and reset](../guides/init-and-reset.md) for the full teardown-and-bootstrap loop.
 

--- a/docs/site/faq.md
+++ b/docs/site/faq.md
@@ -23,7 +23,7 @@ Yes. Kukeon uses its own containerd namespaces (`<realm>.kukeon.io` — `default
 
 ## Can I run Kukeon without the daemon?
 
-Mostly, yes. Every `kuke` subcommand accepts `--no-daemon`, which runs the operation in-process. You lose the benefit of a long-lived state holder, but for one-off commands it works.
+Mostly, yes — but the explicit `--no-daemon` flag has been retired on daemon-routed workload commands (see #222). To run in-process you can either set `KUKEON_NO_DAEMON=true` in the environment, or pass an explicit `--run-path /some/path` (which auto-promotes to in-process mode). `--no-daemon` is still accepted on the commands where it remains an explicit toggle: `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (the last one keeps the daemon-parity escape hatch).
 
 See [Client and daemon](concepts/client-and-daemon.md).
 

--- a/docs/site/faq.md
+++ b/docs/site/faq.md
@@ -23,7 +23,7 @@ Yes. Kukeon uses its own containerd namespaces (`<realm>.kukeon.io` — `default
 
 ## Can I run Kukeon without the daemon?
 
-Mostly, yes — but the explicit `--no-daemon` flag has been retired on daemon-routed workload commands (see #222). To run in-process you can either set `KUKEON_NO_DAEMON=true` in the environment, or pass an explicit `--run-path /some/path` (which auto-promotes to in-process mode). `--no-daemon` is still accepted on the commands where it remains an explicit toggle: `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm` (the last one keeps the daemon-parity escape hatch).
+Mostly, yes — but the explicit `--no-daemon` flag has been retired on daemon-routed workload commands (see #222). To run in-process you can either set `KUKEON_NO_DAEMON=true` in the environment, or pass an explicit `--run-path /some/path` (which auto-promotes to in-process mode). `--no-daemon` is still accepted on the commands where it remains an explicit toggle: `kuke init`, `kuke uninstall`, `kuke purge`, and every `kuke get <kind>` (the `get` kinds were retained per a user override on the original #222 AC so the in-process escape hatch stays available for every resource lookup, not just `get realm`).
 
 See [Client and daemon](concepts/client-and-daemon.md).
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -63,7 +63,7 @@ sudo usermod -aG kukeon $USER
 # Log out and back in (or run `newgrp kukeon`) so the group takes effect.
 ```
 
-The rest of this guide assumes you have done that. If you skip this step, prepend `sudo` to every `kuke` command below. Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (`kuke get realm --no-daemon`, `kuke purge ... --no-daemon`, or any command with `KUKEON_NO_DAEMON=true` / an explicit `--run-path`).
+The rest of this guide assumes you have done that. If you skip this step, prepend `sudo` to every `kuke` command below. Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (`kuke get <kind> --no-daemon`, `kuke purge ... --no-daemon`, or any command with `KUKEON_NO_DAEMON=true` / an explicit `--run-path`).
 
 ## 5. Verify with `kuke get`
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -63,7 +63,7 @@ sudo usermod -aG kukeon $USER
 # Log out and back in (or run `newgrp kukeon`) so the group takes effect.
 ```
 
-The rest of this guide assumes you have done that. If you skip this step, prepend `sudo` to every `kuke` command below. Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), `kuke doctor cgroups --probe`, and any command run with `--no-daemon`.
+The rest of this guide assumes you have done that. If you skip this step, prepend `sudo` to every `kuke` command below. Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (`kuke get realm --no-daemon`, `kuke purge ... --no-daemon`, or any command with `KUKEON_NO_DAEMON=true` / an explicit `--run-path`).
 
 ## 5. Verify with `kuke get`
 
@@ -129,11 +129,8 @@ spec:
 Apply it:
 
 ```bash
-sudo kuke apply -f docs/examples/hello-world.yaml --no-daemon
+sudo kuke apply -f docs/examples/hello-world.yaml
 ```
-
-!!! info "Why `--no-daemon` here"
-The released `kukeond` container image does not yet bind-mount `/run/containerd/containerd.sock`, so cell creation currently must run in-process via `--no-daemon`. This will change in a future release; see issue #217 for the daemon-only verb track.
 
 Confirm the cell is ready, find its IP on the default-default bridge, and curl it:
 
@@ -149,7 +146,7 @@ Tear it down with:
 
 ```bash
 sudo kuke delete cell hello-world \
-    --realm default --space default --stack default --cascade --no-daemon
+    --realm default --space default --stack default --cascade
 ```
 
 ## 7. Enable shell autocomplete

--- a/docs/site/guides/apply-manifests.md
+++ b/docs/site/guides/apply-manifests.md
@@ -99,15 +99,17 @@ or multi-doc:
 cat realm.yaml space.yaml stack.yaml cell.yaml | sudo kuke apply -f -
 ```
 
-## `--no-daemon` caveat
+## In-process escape hatch
 
-Today, cell creation runs under `--no-daemon` because the released `kukeond` image doesn't bind-mount the containerd socket. If you see `apply` hang or fail when creating a cell, retry with `--no-daemon`:
+`kuke apply` routes through `kukeond` by default. When the daemon is down or you need to debug locally, reach the in-process path via `KUKEON_NO_DAEMON=true` in the env or an explicit `--run-path` (which auto-promotes to in-process mode):
 
 ```bash
-sudo kuke apply -f cell.yaml --no-daemon
+sudo KUKEON_NO_DAEMON=true kuke apply -f cell.yaml
+# or
+sudo kuke apply -f cell.yaml --run-path /opt/kukeon
 ```
 
-See [Client and daemon](../concepts/client-and-daemon.md) for the broader story.
+The `--no-daemon` flag itself was retired from workload commands by #222; see [Client and daemon](../concepts/client-and-daemon.md) for the broader story.
 
 ## Parameterized cell profiles
 

--- a/docs/site/guides/local-dev.md
+++ b/docs/site/guides/local-dev.md
@@ -30,7 +30,7 @@ default      default.kukeon.io      Ready  /kukeon/default
 kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
 ```
 
-If only `kuke get realms --no-daemon` returns that table but `kuke get realms` (daemon-routed) does not, the daemon's view of `/opt/kukeon` diverged from the in-process controller — usually a missing bind-mount in the `kukeond` cell spec. (`get realms` still keeps the `--no-daemon` flag; other workload `get` kinds no longer do — reach in-process mode there via `--run-path /opt/kukeon` or `KUKEON_NO_DAEMON=true`.) See [Troubleshooting → `kuke get` and `kuke get --no-daemon` disagree](troubleshooting.md#kuke-get-and-kuke-get---no-daemon-disagree).
+If only `kuke get realms --no-daemon` returns that table but `kuke get realms` (daemon-routed) does not, the daemon's view of `/opt/kukeon` diverged from the in-process controller — usually a missing bind-mount in the `kukeond` cell spec. (Every `kuke get <kind>` keeps the `--no-daemon` flag; `KUKEON_NO_DAEMON=true` and `--run-path /opt/kukeon` work too.) See [Troubleshooting → `kuke get` and `kuke get --no-daemon` disagree](troubleshooting.md#kuke-get-and-kuke-get---no-daemon-disagree).
 
 User data under `/opt/kukeon/default/**` is untouched across iterations; only the system cell is replaced.
 
@@ -98,7 +98,7 @@ To run individual phases by hand — typically while debugging a single phase:
 
 ## Running without the daemon
 
-When iterating on controller code you often don't need the daemon up at all. In-process mode runs every `kuke` command against your freshly built binary without the socket round-trip. Reach it by passing `--run-path /opt/kukeon` (which auto-promotes) or by exporting `KUKEON_NO_DAEMON=true`; the `--no-daemon` flag itself still works on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm`:
+When iterating on controller code you often don't need the daemon up at all. In-process mode runs every `kuke` command against your freshly built binary without the socket round-trip. Reach it by passing `--run-path /opt/kukeon` (which auto-promotes) or by exporting `KUKEON_NO_DAEMON=true`; the `--no-daemon` flag itself still works on `kuke init`, `kuke uninstall`, `kuke purge`, and every `kuke get <kind>`:
 
 ```bash
 sudo kuke get realms --no-daemon

--- a/docs/site/guides/local-dev.md
+++ b/docs/site/guides/local-dev.md
@@ -30,7 +30,7 @@ default      default.kukeon.io      Ready  /kukeon/default
 kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
 ```
 
-If only `kuke get realms --no-daemon` returns that table but `kuke get realms` (daemon-routed) does not, the daemon's view of `/opt/kukeon` diverged from the in-process controller — usually a missing bind-mount in the `kukeond` cell spec. See [Troubleshooting → `kuke get` and `kuke get --no-daemon` disagree](troubleshooting.md#kuke-get-and-kuke-get---no-daemon-disagree).
+If only `kuke get realms --no-daemon` returns that table but `kuke get realms` (daemon-routed) does not, the daemon's view of `/opt/kukeon` diverged from the in-process controller — usually a missing bind-mount in the `kukeond` cell spec. (`get realms` still keeps the `--no-daemon` flag; other workload `get` kinds no longer do — reach in-process mode there via `--run-path /opt/kukeon` or `KUKEON_NO_DAEMON=true`.) See [Troubleshooting → `kuke get` and `kuke get --no-daemon` disagree](troubleshooting.md#kuke-get-and-kuke-get---no-daemon-disagree).
 
 User data under `/opt/kukeon/default/**` is untouched across iterations; only the system cell is replaced.
 
@@ -98,11 +98,12 @@ To run individual phases by hand — typically while debugging a single phase:
 
 ## Running without the daemon
 
-When iterating on controller code you often don't need the daemon up at all. `--no-daemon` runs every `kuke` command in-process against your freshly built binary:
+When iterating on controller code you often don't need the daemon up at all. In-process mode runs every `kuke` command against your freshly built binary without the socket round-trip. Reach it by passing `--run-path /opt/kukeon` (which auto-promotes) or by exporting `KUKEON_NO_DAEMON=true`; the `--no-daemon` flag itself still works on `kuke init`, `kuke uninstall`, `kuke purge`, and `kuke get realm`:
 
 ```bash
 sudo kuke get realms --no-daemon
-sudo kuke apply -f my-cell.yaml --no-daemon
+sudo kuke apply -f my-cell.yaml --run-path /opt/kukeon
+sudo KUKEON_NO_DAEMON=true kuke get cells --realm default --space default --stack default
 ```
 
 This is the fastest feedback loop — no image build, no reload, just `make kuke` and go.

--- a/docs/site/guides/run-claude-code.md
+++ b/docs/site/guides/run-claude-code.md
@@ -59,7 +59,7 @@ If you don't run Docker, use the `nerdctl save … | sudo kuke image load -` for
 sudo kuke apply -f docs/examples/claude-code/cell.yaml
 ```
 
-`kuke apply` creates the cell. If you hit a daemon issue, [retry under `--no-daemon`](apply-manifests.md#--no-daemon-caveat).
+`kuke apply` creates the cell. If you hit a daemon issue, [retry in-process](apply-manifests.md#in-process-escape-hatch).
 
 Then connect a terminal to the `work` container:
 
@@ -74,10 +74,10 @@ Press `^]^]` (two consecutive `Ctrl-]` keystrokes) to detach cleanly. The cell k
 ### Tear-down
 
 ```bash
-sudo kuke delete cell claude-code --cascade --no-daemon
+sudo kuke delete cell claude-code --cascade
 ```
 
-`--cascade` removes the cell's containers in the same call. The `--no-daemon` flag is the same caveat as in `kuke apply` — see [Applying manifests](apply-manifests.md#--no-daemon-caveat).
+`--cascade` removes the cell's containers in the same call. If `kuke delete` fails because the daemon is down, fall back to in-process mode the same way `kuke apply` does — see [Applying manifests](apply-manifests.md#in-process-escape-hatch).
 
 ### Optional: persist `~/.claude` across restarts
 
@@ -130,4 +130,4 @@ See [`kuke run`](../cli/kuke-run.md) for the full flag surface, including `--nam
 
 - **The full crew agent-runner shape.** [`eminwux/crew`](https://github.com/eminwux/crew) — SSH bind, GPG-signed commits, agents-repo clone, project-repo clone, the orchestrator that dispatches per-call cells. Two layers up from this guide.
 - **Cell teardown verbs.** [`docs/cli-use-cases.md`](https://github.com/eminwux/kukeon/blob/main/docs/cli-use-cases.md) — the full operator workflow reference, including `stop` / `kill` / `delete` / `purge --cascade` for cells.
-- **Manifest reference.** [Applying manifests](apply-manifests.md) — multi-doc manifests, the `--no-daemon` caveat, profile parameter resolution order.
+- **Manifest reference.** [Applying manifests](apply-manifests.md) — multi-doc manifests, the in-process escape hatch, profile parameter resolution order.

--- a/docs/site/guides/troubleshooting.md
+++ b/docs/site/guides/troubleshooting.md
@@ -158,7 +158,7 @@ sudo kuke init
 
 ## `kuke get realms` and `kuke get realms --no-daemon` disagree
 
-**Symptom.** The same `kuke get realms` returns different data depending on whether it goes through the daemon or runs in-process (the `--no-daemon` flag is still accepted on `kuke get realm` as the canonical daemon-parity check; see #223 for its eventual retirement).
+**Symptom.** The same `kuke get realms` returns different data depending on whether it goes through the daemon or runs in-process (the `--no-daemon` flag is still accepted on every `kuke get <kind>`; `get realms` is the canonical daemon-parity check, see #223 for its eventual retirement once `kuke status` absorbs the parity contract).
 
 **What it means.** The `kukeond` container isn't bind-mounting `/opt/kukeon` (or `/run/kukeon`) correctly. Both code paths share a reconciler, so divergence is always about what the daemon can see on disk.
 

--- a/docs/site/guides/troubleshooting.md
+++ b/docs/site/guides/troubleshooting.md
@@ -19,7 +19,7 @@ sudo usermod -aG kukeon $USER
 # Log out and back in so the new group membership is picked up.
 ```
 
-After logging back in, `id -nG | grep kukeon` should show the group. Daemon-routed commands now work without `sudo`. Commands that mutate the host (`kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), `kuke doctor cgroups --probe`) still require root regardless.
+After logging back in, `id -nG | grep kukeon` should show the group. Daemon-routed commands now work without `sudo`. Commands that mutate the host (`kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`) still require root regardless.
 
 ## `kuke doctor cgroups` exits non-zero
 
@@ -135,8 +135,9 @@ dial unix /run/kukeon/kukeond.sock: connect: no such file or directory
 **Diagnosis.**
 
 ```bash
-# Is the daemon cell running?
-sudo kuke get cells --realm kuke-system --space kukeon --stack kukeon --no-daemon
+# Is the daemon cell running? (in-process via --run-path promotion so
+# we don't depend on the daemon we are trying to diagnose)
+sudo kuke get cells --realm kuke-system --space kukeon --stack kukeon --run-path /opt/kukeon
 
 # Is the socket actually on disk?
 ls -l /run/kukeon/
@@ -155,9 +156,9 @@ sudo kuke daemon reset
 sudo kuke init
 ```
 
-## `kuke get` and `kuke get --no-daemon` disagree
+## `kuke get realms` and `kuke get realms --no-daemon` disagree
 
-**Symptom.** The same `get` returns different data depending on whether it goes through the daemon or runs in-process.
+**Symptom.** The same `kuke get realms` returns different data depending on whether it goes through the daemon or runs in-process (the `--no-daemon` flag is still accepted on `kuke get realm` as the canonical daemon-parity check; see #223 for its eventual retirement).
 
 **What it means.** The `kukeond` container isn't bind-mounting `/opt/kukeon` (or `/run/kukeon`) correctly. Both code paths share a reconciler, so divergence is always about what the daemon can see on disk.
 

--- a/docs/site/install.sh
+++ b/docs/site/install.sh
@@ -189,10 +189,11 @@ check_containerd() {
 # image bundles them at /opt/cni/bin (Dockerfile cni-plugins stage), and
 # `kukeondCellDoc` (internal/controller/bootstrap.go) only bind-mounts CNI
 # state directories (/opt/cni/net.d, /var/lib/cni, /opt/cni/cache) from the
-# host — not the plugin binaries. Host plugins are needed only by `--no-daemon`
-# workflows (documented at docs/site/cli/commands.md). Requiring them in the
-# default install path would force every operator to apt-install a package
-# the standard daemon path never reads.
+# host — not the plugin binaries. Host plugins are needed only by in-process
+# workflows (KUKEON_NO_DAEMON=true or explicit --run-path; documented at
+# docs/site/cli/commands.md). Requiring them in the default install path
+# would force every operator to apt-install a package the standard daemon
+# path never reads.
 run_prereqs() {
     step "Checking prerequisites"
     check_cgroupv2 || true

--- a/docs/site/install/build-from-source.md
+++ b/docs/site/install/build-from-source.md
@@ -65,9 +65,9 @@ To iterate after a code change, tear down the kukeond cell (user data under `/op
 
 ```bash
 sudo kuke kill cell kukeond \
-    --realm kuke-system --space kukeon --stack kukeon --no-daemon
+    --realm kuke-system --space kukeon --stack kukeon --run-path /opt/kukeon
 sudo kuke delete cell kukeond \
-    --realm kuke-system --space kukeon --stack kukeon --no-daemon
+    --realm kuke-system --space kukeon --stack kukeon --run-path /opt/kukeon
 sudo rm -f /run/kukeon/kukeond.sock /run/kukeon/kukeond.pid
 
 # Rebuild, reload, re-init

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -88,7 +88,7 @@ sudo usermod -aG kukeon $USER
 kuke get realms
 ```
 
-Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (`kuke get realm --no-daemon`, `kuke purge ... --no-daemon`, or any command with `KUKEON_NO_DAEMON=true` / an explicit `--run-path`).
+Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (`kuke get <kind> --no-daemon`, `kuke purge ... --no-daemon`, or any command with `KUKEON_NO_DAEMON=true` / an explicit `--run-path`).
 
 ## Host supervisor
 

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -88,7 +88,7 @@ sudo usermod -aG kukeon $USER
 kuke get realms
 ```
 
-Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), `kuke doctor cgroups --probe`, and any command run with the `--no-daemon` flag.
+Operations that bypass the daemon still need root: `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (`kuke get realm --no-daemon`, `kuke purge ... --no-daemon`, or any command with `KUKEON_NO_DAEMON=true` / an explicit `--run-path`).
 
 ## Host supervisor
 

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -5,7 +5,7 @@ Kukeon (v0.5.0 beta) runs on a single Linux host and relies on two things being 
 1. A kernel with **cgroups v2** enabled
 2. A running **containerd** daemon
 
-CNI plugins are bundled inside the `kukeond` container image, so the standard daemon-mediated install path does **not** need them on the host. If you plan to use the transitional `--no-daemon` flag for some operations, see the [`--no-daemon` host-CNI note below](#cni-plugins-for---no-daemon-only).
+CNI plugins are bundled inside the `kukeond` container image, so the standard daemon-mediated install path does **not** need them on the host. If you plan to run any operation in in-process mode (`kuke get realm --no-daemon`, `kuke purge ... --no-daemon`, `KUKEON_NO_DAEMON=true ...`, or any command with an explicit `--run-path`), see the [host-CNI note below](#cni-plugins-for-in-process-mode-only).
 
 The [one-line installer](install-linux.md) checks both prereqs for you before touching the system; the notes below cover the same checks for operators driving the install manually or debugging a failed installer run.
 
@@ -51,11 +51,11 @@ sudo ctr version
 
 Kukeon uses its own containerd namespaces (one per realm: `<realm>.kukeon.io`). `kuke init` provisions two by default — `default.kukeon.io` for user workloads and `kuke-system.kukeon.io` for the `kukeond` daemon. Kukeon does not interfere with existing containerd namespaces used by Docker, nerdctl, or other tools.
 
-## CNI plugins (for `--no-daemon` only)
+## CNI plugins (for in-process mode only)
 
 The `kukeond` container image bundles the CNI reference plugins at `/opt/cni/bin` inside the container, and the daemon invokes them from there. The standard install path (`kuke init` → daemon-mediated operations) therefore does **not** require host-side CNI plugins.
 
-You only need to install plugins on the host if you plan to run operations with `--no-daemon`, which executes controllers in-process via the `kuke` binary instead of routing through `kukeond`. In that mode `kuke` shells out to plugin binaries at the host's `/opt/cni/bin`. See [`--no-daemon` host prerequisites](../cli/commands.md#-no-daemon-host-prerequisites) for the canonical reference. Note that `--no-daemon` is slated for removal from creation commands in a future release.
+You only need to install plugins on the host if you plan to run operations in in-process mode (`kuke get realm --no-daemon`, `kuke purge ... --no-daemon`, `KUKEON_NO_DAEMON=true ...`, or any command with an explicit `--run-path`), which executes controllers in-process via the `kuke` binary instead of routing through `kukeond`. In that mode `kuke` shells out to plugin binaries at the host's `/opt/cni/bin`. See [in-process mode host prerequisites](../cli/commands.md#in-process-mode-host-prerequisites) for the canonical reference. The in-process path itself is slated for retirement once `ClientFromCmd`'s in-process branch is removed (#566).
 
 If you do need it, install from [containernetworking/plugins](https://github.com/containernetworking/plugins):
 
@@ -72,7 +72,7 @@ At minimum Kukeon needs `bridge`, `host-local`, `loopback`, and `portmap`.
 
 Two paths exist, depending on whether the command goes through `kukeond` or bypasses it:
 
-- **Direct host writes need root.** `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — `--no-daemon` is ignored on image subcommands), `kuke doctor cgroups --probe`, and anything else run with `--no-daemon` touch cgroups, netlink, containerd, or `/opt/kukeon` directly. Run them with `sudo`; otherwise they fail fast with a clear "must run as root" error before touching anything.
+- **Direct host writes need root.** `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (the four `--no-daemon`-accepting commands, plus anything with `KUKEON_NO_DAEMON=true` or an explicit `--run-path`) touch cgroups, netlink, containerd, or `/opt/kukeon` directly. Run them with `sudo`; otherwise they fail fast with a clear "must run as root" error before touching anything.
 - **Daemon-routed commands do not need root.** `kuke init` provisions a system `kukeon` group and sets the daemon socket at `/run/kukeon/kukeond.sock` to mode `0660 root:kukeon`. Adding a user to that group (`sudo usermod -aG kukeon $USER`, then re-login) is enough for `kuke get`, `kuke create`, `kuke apply`, `kuke delete`, `kuke log`, and `kuke attach` to work without `sudo`. Writes under `/opt/kukeon` still require root, but they go through the daemon.
 
 See [Getting Started → Daily use without sudo](../getting-started.md#daily-use-without-sudo) for the post-init steps.

--- a/docs/site/install/prerequisites.md
+++ b/docs/site/install/prerequisites.md
@@ -5,7 +5,7 @@ Kukeon (v0.5.0 beta) runs on a single Linux host and relies on two things being 
 1. A kernel with **cgroups v2** enabled
 2. A running **containerd** daemon
 
-CNI plugins are bundled inside the `kukeond` container image, so the standard daemon-mediated install path does **not** need them on the host. If you plan to run any operation in in-process mode (`kuke get realm --no-daemon`, `kuke purge ... --no-daemon`, `KUKEON_NO_DAEMON=true ...`, or any command with an explicit `--run-path`), see the [host-CNI note below](#cni-plugins-for-in-process-mode-only).
+CNI plugins are bundled inside the `kukeond` container image, so the standard daemon-mediated install path does **not** need them on the host. If you plan to run any operation in in-process mode (`kuke get <kind> --no-daemon`, `kuke purge ... --no-daemon`, `KUKEON_NO_DAEMON=true ...`, or any command with an explicit `--run-path`), see the [host-CNI note below](#cni-plugins-for-in-process-mode-only).
 
 The [one-line installer](install-linux.md) checks both prereqs for you before touching the system; the notes below cover the same checks for operators driving the install manually or debugging a failed installer run.
 
@@ -55,7 +55,7 @@ Kukeon uses its own containerd namespaces (one per realm: `<realm>.kukeon.io`). 
 
 The `kukeond` container image bundles the CNI reference plugins at `/opt/cni/bin` inside the container, and the daemon invokes them from there. The standard install path (`kuke init` → daemon-mediated operations) therefore does **not** require host-side CNI plugins.
 
-You only need to install plugins on the host if you plan to run operations in in-process mode (`kuke get realm --no-daemon`, `kuke purge ... --no-daemon`, `KUKEON_NO_DAEMON=true ...`, or any command with an explicit `--run-path`), which executes controllers in-process via the `kuke` binary instead of routing through `kukeond`. In that mode `kuke` shells out to plugin binaries at the host's `/opt/cni/bin`. See [in-process mode host prerequisites](../cli/commands.md#in-process-mode-host-prerequisites) for the canonical reference. The in-process path itself is slated for retirement once `ClientFromCmd`'s in-process branch is removed (#566).
+You only need to install plugins on the host if you plan to run operations in in-process mode (`kuke get <kind> --no-daemon`, `kuke purge ... --no-daemon`, `KUKEON_NO_DAEMON=true ...`, or any command with an explicit `--run-path`), which executes controllers in-process via the `kuke` binary instead of routing through `kukeond`. In that mode `kuke` shells out to plugin binaries at the host's `/opt/cni/bin`. See [in-process mode host prerequisites](../cli/commands.md#in-process-mode-host-prerequisites) for the canonical reference. The in-process path itself is slated for retirement once `ClientFromCmd`'s in-process branch is removed (#566).
 
 If you do need it, install from [containernetworking/plugins](https://github.com/containernetworking/plugins):
 
@@ -72,7 +72,7 @@ At minimum Kukeon needs `bridge`, `host-local`, `loopback`, and `portmap`.
 
 Two paths exist, depending on whether the command goes through `kukeond` or bypasses it:
 
-- **Direct host writes need root.** `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (the four `--no-daemon`-accepting commands, plus anything with `KUKEON_NO_DAEMON=true` or an explicit `--run-path`) touch cgroups, netlink, containerd, or `/opt/kukeon` directly. Run them with `sudo`; otherwise they fail fast with a clear "must run as root" error before touching anything.
+- **Direct host writes need root.** `kuke init`, `kuke daemon reset`, `kuke image load` (in-process by design — image commands run in-process regardless of flags), `kuke doctor cgroups --probe`, and any command that runs in-process (the `--no-daemon`-accepting commands listed above, plus anything with `KUKEON_NO_DAEMON=true` or an explicit `--run-path`) touch cgroups, netlink, containerd, or `/opt/kukeon` directly. Run them with `sudo`; otherwise they fail fast with a clear "must run as root" error before touching anything.
 - **Daemon-routed commands do not need root.** `kuke init` provisions a system `kukeon` group and sets the daemon socket at `/run/kukeon/kukeond.sock` to mode `0660 root:kukeon`. Adding a user to that group (`sudo usermod -aG kukeon $USER`, then re-login) is enough for `kuke get`, `kuke create`, `kuke apply`, `kuke delete`, `kuke log`, and `kuke attach` to work without `sudo`. Writes under `/opt/kukeon` still require root, but they go through the daemon.
 
 See [Getting Started → Daily use without sudo](../getting-started.md#daily-use-without-sudo) for the post-init steps.

--- a/docs/site/tutorials/first-stack.md
+++ b/docs/site/tutorials/first-stack.md
@@ -74,7 +74,7 @@ spec:
 ## 2. Apply it
 
 ```bash
-sudo kuke apply -f tutorial.yaml --no-daemon
+sudo kuke apply -f tutorial.yaml
 ```
 
 Kukeon creates the space, stack, and two cells in dependency order. The nginx cell gets one IP on the `tutorial` space's bridge; the busybox cell gets another.
@@ -106,10 +106,10 @@ In this example `wget http://web` works because the space's bridge has a resolve
 
 ```bash
 # Cascade-delete the whole stack (both cells and their containers)
-sudo kuke delete stack demo --realm default --space tutorial --cascade --no-daemon
+sudo kuke delete stack demo --realm default --space tutorial --cascade
 
 # Then the space (if you're done with it)
-sudo kuke delete space tutorial --realm default --cascade --no-daemon
+sudo kuke delete space tutorial --realm default --cascade
 ```
 
 ## What you just learned

--- a/docs/site/tutorials/hello-world.md
+++ b/docs/site/tutorials/hello-world.md
@@ -47,10 +47,10 @@ It's a single cell with a single container. The container bootstraps an `index.h
 ## 2. Apply it
 
 ```bash
-sudo kuke apply -f docs/examples/hello-world.yaml --no-daemon
+sudo kuke apply -f docs/examples/hello-world.yaml
 ```
 
-`--no-daemon` is required today because the released daemon container image doesn't bind-mount the containerd socket. See [Client and daemon](../concepts/client-and-daemon.md).
+See [Client and daemon](../concepts/client-and-daemon.md) for how `kuke` routes through `kukeond` by default, and the in-process escape hatch when the daemon is down.
 
 ## 3. Confirm the cell is Ready
 
@@ -85,7 +85,7 @@ In the default bootstrap, the containerd namespace for `realm=default` is `kukeo
 
 ```bash
 sudo kuke delete cell hello-world \
-    --realm default --space default --stack default --cascade --no-daemon
+    --realm default --space default --stack default --cascade
 ```
 
 `--cascade` removes every container in the cell along with the cell itself.

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -64,8 +64,9 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	t.Parallel()
 
 	// Setup: isolated runPath, unique resource names, in-process controller
-	// (`--no-daemon`) so the per-container socket lives under the test's
-	// runPath rather than the host daemon's.
+	// (promoted by passing `--run-path` to a workload command) so the
+	// per-container socket lives under the test's runPath rather than the
+	// host daemon's.
 	runPath := getRandomRunPath(t)
 
 	realmName := generateUniqueRealmName(t)
@@ -230,9 +231,9 @@ func verifyContainerTaskIsRunning(t *testing.T, namespace, containerID string) b
 
 // cleanupRealmNoDaemon, cleanupSpaceNoDaemon, cleanupStackNoDaemon, and
 // cleanupCellNoDaemon mirror the existing cleanup helpers but route through
-// `--no-daemon` so they use the same in-process controller as the test
-// itself. Without this the cleanup goes via the host daemon (different
-// runPath) and silently no-ops, leaving resources behind.
+// in-process mode (via the `--run-path` promotion) so they use the same
+// controller as the test itself. Without this the cleanup goes via the host
+// daemon (different runPath) and silently no-ops, leaving resources behind.
 func cleanupRealmNoDaemon(t *testing.T, runPath, realmName string) {
 	t.Helper()
 	args := append(buildKukeRunPathArgs(runPath), "delete", "realm", realmName, "--cascade")
@@ -262,7 +263,7 @@ func cleanupCellNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName,
 
 // getCellIDNoDaemon mirrors getCellID but goes through the in-process
 // controller. The realm namespace argument used elsewhere collapses to the
-// realm name when --no-daemon owns the metadata.
+// realm name when the in-process controller owns the metadata.
 func getCellIDNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) (string, error) {
 	t.Helper()
 

--- a/e2e/e2e_kuke_invalid_names_test.go
+++ b/e2e/e2e_kuke_invalid_names_test.go
@@ -24,7 +24,7 @@ import (
 // TestKuke_CreateSpace_RejectsInvalidNames covers the AC for #180: invalid
 // space names ("_" or "/") must be rejected end-to-end with a non-zero exit
 // code and a clear error message that names the offending input. Run via the
-// in-process controller (--no-daemon) so the test is self-contained — the
+// in-process controller (via the `--run-path` promotion) so the test is self-contained — the
 // validator is wired at both controller and runner boundaries, so the same
 // rejection fires either way.
 func TestKuke_CreateSpace_RejectsInvalidNames(t *testing.T) {

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -82,12 +82,13 @@ spec:
   # Default: unix:///run/kukeon/kukeond.sock
   host: unix:///run/kukeon/kukeond.sock
 
-  # Kukeon runtime root used by --no-daemon operations that read /opt/kukeon
-  # directly instead of going through kukeond.
+  # Kukeon runtime root used by in-process operations that read /opt/kukeon
+  # directly instead of going through kukeond. An explicit --run-path on the
+  # CLI promotes the command into in-process mode.
   # Default: /opt/kukeon
   runPath: /opt/kukeon
 
-  # Containerd unix socket --no-daemon operations connect to.
+  # Containerd unix socket in-process operations connect to.
   # Default: /run/containerd/containerd.sock
   containerdSocket: /run/containerd/containerd.sock
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -189,10 +189,11 @@ check_containerd() {
 # image bundles them at /opt/cni/bin (Dockerfile cni-plugins stage), and
 # `kukeondCellDoc` (internal/controller/bootstrap.go) only bind-mounts CNI
 # state directories (/opt/cni/net.d, /var/lib/cni, /opt/cni/cache) from the
-# host — not the plugin binaries. Host plugins are needed only by `--no-daemon`
-# workflows (documented at docs/site/cli/commands.md). Requiring them in the
-# default install path would force every operator to apt-install a package
-# the standard daemon path never reads.
+# host — not the plugin binaries. Host plugins are needed only by in-process
+# workflows (KUKEON_NO_DAEMON=true or explicit --run-path; documented at
+# docs/site/cli/commands.md). Requiring them in the default install path
+# would force every operator to apt-install a package the standard daemon
+# path never reads.
 run_prereqs() {
     step "Checking prerequisites"
     check_cgroupv2 || true


### PR DESCRIPTION
## Summary
- Demotes `--no-daemon` from a root-persistent flag to a per-command opt-in. Retained on `kuke init`, `kuke uninstall`, `kuke purge` (persistent on the parent — propagates to every subcommand), and **every `kuke get <kind>`** (persistent on the parent — propagates to `cell` / `space` / `stack` / `cell` / `container` / `realm`). Removed from the remaining daemon-routed workload commands: `apply`, `create`, `run`, `attach`, `delete`, `kill`, `start`, `stop`, `log`, `refresh`.
- **User override on the original AC.** Issue #222 originally said "remove from `kuke get` (all kinds except `realms`)." A follow-up directive on this PR widened the retention so every `get <kind>` keeps `--no-daemon`. The in-process escape hatch is just as useful when looking up spaces / stacks / cells / containers as it is for realms (and the dev-init parity check still happens to land on `get realms` because that's the canonical daemon-parity probe).
- The in-process controller path itself stays reachable on the workload commands that lost the flag via `KUKEON_NO_DAEMON=true` or the existing `--run-path` promotion added in #555 — phase 1 of #222 is cobra-def-only; the in-process branch in `ClientFromCmd` lives on until #566.
- Adds `cmd/kuke/shared/no_daemon.go` so the retained registrations share one source of truth for the flag's name and usage. `rebindNoDaemonViperToLeaf` rebinds the viper key to the actually-executing leaf at `PersistentPreRunE`, since multiple per-command `BindPFlag` calls would otherwise let last-bind-wins read from the wrong instance. `KUKEON_NO_DAEMON` env binding now lives in `loadConfig` rather than on the (now-removed) root flag.
- Doc + comment sweep: README, the full docs/site tree, `docs/cli-use-cases.md`, `docs/kuke.yaml`, `internal/clientconfig/clientconfig.go`, `scripts/install.sh`, and a handful of e2e test rationale comments shift from "pass `--no-daemon`" to "in-process mode (via `--run-path` / `KUKEON_NO_DAEMON=true`)". Daemon-cell-teardown snippets (`kuke kill cell kukeond` / `kuke delete cell kukeond` in README, build-from-source, system-realm) now use `--run-path /opt/kukeon` — required because the daemon is what's being torn down. The kukeond cell still ships with `--no-daemon` retained on init/uninstall/purge/get per the AC.

### Non-obvious calls flagged for review
- **`get` keeps the flag on every kind (user override on the AC).** See top of summary — explicit override on this PR after the issue's original "only realms" wording. Restored after the initial commit; the fix-up commit on this branch is the lineage of that override.
- **Side effect on unannounced commands.** Removing the root-persistent registration also drops `--no-daemon` from `start`, `stop`, `log`, and `refresh`, which aren't listed in the issue body. They're daemon-routed workload commands by the same reasoning as the AC-listed ones; in-process reach is still available via `KUKEON_NO_DAEMON=true` / `--run-path`. Documented in the heads-up comment on the issue.
- **`--no-daemon` re-registered on `purge` and `get` persistently rather than per leaf.** Matches existing behavior (`purge` previously inherited it from root via the same propagation), and the persistent variant means every `purge <kind>` / `get <kind>` inherits it without per-subcommand wiring.
- **`kuke run --rm` error string updated** from "incompatible with `--no-daemon`" to "incompatible with in-process mode (`KUKEON_NO_DAEMON=true` or `--run-path` promotion)" since the literal flag is gone from `kuke run`. `cmd/kuke/run/run_test.go` updated to match.
- **`TestRunPathImpliesNoDaemon` updated** to walk to the leaf and call `ParseFlags(nil)` so cobra merges inherited persistent flags before the test reads them — previously the test set flags on the root, which still happens to host `--run-path` but no longer hosts `--no-daemon`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (all packages green; updated tests pass: `cmd/kuke`, `cmd/kuke/get/*`, `cmd/kuke/run`)
- [x] Literal-flag grep: `grep -rn '"--no-daemon"' --include="*.go" --include="*.sh" --include="*.yaml" --include="*.yml" .` returns no caller occurrences
- [x] Runtime check: every `kuke get <cells|spaces|stacks|containers|realms> --help` now exposes `--no-daemon` under Global Flags (inherited from the parent `get` cmd's persistent registration)
- [x] `make dev-init` smoke (daemon-parity check + `kuke attach` smoke + nested-mode parent-attach post-flight all clean on the fix-up commit)

Closes #222