### PR TITLE
build(deps): bump sbsh to v0.11.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.11.3
+	github.com/eminwux/sbsh v0.11.4
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.11.3 h1:Y05/45HCacxA4RM0cizAw1NdQQTIkWzID/ITOfP72n0=
-github.com/eminwux/sbsh v0.11.3/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
+github.com/eminwux/sbsh v0.11.4 h1:HWtdqOUIkgpbAGNGZwzHey3pUYMDI/IlxUnOD3vIFvM=
+github.com/eminwux/sbsh v0.11.4/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Summary

- sbsh v0.11.4 ships [eminwux/sbsh#274](https://github.com/eminwux/sbsh/pull/274) (option A from sbsh#273 — the upstream filed under AC1 of this issue), which makes the `terminals/<id>/` subdir implicit-opt-out: when an embedder supplies all three of `WithLogFile` / `WithCaptureFile` / `WithSocketFile`, the builder sets a new `TerminalSpec.MetadataDir` to `LogFile.dirname` and the runner places `metadata.json` there directly instead of `MkdirAll`-ing `runPath/terminals/<id>/`.
- Kukeon already supplies all three via `internal/controller/runner/attachable.go:193,201,256` — defaulting to `/run/kukeon/tty/{socket,capture,kuketty.log}`, the same per-container tty bind-mount dir — so the bump is enough to trigger the opt-out. No new builder option exists; no kukeon code change is required beyond the version pin.

## Context — AC reinterpretation

The issue's AC2 references a zeroing workaround at `internal/controller/runner/attachable.go:270-284` (`terminalSpec.LogFile = ""` / `LogFileMode = 0` / `LogFileGID = nil`). That workaround was already removed by #608 (always-on kuketty debug log), so AC2 as written has no code left to simplify — confirmed by re-reading the current tree before opening this PR (lines 270-284 are now the `WithCommand` opt + `BuildTerminalSpec` call + `TerminalDoc` construction). Following CLAUDE.md's "issue body's premise has rotted but intent is still inferable" path: this PR proceeds with the reinterpreted scope (bump + AC3 verification) and surfaces the divergence here for the reviewer.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — full unit-test sweep passes
- [x] `make dev-init` — daemon-parity check shows both `kuke get realms` views identical (`default` + `kuke-system`, both Ready); the canonical `kuke attach` smoke against a kuketty-wrapped cell completes; nested-mode post-flight verifies parent host attach plumbing intact
- [x] **AC3 — no stray `terminals/` subdir at runtime** — created a disposable attachable cell on the nested v0.11.4 daemon (realm `verify-600`, cell `cverify`, attachable container `work`). After kuketty bound the per-container socket:
  - `/opt/kukeon/data/verify-600/vs/vks/cverify/work/tty/` contains exactly `capture`, `kuketty.log`, `metadata.json`, `socket` — **no `terminals/` subdir**.
  - Rendered `metadata.json` carries `"metadataDir": "/run/kukeon/tty"` confirming sbsh's new field is set; kuketty's `CreateMetadata` log shows the override path used verbatim and `metadata.json` placed at the tty root rather than under `terminals/<id>/`.

## Acceptance criteria

- [x] AC1 — upstream sbsh issue filed: [eminwux/sbsh#273](https://github.com/eminwux/sbsh/issues/273), implemented via [eminwux/sbsh#274](https://github.com/eminwux/sbsh/pull/274) (shipped in sbsh v0.11.4)
- [x] AC2 — workaround at `internal/controller/runner/attachable.go:270-284` simplified or removed: already removed by #608 (premise rot — see Context above); no code change needed in this PR
- [x] AC3 — no stray `terminals/` subdir under any cell's per-container `tty/` at runtime — verified manually under the nested daemon (see Test plan)

Closes #600