### PR TITLE
feat(secret): add kind: Secret schema + daemon storage primitive + apply (phase 3a)

### DIFF
--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -288,6 +288,48 @@ sudo kuke apply -f manifest.yaml -o json
 - A non-existent file exits non-zero with `failed to open file`.
 - `apply` updates a divergent existing cell (e.g. after `kuke kill cell` left the root container missing) and reports `Cell <name>: updated` with a per-component summary. `kuke run -f` against the same divergent state would refuse.
 
+### Secrets (`kind: Secret`)
+
+**Intent.** Store a named, scoped, daemon-managed credential. Phase 3a (issue #619) ships the storage primitive and the `apply` verb only — there is **no** `get` / `delete` verb (tracked in #622) and **no** way to reference a stored secret from a container yet (`ContainerSecret.secretRef`, tracked in #623). The existing `containers[].secrets[].fromFile` / `fromEnv` sources are unaffected and stay supported.
+
+**Sequence.**
+
+```bash
+sudo kuke apply -f secret.yaml
+```
+
+```yaml
+apiVersion: v1beta1
+kind: Secret
+metadata:
+  name: anthropic-token
+  realm: kuke-system # scope coordinates; deepest non-empty wins
+  # space: team-a               # optional — space-scoped
+  # stack: web                  # optional — stack-scoped (requires space)
+  # cell: api                   # optional — cell-scoped (requires stack)
+spec:
+  data: <bytes> # write-only; never echoed back
+```
+
+**Storage layout.** The daemon writes the bytes to a root-owned file under the scope's metadata tree:
+
+```
+<runPath>/data/<realm>/secrets/<name>                         # realm-scoped
+<runPath>/data/<realm>/<space>/secrets/<name>                 # space-scoped
+<runPath>/data/<realm>/<space>/<stack>/secrets/<name>         # stack-scoped
+<runPath>/data/<realm>/<space>/<stack>/<cell>/secrets/<name>  # cell-scoped
+```
+
+The `secrets/` directory is `0700` and each secret file is `0600`, both owned by root — stricter than the `0o2750` setgid metadata directories, so the `kuke` group cannot read secret material. Nesting `secrets/` inside the scope's metadata directory means the same teardown that reclaims a scope (`kuke purge` / `kuke delete`, which `rm -rf` the scope dir) reclaims its secrets too. No crypto-at-rest in v1 — this matches kubelet's default file-backed secret model.
+
+**Invariants.**
+
+- Exit code 0 on success; the result reports `created` on the first apply of a name and `updated` on re-apply (write-through — the daemon overwrites without reading the prior bytes back to diff them).
+- `metadata.name` and `metadata.realm` are required. A deeper scope coordinate requires every shallower one (a `cell`-scoped secret must also name its `stack` and `space`); a gap exits non-zero.
+- `spec.data` is required and must be non-empty; an empty `data` exits non-zero.
+- The scope must already exist — apply does **not** auto-create a missing realm/space/stack/cell for a secret (unlike the hierarchy reconcilers). An unreachable scope exits non-zero with a `scope does not exist` message.
+- `spec.data` is never echoed back in any apply output, daemon log, or audit trail.
+
 ### Inspect, log, attach
 
 **Intent.** Read what a running cell is doing.

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -132,6 +132,40 @@ func NormalizeRealm(req ext.RealmDoc) (intmodel.Realm, ext.Version, error) {
 	return internal, version, nil
 }
 
+// ConvertSecretDocToInternal converts an external SecretDoc to the internal
+// hub type (issue #619). A Secret has no status to map, so this is a flat
+// field copy of the scope coordinates and the material.
+func ConvertSecretDocToInternal(in ext.SecretDoc) (intmodel.Secret, error) {
+	switch in.APIVersion {
+	case VersionV1Beta1, "": // default/empty treated as v1beta1
+		return intmodel.Secret{
+			Metadata: intmodel.SecretMetadata{
+				Name:  in.Metadata.Name,
+				Realm: in.Metadata.Realm,
+				Space: in.Metadata.Space,
+				Stack: in.Metadata.Stack,
+				Cell:  in.Metadata.Cell,
+			},
+			Spec: intmodel.SecretSpec{
+				Data: in.Spec.Data,
+			},
+		}, nil
+	default:
+		return intmodel.Secret{}, fmt.Errorf("unsupported apiVersion for Secret: %s", in.APIVersion)
+	}
+}
+
+// NormalizeSecret takes an external SecretDoc request and returns an internal
+// object and chosen apiVersion.
+func NormalizeSecret(req ext.SecretDoc) (intmodel.Secret, ext.Version, error) {
+	version := DefaultVersion(req.APIVersion)
+	internal, err := ConvertSecretDocToInternal(req)
+	if err != nil {
+		return intmodel.Secret{}, "", err
+	}
+	return internal, version, nil
+}
+
 // ConvertSpaceDocToInternal converts an external SpaceDoc to the internal hub type.
 func ConvertSpaceDocToInternal(in ext.SpaceDoc) (intmodel.Space, error) {
 	switch in.APIVersion {

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -2089,3 +2089,44 @@ func TestStatusLifecycleFieldsZeroDefault(t *testing.T) {
 		}
 	})
 }
