### PR TITLE
fix(daemon): probe kukeond socket alongside cell metadata in lifecycle verbs

### DIFF
--- a/cmd/kuke/daemon/internal/lifecycle/lifecycle.go
+++ b/cmd/kuke/daemon/internal/lifecycle/lifecycle.go
@@ -24,13 +24,16 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
+	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // MockClientKey injects a kukeonv1.Client (typically a fake) via the command
@@ -45,6 +48,13 @@ type MockClientKey struct{}
 // verbs cannot drift on what "graceful" means.
 const DefaultTimeout = 10 * time.Second
 
+// DefaultReachableTimeout is the dial budget the lifecycle verbs use when
+// probing the kukeond socket. Short on purpose: the only acceptable failure
+// mode here is "the socket is dead" — a healthy daemon answers in <1ms over
+// the local unix socket, so 500ms is generous and a hung accept still
+// surfaces fast enough that the operator notices.
+const DefaultReachableTimeout = 500 * time.Millisecond
+
 // IsCellRunning treats the cell as live if any container reports Ready, or
 // if the persisted cell state is Ready. Every `kuke daemon` lifecycle verb
 // uses this to agree on what "running" means; the controller's StartCell
@@ -57,6 +67,63 @@ func IsCellRunning(cell v1beta1.CellDoc) bool {
 		}
 	}
 	return cell.Status.State == v1beta1.CellStateReady
