### PR TITLE
fix: diff Spec.Repos and Spec.Secrets in diffContainerSpec

### DIFF
--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -649,6 +649,24 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bo
 		result.Details["resources"] = "resource limits changed"
 	}
 
+	if !secretsEqual(desired.Secrets, actual.Secrets) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "secrets")
+		result.Details["secrets"] = "secrets changed"
+	}
+
+	if !reposEqual(desired.Repos, actual.Repos) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "repos")
+		result.Details["repos"] = "repos changed"
+	}
+
 	return result
 }
 
@@ -853,6 +871,45 @@ func volumeMountsEqual(a, b []intmodel.VolumeMount) bool {
 		}
 	}
 	return true
+}
+
+func reposEqual(a, b []intmodel.ContainerRepo) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		// ContainerRepo is a flat struct of comparable fields.
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func secretsEqual(a, b []intmodel.ContainerSecret) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name ||
+			a[i].FromFile != b[i].FromFile ||
+			a[i].FromEnv != b[i].FromEnv ||
+			a[i].MountPath != b[i].MountPath ||
+			!secretRefEqual(a[i].SecretRef, b[i].SecretRef) {
+			return false
+		}
+	}
+	return true
+}
+
+func secretRefEqual(a, b *intmodel.ContainerSecretRef) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 func registryCredentialsEqual(a, b []intmodel.RegistryCredentials) bool {

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -508,3 +508,93 @@ func TestDiffContainer_NonRootInPlace(t *testing.T) {
 		t.Errorf("non-root image bump must not populate BreakingChanges, got %v", diff.BreakingChanges)
 	}
 }
+
+func hasChangedField(diff apply.DiffResult, field string) bool {
+	for _, f := range diff.ChangedFields {
+		if f == field {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDiffContainer_ReposChange exercises the repos[]-only edit path: an apply
+// that touches only Spec.Repos must register as a compatible change so the
+// reconcile triggers, rather than being realized lazily on the next start
+// (issue #647).
+func TestDiffContainer_ReposChange(t *testing.T) {
+	desired := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "web"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "web",
+			RealmName: "default", SpaceName: "default", StackName: "default", CellName: "hello-world",
+			Image: "nginx:1.27",
+			Repos: []intmodel.ContainerRepo{{Name: "app", URL: "https://example.com/app.git", Target: "/src"}},
+		},
+	}
+	actual := desired
+	actual.Spec.Repos = []intmodel.ContainerRepo{{Name: "app", URL: "https://example.com/app.git", Target: "/srv"}}
+
+	diff := apply.DiffContainer(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible change for repos edit, got %v", diff.ChangeType)
+	}
+	if !hasChangedField(diff, "repos") {
+		t.Errorf("expected ChangedFields to include repos, got %v", diff.ChangedFields)
+	}
+}
+
+// TestDiffContainer_SecretsChange exercises the secrets[]-only edit path,
+// including the SecretRef pointer-value comparison (issue #647).
+func TestDiffContainer_SecretsChange(t *testing.T) {
+	desired := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "web"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "web",
+			RealmName: "default", SpaceName: "default", StackName: "default", CellName: "hello-world",
+			Image: "nginx:1.27",
+			Secrets: []intmodel.ContainerSecret{{
+				Name:      "db",
+				SecretRef: &intmodel.ContainerSecretRef{Name: "db-creds", Realm: "default"},
+			}},
+		},
+	}
+	actual := desired
+	actual.Spec.Secrets = []intmodel.ContainerSecret{{
+		Name:      "db",
+		SecretRef: &intmodel.ContainerSecretRef{Name: "db-creds", Realm: "prod"},
+	}}
+
+	diff := apply.DiffContainer(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible change for secrets edit, got %v", diff.ChangeType)
+	}
+	if !hasChangedField(diff, "secrets") {
+		t.Errorf("expected ChangedFields to include secrets, got %v", diff.ChangedFields)
+	}
+}
+
+// TestDiffContainer_ReposSecretsNoChange guards the equality helpers: identical
+// repos/secrets (including a populated SecretRef) must not register drift on a
+// same-spec re-apply.
+func TestDiffContainer_ReposSecretsNoChange(t *testing.T) {
+	desired := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "web"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "web",
+			RealmName: "default", SpaceName: "default", StackName: "default", CellName: "hello-world",
+			Image: "nginx:1.27",
+			Repos: []intmodel.ContainerRepo{{Name: "app", URL: "https://example.com/app.git", Target: "/src", Required: true}},
+			Secrets: []intmodel.ContainerSecret{{
+				Name:      "db",
+				SecretRef: &intmodel.ContainerSecretRef{Name: "db-creds", Realm: "default"},
+			}},
+		},
+	}
+	actual := desired
+
+	diff := apply.DiffContainer(desired, actual)
+	if diff.HasChanges {
+		t.Fatalf("expected no changes for identical repos/secrets, got %v", diff.ChangedFields)
+	}
+}


### PR DESCRIPTION
## Summary
- `diffContainerSpec` enumerated container spec fields one-by-one but never compared `.Spec.Repos` (added in #627) or `.Spec.Secrets` (pre-existing), so a `kuke apply` editing only `repos[]` or `secrets[]` registered no drift — the new declaration was realized lazily on the next container start instead of triggering an update/recreate.
- Took the precedent's "diff both fields" option from the issue (not the "document as intentional" alternative): added `secrets` and `repos` compatible-change branches alongside `tmpfs`/`volumes`, plus `reposEqual` / `secretsEqual` helpers mirroring `tmpfsEqual`/`volumeMountsEqual`.
- `ContainerRepo` is a flat comparable struct (direct `!=`); `ContainerSecret` carries a `*ContainerSecretRef` pointer, so `secretsEqual` compares scalar fields and dereferences `SecretRef` via a nil-safe `secretRefEqual`.

## Test plan
- [x] `make test` (full CI target: `go test $(go list ./... | grep -v /e2e)` + `cd cmd/kukebuild && go test ./...`) — passes
- [x] `GOWORK=off go build ./...` / `go vet ./internal/controller/apply/` — clean
- [x] New tests: `TestDiffContainer_ReposChange`, `TestDiffContainer_SecretsChange` (incl. `SecretRef` pointer-value comparison), `TestDiffContainer_ReposSecretsNoChange`

Closes #647