### PR TITLE
fix: serialize lazy ctrClient init with sync.Once

### DIFF
--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/eminwux/kukeon/internal/cni"
@@ -168,6 +169,13 @@ type Exec struct {
 	opts   Options
 
 	ctrClient ctr.Client
+	// ctrClientOnce serializes the lazy construction of ctrClient so two
+	// concurrent first-use goroutines (e.g. the first RPC handler and the
+	// first reconcile tick) cannot each build a client and overwrite the
+	// other's assignment — a data race on the pointer plus a duplicate
+	// containerd connection (issue #684). Connect() itself stays outside the
+	// Once so the reconnect-on-broken-connection path still runs every call.
+	ctrClientOnce sync.Once
 
 	cniConf *cni.Conf
 
@@ -274,8 +282,13 @@ func (r *Exec) Close() error {
 // ensureClientConnected ensures the containerd client is initialized and connected.
 // It creates a new client if needed, and reconnects if the connection was closed.
 func (r *Exec) ensureClientConnected() error {
-	if r.ctrClient == nil {
-		r.ctrClient = ctr.NewClient(r.ctx, r.logger, r.opts.ContainerdSocket)
-	}
+	r.ctrClientOnce.Do(func() {
+		// Guard the nil check so a test-injected fake (constructed via
+		// &Exec{ctrClient: fake}) survives — only a runner that started with
+		// no client builds the real one here.
+		if r.ctrClient == nil {
+			r.ctrClient = ctr.NewClient(r.ctx, r.logger, r.opts.ContainerdSocket)
+		}
+	})
 	return r.ctrClient.Connect()
 }

--- a/internal/controller/runner/runner_test.go
+++ b/internal/controller/runner/runner_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.ensureClientConnected against in-package state
+package runner
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/ctr"
+)
+
+// TestEnsureClientConnected_ConcurrentFirstUseSingleClient pins issue #684:
+// two concurrent first-use goroutines must not each construct a ctr.Client and
+// overwrite the other's assignment to r.ctrClient. The sync.Once guard
+// serializes construction, so every goroutine observes the same client
+// pointer. Run under `go test -race` to also catch the unguarded
+// nil-check-then-assign data race the fix removes.
+//
+// The socket points at a nonexistent path and the runner context carries a
+// short deadline, so the constructed client's Connect fails fast without a
+// real containerd; the error is irrelevant here — the assertion is on the
+// single, stable client pointer.
+func TestEnsureClientConnected_ConcurrentFirstUseSingleClient(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	r := &Exec{
+		ctx:    ctx,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:   Options{ContainerdSocket: "/nonexistent/kukeon-test-containerd.sock"},
+	}
+
+	const goroutines = 32
+	observed := make([]ctr.Client, goroutines)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for i := range observed {
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			_ = r.ensureClientConnected()
+			observed[idx] = r.ctrClient
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if r.ctrClient == nil {
+		t.Fatal("ctrClient is nil after concurrent first-use")
+	}
+	for idx, c := range observed {
+		if c != r.ctrClient {
+			t.Fatalf("goroutine %d observed a different client pointer (%p) than the final one (%p): two clients were constructed", idx, c, r.ctrClient)
+		}
+	}
+}
+
+// connectCountingClient is a ctr.Client whose only behavior is to count
+// Connect calls. It embeds deleteCellFakeClient (defined in delete_cell_test.go)
+// so it satisfies the full interface with zero-value methods, overriding only
+// Connect.
+type connectCountingClient struct {
+	deleteCellFakeClient
+	connects int64
+	mu       sync.Mutex
+}
+
+func (c *connectCountingClient) Connect() error {
+	c.mu.Lock()
+	c.connects++
+	c.mu.Unlock()
+	return nil
+}
+
+// TestEnsureClientConnected_PreservesInjectedClient guards the nil-check inside
+// the sync.Once: a test-injected fake (constructed via &Exec{ctrClient: fake})
+// must never be overwritten by a lazily-built real client. Without the nil
+// guard the Once would clobber the fake on first use.
+func TestEnsureClientConnected_PreservesInjectedClient(t *testing.T) {
+	fake := &connectCountingClient{}
+	r := &Exec{
+		ctx:       context.Background(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:      Options{ContainerdSocket: "/nonexistent/kukeon-test-containerd.sock"},
+		ctrClient: fake,
+	}
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := r.ensureClientConnected(); err != nil {
+				t.Errorf("ensureClientConnected: %v", err)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if r.ctrClient != ctr.Client(fake) {
+		t.Fatalf("injected fake was overwritten: got %p, want %p", r.ctrClient, fake)
+	}
+	if fake.connects != goroutines {
+		t.Fatalf("Connect called %d times, want %d (one per ensureClientConnected)", fake.connects, goroutines)
+	}
+}

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -34,6 +34,7 @@ type client struct {
 	ctx                  context.Context
 	logger               *slog.Logger
 	socket               string
+	cClientMu            sync.Mutex
 	cClient              *containerd.Client
 	cgroupsMu            sync.RWMutex
 	cgroups              map[string]*cgroup2.Manager
@@ -170,6 +171,15 @@ func (c *client) verifyConnection() error {
 }
 
 func (c *client) Connect() error {
+	// cClientMu serializes the read-modify-write of c.cClient so concurrent
+	// first-use callers (the first RPC handler and the first reconcile tick,
+	// per issue #684) can't each observe nil and each dial containerd —
+	// leaking N-1 connections and racing on the pointer. The sync.Once in the
+	// runner serializes wrapper construction; this lock serializes the
+	// connection the wrapper owns.
+	c.cClientMu.Lock()
+	defer c.cClientMu.Unlock()
+
 	// If already connected, verify the connection is still valid
 	if c.cClient != nil {
 		err := c.verifyConnection()
@@ -187,7 +197,7 @@ func (c *client) Connect() error {
 			"error",
 			err,
 		)
-		_ = c.Close() // Close the invalid connection
+		_ = c.closeLocked() // Close the invalid connection (lock already held)
 	}
 
 	// Create new connection
@@ -200,7 +210,7 @@ func (c *client) Connect() error {
 
 	// Verify the new connection works
 	if err = c.verifyConnection(); err != nil {
-		_ = c.Close()
+		_ = c.closeLocked() // lock already held
 		return fmt.Errorf("failed to verify new connection: %w", err)
 	}
 
@@ -209,6 +219,16 @@ func (c *client) Connect() error {
 }
 
 func (c *client) Close() error {
+	c.cClientMu.Lock()
+	defer c.cClientMu.Unlock()
+	return c.closeLocked()
+}
+
+// closeLocked tears down c.cClient. The caller must hold c.cClientMu — it is
+// invoked both by the public Close() (which takes the lock) and by Connect()'s
+// reconnect path (which already holds the lock), so the teardown stays guarded
+// without re-entrant locking.
+func (c *client) closeLocked() error {
 	if c.cClient != nil {
 		err := c.cClient.Close()
 		if err != nil {


### PR DESCRIPTION
## Summary
- `ensureClientConnected` did an unguarded nil-check-then-assign of `r.ctrClient` (`internal/controller/runner/runner.go`). Two concurrent first-use goroutines (e.g. the first RPC handler and the first reconcile tick) could each observe nil, each construct a client, and the second assignment overwrite the first — a data race on the pointer plus a duplicate containerd connection.
- Fix guards the lazy construction with a `sync.Once`, the lower-blast-radius option the issue offers alongside eager init. Eager init in `NewRunner` was rejected: `TestMarkCellFailed_PreStampsBeforeKillCell` builds `&Exec{}` directly with no `ctrClient` and relies on lazy init creating a real client that errors at connect (no socket); removing the nil-check would nil-panic it.
- The nil-check is kept *inside* the `Once.Do` so a test-injected fake (`&Exec{ctrClient: fake}`, used by `delete_cell_test.go` et al.) is not clobbered on first use; `Connect()` stays outside the Once so the reconnect-on-broken-connection path still runs every call.
- **Review fix-up (`dbde4e4`):** the `Once` only serialized wrapper construction — the two first-use goroutines then both called `Connect()` concurrently on the shared `*client`, racing on `c.cClient` (`internal/ctr/client.go`) with no lock and each dialing containerd (the duplicate-connection harm #684 names). Added a `cClientMu sync.Mutex` to `ctr.client` guarding the read-modify-write of `c.cClient` in `Connect()`/`Close()`. Extracted `closeLocked()` (the un-locked teardown body) so `Connect()`'s internal reconnect/verify-failure paths reuse it without re-entrant locking, while public `Close()` takes the lock then delegates. Post-connect reads of `c.cClient` (image.go, container.go, …) run after the connection is established and are sequenced behind it, so they stay outside the lock — the fix is scoped to the construction/teardown race the reviewer flagged.

## Test plan
- [x] `make test` (CI target) — passes (main module + `cmd/kukebuild`).
- [x] `go build ./internal/ctr/... ./internal/controller/runner/...` / `go vet` — clean.
- [x] `TestEnsureClientConnected_ConcurrentFirstUseSingleClient` — 32 goroutines hit first-use concurrently; asserts a single, stable client pointer (every goroutine observes the same one). Runner context carries a 100ms deadline so the dial against a nonexistent socket fails fast.
- [x] `TestEnsureClientConnected_PreservesInjectedClient` — 16 concurrent calls; asserts an injected fake survives (not overwritten) and `Connect` is called once per call.
- [ ] `go test -race` — not run on the dev host: no C compiler (`gcc`/`cc`/`clang` absent, re-verified this session), and `-race` requires cgo. CI's `make test` target does not use `-race` either. With the fix-up, the `c.cClient` read-modify-write in `Connect()`/`Close()` is now fully mutex-guarded, so `TestEnsureClientConnected_ConcurrentFirstUseSingleClient` is race-free by construction on a cgo-enabled host; verified functionally under plain `go test`.

Note: pre-commit `golangci-lint` hook panics on this host (go1.24 binary type-checking the go1.25 module via the `go.work` union — environmental, not a finding); all other hooks (go-fmt, go-mod-tidy, addlicense, whitespace) pass.

Closes #684