### PR TITLE
feat(run): complete kuke run -f create-or-attach state machine

### DIFF
--- a/cmd/kuke/run/print.go
+++ b/cmd/kuke/run/print.go
@@ -150,3 +150,13 @@ func noOpResultFromGet(pre kukeonv1.GetCellResult) kukeonv1.CreateCellResult {
 	}
 	return res
 }
+
+// startedResultFromGet shapes a CreateCellResult for the matching-spec +
+// Stopped → StartCell path: the cell already existed on disk (Created=false),
+// so the rollup mirrors noOpResultFromGet but reflects the StartCell outcome
+// in Started rather than always reporting "not started".
+func startedResultFromGet(pre kukeonv1.GetCellResult, started bool) kukeonv1.CreateCellResult {
+	res := noOpResultFromGet(pre)
+	res.Started = started
+	return res
+}

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -57,8 +57,11 @@ func NewRunCmd() *cobra.Command {
 		Short: "Create and start a single cell from a YAML file or a profile",
 		Long: "Create and start a single cell from a YAML file or stdin (-f), " +
 			"or from a per-user profile under $HOME/.kuke/profiles.d/<name>.yaml (-p). " +
-			"Conceptually `kuke apply -f` (single-cell) plus `kuke start cell`, but refuses " +
-			"to update a divergent on-disk spec. To re-attach to an existing cell use " +
+			"-f is create-or-attach by metadata.name: a missing cell is created and " +
+			"attached; a Ready cell is attached as a no-op; a Stopped cell is started " +
+			"then attached; a divergent on-disk spec is refused (use `kuke apply -f` to " +
+			"update); a cell in an error or partial state is refused with a " +
+			"`kuke delete cell <name>` pointer. To re-attach to an existing cell use " +
 			"`kuke attach <cell>`.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
@@ -242,25 +245,15 @@ func runRun(cmd *cobra.Command, args []string) error {
 				strings.Join(changed, ", "),
 			)
 		}
-		// Matching spec + already-Ready cell: print a no-op summary without
-		// re-entering the daemon's CreateCell→StartCell path. That path is
-		// not safe to re-enter on a healthy cell today: runner.StartCell
-		// re-attaches the root container to its CNI network, which the
-		// bridge plugin rejects with `duplicate allocation`. Pre-existing
-		// daemon bug, surfaced here because the AC requires idempotency.
-		if pre.Cell.Status.State == v1beta1.CellStateReady {
-			if printErr := printRunResult(cmd, noOpResultFromGet(pre), flags.output); printErr != nil {
-				return printErr
-			}
-			if !flags.detach {
-				return attachAndMaybeAutoDelete(cmd, client, cellDoc, flags)
-			}
-			return nil
-		}
+		// A live cell whose on-disk spec matches the file: drive the
+		// create-or-attach state machine instead of re-entering CreateCell.
+		return runExistingCell(cmd, client, cellDoc, pre, flags)
 	case getErr != nil && !errors.Is(getErr, errdefs.ErrCellNotFound):
 		return getErr
 	}
 
