### PR TITLE
feat(tty): add TtyStage.runOn field + create-stage executor routing (phase A)

### DIFF
--- a/cmd/kuketty/main.go
+++ b/cmd/kuketty/main.go
@@ -146,6 +146,18 @@ func run(args []string) error {
 		return err
 	}
 
+	// Pre-Serve step (issue #635): run the container's runOn: create TtyStages
+	// to completion before the workload starts. Like a required-repo failure, a
+	// failed create stage returns here so kuketty exits non-zero before
+	// sbshserver.Serve and the daemon observes the task as Failed. runOn: start
+	// (and absent) stages are not run here — they were forwarded to sbsh's
+	// Stages.OnInit at buildTerminalSpec and run in-shell every boot. Reporting
+	// per-stage outcomes into ContainerStatus.Stages over the RPC is phase B
+	// (#689); this phase wires the executor only.
+	if err := processStages(ctx, createStages(doc.Spec.Tty), logger); err != nil {
+		return err
+	}
+
 	// Register the GetSetupStatus verb on the same control socket the daemon
 	// dials for `kuke attach`, so kukeond can pull the repo outcomes post-Serve
 	// and write ContainerStatus.Repos (issue #642). ContainerStatus is the

--- a/cmd/kuketty/spec.go
+++ b/cmd/kuketty/spec.go
@@ -119,7 +119,11 @@ func buildTerminalSpec(
 	}
 	if spec.Tty != nil && len(spec.Tty.OnInit) > 0 {
 		// Inline OnInit (#494): map the cell's TtyStage{Script} entries to
-		// sbsh's api.ExecStep{Script}.
+		// sbsh's api.ExecStep{Script}. Only runOn: start (and absent) stages
+		// forward here — runOn: create stages run in kuketty's pre-Serve
+		// executor instead and are never handed to sbsh (#635). An all-create
+		// OnInit therefore yields a nil ExecStep slice, leaving Stages.OnInit
+		// zero just as an absent block would.
 		opts = append(opts, sbshbuilder.WithOnInit(ttyStagesToExecSteps(spec.Tty.OnInit)))
 	}
 	if mode := modeIfGroupSet(kukeonGroupGID, attachableSocketMode); mode != "" {
@@ -214,18 +218,53 @@ func resolveTtyLogLevel(t *v1beta1.ContainerTty) string {
 }
 
 // ttyStagesToExecSteps maps the cell's inline Tty.OnInit entries into sbsh's
-// api.ExecStep slice. Each stage carries only Script today; sbsh's ExecStep
-// also supports Env, but the cell schema does not surface it yet (a future
-// TtyStage knob lands here without touching the transform).
+// api.ExecStep slice. Only runOn: start (and absent — the default) stages are
+// forwarded; runOn: create stages are routed into kuketty's pre-Serve executor
+// (see createStages / processStages) and skipped here. Each forwarded stage
+// carries only Script today; sbsh's ExecStep also supports Env, but the cell
+// schema does not surface it yet (a future TtyStage knob lands here without
+// touching the transform). Issue #635.
 func ttyStagesToExecSteps(in []v1beta1.TtyStage) []sbshapi.ExecStep {
 	if len(in) == 0 {
 		return nil
 	}
-	out := make([]sbshapi.ExecStep, len(in))
-	for i, s := range in {
-		out[i] = sbshapi.ExecStep{Script: s.Script}
+	out := make([]sbshapi.ExecStep, 0, len(in))
+	for _, s := range in {
+		if s.RunOn == v1beta1.RunOnCreate {
+			continue
+		}
+		out = append(out, sbshapi.ExecStep{Script: s.Script})
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
+}
+
+// createStages returns the runOn: create stages from the container's
+// Tty.OnInit, in declaration order, paired with their index within the full
+// OnInit slice so the pre-Serve executor and the (phase B) status reporter
+// share one stable identity. Returns nil when the tty block is absent or
+// declares no create stages. Issue #635.
+func createStages(tty *v1beta1.ContainerTty) []indexedStage {
+	if tty == nil {
+		return nil
+	}
+	var out []indexedStage
+	for i, s := range tty.OnInit {
+		if s.RunOn == v1beta1.RunOnCreate {
+			out = append(out, indexedStage{Index: i, Stage: s})
+		}
+	}
+	return out
+}
+
+// indexedStage pairs a create stage with its position in the container's full
+// OnInit slice — the identity carried into ContainerStatus.Stages (#635). The
+// run-once "done" key (e.g. a content hash) is settled in phase C (#690).
+type indexedStage struct {
+	Index int
+	Stage v1beta1.TtyStage
 }
 
 // modeIfGroupSet returns the octal-mode string only when the kukeon group GID

--- a/cmd/kuketty/spec_test.go
+++ b/cmd/kuketty/spec_test.go
@@ -461,5 +461,97 @@ func TestBuildTerminalSpec_EmptyWorkloadFallsBackToBuilderDefault(t *testing.T) 
 	}
 }
 
+// TestTtyStagesToExecSteps_RoutingSplit locks the runOn routing split (#635):
+// only runOn: start (and absent) stages forward to sbsh's Stages.OnInit;
+// runOn: create stages are skipped here (they run in the pre-Serve executor).
+func TestTtyStagesToExecSteps_RoutingSplit(t *testing.T) {
+	in := []v1beta1.TtyStage{
+		{Script: "echo absent"},                             // absent → start lane
+		{Script: "echo start", RunOn: v1beta1.RunOnStart},   // explicit start → start lane
+		{Script: "echo create", RunOn: v1beta1.RunOnCreate}, // create → skipped here
+		{Script: "echo absent2"},                            // absent → start lane
+	}
+	got := ttyStagesToExecSteps(in)
+	want := []string{"echo absent", "echo start", "echo absent2"}
+	if len(got) != len(want) {
+		t.Fatalf("ExecSteps len = %d, want %d (%+v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].Script != w {
+			t.Errorf("ExecStep[%d].Script = %q, want %q", i, got[i].Script, w)
+		}
+	}
+}
+
+// TestTtyStagesToExecSteps_AllCreateYieldsNil: an OnInit made entirely of
+// create stages forwards nothing to sbsh — same shape as an absent block.
+func TestTtyStagesToExecSteps_AllCreateYieldsNil(t *testing.T) {
+	in := []v1beta1.TtyStage{
+		{Script: "echo a", RunOn: v1beta1.RunOnCreate},
+		{Script: "echo b", RunOn: v1beta1.RunOnCreate},
+	}
+	if got := ttyStagesToExecSteps(in); got != nil {
+		t.Errorf("ttyStagesToExecSteps = %+v, want nil (all create stages skipped)", got)
+	}
+}
+
+// TestBuildTerminalSpec_StartAndAbsentRoundTripUnchanged: runOn: start and
+// absent stages land in Stages.OnInit byte-for-byte as before, with the create
+// stage filtered out — the AC that today's behavior is unchanged for start.
+func TestBuildTerminalSpec_StartAndAbsentRoundTripUnchanged(t *testing.T) {
+	out := buildSpec(t, v1beta1.ContainerSpec{
+		ID:      "c1",
+		Command: "/bin/sh",
+		Tty: &v1beta1.ContainerTty{
+			OnInit: []v1beta1.TtyStage{
+				{Script: "echo hello"},
+				{Script: "npm ci", RunOn: v1beta1.RunOnCreate},
+				{Script: "echo world", RunOn: v1beta1.RunOnStart},
+			},
+		},
+	})
+	if len(out.Stages.OnInit) != 2 {
+		t.Fatalf("Stages.OnInit len = %d, want 2 (create stage filtered)", len(out.Stages.OnInit))
+	}
+	if out.Stages.OnInit[0].Script != "echo hello" || out.Stages.OnInit[1].Script != "echo world" {
+		t.Errorf("Stages.OnInit = %+v, want [echo hello, echo world]", out.Stages.OnInit)
+	}
+}
+
+// TestCreateStages_FiltersAndIndexes locks createStages (#635): it returns only
+// runOn: create stages, paired with their index within the full OnInit slice.
+func TestCreateStages_FiltersAndIndexes(t *testing.T) {
+	tty := &v1beta1.ContainerTty{
+		OnInit: []v1beta1.TtyStage{
+			{Script: "echo a"}, // 0: start lane
+			{Script: "npm ci", RunOn: v1beta1.RunOnCreate},  // 1: create
+			{Script: "echo b", RunOn: v1beta1.RunOnStart},   // 2: start lane
+			{Script: "seed.sh", RunOn: v1beta1.RunOnCreate}, // 3: create
+		},
+	}
+	got := createStages(tty)
+	if len(got) != 2 {
+		t.Fatalf("createStages len = %d, want 2", len(got))
+	}
+	if got[0].Index != 1 || got[0].Stage.Script != "npm ci" {
+		t.Errorf("createStages[0] = %+v, want index 1 / npm ci", got[0])
+	}
+	if got[1].Index != 3 || got[1].Stage.Script != "seed.sh" {
+		t.Errorf("createStages[1] = %+v, want index 3 / seed.sh", got[1])
+	}
+}
+
+// TestCreateStages_NilAndNoCreate: an absent tty block or one with no create
+// stages yields nil.
+func TestCreateStages_NilAndNoCreate(t *testing.T) {
+	if got := createStages(nil); got != nil {
+		t.Errorf("createStages(nil) = %+v, want nil", got)
+	}
+	tty := &v1beta1.ContainerTty{OnInit: []v1beta1.TtyStage{{Script: "echo a"}}}
+	if got := createStages(tty); got != nil {
+		t.Errorf("createStages with no create stages = %+v, want nil", got)
+	}
+}
+
 // intPtr is a one-off helper for the always-on log table-test.
 func intPtr(v int) *int { return &v }

--- a/cmd/kuketty/stages.go
+++ b/cmd/kuketty/stages.go
@@ -1,0 +1,84 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// errRequiredStageFailed signals that at least one runOn: create stage failed.
+// run() maps it to a non-zero exit before sbshserver.Serve so the daemon
+// observes the container task as Failed — the required-failure contract phase
+// 1a established for repos (issue #617), applied to create stages here: a
+// TtyStage carries no per-stage Required knob, so every create stage is
+// implicitly required and any failure is fatal. The per-stage detail is logged
+// to kuketty's slog output as each stage runs. Issue #635.
+var errRequiredStageFailed = errors.New("one or more required create stages failed")
+
+// processStages is kuketty's pre-Serve step for runOn: create TtyStages: it
+// runs each create stage's Script to completion, in declaration order, before
+// the workload starts. Stages run with kuketty's own environment (the
+// container's OCI Process.Env — the same identity onInit scripts and repo
+// clones use), via `sh -c <script>`.
+//
+// An empty stage list is a no-op — the common case for a container with no
+// create stages. On the first failing stage processStages logs the outcome and
+// returns errRequiredStageFailed, so run() exits before Serve and the daemon
+// sees the task as Failed; subsequent stages do not run. Reporting per-stage
+// outcomes into ContainerStatus.Stages over the GetSetupStatus RPC is deferred
+// to phase B (#689); this phase wires the executor and routing only. Issue
+// #635.
+func processStages(ctx context.Context, stages []indexedStage, logger *slog.Logger) error {
+	for _, st := range stages {
+		logger.InfoContext(ctx, "running create stage", "index", st.Index)
+		if err := runStage(ctx, st.Stage); err != nil {
+			logger.WarnContext(ctx, "create stage failed", "index", st.Index, "error", err)
+			return fmt.Errorf("%w: stage %d: %v", errRequiredStageFailed, st.Index, err)
+		}
+		logger.InfoContext(ctx, "create stage completed", "index", st.Index)
+	}
+	return nil
+}
+
+// runStage runs a single create stage's Script through `sh -c`, inheriting
+// kuketty's environment. On failure the combined output is folded into the
+// error so the log line carries an actionable message. An empty Script is a
+// no-op success.
+func runStage(ctx context.Context, stage v1beta1.TtyStage) error {
+	if strings.TrimSpace(stage.Script) == "" {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, "sh", "-c", stage.Script)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed != "" {
+			return fmt.Errorf("%w: %s", err, trimmed)
+		}
+		return err
+	}
+	return nil
+}

