### PR TITLE
docs(manifests): document generation/observedGeneration in manifest reference

### DIFF
--- a/docs/site/manifests/cell.md
+++ b/docs/site/manifests/cell.md
@@ -72,6 +72,7 @@ This is opt-in because the default subset minimises the controller surface enabl
 | `reason`             | string                                             | Short reason code summarizing why `state` is in its current value.                                                                                                                                                                                                |
 | `message`            | string                                             | Human-readable detail backing `reason`; especially valuable on `state: Failed`.                                                                                                                                                                                   |
 | `cgroupReady`        | bool                                               | Whether `cgroupPath` actually exists on the host filesystem as of the last status write.                                                                                                                                                                          |
+| `observedGeneration` | int                                                | The `metadata.generation` the reconciler last acted on. Defaults to zero (omitted) and stays inert until writers begin bumping `generation`; the reconciler then compares the two to skip stale work.                                                              |
 
 ## Minimal
 

--- a/docs/site/manifests/overview.md
+++ b/docs/site/manifests/overview.md
@@ -47,6 +47,10 @@ Required, string. Unique within its parent. The name is also what you use as `re
 
 Optional, map of string to string. Arbitrary key-value metadata. Not used by any Kukeon logic today; labels are preserved on round-trip.
 
+### `metadata.generation`
+
+Read-only, integer. Monotonic counter bumped by a writer on each spec-changing update, so a reconciler can tell whether it has observed the latest spec (compare against `status.observedGeneration`). Defaults to zero and is omitted when zero. Writers do not bump it yet, so it stays absent until a later release wires them up. Present on realm, space, stack, and cell — not container.
+
 ### `status.state`
 
 Read-only. Managed by Kukeon. Takes one of:

--- a/docs/site/manifests/realm.md
+++ b/docs/site/manifests/realm.md
@@ -57,6 +57,7 @@ spec:
 | `message`                  | string                                                          | Human-readable detail backing `reason`; especially valuable on `state: Failed`.                                                                   |
 | `cgroupReady`              | bool                                                            | Whether `cgroupPath` actually exists on the host filesystem as of the last status write — separates intent from observation.                      |
 | `containerdNamespaceReady` | bool                                                            | Whether the containerd namespace recorded in `spec.namespace` was actually present as of the last status write.                                   |
+| `observedGeneration`       | int                                                             | The `metadata.generation` the reconciler last acted on. Defaults to zero (omitted) and stays inert until writers begin bumping `generation`; the reconciler then compares the two to skip stale work. |
 
 `status` is populated by Kukeon; anything you set when applying is overwritten on reconcile.
 

--- a/docs/site/manifests/space.md
+++ b/docs/site/manifests/space.md
@@ -111,6 +111,7 @@ Supported fields (each mirrors `ContainerSpec`): `user`, `readOnlyRootFilesystem
 | `reason`             | string                                  | Short reason code summarizing why `state` is in its current value.                                                                                   |
 | `message`            | string                                  | Human-readable detail backing `reason`; especially valuable on `state: Failed`.                                                                      |
 | `cgroupReady`        | bool                                    | Whether `cgroupPath` actually exists on the host filesystem as of the last status write.                                                             |
+| `observedGeneration` | int                                     | The `metadata.generation` the reconciler last acted on. Defaults to zero (omitted) and stays inert until writers begin bumping `generation`; the reconciler then compares the two to skip stale work. |
 
 ## Bridge naming
 

--- a/docs/site/manifests/stack.md
+++ b/docs/site/manifests/stack.md
@@ -41,6 +41,7 @@ Today the stack schema requires both `metadata.name` and `spec.id`, and they sho
 | `reason`             | string                                  | Short reason code summarizing why `state` is in its current value.                                                                                   |
 | `message`            | string                                  | Human-readable detail backing `reason`; especially valuable on `state: Failed`.                                                                      |
 | `cgroupReady`        | bool                                    | Whether `cgroupPath` actually exists on the host filesystem as of the last status write.                                                             |
+| `observedGeneration` | int                                     | The `metadata.generation` the reconciler last acted on. Defaults to zero (omitted) and stays inert until writers begin bumping `generation`; the reconciler then compares the two to skip stale work. |
 
 ## Minimal
 


### PR DESCRIPTION
## Summary
- Documents the `Generation` (metadata) and `ObservedGeneration` (status) fields added to realm/space/stack/cell in #628, so the public-surface reference doesn't silently drift.
- `observedGeneration` row added to each of the 4 per-kind `status` tables (`realm.md`, `space.md`, `stack.md`, `cell.md`), mirroring the existing `cgroupReady` row style as the issue suggested.
- `metadata.generation` documented once in `overview.md` under "Common fields".

## Premise reinterpretation (documented for reviewer)
The issue's suggested fix says "add a `generation` row to each **metadata table**". There is no per-kind metadata table in these docs — metadata fields (`metadata.name`, `metadata.labels`) are documented centrally in `overview.md`'s "Common fields" section, not repeated per kind. To stay consistent with that established pattern, `metadata.generation` is documented there (with a scope note: present on realm/space/stack/cell, not container — confirmed `Generation`/`ObservedGeneration` absent from `pkg/api/model/v1beta1/container.go`). `observedGeneration` follows the issue literally, since per-kind `status` tables do exist. Field semantics taken from the godoc in `pkg/api/model/v1beta1/{realm,space,stack,cell}.go` — both fields inert (omitted, zero) until phase 3 wires writers/reconciler.

## Test plan
- [x] Verified `Generation`/`ObservedGeneration` exist on all 4 kinds in `pkg/api/model/v1beta1/` and are absent from `container.go`.
- [x] Confirmed docs had no prior rows for either field before editing.
- [x] Docs-only change (markdown tables + one common-fields entry); no code, no test, no behavior change — no build/test target applies.

Closes #629