+	// No live cell (ErrCellNotFound, or a nil read with no metadata): create
+	// the cell and attach.
 	result, err := client.CreateCell(cmd.Context(), cellDoc)
 	if err != nil {
 		return err
@@ -269,6 +262,63 @@ func runRun(cmd *cobra.Command, args []string) error {
 	if printErr := printRunResult(cmd, result, flags.output); printErr != nil {
 		return printErr
 	}
+	if !flags.detach {
+		return attachAndMaybeAutoDelete(cmd, client, cellDoc, flags)
+	}
+	return nil
+}
+
+// runExistingCell drives the create-or-attach state machine for a live cell
+// whose on-disk spec already matches the file (the caller rejected divergence
+// before delegating here). The four terminal states:
+//
+//   - Ready   → print a no-op summary, then attach. Re-entering the daemon's
+//     CreateCell→StartCell path on a healthy cell trips the runner's CNI
+//     duplicate-allocation bug (#630), so the short-circuit is mandatory, not
+//     just an optimisation.
+//   - Stopped → StartCell, then attach. The routing is the correct verb (the
+//     prior fall-through to CreateCell was itself an unsafe re-entry). The
+//     live start+attach is gated on the same CNI fix (#630): StartCell re-ADDs
+//     the root container to its bridge network, which the daemon rejects with
+//     `duplicate allocation` until it releases the prior allocation on
+//     teardown. The path converges with no further CLI change once #630 lands.
+//   - error / partial (Pending, Failed, Unknown) → refuse with a
+//     `kuke delete cell <name>` pointer (parity with the `-c` identity contract
+//     in #625). `run` does not reconcile a degraded cell in place; the operator
+//     deletes and re-runs.
+func runExistingCell(
+	cmd *cobra.Command,
+	client kukeonv1.Client,
+	cellDoc v1beta1.CellDoc,
+	pre kukeonv1.GetCellResult,
+	flags runFlags,
+) error {
+	switch pre.Cell.Status.State {
+	case v1beta1.CellStateReady:
+		if printErr := printRunResult(cmd, noOpResultFromGet(pre), flags.output); printErr != nil {
+			return printErr
+		}
+	case v1beta1.CellStateStopped:
+		startRes, err := client.StartCell(cmd.Context(), cellDoc)
+		if err != nil {
+			return err
+		}
+		if printErr := printRunResult(cmd, startedResultFromGet(pre, startRes.Started), flags.output); printErr != nil {
+			return printErr
+		}
+	case v1beta1.CellStatePending, v1beta1.CellStateFailed, v1beta1.CellStateUnknown:
+		// error / partial: no clean start path. Refuse and point the operator
+		// at delete-then-rerun. Listing the states explicitly (rather than a
+		// default) keeps the exhaustive linter as a forward guard: a new
+		// CellState must be categorised here deliberately.
+		return fmt.Errorf(
+			"cell %q exists in %s state; delete it with `kuke delete cell %s` before re-running",
+			cellDoc.Metadata.Name,
+			pre.Cell.Status.State.String(),
+			cellDoc.Metadata.Name,
+		)
+	}
+
 	if !flags.detach {
 		return attachAndMaybeAutoDelete(cmd, client, cellDoc, flags)
 	}

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -130,14 +130,17 @@ type fakeClient struct {
 
 	getCellFn         func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
 	createCellFn      func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
+	startCellFn       func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
 	attachContainerFn func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error)
 	killCellFn        func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
 
 	getCalls    int
 	createCalls int
+	startCalls  int
 	attachCalls int
 	killCalls   int
 	createDoc   v1beta1.CellDoc
+	startDoc    v1beta1.CellDoc
 	attachDoc   v1beta1.ContainerDoc
 	killDoc     v1beta1.CellDoc
 }
@@ -157,6 +160,15 @@ func (f *fakeClient) CreateCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv
 		return kukeonv1.CreateCellResult{}, errors.New("unexpected CreateCell call")
 	}
 	return f.createCellFn(doc)
+}
+
+func (f *fakeClient) StartCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+	f.startCalls++
+	f.startDoc = doc
+	if f.startCellFn == nil {
+		return kukeonv1.StartCellResult{}, errors.New("unexpected StartCell call")
+	}
+	return f.startCellFn(doc)
 }
 
 func (f *fakeClient) AttachContainer(
@@ -472,12 +484,11 @@ func TestRun_ExistingCell_MatchingSpec_AlreadyReady_ShortCircuits(t *testing.T) 
 	}
 }
 
