### PR TITLE
build(deps): bump github.com/eminwux/sbsh from v0.11.2 to v0.11.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.11.2
+	github.com/eminwux/sbsh v0.11.3
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.11.2 h1:/JnQl7IeCbugePX+tHQ/kC1iTb7hCtezzZsC5ZQheQY=
-github.com/eminwux/sbsh v0.11.2/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
+github.com/eminwux/sbsh v0.11.3 h1:Y05/45HCacxA4RM0cizAw1NdQQTIkWzID/ITOfP72n0=
+github.com/eminwux/sbsh v0.11.3/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Summary

- Bumps `github.com/eminwux/sbsh` from `v0.11.2` to `v0.11.3` in `go.mod` and refreshes `go.sum` via `go mod tidy`. Two-line diff in `go.mod` + four-line hash swap in `go.sum`; no other modules churn.
- Upstream v0.11.3 ([compare](https://github.com/eminwux/sbsh/compare/v0.11.2...v0.11.3)) ships four fixes — three of them in the terminal-RPC and runner layers `kuke attach` / `kuketty` actively use (`internal/controller/runner/attachable.go`, `cmd/kuke/attach/attach.go`, `cmd/kuketty/main.go`):
  - `fix(terminalrpc): close sender-side fds after SCM_RIGHTS send` (sbsh#213)
  - `fix(terminalrunner): close client pipe fds on cleanup and detach` (sbsh#216)
  - `fix(terminalrunner): bound interactive attacher writer to unblock fan-out` (sbsh#217)
  - `test(e2e): use t.TempDir for run-path scratch` (sbsh#218)
- No public API changes between v0.11.2 and v0.11.3 — all four commits are internal fixes / test hygiene, so no call-site churn in kukeon.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make test` (unit suite) green — full package set passes against bumped sbsh
- [x] `make dev-init` smoke passes — daemon parity check matches the AC tail (`default` + `kuke-system` both `Ready`), `kuke attach` smoke against a kuketty-wrapped cell exits cleanly, nested parent-host attach socket stays intact through purge cycle
- [x] `e2e/e2e_kuke_attach_test.go` — `TestKuke_AttachDetach_KeepsTaskRunning` passes against the bumped dep (13.4s)
- [ ] `make e2e` (full suite) — overridden for this PR per maintainer direction; the targeted attach e2e (the only test path that actually exercises the sbsh terminal-RPC + runner surface this bump touches) was run and green above. CI will run the full suite on push.

Closes #578