--- a/cmd/kuketty/stages_test.go
+++ b/cmd/kuketty/stages_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestProcessStages_EmptyIsNoOp(t *testing.T) {
+	if err := processStages(context.Background(), nil, discardLogger()); err != nil {
+		t.Fatalf("nil stages should be a no-op, got %v", err)
+	}
+	if err := processStages(context.Background(), []indexedStage{}, discardLogger()); err != nil {
+		t.Fatalf("empty stages should be a no-op, got %v", err)
+	}
+}
+
+// TestProcessStages_RunsScriptsInOrder confirms the executor invokes each
+// create stage's Script: two stages each touch a marker file, asserted present
+// after processStages returns.
+func TestProcessStages_RunsScriptsInOrder(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	stages := []indexedStage{
+		{Index: 1, Stage: v1beta1.TtyStage{Script: "touch " + a, RunOn: v1beta1.RunOnCreate}},
+		{Index: 3, Stage: v1beta1.TtyStage{Script: "touch " + b, RunOn: v1beta1.RunOnCreate}},
+	}
+	if err := processStages(context.Background(), stages, discardLogger()); err != nil {
+		t.Fatalf("processStages: %v", err)
+	}
+	for _, f := range []string{a, b} {
+		if _, err := os.Stat(f); err != nil {
+			t.Errorf("expected marker %q to exist: %v", f, err)
+		}
+	}
+}
+
+// TestProcessStages_FailurePropagates: a failing create stage returns
+// errRequiredStageFailed (the required-failure contract) and stops before the
+// next stage runs.
+func TestProcessStages_FailurePropagates(t *testing.T) {
+	dir := t.TempDir()
+	after := filepath.Join(dir, "after")
+	stages := []indexedStage{
+		{Index: 0, Stage: v1beta1.TtyStage{Script: "exit 7", RunOn: v1beta1.RunOnCreate}},
+		{Index: 1, Stage: v1beta1.TtyStage{Script: "touch " + after, RunOn: v1beta1.RunOnCreate}},
+	}
+	err := processStages(context.Background(), stages, discardLogger())
+	if err == nil {
+		t.Fatal("processStages: expected error for failing stage, got nil")
+	}
+	if !errors.Is(err, errRequiredStageFailed) {
+		t.Errorf("error = %v, want errRequiredStageFailed", err)
+	}
+	if _, statErr := os.Stat(after); statErr == nil {
+		t.Errorf("stage after the failing one ran; expected execution to stop")
+	}
+}
+
+// TestProcessStages_CapturesOutputInError: a failing stage folds its combined
+// output into the returned error so the log line is actionable.
+func TestProcessStages_CapturesOutputInError(t *testing.T) {
+	stages := []indexedStage{
+		{Index: 0, Stage: v1beta1.TtyStage{Script: "echo boom >&2; exit 1", RunOn: v1beta1.RunOnCreate}},
+	}
+	err := processStages(context.Background(), stages, discardLogger())
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if got := err.Error(); !contains(got, "boom") {
+		t.Errorf("error %q does not carry the stage's output", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -439,6 +439,7 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 				ExitCode:     in.Status.ExitCode,
 				ExitSignal:   in.Status.ExitSignal,
 				Repos:        repoStatusesToInternal(in.Status.Repos),
+				Stages:       stageStatusesToInternal(in.Status.Stages),
 			},
 		}, nil
 	default:
@@ -502,6 +503,7 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 				ExitCode:     in.Status.ExitCode,
 				ExitSignal:   in.Status.ExitSignal,
 				Repos:        repoStatusesToExternal(in.Status.Repos),
+				Stages:       stageStatusesToExternal(in.Status.Stages),
 			},
 		}, nil
 	default:
@@ -614,7 +616,7 @@ func convertContainerTtyToInternal(in *ext.ContainerTty) *intmodel.ContainerTty 
 	if len(in.OnInit) > 0 {
 		out.OnInit = make([]intmodel.TtyStage, len(in.OnInit))
 		for i, s := range in.OnInit {
-			out.OnInit[i] = intmodel.TtyStage{Script: s.Script}
+			out.OnInit[i] = intmodel.TtyStage{Script: s.Script, RunOn: s.RunOn}
 		}
 	}
 	return out
@@ -634,7 +636,7 @@ func buildContainerTtyExternalFromInternal(in *intmodel.ContainerTty) *ext.Conta
 	if len(in.OnInit) > 0 {
 		out.OnInit = make([]ext.TtyStage, len(in.OnInit))
 		for i, s := range in.OnInit {
-			out.OnInit[i] = ext.TtyStage{Script: s.Script}
+			out.OnInit[i] = ext.TtyStage{Script: s.Script, RunOn: s.RunOn}
 		}
 	}
 	return out
@@ -682,6 +684,11 @@ func validateContainerTty(spec ext.ContainerSpec) error {
 	if err := validateTtyLogLevel(spec.Tty.LogLevel); err != nil {
 		return fmt.Errorf("container %q: %w", spec.ID, err)
 	}
+	for i, s := range spec.Tty.OnInit {
+		if err := validateTtyStageRunOn(s.RunOn); err != nil {
+			return fmt.Errorf("container %q: onInit[%d]: %w", spec.ID, i, err)
+		}
+	}
 	return nil
 }
 
