### PR TITLE
fix: route kuke delete -f through daemon (symmetric with apply -f)

### DIFF
--- a/cmd/kuke/delete/delete.go
+++ b/cmd/kuke/delete/delete.go
@@ -17,8 +17,8 @@
 package deletecmd
 
 import (
-	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
@@ -29,18 +29,15 @@ import (
 	"github.com/eminwux/kukeon/cmd/kuke/delete/space"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/stack"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
-	"github.com/eminwux/kukeon/internal/apply/parser"
-	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-type deleteController interface {
-	DeleteDocuments(docs []parser.Document, cascade, force bool) (controller.DeleteResult, error)
-}
-
-// MockControllerKey is used to inject mock controllers in tests via context.
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+// Name kept for source-compat with existing test helpers; the value is now a
+// kukeonv1.Client (mirroring apply -f).
 type MockControllerKey struct{}
 
 // NewDeleteCmd builds the `kuke delete` parent command and registers all resource
@@ -115,71 +112,61 @@ func completeDeleteSubcommands(_ *cobra.Command, _ []string, toComplete string) 
 	return matches, cobra.ShellCompDirectiveNoFileComp
 }
 
-// handleFileDeletion handles deletion from a YAML file.
+// handleFileDeletion handles deletion from a YAML file by routing through the
+// daemon-aware kukeonv1.Client — symmetric with `kuke apply -f`. The previous
+// in-process `controller.Exec` shortcut was a #574-class bug: it bypassed
+// `--host`/`KUKEON_HOST` and read /opt/kukeon directly even when a daemon
+// was managing a different run path.
 func handleFileDeletion(cmd *cobra.Command, file string) error {
 	output, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return err
 	}
 
-	// Read input
+	// Read raw YAML; the client (local or RPC) owns parse/validate.
 	reader, cleanup, err := kukshared.ReadFileOrStdin(file)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if cleanupErr := cleanup(); cleanupErr != nil {
-			// Log cleanup error but don't fail the operation
-			_ = cleanupErr
-		}
-	}()
+	defer func() { _ = cleanup() }()
 
-	// Parse and validate documents
-	docs, validationErrors, err := kukshared.ParseAndValidateDocuments(reader)
+	rawYAML, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	cascade := shared.ParseCascadeFlag(cmd)
+	force := shared.ParseForceFlag(cmd)
+
+	result, err := client.DeleteDocuments(cmd.Context(), rawYAML, cascade, force)
 	if err != nil {
 		return err
 	}
 
-	// Report validation errors
-	if len(validationErrors) > 0 {
-		return kukshared.FormatValidationErrors(validationErrors)
-	}
-
-	if len(docs) == 0 {
-		return errors.New("no valid documents found in input")
-	}
-
-	// Get controller
-	var ctrl deleteController
-	if mockCtrl, ok := cmd.Context().Value(MockControllerKey{}).(deleteController); ok {
-		ctrl = mockCtrl
-	} else {
-		realCtrl, ctrlErr := shared.ControllerFromCmd(cmd)
-		if ctrlErr != nil {
-			return ctrlErr
-		}
-		ctrl = realCtrl
-	}
-
-	// Get cascade and force flags
-	cascade := shared.ParseCascadeFlag(cmd)
-	force := shared.ParseForceFlag(cmd)
-
-	// Delete documents
-	result, err := ctrl.DeleteDocuments(docs, cascade, force)
-	if err != nil {
-		return fmt.Errorf("failed to delete documents: %w", err)
-	}
-
-	// Print results
 	if output == "json" || output == "yaml" {
 		return printDeleteResultJSON(cmd, result, output)
 	}
 	return printDeleteResult(cmd, result)
 }
 
+// resolveClient picks the test-injected mock from context if present, else
+// returns a real daemon-aware client via the shared resolver. Mirrors
+// apply.resolveClient so both `-f` paths share the same seam.
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukshared.ClientFromCmd(cmd)
+}
+
 // printDeleteResult prints deletion results in human-readable format.
