### PR TITLE
fix(run): refuse phantom attach when containerd lost a Ready cell's containers

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -272,10 +272,16 @@ func runRun(cmd *cobra.Command, args []string) error {
 // whose on-disk spec already matches the file (the caller rejected divergence
 // before delegating here). The four terminal states:
 //
-//   - Ready   → print a no-op summary, then attach. Re-entering the daemon's
-//     CreateCell→StartCell path on a healthy cell trips the runner's CNI
-//     duplicate-allocation bug (#630), so the short-circuit is mandatory, not
-//     just an optimisation.
+//   - Ready   → reconcile against containerd first. The recorded state asserts
+//     a live root container; if containerd has lost it (a daemon/host restart
+//     per #648 dropped the containers while the on-disk metadata survived), the
+//     no-op summary would report phantom `container … already existed` /
+//     `containers: started` and then attach to a dead socket
+//     (`connection refused`, #654). On that divergence, refuse with a
+//     delete-then-rerun pointer. Otherwise print a no-op summary, then attach.
+//     Re-entering the daemon's CreateCell→StartCell path on a healthy cell trips
+//     the runner's CNI duplicate-allocation bug (#630), so the short-circuit is
+//     mandatory, not just an optimisation.
 //   - Stopped → StartCell, then attach. The routing is the correct verb (the
 //     prior fall-through to CreateCell was itself an unsafe re-entry). The
 //     live start+attach is gated on the same CNI fix (#630): StartCell re-ADDs
@@ -295,6 +301,28 @@ func runExistingCell(
 ) error {
 	switch pre.Cell.Status.State {
 	case v1beta1.CellStateReady:
+		// Divergence guard (#654): the metadata records this cell as Ready, but
+		// containerd no longer has its root container — typically a daemon/host
+		// restart (#648) dropped the cell's containers while the on-disk
+		// metadata survived. Trusting the stale metadata would print phantom
+		// `already existed` / `containers: started` lines and then attach to a
+		// socket backed by nothing (`connection refused`). Refuse with a
+		// delete-then-rerun pointer instead. We deliberately do not recreate in
+		// place: re-entering CreateCell/StartCell here is the exact #630 CNI
+		// duplicate-allocation re-entry the Ready short-circuit exists to avoid,
+		// and the operator-driven delete releases any half-held allocation
+		// cleanly. (A legitimately Stopped cell has no root container in
+		// containerd by design — StopCell deletes it — so this guard is scoped
+		// to Ready, where the container is asserted live.)
+		if !pre.RootContainerExists {
+			return fmt.Errorf(
+				"cell %q is recorded Ready but its containers are gone from containerd "+
+					"(kukeon metadata and containerd have diverged); "+
+					"delete it with `kuke delete cell %s` before re-running",
+				cellDoc.Metadata.Name,
+				cellDoc.Metadata.Name,
+			)
+		}
 		if printErr := printRunResult(cmd, noOpResultFromGet(pre), flags.output); printErr != nil {
 			return printErr
 		}

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -484,6 +484,81 @@ func TestRun_ExistingCell_MatchingSpec_AlreadyReady_ShortCircuits(t *testing.T) 
 	}
 }
 
+func TestRun_ExistingCell_RecordedReady_ContainerdLostContainers_Refuses(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// #654: the cell is recorded Ready on disk, but containerd no longer has
+	// its root container (a daemon/host restart dropped the containers while
+	// the metadata survived). Run must NOT print phantom `already existed` /
+	// `containers: started` lines and must NOT attach to the dead socket;
+	// instead it refuses with a divergence message + delete-then-rerun pointer.
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:           existing,
+				MetadataExists: true,
+				CgroupExists:   true,
+				// Containerd lost the root container — the divergence signal.
+				RootContainerExists: false,
+			}, nil
+		},
+	}
+	// Default (attach) mode: the bug attaches to a dead socket. Omit -d so the
+	// test exercises the path that would otherwise reach the failing attach.
+	cmd, out := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute: want divergence refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "diverged") {
+		t.Errorf("error missing divergence wording: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke delete cell my-cell") {
+		t.Errorf("error missing `kuke delete cell` recovery pointer: %v", err)
+	}
+	if strings.Contains(out.String(), "already existed") {
+		t.Errorf("must not print phantom `already existed` for a diverged cell:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "containers: started") {
+		t.Errorf("must not print phantom `containers: started` for a diverged cell:\n%s", out.String())
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (refuse, do not re-enter create — #630)", fc.createCalls)
+	}
+	if fc.startCalls != 0 {
+		t.Errorf("StartCell calls=%d want 0 (refuse, do not re-enter start — #630)", fc.startCalls)
+	}
+	if fc.attachCalls != 0 {
+		t.Errorf("AttachContainer calls=%d want 0 (must not attach to a dead socket)", fc.attachCalls)
+	}
+}
+
 func TestRun_ExistingCell_MatchingSpec_Stopped_StartsAndAttaches(t *testing.T) {
 	t.Cleanup(viper.Reset)
 


### PR DESCRIPTION
## Summary

`kuke run` on a cell recorded `Ready` whose containers containerd has lost (typically a daemon/host restart per #648 dropped the cell's containers while the on-disk metadata survived) printed phantom `container … already existed` / `containers: started`, then attached to a socket backed by nothing — surfacing as a raw `connection refused`.

The root cause: the `CellStateReady` branch in `runExistingCell` (`cmd/kuke/run/run.go`) trusted persisted metadata and short-circuited to the no-op summary + attach without reconciling against containerd. `noOpResultFromGet` hardcodes `ExistsPost: true` for every container, which is the phantom `already existed` output regardless of containerd reality.

The fix reconciles before deciding the verb. `GetCellResult.RootContainerExists` already reflects live containerd state (`runner.ExistsCellRootContainer` queries containerd directly and the value flows over the wire to the CLI). When the recorded state is `Ready` but `RootContainerExists` is false, `run` now refuses with a clear `kukeon metadata and containerd have diverged` message plus a `kuke delete cell <name>` recovery pointer — parity in spirit with the existing `Pending/Failed/Unknown` "delete and re-run" guidance.

### Non-obvious implementation calls (reviewer please push back)

- **Refuse, not recreate.** The AC permits either `(re)creates+starts the missing containers` *or* `exits with a clear divergence message + recovery pointer`. I chose refuse — the lower-blast-radius option. Recreating in place would re-enter `CreateCell`/`StartCell` on a cell whose CNI allocation may still be half-held, the exact #630 duplicate-allocation re-entry the `Ready` short-circuit exists to avoid; the operator-driven `kuke delete cell` releases any half-held allocation cleanly. This trivially satisfies AC bullet 3 (no #630 regression) since the path no longer re-enters create/start at all. The issue explicitly leaves the mechanism to dev.
- **Guard scoped to `Ready` only.** A legitimately `Stopped` cell has `RootContainerExists == false` *by design* — `StopCell` deletes the root container from containerd (`internal/controller/runner/stop.go:252`), and the `Stopped` path correctly recreates via `StartCell`. So `RootContainerExists` is only a divergence signal in the `Ready` state, where the container is asserted live. Applying the guard to `Stopped` would wrongly refuse every normal stopped cell.

### Out of scope (per AC)

The secondary variant in the issue Notes — a `Ready` cell whose *workload task* exited while the root container still exists in containerd (`RootContainerExists` is true, attach hits a `0755` pre-`applySocketPerms` socket → `permission denied`) — is **not** addressed here. The AC checkboxes are about *recorded containers absent from containerd*; detecting an exited-but-present workload requires task-state inspection (a broader change). Left for a follow-up under the same dead-socket family (#224 / #217 reconciler convergence, #648 restart survival).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/kuke/run/...`
- [x] `make test` (full CI target) — green
- [x] `pre-commit run --files <changed>` — all hooks pass (go fmt, go-mod-tidy, golangci-lint, addlicense, …)
- [x] **AC — no phantom output on divergence:** new `TestRun_ExistingCell_RecordedReady_ContainerdLostContainers_Refuses` asserts a `Ready` cell with `RootContainerExists: false` neither prints `already existed` / `containers: started` nor attaches, and refuses with the divergence message + `kuke delete cell` pointer.
- [x] **AC — clear divergence message, not a raw `connection refused`:** asserted on the error string (`diverged`, `kuke delete cell my-cell`).
- [x] **AC — no #630 regression:** asserted `CreateCell`/`StartCell` call counts are 0 on the refuse path; the healthy-`Ready` short-circuit (`RootContainerExists: true`) and `Stopped`→`StartCell` paths are unchanged and still green (`TestRun_ExistingCell_MatchingSpec_AlreadyReady_ShortCircuits`, `..._Stopped_StartsAndAttaches`).
- [ ] `make dev-init` daemon-parity smoke — not run: the diff is CLI-only (`cmd/kuke/run`), reads a `GetCellResult` field the daemon already computes and returns, and touches nothing the daemon reads, builds, or stores under `/opt/kukeon`. The daemon-parity guard is not applicable to this change.

Closes #654