### PR TITLE
feat: add kind CellBlueprint with daemon storage and kuke run -b

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -427,6 +427,8 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_PROFILE = DefineKV("KUKE_RUN_PROFILE", "kuke/run/profile")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_BLUEPRINT = DefineKV("KUKE_RUN_BLUEPRINT", "kuke/run/blueprint")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_RM = DefineKV("KUKE_RUN_RM", "kuke/run/rm")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_NAME = DefineKV("KUKE_RUN_NAME", "kuke/run/name")

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -35,6 +35,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/config"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/cellblueprint"
 	"github.com/eminwux/kukeon/internal/cellprofile"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -53,10 +54,14 @@ type MockControllerKey struct{}
 // `-d/--detach` opts out of the post-start attach.
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run (-f <file> | -p <profile>)",
-		Short: "Create and start a single cell from a YAML file or a profile",
+		Use:   "run (-f <file> | -p <profile> | -b <blueprint>)",
+		Short: "Create and start a single cell from a YAML file, a profile, or a daemon-stored blueprint",
 		Long: "Create and start a single cell from a YAML file or stdin (-f), " +
-			"or from a per-user profile under $HOME/.kuke/profiles.d/<name>.yaml (-p). " +
+			"from a per-user profile under $HOME/.kuke/profiles.d/<name>.yaml (-p), " +
+			"or from a daemon-stored CellBlueprint (-b), resolved from the scope named by " +
+			"--realm/--space/--stack. -b substitutes scalar --param values and materializes " +
+			"a fresh <prefix>-<6hex> cell every invocation; structural slot fill (repo URLs, " +
+			"secret sources) requires a CellConfig and `kuke run -c` (#625). " +
 			"-f is create-or-attach by metadata.name: a missing cell is created and " +
 			"attached; a Ready cell is attached as a no-op; a Stopped cell is started " +
 			"then attached; a divergent on-disk spec is refused (use `kuke apply -f` to " +
@@ -73,27 +78,34 @@ func NewRunCmd() *cobra.Command {
 	_ = viper.BindPFlag(config.KUKE_RUN_FILE.ViperKey, cmd.Flags().Lookup("file"))
 
 	cmd.Flags().StringP("profile", "p", "",
-		"Cell profile name to load from $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR); mutually exclusive with -f")
+		"Cell profile name to load from $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR); mutually exclusive with -f/-b. "+
+			"Deprecated: apply a kind: CellBlueprint and use -b/-c instead.")
 	_ = viper.BindPFlag(config.KUKE_RUN_PROFILE.ViperKey, cmd.Flags().Lookup("profile"))
+
+	cmd.Flags().StringP("blueprint", "b", "",
+		"Daemon-stored CellBlueprint name to run, resolved from the scope named by "+
+			"--realm/--space/--stack; mutually exclusive with -f/-p. Substitutes scalar --param "+
+			"values and materializes a fresh <prefix>-<6hex> cell.")
+	_ = viper.BindPFlag(config.KUKE_RUN_BLUEPRINT.ViperKey, cmd.Flags().Lookup("blueprint"))
 
 	cmd.Flags().String("name", "",
 		"Override the materialized cell name (default: <metadata.name>-<6hex>). "+
-			"Only valid with -p; rejected with -f, where metadata.name is the cell name verbatim.")
+			"Valid with -p/-b; rejected with -f, where metadata.name is the cell name verbatim.")
 	_ = viper.BindPFlag(config.KUKE_RUN_NAME.ViperKey, cmd.Flags().Lookup("name"))
 
 	cmd.Flags().StringArray("param", nil,
-		"Profile parameter override as KEY=VALUE; repeatable. Only valid with -p. "+
+		"Scalar parameter override as KEY=VALUE; repeatable. Valid with -p/-b. "+
 			"Each KEY must be declared in spec.parameters[]. Wins over the parameter's "+
 			"default and over --param-file when both set the same key.")
 
 	cmd.Flags().String("param-file", "",
-		"File of KEY=VALUE lines whose values seed profile parameters; one per line, "+
+		"File of KEY=VALUE lines whose values seed scalar parameters; one per line, "+
 			"`#` starts a comment. Same declaration rules as --param. CLI --param wins on "+
 			"duplicate keys.")
 	_ = viper.BindPFlag(config.KUKE_RUN_PARAM_FILE.ViperKey, cmd.Flags().Lookup("param-file"))
 
-	cmd.MarkFlagsMutuallyExclusive("file", "profile")
-	cmd.MarkFlagsOneRequired("file", "profile")
+	cmd.MarkFlagsMutuallyExclusive("file", "profile", "blueprint")
+	cmd.MarkFlagsOneRequired("file", "profile", "blueprint")
 
 	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
 	_ = viper.BindPFlag(config.KUKE_RUN_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
@@ -141,6 +153,7 @@ func NewRunCmd() *cobra.Command {
 type runFlags struct {
 	file          string
 	profileName   string
+	blueprintName string
 	output        string
 	detach        bool
 	containerFlag string
@@ -154,6 +167,7 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 	flags := runFlags{
 		file:          strings.TrimSpace(viper.GetString(config.KUKE_RUN_FILE.ViperKey)),
 		profileName:   strings.TrimSpace(viper.GetString(config.KUKE_RUN_PROFILE.ViperKey)),
+		blueprintName: strings.TrimSpace(viper.GetString(config.KUKE_RUN_BLUEPRINT.ViperKey)),
 		detach:        viper.GetBool(config.KUKE_RUN_DETACH.ViperKey),
 		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
 		autoDelete:    viper.GetBool(config.KUKE_RUN_RM.ViperKey),
@@ -187,18 +201,18 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		return runFlags{}, errors.New("--output is incompatible with attach mode (pass -d/--detach)")
 	}
 	if flags.file != "" {
-		// --name, --param, --param-file are profile-only knobs (per issue
-		// #355). With -f the file's metadata.name is authoritative and the
-		// substitution surface doesn't apply, so reject the combination
-		// rather than silently dropping the flag.
+		// --name, --param, --param-file are template knobs (per issue #355)
+		// shared by the -p and -b paths. With -f the file's metadata.name is
+		// authoritative and the substitution surface doesn't apply, so reject
+		// the combination rather than silently dropping the flag.
 		if flags.nameOverride != "" {
-			return runFlags{}, errors.New("--name is only valid with -p/--profile")
+			return runFlags{}, errors.New("--name is only valid with -p/--profile or -b/--blueprint")
 		}
 		if len(flags.paramArgs) > 0 {
-			return runFlags{}, errors.New("--param is only valid with -p/--profile")
+			return runFlags{}, errors.New("--param is only valid with -p/--profile or -b/--blueprint")
 		}
 		if flags.paramFile != "" {
-			return runFlags{}, errors.New("--param-file is only valid with -p/--profile")
+			return runFlags{}, errors.New("--param-file is only valid with -p/--profile or -b/--blueprint")
 		}
 	}
 	return flags, nil
@@ -210,7 +224,16 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cellDoc, err := loadCellDoc(flags)
+	// Resolve the client first: the -b path resolves its blueprint from daemon
+	// storage over this client, so it must be live before loadCellDoc runs. The
+	// -f/-p paths ignore it during load.
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	cellDoc, err := loadCellDoc(cmd, client, flags)
 	if err != nil {
 		return err
 	}
@@ -228,12 +251,6 @@ func runRun(cmd *cobra.Command, args []string) error {
 	if validateErr := validateResolvedCell(cellDoc); validateErr != nil {
 		return validateErr
 	}
-
-	client, err := resolveClient(cmd)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = client.Close() }()
 
 	pre, getErr := client.GetCell(cmd.Context(), cellDoc)
 	switch {
@@ -424,15 +441,73 @@ func attachAfterRun(
 	return runAttachLoop(cmd, client, doc, target)
 }
 
-// loadCellDoc dispatches to the file or profile loader. Exactly one of
-// flags.file or flags.profileName is non-empty (the cobra mutex enforces
-// this before the handler runs); --name and --param* are profile-only and
-// already rejected against -f in parseRunFlags.
-func loadCellDoc(flags runFlags) (v1beta1.CellDoc, error) {
-	if flags.profileName != "" {
+// loadCellDoc dispatches to the file, profile, or blueprint loader. Exactly
+// one of flags.file / flags.profileName / flags.blueprintName is non-empty (the
+// cobra mutex enforces this before the handler runs); --name and --param* are
+// template knobs already rejected against -f in parseRunFlags. The blueprint
+// path resolves over client; the file/profile paths ignore it.
+func loadCellDoc(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (v1beta1.CellDoc, error) {
+	switch {
+	case flags.blueprintName != "":
+		return loadFromBlueprint(cmd, client, flags)
+	case flags.profileName != "":
+		fmt.Fprintln(cmd.ErrOrStderr(),
+			"kuke run: -p/--profile is deprecated and will be removed (#626); "+
+				"apply a kind: CellBlueprint and use `kuke run -b` (or `kuke run -c` for a CellConfig, #625).")
 		return loadFromProfile(flags)
+	default:
+		return loadFromFile(flags.file)
 	}
-	return loadFromFile(flags.file)
+}
+
+// loadFromBlueprint resolves the named CellBlueprint from daemon storage at the
+// scope named by --realm/--space/--stack, substitutes scalar --param values,
+// and materializes a fresh `<prefix>-<6hex>` CellDoc (--name overrides the name
+// verbatim). The blueprint's metadata scope drives the materialized cell's
+// realm/space/stack; resolveCellLocation later fills any coordinate the
+// blueprint left empty from the run flags / session defaults.
+//
+// The lookup scope takes realm from --realm (defaulted to "default") and
+// space/stack only when the operator set them *explicitly* — via the flag or
+// the KUKE_RUN_SPACE/STACK env var. The session default for those keys is
+// "default" (DefineKV calls viper.SetDefault), so reading them through viper
+// would wrongly narrow every lookup to default/default and hide realm-scoped
+// blueprints; explicitScope reads the raw flag/env instead. A blueprint that
+// declares structural slots the inline path cannot fill (secret slots, required
+// repo slots with no url) is refused by Materialize with a pointer to
+// `kuke run -c`.
+func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (v1beta1.CellDoc, error) {
+	cliParams, err := buildParamMap(flags)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+
+	lookup := v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  flags.blueprintName,
+			Realm: pickLocation("", &config.KUKE_RUN_REALM),
+			Space: explicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
+			Stack: explicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
+		},
+	}
+
+	res, err := client.GetBlueprint(cmd.Context(), lookup)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !res.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (blueprint %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrBlueprintNotFound, lookup.Metadata.Name,
+			lookup.Metadata.Realm, lookup.Metadata.Space, lookup.Metadata.Stack,
+		)
+	}
+
+	resolved, err := cellblueprint.Resolve(res.Blueprint, cliParams, os.LookupEnv)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	return cellblueprint.MaterializeWithName(resolved, flags.nameOverride)
 }
 
 // loadFromFile preserves the phase-1c -f path: read the file (or stdin),
@@ -564,6 +639,24 @@ func resolveCellLocation(doc *v1beta1.CellDoc) {
 	doc.Spec.RealmID = pickLocation(doc.Spec.RealmID, &config.KUKE_RUN_REALM)
 	doc.Spec.SpaceID = pickLocation(doc.Spec.SpaceID, &config.KUKE_RUN_SPACE)
 	doc.Spec.StackID = pickLocation(doc.Spec.StackID, &config.KUKE_RUN_STACK)
+}
+
+// explicitScope returns a blueprint-lookup scope coordinate only when the
+// operator set it explicitly — the cobra flag was changed on this invocation,
+// or the backing env var (kv.Key) is present in the environment. It deliberately
+// bypasses viper.GetString: DefineKV registers a viper default of "default" for
+// the run space/stack keys, so viper would report "default" for an unset
+// coordinate and narrow every lookup to default/default, hiding realm-scoped
+// blueprints. An empty return means "don't constrain this coordinate".
+func explicitScope(cmd *cobra.Command, flagName string, kv *config.Var) string {
+	if cmd.Flags().Changed(flagName) {
+		v, _ := cmd.Flags().GetString(flagName)
+		return strings.TrimSpace(v)
+	}
+	if v, ok := os.LookupEnv(kv.Key); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
 }
 
 func pickLocation(fromDoc string, kv *config.Var) string {

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -133,6 +134,7 @@ type fakeClient struct {
 	startCellFn       func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
 	attachContainerFn func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error)
 	killCellFn        func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
+	getBlueprintFn    func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error)
 
 	getCalls    int
 	createCalls int
@@ -190,6 +192,16 @@ func (f *fakeClient) KillCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.
 		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
 	}
 	return f.killCellFn(doc)
+}
+
+func (f *fakeClient) GetBlueprint(
+	_ context.Context,
+	doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.GetBlueprintResult, error) {
+	if f.getBlueprintFn == nil {
+		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")
+	}
+	return f.getBlueprintFn(doc)
 }
 
 // runCapture records the Options passed to the in-process attach loop. By
@@ -1203,10 +1215,11 @@ func TestRun_MissingFileAndProfile_Errors(t *testing.T) {
 
 	err := cmd.Execute()
 	// MarkFlagsOneRequired produces "at least one of the flags in the group
-	// [file profile] is required" — match on the stable phrase rather than
-	// the exact wording so a cobra phrasing change doesn't break the test.
-	if err == nil || !strings.Contains(err.Error(), "[file profile]") {
-		t.Fatalf("err=%v want one-of error naming both flags", err)
+	// [file profile blueprint] is required" — match on the stable group
+	// listing rather than the exact wording so a cobra phrasing change doesn't
+	// break the test.
+	if err == nil || !strings.Contains(err.Error(), "[file profile blueprint]") {
+		t.Fatalf("err=%v want one-of error naming the file/profile/blueprint group", err)
 	}
 }
 
@@ -2583,5 +2596,134 @@ func TestPickLocation_DefaultsViaConfigKV(t *testing.T) {
 	}
 	if got := strings.TrimSpace(config.KUKE_RUN_STACK.ValueOrDefault()); got != "default" {
 		t.Errorf("KUKE_RUN_STACK default=%q want default", got)
+	}
+}
+
+// blueprintDoc returns a minimal runnable CellBlueprintDoc the fake daemon can
+// hand back over GetBlueprint, with one ${TAG} parameter substituted into the
+// image.
+func blueprintDoc() v1beta1.CellBlueprintDoc {
+	def := "latest"
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: "my-realm",
+			Space: "my-space",
+			Stack: "my-stack",
+		},
+		Spec: v1beta1.CellBlueprintSpec{
+			Prefix:     "web",
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
+				},
+			},
+		},
+	}
+}
+
+func TestRun_FromBlueprint_ResolvesAndCreates(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			// The lookup carries the requested name + scope; echo back the body.
+			if doc.Metadata.Name != "web" {
+				t.Errorf("lookup name=%q want web", doc.Metadata.Name)
+			}
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return kukeonv1.CreateCellResult{
+				Cell: doc, Created: true, MetadataExistsPost: true,
+				CgroupCreated: true, CgroupExistsPost: true,
+				RootContainerCreated: true, RootContainerExistsPost: true, Started: true,
+				Containers: []kukeonv1.ContainerCreationOutcome{{Name: "main", ExistsPost: true, Created: true}},
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-b", "web", "--param", "TAG=v2", "--realm", "my-realm", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 1 {
+		t.Fatalf("CreateCell calls=%d want 1", fc.createCalls)
+	}
+	// Fresh <prefix>-<6hex> name, scope from blueprint metadata, ${TAG} filled.
+	if got := fc.createDoc.Metadata.Name; !regexp.MustCompile(`^web-[0-9a-f]{6}$`).MatchString(got) {
+		t.Errorf("cell name=%q want web-<6hex>", got)
+	}
+	if got := fc.createDoc.Spec.RealmID; got != "my-realm" {
+		t.Errorf("RealmID=%q want my-realm", got)
+	}
+	if got := fc.createDoc.Spec.Containers[0].Image; got != "registry.example.com/web:v2" {
+		t.Errorf("image=%q want ${TAG} substituted to v2", got)
+	}
+}
+
+func TestRun_FromBlueprint_NotFound_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-b", "ghost", "--realm", "my-realm", "-d"})
+
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, errdefs.ErrBlueprintNotFound) {
+		t.Fatalf("err=%v want ErrBlueprintNotFound", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell called %d times, want 0 on not-found", fc.createCalls)
+	}
+}
+
+func TestRun_FromBlueprint_NameOverride(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return kukeonv1.CreateCellResult{
+				Cell: doc, Created: true, MetadataExistsPost: true,
+				CgroupCreated: true, CgroupExistsPost: true,
+				RootContainerCreated: true, RootContainerExistsPost: true, Started: true,
+				Containers: []kukeonv1.ContainerCreationOutcome{{Name: "main", ExistsPost: true, Created: true}},
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-b", "web", "--name", "pinned", "--realm", "my-realm", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got := fc.createDoc.Metadata.Name; got != "pinned" {
+		t.Errorf("cell name=%q want pinned (--name override)", got)
+	}
+}
+
+func TestRun_Profile_EmitsDeprecationNotice(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, out := newCmd(t, fc)
+	// A bogus profile dir so the load fails fast after the notice prints; we
+	// assert only that the deprecation notice reached stderr (shared buffer).
+	cmd.SetArgs([]string{"-p", "nonexistent-profile", "-d"})
+	_ = cmd.Execute()
+
+	if !strings.Contains(out.String(), "-p/--profile is deprecated") {
+		t.Errorf("expected -p deprecation notice, got:\n%s", out.String())
 	}
 }

