### PR TITLE
fix: recreate /run/kukeon bind source on daemon start/restart

### DIFF
--- a/cmd/kuke/daemon/internal/lifecycle/socketdir.go
+++ b/cmd/kuke/daemon/internal/lifecycle/socketdir.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/sysuser"
+	"github.com/spf13/cobra"
+)
+
+// EnsureSocketDirKey injects a socket-dir recreate func via the command
+// context so unit tests can drive `kuke daemon start`/`restart` without root
+// or a real /run/kukeon. Same pattern as MockClientKey / ReachableProbeKey:
+// the key lives here so every verb's resolver agrees on a single identity.
+type EnsureSocketDirKey struct{}
+
+// ResolveEnsureSocketDir picks the recreate-/run/kukeon step the start and
+// restart verbs run before launching the cell. Tests inject a stub via
+// EnsureSocketDirKey; production recreates the parent directory of the
+// resolved kukeond socket. The indirection lets both verbs call the same
+// one-liner without duplicating the context-value lookup.
+func ResolveEnsureSocketDir(cmd *cobra.Command) func() error {
+	if f, ok := cmd.Context().Value(EnsureSocketDirKey{}).(func() error); ok && f != nil {
+		return f
+	}
+	return func() error { return EnsureSocketDir(ResolveSocketPath()) }
+}
+
+// applyRunDirOwnership re-asserts root:kukeon ownership and the kukeon SGID
+// mode on the kukeond socket's parent directory. It is a package var so the
+// unit suite can substitute a non-root stub: the production implementation
+// chowns to uid 0, which only root may do, and resolves the kukeon group that
+// `kuke init` provisions on the host but a CI test box does not have.
+//
+//nolint:gochecknoglobals // test seam for the production run-dir ownership step
+var applyRunDirOwnership = func(dir string) error {
+	grp, err := user.LookupGroup(consts.KukeonSystemGroup)
+	if err != nil {
+		return fmt.Errorf("lookup group %q: %w", consts.KukeonSystemGroup, err)
+	}
+	gid, err := strconv.Atoi(grp.Gid)
+	if err != nil {
+		return fmt.Errorf("parse gid %q for group %q: %w", grp.Gid, consts.KukeonSystemGroup, err)
+	}
+	return sysuser.ChownAndChmod(dir, 0, gid, consts.KukeonRunDirMode)
+}
+
+// SetRunDirOwnershipForTesting replaces the ownership step EnsureSocketDir
+// runs and returns a restore func. Tests use it to assert the directory the
+// step receives without needing root or a real kukeon group.
+func SetRunDirOwnershipForTesting(f func(dir string) error) func() {
+	prev := applyRunDirOwnership
+	applyRunDirOwnership = f
+	return func() { applyRunDirOwnership = prev }
+}
+
+// EnsureSocketDir recreates the kukeond socket's parent directory — the
+// /run/kukeon bind-mount source the kukeond cell spec requires — and
+// re-asserts the root:kukeon SGID 0750 ownership `kuke init` applies.
+//
+// `kuke init` creates this directory once via the controller bootstrap, but
+// /run is a tmpfs that is wiped on every reboot, so the bind source is gone
+// when `kuke daemon start`/`restart` later launch the cell — runc then fails
+// the mount with "open /run/kukeon: no such file or directory". Calling this
+// before the start path makes the daemon recoverable after a reboot without a
+// manual `mkdir` or a full re-`init`. Idempotent: on a healthy host the
+// MkdirAll is a no-op and the ownership/mode are simply re-applied.
+//
+// socketPath is the resolved kukeond socket; its parent directory is the
+// bind-mount source, so passing the configured socket (which honours a
+// nested-mode KUKEOND_SOCKET override) recreates the directory the persisted
+// cell spec actually binds.
+func EnsureSocketDir(socketPath string) error {
+	dir := filepath.Dir(socketPath)
+	if err := os.MkdirAll(dir, consts.KukeonRunDirMode.Perm()); err != nil {
+		return fmt.Errorf("create kukeond socket dir %q: %w", dir, err)
+	}
+	if err := applyRunDirOwnership(dir); err != nil {
+		return fmt.Errorf("apply kukeon ownership to %q: %w", dir, err)
+	}
+	return nil
+}

