### PR TITLE
feat(kuketty): mount ContainerDoc and build TerminalSpec in-wrapper

### DIFF
--- a/cmd/kuketty/main.go
+++ b/cmd/kuketty/main.go
@@ -16,9 +16,10 @@
 
 // kuketty is the kukeon-owned terminal wrapper that runs inside an attachable
 // container in place of sbsh. It reads its runtime configuration from a
-// bind-mounted api.TerminalDoc (no CLI flags beyond an optional --config
-// override) and serves the JSON-RPC + SCM_RIGHTS attach protocol via sbsh's
-// public pkg/terminal/server facade, so `kuke attach` consumes the same
+// bind-mounted kukeon ContainerDoc (no CLI flags beyond an optional --config
+// override), builds the sbsh TerminalSpec from kukeon's own ContainerSpec
+// (issue #641), and serves the JSON-RPC + SCM_RIGHTS attach protocol via
+// sbsh's public pkg/terminal/server facade, so `kuke attach` consumes the same
 // wire protocol it does on the host.
 //
 // kuketty is a standalone binary — not argv[0]-dispatched from the kuke
@@ -41,15 +42,15 @@ import (
 	"os/signal"
 	"syscall"
 
-	sbshapi "github.com/eminwux/sbsh/pkg/api"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	sbshlogging "github.com/eminwux/sbsh/pkg/logging"
 	sbshserver "github.com/eminwux/sbsh/pkg/terminal/server"
 )
 
 // defaultConfigPath is the fixed in-container path of the kukeond-rendered
-// api.TerminalDoc. The daemon bind-mounts the per-container metadata file
-// over this path at OCI spec build time (see internal/ctr/attachable.go).
-// Kept in sync with ctr.AttachableMetadataPath.
+// ContainerDoc. The daemon bind-mounts the per-container metadata file over
+// this path at OCI spec build time (see internal/ctr/attachable.go). Kept in
+// sync with ctr.AttachableMetadataPath.
 const defaultConfigPath = "/.kukeon/kuketty/metadata.json"
 
 // exitCodeUsage is returned when invocation is malformed (e.g. unknown flag,
@@ -85,22 +86,17 @@ type usageError struct{ msg string }
 
 func (e *usageError) Error() string { return e.msg }
 
-// run parses the (single optional) flag, loads the TerminalDoc from disk,
-// binds the control socket, and hands the listener + spec to sbsh's
-// server facade. Returns the terminating cause; main() maps the error
-// class to an exit code.
+// run parses the (single optional) flag, loads the ContainerDoc from disk,
+// builds the sbsh TerminalSpec from kukeon's own ContainerSpec, binds the
+// control socket, and hands the listener + spec to sbsh's server facade.
+// Returns the terminating cause; main() maps the error class to an exit code.
 func run(args []string) error {
 	configPath, err := parseArgs(args)
 	if err != nil {
 		return err
 	}
 
-	doc, err := loadTerminalDoc(configPath)
-	if err != nil {
-		return err
-	}
-
-	listener, err := claimSocketListener(doc.Spec.SocketFile)
+	doc, err := loadContainerDoc(configPath)
 	if err != nil {
 		return err
 	}
@@ -119,12 +115,26 @@ func run(args []string) error {
 		}
 	}()
 
-	logger, closeLogger, err := openTerminalLogger(doc.Spec.LogFile, doc.Spec.LogLevel)
+	// Build the sbsh TerminalSpec from kukeon's ContainerSpec (issue #641).
+	// A bootstrap stderr logger covers the build step; the file-backed logger
+	// kuketty serves under is opened from the resulting spec below.
+	buildLogger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	spec, err := buildTerminalSpec(ctx, buildLogger, doc.Spec)
+	if err != nil {
+		return err
+	}
+
+	listener, err := claimSocketListener(spec.SocketFile)
+	if err != nil {
+		return err
+	}
+
+	logger, closeLogger, err := openTerminalLogger(spec.LogFile, spec.LogLevel)
 	if err != nil {
 		return err
 	}
 	defer closeLogger()
