### PR TITLE
test(e2e): wait-based fast-fail in startKukeondDaemon

### DIFF
--- a/e2e/harness_daemon_test.go
+++ b/e2e/harness_daemon_test.go
@@ -111,17 +111,41 @@ func startKukeondDaemon(t *testing.T, runPath string) string {
 		t.Fatalf("start kukeond serve: %v", startErr)
 	}
 
+	// Single Wait() across the function: both the startup probe and the
+	// cleanup select on this channel. kill(pid, 0) cannot fast-fail an
+	// early-crashing daemon — on Linux an unreaped zombie answers signal 0
+	// as alive — so the only reliable early-exit signal is a real Wait().
+	exit := make(chan error, 1)
+	go func() { exit <- cmd.Wait() }()
+
 	// Wait for the listener socket to appear. `kukeond serve` writes the
 	// socket synchronously inside Serve before entering Accept, so the file's
 	// presence is a reliable readiness signal.
-	deadline := time.Now().Add(daemonStartupTimeout)
-	for {
+	deadline := time.NewTimer(daemonStartupTimeout)
+	defer deadline.Stop()
+	poll := time.NewTicker(50 * time.Millisecond)
+	defer poll.Stop()
+
+	started := false
+	for !started {
 		if _, statErr := os.Stat(sockPath); statErr == nil {
-			break
+			started = true
+			continue
 		}
-		if time.Now().After(deadline) {
+		select {
+		case waitErr := <-exit:
+			cancel()
+			logBytes, _ := os.ReadFile(logFile.Name())
+			_ = logFile.Close()
+			_ = os.Remove(logFile.Name())
+			_ = os.RemoveAll(sockDir)
+			t.Fatalf(
+				"kukeond exited before socket %s appeared (wait=%v); daemon log:\n%s",
+				sockPath, waitErr, string(logBytes),
+			)
+		case <-deadline.C:
 			_ = cmd.Process.Signal(syscall.SIGKILL)
-			_, _ = cmd.Process.Wait()
+			<-exit
 			cancel()
 			logBytes, _ := os.ReadFile(logFile.Name())
 			_ = logFile.Close()
@@ -131,34 +155,19 @@ func startKukeondDaemon(t *testing.T, runPath string) string {
 				"kukeond did not create socket %s within %s; daemon log:\n%s",
 				sockPath, daemonStartupTimeout, string(logBytes),
 			)
+		case <-poll.C:
 		}
-		// Detect early exit so the test fails fast with the daemon log
-		// instead of waiting out the timeout.
-		if exitedErr := cmd.Process.Signal(syscall.Signal(0)); exitedErr != nil {
-			cancel()
-			logBytes, _ := os.ReadFile(logFile.Name())
-			_ = logFile.Close()
-			_ = os.Remove(logFile.Name())
-			_ = os.RemoveAll(sockDir)
-			t.Fatalf(
-				"kukeond exited before socket %s appeared; daemon log:\n%s",
-				sockPath, string(logBytes),
-			)
-		}
-		time.Sleep(50 * time.Millisecond)
 	}
 
 	t.Cleanup(func() {
 		// Graceful shutdown: SIGTERM and wait. Escalate to SIGKILL if the
 		// daemon ignores the term within daemonShutdownTimeout.
 		_ = cmd.Process.Signal(syscall.SIGTERM)
-		done := make(chan error, 1)
-		go func() { done <- cmd.Wait() }()
 		select {
-		case <-done:
+		case <-exit:
 		case <-time.After(daemonShutdownTimeout):
 			_ = cmd.Process.Signal(syscall.SIGKILL)
-			<-done
+			<-exit
 		}
 		cancel()
 		_ = logFile.Close()


### PR DESCRIPTION
## Summary

- Replace the `kill(pid, 0)` liveness probe in `startKukeondDaemon` (`e2e/harness_daemon_test.go:137`) with a `cmd.Wait()` goroutine whose result the startup loop selects on. On Linux an unreaped zombie answers signal 0 as alive, so a crashing `kukeond serve` previously burned the full 10s `daemonStartupTimeout` before the harness reported failure — the opposite of the comment's stated fast-fail contract. With a real `Wait()` in flight, an early exit short-circuits the loop immediately and the daemon log lands in the `t.Fatalf` message.
- Convert the 50ms polling loop into a `select` over the shared `exit` channel, a `time.NewTimer` deadline, and a `time.NewTicker` poll — mirroring the shape of the existing shutdown logic at `e2e/harness_daemon_test.go:151`.
- Reuse the same `exit` channel in the `t.Cleanup` SIGTERM/SIGKILL path so `cmd.Wait()` is called exactly once for the lifetime of the daemon. The previous cleanup spawned its own goroutine + channel, which would have raced the (now-unified) startup goroutine if both attempted `Wait()`.

Source: post-merge nit on #575.

## Test plan

- [x] `go build ./...` — compiles.
- [x] `go vet ./...` — clean.
- [x] `make test` — full unit test target green (note: `make test` excludes `/e2e` by design; the change is in the e2e harness).
- [x] `go test ./e2e/...` — runs against the harness; `TestKuke_AttachDetach_KeepsTaskRunning` fails on this branch with `UtimesNanoAt … no such file or directory` from containerd's image-unpack path, and reproduces on `origin/main` with a different environmental error (`kuketty binary not found`). Failure is pre-existing host-env noise, downstream of `startKukeondDaemon` (daemon started → `kuke apply` ran → containerd failed), unrelated to this diff.
- [x] `pre-commit run --files e2e/harness_daemon_test.go` — gofmt, go-mod-tidy, golangci-lint, addlicense all green.
- [ ] Synthetic crashing-daemon harness test to lock the fast-fail behavior — not added. `startKukeondDaemon` calls `t.Fatalf` directly, so exercising the failure paths from a unit test would require either capturing `t.Fatalf` or refactoring the failure paths to return an error; both feel disproportionate to a non-blocking nit. The behavior is exercised implicitly by every daemon-mode e2e test on the success path.

Closes #582