### PR TITLE
feat(build): add kuke build --push + registry auth (phase 2b)

### DIFF
--- a/cmd/kuke/build/build.go
+++ b/cmd/kuke/build/build.go
@@ -55,7 +55,7 @@ func NewBuildCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "build [-f Dockerfile] [-t name:tag] [--realm <name>] [--build-arg K=V]... " +
 			"[--secret id=NAME,src=PATH]... [--cache-to type=local,dest=PATH]... " +
-			"[--cache-from type=local,src=PATH]... <context>",
+			"[--cache-from type=local,src=PATH]... [--push] <context>",
 		Short: "Build an OCI image from a Dockerfile into a realm's containerd namespace",
 		Long: "Build an OCI image from a Dockerfile using kukeon's native builder.\n\n" +
 			"`kuke build` is a thin shim: it locates the `kukebuild` binary on PATH and\n" +
@@ -68,7 +68,13 @@ func NewBuildCmd() *cobra.Command {
 			"File-based secrets only; the flag is repeatable.\n\n" +
 			"Build cache: --cache-to type=local,dest=PATH exports the build cache to a local\n" +
 			"directory and --cache-from type=local,src=PATH imports it back, reusing layers\n" +
-			"across builds. Only type=local is supported; both flags are repeatable.",
+			"across builds. Only type=local is supported; both flags are repeatable.\n\n" +
+			"Registry push: --push pushes the built image to its tag's registry after a\n" +
+			"successful build. The tag must be a fully qualified registry reference\n" +
+			"(REGISTRY/REPO:TAG); a bare name:tag is rejected. Push is additive — the image\n" +
+			"is still written to the realm's containerd namespace. Credentials resolve in\n" +
+			"order: (1) $DOCKER_CONFIG/config.json when DOCKER_CONFIG is set, (2)\n" +
+			"~/.docker/config.json, (3) the KUKEON_REGISTRY_AUTH env var (base64 user:pass).",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -91,6 +97,13 @@ func NewBuildCmd() *cobra.Command {
 	)
 	cmd.Flags().StringArray("cache-to", nil, "Export build cache: type=local,dest=PATH (repeatable)")
 	cmd.Flags().StringArray("cache-from", nil, "Import build cache: type=local,src=PATH (repeatable)")
+	cmd.Flags().Bool(
+		"push",
+		false,
+		"After a successful build, push the image to its tag's registry (requires a fully qualified "+
+			"REGISTRY/REPO:TAG); credentials resolve from $DOCKER_CONFIG/config.json, then ~/.docker/config.json, "+
+			"then $KUKEON_REGISTRY_AUTH",
+	)
 
 	return cmd
 }
