### PR TITLE
docs: enable mkdocs-material blog plugin and surface Blog in nav

### DIFF
--- a/docs/site/blog/index.md
+++ b/docs/site/blog/index.md
@@ -1,0 +1,3 @@
+# Blog
+
+Posts on kukeon's design, workflows, and how it compares to other tooling for single-host container environments.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,8 @@ nav:
   - Tutorials:
       - tutorials/hello-world.md
       - tutorials/first-stack.md
+  - Blog:
+      - blog/index.md
   - FAQ: faq.md
 
 extra:
@@ -134,3 +136,4 @@ plugins:
   - search
   - git-revision-date-localized:
       enable_creation_date: true
+  - blog


### PR DESCRIPTION
## Summary
- Enables the `blog` plugin in `mkdocs.yml` so files under `docs/site/blog/posts/` build as a real blog section (index, date ordering, archive/categories) instead of orphan pages.
- Adds a top-level `Blog` nav entry pointing at `blog/index.md` so the section is reachable from site navigation.
- Adds a minimal `docs/site/blog/index.md` stub — the blog plugin uses it as the section entry point; content is one line of prose, the plugin appends the auto-generated post list below it.
- No `pip install` change: the `blog` plugin ships inside `mkdocs-material`, already installed at `.github/workflows/mkdocs.yaml:38`.

## Test plan
- [x] `mkdocs build` succeeds locally with no `INFO`/`WARNING` about the existing post being outside the nav.
- [x] Generated `build/blog/index.html` lists the existing post (`kuke run as a Docker-compatible workflow for dev containers`) under the Blog section.
- [x] Generated `build/blog/2026/05/` contains the post page, confirming the blog plugin's date-ordered layout is active.
- [ ] Post-merge confirmation that https://kukeon.io renders the Blog tab and the post — verifiable only after the `Deploy Docs` workflow runs on `main`.

Closes #586