### PR TITLE
feat(metadata): introduce sidecar flock + CAS primitives for concurrent writers

### DIFF
--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -41,6 +41,15 @@ var (
 	ErrUpdateRealmMetadata    = errors.New("failed to update realm metadata")
 	ErrCreateRealmNamespace   = errors.New("failed to create realm namespace")
 	ErrMissingMetadataFile    = errors.New("missing metadata file")
+	// ErrStaleResource fires from metadata.WriteMetadataCAS when the
+	// on-disk bytes diverged between the caller's prior read and the
+	// compare-and-swap write. Surfaces to a controller writer that read,
+	// mutated, and tried to persist a metadata document while another
+	// writer (daemon, `kuke --no-daemon`, or the reconciler) committed
+	// an intervening write under the same exclusive flock. The caller
+	// must re-read, re-apply the mutation, and retry — there is no
+	// silent merge of disjoint edits.
+	ErrStaleResource = errors.New("metadata resource changed since prior read")
 	ErrUnsupportedAPIVersion  = errors.New("unsupported apiVersion")
 	ErrUnknownKind            = errors.New("unknown kind")
 	ErrConversionFailed       = errors.New("conversion failed")

--- a/internal/metadata/lock.go
+++ b/internal/metadata/lock.go
@@ -52,22 +52,44 @@ func LockFilePath(file string) string {
 	return file + LockFileSuffix
 }
 
-// acquireFlock opens (creating if absent) the sidecar lock file for the
-// metadata file at `file` and acquires the requested flock mode. The
-// returned release closes the underlying file descriptor, which the
-// kernel uses to drop the flock.
+// acquireFlock opens the sidecar lock file for the metadata file at
+// `file` and acquires the requested flock mode. The returned release
+// closes the underlying file descriptor, which the kernel uses to drop
+// the flock.
 //
-// The parent directory is created up-front so the sidecar has somewhere
-// to live; this matches WriteMetadata's existing MkdirAll on the
-// create-new path.
+// Side effects differ by mode:
+//
+//   - Exclusive (write path): the parent directory is created via
+//     MkdirAll and the sidecar is opened with O_CREATE, mirroring
+//     WriteMetadata's existing create-new path. A writer always lands
+//     a sidecar — Phase 3 adopters can rely on that invariant.
+//
+//   - Shared (read path): neither the parent directory nor the sidecar
+//     is created. A missing sidecar surfaces as ErrMissingMetadataFile
+//     so a sibling DeleteMetadata that swept between the caller's
+//     existence pre-check and this acquire cannot be papered over by
+//     resurrecting a stale parent + sidecar that then leak after the
+//     read returns ErrMissingMetadataFile anyway.
 func acquireFlock(file string, exclusive bool) (func(), error) {
-	parent := filepath.Dir(file)
-	if mkErr := os.MkdirAll(parent, metadataDirMode); mkErr != nil {
-		return nil, fmt.Errorf("mkdir lock parent %s: %w", parent, mkErr)
+	if exclusive {
+		parent := filepath.Dir(file)
+		if mkErr := os.MkdirAll(parent, metadataDirMode); mkErr != nil {
+			return nil, fmt.Errorf("mkdir lock parent %s: %w", parent, mkErr)
+		}
 	}
 	lockPath := LockFilePath(file)
-	f, openErr := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, lockFilePerm)
+	openFlag := os.O_RDWR
+	if exclusive {
+		openFlag |= os.O_CREATE
+	}
+	f, openErr := os.OpenFile(lockPath, openFlag, lockFilePerm)
 	if openErr != nil {
+		if !exclusive && os.IsNotExist(openErr) {
+			return nil, fmt.Errorf(
+				"sidecar lock file missing for %s: %w",
+				file, errdefs.ErrMissingMetadataFile,
+			)
+		}
 		return nil, fmt.Errorf("open lock file %s: %w", lockPath, openErr)
 	}
 	mode := syscall.LOCK_SH

--- a/internal/metadata/lock.go
+++ b/internal/metadata/lock.go
@@ -1,0 +1,180 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// lockFilePerm is the mode used for newly-created sidecar lock files. The
+// sidecar carries no payload — its only role is to anchor the flock — so
+// it inherits the data file's 0o644 and the parent dir's 0o0750 + setgid
+// keeps it out of reach of non-kukeon-group operators.
+const lockFilePerm os.FileMode = 0o644
+
+// LockFileSuffix is appended to a metadata file path to derive its
+// sidecar lock file. Exported so callers that iterate directories
+// containing metadata.json files (list/walk paths) can filter out the
+// sidecar instead of mis-treating it as another metadata document.
+const LockFileSuffix = ".lock"
+
+// LockFilePath returns the sidecar lock file path for a metadata file.
+// The sidecar lives next to the metadata file at <file>.lock.
+//
+// Locks are kept on the sidecar, not the data file, because WriteMetadata
+// persists via tmp-file + rename. Renaming swaps the data file's inode
+// out from under any flock the caller might have held on the previous
+// inode; the sidecar's inode is never replaced, so the lock identity
+// remains stable across writes.
+func LockFilePath(file string) string {
+	return file + LockFileSuffix
+}
+
+// acquireFlock opens (creating if absent) the sidecar lock file for the
+// metadata file at `file` and acquires the requested flock mode. The
+// returned release closes the underlying file descriptor, which the
+// kernel uses to drop the flock.
+//
+// The parent directory is created up-front so the sidecar has somewhere
+// to live; this matches WriteMetadata's existing MkdirAll on the
+// create-new path.
+func acquireFlock(file string, exclusive bool) (func(), error) {
+	parent := filepath.Dir(file)
+	if mkErr := os.MkdirAll(parent, metadataDirMode); mkErr != nil {
+		return nil, fmt.Errorf("mkdir lock parent %s: %w", parent, mkErr)
+	}
+	lockPath := LockFilePath(file)
+	f, openErr := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, lockFilePerm)
+	if openErr != nil {
+		return nil, fmt.Errorf("open lock file %s: %w", lockPath, openErr)
+	}
+	mode := syscall.LOCK_SH
+	if exclusive {
+		mode = syscall.LOCK_EX
+	}
+	if flockErr := syscall.Flock(int(f.Fd()), mode); flockErr != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("flock %s: %w", lockPath, flockErr)
+	}
+	return func() {
+		// Close releases the flock atomically with closing the fd.
+		_ = f.Close()
+	}, nil
+}
+
+// WithExclusiveLock acquires the sidecar exclusive flock for the
+// metadata file at `file`, runs fn while holding it, then releases the
+// lock. fn must NOT call any flock-acquiring API on the same file or it
+// will deadlock — BSD flock is non-reentrant on the same open-file
+// description, and each call here opens a fresh descriptor.
+//
+// Use the WriteMetadataNoLock / ReadRawNoLock helpers from inside fn to
+// touch the data file while holding the lock.
+func WithExclusiveLock(_ context.Context, _ *slog.Logger, file string, fn func() error) error {
+	release, err := acquireFlock(file, true)
+	if err != nil {
+		return fmt.Errorf("acquire exclusive lock: %w", err)
+	}
+	defer release()
+	return fn()
+}
+
+// WithSharedLock is the read-only counterpart of WithExclusiveLock: it
+// acquires the sidecar shared flock for the duration of fn. Multiple
+// concurrent shared holders are admitted; an exclusive holder blocks
+// every new shared acquisition until it releases.
+func WithSharedLock(_ context.Context, _ *slog.Logger, file string, fn func() error) error {
+	release, err := acquireFlock(file, false)
+	if err != nil {
+		return fmt.Errorf("acquire shared lock: %w", err)
+	}
+	defer release()
+	return fn()
+}
+
+// WriteMetadataNoLock is the inner write helper used by WriteMetadata
+// and WriteMetadataCAS. It is exported for callers that already hold
+// the sidecar flock via WithExclusiveLock. The caller is responsible
+// for the flock; if you are not sure, call WriteMetadata instead.
+func WriteMetadataNoLock(ctx context.Context, logger *slog.Logger, metadata any, file string) error {
+	return writeMetadataUnlocked(ctx, logger, metadata, file)
+}
+
+// ReadRawNoLock is the inner read helper used by ReadRaw and
+// WriteMetadataCAS. It is exported for callers that already hold the
+// sidecar flock via WithExclusiveLock or WithSharedLock. The caller is
+// responsible for the flock; if you are not sure, call ReadRaw instead.
+//
+// Returns ErrMissingMetadataFile (wrapped) when the data file does not
+// exist; that result is consistent regardless of whether the caller
+// holds the flock.
+func ReadRawNoLock(_ context.Context, _ *slog.Logger, file string) ([]byte, error) {
+	if !existsFilePath(file) {
+		return nil, fmt.Errorf("metadata file does not exist: %w", errdefs.ErrMissingMetadataFile)
+	}
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", file, err)
+	}
+	return data, nil
+}
+
+// WriteMetadataCAS writes new metadata only if the on-disk bytes match
+// the caller's observed prior bytes. The read-compare-write window runs
+// under a single exclusive flock on the sidecar lock file.
+//
+// prior == nil asserts "no file should exist yet" — the write fails
+// with ErrStaleResource if a data file is present. Conversely, if a
+// data file exists on disk but its bytes disagree with prior (including
+// the case where prior is non-nil but the data file was deleted), the
+// write fails with ErrStaleResource and the caller must re-read and
+// retry.
+//
+// The bytes compared are the raw payload — the exact return value of
+// ReadRaw / ReadRawNoLock. Callers must pass back the bytes they
+// observed, not a re-marshaled document, because JSON serialization is
+// not guaranteed to be byte-stable across edits.
+func WriteMetadataCAS(
+	ctx context.Context,
+	logger *slog.Logger,
+	prior []byte,
+	metadata any,
+	file string,
+) error {
+	return WithExclusiveLock(ctx, logger, file, func() error {
+		var current []byte
+		if existsFilePath(file) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				return fmt.Errorf("read %s for cas: %w", file, err)
+			}
+			current = data
+		}
+		if !bytes.Equal(prior, current) {
+			return fmt.Errorf("cas check failed for %s: %w", file, errdefs.ErrStaleResource)
+		}
+		return writeMetadataUnlocked(ctx, logger, metadata, file)
+	})
+}