-func TestRun_ExistingCell_MatchingSpec_NotReady_StillEnsures(t *testing.T) {
+func TestRun_ExistingCell_MatchingSpec_Stopped_StartsAndAttaches(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
-	// Cell exists with matching spec but its runtime state is not Ready
-	// (Pending/Stopped). Run must fall through to CreateCell so the daemon
-	// can ensure resources and start containers.
+	// Cell exists with matching spec but is Stopped. Run must call StartCell
+	// (not CreateCell — that was an unsafe re-entry per #630) and then attach.
 	existing := v1beta1.CellDoc{
 		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
 		Spec: v1beta1.CellSpec{
@@ -511,25 +522,96 @@ func TestRun_ExistingCell_MatchingSpec_NotReady_StillEnsures(t *testing.T) {
 				RootContainerExists: true,
 			}, nil
 		},
-		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-			return kukeonv1.CreateCellResult{
-				Cell:                    doc,
-				Created:                 false,
-				MetadataExistsPost:      true,
-				CgroupExistsPost:        true,
-				RootContainerExistsPost: true,
-				Started:                 true,
-			}, nil
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
 		},
 	}
-	cmd, _ := newCmd(t, fc)
+	cmd, out := newCmd(t, fc)
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if fc.createCalls != 1 {
-		t.Fatalf("CreateCell calls=%d want 1 (must ensure+start when not Ready)", fc.createCalls)
+	if fc.createCalls != 0 {
+		t.Fatalf("CreateCell calls=%d want 0 (Stopped must start, not re-create)", fc.createCalls)
+	}
+	if fc.startCalls != 1 {
+		t.Fatalf("StartCell calls=%d want 1 (Stopped must start)", fc.startCalls)
+	}
+	if !strings.Contains(out.String(), "  - containers: started") {
+		t.Errorf("output missing 'containers: started' marker:\n%s", out.String())
+	}
+}
+
+func TestRun_ExistingCell_MatchingSpec_ErrorPartial_Refuses(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// A cell in an error / partial state has no clean start path. Run must
+	// refuse with a `kuke delete cell <name>` pointer (parity with the `-c`
+	// identity contract in #625) rather than re-create or start.
+	base := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name  string
+		state v1beta1.CellState
+	}{
+		{"failed", v1beta1.CellStateFailed},
+		{"pending", v1beta1.CellStatePending},
+		{"unknown", v1beta1.CellStateUnknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			existing := base
+			existing.Status = v1beta1.CellStatus{State: tc.state}
+			fc := &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell:                existing,
+						MetadataExists:      true,
+						CgroupExists:        true,
+						RootContainerExists: true,
+					}, nil
+				},
+			}
+			cmd, _ := newCmd(t, fc)
+			cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML), "-d"})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("Execute: want refusal error for %s state, got nil", tc.state.String())
+			}
+			if !strings.Contains(err.Error(), "kuke delete cell my-cell") {
+				t.Errorf("error missing `kuke delete cell` pointer: %v", err)
+			}
+			if fc.createCalls != 0 {
+				t.Errorf("CreateCell calls=%d want 0 (must refuse, not re-create)", fc.createCalls)
+			}
+			if fc.startCalls != 0 {
+				t.Errorf("StartCell calls=%d want 0 (must refuse, not start)", fc.startCalls)
+			}
+		})
 	}
 }
 

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -257,6 +257,11 @@ sudo kuke run -f spec.yaml --rm                             # auto-delete after 
 
 - Exit code 0 once the cell is materialized and its containers started.
 - Side effect on success: the cell appears in `kuke get cells` in the `Ready` state with metadata under `/opt/kukeon/<realm>/<space>/<stack>/<cell>/metadata.json`.
