### PR TITLE
fix: report absent containers as NotCreated instead of Stopped

### DIFF
--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -414,6 +414,8 @@ func containerStateToString(state v1beta1.ContainerState) string {
 		return "Pausing"
 	case v1beta1.ContainerStateFailed:
 		return "Failed"
+	case v1beta1.ContainerStateNotCreated:
+		return "NotCreated"
 	default:
 		return "Unknown"
 	}

--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -152,12 +152,17 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 	}
 
 	if !containerExists {
-		// Container doesn't exist in containerd
+		// No containerd record at all — distinct from Stopped (a record that
+		// exists but whose task is gone, handled below). Reporting must not
+		// collapse the two: an absent record means the container was never
+		// realized or was reaped/lost, which an operator needs to tell apart
+		// from a normal clean stop (#670). The reconciler treats NotCreated
+		// exactly like Stopped for its lifecycle decisions — see refresh.go.
 		r.logger.InfoContext(r.ctx, "container does not exist in containerd",
 			"container", containerID,
 			"containerdID", containerdID,
 			"namespace", namespace)
-		return intmodel.ContainerStateStopped, nil
+		return intmodel.ContainerStateNotCreated, nil
 	}
 
 	// Get container state using TaskStatus from ctr package

--- a/internal/controller/runner/container_state_test.go
+++ b/internal/controller/runner/container_state_test.go
@@ -92,13 +92,15 @@ func TestGetContainerState_TaskNotFound_ReturnsStopped(t *testing.T) {
 	}
 }
 
