### PR TITLE
refactor: route workload commands through DaemonClientFromCmd (phase 3 of #217)

### DIFF
--- a/cmd/kuke/apply/apply.go
+++ b/cmd/kuke/apply/apply.go
@@ -92,7 +92,7 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukshared.ClientFromCmd(cmd)
+	return kukshared.DaemonClientFromCmd(cmd)
 }
 
 func printApplyResult(cmd *cobra.Command, result kukeonv1.ApplyDocumentsResult) error {

--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -152,7 +152,7 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }
 
 func resolveRun(cmd *cobra.Command) runFn {

--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -114,7 +114,7 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }
 
 func printCellResult(cmd *cobra.Command, result kukeonv1.CreateCellResult) {

--- a/cmd/kuke/create/container/container.go
+++ b/cmd/kuke/create/container/container.go
@@ -304,7 +304,7 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }
 
 func printContainerResult(cmd *cobra.Command, result kukeonv1.CreateContainerResult) {

--- a/cmd/kuke/create/realm/realm.go
+++ b/cmd/kuke/create/realm/realm.go
@@ -83,7 +83,7 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }
 
 func printRealmResult(cmd *cobra.Command, result kukeonv1.CreateRealmResult) {

--- a/cmd/kuke/create/space/space.go
+++ b/cmd/kuke/create/space/space.go
@@ -89,7 +89,7 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }
 
 func printSpaceResult(cmd *cobra.Command, result kukeonv1.CreateSpaceResult) {

--- a/cmd/kuke/create/stack/stack.go
+++ b/cmd/kuke/create/stack/stack.go
@@ -103,7 +103,7 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }
 
 func printStackResult(cmd *cobra.Command, result kukeonv1.CreateStackResult) {

--- a/cmd/kuke/delete/cell/cell.go
+++ b/cmd/kuke/delete/cell/cell.go
@@ -105,5 +105,5 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }

--- a/cmd/kuke/delete/container/container.go
+++ b/cmd/kuke/delete/container/container.go
@@ -107,5 +107,5 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }

--- a/cmd/kuke/delete/delete.go
+++ b/cmd/kuke/delete/delete.go
@@ -162,7 +162,7 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukshared.ClientFromCmd(cmd)
+	return kukshared.DaemonClientFromCmd(cmd)
 }
 
 // printDeleteResult prints deletion results in human-readable format.

--- a/cmd/kuke/delete/realm/realm.go
+++ b/cmd/kuke/delete/realm/realm.go
@@ -77,5 +77,5 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }

--- a/cmd/kuke/delete/space/space.go
+++ b/cmd/kuke/delete/space/space.go
@@ -98,5 +98,5 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }

--- a/cmd/kuke/delete/stack/stack.go
+++ b/cmd/kuke/delete/stack/stack.go
@@ -101,5 +101,5 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }

--- a/cmd/kuke/kill/cell/cell.go
+++ b/cmd/kuke/kill/cell/cell.go
@@ -111,5 +111,5 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }

