### PR TITLE
feat(secret): add kuke get/delete secret verbs (phase 3b)

### DIFF
--- a/cmd/config/autocomplete.go
+++ b/cmd/config/autocomplete.go
@@ -529,6 +529,66 @@ func CompleteContainerNames(cmd *cobra.Command, args []string, toComplete string
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
+// CompleteSecretNames provides shell completion for `kind: Secret` names by
+// listing existing secrets (issue #622). It can be used as a ValidArgsFunction
+// or for flag completion. Scope flags filter the candidate set: --realm
+// defaults to "default", while --space/--stack/--cell are unset by default
+// (an unset deeper coordinate means "list the whole subtree"). When used as a
+// ValidArgsFunction it requires --realm to be set before completing.
+func CompleteSecretNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) >= 1 && toComplete == "" {
+		if cmd.ValidArgsFunction != nil {
+			testArgs := make([]string, len(args), len(args)+1)
+			copy(testArgs, args)
+			testArgs = append(testArgs, "test")
+			if cmd.Args != nil {
+				if err := cmd.Args(cmd, testArgs); err != nil {
+					return []string{}, cobra.ShellCompDirectiveNoFileComp
+				}
+			}
+		}
+	}
+
+	client, err := completionClient(cmd)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer func() { _ = client.Close() }()
+
+	realmName := getFlagValueWithDefault(cmd, "realm", "default")
+	spaceName := getFlagValueWithDefault(cmd, "space", "")
+	stackName := getFlagValueWithDefault(cmd, "stack", "")
+	cellName := getFlagValueWithDefault(cmd, "cell", "")
+
+	if cmd.ValidArgsFunction != nil && len(args) == 0 {
+		if realmName == "" {
+			return []string{}, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
+	secrets, err := client.ListSecrets(ctx, realmName, spaceName, stackName, cellName)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	seen := make(map[string]bool)
+	names := make([]string, 0, len(secrets))
+	for _, secret := range secrets {
+		name := secret.Metadata.Name
+		if toComplete == "" || strings.HasPrefix(name, toComplete) {
+			if !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
 // CompleteProfileNames provides shell completion for `-p/--profile` by listing
 // every CellProfile under the active profiles directory ($KUKE_PROFILES_DIR or
 // $HOME/.kuke/profiles.d). Errors swallow to an empty list — a fresh shell with

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -309,6 +309,16 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_CONTAINER_CELL = DefineKV("KUKE_GET_CONTAINER_CELL", "kuke/get/container/cell")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_SECRET_NAME = DefineKV("KUKE_GET_SECRET_NAME", "kuke/get/secret/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_SECRET_REALM = DefineKV("KUKE_GET_SECRET_REALM", "kuke/get/secret/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_SECRET_SPACE = DefineKV("KUKE_GET_SECRET_SPACE", "kuke/get/secret/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_SECRET_STACK = DefineKV("KUKE_GET_SECRET_STACK", "kuke/get/secret/stack")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_SECRET_CELL = DefineKV("KUKE_GET_SECRET_CELL", "kuke/get/secret/cell")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_OUTPUT = DefineKV("KUKE_GET_OUTPUT", "kuke/get/output")
 
 	// Delete command variables
@@ -342,6 +352,16 @@ var (
 	KUKE_DELETE_CONTAINER_STACK = DefineKV("KUKE_DELETE_CONTAINER_STACK", "kuke/delete/container/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DELETE_CONTAINER_CELL = DefineKV("KUKE_DELETE_CONTAINER_CELL", "kuke/delete/container/cell")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_SECRET_NAME = DefineKV("KUKE_DELETE_SECRET_NAME", "kuke/delete/secret/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_SECRET_REALM = DefineKV("KUKE_DELETE_SECRET_REALM", "kuke/delete/secret/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_SECRET_SPACE = DefineKV("KUKE_DELETE_SECRET_SPACE", "kuke/delete/secret/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_SECRET_STACK = DefineKV("KUKE_DELETE_SECRET_STACK", "kuke/delete/secret/stack")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_SECRET_CELL = DefineKV("KUKE_DELETE_SECRET_CELL", "kuke/delete/secret/cell")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DELETE_FORCE = DefineKV("KUKE_DELETE_FORCE", "kuke/delete/force")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/delete/delete.go
+++ b/cmd/kuke/delete/delete.go
@@ -25,6 +25,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/kuke/delete/cell"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/container"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/realm"
+	secretdelete "github.com/eminwux/kukeon/cmd/kuke/delete/secret"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/shared"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/space"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/stack"
@@ -47,7 +48,7 @@ func NewDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [name]",
 		Aliases: []string{"d"},
-		Short:   "Delete Kukeon resources (realm, space, stack, cell, container)",
+		Short:   "Delete Kukeon resources (realm, space, stack, cell, container, secret)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if -f flag is provided
 			file, err := cmd.Flags().GetString("file")
@@ -89,6 +90,7 @@ func NewDeleteCmd() *cobra.Command {
 		stack.NewStackCmd(),
 		cell.NewCellCmd(),
 		container.NewContainerCmd(),
+		secretdelete.NewSecretCmd(),
 	)
 
 	return cmd
@@ -96,7 +98,7 @@ func NewDeleteCmd() *cobra.Command {
 
 // completeDeleteSubcommands provides shell completion for delete subcommand names.
 func completeDeleteSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container"}
+	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/delete/delete_test.go
+++ b/cmd/kuke/delete/delete_test.go
@@ -50,7 +50,7 @@ func TestNewDeleteCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Delete Kukeon resources (realm, space, stack, cell, container)"
+				expected := "Delete Kukeon resources (realm, space, stack, cell, container, secret)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -207,7 +207,7 @@ func TestNewDeleteCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container"}
+	expected := []string{"realm", "space", "stack", "cell", "container", "secret"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}

--- a/cmd/kuke/delete/secret/secret.go
+++ b/cmd/kuke/delete/secret/secret.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// unsafeDeleteWarning documents the temporary window the AC of issue #622 calls
+// out: until the secretRef referencing path ships in phase 3c, delete cannot
+// know whether a live container still references the secret, so it removes the
+// file unconditionally.
+const unsafeDeleteWarning = "WARNING: until the secretRef referencing path ships (phase 3c), this verb " +
+	"cannot detect a live container that references the secret and will delete it " +
+	"unconditionally. Deleting a referenced secret may break running workloads."
+
+// NewSecretCmd builds `kuke delete secret <name>` (issue #622). It removes the
+// daemon-stored bytes file for a single named, scoped Secret. The secret is
+// identified by its name plus its binding scope (--realm/--space/--stack/--cell).
+func NewSecretCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "secret [name]",
+		Aliases:       []string{"sec"},
+		Short:         "Delete a kind: Secret",
+		Long:          "Delete a kind: Secret's daemon-stored bytes.\n\n" + unsafeDeleteWarning,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+
+			realm := strings.TrimSpace(config.KUKE_DELETE_SECRET_REALM.ValueOrDefault())
+			space := config.KUKE_DELETE_SECRET_SPACE.ValueOrDefault()
+			stack := config.KUKE_DELETE_SECRET_STACK.ValueOrDefault()
+			cell := config.KUKE_DELETE_SECRET_CELL.ValueOrDefault()
+			if realm == "" {
+				return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+			}
+
+			doc := v1beta1.SecretDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindSecret,
+				Metadata: v1beta1.SecretMetadata{
+					Name:  name,
+					Realm: realm,
+					Space: strings.TrimSpace(space),
+					Stack: strings.TrimSpace(stack),
+					Cell:  strings.TrimSpace(cell),
+				},
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			result, err := client.DeleteSecret(cmd.Context(), doc)
+			if err != nil {
+				return err
+			}
+
+			secretName := name
+			if result.Secret.Metadata.Name != "" {
+				secretName = result.Secret.Metadata.Name
+			}
+			cmd.Printf("Deleted secret %q\n", secretName)
+			return nil
+		},
+	}
+
+	cmd.Flags().String("realm", "", "Realm the secret is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_SECRET_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Space the secret is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_SECRET_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Stack the secret is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_SECRET_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+	cmd.Flags().String("cell", "", "Cell the secret is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_SECRET_CELL.ViperKey, cmd.Flags().Lookup("cell"))
+
+	cmd.ValidArgsFunction = config.CompleteSecretNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("cell", config.CompleteCellNames)
+
+	return cmd
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.DaemonClientFromCmd(cmd)
+}

--- a/cmd/kuke/delete/secret/secret_test.go
+++ b/cmd/kuke/delete/secret/secret_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secret_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	secret "github.com/eminwux/kukeon/cmd/kuke/delete/secret"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestDeleteSecret(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func(t *testing.T, cmd *cobra.Command)
+		fake       *fakeClient
+		wantErr    string
+		wantScope  v1beta1.SecretMetadata
+		wantOutput string
+	}{
+		{
+			name: "success at realm scope",
+			args: []string{"tok"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteSecretFn: func(doc v1beta1.SecretDoc) (kukeonv1.DeleteSecretResult, error) {
+					return kukeonv1.DeleteSecretResult{Secret: doc, Deleted: true}, nil
+				},
+			},
+			wantScope:  v1beta1.SecretMetadata{Name: "tok", Realm: "r1"},
+			wantOutput: `Deleted secret "tok"`,
+		},
+		{
+			name: "success at cell scope passes full coordinates",
+			args: []string{"cell-tok"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+				_ = cmd.Flags().Set("space", "s1")
+				_ = cmd.Flags().Set("stack", "st1")
+				_ = cmd.Flags().Set("cell", "ce1")
+			},
+			fake: &fakeClient{
+				deleteSecretFn: func(doc v1beta1.SecretDoc) (kukeonv1.DeleteSecretResult, error) {
+					return kukeonv1.DeleteSecretResult{Secret: doc, Deleted: true}, nil
+				},
+			},
+			wantScope:  v1beta1.SecretMetadata{Name: "cell-tok", Realm: "r1", Space: "s1", Stack: "st1", Cell: "ce1"},
+			wantOutput: `Deleted secret "cell-tok"`,
+		},
+		{
+			name: "not found surfaces error",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteSecretFn: func(_ v1beta1.SecretDoc) (kukeonv1.DeleteSecretResult, error) {
+					return kukeonv1.DeleteSecretResult{}, errdefs.ErrSecretNotFound
+				},
+			},
+			wantErr: "secret not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := secret.NewSecretCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, secret.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantScope != (v1beta1.SecretMetadata{}) && tt.fake.gotDoc.Metadata != tt.wantScope {
+				t.Errorf("scope passed = %+v, want %+v", tt.fake.gotDoc.Metadata, tt.wantScope)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+// TestDeleteSecret_HelpDocumentsUnsafeWindow confirms the verb's long help
+// names the temporary unconditional-delete window the AC of issue #622 calls
+// out, so the operator sees the phase-3c caveat.
+func TestDeleteSecret_HelpDocumentsUnsafeWindow(t *testing.T) {
+	cmd := secret.NewSecretCmd()
+	if !strings.Contains(cmd.Long, "phase 3c") {
+		t.Errorf("delete secret long help does not document the phase-3c unsafe-delete window\nGot:\n%s", cmd.Long)
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	deleteSecretFn func(doc v1beta1.SecretDoc) (kukeonv1.DeleteSecretResult, error)
+	gotDoc         v1beta1.SecretDoc
+}
+
+func (f *fakeClient) DeleteSecret(_ context.Context, doc v1beta1.SecretDoc) (kukeonv1.DeleteSecretResult, error) {
+	f.gotDoc = doc
+	if f.deleteSecretFn == nil {
+		return kukeonv1.DeleteSecretResult{}, errors.New("unexpected DeleteSecret call")
+	}
+	return f.deleteSecretFn(doc)
+}

--- a/cmd/kuke/get/get.go
+++ b/cmd/kuke/get/get.go
@@ -22,9 +22,10 @@ import (
 	cellcmd "github.com/eminwux/kukeon/cmd/kuke/get/cell"
 	containercmd "github.com/eminwux/kukeon/cmd/kuke/get/container"
 	realmcmd "github.com/eminwux/kukeon/cmd/kuke/get/realm"
-	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	secretcmd "github.com/eminwux/kukeon/cmd/kuke/get/secret"
 	spacecmd "github.com/eminwux/kukeon/cmd/kuke/get/space"
 	stackcmd "github.com/eminwux/kukeon/cmd/kuke/get/stack"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/spf13/cobra"
 )
 
@@ -35,7 +36,7 @@ func NewGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "get [name]",
 		Aliases: []string{"g"},
-		Short:   "Get or list Kukeon resources (realm, space, stack, cell, container)",
+		Short:   "Get or list Kukeon resources (realm, space, stack, cell, container, secret)",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
@@ -57,6 +58,7 @@ func NewGetCmd() *cobra.Command {
 		stackcmd.NewStackCmd(),
 		cellcmd.NewCellCmd(),
 		containercmd.NewContainerCmd(),
+		secretcmd.NewSecretCmd(),
 	)
 
 	return cmd
@@ -64,7 +66,7 @@ func NewGetCmd() *cobra.Command {
 
 // completeGetSubcommands provides shell completion for get subcommand names.
 func completeGetSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container"}
+	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/get/get_test.go
+++ b/cmd/kuke/get/get_test.go
@@ -41,7 +41,7 @@ func TestNewGetCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Get or list Kukeon resources (realm, space, stack, cell, container)"
+				expected := "Get or list Kukeon resources (realm, space, stack, cell, container, secret)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -103,7 +103,7 @@ func TestNewGetCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container"}
+	expected := []string{"realm", "space", "stack", "cell", "container", "secret"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}

--- a/cmd/kuke/get/secret/secret.go
+++ b/cmd/kuke/get/secret/secret.go
@@ -1,0 +1,197 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewSecretCmd builds `kuke get secret(s)` (issue #622). Secrets are
+// metadata-only here: a Secret's bytes are never echoed by get — only its
+// scope coordinates and name. With a name it shows one secret's metadata;
+// without one it lists every secret bound to the filter scope or any scope
+// nested within it (subtree-filter semantics, matching `kuke get cells`).
+func NewSecretCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "secret [name]",
+		Aliases:       []string{"secrets", "sec"},
+		Short:         "Get or list kind: Secret metadata (spec.data is never echoed)",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			outputFormat, err := shared.ParseOutputFormat(cmd)
+			if err != nil {
+				return err
+			}
+
+			// List filters: an unset flag means "no filter" (ExplicitFlag),
+			// so `kuke get secrets` with no flags lists the whole subtree.
+			realm := shared.ExplicitFlag(cmd, "realm", config.KUKE_GET_SECRET_REALM.ViperKey)
+			space := shared.ExplicitFlag(cmd, "space", config.KUKE_GET_SECRET_SPACE.ViperKey)
+			stack := shared.ExplicitFlag(cmd, "stack", config.KUKE_GET_SECRET_STACK.ViperKey)
+			cell := shared.ExplicitFlag(cmd, "cell", config.KUKE_GET_SECRET_CELL.ViperKey)
+
+			var name string
+			if len(args) > 0 {
+				name = strings.TrimSpace(args[0])
+			} else {
+				name = strings.TrimSpace(viper.GetString(config.KUKE_GET_SECRET_NAME.ViperKey))
+			}
+
+			if name != "" {
+				// A single secret is identified by its name plus its exact
+				// binding scope. Default the realm to the operator's current
+				// realm; deeper coordinates stay unset unless provided.
+				if realm == "" {
+					realm = strings.TrimSpace(config.KUKE_GET_SECRET_REALM.ValueOrDefault())
+				}
+				if realm == "" {
+					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+				}
+				doc := v1beta1.SecretDoc{
+					APIVersion: v1beta1.APIVersionV1Beta1,
+					Kind:       v1beta1.KindSecret,
+					Metadata: v1beta1.SecretMetadata{
+						Name:  name,
+						Realm: realm,
+						Space: space,
+						Stack: stack,
+						Cell:  cell,
+					},
+				}
+				result, getErr := client.GetSecret(cmd.Context(), doc)
+				if getErr != nil {
+					if errors.Is(getErr, errdefs.ErrSecretNotFound) {
+						return fmt.Errorf("secret %q not found", name)
+					}
+					return getErr
+				}
+				if !result.MetadataExists {
+					return fmt.Errorf("secret %q not found", name)
+				}
+				return printSecret(&result.Secret, outputFormat)
+			}
+
+			secrets, err := client.ListSecrets(cmd.Context(), realm, space, stack, cell)
+			if err != nil {
+				return err
+			}
+			return printSecrets(cmd, secrets, outputFormat)
+		},
+	}
+
+	cmd.Flags().String("realm", "", "Filter secrets by realm name")
+	_ = viper.BindPFlag(config.KUKE_GET_SECRET_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Filter secrets by space name")
+	_ = viper.BindPFlag(config.KUKE_GET_SECRET_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Filter secrets by stack name")
+	_ = viper.BindPFlag(config.KUKE_GET_SECRET_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+	cmd.Flags().String("cell", "", "Filter secrets by cell name")
+	_ = viper.BindPFlag(config.KUKE_GET_SECRET_CELL.ViperKey, cmd.Flags().Lookup("cell"))
+	cmd.Flags().
+		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
+	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+
+	cmd.ValidArgsFunction = config.CompleteSecretNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("cell", config.CompleteCellNames)
+	_ = cmd.RegisterFlagCompletionFunc("output", config.CompleteOutputFormat)
+	_ = cmd.RegisterFlagCompletionFunc("o", config.CompleteOutputFormat)
+
+	return cmd
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.ClientFromCmd(cmd)
+}
+
+func printSecret(secret *v1beta1.SecretDoc, format shared.OutputFormat) error {
+	switch format {
+	case shared.OutputFormatJSON:
+		return shared.PrintJSON(secret)
+	case shared.OutputFormatYAML, shared.OutputFormatTable:
+		return shared.PrintYAML(secret)
+	default:
+		return shared.PrintYAML(secret)
+	}
+}
+
+func printSecrets(cmd *cobra.Command, secrets []v1beta1.SecretDoc, format shared.OutputFormat) error {
+	switch format {
+	case shared.OutputFormatYAML:
+		return shared.PrintYAML(secrets)
+	case shared.OutputFormatJSON:
+		return shared.PrintJSON(secrets)
+	case shared.OutputFormatTable:
+		if len(secrets) == 0 {
+			cmd.Println("No secrets found.")
+			return nil
+		}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK", "CELL"}
+		rows := make([][]string, 0, len(secrets))
+		for i := range secrets {
+			s := &secrets[i]
+			rows = append(rows, []string{
+				s.Metadata.Name,
+				dashIfEmpty(s.Metadata.Realm),
+				dashIfEmpty(s.Metadata.Space),
+				dashIfEmpty(s.Metadata.Stack),
+				dashIfEmpty(s.Metadata.Cell),
+			})
+		}
+		shared.PrintTable(cmd, headers, rows)
+		return nil
+	default:
+		return shared.PrintYAML(secrets)
+	}
+}
+
+// dashIfEmpty renders an unset scope coordinate as "-" so the table column
+// never collapses to an unaligned blank cell.
+func dashIfEmpty(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/kuke/get/secret/secret_test.go
+++ b/cmd/kuke/get/secret/secret_test.go
@@ -1,0 +1,212 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secret_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	secret "github.com/eminwux/kukeon/cmd/kuke/get/secret"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestNewSecretCmd(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name            string
+		args            []string
+		setup           func(t *testing.T, cmd *cobra.Command)
+		fake            *fakeClient
+		wantErr         string
+		wantOutput      string
+		wantNotInOutput []string
+	}{
+		{
+			// Single-resource get renders YAML to os.Stdout (not the command
+			// buffer), so this case only asserts the happy path returns no
+			// error; the metadata-only / never-echo guarantee is pinned at the
+			// controller and runner layers.
+			name: "get single secret metadata",
+			args: []string{"tok"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+				_ = cmd.Flags().Set("space", "s1")
+			},
+			fake: &fakeClient{
+				getSecretFn: func(doc v1beta1.SecretDoc) (kukeonv1.GetSecretResult, error) {
+					return kukeonv1.GetSecretResult{
+						Secret:         v1beta1.SecretDoc{Metadata: doc.Metadata},
+						MetadataExists: true,
+					}, nil
+				},
+			},
+		},
+		{
+			name: "get not found surfaces friendly error",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				getSecretFn: func(_ v1beta1.SecretDoc) (kukeonv1.GetSecretResult, error) {
+					return kukeonv1.GetSecretResult{}, errdefs.ErrSecretNotFound
+				},
+			},
+			wantErr: `secret "missing" not found`,
+		},
+		{
+			name: "get not found via MetadataExists=false",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				getSecretFn: func(_ v1beta1.SecretDoc) (kukeonv1.GetSecretResult, error) {
+					return kukeonv1.GetSecretResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: `secret "missing" not found`,
+		},
+		{
+			name: "list empty",
+			fake: &fakeClient{
+				listSecretsFn: func(_, _, _, _ string) ([]v1beta1.SecretDoc, error) {
+					return nil, nil
+				},
+			},
+			wantOutput: "No secrets found.",
+		},
+		{
+			name: "list table renders scope columns",
+			fake: &fakeClient{
+				listSecretsFn: func(_, _, _, _ string) ([]v1beta1.SecretDoc, error) {
+					return []v1beta1.SecretDoc{
+						{Metadata: v1beta1.SecretMetadata{Name: "realm-tok", Realm: "default"}},
+						{
+							Metadata: v1beta1.SecretMetadata{
+								Name:  "cell-tok",
+								Realm: "default",
+								Space: "s",
+								Stack: "st",
+								Cell:  "c",
+							},
+						},
+					}, nil
+				},
+			},
+			wantOutput:      "realm-tok",
+			wantNotInOutput: []string{"data:"},
+		},
+		{
+			name: "list passes filter scope through",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "default")
+				_ = cmd.Flags().Set("space", "team-a")
+			},
+			fake: &fakeClient{
+				listSecretsFn: func(realm, space, _, _ string) ([]v1beta1.SecretDoc, error) {
+					if realm != "default" || space != "team-a" {
+						return nil, errors.New("unexpected filter scope")
+					}
+					return []v1beta1.SecretDoc{
+						{Metadata: v1beta1.SecretMetadata{Name: "space-tok", Realm: realm, Space: space}},
+					}, nil
+				},
+			},
+			wantOutput: "space-tok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := secret.NewSecretCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, secret.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+			for _, banned := range tt.wantNotInOutput {
+				if strings.Contains(buf.String(), banned) {
+					t.Errorf("output unexpectedly contains %q\nGot:\n%s", banned, buf.String())
+				}
+			}
+		})
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getSecretFn   func(doc v1beta1.SecretDoc) (kukeonv1.GetSecretResult, error)
+	listSecretsFn func(realm, space, stack, cell string) ([]v1beta1.SecretDoc, error)
+}
+
+func (f *fakeClient) GetSecret(_ context.Context, doc v1beta1.SecretDoc) (kukeonv1.GetSecretResult, error) {
+	if f.getSecretFn == nil {
+		return kukeonv1.GetSecretResult{}, errors.New("unexpected GetSecret call")
+	}
+	return f.getSecretFn(doc)
+}
+
+func (f *fakeClient) ListSecrets(
+	_ context.Context,
+	realm, space, stack, cell string,
+) ([]v1beta1.SecretDoc, error) {
+	if f.listSecretsFn == nil {
+		return nil, errors.New("unexpected ListSecrets call")
+	}
+	return f.listSecretsFn(realm, space, stack, cell)
+}

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -166,6 +166,37 @@ func NormalizeSecret(req ext.SecretDoc) (intmodel.Secret, ext.Version, error) {
 	return internal, version, nil
 }
 
+// ConvertSecretToExternal builds a metadata-only external SecretDoc from the
+// internal hub type (issue #622). Spec.Data is deliberately left zero: the
+// get/list verbs never echo the secret material, preserving the
+// never-round-tripped contract from #619.
+func ConvertSecretToExternal(in intmodel.Secret) ext.SecretDoc {
+	return ext.SecretDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindSecret,
+		Metadata: ext.SecretMetadata{
+			Name:  in.Metadata.Name,
+			Realm: in.Metadata.Realm,
+			Space: in.Metadata.Space,
+			Stack: in.Metadata.Stack,
+			Cell:  in.Metadata.Cell,
+		},
+	}
+}
+
+// ConvertSecretListToExternal maps a slice of internal Secrets to metadata-only
+// external SecretDocs (issue #622).
+func ConvertSecretListToExternal(in []intmodel.Secret) []ext.SecretDoc {
+	if in == nil {
+		return nil
+	}
+	out := make([]ext.SecretDoc, len(in))
+	for i := range in {
+		out[i] = ConvertSecretToExternal(in[i])
+	}
+	return out
+}
+
 // ConvertSpaceDocToInternal converts an external SpaceDoc to the internal hub type.
 func ConvertSpaceDocToInternal(in ext.SpaceDoc) (intmodel.Space, error) {
 	switch in.APIVersion {

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -327,6 +327,21 @@ func (c *Client) GetContainer(_ context.Context, doc v1beta1.ContainerDoc) (kuke
 	}, nil
 }
 
+func (c *Client) GetSecret(_ context.Context, doc v1beta1.SecretDoc) (kukeonv1.GetSecretResult, error) {
+	internal, _, err := apischeme.NormalizeSecret(doc)
+	if err != nil {
+		return kukeonv1.GetSecretResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.GetSecret(internal)
+	if err != nil {
+		return kukeonv1.GetSecretResult{}, err
+	}
+	return kukeonv1.GetSecretResult{
+		Secret:         apischeme.ConvertSecretToExternal(res.Secret),
+		MetadataExists: res.MetadataExists,
+	}, nil
+}
+
 // ---- List ----
 
 func (c *Client) ListRealms(_ context.Context) ([]v1beta1.RealmDoc, error) {
@@ -390,6 +405,17 @@ func (c *Client) ListContainers(
 		return nil, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
 	}
 	return derefDocs(ext), nil
+}
+
+func (c *Client) ListSecrets(
+	_ context.Context,
+	realmName, spaceName, stackName, cellName string,
+) ([]v1beta1.SecretDoc, error) {
+	secrets, err := c.ctrl.ListSecrets(realmName, spaceName, stackName, cellName)
+	if err != nil {
+		return nil, err
+	}
+	return apischeme.ConvertSecretListToExternal(secrets), nil
 }
 
 // derefDocs converts a []*T returned by fs.Convert* helpers into the
@@ -627,6 +653,21 @@ func (c *Client) DeleteContainer(_ context.Context, doc v1beta1.ContainerDoc) (k
 		CellMetadataExists: res.CellMetadataExists,
 		ContainerExists:    res.ContainerExists,
 		Deleted:            res.Deleted,
+	}, nil
+}
+
+func (c *Client) DeleteSecret(_ context.Context, doc v1beta1.SecretDoc) (kukeonv1.DeleteSecretResult, error) {
+	internal, _, err := apischeme.NormalizeSecret(doc)
+	if err != nil {
+		return kukeonv1.DeleteSecretResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.DeleteSecret(internal)
+	if err != nil {
+		return kukeonv1.DeleteSecretResult{}, err
+	}
+	return kukeonv1.DeleteSecretResult{
+		Secret:  apischeme.ConvertSecretToExternal(res.Secret),
+		Deleted: res.Deleted,
 	}, nil
 }
 

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -60,7 +60,10 @@ type fakeRunner struct {
 	DeleteStackFn func(stack intmodel.Stack) error
 
 	// Secret methods
-	WriteSecretFn func(secret intmodel.Secret) (bool, error)
+	WriteSecretFn  func(secret intmodel.Secret) (bool, error)
+	GetSecretFn    func(secret intmodel.Secret) (intmodel.Secret, error)
+	ListSecretsFn  func(realmName, spaceName, stackName, cellName string) ([]intmodel.Secret, error)
+	DeleteSecretFn func(secret intmodel.Secret) error
 
 	// Cell methods
 	GetCellFn                 func(cell intmodel.Cell) (intmodel.Cell, error)
@@ -264,6 +267,27 @@ func (f *fakeRunner) WriteSecret(secret intmodel.Secret) (bool, error) {
 		return f.WriteSecretFn(secret)
 	}
 	return false, errors.New("unexpected call to WriteSecret")
+}
+
+func (f *fakeRunner) GetSecret(secret intmodel.Secret) (intmodel.Secret, error) {
+	if f.GetSecretFn != nil {
+		return f.GetSecretFn(secret)
+	}
+	return intmodel.Secret{}, errors.New("unexpected call to GetSecret")
+}
+
+func (f *fakeRunner) ListSecrets(realmName, spaceName, stackName, cellName string) ([]intmodel.Secret, error) {
+	if f.ListSecretsFn != nil {
+		return f.ListSecretsFn(realmName, spaceName, stackName, cellName)
+	}
+	return nil, errors.New("unexpected call to ListSecrets")
+}
+
+func (f *fakeRunner) DeleteSecret(secret intmodel.Secret) error {
+	if f.DeleteSecretFn != nil {
+		return f.DeleteSecretFn(secret)
+	}
+	return errors.New("unexpected call to DeleteSecret")
 }
 
 // Cell methods

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -103,6 +103,20 @@ type Runner interface {
 	// the scope itself.
 	WriteSecret(secret intmodel.Secret) (created bool, err error)
 
+	// GetSecret reports the metadata-only view of a single named, scoped
+	// `kind: Secret` and whether it exists on disk (issue #622). The bytes
+	// are never read — a stat confirms existence. Returns
+	// errdefs.ErrSecretNotFound when absent.
+	GetSecret(secret intmodel.Secret) (intmodel.Secret, error)
+	// ListSecrets enumerates the metadata of every Secret bound to the
+	// filter scope or any scope nested within it (issue #622). An empty
+	// realmName lists across all realms; the filter is a subtree prefix.
+	ListSecrets(realmName, spaceName, stackName, cellName string) ([]intmodel.Secret, error)
+	// DeleteSecret removes the daemon-stored bytes file for a single named,
+	// scoped Secret (issue #622). Returns errdefs.ErrSecretNotFound when
+	// the file is absent.
+	DeleteSecret(secret intmodel.Secret) error
+
 	ExistsCgroup(doc any) (bool, error)
 
 	PurgeRealm(realm intmodel.Realm) (namespaceRemoved bool, err error)

--- a/internal/controller/runner/secret.go
+++ b/internal/controller/runner/secret.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -82,6 +85,210 @@ func (r *Exec) WriteSecret(secret intmodel.Secret) (bool, error) {
 		"cell", md.Cell,
 	)
 	return created, nil
+}
+
+// GetSecret reports whether a single named, scoped Secret exists on disk and
+// returns its metadata-only view (issue #622). The bytes are never read: a
+// stat is sufficient to confirm existence, and echoing the material would
+// violate the never-round-tripped contract from #619. Returns
+// errdefs.ErrSecretNotFound when the file is absent.
+func (r *Exec) GetSecret(secret intmodel.Secret) (intmodel.Secret, error) {
+	md := secret.Metadata
+	path := fs.SecretPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Cell, md.Name)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return intmodel.Secret{}, errdefs.ErrSecretNotFound
+		}
+		return intmodel.Secret{}, fmt.Errorf("%w: %w", errdefs.ErrGetSecret, err)
+	}
+	if info.IsDir() {
+		// A directory at the secret path is not a secret.
+		return intmodel.Secret{}, errdefs.ErrSecretNotFound
+	}
+
+	// Metadata-only: scope + name come from the path, never the bytes.
+	return intmodel.Secret{Metadata: md}, nil
+}
+
+// ListSecrets enumerates the metadata of every Secret bound to the scope
+// identified by the filter coordinates, plus every Secret bound to a deeper
+// scope nested within it (issue #622). The filter is a prefix: an empty
+// realmName lists across all realms; a set realmName with an empty spaceName
+// lists realm-scoped secrets and everything under that realm; and so on. This
+// mirrors the subtree-filter semantics of `kuke get cells --realm <r>`. The
+// bytes are never read — only the scope coordinates (from the path) and the
+// secret name (the file basename) are returned.
+func (r *Exec) ListSecrets(realmName, spaceName, stackName, cellName string) ([]intmodel.Secret, error) {
+	realmDirs, err := r.resolveRealmDirs(realmName)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errdefs.ErrListSecrets, err)
+	}
+
+	var out []intmodel.Secret
+	for _, realmDir := range realmDirs {
+		realm := filepath.Base(realmDir)
+		if walkErr := r.collectSecretSubtree(&out, realm, spaceName, stackName, cellName); walkErr != nil {
+			return nil, fmt.Errorf("%w: %w", errdefs.ErrListSecrets, walkErr)
+		}
+	}
+	return out, nil
+}
+
+// collectSecretSubtree appends the metadata of every Secret bound to scope
+// (realm, space, stack, cell) — where a trailing coordinate that is "" marks
+// the filter floor — and every Secret in scopes nested within it. The rule:
+// collect a level's own secrets only when the next-deeper filter coordinate is
+// empty (so a set deeper coordinate excludes shallower scopes), and descend
+// into a child only when it matches a set filter coordinate or the filter is
+// empty at that level (collect-all). The walk is bounded at cell depth, so the
+// per-container subdirectories under a cell are never mistaken for scopes.
+func (r *Exec) collectSecretSubtree(out *[]intmodel.Secret, realm, space, stack, cell string) error {
+	// Realm level: collect realm-scoped secrets only when no deeper coordinate
+	// is requested (space empty ⇒ realm is the floor or we're collecting the
+	// whole realm subtree).
+	if space == "" {
+		if err := r.collectSecretsInScope(out, realm, "", "", ""); err != nil {
+			return err
+		}
+	}
+
+	spaces, err := r.childScopeNames(fs.RealmMetadataDir(r.opts.RunPath, realm), space)
+	if err != nil {
+		return err
+	}
+	for _, sp := range spaces {
+		if stack == "" {
+			if err = r.collectSecretsInScope(out, realm, sp, "", ""); err != nil {
+				return err
+			}
+		}
+
+		stacks, stErr := r.childScopeNames(fs.SpaceMetadataDir(r.opts.RunPath, realm, sp), stack)
+		if stErr != nil {
+			return stErr
+		}
+		for _, st := range stacks {
+			if cell == "" {
+				if err = r.collectSecretsInScope(out, realm, sp, st, ""); err != nil {
+					return err
+				}
+			}
+
+			cells, cErr := r.childScopeNames(fs.StackMetadataDir(r.opts.RunPath, realm, sp, st), cell)
+			if cErr != nil {
+				return cErr
+			}
+			for _, ce := range cells {
+				if err = r.collectSecretsInScope(out, realm, sp, st, ce); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// childScopeNames returns the child-resource subdirectory names directly under
+// dir, excluding the reserved secrets/ subdirectory. When want is non-empty it
+// is treated as a filter: only that child is returned, and only if it exists.
+// A missing dir yields no children (graceful, matching the list verbs' "no
+// filter match ⇒ empty" contract).
+func (r *Exec) childScopeNames(dir, want string) ([]string, error) {
+	if strings.TrimSpace(want) != "" {
+		child := filepath.Join(dir, want)
+		info, err := os.Stat(child)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to stat scope dir %q: %w", child, err)
+		}
+		if !info.IsDir() {
+			return nil, nil
+		}
+		return []string{want}, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read scope dir %q: %w", dir, err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if entry.Name() == consts.KukeonSecretsSubdir {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
+// collectSecretsInScope appends the metadata of every Secret stored directly at
+// the given scope (realm, space, stack, cell). Regular secret files are bytes
+// files; the in-flight ".secret-*.tmp" temp files atomicWriteSecret creates are
+// skipped so a concurrent apply never surfaces a half-written name.
+func (r *Exec) collectSecretsInScope(out *[]intmodel.Secret, realm, space, stack, cell string) error {
+	dir := fs.SecretsDir(r.opts.RunPath, realm, space, stack, cell)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read secrets dir %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".secret-") && strings.HasSuffix(name, ".tmp") {
+			continue
+		}
+		*out = append(*out, intmodel.Secret{
+			Metadata: intmodel.SecretMetadata{
+				Name:  name,
+				Realm: realm,
+				Space: space,
+				Stack: stack,
+				Cell:  cell,
+			},
+		})
+	}
+	return nil
+}
+
+// DeleteSecret removes the daemon-stored bytes file for a single named, scoped
+// Secret (issue #622). Returns errdefs.ErrSecretNotFound when the file is
+// absent so the caller can report a clear "not found" instead of a silent
+// success. The bytes are never read before removal.
+func (r *Exec) DeleteSecret(secret intmodel.Secret) error {
+	md := secret.Metadata
+	path := fs.SecretPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Cell, md.Name)
+
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errdefs.ErrSecretNotFound
+		}
+		return fmt.Errorf("%w: %w", errdefs.ErrDeleteSecret, err)
+	}
+
+	// Log the scope + name only — never the bytes.
+	r.logger.InfoContext(r.ctx, "secret deleted",
+		"name", md.Name,
+		"realm", md.Realm,
+		"space", md.Space,
+		"stack", md.Stack,
+		"cell", md.Cell,
+	)
+	return nil
 }
 
 // atomicWriteSecret writes data to path via a temp file in the same directory

--- a/internal/controller/runner/secret_test.go
+++ b/internal/controller/runner/secret_test.go
@@ -20,10 +20,13 @@
 package runner
 
 import (
+	"errors"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
 )
@@ -129,5 +132,200 @@ func TestWriteSecret_DeeperScopeNestsUnderScopeDir(t *testing.T) {
 	realmScoped := fs.SecretPath(runPath, "default", "", "", "", "db-pw")
 	if _, err := os.Stat(realmScoped); !os.IsNotExist(err) {
 		t.Errorf("secret leaked into realm scope at %s (err=%v)", realmScoped, err)
+	}
+}
+
+// TestGetSecret_MetadataOnly confirms GetSecret returns the requested secret's
+// scope coordinates without ever reading the bytes, and reports
+// ErrSecretNotFound for an absent name (issue #622).
+func TestGetSecret_MetadataOnly(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	stored := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default", Space: "team-a"},
+		Spec:     intmodel.SecretSpec{Data: "do-not-echo"},
+	}
+	if _, err := r.WriteSecret(stored); err != nil {
+		t.Fatalf("WriteSecret() error = %v", err)
+	}
+
+	got, err := r.GetSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("GetSecret() error = %v", err)
+	}
+	if got.Metadata.Name != "tok" || got.Metadata.Realm != "default" || got.Metadata.Space != "team-a" {
+		t.Errorf("metadata = %+v, want name=tok realm=default space=team-a", got.Metadata)
+	}
+	if got.Spec.Data != "" {
+		t.Errorf("Spec.Data = %q, want empty (bytes must never be echoed)", got.Spec.Data)
+	}
+}
+
+func TestGetSecret_NotFound(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	_, err := r.GetSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "ghost", Realm: "default"},
+	})
+	if !errors.Is(err, errdefs.ErrSecretNotFound) {
+		t.Errorf("GetSecret() error = %v, want ErrSecretNotFound", err)
+	}
+}
+
+// TestListSecrets_SubtreeFilter pins the subtree-filter list semantics: an
+// empty filter lists every scope, a set realm bounds the walk to that realm
+// (and everything nested under it), and a set deeper coordinate excludes
+// shallower scopes. The bytes are never read; only scope + name surface.
+func TestListSecrets_SubtreeFilter(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seed := []intmodel.Secret{
+		{Metadata: intmodel.SecretMetadata{Name: "realm-tok", Realm: "default"}},
+		{Metadata: intmodel.SecretMetadata{Name: "space-tok", Realm: "default", Space: "team-a"}},
+		{
+			Metadata: intmodel.SecretMetadata{
+				Name:  "cell-tok",
+				Realm: "default",
+				Space: "team-a",
+				Stack: "web",
+				Cell:  "api",
+			},
+		},
+		{Metadata: intmodel.SecretMetadata{Name: "other-realm", Realm: "kuke-system"}},
+	}
+	for _, s := range seed {
+		s.Spec = intmodel.SecretSpec{Data: "x"}
+		if _, err := r.WriteSecret(s); err != nil {
+			t.Fatalf("WriteSecret(%s) error = %v", s.Metadata.Name, err)
+		}
+	}
+
+	names := func(secrets []intmodel.Secret) []string {
+		got := make([]string, 0, len(secrets))
+		for _, s := range secrets {
+			got = append(got, s.Metadata.Name)
+		}
+		sort.Strings(got)
+		return got
+	}
+	eq := func(got, want []string) bool {
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	t.Run("no_filter_lists_all", func(t *testing.T) {
+		out, err := r.ListSecrets("", "", "", "")
+		if err != nil {
+			t.Fatalf("ListSecrets() error = %v", err)
+		}
+		want := []string{"cell-tok", "other-realm", "realm-tok", "space-tok"}
+		if got := names(out); !eq(got, want) {
+			t.Errorf("names = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("realm_filter_bounds_subtree", func(t *testing.T) {
+		out, err := r.ListSecrets("default", "", "", "")
+		if err != nil {
+			t.Fatalf("ListSecrets() error = %v", err)
+		}
+		want := []string{"cell-tok", "realm-tok", "space-tok"}
+		if got := names(out); !eq(got, want) {
+			t.Errorf("names = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("space_filter_excludes_realm_scope", func(t *testing.T) {
+		out, err := r.ListSecrets("default", "team-a", "", "")
+		if err != nil {
+			t.Fatalf("ListSecrets() error = %v", err)
+		}
+		want := []string{"cell-tok", "space-tok"}
+		if got := names(out); !eq(got, want) {
+			t.Errorf("names = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("verifies_bytes_never_surface", func(t *testing.T) {
+		out, err := r.ListSecrets("", "", "", "")
+		if err != nil {
+			t.Fatalf("ListSecrets() error = %v", err)
+		}
+		for _, s := range out {
+			if s.Spec.Data != "" {
+				t.Errorf("secret %q carried bytes %q, want empty", s.Metadata.Name, s.Spec.Data)
+			}
+		}
+	})
+}
+
+// TestListSecrets_SkipsTempFiles confirms an in-flight ".secret-*.tmp" temp
+// file left by a concurrent atomic write never surfaces as a secret name.
+func TestListSecrets_SkipsTempFiles(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	if _, err := r.WriteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "real", Realm: "default"},
+		Spec:     intmodel.SecretSpec{Data: "x"},
+	}); err != nil {
+		t.Fatalf("WriteSecret() error = %v", err)
+	}
+
+	dir := fs.SecretsDir(runPath, "default", "", "", "")
+	if err := os.WriteFile(dir+"/.secret-1234.tmp", []byte("partial"), 0o600); err != nil {
+		t.Fatalf("seeding temp file: %v", err)
+	}
+
+	out, err := r.ListSecrets("default", "", "", "")
+	if err != nil {
+		t.Fatalf("ListSecrets() error = %v", err)
+	}
+	if len(out) != 1 || out[0].Metadata.Name != "real" {
+		t.Errorf("ListSecrets() = %+v, want only [real]", out)
+	}
+}
+
+// TestDeleteSecret removes the bytes file and reports ErrSecretNotFound on a
+// second delete of the same name (issue #622).
+func TestDeleteSecret(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	stored := intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+		Spec:     intmodel.SecretSpec{Data: "x"},
+	}
+	if _, err := r.WriteSecret(stored); err != nil {
+		t.Fatalf("WriteSecret() error = %v", err)
+	}
+
+	if err := r.DeleteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+	}); err != nil {
+		t.Fatalf("DeleteSecret() error = %v", err)
+	}
+
+	path := fs.SecretPath(runPath, "default", "", "", "", "tok")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("secret file still present after delete (err=%v)", err)
+	}
+
+	if err := r.DeleteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+	}); !errors.Is(err, errdefs.ErrSecretNotFound) {
+		t.Errorf("second DeleteSecret() error = %v, want ErrSecretNotFound", err)
 	}
 }

