### PR TITLE
fix(serverconfig): render WriteDefault YAML from the caller's resolved spec

### DIFF
--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -292,9 +292,35 @@ func envSet(v config.Var) bool {
 // host's template on first boot. Errors are intentionally swallowed: a
 // read-only /etc or unwritable parent dir must not block the daemon from
 // starting on the in-binary defaults.
+//
+// The spec we hand to WriteDefault is read back from viper at write time so
+// the dumped document reflects the values the daemon actually bound to —
+// flag / env overrides included — instead of a hardcoded snapshot of the
+// compile-time defaults (issue #581). The YAML has not been loaded yet on
+// the first-write path, so viper holds exactly the flag-and-env-resolved
+// state we want to record.
 func maybeWriteServerConfigurationDefault(_ *cobra.Command, path string) {
 	if path != config.DefaultServerConfigurationFile() {
 		return
 	}
-	_, _ = serverconfig.WriteDefault(path)
+	_, _ = serverconfig.WriteDefault(path, currentResolvedSpec())
+}
+
+// currentResolvedSpec snapshots the post-flag, post-env viper state into a
+// ServerConfigurationSpec for serverconfig.WriteDefault. The KukeondImage
+// field is intentionally left empty — the daemon has no --kukeond-image
+// flag (it's a `kuke init` concern) and the commented default explains
+// that `kuke init` resolves the value at runtime.
+func currentResolvedSpec() v1beta1.ServerConfigurationSpec {
+	return v1beta1.ServerConfigurationSpec{
+		Socket:                    viper.GetString(config.KUKEOND_SOCKET.ViperKey),
+		SocketGID:                 viper.GetInt(config.KUKEOND_SOCKET_GID.ViperKey),
+		RunPath:                   viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket:          viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+		LogLevel:                  viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey),
+		ReconcileInterval:         viper.GetString(config.KUKEOND_RECONCILE_INTERVAL.ViperKey),
+		ContainerdNamespaceSuffix: viper.GetString(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey),
+		CgroupRoot:                viper.GetString(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey),
+		DefaultMemoryLimitBytes:   viper.GetInt64(config.KUKEOND_DEFAULT_MEMORY_LIMIT_BYTES.ViperKey),
+	}
 }

--- a/cmd/kukeond/kukeond_test.go
+++ b/cmd/kukeond/kukeond_test.go
@@ -311,3 +311,60 @@ func TestMaybeWriteServerConfigurationDefaultSkipsCustomPath(t *testing.T) {
 		t.Fatalf("custom path was written; got Stat err=%v, want IsNotExist", statErr)
 	}
 }
+
+// TestCurrentResolvedSpecReflectsViper is the kukeond-side regression guard
+// for issue #581: the spec we feed to serverconfig.WriteDefault must mirror
+// the flag-and-env-resolved viper state at first-write time, so the dumped
+// document records the values the daemon actually bound to instead of the
+// compile-time defaults. Mutating viper directly here proxies for the flag
+// and env paths — applyServerConfiguration has not run yet on the first-
+// write code path (the YAML doesn't exist), so viper holds exactly the
+// resolved state we want to snapshot.
+func TestCurrentResolvedSpecReflectsViper(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+
+	if _, err := NewKukeondCmd(); err != nil {
+		t.Fatalf("NewKukeondCmd() error = %v", err)
+	}
+
+	viper.Set(config.KUKEOND_SOCKET.ViperKey, "/tmp/A/kukeond.sock")
+	viper.Set(config.KUKEOND_SOCKET_GID.ViperKey, 4242)
+	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, "/tmp/A")
+	viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, "/run/containerd/test.sock")
+	viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, "debug")
+	viper.Set(config.KUKEOND_RECONCILE_INTERVAL.ViperKey, "45s")
+	viper.Set(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey, "dev.kukeon.io")
+	viper.Set(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey, "/kukeon-dev")
+	viper.Set(config.KUKEOND_DEFAULT_MEMORY_LIMIT_BYTES.ViperKey, int64(2*1024*1024*1024))
+
+	spec := currentResolvedSpec()
+
+	if spec.Socket != "/tmp/A/kukeond.sock" {
+		t.Errorf("Socket: got %q", spec.Socket)
+	}
+	if spec.SocketGID != 4242 {
+		t.Errorf("SocketGID: got %d", spec.SocketGID)
+	}
+	if spec.RunPath != "/tmp/A" {
+		t.Errorf("RunPath: got %q", spec.RunPath)
+	}
+	if spec.ContainerdSocket != "/run/containerd/test.sock" {
+		t.Errorf("ContainerdSocket: got %q", spec.ContainerdSocket)
+	}
+	if spec.LogLevel != "debug" {
+		t.Errorf("LogLevel: got %q", spec.LogLevel)
+	}
+	if spec.ReconcileInterval != "45s" {
+		t.Errorf("ReconcileInterval: got %q", spec.ReconcileInterval)
+	}
+	if spec.ContainerdNamespaceSuffix != "dev.kukeon.io" {
+		t.Errorf("ContainerdNamespaceSuffix: got %q", spec.ContainerdNamespaceSuffix)
+	}
+	if spec.CgroupRoot != "/kukeon-dev" {
+		t.Errorf("CgroupRoot: got %q", spec.CgroupRoot)
+	}
+	if spec.DefaultMemoryLimitBytes != int64(2*1024*1024*1024) {
+		t.Errorf("DefaultMemoryLimitBytes: got %d", spec.DefaultMemoryLimitBytes)
+	}
+}