-	srv, err := sbshserver.New(&doc.Spec, logger)
+	srv, err := sbshserver.New(spec, logger)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}
@@ -143,7 +153,7 @@ func parseArgs(args []string) (string, error) {
 	fs := flag.NewFlagSet("kuketty", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	configPath := fs.String("config", defaultConfigPath,
-		"path to the kuketty terminal config (an api.TerminalDoc JSON document); "+
+		"path to the kuketty config (a kukeon ContainerDoc JSON document); "+
 			"normally bind-mounted by kukeond at "+defaultConfigPath)
 	if err := fs.Parse(args); err != nil {
 		return "", &usageError{msg: err.Error()}
@@ -156,29 +166,28 @@ func parseArgs(args []string) (string, error) {
 	return *configPath, nil
 }
 
-// loadTerminalDoc reads the bind-mounted config file, decodes it as an
-// api.TerminalDoc, and validates the APIVersion + Kind discriminator so a
-// kuketty binary that loaded a malformed (or wrong-schema) file refuses
-// cleanly rather than silently misinterpreting fields.
-func loadTerminalDoc(path string) (*sbshapi.TerminalDoc, error) {
+// loadContainerDoc reads the bind-mounted config file, decodes it as a kukeon
+// ContainerDoc, and validates the APIVersion + Kind discriminator so a kuketty
+// binary that loaded a malformed (or wrong-schema) file refuses cleanly rather
+// than silently misinterpreting fields. The socket path is no longer validated
+// here — kuketty derives it from the kukeon contract constant when it builds
+// the TerminalSpec (issue #641), so it is never read off the doc.
+func loadContainerDoc(path string) (*v1beta1.ContainerDoc, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read config %s: %w", path, err)
 	}
-	var doc sbshapi.TerminalDoc
+	var doc v1beta1.ContainerDoc
 	if err = json.Unmarshal(data, &doc); err != nil {
 		return nil, fmt.Errorf("parse config %s: %w", path, err)
 	}
-	if doc.APIVersion != sbshapi.APIVersionV1Beta1 {
+	if doc.APIVersion != v1beta1.APIVersionV1Beta1 {
 		return nil, fmt.Errorf("config %s: apiVersion %q, want %q",
-			path, doc.APIVersion, sbshapi.APIVersionV1Beta1)
+			path, doc.APIVersion, v1beta1.APIVersionV1Beta1)
 	}
-	if doc.Kind != sbshapi.KindTerminal {
+	if doc.Kind != v1beta1.KindContainer {
 		return nil, fmt.Errorf("config %s: kind %q, want %q",
-			path, doc.Kind, sbshapi.KindTerminal)
-	}
-	if doc.Spec.SocketFile == "" {
-		return nil, fmt.Errorf("config %s: spec.socketIO is required", path)
+			path, doc.Kind, v1beta1.KindContainer)
 	}
 	return &doc, nil
 }

--- a/cmd/kuketty/main_test.go
+++ b/cmd/kuketty/main_test.go
@@ -24,7 +24,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	sbshapi "github.com/eminwux/sbsh/pkg/api"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 // TestParseArgs_Default locks in the no-flags contract: with zero argv
@@ -86,108 +86,89 @@ func TestParseArgs_UnknownFlag(t *testing.T) {
 	}
 }
 
-// TestLoadTerminalDoc_Happy locks the on-disk schema kukeon's render path
-// commits to: an api.TerminalDoc with APIVersion=sbsh/v1beta1 and
-// Kind=Terminal. Round-trips a minimal doc and confirms the decoded
-// spec values survive verbatim.
-func TestLoadTerminalDoc_Happy(t *testing.T) {
+// TestLoadContainerDoc_Happy locks the on-disk schema the daemon's render
+// path commits to after issue #641: a kukeon ContainerDoc with
+// APIVersion=v1beta1 and Kind=Container. Round-trips a minimal doc and
+// confirms the decoded spec values survive verbatim.
+func TestLoadContainerDoc_Happy(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "metadata.json")
-	want := sbshapi.TerminalDoc{
-		APIVersion: sbshapi.APIVersionV1Beta1,
-		Kind:       sbshapi.KindTerminal,
-		Metadata:   sbshapi.TerminalMetadata{Name: "c1"},
-		Spec: sbshapi.TerminalSpec{
-			Command:     "/bin/sh",
-			CommandArgs: []string{"-c", "echo hello"},
-			SocketFile:  "/run/kukeon/tty/socket",
-			RunPath:     "/run/kukeon/tty",
+	want := v1beta1.ContainerDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindContainer,
+		Metadata:   v1beta1.ContainerMetadata{Name: "c1"},
+		Spec: v1beta1.ContainerSpec{
+			ID:      "c1",
+			Command: "/bin/sh",
+			Args:    []string{"-c", "echo hello"},
 		},
 	}
 	writeDoc(t, path, want)
 
-	got, err := loadTerminalDoc(path)
+	got, err := loadContainerDoc(path)
 	if err != nil {
-		t.Fatalf("loadTerminalDoc: %v", err)
+		t.Fatalf("loadContainerDoc: %v", err)
 	}
 	if got.Spec.Command != want.Spec.Command {
 		t.Errorf("Spec.Command = %q, want %q", got.Spec.Command, want.Spec.Command)
 	}
-	if got.Spec.SocketFile != want.Spec.SocketFile {
-		t.Errorf("Spec.SocketFile = %q, want %q", got.Spec.SocketFile, want.Spec.SocketFile)
+	if len(got.Spec.Args) != len(want.Spec.Args) {
+		t.Fatalf("Spec.Args = %v, want %v", got.Spec.Args, want.Spec.Args)
 	}
 	if got.Metadata.Name != want.Metadata.Name {
 		t.Errorf("Metadata.Name = %q, want %q", got.Metadata.Name, want.Metadata.Name)
 	}
 }
 
-// TestLoadTerminalDoc_WrongAPIVersion locks the schema discriminator: a
+// TestLoadContainerDoc_WrongAPIVersion locks the schema discriminator: a
 // document tagged with the wrong apiVersion (e.g., a stale kukeon-side
 // schema rendered by a daemon that hasn't been re-built) must fail loudly
-// rather than being silently interpreted as a Terminal.
-func TestLoadTerminalDoc_WrongAPIVersion(t *testing.T) {
+// rather than being silently interpreted.
+func TestLoadContainerDoc_WrongAPIVersion(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "metadata.json")
-	doc := sbshapi.TerminalDoc{
+	doc := v1beta1.ContainerDoc{
 		APIVersion: "kuketty.kukeon.io/v1alpha1",
-		Kind:       sbshapi.KindTerminal,
-		Spec:       sbshapi.TerminalSpec{SocketFile: "/run/kukeon/tty/socket"},
+		Kind:       v1beta1.KindContainer,
+		Spec:       v1beta1.ContainerSpec{ID: "c1"},
 	}
 	writeDoc(t, path, doc)
-	_, err := loadTerminalDoc(path)
+	_, err := loadContainerDoc(path)
 	if err == nil {
-		t.Fatalf("loadTerminalDoc returned nil, want apiVersion error")
+		t.Fatalf("loadContainerDoc returned nil, want apiVersion error")
 	}
 }
 
-// TestLoadTerminalDoc_WrongKind catches the case where the apiVersion is
-// correct (sbsh/v1beta1) but the kind is e.g. TerminalProfile — kuketty
-// must refuse rather than apply profile semantics to a Terminal-shaped
-// runner.
-func TestLoadTerminalDoc_WrongKind(t *testing.T) {
+// TestLoadContainerDoc_WrongKind catches the case where the apiVersion is
+// correct (v1beta1) but the kind is e.g. Cell — kuketty must refuse rather
+// than apply Container semantics to a different-shaped doc.
+func TestLoadContainerDoc_WrongKind(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "metadata.json")
-	doc := sbshapi.TerminalDoc{
-		APIVersion: sbshapi.APIVersionV1Beta1,
-		Kind:       sbshapi.KindTerminalProfile,
-		Spec:       sbshapi.TerminalSpec{SocketFile: "/run/kukeon/tty/socket"},
+	doc := v1beta1.ContainerDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Spec:       v1beta1.ContainerSpec{ID: "c1"},
 	}
 	writeDoc(t, path, doc)
-	_, err := loadTerminalDoc(path)
+	_, err := loadContainerDoc(path)
 	if err == nil {
-		t.Fatalf("loadTerminalDoc returned nil, want kind error")
+		t.Fatalf("loadContainerDoc returned nil, want kind error")
 	}
 }
 
-// TestLoadTerminalDoc_MissingSocket rejects a doc whose spec carries no
-// SocketFile — without it kuketty has nothing to bind, and a default
-// fallback would silently bind a path the host has no bind-mount for.
-func TestLoadTerminalDoc_MissingSocket(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "metadata.json")
-	doc := sbshapi.TerminalDoc{
-		APIVersion: sbshapi.APIVersionV1Beta1,
-		Kind:       sbshapi.KindTerminal,
-	}
-	writeDoc(t, path, doc)
-	_, err := loadTerminalDoc(path)
-	if err == nil {
-		t.Fatalf("loadTerminalDoc returned nil, want spec.socketIO error")
-	}
-}
-
-// TestLoadTerminalDoc_Malformed locks the json-parse error path so a
+// TestLoadContainerDoc_Malformed locks the json-parse error path so a
 // half-written file (crashed renderer) produces a clean failure rather
-// than a silently-zero TerminalDoc.
-func TestLoadTerminalDoc_Malformed(t *testing.T) {
+// than a silently-zero ContainerDoc.
+func TestLoadContainerDoc_Malformed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "metadata.json")
 	if err := os.WriteFile(path, []byte("{ not json"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	_, err := loadTerminalDoc(path)
+	_, err := loadContainerDoc(path)
 	if err == nil {
-		t.Fatalf("loadTerminalDoc returned nil, want parse error")
+		t.Fatalf("loadContainerDoc returned nil, want parse error")
 	}
 }
 
@@ -230,7 +211,7 @@ func TestIsCleanShutdown(t *testing.T) {
 	}
 }
 
-func writeDoc(t *testing.T, path string, doc sbshapi.TerminalDoc) {
+func writeDoc(t *testing.T, path string, doc v1beta1.ContainerDoc) {
 	t.Helper()
 	data, err := json.Marshal(doc)
 	if err != nil {

--- a/cmd/kuketty/spec.go
+++ b/cmd/kuketty/spec.go
@@ -1,0 +1,221 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	sbshapi "github.com/eminwux/sbsh/pkg/api"
+	sbshbuilder "github.com/eminwux/sbsh/pkg/builder"
+)
+
+// Reserved in-container paths and modes kuketty claims when it builds the sbsh
+// TerminalSpec from the mounted ContainerDoc (issue #641). These are kukeon
+// contract constants — the in-container layout the daemon's bind mounts
+// produce — so they live on both sides by construction rather than travelling
+// in the doc. Kept in sync with the Attachable* constants in
+// internal/ctr/attachable.go (kuketty cannot import internal/ctr without
+// dragging in the containerd/gRPC closure that issue #165 keeps it clear of —
+// the same reason main.go's defaultConfigPath duplicates ctr.AttachableMetadataPath).
+const (
+	// attachableTTYDir is sbsh's per-terminal run path inside the container;
+	// the daemon bind-mounts the per-container tty directory here. Mirrors
+	// ctr.AttachableTTYDir.
+	attachableTTYDir = "/run/kukeon/tty"
+
+	// attachableSocketPath is where kuketty listens for the attach control
+	// connection. Mirrors ctr.AttachableSocketPath.
+	attachableSocketPath = attachableTTYDir + "/socket"
+
+	// attachableCapturePath is where sbsh writes the workload capture
+	// transcript. Mirrors ctr.AttachableCapturePath.
+	attachableCapturePath = attachableTTYDir + "/capture"
+
+	// attachableKukettyLogPath is the default in-container path of kuketty's
+	// own slog output, peer to the socket/capture inodes inside the tty bind
+	// mount. Mirrors ctr.AttachableKukettyLogPath
+	// (= AttachableTTYDir + "/" + consts.KukeonContainerKukettyLogFile).
+	attachableKukettyLogPath = attachableTTYDir + "/kuketty.log"
+
+	// attachableSocketMode / attachableCaptureMode / attachableLogFileMode are
+	// the octal modes applied to the respective inodes when a kukeon group GID
+	// is configured. Mirror ctr.AttachableSocketMode / AttachableCaptureMode /
+	// AttachableLogFileMode.
+	attachableSocketMode  = "0660"
+	attachableCaptureMode = "0640"
+	attachableLogFileMode = "0640"
+)
+
+// buildTerminalSpec is the ContainerSpec -> sbsh TerminalSpec transform that
+// used to live daemon-side in the runner's writeKukettyMetadata. Moving it
+// into kuketty (issue #641) lets the daemon mount kukeon's own ContainerDoc
+// instead of a pre-rendered sbsh TerminalDoc, so the crew-absorption layers
+// (#617 repos, #635 run-once stages) can act on kukeon's spec inside the
+// container and report into ContainerStatus without bolting fields onto the
+// external sbsh type.
+//
+// The transform is a pure ContainerSpec -> TerminalSpec mapping: every input
+// it needs is either a kukeon contract constant kuketty knows directly (the
+// fixed socket/capture/log paths and modes above) or a value the daemon
+// resolved and stamped into the doc — the resolved workload argv in
+// Spec.Command/Spec.Args, the kukeon-group GID in Spec.KukeonGroupGID, and the
+// resolved log level in Spec.Tty.LogLevel. kuketty applies no daemon-side
+// defaulting of its own.
+func buildTerminalSpec(
+	ctx context.Context,
+	logger *slog.Logger,
+	spec v1beta1.ContainerSpec,
+) (*sbshapi.TerminalSpec, error) {
+	kukeonGroupGID := spec.KukeonGroupGID
+
+	prompt := ""
+	if spec.Tty != nil {
+		prompt = spec.Tty.Prompt
+	}
+
+	opts := []sbshbuilder.TerminalOption{
+		sbshbuilder.WithSocketFile(attachableSocketPath),
+		// Capture file is anchored to the kukeon-controlled per-container tty
+		// dir so `kuke log` (which tails ContainerCapturePath on the host) and
+		// the in-container writer see the same inode through the directory bind
+		// mount. Without an explicit WithCaptureFile, sbsh's inline builder
+		// derives a capture path from runPath + ID that would land outside the
+		// bind-mount, hiding the transcript from the host.
+		sbshbuilder.WithCaptureFile(attachableCapturePath),
+		// Spec.Prompt + Spec.SetPrompt are stamped from the cell's inline
+		// Tty.Prompt with no profile loader involved (#494): an empty prompt
+		// pairs with DisableSetPrompt(true) so a non-shell workload (nginx,
+		// python) never receives a literal `export PS1=…` on stdin; a non-empty
+		// prompt flips SetPrompt on (sbsh's `!DisableSetPrompt` rule).
+		sbshbuilder.WithPrompt(prompt),
+		sbshbuilder.WithDisableSetPrompt(prompt == ""),
+		// Spec.EnvInherit=true tells sbsh's terminal runner to forward
+		// kuketty's os.Environ() (which is the container's OCI Process.Env —
+		// user-supplied containerSpec.Env merged with kukeon's KUKEON_* identity
+		// vars at ctr.BuildContainerSpec) to the workload child. Without it,
+		// sbsh's runner spawns the workload with only HOME + SBSH_* set
+		// (sbsh@v0.11.2/internal/terminal/terminalrunner/terminal.go:54) — every
+		// user env entry and every KUKEON_* entry gets stripped at the
+		// kuketty → workload boundary. Pinned by the comprehensive transform
+		// test so a future refactor cannot drop it (#494).
+		sbshbuilder.WithEnvInherit(true),
+	}
+	if spec.Tty != nil && len(spec.Tty.OnInit) > 0 {
+		// Inline OnInit (#494): map the cell's TtyStage{Script} entries to
+		// sbsh's api.ExecStep{Script}.
+		opts = append(opts, sbshbuilder.WithOnInit(ttyStagesToExecSteps(spec.Tty.OnInit)))
+	}
+	if mode := modeIfGroupSet(kukeonGroupGID, attachableSocketMode); mode != "" {
+		opts = append(opts, sbshbuilder.WithSocketMode(mode))
+	}
+	if mode := modeIfGroupSet(kukeonGroupGID, attachableCaptureMode); mode != "" {
+		opts = append(opts, sbshbuilder.WithCaptureMode(mode))
+	}
+	if kukeonGroupGID > 0 {
+		opts = append(opts, sbshbuilder.WithSocketGID(kukeonGroupGID))
+		opts = append(opts, sbshbuilder.WithCaptureGID(kukeonGroupGID))
+	}
+	// Kuketty's own slog output is always-on at a daemon-controlled path by
+	// default (peer to socket/capture inside the tty bind mount). A cell may
+	// pin Tty.LogFile to an alternate in-container path; kuketty honors it
+	// verbatim (#599).
+	opts = append(opts, sbshbuilder.WithLogFile(resolveTtyLogFile(spec.Tty)))
+	if mode := modeIfGroupSet(kukeonGroupGID, attachableLogFileMode); mode != "" {
+		opts = append(opts, sbshbuilder.WithLogFileMode(mode))
+	}
+	if kukeonGroupGID > 0 {
+		opts = append(opts, sbshbuilder.WithLogFileGID(kukeonGroupGID))
+	}
+	// The daemon resolved the per-container → server-config → "info" log-level
+	// chain and stamped the result onto Tty.LogLevel; kuketty reads it
+	// verbatim (sbsh's NewFileLogger rejects an empty level).
+	opts = append(opts, sbshbuilder.WithLogLevel(resolveTtyLogLevel(spec.Tty)))
+	if argv := workloadArgv(spec); len(argv) > 0 {
+		opts = append(opts, sbshbuilder.WithCommand(argv))
+	}
+
+	terminalSpec, err := sbshbuilder.BuildTerminalSpec(ctx, logger, attachableTTYDir, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("build kuketty terminal spec: %w", err)
+	}
+	return terminalSpec, nil
+}
+
+// workloadArgv reconstructs the resolved workload argv the daemon stamped into
+// Spec.Command / Spec.Args. An empty Command means the args-wrap captured no
+// resolved Process.Args (image with no ENTRYPOINT/CMD and no override); the
+// caller then leaves sbsh's inline-builder default (/bin/bash -i) in place.
+func workloadArgv(spec v1beta1.ContainerSpec) []string {
+	if spec.Command == "" {
+		return nil
+	}
+	return append([]string{spec.Command}, spec.Args...)
+}
+
+// resolveTtyLogFile returns the in-container path kuketty's slog output lands
+// at: the operator-pinned Tty.LogFile when set, else the daemon-controlled
+// default peer to the capture inode inside the tty bind mount. The always-on
+// invariant holds either way — the return is never empty, so kuketty's
+// openTerminalLogger never falls through to the discard logger (#599).
+func resolveTtyLogFile(t *v1beta1.ContainerTty) string {
+	if t != nil && t.LogFile != "" {
+		return t.LogFile
+	}
+	return attachableKukettyLogPath
+}
+
+// resolveTtyLogLevel reads the log level the daemon resolved and stamped onto
+// Tty.LogLevel. The "info" fallback is a defensive guard against a malformed
+// doc (a nil Tty or empty level) — not daemon-side defaulting: the daemon owns
+// the per-container → server-config → "info" chain in writeKukettyDoc and
+// always stamps a non-empty value. sbsh's NewFileLogger rejects an empty level.
+func resolveTtyLogLevel(t *v1beta1.ContainerTty) string {
+	if t != nil && t.LogLevel != "" {
+		return t.LogLevel
+	}
+	return "info"
+}
+
+// ttyStagesToExecSteps maps the cell's inline Tty.OnInit entries into sbsh's
+// api.ExecStep slice. Each stage carries only Script today; sbsh's ExecStep
+// also supports Env, but the cell schema does not surface it yet (a future
+// TtyStage knob lands here without touching the transform).
+func ttyStagesToExecSteps(in []v1beta1.TtyStage) []sbshapi.ExecStep {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]sbshapi.ExecStep, len(in))
+	for i, s := range in {
+		out[i] = sbshapi.ExecStep{Script: s.Script}
+	}
+	return out
+}
+
+// modeIfGroupSet returns the octal-mode string only when the kukeon group GID
+// is configured; otherwise empty so kuketty applies the OS-default
+// (umask-clipped) mode on the inode the mode applies to (socket, capture file,
+// log file). Matches the legacy 0o600-owner-only fallback when no kukeon group
+// exists.
+func modeIfGroupSet(gid int, mode string) string {
+	if gid > 0 {
+		return mode
+	}
+	return ""
+}

--- a/cmd/kuketty/spec_test.go
+++ b/cmd/kuketty/spec_test.go
@@ -1,0 +1,437 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"reflect"
+	"testing"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	sbshapi "github.com/eminwux/sbsh/pkg/api"
+)
+
+// buildSpec runs the transform under test against a discard logger and fails
+// the test on error. The transform moved into kuketty in issue #641 (it used
+// to live daemon-side as the runner's writeKukettyMetadata); these tests are
+// the ported coverage the AC requires.
+func buildSpec(t *testing.T, spec v1beta1.ContainerSpec) *sbshapi.TerminalSpec {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	out, err := buildTerminalSpec(context.Background(), logger, spec)
+	if err != nil {
+		t.Fatalf("buildTerminalSpec: %v", err)
+	}
+	return out
+}
+
+// TestBuildTerminalSpec_KukeonGroupSet locks the TerminalSpec the transform
+// produces when the daemon stamped a kukeon-group GID into Spec.KukeonGroupGID:
+// socket/capture/log mode + gid are filled in so kuketty applies the
+// kukeon-group ownership the daemon used to fold into the rendered spec, and
+// the resolved workload argv lands in Spec.Command / Spec.CommandArgs.
+func TestBuildTerminalSpec_KukeonGroupSet(t *testing.T) {
+	const kukeonGID = 986
+	spec := v1beta1.ContainerSpec{
+		ID:             "c1",
+		Command:        "/bin/sh",
+		Args:           []string{"-c", "echo hello"},
+		KukeonGroupGID: kukeonGID,
+		Tty:            &v1beta1.ContainerTty{LogLevel: "info"},
+	}
+
+	out := buildSpec(t, spec)
+
+	if out.SocketFile != attachableSocketPath {
+		t.Errorf("SocketFile = %q, want %q", out.SocketFile, attachableSocketPath)
+	}
+	if out.RunPath != attachableTTYDir {
+		t.Errorf("RunPath = %q, want %q", out.RunPath, attachableTTYDir)
+	}
+	if out.Command != "/bin/sh" {
+		t.Errorf("Command = %q, want /bin/sh", out.Command)
+	}
+	wantArgs := []string{"-c", "echo hello"}
+	if !reflect.DeepEqual(out.CommandArgs, wantArgs) {
+		t.Errorf("CommandArgs = %v, want %v", out.CommandArgs, wantArgs)
+	}
+	if out.SocketMode.Perm() != 0o660 {
+		t.Errorf("SocketMode = %v, want perm 0660", out.SocketMode)
+	}
+	if out.SocketGID == nil || *out.SocketGID != kukeonGID {
+		t.Errorf("SocketGID = %v, want pointer to %d", out.SocketGID, kukeonGID)
+	}
+	if out.CaptureFile != attachableCapturePath {
+		t.Errorf("CaptureFile = %q, want %q", out.CaptureFile, attachableCapturePath)
+	}
+	if out.CaptureMode.Perm() != 0o640 {
+		t.Errorf("CaptureMode = %v, want perm 0640", out.CaptureMode)
+	}
+	if out.CaptureGID == nil || *out.CaptureGID != kukeonGID {
+		t.Errorf("CaptureGID = %v, want pointer to %d", out.CaptureGID, kukeonGID)
+	}
+	if out.LogFile != attachableKukettyLogPath {
+		t.Errorf("LogFile = %q, want %q", out.LogFile, attachableKukettyLogPath)
+	}
+	if out.LogFileMode.Perm() != 0o640 {
+		t.Errorf("LogFileMode perm = %#o, want 0640", out.LogFileMode.Perm())
+	}
+	if out.LogFileGID == nil || *out.LogFileGID != kukeonGID {
+		t.Errorf("LogFileGID = %v, want pointer to %d", out.LogFileGID, kukeonGID)
+	}
+	if out.LogLevel != "info" {
+		t.Errorf("LogLevel = %q, want info", out.LogLevel)
+	}
+	if out.SetPrompt {
+		t.Errorf("SetPrompt = true, want false (no prompt)")
+	}
+}
+
+// TestBuildTerminalSpec_NoKukeonGroup locks the legacy fallback: with no
+// kukeon group (GID 0), neither mode nor gid is set on the socket / capture /
+// log inodes so sbsh's runner leaves OS-default (umask-clipped) permissions —
+// matching the sbsh wrapper's behavior on a host with no kukeon group. The
+// capture/log file paths are still anchored to the kukeon-controlled tty dir.
+func TestBuildTerminalSpec_NoKukeonGroup(t *testing.T) {
+	out := buildSpec(t, v1beta1.ContainerSpec{ID: "c1", Command: "/bin/sh"})
+
+	if out.SocketMode.Perm() != 0 {
+		t.Errorf("SocketMode perm = %#o, want 0 (no kukeon group)", out.SocketMode.Perm())
+	}
+	if out.SocketGID != nil {
+		t.Errorf("SocketGID = %v, want nil (no kukeon group)", out.SocketGID)
+	}
+	if out.CaptureFile != attachableCapturePath {
+		t.Errorf("CaptureFile = %q, want %q", out.CaptureFile, attachableCapturePath)
+	}
+	if out.CaptureMode.Perm() != 0 {
+		t.Errorf("CaptureMode perm = %#o, want 0 (no kukeon group)", out.CaptureMode.Perm())
+	}
+	if out.CaptureGID != nil {
+		t.Errorf("CaptureGID = %v, want nil (no kukeon group)", out.CaptureGID)
+	}
+	if out.LogFile != attachableKukettyLogPath {
+		t.Errorf("LogFile = %q, want %q (always-on)", out.LogFile, attachableKukettyLogPath)
+	}
+	if out.LogFileMode.Perm() != 0 {
+		t.Errorf("LogFileMode perm = %#o, want 0 (no kukeon group)", out.LogFileMode.Perm())
+	}
+	if out.LogFileGID != nil {
+		t.Errorf("LogFileGID = %v, want nil (no kukeon group)", out.LogFileGID)
+	}
+}
+
+// TestBuildTerminalSpec_KukettyLogAlwaysOn locks issue #599's always-on
+// kuketty-process log: regardless of cell YAML, every Attachable container
+// renders Spec.LogFile pointing at the daemon-controlled default path (peer to
+// socket/capture inside the per-container tty bind mount). The mode + gid track
+// the kukeon-group config.
+func TestBuildTerminalSpec_KukettyLogAlwaysOn(t *testing.T) {
+	cases := []struct {
+		name      string
+		kukeonGID int
+		tty       *v1beta1.ContainerTty
+		wantMode  uint32
+		wantGID   *int
+	}{
+		{"no Tty block: log still rendered", 986, nil, 0o640, intPtr(986)},
+		{
+			"Tty without LogLevel: log still rendered",
+			986,
+			&v1beta1.ContainerTty{Prompt: `claude> `},
+			0o640,
+			intPtr(986),
+		},
+		{"no kukeon group: log path set, mode+gid zero", 0, nil, 0, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := buildSpec(
+				t,
+				v1beta1.ContainerSpec{ID: "c1", Command: "/bin/sh", KukeonGroupGID: tc.kukeonGID, Tty: tc.tty},
+			)
+			if out.LogFile != attachableKukettyLogPath {
+				t.Errorf("LogFile = %q, want %q (always-on)", out.LogFile, attachableKukettyLogPath)
+			}
+			if uint32(out.LogFileMode.Perm()) != tc.wantMode {
+				t.Errorf("LogFileMode perm = %#o, want %#o", out.LogFileMode.Perm(), tc.wantMode)
+			}
+			switch {
+			case tc.wantGID != nil && (out.LogFileGID == nil || *out.LogFileGID != *tc.wantGID):
+				t.Errorf("LogFileGID = %v, want pointer to %d", out.LogFileGID, *tc.wantGID)
+			case tc.wantGID == nil && out.LogFileGID != nil:
+				t.Errorf("LogFileGID = %v, want nil", out.LogFileGID)
+			}
+		})
+	}
+}
+
+// TestBuildTerminalSpec_LogLevelVerbatim locks the post-#641 contract that
+// kuketty reads the level the daemon resolved and stamped onto Tty.LogLevel
+// verbatim — no defaulting of its own beyond the defensive empty→"info" guard
+// for a malformed doc. The per-container → server-config → "info" resolution
+// chain now lives daemon-side (see the runner test).
+func TestBuildTerminalSpec_LogLevelVerbatim(t *testing.T) {
+	cases := []struct {
+		name      string
+		tty       *v1beta1.ContainerTty
+		wantLevel string
+	}{
+		{"nil Tty: defensive info", nil, "info"},
+		{"empty LogLevel: defensive info", &v1beta1.ContainerTty{Prompt: "x> "}, "info"},
+		{"debug verbatim", &v1beta1.ContainerTty{LogLevel: "debug"}, "debug"},
+		{"warn verbatim", &v1beta1.ContainerTty{LogLevel: "warn"}, "warn"},
+		{"error verbatim", &v1beta1.ContainerTty{LogLevel: "error"}, "error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := buildSpec(t, v1beta1.ContainerSpec{ID: "c1", Command: "/bin/sh", Tty: tc.tty})
+			if out.LogLevel != tc.wantLevel {
+				t.Errorf("LogLevel = %q, want %q", out.LogLevel, tc.wantLevel)
+			}
+		})
+	}
+}
+
+// TestBuildTerminalSpec_LogFileOverride locks #599's operator-override path:
+// when a cell pins Tty.LogFile to a custom in-container location, the transform
+// stamps it verbatim — no rewriting, no anchoring to the bind mount. Default
+// (LogFile empty) resolves to the daemon-controlled default.
+func TestBuildTerminalSpec_LogFileOverride(t *testing.T) {
+	cases := []struct {
+		name    string
+		tty     *v1beta1.ContainerTty
+		wantLog string
+	}{
+		{"no Tty: daemon default", nil, attachableKukettyLogPath},
+		{"empty LogFile: daemon default", &v1beta1.ContainerTty{Prompt: "x> "}, attachableKukettyLogPath},
+		{
+			"override inside bind mount",
+			&v1beta1.ContainerTty{LogFile: attachableTTYDir + "/custom.log"},
+			attachableTTYDir + "/custom.log",
+		},
+		{
+			"override outside bind mount",
+			&v1beta1.ContainerTty{LogFile: "/var/log/sbsh-debug.log"},
+			"/var/log/sbsh-debug.log",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := buildSpec(t, v1beta1.ContainerSpec{ID: "c1", Command: "/bin/sh", KukeonGroupGID: 986, Tty: tc.tty})
+			if out.LogFile != tc.wantLog {
+				t.Errorf("LogFile = %q, want %q", out.LogFile, tc.wantLog)
+			}
+			if out.LogFile == "" {
+				t.Errorf("LogFile is empty; always-on invariant from #599 broken")
+			}
+		})
+	}
+}
+
+// ttyFieldsCoveredByMapping is the structural half of #493's "every Tty field
+// must map" guard, ported to kuketty (which now owns the transform and reads
+// the v1beta1 schema). It enumerates v1beta1.ContainerTty via reflection and
+// fails when a declared field is missing from mapperedFields, or when
+// mapperedFields carries a stale entry the struct no longer declares.
+//
+// New fields landing on v1beta1.ContainerTty must touch two places to keep the
+// test green: add the name to mapperedFields here, and wire it through
+// buildTerminalSpec with an assertion in TestBuildTerminalSpec_AllTtyFieldsMap.
+func ttyFieldsCoveredByMapping(t *testing.T) {
+	t.Helper()
+	mapperedFields := map[string]struct{}{
+		"LogFile":  {},
+		"LogLevel": {},
+		"OnInit":   {},
+		"Prompt":   {},
+	}
+	typ := reflect.TypeOf(v1beta1.ContainerTty{})
+	declared := make(map[string]struct{}, typ.NumField())
+	for i := range typ.NumField() {
+		name := typ.Field(i).Name
+		declared[name] = struct{}{}
+		if _, ok := mapperedFields[name]; !ok {
+			t.Errorf(
+				"v1beta1.ContainerTty.%s is declared on the schema but missing from "+
+					"mapperedFields. Decide whether buildTerminalSpec should stamp it onto "+
+					"the TerminalSpec; if yes, wire it through and extend "+
+					"TestBuildTerminalSpec_AllTtyFieldsMap with an assertion; if no, document "+
+					"the deliberate drop in a code comment and still add the field here.",
+				name,
+			)
+		}
+	}
+	for name := range mapperedFields {
+		if _, ok := declared[name]; !ok {
+			t.Errorf(
+				"mapperedFields references %q but v1beta1.ContainerTty no longer declares it — "+
+					"drop the stale entry.",
+				name,
+			)
+		}
+	}
+}
+
+// TestBuildTerminalSpec_AllTtyFieldsMap is the comprehensive transform guard
+// #493 calls for, ported to kuketty. It exercises reflective coverage, the
+// per-field behavioral mapping, and the transform-default invariants the cell
+// schema does not surface but the transform must stamp on every spec
+// (EnvInherit, SocketFile, CaptureFile, RunPath).
+func TestBuildTerminalSpec_AllTtyFieldsMap(t *testing.T) {
+	ttyFieldsCoveredByMapping(t)
+
+	const wantPrompt = `"\u@\h:\w\$ "`
+	wantOnInit := []v1beta1.TtyStage{{Script: "echo hello"}, {Script: "echo world"}}
+	const wantLogLevel = "debug"
+	const wantLogFile = "/var/log/kuketty-override.log"
+	workload := []string{"/bin/sh", "-c", "exec /workload"}
+
+	spec := v1beta1.ContainerSpec{
+		ID:             "c1",
+		Command:        workload[0],
+		Args:           workload[1:],
+		Attachable:     true,
+		KukeonGroupGID: 986,
+		Tty: &v1beta1.ContainerTty{
+			Prompt:   wantPrompt,
+			OnInit:   wantOnInit,
+			LogFile:  wantLogFile,
+			LogLevel: wantLogLevel,
+		},
+	}
+
+	out := buildSpec(t, spec)
+
+	if out.Prompt != wantPrompt {
+		t.Errorf("Tty.Prompt: Prompt = %q, want %q", out.Prompt, wantPrompt)
+	}
+	if !out.SetPrompt {
+		t.Errorf("Tty.Prompt: SetPrompt = false, want true (non-empty inline prompt)")
+	}
+	if len(out.Stages.OnInit) != len(wantOnInit) {
+		t.Fatalf("Tty.OnInit: Stages.OnInit len = %d, want %d", len(out.Stages.OnInit), len(wantOnInit))
+	}
+	for i, want := range wantOnInit {
+		if out.Stages.OnInit[i].Script != want.Script {
+			t.Errorf("Tty.OnInit[%d].Script = %q, want %q", i, out.Stages.OnInit[i].Script, want.Script)
+		}
+	}
+	if len(out.Stages.PostAttach) != 0 {
+		t.Errorf("Stages.PostAttach = %+v, want empty (not surfaced on cell schema)", out.Stages.PostAttach)
+	}
+	if out.LogLevel != wantLogLevel {
+		t.Errorf("Tty.LogLevel: LogLevel = %q, want %q", out.LogLevel, wantLogLevel)
+	}
+	if !out.EnvInherit {
+		t.Errorf("EnvInherit = false, want true — kuketty must forward its os.Environ() " +
+			"(== OCI Process.Env) to the workload; without it sbsh strips all but HOME + SBSH_*. #494.")
+	}
+	if out.SocketFile != attachableSocketPath {
+		t.Errorf("SocketFile = %q, want %q", out.SocketFile, attachableSocketPath)
+	}
+	if out.CaptureFile != attachableCapturePath {
+		t.Errorf("CaptureFile = %q, want %q", out.CaptureFile, attachableCapturePath)
+	}
+	if out.LogFile != wantLogFile {
+		t.Errorf("Tty.LogFile: LogFile = %q, want %q (override stamped verbatim)", out.LogFile, wantLogFile)
+	}
+	if out.RunPath != attachableTTYDir {
+		t.Errorf("RunPath = %q, want %q", out.RunPath, attachableTTYDir)
+	}
+	if out.Command != workload[0] {
+		t.Errorf("Command = %q, want %q", out.Command, workload[0])
+	}
+	if !reflect.DeepEqual(out.CommandArgs, workload[1:]) {
+		t.Errorf("CommandArgs = %v, want %v", out.CommandArgs, workload[1:])
+	}
+}
+
+// TestBuildTerminalSpec_PromptConfigured locks the inline-Prompt lane (#494):
+// a non-empty Tty.Prompt stamps Spec.Prompt and flips SetPrompt on.
+func TestBuildTerminalSpec_PromptConfigured(t *testing.T) {
+	const wantPrompt = `"\[\e[1;36m\]claude \u@\h\[\e[0m\]:\w\$ "`
+	out := buildSpec(t, v1beta1.ContainerSpec{
+		ID:      "c1",
+		Command: "/bin/sh",
+		Tty:     &v1beta1.ContainerTty{Prompt: wantPrompt},
+	})
+	if out.Prompt != wantPrompt {
+		t.Errorf("Prompt = %q, want %q", out.Prompt, wantPrompt)
+	}
+	if !out.SetPrompt {
+		t.Errorf("SetPrompt = false, want true (non-empty inline Tty.Prompt flips it on)")
+	}
+}
+
+// TestBuildTerminalSpec_OnInitConfigured locks the inline-OnInit lane (#494):
+// each TtyStage.Script lands as an api.ExecStep in order.
+func TestBuildTerminalSpec_OnInitConfigured(t *testing.T) {
+	out := buildSpec(t, v1beta1.ContainerSpec{
+		ID:      "c1",
+		Command: "/bin/sh",
+		Tty: &v1beta1.ContainerTty{
+			OnInit: []v1beta1.TtyStage{{Script: "echo hello"}, {Script: "echo world"}},
+		},
+	})
+	if len(out.Stages.OnInit) != 2 {
+		t.Fatalf("Stages.OnInit len = %d, want 2", len(out.Stages.OnInit))
+	}
+	if out.Stages.OnInit[0].Script != "echo hello" || out.Stages.OnInit[1].Script != "echo world" {
+		t.Errorf("Stages.OnInit = %+v, want [echo hello, echo world]", out.Stages.OnInit)
+	}
+	if len(out.Stages.PostAttach) != 0 {
+		t.Errorf("Stages.PostAttach = %+v, want empty", out.Stages.PostAttach)
+	}
+}
+
+// TestBuildTerminalSpec_EmptyTtyKeepsSafeDefault locks the safe-default branch
+// for an unconfigured Tty (#494): no Prompt or OnInit means SetPrompt stays
+// false (DisableSetPrompt(true) is forced) and Stages stays zero, so a
+// non-shell workload never receives a literal PS1 injection on stdin.
+func TestBuildTerminalSpec_EmptyTtyKeepsSafeDefault(t *testing.T) {
+	out := buildSpec(t, v1beta1.ContainerSpec{ID: "c1", Command: "/bin/sh"})
+	if out.SetPrompt {
+		t.Errorf("SetPrompt = true, want false (no inline Prompt → DisableSetPrompt(true))")
+	}
+	if out.Prompt != "" {
+		t.Errorf("Prompt = %q, want empty", out.Prompt)
+	}
+	if len(out.Stages.OnInit) != 0 {
+		t.Errorf("Stages.OnInit = %+v, want empty", out.Stages.OnInit)
+	}
+	if len(out.Stages.PostAttach) != 0 {
+		t.Errorf("Stages.PostAttach = %+v, want empty", out.Stages.PostAttach)
+	}
+}
+
+// TestBuildTerminalSpec_EmptyWorkloadFallsBackToBuilderDefault: when the doc
+// carries no resolved argv (empty Command — image with no ENTRYPOINT/CMD and no
+// override), the transform leaves Spec.Command at sbsh's hardcoded default
+// (/bin/bash -i) rather than rendering an empty Command, which server.New
+// rejects.
+func TestBuildTerminalSpec_EmptyWorkloadFallsBackToBuilderDefault(t *testing.T) {
+	out := buildSpec(t, v1beta1.ContainerSpec{ID: "c1"})
+	if out.Command == "" {
+		t.Errorf("Command is empty; expected sbsh builder's hardcoded fallback")
+	}
+}
+
+// intPtr is a one-off helper for the always-on log table-test.
+func intPtr(v int) *int { return &v }

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -25,13 +25,13 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/eminwux/kukeon/internal/apischeme"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
-	sbshapi "github.com/eminwux/sbsh/pkg/api"
-	sbshbuilder "github.com/eminwux/sbsh/pkg/builder"
+	extmodel "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 // attachableTTYDirRootMode is the mode applied to the per-container tty
@@ -93,9 +93,9 @@ func attachableTTYDirInitialPerms(kukeonGroupGID int) (os.FileMode, int) {
 //     so runc has a host-visible source for the kuketty bind mount;
 //   - registers a metadata renderer that fires from inside the OCI
 //     args-wrap closure once containerd has resolved the workload argv,
-//     producing the per-container api.TerminalDoc at <containerDir>/
-//     kuketty-metadata.json that the bind mount maps onto kuketty's fixed
-//     in-container metadata path.
+//     producing the per-container api/model/v1beta1.ContainerDoc at
+//     <containerDir>/kuketty-metadata.json that the bind mount maps onto
+//     kuketty's fixed in-container metadata path.
 //
 // The tty directory is created with mode 02750 owned by root:kukeon group
 // when the kukeon group GID is configured, so non-root operators in the
@@ -152,7 +152,7 @@ func (r *Exec) attachableBuildOpts(_ string, spec intmodel.ContainerSpec, _ []ct
 	metadataPath := filepath.Join(containerDir, ctr.AttachableMetadataFile)
 	kukeonGID := r.opts.KukeonGroupGID
 	renderer := func(workloadArgv []string) error {
-		return r.writeKukettyMetadata(metadataPath, spec, kukeonGID, workloadArgv)
+		return r.writeKukettyDoc(metadataPath, spec, kukeonGID, workloadArgv)
 	}
 
 	return []ctr.BuildOption{
@@ -165,156 +165,94 @@ func (r *Exec) attachableBuildOpts(_ string, spec intmodel.ContainerSpec, _ []ct
 	}, nil
 }
 
-// writeKukettyMetadata renders the per-container api.TerminalDoc and writes
-// it atomically (tmp + rename) so a partially-written file is never visible
-// to a racing kuketty in the container. 0o600 because the file lives inside
-// the per-container parent directory, which is daemon-private (0o2750 or
-// 0o700) — keeping the inner file similarly tight guards against a future
-// loosening of the parent dir.
+// writeKukettyDoc renders the per-container ContainerDoc and writes it
+// atomically (tmp + rename) so a partially-written file is never visible to a
+// racing kuketty in the container. 0o600 because the file lives inside the
+// per-container parent directory, which is daemon-private (0o2750 or 0o700) —
+// keeping the inner file similarly tight guards against a future loosening of
+// the parent dir.
 //
-// workloadArgv is the resolved Process.Args captured by the OCI args-wrap
-// closure (image ENTRYPOINT+CMD merged with any user override). It is moved
-// into TerminalSpec.Command / TerminalSpec.CommandArgs via sbsh's
-// builder.WithCommand so the kuketty side spawns the workload via sbsh's
-// terminal runner instead of the wrapper's argv. An empty workloadArgv
-// leaves sbsh's inline-builder default (/bin/bash -i) in place, matching
-// the legacy fallback when the user supplied no command.
-func (r *Exec) writeKukettyMetadata(
+// The mounted artifact carries kukeon's own ContainerSpec (issue #641), not a
+// pre-rendered sbsh TerminalDoc: kuketty reads ContainerDoc.Spec, runs sbsh's
+// builder, and serves. Three inputs the transform folds in are not knowable
+// inside the container, so the daemon resolves and stamps them here:
+//
+//   - the resolved workload argv (image ENTRYPOINT+CMD merged with any user
+//     override, captured by the OCI args-wrap closure) into Spec.Command /
+//     Spec.Args. An empty argv (image with no ENTRYPOINT/CMD and no override)
+//     leaves the converted Command/Args as-is so kuketty falls through to
+//     sbsh's inline-builder default (/bin/bash -i), matching the legacy
+//     WithCommand gate;
+//   - the kukeon-group GID into Spec.KukeonGroupGID, so kuketty applies the
+//     kukeon-group socket/capture/log ownership the daemon used to fold into
+//     the rendered TerminalSpec;
+//   - the resolved kuketty log level (per-container → server-config → "info")
+//     into Spec.Tty.LogLevel, allocating the Tty block when the cell omitted
+//     it so kuketty reads a non-empty level verbatim (sbsh's NewFileLogger
+//     rejects an empty level) with no daemon-side defaulting of its own.
+//
+// Everything else the transform needs — the fixed in-container socket /
+// capture / log paths and their modes — are kukeon contract constants kuketty
+// knows directly, so they are not carried in the doc.
+func (r *Exec) writeKukettyDoc(
 	path string,
 	spec intmodel.ContainerSpec,
 	kukeonGroupGID int,
 	workloadArgv []string,
 ) error {
-	prompt := ""
-	if spec.Tty != nil {
-		prompt = spec.Tty.Prompt
-	}
-	opts := []sbshbuilder.TerminalOption{
-		sbshbuilder.WithSocketFile(ctr.AttachableSocketPath),
-		// Capture file is anchored to the kukeon-controlled per-container
-		// tty dir so `kuke log` (which tails ContainerCapturePath on the
-		// host) and the in-container writer see the same inode through the
-		// directory bind mount. Without an explicit WithCaptureFile, sbsh's
-		// inline builder derives a capture path from runPath + ID that
-		// would land outside the bind-mount, hiding the transcript from the
-		// host.
-		sbshbuilder.WithCaptureFile(ctr.AttachableCapturePath),
-		// Spec.Prompt + Spec.SetPrompt are stamped from the cell's inline
-		// Tty.Prompt with no profile loader involved (#494): an empty
-		// prompt pairs with DisableSetPrompt(true) so a non-shell workload
-		// (nginx, python) never receives a literal `export PS1=…` on
-		// stdin; a non-empty prompt flips SetPrompt on (sbsh's
-		// `!DisableSetPrompt` rule). Replaces the phase-4 (#290) profile
-		// lane that loaded sbsh TerminalProfile YAML from disk.
-		sbshbuilder.WithPrompt(prompt),
-		sbshbuilder.WithDisableSetPrompt(prompt == ""),
-		// Spec.EnvInherit=true tells sbsh's terminal runner to forward
-		// kuketty's os.Environ() (which is the container's OCI Process.Env
-		// — user-supplied containerSpec.Env merged with kukeon's KUKEON_*
-		// identity vars at ctr.BuildContainerSpec) to the workload child.
-		// Without it, sbsh's runner spawns the workload with only HOME +
-		// SBSH_* set (sbsh@v0.11.2/internal/terminal/terminalrunner/
-		// terminal.go:54) — every user env entry and every KUKEON_* entry
-		// gets stripped at the kuketty → workload boundary. Pre-#494 the
-		// profile lane's no-profile fallback defaulted EnvInherit=true
-		// (sbsh@v0.11.1/internal/profile/profile.go:454), so the inline-
-		// builder migration silently regressed env passthrough — this
-		// option restores the kukeon contract that the OCI Process.Env IS
-		// the workload's env. Pinned by the comprehensive renderer test in
-		// attachable_test.go so a future refactor cannot drop it.
-		sbshbuilder.WithEnvInherit(true),
-	}
-	if spec.Tty != nil && len(spec.Tty.OnInit) > 0 {
-		// Inline OnInit (#494): map the cell's TtyStage{Script} entries to
-		// sbsh's api.ExecStep{Script}. Before this lane existed, OnInit set
-		// on a cell with no profile was silently dropped (#494 problem 1).
-		opts = append(opts, sbshbuilder.WithOnInit(ttyStagesToExecSteps(spec.Tty.OnInit)))
-	}
-	if mode := modeIfGroupSet(kukeonGroupGID, ctr.AttachableSocketMode); mode != "" {
-		opts = append(opts, sbshbuilder.WithSocketMode(mode))
-	}
-	if mode := modeIfGroupSet(kukeonGroupGID, ctr.AttachableCaptureMode); mode != "" {
-		opts = append(opts, sbshbuilder.WithCaptureMode(mode))
-	}
-	if kukeonGroupGID > 0 {
-		opts = append(opts, sbshbuilder.WithSocketGID(kukeonGroupGID))
-		opts = append(opts, sbshbuilder.WithCaptureGID(kukeonGroupGID))
-	}
-	// Kuketty's own slog output is always-on. The path defaults to a
-	// daemon-controlled location (peer to AttachableSocketPath /
-	// AttachableCapturePath inside the per-container tty bind mount, so
-	// the host-visible peer fs.ContainerKukettyLogPath resolves to the
-	// same inode) and reverses #289 phase 3's opt-in design specifically
-	// for the kuketty-process log (issue #599): the wrapper's debug log
-	// is the operator's primary diagnostic when an attach session
-	// misbehaves, and gating it on cell YAML left a class of "kuketty
-	// crashed silently" bugs unobservable. Cells that need the log to
-	// land elsewhere — custom bind mount, fixed external mount — pin
-	// Tty.LogFile to an alternate in-container path; the daemon stamps
-	// it verbatim without rewriting. Workload capture
-	// (AttachableCapturePath) stays a separate, opt-in concern.
-	opts = append(opts, sbshbuilder.WithLogFile(resolveTtyLogFile(spec.Tty)))
-	if mode := modeIfGroupSet(kukeonGroupGID, ctr.AttachableLogFileMode); mode != "" {
-		opts = append(opts, sbshbuilder.WithLogFileMode(mode))
-	}
-	if kukeonGroupGID > 0 {
-		opts = append(opts, sbshbuilder.WithLogFileGID(kukeonGroupGID))
-	}
-	// Tty.LogLevel resolution: per-container → server-config (plumbed
-	// via runner.Options.KukettyLogLevel) → hardcoded "info". sbsh's
-	// pkg/logging.NewFileLogger rejects an empty level at file-open
-	// time, so the renderer pins a non-empty default here rather than
-	// threading the fallback through kuketty.
-	opts = append(opts, sbshbuilder.WithLogLevel(resolveTtyLogLevel(spec.Tty, r.opts.KukettyLogLevel)))
+	extSpec := apischeme.BuildContainerSpecExternalFromInternal(spec)
+
+	// The terminal command derives solely from the resolved Process.Args the
+	// args-wrap captured — overwrite the user-authored Command/Args the
+	// conversion carried so the doc's Command is the authoritative resolved
+	// argv. An empty argv (image with no ENTRYPOINT/CMD and no override)
+	// leaves Command/Args empty so kuketty falls through to sbsh's
+	// inline-builder default (/bin/bash -i), matching the legacy gate.
+	extSpec.Command = ""
+	extSpec.Args = nil
 	if len(workloadArgv) > 0 {
-		opts = append(opts, sbshbuilder.WithCommand(workloadArgv))
+		extSpec.Command = workloadArgv[0]
+		extSpec.Args = append([]string(nil), workloadArgv[1:]...)
 	}
 
-	terminalSpec, err := sbshbuilder.BuildTerminalSpec(r.ctx, r.logger, ctr.AttachableTTYDir, opts...)
-	if err != nil {
-		return fmt.Errorf("build kuketty terminal spec: %w", err)
-	}
+	extSpec.KukeonGroupGID = kukeonGroupGID
 
-	doc := sbshapi.TerminalDoc{
-		APIVersion: sbshapi.APIVersionV1Beta1,
-		Kind:       sbshapi.KindTerminal,
-		Metadata: sbshapi.TerminalMetadata{
+	// Resolve the log level daemon-side (the server-config tier is not visible
+	// inside the container) and stamp it onto Tty.LogLevel so kuketty reads it
+	// verbatim. Allocate the Tty block when the cell omitted it entirely —
+	// buildContainerTtyExternalFromInternal returns nil for an empty Tty.
+	resolvedLevel := resolveTtyLogLevel(spec.Tty, r.opts.KukettyLogLevel)
+	if extSpec.Tty == nil {
+		extSpec.Tty = &extmodel.ContainerTty{}
+	}
+	extSpec.Tty.LogLevel = resolvedLevel
+
+	doc := extmodel.ContainerDoc{
+		APIVersion: extmodel.APIVersionV1Beta1,
+		Kind:       extmodel.KindContainer,
+		Metadata: extmodel.ContainerMetadata{
 			Name:   spec.ID,
 			Labels: kukettyMetadataLabels(spec),
 		},
-		Spec: *terminalSpec,
+		Spec: extSpec,
+		// Status is left zero: the daemon stamps spec only. kuketty (and the
+		// later crew-absorption phases of #423) own the status channel back
+		// into ContainerStatus. AC #1.
 	}
 
 	data, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal kuketty metadata: %w", err)
+		return fmt.Errorf("marshal kuketty doc: %w", err)
 	}
 	tmp := path + ".tmp"
 	if err = os.WriteFile(tmp, data, 0o600); err != nil {
-		return fmt.Errorf("write kuketty metadata %q: %w", tmp, err)
+		return fmt.Errorf("write kuketty doc %q: %w", tmp, err)
 	}
 	if err = os.Rename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
-		return fmt.Errorf("rename kuketty metadata %q -> %q: %w", tmp, path, err)
+		return fmt.Errorf("rename kuketty doc %q -> %q: %w", tmp, path, err)
 	}
 	return nil
-}
-
-// resolveTtyLogFile returns the in-container path the kuketty wrapper's
-// slog output lands at. Per #599 the path is daemon-controlled by default
-// (ctr.AttachableKukettyLogPath, the peer to capture inside the per-
-// container tty bind mount, so the host-visible peer is always
-// fs.ContainerKukettyLogPath). A cell may pin Tty.LogFile to an alternate
-// in-container path — the daemon stamps it verbatim without rewriting or
-// anchoring it to the bind mount. The always-on invariant holds either
-// way: Spec.LogFile is never empty after the renderer, so kuketty's
-// openTerminalLogger never falls through to the discard logger in the
-// OCI-injection path.
-func resolveTtyLogFile(t *intmodel.ContainerTty) string {
-	if t != nil && t.LogFile != "" {
-		return t.LogFile
-	}
-	return ctr.AttachableKukettyLogPath
 }
 
 // resolveTtyLogLevel returns the operator-supplied LogLevel from the cell
@@ -337,23 +275,8 @@ func resolveTtyLogLevel(t *intmodel.ContainerTty, serverConfigLevel string) stri
 	return "info"
 }
 
-// ttyStagesToExecSteps maps the cell's inline Tty.OnInit entries into
-// sbsh's api.ExecStep slice. Each stage carries only Script today; sbsh's
-// ExecStep also supports Env, but the cell schema does not surface it yet
-// (a future TtyStage knob lands here without touching the renderer).
-func ttyStagesToExecSteps(in []intmodel.TtyStage) []sbshapi.ExecStep {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]sbshapi.ExecStep, len(in))
-	for i, s := range in {
-		out[i] = sbshapi.ExecStep{Script: s.Script}
-	}
-	return out
-}
-
 // kukettyMetadataLabels stamps the cell-context identity on the rendered
