### PR TITLE
feat(build): kuke build flags phase 2a — secrets + local cache

### DIFF
--- a/cmd/kuke/build/build.go
+++ b/cmd/kuke/build/build.go
@@ -53,14 +53,22 @@ var (
 // NewBuildCmd builds the `kuke build` subcommand.
 func NewBuildCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "build [-f Dockerfile] [-t name:tag] [--realm <name>] [--build-arg K=V]... <context>",
+		Use: "build [-f Dockerfile] [-t name:tag] [--realm <name>] [--build-arg K=V]... " +
+			"[--secret id=NAME,src=PATH]... [--cache-to type=local,dest=PATH]... " +
+			"[--cache-from type=local,src=PATH]... <context>",
 		Short: "Build an OCI image from a Dockerfile into a realm's containerd namespace",
 		Long: "Build an OCI image from a Dockerfile using kukeon's native builder.\n\n" +
 			"`kuke build` is a thin shim: it locates the `kukebuild` binary on PATH and\n" +
 			"exec's it. `kukebuild` embeds BuildKit, builds the context with the Dockerfile\n" +
 			"frontend, and writes the resulting image into the containerd namespace mapped\n" +
 			"to --realm (<realm>.kukeon.io), ready for `kuke image get` and `kuke create`.\n\n" +
-			"No docker or standalone buildkitd is required — only a running host containerd.",
+			"No docker or standalone buildkitd is required — only a running host containerd.\n\n" +
+			"Build-time secrets: --secret id=NAME,src=PATH mounts a host file into the build\n" +
+			"at /run/secrets/NAME, consumed by a Dockerfile `RUN --mount=type=secret,id=NAME`.\n" +
+			"File-based secrets only; the flag is repeatable.\n\n" +
+			"Build cache: --cache-to type=local,dest=PATH exports the build cache to a local\n" +
+			"directory and --cache-from type=local,src=PATH imports it back, reusing layers\n" +
+			"across builds. Only type=local is supported; both flags are repeatable.",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -76,6 +84,13 @@ func NewBuildCmd() *cobra.Command {
 		"",
 		"Path to kukeond.yaml; resolves the realm namespace suffix (default /etc/kukeon/kukeond.yaml)",
 	)
+	cmd.Flags().StringArray(
+		"secret",
+		nil,
+		"Expose a file secret to the build at /run/secrets/NAME: id=NAME,src=PATH (repeatable)",
+	)
+	cmd.Flags().StringArray("cache-to", nil, "Export build cache: type=local,dest=PATH (repeatable)")
+	cmd.Flags().StringArray("cache-from", nil, "Import build cache: type=local,src=PATH (repeatable)")
 
 	return cmd
 }