@@ -164,6 +177,10 @@ func buildArgv(cmd *cobra.Command, args []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	push, err := cmd.Flags().GetBool("push")
+	if err != nil {
+		return nil, err
+	}
 
 	argv := []string{kukebuildBinary, "--tag", tag, "--realm", realm}
 	if strings.TrimSpace(file) != "" {
@@ -183,6 +200,9 @@ func buildArgv(cmd *cobra.Command, args []string) ([]string, error) {
 	}
 	for _, c := range cacheFrom {
 		argv = append(argv, "--cache-from", c)
+	}
+	if push {
+		argv = append(argv, "--push")
 	}
 	// Context directory is positional and validated by cobra.ExactArgs(1).
 	argv = append(argv, args[0])

--- a/cmd/kuke/build/build_test.go
+++ b/cmd/kuke/build/build_test.go
@@ -181,6 +181,56 @@ func TestRunBuildForwardsKukeondConfig(t *testing.T) {
 	}
 }
 
+func TestRunBuildForwardsPush(t *testing.T) {
+	var gotArgv []string
+	withStubs(t,
+		func(string) (string, error) { return "/usr/local/bin/kukebuild", nil },
+		func(_ string, argv []string, _ []string) error { gotArgv = argv; return nil },
+	)
+
+	cmd := NewBuildCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"-t", "registry:5000/app:dev", "--push", "."})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: unexpected error: %v", err)
+	}
+	want := []string{
+		"kukebuild",
+		"--tag", "registry:5000/app:dev",
+		"--realm", consts.KukeonDefaultRealmName,
+		"--push",
+		".",
+	}
+	if !reflect.DeepEqual(gotArgv, want) {
+		t.Errorf("argv = %v, want %v", gotArgv, want)
+	}
+}
+
+// Without --push the shim forwards no --push flag (it is a boolean default-off).
+func TestRunBuildNoPushByDefault(t *testing.T) {
+	var gotArgv []string
+	withStubs(t,
+		func(string) (string, error) { return "/usr/local/bin/kukebuild", nil },
+		func(_ string, argv []string, _ []string) error { gotArgv = argv; return nil },
+	)
+
+	cmd := NewBuildCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"-t", "x:1", "."})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: unexpected error: %v", err)
+	}
+	for _, a := range gotArgv {
+		if a == "--push" {
+			t.Errorf("argv = %v, must not contain --push when the flag is unset", gotArgv)
+		}
+	}
+}
+
 func TestRunBuildDefaultRealm(t *testing.T) {
 	var gotArgv []string
 	withStubs(t,

--- a/cmd/kukebuild/auth.go
+++ b/cmd/kukebuild/auth.go
@@ -1,0 +1,205 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/distribution/reference"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
+)
+
+// envKukeonRegistryAuth is the ephemeral / CI credential fallback: a
+// base64-encoded `user:pass` matching the docker-config `auth` field. It is
+// consulted only when neither $DOCKER_CONFIG/config.json nor
+// ~/.docker/config.json carries credentials for the target registry host —
+// step 3 of the --push credential precedence (issue #524).
+const envKukeonRegistryAuth = "KUKEON_REGISTRY_AUTH"
+
+// dockerHubDomain is the domain reference.Domain returns for a docker-hub
+// reference (e.g. docker.io/library/app:dev). Docker stores hub credentials
+// under a distinct config-file key (authprovider.DockerHubConfigfileKey), so
+// the KUKEON_REGISTRY_AUTH fallback for an explicit docker.io push must be
+// injected under that key, not "docker.io", to be served back to BuildKit.
+const dockerHubDomain = "docker.io"
+
+// hasExplicitRegistry reports whether tag names a registry host explicitly. It
+// mirrors docker's splitDockerDomain heuristic (github.com/distribution/
+// reference): the segment before the first '/' is a registry host only when it
+// is "localhost" or contains a '.' or ':'. A bare `name:tag`, or a docker-hub
+// `user/repo:tag` that would silently normalize to docker.io, is therefore not
+// explicit — `--push` requires the operator to name the registry so a push
+// never lands somewhere unintended.
+func hasExplicitRegistry(tag string) bool {
+	i := strings.IndexByte(tag, '/')
+	if i < 0 {
+		return false
+	}
+	prefix := tag[:i]
+	return prefix == "localhost" || strings.ContainsAny(prefix, ".:")
+}
+
+// requirePushableReference enforces the --push contract: the -t tag must be a
+// fully qualified registry reference. Returns a *usageError otherwise so main()
+// maps it to exitCodeUsage.
+func requirePushableReference(tag string) error {
+	if !hasExplicitRegistry(tag) {
+		return &usageError{msg: fmt.Sprintf(
+			"--push requires a fully qualified registry reference: REGISTRY/REPO:TAG (got %q)", tag)}
+	}
+	return nil
+}
+
+// registryHost returns the registry host of a reference, e.g. "registry:5000"
+// for "registry:5000/app:dev" or "ghcr.io" for "ghcr.io/eminwux/kukeon:v1". It
+// is the AuthConfigs key under which the KUKEON_REGISTRY_AUTH fallback is
+// injected and the host the anonymous-rejection error names.
+func registryHost(tag string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(tag)
+	if err != nil {
+		return "", fmt.Errorf("invalid image tag %q: %w", tag, err)
+	}
+	return reference.Domain(named), nil
+}
+
+// authConfigKey maps a registry host to the docker config-file key under which
+// its credentials live. Every host keys under itself except docker hub, whose
+// credentials docker stores under the legacy index URL — the same mapping
+// BuildKit's authprovider applies when it serves credentials back.
+func authConfigKey(host string) string {
+	if host == dockerHubDomain || host == authprovider.DockerHubRegistryHost {
+		return authprovider.DockerHubConfigfileKey
+	}
+	return host
+}
+
+// dockerConfigDir resolves the docker config directory using the --push
+// credential precedence's first two layers: $DOCKER_CONFIG when set, else
+// ~/.docker. getenv is injected so the resolver is unit-testable without
+// touching the host environment.
+func dockerConfigDir(getenv func(string) string) string {
+	if d := strings.TrimSpace(getenv("DOCKER_CONFIG")); d != "" {
+		return d
+	}
+	if home := strings.TrimSpace(getenv("HOME")); home != "" {
+		return filepath.Join(home, ".docker")
+	}
+	return ""
+}
+
+// hasCreds reports whether cf carries inline credentials for key. It inspects
+// the AuthConfigs map directly rather than calling GetAuthConfig so the check
+// never execs a credential helper. Helper-sourced credentials still flow to the
+// push through authprovider.LoadAuthConfig (which does consult helpers) — this
+// signal only tailors the anonymous-rejection error message.
+func hasCreds(cf *configfile.ConfigFile, key string) bool {
+	ac, ok := cf.AuthConfigs[key]
+	if !ok {
+		return false
+	}
+	return ac.Username != "" || ac.Password != "" || ac.Auth != "" ||
+		ac.IdentityToken != "" || ac.RegistryToken != ""
+}
+
+// resolveRegistryAuth builds the docker-compatible credential config kukebuild
+// hands BuildKit's auth provider for a push to host. Precedence (issue #524):
+//
+//  1. $DOCKER_CONFIG/config.json when DOCKER_CONFIG is set;
+//  2. else ~/.docker/config.json when present;
+//  3. else the KUKEON_REGISTRY_AUTH env var (base64 user:pass), applied only
+//     when layers 1-2 carry no entry for host.
+//
+// credsFound reports whether any layer yielded inline credentials for host, so
+// the caller can tailor an anonymous-rejection error. getenv is injected for
+// testability.
+func resolveRegistryAuth(getenv func(string) string, host string) (*configfile.ConfigFile, bool, error) {
+	cf, err := config.Load(dockerConfigDir(getenv))
+	if err != nil {
+		return nil, false, fmt.Errorf("load docker registry config: %w", err)
+	}
+	key := authConfigKey(host)
+	credsFound := hasCreds(cf, key)
+	if !credsFound {
+		if raw := strings.TrimSpace(getenv(envKukeonRegistryAuth)); raw != "" {
+			cf.AuthConfigs[key] = types.AuthConfig{ServerAddress: host, Auth: raw}
+			credsFound = true
+		}
+	}
+	return cf, credsFound, nil
+}
+
+// newAuthProvider resolves registry credentials for host per the --push
+// precedence and wraps them in a BuildKit session attachable. credsFound flows
+// through so a later anonymous-rejection can name the precedence list.
+func newAuthProvider(getenv func(string) string, host string) (session.Attachable, bool, error) {
+	cf, credsFound, err := resolveRegistryAuth(getenv, host)
+	if err != nil {
+		return nil, false, err
+	}
+	ap := authprovider.NewDockerAuthProvider(authprovider.DockerAuthProviderConfig{
+		AuthConfigProvider: authprovider.LoadAuthConfig(cf),
+	})
+	return ap, credsFound, nil
+}
+
+// isRegistryAuthError reports whether err looks like a registry rejecting the
+// push for authentication/authorization reasons. BuildKit / containerd surface
+// these as opaque wrapped strings, so this matches the canonical registry-auth
+// substrings rather than a typed error. Used only to decide whether to rewrite
+// a push failure into the credential-precedence hint.
+func isRegistryAuthError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"401",
+		"403",
+		"unauthorized",
+		"authentication required",
+		"failed to authorize",
+		"denied",
+		"no basic auth credentials",
+		"forbidden",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// pushAuthError rewrites a push failure that looks like a registry auth
+// rejection into a message that points the operator at the credential
+// precedence list. When no credentials resolved (credsFound is false) the
+// message leads with "no credentials for <host>"; when credentials did resolve
+// but were rejected, it points at verifying them.
+func pushAuthError(tag, host string, credsFound bool, cause error) error {
+	const precedence = "(1) $DOCKER_CONFIG/config.json, (2) ~/.docker/config.json, " +
+		"(3) the KUKEON_REGISTRY_AUTH env var (base64 user:pass)"
+	if !credsFound {
+		return fmt.Errorf(
+			"push %q failed: no credentials for %s. kukebuild resolves registry credentials in order: %s — "+
+				"supply one of these for the registry: %w", tag, host, precedence, cause)
+	}
+	return fmt.Errorf(
+		"push %q failed: %s rejected the resolved credentials. kukebuild resolves registry credentials in order: %s — "+
+			"verify the credentials for this registry: %w", tag, host, precedence, cause)
+}

--- a/cmd/kukebuild/auth_test.go
+++ b/cmd/kukebuild/auth_test.go
@@ -1,0 +1,308 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moby/buildkit/session/auth/authprovider"
+)
+
+func TestHasExplicitRegistry(t *testing.T) {
+	cases := []struct {
+		tag  string
+		want bool
+	}{
+		{"app:dev", false},
+		{"app", false},
+		{"eminwux/kukeon:v1", false}, // docker-hub repo, not an explicit host
+		{"library/app:dev", false},
+		{"ghcr.io/eminwux/kukeon:v1", true},
+		{"docker.io/library/app:dev", true},
+		{"registry:5000/app:dev", true},
+		{"localhost/app:dev", true},
+		{"localhost:5000/app:dev", true},
+		{"myregistry.local/app", true},
+	}
+	for _, tc := range cases {
+		if got := hasExplicitRegistry(tc.tag); got != tc.want {
+			t.Errorf("hasExplicitRegistry(%q) = %v, want %v", tc.tag, got, tc.want)
+		}
+	}
+}
+
+func TestRequirePushableReference(t *testing.T) {
+	// A bare reference is a usageError naming the required form.
+	err := requirePushableReference("app:dev")
+	if err == nil {
+		t.Fatal("requirePushableReference(app:dev): expected error, got nil")
+	}
+	var ue *usageError
+	if !errors.As(err, &ue) {
+		t.Errorf("error %v is not a *usageError", err)
+	}
+	if !strings.Contains(err.Error(), "REGISTRY/REPO:TAG") {
+		t.Errorf("error %q does not name the required form REGISTRY/REPO:TAG", err)
+	}
+	// A fully qualified reference passes.
+	if err := requirePushableReference("registry:5000/app:dev"); err != nil {
+		t.Errorf("requirePushableReference(registry:5000/app:dev): unexpected error: %v", err)
+	}
+}
+
+func TestRegistryHost(t *testing.T) {
+	cases := []struct {
+		tag  string
+		want string
+	}{
+		{"registry:5000/app:dev", "registry:5000"},
+		{"ghcr.io/eminwux/kukeon:v1", "ghcr.io"},
+		{"localhost:5000/app", "localhost:5000"},
+		{"docker.io/library/app:dev", "docker.io"},
+	}
+	for _, tc := range cases {
+		got, err := registryHost(tc.tag)
+		if err != nil {
+			t.Errorf("registryHost(%q): unexpected error: %v", tc.tag, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("registryHost(%q) = %q, want %q", tc.tag, got, tc.want)
+		}
+	}
+}
+
+func TestAuthConfigKey(t *testing.T) {
+	if got := authConfigKey("registry:5000"); got != "registry:5000" {
+		t.Errorf("authConfigKey(registry:5000) = %q, want registry:5000", got)
+	}
+	if got := authConfigKey("docker.io"); got != authprovider.DockerHubConfigfileKey {
+		t.Errorf("authConfigKey(docker.io) = %q, want %q", got, authprovider.DockerHubConfigfileKey)
+	}
+	if got := authConfigKey(authprovider.DockerHubRegistryHost); got != authprovider.DockerHubConfigfileKey {
+		t.Errorf("authConfigKey(%q) = %q, want %q",
+			authprovider.DockerHubRegistryHost, got, authprovider.DockerHubConfigfileKey)
+	}
+}
+
+// writeDockerConfig writes a minimal docker config.json carrying an auth entry
+// for host into a temp dir and returns that dir (for use as DOCKER_CONFIG).
+func writeDockerConfig(t *testing.T, host, userPass string) string {
+	t.Helper()
+	dir := t.TempDir()
+	auth := base64.StdEncoding.EncodeToString([]byte(userPass))
+	doc := `{"auths":{"` + host + `":{"auth":"` + auth + `"}}}`
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(doc), 0o600); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	return dir
+}
+
+// fakeEnv returns a getenv backed by a fixed map, so the resolver's env
+// precedence is exercised without touching the host environment.
+func fakeEnv(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestResolveRegistryAuthDockerConfig(t *testing.T) {
+	dir := writeDockerConfig(t, "registry:5000", "alice:secret")
+	cf, found, err := resolveRegistryAuth(fakeEnv(map[string]string{"DOCKER_CONFIG": dir}), "registry:5000")
+	if err != nil {
+		t.Fatalf("resolveRegistryAuth: %v", err)
+	}
+	if !found {
+		t.Error("credsFound = false, want true when DOCKER_CONFIG carries the host")
+	}
+	// docker's loader decodes the `auth` field into Username/Password, so assert
+	// via hasCreds rather than the (now-cleared) Auth string.
+	if !hasCreds(cf, "registry:5000") {
+		t.Error("expected the docker-config credentials to survive into the config file")
+	}
+}
+
+func TestResolveRegistryAuthHomeFallback(t *testing.T) {
+	// No DOCKER_CONFIG: resolution falls through to $HOME/.docker/config.json.
+	home := t.TempDir()
+	docker := filepath.Join(home, ".docker")
+	if err := os.MkdirAll(docker, 0o700); err != nil {
+		t.Fatalf("mkdir .docker: %v", err)
+	}
+	auth := base64.StdEncoding.EncodeToString([]byte("bob:pw"))
+	doc := `{"auths":{"ghcr.io":{"auth":"` + auth + `"}}}`
+	if err := os.WriteFile(filepath.Join(docker, "config.json"), []byte(doc), 0o600); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	cf, found, err := resolveRegistryAuth(fakeEnv(map[string]string{"HOME": home}), "ghcr.io")
+	if err != nil {
+		t.Fatalf("resolveRegistryAuth: %v", err)
+	}
+	if !found {
+		t.Error("credsFound = false, want true when ~/.docker/config.json carries the host")
+	}
+	if !hasCreds(cf, "ghcr.io") {
+		t.Error("expected the ~/.docker credentials to survive into the config file")
+	}
+}
+
+func TestResolveRegistryAuthEnvFallback(t *testing.T) {
+	// No docker config at all (empty HOME dir, no DOCKER_CONFIG): the
+	// KUKEON_REGISTRY_AUTH env var supplies the credentials.
+	raw := base64.StdEncoding.EncodeToString([]byte("ci:token"))
+	cf, found, err := resolveRegistryAuth(fakeEnv(map[string]string{
+		"HOME":                t.TempDir(),
+		envKukeonRegistryAuth: raw,
+	}), "registry:5000")
+	if err != nil {
+		t.Fatalf("resolveRegistryAuth: %v", err)
+	}
+	if !found {
+		t.Error("credsFound = false, want true when KUKEON_REGISTRY_AUTH is set")
+	}
+	if got := cf.AuthConfigs["registry:5000"].Auth; got != raw {
+		t.Errorf("AuthConfigs[registry:5000].Auth = %q, want %q", got, raw)
+	}
+}
+
+func TestResolveRegistryAuthDockerConfigBeatsEnv(t *testing.T) {
+	// When DOCKER_CONFIG carries the host, the env fallback must not override it
+	// — the env var is only a fallback (precedence step 3).
+	dir := writeDockerConfig(t, "registry:5000", "alice:fromconfig")
+	envAuth := base64.StdEncoding.EncodeToString([]byte("ci:fromenv"))
+	cf, found, err := resolveRegistryAuth(fakeEnv(map[string]string{
+		"DOCKER_CONFIG":       dir,
+		envKukeonRegistryAuth: envAuth,
+	}), "registry:5000")
+	if err != nil {
+		t.Fatalf("resolveRegistryAuth: %v", err)
+	}
+	if !found {
+		t.Fatal("credsFound = false, want true")
+	}
+	// The docker-config credential (alice, decoded into Username) must win — the
+	// env fallback is applied only when the config carries no entry for the host.
+	if got := cf.AuthConfigs["registry:5000"].Username; got != "alice" {
+		t.Errorf("AuthConfigs[registry:5000].Username = %q, want the docker-config value \"alice\" (env must not override)", got)
+	}
+}
+
+func TestResolveRegistryAuthNoneResolve(t *testing.T) {
+	// No docker config, no env var: nothing resolves and credsFound is false so
+	// the caller can emit the "no credentials" variant of the push error.
+	cf, found, err := resolveRegistryAuth(fakeEnv(map[string]string{"HOME": t.TempDir()}), "registry:5000")
+	if err != nil {
+		t.Fatalf("resolveRegistryAuth: %v", err)
+	}
+	if found {
+		t.Error("credsFound = true, want false when no layer carries credentials")
+	}
+	if hasCreds(cf, "registry:5000") {
+		t.Error("hasCreds = true, want false for an empty config")
+	}
+}
+
+func TestResolveRegistryAuthDockerHubKey(t *testing.T) {
+	// An explicit docker.io push with only the env fallback must inject under
+	// the docker-hub config-file key, not "docker.io", so authprovider serves it.
+	raw := base64.StdEncoding.EncodeToString([]byte("ci:token"))
+	cf, found, err := resolveRegistryAuth(fakeEnv(map[string]string{
+		"HOME":                t.TempDir(),
+		envKukeonRegistryAuth: raw,
+	}), "docker.io")
+	if err != nil {
+		t.Fatalf("resolveRegistryAuth: %v", err)
+	}
+	if !found {
+		t.Fatal("credsFound = false, want true")
+	}
+	if _, ok := cf.AuthConfigs["docker.io"]; ok {
+		t.Error("env fallback keyed under docker.io; want the docker-hub config-file key")
+	}
+	if cf.AuthConfigs[authprovider.DockerHubConfigfileKey].Auth != raw {
+		t.Errorf("env fallback not keyed under %q", authprovider.DockerHubConfigfileKey)
+	}
+}
+
+func TestNewAuthProvider(t *testing.T) {
+	ap, found, err := newAuthProvider(fakeEnv(map[string]string{
+		"HOME":                t.TempDir(),
+		envKukeonRegistryAuth: base64.StdEncoding.EncodeToString([]byte("u:p")),
+	}), "registry:5000")
+	if err != nil {
+		t.Fatalf("newAuthProvider: %v", err)
+	}
+	if ap == nil {
+		t.Error("newAuthProvider returned a nil attachable")
+	}
+	if !found {
+		t.Error("credsFound = false, want true")
+	}
+}
+
+func TestIsRegistryAuthError(t *testing.T) {
+	authy := []string{
+		"failed to push: unexpected status: 401 Unauthorized",
+		"denied: requested access to the resource is denied",
+		"unauthorized: authentication required",
+		"failed to authorize: no basic auth credentials",
+		"403 Forbidden",
+	}
+	for _, m := range authy {
+		if !isRegistryAuthError(errors.New(m)) {
+			t.Errorf("isRegistryAuthError(%q) = false, want true", m)
+		}
+	}
+	notAuthy := []string{
+		"dockerfile parse error on line 3",
+		"failed to solve: executor failed running [/bin/sh -c make]: exit code 2",
+	}
+	for _, m := range notAuthy {
+		if isRegistryAuthError(errors.New(m)) {
+			t.Errorf("isRegistryAuthError(%q) = true, want false", m)
+		}
+	}
+}
+
+func TestPushAuthError(t *testing.T) {
+	cause := errors.New("401 Unauthorized")
+	// No credentials resolved: leads with "no credentials" and names the host
+	// and the precedence list.
+	noCreds := pushAuthError("registry:5000/app:dev", "registry:5000", false, cause)
+	for _, want := range []string{"no credentials", "registry:5000", "DOCKER_CONFIG", "KUKEON_REGISTRY_AUTH"} {
+		if !strings.Contains(noCreds.Error(), want) {
+			t.Errorf("no-creds push error %q missing %q", noCreds, want)
+		}
+	}
+	if !errors.Is(noCreds, cause) {
+		t.Error("no-creds push error does not wrap the cause")
+	}
+	// Credentials resolved but rejected: points at verifying them, still cites
+	// the precedence list and wraps the cause.
+	rejected := pushAuthError("registry:5000/app:dev", "registry:5000", true, cause)
+	for _, want := range []string{"rejected", "DOCKER_CONFIG", "KUKEON_REGISTRY_AUTH"} {
+		if !strings.Contains(rejected.Error(), want) {
+			t.Errorf("rejected push error %q missing %q", rejected, want)
+		}
+	}
+	if !errors.Is(rejected, cause) {
+		t.Error("rejected push error does not wrap the cause")
+	}
+}

--- a/cmd/kukebuild/build.go
+++ b/cmd/kukebuild/build.go
@@ -169,7 +169,27 @@ func runBuild(ctx context.Context, cfg *buildConfig, progressW io.Writer) error 
 	}
 	defer func() { _ = c.Close() }()
 