--- a/internal/metadata/lock_test.go
+++ b/internal/metadata/lock_test.go
@@ -25,6 +25,8 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -528,6 +530,132 @@ func TestWriteMetadataCASRetryAfterStale(t *testing.T) {
 	}
 	if got["counter"] != 101 {
 		t.Fatalf("counter after retry = %d, want 101", got["counter"])
+	}
+}
+
+// TestWithSharedLockDoesNotResurrectAfterDelete reproduces the TOCTOU
+// race the reviewer flagged in PR #607: a sibling DeleteMetadata sweeps
+// the parent dir + sidecar between a reader's existence pre-check and
+// the shared-lock acquire. The acquire must surface
+// ErrMissingMetadataFile WITHOUT recreating the parent dir or sidecar —
+// otherwise both leak after the read returns ErrMissingMetadataFile
+// anyway, and phase-3 adopters retrying on ErrStaleResource will widen
+// the window.
+//
+// We drive the race deterministically: seed normal state, then call
+// os.RemoveAll on the parent to simulate the deleter completing
+// mid-flight, then invoke WithSharedLock directly. A racy two-goroutine
+// arrangement would test the same property less reliably.
+func TestWithSharedLockDoesNotResurrectAfterDelete(t *testing.T) {
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "cell")
+	file := filepath.Join(parent, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	if err := metadata.WriteMetadata(ctx, logger, map[string]string{"k": "v"}, file); err != nil {
+		t.Fatalf("seed WriteMetadata: %v", err)
+	}
+	if err := os.RemoveAll(parent); err != nil {
+		t.Fatalf("simulate concurrent DeleteMetadata: %v", err)
+	}
+
+	err := metadata.WithSharedLock(ctx, logger, file, func() error {
+		t.Errorf("fn ran despite missing data file — shared-lock acquire should have failed")
+		return nil
+	})
+	if !errors.Is(err, errdefs.ErrMissingMetadataFile) {
+		t.Fatalf("WithSharedLock after parent rm: err = %v, want ErrMissingMetadataFile", err)
+	}
+
+	if _, statErr := os.Stat(parent); !os.IsNotExist(statErr) {
+		t.Errorf("parent dir resurrected by shared-lock acquire: stat err = %v", statErr)
+	}
+	if _, statErr := os.Stat(metadata.LockFilePath(file)); !os.IsNotExist(statErr) {
+		t.Errorf("sidecar resurrected by shared-lock acquire: stat err = %v", statErr)
+	}
+}
+
+// TestStressConcurrentWriteReadDelete hammers the same path with
+// concurrent Write/Read/Delete goroutines. After every goroutine
+// returns, the working dir must be in one of two well-defined terminal
+// states:
+//
+//   - parent absent (last meaningful op was a successful DeleteMetadata
+//     that rmdir'd the empty parent), or
+//   - parent contains exactly {data file, sidecar} (last op was a
+//     WriteMetadata that completed atomically).
+//
+// Any other state is the reviewer's bug shape — orphan parent dir,
+// stray .lock without a data file, or data file without its sidecar.
+// Both pre-fix race windows (ReadRaw resurrecting parent+sidecar after
+// a sweep; DeleteMetadata racing a writer's atomicWriteFile rename to
+// strand data without a sidecar) would manifest here.
+func TestStressConcurrentWriteReadDelete(t *testing.T) {
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "cell")
+	file := filepath.Join(parent, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	const (
+		writers  = 8
+		readers  = 8
+		deleters = 4
+		iters    = 50
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers + deleters)
+
+	for w := 0; w < writers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_ = metadata.WriteMetadata(ctx, logger, map[string]int{"w": id, "i": i}, file)
+			}
+		}(w)
+	}
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_, _ = metadata.ReadRaw(ctx, logger, file)
+			}
+		}()
+	}
+	for d := 0; d < deleters; d++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_ = metadata.DeleteMetadata(ctx, logger, file)
+			}
+		}()
+	}
+	wg.Wait()
+
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			t.Fatalf("ReadDir parent: %v", err)
+		}
+		return // parent absent — clean terminal state
+	}
+
+	got := make([]string, 0, len(entries))
+	for _, e := range entries {
+		got = append(got, e.Name())
+	}
+	sort.Strings(got)
+
+	want := []string{
+		filepath.Base(file),
+		filepath.Base(file) + metadata.LockFileSuffix,
+	}
+	sort.Strings(want)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("orphan terminal state after stress: parent contents = %v; want %v or empty parent", got, want)
 	}
 }
 

