### PR TITLE
feat(secret): add ContainerSecret.secretRef source + resolution path (phase 3c)

### DIFF
--- a/cmd/kuke/delete/secret/secret.go
+++ b/cmd/kuke/delete/secret/secret.go
@@ -32,13 +32,12 @@ import (
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
-// unsafeDeleteWarning documents the temporary window the AC of issue #622 calls
-// out: until the secretRef referencing path ships in phase 3c, delete cannot
-// know whether a live container still references the secret, so it removes the
-// file unconditionally.
-const unsafeDeleteWarning = "WARNING: until the secretRef referencing path ships (phase 3c), this verb " +
-	"cannot detect a live container that references the secret and will delete it " +
-	"unconditionally. Deleting a referenced secret may break running workloads."
+// deleteGuardNote documents the live-reference safety gate wired in phase 3c
+// (issue #623): the verb refuses to delete a Secret while any cell's container
+// still references it via secretRef, naming the referencing cells so the
+// operator can detach or delete them first.
+const deleteGuardNote = "Deletion is refused while a cell's container references the secret via " +
+	"secretRef; the error lists the referencing cells so they can be detached or deleted first."
 
 // NewSecretCmd builds `kuke delete secret <name>` (issue #622). It removes the
 // daemon-stored bytes file for a single named, scoped Secret. The secret is
@@ -48,7 +47,7 @@ func NewSecretCmd() *cobra.Command {
 		Use:           "secret [name]",
 		Aliases:       []string{"sec"},
 		Short:         "Delete a kind: Secret",
-		Long:          "Delete a kind: Secret's daemon-stored bytes.\n\n" + unsafeDeleteWarning,
+		Long:          "Delete a kind: Secret's daemon-stored bytes.\n\n" + deleteGuardNote,
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,

--- a/cmd/kuke/delete/secret/secret_test.go
+++ b/cmd/kuke/delete/secret/secret_test.go
@@ -132,13 +132,13 @@ func TestDeleteSecret(t *testing.T) {
 	}
 }
 
-// TestDeleteSecret_HelpDocumentsUnsafeWindow confirms the verb's long help
-// names the temporary unconditional-delete window the AC of issue #622 calls
-// out, so the operator sees the phase-3c caveat.
-func TestDeleteSecret_HelpDocumentsUnsafeWindow(t *testing.T) {
+// TestDeleteSecret_HelpDocumentsReferenceGuard confirms the verb's long help
+// names the live-reference safety gate wired in phase 3c (issue #623), so the
+// operator knows deletion is refused while a cell references the secret.
+func TestDeleteSecret_HelpDocumentsReferenceGuard(t *testing.T) {
 	cmd := secret.NewSecretCmd()
-	if !strings.Contains(cmd.Long, "phase 3c") {
-		t.Errorf("delete secret long help does not document the phase-3c unsafe-delete window\nGot:\n%s", cmd.Long)
+	if !strings.Contains(cmd.Long, "secretRef") {
+		t.Errorf("delete secret long help does not document the live-reference guard\nGot:\n%s", cmd.Long)
 	}
 }
 

--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -99,14 +99,17 @@ volumes:
 
 Each entry in `spec.secrets` references a credential the daemon resolves at apply time. Only the reference is persisted — the resolved value never appears in `kuke get -o yaml`, in object status, or in daemon logs.
 
-| Field       | Type   | Required        | Description                                                                                                                                             |
-| ----------- | ------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`      | string | yes             | Environment-variable name (default mode) or basename of the mounted secret file when `mountPath` is set                                                 |
-| `fromFile`  | string | one of required | Absolute host path the daemon reads at apply time. Missing files produce a clear error.                                                                 |
-| `fromEnv`   | string | one of required | Name of an environment variable set on the daemon host. Missing env vars produce a clear error.                                                         |
-| `mountPath` | string | no              | Absolute path inside the container. When set, the secret is staged with mode `0400` and bind-mounted read-only instead of being injected as an env var. |
+| Field       | Type                | Required        | Description                                                                                                                                             |
+| ----------- | ------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`      | string              | yes             | Environment-variable name (default mode) or basename of the mounted secret file when `mountPath` is set                                                 |
+| `fromFile`  | string              | one of required | Absolute host path the daemon reads at apply time. Missing files produce a clear error.                                                                 |
+| `fromEnv`   | string              | one of required | Name of an environment variable set on the daemon host. Missing env vars produce a clear error.                                                         |
+| `secretRef` | `ContainerSecretRef` | one of required | Reference to a daemon-managed `kind: Secret` by name and scope. Resolved from the scope's secrets tree at container start; a missing Secret produces a clear error naming the expected scope path. |
+| `mountPath` | string              | no              | Absolute path inside the container. When set, the secret is staged with mode `0400` and bind-mounted read-only instead of being injected as an env var. |
 
-Exactly one of `fromFile` / `fromEnv` must be set. Example:
+Exactly one of `fromFile` / `fromEnv` / `secretRef` must be set.
+
+`secretRef` carries the referenced Secret's `name` plus its scope coordinates, following the same contract as [`kind: Secret`](#) metadata: `realm` is always required, and a deeper coordinate (`space` → `stack` → `cell`) may only be set when every shallower one is. A container may reference a Secret owned by a different scope — e.g. a workload in `default` reading a `kuke-system`-scoped token. Example:
 
 ```yaml
 secrets:
@@ -117,7 +120,19 @@ secrets:
   - name: tls.crt
     fromFile: /etc/kukeon/secrets/tls.crt
     mountPath: /run/secrets/tls.crt
+  - name: ANTHROPIC_AUTH_TOKEN
+    secretRef:
+      name: anthropic-token
+      realm: kuke-system
 ```
+
+| `ContainerSecretRef` field | Type   | Required | Description                                          |
+| -------------------------- | ------ | -------- | ---------------------------------------------------- |
+| `name`                     | string | yes      | The referenced Secret's name within its scope        |
+| `realm`                    | string | yes      | Always-required top-level scope coordinate           |
+| `space`                    | string | no       | Scopes the reference to a space within `realm`       |
+| `stack`                    | string | no       | Scopes the reference to a stack within `space`       |
+| `cell`                     | string | no       | Scopes the reference to a cell within `stack`        |
 
 File-mount mode stages secrets under `/run/kukeon/secrets/<containerdId>/<name>` on the host, with owner-only read perms, then bind-mounts them read-only into the container. Because containerd persists resolved env vars in its own runtime spec, env-injection mode leaves the value in containerd's state; file-mount mode keeps it only in the tmpfs staging file.
 

--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -109,7 +109,7 @@ Each entry in `spec.secrets` references a credential the daemon resolves at appl
 
 Exactly one of `fromFile` / `fromEnv` / `secretRef` must be set.
 
-`secretRef` carries the referenced Secret's `name` plus its scope coordinates, following the same contract as [`kind: Secret`](#) metadata: `realm` is always required, and a deeper coordinate (`space` → `stack` → `cell`) may only be set when every shallower one is. A container may reference a Secret owned by a different scope — e.g. a workload in `default` reading a `kuke-system`-scoped token. Example:
+`secretRef` carries the referenced Secret's `name` plus its scope coordinates, following the same contract as `kind: Secret` metadata: `realm` is always required, and a deeper coordinate (`space` → `stack` → `cell`) may only be set when every shallower one is. A container may reference a Secret owned by a different scope — e.g. a workload in `default` reading a `kuke-system`-scoped token. Example:
 
 ```yaml
 secrets:

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -859,10 +859,26 @@ func convertSecretsToInternal(in []ext.ContainerSecret) []intmodel.ContainerSecr
 			Name:      s.Name,
 			FromFile:  s.FromFile,
 			FromEnv:   s.FromEnv,
+			SecretRef: secretRefToInternal(s.SecretRef),
 			MountPath: s.MountPath,
 		}
 	}
 	return out
+}
+
+// secretRefToInternal copies an external ContainerSecretRef into the internal
+// model, preserving nil. Issue #623.
+func secretRefToInternal(in *ext.ContainerSecretRef) *intmodel.ContainerSecretRef {
+	if in == nil {
+		return nil
+	}
+	return &intmodel.ContainerSecretRef{
+		Name:  in.Name,
+		Realm: in.Realm,
+		Space: in.Space,
+		Stack: in.Stack,
+		Cell:  in.Cell,
+	}
 }
 
 // buildSecretsExternalFromInternal is the inverse of convertSecretsToInternal.
@@ -876,10 +892,25 @@ func buildSecretsExternalFromInternal(in []intmodel.ContainerSecret) []ext.Conta
 			Name:      s.Name,
 			FromFile:  s.FromFile,
 			FromEnv:   s.FromEnv,
+			SecretRef: secretRefToExternal(s.SecretRef),
 			MountPath: s.MountPath,
 		}
 	}
 	return out
+}
+
+// secretRefToExternal is the inverse of secretRefToInternal. Issue #623.
+func secretRefToExternal(in *intmodel.ContainerSecretRef) *ext.ContainerSecretRef {
+	if in == nil {
+		return nil
+	}
+	return &ext.ContainerSecretRef{
+		Name:  in.Name,
+		Realm: in.Realm,
+		Space: in.Space,
+		Stack: in.Stack,
+		Cell:  in.Cell,
+	}
 }
 
 // reposToInternal copies external repo declarations into the internal model.

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -1148,6 +1148,73 @@ func TestContainerSecretsRoundTripV1Beta1(t *testing.T) {
 	}
 }
 
+// TestContainerSecretRefRoundTripV1Beta1 ensures the secretRef source survives
+// external→internal→external conversion, including a deep-copy of the pointer
+// (not a shared referent). Issue #623.
+func TestContainerSecretRefRoundTripV1Beta1(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "container-secretref"},
+		Spec: ext.ContainerSpec{
+			ID:      "container-secretref",
+			RealmID: "realm0",
+			SpaceID: "space0",
+			StackID: "stack0",
+			CellID:  "cell0",
+			Image:   "alpine:latest",
+			Secrets: []ext.ContainerSecret{
+				{
+					Name:      "ANTHROPIC_AUTH_TOKEN",
+					SecretRef: &ext.ContainerSecretRef{Name: "anthropic-token", Realm: "kuke-system"},
+				},
+				{
+					Name: "tls.crt",
+					SecretRef: &ext.ContainerSecretRef{
+						Name:  "tls-cert",
+						Realm: "default",
+						Space: "ai",
+						Stack: "agents",
+						Cell:  "claude",
+					},
+					MountPath: "/run/secrets/tls.crt",
+				},
+			},
+		},
+	}
+
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	if internal.Spec.Secrets[0].SecretRef == nil ||
+		internal.Spec.Secrets[0].SecretRef.Name != "anthropic-token" ||
+		internal.Spec.Secrets[0].SecretRef.Realm != "kuke-system" {
+		t.Fatalf("secret[0] secretRef did not normalize: %+v", internal.Spec.Secrets[0].SecretRef)
+	}
+	if internal.Spec.Secrets[1].SecretRef == nil ||
+		internal.Spec.Secrets[1].SecretRef.Cell != "claude" {
+		t.Fatalf("secret[1] secretRef did not normalize: %+v", internal.Spec.Secrets[1].SecretRef)
+	}
+
+	output, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	for i, want := range input.Spec.Secrets {
+		got := output.Spec.Secrets[i]
+		if got.Name != want.Name || got.MountPath != want.MountPath {
+			t.Errorf("secret[%d] round-trip = %+v, want %+v", i, got, want)
+		}
+		if got.SecretRef == nil || *got.SecretRef != *want.SecretRef {
+			t.Errorf("secret[%d] secretRef round-trip = %+v, want %+v", i, got.SecretRef, want.SecretRef)
+		}
+		if got.SecretRef == want.SecretRef {
+			t.Errorf("secret[%d] secretRef pointer not deep-copied", i)
+		}
+	}
+}
+
 // TestContainerAttachableRoundTrips ensures the new Attachable field
 // survives both directions of conversion (external→internal→external) and
 // across the nested cell-spec converters used when a Container appears

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -490,20 +490,34 @@ func validateRepos(repos []v1beta1.ContainerRepo) error {
 }
 
 // validateSecrets enforces the shape of secret references: name required,
-// exactly one of fromFile/fromEnv, and mountPath (if set) absolute.
+// exactly one of fromFile/fromEnv/secretRef, and mountPath (if set) absolute.
 func validateSecrets(secrets []v1beta1.ContainerSecret) error {
 	for i, s := range secrets {
 		name := strings.TrimSpace(s.Name)
 		if name == "" {
 			return fmt.Errorf("%w (secrets[%d])", errdefs.ErrSecretNameRequired, i)
 		}
-		fromFile := strings.TrimSpace(s.FromFile)
-		fromEnv := strings.TrimSpace(s.FromEnv)
+		// Exactly one of fromFile / fromEnv / secretRef must be set.
+		sources := 0
+		if strings.TrimSpace(s.FromFile) != "" {
+			sources++
+		}
+		if strings.TrimSpace(s.FromEnv) != "" {
+			sources++
+		}
+		if s.SecretRef != nil {
+			sources++
+		}
 		switch {
-		case fromFile == "" && fromEnv == "":
+		case sources == 0:
 			return fmt.Errorf("%w (secrets[%d] %q)", errdefs.ErrSecretSourceRequired, i, name)
-		case fromFile != "" && fromEnv != "":
+		case sources > 1:
 			return fmt.Errorf("%w (secrets[%d] %q)", errdefs.ErrSecretMultipleSources, i, name)
+		}
+		if s.SecretRef != nil {
+			if refErr := validateSecretRef(*s.SecretRef, i, name); refErr != nil {
+				return refErr
+			}
 		}
 		mountPath := strings.TrimSpace(s.MountPath)
 		if mountPath != "" && !filepath.IsAbs(mountPath) {
@@ -515,6 +529,36 @@ func validateSecrets(secrets []v1beta1.ContainerSecret) error {
 				mountPath,
 			)
 		}
+	}
+	return nil
+}
+
+// validateSecretRef enforces the secretRef shape: a referenced name plus a
+// scope that follows the same coordinate contract as a kind: Secret — realm
+// always required, a deeper coordinate only when every shallower one is set.
+// It does not check that the Secret exists on the host; that reachability gate
+// runs at container-start time against the runner, because only the daemon can
+// read the scope's secrets tree. Issue #623.
+func validateSecretRef(ref v1beta1.ContainerSecretRef, i int, name string) error {
+	if strings.TrimSpace(ref.Name) == "" {
+		return fmt.Errorf("%w (secrets[%d] %q)", errdefs.ErrSecretRefNameRequired, i, name)
+	}
+	realm := strings.TrimSpace(ref.Realm)
+	space := strings.TrimSpace(ref.Space)
+	stack := strings.TrimSpace(ref.Stack)
+	cell := strings.TrimSpace(ref.Cell)
+	if realm == "" {
+		return fmt.Errorf("%w (secrets[%d] %q)", errdefs.ErrSecretRefRealmRequired, i, name)
+	}
+	if cell != "" && stack == "" {
+		return fmt.Errorf(
+			"%w (secrets[%d] %q: cell set without stack)", errdefs.ErrSecretRefScopeIncomplete, i, name,
+		)
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf(
+			"%w (secrets[%d] %q: stack set without space)", errdefs.ErrSecretRefScopeIncomplete, i, name,
+		)
 	}
 	return nil
 }

--- a/internal/apply/parser/parser_test.go
+++ b/internal/apply/parser/parser_test.go
@@ -448,6 +448,133 @@ spec:
 	}
 }
 
+func TestValidateDocument_Container_SecretRefValidFormsAccepted(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  secrets:
+    - name: ANTHROPIC_AUTH_TOKEN
+      secretRef:
+        name: anthropic-token
+        realm: kuke-system
+    - name: tls.crt
+      secretRef:
+        name: tls-cert
+        realm: default
+        space: ai
+        stack: agents
+        cell: claude
+      mountPath: /run/secrets/tls.crt
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+
+	if validationErr := parser.ValidateDocument(doc); validationErr != nil {
+		t.Fatalf("expected valid secretRef forms to pass, got: %v", validationErr)
+	}
+}
+
+func TestValidateDocument_Container_SecretRefValidation(t *testing.T) {
+	base := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  secrets:
+    - name: TOKEN
+      secretRef:
+`
+	cases := []struct {
+		name    string
+		refYAML string
+		wantErr error
+	}{
+		{
+			name:    "missing name",
+			refYAML: "        realm: kuke-system\n",
+			wantErr: errdefs.ErrSecretRefNameRequired,
+		},
+		{
+			name:    "missing realm",
+			refYAML: "        name: anthropic-token\n",
+			wantErr: errdefs.ErrSecretRefRealmRequired,
+		},
+		{
+			name:    "cell without stack",
+			refYAML: "        name: anthropic-token\n        realm: default\n        space: ai\n        cell: claude\n",
+			wantErr: errdefs.ErrSecretRefScopeIncomplete,
+		},
+		{
+			name:    "stack without space",
+			refYAML: "        name: anthropic-token\n        realm: default\n        stack: agents\n",
+			wantErr: errdefs.ErrSecretRefScopeIncomplete,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := parser.ParseDocument(0, []byte(base+tc.refYAML))
+			if err != nil {
+				t.Fatalf("ParseDocument failed: %v", err)
+			}
+			validationErr := parser.ValidateDocument(doc)
+			if validationErr == nil {
+				t.Fatalf("expected validation error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(validationErr.Error(), tc.wantErr.Error()) {
+				t.Errorf("expected %v, got: %v", tc.wantErr, validationErr)
+			}
+		})
+	}
+}
+
+func TestValidateDocument_Container_SecretRefRejectsExtraSource(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: Container
+metadata:
+  name: test-container
+spec:
+  id: test-container
+  realmId: r
+  spaceId: s
+  stackId: k
+  cellId: c
+  image: alpine:latest
+  secrets:
+    - name: TOKEN
+      fromEnv: SOME_ENV
+      secretRef:
+        name: anthropic-token
+        realm: kuke-system
+`
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+	validationErr := parser.ValidateDocument(doc)
+	if validationErr == nil {
+		t.Fatal("expected validation error for fromEnv + secretRef, got nil")
+	}
+	if !strings.Contains(validationErr.Error(), errdefs.ErrSecretMultipleSources.Error()) {
+		t.Errorf("expected ErrSecretMultipleSources, got: %v", validationErr)
+	}
+}
+
 func TestValidateDocument_Container_RepoValidation(t *testing.T) {
 	base := `apiVersion: v1beta1
 kind: Container

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -243,14 +243,20 @@ func (r *Exec) netPolicyEnforcer() netpolicy.Enforcer {
 }
 
 // daemonDefaultBuildOpts returns ctr.BuildOption entries that carry daemon-
-// wide knobs into ctr.BuildContainerSpec / ctr.BuildRootContainerSpec. Today
-// just the daemon-default memory cap (issue #531); returns nil when no
-// daemon-wide options are configured so existing call sites pay no cost.
+// wide knobs into ctr.BuildContainerSpec / ctr.BuildRootContainerSpec: the
+// daemon-default memory cap (issue #531) and the RunPath used to resolve a
+// ContainerSecret.secretRef from its scope's secrets tree (issue #623).
+// Returns nil when no daemon-wide options are configured so existing call
+// sites pay no cost.
 func (r *Exec) daemonDefaultBuildOpts() []ctr.BuildOption {
-	if r.opts.DefaultMemoryLimitBytes <= 0 {
-		return nil
+	var opts []ctr.BuildOption
+	if r.opts.DefaultMemoryLimitBytes > 0 {
+		opts = append(opts, ctr.WithDefaultMemoryLimit(r.opts.DefaultMemoryLimitBytes))
 	}
-	return []ctr.BuildOption{ctr.WithDefaultMemoryLimit(r.opts.DefaultMemoryLimitBytes)}
+	if r.opts.RunPath != "" {
+		opts = append(opts, ctr.WithSecretRunPath(r.opts.RunPath))
+	}
+	return opts
 }
 
 func (r *Exec) BootstrapCNI(cfgDir, cacheDir, binDir string) (cni.BootstrapReport, error) {

--- a/internal/controller/secret.go
+++ b/internal/controller/secret.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
 )
 
 // GetSecretResult reports the metadata-only view of a single `kind: Secret`
@@ -85,16 +86,27 @@ func (b *Exec) ListSecrets(realmName, spaceName, stackName, cellName string) ([]
 // Returns a "not found" error when the secret does not exist, matching the
 // DeleteRealm contract.
 //
-// NOTE: the live-reference safety gate the AC describes — refusing to delete a
-// Secret a running container still references via secretRef — is wired by the
-// separately-filed phase-3c slice that introduces the referencing path. Until
-// 3c lands, delete is unconditional; the verb's help text documents this
-// temporary unsafe-delete window.
+// Live-reference safety gate (issue #623, AC5): before unlinking, scan every
+// persisted cell's container specs for a secretRef pointing at this secret. If
+// any references it, refuse with ErrSecretInUse naming the referencing cells —
+// deleting the bytes out from under a live container would break it on its next
+// start. This mirrors the DeleteRealm dependency guard.
 func (b *Exec) DeleteSecret(secret intmodel.Secret) (DeleteSecretResult, error) {
 	var res DeleteSecretResult
 
 	if err := validateSecretLookup(secret.Metadata); err != nil {
 		return res, err
+	}
+
+	refs, err := b.secretReferences(secret.Metadata)
+	if err != nil {
+		return res, fmt.Errorf("%w: check live references: %w", errdefs.ErrDeleteSecret, err)
+	}
+	if len(refs) > 0 {
+		return res, fmt.Errorf(
+			"%w: secret %q is referenced by %d cell(s): %s. Delete or detach them before deleting the secret",
+			errdefs.ErrSecretInUse, secret.Metadata.Name, len(refs), strings.Join(refs, ", "),
+		)
 	}
 
 	if err := b.runner.DeleteSecret(secret); err != nil {
@@ -107,6 +119,47 @@ func (b *Exec) DeleteSecret(secret intmodel.Secret) (DeleteSecretResult, error) 
 	res.Deleted = true
 	res.Secret = secret
 	return res, nil
+}
+
+// secretReferences returns the scope paths of every persisted cell whose
+// container specs reference the given secret via secretRef. The match is by
+// resolved storage path (fs.SecretPath), so a reference and the target secret
+// are "the same secret" exactly when they resolve to the same on-disk file —
+// the identity the resolver (internal/ctr.readSecretRefValue) reads at
+// container start. Each referencing cell is listed once, even when several of
+// its containers reference the secret.
+func (b *Exec) secretReferences(md intmodel.SecretMetadata) ([]string, error) {
+	targetPath := fs.SecretPath(b.opts.RunPath, md.Realm, md.Space, md.Stack, md.Cell, md.Name)
+
+	cells, err := b.runner.ListCells("", "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	var refs []string
+	seen := make(map[string]struct{})
+	for _, cell := range cells {
+		scope := fmt.Sprintf("%s/%s/%s/%s",
+			cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name)
+		for _, c := range cell.Spec.Containers {
+			for _, s := range c.Secrets {
+				if s.SecretRef == nil {
+					continue
+				}
+				ref := s.SecretRef
+				refPath := fs.SecretPath(b.opts.RunPath, ref.Realm, ref.Space, ref.Stack, ref.Cell, ref.Name)
+				if refPath != targetPath {
+					continue
+				}
+				if _, ok := seen[scope]; ok {
+					continue
+				}
+				seen[scope] = struct{}{}
+				refs = append(refs, scope)
+			}
+		}
+	}
+	return refs, nil
 }
 
 // validateSecretLookup enforces the scope contract for a single-secret get or

--- a/internal/controller/secret_test.go
+++ b/internal/controller/secret_test.go
@@ -20,6 +20,7 @@ package controller_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -145,6 +146,7 @@ func TestListSecrets_PassesScopeThrough(t *testing.T) {
 
 func TestDeleteSecret_ReportsNotFound(t *testing.T) {
 	ctrl := setupTestController(t, &fakeRunner{
+		ListCellsFn: func(_, _, _ string) ([]intmodel.Cell, error) { return nil, nil },
 		DeleteSecretFn: func(_ intmodel.Secret) error {
 			return errdefs.ErrSecretNotFound
 		},
@@ -164,6 +166,7 @@ func TestDeleteSecret_ReportsNotFound(t *testing.T) {
 func TestDeleteSecret_Succeeds(t *testing.T) {
 	var deleted intmodel.Secret
 	ctrl := setupTestController(t, &fakeRunner{
+		ListCellsFn: func(_, _, _ string) ([]intmodel.Cell, error) { return nil, nil },
 		DeleteSecretFn: func(s intmodel.Secret) error {
 			deleted = s
 			return nil
@@ -181,5 +184,82 @@ func TestDeleteSecret_Succeeds(t *testing.T) {
 	}
 	if deleted.Metadata.Name != "tok" {
 		t.Errorf("runner received name %q, want tok", deleted.Metadata.Name)
+	}
+}
+
+// cellWithSecretRef builds a one-container cell whose single secret references
+// the given scoped secret, for exercising the live-reference delete guard.
+func cellWithSecretRef(cellName string, ref intmodel.ContainerSecretRef) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			RealmName: ref.Realm, SpaceName: "team-a", StackName: "web",
+			Containers: []intmodel.ContainerSpec{{
+				Secrets: []intmodel.ContainerSecret{{Name: "TOKEN", SecretRef: &ref}},
+			}},
+		},
+	}
+}
+
+// TestDeleteSecret_RefusesWhenReferenced pins AC5 (issue #623): delete is
+// refused while a cell's container references the secret via secretRef, the
+// error names the referencing cell, and the runner delete never fires.
+func TestDeleteSecret_RefusesWhenReferenced(t *testing.T) {
+	var deleteCalled bool
+	ctrl := setupTestController(t, &fakeRunner{
+		ListCellsFn: func(_, _, _ string) ([]intmodel.Cell, error) {
+			return []intmodel.Cell{
+				cellWithSecretRef("api", intmodel.ContainerSecretRef{Name: "tok", Realm: "default"}),
+			}, nil
+		},
+		DeleteSecretFn: func(_ intmodel.Secret) error {
+			deleteCalled = true
+			return nil
+		},
+	})
+
+	res, err := ctrl.DeleteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+	})
+	if !errors.Is(err, errdefs.ErrSecretInUse) {
+		t.Fatalf("DeleteSecret() error = %v, want ErrSecretInUse", err)
+	}
+	if res.Deleted {
+		t.Errorf("Deleted = true, want false when referenced")
+	}
+	if deleteCalled {
+		t.Errorf("runner.DeleteSecret called, want skipped when referenced")
+	}
+	if !strings.Contains(err.Error(), "api") {
+		t.Errorf("error %q does not name the referencing cell", err)
+	}
+}
+
+// TestDeleteSecret_IgnoresNonMatchingRef confirms a secretRef to a different
+// secret (different scope) does not block deletion — the match is by resolved
+// storage path, not by name alone.
+func TestDeleteSecret_IgnoresNonMatchingRef(t *testing.T) {
+	var deleteCalled bool
+	ctrl := setupTestController(t, &fakeRunner{
+		ListCellsFn: func(_, _, _ string) ([]intmodel.Cell, error) {
+			return []intmodel.Cell{
+				// Same name, different realm scope → different on-disk path.
+				cellWithSecretRef("api", intmodel.ContainerSecretRef{Name: "tok", Realm: "other"}),
+			}, nil
+		},
+		DeleteSecretFn: func(_ intmodel.Secret) error {
+			deleteCalled = true
+			return nil
+		},
+	})
+
+	res, err := ctrl.DeleteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteSecret() error = %v, want nil", err)
+	}
+	if !res.Deleted || !deleteCalled {
+		t.Errorf("Deleted=%v deleteCalled=%v, want both true for non-matching ref", res.Deleted, deleteCalled)
 	}
 }

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -544,12 +544,18 @@ func (c *client) CreateContainerFromSpec(
 	// Resolve declared secrets before building the OCI spec. Env entries are
 	// appended to containerSpec.Env (containerd stores these in its own
 	// runtime spec, not in kukeon metadata); file-mounted secrets are staged
-	// on the host at 0400 and added as read-only bind mounts.
+	// on the host at 0400 and added as read-only bind mounts. The daemon's
+	// RunPath (forwarded via WithSecretRunPath) lets a secretRef resolve from
+	// the referenced scope's secrets tree (issue #623).
 	containerdID := containerSpec.ContainerdID
 	if containerdID == "" {
 		containerdID = containerSpec.ID
 	}
-	resolved, err := resolveSecrets(containerdID, containerSpec.Secrets, DefaultSecretsStagingDir)
+	var bo buildOpts
+	for _, apply := range opts {
+		apply(&bo)
+	}
+	resolved, err := resolveSecrets(containerdID, containerSpec.Secrets, DefaultSecretsStagingDir, bo.secretRunPath)
 	if err != nil {
 		c.logger.ErrorContext(
 			c.ctx,

--- a/internal/ctr/secrets.go
+++ b/internal/ctr/secrets.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
 )
 
 // DefaultSecretsStagingDir is the host directory the daemon uses to stage
@@ -45,17 +46,23 @@ type resolvedSecrets struct {
 	MountAdds []intmodel.VolumeMount
 }
 
-// resolveSecrets reads each declared ContainerSecret from its host source
-// (file or env var) and returns env-var strings plus bind mounts for file
-// mode. Resolved values never appear in the returned strings beyond the env
-// entries themselves; callers must not log EnvAdds.
+// resolveSecrets reads each declared ContainerSecret from its source — a host
+// file (fromFile), a daemon-host env var (fromEnv), or a daemon-managed
+// kind: Secret (secretRef, issue #623) — and returns env-var strings plus bind
+// mounts for file mode. Resolved values never appear in the returned strings
+// beyond the env entries themselves; callers must not log EnvAdds.
 //
 // stagingDir is the host directory under which per-container secret files
-// are written (mode 0400). The directory is created on demand.
+// are written (mode 0400). The directory is created on demand. runPath is the
+// daemon's RunPath, used to locate secretRef material under the referenced
+// scope's secrets tree (the same <RunPath>/data/<scope>/secrets/<name> layout
+// the storage primitive writes — issue #619); callers that declare no
+// secretRef may pass "".
 func resolveSecrets(
 	containerdID string,
 	secrets []intmodel.ContainerSecret,
 	stagingDir string,
+	runPath string,
 ) (resolvedSecrets, error) {
 	var out resolvedSecrets
 	if len(secrets) == 0 {
@@ -75,12 +82,25 @@ func resolveSecrets(
 		if name == "" {
 			return resolvedSecrets{}, fmt.Errorf("%w (secrets[%d])", errdefs.ErrSecretNameRequired, i)
 		}
+		// Exactly one of fromFile / fromEnv / secretRef must be set. This is
+		// already enforced by the apply parser, but the runner is reachable
+		// from reconcile paths that bypass apply, so re-check defensively.
+		sources := 0
+		if fromFile != "" {
+			sources++
+		}
+		if fromEnv != "" {
+			sources++
+		}
+		if s.SecretRef != nil {
+			sources++
+		}
 		switch {
-		case fromFile == "" && fromEnv == "":
+		case sources == 0:
 			return resolvedSecrets{}, fmt.Errorf(
 				"%w (secrets[%d] %q)", errdefs.ErrSecretSourceRequired, i, name,
 			)
-		case fromFile != "" && fromEnv != "":
+		case sources > 1:
 			return resolvedSecrets{}, fmt.Errorf(
 				"%w (secrets[%d] %q)", errdefs.ErrSecretMultipleSources, i, name,
 			)
@@ -92,7 +112,7 @@ func resolveSecrets(
 			)
 		}
 
-		value, err := readSecretValue(fromFile, fromEnv, name)
+		value, err := readSecretValue(s, runPath)
 		if err != nil {
 			return resolvedSecrets{}, err
 		}
@@ -130,8 +150,15 @@ func resolveSecrets(
 	return out, nil
 }
 
-func readSecretValue(fromFile, fromEnv, name string) (string, error) {
-	if fromFile != "" {
+func readSecretValue(s intmodel.ContainerSecret, runPath string) (string, error) {
+	name := strings.TrimSpace(s.Name)
+	fromFile := strings.TrimSpace(s.FromFile)
+	fromEnv := strings.TrimSpace(s.FromEnv)
+
+	switch {
+	case s.SecretRef != nil:
+		return readSecretRefValue(*s.SecretRef, runPath, name)
+	case fromFile != "":
 		data, err := os.ReadFile(fromFile)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -143,15 +170,36 @@ func readSecretValue(fromFile, fromEnv, name string) (string, error) {
 			return "", fmt.Errorf("failed to read secret %q from %q: %w", name, fromFile, err)
 		}
 		return string(data), nil
+	default:
+		value, ok := os.LookupEnv(fromEnv)
+		if !ok {
+			return "", fmt.Errorf(
+				"%w (secret %q env %q)",
+				errdefs.ErrSecretFromEnvNotSet, name, fromEnv,
+			)
+		}
+		return value, nil
 	}
-	value, ok := os.LookupEnv(fromEnv)
-	if !ok {
-		return "", fmt.Errorf(
-			"%w (secret %q env %q)",
-			errdefs.ErrSecretFromEnvNotSet, name, fromEnv,
-		)
+}
+
+// readSecretRefValue reads a daemon-managed kind: Secret's bytes from its
+// scope's storage tree (issue #619 layout, fs.SecretPath). A missing file
+// surfaces ErrSecretRefNotFound naming the referenced secret and its expected
+// scope path; the path lets the operator confirm the scope, but the bytes are
+// never logged. Issue #623.
+func readSecretRefValue(ref intmodel.ContainerSecretRef, runPath, name string) (string, error) {
+	path := fs.SecretPath(runPath, ref.Realm, ref.Space, ref.Stack, ref.Cell, ref.Name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf(
+				"%w (secret %q ref %q at %q)",
+				errdefs.ErrSecretRefNotFound, name, ref.Name, path,
+			)
+		}
+		return "", fmt.Errorf("failed to read referenced secret %q from %q: %w", ref.Name, path, err)
 	}
-	return value, nil
+	return string(data), nil
 }
 
 // writeSecretFile writes the secret value atomically with 0400 perms so the

--- a/internal/ctr/secrets_test.go
+++ b/internal/ctr/secrets_test.go
@@ -24,7 +24,22 @@ import (
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
 )
+
+// writeScopedSecret stages a daemon-managed Secret's bytes at the #619 storage
+// layout under runPath so a secretRef resolution test can read them back.
+func writeScopedSecret(t *testing.T, runPath, realm, space, stack, cell, name, value string) {
+	t.Helper()
+	dir := fs.SecretsDir(runPath, realm, space, stack, cell)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir secrets dir: %v", err)
+	}
+	path := fs.SecretPath(runPath, realm, space, stack, cell, name)
+	if err := os.WriteFile(path, []byte(value), 0o600); err != nil {
+		t.Fatalf("write scoped secret: %v", err)
+	}
+}
 
 func TestResolveSecretsFromFileEnvInjection(t *testing.T) {
 	t.Parallel()
@@ -39,7 +54,7 @@ func TestResolveSecretsFromFileEnvInjection(t *testing.T) {
 		{Name: "ANTHROPIC_API_KEY", FromFile: secretPath},
 	}
 
-	got, err := resolveSecrets("cntr-1", secrets, filepath.Join(dir, "staging"))
+	got, err := resolveSecrets("cntr-1", secrets, filepath.Join(dir, "staging"), "")
 	if err != nil {
 		t.Fatalf("resolveSecrets: %v", err)
 	}
@@ -58,7 +73,7 @@ func TestResolveSecretsFromEnvInjection(t *testing.T) {
 		{Name: "GITHUB_TOKEN", FromEnv: "KUKEON_TEST_SCOPED_TOKEN"},
 	}
 
-	got, err := resolveSecrets("cntr-2", secrets, t.TempDir())
+	got, err := resolveSecrets("cntr-2", secrets, t.TempDir(), "")
 	if err != nil {
 		t.Fatalf("resolveSecrets: %v", err)
 	}
@@ -85,7 +100,7 @@ func TestResolveSecretsFileMountMode(t *testing.T) {
 		},
 	}
 
-	got, err := resolveSecrets("cntr-3", secrets, stagingDir)
+	got, err := resolveSecrets("cntr-3", secrets, stagingDir, "")
 	if err != nil {
 		t.Fatalf("resolveSecrets: %v", err)
 	}
@@ -130,7 +145,7 @@ func TestResolveSecretsMissingFileErrors(t *testing.T) {
 		{Name: "MISSING", FromFile: "/nonexistent/path/secret"},
 	}
 
-	_, err := resolveSecrets("cntr-4", secrets, t.TempDir())
+	_, err := resolveSecrets("cntr-4", secrets, t.TempDir(), "")
 	if err == nil {
 		t.Fatalf("expected error for missing file")
 	}
@@ -149,7 +164,7 @@ func TestResolveSecretsMissingEnvErrors(t *testing.T) {
 		{Name: "MISSING", FromEnv: "KUKEON_TEST_MISSING_SECRET_VAR"},
 	}
 
-	_, err := resolveSecrets("cntr-5", secrets, t.TempDir())
+	_, err := resolveSecrets("cntr-5", secrets, t.TempDir(), "")
 	if err == nil {
 		t.Fatalf("expected error for missing env var")
 	}
@@ -165,7 +180,7 @@ func TestResolveSecretsRejectsMultipleSources(t *testing.T) {
 		{Name: "BOTH", FromFile: "/tmp/x", FromEnv: "Y"},
 	}
 
-	_, err := resolveSecrets("cntr-6", secrets, t.TempDir())
+	_, err := resolveSecrets("cntr-6", secrets, t.TempDir(), "")
 	if !errors.Is(err, errdefs.ErrSecretMultipleSources) {
 		t.Fatalf("want ErrSecretMultipleSources, got %v", err)
 	}
@@ -176,7 +191,7 @@ func TestResolveSecretsRejectsMissingSource(t *testing.T) {
 
 	secrets := []intmodel.ContainerSecret{{Name: "NOSRC"}}
 
-	_, err := resolveSecrets("cntr-7", secrets, t.TempDir())
+	_, err := resolveSecrets("cntr-7", secrets, t.TempDir(), "")
 	if !errors.Is(err, errdefs.ErrSecretSourceRequired) {
 		t.Fatalf("want ErrSecretSourceRequired, got %v", err)
 	}
@@ -189,7 +204,7 @@ func TestResolveSecretsRejectsRelativeMountPath(t *testing.T) {
 		{Name: "X", FromEnv: "HOME", MountPath: "relative/path"},
 	}
 
-	_, err := resolveSecrets("cntr-8", secrets, t.TempDir())
+	_, err := resolveSecrets("cntr-8", secrets, t.TempDir(), "")
 	if !errors.Is(err, errdefs.ErrSecretMountPathNotAbsolute) {
 		t.Fatalf("want ErrSecretMountPathNotAbsolute, got %v", err)
 	}
@@ -198,7 +213,7 @@ func TestResolveSecretsRejectsRelativeMountPath(t *testing.T) {
 func TestResolveSecretsEmptySliceIsNoop(t *testing.T) {
 	t.Parallel()
 
-	got, err := resolveSecrets("cntr-9", nil, "")
+	got, err := resolveSecrets("cntr-9", nil, "", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -221,7 +236,7 @@ func TestResolveSecretsMixesEnvAndMountModes(t *testing.T) {
 		{Name: "tls.crt", FromFile: certPath, MountPath: "/run/secrets/tls.crt"},
 	}
 
-	got, err := resolveSecrets("cntr-10", secrets, stagingDir)
+	got, err := resolveSecrets("cntr-10", secrets, stagingDir, "")
 	if err != nil {
 		t.Fatalf("resolveSecrets: %v", err)
 	}
@@ -230,5 +245,109 @@ func TestResolveSecretsMixesEnvAndMountModes(t *testing.T) {
 	}
 	if len(got.MountAdds) != 1 || got.MountAdds[0].Target != "/run/secrets/tls.crt" {
 		t.Fatalf("mount adds = %#v", got.MountAdds)
+	}
+}
+
+func TestResolveSecretsFromSecretRefEnvInjection(t *testing.T) {
+	t.Parallel()
+
+	runPath := t.TempDir()
+	// Stage a kuke-system-realm-scoped Secret; the referencing container need
+	// not live in that scope — the ref names its own scope coordinates.
+	writeScopedSecret(t, runPath, "kuke-system", "", "", "", "anthropic-token", "sk-ant-ref")
+
+	secrets := []intmodel.ContainerSecret{
+		{
+			Name:      "ANTHROPIC_AUTH_TOKEN",
+			SecretRef: &intmodel.ContainerSecretRef{Name: "anthropic-token", Realm: "kuke-system"},
+		},
+	}
+
+	got, err := resolveSecrets("cntr-ref-1", secrets, t.TempDir(), runPath)
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+	if len(got.MountAdds) != 0 {
+		t.Fatalf("expected no mount adds, got %d", len(got.MountAdds))
+	}
+	if len(got.EnvAdds) != 1 || got.EnvAdds[0] != "ANTHROPIC_AUTH_TOKEN=sk-ant-ref" {
+		t.Fatalf("unexpected env adds: %#v", got.EnvAdds)
+	}
+}
+
+func TestResolveSecretsFromSecretRefMountMode(t *testing.T) {
+	t.Parallel()
+
+	runPath := t.TempDir()
+	stagingDir := t.TempDir()
+	writeScopedSecret(t, runPath, "default", "ai", "agents", "claude", "tls.crt", "-----BEGIN CERT-----")
+
+	secrets := []intmodel.ContainerSecret{
+		{
+			Name: "tls.crt",
+			SecretRef: &intmodel.ContainerSecretRef{
+				Name:  "tls.crt",
+				Realm: "default",
+				Space: "ai",
+				Stack: "agents",
+				Cell:  "claude",
+			},
+			MountPath: "/etc/secrets/tls.crt",
+		},
+	}
+
+	got, err := resolveSecrets("cntr-ref-2", secrets, stagingDir, runPath)
+	if err != nil {
+		t.Fatalf("resolveSecrets: %v", err)
+	}
+	if len(got.EnvAdds) != 0 {
+		t.Fatalf("expected no env adds, got %#v", got.EnvAdds)
+	}
+	if len(got.MountAdds) != 1 {
+		t.Fatalf("expected 1 mount add, got %d", len(got.MountAdds))
+	}
+	wantSource := filepath.Join(stagingDir, "cntr-ref-2", "tls.crt")
+	if got.MountAdds[0].Source != wantSource {
+		t.Fatalf("mount source = %q want %q", got.MountAdds[0].Source, wantSource)
+	}
+	data, err := os.ReadFile(wantSource)
+	if err != nil {
+		t.Fatalf("read staged file: %v", err)
+	}
+	if string(data) != "-----BEGIN CERT-----" {
+		t.Fatalf("staged contents = %q", data)
+	}
+}
+
+func TestResolveSecretsSecretRefMissingErrors(t *testing.T) {
+	t.Parallel()
+
+	secrets := []intmodel.ContainerSecret{
+		{
+			Name:      "ABSENT",
+			SecretRef: &intmodel.ContainerSecretRef{Name: "no-such-secret", Realm: "kuke-system"},
+		},
+	}
+
+	_, err := resolveSecrets("cntr-ref-3", secrets, t.TempDir(), t.TempDir())
+	if !errors.Is(err, errdefs.ErrSecretRefNotFound) {
+		t.Fatalf("want ErrSecretRefNotFound, got %v", err)
+	}
+}
+
+func TestResolveSecretsRejectsRefPlusOtherSource(t *testing.T) {
+	t.Parallel()
+
+	secrets := []intmodel.ContainerSecret{
+		{
+			Name:      "BOTH",
+			FromEnv:   "HOME",
+			SecretRef: &intmodel.ContainerSecretRef{Name: "x", Realm: "kuke-system"},
+		},
+	}
+
+	_, err := resolveSecrets("cntr-ref-4", secrets, t.TempDir(), t.TempDir())
+	if !errors.Is(err, errdefs.ErrSecretMultipleSources) {
+		t.Fatalf("want ErrSecretMultipleSources, got %v", err)
 	}
 }

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -178,6 +178,7 @@ type BuildOption func(*buildOpts)
 type buildOpts struct {
 	attachable              AttachableInjection
 	defaultMemoryLimitBytes int64
+	secretRunPath           string
 }
 
 // WithAttachableInjection configures the host-side paths used when wrapping
@@ -199,6 +200,21 @@ func WithDefaultMemoryLimit(bytes int64) BuildOption {
 	return func(o *buildOpts) {
 		if bytes > 0 {
 			o.defaultMemoryLimitBytes = bytes
+		}
+	}
+}
+
+// WithSecretRunPath carries the daemon's RunPath into CreateContainerFromSpec
+// so a ContainerSecret with a secretRef can be resolved from the referenced
+// scope's secrets tree (<RunPath>/data/<scope>/secrets/<name>, issue #619).
+// Has no effect on BuildContainerSpec itself — the value is consumed by
+// resolveSecrets before the OCI spec is built. An empty argument is a no-op so
+// callers can pass it unconditionally; specs that declare no secretRef never
+// touch the path. Issue #623.
+func WithSecretRunPath(runPath string) BuildOption {
+	return func(o *buildOpts) {
+		if runPath != "" {
+			o.secretRunPath = runPath
 		}
 	}
 }

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -284,12 +284,21 @@ var (
 	// Secret-related errors.
 
 	ErrSecretNameRequired         = errors.New("secret name is required")
-	ErrSecretSourceRequired       = errors.New("secret requires exactly one of fromFile or fromEnv")
-	ErrSecretMultipleSources      = errors.New("secret must not set both fromFile and fromEnv")
+	ErrSecretSourceRequired       = errors.New("secret requires exactly one of fromFile, fromEnv, or secretRef")
+	ErrSecretMultipleSources      = errors.New("secret must set exactly one of fromFile, fromEnv, or secretRef")
 	ErrSecretMountPathNotAbsolute = errors.New("secret mountPath must be an absolute container path")
 	ErrSecretFromFileNotFound     = errors.New("secret fromFile path does not exist on the host")
 	ErrSecretFromEnvNotSet        = errors.New("secret fromEnv env var is not set on the daemon host")
 	ErrSecretStagingFailed        = errors.New("failed to stage secret file for mount")
+
+	// ContainerSecret.secretRef source errors (issue #623).
+
+	ErrSecretRefNameRequired    = errors.New("secret secretRef.name is required")
+	ErrSecretRefRealmRequired   = errors.New("secret secretRef.realm is required")
+	ErrSecretRefScopeIncomplete = errors.New(
+		"secret secretRef scope is incomplete: a deeper scope coordinate requires all shallower ones",
+	)
+	ErrSecretRefNotFound = errors.New("referenced secret does not exist in the requested scope")
 
 	// Secret kind (kind: Secret) storage-primitive errors (issue #619).
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -299,6 +299,7 @@ var (
 		"secret secretRef scope is incomplete: a deeper scope coordinate requires all shallower ones",
 	)
 	ErrSecretRefNotFound = errors.New("referenced secret does not exist in the requested scope")
+	ErrSecretInUse       = errors.New("secret is referenced by a live container via secretRef")
 
 	// Secret kind (kind: Secret) storage-primitive errors (issue #619).
 

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -150,12 +150,25 @@ func (t *ContainerTty) IsEmpty() bool {
 // ContainerSecret references a credential resolved by the daemon at apply
 // time. Only the reference is persisted in the hub; the resolved value lives
 // only in the OCI runtime spec (for env injection) or in the staged secret
-// file (for mount mode).
+// file (for mount mode). Exactly one source must be set: FromFile, FromEnv, or
+// SecretRef (a daemon-managed kind: Secret, issue #623).
 type ContainerSecret struct {
 	Name      string
 	FromFile  string
 	FromEnv   string
+	SecretRef *ContainerSecretRef
 	MountPath string
+}
+
+// ContainerSecretRef mirrors the v1beta1 ContainerSecretRef payload — a name +
+// scope pointing at a daemon-managed kind: Secret (issue #619). See the
+// v1beta1 type for the scope-coordinate contract. Issue #623.
+type ContainerSecretRef struct {
+	Name  string
+	Realm string
+	Space string
+	Stack string
+	Cell  string
 }
 
 // VolumeKind discriminates between the supported VolumeMount kinds. An empty

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -225,11 +225,39 @@ func (t *ContainerTty) IsEmpty() bool {
 // (default) or as a read-only file when MountPath is set. Only the reference
 // is persisted; the resolved value is never written to status, metadata, or
 // logs.
+//
+// Exactly one source must be set: FromFile (host-path reference), FromEnv
+// (daemon-host env var), or SecretRef (a daemon-managed kind: Secret resolved
+// from its scope's storage tree, issue #623). The env-vs-file dispatch is the
+// same for all three: empty MountPath injects an env var, a set MountPath
+// stages a read-only file mount.
 type ContainerSecret struct {
-	Name      string `json:"name"                yaml:"name"`
-	FromFile  string `json:"fromFile,omitempty"  yaml:"fromFile,omitempty"`
-	FromEnv   string `json:"fromEnv,omitempty"   yaml:"fromEnv,omitempty"`
-	MountPath string `json:"mountPath,omitempty" yaml:"mountPath,omitempty"`
+	Name      string              `json:"name"                yaml:"name"`
+	FromFile  string              `json:"fromFile,omitempty"  yaml:"fromFile,omitempty"`
+	FromEnv   string              `json:"fromEnv,omitempty"   yaml:"fromEnv,omitempty"`
+	SecretRef *ContainerSecretRef `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	MountPath string              `json:"mountPath,omitempty" yaml:"mountPath,omitempty"`
+}
+
+// ContainerSecretRef points at a daemon-managed kind: Secret (issue #619) by
+// name and scope. The scope follows the same coordinate contract as
+// SecretMetadata: Realm is always required and a deeper coordinate may only be
+// set when every shallower one is (a cell-scoped reference must also name its
+// stack, space, and realm). The reference resolves to the same on-disk path
+// the Secret's bytes were written to, so a container in one realm may
+// reference a Secret owned by another (e.g. a workload in `default` reading a
+// `kuke-system`-scoped token). Issue #623.
+type ContainerSecretRef struct {
+	// Name is the referenced Secret's name within its scope. Required.
+	Name string `json:"name"            yaml:"name"`
+	// Realm is the always-required top-level scope coordinate.
+	Realm string `json:"realm"           yaml:"realm"`
+	// Space, when set, scopes the reference to a space within Realm.
+	Space string `json:"space,omitempty" yaml:"space,omitempty"`
+	// Stack, when set, scopes the reference to a stack within Space.
+	Stack string `json:"stack,omitempty" yaml:"stack,omitempty"`
+	// Cell, when set, scopes the reference to a cell within Stack.
+	Cell string `json:"cell,omitempty"  yaml:"cell,omitempty"`
 }
 
 // VolumeKind discriminates between the supported VolumeMount kinds. Mirrors
@@ -538,6 +566,14 @@ func cloneSecrets(in []ContainerSecret) []ContainerSecret {
 
 	out := make([]ContainerSecret, len(in))
 	copy(out, in)
+	// copy() is shallow: deep-copy the SecretRef pointer so a clone never
+	// shares the referent struct with the original.
+	for i := range out {
+		if in[i].SecretRef != nil {
+			ref := *in[i].SecretRef
+			out[i].SecretRef = &ref
+		}
+	}
 	return out
 }
 


### PR DESCRIPTION
## Summary
- Adds a third `ContainerSecret` source, `secretRef`, pointing at a daemon-managed `kind: Secret` (#619) by name + scope, alongside the existing `fromFile`/`fromEnv`.
- Container start resolves `secretRef` → reads bytes from the #619 storage layout via `fs.SecretPath`, then feeds the existing `resolvedSecrets` env/mount dispatch (no new injection machinery).
- Apply-time validation: exactly one of `fromFile`/`fromEnv`/`secretRef`; for `secretRef`, name + realm required and deeper scope coordinates require every shallower one.
- **AC5 delete-blocking guard (added in review fix-up `bbc4169`):** `kuke delete secret` now refuses while any persisted cell's container references the secret via `secretRef`, with an error naming the referencing cells (`ErrSecretInUse`). Matching is by resolved `fs.SecretPath`, so a reference and the target are "the same secret" exactly when they resolve to the same on-disk file. The stale `unsafeDeleteWarning` help text and its test were replaced with the new guard contract.

## Implementation notes (for reviewer)
- **AC storage-path divergence:** the issue's AC cites `/opt/kukeon/<scope>/secrets/<name>`, but the actual #619 layout is `<RunPath>/data/<scope>/secrets/<name>`. Reused `fs.SecretPath` (the #619 helper) rather than hardcoding the AC's literal path, so resolution tracks the real layout. RunPath is threaded into the spec builder via a new `WithSecretRunPath` option, injected once in `daemonDefaultBuildOpts`.
- **AC5 placement (resolved):** the issue's ordering note assigns the delete-blocking AC to "whichever lands second" between #622/#3b and this. Phase 3b (#664) has merged, so per the issue's own framing it lands here — implemented in `internal/controller/secret.go`'s `DeleteSecret` (the guard scans `runner.ListCells` for matching `secretRef`s). The earlier deferral note was wrong and is withdrawn.
- **"Live" scope:** the guard blocks on any cell whose persisted spec references the secret (not just running cells) — deleting the bytes would break a stopped-but-declared cell on its next start. Mirrors the `DeleteRealm` dependency guard.

## Test plan
- [x] `make test` (full CI target, `GOWORK=off`; 92 packages green incl. new guard tests in `internal/controller/secret_test.go`)
- [x] `go vet ./...` (`GOWORK=off`)
- [x] `go build ./...` (`GOWORK=off`)
- [x] `make dev-init` smoke (daemon-parity check passed — from the original PR run)
- [ ] `make e2e` — environmental: image pulls fail on this host (`lookup registry-1.docker.io ... i/o timeout`); no code-related failures. CI `make e2e` is green.

> Note on the earlier "ambiguous genproto import" build note: the real cause is the `go.work` workspace union (kukebuild's go-1.25 BuildKit closure vs. the root module's graph are deliberately incompatible). `go.work` itself documents that builds/tests must run per-module with `GOWORK=off`, which is what `make` and CI do. With `GOWORK=off` the build/vet/test all pass locally.

Closes #623