### PR TITLE
feat(container): add git[] sugar over GIT_* env-var protocol (phase 2)

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -321,6 +321,9 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 		if err := validateContainerTty(in.Spec); err != nil {
 			return intmodel.Container{}, err
 		}
+		if err := validateContainerGit(in.Spec); err != nil {
+			return intmodel.Container{}, err
+		}
 		return intmodel.Container{
 			Metadata: intmodel.ContainerMetadata{
 				Name:   in.Metadata.Name,
@@ -354,6 +357,7 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				Resources:              convertResourcesToInternal(in.Spec.Resources),
 				Secrets:                convertSecretsToInternal(in.Spec.Secrets),
 				Repos:                  reposToInternal(in.Spec.Repos),
+				Git:                    gitToInternal(in.Spec.Git),
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
 				Attachable:             in.Spec.Attachable,
@@ -416,6 +420,7 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				Resources:              buildResourcesExternalFromInternal(in.Spec.Resources),
 				Secrets:                buildSecretsExternalFromInternal(in.Spec.Secrets),
 				Repos:                  reposToExternal(in.Spec.Repos),
+				Git:                    gitToExternal(in.Spec.Git),
 				CNIConfigPath:          in.Spec.CNIConfigPath,
 				RestartPolicy:          in.Spec.RestartPolicy,
 				Attachable:             in.Spec.Attachable,
@@ -481,6 +486,7 @@ func convertContainerSpecToInternal(in ext.ContainerSpec) intmodel.ContainerSpec
 		Resources:              convertResourcesToInternal(in.Resources),
 		Secrets:                convertSecretsToInternal(in.Secrets),
 		Repos:                  reposToInternal(in.Repos),
+		Git:                    gitToInternal(in.Git),
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
 		Attachable:             in.Attachable,
@@ -520,6 +526,7 @@ func BuildContainerSpecExternalFromInternal(in intmodel.ContainerSpec) ext.Conta
 		Resources:              buildResourcesExternalFromInternal(in.Resources),
 		Secrets:                buildSecretsExternalFromInternal(in.Secrets),
 		Repos:                  reposToExternal(in.Repos),
+		Git:                    gitToExternal(in.Git),
 		CNIConfigPath:          in.CNIConfigPath,
 		RestartPolicy:          in.RestartPolicy,
 		Attachable:             in.Attachable,
@@ -884,6 +891,91 @@ func repoStatusesToExternal(in []intmodel.RepoStatus) []ext.RepoStatus {
 	return out
 }
 
+// gitToInternal copies the external git sugar block into the internal model,
+// deep-copying the Author/Committer pointers and Sign slice. Issue #618.
+func gitToInternal(in *ext.ContainerGit) *intmodel.ContainerGit {
+	if in == nil {
+		return nil
+	}
+	out := &intmodel.ContainerGit{
+		SigningKey:     in.SigningKey,
+		Sign:           cloneStringSlice(in.Sign),
+		AllowedSigners: in.AllowedSigners,
+	}
+	if in.Author != nil {
+		out.Author = &intmodel.GitIdentity{Name: in.Author.Name, Email: in.Author.Email}
+	}
+	if in.Committer != nil {
+		out.Committer = &intmodel.GitIdentity{Name: in.Committer.Name, Email: in.Committer.Email}
+	}
+	return out
+}
+
+// gitToExternal is the inverse of gitToInternal.
+func gitToExternal(in *intmodel.ContainerGit) *ext.ContainerGit {
+	if in == nil {
+		return nil
+	}
+	out := &ext.ContainerGit{
+		SigningKey:     in.SigningKey,
+		Sign:           cloneStringSlice(in.Sign),
+		AllowedSigners: in.AllowedSigners,
+	}
+	if in.Author != nil {
+		out.Author = &ext.GitIdentity{Name: in.Author.Name, Email: in.Author.Email}
+	}
+	if in.Committer != nil {
+		out.Committer = &ext.GitIdentity{Name: in.Committer.Name, Email: in.Committer.Email}
+	}
+	return out
+}
+
+// validateContainerGit enforces the ContainerGit invariants (issue #618):
+//   - author and committer each require both name and email when present, so
+//     a half-specified identity never renders a GIT_AUTHOR_EMAIL= empty entry.
+//   - sign requires signingKey, since commit.gpgsign/tag.gpgsign with no
+//     user.signingkey makes git fail the commit at runtime rather than at
+//     apply time.
+//   - each sign entry must be a known target (commits or tags), rejected at
+//     apply time rather than silently dropped during expansion.
+func validateContainerGit(spec ext.ContainerSpec) error {
+	git := spec.Git
+	if git == nil {
+		return nil
+	}
+	if err := validateGitIdentity("author", git.Author); err != nil {
+		return fmt.Errorf("container %q: %w", spec.ID, err)
+	}
+	if err := validateGitIdentity("committer", git.Committer); err != nil {
+		return fmt.Errorf("container %q: %w", spec.ID, err)
+	}
+	for _, s := range git.Sign {
+		if s != ext.GitSignCommits && s != ext.GitSignTags {
+			return fmt.Errorf(
+				"container %q: git.sign %q: must be one of %q, %q",
+				spec.ID, s, ext.GitSignCommits, ext.GitSignTags,
+			)
+		}
+	}
+	if len(git.Sign) > 0 && git.SigningKey == "" {
+		return fmt.Errorf("container %q: git.sign requires git.signingKey to be set", spec.ID)
+	}
+	return nil
+}
+
+// validateGitIdentity rejects a git identity that sets only one of name/email
+// — both are required so the expanded GIT_*_NAME / GIT_*_EMAIL pair is never
+// half-empty.
+func validateGitIdentity(role string, id *ext.GitIdentity) error {
+	if id == nil {
+		return nil
+	}
+	if id.Name == "" || id.Email == "" {
+		return fmt.Errorf("git.%s requires both name and email", role)
+	}
+	return nil
+}
+
 func convertSpaceDefaultsToInternal(in *ext.SpaceDefaults) *intmodel.SpaceDefaults {
 	if in == nil {
 		return nil
@@ -1035,6 +1127,9 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 	case VersionV1Beta1, "": // default/empty treated as v1beta1
 		for _, c := range in.Spec.Containers {
 			if err := validateContainerTty(c); err != nil {
+				return intmodel.Cell{}, err
+			}
+			if err := validateContainerGit(c); err != nil {
 				return intmodel.Cell{}, err
 			}
 		}

--- a/internal/apischeme/scheme_git_test.go
+++ b/internal/apischeme/scheme_git_test.go
@@ -1,0 +1,166 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func gitContainerDoc(git *ext.ContainerGit) ext.ContainerDoc {
+	return ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "c"},
+		Spec: ext.ContainerSpec{
+			ID:      "c",
+			RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+			Image: "alpine:latest",
+			Git:   git,
+		},
+	}
+}
+
+// TestContainerGitRoundTripV1Beta1 covers that a populated git block survives
+// ConvertContainerDocToInternal + BuildContainerExternalFromInternal with no
+// fields dropped. Issue #618.
+func TestContainerGitRoundTripV1Beta1(t *testing.T) {
+	input := gitContainerDoc(&ext.ContainerGit{
+		Author:         &ext.GitIdentity{Name: "Dev", Email: "dev@eminwux.com"},
+		Committer:      &ext.GitIdentity{Name: "Dev", Email: "dev@eminwux.com"},
+		SigningKey:     "/home/claude/.ssh/id_ed25519.pub",
+		Sign:           []string{ext.GitSignCommits, ext.GitSignTags},
+		AllowedSigners: "/home/claude/.ssh/allowed_signers",
+	})
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	if internal.Spec.Git == nil {
+		t.Fatalf("internal.Spec.Git = nil, want populated")
+	}
+	if internal.Spec.Git.Author == nil || internal.Spec.Git.Author.Email != "dev@eminwux.com" {
+		t.Errorf("internal author = %+v, want dev@eminwux.com", internal.Spec.Git.Author)
+	}
+	if internal.Spec.Git.SigningKey != input.Spec.Git.SigningKey {
+		t.Errorf("internal signingKey = %q, want %q", internal.Spec.Git.SigningKey, input.Spec.Git.SigningKey)
+	}
+	if len(internal.Spec.Git.Sign) != 2 {
+		t.Errorf("internal sign = %v, want 2 entries", internal.Spec.Git.Sign)
+	}
+	if internal.Spec.Git.AllowedSigners != input.Spec.Git.AllowedSigners {
+		t.Errorf("internal allowedSigners = %q, want %q", internal.Spec.Git.AllowedSigners, input.Spec.Git.AllowedSigners)
+	}
+
+	out, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	if out.Spec.Git == nil {
+		t.Fatalf("round-trip dropped git block: %+v", out.Spec)
+	}
+	if out.Spec.Git.Committer == nil || out.Spec.Git.Committer.Name != "Dev" {
+		t.Errorf("round-trip committer = %+v, want Dev", out.Spec.Git.Committer)
+	}
+	if out.Spec.Git.AllowedSigners != input.Spec.Git.AllowedSigners {
+		t.Errorf("round-trip allowedSigners = %q, want %q", out.Spec.Git.AllowedSigners, input.Spec.Git.AllowedSigners)
+	}
+}
+
+// TestContainerGitDeepCopy asserts gitToInternal deep-copies the Author
+// pointer and Sign slice, so mutating the source after conversion can't bleed
+// into the internal model.
+func TestContainerGitDeepCopy(t *testing.T) {
+	src := &ext.ContainerGit{
+		Author:     &ext.GitIdentity{Name: "Dev", Email: "dev@eminwux.com"},
+		SigningKey: "/k.pub",
+		Sign:       []string{ext.GitSignCommits},
+	}
+	internal, _, err := apischeme.NormalizeContainer(gitContainerDoc(src))
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	src.Author.Email = "mutated@example.com"
+	src.Sign[0] = "mutated"
+	if internal.Spec.Git.Author.Email != "dev@eminwux.com" {
+		t.Errorf("internal author email mutated through shared pointer: %q", internal.Spec.Git.Author.Email)
+	}
+	if internal.Spec.Git.Sign[0] != ext.GitSignCommits {
+		t.Errorf("internal sign mutated through shared slice: %q", internal.Spec.Git.Sign[0])
+	}
+}
+
+func TestContainerGitValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		git     *ext.ContainerGit
+		wantErr string // substring; "" means expect success
+	}{
+		{
+			name: "full block valid",
+			git: &ext.ContainerGit{
+				Author:         &ext.GitIdentity{Name: "Dev", Email: "dev@eminwux.com"},
+				Committer:      &ext.GitIdentity{Name: "Dev", Email: "dev@eminwux.com"},
+				SigningKey:     "/k.pub",
+				Sign:           []string{ext.GitSignCommits, ext.GitSignTags},
+				AllowedSigners: "/allowed",
+			},
+		},
+		{name: "nil git valid", git: nil},
+		{
+			name:    "author missing email",
+			git:     &ext.ContainerGit{Author: &ext.GitIdentity{Name: "Dev"}},
+			wantErr: "git.author requires both name and email",
+		},
+		{
+			name:    "committer missing name",
+			git:     &ext.ContainerGit{Committer: &ext.GitIdentity{Email: "dev@eminwux.com"}},
+			wantErr: "git.committer requires both name and email",
+		},
+		{
+			name:    "sign without signingKey",
+			git:     &ext.ContainerGit{Sign: []string{ext.GitSignCommits}},
+			wantErr: "git.sign requires git.signingKey",
+		},
+		{
+			name:    "unknown sign target",
+			git:     &ext.ContainerGit{SigningKey: "/k.pub", Sign: []string{"branches"}},
+			wantErr: "must be one of",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := apischeme.ConvertContainerDocToInternal(gitContainerDoc(tt.git))
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -422,17 +422,20 @@ func nestedCgroupMount() runtimespec.Mount {
 }
 
 // kukeonContainerEnv builds the final container env: a set of KUKEON_*
-// identity vars derived from the container spec's cell-context fields,
-// merged with the user-supplied spec.Env. User entries override defaults on
-// key collisions; empty cell-context fields produce no entry. Order in the
-// returned slice is: surviving defaults in canonical order, then user
-// entries in their declared order. The merge is done here (rather than
+// identity vars derived from the container spec's cell-context fields, plus
+// the GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_* block expanded from
+// spec.Git (issue #618), all merged with the user-supplied spec.Env. User
+// entries override defaults on key collisions; empty cell-context fields and
+// an absent git block produce no entries. Order in the returned slice is:
+// surviving defaults in canonical order, then user entries in their declared
+// order. The merge is done here (rather than
 // trusting oci.WithEnv) because containerd's replaceOrAppendEnvValues
 // dedupes only against keys already present in spec.Process.Env when WithEnv
 // runs, so two entries with the same key inside a single overrides slice
 // would both end up in the final env. Issue #351.
 func kukeonContainerEnv(spec intmodel.ContainerSpec) []string {
 	defaults := kukeonDefaultEnv(spec)
+	defaults = append(defaults, gitEnv(spec.Git)...)
 	switch {
 	case len(spec.Env) == 0:
 		return defaults
@@ -477,6 +480,67 @@ func kukeonDefaultEnv(spec intmodel.ContainerSpec) []string {
 			continue
 		}
 		out = append(out, p.key+"="+p.value)
+	}
+	return out
+}
+
+// gitEnv expands a container's git identity/signing sugar (ContainerSpec.Git)
+// into the GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_* env-var block git
+// reads natively, replacing the hand-rolled block crew templates duplicate
+// per cell today. Returns nil when git is unset. The GIT_CONFIG_* signing
+// pairs are emitted in crew's canonical order — user.signingkey, gpg.format,
+// commit.gpgsign, tag.gpgsign, gpg.ssh.allowedSignersFile — with
+// GIT_CONFIG_COUNT tracking the live pair count, so a block that omits signing
+// renders no GIT_CONFIG_* entries at all. gpg.format=ssh is implied by a
+// non-empty signingKey (kukeon signs with SSH keys). The returned entries are
+// merged with the user's explicit env by kukeonContainerEnv, where an explicit
+// env: entry wins on key collision. Issue #618.
+func gitEnv(git *intmodel.ContainerGit) []string {
+	if git == nil {
+		return nil
+	}
+	var out []string
+	if git.Author != nil {
+		out = append(out,
+			"GIT_AUTHOR_NAME="+git.Author.Name,
+			"GIT_AUTHOR_EMAIL="+git.Author.Email,
+		)
+	}
+	if git.Committer != nil {
+		out = append(out,
+			"GIT_COMMITTER_NAME="+git.Committer.Name,
+			"GIT_COMMITTER_EMAIL="+git.Committer.Email,
+		)
+	}
+
+	type configPair struct{ key, value string }
+	var pairs []configPair
+	if git.SigningKey != "" {
+		pairs = append(pairs,
+			configPair{"user.signingkey", git.SigningKey},
+			configPair{"gpg.format", "ssh"},
+		)
+	}
+	for _, s := range git.Sign {
+		switch s {
+		case intmodel.GitSignCommits:
+			pairs = append(pairs, configPair{"commit.gpgsign", "true"})
+		case intmodel.GitSignTags:
+			pairs = append(pairs, configPair{"tag.gpgsign", "true"})
+		}
+	}
+	if git.AllowedSigners != "" {
+		pairs = append(pairs, configPair{"gpg.ssh.allowedSignersFile", git.AllowedSigners})
+	}
+	if len(pairs) > 0 {
+		out = append(out, "GIT_CONFIG_COUNT="+strconv.Itoa(len(pairs)))
+		for i, p := range pairs {
+			n := strconv.Itoa(i)
+			out = append(out,
+				"GIT_CONFIG_KEY_"+n+"="+p.key,
+				"GIT_CONFIG_VALUE_"+n+"="+p.value,
+			)
+		}
 	}
 	return out
 }

--- a/internal/ctr/spec_git_env_test.go
+++ b/internal/ctr/spec_git_env_test.go
@@ -1,0 +1,183 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr_test
+
+import (
+	"strconv"
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// fullGitSpec mirrors crew's git block: author + committer identity, an SSH
+// signing key, commit + tag signing, and an allowed-signers file. This is the
+// 15-var rendering (GIT_CONFIG_COUNT=5) the live crew templates emit today.
+func fullGitSpec() *intmodel.ContainerGit {
+	return &intmodel.ContainerGit{
+		Author:         &intmodel.GitIdentity{Name: "Emiliano Spinella", Email: "dev@eminwux.com"},
+		Committer:      &intmodel.GitIdentity{Name: "Emiliano Spinella", Email: "dev@eminwux.com"},
+		SigningKey:     "/home/claude/.ssh/id_ed25519.pub",
+		Sign:           []string{intmodel.GitSignCommits, intmodel.GitSignTags},
+		AllowedSigners: "/home/claude/.ssh/allowed_signers",
+	}
+}
+
+// TestBuildContainerSpec_GitEnv asserts the full git block expands to the
+// exact GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_* env-var set crew emits
+// by hand today, including gpg.format=ssh implied by signingKey. Issue #618.
+func TestBuildContainerSpec_GitEnv(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:    "work",
+		Image: "registry.eminwux.com/busybox:latest",
+		Git:   fullGitSpec(),
+	})
+	got := envMap(spec.Process.Env)
+
+	want := map[string]string{
+		"GIT_AUTHOR_NAME":     "Emiliano Spinella",
+		"GIT_AUTHOR_EMAIL":    "dev@eminwux.com",
+		"GIT_COMMITTER_NAME":  "Emiliano Spinella",
+		"GIT_COMMITTER_EMAIL": "dev@eminwux.com",
+		"GIT_CONFIG_COUNT":    "5",
+		"GIT_CONFIG_KEY_0":    "user.signingkey",
+		"GIT_CONFIG_VALUE_0":  "/home/claude/.ssh/id_ed25519.pub",
+		"GIT_CONFIG_KEY_1":    "gpg.format",
+		"GIT_CONFIG_VALUE_1":  "ssh",
+		"GIT_CONFIG_KEY_2":    "commit.gpgsign",
+		"GIT_CONFIG_VALUE_2":  "true",
+		"GIT_CONFIG_KEY_3":    "tag.gpgsign",
+		"GIT_CONFIG_VALUE_3":  "true",
+		"GIT_CONFIG_KEY_4":    "gpg.ssh.allowedSignersFile",
+		"GIT_CONFIG_VALUE_4":  "/home/claude/.ssh/allowed_signers",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("Process.Env[%q] = %q, want %q (full env: %v)", k, got[k], v, spec.Process.Env)
+		}
+	}
+}
+
+// TestBuildContainerSpec_GitEnv_NoSigningRendersNoConfig locks that an
+// identity-only git block (no signingKey, no sign) emits the author/committer
+// vars but zero GIT_CONFIG_* entries — so a spec that only sets identity never
+// leaks an empty GIT_CONFIG_COUNT.
+func TestBuildContainerSpec_GitEnv_NoSigningRendersNoConfig(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:    "work",
+		Image: "registry.eminwux.com/busybox:latest",
+		Git: &intmodel.ContainerGit{
+			Author:    &intmodel.GitIdentity{Name: "A", Email: "a@example.com"},
+			Committer: &intmodel.GitIdentity{Name: "A", Email: "a@example.com"},
+		},
+	})
+	got := envMap(spec.Process.Env)
+	if got["GIT_AUTHOR_NAME"] != "A" {
+		t.Errorf("GIT_AUTHOR_NAME = %q, want %q", got["GIT_AUTHOR_NAME"], "A")
+	}
+	for _, k := range []string{"GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0"} {
+		if _, ok := got[k]; ok {
+			t.Errorf("Process.Env carries %q with no signing config: %q", k, got[k])
+		}
+	}
+}
+
+// TestBuildContainerSpec_GitEnv_SigningKeyWithoutAllowedSigners reproduces the
+// issue's documented 13-var rendering (GIT_CONFIG_COUNT=4): a signing block
+// with no allowedSigners omits the gpg.ssh.allowedSignersFile pair entirely.
+func TestBuildContainerSpec_GitEnv_SigningKeyWithoutAllowedSigners(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:    "work",
+		Image: "registry.eminwux.com/busybox:latest",
+		Git: &intmodel.ContainerGit{
+			SigningKey: "/k.pub",
+			Sign:       []string{intmodel.GitSignCommits, intmodel.GitSignTags},
+		},
+	})
+	got := envMap(spec.Process.Env)
+	if got["GIT_CONFIG_COUNT"] != "4" {
+		t.Errorf("GIT_CONFIG_COUNT = %q, want %q", got["GIT_CONFIG_COUNT"], "4")
+	}
+	for i := 0; i < 4; i++ {
+		key := got["GIT_CONFIG_KEY_"+strconv.Itoa(i)]
+		if key == "gpg.ssh.allowedSignersFile" {
+			t.Errorf("GIT_CONFIG_KEY_%d unexpectedly = gpg.ssh.allowedSignersFile", i)
+		}
+	}
+	if _, ok := got["GIT_CONFIG_KEY_4"]; ok {
+		t.Errorf("GIT_CONFIG_KEY_4 present, want only 4 pairs (env: %v)", spec.Process.Env)
+	}
+}
+
+// TestBuildContainerSpec_GitEnv_CommitsOnly asserts a single sign target
+// renders only its config key — tags signing stays off.
+func TestBuildContainerSpec_GitEnv_CommitsOnly(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:    "work",
+		Image: "registry.eminwux.com/busybox:latest",
+		Git: &intmodel.ContainerGit{
+			SigningKey: "/k.pub",
+			Sign:       []string{intmodel.GitSignCommits},
+		},
+	})
+	got := envMap(spec.Process.Env)
+	// user.signingkey, gpg.format, commit.gpgsign — no tag.gpgsign.
+	if got["GIT_CONFIG_COUNT"] != "3" {
+		t.Errorf("GIT_CONFIG_COUNT = %q, want %q", got["GIT_CONFIG_COUNT"], "3")
+	}
+	for k, v := range envMap(spec.Process.Env) {
+		if v == "tag.gpgsign" {
+			t.Errorf("found tag.gpgsign key %q with commits-only sign", k)
+		}
+	}
+}
+
+// TestBuildContainerSpec_GitEnv_UserEnvWinsOnCollision asserts the issue's
+// merge rule: an explicit env: entry overrides a git-expanded var of the same
+// key, with no duplicate left behind.
+func TestBuildContainerSpec_GitEnv_UserEnvWinsOnCollision(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:    "work",
+		Image: "registry.eminwux.com/busybox:latest",
+		Git:   fullGitSpec(),
+		Env:   []string{"GIT_AUTHOR_EMAIL=override@example.com"},
+	})
+	got := envMap(spec.Process.Env)
+	if got["GIT_AUTHOR_EMAIL"] != "override@example.com" {
+		t.Errorf("GIT_AUTHOR_EMAIL = %q, want override (explicit env should win)", got["GIT_AUTHOR_EMAIL"])
+	}
+	if n := envKeyOccurrences(spec.Process.Env, "GIT_AUTHOR_EMAIL"); n != 1 {
+		t.Errorf("GIT_AUTHOR_EMAIL appeared %d times, want 1 (env: %v)", n, spec.Process.Env)
+	}
+	// Untouched git var still present.
+	if got["GIT_AUTHOR_NAME"] != "Emiliano Spinella" {
+		t.Errorf("GIT_AUTHOR_NAME = %q, want untouched git value", got["GIT_AUTHOR_NAME"])
+	}
+}
+
+// TestBuildContainerSpec_GitEnv_NilNoEntries locks that a spec without a git
+// block emits no GIT_* entries at all — no behaviour change for existing specs.
+func TestBuildContainerSpec_GitEnv_NilNoEntries(t *testing.T) {
+	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
+		ID:    "work",
+		Image: "registry.eminwux.com/busybox:latest",
+	})
+	for _, kv := range spec.Process.Env {
+		if len(kv) >= 4 && kv[:4] == "GIT_" {
+			t.Errorf("Process.Env carries unexpected git entry %q with no git block", kv)
+		}
+	}
+}

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -70,7 +70,12 @@ type ContainerSpec struct {
 	// Repos mirrors the v1beta1 ContainerSpec.Repos payload — git
 	// repositories kuketty clones/fetches in its pre-Serve step. See the
 	// v1beta1 type for field semantics. Issue #617.
-	Repos         []ContainerRepo
+	Repos []ContainerRepo
+	// Git mirrors the v1beta1 ContainerSpec.Git payload — declarative git
+	// identity/signing sugar that BuildContainerSpec / BuildRootContainerSpec
+	// expand into the GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_* env block.
+	// See the v1beta1 type for field semantics. Issue #618.
+	Git           *ContainerGit
 	CNIConfigPath string
 	RestartPolicy string
 	Attachable    bool
@@ -194,6 +199,30 @@ type ContainerRepo struct {
 	Branch   string
 	URL      string
 	Required bool
+}
+
+// GitSignTarget enumerates the artefacts ContainerGit.Sign can enable signing
+// for. Mirrors the v1beta1 constants.
+const (
+	GitSignCommits = "commits"
+	GitSignTags    = "tags"
+)
+
+// ContainerGit mirrors the v1beta1 ContainerGit payload — declarative sugar
+// over the GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_* env-var protocol. See
+// the v1beta1 type for field semantics. Issue #618.
+type ContainerGit struct {
+	Author         *GitIdentity
+	Committer      *GitIdentity
+	SigningKey     string
+	Sign           []string
+	AllowedSigners string
+}
+
+// GitIdentity mirrors the v1beta1 GitIdentity payload.
+type GitIdentity struct {
+	Name  string
+	Email string
 }
 
 // ContainerCapabilities groups Linux capability deltas applied relative to the

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -100,9 +100,19 @@ type ContainerSpec struct {
 	// Attachable=true (kuketty owns the resolution step). Per-repo outcome
 	// surfaces in ContainerStatus.Repos over RPC in phase 1b (#642). Issue
 	// #617, phase 1a of #423.
-	Repos         []ContainerRepo `json:"repos,omitempty"                  yaml:"repos,omitempty"`
-	CNIConfigPath string          `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
-	RestartPolicy string          `json:"restartPolicy"                    yaml:"restartPolicy"`
+	Repos []ContainerRepo `json:"repos,omitempty"                  yaml:"repos,omitempty"`
+	// Git declares the container's git identity and signing config as
+	// declarative sugar over the GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_*
+	// environment-variable protocol git reads natively. The container runtime
+	// expands it into that env-var block before container start (merged with
+	// any explicit env: entries, which win on key collision), so cell
+	// templates carry a four-line git: block instead of the hand-rolled
+	// ~13-line GIT_* env duplication. The signingKey path stays per-container
+	// (root-cell vs non-root-cell key paths are not globalised). Issue #618,
+	// phase 2 of #423.
+	Git           *ContainerGit `json:"git,omitempty"                    yaml:"git,omitempty"`
+	CNIConfigPath string        `json:"cniConfigPath,omitempty"          yaml:"cniConfigPath,omitempty"`
+	RestartPolicy string        `json:"restartPolicy"                    yaml:"restartPolicy"`
 	// Attachable opts the container into kuketty-wrapper injection. When
 	// true, the daemon rewrites process.args to a single element
 	// [/.kukeon/bin/kuketty] — no CLI flags, every runtime input flows
@@ -276,6 +286,52 @@ type ContainerRepo struct {
 	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
 }
 
+// GitSignTarget enumerates the artefacts ContainerGit.Sign can enable signing
+// for. An entry maps to the matching git config key (commit.gpgsign /
+// tag.gpgsign) in the expanded GIT_CONFIG_* block.
+const (
+	// GitSignCommits enables commit signing (commit.gpgsign=true).
+	GitSignCommits = "commits"
+	// GitSignTags enables tag signing (tag.gpgsign=true).
+	GitSignTags = "tags"
+)
+
+// ContainerGit is declarative sugar over the GIT_AUTHOR_* / GIT_COMMITTER_* /
+// GIT_CONFIG_* env-var protocol git reads natively. The container runtime
+// expands it into that env block before container start. Author/Committer
+// render the GIT_AUTHOR_*/GIT_COMMITTER_* identity vars; SigningKey, Sign, and
+// AllowedSigners render the GIT_CONFIG_* signing pairs (user.signingkey,
+// gpg.format=ssh, commit.gpgsign, tag.gpgsign, gpg.ssh.allowedSignersFile)
+// with GIT_CONFIG_COUNT tracking the live pair count. Issue #618.
+type ContainerGit struct {
+	// Author sets git's author identity (GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL).
+	// Both name and email are required when present.
+	Author *GitIdentity `json:"author,omitempty"         yaml:"author,omitempty"`
+	// Committer sets git's committer identity (GIT_COMMITTER_NAME /
+	// GIT_COMMITTER_EMAIL). Both name and email are required when present.
+	Committer *GitIdentity `json:"committer,omitempty"      yaml:"committer,omitempty"`
+	// SigningKey is the absolute in-container path to the signing key
+	// (user.signingkey). kukeon signs with SSH keys, so a non-empty
+	// SigningKey also renders gpg.format=ssh. Per-container — root-cell vs
+	// non-root-cell key paths stay local to the container, not globalised.
+	SigningKey string `json:"signingKey,omitempty"     yaml:"signingKey,omitempty"`
+	// Sign enables signing for the listed artefacts: "commits"
+	// (commit.gpgsign=true) and/or "tags" (tag.gpgsign=true). Requires
+	// SigningKey to be set.
+	Sign []string `json:"sign,omitempty"           yaml:"sign,omitempty"`
+	// AllowedSigners is the absolute in-container path to git's SSH
+	// allowed-signers file (gpg.ssh.allowedSignersFile), used to verify
+	// signatures. Optional; rendered only when set. Crew sets this today, so
+	// the field exists for the env block to be a strict superset of crew's.
+	AllowedSigners string `json:"allowedSigners,omitempty" yaml:"allowedSigners,omitempty"`
+}
+
+// GitIdentity is a name/email pair for a git author or committer identity.
+type GitIdentity struct {
+	Name  string `json:"name"  yaml:"name"`
+	Email string `json:"email" yaml:"email"`
+}
+
 // ContainerCapabilities groups Linux capability deltas applied to the
 // container process relative to the image default set.
 type ContainerCapabilities struct {
@@ -428,6 +484,7 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 	out.Spec.SecurityOpts = cloneSlice(out.Spec.SecurityOpts)
 	out.Spec.Secrets = cloneSecrets(out.Spec.Secrets)
 	out.Spec.Repos = cloneRepos(out.Spec.Repos)
+	out.Spec.Git = cloneGit(out.Spec.Git)
 	out.Status.Repos = cloneRepoStatuses(out.Status.Repos)
 
 	if out.Spec.Capabilities != nil {
@@ -492,6 +549,26 @@ func cloneRepos(in []ContainerRepo) []ContainerRepo {
 	out := make([]ContainerRepo, len(in))
 	copy(out, in)
 	return out
+}
+
+// cloneGit deep-copies a ContainerGit, including its Author/Committer
+// pointers and Sign slice, so a cloned ContainerDoc shares no mutable state
+// with its source.
+func cloneGit(in *ContainerGit) *ContainerGit {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if in.Author != nil {
+		author := *in.Author
+		out.Author = &author
+	}
+	if in.Committer != nil {
+		committer := *in.Committer
+		out.Committer = &committer
+	}
+	out.Sign = cloneSlice(in.Sign)
+	return &out
 }
 
 func cloneRepoStatuses(in []RepoStatus) []RepoStatus {


### PR DESCRIPTION
## Summary

Phase 2 of #423. Adds a declarative `git` block to `ContainerSpec` that the
container runtime expands into the `GIT_AUTHOR_* / GIT_COMMITTER_* /
GIT_CONFIG_*` env-var block git reads natively — replacing the hand-rolled
~13-line `GIT_*` block crew templates duplicate per cell with a four-line
`git:` block. Pure schema sugar that compiles to the existing env-var
protocol; no behavior change for specs that omit `git`.

```yaml
spec:
  containers:
    - id: work
      git:
        author:     { name: ${GIT_USER_NAME}, email: ${GIT_USER_EMAIL} }
        committer:  { name: ${GIT_USER_NAME}, email: ${GIT_USER_EMAIL} }
        signingKey: /home/claude/.ssh/id_ed25519.pub
        sign:       [commits, tags]
```

### What the diff does

- **Schema** (`pkg/api/model/v1beta1/container.go`, `internal/modelhub/container.go`):
  `Git *ContainerGit` on `ContainerSpec`, with `author`/`committer`
  (`*GitIdentity`), `signingKey`, `sign` (`[]string`), and `allowedSigners`.
  Deep-clone in `NewContainerDoc` (`cloneGit`), internal-model mirror, and
  `GitSignCommits`/`GitSignTags` constants in both packages (matching the
  existing `VolumeKind` cross-package duplication).
- **Expansion** (`internal/ctr/spec.go`): `gitEnv` renders the block; merged
  into `kukeonContainerEnv` so both `BuildContainerSpec` and
  `BuildRootContainerSpec` get it. Explicit `env:` entries win on key
  collision (reuses the existing KUKEON_* merge, dedup-by-key). `GIT_CONFIG_*`
  pairs emit in crew's canonical order — `user.signingkey`, `gpg.format=ssh`,
  `commit.gpgsign`, `tag.gpgsign`, `gpg.ssh.allowedSignersFile` — with
  `GIT_CONFIG_COUNT` tracking the live pair count.
- **Conversion + validation** (`internal/apischeme/scheme.go`):
  `gitToInternal`/`gitToExternal` wired into all four container conversion
  paths (doc + nested-cell, both directions); `validateContainerGit` called at
  both `ConvertContainerDocToInternal` and the `ConvertCellDocToInternal`
  per-container loop, mirroring `validateContainerTty`. Enforces the AC:
  author/committer each require both name+email when present; `sign` requires
  `signingKey`; unknown `sign` targets rejected at apply time.

### Design calls (reviewer please confirm)

1. **Added an `allowedSigners` field beyond the four AC-enumerated fields**, as
   flagged in the prior heads-up comment on #618. The issue describes a 13-var
   block (`GIT_CONFIG_COUNT=4`). I verified the live crew env in this
   environment emits **`GIT_CONFIG_COUNT=5`**, whose 5th pair is
   `gpg.ssh.allowedSignersFile=/…/allowed_signers`. AC checkbox 4 ("the new
   schema covers every key crew sets today") cannot hold against current crew
   without it. `allowedSigners` renders only when set, so omitting it
   reproduces exactly the issue's 13-var rendering (covered by a test); the
   four AC fields remain a strict subset.
2. **`gpg.format=ssh` is implied by a non-empty `signingKey`** rather than
   exposed as a field — kukeon signs with SSH keys (the example `signingKey` is
   an SSH `.pub` path), and `gpg.format=ssh` is required for SSH-key signing to
   work. Keeps the schema to the AC fields + `allowedSigners`.
3. **`GIT_SSH_COMMAND` is intentionally out of scope.** The AC scopes the sugar
   to the `GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_*` block (the issue's
   Proposal enumerates exactly those). `GIT_SSH_COMMAND` is an SSH-transport
   knob, not part of the `GIT_CONFIG` protocol; it stays an explicit `env:`
   entry. Flagging since crew also sets it — if the intent was to subsume it
   too, that's a follow-up field, not this PR.

Crew's `GIT_*` block deletion (AC checkbox 4) is the out-of-scope change in
crew's repo, not this one.

## Test plan

- [x] `make test` (CI unit target) — full suite green
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `gofmt -l` on touched files — clean
- [x] New unit tests: `internal/ctr/spec_git_env_test.go` (full block →
  exact 15-var set; identity-only → no GIT_CONFIG_*; signing without
  allowedSigners → the issue's 13-var/COUNT=4 rendering; commits-only;
  explicit-env-wins merge; nil → no GIT_* leak) and
  `internal/apischeme/scheme_git_test.go` (round-trip, deep-copy, validation
  table).
- [x] `make dev-init` smoke — daemon-parity check passed (both `kuke get
  realms` and `--no-daemon` identical); attach + nested smokes clean. Run
  because the diff touches `internal/ctr/spec.go`, which the daemon reads.

Closes #618