### PR TITLE
fix: start tasks in RecreateCell before stamping Ready

### DIFF
--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -111,11 +111,12 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	}
 
 	// Release the root container's CNI/IPAM reservation before deleting it.
-	// createCellContainers below rebuilds the root under this same deterministic
-	// containerd ID and re-runs CNI ADD; without releasing first, host-local
-	// IPAM rejects the re-ADD as a duplicate allocation (issue #630). releaseCNI
-	// runs before the stop/delete so the netns is still valid for CNI DEL where
-	// applicable; purgeCNI scrubs the residual allocation file afterward.
+	// createCellContainers below rebuilds the root container record under this
+	// same deterministic containerd ID, and the StartCell call at the end of
+	// RecreateCell re-runs CNI ADD against it; without releasing first,
+	// host-local IPAM rejects the re-ADD as a duplicate allocation (issue #630).
+	// releaseCNI runs before the stop/delete so the netns is still valid for CNI
+	// DEL where applicable; purgeCNI scrubs the residual allocation file afterward.
 	cellName := strings.TrimSpace(existing.Metadata.Name)
 	cniConfigPath, _ := r.resolveSpaceCNIConfigPath(realmName, spaceName)
 	networkName := r.resolveRootCNINetworkName(realmName, spaceName)
@@ -175,12 +176,25 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, fmt.Errorf("failed to recreate cell containers: %w", err)
 	}
 
-	markCellReady(&desired)
-
-	// Update metadata
+	// Persist the recreated container records (new root spec + freshly assigned
+	// containerd IDs) so StartCell's GetCell reads them. Ready is intentionally
+	// NOT stamped here: createCellContainers only created container *records* —
+	// no task is running and CNI ADD has not run yet (issue #682). Stamping
+	// Ready now would leave the cell reporting Ready over created-but-not-started
+	// containers if StartCell never ran.
 	if updateErr := r.UpdateCellMetadata(desired); updateErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrUpdateCellMetadata, updateErr)
 	}
 
-	return desired, nil
+	// Bring the recreated cell to the same running state a fresh create -> start
+	// produces before Ready is stamped — mirrors the create branch in
+	// apply/reconcile.go (CreateCell -> StartCell). StartCell starts the tasks,
+	// runs CNI ADD against the deterministic root ID, and stamps + persists Ready
+	// only once the cell is actually up.
+	started, startErr := r.StartCell(desired)
+	if startErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to start recreated cell: %w", startErr)
+	}
+
+	return started, nil
 }

