### PR TITLE
feat: derive kukeond socket from --run-path so nested e2e init avoids parent collision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,15 +99,27 @@ KUKEON_E2E_IMAGE ?= docker.io/library/$(KUKEON_E2E_IMAGE_DOCKER_NAME)
 
 e2e: test-e2e
 .PHONY: test-e2e
+# `env -u KUKEOND_SOCKET` (rather than re-exporting an absent value) keeps the
+# AC's "no global KUKEOND_SOCKET for the test run" constraint honest: any
+# leftover from an interactive shell — including a parent dev-init.sh that
+# pinned `/run/kukeon-dev/kukeond.sock` for the nested daemon — is stripped
+# before `go test` so `kuke init --run-path <tempdir>` falls through to the
+# per-runPath auto-derivation. The nested probe (`/.kukeon/bin/kuketty`,
+# mirrors `scripts/dev-init.sh`) only emits a diagnostic; the unset is
+# unconditional because the e2e suite's daemon-bringing tests rely on the
+# per-test --run-path → socket derivation in either mode.
 test-e2e: kuke kuketty
 	@echo "Building local kukeond image $(KUKEON_E2E_IMAGE_DOCKER_NAME) for e2e"
 	docker build --build-arg VERSION=v0.0.0-e2e -t $(KUKEON_E2E_IMAGE_DOCKER_NAME) .
 	@echo "Running e2e tests using binaries in project root"
+	@if [ -x /.kukeon/bin/kuketty ]; then \
+		echo "[nested mode: kuke init --run-path <tempdir> derives <tempdir>/kukeond.sock; parent dev cell's /run/kukeon/ socket untouched]"; \
+	fi
 	HOME=$(HOME) PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$(PATH) \
 		E2E_BIN_DIR=$(CURDIR) \
 		KUKEON_E2E_IMAGE=$(KUKEON_E2E_IMAGE) \
 		KUKEON_E2E_IMAGE_DOCKER_NAME=$(KUKEON_E2E_IMAGE_DOCKER_NAME) \
-		go test -v ./e2e
+		env -u KUKEOND_SOCKET go test -v ./e2e
 
 tag:
 	git tag -s v$(KUKEON_VERSION) -m "Release version $(KUKEON_VERSION)"

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -211,6 +211,50 @@ func setPersistentFlags(_ *cobra.Command) error {
 	return nil
 }
 
+// applyRunPathImpliesKukeondSocket derives the daemon's listen socket as
+// `<runPath>/kukeond.sock` when the operator passed `--run-path` explicitly
+// (flag or KUKEON_RUN_PATH env) but did not pin KUKEOND_SOCKET themselves.
+// Without this, `kuke init --run-path X` always bootstraps the kukeond
+// system cell bind-bound to the default `/run/kukeon/kukeond.sock` — which
+// collides with the parent host's daemon when running inside a nested
+// `kukeon-dev-root` cell (PR #548 bind-mounts the parent's `/run/kukeon/`
+// into the nest at the same path), and blocks per-test isolation in the
+// e2e suite's TestKuke_Init_VerifyState.
+//
+// Operator intent: `--run-path` is per-invocation, explicit "this run
+// lives under X" signal. The daemon socket living under X follows; the
+// operator who genuinely wants the in-tree convention restores it with
+// `KUKEOND_SOCKET=/run/kukeon/kukeond.sock kuke init --run-path X`.
+//
+// ServerConfiguration's spec.Socket trips !viper.IsSet through
+// applyServerConfiguration's viper.Set, so YAML-configured socket paths
+// are respected.
+func applyRunPathImpliesKukeondSocket(cmd *cobra.Command, runPath string) {
+	if viper.IsSet(config.KUKEOND_SOCKET.ViperKey) {
+		return
+	}
+	if !flagChanged(cmd, "run-path") && !envSet(config.KUKEON_ROOT_RUN_PATH) {
+		return
+	}
+	viper.Set(config.KUKEOND_SOCKET.ViperKey, filepath.Join(runPath, "kukeond.sock"))
+}
+
+// flagChanged checks both the local and persistent flag sets so the helper
+// is correct in both unit tests (where cmd is built bare and persistent
+// flags are not yet merged into cmd.Flags()) and in production (where
+// cmd is the leaf subcommand and the merged set already contains the
+// parent's persistent flags). Mirrors the helper of the same name in
+// cmd/kuke/kuke.go.
+func flagChanged(cmd *cobra.Command, name string) bool {
+	if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+		return true
+	}
+	if f := cmd.PersistentFlags().Lookup(name); f != nil && f.Changed {
+		return true
+	}
+	return false
+}
+
 // applyServerConfiguration layers the loaded ServerConfiguration on top of
 // viper for fields the operator did not explicitly set on the command line
 // or via environment. Order of precedence: explicit `--flag` > env >
