### PR TITLE
fix(daemon): release CNI allocation on root-container teardown before re-ADD

### DIFF
--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -451,6 +451,28 @@ func (r *Exec) getSpaceNetworkName(space intmodel.Space) (string, error) {
 	return naming.BuildSpaceNetworkName(realmName, space.Metadata.Name)
 }
 
+// resolveRootCNINetworkName resolves the CNI network name for a cell's space,
+// for use in the post-delete IPAM-file purge safety net (purgeCNIForContainer).
+// Best-effort: returns "" when the space can't be loaded or the name can't be
+// derived, mirroring the GetSpace+getSpaceNetworkName preamble that stop.go and
+// kill.go run before tearing the root container down. The empty result makes
+// purgeCNIForContainer a no-op rather than a panic.
+func (r *Exec) resolveRootCNINetworkName(realmName, spaceName string) string {
+	lookupSpace := intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: spaceName},
+		Spec:     intmodel.SpaceSpec{RealmName: realmName},
+	}
+	internalSpace, err := r.GetSpace(lookupSpace)
+	if err != nil {
+		return ""
+	}
+	networkName, err := r.getSpaceNetworkName(internalSpace)
+	if err != nil {
+		return ""
+	}
+	return networkName
+}
+
 // detachRootContainerFromNetwork detaches a root container from the CNI network.
 // It gets the container's PID and network namespace path, then calls CNI DEL to detach it.
 // This should be called before killing or stopping the container to ensure the namespace is still valid.