--- a/internal/apischeme/cellblueprint.go
+++ b/internal/apischeme/cellblueprint.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme
+
+import (
+	"fmt"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// ConvertCellBlueprintDocToInternal converts an external CellBlueprintDoc to
+// the internal hub carrier (issue #620). The body is serialized verbatim into
+// the carrier's Document — the daemon stores and round-trips it without
+// interpreting it — while the scope coordinates are lifted onto the metadata
+// so the storage runner can resolve the on-disk path. The apiVersion/kind are
+// normalized on the way in so the stored document is always canonical.
+func ConvertCellBlueprintDocToInternal(in ext.CellBlueprintDoc) (intmodel.CellBlueprint, error) {
+	switch in.APIVersion {
+	case VersionV1Beta1, "": // default/empty treated as v1beta1
+		canonical := in
+		canonical.APIVersion = ext.APIVersionV1Beta1
+		canonical.Kind = ext.KindCellBlueprint
+		document, err := yaml.Marshal(canonical)
+		if err != nil {
+			return intmodel.CellBlueprint{}, fmt.Errorf("marshal CellBlueprint document: %w", err)
+		}
+		return intmodel.CellBlueprint{
+			Metadata: intmodel.CellBlueprintMetadata{
+				Name:  in.Metadata.Name,
+				Realm: in.Metadata.Realm,
+				Space: in.Metadata.Space,
+				Stack: in.Metadata.Stack,
+			},
+			Document: document,
+		}, nil
+	default:
+		return intmodel.CellBlueprint{}, fmt.Errorf("unsupported apiVersion for CellBlueprint: %s", in.APIVersion)
+	}
+}
+
+// NormalizeCellBlueprint takes an external CellBlueprintDoc request and returns
+// an internal carrier and the chosen apiVersion.
+func NormalizeCellBlueprint(req ext.CellBlueprintDoc) (intmodel.CellBlueprint, ext.Version, error) {
+	version := DefaultVersion(req.APIVersion)
+	internal, err := ConvertCellBlueprintDocToInternal(req)
+	if err != nil {
+		return intmodel.CellBlueprint{}, "", err
+	}
+	return internal, version, nil
+}
+
+// ConvertCellBlueprintToExternal reconstructs the external CellBlueprintDoc
+// from the internal carrier's stored Document (issue #620). It is the inverse
+// of ConvertCellBlueprintDocToInternal, used by GetBlueprint to hand the full
+// template back to `kuke run -b` for materialization.
+func ConvertCellBlueprintToExternal(in intmodel.CellBlueprint) (ext.CellBlueprintDoc, error) {
+	var doc ext.CellBlueprintDoc
+	if err := yaml.Unmarshal(in.Document, &doc); err != nil {
+		return ext.CellBlueprintDoc{}, fmt.Errorf("unmarshal CellBlueprint document: %w", err)
+	}
+	return doc, nil
+}

--- a/internal/apischeme/cellblueprint_test.go
+++ b/internal/apischeme/cellblueprint_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func sampleBlueprintDoc() ext.CellBlueprintDoc {
+	return ext.CellBlueprintDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCellBlueprint,
+		Metadata: ext.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: "default",
+			Space: "agents",
+		},
+		Spec: ext.CellBlueprintSpec{
+			Prefix: "web",
+			Cell: ext.BlueprintCellSpec{
+				Containers: []ext.BlueprintContainer{
+					{ID: "main", Image: "alpine:latest", Attachable: true},
+				},
+			},
+		},
+	}
+}
+
+// TestCellBlueprintRoundTripV1Beta1 confirms the external doc survives the
+// to-internal / from-internal carrier hop verbatim: the daemon stores the body
+// opaquely in Document and reconstructs the same external shape on read-back.
+func TestCellBlueprintRoundTripV1Beta1(t *testing.T) {
+	in := sampleBlueprintDoc()
+
+	internal, version, err := apischeme.NormalizeCellBlueprint(in)
+	if err != nil {
+		t.Fatalf("NormalizeCellBlueprint() error = %v", err)
+	}
+	if version != ext.APIVersionV1Beta1 {
+		t.Errorf("version = %q, want v1beta1", version)
+	}
+	if internal.Metadata.Name != "web" || internal.Metadata.Realm != "default" || internal.Metadata.Space != "agents" {
+		t.Errorf("carrier metadata = %+v, want name=web realm=default space=agents", internal.Metadata)
+	}
+	if len(internal.Document) == 0 {
+		t.Fatal("carrier Document is empty, want serialized body")
+	}
+
+	out, err := apischeme.ConvertCellBlueprintToExternal(internal)
+	if err != nil {
+		t.Fatalf("ConvertCellBlueprintToExternal() error = %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("round-trip mismatch:\n in = %+v\nout = %+v", in, out)
+	}
+}
+
+// TestConvertCellBlueprint_NormalizesKindAndVersion confirms an empty
+// apiVersion/kind on the way in is canonicalized in the stored document.
+func TestConvertCellBlueprint_NormalizesKindAndVersion(t *testing.T) {
+	in := sampleBlueprintDoc()
+	in.APIVersion = ""
+	in.Kind = ""
+
+	internal, _, err := apischeme.NormalizeCellBlueprint(in)
+	if err != nil {
+		t.Fatalf("NormalizeCellBlueprint() error = %v", err)
+	}
+	out, err := apischeme.ConvertCellBlueprintToExternal(internal)
+	if err != nil {
+		t.Fatalf("ConvertCellBlueprintToExternal() error = %v", err)
+	}
+	if out.APIVersion != ext.APIVersionV1Beta1 || out.Kind != ext.KindCellBlueprint {
+		t.Errorf("stored doc not canonicalized: apiVersion=%q kind=%q", out.APIVersion, out.Kind)
+	}
+}
+
+func TestConvertCellBlueprint_UnsupportedVersion(t *testing.T) {
+	in := sampleBlueprintDoc()
+	in.APIVersion = "v2"
+	if _, err := apischeme.ConvertCellBlueprintDocToInternal(in); err == nil {
+		t.Fatal("expected error for unsupported apiVersion, got nil")
+	}
+}

--- a/internal/apply/parser/blueprint_test.go
+++ b/internal/apply/parser/blueprint_test.go
@@ -1,0 +1,228 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package parser_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// requireValidationErr asserts the validation error is non-nil and wraps (by
+// message — ValidationError carries the sentinel in its rendered string) the
+// expected sentinel, matching the convention in parser_test.go.
+func requireValidationErr(t *testing.T, err error, want error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected validation error %v, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want.Error()) {
+		t.Fatalf("err = %v, want it to contain %v", err, want)
+	}
+}
+
+func parseBlueprint(t *testing.T, yaml string) *parser.Document {
+	t.Helper()
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+	if doc.Kind != v1beta1.KindCellBlueprint {
+		t.Fatalf("kind = %q, want CellBlueprint", doc.Kind)
+	}
+	return doc
+}
+
+const validBlueprint = `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+  space: agents
+spec:
+  prefix: web
+  parameters:
+    - name: TAG
+      default: latest
+  cell:
+    containers:
+      - id: main
+        image: registry.example.com/web:${TAG}
+        attachable: true
+`
+
+func TestValidateDocument_Blueprint_Valid(t *testing.T) {
+	doc := parseBlueprint(t, validBlueprint)
+	if err := parser.ValidateDocument(doc); err != nil {
+		t.Fatalf("expected valid blueprint, got: %v", err)
+	}
+}
+
+func TestValidateDocument_Blueprint_MissingRealm(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+spec:
+  cell:
+    containers:
+      - id: main
+        image: alpine:latest
+`
+	doc := parseBlueprint(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrBlueprintRealmRequired)
+}
+
+func TestValidateDocument_Blueprint_StackWithoutSpace(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+  stack: claude
+spec:
+  cell:
+    containers:
+      - id: main
+        image: alpine:latest
+`
+	doc := parseBlueprint(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrBlueprintScopeIncomplete)
+}
+
+func TestValidateDocument_Blueprint_RepoSlotNoURLValid(t *testing.T) {
+	// Unlike the Cell/Container apply path, a repo with no url is a valid
+	// structural slot in a blueprint (CellConfig fills it, #624).
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+spec:
+  cell:
+    containers:
+      - id: main
+        image: alpine:latest
+        repos:
+          - name: app
+            target: /src
+`
+	doc := parseBlueprint(t, yaml)
+	if err := parser.ValidateDocument(doc); err != nil {
+		t.Fatalf("repo slot without url should validate in a blueprint, got: %v", err)
+	}
+}
+
+func TestValidateDocument_Blueprint_RepoSlotRelativeTarget(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+spec:
+  cell:
+    containers:
+      - id: main
+        image: alpine:latest
+        repos:
+          - name: app
+            target: relative/path
+`
+	doc := parseBlueprint(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrRepoTargetNotAbsolute)
+}
+
+func TestValidateDocument_Blueprint_SecretSlotEnvMissingEnvName(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+spec:
+  cell:
+    containers:
+      - id: main
+        image: alpine:latest
+        secrets:
+          - name: token
+            mode: env
+`
+	doc := parseBlueprint(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrBlueprintSecretSlotEnvName)
+}
+
+func TestValidateDocument_Blueprint_SecretSlotFileRelativeMount(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+spec:
+  cell:
+    containers:
+      - id: main
+        image: alpine:latest
+        secrets:
+          - name: token
+            mode: file
+            mountPath: rel/path
+`
+	doc := parseBlueprint(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrBlueprintSecretSlotMountPath)
+}
+
+func TestValidateDocument_Blueprint_SecretSlotBadMode(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+spec:
+  cell:
+    containers:
+      - id: main
+        image: alpine:latest
+        secrets:
+          - name: token
+            mode: bogus
+`
+	doc := parseBlueprint(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrBlueprintSecretSlotMode)
+}
+
+func TestValidateDocument_Blueprint_NoContainers(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+spec:
+  cell: {}
+`
+	doc := parseBlueprint(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrBlueprintCellRequired)
+}
+
+func TestParseDocument_Blueprint_RoundTripsSlots(t *testing.T) {
+	doc := parseBlueprint(t, validBlueprint)
+	if got := doc.CellBlueprintDoc.Spec.Cell.Containers[0].Image; !strings.Contains(got, "${TAG}") {
+		t.Fatalf("image = %q, want raw ${TAG} preserved before substitution", got)
+	}
+}

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -32,16 +32,17 @@ import (
 
 // Document represents a parsed YAML document with its type information.
 type Document struct {
-	Index        int
-	Raw          []byte
-	APIVersion   v1beta1.Version
-	Kind         v1beta1.Kind
-	RealmDoc     *v1beta1.RealmDoc
-	SpaceDoc     *v1beta1.SpaceDoc
-	StackDoc     *v1beta1.StackDoc
-	CellDoc      *v1beta1.CellDoc
-	ContainerDoc *v1beta1.ContainerDoc
-	SecretDoc    *v1beta1.SecretDoc
+	Index            int
+	Raw              []byte
+	APIVersion       v1beta1.Version
+	Kind             v1beta1.Kind
+	RealmDoc         *v1beta1.RealmDoc
+	SpaceDoc         *v1beta1.SpaceDoc
+	StackDoc         *v1beta1.StackDoc
+	CellDoc          *v1beta1.CellDoc
+	ContainerDoc     *v1beta1.ContainerDoc
+	SecretDoc        *v1beta1.SecretDoc
+	CellBlueprintDoc *v1beta1.CellBlueprintDoc
 }
 
 // ValidationError represents a validation error for a specific document.
@@ -170,6 +171,14 @@ func ParseDocument(index int, raw []byte) (*Document, error) {
 		doc.SecretDoc = &secretDoc
 		doc.APIVersion = secretDoc.APIVersion
 
+	case v1beta1.KindCellBlueprint:
+		var blueprintDoc v1beta1.CellBlueprintDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &blueprintDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse CellBlueprint: %w", index, unmarshalErr)
+		}
+		doc.CellBlueprintDoc = &blueprintDoc
+		doc.APIVersion = blueprintDoc.APIVersion
+
 	default:
 		return nil, fmt.Errorf("document %d: %w: %s", index, errdefs.ErrUnknownKind, kind)
 	}