@@ -137,6 +152,18 @@ func buildArgv(cmd *cobra.Command, args []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	secrets, err := cmd.Flags().GetStringArray("secret")
+	if err != nil {
+		return nil, err
+	}
+	cacheTo, err := cmd.Flags().GetStringArray("cache-to")
+	if err != nil {
+		return nil, err
+	}
+	cacheFrom, err := cmd.Flags().GetStringArray("cache-from")
+	if err != nil {
+		return nil, err
+	}
 
 	argv := []string{kukebuildBinary, "--tag", tag, "--realm", realm}
 	if strings.TrimSpace(file) != "" {
@@ -147,6 +174,15 @@ func buildArgv(cmd *cobra.Command, args []string) ([]string, error) {
 	}
 	for _, ba := range buildArgs {
 		argv = append(argv, "--build-arg", ba)
+	}
+	for _, s := range secrets {
+		argv = append(argv, "--secret", s)
+	}
+	for _, c := range cacheTo {
+		argv = append(argv, "--cache-to", c)
+	}
+	for _, c := range cacheFrom {
+		argv = append(argv, "--cache-from", c)
 	}
 	// Context directory is positional and validated by cobra.ExactArgs(1).
 	argv = append(argv, args[0])

--- a/cmd/kuke/build/build_test.go
+++ b/cmd/kuke/build/build_test.go
@@ -117,6 +117,43 @@ func TestRunBuildExecHandoff(t *testing.T) {
 	}
 }
 
+func TestRunBuildForwardsSecretsAndCache(t *testing.T) {
+	var gotArgv []string
+	withStubs(t,
+		func(string) (string, error) { return "/usr/local/bin/kukebuild", nil },
+		func(_ string, argv []string, _ []string) error { gotArgv = argv; return nil },
+	)
+
+	cmd := NewBuildCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{
+		"-t", "x:1",
+		"--secret", "id=npmrc,src=/host/.npmrc",
+		"--secret", "id=tok,src=/host/tok",
+		"--cache-to", "type=local,dest=/cache/out",
+		"--cache-from", "type=local,src=/cache/in",
+		".",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: unexpected error: %v", err)
+	}
+	want := []string{
+		"kukebuild",
+		"--tag", "x:1",
+		"--realm", consts.KukeonDefaultRealmName,
+		"--secret", "id=npmrc,src=/host/.npmrc",
+		"--secret", "id=tok,src=/host/tok",
+		"--cache-to", "type=local,dest=/cache/out",
+		"--cache-from", "type=local,src=/cache/in",
+		".",
+	}
+	if !reflect.DeepEqual(gotArgv, want) {
+		t.Errorf("argv = %v, want %v", gotArgv, want)
+	}
+}
+
 func TestRunBuildForwardsKukeondConfig(t *testing.T) {
 	var gotArgv []string
 	withStubs(t,

--- a/cmd/kukebuild/build.go
+++ b/cmd/kukebuild/build.go
@@ -29,12 +29,15 @@ import (
 	ctd "github.com/containerd/containerd/v2/client"
 	ctddefaults "github.com/containerd/containerd/v2/defaults"
 	"github.com/distribution/reference"
+	"github.com/moby/buildkit/cache/remotecache"
+	localremotecache "github.com/moby/buildkit/cache/remotecache/local"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/control"
 	"github.com/moby/buildkit/frontend"
 	dockerfile "github.com/moby/buildkit/frontend/dockerfile/builder"
 	"github.com/moby/buildkit/frontend/gateway/forwarder"
 	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/secrets/secretsprovider"
 	"github.com/moby/buildkit/solver"
 	"github.com/moby/buildkit/solver/bboltcachestorage"
 	"github.com/moby/buildkit/util/db/boltutil"
@@ -237,7 +240,7 @@ func newSolveOpt(cfg *buildConfig) (*client.SolveOpt, error) {
 		return nil, err
 	}
 
-	return &client.SolveOpt{
+	solveOpt := &client.SolveOpt{
 		Frontend:      dockerfileFrontend,
 		FrontendAttrs: frontendAttrs,
 		LocalMounts: map[string]fsutil.FS{
@@ -256,16 +259,48 @@ func newSolveOpt(cfg *buildConfig) (*client.SolveOpt, error) {
 				},
 			},
 		},
-	}, nil
+	}
+
+	// Build secrets ride in on a session attachable: the Dockerfile frontend
+	// requests a secret by id over the session, and the secretsprovider serves
+	// it from the host file. A RUN step opts in with
+	// --mount=type=secret,id=<id>, which BuildKit mounts at /run/secrets/<id>.
+	// NewStore stats each src up front, so a missing/oversized secret file
+	// fails fast here rather than mid-solve.
+	if len(cfg.secrets) > 0 {
+		sources := make([]secretsprovider.Source, 0, len(cfg.secrets))
+		for _, s := range cfg.secrets {
+			sources = append(sources, secretsprovider.Source{ID: s.id, FilePath: s.src})
+		}
+		store, err := secretsprovider.NewStore(sources)
+		if err != nil {
+			return nil, fmt.Errorf("prepare build secrets: %w", err)
+		}
+		solveOpt.Session = append(solveOpt.Session, secretsprovider.NewSecretProvider(store))
+	}
+
+	// Local cache export/import: the BuildKit client wires the dest/src dirs
+	// into a content store and the session itself (see client.parseCacheOptions
+	// for type=local), so kukebuild only has to forward the entries.
+	for _, ce := range cfg.cacheExports {
+		solveOpt.CacheExports = append(solveOpt.CacheExports, client.CacheOptionsEntry{Type: ce.typ, Attrs: ce.attrs})
+	}
+	for _, ci := range cfg.cacheImports {
+		solveOpt.CacheImports = append(solveOpt.CacheImports, client.CacheOptionsEntry{Type: ci.typ, Attrs: ci.attrs})
+	}
+
+	return solveOpt, nil
 }
 
 // newController assembles BuildKit's in-process Controller backed by a
 // containerd worker pointed at cfg.containerdSocket and scoped to the realm's
 // containerd namespace. It mirrors buildkitd's own newController
-// (cmd/buildkitd/main.go) trimmed to the phase-1 surface: the Dockerfile
-// frontend only, no remote-cache import/export resolvers (those are phase 2a,
-// #523), no tracing, no gateway frontend. The returned cleanup closes the
-// history DB and the worker controller; callers must defer it.
+// (cmd/buildkitd/main.go) trimmed to the phase-1/2a surface: the Dockerfile
+// frontend only, no registry-backed cache resolvers (registry/s3/gha cache is
+// deferred — phase 2a only wires local-disk cache, which the BuildKit client
+// handles via content stores, no controller-side resolver), no tracing, no
+// gateway frontend. The returned cleanup closes the history DB and the worker
+// controller; callers must defer it.
 func newController(ctx context.Context, cfg *buildConfig, namespace string) (*control.Controller, func(), error) {
 	sessionManager, err := session.NewManager()
 	if err != nil {
@@ -297,12 +332,22 @@ func newController(ctx context.Context, cfg *buildConfig, namespace string) (*co
 		WorkerController: wc,
 		Frontends:        frontends,
 		CacheManager:     solver.NewCacheManager(ctx, "local", cacheStorage, worker.NewCacheResultStorage(wc)),
-		HistoryDB:        historyDB,
-		CacheStore:       cacheStorage,
-		LeaseManager:     w.LeaseManager(),
-		ContentStore:     w.ContentStore(),
-		GarbageCollect:   w.GarbageCollect,
-		GracefulStop:     ctx.Done(),
+		// Register the local-disk cache exporter/importer so --cache-to /
+		// --cache-from type=local resolve (issue #523). Registry/s3/gha backends
+		// are deferred — only "local" is wired, matching buildkitd's
+		// remoteCacheExporterFuncs map trimmed to the phase-2a surface.
+		ResolveCacheExporterFuncs: map[string]remotecache.ResolveCacheExporterFunc{
+			"local": localremotecache.ResolveCacheExporterFunc(sessionManager),
+		},
+		ResolveCacheImporterFuncs: map[string]remotecache.ResolveCacheImporterFunc{
+			"local": localremotecache.ResolveCacheImporterFunc(sessionManager),
+		},
+		HistoryDB:      historyDB,
+		CacheStore:     cacheStorage,
+		LeaseManager:   w.LeaseManager(),
+		ContentStore:   w.ContentStore(),
+		GarbageCollect: w.GarbageCollect,
+		GracefulStop:   ctx.Done(),
 	})
 	if err != nil {
 		_ = historyDB.Close()

--- a/cmd/kukebuild/build_test.go
+++ b/cmd/kukebuild/build_test.go
@@ -16,7 +16,73 @@
 
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newSolveOptFixture writes a minimal build context (an empty Dockerfile) into
+// a temp dir and returns a buildConfig pointed at it. Callers add secrets /
+// cache entries before calling newSolveOpt.
+func newSolveOptFixture(t *testing.T) *buildConfig {
+	t.Helper()
+	dir := t.TempDir()
+	dockerfile := filepath.Join(dir, "Dockerfile")
+	if err := os.WriteFile(dockerfile, []byte("FROM scratch\n"), 0o600); err != nil {
+		t.Fatalf("write Dockerfile: %v", err)
+	}
+	return &buildConfig{contextDir: dir, dockerfile: dockerfile, tag: "x:1"}
+}
+
+func TestNewSolveOptWiresCache(t *testing.T) {
+	cfg := newSolveOptFixture(t)
+	cfg.cacheExports = []cacheSpec{{typ: "local", attrs: map[string]string{"dest": "/c/out"}}}
+	cfg.cacheImports = []cacheSpec{{typ: "local", attrs: map[string]string{"src": "/c/in"}}}
+
+	so, err := newSolveOpt(cfg)
+	if err != nil {
+		t.Fatalf("newSolveOpt: %v", err)
+	}
+	if len(so.CacheExports) != 1 || so.CacheExports[0].Type != "local" ||
+		so.CacheExports[0].Attrs["dest"] != "/c/out" {
+		t.Errorf("CacheExports = %+v, want one local dest=/c/out", so.CacheExports)
+	}
+	if len(so.CacheImports) != 1 || so.CacheImports[0].Type != "local" ||
+		so.CacheImports[0].Attrs["src"] != "/c/in" {
+		t.Errorf("CacheImports = %+v, want one local src=/c/in", so.CacheImports)
+	}
+	if len(so.Session) != 0 {
+		t.Errorf("Session = %d entries, want 0 when no secrets", len(so.Session))
+	}
+}
+
+func TestNewSolveOptWiresSecrets(t *testing.T) {
+	cfg := newSolveOptFixture(t)
+	secretFile := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(secretFile, []byte("s3cr3t"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	cfg.secrets = []secretSpec{{id: "tok", src: secretFile}}
+
+	so, err := newSolveOpt(cfg)
+	if err != nil {
+		t.Fatalf("newSolveOpt: %v", err)
+	}
+	// One secretsprovider attachable is added to the session.
+	if len(so.Session) != 1 {
+		t.Errorf("Session = %d entries, want 1 secrets provider", len(so.Session))
+	}
+}
+
+func TestNewSolveOptSecretFileMissing(t *testing.T) {
+	cfg := newSolveOptFixture(t)
+	cfg.secrets = []secretSpec{{id: "tok", src: filepath.Join(t.TempDir(), "does-not-exist")}}
+
+	if _, err := newSolveOpt(cfg); err == nil {
+		t.Fatal("newSolveOpt: expected error for missing secret file, got nil")
+	}
+}
 
 func TestResolveBuildRoot(t *testing.T) {
 	cases := []struct {

--- a/cmd/kukebuild/main.go
+++ b/cmd/kukebuild/main.go
@@ -41,9 +41,10 @@
 // Phase 1 (#522) wires the engine and validates a trivial single-stage
 // Dockerfile. Phase 1b (#616) validated multi-stage, COPY --from=, --build-arg
 // and --platform=$BUILDPLATFORM against kukeon's own Dockerfile end-to-end
-// (host network mode + the default overlayfs snapshotter sufficed). The
-// --secret / --cache-* / --push / --platform-flag surface is deferred to the
-// phase 2 follow-ups (#523, #524, #646).
+// (host network mode + the default overlayfs snapshotter sufficed). Phase 2a
+// (#523) adds build-time file secrets (--secret) and local-disk cache
+// export/import (--cache-to / --cache-from). The --push / --platform-flag
+// surface remains deferred to the phase 2 follow-ups (#524, #646).
 package main
 
 import (
@@ -149,6 +150,32 @@ type buildConfig struct {
 	// back to /etc/kukeon/kukeond.yaml and then the hardcoded default suffix;
 	// see resolveNamespaceSuffix.
 	kukeondConfig string
+	// secrets are the --secret entries: build-time file secrets exposed to the
+	// Dockerfile at /run/secrets/<id> via RUN --mount=type=secret,id=<id>.
+	// File-based only in phase 2a (#523); env-var-source secrets are deferred.
+	secrets []secretSpec
+	// cacheExports / cacheImports are the --cache-to / --cache-from entries,
+	// forwarded to BuildKit's CacheExports / CacheImports. Scoped to
+	// type=local (local-disk export/import) in phase 2a (#523); registry/s3/gha
+	// backends are deferred.
+	cacheExports []cacheSpec
+	cacheImports []cacheSpec
+}
+
+// secretSpec is a resolved --secret entry: a build secret named id, sourced
+// from the host file at src. BuildKit exposes it inside a RUN step that opts in
+// with --mount=type=secret,id=<id> at the BuildKit-standard /run/secrets/<id>.
+type secretSpec struct {
+	id  string
+	src string
+}
+
+// cacheSpec is a resolved --cache-to / --cache-from entry: a BuildKit cache
+// backend type plus its attributes (e.g. type=local with dest/src). Forwarded
+// verbatim to BuildKit's CacheOptionsEntry.
+type cacheSpec struct {
+	typ   string
+	attrs map[string]string
 }
 
 // defaultContainerdSocket is the standalone host containerd socket the
@@ -211,6 +238,13 @@ func parseArgs(args []string) (*buildConfig, error) {
 	var buildArgs repeatableFlag
 	fs.Var(&buildArgs, "build-arg", "set a build-time variable KEY=VALUE (repeatable)")
 
+	var secrets repeatableFlag
+	fs.Var(&secrets, "secret", "expose a file secret to the build at /run/secrets/NAME: id=NAME,src=PATH (repeatable)")
+	var cacheTo repeatableFlag
+	fs.Var(&cacheTo, "cache-to", "export build cache: type=local,dest=PATH (repeatable)")
+	var cacheFrom repeatableFlag
+	fs.Var(&cacheFrom, "cache-from", "import build cache: type=local,src=PATH (repeatable)")
+
 	if err := fs.Parse(args); err != nil {
 		return nil, &usageError{msg: err.Error()}
 	}
@@ -243,6 +277,19 @@ func parseArgs(args []string) (*buildConfig, error) {
 		return nil, err
 	}
 
+	parsedSecrets, err := parseSecrets(secrets)
+	if err != nil {
+		return nil, err
+	}
+	parsedCacheExports, err := parseCacheOpts(cacheTo, "cache-to")
+	if err != nil {
+		return nil, err
+	}
+	parsedCacheImports, err := parseCacheOpts(cacheFrom, "cache-from")
+	if err != nil {
+		return nil, err
+	}
+
 	dockerfile := *file
 	if strings.TrimSpace(dockerfile) == "" {
 		dockerfile = filepath.Join(contextDir, "Dockerfile")
@@ -258,6 +305,9 @@ func parseArgs(args []string) (*buildConfig, error) {
 		root:             strings.TrimSpace(*root),
 		rootExplicit:     rootExplicit,
 		kukeondConfig:    strings.TrimSpace(*kukeondConfig),
+		secrets:          parsedSecrets,
+		cacheExports:     parsedCacheExports,
+		cacheImports:     parsedCacheImports,
 	}, nil
 }
 
@@ -272,6 +322,102 @@ func parseBuildArgs(raw []string) (map[string]string, error) {
 			return nil, &usageError{msg: fmt.Sprintf("invalid --build-arg %q: expected KEY=VALUE", kv)}
 		}
 		out[k] = v
+	}
+	return out, nil
+}
+
+// parseCSVPairs splits a comma-separated KEY=VALUE list (e.g.
+// "id=NAME,src=PATH") into a map. Empty segments are skipped; a segment without
+// an `=` or with an empty key is a usage error attributed to --<flag>. The
+// caller validates the recognized keys.
+func parseCSVPairs(flag, raw string) (map[string]string, error) {
+	out := map[string]string{}
+	for _, seg := range strings.Split(raw, ",") {
+		if strings.TrimSpace(seg) == "" {
+			continue
+		}
+		k, v, ok := strings.Cut(seg, "=")
+		k = strings.TrimSpace(k)
+		if !ok || k == "" {
+			return nil, &usageError{msg: fmt.Sprintf("invalid --%s %q: expected comma-separated KEY=VALUE pairs", flag, raw)}
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// parseSecrets turns the raw --secret values into resolved secretSpecs. The
+// supported form is `id=NAME,src=PATH`: a host file exposed to the build at
+// /run/secrets/NAME. Both keys are required, env-var-source secrets (`env=…`)
+// are rejected as deferred (issue #523 out-of-scope), and an unknown key is a
+// usage error so a typo surfaces at parse time.
+func parseSecrets(raw []string) ([]secretSpec, error) {
+	out := make([]secretSpec, 0, len(raw))
+	for _, s := range raw {
+		kv, err := parseCSVPairs("secret", s)
+		if err != nil {
+			return nil, err
+		}
+		if env, ok := kv["env"]; ok {
+			return nil, &usageError{msg: fmt.Sprintf(
+				"invalid --secret %q: env-var-source secrets (env=%s) are not supported yet; use src=PATH", s, env)}
+		}
+		for k := range kv {
+			if k != "id" && k != "src" {
+				return nil, &usageError{msg: fmt.Sprintf("invalid --secret %q: unknown key %q (expected id, src)", s, k)}
+			}
+		}
+		id := strings.TrimSpace(kv["id"])
+		src := strings.TrimSpace(kv["src"])
+		if id == "" {
+			return nil, &usageError{msg: fmt.Sprintf("invalid --secret %q: id is required (id=NAME,src=PATH)", s)}
+		}
+		if src == "" {
+			return nil, &usageError{msg: fmt.Sprintf("invalid --secret %q: src is required — file-based secrets only (id=NAME,src=PATH)", s)}
+		}
+		out = append(out, secretSpec{id: id, src: src})
+	}
+	return out, nil
+}
+
+// parseCacheOpts turns the raw --cache-to / --cache-from values into resolved
+// cacheSpecs. Only `type=local` is supported in phase 2a (#523): cache-to
+// requires `dest=PATH`, cache-from requires `src=PATH`. A missing or non-local
+// type, or a missing path, is a usage error; registry/s3/gha backends are
+// rejected as deferred. All non-type keys are forwarded verbatim to BuildKit so
+// optional local-cache attrs (e.g. mode, compression) pass through.
+func parseCacheOpts(raw []string, flag string) ([]cacheSpec, error) {
+	requiredAttr := "dest"
+	if flag == "cache-from" {
+		requiredAttr = "src"
+	}
+	out := make([]cacheSpec, 0, len(raw))
+	for _, s := range raw {
+		kv, err := parseCSVPairs(flag, s)
+		if err != nil {
+			return nil, err
+		}
+		typ := strings.TrimSpace(kv["type"])
+		if typ == "" {
+			return nil, &usageError{msg: fmt.Sprintf(
+				"invalid --%s %q: type is required (only type=local is supported)", flag, s)}
+		}
+		if typ != "local" {
+			return nil, &usageError{msg: fmt.Sprintf(
+				"invalid --%s %q: type=%s is not supported yet; only type=local (local-disk cache) is available", flag, s, typ)}
+		}
+		if strings.TrimSpace(kv[requiredAttr]) == "" {
+			return nil, &usageError{msg: fmt.Sprintf(
+				"invalid --%s %q: type=local requires %s=PATH", flag, s, requiredAttr)}
+		}
+		attrs := make(map[string]string, len(kv))
+		for k, v := range kv {
+			if k == "type" {
+				continue
+			}
+			attrs[k] = v
+		}
+		out = append(out, cacheSpec{typ: typ, attrs: attrs})
 	}
 	return out, nil
 }

--- a/cmd/kukebuild/main_test.go
+++ b/cmd/kukebuild/main_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"errors"
 	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -95,6 +96,83 @@ func TestParseArgsAllFlags(t *testing.T) {
 	// A value containing '=' must survive intact (only the first '=' splits).
 	if cfg.buildArgs["BAZ"] != "qux=quux" {
 		t.Errorf("buildArgs[BAZ] = %q, want qux=quux", cfg.buildArgs["BAZ"])
+	}
+}
+
+func TestParseArgsSecretsAndCache(t *testing.T) {
+	cfg, err := parseArgs([]string{
+		"-t", "x:1",
+		"--secret", "id=npmrc,src=/host/.npmrc",
+		"--secret", "id=tok,src=/host/tok",
+		"--cache-to", "type=local,dest=/cache/out",
+		"--cache-from", "type=local,src=/cache/in",
+		"/ctx",
+	})
+	if err != nil {
+		t.Fatalf("parseArgs: unexpected error: %v", err)
+	}
+	wantSecrets := []secretSpec{
+		{id: "npmrc", src: "/host/.npmrc"},
+		{id: "tok", src: "/host/tok"},
+	}
+	if !reflect.DeepEqual(cfg.secrets, wantSecrets) {
+		t.Errorf("secrets = %+v, want %+v", cfg.secrets, wantSecrets)
+	}
+	if len(cfg.cacheExports) != 1 || cfg.cacheExports[0].typ != "local" ||
+		cfg.cacheExports[0].attrs["dest"] != "/cache/out" {
+		t.Errorf("cacheExports = %+v, want one local entry dest=/cache/out", cfg.cacheExports)
+	}
+	if len(cfg.cacheImports) != 1 || cfg.cacheImports[0].typ != "local" ||
+		cfg.cacheImports[0].attrs["src"] != "/cache/in" {
+		t.Errorf("cacheImports = %+v, want one local entry src=/cache/in", cfg.cacheImports)
+	}
+}
+
+func TestParseSecretsForwardsExtraCacheAttrs(t *testing.T) {
+	// Non-type cache attrs (e.g. mode) pass through to BuildKit verbatim.
+	cfg, err := parseArgs([]string{
+		"-t", "x:1",
+		"--cache-to", "type=local,dest=/c,mode=max",
+		"/ctx",
+	})
+	if err != nil {
+		t.Fatalf("parseArgs: unexpected error: %v", err)
+	}
+	if got := cfg.cacheExports[0].attrs["mode"]; got != "max" {
+		t.Errorf("cacheExports[0].attrs[mode] = %q, want max", got)
+	}
+	if _, ok := cfg.cacheExports[0].attrs["type"]; ok {
+		t.Error("type must not be carried in attrs (it is the cacheSpec.typ field)")
+	}
+}
+
+func TestParseSecretsUsageErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"secret missing id", []string{"-t", "x:1", "--secret", "src=/p", "/ctx"}},
+		{"secret missing src", []string{"-t", "x:1", "--secret", "id=n", "/ctx"}},
+		{"secret env source deferred", []string{"-t", "x:1", "--secret", "id=n,env=TOKEN", "/ctx"}},
+		{"secret unknown key", []string{"-t", "x:1", "--secret", "id=n,src=/p,foo=bar", "/ctx"}},
+		{"secret no equals", []string{"-t", "x:1", "--secret", "id", "/ctx"}},
+		{"cache-to missing type", []string{"-t", "x:1", "--cache-to", "dest=/c", "/ctx"}},
+		{"cache-to non-local type", []string{"-t", "x:1", "--cache-to", "type=registry,ref=r", "/ctx"}},
+		{"cache-to missing dest", []string{"-t", "x:1", "--cache-to", "type=local", "/ctx"}},
+		{"cache-from missing src", []string{"-t", "x:1", "--cache-from", "type=local", "/ctx"}},
+		{"cache-from non-local type", []string{"-t", "x:1", "--cache-from", "type=s3", "/ctx"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseArgs(tc.args)
+			if err == nil {
+				t.Fatalf("parseArgs(%v): expected error, got nil", tc.args)
+			}
+			var ue *usageError
+			if !errors.As(err, &ue) {
+				t.Errorf("parseArgs(%v): error %v is not a *usageError", tc.args, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds two build-input flag surfaces to `kuke build` / `kukebuild` on top of the phase-1 engine (#522). Output shape and destination are unchanged — same image into the target realm's containerd namespace.
- **`--secret id=NAME,src=PATH`** (repeatable): mounts a host file into the build at the BuildKit-standard `/run/secrets/NAME`, consumed by `RUN --mount=type=secret,id=NAME`. Wired via a `secretsprovider` session attachable. File-based only; `env=…` sources are rejected with a "deferred" usage error.
- **`--cache-to type=local,dest=PATH` / `--cache-from type=local,src=PATH`** (each repeatable): local-disk BuildKit cache export/import. Forwarded to the client's `CacheExports`/`CacheImports`, and the controller now registers the `local` cache exporter/importer funcs. Only `type=local` is accepted; `registry`/`s3`/`gha` are rejected with a "deferred" usage error.
- `kuke build` shim forwards all three flags verbatim to `kukebuild`; `--help` documents each flag and its spec syntax.

## Implementation notes (for reviewer)

- **Controller-side cache registration was required, not just client-side.** Setting `SolveOpt.CacheExports` alone yields `failed to solve: unknown cache exporter: "local"` — the in-process controller must also register `ResolveCacheExporterFuncs["local"]` / `ResolveCacheImporterFuncs["local"]` (buildkitd does this in `cmd/buildkitd/main.go:851`). I trimmed the map to `local` only; registry/s3/gha remain deferred, matching the issue's out-of-scope list. Caught by the end-to-end smoke below, not by unit tests.
- **Spec parsing** lives in `cmd/kukebuild/main.go` (`parseSecrets`, `parseCacheOpts`, shared `parseCSVPairs`), matching the existing `parseBuildArgs` style. Unknown `--secret` keys, missing `id`/`src`, missing/non-local cache `type`, and missing `dest`/`src` all surface as typed `usageError`s at parse time.
- Non-`type` cache attrs (e.g. `mode=max`) pass through to BuildKit verbatim; `type` is lifted into the `cacheSpec.typ` field and not duplicated in `attrs`.
- Stale doc comments updated: the `main.go` package doc and `newController`'s "phase 2a #523" deferral note now reflect that local cache + secrets have landed.

## Test plan

- [x] `make test` (root module + `cmd/kukebuild` module) — all green.
- [x] `go build ./...` + `go vet ./...` in the `cmd/kukebuild` module.
- [x] `go mod tidy` in `cmd/kukebuild` — no `go.mod`/`go.sum` diff (new imports already in closure).
- [x] **AC1 — secret mount, end-to-end:** built a busybox Dockerfile with `RUN --mount=type=secret,id=mytoken test "$(cat /run/secrets/mytoken)" = "TOPSECRET-VALUE-42"` against a real host containerd; build log printed `SECRET-OK: TOPSECRET-VALUE-42`.
- [x] **AC2 — local cache reuse, end-to-end:** `--cache-to type=local,dest=…` wrote the BuildKit local layout (`blobs/`, `index.json`, `oci-layout`); a second build with the per-namespace state root wiped and `--cache-from type=local,src=…` showed `importing cache manifest from local:…` then `CACHED` for both RUN layers.
- [x] **AC3 — colocated tests:** added in `cmd/kukebuild/main_test.go` (parse + usage errors), `cmd/kukebuild/build_test.go` (`newSolveOpt` secret/cache wiring), `cmd/kuke/build/build_test.go` (shim forwarding).
- [x] **AC4 — help text:** `kuke build --help` documents `--secret`, `--cache-to`, `--cache-from` and the spec syntax.

Closes #523