+- `kuke run -f` is **create-or-attach keyed by `metadata.name`**. Against a cell whose on-disk spec matches the file, the runtime state selects the transition:
+  - **No live cell** → create the cell, start its containers, attach.
+  - **Ready** → no-op summary (no re-create), then attach.
+  - **Stopped** → `StartCell`, then attach (no re-create). The prior fall-through to create was an unsafe re-entry; the live start+attach converges once the CNI duplicate-allocation fix (#630) lands.
+  - **Error / partial** (`Pending`, `Failed`, `Unknown`) → refused with `cell "<name>" exists in <state> state; delete it with \`kuke delete cell <name>\` before re-running`. Exit code non-zero. `run` does not reconcile a degraded cell in place.
 - Re-running `kuke run -f` against an existing cell whose on-disk spec **diverges** from the file is **refused**, not silently updated. The error message points the operator at `kuke apply -f` for the update path. Exit code non-zero.
 - `-f` and `-p` are mutually exclusive; `--name` is rejected with `-f` (the YAML's `metadata.name` is the cell name verbatim).
 - `--container` is only valid in attach mode; passing both `--container` and `-d/--detach` exits non-zero.


### PR DESCRIPTION
## Summary

- Completes the `kuke run -f` create-or-attach state machine in `runExistingCell` (`cmd/kuke/run/run.go`). Against a live cell whose on-disk spec matches the file, the runtime state now selects the transition explicitly instead of falling every non-Ready state through to `CreateCell`:
  - **No live cell** → create + attach (unchanged).
  - **Ready** → no-op summary, then attach (unchanged).
  - **Stopped** → `StartCell`, then attach. The prior fall-through to `CreateCell` was itself an unsafe re-entry; `StartCell` is the correct verb.
  - **error / partial** (`Pending`, `Failed`, `Unknown`) → refuse with a `kuke delete cell <name>` pointer (new dedicated branch).
  - **Divergent spec** → unchanged hard refuse routing to `kuke apply -f`.
- Help text on `kuke run` now states `-f` is create-or-attach by `metadata.name` and enumerates the transitions.
- `docs/cli-use-cases.md` run-`-f` invariants updated to document the state machine (keeps the source-of-truth UX doc consistent with the shipped behavior).

## Design calls (reviewer please push back)

- **#630 dependency is scoped to AC1's runtime, not the whole issue.** The issue gates only the *stopped → start* transition on the CNI duplicate-allocation fix (#630), which is open with no PR. I did **not** stall the issue: the CLI routing (`StartCell` instead of `CreateCell`) is correct regardless, is fully unit-testable with a mock client, and is strictly no worse than today's stopped→`CreateCell` fall-through (both hit the same CNI bug until #630, so no regression). The live stopped→start path converges with **zero further CLI change** once #630 lands. The error/partial-refuse, divergent-spec, help-text, and no-cell/Ready ACs are fully independent of #630 and verified now.
- **error / partial = `Pending`, `Failed`, `Unknown`.** These three states map to the issue's "error / partial" bucket (parity with the `-c` identity contract in #625: running / stopped / error). Listed explicitly in the `switch` (no `default`) so the `exhaustive` linter forces any future `CellState` to be categorised deliberately.
- **Stale test replaced.** `TestRun_ExistingCell_MatchingSpec_NotReady_StillEnsures` asserted the now-removed stopped→`CreateCell` fall-through. Replaced with `..._Stopped_StartsAndAttaches` (asserts `StartCell`, no `CreateCell`) and `..._ErrorPartial_Refuses` (Failed/Pending/Unknown all refuse with the delete pointer, no create/start).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/kuke/run/...`
- [x] `make test` (full CI target, `go test $(go list ./... | grep -v /e2e)`) — all green, including new `cmd/kuke/run` coverage for Stopped→start and error/partial refuse
- [x] `pre-commit run --files <changed>` — all hooks pass (golangci-lint incl. `exhaustive`)
- [ ] Live `kuke run -f` against a real **Stopped** cell (AC1 end-to-end) — **deferred to #630**: `StartCell` re-ADDs the root container to its bridge network, which the daemon rejects with `duplicate allocation` until #630 releases the prior allocation on teardown. The CLI routing is unit-verified; the live path converges once #630 merges, no further CLI change.

## Acceptance criteria

- [x] `kuke run -f` against a **stopped** cell with matching spec routes to `StartCell` + attach — no re-create (unit-verified; live path gated on #630 per above).
- [x] `kuke run -f` against a cell in **error / partial** state refuses with a `kuke delete cell <name>` pointer.
- [x] **Divergent-spec** behavior unchanged: hard refuse routing to `kuke apply -f`.
- [x] No-cell and `Ready` cases unchanged.
- [x] `kuke run` help text states that `-f` is create-or-attach by `metadata.name`.

Closes #631