### PR TITLE
feat(container): report repo setup status over GetSetupStatus RPC into ContainerStatus (phase 1b)

### DIFF
--- a/cmd/kuketty/main.go
+++ b/cmd/kuketty/main.go
@@ -138,12 +138,19 @@ func run(args []string) error {
 	// Pre-Serve step (issue #617): clone/fetch the container's declared repos
 	// before the workload starts. A required-repo failure returns here, so
 	// kuketty exits non-zero before sbshserver.Serve and the daemon observes
-	// the task as Failed. An empty repos[] is a no-op.
-	if err = processRepos(ctx, doc.Spec.Repos, logger); err != nil {
+	// the task as Failed (the RPC below is never reached on that path — AC #5).
+	// An empty repos[] is a no-op. The per-repo outcomes feed the GetSetupStatus
+	// verb registered on the control server below (issue #642).
+	repoStatuses, err := processRepos(ctx, doc.Spec.Repos, logger)
+	if err != nil {
 		return err
 	}
 
-	srv, err := sbshserver.New(spec, logger)
+	// Register the GetSetupStatus verb on the same control socket the daemon
+	// dials for `kuke attach`, so kukeond can pull the repo outcomes post-Serve
+	// and write ContainerStatus.Repos (issue #642). ContainerStatus is the
+	// single source of truth — there is no status file in the container.
+	srv, err := sbshserver.New(spec, logger, setupStatusOption(repoStatuses)...)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/kuketty/repos.go
+++ b/cmd/kuketty/repos.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
@@ -43,65 +44,76 @@ var errRequiredRepoFailed = errors.New("one or more required repos failed to res
 // repos[] straight from the spec (since kuketty owns the spec→TerminalSpec
 // build, issue #641) means there is no daemon-rendered sidecar doc.
 //
-// An empty repos[] is a no-op (nil) — the common case. When any repo marked
-// required fails, processRepos logs each outcome and returns
-// errRequiredRepoFailed; non-required failures are logged but do not
-// propagate. Per-repo status reporting into ContainerStatus.Repos rides the
-// GetSetupStatus RPC in phase 1b (#642) — phase 1a clones and logs only.
-func processRepos(ctx context.Context, repos []v1beta1.ContainerRepo, logger *slog.Logger) error {
+// An empty repos[] is a no-op (nil statuses) — the common case. When any repo
+// marked required fails, processRepos logs each outcome and returns
+// errRequiredRepoFailed alongside the partial statuses collected so far;
+// non-required failures are logged but do not propagate. The returned
+// statuses are the payload the GetSetupStatus RPC reports into
+// ContainerStatus.Repos (phase 1b, #642) — kukeond pulls them post-Serve. On
+// a required failure kuketty exits before Serve, so those statuses are never
+// reachable over the RPC; that path stays exit-code-driven (AC #5).
+func processRepos(ctx context.Context, repos []v1beta1.ContainerRepo, logger *slog.Logger) ([]setupstatus.Repo, error) {
 	if len(repos) == 0 {
-		return nil
+		return nil, nil
 	}
 
+	statuses := make([]setupstatus.Repo, 0, len(repos))
 	var requiredFailed bool
 	for i := range repos {
 		repo := repos[i]
-		if err := resolveRepo(ctx, repo, logger); err != nil {
+		status := resolveRepo(ctx, repo, logger)
+		statuses = append(statuses, status)
+		if status.State == setupstatus.StateFailed {
 			logger.WarnContext(ctx, "repo resolution failed",
-				"repo", repo.Name, "target", repo.Target, "required", repo.Required, "error", err)
+				"repo", repo.Name, "target", repo.Target, "required", repo.Required, "error", status.Error)
 			if repo.Required {
 				requiredFailed = true
 			}
-			continue
 		}
 	}
 
 	if requiredFailed {
-		return errRequiredRepoFailed
+		return statuses, errRequiredRepoFailed
 	}
-	return nil
+	return statuses, nil
 }
 
-// resolveRepo clones or fetches a single repo. If target/.git already exists it
-// fetches + fast-forwards (clone-if-absent idempotency: the writable rootfs
-// persists across kuke stop/start, so a restart never re-clones); otherwise it
-// clones. On success it logs the resolved HEAD commit.
-func resolveRepo(ctx context.Context, repo v1beta1.ContainerRepo, logger *slog.Logger) error {
+// resolveRepo clones or fetches a single repo and returns its resolved
+// setupstatus.Repo. If target/.git already exists it fetches + fast-forwards
+// (clone-if-absent idempotency: the writable rootfs persists across
+// kuke stop/start, so a restart never re-clones); otherwise it clones. On
+// success it logs the resolved HEAD commit and reports State cloned/fetched
+// with the commit; on failure it reports State failed with the error detail.
+func resolveRepo(ctx context.Context, repo v1beta1.ContainerRepo, logger *slog.Logger) setupstatus.Repo {
+	status := setupstatus.Repo{Name: repo.Name, Target: repo.Target}
+
 	gitDir := filepath.Join(repo.Target, ".git")
 	exists := false
 	if info, statErr := os.Stat(gitDir); statErr == nil && info.IsDir() {
 		exists = true
 	}
 
-	state := "cloned"
+	state := setupstatus.StateCloned
 	var opErr error
 	if exists {
-		state = "fetched"
+		state = setupstatus.StateFetched
 		opErr = fetchRepo(ctx, repo)
 	} else {
 		opErr = cloneRepo(ctx, repo)
 	}
 	if opErr != nil {
-		return opErr
+		status.State = setupstatus.StateFailed
+		status.Error = opErr.Error()
+		return status
 	}
 
-	commit := ""
+	status.State = state
 	if head, headErr := repoHead(ctx, repo.Target); headErr == nil {
-		commit = head
+		status.Commit = head
 	}
 	logger.InfoContext(ctx, "repo resolved",
-		"repo", repo.Name, "target", repo.Target, "state", state, "commit", commit)
-	return nil
+		"repo", repo.Name, "target", repo.Target, "state", status.State, "commit", status.Commit)
+	return status
 }
 
 // cloneRepo clones repo.URL into repo.Target, optionally pinned to repo.Branch.

--- a/cmd/kuketty/repos_test.go
+++ b/cmd/kuketty/repos_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
@@ -68,11 +69,19 @@ func makeSourceRepo(t *testing.T, fileName string) string {
 }
 
 func TestProcessRepos_EmptyIsNoOp(t *testing.T) {
-	if err := processRepos(context.Background(), nil, discardLogger()); err != nil {
+	statuses, err := processRepos(context.Background(), nil, discardLogger())
+	if err != nil {
 		t.Fatalf("nil repos should be a no-op, got %v", err)
 	}
-	if err := processRepos(context.Background(), []v1beta1.ContainerRepo{}, discardLogger()); err != nil {
+	if statuses != nil {
+		t.Fatalf("nil repos should yield nil statuses, got %v", statuses)
+	}
+	statuses, err = processRepos(context.Background(), []v1beta1.ContainerRepo{}, discardLogger())
+	if err != nil {
 		t.Fatalf("empty repos should be a no-op, got %v", err)
+	}
+	if statuses != nil {
+		t.Fatalf("empty repos should yield nil statuses, got %v", statuses)
 	}
 }
 
@@ -83,11 +92,25 @@ func TestProcessRepos_ClonesIntoTarget(t *testing.T) {
 	repos := []v1beta1.ContainerRepo{
 		{Name: "project", Target: target, Branch: "main", URL: src, Required: true},
 	}
-	if err := processRepos(context.Background(), repos, discardLogger()); err != nil {
+	statuses, err := processRepos(context.Background(), repos, discardLogger())
+	if err != nil {
 		t.Fatalf("processRepos: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(target, "README.md")); err != nil {
+	if _, err = os.Stat(filepath.Join(target, "README.md")); err != nil {
 		t.Fatalf("expected cloned file: %v", err)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("want 1 status, got %d: %v", len(statuses), statuses)
+	}
+	got := statuses[0]
+	if got.Name != "project" || got.Target != target || got.State != setupstatus.StateCloned {
+		t.Errorf("unexpected status: %+v", got)
+	}
+	if got.Commit == "" {
+		t.Errorf("cloned repo should report a resolved HEAD commit, got empty")
+	}
+	if got.Error != "" {
+		t.Errorf("successful clone should report no error, got %q", got.Error)
 	}
 }
 
@@ -99,7 +122,7 @@ func TestProcessRepos_FetchesExistingCheckout(t *testing.T) {
 	}
 
 	// First pass clones.
-	if err := processRepos(context.Background(), repos, discardLogger()); err != nil {
+	if _, err := processRepos(context.Background(), repos, discardLogger()); err != nil {
 		t.Fatalf("first processRepos (clone): %v", err)
 	}
 
@@ -110,11 +133,18 @@ func TestProcessRepos_FetchesExistingCheckout(t *testing.T) {
 	gitRun(t, src, "add", ".")
 	gitRun(t, src, "commit", "-m", "second")
 
-	if err := processRepos(context.Background(), repos, discardLogger()); err != nil {
+	statuses, err := processRepos(context.Background(), repos, discardLogger())
+	if err != nil {
 		t.Fatalf("second processRepos (fetch): %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(target, "second.txt")); err != nil {
+	if _, err = os.Stat(filepath.Join(target, "second.txt")); err != nil {
 		t.Errorf("fetch should have fast-forwarded the new commit: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].State != setupstatus.StateFetched {
+		t.Fatalf("want a single fetched status, got %+v", statuses)
+	}
+	if statuses[0].Commit == "" {
+		t.Errorf("fetched repo should report a resolved HEAD commit, got empty")
 	}
 }
 
@@ -129,9 +159,18 @@ func TestProcessRepos_RequiredFailurePropagates(t *testing.T) {
 		},
 	}
 
-	err := processRepos(context.Background(), repos, discardLogger())
+	statuses, err := processRepos(context.Background(), repos, discardLogger())
 	if !errors.Is(err, errRequiredRepoFailed) {
 		t.Fatalf("want errRequiredRepoFailed, got %v", err)
+	}
+	// Even on the required-failure path the partial statuses are returned so
+	// callers (and tests) can see the failure detail, though kuketty exits
+	// before Serve so the RPC never reports them.
+	if len(statuses) != 1 || statuses[0].State != setupstatus.StateFailed {
+		t.Fatalf("want a single failed status, got %+v", statuses)
+	}
+	if statuses[0].Error == "" {
+		t.Errorf("failed repo should carry an error detail, got empty")
 	}
 }
 
@@ -146,8 +185,12 @@ func TestProcessRepos_NonRequiredFailureDoesNotPropagate(t *testing.T) {
 		},
 	}
 
-	if err := processRepos(context.Background(), repos, discardLogger()); err != nil {
+	statuses, err := processRepos(context.Background(), repos, discardLogger())
+	if err != nil {
 		t.Fatalf("non-required failure must not propagate, got %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].State != setupstatus.StateFailed {
+		t.Fatalf("a non-required failure should still be reported as a failed status, got %+v", statuses)
 	}
 }
 
@@ -159,12 +202,22 @@ func TestProcessRepos_RequiredFailureAfterSuccessStillPropagates(t *testing.T) {
 		{Name: "bad", Target: filepath.Join(dir, "bad"), URL: filepath.Join(dir, "nope"), Required: true},
 	}
 
-	err := processRepos(context.Background(), repos, discardLogger())
+	statuses, err := processRepos(context.Background(), repos, discardLogger())
 	if !errors.Is(err, errRequiredRepoFailed) {
 		t.Fatalf("want errRequiredRepoFailed, got %v", err)
 	}
 	// The good repo (declared before the failing one) was still resolved.
 	if _, statErr := os.Stat(filepath.Join(dir, "good", "README.md")); statErr != nil {
 		t.Errorf("expected the non-required repo to clone despite a later required failure: %v", statErr)
+	}
+	// Statuses preserve declaration order: good (cloned) then bad (failed).
+	if len(statuses) != 2 {
+		t.Fatalf("want 2 statuses, got %d: %+v", len(statuses), statuses)
+	}
+	if statuses[0].Name != "good" || statuses[0].State != setupstatus.StateCloned {
+		t.Errorf("status[0] = %+v, want good/cloned", statuses[0])
+	}
+	if statuses[1].Name != "bad" || statuses[1].State != setupstatus.StateFailed {
+		t.Errorf("status[1] = %+v, want bad/failed", statuses[1])
 	}
 }

--- a/cmd/kuketty/setupstatus.go
+++ b/cmd/kuketty/setupstatus.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
+	sbshserver "github.com/eminwux/sbsh/pkg/terminal/server"
+)
+
+// setupStatusHandler is the receiver kuketty registers as a custom JSON-RPC
+// service on the sbsh control server (issue #642). It serves the per-repo
+// outcome of the pre-Serve clone/fetch step (issue #617) so kukeond can pull
+// it post-Serve and write ContainerStatus.Repos.
+//
+// The statuses are captured once, before Serve brings the control RPC live,
+// and never mutated afterward, so the read in GetSetupStatus needs no
+// synchronization — the slice is published happens-before the server goroutine
+// that serves the verb is started.
+type setupStatusHandler struct {
+	repos []setupstatus.Repo
+}
+
+// GetSetupStatus reports kuketty's pre-Serve repo outcomes. The wire method is
+// "<setupstatus.ServiceName>.GetSetupStatus" (see setupstatus.Method). The
+// net/rpc signature scheme requires (args, reply *T) error with exported
+// argument/reply types — satisfied by setupstatus.Args and setupstatus.Reply.
+// The error return is mandated by that signature even though this read-only
+// verb never fails; net/rpc would reject the method as an RPC handler without
+// it.
+//
+//nolint:unparam // error return required by net/rpc's handler signature (see godoc above)
+func (h *setupStatusHandler) GetSetupStatus(_ setupstatus.Args, reply *setupstatus.Reply) error {
+	reply.Repos = h.repos
+	return nil
+}
+
+// setupStatusOption returns the sbsh server option that registers the
+// GetSetupStatus verb on the control socket, carrying the resolved repo
+// statuses. Returned as a slice so run() can splat it into server.New
+// uniformly whether or not there are repos to report — an empty repos[] still
+// registers the verb (kukeond gets an empty Reply rather than a dial error,
+// keeping the daemon-side pull a single code path).
+func setupStatusOption(repos []setupstatus.Repo) []sbshserver.Option {
+	return []sbshserver.Option{
+		sbshserver.WithHandlers(sbshserver.Handler{
+			Name:     setupstatus.ServiceName,
+			Receiver: &setupStatusHandler{repos: repos},
+		}),
+	}
+}

--- a/cmd/kuketty/setupstatus_test.go
+++ b/cmd/kuketty/setupstatus_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
+)
+
+func TestSetupStatusHandler_ReturnsStoredRepos(t *testing.T) {
+	repos := []setupstatus.Repo{
+		{Name: "a", Target: "/work/a", State: setupstatus.StateCloned, Commit: "deadbeef"},
+		{Name: "b", Target: "/work/b", State: setupstatus.StateFailed, Error: "boom"},
+	}
+	h := &setupStatusHandler{repos: repos}
+
+	var reply setupstatus.Reply
+	if err := h.GetSetupStatus(setupstatus.Args{}, &reply); err != nil {
+		t.Fatalf("GetSetupStatus: %v", err)
+	}
+	if len(reply.Repos) != 2 {
+		t.Fatalf("want 2 repos, got %d: %+v", len(reply.Repos), reply.Repos)
+	}
+	if reply.Repos[0] != repos[0] || reply.Repos[1] != repos[1] {
+		t.Errorf("reply.Repos = %+v, want %+v", reply.Repos, repos)
+	}
+}
+
+func TestSetupStatusHandler_EmptyReposIsEmptyReply(t *testing.T) {
+	h := &setupStatusHandler{repos: nil}
+
+	var reply setupstatus.Reply
+	if err := h.GetSetupStatus(setupstatus.Args{}, &reply); err != nil {
+		t.Fatalf("GetSetupStatus: %v", err)
+	}
+	if len(reply.Repos) != 0 {
+		t.Errorf("want empty reply, got %+v", reply.Repos)
+	}
+}
+
+func TestSetupStatusOption_RegistersVerb(t *testing.T) {
+	// The option splat must always register exactly one handler under the
+	// agreed service name, even when there are no repos to report — kukeond's
+	// pull is a single code path that expects the verb to exist.
+	opts := setupStatusOption(nil)
+	if len(opts) != 1 {
+		t.Fatalf("want exactly one server option, got %d", len(opts))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.11.5-0.20260521084435-a101efe9914c
+	github.com/eminwux/sbsh v0.12.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1
@@ -45,6 +45,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/compress v1.18.1 // indirect
 	github.com/moby/locker v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.11.4
+	github.com/eminwux/sbsh v0.11.5-0.20260521084435-a101efe9914c
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.11.4 h1:HWtdqOUIkgpbAGNGZwzHey3pUYMDI/IlxUnOD3vIFvM=
-github.com/eminwux/sbsh v0.11.4/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
+github.com/eminwux/sbsh v0.11.5-0.20260521084435-a101efe9914c h1:D8kZ1CN+LHb/0GtfOcu7bc9IRymogdAciOqXUuaEGlA=
+github.com/eminwux/sbsh v0.11.5-0.20260521084435-a101efe9914c/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.11.5-0.20260521084435-a101efe9914c h1:D8kZ1CN+LHb/0GtfOcu7bc9IRymogdAciOqXUuaEGlA=
-github.com/eminwux/sbsh v0.11.5-0.20260521084435-a101efe9914c/go.mod h1:AsDnK44VUZjB5tpUn6oV/0isaIudbLLQst8FYFXPJcs=
+github.com/eminwux/sbsh v0.12.0 h1:vnWA6SNGA+BQGF4NrTcmgMqY7l9WyOal8svvPo5FL8E=
+github.com/eminwux/sbsh v0.12.0/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -114,6 +114,8 @@ github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6/go.mod h1:I6V7YzU0XDp
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs104wLj8l5GEththEw6+F79YsIY=
+github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/native v1.1.0 h1:uuaP0hAbW7Y4l0ZRQ6C9zfb7Mg1mbFKry/xzDAfmtLA=

--- a/internal/controller/get_container.go
+++ b/internal/controller/get_container.go
@@ -129,6 +129,13 @@ func (b *Exec) GetContainer(container intmodel.Container) (GetContainerResult, e
 				Name:  name,
 				ID:    name,
 				State: actualState,
+				// GetCell populated per-container statuses, including the
+				// per-repo clone/fetch outcome pulled over the GetSetupStatus
+				// RPC (issue #642). Carry the Repos slice through so
+				// `kuke get container <name> -o yaml/json` surfaces it; the
+				// rest of the status is rebuilt inline from the freshly-queried
+				// containerd state above.
+				Repos: repoStatusesForContainer(internalCell, name),
 			},
 		}
 	} else {
@@ -140,6 +147,19 @@ func (b *Exec) GetContainer(container intmodel.Container) (GetContainerResult, e
 	}
 
 	return res, nil
+}
+
+// repoStatusesForContainer returns the per-repo clone/fetch outcome that
+// GetCell pulled into the cell's container statuses (over the GetSetupStatus
+// RPC, issue #642) for the named container, or nil when the container has no
+// repo status (no repos[], not yet Ready, or the pull was unavailable).
+func repoStatusesForContainer(cell intmodel.Cell, name string) []intmodel.RepoStatus {
+	for i := range cell.Status.Containers {
+		if cell.Status.Containers[i].ID == name {
+			return cell.Status.Containers[i].Repos
+		}
+	}
+	return nil
 }
 
 // ListContainers lists all containers, optionally filtered by realm, space, stack, and/or cell.

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -710,11 +710,53 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 			ExitCode:     0,           // TODO: retrieve from containerd
 			ExitSignal:   "",          // TODO: retrieve from containerd
 		}
+		// Pull per-repo clone/fetch outcome over the kuketty control socket
+		// (issue #642). Best-effort: only Attachable containers that declared
+		// repos[] and are Ready can serve the verb, and any failure leaves
+		// Repos empty rather than blocking the status read.
+		status.Repos = r.repoStatuses(cell, containerSpec, state)
 		statuses = append(statuses, status)
 	}
 
 	cell.Status.Containers = statuses
 	return nil
+}
+
+// repoStatuses pulls the per-repo clone/fetch outcome from a container's
+// kuketty control socket via the GetSetupStatus RPC (issue #642), mapping the
+// wire payload into the internal RepoStatus the controller persists in
+// ContainerStatus.Repos. ContainerStatus is the single source of truth — there
+// is no status file in the container.
+//
+// The pull is skipped (returns nil) unless the container is Attachable, has
+// declared repos[], and is Ready: a kuketty that has not reached Serve does
+// not yet serve the verb, and one that exited on a required-repo failure never
+// will (its outcome comes from the task-failed signal + kuketty log instead —
+// AC #5). Any dial/call error is logged at debug and yields nil so a wedged or
+// still-starting kuketty never stalls `kuke get`.
+func (r *Exec) repoStatuses(
+	cell *intmodel.Cell,
+	containerSpec intmodel.ContainerSpec,
+	state intmodel.ContainerState,
+) []intmodel.RepoStatus {
+	if !containerSpec.Attachable || len(containerSpec.Repos) == 0 || state != intmodel.ContainerStateReady {
+		return nil
+	}
+
+	socketPath := fs.ContainerSocketSymlinkPath(
+		r.opts.RunPath,
+		cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name,
+		containerSpec.ID,
+	)
+	repos, err := pullSetupStatus(r.ctx, socketPath)
+	if err != nil {
+		r.logger.DebugContext(r.ctx, "failed to pull repo setup status",
+			"container", containerSpec.ID,
+			"socket", socketPath,
+			"error", err)
+		return nil
+	}
+	return setupStatusToInternal(repos)
 }
 
 // PopulateAndPersistCellContainerStatuses populates container statuses from containerd

--- a/internal/controller/runner/setup_status_client.go
+++ b/internal/controller/runner/setup_status_client.go
@@ -30,9 +30,10 @@ import (
 
 // setupStatusDialTimeout bounds the connect + round-trip to a container's
 // kuketty control socket. The pull is a best-effort enrichment of a `kuke get`
-// read (see populateRepoStatuses): a slow or wedged kuketty must never stall
-// the status read, so the call gives up quickly and leaves Repos empty rather
-// than blocking the operator's `kuke get`.
+// read (see repoStatuses / populateCellContainerStatuses in helpers.go): a
+// slow or wedged kuketty must never stall the status read, so the call gives
+// up quickly and leaves Repos empty rather than blocking the operator's
+// `kuke get`.
 const setupStatusDialTimeout = 2 * time.Second
 
 // pullSetupStatus dials a container's kuketty control socket and invokes the

--- a/internal/controller/runner/setup_status_client.go
+++ b/internal/controller/runner/setup_status_client.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// setupStatusDialTimeout bounds the connect + round-trip to a container's
+// kuketty control socket. The pull is a best-effort enrichment of a `kuke get`
+// read (see populateRepoStatuses): a slow or wedged kuketty must never stall
+// the status read, so the call gives up quickly and leaves Repos empty rather
+// than blocking the operator's `kuke get`.
+const setupStatusDialTimeout = 2 * time.Second
+
+// pullSetupStatus dials a container's kuketty control socket and invokes the
+// GetSetupStatus verb (issue #642), returning the per-repo clone/fetch outcome
+// kuketty reported after its pre-Serve step. The socket is the same one
+// `kuke attach` connects to; the verb is served over the same JSON-RPC codec,
+// so a stdlib net/rpc/jsonrpc client is wire-compatible for this non-FD method
+// (sbsh's own pkg/rpcclient uses the same codec for its non-FD verbs).
+//
+// The whole call is bounded by setupStatusDialTimeout. Callers treat any error
+// as "status not available yet" and proceed with an empty Repos — the verb is
+// only reachable once kuketty is past Serve (container Ready), and a container
+// that exited on a required-repo failure never serves it (AC #5).
+func pullSetupStatus(ctx context.Context, socketPath string) ([]setupstatus.Repo, error) {
+	dialCtx, cancel := context.WithTimeout(ctx, setupStatusDialTimeout)
+	defer cancel()
+
+	var d net.Dialer
+	conn, err := d.DialContext(dialCtx, "unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("dial kuketty socket %q: %w", socketPath, err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Bound the round-trip on the conn too: DialContext only covers connect,
+	// not the Call. A deadline on the conn unblocks a hung read/write.
+	if deadline, ok := dialCtx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+
+	client := rpc.NewClientWithCodec(jsonrpc.NewClientCodec(conn))
+	defer func() { _ = client.Close() }()
+
+	var reply setupstatus.Reply
+	if callErr := client.Call(setupstatus.Method, setupstatus.Args{}, &reply); callErr != nil {
+		return nil, fmt.Errorf("call %s on %q: %w", setupstatus.Method, socketPath, callErr)
+	}
+	return reply.Repos, nil
+}
+
+// setupStatusToInternal maps the wire payload onto the internal RepoStatus
+// type the controller persists in ContainerStatus.Repos. Returns nil for an
+// empty input so a container with no repos[] reports a nil Repos (mirrors the
+// omitempty wire/YAML shape) rather than an empty slice.
+func setupStatusToInternal(repos []setupstatus.Repo) []intmodel.RepoStatus {
+	if len(repos) == 0 {
+		return nil
+	}
+	out := make([]intmodel.RepoStatus, len(repos))
+	for i, r := range repos {
+		out[i] = intmodel.RepoStatus{
+			Name:   r.Name,
+			Target: r.Target,
+			State:  r.State,
+			Commit: r.Commit,
+			Error:  r.Error,
+		}
+	}
+	return out
+}

--- a/internal/controller/runner/setup_status_client_test.go
+++ b/internal/controller/runner/setup_status_client_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"context"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
+)
+
+// stubSetupService mirrors kuketty's setupStatusHandler: a net/rpc receiver
+// registered under setupstatus.ServiceName whose GetSetupStatus method returns
+// a fixed Reply. Serving it over the stdlib jsonrpc server codec proves the
+// daemon-side pullSetupStatus client speaks the same wire protocol kuketty's
+// handler is served over (both are net/rpc + JSON-RPC for this non-FD verb),
+// without standing up a full sbsh server.
+type stubSetupService struct {
+	repos []setupstatus.Repo
+}
+
+func (s *stubSetupService) GetSetupStatus(_ setupstatus.Args, reply *setupstatus.Reply) error {
+	reply.Repos = s.repos
+	return nil
+}
+
+// serveStubSetup registers svc under setupstatus.ServiceName on a fresh
+// rpc.Server, listens on a unix socket inside a temp dir, and serves
+// connections with the stdlib jsonrpc server codec until the test ends.
+// Returns the socket path the client should dial.
+func serveStubSetup(t *testing.T, svc *stubSetupService) string {
+	t.Helper()
+	srv := rpc.NewServer()
+	if err := srv.RegisterName(setupstatus.ServiceName, svc); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+
+	// A short socket path (temp dir) so we stay well inside SUN_PATH.
+	socketPath := filepath.Join(t.TempDir(), "socket")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return // listener closed by cleanup
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+	return socketPath
+}
+
+func TestPullSetupStatus_RoundTrip(t *testing.T) {
+	want := []setupstatus.Repo{
+		{Name: "app", Target: "/work/app", State: setupstatus.StateCloned, Commit: "abc123"},
+		{Name: "lib", Target: "/work/lib", State: setupstatus.StateFailed, Error: "auth failed"},
+	}
+	socketPath := serveStubSetup(t, &stubSetupService{repos: want})
+
+	got, err := pullSetupStatus(context.Background(), socketPath)
+	if err != nil {
+		t.Fatalf("pullSetupStatus: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("want %d repos, got %d: %+v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("repo[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPullSetupStatus_EmptyReply(t *testing.T) {
+	socketPath := serveStubSetup(t, &stubSetupService{repos: nil})
+
+	got, err := pullSetupStatus(context.Background(), socketPath)
+	if err != nil {
+		t.Fatalf("pullSetupStatus: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("want empty repos, got %+v", got)
+	}
+}
+
+func TestPullSetupStatus_DialError(t *testing.T) {
+	// No server listening at this path — the dial must fail fast (bounded by
+	// setupStatusDialTimeout) rather than block, so the caller falls back to
+	// an empty Repos.
+	missing := filepath.Join(t.TempDir(), "absent")
+	if _, err := pullSetupStatus(context.Background(), missing); err == nil {
+		t.Fatal("want a dial error for an absent socket, got nil")
+	}
+}
+
+func TestSetupStatusToInternal(t *testing.T) {
+	if got := setupStatusToInternal(nil); got != nil {
+		t.Errorf("nil input should map to nil, got %+v", got)
+	}
+	in := []setupstatus.Repo{
+		{Name: "app", Target: "/work/app", State: setupstatus.StateCloned, Commit: "abc123"},
+	}
+	got := setupStatusToInternal(in)
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	if got[0].Name != "app" || got[0].Target != "/work/app" ||
+		got[0].State != setupstatus.StateCloned || got[0].Commit != "abc123" {
+		t.Errorf("unexpected mapping: %+v", got[0])
+	}
+}

--- a/internal/kuketty/setupstatus/setupstatus.go
+++ b/internal/kuketty/setupstatus/setupstatus.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package setupstatus is the wire contract for the GetSetupStatus RPC verb
+// (issue #642, phase 1b). kuketty registers the verb as a custom JSON-RPC
+// service on its sbsh control socket — the same socket the daemon already
+// dials for `kuke attach` — and reports the per-repo outcome of its pre-Serve
+// clone/fetch step (issue #617). kukeond pulls the result post-Serve and
+// writes it into ContainerStatus.Repos, surfaced in `kuke get`.
+//
+// The package is deliberately leaf-level (only the standard library) so it can
+// be imported by both the kuketty wrapper (whose import closure must stay
+// small — see cmd/kuketty/main.go) and the daemon-side controller without
+// dragging in either side's heavy dependency set.
+//
+// ContainerStatus is the single source of truth for setup status: there is no
+// status file in the container. The earlier file-based first cut
+// (repos-status.json read back through the tty-dir bind mount) is not used.
+package setupstatus
+
+// ServiceName is the net/rpc service name kuketty registers on the sbsh
+// control server via server.WithHandlers. A client invokes the verb with the
+// wire method "<ServiceName>.<MethodName>" — see Method.
+const ServiceName = "Setup"
+
+// MethodName is the exported method on the registered receiver.
+const MethodName = "GetSetupStatus"
+
+// Method is the full "Service.Method" string the daemon-side JSON-RPC client
+// passes to (*rpc.Client).Call. Kept in one place so the producer
+// (registration) and consumer (call) cannot drift.
+const Method = ServiceName + "." + MethodName
+
+// Args is the (empty) request payload for GetSetupStatus. The verb takes no
+// parameters — kuketty already knows its own repos[] outcome. An exported
+// struct (rather than a bare type) keeps the net/rpc signature scheme happy
+// and leaves room for future request fields without a wire break.
+type Args struct{}
+
+// Reply is the GetSetupStatus response: the per-repo outcome of kuketty's
+// pre-Serve clone/fetch step, in the order the repos were declared on the
+// container spec. An empty Repos means the container declared no repos[].
+type Reply struct {
+	Repos []Repo `json:"repos"`
+}
+
+// Repo is the resolved state of a single ContainerRepo after kuketty's
+// pre-Serve step. Field set mirrors api/model/v1beta1.RepoStatus so the
+// daemon can map it straight into ContainerStatus.Repos.
+type Repo struct {
+	Name   string `json:"name"`
+	Target string `json:"target"`
+	// State is one of StateCloned, StateFetched, or StateFailed.
+	State string `json:"state"`
+	// Commit is the resolved HEAD commit (full SHA) on success; empty on
+	// failure.
+	Commit string `json:"commit,omitempty"`
+	// Error is the failure detail when State == StateFailed; empty otherwise.
+	Error string `json:"error,omitempty"`
+}
+
+// Repo state values. These match the strings phase 1a already logs and the
+// values api/model/v1beta1.RepoStatus.State documents.
+const (
+	// StateCloned means the target had no .git and was freshly cloned.
+	StateCloned = "cloned"
+	// StateFetched means the target already had a checkout and was
+	// fetched + fast-forwarded.
+	StateFetched = "fetched"
+	// StateFailed means the clone/fetch failed; Error carries the detail.
+	StateFailed = "failed"
+)


### PR DESCRIPTION
## Summary

Phase 1b of `containers[].repos[]` (#642, split from #617). Phase 1a (#627) clones/fetches a container's declared repos in kuketty's pre-Serve step but only **logs** the outcome. This wires the locked design: kuketty reports per-repo outcome to `kukeond` over a **custom RPC verb on its existing sbsh control socket** (the same socket `kuke attach` dials), and `kukeond` pulls it post-Serve into `ContainerStatus.Repos`. `ContainerStatus` is the single source of truth — there is no status file in the container.

- **kuketty (producer):** `processRepos` now returns the per-repo outcome (`cloned`/`fetched`/`failed`, with commit/error) instead of logging only; a `GetSetupStatus` verb is registered on the sbsh control server via the new `server.WithHandlers` hook and serves that snapshot.
- **kukeond (consumer):** a stdlib `net/rpc/jsonrpc` client (`pullSetupStatus`) dials the container's kuketty socket and calls `Setup.GetSetupStatus`; `populateCellContainerStatuses` invokes it best-effort for Attachable + Ready containers with `repos[]` and writes `ContainerStatus.Repos`. Any dial/call error leaves `Repos` empty so a still-starting or wedged kuketty never stalls `kuke get`.
- **`kuke get`:** `GetContainer` carries the populated `Repos` slice through, so `kuke get container <name> -o yaml/json` surfaces it.

## ✅ MERGE-BLOCK RESOLVED — re-pinned to tagged sbsh v0.12.0

This depended on the custom-RPC-handler-registration API (`server.WithHandlers`) from **eminwux/sbsh#291** (landed via sbsh PR #294, commit `a101efe`). sbsh has now cut **`v0.12.0`**, which contains that commit (`a101efe` is an ancestor of the `v0.12.0` tag — verified via `gh api .../compare/a101efe...v0.12.0` → `ahead`).

`go.mod` has been re-pinned from the temporary pseudo-version (`v0.11.5-0.20260521084435-a101efe9914c`) to the tagged release **`github.com/eminwux/sbsh v0.12.0`** (commit `build: re-pin sbsh to tagged v0.12.0 (drop pseudo-version)`), per the review note's "same pattern as the v0.11.4 bump." The pseudo-version is gone; this is now the intended merge state. `go mod tidy` pulled in one transitive indirect dep (`github.com/hinshun/vt10x`).

## Notes / non-obvious calls

- **AC #4 (remove `repos-status.json`) is a no-op:** the file-based first cut described in the issue context was never actually landed by phase 1a (#627) — `grep -rn repos-status` finds nothing in the tree. There is no status file to remove; the RPC is the only status channel.
- **sbsh is now pinned to the tagged release `v0.12.0`** (contains the `#294` handler-registration commit `a101efe`). The earlier pseudo-version pinned `a101efe` directly to compile/test ahead of the release; that artifact has been replaced by the tag.
- **`//nolint:unparam` on `GetSetupStatus`:** the `error` return is mandated by net/rpc's handler signature even though the read-only verb never fails.
- The `GetSetupStatus` channel is reused by #635 (`runOn: create` stage outcomes).

## Test plan

- [x] `GOWORK=off go build ./...` (build each module on its own, per the repo's `go.work` contract)
- [x] `GOWORK=off go vet ./...`
- [x] `make test` equivalent — `GOWORK=off go test $(go list ./... | grep -v /e2e)` + `cd cmd/kukebuild && go test ./...` (all pass)
- [x] golangci-lint (`GOWORK=off`) clean on changed files
- [x] `make dev-init` smoke — daemon-parity regression guard intact (both `kuke get realms` and `--no-daemon` show both realms `Ready`); nested-mode parent attach plumbing intact
- [x] **End-to-end:** applied an Attachable cell with a non-required `repos[]` entry against the rebuilt daemon; container reached `Ready` and `kuke get container app -o yaml`/`-o json` surfaced `status.repos` with `state: failed` + the git error (busybox lacks git) — proving the new sbsh `WithHandlers` API works at runtime and the full produce→pull→surface path is live
- [x] `go build`/`go vet`/`go test` (main module + `cmd/kukebuild`, `GOWORK=off`) all green after re-pinning to sbsh `v0.12.0`
- [x] Merge-block resolved: sbsh dep re-pinned from pseudo-version to tagged release `v0.12.0`; pseudo-version dropped from `go.mod`/`go.sum`

## Acceptance criteria

- [x] kuketty registers a `GetSetupStatus` RPC verb on the sbsh control server (via `server.WithHandlers`)
- [x] `kukeond` pulls per-repo outcome post-Serve and populates `ContainerStatus.Repos` (`name`, `target`, `state`, `commit?`, `error?`)
- [x] Per-repo clone state is visible in `kuke get container <name> -o yaml/json`
- [x] No status file in the container (none existed; nothing to remove — see Notes)
- [x] `required: true` failure path (exit before `Serve`) unchanged — kuketty still exits non-zero before `Serve`, so the RPC is never reached; status comes from the task-failed signal + kuketty log

Closes #642