### PR TITLE
feat(controller): guarded-skip stale persist in realm/space/stack refresh

### DIFF
--- a/internal/controller/runner/metadata_generation_test.go
+++ b/internal/controller/runner/metadata_generation_test.go
@@ -186,6 +186,180 @@ func TestUpdateRealmMetadataConcurrentWritesConverge(t *testing.T) {
 	}
 }
 
+// TestPersistRealmStatusGuardedSkipsWhenBehind pins issue #636 for the realm
+// refresh path: when a concurrent spec write has advanced the on-disk
+// Generation past the value the refresh observed, the guarded persist skips
+// (persisted=false, nil err) rather than surfacing ErrStaleResource as a hard
+// error; a current observation persists normally. Mirrors the cell path's
+// persistCellStatusGuarded behavior.
+func TestPersistRealmStatusGuardedSkipsWhenBehind(t *testing.T) {
+	r := newGenerationTestExec(t, t.TempDir())
+	seed := intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: "r-guard"},
+		Spec:     intmodel.RealmSpec{Namespace: "r-guard.kukeon.io"},
+		Status:   intmodel.RealmStatus{State: intmodel.RealmStateReady},
+	}
+	if err := r.UpdateRealmMetadata(seed); err != nil {
+		t.Fatalf("seed UpdateRealmMetadata: %v", err)
+	}
+
+	// Capture the stale refresh view (generation 1) before the spec moves.
+	staleView := readRealmGeneration(t, r, "r-guard")
+
+	// A concurrent spec writer advances the realm to generation 2.
+	specWrite := readRealmGeneration(t, r, "r-guard")
+	specWrite.Spec.RegistryCredentials = append(specWrite.Spec.RegistryCredentials,
+		intmodel.RegistryCredentials{ServerAddress: "reg-a"})
+	if err := r.UpdateRealmMetadata(specWrite); err != nil {
+		t.Fatalf("concurrent spec UpdateRealmMetadata: %v", err)
+	}
+
+	// The refresh tries to persist a status flip against its stale view.
+	staleView.Status.State = intmodel.RealmStateUnknown
+	persisted, err := r.persistRealmStatusGuarded(staleView)
+	if err != nil {
+		t.Fatalf("guarded persist (stale): %v", err)
+	}
+	if persisted {
+		t.Fatal("guarded persist reported persisted=true for a stale observation")
+	}
+	afterSkip := readRealmGeneration(t, r, "r-guard")
+	if len(afterSkip.Spec.RegistryCredentials) != 1 {
+		t.Error("spec clobbered by stale refresh: RegistryCredentials reverted")
+	}
+	if afterSkip.Status.State == intmodel.RealmStateUnknown {
+		t.Error("stale status flip leaked to disk despite the skip")
+	}
+
+	// A current observation (generation 2) persists.
+	current := readRealmGeneration(t, r, "r-guard")
+	current.Status.State = intmodel.RealmStateUnknown
+	persisted, err = r.persistRealmStatusGuarded(current)
+	if err != nil {
+		t.Fatalf("guarded persist (current): %v", err)
+	}
+	if !persisted {
+		t.Fatal("guarded persist skipped a current observation")
+	}
+	if readRealmGeneration(t, r, "r-guard").Status.State != intmodel.RealmStateUnknown {
+		t.Error("status flip not persisted for a current observation")
+	}
+}
+
+// TestPersistSpaceStatusGuardedSkipsWhenBehind is the Space counterpart.
+func TestPersistSpaceStatusGuardedSkipsWhenBehind(t *testing.T) {
+	r := newGenerationTestExec(t, t.TempDir())
+	seed := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: "sp-guard"},
+		Spec:     intmodel.SpaceSpec{RealmName: "r1", CNIConfigPath: "/etc/cni/sp.conf"},
+		Status:   intmodel.SpaceStatus{State: intmodel.SpaceStateReady},
+	}
+	if err := r.UpdateSpaceMetadata(seed); err != nil {
+		t.Fatalf("seed UpdateSpaceMetadata: %v", err)
+	}
+	read := func() intmodel.Space {
+		got, err := r.readSpaceInternal(fs.SpaceMetadataPath(r.opts.RunPath, "r1", "sp-guard"))
+		if err != nil {
+			t.Fatalf("readSpaceInternal: %v", err)
+		}
+		return got
+	}
+
+	staleView := read()
+
+	specWrite := read()
+	specWrite.Spec.CNIConfigPath = "/etc/cni/sp-moved.conf"
+	if err := r.UpdateSpaceMetadata(specWrite); err != nil {
+		t.Fatalf("concurrent spec UpdateSpaceMetadata: %v", err)
+	}
+
+	staleView.Status.State = intmodel.SpaceStateUnknown
+	persisted, err := r.persistSpaceStatusGuarded(staleView)
+	if err != nil {
+		t.Fatalf("guarded persist (stale): %v", err)
+	}
+	if persisted {
+		t.Fatal("guarded persist reported persisted=true for a stale observation")
+	}
+	afterSkip := read()
+	if afterSkip.Spec.CNIConfigPath != "/etc/cni/sp-moved.conf" {
+		t.Error("spec clobbered by stale refresh: CNIConfigPath reverted")
+	}
+	if afterSkip.Status.State == intmodel.SpaceStateUnknown {
+		t.Error("stale status flip leaked to disk despite the skip")
+	}
+
+	current := read()
+	current.Status.State = intmodel.SpaceStateUnknown
+	persisted, err = r.persistSpaceStatusGuarded(current)
+	if err != nil {
+		t.Fatalf("guarded persist (current): %v", err)
+	}
+	if !persisted {
+		t.Fatal("guarded persist skipped a current observation")
+	}
+	if read().Status.State != intmodel.SpaceStateUnknown {
+		t.Error("status flip not persisted for a current observation")
+	}
+}
+
+// TestPersistStackStatusGuardedSkipsWhenBehind is the Stack counterpart.
+func TestPersistStackStatusGuardedSkipsWhenBehind(t *testing.T) {
+	r := newGenerationTestExec(t, t.TempDir())
+	seed := intmodel.Stack{
+		Metadata: intmodel.StackMetadata{Name: "st-guard"},
+		Spec:     intmodel.StackSpec{ID: "stk-1", RealmName: "r1", SpaceName: "s1"},
+		Status:   intmodel.StackStatus{State: intmodel.StackStateReady},
+	}
+	if err := r.UpdateStackMetadata(seed); err != nil {
+		t.Fatalf("seed UpdateStackMetadata: %v", err)
+	}
+	read := func() intmodel.Stack {
+		got, err := r.readStackInternal(fs.StackMetadataPath(r.opts.RunPath, "r1", "s1", "st-guard"))
+		if err != nil {
+			t.Fatalf("readStackInternal: %v", err)
+		}
+		return got
+	}
+
+	staleView := read()
+
+	specWrite := read()
+	specWrite.Spec.ID = "stk-2"
+	if err := r.UpdateStackMetadata(specWrite); err != nil {
+		t.Fatalf("concurrent spec UpdateStackMetadata: %v", err)
+	}
+
+	staleView.Status.State = intmodel.StackStateUnknown
+	persisted, err := r.persistStackStatusGuarded(staleView)
+	if err != nil {
+		t.Fatalf("guarded persist (stale): %v", err)
+	}
+	if persisted {
+		t.Fatal("guarded persist reported persisted=true for a stale observation")
+	}
+	afterSkip := read()
+	if afterSkip.Spec.ID != "stk-2" {
+		t.Error("spec clobbered by stale refresh: Spec.ID reverted")
+	}
+	if afterSkip.Status.State == intmodel.StackStateUnknown {
+		t.Error("stale status flip leaked to disk despite the skip")
+	}
+
+	current := read()
+	current.Status.State = intmodel.StackStateUnknown
+	persisted, err = r.persistStackStatusGuarded(current)
+	if err != nil {
+		t.Fatalf("guarded persist (current): %v", err)
+	}
+	if !persisted {
+		t.Fatal("guarded persist skipped a current observation")
+	}
+	if read().Status.State != intmodel.StackStateUnknown {
+		t.Error("status flip not persisted for a current observation")
+	}
+}
+
 func seedCell(t *testing.T, r *Exec) intmodel.Cell {
 	t.Helper()
 	cell := intmodel.Cell{

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -62,6 +62,61 @@ func (r *Exec) persistCellStatusGuarded(cell intmodel.Cell) (bool, error) {
 	return true, nil
 }
 
+// persistRealmStatusGuarded persists a realm whose status the refresh path
+// just re-derived, treating a CAS rejection from a concurrent spec writer as
+// a benign skip rather than a hard error. UpdateRealmMetadata rides the
+// writer's optimistic token (phase 3 — #633) and returns
+// errdefs.ErrStaleResource when the on-disk generation has advanced past the
+// observation the refresh read with. Mirrors persistCellStatusGuarded so the
+// realm/space/stack refresh paths match the cell path: a stale race
+// self-heals on the next refresh tick instead of surfacing as a reported
+// `Errors:` line in `kuke refresh` (issue #636).
+func (r *Exec) persistRealmStatusGuarded(realm intmodel.Realm) (bool, error) {
+	if err := r.UpdateRealmMetadata(realm); err != nil {
+		if errors.Is(err, errdefs.ErrStaleResource) {
+			r.logger.DebugContext(r.ctx,
+				"refresh: skipping stale realm persist; on-disk generation advanced",
+				"realm", realm.Metadata.Name,
+				"observed", realm.Metadata.Generation)
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// persistSpaceStatusGuarded is the Space counterpart of
+// persistRealmStatusGuarded.
+func (r *Exec) persistSpaceStatusGuarded(space intmodel.Space) (bool, error) {
+	if err := r.UpdateSpaceMetadata(space); err != nil {
+		if errors.Is(err, errdefs.ErrStaleResource) {
+			r.logger.DebugContext(r.ctx,
+				"refresh: skipping stale space persist; on-disk generation advanced",
+				"space", space.Metadata.Name,
+				"observed", space.Metadata.Generation)
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// persistStackStatusGuarded is the Stack counterpart of
+// persistRealmStatusGuarded.
+func (r *Exec) persistStackStatusGuarded(stack intmodel.Stack) (bool, error) {
+	if err := r.UpdateStackMetadata(stack); err != nil {
+		if errors.Is(err, errdefs.ErrStaleResource) {
+			r.logger.DebugContext(r.ctx,
+				"refresh: skipping stale stack persist; on-disk generation advanced",
+				"stack", stack.Metadata.Name,
+				"observed", stack.Metadata.Generation)
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // RefreshRealm refreshes the status of a realm by checking cgroup and containerd namespace.
 // Returns the updated realm, whether it was updated, and any error.
 func (r *Exec) RefreshRealm(realm intmodel.Realm) (intmodel.Realm, bool, error) {
@@ -133,10 +188,14 @@ func (r *Exec) RefreshRealm(realm intmodel.Realm) (intmodel.Realm, bool, error) 
 		newStatus.CgroupReady != originalStatus.CgroupReady ||
 		newStatus.ContainerdNamespaceReady != originalStatus.ContainerdNamespaceReady {
 		realm.Status = newStatus
-		if updateErr := r.UpdateRealmMetadata(realm); updateErr != nil {
+		persisted, updateErr := r.persistRealmStatusGuarded(realm)
+		if updateErr != nil {
 			return realm, false, fmt.Errorf("failed to update realm metadata: %w", updateErr)
 		}
-		updated = true
+		// A concurrent spec write advanced the realm's generation past the
+		// refreshed view: the derived status was skipped rather than
+		// clobbering the newer spec, so report nothing updated.
+		updated = persisted
 	}
 
 	return realm, updated, nil
@@ -215,10 +274,13 @@ func (r *Exec) RefreshSpace(space intmodel.Space) (intmodel.Space, bool, error) 
 		newStatus.CgroupPath != originalStatus.CgroupPath ||
 		newStatus.CgroupReady != originalStatus.CgroupReady {
 		space.Status = newStatus
-		if updateErr := r.UpdateSpaceMetadata(space); updateErr != nil {
+		persisted, updateErr := r.persistSpaceStatusGuarded(space)
+		if updateErr != nil {
 			return space, false, fmt.Errorf("failed to update space metadata: %w", updateErr)
 		}
-		updated = true
+		// A concurrent spec write advanced the space's generation past the
+		// refreshed view: skip rather than clobber the newer spec.
+		updated = persisted
 	}
 
 	return space, updated, nil
@@ -263,10 +325,13 @@ func (r *Exec) RefreshStack(stack intmodel.Stack) (intmodel.Stack, bool, error) 
 		newStatus.CgroupPath != originalStatus.CgroupPath ||
 		newStatus.CgroupReady != originalStatus.CgroupReady {
 		stack.Status = newStatus
-		if updateErr := r.UpdateStackMetadata(stack); updateErr != nil {
+		persisted, updateErr := r.persistStackStatusGuarded(stack)
+		if updateErr != nil {
 			return stack, false, fmt.Errorf("failed to update stack metadata: %w", updateErr)
 		}
-		updated = true
+		// A concurrent spec write advanced the stack's generation past the
+		// refreshed view: skip rather than clobber the newer spec.
+		updated = persisted
 	}
 
 	return stack, updated, nil


### PR DESCRIPTION
## Summary

- Extends the guarded-skip persist pattern (`persistCellStatusGuarded`) to the realm/space/stack refresh paths, closing the gap #633 phase-3 left: those three `Update*Metadata` writers now ride a CAS+optimistic-token, so a concurrent spec write during a refresh returns `errdefs.ErrStaleResource`. Before this change the cell path absorbed that as a benign skip while `RefreshRealm`/`RefreshSpace`/`RefreshStack` surfaced it as a hard error — a `result.Errors` line under `Errors:` in `kuke refresh` and a daemon reconcile-loop warning. The race was already functionally correct (no clobber, self-heals next tick, `kuke refresh` still exits 0); this removes the cosmetic/operational noise.
- Adds `persistRealmStatusGuarded` / `persistSpaceStatusGuarded` / `persistStackStatusGuarded`, mirroring `persistCellStatusGuarded`: a stale CAS rejection is logged at debug and returned as `(persisted=false, nil)`, any other error bubbles up unchanged. The three refresh call sites now set `updated = persisted`, so a skipped stale write reports nothing-updated instead of erroring.

### Design call (please push back)

- The cell helper additionally stamps `Status.ObservedGeneration` before persisting. The three new helpers deliberately **do not** — the realm/space/stack refresh paths never stamped ObservedGeneration (only the cell reconcile/refresh path consumes it via `observedGenerationBehind`), and the issue scope is the stale-skip, not adding generation-convergence to those kinds. Kept minimal; flagging in case a reviewer wants the symmetry extended.

## Test plan

- [x] `make test` — full unit suite green, including 3 new tests (`TestPersist{Realm,Space,Stack}StatusGuardedSkipsWhenBehind`) that drive a concurrent spec write to advance the on-disk generation, then assert the guarded persist skips (no clobber, no error) for the stale view and persists for a current observation. Mirrors `TestPersistCellStatusGuardedSkipsWhenBehind`.
- [x] `go build ./...` + `go vet ./internal/controller/...` — clean.
- [x] `pre-commit run` (go-mod-tidy, golangci-lint, addlicense) — passed.
- [x] `make dev-init` **daemon-parity regression guard** — passed identically on both `kuke get realms` and `kuke get realms --no-daemon` views (the bind-mount regression check CLAUDE.md mandates):
  ```
  default      default.kukeon.io      Ready  /kukeon/default
  kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
  ```
- [ ] `make dev-init` **kuketty attach-smoke sub-step** — not green on this dev host; failed differently across two runs (kuketty socket not bound within the 20s window once; a tmpfile-`rename` `ENOENT` during `kuke create stack` the next). Non-deterministic ⇒ environmental flakiness in this sandbox, not a regression: this diff only changes the `ErrStaleResource` branch of the realm/space/stack **refresh** (reconcile) persist path, which is a literal no-op absent a concurrent-spec CAS race; the second failure is in the **create** path (`kuke create stack` → `UpdateStackMetadata` directly, not through the new guarded helpers). Reviewer should confirm the attach smoke on a host without the registry-egress / fs-race flakiness.

Closes #636
