### PR TITLE
fix: scope kukebuild's default build root per target namespace

### DIFF
--- a/cmd/kukebuild/build.go
+++ b/cmd/kukebuild/build.go
@@ -118,15 +118,23 @@ func runBuild(ctx context.Context, cfg *buildConfig, progressW io.Writer) error 
 	if _, err := os.Stat(cfg.dockerfile); err != nil {
 		return fmt.Errorf("dockerfile %q: %w", cfg.dockerfile, err)
 	}
-	if err := os.MkdirAll(cfg.root, buildStateDirMode); err != nil {
-		return fmt.Errorf("create build state dir %q: %w", cfg.root, err)
-	}
 
 	suffix, err := resolveNamespaceSuffix(cfg.kukeondConfig)
 	if err != nil {
 		return err
 	}
 	namespace := realmNamespace(cfg.realm, suffix)
+
+	// Scope the default build state root per target namespace before creating
+	// it: BuildKit's cache under --root mirrors a single containerd content
+	// store, but that store is per-namespace, so a default root shared across
+	// namespaces makes build 2 reuse build 1's cache entry and skip
+	// re-materializing the layer into namespace 2's store — the unpack then
+	// can't find the blob (issue #663).
+	cfg.root = resolveBuildRoot(cfg.root, cfg.rootExplicit, namespace)
+	if err := os.MkdirAll(cfg.root, buildStateDirMode); err != nil {
+		return fmt.Errorf("create build state dir %q: %w", cfg.root, err)
+	}
 
 	ctrl, cleanup, err := newController(ctx, cfg, namespace)
 	if err != nil {
@@ -183,6 +191,22 @@ func runBuild(ctx context.Context, cfg *buildConfig, progressW io.Writer) error 
 		return fmt.Errorf("build %q: %w", cfg.tag, waitErr)
 	}
 	return nil
+}
+
+// resolveBuildRoot returns the directory BuildKit uses for its own state for a
+// build into namespace. The default root is scoped per namespace
+// (<root>/<namespace>) so consecutive builds targeting different containerd
+// namespaces never share a single BuildKit cache: a shared cache records a
+// layer as already materialized in the first namespace's content store, and
+// the `unpack: "true"` export into the second namespace then fails to find the
+// blob in that namespace's (separate) store — issue #663. An operator-supplied
+// --root (explicit) is honored verbatim; keeping it unique per namespace is
+// then the operator's responsibility.
+func resolveBuildRoot(root string, explicit bool, namespace string) string {
+	if explicit {
+		return root
+	}
+	return filepath.Join(root, namespace)
 }
 
 // newSolveOpt builds the BuildKit SolveOpt for a Dockerfile build: the

--- a/cmd/kukebuild/build_test.go
+++ b/cmd/kukebuild/build_test.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import "testing"
+
+func TestResolveBuildRoot(t *testing.T) {
+	cases := []struct {
+		name      string
+		root      string
+		explicit  bool
+		namespace string
+		want      string
+	}{
+		{
+			name:      "default root scoped per namespace",
+			root:      defaultBuildRoot,
+			explicit:  false,
+			namespace: "default.kukeon.io",
+			want:      "/var/lib/kukebuild/default.kukeon.io",
+		},
+		{
+			name:      "default root scoped per different namespace",
+			root:      defaultBuildRoot,
+			explicit:  false,
+			namespace: "kuke-system.kukeon.io",
+			want:      "/var/lib/kukebuild/kuke-system.kukeon.io",
+		},
+		{
+			name:      "default root scoped per custom-suffix namespace",
+			root:      defaultBuildRoot,
+			explicit:  false,
+			namespace: "default.dev.kukeon.io",
+			want:      "/var/lib/kukebuild/default.dev.kukeon.io",
+		},
+		{
+			name:      "explicit root honored verbatim",
+			root:      "/tmp/freshroot",
+			explicit:  true,
+			namespace: "default.kukeon.io",
+			want:      "/tmp/freshroot",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveBuildRoot(tc.root, tc.explicit, tc.namespace); got != tc.want {
+				t.Errorf("resolveBuildRoot(%q, %v, %q) = %q, want %q",
+					tc.root, tc.explicit, tc.namespace, got, tc.want)
+			}
+		})
+	}
+}
+
+// Two consecutive default-root builds into different namespaces must resolve to
+// distinct BuildKit state roots — the isolation that prevents the cross-
+// namespace cache reuse in issue #663.
+func TestResolveBuildRootIsolatesNamespaces(t *testing.T) {
+	first := resolveBuildRoot(defaultBuildRoot, false, "default.kukeon.io")
+	second := resolveBuildRoot(defaultBuildRoot, false, "kuke-system.kukeon.io")
+	if first == second {
+		t.Errorf("default roots for distinct namespaces collide: %q == %q", first, second)
+	}
+}