-func printDeleteResult(cmd *cobra.Command, result controller.DeleteResult) error {
+func printDeleteResult(cmd *cobra.Command, result kukeonv1.DeleteDocumentsResult) error {
 	hasFailures := false
 	for _, resource := range result.Resources {
 		switch resource.Action {
@@ -210,8 +197,8 @@ func printDeleteResult(cmd *cobra.Command, result controller.DeleteResult) error
 		case actionFailed:
 			hasFailures = true
 			cmd.Printf("%s %q: failed\n", resource.Kind, resource.Name)
-			if resource.Error != nil {
-				cmd.Printf("  Error: %v\n", resource.Error)
+			if resource.Error != "" {
+				cmd.Printf("  Error: %s\n", resource.Error)
 			}
 		}
 	}
@@ -224,9 +211,9 @@ func printDeleteResult(cmd *cobra.Command, result controller.DeleteResult) error
 }
 
 // printDeleteResultJSON prints deletion results in JSON or YAML format.
-func printDeleteResultJSON(cmd *cobra.Command, result controller.DeleteResult, format string) error {
+func printDeleteResultJSON(cmd *cobra.Command, result kukeonv1.DeleteDocumentsResult, format string) error {
 	output := struct {
-		Resources []controller.ResourceDeleteResult `json:"resources"`
+		Resources []kukeonv1.DeleteResourceResult `json:"resources" yaml:"resources"`
 	}{
 		Resources: result.Resources,
 	}

--- a/cmd/kuke/delete/delete_test.go
+++ b/cmd/kuke/delete/delete_test.go
@@ -19,6 +19,7 @@ package deletecmd_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -28,8 +29,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/config"
 	deletecmd "github.com/eminwux/kukeon/cmd/kuke/delete"
 	"github.com/eminwux/kukeon/cmd/types"
-	"github.com/eminwux/kukeon/internal/apply/parser"
-	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -255,18 +255,27 @@ func findSubCommand(cmd *cobra.Command, name string) *cobra.Command {
 	return nil
 }
 
-type fakeDeleteController struct {
-	deleteDocumentsFn func(docs []parser.Document, cascade, force bool) (controller.DeleteResult, error)
+// fakeClient is the daemon-aware test seam for `kuke delete -f`. Embedding
+// kukeonv1.FakeClient defaults every unimplemented method to ErrUnexpectedCall,
+// which is the regression guard against this code path silently invoking
+// anything other than DeleteDocuments. The bug fixed in #574 is exactly this
+// invariant: `delete -f` must route through the Client (so `--host`/daemon
+// routing applies), not bypass it to construct an in-process controller.
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	deleteFn func(raw []byte, cascade, force bool) (kukeonv1.DeleteDocumentsResult, error)
 }
 
-func (f *fakeDeleteController) DeleteDocuments(
-	docs []parser.Document,
+func (f *fakeClient) DeleteDocuments(
+	_ context.Context,
+	raw []byte,
 	cascade, force bool,
-) (controller.DeleteResult, error) {
-	if f.deleteDocumentsFn == nil {
-		return controller.DeleteResult{}, nil
+) (kukeonv1.DeleteDocumentsResult, error) {
+	if f.deleteFn == nil {
+		return kukeonv1.DeleteDocumentsResult{}, errors.New("unexpected DeleteDocuments call")
 	}
-	return f.deleteDocumentsFn(docs, cascade, force)
+	return f.deleteFn(raw, cascade, force)
 }
 
 func TestNewDeleteCmd_FileFlag(t *testing.T) {
@@ -319,8 +328,8 @@ func TestNewDeleteCmd_RunE_InvalidYAML(t *testing.T) {
 	}
 	defer os.Remove(tmpFile.Name())
 
-	_, err = tmpFile.WriteString("invalid: yaml: [")
-	if err != nil {
+	const invalid = "invalid: yaml: ["
+	if _, err = tmpFile.WriteString(invalid); err != nil {
 		t.Fatalf("failed to write to temp file: %v", err)
 	}
 	tmpFile.Close()
@@ -331,6 +340,15 @@ func TestNewDeleteCmd_RunE_InvalidYAML(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	// Surface the invalid YAML through the client by having the fake echo
+	// the same shape the daemon would: validation rejection bubbled as an
+	// error from DeleteDocuments.
+	fakeCtrl := &fakeClient{
+		deleteFn: func(_ []byte, _, _ bool) (kukeonv1.DeleteDocumentsResult, error) {
+			return kukeonv1.DeleteDocumentsResult{}, errors.New("failed to parse YAML: invalid")
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
 	cmd.SetContext(ctx)
 
 	cmd.SetArgs([]string{"-f", tmpFile.Name()})
@@ -339,9 +357,8 @@ func TestNewDeleteCmd_RunE_InvalidYAML(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid YAML, got nil")
 	}
-	// Invalid YAML can result in either parsing error or validation error
-	if !strings.Contains(err.Error(), "failed to parse YAML") && !strings.Contains(err.Error(), "validation errors") {
-		t.Errorf("expected error about YAML parsing or validation, got: %v", err)
+	if !strings.Contains(err.Error(), "failed to parse YAML") {
+		t.Errorf("expected error about YAML parsing, got: %v", err)
 	}
 }
 
@@ -360,8 +377,7 @@ metadata:
 spec:
   namespace: test-ns
 `
-	_, err = tmpFile.WriteString(yaml)
-	if err != nil {
+	if _, err = tmpFile.WriteString(yaml); err != nil {
 		t.Fatalf("failed to write to temp file: %v", err)
 	}
 	tmpFile.Close()
@@ -374,10 +390,10 @@ spec:
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 
-	fakeCtrl := &fakeDeleteController{
-		deleteDocumentsFn: func(docs []parser.Document, cascade, force bool) (controller.DeleteResult, error) {
-			if len(docs) != 1 {
-				t.Errorf("expected 1 document, got %d", len(docs))
+	fakeCtrl := &fakeClient{
+		deleteFn: func(raw []byte, cascade, force bool) (kukeonv1.DeleteDocumentsResult, error) {
+			if !bytes.Contains(raw, []byte("test-realm")) {
+				t.Errorf("expected raw YAML to contain test-realm, got %q", string(raw))
 			}
 			if cascade {
 				t.Error("expected cascade to be false")
@@ -385,35 +401,28 @@ spec:
 			if force {
 				t.Error("expected force to be false")
 			}
-			return controller.DeleteResult{
-				Resources: []controller.ResourceDeleteResult{
-					{
-						Index:  0,
-						Kind:   "Realm",
-						Name:   "test-realm",
-						Action: "deleted",
-					},
+			return kukeonv1.DeleteDocumentsResult{
+				Resources: []kukeonv1.DeleteResourceResult{
+					{Index: 0, Kind: "Realm", Name: "test-realm", Action: "deleted"},
 				},
 			}, nil
 		},
 	}
-	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
 	cmd.SetContext(ctx)
 
 	cmd.SetArgs([]string{"-f", tmpFile.Name()})
-	err = cmd.Execute()
-	if err != nil {
+	if err = cmd.Execute(); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
 	output := outBuf.String()
-	if !strings.Contains(output, "Realm \"test-realm\": deleted") {
+	if !strings.Contains(output, `Realm "test-realm": deleted`) {
 		t.Errorf("expected output to contain 'Realm \"test-realm\": deleted', got: %q", output)
 	}
 }
 
 func TestNewDeleteCmd_RunE_NotFound(t *testing.T) {
-	// Create temporary file with valid YAML
 	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
@@ -427,8 +436,7 @@ metadata:
 spec:
   namespace: test-ns
 `
-	_, err = tmpFile.WriteString(yaml)
-	if err != nil {
+	if _, err = tmpFile.WriteString(yaml); err != nil {
 		t.Fatalf("failed to write to temp file: %v", err)
 	}
 	tmpFile.Close()
@@ -441,37 +449,30 @@ spec:
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 
-	fakeCtrl := &fakeDeleteController{
-		deleteDocumentsFn: func(_ []parser.Document, _ bool, _ bool) (controller.DeleteResult, error) {
-			return controller.DeleteResult{
-				Resources: []controller.ResourceDeleteResult{
-					{
-						Index:  0,
-						Kind:   "Realm",
-						Name:   "test-realm",
-						Action: "not found",
-					},
+	fakeCtrl := &fakeClient{
+		deleteFn: func(_ []byte, _, _ bool) (kukeonv1.DeleteDocumentsResult, error) {
+			return kukeonv1.DeleteDocumentsResult{
+				Resources: []kukeonv1.DeleteResourceResult{
+					{Index: 0, Kind: "Realm", Name: "test-realm", Action: "not found"},
 				},
 			}, nil
 		},
 	}
-	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
 	cmd.SetContext(ctx)
 
 	cmd.SetArgs([]string{"-f", tmpFile.Name()})
-	err = cmd.Execute()
-	if err != nil {
+	if err = cmd.Execute(); err != nil {
 		t.Fatalf("expected no error for not found (idempotent), got: %v", err)
 	}
 
 	output := outBuf.String()
-	if !strings.Contains(output, "Realm \"test-realm\": not found") {
+	if !strings.Contains(output, `Realm "test-realm": not found`) {
 		t.Errorf("expected output to contain 'Realm \"test-realm\": not found', got: %q", output)
 	}
 }
 
 func TestNewDeleteCmd_RunE_CascadeFlag(t *testing.T) {
-	// Create temporary file with valid YAML
 	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
@@ -485,8 +486,7 @@ metadata:
 spec:
   namespace: test-ns
 `
-	_, err = tmpFile.WriteString(yaml)
-	if err != nil {
+	if _, err = tmpFile.WriteString(yaml); err != nil {
 		t.Fatalf("failed to write to temp file: %v", err)
 	}
 	tmpFile.Close()
@@ -499,13 +499,13 @@ spec:
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 
-	fakeCtrl := &fakeDeleteController{
-		deleteDocumentsFn: func(_ []parser.Document, cascade, _ bool) (controller.DeleteResult, error) {
+	fakeCtrl := &fakeClient{
+		deleteFn: func(_ []byte, cascade, _ bool) (kukeonv1.DeleteDocumentsResult, error) {
 			if !cascade {
 				t.Error("expected cascade to be true")
 			}
-			return controller.DeleteResult{
-				Resources: []controller.ResourceDeleteResult{
+			return kukeonv1.DeleteDocumentsResult{
+				Resources: []kukeonv1.DeleteResourceResult{
 					{
 						Index:    0,
 						Kind:     "Realm",
@@ -517,17 +517,16 @@ spec:
 			}, nil
 		},
 	}
-	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
 	cmd.SetContext(ctx)
 
 	cmd.SetArgs([]string{"-f", tmpFile.Name(), "--cascade"})
-	err = cmd.Execute()
-	if err != nil {
+	if err = cmd.Execute(); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
 	output := outBuf.String()
-	if !strings.Contains(output, "Realm \"test-realm\": deleted") {
+	if !strings.Contains(output, `Realm "test-realm": deleted`) {
 		t.Errorf("expected output to contain 'Realm \"test-realm\": deleted', got: %q", output)
 	}
 	if !strings.Contains(output, "1 space(s) deleted (cascade)") {
@@ -535,8 +534,7 @@ spec:
 	}
 }
 
-func TestNewDeleteCmd_RunE_JSONOutput(t *testing.T) {
-	// Create temporary file with valid YAML
+func TestNewDeleteCmd_RunE_ForceFlag(t *testing.T) {
 	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
@@ -550,8 +548,150 @@ metadata:
 spec:
   namespace: test-ns
 `
-	_, err = tmpFile.WriteString(yaml)
+	if _, err = tmpFile.WriteString(yaml); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeClient{
+		deleteFn: func(_ []byte, _, force bool) (kukeonv1.DeleteDocumentsResult, error) {
+			if !force {
+				t.Error("expected force to be true")
+			}
+			return kukeonv1.DeleteDocumentsResult{
+				Resources: []kukeonv1.DeleteResourceResult{
+					{Index: 0, Kind: "Realm", Name: "test-realm", Action: "deleted"},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name(), "--force"})
+	if err = cmd.Execute(); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestNewDeleteCmd_RunE_FailedExit(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
 	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	if _, err = tmpFile.WriteString(yaml); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	var outBuf bytes.Buffer
+	cmd.SetOut(&outBuf)
+	cmd.SetErr(&bytes.Buffer{})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeClient{
+		deleteFn: func(_ []byte, _, _ bool) (kukeonv1.DeleteDocumentsResult, error) {
+			return kukeonv1.DeleteDocumentsResult{
+				Resources: []kukeonv1.DeleteResourceResult{
+					{Index: 0, Kind: "Realm", Name: "test-realm", Action: "failed", Error: "boom"},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name()})
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected non-nil error when daemon reports failed action")
+	}
+	if !strings.Contains(err.Error(), "some resources failed to delete") {
+		t.Errorf("expected aggregated failure error, got: %v", err)
+	}
+	if !strings.Contains(outBuf.String(), "Error: boom") {
+		t.Errorf("expected per-resource error in output, got: %q", outBuf.String())
+	}
+}
+
+func TestNewDeleteCmd_RunE_ClientError(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	if _, err = tmpFile.WriteString(yaml); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tmpFile.Close()
+
+	cmd := deletecmd.NewDeleteCmd()
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fakeCtrl := &fakeClient{
+		deleteFn: func(_ []byte, _, _ bool) (kukeonv1.DeleteDocumentsResult, error) {
+			return kukeonv1.DeleteDocumentsResult{}, errors.New("dial unix: server unavailable")
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", tmpFile.Name()})
+	err = cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error to bubble from client, got nil")
+	}
+	if !strings.Contains(err.Error(), "server unavailable") {
+		t.Errorf("expected wrapped client error, got: %v", err)
+	}
+}
+
+func TestNewDeleteCmd_RunE_JSONOutput(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	yaml := `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: test-realm
+spec:
+  namespace: test-ns
+`
+	if _, err = tmpFile.WriteString(yaml); err != nil {
 		t.Fatalf("failed to write to temp file: %v", err)
 	}
 	tmpFile.Close()
@@ -564,37 +704,33 @@ spec:
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 
-	fakeCtrl := &fakeDeleteController{
-		deleteDocumentsFn: func(_ []parser.Document, _ bool, _ bool) (controller.DeleteResult, error) {
-			return controller.DeleteResult{
-				Resources: []controller.ResourceDeleteResult{
-					{
-						Index:  0,
-						Kind:   "Realm",
-						Name:   "test-realm",
-						Action: "deleted",
-					},
+	fakeCtrl := &fakeClient{
+		deleteFn: func(_ []byte, _, _ bool) (kukeonv1.DeleteDocumentsResult, error) {
+			return kukeonv1.DeleteDocumentsResult{
+				Resources: []kukeonv1.DeleteResourceResult{
+					{Index: 0, Kind: "Realm", Name: "test-realm", Action: "deleted"},
 				},
 			}, nil
 		},
 	}
-	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
 	cmd.SetContext(ctx)
 
 	cmd.SetArgs([]string{"-f", tmpFile.Name(), "--output", "json"})
-	err = cmd.Execute()
-	if err != nil {
+	if err = cmd.Execute(); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 
 	output := outBuf.String()
-	if !strings.Contains(output, "kind") || !strings.Contains(output, "Realm") {
+	// JSON keys must remain lowercase (preserved via DeleteResourceResult tags
+	// — net/rpc gob wire is unaffected).
+	if !strings.Contains(output, `"kind"`) || !strings.Contains(output, "Realm") {
 		t.Errorf("expected JSON output with kind and Realm, got: %q", output)
 	}
-	if !strings.Contains(output, "name") || !strings.Contains(output, "test-realm") {
+	if !strings.Contains(output, `"name"`) || !strings.Contains(output, "test-realm") {
 		t.Errorf("expected JSON output with name and test-realm, got: %q", output)
 	}
-	if !strings.Contains(output, "action") || !strings.Contains(output, "deleted") {
+	if !strings.Contains(output, `"action"`) || !strings.Contains(output, "deleted") {
 		t.Errorf("expected JSON output with action and deleted, got: %q", output)
 	}
 }
@@ -616,21 +752,19 @@ spec:
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 
-	fakeCtrl := &fakeDeleteController{
-		deleteDocumentsFn: func(_ []parser.Document, _ bool, _ bool) (controller.DeleteResult, error) {
-			return controller.DeleteResult{
-				Resources: []controller.ResourceDeleteResult{
-					{
-						Index:  0,
-						Kind:   "Realm",
-						Name:   "test-realm",
-						Action: "deleted",
-					},
+	fakeCtrl := &fakeClient{
+		deleteFn: func(raw []byte, _, _ bool) (kukeonv1.DeleteDocumentsResult, error) {
+			if !bytes.Contains(raw, []byte("test-realm")) {
+				t.Errorf("expected raw YAML to contain test-realm, got %q", string(raw))
+			}
+			return kukeonv1.DeleteDocumentsResult{
+				Resources: []kukeonv1.DeleteResourceResult{
+					{Index: 0, Kind: "Realm", Name: "test-realm", Action: "deleted"},
 				},
 			}, nil
 		},
 	}
-	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, fakeCtrl)
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
 	cmd.SetContext(ctx)
 
 	// Create a pipe to simulate stdin
@@ -653,14 +787,12 @@ spec:
 	}()
 
 	cmd.SetArgs([]string{"-f", "-"})
-	err = cmd.Execute()
-	if err != nil {
+	if err = cmd.Execute(); err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 }
 
 func TestNewDeleteCmd_RunE_ValidationError(t *testing.T) {
-	// Create temporary file with invalid document (missing required field)
 	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.yaml")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
@@ -674,8 +806,7 @@ metadata:
 spec:
   namespace: test-ns
 `
-	_, err = tmpFile.WriteString(yaml)
-	if err != nil {
+	if _, err = tmpFile.WriteString(yaml); err != nil {
 		t.Fatalf("failed to write to temp file: %v", err)
 	}
 	tmpFile.Close()
@@ -686,6 +817,14 @@ spec:
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	// Validation now happens client-side (local) or server-side (daemon);
+	// either path returns the validation error through DeleteDocuments.
+	fakeCtrl := &fakeClient{
+		deleteFn: func(_ []byte, _, _ bool) (kukeonv1.DeleteDocumentsResult, error) {
+			return kukeonv1.DeleteDocumentsResult{}, errors.New("validation failed:\n  metadata.name is required")
+		},
+	}
+	ctx = context.WithValue(ctx, deletecmd.MockControllerKey{}, kukeonv1.Client(fakeCtrl))
 	cmd.SetContext(ctx)
 
 	cmd.SetArgs([]string{"-f", tmpFile.Name()})
@@ -694,7 +833,7 @@ spec:
 	if err == nil {
 		t.Fatal("expected error for validation failure, got nil")
 	}
-	if !strings.Contains(err.Error(), "validation errors") {
+	if !strings.Contains(err.Error(), "validation") {
 		t.Errorf("expected error about validation, got: %v", err)
 	}
 }

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -833,6 +833,47 @@ func (c *Client) ApplyDocuments(_ context.Context, rawYAML []byte) (kukeonv1.App
 	return out, nil
 }
 
+func (c *Client) DeleteDocuments(
+	_ context.Context,
+	rawYAML []byte,
+	cascade, force bool,
+) (kukeonv1.DeleteDocumentsResult, error) {
+	docs, validationErrors, err := parseAndValidate(rawYAML)
+	if err != nil {
+		return kukeonv1.DeleteDocumentsResult{}, err
+	}
+	if len(validationErrors) > 0 {
+		return kukeonv1.DeleteDocumentsResult{}, formatValidationErrors(validationErrors)
+	}
+	if len(docs) == 0 {
+		return kukeonv1.DeleteDocumentsResult{}, errors.New("no valid documents found in input")
+	}
+
+	res, err := c.ctrl.DeleteDocuments(docs, cascade, force)
+	if err != nil {
+		return kukeonv1.DeleteDocumentsResult{}, err
+	}
+
+	out := kukeonv1.DeleteDocumentsResult{
+		Resources: make([]kukeonv1.DeleteResourceResult, 0, len(res.Resources)),
+	}
+	for _, r := range res.Resources {
+		item := kukeonv1.DeleteResourceResult{
+			Index:    r.Index,
+			Kind:     r.Kind,
+			Name:     r.Name,
+			Action:   r.Action,
+			Cascaded: r.Cascaded,
+			Details:  r.Details,
+		}
+		if r.Error != nil {
+			item.Error = r.Error.Error()
+		}
+		out.Resources = append(out.Resources, item)
+	}
+	return out, nil
+}
+
 // parseAndValidate mirrors cmd/kuke/shared.ParseAndValidateDocuments, but
 // takes a byte slice so it works both server-side (from the wire) and in
 // the --no-daemon CLI path.

--- a/internal/daemon/delete_documents_rpc_test.go
+++ b/internal/daemon/delete_documents_rpc_test.go
@@ -1,0 +1,127 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package daemon_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/daemon"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+)
+
+// deleteDocsClientFake stubs DeleteDocuments on the in-process Client the
+// daemon binds to. Every other Client method stays at the FakeClient default
+// (ErrUnexpectedCall) so the test would fail loudly if the RPC handler
+// accidentally invoked a different method.
+type deleteDocsClientFake struct {
+	kukeonv1.FakeClient
+
+	gotRaw     []byte
+	gotCascade bool
+	gotForce   bool
+
+	result kukeonv1.DeleteDocumentsResult
+	err    error
+}
+
+func (d *deleteDocsClientFake) DeleteDocuments(
+	_ context.Context,
+	raw []byte,
+	cascade, force bool,
+) (kukeonv1.DeleteDocumentsResult, error) {
+	d.gotRaw = raw
+	d.gotCascade = cascade
+	d.gotForce = force
+	return d.result, d.err
+}
+
+// TestDeleteDocuments_RPCRoundTrip pins the daemon RPC layer's pass-through of
+// the cascade/force flags and the wire-level Result for `kuke delete -f` —
+// the symmetry restored by #574 (previously the CLI bypassed the daemon
+// entirely so this RPC path was effectively dead).
+func TestDeleteDocuments_RPCRoundTrip(t *testing.T) {
+	const wantRaw = "apiVersion: v1beta1\nkind: Realm\n"
+
+	core := &deleteDocsClientFake{
+		result: kukeonv1.DeleteDocumentsResult{
+			Resources: []kukeonv1.DeleteResourceResult{
+				{Index: 0, Kind: "Realm", Name: "r1", Action: "deleted", Cascaded: []string{"default"}},
+			},
+		},
+	}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core)
+
+	args := &kukeonv1.DeleteDocumentsArgs{
+		RawYAML: []byte(wantRaw),
+		Cascade: true,
+		Force:   true,
+	}
+	reply := &kukeonv1.DeleteDocumentsReply{}
+	if err := svc.DeleteDocuments(args, reply); err != nil {
+		t.Fatalf("DeleteDocuments returned transport error: %v", err)
+	}
+	if reply.Err != nil {
+		t.Fatalf("expected wire-level Err to be nil, got %v", kukeonv1.FromAPIError(reply.Err))
+	}
+
+	if !bytes.Equal(core.gotRaw, []byte(wantRaw)) {
+		t.Errorf("RawYAML passthrough mismatch: got %q want %q", string(core.gotRaw), wantRaw)
+	}
+	if !core.gotCascade {
+		t.Errorf("Cascade not forwarded to core client")
+	}
+	if !core.gotForce {
+		t.Errorf("Force not forwarded to core client")
+	}
+
+	if got := len(reply.Result.Resources); got != 1 {
+		t.Fatalf("expected 1 wire resource, got %d", got)
+	}
+	r := reply.Result.Resources[0]
+	if r.Kind != "Realm" || r.Name != "r1" || r.Action != "deleted" {
+		t.Errorf("wire resource mismatch: %+v", r)
+	}
+	if len(r.Cascaded) != 1 || r.Cascaded[0] != "default" {
+		t.Errorf("Cascaded list lost on the wire: %+v", r.Cascaded)
+	}
+}
+
+// TestDeleteDocuments_RPCSurfacesSentinel pins the structured-error
+// pass-through: an errdefs sentinel returned by the in-process Client must
+// survive the wire as a typed APIError so `kuke delete -f` can render
+// idempotent "not found" semantics even when routed through the daemon.
+func TestDeleteDocuments_RPCSurfacesSentinel(t *testing.T) {
+	core := &deleteDocsClientFake{err: errdefs.ErrRealmNotFound}
+	svc := daemon.NewKukeonV1Service(context.Background(), discardLogger(), core)
+
+	args := &kukeonv1.DeleteDocumentsArgs{RawYAML: []byte("apiVersion: v1beta1\n")}
+	reply := &kukeonv1.DeleteDocumentsReply{}
+	if err := svc.DeleteDocuments(args, reply); err != nil {
+		t.Fatalf("DeleteDocuments returned transport error: %v", err)
+	}
+	if reply.Err == nil {
+		t.Fatalf("expected wire-level Err to be populated, got nil")
+	}
+	wireErr := kukeonv1.FromAPIError(reply.Err)
+	if !errors.Is(wireErr, errdefs.ErrRealmNotFound) {
+		t.Errorf("wire error %q does not unwrap to ErrRealmNotFound", wireErr)
+	}
+}

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -367,6 +367,18 @@ func (s *KukeonV1Service) ApplyDocuments(args *kukeonv1.ApplyDocumentsArgs, repl
 	return nil
 }
 
+// ---- Delete (file-driven) ----
+
+func (s *KukeonV1Service) DeleteDocuments(
+	args *kukeonv1.DeleteDocumentsArgs,
+	reply *kukeonv1.DeleteDocumentsReply,
+) error {
+	result, err := s.core.DeleteDocuments(s.ctx, args.RawYAML, args.Cascade, args.Force)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
 // Image methods (LoadImage / ListImages / GetImage / DeleteImage) are
 // intentionally not served over RPC — `kuke image *` is daemon-independent
 // by design (#226). The CLI constructs a local in-process client directly.

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -84,6 +84,11 @@ type Client interface {
 
 	RefreshAll(ctx context.Context) (RefreshAllResult, error)
 	ApplyDocuments(ctx context.Context, rawYAML []byte) (ApplyDocumentsResult, error)
+	// DeleteDocuments is the file-driven counterpart to ApplyDocuments —
+	// `kuke delete -f` sends the raw YAML over the wire so deletes honor
+	// `--host` routing the same way applies do. Per-resource cascade/force
+	// semantics match the single-kind Delete{Realm,Space,Stack} methods.
+	DeleteDocuments(ctx context.Context, rawYAML []byte, cascade, force bool) (DeleteDocumentsResult, error)
 
 	// NOTE: image operations (LoadImage / ListImages / GetImage /
 	// DeleteImage) are intentionally NOT on this interface. They are
@@ -181,8 +186,9 @@ const (
 	MethodPurgeCell      = ServiceName + ".PurgeCell"
 	MethodPurgeContainer = ServiceName + ".PurgeContainer"
 
-	MethodRefreshAll     = ServiceName + ".RefreshAll"
-	MethodApplyDocuments = ServiceName + ".ApplyDocuments"
+	MethodRefreshAll      = ServiceName + ".RefreshAll"
+	MethodApplyDocuments  = ServiceName + ".ApplyDocuments"
+	MethodDeleteDocuments = ServiceName + ".DeleteDocuments"
 
 	MethodPing = ServiceName + ".Ping"
 )

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -177,6 +177,10 @@ func (FakeClient) ApplyDocuments(context.Context, []byte) (ApplyDocumentsResult,
 	return ApplyDocumentsResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) DeleteDocuments(context.Context, []byte, bool, bool) (DeleteDocumentsResult, error) {
+	return DeleteDocumentsResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) Ping(context.Context) error {
 	return ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -621,6 +621,23 @@ func (c *UnixClient) ApplyDocuments(ctx context.Context, rawYAML []byte) (ApplyD
 	return reply.Result, nil
 }
 
+// DeleteDocuments implements Client.
+func (c *UnixClient) DeleteDocuments(
+	ctx context.Context,
+	rawYAML []byte,
+	cascade, force bool,
+) (DeleteDocumentsResult, error) {
+	args := &DeleteDocumentsArgs{RawYAML: rawYAML, Cascade: cascade, Force: force}
+	reply := &DeleteDocumentsReply{}
+	if err := c.call(ctx, MethodDeleteDocuments, args, reply); err != nil {
+		return DeleteDocumentsResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // Ping implements Client.
 func (c *UnixClient) Ping(ctx context.Context) error {
 	args := &PingArgs{}

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -654,6 +654,40 @@ type ApplyResourceResult struct {
 	Details map[string]string
 }
 
+// ---- Delete ----
+
+// DeleteDocumentsArgs carries a raw multi-document YAML blob plus the same
+// cascade/force flags exposed on `kuke delete -f`. The server parses and
+// validates; validation errors are returned in the Reply.Err.
+type DeleteDocumentsArgs struct {
+	RawYAML []byte
+	Cascade bool
+	Force   bool
+}
+
+type DeleteDocumentsReply struct {
+	Result DeleteDocumentsResult
+	Err    *APIError
+}
+
+type DeleteDocumentsResult struct {
+	Resources []DeleteResourceResult
+}
+
+// DeleteResourceResult is the per-resource outcome of a DeleteDocuments call.
+// JSON/YAML tags preserve the lowercase `kuke delete -f -o json` shape that
+// previously came from internal/controller.ResourceDeleteResult's custom
+// marshalers (the wire is gob and ignores these tags).
+type DeleteResourceResult struct {
+	Index    int               `json:"index"              yaml:"index"`
+	Kind     string            `json:"kind"               yaml:"kind"`
+	Name     string            `json:"name"               yaml:"name"`
+	Action   string            `json:"action"             yaml:"action"`
+	Error    string            `json:"error,omitempty"    yaml:"error,omitempty"`
+	Cascaded []string          `json:"cascaded,omitempty" yaml:"cascaded,omitempty"`
+	Details  map[string]string `json:"details,omitempty"  yaml:"details,omitempty"`
+}
+
 // ---- Image ----
 //
 // Image result types live here (and not on the RPC interface) so the in-


### PR DESCRIPTION
## Summary

- Adds `KukeonV1.DeleteDocuments(rawYAML, cascade, force)` to the kukeonv1 wire surface — mirrors `ApplyDocuments` exactly: raw YAML over gob, daemon parses + validates, controller does the work, wire result carries per-resource action/cascaded/details/error. Implementations land on `UnixClient`, `*local.Client`, `KukeonV1Service`, and `FakeClient`.
- Rewrites `handleFileDeletion` in `cmd/kuke/delete/delete.go` to resolve a `kukeonv1.Client` via `kukshared.ClientFromCmd` (the daemon-aware resolver) instead of constructing an in-process `controller.Exec` directly. The previous code (`shared.ControllerFromCmd` at `delete.go:157`) was the bug — it bypassed `--host`/`KUKEON_HOST` and read `/opt/kukeon` no matter where the daemon was actually managing state.
- `MockControllerKey` is preserved by name (source-compat with existing tests); its value type widens from `deleteController` to `kukeonv1.Client`, matching `apply.MockControllerKey`.
- `DeleteResourceResult` (new wire type) carries the lowercase JSON/YAML tags previously provided by `controller.ResourceDeleteResult`'s custom marshalers — `kuke delete -f -o json` output shape is preserved. (The wire is gob; tags only affect JSON/YAML rendering.)

### Repro (issue #574), pre-fix vs post-fix

```bash
runPath=/tmp/rp; mkdir -p "$runPath"
./kukeond serve --socket "$runPath/kukeond.sock" --run-path "$runPath" \
    --reconcile-interval 0 --configuration "$runPath/kukeond.yaml" &
cat > /tmp/realm.yaml <<YAML
apiVersion: v1beta1
kind: Realm
metadata: { name: trial-realm }
spec: { namespace: trial-ns }
YAML
./kuke --host unix://"$runPath/kukeond.sock" apply -f /tmp/realm.yaml
./kuke --host unix://"$runPath/kukeond.sock" delete -f /tmp/realm.yaml
```

Pre-fix: `apply` → `created` (daemon-routed), `delete` → `not found` (in-process, read the wrong tree).
Post-fix (this PR, verified against this PR's binary): `apply` → `created`, `delete` → `deleted`, second `delete` → `not found` (idempotent).

### Scope vs AC bullet 4

AC bullet 4 — collapsing the `buildKukeRunPathArgs(runPath)` workarounds in `e2e/e2e_kuke_delete_f_test.go` back to `buildKukeDaemonArgs(host)` — depends on the per-test daemon harness from PR #575, which is not yet merged on `main`. The fix in this PR unblocks that collapse; the actual edit will land in (or after) #575 alongside the rest of the harness conversion. The bug fix itself does not require it.

### Why local.Client.DeleteDocuments still parses YAML

`--no-daemon` and the `--run-path` promotion path (`applyRunPathImpliesNoDaemon`) both resolve `ClientFromCmd` to `*local.Client`. The new `local.Client.DeleteDocuments` therefore owns parse + validate + controller invocation for the in-process path — same pattern as `local.Client.ApplyDocuments` introduced when `apply -f` was migrated. This keeps the existing e2e suite green: e2e tests still pass `--run-path` (which triggers `noDaemon=true` via promotion) and route through the local client.

## Test plan

- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `make test` green — full unit suite, including the new `internal/daemon/delete_documents_rpc_test.go` RPC pass-through tests (cascade/force forwarding, structured-error survival) and the rewired `cmd/kuke/delete/delete_test.go` fakeClient seam (success, not-found idempotency, cascade, force, json output, stdin, validation error, client error, failed-exit aggregation).
- [x] Live reproduction of issue #574's bug — `kukeond serve` + `kuke --host unix://... apply -f` + `kuke --host unix://... delete -f` on `trial-realm`: post-fix produces `created` → `deleted` → `not found` as expected. Pre-fix would have surfaced `not found` on the first delete.
- [ ] `make e2e` (full suite) — **deferred to CI.** Local `docker build` in this sandbox hits intermittent DNS UDP timeouts to Cloudflare 1.0.0.1 from inside the build network namespace (same constraint documented on PR #575). CI's docker daemon is unaffected.

## References

- Bug site: `cmd/kuke/delete/delete.go:157` (pre-fix) — `shared.ControllerFromCmd` bypassed the daemon.
- Counterpart: `cmd/kuke/apply/apply.go:95` — `kukshared.ClientFromCmd`, the pattern we now mirror.
- Surfaced by: #565 (phase-2 e2e harness, PR #575).
- Out of scope per issue: #566 (delete the in-process branch in `ClientFromCmd` for the `--no-daemon` fallback).

Closes #574