### PR TITLE
fix(kukeonv1): add json/yaml tags to ApplyResourceResult so -o json emits lowercase keys

### DIFF
--- a/cmd/kuke/apply/apply_test.go
+++ b/cmd/kuke/apply/apply_test.go
@@ -135,6 +135,52 @@ spec:
 	}
 }
 
+// TestNewApplyCmd_RunE_JSONOutput locks the lowercase shape of
+// `kuke apply -f -o json` so the keys can't drift back to Go's default
+// uppercase marshaling. Mirrors TestNewDeleteCmd_RunE_JSONOutput on the
+// sibling delete command.
+func TestNewApplyCmd_RunE_JSONOutput(t *testing.T) {
+	const validYAML = `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: r1
+spec:
+  namespace: r1
+`
+
+	cmd := apply.NewApplyCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	fc := &fakeClient{
+		applyFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{Index: 0, Kind: "Realm", Name: "r1", Action: "created"},
+				},
+			}, nil
+		},
+	}
+	ctx = context.WithValue(ctx, apply.MockControllerKey{}, kukeonv1.Client(fc))
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validYAML), "--output", "json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	for _, want := range []string{`"index"`, `"kind"`, `"name"`, `"action"`, `"resources"`, "Realm", "r1", "created"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("expected JSON output to contain %q, got: %q", want, output)
+		}
+	}
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -644,14 +644,18 @@ type ApplyDocumentsResult struct {
 	Resources []ApplyResourceResult
 }
 
+// ApplyResourceResult is the per-resource outcome of an ApplyDocuments call.
+// JSON/YAML tags preserve the lowercase `kuke apply -f -o json` shape that
+// matches the sibling `kuke delete -f -o json` contract on
+// [DeleteResourceResult] (the wire is gob and ignores these tags).
 type ApplyResourceResult struct {
-	Index   int
-	Kind    string
-	Name    string
-	Action  string
-	Error   string
-	Changes []string
-	Details map[string]string
+	Index   int               `json:"index"             yaml:"index"`
+	Kind    string            `json:"kind"              yaml:"kind"`
+	Name    string            `json:"name"              yaml:"name"`
+	Action  string            `json:"action"            yaml:"action"`
+	Error   string            `json:"error,omitempty"   yaml:"error,omitempty"`
+	Changes []string          `json:"changes,omitempty" yaml:"changes,omitempty"`
+	Details map[string]string `json:"details,omitempty" yaml:"details,omitempty"`
 }
 
 // ---- Delete ----


### PR DESCRIPTION
## Summary

- Thread `json:\"…\" yaml:\"…\"` tags onto the 7 fields of `kukeonv1.ApplyResourceResult` (`pkg/api/kukeonv1/types.go:647-660`), mirroring the shape #576 put on the sibling `DeleteResourceResult`. Without these tags, Go's default marshaler capitalised the keys, so `kuke apply -f -o json` emitted `{\"Index\":…,\"Kind\":…}` while `kuke delete -f -o json` (post-#576) already emitted `{\"index\":…,\"kind\":…}` — a divergence invisible at unit-test time but a real consumer-scripting footgun.
- Add `TestNewApplyCmd_RunE_JSONOutput` in `cmd/kuke/apply/apply_test.go` to lock the lowercase shape, mirroring `TestNewDeleteCmd_RunE_JSONOutput`.
- Wire is net/rpc gob, so tag changes have no protocol impact (same as the #576 trail noted).

## Test plan

- [x] `go test ./cmd/kuke/apply/ -run TestNewApplyCmd_RunE_JSONOutput -v` — new test passes.
- [x] `make test` — full unit test target green, no regressions.
- [x] `pre-commit run --files <diff>` — all hooks (gofmt, golangci-lint, addlicense, …) green.

Closes #577