### PR TITLE
fix(cli): route shell completion through the daemon client

### DIFF
--- a/cmd/config/autocomplete.go
+++ b/cmd/config/autocomplete.go
@@ -17,40 +17,86 @@
 package config
 
 import (
+	"context"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/cellprofile"
+	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/controller"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-// MockControllerKey is used to inject mock controllers in tests via context.
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in
+// tests, matching the convention every other command package uses (see e.g.
+// cmd/kuke/get/cell). Despite the historical name it now carries a
+// kukeonv1.Client, not a controller.Exec.
 type MockControllerKey struct{}
 
-// controllerFromCmd creates a controller.Exec from the command context.
-// This duplicates the logic from cmd/kuke/create/shared to avoid import cycles.
-// If a mock controller is provided in the context, it will be used instead of creating a real one.
-func controllerFromCmd(cmd *cobra.Command) (*controller.Exec, error) {
-	// Check for mock controller in context (for testing)
-	if mockCtrl, ok := cmd.Context().Value(MockControllerKey{}).(*controller.Exec); ok {
-		return mockCtrl, nil
+// completionTimeout bounds how long a completer waits on the daemon before
+// degrading to an empty list. Shell completion must never block the prompt,
+// so this is deliberately short: a slow, hung, or unreachable daemon yields
+// no candidates rather than a frozen terminal (issue #634).
+const completionTimeout = 2 * time.Second
+
+// completionClient returns the kukeonv1.Client the completers resolve resource
+// names through. It mirrors shared.ClientFromCmd's source selection so
+// completion reflects the same authoritative view `kuke get …` shows the user
+// running it: the `kukeon/noDaemon` viper key picks the in-process controller
+// (local.New, direct on-disk metadata reads, requires privileges) versus the
+// kukeond daemon (RPC over the configured KUKEON_HOST socket).
+//
+// The default is the daemon path. This is the fix for issue #634: the
+// completers previously read /opt/kukeon/data directly via controller.Exec,
+// which an unprivileged shell user cannot read on the standard root-owned
+// install, so completion silently returned nothing while `kuke get …` (which
+// routes through the group-accessible daemon socket) worked. Routing
+// completion through the daemon makes it work for any user who can already
+// run `kuke get …`.
+//
+// --no-daemon story: completion follows the same `kukeon/noDaemon` viper key
+// the get verbs honor — there is no second selection path to keep in sync.
+// One caveat is worth stating because it shapes what works at a live prompt:
+// cobra's hidden `__complete` command does not run the root PersistentPreRunE,
+// and it does not mark inherited *persistent flags* (`--host`, `--no-daemon`,
+// `--run-path`) as changed for the completion request. So during real shell
+// completion those flags do not reach viper; what does reach it is the env
+// (KUKEON_HOST, KUKEON_NO_DAEMON, KUKEON_RUN_PATH, bound via config.DefineKV's
+// viper.SetDefault plus the env bindings) and the built-in defaults. In
+// practice that is exactly right for the standard install: completion dials
+// the default kukeond socket (or KUKEON_HOST when the operator overrides it)
+// and stays on the daemon path. The in-process branch remains reachable when
+// the viper key is set directly — programmatically or via KUKEON_NO_DAEMON —
+// which is also how the unit tests exercise it.
+//
+// The caller owns the returned Client and must Close it.
+func completionClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	// Check for an injected mock client in context (for testing).
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
 	}
 
-	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
-	if !ok || logger == nil {
-		return nil, errdefs.ErrLoggerNotFound
+	if viper.GetBool(KUKEON_ROOT_NO_DAEMON.ViperKey) {
+		logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+		if !ok || logger == nil {
+			return nil, errdefs.ErrLoggerNotFound
+		}
+		return local.New(cmd.Context(), logger, controller.Options{
+			RunPath:          viper.GetString(KUKEON_ROOT_RUN_PATH.ViperKey),
+			ContainerdSocket: viper.GetString(KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+		}), nil
 	}
 
-	opts := controller.Options{
-		RunPath:          viper.GetString(KUKEON_ROOT_RUN_PATH.ViperKey),
-		ContainerdSocket: viper.GetString(KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	host := viper.GetString(KUKEON_ROOT_HOST.ViperKey)
+	if host == "" {
+		host = KUKEON_ROOT_HOST.Default
 	}
-
-	return controller.NewControllerExec(cmd.Context(), logger, opts), nil
+	return kukeonv1.Dial(cmd.Context(), host)
 }
 
 // getFlagValueWithDefault gets a flag value, falling back to Viper (which includes defaults) and then to a provided default.
@@ -130,15 +176,19 @@ func CompleteRealmNames(cmd *cobra.Command, args []string, toComplete string) ([
 		}
 	}
 
-	ctrl, err := controllerFromCmd(cmd)
+	client, err := completionClient(cmd)
 	if err != nil {
-		// Return empty completion on error (controller unavailable)
+		// Return empty completion on error (client unavailable)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
+	defer func() { _ = client.Close() }()
 
-	realms, err := ctrl.ListRealms()
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
+	realms, err := client.ListRealms(ctx)
 	if err != nil {
-		// Return empty completion on error
+		// Return empty completion on error (daemon unreachable, timeout, etc.)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
 
@@ -189,11 +239,12 @@ func CompleteSpaceNames(cmd *cobra.Command, args []string, toComplete string) ([
 		}
 	}
 
-	ctrl, err := controllerFromCmd(cmd)
+	client, err := completionClient(cmd)
 	if err != nil {
-		// Return empty completion on error (controller unavailable)
+		// Return empty completion on error (client unavailable)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
+	defer func() { _ = client.Close() }()
 
 	// Read realm flag with default fallback
 	realmName := getFlagValueWithDefault(cmd, "realm", "default")
@@ -208,10 +259,13 @@ func CompleteSpaceNames(cmd *cobra.Command, args []string, toComplete string) ([
 		}
 	}
 
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
 	// List spaces, optionally filtered by realm
-	spaces, err := ctrl.ListSpaces(realmName)
+	spaces, err := client.ListSpaces(ctx, realmName)
 	if err != nil {
-		// Return empty completion on error
+		// Return empty completion on error (daemon unreachable, timeout, etc.)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
 
@@ -262,11 +316,12 @@ func CompleteStackNames(cmd *cobra.Command, args []string, toComplete string) ([
 		}
 	}
 
-	ctrl, err := controllerFromCmd(cmd)
+	client, err := completionClient(cmd)
 	if err != nil {
-		// Return empty completion on error (controller unavailable)
+		// Return empty completion on error (client unavailable)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
+	defer func() { _ = client.Close() }()
 
 	// Read realm and space flags with default fallback
 	realmName := getFlagValueWithDefault(cmd, "realm", "default")
@@ -282,10 +337,13 @@ func CompleteStackNames(cmd *cobra.Command, args []string, toComplete string) ([
 		}
 	}
 
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
 	// List stacks, optionally filtered by realm and space
-	stacks, err := ctrl.ListStacks(realmName, spaceName)
+	stacks, err := client.ListStacks(ctx, realmName, spaceName)
 	if err != nil {
-		// Return empty completion on error
+		// Return empty completion on error (daemon unreachable, timeout, etc.)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
 
@@ -336,11 +394,12 @@ func CompleteCellNames(cmd *cobra.Command, args []string, toComplete string) ([]
 		}
 	}
 
-	ctrl, err := controllerFromCmd(cmd)
+	client, err := completionClient(cmd)
 	if err != nil {
-		// Return empty completion on error (controller unavailable)
+		// Return empty completion on error (client unavailable)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
+	defer func() { _ = client.Close() }()
 
 	// Read realm, space, and stack flags with default fallback
 	realmName := getFlagValueWithDefault(cmd, "realm", "default")
@@ -357,10 +416,13 @@ func CompleteCellNames(cmd *cobra.Command, args []string, toComplete string) ([]
 		}
 	}
 
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
 	// List cells, optionally filtered by realm, space, and stack
-	cells, err := ctrl.ListCells(realmName, spaceName, stackName)
+	cells, err := client.ListCells(ctx, realmName, spaceName, stackName)
 	if err != nil {
-		// Return empty completion on error
+		// Return empty completion on error (daemon unreachable, timeout, etc.)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
 
@@ -411,11 +473,12 @@ func CompleteContainerNames(cmd *cobra.Command, args []string, toComplete string
 		}
 	}
 
-	ctrl, err := controllerFromCmd(cmd)
+	client, err := completionClient(cmd)
 	if err != nil {
-		// Return empty completion on error (controller unavailable)
+		// Return empty completion on error (client unavailable)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
+	defer func() { _ = client.Close() }()
 
 	// Read required flags with default fallback (cell has no default)
 	realmName := getFlagValueWithDefault(cmd, "realm", "default")
@@ -438,10 +501,13 @@ func CompleteContainerNames(cmd *cobra.Command, args []string, toComplete string
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
 	// List containers filtered by realm, space, stack, and cell
-	containers, err := ctrl.ListContainers(realmName, spaceName, stackName, cellName)
+	containers, err := client.ListContainers(ctx, realmName, spaceName, stackName, cellName)
 	if err != nil {
-		// Return empty completion on error
+		// Return empty completion on error (daemon unreachable, timeout, etc.)
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
 	}
 

--- a/cmd/config/autocomplete_daemon_test.go
+++ b/cmd/config/autocomplete_daemon_test.go
@@ -1,0 +1,194 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	"github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// fakeCompletionClient is a kukeonv1.Client whose List* methods return canned
+// data, modelling the kukeond daemon's authoritative view. It embeds
+// kukeonv1.FakeClient so the methods the completers don't touch return
+// ErrUnexpectedCall.
+type fakeCompletionClient struct {
+	kukeonv1.FakeClient
+
+	realms []v1beta1.RealmDoc
+	cells  []v1beta1.CellDoc
+
+	cellCalls int
+}
+
+func (f *fakeCompletionClient) ListRealms(context.Context) ([]v1beta1.RealmDoc, error) {
+	return f.realms, nil
+}
+
+func (f *fakeCompletionClient) ListCells(_ context.Context, _, _, _ string) ([]v1beta1.CellDoc, error) {
+	f.cellCalls++
+	return f.cells, nil
+}
+
+// daemonCmd builds a bare cobra command with a logger in context and the
+// daemon (non-no-daemon) completion path selected. When client is non-nil it
+// is injected via MockControllerKey so completionClient resolves through it.
+func daemonCmd(t *testing.T, client kukeonv1.Client) *cobra.Command {
+	t.Helper()
+
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+	// Daemon path is the default; be explicit so the intent is clear and a
+	// leaked viper key from another test can't flip us onto the in-process path.
+	viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, false)
+
+	cmd := &cobra.Command{Use: "test"}
+	ctx := context.WithValue(context.Background(), types.CtxLogger, discardLogger())
+	if client != nil {
+		ctx = context.WithValue(ctx, config.MockControllerKey{}, client)
+	}
+	cmd.SetContext(ctx)
+	return cmd
+}
+
+// TestCompleteCellNames_DaemonBackedClient asserts the happy path: a completer
+// returns names resolved through the daemon-backed client rather than the
+// metadata-direct controller.Exec the older code used.
+func TestCompleteCellNames_DaemonBackedClient(t *testing.T) {
+	fake := &fakeCompletionClient{
+		cells: []v1beta1.CellDoc{
+			{Metadata: v1beta1.CellMetadata{Name: "alpha"}},
+			{Metadata: v1beta1.CellMetadata{Name: "bravo"}},
+			{Metadata: v1beta1.CellMetadata{Name: "charlie"}},
+		},
+	}
+	cmd := daemonCmd(t, fake)
+
+	names, directive := config.CompleteCellNames(cmd, []string{}, "")
+
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want %v", directive, cobra.ShellCompDirectiveNoFileComp)
+	}
+	if fake.cellCalls != 1 {
+		t.Errorf("expected exactly one ListCells call through the daemon client, got %d", fake.cellCalls)
+	}
+	assertNames(t, names, []string{"alpha", "bravo", "charlie"})
+}
+
+// TestCompleteRealmNames_DaemonBackedClient mirrors the above for realms so the
+// daemon path is exercised at the top of the resource hierarchy too.
+func TestCompleteRealmNames_DaemonBackedClient(t *testing.T) {
+	fake := &fakeCompletionClient{
+		realms: []v1beta1.RealmDoc{
+			{Metadata: v1beta1.RealmMetadata{Name: "default"}},
+			{Metadata: v1beta1.RealmMetadata{Name: "kuke-system"}},
+		},
+	}
+	cmd := daemonCmd(t, fake)
+
+	names, directive := config.CompleteRealmNames(cmd, []string{}, "")
+
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want %v", directive, cobra.ShellCompDirectiveNoFileComp)
+	}
+	assertNames(t, names, []string{"default", "kuke-system"})
+}
+
+// TestCompleteCellNames_DegradesWhenDaemonUnavailable asserts the
+// graceful-degradation criterion: with the daemon socket absent, the completer
+// returns an empty list and the standard directive quickly, without hanging or
+// surfacing an error at the prompt.
+func TestCompleteCellNames_DegradesWhenDaemonUnavailable(t *testing.T) {
+	cmd := daemonCmd(t, nil) // no mock: completionClient dials a real socket
+	// Point at a socket that does not exist; the dial fails immediately.
+	missing := "unix://" + filepath.Join(t.TempDir(), "absent-kukeond.sock")
+	viper.Set(config.KUKEON_ROOT_HOST.ViperKey, missing)
+
+	start := time.Now()
+	names, directive := config.CompleteCellNames(cmd, []string{}, "")
+	elapsed := time.Since(start)
+
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive = %v, want %v", directive, cobra.ShellCompDirectiveNoFileComp)
+	}
+	if len(names) != 0 {
+		t.Errorf("expected empty completion when daemon is unavailable, got %v", names)
+	}
+	// A missing unix socket fails the dial without blocking; well under the
+	// completion timeout. Generous bound to stay non-flaky under load.
+	if elapsed > 5*time.Second {
+		t.Errorf("completion took %v with daemon absent; expected prompt degradation", elapsed)
+	}
+}
+
+// TestCompleteCellNames_FollowsDaemonNotOnDisk models the reported bug: the
+// daemon returns cell names that a metadata-direct read of the run path could
+// not (the unprivileged-user-vs-root-daemon case). The daemon-backed path
+// surfaces them; the in-process path over the same empty run path surfaces
+// nothing — proving completion now follows the daemon, not the on-disk tree.
+func TestCompleteCellNames_FollowsDaemonNotOnDisk(t *testing.T) {
+	runPath := t.TempDir() // deliberately empty: no on-disk cell metadata
+
+	// Daemon path: the daemon knows about "alpha"/"bravo".
+	fake := &fakeCompletionClient{
+		cells: []v1beta1.CellDoc{
+			{Metadata: v1beta1.CellMetadata{Name: "alpha"}},
+			{Metadata: v1beta1.CellMetadata{Name: "bravo"}},
+		},
+	}
+	daemon := daemonCmd(t, fake)
+	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, runPath)
+
+	daemonNames, _ := config.CompleteCellNames(daemon, []string{}, "")
+	assertNames(t, daemonNames, []string{"alpha", "bravo"})
+
+	// In-process path over the same empty run path: no metadata, no names.
+	// This is what the unprivileged user effectively saw before #634 (an
+	// unreadable/empty direct read), and what the daemon path now fixes.
+	onDisk := setupTestCommand(t, runPath, false)
+	onDiskNames, _ := config.CompleteCellNames(onDisk, []string{}, "")
+	assertNames(t, onDiskNames, []string{})
+}
+
+func assertNames(t *testing.T, got, want []string) {
+	t.Helper()
+	sort.Strings(got)
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("got %d names %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("names[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/cmd/config/autocomplete_test.go
+++ b/cmd/config/autocomplete_test.go
@@ -126,6 +126,12 @@ func setupTestCommand(t *testing.T, runPath string, noLogger bool) *cobra.Comman
 
 	viper.Set(config.KUKEON_ROOT_RUN_PATH.ViperKey, runPath)
 	viper.Set(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey, filepath.Join(runPath, "containerd.sock"))
+	// These on-disk-metadata fixtures exercise the in-process completion path.
+	// Issue #634 made the daemon the default source for the completers, so set
+	// the same `kukeon/noDaemon` viper key the get verbs honor to keep these
+	// cases reading the metadata tree under runPath. The daemon-backed path is
+	// covered separately by the mock-client tests below.
+	viper.Set(config.KUKEON_ROOT_NO_DAEMON.ViperKey, true)
 
 	cmd := &cobra.Command{Use: "test"}
 

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -18,6 +18,8 @@ package e2e_test
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,7 +28,9 @@ import (
 	"time"
 
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/metadata"
 	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 // TestKuke_Help tests kuke help command.
@@ -711,6 +715,110 @@ func TestKuke_Autocomplete_Bash(t *testing.T) {
 	// Step 4: Verify output is substantial (bash completion scripts are typically hundreds of lines)
 	if len(outputStr) < 50 {
 		t.Fatalf("bash completion script output too short: %d bytes", len(outputStr))
+	}
+}
+
+// seedCellMetadata writes the realm/space/stack/cell metadata chain on disk
+// under runPath so a daemon bound to that run path lists the cell without any
+// containerd interaction (ListCells is a pure on-disk traversal). This keeps
+// the completion e2e free of the containerd/cgroup/root prerequisites that
+// `kuke create cell` would pull in, while still exercising the daemon RPC
+// path end-to-end.
+func seedCellMetadata(t *testing.T, runPath, realm, space, stack, cell string) {
+	t.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	write := func(dir string, doc any) {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %q: %v", dir, err)
+		}
+		path := filepath.Join(dir, consts.KukeonMetadataFile)
+		if err := metadata.WriteMetadata(context.Background(), logger, doc, path); err != nil {
+			t.Fatalf("write metadata %q: %v", path, err)
+		}
+	}
+
+	write(fs.RealmMetadataDir(runPath, realm), &v1beta1.RealmDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindRealm,
+		Metadata:   v1beta1.RealmMetadata{Name: realm},
+		Spec:       v1beta1.RealmSpec{Namespace: realm + "-ns"},
+		Status:     v1beta1.RealmStatus{State: v1beta1.RealmStateReady},
+	})
+	write(fs.SpaceMetadataDir(runPath, realm, space), &v1beta1.SpaceDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindSpace,
+		Metadata:   v1beta1.SpaceMetadata{Name: space},
+		Spec:       v1beta1.SpaceSpec{RealmID: realm},
+		Status:     v1beta1.SpaceStatus{State: v1beta1.SpaceStateReady},
+	})
+	write(fs.StackMetadataDir(runPath, realm, space, stack), &v1beta1.StackDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindStack,
+		Metadata:   v1beta1.StackMetadata{Name: stack},
+		Spec:       v1beta1.StackSpec{RealmID: realm, SpaceID: space},
+		Status:     v1beta1.StackStatus{State: v1beta1.StackStateReady},
+	})
+	write(fs.CellMetadataDir(runPath, realm, space, stack, cell), &v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: cell},
+		Spec:       v1beta1.CellSpec{ID: cell, RealmID: realm, SpaceID: space, StackID: stack},
+		Status:     v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	})
+}
+
+// TestKuke_Autocomplete_GetCell_ViaDaemon is the regression guard for issue
+// #634: `kuke __complete get cell ”` must surface cell names resolved through
+// the kukeond daemon, not the metadata-direct controller read that an
+// unprivileged shell user cannot perform against a root-owned /opt/kukeon.
+// It mirrors the manual repro in the issue (which returned `:4` with zero
+// candidates) but against a daemon that knows about a seeded cell, asserting
+// the cell name appears and the directive is ShellCompDirectiveNoFileComp.
+func TestKuke_Autocomplete_GetCell_ViaDaemon(t *testing.T) {
+	t.Parallel()
+
+	runPath := getRandomRunPath(t)
+	realm, space, stack, cell := "rcomp", "scomp", "stcomp", "cellcomp"
+	seedCellMetadata(t, runPath, realm, space, stack, cell)
+
+	host := startKukeondDaemon(t, runPath)
+
+	// `kuke __complete <command line…> <toComplete>`: the trailing "" is the
+	// positional cell name being completed. The completer's daemon endpoint is
+	// pointed at the per-test kukeond via KUKEON_HOST rather than `--host`:
+	// cobra's `__complete` does not mark inherited persistent flags as changed
+	// for the completion request (and skips the root PreRun), so the `--host`
+	// flag would not reach viper here — the env var does. This mirrors how an
+	// operator on a non-default socket drives completion (see the
+	// completionClient doc in cmd/config/autocomplete.go).
+	exitCode, stdout, stderr := runBinary(t, []string{"KUKEON_HOST=" + host}, kuke,
+		"__complete",
+		"get", "cell",
+		"--realm", realm, "--space", space, "--stack", stack,
+		"",
+	)
+	if exitCode != 0 {
+		t.Fatalf("__complete exited %d; stdout=%q stderr=%q", exitCode, string(stdout), string(stderr))
+	}
+
+	out := string(stdout)
+
+	// The seeded cell must appear as a candidate.
+	foundCell := false
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == cell {
+			foundCell = true
+			break
+		}
+	}
+	if !foundCell {
+		t.Errorf("expected cell %q in completion candidates; got stdout=%q stderr=%q", cell, out, string(stderr))
+	}
+
+	// cobra emits the directive as a `:<bitmask>` line; ShellCompDirectiveNoFileComp == 4.
+	if !strings.Contains(out, ":4") {
+		t.Errorf("expected ShellCompDirectiveNoFileComp (:4) in completion output; got %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Shell completion of resource names (`kuke get cell <TAB>`, and the realm/space/stack/cell/container completers) silently returned nothing on the standard install where `kukeond` runs as root and the operator runs `kuke` unprivileged: the completers read the on-disk metadata tree under `--run-path` directly via `controller.NewControllerExec`, which an unprivileged shell user cannot read against root-owned `/opt/kukeon`. The `get` verbs worked because they route through the group-accessible kukeond socket.
- This routes the completers through a `kukeonv1.Client` (`completionClient` in `cmd/config/autocomplete.go`) instead of the metadata-direct controller, mirroring `shared.ClientFromCmd`'s source selection so completion reflects the same authoritative view `kuke get …` shows the user running it.
- Each completer now wraps its `List*` call in a short (`2s`) context so a slow/hung/absent daemon degrades to an empty list quickly rather than blocking the prompt.

### `--no-daemon` decision (AC item)

Completion follows the **same `kukeon/noDaemon` viper key the `get` verbs honor** — there is no second selection path to keep in sync. Default is the daemon; the in-process branch is taken when that key is set.

One caveat is documented in the `completionClient` godoc and drove the e2e harness wiring: cobra's hidden `__complete` command does not run the root `PersistentPreRunE` and does **not** mark inherited *persistent flags* (`--host`, `--no-daemon`, `--run-path`) as changed for the completion request. So during real shell completion those flags do not reach viper; the **env vars** (`KUKEON_HOST`, `KUKEON_NO_DAEMON`, …) and the built-in viper defaults do. For the standard install this is exactly right — completion dials the default kukeond socket (or `KUKEON_HOST` when overridden) and stays on the daemon path. This was verified empirically while building the e2e test (env-host completes the cell; `--host` flag does not), which is why the e2e points the daemon via `KUKEON_HOST`.

## Non-obvious calls (for reviewer scrutiny)

- **`MockControllerKey` now carries a `kukeonv1.Client`, not a `*controller.Exec`.** Nothing outside `autocomplete.go` referenced the old type; this aligns the completion package with the `MockControllerKey`-injects-a-`Client` convention every other command package already uses (e.g. `cmd/kuke/get/cell`).
- **Existing on-disk-metadata unit tests are preserved** by setting `kukeon/noDaemon=true` in `setupTestCommand`, so they keep exercising the in-process path verbatim. New mock-client tests cover the daemon-backed path, degradation, and the bug.
- **The e2e seeds cell metadata on disk** (full realm/space/stack/cell chain) and reads it back through a real `kukeond serve`, rather than `kuke create cell`. `ListCells` is a pure on-disk traversal (no containerd), so this exercises the daemon RPC completion path end-to-end without the containerd/cgroup/root prerequisites `create` would pull in — keeping the test runnable in CI without the full init stack.

## Test plan

- [x] `make test` — full CI unit-test target, all packages pass (exit 0).
- [x] `go vet ./...` — clean.
- [x] `go build ./...` — clean.
- [x] `pre-commit run --files <changed>` — gofmt/golangci-lint/addlicense all pass.
- [x] New unit tests in `cmd/config/autocomplete_daemon_test.go`: daemon-backed happy path (cell + realm), graceful degradation with the socket absent, and the bug case (daemon returns names an empty on-disk tree cannot).
- [x] New e2e `TestKuke_Autocomplete_GetCell_ViaDaemon`: `kuke __complete get cell ''` against a real running daemon with a seeded cell asserts the cell name appears and the directive is `ShellCompDirectiveNoFileComp` (`:4`). Verified locally via `E2E_BIN_DIR=$(pwd) go test -run TestKuke_Autocomplete_GetCell_ViaDaemon ./e2e`.
- [ ] `make dev-init` daemon-parity smoke — not applicable: this change is CLI-completion-only (client-side data path); it does not touch the daemon, the build path, or anything under `/opt/kukeon` that the daemon reads. (docker/containerd are also not running on this dev host.)

Closes #634