@@ -371,16 +415,21 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("configure runtime: %w", cfgErr)
 	}
 
-	socketPath := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
-	if socketPath == "" {
-		socketPath = config.KUKEOND_SOCKET.Default
-	}
-
 	image := resolveKukeondImage()
 
 	runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
 	if runPath == "" {
 		runPath = config.DefaultRunPath()
+	}
+
+	// Must run after applyServerConfiguration (which may viper.Set the
+	// socket from YAML) and after runPath is resolved (the derived value
+	// is `<runPath>/kukeond.sock`).
+	applyRunPathImpliesKukeondSocket(cmd, runPath)
+
+	socketPath := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
+	if socketPath == "" {
+		socketPath = config.KUKEOND_SOCKET.Default
 	}
 
 	containerdSocket := viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey)

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -91,6 +91,14 @@ func resolveKukeondImage() string
 //go:linkname applyServerConfiguration github.com/eminwux/kukeon/cmd/kuke/init.applyServerConfiguration
 func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurationSpec)
 
+//go:linkname applyRunPathImpliesKukeondSocket github.com/eminwux/kukeon/cmd/kuke/init.applyRunPathImpliesKukeondSocket
+func applyRunPathImpliesKukeondSocket(cmd *cobra.Command, runPath string)
+
+// ApplyRunPathImpliesKukeondSocket exposes the unexported helper for tests.
+func ApplyRunPathImpliesKukeondSocket(cmd *cobra.Command, runPath string) {
+	applyRunPathImpliesKukeondSocket(cmd, runPath)
+}
+
 // ResolveKukeondImage exposes the unexported helper for tests.
 func ResolveKukeondImage() string {
 	return resolveKukeondImage()
@@ -866,6 +874,116 @@ func TestApplyServerConfigurationEnvOverridesConfig(t *testing.T) {
 	// the env check is per-field, not all-or-nothing.
 	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "warn" {
 		t.Errorf("LogLevel: got %q, want %q", got, "warn")
+	}
+}
+
+// TestApplyRunPathImpliesKukeondSocket locks in the issue #557 contract:
+// `kuke init --run-path X` (or KUKEON_RUN_PATH=X env) auto-derives the
+// daemon socket to `<X>/kukeond.sock` when KUKEOND_SOCKET is not pinned,
+// unblocking nested e2e (TestKuke_Init_VerifyState) without colliding with
+// the parent dev cell's `/run/kukeon/kukeond.sock` plumbing.
+func TestApplyRunPathImpliesKukeondSocket(t *testing.T) {
+	testCases := []struct {
+		name             string
+		runPathFlag      bool
+		runPathEnv       bool
+		socketEnv        string
+		preSetSocket     string // simulates applyServerConfiguration spec.Socket
+		runPath          string
+		wantSocketChange bool
+		wantSocket       string
+	}{
+		{
+			name:             "explicit-flag-and-no-socket-env-derives",
+			runPathFlag:      true,
+			runPath:          "/tmp/init-557",
+			wantSocketChange: true,
+			wantSocket:       "/tmp/init-557/kukeond.sock",
+		},
+		{
+			name:             "env-run-path-and-no-socket-env-derives",
+			runPathEnv:       true,
+			runPath:          "/tmp/init-557-env",
+			wantSocketChange: true,
+			wantSocket:       "/tmp/init-557-env/kukeond.sock",
+		},
+		{
+			name:        "implicit-run-path-no-derivation",
+			runPath:     "/opt/kukeon",
+			socketEnv:   "",
+			runPathFlag: false,
+			// Viper is reset in setup; with no env, no flag-changed, and
+			// no pre-set, GetString returns empty — the helper must not
+			// override that.
+			wantSocket: "",
+		},
+		{
+			name:        "explicit-flag-but-socket-env-pinned-respects-env",
+			runPathFlag: true,
+			runPath:     "/tmp/init-557",
+			socketEnv:   "/run/kukeon/operator.sock",
+			wantSocket:  "/run/kukeon/operator.sock",
+		},
+		{
+			name:         "explicit-flag-but-server-config-pinned-respects-yaml",
+			runPathFlag:  true,
+			runPath:      "/tmp/init-557",
+			preSetSocket: "/run/kukeon/from-yaml.sock",
+			wantSocket:   "/run/kukeon/from-yaml.sock",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			viper.Reset()
+
+			if tc.socketEnv != "" {
+				t.Setenv(config.KUKEOND_SOCKET.EnvVar(), tc.socketEnv)
+			}
+			if tc.runPathEnv {
+				t.Setenv(config.KUKEON_ROOT_RUN_PATH.EnvVar(), tc.runPath)
+			}
+
+			// Mirror production wiring: kuke.LoadConfig binds env keys.
+			if err := kuke.LoadConfig(); err != nil {
+				t.Fatalf("kuke.LoadConfig: %v", err)
+			}
+			cmd := initpkg.NewInitCmd()
+			if cmd == nil {
+				t.Fatal("NewInitCmd() returned nil")
+			}
+
+			// Re-register the persistent --run-path flag the root CLI
+			// adds, since NewInitCmd is built bare in this unit test.
+			cmd.PersistentFlags().String("run-path", "/opt/kukeon", "run path")
+			if err := viper.BindPFlag(
+				config.KUKEON_ROOT_RUN_PATH.ViperKey,
+				cmd.PersistentFlags().Lookup("run-path"),
+			); err != nil {
+				t.Fatalf("BindPFlag run-path: %v", err)
+			}
+
+			if tc.runPathFlag {
+				if err := cmd.PersistentFlags().Set("run-path", tc.runPath); err != nil {
+					t.Fatalf("flag set: %v", err)
+				}
+			}
+
+			if tc.preSetSocket != "" {
+				// Stand-in for applyServerConfiguration's viper.Set when
+				// ServerConfiguration's spec.Socket is non-empty and env
+				// is unset.
+				viper.Set(config.KUKEOND_SOCKET.ViperKey, tc.preSetSocket)
+			}
+
+			ApplyRunPathImpliesKukeondSocket(cmd, tc.runPath)
+
+			got := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
+			if got != tc.wantSocket {
+				t.Errorf("socket: got %q, want %q", got, tc.wantSocket)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Auto-derive `KUKEOND_SOCKET=<runPath>/kukeond.sock` inside `kuke init` when `--run-path` is explicit (flag or env) and the operator did not pin `KUKEOND_SOCKET` themselves. Closes the nested-cell collision on `TestKuke_Init_VerifyState` without adding a new flag — operator intent ("this run lives under X") naturally extends to the daemon socket; operators who want the in-tree convention restore it via `KUKEOND_SOCKET=/run/kukeon/kukeond.sock kuke init --run-path X`.
- Wire `env -u KUKEOND_SOCKET` into Makefile's `test-e2e` so any leftover from an interactive shell (e.g. a parent `make dev-init` that pinned `/run/kukeon-dev/kukeond.sock`) is stripped before `go test`, letting init's per-runPath derivation kick in. Nested probe (`/.kukeon/bin/kuketty`, mirrors `scripts/dev-init.sh`) only emits a diagnostic; the unset is unconditional because the e2e suite's daemon-bringing tests rely on the per-test `--run-path` → socket derivation in either mode.

Picked option (b) from the issue body (auto-derive in `kuke init`) over option (a) (new `--socket` flag) per the issue's "smaller blast radius after review" criterion. ServerConfiguration's `spec.Socket` continues to win via `applyServerConfiguration`'s `viper.Set`, so YAML-configured socket paths are respected.

## Test plan

- [x] `go test ./cmd/kuke/init/... -run TestApplyRunPathImpliesKukeondSocket -v` — new regression test, five cases (flag-explicit, env-explicit, implicit-no-derivation, env-pinned-respects-env, YAML-pinned-respects-YAML).
- [x] `make test` — full unit suite, all pass.
- [x] `make dev-init` — daemon-parity check (the regression guard CLAUDE.md mandates for any daemon-reading change) succeeds inside this nested `kukeon-dev-root` cell. KUKEOND_SOCKET is explicitly exported by dev-init.sh, so the derivation deliberately stays inert in that path; daemon brings up at `/run/kukeon-dev/kukeond.sock` as before, parity check matches, attach smoke and nested post-flight succeed.
- [x] `pre-commit run --files Makefile cmd/kuke/init/init.go cmd/kuke/init/init_test.go` — all hooks pass.
- [ ] `make e2e` (`TestKuke_Init_VerifyState` nested) — blocked by #568 (`buildKukeRunPathArgs` puts `--no-daemon` at root, which #567 retired). Filed verified-bug with reproduction. Cobra fails at arg-parse before the test ever reaches the socket-collision path this PR fixes; AC validation deferred until #568 lands. Reviewer: please run after #568 merges.
- [ ] `make e2e` (host-mode) — same blocker as above.

## Acceptance criteria (issue #557)

- [ ] `make e2e` inside a kuke-managed dev-root cell passes `TestKuke_Init_VerifyState` without disturbing the parent dev cell's daemon at `/run/kukeon-dev/kukeond.sock` — code path verified via unit test + `make dev-init` smoke; end-to-end `make e2e` blocked on #568.
- [x] Approach wired in `Makefile`'s `test-e2e` (nested-aware probe + `env -u KUKEOND_SOCKET`) and in `cmd/kuke/init/init.go` (`applyRunPathImpliesKukeondSocket`) — not by mutating `KUKEOND_SOCKET` globally for the test run.
- [ ] Existing host-mode `make e2e` continues to pass — blocked on #568.

## Notes for the reviewer

- The auto-derivation lives only in `kuke init` (not CLI-wide) per the issue's "inside `kuke init`" wording. Asymmetric consequence: `kuke daemon reset --run-path X` still looks for the socket file at `/run/kukeon/kukeond.sock` (not under `X`), so a stranded `<X>/kukeond.sock` won't be explicitly removed by reset. In practice this is harmless for e2e (runPath lives under `t.TempDir()` which is auto-cleaned) and for operators who want symmetry the env-var override works. Happy to extend to a `cmd/kuke/kuke.go`-level promotion (like `applyRunPathImpliesNoDaemon`) if you'd prefer the symmetric contract.
- The Makefile change uses `env -u KUKEOND_SOCKET` rather than re-exporting an absent value to keep the "no global KUKEOND_SOCKET for the test run" AC honest. The nested probe is purely diagnostic for option (b); option (a) would have used the probe to seed a per-test socket env, but auto-derivation in init makes that redundant.

Closes #557