### PR TITLE
docs: drop 'disposable host' framing for make e2e; document nested support

### DIFF
--- a/docs/site/guides/local-dev.md
+++ b/docs/site/guides/local-dev.md
@@ -43,7 +43,7 @@ User data under `/opt/kukeon/default/**` is untouched across iterations; only th
 | `make uninstall-dev` | Remove both symlinks from `$(INSTALL_PREFIX)`.                                                                                |
 | `make dev-init`      | The full canonical loop above. Auto-invokes `install-dev` so `sudo kuke …` works from any directory.                          |
 | `make test`          | Run the Go unit test suite                                                                                                    |
-| `make e2e`           | Run end-to-end tests against a real containerd (requires root)                                                                |
+| `make e2e`           | Run end-to-end tests against a real containerd (requires root). Supports both a clean host and a nested run inside a `kukeon-dev-root` cell — each test derives its socket from its own `--run-path <tempdir>` so the parent dev cell's `/run/kukeon/` plumbing is untouched. |
 | `make lint`          | Run `golangci-lint` with the repo's config                                                                                    |
 
 Override `INSTALL_PREFIX` for non-standard PATH layouts: `make install-dev INSTALL_PREFIX=$HOME/.local/bin`.

--- a/docs/site/install/build-from-source.md
+++ b/docs/site/install/build-from-source.md
@@ -85,6 +85,8 @@ See [Guides → Local development](../guides/local-dev.md) for the full dev loop
 # Unit tests
 go test ./...
 
-# End-to-end tests (require containerd, root, and a disposable host)
+# End-to-end tests
 make e2e
 ```
+
+`make e2e` needs root, a running docker daemon, and standalone containerd at `/run/containerd/containerd.sock` (the same prerequisites `make dev-init` calls out under [Guides → Local development](../guides/local-dev.md)). Both supported paths work: a clean host where the suite owns `/run/kukeon/`, and a nested run inside a kukeon-managed `kukeon-dev-root` cell where each test auto-derives its own socket from `--run-path <tempdir>` so the parent dev cell's `/run/kukeon/` plumbing is untouched (see [`docs/dev-init.md`](https://github.com/eminwux/kukeon/blob/main/docs/dev-init.md)).


### PR DESCRIPTION
## Summary

- Reword `docs/site/install/build-from-source.md:88-89` and the `make e2e` row in `docs/site/guides/local-dev.md:46` to drop the "disposable host" framing now that nested `make e2e` is fully green.
- Both supported paths are now documented: clean host (suite owns `/run/kukeon/`) and nested run inside a `kukeon-managed kukeon-dev-root` cell (each test derives its socket from `--run-path <tempdir>`).

## Why now (premise un-rotted)

This issue was stalled on #568 (`buildKukeRunPathArgs` prepended `--no-daemon` at root, broken by #567's flag retirement). #568 has since landed (fix in #571, CI integration in #572), so the docs claim "requires a disposable host" no longer matches reality and the AC #3 verification is unblocked.

## Test plan

- [x] AC #1 verified: `docs/site/install/build-from-source.md:88-89` no longer claims `make e2e` requires "a disposable host"; the new paragraph names the actual prerequisites (root, docker, standalone containerd) and both supported paths.
- [x] AC #2 verified: `docs/site/guides/local-dev.md:46` matches — the `make e2e` row extends "requires root" with the nested-supported note.
- [x] AC #3 verified: `make e2e` ran nested inside a `kukeon-dev-root` cell — first run was 75/75 PASS in ~61s with no unexplained failures. A second back-to-back run hit 7 environmental failures (DNS timeouts pulling `busybox:latest` and `signal: killed` on image pulls to `registry.eminwux.com`) that are sandbox-network flakes, not nested-mode regressions. CI on `main` (run 26020242126 on `63f5a7f`) reports `make e2e` SUCCESS end-to-end, which is the authoritative signal that the suite is honestly green.
- [x] Render-check: doc diff is markdown-only, no MkDocs config touched, internal link `../guides/local-dev.md` already present in the file, `docs/dev-init.md` reference uses an absolute GitHub URL (consistent with how other site pages reference repo-root docs).

Closes #556