### PR TITLE
feat(container): add repos[] with kuketty pre-Serve clone (phase 1a)

### DIFF
--- a/cmd/kuketty/main.go
+++ b/cmd/kuketty/main.go
@@ -134,6 +134,15 @@ func run(args []string) error {
 		return err
 	}
 	defer closeLogger()
+
+	// Pre-Serve step (issue #617): clone/fetch the container's declared repos
+	// before the workload starts. A required-repo failure returns here, so
+	// kuketty exits non-zero before sbshserver.Serve and the daemon observes
+	// the task as Failed. An empty repos[] is a no-op.
+	if err = processRepos(ctx, doc.Spec.Repos, logger); err != nil {
+		return err
+	}
+
 	srv, err := sbshserver.New(spec, logger)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)

--- a/cmd/kuketty/repos.go
+++ b/cmd/kuketty/repos.go
@@ -1,0 +1,190 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// errRequiredRepoFailed signals that at least one required repo failed to
+// clone or fetch. run() maps it to a non-zero exit before sbshserver.Serve so
+// the daemon observes the container task as Failed (issue #617, AC: required
+// failure is fatal). The per-repo detail is logged to kuketty's slog output as
+// each repo is resolved.
+var errRequiredRepoFailed = errors.New("one or more required repos failed to resolve")
+
+// processRepos is kuketty's pre-Serve step: it clones (or fetches) each repo
+// declared on the mounted ContainerDoc.Spec into its target using the
+// container's own git identity (inherited env: HOME, ~/.ssh, ~/.gitconfig,
+// GIT_SSH_COMMAND — the same identity onInit scripts use today). Reading
+// repos[] straight from the spec (since kuketty owns the spec→TerminalSpec
+// build, issue #641) means there is no daemon-rendered sidecar doc.
+//
+// An empty repos[] is a no-op (nil) — the common case. When any repo marked
+// required fails, processRepos logs each outcome and returns
+// errRequiredRepoFailed; non-required failures are logged but do not
+// propagate. Per-repo status reporting into ContainerStatus.Repos rides the
+// GetSetupStatus RPC in phase 1b (#642) — phase 1a clones and logs only.
+func processRepos(ctx context.Context, repos []v1beta1.ContainerRepo, logger *slog.Logger) error {
+	if len(repos) == 0 {
+		return nil
+	}
+
+	var requiredFailed bool
+	for i := range repos {
+		repo := repos[i]
+		if err := resolveRepo(ctx, repo, logger); err != nil {
+			logger.WarnContext(ctx, "repo resolution failed",
+				"repo", repo.Name, "target", repo.Target, "required", repo.Required, "error", err)
+			if repo.Required {
+				requiredFailed = true
+			}
+			continue
+		}
+	}
+
+	if requiredFailed {
+		return errRequiredRepoFailed
+	}
+	return nil
+}
+
+// resolveRepo clones or fetches a single repo. If target/.git already exists it
+// fetches + fast-forwards (clone-if-absent idempotency: the writable rootfs
+// persists across kuke stop/start, so a restart never re-clones); otherwise it
+// clones. On success it logs the resolved HEAD commit.
+func resolveRepo(ctx context.Context, repo v1beta1.ContainerRepo, logger *slog.Logger) error {
+	gitDir := filepath.Join(repo.Target, ".git")
+	exists := false
+	if info, statErr := os.Stat(gitDir); statErr == nil && info.IsDir() {
+		exists = true
+	}
+
+	state := "cloned"
+	var opErr error
+	if exists {
+		state = "fetched"
+		opErr = fetchRepo(ctx, repo)
+	} else {
+		opErr = cloneRepo(ctx, repo)
+	}
+	if opErr != nil {
+		return opErr
+	}
+
+	commit := ""
+	if head, headErr := repoHead(ctx, repo.Target); headErr == nil {
+		commit = head
+	}
+	logger.InfoContext(ctx, "repo resolved",
+		"repo", repo.Name, "target", repo.Target, "state", state, "commit", commit)
+	return nil
+}
+
+// cloneRepo clones repo.URL into repo.Target, optionally pinned to repo.Branch.
+func cloneRepo(ctx context.Context, repo v1beta1.ContainerRepo) error {
+	args := []string{"clone"}
+	if repo.Branch != "" {
+		args = append(args, "--branch", repo.Branch)
+	}
+	args = append(args, repo.URL, repo.Target)
+	return runGit(ctx, "", args...)
+}
+
+// fetchRepo updates an existing checkout: fetch the remote, then (when a branch
+// is requested) check it out and fast-forward. A non-fast-forwardable local
+// state surfaces as an error rather than a silent divergence.
+func fetchRepo(ctx context.Context, repo v1beta1.ContainerRepo) error {
+	if err := runGit(ctx, repo.Target, "fetch", "--prune", "origin"); err != nil {
+		return err
+	}
+	if repo.Branch != "" {
+		if err := runGit(ctx, repo.Target, "checkout", repo.Branch); err != nil {
+			return err
+		}
+	}
+	return runGit(ctx, repo.Target, "pull", "--ff-only")
+}
+
+// repoHead returns the full HEAD commit SHA of the checkout at target.
+func repoHead(ctx context.Context, target string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", target, "rev-parse", "HEAD")
+	cmd.Env = gitEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// runGit runs a git subcommand with the container's git identity (HOME,
+// ~/.ssh, ~/.gitconfig — inherited via gitEnv) plus the non-interactive guards
+// gitEnv adds. dir is the working directory ("" for the process cwd, e.g.
+// clone). On failure the combined output is folded into the error so the log
+// line carries an actionable message.
+func runGit(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = gitEnv()
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed != "" {
+			return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, trimmed)
+		}
+		return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+// gitEnv returns kuketty's environment (so the container's git identity —
+// HOME, ~/.ssh, ~/.gitconfig — is used) augmented with non-interactive guards
+// so a first-time clone of an unseen host never hangs waiting for operator
+// input (issue #617, non-interactive host-key handling):
+//
+//   - GIT_TERMINAL_PROMPT=0 makes git fail instead of prompting for HTTPS
+//     credentials.
+//   - GIT_SSH_COMMAND defaults to `ssh -o StrictHostKeyChecking=accept-new
+//     -o BatchMode=yes` so a first-time git@host clone trust-on-first-use
+//     accepts the new key (but still errors on a *changed* key) rather than
+//     blocking on the interactive yes/no prompt.
+//
+// Both defaults yield to a value the container already set: an image that
+// pre-seeds known_hosts and exports its own GIT_SSH_COMMAND, or one that wants
+// HTTPS credential prompting, wins. kuketty only fills the gap so the
+// out-of-the-box path is non-interactive.
+func gitEnv() []string {
+	env := os.Environ()
+	if _, ok := os.LookupEnv("GIT_TERMINAL_PROMPT"); !ok {
+		env = append(env, "GIT_TERMINAL_PROMPT=0")
+	}
+	if _, ok := os.LookupEnv("GIT_SSH_COMMAND"); !ok {
+		env = append(env, "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes")
+	}
+	return env
+}

--- a/cmd/kuketty/repos_test.go
+++ b/cmd/kuketty/repos_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// discardLogger is a logger that drops output, for tests that exercise
+// processRepos without asserting on log lines.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// gitRun runs git in dir with a hermetic identity so the test never depends on
+// (or mutates) the host's global git config.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	full := append([]string{
+		"-c", "user.email=test@kukeon.invalid",
+		"-c", "user.name=kukeon test",
+		"-c", "init.defaultBranch=main",
+		"-c", "commit.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %q: %v\n%s", args, dir, err, out)
+	}
+}
+
+// makeSourceRepo creates a non-bare source repo on branch main with one commit
+// adding fileName, and returns its path (usable as a clone URL).
+func makeSourceRepo(t *testing.T, fileName string) string {
+	t.Helper()
+	src := t.TempDir()
+	gitRun(t, src, "init")
+	if err := os.WriteFile(filepath.Join(src, fileName), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "initial")
+	return src
+}
+
+func TestProcessRepos_EmptyIsNoOp(t *testing.T) {
+	if err := processRepos(context.Background(), nil, discardLogger()); err != nil {
+		t.Fatalf("nil repos should be a no-op, got %v", err)
+	}
+	if err := processRepos(context.Background(), []v1beta1.ContainerRepo{}, discardLogger()); err != nil {
+		t.Fatalf("empty repos should be a no-op, got %v", err)
+	}
+}
+
+func TestProcessRepos_ClonesIntoTarget(t *testing.T) {
+	src := makeSourceRepo(t, "README.md")
+	target := filepath.Join(t.TempDir(), "checkout")
+
+	repos := []v1beta1.ContainerRepo{
+		{Name: "project", Target: target, Branch: "main", URL: src, Required: true},
+	}
+	if err := processRepos(context.Background(), repos, discardLogger()); err != nil {
+		t.Fatalf("processRepos: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "README.md")); err != nil {
+		t.Fatalf("expected cloned file: %v", err)
+	}
+}
+
+func TestProcessRepos_FetchesExistingCheckout(t *testing.T) {
+	src := makeSourceRepo(t, "README.md")
+	target := filepath.Join(t.TempDir(), "checkout")
+	repos := []v1beta1.ContainerRepo{
+		{Name: "project", Target: target, Branch: "main", URL: src, Required: true},
+	}
+
+	// First pass clones.
+	if err := processRepos(context.Background(), repos, discardLogger()); err != nil {
+		t.Fatalf("first processRepos (clone): %v", err)
+	}
+
+	// Add a new commit upstream, then re-run: existing .git → fetch path.
+	if err := os.WriteFile(filepath.Join(src, "second.txt"), []byte("more\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "second")
+
+	if err := processRepos(context.Background(), repos, discardLogger()); err != nil {
+		t.Fatalf("second processRepos (fetch): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "second.txt")); err != nil {
+		t.Errorf("fetch should have fast-forwarded the new commit: %v", err)
+	}
+}
+
+func TestProcessRepos_RequiredFailurePropagates(t *testing.T) {
+	dir := t.TempDir()
+	repos := []v1beta1.ContainerRepo{
+		{
+			Name:     "missing",
+			Target:   filepath.Join(dir, "checkout"),
+			URL:      filepath.Join(dir, "does-not-exist"),
+			Required: true,
+		},
+	}
+
+	err := processRepos(context.Background(), repos, discardLogger())
+	if !errors.Is(err, errRequiredRepoFailed) {
+		t.Fatalf("want errRequiredRepoFailed, got %v", err)
+	}
+}
+
+func TestProcessRepos_NonRequiredFailureDoesNotPropagate(t *testing.T) {
+	dir := t.TempDir()
+	repos := []v1beta1.ContainerRepo{
+		{
+			Name:     "optional",
+			Target:   filepath.Join(dir, "checkout"),
+			URL:      filepath.Join(dir, "does-not-exist"),
+			Required: false,
+		},
+	}
+
+	if err := processRepos(context.Background(), repos, discardLogger()); err != nil {
+		t.Fatalf("non-required failure must not propagate, got %v", err)
+	}
+}
+
+func TestProcessRepos_RequiredFailureAfterSuccessStillPropagates(t *testing.T) {
+	src := makeSourceRepo(t, "README.md")
+	dir := t.TempDir()
+	repos := []v1beta1.ContainerRepo{
+		{Name: "good", Target: filepath.Join(dir, "good"), Branch: "main", URL: src, Required: false},
+		{Name: "bad", Target: filepath.Join(dir, "bad"), URL: filepath.Join(dir, "nope"), Required: true},
+	}
+
+	err := processRepos(context.Background(), repos, discardLogger())
+	if !errors.Is(err, errRequiredRepoFailed) {
+		t.Fatalf("want errRequiredRepoFailed, got %v", err)
+	}
+	// The good repo (declared before the failing one) was still resolved.
+	if _, statErr := os.Stat(filepath.Join(dir, "good", "README.md")); statErr != nil {
+		t.Errorf("expected the non-required repo to clone despite a later required failure: %v", statErr)
+	}
+}

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -353,6 +353,7 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				Tmpfs:                  convertTmpfsMountsToInternal(in.Spec.Tmpfs),
 				Resources:              convertResourcesToInternal(in.Spec.Resources),
 				Secrets:                convertSecretsToInternal(in.Spec.Secrets),
+				Repos:                  reposToInternal(in.Spec.Repos),
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
 				Attachable:             in.Spec.Attachable,
@@ -368,6 +369,7 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				FinishTime:   in.Status.FinishTime,
 				ExitCode:     in.Status.ExitCode,
 				ExitSignal:   in.Status.ExitSignal,
+				Repos:        repoStatusesToInternal(in.Status.Repos),
 			},
 		}, nil
 	default:
@@ -413,6 +415,7 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				Tmpfs:                  buildTmpfsMountsExternalFromInternal(in.Spec.Tmpfs),
 				Resources:              buildResourcesExternalFromInternal(in.Spec.Resources),
 				Secrets:                buildSecretsExternalFromInternal(in.Spec.Secrets),
+				Repos:                  reposToExternal(in.Spec.Repos),
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
 				Attachable:             in.Spec.Attachable,
@@ -428,6 +431,7 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				FinishTime:   in.Status.FinishTime,
 				ExitCode:     in.Status.ExitCode,
 				ExitSignal:   in.Status.ExitSignal,
+				Repos:        repoStatusesToExternal(in.Status.Repos),
 			},
 		}, nil
 	default:
@@ -476,6 +480,7 @@ func convertContainerSpecToInternal(in ext.ContainerSpec) intmodel.ContainerSpec
 		Tmpfs:                  convertTmpfsMountsToInternal(in.Tmpfs),
 		Resources:              convertResourcesToInternal(in.Resources),
 		Secrets:                convertSecretsToInternal(in.Secrets),
+		Repos:                  reposToInternal(in.Repos),
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
 		Attachable:             in.Attachable,
@@ -514,6 +519,7 @@ func BuildContainerSpecExternalFromInternal(in intmodel.ContainerSpec) ext.Conta
 		Tmpfs:                  buildTmpfsMountsExternalFromInternal(in.Tmpfs),
 		Resources:              buildResourcesExternalFromInternal(in.Resources),
 		Secrets:                buildSecretsExternalFromInternal(in.Secrets),
+		Repos:                  reposToExternal(in.Repos),
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
 		Attachable:             in.Attachable,
@@ -799,6 +805,80 @@ func buildSecretsExternalFromInternal(in []intmodel.ContainerSecret) []ext.Conta
 			FromFile:  s.FromFile,
 			FromEnv:   s.FromEnv,
 			MountPath: s.MountPath,
+		}
+	}
+	return out
+}
+
+// reposToInternal copies external repo declarations into the internal model.
+// Issue #617.
+func reposToInternal(in []ext.ContainerRepo) []intmodel.ContainerRepo {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]intmodel.ContainerRepo, len(in))
+	for i, r := range in {
+		out[i] = intmodel.ContainerRepo{
+			Name:     r.Name,
+			Target:   r.Target,
+			Branch:   r.Branch,
+			URL:      r.URL,
+			Required: r.Required,
+		}
+	}
+	return out
+}
+
+// reposToExternal is the inverse of reposToInternal.
+func reposToExternal(in []intmodel.ContainerRepo) []ext.ContainerRepo {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ext.ContainerRepo, len(in))
+	for i, r := range in {
+		out[i] = ext.ContainerRepo{
+			Name:     r.Name,
+			Target:   r.Target,
+			Branch:   r.Branch,
+			URL:      r.URL,
+			Required: r.Required,
+		}
+	}
+	return out
+}
+
+// repoStatusesToInternal copies external per-repo status into the internal
+// model. Issue #617.
+func repoStatusesToInternal(in []ext.RepoStatus) []intmodel.RepoStatus {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]intmodel.RepoStatus, len(in))
+	for i, s := range in {
+		out[i] = intmodel.RepoStatus{
+			Name:   s.Name,
+			Target: s.Target,
+			State:  s.State,
+			Commit: s.Commit,
+			Error:  s.Error,
+		}
+	}
+	return out
+}
+
+// repoStatusesToExternal is the inverse of repoStatusesToInternal.
+func repoStatusesToExternal(in []intmodel.RepoStatus) []ext.RepoStatus {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ext.RepoStatus, len(in))
+	for i, s := range in {
+		out[i] = ext.RepoStatus{
+			Name:   s.Name,
+			Target: s.Target,
+			State:  s.State,
+			Commit: s.Commit,
+			Error:  s.Error,
 		}
 	}
 	return out

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -710,6 +710,79 @@ func TestContainerRoundTripV1Beta1(t *testing.T) {
 	}
 }
 
