### PR TITLE
fix: purge stale root-container CNI/IPAM reservation on create-fresh start path

### DIFF
--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -153,6 +153,28 @@ func teardownRootContainerCNI(releaseCNI func(), deleteContainer func() error, p
 	return delErr
 }
 
+// purgeStaleRootContainerCNI is the create-fresh-path safety net for the
+// root-container CNI re-ADD collision (issue #649). After a clean stop/kill the
+// root container is *deleted*, so StartCell's container-exists teardown branch
+// (teardownRootContainerCNI) never runs on the next start — but a best-effort
+// stop/kill purge that failed (netns already gone, mismatched network name, or
+// a crash mid-teardown) can leave a stale /var/lib/cni/networks/<network>/<ip>
+// reservation keyed to the deterministic root-container ID. host-local then
+// rejects the re-ADD as a duplicate allocation. This scrubs that reservation
+// before CNI ADD on the ErrContainerNotFound branch, giving the create-fresh
+// path the same second line of defence the teardown branch already has.
+//
+// Best-effort and a no-op when networkName is "" (resolveRootCNINetworkName
+// couldn't derive a name), so a clean start with no stale reservation is
+// unaffected. Decoupled from the concrete CNI client — same rationale as
+// teardownRootContainerCNI — so the run/no-op decision is unit-testable.
+func purgeStaleRootContainerCNI(networkName string, purge func()) {
+	if networkName == "" {
+		return
+	}
+	purge()
+}
+
 // maxFailureMessageLen caps Status.Message so a long, multi-line wrap from
 // `fmt.Errorf("%w: %w", …)` chains doesn't blow up `kuke get cell -o yaml`.
 // 256 bytes is comfortably wider than any error sentinel string in the repo
@@ -411,6 +433,16 @@ func (r *Exec) StartCell(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
 				"root container does not exist, will create fresh",
 				fields...,
 			)
+			// Create-fresh safety net (issue #649): the root container is gone,
+			// so the teardown branch below never runs — but a prior stop/kill
+			// (or a crash mid-teardown) may have left a stale host-local IPAM
+			// reservation keyed to this deterministic root-container ID. Scrub
+			// it before CNI ADD so the re-ADD isn't rejected as a duplicate
+			// allocation. Best-effort and a no-op when no stale file exists.
+			networkName := r.resolveRootCNINetworkName(realmID, spaceID)
+			purgeStaleRootContainerCNI(networkName, func() {
+				_ = r.purgeCNIForContainer(containerID, "", networkName)
+			})
 		} else {
 			// Other errors are unexpected
 			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -351,6 +351,32 @@ func TestTeardownRootContainerCNI_OrderingAndSafetyNet(t *testing.T) {
 	})
 }
 
+// TestPurgeStaleRootContainerCNI_CreateFreshSafetyNet is the regression guard
+// for issue #649. On StartCell's ErrContainerNotFound (create-fresh) branch the
+// root container is already deleted, so the teardownRootContainerCNI net never
+// runs — purgeStaleRootContainerCNI must scrub a stale host-local IPAM
+// reservation keyed to the deterministic root-container ID before CNI ADD so
+// the re-ADD isn't rejected as a duplicate allocation. The purge is best-effort
+// and must be a no-op when resolveRootCNINetworkName couldn't derive a name (""),
+// leaving a clean start with no stale reservation unaffected.
+func TestPurgeStaleRootContainerCNI_CreateFreshSafetyNet(t *testing.T) {
+	t.Run("purge_runs_when_network_name_resolves", func(t *testing.T) {
+		called := false
+		purgeStaleRootContainerCNI("kuke-default", func() { called = true })
+		if !called {
+			t.Error("purge must run on the create-fresh path when the network name resolves")
+		}
+	})
+
+	t.Run("purge_is_noop_when_network_name_empty", func(t *testing.T) {
+		called := false
+		purgeStaleRootContainerCNI("", func() { called = true })
+		if called {
+			t.Error("purge must be a no-op when network name is empty (clean start unaffected)")
+		}
+	})
+}
+
 // TestTruncateFailureMessage pins the single-line + length-bounded contract
 // markCellFailed relies on for Status.Message: long, multi-line wrapped
 // `fmt.Errorf("%w: %w", …)` chains must end up as a single, capped string


### PR DESCRIPTION
## Summary

- `kuke start cell` could fail with `<ip> has been allocated to <root-id>, duplicate allocation is not allowed` when a prior stop/kill (or a crash mid-teardown) left a stale host-local IPAM reservation keyed to the cell's deterministic root-container ID.
- #640 added the release-before-recreate net (`teardownRootContainerCNI`), but it only runs on the **container-exists** branch. After a clean `stop`/`kill` the root container is *deleted*, so `StartCell` takes the `ErrContainerNotFound` (create-fresh) branch — which fell straight through to CNI ADD with no IPAM purge, leaving the create-fresh path with no second line of defence.
- Adds a best-effort IPAM-file purge on the create-fresh branch too: resolve the network name (`resolveRootCNINetworkName`) and call `purgeCNIForContainer(containerID, "", networkName)` before CNI ADD, so a stale reservation is scrubbed and `kuke start cell` is idempotent regardless of whether the root container survived.
- Extracted a small decoupled helper `purgeStaleRootContainerCNI(networkName, purge)` (no-op when the name is `""`) mirroring `teardownRootContainerCNI`, so the run/no-op decision is unit-testable without a live runtime.

## Test plan

- [x] `make test` — full CI unit suite passes (`go list ./... | grep -v /e2e`).
- [x] `go build ./...`, `go vet ./internal/controller/runner/`
- [x] `go test ./internal/controller/runner/ -run 'TestPurgeStaleRootContainerCNI|TestTeardownRootContainerCNI' -v` — new test asserts the purge runs when the network name resolves and is a no-op when empty, mirroring the existing teardown ordering test.
- [x] `pre-commit run --files <changed>` — all hooks pass (golangci-lint, go fmt, addlicense).
- [ ] `make dev-init` smoke — not run: change is confined to `internal/controller/runner` logic and touches no build path, daemon bootstrap, or `/opt/kukeon` layout, so the daemon-parity regression guard does not apply.

## Acceptance criteria

- [x] `kuke start cell <name>` purges any stale host-local IPAM reservation keyed to the root-container ID before CNI ADD on the `ErrContainerNotFound` branch as well as the container-exists teardown path.
- [x] A cell whose prior stop/kill left an orphaned `/var/lib/cni/networks/<network>/<ip>` file for its root container starts without manual cleanup (the create-fresh branch now scrubs it before re-ADD).
- [x] The purge is best-effort (warn-and-continue via `purgeCNIForContainer`) and a no-op when the network name can't be resolved, so a clean start path is unaffected.
- [x] Covered by a unit test (`TestPurgeStaleRootContainerCNI_CreateFreshSafetyNet`) mirroring the existing `teardownRootContainerCNI` ordering test in `start_test.go`.

Closes #649