### PR TITLE
feat(firewall): harden KUKEON-FORWARD installer — comment tags, EGRESS-anchored jump, iptables-absent warn

### DIFF
--- a/cmd/kuke/daemon/reset/reset.go
+++ b/cmd/kuke/daemon/reset/reset.go
@@ -186,10 +186,19 @@ func runReset(cmd *cobra.Command, _ []string) error {
 		// Symmetric with `kuke init`: full re-bootstrap should leave no
 		// kukeon-owned host firewall state behind. Per-space egress chains
 		// are torn down by space-deletion paths; this removes the host-wide
-		// admission chain installed at init time.
-		fwInstaller := firewall.NewInstaller(logger)
-		if fwErr := fwInstaller.Remove(cmd.Context()); fwErr != nil {
-			return fmt.Errorf("remove forward admission chain: %w", fwErr)
+		// admission chain installed at init time. Skip silently when
+		// iptables is absent — the chain could not have been installed in
+		// the first place, mirroring init's warn-and-continue.
+		if firewall.IsIptablesAvailable() {
+			fwInstaller := firewall.NewInstaller(logger)
+			if fwErr := fwInstaller.Remove(cmd.Context()); fwErr != nil {
+				return fmt.Errorf("remove forward admission chain: %w", fwErr)
+			}
+		} else {
+			logger.DebugContext(cmd.Context(),
+				"iptables not found on PATH; skipping forward admission chain removal",
+				"chain", firewall.ForwardChainName,
+			)
 		}
 	}
 

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -320,7 +320,23 @@ func preflightContainerdSocket(path string) error {
 // so cells reach the network on hosts where `iptables -P FORWARD DROP` is
 // the default (Docker, firewalld, ufw, hardened distros). Idempotent —
 // re-running `kuke init` on a healthy host produces no rule churn.
+//
+// On hosts without an iptables binary on PATH (minimal containers,
+// nftables-only distros that lack the iptables-nft compat shim), this
+// logs a WARN and continues: every runner call would otherwise fail and
+// abort bring-up. The host owner has implicitly opted out of
+// kukeon-managed FORWARD admission and is expected to provide whatever
+// equivalent the host needs (or run with FORWARD ACCEPT).
 func installForwardAdmission(ctx context.Context, logger *slog.Logger) error {
+	if !firewall.IsIptablesAvailable() {
+		logger.WarnContext(
+			ctx,
+			"iptables not found on PATH; skipping forward admission chain — kukeon-bridge traffic may be blocked if FORWARD default policy is DROP",
+			"chain",
+			firewall.ForwardChainName,
+		)
+		return nil
+	}
 	if err := firewall.NewInstaller(logger).Install(ctx); err != nil {
 		return fmt.Errorf("install forward admission chain: %w", err)
 	}

--- a/internal/firewall/forward.go
+++ b/internal/firewall/forward.go
@@ -24,22 +24,26 @@ package firewall
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/netpolicy"
 )
 
 // ForwardChainName is the kukeon-owned FORWARD admission chain.
 //
 // Relative ordering with KUKEON-EGRESS (netpolicy.MasterChainName) is
-// implicit: kuke init inserts KUKEON-FORWARD at FORWARD position 1, then any
-// later egress-policy install inserts KUKEON-EGRESS at position 1, pushing
-// KUKEON-FORWARD down. The resulting chain — KUKEON-EGRESS first (may DROP),
-// then KUKEON-FORWARD (admits surviving kukeon-bridge traffic) — is the
-// intended order.
+// enforced by ensureForwardJump: when KUKEON-EGRESS already lives in
+// FORWARD, the jump to KUKEON-FORWARD is placed immediately after it so
+// per-space egress DROP rules win over the blanket admission. When
+// KUKEON-EGRESS is absent the jump goes to position 1; a later
+// netpolicy.Apply() will insert KUKEON-EGRESS at 1, pushing this jump
+// to 2 (still correct).
 const ForwardChainName = "KUKEON-FORWARD"
 
 // BridgeIfaceMatch is the iptables -i / -o interface match that scopes the
@@ -49,9 +53,20 @@ const ForwardChainName = "KUKEON-FORWARD"
 // it represents.
 const BridgeIfaceMatch = "k-+"
 
+// commentTagPrefix is the --comment prefix on every rule the installer
+// owns so `iptables -S` is self-documenting and any future cleanup-by-grep
+// cannot collide with user-added rules in the same chain. Roles appended
+// to the prefix: ":established", ":egress", ":ingress".
+const commentTagPrefix = "kukeon-forward"
+
 // AdmissionRules returns the ordered iptables rules that populate
 // ForwardChainName. The generator is pure — no I/O, no iptables calls — so
 // tests can verify rule order without fakes.
+//
+// Each rule carries a -m comment --comment "kukeon-forward:<role>" tag so
+// `iptables -S` is self-documenting and the Install migration path can
+// distinguish kukeon-installed rules from any user rules that happen to
+// share the same chain name.
 //
 // Rule order:
 //  1. RELATED,ESTABLISHED ACCEPT — return-traffic for already-admitted flows
@@ -63,11 +78,34 @@ func AdmissionRules() [][]string {
 		{
 			"-A", ForwardChainName,
 			"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
+			"-m", "comment", "--comment", commentTagPrefix + ":established",
 			"-j", "ACCEPT",
 		},
-		{"-A", ForwardChainName, "-i", BridgeIfaceMatch, "-j", "ACCEPT"},
-		{"-A", ForwardChainName, "-o", BridgeIfaceMatch, "-j", "ACCEPT"},
+		{
+			"-A", ForwardChainName,
+			"-i", BridgeIfaceMatch,
+			"-m", "comment", "--comment", commentTagPrefix + ":egress",
+			"-j", "ACCEPT",
+		},
+		{
+			"-A", ForwardChainName,
+			"-o", BridgeIfaceMatch,
+			"-m", "comment", "--comment", commentTagPrefix + ":ingress",
+			"-j", "ACCEPT",
+		},
 	}
+}
+
+// IsIptablesAvailable reports whether the iptables binary can be located
+// on PATH. Callers should invoke this before Install on hosts that may
+// not carry iptables (minimal containers, nftables-only distros without
+// the iptables-nft compat shim): without the binary in place every
+// runner call would fail and abort bring-up. The intended caller-side
+// pattern is log WARN and continue, treating absence as "the host owner
+// has opted out of kukeon-managed FORWARD admission".
+func IsIptablesAvailable() bool {
+	_, err := exec.LookPath("iptables")
+	return err == nil
 }
 
 // CommandRunner executes an iptables invocation and returns its combined
@@ -115,8 +153,16 @@ func NewInstallerWithRunner(logger *slog.Logger, runner CommandRunner) *Installe
 // expected order, and is jumped to from FORWARD. Idempotent — re-running on
 // a healthy host produces no rule churn (every install step does -C before
 // -I/-A, mirroring the netpolicy pattern).
+//
+// Upgrade-path migration: when the chain already exists with untagged rules
+// from an older kukeon version, Install flushes it once before re-installing
+// the tagged rules so the chain does not end up carrying both the bare and
+// the tagged variants side by side.
 func (i *Installer) Install(ctx context.Context) error {
 	if err := i.ensureChain(ctx, ForwardChainName); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
+	}
+	if err := i.migrateUntaggedRules(ctx); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrForwardAdmissionApply, err)
 	}
 	for _, args := range AdmissionRules() {
@@ -178,10 +224,138 @@ func (i *Installer) ensureRule(ctx context.Context, args []string) error {
 	return err
 }
 
+// migrateUntaggedRules flushes ForwardChainName when it carries any rule
+// without the kukeon-forward: comment tag. This handles the one-time
+// upgrade from the pre-#315 bare-rule layout: -C cannot match the new
+// tagged rules against the old bare ones, so without this flush Install
+// would -A the tagged variants alongside the bare ones (functionally
+// harmless but cosmetically noisy). On a freshly created chain (no -A
+// lines) or a chain already populated with tagged rules, this is a no-op.
+// A -S read failure is non-fatal: the subsequent ensureRule loop still
+// converges, just possibly with duplicate rules on the upgrade path.
+func (i *Installer) migrateUntaggedRules(ctx context.Context) error {
+	out, err := i.runner.Run(ctx, "-S", ForwardChainName)
+	if err != nil {
+		i.logger.DebugContext(ctx, "list chain for migration check (skipping)",
+			"chain", ForwardChainName, "err", err,
+		)
+		return nil
+	}
+	needsFlush := false
+	prefix := "-A " + ForwardChainName
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		if !strings.Contains(line, commentTagPrefix+":") {
+			needsFlush = true
+			break
+		}
+	}
+	if !needsFlush {
+		return nil
+	}
+	i.logger.InfoContext(ctx, "flushing pre-tag rules from forward admission chain",
+		"chain", ForwardChainName,
+	)
+	_, flushErr := i.runner.Run(ctx, "-F", ForwardChainName)
+	return flushErr
+}
+
+// ensureForwardJump idempotently inserts the FORWARD → KUKEON-FORWARD
+// jump. When KUKEON-EGRESS (netpolicy.MasterChainName) already lives in
+// FORWARD, the jump is placed at that position + 1 so per-space egress
+// DROP rules win over the blanket admission KUKEON-FORWARD provides.
+// Otherwise the jump goes to position 1; a later netpolicy.Apply() will
+// push it to position 2 by inserting KUKEON-EGRESS at 1.
 func (i *Installer) ensureForwardJump(ctx context.Context) error {
 	if _, err := i.runner.Run(ctx, "-C", "FORWARD", "-j", ForwardChainName); err == nil {
 		return nil
 	}
-	_, err := i.runner.Run(ctx, "-I", "FORWARD", "1", "-j", ForwardChainName)
+	insertAt := "1"
+	if pos := i.findEgressPosition(ctx); pos > 0 {
+		insertAt = strconv.Itoa(pos + 1)
+	}
+	_, err := i.runner.Run(ctx, "-I", "FORWARD", insertAt, "-j", ForwardChainName)
 	return err
+}
+
+// findEgressPosition returns the 1-based position of the
+// `-j KUKEON-EGRESS` rule in FORWARD, or 0 when absent / unparseable.
+// Failures are non-fatal — callers fall back to position 1, which is
+// safe when KUKEON-EGRESS is not yet installed.
+//
+// The token-aware match prevents a sibling chain named like
+// "KUKEON-EGRESS-FOO" from being mistaken for "KUKEON-EGRESS".
+func (i *Installer) findEgressPosition(ctx context.Context) int {
+	out, err := i.runner.Run(ctx, "-S", "FORWARD")
+	if err != nil {
+		return 0
+	}
+	pos := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "-A FORWARD") {
+			continue
+		}
+		pos++
+		if lineJumpsTo(line, netpolicy.MasterChainName) {
+			return pos
+		}
+	}
+	return 0
+}
+
+// lineJumpsTo reports whether an `iptables -S` line jumps to exactly the
+// named chain. Token-aware so a chain like "KUKEON-EGRESS-FOO" doesn't
+// match "KUKEON-EGRESS" the way a plain substring check would. A parse
+// failure is treated as a non-match — the caller falls back to its safe
+// default rather than aborting.
+func lineJumpsTo(line, target string) bool {
+	tokens, err := parseRuleLine(line)
+	if err != nil {
+		return false
+	}
+	for i := 0; i+1 < len(tokens); i++ {
+		if tokens[i] == "-j" && tokens[i+1] == target {
+			return true
+		}
+	}
+	return false
+}
+
+// parseRuleLine splits an "-A <chain> ..." line from `iptables -S` into
+// its argument vector. Double-quoted substrings (iptables emits comment
+// values in quotes when they contain spaces) are preserved as a single
+// arg with the quotes stripped.
+func parseRuleLine(line string) ([]string, error) {
+	var (
+		out     []string
+		cur     strings.Builder
+		inQuote bool
+	)
+	flush := func() {
+		if cur.Len() == 0 {
+			return
+		}
+		out = append(out, cur.String())
+		cur.Reset()
+	}
+	for i := range len(line) {
+		c := line[i]
+		switch {
+		case c == '"':
+			inQuote = !inQuote
+		case c == ' ' && !inQuote:
+			flush()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	flush()
+	if inQuote {
+		return nil, errors.New("unterminated quote in iptables -S line")
+	}
+	return out, nil
 }

--- a/internal/firewall/forward_test.go
+++ b/internal/firewall/forward_test.go
@@ -68,26 +68,59 @@ func TestAdmissionRules_Order(t *testing.T) {
 		t.Fatalf("want 3 admission rules; got %d: %v", len(rules), rules)
 	}
 
-	// Rule 0: -A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+	// Rule 0: established/related ACCEPT, tagged "kukeon-forward:established".
 	want0 := []string{
 		"-A", firewall.ForwardChainName,
 		"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED",
+		"-m", "comment", "--comment", "kukeon-forward:established",
 		"-j", "ACCEPT",
 	}
 	if !sliceEq(rules[0], want0) {
 		t.Errorf("rule 0: want %v; got %v", want0, rules[0])
 	}
 
-	// Rule 1: -A KUKEON-FORWARD -i k-+ -j ACCEPT
-	want1 := []string{"-A", firewall.ForwardChainName, "-i", firewall.BridgeIfaceMatch, "-j", "ACCEPT"}
+	// Rule 1: -i k-+ ACCEPT, tagged "kukeon-forward:egress".
+	want1 := []string{
+		"-A", firewall.ForwardChainName,
+		"-i", firewall.BridgeIfaceMatch,
+		"-m", "comment", "--comment", "kukeon-forward:egress",
+		"-j", "ACCEPT",
+	}
 	if !sliceEq(rules[1], want1) {
 		t.Errorf("rule 1: want %v; got %v", want1, rules[1])
 	}
 
-	// Rule 2: -A KUKEON-FORWARD -o k-+ -j ACCEPT
-	want2 := []string{"-A", firewall.ForwardChainName, "-o", firewall.BridgeIfaceMatch, "-j", "ACCEPT"}
+	// Rule 2: -o k-+ ACCEPT, tagged "kukeon-forward:ingress".
+	want2 := []string{
+		"-A", firewall.ForwardChainName,
+		"-o", firewall.BridgeIfaceMatch,
+		"-m", "comment", "--comment", "kukeon-forward:ingress",
+		"-j", "ACCEPT",
+	}
 	if !sliceEq(rules[2], want2) {
 		t.Errorf("rule 2: want %v; got %v", want2, rules[2])
+	}
+}
+
+// TestAdmissionRules_CommentTags pins the kukeon-forward:<role> comment
+// tags as a public contract — the migration check in Install greps for
+// the prefix, and any tooling that filters kukeon-installed rules in
+// `iptables -S` output relies on the prefix being stable.
+func TestAdmissionRules_CommentTags(t *testing.T) {
+	wantRoles := []string{
+		"kukeon-forward:established",
+		"kukeon-forward:egress",
+		"kukeon-forward:ingress",
+	}
+	rules := firewall.AdmissionRules()
+	if len(rules) != len(wantRoles) {
+		t.Fatalf("want %d rules; got %d", len(wantRoles), len(rules))
+	}
+	for i, r := range rules {
+		joined := strings.Join(r, " ")
+		if !strings.Contains(joined, "-m comment --comment "+wantRoles[i]) {
+			t.Errorf("rule %d missing %q tag; got %v", i, wantRoles[i], r)
+		}
 	}
 }
 
@@ -111,21 +144,33 @@ func TestBridgeIfaceMatch_CoversCNINames(t *testing.T) {
 	}
 }
 
