### PR TITLE
test(e2e): pivot suite to per-test kukeond daemon harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ e2e: test-e2e
 # mirrors `scripts/dev-init.sh`) only emits a diagnostic; the unset is
 # unconditional because the e2e suite's daemon-bringing tests rely on the
 # per-test --run-path → socket derivation in either mode.
-test-e2e: kuke kuketty
+test-e2e: kuke kukeond kuketty
 	@echo "Building local kukeond image $(KUKEON_E2E_IMAGE_DOCKER_NAME) for e2e"
 	docker build --build-arg VERSION=v0.0.0-e2e -t $(KUKEON_E2E_IMAGE_DOCKER_NAME) .
 	@echo "Running e2e tests using binaries in project root"

--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,21 @@ e2e: test-e2e
 # mirrors `scripts/dev-init.sh`) only emits a diagnostic; the unset is
 # unconditional because the e2e suite's daemon-bringing tests rely on the
 # per-test --run-path → socket derivation in either mode.
+#
+# `KUKE_INIT_SERVER_CONFIGURATION=/dev/null` short-circuits cross-test
+# contamination via `/etc/kukeon/kukeond.yaml`: the first test's `kuke init`
+# brings up kukeond, which writes the auto-generated default YAML on first
+# start (internal/serverconfig.WriteDefault, O_EXCL — first writer wins). That
+# YAML hardcodes `spec.socket: /run/kukeon/kukeond.sock` regardless of what
+# socket the daemon was launched with (see issue #581). Subsequent tests'
+# `kuke init` reads it via applyServerConfiguration, calls
+# `viper.Set(KUKEOND_SOCKET, "/run/kukeon/kukeond.sock")`, and trips the
+# `viper.IsSet` gate in `applyRunPathImpliesKukeondSocket` — derivation is
+# skipped, kukeond comes up on the wrong socket, and the test's
+# `unix://<runPath>/kukeond.sock` client dial fails with "no such file or
+# directory". Pointing init at `/dev/null` (serverconfig.Load handles the
+# zero-byte read as an absent-doc fall-through, returning a zero-value
+# document with no error) keeps the contamination out of the init read path.
 test-e2e: kuke kukeond kuketty
 	@echo "Building local kukeond image $(KUKEON_E2E_IMAGE_DOCKER_NAME) for e2e"
 	docker build --build-arg VERSION=v0.0.0-e2e -t $(KUKEON_E2E_IMAGE_DOCKER_NAME) .
@@ -119,6 +134,7 @@ test-e2e: kuke kukeond kuketty
 		E2E_BIN_DIR=$(CURDIR) \
 		KUKEON_E2E_IMAGE=$(KUKEON_E2E_IMAGE) \
 		KUKEON_E2E_IMAGE_DOCKER_NAME=$(KUKEON_E2E_IMAGE_DOCKER_NAME) \
+		KUKE_INIT_SERVER_CONFIGURATION=/dev/null \
 		env -u KUKEOND_SOCKET go test -v ./e2e
 
 tag:

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -42,6 +42,24 @@ func DefineKV(envName, viperKey string, defaultVal ...string) Var {
 	return v
 }
 
+// DefineKVNoViperDefault is like DefineKV but does not register the default
+// with viper.SetDefault. Use for keys whose downstream logic relies on
+// viper.IsSet to distinguish "operator pinned this explicitly" from
+// "fall through to derivation" — viper.SetDefault trips IsSet (viper v1.21)
+// and would silently disable the derivation. Callers must fall back to
+// .Default themselves via the `viper.GetString(...); if "" { = .Default }`
+// pattern. Currently used by KUKEOND_SOCKET so that
+// applyRunPathImpliesKukeondSocket can derive `<runPath>/kukeond.sock`
+// when no env / flag / YAML pinned the key.
+func DefineKVNoViperDefault(envName, viperKey, defaultVal string) Var {
+	return Var{
+		Key:        envName,
+		ViperKey:   viperKey,
+		Default:    defaultVal,
+		HasDefault: true,
+	}
+}
+
 func Define(envName string, defaultVal ...string) Var {
 	return DefineKV(envName, "", defaultVal...)
 }
