### PR TITLE
fix: guard cgroups manager cache with a mutex

### DIFF
--- a/internal/ctr/cgroups.go
+++ b/internal/ctr/cgroups.go
@@ -547,6 +547,8 @@ func (c *client) effectiveMountpoint(mountpoint string) string {
 }
 
 func (c *client) storeManager(group string, manager *cgroup2.Manager) {
+	c.cgroupsMu.Lock()
+	defer c.cgroupsMu.Unlock()
 	if c.cgroups == nil {
 		c.cgroups = make(map[string]*cgroup2.Manager)
 	}
@@ -554,6 +556,8 @@ func (c *client) storeManager(group string, manager *cgroup2.Manager) {
 }
 
 func (c *client) dropManager(group string) {
+	c.cgroupsMu.Lock()
+	defer c.cgroupsMu.Unlock()
 	if c.cgroups == nil {
 		return
 	}
@@ -564,7 +568,10 @@ func (c *client) managerFor(group, mountpoint string) (*cgroup2.Manager, error) 
 	if err := validateGroupPath(group); err != nil {
 		return nil, err
 	}
-	if manager, ok := c.cgroups[group]; ok {
+	c.cgroupsMu.RLock()
+	manager, ok := c.cgroups[group]
+	c.cgroupsMu.RUnlock()
+	if ok {
 		return manager, nil
 	}
 	mp := c.effectiveMountpoint(mountpoint)

--- a/internal/ctr/cgroups_internal_test.go
+++ b/internal/ctr/cgroups_internal_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // Tests inner workings of the cgroups manager cache.
+package ctr
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+func setupTestClientForCgroupsCache(t *testing.T) *client {
+	t.Helper()
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewClient(ctx, logger, "/test/socket").(*client)
+}
+
+func TestStoreManagerInitializesMap(t *testing.T) {
+	c := setupTestClientForCgroupsCache(t)
+	c.cgroups = nil // Simulate uninitialized map
+
+	c.storeManager("/kukeon/test", nil)
+
+	if c.cgroups == nil {
+		t.Fatal("cgroups map should be initialized")
+	}
+	if _, ok := c.cgroups["/kukeon/test"]; !ok {
+		t.Error("manager should be stored in cache")
+	}
+}
+
+func TestDropManagerNilMap(t *testing.T) {
+	c := setupTestClientForCgroupsCache(t)
+	c.cgroups = nil // Should not panic
+
+	c.dropManager("/kukeon/test")
+}
+
+func TestDropManager(t *testing.T) {
+	c := setupTestClientForCgroupsCache(t)
+	c.storeManager("/kukeon/test", nil)
+
+	c.dropManager("/kukeon/test")
+
+	if _, ok := c.cgroups["/kukeon/test"]; ok {
+		t.Error("manager should be removed from cache")
+	}
+}
+
+// TestCgroupsCacheConcurrency drives concurrent store/drop/load of the cgroups
+// manager cache so `go test -race` flags any unsynchronized map access. The
+// load path (managerFor) is exercised against a pre-populated, never-dropped
+// group so it stays a cache hit and never falls through to cgroup2.LoadManager
+// (which would touch the filesystem); the store/drop churn runs on a disjoint
+// set of groups concurrently. Without cgroupsMu this races with a fatal
+// "concurrent map writes" / detector report.
+func TestCgroupsCacheConcurrency(t *testing.T) {
+	c := setupTestClientForCgroupsCache(t)
+
+	const stable = "/kukeon/stable"
+	c.storeManager(stable, nil) // cache hit target for the load path
+
+	const workers = 8
+	var wg sync.WaitGroup
+	wg.Add(workers * 3)
+
+	for w := 0; w < workers; w++ {
+		group := fmt.Sprintf("/kukeon/churn-%d", w)
+		go func() {
+			defer wg.Done()
+			c.storeManager(group, nil)
+		}()
+		go func() {
+			defer wg.Done()
+			c.dropManager(group)
+		}()
+		go func() {
+			defer wg.Done()
+			if _, err := c.managerFor(stable, "/sys/fs/cgroup"); err != nil {
+				t.Errorf("managerFor(%q) cache hit returned error: %v", stable, err)
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -35,6 +35,7 @@ type client struct {
 	logger               *slog.Logger
 	socket               string
 	cClient              *containerd.Client
+	cgroupsMu            sync.RWMutex
 	cgroups              map[string]*cgroup2.Manager
 	containersMu         sync.RWMutex
 	containers           map[string]containerd.Container


### PR DESCRIPTION
## Summary
- The shared `ctr.client` cached cgroup2 managers in an unsynchronized map (`internal/ctr/client.go:38`). The daemon serves each RPC connection in its own goroutine plus a background reconcile loop, all sharing one client. The sibling `containers`/`tasks` caches are guarded by `containersMu`/`tasksMu`; the `cgroups` map had no mutex, so concurrent CreateCell/StartCell vs DeleteCell/purge vs reconcile could produce `fatal error: concurrent map writes` and panic the daemon.
- Add `cgroupsMu sync.RWMutex` and guard all three accessors (`storeManager`/`dropManager`/`managerFor`) consistently with the existing container/task caches: write-lock the store/drop mutations; `managerFor` takes the read lock for the cache-hit check and releases it before the (filesystem-touching) `cgroup2.LoadManager` miss path, mirroring `loadContainer` in `cache.go`.

## Test plan
- [x] `make test` — full CI target, passes (ctr package included).
- [x] `go build ./...`, `go vet ./internal/ctr/...` — clean.
- [x] New `TestCgroupsCacheConcurrency` (plus `TestStoreManagerInitializesMap`/`TestDropManager`/`TestDropManagerNilMap`) drives concurrent store/drop/load of the cgroups cache; passes under `make test`. It mirrors the sibling `TestContainerCacheConcurrency`/`TestTaskCacheConcurrency` and is structured for the race detector (load path pinned to a pre-populated cache-hit group so it never falls through to `cgroup2.LoadManager`).
- [ ] `go test -race` — could not run locally: `-race` requires cgo and no C compiler (`gcc`/`clang`/`cc`) is present on the dev host. The repo's CI target (`make test`, `.github/workflows/test.yaml`) does not pass `-race`, so this is not a CI-target gap; the test still exercises the concurrent paths under plain `go test`.

## Notes
- Same #303 concurrency class (5e76b30) as the lazy-`ctrClient`-init race in #684; this PR fixes only the cgroups cache field that refactor missed. #684 is left as its own change (the issue noted bundling was optional).

Closes #681