-// TerminalDoc.Metadata so an operator inspecting the host-side file can
+// ContainerDoc.Metadata so an operator inspecting the host-side file can
 // trace it back to the realm/space/stack/cell/container it belongs to
 // without having to walk the bind-mount source. Empty fields are dropped
 // rather than producing empty string values, so the labels map mirrors
@@ -377,18 +300,6 @@ func kukettyMetadataLabels(spec intmodel.ContainerSpec) map[string]string {
 		return nil
 	}
 	return out
-}
-
-// modeIfGroupSet returns the octal-mode string only when the kukeon
-// group GID is configured; otherwise empty so kuketty applies the OS-default
-// (umask-clipped) mode on the per-terminal inode the mode applies to
-// (socket, capture file, log file). Matches the legacy 0o600-owner-only
-// fallback the sbsh wrapper had when no kukeon group existed.
-func modeIfGroupSet(gid int, mode string) string {
-	if gid > 0 {
-		return mode
-	}
-	return ""
 }
 
 // stageKukettyBinary ensures a host-visible copy of the kuketty binary

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -16,7 +16,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint:testpackage // exercises private writeKukettyMetadata and attachableTTYDirInitialPerms.
+//nolint:testpackage // exercises private writeKukettyDoc and attachableTTYDirInitialPerms.
 package runner
 
 import (
@@ -27,16 +27,14 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/consts"
-	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
-	sbshapi "github.com/eminwux/sbsh/pkg/api"
+	extmodel "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 // TestAttachableTTYDirInitialPerms locks the (mode, gid) tuple for the per-
@@ -105,20 +103,14 @@ func TestAttachableTTYDirRootMode_SetsSGIDBit(t *testing.T) {
 	}
 }
 