--- a/internal/serverconfig/serverconfig.go
+++ b/internal/serverconfig/serverconfig.go
@@ -22,10 +22,12 @@
 package serverconfig
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -65,11 +67,14 @@ func Load(path string) (*v1beta1.ServerConfigurationDoc, error) {
 	return &doc, nil
 }
 
-// defaultDocument is the commented YAML written by WriteDefault on first
-// kukeond start. Every spec field is present with its in-binary default and
-// a header comment explaining its purpose so the operator can tweak the file
-// without consulting source. The string round-trips through Load.
-const defaultDocument = `# kukeond ServerConfiguration — auto-generated default.
+// defaultDocumentTemplate is the commented YAML rendered by WriteDefault on
+// first kukeond start. Every spec field is present with its in-binary default
+// surfaced in a `# Default: …` comment so the operator can tweak the file
+// without consulting source, and the live value is rendered from the spec the
+// caller passes in — so the on-disk document reflects what the daemon
+// actually bound to, not the compile-time defaults (issue #581). The string
+// round-trips through Load.
+const defaultDocumentTemplate = `# kukeond ServerConfiguration — auto-generated default.
 # kukeond reads this file via --configuration (default /etc/kukeon/kukeond.yaml).
 # Precedence: explicit --flag > KUKEON_*/KUKEOND_* env > this file > hardcoded default.
 # Existing files are never overwritten; delete this file to regenerate.
@@ -80,52 +85,52 @@ metadata:
 spec:
   # Unix socket path the daemon listens on.
   # Default: /run/kukeon/kukeond.sock
-  socket: /run/kukeon/kukeond.sock
+  socket: {{printf "%q" .Socket}}
 
   # Numeric group ID the daemon chowns its listener socket to (mode 0o660 with
   # group). Zero means root-only access. ` + "`kuke init`" + ` plumbs the kukeon GID here
   # so non-root group members can dial the daemon after a kukeond restart.
   # Default: 0
-  socketGID: 0
+  socketGID: {{.SocketGID}}
 
   # Kukeon runtime root — the on-disk hierarchy under which realms, spaces,
   # stacks, and cells live.
   # Default: /opt/kukeon
-  runPath: /opt/kukeon
+  runPath: {{printf "%q" .RunPath}}
 
   # Path to the containerd unix socket the daemon connects to.
   # Default: /run/containerd/containerd.sock
-  containerdSocket: /run/containerd/containerd.sock
+  containerdSocket: {{printf "%q" .ContainerdSocket}}
 
   # Daemon log level (debug, info, warn, error).
   # Default: info
-  logLevel: info
+  logLevel: {{printf "%q" .LogLevel}}
 
   # Period of the daemon's background cell-reconciliation loop, expressed as a
   # Go time.Duration string. The loop walks every cell and re-derives
   # ` + "`status.state`" + ` against observed container state once per tick. Zero or
   # negative disables the loop.
   # Default: 30s
-  reconcileInterval: 30s
+  reconcileInterval: {{printf "%q" .ReconcileInterval}}
 
   # Container image ` + "`kuke init`" + ` provisions for the kukeond system cell.
   # Read by ` + "`kuke init`" + ` only; the daemon ignores it. Empty means kuke init
   # picks the release-matching ghcr.io/eminwux/kukeon image automatically.
   # Default: ""
-  kukeondImage: ""
+  kukeondImage: {{printf "%q" .KukeondImage}}
 
   # Suffix appended to every realm name to form its containerd namespace.
   # Realm "default" + suffix "kukeon.io" -> namespace "default.kukeon.io".
   # Set to a different suffix (e.g. "dev.kukeon.io") to run a parallel
   # kukeon instance on the same host under a disjoint containerd namespace.
   # Default: kukeon.io
-  containerdNamespaceSuffix: kukeon.io
+  containerdNamespaceSuffix: {{printf "%q" .ContainerdNamespaceSuffix}}
 
   # Cgroup root under which all realms / spaces / stacks / cells live.
   # Set to a different root (e.g. "/kukeon-dev") to run a parallel kukeon
   # instance on the same host under a disjoint cgroup tree.
   # Default: /kukeon
-  cgroupRoot: /kukeon
+  cgroupRoot: {{printf "%q" .CgroupRoot}}
 
   # Daemon-wide fallback memory limit (in bytes) applied to every admitted
   # container whose Resources.MemoryLimitBytes is unset or zero. An explicit
@@ -133,15 +138,32 @@ spec:
   # without a userspace OOM guard (systemd-oomd / earlyoom), where an
   # unbounded workload can wedge the whole host. Zero disables the fallback.
   # Default: 0
-  defaultMemoryLimitBytes: 0
+  defaultMemoryLimitBytes: {{.DefaultMemoryLimitBytes}}
 `
 
