### PR TITLE
ci: gate test/e2e workflow on Go-relevant path changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,9 +3,29 @@ on:
   pull_request:
     branches:
       - main
+    # Skip on changes that can't affect Go build/test/e2e outcomes (docs-only
+    # PRs, mkdocs site edits, release tooling, etc.). `make e2e` shells out to
+    # `docker build` against the repo root Dockerfile and runs Go binaries
+    # produced from the Makefile, so both stay in the trigger set alongside
+    # `**/*.go` and the module files. The workflow self-reference ensures CI
+    # edits to this file still run their own job.
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - "Dockerfile"
+      - ".github/workflows/test.yaml"
   push:
     branches:
       - main
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - "Dockerfile"
+      - ".github/workflows/test.yaml"
 
 # Both jobs only check out the repo and run tests — no PR comments, no
 # release artifacts, no remote pushes. The minimal read-only default


### PR DESCRIPTION
## Summary
- Adds a `paths` filter to the `Test` workflow so the `make test` and `make e2e` jobs no longer run on PRs/pushes that can't affect Go build outcomes (docs-only, mkdocs site edits, release tooling, installer-only edits, etc.).
- Trigger set mirrors what `make test` and `make e2e` actually read: `**/*.go`, `go.mod`, `go.sum`, `Makefile` (test/e2e targets), `Dockerfile` (e2e builds the local kukeond image from it), and `.github/workflows/test.yaml` itself so changes to the workflow keep running their own job.
- Filed directly with `ready-to-merge` per user override.

## Test plan
- [x] `make test` — green locally on this branch.
- [ ] `make e2e` — not run; pure CI-config edit with no Go/runtime impact.
- [x] `python3 -c "yaml.safe_load(...)"` validates the workflow YAML parses.

Note for reviewer: the trigger set intentionally excludes `scripts/`, `docs/`, `mkdocs.yml`, and the other workflow files; the `Installer` workflow already has its own `paths:` gate for `scripts/install.sh`, so installer coverage is unchanged.