@@ -197,7 +206,7 @@ func ValidateDocument(doc *Document) *ValidationError {
 	// Validate kind
 	switch doc.Kind {
 	case v1beta1.KindRealm, v1beta1.KindSpace, v1beta1.KindStack, v1beta1.KindCell,
-		v1beta1.KindContainer, v1beta1.KindSecret:
+		v1beta1.KindContainer, v1beta1.KindSecret, v1beta1.KindCellBlueprint:
 		// Valid kind
 	default:
 		return &ValidationError{
@@ -433,6 +442,11 @@ func ValidateDocument(doc *Document) *ValidationError {
 				Err:   errdefs.ErrSecretDataRequired,
 			}
 		}
+
+	case v1beta1.KindCellBlueprint:
+		if validationErr := validateBlueprint(doc); validationErr != nil {
+			return validationErr
+		}
 	}
 
 	return nil
@@ -456,6 +470,104 @@ func validateSecretSegment(value string) error {
 		strings.ContainsRune(value, '\\') ||
 		strings.ContainsRune(value, filepath.Separator) {
 		return errdefs.ErrSecretCoordUnsafe
+	}
+	return nil
+}
+
+// validateBlueprint enforces the structural contract for a kind: CellBlueprint
+// document (issue #620): name + scope coordinates, a non-empty cell template,
+// and the repo/secret slot shapes. The scope reachability gate (the named
+// realm/space/stack must exist) runs at reconcile time against the runner, the
+// same split the Secret kind uses (only the daemon can read /opt/kukeon).
+func validateBlueprint(doc *Document) *ValidationError {
+	if doc.CellBlueprintDoc == nil {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Err: errors.New("blueprint document is nil")}
+	}
+	bp := doc.CellBlueprintDoc
+	if strings.TrimSpace(bp.Metadata.Name) == "" {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Err: errdefs.ErrBlueprintNameRequired}
+	}
+	if scopeErr := validateBlueprintScope(bp.Metadata); scopeErr != nil {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: bp.Metadata.Name, Err: scopeErr}
+	}
+	if len(bp.Spec.Cell.Containers) == 0 {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: bp.Metadata.Name, Err: errdefs.ErrBlueprintCellRequired}
+	}
+	for _, c := range bp.Spec.Cell.Containers {
+		if repoErr := validateBlueprintRepos(c.Repos); repoErr != nil {
+			return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: bp.Metadata.Name, Err: repoErr}
+		}
+		if secretErr := validateBlueprintSecretSlots(c.Secrets); secretErr != nil {
+			return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: bp.Metadata.Name, Err: secretErr}
+		}
+	}
+	return nil
+}
+
+// validateBlueprintScope enforces the Blueprint scope-coordinate contract:
+// metadata.realm is always required, a deeper coordinate may only be set when
+// every shallower one is, and — unlike a Secret — a Blueprint may not be
+// cell-scoped (a template scoped to one cell is nonsensical, #423).
+func validateBlueprintScope(md v1beta1.CellBlueprintMetadata) error {
+	realm := strings.TrimSpace(md.Realm)
+	space := strings.TrimSpace(md.Space)
+	stack := strings.TrimSpace(md.Stack)
+
+	if realm == "" {
+		return errdefs.ErrBlueprintRealmRequired
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrBlueprintScopeIncomplete)
+	}
+	return nil
+}
+
+// validateBlueprintRepos enforces the blueprint repo-slot shape: name required,
+// target required and absolute. Unlike the Cell/Container apply path
+// (validateRepos), url is NOT required: a repo with no url is a structural slot
+// a CellConfig fills (#624). A url supplied inline (directly or via ${PARAM})
+// is carried through to the materialized cell unchanged.
+func validateBlueprintRepos(repos []v1beta1.ContainerRepo) error {
+	for i, r := range repos {
+		name := strings.TrimSpace(r.Name)
+		if name == "" {
+			return fmt.Errorf("%w (repos[%d])", errdefs.ErrRepoNameRequired, i)
+		}
+		target := strings.TrimSpace(r.Target)
+		if target == "" {
+			return fmt.Errorf("%w (repos[%d] %q)", errdefs.ErrRepoTargetRequired, i, name)
+		}
+		if !filepath.IsAbs(target) {
+			return fmt.Errorf("%w (repos[%d] %q target %q)", errdefs.ErrRepoTargetNotAbsolute, i, name, target)
+		}
+	}
+	return nil
+}
+
+// validateBlueprintSecretSlots enforces the blueprint secret-slot shape: name
+// required; mode (default "env") one of env/file; env mode requires envName;
+// file mode requires an absolute mountPath. The source side (which kind: Secret
+// provides the bytes) is intentionally absent — a CellConfig fills it (#624).
+func validateBlueprintSecretSlots(slots []v1beta1.BlueprintSecretSlot) error {
+	for i, s := range slots {
+		name := strings.TrimSpace(s.Name)
+		if name == "" {
+			return fmt.Errorf("%w (secrets[%d])", errdefs.ErrBlueprintSecretSlotNameRequired, i)
+		}
+		mode := strings.TrimSpace(s.Mode)
+		switch mode {
+		case "", v1beta1.BlueprintSecretModeEnv:
+			if strings.TrimSpace(s.EnvName) == "" {
+				return fmt.Errorf("%w (secrets[%d] %q)", errdefs.ErrBlueprintSecretSlotEnvName, i, name)
+			}
+		case v1beta1.BlueprintSecretModeFile:
+			mountPath := strings.TrimSpace(s.MountPath)
+			if mountPath == "" || !filepath.IsAbs(mountPath) {
+				return fmt.Errorf("%w (secrets[%d] %q)", errdefs.ErrBlueprintSecretSlotMountPath, i, name)
+			}
+		default:
+			return fmt.Errorf("%w (secrets[%d] %q mode %q)", errdefs.ErrBlueprintSecretSlotMode, i, name, mode)
+		}
 	}
 	return nil
 }