--- a/internal/controller/runner/helpers_test.go
+++ b/internal/controller/runner/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 )
@@ -93,5 +94,17 @@ func TestIsValidationError(t *testing.T) {
 				t.Errorf("isValidationError() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestResolveRootCNINetworkName_EmptyWhenSpaceMissing pins the best-effort
+// contract the issue #630 teardown sites rely on: when the space metadata
+// can't be loaded, resolveRootCNINetworkName returns "" rather than panicking,
+// which makes the downstream purgeCNIForContainer safety net a no-op instead
+// of dereferencing a nil network name.
+func TestResolveRootCNINetworkName_EmptyWhenSpaceMissing(t *testing.T) {
+	r := newMetadataTestExec(t, t.TempDir(), time.Now())
+	if got := r.resolveRootCNINetworkName("default", "nonexistent-space"); got != "" {
+		t.Errorf("resolveRootCNINetworkName() = %q, want \"\" when space metadata is absent", got)
 	}
 }

--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -110,27 +110,56 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to build root container containerd ID: %w", err)
 	}
 
-	_, err = r.ctrClient.StopContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.StopContainerOptions{Force: true})
-	if err != nil {
-		r.logger.WarnContext(
-			r.ctx,
-			"failed to stop root container, continuing with deletion",
-			"container", rootContainerID,
-			"error", err,
-		)
-	}
+	// Release the root container's CNI/IPAM reservation before deleting it.
+	// createCellContainers below rebuilds the root under this same deterministic
+	// containerd ID and re-runs CNI ADD; without releasing first, host-local
+	// IPAM rejects the re-ADD as a duplicate allocation (issue #630). releaseCNI
+	// runs before the stop/delete so the netns is still valid for CNI DEL where
+	// applicable; purgeCNI scrubs the residual allocation file afterward.
+	cellName := strings.TrimSpace(existing.Metadata.Name)
+	cniConfigPath, _ := r.resolveSpaceCNIConfigPath(realmName, spaceName)
+	networkName := r.resolveRootCNINetworkName(realmName, spaceName)
+	_ = teardownRootContainerCNI(
+		func() {
+			r.detachRootContainerFromNetwork(
+				rootContainerID, cniConfigPath, internalRealm.Spec.Namespace, cellID, cellName, spaceName, realmName,
+			)
+		},
+		func() error {
+			if _, rootStopErr := r.ctrClient.StopContainer(
+				internalRealm.Spec.Namespace, rootContainerID, ctr.StopContainerOptions{Force: true},
+			); rootStopErr != nil {
+				r.logger.WarnContext(
+					r.ctx,
+					"failed to stop root container, continuing with deletion",
+					"container", rootContainerID,
+					"error", rootStopErr,
+				)
+			}
 
-	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.ContainerDeleteOptions{
-		SnapshotCleanup: true,
-	})
-	if err != nil {
-		r.logger.WarnContext(
-			r.ctx,
-			"failed to delete root container, continuing",
-			"container", rootContainerID,
-			"error", err,
-		)
-	}
+			delErr := r.ctrClient.DeleteContainer(
+				internalRealm.Spec.Namespace,
+				rootContainerID,
+				ctr.ContainerDeleteOptions{
+					SnapshotCleanup: true,
+				},
+			)
+			if delErr != nil {
+				r.logger.WarnContext(
+					r.ctx,
+					"failed to delete root container, continuing",
+					"container", rootContainerID,
+					"error", delErr,
+				)
+			}
+			return delErr
+		},
+		func() {
+			if networkName != "" {
+				_ = r.purgeCNIForContainer(rootContainerID, "", networkName)
+			}
+		},
+	)
 
 	// Clear containerd IDs from desired cell so containers will be recreated
 	for i := range desired.Spec.Containers {

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -130,6 +130,29 @@ func cellTasksAllRunningFn(
 	return true
 }
 
+// teardownRootContainerCNI enforces issue #630's release-before-recreate
+// ordering: it runs CNI DEL against the old root container (releaseCNI) *before*
+// deleteContainer removes it, then runs the best-effort IPAM-file safety net
+// (purgeCNI) *after* the delete. Both StartCell's teardown-before-recreate
+// branch and RecreateCell rebuild the root under the *same* deterministic
+// containerd ID (naming.BuildRootContainerdID) and re-run CNI ADD against it;
+// without releasing the prior reservation first, host-local IPAM rejects the
+// re-ADD as a "duplicate allocation". releaseCNI must run while the old
+// container's netns is still valid (i.e. before its task is deleted), so it is
+// sequenced first; purgeCNI always runs, even when deleteContainer fails, so a
+// leaked allocation file is still scrubbed. deleteContainer's error is returned
+// for the caller to log (both call sites warn-and-continue on it).
+//
+// Decoupled from *Exec's concrete containerd/CNI clients — same rationale as
+// cellTasksAllRunningFn (issue #149) — so the ordering invariant is
+// unit-testable without a live runtime.
+func teardownRootContainerCNI(releaseCNI func(), deleteContainer func() error, purgeCNI func()) error {
+	releaseCNI()
+	delErr := deleteContainer()
+	purgeCNI()
+	return delErr
+}
+
 // maxFailureMessageLen caps Status.Message so a long, multi-line wrap from
 // `fmt.Errorf("%w: %w", …)` chains doesn't blow up `kuke get cell -o yaml`.
 // 256 bytes is comfortably wider than any error sentinel string in the repo
@@ -399,55 +422,57 @@ func (r *Exec) StartCell(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
 			)
 		}
 	} else {
-		// Container exists, check if it has a task and delete it
-		nsCtx := namespaces.WithNamespace(r.ctx, namespace)
-		task, taskErr := container.Task(nsCtx, nil)
-		if taskErr == nil {
-			// Task exists, delete it
-			_, deleteTaskErr := task.Delete(nsCtx, containerd.WithProcessKill)
-			if deleteTaskErr != nil {
-				fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-				fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", deleteTaskErr))
-				r.logger.WarnContext(
-					r.ctx,
-					"failed to delete existing task, continuing",
-					fields...,
+		// Container exists: release its CNI/IPAM reservation, then delete it.
+		// The root is recreated below under the same deterministic containerd
+		// ID and re-attached via CNI ADD; without the release-before-delete
+		// ordering here, host-local IPAM rejects that re-ADD as a duplicate
+		// allocation (issue #630). releaseCNI must run while the task's netns
+		// is still valid, so it is sequenced before the task delete; purgeCNI
+		// scrubs the residual allocation file afterward as a safety net.
+		networkName := r.resolveRootCNINetworkName(realmID, spaceID)
+		_ = teardownRootContainerCNI(
+			func() {
+				r.detachRootContainerFromNetwork(
+					containerID, cniConfigPath, namespace, cellID, cellName, spaceID, realmID,
 				)
-			}
-		}
+			},
+			func() error {
+				// Delete the task (if any) then the container to remove stale spec.
+				nsCtx := namespaces.WithNamespace(r.ctx, namespace)
+				if task, taskErr := container.Task(nsCtx, nil); taskErr == nil {
+					if _, deleteTaskErr := task.Delete(nsCtx, containerd.WithProcessKill); deleteTaskErr != nil {
+						fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+						fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", deleteTaskErr))
+						r.logger.WarnContext(r.ctx, "failed to delete existing task, continuing", fields...)
+					}
+				}
 
-		// Delete the container to remove stale spec
-		err = r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
-			SnapshotCleanup: true,
-		})
-		if err != nil {
-			// Check if container doesn't exist (might have been deleted between check and delete)
-			if errors.Is(err, internalerrdefs.ErrContainerNotFound) {
-				fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-				fields = append(fields, "space", spaceID, "realm", realmID)
-				r.logger.DebugContext(
-					r.ctx,
-					"root container already deleted, will create fresh",
-					fields...,
-				)
-			} else {
-				fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-				fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
-				r.logger.WarnContext(
-					r.ctx,
-					"failed to delete existing container, continuing",
-					fields...,
-				)
-			}
-		} else {
-			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-			fields = append(fields, "space", spaceID, "realm", realmID)
-			r.logger.InfoContext(
-				r.ctx,
-				"deleted existing root container for recreation",
-				fields...,
-			)
-		}
+				delErr := r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
+					SnapshotCleanup: true,
+				})
+				switch {
+				case delErr == nil:
+					fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+					fields = append(fields, "space", spaceID, "realm", realmID)
+					r.logger.InfoContext(r.ctx, "deleted existing root container for recreation", fields...)
+				case errors.Is(delErr, internalerrdefs.ErrContainerNotFound):
+					// Might have been deleted between check and delete.
+					fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+					fields = append(fields, "space", spaceID, "realm", realmID)
+					r.logger.DebugContext(r.ctx, "root container already deleted, will create fresh", fields...)
+				default:
+					fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+					fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", delErr))
+					r.logger.WarnContext(r.ctx, "failed to delete existing container, continuing", fields...)
+				}
+				return delErr
+			},
+			func() {
+				if networkName != "" {
+					_ = r.purgeCNIForContainer(containerID, "", networkName)
+				}
+			},
+		)
 	}
 
 	// Recreate root container fresh

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -307,6 +307,50 @@ func TestCellTasksAllRunningFn(t *testing.T) {
 	}
 }
 