--- a/cmd/kuke/daemon/internal/lifecycle/socketdir_test.go
+++ b/cmd/kuke/daemon/internal/lifecycle/socketdir_test.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package lifecycle_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
+)
+
+// stubOwnership swaps the root-requiring ownership step for one that records
+// the directory it was handed, so the test runs without root or a real kukeon
+// group. Returns a pointer to the captured dir and registers the restore.
+func stubOwnership(t *testing.T, ret error) *string {
+	t.Helper()
+	var got string
+	restore := lifecycle.SetRunDirOwnershipForTesting(func(dir string) error {
+		got = dir
+		return ret
+	})
+	t.Cleanup(restore)
+	return &got
+}
+
+func TestEnsureSocketDir_CreatesMissingParent(t *testing.T) {
+	// Parent does not exist yet — mirrors a tmpfs clear after reboot.
+	socketPath := filepath.Join(t.TempDir(), "kukeon", "kukeond.sock")
+	wantDir := filepath.Dir(socketPath)
+	gotDir := stubOwnership(t, nil)
+
+	if err := lifecycle.EnsureSocketDir(socketPath); err != nil {
+		t.Fatalf("EnsureSocketDir: %v", err)
+	}
+
+	info, err := os.Stat(wantDir)
+	if err != nil {
+		t.Fatalf("stat created dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%q is not a directory", wantDir)
+	}
+	if *gotDir != wantDir {
+		t.Fatalf("ownership applied to %q, want %q", *gotDir, wantDir)
+	}
+}
+
+func TestEnsureSocketDir_IdempotentOnExistingDir(t *testing.T) {
+	// Directory already present (healthy host) — re-running must succeed.
+	dir := filepath.Join(t.TempDir(), "kukeon")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("pre-create dir: %v", err)
+	}
+	socketPath := filepath.Join(dir, "kukeond.sock")
+	stubOwnership(t, nil)
+
+	for i := range 2 {
+		if err := lifecycle.EnsureSocketDir(socketPath); err != nil {
+			t.Fatalf("EnsureSocketDir (pass %d): %v", i, err)
+		}
+	}
+}
+
+func TestEnsureSocketDir_PropagatesOwnershipError(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "kukeon", "kukeond.sock")
+	sentinel := errors.New("chown boom")
+	stubOwnership(t, sentinel)
+
+	err := lifecycle.EnsureSocketDir(socketPath)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("EnsureSocketDir error = %v, want wrap of %v", err, sentinel)
+	}
+}

