### PR TITLE
refactor: promote applyRunPathImpliesKukeondSocket to root for symmetric --run-path → socket derivation

### DIFF
--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -211,37 +211,6 @@ func setPersistentFlags(_ *cobra.Command) error {
 	return nil
 }
 
-// applyRunPathImpliesKukeondSocket derives the daemon's listen socket as
-// `<runPath>/kukeond.sock` when the operator passed `--run-path` explicitly
-// (flag or KUKEON_RUN_PATH env) but did not pin KUKEOND_SOCKET themselves.
-// Without this, `kuke init --run-path X` always bootstraps the kukeond
-// system cell bind-bound to the default `/run/kukeon/kukeond.sock` — which
-// collides with the parent host's daemon when running inside a nested
-// `kukeon-dev-root` cell (PR #548 bind-mounts the parent's `/run/kukeon/`
-// into the nest at the same path), and blocks per-test isolation in the
-// e2e suite's TestKuke_Init_VerifyState.
-//
-// Operator intent: `--run-path` is per-invocation, explicit "this run
-// lives under X" signal. The daemon socket living under X follows; the
-// operator who genuinely wants the in-tree convention restores it with
-// `KUKEOND_SOCKET=/run/kukeon/kukeond.sock kuke init --run-path X`.
-//
-// ServerConfiguration's spec.Socket trips !viper.IsSet through
-// applyServerConfiguration's viper.Set, so YAML-configured socket paths
-// are respected. KUKEOND_SOCKET is registered via DefineKVNoViperDefault
-// (cmd/config/env.go) precisely so this IsSet check stays meaningful —
-// viper.SetDefault would trip IsSet even with no env/flag/YAML and
-// silently disable derivation.
-func applyRunPathImpliesKukeondSocket(cmd *cobra.Command, runPath string) {
-	if viper.IsSet(config.KUKEOND_SOCKET.ViperKey) {
-		return
-	}
-	if !flagChanged(cmd, "run-path") && !envSet(config.KUKEON_ROOT_RUN_PATH) {
-		return
-	}
-	viper.Set(config.KUKEOND_SOCKET.ViperKey, filepath.Join(runPath, "kukeond.sock"))
-}
-
 // flagChanged checks both the local and persistent flag sets so the helper
 // is correct in both unit tests (where cmd is built bare and persistent
 // flags are not yet merged into cmd.Flags()) and in production (where
@@ -424,11 +393,6 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	if runPath == "" {
 		runPath = config.DefaultRunPath()
 	}
-
-	// Must run after applyServerConfiguration (which may viper.Set the
-	// socket from YAML) and after runPath is resolved (the derived value
-	// is `<runPath>/kukeond.sock`).
-	applyRunPathImpliesKukeondSocket(cmd, runPath)
 
 	socketPath := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
 	if socketPath == "" {

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -91,14 +91,6 @@ func resolveKukeondImage() string
 //go:linkname applyServerConfiguration github.com/eminwux/kukeon/cmd/kuke/init.applyServerConfiguration
 func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurationSpec)
 