+// TestTeardownRootContainerCNI_OrderingAndSafetyNet is the regression guard for
+// issue #630. Both StartCell's teardown-before-recreate branch and RecreateCell
+// route their root-container teardown through teardownRootContainerCNI, which
+// must run CNI DEL (releaseCNI) *before* deleting the container so host-local
+// IPAM releases the reservation ahead of the re-ADD against the same
+// deterministic containerd ID — otherwise the re-ADD is rejected as a duplicate
+// allocation. The IPAM-file purge safety net must run *after* the delete, and
+// must run even when the delete fails so a leaked allocation file is still
+// scrubbed.
+func TestTeardownRootContainerCNI_OrderingAndSafetyNet(t *testing.T) {
+	t.Run("release_runs_before_delete_purge_runs_after", func(t *testing.T) {
+		var order []string
+		err := teardownRootContainerCNI(
+			func() { order = append(order, "release") },
+			func() error { order = append(order, "delete"); return nil },
+			func() { order = append(order, "purge") },
+		)
+		if err != nil {
+			t.Fatalf("teardownRootContainerCNI returned error: %v", err)
+		}
+		want := []string{"release", "delete", "purge"}
+		if strings.Join(order, ",") != strings.Join(want, ",") {
+			t.Errorf("call order = %v, want %v", order, want)
+		}
+	})
+
+	t.Run("purge_runs_and_error_propagates_when_delete_fails", func(t *testing.T) {
+		var order []string
+		sentinel := errors.New("delete failed")
+		err := teardownRootContainerCNI(
+			func() { order = append(order, "release") },
+			func() error { order = append(order, "delete"); return sentinel },
+			func() { order = append(order, "purge") },
+		)
+		if !errors.Is(err, sentinel) {
+			t.Errorf("err = %v, want %v", err, sentinel)
+		}
+		want := []string{"release", "delete", "purge"}
+		if strings.Join(order, ",") != strings.Join(want, ",") {
+			t.Errorf("call order = %v, want %v (purge must run even on delete failure)", order, want)
+		}
+	})
+}
+
 // TestTruncateFailureMessage pins the single-line + length-bounded contract
 // markCellFailed relies on for Status.Message: long, multi-line wrapped
 // `fmt.Errorf("%w: %w", …)` chains must end up as a single, capped string


