### PR TITLE
refactor(daemon): extract internal/lifecycle for shared verb helpers + errdefs sentinels

### DIFF
--- a/cmd/kuke/daemon/internal/lifecycle/lifecycle.go
+++ b/cmd/kuke/daemon/internal/lifecycle/lifecycle.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package lifecycle holds the scaffolding shared by the `kuke daemon`
+// lifecycle verbs (start, stop, kill, restart, reset, logs). Each verb used
+// to maintain its own near-identical copy of these helpers; centralising
+// them prevents silent drift of the "running" definition, the
+// SIGTERM → SIGKILL grace period, and the test-injection key.
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+)
+
+// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
+// context so unit tests can drive the daemon-lifecycle verbs without a real
+// controller. The key lives in this package so every verb's resolveClient
+// agrees on a single context-value identity, and the type stays off each
+// verb's production surface.
+type MockClientKey struct{}
+
+// DefaultTimeout is the SIGTERM grace period before SIGKILL escalation,
+// shared by `kuke daemon stop`/`restart`/`reset`. Centralised so the three
+// verbs cannot drift on what "graceful" means.
+const DefaultTimeout = 10 * time.Second
+
+// IsCellRunning treats the cell as live if any container reports Ready, or
+// if the persisted cell state is Ready. Every `kuke daemon` lifecycle verb
+// uses this to agree on what "running" means; the controller's StartCell
+// path uses the same definition so the in-process and stateful views stay
+// aligned even when external crashes leave the persisted state stale.
+func IsCellRunning(cell v1beta1.CellDoc) bool {
+	for _, c := range cell.Status.Containers {
+		if c.State == v1beta1.ContainerStateReady {
+			return true
+		}
+	}
+	return cell.Status.State == v1beta1.CellStateReady
+}
+
+// StopPhase runs the graceful StopCell → SIGKILL escalation used by
+// `kuke daemon stop`/`restart`/`reset`. The inner StopCell call runs in a
+// goroutine under a context derived from `cmd.Context()` via
+// context.WithCancel; on timeout, the derived context is cancelled before
+// KillCell is invoked so the orphan StopCell observes the cancellation
+// instead of continuing against an unmodified parent context. KillCell uses
+// the original `cmd.Context()` so the escalation itself is not affected by
+// the stop cancellation.
+func StopPhase(
+	cmd *cobra.Command,
+	client kukeonv1.Client,
+	doc v1beta1.CellDoc,
+	timeout time.Duration,
+) error {
+	stopCtx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	type stopOutcome struct {
+		res kukeonv1.StopCellResult
+		err error
+	}
+	done := make(chan stopOutcome, 1)
+	go func() {
+		res, sErr := client.StopCell(stopCtx, doc)
+		done <- stopOutcome{res: res, err: sErr}
+	}()
+
+	select {
+	case out := <-done:
+		if out.err != nil {
+			return fmt.Errorf("stop kukeond cell: %w", out.err)
+		}
+		if !out.res.Stopped {
+			return fmt.Errorf("stop kukeond cell: %w", errdefs.ErrControllerNoChange)
+		}
+		cmd.Printf(
+			"kukeond stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	case <-time.After(timeout):
+		cancel()
+		killRes, killErr := client.KillCell(cmd.Context(), doc)
+		if killErr != nil {
+			return fmt.Errorf(
+				"kill kukeond cell after %s grace period expired: %w",
+				timeout, killErr,
+			)
+		}
+		if !killRes.Killed {
+			return fmt.Errorf("kill kukeond cell: %w", errdefs.ErrControllerNoChange)
+		}
+		cmd.Printf(
+			"kukeond force-killed after %s grace period expired (cell %q in realm %q)\n",
+			timeout, consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+		return nil
+	}
+}

--- a/cmd/kuke/daemon/internal/lifecycle/lifecycle_test.go
+++ b/cmd/kuke/daemon/internal/lifecycle/lifecycle_test.go
@@ -1,0 +1,273 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package lifecycle_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+)
+
+func TestIsCellRunning(t *testing.T) {
+	cases := []struct {
+		name string
+		cell v1beta1.CellDoc
+		want bool
+	}{
+		{
+			name: "container ready means running even when cell state lags",
+			cell: v1beta1.CellDoc{Status: v1beta1.CellStatus{
+				State: v1beta1.CellStateStopped,
+				Containers: []v1beta1.ContainerStatus{
+					{State: v1beta1.ContainerStateReady},
+				},
+			}},
+			want: true,
+		},
+		{
+			name: "cell state ready means running even with no containers",
+			cell: v1beta1.CellDoc{Status: v1beta1.CellStatus{State: v1beta1.CellStateReady}},
+			want: true,
+		},
+		{
+			name: "stopped cell with no containers is not running",
+			cell: v1beta1.CellDoc{Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped}},
+			want: false,
+		},
+		{
+			name: "stopped cell with stopped containers is not running",
+			cell: v1beta1.CellDoc{Status: v1beta1.CellStatus{
+				State: v1beta1.CellStateStopped,
+				Containers: []v1beta1.ContainerStatus{
+					{State: v1beta1.ContainerStateStopped},
+				},
+			}},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lifecycle.IsCellRunning(tc.cell); got != tc.want {
+				t.Fatalf("IsCellRunning: want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestStopPhase_GracefulSuccess(t *testing.T) {
+	fc := &fakeClient{
+		stopCellFn: func(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(_ context.Context, _ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			t.Fatal("KillCell must not run when StopCell succeeds within the grace period")
+			return kukeonv1.KillCellResult{}, nil
+		},
+	}
+	cmd := newCmdWithContext(context.Background(), t)
+	if err := lifecycle.StopPhase(cmd, fc, v1beta1.CellDoc{}, time.Second); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStopPhase_GracefulNoChangeWrapsSentinel(t *testing.T) {
+	fc := &fakeClient{
+		stopCellFn: func(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: false}, nil
+		},
+	}
+	cmd := newCmdWithContext(context.Background(), t)
+	err := lifecycle.StopPhase(cmd, fc, v1beta1.CellDoc{}, time.Second)
+	if err == nil {
+		t.Fatal("want error from StopPhase no-change path, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrControllerNoChange) {
+		t.Fatalf("want errors.Is(..., ErrControllerNoChange) true, got err=%v", err)
+	}
+	if !strings.Contains(err.Error(), "stop kukeond cell:") {
+		t.Fatalf("want wrap prefix \"stop kukeond cell:\", got %q", err.Error())
+	}
+}
+
+func TestStopPhase_TimeoutEscalatesAndCancelsOrphan(t *testing.T) {
+	// The fix verified here: when StopPhase's grace period expires, the
+	// derived stopCtx is cancelled *before* KillCell runs. The in-flight
+	// StopCell goroutine therefore sees ctx.Done() instead of continuing
+	// against an unmodified parent context.
+	stopReturned := make(chan struct{})
+	seen := &ctxCapture{}
+	killCalled := atomicBool{}
+	fc := &fakeClient{
+		stopCellFn: func(ctx context.Context, _ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			<-ctx.Done()
+			seen.set(ctx)
+			close(stopReturned)
+			return kukeonv1.StopCellResult{}, ctx.Err()
+		},
+		killCellFn: func(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			killCalled.Store(true)
+			// Wait for the StopCell goroutine to observe cancellation so the
+			// race between cancel + KillCell is deterministic in the test.
+			select {
+			case <-stopReturned:
+			case <-time.After(time.Second):
+				t.Fatal("StopCell did not observe ctx cancellation before KillCell returned")
+			}
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+	}
+	cmd := newCmdWithContext(context.Background(), t)
+	if err := lifecycle.StopPhase(cmd, fc, v1beta1.CellDoc{}, 20*time.Millisecond); err != nil {
+		t.Fatalf("unexpected error from timeout-escalation path: %v", err)
+	}
+	if !killCalled.Load() {
+		t.Fatal("KillCell must run after the grace period expires")
+	}
+	got := seen.get()
+	if got == nil || got.Err() == nil {
+		t.Fatal("StopCell goroutine must have seen ctx cancellation before returning")
+	}
+}
+
+func TestStopPhase_KillNoChangeWrapsSentinel(t *testing.T) {
+	fc := &fakeClient{
+		stopCellFn: func(ctx context.Context, _ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			<-ctx.Done()
+			return kukeonv1.StopCellResult{}, ctx.Err()
+		},
+		killCellFn: func(_ context.Context, _ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{Killed: false}, nil
+		},
+	}
+	cmd := newCmdWithContext(context.Background(), t)
+	err := lifecycle.StopPhase(cmd, fc, v1beta1.CellDoc{}, 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("want error from KillCell no-change path, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrControllerNoChange) {
+		t.Fatalf("want errors.Is(..., ErrControllerNoChange) true, got err=%v", err)
+	}
+	if !strings.Contains(err.Error(), "kill kukeond cell:") {
+		t.Fatalf("want wrap prefix \"kill kukeond cell:\", got %q", err.Error())
+	}
+}
+
+// TestErrHostNotInitialized_IsBoundary proves errors.Is identity survives
+// the verb-callsite wrap pattern. The hoisted sentinel must compare equal
+// when returned bare *and* when wrapped via fmt.Errorf("...: %w", err) — the
+// shape every `kuke daemon` read/write verb uses for "host not initialized.".
+func TestErrHostNotInitialized_IsBoundary(t *testing.T) {
+	bare := errdefs.ErrHostNotInitialized
+	if !errors.Is(bare, errdefs.ErrHostNotInitialized) {
+		t.Fatal("bare sentinel must satisfy errors.Is identity")
+	}
+	wrapped := fmt.Errorf("inspect kukeond cell: %w", errdefs.ErrHostNotInitialized)
+	if !errors.Is(wrapped, errdefs.ErrHostNotInitialized) {
+		t.Fatalf("wrapped sentinel must satisfy errors.Is identity; got %v", wrapped)
+	}
+}
+
+// TestErrControllerNoChange_IsBoundary proves errors.Is identity survives
+// the canonical wrap pattern callers use ("<verb> kukeond cell: %w"). The
+// lifecycle StopPhase helper and every verb that handles a !Started /
+// !Stopped / !Killed / !MetadataDeleted result must produce errors that
+// match this sentinel.
+func TestErrControllerNoChange_IsBoundary(t *testing.T) {
+	wrapped := fmt.Errorf("stop kukeond cell: %w", errdefs.ErrControllerNoChange)
+	if !errors.Is(wrapped, errdefs.ErrControllerNoChange) {
+		t.Fatalf("wrapped sentinel must satisfy errors.Is identity; got %v", wrapped)
+	}
+	doubleWrapped := fmt.Errorf("orchestrator: %w", wrapped)
+	if !errors.Is(doubleWrapped, errdefs.ErrControllerNoChange) {
+		t.Fatalf("double-wrapped sentinel must satisfy errors.Is identity; got %v", doubleWrapped)
+	}
+}
+
+func newCmdWithContext(ctx context.Context, t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetContext(ctx)
+	return cmd
+}
+
+type ctxCapture struct {
+	mu  sync.Mutex
+	ctx context.Context //nolint:containedctx // test fake; captures cancelled ctx for assertion
+}
+
+func (c *ctxCapture) set(ctx context.Context) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ctx = ctx
+}
+
+func (c *ctxCapture) get() context.Context {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ctx
+}
+
+type atomicBool struct {
+	mu sync.Mutex
+	v  bool
+}
+
+func (a *atomicBool) Store(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.v = v
+}
+
+func (a *atomicBool) Load() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.v
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	stopCellFn func(context.Context, v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
+	killCellFn func(context.Context, v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
+}
+
+func (f *fakeClient) StopCell(ctx context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+	if f.stopCellFn == nil {
+		return kukeonv1.StopCellResult{}, errors.New("unexpected StopCell call")
+	}
+	return f.stopCellFn(ctx, doc)
+}
+
+func (f *fakeClient) KillCell(ctx context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+	if f.killCellFn == nil {
+		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
+	}
+	return f.killCellFn(ctx, doc)
+}

--- a/cmd/kuke/daemon/kill/kill.go
+++ b/cmd/kuke/daemon/kill/kill.go
@@ -20,11 +20,11 @@
 package kill
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
@@ -36,10 +36,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
-// context so unit tests can exercise runKill without a real controller.
-type MockClientKey struct{}
 
 // NewKillCmd builds the `kuke daemon kill` cobra command.
 func NewKillCmd() *cobra.Command {
@@ -79,10 +75,10 @@ func runKill(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("inspect kukeond cell: %w", err)
 	}
 	if !getRes.MetadataExists {
-		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
+		return errdefs.ErrHostNotInitialized
 	}
 
-	if !isCellRunning(getRes.Cell) {
+	if !lifecycle.IsCellRunning(getRes.Cell) {
 		cmd.Printf(
 			"kukeond is already stopped (cell %q in realm %q)\n",
 			consts.KukeSystemCellName, consts.KukeSystemRealmName,
@@ -95,7 +91,7 @@ func runKill(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("kill kukeond cell: %w", err)
 	}
 	if !killRes.Killed {
-		return errors.New("kill kukeond cell: controller reported no change")
+		return fmt.Errorf("kill kukeond cell: %w", errdefs.ErrControllerNoChange)
 	}
 
 	cmd.Printf(
@@ -124,24 +120,12 @@ func kukeondCellDoc() v1beta1.CellDoc {
 	}
 }
 
-// isCellRunning treats the cell as live if any container reports Ready, or if
-// the persisted cell state is Ready. Mirrors the check in `kuke daemon start`
-// and `kuke daemon stop` so all three verbs agree on what "running" means.
-func isCellRunning(cell v1beta1.CellDoc) bool {
-	for _, c := range cell.Status.Containers {
-		if c.State == v1beta1.ContainerStateReady {
-			return true
-		}
-	}
-	return cell.Status.State == v1beta1.CellStateReady
-}
-
 // resolveClient returns the kukeonv1.Client used by runKill. Tests inject a
-// fake via MockClientKey; production always builds an in-process client —
-// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
-// through the daemon is impossible by definition.
+// fake via lifecycle.MockClientKey; production always builds an in-process
+// client — `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so
+// routing through the daemon is impossible by definition.
 func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
-	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+	if mockClient, ok := cmd.Context().Value(lifecycle.MockClientKey{}).(kukeonv1.Client); ok {
 		return mockClient
 	}
 	opts := controller.Options{

--- a/cmd/kuke/daemon/kill/kill_test.go
+++ b/cmd/kuke/daemon/kill/kill_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	kill "github.com/eminwux/kukeon/cmd/kuke/daemon/kill"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -167,7 +168,7 @@ func TestDaemonKill(t *testing.T) {
 			cmd.SetErr(buf)
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-			ctx = context.WithValue(ctx, kill.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
 			cmd.SetContext(ctx)
 			cmd.SetArgs(nil)
 

--- a/cmd/kuke/daemon/logs/logs.go
+++ b/cmd/kuke/daemon/logs/logs.go
@@ -33,6 +33,7 @@ import (
 	"os"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	logcmd "github.com/eminwux/kukeon/cmd/kuke/log"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -45,10 +46,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
-// context so unit tests can exercise runLogs without a real controller.
-type MockClientKey struct{}
 
 // MockTailKey injects a logcmd.TailFn via context for tests so the real
 // follow loop (which would block on a real file) can be bypassed.
@@ -99,11 +96,9 @@ func runLogs(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("inspect kukeond cell: %w", err)
 	}
 	if !getRes.MetadataExists {
-		return errors.New(
-			"kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first",
-		)
+		return errdefs.ErrHostNotInitialized
 	}
-	if !isCellRunning(getRes.Cell) {
+	if !lifecycle.IsCellRunning(getRes.Cell) {
 		return fmt.Errorf(
 			"kukeond is not running (cell %q in realm %q); run `kuke daemon start` to bring it up "+
 				"(or `kuke status` to inspect)",
@@ -184,25 +179,12 @@ func kukeondContainerDoc() v1beta1.ContainerDoc {
 	}
 }
 
-// isCellRunning treats the cell as live if any container reports Ready, or
-// if the persisted cell state is Ready. Same definition the other daemon
-// lifecycle verbs use, so "not running" means the same thing across the
-// `kuke daemon` subcommand group.
-func isCellRunning(cell v1beta1.CellDoc) bool {
-	for _, c := range cell.Status.Containers {
-		if c.State == v1beta1.ContainerStateReady {
-			return true
-		}
-	}
-	return cell.Status.State == v1beta1.CellStateReady
-}
-
 // resolveClient returns the kukeonv1.Client used by runLogs. Tests inject a
-// fake via MockClientKey; production always builds an in-process client —
-// `kuke daemon logs` is part of the daemon-lifecycle umbrella, so it must
-// work even when the daemon socket is not reachable.
+// fake via lifecycle.MockClientKey; production always builds an in-process
+// client — `kuke daemon logs` is part of the daemon-lifecycle umbrella, so
+// it must work even when the daemon socket is not reachable.
 func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
-	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+	if mockClient, ok := cmd.Context().Value(lifecycle.MockClientKey{}).(kukeonv1.Client); ok {
 		return mockClient
 	}
 	opts := controller.Options{

--- a/cmd/kuke/daemon/logs/logs_test.go
+++ b/cmd/kuke/daemon/logs/logs_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	logscmd "github.com/eminwux/kukeon/cmd/kuke/daemon/logs"
 	logcmd "github.com/eminwux/kukeon/cmd/kuke/log"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
@@ -111,7 +112,7 @@ func newCmd(t *testing.T, fc *fakeClient, tail *tailCapture) (*cobra.Command, *b
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 	if fc != nil {
-		ctx = context.WithValue(ctx, logscmd.MockClientKey{}, kukeonv1.Client(fc))
+		ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fc))
 	}
 	if tail != nil {
 		ctx = context.WithValue(ctx, logscmd.MockTailKey{}, logcmd.TailFn(tail.fn))

--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -25,14 +25,13 @@
 package reset
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
@@ -46,10 +45,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
-// context so unit tests can exercise runReset without a real controller.
-type MockClientKey struct{}
-
 // MockSocketDirKey overrides the directory containing kukeond.{sock,pid}.
 // Tests use this to point the cleanup step at a tmpdir; production reads the
 // path from KUKEOND_SOCKET viper config.
@@ -59,10 +54,6 @@ type MockSocketDirKey struct{}
 // /opt/kukeon/kuke-system from. Tests use this to point at a tmpdir so the
 // cleanup never touches the real /opt/kukeon.
 type MockRunPathKey struct{}
-
-// defaultTimeout matches `kuke daemon stop`'s grace period (#219) so the two
-// verbs agree on how long the SIGTERM phase gets before SIGKILL escalates.
-const defaultTimeout = 10 * time.Second
 
 // NewResetCmd builds the `kuke daemon reset` cobra command.
 func NewResetCmd() *cobra.Command {
@@ -86,7 +77,7 @@ func NewResetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Duration(
-		"timeout", defaultTimeout,
+		"timeout", lifecycle.DefaultTimeout,
 		"Grace period for the stop phase before escalating from SIGTERM to SIGKILL",
 	)
 	_ = viper.BindPFlag(config.KUKE_DAEMON_RESET_TIMEOUT.ViperKey, cmd.Flags().Lookup("timeout"))
@@ -112,7 +103,7 @@ func runReset(cmd *cobra.Command, _ []string) error {
 
 	timeout := viper.GetDuration(config.KUKE_DAEMON_RESET_TIMEOUT.ViperKey)
 	if timeout <= 0 {
-		timeout = defaultTimeout
+		timeout = lifecycle.DefaultTimeout
 	}
 	purgeSystem := viper.GetBool(config.KUKE_DAEMON_RESET_PURGE_SYSTEM.ViperKey)
 
@@ -126,8 +117,8 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("inspect kukeond cell: %w", err)
 	}
 	if getRes.MetadataExists {
-		if isCellRunning(getRes.Cell) {
-			if stopErr := stopPhase(cmd, client, doc, timeout); stopErr != nil {
+		if lifecycle.IsCellRunning(getRes.Cell) {
+			if stopErr := lifecycle.StopPhase(cmd, client, doc, timeout); stopErr != nil {
 				return stopErr
 			}
 		} else {
@@ -142,7 +133,7 @@ func runReset(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("delete kukeond cell: %w", err)
 		}
 		if !delRes.MetadataDeleted {
-			return errors.New("delete kukeond cell: controller reported no change")
+			return fmt.Errorf("delete kukeond cell: %w", errdefs.ErrControllerNoChange)
 		}
 		cmd.Printf(
 			"kukeond cell deleted (cell %q in realm %q)\n",
@@ -205,58 +196,6 @@ func runReset(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// stopPhase mirrors `kuke daemon stop`: graceful StopCell with SIGTERM →
-// SIGKILL escalation when the grace period expires. Duplicated here rather
-// than imported from the stop package to keep each daemon-lifecycle verb
-// self-contained — start/stop/kill/restart follow the same convention.
-func stopPhase(
-	cmd *cobra.Command,
-	client kukeonv1.Client,
-	doc v1beta1.CellDoc,
-	timeout time.Duration,
-) error {
-	type stopOutcome struct {
-		res kukeonv1.StopCellResult
-		err error
-	}
-	done := make(chan stopOutcome, 1)
-	go func() {
-		res, sErr := client.StopCell(cmd.Context(), doc)
-		done <- stopOutcome{res: res, err: sErr}
-	}()
-
-	select {
-	case out := <-done:
-		if out.err != nil {
-			return fmt.Errorf("stop kukeond cell: %w", out.err)
-		}
-		if !out.res.Stopped {
-			return errors.New("stop kukeond cell: controller reported no change")
-		}
-		cmd.Printf(
-			"kukeond stopped (cell %q in realm %q)\n",
-			consts.KukeSystemCellName, consts.KukeSystemRealmName,
-		)
-		return nil
-	case <-time.After(timeout):
-		killRes, killErr := client.KillCell(cmd.Context(), doc)
-		if killErr != nil {
-			return fmt.Errorf(
-				"kill kukeond cell after %s grace period expired: %w",
-				timeout, killErr,
-			)
-		}
-		if !killRes.Killed {
-			return errors.New("kill kukeond cell: controller reported no change")
-		}
-		cmd.Printf(
-			"kukeond force-killed after %s grace period expired (cell %q in realm %q)\n",
-			timeout, consts.KukeSystemCellName, consts.KukeSystemRealmName,
-		)
-		return nil
-	}
-}
-
 // removeFileIfExists removes a single file. Missing-file is a no-op so a
 // re-run of `kuke daemon reset` on a clean tree does not error.
 func removeFileIfExists(path string) (bool, error) {
@@ -305,24 +244,12 @@ func kukeondCellDoc() v1beta1.CellDoc {
 	}
 }
 
-// isCellRunning treats the cell as live if any container reports Ready, or if
-// the persisted cell state is Ready. Mirrors the check used by all other
-// daemon-lifecycle verbs so they agree on what "running" means.
-func isCellRunning(cell v1beta1.CellDoc) bool {
-	for _, c := range cell.Status.Containers {
-		if c.State == v1beta1.ContainerStateReady {
-			return true
-		}
-	}
-	return cell.Status.State == v1beta1.CellStateReady
-}
-
 // resolveClient returns the kukeonv1.Client used by runReset. Tests inject a
-// fake via MockClientKey; production always builds an in-process client —
-// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
-// through the daemon is impossible by definition.
+// fake via lifecycle.MockClientKey; production always builds an in-process
+// client — `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so
+// routing through the daemon is impossible by definition.
 func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
-	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+	if mockClient, ok := cmd.Context().Value(lifecycle.MockClientKey{}).(kukeonv1.Client); ok {
 		return mockClient
 	}
 	opts := controller.Options{

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	reset "github.com/eminwux/kukeon/cmd/kuke/daemon/reset"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -247,7 +248,7 @@ func TestDaemonReset(t *testing.T) {
 			cmd.SetErr(buf)
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-			ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
 			ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
 			ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
 			cmd.SetContext(ctx)
@@ -321,7 +322,7 @@ func TestDaemonReset_RemovesSocketAndPidFiles(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, socketDir)
 	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
 	cmd.SetContext(ctx)
@@ -368,7 +369,7 @@ func TestDaemonReset_MissingSockAndPidIsNoOp(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
 	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
 	cmd.SetContext(ctx)
@@ -426,7 +427,7 @@ func TestDaemonReset_PreservesDefaultRealm(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
 	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
 	cmd.SetContext(ctx)
@@ -474,7 +475,7 @@ func TestDaemonReset_PurgeSystemAfterTeardown(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
 	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
 	cmd.SetContext(ctx)
@@ -512,7 +513,7 @@ func TestDaemonReset_PurgeSystemAfterTeardownNoSystemDir(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
 	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
 	cmd.SetContext(ctx)
@@ -563,7 +564,7 @@ func TestDaemonReset_NoPurgeSystemKeepsKukeSystem(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
 	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, runPath)
 	cmd.SetContext(ctx)
@@ -623,7 +624,7 @@ func TestDaemonReset_GracefulTimeoutEscalatesToKill(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, reset.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
 	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
 	cmd.SetContext(ctx)

--- a/cmd/kuke/daemon/restart/restart.go
+++ b/cmd/kuke/daemon/restart/restart.go
@@ -21,12 +21,11 @@
 package restart
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
@@ -38,14 +37,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
-// context so unit tests can exercise runRestart without a real controller.
-type MockClientKey struct{}
-
-// defaultTimeout matches `kuke daemon stop`'s grace period (#219) so the two
-// verbs agree on how long the SIGTERM phase gets before SIGKILL escalates.
-const defaultTimeout = 10 * time.Second
 
 // NewRestartCmd builds the `kuke daemon restart` cobra command.
 func NewRestartCmd() *cobra.Command {
@@ -65,7 +56,7 @@ func NewRestartCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Duration(
-		"timeout", defaultTimeout,
+		"timeout", lifecycle.DefaultTimeout,
 		"Grace period for the stop phase before escalating from SIGTERM to SIGKILL",
 	)
 	_ = viper.BindPFlag(config.KUKE_DAEMON_RESTART_TIMEOUT.ViperKey, cmd.Flags().Lookup("timeout"))
@@ -85,7 +76,7 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 
 	timeout := viper.GetDuration(config.KUKE_DAEMON_RESTART_TIMEOUT.ViperKey)
 	if timeout <= 0 {
-		timeout = defaultTimeout
+		timeout = lifecycle.DefaultTimeout
 	}
 
 	client := resolveClient(cmd, logger)
@@ -98,11 +89,11 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("inspect kukeond cell: %w", err)
 	}
 	if !getRes.MetadataExists {
-		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
+		return errdefs.ErrHostNotInitialized
 	}
 
-	if isCellRunning(getRes.Cell) {
-		if stopErr := stopPhase(cmd, client, doc, timeout); stopErr != nil {
+	if lifecycle.IsCellRunning(getRes.Cell) {
+		if stopErr := lifecycle.StopPhase(cmd, client, doc, timeout); stopErr != nil {
 			return stopErr
 		}
 	} else {
@@ -117,7 +108,7 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("start kukeond cell: %w", err)
 	}
 	if !startRes.Started {
-		return errors.New("start kukeond cell: controller reported no change")
+		return fmt.Errorf("start kukeond cell: %w", errdefs.ErrControllerNoChange)
 	}
 
 	cmd.Printf(
@@ -125,58 +116,6 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 		consts.KukeSystemCellName, consts.KukeSystemRealmName,
 	)
 	return nil
-}
-
-// stopPhase mirrors `kuke daemon stop`: graceful StopCell with SIGTERM →
-// SIGKILL escalation when the grace period expires. Duplicated here rather
-// than imported from the stop package to keep each daemon-lifecycle verb
-// self-contained — start/stop/kill follow the same convention.
-func stopPhase(
-	cmd *cobra.Command,
-	client kukeonv1.Client,
-	doc v1beta1.CellDoc,
-	timeout time.Duration,
-) error {
-	type stopOutcome struct {
-		res kukeonv1.StopCellResult
-		err error
-	}
-	done := make(chan stopOutcome, 1)
-	go func() {
-		res, sErr := client.StopCell(cmd.Context(), doc)
-		done <- stopOutcome{res: res, err: sErr}
-	}()
-
-	select {
-	case out := <-done:
-		if out.err != nil {
-			return fmt.Errorf("stop kukeond cell: %w", out.err)
-		}
-		if !out.res.Stopped {
-			return errors.New("stop kukeond cell: controller reported no change")
-		}
-		cmd.Printf(
-			"kukeond stopped (cell %q in realm %q)\n",
-			consts.KukeSystemCellName, consts.KukeSystemRealmName,
-		)
-		return nil
-	case <-time.After(timeout):
-		killRes, killErr := client.KillCell(cmd.Context(), doc)
-		if killErr != nil {
-			return fmt.Errorf(
-				"kill kukeond cell after %s grace period expired: %w",
-				timeout, killErr,
-			)
-		}
-		if !killRes.Killed {
-			return errors.New("kill kukeond cell: controller reported no change")
-		}
-		cmd.Printf(
-			"kukeond force-killed after %s grace period expired (cell %q in realm %q)\n",
-			timeout, consts.KukeSystemCellName, consts.KukeSystemRealmName,
-		)
-		return nil
-	}
 }
 
 // kukeondCellDoc builds the lookup CellDoc for the system kukeond cell. The
@@ -198,24 +137,12 @@ func kukeondCellDoc() v1beta1.CellDoc {
 	}
 }
 
-// isCellRunning treats the cell as live if any container reports Ready, or if
-// the persisted cell state is Ready. Mirrors the check in `kuke daemon
-// start`/`stop`/`kill` so all four verbs agree on what "running" means.
-func isCellRunning(cell v1beta1.CellDoc) bool {
-	for _, c := range cell.Status.Containers {
-		if c.State == v1beta1.ContainerStateReady {
-			return true
-		}
-	}
-	return cell.Status.State == v1beta1.CellStateReady
-}
-
-// resolveClient returns the kukeonv1.Client used by runRestart. Tests inject a
-// fake via MockClientKey; production always builds an in-process client —
-// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
-// through the daemon is impossible by definition.
+// resolveClient returns the kukeonv1.Client used by runRestart. Tests inject
+// a fake via lifecycle.MockClientKey; production always builds an in-process
+// client — `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so
+// routing through the daemon is impossible by definition.
 func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
-	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+	if mockClient, ok := cmd.Context().Value(lifecycle.MockClientKey{}).(kukeonv1.Client); ok {
 		return mockClient
 	}
 	opts := controller.Options{

--- a/cmd/kuke/daemon/restart/restart_test.go
+++ b/cmd/kuke/daemon/restart/restart_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	restart "github.com/eminwux/kukeon/cmd/kuke/daemon/restart"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -240,7 +241,7 @@ func TestDaemonRestart(t *testing.T) {
 			cmd.SetErr(buf)
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-			ctx = context.WithValue(ctx, restart.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
 			cmd.SetContext(ctx)
 			cmd.SetArgs(tt.args)
 
@@ -317,7 +318,7 @@ func TestDaemonRestart_GracefulTimeoutEscalatesToKillThenStarts(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, restart.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--timeout", "50ms"})
 
@@ -397,7 +398,7 @@ func TestDaemonRestart_TimeoutOverridesDefault(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, restart.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--timeout", "20ms"})
 
@@ -461,7 +462,7 @@ func TestDaemonRestart_KillCellErrorIsWrapped(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, restart.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--timeout", "20ms"})
 

--- a/cmd/kuke/daemon/start/start.go
+++ b/cmd/kuke/daemon/start/start.go
@@ -21,11 +21,11 @@
 package start
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
@@ -37,10 +37,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
-// context so unit tests can exercise runStart without a real controller.
-type MockClientKey struct{}
 
 // NewStartCmd builds the `kuke daemon start` cobra command.
 func NewStartCmd() *cobra.Command {
@@ -79,10 +75,10 @@ func runStart(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("inspect kukeond cell: %w", err)
 	}
 	if !getRes.MetadataExists {
-		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
+		return errdefs.ErrHostNotInitialized
 	}
 
-	if isCellRunning(getRes.Cell) {
+	if lifecycle.IsCellRunning(getRes.Cell) {
 		cmd.Printf(
 			"kukeond is already running (cell %q in realm %q)\n",
 			consts.KukeSystemCellName, consts.KukeSystemRealmName,
@@ -95,7 +91,7 @@ func runStart(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("start kukeond cell: %w", err)
 	}
 	if !startRes.Started {
-		return errors.New("start kukeond cell: controller reported no change")
+		return fmt.Errorf("start kukeond cell: %w", errdefs.ErrControllerNoChange)
 	}
 
 	cmd.Printf(
@@ -124,24 +120,12 @@ func kukeondCellDoc() v1beta1.CellDoc {
 	}
 }
 
-// isCellRunning mirrors the running-check the controller's StartCell uses:
-// any container in the Ready state means the cell is live, regardless of the
-// cell's persisted metadata state (which can lag external crashes).
-func isCellRunning(cell v1beta1.CellDoc) bool {
-	for _, c := range cell.Status.Containers {
-		if c.State == v1beta1.ContainerStateReady {
-			return true
-		}
-	}
-	return cell.Status.State == v1beta1.CellStateReady
-}
-
 // resolveClient returns the kukeonv1.Client used by runStart. Tests inject a
-// fake via MockClientKey; production always builds an in-process client —
-// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
-// through the daemon is impossible by definition.
+// fake via lifecycle.MockClientKey; production always builds an in-process
+// client — `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so
+// routing through the daemon is impossible by definition.
 func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
-	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+	if mockClient, ok := cmd.Context().Value(lifecycle.MockClientKey{}).(kukeonv1.Client); ok {
 		return mockClient
 	}
 	opts := controller.Options{

--- a/cmd/kuke/daemon/start/start_test.go
+++ b/cmd/kuke/daemon/start/start_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	start "github.com/eminwux/kukeon/cmd/kuke/daemon/start"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -163,7 +164,7 @@ func TestDaemonStart(t *testing.T) {
 			cmd.SetErr(buf)
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-			ctx = context.WithValue(ctx, start.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
 			cmd.SetContext(ctx)
 			cmd.SetArgs(nil)
 

--- a/cmd/kuke/daemon/stop/stop.go
+++ b/cmd/kuke/daemon/stop/stop.go
@@ -21,12 +21,11 @@
 package stop
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/client/local"
@@ -38,14 +37,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-// MockClientKey injects a kukeonv1.Client (typically a fake) via the command
-// context so unit tests can exercise runStop without a real controller.
-type MockClientKey struct{}
-
-// defaultTimeout matches the issue spec (#219): 10s graceful grace period
-// before SIGKILL escalation.
-const defaultTimeout = 10 * time.Second
 
 // NewStopCmd builds the `kuke daemon stop` cobra command.
 func NewStopCmd() *cobra.Command {
@@ -63,7 +54,7 @@ func NewStopCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Duration(
-		"timeout", defaultTimeout,
+		"timeout", lifecycle.DefaultTimeout,
 		"Grace period before escalating from SIGTERM to SIGKILL",
 	)
 	_ = viper.BindPFlag(config.KUKE_DAEMON_STOP_TIMEOUT.ViperKey, cmd.Flags().Lookup("timeout"))
@@ -83,7 +74,7 @@ func runStop(cmd *cobra.Command, _ []string) error {
 
 	timeout := viper.GetDuration(config.KUKE_DAEMON_STOP_TIMEOUT.ViperKey)
 	if timeout <= 0 {
-		timeout = defaultTimeout
+		timeout = lifecycle.DefaultTimeout
 	}
 
 	client := resolveClient(cmd, logger)
@@ -96,10 +87,10 @@ func runStop(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("inspect kukeond cell: %w", err)
 	}
 	if !getRes.MetadataExists {
-		return errors.New("kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first")
+		return errdefs.ErrHostNotInitialized
 	}
 
-	if !isCellRunning(getRes.Cell) {
+	if !lifecycle.IsCellRunning(getRes.Cell) {
 		cmd.Printf(
 			"kukeond is already stopped (cell %q in realm %q)\n",
 			consts.KukeSystemCellName, consts.KukeSystemRealmName,
@@ -107,50 +98,7 @@ func runStop(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	type stopOutcome struct {
-		res kukeonv1.StopCellResult
-		err error
-	}
-	done := make(chan stopOutcome, 1)
-	go func() {
-		res, sErr := client.StopCell(cmd.Context(), doc)
-		done <- stopOutcome{res: res, err: sErr}
-	}()
-
-	select {
-	case out := <-done:
-		if out.err != nil {
-			return fmt.Errorf("stop kukeond cell: %w", out.err)
-		}
-		if !out.res.Stopped {
-			return errors.New("stop kukeond cell: controller reported no change")
-		}
-		cmd.Printf(
-			"kukeond stopped (cell %q in realm %q)\n",
-			consts.KukeSystemCellName, consts.KukeSystemRealmName,
-		)
-		return nil
-	case <-time.After(timeout):
-		// Graceful path did not complete within the grace period — escalate.
-		// The in-flight StopCell may still be running; the underlying containerd
-		// task will be torn down by KillCell regardless, and the goroutine exits
-		// cleanly when its call returns.
-		killRes, killErr := client.KillCell(cmd.Context(), doc)
-		if killErr != nil {
-			return fmt.Errorf(
-				"kill kukeond cell after %s grace period expired: %w",
-				timeout, killErr,
-			)
-		}
-		if !killRes.Killed {
-			return errors.New("kill kukeond cell: controller reported no change")
-		}
-		cmd.Printf(
-			"kukeond force-killed after %s grace period expired (cell %q in realm %q)\n",
-			timeout, consts.KukeSystemCellName, consts.KukeSystemRealmName,
-		)
-		return nil
-	}
+	return lifecycle.StopPhase(cmd, client, doc, timeout)
 }
 
 // kukeondCellDoc builds the lookup CellDoc for the system kukeond cell. The
@@ -172,24 +120,12 @@ func kukeondCellDoc() v1beta1.CellDoc {
 	}
 }
 
-// isCellRunning treats the cell as live if any container reports Ready, or if
-// the persisted cell state is Ready. This mirrors the running-check used by
-// `kuke daemon start` so the two verbs agree on what "running" means.
-func isCellRunning(cell v1beta1.CellDoc) bool {
-	for _, c := range cell.Status.Containers {
-		if c.State == v1beta1.ContainerStateReady {
-			return true
-		}
-	}
-	return cell.Status.State == v1beta1.CellStateReady
-}
-
 // resolveClient returns the kukeonv1.Client used by runStop. Tests inject a
-// fake via MockClientKey; production always builds an in-process client —
-// `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so routing
-// through the daemon is impossible by definition.
+// fake via lifecycle.MockClientKey; production always builds an in-process
+// client — `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so
+// routing through the daemon is impossible by definition.
 func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
-	if mockClient, ok := cmd.Context().Value(MockClientKey{}).(kukeonv1.Client); ok {
+	if mockClient, ok := cmd.Context().Value(lifecycle.MockClientKey{}).(kukeonv1.Client); ok {
 		return mockClient
 	}
 	opts := controller.Options{

--- a/cmd/kuke/daemon/stop/stop_test.go
+++ b/cmd/kuke/daemon/stop/stop_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	stop "github.com/eminwux/kukeon/cmd/kuke/daemon/stop"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -176,7 +177,7 @@ func TestDaemonStop(t *testing.T) {
 			cmd.SetErr(buf)
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-			ctx = context.WithValue(ctx, stop.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
 			cmd.SetContext(ctx)
 			cmd.SetArgs(tt.args)
 
@@ -241,7 +242,7 @@ func TestDaemonStop_GracefulTimeoutEscalatesToKill(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, stop.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--timeout", "50ms"})
 
@@ -308,7 +309,7 @@ func TestDaemonStop_KillCellErrorIsWrapped(t *testing.T) {
 	cmd.SetErr(buf)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, stop.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--timeout", "20ms"})
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -278,4 +278,22 @@ var (
 	// (kuke get, kuke create, kuke apply, kuke delete, …) do not gate on
 	// this — those are the supported `kukeon`-group rootless-client path.
 	ErrMustRunAsRoot = errors.New("command must run as root")
+
+	// kuke daemon lifecycle errors.
+
+	// ErrHostNotInitialized fires from every `kuke daemon` read/write verb
+	// (start, stop, kill, restart, reset, logs) when the kukeond cell
+	// metadata is missing — i.e. the host has not been bootstrapped yet.
+	// Centralised here so the surface text and errors.Is identity are
+	// shared across verbs.
+	ErrHostNotInitialized = errors.New(
+		"kukeon host is not initialized: kukeond cell metadata is missing; run `kuke init` first",
+	)
+
+	// ErrControllerNoChange fires when a Start/Stop/Kill/Delete controller
+	// call returns success but reports the cell was already in the target
+	// state. Callers wrap with `fmt.Errorf("<verb> kukeond cell: %w",
+	// errdefs.ErrControllerNoChange)` so `errors.Is` works across the
+	// boundary without diverging the surface text.
+	ErrControllerNoChange = errors.New("controller reported no change")
 )


### PR DESCRIPTION
## Summary

- Hoist the duplicated daemon-verb scaffolding (`isCellRunning`, `defaultTimeout`, `stopPhase`, `MockClientKey`) into a single `cmd/kuke/daemon/internal/lifecycle` package so the 6 verbs (start / stop / kill / restart / reset / logs) cannot silently drift on what "running" means, the SIGTERM → SIGKILL grace period, or the test-injection key.
- Add `errdefs.ErrHostNotInitialized` and `errdefs.ErrControllerNoChange` so `errors.Is` works across the verb-callsite boundary; each verb returns the bare or wrapped sentinel instead of `errors.New` with literal surface text.
- Fix the orphaned-`StopCell`-goroutine bug `lifecycle.StopPhase` inherited from the old per-verb copies: the in-flight `StopCell` now runs under a `context.WithCancel(parent)`-derived ctx that the timeout-escalation branch cancels **before** invoking `KillCell`, so the orphan observes cancellation instead of continuing against an unmodified parent context.
- Migrate all 6 verbs + their test files to read from `lifecycle.MockClientKey{}` (one context-value identity across the verb group, no `MockClientKey` exported on production daemon-verb surfaces).

Bundles and supersedes #234, #237, #242, #243, #393 per the issue body's design rationale (single architectural decision — package layout + `StopPhase` signature — so splitting would force the second pass to relocate symbols).

## Test plan

- [x] `make test` — full unit test target green, including the 7 new `lifecycle_test.go` cases (4 `IsCellRunning` table rows, 2 `StopPhase` happy/no-change rows, 1 `StopPhase` timeout-escalation row that asserts the orphan's ctx was cancelled before `KillCell` ran, 2 `errors.Is` boundary tests per sentinel).
- [x] `make dev-init` smoke — daemon-parity tail matches the `CLAUDE.md` regression-guard output verbatim (`default` + `kuke-system` both `Ready`, both visible to `kuke get realms` and `kuke get realms --no-daemon`).
- [x] Grep-based AC checklist:
  - `grep -rn "func isCellRunning" cmd/kuke/daemon/` — 0 hits
  - `grep -rn "defaultTimeout" cmd/kuke/daemon/` — 0 hits
  - `grep -rn "func stopPhase" cmd/kuke/daemon/` — 0 hits
  - `grep -rn 'errors.New("kukeon host is not initialized' cmd/kuke/daemon/` — 0 hits
  - `grep -rn 'errors.New(".*controller reported no change' cmd/kuke/daemon/` — 0 hits
  - `grep -rn "type MockClientKey" cmd/kuke/daemon/*/[!_]*.go` — 0 hits
- [x] `pre-commit run --files <diff>` — all hooks (gofmt, go-mod-tidy, golangci-lint, addlicense, …) green.

## Notes for the reviewer

- The reset-specific `MockSocketDirKey` and `MockRunPathKey` (no duplication, reset-only) and the logs-specific `MockTailKey` are deliberately left in place — the AC narrowly targets `MockClientKey` only.
- `resolveClient` itself stays per-verb (now referencing `lifecycle.MockClientKey{}`); the AC checklist doesn't call for its extraction and pulling it into lifecycle would be scope creep beyond the issue's literal scope.
- Verb tests retain orchestration coverage above the helper layer; new helper-level tests live alongside the helper in `cmd/kuke/daemon/internal/lifecycle/lifecycle_test.go`.

Closes #426