-// TestWriteKukettyMetadata_KukeonGroupSet locks the phase-1b TerminalDoc
-// rendering when the daemon has a kukeon group configured: socket mode +
-// gid are filled in so kuketty applies the kukeon-group ownership the sbsh
-// wrapper used to apply via flags. APIVersion/Kind use sbsh's public
-// discriminator (api.APIVersionV1Beta1 + api.KindTerminal), and the
-// resolved workload argv lands in Spec.Command / Spec.CommandArgs (no
-// trailing argv on the OCI side).
-//
-// Phase 2 (#288) extends the same case to cover the capture-file fields:
-// CaptureFile is anchored to the per-container tty dir so `kuke log` and
-// sbsh's in-container writer see the same inode through the bind mount,
-// and CaptureMode/CaptureGID mirror the socket pattern (gated on kukeon
-// group configured).
-func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
+// TestWriteKukettyDoc_EmitsContainerDoc locks the post-#641 mounted artifact:
+// the daemon writes a kukeon ContainerDoc (not a pre-rendered sbsh TerminalDoc)
+// with the spec populated, the status left zero, and the cell-context labels
+// stamped on Metadata. The three daemon-only resolved values travel in the
+// doc — the resolved workload argv in Spec.Command/Spec.Args, the kukeon-group
+// GID in Spec.KukeonGroupGID, and the resolved log level in Spec.Tty.LogLevel —
+// so kuketty's transform stays a pure ContainerSpec -> TerminalSpec mapping.
+func TestWriteKukettyDoc_EmitsContainerDoc(t *testing.T) {
 	r := newTestRunner(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kuketty-metadata.json")
@@ -132,16 +124,16 @@ func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
 	const kukeonGID = 986
 	workload := []string{"/bin/sh", "-c", "echo hello"}
 
-	if err := r.writeKukettyMetadata(path, spec, kukeonGID, workload); err != nil {
-		t.Fatalf("writeKukettyMetadata: %v", err)
+	if err := r.writeKukettyDoc(path, spec, kukeonGID, workload); err != nil {
+		t.Fatalf("writeKukettyDoc: %v", err)
 	}
 
 	doc := readDoc(t, path)
-	if doc.APIVersion != sbshapi.APIVersionV1Beta1 {
-		t.Errorf("APIVersion = %q, want %q", doc.APIVersion, sbshapi.APIVersionV1Beta1)
+	if doc.APIVersion != extmodel.APIVersionV1Beta1 {
+		t.Errorf("APIVersion = %q, want %q", doc.APIVersion, extmodel.APIVersionV1Beta1)
 	}
-	if doc.Kind != sbshapi.KindTerminal {
-		t.Errorf("Kind = %q, want %q", doc.Kind, sbshapi.KindTerminal)
+	if doc.Kind != extmodel.KindContainer {
+		t.Errorf("Kind = %q, want %q", doc.Kind, extmodel.KindContainer)
 	}
 	if doc.Metadata.Name != "c1" {
 		t.Errorf("Metadata.Name = %q, want c1", doc.Metadata.Name)
@@ -158,78 +150,46 @@ func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
 			t.Errorf("Metadata.Labels[%q] = %q, want %q", k, got, want)
 		}
 	}
-	if doc.Spec.SocketFile != ctr.AttachableSocketPath {
-		t.Errorf("Spec.SocketFile = %q, want %q", doc.Spec.SocketFile, ctr.AttachableSocketPath)
-	}
-	if doc.Spec.RunPath != ctr.AttachableTTYDir {
-		t.Errorf("Spec.RunPath = %q, want %q", doc.Spec.RunPath, ctr.AttachableTTYDir)
-	}
+	// Resolved workload argv travels in Command/Args.
 	if doc.Spec.Command != "/bin/sh" {
 		t.Errorf("Spec.Command = %q, want /bin/sh", doc.Spec.Command)
 	}
 	wantArgs := []string{"-c", "echo hello"}
-	if len(doc.Spec.CommandArgs) != len(wantArgs) {
-		t.Fatalf(
-			"Spec.CommandArgs len = %d, want %d (full=%v)",
-			len(doc.Spec.CommandArgs),
-			len(wantArgs),
-			doc.Spec.CommandArgs,
-		)
+	if len(doc.Spec.Args) != len(wantArgs) {
+		t.Fatalf("Spec.Args = %v, want %v", doc.Spec.Args, wantArgs)
 	}
 	for i, want := range wantArgs {
-		if doc.Spec.CommandArgs[i] != want {
-			t.Errorf("Spec.CommandArgs[%d] = %q, want %q", i, doc.Spec.CommandArgs[i], want)
+		if doc.Spec.Args[i] != want {
+			t.Errorf("Spec.Args[%d] = %q, want %q", i, doc.Spec.Args[i], want)
 		}
 	}
-	// Permission fields: sbsh's builder accepts the canonical octal
-	// string "0660" via WithSocketMode and parses it into os.FileMode at
-	// build time. The doc round-trips it as the FileMode (perm bits).
-	if doc.Spec.SocketMode.Perm() != 0o660 {
-		t.Errorf("Spec.SocketMode = %v, want perm 0660", doc.Spec.SocketMode)
+	// Kukeon-group GID travels in Spec.KukeonGroupGID.
+	if doc.Spec.KukeonGroupGID != kukeonGID {
+		t.Errorf("Spec.KukeonGroupGID = %d, want %d", doc.Spec.KukeonGroupGID, kukeonGID)
 	}
-	if doc.Spec.SocketGID == nil || *doc.Spec.SocketGID != kukeonGID {
-		t.Errorf("Spec.SocketGID = %v, want pointer to %d", doc.Spec.SocketGID, kukeonGID)
+	// Resolved log level travels in Spec.Tty.LogLevel (allocated even though
+	// the cell omitted the Tty block).
+	if doc.Spec.Tty == nil {
+		t.Fatalf("Spec.Tty is nil; want allocated to carry the resolved log level")
 	}
-	// Capture fields (phase 2 #288): path is anchored on the kukeon-
-	// controlled in-container tty dir so the host-side ContainerCapturePath
-	// `kuke log` tails resolves to the same inode through the bind mount;
-	// mode + gid mirror the socket pattern.
-	if doc.Spec.CaptureFile != ctr.AttachableCapturePath {
-		t.Errorf("Spec.CaptureFile = %q, want %q", doc.Spec.CaptureFile, ctr.AttachableCapturePath)
+	if doc.Spec.Tty.LogLevel != "info" {
+		t.Errorf("Spec.Tty.LogLevel = %q, want info (default)", doc.Spec.Tty.LogLevel)
 	}
-	if doc.Spec.CaptureMode.Perm() != 0o640 {
-		t.Errorf("Spec.CaptureMode = %v, want perm 0640", doc.Spec.CaptureMode)
+	// Status is left zero (AC #1). Compare field-wise rather than with == :
+	// time.Time zero values do not round-trip equal through JSON (the decoded
+	// loc is UTC, the zero-value loc is nil), so a struct == would spuriously
+	// fail on the timestamp fields.
+	if doc.Status.State != extmodel.ContainerStatePending {
+		t.Errorf("Status.State = %v, want zero (Pending)", doc.Status.State)
 	}
-	if doc.Spec.CaptureGID == nil || *doc.Spec.CaptureGID != kukeonGID {
-		t.Errorf("Spec.CaptureGID = %v, want pointer to %d", doc.Spec.CaptureGID, kukeonGID)
+	if doc.Status.Name != "" || doc.Status.ID != "" || doc.Status.ExitCode != 0 ||
+		doc.Status.RestartCount != 0 || doc.Status.ExitSignal != "" {
+		t.Errorf("Status carries non-zero scalar fields: %+v", doc.Status)
 	}
-	// Kuketty log fields are always-on at the daemon-controlled
-	// AttachableKukettyLogPath (issue #599 reverses #289 phase 3 for the
-	// kuketty-process log specifically). The kukeon group is configured
-	// here, so mode + gid track the socket/capture pattern.
-	if doc.Spec.LogFile != ctr.AttachableKukettyLogPath {
-		t.Errorf("Spec.LogFile = %q, want %q (always-on kuketty log)", doc.Spec.LogFile, ctr.AttachableKukettyLogPath)
+	if !doc.Status.StartTime.IsZero() || !doc.Status.FinishTime.IsZero() || !doc.Status.RestartTime.IsZero() {
+		t.Errorf("Status timestamps not zero: %+v", doc.Status)
 	}
-	if doc.Spec.LogFileMode.Perm() != 0o640 {
-		t.Errorf("Spec.LogFileMode perm = %#o, want 0640 (kukeon group set)", doc.Spec.LogFileMode.Perm())
-	}
-	if doc.Spec.LogFileGID == nil || *doc.Spec.LogFileGID != kukeonGID {
-		t.Errorf("Spec.LogFileGID = %v, want pointer to %d", doc.Spec.LogFileGID, kukeonGID)
-	}
-	// LogLevel defaults to "info" when the cell omits it (sbsh's
-	// NewFileLogger rejects an empty level, so the daemon pins the
-	// default rather than threading the fallback through kuketty).
-	if doc.Spec.LogLevel != "info" {
-		t.Errorf("Spec.LogLevel = %q, want %q (default when Tty.LogLevel is empty)", doc.Spec.LogLevel, "info")
-	}
-	// SetPrompt off in phase 1b: arbitrary workloads (nginx, python)
-	// would receive a literal `export PS1=…` injection into stdin
-	// otherwise. Phase 4 (#290) wires Tty.Prompt through the builder.
-	if doc.Spec.SetPrompt {
-		t.Errorf("Spec.SetPrompt = true, want false in phase 1b")
-	}
-	// File permissions: daemon-private (0o600). A future loosening of
-	// the parent dir must not silently expose the file.
+	// File permissions: daemon-private (0o600).
 	info, statErr := os.Stat(path)
 	if statErr != nil {
 		t.Fatalf("stat metadata: %v", statErr)
@@ -239,273 +199,45 @@ func TestWriteKukettyMetadata_KukeonGroupSet(t *testing.T) {
 	}
 }
 
-// TestWriteKukettyMetadata_NoKukeonGroup locks the legacy fallback: when
-// no kukeon group is configured (GID 0), neither SocketMode nor SocketGID
-// is set on the spec so the sbsh server leaves the OS-default
-// (umask-clipped) permissions on the socket inode — matching the sbsh
-// wrapper's behavior on a host with no kukeon group.
-//
-// Phase 2 (#288) extends the same case to cover the capture-file fields:
-// CaptureFile is still anchored to the kukeon-controlled per-container tty
-// dir so `kuke log` resolves to the same inode regardless of group config;
-// CaptureMode + CaptureGID stay zero so sbsh's runner falls through to its
-// OS-default mode and leaves the group unchanged.
-func TestWriteKukettyMetadata_NoKukeonGroup(t *testing.T) {
+// TestWriteKukettyDoc_EmptyWorkloadClearsCommand locks the empty-argv branch:
+// when the args-wrap captured no resolved Process.Args (image with no
+// ENTRYPOINT/CMD and no override), the daemon clears Command/Args so kuketty
+// falls through to sbsh's inline-builder default rather than carrying a stale
+// user-authored command.
+func TestWriteKukettyDoc_EmptyWorkloadClearsCommand(t *testing.T) {
 	r := newTestRunner(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kuketty-metadata.json")
-	spec := intmodel.ContainerSpec{ID: "c1"}
+	spec := intmodel.ContainerSpec{ID: "c1", Command: "/bin/leftover", Args: []string{"x"}}
 
-	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
-		t.Fatalf("writeKukettyMetadata: %v", err)
+	if err := r.writeKukettyDoc(path, spec, 0, nil); err != nil {
+		t.Fatalf("writeKukettyDoc: %v", err)
 	}
 	doc := readDoc(t, path)
-	if doc.Spec.SocketMode.Perm() != 0 {
-		t.Errorf("Spec.SocketMode perm = %#o, want 0 (no kukeon group)", doc.Spec.SocketMode.Perm())
+	if doc.Spec.Command != "" {
+		t.Errorf("Spec.Command = %q, want empty (no resolved argv)", doc.Spec.Command)
 	}
-	if doc.Spec.SocketGID != nil {
-		t.Errorf("Spec.SocketGID = %v, want nil (no kukeon group)", doc.Spec.SocketGID)
-	}
-	// CaptureFile is set regardless of group config: kuketty must write
-	// the transcript at the kukeon-controlled bind-mount path so `kuke log`
-	// keeps tailing the host-side peer of the same inode. Mode + GID stay
-	// zero so sbsh's runner defaults apply.
-	if doc.Spec.CaptureFile != ctr.AttachableCapturePath {
-		t.Errorf("Spec.CaptureFile = %q, want %q", doc.Spec.CaptureFile, ctr.AttachableCapturePath)
-	}
-	if doc.Spec.CaptureMode.Perm() != 0 {
-		t.Errorf("Spec.CaptureMode perm = %#o, want 0 (no kukeon group)", doc.Spec.CaptureMode.Perm())
-	}
-	if doc.Spec.CaptureGID != nil {
-		t.Errorf("Spec.CaptureGID = %v, want nil (no kukeon group)", doc.Spec.CaptureGID)
-	}
-	// Kuketty log: always-on path even without a kukeon group, but
-	// mode + GID stay zero so sbsh's runner applies its OS-default
-	// (umask-clipped) mode and leaves the group untouched (matches
-	// the socket/capture treatment when no kukeon group is configured).
-	if doc.Spec.LogFile != ctr.AttachableKukettyLogPath {
-		t.Errorf("Spec.LogFile = %q, want %q (always-on kuketty log)", doc.Spec.LogFile, ctr.AttachableKukettyLogPath)
-	}
-	if doc.Spec.LogFileMode.Perm() != 0 {
-		t.Errorf("Spec.LogFileMode perm = %#o, want 0 (no kukeon group)", doc.Spec.LogFileMode.Perm())
-	}
-	if doc.Spec.LogFileGID != nil {
-		t.Errorf("Spec.LogFileGID = %v, want nil (no kukeon group)", doc.Spec.LogFileGID)
-	}
-	if doc.Spec.LogLevel != "info" {
-		t.Errorf("Spec.LogLevel = %q, want %q (default)", doc.Spec.LogLevel, "info")
+	if len(doc.Spec.Args) != 0 {
+		t.Errorf("Spec.Args = %v, want empty", doc.Spec.Args)
 	}
 }
 
-// TestWriteKukettyMetadata_KukettyLogAlwaysOn locks issue #599's reversal of
-// #289 phase 3 for the kuketty-process log specifically: regardless of cell
-// YAML, every Attachable container renders Spec.LogFile pointing at the
-// daemon-controlled AttachableKukettyLogPath (peer to socket/capture inside
-// the per-container tty bind mount). Operators do not pick the path — the
-// only knob the cell schema surfaces is verbosity, validated separately.
-func TestWriteKukettyMetadata_KukettyLogAlwaysOn(t *testing.T) {
+// TestWriteKukettyDoc_LogLevelResolution locks the per-container → server-config
+// → "info" precedence the daemon owns (the server-config tier is not visible
+// inside the container, so kuketty cannot resolve it). The resolved value is
+// stamped onto Spec.Tty.LogLevel; kuketty reads it verbatim.
+func TestWriteKukettyDoc_LogLevelResolution(t *testing.T) {
 	cases := []struct {
-		name      string
-		kukeonGID int
-		tty       *intmodel.ContainerTty
-		wantMode  os.FileMode
-		wantGID   *int
+		name         string
+		tty          *intmodel.ContainerTty
+		serverConfig string
+		wantLevel    string
 	}{
-		{
-			// No Tty block at all → still produces a log writer at the
-			// fixed daemon path. The pre-#599 design left Spec.LogFile
-			// empty here and operators had no diagnostic to read.
-			name:      "no Tty block: log still rendered",
-			kukeonGID: 986,
-			tty:       nil,
-			wantMode:  0o640,
-			wantGID:   intPtr(986),
-		},
-		{
-			// Tty block carries unrelated fields (prompt) → log stays
-			// always-on.
-			name:      "Tty without LogLevel: log still rendered",
-			kukeonGID: 986,
-			tty:       &intmodel.ContainerTty{Prompt: `claude> `},
-			wantMode:  0o640,
-			wantGID:   intPtr(986),
-		},
-		{
-			// No kukeon group → log path still set, but mode + GID
-			// stay zero so sbsh's runner applies OS-default perms.
-			name:      "no kukeon group: log path set, mode+gid zero",
-			kukeonGID: 0,
-			tty:       nil,
-			wantMode:  0,
-			wantGID:   nil,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := newTestRunner(t)
-			dir := t.TempDir()
-			path := filepath.Join(dir, "kuketty-metadata.json")
-			spec := intmodel.ContainerSpec{ID: "c1", Tty: tc.tty}
-			if err := r.writeKukettyMetadata(path, spec, tc.kukeonGID, []string{"/bin/sh"}); err != nil {
-				t.Fatalf("writeKukettyMetadata: %v", err)
-			}
-			doc := readDoc(t, path)
-			if doc.Spec.LogFile != ctr.AttachableKukettyLogPath {
-				t.Errorf("Spec.LogFile = %q, want %q (always-on)", doc.Spec.LogFile, ctr.AttachableKukettyLogPath)
-			}
-			if doc.Spec.LogFileMode.Perm() != tc.wantMode {
-				t.Errorf("Spec.LogFileMode perm = %#o, want %#o", doc.Spec.LogFileMode.Perm(), tc.wantMode)
-			}
-			switch {
-			case tc.wantGID != nil && (doc.Spec.LogFileGID == nil || *doc.Spec.LogFileGID != *tc.wantGID):
-				t.Errorf("Spec.LogFileGID = %v, want pointer to %d", doc.Spec.LogFileGID, *tc.wantGID)
-			case tc.wantGID == nil && doc.Spec.LogFileGID != nil:
-				t.Errorf("Spec.LogFileGID = %v, want nil", doc.Spec.LogFileGID)
-			}
-		})
-	}
-}
-
-// TestWriteKukettyMetadata_LogLevelHonored locks the LogLevel plumbing
-// added in issue #599: when the cell sets Tty.LogLevel, the renderer
-// stamps it onto Spec.LogLevel verbatim; when the cell omits it (or
-// passes "" explicitly), the renderer pins the "info" default daemon-side
-// so kuketty's sbshlogging.NewFileLogger (which rejects an empty level)
-// always sees a usable value.
-func TestWriteKukettyMetadata_LogLevelHonored(t *testing.T) {
-	cases := []struct {
-		name      string
-		tty       *intmodel.ContainerTty
-		wantLevel string
-	}{
-		{"empty Tty: default info", nil, "info"},
-		{"empty LogLevel: default info", &intmodel.ContainerTty{Prompt: "x> "}, "info"},
-		{"debug", &intmodel.ContainerTty{LogLevel: "debug"}, "debug"},
-		{"warn", &intmodel.ContainerTty{LogLevel: "warn"}, "warn"},
-		{"error", &intmodel.ContainerTty{LogLevel: "error"}, "error"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := newTestRunner(t)
-			dir := t.TempDir()
-			path := filepath.Join(dir, "kuketty-metadata.json")
-			spec := intmodel.ContainerSpec{ID: "c1", Tty: tc.tty}
-			if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
-				t.Fatalf("writeKukettyMetadata: %v", err)
-			}
-			doc := readDoc(t, path)
-			if doc.Spec.LogLevel != tc.wantLevel {
-				t.Errorf("Spec.LogLevel = %q, want %q", doc.Spec.LogLevel, tc.wantLevel)
-			}
-		})
-	}
-}
-
-// TestWriteKukettyMetadata_LogFileOverride locks the operator-override path
-// that #599's reviewer asked us to preserve: when a cell pins Tty.LogFile to
-// a custom in-container location (e.g., a fixed external mount), the renderer
-// stamps it verbatim — no daemon-side rewriting, no anchoring to the bind
-// mount. Default (LogFile empty) still resolves to the daemon-controlled
-// AttachableKukettyLogPath so the always-on contract from issue #599 holds.
-func TestWriteKukettyMetadata_LogFileOverride(t *testing.T) {
-	cases := []struct {
-		name    string
-		tty     *intmodel.ContainerTty
-		wantLog string
-	}{
-		{
-			"no Tty: daemon default",
-			nil,
-			ctr.AttachableKukettyLogPath,
-		},
-		{
-			"empty LogFile: daemon default",
-			&intmodel.ContainerTty{Prompt: "x> "},
-			ctr.AttachableKukettyLogPath,
-		},
-		{
-			"operator override inside bind mount",
-			&intmodel.ContainerTty{LogFile: ctr.AttachableTTYDir + "/custom.log"},
-			ctr.AttachableTTYDir + "/custom.log",
-		},
-		{
-			"operator override outside bind mount",
-			&intmodel.ContainerTty{LogFile: "/var/log/sbsh-debug.log"},
-			"/var/log/sbsh-debug.log",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := newTestRunner(t)
-			dir := t.TempDir()
-			path := filepath.Join(dir, "kuketty-metadata.json")
-			spec := intmodel.ContainerSpec{ID: "c1", Tty: tc.tty}
-			if err := r.writeKukettyMetadata(path, spec, 986, []string{"/bin/sh"}); err != nil {
-				t.Fatalf("writeKukettyMetadata: %v", err)
-			}
-			doc := readDoc(t, path)
-			if doc.Spec.LogFile != tc.wantLog {
-				t.Errorf("Spec.LogFile = %q, want %q", doc.Spec.LogFile, tc.wantLog)
-			}
-			// Always-on invariant: regardless of override or default,
-			// Spec.LogFile is non-empty so kuketty's openTerminalLogger
-			// never falls through to the discard logger.
-			if doc.Spec.LogFile == "" {
-				t.Errorf("Spec.LogFile is empty; always-on invariant from #599 broken")
-			}
-		})
-	}
-}
-
-// TestWriteKukettyMetadata_LogLevelGlobalDefault locks #599's reviewer-asked
-// precedence chain for the kuketty log level: per-container Tty.LogLevel →
-// server-config kuketty.logLevel (plumbed via runner.Options.KukettyLogLevel)
-// → hardcoded "info". The daemon-wide knob lets operators flip every
-// attachable cell on the host without editing each cell YAML; the per-
-// container knob still wins so cell authors retain a local override.
-func TestWriteKukettyMetadata_LogLevelGlobalDefault(t *testing.T) {
-	cases := []struct {
-		name             string
-		tty              *intmodel.ContainerTty
-		serverConfig     string
-		wantLevel        string
-		whyCommentForLog string
-	}{
-		{
-			name:             "per-container wins over server-config",
-			tty:              &intmodel.ContainerTty{LogLevel: "debug"},
-			serverConfig:     "warn",
-			wantLevel:        "debug",
-			whyCommentForLog: "cell-supplied LogLevel must override the daemon-wide default",
-		},
-		{
-			name:             "server-config wins when per-container empty",
-			tty:              nil,
-			serverConfig:     "warn",
-			wantLevel:        "warn",
-			whyCommentForLog: "daemon-wide knob applies when the cell omits LogLevel",
-		},
-		{
-			name:             "server-config wins with non-LogLevel Tty fields",
-			tty:              &intmodel.ContainerTty{Prompt: "x> "},
-			serverConfig:     "error",
-			wantLevel:        "error",
-			whyCommentForLog: "Tty present but LogLevel empty still falls through to server-config",
-		},
-		{
-			name:             "hardcoded info when both empty",
-			tty:              nil,
-			serverConfig:     "",
-			wantLevel:        "info",
-			whyCommentForLog: "no per-container, no server-config — last-resort 'info' from the renderer",
-		},
-		{
-			name:             "per-container wins over empty server-config",
-			tty:              &intmodel.ContainerTty{LogLevel: "debug"},
-			serverConfig:     "",
-			wantLevel:        "debug",
-			whyCommentForLog: "cell wins regardless of whether the server-config tier is populated",
-		},
+		{"per-container wins over server-config", &intmodel.ContainerTty{LogLevel: "debug"}, "warn", "debug"},
+		{"server-config wins when per-container empty", nil, "warn", "warn"},
+		{"server-config wins with non-LogLevel Tty fields", &intmodel.ContainerTty{Prompt: "x> "}, "error", "error"},
+		{"hardcoded info when both empty", nil, "", "info"},
+		{"per-container wins over empty server-config", &intmodel.ContainerTty{LogLevel: "debug"}, "", "debug"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -514,355 +246,38 @@ func TestWriteKukettyMetadata_LogLevelGlobalDefault(t *testing.T) {
 			dir := t.TempDir()
 			path := filepath.Join(dir, "kuketty-metadata.json")
 			spec := intmodel.ContainerSpec{ID: "c1", Tty: tc.tty}
-			if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
-				t.Fatalf("writeKukettyMetadata: %v", err)
+			if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}); err != nil {
+				t.Fatalf("writeKukettyDoc: %v", err)
 			}
 			doc := readDoc(t, path)
-			if doc.Spec.LogLevel != tc.wantLevel {
-				t.Errorf(
-					"Spec.LogLevel = %q, want %q (%s)",
-					doc.Spec.LogLevel, tc.wantLevel, tc.whyCommentForLog,
-				)
+			if doc.Spec.Tty == nil {
+				t.Fatalf("Spec.Tty is nil; want resolved log level")
+			}
+			if doc.Spec.Tty.LogLevel != tc.wantLevel {
+				t.Errorf("Spec.Tty.LogLevel = %q, want %q", doc.Spec.Tty.LogLevel, tc.wantLevel)
 			}
 		})
 	}
 }
 
-// intPtr is a one-off helper for the always-on log table-test to avoid the
-// awkward "&literal" pattern inside struct initializers.
-func intPtr(v int) *int { return &v }
-
-// ttyFieldsCoveredByMapping is the structural half of #493's "every Tty
-// field must map" guard: it enumerates intmodel.ContainerTty via
-// reflection and fails the test when a declared field is missing from
-// mapperedFields, or when mapperedFields carries a stale entry the
-// struct no longer declares. The comprehensive test below supplies the
-// behavioral half (each mapped field has a TerminalDoc.Spec assertion).
-//
-// New fields landing on intmodel.ContainerTty must touch two places to
-// keep the test green:
-//
-//  1. Add the field name to mapperedFields here.
-//  2. Wire it through writeKukettyMetadata and add an assertion to
-//     TestWriteKukettyMetadata_AllTtyFieldsMap.
-//
-// Skipping step 1 fails the structural check; skipping step 2 fails the
-// per-field behavioral check. The pre-#494 silent-drop pattern (Tty.OnInit
-// declared on the schema but never read by the renderer) fails (2).
-func ttyFieldsCoveredByMapping(t *testing.T) {
-	t.Helper()
-	// Local map so the linter's gochecknoglobals rule stays clean and the
-	// list reads as part of the test contract rather than a package
-	// secret. Keep alphabetized.
-	mapperedFields := map[string]struct{}{
-		"LogFile":  {},
-		"LogLevel": {},
-		"OnInit":   {},
-		"Prompt":   {},
-	}
-	typ := reflect.TypeOf(intmodel.ContainerTty{})
-	declared := make(map[string]struct{}, typ.NumField())
-	for i := range typ.NumField() {
-		name := typ.Field(i).Name
-		declared[name] = struct{}{}
-		if _, ok := mapperedFields[name]; !ok {
-			t.Errorf(
-				"intmodel.ContainerTty.%s is declared on the cell schema but missing from "+
-					"mapperedFields. Decide whether writeKukettyMetadata should stamp it onto "+
-					"TerminalDoc.Spec; if yes, wire it through and extend "+
-					"TestWriteKukettyMetadata_AllTtyFieldsMap with an assertion; if no, document "+
-					"the deliberate drop in a code comment and still add the field here so the "+
-					"reflect check sees it.",
-				name,
-			)
-		}
-	}
-	for name := range mapperedFields {
-		if _, ok := declared[name]; !ok {
-			t.Errorf(
-				"mapperedFields references %q but intmodel.ContainerTty no longer declares it — "+
-					"drop the stale entry.",
-				name,
-			)
-		}
-	}
-}
-
-// TestWriteKukettyMetadata_AllTtyFieldsMap is the comprehensive renderer
-// guard #493 calls for. It exercises three concentric invariants:
-//
-//  1. Reflective coverage (ttyFieldsCoveredByMapping): every field declared
-//     on intmodel.ContainerTty is listed in mapperedFields. New fields
-//     must touch this file or the test fails.
-//  2. Per-field behavior: each Tty.* knob set on the input has a non-zero
-//     counterpart on the rendered TerminalDoc.Spec. The pre-#494 Tty.OnInit
-//     drop (declared on the schema, never read by the renderer) is the
-//     canonical failure mode this catches.
-//  3. Renderer-default invariants the cell schema does NOT surface but the
-//     renderer is responsible for stamping on every TerminalDoc:
-//     EnvInherit, SocketFile, CaptureFile, RunPath. EnvInherit=true is the
-//     bug fix from #494 that this test pins — without it, sbsh's terminal
-//     runner spawns the workload with HOME + SBSH_* only, stripping the
-//     user-supplied env and the KUKEON_* identity vars the OCI Process.Env
-//     already carries (sbsh@v0.11.2/internal/terminal/terminalrunner/
-//     terminal.go:54). Pre-#494 the profile loader's no-profile fallback
-//     defaulted EnvInherit=true (sbsh@v0.11.1/internal/profile/
-//     profile.go:454), so the inline-builder migration silently regressed
-//     env passthrough.
-//
-// When a new field lands on ContainerTty, this is the test that fails
-// until the renderer is taught to forward it and the mapping list is
-// updated.
-func TestWriteKukettyMetadata_AllTtyFieldsMap(t *testing.T) {
-	ttyFieldsCoveredByMapping(t)
-
+// TestWriteKukettyDoc_LogFileOverridePreserved confirms the daemon carries an
+// operator-pinned Tty.LogFile through to the doc verbatim (kuketty applies the
+// override at transform time). The default (no Tty) leaves LogFile empty in the
+// doc — kuketty resolves the daemon-controlled default path from its own
+// contract constant.
+func TestWriteKukettyDoc_LogFileOverridePreserved(t *testing.T) {
 	r := newTestRunner(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kuketty-metadata.json")
+	const override = "/var/log/sbsh-debug.log"
+	spec := intmodel.ContainerSpec{ID: "c1", Tty: &intmodel.ContainerTty{LogFile: override}}
 
-	const wantPrompt = `"\u@\h:\w\$ "`
-	wantOnInit := []intmodel.TtyStage{
-		{Script: "echo hello"},
-		{Script: "echo world"},
-	}
-	const wantLogLevel = "debug"
-	// Exercise the LogFile override (#599 reviewer ask): the renderer must
-	// stamp the operator-supplied path verbatim instead of the daemon
-	// default at ctr.AttachableKukettyLogPath. Picked outside the bind-
-	// mount root to prove the daemon does not anchor or rewrite the path.
-	const wantLogFile = "/var/log/kuketty-override.log"
-	const kukeonGID = 986
-	workload := []string{"/bin/sh", "-c", "exec /workload"}
-
-	spec := intmodel.ContainerSpec{
-		ID:         "c1",
-		RealmName:  "rA",
-		SpaceName:  "sB",
-		StackName:  "kC",
-		CellName:   "lD",
-		Attachable: true,
-		Tty: &intmodel.ContainerTty{
-			Prompt:   wantPrompt,
-			OnInit:   wantOnInit,
-			LogFile:  wantLogFile,
-			LogLevel: wantLogLevel,
-		},
-	}
-
-	if err := r.writeKukettyMetadata(path, spec, kukeonGID, workload); err != nil {
-		t.Fatalf("writeKukettyMetadata: %v", err)
+	if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}); err != nil {
+		t.Fatalf("writeKukettyDoc: %v", err)
 	}
 	doc := readDoc(t, path)
-
-	// Tty.Prompt → Spec.Prompt + Spec.SetPrompt (sbsh's `SetPrompt =
-	// !DisableSetPrompt` rule flips SetPrompt on for a non-empty prompt).
-	if doc.Spec.Prompt != wantPrompt {
-		t.Errorf("Tty.Prompt: Spec.Prompt = %q, want %q", doc.Spec.Prompt, wantPrompt)
-	}
-	if !doc.Spec.SetPrompt {
-		t.Errorf("Tty.Prompt: Spec.SetPrompt = false, want true (non-empty inline prompt)")
-	}
-
-	// Tty.OnInit → Spec.Stages.OnInit. The pre-#494 silent-drop fix: each
-	// TtyStage.Script lands as an api.ExecStep.Script in order. Stages.PostAttach
-	// is not surfaced on the cell schema and must stay zero.
-	if len(doc.Spec.Stages.OnInit) != len(wantOnInit) {
-		t.Fatalf(
-			"Tty.OnInit: Spec.Stages.OnInit len = %d, want %d (full=%+v)",
-			len(doc.Spec.Stages.OnInit), len(wantOnInit), doc.Spec.Stages.OnInit,
-		)
-	}
-	for i, want := range wantOnInit {
-		if doc.Spec.Stages.OnInit[i].Script != want.Script {
-			t.Errorf(
-				"Tty.OnInit[%d]: Spec.Stages.OnInit[%d].Script = %q, want %q",
-				i, i, doc.Spec.Stages.OnInit[i].Script, want.Script,
-			)
-		}
-	}
-	if len(doc.Spec.Stages.PostAttach) != 0 {
-		t.Errorf("Spec.Stages.PostAttach = %+v, want empty (not surfaced on cell schema)", doc.Spec.Stages.PostAttach)
-	}
-
-	// Tty.LogLevel → Spec.LogLevel (verbatim). The wrapper-log path
-	// itself is daemon-controlled and asserted via the always-on
-	// Spec.LogFile invariant a few lines below — operators only pick
-	// verbosity (issue #599).
-	if doc.Spec.LogLevel != wantLogLevel {
-		t.Errorf("Tty.LogLevel: Spec.LogLevel = %q, want %q", doc.Spec.LogLevel, wantLogLevel)
-	}
-
-	// Renderer-default invariants the cell schema does NOT surface. These
-	// are kukeon-side contracts the renderer must stamp regardless of cell
-	// YAML — a regression in any of them silently changes runtime behavior.
-	if !doc.Spec.EnvInherit {
-		t.Errorf(
-			"Spec.EnvInherit = false, want true. kuketty must forward its os.Environ() " +
-				"(== OCI Process.Env, which contains user env + KUKEON_*) to the workload; " +
-				"without WithEnvInherit(true), sbsh's runner strips everything but HOME + SBSH_* " +
-				"(sbsh@v0.11.2/internal/terminal/terminalrunner/terminal.go:54). #494 regression.",
-		)
-	}
-	if doc.Spec.SocketFile != ctr.AttachableSocketPath {
-		t.Errorf(
-			"Spec.SocketFile = %q, want %q (kukeon-controlled bind-mount path)",
-			doc.Spec.SocketFile,
-			ctr.AttachableSocketPath,
-		)
-	}
-	if doc.Spec.CaptureFile != ctr.AttachableCapturePath {
-		t.Errorf(
-			"Spec.CaptureFile = %q, want %q (kukeon-controlled bind-mount path)",
-			doc.Spec.CaptureFile,
-			ctr.AttachableCapturePath,
-		)
-	}
-	// Issue #599: Tty.LogFile override is stamped verbatim. Always-on
-	// behavior (Spec.LogFile non-empty regardless of cell YAML) is
-	// pinned by TestWriteKukettyMetadata_KukettyLogAlwaysOn; here we
-	// prove the override path round-trips without daemon-side rewriting.
-	if doc.Spec.LogFile != wantLogFile {
-		t.Errorf(
-			"Tty.LogFile: Spec.LogFile = %q, want %q (operator override stamped verbatim)",
-			doc.Spec.LogFile,
-			wantLogFile,
-		)
-	}
-	if doc.Spec.RunPath != ctr.AttachableTTYDir {
-		t.Errorf("Spec.RunPath = %q, want %q (sbsh's per-terminal root)", doc.Spec.RunPath, ctr.AttachableTTYDir)
-	}
-
-	// workloadArgv → Spec.Command + Spec.CommandArgs. Sanity-checked here
-	// alongside the Tty assertions because the comprehensive test is the
-	// single place a contributor can read off "what the renderer produces
-	// from a fully-populated input" without chasing per-field tests.
-	if doc.Spec.Command != workload[0] {
-		t.Errorf("workloadArgv: Spec.Command = %q, want %q", doc.Spec.Command, workload[0])
-	}
-	if len(doc.Spec.CommandArgs) != len(workload)-1 {
-		t.Fatalf("workloadArgv: Spec.CommandArgs len = %d, want %d", len(doc.Spec.CommandArgs), len(workload)-1)
-	}
-	for i, want := range workload[1:] {
-		if doc.Spec.CommandArgs[i] != want {
-			t.Errorf("workloadArgv: Spec.CommandArgs[%d] = %q, want %q", i, doc.Spec.CommandArgs[i], want)
-		}
-	}
-}
-
-// TestWriteKukettyMetadata_PromptConfigured locks the inline-Prompt lane
-// (#494): when the cell sets Tty.Prompt, the renderer stamps it onto
-// Spec.Prompt and flips Spec.SetPrompt on via sbsh's WithPrompt +
-// WithDisableSetPrompt(false). No profile YAML is loaded — the renderer
-// uses sbsh's inline BuildTerminalSpec entry point (sbsh v0.11.2 #209).
-// Replaces the pre-#494 phase-4 profile-coupling test that round-tripped a
-// TerminalProfile YAML through sbsh's pkg/discovery loader.
-func TestWriteKukettyMetadata_PromptConfigured(t *testing.T) {
-	r := newTestRunner(t)
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kuketty-metadata.json")
-	const wantPrompt = `"\[\e[1;36m\]claude \u@\h\[\e[0m\]:\w\$ "`
-	spec := intmodel.ContainerSpec{
-		ID:  "c1",
-		Tty: &intmodel.ContainerTty{Prompt: wantPrompt},
-	}
-
-	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
-		t.Fatalf("writeKukettyMetadata: %v", err)
-	}
-	doc := readDoc(t, path)
-	if doc.Spec.Prompt != wantPrompt {
-		t.Errorf("Spec.Prompt = %q, want %q", doc.Spec.Prompt, wantPrompt)
-	}
-	if !doc.Spec.SetPrompt {
-		t.Errorf("Spec.SetPrompt = false, want true (non-empty inline Tty.Prompt flips it on)")
-	}
-}
-
-// TestWriteKukettyMetadata_OnInitConfigured locks the inline-OnInit lane
-// (#494): when the cell sets Tty.OnInit, the renderer forwards each
-// TtyStage.Script to sbsh's WithOnInit as an api.ExecStep, in order, and
-// the rendered Spec.Stages.OnInit carries the same scripts. Closes the
-// pre-#494 silent drop where OnInit set on a cell with no profile was
-// never stamped onto the TerminalDoc (problem 1 in #494's Context).
-func TestWriteKukettyMetadata_OnInitConfigured(t *testing.T) {
-	r := newTestRunner(t)
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kuketty-metadata.json")
-	spec := intmodel.ContainerSpec{
-		ID: "c1",
-		Tty: &intmodel.ContainerTty{
-			OnInit: []intmodel.TtyStage{
-				{Script: "echo hello"},
-				{Script: "echo world"},
-			},
-		},
-	}
-
-	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
-		t.Fatalf("writeKukettyMetadata: %v", err)
-	}
-	doc := readDoc(t, path)
-	if len(doc.Spec.Stages.OnInit) != 2 {
-		t.Fatalf("Spec.Stages.OnInit len = %d, want 2", len(doc.Spec.Stages.OnInit))
-	}
-	if doc.Spec.Stages.OnInit[0].Script != "echo hello" ||
-		doc.Spec.Stages.OnInit[1].Script != "echo world" {
-		t.Errorf("Spec.Stages.OnInit = %+v, want [echo hello, echo world]", doc.Spec.Stages.OnInit)
-	}
-	if len(doc.Spec.Stages.PostAttach) != 0 {
-		t.Errorf("Spec.Stages.PostAttach = %+v, want empty (cell did not set it)", doc.Spec.Stages.PostAttach)
-	}
-}
-
-// TestWriteKukettyMetadata_EmptyTtyKeepsSafeDefault locks the safe-default
-// branch for an unconfigured Tty (#494): no cell-level Prompt or OnInit
-// means Spec.SetPrompt stays false (DisableSetPrompt(true) is forced) and
-// Spec.Stages stays zero. Without the DisableSetPrompt(true) belt, sbsh's
-// inline builder would flip SetPrompt on by default (`SetPrompt =
-// !DisableSetPrompt`), which would inject a literal PS1 onto a non-shell
-// workload's stdin. Same invariant the pre-#494 NoProfileKeepsSafeDefault
-// test enforced, now on the profile-free renderer.
-func TestWriteKukettyMetadata_EmptyTtyKeepsSafeDefault(t *testing.T) {
-	r := newTestRunner(t)
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kuketty-metadata.json")
-	spec := intmodel.ContainerSpec{ID: "c1"}
-
-	if err := r.writeKukettyMetadata(path, spec, 0, []string{"/bin/sh"}); err != nil {
-		t.Fatalf("writeKukettyMetadata: %v", err)
-	}
-	doc := readDoc(t, path)
-	if doc.Spec.SetPrompt {
-		t.Errorf("Spec.SetPrompt = true, want false (no inline Prompt → DisableSetPrompt(true))")
-	}
-	if doc.Spec.Prompt != "" {
-		t.Errorf("Spec.Prompt = %q, want empty (no inline Tty.Prompt)", doc.Spec.Prompt)
-	}
-	if len(doc.Spec.Stages.OnInit) != 0 {
-		t.Errorf("Spec.Stages.OnInit = %+v, want empty (no inline Tty.OnInit)", doc.Spec.Stages.OnInit)
-	}
-	if len(doc.Spec.Stages.PostAttach) != 0 {
-		t.Errorf("Spec.Stages.PostAttach = %+v, want empty (no inline Tty.OnInit)", doc.Spec.Stages.PostAttach)
-	}
-}
-
-// TestWriteKukettyMetadata_EmptyWorkloadFallsBackToBuilderDefault: when
-// the OCI args-wrap captures an empty Process.Args (image with no
-// ENTRYPOINT/CMD and no user override), the renderer leaves Spec.Command
-// at sbsh's hardcoded default (/bin/bash -i) rather than rendering an
-// empty Command — server.New rejects empty Command, which would brick
-// every container with an unset entrypoint.
-func TestWriteKukettyMetadata_EmptyWorkloadFallsBackToBuilderDefault(t *testing.T) {
-	r := newTestRunner(t)
-	dir := t.TempDir()
-	path := filepath.Join(dir, "kuketty-metadata.json")
-
-	if err := r.writeKukettyMetadata(path, intmodel.ContainerSpec{ID: "c1"}, 0, nil); err != nil {
-		t.Fatalf("writeKukettyMetadata: %v", err)
-	}
-	doc := readDoc(t, path)
-	if doc.Spec.Command == "" {
-		t.Errorf("Spec.Command is empty; expected the sbsh builder's hardcoded fallback")
+	if doc.Spec.Tty == nil || doc.Spec.Tty.LogFile != override {
+		t.Errorf("Spec.Tty.LogFile = %v, want %q", doc.Spec.Tty, override)
 	}
 }
 
@@ -970,13 +385,13 @@ func newTestRunner(t *testing.T) *Exec {
 	}
 }
 
-func readDoc(t *testing.T, path string) sbshapi.TerminalDoc {
+func readDoc(t *testing.T, path string) extmodel.ContainerDoc {
 	t.Helper()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}
-	var doc sbshapi.TerminalDoc
+	var doc extmodel.ContainerDoc
 	if err = json.Unmarshal(data, &doc); err != nil {
 		t.Fatalf("unmarshal %s: %v", path, err)
 	}

--- a/internal/ctr/attachable.go
+++ b/internal/ctr/attachable.go
@@ -30,10 +30,12 @@ import (
 // in pkg/api/model/v1beta1/container.go.
 //
 // kuketty (issue #165) replaces sbsh on the OCI injection path. Phase 1b
-// (#410) lands the attach-socket RPC server: kuketty consumes the
-// kukeond-rendered api.TerminalDoc directly via sbsh's pkg/terminal/server
-// facade. The wrapper is invoked with no CLI flags — every runtime input
-// flows through the bind-mounted metadata file.
+// (#410) lands the attach-socket RPC server. Issue #641 makes the daemon mount
+// kukeon's own api/model/v1beta1.ContainerDoc instead of a pre-rendered sbsh
+// TerminalDoc: kuketty reads ContainerDoc.Spec, builds the TerminalSpec, and
+// serves it via sbsh's pkg/terminal/server facade. The wrapper is invoked with
+// no CLI flags — every runtime input flows through the bind-mounted metadata
+// file.
 const (
 	// AttachableBinaryPath is where the kuketty binary is bind-mounted
 	// read-only inside the container. The host source is staged from
@@ -135,10 +137,10 @@ type AttachableInjection struct {
 	// of the image's ENTRYPOINT + CMD and any user override that
 	// containerd's WithImageConfig and our WithProcessArgs have already
 	// applied to s.Process.Args by the time the wrap runs. The callback
-	// is expected to render the api.TerminalDoc with the workload argv
-	// baked into Spec.Command / Spec.CommandArgs and write it atomically
-	// to HostMetadataPath. nil disables metadata rendering — used by
-	// unit tests that exercise only the args-wrap shape.
+	// is expected to render the ContainerDoc with the workload argv baked
+	// into Spec.Command / Spec.Args and write it atomically to
+	// HostMetadataPath. nil disables metadata rendering — used by unit
+	// tests that exercise only the args-wrap shape.
 	RenderMetadata func(workloadArgv []string) error
 }
 
@@ -194,8 +196,8 @@ func withAttachableMounts(inj AttachableInjection) oci.SpecOpts {
 // s.Process.Args (containerd's WithImageConfigArgs and any user-supplied
 // WithProcessArgs have already run by this point), hands the argv to the
 // injection's metadata renderer so kuketty receives the workload in
-// Spec.Command / Spec.CommandArgs of the bind-mounted api.TerminalDoc, and
-// then rewrites Process.Args to a single element: the kuketty binary path.
+// Spec.Command / Spec.Args of the bind-mounted ContainerDoc, and then
+// rewrites Process.Args to a single element: the kuketty binary path.
 // No CLI flags by design (issue #410 redirect): kuketty reads every runtime
 // input — including the workload to spawn — from the metadata file. The
 // optional `--config` override exists only for test/debug ergonomics and is

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -101,9 +101,10 @@ type ContainerSpec struct {
 	// tty directory at /run/kukeon/tty (kuketty owns the attach socket
 	// inside it; capture and log files land in later phases), and
 	// bind-mounts the per-container metadata file read-only at
-	// /.kukeon/kuketty/metadata.json (carries the rendered api.TerminalDoc
-	// with the workload argv baked into Spec.Command / Spec.CommandArgs).
-	// The host-visible peer of the tty directory lives in the per-container
+	// /.kukeon/kuketty/metadata.json (carries this ContainerDoc with the
+	// resolved workload argv baked into Spec.Command / Spec.Args, from which
+	// kuketty builds the sbsh TerminalSpec it serves — issue #641). The
+	// host-visible peer of the tty directory lives in the per-container
 	// metadata dir and its `socket` entry is what `kuke attach` connects
 	// to. Default false — no behavior change for existing specs.
 	Attachable bool `json:"attachable,omitempty"             yaml:"attachable,omitempty"`
@@ -113,6 +114,18 @@ type ContainerSpec struct {
 	// layers the container model can't express. Setting any tty field with
 	// Attachable=false is a validation error.
 	Tty *ContainerTty `json:"tty,omitempty"                    yaml:"tty,omitempty"`
+	// KukeonGroupGID is a daemon-stamped transport field, not user-authored
+	// config. It carries the resolved kukeon-group GID into the ContainerDoc
+	// the daemon mounts at /.kukeon/kuketty/metadata.json so kuketty can apply
+	// the kukeon-group ownership (socket / capture / log GID + mode) the daemon
+	// used to fold into the rendered TerminalSpec — a value not knowable from
+	// inside the container. Zero means no kukeon group is configured (kuketty
+	// then leaves OS-default permissions on the inodes it creates, matching the
+	// no-group fallback). Always zero on the persisted ContainerDoc and on
+	// `kuke get` output (omitempty): the daemon populates it only on the
+	// kuketty-mounted doc, and the read path never round-trips it back into the
+	// internal model. Issue #641.
+	KukeonGroupGID int `json:"kukeonGroupGID,omitempty"         yaml:"kukeonGroupGID,omitempty"`
 }
 
 // ContainerTty carries per-attach shell-UX config that the daemon threads

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -203,15 +203,17 @@ step "Daemon parity check (both must show identical output)"
 sudo --preserve-env=KUKEON_HOST ./kuke get realms
 sudo ./kuke get realms --no-daemon
 
-# Phase 1b smoke (#410): the daemon's metadata-rendering path now emits
-# api.TerminalDoc consumed by kuketty's sbsh-backed RPC server. A regression
-# in the renderer or the kuketty image bundle would otherwise surface only
-# the next time someone ran `kuke attach`, well after the dev-init success
-# message had lulled the contributor into a false sense of safety. Drive a
-# disposable attachable cell through the daemon, wait for kuketty to bind
-# the per-container socket, sanity-check the rendered TerminalDoc, and run
-# a PTY-driven `kuke attach` that detaches cleanly via the standard ^]^]
-# sequence.
+# Phase 1b smoke (#410): the daemon's metadata-rendering path emits the
+# bind-mounted kuketty config consumed by kuketty's sbsh-backed RPC server.
+# Since issue #641 that config is a kukeon ContainerDoc (kuketty builds the
+# sbsh TerminalSpec from it in-process) rather than a pre-rendered TerminalDoc.
+# A regression in the renderer or the kuketty image bundle would otherwise
+# surface only the next time someone ran `kuke attach`, well after the
+# dev-init success message had lulled the contributor into a false sense of
+# safety. Drive a disposable attachable cell through the daemon, wait for
+# kuketty to bind the per-container socket, sanity-check the rendered
+# ContainerDoc, and run a PTY-driven `kuke attach` that detaches cleanly via
+# the standard ^]^] sequence.
 step "kuke attach smoke against a kuketty-wrapped cell"
 
 ATTACH_SMOKE_REALM="dev-init-attach"
@@ -292,13 +294,16 @@ done
 sudo test -S "${ATTACH_SMOKE_SOCKET}" \
     || { printf 'kuketty socket not bound at %s after 20s\n' "${ATTACH_SMOKE_SOCKET}" >&2; exit 1; }
 
-# Validate the on-disk schema discriminator. A renderer regression
-# (e.g. kukeon-side v1alpha1 schema sneaking back in) is caught here
-# rather than as an opaque "kind/apiVersion mismatch" in the kuketty log.
-sudo grep -q '"apiVersion": "sbsh/v1beta1"' "${ATTACH_SMOKE_METADATA}" \
-    || { printf 'rendered metadata at %s missing apiVersion sbsh/v1beta1\n' "${ATTACH_SMOKE_METADATA}" >&2; exit 1; }
-sudo grep -q '"kind": "Terminal"' "${ATTACH_SMOKE_METADATA}" \
-    || { printf 'rendered metadata at %s missing kind Terminal\n' "${ATTACH_SMOKE_METADATA}" >&2; exit 1; }
+# Validate the on-disk schema discriminator. Since issue #641 the daemon
+# mounts a kukeon ContainerDoc (apiVersion v1beta1, kind Container) rather
+# than a pre-rendered sbsh TerminalDoc — kuketty reads ContainerDoc.Spec and
+# builds the TerminalSpec itself. A renderer regression (e.g. an old
+# TerminalDoc schema sneaking back in) is caught here rather than as an opaque
+# kind/apiVersion mismatch in the kuketty log.
+sudo grep -q '"apiVersion": "v1beta1"' "${ATTACH_SMOKE_METADATA}" \
+    || { printf 'rendered metadata at %s missing apiVersion v1beta1\n' "${ATTACH_SMOKE_METADATA}" >&2; exit 1; }
+sudo grep -q '"kind": "Container"' "${ATTACH_SMOKE_METADATA}" \
+    || { printf 'rendered metadata at %s missing kind Container\n' "${ATTACH_SMOKE_METADATA}" >&2; exit 1; }
 
 # PTY-driven `kuke attach` smoke. hack/attach-smoke allocates a TTY
 # (pkg/attach requires one), waits for pkg/attach's raw-mode keyboard


### PR DESCRIPTION
## Summary

Phase 0 of #423 — the foundation the repos (#617) and run-once `onInit` (#635) work build on. Today kuketty is a pure passthrough of a daemon-rendered sbsh `TerminalDoc` and has no view of kukeon's own `ContainerSpec` and no typed home for status. This PR makes the daemon mount kukeon's native `ContainerDoc` and relocates the `ContainerSpec → TerminalSpec` transform into kuketty, so future crew-absorption layers can act on kukeon's spec inside the container and report into `ContainerStatus` without bolting fields onto the external sbsh type (which is what forced #627 to invent a sibling `repos.json`).

- **Daemon emits a `ContainerDoc`, not a `TerminalDoc`** (`writeKukettyMetadata` → `writeKukettyDoc` in `internal/controller/runner/attachable.go`). It converts the internal spec via the existing `apischeme.BuildContainerSpecExternalFromInternal`, stamps the three daemon-only resolved values, and writes a `v1beta1.ContainerDoc` (spec populated, status zero, cell-context labels on `Metadata`).
- **kuketty owns the transform** (`cmd/kuketty/spec.go`): reads `ContainerDoc.Spec`, runs `sbshbuilder.BuildTerminalSpec`, and serves. It gains a build-dep on `sbsh/pkg/builder` (same module it already pulled `server` from — no new external dep) and on `pkg/api/model/v1beta1` (zero heavy deps). **kuketty's import closure stays free of containerd/grpc/protobuf** — verified below; this is the #165 invariant.
- The three values not knowable inside the container travel in the doc: resolved workload argv → `Spec.Command`/`Spec.Args`; kukeon-group GID → new `Spec.KukeonGroupGID` transport field; resolved log level (per-container → server-config → "info", a chain whose middle tier is daemon-only) → `Spec.Tty.LogLevel`. Everything else (fixed in-container socket/capture/log paths and modes) are kukeon contract constants kuketty knows directly.

## Design calls (reviewer, please push back)

- **New `Spec.KukeonGroupGID int` field on `v1beta1.ContainerSpec`** (`omitempty`, daemon-stamped transport, documented as such). The AC mandates the GID "travel in the mounted doc"; this is the typed home. It is never persisted nor round-tripped back into the internal model (the read path has no such field) and is zero on `kuke get` output. Alternative considered: stuff it in `Metadata.Labels` as a string — rejected for losing type safety on a scalar the AC calls out explicitly.
- **In-container path/mode constants are duplicated in `cmd/kuketty/spec.go` with a "kept in sync with `internal/ctr/attachable.go`" comment**, matching the established `defaultConfigPath` ↔ `ctr.AttachableMetadataPath` precedent in `main.go`. kuketty cannot import `internal/ctr` (it drags in the whole containerd closure). A shared zero-dep consts package is the cleaner long-term design but would churn every `ctr.Attachable*` caller across the heavy package; deferred to keep this diff focused on the matched-pair wire change.
- **Resolved log level reuses `Tty.LogLevel`** (daemon allocates the `Tty` block when the cell omitted it) rather than adding a second log-level field, so kuketty reads one unambiguous value verbatim.

## Test plan

- [x] `make test` (full CI target) — all green, incl. the 70s `internal/ctr` suite.
- [x] `go build ./...` and `go vet ./...` — clean.
- [x] `pre-commit run --files <changed>` — trailing-whitespace, go-fmt, go-mod-tidy, **golangci-lint**, addlicense all pass.
- [x] Renderer-invariant coverage ported to the kuketty side (`cmd/kuketty/spec_test.go`): env-inherit, socket/capture/log GID + mode gating, prompt/SetPrompt, OnInit, log-file override, log-level-verbatim, the reflective "every Tty field maps" guard, and the empty-workload sbsh-default fallback — all asserting on the built `*TerminalSpec`.
- [x] Daemon doc emission test (`internal/controller/runner/attachable_test.go`): `ContainerDoc` shape (apiVersion/kind/labels/zero-status/0o600), argv stamped into `Command`/`Args`, `KukeonGroupGID` carried, and the per-container → server-config → "info" log-level resolution that stays daemon-side.
- [x] **`make dev-init` smoke + `kuke attach`** (daemon-parity check per CLAUDE.md): both `kuke get realms` and `--no-daemon` show identical output; `kuke attach exited cleanly` against a kuketty-wrapped cell; the `scripts/dev-init.sh` metadata discriminator check (updated to `apiVersion v1beta1` / `kind Container`) passed; nested parent-attach plumbing intact.
- [x] kuketty closure stays clean: `go list -deps ./cmd/kuketty/ | grep -E 'containerd|grpc|protobuf'` returns empty.

## Notes

- No external dependency — does **not** need eminwux/sbsh#291 (that gates only the status RPC in phase 1b).
- `scripts/dev-init.sh` is updated in lockstep because the mounted artifact's schema discriminator changed (`sbsh/v1beta1`/`Terminal` → `v1beta1`/`Container`); the daemon-parity tail is unchanged.

Closes #641