### PR TITLE
feat(metadata): RMW-under-flock generation bump + reconciler stale skip (phase 3)

### DIFF
--- a/internal/controller/runner/create_cell.go
+++ b/internal/controller/runner/create_cell.go
@@ -180,6 +180,11 @@ func (r *Exec) EnsureCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	if err := r.UpdateCellMetadata(ensuredCell); err != nil {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, err)
 	}
+	// The write above may have bumped the generation (a merged container is
+	// a spec change). Sync the in-memory token so the caller's follow-up
+	// status persist (PopulateAndPersistCellContainerStatuses) is not
+	// rejected as stale against its own write.
+	r.refreshCellGeneration(&ensuredCell)
 
 	return ensuredCell, nil
 }

--- a/internal/controller/runner/metadata.go
+++ b/internal/controller/runner/metadata.go
@@ -17,7 +17,12 @@
 package runner
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/eminwux/kukeon/internal/apischeme"
@@ -25,7 +30,121 @@ import (
 	"github.com/eminwux/kukeon/internal/metadata"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// firstGeneration is the Metadata.Generation stamped on the initial write
+// of a resource — there is no prior spec on disk, so the spec is "new" and
+// the monotonic counter starts at 1 (matching the Kubernetes convention a
+// freshly-created object has generation 1).
+const firstGeneration int64 = 1
+
+// writeDocWithGeneration performs the phase-3 read-modify-write the four
+// Update*Metadata writers share. Under the sidecar flock it reads the prior
+// on-disk document, treats the caller's incoming Generation as an optimistic
+// token, bumps Metadata.Generation only when the incoming spec differs from
+// the persisted spec (a status-only update preserves it), and CAS-writes the
+// result against the bytes it observed.
+//
+// Lost-update protection has two layers:
+//
+//   - Optimistic token: a versioned caller (incoming Generation > 0) that
+//     read generation G is rejected with errdefs.ErrStaleResource when the
+//     on-disk generation has advanced past G. This catches a writer whose
+//     in-memory snapshot was made stale by an intervening write — the very
+//     gap the reconciler-vs-user race opens.
+//   - CAS: the WriteMetadataCAS against the observed bytes catches a write
+//     that lands in the narrow window between this read and the write.
+//
+// An incoming Generation of 0 is the "unversioned" escape hatch for callers
+// that constructed the document from scratch rather than reading it back
+// (create/provision flows): the spec-vs-disk bump still applies, but the
+// token check is skipped so the create's own follow-up writes do not trip a
+// false stale. A freshly-read document always carries a non-zero generation,
+// so 0 reliably distinguishes "built it" from "read then modified it".
+func writeDocWithGeneration[D any](
+	ctx context.Context,
+	logger *slog.Logger,
+	file string,
+	doc D,
+	getGeneration func(D) int64,
+	setGeneration func(*D, int64),
+	specOf func(D) any,
+) error {
+	prior, readErr := metadata.ReadRaw(ctx, logger, file)
+	if errors.Is(readErr, errdefs.ErrMissingMetadataFile) {
+		// No prior document: this is the initial spec write. CAS with a
+		// nil prior asserts the file does not yet exist, so a concurrent
+		// creator racing us surfaces as ErrStaleResource.
+		setGeneration(&doc, firstGeneration)
+		return metadata.WriteMetadataCAS(ctx, logger, nil, doc, file)
+	}
+	if readErr != nil {
+		return readErr
+	}
+
+	var priorDoc D
+	if err := json.Unmarshal(prior, &priorDoc); err != nil {
+		return fmt.Errorf("decode prior metadata %s: %w", file, err)
+	}
+
+	onDiskGeneration := getGeneration(priorDoc)
+	if incoming := getGeneration(doc); incoming > 0 && onDiskGeneration > incoming {
+		return fmt.Errorf(
+			"write %s: caller observed generation %d, on-disk is %d: %w",
+			file, incoming, onDiskGeneration, errdefs.ErrStaleResource,
+		)
+	}
+
+	newGeneration := onDiskGeneration
+	specUnchanged, err := jsonEqual(specOf(priorDoc), specOf(doc))
+	if err != nil {
+		return fmt.Errorf("compare spec for %s: %w", file, err)
+	}
+	if !specUnchanged {
+		newGeneration++
+	}
+	setGeneration(&doc, newGeneration)
+
+	return metadata.WriteMetadataCAS(ctx, logger, prior, doc, file)
+}
+
+// refreshCellGeneration syncs cell.Metadata.Generation to the value
+// currently persisted on disk. Chained writers call it after a
+// spec-bumping write so a follow-up status persist on the same in-memory
+// object carries the current optimistic token instead of a stale one that
+// the writer would (correctly) reject as ErrStaleResource. A read failure
+// leaves the in-memory token untouched — best-effort, the follow-up write
+// then falls back to surfacing the stale error rather than masking it.
+func (r *Exec) refreshCellGeneration(cell *intmodel.Cell) {
+	path := fs.CellMetadataPath(
+		r.opts.RunPath,
+		cell.Spec.RealmName,
+		cell.Spec.SpaceName,
+		cell.Spec.StackName,
+		cell.Metadata.Name,
+	)
+	if onDisk, err := r.readCellInternal(path); err == nil {
+		cell.Metadata.Generation = onDisk.Metadata.Generation
+	}
+}
+
+// jsonEqual reports whether two values serialise to identical JSON. The
+// writers compare spec sub-documents through it rather than reflect.DeepEqual
+// so the comparison matches the persisted form exactly — the prior doc is
+// decoded from disk and the candidate doc is produced by the deterministic
+// apischeme conversion, so an unchanged spec round-trips to identical bytes.
+func jsonEqual(a, b any) (bool, error) {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		return false, err
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(ab, bb), nil
+}
 
 // nowUTC returns the current wall clock in UTC. Wrapped through the Exec
 // so tests that need to freeze time can override the function.
@@ -95,7 +214,11 @@ func (r *Exec) UpdateRealmMetadata(realm intmodel.Realm) error {
 	}
 
 	metadataFilePath := fs.RealmMetadataPath(r.opts.RunPath, realmDoc.Metadata.Name)
-	err = metadata.WriteMetadata(r.ctx, r.logger, realmDoc, metadataFilePath)
+	err = writeDocWithGeneration(r.ctx, r.logger, metadataFilePath, realmDoc,
+		func(d v1beta1.RealmDoc) int64 { return d.Metadata.Generation },
+		func(d *v1beta1.RealmDoc, g int64) { d.Metadata.Generation = g },
+		func(d v1beta1.RealmDoc) any { return d.Spec },
+	)
 	if err != nil {
 		r.logger.Error("failed to write metadata", "err", fmt.Sprintf("%v", err))
 		return fmt.Errorf("%w: %w", errdefs.ErrWriteMetadata, err)
@@ -117,7 +240,11 @@ func (r *Exec) UpdateSpaceMetadata(space intmodel.Space) error {
 		spaceDoc.Spec.RealmID,
 		spaceDoc.Metadata.Name,
 	)
-	err = metadata.WriteMetadata(r.ctx, r.logger, spaceDoc, metadataFilePath)
+	err = writeDocWithGeneration(r.ctx, r.logger, metadataFilePath, spaceDoc,
+		func(d v1beta1.SpaceDoc) int64 { return d.Metadata.Generation },
+		func(d *v1beta1.SpaceDoc, g int64) { d.Metadata.Generation = g },
+		func(d v1beta1.SpaceDoc) any { return d.Spec },
+	)
 	if err != nil {
 		r.logger.Error("failed to write metadata", "err", fmt.Sprintf("%v", err))
 		return fmt.Errorf("%w: %w", errdefs.ErrWriteMetadata, err)
@@ -140,7 +267,11 @@ func (r *Exec) UpdateStackMetadata(stack intmodel.Stack) error {
 		stackDoc.Spec.SpaceID,
 		stackDoc.Metadata.Name,
 	)
-	err = metadata.WriteMetadata(r.ctx, r.logger, stackDoc, metadataFilePath)
+	err = writeDocWithGeneration(r.ctx, r.logger, metadataFilePath, stackDoc,
+		func(d v1beta1.StackDoc) int64 { return d.Metadata.Generation },
+		func(d *v1beta1.StackDoc, g int64) { d.Metadata.Generation = g },
+		func(d v1beta1.StackDoc) any { return d.Spec },
+	)
 	if err != nil {
 		r.logger.Error("failed to write metadata", "err", fmt.Sprintf("%v", err))
 		return fmt.Errorf("%w: %w", errdefs.ErrWriteMetadata, err)
@@ -164,7 +295,11 @@ func (r *Exec) UpdateCellMetadata(cell intmodel.Cell) error {
 		cellDoc.Spec.StackID,
 		cellDoc.Metadata.Name,
 	)
-	err = metadata.WriteMetadata(r.ctx, r.logger, cellDoc, metadataFilePath)
+	err = writeDocWithGeneration(r.ctx, r.logger, metadataFilePath, cellDoc,
+		func(d v1beta1.CellDoc) int64 { return d.Metadata.Generation },
+		func(d *v1beta1.CellDoc, g int64) { d.Metadata.Generation = g },
+		func(d v1beta1.CellDoc) any { return d.Spec },
+	)
 	if err != nil {
 		r.logger.Error("failed to write metadata", "err", fmt.Sprintf("%v", err))
 		return fmt.Errorf("%w: %w", errdefs.ErrWriteMetadata, err)

--- a/internal/controller/runner/metadata_generation_test.go
+++ b/internal/controller/runner/metadata_generation_test.go
@@ -1,0 +1,323 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises the unexported generation/CAS write helpers
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+func newGenerationTestExec(t *testing.T, runPath string) *Exec {
+	t.Helper()
+	return &Exec{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:   Options{RunPath: runPath},
+		nowFn:  func() time.Time { return time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC) },
+	}
+}
+
+func readRealmGeneration(t *testing.T, r *Exec, name string) intmodel.Realm {
+	t.Helper()
+	got, err := r.readRealmInternal(fs.RealmMetadataPath(r.opts.RunPath, name))
+	if err != nil {
+		t.Fatalf("readRealmInternal(%s): %v", name, err)
+	}
+	return got
+}
+
+// TestUpdateRealmMetadataBumpsGenerationOnSpecChange pins AC1: the writer
+// stamps generation 1 on the first persist, leaves it untouched on a
+// status-only update, and bumps it only when the spec actually changes.
+func TestUpdateRealmMetadataBumpsGenerationOnSpecChange(t *testing.T) {
+	r := newGenerationTestExec(t, t.TempDir())
+	ref := intmodel.RealmMetadata{Name: "r-gen"}
+
+	realm := intmodel.Realm{
+		Metadata: ref,
+		Spec:     intmodel.RealmSpec{Namespace: "r-gen.kukeon.io"},
+		Status:   intmodel.RealmStatus{State: intmodel.RealmStateCreating},
+	}
+	if err := r.UpdateRealmMetadata(realm); err != nil {
+		t.Fatalf("first UpdateRealmMetadata: %v", err)
+	}
+	if got := readRealmGeneration(t, r, "r-gen").Metadata.Generation; got != 1 {
+		t.Fatalf("first persist generation = %d, want 1", got)
+	}
+
+	// Status-only update: state flips, spec is byte-identical → no bump.
+	statusOnly := readRealmGeneration(t, r, "r-gen")
+	statusOnly.Status.State = intmodel.RealmStateReady
+	statusOnly.Status.Message = "now ready"
+	if err := r.UpdateRealmMetadata(statusOnly); err != nil {
+		t.Fatalf("status-only UpdateRealmMetadata: %v", err)
+	}
+	if got := readRealmGeneration(t, r, "r-gen").Metadata.Generation; got != 1 {
+		t.Fatalf("status-only persist generation = %d, want 1 (no bump)", got)
+	}
+
+	// Spec change: append a registry credential → generation bumps to 2.
+	specChange := readRealmGeneration(t, r, "r-gen")
+	specChange.Spec.RegistryCredentials = append(specChange.Spec.RegistryCredentials,
+		intmodel.RegistryCredentials{ServerAddress: "registry.example.com"})
+	if err := r.UpdateRealmMetadata(specChange); err != nil {
+		t.Fatalf("spec-change UpdateRealmMetadata: %v", err)
+	}
+	if got := readRealmGeneration(t, r, "r-gen").Metadata.Generation; got != 2 {
+		t.Fatalf("spec-change persist generation = %d, want 2", got)
+	}
+}
+
+// TestUpdateRealmMetadataStaleTokenRejected pins AC2: a versioned caller
+// whose observed generation has been overtaken on disk is rejected with
+// errdefs.ErrStaleResource at the writer's call site, rather than silently
+// clobbering the newer write.
+func TestUpdateRealmMetadataStaleTokenRejected(t *testing.T) {
+	r := newGenerationTestExec(t, t.TempDir())
+	seed := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: "r-cas"},
+		Spec:     intmodel.RealmSpec{Namespace: "r-cas.kukeon.io"},
+		Status:   intmodel.RealmStatus{State: intmodel.RealmStateReady},
+	}
+	if err := r.UpdateRealmMetadata(seed); err != nil {
+		t.Fatalf("seed UpdateRealmMetadata: %v", err)
+	}
+
+	// Two callers read the same generation-1 snapshot.
+	writerA := readRealmGeneration(t, r, "r-cas")
+	writerB := readRealmGeneration(t, r, "r-cas")
+
+	// A lands a spec change first, advancing the on-disk generation to 2.
+	writerA.Spec.RegistryCredentials = append(writerA.Spec.RegistryCredentials,
+		intmodel.RegistryCredentials{ServerAddress: "reg-a"})
+	if err := r.UpdateRealmMetadata(writerA); err != nil {
+		t.Fatalf("writer A UpdateRealmMetadata: %v", err)
+	}
+
+	// B writes against its now-stale generation-1 token and is rejected.
+	writerB.Spec.RegistryCredentials = append(writerB.Spec.RegistryCredentials,
+		intmodel.RegistryCredentials{ServerAddress: "reg-b"})
+	err := r.UpdateRealmMetadata(writerB)
+	if !errors.Is(err, errdefs.ErrStaleResource) {
+		t.Fatalf("stale writer B error = %v, want ErrStaleResource", err)
+	}
+
+	// A's write survived intact; B's clobber was rejected.
+	final := readRealmGeneration(t, r, "r-cas")
+	if len(final.Spec.RegistryCredentials) != 1 || final.Spec.RegistryCredentials[0].ServerAddress != "reg-a" {
+		t.Fatalf("on-disk credentials = %+v, want only reg-a", final.Spec.RegistryCredentials)
+	}
+}
+
+// TestUpdateRealmMetadataConcurrentWritesConverge pins AC4: many concurrent
+// read-modify-write spec mutations that retry on ErrStaleResource all land
+// without a lost update. Goroutines stand in for the daemon and
+// `kuke --no-daemon` writers — both go through the same flock + optimistic
+// generation primitive, so the convergence property is identical.
+func TestUpdateRealmMetadataConcurrentWritesConverge(t *testing.T) {
+	r := newGenerationTestExec(t, t.TempDir())
+	seed := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: "r-converge"},
+		Spec:     intmodel.RealmSpec{Namespace: "r-converge.kukeon.io"},
+		Status:   intmodel.RealmStatus{State: intmodel.RealmStateReady},
+	}
+	if err := r.UpdateRealmMetadata(seed); err != nil {
+		t.Fatalf("seed UpdateRealmMetadata: %v", err)
+	}
+
+	const writers = 8
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for i := range writers {
+		go func(i int) {
+			defer wg.Done()
+			for {
+				got := readRealmGeneration(t, r, "r-converge")
+				got.Spec.RegistryCredentials = append(got.Spec.RegistryCredentials,
+					intmodel.RegistryCredentials{ServerAddress: fmt.Sprintf("reg-%d", i)})
+				err := r.UpdateRealmMetadata(got)
+				if err == nil {
+					return
+				}
+				if errors.Is(err, errdefs.ErrStaleResource) {
+					continue // re-read the winner's state and retry
+				}
+				t.Errorf("writer %d: unexpected error: %v", i, err)
+				return
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	final := readRealmGeneration(t, r, "r-converge")
+	if got := len(final.Spec.RegistryCredentials); got != writers {
+		t.Fatalf("converged credential count = %d, want %d (lost update)", got, writers)
+	}
+	// Seed (gen 1) + one bump per successful spec-changing write.
+	if got := final.Metadata.Generation; got != int64(1+writers) {
+		t.Fatalf("converged generation = %d, want %d", got, 1+writers)
+	}
+}
+
+func seedCell(t *testing.T, r *Exec) intmodel.Cell {
+	t.Helper()
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "c1"},
+		Spec: intmodel.CellSpec{
+			ID:        "cell-1",
+			RealmName: "r1",
+			SpaceName: "s1",
+			StackName: "st1",
+		},
+		Status: intmodel.CellStatus{State: intmodel.CellStatePending},
+	}
+	if err := r.UpdateCellMetadata(cell); err != nil {
+		t.Fatalf("seed UpdateCellMetadata: %v", err)
+	}
+	return cell
+}
+
+func readCell(t *testing.T, r *Exec) intmodel.Cell {
+	t.Helper()
+	got, err := r.readCellInternal(fs.CellMetadataPath(r.opts.RunPath, "r1", "s1", "st1", "c1"))
+	if err != nil {
+		t.Fatalf("readCellInternal: %v", err)
+	}
+	return got
+}
+
+// TestChainedSpecThenStatusWriteNeedsGenerationRefresh locks in the
+// optimistic-token escape valve the create-into-existing-cell chain depends
+// on: after a spec-bumping write the in-memory token is stale, so a
+// follow-up status persist on the same object is rejected — until
+// refreshCellGeneration re-syncs it. EnsureCell calls the refresh for this
+// reason.
+func TestChainedSpecThenStatusWriteNeedsGenerationRefresh(t *testing.T) {
+	r := newGenerationTestExec(t, t.TempDir())
+	seedCell(t, r) // generation 1
+
+	// A spec change bumps the on-disk generation to 2; the in-memory copy
+	// still carries the generation-1 token it was read with.
+	chained := readCell(t, r)
+	chained.Spec.AutoDelete = true
+	if err := r.UpdateCellMetadata(chained); err != nil {
+		t.Fatalf("spec-bump UpdateCellMetadata: %v", err)
+	}
+
+	// Without a refresh, a follow-up status write on the stale object is
+	// (correctly) rejected as stale.
+	stale := chained
+	stale.Status.State = intmodel.CellStateReady
+	if err := r.UpdateCellMetadata(stale); !errors.Is(err, errdefs.ErrStaleResource) {
+		t.Fatalf("stale follow-up write error = %v, want ErrStaleResource", err)
+	}
+
+	// After re-syncing the token, the same status write lands.
+	refreshed := chained
+	r.refreshCellGeneration(&refreshed)
+	refreshed.Status.State = intmodel.CellStateReady
+	if err := r.UpdateCellMetadata(refreshed); err != nil {
+		t.Fatalf("refreshed follow-up write: %v", err)
+	}
+	final := readCell(t, r)
+	if final.Status.State != intmodel.CellStateReady {
+		t.Errorf("status flip not persisted: state = %v", final.Status.State)
+	}
+	if final.Metadata.Generation != 2 {
+		t.Errorf("status-only follow-up bumped generation: got %d, want 2", final.Metadata.Generation)
+	}
+}
+
+// TestPersistCellStatusGuardedSkipsWhenBehind pins AC3/AC5: when a
+// concurrent spec write has advanced the on-disk Generation past the value
+// the reconciler observed, the guarded persist skips rather than clobbering
+// the newer spec; when the observation is current, it stamps
+// ObservedGeneration and persists.
+func TestPersistCellStatusGuardedSkipsWhenBehind(t *testing.T) {
+	r := newGenerationTestExec(t, t.TempDir())
+	seedCell(t, r) // generation 1
+
+	// Capture the stale reconciler view (generation 1) before the spec moves.
+	staleView := readCell(t, r)
+	if staleView.Metadata.Generation != 1 {
+		t.Fatalf("seed generation = %d, want 1", staleView.Metadata.Generation)
+	}
+
+	// A concurrent spec writer advances the cell to generation 2.
+	specWrite := readCell(t, r)
+	specWrite.Spec.AutoDelete = true
+	if err := r.UpdateCellMetadata(specWrite); err != nil {
+		t.Fatalf("concurrent spec UpdateCellMetadata: %v", err)
+	}
+	if got := readCell(t, r).Metadata.Generation; got != 2 {
+		t.Fatalf("post-spec-write generation = %d, want 2", got)
+	}
+
+	// The reconciler tries to persist a status flip against its stale view.
+	staleView.Status.State = intmodel.CellStateReady
+	persisted, err := r.persistCellStatusGuarded(staleView)
+	if err != nil {
+		t.Fatalf("guarded persist (stale): %v", err)
+	}
+	if persisted {
+		t.Fatal("guarded persist reported persisted=true for a stale observation")
+	}
+	afterSkip := readCell(t, r)
+	if !afterSkip.Spec.AutoDelete {
+		t.Error("spec clobbered by stale reconciler: AutoDelete reverted to false")
+	}
+	if afterSkip.Status.State == intmodel.CellStateReady {
+		t.Error("stale status flip leaked to disk despite the skip")
+	}
+	if afterSkip.Metadata.Generation != 2 {
+		t.Errorf("generation moved on a skip: got %d, want 2", afterSkip.Metadata.Generation)
+	}
+
+	// A current observation (generation 2) persists and stamps ObservedGeneration.
+	current := readCell(t, r)
+	current.Status.State = intmodel.CellStateReady
+	persisted, err = r.persistCellStatusGuarded(current)
+	if err != nil {
+		t.Fatalf("guarded persist (current): %v", err)
+	}
+	if !persisted {
+		t.Fatal("guarded persist skipped a current observation")
+	}
+	final := readCell(t, r)
+	if final.Status.ObservedGeneration != 2 {
+		t.Errorf("ObservedGeneration = %d, want 2", final.Status.ObservedGeneration)
+	}
+	if final.Status.State != intmodel.CellStateReady {
+		t.Errorf("status flip not persisted: state = %v", final.Status.State)
+	}
+	if final.Metadata.Generation != 2 {
+		t.Errorf("status-only persist bumped generation: got %d, want 2", final.Metadata.Generation)
+	}
+}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -17,12 +17,50 @@
 package runner
 
 import (
+	"errors"
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/naming"
 )
+
+// observedGenerationBehind reports whether the reconciler has not yet
+// recorded, via Status.ObservedGeneration, that it acted on the cell's
+// current Metadata.Generation. When true the reconciler persists even if no
+// derived status field changed, so ObservedGeneration converges to
+// Generation after a spec write and the AC5 stale-skip comparison stays
+// meaningful (a cell that reached Ready synchronously, never via a
+// reconcile persist, would otherwise sit at ObservedGeneration 0 forever).
+func observedGenerationBehind(status intmodel.CellStatus, generation int64) bool {
+	return status.ObservedGeneration != generation
+}
+
+// persistCellStatusGuarded stamps Status.ObservedGeneration with the
+// generation the reconciler observed when the cell was listed and persists
+// the cell — but only when no concurrent spec writer has advanced the
+// on-disk Generation past that observation. The guard rides the writer's
+// optimistic token: UpdateCellMetadata carries the observed generation, and
+// the writer rejects with errdefs.ErrStaleResource when the on-disk
+// generation has moved past it (or when a spec write lands in the CAS
+// window). A stale observation is reported as a benign skip (persisted ==
+// false, nil error): the next reconcile tick re-derives status from the
+// fresher spec rather than clobbering it with a stale view.
+func (r *Exec) persistCellStatusGuarded(cell intmodel.Cell) (bool, error) {
+	cell.Status.ObservedGeneration = cell.Metadata.Generation
+	if err := r.UpdateCellMetadata(cell); err != nil {
+		if errors.Is(err, errdefs.ErrStaleResource) {
+			r.logger.DebugContext(r.ctx,
+				"reconcile: skipping stale cell persist; on-disk generation advanced",
+				"cell", cell.Metadata.Name,
+				"observed", cell.Metadata.Generation)
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
 
 // RefreshRealm refreshes the status of a realm by checking cgroup and containerd namespace.
 // Returns the updated realm, whether it was updated, and any error.
@@ -336,8 +374,15 @@ func (r *Exec) RefreshCell(cell intmodel.Cell) (intmodel.Cell, int, error) {
 	}
 
 	if cellUpdated || containersUpdated > 0 {
-		if updateErr := r.UpdateCellMetadata(cell); updateErr != nil {
+		persisted, updateErr := r.persistCellStatusGuarded(cell)
+		if updateErr != nil {
 			return cell, containersUpdated, fmt.Errorf("failed to update cell metadata: %w", updateErr)
+		}
+		// A concurrent spec write advanced the cell's generation past the
+		// refreshed view: the derived status was discarded rather than
+		// clobbering the newer spec, so report nothing updated.
+		if !persisted {
+			return cell, 0, nil
 		}
 		return cell, containersUpdated, nil
 	}
@@ -536,11 +581,14 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 			r.logger.DebugContext(r.ctx, "populate container statuses failed",
 				"cell", cell.Metadata.Name, "error", err)
 		}
-		updated := !containerStatusesEqual(originalStatus.Containers, cell.Status.Containers)
+		updated := !containerStatusesEqual(originalStatus.Containers, cell.Status.Containers) ||
+			observedGenerationBehind(originalStatus, cell.Metadata.Generation)
 		if updated {
-			if updateErr := r.UpdateCellMetadata(cell); updateErr != nil {
+			persisted, updateErr := r.persistCellStatusGuarded(cell)
+			if updateErr != nil {
 				return cell, ReconcileOutcome{}, fmt.Errorf("failed to update cell metadata: %w", updateErr)
 			}
+			updated = persisted
 		}
 		return cell, ReconcileOutcome{Updated: updated}, nil
 	}
@@ -598,11 +646,16 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 	if !containerStatusesEqual(originalStatus.Containers, cell.Status.Containers) {
 		updated = true
 	}
+	if observedGenerationBehind(originalStatus, cell.Metadata.Generation) {
+		updated = true
+	}
 
 	if updated {
-		if updateErr := r.UpdateCellMetadata(cell); updateErr != nil {
+		persisted, updateErr := r.persistCellStatusGuarded(cell)
+		if updateErr != nil {
 			return cell, ReconcileOutcome{}, fmt.Errorf("failed to update cell metadata: %w", updateErr)
 		}
+		updated = persisted
 	}
 	return cell, ReconcileOutcome{Updated: updated}, nil
 }


### PR DESCRIPTION
## Summary

Phase 3 of the metadata concurrency primitives (after #205 flock+CAS, #628 Generation/ObservedGeneration type fields). Closes the lost-update gap between the daemon reconcile loop and concurrent user writes.

- **Writers RMW under flock, bump `Generation` only on spec change.** The four `Update{Realm,Space,Stack,Cell}Metadata` now route through a shared generic `writeDocWithGeneration` helper that, under the sidecar flock, reads the prior on-disk doc, treats the caller's incoming `Generation` as an optimistic token, bumps `Metadata.Generation` only when the persisted spec differs (a status-only update preserves it), and CAS-writes against the observed bytes.
- **CAS/token failure surfaces as `errdefs.ErrStaleResource` at the writer's call site** — propagated through the existing `errdefs.ErrWriteMetadata` wrap, so `errors.Is` chains hold.
- **Reconciler stamps `ObservedGeneration` after each persist and skips stale persists.** `persistCellStatusGuarded` stamps `Status.ObservedGeneration = Metadata.Generation` before writing; an `ErrStaleResource` (a concurrent spec writer advanced the on-disk generation past the reconciler's observation) is reported as a benign skip (`persisted=false`, nil err) so the next tick re-derives from the fresher spec instead of clobbering it.

## Design calls (reviewer please push back)

- **Optimistic-token model over CAS-against-own-read.** A blind full-object-set API (`UpdateXMetadata(value)`) cannot prevent lost updates by CASing against the writer's *own* fresh read — a caller modifying a stale snapshot still wins the CAS. The incoming `Generation` is the token; the writer rejects when on-disk generation has moved past it. This is the core fix for the daemon-status-vs-user-spec race the issue describes.
- **`Generation == 0` escape hatch.** Create/provision flows construct the doc from scratch (gen 0) rather than reading it back; the token check is skipped for them (the spec-vs-disk bump still applies) so a create's own follow-up writes don't trip a false stale. A freshly-read doc always carries gen ≥ 1, so 0 reliably means "built it, didn't read it."
- **`refreshCellGeneration` after `EnsureCell`'s spec write.** `CreateCell` into an *existing* cell does a spec-bumping write (merged container) then a follow-up status persist on the same in-memory object; without re-syncing the token the follow-up would be rejected as stale against its own write. Added a regression test for this chained-write path.
- **`observedGenerationBehind` wired into `ReconcileCell` only, not `RefreshCell`.** Without it, a cell that reached Ready synchronously (never via a reconcile persist) sits at `ObservedGeneration=0` forever, making the AC5 skip comparison meaningless. The daemon reconcile loop now persists once to converge `ObservedGeneration` → `Generation` even with no derived-status change. I deliberately left `kuke refresh` (`RefreshCell`) untouched — it's operator-driven and shouldn't manufacture writes purely to bump a bookkeeping field; it still stamps `ObservedGeneration` via the guarded persist on any real status change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/controller/...`
- [x] New tests: `go test ./internal/controller/runner/ -run 'Generation|StaleToken|Converge|ChainedSpec|PersistCellStatusGuarded' -v` — 5/5 pass
  - `TestUpdateRealmMetadataBumpsGenerationOnSpecChange` (AC1: first→1, status-only→1, spec-change→2)
  - `TestUpdateRealmMetadataStaleTokenRejected` (AC2: stale token → `ErrStaleResource`, winner survives)
  - `TestUpdateRealmMetadataConcurrentWritesConverge` (AC4: 8 goroutines RMW-with-retry, no lost updates)
  - `TestChainedSpecThenStatusWriteNeedsGenerationRefresh` (EnsureCell refresh regression)
  - `TestPersistCellStatusGuardedSkipsWhenBehind` (AC3/AC5: stale view skips without clobbering spec; current view persists + stamps ObservedGeneration)
- [x] `make test` (full CI target, `go test $(go list ./... | grep -v /e2e)`) — all green
- [x] `make dev-init` smoke + daemon-parity check — both `kuke get realms` and `--no-daemon` show identical output; verified the kukeond cell converged to `generation: 2 | observedGeneration: 2 | state: Ready` (was stuck at `observedGeneration: 0` before this fix)

Closes #597