@@ -693,6 +700,19 @@ func validateTtyLogLevel(level string) error {
 		return nil
 	}
 	return fmt.Errorf("tty.logLevel %q: must be one of debug, info, warn, error", level)
+}
+
+// validateTtyStageRunOn accepts the empty string (treated as "start"
+// downstream) or one of the two known runOn values. Unknown values are
+// rejected at apply time rather than silently routed to the default lane, so a
+// typo'd `runOn: craete` surfaces as an error instead of running the stage on
+// every boot. Issue #635.
+func validateTtyStageRunOn(runOn string) error {
+	switch runOn {
+	case "", ext.RunOnStart, ext.RunOnCreate:
+		return nil
+	}
+	return fmt.Errorf("tty stage runOn %q: must be one of %q, %q (or empty)", runOn, ext.RunOnStart, ext.RunOnCreate)
 }
 
 // resolveCellRootContainer enforces the rules around CellSpec.RootContainerID
@@ -982,6 +1002,39 @@ func repoStatusesToExternal(in []intmodel.RepoStatus) []ext.RepoStatus {
 			State:  s.State,
 			Commit: s.Commit,
 			Error:  s.Error,
+		}
+	}
+	return out
+}
+
+// stageStatusesToInternal copies external per-stage status into the internal
+// model. Schema only this phase; populated in phase B (#689). Issue #635.
+func stageStatusesToInternal(in []ext.StageStatus) []intmodel.StageStatus {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]intmodel.StageStatus, len(in))
+	for i, s := range in {
+		out[i] = intmodel.StageStatus{
+			Index: s.Index,
+			State: s.State,
+			Error: s.Error,
+		}
+	}
+	return out
+}
+
+// stageStatusesToExternal is the inverse of stageStatusesToInternal.
+func stageStatusesToExternal(in []intmodel.StageStatus) []ext.StageStatus {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]ext.StageStatus, len(in))
+	for i, s := range in {
+		out[i] = ext.StageStatus{
+			Index: s.Index,
+			State: s.State,
+			Error: s.Error,
 		}
 	}
 	return out

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -1270,7 +1270,8 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 				Prompt: `"\[\e[1;36m\]claude \u@\h\[\e[0m\]:\w\$ "`,
 				OnInit: []ext.TtyStage{
 					{Script: "git pull"},
-					{Script: "claude"},
+					{Script: "npm ci", RunOn: ext.RunOnCreate},
+					{Script: "claude", RunOn: ext.RunOnStart},
 				},
 				LogFile:  "/run/kukeon/tty/custom.log",
 				LogLevel: "debug",