--- a/internal/metadata/lock_test.go
+++ b/internal/metadata/lock_test.go
@@ -1,0 +1,586 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metadata_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/metadata"
+)
+
+// discardLogger returns a slog logger that drops every record — keeps
+// test output clean while exercising the production code paths that
+// expect a non-nil *slog.Logger.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestExclusiveLockBlocksExclusiveAndShared locks the exclusive-blocks-
+// every-other-acquisition invariant: while a goroutine holds the
+// exclusive sidecar flock, both another exclusive acquisition and a
+// shared acquisition must block until the original holder releases.
+//
+// We assert blocking by running the second acquisition with a short
+// deadline against a timer-armed release. Acquisitions that complete
+// before the release fires would falsify the invariant.
+func TestExclusiveLockBlocksExclusiveAndShared(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	// Seed the file so the lock parent exists from the start.
+	if err := metadata.WriteMetadata(ctx, logger, map[string]string{"k": "v"}, file); err != nil {
+		t.Fatalf("seed WriteMetadata: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		acquire  func() error
+		exclusiv bool
+	}{
+		{
+			name: "exclusive blocks exclusive",
+			acquire: func() error {
+				return metadata.WithExclusiveLock(ctx, logger, file, func() error { return nil })
+			},
+		},
+		{
+			name: "exclusive blocks shared",
+			acquire: func() error {
+				return metadata.WithSharedLock(ctx, logger, file, func() error { return nil })
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			holdStarted := make(chan struct{})
+			releaseAt := 200 * time.Millisecond
+			holdDone := make(chan struct{})
+
+			go func() {
+				_ = metadata.WithExclusiveLock(ctx, logger, file, func() error {
+					close(holdStarted)
+					time.Sleep(releaseAt)
+					return nil
+				})
+				close(holdDone)
+			}()
+
+			// Wait for the holder to have the lock in hand before
+			// we race to acquire it.
+			<-holdStarted
+
+			acquireStart := time.Now()
+			if err := tc.acquire(); err != nil {
+				t.Fatalf("contended acquire returned error: %v", err)
+			}
+			elapsed := time.Since(acquireStart)
+
+			// The contended acquisition must have waited at
+			// least most of the hold duration. A generous lower
+			// bound (60% of the hold) avoids flakes on busy
+			// schedulers while still failing if the lock was
+			// not respected at all.
+			minWait := time.Duration(float64(releaseAt) * 0.6)
+			if elapsed < minWait {
+				t.Fatalf("contended acquire took %v, expected ≥ %v — exclusive lock was not respected", elapsed, minWait)
+			}
+
+			<-holdDone
+		})
+	}
+}
+
+// TestSharedLockAllowsSharedConcurrency asserts the read-side parallel
+// admission contract: multiple shared holders must run concurrently. We
+// gate two goroutines on a shared flock and check that the second one
+// enters before the first releases. If the implementation degenerated
+// shared to exclusive, the second would block on the first.
+func TestSharedLockAllowsSharedConcurrency(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	if err := metadata.WriteMetadata(ctx, logger, map[string]string{"k": "v"}, file); err != nil {
+		t.Fatalf("seed WriteMetadata: %v", err)
+	}
+
+	const holdDuration = 200 * time.Millisecond
+
+	firstInside := make(chan struct{})
+	secondInside := make(chan struct{})
+	var firstReleased atomic.Bool
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		_ = metadata.WithSharedLock(ctx, logger, file, func() error {
+			close(firstInside)
+			time.Sleep(holdDuration)
+			firstReleased.Store(true)
+			return nil
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		// Wait for the first holder to be inside its critical
+		// section so we exercise the concurrent-shared path
+		// rather than a sequential acquire-release-acquire.
+		<-firstInside
+		_ = metadata.WithSharedLock(ctx, logger, file, func() error {
+			if firstReleased.Load() {
+				t.Errorf("second shared holder entered after first released — that exercises sequential acquisition, not concurrent")
+			}
+			close(secondInside)
+			return nil
+		})
+	}()
+
+	select {
+	case <-secondInside:
+		// Concurrent admission confirmed.
+	case <-time.After(holdDuration / 2):
+		t.Fatalf("second shared holder did not enter within %v — shared lock did not admit concurrent reader", holdDuration/2)
+	}
+
+	wg.Wait()
+}
+
+// TestConcurrentWritersDoNotTearBytes hammers the same metadata file
+// from many goroutines, each writing a different payload. With the
+// exclusive flock holding the read-and-rename window, every final read
+// observed during and after the storm must be one of the well-formed
+// payloads any writer produced — never a partial or interleaved one.
+func TestConcurrentWritersDoNotTearBytes(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	const (
+		writers      = 8
+		writesEach   = 20
+		readerProbes = 200
+	)
+
+	// Pre-create the parent so the first lock acquisition does not
+	// race the very first writer's MkdirAll. Cheap, deterministic.
+	if err := os.MkdirAll(filepath.Dir(file), 0o0755); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+
+	type payload struct {
+		Writer int    `json:"writer"`
+		Seq    int    `json:"seq"`
+		Filler string `json:"filler"`
+	}
+
+	// A wide filler keeps each payload above 4 KiB so a torn write
+	// (multiple sub-page writes interleaved at the kernel) would be
+	// observable as an unmarshal failure or as a Filler whose length
+	// does not match its expected size.
+	const fillerLen = 8 * 1024
+	filler := make([]byte, fillerLen)
+	for i := range filler {
+		filler[i] = 'x'
+	}
+	fillerStr := string(filler)
+
+	var wg sync.WaitGroup
+
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			for s := 0; s < writesEach; s++ {
+				doc := payload{Writer: id, Seq: s, Filler: fillerStr}
+				if err := metadata.WriteMetadata(ctx, logger, doc, file); err != nil {
+					t.Errorf("writer %d seq %d: %v", id, s, err)
+					return
+				}
+			}
+		}(w)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < readerProbes; i++ {
+			raw, err := metadata.ReadRaw(ctx, logger, file)
+			if err != nil {
+				if errors.Is(err, errdefs.ErrMissingMetadataFile) {
+					// First reader may arrive before the
+					// first writer renames; allow that.
+					continue
+				}
+				t.Errorf("reader probe %d: %v", i, err)
+				return
+			}
+			var got payload
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Errorf("reader probe %d: unmarshal failed on %d bytes — torn write surfaced: %v", i, len(raw), err)
+				return
+			}
+			if len(got.Filler) != fillerLen {
+				t.Errorf("reader probe %d: filler length %d, want %d — torn payload surfaced", i, len(got.Filler), fillerLen)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	// Final read must parse cleanly to one of the writers' payloads.
+	raw, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("final ReadRaw: %v", err)
+	}
+	var final payload
+	if err := json.Unmarshal(raw, &final); err != nil {
+		t.Fatalf("final unmarshal: %v on %d bytes", err, len(raw))
+	}
+	if final.Writer < 0 || final.Writer >= writers || final.Seq < 0 || final.Seq >= writesEach {
+		t.Fatalf("final payload out of range: %+v", final)
+	}
+	if len(final.Filler) != fillerLen {
+		t.Fatalf("final filler length %d, want %d", len(final.Filler), fillerLen)
+	}
+}
+
+// TestWriteMetadataCAS_FirstCreateAndSecondCreateRace covers the two
+// boundary conditions of the CAS contract: a first writer creating the
+// file from scratch (prior == nil, no file present) succeeds, and a
+// second writer that also passed prior == nil after the file exists
+// fails with ErrStaleResource.
+func TestWriteMetadataCAS_FirstCreateAndSecondCreateRace(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	doc := map[string]string{"phase": "one"}
+	if err := metadata.WriteMetadataCAS(ctx, logger, nil, doc, file); err != nil {
+		t.Fatalf("first CAS create: %v", err)
+	}
+
+	// Same prior == nil now stale: file exists.
+	err := metadata.WriteMetadataCAS(ctx, logger, nil, map[string]string{"phase": "two"}, file)
+	if !errors.Is(err, errdefs.ErrStaleResource) {
+		t.Fatalf("second CAS with prior==nil: err = %v, want ErrStaleResource", err)
+	}
+}
+
+// TestWriteMetadataCAS_StaleAfterIntermediateWrite covers the canonical
+// adoption pattern: a caller does ReadRaw + mutate + WriteMetadataCAS,
+// but another writer slipped a write in between. The CAS must fail with
+// ErrStaleResource so the caller knows to retry.
+func TestWriteMetadataCAS_StaleAfterIntermediateWrite(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	if err := metadata.WriteMetadata(ctx, logger, map[string]string{"v": "0"}, file); err != nil {
+		t.Fatalf("seed WriteMetadata: %v", err)
+	}
+	prior, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("ReadRaw prior: %v", err)
+	}
+
+	// Intervening writer — bytes on disk now diverge from `prior`.
+	if err := metadata.WriteMetadata(ctx, logger, map[string]string{"v": "intervening"}, file); err != nil {
+		t.Fatalf("intervening WriteMetadata: %v", err)
+	}
+
+	err = metadata.WriteMetadataCAS(ctx, logger, prior, map[string]string{"v": "caller-update"}, file)
+	if !errors.Is(err, errdefs.ErrStaleResource) {
+		t.Fatalf("CAS after intervening write: err = %v, want ErrStaleResource", err)
+	}
+
+	// On-disk payload must still be the intervening writer's value —
+	// CAS must not have written through on a stale check.
+	after, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("ReadRaw after: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(after, &got); err != nil {
+		t.Fatalf("unmarshal after: %v", err)
+	}
+	if got["v"] != "intervening" {
+		t.Fatalf("CAS over-wrote on stale check: got %v, want 'intervening'", got["v"])
+	}
+}
+
+// TestWriteMetadataCAS_SucceedsWhenPriorMatches exercises the happy
+// path: a caller reads, then writes back under the same observed bytes
+// without anyone else racing. The new payload must land on disk.
+func TestWriteMetadataCAS_SucceedsWhenPriorMatches(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	if err := metadata.WriteMetadata(ctx, logger, map[string]string{"v": "0"}, file); err != nil {
+		t.Fatalf("seed WriteMetadata: %v", err)
+	}
+	prior, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("ReadRaw prior: %v", err)
+	}
+
+	if err := metadata.WriteMetadataCAS(ctx, logger, prior, map[string]string{"v": "1"}, file); err != nil {
+		t.Fatalf("CAS happy path: %v", err)
+	}
+
+	raw, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("ReadRaw after: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["v"] != "1" {
+		t.Fatalf("CAS did not persist: got %v, want '1'", got["v"])
+	}
+}
+
+// TestLockFilePathIsSidecar locks the on-disk shape of the lock file:
+// it sits next to the metadata file with a deterministic suffix so
+// callers can filter it out of directory walks.
+func TestLockFilePathIsSidecar(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/opt/kukeon/data/default/metadata.json", "/opt/kukeon/data/default/metadata.json.lock"},
+		{"metadata.json", "metadata.json.lock"},
+	}
+	for _, tc := range cases {
+		if got := metadata.LockFilePath(tc.in); got != tc.want {
+			t.Errorf("LockFilePath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestWriteMetadataCreatesSidecarLockFile ensures the sidecar appears
+// next to the data file after a successful write. The phase-3 adopters
+// will rely on the sidecar being present after any write.
+func TestWriteMetadataCreatesSidecarLockFile(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	if err := metadata.WriteMetadata(ctx, logger, map[string]string{"k": "v"}, file); err != nil {
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+	if _, err := os.Stat(metadata.LockFilePath(file)); err != nil {
+		t.Fatalf("sidecar missing after WriteMetadata: %v", err)
+	}
+}
+
+// TestDeleteMetadataRemovesSidecarAndEmptyParent verifies the parent-
+// directory cleanup path still fires once the sidecar exists: without
+// the sidecar removal in DeleteMetadata, the leftover .lock entry
+// would keep the parent dir non-empty and break the cleanup.
+func TestDeleteMetadataRemovesSidecarAndEmptyParent(t *testing.T) {
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "cell")
+	file := filepath.Join(parent, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	if err := metadata.WriteMetadata(ctx, logger, map[string]string{"k": "v"}, file); err != nil {
+		t.Fatalf("seed WriteMetadata: %v", err)
+	}
+	if _, err := os.Stat(metadata.LockFilePath(file)); err != nil {
+		t.Fatalf("seed sidecar missing: %v", err)
+	}
+
+	if err := metadata.DeleteMetadata(ctx, logger, file); err != nil {
+		t.Fatalf("DeleteMetadata: %v", err)
+	}
+
+	if _, err := os.Stat(file); !os.IsNotExist(err) {
+		t.Errorf("data file still present after delete: err = %v", err)
+	}
+	if _, err := os.Stat(metadata.LockFilePath(file)); !os.IsNotExist(err) {
+		t.Errorf("sidecar still present after delete: err = %v", err)
+	}
+	if _, err := os.Stat(parent); !os.IsNotExist(err) {
+		t.Errorf("parent dir still present after delete (sidecar cleanup may have leaked): err = %v", err)
+	}
+}
+
+// TestReadRawDoesNotMaterializeSidecarForMissingFile guards the "probe
+// for an optional realm" use case: ReadRaw on a never-written path
+// must short-circuit to ErrMissingMetadataFile without creating the
+// sidecar lock file. Otherwise the daemon's list-walks would leak
+// .lock files into directories that were never intended to host
+// metadata.
+func TestReadRawDoesNotMaterializeSidecarForMissingFile(t *testing.T) {
+	tmp := t.TempDir()
+	// Make the parent dir exist (mirrors a realm-dir-but-no-spaces
+	// arrangement) so the only way a sidecar appears is via ReadRaw.
+	parent := filepath.Join(tmp, "realm")
+	if err := os.MkdirAll(parent, 0o0750); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+	file := filepath.Join(parent, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	_, err := metadata.ReadRaw(ctx, logger, file)
+	if !errors.Is(err, errdefs.ErrMissingMetadataFile) {
+		t.Fatalf("ReadRaw on missing file: err = %v, want ErrMissingMetadataFile", err)
+	}
+	if _, err := os.Stat(metadata.LockFilePath(file)); !os.IsNotExist(err) {
+		t.Errorf("sidecar leaked from probe-read of missing file: err = %v", err)
+	}
+}
+
+// TestWriteMetadataCASRetryAfterStale documents the canonical
+// retry-on-stale loop a phase-3 adopter will use: ReadRaw, mutate, CAS;
+// on ErrStaleResource re-read and retry. The loop must terminate with
+// the post-mutation payload on disk.
+func TestWriteMetadataCASRetryAfterStale(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	if err := metadata.WriteMetadata(ctx, logger, map[string]int{"counter": 0}, file); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Caller A reads.
+	priorA, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("ReadRaw A: %v", err)
+	}
+
+	// Caller B writes underneath A.
+	if err := metadata.WriteMetadata(ctx, logger, map[string]int{"counter": 100}, file); err != nil {
+		t.Fatalf("WriteMetadata B: %v", err)
+	}
+
+	// A's first CAS attempt fails.
+	err = metadata.WriteMetadataCAS(ctx, logger, priorA, map[string]int{"counter": 1}, file)
+	if !errors.Is(err, errdefs.ErrStaleResource) {
+		t.Fatalf("first CAS: err = %v, want ErrStaleResource", err)
+	}
+
+	// Retry: re-read, then CAS with the freshly observed bytes.
+	priorA, err = metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("ReadRaw A retry: %v", err)
+	}
+	var current map[string]int
+	if err := json.Unmarshal(priorA, &current); err != nil {
+		t.Fatalf("unmarshal current: %v", err)
+	}
+	current["counter"]++
+	if err := metadata.WriteMetadataCAS(ctx, logger, priorA, current, file); err != nil {
+		t.Fatalf("retry CAS: %v", err)
+	}
+
+	raw, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("ReadRaw final: %v", err)
+	}
+	var got map[string]int
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal final: %v", err)
+	}
+	if got["counter"] != 101 {
+		t.Fatalf("counter after retry = %d, want 101", got["counter"])
+	}
+}
+
+// TestWriteMetadataNoLockUnderWithExclusiveLock asserts the
+// caller-holds-the-lock helper pair works end-to-end: a caller can
+// acquire the exclusive flock once, do an arbitrary read + write
+// sequence under it, and observe a coherent payload — without the
+// inner write deadlocking on its own attempted acquisition.
+func TestWriteMetadataNoLockUnderWithExclusiveLock(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	if err := metadata.WriteMetadata(ctx, logger, map[string]int{"x": 0}, file); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		err := metadata.WithExclusiveLock(ctx, logger, file, func() error {
+			raw, readErr := metadata.ReadRawNoLock(ctx, logger, file)
+			if readErr != nil {
+				return fmt.Errorf("inner read: %w", readErr)
+			}
+			var doc map[string]int
+			if jsonErr := json.Unmarshal(raw, &doc); jsonErr != nil {
+				return fmt.Errorf("inner unmarshal: %w", jsonErr)
+			}
+			doc["x"]++
+			return metadata.WriteMetadataNoLock(ctx, logger, doc, file)
+		})
+		if err != nil {
+			t.Errorf("WithExclusiveLock fn: %v", err)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("WithExclusiveLock + No-Lock helpers deadlocked")
+	}
+
+	raw, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("final ReadRaw: %v", err)
+	}
+	var got map[string]int
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["x"] != 1 {
+		t.Fatalf("inner increment did not land: got %d, want 1", got["x"])
+	}
+}

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -210,10 +210,15 @@ func ReadRaw(ctx context.Context, logger *slog.Logger, file string) ([]byte, err
 // The sidecar lock file at <file>.lock is removed alongside the data
 // file so the parent-directory cleanup path still fires — without this,
 // the leftover .lock entry would keep the empty-dir branch from
-// triggering. The lock is not acquired during deletion because the
-// caller is teardown logic that owns the entity exclusively (cell /
-// stack / space / realm delete); racing writers on a being-deleted
-// resource is out of scope for the phase-1 primitives.
+// triggering.
+//
+// The remove window runs under the same exclusive flock writers take so
+// a concurrent WriteMetadata mid-write cannot end with a data file
+// stranded without its sidecar (the writer's atomicWriteFile rename
+// would otherwise race the unlocked deleter's rm-sidecar). The
+// existsFilePath short-circuit before the flock keeps the fast path
+// (nothing to delete) cheap; a sibling deleter racing past the
+// short-circuit is tolerated via IsNotExist on the actual os.Remove.
 func DeleteMetadata(ctx context.Context, logger *slog.Logger, file string) error {
 	logger.DebugContext(ctx, "deleting metadata", "file", file)
 
@@ -222,41 +227,38 @@ func DeleteMetadata(ctx context.Context, logger *slog.Logger, file string) error
 		return nil // Idempotent: file doesn't exist, consider it deleted
 	}
 
-	// Delete the metadata file
-	if err := os.Remove(file); err != nil {
-		logger.ErrorContext(ctx, "failed to delete metadata file", "file", file, "error", err)
-		return fmt.Errorf("failed to delete metadata file %s: %w", file, err)
-	}
-
-	logger.InfoContext(ctx, "deleted metadata file", "file", file)
-
-	// Best-effort removal of the sidecar lock file. A missing sidecar is
-	// fine (pre-flock writes or a writer that never created it); any
-	// other error is logged but not surfaced so a stale lock leftover
-	// cannot block the higher-level teardown.
-	lockPath := LockFilePath(file)
-	if rmErr := os.Remove(lockPath); rmErr != nil && !os.IsNotExist(rmErr) {
-		logger.DebugContext(ctx, "could not remove sidecar lock file", "file", lockPath, "error", rmErr)
-	}
-
-	// Try to remove the parent directory if it's empty
-	dir := filepath.Dir(file)
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		// Directory might not exist or we can't read it - that's OK
-		logger.DebugContext(ctx, "could not read directory, skipping directory removal", "dir", dir, "error", err)
-		return nil
-	}
-
-	// If directory is empty (only . and ..), remove it
-	if len(entries) == 0 {
-		if err = os.Remove(dir); err != nil {
-			logger.DebugContext(ctx, "could not remove empty directory", "dir", dir, "error", err)
-			// Don't fail if we can't remove the directory
-		} else {
-			logger.DebugContext(ctx, "removed empty metadata directory", "dir", dir)
+	return WithExclusiveLock(ctx, logger, file, func() error {
+		if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
+			logger.ErrorContext(ctx, "failed to delete metadata file", "file", file, "error", err)
+			return fmt.Errorf("failed to delete metadata file %s: %w", file, err)
 		}
-	}
 
-	return nil
+		logger.InfoContext(ctx, "deleted metadata file", "file", file)
+
+		// Best-effort removal of the sidecar lock file. A missing sidecar
+		// is fine (pre-flock writes or a writer that never created it);
+		// any other error is logged but not surfaced so a stale lock
+		// leftover cannot block the higher-level teardown.
+		lockPath := LockFilePath(file)
+		if rmErr := os.Remove(lockPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			logger.DebugContext(ctx, "could not remove sidecar lock file", "file", lockPath, "error", rmErr)
+		}
+
+		// Try to remove the parent directory if it's empty.
+		dir := filepath.Dir(file)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			logger.DebugContext(ctx, "could not read directory, skipping directory removal", "dir", dir, "error", err)
+			return nil
+		}
+		if len(entries) == 0 {
+			if err = os.Remove(dir); err != nil {
+				logger.DebugContext(ctx, "could not remove empty directory", "dir", dir, "error", err)
+			} else {
+				logger.DebugContext(ctx, "removed empty metadata directory", "dir", dir)
+			}
+		}
+
+		return nil
+	})
 }

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -46,7 +46,22 @@ func existsFilePath(filepath string) bool {
 	return !os.IsNotExist(err)
 }
 