-	solveOpt, err := newSolveOpt(cfg)
+	// Resolve registry credentials before the solve when pushing, so a
+	// misconfigured docker config fails fast and credsFound can tailor an
+	// anonymous-rejection error after the push attempt. registryHost is safe to
+	// recompute — parseArgs already validated the reference is fully qualified.
+	var (
+		authProvider session.Attachable
+		pushHost     string
+		credsFound   bool
+	)
+	if cfg.push {
+		pushHost, err = registryHost(cfg.tag)
+		if err != nil {
+			return err
+		}
+		authProvider, credsFound, err = newAuthProvider(os.Getenv, pushHost)
+		if err != nil {
+			return err
+		}
+	}
+
+	solveOpt, err := newSolveOpt(cfg, authProvider)
 	if err != nil {
 		return err
 	}
@@ -192,6 +212,9 @@ func runBuild(ctx context.Context, cfg *buildConfig, progressW io.Writer) error 
 		return derr
 	})
 	if waitErr := eg.Wait(); waitErr != nil {
+		if cfg.push && isRegistryAuthError(waitErr) {
+			return pushAuthError(cfg.tag, pushHost, credsFound, waitErr)
+		}
 		return fmt.Errorf("build %q: %w", cfg.tag, waitErr)
 	}
 	return nil