+
+// TestNormalizeSecret_FlatFieldCopy pins the issue #619 conversion: the scope
+// coordinates and the material copy across verbatim, and an unsupported
+// apiVersion is rejected.
+func TestNormalizeSecret_FlatFieldCopy(t *testing.T) {
+	in := ext.SecretDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindSecret,
+		Metadata: ext.SecretMetadata{
+			Name:  "anthropic-token",
+			Realm: "default",
+			Space: "team-a",
+		},
+		Spec: ext.SecretSpec{Data: "s3cr3t"},
+	}
+
+	got, version, err := apischeme.NormalizeSecret(in)
+	if err != nil {
+		t.Fatalf("NormalizeSecret() error = %v", err)
+	}
+	if version != apischeme.VersionV1Beta1 {
+		t.Errorf("version = %q, want %q", version, apischeme.VersionV1Beta1)
+	}
+	want := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "anthropic-token", Realm: "default", Space: "team-a"},
+		Spec:     intmodel.SecretSpec{Data: "s3cr3t"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("NormalizeSecret() = %+v, want %+v", got, want)
+	}
+}
+
+func TestNormalizeSecret_UnsupportedVersion(t *testing.T) {
+	_, _, err := apischeme.NormalizeSecret(ext.SecretDoc{APIVersion: "v0alpha9"})
+	if err == nil {
+		t.Fatal("NormalizeSecret() error = nil, want unsupported-version error")
+	}
+	if !strings.Contains(err.Error(), "unsupported apiVersion for Secret") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -41,6 +41,7 @@ type Document struct {
 	StackDoc     *v1beta1.StackDoc
 	CellDoc      *v1beta1.CellDoc
 	ContainerDoc *v1beta1.ContainerDoc
+	SecretDoc    *v1beta1.SecretDoc
 }
 
 // ValidationError represents a validation error for a specific document.
@@ -161,6 +162,14 @@ func ParseDocument(index int, raw []byte) (*Document, error) {
 		doc.ContainerDoc = &containerDoc
 		doc.APIVersion = containerDoc.APIVersion
 
+	case v1beta1.KindSecret:
+		var secretDoc v1beta1.SecretDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &secretDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse Secret: %w", index, unmarshalErr)
+		}
+		doc.SecretDoc = &secretDoc
+		doc.APIVersion = secretDoc.APIVersion
+
 	default:
 		return nil, fmt.Errorf("document %d: %w: %s", index, errdefs.ErrUnknownKind, kind)
 	}
@@ -187,7 +196,8 @@ func ValidateDocument(doc *Document) *ValidationError {
 
 	// Validate kind
 	switch doc.Kind {
-	case v1beta1.KindRealm, v1beta1.KindSpace, v1beta1.KindStack, v1beta1.KindCell, v1beta1.KindContainer:
+	case v1beta1.KindRealm, v1beta1.KindSpace, v1beta1.KindStack, v1beta1.KindCell,
+		v1beta1.KindContainer, v1beta1.KindSecret:
 		// Valid kind
 	default:
 		return &ValidationError{
@@ -391,8 +401,66 @@ func ValidateDocument(doc *Document) *ValidationError {
 				Err:   repoErr,
 			}
 		}
+
+	case v1beta1.KindSecret:
+		if doc.SecretDoc == nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("secret document is nil"),
+			}
+		}
+		if doc.SecretDoc.Metadata.Name == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Err:   errors.New("metadata.name is required"),
+			}
+		}
+		if secretErr := validateSecretScope(doc.SecretDoc.Metadata); secretErr != nil {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.SecretDoc.Metadata.Name,
+				Err:   secretErr,
+			}
+		}
+		if strings.TrimSpace(doc.SecretDoc.Spec.Data) == "" {
+			return &ValidationError{
+				Index: doc.Index,
+				Kind:  doc.Kind,
+				Name:  doc.SecretDoc.Metadata.Name,
+				Err:   errdefs.ErrSecretDataRequired,
+			}
+		}
 	}
 
+	return nil
+}
+
+// validateSecretScope enforces the `kind: Secret` scope-coordinate contract:
+// metadata.realm is always required, and a deeper coordinate may only be set
+// when every shallower one is also set (a cell-scoped secret must name its
+// stack, space, and realm). It does not check that the scope exists on the
+// host — that reachability gate runs at reconcile time against the runner,
+// because only the daemon can read /opt/kukeon. Issue #619.
+func validateSecretScope(md v1beta1.SecretMetadata) error {
+	realm := strings.TrimSpace(md.Realm)
+	space := strings.TrimSpace(md.Space)
+	stack := strings.TrimSpace(md.Stack)
+	cell := strings.TrimSpace(md.Cell)
+
+	if realm == "" {
+		return errdefs.ErrSecretRealmRequired
+	}
+	// A deeper coordinate requires all shallower ones. Walk outward: the
+	// first non-empty coordinate that sits below an empty parent is a gap.
+	if cell != "" && stack == "" {
+		return fmt.Errorf("%w (cell set without stack)", errdefs.ErrSecretScopeIncomplete)
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrSecretScopeIncomplete)
+	}
 	return nil
 }
 

