### PR TITLE
fix: gate run/attach on root-container task liveness, not record existence

### DIFF
--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -120,6 +120,19 @@ func runAttach(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Divergence guard (#683): refuse to attach to a cell whose metadata records
+	// it Ready but whose root-container task is gone from containerd (post-reboot
+	// divergence). Without this, attach hands back a socket backed by a dead task
+	// and the sbsh loop fails with `connection refused`. Shares the run path's
+	// guard so both entry points refuse identically.
+	cellGet, err := client.GetCell(cmd.Context(), buildCellDoc(cell, realm, space, stack))
+	if err != nil {
+		return err
+	}
+	if err := kukeshared.GuardCellTaskLiveness(cellGet, cell); err != nil {
+		return err
+	}
+
 	doc := buildContainerDoc(container, realm, space, stack, cell)
 	result, err := client.AttachContainer(cmd.Context(), doc)
 	if err != nil {
@@ -160,6 +173,25 @@ func resolveRun(cmd *cobra.Command) runFn {
 		return mock
 	}
 	return attach.Run
+}
+
+// buildCellDoc assembles the lookup CellDoc the divergence guard queries via
+// GetCell. Only the identity coordinates are needed — GetCell resolves the
+// persisted spec and the live root-task status from them.
+func buildCellDoc(cell, realm, space, stack string) v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   cell,
+			Labels: make(map[string]string),
+		},
+		Spec: v1beta1.CellSpec{
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+		},
+	}
 }
 
 func buildContainerDoc(name, realm, space, stack, cell string) v1beta1.ContainerDoc {

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -40,7 +40,26 @@ type fakeClient struct {
 	kukeonv1.FakeClient
 
 	listContainersFn  func(realm, space, stack, cell string) ([]v1beta1.ContainerSpec, error)
+	getCellFn         func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
 	attachContainerFn func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error)
+}
+
+// GetCell backs the divergence guard. With no getCellFn set it reports a
+// healthy Ready cell whose root task is live, so attach proceeds — the default
+// for every test not exercising the divergence path.
+func (f *fakeClient) GetCell(
+	_ context.Context,
+	doc v1beta1.CellDoc,
+) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn != nil {
+		return f.getCellFn(doc)
+	}
+	return kukeonv1.GetCellResult{
+		Cell:                     v1beta1.CellDoc{Status: v1beta1.CellStatus{State: v1beta1.CellStateReady}},
+		MetadataExists:           true,
+		RootContainerExists:      true,
+		RootContainerTaskRunning: true,
+	}, nil
 }
 
 func (f *fakeClient) ListContainers(
@@ -372,6 +391,55 @@ func TestAttach_ExplicitContainer_Attachable_Succeeds(t *testing.T) {
 	}
 	if run.opts.SocketPath != testHostSocket {
 		t.Errorf("Options.SocketPath = %q, want %q", run.opts.SocketPath, testHostSocket)
+	}
+}
+
+// TestAttach_RecordedReady_TaskGone_Refuses covers #683: the cell metadata
+// records Ready and the containerd container record still exists (it survives a
+// host/daemon restart), but the backing root task is gone. Attach must refuse
+// with the diverged-state error and never reach AttachContainer / the sbsh
+// loop — otherwise it hands back a socket backed by a dead task.
+func TestAttach_RecordedReady_TaskGone_Refuses(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	attachCalls := 0
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:           v1beta1.CellDoc{Status: v1beta1.CellStatus{State: v1beta1.CellStateReady}},
+				MetadataExists: true,
+				// Record survived the restart; the task did not.
+				RootContainerExists:      true,
+				RootContainerTaskRunning: false,
+			}, nil
+		},
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			attachCalls++
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil, want divergence refusal")
+	}
+	if !strings.Contains(err.Error(), "diverged") {
+		t.Errorf("error %q missing divergence wording", err.Error())
+	}
+	if !strings.Contains(err.Error(), "kuke delete cell c1") {
+		t.Errorf("error %q missing `kuke delete cell` recovery pointer", err.Error())
+	}
+	if attachCalls != 0 {
+		t.Errorf("AttachContainer calls=%d, want 0 (must not attach to a dead socket)", attachCalls)
+	}
+	if run.calls != 0 {
+		t.Errorf("attach.Run called %d times, want 0", run.calls)
 	}
 }
 

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -301,27 +301,24 @@ func runExistingCell(
 ) error {
 	switch pre.Cell.Status.State {
 	case v1beta1.CellStateReady:
-		// Divergence guard (#654): the metadata records this cell as Ready, but
-		// containerd no longer has its root container — typically a daemon/host
-		// restart (#648) dropped the cell's containers while the on-disk
-		// metadata survived. Trusting the stale metadata would print phantom
-		// `already existed` / `containers: started` lines and then attach to a
-		// socket backed by nothing (`connection refused`). Refuse with a
+		// Divergence guard (#654, #683): the metadata records this cell as
+		// Ready, but its root-container task is gone from containerd — typically
+		// a daemon/host restart (#648) dropped the cell's tasks while the
+		// container records and on-disk metadata survived. Keying on record
+		// existence alone (#654's original guard) passes in that case because
+		// the records outlive the tasks, so we gate on task liveness instead
+		// (#683). Trusting the stale metadata would print phantom `already
+		// existed` / `containers: started` lines and then attach to a socket
+		// backed by nothing (`connection refused`). Refuse with a
 		// delete-then-rerun pointer instead. We deliberately do not recreate in
 		// place: re-entering CreateCell/StartCell here is the exact #630 CNI
 		// duplicate-allocation re-entry the Ready short-circuit exists to avoid,
 		// and the operator-driven delete releases any half-held allocation
-		// cleanly. (A legitimately Stopped cell has no root container in
-		// containerd by design — StopCell deletes it — so this guard is scoped
-		// to Ready, where the container is asserted live.)
-		if !pre.RootContainerExists {
-			return fmt.Errorf(
-				"cell %q is recorded Ready but its containers are gone from containerd "+
-					"(kukeon metadata and containerd have diverged); "+
-					"delete it with `kuke delete cell %s` before re-running",
-				cellDoc.Metadata.Name,
-				cellDoc.Metadata.Name,
-			)
+		// cleanly. (A legitimately Stopped cell has no live root task by
+		// design — StopCell deletes it — so this guard is scoped to Ready, where
+		// the task is asserted live.)
+		if err := kukshared.GuardCellTaskLiveness(pre, cellDoc.Metadata.Name); err != nil {
+			return err
 		}
 		if printErr := printRunResult(cmd, noOpResultFromGet(pre), flags.output); printErr != nil {
 			return printErr

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -463,10 +463,11 @@ func TestRun_ExistingCell_MatchingSpec_AlreadyReady_ShortCircuits(t *testing.T) 
 	fc := &fakeClient{
 		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 			return kukeonv1.GetCellResult{
-				Cell:                existing,
-				MetadataExists:      true,
-				CgroupExists:        true,
-				RootContainerExists: true,
+				Cell:                     existing,
+				MetadataExists:           true,
+				CgroupExists:             true,
+				RootContainerExists:      true,
+				RootContainerTaskRunning: true,
 			}, nil
 		},
 	}
@@ -553,6 +554,72 @@ func TestRun_ExistingCell_RecordedReady_ContainerdLostContainers_Refuses(t *test
 	}
 	if fc.startCalls != 0 {
 		t.Errorf("StartCell calls=%d want 0 (refuse, do not re-enter start — #630)", fc.startCalls)
+	}
+	if fc.attachCalls != 0 {
+		t.Errorf("AttachContainer calls=%d want 0 (must not attach to a dead socket)", fc.attachCalls)
+	}
+}
+
+// TestRun_ExistingCell_RecordedReady_TaskGone_Refuses covers #683: unlike #654
+// (the root container *record* is gone), here the record survived a host/daemon
+// restart but its backing task did not. The original record-existence guard
+// would pass — RootContainerExists is true — and run would attach to a dead
+// socket. The task-liveness guard must refuse instead, identically to the
+// record-gone case: no phantom output, no attach, divergence error.
+func TestRun_ExistingCell_RecordedReady_TaskGone_Refuses(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:           existing,
+				MetadataExists: true,
+				CgroupExists:   true,
+				// Record survived the restart; the task did not — the #683 signal.
+				RootContainerExists:      true,
+				RootContainerTaskRunning: false,
+			}, nil
+		},
+	}
+	cmd, out := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, validCellYAML)})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute: want divergence refusal, got nil")
+	}
+	if !strings.Contains(err.Error(), "diverged") {
+		t.Errorf("error missing divergence wording: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke delete cell my-cell") {
+		t.Errorf("error missing `kuke delete cell` recovery pointer: %v", err)
+	}
+	if strings.Contains(out.String(), "already existed") {
+		t.Errorf("must not print phantom `already existed` for a diverged cell:\n%s", out.String())
 	}
 	if fc.attachCalls != 0 {
 		t.Errorf("AttachContainer calls=%d want 0 (must not attach to a dead socket)", fc.attachCalls)
@@ -727,10 +794,11 @@ func TestRun_ExistingCell_SynthesizedRoot_DoesNotDiverge(t *testing.T) {
 	fc := &fakeClient{
 		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 			return kukeonv1.GetCellResult{
-				Cell:                existing,
-				MetadataExists:      true,
-				CgroupExists:        true,
-				RootContainerExists: true,
+				Cell:                     existing,
+				MetadataExists:           true,
+				CgroupExists:             true,
+				RootContainerExists:      true,
+				RootContainerTaskRunning: true,
 			}, nil
 		},
 	}
@@ -1587,10 +1655,11 @@ func TestRun_Attach_AlreadyReady_ShortCircuitThenAttaches(t *testing.T) {
 	fc := &fakeClient{
 		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 			return kukeonv1.GetCellResult{
-				Cell:                existing,
-				MetadataExists:      true,
-				CgroupExists:        true,
-				RootContainerExists: true,
+				Cell:                     existing,
+				MetadataExists:           true,
+				CgroupExists:             true,
+				RootContainerExists:      true,
+				RootContainerTaskRunning: true,
 			}, nil
 		},
 		attachContainerFn: attachSuccessFn(),
@@ -2203,10 +2272,11 @@ func TestRun_RmAttach_AlreadyReady_StillKillsCellOnPeerClosed(t *testing.T) {
 	fc := &fakeClient{
 		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 			return kukeonv1.GetCellResult{
-				Cell:                existing,
-				MetadataExists:      true,
-				CgroupExists:        true,
-				RootContainerExists: true,
+				Cell:                     existing,
+				MetadataExists:           true,
+				CgroupExists:             true,
+				RootContainerExists:      true,
+				RootContainerTaskRunning: true,
 			}, nil
 		},
 		attachContainerFn: attachSuccessFn(),

--- a/cmd/kuke/shared/cell_liveness.go
+++ b/cmd/kuke/shared/cell_liveness.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"fmt"
+
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// GuardCellTaskLiveness refuses to attach to a cell whose on-disk metadata
+// records it Ready but whose root-container task is gone from containerd. This
+// is the post-reboot divergence (#654, #683): containerd container *records*
+// survive a host/daemon restart while the backing tasks do not, so a
+// record-existence check passes even though attaching would land on a dead
+// socket. The guard keys on task liveness (the root task is Running) rather
+// than record existence.
+//
+// It is scoped to Ready: a legitimately Stopped cell has no live task by
+// design, and the run path's Stopped branch starts it before attaching.
+// Returns nil when the cell is not Ready or its root task is live; otherwise
+// the diverged-state error with a delete-then-rerun pointer.
+//
+// Both `kuke run` (Ready short-circuit) and `kuke attach` call this before
+// handing a host socket path to the in-process sbsh attach loop — the single
+// shared guard backing both entry points.
+func GuardCellTaskLiveness(get kukeonv1.GetCellResult, cellName string) error {
+	if get.Cell.Status.State != v1beta1.CellStateReady {
+		return nil
+	}
+	if get.RootContainerTaskRunning {
+		return nil
+	}
+	return fmt.Errorf(
+		"cell %q is recorded Ready but its containers are gone from containerd "+
+			"(kukeon metadata and containerd have diverged); "+
+			"delete it with `kuke delete cell %s` before re-running",
+		cellName,
+		cellName,
+	)
+}

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -300,10 +300,11 @@ func (c *Client) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCe
 		return kukeonv1.GetCellResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
 	}
 	return kukeonv1.GetCellResult{
-		Cell:                *extCell,
-		MetadataExists:      res.MetadataExists,
-		CgroupExists:        res.CgroupExists,
-		RootContainerExists: res.RootContainerExists,
+		Cell:                     *extCell,
+		MetadataExists:           res.MetadataExists,
+		CgroupExists:             res.CgroupExists,
+		RootContainerExists:      res.RootContainerExists,
+		RootContainerTaskRunning: res.RootContainerTaskRunning,
 	}, nil
 }
 

--- a/internal/controller/get_cell.go
+++ b/internal/controller/get_cell.go
@@ -31,6 +31,13 @@ type GetCellResult struct {
 	MetadataExists      bool
 	CgroupExists        bool
 	RootContainerExists bool
+	// RootContainerTaskRunning reports whether the cell's root container has a
+	// live containerd task (status Running). RootContainerExists keys on the
+	// containerd container *record*, which survives a host/daemon restart while
+	// the backing task does not (#654, #683): a record-existence check passes
+	// even when attaching would land on a dead socket. Callers gating an attach
+	// must consult this task-liveness signal, not record existence.
+	RootContainerTaskRunning bool
 }
 
 // GetCell retrieves a single cell and reports its current state.
@@ -96,10 +103,50 @@ func (b *Exec) GetCell(cell intmodel.Cell) (GetCellResult, error) {
 		if err != nil {
 			return res, fmt.Errorf("failed to check root container: %w", err)
 		}
+		if res.RootContainerExists {
+			res.RootContainerTaskRunning, err = b.rootContainerTaskRunning(internalCell)
+			if err != nil {
+				return res, fmt.Errorf("failed to check root container task: %w", err)
+			}
+		}
 		res.Cell = internalCell
 	}
 
 	return res, nil
+}
+
+// rootContainerTaskRunning reports whether the cell's root container has a live
+// containerd task. It locates the root container in the cell spec (Root=true,
+// falling back to RootContainerID) and queries its actual task status; only a
+// Running task (intmodel.ContainerStateReady) counts as live. A cell whose root
+// is absent from the spec is treated as live, matching the reconciler's
+// deriveCellStateFromRootContainer: the divergence this signal exists to catch
+// is a present-but-dead root, not a synthesized one.
+func (b *Exec) rootContainerTaskRunning(cell intmodel.Cell) (bool, error) {
+	rootID := rootContainerID(cell)
+	if rootID == "" {
+		return true, nil
+	}
+	state, err := b.runner.GetContainerState(cell, rootID)
+	if err != nil {
+		return false, err
+	}
+	return state == intmodel.ContainerStateReady, nil
+}
+
+// rootContainerID returns the spec ID of the cell's root container, preferring
+// the Root=true flag and falling back to Spec.RootContainerID. Empty when the
+// spec carries no root container.
+func rootContainerID(cell intmodel.Cell) string {
+	for i := range cell.Spec.Containers {
+		if cell.Spec.Containers[i].Root {
+			return cell.Spec.Containers[i].ID
+		}
+	}
+	if cell.Spec.RootContainerID != "" {
+		return cell.Spec.RootContainerID
+	}
+	return ""
 }
 
 // ListCells lists all cells, optionally filtered by realm, space, and/or stack.

--- a/internal/controller/get_cell_test.go
+++ b/internal/controller/get_cell_test.go
@@ -105,6 +105,82 @@ func TestGetCell_SuccessfulRetrieval(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// #683: root container record exists and its task is Running — the
+			// cell is genuinely live, so RootContainerTaskRunning is true.
+			name:      "root container task running",
+			cellName:  "test-cell",
+			realmName: "test-realm",
+			spaceName: "test-space",
+			stackName: "test-stack",
+			setupRunner: func(f *fakeRunner) {
+				cell := buildTestCell("test-cell", "test-realm", "test-space", "test-stack")
+				cell.Spec.Containers = []intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+				}
+				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return cell, nil
+				}
+				f.ExistsCgroupFn = func(_ any) (bool, error) {
+					return true, nil
+				}
+				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
+					return true, nil
+				}
+				f.GetContainerStateFn = func(_ intmodel.Cell, containerID string) (intmodel.ContainerState, error) {
+					if containerID != "root" {
+						t.Errorf("GetContainerState called for %q, want root", containerID)
+					}
+					return intmodel.ContainerStateReady, nil
+				}
+			},
+			wantResult: func(t *testing.T, result controller.GetCellResult) {
+				if !result.RootContainerExists {
+					t.Error("expected RootContainerExists to be true")
+				}
+				if !result.RootContainerTaskRunning {
+					t.Error("expected RootContainerTaskRunning to be true")
+				}
+			},
+			wantErr: false,
+		},
+		{
+			// #683 headline case: the record survives a host/daemon restart but
+			// the task is gone (Stopped). RootContainerExists stays true while
+			// RootContainerTaskRunning must report false so attach gating refuses.
+			name:      "root container record present but task gone",
+			cellName:  "test-cell",
+			realmName: "test-realm",
+			spaceName: "test-space",
+			stackName: "test-stack",
+			setupRunner: func(f *fakeRunner) {
+				cell := buildTestCell("test-cell", "test-realm", "test-space", "test-stack")
+				cell.Spec.Containers = []intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+				}
+				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return cell, nil
+				}
+				f.ExistsCgroupFn = func(_ any) (bool, error) {
+					return true, nil
+				}
+				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
+					return true, nil
+				}
+				f.GetContainerStateFn = func(_ intmodel.Cell, _ string) (intmodel.ContainerState, error) {
+					return intmodel.ContainerStateStopped, nil
+				}
+			},
+			wantResult: func(t *testing.T, result controller.GetCellResult) {
+				if !result.RootContainerExists {
+					t.Error("expected RootContainerExists to be true (record survives restart)")
+				}
+				if result.RootContainerTaskRunning {
+					t.Error("expected RootContainerTaskRunning to be false (task gone)")
+				}
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -470,6 +546,33 @@ func TestGetCell_RunnerErrors(t *testing.T) {
 			},
 			wantErr:     nil,
 			errContains: "failed to check root container",
+		},
+		{
+			name:      "root container task check fails",
+			cellName:  "test-cell",
+			realmName: "test-realm",
+			spaceName: "test-space",
+			stackName: "test-stack",
+			setupRunner: func(f *fakeRunner) {
+				cell := buildTestCell("test-cell", "test-realm", "test-space", "test-stack")
+				cell.Spec.Containers = []intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+				}
+				f.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+					return cell, nil
+				}
+				f.ExistsCgroupFn = func(_ any) (bool, error) {
+					return true, nil
+				}
+				f.ExistsCellRootContainerFn = func(_ intmodel.Cell) (bool, error) {
+					return true, nil
+				}
+				f.GetContainerStateFn = func(_ intmodel.Cell, _ string) (intmodel.ContainerState, error) {
+					return intmodel.ContainerStateUnknown, errors.New("task status query failed")
+				}
+			},
+			wantErr:     nil,
+			errContains: "failed to check root container task",
 		},
 	}
 

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -179,6 +179,12 @@ type GetCellResult struct {
 	MetadataExists      bool
 	CgroupExists        bool
 	RootContainerExists bool
+	// RootContainerTaskRunning reports whether the cell's root container has a
+	// live containerd task. Distinct from RootContainerExists, which keys on the
+	// containerd record that survives a host/daemon restart while the task does
+	// not (#654, #683). Attach gating must consult task liveness, not record
+	// existence, to avoid handing back a dead socket.
+	RootContainerTaskRunning bool
 }
 
 type GetContainerArgs struct {


### PR DESCRIPTION
## Summary
- The #654 phantom-attach guard at `cmd/kuke/run/run.go` keyed on `RootContainerExists`, which is containerd container-*record* existence. Records survive a host/daemon restart while their tasks do not, so the guard passed even when the backing task was dead and `kuke run` attached to a dead socket. `kuke attach` had no guard at all.
- Gate on task liveness instead: a new `RootContainerTaskRunning` signal on `GetCellResult` reports whether the root container's containerd task is actually Running (`GetContainerState == ContainerStateReady`). A single shared guard (`shared.GuardCellTaskLiveness`) backs both `kuke run`'s Ready short-circuit and `kuke attach`, refusing with the same diverged-state error + `kuke delete cell` pointer.
- Scoped to Ready (a legitimately Stopped cell has no live task by design and is handled by run's start path). Per the issue proposal, only a Running task counts as live — a record-present-but-task-gone, NotCreated, or transient-Unknown root all refuse.

## Design notes
- `controller.GetCell` now queries the root container's live task state only when `RootContainerExists` is true; a cell whose spec carries no root container is treated as live (matching the reconciler's `deriveCellStateFromRootContainer`).
- `kuke attach` previously issued no `GetCell`; it now does one before `AttachContainer` to evaluate the guard. The guard returns nil for non-Ready cells, so the attach error surface for Stopped/missing cells is unchanged.

## Test plan
- [x] `make test` (root module + kukebuild module) — pass
- [x] `go build ./cmd/... ./internal/... ./pkg/...` — pass
- [x] `go vet` on changed packages — pass
- [x] New: `TestRun_ExistingCell_RecordedReady_TaskGone_Refuses` (run refuses when record present but task gone)
- [x] New: `TestAttach_RecordedReady_TaskGone_Refuses` (attach refuses, never reaches AttachContainer / sbsh loop)
- [x] New controller cases: `RootContainerTaskRunning` true (Running task) / false (record present, task Stopped) / error path
- [ ] Local smoke test (`make dev-init`) — not run: this change is in the CLI guard / controller read path, touches no build path, daemon serve path, or `/opt/kukeon` layout, so the daemon-parity regression guard does not apply.

Closes #683