@@ -110,7 +128,11 @@ var (
 	KUKE_CONFIGURATION = DefineKV("KUKE_CONFIGURATION", "kuke/configuration")
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKEOND_SOCKET = DefineKV("KUKEOND_SOCKET", "kukeond/socket", "/run/kukeon/kukeond.sock")
+	// KUKEOND_SOCKET intentionally bypasses viper.SetDefault — see
+	// DefineKVNoViperDefault and applyRunPathImpliesKukeondSocket.
+	KUKEOND_SOCKET = DefineKVNoViperDefault(
+		"KUKEOND_SOCKET", "kukeond/socket", "/run/kukeon/kukeond.sock",
+	)
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEOND_SOCKET_GID = DefineKV("KUKEOND_SOCKET_GID", "kukeond/socketGID", "0")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/config/env_test.go
+++ b/cmd/config/env_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+// TestDefineKV_SetsViperDefault locks in that DefineKV registers the
+// default with viper (viper.GetString returns it without any further
+// wiring), so callers can rely on viper.GetString as a single read.
+func TestDefineKV_SetsViperDefault(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	v := DefineKV("TEST_DEFINE_KV_VIPER", "test/defineKV/viper", "fallback-value")
+
+	if got := viper.GetString(v.ViperKey); got != "fallback-value" {
+		t.Errorf("viper.GetString: got %q, want %q (DefineKV must call viper.SetDefault)",
+			got, "fallback-value")
+	}
+	if !viper.IsSet(v.ViperKey) {
+		t.Error("viper.IsSet returned false after DefineKV — SetDefault should trip IsSet")
+	}
+	if v.Default != "fallback-value" || !v.HasDefault {
+		t.Errorf("Var fields: Default=%q HasDefault=%v, want %q true",
+			v.Default, v.HasDefault, "fallback-value")
+	}
+}
+
+// TestDefineKVNoViperDefault_DoesNotSetViperDefault locks in the inverse
+// of TestDefineKV_SetsViperDefault: DefineKVNoViperDefault must NOT call
+// viper.SetDefault. The contract matters because applyRunPathImpliesKukeondSocket
+// uses viper.IsSet to gate derivation — if SetDefault were called for
+// KUKEOND_SOCKET, IsSet would always be true and `kuke --run-path X init`
+// would silently keep the daemon on `/run/kukeon/kukeond.sock` regardless
+// of X. If someone in the future "fixes" this constructor to call
+// SetDefault, this test catches it before the next e2e cycle does.
+func TestDefineKVNoViperDefault_DoesNotSetViperDefault(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	v := DefineKVNoViperDefault(
+		"TEST_DEFINE_KV_NO_VIPER", "test/defineKV/noViper", "fallback-value",
+	)
+
+	if viper.IsSet(v.ViperKey) {
+		t.Error("viper.IsSet returned true after DefineKVNoViperDefault — " +
+			"SetDefault must NOT be called for this constructor")
+	}
+	if got := viper.GetString(v.ViperKey); got != "" {
+		t.Errorf("viper.GetString: got %q, want %q (no viper.SetDefault expected)",
+			got, "")
+	}
+	if v.Default != "fallback-value" || !v.HasDefault {
+		t.Errorf("Var fields: Default=%q HasDefault=%v, want %q true (Go-side .Default still populated)",
+			v.Default, v.HasDefault, "fallback-value")
+	}
+}

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -228,7 +228,10 @@ func setPersistentFlags(_ *cobra.Command) error {
 //
 // ServerConfiguration's spec.Socket trips !viper.IsSet through
 // applyServerConfiguration's viper.Set, so YAML-configured socket paths
-// are respected.
+// are respected. KUKEOND_SOCKET is registered via DefineKVNoViperDefault
+// (cmd/config/env.go) precisely so this IsSet check stays meaningful —
+// viper.SetDefault would trip IsSet even with no env/flag/YAML and
+// silently disable derivation.
 func applyRunPathImpliesKukeondSocket(cmd *cobra.Command, runPath string) {
 	if viper.IsSet(config.KUKEOND_SOCKET.ViperKey) {
 		return

--- a/e2e/e2e_kuke_apply_test.go
+++ b/e2e/e2e_kuke_apply_test.go
@@ -142,7 +142,7 @@ func TestKukeApply_VerifyTestdataYAMLs(t *testing.T) {
 }
 
 // applyYAMLFile reads a YAML file, applies string replacements, writes to temp file, runs apply command.
-func applyYAMLFile(t *testing.T, runPath, yamlFile string, replacements map[string]string) []byte {
+func applyYAMLFile(t *testing.T, host, yamlFile string, replacements map[string]string) []byte {
 	t.Helper()
 
 	// Read the YAML file
@@ -162,18 +162,18 @@ func applyYAMLFile(t *testing.T, runPath, yamlFile string, replacements map[stri
 	}
 
 	// Run apply command
-	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", tmpFile)
+	args := append(buildKukeDaemonArgs(host), "apply", "-f", tmpFile)
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	return output
 }
 
 // getContainerIDsFromCell gets all container IDs from a cell's spec.
-func getContainerIDsFromCell(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) []string {
+func getContainerIDsFromCell(t *testing.T, host, realmName, spaceName, stackName, cellName string) []string {
 	t.Helper()
 
 	args := append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -239,11 +239,12 @@ func TestKukeApply_Realm_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 
 	// Cleanup: Delete realm
 	t.Cleanup(func() {
-		cleanupRealm(t, runPath, realmName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Apply realm.yaml with name replacements
@@ -251,7 +252,7 @@ func TestKukeApply_Realm_VerifyState(t *testing.T) {
 		"test-realm": realmName,
 		"test-ns":    realmName + "-ns",
 	}
-	output := applyYAMLFile(t, runPath, "realm.yaml", replacements)
+	output := applyYAMLFile(t, host, "realm.yaml", replacements)
 
 	if len(output) == 0 {
 		t.Fatal("expected output from apply command")
@@ -269,17 +270,17 @@ func TestKukeApply_Realm_VerifyState(t *testing.T) {
 	}
 
 	// Verify realm appears in list
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found in realm list", realmName)
 	}
 
 	// Verify realm can be retrieved individually
-	if !verifyRealmExists(t, runPath, realmName) {
+	if !verifyRealmExists(t, host, realmName) {
 		t.Fatalf("realm %q cannot be retrieved individually", realmName)
 	}
 
 	// Verify cgroup path exists
-	args := append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	realmOutput := runReturningBinary(t, nil, kuke, args...)
 
 	realm, err := parseRealmJSON(t, realmOutput)
@@ -315,17 +316,18 @@ func TestKukeApply_Space_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 
 	// Cleanup: Delete space first, then realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Apply space.yaml with name replacements
@@ -333,7 +335,7 @@ func TestKukeApply_Space_VerifyState(t *testing.T) {
 		"test-space": spaceName,
 		"test-realm": realmName,
 	}
-	output := applyYAMLFile(t, runPath, "space.yaml", replacements)
+	output := applyYAMLFile(t, host, "space.yaml", replacements)
 
 	if len(output) == 0 {
 		t.Fatal("expected output from apply command")
@@ -350,17 +352,17 @@ func TestKukeApply_Space_VerifyState(t *testing.T) {
 	}
 
 	// Verify space appears in list
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q not found in space list", spaceName)
 	}
 
 	// Verify space can be retrieved individually
-	if !verifySpaceExists(t, runPath, realmName, spaceName) {
+	if !verifySpaceExists(t, host, realmName, spaceName) {
 		t.Fatalf("space %q cannot be retrieved individually", spaceName)
 	}
 
 	// Verify cgroup path exists
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	spaceOutput := runReturningBinary(t, nil, kuke, args...)
 
 	space, err := parseSpaceJSON(t, spaceOutput)
@@ -394,23 +396,24 @@ func TestKukeApply_Stack_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
 
 	// Cleanup: Delete stack, space, realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Apply stack.yaml with name replacements
@@ -419,7 +422,7 @@ func TestKukeApply_Stack_VerifyState(t *testing.T) {
 		"test-realm": realmName,
 		"test-space": spaceName,
 	}
-	output := applyYAMLFile(t, runPath, "stack.yaml", replacements)
+	output := applyYAMLFile(t, host, "stack.yaml", replacements)
 
 	if len(output) == 0 {
 		t.Fatal("expected output from apply command")
@@ -431,18 +434,18 @@ func TestKukeApply_Stack_VerifyState(t *testing.T) {
 	}
 
 	// Verify stack appears in list
-	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q not found in stack list", stackName)
 	}
 
 	// Verify stack can be retrieved individually
-	if !verifyStackExists(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackExists(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q cannot be retrieved individually", stackName)
 	}
 
 	// Verify cgroup path exists
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,
@@ -486,6 +489,7 @@ func TestKukeApply_Cell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -493,23 +497,23 @@ func TestKukeApply_Cell_VerifyState(t *testing.T) {
 
 	// Cleanup: Delete cell, stack, space, realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -527,7 +531,7 @@ func TestKukeApply_Cell_VerifyState(t *testing.T) {
 		"test-space": spaceName,
 		"test-stack": stackName,
 	}
-	output := applyYAMLFile(t, runPath, "cell.yaml", replacements)
+	output := applyYAMLFile(t, host, "cell.yaml", replacements)
 
 	if len(output) == 0 {
 		t.Fatal("expected output from apply command")
@@ -539,18 +543,18 @@ func TestKukeApply_Cell_VerifyState(t *testing.T) {
 	}
 
 	// Verify cell appears in list
-	if !verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellInList(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q not found in cell list", cellName)
 	}
 
 	// Verify cell can be retrieved individually
-	if !verifyCellExists(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellExists(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q cannot be retrieved individually", cellName)
 	}
 
 	// Verify cgroup path exists
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -596,7 +600,7 @@ func TestKukeApply_Cell_VerifyState(t *testing.T) {
 	}
 
 	// Get realm namespace for container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -622,7 +626,7 @@ func TestKukeApply_Cell_VerifyState(t *testing.T) {
 	}
 
 	// Get all container IDs from cell spec
-	containerIDs := getContainerIDsFromCell(t, runPath, realmName, spaceName, stackName, cellName)
+	containerIDs := getContainerIDsFromCell(t, host, realmName, spaceName, stackName, cellName)
 
 	// Verify all containers exist in containerd
 	verifyCellContainersExist(t, realmNamespace, spaceName, stackName, cellID, containerIDs)
@@ -634,15 +638,16 @@ func TestKukeApply_MultiResource_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
 
 	// Cleanup: Delete stack, space, realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Apply multi-resource.yaml with name replacements
@@ -652,7 +657,7 @@ func TestKukeApply_MultiResource_VerifyState(t *testing.T) {
 		"multi-space": spaceName,
 		"multi-stack": stackName,
 	}
-	output := applyYAMLFile(t, runPath, "multi-resource.yaml", replacements)
+	output := applyYAMLFile(t, host, "multi-resource.yaml", replacements)
 
 	if len(output) == 0 {
 		t.Fatal("expected output from apply command")
@@ -668,16 +673,16 @@ func TestKukeApply_MultiResource_VerifyState(t *testing.T) {
 		t.Fatalf("realm metadata file not found for realm %q", realmName)
 	}
 
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found in realm list", realmName)
 	}
 
-	if !verifyRealmExists(t, runPath, realmName) {
+	if !verifyRealmExists(t, host, realmName) {
 		t.Fatalf("realm %q cannot be retrieved individually", realmName)
 	}
 
 	// Verify realm cgroup path
-	args := append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	realmOutput := runReturningBinary(t, nil, kuke, args...)
 
 	realm, err := parseRealmJSON(t, realmOutput)
@@ -702,16 +707,16 @@ func TestKukeApply_MultiResource_VerifyState(t *testing.T) {
 		t.Fatalf("space metadata file not found for space %q", spaceName)
 	}
 
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q not found in space list", spaceName)
 	}
 
-	if !verifySpaceExists(t, runPath, realmName, spaceName) {
+	if !verifySpaceExists(t, host, realmName, spaceName) {
 		t.Fatalf("space %q cannot be retrieved individually", spaceName)
 	}
 
 	// Verify space cgroup path
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	spaceOutput := runReturningBinary(t, nil, kuke, args...)
 
 	space, err := parseSpaceJSON(t, spaceOutput)
@@ -732,17 +737,17 @@ func TestKukeApply_MultiResource_VerifyState(t *testing.T) {
 		t.Fatalf("stack metadata file not found for stack %q", stackName)
 	}
 
-	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q not found in stack list", stackName)
 	}
 
-	if !verifyStackExists(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackExists(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q cannot be retrieved individually", stackName)
 	}
 
 	// Verify stack cgroup path
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,

--- a/e2e/e2e_kuke_cell_test.go
+++ b/e2e/e2e_kuke_cell_test.go
@@ -26,12 +26,14 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
-// cleanupCell deletes a cell with cascade.
-func cleanupCell(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) {
+// cleanupCell deletes a cell with cascade through the per-test daemon.
+// Register after startKukeondDaemon so t.Cleanup's LIFO order runs delete
+// before the daemon is signaled.
+func cleanupCell(t *testing.T, host, realmName, spaceName, stackName, cellName string) {
 	t.Helper()
 
 	args := append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"delete",
 		"cell",
 		cellName,
@@ -51,8 +53,9 @@ func TestKuke_NoCells(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "cell", "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "cell", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	var cells []v1beta1.CellDoc
@@ -71,6 +74,7 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -78,23 +82,23 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 
 	// Cleanup: Delete cell first, then stack, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -107,7 +111,7 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -126,19 +130,19 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 	}
 
 	// Step 6: Verify cell appears in list (JSON parsing)
-	if !verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellInList(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q not found in cell list", cellName)
 	}
 
 	// Step 7: Verify cell can be retrieved individually
-	if !verifyCellExists(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellExists(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q cannot be retrieved individually", cellName)
 	}
 
 	// Step 8: Verify cgroup path exists
 	// Get cell JSON to extract cgroup path
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -178,7 +182,7 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 	}
 
 	// Step 9: Get realm namespace
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -224,6 +228,7 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -231,23 +236,23 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 
 	// Cleanup: Safety net (cell should already be deleted, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -260,7 +265,7 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (prerequisite for deletion test)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -278,17 +283,17 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 		t.Fatalf("cell metadata file not found for cell %q", cellName)
 	}
 
-	if !verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellInList(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q not found in cell list", cellName)
 	}
 
-	if !verifyCellExists(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellExists(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q cannot be retrieved individually", cellName)
 	}
 
 	// Get cell JSON to extract cgroup path and cell ID for later verification
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -319,7 +324,7 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 	}
 
 	// Get realm namespace and cell ID for root container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -341,7 +346,7 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 
 	// Step 6: Delete the cell
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"delete",
 		"cell",
 		cellName,
@@ -383,13 +388,13 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 	}
 
 	// Step 10: Verify cell does NOT appear in list
-	if verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+	if verifyCellInList(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q still appears in cell list after deletion", cellName)
 	}
 
 	// Step 11: Verify individual get FAILS (returns non-zero exit code)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -416,6 +421,7 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -423,23 +429,23 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 
 	// Cleanup: Delete cell, then stack, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -452,7 +458,7 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (cell should be in Pending state after creation)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -466,7 +472,7 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 5: Get realm namespace and cell ID for container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -474,7 +480,7 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 		t.Fatal("realm namespace is empty")
 	}
 
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -487,7 +493,7 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 
 	// Step 7: Get cell state after creation
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -510,7 +516,7 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 	// Step 8: Start the cell only if not already running (containers may auto-start on creation)
 	if cell.Status.State == 0 {
 		args = append(
-			buildKukeRunPathArgs(runPath),
+			buildKukeDaemonArgs(host),
 			"start",
 			"cell",
 			cellName,
@@ -535,7 +541,7 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 
 	// Step 10: Verify cell state updated to Ready
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -570,6 +576,7 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -577,23 +584,23 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 
 	// Cleanup: Delete cell, then stack, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -606,7 +613,7 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (containers auto-start on creation, so cell is Ready)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -620,7 +627,7 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 5: Get realm namespace and cell ID for container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -628,7 +635,7 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 		t.Fatal("realm namespace is empty")
 	}
 
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -641,7 +648,7 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 
 	// Step 7: Verify cell is in Ready state and containers are running (baseline)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -677,7 +684,7 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 
 	// Step 8: Stop the cell
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"stop",
 		"cell",
 		cellName,
@@ -701,7 +708,7 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 
 	// Step 10: Verify cell state updated to Stopped
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -736,6 +743,7 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -743,23 +751,23 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 
 	// Cleanup: Delete cell, then stack, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -772,7 +780,7 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (containers auto-start on creation, so cell is Ready)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -786,7 +794,7 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 5: Get realm namespace and cell ID for container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -794,7 +802,7 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 		t.Fatal("realm namespace is empty")
 	}
 
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -807,7 +815,7 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 
 	// Step 7: Verify cell is in Ready state and containers are running (baseline)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -843,7 +851,7 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 
 	// Step 8: Kill the cell
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"kill",
 		"cell",
 		cellName,
@@ -867,7 +875,7 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 
 	// Step 10: Verify cell state updated to Stopped
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -902,6 +910,7 @@ func TestKuke_PurgeCell_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -909,23 +918,23 @@ func TestKuke_PurgeCell_VerifyState(t *testing.T) {
 
 	// Cleanup: Safety net (cell should already be purged, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -938,7 +947,7 @@ func TestKuke_PurgeCell_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (prerequisite for purge test)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -956,17 +965,17 @@ func TestKuke_PurgeCell_VerifyState(t *testing.T) {
 		t.Fatalf("cell metadata file not found for cell %q", cellName)
 	}
 
-	if !verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellInList(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q not found in cell list", cellName)
 	}
 
-	if !verifyCellExists(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellExists(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q cannot be retrieved individually", cellName)
 	}
 
 	// Get cell JSON to extract cgroup path and cell ID for later verification
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -997,7 +1006,7 @@ func TestKuke_PurgeCell_VerifyState(t *testing.T) {
 	}
 
 	// Get realm namespace and cell ID for root container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -1061,13 +1070,13 @@ func TestKuke_PurgeCell_VerifyState(t *testing.T) {
 	}
 
 	// Step 10: Verify cell does NOT appear in list
-	if verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+	if verifyCellInList(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q still appears in cell list after purge", cellName)
 	}
 
 	// Step 11: Verify individual get FAILS (returns non-zero exit code)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,

--- a/e2e/e2e_kuke_container_test.go
+++ b/e2e/e2e_kuke_container_test.go
@@ -50,8 +50,9 @@ func TestKuke_NoContainers(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "container", "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "container", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	var containers []v1beta1.ContainerSpec
@@ -70,6 +71,7 @@ func TestKuke_CreateContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -79,23 +81,23 @@ func TestKuke_CreateContainer_VerifyState(t *testing.T) {
 	// Cleanup: Delete container first, then cell, then stack, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
 		cleanupContainer(t, runPath, realmName, spaceName, stackName, cellName, containerName)
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -108,7 +110,7 @@ func TestKuke_CreateContainer_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -123,7 +125,7 @@ func TestKuke_CreateContainer_VerifyState(t *testing.T) {
 
 	// Step 5: Create container
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"container",
 		containerName,
@@ -145,7 +147,7 @@ func TestKuke_CreateContainer_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 6: Get realm namespace
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -154,7 +156,7 @@ func TestKuke_CreateContainer_VerifyState(t *testing.T) {
 	}
 
 	// Step 7: Get cell ID (needed to build container containerd ID)
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -182,6 +184,7 @@ func TestKuke_DeleteContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -191,23 +194,23 @@ func TestKuke_DeleteContainer_VerifyState(t *testing.T) {
 	// Cleanup: Safety net (container should already be deleted, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
 		cleanupContainer(t, runPath, realmName, spaceName, stackName, cellName, containerName)
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -220,7 +223,7 @@ func TestKuke_DeleteContainer_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -235,7 +238,7 @@ func TestKuke_DeleteContainer_VerifyState(t *testing.T) {
 
 	// Step 5: Create container (prerequisite for deletion test)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"container",
 		containerName,
@@ -257,7 +260,7 @@ func TestKuke_DeleteContainer_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 6: Get realm namespace
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -266,7 +269,7 @@ func TestKuke_DeleteContainer_VerifyState(t *testing.T) {
 	}
 
 	// Step 7: Get cell ID (needed to build container containerd ID)
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -288,7 +291,7 @@ func TestKuke_DeleteContainer_VerifyState(t *testing.T) {
 
 	// Step 10: Delete the container
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"delete",
 		"container",
 		containerName,
@@ -330,6 +333,7 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -339,23 +343,23 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 	// Cleanup: Delete container, then cell, then stack, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
 		cleanupContainer(t, runPath, realmName, spaceName, stackName, cellName, containerName)
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -368,7 +372,7 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -383,7 +387,7 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 
 	// Step 5: Create container (container is automatically started after creation)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"container",
 		containerName,
@@ -405,7 +409,7 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 6: Get realm namespace and cell ID for container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -413,7 +417,7 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 		t.Fatal("realm namespace is empty")
 	}
 
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -436,7 +440,7 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 
 	// Step 9: Stop the container first (to test starting it)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"stop",
 		"container",
 		containerName,
@@ -462,7 +466,7 @@ func TestKuke_StartContainer_VerifyState(t *testing.T) {
 
 	// Step 11: Start the container
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"start",
 		"container",
 		containerName,
@@ -495,6 +499,7 @@ func TestKuke_StopContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -504,23 +509,23 @@ func TestKuke_StopContainer_VerifyState(t *testing.T) {
 	// Cleanup: Delete container, then cell, then stack, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
 		cleanupContainer(t, runPath, realmName, spaceName, stackName, cellName, containerName)
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -533,7 +538,7 @@ func TestKuke_StopContainer_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -548,7 +553,7 @@ func TestKuke_StopContainer_VerifyState(t *testing.T) {
 
 	// Step 5: Create container (container is automatically started after creation)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"container",
 		containerName,
@@ -570,7 +575,7 @@ func TestKuke_StopContainer_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 6: Get realm namespace and cell ID for container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -578,7 +583,7 @@ func TestKuke_StopContainer_VerifyState(t *testing.T) {
 		t.Fatal("realm namespace is empty")
 	}
 
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -601,7 +606,7 @@ func TestKuke_StopContainer_VerifyState(t *testing.T) {
 
 	// Step 9: Stop the container
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"stop",
 		"container",
 		containerName,
@@ -634,6 +639,7 @@ func TestKuke_KillContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -643,23 +649,23 @@ func TestKuke_KillContainer_VerifyState(t *testing.T) {
 	// Cleanup: Delete container, then cell, then stack, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
 		cleanupContainer(t, runPath, realmName, spaceName, stackName, cellName, containerName)
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -672,7 +678,7 @@ func TestKuke_KillContainer_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -687,7 +693,7 @@ func TestKuke_KillContainer_VerifyState(t *testing.T) {
 
 	// Step 5: Create container (container is automatically started after creation)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"container",
 		containerName,
@@ -709,7 +715,7 @@ func TestKuke_KillContainer_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 6: Get realm namespace and cell ID for container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -717,7 +723,7 @@ func TestKuke_KillContainer_VerifyState(t *testing.T) {
 		t.Fatal("realm namespace is empty")
 	}
 
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -740,7 +746,7 @@ func TestKuke_KillContainer_VerifyState(t *testing.T) {
 
 	// Step 9: Kill the container
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"kill",
 		"container",
 		containerName,
@@ -774,6 +780,7 @@ func TestKuke_PurgeContainer_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
@@ -783,23 +790,23 @@ func TestKuke_PurgeContainer_VerifyState(t *testing.T) {
 	// Cleanup: Safety net (container should already be purged, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
 		cleanupContainer(t, runPath, realmName, spaceName, stackName, cellName, containerName)
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -812,7 +819,7 @@ func TestKuke_PurgeContainer_VerifyState(t *testing.T) {
 
 	// Step 4: Create cell (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"cell",
 		cellName,
@@ -827,7 +834,7 @@ func TestKuke_PurgeContainer_VerifyState(t *testing.T) {
 
 	// Step 5: Create container (prerequisite for purge test)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"container",
 		containerName,
@@ -849,7 +856,7 @@ func TestKuke_PurgeContainer_VerifyState(t *testing.T) {
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 6: Get realm namespace
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
@@ -858,7 +865,7 @@ func TestKuke_PurgeContainer_VerifyState(t *testing.T) {
 	}
 
 	// Step 7: Get cell ID (needed to build container containerd ID)
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}

--- a/e2e/e2e_kuke_delete_f_test.go
+++ b/e2e/e2e_kuke_delete_f_test.go
@@ -78,8 +78,7 @@ spec:
 		t.Fatalf("failed to write delete YAML file: %v", err)
 	}
 
-	// Delete the realm — `delete -f` routes in-process (see deleteYAMLFileFromTestdata note).
-	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile)
+	args = append(buildKukeDaemonArgs(host), "delete", "-f", deleteYamlFile)
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	if len(output) == 0 {
@@ -169,7 +168,7 @@ spec:
 	}
 
 	// Delete resources (should delete in reverse dependency order: Space first, then Realm)
-	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile)
+	args = append(buildKukeDaemonArgs(host), "delete", "-f", deleteYamlFile)
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	if len(output) == 0 {
@@ -250,7 +249,7 @@ spec:
 	}
 
 	// Delete realm with cascade flag
-	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile, "--cascade")
+	args = append(buildKukeDaemonArgs(host), "delete", "-f", deleteYamlFile, "--cascade")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	if len(output) == 0 {
@@ -269,8 +268,8 @@ spec:
 func TestKukeDeleteF_Idempotent(t *testing.T) {
 	t.Parallel()
 
-	// `delete -f` routes in-process, so no daemon is required for this test.
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 
@@ -291,7 +290,7 @@ spec:
 	}
 
 	// Try to delete non-existent realm (should be idempotent, not an error)
-	args := append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile)
+	args := append(buildKukeDaemonArgs(host), "delete", "-f", deleteYamlFile)
 	output1 := runReturningBinary(t, nil, kuke, args...)
 
 	if len(output1) == 0 {
@@ -373,13 +372,9 @@ func applyYAMLFileFromTestdata(t *testing.T, host, yamlFile string, replacements
 }
 
 // deleteYAMLFileFromTestdata reads a YAML file from testdata, applies replacements, and runs delete command.
-//
-// NOTE: `kuke delete -f` routes through ControllerFromCmd (in-process) rather than
-// ClientFromCmd (daemon-aware), so this helper takes runPath and uses the in-process
-// path. Tracked as #574; once fixed, callers can collapse back to the daemon helper.
 func deleteYAMLFileFromTestdata(
 	t *testing.T,
-	runPath, yamlFile string,
+	host, yamlFile string,
 	replacements map[string]string,
 	cascade bool,
 ) []byte {
@@ -387,8 +382,7 @@ func deleteYAMLFileFromTestdata(
 
 	tmpFile := writeTempYAMLFile(t, yamlFile, replacements)
 
-	// Build delete command arguments
-	args := append(buildKukeRunPathArgs(runPath), "delete", "-f", tmpFile)
+	args := append(buildKukeDaemonArgs(host), "delete", "-f", tmpFile)
 	if cascade {
 		args = append(args, "--cascade")
 	}
@@ -454,7 +448,7 @@ func TestDeleteF_Realm_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Step 3: Delete using delete -f
-	_ = deleteYAMLFileFromTestdata(t, runPath, "realm.yaml", replacements, false)
+	_ = deleteYAMLFileFromTestdata(t, host, "realm.yaml", replacements, false)
 
 	// Step 4: Verify containerd namespace does NOT exist
 	if verifyContainerdNamespace(t, namespace) {
@@ -539,7 +533,7 @@ func TestDeleteF_Space_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Step 4: Delete using delete -f
-	_ = deleteYAMLFileFromTestdata(t, runPath, "space.yaml", replacements, false)
+	_ = deleteYAMLFileFromTestdata(t, host, "space.yaml", replacements, false)
 
 	// Step 5: Verify CNI config file does NOT exist (network)
 	if verifySpaceCNIConfigExists(t, runPath, realmName, spaceName) {
@@ -638,7 +632,7 @@ func TestDeleteF_Stack_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Step 5: Delete using delete -f
-	_ = deleteYAMLFileFromTestdata(t, runPath, "stack.yaml", replacements, false)
+	_ = deleteYAMLFileFromTestdata(t, host, "stack.yaml", replacements, false)
 
 	// Step 6: Verify cgroup path does NOT exist
 	if verifyCgroupPathExists(t, cgroupPath) {
@@ -769,7 +763,7 @@ func TestDeleteF_Cell_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Step 6: Delete using delete -f
-	_ = deleteYAMLFileFromTestdata(t, runPath, "cell.yaml", replacements, false)
+	_ = deleteYAMLFileFromTestdata(t, host, "cell.yaml", replacements, false)
 
 	// Step 7: Verify cgroup path does NOT exist
 	if verifyCgroupPathExists(t, cgroupPath) {
@@ -938,8 +932,8 @@ spec:
 		t.Fatalf("failed to write container YAML file: %v", err)
 	}
 
-	// Step 7: Delete using delete -f (`delete -f` routes in-process; see deleteYAMLFileFromTestdata note)
-	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", containerYAMLFile)
+	// Step 7: Delete using delete -f
+	args = append(buildKukeDaemonArgs(host), "delete", "-f", containerYAMLFile)
 	_ = runReturningBinary(t, nil, kuke, args...)
 
 	// Step 8: Verify container does NOT exist in containerd

--- a/e2e/e2e_kuke_delete_f_test.go
+++ b/e2e/e2e_kuke_delete_f_test.go
@@ -30,11 +30,12 @@ func TestKukeDeleteF_Realm(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 
 	t.Cleanup(func() {
-		cleanupRealm(t, runPath, realmName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// First, create a realm using apply
@@ -54,11 +55,11 @@ spec:
 	}
 
 	// Apply to create the realm
-	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", applyYamlFile)
+	args := append(buildKukeDaemonArgs(host), "apply", "-f", applyYamlFile)
 	_ = runReturningBinary(t, nil, kuke, args...)
 
 	// Verify realm was created
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found after apply", realmName)
 	}
 
@@ -77,7 +78,7 @@ spec:
 		t.Fatalf("failed to write delete YAML file: %v", err)
 	}
 
-	// Delete the realm
+	// Delete the realm — `delete -f` routes in-process (see deleteYAMLFileFromTestdata note).
 	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", deleteYamlFile)
 	output := runReturningBinary(t, nil, kuke, args...)
 
@@ -86,7 +87,7 @@ spec:
 	}
 
 	// Verify realm was deleted
-	if verifyRealmInList(t, runPath, realmName) {
+	if verifyRealmInList(t, host, realmName) {
 		t.Errorf("realm %q still found in list after delete", realmName)
 	}
 
@@ -100,13 +101,14 @@ func TestKukeDeleteF_MultiResource(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := "delete-space-" + strings.TrimPrefix(realmName, "e-r-")
 
 	t.Cleanup(func() {
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// First, create resources using apply
@@ -133,14 +135,14 @@ spec:
 	}
 
 	// Apply to create resources
-	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", applyYamlFile)
+	args := append(buildKukeDaemonArgs(host), "apply", "-f", applyYamlFile)
 	_ = runReturningBinary(t, nil, kuke, args...)
 
 	// Verify resources were created
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found after apply", realmName)
 	}
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q not found after apply", spaceName)
 	}
 
@@ -175,10 +177,10 @@ spec:
 	}
 
 	// Verify resources were deleted
-	if verifySpaceInList(t, runPath, realmName, spaceName) {
+	if verifySpaceInList(t, host, realmName, spaceName) {
 		t.Errorf("space %q still found in list after delete", spaceName)
 	}
-	if verifyRealmInList(t, runPath, realmName) {
+	if verifyRealmInList(t, host, realmName) {
 		t.Errorf("realm %q still found in list after delete", realmName)
 	}
 }
@@ -187,13 +189,14 @@ func TestKukeDeleteF_Cascade(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := "delete-cascade-space-" + strings.TrimPrefix(realmName, "e-r-")
 
 	t.Cleanup(func() {
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// First, create resources using apply
@@ -220,14 +223,14 @@ spec:
 	}
 
 	// Apply to create resources
-	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", applyYamlFile)
+	args := append(buildKukeDaemonArgs(host), "apply", "-f", applyYamlFile)
 	_ = runReturningBinary(t, nil, kuke, args...)
 
 	// Verify resources were created
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found after apply", realmName)
 	}
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q not found after apply", spaceName)
 	}
 
@@ -255,10 +258,10 @@ spec:
 	}
 
 	// Verify both resources were deleted (cascade)
-	if verifySpaceInList(t, runPath, realmName, spaceName) {
+	if verifySpaceInList(t, host, realmName, spaceName) {
 		t.Errorf("space %q still found in list after cascade delete", spaceName)
 	}
-	if verifyRealmInList(t, runPath, realmName) {
+	if verifyRealmInList(t, host, realmName) {
 		t.Errorf("realm %q still found in list after delete", realmName)
 	}
 }
@@ -266,6 +269,7 @@ spec:
 func TestKukeDeleteF_Idempotent(t *testing.T) {
 	t.Parallel()
 
+	// `delete -f` routes in-process, so no daemon is required for this test.
 	runPath := getRandomRunPath(t)
 
 	realmName := generateUniqueRealmName(t)
@@ -356,19 +360,23 @@ func writeTempYAMLFile(t *testing.T, yamlFile string, replacements map[string]st
 }
 
 // applyYAMLFileFromTestdata reads a YAML file from testdata, applies replacements, and runs apply command.
-func applyYAMLFileFromTestdata(t *testing.T, runPath, yamlFile string, replacements map[string]string) []byte {
+func applyYAMLFileFromTestdata(t *testing.T, host, yamlFile string, replacements map[string]string) []byte {
 	t.Helper()
 
 	tmpFile := writeTempYAMLFile(t, yamlFile, replacements)
 
 	// Run apply command
-	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", tmpFile)
+	args := append(buildKukeDaemonArgs(host), "apply", "-f", tmpFile)
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	return output
 }
 
 // deleteYAMLFileFromTestdata reads a YAML file from testdata, applies replacements, and runs delete command.
+//
+// NOTE: `kuke delete -f` routes through ControllerFromCmd (in-process) rather than
+// ClientFromCmd (daemon-aware), so this helper takes runPath and uses the in-process
+// path. Tracked as #574; once fixed, callers can collapse back to the daemon helper.
 func deleteYAMLFileFromTestdata(
 	t *testing.T,
 	runPath, yamlFile string,
@@ -396,13 +404,14 @@ func TestDeleteF_Realm_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	namespace := realmName + "-ns"
 
 	// Cleanup: Safety net
 	t.Cleanup(func() {
-		cleanupRealm(t, runPath, realmName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Apply realm.yaml to create the realm
@@ -410,7 +419,7 @@ func TestDeleteF_Realm_VerifyAllResourcesDeleted(t *testing.T) {
 		"test-realm": realmName,
 		"test-ns":    namespace,
 	}
-	_ = applyYAMLFileFromTestdata(t, runPath, "realm.yaml", replacements)
+	_ = applyYAMLFileFromTestdata(t, host, "realm.yaml", replacements)
 
 	// Step 2: Verify realm was created
 	if !verifyContainerdNamespace(t, namespace) {
@@ -421,12 +430,12 @@ func TestDeleteF_Realm_VerifyAllResourcesDeleted(t *testing.T) {
 		t.Fatalf("realm metadata file not found for realm %q", realmName)
 	}
 
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found in realm list", realmName)
 	}
 
 	// Get realm JSON to extract cgroup path
-	args := append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	realm, err := parseRealmJSON(t, output)
@@ -465,7 +474,7 @@ func TestDeleteF_Realm_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Step 7: Verify realm does NOT appear in list
-	if verifyRealmInList(t, runPath, realmName) {
+	if verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q still appears in realm list after deletion", realmName)
 	}
 }
@@ -475,18 +484,19 @@ func TestDeleteF_Space_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 
 	// Cleanup: Safety net
 	t.Cleanup(func() {
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Apply space.yaml to create the space
@@ -494,7 +504,7 @@ func TestDeleteF_Space_VerifyAllResourcesDeleted(t *testing.T) {
 		"test-space": spaceName,
 		"test-realm": realmName,
 	}
-	_ = applyYAMLFileFromTestdata(t, runPath, "space.yaml", replacements)
+	_ = applyYAMLFileFromTestdata(t, host, "space.yaml", replacements)
 
 	// Step 3: Verify space was created
 	if !verifySpaceCNIConfigExists(t, runPath, realmName, spaceName) {
@@ -505,12 +515,12 @@ func TestDeleteF_Space_VerifyAllResourcesDeleted(t *testing.T) {
 		t.Fatalf("space metadata file not found for space %q", spaceName)
 	}
 
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q not found in space list", spaceName)
 	}
 
 	// Get space JSON to extract cgroup path
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	space, err := parseSpaceJSON(t, output)
@@ -549,7 +559,7 @@ func TestDeleteF_Space_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Step 8: Verify space does NOT appear in list
-	if verifySpaceInList(t, runPath, realmName, spaceName) {
+	if verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q still appears in space list after deletion", spaceName)
 	}
 }
@@ -559,6 +569,7 @@ func TestDeleteF_Stack_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
@@ -566,17 +577,17 @@ func TestDeleteF_Stack_VerifyAllResourcesDeleted(t *testing.T) {
 
 	// Cleanup: Safety net
 	t.Cleanup(func() {
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Apply stack.yaml to create the stack
@@ -585,20 +596,20 @@ func TestDeleteF_Stack_VerifyAllResourcesDeleted(t *testing.T) {
 		"test-realm": realmName,
 		"test-space": spaceName,
 	}
-	_ = applyYAMLFileFromTestdata(t, runPath, "stack.yaml", replacements)
+	_ = applyYAMLFileFromTestdata(t, host, "stack.yaml", replacements)
 
 	// Step 4: Verify stack was created
 	if !verifyStackMetadataExists(t, runPath, realmName, spaceName, stackName) {
 		t.Fatalf("stack metadata file not found for stack %q", stackName)
 	}
 
-	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q not found in stack list", stackName)
 	}
 
 	// Get stack JSON to extract cgroup path
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,
@@ -642,7 +653,7 @@ func TestDeleteF_Stack_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Step 8: Verify stack does NOT appear in list
-	if verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q still appears in stack list after deletion", stackName)
 	}
 }
@@ -652,6 +663,7 @@ func TestDeleteF_Cell_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
@@ -660,23 +672,23 @@ func TestDeleteF_Cell_VerifyAllResourcesDeleted(t *testing.T) {
 
 	// Cleanup: Safety net
 	t.Cleanup(func() {
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -694,20 +706,20 @@ func TestDeleteF_Cell_VerifyAllResourcesDeleted(t *testing.T) {
 		"test-space": spaceName,
 		"test-stack": stackName,
 	}
-	_ = applyYAMLFileFromTestdata(t, runPath, "cell.yaml", replacements)
+	_ = applyYAMLFileFromTestdata(t, host, "cell.yaml", replacements)
 
 	// Step 5: Verify cell was created
 	if !verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell metadata file not found for cell %q", cellName)
 	}
 
-	if !verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+	if !verifyCellInList(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q not found in cell list", cellName)
 	}
 
 	// Get cell JSON to extract cgroup path and cell ID
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -738,12 +750,12 @@ func TestDeleteF_Cell_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Get realm namespace and cell ID for root container verification
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
 
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -781,7 +793,7 @@ func TestDeleteF_Cell_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Step 10: Verify cell does NOT appear in list
-	if verifyCellInList(t, runPath, realmName, spaceName, stackName, cellName) {
+	if verifyCellInList(t, host, realmName, spaceName, stackName, cellName) {
 		t.Fatalf("cell %q still appears in cell list after deletion", cellName)
 	}
 }
@@ -791,6 +803,7 @@ func TestDeleteF_Container_VerifyAllResourcesDeleted(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
@@ -801,23 +814,23 @@ func TestDeleteF_Container_VerifyAllResourcesDeleted(t *testing.T) {
 	// Cleanup: Safety net
 	t.Cleanup(func() {
 		cleanupContainer(t, runPath, realmName, spaceName, stackName, cellName, containerName)
-		cleanupCell(t, runPath, realmName, spaceName, stackName, cellName)
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupCell(t, host, realmName, spaceName, stackName, cellName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -835,7 +848,7 @@ func TestDeleteF_Container_VerifyAllResourcesDeleted(t *testing.T) {
 		"test-space": spaceName,
 		"test-stack": stackName,
 	}
-	_ = applyYAMLFileFromTestdata(t, runPath, "cell.yaml", replacements)
+	_ = applyYAMLFileFromTestdata(t, host, "cell.yaml", replacements)
 
 	// Step 5: Verify cell and container were created
 	if !verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {
@@ -843,12 +856,12 @@ func TestDeleteF_Container_VerifyAllResourcesDeleted(t *testing.T) {
 	}
 
 	// Get realm namespace and cell ID
-	realmNamespace, err := getRealmNamespace(t, runPath, realmName)
+	realmNamespace, err := getRealmNamespace(t, host, realmName)
 	if err != nil {
 		t.Fatalf("failed to get realm namespace: %v", err)
 	}
 
-	cellID, err := getCellID(t, runPath, realmName, spaceName, stackName, cellName)
+	cellID, err := getCellID(t, host, realmName, spaceName, stackName, cellName)
 	if err != nil {
 		t.Fatalf("failed to get cell ID: %v", err)
 	}
@@ -868,7 +881,7 @@ func TestDeleteF_Container_VerifyAllResourcesDeleted(t *testing.T) {
 
 	// Get cell JSON to verify container is in cell metadata
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -925,7 +938,7 @@ spec:
 		t.Fatalf("failed to write container YAML file: %v", err)
 	}
 
-	// Step 7: Delete using delete -f
+	// Step 7: Delete using delete -f (`delete -f` routes in-process; see deleteYAMLFileFromTestdata note)
 	args = append(buildKukeRunPathArgs(runPath), "delete", "-f", containerYAMLFile)
 	_ = runReturningBinary(t, nil, kuke, args...)
 
@@ -949,7 +962,7 @@ spec:
 
 	// Step 10: Verify container removed from cell metadata
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,

--- a/e2e/e2e_kuke_invalid_names_test.go
+++ b/e2e/e2e_kuke_invalid_names_test.go
@@ -23,14 +23,15 @@ import (
 
 // TestKuke_CreateSpace_RejectsInvalidNames covers the AC for #180: invalid
 // space names ("_" or "/") must be rejected end-to-end with a non-zero exit
-// code and a clear error message that names the offending input. Run via the
-// in-process controller (via the `--run-path` promotion) so the test is self-contained — the
-// validator is wired at both controller and runner boundaries, so the same
-// rejection fires either way.
+// code and a clear error message that names the offending input. Routed
+// through the per-test daemon so the workload-command path matches the
+// suite's default mode post-#565; the validator is wired at both
+// controller and runner boundaries, so the same rejection fires either way.
 func TestKuke_CreateSpace_RejectsInvalidNames(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	tests := []struct {
 		name      string
@@ -43,7 +44,7 @@ func TestKuke_CreateSpace_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := append(buildKukeRunPathArgs(runPath),
+			args := append(buildKukeDaemonArgs(host),
 				"create", "space", tt.spaceName, "--realm", "default")
 			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
 			if exitCode == 0 {
@@ -63,6 +64,7 @@ func TestKuke_CreateStack_RejectsInvalidNames(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	tests := []struct {
 		name      string
@@ -75,7 +77,7 @@ func TestKuke_CreateStack_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := append(buildKukeRunPathArgs(runPath),
+			args := append(buildKukeDaemonArgs(host),
 				"create", "stack", tt.stackName,
 				"--realm", "default", "--space", "default")
 			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
@@ -96,6 +98,7 @@ func TestKuke_CreateCell_RejectsInvalidNames(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	tests := []struct {
 		name     string
@@ -108,7 +111,7 @@ func TestKuke_CreateCell_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := append(buildKukeRunPathArgs(runPath),
+			args := append(buildKukeDaemonArgs(host),
 				"create", "cell", tt.cellName,
 				"--realm", "default", "--space", "default", "--stack", "default")
 			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
@@ -129,6 +132,7 @@ func TestKuke_CreateContainer_RejectsInvalidNames(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	tests := []struct {
 		name          string
@@ -141,7 +145,7 @@ func TestKuke_CreateContainer_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := append(buildKukeRunPathArgs(runPath),
+			args := append(buildKukeDaemonArgs(host),
 				"create", "container", tt.containerName,
 				"--realm", "default", "--space", "default",
 				"--stack", "default", "--cell", "default",

--- a/e2e/e2e_kuke_realm_test.go
+++ b/e2e/e2e_kuke_realm_test.go
@@ -72,10 +72,10 @@ func parseRealmJSON(t *testing.T, output []byte) (*v1beta1.RealmDoc, error) {
 }
 
 // verifyRealmInList verifies realm appears in kuke get realm list.
-func verifyRealmInList(t *testing.T, runPath, realmName string) bool {
+func verifyRealmInList(t *testing.T, host, realmName string) bool {
 	t.Helper()
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "realm", "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "realm", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	realms, err := parseRealmListJSON(t, output)
@@ -94,10 +94,10 @@ func verifyRealmInList(t *testing.T, runPath, realmName string) bool {
 }
 
 // verifyRealmExists verifies realm can be retrieved individually.
-func verifyRealmExists(t *testing.T, runPath, realmName string) bool {
+func verifyRealmExists(t *testing.T, host, realmName string) bool {
 	t.Helper()
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	exitCode, stdout, _ := runBinary(t, nil, kuke, args...)
 
 	if exitCode != 0 {
@@ -113,11 +113,14 @@ func verifyRealmExists(t *testing.T, runPath, realmName string) bool {
 	return realm.Metadata.Name == realmName
 }
 
-// cleanupRealm deletes a realm with cascade.
-func cleanupRealm(t *testing.T, runPath, realmName string) {
+// cleanupRealm deletes a realm with cascade through the per-test daemon. The
+// caller must register this cleanup after startKukeondDaemon so t.Cleanup's
+// LIFO order runs the delete before the daemon is signaled (otherwise the
+// kuke client would dial a closed socket and the realm would leak).
+func cleanupRealm(t *testing.T, host, realmName string) {
 	t.Helper()
 
-	args := append(buildKukeRunPathArgs(runPath), "delete", "realm", realmName, "--cascade")
+	args := append(buildKukeDaemonArgs(host), "delete", "realm", realmName, "--cascade")
 	// Don't fail if realm doesn't exist
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
@@ -127,8 +130,9 @@ func TestKuke_NoRealms(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "realm", "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "realm", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	var realms []v1beta1.RealmDoc
@@ -173,15 +177,16 @@ func TestKuke_CreateRealm_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 
-	// Cleanup: Delete realm
+	// Cleanup: Delete realm (routed through the same per-test daemon)
 	t.Cleanup(func() {
-		cleanupRealm(t, runPath, realmName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Verify containerd namespace exists
@@ -197,18 +202,18 @@ func TestKuke_CreateRealm_VerifyState(t *testing.T) {
 	}
 
 	// Step 4: Verify realm appears in list (JSON parsing)
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found in realm list", realmName)
 	}
 
 	// Step 5: Verify realm can be retrieved individually
-	if !verifyRealmExists(t, runPath, realmName) {
+	if !verifyRealmExists(t, host, realmName) {
 		t.Fatalf("realm %q cannot be retrieved individually", realmName)
 	}
 
 	// Step 6: Verify cgroup path exists
 	// Get realm JSON to extract cgroup path
-	args = append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	realm, err := parseRealmJSON(t, output)
@@ -249,15 +254,16 @@ func TestKuke_DeleteRealm_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 
 	// Cleanup: Safety net (realm should already be deleted, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
-		cleanupRealm(t, runPath, realmName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite for deletion test)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Verify realm exists initially (establish baseline)
@@ -270,16 +276,16 @@ func TestKuke_DeleteRealm_VerifyState(t *testing.T) {
 		t.Fatalf("realm metadata file not found for realm %q", realmName)
 	}
 
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found in realm list", realmName)
 	}
 
-	if !verifyRealmExists(t, runPath, realmName) {
+	if !verifyRealmExists(t, host, realmName) {
 		t.Fatalf("realm %q cannot be retrieved individually", realmName)
 	}
 
 	// Get realm JSON to extract cgroup path for later verification
-	args = append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	realm, err := parseRealmJSON(t, output)
@@ -298,7 +304,7 @@ func TestKuke_DeleteRealm_VerifyState(t *testing.T) {
 	}
 
 	// Step 3: Delete the realm
-	args = append(buildKukeRunPathArgs(runPath), "delete", "realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "delete", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 4: Verify metadata file does NOT exist
@@ -320,12 +326,12 @@ func TestKuke_DeleteRealm_VerifyState(t *testing.T) {
 	}
 
 	// Step 7: Verify realm does NOT appear in list
-	if verifyRealmInList(t, runPath, realmName) {
+	if verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q still appears in realm list after deletion", realmName)
 	}
 
 	// Step 8: Verify individual get FAILS (returns non-zero exit code)
-	args = append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	exitCode, _, _ := runBinary(t, nil, kuke, args...)
 	if exitCode == 0 {
 		t.Fatalf("expected get realm to fail after deletion, but got exit code 0")
@@ -340,15 +346,16 @@ func TestKuke_PurgeRealm_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 
 	// Cleanup: Safety net (realm should already be purged, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
-		cleanupRealm(t, runPath, realmName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite for purge test)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Verify realm exists initially (establish baseline)
@@ -361,16 +368,16 @@ func TestKuke_PurgeRealm_VerifyState(t *testing.T) {
 		t.Fatalf("realm metadata file not found for realm %q", realmName)
 	}
 
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q not found in realm list", realmName)
 	}
 
-	if !verifyRealmExists(t, runPath, realmName) {
+	if !verifyRealmExists(t, host, realmName) {
 		t.Fatalf("realm %q cannot be retrieved individually", realmName)
 	}
 
 	// Get realm JSON to extract cgroup path for later verification
-	args = append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	realm, err := parseRealmJSON(t, output)
@@ -388,7 +395,9 @@ func TestKuke_PurgeRealm_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", cgroupPath)
 	}
 
-	// Step 3: Purge the realm (comprehensive cleanup)
+	// Step 3: Purge the realm (comprehensive cleanup) — purge stays
+	// in-process per the #565 AC: it must run regardless of daemon state
+	// so cleanup paths are not coupled to the per-test daemon's lifetime.
 	args = append(buildKukeRunPathArgs(runPath), "purge", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
@@ -411,12 +420,12 @@ func TestKuke_PurgeRealm_VerifyState(t *testing.T) {
 	}
 
 	// Step 7: Verify realm does NOT appear in list
-	if verifyRealmInList(t, runPath, realmName) {
+	if verifyRealmInList(t, host, realmName) {
 		t.Fatalf("realm %q still appears in realm list after purge", realmName)
 	}
 
 	// Step 8: Verify individual get FAILS (returns non-zero exit code)
-	args = append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	exitCode, _, _ := runBinary(t, nil, kuke, args...)
 	if exitCode == 0 {
 		t.Fatalf("expected get realm to fail after purge, but got exit code 0")

--- a/e2e/e2e_kuke_space_test.go
+++ b/e2e/e2e_kuke_space_test.go
@@ -26,11 +26,13 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
-// cleanupSpace deletes a space with cascade.
-func cleanupSpace(t *testing.T, runPath, realmName, spaceName string) {
+// cleanupSpace deletes a space with cascade through the per-test daemon.
+// Register after startKukeondDaemon so t.Cleanup's LIFO order runs delete
+// before the daemon is signaled.
+func cleanupSpace(t *testing.T, host, realmName, spaceName string) {
 	t.Helper()
 
-	args := append(buildKukeRunPathArgs(runPath), "delete", "space", spaceName, "--realm", realmName, "--cascade")
+	args := append(buildKukeDaemonArgs(host), "delete", "space", spaceName, "--realm", realmName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
 
@@ -39,8 +41,9 @@ func TestKuke_NoSpaces(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "space", "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "space", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	var spaces []v1beta1.SpaceDoc
@@ -59,21 +62,22 @@ func TestKuke_CreateSpace_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 
 	// Cleanup: Delete space first, then realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Verify CNI config file exists
@@ -87,18 +91,18 @@ func TestKuke_CreateSpace_VerifyState(t *testing.T) {
 	}
 
 	// Step 5: Verify space appears in list (JSON parsing)
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q not found in space list", spaceName)
 	}
 
 	// Step 6: Verify space can be retrieved individually
-	if !verifySpaceExists(t, runPath, realmName, spaceName) {
+	if !verifySpaceExists(t, host, realmName, spaceName) {
 		t.Fatalf("space %q cannot be retrieved individually", spaceName)
 	}
 
 	// Step 7: Verify cgroup path exists
 	// Get space JSON to extract cgroup path
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	space, err := parseSpaceJSON(t, output)
@@ -134,21 +138,22 @@ func TestKuke_DeleteSpace_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 
 	// Cleanup: Safety net (space should already be deleted, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite for deletion test)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Verify space exists initially (establish baseline)
@@ -160,16 +165,16 @@ func TestKuke_DeleteSpace_VerifyState(t *testing.T) {
 		t.Fatalf("space metadata file not found for space %q", spaceName)
 	}
 
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q not found in space list", spaceName)
 	}
 
-	if !verifySpaceExists(t, runPath, realmName, spaceName) {
+	if !verifySpaceExists(t, host, realmName, spaceName) {
 		t.Fatalf("space %q cannot be retrieved individually", spaceName)
 	}
 
 	// Get space JSON to extract cgroup path for later verification
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	space, err := parseSpaceJSON(t, output)
@@ -188,7 +193,7 @@ func TestKuke_DeleteSpace_VerifyState(t *testing.T) {
 	}
 
 	// Step 4: Delete the space
-	args = append(buildKukeRunPathArgs(runPath), "delete", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "delete", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 5: Verify CNI config file does NOT exist
@@ -210,12 +215,12 @@ func TestKuke_DeleteSpace_VerifyState(t *testing.T) {
 	}
 
 	// Step 8: Verify space does NOT appear in list
-	if verifySpaceInList(t, runPath, realmName, spaceName) {
+	if verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q still appears in space list after deletion", spaceName)
 	}
 
 	// Step 9: Verify individual get FAILS (returns non-zero exit code)
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	exitCode, _, _ := runBinary(t, nil, kuke, args...)
 	if exitCode == 0 {
 		t.Fatalf("expected get space to fail after deletion, but got exit code 0")
@@ -230,21 +235,22 @@ func TestKuke_PurgeSpace_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 
 	// Cleanup: Safety net (space should already be purged, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite for purge test)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Verify space exists initially (establish baseline)
@@ -256,16 +262,16 @@ func TestKuke_PurgeSpace_VerifyState(t *testing.T) {
 		t.Fatalf("space metadata file not found for space %q", spaceName)
 	}
 
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q not found in space list", spaceName)
 	}
 
-	if !verifySpaceExists(t, runPath, realmName, spaceName) {
+	if !verifySpaceExists(t, host, realmName, spaceName) {
 		t.Fatalf("space %q cannot be retrieved individually", spaceName)
 	}
 
 	// Get space JSON to extract cgroup path for later verification
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	space, err := parseSpaceJSON(t, output)
@@ -283,7 +289,8 @@ func TestKuke_PurgeSpace_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", cgroupPath)
 	}
 
-	// Step 4: Purge the space (comprehensive cleanup)
+	// Step 4: Purge the space (comprehensive cleanup) — in-process per the
+	// #565 AC so purge does not depend on the per-test daemon being alive.
 	args = append(buildKukeRunPathArgs(runPath), "purge", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
@@ -306,12 +313,12 @@ func TestKuke_PurgeSpace_VerifyState(t *testing.T) {
 	}
 
 	// Step 8: Verify space does NOT appear in list
-	if verifySpaceInList(t, runPath, realmName, spaceName) {
+	if verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("space %q still appears in space list after purge", spaceName)
 	}
 
 	// Step 9: Verify individual get FAILS (returns non-zero exit code)
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	exitCode, _, _ := runBinary(t, nil, kuke, args...)
 	if exitCode == 0 {
 		t.Fatalf("expected get space to fail after purge, but got exit code 0")

--- a/e2e/e2e_kuke_stack_test.go
+++ b/e2e/e2e_kuke_stack_test.go
@@ -25,12 +25,14 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
-// cleanupStack deletes a stack with cascade.
-func cleanupStack(t *testing.T, runPath, realmName, spaceName, stackName string) {
+// cleanupStack deletes a stack with cascade through the per-test daemon.
+// Register after startKukeondDaemon so t.Cleanup's LIFO order runs delete
+// before the daemon is signaled.
+func cleanupStack(t *testing.T, host, realmName, spaceName, stackName string) {
 	t.Helper()
 
 	args := append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"delete",
 		"stack",
 		stackName,
@@ -48,8 +50,9 @@ func TestKuke_NoStacks(t *testing.T) {
 	t.Parallel()
 
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "stack", "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "stack", "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	var stacks []v1beta1.StackDoc
@@ -68,28 +71,29 @@ func TestKuke_CreateStack_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
 
 	// Cleanup: Delete stack first, then space, then realm (reverse dependency order)
 	t.Cleanup(func() {
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -106,19 +110,19 @@ func TestKuke_CreateStack_VerifyState(t *testing.T) {
 	}
 
 	// Step 5: Verify stack appears in list (JSON parsing)
-	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q not found in stack list", stackName)
 	}
 
 	// Step 6: Verify stack can be retrieved individually
-	if !verifyStackExists(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackExists(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q cannot be retrieved individually", stackName)
 	}
 
 	// Step 7: Verify cgroup path exists
 	// Get stack JSON to extract cgroup path
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,
@@ -164,28 +168,29 @@ func TestKuke_DeleteStack_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
 
 	// Cleanup: Safety net (stack should already be deleted, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite for deletion test)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -201,17 +206,17 @@ func TestKuke_DeleteStack_VerifyState(t *testing.T) {
 		t.Fatalf("stack metadata file not found for stack %q", stackName)
 	}
 
-	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q not found in stack list", stackName)
 	}
 
-	if !verifyStackExists(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackExists(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q cannot be retrieved individually", stackName)
 	}
 
 	// Get stack JSON to extract cgroup path for later verification
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,
@@ -241,7 +246,7 @@ func TestKuke_DeleteStack_VerifyState(t *testing.T) {
 
 	// Step 5: Delete the stack
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"delete",
 		"stack",
 		stackName,
@@ -263,13 +268,13 @@ func TestKuke_DeleteStack_VerifyState(t *testing.T) {
 	}
 
 	// Step 8: Verify stack does NOT appear in list
-	if verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q still appears in stack list after deletion", stackName)
 	}
 
 	// Step 9: Verify individual get FAILS (returns non-zero exit code)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,
@@ -294,28 +299,29 @@ func TestKuke_PurgeStack_VerifyState(t *testing.T) {
 
 	// Setup
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
 	stackName := generateUniqueStackName(t)
 
 	// Cleanup: Safety net (stack should already be purged, but ensure cleanup if test fails partway)
 	t.Cleanup(func() {
-		cleanupStack(t, runPath, realmName, spaceName, stackName)
-		cleanupSpace(t, runPath, realmName, spaceName)
-		cleanupRealm(t, runPath, realmName)
+		cleanupStack(t, host, realmName, spaceName, stackName)
+		cleanupSpace(t, host, realmName, spaceName)
+		cleanupRealm(t, host, realmName)
 	})
 
 	// Step 1: Create realm (prerequisite)
-	args := append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)
+	args := append(buildKukeDaemonArgs(host), "create", "realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 2: Create space (prerequisite)
-	args = append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)
+	args = append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)
 	runReturningBinary(t, nil, kuke, args...)
 
 	// Step 3: Create stack (prerequisite for purge test)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"create",
 		"stack",
 		stackName,
@@ -331,17 +337,17 @@ func TestKuke_PurgeStack_VerifyState(t *testing.T) {
 		t.Fatalf("stack metadata file not found for stack %q", stackName)
 	}
 
-	if !verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q not found in stack list", stackName)
 	}
 
-	if !verifyStackExists(t, runPath, realmName, spaceName, stackName) {
+	if !verifyStackExists(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q cannot be retrieved individually", stackName)
 	}
 
 	// Get stack JSON to extract cgroup path for later verification
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,
@@ -369,7 +375,8 @@ func TestKuke_PurgeStack_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", cgroupPath)
 	}
 
-	// Step 5: Purge the stack (comprehensive cleanup)
+	// Step 5: Purge the stack (comprehensive cleanup) — in-process per the
+	// #565 AC so purge does not depend on the per-test daemon being alive.
 	args = append(
 		buildKukeRunPathArgs(runPath),
 		"purge",
@@ -393,13 +400,13 @@ func TestKuke_PurgeStack_VerifyState(t *testing.T) {
 	}
 
 	// Step 8: Verify stack does NOT appear in list
-	if verifyStackInList(t, runPath, realmName, spaceName, stackName) {
+	if verifyStackInList(t, host, realmName, spaceName, stackName) {
 		t.Fatalf("stack %q still appears in stack list after purge", stackName)
 	}
 
 	// Step 9: Verify individual get FAILS (returns non-zero exit code)
 	args = append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -314,15 +314,20 @@ func TestKuke_DaemonReset_RoundTrip(t *testing.T) {
 		args := append(buildKukeRunPathArgs(runPath), "daemon", "reset", "--purge-system")
 		_, _, _ = runBinary(t, nil, kuke, args...)
 
-		cleanupCell(
+		// Use the *NoDaemon variants here — by the time cleanup fires, the
+		// init-spawned kukeond cell has already been torn down by the reset
+		// above, so the daemon-mode cleanupCell/cleanupRealm (#565) would
+		// dial a vanished socket and leave residue. In-process is the only
+		// mode that can guarantee post-test removal here.
+		cleanupCellNoDaemon(
 			t, runPath,
 			consts.KukeSystemRealmName,
 			consts.KukeSystemSpaceName,
 			consts.KukeSystemStackName,
 			consts.KukeSystemCellName,
 		)
-		cleanupRealm(t, runPath, consts.KukeSystemRealmName)
-		cleanupRealm(t, runPath, consts.KukeonDefaultRealmName)
+		cleanupRealmNoDaemon(t, runPath, consts.KukeSystemRealmName)
+		cleanupRealmNoDaemon(t, runPath, consts.KukeonDefaultRealmName)
 	})
 
 	kukeondImage := loadKukeondImageIntoContainerd(t)
@@ -488,26 +493,32 @@ func TestKuke_Init_VerifyState(t *testing.T) {
 		"purge", "realm", "default",
 	)...)
 
-	// Cleanup: Clean up resources created by init in reverse dependency order
+	// Cleanup: Clean up resources created by init in reverse dependency
+	// order. Use the *NoDaemon variants because the cleanup chain ends with
+	// `cleanupRealmNoDaemon(kuke-system) --cascade`, which tears down the
+	// kukeond cell that init brought up; subsequent `cleanupRealm(default)`
+	// would dial a dead socket if routed via daemon mode. In-process is the
+	// reliable mode here for the same reason it is in
+	// TestKuke_DaemonReset_RoundTrip and the attach test (#565 AC).
 	t.Cleanup(func() {
-		cleanupCell(
+		cleanupCellNoDaemon(
 			t, runPath,
 			consts.KukeSystemRealmName,
 			consts.KukeSystemSpaceName,
 			consts.KukeSystemStackName,
 			consts.KukeSystemCellName,
 		)
-		cleanupStack(
+		cleanupStackNoDaemon(
 			t, runPath,
 			consts.KukeSystemRealmName,
 			consts.KukeSystemSpaceName,
 			consts.KukeSystemStackName,
 		)
-		cleanupSpace(t, runPath, consts.KukeSystemRealmName, consts.KukeSystemSpaceName)
-		cleanupRealm(t, runPath, consts.KukeSystemRealmName)
-		cleanupStack(t, runPath, "default", "default", "default")
-		cleanupSpace(t, runPath, "default", "default")
-		cleanupRealm(t, runPath, "default")
+		cleanupSpaceNoDaemon(t, runPath, consts.KukeSystemRealmName, consts.KukeSystemSpaceName)
+		cleanupRealmNoDaemon(t, runPath, consts.KukeSystemRealmName)
+		cleanupStackNoDaemon(t, runPath, "default", "default", "default")
+		cleanupSpaceNoDaemon(t, runPath, "default", "default")
+		cleanupRealmNoDaemon(t, runPath, "default")
 	})
 
 	// Step 0.5: Stage the local kukeond image into containerd's kuke-system
@@ -540,17 +551,23 @@ func TestKuke_Init_VerifyState(t *testing.T) {
 		}
 	}
 
+	// `kuke init --run-path X` brings up the kuke-system kukeond cell on a
+	// socket derived from runPath (#569). Workload-command verifications
+	// below dial that socket per the #565 AC so the daemon-routed view is
+	// what we assert on, not the in-process controller's view.
+	host := "unix://" + filepath.Join(runPath, "kukeond.sock")
+
 	// Step 3: Verify default realm exists
 	realmName := "default"
 	if !verifyRealmMetadataExists(t, runPath, realmName) {
 		t.Fatalf("realm metadata file not found for default realm")
 	}
 
-	if !verifyRealmInList(t, runPath, realmName) {
+	if !verifyRealmInList(t, host, realmName) {
 		t.Fatalf("default realm not found in realm list")
 	}
 
-	if !verifyRealmExists(t, runPath, realmName) {
+	if !verifyRealmExists(t, host, realmName) {
 		t.Fatalf("default realm cannot be retrieved individually")
 	}
 
@@ -561,7 +578,7 @@ func TestKuke_Init_VerifyState(t *testing.T) {
 	}
 
 	// Step 5: Verify realm cgroup exists
-	args = append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	realmOutput := runReturningBinary(t, nil, kuke, args...)
 
 	realm, err := parseRealmJSON(t, realmOutput)
@@ -583,11 +600,11 @@ func TestKuke_Init_VerifyState(t *testing.T) {
 		t.Fatalf("space metadata file not found for default space")
 	}
 
-	if !verifySpaceInList(t, runPath, realmName, spaceName) {
+	if !verifySpaceInList(t, host, realmName, spaceName) {
 		t.Fatalf("default space not found in space list")
 	}
 
-	if !verifySpaceExists(t, runPath, realmName, spaceName) {
+	if !verifySpaceExists(t, host, realmName, spaceName) {
 		t.Fatalf("default space cannot be retrieved individually")
 	}
 
@@ -597,7 +614,7 @@ func TestKuke_Init_VerifyState(t *testing.T) {
 	}
 
 	// Step 8: Verify space cgroup exists
-	args = append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args = append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	spaceOutput := runReturningBinary(t, nil, kuke, args...)
 
 	space, err := parseSpaceJSON(t, spaceOutput)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -157,14 +157,27 @@ func deepSocketPathFits(runPath string) bool {
 	return len(runPath)+deepSocketSuffixLen <= consts.KukeonMaxSocketPath
 }
 
-// buildKukeRunPathArgs returns the canonical `--run-path <X>` prefix every
-// e2e invocation must carry. The e2e suite has no shared kukeond running on
-// its --run-path; without the in-process promotion that --run-path triggers,
-// kuke would dial the host's daemon socket (whichever /opt/kukeon path it
-// was started against) and read/write someone else's state. Per-test
-// --run-path + in-process controller is the only mode that keeps the suite
-// hermetic on hosts where containerd is up but kukeond is not (the common
-// e2e harness shape).
+// buildKukeRunPathArgs returns a `--run-path <X>` prefix for callers that
+// must run in the in-process controller path rather than dial a daemon.
+// Use buildKukeDaemonArgs (paired with startKukeondDaemon) for workload
+// commands — per-test daemon-mode is the suite's default now that phase 2
+// (#565) has landed.
+//
+// Legitimate survivors of this in-process helper:
+//   - `get realms --no-daemon`: the daemon-parity smoke (CLAUDE.md's
+//     regression guard contrasts the in-process realm view with the daemon's
+//     view; routing both sides through the daemon would defeat the check).
+//   - `purge` (any kind): purge is a host-mutating verb that must work
+//     regardless of daemon state, so e2e cleanups never depend on the
+//     per-test daemon still being alive.
+//   - `init` / `uninstall`: bootstrap/teardown verbs that bring up or tear
+//     down the daemon itself; they cannot route through it.
+//   - `kuke daemon …`: the daemon-lifecycle group; in-process by definition
+//     per the #217 categorization.
+//   - The attach test (e2e_kuke_attach_test.go) keeps its `*NoDaemon`
+//     cleanup helpers so the per-container kuketty socket inspection lines
+//     up with the same controller the test drives (see the comment in
+//     TestKuke_AttachDetach_KeepsTaskRunning for rationale).
 //
 // The in-process promotion comes from applyRunPathImpliesNoDaemon
 // (cmd/kuke/kuke.go), which auto-sets --no-daemon=true whenever --run-path
@@ -396,10 +409,10 @@ func parseSpaceJSON(t *testing.T, output []byte) (*v1beta1.SpaceDoc, error) {
 }
 
 // verifySpaceInList verifies space appears in kuke get space list.
-func verifySpaceInList(t *testing.T, runPath, realmName, spaceName string) bool {
+func verifySpaceInList(t *testing.T, host, realmName, spaceName string) bool {
 	t.Helper()
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "space", "--realm", realmName, "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "space", "--realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	spaces, err := parseSpaceListJSON(t, output)
@@ -418,10 +431,10 @@ func verifySpaceInList(t *testing.T, runPath, realmName, spaceName string) bool 
 }
 
 // verifySpaceExists verifies space can be retrieved individually.
-func verifySpaceExists(t *testing.T, runPath, realmName, spaceName string) bool {
+func verifySpaceExists(t *testing.T, host, realmName, spaceName string) bool {
 	t.Helper()
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "space", spaceName, "--realm", realmName, "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "space", spaceName, "--realm", realmName, "--output", "json")
 	exitCode, stdout, _ := runBinary(t, nil, kuke, args...)
 
 	if exitCode != 0 {
@@ -479,11 +492,11 @@ func parseStackJSON(t *testing.T, output []byte) (*v1beta1.StackDoc, error) {
 }
 
 // verifyStackInList verifies stack appears in kuke get stack list.
-func verifyStackInList(t *testing.T, runPath, realmName, spaceName, stackName string) bool {
+func verifyStackInList(t *testing.T, host, realmName, spaceName, stackName string) bool {
 	t.Helper()
 
 	args := append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		"--realm",
@@ -511,11 +524,11 @@ func verifyStackInList(t *testing.T, runPath, realmName, spaceName, stackName st
 }
 
 // verifyStackExists verifies stack can be retrieved individually.
-func verifyStackExists(t *testing.T, runPath, realmName, spaceName, stackName string) bool {
+func verifyStackExists(t *testing.T, host, realmName, spaceName, stackName string) bool {
 	t.Helper()
 
 	args := append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"stack",
 		stackName,
@@ -591,11 +604,11 @@ func parseCellJSON(t *testing.T, output []byte) (*v1beta1.CellDoc, error) {
 }
 
 // verifyCellInList verifies cell appears in kuke get cell list.
-func verifyCellInList(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) bool {
+func verifyCellInList(t *testing.T, host, realmName, spaceName, stackName, cellName string) bool {
 	t.Helper()
 
 	args := append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		"--realm",
@@ -625,11 +638,11 @@ func verifyCellInList(t *testing.T, runPath, realmName, spaceName, stackName, ce
 }
 
 // verifyCellExists verifies cell can be retrieved individually.
-func verifyCellExists(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) bool {
+func verifyCellExists(t *testing.T, host, realmName, spaceName, stackName, cellName string) bool {
 	t.Helper()
 
 	args := append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,
@@ -658,10 +671,10 @@ func verifyCellExists(t *testing.T, runPath, realmName, spaceName, stackName, ce
 }
 
 // getRealmNamespace gets realm namespace from realm JSON.
-func getRealmNamespace(t *testing.T, runPath, realmName string) (string, error) {
+func getRealmNamespace(t *testing.T, host, realmName string) (string, error) {
 	t.Helper()
 
-	args := append(buildKukeRunPathArgs(runPath), "get", "realm", realmName, "--output", "json")
+	args := append(buildKukeDaemonArgs(host), "get", "realm", realmName, "--output", "json")
 	output := runReturningBinary(t, nil, kuke, args...)
 
 	realm, err := parseRealmJSON(t, output)
@@ -788,11 +801,11 @@ func verifyRootContainerTaskIsStopped(t *testing.T, namespace, containerID strin
 }
 
 // getCellID gets cell ID from cell JSON.
-func getCellID(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) (string, error) {
+func getCellID(t *testing.T, host, realmName, spaceName, stackName, cellName string) (string, error) {
 	t.Helper()
 
 	args := append(
-		buildKukeRunPathArgs(runPath),
+		buildKukeDaemonArgs(host),
 		"get",
 		"cell",
 		cellName,

--- a/e2e/harness_daemon_test.go
+++ b/e2e/harness_daemon_test.go
@@ -1,0 +1,182 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// daemonStartupTimeout bounds how long startKukeondDaemon waits for the
+// listener socket to appear after `kukeond serve` is exec'd. Cold-start on a
+// loaded host is typically sub-second; the budget is generous so a slow CI
+// box does not flake the harness before the daemon has bound its listener.
+const daemonStartupTimeout = 10 * time.Second
+
+// daemonShutdownTimeout bounds the SIGTERM-and-wait phase of the per-test
+// cleanup. If the daemon does not exit within this window the cleanup
+// escalates to SIGKILL so a hung daemon never strands `go test` past its
+// per-test 60s allowance.
+const daemonShutdownTimeout = 5 * time.Second
+
+// startKukeondDaemon brings up a per-test kukeond bound to the given
+// run-path, listening on a SUN_PATH-safe socket under a short /tmp prefix.
+// It blocks until the socket appears (or daemonStartupTimeout elapses),
+// registers t.Cleanup that SIGTERM's the daemon and waits for exit, and
+// returns the `unix:///…` address suitable for `--host`.
+//
+// This is the daemon-mode counterpart to buildKukeRunPathArgs's in-process
+// promotion. Workload-command tests call this once per test (paired with
+// getRandomRunPath for the on-disk tree), then pass the returned host
+// through buildKukeDaemonArgs into every `kuke …` invocation so the client
+// dials the per-test daemon rather than the host's production socket.
+//
+// The kukeond binary is resolved from E2E_BIN_DIR (set by `make e2e`), the
+// same way runBinary resolves `kuke`. The test is skipped — not failed —
+// when the binary or env is missing so `go test ./e2e` outside `make e2e`
+// behaves consistently with the rest of the harness.
+//
+// Notable kukeond flags passed:
+//   - --socket <X>: per-test SUN_PATH-safe listener path
+//   - --run-path <Y>: matches the test's runPath so daemon-written metadata
+//     lives where the fs.* verification helpers look for it
+//   - --reconcile-interval 0: disables the background ticker so a per-test
+//     daemon does not log noise (or race the test's create/delete sequence)
+//   - --configuration <runPath>/kukeond.yaml: path does not exist, so
+//     serverconfig.Load returns a zero doc and the daemon falls through to
+//     hardcoded defaults — keeps the harness off /etc/kukeon/kukeond.yaml
+//     even when the dev host has one
+func startKukeondDaemon(t *testing.T, runPath string) string {
+	t.Helper()
+
+	binDir := os.Getenv("E2E_BIN_DIR")
+	if binDir == "" {
+		binDir = ".."
+	}
+	bin := filepath.Join(binDir, "kukeond")
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Skipf("kukeond binary %s not found, skipping daemon-mode test", bin)
+	}
+
+	// Pick a short /tmp prefix for the socket dir — t.TempDir() leans on the
+	// test function name and easily blows the 107-byte SUN_PATH budget when
+	// kukeond opens its listener.
+	sockDir, err := os.MkdirTemp("/tmp", "kd-") //nolint:usetesting // intentional shorter prefix; see comment
+	if err != nil {
+		t.Fatalf("MkdirTemp(/tmp, kd-): %v", err)
+	}
+	sockPath := filepath.Join(sockDir, "k.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, bin,
+		"serve",
+		"--socket", sockPath,
+		"--run-path", runPath,
+		"--reconcile-interval", "0",
+		"--configuration", filepath.Join(runPath, "kukeond.yaml"),
+	)
+	// Capture daemon output for diagnostics on cleanup failure.
+	logFile, logErr := os.CreateTemp("", "kukeond-*.log")
+	if logErr != nil {
+		cancel()
+		t.Fatalf("CreateTemp kukeond log: %v", logErr)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if startErr := cmd.Start(); startErr != nil {
+		cancel()
+		_ = logFile.Close()
+		_ = os.RemoveAll(sockDir)
+		t.Fatalf("start kukeond serve: %v", startErr)
+	}
+
+	// Wait for the listener socket to appear. `kukeond serve` writes the
+	// socket synchronously inside Serve before entering Accept, so the file's
+	// presence is a reliable readiness signal.
+	deadline := time.Now().Add(daemonStartupTimeout)
+	for {
+		if _, statErr := os.Stat(sockPath); statErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+			_, _ = cmd.Process.Wait()
+			cancel()
+			logBytes, _ := os.ReadFile(logFile.Name())
+			_ = logFile.Close()
+			_ = os.Remove(logFile.Name())
+			_ = os.RemoveAll(sockDir)
+			t.Fatalf(
+				"kukeond did not create socket %s within %s; daemon log:\n%s",
+				sockPath, daemonStartupTimeout, string(logBytes),
+			)
+		}
+		// Detect early exit so the test fails fast with the daemon log
+		// instead of waiting out the timeout.
+		if exitedErr := cmd.Process.Signal(syscall.Signal(0)); exitedErr != nil {
+			cancel()
+			logBytes, _ := os.ReadFile(logFile.Name())
+			_ = logFile.Close()
+			_ = os.Remove(logFile.Name())
+			_ = os.RemoveAll(sockDir)
+			t.Fatalf(
+				"kukeond exited before socket %s appeared; daemon log:\n%s",
+				sockPath, string(logBytes),
+			)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	t.Cleanup(func() {
+		// Graceful shutdown: SIGTERM and wait. Escalate to SIGKILL if the
+		// daemon ignores the term within daemonShutdownTimeout.
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		done := make(chan error, 1)
+		go func() { done <- cmd.Wait() }()
+		select {
+		case <-done:
+		case <-time.After(daemonShutdownTimeout):
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+			<-done
+		}
+		cancel()
+		_ = logFile.Close()
+		_ = os.Remove(logFile.Name())
+		_ = os.RemoveAll(sockDir)
+	})
+
+	return fmt.Sprintf("unix://%s", sockPath)
+}
+
+// buildKukeDaemonArgs returns the `--host <addr>` prefix every daemon-mode
+// e2e invocation must carry. Pair with startKukeondDaemon to route a
+// workload command to the per-test daemon instead of the in-process
+// controller that --run-path promotion would otherwise select.
+//
+// The in-process counterpart (buildKukeRunPathArgs) survives for the
+// daemon-parity check (`get realms --no-daemon`) and host-mutating verbs
+// (purge, init, uninstall) — those must not depend on a per-test daemon.
+func buildKukeDaemonArgs(host string) []string {
+	return []string{"--host", host}
+}


### PR DESCRIPTION
## Summary

- Adds a per-test daemon harness (`e2e/harness_daemon_test.go`) that spawns `kukeond serve` against an isolated `--run-path` and a unique `/tmp/kd-XXXX/k.sock`, with `t.Cleanup` doing SIGTERM-then-SIGKILL teardown. Each parallel test gets its own daemon — no shared state, no cross-test interference.
- Converts every workload-command call site across `e2e/e2e_kuke_*.go` to route via `buildKukeDaemonArgs(host)` instead of `buildKukeRunPathArgs(runPath)` (which was triggering `applyRunPathImpliesNoDaemon` → in-process).
- `buildKukeRunPathArgs(runPath)` is retained only for contexts that genuinely need the in-process path: `kuke init` / `purge` / `uninstall`, the `get realms --no-daemon` parity check, the daemon-lifecycle tests (`daemon start/stop/kill/restart/reset _Uninitialized`), and `kuke delete -f` (see below).
- The harness uses `E2E_BIN_DIR` (set by `make e2e`'s test-e2e target) to locate `./kukeond`; falls back to `..` for direct `go test ./e2e/` invocations.

### `delete -f` exception (verified pre-existing bug)

`kuke delete -f` is hardcoded in-process at `cmd/kuke/delete/delete.go:157` (it calls `shared.ControllerFromCmd`), unlike `kuke apply -f` which uses `kukshared.ClientFromCmd` and routes through the daemon. Routing the new e2e daemon socket at `delete -f` therefore surfaces resources as \"not found\" even though they exist on disk and are visible to every other daemon-routed command.

This is not a regression of this PR — it's pre-existing on `main`, reproducible with a hand-rolled `kukeond serve` + `kuke --host unix://... delete -f` against any apply'd resource. Filed as **#574** (verified-bug + priority:B + cli). The 6 `delete -f` call sites in `e2e/e2e_kuke_delete_f_test.go` (and the `deleteYAMLFileFromTestdata` helper) retain `buildKukeRunPathArgs(runPath)` with inline `// see #574` notes; once #574 is fixed those collapse back to `buildKukeDaemonArgs(host)`.

This matches the AC's carve-out: *\"`buildKukeRunPathArgs(runPath)` survives only for contexts that still need the in-process path.\"*

### Init / lifecycle test cleanup ordering

`TestKuke_Init_VerifyState` and `TestKuke_DaemonReset_RoundTrip` bring up and tear down a full daemon themselves (via `kuke init` / `kuke daemon reset`). Their cleanup helpers were switched to the existing `cleanup{Realm,Space,Stack,Cell}NoDaemon` variants because the daemon is down by the time `t.Cleanup` runs.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `make test` (unit suite) green
- [x] Targeted e2e via per-test daemon harness — 13 conversion-sensitive tests pass against the new harness:
  - `TestKukeApply_{Realm,Space,Stack,MultiResource}_VerifyState`
  - `TestKukeApply_VerifyTestdataYAMLs` (+ all subtests)
  - `TestKukeDeleteF_{Realm,MultiResource,Cascade,Idempotent}`
  - `TestDeleteF_{Realm,Space,Stack}_VerifyAllResourcesDeleted`
  - `TestDeleteF_VerifyTestdataYAMLsComplete`
- [ ] `make e2e` (full suite) — **deferred to CI.** Local `docker build` in this sandbox hits intermittent DNS UDP timeouts to Cloudflare 1.0.0.1 from inside the build network namespace (first attempt failed `curl https://github.com/...` for the CNI plugins tarball; second attempt cached past that and failed `go mod download` against `proxy.golang.org` with the same UDP/53 timeout class). The same DNS-from-container-bridge restriction causes the cell-creating tests' `crictl pull registry.eminwux.com/busybox:latest` to fail in this sandbox — `TestKukeApply_Cell_VerifyState`, `TestDeleteF_Cell_VerifyAllResourcesDeleted`, `TestDeleteF_Container_VerifyAllResourcesDeleted`. Not conversion regressions — the pulls would fail under the prior `--run-path` mode too. CI's docker daemon is unaffected.

## References

- Umbrella: #217
- Phase 1: #222 (retired `--no-daemon` from workload command flags)
- Phase 3 (blocked on this): #566 (delete the in-process branch in `ClientFromCmd`)
- Surfaced bug: #574 (`kuke delete -f` doesn't route via daemon)

Closes #565