--- a/internal/controller/secret.go
+++ b/internal/controller/secret.go
@@ -1,0 +1,151 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// GetSecretResult reports the metadata-only view of a single `kind: Secret`
+// (issue #622). The bytes are never carried — Secret.Spec is left zero so the
+// never-round-tripped contract from #619 holds end to end.
+type GetSecretResult struct {
+	Secret         intmodel.Secret
+	MetadataExists bool
+}
+
+// DeleteSecretResult reports the outcome of removing a single Secret's
+// daemon-stored file.
+type DeleteSecretResult struct {
+	Secret  intmodel.Secret
+	Deleted bool
+}
+
+// GetSecret retrieves the metadata-only view of one named, scoped Secret. The
+// scope coordinates are validated for completeness (a deeper coordinate
+// requires every shallower one); realm and name are mandatory. Returns a
+// result with MetadataExists=false (and no error) when the secret is absent,
+// mirroring GetRealm's "report, don't error on not-found" shape.
+func (b *Exec) GetSecret(secret intmodel.Secret) (GetSecretResult, error) {
+	var res GetSecretResult
+
+	if err := validateSecretLookup(secret.Metadata); err != nil {
+		return res, err
+	}
+
+	got, err := b.runner.GetSecret(secret)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrSecretNotFound) {
+			res.MetadataExists = false
+			return res, nil
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetSecret, err)
+	}
+
+	res.MetadataExists = true
+	res.Secret = got
+	return res, nil
+}
+
+// ListSecrets lists the metadata of every Secret bound to the filter scope or
+// any scope nested within it. An empty realm lists across all realms; the
+// filter coordinates must still be contiguous (no gap below a set level).
+func (b *Exec) ListSecrets(realmName, spaceName, stackName, cellName string) ([]intmodel.Secret, error) {
+	if err := validateSecretScopeFilter(realmName, spaceName, stackName, cellName); err != nil {
+		return nil, err
+	}
+	return b.runner.ListSecrets(
+		strings.TrimSpace(realmName),
+		strings.TrimSpace(spaceName),
+		strings.TrimSpace(stackName),
+		strings.TrimSpace(cellName),
+	)
+}
+
+// DeleteSecret removes a single named, scoped Secret's daemon-stored file.
+// Returns a "not found" error when the secret does not exist, matching the
+// DeleteRealm contract.
+//
+// NOTE: the live-reference safety gate the AC describes — refusing to delete a
+// Secret a running container still references via secretRef — is wired by the
+// separately-filed phase-3c slice that introduces the referencing path. Until
+// 3c lands, delete is unconditional; the verb's help text documents this
+// temporary unsafe-delete window.
+func (b *Exec) DeleteSecret(secret intmodel.Secret) (DeleteSecretResult, error) {
+	var res DeleteSecretResult
+
+	if err := validateSecretLookup(secret.Metadata); err != nil {
+		return res, err
+	}
+
+	if err := b.runner.DeleteSecret(secret); err != nil {
+		if errors.Is(err, errdefs.ErrSecretNotFound) {
+			return res, fmt.Errorf("secret %q not found", secret.Metadata.Name)
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrDeleteSecret, err)
+	}
+
+	res.Deleted = true
+	res.Secret = secret
+	return res, nil
+}
+
+// validateSecretLookup enforces the scope contract for a single-secret get or
+// delete: name and realm are mandatory and the scope coordinates must be
+// contiguous (a cell-scoped secret must also name its stack, space, and realm).
+func validateSecretLookup(md intmodel.SecretMetadata) error {
+	if strings.TrimSpace(md.Name) == "" {
+		return errdefs.ErrSecretNameRequired
+	}
+	if strings.TrimSpace(md.Realm) == "" {
+		return errdefs.ErrSecretRealmRequired
+	}
+	return validateSecretScopeContiguity(md.Space, md.Stack, md.Cell)
+}
+
+// validateSecretScopeFilter enforces the scope contract for a list filter:
+// realm is optional (an empty realm lists across all realms), but a set deeper
+// coordinate still requires every shallower one to be set.
+func validateSecretScopeFilter(realm, space, stack, cell string) error {
+	if strings.TrimSpace(realm) == "" &&
+		(strings.TrimSpace(space) != "" || strings.TrimSpace(stack) != "" || strings.TrimSpace(cell) != "") {
+		return fmt.Errorf("%w (scope set without realm)", errdefs.ErrSecretScopeIncomplete)
+	}
+	return validateSecretScopeContiguity(space, stack, cell)
+}
+
+// validateSecretScopeContiguity rejects a scope gap below the realm level: a
+// set cell requires a set stack, and a set stack requires a set space. Mirrors
+// the parser's apply-time validateSecretScope check (issue #619).
+func validateSecretScopeContiguity(space, stack, cell string) error {
+	space = strings.TrimSpace(space)
+	stack = strings.TrimSpace(stack)
+	cell = strings.TrimSpace(cell)
+
+	if cell != "" && stack == "" {
+		return fmt.Errorf("%w (cell set without stack)", errdefs.ErrSecretScopeIncomplete)
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrSecretScopeIncomplete)
+	}
+	return nil
+}

