### PR TITLE
docs(kukebuild): record phase-1b real-Dockerfile validation verdict

### DIFF
--- a/cmd/kukebuild/build.go
+++ b/cmd/kukebuild/build.go
@@ -59,8 +59,9 @@ const grpcMaxMsgSize = 1 << 30
 
 // dockerfileFrontend is BuildKit's built-in Dockerfile frontend key. The
 // frontend handles multi-stage, COPY --from=, --build-arg and
-// --platform=$BUILDPLATFORM at the library level (phase 1b, #616, validates
-// those against kukeon's own Dockerfile).
+// --platform=$BUILDPLATFORM at the library level — phase 1b (#616) validated
+// all four against kukeon's own multi-stage Dockerfile end-to-end, with no
+// frontend-side wiring beyond the attrs newSolveOpt already sets.
 const dockerfileFrontend = "dockerfile.v0"
 
 // localNameContext / localNameDockerfile are the LocalMounts keys BuildKit's
@@ -319,10 +320,14 @@ func newController(ctx context.Context, cfg *buildConfig, namespace string) (*co
 // newWorkerController builds a single-worker controller using BuildKit's
 // containerd worker backend. The worker connects to cfg.containerdSocket and
 // is scoped to the realm's containerd namespace, so the image exporter writes
-// layers + manifest into <realm>.kukeon.io. Host network mode keeps phase 1
-// simple — a trivial single-stage Dockerfile needs no build network, and the
-// CNI / build-network quirks that surface on a real multi-stage build are
-// deferred to phase 1b (#616).
+// layers + manifest into <realm>.kukeon.io. Host network mode (the build
+// containers share the host's network namespace) was confirmed sufficient in
+// phase 1b (#616): kukeon's own Dockerfile reaches the network from a RUN step
+// for the CNI-plugins curl-fetch + sha256-verify, and that succeeds over host
+// mode with no CNI / build-network wiring — no bridge provider is needed.
+// SnapshotterName is the containerd default (overlayfs on Linux); phase 1b
+// confirmed it handles multi-stage cache reuse and COPY --from= against the
+// real recipe without further plumbing.
 func newWorkerController(
 	ctx context.Context,
 	cfg *buildConfig,

--- a/cmd/kukebuild/main.go
+++ b/cmd/kukebuild/main.go
@@ -39,9 +39,11 @@
 // embedded buildkitd).
 //
 // Phase 1 (#522) wires the engine and validates a trivial single-stage
-// Dockerfile. Multi-stage validation against kukeon's own Dockerfile, plus
-// --secret / --cache-* / --push / --platform flags, are deferred to the phase
-// 1b / 2 follow-ups (#616, #523, #524, #646).
+// Dockerfile. Phase 1b (#616) validated multi-stage, COPY --from=, --build-arg
+// and --platform=$BUILDPLATFORM against kukeon's own Dockerfile end-to-end
+// (host network mode + the default overlayfs snapshotter sufficed). The
+// --secret / --cache-* / --push / --platform-flag surface is deferred to the
+// phase 2 follow-ups (#523, #524, #646).
 package main
 
 import (


### PR DESCRIPTION
## Summary

Phase 1b (#616) validates the `kuke build` / `kukebuild` pipeline (#522) against
kukeon's *own* multi-stage `Dockerfile` — not the trivial single-stage smoke from
phase 1. The verdict is **clean**: the real recipe builds end-to-end with no
quirks, so this PR ships no behavior change. It instead **codifies the verdict
in-package**, updating the three now-stale forward-looking comments that said
multi-stage / CNI / build-network handling was "deferred to phase 1b (#616)" —
phase 1b is this issue, and it is now validated.

Why these comment edits and nothing else: the issue asked to "run kukeon's own
Dockerfile through `kuke build` end-to-end and resolve any quirks." No quirks
surfaced — host network mode and the default snapshotter both sufficed
unmodified — so the deliverable is the validation evidence (below) plus the
in-package codification, per CLAUDE.md's clean-verdict guidance.

### Build-network strategy (AC: documented)

`newWorkerController` sets `NetworkOpt: netproviders.Opt{Mode: "host"}` (build
containers share the host network namespace). **No CNI / bridge provider wiring
was required.** The CNI-plugins `curl`-fetch in the Dockerfile's `cni-plugins`
stage (curl the `.tgz` + `.sha256`, `sha256sum -c`, untar into `/opt/cni/bin`)
reached the network and the sha256 verification passed over host mode. All 18
upstream plugins (bridge, host-local, loopback, …) landed in the final image —
confirmed by running the built image and listing `/opt/cni/bin`.

### Snapshotter choice (AC: documented)

`SnapshotterName: ctddefaults.DefaultSnapshotter` — overlayfs on Linux. It
handled multi-stage cache reuse and `COPY --from=` against the real recipe with
no further plumbing. No `--platform`-specific snapshotter wiring was needed; the
`--platform=$BUILDPLATFORM` / `TARGETOS` / `TARGETARCH` semantics are resolved by
the Dockerfile frontend (`dockerfile.v0`) at the library level — `kukebuild`
forwards only `--build-arg` attrs.

## Test plan

- [x] `kuke build -t kukeon-local:dev --realm kuke-system .` against the repo's
      `Dockerfile` — succeeded (EXIT=0), no docker fallback. Multi-stage,
      `COPY --from=`, `--build-arg` (VERSION/TARGETOS/TARGETARCH), and
      `--platform=$BUILDPLATFORM` all resolved.
- [x] Image lands in the `kuke-system.kukeon.io` containerd namespace —
      `ctr -n kuke-system.kukeon.io images ls` shows `docker.io/library/kukeon-local:dev` (97.9 MiB, linux/amd64).
- [x] Consumable by `kuke image get --realm kuke-system` — listed.
- [x] CNI curl-fetch + sha256 passes — ran the built image; all 18 plugins
      present under `/opt/cni/bin`, plus `/bin/kuke`, `/bin/kukeond`, `/bin/kuketty`.
- [x] Usable as `--kukeond-image` for `kuke init` — `kuke daemon reset` +
      `kuke init --kukeond-image docker.io/library/kukeon-local:dev` booted the
      daemon to Ready (validated in nested dev-cell mode via `/run/kukeon-dev/`).
- [x] Daemon-parity regression guard — both `kuke get realms` and
      `kuke get realms --no-daemon` produce the matching default + kuke-system
      Ready table; parent attach plumbing left intact.
- [x] No regression to the phase-1 single-stage smoke — a trivial
      `FROM busybox + RUN` build into `--realm default` succeeded (EXIT=0),
      image landed in `default.kukeon.io`.
- [x] `make test` (root module + `cmd/kukebuild` module) — passes.
- [x] `go build` of `cmd/kukebuild` — clean (binary built `kukeon-local:dev`).

## Notes

- No new CLI flags added (per the issue; flag additions are #523 / #524).
- Comment-only diff. Kept in the code lane (non-`docs/` branch) rather than the
  trivial-edit `ready-to-merge` shortcut so a reviewer can audit the validation
  evidence on this milestone, which unblocks #525 (`scripts/dev-init.sh`
  migration off docker).

Closes #616