+// TestContainerRoundTripReposV1Beta1 pins the repos[] spec and the per-repo
+// status round trip: a YAML author's containers[].repos[] must survive
+// Normalize → controller → Build with no drops, and the controller-populated
+// ContainerStatus.Repos must survive Build out to the external doc. Issue #617.
+func TestContainerRoundTripReposV1Beta1(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "work"},
+		Spec: ext.ContainerSpec{
+			ID:         "work",
+			RealmID:    "realm0",
+			SpaceID:    "space0",
+			StackID:    "stack0",
+			CellID:     "cell0",
+			Image:      "alpine:latest",
+			Attachable: true,
+			Repos: []ext.ContainerRepo{
+				{
+					Name:     "project",
+					Target:   "/home/claude/project",
+					Branch:   "main",
+					URL:      "git@example.com:org/p.git",
+					Required: true,
+				},
+				{Name: "docs", Target: "/home/claude/docs", URL: "https://example.com/docs.git"},
+			},
+		},
+		Status: ext.ContainerStatus{State: ext.ContainerStatePending},
+	}
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer failed: %v", err)
+	}
+	if len(internal.Spec.Repos) != 2 {
+		t.Fatalf("internal repos len = %d, want 2", len(internal.Spec.Repos))
+	}
+	if internal.Spec.Repos[0] != (intmodel.ContainerRepo{
+		Name: "project", Target: "/home/claude/project", Branch: "main", URL: "git@example.com:org/p.git", Required: true,
+	}) {
+		t.Errorf("internal repo[0] = %+v", internal.Spec.Repos[0])
+	}
+
+	// Simulate the controller stamping per-repo status read back from kuketty.
+	internal.Status.Repos = []intmodel.RepoStatus{
+		{Name: "project", Target: "/home/claude/project", State: "cloned", Commit: "deadbeef"},
+		{Name: "docs", Target: "/home/claude/docs", State: "failed", Error: "boom"},
+	}
+
+	output, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal failed: %v", err)
+	}
+	if len(output.Spec.Repos) != 2 {
+		t.Fatalf("output repos len = %d, want 2", len(output.Spec.Repos))
+	}
+	for i := range input.Spec.Repos {
+		if output.Spec.Repos[i] != input.Spec.Repos[i] {
+			t.Errorf("repo[%d] = %+v, want %+v", i, output.Spec.Repos[i], input.Spec.Repos[i])
+		}
+	}
+	if len(output.Status.Repos) != 2 {
+		t.Fatalf("output status repos len = %d, want 2", len(output.Status.Repos))
+	}
+	if output.Status.Repos[0].State != "cloned" || output.Status.Repos[0].Commit != "deadbeef" {
+		t.Errorf("status repo[0] = %+v", output.Status.Repos[0])
+	}
+	if output.Status.Repos[1].State != "failed" || output.Status.Repos[1].Error != "boom" {
+		t.Errorf("status repo[1] = %+v", output.Status.Repos[1])
+	}
+}
+
 // TestContainerRoundTripVolumeKindTmpfsV1Beta1 pins the tmpfs path on
 // VolumeMount: a YAML author who writes `kind: tmpfs` with size/mode must see
 // those fields survive Normalize → controller → Build with no drops, alongside

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -383,8 +383,41 @@ func ValidateDocument(doc *Document) *ValidationError {
 				Err:   secretErr,
 			}
 		}