--- a/internal/apply/parser/parser_test.go
+++ b/internal/apply/parser/parser_test.go
@@ -18,6 +18,7 @@ package parser_test
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -760,5 +761,123 @@ spec:
 	}
 	if !strings.Contains(string(docs[2]), "kind: Stack") {
 		t.Errorf("expected third document to be a Stack")
+	}
+}
+
+// TestParseDocument_Secret confirms a Secret document parses into the typed
+// SecretDoc with its scope coordinates and material (issue #619).
+func TestParseDocument_Secret(t *testing.T) {
+	yaml := `
+apiVersion: v1beta1
+kind: Secret
+metadata:
+  name: anthropic-token
+  realm: kuke-system
+spec:
+  data: s3cr3t-bytes`
+
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+	if doc.Kind != v1beta1.KindSecret {
+		t.Errorf("Kind = %q, want %q", doc.Kind, v1beta1.KindSecret)
+	}
+	if doc.SecretDoc == nil {
+		t.Fatal("SecretDoc is nil")
+	}
+	if doc.SecretDoc.Metadata.Name != "anthropic-token" {
+		t.Errorf("name = %q, want anthropic-token", doc.SecretDoc.Metadata.Name)
+	}
+	if doc.SecretDoc.Metadata.Realm != "kuke-system" {
+		t.Errorf("realm = %q, want kuke-system", doc.SecretDoc.Metadata.Realm)
+	}
+	if doc.SecretDoc.Spec.Data != "s3cr3t-bytes" {
+		t.Errorf("data = %q, want s3cr3t-bytes", doc.SecretDoc.Spec.Data)
+	}
+}
+
+// TestValidateDocument_Secret exercises the issue #619 apply-time gates that
+// don't require the runner: name required, realm required, scope-coordinate
+// completeness, and non-empty data. The scope-reachability gate is enforced
+// at reconcile time and is not covered here.
+func TestValidateDocument_Secret(t *testing.T) {
+	base := func() *v1beta1.SecretDoc {
+		return &v1beta1.SecretDoc{
+			APIVersion: v1beta1.APIVersionV1Beta1,
+			Kind:       v1beta1.KindSecret,
+			Metadata:   v1beta1.SecretMetadata{Name: "tok", Realm: "default"},
+			Spec:       v1beta1.SecretSpec{Data: "x"},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*v1beta1.SecretDoc)
+		wantErr error // nil means valid
+	}{
+		{name: "valid realm-scoped", mutate: func(*v1beta1.SecretDoc) {}},
+		{
+			name:   "valid cell-scoped",
+			mutate: func(d *v1beta1.SecretDoc) { d.Metadata.Space, d.Metadata.Stack, d.Metadata.Cell = "s", "st", "c" },
+		},
+		{
+			name:    "missing name",
+			mutate:  func(d *v1beta1.SecretDoc) { d.Metadata.Name = "" },
+			wantErr: nil, // name error is a plain errors.New, asserted by message below
+		},
+		{
+			name:    "missing realm",
+			mutate:  func(d *v1beta1.SecretDoc) { d.Metadata.Realm = "" },
+			wantErr: errdefs.ErrSecretRealmRequired,
+		},
+		{
+			name:    "stack without space",
+			mutate:  func(d *v1beta1.SecretDoc) { d.Metadata.Stack = "st" },
+			wantErr: errdefs.ErrSecretScopeIncomplete,
+		},
+		{
+			name:    "cell without stack",
+			mutate:  func(d *v1beta1.SecretDoc) { d.Metadata.Space, d.Metadata.Cell = "s", "c" },
+			wantErr: errdefs.ErrSecretScopeIncomplete,
+		},
+		{
+			name:    "empty data",
+			mutate:  func(d *v1beta1.SecretDoc) { d.Spec.Data = "   " },
+			wantErr: errdefs.ErrSecretDataRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			secretDoc := base()
+			tt.mutate(secretDoc)
+			doc := &parser.Document{
+				Index:      0,
+				APIVersion: secretDoc.APIVersion,
+				Kind:       v1beta1.KindSecret,
+				SecretDoc:  secretDoc,
+			}
+			err := parser.ValidateDocument(doc)
+
+			// "missing name" surfaces a plain errors.New, not a sentinel, so
+			// it is asserted by message rather than via errors.Is.
+			if tt.name == "missing name" {
+				if err == nil || !strings.Contains(err.Error(), "metadata.name is required") {
+					t.Fatalf("err = %v, want metadata.name required", err)
+				}
+				return
+			}
+
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("ValidateDocument() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !errors.Is(err.Err, tt.wantErr) {
+				t.Fatalf("ValidateDocument() = %v, want %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -37,6 +37,15 @@ const (
 	// .kukeon-instance.json file — are not mistaken for realm directories.
 	KukeonMetadataSubdir = "data"
 
+	// KukeonSecretsSubdir is the basename of the per-scope subdirectory that
+	// owns daemon-managed `kind: Secret` bytes (issue #619). It lives inside
+	// the scope's metadata directory (e.g. <RunPath>/data/<realm>/secrets/) so
+	// the same os.RemoveAll that purge/delete already runs on a scope's
+	// metadata dir reclaims its secrets too. Unlike the 0o2750 setgid
+	// metadata directories the kuke group can traverse, the secrets directory
+	// and the files in it are root-only (0o700 / 0o600).
+	KukeonSecretsSubdir = "secrets"
+
 	// KukeonContainerTTYDir is the basename of the per-container directory
 	// that owns the sbsh terminal socket plus its capture and log siblings.
 	// kukeon bind-mounts this directory (not a single file) into the

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -202,6 +202,23 @@ func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
 			resourceResult.Name = container.Metadata.Name
 			reconcileResult, reconcileErr = applypkg.ReconcileContainer(b.runner, container)
 
+		case v1beta1.KindSecret:
+			if doc.SecretDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("secret document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			secret, _, err := apischeme.NormalizeSecret(*doc.SecretDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = secret.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileSecret(b.runner, secret)
+
 		default:
 			resourceResult.Action = actionFailed
 			resourceResult.Error = fmt.Errorf("%w: %s", errdefs.ErrUnknownKind, doc.Kind)

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -536,6 +536,102 @@ func ReconcileContainer(r runner.Runner, desired intmodel.Container) (ReconcileR
 	return result, nil
 }
 
+// ReconcileSecret reconciles a desired `kind: Secret` by verifying its scope
+// exists and persisting its bytes to the daemon-managed file (issue #619).
+//
+// Unlike the hierarchy reconcilers, ReconcileSecret never auto-creates a
+// missing parent: a Secret targets an existing scope, so an unreachable
+// realm/space/stack/cell is an apply-time error, not an implicit create. The
+// scope coordinates are validated for completeness at parse time
+// (validateSecretScope); this function adds the reachability gate the AC
+// requires (scope must exist). The secret material itself is written
+// write-through — re-applying overwrites and reports "updated"; the daemon
+// never reads the bytes back to diff them, keeping the never-round-tripped
+// contract crisp.
+func ReconcileSecret(r runner.Runner, desired intmodel.Secret) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "Secret",
+		Name:   desired.Metadata.Name,
+	}
+
+	if err := ensureSecretScopeExists(r, desired.Metadata); err != nil {
+		return result, err
+	}
+
+	created, writeErr := r.WriteSecret(desired)
+	if writeErr != nil {
+		return result, writeErr
+	}
+	if created {
+		result.Action = actionCreated
+	} else {
+		result.Action = actionUpdated
+	}
+	return result, nil
+}
+
+// ensureSecretScopeExists verifies every scope coordinate the secret names is
+// reachable, deepest-first short-circuiting on the first miss. A NotFound is
+// translated to errdefs.ErrSecretScopeNotFound so apply surfaces a single,
+// stable "scope does not exist" error regardless of which level is missing.
+func ensureSecretScopeExists(r runner.Runner, md intmodel.SecretMetadata) error {
+	if _, err := r.GetRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: md.Realm},
+	}); err != nil {
+		return scopeLookupError(err, "realm", md.Realm)
+	}
+
+	if md.Space != "" {
+		if _, err := r.GetSpace(intmodel.Space{
+			Metadata: intmodel.SpaceMetadata{Name: md.Space},
+			Spec:     intmodel.SpaceSpec{RealmName: md.Realm},
+		}); err != nil {
+			return scopeLookupError(err, "space", md.Space)
+		}
+	}
+
+	if md.Stack != "" {
+		if _, err := r.GetStack(intmodel.Stack{
+			Metadata: intmodel.StackMetadata{Name: md.Stack},
+			Spec:     intmodel.StackSpec{RealmName: md.Realm, SpaceName: md.Space},
+		}); err != nil {
+			return scopeLookupError(err, "stack", md.Stack)
+		}
+	}
+
+	if md.Cell != "" {
+		if _, err := r.GetCell(intmodel.Cell{
+			Metadata: intmodel.CellMetadata{Name: md.Cell},
+			Spec: intmodel.CellSpec{
+				RealmName: md.Realm,
+				SpaceName: md.Space,
+				StackName: md.Stack,
+			},
+		}); err != nil {
+			return scopeLookupError(err, "cell", md.Cell)
+		}
+	}
+
+	return nil
+}
+
+// scopeLookupError maps a scope Get failure to a stable error. A NotFound at
+// any level becomes ErrSecretScopeNotFound (the AC's "scope must exist"
+// gate); any other error (e.g. a corrupt metadata read) is propagated with
+// context so it is not masked as a missing scope.
+func scopeLookupError(err error, level, name string) error {
+	switch {
+	case errors.Is(err, errdefs.ErrRealmNotFound),
+		errors.Is(err, errdefs.ErrSpaceNotFound),
+		errors.Is(err, errdefs.ErrStackNotFound),
+		errors.Is(err, errdefs.ErrCellNotFound):
+		return fmt.Errorf("%w: %s %q", errdefs.ErrSecretScopeNotFound, level, name)
+	default:
+		return fmt.Errorf("failed to verify secret scope %s %q: %w", level, name, err)
+	}
+}
+
 // ReconcileResult represents the result of reconciling a resource.
 type ReconcileResult struct {
 	Action   string            // "created", "updated", "unchanged", "deleted"

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -59,6 +59,9 @@ type fakeRunner struct {
 	EnsureStackFn func(stack intmodel.Stack) (intmodel.Stack, error)
 	DeleteStackFn func(stack intmodel.Stack) error
 
+	// Secret methods
+	WriteSecretFn func(secret intmodel.Secret) (bool, error)
+
 	// Cell methods
 	GetCellFn                 func(cell intmodel.Cell) (intmodel.Cell, error)
 	ListCellsFn               func(realmName, spaceName, stackName string) ([]intmodel.Cell, error)
@@ -252,6 +255,15 @@ func (f *fakeRunner) DeleteStack(stack intmodel.Stack) error {
 		return f.DeleteStackFn(stack)
 	}
 	return errors.New("unexpected call to DeleteStack")
+}
+
+// Secret methods
+
+func (f *fakeRunner) WriteSecret(secret intmodel.Secret) (bool, error) {
+	if f.WriteSecretFn != nil {
+		return f.WriteSecretFn(secret)
+	}
+	return false, errors.New("unexpected call to WriteSecret")
 }
 
 // Cell methods

--- a/internal/controller/documents.go
+++ b/internal/controller/documents.go
@@ -40,6 +40,12 @@ func SortDocumentsByKind(docs []parser.Document, reverse bool) []parser.Document
 		v1beta1.KindCell:      4,
 		v1beta1.KindContainer: 5,
 	}
+	// Secrets sort one past the deepest hierarchy kind so any scope
+	// (realm/space/stack/cell) bundled in the same apply file is materialized
+	// before a secret that targets it — apply rejects a secret whose scope
+	// does not yet exist. Derived from the map length rather than a literal so
+	// it stays correct if a kind is inserted above.
+	kindOrder[v1beta1.KindSecret] = len(kindOrder) + 1
 
 	// Sort by kind order, then by original index
 	sort.Slice(sorted, func(i, j int) bool {

--- a/internal/controller/reconcile_secret_test.go
+++ b/internal/controller/reconcile_secret_test.go
@@ -1,0 +1,109 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"testing"
+
+	applypkg "github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestReconcileSecret_WritesWhenScopeExists is the issue #619 happy path: with
+// the realm reachable, ReconcileSecret writes the bytes and reports created.
+func TestReconcileSecret_WritesWhenScopeExists(t *testing.T) {
+	var wroteData string
+	f := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) { return realm, nil },
+		WriteSecretFn: func(secret intmodel.Secret) (bool, error) {
+			wroteData = secret.Spec.Data
+			return true, nil
+		},
+	}
+
+	desired := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "kuke-system"},
+		Spec:     intmodel.SecretSpec{Data: "s3cr3t"},
+	}
+	result, err := applypkg.ReconcileSecret(f, desired)
+	if err != nil {
+		t.Fatalf("ReconcileSecret() error = %v", err)
+	}
+	if result.Action != "created" {
+		t.Errorf("action = %q, want created", result.Action)
+	}
+	if wroteData != "s3cr3t" {
+		t.Errorf("WriteSecret got data %q, want s3cr3t", wroteData)
+	}
+}
+
+// TestReconcileSecret_RejectsMissingScope confirms the AC's scope-reachability
+// gate: a realm-not-found surfaces ErrSecretScopeNotFound and WriteSecret is
+// never reached (no auto-create of the scope, unlike the hierarchy reconcilers).
+func TestReconcileSecret_RejectsMissingScope(t *testing.T) {
+	var wrote bool
+	f := &fakeRunner{
+		GetRealmFn: func(intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errdefs.ErrRealmNotFound
+		},
+		WriteSecretFn: func(intmodel.Secret) (bool, error) {
+			wrote = true
+			return false, nil
+		},
+	}
+
+	desired := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "ghost"},
+		Spec:     intmodel.SecretSpec{Data: "x"},
+	}
+	_, err := applypkg.ReconcileSecret(f, desired)
+	if !errors.Is(err, errdefs.ErrSecretScopeNotFound) {
+		t.Fatalf("err = %v, want ErrSecretScopeNotFound", err)
+	}
+	if wrote {
+		t.Error("WriteSecret was called despite a missing scope")
+	}
+}
+
+// TestReconcileSecret_ChecksDeepestScope confirms a cell-scoped secret verifies
+// every coordinate down to the cell, and a missing cell rejects.
+func TestReconcileSecret_ChecksDeepestScope(t *testing.T) {
+	f := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) { return realm, nil },
+		GetSpaceFn: func(space intmodel.Space) (intmodel.Space, error) { return space, nil },
+		GetStackFn: func(stack intmodel.Stack) (intmodel.Stack, error) { return stack, nil },
+		GetCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			return intmodel.Cell{}, errdefs.ErrCellNotFound
+		},
+		WriteSecretFn: func(intmodel.Secret) (bool, error) { return false, nil },
+	}
+
+	desired := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{
+			Name: "tok", Realm: "default", Space: "team-a", Stack: "web", Cell: "api",
+		},
+		Spec: intmodel.SecretSpec{Data: "x"},
+	}
+	_, err := applypkg.ReconcileSecret(f, desired)
+	if !errors.Is(err, errdefs.ErrSecretScopeNotFound) {
+		t.Fatalf("err = %v, want ErrSecretScopeNotFound for missing cell", err)
+	}
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -95,6 +95,14 @@ type Runner interface {
 	UpdateStack(stack intmodel.Stack) (intmodel.Stack, error)
 	DeleteStack(stack intmodel.Stack) error
 
+	// WriteSecret persists a `kind: Secret`'s bytes to the daemon-managed,
+	// root-owned, 0o600 file under the scope's metadata tree (issue #619).
+	// It returns whether the file was newly created (vs. overwritten). The
+	// caller (ReconcileSecret) is responsible for having verified the scope
+	// exists; WriteSecret only creates the secrets/ subdir and the file, not
+	// the scope itself.
+	WriteSecret(secret intmodel.Secret) (created bool, err error)
+
 	ExistsCgroup(doc any) (bool, error)
 
 	PurgeRealm(realm intmodel.Realm) (namespaceRemoved bool, err error)

--- a/internal/controller/runner/secret.go
+++ b/internal/controller/runner/secret.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// secretsDirMode is the mode of the per-scope secrets/ directory. Unlike the
+// 0o2750 setgid metadata directories the kuke group may traverse, the
+// secrets directory is root-only: only the daemon (root) reads or writes
+// secret material.
+const secretsDirMode os.FileMode = 0o700
+
+// secretFileMode is the mode of an individual secret's bytes file: read/write
+// for the owner (root) only, matching the AC's chmod-600 requirement.
+const secretFileMode os.FileMode = 0o600
+
+// WriteSecret persists a Secret's bytes to <RunPath>/data/<scope>/secrets/<name>,
+// root-owned and 0o600 (issue #619). The bytes are written atomically via a
+// temp file + rename so a reader never observes a partially-written secret,
+// and the data is never logged. Returns whether the file was newly created.
+//
+// The daemon runs as root, so files it creates are root-owned by default;
+// WriteSecret additionally chmods the directory and file to strip any umask
+// bits, so the 0o700/0o600 contract holds regardless of the daemon's umask.
+func (r *Exec) WriteSecret(secret intmodel.Secret) (bool, error) {
+	md := secret.Metadata
+	dir := fs.SecretsDir(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Cell)
+	path := fs.SecretPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Cell, md.Name)
+
+	if err := os.MkdirAll(dir, secretsDirMode); err != nil {
+		return false, fmt.Errorf("%w: create secrets dir: %w", errdefs.ErrWriteSecret, err)
+	}
+	// MkdirAll honors only the rwx bits and leaves a pre-existing directory's
+	// mode intact; chmod unconditionally so the root-only contract holds even
+	// when a parent created the dir with looser bits or the umask stripped them.
+	if err := os.Chmod(dir, secretsDirMode); err != nil {
+		return false, fmt.Errorf("%w: chmod secrets dir: %w", errdefs.ErrWriteSecret, err)
+	}
+
+	_, statErr := os.Stat(path)
+	created := errors.Is(statErr, os.ErrNotExist)
+	if statErr != nil && !created {
+		return false, fmt.Errorf("%w: stat secret: %w", errdefs.ErrWriteSecret, statErr)
+	}
+
+	if err := atomicWriteSecret(dir, path, []byte(secret.Spec.Data)); err != nil {
+		return false, fmt.Errorf("%w: %w", errdefs.ErrWriteSecret, err)
+	}
+
+	action := "updated"
+	if created {
+		action = "created"
+	}
+	// Log the scope + name + action only — never the bytes.
+	r.logger.InfoContext(r.ctx, "secret "+action,
+		"name", md.Name,
+		"realm", md.Realm,
+		"space", md.Space,
+		"stack", md.Stack,
+		"cell", md.Cell,
+	)
+	return created, nil
+}
+
+// atomicWriteSecret writes data to path via a temp file in the same directory
+// followed by a rename, so a concurrent reader sees either the old inode or
+// the fully-written new one — never a torn write. The temp file is created at
+// secretFileMode and chmod'd to strip the umask before the rename.
+func atomicWriteSecret(dir, path string, data []byte) error {
+	tmp, err := os.CreateTemp(dir, ".secret-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp secret: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we bail before the rename succeeds.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, writeErr := tmp.Write(data); writeErr != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp secret: %w", writeErr)
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		return fmt.Errorf("close temp secret: %w", closeErr)
+	}
+	if chmodErr := os.Chmod(tmpName, secretFileMode); chmodErr != nil {
+		return fmt.Errorf("chmod temp secret: %w", chmodErr)
+	}
+	if renameErr := os.Rename(tmpName, path); renameErr != nil {
+		return fmt.Errorf("rename secret into place: %w", renameErr)
+	}
+	return nil
+}