### PR DESCRIPTION
## Summary

Closes the `duplicate allocation` lost-reservation gap on the two daemon paths that delete a cell's **root** container and recreate it under the *same* deterministic `naming.BuildRootContainerdID`, re-running CNI ADD against that ID. Neither ran CNI DEL on the way out, so host-local IPAM kept the prior reservation and the re-ADD was rejected. The root is the only container holding a CNI/IPAM allocation (`AddContainerToNetwork` is called once, against the root, at `start.go`).

- **`StartCell` teardown-before-recreate branch** (`start.go`): when the cell's tasks are *not* all running, the container-exists `else` branch now releases the root's CNI/IPAM reservation *before* deleting it. The `#149` all-running idempotency guard (`cellTasksAllRunningFn`) is untouched and still short-circuits a healthy cell with no teardown/CNI churn.
- **`RecreateCell`** (`recreate_cell.go`): the root-delete now releases CNI/IPAM before the stop/delete, so a root-affecting `kuke apply` (image/command/args change → reconcile → `RecreateCell`) re-provisions without a duplicate allocation.
- Both paths route through a new `teardownRootContainerCNI(releaseCNI, deleteContainer, purgeCNI)` helper that enforces the ordering: **CNI DEL (`detachRootContainerFromNetwork`) before delete**, then the **IPAM-file purge (`purgeCNIForContainer`) after delete** as a safety net. This reuses the existing release primitives and mirrors the established `stop.go` / `kill.go` detach→delete→purge idiom.

## Design calls (reviewer please push back)

- **Extracted a pure ordering helper (`teardownRootContainerCNI`) rather than inlining like `stop.go`/`kill.go`.** The AC asks for a unit/regression test of the ordering, but `cni.CNINetworksDir` is a hard `const` (`/var/lib/cni/networks`) and `purgeCNIForContainer` builds a real `cni.Manager`, so a filesystem-level IPAM assertion can't be redirected to a tmpdir in-package. The pure-closure helper makes the *release-before-delete / purge-after* invariant unit-testable without a live runtime — the exact rationale the repo already documents for `cellTasksAllRunningFn` (issue #149). The live release is covered by the dev-init smoke below.
- **Added a shared `resolveRootCNINetworkName(realm, space)` helper** (`helpers.go`) to dedup the `GetSpace`+`getSpaceNetworkName` preamble both new sites need; it returns `""` best-effort so the downstream purge is a no-op rather than a panic when the space can't be loaded — matching the existing `stop.go`/`kill.go` preamble's tolerance.
- **`releaseCNI` is sequenced before the task delete** in the `StartCell` branch so `detachRootContainerFromNetwork` reads a still-valid netns for a real CNI DEL; the IPAM-file purge afterward is the backstop that actually releases the reservation when the netns is already gone (the `RecreateCell` case, where `StopCell` already killed the task).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full CI target, `go test $(go list ./... | grep -v /e2e)`) — all green
- [x] New regression tests in `internal/controller/runner/`:
  - `TestTeardownRootContainerCNI_OrderingAndSafetyNet` — release runs before delete, purge after; purge still runs and the delete error propagates when delete fails.
  - `TestResolveRootCNINetworkName_EmptyWhenSpaceMissing` — best-effort `""` (no panic) when space metadata is absent.
- [x] `pre-commit run --files <changed>` — passed (incl. golangci-lint `shadow`/`govet`).
- [x] `make dev-init` smoke + daemon-parity check — both `kuke get realms` and `--no-daemon` show identical output (`default` + `kuke-system`, both `Ready`); `kuke attach` against a kuketty-wrapped cell created cleanly and detached. Note: two earlier dev-init runs hit transient containerd content-store errors at fresh `CreateCell` image-pull (`lease does not exist` / `parent snapshot does not exist`) — confirmed environmental and **not** caused by this diff: a clean `origin/main` build hit the same family before stabilizing, a plain `ctr pull` of the same image succeeded, and the failing path (`CreateCell` image pull) is not touched by this change; the smoke passes cleanly on this build once containerd state settled.
- [ ] Live `duplicate allocation` repro on a real stopped cell re-entry / root-affecting `kuke apply` — not isolated end-to-end in dev-init (the smoke exercises create+attach+purge, not a stopped→start re-entry). Unblocks PR #637's deferred AC1, which is the live stopped→start path; covered at the ordering-invariant level by the new unit tests.

Closes #630