### PR TITLE
fix(metadata): materialise sidecar on shared-lock read of pre-#607 data

### DIFF
--- a/internal/metadata/lock.go
+++ b/internal/metadata/lock.go
@@ -64,12 +64,14 @@ func LockFilePath(file string) string {
 //     WriteMetadata's existing create-new path. A writer always lands
 //     a sidecar — Phase 3 adopters can rely on that invariant.
 //
-//   - Shared (read path): neither the parent directory nor the sidecar
-//     is created. A missing sidecar surfaces as ErrMissingMetadataFile
-//     so a sibling DeleteMetadata that swept between the caller's
-//     existence pre-check and this acquire cannot be papered over by
-//     resurrecting a stale parent + sidecar that then leak after the
-//     read returns ErrMissingMetadataFile anyway.
+//   - Shared (read path): the sidecar is opened without O_CREATE so a
+//     sibling DeleteMetadata that swept between the caller's existence
+//     pre-check and this acquire surfaces as ErrMissingMetadataFile
+//     instead of being papered over by a resurrected parent + sidecar
+//     that then leak. The legacy fall-through below distinguishes that
+//     TOCTOU case from a data file written by a pre-sidecar binary
+//     (#607 rollout) where the data file is still on disk but its
+//     sidecar was never materialised.
 func acquireFlock(file string, exclusive bool) (func(), error) {
 	if exclusive {
 		parent := filepath.Dir(file)
@@ -83,13 +85,23 @@ func acquireFlock(file string, exclusive bool) (func(), error) {
 		openFlag |= os.O_CREATE
 	}
 	f, openErr := os.OpenFile(lockPath, openFlag, lockFilePerm)
-	if openErr != nil {
-		if !exclusive && os.IsNotExist(openErr) {
+	if openErr != nil && !exclusive && os.IsNotExist(openErr) {
+		// Either (a) the data file was concurrently deleted — the
+		// TOCTOU sweep ReadRaw's existence pre-check defends against,
+		// or (b) the data file is still on disk but was written by a
+		// pre-#607 binary that never staged a sidecar. Re-check the
+		// data file: gone → surface ErrMissingMetadataFile without
+		// resurrecting parent + sidecar; present → materialise the
+		// sidecar so legacy state stays readable.
+		if !existsFilePath(file) {
 			return nil, fmt.Errorf(
 				"sidecar lock file missing for %s: %w",
 				file, errdefs.ErrMissingMetadataFile,
 			)
 		}
+		f, openErr = os.OpenFile(lockPath, openFlag|os.O_CREATE, lockFilePerm)
+	}
+	if openErr != nil {
 		return nil, fmt.Errorf("open lock file %s: %w", lockPath, openErr)
 	}
 	mode := syscall.LOCK_SH

--- a/internal/metadata/lock_test.go
+++ b/internal/metadata/lock_test.go
@@ -576,6 +576,48 @@ func TestWithSharedLockDoesNotResurrectAfterDelete(t *testing.T) {
 	}
 }
 
+// TestWithSharedLockReadsLegacyMetadataWithoutSidecar guards the
+// rollout path for #607: a host whose metadata files were written by a
+// pre-sidecar binary still has the data file on disk but no `.lock`
+// sidecar next to it. The shared-lock acquire must materialise the
+// sidecar in that case and let the read proceed, instead of treating
+// the missing sidecar as ErrMissingMetadataFile (which would surface
+// upstream as ErrRealmNotFound and break `kuke get realms --no-daemon`
+// + `kuke image load --realm …` on any host upgraded across the #607
+// boundary). The TOCTOU branch — data file ALSO missing — stays
+// covered by TestWithSharedLockDoesNotResurrectAfterDelete above.
+func TestWithSharedLockReadsLegacyMetadataWithoutSidecar(t *testing.T) {
+	tmp := t.TempDir()
+	parent := filepath.Join(tmp, "realm")
+	if err := os.MkdirAll(parent, 0o0750); err != nil {
+		t.Fatalf("mkdir parent: %v", err)
+	}
+	file := filepath.Join(parent, "metadata.json")
+	logger := discardLogger()
+	ctx := context.Background()
+
+	// Stage the data file directly to simulate pre-#607 on-disk state:
+	// the data is there, the sidecar is not.
+	want := []byte(`{"k":"v"}`)
+	if err := os.WriteFile(file, want, 0o0640); err != nil {
+		t.Fatalf("seed legacy data file: %v", err)
+	}
+	if _, statErr := os.Stat(metadata.LockFilePath(file)); !os.IsNotExist(statErr) {
+		t.Fatalf("precondition: sidecar should not exist, stat err = %v", statErr)
+	}
+
+	got, err := metadata.ReadRaw(ctx, logger, file)
+	if err != nil {
+		t.Fatalf("ReadRaw on legacy file: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("ReadRaw payload = %q, want %q", got, want)
+	}
+	if _, statErr := os.Stat(metadata.LockFilePath(file)); statErr != nil {
+		t.Errorf("sidecar not materialised after legacy ReadRaw: stat err = %v", statErr)
+	}
+}
+
 // TestStressConcurrentWriteReadDelete hammers the same path with
 // concurrent Write/Read/Delete goroutines. After every goroutine
 // returns, the working dir must be in one of two well-defined terminal


### PR DESCRIPTION
## Summary

- **Symptom:** on a host upgraded across the #607 boundary, `make dev-init` fails at the `kuke image load --realm kuke-system` step with `Error: realm not found: kuke-system`. The same host also reports `No realms found.` from `kuke get realms --no-daemon`, even though `/opt/kukeon/data/{default,kuke-system}/metadata.json` are both on disk.
- **Cause:** PR #607's shared-lock read path opens the sidecar `.lock` without `O_CREATE` and turns `IsNotExist` into `ErrMissingMetadataFile`. Upstream that becomes `ErrRealmNotFound` (`internal/controller/runner/get.go:38`). Pre-#607 binaries wrote the data file without ever staging a sidecar, so the first read by a post-#607 binary on any such file is a miss.
- **Fix:** in `acquireFlock`'s shared path, distinguish the two missing-sidecar cases. Data file gone → preserve the TOCTOU behaviour the existing comment describes (return `ErrMissingMetadataFile` without resurrecting parent + sidecar; `TestWithSharedLockDoesNotResurrectAfterDelete` still passes). Data file present → materialise the sidecar with `O_CREATE` so legacy state stays readable.
- **Race analysis:** `DeleteMetadata` holds the exclusive flock while it unlinks the data file and sidecar, so any reader that races into the legacy branch either (a) opens an inode the deleter still holds exclusively and then sees the data file gone under `ReadRawNoLock` (returns `ErrMissingMetadataFile`), or (b) opens a fresh sidecar inode the deleter never touched and reads a still-extant data file. Concurrent legacy readers/writers serialise on the materialised sidecar normally.

## Test plan

- [x] `go test ./internal/metadata/...` — new `TestWithSharedLockReadsLegacyMetadataWithoutSidecar` asserts ReadRaw on a sidecar-less data file returns the payload and materialises the sidecar. Existing TOCTOU test (`TestWithSharedLockDoesNotResurrectAfterDelete`) still passes because it removes the whole parent dir, so the legacy fall-through's data-file existence check correctly fails.
- [x] `make dev-init` end-to-end on a host carrying pre-#607 `/opt/kukeon/data/{default,kuke-system}/metadata.json` (no sidecars). Daemon parity check now shows both realms in both `kuke get realms` and `kuke get realms --no-daemon`. kuke-attach smoke roundtrips cleanly. Sidecars present in `/opt/kukeon/data/` after the run.