--- a/internal/controller/runner/secret_test.go
+++ b/internal/controller/runner/secret_test.go
@@ -1,0 +1,133 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests the unexported WriteSecret path against a temp RunPath
+package runner
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// TestWriteSecret_CreatesRootOnlyFile pins the issue #619 storage contract:
+// the bytes land at <RunPath>/data/<scope>/secrets/<name>, the file is 0o600,
+// the secrets/ directory is 0o700, and the first write reports created=true.
+func TestWriteSecret_CreatesRootOnlyFile(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	secret := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "anthropic-token", Realm: "kuke-system"},
+		Spec:     intmodel.SecretSpec{Data: "s3cr3t-bytes"},
+	}
+
+	created, err := r.WriteSecret(secret)
+	if err != nil {
+		t.Fatalf("WriteSecret() error = %v", err)
+	}
+	if !created {
+		t.Errorf("created = false, want true on first write")
+	}
+
+	path := fs.SecretPath(runPath, "kuke-system", "", "", "", "anthropic-token")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written secret: %v", err)
+	}
+	if string(got) != "s3cr3t-bytes" {
+		t.Errorf("secret bytes = %q, want %q", got, "s3cr3t-bytes")
+	}
+
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat secret file: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0o600 {
+		t.Errorf("secret file mode = %o, want 600", perm)
+	}
+
+	dirInfo, err := os.Stat(fs.SecretsDir(runPath, "kuke-system", "", "", ""))
+	if err != nil {
+		t.Fatalf("stat secrets dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o700 {
+		t.Errorf("secrets dir mode = %o, want 700", perm)
+	}
+}
+
+// TestWriteSecret_OverwriteReportsUpdated confirms a re-apply overwrites the
+// bytes and reports created=false (the write-through "updated" path).
+func TestWriteSecret_OverwriteReportsUpdated(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	secret := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+		Spec:     intmodel.SecretSpec{Data: "v1"},
+	}
+	if _, err := r.WriteSecret(secret); err != nil {
+		t.Fatalf("first WriteSecret() error = %v", err)
+	}
+
+	secret.Spec.Data = "v2"
+	created, err := r.WriteSecret(secret)
+	if err != nil {
+		t.Fatalf("second WriteSecret() error = %v", err)
+	}
+	if created {
+		t.Errorf("created = true, want false on overwrite")
+	}
+
+	path := fs.SecretPath(runPath, "default", "", "", "", "tok")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading overwritten secret: %v", err)
+	}
+	if string(got) != "v2" {
+		t.Errorf("secret bytes = %q, want %q", got, "v2")
+	}
+}
+
+// TestWriteSecret_DeeperScopeNestsUnderScopeDir confirms a space-scoped secret
+// lands under the space metadata dir, not the realm dir — so scope teardown
+// (os.RemoveAll on the scope dir) reclaims it.
+func TestWriteSecret_DeeperScopeNestsUnderScopeDir(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	secret := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "db-pw", Realm: "default", Space: "team-a"},
+		Spec:     intmodel.SecretSpec{Data: "x"},
+	}
+	if _, err := r.WriteSecret(secret); err != nil {
+		t.Fatalf("WriteSecret() error = %v", err)
+	}
+
+	spaceScoped := fs.SecretPath(runPath, "default", "team-a", "", "", "db-pw")
+	if _, err := os.Stat(spaceScoped); err != nil {
+		t.Errorf("space-scoped secret not found at %s: %v", spaceScoped, err)
+	}
+	realmScoped := fs.SecretPath(runPath, "default", "", "", "", "db-pw")
+	if _, err := os.Stat(realmScoped); !os.IsNotExist(err) {
+		t.Errorf("secret leaked into realm scope at %s (err=%v)", realmScoped, err)
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -291,6 +291,16 @@ var (
 	ErrSecretFromEnvNotSet        = errors.New("secret fromEnv env var is not set on the daemon host")
 	ErrSecretStagingFailed        = errors.New("failed to stage secret file for mount")
 
+	// Secret kind (kind: Secret) storage-primitive errors (issue #619).
+
+	ErrSecretRealmRequired   = errors.New("secret metadata.realm is required")
+	ErrSecretScopeIncomplete = errors.New(
+		"secret scope is incomplete: a deeper scope coordinate requires all shallower ones",
+	)
+	ErrSecretDataRequired  = errors.New("secret spec.data is required and must not be empty")
+	ErrSecretScopeNotFound = errors.New("secret scope does not exist")
+	ErrWriteSecret         = errors.New("failed to write secret bytes")
+
 	// Repo-related errors (containers[].repos[], issue #617).
 
 	ErrRepoNameRequired      = errors.New("repo name is required")

--- a/internal/modelhub/secret.go
+++ b/internal/modelhub/secret.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelhub
+
+// Secret is the internal carrier for a named, scoped, daemon-managed
+// credential (kind: Secret, issue #619). It has no Status because a Secret
+// has no runtime: the bytes are written once to a daemon-owned file and the
+// model exists only to ferry the scope coordinates and the material from the
+// apply parser to the storage runner. Spec.Data is never round-tripped back
+// out of the daemon.
+type Secret struct {
+	Metadata SecretMetadata
+	Spec     SecretSpec
+}
+
+// SecretMetadata identifies a Secret by name and the scope it binds to. The
+// scope is the deepest non-empty coordinate; a deeper coordinate requires
+// every shallower one. See the external v1beta1.SecretMetadata for the full
+// contract.
+type SecretMetadata struct {
+	Name  string
+	Realm string
+	Space string
+	Stack string
+	Cell  string
+}
+
+// SecretSpec carries the secret material supplied at apply time.
+type SecretSpec struct {
+	Data string
+}

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -237,6 +237,44 @@ func ContainerLogPath(baseRunPath, realmName, spaceName, stackName, cellName, co
 	)
 }
 
+// SecretScopeDir returns the metadata directory of the scope a `kind: Secret`
+// is bound to (issue #619). The scope is the deepest non-empty coordinate:
+// passing only realmName yields the realm dir, realmName+spaceName the space
+// dir, and so on. Empty deeper coordinates are ignored — the caller is
+// responsible for having validated coordinate completeness (a non-empty cell
+// requires a non-empty stack, space, and realm) before calling.
+func SecretScopeDir(baseRunPath, realmName, spaceName, stackName, cellName string) string {
+	switch {
+	case cellName != "":
+		return CellMetadataDir(baseRunPath, realmName, spaceName, stackName, cellName)
+	case stackName != "":
+		return StackMetadataDir(baseRunPath, realmName, spaceName, stackName)
+	case spaceName != "":
+		return SpaceMetadataDir(baseRunPath, realmName, spaceName)
+	default:
+		return RealmMetadataDir(baseRunPath, realmName)
+	}
+}
+
+// SecretsDir returns the per-scope secrets directory — the root-only
+// (0o700) directory under the scope's metadata tree that owns daemon-managed
+// secret bytes. Nested inside the scope dir so scope teardown reclaims it.
+func SecretsDir(baseRunPath, realmName, spaceName, stackName, cellName string) string {
+	return filepath.Join(
+		SecretScopeDir(baseRunPath, realmName, spaceName, stackName, cellName),
+		consts.KukeonSecretsSubdir,
+	)
+}
+
+// SecretPath returns the host-side path of a single daemon-managed secret's
+// bytes: <scope>/secrets/<name>, root-owned and 0o600.
+func SecretPath(baseRunPath, realmName, spaceName, stackName, cellName, secretName string) string {
+	return filepath.Join(
+		SecretsDir(baseRunPath, realmName, spaceName, stackName, cellName),
+		secretName,
+	)
+}
+
 type metadataHeader struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`

--- a/internal/util/fs/metadata_test.go
+++ b/internal/util/fs/metadata_test.go
@@ -216,3 +216,55 @@ func TestDetectMetadataVersion(t *testing.T) {
 		})
 	}
 }
+
+// TestSecretScopeDir_PicksDeepestCoordinate pins the issue #619 scope-path
+// rule: the secret's scope dir is the metadata dir of the deepest non-empty
+// coordinate, so realm/space/stack/cell-scoped secrets each nest under their
+// own scope and are reclaimed by that scope's teardown.
+func TestSecretScopeDir_PicksDeepestCoordinate(t *testing.T) {
+	const base = "/opt/kukeon"
+	tests := []struct {
+		name                            string
+		realm, space, stack, cell, want string
+	}{
+		{
+			name:  "realm scope",
+			realm: "kuke-system",
+			want:  fs.RealmMetadataDir(base, "kuke-system"),
+		},
+		{
+			name:  "space scope",
+			realm: "default", space: "team-a",
+			want: fs.SpaceMetadataDir(base, "default", "team-a"),
+		},
+		{
+			name:  "stack scope",
+			realm: "default", space: "team-a", stack: "web",
+			want: fs.StackMetadataDir(base, "default", "team-a", "web"),
+		},
+		{
+			name:  "cell scope",
+			realm: "default", space: "team-a", stack: "web", cell: "api",
+			want: fs.CellMetadataDir(base, "default", "team-a", "web", "api"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fs.SecretScopeDir(base, tt.realm, tt.space, tt.stack, tt.cell)
+			if got != tt.want {
+				t.Errorf("SecretScopeDir = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSecretPath_UnderSecretsSubdir confirms a secret's bytes path is
+// <scope>/secrets/<name>, nesting the secrets/ subdir inside the scope dir.
+func TestSecretPath_UnderSecretsSubdir(t *testing.T) {
+	const base = "/opt/kukeon"
+	got := fs.SecretPath(base, "kuke-system", "", "", "", "anthropic-token")
+	want := fs.RealmMetadataDir(base, "kuke-system") + "/" + consts.KukeonSecretsSubdir + "/anthropic-token"
+	if got != want {
+		t.Errorf("SecretPath = %q, want %q", got, want)
+	}
+}

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -33,6 +33,11 @@ const (
 	KindSpace Kind = "Space"
 	// KindStack identifies stack documents.
 	KindStack Kind = "Stack"
+	// KindSecret identifies named, scoped, daemon-managed credential
+	// documents (issue #619). `kuke apply` writes the secret bytes to a
+	// root-owned file under the scope's metadata tree; phase 3a ships no
+	// `get`/`delete`/referencing surface (tracked in #622 and #623).
+	KindSecret Kind = "Secret"
 	// KindCellProfile identifies per-user cell-template documents loaded by
 	// `kuke run -p`. Profiles are not server-side resources — `kuke apply`
 	// rejects them.

--- a/pkg/api/model/v1beta1/secret.go
+++ b/pkg/api/model/v1beta1/secret.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+// SecretDoc is the top-level document for a named, scoped, daemon-managed
+// credential (kind: Secret, issue #619). Unlike the realm/space/stack/cell
+// hierarchy resources it carries no Status: a Secret has no runtime — its
+// bytes are written once to a daemon-owned file under the scope's metadata
+// tree and are never round-tripped back into any output, log, or audit
+// trail. Phase 3a ships only the schema + storage primitive + `kuke apply`;
+// the `kuke get`/`kuke delete` verbs (#622) and the `ContainerSecret.secretRef`
+// source (#623) build on this foundation.
+type SecretDoc struct {
+	APIVersion Version        `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind           `json:"kind"       yaml:"kind"`
+	Metadata   SecretMetadata `json:"metadata"   yaml:"metadata"`
+	Spec       SecretSpec     `json:"spec"       yaml:"spec"`
+}
+
+// SecretMetadata identifies a Secret by name and the scope it is bound to.
+// The scope is the deepest non-empty coordinate: a Secret with only Realm
+// set is realm-scoped; one with Realm+Space+Stack set is stack-scoped; and
+// so on. A deeper coordinate requires every shallower one (a Cell-scoped
+// Secret must also name its Stack, Space, and Realm) — apply rejects a gap.
+// Scope coordinates live on the metadata (not the spec) so the Secret's
+// full identity is its scope plus its name.
+type SecretMetadata struct {
+	// Name is the secret's name, unique within its scope.
+	Name string `json:"name"            yaml:"name"`
+	// Realm is the always-required top-level scope coordinate.
+	Realm string `json:"realm"           yaml:"realm"`
+	// Space, when set, scopes the secret to a space within Realm.
+	Space string `json:"space,omitempty" yaml:"space,omitempty"`
+	// Stack, when set, scopes the secret to a stack within Space.
+	Stack string `json:"stack,omitempty" yaml:"stack,omitempty"`
+	// Cell, when set, scopes the secret to a cell within Stack.
+	Cell string `json:"cell,omitempty"  yaml:"cell,omitempty"`
+}
+
+// SecretSpec carries the secret material supplied at apply time. Data is
+// write-only from the operator's perspective: it is persisted to the
+// daemon-managed file and never echoed back. The omitempty tag keeps a
+// zero value out of any incidental serialization, but the value itself is
+// never serialized into a result or status by design.
+type SecretSpec struct {
+	// Data is the raw secret material supplied at apply time.
+	Data string `json:"data,omitempty" yaml:"data,omitempty"`
+}