--- a/cmd/kuke/daemon/restart/restart.go
+++ b/cmd/kuke/daemon/restart/restart.go
@@ -128,6 +128,13 @@ func runRestart(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	// Recreate /run/kukeon (the cell's bind-mount source) if a reboot wiped
+	// the tmpfs — only `kuke init` created it, so without this the start
+	// phase fails with "open /run/kukeon: no such file or directory".
+	if ensureErr := lifecycle.ResolveEnsureSocketDir(cmd)(); ensureErr != nil {
+		return fmt.Errorf("ensure kukeond socket dir: %w", ensureErr)
+	}
+
 	startRes, err := client.StartCell(cmd.Context(), doc)
 	if err != nil {
 		return fmt.Errorf("start kukeond cell: %w", err)

--- a/cmd/kuke/daemon/restart/restart_test.go
+++ b/cmd/kuke/daemon/restart/restart_test.go
@@ -287,6 +287,7 @@ func TestDaemonRestart(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
 			if tt.probe != nil {
 				ctx = context.WithValue(ctx, lifecycle.ReachableProbeKey{}, tt.probe)
 			}
@@ -367,6 +368,7 @@ func TestDaemonRestart_GracefulTimeoutEscalatesToKillThenStarts(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--timeout", "50ms"})
 
@@ -447,6 +449,7 @@ func TestDaemonRestart_TimeoutOverridesDefault(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--timeout", "20ms"})
 
@@ -511,6 +514,7 @@ func TestDaemonRestart_KillCellErrorIsWrapped(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
 	cmd.SetContext(ctx)
 	cmd.SetArgs([]string{"--timeout", "20ms"})
 

--- a/cmd/kuke/daemon/start/start.go
+++ b/cmd/kuke/daemon/start/start.go
@@ -105,6 +105,13 @@ func runStart(cmd *cobra.Command, _ []string) error {
 		)
 	}
 
+	// Recreate /run/kukeon (the cell's bind-mount source) if a reboot wiped
+	// the tmpfs — only `kuke init` created it, so without this the start
+	// fails with "open /run/kukeon: no such file or directory".
+	if ensureErr := lifecycle.ResolveEnsureSocketDir(cmd)(); ensureErr != nil {
+		return fmt.Errorf("ensure kukeond socket dir: %w", ensureErr)
+	}
+
 	startRes, err := client.StartCell(cmd.Context(), doc)
 	if err != nil {
 		return fmt.Errorf("start kukeond cell: %w", err)

--- a/cmd/kuke/daemon/start/start_test.go
+++ b/cmd/kuke/daemon/start/start_test.go
@@ -210,6 +210,7 @@ func TestDaemonStart(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
 			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
 			if tt.probe != nil {
 				ctx = context.WithValue(ctx, lifecycle.ReachableProbeKey{}, tt.probe)
 			}

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -63,7 +63,6 @@ const (
 	// the daemon writes later (metadata.json, CNI state, etc.) inherit
 	// the kukeon group instead of landing as root:root and breaking
 	// `--no-daemon` reads for non-root operators.
-	kukeonRunDirMode      os.FileMode = os.ModeSetgid | 0o750
 	kukeonRunPathDirMode  os.FileMode = os.ModeSetgid | 0o750
 	kukeonRunPathFileMode os.FileMode = 0o640
 	kukeonSocketMode      os.FileMode = 0o660
@@ -363,7 +362,7 @@ func applyKukeonOwnership(
 		RunPath:      runPath,
 		SocketPath:   socketPath,
 	}
-	if err := sysuser.ChownAndChmod(runDir, 0, ensure.GID, kukeonRunDirMode); err != nil {
+	if err := sysuser.ChownAndChmod(runDir, 0, ensure.GID, consts.KukeonRunDirMode); err != nil {
 		return r, fmt.Errorf("apply kukeon ownership to %q: %w", runDir, err)
 	}
 	r.RunDirApplied = true
@@ -599,7 +598,7 @@ func printPermissionsActions(cmd *cobra.Command, perms permissionsReport) {
 	if perms.RunDirApplied {
 		cmd.Println(fmt.Sprintf(
 			"    - %q: chown root:%s mode %s",
-			perms.RunDirPath, perms.Group, formatPosixMode(kukeonRunDirMode),
+			perms.RunDirPath, perms.Group, formatPosixMode(consts.KukeonRunDirMode),
 		))
 	}
 	if perms.RunPathApplied {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -18,6 +18,7 @@ package consts
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -122,6 +123,16 @@ const (
 	// require root; they go through the daemon.
 	KukeonSystemUser  = "kukeon"
 	KukeonSystemGroup = "kukeon"
+
+	// KukeonRunDirMode is the mode applied to the kukeond socket's parent
+	// directory (the /run/kukeon bind-mount source) by `kuke init` and
+	// re-asserted by `kuke daemon start`/`restart` so the directory survives
+	// a tmpfs clear (host reboot). The SGID bit makes files the daemon later
+	// writes there inherit the kukeon group instead of root:root; 0o750 lets
+	// the kukeon group traverse without world access. Single source of truth
+	// shared by the init bootstrap and the daemon start/restart recreate path
+	// so the two cannot drift on what `kuke init` produces.
+	KukeonRunDirMode os.FileMode = os.ModeSetgid | 0o750
 
 	// DefaultRealmNamespaceSuffix is the in-binary default for the
 	// containerd namespace suffix appended to every realm name (without a


### PR DESCRIPTION
## Summary

- `kuke daemon start`/`restart` fail after a host reboot with `runc create failed: ... open /run/kukeon: no such file or directory`. The kukeond cell spec bind-mounts host `/run/kukeon` → container `/run/kukeon`, and runc requires the bind **source** to exist. That directory was created exactly once, by the controller bootstrap's `ensureSocketDir`, whose only non-test caller is `kuke init`. `/run` is a tmpfs, so the directory is wiped on every reboot and the start path (`client.StartCell`) never recreates it — leaving the daemon non-recoverable without a manual `mkdir` or a full re-`init`.
- New `lifecycle.EnsureSocketDir` recreates the socket's parent directory and re-asserts the same `root:kukeon` SGID `0750` ownership `kuke init` produces, then `runStart`/`runRestart` call it (via `ResolveEnsureSocketDir`) immediately before `client.StartCell`. Idempotent: `MkdirAll` no-ops on a healthy host and the ownership/mode are simply re-applied.

### Non-obvious implementation calls (reviewer please push back)

- **Where the call lives.** `controller.StartCell` is generic across *all* cells (user cells included), so recreating `/run/kukeon` there would be wrong. Both lifecycle verbs already funnel through `client.StartCell` on the kukeond cell doc and share the `lifecycle` package, so the recreate step lives there and is invoked only on the kukeond start/restart path. `kuke init` keeps its own bootstrap `ensureSocketDir` — this change does not touch that path.
- **Directory derived from the resolved socket, not a hard-coded `/run/kukeon`.** `EnsureSocketDir(lifecycle.ResolveSocketPath())` uses `filepath.Dir` of the configured kukeond socket, so nested dev-init mode (which redirects the socket to `/run/kukeon-dev/`) recreates the directory the persisted cell spec actually binds. Verified against `internal/controller/bootstrap.go:463-465`, where the cell's bind source is `socketDir(socketPath)`.
- **Single source of truth for the mode.** Moved `init`'s private `kukeonRunDirMode` (`os.ModeSetgid | 0o750`) to `consts.KukeonRunDirMode` so the bootstrap chown and the new recreate path cannot drift on what `kuke init` produces. `init.go`'s other run-path modes are left local (different semantic). The AC phrases the mode as "root:kukeon, 0750"; the literal value `kuke init` applies is SGID-`0750` (mode `2750`), so this PR matches the exact init behavior, SGID bit included.
- **Two test seams.** `SetRunDirOwnershipForTesting` lets the colocated unit test exercise `MkdirAll`/idempotency without root or a real kukeon group (the production ownership step chowns to uid 0). `EnsureSocketDirKey` is a context-injection seam (same idiom as `MockClientKey`/`ReachableProbeKey`) so the existing start/restart command tests inject a no-op rather than touching the real `/run/kukeon`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full CI target) — green
- [x] `pre-commit run --files <changed>` — all hooks pass (go fmt, go-mod-tidy, golangci-lint, addlicense, …)
- [x] New colocated unit tests (`cmd/kuke/daemon/internal/lifecycle/socketdir_test.go`): creates a missing parent, idempotent on an existing dir, propagates the ownership error.
- [x] `make dev-init` daemon-parity check green (both realms Ready; both `kuke get realms` views identical) — ran in nested mode (socket `/run/kukeon-dev/`).
- [x] **AC #1 + #3 — reboot recovery (end-to-end, real containerd + daemon):** after `make dev-init`, `rm -rf /run/kukeon-dev` (simulates the tmpfs clear), then `kuke daemon restart` → **exit 0** (`kukeond stopped` / `kukeond started`); previously failed with `open /run/kukeon: no such file or directory`. Directory recreated.
- [x] **AC #2 — ownership/mode:** recreated dir is `drwxr-s--- root kukeon` (SGID `0750`, mode `2750`), matching `kuke init`.
- [x] **AC #4 — idempotent on healthy host:** re-running `kuke daemon restart` and `kuke daemon start` on the now-present dir succeeds (`already running`) and leaves ownership/mode intact (`drwxr-s--- root kukeon`).

No CLI flags or env-var keys were added/removed, so the literal-flag-string grep does not apply.

Closes #648