### PR TITLE
fix(e2e): drop --no-daemon prefix from buildKukeRunPathArgs after root-flag retirement

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -157,21 +157,23 @@ func deepSocketPathFits(runPath string) bool {
 	return len(runPath)+deepSocketSuffixLen <= consts.KukeonMaxSocketPath
 }
 
-// buildKukeRunPathArgs returns the canonical `--no-daemon --run-path <X>`
-// prefix every e2e invocation must carry. The two flags travel together
-// because the e2e suite has no shared kukeond running on its --run-path:
-// without --no-daemon, kuke would dial the host's daemon socket (whichever
-// /opt/kukeon path it was started against) and read/write someone else's
-// state. Per-test --run-path + in-process controller is the only mode that
-// keeps the suite hermetic on hosts where containerd is up but kukeond is
-// not (the common e2e harness shape).
+// buildKukeRunPathArgs returns the canonical `--run-path <X>` prefix every
+// e2e invocation must carry. The e2e suite has no shared kukeond running on
+// its --run-path; without the in-process promotion that --run-path triggers,
+// kuke would dial the host's daemon socket (whichever /opt/kukeon path it
+// was started against) and read/write someone else's state. Per-test
+// --run-path + in-process controller is the only mode that keeps the suite
+// hermetic on hosts where containerd is up but kukeond is not (the common
+// e2e harness shape).
 //
-// Note: --run-path alone already implies --no-daemon at the CLI layer via
-// applyRunPathImpliesNoDaemon (cmd/kuke/kuke.go), so this prefix is
-// belt-and-suspenders. Spelling both out keeps test source self-
-// documenting and severs the dependency on that promotion.
+// The in-process promotion comes from applyRunPathImpliesNoDaemon
+// (cmd/kuke/kuke.go), which auto-sets --no-daemon=true whenever --run-path
+// is explicit. The flag is no longer accepted at root (#222 / #567 retired
+// it from workload commands and demoted it to per-command local
+// registration), so spelling it out here would now mis-parse as an unknown
+// root flag and shift the subcommand token.
 func buildKukeRunPathArgs(runPath string) []string {
-	return []string{"--no-daemon", "--run-path", runPath}
+	return []string{"--run-path", runPath}
 }
 
 // loadKukeondImageIntoContainerd stages the local kukeond image into the


### PR DESCRIPTION
## Summary

- After PR #567 retired `--no-daemon` from `rootCmd.PersistentFlags()`, the e2e helper at `e2e/e2e_test.go:173` (introduced by #564 as a belt-and-suspenders prefix) still shells out `./kuke --no-daemon --run-path <X> <subcmd> ...`. Cobra mis-parses the unknown root-level flag and the next non-flag token (`<runPath>`) is interpreted as the subcommand, breaking every e2e test (`unknown command "/tmp/..." for "kuke"`).
- `--run-path` alone auto-promotes the invocation into in-process mode via `applyRunPathImpliesNoDaemon` (`cmd/kuke/kuke.go:367`), so the e2e suite's hermeticity contract is preserved with the single-flag prefix.
- Comment block rewritten: the "two flags travel together / belt-and-suspenders" framing is replaced by an explicit reference to the auto-promotion plus a one-liner explaining why spelling `--no-daemon` here would now mis-parse — so a future contributor doesn't reintroduce it.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (CI's `go test \$(go list ./... | grep -v /e2e)`)
- [x] `make test-e2e` — `TestKuke_NoRealms` (the named failure in #568) now passes; the prior `unknown command "/tmp/..." for "kuke"` parse error is gone across the suite. Three tests still fail on this host but are environmental and unrelated to this fix: `TestKuke_Init_VerifyState` and `TestKuke_StopContainer_VerifyState` fail on DNS timeouts pulling `docker.io/library/busybox` and `registry.eminwux.com/debian` (the dev container lacks egress to those registries); `TestKuke_CreateCell_VerifyState` fails on a `/sys/fs/cgroup/kukeon/...` stat that pre-dates this branch. None reach the helper-args path under test.
- [x] `grep -rn '"--no-daemon"' e2e/ scripts/ docs/` — only Go-source literal was `e2e/e2e_test.go:174` (this fix). Remaining matches in `scripts/dev-init.sh` are shell tokens against `kuke get realms --no-daemon`, valid because `--no-daemon` remains registered on `get` per #222's user override.

Closes #568