+		if repoErr := validateRepos(doc.ContainerDoc.Spec.Repos); repoErr != nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.ContainerDoc.Metadata.Name,
+				Err:   repoErr,
+			}
+		}
 	}
 
+	return nil
+}
+
+// validateRepos enforces the shape of repo declarations: name required, target
+// required and absolute, url required. Mirrors validateSecrets. kuketty reads
+// repos[] straight from the mounted ContainerDoc.Spec and performs no
+// validation of its own, so this apply-time gate is the single check before a
+// malformed repos[] reaches the wrapper. Issue #617.
+func validateRepos(repos []v1beta1.ContainerRepo) error {
+	for i, r := range repos {
+		name := strings.TrimSpace(r.Name)
+		if name == "" {
+			return fmt.Errorf("%w (repos[%d])", errdefs.ErrRepoNameRequired, i)
+		}
+		target := strings.TrimSpace(r.Target)
+		if target == "" {
+			return fmt.Errorf("%w (repos[%d] %q)", errdefs.ErrRepoTargetRequired, i, name)
+		}
+		if !filepath.IsAbs(target) {
+			return fmt.Errorf("%w (repos[%d] %q target %q)", errdefs.ErrRepoTargetNotAbsolute, i, name, target)
+		}
+		if strings.TrimSpace(r.URL) == "" {
+			return fmt.Errorf("%w (repos[%d] %q)", errdefs.ErrRepoURLRequired, i, name)
+		}
+	}
 	return nil
 }
 

