### PR TITLE
build: migrate dev-init.sh and CLAUDE.md off docker (phase 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,13 @@ When a change touches the build path, the daemon, or anything under `/opt/kukeon
 
 ### Prerequisites
 
-`make dev-init` requires two daemons to be running on the host:
+`make dev-init` requires one daemon to be running on the host:
 
-- **Docker daemon** — used to build the local `kukeon-local:dev` image. Start with `service docker start` (or `systemctl start docker`).
-- **Standalone containerd** at `/run/containerd/containerd.sock` — used by `kuke image load` and `kuke init`. This is _not_ the docker-private containerd at `/var/run/docker/containerd/containerd.toml`; `pgrep containerd` may show that one even when the system socket is missing. If `ls /run/containerd/containerd.sock` returns no such file, start it with `service containerd start` (or `systemctl start containerd`). On hosts with no init script and no systemd (e.g., the agent dev container), launch the binary directly: `containerd > /tmp/containerd.log 2>&1 &`.
+- **Standalone containerd** at `/run/containerd/containerd.sock` — used by `kuke build` and `kuke init`. This is _not_ the docker-private containerd at `/var/run/docker/containerd/containerd.toml`; `pgrep containerd` may show that one even when the system socket is missing. If `ls /run/containerd/containerd.sock` returns no such file, start it with `service containerd start` (or `systemctl start containerd`). On hosts with no init script and no systemd (e.g., the agent dev container), launch the binary directly: `containerd > /tmp/containerd.log 2>&1 &`.
 
-A failure in either daemon surfaces as a confusing error several phases into the script — `dial unix /var/run/docker.sock: connect: no such file or directory` for docker, or `failed to connect to containerd: ... dial unix:///run/containerd/containerd.sock: timeout` for containerd. Bring both up before invoking `make dev-init` to skip the rabbit hole.
+No docker daemon is required. `kuke build` invokes the standalone `kukebuild` binary on the host — a BuildKit-as-library image builder that writes straight into the target realm's containerd namespace over the same `/run/containerd/containerd.sock`. `make dev-init`'s build phase produces `kukebuild` alongside `kuke` and places it on `PATH` (`/usr/local/bin`) so the `sudo ./kuke build` step resolves it; a missing `kukebuild` fails fast with `kuke build`'s "not found on PATH" message.
+
+A containerd failure surfaces as a confusing error several phases into the script — `failed to connect to containerd: ... dial unix:///run/containerd/containerd.sock: timeout`. Bring it up before invoking `make dev-init` to skip the rabbit hole.
 
 When run from inside a `kukeon-dev-root` cell (the canonical agent workflow), `make dev-init` automatically redirects the kukeond socket to `/run/kukeon-dev/` so it doesn't clobber the parent host's `kuke attach` plumbing — see [`docs/dev-init.md`](docs/dev-init.md) for the full bare-host vs. nested-mode contract.
 
@@ -44,7 +45,7 @@ When run from inside a `kukeon-dev-root` cell (the canonical agent workflow), `m
 make dev-init
 ```
 
-`scripts/dev-init.sh` composes the full re-bootstrap loop: `make kuke` + `kukeond` symlink, `docker build` of `kukeon-local:dev`, `kuke daemon reset` of the prior cell, `kuke image load --from-docker` of the freshly built image into the `kuke-system` realm, `kuke init --kukeond-image docker.io/library/kukeon-local:dev`, and the daemon-parity check below. The script is idempotent — re-running on a healthy host produces a clean re-bootstrap.
+`scripts/dev-init.sh` composes the full re-bootstrap loop: `make kuke kukebuild` + `kukeond` symlink, `kuke daemon reset` of the prior cell, `kuke build -t kukeon-local:dev --realm kuke-system .` building the image straight into the `kuke-system` realm's containerd namespace, `kuke init --kukeond-image docker.io/library/kukeon-local:dev`, and the daemon-parity check below. The script is idempotent — re-running on a healthy host produces a clean re-bootstrap.
 
 The daemon-parity tail of the output (the regression guard) must read:
 
@@ -68,16 +69,21 @@ To run individual phases by hand — e.g. while debugging a single phase — inv
 2. **Build the binaries.**
 
    ```bash
-   rm -f kuke kukeond
-   make kuke           # produces ./kuke
+   rm -f kuke kukeond kukebuild
+   make kuke kukebuild # produces ./kuke and ./kukebuild
    ln -sf kuke kukeond # kukeond is argv[0]-dispatched from the same binary
+   sudo ln -sf "$(pwd)/kukebuild" /usr/local/bin/kukebuild # kuke build resolves kukebuild via PATH
    ```
 
-3. **Build and load the local `kukeond` image (no registry push).**
+3. **Build the local `kukeond` image into the `kuke-system` realm (no registry push).**
+
+   `kuke build` invokes `kukebuild` (BuildKit as a library), which writes the
+   image straight into the realm's containerd namespace — no docker daemon and
+   no `--from-docker` loader hop. The `kuke-system` realm must already exist
+   (created by an earlier `kuke init` pass).
 
    ```bash
-   docker build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev .
-   sudo ./kuke image load --from-docker kukeon-local:dev --realm kuke-system
+   sudo ./kuke build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev --realm kuke-system .
    sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
    ```
 

--- a/Makefile
+++ b/Makefile
@@ -201,14 +201,21 @@ dev-init:
 # are picked up automatically — a stale hard copy is exactly the footgun a
 # dev workflow can't afford. argv[0] dispatch resolves `kukeond` to the
 # daemon entrypoint because the basename of the exec path is `kukeond`.
+#
+# kukebuild is symlinked only when it has been built (the `[ -f ]` guard), so
+# `kuke build` resolves it on PATH after `make dev-init` (which runs `make kuke
+# kukebuild` before this target) without imposing kukebuild's separate-module
+# build on a plain `make install-dev`. Routing it through INSTALL_PREFIX here
+# keeps a single PATH-placement mechanism instead of a second one in dev-init.sh.
 .PHONY: install-dev uninstall-dev
 install-dev: kuke
 	ln -sf kuke kukeond
 	sudo ln -sf $(CURDIR)/kuke $(INSTALL_PREFIX)/kuke
 	sudo ln -sf $(CURDIR)/kuke $(INSTALL_PREFIX)/kukeond
+	@[ -f $(CURDIR)/kukebuild ] && sudo ln -sf $(CURDIR)/kukebuild $(INSTALL_PREFIX)/kukebuild || true
 
 uninstall-dev:
-	sudo rm -f $(INSTALL_PREFIX)/kuke $(INSTALL_PREFIX)/kukeond
+	sudo rm -f $(INSTALL_PREFIX)/kuke $(INSTALL_PREFIX)/kukeond $(INSTALL_PREFIX)/kukebuild
 
 # Publish the one-line installer through the mkdocs site: copy
 # `scripts/install.sh` (canonical source) into `docs/site/install.sh` so

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -2,7 +2,7 @@
 # Copyright 2025 Emiliano Spinella (eminwux)
 # SPDX-License-Identifier: Apache-2.0
 #
-# dev-init.sh — local kukeond build + load + init loop for contributors.
+# dev-init.sh — local kukeond build + init loop for contributors.
 #
 # Composes existing primitives end-to-end so a `kuke init` runs against the
 # locally built kukeond image instead of the registry-resolved default. Lifts
@@ -10,10 +10,9 @@
 #
 # Idempotent: re-running on a healthy host produces a clean re-bootstrap.
 # On a fresh host (no /opt/kukeon/data/kuke-system) the script first runs
-# `kuke init` to create realm metadata so the subsequent `kuke image load
-# --realm kuke-system` has a realm to land into; cell provisioning during
-# that first-pass init may fail before the image is staged, which is
-# expected.
+# `kuke init` to create realm metadata so the subsequent `kuke build --realm
+# kuke-system` has a realm to write into; cell provisioning during that
+# first-pass init may fail before the image is built, which is expected.
 
 set -euo pipefail
 
@@ -132,7 +131,7 @@ verify_parent_attach_intact() {
 }
 
 # Register the post-flight check BEFORE any state-mutating step so an
-# early failure (e.g. during `make kuke`, `docker build`, or the first
+# early failure (e.g. during `make kuke`, `kuke build`, or the first
 # `kuke init`) still surfaces a disturbance of the parent's attach
 # plumbing. The smoke section below replaces this trap with
 # `cleanup_attach_smoke`, whose last step is the same
@@ -140,15 +139,21 @@ verify_parent_attach_intact() {
 # holds at every exit point in the script.
 trap 'verify_parent_attach_intact || exit 1' EXIT
 
-step "Build kuke (and the kukeond symlink)"
-make kuke
+step "Build kuke, kukebuild (and the kukeond symlink)"
+make kuke kukebuild
 ln -sf kuke kukeond
 
 step "Install dev symlinks on PATH (make install-dev)"
 make install-dev
+# `kuke build` (used below in place of the old docker build) is a thin shim
+# that resolves the standalone `kukebuild` binary via PATH and exec's it. The
+# build step runs as `sudo ./kuke build`, so kukebuild must sit on root's
+# secure_path. install-dev only symlinks kuke/kukeond into /usr/local/bin, so
+# place kukebuild there too (mirroring install-dev's INSTALL_PREFIX default).
+sudo ln -sf "${REPO_ROOT}/kukebuild" /usr/local/bin/kukebuild
 
 # Pre-flight: catch missing host cgroup-v2 controller delegation BEFORE the
-# multi-minute docker build runs (issue #324). On a fully-delegated host
+# multi-minute kuke build runs (issue #324). On a fully-delegated host
 # this is silent; on a misconfigured host (e.g. cgroup namespace whose
 # parent only delegated a subset) it fails fast with the missing
 # controllers named and a copy-pasteable remediation. --probe attempts the
@@ -159,27 +164,25 @@ step "Pre-flight: host cgroup controller delegation"
 sudo ./kuke doctor cgroups --probe
 
 # Pre-flight: catch a missing standalone containerd BEFORE the multi-minute
-# docker build, and BEFORE the first-pass `kuke init` below whose tolerate-
-# non-zero (image-not-staged) would otherwise swallow the connection-timeout
-# error and surface a misleading downstream "realm not found: kuke-system"
-# at image load (issue #344).
+# kuke build (kukebuild dials the same /run/containerd/containerd.sock), and
+# BEFORE the first-pass `kuke init` below whose tolerate-non-zero (image-not-
+# staged) would otherwise swallow the connection-timeout error and surface a
+# misleading downstream "realm not found: kuke-system" at build time
+# (issue #344).
 step "Pre-flight: containerd reachability"
 if [ ! -S /run/containerd/containerd.sock ]; then
     printf 'containerd is not running at /run/containerd/containerd.sock — start it before re-running\n' >&2
     exit 1
 fi
 
-step "Build local kukeond image (${LOCAL_TAG})"
-docker build --build-arg VERSION=v0.0.0-dev -t "${LOCAL_TAG}" .
-
 if [ ! -d "${SYSTEM_REALM_DIR}" ]; then
     step "First-time bootstrap: run kuke init to create realm metadata"
-    # The kuke-system realm must exist before `kuke image load --realm
-    # kuke-system` will accept the load. On a fresh host that realm is
-    # created by kuke init's bootstrap pass; cell provisioning at the end
-    # of that pass may fail because the local image is not yet staged in
-    # containerd. Tolerate that — the second init below recreates the
-    # cell after the image load succeeds.
+    # The kuke-system realm must exist before `kuke build --realm
+    # kuke-system` will write the image into its containerd namespace. On a
+    # fresh host that realm is created by kuke init's bootstrap pass; cell
+    # provisioning at the end of that pass may fail because the local image
+    # is not yet built into containerd. Tolerate that — the second init
+    # below recreates the cell after the build succeeds.
     sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
         || echo "first-pass init returned non-zero (expected before image is staged); continuing"
 fi
@@ -191,10 +194,15 @@ else
     step "No prior kukeond cell at ${KUKEOND_CELL_DIR}; skipping reset"
 fi
 
-step "Load ${LOCAL_TAG} into the kuke-system realm"
-# `kuke image load` is in-process by design (#226); --no-daemon is not
-# passed because the flag is a no-op for image subcommands.
-sudo --preserve-env=KUKEON_HOST ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system
+step "Build ${LOCAL_TAG} into the kuke-system realm"
+# `kuke build` shells out to `kukebuild`, which embeds BuildKit and writes the
+# image straight into the kuke-system realm's containerd namespace — no docker
+# daemon, no docker-private containerd, no `--from-docker` loader hop. The -t
+# short tag normalizes to docker.io/library/kukeon-local:dev (kukebuild's
+# normalizeImageName), the exact ref `kuke init --kukeond-image` resolves below.
+sudo --preserve-env=KUKEON_HOST ./kuke build --build-arg VERSION=v0.0.0-dev \
+    -t "${LOCAL_TAG}" \
+    --realm kuke-system .
 
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
 sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}"

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -144,13 +144,13 @@ make kuke kukebuild
 ln -sf kuke kukeond
 
 step "Install dev symlinks on PATH (make install-dev)"
+# install-dev symlinks kuke/kukeond and — because `make kuke kukebuild` above
+# has built it — kukebuild into INSTALL_PREFIX (/usr/local/bin by default). The
+# `kuke build` step below runs as `sudo ./kuke build`, a thin shim that resolves
+# `kukebuild` via PATH and exec's it, so kukebuild must sit on root's
+# secure_path; routing it through install-dev keeps a single PATH-placement
+# mechanism.
 make install-dev
-# `kuke build` (used below in place of the old docker build) is a thin shim
-# that resolves the standalone `kukebuild` binary via PATH and exec's it. The
-# build step runs as `sudo ./kuke build`, so kukebuild must sit on root's
-# secure_path. install-dev only symlinks kuke/kukeond into /usr/local/bin, so
-# place kukebuild there too (mirroring install-dev's INSTALL_PREFIX default).
-sudo ln -sf "${REPO_ROOT}/kukebuild" /usr/local/bin/kukebuild
 
 # Pre-flight: catch missing host cgroup-v2 controller delegation BEFORE the
 # multi-minute kuke build runs (issue #324). On a fully-delegated host


### PR DESCRIPTION
## Summary

Phase 3 of dropping the contributor onboarding path's docker dependency (#525, follows phase 1 #522 which shipped `kuke build`). The build path now writes the local `kukeon-local:dev` image straight into the `kuke-system` realm's containerd namespace via a single `kuke build` call — no docker daemon, no docker-private containerd, no `--from-docker` loader hop.

- **`scripts/dev-init.sh`**: the `docker build` step and the `kuke image load --from-docker` step collapse into one `sudo ./kuke build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev --realm kuke-system .`. The `kuke-system`-realm-must-exist-first ordering (first-pass `kuke init`) is preserved. Pre-flight/trap comments referencing `docker build` are refreshed.
- **`Makefile`**: `install-dev` symlinks `kukebuild` into `INSTALL_PREFIX` when the binary exists (conditional guard); `uninstall-dev` removes it.
- **`CLAUDE.md`**: the "Local smoke test → Prerequisites" section drops the docker-daemon requirement and the `dial unix /var/run/docker.sock` error hint, adds a `kukebuild` paragraph, and keeps the standalone-containerd note. Manual phases 2–3 updated to the new `kuke build` call.

### Implementation note

`kuke build` is a thin shim that resolves the standalone `kukebuild` binary via `exec.LookPath` and exec's it. The script runs `sudo ./kuke build`, so `kukebuild` must sit on root's `secure_path`. Per review, the PATH placement routes through the existing `install-dev` mechanism: `install-dev` gains a conditional `@[ -f $(CURDIR)/kukebuild ] && sudo ln -sf $(CURDIR)/kukebuild $(INSTALL_PREFIX)/kukebuild || true` line. This honors `INSTALL_PREFIX` and keeps a single PATH-placement mechanism, while the `[ -f ]` guard means a plain `make install-dev` (without a built `kukebuild`) is unaffected — no `go 1.25` separate-module build (#655) is imposed on contributors who only want `kuke`. `dev-init.sh`'s `make kuke kukebuild` (build phase) guarantees the binary is present before `make install-dev` runs.

The `-t kukeon-local:dev` short tag normalizes to `docker.io/library/kukeon-local:dev` via kukebuild's `normalizeImageName` (`cmd/kukebuild/build.go:464`), which is the exact ref `kuke init --kukeond-image docker.io/library/kukeon-local:dev` resolves — so the build/init handoff round-trips.

### Before / after — `scripts/dev-init.sh`

Before:
```bash
step "Build local kukeond image (${LOCAL_TAG})"
docker build --build-arg VERSION=v0.0.0-dev -t "${LOCAL_TAG}" .
...
step "Load ${LOCAL_TAG} into the kuke-system realm"
sudo --preserve-env=KUKEON_HOST ./kuke image load --from-docker "${LOCAL_TAG}" --realm kuke-system
```

After (docker build removed; load replaced by build):
```bash
step "Build ${LOCAL_TAG} into the kuke-system realm"
sudo --preserve-env=KUKEON_HOST ./kuke build --build-arg VERSION=v0.0.0-dev \
    -t "${LOCAL_TAG}" \
    --realm kuke-system .
```
The build phase runs `make kuke kukebuild`; `make install-dev` then places `kukebuild` on PATH (no second symlink mechanism in the script).

### Before / after — `CLAUDE.md` prerequisites

Before:
> `make dev-init` requires two daemons to be running on the host:
> - **Docker daemon** — used to build the local `kukeon-local:dev` image. …
> - **Standalone containerd** … used by `kuke image load` and `kuke init`. …

After:
> `make dev-init` requires one daemon to be running on the host:
> - **Standalone containerd** … used by `kuke build` and `kuke init`. …
>
> No docker daemon is required. `kuke build` invokes the standalone `kukebuild` binary … `make dev-init`'s build phase produces `kukebuild` alongside `kuke` and places it on `PATH` …

## Test plan
- [x] `make test` — both modules (root + `cmd/kukebuild`) pass.
- [x] `bash -n scripts/dev-init.sh` — syntax OK. (shellcheck not installed on the dev host.)
- [x] `make dev-init` end-to-end **exit 0** in the canonical nested `kukeon-dev-root` cell with **no docker build invoked** (`grep -c "docker build"` over the run log = 0; build ran through BuildKit's Dockerfile frontend). Re-run after the install-dev fix-up. AC#2.
- [x] Daemon-parity regression guard: both `kuke get realms` and `kuke get realms --no-daemon` printed the identical two-realm `Ready` table. AC#3.
- [x] `kuke attach` smoke against a kuketty-wrapped cell exited cleanly; nested-mode parent attach plumbing verified intact post-flight.
- [x] `install-dev` symlinks `kukebuild` when present and `sudo ./kuke build` resolves it over sudo's `secure_path`; with the binary absent, `install-dev` exits cleanly and creates no symlink; `uninstall-dev` removes it.

Closes #525