--- a/internal/controller/secret_test.go
+++ b/internal/controller/secret_test.go
@@ -1,0 +1,185 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestGetSecret_ReportsNotFoundWithoutError pins the GetRealm-shaped contract:
+// an absent secret yields MetadataExists=false and a nil error, never an error.
+func TestGetSecret_ReportsNotFoundWithoutError(t *testing.T) {
+	mockRunner := &fakeRunner{
+		GetSecretFn: func(_ intmodel.Secret) (intmodel.Secret, error) {
+			return intmodel.Secret{}, errdefs.ErrSecretNotFound
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.GetSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("GetSecret() error = %v, want nil", err)
+	}
+	if res.MetadataExists {
+		t.Errorf("MetadataExists = true, want false for absent secret")
+	}
+}
+
+// TestGetSecret_MetadataOnly confirms a present secret surfaces its metadata
+// and never carries the bytes back through the controller.
+func TestGetSecret_MetadataOnly(t *testing.T) {
+	mockRunner := &fakeRunner{
+		GetSecretFn: func(secret intmodel.Secret) (intmodel.Secret, error) {
+			return intmodel.Secret{Metadata: secret.Metadata}, nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.GetSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("GetSecret() error = %v", err)
+	}
+	if !res.MetadataExists {
+		t.Fatal("MetadataExists = false, want true")
+	}
+	if res.Secret.Metadata.Name != "tok" || res.Secret.Metadata.Space != "team-a" {
+		t.Errorf("metadata = %+v, want name=tok space=team-a", res.Secret.Metadata)
+	}
+	if res.Secret.Spec.Data != "" {
+		t.Errorf("Spec.Data = %q, want empty", res.Secret.Spec.Data)
+	}
+}
+
+func TestGetSecret_ValidatesScope(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+
+	tests := []struct {
+		name string
+		md   intmodel.SecretMetadata
+		want error
+	}{
+		{"missing_name", intmodel.SecretMetadata{Realm: "default"}, errdefs.ErrSecretNameRequired},
+		{"missing_realm", intmodel.SecretMetadata{Name: "tok"}, errdefs.ErrSecretRealmRequired},
+		{
+			"cell_without_stack",
+			intmodel.SecretMetadata{Name: "tok", Realm: "default", Space: "s", Cell: "c"},
+			errdefs.ErrSecretScopeIncomplete,
+		},
+		{
+			"stack_without_space",
+			intmodel.SecretMetadata{Name: "tok", Realm: "default", Stack: "st"},
+			errdefs.ErrSecretScopeIncomplete,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ctrl.GetSecret(intmodel.Secret{Metadata: tt.md}); !errors.Is(err, tt.want) {
+				t.Errorf("GetSecret() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestListSecrets_ValidatesFilter(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{
+		ListSecretsFn: func(_, _, _, _ string) ([]intmodel.Secret, error) {
+			return nil, nil
+		},
+	})
+
+	// A set space with an empty realm is an incomplete filter.
+	if _, err := ctrl.ListSecrets("", "team-a", "", ""); !errors.Is(err, errdefs.ErrSecretScopeIncomplete) {
+		t.Errorf("ListSecrets(empty realm, set space) error = %v, want ErrSecretScopeIncomplete", err)
+	}
+
+	// An empty filter is valid (lists across all realms).
+	if _, err := ctrl.ListSecrets("", "", "", ""); err != nil {
+		t.Errorf("ListSecrets(empty filter) error = %v, want nil", err)
+	}
+}
+
+func TestListSecrets_PassesScopeThrough(t *testing.T) {
+	var gotR, gotS, gotSt, gotC string
+	ctrl := setupTestController(t, &fakeRunner{
+		ListSecretsFn: func(r, s, st, c string) ([]intmodel.Secret, error) {
+			gotR, gotS, gotSt, gotC = r, s, st, c
+			return []intmodel.Secret{{Metadata: intmodel.SecretMetadata{Name: "tok", Realm: r}}}, nil
+		},
+	})
+
+	out, err := ctrl.ListSecrets("default", "team-a", "web", "api")
+	if err != nil {
+		t.Fatalf("ListSecrets() error = %v", err)
+	}
+	if gotR != "default" || gotS != "team-a" || gotSt != "web" || gotC != "api" {
+		t.Errorf("scope passed = %q/%q/%q/%q, want default/team-a/web/api", gotR, gotS, gotSt, gotC)
+	}
+	if len(out) != 1 {
+		t.Errorf("len(out) = %d, want 1", len(out))
+	}
+}
+
+func TestDeleteSecret_ReportsNotFound(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{
+		DeleteSecretFn: func(_ intmodel.Secret) error {
+			return errdefs.ErrSecretNotFound
+		},
+	})
+
+	res, err := ctrl.DeleteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "ghost", Realm: "default"},
+	})
+	if err == nil {
+		t.Fatal("DeleteSecret() error = nil, want not-found error")
+	}
+	if res.Deleted {
+		t.Errorf("Deleted = true, want false on not-found")
+	}
+}
+
+func TestDeleteSecret_Succeeds(t *testing.T) {
+	var deleted intmodel.Secret
+	ctrl := setupTestController(t, &fakeRunner{
+		DeleteSecretFn: func(s intmodel.Secret) error {
+			deleted = s
+			return nil
+		},
+	})
+
+	res, err := ctrl.DeleteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteSecret() error = %v", err)
+	}
+	if !res.Deleted {
+		t.Errorf("Deleted = false, want true")
+	}
+	if deleted.Metadata.Name != "tok" {
+		t.Errorf("runner received name %q, want tok", deleted.Metadata.Name)
+	}
+}

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -150,6 +150,13 @@ func (s *KukeonV1Service) GetContainer(args *kukeonv1.GetContainerArgs, reply *k
 	return nil
 }
 