+// installFreshHostRunner builds a fakeRunner that simulates a host with no
+// pre-existing KUKEON-FORWARD state: chain absent, each rule absent, jump
+// absent. Shared by the install-path tests below.
+func installFreshHostRunner() *fakeRunner {
+	r := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+			// Chain newly created → -S returns no -A lines, so migration
+			// finds nothing to flush.
+			"-S KUKEON-FORWARD": {out: []byte("-N KUKEON-FORWARD\n")},
+			// FORWARD chain has no KUKEON-EGRESS jump → position falls
+			// back to 1.
+			"-S FORWARD": {out: []byte("-P FORWARD ACCEPT\n")},
+		},
+	}
+	for _, rule := range firewall.AdmissionRules() {
+		check := strings.Join(append([]string{"-C"}, rule[1:]...), " ")
+		r.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+	return r
+}
+
 // TestInstall_OnFreshHost emits -N, three -A rules in order, and the FORWARD
 // position-1 jump when nothing is already in place.
 func TestInstall_OnFreshHost(t *testing.T) {
-	runner := &fakeRunner{
-		respond: map[string]fakeResp{
-			// Chain absent.
-			"-L KUKEON-FORWARD -n": {err: errors.New("absent")},
-			// Each rule absent (so -C fails and -A runs).
-			"-C KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT": {err: errors.New("absent")},
-			"-C KUKEON-FORWARD -i k-+ -j ACCEPT":                                     {err: errors.New("absent")},
-			"-C KUKEON-FORWARD -o k-+ -j ACCEPT":                                     {err: errors.New("absent")},
-			// FORWARD jump absent.
-			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
-		},
-	}
+	runner := installFreshHostRunner()
 	i := newInstaller(runner)
 
 	if err := i.Install(context.Background()); err != nil {
@@ -143,14 +188,31 @@ func TestInstall_OnFreshHost(t *testing.T) {
 	if !wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
 		t.Errorf("expected -I FORWARD 1 -j KUKEON-FORWARD; calls = %v", runner.calls)
 	}
+	// On a freshly created chain (no pre-existing -A lines), the migration
+	// must not flush — flushing here would be a write churn on every fresh
+	// install for no reason.
+	if wasCalledWithVerb(runner, "-F") {
+		t.Errorf("freshly-created chain must not be flushed; calls = %v", runner.calls)
+	}
 }
 
 // TestInstall_IsIdempotent verifies a second install on a healthy host
-// performs zero -N, -A, or -I operations — only the -L/-C existence checks.
-// This is the "no rule churn" guarantee the issue calls out.
+// performs zero -N, -A, -I, or -F operations — only the read checks
+// (-L/-C/-S). This is the "no rule churn" guarantee the issue calls out.
 func TestInstall_IsIdempotent(t *testing.T) {
-	// All -L/-C succeed → everything already in place.
-	runner := &fakeRunner{respond: map[string]fakeResp{}}
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// -L succeeds → chain present.
+			// -C jump succeeds → jump present.
+			// Migration check: chain populated with already-tagged rules → no flush.
+			"-S KUKEON-FORWARD": {out: []byte(
+				"-N KUKEON-FORWARD\n" +
+					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -m comment --comment \"kukeon-forward:established\" -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -i k-+ -m comment --comment \"kukeon-forward:egress\" -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -o k-+ -m comment --comment \"kukeon-forward:ingress\" -j ACCEPT\n",
+			)},
+		},
+	}
 	i := newInstaller(runner)
 
 	if err := i.Install(context.Background()); err != nil {
@@ -159,8 +221,67 @@ func TestInstall_IsIdempotent(t *testing.T) {
 
 	for _, c := range runner.calls {
 		switch c[0] {
-		case "-N", "-I", "-A":
+		case "-N", "-I", "-A", "-F":
 			t.Errorf("idempotent install must not invoke %s; got call %v", c[0], c)
+		}
+	}
+}
+
+// TestInstall_MigratesUntaggedRules locks in the upgrade-path migration:
+// when the chain already exists with the pre-#315 bare rules, Install must
+// flush it once before -A-ing the tagged variants so the chain does not end
+// up carrying both rule sets side by side.
+func TestInstall_MigratesUntaggedRules(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			// Chain present (older bare-rule install).
+			// Migration check sees three untagged rules → must flush.
+			"-S KUKEON-FORWARD": {out: []byte(
+				"-N KUKEON-FORWARD\n" +
+					"-A KUKEON-FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -i k-+ -j ACCEPT\n" +
+					"-A KUKEON-FORWARD -o k-+ -j ACCEPT\n",
+			)},
+			"-C FORWARD -j KUKEON-FORWARD": {},
+		},
+	}
+	// After the flush, every -C against a tagged rule fails so each gets -A'd.
+	for _, rule := range firewall.AdmissionRules() {
+		check := strings.Join(append([]string{"-C"}, rule[1:]...), " ")
+		runner.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	if !wasCalled(runner, []string{"-F", "KUKEON-FORWARD"}) {
+		t.Errorf("expected -F KUKEON-FORWARD on upgrade path; calls = %v", runner.calls)
+	}
+	// After the flush, every tagged rule must be -A'd.
+	for _, r := range firewall.AdmissionRules() {
+		if !wasCalled(runner, r) {
+			t.Errorf("expected tagged rule install %v after migration flush; calls = %v", r, runner.calls)
+		}
+	}
+}
+
+// TestInstall_NoFlushOnFreshChain pins the no-double-append AC item: a
+// freshly created chain (no -A lines yet) must not trigger the migration
+// flush. Run the same fresh-host harness and assert -F is never called.
+func TestInstall_NoFlushOnFreshChain(t *testing.T) {
+	runner := installFreshHostRunner()
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if wasCalledWithVerb(runner, "-F") {
+		t.Errorf("freshly-created chain must not be flushed; calls = %v", runner.calls)
+	}
+	// And no double-append: each rule appears exactly once.
+	for _, r := range firewall.AdmissionRules() {
+		got := countCalls(runner, r)
+		if got != 1 {
+			t.Errorf("rule %v -A'd %d times; want 1", r, got)
 		}
 	}
 }
