### PR TITLE
ci: split kukebuild tests into a distinct CI step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,8 +53,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Run unit tests
-        run: make test
+      # Split per Go module so a red run names the failing component in the
+      # step status (issue #696): root-module unit tests vs. the standalone
+      # cmd/kukebuild module. Both still run on every PR/push; GOWORK=off is
+      # preserved by the Makefile's top-level export, so neither step re-couples
+      # the workspace-union import graph.
+      - name: Run root-module tests
+        run: make test-root
+
+      - name: Run kukebuild module tests
+        run: make test-kukebuild
 
   # `make e2e` needs three host prerequisites — root (sudo -E), a docker
   # daemon for `docker build` of the local kukeond image, and a standalone

--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,16 @@ kill:
 # tests (excluding the e2e suite) and the kukebuild module's tests. `go list
 # ./...` from the root lists only root-module packages — the nested kukebuild
 # module is excluded — so its tests are run explicitly from its module dir.
-test:
+# Split into per-module sub-targets so CI can run each as its own named step
+# and a red run names the failing component (issue #696); `make test` keeps
+# running both locally. GOWORK=off (exported above) reaches every sub-recipe.
+.PHONY: test test-root test-kukebuild
+test: test-root test-kukebuild
+
+test-root:
 	go test $(shell go list ./... | grep -v /e2e)
+
+test-kukebuild:
 	cd cmd/kukebuild && go test ./...
 
 # Tag the e2e suite uses to refer to the local kukeond image. The e2e harness


### PR DESCRIPTION
## Summary
- The CI `test` job ran `make test` as a single step, whose recipe runs both the root-module unit tests and the standalone `cmd/kukebuild` module tests sequentially. A red run gave one combined status, so you couldn't tell from the job summary which module regressed without opening the log.
- Split the Makefile `test` recipe into `test-root` + `test-kukebuild` sub-targets (with `test: test-root test-kukebuild`), so `make test` still runs both locally — no local behavior change — while CI can invoke each independently.
- Replaced the single "Run unit tests" workflow step with two distinctly-named steps: "Run root-module tests" (`make test-root`) and "Run kukebuild module tests" (`make test-kukebuild`). A failure now names the component in the step status.
- `GOWORK=off` is preserved by the Makefile's existing top-level `export GOWORK := off`, which reaches every recipe — no workspace-union ambiguous-import regression.

## Test plan
- [x] `make test-root` — root-module unit tests pass (e2e excluded)
- [x] `make test-kukebuild` — `ok github.com/eminwux/kukeon/cmd/kukebuild`
- [x] `GOWORK=off go vet ./...` (e2e excluded) — clean
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [ ] `make e2e` — not run; unaffected by this change (e2e job and `test-e2e` target untouched) and requires root + docker + standalone containerd not available here

Closes #696