--- a/cmd/kuke/kill/container/container.go
+++ b/cmd/kuke/kill/container/container.go
@@ -122,5 +122,5 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukeshared.ClientFromCmd(cmd)
+	return kukeshared.DaemonClientFromCmd(cmd)
 }

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -341,10 +341,14 @@ func applyClientConfiguration(cmd *cobra.Command, spec v1beta1.ClientConfigurati
 // fires, so cmd.Flags().Lookup picks up both local registrations (init's own
 // flag) and persistent ones inherited from a parent (purge's parent flag
 // reaching purge realm). Commands without `--no-daemon` (apply, create, run,
-// attach, delete, kill, get cell/space/stack/container, start, stop, log,
-// refresh, image *, daemon *) get nil from Lookup and viper falls back to
-// the env binding from loadConfig (KUKEON_NO_DAEMON) and the Set override
-// from applyRunPathImpliesNoDaemon below.
+// attach, delete, kill, start, stop, log, refresh, image *, daemon *) get
+// nil from Lookup and viper falls back to the env binding from loadConfig
+// (KUKEON_NO_DAEMON) and the Set override from applyRunPathImpliesNoDaemon
+// below. Of those, the workload commands (apply, create *, run, attach,
+// delete *, kill *) ignore the viper key entirely after #566 — they go
+// through DaemonClientFromCmd, which always dials kukeond — so for them
+// the rebind path is a no-op even when `KUKEON_NO_DAEMON=true` or the
+// `--run-path` promotion lands.
 func rebindNoDaemonViperToLeaf(cmd *cobra.Command) {
 	if flag := cmd.Flags().Lookup("no-daemon"); flag != nil {
 		_ = viper.BindPFlag(config.KUKEON_ROOT_NO_DAEMON.ViperKey, flag)
@@ -364,6 +368,20 @@ func rebindNoDaemonViperToLeaf(cmd *cobra.Command) {
 // with a non-default ClientConfiguration shouldn't have their daemon
 // access silently disabled. Flag/env are explicit per-invocation intent;
 // YAML is ambient configuration.
+//
+// Surviving callers after #566 (workload commands no longer consult the
+// `kukeon/noDaemon` viper key — they route through DaemonClientFromCmd):
+//   - init, uninstall, purge *, get * — expose `--no-daemon` user-facing
+//     and inherit the promotion when the operator passes `--run-path`
+//     without `--no-daemon`.
+//   - log, refresh, start *, stop *, doctor/cgroups — no `--no-daemon`
+//     flag at the CLI surface; the promotion is the only path that
+//     reaches the in-process branch in shared.ClientFromCmd for these.
+//
+// For the workload commands (apply, create *, run, attach, delete *,
+// kill *) the promotion still fires (the PreRun hook is unconditional),
+// but the resulting viper bit is now inert because DaemonClientFromCmd
+// does not read it.
 func applyRunPathImpliesNoDaemon(cmd *cobra.Command) {
 	runPathExplicit := flagChanged(cmd, "run-path") || envSet(config.KUKEON_ROOT_RUN_PATH)
 	noDaemonExplicit := flagChanged(cmd, "no-daemon") || envSet(config.KUKEON_ROOT_NO_DAEMON)

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -119,9 +119,7 @@ func NewRunCmd() *cobra.Command {
 			"long-lived root (e.g. `sleep infinity`) does not pin the "+
 			"cell. A clean ^]^] detach is NOT a trigger: the cell stays "+
 			"alive so the operator can re-attach later (parity with "+
-			"`kuke attach`). Daemon-mode only — incompatible with "+
-			"in-process mode (KUKEON_NO_DAEMON=true or `--run-path` "+
-			"promotion). Cleanup runs from kukeond's reconcile loop, "+
+			"`kuke attach`). Cleanup runs from kukeond's reconcile loop, "+
 			"so latency is bounded by the reconcile interval rather "+
 			"than firing the instant the trigger fires.")
 	_ = viper.BindPFlag(config.KUKE_RUN_RM.ViperKey, cmd.Flags().Lookup("rm"))
@@ -184,17 +182,6 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		// garbled output that nothing can parse. Reject the combination
 		// so callers pick one mode.
 		return runFlags{}, errors.New("--output is incompatible with attach mode (pass -d/--detach)")
-	}
-	if flags.autoDelete && viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey) {
-		// --rm needs a long-lived process to watch the root task and trigger
-		// cleanup. The in-process CLI path exits as soon as create+start
-		// returns, so the watcher would never run. `--no-daemon` is not a
-		// user-facing flag on `kuke run` after #222; the in-process path is
-		// reached via `--run-path` promotion or `KUKEON_NO_DAEMON=true`.
-		return runFlags{}, errors.New(
-			"--rm is incompatible with in-process mode " +
-				"(KUKEON_NO_DAEMON=true or --run-path promotion)",
-		)
 	}
 	if flags.file != "" {
 		// --name, --param, --param-file are profile-only knobs (per issue
@@ -747,5 +734,5 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
 		return mockClient, nil
 	}
-	return kukshared.ClientFromCmd(cmd)
+	return kukshared.DaemonClientFromCmd(cmd)
 }

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1759,30 +1759,6 @@ func TestRun_NoRmFlag_LeavesAutoDeleteFalse(t *testing.T) {
 	}
 }
 
-func TestRun_RmFlag_RejectsNoDaemon(t *testing.T) {
-	// --rm needs a long-lived process to watch the root task. The in-process
-	// CLI returns immediately after CreateCell, so the watcher would never
-	// run. Reject the combo at flag-parse — before any cell is mutated.
-	t.Cleanup(viper.Reset)
-	// `--no-daemon` is not a user-facing flag on `kuke run` after #222;
-	// the in-process path is reached via `--run-path` promotion or
-	// `KUKEON_NO_DAEMON=true`. Flip the underlying viper key directly to
-	// simulate either path.
-	viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, true)
-
-	fc := &fakeClient{}
-	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d", "--rm"})
-
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "--rm is incompatible with in-process mode") {
-		t.Fatalf("err=%v want '--rm is incompatible with in-process mode'", err)
-	}
-	if fc.createCalls != 0 {
-		t.Errorf("CreateCell calls=%d want 0 (must reject before mutating)", fc.createCalls)
-	}
-}
-
 func TestRun_RmFlag_FromYAMLAlreadySet_StillHonored(t *testing.T) {
 	// A YAML manifest with `autoDelete: true` already in the spec must be
 	// honored even without --rm — the spec is the declarative source of

--- a/cmd/kuke/shared/controller.go
+++ b/cmd/kuke/shared/controller.go
@@ -103,6 +103,14 @@ func GetControllerWithMockWrapper[T any](cmd *cobra.Command, mockKey any, wrappe
 // True → in-process Client backed by a fresh controller.Exec (requires
 // privileges). False → JSON-RPC Client dialing KUKEON_HOST (unix:///...
 // today). The caller owns the returned Client and must Close it.
+//
+// Workload commands (apply, create *, run, attach, delete *, kill *) no
+// longer route through here — #566 routed them through DaemonClientFromCmd
+// so the in-process branch is unreachable from the workload CLI surface.
+// Surviving callers: log, refresh, start, stop, doctor/cgroups (in-process
+// reachable only via the `--run-path` promotion since they don't expose
+// `--no-daemon`), plus get *, purge *, init, uninstall (in-process
+// reachable via either the explicit `--no-daemon` flag or the promotion).
 func ClientFromCmd(cmd *cobra.Command) (kukeonv1.Client, error) {
 	if viper.GetBool(config.KUKEON_ROOT_NO_DAEMON.ViperKey) {
 		logger, err := LoggerFromCmd(cmd)
@@ -115,6 +123,28 @@ func ClientFromCmd(cmd *cobra.Command) (kukeonv1.Client, error) {
 		}), nil
 	}
 
+	return dialDaemon(cmd)
+}
+
+// DaemonClientFromCmd returns a kukeonv1.Client that always dials kukeond
+// (RPC only — never the in-process branch). #566 phase 3 routes every
+// workload command (apply, create *, run, attach, delete *, kill *)
+// through here so the user-facing CLI surface for those verbs has no
+// in-process escape hatch even when `--run-path` (which would otherwise
+// promote `KUKEON_NO_DAEMON=true` via applyRunPathImpliesNoDaemon) is set.
+// The promotion still fires for the surviving ClientFromCmd callers
+// enumerated above; for the workload commands it is now a no-op because
+// this helper ignores the `kukeon/noDaemon` viper key.
+//
+// The caller owns the returned Client and must Close it.
+func DaemonClientFromCmd(cmd *cobra.Command) (kukeonv1.Client, error) {
+	return dialDaemon(cmd)
+}
+
+// dialDaemon resolves the configured kukeond endpoint (KUKEON_HOST, with
+// fallback to the default) and dials it. Shared by ClientFromCmd's RPC
+// branch and DaemonClientFromCmd.
+func dialDaemon(cmd *cobra.Command) (kukeonv1.Client, error) {
 	host := viper.GetString(config.KUKEON_ROOT_HOST.ViperKey)
 	if host == "" {
 		host = config.KUKEON_ROOT_HOST.Default

--- a/cmd/kuke/shared/no_daemon.go
+++ b/cmd/kuke/shared/no_daemon.go
@@ -28,10 +28,14 @@ const noDaemonFlagUsage = "bypass kukeond and run operations in-process (require
 // subcommand. #222 demoted it to a per-command opt-in: only the commands that
 // still accept it user-facing (kuke init, kuke uninstall, and — via the
 // persistent variant below — kuke purge and every kuke get <kind>) call this
-// helper or its persistent sibling. Daemon-routed workload commands (apply,
-// create, run, attach, delete, kill, start, stop, log, refresh) no longer
-// accept the flag at the CLI surface; they still reach the in-process branch
-// via the `--run-path` promotion in applyRunPathImpliesNoDaemon and via
+// helper or its persistent sibling. The workload commands (apply, create,
+// run, attach, delete, kill) no longer accept the flag at the CLI surface
+// AND no longer reach the in-process branch at all — #566 routed them
+// through shared.DaemonClientFromCmd, which always dials kukeond. The
+// remaining non-workload commands without `--no-daemon` (start, stop, log,
+// refresh, doctor cgroups) keep the older shape: they go through
+// shared.ClientFromCmd and reach the in-process branch via the
+// `--run-path` promotion in applyRunPathImpliesNoDaemon or via
 // `KUKEON_NO_DAEMON=true`.
 //
 // Bind to viper at PreRun time, not here — see kuke.go's

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -259,7 +259,7 @@ sudo kuke run -f spec.yaml --rm                             # auto-delete after 
 - Re-running `kuke run -f` against an existing cell whose on-disk spec **diverges** from the file is **refused**, not silently updated. The error message points the operator at `kuke apply -f` for the update path. Exit code non-zero.
 - `-f` and `-p` are mutually exclusive; `--name` is rejected with `-f` (the YAML's `metadata.name` is the cell name verbatim).
 - `--container` is only valid in attach mode; passing both `--container` and `-d/--detach` exits non-zero.
-- `--rm` is daemon-mode only and incompatible with in-process mode (`KUKEON_NO_DAEMON=true` or `--run-path` promotion). Cleanup latency is bounded by the daemon's reconcile interval (default 30s), not real-time.
+- `--rm` is processed by `kukeond`'s reconcile loop. `kuke run` is daemon-only after #566 — `KUKEON_NO_DAEMON=true` and `--run-path` promotion no longer reach an in-process branch for workload verbs, so `--rm` and `--run-path` are not mutually exclusive on `kuke run`. Cleanup latency is bounded by the daemon's reconcile interval (default 30s), not real-time.
 - A clean `^]^]` detach in attach mode does **not** trigger `--rm` cleanup; the cell stays alive for re-attach. Only workload termination, peer hangup, or an unrecoverable controller error fires cleanup.
 - `kuke run -f /missing.yaml` exits non-zero with a `failed to open file` error.
 - A reference to an unavailable image surfaces the containerd resolver error verbatim (e.g. `pull access denied, repository does not exist or may require authorization`) and exits non-zero; the half-created cell may need `kuke purge cell` to clean up.

--- a/docs/site/cli/kuke-run.md
+++ b/docs/site/cli/kuke-run.md
@@ -53,7 +53,7 @@ Keys not declared in `spec.parameters[]` are rejected.
 
 ## Cleanup with `--rm`
 
-`--rm` best-effort deletes the cell after it's no longer needed (any return code). Daemon-mode only — incompatible with in-process mode (set with `KUKEON_NO_DAEMON=true` or by passing `--run-path`, which auto-promotes). Cleanup runs from `kukeond`'s reconcile loop, so latency is bounded by the reconcile interval rather than firing the instant the trigger fires.
+`--rm` best-effort deletes the cell after it's no longer needed (any return code). `kuke run` is daemon-only after #566 — `KUKEON_NO_DAEMON=true` and `--run-path` promotion are inert for workload verbs and no longer reach an in-process branch for `run`, so `--rm` is always available. Cleanup runs from `kukeond`'s reconcile loop, so latency is bounded by the reconcile interval rather than firing the instant the trigger fires.
 
 Triggers:
 

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -63,11 +63,14 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// the suite.
 	t.Parallel()
 
-	// Setup: isolated runPath, unique resource names, in-process controller
-	// (promoted by passing `--run-path` to a workload command) so the
-	// per-container socket lives under the test's runPath rather than the
-	// host daemon's.
+	// Setup: isolated runPath + per-test kukeond bound to that runPath.
+	// Workload commands route through the daemon (#566 made them RPC-only),
+	// but because the daemon's --run-path matches the test's the daemon
+	// still lays down the per-container kuketty socket under the test's
+	// runPath — which is what `kuke attach` and the post-detach `ctr task
+	// ls` need to inspect.
 	runPath := getRandomRunPath(t)
+	host := startKukeondDaemon(t, runPath)
 
 	realmName := generateUniqueRealmName(t)
 	spaceName := generateUniqueSpaceName(t)
@@ -84,11 +87,11 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// Step 1: provision realm/space/stack as plain create commands so the
 	// remaining apply call exercises the cell path and only the cell path.
 	runReturningBinary(t, nil, kuke,
-		append(buildKukeRunPathArgs(runPath), "create", "realm", realmName)...)
+		append(buildKukeDaemonArgs(host), "create", "realm", realmName)...)
 	runReturningBinary(t, nil, kuke,
-		append(buildKukeRunPathArgs(runPath), "create", "space", spaceName, "--realm", realmName)...)
+		append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)...)
 	runReturningBinary(t, nil, kuke,
-		append(buildKukeRunPathArgs(runPath), "create", "stack", stackName,
+		append(buildKukeDaemonArgs(host), "create", "stack", stackName,
 			"--realm", realmName, "--space", spaceName)...)
 
 	// Step 2: apply the attachable cell fixture. Auto-starts the workload
@@ -99,7 +102,7 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 	// does not pre-create any placeholder socket file (the old workaround
 	// was broken because sbsh unlinks-and-recreates the destination,
 	// producing a fresh inode invisible to the host).
-	applyAttachableCell(t, runPath, realmName, spaceName, stackName, cellName)
+	applyAttachableCell(t, host, realmName, spaceName, stackName, cellName)
 
 	// Step 3: confirm the per-container kuketty socket is in place. The runner
 	// creates the metadata dir at provision time and sbsh binds the socket
@@ -115,7 +118,7 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 
 	// Step 4: drive `kuke attach` over a real PTY and detach.
 	session := startPTY(t, nil, kuke,
-		append(buildKukeRunPathArgs(runPath),
+		append(buildKukeDaemonArgs(host),
 			"attach", cellName,
 			"--realm", realmName,
 			"--space", spaceName,
@@ -161,8 +164,9 @@ func TestKuke_AttachDetach_KeepsTaskRunning(t *testing.T) {
 }
 
 // applyAttachableCell substitutes test-side names into the
-// attachable-cell.yaml fixture and runs `kuke apply` against it.
-func applyAttachableCell(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) {
+// attachable-cell.yaml fixture and runs `kuke apply` against it via the
+// per-test daemon (apply is daemon-only after #566).
+func applyAttachableCell(t *testing.T, host, realmName, spaceName, stackName, cellName string) {
 	t.Helper()
 
 	yamlContent := readTestdataYAML(t, "attachable-cell.yaml")
@@ -181,7 +185,7 @@ func applyAttachableCell(t *testing.T, runPath, realmName, spaceName, stackName,
 		t.Fatalf("write tmp yaml: %v", err)
 	}
 
-	args := append(buildKukeRunPathArgs(runPath), "apply", "-f", tmpFile)
+	args := append(buildKukeDaemonArgs(host), "apply", "-f", tmpFile)
 	runReturningBinary(t, nil, kuke, args...)
 }
 
@@ -230,33 +234,37 @@ func verifyContainerTaskIsRunning(t *testing.T, namespace, containerID string) b
 }
 
 // cleanupRealmNoDaemon, cleanupSpaceNoDaemon, cleanupStackNoDaemon, and
-// cleanupCellNoDaemon mirror the existing cleanup helpers but route through
-// in-process mode (via the `--run-path` promotion) so they use the same
-// controller as the test itself. Without this the cleanup goes via the host
-// daemon (different runPath) and silently no-ops, leaving resources behind.
+// cleanupCellNoDaemon route through `purge --cascade` in-process (via the
+// `--run-path` promotion). Purge — not delete — because #566 made the
+// workload `delete *` verbs daemon-only, and these helpers must work
+// when no daemon is alive (post-reset, post-cascade-realm-teardown of the
+// kuke-system cell that ran kukeond). Purge keeps the in-process branch
+// per the issue's surviving-callers enumeration, so cleanup runs even
+// against a runPath whose owning daemon (if any) has already been torn
+// down by the test body.
 func cleanupRealmNoDaemon(t *testing.T, runPath, realmName string) {
 	t.Helper()
-	args := append(buildKukeRunPathArgs(runPath), "delete", "realm", realmName, "--cascade")
+	args := append(buildKukeRunPathArgs(runPath), "purge", "realm", realmName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
 
 func cleanupSpaceNoDaemon(t *testing.T, runPath, realmName, spaceName string) {
 	t.Helper()
-	args := append(buildKukeRunPathArgs(runPath), "delete", "space", spaceName,
+	args := append(buildKukeRunPathArgs(runPath), "purge", "space", spaceName,
 		"--realm", realmName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
 
 func cleanupStackNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName string) {
 	t.Helper()
-	args := append(buildKukeRunPathArgs(runPath), "delete", "stack", stackName,
+	args := append(buildKukeRunPathArgs(runPath), "purge", "stack", stackName,
 		"--realm", realmName, "--space", spaceName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }
 
 func cleanupCellNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName, cellName string) {
 	t.Helper()
-	args := append(buildKukeRunPathArgs(runPath), "delete", "cell", cellName,
+	args := append(buildKukeRunPathArgs(runPath), "purge", "cell", cellName,
 		"--realm", realmName, "--space", spaceName, "--stack", stackName, "--cascade")
 	_, _, _ = runBinary(t, nil, kuke, args...)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -161,7 +161,9 @@ func deepSocketPathFits(runPath string) bool {
 // must run in the in-process controller path rather than dial a daemon.
 // Use buildKukeDaemonArgs (paired with startKukeondDaemon) for workload
 // commands — per-test daemon-mode is the suite's default now that phase 2
-// (#565) has landed.
+// (#565) has landed, and phase 3 (#566) made the workload verbs (apply,
+// create *, run, attach, delete *, kill *) daemon-only at the code-path
+// level, so they cannot use the in-process helper at all.
 //
 // Legitimate survivors of this in-process helper:
 //   - `get realms --no-daemon`: the daemon-parity smoke (CLAUDE.md's
@@ -169,15 +171,13 @@ func deepSocketPathFits(runPath string) bool {
 //     view; routing both sides through the daemon would defeat the check).
 //   - `purge` (any kind): purge is a host-mutating verb that must work
 //     regardless of daemon state, so e2e cleanups never depend on the
-//     per-test daemon still being alive.
+//     per-test daemon still being alive. The attach test's cleanup helpers
+//     (cleanup{Realm,Space,Stack,Cell}NoDaemon) call `purge --cascade` for
+//     this reason after #566 took `delete *` off the in-process branch.
 //   - `init` / `uninstall`: bootstrap/teardown verbs that bring up or tear
 //     down the daemon itself; they cannot route through it.
 //   - `kuke daemon …`: the daemon-lifecycle group; in-process by definition
 //     per the #217 categorization.
-//   - The attach test (e2e_kuke_attach_test.go) keeps its `*NoDaemon`
-//     cleanup helpers so the per-container kuketty socket inspection lines
-//     up with the same controller the test drives (see the comment in
-//     TestKuke_AttachDetach_KeepsTaskRunning for rationale).
 //
 // The in-process promotion comes from applyRunPathImpliesNoDaemon
 // (cmd/kuke/kuke.go), which auto-sets --no-daemon=true whenever --run-path

--- a/e2e/harness_daemon_test.go
+++ b/e2e/harness_daemon_test.go
@@ -171,8 +171,10 @@ func startKukeondDaemon(t *testing.T, runPath string) string {
 
 // buildKukeDaemonArgs returns the `--host <addr>` prefix every daemon-mode
 // e2e invocation must carry. Pair with startKukeondDaemon to route a
-// workload command to the per-test daemon instead of the in-process
-// controller that --run-path promotion would otherwise select.
+// workload command to the per-test daemon — required for apply, create *,
+// run, attach, delete *, kill * after #566 made the workload verbs
+// daemon-only at the code-path level (the `--run-path` promotion no longer
+// reaches an in-process branch for them).
 //
 // The in-process counterpart (buildKukeRunPathArgs) survives for the
 // daemon-parity check (`get realms --no-daemon`) and host-mutating verbs

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -15,9 +15,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package local provides an in-process kukeonv1.Client backed by a
-// controller.Exec. Used by the CLI in --no-daemon mode (workload commands
-// per #222), by the `kuke image *` subcommands as the always-in-process
-// path (#226), and by the daemon itself when servicing RPC calls.
+// controller.Exec. Used by the CLI in --no-daemon mode (init, uninstall,
+// purge *, get *, plus log/refresh/start/stop/doctor-cgroups via the
+// `--run-path` promotion — workload commands routed through here pre-#566
+// were moved off to shared.DaemonClientFromCmd in phase 3), by the
+// `kuke image *` subcommands as the always-in-process path (#226), and by
+// the daemon itself when servicing RPC calls.
 package local
 
 import (


### PR DESCRIPTION
## Summary
- Split `shared.ClientFromCmd` into `DaemonClientFromCmd` (workload — always RPC) and the legacy `ClientFromCmd` (kept for `get *`, `purge *`, `log`, `start`, `refresh`, `doctor/cgroups`, `stop`, `init`, `uninstall`).
- Routed every workload verb — `apply`, `create *`, `run`, `attach`, `delete *`, `kill *` — through `DaemonClientFromCmd` at the cobra call sites. The in-process branch is now unreachable from the workload CLI surface even when `--run-path` is explicit.
- Kept `applyRunPathImpliesNoDaemon`; it still fires for the surviving `ClientFromCmd` callers enumerated above and is inert for the workload commands (their helper ignores the `kukeon/noDaemon` viper key). Doc-comments in `cmd/kuke/kuke.go`, `cmd/kuke/shared/controller.go`, and `cmd/kuke/shared/no_daemon.go` enumerate which verbs each branch affects.
- Dropped the now-stale `--no-daemon` exercises in `cmd/kuke/run/run_test.go` (the run command no longer has an in-process branch to cover).
- Updated `e2e/` and `internal/client/local/local.go` callers for the new helper layout.

## Test plan
- [x] `make test` — green
- [x] `make e2e` — green
- [x] `git rebase origin/main` clean (3 unrelated commits had landed on main; rebased and force-with-lease pushed)
- [x] Audited callers: all workload verbs (`apply`, `create {cell,container,realm,space,stack}`, `delete {cell,container,realm,space,stack}`, `kill {cell,container}`, `run`, `attach`, `delete`) call `DaemonClientFromCmd`; non-workload verbs (`get *`, `purge *`, `log`, `refresh`, `start *`, `stop *`, `doctor/cgroups`) continue to call `ClientFromCmd`

Closes #566