-//go:linkname applyRunPathImpliesKukeondSocket github.com/eminwux/kukeon/cmd/kuke/init.applyRunPathImpliesKukeondSocket
-func applyRunPathImpliesKukeondSocket(cmd *cobra.Command, runPath string)
-
-// ApplyRunPathImpliesKukeondSocket exposes the unexported helper for tests.
-func ApplyRunPathImpliesKukeondSocket(cmd *cobra.Command, runPath string) {
-	applyRunPathImpliesKukeondSocket(cmd, runPath)
-}
-
 // ResolveKukeondImage exposes the unexported helper for tests.
 func ResolveKukeondImage() string {
 	return resolveKukeondImage()
@@ -874,116 +866,6 @@ func TestApplyServerConfigurationEnvOverridesConfig(t *testing.T) {
 	// the env check is per-field, not all-or-nothing.
 	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "warn" {
 		t.Errorf("LogLevel: got %q, want %q", got, "warn")
-	}
-}
-
-// TestApplyRunPathImpliesKukeondSocket locks in the issue #557 contract:
-// `kuke init --run-path X` (or KUKEON_RUN_PATH=X env) auto-derives the
-// daemon socket to `<X>/kukeond.sock` when KUKEOND_SOCKET is not pinned,
-// unblocking nested e2e (TestKuke_Init_VerifyState) without colliding with
-// the parent dev cell's `/run/kukeon/kukeond.sock` plumbing.
-func TestApplyRunPathImpliesKukeondSocket(t *testing.T) {
-	testCases := []struct {
-		name             string
-		runPathFlag      bool
-		runPathEnv       bool
-		socketEnv        string
-		preSetSocket     string // simulates applyServerConfiguration spec.Socket
-		runPath          string
-		wantSocketChange bool
-		wantSocket       string
-	}{
-		{
-			name:             "explicit-flag-and-no-socket-env-derives",
-			runPathFlag:      true,
-			runPath:          "/tmp/init-557",
-			wantSocketChange: true,
-			wantSocket:       "/tmp/init-557/kukeond.sock",
-		},
-		{
-			name:             "env-run-path-and-no-socket-env-derives",
-			runPathEnv:       true,
-			runPath:          "/tmp/init-557-env",
-			wantSocketChange: true,
-			wantSocket:       "/tmp/init-557-env/kukeond.sock",
-		},
-		{
-			name:        "implicit-run-path-no-derivation",
-			runPath:     "/opt/kukeon",
-			socketEnv:   "",
-			runPathFlag: false,
-			// Viper is reset in setup; with no env, no flag-changed, and
-			// no pre-set, GetString returns empty — the helper must not
-			// override that.
-			wantSocket: "",
-		},
-		{
-			name:        "explicit-flag-but-socket-env-pinned-respects-env",
-			runPathFlag: true,
-			runPath:     "/tmp/init-557",
-			socketEnv:   "/run/kukeon/operator.sock",
-			wantSocket:  "/run/kukeon/operator.sock",
-		},
-		{
-			name:         "explicit-flag-but-server-config-pinned-respects-yaml",
-			runPathFlag:  true,
-			runPath:      "/tmp/init-557",
-			preSetSocket: "/run/kukeon/from-yaml.sock",
-			wantSocket:   "/run/kukeon/from-yaml.sock",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Cleanup(viper.Reset)
-			viper.Reset()
-
-			if tc.socketEnv != "" {
-				t.Setenv(config.KUKEOND_SOCKET.EnvVar(), tc.socketEnv)
-			}
-			if tc.runPathEnv {
-				t.Setenv(config.KUKEON_ROOT_RUN_PATH.EnvVar(), tc.runPath)
-			}
-
-			// Mirror production wiring: kuke.LoadConfig binds env keys.
-			if err := kuke.LoadConfig(); err != nil {
-				t.Fatalf("kuke.LoadConfig: %v", err)
-			}
-			cmd := initpkg.NewInitCmd()
-			if cmd == nil {
-				t.Fatal("NewInitCmd() returned nil")
-			}
-
-			// Re-register the persistent --run-path flag the root CLI
-			// adds, since NewInitCmd is built bare in this unit test.
-			cmd.PersistentFlags().String("run-path", "/opt/kukeon", "run path")
-			if err := viper.BindPFlag(
-				config.KUKEON_ROOT_RUN_PATH.ViperKey,
-				cmd.PersistentFlags().Lookup("run-path"),
-			); err != nil {
-				t.Fatalf("BindPFlag run-path: %v", err)
-			}
-
-			if tc.runPathFlag {
-				if err := cmd.PersistentFlags().Set("run-path", tc.runPath); err != nil {
-					t.Fatalf("flag set: %v", err)
-				}
-			}
-
-			if tc.preSetSocket != "" {
-				// Stand-in for applyServerConfiguration's viper.Set when
-				// ServerConfiguration's spec.Socket is non-empty and env
-				// is unset.
-				viper.Set(config.KUKEOND_SOCKET.ViperKey, tc.preSetSocket)
-			}
-
-			ApplyRunPathImpliesKukeondSocket(cmd, tc.runPath)
-
-			got := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
-			if got != tc.wantSocket {
-				t.Errorf("socket: got %q, want %q", got, tc.wantSocket)
-			}
-		})
 	}
 }
 

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	applycmd "github.com/eminwux/kukeon/cmd/kuke/apply"
@@ -115,6 +116,7 @@ func NewKukeCmd() (*cobra.Command, error) {
 
 			rebindNoDaemonViperToLeaf(cmd)
 			applyRunPathImpliesNoDaemon(cmd)
+			applyRunPathImpliesKukeondSocket(cmd)
 			return nil
 		},
 		Run: func(cmd *cobra.Command, _ []string) {
@@ -388,6 +390,39 @@ func applyRunPathImpliesNoDaemon(cmd *cobra.Command) {
 	if runPathExplicit && !noDaemonExplicit {
 		viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, true)
 	}
+}
+
+// applyRunPathImpliesKukeondSocket derives the daemon's listen socket as
+// `<runPath>/kukeond.sock` when the operator passed `--run-path` explicitly
+// (flag or KUKEON_RUN_PATH env) but did not pin KUKEOND_SOCKET themselves.
+// Promoted to root-PersistentPreRunE per #570 so non-init verbs that also
+// resolve the socket (notably `kuke daemon reset`, plus the other daemon
+// lifecycle verbs and any caller dialing kukeond) honor the same
+// `--run-path → <X>/kukeond.sock` contract `kuke init` does — without this,
+// `kuke init --run-path X` lays the socket under X but `kuke daemon reset
+// --run-path X` cleans the default `/run/kukeon/`, an operator footgun for
+// custom run-paths outside `t.TempDir()`.
+//
+// Init's `applyServerConfiguration` still wins for `spec.Socket` (it runs
+// later inside runInit and unconditionally viper.Set's when env is unset),
+// so YAML-configured socket paths remain authoritative for `kuke init`.
+//
+// KUKEOND_SOCKET is registered via DefineKVNoViperDefault (cmd/config/env.go)
+// precisely so this viper.IsSet check stays meaningful — viper.SetDefault
+// would trip IsSet even with no env/flag/YAML and silently disable
+// derivation.
+func applyRunPathImpliesKukeondSocket(cmd *cobra.Command) {
+	if viper.IsSet(config.KUKEOND_SOCKET.ViperKey) {
+		return
+	}
+	if !flagChanged(cmd, "run-path") && !envSet(config.KUKEON_ROOT_RUN_PATH) {
+		return
+	}
+	runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
+	if runPath == "" {
+		runPath = config.DefaultRunPath()
+	}
+	viper.Set(config.KUKEOND_SOCKET.ViperKey, filepath.Join(runPath, "kukeond.sock"))
 }
 
 // flagChanged checks both the local and persistent flag sets so the helper