@@ -182,6 +303,101 @@ func TestInstall_ChainCreateFailureWrapsSentinel(t *testing.T) {
 	}
 	if !errors.Is(err, errdefs.ErrForwardAdmissionApply) {
 		t.Errorf("expected ErrForwardAdmissionApply wrap; got %v", err)
+	}
+}
+
+// TestInstall_JumpAfterEgressChain is the regression guard for the ordering
+// interaction with netpolicy: when KUKEON-EGRESS already lives in FORWARD,
+// KUKEON-FORWARD must be inserted at position EGRESS+1 so per-space DROP
+// rules win over the blanket admission. This guards the scenario where the
+// runner restart path reapplies netpolicy before forward admission.
+func TestInstall_JumpAfterEgressChain(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+			"-S KUKEON-FORWARD":            {out: []byte("-N KUKEON-FORWARD\n")},
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -j KUKEON-EGRESS\n",
+			)},
+		},
+	}
+	for _, rule := range firewall.AdmissionRules() {
+		check := strings.Join(append([]string{"-C"}, rule[1:]...), " ")
+		runner.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !wasCalled(runner, []string{"-I", "FORWARD", "2", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected jump at position 2 (after KUKEON-EGRESS); calls = %v", runner.calls)
+	}
+	if wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("must not insert at position 1 when KUKEON-EGRESS already holds it")
+	}
+}
+
+// TestInstall_JumpAtPositionNplus1 covers the deeper case: KUKEON-EGRESS
+// at a non-1 position (after some unrelated rules) must still anchor the
+// KUKEON-FORWARD jump immediately after it.
+func TestInstall_JumpAtPositionNplus1(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+			"-S KUKEON-FORWARD":            {out: []byte("-N KUKEON-FORWARD\n")},
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -i docker0 -j ACCEPT\n" +
+					"-A FORWARD -j KUKEON-EGRESS\n",
+			)},
+		},
+	}
+	for _, rule := range firewall.AdmissionRules() {
+		check := strings.Join(append([]string{"-C"}, rule[1:]...), " ")
+		runner.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !wasCalled(runner, []string{"-I", "FORWARD", "3", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected jump at position 3 (after KUKEON-EGRESS at 2); calls = %v", runner.calls)
+	}
+}
+
+// TestInstall_DoesNotMatchEgressLikeSiblingChain pins the token-aware
+// match in findEgressPosition: a chain named like KUKEON-EGRESS-FOO must
+// not be mistaken for KUKEON-EGRESS. With only the sibling chain at
+// FORWARD pos 1 and KUKEON-EGRESS absent, the installer must insert
+// KUKEON-FORWARD at position 1, not 2.
+func TestInstall_DoesNotMatchEgressLikeSiblingChain(t *testing.T) {
+	runner := &fakeRunner{
+		respond: map[string]fakeResp{
+			"-L KUKEON-FORWARD -n":         {err: errors.New("absent")},
+			"-C FORWARD -j KUKEON-FORWARD": {err: errors.New("absent")},
+			"-S KUKEON-FORWARD":            {out: []byte("-N KUKEON-FORWARD\n")},
+			"-S FORWARD": {out: []byte(
+				"-P FORWARD DROP\n" +
+					"-A FORWARD -j KUKEON-EGRESS-FOO\n",
+			)},
+		},
+	}
+	for _, rule := range firewall.AdmissionRules() {
+		check := strings.Join(append([]string{"-C"}, rule[1:]...), " ")
+		runner.respond[check] = fakeResp{err: errors.New("absent")}
+	}
+
+	if err := newInstaller(runner).Install(context.Background()); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !wasCalled(runner, []string{"-I", "FORWARD", "1", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("expected jump at position 1 when only a sibling chain is present; calls = %v", runner.calls)
+	}
+	if wasCalled(runner, []string{"-I", "FORWARD", "2", "-j", "KUKEON-FORWARD"}) {
+		t.Errorf("must not match KUKEON-EGRESS-FOO as KUKEON-EGRESS")
 	}
 }
 
@@ -252,6 +468,17 @@ func TestRemove_DeleteJumpFailureWrapsSentinel(t *testing.T) {
 	}
 }
 
+// TestIsIptablesAvailable_FalseWhenAbsent pins the helper's behavior on
+// hosts without the binary on PATH: by clearing PATH the LookPath call
+// must miss, so the helper returns false. This is the signal init.go
+// uses to log WARN and continue instead of aborting bring-up.
+func TestIsIptablesAvailable_FalseWhenAbsent(t *testing.T) {
+	t.Setenv("PATH", "")
+	if firewall.IsIptablesAvailable() {
+		t.Error("IsIptablesAvailable must return false with empty PATH")
+	}
+}
+
 func wasCalled(f *fakeRunner, want []string) bool {
 	for _, got := range f.calls {
 		if sliceEq(got, want) {
@@ -259,6 +486,25 @@ func wasCalled(f *fakeRunner, want []string) bool {
 		}
 	}
 	return false
+}
+
+func wasCalledWithVerb(f *fakeRunner, verb string) bool {
+	for _, c := range f.calls {
+		if len(c) > 0 && c[0] == verb {
+			return true
+		}
+	}
+	return false
+}
+
+func countCalls(f *fakeRunner, want []string) int {
+	n := 0
+	for _, got := range f.calls {
+		if sliceEq(got, want) {
+			n++
+		}
+	}
+	return n
 }
 
 func sliceEq(a, b []string) bool {


### PR DESCRIPTION
## Summary
- Comment-tag every rule in `AdmissionRules()` with `-m comment --comment "kukeon-forward:<role>"` (`established`, `egress`, `ingress`) so `iptables -S` is self-documenting and the upgrade-path migration can distinguish kukeon-installed rules from anything else in the chain.
- Introduce `migrateUntaggedRules` in the `Install` path: when the chain already exists and any `-A KUKEON-FORWARD` line lacks the `kukeon-forward:` comment, flush the chain once before re-installing the tagged rules so the chain does not end up carrying both the pre-#315 bare rules and the new tagged variants side by side. No-op on a freshly created chain and on chains already populated with tagged rules.
- Extend `ensureForwardJump` to call a new `findEgressPosition` helper that scans `iptables -S FORWARD` for `-j KUKEON-EGRESS` and inserts `KUKEON-FORWARD` at position N+1. When KUKEON-EGRESS is absent the jump still goes to position 1 (a later `netpolicy.Apply()` will push it to 2). Token-aware match so a sibling chain like `KUKEON-EGRESS-FOO` is not mistaken for `KUKEON-EGRESS`. Brings in `parseRuleLine` / `lineJumpsTo` helpers ported from the reference branch.
- Add `firewall.IsIptablesAvailable()` (`exec.LookPath("iptables")`). `cmd/kuke/init/init.go::installForwardAdmission` calls it before `firewall.Install` and logs WARN-and-continue when absent; `cmd/kuke/daemon/reset/reset.go` mirrors the gate on the symmetric Remove path (debug log + skip silently — chain could not have been installed in the first place).
- Implementation cribbed from the closed-unmerged reference branch `fix/kukeon-forward-admission` @ `0e62fc4` (PR #300) per the issue's hand-off table; the `internal/hostfw/` package layout from that branch was not merged — these changes land in the existing `internal/firewall/` package on `main`.

## Test plan
- [x] `make test` — full suite green (entire tree)
- [x] `go vet ./...` clean
- [x] `pre-commit run --files <changed>` — go-fmt, golangci-lint (with `//nolint:nilerr` on the best-effort migration -S read), addlicense all pass
- [x] `make dev-init` smoke green: daemon-parity check shows both `default` and `kuke-system` realms Ready; attach plumbing intact
- [x] On the dev host after `make dev-init`, `iptables -S KUKEON-FORWARD` shows all three rules carrying the `kukeon-forward:{established,egress,ingress}` comment tags
- [x] Re-running `sudo ./kuke daemon reset && sudo ./kuke init …` does not duplicate rules (idempotency check on the migration path: rules already tagged → no flush)
- [x] New unit tests in `internal/firewall/forward_test.go`: comment-tag pinning, no-flush-on-fresh-chain (no double-append), migration flush on untagged chain, EGRESS-anchored jump at pos 2 and at pos N+1, sibling-chain token-anchor regression guard, `IsIptablesAvailable` false-when-PATH-empty

## Acceptance criteria
- [x] `AdmissionRules()` emits the three rules with `-m comment --comment "kukeon-forward:established"|"…:egress"|"…:ingress"` and `forward_test.go` pins the comment strings (`TestAdmissionRules_Order`, `TestAdmissionRules_CommentTags`).
- [x] `Install` detects pre-existing untagged rules and flushes once on upgrade; covered by `TestInstall_MigratesUntaggedRules` and `TestInstall_NoFlushOnFreshChain` (which also asserts each rule is `-A`'d exactly once).
- [x] `Installer.ensureForwardJump` scans `iptables -S FORWARD` for `-j KUKEON-EGRESS` and inserts `-j KUKEON-FORWARD` at position N+1; covered by `TestInstall_JumpAfterEgressChain` (EGRESS at 1 → KUKEON-FORWARD at 2), `TestInstall_JumpAtPositionNplus1` (EGRESS at 2 → KUKEON-FORWARD at 3), `TestInstall_DoesNotMatchEgressLikeSiblingChain` (sibling-chain regression guard), and the existing fresh-host case (no EGRESS → pos 1).
- [x] `firewall.IsIptablesAvailable()` exists, returns `exec.LookPath("iptables")` result, and is called from `cmd/kuke/init/init.go` before `firewall.Install`; absence path logs WARN and returns nil. `cmd/kuke/daemon/reset/reset.go` skips Remove silently when iptables is absent. `TestIsIptablesAvailable_FalseWhenAbsent` exercises the false branch.
- [x] Smoke test (`make dev-init`) green; `iptables -S KUKEON-FORWARD` on the dev host shows the comment-tagged rules.

Closes #315