### PR TITLE
fix: reject path-traversal in secret name and scope coordinates

### DIFF
--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -438,6 +438,28 @@ func ValidateDocument(doc *Document) *ValidationError {
 	return nil
 }
 
+// validateSecretSegment rejects a single secret name or scope coordinate that
+// would escape the secrets tree once fs.SecretPath filepath.Join's it into a
+// host path: a "/" or "\" separator, a "." or ".." element, or a NUL byte.
+// Empty values are the caller's concern (a missing coordinate is legal; an
+// empty name is rejected separately), so this only guards non-empty segments.
+// Issue #673.
+func validateSecretSegment(value string) error {
+	if value == "" {
+		return nil
+	}
+	if value == "." || value == ".." {
+		return errdefs.ErrSecretCoordUnsafe
+	}
+	if strings.ContainsRune(value, 0) ||
+		strings.ContainsRune(value, '/') ||
+		strings.ContainsRune(value, '\\') ||
+		strings.ContainsRune(value, filepath.Separator) {
+		return errdefs.ErrSecretCoordUnsafe
+	}
+	return nil
+}
+
 // validateSecretScope enforces the `kind: Secret` scope-coordinate contract:
 // metadata.realm is always required, and a deeper coordinate may only be set
 // when every shallower one is also set (a cell-scoped secret must name its
@@ -460,6 +482,18 @@ func validateSecretScope(md v1beta1.SecretMetadata) error {
 	}
 	if stack != "" && space == "" {
 		return fmt.Errorf("%w (stack set without space)", errdefs.ErrSecretScopeIncomplete)
+	}
+	// Reject any name or coordinate that would escape the secrets tree.
+	for _, seg := range []struct{ field, value string }{
+		{"metadata.name", strings.TrimSpace(md.Name)},
+		{"metadata.realm", realm},
+		{"metadata.space", space},
+		{"metadata.stack", stack},
+		{"metadata.cell", cell},
+	} {
+		if err := validateSecretSegment(seg.value); err != nil {
+			return fmt.Errorf("%w (%s)", err, seg.field)
+		}
 	}
 	return nil
 }
@@ -559,6 +593,18 @@ func validateSecretRef(ref v1beta1.ContainerSecretRef, i int, name string) error
 		return fmt.Errorf(
 			"%w (secrets[%d] %q: stack set without space)", errdefs.ErrSecretRefScopeIncomplete, i, name,
 		)
+	}
+	// Reject any referenced name or coordinate that would escape the secrets tree.
+	for _, seg := range []struct{ field, value string }{
+		{"secretRef.name", strings.TrimSpace(ref.Name)},
+		{"secretRef.realm", realm},
+		{"secretRef.space", space},
+		{"secretRef.stack", stack},
+		{"secretRef.cell", cell},
+	} {
+		if err := validateSecretSegment(seg.value); err != nil {
+			return fmt.Errorf("%w (secrets[%d] %q %s)", err, i, name, seg.field)
+		}
 	}
 	return nil
 }

--- a/internal/apply/parser/parser_test.go
+++ b/internal/apply/parser/parser_test.go
@@ -525,6 +525,21 @@ spec:
 			refYAML: "        name: anthropic-token\n        realm: default\n        stack: agents\n",
 			wantErr: errdefs.ErrSecretRefScopeIncomplete,
 		},