@@ -217,8 +240,12 @@ func resolveBuildRoot(root string, explicit bool, namespace string) string {
 // Dockerfile frontend, the context + dockerfile local mounts, the
 // forwarded --build-arg values, and the containerd image exporter that names
 // the result cfg.tag. The "image" exporter writes into the worker's
-// containerd namespace, which newController points at <realm>.kukeon.io.
-func newSolveOpt(cfg *buildConfig) (*client.SolveOpt, error) {
+// containerd namespace, which newController points at <realm>.kukeon.io. When
+// cfg.push is set the same exporter also pushes to the tag's registry (push is
+// additive — the image still lands in the namespace) and authProvider, a
+// BuildKit session attachable carrying the resolved registry credentials, is
+// attached to the session; authProvider is nil when cfg.push is false.
+func newSolveOpt(cfg *buildConfig, authProvider session.Attachable) (*client.SolveOpt, error) {
 	contextFS, err := fsutil.NewFS(cfg.contextDir)
 	if err != nil {
 		return nil, fmt.Errorf("open build context %q: %w", cfg.contextDir, err)
@@ -259,6 +286,18 @@ func newSolveOpt(cfg *buildConfig) (*client.SolveOpt, error) {
 				},
 			},
 		},
+	}
+
+	// --push: the image exporter both writes the image into the containerd
+	// namespace (the name/unpack attrs above) and pushes it to the tag's
+	// registry. push is therefore additive, not substitutive — the local image
+	// remains inspectable via `kuke image get`. The auth provider rides in on
+	// the session so BuildKit resolves registry credentials during the push.
+	if cfg.push {
+		solveOpt.Exports[0].Attrs["push"] = "true"
+		if authProvider != nil {
+			solveOpt.Session = append(solveOpt.Session, authProvider)
+		}
 	}
 
 	// Build secrets ride in on a session attachable: the Dockerfile frontend

--- a/cmd/kukebuild/build_test.go
+++ b/cmd/kukebuild/build_test.go
@@ -40,7 +40,7 @@ func TestNewSolveOptWiresCache(t *testing.T) {
 	cfg.cacheExports = []cacheSpec{{typ: "local", attrs: map[string]string{"dest": "/c/out"}}}
 	cfg.cacheImports = []cacheSpec{{typ: "local", attrs: map[string]string{"src": "/c/in"}}}
 
-	so, err := newSolveOpt(cfg)
+	so, err := newSolveOpt(cfg, nil)
 	if err != nil {
 		t.Fatalf("newSolveOpt: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestNewSolveOptWiresSecrets(t *testing.T) {
 	}
 	cfg.secrets = []secretSpec{{id: "tok", src: secretFile}}
 
-	so, err := newSolveOpt(cfg)
+	so, err := newSolveOpt(cfg, nil)
 	if err != nil {
 		t.Fatalf("newSolveOpt: %v", err)
 	}
@@ -79,8 +79,63 @@ func TestNewSolveOptSecretFileMissing(t *testing.T) {
 	cfg := newSolveOptFixture(t)
 	cfg.secrets = []secretSpec{{id: "tok", src: filepath.Join(t.TempDir(), "does-not-exist")}}
 
-	if _, err := newSolveOpt(cfg); err == nil {
+	if _, err := newSolveOpt(cfg, nil); err == nil {
 		t.Fatal("newSolveOpt: expected error for missing secret file, got nil")
+	}
+}
+
+func TestNewSolveOptWiresPush(t *testing.T) {
+	cfg := newSolveOptFixture(t)
+	cfg.tag = "registry:5000/app:dev"
+	cfg.push = true
+	// A real auth attachable, resolved with the env fallback so the test needs
+	// no on-disk docker config.
+	ap, _, err := newAuthProvider(fakeEnv(map[string]string{"HOME": t.TempDir()}), "registry:5000")
+	if err != nil {
+		t.Fatalf("newAuthProvider: %v", err)
+	}
+
+	so, err := newSolveOpt(cfg, ap)
+	if err != nil {
+		t.Fatalf("newSolveOpt: %v", err)
+	}
+	if got := so.Exports[0].Attrs["push"]; got != "true" {
+		t.Errorf(`Exports[0].Attrs["push"] = %q, want "true"`, got)
+	}
+	if len(so.Session) != 1 {
+		t.Errorf("Session = %d entries, want 1 (the auth provider)", len(so.Session))
+	}
+}
+
+func TestNewSolveOptNoPushByDefault(t *testing.T) {
+	cfg := newSolveOptFixture(t) // push defaults to false
+	so, err := newSolveOpt(cfg, nil)
+	if err != nil {
+		t.Fatalf("newSolveOpt: %v", err)
+	}
+	if _, ok := so.Exports[0].Attrs["push"]; ok {
+		t.Error(`Exports[0].Attrs["push"] is set, want absent when --push is off`)
+	}
+	if len(so.Session) != 0 {
+		t.Errorf("Session = %d entries, want 0 when not pushing", len(so.Session))
+	}
+}
+
+// A push build with a nil auth provider (anonymous push) still sets the push
+// attr and must not panic appending to the session.
+func TestNewSolveOptPushNilAuth(t *testing.T) {
+	cfg := newSolveOptFixture(t)
+	cfg.tag = "registry:5000/app:dev"
+	cfg.push = true
+	so, err := newSolveOpt(cfg, nil)
+	if err != nil {
+		t.Fatalf("newSolveOpt: %v", err)
+	}
+	if so.Exports[0].Attrs["push"] != "true" {
+		t.Error(`Exports[0].Attrs["push"] != "true" for an anonymous push`)
+	}
+	if len(so.Session) != 0 {
+		t.Errorf("Session = %d entries, want 0 for nil auth provider", len(so.Session))
 	}
 }
 

--- a/cmd/kukebuild/go.mod
+++ b/cmd/kukebuild/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require (
 	github.com/containerd/containerd/v2 v2.2.1
 	github.com/distribution/reference v0.6.0
+	github.com/docker/cli v29.2.1+incompatible
 	github.com/moby/buildkit v0.28.1
 	github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f
 	golang.org/x/sync v0.19.0
@@ -42,6 +43,7 @@ require (
 	github.com/containernetworking/cni v1.3.0 // indirect
 	github.com/containernetworking/plugins v1.9.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.0 // indirect
+	github.com/docker/docker-credential-helpers v0.9.5 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
@@ -55,6 +57,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hiddeco/sshsig v0.2.0 // indirect

--- a/cmd/kukebuild/go.sum
+++ b/cmd/kukebuild/go.sum
@@ -195,6 +195,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 h1:NmZ1PKzSTQbuGHw9DGPFomqkkLW
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3/go.mod h1:zQrxl1YP88HQlA6i9c63DSVPFklWpGX4OWAc9bFuaH4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0 h1:CUW5RYIcysz+D3B+l1mDeXrQ7fUvGGCwJfdASSzbrfo=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0/go.mod h1:hgdqLXA4f6NIjRVisM1TJ9aOJVNRqKZj+xDGF6m7PBw=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=

--- a/cmd/kukebuild/main.go
+++ b/cmd/kukebuild/main.go
@@ -43,8 +43,10 @@
 // and --platform=$BUILDPLATFORM against kukeon's own Dockerfile end-to-end
 // (host network mode + the default overlayfs snapshotter sufficed). Phase 2a
 // (#523) adds build-time file secrets (--secret) and local-disk cache
-// export/import (--cache-to / --cache-from). The --push / --platform-flag
-// surface remains deferred to the phase 2 follow-ups (#524, #646).
+// export/import (--cache-to / --cache-from). Phase 2b (#524) adds direct
+// registry push (--push) with docker-config-compatible credential resolution
+// (see auth.go). The --platform multi-platform surface remains deferred to its
+// phase 2 follow-up (#646).
 package main
 
 import (
@@ -160,6 +162,12 @@ type buildConfig struct {
 	// backends are deferred.
 	cacheExports []cacheSpec
 	cacheImports []cacheSpec
+	// push, when true, pushes the built image to its tag's registry after the
+	// build succeeds (--push, phase 2b #524). The image is still written to the
+	// target realm's containerd namespace — push is additive. Requires tag to be
+	// a fully qualified registry reference; credentials resolve per the --push
+	// precedence (see auth.go).
+	push bool
 }
 
 // secretSpec is a resolved --secret entry: a build secret named id, sourced
@@ -245,6 +253,13 @@ func parseArgs(args []string) (*buildConfig, error) {
 	var cacheFrom repeatableFlag
 	fs.Var(&cacheFrom, "cache-from", "import build cache: type=local,src=PATH (repeatable)")
 
+	push := fs.Bool(
+		"push",
+		false,
+		"after a successful build, push the image to its tag's registry (requires a fully qualified REGISTRY/REPO:TAG); "+
+			"credentials resolve from $DOCKER_CONFIG/config.json, then ~/.docker/config.json, then $KUKEON_REGISTRY_AUTH",
+	)
+
 	if err := fs.Parse(args); err != nil {
 		return nil, &usageError{msg: err.Error()}
 	}
@@ -270,6 +285,11 @@ func parseArgs(args []string) (*buildConfig, error) {
 	}
 	if strings.TrimSpace(*realm) == "" {
 		return nil, &usageError{msg: "--realm must not be empty"}
+	}
+	if *push {
+		if err := requirePushableReference(strings.TrimSpace(*tag)); err != nil {
+			return nil, err
+		}
 	}
 
 	parsedArgs, err := parseBuildArgs(buildArgs)
@@ -308,6 +328,7 @@ func parseArgs(args []string) (*buildConfig, error) {
 		secrets:          parsedSecrets,
 		cacheExports:     parsedCacheExports,
 		cacheImports:     parsedCacheImports,
+		push:             *push,
 	}, nil
 }
 

--- a/cmd/kukebuild/main_test.go
+++ b/cmd/kukebuild/main_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -173,6 +174,47 @@ func TestParseSecretsUsageErrors(t *testing.T) {
 				t.Errorf("parseArgs(%v): error %v is not a *usageError", tc.args, err)
 			}
 		})
+	}
+}
+
+func TestParseArgsPush(t *testing.T) {
+	// --push defaults off.
+	cfg, err := parseArgs([]string{"-t", "registry:5000/app:dev", "/ctx"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+	if cfg.push {
+		t.Error("push = true, want false when --push is not supplied")
+	}
+
+	// --push with a fully qualified reference parses and sets the flag.
+	cfg, err = parseArgs([]string{"-t", "registry:5000/app:dev", "--push", "/ctx"})
+	if err != nil {
+		t.Fatalf("parseArgs(--push qualified): %v", err)
+	}
+	if !cfg.push {
+		t.Error("push = false, want true when --push is supplied")
+	}
+}
+
+func TestParseArgsPushRequiresQualifiedTag(t *testing.T) {
+	// --push with a bare name:tag is a usageError naming the required form.
+	cases := [][]string{
+		{"-t", "app:dev", "--push", "/ctx"},
+		{"-t", "eminwux/kukeon:v1", "--push", "/ctx"}, // docker-hub repo, host not explicit
+	}
+	for _, args := range cases {
+		_, err := parseArgs(args)
+		if err == nil {
+			t.Fatalf("parseArgs(%v): expected error, got nil", args)
+		}
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("parseArgs(%v): error %v is not a *usageError", args, err)
+		}
+		if !strings.Contains(err.Error(), "REGISTRY/REPO:TAG") {
+			t.Errorf("parseArgs(%v): error %q does not name REGISTRY/REPO:TAG", args, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 2b of `kuke build` (#524, sibling of phase 2a #674 which is already merged). Adds direct registry push after a successful local build, with docker-config-compatible credential resolution. No new subcommands — `--push` rides on the existing `kuke build` surface.

- **`--push` (cmd/kukebuild/main.go, build.go):** sets `push=true` on the existing containerd image exporter, so the same exporter both writes the image into the target realm's containerd namespace **and** pushes it to the tag's registry. Push is additive, not substitutive — the local image still lands and stays inspectable via `kuke image get`.
- **Credential resolution (cmd/kukebuild/auth.go):** resolves registry credentials in the documented precedence and wraps them in BuildKit's `authprovider.NewDockerAuthProvider` session attachable:
  1. `$DOCKER_CONFIG/config.json` when `DOCKER_CONFIG` is set;
  2. else `~/.docker/config.json`;
  3. else the `KUKEON_REGISTRY_AUTH` env var (base64 `user:pass`), applied only when layers 1–2 carry no entry for the host.
- **Fully-qualified-reference gate:** a bare `name:tag` (or a docker-hub `user/repo:tag` whose host is implicit) used with `--push` is a parse-time usage error (exit 64): `--push requires a fully qualified registry reference: REGISTRY/REPO:TAG`.
- **Anonymous-rejection error:** when the build's push fails with a registry-auth error (`401`/`403`/`unauthorized`/`denied`/…), the failure is rewritten to point at the credential precedence list; the `no credentials for <host>` variant is used when nothing resolved.
- **Shim (cmd/kuke/build/build.go):** forwards `--push` to `kukebuild` and documents the flag + credential precedence in `kuke build --help`.
- **BuildKit auth API:** uses `authprovider.LoadAuthConfig(*configfile.ConfigFile)` + `NewDockerAuthProvider(DockerAuthProviderConfig{...})` (v0.28.1 surface). `go mod tidy` promotes `github.com/docker/cli` to a direct dep.

### Non-obvious calls (reviewer, please push back)
- **Explicit-registry heuristic** mirrors docker's `splitDockerDomain`: the segment before the first `/` is a registry host only when it is `localhost` or contains `.`/`:`. So `eminwux/kukeon:v1` is rejected for `--push` (its host would silently normalize to docker.io). This matches the issue's "bare `name:tag` errors" intent and avoids a push landing somewhere unintended.
- **Docker-hub key mapping:** the `KUKEON_REGISTRY_AUTH` fallback for an explicit `docker.io/...` push is injected under `authprovider.DockerHubConfigfileKey` (`https://index.docker.io/v1/`), not `docker.io`, so BuildKit serves it back. Non-hub hosts key under themselves.
- **`isRegistryAuthError` is substring-based** (BuildKit/containerd surface push-auth failures as opaque wrapped strings, not typed errors). It only decides whether to rewrite the error into the precedence hint; a false negative just yields the generic `build %q` wrapper.
- **Out of scope (per AC):** `kuke login`/credential-manager, OCI mirroring/proxy, cosign/SBOM/attestations. Also out of scope and **not added**: insecure-registry (plain-HTTP) push config — `--push` assumes a TLS registry, matching docker/buildkit defaults.

## Test plan
- [x] `make test` (root module + `cd cmd/kukebuild && go test ./...`) — green.
- [x] `go build ./...` + `go vet ./...` in the kukebuild module — green.
- [x] `make kukebuild` + `make kuke` link cleanly.
- [x] Unit coverage (cmd/kukebuild/auth_test.go, build_test.go, main_test.go; cmd/kuke/build/build_test.go): resolver precedence (DOCKER_CONFIG / ~/.docker / env fallback / none resolve / config-beats-env), docker-hub key mapping, host extraction, fully-qualified-reference gate, push wiring (`push` attr + auth session appended; anonymous nil-auth path), auth-error detection, both error-message variants, shim flag forwarding.
- [x] Binary-level usage path: `kukebuild --push -t app:dev <ctx>` and `--push -t eminwux/kukeon:v1 <ctx>` both exit 64 with the REGISTRY/REPO:TAG message; `kuke build --help` shows the `--push` flag + credential precedence.
- [x] AC #2 (push is additive) observed in passing: a `--push -t registry:5000/app:dev` build (run as root against host containerd) wrote the image into `default.kukeon.io` even though the remote target was unreachable.
- [ ] AC #1 / #5 live `registry:2` push (success path + anonymous-rejection) — **not run on the dev host**: docker is absent and there is no local registry/insecure-registry config here, so a TLS-terminated `registry:2` can't be stood up safely. Please verify against a local `registry:2` in a clean environment. The push wiring, auth resolution, and error paths are unit-covered above.

Closes #524