### PR DESCRIPTION
## Summary

Phase 3a of #423 (first slice of phase 3): the foundation both #622 (`get`/`delete` verbs) and #623 (`secretRef` source) build on. Adds a new top-level `kind: Secret` — a named, scoped, daemon-managed credential written to a root-owned file under the scope's metadata tree. Operators can `apply`; there is deliberately no `get`/`delete`/referencing surface yet (out of scope, tracked in #622/#623).

- **No new RPC handler.** `kuke apply` already routes raw YAML through the generic `ApplyDocuments` RPC and dispatches by kind inside the controller, so the daemon wiring is a single new `case` in the existing kind switch — not a new endpoint.
- **Storage primitive.** A new runner method `WriteSecret` persists bytes atomically (temp + rename) to `<runPath>/data/<scope>/secrets/<name>`, `0600` root-owned, inside a `0700` root-only `secrets/` dir. Nested under the scope's metadata dir so the existing `purge`/`delete` `os.RemoveAll` reclaims secrets for free.
- **Never round-tripped.** `spec.data` is write-only: the apply result carries only kind/name/action, `WriteSecret` logs scope+name+action but never the bytes, and the daemon never reads the bytes back to diff them (re-apply is write-through → `updated`).
- **Validation split by layer.** Parse-time (`ValidateDocument`): name required, realm required, scope-coordinate completeness (a deeper coordinate requires all shallower ones), non-empty data. Reconcile-time (`ReconcileSecret`, needs the runner): the scope must already exist — unlike the hierarchy reconcilers, a secret never auto-creates a missing scope.

