### PR TITLE
feat(metadata): add Generation/ObservedGeneration to all 4 kinds (phase 2)

### DIFF
--- a/internal/apischeme/generation_test.go
+++ b/internal/apischeme/generation_test.go
@@ -1,0 +1,350 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// The tests below cover issue #596 phase 2: Metadata.Generation and
+// Status.ObservedGeneration are mechanical type-layer fields. They must
+// (a) survive the external→internal→external round-trip through all 8
+// apischeme converters, (b) read back as zero from pre-existing metadata
+// that predates the fields, and (c) stay omitted from the serialized form
+// when zero so existing manifests keep their on-disk shape.
+
+// TestRealmGenerationRoundTrip pins Generation/ObservedGeneration through the
+// realm converter pair and the YAML form.
+func TestRealmGenerationRoundTrip(t *testing.T) {
+	input := ext.RealmDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindRealm,
+		Metadata:   ext.RealmMetadata{Name: "realm0", Generation: 7},
+		Spec:       ext.RealmSpec{Namespace: "realm0"},
+		Status:     ext.RealmStatus{State: ext.RealmStateReady, ObservedGeneration: 6},
+	}
+
+	internal, version, err := apischeme.NormalizeRealm(input)
+	if err != nil {
+		t.Fatalf("NormalizeRealm: %v", err)
+	}
+	if internal.Metadata.Generation != 7 {
+		t.Errorf("internal Generation = %d, want 7", internal.Metadata.Generation)
+	}
+	if internal.Status.ObservedGeneration != 6 {
+		t.Errorf("internal ObservedGeneration = %d, want 6", internal.Status.ObservedGeneration)
+	}
+
+	output, err := apischeme.BuildRealmExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildRealmExternalFromInternal: %v", err)
+	}
+	if output.Metadata.Generation != 7 {
+		t.Errorf("external Generation = %d, want 7", output.Metadata.Generation)
+	}
+	if output.Status.ObservedGeneration != 6 {
+		t.Errorf("external ObservedGeneration = %d, want 6", output.Status.ObservedGeneration)
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if !strings.Contains(string(rendered), "generation: 7") {
+		t.Errorf("rendered YAML missing generation; got:\n%s", string(rendered))
+	}
+	if !strings.Contains(string(rendered), "observedGeneration: 6") {
+		t.Errorf("rendered YAML missing observedGeneration; got:\n%s", string(rendered))
+	}
+}
+
+// TestRealmGenerationZeroValue covers reading a pre-existing realm metadata
+// document that predates the fields: they unmarshal to zero, survive the
+// round-trip, and stay omitted from the re-serialized form.
+func TestRealmGenerationZeroValue(t *testing.T) {
+	const legacy = `apiVersion: v1beta1
+kind: Realm
+metadata:
+  name: realm0
+spec:
+  namespace: realm0
+status:
+  state: 2
+`
+	var doc ext.RealmDoc
+	if err := yaml.Unmarshal([]byte(legacy), &doc); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if doc.Metadata.Generation != 0 || doc.Status.ObservedGeneration != 0 {
+		t.Fatalf("legacy doc did not zero-default: gen=%d obs=%d",
+			doc.Metadata.Generation, doc.Status.ObservedGeneration)
+	}
+
+	internal, version, err := apischeme.NormalizeRealm(doc)
+	if err != nil {
+		t.Fatalf("NormalizeRealm: %v", err)
+	}
+	output, err := apischeme.BuildRealmExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildRealmExternalFromInternal: %v", err)
+	}
+	if output.Metadata.Generation != 0 || output.Status.ObservedGeneration != 0 {
+		t.Errorf("zero values not preserved: gen=%d obs=%d",
+			output.Metadata.Generation, output.Status.ObservedGeneration)
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if strings.Contains(string(rendered), "generation:") {
+		t.Errorf("generation must be omitted when zero; got:\n%s", string(rendered))
+	}
+	if strings.Contains(string(rendered), "observedGeneration:") {
+		t.Errorf("observedGeneration must be omitted when zero; got:\n%s", string(rendered))
+	}
+}
+
+// TestSpaceGenerationRoundTrip pins the fields through the space converter pair.
+func TestSpaceGenerationRoundTrip(t *testing.T) {
+	input := ext.SpaceDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindSpace,
+		Metadata:   ext.SpaceMetadata{Name: "space0", Generation: 3},
+		Spec:       ext.SpaceSpec{RealmID: "realm0"},
+		Status:     ext.SpaceStatus{State: ext.SpaceStateReady, ObservedGeneration: 2},
+	}
+
+	internal, version, err := apischeme.NormalizeSpace(input)
+	if err != nil {
+		t.Fatalf("NormalizeSpace: %v", err)
+	}
+	if internal.Metadata.Generation != 3 || internal.Status.ObservedGeneration != 2 {
+		t.Errorf("internal gen=%d obs=%d, want 3/2",
+			internal.Metadata.Generation, internal.Status.ObservedGeneration)
+	}
+
+	output, err := apischeme.BuildSpaceExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildSpaceExternalFromInternal: %v", err)
+	}
+	if output.Metadata.Generation != 3 || output.Status.ObservedGeneration != 2 {
+		t.Errorf("external gen=%d obs=%d, want 3/2",
+			output.Metadata.Generation, output.Status.ObservedGeneration)
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if !strings.Contains(string(rendered), "generation: 3") ||
+		!strings.Contains(string(rendered), "observedGeneration: 2") {
+		t.Errorf("rendered YAML missing generation fields; got:\n%s", string(rendered))
+	}
+}
+
+// TestSpaceGenerationZeroValue covers the pre-existing-metadata read for spaces.
+func TestSpaceGenerationZeroValue(t *testing.T) {
+	input := ext.SpaceDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindSpace,
+		Metadata:   ext.SpaceMetadata{Name: "space0"},
+		Spec:       ext.SpaceSpec{RealmID: "realm0"},
+		Status:     ext.SpaceStatus{State: ext.SpaceStatePending},
+	}
+
+	internal, version, err := apischeme.NormalizeSpace(input)
+	if err != nil {
+		t.Fatalf("NormalizeSpace: %v", err)
+	}
+	output, err := apischeme.BuildSpaceExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildSpaceExternalFromInternal: %v", err)
+	}
+	if output.Metadata.Generation != 0 || output.Status.ObservedGeneration != 0 {
+		t.Errorf("zero values not preserved: gen=%d obs=%d",
+			output.Metadata.Generation, output.Status.ObservedGeneration)
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if strings.Contains(string(rendered), "generation:") ||
+		strings.Contains(string(rendered), "observedGeneration:") {
+		t.Errorf("generation fields must be omitted when zero; got:\n%s", string(rendered))
+	}
+}
+
+// TestStackGenerationRoundTrip pins the fields through the stack converter pair.
+func TestStackGenerationRoundTrip(t *testing.T) {
+	input := ext.StackDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindStack,
+		Metadata:   ext.StackMetadata{Name: "stack0", Generation: 11},
+		Spec:       ext.StackSpec{ID: "stack0", RealmID: "realm0", SpaceID: "space0"},
+		Status:     ext.StackStatus{State: ext.StackStateReady, ObservedGeneration: 10},
+	}
+
+	internal, version, err := apischeme.NormalizeStack(input)
+	if err != nil {
+		t.Fatalf("NormalizeStack: %v", err)
+	}
+	if internal.Metadata.Generation != 11 || internal.Status.ObservedGeneration != 10 {
+		t.Errorf("internal gen=%d obs=%d, want 11/10",
+			internal.Metadata.Generation, internal.Status.ObservedGeneration)
+	}
+
+	output, err := apischeme.BuildStackExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildStackExternalFromInternal: %v", err)
+	}
+	if output.Metadata.Generation != 11 || output.Status.ObservedGeneration != 10 {
+		t.Errorf("external gen=%d obs=%d, want 11/10",
+			output.Metadata.Generation, output.Status.ObservedGeneration)
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if !strings.Contains(string(rendered), "generation: 11") ||
+		!strings.Contains(string(rendered), "observedGeneration: 10") {
+		t.Errorf("rendered YAML missing generation fields; got:\n%s", string(rendered))
+	}
+}
+
+// TestStackGenerationZeroValue covers the pre-existing-metadata read for stacks.
+func TestStackGenerationZeroValue(t *testing.T) {
+	input := ext.StackDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindStack,
+		Metadata:   ext.StackMetadata{Name: "stack0"},
+		Spec:       ext.StackSpec{ID: "stack0", RealmID: "realm0", SpaceID: "space0"},
+		Status:     ext.StackStatus{State: ext.StackStatePending},
+	}
+
+	internal, version, err := apischeme.NormalizeStack(input)
+	if err != nil {
+		t.Fatalf("NormalizeStack: %v", err)
+	}
+	output, err := apischeme.BuildStackExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildStackExternalFromInternal: %v", err)
+	}
+	if output.Metadata.Generation != 0 || output.Status.ObservedGeneration != 0 {
+		t.Errorf("zero values not preserved: gen=%d obs=%d",
+			output.Metadata.Generation, output.Status.ObservedGeneration)
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if strings.Contains(string(rendered), "generation:") ||
+		strings.Contains(string(rendered), "observedGeneration:") {
+		t.Errorf("generation fields must be omitted when zero; got:\n%s", string(rendered))
+	}
+}
+
+// TestCellGenerationRoundTrip pins the fields through the cell converter pair.
+func TestCellGenerationRoundTrip(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "cell0", Generation: 5},
+		Spec: ext.CellSpec{
+			ID:         "cell0",
+			RealmID:    "realm0",
+			SpaceID:    "space0",
+			StackID:    "stack0",
+			Containers: []ext.ContainerSpec{},
+		},
+		Status: ext.CellStatus{State: ext.CellStateReady, ObservedGeneration: 4},
+	}
+
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	if internal.Metadata.Generation != 5 || internal.Status.ObservedGeneration != 4 {
+		t.Errorf("internal gen=%d obs=%d, want 5/4",
+			internal.Metadata.Generation, internal.Status.ObservedGeneration)
+	}
+
+	output, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if output.Metadata.Generation != 5 || output.Status.ObservedGeneration != 4 {
+		t.Errorf("external gen=%d obs=%d, want 5/4",
+			output.Metadata.Generation, output.Status.ObservedGeneration)
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if !strings.Contains(string(rendered), "generation: 5") ||
+		!strings.Contains(string(rendered), "observedGeneration: 4") {
+		t.Errorf("rendered YAML missing generation fields; got:\n%s", string(rendered))
+	}
+}
+
+// TestCellGenerationZeroValue covers the pre-existing-metadata read for cells.
+func TestCellGenerationZeroValue(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "cell0"},
+		Spec: ext.CellSpec{
+			ID:         "cell0",
+			RealmID:    "realm0",
+			SpaceID:    "space0",
+			StackID:    "stack0",
+			Containers: []ext.ContainerSpec{},
+		},
+		Status: ext.CellStatus{State: ext.CellStatePending},
+	}
+
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell: %v", err)
+	}
+	output, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if output.Metadata.Generation != 0 || output.Status.ObservedGeneration != 0 {
+		t.Errorf("zero values not preserved: gen=%d obs=%d",
+			output.Metadata.Generation, output.Status.ObservedGeneration)
+	}
+
+	rendered, err := yaml.Marshal(output)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	if strings.Contains(string(rendered), "generation:") ||
+		strings.Contains(string(rendered), "observedGeneration:") {
+		t.Errorf("generation fields must be omitted when zero; got:\n%s", string(rendered))
+	}
+}

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -51,8 +51,9 @@ func ConvertRealmDocToInternal(in ext.RealmDoc) (intmodel.Realm, error) {
 		}
 		return intmodel.Realm{
 			Metadata: intmodel.RealmMetadata{
-				Name:   in.Metadata.Name,
-				Labels: in.Metadata.Labels,
+				Name:       in.Metadata.Name,
+				Labels:     in.Metadata.Labels,
+				Generation: in.Metadata.Generation,
 			},
 			Spec: intmodel.RealmSpec{
 				Namespace:           in.Spec.Namespace,
@@ -69,6 +70,7 @@ func ConvertRealmDocToInternal(in ext.RealmDoc) (intmodel.Realm, error) {
 				Message:                  in.Status.Message,
 				CgroupReady:              in.Status.CgroupReady,
 				ContainerdNamespaceReady: in.Status.ContainerdNamespaceReady,
+				ObservedGeneration:       in.Status.ObservedGeneration,
 			},
 		}, nil
 	default:
@@ -92,8 +94,9 @@ func BuildRealmExternalFromInternal(in intmodel.Realm, apiVersion ext.Version) (
 			APIVersion: VersionV1Beta1,
 			Kind:       ext.KindRealm,
 			Metadata: ext.RealmMetadata{
-				Name:   in.Metadata.Name,
-				Labels: in.Metadata.Labels,
+				Name:       in.Metadata.Name,
+				Labels:     in.Metadata.Labels,
+				Generation: in.Metadata.Generation,
 			},
 			Spec: ext.RealmSpec{
 				Namespace:           in.Spec.Namespace,
@@ -110,6 +113,7 @@ func BuildRealmExternalFromInternal(in intmodel.Realm, apiVersion ext.Version) (
 				Message:                  in.Status.Message,
 				CgroupReady:              in.Status.CgroupReady,
 				ContainerdNamespaceReady: in.Status.ContainerdNamespaceReady,
+				ObservedGeneration:       in.Status.ObservedGeneration,
 			},
 		}, nil
 	default:
@@ -146,8 +150,9 @@ func ConvertSpaceDocToInternal(in ext.SpaceDoc) (intmodel.Space, error) {
 		}
 		return intmodel.Space{
 			Metadata: intmodel.SpaceMetadata{
-				Name:   in.Metadata.Name,
-				Labels: in.Metadata.Labels,
+				Name:       in.Metadata.Name,
+				Labels:     in.Metadata.Labels,
+				Generation: in.Metadata.Generation,
 			},
 			Spec: intmodel.SpaceSpec{
 				RealmName:     in.Spec.RealmID,
@@ -165,6 +170,7 @@ func ConvertSpaceDocToInternal(in ext.SpaceDoc) (intmodel.Space, error) {
 				Reason:             in.Status.Reason,
 				Message:            in.Status.Message,
 				CgroupReady:        in.Status.CgroupReady,
+				ObservedGeneration: in.Status.ObservedGeneration,
 			},
 		}, nil
 	default:
@@ -192,8 +198,9 @@ func BuildSpaceExternalFromInternal(in intmodel.Space, apiVersion ext.Version) (
 			APIVersion: VersionV1Beta1,
 			Kind:       ext.KindSpace,
 			Metadata: ext.SpaceMetadata{
-				Name:   in.Metadata.Name,
-				Labels: in.Metadata.Labels,
+				Name:       in.Metadata.Name,
+				Labels:     in.Metadata.Labels,
+				Generation: in.Metadata.Generation,
 			},
 			Spec: ext.SpaceSpec{
 				RealmID:       in.Spec.RealmName,
@@ -211,6 +218,7 @@ func BuildSpaceExternalFromInternal(in intmodel.Space, apiVersion ext.Version) (
 				Reason:             in.Status.Reason,
 				Message:            in.Status.Message,
 				CgroupReady:        in.Status.CgroupReady,
+				ObservedGeneration: in.Status.ObservedGeneration,
 			},
 		}, nil
 	default:
@@ -234,8 +242,9 @@ func ConvertStackDocToInternal(in ext.StackDoc) (intmodel.Stack, error) {
 	case VersionV1Beta1, "": // default/empty treated as v1beta1
 		return intmodel.Stack{
 			Metadata: intmodel.StackMetadata{
-				Name:   in.Metadata.Name,
-				Labels: in.Metadata.Labels,
+				Name:       in.Metadata.Name,
+				Labels:     in.Metadata.Labels,
+				Generation: in.Metadata.Generation,
 			},
 			Spec: intmodel.StackSpec{
 				ID:        in.Spec.ID,
@@ -252,6 +261,7 @@ func ConvertStackDocToInternal(in ext.StackDoc) (intmodel.Stack, error) {
 				Reason:             in.Status.Reason,
 				Message:            in.Status.Message,
 				CgroupReady:        in.Status.CgroupReady,
+				ObservedGeneration: in.Status.ObservedGeneration,
 			},
 		}, nil
 	default:
@@ -267,8 +277,9 @@ func BuildStackExternalFromInternal(in intmodel.Stack, apiVersion ext.Version) (
 			APIVersion: VersionV1Beta1,
 			Kind:       ext.KindStack,
 			Metadata: ext.StackMetadata{
-				Name:   in.Metadata.Name,
-				Labels: in.Metadata.Labels,
+				Name:       in.Metadata.Name,
+				Labels:     in.Metadata.Labels,
+				Generation: in.Metadata.Generation,
 			},
 			Spec: ext.StackSpec{
 				ID:      in.Spec.ID,
@@ -285,6 +296,7 @@ func BuildStackExternalFromInternal(in intmodel.Stack, apiVersion ext.Version) (
 				Reason:             in.Status.Reason,
 				Message:            in.Status.Message,
 				CgroupReady:        in.Status.CgroupReady,
+				ObservedGeneration: in.Status.ObservedGeneration,
 			},
 		}, nil
 	default:
@@ -951,8 +963,9 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 		}
 		cell := intmodel.Cell{
 			Metadata: intmodel.CellMetadata{
-				Name:   in.Metadata.Name,
-				Labels: in.Metadata.Labels,
+				Name:       in.Metadata.Name,
+				Labels:     in.Metadata.Labels,
+				Generation: in.Metadata.Generation,
 			},
 			Spec: intmodel.CellSpec{
 				ID:                  in.Spec.ID,
@@ -971,14 +984,15 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				Network: intmodel.CellNetworkStatus{
 					BridgeName: in.Status.Network.BridgeName,
 				},
-				Containers:    convertContainerStatusesToInternal(in.Status.Containers),
-				ReadyObserved: in.Status.ReadyObserved,
-				CreatedAt:     in.Status.CreatedAt,
-				UpdatedAt:     in.Status.UpdatedAt,
-				ReadyAt:       in.Status.ReadyAt,
-				Reason:        in.Status.Reason,
-				Message:       in.Status.Message,
-				CgroupReady:   in.Status.CgroupReady,
+				Containers:         convertContainerStatusesToInternal(in.Status.Containers),
+				ReadyObserved:      in.Status.ReadyObserved,
+				CreatedAt:          in.Status.CreatedAt,
+				UpdatedAt:          in.Status.UpdatedAt,
+				ReadyAt:            in.Status.ReadyAt,
+				Reason:             in.Status.Reason,
+				Message:            in.Status.Message,
+				CgroupReady:        in.Status.CgroupReady,
+				ObservedGeneration: in.Status.ObservedGeneration,
 			},
 		}
 
@@ -1014,8 +1028,9 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 			APIVersion: VersionV1Beta1,
 			Kind:       ext.KindCell,
 			Metadata: ext.CellMetadata{
-				Name:   in.Metadata.Name,
-				Labels: in.Metadata.Labels,
+				Name:       in.Metadata.Name,
+				Labels:     in.Metadata.Labels,
+				Generation: in.Metadata.Generation,
 			},
 			Spec: ext.CellSpec{
 				ID:                  in.Spec.ID,
@@ -1034,14 +1049,15 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				Network: ext.CellNetworkStatus{
 					BridgeName: in.Status.Network.BridgeName,
 				},
-				Containers:    buildContainerStatusesExternalFromInternal(in.Status.Containers),
-				ReadyObserved: in.Status.ReadyObserved,
-				CreatedAt:     in.Status.CreatedAt,
-				UpdatedAt:     in.Status.UpdatedAt,
-				ReadyAt:       in.Status.ReadyAt,
-				Reason:        in.Status.Reason,
-				Message:       in.Status.Message,
-				CgroupReady:   in.Status.CgroupReady,
+				Containers:         buildContainerStatusesExternalFromInternal(in.Status.Containers),
+				ReadyObserved:      in.Status.ReadyObserved,
+				CreatedAt:          in.Status.CreatedAt,
+				UpdatedAt:          in.Status.UpdatedAt,
+				ReadyAt:            in.Status.ReadyAt,
+				Reason:             in.Status.Reason,
+				Message:            in.Status.Message,
+				CgroupReady:        in.Status.CgroupReady,
+				ObservedGeneration: in.Status.ObservedGeneration,
 			},
 		}
 

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -27,6 +27,10 @@ type Cell struct {
 type CellMetadata struct {
 	Name   string
 	Labels map[string]string
+	// Generation is a monotonic counter bumped by a writer on each
+	// spec-changing update. Defaults to zero; phase 3 wires the writers to
+	// populate it. See ObservedGeneration on the status.
+	Generation int64
 }
 
 type CellSpec struct {
@@ -84,6 +88,10 @@ type CellStatus struct {
 	Reason      string
 	Message     string
 	CgroupReady bool
+	// ObservedGeneration is the Metadata.Generation the reconciler last
+	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
+	// it against Generation to skip stale work.
+	ObservedGeneration int64
 }
 
 // CellNetworkStatus records the network endpoints the cell is attached to.

--- a/internal/modelhub/realm.go
+++ b/internal/modelhub/realm.go
@@ -27,6 +27,10 @@ type Realm struct {
 type RealmMetadata struct {
 	Name   string
 	Labels map[string]string
+	// Generation is a monotonic counter bumped by a writer on each
+	// spec-changing update. Defaults to zero; phase 3 (issue #596 follow-up)
+	// wires the writers to populate it. See ObservedGeneration on the status.
+	Generation int64
 }
 
 type RealmSpec struct {
@@ -72,6 +76,10 @@ type RealmStatus struct {
 	// ContainerdNamespaceReady reports whether the realm's containerd
 	// namespace was observed to exist as of the last status write.
 	ContainerdNamespaceReady bool
+	// ObservedGeneration is the Metadata.Generation the reconciler last
+	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
+	// it against Generation to skip stale work.
+	ObservedGeneration int64
 }
 
 type RealmState int

--- a/internal/modelhub/space.go
+++ b/internal/modelhub/space.go
@@ -27,6 +27,10 @@ type Space struct {
 type SpaceMetadata struct {
 	Name   string
 	Labels map[string]string
+	// Generation is a monotonic counter bumped by a writer on each
+	// spec-changing update. Defaults to zero; phase 3 wires the writers to
+	// populate it. See ObservedGeneration on the status.
+	Generation int64
 }
 
 type SpaceSpec struct {
@@ -98,6 +102,10 @@ type SpaceStatus struct {
 	Reason      string
 	Message     string
 	CgroupReady bool
+	// ObservedGeneration is the Metadata.Generation the reconciler last
+	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
+	// it against Generation to skip stale work.
+	ObservedGeneration int64
 }
 
 type SpaceState int

--- a/internal/modelhub/stack.go
+++ b/internal/modelhub/stack.go
@@ -27,6 +27,10 @@ type Stack struct {
 type StackMetadata struct {
 	Name   string
 	Labels map[string]string
+	// Generation is a monotonic counter bumped by a writer on each
+	// spec-changing update. Defaults to zero; phase 3 wires the writers to
+	// populate it. See ObservedGeneration on the status.
+	Generation int64
 }
 
 type StackSpec struct {
@@ -51,6 +55,10 @@ type StackStatus struct {
 	Reason      string
 	Message     string
 	CgroupReady bool
+	// ObservedGeneration is the Metadata.Generation the reconciler last
+	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
+	// it against Generation to skip stale work.
+	ObservedGeneration int64
 }
 
 type StackState int

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -29,6 +29,10 @@ type CellDoc struct {
 type CellMetadata struct {
 	Name   string            `json:"name"   yaml:"name"`
 	Labels map[string]string `json:"labels" yaml:"labels"`
+	// Generation is a monotonic counter bumped by a writer on each
+	// spec-changing update. Defaults to zero; phase 3 wires the writers to
+	// populate it. See ObservedGeneration on the status.
+	Generation int64 `json:"generation,omitempty" yaml:"generation,omitempty"`
 }
 
 type CellSpec struct {
@@ -94,6 +98,10 @@ type CellStatus struct {
 	Reason      string    `json:"reason,omitempty"        yaml:"reason,omitempty"`
 	Message     string    `json:"message,omitempty"       yaml:"message,omitempty"`
 	CgroupReady bool      `json:"cgroupReady,omitempty"   yaml:"cgroupReady,omitempty"`
+	// ObservedGeneration is the Metadata.Generation the reconciler last
+	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
+	// it against Generation to skip stale work.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 // CellNetworkStatus exposes the host-side bridge a cell is attached to.

--- a/pkg/api/model/v1beta1/realm.go
+++ b/pkg/api/model/v1beta1/realm.go
@@ -29,6 +29,10 @@ type RealmDoc struct {
 type RealmMetadata struct {
 	Name   string            `json:"name"   yaml:"name"`
 	Labels map[string]string `json:"labels" yaml:"labels"`
+	// Generation is a monotonic counter bumped by a writer on each
+	// spec-changing update. Defaults to zero; phase 3 (issue #596 follow-up)
+	// wires the writers to populate it. See ObservedGeneration on the status.
+	Generation int64 `json:"generation,omitempty" yaml:"generation,omitempty"`
 }
 
 type RealmSpec struct {
@@ -81,6 +85,10 @@ type RealmStatus struct {
 	// the last status write. Like CgroupReady, this separates intent
 	// from observation.
 	ContainerdNamespaceReady bool `json:"containerdNamespaceReady,omitempty" yaml:"containerdNamespaceReady,omitempty"`
+	// ObservedGeneration is the Metadata.Generation the reconciler last
+	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
+	// it against Generation to skip stale work.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type RealmState int

--- a/pkg/api/model/v1beta1/space.go
+++ b/pkg/api/model/v1beta1/space.go
@@ -29,6 +29,10 @@ type SpaceDoc struct {
 type SpaceMetadata struct {
 	Name   string            `json:"name"   yaml:"name"`
 	Labels map[string]string `json:"labels" yaml:"labels"`
+	// Generation is a monotonic counter bumped by a writer on each
+	// spec-changing update. Defaults to zero; phase 3 wires the writers to
+	// populate it. See ObservedGeneration on the status.
+	Generation int64 `json:"generation,omitempty" yaml:"generation,omitempty"`
 }
 
 type SpaceSpec struct {
@@ -114,6 +118,10 @@ type SpaceStatus struct {
 	Reason      string    `json:"reason,omitempty"             yaml:"reason,omitempty"`
 	Message     string    `json:"message,omitempty"            yaml:"message,omitempty"`
 	CgroupReady bool      `json:"cgroupReady,omitempty"        yaml:"cgroupReady,omitempty"`
+	// ObservedGeneration is the Metadata.Generation the reconciler last
+	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
+	// it against Generation to skip stale work.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type SpaceState int

--- a/pkg/api/model/v1beta1/stack.go
+++ b/pkg/api/model/v1beta1/stack.go
@@ -29,6 +29,10 @@ type StackDoc struct {
 type StackMetadata struct {
 	Name   string            `json:"name"   yaml:"name"`
 	Labels map[string]string `json:"labels" yaml:"labels"`
+	// Generation is a monotonic counter bumped by a writer on each
+	// spec-changing update. Defaults to zero; phase 3 wires the writers to
+	// populate it. See ObservedGeneration on the status.
+	Generation int64 `json:"generation,omitempty" yaml:"generation,omitempty"`
 }
 
 type StackSpec struct {
@@ -52,6 +56,10 @@ type StackStatus struct {
 	Reason      string    `json:"reason,omitempty"             yaml:"reason,omitempty"`
 	Message     string    `json:"message,omitempty"            yaml:"message,omitempty"`
 	CgroupReady bool      `json:"cgroupReady,omitempty"        yaml:"cgroupReady,omitempty"`
+	// ObservedGeneration is the Metadata.Generation the reconciler last
+	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
+	// it against Generation to skip stale work.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
 }
 
 type StackState int


### PR DESCRIPTION
## Summary
- Phase 2 of the metadata concurrency-primitives work (#205 phase 1 landed flock + CAS). This adds the generation-counter fields to the type layer so phase 3 can wire the writers/reconciler. **No behavior change** — both fields default to zero, no caller bumps `Generation` or reads `ObservedGeneration` yet.
- `Generation int64` added to `*Metadata` on all 4 kinds (realm/space/stack/cell), internal (`internal/modelhub/`) + external (`pkg/api/model/v1beta1/`). External fields carry `json/yaml:"generation,omitempty"` so pre-existing `metadata.json`/manifests keep their on-disk shape.
- `ObservedGeneration int64` added to `*Status` on all 4 kinds, both layers, tagged `observedGeneration,omitempty`.
- All 8 apischeme converters (`*ToInternal` / `Build*ExternalFromInternal` for each kind) plumb both fields round-trip.

## Notes
- The issue lists the field locations as `internal/modelhub/{realm,space,stack,cell}.go` and `pkg/api/model/v1beta1/{realm,space,stack,cell}.go` plus the converters in `internal/apischeme/scheme.go` — all confirmed present and matching the architecture.
- Field godoc references "phase 3" as the value-shipping phase per the issue's own framing; no follow-up issue filed since phase 3 is already tracked as the next phase of the #205 series.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/apischeme/ ./internal/modelhub/ ./pkg/api/model/v1beta1/`
- [x] `make test` (full target: `go test $(go list ./... | grep -v /e2e)`) — all packages pass
- [x] New `internal/apischeme/generation_test.go`: per-kind round-trip of non-zero values through both converters + YAML, and zero-value reads from pre-existing metadata (fields default to zero, omitted from re-serialized YAML)
- [ ] `make dev-init` smoke — not run: type-layer-only change, touches no build path, daemon, or `/opt/kukeon` data, so the smoke regression guard does not apply

Closes #596