@@ -1293,10 +1294,13 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 	if internal.Spec.Tty.LogLevel != input.Spec.Tty.LogLevel {
 		t.Errorf("internal logLevel = %q, want %q", internal.Spec.Tty.LogLevel, input.Spec.Tty.LogLevel)
 	}
-	if len(internal.Spec.Tty.OnInit) != 2 ||
+	if len(internal.Spec.Tty.OnInit) != 3 ||
 		internal.Spec.Tty.OnInit[0].Script != "git pull" ||
-		internal.Spec.Tty.OnInit[1].Script != "claude" {
-		t.Errorf("internal onInit = %+v, want [git pull, claude]", internal.Spec.Tty.OnInit)
+		internal.Spec.Tty.OnInit[1].Script != "npm ci" ||
+		internal.Spec.Tty.OnInit[1].RunOn != ext.RunOnCreate ||
+		internal.Spec.Tty.OnInit[2].Script != "claude" ||
+		internal.Spec.Tty.OnInit[2].RunOn != ext.RunOnStart {
+		t.Errorf("internal onInit = %+v, want [git pull, npm ci/create, claude/start]", internal.Spec.Tty.OnInit)
 	}
 	out, err := apischeme.BuildContainerExternalFromInternal(internal, version)
 	if err != nil {
@@ -1319,7 +1323,10 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 	}
 	for i, s := range input.Spec.Tty.OnInit {
 		if out.Spec.Tty.OnInit[i].Script != s.Script {
-			t.Errorf("round-trip onInit[%d] = %q, want %q", i, out.Spec.Tty.OnInit[i].Script, s.Script)
+			t.Errorf("round-trip onInit[%d].Script = %q, want %q", i, out.Spec.Tty.OnInit[i].Script, s.Script)
+		}
+		if out.Spec.Tty.OnInit[i].RunOn != s.RunOn {
+			t.Errorf("round-trip onInit[%d].RunOn = %q, want %q", i, out.Spec.Tty.OnInit[i].RunOn, s.RunOn)
 		}
 	}
 }
@@ -1495,6 +1502,91 @@ func TestContainerTtyLogLevelEnumValidation(t *testing.T) {
 				t.Fatalf("NormalizeContainer accepted bogus level %q; want validation error", level)
 			}
 		})