-// TestGetContainerState_ContainerGoneAlsoStopped sanity-checks the existing
-// pre-fix path: a container that's been removed from containerd entirely
-// (operator ran `ctr -n <ns> containers rm` between boots) reads back as
-// Stopped via the "container does not exist" branch. The Layer 2 fix added
-// in #543 must not regress this case — both paths land at Stopped so the
-// cell-level derivation reaches a terminal state either way.
-func TestGetContainerState_ContainerGoneAlsoStopped(t *testing.T) {
+// TestGetContainerState_ContainerAbsentReturnsNotCreated locks down the #670
+// reporting fix: a container with no containerd record at all (never realized,
+// or reaped/lost — operator ran `ctr -n <ns> containers rm`, or the records
+// vanished per #671) must read back as NotCreated, NOT Stopped. Collapsing the
+// two makes a cell whose containers were lost indistinguishable from a normally
+// stopped cell. The reconciler still treats NotCreated as terminal alongside
+// Stopped (see refresh.go), so the cell-level derivation reaches a terminal
+// state either way — only the reported per-container STATE differs.
+func TestGetContainerState_ContainerAbsentReturnsNotCreated(t *testing.T) {
 	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
 	containerID, containerdID := "root", "kukeon_kukeon_web_root"
 
@@ -114,9 +116,9 @@ func TestGetContainerState_ContainerGoneAlsoStopped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetContainerState: unexpected error: %v", err)
 	}
-	if state != intmodel.ContainerStateStopped {
+	if state != intmodel.ContainerStateNotCreated {
 		t.Errorf(
-			"GetContainerState = %v, want Stopped (container fully gone branch — sanity check the existing path isn't regressed)",
+			"GetContainerState = %v, want NotCreated (no containerd record must not collapse to Stopped, #670)",
 			state,
 		)
 	}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -806,9 +806,10 @@ func cellStateAutoDeleteTriggers(s intmodel.CellState) bool {
 
 // latchReadyObserved is the one-way latch the reconciler uses to decide
 // whether a cell has ever been Ready. A cell that has never reached
-// Ready must not be auto-deleted: GetContainerState returns Stopped
+// Ready must not be auto-deleted: GetContainerState returns NotCreated
 // for a not-yet-existing container (the "container does not exist in
-// containerd" branch in container_state.go), and the reconciler ticking
+// containerd" branch in container_state.go), which the cell-level
+// derivation treats as Stopped, and the reconciler ticking
 // inside the gap between cgroup creation and root-container
 // registration in CreateCell would otherwise reap an in-flight cell.
 //
@@ -881,6 +882,7 @@ func rootContainerStillRunning(rootID string, statuses []intmodel.ContainerStatu
 			return true
 		case intmodel.ContainerStateStopped,
 			intmodel.ContainerStateFailed,
+			intmodel.ContainerStateNotCreated,
 			intmodel.ContainerStateUnknown:
 			return false
 		}
@@ -932,9 +934,10 @@ func (r *Exec) deriveCellState(cell intmodel.Cell) intmodel.CellState {
 // wind-down KillCell. Wait for the next reconcile pass to settle.
 //
 // "Container does not exist in containerd" is mapped to
-// ContainerStateStopped by GetContainerState, so a non-root workload
-// that exited and was reaped naturally counts toward "all stopped"
-// here.
+// ContainerStateNotCreated by GetContainerState; this derivation treats
+// NotCreated as a terminal state alongside Stopped/Failed, so a non-root
+// workload that exited and was reaped naturally still counts toward "all
+// stopped" here.
 func deriveCellStateFromNonRootContainerStatuses(
 	specs []intmodel.ContainerSpec,
 	statuses []intmodel.ContainerStatus,
@@ -962,8 +965,11 @@ func deriveCellStateFromNonRootContainerStatuses(
 			anyActive = true
 		case intmodel.ContainerStateUnknown:
 			anyUnknown = true
-		case intmodel.ContainerStateStopped, intmodel.ContainerStateFailed:
-			// terminal — does not contribute to active.
+		case intmodel.ContainerStateStopped,
+			intmodel.ContainerStateFailed,
+			intmodel.ContainerStateNotCreated:
+			// terminal — does not contribute to active. A reaped/absent
+			// workload (NotCreated) counts the same as a clean stop here.
 		}
 	}
 
@@ -1014,7 +1020,9 @@ func (r *Exec) deriveCellStateFromRootContainer(cell intmodel.Cell) intmodel.Cel
 		intmodel.ContainerStatePaused,
 		intmodel.ContainerStatePausing:
 		return intmodel.CellStateReady
-	case intmodel.ContainerStateStopped, intmodel.ContainerStateFailed:
+	case intmodel.ContainerStateStopped,
+		intmodel.ContainerStateFailed,
+		intmodel.ContainerStateNotCreated:
 		return intmodel.CellStateStopped
 	default:
 		return intmodel.CellStateUnknown

--- a/internal/controller/runner/refresh_test.go
+++ b/internal/controller/runner/refresh_test.go
@@ -360,6 +360,21 @@ func TestDeriveCellStateFromNonRootContainerStatuses(t *testing.T) {
 			want: intmodel.CellStateStopped,
 		},
 		{
+			name: "absent_workload_counts_as_terminal_like_stopped",
+			specs: []intmodel.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "work", Root: false},
+			},
+			// The workload's containerd record vanished (#670/#671) — the
+			// reconciler must still wind the cell down, exactly as for a
+			// clean stop. NotCreated is terminal here.
+			statuses: []intmodel.ContainerStatus{
+				{ID: "root", State: intmodel.ContainerStateReady},
+				{ID: "work", State: intmodel.ContainerStateNotCreated},
+			},
+			want: intmodel.CellStateStopped,
+		},
+		{
 			name: "workload_reads_back_unknown_blocks_stopped_defensive_against_301",
 			specs: []intmodel.ContainerSpec{
 				{ID: "root", Root: true},

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -293,4 +293,9 @@ const (
 	ContainerStatePausing
 	ContainerStateFailed
 	ContainerStateUnknown
+	// ContainerStateNotCreated marks a container with no containerd record at
+	// all — distinct from Stopped (a record that exists but whose task is
+	// gone). Appended last to keep the ordinals in lockstep with the v1beta1
+	// ContainerState enum, which scheme.go converts by direct int cast.
+	ContainerStateNotCreated
 )

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -65,4 +65,7 @@ const (
 	StateUnknownStr  = "Unknown"
 	StateCreatingStr = "Creating"
 	StateDeletingStr = "Deleting"
+	// StateNotCreatedStr is the display label for a container with no
+	// containerd record at all (see ContainerStateNotCreated).
+	StateNotCreatedStr = "NotCreated"
 )

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -423,6 +423,11 @@ const (
 	ContainerStatePausing
 	ContainerStateFailed
 	ContainerStateUnknown
+	// ContainerStateNotCreated marks a container with no containerd record at
+	// all — distinct from Stopped (a record that exists but whose task is
+	// gone). Appended last to keep the ordinals in lockstep with the internal
+	// modelhub.ContainerState enum, which scheme.go converts by direct int cast.
+	ContainerStateNotCreated
 )
 
 func (c *ContainerState) String() string {
@@ -441,6 +446,8 @@ func (c *ContainerState) String() string {
 		return StateFailedStr
 	case ContainerStateUnknown:
 		return StateUnknownStr
+	case ContainerStateNotCreated:
+		return StateNotCreatedStr
 	}
 	return StateUnknownStr
 }

--- a/pkg/api/model/v1beta1/state_marshal.go
+++ b/pkg/api/model/v1beta1/state_marshal.go
@@ -339,6 +339,8 @@ func parseContainerState(in string, out *ContainerState) error {
 		*out = ContainerStateFailed
 	case StateUnknownStr:
 		*out = ContainerStateUnknown
+	case StateNotCreatedStr:
+		*out = ContainerStateNotCreated
 	default:
 		return fmt.Errorf("container state: unknown label %q", in)
 	}
@@ -347,7 +349,7 @@ func parseContainerState(in string, out *ContainerState) error {
 
 func assignContainerStateInt(i int, out *ContainerState) error {
 	v := ContainerState(i)
-	if v < ContainerStatePending || v > ContainerStateUnknown {
+	if v < ContainerStatePending || v > ContainerStateNotCreated {
 		return fmt.Errorf("container state: int %d out of range", i)
 	}
 	*out = v


### PR DESCRIPTION
## Summary
- `kuke get co` collapsed two distinct conditions into `Stopped`: a container whose containerd record exists but whose task is gone (a clean stop / post-reboot, #543) **and** a container with no containerd record at all (never realized, or reaped/lost — #671). An operator could not tell a cell whose containers vanished from a normally-stopped cell.
- The emitting site `internal/controller/runner/container_state.go:154` (the `!containerExists` branch) now returns a new `ContainerStateNotCreated` instead of `Stopped`. The task-gone branch below it still returns `Stopped`, so the two are now visibly distinct in the STATE column ("NotCreated" vs "Stopped").
- Behaviour is identical on the daemon and `--no-daemon` paths since both go through `GetContainerState`.

## Design notes (for reviewer)
- **Enum ordinal lockstep.** `intmodel.ContainerState` and `v1beta1.ContainerState` are converted by a direct `int` cast (`internal/apischeme/scheme.go:434,497`), so the new value is appended **last** in both enums (after `Unknown`) to avoid renumbering existing ordinals. `assignContainerStateInt`'s range check upper bound was bumped to `ContainerStateNotCreated`, and `String()`/`parseContainerState`/`StateNotCreatedStr` were added so the daemon's JSON round-trip carries the distinct label rather than collapsing to `Unknown`.
- **Reconciler behavior preserved.** `refresh.go` deliberately relies on absent→`Stopped` for lifecycle decisions (auto-delete latch #543, wind-down #301). All three switches that classify `GetContainerState`'s result (`rootContainerStillRunning`, `deriveCellStateFromNonRootContainerStatuses`, `deriveCellStateFromRootContainer`) now treat `NotCreated` exactly like `Stopped`, so cell-state derivation and auto-delete/wind-down behavior are unchanged — only the per-container reported STATE differs. Two stale comments referencing the old absent→Stopped mapping were updated.

## Test plan
- [x] `make test` (root module unit suite + kukebuild module) — pass
- [x] `GOWORK=off go build ./...` / `go vet ./...` on affected packages — pass
- [x] `internal/controller/runner/container_state_test.go`: the absent-branch test now asserts `NotCreated` (was `Stopped`); renamed `TestGetContainerState_ContainerAbsentReturnsNotCreated`
- [x] `internal/controller/runner/refresh_test.go`: added `absent_workload_counts_as_terminal_like_stopped` locking in that a `NotCreated` workload still winds the cell to `Stopped`
- [ ] `make dev-init` daemon-parity smoke — not run: this change is in query-time container-state derivation, not the daemon's `/opt/kukeon` read/bootstrap path the parity check guards; cell-state derivation outcomes are unchanged (NotCreated treated as Stopped).

Closes #670