-// WriteDefault writes the commented default ServerConfiguration to path when
-// the file is absent. Returns true only when this call created the file; an
-// existing file (any contents) is left untouched, satisfying the "first-write
-// only" rule. Creates the parent directory if missing. Any other failure is
-// returned wrapped.
-func WriteDefault(path string) (bool, error) {
+// defaultDocumentTmpl is the parsed template used by WriteDefault. Parsing
+// once at package init keeps the per-call cost down and surfaces any
+// future template-syntax breakage at process start rather than first write.
+//
+//nolint:gochecknoglobals // package-level parsed template — see godoc above.
+var defaultDocumentTmpl = template.Must(
+	template.New("kukeond-serverconfig-default").Parse(defaultDocumentTemplate),
+)
+
+// WriteDefault renders the commented default ServerConfiguration with the
+// resolved spec the caller passes and writes it to path when the file is
+// absent. Returns true only when this call created the file; an existing
+// file (any contents) is left untouched, satisfying the "first-write only"
+// rule. The spec's values are interpolated into the YAML so the on-disk
+// document reflects the values the daemon actually started with, not a
+// hardcoded snapshot of the compile-time defaults (issue #581). Creates
+// the parent directory if missing. Any other failure is returned wrapped.
+func WriteDefault(path string, spec v1beta1.ServerConfigurationSpec) (bool, error) {
+	var rendered bytes.Buffer
+	if err := defaultDocumentTmpl.Execute(&rendered, spec); err != nil {
+		return false, fmt.Errorf("render default server configuration: %w", err)
+	}
+
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return false, fmt.Errorf("create parent directory for %q: %w", path, err)
 	}
@@ -155,7 +177,7 @@ func WriteDefault(path string) (bool, error) {
 		return false, fmt.Errorf("create %q: %w", path, err)
 	}
 	defer f.Close()
-	if _, writeErr := f.WriteString(defaultDocument); writeErr != nil {
+	if _, writeErr := f.Write(rendered.Bytes()); writeErr != nil {
 		return false, fmt.Errorf("write %q: %w", path, writeErr)
 	}
 	return true, nil

--- a/internal/serverconfig/serverconfig_test.go
+++ b/internal/serverconfig/serverconfig_test.go
@@ -171,12 +171,31 @@ func TestLoadEmptyKindAccepted(t *testing.T) {
 	}
 }
 
+// canonicalDefaultsSpec mirrors the compile-time defaults documented in each
+// `# Default: …` comment in defaultDocumentTemplate. Use as the spec for
+// WriteDefault when a test wants the dumped YAML to match the documented
+// defaults verbatim.
+func canonicalDefaultsSpec() v1beta1.ServerConfigurationSpec {
+	return v1beta1.ServerConfigurationSpec{
+		Socket:                    "/run/kukeon/kukeond.sock",
+		SocketGID:                 0,
+		RunPath:                   "/opt/kukeon",
+		ContainerdSocket:          "/run/containerd/containerd.sock",
+		LogLevel:                  "info",
+		ReconcileInterval:         "30s",
+		KukeondImage:              "",
+		ContainerdNamespaceSuffix: "kukeon.io",
+		CgroupRoot:                "/kukeon",
+		DefaultMemoryLimitBytes:   0,
+	}
+}
+
 func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 	dir := t.TempDir()
 	// Nested parent directory exercises the MkdirAll branch.
 	path := filepath.Join(dir, "a", "b", "kukeond.yaml")
 
-	wrote, err := WriteDefault(path)
+	wrote, err := WriteDefault(path, canonicalDefaultsSpec())
 	if err != nil {
 		t.Fatalf("WriteDefault: %v", err)
 	}
@@ -260,7 +279,7 @@ func TestWriteDefaultLeavesExistingFileUntouched(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	wrote, err := WriteDefault(path)
+	wrote, err := WriteDefault(path, canonicalDefaultsSpec())
 	if err != nil {
 		t.Fatalf("WriteDefault: %v", err)
 	}
@@ -273,5 +292,99 @@ func TestWriteDefaultLeavesExistingFileUntouched(t *testing.T) {
 	}
 	if string(got) != string(preexisting) {
 		t.Errorf("file contents changed:\n got: %q\nwant: %q", got, preexisting)
+	}
+}
+
+// TestWriteDefaultRendersResolvedSpec is the regression guard for issue #581:
+// the dumped YAML must reflect the spec the caller passes (which on the
+// kukeond boot path mirrors the flag-and-env-resolved viper state), not a
+// hardcoded snapshot of the compile-time defaults. Before the fix,
+// `kukeond serve --run-path /tmp/A` wrote `runPath: /opt/kukeon` and
+// `socket: /run/kukeon/kukeond.sock` to /etc/kukeon/kukeond.yaml regardless
+// of the launched values; subsequent `kuke init --run-path /tmp/B`
+// invocations then read that lying file back via applyServerConfiguration
+// and silently bound the daemon to the leftover socket.
+func TestWriteDefaultRendersResolvedSpec(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kukeond.yaml")
+
+	spec := v1beta1.ServerConfigurationSpec{
+		Socket:                    "/tmp/A/kukeond.sock",
+		SocketGID:                 4242,
+		RunPath:                   "/tmp/A",
+		ContainerdSocket:          "/run/containerd/test.sock",
+		LogLevel:                  "debug",
+		ReconcileInterval:         "45s",
+		KukeondImage:              "docker.io/library/kukeon:test",
+		ContainerdNamespaceSuffix: "dev.kukeon.io",
+		CgroupRoot:                "/kukeon-dev",
+		DefaultMemoryLimitBytes:   2 * 1024 * 1024 * 1024,
+	}
+
+	wrote, err := WriteDefault(path, spec)
+	if err != nil {
+		t.Fatalf("WriteDefault: %v", err)
+	}
+	if !wrote {
+		t.Fatal("WriteDefault returned wrote=false on a fresh path")
+	}
+
+	doc, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() round-trip: %v", err)
+	}
+	if doc.Spec.Socket != spec.Socket {
+		t.Errorf("Spec.Socket: got %q, want %q (the launched value, not the binary default)",
+			doc.Spec.Socket, spec.Socket)
+	}
+	if doc.Spec.SocketGID != spec.SocketGID {
+		t.Errorf("Spec.SocketGID: got %d, want %d", doc.Spec.SocketGID, spec.SocketGID)
+	}
+	if doc.Spec.RunPath != spec.RunPath {
+		t.Errorf("Spec.RunPath: got %q, want %q (the launched value, not the binary default)",
+			doc.Spec.RunPath, spec.RunPath)
+	}
+	if doc.Spec.ContainerdSocket != spec.ContainerdSocket {
+		t.Errorf("Spec.ContainerdSocket: got %q, want %q", doc.Spec.ContainerdSocket, spec.ContainerdSocket)
+	}
+	if doc.Spec.LogLevel != spec.LogLevel {
+		t.Errorf("Spec.LogLevel: got %q, want %q", doc.Spec.LogLevel, spec.LogLevel)
+	}
+	if doc.Spec.ReconcileInterval != spec.ReconcileInterval {
+		t.Errorf("Spec.ReconcileInterval: got %q, want %q",
+			doc.Spec.ReconcileInterval, spec.ReconcileInterval)
+	}
+	if doc.Spec.KukeondImage != spec.KukeondImage {
+		t.Errorf("Spec.KukeondImage: got %q, want %q", doc.Spec.KukeondImage, spec.KukeondImage)
+	}
+	if doc.Spec.ContainerdNamespaceSuffix != spec.ContainerdNamespaceSuffix {
+		t.Errorf("Spec.ContainerdNamespaceSuffix: got %q, want %q",
+			doc.Spec.ContainerdNamespaceSuffix, spec.ContainerdNamespaceSuffix)
+	}
+	if doc.Spec.CgroupRoot != spec.CgroupRoot {
+		t.Errorf("Spec.CgroupRoot: got %q, want %q", doc.Spec.CgroupRoot, spec.CgroupRoot)
+	}
+	if doc.Spec.DefaultMemoryLimitBytes != spec.DefaultMemoryLimitBytes {
+		t.Errorf("Spec.DefaultMemoryLimitBytes: got %d, want %d",
+			doc.Spec.DefaultMemoryLimitBytes, spec.DefaultMemoryLimitBytes)
+	}
+
+	// The compile-time-default markers in the header comments must survive
+	// even when the rendered values diverge — the `# Default: …` line
+	// documents the binary's intrinsic default for the operator, not the
+	// current effective value.
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	rawStr := string(raw)
+	for _, marker := range []string{
+		"# Default: /run/kukeon/kukeond.sock",
+		"# Default: /opt/kukeon",
+		"# Default: /run/containerd/containerd.sock",
+	} {
+		if !strings.Contains(rawStr, marker) {
+			t.Errorf("missing compile-time-default marker %q in rendered YAML", marker)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- The auto-generated `/etc/kukeon/kukeond.yaml` was a `const string` in `internal/serverconfig/serverconfig.go` with every spec field hardcoded (`socket: /run/kukeon/kukeond.sock`, `runPath: /opt/kukeon`, etc.). On first kukeond start, that exact string was written to disk regardless of how the daemon was actually launched — so `kukeond serve --run-path /tmp/A` wrote a YAML that lied about the bound socket and run-path. Subsequent `kuke init --run-path /tmp/B` invocations then read that lying file back via `applyServerConfiguration`, tripped the `viper.IsSet` gate in `applyRunPathImpliesKukeondSocket`, and silently bound the daemon to the leftover hardcoded socket — exactly the failure mode that surfaced in PR #575's per-test e2e harness CI run (issue #581).
- Convert `defaultDocument` to a `text/template` (parsed once at package init) and change the signature to `WriteDefault(path string, spec v1beta1.ServerConfigurationSpec)`. Each spec value is rendered into its YAML field with `printf "%q"` so the on-disk document records what the daemon actually started with. The header comments and per-field `# Default: …` lines are intentionally preserved verbatim — they document the binary's compile-time defaults for the operator, not the current effective values.
- Update kukeond's first-write call site (`maybeWriteServerConfigurationDefault`) to snapshot the post-flag, post-env viper state into a spec via a new `currentResolvedSpec()` helper and pass it to `WriteDefault`. The first-write path runs before `applyServerConfiguration` (which requires the YAML to exist), so viper holds exactly the resolved state we want to record.

### Picked option 1 (template-render at write time) over option 2 (drop the auto-write)

The issue body offered two reasonable shapes. I picked **option 1** because it fixes the bug without forfeiting the discoverability value of an auto-written commented template, and the diff is small (one template + one helper). Option 2 would have required either a new `kukeond config dump-default` subcommand or a checked-in `docs/server-config.yaml` reference to preserve that nicety — both larger surface changes. The reviewer can push back if they disagree.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — green (full project Go test target; includes new `TestWriteDefaultRendersResolvedSpec` regression guard in `internal/serverconfig` and new `TestCurrentResolvedSpecReflectsViper` in `cmd/kukeond`)
- [x] Pre-existing `TestWriteDefaultCreatesFileWithDefaults` and `TestWriteDefaultLeavesExistingFileUntouched` updated to pass a `canonicalDefaultsSpec()` matching the documented `# Default: …` markers
- [x] `make dev-init` — full smoke test green, daemon parity check matches required output verbatim:
  ```
  NAME         NAMESPACE              STATE  CGROUP
  -----------  ---------------------  -----  -------------------
  default      default.kukeon.io      Ready  /kukeon/default
  kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
  ```
- [x] Manually inspected `/etc/kukeon/kukeond.yaml` after `make dev-init` from inside a nested `kukeon-dev-root` cell — the dumped document now correctly shows `socket: "/run/kukeon-dev/kukeond.sock"` and `socketGID: 996` (the actual launched values), where before the fix it would have shown the hardcoded `/run/kukeon/kukeond.sock` and `0`. Header comments and `# Default: …` markers preserved.
- [x] `pre-commit run --files <changed>` — passed (go fmt, golangci-lint, addlicense, etc.)

Closes #581