+}
+
+// ReachableProbe reports whether a kukeond socket at socketPath answers a
+// short-budget dial. The lifecycle verbs use it together with IsCellRunning
+// to disambiguate the two staleness directions: persisted state says Ready
+// while the daemon has been externally killed (socket=down → start must
+// re-bring it up, stop must not silently no-op), and persisted state lags
+// behind a live daemon (socket=up → stop/kill must not silently no-op).
+type ReachableProbe func(ctx context.Context, socketPath string, timeout time.Duration) bool
+
+// ReachableProbeKey injects a custom ReachableProbe via the command context
+// so unit tests can drive the verbs without a real listening socket. Same
+// pattern as MockClientKey; production verbs call ResolveReachableProbe to
+// pick either the injected fake or the net.Dialer-backed default.
+type ReachableProbeKey struct{}
+
+// IsDaemonReachable is the production reachability probe: a bounded
+// net.Dialer-backed dial of the kukeond unix socket. Empty socketPath is
+// treated as unreachable so a missing config does not masquerade as "up".
+// The dial errors are intentionally not surfaced to the caller — the only
+// question this answers is "did the socket accept a connection within the
+// budget?", and any error (ENOENT, ECONNREFUSED, ETIMEDOUT) maps to no.
+func IsDaemonReachable(ctx context.Context, socketPath string, timeout time.Duration) bool {
+	if socketPath == "" {
+		return false
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var d net.Dialer
+	conn, err := d.DialContext(dialCtx, "unix", socketPath)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// ResolveReachableProbe picks the probe a lifecycle verb uses. Tests inject
+// a fake via ReachableProbeKey; production returns IsDaemonReachable. The
+// indirection lets every verb call the same one-liner without duplicating
+// the context-value lookup or hard-coding the default.
+func ResolveReachableProbe(cmd *cobra.Command) ReachableProbe {
+	if probe, ok := cmd.Context().Value(ReachableProbeKey{}).(ReachableProbe); ok && probe != nil {
+		return probe
+	}
+	return IsDaemonReachable
+}
+
+// ResolveSocketPath returns the kukeond socket path the reachability probe
+// should dial. Honours an explicit KUKEOND_SOCKET (env or viper) and falls
+// back to the registered default. Centralised so every lifecycle verb agrees
+// on which socket counts as the source of truth.
+func ResolveSocketPath() string {
+	if path := viper.GetString(config.KUKEOND_SOCKET.ViperKey); path != "" {
+		return path
+	}
+	return config.KUKEOND_SOCKET.Default
 }
 
 // StopPhase runs the graceful StopCell → SIGKILL escalation used by

--- a/cmd/kuke/daemon/internal/lifecycle/lifecycle_test.go
+++ b/cmd/kuke/daemon/internal/lifecycle/lifecycle_test.go
@@ -21,16 +21,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func TestIsCellRunning(t *testing.T) {
@@ -174,6 +178,73 @@ func TestStopPhase_KillNoChangeWrapsSentinel(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "kill kukeond cell:") {
 		t.Fatalf("want wrap prefix \"kill kukeond cell:\", got %q", err.Error())
+	}
+}
+
+// TestIsDaemonReachable_Listening verifies the production probe answers true
+// against a real unix-socket listener. Pairs with the not-listening case to
+// pin both branches of the dial result.
+func TestIsDaemonReachable_Listening(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "kukeond.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	if !lifecycle.IsDaemonReachable(context.Background(), socketPath, 500*time.Millisecond) {
+		t.Fatal("IsDaemonReachable returned false against a real listener")
+	}
+}
+
+// TestIsDaemonReachable_NotListening verifies the production probe answers
+// false when the socket path does not exist. Empty paths must also resolve
+// to false rather than dialing the empty string and surfacing a confusing
+// "invalid address" error.
+func TestIsDaemonReachable_NotListening(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.sock")
+	if lifecycle.IsDaemonReachable(context.Background(), missing, 100*time.Millisecond) {
+		t.Fatal("IsDaemonReachable returned true against a missing socket")
+	}
+	if lifecycle.IsDaemonReachable(context.Background(), "", 100*time.Millisecond) {
+		t.Fatal("IsDaemonReachable returned true for an empty socket path")
+	}
+}
+
+// TestResolveReachableProbe_DefaultAndInjected confirms the indirection
+// returns the production probe by default and honours a context-injected
+// fake — the contract every lifecycle verb relies on for unit testing.
+func TestResolveReachableProbe_DefaultAndInjected(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	if probe := lifecycle.ResolveReachableProbe(cmd); probe == nil {
+		t.Fatal("default probe must not be nil")
+	}
+
+	injected := func(_ context.Context, _ string, _ time.Duration) bool { return true }
+	cmd.SetContext(
+		context.WithValue(context.Background(), lifecycle.ReachableProbeKey{}, lifecycle.ReachableProbe(injected)),
+	)
+	probe := lifecycle.ResolveReachableProbe(cmd)
+	if !probe(context.Background(), "ignored", time.Millisecond) {
+		t.Fatal("ResolveReachableProbe did not return the injected fake")
+	}
+}
+
+// TestResolveSocketPath honours both an explicit viper override and the
+// registered default. Centralising the lookup means every lifecycle verb
+// agrees on which socket counts as the source of truth.
+func TestResolveSocketPath(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	if got := lifecycle.ResolveSocketPath(); got != config.KUKEOND_SOCKET.Default {
+		t.Fatalf("default path: got %q, want %q", got, config.KUKEOND_SOCKET.Default)
+	}
+
+	viper.Set(config.KUKEOND_SOCKET.ViperKey, "/run/kukeon-dev/kukeond.sock")
+	if got := lifecycle.ResolveSocketPath(); got != "/run/kukeon-dev/kukeond.sock" {
+		t.Fatalf("override path: got %q, want %q", got, "/run/kukeon-dev/kukeond.sock")
 	}
 }
 

--- a/cmd/kuke/daemon/kill/kill.go
+++ b/cmd/kuke/daemon/kill/kill.go
@@ -79,11 +79,28 @@ func runKill(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !lifecycle.IsCellRunning(getRes.Cell) {
+		probe := lifecycle.ResolveReachableProbe(cmd)
+		socketPath := lifecycle.ResolveSocketPath()
+		if !probe(cmd.Context(), socketPath, lifecycle.DefaultReachableTimeout) {
+			cmd.Printf(
+				"kukeond is already stopped (cell %q in realm %q)\n",
+				consts.KukeSystemCellName, consts.KukeSystemRealmName,
+			)
+			return nil
+		}
+		// Persisted state reads not-Ready but the socket answers — the
+		// daemon is up and metadata lags. Fall through to KillCell rather
+		// than silently no-op while the daemon is still serving.
 		cmd.Printf(
-			"kukeond is already stopped (cell %q in realm %q)\n",
-			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+			"kukeond metadata reports not-Ready but socket %s is reachable; killing cell\n",
+			socketPath,
 		)
-		return nil
+		logger.WarnContext(cmd.Context(),
+			"daemon metadata stale: marked not-Ready but socket reachable; killing cell",
+			"socket", socketPath,
+			"cell", consts.KukeSystemCellName,
+			"realm", consts.KukeSystemRealmName,
+		)
 	}
 
 	killRes, err := client.KillCell(cmd.Context(), doc)

--- a/cmd/kuke/daemon/kill/kill_test.go
+++ b/cmd/kuke/daemon/kill/kill_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	kill "github.com/eminwux/kukeon/cmd/kuke/daemon/kill"
@@ -35,6 +36,14 @@ import (
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// fixedProbe returns a ReachableProbe that always reports `reachable`. Used
+// to drive the socket-staleness branches deterministically without needing a
+// real listening socket — the production default would dial the configured
+// KUKEOND_SOCKET path, which is host-state dependent.
+func fixedProbe(reachable bool) lifecycle.ReachableProbe {
+	return func(_ context.Context, _ string, _ time.Duration) bool { return reachable }
+}
 
 // TestMain mocks the shared euid lookup to euid=0 for every test in this
 // package so the fail-fast root gate in runKill does not short-circuit the
@@ -52,6 +61,7 @@ func TestDaemonKill(t *testing.T) {
 	tests := []struct {
 		name       string
 		fake       *fakeClient
+		probe      lifecycle.ReachableProbe
 		wantErr    string
 		wantOutput string
 	}{
@@ -80,7 +90,7 @@ func TestDaemonKill(t *testing.T) {
 			wantOutput: `kukeond force-killed (cell "kukeond" in realm "kuke-system")`,
 		},
 		{
-			name: "already-stopped cell is a no-op",
+			name: "already-stopped cell with unreachable socket is a no-op",
 			fake: &fakeClient{
 				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 					return kukeonv1.GetCellResult{
@@ -95,7 +105,31 @@ func TestDaemonKill(t *testing.T) {
 					return kukeonv1.KillCellResult{}, nil
 				},
 			},
+			probe:      fixedProbe(false),
 			wantOutput: `kukeond is already stopped (cell "kukeond" in realm "kuke-system")`,
+		},
+		{
+			// Other-direction staleness fix (#611): metadata reads
+			// not-Ready but the socket still answers, so the daemon is up
+			// and the controller's status simply lags. Old behaviour would
+			// silently no-op; new behaviour falls through to KillCell so
+			// the live daemon is actually torn down.
+			name: "metadata says not-Ready but socket is reachable falls through to KillCell",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+					return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+				},
+			},
+			probe:      fixedProbe(true),
+			wantOutput: "metadata reports not-Ready but socket",
 		},
 		{
 			name: "host not initialized",
@@ -169,6 +203,9 @@ func TestDaemonKill(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
+			if tt.probe != nil {
+				ctx = context.WithValue(ctx, lifecycle.ReachableProbeKey{}, tt.probe)
+			}
 			cmd.SetContext(ctx)
 			cmd.SetArgs(nil)
 

--- a/cmd/kuke/daemon/restart/restart.go
+++ b/cmd/kuke/daemon/restart/restart.go
@@ -92,15 +92,40 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 		return errdefs.ErrHostNotInitialized
 	}
 
-	if lifecycle.IsCellRunning(getRes.Cell) {
-		if stopErr := lifecycle.StopPhase(cmd, client, doc, timeout); stopErr != nil {
-			return stopErr
-		}
-	} else {
+	probe := lifecycle.ResolveReachableProbe(cmd)
+	socketPath := lifecycle.ResolveSocketPath()
+	socketReachable := probe(cmd.Context(), socketPath, lifecycle.DefaultReachableTimeout)
+	cellRunning := lifecycle.IsCellRunning(getRes.Cell)
+	switch {
+	case !cellRunning && !socketReachable:
 		cmd.Printf(
 			"kukeond was already stopped (cell %q in realm %q)\n",
 			consts.KukeSystemCellName, consts.KukeSystemRealmName,
 		)
+	case !cellRunning && socketReachable:
+		// Metadata lags behind a live daemon — fall through to StopPhase
+		// rather than skipping the stop phase and trying to re-start on
+		// top of an already-running cell.
+		cmd.Printf(
+			"kukeond metadata reports not-Ready but socket %s is reachable; stopping cell\n",
+			socketPath,
+		)
+		logger.WarnContext(cmd.Context(),
+			"daemon metadata stale: marked not-Ready but socket reachable; stopping cell",
+			"socket", socketPath,
+			"cell", consts.KukeSystemCellName,
+			"realm", consts.KukeSystemRealmName,
+		)
+		if stopErr := lifecycle.StopPhase(cmd, client, doc, timeout); stopErr != nil {
+			return stopErr
+		}
+	default:
+		// cellRunning — either fully-live or stale-Ready. Run StopPhase
+		// so the controller reconciles cell state regardless of which
+		// side is stale.
+		if stopErr := lifecycle.StopPhase(cmd, client, doc, timeout); stopErr != nil {
+			return stopErr
+		}
 	}
 
 	startRes, err := client.StartCell(cmd.Context(), doc)

--- a/cmd/kuke/daemon/restart/restart_test.go
+++ b/cmd/kuke/daemon/restart/restart_test.go
@@ -51,11 +51,20 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// fixedProbe returns a ReachableProbe that always reports `reachable`. Used
+// to drive the socket-staleness branches deterministically without needing a
+// real listening socket — the production default would dial the configured
+// KUKEOND_SOCKET path, which is host-state dependent.
+func fixedProbe(reachable bool) lifecycle.ReachableProbe {
+	return func(_ context.Context, _ string, _ time.Duration) bool { return reachable }
+}
+
 func TestDaemonRestart(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           []string
 		fake           *fakeClient
+		probe          lifecycle.ReachableProbe
 		wantErr        string
 		wantOutputs    []string
 		wantNotOutputs []string
@@ -96,7 +105,7 @@ func TestDaemonRestart(t *testing.T) {
 			},
 		},
 		{
-			name: "already-stopped cell skips stop phase and starts",
+			name: "already-stopped cell with unreachable socket skips stop phase and starts",
 			fake: &fakeClient{
 				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 					return kukeonv1.GetCellResult{
@@ -114,9 +123,44 @@ func TestDaemonRestart(t *testing.T) {
 					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
 				},
 			},
+			probe: fixedProbe(false),
 			wantOutputs: []string{
 				`kukeond was already stopped (cell "kukeond" in realm "kuke-system")`,
 				`kukeond started (cell "kukeond" in realm "kuke-system")`,
+			},
+		},
+		{
+			// Other-direction staleness fix (#611): metadata reads
+			// not-Ready but the socket still answers, so the daemon is
+			// live and the controller's status lags. Old behaviour
+			// would skip the stop phase and call StartCell on top of a
+			// running daemon; new behaviour falls through to StopPhase
+			// first so restart actually restarts.
+			name: "metadata says not-Ready but socket is reachable runs stop phase then starts",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+				},
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+				},
+			},
+			probe: fixedProbe(true),
+			wantOutputs: []string{
+				"metadata reports not-Ready but socket",
+				`kukeond stopped (cell "kukeond" in realm "kuke-system")`,
+				`kukeond started (cell "kukeond" in realm "kuke-system")`,
+			},
+			wantNotOutputs: []string{
+				`kukeond was already stopped`,
 			},
 		},
 		{
@@ -229,6 +273,7 @@ func TestDaemonRestart(t *testing.T) {
 					return kukeonv1.StartCellResult{Cell: doc, Started: false}, nil
 				},
 			},
+			probe:   fixedProbe(false),
 			wantErr: "start kukeond cell: controller reported no change",
 		},
 	}
@@ -242,6 +287,9 @@ func TestDaemonRestart(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
+			if tt.probe != nil {
+				ctx = context.WithValue(ctx, lifecycle.ReachableProbeKey{}, tt.probe)
+			}
 			cmd.SetContext(ctx)
 			cmd.SetArgs(tt.args)
 

--- a/cmd/kuke/daemon/start/start.go
+++ b/cmd/kuke/daemon/start/start.go
@@ -79,11 +79,30 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	}
 
 	if lifecycle.IsCellRunning(getRes.Cell) {
+		probe := lifecycle.ResolveReachableProbe(cmd)
+		socketPath := lifecycle.ResolveSocketPath()
+		if probe(cmd.Context(), socketPath, lifecycle.DefaultReachableTimeout) {
+			cmd.Printf(
+				"kukeond is already running (cell %q in realm %q)\n",
+				consts.KukeSystemCellName, consts.KukeSystemRealmName,
+			)
+			return nil
+		}
+		// Persisted state reads Ready but the socket does not answer — the
+		// daemon was killed externally (OOM, host reboot mid-run, kill -9)
+		// and the metadata never got the "stopped" write. Reconcile by
+		// falling through to StartCell rather than claiming "already
+		// running" while the socket is missing.
 		cmd.Printf(
-			"kukeond is already running (cell %q in realm %q)\n",
-			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+			"kukeond metadata reports Ready but socket %s is unreachable; restarting cell\n",
+			socketPath,
 		)
-		return nil
+		logger.WarnContext(cmd.Context(),
+			"daemon metadata stale: marked Ready but socket unreachable; restarting cell",
+			"socket", socketPath,
+			"cell", consts.KukeSystemCellName,
+			"realm", consts.KukeSystemRealmName,
+		)
 	}
 
 	startRes, err := client.StartCell(cmd.Context(), doc)

--- a/cmd/kuke/daemon/start/start_test.go
+++ b/cmd/kuke/daemon/start/start_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
 	start "github.com/eminwux/kukeon/cmd/kuke/daemon/start"
@@ -35,6 +36,14 @@ import (
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// fixedProbe returns a ReachableProbe that always reports `reachable`. Used
+// to drive the socket-staleness branches deterministically without needing a
+// real listening socket — the production default would dial the configured
+// KUKEOND_SOCKET path, which is host-state dependent.
+func fixedProbe(reachable bool) lifecycle.ReachableProbe {
+	return func(_ context.Context, _ string, _ time.Duration) bool { return reachable }
+}
 
 // TestMain mocks the shared euid lookup to euid=0 for every test in this
 // package so the fail-fast root gate in runStart does not short-circuit the
@@ -52,6 +61,7 @@ func TestDaemonStart(t *testing.T) {
 	tests := []struct {
 		name       string
 		fake       *fakeClient
+		probe      lifecycle.ReachableProbe
 		wantErr    string
 		wantOutput string
 	}{
@@ -72,10 +82,11 @@ func TestDaemonStart(t *testing.T) {
 					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
 				},
 			},
+			probe:      fixedProbe(false),
 			wantOutput: `kukeond started (cell "kukeond" in realm "kuke-system")`,
 		},
 		{
-			name: "already-running cell is a no-op",
+			name: "already-running cell with reachable socket is a no-op",
 			fake: &fakeClient{
 				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 					return kukeonv1.GetCellResult{
@@ -95,10 +106,11 @@ func TestDaemonStart(t *testing.T) {
 					return kukeonv1.StartCellResult{}, nil
 				},
 			},
+			probe:      fixedProbe(true),
 			wantOutput: `kukeond is already running (cell "kukeond" in realm "kuke-system")`,
 		},
 		{
-			name: "running by container state alone (stale cell metadata)",
+			name: "running by container state alone (stale cell metadata) with reachable socket",
 			fake: &fakeClient{
 				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 					return kukeonv1.GetCellResult{
@@ -118,7 +130,39 @@ func TestDaemonStart(t *testing.T) {
 					return kukeonv1.StartCellResult{}, nil
 				},
 			},
+			probe:      fixedProbe(true),
 			wantOutput: "kukeond is already running",
+		},
+		{
+			// The headline failure mode this issue (#611) fixes: persisted
+			// state still reads Ready (daemon was OOM-killed / host-rebooted
+			// before the controller could write a "stopped" status), but the
+			// socket no longer answers. Old behaviour was to print "already
+			// running" and exit 0, leaving the operator to discover the
+			// missing daemon via the next daemon-routed command's
+			// dial-unix error. New behaviour: log the staleness and fall
+			// through to StartCell so the cell actually comes back up.
+			name: "metadata says Ready but socket is unreachable falls through to StartCell",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+				},
+			},
+			probe:      fixedProbe(false),
+			wantOutput: "metadata reports Ready but socket",
 		},
 		{
 			name: "host not initialized",
@@ -153,6 +197,7 @@ func TestDaemonStart(t *testing.T) {
 					return kukeonv1.StartCellResult{}, errors.New("runner blew up")
 				},
 			},
+			probe:   fixedProbe(false),
 			wantErr: "start kukeond cell:",
 		},
 	}
@@ -165,6 +210,9 @@ func TestDaemonStart(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
+			if tt.probe != nil {
+				ctx = context.WithValue(ctx, lifecycle.ReachableProbeKey{}, tt.probe)
+			}
 			cmd.SetContext(ctx)
 			cmd.SetArgs(nil)
 

--- a/cmd/kuke/daemon/stop/stop.go
+++ b/cmd/kuke/daemon/stop/stop.go
@@ -91,11 +91,28 @@ func runStop(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !lifecycle.IsCellRunning(getRes.Cell) {
+		probe := lifecycle.ResolveReachableProbe(cmd)
+		socketPath := lifecycle.ResolveSocketPath()
+		if !probe(cmd.Context(), socketPath, lifecycle.DefaultReachableTimeout) {
+			cmd.Printf(
+				"kukeond is already stopped (cell %q in realm %q)\n",
+				consts.KukeSystemCellName, consts.KukeSystemRealmName,
+			)
+			return nil
+		}
+		// Persisted state reads not-Ready but the socket answers — the
+		// daemon is up and metadata lags. Fall through to StopPhase
+		// rather than silently no-op while the daemon is still serving.
 		cmd.Printf(
-			"kukeond is already stopped (cell %q in realm %q)\n",
-			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+			"kukeond metadata reports not-Ready but socket %s is reachable; stopping cell\n",
+			socketPath,
 		)
-		return nil
+		logger.WarnContext(cmd.Context(),
+			"daemon metadata stale: marked not-Ready but socket reachable; stopping cell",
+			"socket", socketPath,
+			"cell", consts.KukeSystemCellName,
+			"realm", consts.KukeSystemRealmName,
+		)
 	}
 
 	return lifecycle.StopPhase(cmd, client, doc, timeout)

--- a/cmd/kuke/daemon/stop/stop_test.go
+++ b/cmd/kuke/daemon/stop/stop_test.go
@@ -51,11 +51,20 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// fixedProbe returns a ReachableProbe that always reports `reachable`. Used
+// to drive the socket-staleness branches deterministically without needing a
+// real listening socket — the production default would dial the configured
+// KUKEOND_SOCKET path, which is host-state dependent.
+func fixedProbe(reachable bool) lifecycle.ReachableProbe {
+	return func(_ context.Context, _ string, _ time.Duration) bool { return reachable }
+}
+
 func TestDaemonStop(t *testing.T) {
 	tests := []struct {
 		name       string
 		args       []string
 		fake       *fakeClient
+		probe      lifecycle.ReachableProbe
 		wantErr    string
 		wantOutput string
 	}{
@@ -88,7 +97,7 @@ func TestDaemonStop(t *testing.T) {
 			wantOutput: `kukeond stopped (cell "kukeond" in realm "kuke-system")`,
 		},
 		{
-			name: "already-stopped cell is a no-op",
+			name: "already-stopped cell with unreachable socket is a no-op",
 			fake: &fakeClient{
 				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 					return kukeonv1.GetCellResult{
@@ -103,7 +112,31 @@ func TestDaemonStop(t *testing.T) {
 					return kukeonv1.StopCellResult{}, nil
 				},
 			},
+			probe:      fixedProbe(false),
 			wantOutput: `kukeond is already stopped (cell "kukeond" in realm "kuke-system")`,
+		},
+		{
+			// The other-direction staleness fix from #611: metadata reads
+			// not-Ready but the socket still answers, so the daemon is up
+			// and the controller's status simply lags. Old behaviour would
+			// silently no-op and leave the live daemon untouched. New
+			// behaviour: log the staleness and fall through to StopPhase.
+			name: "metadata says not-Ready but socket is reachable falls through to StopPhase",
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+				},
+			},
+			probe:      fixedProbe(true),
+			wantOutput: "metadata reports not-Ready but socket",
 		},
 		{
 			name: "host not initialized",
@@ -178,6 +211,9 @@ func TestDaemonStop(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
+			if tt.probe != nil {
+				ctx = context.WithValue(ctx, lifecycle.ReachableProbeKey{}, tt.probe)
+			}
 			cmd.SetContext(ctx)
 			cmd.SetArgs(tt.args)
 

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -132,6 +132,7 @@ sudo kuke daemon logs -f               # follow until SIGINT
 
 - `daemon start` is idempotent. Running it while the daemon is up succeeds with a clear "already running" message; exit code 0.
 - `daemon stop` is idempotent. Running it while the daemon is down succeeds with a clear "already stopped" message; exit code 0.
+- Idempotence is keyed on **liveness**, not persisted cell state. Each lifecycle verb dials the kukeond socket alongside reading the cell's `.status` so that an externally-killed daemon (OOM, host reboot mid-run, `kill -9`) does not silently mask itself as "already running" — `daemon start` falls through to bring the cell back up, while `daemon stop` / `kill` / `restart` falls through to act on a live daemon whose persisted status lags. The probe budget is sub-second; a stale-Ready or stale-not-Ready divergence is printed on stdout before the reconciling action runs.
 - `daemon start` errors when the host has not been `kuke init`-ed yet (no cell to start). Exit code non-zero with a message pointing the operator at `kuke init`.
 - `daemon kill` has no grace period; this is the escape hatch for a hung daemon. Use `stop` for the graceful path.
 - `daemon reset` is destructive (cell deletion + socket removal) and described in the Bootstrap & teardown section.


### PR DESCRIPTION
## Summary
- `kuke daemon start` used to read only persisted `Cell.Status.{State,Containers[].State}` to decide "already running" and exit 0. If the daemon was killed externally (OOM, host reboot mid-run, `kill -9`, containerd panic) the metadata still said `Ready`, the operator saw "already running", and the very next daemon-routed command failed with `dial unix /run/kukeon/kukeond.sock: connect: no such file or directory`. Same `IsCellRunning` short-circuit gates the idempotent no-op branches in `stop`, `kill`, and `restart`, with the symmetric staleness failure (metadata=NotReady but socket=up → silent no-op against a live daemon).
- This PR adds `lifecycle.IsDaemonReachable(ctx, socketPath, timeout)` — a 500ms `net.Dialer`-backed dial of the kukeond unix socket — and threads it through `start` (Ready+socket=down → log and fall through to `StartCell`), `stop` / `kill` (NotReady+socket=up → log and fall through to the act-on-live-daemon path), and `restart` (likewise — preserves the existing "skip stop, run start" branch only when *both* axes agree the daemon is down).
- Probe injection point matches the existing `MockClientKey` pattern (`ReachableProbe` type + `ReachableProbeKey` context value + `ResolveReachableProbe(cmd)` resolver) so the new branches are unit-testable without a real listening socket. `ResolveSocketPath()` centralises the `KUKEOND_SOCKET` viper lookup so every verb agrees on which socket counts as the source of truth.
- The fall-through-to-`StartCell` path is correctly closed downstream — `internal/controller/start_cell.go:42-58` already refreshes container state from containerd via `populateCellContainerStatuses` before deciding the cell is busy, so a genuinely OOM-killed cell (containers actually dead, metadata stale-Ready) lets `StartCell` proceed and bring the daemon back up.
- Out of scope per issue: `kuke daemon reset` / `kuke daemon logs` short-circuits, and repair of the stale `.status` field itself (#161/#224's lane). `kuke refresh` is intentionally *not* a substitute — refresh reconciles from containerd's view, not from socket reachability, and won't detect a crashed-but-task-still-registered kukeond.

## Test plan
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `make test` — full suite passes, including new cases in start/stop/kill/restart/lifecycle.
- [x] `pre-commit run --files $(git diff --name-only HEAD)` — passes (golangci-lint auto-fix re-run lands clean).
- [x] `make dev-init` smoke — daemon-parity guard prints both Ready realms identically; nested attach plumbing intact.
- [x] Manual end-to-end: `sudo KUKEOND_SOCKET=/run/kukeon-dev/kukeond.sock ./kuke daemon start` against the live nested daemon prints "kukeond is already running" (probe reachable → existing path). `sudo ./kuke daemon start` with the default `/run/kukeon/kukeond.sock` (which is *not* the live nested socket) prints "kukeond metadata reports Ready but socket /run/kukeon/kukeond.sock is unreachable; restarting cell" — the new staleness branch fires as designed. Note: in this nested smoke the daemon's containers were genuinely still running (just at a different socket path) so `StartCell` correctly returned the "has running containers" error per `start_cell.go:43-57` — that is the controller path doing its containerd-refresh-based safety check, not a downstream gap.

## Notes for the reviewer
- Probe budget is 500ms; chose generous-but-fast because the local-socket happy path answers in <1ms and a hung accept still surfaces well below human reaction time.
- `daemon reset` / `daemon logs` callsites were left alone per the AC. Reset's `IsCellRunning` gate decides whether to invoke `StopPhase` (StopCell is idempotent at the controller layer, so a stale-Ready dispatch is harmless); logs returns an error rather than no-op on `!IsCellRunning`, so the staleness failure-mode shape there is different.

Closes #611