### Design calls (documented for reviewer push-back)

- **Scope coordinates live on `metadata` (not `spec`).** The issue's proposal YAML places `realm:` under `metadata`, so a Secret's full identity is `scope + name`. This differs from the hierarchy kinds' `spec.realmId`/`spec.spaceId` convention; followed the issue body's explicit placement.
- **Path layout follows the existing metadata tree** (`data/<realm>/...`), which the issue defers to ("same conventions as existing resources"). The AC's shorthand `/opt/kukeon/<scope>/secrets/<name>` resolves to `<runPath>/data/<scope-path>/secrets/<name>`.
- **Re-apply reports `updated`, not `unchanged`.** Chose the crisp "daemon never reads secret bytes back" property over content-diff idempotency — a deliberate trade given the issue's trust-model framing.
- **`kuke delete -f secret.yaml` rejects with `unknown kind`** (delete dispatch has no Secret case yet — that's #622). Safe rejection, no panic/silent success.

## Test plan

- [x] `make test` (full unit CI target) — passes.
- [x] `go build ./...`, `go vet ./internal/...` — clean.
- [x] `pre-commit run --files <changed>` (gofmt, golangci-lint, prettier, addlicense) — all pass.
- [x] New unit tests: parser validation (name/realm/scope-completeness/empty-data), `fs` scope-path helpers, `apischeme.NormalizeSecret`, `runner.WriteSecret` (real temp-dir: 0600 file / 0700 dir / created-vs-updated / deeper-scope nesting), `ReconcileSecret` (scope-exists / missing-scope / deepest-scope rejection).
- [x] `make dev-init` smoke (change touches the daemon) — daemon-parity tail green, both `kuke get realms` views agree.
- [x] **End-to-end against the live daemon** (`kuke --host … apply -f secret.yaml`):
  - `Secret "anthropic-token": created`, output does **not** echo the data.
  - On disk: `/opt/kukeon/data/kuke-system/secrets/anthropic-token` is `600 root:root`, `secrets/` dir is `700`.
  - Re-apply → `updated`.
  - Missing scope (`realm: ghost-realm`) → exit 1, `secret scope does not exist: realm "ghost-realm"`.
  - Empty `data` → exit 1, validation error.
  - Incomplete scope (`stack` without `space`) → exit 1, validation error.

Closes #619