+	}
+}
+
+// TestContainerTtyStageRunOnEnumValidation enforces the AC that a stage's
+// runOn only accepts the empty string (treated as "start"), "start", or
+// "create". An unknown value (typically a typo like "craete") is rejected at
+// apply time rather than silently routed to the start lane and re-run on every
+// boot. Issue #635.
+func TestContainerTtyStageRunOnEnumValidation(t *testing.T) {
+	accepted := []string{"", ext.RunOnStart, ext.RunOnCreate}
+	for _, runOn := range accepted {
+		t.Run("accepted/"+runOn, func(t *testing.T) {
+			input := ext.ContainerDoc{
+				APIVersion: ext.APIVersionV1Beta1,
+				Kind:       ext.KindContainer,
+				Metadata:   ext.ContainerMetadata{Name: "c"},
+				Spec: ext.ContainerSpec{
+					ID:      "c",
+					RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+					Image:      "alpine:latest",
+					Attachable: true,
+					Tty:        &ext.ContainerTty{OnInit: []ext.TtyStage{{Script: "echo hi", RunOn: runOn}}},
+				},
+			}
+			if _, _, err := apischeme.NormalizeContainer(input); err != nil {
+				t.Fatalf("NormalizeContainer rejected runOn %q: %v", runOn, err)
+			}
+		})
+	}
+	rejected := []string{"craete", "START", "Create", "boot", "once", "delete"}
+	for _, runOn := range rejected {
+		t.Run("rejected/"+runOn, func(t *testing.T) {
+			input := ext.ContainerDoc{
+				APIVersion: ext.APIVersionV1Beta1,
+				Kind:       ext.KindContainer,
+				Metadata:   ext.ContainerMetadata{Name: "c"},
+				Spec: ext.ContainerSpec{
+					ID:      "c",
+					RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+					Image:      "alpine:latest",
+					Attachable: true,
+					Tty:        &ext.ContainerTty{OnInit: []ext.TtyStage{{Script: "echo hi", RunOn: runOn}}},
+				},
+			}
+			if _, _, err := apischeme.NormalizeContainer(input); err == nil {
+				t.Fatalf("NormalizeContainer accepted bogus runOn %q; want validation error", runOn)
+			}
+		})
+	}
+}
+
+// TestContainerStatusStagesRoundTrip pins the ContainerStatus.Stages schema
+// (#635): stage status stamped on the internal model survives the build back
+// to v1beta1. Schema only this phase; phase B (#689) populates it over RPC.
+func TestContainerStatusStagesRoundTrip(t *testing.T) {
+	input := ext.ContainerDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindContainer,
+		Metadata:   ext.ContainerMetadata{Name: "c"},
+		Spec: ext.ContainerSpec{
+			ID:      "c",
+			RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+			Image: "alpine:latest",
+		},
+	}
+	internal, version, err := apischeme.NormalizeContainer(input)
+	if err != nil {
+		t.Fatalf("NormalizeContainer: %v", err)
+	}
+	internal.Status.Stages = []intmodel.StageStatus{
+		{Index: 1, State: "ran"},
+		{Index: 3, State: "failed", Error: "boom"},
+	}
+	out, err := apischeme.BuildContainerExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildContainerExternalFromInternal: %v", err)
+	}
+	if len(out.Status.Stages) != 2 {
+		t.Fatalf("output status stages len = %d, want 2", len(out.Status.Stages))
+	}
+	if out.Status.Stages[0] != (ext.StageStatus{Index: 1, State: "ran"}) {
+		t.Errorf("status stage[0] = %+v", out.Status.Stages[0])
+	}
+	if out.Status.Stages[1] != (ext.StageStatus{Index: 3, State: "failed", Error: "boom"}) {
+		t.Errorf("status stage[1] = %+v", out.Status.Stages[1])
 	}
 }
 

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -120,9 +120,12 @@ type ContainerTty struct {
 	LogLevel string
 }
 
-// TtyStage mirrors the v1beta1 TtyStage payload.
+// TtyStage mirrors the v1beta1 TtyStage payload. See the v1beta1 type for
+// field semantics. RunOn is empty/"start" (forward to sbsh's Stages.OnInit) or
+// "create" (kuketty pre-Serve executor). Issue #635.
 type TtyStage struct {
 	Script string
+	RunOn  string
 }
 
 // IsEmpty reports whether the tty block carries no user-supplied config.
