### PR TITLE
fix: run an eager reconcile pass on daemon startup

### DIFF
--- a/internal/daemon/reconcile_test.go
+++ b/internal/daemon/reconcile_test.go
@@ -45,6 +45,27 @@ func TestServer_ReconcileLoopFires(t *testing.T) {
 	waitForCalls(t, &calls, 2, 2*time.Second)
 }
 
+// TestServer_ReconcileRunsEagerlyOnStartup confirms the daemon runs one
+// reconcile pass immediately on startup, before the first ticker interval
+// elapses (#671). A large interval is used so the only way a call can land
+// inside the short deadline is the eager startup pass — not the ticker. The
+// headline case is a host restart that dropped containerd's tasks/records:
+// the eager pass converges the stale on-disk Status (and triggers AutoDelete
+// cleanup of now-phantom cells) at once instead of after a full interval.
+func TestServer_ReconcileRunsEagerlyOnStartup(t *testing.T) {
+	srv := newTestServer(t, 10*time.Second)
+	var calls atomic.Int32
+	srv.reconcileFn = func() (controller.ReconcileResult, error) {
+		calls.Add(1)
+		return controller.ReconcileResult{CellsScanned: 1}, nil
+	}
+
+	startServer(t, srv)
+	// Far shorter than the 10s interval: a call here can only come from the
+	// eager startup pass.
+	waitForCalls(t, &calls, 1, 1*time.Second)
+}
+
 // TestServer_ReconcileLoopAcceptsCellsDeletedResult is the daemon-side
 // half of #266: a reconcile pass that reports CellsDeleted (the AutoDelete
 // migration's new counter) flows through runReconcileOnce without

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -169,6 +169,28 @@ func (s *Server) startReconcileLoop() {
 
 func (s *Server) runReconcileLoop(interval time.Duration) {
 	defer s.loopWG.Done()
+
+	// Run one pass immediately, before the first ticker tick, so a freshly
+	// started daemon converges every cell's persisted Status to live
+	// containerd reality at once instead of serving the pre-restart snapshot
+	// for up to a full interval. The headline case is a host restart that
+	// dropped containerd's tasks/records (#671): the on-disk metadata still
+	// reads Ready and lists containers that no longer exist, so without this
+	// eager pass `kuke get cell` shows stale state and AutoDelete cleanup of
+	// now-phantom cells is delayed until the first tick. Gated on the same
+	// shutdown signals as the loop so a daemon cancelled before the loop
+	// starts does not run a pass.
+	select {
+	case <-s.ctx.Done():
+		s.logger.InfoContext(s.ctx, "reconcile loop stopped")
+		return
+	case <-s.stopCh:
+		s.logger.InfoContext(s.ctx, "reconcile loop stopped")
+		return
+	default:
+		s.runReconcileOnce()
+	}
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {


### PR DESCRIPTION
## Summary

- **Root cause (AC #1).** The issue's guessed mechanism — "the payload exits and the containerd container is reaped" — is not what happens: there is no task-exit reaper in the codebase (no `/tasks/exit` subscription, no background reap). containerd container records are removed only by the explicit teardown verbs: `StopCell`/`KillCell` (`internal/controller/runner/stop.go`, `kill.go`) both `DeleteContainer{SnapshotCleanup:true}` for root + workloads and then **persist the cell as `Stopped`** (`kill.go:294-297`, `stop.go:317-320`) without deleting `metadata.json`; the reconciler's wind-down (`refresh.go:739`) and auto-delete (`refresh.go:761`) drive those same paths. So "records gone, metadata persists" is the established, intentional contract — only `DeleteCell` removes metadata. Records can *also* vanish wholesale on a host restart that drops containerd's tasks/records (the author's "consider the case when the host restarts" note), which is the same observable end-state.
- #670 already made reporting honest: `GetContainerState` (`internal/controller/runner/container_state.go:154-166`) maps an absent record to `ContainerStateNotCreated`, and `kuke get co` live-probes per-container, so it shows `NotCreated` rather than a phantom `Stopped`. The residual gap is at the **cell** level: `GetCell` (`internal/controller/get_cell.go:99`) returns the *persisted* `Status` (state + container list), and the reconcile loop (`internal/daemon/server.go:runReconcileLoop`) used `time.NewTicker` whose first tick lands only after a **full `ReconcileInterval`**. After a restart the daemon therefore served the stale pre-restart snapshot (`Ready`, with containers that no longer exist) — and delayed AutoDelete cleanup of now-phantom cells — for up to one interval.
- **Fix.** Run one reconcile pass immediately at the top of `runReconcileLoop`, gated on the same `ctx`/`stopCh` shutdown signals, before entering the ticker loop. A freshly started / post-restart daemon now converges every cell's persisted `Status` to live containerd reality at once (and triggers AutoDelete cleanup of phantom cells) instead of waiting a full interval. Reuses the existing `runReconcileOnce` (panic-recovery + logging). It lives inside `runReconcileLoop`, which only starts when `ReconcileInterval > 0`, so the `--reconcile-interval 0` opt-out still runs zero passes.

## Test plan

- [x] `make test` (full module + `cmd/kukebuild`) — pass, 0 failures
- [x] `GOWORK=off go test ./internal/daemon/ -run TestServer_Reconcile -v` — all reconcile tests pass, incl. new `TestServer_ReconcileRunsEagerlyOnStartup` (call lands in 0.01s against a 10s interval → eager pass, not the ticker) and existing `TestServer_ReconcileLoopDisabledWhenIntervalZero` (eager pass correctly suppressed when loop disabled)
- [x] `GOWORK=off go build ./...` / `go vet ./internal/daemon/` — clean
- [x] `make dev-init` smoke — daemon-parity regression guard passes (identical `kuke get realms` and `--no-daemon`, both realms `Ready`); attach + nested smokes pass; daemon starts cleanly with the eager pass

## Notes

- AC #2 (`kuke get co` and `ctr c ls` agree on whether the container exists) was already satisfied for the per-container view by #670's live-probed `NotCreated`; this PR closes the cell-level/persisted-state lag that the host-restart consideration exposed.
- Lower-blast-radius call: the eager pass runs in the existing reconcile goroutine (concurrent with `acceptLoop`), shrinking the divergence window from a full interval to milliseconds without blocking socket-accept on a full reconcile. Documented here so the reviewer can push back if a converge-before-serve guarantee is wanted instead.

Closes #671