### PR TITLE
fix: anchor kuketty terminal metadata.json inside the tty bind mount

### DIFF
--- a/cmd/kuketty/spec.go
+++ b/cmd/kuketty/spec.go
@@ -155,6 +155,26 @@ func buildTerminalSpec(
 	if err != nil {
 		return nil, fmt.Errorf("build kuketty terminal spec: %w", err)
 	}
+
+	// Anchor sbsh's metadata.json inside the per-container tty bind mount
+	// (issue #672). sbsh writes metadata.json via an atomic
+	// create-temp-then-rename that needs write+exec on the holding directory at
+	// every point in the terminal lifecycle — create AND close. The legacy
+	// layout (RunPath/terminals/<id>/, mode 0700, owned by the creating uid)
+	// denied the close-time write whenever the closing uid differed from the
+	// creating uid. We pin MetadataDir to attachableTTYDir — the directory the
+	// daemon bind-mounts and attachablePostCreateChown re-owns to the resolved
+	// container uid — so the holding dir is always the kukeon-owned, host-
+	// visible tty dir. Setting it explicitly (rather than leaning on sbsh's
+	// implicit "MetadataDir = dirname(LogFile) when all three artifact paths are
+	// caller-supplied" derivation) keeps metadata.json in the bind mount even
+	// when an operator pins Tty.LogFile outside it, and survives a future
+	// refactor that drops one of the WithSocketFile/WithCaptureFile/WithLogFile
+	// options (which would otherwise empty MetadataDir and resurrect the
+	// terminals/<id>/ layout). No basename collision: kuketty's own rendered doc
+	// is kuketty-metadata.json; sbsh writes metadata.json.
+	terminalSpec.MetadataDir = attachableTTYDir
+
 	return terminalSpec, nil
 }
 

--- a/cmd/kuketty/spec_test.go
+++ b/cmd/kuketty/spec_test.go
@@ -245,6 +245,34 @@ func TestBuildTerminalSpec_LogFileOverride(t *testing.T) {
 	}
 }
 
+// TestBuildTerminalSpec_MetadataDirAnchored locks #672: metadata.json is always
+// written into the per-container tty bind mount (attachableTTYDir), the dir the
+// daemon owns and attachablePostCreateChown re-owns to the resolved container
+// uid — never the legacy single-owner RunPath/terminals/<id>/ subtree whose
+// 0700/creating-uid ownership denied the close-time write. The anchor must hold
+// regardless of where the operator points Tty.LogFile: leaning on sbsh's
+// implicit "MetadataDir = dirname(LogFile)" derivation would let an
+// out-of-bind-mount log path (the "override outside bind mount" case) drag
+// metadata.json out of the kukeon-owned, host-visible dir.
+func TestBuildTerminalSpec_MetadataDirAnchored(t *testing.T) {
+	cases := []struct {
+		name string
+		tty  *v1beta1.ContainerTty
+	}{
+		{"no Tty: daemon default log", nil},
+		{"log inside bind mount", &v1beta1.ContainerTty{LogFile: attachableTTYDir + "/custom.log"}},
+		{"log outside bind mount", &v1beta1.ContainerTty{LogFile: "/var/log/sbsh-debug.log"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := buildSpec(t, v1beta1.ContainerSpec{ID: "c1", Command: "/bin/sh", KukeonGroupGID: 986, Tty: tc.tty})
+			if out.MetadataDir != attachableTTYDir {
+				t.Errorf("MetadataDir = %q, want %q (anchored in tty bind mount)", out.MetadataDir, attachableTTYDir)
+			}
+		})
+	}
+}
+
 // ttyFieldsCoveredByMapping is the structural half of #493's "every Tty field
 // must map" guard, ported to kuketty (which now owns the transform and reads
 // the v1beta1 schema). It enumerates v1beta1.ContainerTty via reflection and


### PR DESCRIPTION
## Summary
- kuketty now explicitly sets `TerminalSpec.MetadataDir = attachableTTYDir` (`/run/kukeon/tty`) in `cmd/kuketty/spec.go`, so sbsh writes terminal `metadata.json` into the per-container tty bind mount — the directory the daemon owns and `attachablePostCreateChown` re-owns to the resolved container uid — instead of the legacy single-owner `RunPath/terminals/<id>/` (mode 0700) subtree whose ownership denied the close-time write the issue reports.
- Added `TestBuildTerminalSpec_MetadataDirAnchored` pinning the invariant across default, in-bind-mount, and out-of-bind-mount `Tty.LogFile` values.

## Premise rot / reinterpreted scope (please audit)
The issue (#672) was filed against sbsh **v0.11.1**, where the runner unconditionally wrote `RunPath/terminals/<id>/metadata.json` via `MkdirAll(..., 0o700)` — the path named in the issue's permission-denied logs. Current `main` already depends on sbsh **v0.12.0** (bumped in #667, the second-most-recent commit on `main`), which added `TerminalSpec.MetadataDir`: when all three of `LogFile`/`CaptureFile`/`SocketFile` are caller-supplied, sbsh's builder derives `MetadataDir = filepath.Dir(LogFile)` and skips the `terminals/<id>/` subdir (`internal/profile/profile.go:305-337`, `pkg/api/terminal.go:97-106`). kuketty's `buildTerminalSpec` already supplies all three (`spec.go:94,101,139`), so on `main` metadata.json no longer lands in the un-chowned `terminals/<id>/` subtree for the default log path.

So the issue's **literal mechanism** (kukeon must chown `terminals/<id>/`) has rotted — that subtree is dead on `main`, and a chown of it would be a no-op. Per dev CLAUDE.md's premise-rot guidance I proceeded with the **salvageable intent** (terminal metadata persists on close, in the kukeon-owned/host-visible/chowned dir, for a non-root image USER) rather than stalling:

- The implicit `dirname(LogFile)` derivation leaves a residual gap: when an operator pins `Tty.LogFile` outside the bind mount (covered today by `TestBuildTerminalSpec_LogFileOverride`'s `/var/log/sbsh-debug.log` case), `MetadataDir` follows the log out of `/run/kukeon/tty`, dragging metadata.json out of the kukeon-owned, host-visible dir.
- Setting `MetadataDir` explicitly closes that gap and is robust to a future refactor dropping one of the `With*` artifact options (which would otherwise empty `MetadataDir` and resurrect the `terminals/<id>/` layout). For the default config the value is byte-identical to the implicit derivation — **no behavior change** there.

sbsh exposes no `WithMetadataDir` builder option (checked v0.12.0 `pkg/builder/terminal.go`), so the anchor is applied by mutating the returned `*TerminalSpec` before it is handed to `sbshserver.New` (`cmd/kuketty/main.go:122,153`).

## Test plan
- [x] `make test` (full suite incl. `cmd/kukebuild`) — green, 92 pkg ok
- [x] `GOWORK=off go build ./...`, `go vet ./cmd/kuketty/...` — clean
- [x] `go test ./cmd/kuketty/...` — incl. the new `TestBuildTerminalSpec_MetadataDirAnchored`
- [ ] Live attach→exit→inspect smoke (AC #3's manual step: attach to a cell, exit the shell, confirm terminal metadata reflects the closed state with no permission errors) — not run: needs a live daemon + `kuke attach` plumbing + a non-root-USER image, an environmental e2e tier not available in this dev sandbox. The transform-level invariant is covered by the new unit test; defer the host smoke to a reviewer environment.

Closes #672