--- a/internal/controller/runner/recreate_cell_test.go
+++ b/internal/controller/runner/recreate_cell_test.go
@@ -1,0 +1,225 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.RecreateCell against an in-package ctr.Client fake
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/metadata"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// recreateCellTask is a near-empty containerd.Task. StartCell only reads
+// Pid() on the root task it starts; every other method is promoted from the
+// embedded nil interface and panics if called, which is the desired tripwire
+// if StartCell ever grows a new dependency on the returned task.
+type recreateCellTask struct {
+	containerd.Task
+	pid uint32
+}
+
+func (t recreateCellTask) Pid() uint32 { return t.pid }
+
+// recreateCellFakeClient reuses deleteCellFakeClient for the bulk of the
+// ctr.Client surface and adds the StartContainer hook RecreateCell -> StartCell
+// needs (the embedded fake returns a nil task, which would panic at Pid()).
+type recreateCellFakeClient struct {
+	*deleteCellFakeClient
+	startContainerFn func(namespace string, spec ctr.ContainerSpec, taskSpec ctr.TaskSpec) (containerd.Task, error)
+}
+
+func (c *recreateCellFakeClient) StartContainer(
+	namespace string, spec ctr.ContainerSpec, taskSpec ctr.TaskSpec,
+) (containerd.Task, error) {
+	if c.startContainerFn != nil {
+		return c.startContainerFn(namespace, spec, taskSpec)
+	}
+	return c.deleteCellFakeClient.StartContainer(namespace, spec, taskSpec)
+}
+
+var _ ctr.Client = (*recreateCellFakeClient)(nil)
+
+func newRecreateCellTestExec(t *testing.T, fake *recreateCellFakeClient) *Exec {
+	t.Helper()
+	runPath := t.TempDir()
+	cniCacheDir := t.TempDir()
+	return &Exec{
+		ctx:       context.Background(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctrClient: fake,
+		opts:      Options{RunPath: runPath},
+		cniConf:   &cni.Conf{CniCacheDir: cniCacheDir},
+		nowFn:     func() time.Time { return time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC) },
+	}
+}
+
+func seedRecreateCellSpace(t *testing.T, r *Exec, realm, space string) {
+	t.Helper()
+	doc := v1beta1.SpaceDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindSpace,
+		Metadata:   v1beta1.SpaceMetadata{Name: space},
+		// An explicit CNIConfigPath short-circuits resolveSpaceCNIConfigPath's
+		// default-path build; the path is never read because the root is
+		// host-network (CNI ADD is skipped).
+		Spec: v1beta1.SpaceSpec{RealmID: realm, CNIConfigPath: filepath.Join(t.TempDir(), "cni.conflist")},
+	}
+	path := fs.SpaceMetadataPath(r.opts.RunPath, realm, space)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir space metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write space metadata: %v", err)
+	}
+}
+
+// recreateCellHostNetworkCell returns an existing (on-disk) cell and the
+// desired cell carrying a changed root image. The root is host-network so
+// StartCell skips the CNI dance the unit harness can't satisfy; a single
+// root container keeps StartCell's non-root recreate loop out of the picture.
+func recreateCellHostNetworkCell(realm, space, stack, name, image string) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: name},
+		Spec: intmodel.CellSpec{
+			ID:              name,
+			RealmName:       realm,
+			SpaceName:       space,
+			StackName:       stack,
+			RootContainerID: "root",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, HostNetwork: true, Image: image},
+			},
+		},
+		Status: intmodel.CellStatus{State: intmodel.CellStatePending},
+	}
+}
+
+// TestRecreateCell_StartsTasksBeforeReady is the regression guard for issue
+// #682: RecreateCell (the apply root-container-change handler at
+// apply/reconcile.go's diff.RootContainerChanged branch) used to stamp Ready
+// straight after createCellContainers, which only creates container *records*
+// — no task running, no CNI ADD. The fix routes the recreated cell through
+// StartCell so the root task is actually started before Ready is persisted.
+func TestRecreateCell_StartsTasksBeforeReady(t *testing.T) {
+	const (
+		realm = "default"
+		space = "default"
+		stack = "default"
+		cell  = "web"
+	)
+
+	var startContainerCalls int
+	fake := &recreateCellFakeClient{
+		deleteCellFakeClient: &deleteCellFakeClient{},
+		startContainerFn: func(_ string, _ ctr.ContainerSpec, _ ctr.TaskSpec) (containerd.Task, error) {
+			startContainerCalls++
+			return recreateCellTask{pid: 4242}, nil
+		},
+	}
+	r := newRecreateCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	seedRecreateCellSpace(t, r, realm, space)
+
+	// Seed the existing cell with the old root image; persisting it is what
+	// RecreateCell's leading GetCell reads back.
+	existing := recreateCellHostNetworkCell(realm, space, stack, cell, "alpine:3.18")
+	existing.Status.State = intmodel.CellStateReady
+	if err := r.UpdateCellMetadata(existing); err != nil {
+		t.Fatalf("seed existing cell: %v", err)
+	}
+
+	desired := recreateCellHostNetworkCell(realm, space, stack, cell, "alpine:3.19")
+
+	got, err := r.RecreateCell(desired)
+	if err != nil {
+		t.Fatalf("RecreateCell: %v", err)
+	}
+
+	if startContainerCalls == 0 {
+		t.Error("RecreateCell did not start any task — Ready was stamped over created-but-not-started containers (issue #682)")
+	}
+	if got.Status.State != intmodel.CellStateReady {
+		t.Errorf("returned cell State = %v, want Ready", got.Status.State)
+	}
+
+	persisted, err := r.GetCell(desired)
+	if err != nil {
+		t.Fatalf("GetCell after RecreateCell: %v", err)
+	}
+	if persisted.Status.State != intmodel.CellStateReady {
+		t.Errorf("persisted cell State = %v, want Ready", persisted.Status.State)
+	}
+}
+
+// TestRecreateCell_DoesNotStampReadyWhenStartFails pins AC #2: Ready is never
+// persisted on created-but-not-started containers. When the root task fails to
+// start, RecreateCell must surface the error and the cell must not be left
+// Ready — the precise divergence the old markCellReady-without-start produced.
+func TestRecreateCell_DoesNotStampReadyWhenStartFails(t *testing.T) {
+	const (
+		realm = "default"
+		space = "default"
+		stack = "default"
+		cell  = "web"
+	)
+
+	startBoom := errors.New("task start refused")
+	fake := &recreateCellFakeClient{
+		deleteCellFakeClient: &deleteCellFakeClient{},
+		startContainerFn: func(_ string, _ ctr.ContainerSpec, _ ctr.TaskSpec) (containerd.Task, error) {
+			return nil, startBoom
+		},
+	}
+	r := newRecreateCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	seedRecreateCellSpace(t, r, realm, space)
+
+	existing := recreateCellHostNetworkCell(realm, space, stack, cell, "alpine:3.18")
+	existing.Status.State = intmodel.CellStateReady
+	if err := r.UpdateCellMetadata(existing); err != nil {
+		t.Fatalf("seed existing cell: %v", err)
+	}
+
+	desired := recreateCellHostNetworkCell(realm, space, stack, cell, "alpine:3.19")
+
+	if _, err := r.RecreateCell(desired); err == nil {
+		t.Fatal("RecreateCell returned nil error despite the root task failing to start")
+	}
+
+	persisted, err := r.GetCell(desired)
+	if err != nil {
+		t.Fatalf("GetCell after failed RecreateCell: %v", err)
+	}
+	if persisted.Status.State == intmodel.CellStateReady {
+		t.Error("cell persisted Ready after the root task failed to start (issue #682 AC #2)")
+	}
+}