--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -1,0 +1,301 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cellblueprint resolves daemon-stored CellBlueprint templates into
+// CellDocs for `kuke run -b`. It is the blueprint analog of the cellprofile
+// package: scalar `${KEY}` substitution (shared with cellprofile via
+// SubstituteScalars), a fresh `<prefix>-<6hex>` cell name per invocation, and a
+// kukeon.io/blueprint back-reference label. Structural slots (secret slots,
+// repo slots with no url) are *not* fillable inline — they require a CellConfig
+// (`kuke run -c`, #625) — so materialization drops unfilled optional slots and
+// refuses unfilled required ones.
+package cellblueprint
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/cellprofile"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// LabelBlueprint is the cell label recording the CellBlueprint a cell was
+// materialized from, the blueprint analog of cellprofile.LabelProfile. Set on
+// every cell produced by `kuke run -b` so operators can list all instances
+// with `kuke get cells -l kukeon.io/blueprint=<name>`.
+const LabelBlueprint = "kukeon.io/blueprint"
+
+// nameSuffixBytes is the entropy width for the `<prefix>-<6hex>` suffix —
+// 3 bytes → 6 lowercase hex chars, matching cellprofile.
+const nameSuffixBytes = 3
+
+// Resolve substitutes `${KEY}` scalar parameters in the blueprint body against
+// the resolution order cliParams[k] > parameters[k].default > lookupEnv(k),
+// returning a resolved copy of the document. It mirrors
+// cellprofile.LoadResolved's contract (issue #355) for the daemon-stored
+// blueprint path:
+//
+//   - an undeclared --param key errors (typo at call time);
+//   - a parameter declared required that resolves to no value errors;
+//   - empty string is a valid resolved value; an unset, non-required parameter
+//     substitutes to empty so a declared-but-unused `${KEY}` drops out cleanly.
+//
+// When lookupEnv is nil the env fallback is skipped.
+func Resolve(
+	doc v1beta1.CellBlueprintDoc,
+	cliParams map[string]string,
+	lookupEnv func(string) (string, bool),
+) (v1beta1.CellBlueprintDoc, error) {
+	values, err := resolveValues(doc, cliParams, lookupEnv)
+	if err != nil {
+		return v1beta1.CellBlueprintDoc{}, err
+	}
+
+	raw, err := yaml.Marshal(doc)
+	if err != nil {
+		return v1beta1.CellBlueprintDoc{}, fmt.Errorf("blueprint %q: marshal for substitution: %w", doc.Metadata.Name, err)
+	}
+	var node yaml.Node
+	if unmarshalErr := yaml.Unmarshal(raw, &node); unmarshalErr != nil {
+		return v1beta1.CellBlueprintDoc{}, fmt.Errorf("blueprint %q: parse for substitution: %w", doc.Metadata.Name, unmarshalErr)
+	}
+
+	cellprofile.SubstituteScalars(&node, values)
+
+	var out v1beta1.CellBlueprintDoc
+	if decodeErr := node.Decode(&out); decodeErr != nil {
+		return v1beta1.CellBlueprintDoc{}, fmt.Errorf(
+			"blueprint %q: re-decode after parameter substitution: %w: %w",
+			doc.Metadata.Name, errdefs.ErrBlueprintInvalid, decodeErr,
+		)
+	}
+	return out, nil
+}
+
+// resolveValues validates cliParams against the declared parameters and builds
+// the substitution value map. The substitution leaves `default` declarations
+// themselves untouched (cellprofile.SubstituteScalars rewrites every scalar,
+// but a missing key is left literal; declared params are always in the map).
+func resolveValues(
+	doc v1beta1.CellBlueprintDoc,
+	cliParams map[string]string,
+	lookupEnv func(string) (string, bool),
+) (map[string]string, error) {
+	declared := make(map[string]v1beta1.CellProfileParameter, len(doc.Spec.Parameters))
+	for _, p := range doc.Spec.Parameters {
+		declared[p.Name] = p
+	}
+
+	for k := range cliParams {
+		if _, ok := declared[k]; !ok {
+			return nil, fmt.Errorf(
+				"blueprint %q: --param %q is not declared in spec.parameters[]: %w",
+				doc.Metadata.Name, k, errdefs.ErrBlueprintInvalid,
+			)
+		}
+	}
+
+	values := make(map[string]string, len(declared))
+	for _, p := range doc.Spec.Parameters {
+		if v, ok := cliParams[p.Name]; ok {
+			values[p.Name] = v
+			continue
+		}
+		if p.Default != nil {
+			values[p.Name] = *p.Default
+			continue
+		}
+		if lookupEnv != nil {
+			if v, ok := lookupEnv(p.Name); ok {
+				values[p.Name] = v
+				continue
+			}
+		}
+		if p.Required {
+			return nil, fmt.Errorf(
+				"blueprint %q: required parameter %q is not set "+
+					"(provide --param %s=... or declare a spec.parameters[].default): %w",
+				doc.Metadata.Name, p.Name, p.Name, errdefs.ErrBlueprintInvalid,
+			)
+		}
+		values[p.Name] = ""
+	}
+	return values, nil
+}
+
+// Materialize converts a resolved blueprint into a CellDoc, equivalent to
+// cellprofile.Materialize for the -b path. See MaterializeWithName.
+func Materialize(doc v1beta1.CellBlueprintDoc) (v1beta1.CellDoc, error) {
+	return MaterializeWithName(doc, "")
+}
+
+// MaterializeWithName converts a (resolved) blueprint into a CellDoc named
+// `<prefix>-<6hex>` (prefix = spec.prefix or metadata.name), or nameOverride
+// verbatim when non-empty. The realm/space/stack triple comes from the
+// blueprint metadata. Every cell carries the kukeon.io/blueprint=<name> label.
+//
+// Structural slots are resolved against the "scalar-only inline" contract:
+// a repo whose url is still empty after substitution, and every secret slot
+// (which never carries a source — that is a CellConfig's job, #624), are
+// unfilled. An unfilled *required* slot makes the blueprint un-runnable inline
+// and returns ErrBlueprintStructuralSlots naming the offenders; an unfilled
+// *optional* slot is dropped from the materialized container.
+func MaterializeWithName(doc v1beta1.CellBlueprintDoc, nameOverride string) (v1beta1.CellDoc, error) {
+	cellName, err := resolveCellName(doc, nameOverride)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+
+	containers := make([]v1beta1.ContainerSpec, 0, len(doc.Spec.Cell.Containers))
+	var blockers []string
+	for _, bc := range doc.Spec.Cell.Containers {
+		cs, missing := materializeContainer(bc)
+		blockers = append(blockers, missing...)
+		containers = append(containers, cs)
+	}
+	if len(blockers) > 0 {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (blueprint %q: %s); use `kuke run -c` once CellConfig lands (#625)",
+			errdefs.ErrBlueprintStructuralSlots, doc.Metadata.Name, strings.Join(blockers, ", "),
+		)
+	}
+
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   cellName,
+			Labels: mergeLabels(doc.Metadata.Labels, LabelBlueprint, doc.Metadata.Name),
+		},
+		Spec: v1beta1.CellSpec{
+			ID:                  cellName,
+			RealmID:             strings.TrimSpace(doc.Metadata.Realm),
+			SpaceID:             strings.TrimSpace(doc.Metadata.Space),
+			StackID:             strings.TrimSpace(doc.Metadata.Stack),
+			Tty:                 cloneCellTty(doc.Spec.Cell.Tty),
+			Containers:          containers,
+			AutoDelete:          doc.Spec.Cell.AutoDelete,
+			NestedCgroupRuntime: doc.Spec.Cell.NestedCgroupRuntime,
+		},
+	}, nil
+}
+
+// materializeContainer maps a BlueprintContainer to a runtime ContainerSpec and
+// returns the names of any unfilled *required* structural slots (which block
+// inline `-b`). Unfilled optional slots are dropped. A repo with a url (scalar
+// mode) is carried through unchanged.
+func materializeContainer(bc v1beta1.BlueprintContainer) (v1beta1.ContainerSpec, []string) {
+	var blockers []string
+
+	repos := make([]v1beta1.ContainerRepo, 0, len(bc.Repos))
+	for _, r := range bc.Repos {
+		if strings.TrimSpace(r.URL) == "" {
+			// Structural repo slot: url is filled by a CellConfig (#624).
+			if r.Required {
+				blockers = append(blockers, fmt.Sprintf("container %q repo slot %q (url)", bc.ID, r.Name))
+			}
+			continue
+		}
+		repos = append(repos, r)
+	}
+
+	// Every secret slot is structural: a blueprint never carries the secret
+	// source (which kind: Secret provides the bytes) — that is filled by a
+	// CellConfig (#624). So inline `-b` can never satisfy one. Required slots
+	// block; optional slots drop.
+	for _, s := range bc.Secrets {
+		if s.Required {
+			blockers = append(blockers, fmt.Sprintf("container %q secret slot %q", bc.ID, s.Name))
+		}
+	}
+
+	cs := v1beta1.ContainerSpec{
+		ID:                     bc.ID,
+		Root:                   bc.Root,
+		Image:                  bc.Image,
+		Command:                bc.Command,
+		Args:                   bc.Args,
+		WorkingDir:             bc.WorkingDir,
+		Env:                    bc.Env,
+		Ports:                  bc.Ports,
+		Volumes:                bc.Volumes,
+		Networks:               bc.Networks,
+		NetworksAliases:        bc.NetworksAliases,
+		Privileged:             bc.Privileged,
+		HostNetwork:            bc.HostNetwork,
+		HostPID:                bc.HostPID,
+		HostCgroup:             bc.HostCgroup,
+		User:                   bc.User,
+		ReadOnlyRootFilesystem: bc.ReadOnlyRootFilesystem,
+		Capabilities:           bc.Capabilities,
+		SecurityOpts:           bc.SecurityOpts,
+		Tmpfs:                  bc.Tmpfs,
+		Resources:              bc.Resources,
+		Repos:                  repos,
+		Git:                    bc.Git,
+		RestartPolicy:          bc.RestartPolicy,
+		Attachable:             bc.Attachable,
+		Tty:                    bc.Tty,
+	}
+	if len(repos) == 0 {
+		cs.Repos = nil
+	}
+	return cs, blockers
+}
+
+func resolveCellName(doc v1beta1.CellBlueprintDoc, nameOverride string) (string, error) {
+	if override := strings.TrimSpace(nameOverride); override != "" {
+		return override, nil
+	}
+	prefix := strings.TrimSpace(doc.Spec.Prefix)
+	if prefix == "" {
+		prefix = doc.Metadata.Name
+	}
+	suffix, err := randomHexSuffix()
+	if err != nil {
+		return "", fmt.Errorf("generate name suffix for blueprint %q: %w", doc.Metadata.Name, err)
+	}
+	return prefix + "-" + suffix, nil
+}
+
+func randomHexSuffix() (string, error) {
+	b := make([]byte, nameSuffixBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func cloneCellTty(in *v1beta1.CellTty) *v1beta1.CellTty {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func mergeLabels(in map[string]string, k, v string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+	for lk, lv := range in {
+		out[lk] = lv
+	}
+	out[k] = v
+	return out
+}

--- a/internal/cellblueprint/cellblueprint_test.go
+++ b/internal/cellblueprint/cellblueprint_test.go
@@ -1,0 +1,251 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellblueprint_test
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func strptr(s string) *string { return &s }
+
+// baseDoc returns a minimal runnable blueprint with a single container and one
+// parameter substituted into the image tag.
+func baseDoc() v1beta1.CellBlueprintDoc {
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:   "web",
+			Realm:  "default",
+			Space:  "agents",
+			Stack:  "claude",
+			Labels: map[string]string{"team": "infra"},
+		},
+		Spec: v1beta1.CellBlueprintSpec{
+			Prefix: "web",
+			Parameters: []v1beta1.CellProfileParameter{
+				{Name: "TAG", Default: strptr("latest")},
+			},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{
+						ID:         "main",
+						Image:      "registry.example.com/web:${TAG}",
+						Attachable: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestResolve_DefaultParameter(t *testing.T) {
+	out, err := cellblueprint.Resolve(baseDoc(), nil, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := out.Spec.Cell.Containers[0].Image; got != "registry.example.com/web:latest" {
+		t.Fatalf("image = %q, want default-substituted", got)
+	}
+}
+
+func TestResolve_CliParamWins(t *testing.T) {
+	out, err := cellblueprint.Resolve(baseDoc(), map[string]string{"TAG": "v2"}, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := out.Spec.Cell.Containers[0].Image; got != "registry.example.com/web:v2" {
+		t.Fatalf("image = %q, want cli-param override", got)
+	}
+}
+
+func TestResolve_EnvFallback(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Parameters = []v1beta1.CellProfileParameter{{Name: "TAG"}} // no default
+	lookup := func(k string) (string, bool) {
+		if k == "TAG" {
+			return "from-env", true
+		}
+		return "", false
+	}
+	out, err := cellblueprint.Resolve(doc, nil, lookup)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := out.Spec.Cell.Containers[0].Image; got != "registry.example.com/web:from-env" {
+		t.Fatalf("image = %q, want env fallback", got)
+	}
+}
+
+func TestResolve_UndeclaredParamErrors(t *testing.T) {
+	_, err := cellblueprint.Resolve(baseDoc(), map[string]string{"NOPE": "x"}, nil)
+	if !errors.Is(err, errdefs.ErrBlueprintInvalid) {
+		t.Fatalf("err = %v, want ErrBlueprintInvalid for undeclared param", err)
+	}
+}
+
+func TestResolve_RequiredUnsetErrors(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Parameters = []v1beta1.CellProfileParameter{{Name: "TAG", Required: true}}
+	_, err := cellblueprint.Resolve(doc, nil, nil)
+	if !errors.Is(err, errdefs.ErrBlueprintInvalid) {
+		t.Fatalf("err = %v, want ErrBlueprintInvalid for required-unset param", err)
+	}
+}
+
+var hexSuffixRE = regexp.MustCompile(`^web-[0-9a-f]{6}$`)
+
+func TestMaterialize_GeneratedNameAndScope(t *testing.T) {
+	resolved, err := cellblueprint.Resolve(baseDoc(), nil, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	cell, err := cellblueprint.Materialize(resolved)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if !hexSuffixRE.MatchString(cell.Metadata.Name) {
+		t.Fatalf("name = %q, want <prefix>-<6hex>", cell.Metadata.Name)
+	}
+	if cell.Spec.ID != cell.Metadata.Name {
+		t.Fatalf("spec.id = %q, want = metadata.name %q", cell.Spec.ID, cell.Metadata.Name)
+	}
+	if cell.Spec.RealmID != "default" || cell.Spec.SpaceID != "agents" || cell.Spec.StackID != "claude" {
+		t.Fatalf("scope = %q/%q/%q, want default/agents/claude", cell.Spec.RealmID, cell.Spec.SpaceID, cell.Spec.StackID)
+	}
+	if cell.Metadata.Labels[cellblueprint.LabelBlueprint] != "web" {
+		t.Fatalf("missing blueprint back-reference label: %v", cell.Metadata.Labels)
+	}
+	if cell.Metadata.Labels["team"] != "infra" {
+		t.Fatalf("metadata labels not carried through: %v", cell.Metadata.Labels)
+	}
+}
+
+func TestMaterialize_FreshNameEachCall(t *testing.T) {
+	resolved, _ := cellblueprint.Resolve(baseDoc(), nil, nil)
+	a, _ := cellblueprint.Materialize(resolved)
+	b, _ := cellblueprint.Materialize(resolved)
+	if a.Metadata.Name == b.Metadata.Name {
+		t.Fatalf("two materializations produced the same name %q", a.Metadata.Name)
+	}
+}
+
+func TestMaterialize_NameOverride(t *testing.T) {
+	resolved, _ := cellblueprint.Resolve(baseDoc(), nil, nil)
+	cell, err := cellblueprint.MaterializeWithName(resolved, "pinned")
+	if err != nil {
+		t.Fatalf("MaterializeWithName: %v", err)
+	}
+	if cell.Metadata.Name != "pinned" || cell.Spec.ID != "pinned" {
+		t.Fatalf("override not honored: name=%q id=%q", cell.Metadata.Name, cell.Spec.ID)
+	}
+}
+
+func TestMaterialize_FilledRepoCarried(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Cell.Containers[0].Repos = []v1beta1.ContainerRepo{
+		{Name: "app", Target: "/src", URL: "https://example.com/app.git"},
+	}
+	resolved, _ := cellblueprint.Resolve(doc, nil, nil)
+	cell, err := cellblueprint.Materialize(resolved)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if len(cell.Spec.Containers[0].Repos) != 1 {
+		t.Fatalf("filled repo dropped: %+v", cell.Spec.Containers[0].Repos)
+	}
+}
+
+func TestMaterialize_OptionalEmptyRepoDropped(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Cell.Containers[0].Repos = []v1beta1.ContainerRepo{
+		{Name: "app", Target: "/src"}, // no url, not required → structural slot, dropped
+	}
+	resolved, _ := cellblueprint.Resolve(doc, nil, nil)
+	cell, err := cellblueprint.Materialize(resolved)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if len(cell.Spec.Containers[0].Repos) != 0 {
+		t.Fatalf("optional empty repo slot not dropped: %+v", cell.Spec.Containers[0].Repos)
+	}
+}
+
+func TestMaterialize_RequiredEmptyRepoBlocks(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Cell.Containers[0].Repos = []v1beta1.ContainerRepo{
+		{Name: "app", Target: "/src", Required: true}, // no url, required → blocks inline -b
+	}
+	resolved, _ := cellblueprint.Resolve(doc, nil, nil)
+	_, err := cellblueprint.Materialize(resolved)
+	if !errors.Is(err, errdefs.ErrBlueprintStructuralSlots) {
+		t.Fatalf("err = %v, want ErrBlueprintStructuralSlots", err)
+	}
+}
+
+func TestMaterialize_RequiredSecretSlotBlocks(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Cell.Containers[0].Secrets = []v1beta1.BlueprintSecretSlot{
+		{Name: "token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "TOKEN", Required: true},
+	}
+	resolved, _ := cellblueprint.Resolve(doc, nil, nil)
+	_, err := cellblueprint.Materialize(resolved)
+	if !errors.Is(err, errdefs.ErrBlueprintStructuralSlots) {
+		t.Fatalf("err = %v, want ErrBlueprintStructuralSlots for required secret slot", err)
+	}
+	if !strings.Contains(err.Error(), "token") {
+		t.Fatalf("error should name the offending slot: %v", err)
+	}
+}
+
+func TestMaterialize_OptionalSecretSlotDropped(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Cell.Containers[0].Secrets = []v1beta1.BlueprintSecretSlot{
+		{Name: "token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "TOKEN"}, // optional
+	}
+	resolved, _ := cellblueprint.Resolve(doc, nil, nil)
+	cell, err := cellblueprint.Materialize(resolved)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	// Secret slots never land on the runtime ContainerSpec (no secret field on
+	// it yet — Config-side fill lands in #624); the optional slot simply drops.
+	if len(cell.Spec.Containers) != 1 {
+		t.Fatalf("container count changed: %d", len(cell.Spec.Containers))
+	}
+}
+
+func TestMaterialize_PrefixFallsBackToName(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Prefix = ""
+	doc.Metadata.Name = "fallback"
+	resolved, _ := cellblueprint.Resolve(doc, nil, nil)
+	cell, err := cellblueprint.Materialize(resolved)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	if !strings.HasPrefix(cell.Metadata.Name, "fallback-") {
+		t.Fatalf("name = %q, want prefix from metadata.name", cell.Metadata.Name)
+	}
+}

--- a/internal/cellprofile/params.go
+++ b/internal/cellprofile/params.go
@@ -321,6 +321,30 @@ func cloneNode(n *yaml.Node) *yaml.Node {
 	return &out
 }
 
+// SubstituteScalars rewrites every `${KEY}` occurrence inside the scalar
+// values of node with values[KEY], in place. It is the exported entry point
+// the CellBlueprint materialize path (issue #620) shares with the CellProfile
+// loader: both substitute the same `${KEY}` shape against a declared parameter
+// map. Keys absent from values are left as literal `${KEY}` (callers validate
+// references first). Mapping keys are never rewritten.
+func SubstituteScalars(node *yaml.Node, values map[string]string) {
+	substituteScalars(node, values)
+}
+
+// CloneNode returns a deep copy of n so substitutions don't mutate the input.
+// Exported for the CellBlueprint materialize path (issue #620).
+func CloneNode(n *yaml.Node) *yaml.Node {
+	return cloneNode(n)
+}
+
+// ParamRefRE returns the compiled `${KEY}` reference matcher shared by the
+// profile and blueprint substitution paths. Exposed so the blueprint resolver
+// can scan a template body for the parameter shape without re-deriving the
+// regex. Issue #620.
+func ParamRefRE() *regexp.Regexp {
+	return paramRefRE
+}
+
 // ParseParamArgs validates a slice of `KEY=VALUE` strings (from --param) and
 // returns the equivalent map. Empty values are allowed (`KEY=` → "");
 // missing `=` errors. Duplicate keys: last occurrence wins, matching `docker

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -343,6 +343,30 @@ func (c *Client) GetSecret(_ context.Context, doc v1beta1.SecretDoc) (kukeonv1.G
 	}, nil
 }
 
+func (c *Client) GetBlueprint(
+	_ context.Context, doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.GetBlueprintResult, error) {
+	internal, _, err := apischeme.NormalizeCellBlueprint(doc)
+	if err != nil {
+		return kukeonv1.GetBlueprintResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.GetBlueprint(internal)
+	if err != nil {
+		return kukeonv1.GetBlueprintResult{}, err
+	}
+	if !res.MetadataExists {
+		return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
+	}
+	ext, err := apischeme.ConvertCellBlueprintToExternal(res.Blueprint)
+	if err != nil {
+		return kukeonv1.GetBlueprintResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	return kukeonv1.GetBlueprintResult{
+		Blueprint:      ext,
+		MetadataExists: true,
+	}, nil
+}
+
 // ---- List ----
 
 func (c *Client) ListRealms(_ context.Context) ([]v1beta1.RealmDoc, error) {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -46,6 +46,15 @@ const (
 	// and the files in it are root-only (0o700 / 0o600).
 	KukeonSecretsSubdir = "secrets"
 
+	// KukeonBlueprintsSubdir is the basename of the per-scope subdirectory that
+	// owns daemon-managed `kind: CellBlueprint` documents (issue #620). Like
+	// the secrets subdir it lives inside the scope's metadata directory (e.g.
+	// <RunPath>/data/<realm>/blueprints/) so a scope teardown reclaims it.
+	// Unlike secrets, a blueprint carries no credential bytes — only template
+	// references — so the directory and files are root-owned but world-readable
+	// (0o755 / 0o644).
+	KukeonBlueprintsSubdir = "blueprints"
+
 	// KukeonContainerTTYDir is the basename of the per-container directory
 	// that owns the sbsh terminal socket plus its capture and log siblings.
 	// kukeon bind-mounts this directory (not a single file) into the

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -219,6 +219,23 @@ func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
 			resourceResult.Name = secret.Metadata.Name
 			reconcileResult, reconcileErr = applypkg.ReconcileSecret(b.runner, secret)
 
+		case v1beta1.KindCellBlueprint:
+			if doc.CellBlueprintDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("blueprint document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			blueprint, _, err := apischeme.NormalizeCellBlueprint(*doc.CellBlueprintDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = blueprint.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileBlueprint(b.runner, blueprint)
+
 		default:
 			resourceResult.Action = actionFailed
 			resourceResult.Error = fmt.Errorf("%w: %s", errdefs.ErrUnknownKind, doc.Kind)

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -616,6 +616,81 @@ func ensureSecretScopeExists(r runner.Runner, md intmodel.SecretMetadata) error 
 	return nil
 }
 
+// ReconcileBlueprint reconciles a desired `kind: CellBlueprint` by verifying
+// its scope exists and persisting its document to the daemon-managed file
+// (issue #620). Like ReconcileSecret it never auto-creates a missing scope: a
+// Blueprint targets an existing realm/space/stack, so an unreachable scope is
+// an apply-time error. The document is written write-through — re-applying
+// overwrites and reports "updated".
+func ReconcileBlueprint(r runner.Runner, desired intmodel.CellBlueprint) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "CellBlueprint",
+		Name:   desired.Metadata.Name,
+	}
+
+	if err := ensureBlueprintScopeExists(r, desired.Metadata); err != nil {
+		return result, err
+	}
+
+	created, writeErr := r.WriteBlueprint(desired)
+	if writeErr != nil {
+		return result, writeErr
+	}
+	if created {
+		result.Action = actionCreated
+	} else {
+		result.Action = actionUpdated
+	}
+	return result, nil
+}
+
+// ensureBlueprintScopeExists verifies every scope coordinate the blueprint
+// names is reachable, deepest-first. A Blueprint is scopable at realm/space/
+// stack only (never cell), so the walk stops at the stack. A NotFound is
+// translated to errdefs.ErrBlueprintScopeNotFound.
+func ensureBlueprintScopeExists(r runner.Runner, md intmodel.CellBlueprintMetadata) error {
+	if _, err := r.GetRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: md.Realm},
+	}); err != nil {
+		return blueprintScopeLookupError(err, "realm", md.Realm)
+	}
+
+	if md.Space != "" {
+		if _, err := r.GetSpace(intmodel.Space{
+			Metadata: intmodel.SpaceMetadata{Name: md.Space},
+			Spec:     intmodel.SpaceSpec{RealmName: md.Realm},
+		}); err != nil {
+			return blueprintScopeLookupError(err, "space", md.Space)
+		}
+	}
+
+	if md.Stack != "" {
+		if _, err := r.GetStack(intmodel.Stack{
+			Metadata: intmodel.StackMetadata{Name: md.Stack},
+			Spec:     intmodel.StackSpec{RealmName: md.Realm, SpaceName: md.Space},
+		}); err != nil {
+			return blueprintScopeLookupError(err, "stack", md.Stack)
+		}
+	}
+
+	return nil
+}
+
+// blueprintScopeLookupError maps a scope Get failure to a stable error. A
+// NotFound at any level becomes ErrBlueprintScopeNotFound; any other error is
+// propagated with context so it is not masked as a missing scope.
+func blueprintScopeLookupError(err error, level, name string) error {
+	switch {
+	case errors.Is(err, errdefs.ErrRealmNotFound),
+		errors.Is(err, errdefs.ErrSpaceNotFound),
+		errors.Is(err, errdefs.ErrStackNotFound):
+		return fmt.Errorf("%w: %s %q", errdefs.ErrBlueprintScopeNotFound, level, name)
+	default:
+		return fmt.Errorf("failed to verify blueprint scope %s %q: %w", level, name, err)
+	}
+}
+
 // scopeLookupError maps a scope Get failure to a stable error. A NotFound at
 // any level becomes ErrSecretScopeNotFound (the AC's "scope must exist"
 // gate); any other error (e.g. a corrupt metadata read) is propagated with

--- a/internal/controller/blueprint.go
+++ b/internal/controller/blueprint.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// GetBlueprintResult reports the full document view of a single
+// `kind: CellBlueprint` (issue #620). Unlike a Secret, a blueprint carries no
+// credential bytes — only template references — so the whole document is
+// returned for `kuke run -b` to materialize.
+type GetBlueprintResult struct {
+	Blueprint      intmodel.CellBlueprint
+	MetadataExists bool
+}
+
+// GetBlueprint reads one named, scoped CellBlueprint's document. The scope
+// coordinates are validated for completeness (a deeper coordinate requires
+// every shallower one; a Blueprint may not be cell-scoped); realm and name are
+// mandatory. Returns MetadataExists=false (no error) when the blueprint is
+// absent, mirroring GetSecret's "report, don't error on not-found" shape.
+func (b *Exec) GetBlueprint(blueprint intmodel.CellBlueprint) (GetBlueprintResult, error) {
+	var res GetBlueprintResult
+
+	if err := validateBlueprintLookup(blueprint.Metadata); err != nil {
+		return res, err
+	}
+
+	got, err := b.runner.GetBlueprint(blueprint)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrBlueprintNotFound) {
+			res.MetadataExists = false
+			return res, nil
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetBlueprint, err)
+	}
+
+	res.MetadataExists = true
+	res.Blueprint = got
+	return res, nil
+}
+
+// validateBlueprintLookup enforces the scope contract for a single-blueprint
+// get: name and realm are mandatory and the scope coordinates must be
+// contiguous, with the Blueprint-specific rule that a cell coordinate is never
+// valid (a Blueprint is realm/space/stack-scoped only).
+func validateBlueprintLookup(md intmodel.CellBlueprintMetadata) error {
+	if strings.TrimSpace(md.Name) == "" {
+		return errdefs.ErrBlueprintNameRequired
+	}
+	if strings.TrimSpace(md.Realm) == "" {
+		return errdefs.ErrBlueprintRealmRequired
+	}
+	if strings.TrimSpace(md.Stack) != "" && strings.TrimSpace(md.Space) == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrBlueprintScopeIncomplete)
+	}
+	return nil
+}

--- a/internal/controller/blueprint_test.go
+++ b/internal/controller/blueprint_test.go
@@ -1,0 +1,97 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestGetBlueprint_ReportsNotFoundWithoutError pins the GetSecret-shaped
+// contract: an absent blueprint yields MetadataExists=false and a nil error.
+func TestGetBlueprint_ReportsNotFoundWithoutError(t *testing.T) {
+	mockRunner := &fakeRunner{
+		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return intmodel.CellBlueprint{}, errdefs.ErrBlueprintNotFound
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.GetBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("GetBlueprint() error = %v, want nil", err)
+	}
+	if res.MetadataExists {
+		t.Errorf("MetadataExists = true, want false for absent blueprint")
+	}
+}
+
+// TestGetBlueprint_ReturnsFullDocument confirms a present blueprint surfaces its
+// full document (unlike GetSecret, which is metadata-only).
+func TestGetBlueprint_ReturnsFullDocument(t *testing.T) {
+	mockRunner := &fakeRunner{
+		GetBlueprintFn: func(bp intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return intmodel.CellBlueprint{Metadata: bp.Metadata, Document: []byte("body")}, nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.GetBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("GetBlueprint() error = %v", err)
+	}
+	if !res.MetadataExists {
+		t.Fatal("MetadataExists = false, want true")
+	}
+	if string(res.Blueprint.Document) != "body" {
+		t.Errorf("Document = %q, want body", res.Blueprint.Document)
+	}
+}
+
+func TestGetBlueprint_ValidatesScope(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+
+	tests := []struct {
+		name string
+		md   intmodel.CellBlueprintMetadata
+		want error
+	}{
+		{"missing_name", intmodel.CellBlueprintMetadata{Realm: "default"}, errdefs.ErrBlueprintNameRequired},
+		{"missing_realm", intmodel.CellBlueprintMetadata{Name: "web"}, errdefs.ErrBlueprintRealmRequired},
+		{
+			"stack_without_space",
+			intmodel.CellBlueprintMetadata{Name: "web", Realm: "default", Stack: "st"},
+			errdefs.ErrBlueprintScopeIncomplete,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ctrl.GetBlueprint(intmodel.CellBlueprint{Metadata: tt.md}); !errors.Is(err, tt.want) {
+				t.Errorf("GetBlueprint() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -65,6 +65,10 @@ type fakeRunner struct {
 	ListSecretsFn  func(realmName, spaceName, stackName, cellName string) ([]intmodel.Secret, error)
 	DeleteSecretFn func(secret intmodel.Secret) error
 
+	// Blueprint methods
+	WriteBlueprintFn func(bp intmodel.CellBlueprint) (bool, error)
+	GetBlueprintFn   func(bp intmodel.CellBlueprint) (intmodel.CellBlueprint, error)
+
 	// Cell methods
 	GetCellFn                 func(cell intmodel.Cell) (intmodel.Cell, error)
 	ListCellsFn               func(realmName, spaceName, stackName string) ([]intmodel.Cell, error)
@@ -288,6 +292,22 @@ func (f *fakeRunner) DeleteSecret(secret intmodel.Secret) error {
 		return f.DeleteSecretFn(secret)
 	}
 	return errors.New("unexpected call to DeleteSecret")
+}
+
+// Blueprint methods
+
+func (f *fakeRunner) WriteBlueprint(bp intmodel.CellBlueprint) (bool, error) {
+	if f.WriteBlueprintFn != nil {
+		return f.WriteBlueprintFn(bp)
+	}
+	return false, errors.New("unexpected call to WriteBlueprint")
+}
+
+func (f *fakeRunner) GetBlueprint(bp intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+	if f.GetBlueprintFn != nil {
+		return f.GetBlueprintFn(bp)
+	}
+	return intmodel.CellBlueprint{}, errors.New("unexpected call to GetBlueprint")
 }
 
 // Cell methods

--- a/internal/controller/documents.go
+++ b/internal/controller/documents.go
@@ -46,6 +46,12 @@ func SortDocumentsByKind(docs []parser.Document, reverse bool) []parser.Document
 	// does not yet exist. Derived from the map length rather than a literal so
 	// it stays correct if a kind is inserted above.
 	kindOrder[v1beta1.KindSecret] = len(kindOrder) + 1
+	// CellBlueprints, like Secrets, target an existing scope (realm/space/stack)
+	// rather than creating one, so they sort after the hierarchy kinds: any
+	// scope bundled in the same apply file is materialized before a blueprint
+	// that targets it (reconcile rejects a blueprint whose scope does not yet
+	// exist). Evaluated after the Secret line so it lands one slot further out.
+	kindOrder[v1beta1.KindCellBlueprint] = len(kindOrder) + 1
 
 	// Sort by kind order, then by original index
 	sort.Slice(sorted, func(i, j int) bool {

--- a/internal/controller/reconcile_blueprint_test.go
+++ b/internal/controller/reconcile_blueprint_test.go
@@ -1,0 +1,107 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"testing"
+
+	applypkg "github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestReconcileBlueprint_WritesWhenScopeExists is the issue #620 happy path:
+// with the realm reachable, ReconcileBlueprint writes the document and reports
+// created.
+func TestReconcileBlueprint_WritesWhenScopeExists(t *testing.T) {
+	var wrote []byte
+	f := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) { return realm, nil },
+		WriteBlueprintFn: func(bp intmodel.CellBlueprint) (bool, error) {
+			wrote = bp.Document
+			return true, nil
+		},
+	}
+
+	desired := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default"},
+		Document: []byte("body"),
+	}
+	result, err := applypkg.ReconcileBlueprint(f, desired)
+	if err != nil {
+		t.Fatalf("ReconcileBlueprint() error = %v", err)
+	}
+	if result.Action != "created" {
+		t.Errorf("action = %q, want created", result.Action)
+	}
+	if string(wrote) != "body" {
+		t.Errorf("WriteBlueprint got document %q, want body", wrote)
+	}
+}
+
+// TestReconcileBlueprint_RejectsMissingScope confirms the scope-reachability
+// gate: a realm-not-found surfaces ErrBlueprintScopeNotFound and WriteBlueprint
+// is never reached.
+func TestReconcileBlueprint_RejectsMissingScope(t *testing.T) {
+	var wrote bool
+	f := &fakeRunner{
+		GetRealmFn: func(intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errdefs.ErrRealmNotFound
+		},
+		WriteBlueprintFn: func(intmodel.CellBlueprint) (bool, error) {
+			wrote = true
+			return false, nil
+		},
+	}
+
+	desired := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "ghost"},
+		Document: []byte("x"),
+	}
+	_, err := applypkg.ReconcileBlueprint(f, desired)
+	if !errors.Is(err, errdefs.ErrBlueprintScopeNotFound) {
+		t.Fatalf("err = %v, want ErrBlueprintScopeNotFound", err)
+	}
+	if wrote {
+		t.Error("WriteBlueprint was called despite a missing scope")
+	}
+}
+
+// TestReconcileBlueprint_ChecksSpaceScope confirms a space-scoped blueprint
+// verifies the space coordinate and rejects when it is missing. (Blueprints
+// are never cell-scoped, so the walk stops at the stack.)
+func TestReconcileBlueprint_ChecksSpaceScope(t *testing.T) {
+	f := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) { return realm, nil },
+		GetSpaceFn: func(intmodel.Space) (intmodel.Space, error) {
+			return intmodel.Space{}, errdefs.ErrSpaceNotFound
+		},
+		WriteBlueprintFn: func(intmodel.CellBlueprint) (bool, error) { return false, nil },
+	}
+
+	desired := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default", Space: "ghost"},
+		Document: []byte("x"),
+	}
+	_, err := applypkg.ReconcileBlueprint(f, desired)
+	if !errors.Is(err, errdefs.ErrBlueprintScopeNotFound) {
+		t.Fatalf("err = %v, want ErrBlueprintScopeNotFound for missing space", err)
+	}
+}

--- a/internal/controller/runner/blueprint.go
+++ b/internal/controller/runner/blueprint.go
@@ -1,0 +1,130 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// blueprintsDirMode is the mode of the per-scope blueprints/ directory. Unlike
+// the root-only secrets/ directory, a blueprint carries no credential bytes —
+// only template references — so the directory is world-readable (issue #620).
+const blueprintsDirMode os.FileMode = 0o755
+
+// blueprintFileMode is the mode of an individual blueprint document file:
+// root-owned, world-readable. References only, no secret material.
+const blueprintFileMode os.FileMode = 0o644
+
+// WriteBlueprint persists a CellBlueprint's serialized document to
+// <RunPath>/data/<scope>/blueprints/<name>, root-owned and world-readable
+// (issue #620). The document is written atomically via a temp file + rename so
+// a reader never observes a partially-written blueprint. Returns whether the
+// file was newly created (vs. overwritten). The caller (ReconcileBlueprint) is
+// responsible for having verified the scope exists.
+func (r *Exec) WriteBlueprint(blueprint intmodel.CellBlueprint) (bool, error) {
+	md := blueprint.Metadata
+	dir := fs.BlueprintsDir(r.opts.RunPath, md.Realm, md.Space, md.Stack)
+	path := fs.BlueprintPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	if err := os.MkdirAll(dir, blueprintsDirMode); err != nil {
+		return false, fmt.Errorf("%w: create blueprints dir: %w", errdefs.ErrWriteBlueprint, err)
+	}
+	// MkdirAll honors only the rwx bits and leaves a pre-existing directory's
+	// mode intact; chmod unconditionally so the world-readable contract holds
+	// even when a parent created the dir with tighter bits or the umask
+	// stripped them.
+	if err := os.Chmod(dir, blueprintsDirMode); err != nil {
+		return false, fmt.Errorf("%w: chmod blueprints dir: %w", errdefs.ErrWriteBlueprint, err)
+	}
+
+	_, statErr := os.Stat(path)
+	created := errors.Is(statErr, os.ErrNotExist)
+	if statErr != nil && !created {
+		return false, fmt.Errorf("%w: stat blueprint: %w", errdefs.ErrWriteBlueprint, statErr)
+	}
+
+	if err := atomicWriteFileMode(dir, path, ".blueprint-*.tmp", blueprint.Document, blueprintFileMode); err != nil {
+		return false, fmt.Errorf("%w: %w", errdefs.ErrWriteBlueprint, err)
+	}
+
+	action := "updated"
+	if created {
+		action = "created"
+	}
+	r.logger.InfoContext(r.ctx, "blueprint "+action,
+		"name", md.Name,
+		"realm", md.Realm,
+		"space", md.Space,
+		"stack", md.Stack,
+	)
+	return created, nil
+}
+
+// GetBlueprint reads a single named, scoped CellBlueprint's document off disk
+// (issue #620). Unlike GetSecret — which is metadata-only because secret bytes
+// must never round-trip — a blueprint carries only template references, so the
+// full document is read back and returned for `kuke run -b` to materialize.
+// Returns errdefs.ErrBlueprintNotFound when the file is absent.
+func (r *Exec) GetBlueprint(blueprint intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+	md := blueprint.Metadata
+	path := fs.BlueprintPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return intmodel.CellBlueprint{}, errdefs.ErrBlueprintNotFound
+		}
+		return intmodel.CellBlueprint{}, fmt.Errorf("%w: %w", errdefs.ErrGetBlueprint, err)
+	}
+
+	return intmodel.CellBlueprint{Metadata: md, Document: data}, nil
+}
+
+// atomicWriteFileMode writes data to path via a temp file in the same
+// directory followed by a rename, so a concurrent reader sees either the old
+// inode or the fully-written new one — never a torn write. The temp file is
+// chmod'd to mode (stripping the umask) before the rename. Pattern is the
+// CreateTemp prefix glob used for the in-flight temp file.
+func atomicWriteFileMode(dir, path, pattern string, data []byte, mode os.FileMode) error {
+	tmp, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, writeErr := tmp.Write(data); writeErr != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file: %w", writeErr)
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		return fmt.Errorf("close temp file: %w", closeErr)
+	}
+	if chmodErr := os.Chmod(tmpName, mode); chmodErr != nil {
+		return fmt.Errorf("chmod temp file: %w", chmodErr)
+	}
+	if renameErr := os.Rename(tmpName, path); renameErr != nil {
+		return fmt.Errorf("rename file into place: %w", renameErr)
+	}
+	return nil
+}