+		{
+			name:    "name traversal",
+			refYAML: "        name: ../../../etc/shadow\n        realm: kuke-system\n",
+			wantErr: errdefs.ErrSecretCoordUnsafe,
+		},
+		{
+			name:    "realm traversal",
+			refYAML: "        name: anthropic-token\n        realm: ..\n",
+			wantErr: errdefs.ErrSecretCoordUnsafe,
+		},
+		{
+			name:    "cell separator",
+			refYAML: "        name: anthropic-token\n        realm: default\n        space: ai\n        stack: agents\n        cell: claude/../../root\n",
+			wantErr: errdefs.ErrSecretCoordUnsafe,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -972,6 +987,28 @@ func TestValidateDocument_Secret(t *testing.T) {
 			name:    "empty data",
 			mutate:  func(d *v1beta1.SecretDoc) { d.Spec.Data = "   " },
 			wantErr: errdefs.ErrSecretDataRequired,
+		},
+		{
+			name:    "name traversal dotdot",
+			mutate:  func(d *v1beta1.SecretDoc) { d.Metadata.Name = "../../../etc/shadow" },
+			wantErr: errdefs.ErrSecretCoordUnsafe,
+		},
+		{
+			name:    "name is dotdot",
+			mutate:  func(d *v1beta1.SecretDoc) { d.Metadata.Name = ".." },
+			wantErr: errdefs.ErrSecretCoordUnsafe,
+		},
+		{
+			name:    "realm separator",
+			mutate:  func(d *v1beta1.SecretDoc) { d.Metadata.Realm = "default/../kuke-system" },
+			wantErr: errdefs.ErrSecretCoordUnsafe,
+		},
+		{
+			name: "cell traversal",
+			mutate: func(d *v1beta1.SecretDoc) {
+				d.Metadata.Space, d.Metadata.Stack, d.Metadata.Cell = "s", "st", ".."
+			},
+			wantErr: errdefs.ErrSecretCoordUnsafe,
 		},
 	}
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -291,6 +291,15 @@ var (
 	ErrSecretFromEnvNotSet        = errors.New("secret fromEnv env var is not set on the daemon host")
 	ErrSecretStagingFailed        = errors.New("failed to stage secret file for mount")
 
+	// ErrSecretCoordUnsafe guards every secret name and scope coordinate that
+	// flows into fs.SecretPath against path traversal: a "/" or "\" separator,
+	// a "." or ".." element, or a NUL byte would let filepath.Join escape the
+	// secrets tree (issue #673). Shared by both validateSecretRef and
+	// validateSecretScope so the whole secret subsystem is covered.
+	ErrSecretCoordUnsafe = errors.New(
+		"secret name and scope coordinates must not contain path separators or '.'/'..' elements",
+	)
+
 	// ContainerSecret.secretRef source errors (issue #623).
 
 	ErrSecretRefNameRequired    = errors.New("secret secretRef.name is required")


### PR DESCRIPTION
## Summary
- `validateSecretRef` and `validateSecretScope` (`internal/apply/parser/parser.go`) validated secret names and scope coordinates only for non-empty + coordinate contiguity. The values then flow unsanitized into `fs.SecretPath` → `filepath.Join` (`internal/util/fs/metadata.go:271`) and on into `os.ReadFile` as root via `readSecretRefValue` (`internal/ctr/secrets.go:190`). A crafted name or coordinate such as `../../../etc/shadow` would `filepath.Join`-clean out of the secrets tree, letting the daemon read an arbitrary host file into a container env var / mount.
- Adds a shared `validateSecretSegment` helper that rejects any non-empty name or coordinate containing a `/`/`\`/`filepath.Separator`, a NUL byte, or that is exactly `.`/`..`, and applies it at **both** validators so the whole secret subsystem (`kind: Secret` write path and `secretRef` read path) is covered — per the issue's suggested fix.
- New `errdefs.ErrSecretCoordUnsafe` sentinel so the rejection is classifiable via `errors.Is`, matching the existing `errdefs` convention for the secret subsystem.

## Notes
- Not a privilege boundary in the current model (root-owned daemon socket, operator-authored manifests), which is why #669 was not blocked on it — this closes the latent risk as defense-in-depth.
- Empty coordinates remain legal (a missing coordinate means "not scoped at that level"); the segment guard only fires on non-empty values, and the existing realm-required / contiguity checks run first.

## Test plan
- [x] `make test` (full CI gate — both modules green, exit 0, zero failures).
- [x] `go build ./...` / `go vet ./internal/apply/parser/... ./internal/errdefs/...` — clean.
- [x] Extended `TestValidateDocument_Secret` and `TestValidateDocument_Container_SecretRefValidation` with traversal cases (`..`, embedded `/`, dot-dot coordinate) on both the `kind: Secret` and `secretRef` paths; assert `ErrSecretCoordUnsafe`.
- [ ] golangci-lint pre-commit hook — environmental panic on this host (`package requires newer Go version go1.25 (application built with go1.24)`); not a CI gate (`.github/workflows` runs `make test` + `make e2e`). All other hooks (gofmt, go-mod-tidy, addlicense, whitespace) pass.
- [ ] `make dev-init` smoke — N/A: apply-time parser validation only; touches neither the daemon, the build path, nor `/opt/kukeon`.

Closes #673