+func (s *KukeonV1Service) GetSecret(args *kukeonv1.GetSecretArgs, reply *kukeonv1.GetSecretReply) error {
+	result, err := s.core.GetSecret(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
 // ---- List ----
 
 func (s *KukeonV1Service) ListRealms(_ *kukeonv1.ListRealmsArgs, reply *kukeonv1.ListRealmsReply) error {
@@ -183,6 +190,13 @@ func (s *KukeonV1Service) ListCells(args *kukeonv1.ListCellsArgs, reply *kukeonv
 func (s *KukeonV1Service) ListContainers(args *kukeonv1.ListContainersArgs, reply *kukeonv1.ListContainersReply) error {
 	containers, err := s.core.ListContainers(s.ctx, args.RealmName, args.SpaceName, args.StackName, args.CellName)
 	reply.Containers = containers
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
+func (s *KukeonV1Service) ListSecrets(args *kukeonv1.ListSecretsArgs, reply *kukeonv1.ListSecretsReply) error {
+	secrets, err := s.core.ListSecrets(s.ctx, args.RealmName, args.SpaceName, args.StackName, args.CellName)
+	reply.Secrets = secrets
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil
 }
@@ -297,6 +311,13 @@ func (s *KukeonV1Service) DeleteContainer(
 	reply *kukeonv1.DeleteContainerReply,
 ) error {
 	result, err := s.core.DeleteContainer(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
+func (s *KukeonV1Service) DeleteSecret(args *kukeonv1.DeleteSecretArgs, reply *kukeonv1.DeleteSecretReply) error {
+	result, err := s.core.DeleteSecret(s.ctx, args.Doc)
 	reply.Result = result
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -301,6 +301,15 @@ var (
 	ErrSecretScopeNotFound = errors.New("secret scope does not exist")
 	ErrWriteSecret         = errors.New("failed to write secret bytes")
 
+	// Secret kind read/delete-verb errors (issue #622). The bytes are never
+	// surfaced by these paths — get reports metadata only, delete removes the
+	// daemon-stored file.
+
+	ErrSecretNotFound = errors.New("secret not found")
+	ErrGetSecret      = errors.New("failed to get secret")
+	ErrListSecrets    = errors.New("failed to list secrets")
+	ErrDeleteSecret   = errors.New("failed to delete secret")
+
 	// Repo-related errors (containers[].repos[], issue #617).
 
 	ErrRepoNameRequired      = errors.New("repo name is required")

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -43,6 +43,10 @@ type Client interface {
 	GetStack(ctx context.Context, doc v1beta1.StackDoc) (GetStackResult, error)
 	GetCell(ctx context.Context, doc v1beta1.CellDoc) (GetCellResult, error)
 	GetContainer(ctx context.Context, doc v1beta1.ContainerDoc) (GetContainerResult, error)
+	// GetSecret reports the metadata-only view of a single named, scoped
+	// `kind: Secret` (issue #622). Spec.data is never echoed — the bytes do
+	// not traverse this RPC by design (#619).
+	GetSecret(ctx context.Context, doc v1beta1.SecretDoc) (GetSecretResult, error)
 
 	ListRealms(ctx context.Context) ([]v1beta1.RealmDoc, error)
 	ListSpaces(ctx context.Context, realmName string) ([]v1beta1.SpaceDoc, error)
@@ -52,6 +56,10 @@ type Client interface {
 		ctx context.Context,
 		realmName, spaceName, stackName, cellName string,
 	) ([]v1beta1.ContainerSpec, error)
+	// ListSecrets enumerates the metadata of every Secret bound to the
+	// filter scope or any scope nested within it (issue #622). An empty
+	// realmName lists across all realms. spec.data is never echoed.
+	ListSecrets(ctx context.Context, realmName, spaceName, stackName, cellName string) ([]v1beta1.SecretDoc, error)
 
 	StartCell(ctx context.Context, doc v1beta1.CellDoc) (StartCellResult, error)
 	StartContainer(ctx context.Context, doc v1beta1.ContainerDoc) (StartContainerResult, error)
@@ -75,6 +83,9 @@ type Client interface {
 	DeleteStack(ctx context.Context, doc v1beta1.StackDoc, force, cascade bool) (DeleteStackResult, error)
 	DeleteCell(ctx context.Context, doc v1beta1.CellDoc) (DeleteCellResult, error)
 	DeleteContainer(ctx context.Context, doc v1beta1.ContainerDoc) (DeleteContainerResult, error)
+	// DeleteSecret removes a single named, scoped Secret's daemon-stored
+	// file (issue #622). The live-reference safety gate ships in phase 3c.
+	DeleteSecret(ctx context.Context, doc v1beta1.SecretDoc) (DeleteSecretResult, error)
 
 	PurgeRealm(ctx context.Context, doc v1beta1.RealmDoc, force, cascade bool) (PurgeRealmResult, error)
 	PurgeSpace(ctx context.Context, doc v1beta1.SpaceDoc, force, cascade bool) (PurgeSpaceResult, error)
@@ -158,12 +169,14 @@ const (
 	MethodGetStack     = ServiceName + ".GetStack"
 	MethodGetCell      = ServiceName + ".GetCell"
 	MethodGetContainer = ServiceName + ".GetContainer"
+	MethodGetSecret    = ServiceName + ".GetSecret"
 
 	MethodListRealms     = ServiceName + ".ListRealms"
 	MethodListSpaces     = ServiceName + ".ListSpaces"
 	MethodListStacks     = ServiceName + ".ListStacks"
 	MethodListCells      = ServiceName + ".ListCells"
 	MethodListContainers = ServiceName + ".ListContainers"
+	MethodListSecrets    = ServiceName + ".ListSecrets"
 
 	MethodStartCell       = ServiceName + ".StartCell"
 	MethodStartContainer  = ServiceName + ".StartContainer"
@@ -179,6 +192,7 @@ const (
 	MethodDeleteStack     = ServiceName + ".DeleteStack"
 	MethodDeleteCell      = ServiceName + ".DeleteCell"
 	MethodDeleteContainer = ServiceName + ".DeleteContainer"
+	MethodDeleteSecret    = ServiceName + ".DeleteSecret"
 
 	MethodPurgeRealm     = ServiceName + ".PurgeRealm"
 	MethodPurgeSpace     = ServiceName + ".PurgeSpace"

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -77,6 +77,10 @@ func (FakeClient) GetContainer(context.Context, v1beta1.ContainerDoc) (GetContai
 	return GetContainerResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) GetSecret(context.Context, v1beta1.SecretDoc) (GetSecretResult, error) {
+	return GetSecretResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) ListRealms(context.Context) ([]v1beta1.RealmDoc, error) {
 	return nil, ErrUnexpectedCall
 }
@@ -94,6 +98,10 @@ func (FakeClient) ListCells(context.Context, string, string, string) ([]v1beta1.
 }
 
 func (FakeClient) ListContainers(context.Context, string, string, string, string) ([]v1beta1.ContainerSpec, error) {
+	return nil, ErrUnexpectedCall
+}
+
+func (FakeClient) ListSecrets(context.Context, string, string, string, string) ([]v1beta1.SecretDoc, error) {
 	return nil, ErrUnexpectedCall
 }
 
@@ -147,6 +155,10 @@ func (FakeClient) DeleteCell(context.Context, v1beta1.CellDoc) (DeleteCellResult
 
 func (FakeClient) DeleteContainer(context.Context, v1beta1.ContainerDoc) (DeleteContainerResult, error) {
 	return DeleteContainerResult{}, ErrUnexpectedCall
+}
+
+func (FakeClient) DeleteSecret(context.Context, v1beta1.SecretDoc) (DeleteSecretResult, error) {
+	return DeleteSecretResult{}, ErrUnexpectedCall
 }
 
 func (FakeClient) PurgeRealm(context.Context, v1beta1.RealmDoc, bool, bool) (PurgeRealmResult, error) {

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -263,6 +263,19 @@ func (c *UnixClient) GetContainer(ctx context.Context, doc v1beta1.ContainerDoc)
 	return reply.Result, nil
 }
 
+// GetSecret implements Client.
+func (c *UnixClient) GetSecret(ctx context.Context, doc v1beta1.SecretDoc) (GetSecretResult, error) {
+	args := &GetSecretArgs{Doc: doc}
+	reply := &GetSecretReply{}
+	if err := c.call(ctx, MethodGetSecret, args, reply); err != nil {
+		return GetSecretResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // ListRealms implements Client.
 func (c *UnixClient) ListRealms(ctx context.Context) ([]v1beta1.RealmDoc, error) {
 	args := &ListRealmsArgs{}
@@ -329,6 +342,22 @@ func (c *UnixClient) ListContainers(
 		return reply.Containers, FromAPIError(reply.Err)
 	}
 	return reply.Containers, nil
+}
+
+// ListSecrets implements Client.
+func (c *UnixClient) ListSecrets(
+	ctx context.Context,
+	realmName, spaceName, stackName, cellName string,
+) ([]v1beta1.SecretDoc, error) {
+	args := &ListSecretsArgs{RealmName: realmName, SpaceName: spaceName, StackName: stackName, CellName: cellName}
+	reply := &ListSecretsReply{}
+	if err := c.call(ctx, MethodListSecrets, args, reply); err != nil {
+		return nil, err
+	}
+	if reply.Err != nil {
+		return reply.Secrets, FromAPIError(reply.Err)
+	}
+	return reply.Secrets, nil
 }
 
 // StartCell implements Client.
@@ -511,6 +540,19 @@ func (c *UnixClient) DeleteContainer(ctx context.Context, doc v1beta1.ContainerD
 	reply := &DeleteContainerReply{}
 	if err := c.call(ctx, MethodDeleteContainer, args, reply); err != nil {
 		return DeleteContainerResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
+// DeleteSecret implements Client.
+func (c *UnixClient) DeleteSecret(ctx context.Context, doc v1beta1.SecretDoc) (DeleteSecretResult, error) {
+	args := &DeleteSecretArgs{Doc: doc}
+	reply := &DeleteSecretReply{}
+	if err := c.call(ctx, MethodDeleteSecret, args, reply); err != nil {
+		return DeleteSecretResult{}, err
 	}
 	if reply.Err != nil {
 		return reply.Result, FromAPIError(reply.Err)

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -196,6 +196,22 @@ type GetContainerResult struct {
 	ContainerExists    bool
 }
 
+type GetSecretArgs struct {
+	Doc v1beta1.SecretDoc
+}
+
+type GetSecretReply struct {
+	Result GetSecretResult
+	Err    *APIError
+}
+
+// GetSecretResult carries the metadata-only view of a Secret. Secret.Spec.Data
+// is never populated — the bytes do not traverse this RPC (issue #619/#622).
+type GetSecretResult struct {
+	Secret         v1beta1.SecretDoc
+	MetadataExists bool
+}
+
 // ---- List ----
 
 type ListRealmsArgs struct{}
@@ -245,6 +261,19 @@ type ListContainersArgs struct {
 type ListContainersReply struct {
 	Containers []v1beta1.ContainerSpec
 	Err        *APIError
+}
+
+type ListSecretsArgs struct {
+	RealmName string
+	SpaceName string
+	StackName string
+	CellName  string
+}
+
+// ListSecretsReply carries metadata-only SecretDocs — Spec.Data is never set.
+type ListSecretsReply struct {
+	Secrets []v1beta1.SecretDoc
+	Err     *APIError
 }
 
 // ---- Lifecycle (Start/Stop/Kill) ----
@@ -410,6 +439,22 @@ type DeleteCellResult struct {
 	ContainersDeleted bool
 	CgroupDeleted     bool
 	MetadataDeleted   bool
+}
+
+type DeleteSecretArgs struct {
+	Doc v1beta1.SecretDoc
+}
+
+type DeleteSecretReply struct {
+	Result DeleteSecretResult
+	Err    *APIError
+}
+
+// DeleteSecretResult reports the removed Secret (metadata only) and whether the
+// file existed to delete.
+type DeleteSecretResult struct {
+	Secret  v1beta1.SecretDoc
+	Deleted bool
 }
 
 type DeleteContainerArgs struct {


### PR DESCRIPTION
## Summary

Phase 3b of #423 — the read and delete verbs over the daemon-stored `kind: Secret` introduced in #619 (PR #660). Until now operators could `kuke apply -f secret.yaml` to write a Secret but had no way to list, inspect, or remove one.

Adds three verb behaviors, modeled on `kuke get realms` / `kuke delete realm` per the issue's sibling-precedent note:

- `kuke get secrets [--realm/--space/--stack/--cell] [-o json]` — lists secrets with subtree-filter semantics (matching `kuke get cells`): an unset filter lists every scope; a set realm bounds the walk to that realm and everything nested under it; a set deeper coordinate excludes shallower scopes.
- `kuke get secret <name> [--realm/...] [-o json]` — shows a single secret's metadata. **`spec.data` is never echoed** — the daemon stats the file for existence and returns metadata only; the never-round-tripped contract from #619 holds end to end (output renders `spec: {}`).
- `kuke delete secret <name> [--realm/...]` — removes the daemon-stored bytes file; reports a clear "not found" when absent.

The full RPC path is wired (`kukeonv1.Client` interface → `UnixClient`/`local.Client` → controller → runner storage), with metadata-only conversion in `apischeme` so the bytes never cross the wire on a get.

### Notable implementation calls (reviewer please confirm)

- **`--scope realm=<r>` syntax reinterpreted as individual `--realm/--space/--stack/--cell` flags.** The issue's Proposal/AC wrote the scope filter as `--scope realm=<r> --scope space=<s> …`, but no `kuke` verb uses that `key=value` form — every scoped verb (`get cells`, `delete realm`, …) uses individual `--realm/--space/--stack/--cell` flags. Per CLAUDE.md §"Sanity-check AC implementation specifics", I posted a heads-up comment on #622 (https://github.com/eminwux/kukeon/issues/622#issuecomment-4513177058) naming the conflict and proceeded with the sibling-precedent reading. No behavioral difference from the AC's intent — only the surface syntax.
- **Unsafe-delete window documented in help text, per AC.** The live-container `secretRef` refusal check ships separately in phase 3c (the referencing path doesn't exist yet). Until then `kuke delete secret` removes the file unconditionally; the verb's `--help` long text carries a `WARNING:` naming the phase-3c gap. A test (`TestDeleteSecret_HelpDocumentsUnsafeWindow`) pins this.
- **Single-secret get default realm = operator's current realm** (`KUKE_GET_SECRET_REALM`, default `default`), matching the AC's "default scope is the operator's current realm". List filters use `ExplicitFlag` (unset = no filter) so bare `kuke get secrets` lists the whole subtree.
- Tab completion fell out naturally (`CompleteSecretNames` + flag completions) — wired, though the AC marks it non-mandatory.

## Test plan

- [x] `make test` — full unit suite, exit 0 (92 packages ok).
- [x] `go build ./...` and `go vet ./...` — clean.
- [x] `pre-commit run --files <changed>` — go-fmt, golangci-lint, addlicense all pass.
- [x] New unit tests: runner (`GetSecret`/`ListSecrets` subtree-filter + temp-file skip/`DeleteSecret`), controller (validation + not-found shapes), and both CLI commands (FakeClient-backed, incl. metadata-only and not-found paths).
- [x] **`make dev-init` smoke (daemon-read path touched).** Exit 0; daemon-parity guard identical for `kuke get realms` and `--no-daemon`. Functional end-to-end against the running daemon: `apply` a Secret → `get secret` and `get secret -o json` both render `spec: {}` (bytes never echoed) → `get secrets` table shows scope columns → `delete secret` removes it → subsequent `get`/`delete` return "not found" (exit 1).

Closes #622