### PR TITLE
refactor(kukebuild): gate runBuild on a testable requireRoot helper

### DIFF
--- a/cmd/kukebuild/build.go
+++ b/cmd/kukebuild/build.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -105,14 +104,8 @@ const containerdDialTimeout = 60 * time.Second
 // resolveNamespaceSuffix). progressW receives the human-readable build
 // progress.
 func runBuild(ctx context.Context, cfg *buildConfig, progressW io.Writer) error {
-	// kukebuild writes directly into containerd's content store; the
-	// standalone containerd socket is root-only on a stock host. Fail fast
-	// under non-root rather than letting containerd surface an opaque EACCES
-	// several phases in. Same posture as `kuke image load --no-daemon`.
-	if os.Geteuid() != 0 {
-		return errors.New(
-			"kukebuild writes to root-owned containerd state — re-run as root (e.g. via `sudo kuke build`)",
-		)
+	if err := requireRoot(); err != nil {
+		return err
 	}
 
 	if fi, err := os.Stat(cfg.contextDir); err != nil {

--- a/cmd/kukebuild/root.go
+++ b/cmd/kukebuild/root.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ErrMustRunAsRoot mirrors the root module's errdefs.ErrMustRunAsRoot
+// sentinel. kukebuild is a separate Go module (#662) whose BuildKit
+// closure is deliberately incompatible with the root module's graph, so
+// the shared sentinel can't be imported across the boundary without
+// re-coupling the two — it's redeclared here so kukebuild callers can
+// classify the root gate via errors.Is.
+var ErrMustRunAsRoot = errors.New("command must run as root")
+
+// geteuid is indirected via a package var so unit tests can drive the
+// non-root branch without forking under a different UID. Mirrors the
+// seam in cmd/kuke/shared.RequireRoot.
+//
+//nolint:gochecknoglobals // test seam for the production euid lookup
+var geteuid = os.Geteuid
+
+// SetGeteuidForTesting replaces the euid lookup with f and returns a
+// restore function. Test-only.
+func SetGeteuidForTesting(f func() int) func() {
+	prev := geteuid
+	geteuid = f
+	return func() { geteuid = prev }
+}
+
+// requireRoot is kukebuild's fail-fast UID gate. kukebuild writes
+// directly into containerd's content store, which is root-only on a
+// stock host, so a non-root invocation fails fast with a wrapped
+// ErrMustRunAsRoot rather than letting containerd surface an opaque
+// EACCES several phases into the build. Same posture as
+// `kuke image load --no-daemon`.
+func requireRoot() error {
+	if geteuid() == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: kukebuild writes to root-owned containerd state — re-run as root (e.g. via `sudo kuke build`)",
+		ErrMustRunAsRoot,
+	)
+}

--- a/cmd/kukebuild/root_test.go
+++ b/cmd/kukebuild/root_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestRequireRoot_AsRoot(t *testing.T) {
+	restore := SetGeteuidForTesting(func() int { return 0 })
+	t.Cleanup(restore)
+
+	if err := requireRoot(); err != nil {
+		t.Fatalf("requireRoot returned error when euid=0: %v", err)
+	}
+}
+
+func TestRequireRoot_NonRoot(t *testing.T) {
+	restore := SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+
+	err := requireRoot()
+	if err == nil {
+		t.Fatal("requireRoot returned nil when euid=1000; want error")
+	}
+	if !errors.Is(err, ErrMustRunAsRoot) {
+		t.Fatalf("requireRoot error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "sudo") {
+		t.Errorf("requireRoot error does not suggest sudo: %q", msg)
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces the inline `os.Geteuid() != 0` root check in `runBuild` (`cmd/kukebuild/build.go`) with a `requireRoot()` helper backed by a `geteuid` package-var seam + `SetGeteuidForTesting`, mirroring `cmd/kuke/shared.RequireRoot`.
- Adds a kukebuild-local `ErrMustRunAsRoot` sentinel so the non-root gate is classifiable via `errors.Is`, and unit tests (`root_test.go`) that drive both the root and non-root branches without forking under a different UID — the testability the inline form lacked.

## Reinterpreted scope (premise rot — please audit)

Issue #656 was filed during review of **#652**, when `cmd/kukebuild` lived **inside the root module**, so its suggested fix — call `cmd/kuke/shared.RequireRoot` or at least return `errdefs.ErrMustRunAsRoot` — was directly importable.

**#662 later split `cmd/kukebuild` into its own Go module** (`cmd/kukebuild/go.mod`, go1.25.5) with a deliberately-incompatible BuildKit dependency closure vs. the root module (go1.24.5). The `go.work` header documents that the two graphs must never be unioned. Importing *either* `cmd/kuke/shared` *or* `internal/errdefs` from kukebuild now requires a cross-module `require`+`replace` of the root module, dragging its closure into kukebuild's — reintroducing the exact coupling #662 removed. The literal fix is therefore infeasible post-split.

The issue's *intent* — a testable root gate that reuses a classifiable sentinel — is still satisfiable **within** the kukebuild module, which is what this PR does: a local `geteuid` seam + local `ErrMustRunAsRoot` sentinel mirroring the shared pattern, with no cross-module import. Cross-module `errors.Is` classification against the root `errdefs.ErrMustRunAsRoot` was never reachable anyway (kukebuild is invoked as a separate binary by `kuke build`). Reviewer: push back if the local-sentinel redeclaration oversteps vs. simply keeping the inline `errors.New`.

## Test plan

- [x] `cd cmd/kukebuild && GOWORK=off go build ./...`
- [x] `cd cmd/kukebuild && GOWORK=off go vet ./...`
- [x] `cd cmd/kukebuild && GOWORK=off go test ./...` (new `root_test.go` passes)
- [x] `make test` (full CI gate — both modules green)
- [ ] golangci-lint pre-commit hook — structurally cannot analyze the go1.25 kukebuild module (v2.6.2's own module declares go1.24, so it errors `Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.5)`). Not a CI gate: `.github/workflows/test.yaml` runs only `make test` + `make e2e`, no lint step. All other pre-commit hooks (gofmt, addlicense, go-mod-tidy, gitlint) pass.
- [ ] `make dev-init` smoke — N/A: behavior-preserving refactor of the build binary's root gate; touches neither the daemon, `kuke init`, nor `/opt/kukeon`.

Closes #656