@@ -140,7 +143,7 @@ func (t *ContainerTty) IsEmpty() bool {
 		return false
 	}
 	for _, s := range t.OnInit {
-		if s.Script != "" {
+		if s.Script != "" || s.RunOn != "" {
 			return false
 		}
 	}
@@ -272,6 +275,11 @@ type ContainerStatus struct {
 	// Repos reports the per-repo outcome of kuketty's pre-Serve clone/fetch
 	// step. Mirrors the v1beta1 ContainerStatus.Repos payload. Issue #617.
 	Repos []RepoStatus
+	// Stages reports the per-stage outcome of kuketty's pre-Serve execution of
+	// the container's runOn: create stages. Mirrors the v1beta1
+	// ContainerStatus.Stages payload; schema only this phase, populated in
+	// phase B (#689). Issue #635.
+	Stages []StageStatus
 }
 
 // RepoStatus mirrors the v1beta1 RepoStatus payload. Issue #617.
@@ -281,6 +289,13 @@ type RepoStatus struct {
 	State  string
 	Commit string
 	Error  string
+}
+
+// StageStatus mirrors the v1beta1 StageStatus payload. Issue #635.
+type StageStatus struct {
+	Index int
+	State string
+	Error string
 }
 
 type ContainerState int

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -190,11 +190,30 @@ type ContainerTty struct {
 }
 
 // TtyStage is a single onInit script entry. Wrapped in a struct rather than
-// a bare string so future stage knobs (timeout, runOn, etc.) can land
-// without breaking the YAML shape.
+// a bare string so future stage knobs (timeout, etc.) can land without
+// breaking the YAML shape.
 type TtyStage struct {
 	Script string `json:"script,omitempty" yaml:"script,omitempty"`
+	// RunOn controls when the stage runs. Empty or "start" (RunOnStart) keeps
+	// today's behavior: the script is forwarded to sbsh's Stages.OnInit and
+	// runs in the wrapped shell on every boot. "create" (RunOnCreate) routes
+	// the script into kuketty's pre-Serve executor, where it runs to completion
+	// as a separate step instead of being handed to sbsh — the foundation for
+	// run-once-per-cell-instance setup (the run-once render gate itself lands
+	// in phase C, #690; this phase adds the field + routing + executor). Any
+	// other value is rejected at apply time by validateContainerTty. Issue #635.
+	RunOn string `json:"runOn,omitempty" yaml:"runOn,omitempty"`
 }
+
+// TtyStage.RunOn values. Empty deserializes as RunOnStart.
+const (
+	// RunOnStart forwards the stage to sbsh's Stages.OnInit (in-shell, every
+	// boot). The default when RunOn is empty.
+	RunOnStart = "start"
+	// RunOnCreate routes the stage into kuketty's pre-Serve executor: it runs
+	// to completion before the workload starts and is never handed to sbsh.
+	RunOnCreate = "create"
+)
 
 // IsEmpty reports whether the tty block carries no user-supplied config —
 // i.e. equivalent to omitting the block entirely. Used by validation to
@@ -213,7 +232,7 @@ func (t *ContainerTty) IsEmpty() bool {
 		return false
 	}
 	for _, s := range t.OnInit {
-		if s.Script != "" {
+		if s.Script != "" || s.RunOn != "" {
 			return false
 		}
 	}
@@ -398,6 +417,12 @@ type ContainerStatus struct {
 	// the GetSetupStatus RPC in phase 1b (#642); phase 1a lands the schema
 	// only. Issue #617.
 	Repos []RepoStatus `json:"repos,omitempty" yaml:"repos,omitempty"`
+	// Stages reports the per-stage outcome of kuketty's pre-Serve execution of
+	// the container's runOn: create TtyStages, in declaration order. Empty for
+	// containers with no create stages or that have not yet been provisioned.
+	// Populated over the GetSetupStatus RPC in phase B (#689); this phase (#635)
+	// lands the schema only. Issue #635.
+	Stages []StageStatus `json:"stages,omitempty" yaml:"stages,omitempty"`
 }
 
 // RepoStatus is the resolved state of a single ContainerRepo after kuketty's
@@ -411,6 +436,23 @@ type RepoStatus struct {
 	Commit string `json:"commit,omitempty" yaml:"commit,omitempty"`
 	// Error is the failure detail when State == "failed".
 	Error string `json:"error,omitempty"  yaml:"error,omitempty"`
+}
+
+// StageStatus is the resolved state of a single runOn: create TtyStage after
+// kuketty's pre-Serve execution. Populated in phase B (#689); this phase
+// (#635) lands the schema only. The stage-identity / run-once "done" key (e.g.
+// a content hash) is settled in phase C (#690), where the render gate that
+// consumes it lands — until then Index (declaration order among create stages)
+// is the only identity carried. Issue #635.
+type StageStatus struct {
+	// Index is the 0-based position of the stage among the container's create
+	// stages, in declaration order.
+	Index int `json:"index"           yaml:"index"`
+	// State is the resolved outcome (e.g. "ran" or "failed"); the exact value
+	// set is defined by the phase-B populator (#689).
+	State string `json:"state"           yaml:"state"`
+	// Error is the failure detail when State reports a failure.
+	Error string `json:"error,omitempty" yaml:"error,omitempty"`
 }
 
 type ContainerState int
@@ -521,6 +563,7 @@ func NewContainerDoc(from *ContainerDoc) *ContainerDoc {
 	out.Spec.Repos = cloneRepos(out.Spec.Repos)
 	out.Spec.Git = cloneGit(out.Spec.Git)
 	out.Status.Repos = cloneRepoStatuses(out.Status.Repos)
+	out.Status.Stages = cloneStageStatuses(out.Status.Stages)
 
 	if out.Spec.Capabilities != nil {
 		caps := *out.Spec.Capabilities
@@ -620,6 +663,16 @@ func cloneRepoStatuses(in []RepoStatus) []RepoStatus {
 	}
 
 	out := make([]RepoStatus, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneStageStatuses(in []StageStatus) []StageStatus {
+	if in == nil {
+		return nil
+	}
+
+	out := make([]StageStatus, len(in))
 	copy(out, in)
 	return out
 }


### PR DESCRIPTION
## Summary

Phase A of run-once `onInit` (#635), the stage-side mirror of the `repos[]` 1a/1b split (#627/#667). Lays the field + routing + executor foundation; the run-once render gate itself is phase C (#690).

- **`TtyStage.RunOn` field** (`pkg/api/model/v1beta1/container.go`, `internal/modelhub/container.go`) with json/yaml tags + `RunOnStart`/`RunOnCreate` constants. Empty/`start` keeps today's behavior; `create` routes to the pre-Serve executor.
- **Validation** (`validateContainerTty`): each stage's `runOn` must be empty, `start`, or `create` — a typo'd value (`craete`) is rejected at apply time rather than silently routed to the start lane and re-run on every boot. Applies to both top-level containers and cell-nested containers (both `validateContainerTty` call sites).
- **Conversion**: `RunOn` round-trips through v1beta1↔internal in both Tty converters.
- **Routing split** (`cmd/kuketty/spec.go`): `ttyStagesToExecSteps` forwards only `start`/absent stages to sbsh's `Stages.OnInit`; `create` stages are skipped there and collected by the new `createStages` helper (paired with their index in the full `OnInit` slice).
- **Pre-Serve executor** (`cmd/kuketty/stages.go`, mirroring `repos.go`): `processStages` runs each `create` stage's `Script` via `sh -c`, inheriting kuketty's environment (the container's OCI `Process.Env`), in declaration order, before `sbshserver.Serve`. Wired into `run()` in `main.go` right after `processRepos`.
- **`ContainerStatus.Stages` schema** (`StageStatus{Index, State, Error}` + conversion + `cloneStageStatuses` clone helper) — schema only this phase, populated over the RPC in phase B (#689), exactly as #617 added the `RepoStatus` schema that #642 populated.

### Notes / non-obvious calls (for reviewer)

- **Failure policy.** The settled design decision says "a failed *required* `create` stage exits before Serve." `TtyStage` carries no per-stage `Required` knob (and the AC doesn't add one), so every `create` stage is treated as implicitly required: the first failing stage returns `errRequiredStageFailed`, so kuketty exits non-zero before `Serve` and the daemon observes the task as `Failed`. Documented on the sentinel and in `processStages`' godoc.
- **Shell choice.** `create` stages run via `sh -c <script>` (portable), distinct from `start`/onInit stages which sbsh writes into the wrapped interactive shell's PTY. The pre-Serve executor runs in kuketty's own process context, independent of the workload shell.
- **`StageStatus` identity.** Carries `Index` (declaration order among create stages) as the only identity this phase. The stage-identity content-hash "done" key is explicitly deferred to phase C (#690), where the render gate that consumes it lands — so the schema does not presuppose a hash field.
- **Premise update (issue body):** the body cites `internal/controller/runner/attachable.go` (`ttyStagesToExecSteps` → `WithOnInit`) as the routing site, but phase 0 (#641) moved the spec→TerminalSpec build into kuketty — the routing now lives in `cmd/kuketty/spec.go`. Implemented there; intent (route `create` away from sbsh) is unchanged.
- **Docs out of scope:** `runOn` is not yet documented in `docs/site/manifests/container.md`; the `repos[]` field docs landed as their own PR (#687) after the schema, so leaving the `runOn` reference to a follow-up doc PR mirrors that precedent rather than bundling user-facing docs into this code PR.

## Test plan

- [x] `make test` (CI target) — passes (main module + `cmd/kukebuild`).
- [x] `go build ./...` (incl. `./e2e/...`) / `go vet` on changed packages — clean.
- [x] `gofmt -l` on changed files — clean.
- [x] New unit tests: routing split (`ttyStagesToExecSteps` start/create/absent; all-create→nil; `createStages` filter+index), executor invocation (`processStages` runs scripts in order, failure propagates `errRequiredStageFailed` and halts, output folded into error), validation accept/reject of `runOn`, `RunOn` + `StageStatus` conversion round-trips.
- [x] `make dev-init` smoke — daemon-parity check shows identical `kuke get realms` / `--no-daemon` output; `kuke attach` smoke against a kuketty-wrapped cell exited cleanly; nested parent-attach plumbing intact.

Closes #635