--- a/cmd/kukebuild/main.go
+++ b/cmd/kukebuild/main.go
@@ -133,8 +133,15 @@ type buildConfig struct {
 	containerdSocket string
 	// root is the directory BuildKit uses for its own state (cache.db,
 	// history.db, snapshot metadata). Distinct from containerd's content
-	// store.
+	// store. When rootExplicit is false this is the base default and gets
+	// scoped per target namespace (see resolveBuildRoot); an operator-supplied
+	// --root is honored verbatim.
 	root string
+	// rootExplicit records whether the operator passed --root. The default
+	// build root is scoped per containerd namespace to keep each namespace's
+	// BuildKit cache isolated (issue #663); an explicit --root opts out of that
+	// scoping and is the operator's responsibility to keep unique per namespace.
+	rootExplicit bool
 	// kukeondConfig is the path to the kukeond.yaml from which kukebuild
 	// resolves the realm->namespace suffix (--kukeond-config). Empty falls
 	// back to /etc/kukeon/kukeond.yaml and then the hardcoded default suffix;
@@ -148,10 +155,13 @@ type buildConfig struct {
 // the docker-private containerd.
 const defaultContainerdSocket = "/run/containerd/containerd.sock"
 
-// defaultBuildRoot is where BuildKit keeps its own state (build cache,
-// history, snapshot metadata) — separate from containerd's content store, per
-// the issue notes. Under /var/lib so it survives across builds for cache
-// reuse; root-owned, matching kukebuild's root-on-host posture.
+// defaultBuildRoot is the base under which BuildKit keeps its own state (build
+// cache, history, snapshot metadata) — separate from containerd's content
+// store, per the issue notes. Under /var/lib so it survives across builds for
+// cache reuse; root-owned, matching kukebuild's root-on-host posture. The
+// effective default root is scoped per target namespace beneath this base
+// (<defaultBuildRoot>/<namespace>, see resolveBuildRoot) so each namespace's
+// cache stays isolated (issue #663).
 const defaultBuildRoot = "/var/lib/kukebuild"
 
 // defaultRealm matches the convention in cmd/kuke/image: the user-owned
@@ -189,7 +199,7 @@ func parseArgs(args []string) (*buildConfig, error) {
 		defaultContainerdSocket,
 		"host containerd socket the worker connects to",
 	)
-	root := fs.String("root", defaultBuildRoot, "directory for BuildKit's own state (cache, history, snapshots)")
+	root := fs.String("root", defaultBuildRoot, "directory for BuildKit's own state (cache, history, snapshots); the default is scoped per target namespace, an explicit value is used verbatim")
 	kukeondConfig := fs.String(
 		"kukeond-config",
 		"",
@@ -202,6 +212,13 @@ func parseArgs(args []string) (*buildConfig, error) {
 	if err := fs.Parse(args); err != nil {
 		return nil, &usageError{msg: err.Error()}
 	}
+
+	rootExplicit := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "root" {
+			rootExplicit = true
+		}
+	})
 
 	rest := fs.Args()
 	if len(rest) == 0 {
@@ -237,6 +254,7 @@ func parseArgs(args []string) (*buildConfig, error) {
 		buildArgs:        parsedArgs,
 		containerdSocket: strings.TrimSpace(*containerdSocket),
 		root:             strings.TrimSpace(*root),
+		rootExplicit:     rootExplicit,
 		kukeondConfig:    strings.TrimSpace(*kukeondConfig),
 	}, nil
 }

--- a/cmd/kukebuild/main_test.go
+++ b/cmd/kukebuild/main_test.go
@@ -45,6 +45,9 @@ func TestParseArgsDefaults(t *testing.T) {
 	if cfg.root != defaultBuildRoot {
 		t.Errorf("root = %q, want %q", cfg.root, defaultBuildRoot)
 	}
+	if cfg.rootExplicit {
+		t.Error("rootExplicit = true, want false when --root is not supplied")
+	}
 	if len(cfg.buildArgs) != 0 {
 		t.Errorf("buildArgs = %v, want empty", cfg.buildArgs)
 	}
@@ -82,6 +85,9 @@ func TestParseArgsAllFlags(t *testing.T) {
 	}
 	if cfg.root != "/tmp/state" {
 		t.Errorf("root = %q", cfg.root)
+	}
+	if !cfg.rootExplicit {
+		t.Error("rootExplicit = false, want true when --root is supplied")
 	}
 	if cfg.buildArgs["FOO"] != "bar" {
 		t.Errorf("buildArgs[FOO] = %q, want bar", cfg.buildArgs["FOO"])


### PR DESCRIPTION
## Summary
- kukebuild's default BuildKit state root (`--root`, `/var/lib/kukebuild`) was a single host path shared across every target containerd namespace. BuildKit's cache under `--root` mirrors a single content store, but containerd's content store is **per-namespace** — so a second build into a *different* namespace reuses the first build's cache entry, skips re-materializing the layer into namespace 2's store, and the `unpack: "true"` export then fails with `content digest …: not found` (issue #663). Reachable today via two different `--realm` values, or via `--kukeond-config` with a non-default `containerdNamespaceSuffix` (the #662 path).
- Fix: scope the **default** build root per target namespace — `<defaultBuildRoot>/<namespace>` (e.g. `/var/lib/kukebuild/default.kukeon.io`) — so each namespace gets an isolated cache and the unpack always finds its blob. This is the smaller of the two options the issue proposed and matches the fact that the content store the cache mirrors is itself per-namespace.
- An operator-supplied `--root` is honored **verbatim** (opt-out of scoping); keeping it unique per namespace is then the operator's responsibility. A new `rootExplicit` flag on `buildConfig` (set via `flag.FlagSet.Visit`) distinguishes the two. The pure `resolveBuildRoot(root, explicit, namespace)` helper does the join and is unit-tested directly. Namespace resolution was moved ahead of the `MkdirAll` so the scoped path is created.

### Note for the reviewer
The `kuke build` CLI shim (`cmd/kuke/build/build.go` `buildArgv`) does **not** forward `--root` at all, so every `kuke build` invocation uses kukebuild's default root — exactly the path this fix scopes. No shim change is needed; verified by reading `buildArgv` (it forwards only `--tag/--realm/--file/--kukeond-config/--build-arg`).

## Test plan
- [x] `make test` (root module + `cd cmd/kukebuild && go test ./...`) — all green.
- [x] `cd cmd/kukebuild && GOWORK=off go build ./... && go vet ./...` — clean (GOWORK=off per the repo-root `go.work` contract: the workspace union deliberately fails on the genproto split).
- [x] New unit tests: `TestResolveBuildRoot` (default-scoped / custom-suffix / explicit-verbatim cases) + `TestResolveBuildRootIsolatesNamespaces`; `rootExplicit` assertions added to `TestParseArgsDefaults` / `TestParseArgsAllFlags`.
- [x] **Functional repro, fixed path:** built `app:dev` into `default.kukeon.io` then `kuke-system.kukeon.io` back-to-back with the default root (as root, against `/run/containerd/containerd.sock`). Both `#6 unpacking … done / #6 DONE`; on-disk roots resolved to isolated `/var/lib/kukebuild/default.kukeon.io/` and `/var/lib/kukebuild/kuke-system.kukeon.io/`.
- [x] **Functional repro, bug confirmation:** same two namespaces with a *shared explicit* `--root` still reproduces `failed to extract layer …: content digest …: not found` — confirming the root cause is precisely the shared root and that explicit `--root` is honored verbatim.

Closes #663