### PR DESCRIPTION
## Summary

- `RecreateCell` (the apply root-container-change handler reached via `apply/reconcile.go`'s `diff.RootContainerChanged` branch) called `createCellContainers` then stamped `Ready` and persisted — but `createCellContainers` only creates container *records*; it does not start tasks or run CNI ADD ("CNI ADD runs during StartCell", `provision.go:1446`). The cell was reported `Ready` with no task running and no network attachment — the same "phantom attach" divergence #657 addressed.
- Fix routes the recreated cell through `StartCell` (mirroring the create branch at `reconcile.go:331` and the re-materialize branch at `reconcile.go:357`, both of which call `StartCell`). The recreated container records are persisted first so `StartCell`'s `GetCell` reads the new root spec + freshly assigned containerd IDs; `StartCell` then starts the tasks, runs CNI ADD against the deterministic root ID, and stamps + persists `Ready` only once the cell is actually up.
- Removed the premature `markCellReady` from `RecreateCell` so `Ready` is never persisted over created-but-not-started containers (AC #2).
- Corrected the inline comment at `recreate_cell.go` that wrongly attributed the CNI re-ADD to `createCellContainers`; the re-ADD happens in the trailing `StartCell` call.

Implementation note (dev's choice per the issue): the fix lives inside `RecreateCell` rather than in the `reconcile.go` caller, keeping `RecreateCell` a complete teardown→recreate→start operation symmetric with `StartCell` itself. The `createCellContainers` → persist → `StartCell` shape matches the existing create-branch pattern (`CreateCell` creates records, `StartCell` recreates and starts them), so the brief double-create of the root is consistent with current behavior, not new churn.

## Test plan
- [x] `make test` (full CI target: `go test $(go list ./... | grep -v /e2e)` + `cd cmd/kukebuild && go test ./...`) — passed
- [x] `go vet ./internal/controller/...` — passed
- [x] New `internal/controller/runner/recreate_cell_test.go`: `TestRecreateCell_StartsTasksBeforeReady` (AC #1/#3 — apply-of-root-spec-change drives the root task start and ends `Ready`) and `TestRecreateCell_DoesNotStampReadyWhenStartFails` (AC #2 — a failed task start surfaces an error and the cell is not left `Ready`). Both fail against the pre-fix code (`startContainerCalls == 0`; `Ready` stamped with nil error).
- [ ] `make dev-init` daemon-parity smoke — not run: no containerd daemon is running in this environment (`/run/containerd/containerd.sock` absent) and the host lacks the image-build path. This smoke guards `kuke init` realm/namespace/cgroup bootstrap + bind-mount parity, which this change does not touch — it alters only the apply recreate-cell lifecycle path, with no change to the build path, `/opt/kukeon` layout, or daemon bootstrap.

Closes #682