+// WriteMetadata persists the JSON-encoded payload at `file` while holding
+// an exclusive flock on the sidecar lock file. The flock is the daemon /
+// `kuke --no-daemon` cross-boundary mutex for the data file's inode; it
+// prevents torn writes when more than one process — or more than one
+// goroutine — tries to update the same metadata document concurrently.
 func WriteMetadata(ctx context.Context, logger *slog.Logger, metadata any, file string) error {
+	return WithExclusiveLock(ctx, logger, file, func() error {
+		return writeMetadataUnlocked(ctx, logger, metadata, file)
+	})
+}
+
+// writeMetadataUnlocked is the inner write helper invoked under the
+// sidecar exclusive flock. It assumes the caller already holds the lock
+// — calling it without the lock is a torn-write footgun and is only
+// safe through WriteMetadata, WriteMetadataNoLock, or WriteMetadataCAS.
+func writeMetadataUnlocked(ctx context.Context, logger *slog.Logger, metadata any, file string) error {
 	logger.DebugContext(ctx, "creating metadata", "file", file)
 
 	if existsFilePath(file) {
@@ -158,21 +173,47 @@ func ReadMetadata[T any](ctx context.Context, logger *slog.Logger, file string) 
 	return out, nil
 }
 
-// ReadRaw reads the metadata file and returns the raw bytes for external decoding.
+// ReadRaw reads the metadata file and returns the raw bytes for external
+// decoding while holding a shared flock on the sidecar lock file. The
+// shared flock keeps concurrent ReadRaw calls non-blocking against each
+// other but blocks them against any in-flight WriteMetadata holder, so a
+// reader never observes a partially-written or post-rename-but-pre-sync
+// payload.
+//
+// A nonexistent data file short-circuits to ErrMissingMetadataFile
+// without acquiring the flock or materialising the sidecar — that keeps
+// "probe whether this realm exists" reads from leaving lock-file detritus
+// in directories that were never written to.
 func ReadRaw(ctx context.Context, logger *slog.Logger, file string) ([]byte, error) {
 	logger.DebugContext(ctx, "reading raw metadata", "file", file)
 	if !existsFilePath(file) {
 		logger.ErrorContext(ctx, "metadata file does not exist", "file", file)
 		return nil, fmt.Errorf("metadata file does not exist: %w", errdefs.ErrMissingMetadataFile)
 	}
-	data, err := os.ReadFile(file)
+	var raw []byte
+	err := WithSharedLock(ctx, logger, file, func() error {
+		data, readErr := ReadRawNoLock(ctx, logger, file)
+		if readErr != nil {
+			return readErr
+		}
+		raw = data
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", file, err)
+		return nil, err
 	}
-	return data, nil
+	return raw, nil
 }
 
 // DeleteMetadata removes a metadata file and its directory if empty.
+//
+// The sidecar lock file at <file>.lock is removed alongside the data
+// file so the parent-directory cleanup path still fires — without this,
+// the leftover .lock entry would keep the empty-dir branch from
+// triggering. The lock is not acquired during deletion because the
+// caller is teardown logic that owns the entity exclusively (cell /
+// stack / space / realm delete); racing writers on a being-deleted
+// resource is out of scope for the phase-1 primitives.
 func DeleteMetadata(ctx context.Context, logger *slog.Logger, file string) error {
 	logger.DebugContext(ctx, "deleting metadata", "file", file)
 
@@ -188,6 +229,15 @@ func DeleteMetadata(ctx context.Context, logger *slog.Logger, file string) error
 	}
 
 	logger.InfoContext(ctx, "deleted metadata file", "file", file)
+
+	// Best-effort removal of the sidecar lock file. A missing sidecar is
+	// fine (pre-flock writes or a writer that never created it); any
+	// other error is logged but not surfaced so a stale lock leftover
+	// cannot block the higher-level teardown.
+	lockPath := LockFilePath(file)
+	if rmErr := os.Remove(lockPath); rmErr != nil && !os.IsNotExist(rmErr) {
+		logger.DebugContext(ctx, "could not remove sidecar lock file", "file", lockPath, "error", rmErr)
+	}
 
 	// Try to remove the parent directory if it's empty
 	dir := filepath.Dir(file)


### PR DESCRIPTION
## Summary

- Phase 1 of the three-phase metadata-concurrency split (#205): adds the locking and stale-detection primitives in `internal/metadata/` without yet adopting the CAS API in any caller.
- `WriteMetadata` now acquires an exclusive flock on a sidecar `<file>.lock` for the full write window, and `ReadRaw` acquires a shared flock — gaining torn-write protection across the daemon and `kuke --no-daemon` boundary today.
- New `WriteMetadataCAS(ctx, logger, prior, metadata, file)` exposes the read-compare-write primitive under the same exclusive flock; returns `errdefs.ErrStaleResource` (also new) when on-disk bytes diverged from the caller's observed `prior`. `WithExclusiveLock` / `WithSharedLock` + `WriteMetadataNoLock` / `ReadRawNoLock` are also exported for the cases phase 3 wants more control over the RMW window.
- `DeleteMetadata` removes the `.lock` sidecar alongside the data file so the existing empty-parent-cleanup branch still fires (preserves prior behavior), AND now wraps its remove window in `WithExclusiveLock` so a concurrent `WriteMetadata` mid-write cannot end with a data file stranded without its sidecar. These are the two out-of-AC touches — flagged here so the reviewer can push back.

## Design choices worth flagging

- **Sidecar `<file>.lock`, not the data file.** `WriteMetadata` persists via temp-file + rename; renaming swaps the data file's inode, which would detach any flock held on the old inode. The sidecar's inode is stable across writes, so the lock identity is preserved.
- **`ReadRaw` short-circuits to `ErrMissingMetadataFile` before acquiring the flock.** Otherwise probe-reads of optional realms (`ListSpaces` walks call `ReadRaw` on `<space>/metadata.json` that may not exist) would leak `.lock` sidecars into directories that were never written. The TOCTOU window matches the pre-existing snapshot semantics — a writer arriving after the existence check is just the same race callers already tolerate.
- **Shared-lock acquire is side-effect-free.** `acquireFlock` only `MkdirAll`s the parent and `O_CREATE`s the sidecar on the exclusive path; the shared path opens without `O_CREATE` and surfaces `ErrMissingMetadataFile` if the sidecar is absent. Closes the TOCTOU window where a sibling `DeleteMetadata` swept the parent dir between `ReadRaw`'s existence pre-check and the lock acquire — without this, the shared acquire would resurrect parent dir + a fresh `.lock` only to leak both after returning `ErrMissingMetadataFile`.
- **CAS compares raw payload bytes**, not a re-marshaled document — the doc comment makes this contract explicit because JSON serialization is not guaranteed byte-stable across edits.
- **`syscall.Flock`** rather than `golang.org/x/sys/unix.Flock` keeps the dependency surface unchanged (the project is Linux-only, already uses `syscall.SIGTERM` etc.).

## Test plan

- [x] `make test` — full named CI target, all packages green (including new `internal/metadata` tests).
- [x] `make dev-init` smoke — daemon parity check passes; `kuke get realms` and `kuke get realms --no-daemon` produce identical output, confirming the daemon's read path correctly traverses the flocked metadata. Re-run after the resurrection-fix landed because that fix touches the daemon's read-path flock handling.
- [x] New tests in `internal/metadata/lock_test.go`:
  - exclusive flock blocks both exclusive and shared acquisitions
  - shared flock admits concurrent shared holders
  - concurrent writers × 8 / 20 each on the same file produce no torn payload (8 KiB filler probed by a parallel reader)
  - `WriteMetadataCAS` returns `ErrStaleResource` on intervening-write, on `prior==nil` after first create, and on the canonical read-mutate-retry loop
  - `ReadRaw` does not leak a sidecar for missing data files
  - `WithExclusiveLock` + `WriteMetadataNoLock` / `ReadRawNoLock` work end-to-end without deadlocking the inner write
  - **NEW:** `WithSharedLock` after a sibling `DeleteMetadata` swept the parent dir returns `ErrMissingMetadataFile` AND does NOT resurrect the parent dir or sidecar on disk (deterministic regression for the reviewer's leak).
  - **NEW:** Stress probe with 8 writers + 8 readers + 4 deleters × 50 iters on the same path — after the storm drains, the parent dir is either absent or contains exactly `{data, sidecar}`; never an orphan dir, stray `.lock`, or data file without its sidecar.

## Out of scope (phases 2 & 3)

- Phase 2 (#596): `Generation` / `ObservedGeneration` fields on internal + external Realm/Space/Stack/Cell types and the 8 apischeme converters.
- Phase 3 (#597): adoption of `WriteMetadataCAS` in `internal/controller/runner/metadata.go` `Update*Metadata` writers and reconciler skip-on-stale on top of these primitives.

Closes #205