--- a/cmd/kuke/kuke_test.go
+++ b/cmd/kuke/kuke_test.go
@@ -570,3 +570,113 @@ func TestRunPathImpliesNoDaemon(t *testing.T) {
 		})
 	}
 }
+
+// TestRunPathImpliesKukeondSocket locks down the issue #570 fix: explicit
+// `--run-path` (flag or env) auto-derives KUKEOND_SOCKET = `<X>/kukeond.sock`
+// for every kuke subcommand, not just `kuke init` (#569). Without this,
+// `kuke daemon reset --run-path X` still cleans the default `/run/kukeon/`
+// while `kuke init --run-path X` lays the socket under X — the asymmetry
+// the source PR #569 flagged in its reviewer notes.
+//
+// The daemon-reset leaf is the canonical regression target; the init leaf
+// case re-verifies the same root promotion still satisfies init's
+// pre-#570 contract (init.go no longer calls the helper itself).
+func TestRunPathImpliesKukeondSocket(t *testing.T) {
+	tests := []struct {
+		name        string
+		leafArgs    []string
+		setFlag     bool   // --run-path on the command line
+		setEnv      string // KUKEON_RUN_PATH in env ("" = unset)
+		setSocket   string // KUKEOND_SOCKET in env ("" = unset)
+		preSet      string // pre-PreRunE viper.Set on KUKEOND_SOCKET ("" = skip)
+		wantSocket  string // empty string asserts viper key remains unset
+		wantNonZero bool   // for default-path cases, just assert non-empty
+	}{
+		{
+			name:       "no-flag-no-env-no-derivation",
+			leafArgs:   []string{"daemon", "reset"},
+			wantSocket: "",
+		},
+		{
+			name:       "run-path-flag-derives-on-reset",
+			leafArgs:   []string{"daemon", "reset"},
+			setFlag:    true,
+			wantSocket: "/tmp/issue-570/kukeond.sock",
+		},
+		{
+			name:       "run-path-env-derives-on-reset",
+			leafArgs:   []string{"daemon", "reset"},
+			setEnv:     "/tmp/issue-570-env",
+			wantSocket: "/tmp/issue-570-env/kukeond.sock",
+		},
+		{
+			name:       "run-path-flag-derives-on-init",
+			leafArgs:   []string{"init"},
+			setFlag:    true,
+			wantSocket: "/tmp/issue-570/kukeond.sock",
+		},
+		{
+			name:       "kukeond-socket-env-pinned-respects-env",
+			leafArgs:   []string{"daemon", "reset"},
+			setFlag:    true,
+			setSocket:  "/run/kukeon/operator.sock",
+			wantSocket: "/run/kukeon/operator.sock",
+		},
+		{
+			name:       "pre-set-viper-respects-existing-pin",
+			leafArgs:   []string{"daemon", "reset"},
+			setFlag:    true,
+			preSet:     "/run/kukeon/from-yaml.sock",
+			wantSocket: "/run/kukeon/from-yaml.sock",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			viper.Reset()
+
+			if tc.setEnv != "" {
+				t.Setenv(config.KUKEON_ROOT_RUN_PATH.EnvVar(), tc.setEnv)
+			}
+			if tc.setSocket != "" {
+				t.Setenv(config.KUKEOND_SOCKET.EnvVar(), tc.setSocket)
+			}
+
+			cmd, err := kuke.NewKukeCmd()
+			if err != nil {
+				t.Fatalf("NewKukeCmd() error = %v", err)
+			}
+
+			leaf, _, findErr := cmd.Find(tc.leafArgs)
+			if findErr != nil {
+				t.Fatalf("find %v subcommand: %v", tc.leafArgs, findErr)
+			}
+			if parseErr := leaf.ParseFlags(nil); parseErr != nil {
+				t.Fatalf("parse leaf flags: %v", parseErr)
+			}
+
+			if tc.setFlag {
+				if setErr := leaf.Flags().Set("run-path", "/tmp/issue-570"); setErr != nil {
+					t.Fatalf("set --run-path on leaf: %v", setErr)
+				}
+			}
+			if tc.preSet != "" {
+				// Stand-in for a pre-derivation pin (env binding's
+				// viper.Set on read, or a future caller that pre-pins
+				// the socket from YAML before the root PreRunE runs).
+				viper.Set(config.KUKEOND_SOCKET.ViperKey, tc.preSet)
+			}
+
+			leaf.SetContext(context.Background())
+			if preErr := cmd.PersistentPreRunE(leaf, []string{}); preErr != nil {
+				t.Fatalf("PersistentPreRunE: %v", preErr)
+			}
+
+			got := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
+			if got != tc.wantSocket {
+				t.Errorf("KUKEOND_SOCKET: got %q, want %q", got, tc.wantSocket)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Promote `applyRunPathImpliesKukeondSocket` from `cmd/kuke/init/init.go` to root `cmd/kuke/kuke.go` and call it from `PersistentPreRunE` (right next to the sibling `applyRunPathImpliesNoDaemon`). Every kuke subcommand — `kuke daemon reset` foremost, plus the rest of the daemon lifecycle verbs and any caller dialing kukeond — now inherits the `--run-path X → KUKEOND_SOCKET=<X>/kukeond.sock` derivation that `kuke init` got in #569. Closes the operator footgun the source PR called out: `kuke init --run-path X` laid the socket under X, but `kuke daemon reset --run-path X` cleaned the default `/run/kukeon/` unless `KUKEOND_SOCKET` was also exported.
- `cmd/kuke/init/init.go`'s previous `runInit`-time call to the helper is now redundant and removed (the root PreRunE already set viper). `init`'s YAML-wins contract is preserved: `applyServerConfiguration` still runs later inside `runInit` and unconditionally `viper.Set`s `KUKEOND_SOCKET` from `spec.Socket` when no env pin exists.
- Precedence guards unchanged: derivation skips when `viper.IsSet(KUKEOND_SOCKET)` is true (env pin or any prior `viper.Set`) and when neither `--run-path` flag nor `KUKEON_RUN_PATH` env is explicit (YAML run-path stays ambient, never trips the implication — mirrors `applyRunPathImpliesNoDaemon`).
- Tests: removed `TestApplyRunPathImpliesKukeondSocket` from `cmd/kuke/init/init_test.go` (the function is no longer in the init package) plus its `//go:linkname` shim. Added `TestRunPathImpliesKukeondSocket` to `cmd/kuke/kuke_test.go`, mirroring the structure of the sibling `TestRunPathImpliesNoDaemon`: six cases exercising both the `daemon reset` leaf (the actual regression target) and the `init` leaf (re-verifies the post-#570 contract still satisfies init), covering flag, env, no-flag-no-env-no-derivation, env-pinned-respects-env, and pre-set-respects-existing-pin.

Implements the exact extension PR #569's reviewer notes offered ("Happy to extend to a `cmd/kuke/kuke.go`-level promotion (like `applyRunPathImpliesNoDaemon`) if you'd prefer the symmetric contract").

## Test plan

- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test ./cmd/kuke/... -run TestRunPathImpliesKukeondSocket -v` — all six cases pass.
- [x] `make test` — full unit suite, all packages pass.
- [x] `make dev-init` — daemon-parity check (the regression guard CLAUDE.md mandates for any daemon-reading change) succeeds inside this nested `kukeon-dev-root` cell. Daemon brings up at `/run/kukeon-dev/kukeond.sock` as before (this run's KUKEOND_SOCKET is exported by `dev-init.sh`, so the derivation deliberately stays inert in that path); `kuke get realms` and `kuke get realms --no-daemon` produce the identical realm/namespace/cgroup tail mandated by `CLAUDE.md`. Attach smoke and nested post-flight succeed.
- [x] `pre-commit run --files cmd/kuke/init/init.go cmd/kuke/init/init_test.go cmd/kuke/kuke.go cmd/kuke/kuke_test.go` — all hooks pass (fmt, mod-tidy, golangci-lint, addlicense).

Closes #570