--- a/internal/controller/runner/blueprint_test.go
+++ b/internal/controller/runner/blueprint_test.go
@@ -1,0 +1,173 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests the unexported WriteBlueprint path against a temp RunPath
+package runner
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// TestWriteBlueprint_CreatesWorldReadableFile pins the issue #620 storage
+// contract: the document lands at <RunPath>/data/<scope>/blueprints/<name>,
+// the file is 0o644 and the blueprints/ dir is 0o755 (world-readable, unlike
+// the root-only 0o700/0o600 secrets path), and the first write reports
+// created=true.
+func TestWriteBlueprint_CreatesWorldReadableFile(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	bp := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default"},
+		Document: []byte("apiVersion: v1beta1\nkind: CellBlueprint\n"),
+	}
+
+	created, err := r.WriteBlueprint(bp)
+	if err != nil {
+		t.Fatalf("WriteBlueprint() error = %v", err)
+	}
+	if !created {
+		t.Errorf("created = false, want true on first write")
+	}
+
+	path := fs.BlueprintPath(runPath, "default", "", "", "web")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written blueprint: %v", err)
+	}
+	if string(got) != string(bp.Document) {
+		t.Errorf("blueprint bytes = %q, want %q", got, bp.Document)
+	}
+
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat blueprint file: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0o644 {
+		t.Errorf("blueprint file mode = %o, want 644 (world-readable)", perm)
+	}
+
+	dirInfo, err := os.Stat(fs.BlueprintsDir(runPath, "default", "", ""))
+	if err != nil {
+		t.Fatalf("stat blueprints dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o755 {
+		t.Errorf("blueprints dir mode = %o, want 755 (world-readable)", perm)
+	}
+}
+
+// TestWriteBlueprint_OverwriteReportsUpdated confirms a re-apply overwrites the
+// document and reports created=false.
+func TestWriteBlueprint_OverwriteReportsUpdated(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	bp := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default"},
+		Document: []byte("v1"),
+	}
+	if _, err := r.WriteBlueprint(bp); err != nil {
+		t.Fatalf("first WriteBlueprint() error = %v", err)
+	}
+
+	bp.Document = []byte("v2")
+	created, err := r.WriteBlueprint(bp)
+	if err != nil {
+		t.Fatalf("second WriteBlueprint() error = %v", err)
+	}
+	if created {
+		t.Errorf("created = true, want false on overwrite")
+	}
+
+	got, err := os.ReadFile(fs.BlueprintPath(runPath, "default", "", "", "web"))
+	if err != nil {
+		t.Fatalf("reading overwritten blueprint: %v", err)
+	}
+	if string(got) != "v2" {
+		t.Errorf("blueprint bytes = %q, want v2", got)
+	}
+}
+
+// TestGetBlueprint_ReturnsFullDocument confirms GetBlueprint reads the full
+// document back (unlike GetSecret, which is metadata-only) and reports
+// ErrBlueprintNotFound for an absent name.
+func TestGetBlueprint_ReturnsFullDocument(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	stored := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default", Space: "team-a"},
+		Document: []byte("the-template-body"),
+	}
+	if _, err := r.WriteBlueprint(stored); err != nil {
+		t.Fatalf("WriteBlueprint() error = %v", err)
+	}
+
+	got, err := r.GetBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("GetBlueprint() error = %v", err)
+	}
+	if string(got.Document) != "the-template-body" {
+		t.Errorf("Document = %q, want the-template-body (full body must round-trip)", got.Document)
+	}
+}
+
+func TestGetBlueprint_NotFound(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	_, err := r.GetBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "ghost", Realm: "default"},
+	})
+	if !errors.Is(err, errdefs.ErrBlueprintNotFound) {
+		t.Errorf("GetBlueprint() error = %v, want ErrBlueprintNotFound", err)
+	}
+}
+
+// TestWriteBlueprint_DeeperScopeNestsUnderScopeDir confirms a space-scoped
+// blueprint lands under the space metadata dir, not the realm dir.
+func TestWriteBlueprint_DeeperScopeNestsUnderScopeDir(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	bp := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default", Space: "team-a"},
+		Document: []byte("x"),
+	}
+	if _, err := r.WriteBlueprint(bp); err != nil {
+		t.Fatalf("WriteBlueprint() error = %v", err)
+	}
+
+	spaceScoped := fs.BlueprintPath(runPath, "default", "team-a", "", "web")
+	if _, err := os.Stat(spaceScoped); err != nil {
+		t.Errorf("space-scoped blueprint not found at %s: %v", spaceScoped, err)
+	}
+	realmScoped := fs.BlueprintPath(runPath, "default", "", "", "web")
+	if _, err := os.Stat(realmScoped); !os.IsNotExist(err) {
+		t.Errorf("blueprint leaked into realm scope at %s (err=%v)", realmScoped, err)
+	}
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -117,6 +117,20 @@ type Runner interface {
 	// the file is absent.
 	DeleteSecret(secret intmodel.Secret) error
 
+	// WriteBlueprint persists a `kind: CellBlueprint`'s serialized document to
+	// the daemon-managed, root-owned, world-readable file under the scope's
+	// metadata tree (issue #620). Returns whether the file was newly created
+	// (vs. overwritten). The caller (ReconcileBlueprint) is responsible for
+	// having verified the scope exists.
+	WriteBlueprint(blueprint intmodel.CellBlueprint) (created bool, err error)
+
+	// GetBlueprint reads a single named, scoped CellBlueprint's document off
+	// disk (issue #620). Unlike GetSecret the full document is returned — a
+	// blueprint carries only template references, no credential bytes — so
+	// `kuke run -b` can materialize it. Returns errdefs.ErrBlueprintNotFound
+	// when the file is absent.
+	GetBlueprint(blueprint intmodel.CellBlueprint) (intmodel.CellBlueprint, error)
+
 	ExistsCgroup(doc any) (bool, error)
 
 	PurgeRealm(realm intmodel.Realm) (namespaceRemoved bool, err error)

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -157,6 +157,13 @@ func (s *KukeonV1Service) GetSecret(args *kukeonv1.GetSecretArgs, reply *kukeonv
 	return nil
 }
 
+func (s *KukeonV1Service) GetBlueprint(args *kukeonv1.GetBlueprintArgs, reply *kukeonv1.GetBlueprintReply) error {
+	result, err := s.core.GetBlueprint(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
 // ---- List ----
 
 func (s *KukeonV1Service) ListRealms(_ *kukeonv1.ListRealmsArgs, reply *kukeonv1.ListRealmsReply) error {

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -336,6 +336,43 @@ var (
 	ErrRepoTargetNotAbsolute = errors.New("repo target must be an absolute container path")
 	ErrRepoURLRequired       = errors.New("repo url is required")
 
+	// CellBlueprint kind (kind: CellBlueprint) storage-primitive errors
+	// (issue #620, phase 4a-i of #423).
+
+	ErrBlueprintNameRequired  = errors.New("blueprint metadata.name is required")
+	ErrBlueprintRealmRequired = errors.New("blueprint metadata.realm is required")
+	// ErrBlueprintScopeIncomplete fires when a deeper scope coordinate is set
+	// without every shallower one. A Blueprint is scopable at realm/space/stack
+	// only, so a set cell coordinate is itself a violation.
+	ErrBlueprintScopeIncomplete = errors.New(
+		"blueprint scope is incomplete: a deeper scope coordinate requires all shallower ones (and a Blueprint may not be cell-scoped)",
+	)
+	ErrBlueprintScopeNotFound = errors.New("blueprint scope does not exist")
+	ErrBlueprintCellRequired  = errors.New("blueprint spec.cell.containers is required and cannot be empty")
+	ErrWriteBlueprint         = errors.New("failed to write blueprint document")
+	ErrBlueprintNotFound      = errors.New("blueprint not found")
+	ErrGetBlueprint           = errors.New("failed to get blueprint")
+	// ErrBlueprintStructuralSlots fires when `kuke run -b` is asked to run a
+	// blueprint that declares structural slots (secret slots, or repo slots
+	// with no url) the inline scalar-param path cannot fill. Such blueprints
+	// require a CellConfig and `kuke run -c` (#625).
+	ErrBlueprintStructuralSlots = errors.New(
+		"blueprint declares structural slots that require a CellConfig: inline `kuke run -b` fills scalar parameters only",
+	)
+	// ErrBlueprintInvalid is returned when `kuke run -b` cannot resolve a
+	// blueprint's scalar parameters (an undeclared --param key, or a required
+	// parameter left unset). The analog of ErrProfileInvalid for the -b path.
+	ErrBlueprintInvalid = errors.New("blueprint is invalid")
+
+	// CellBlueprint slot-declaration shape errors (issue #620).
+
+	ErrBlueprintSecretSlotNameRequired = errors.New("blueprint secret slot name is required")
+	ErrBlueprintSecretSlotMode         = errors.New("blueprint secret slot mode must be \"env\" or \"file\"")
+	ErrBlueprintSecretSlotEnvName      = errors.New("blueprint secret slot with mode \"env\" requires envName")
+	ErrBlueprintSecretSlotMountPath    = errors.New(
+		"blueprint secret slot with mode \"file\" requires an absolute mountPath",
+	)
+
 	// ErrMustRunAsRoot is returned by direct-write subcommands (kuke init,
 	// kuke daemon reset, kuke image load, kuke doctor cgroups --probe)
 	// when invoked with a non-zero effective UID. Wrapped errors must

--- a/internal/modelhub/cellblueprint.go
+++ b/internal/modelhub/cellblueprint.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelhub
+
+// CellBlueprint is the internal carrier for a daemon-stored cell template
+// (kind: CellBlueprint, issue #620). Unlike the hierarchy kinds it has no
+// Status: a Blueprint has no runtime, and the daemon never interprets its
+// body. The body travels as an opaque serialized Document — the direct analog
+// of how Secret carries opaque Spec.Data — because the only daemon-side
+// operations are "write this document under the scope" and "read it back";
+// materialization (scalar substitution + slot mapping) happens client-side in
+// `kuke run -b`. Carrying a fully-typed mirror of the cell template here would
+// duplicate the entire ContainerSpec conversion for no daemon-side benefit.
+//
+// Metadata's scope coordinates are extracted from the document so the storage
+// runner can resolve the on-disk path without parsing the body; Document holds
+// the canonical serialized CellBlueprintDoc that GetBlueprint round-trips back
+// out for materialization.
+type CellBlueprint struct {
+	Metadata CellBlueprintMetadata
+	Document []byte
+}
+
+// CellBlueprintMetadata identifies a Blueprint by name and the scope it binds
+// to. A Blueprint is scopable at realm, space, or stack only — never cell. The
+// scope is the deepest non-empty coordinate; a deeper coordinate requires
+// every shallower one. See external v1beta1.CellBlueprintMetadata for the full
+// contract.
+type CellBlueprintMetadata struct {
+	Name  string
+	Realm string
+	Space string
+	Stack string
+}

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -275,6 +275,42 @@ func SecretPath(baseRunPath, realmName, spaceName, stackName, cellName, secretNa
 	)
 }
 
+// BlueprintScopeDir returns the metadata directory of the scope a
+// `kind: CellBlueprint` is bound to (issue #620). Unlike a Secret, a Blueprint
+// is scopable at realm/space/stack only — never cell — so the deepest
+// coordinate this resolves is the stack dir. The caller is responsible for
+// having validated coordinate completeness.
+func BlueprintScopeDir(baseRunPath, realmName, spaceName, stackName string) string {
+	switch {
+	case stackName != "":
+		return StackMetadataDir(baseRunPath, realmName, spaceName, stackName)
+	case spaceName != "":
+		return SpaceMetadataDir(baseRunPath, realmName, spaceName)
+	default:
+		return RealmMetadataDir(baseRunPath, realmName)
+	}
+}
+
+// BlueprintsDir returns the per-scope blueprints directory — the root-owned,
+// world-readable (0o755) directory under the scope's metadata tree that owns
+// daemon-managed blueprint documents (issue #620). Nested inside the scope dir
+// so scope teardown reclaims it.
+func BlueprintsDir(baseRunPath, realmName, spaceName, stackName string) string {
+	return filepath.Join(
+		BlueprintScopeDir(baseRunPath, realmName, spaceName, stackName),
+		consts.KukeonBlueprintsSubdir,
+	)
+}
+
+// BlueprintPath returns the host-side path of a single daemon-managed
+// blueprint document: <scope>/blueprints/<name>, root-owned and 0o644.
+func BlueprintPath(baseRunPath, realmName, spaceName, stackName, blueprintName string) string {
+	return filepath.Join(
+		BlueprintsDir(baseRunPath, realmName, spaceName, stackName),
+		blueprintName,
+	)
+}
+
 type metadataHeader struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -47,6 +47,12 @@ type Client interface {
 	// `kind: Secret` (issue #622). Spec.data is never echoed — the bytes do
 	// not traverse this RPC by design (#619).
 	GetSecret(ctx context.Context, doc v1beta1.SecretDoc) (GetSecretResult, error)
+	// GetBlueprint reads one named, scoped `kind: CellBlueprint`'s full
+	// document from daemon storage (issue #620). Unlike GetSecret the whole
+	// document is returned — a blueprint carries only template references —
+	// so `kuke run -b` can materialize it. The input doc carries the name and
+	// scope coordinates only; the spec is ignored.
+	GetBlueprint(ctx context.Context, doc v1beta1.CellBlueprintDoc) (GetBlueprintResult, error)
 
 	ListRealms(ctx context.Context) ([]v1beta1.RealmDoc, error)
 	ListSpaces(ctx context.Context, realmName string) ([]v1beta1.SpaceDoc, error)
@@ -170,6 +176,7 @@ const (
 	MethodGetCell      = ServiceName + ".GetCell"
 	MethodGetContainer = ServiceName + ".GetContainer"
 	MethodGetSecret    = ServiceName + ".GetSecret"
+	MethodGetBlueprint = ServiceName + ".GetBlueprint"
 
 	MethodListRealms     = ServiceName + ".ListRealms"
 	MethodListSpaces     = ServiceName + ".ListSpaces"

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -81,6 +81,10 @@ func (FakeClient) GetSecret(context.Context, v1beta1.SecretDoc) (GetSecretResult
 	return GetSecretResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) GetBlueprint(context.Context, v1beta1.CellBlueprintDoc) (GetBlueprintResult, error) {
+	return GetBlueprintResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) ListRealms(context.Context) ([]v1beta1.RealmDoc, error) {
 	return nil, ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -276,6 +276,21 @@ func (c *UnixClient) GetSecret(ctx context.Context, doc v1beta1.SecretDoc) (GetS
 	return reply.Result, nil
 }
 
+// GetBlueprint implements Client.
+func (c *UnixClient) GetBlueprint(
+	ctx context.Context, doc v1beta1.CellBlueprintDoc,
+) (GetBlueprintResult, error) {
+	args := &GetBlueprintArgs{Doc: doc}
+	reply := &GetBlueprintReply{}
+	if err := c.call(ctx, MethodGetBlueprint, args, reply); err != nil {
+		return GetBlueprintResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // ListRealms implements Client.
 func (c *UnixClient) ListRealms(ctx context.Context) ([]v1beta1.RealmDoc, error) {
 	args := &ListRealmsArgs{}

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -218,6 +218,24 @@ type GetSecretResult struct {
 	MetadataExists bool
 }
 
+type GetBlueprintArgs struct {
+	Doc v1beta1.CellBlueprintDoc
+}
+
+type GetBlueprintReply struct {
+	Result GetBlueprintResult
+	Err    *APIError
+}
+
+// GetBlueprintResult carries the full CellBlueprintDoc read from daemon
+// storage (issue #620). Unlike GetSecretResult the whole document is
+// populated — a blueprint carries only template references, no secret bytes —
+// so `kuke run -b` can materialize it.
+type GetBlueprintResult struct {
+	Blueprint      v1beta1.CellBlueprintDoc
+	MetadataExists bool
+}
+
 // ---- List ----
 
 type ListRealmsArgs struct{}

--- a/pkg/api/model/v1beta1/cellblueprint.go
+++ b/pkg/api/model/v1beta1/cellblueprint.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+// CellBlueprintDoc is a daemon-stored, scopable parametrized cell template
+// (kind: CellBlueprint, issue #620, phase 4a-i of #423). It is a *new* kind
+// introduced alongside the client-side CellProfile — not a rename. Where a
+// CellProfile is materialized client-side by `kuke run -p`, a CellBlueprint
+// is written to daemon storage by `kuke apply` and run with `kuke run -b`,
+// which lets blueprints be applied, scoped, and (in later phases) listed and
+// referenced by a CellConfig server-side.
+//
+// A Blueprint declares two fill channels (see #423 "L1↔L2 interface"):
+//
+//  1. Scalar parameters — today's `${KEY}` substitution, reusing the
+//     CellProfileParameter shape. Filled inline by `kuke run -b --param K=V`.
+//  2. Structural slots — named repo/secret slots on each container that a
+//     CellConfig fills with structured values (repo URLs, secret sources).
+//     This kind ships the slot *declarations* only; the Config-side fill
+//     machinery lands in #624.
+type CellBlueprintDoc struct {
+	APIVersion Version               `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind                  `json:"kind"       yaml:"kind"`
+	Metadata   CellBlueprintMetadata `json:"metadata"   yaml:"metadata"`
+	Spec       CellBlueprintSpec     `json:"spec"       yaml:"spec"`
+}
+
+// CellBlueprintMetadata identifies a Blueprint by name and the scope it is
+// bound to. Unlike a Secret, a Blueprint is scopable at realm, space, or
+// stack only — never cell: a template scoped to a single cell is nonsensical
+// (#423). The scope is the deepest non-empty coordinate; a deeper coordinate
+// requires every shallower one (a stack-scoped Blueprint must also name its
+// space and realm). Realm is always required.
+type CellBlueprintMetadata struct {
+	// Name is the blueprint's name, unique within its scope.
+	Name string `json:"name"             yaml:"name"`
+	// Realm is the always-required top-level scope coordinate.
+	Realm string `json:"realm"            yaml:"realm"`
+	// Space, when set, scopes the blueprint to a space within Realm.
+	Space string `json:"space,omitempty"  yaml:"space,omitempty"`
+	// Stack, when set, scopes the blueprint to a stack within Space.
+	Stack string `json:"stack,omitempty"  yaml:"stack,omitempty"`
+	// Labels are copied onto every cell materialized from this blueprint, in
+	// addition to the kukeon.io/blueprint back-reference label.
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// CellBlueprintSpec carries the scalar parameter declarations plus the cell
+// template body. Prefix overrides the cell-name prefix used when generating
+// the `<prefix>-<6hex>` name on each `kuke run -b`; when unset it defaults to
+// metadata.name. Every run produces a fresh hex-suffixed cell — the
+// "Blueprint = always fresh" invariant carried over from CellProfile.
+type CellBlueprintSpec struct {
+	Prefix     string                 `json:"prefix,omitempty"     yaml:"prefix,omitempty"`
+	Parameters []CellProfileParameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Cell       BlueprintCellSpec      `json:"cell"                 yaml:"cell"`
+}
+
+// BlueprintCellSpec is the cell template body of a CellBlueprint. It mirrors
+// the runtime CellSpec's user-authorable surface but is a deliberately
+// decoupled type: its containers carry structural slot declarations
+// (BlueprintContainer.Secrets) whose shape differs from the runtime
+// ContainerSpec, and it omits the daemon-stamped identity fields (id, realmId,
+// spaceId, stackId) that materialization fills from the blueprint's metadata
+// and the generated cell name. Materialization (internal/cellblueprint) maps
+// it to a CellSpec.
+type BlueprintCellSpec struct {
+	Tty                 *CellTty             `json:"tty,omitempty"                 yaml:"tty,omitempty"`
+	Containers          []BlueprintContainer `json:"containers"                    yaml:"containers"`
+	AutoDelete          bool                 `json:"autoDelete,omitempty"          yaml:"autoDelete,omitempty"`
+	NestedCgroupRuntime bool                 `json:"nestedCgroupRuntime,omitempty" yaml:"nestedCgroupRuntime,omitempty"`
+}
+
+// BlueprintContainer is one container in a blueprint's cell template. It
+// carries the user-authorable subset of ContainerSpec verbatim (so a blueprint
+// can express the same workload a hand-written Cell can), plus two structural
+// slot channels:
+//
+//   - Repos reuses the runtime ContainerRepo shape, but unlike `kuke apply`'s
+//     Cell/Container path the url is *not* required at apply time: a repo with
+//     no url is a structural slot a CellConfig fills (#624). A repo whose url
+//     is supplied inline (directly or via a `${PARAM}`) runs as-is under
+//     `kuke run -b`.
+//   - Secrets is a slot-only channel (BlueprintSecretSlot): the blueprint
+//     declares the consumption side (env vs file, the env var / mount path);
+//     the source side (which kind: Secret provides the bytes) is filled by a
+//     CellConfig (#624). Because the source is never part of a blueprint, a
+//     blueprint that declares secret slots cannot be run inline with `-b` —
+//     it requires `kuke run -c` (#625).
+//
+// Daemon-stamped / runtime-resolved fields (containerdId, realmId, spaceId,
+// stackId, cellId, kukeonGroupGID) are intentionally absent: materialization
+// and the runner fill them.
+type BlueprintContainer struct {
+	ID                     string                 `json:"id"                               yaml:"id"`
+	Root                   bool                   `json:"root,omitempty"                   yaml:"root,omitempty"`
+	Image                  string                 `json:"image"                            yaml:"image"`
+	Command                string                 `json:"command,omitempty"                yaml:"command,omitempty"`
+	Args                   []string               `json:"args,omitempty"                   yaml:"args,omitempty"`
+	WorkingDir             string                 `json:"workingDir,omitempty"             yaml:"workingDir,omitempty"`
+	Env                    []string               `json:"env,omitempty"                    yaml:"env,omitempty"`
+	Ports                  []string               `json:"ports,omitempty"                  yaml:"ports,omitempty"`
+	Volumes                []VolumeMount          `json:"volumes,omitempty"                yaml:"volumes,omitempty"`
+	Networks               []string               `json:"networks,omitempty"               yaml:"networks,omitempty"`
+	NetworksAliases        []string               `json:"networksAliases,omitempty"        yaml:"networksAliases,omitempty"`
+	Privileged             bool                   `json:"privileged,omitempty"             yaml:"privileged,omitempty"`
+	HostNetwork            bool                   `json:"hostNetwork,omitempty"            yaml:"hostNetwork,omitempty"`
+	HostPID                bool                   `json:"hostPID,omitempty"                yaml:"hostPID,omitempty"`
+	HostCgroup             bool                   `json:"hostCgroup,omitempty"             yaml:"hostCgroup,omitempty"`
+	User                   string                 `json:"user,omitempty"                   yaml:"user,omitempty"`
+	ReadOnlyRootFilesystem bool                   `json:"readOnlyRootFilesystem,omitempty" yaml:"readOnlyRootFilesystem,omitempty"`
+	Capabilities           *ContainerCapabilities `json:"capabilities,omitempty"           yaml:"capabilities,omitempty"`
+	SecurityOpts           []string               `json:"securityOpts,omitempty"           yaml:"securityOpts,omitempty"`
+	Tmpfs                  []ContainerTmpfsMount  `json:"tmpfs,omitempty"                  yaml:"tmpfs,omitempty"`
+	Resources              *ContainerResources    `json:"resources,omitempty"              yaml:"resources,omitempty"`
+	Repos                  []ContainerRepo        `json:"repos,omitempty"                  yaml:"repos,omitempty"`
+	Git                    *ContainerGit          `json:"git,omitempty"                    yaml:"git,omitempty"`
+	RestartPolicy          string                 `json:"restartPolicy,omitempty"          yaml:"restartPolicy,omitempty"`
+	Attachable             bool                   `json:"attachable,omitempty"             yaml:"attachable,omitempty"`
+	Tty                    *ContainerTty          `json:"tty,omitempty"                    yaml:"tty,omitempty"`
+	Secrets                []BlueprintSecretSlot  `json:"secrets,omitempty"                yaml:"secrets,omitempty"`
+}
+
+// BlueprintSecretSlot is a structural secret slot declared on a blueprint
+// container. It is the consumption side of the two-channel interface (#423):
+// the blueprint owns where the secret lands inside the container (env var or
+// file mount), and a CellConfig owns the source side (which kind: Secret
+// provides the bytes, #624). Name is the slot identity a CellConfig matches
+// against; it is independent of the env var name so a Config can fill the same
+// slot regardless of how the container consumes it.
+type BlueprintSecretSlot struct {
+	// Name is the slot's identity, unique within the container. A CellConfig
+	// fills the slot by this name (#624). Required.
+	Name string `json:"name"                yaml:"name"`
+	// Mode selects how the resolved secret is injected: "env" (default) sets
+	// an environment variable named EnvName; "file" stages a read-only file
+	// mount at MountPath.
+	Mode string `json:"mode,omitempty"      yaml:"mode,omitempty"`
+	// EnvName is the environment variable name for Mode "env". Required when
+	// Mode is "env".
+	EnvName string `json:"envName,omitempty"   yaml:"envName,omitempty"`
+	// MountPath is the absolute in-container path for Mode "file". Required
+	// when Mode is "file".
+	MountPath string `json:"mountPath,omitempty" yaml:"mountPath,omitempty"`
+	// Required gates whether a CellConfig must fill this slot.
+	Required bool `json:"required,omitempty"  yaml:"required,omitempty"`
+}
+
+// Secret-slot modes.
+const (
+	// BlueprintSecretModeEnv injects the resolved secret as an environment
+	// variable named EnvName. The default when Mode is empty.
+	BlueprintSecretModeEnv = "env"
+	// BlueprintSecretModeFile stages the resolved secret as a read-only file
+	// mount at MountPath.
+	BlueprintSecretModeFile = "file"
+)

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -42,6 +42,14 @@ const (
 	// `kuke run -p`. Profiles are not server-side resources — `kuke apply`
 	// rejects them.
 	KindCellProfile Kind = "CellProfile"
+	// KindCellBlueprint identifies daemon-stored, scopable parametrized cell
+	// templates (issue #620, phase 4a-i of #423). A *new* kind introduced
+	// alongside CellProfile — not a rename. `kuke apply` writes the blueprint
+	// to a root-owned, world-readable file under the scope's metadata tree;
+	// `kuke run -b` resolves it from daemon storage and materializes a fresh
+	// `<prefix>-<6hex>` cell. The get/delete verbs (#643), CellConfig (#624),
+	// and `kuke run -c` (#625) build on this foundation.
+	KindCellBlueprint Kind = "CellBlueprint"
 	// KindServerConfiguration identifies the kukeond daemon's configuration
 	// document loaded via `kukeond --configuration` (and consumed by
 	// `kuke init --server-configuration`). Not a server-side resource —


### PR DESCRIPTION
## Summary

Phase 4a-i of the L1↔L2 templating epic (#423). Introduces a **new** `kind: CellBlueprint` — a daemon-stored, scopable, parametrized cell template — alongside the existing client-side `CellProfile` (this is an addition, not a rename). A blueprint is written to daemon storage with `kuke apply` and instantiated with `kuke run -b`.

- **Schema** (`pkg/api/model/v1beta1/cellblueprint.go`): `CellBlueprintDoc` registered as `KindCellBlueprint` in consts. Scopable at realm/space/stack only (never cell — a template scoped to one cell is nonsensical); realm always required. Declares two fill channels: scalar `${KEY}` parameters (reusing `CellProfileParameter`) and **structural slot declarations** — `containers[].repos[]` (the existing `ContainerRepo` shape, but url is *not* required: a urless repo is a slot a CellConfig fills) and `containers[].secrets[]` (`BlueprintSecretSlot`: the consumption side — env/file mode — only). Slot declarations only; the Config-side fill machinery lands in #624.
- **Daemon storage** (`internal/controller/runner/blueprint.go`): persists to `<run-path>/<scope>/blueprints/<name>`, root-owned and **world-readable** (0o755 dir / 0o644 file) — contrasted with the root-only 0o700/0o600 secrets path, since a blueprint carries only template references, no credential bytes. Reuses the #619/#660 atomic temp-file+rename primitive.
- **`kuke apply -f blueprint.yaml`** writes to daemon storage over RPC (`ReconcileBlueprint`, with the same scope-reachability gate as `ReconcileSecret`).
- **`kuke run -b <blueprint> --param K=V`** resolves the blueprint from daemon storage via a new `GetBlueprint` RPC, substitutes scalar parameters, and materializes a fresh `<prefix>-<6hex>` cell carrying a `kukeon.io/blueprint=<name>` back-reference label. `-b` joins the `-f`/`-p` mutual-exclusivity + one-required flag group.
- **`kuke run -p`** now emits a one-line deprecation notice pointing at `-b`/`-c`; CellProfile/`loadFromProfile` behavior otherwise unchanged.

### Design decisions (please push back)

- **Opaque `Document` carrier in the internal model.** `intmodel.CellBlueprint` carries the serialized doc as opaque bytes (analog of `Secret.Data`) plus lifted scope metadata, rather than mirroring the full external struct internally. The daemon stores and round-trips the body without interpreting it; `kuke run -b` re-decodes it client-side. This keeps the internal-model surface minimal.
- **Dedicated `BlueprintContainer` type rather than embedding `ContainerSpec`.** yaml.v3 panics on an inline-embedded struct whose key is shadowed by a sibling field (`repos`), and the blueprint slot shapes (urless repos, source-less secret slots) genuinely differ from the runtime `ContainerSpec`. `materializeContainer` maps `BlueprintContainer` → `ContainerSpec`, dropping unfilled optional slots and refusing unfilled *required* ones (`ErrBlueprintStructuralSlots`).
- **`run -b` is scalar-only.** Inline `-b` fills `${PARAM}` scalars but cannot fill structural slots (a secret slot never carries its source; that's a CellConfig's job). A blueprint with a required slot is refused with a pointer to `kuke run -c` (#625).
- **`GetBlueprint` primitive.** `run -b` needs server-side resolution because apply goes over RPC and the daemon owns `/opt/kukeon`. #643 builds the get/delete *verbs* on this same primitive.
- **Lookup scope reads explicit flags/env, not viper.** `DefineKV` registers a viper default of `"default"` for `KUKE_RUN_SPACE`/`STACK`, so reading the lookup scope through viper would narrow *every* lookup to `default/default` and hide realm-scoped blueprints. `explicitScope` reads the raw changed-flag / env var instead; realm always defaults to `"default"` (a blueprint is always at least realm-scoped). This was caught by the live smoke below.

### Out of scope (confirmed against the issue)

`kuke get`/`delete blueprints` (#643), `kind: CellConfig` (#624), `run -c` (#625), and `-p`/CellProfile removal (#626).

## Test plan

- [x] `make test` (full CI target; e2e excluded as in CI) — pass, no failures
- [x] `go build ./...`, `go vet ./...` — clean
- [x] New unit tests: schema/parser validation, apischeme round-trip, runner storage (world-readable mode + full-document read-back), `Resolve`/`Materialize` (param resolution, structural-slot drop/block, fresh-name), controller `Reconcile`/`GetBlueprint`, and `kuke run -b` command flow (resolve+create, not-found, --name override, -p deprecation notice)
- [x] `pre-commit run --files <changed>` — all fixer hooks pass (golangci-lint hook panics on this host: a go1.24 binary cannot analyze the go1.25 modules through `go.work`; environmental, not a finding — `go vet`/`go fmt` are clean)
- [x] **`make dev-init` smoke** (change touches the daemon + `/opt/kukeon`): daemon-parity regression guard reads identically for `kuke get realms` and `--no-daemon`
- [x] **Live end-to-end** against the dev daemon: `kuke apply -f` lands the blueprint at `/opt/kukeon/data/default/blueprints/smoke-web` (root:root, 0644); `kuke run -b smoke-web --param TAG=latest --realm default` materializes `web-0799d4` with the `kukeon.io/blueprint=smoke-web` label and the `${TAG}` substituted image; artifacts cleaned up afterward

Closes #620