--- a/internal/apply/parser/parser_test.go
+++ b/internal/apply/parser/parser_test.go
@@ -447,6 +447,75 @@ spec:
 	}
 }
 
+func TestValidateDocument_Container_RepoValidation(t *testing.T) {
+	base := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  attachable: true
+  repos:
+`
+	cases := []struct {
+		name     string
+		repoYAML string
+		wantErr  error // nil = expect pass
+	}{
+		{
+			name:     "missing name",
+			repoYAML: "    - target: /home/claude/p\n      url: https://example.com/p.git\n",
+			wantErr:  errdefs.ErrRepoNameRequired,
+		},
+		{
+			name:     "missing target",
+			repoYAML: "    - name: p\n      url: https://example.com/p.git\n",
+			wantErr:  errdefs.ErrRepoTargetRequired,
+		},
+		{
+			name:     "relative target",
+			repoYAML: "    - name: p\n      target: rel/p\n      url: https://example.com/p.git\n",
+			wantErr:  errdefs.ErrRepoTargetNotAbsolute,
+		},
+		{
+			name:     "missing url",
+			repoYAML: "    - name: p\n      target: /home/claude/p\n",
+			wantErr:  errdefs.ErrRepoURLRequired,
+		},
+		{
+			name:     "valid",
+			repoYAML: "    - name: project\n      target: /home/claude/project\n      branch: main\n      url: https://example.com/p.git\n      required: true\n",
+			wantErr:  nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := parser.ParseDocument(0, []byte(base+tc.repoYAML))
+			if err != nil {
+				t.Fatalf("ParseDocument failed: %v", err)
+			}
+			validationErr := parser.ValidateDocument(doc)
+			if tc.wantErr == nil {
+				if validationErr != nil {
+					t.Fatalf("expected valid repos to pass, got: %v", validationErr)
+				}
+				return
+			}
+			if validationErr == nil {
+				t.Fatalf("expected validation error %v, got nil", tc.wantErr)
+			}
+			if !strings.Contains(validationErr.Error(), tc.wantErr.Error()) {
+				t.Errorf("expected %v, got: %v", tc.wantErr, validationErr)
+			}
+		})
+	}
+}
+
 func TestValidateDocument_UnsupportedAPIVersion(t *testing.T) {
 	yaml := `apiVersion: v1alpha1
 kind: Realm

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -49,7 +49,7 @@ var (
 	// an intervening write under the same exclusive flock. The caller
 	// must re-read, re-apply the mutation, and retry — there is no
 	// silent merge of disjoint edits.
-	ErrStaleResource = errors.New("metadata resource changed since prior read")
+	ErrStaleResource          = errors.New("metadata resource changed since prior read")
 	ErrUnsupportedAPIVersion  = errors.New("unsupported apiVersion")
 	ErrUnknownKind            = errors.New("unknown kind")
 	ErrConversionFailed       = errors.New("conversion failed")
@@ -279,6 +279,13 @@ var (
 	ErrSecretFromFileNotFound     = errors.New("secret fromFile path does not exist on the host")
 	ErrSecretFromEnvNotSet        = errors.New("secret fromEnv env var is not set on the daemon host")
 	ErrSecretStagingFailed        = errors.New("failed to stage secret file for mount")
+
+	// Repo-related errors (containers[].repos[], issue #617).
+
+	ErrRepoNameRequired      = errors.New("repo name is required")
+	ErrRepoTargetRequired    = errors.New("repo target is required")
+	ErrRepoTargetNotAbsolute = errors.New("repo target must be an absolute container path")
+	ErrRepoURLRequired       = errors.New("repo url is required")
 
 	// ErrMustRunAsRoot is returned by direct-write subcommands (kuke init,
 	// kuke daemon reset, kuke image load, kuke doctor cgroups --probe)

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -67,10 +67,14 @@ type ContainerSpec struct {
 	Tmpfs                  []ContainerTmpfsMount
 	Resources              *ContainerResources
 	Secrets                []ContainerSecret
-	CNIConfigPath          string
-	RestartPolicy          string
-	Attachable             bool
-	Tty                    *ContainerTty
+	// Repos mirrors the v1beta1 ContainerSpec.Repos payload — git
+	// repositories kuketty clones/fetches in its pre-Serve step. See the
+	// v1beta1 type for field semantics. Issue #617.
+	Repos         []ContainerRepo
+	CNIConfigPath string
+	RestartPolicy string
+	Attachable    bool
+	Tty           *ContainerTty
 	// CellCgroupPath is the absolute cgroup path of the parent cell (mirrors
 	// Cell.Status.CgroupPath). When set, BuildContainerSpec emits an OCI
 	// Linux.CgroupsPath rooted at <CellCgroupPath>/<containerd-id> so the
@@ -181,6 +185,17 @@ type VolumeMount struct {
 	Mode uint32
 }
 
+// ContainerRepo mirrors the v1beta1 ContainerRepo payload — a git repository
+// the container depends on, cloned/fetched by kuketty pre-Serve. See the
+// v1beta1 type for field semantics. Issue #617.
+type ContainerRepo struct {
+	Name     string
+	Target   string
+	Branch   string
+	URL      string
+	Required bool
+}
+
 // ContainerCapabilities groups Linux capability deltas applied relative to the
 // image default set.
 type ContainerCapabilities struct {
@@ -212,6 +227,18 @@ type ContainerStatus struct {
 	FinishTime   time.Time
 	ExitCode     int
 	ExitSignal   string
+	// Repos reports the per-repo outcome of kuketty's pre-Serve clone/fetch
+	// step. Mirrors the v1beta1 ContainerStatus.Repos payload. Issue #617.
+	Repos []RepoStatus
+}
+
+// RepoStatus mirrors the v1beta1 RepoStatus payload. Issue #617.
+type RepoStatus struct {
+	Name   string
+	Target string
+	State  string
+	Commit string
+	Error  string
 }
 
 type ContainerState int

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -91,8 +91,18 @@ type ContainerSpec struct {
 	Tmpfs                  []ContainerTmpfsMount  `json:"tmpfs,omitempty"                  yaml:"tmpfs,omitempty"`
 	Resources              *ContainerResources    `json:"resources,omitempty"              yaml:"resources,omitempty"`
 	Secrets                []ContainerSecret      `json:"secrets,omitempty"                yaml:"secrets,omitempty"`
-	CNIConfigPath          string                 `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
-	RestartPolicy          string                 `json:"restartPolicy"                    yaml:"restartPolicy"`
+	// Repos declares git repositories the container depends on. The kuketty
+	// wrapper clones (or fetches) each one in a pre-Serve step using the
+	// container's own git identity (~/.ssh, ~/.gitconfig, GIT_SSH_COMMAND),
+	// so the daemon never touches user-owned SSH keys. kuketty reads them
+	// straight from this ContainerDoc.Spec (it owns the spec→TerminalSpec
+	// build since issue #641) — there is no sidecar doc. Has no effect unless
+	// Attachable=true (kuketty owns the resolution step). Per-repo outcome
+	// surfaces in ContainerStatus.Repos over RPC in phase 1b (#642). Issue
+	// #617, phase 1a of #423.
+	Repos         []ContainerRepo `json:"repos,omitempty"                  yaml:"repos,omitempty"`
+	CNIConfigPath string          `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
+	RestartPolicy string          `json:"restartPolicy"                    yaml:"restartPolicy"`
 	// Attachable opts the container into kuketty-wrapper injection. When
 	// true, the daemon rewrites process.args to a single element
 	// [/.kukeon/bin/kuketty] — no CLI flags, every runtime input flows
@@ -239,6 +249,33 @@ type VolumeMount struct {
 	Mode      uint32     `json:"mode,omitempty"      yaml:"mode,omitempty"`
 }
 
+// ContainerRepo declares a git repository the container depends on. kuketty
+// clones (or fetches) it into Target before the workload starts, replacing the
+// hand-rolled `if [ ! -d $DIR/.git ]; then git clone …; fi` blocks that crew
+// templates duplicate in onInit scripts today. The clone state becomes daemon-
+// observable via ContainerStatus.Repos (reported over RPC in phase 1b, #642)
+// rather than buried in attach stderr. Issue #617, phase 1a of #423.
+type ContainerRepo struct {
+	// Name is the operator-facing identifier for the repo, echoed back in
+	// per-repo status. Required.
+	Name string `json:"name"               yaml:"name"`
+	// Target is the absolute in-container path the repo is cloned into.
+	// Required.
+	Target string `json:"target"             yaml:"target"`
+	// Branch is the branch to check out. Empty clones the remote's default
+	// branch.
+	Branch string `json:"branch,omitempty"   yaml:"branch,omitempty"`
+	// URL is the clone URL. In phases 1–3 it is supplied via scalar
+	// ${PARAM} substitution; phase 4 (#423) enables structural slot fill
+	// from a CellConfig. Required.
+	URL string `json:"url"                yaml:"url"`
+	// Required gates failure handling. When true, a clone/fetch failure
+	// makes kuketty exit non-zero before sbsh starts, so the daemon
+	// observes the container task as Failed. When false (the default) the
+	// failure is logged but the container proceeds.
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
+}
+
 // ContainerCapabilities groups Linux capability deltas applied to the
 // container process relative to the image default set.
 type ContainerCapabilities struct {
@@ -262,15 +299,34 @@ type ContainerResources struct {
 }
 
 type ContainerStatus struct {
-	Name         string         `json:"name"         yaml:"name"`
-	ID           string         `json:"id"           yaml:"id"`
-	State        ContainerState `json:"state"        yaml:"state"`
-	RestartCount int            `json:"restartCount" yaml:"restartCount"`
-	RestartTime  time.Time      `json:"restartTime"  yaml:"restartTime"`
-	StartTime    time.Time      `json:"startTime"    yaml:"startTime"`
-	FinishTime   time.Time      `json:"finishTime"   yaml:"finishTime"`
-	ExitCode     int            `json:"exitCode"     yaml:"exitCode"`
-	ExitSignal   string         `json:"exitSignal"   yaml:"exitSignal"`
+	Name         string         `json:"name"            yaml:"name"`
+	ID           string         `json:"id"              yaml:"id"`
+	State        ContainerState `json:"state"           yaml:"state"`
+	RestartCount int            `json:"restartCount"    yaml:"restartCount"`
+	RestartTime  time.Time      `json:"restartTime"     yaml:"restartTime"`
+	StartTime    time.Time      `json:"startTime"       yaml:"startTime"`
+	FinishTime   time.Time      `json:"finishTime"      yaml:"finishTime"`
+	ExitCode     int            `json:"exitCode"        yaml:"exitCode"`
+	ExitSignal   string         `json:"exitSignal"      yaml:"exitSignal"`
+	// Repos reports the per-repo outcome of kuketty's pre-Serve clone/fetch
+	// step for an Attachable container's Spec.Repos. Empty for containers
+	// with no repos[] or that have not yet been provisioned. Populated over
+	// the GetSetupStatus RPC in phase 1b (#642); phase 1a lands the schema
+	// only. Issue #617.
+	Repos []RepoStatus `json:"repos,omitempty" yaml:"repos,omitempty"`
+}
+
+// RepoStatus is the resolved state of a single ContainerRepo after kuketty's
+// pre-Serve step. Populated in phase 1b (#642). Issue #617.
+type RepoStatus struct {
+	Name   string `json:"name"             yaml:"name"`
+	Target string `json:"target"           yaml:"target"`
+	// State is one of "cloned", "fetched", or "failed".
+	State string `json:"state"            yaml:"state"`
+	// Commit is the resolved HEAD commit (full SHA) on success.
+	Commit string `json:"commit,omitempty" yaml:"commit,omitempty"`
+	// Error is the failure detail when State == "failed".
+	Error string `json:"error,omitempty"  yaml:"error,omitempty"`
 }
 
 type ContainerState int
@@ -371,6 +427,8 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 	out.Spec.NetworksAliases = cloneSlice(out.Spec.NetworksAliases)
 	out.Spec.SecurityOpts = cloneSlice(out.Spec.SecurityOpts)
 	out.Spec.Secrets = cloneSecrets(out.Spec.Secrets)
+	out.Spec.Repos = cloneRepos(out.Spec.Repos)
+	out.Status.Repos = cloneRepoStatuses(out.Status.Repos)
 
 	if out.Spec.Capabilities != nil {
 		caps := *out.Spec.Capabilities
@@ -422,6 +480,26 @@ func cloneSecrets(in []ContainerSecret) []ContainerSecret {
 	}
 
 	out := make([]ContainerSecret, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneRepos(in []ContainerRepo) []ContainerRepo {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]ContainerRepo, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneRepoStatuses(in []RepoStatus) []RepoStatus {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]RepoStatus, len(in))
 	copy(out, in)
 	return out
 }


### PR DESCRIPTION
## Summary

Phase 1a of #423, rebased onto **phase 0 (#645)**. Adds a first-class `containers[].repos[]` declaration so a container can depend on git repositories without the hand-rolled `if [ ! -d $DIR/.git ]; then git clone …; fi` blocks crew templates duplicate in `onInit` scripts.

**This PR was rescoped after #645 merged.** PM converted the prior revision (sidecar + status-file design) to draft and re-sequenced the work; per the [draft-conversion note](https://github.com/eminwux/kukeon/issues/617) this revision **drops** the `internal/reposwire` sidecar and the `repos-status.json` write-back, and rebases the carry-forward pieces onto phase 0's `ContainerDoc` mount.

### What carried forward from the prior revision
- `ContainerSpec.Repos` / `ContainerStatus.Repos` schema (+ `v1beta1` & `internal/modelhub` mirrors), all four apischeme spec conversions and both status conversions, apply-parser validation (`name`/`target`-absolute/`url` required), and `errdefs` sentinels.
- The clone-if-absent engine in `cmd/kuketty/repos.go`.

### What changed for phase 1a
- **No sidecar doc.** kuketty reads `repos[]` straight from `doc.Spec.Repos` — the kukeon-native `ContainerDoc` it already mounts since #645 (`cmd/kuketty/main.go` calls `processRepos(ctx, doc.Spec.Repos, logger)` after `buildTerminalSpec`, before `sbshserver.Serve`). `internal/reposwire`, the conditional `repos.json` RO bind, and the `daemon-side` renderer changes are gone.
- **No status file.** The `/run/kukeon/tty/repos-status.json` write + daemon read-back are dropped; per-repo status reporting into `ContainerStatus.Repos` rides the `GetSetupStatus` RPC in **phase 1b (#642)**. `ContainerStatus.Repos` lands as schema only here (populated in 1b).
- The field rides phase 0's existing serialization: `writeKukettyDoc` → `BuildContainerSpecExternalFromInternal` (now converts `Repos`) → mounted `metadata.json` → kuketty. **No new daemon code** beyond the conversion helper.

### Design notes (please push back)
- **`required` defaults to `false`** (best-effort: a clone/fetch failure is logged and the container proceeds). `required: true` makes a failure fatal — kuketty returns `errRequiredRepoFailed` before `Serve`, exits non-zero (BSD `EX_SOFTWARE`=70), and the daemon observes the task as Failed (AC3). Matches the Go zero value and the opt-in field name.
- **Non-interactive host-key handling (AC4)** — `gitEnv()` augments kuketty's inherited env (which carries the container's `HOME`/`~/.ssh`/`~/.gitconfig` git identity) with `GIT_TERMINAL_PROMPT=0` and a default `GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes`, so a first-time `git@host` clone trust-on-first-use accepts the new key (still errors on a *changed* key) rather than hanging on the interactive prompt. Both defaults yield to a value the image already set (pre-seeded `known_hosts` + own `GIT_SSH_COMMAND`, or HTTPS credential prompting).
- **AC6** (deleting crew `onInit` clone blocks) is out of scope per the issue; verified by inspection that the schema suffices — `repos[]` carries url/target/branch/required and `onInit` remains for imperative post-clone work.

## Acceptance criteria
- [x] AC1 — `ContainerSpec.Repos` + `ContainerStatus.Repos` schema, conversions, parser validation, errdefs sentinels.
- [x] AC2 — kuketty pre-Serve step reads `repos[]` from the mounted `ContainerDoc.Spec` (no sidecar), clones-if-absent into `target` with the container's git identity, before `Serve`.
- [x] AC3 — a `required: true` failure makes kuketty exit non-zero before `Serve`; daemon surfaces the task as Failed.
- [x] AC4 — non-interactive host-key handling via `GIT_SSH_COMMAND` (`StrictHostKeyChecking=accept-new`, `BatchMode=yes`) + `GIT_TERMINAL_PROMPT=0`, documented above.
- [x] AC5 — repo-less containers' OCI mount list byte-for-byte unchanged (no sidecar bind; confirmed by the attach smoke below).
- [x] AC6 — crew `onInit` `git clone` blocks deletable in favour of `repos[]` (verified by inspection; crew edit out of scope).

## Test plan
- [x] `make test` — full unit suite green, including: kuketty clone/fetch/required-fail/non-required-fail + required-fail-after-success against a real local git fixture (`cmd/kuketty/repos_test.go`), repos+status apischeme round-trip (`internal/apischeme/scheme_test.go`), parser repo validation (`internal/apply/parser/parser_test.go`).
- [x] `go build ./...` + `go vet ./...` — clean.
- [x] `make dev-init` smoke — daemon parity check identical on both `kuke get realms` views; `kuke attach` against a kuketty-wrapped cell exited cleanly; nested parent-attach plumbing intact. Confirms the new spec field flowing through `writeKukettyDoc` does **not** regress the attachable path (smoke cell has no `repos[]`, so `processRepos` is a no-op and the mount list is unchanged).
- [x] `pre-commit run --files <changed>` — passed (incl. golangci-lint, addlicense).
- [ ] Live `repos[]` clone inside a running container — not exercised: needs a git remote reachable from the container netns with the container's git identity, which the dev-init/e2e harness doesn't set up. Covered at unit level by the real-git `processRepos` tests; no-regression confirmed by the attach smoke.

Closes #617