### PR TITLE
feat(build): kuke build --platform multi-platform output (phase 2c)

### DIFF
--- a/cmd/kuke/build/build.go
+++ b/cmd/kuke/build/build.go
@@ -55,7 +55,7 @@ func NewBuildCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "build [-f Dockerfile] [-t name:tag] [--realm <name>] [--build-arg K=V]... " +
 			"[--secret id=NAME,src=PATH]... [--cache-to type=local,dest=PATH]... " +
-			"[--cache-from type=local,src=PATH]... [--push] <context>",
+			"[--cache-from type=local,src=PATH]... [--platform os/arch,...] [--push] <context>",
 		Short: "Build an OCI image from a Dockerfile into a realm's containerd namespace",
 		Long: "Build an OCI image from a Dockerfile using kukeon's native builder.\n\n" +
 			"`kuke build` is a thin shim: it locates the `kukebuild` binary on PATH and\n" +
@@ -69,6 +69,12 @@ func NewBuildCmd() *cobra.Command {
 			"Build cache: --cache-to type=local,dest=PATH exports the build cache to a local\n" +
 			"directory and --cache-from type=local,src=PATH imports it back, reusing layers\n" +
 			"across builds. Only type=local is supported; both flags are repeatable.\n\n" +
+			"Multi-platform: --platform linux/amd64,linux/arm64 builds for each target arch\n" +
+			"and writes the result as a single manifest list — one image reference covering\n" +
+			"every arch, not per-arch tags (operators expecting name:tag-amd64 / -arm64 will\n" +
+			"not find them). `kuke image get --realm <name>` shows the list; each per-arch\n" +
+			"manifest is individually pullable. Distinct from a Dockerfile's $BUILDPLATFORM\n" +
+			"arg, which selects the build host's platform; --platform selects the output set.\n\n" +
 			"Registry push: --push pushes the built image to its tag's registry after a\n" +
 			"successful build. The tag must be a fully qualified registry reference\n" +
 			"(REGISTRY/REPO:TAG); a bare name:tag is rejected. Push is additive — the image\n" +
@@ -97,6 +103,12 @@ func NewBuildCmd() *cobra.Command {
 	)
 	cmd.Flags().StringArray("cache-to", nil, "Export build cache: type=local,dest=PATH (repeatable)")
 	cmd.Flags().StringArray("cache-from", nil, "Import build cache: type=local,src=PATH (repeatable)")
+	cmd.Flags().String(
+		"platform",
+		"",
+		"Comma-separated os/arch[/variant] targets (e.g. linux/amd64,linux/arm64); multiple targets "+
+			"produce a single manifest list, not per-arch tags",
+	)
 	cmd.Flags().Bool(
 		"push",
 		false,
@@ -177,6 +189,10 @@ func buildArgv(cmd *cobra.Command, args []string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	platform, err := cmd.Flags().GetString("platform")
+	if err != nil {
+		return nil, err
+	}
 	push, err := cmd.Flags().GetBool("push")
 	if err != nil {
 		return nil, err
@@ -200,6 +216,9 @@ func buildArgv(cmd *cobra.Command, args []string) ([]string, error) {
 	}
 	for _, c := range cacheFrom {
 		argv = append(argv, "--cache-from", c)
+	}
+	if strings.TrimSpace(platform) != "" {
+		argv = append(argv, "--platform", platform)
 	}
 	if push {
 		argv = append(argv, "--push")

--- a/cmd/kuke/build/build_test.go
+++ b/cmd/kuke/build/build_test.go
@@ -181,6 +181,56 @@ func TestRunBuildForwardsKukeondConfig(t *testing.T) {
 	}
 }
 
+func TestRunBuildForwardsPlatform(t *testing.T) {
+	var gotArgv []string
+	withStubs(t,
+		func(string) (string, error) { return "/usr/local/bin/kukebuild", nil },
+		func(_ string, argv []string, _ []string) error { gotArgv = argv; return nil },
+	)
+
+	cmd := NewBuildCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"-t", "x:1", "--platform", "linux/amd64,linux/arm64", "."})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: unexpected error: %v", err)
+	}
+	want := []string{
+		"kukebuild",
+		"--tag", "x:1",
+		"--realm", consts.KukeonDefaultRealmName,
+		"--platform", "linux/amd64,linux/arm64",
+		".",
+	}
+	if !reflect.DeepEqual(gotArgv, want) {
+		t.Errorf("argv = %v, want %v", gotArgv, want)
+	}
+}
+
+// Without --platform the shim forwards no --platform flag (single-image default).
+func TestRunBuildNoPlatformByDefault(t *testing.T) {
+	var gotArgv []string
+	withStubs(t,
+		func(string) (string, error) { return "/usr/local/bin/kukebuild", nil },
+		func(_ string, argv []string, _ []string) error { gotArgv = argv; return nil },
+	)
+
+	cmd := NewBuildCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"-t", "x:1", "."})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: unexpected error: %v", err)
+	}
+	for _, a := range gotArgv {
+		if a == "--platform" {
+			t.Errorf("argv = %v, must not contain --platform when the flag is unset", gotArgv)
+		}
+	}
+}
+
 func TestRunBuildForwardsPush(t *testing.T) {
 	var gotArgv []string
 	withStubs(t,

--- a/cmd/kukebuild/build.go
+++ b/cmd/kukebuild/build.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	ctd "github.com/containerd/containerd/v2/client"
@@ -260,6 +261,16 @@ func newSolveOpt(cfg *buildConfig, authProvider session.Attachable) (*client.Sol
 	}
 	for k, v := range cfg.buildArgs {
 		frontendAttrs["build-arg:"+k] = v
+	}
+
+	// --platform: the Dockerfile frontend reads the comma-separated `platform`
+	// attr (frontend/dockerui keyTargetPlatform) and, for more than one target,
+	// emits a per-arch ref set that the image exporter writes as a single
+	// manifest list into the realm namespace — no exporter-side wiring beyond
+	// this attr (phase 2c #646). cfg.platforms is already normalized + validated
+	// at parse time; empty leaves the frontend on its build-host default.
+	if len(cfg.platforms) > 0 {
+		frontendAttrs["platform"] = strings.Join(cfg.platforms, ",")
 	}
 
 	name, err := normalizeImageName(cfg.tag)

--- a/cmd/kukebuild/build_test.go
+++ b/cmd/kukebuild/build_test.go
@@ -139,6 +139,45 @@ func TestNewSolveOptPushNilAuth(t *testing.T) {
 	}
 }
 
+func TestNewSolveOptWiresPlatform(t *testing.T) {
+	// Multiple platforms set the comma-separated `platform` frontend attr; the
+	// Dockerfile frontend turns that into a manifest-list result.
+	cfg := newSolveOptFixture(t)
+	cfg.platforms = []string{"linux/amd64", "linux/arm64"}
+
+	so, err := newSolveOpt(cfg, nil)
+	if err != nil {
+		t.Fatalf("newSolveOpt: %v", err)
+	}
+	if got := so.FrontendAttrs["platform"]; got != "linux/amd64,linux/arm64" {
+		t.Errorf(`FrontendAttrs["platform"] = %q, want "linux/amd64,linux/arm64"`, got)
+	}
+}
+
+func TestNewSolveOptSinglePlatform(t *testing.T) {
+	cfg := newSolveOptFixture(t)
+	cfg.platforms = []string{"linux/arm64"}
+
+	so, err := newSolveOpt(cfg, nil)
+	if err != nil {
+		t.Fatalf("newSolveOpt: %v", err)
+	}
+	if got := so.FrontendAttrs["platform"]; got != "linux/arm64" {
+		t.Errorf(`FrontendAttrs["platform"] = %q, want "linux/arm64"`, got)
+	}
+}
+
+func TestNewSolveOptNoPlatformByDefault(t *testing.T) {
+	cfg := newSolveOptFixture(t) // platforms unset
+	so, err := newSolveOpt(cfg, nil)
+	if err != nil {
+		t.Fatalf("newSolveOpt: %v", err)
+	}
+	if _, ok := so.FrontendAttrs["platform"]; ok {
+		t.Error(`FrontendAttrs["platform"] is set, want absent when --platform is off`)
+	}
+}
+
 func TestResolveBuildRoot(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/cmd/kukebuild/go.mod
+++ b/cmd/kukebuild/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	github.com/containerd/containerd/v2 v2.2.1
+	github.com/containerd/platforms v1.0.0-rc.2
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.2.1+incompatible
 	github.com/moby/buildkit v0.28.1
@@ -35,7 +36,6 @@ require (
 	github.com/containerd/go-cni v1.1.13 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/nydus-snapshotter v0.15.11 // indirect
-	github.com/containerd/platforms v1.0.0-rc.2 // indirect
 	github.com/containerd/plugin v1.0.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
 	github.com/containerd/ttrpc v1.2.7 // indirect

--- a/cmd/kukebuild/main.go
+++ b/cmd/kukebuild/main.go
@@ -60,6 +60,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/containerd/platforms"
 )
 
 // exitCodeUsage is returned when invocation is malformed (unknown flag,
@@ -168,6 +170,13 @@ type buildConfig struct {
 	// a fully qualified registry reference; credentials resolve per the --push
 	// precedence (see auth.go).
 	push bool
+	// platforms are the --platform os/arch[/variant] targets (phase 2c #646).
+	// When more than one is set, the build output is a single manifest list (one
+	// image reference covering every target arch), not per-arch tags. Empty
+	// means a single image for the build host's platform — the phase-1 default.
+	// Normalized to containerd's canonical form at parse time; forwarded to the
+	// Dockerfile frontend's `platform` attr (see newSolveOpt).
+	platforms []string
 }
 
 // secretSpec is a resolved --secret entry: a build secret named id, sourced
@@ -253,6 +262,13 @@ func parseArgs(args []string) (*buildConfig, error) {
 	var cacheFrom repeatableFlag
 	fs.Var(&cacheFrom, "cache-from", "import build cache: type=local,src=PATH (repeatable)")
 
+	platform := fs.String(
+		"platform",
+		"",
+		"comma-separated os/arch[/variant] targets (e.g. linux/amd64,linux/arm64); "+
+			"multiple targets produce a single manifest list, not per-arch tags",
+	)
+
 	push := fs.Bool(
 		"push",
 		false,
@@ -309,6 +325,10 @@ func parseArgs(args []string) (*buildConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	parsedPlatforms, err := parsePlatforms(*platform)
+	if err != nil {
+		return nil, err
+	}
 
 	dockerfile := *file
 	if strings.TrimSpace(dockerfile) == "" {
@@ -329,7 +349,44 @@ func parseArgs(args []string) (*buildConfig, error) {
 		cacheExports:     parsedCacheExports,
 		cacheImports:     parsedCacheImports,
 		push:             *push,
+		platforms:        parsedPlatforms,
 	}, nil
+}
+
+// parsePlatforms turns the raw --platform value into normalized os/arch[/variant]
+// targets. The value is comma-separated (e.g. "linux/amd64,linux/arm64"); each
+// entry is parsed and normalized to containerd's canonical form so a typo
+// (unknown os/arch, malformed triple) surfaces as a usage error at parse time
+// rather than mid-solve. An empty value yields nil — the phase-1 single-image,
+// build-host-platform default. Duplicate targets are a usage error so an
+// operator does not silently produce a manifest list with redundant entries.
+func parsePlatforms(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	out := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, seg := range strings.Split(raw, ",") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		p, err := platforms.Parse(seg)
+		if err != nil {
+			return nil, &usageError{msg: fmt.Sprintf(
+				"invalid --platform %q: %v (expected os/arch[/variant], e.g. linux/amd64)", seg, err)}
+		}
+		norm := platforms.Format(platforms.Normalize(p))
+		if _, dup := seen[norm]; dup {
+			return nil, &usageError{msg: fmt.Sprintf("invalid --platform: duplicate target %q", norm)}
+		}
+		seen[norm] = struct{}{}
+		out = append(out, norm)
+	}
+	if len(out) == 0 {
+		return nil, &usageError{msg: fmt.Sprintf("invalid --platform %q: no targets parsed", raw)}
+	}
+	return out, nil
 }
 
 // parseBuildArgs turns the raw --build-arg values into a KEY=VALUE map. Each

--- a/cmd/kukebuild/main_test.go
+++ b/cmd/kukebuild/main_test.go
@@ -218,6 +218,73 @@ func TestParseArgsPushRequiresQualifiedTag(t *testing.T) {
 	}
 }
 
+func TestParseArgsPlatform(t *testing.T) {
+	// No --platform: single-image build-host default (nil platforms).
+	cfg, err := parseArgs([]string{"-t", "x:1", "/ctx"})
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+	if len(cfg.platforms) != 0 {
+		t.Errorf("platforms = %v, want empty when --platform is not supplied", cfg.platforms)
+	}
+
+	// A single target normalizes and is carried through.
+	cfg, err = parseArgs([]string{"-t", "x:1", "--platform", "linux/amd64", "/ctx"})
+	if err != nil {
+		t.Fatalf("parseArgs(single platform): %v", err)
+	}
+	if got := []string{"linux/amd64"}; !reflect.DeepEqual(cfg.platforms, got) {
+		t.Errorf("platforms = %v, want %v", cfg.platforms, got)
+	}
+
+	// A comma-separated list yields the normalized multi-platform set in order.
+	cfg, err = parseArgs([]string{"-t", "x:1", "--platform", "linux/amd64,linux/arm64", "/ctx"})
+	if err != nil {
+		t.Fatalf("parseArgs(multi platform): %v", err)
+	}
+	want := []string{"linux/amd64", "linux/arm64"}
+	if !reflect.DeepEqual(cfg.platforms, want) {
+		t.Errorf("platforms = %v, want %v", cfg.platforms, want)
+	}
+}
+
+func TestParsePlatformsNormalizesAliasesAndSpacing(t *testing.T) {
+	// arm64 is normalized to its canonical os/arch; surrounding whitespace and a
+	// trailing empty segment are tolerated.
+	got, err := parsePlatforms("linux/arm64/v8 , linux/amd64,")
+	if err != nil {
+		t.Fatalf("parsePlatforms: %v", err)
+	}
+	want := []string{"linux/arm64", "linux/amd64"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parsePlatforms = %v, want %v", got, want)
+	}
+}
+
+func TestParsePlatformsUsageErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"platform garbage", []string{"-t", "x:1", "--platform", "not a platform!!", "/ctx"}},
+		{"platform empty value", []string{"-t", "x:1", "--platform", " , ", "/ctx"}},
+		{"platform duplicate", []string{"-t", "x:1", "--platform", "linux/amd64,linux/amd64", "/ctx"}},
+		{"platform duplicate via alias", []string{"-t", "x:1", "--platform", "linux/arm64,linux/arm64/v8", "/ctx"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseArgs(tc.args)
+			if err == nil {
+				t.Fatalf("parseArgs(%v): expected error, got nil", tc.args)
+			}
+			var ue *usageError
+			if !errors.As(err, &ue) {
+				t.Errorf("parseArgs(%v): error %v is not a *usageError", tc.args, err)
+			}
+		})
+	}
+}
+
 func TestParseArgsShortAliases(t *testing.T) {
 	cfg, err := parseArgs([]string{"-f", "/ctx/Containerfile", "-t", "x:1", "/ctx"})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Phase 2c of `kuke build` (#646, carved from #523). Adds `--platform <list>` so a build produces a **single manifest list** covering each target arch, written into the target realm's containerd namespace.
- **Engine (`cmd/kukebuild`):** `--platform` parses a comma-separated `os/arch[/variant]` list, normalizes + validates each entry via `containerd/platforms` at parse time (typos / dup targets fail fast as usage errors), and sets the BuildKit Dockerfile frontend's `platform` attr (`frontend/dockerui` `keyTargetPlatform`). The frontend turns a multi-target attr into a per-arch ref set that the existing image exporter writes as one manifest list — no exporter-side wiring beyond the attr.
- **Shim (`cmd/kuke/build`):** `--platform` flag forwarded verbatim to `kukebuild`; absent flag forwards nothing (phase-1 single-image default preserved).
- **Help text:** documents `--platform` and notes the output is a single manifest list (one reference), **not** per-arch tags, and that it is distinct from the Dockerfile-internal `$BUILDPLATFORM`.

`containerd/platforms` moved from indirect to direct in `cmd/kukebuild/go.mod` (`go mod tidy`, no version change).

## Implementation notes (for reviewer pushback)

- **Validation strictness:** I reject duplicate targets (including alias dups like `linux/arm64,linux/arm64/v8`, both normalize to `linux/arm64`) as a usage error rather than silently de-duping, so an operator does not produce a manifest list with redundant entries. Empty/whitespace segments are tolerated (trailing comma is fine).
- **Sibling #524 (`--push`) already landed** (merged as #675). `--push` + `--platform` compose: the same image exporter both writes the manifest list to the namespace and pushes it as one reference (the push attr rides on the same `Exports[0]`). No extra wiring was needed; not separately smoke-tested here (no registry on the dev host).

## Test plan

- [x] `make test` — full CI target (root module + kukebuild module), all pass.
- [x] `go build ./cmd/...` + `go vet` (root) and `go build ./... && go vet ./...` (kukebuild module) — clean.
- [x] New colocated tests: `cmd/kukebuild/main_test.go` (`--platform` parse, normalization, usage errors incl. dup-via-alias), `cmd/kukebuild/build_test.go` (frontend `platform` attr wiring: multi / single / absent), `cmd/kuke/build/build_test.go` (shim forwarding present/absent).
- [x] **AC#1 — real multi-platform build verified end-to-end** via the actual `kukebuild` engine against a `FROM scratch` + `COPY` context: `./kukebuild --platform linux/amd64,linux/arm64 -t mp-test:dev --realm default <ctx>` produced `exporting manifest list sha256:9082…`. `ctr -n default.kukeon.io images ls` shows the image as `application/vnd.docker.distribution.manifest.list.v2+json` covering `linux/amd64,linux/arm64`; the list's two child manifests (`84af…` amd64, `6d9d…` arm64) are both present in the namespace's content store (individually pullable). Test image removed afterward.
- [x] CLI help text (`kuke build --help`) renders the `--platform` flag + the manifest-list-not-per-arch-tags note.
- [ ] `kuke image get --realm default` display path — **not run**: `kuke image get` validates the realm against kukeon state, which requires `kuke init` (and thus a kukeond image build via docker, not running on this host). This is a `kuke init` precondition orthogonal to `--platform`; `kuke image get` reads the exact `<realm>.kukeon.io` namespace that `ctr` confirms holds the manifest list, so the display is over verified content. A reviewer on an initialized host can confirm the rendered output.
- [ ] `make dev-init` smoke — **not run**: this change touches only the `kuke build` / `kukebuild` image-builder surface, not the daemon bootstrap, `/opt/kukeon`, or anything `make dev-init` exercises (it rebuilds + re-inits kukeond and checks realm parity). No daemon-read path is affected.

### Environmental note (not a code issue)
The repo's `golangci-lint` pre-commit hook panics in this sandbox with `package requires newer Go version go1.25 (application built with go1.24)` — the cached golangci-lint binary is built with go1.24 but the `cmd/kukebuild` module is `go 1.25.5`, and the `go.work` union pulls it in. Verified pre-existing and independent of this diff (same panic on an unmodified `internal/consts/consts.go`). `go vet`/`go build`/`make test` all pass.

Closes #646