### PR TITLE
test: prevent e2e parallel namespace collisions via process-wide name entropy

### DIFF
--- a/e2e/e2e_kuke_realm_test.go
+++ b/e2e/e2e_kuke_realm_test.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -33,9 +32,7 @@ import (
 // generateUniqueRealmName generates a unique realm name for tests.
 func generateUniqueRealmName(t *testing.T) string {
 	t.Helper()
-	timestamp := time.Now().UnixNano()
-	hexID := fmt.Sprintf("%02x", timestamp&0xFF)
-	return fmt.Sprintf("e-r-%s", hexID)
+	return fmt.Sprintf("e-r-%s", uniqueNameID())
 }
 
 // verifyRealmMetadataExists verifies realm metadata file exists.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -18,13 +18,17 @@ package e2e_test
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -37,6 +41,31 @@ const (
 	kuke = "kuke"
 	ctr  = "ctr"
 )
+
+var (
+	// nameSeed is a per-process random base for unique test-resource names. Seeding
+	// from crypto/rand ensures a realm/namespace left behind by a crashed prior run
+	// cannot collide with a fresh run's first-allocated name (e.g. e-r-1).
+	nameSeed = func() uint64 {
+		var b [2]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			return uint64(time.Now().UnixNano() & 0xFFFF)
+		}
+		return uint64(binary.BigEndian.Uint16(b[:]))
+	}()
+	// nameCounter is a process-wide monotonic counter shared by every generator, so
+	// no two names allocated within a single `go test` run can collide regardless of
+	// how closely in time they are requested.
+	nameCounter atomic.Uint64
+)
+
+// uniqueNameID returns a short, collision-free identifier for test-resource names.
+// The seed+counter sum is rendered in base36 (lowercase 0-9a-z) to stay a valid
+// containerd namespace label while keeping names within the namespace-label and
+// /opt/kukeon/data metadata-path length limits the harness already fights.
+func uniqueNameID() string {
+	return strconv.FormatUint(nameSeed+nameCounter.Add(1), 36)
+}
 
 // runReturningBinary runs the provided binary with args, fails the test on non-zero exit or empty output.
 // If the binary file does not exist, the test is skipped.
@@ -356,9 +385,7 @@ func verifyCgroupPathExists(t *testing.T, cgroupPath string) bool {
 // generateUniqueSpaceName generates a unique space name for tests.
 func generateUniqueSpaceName(t *testing.T) string {
 	t.Helper()
-	timestamp := time.Now().UnixNano()
-	hexID := fmt.Sprintf("%02x", timestamp&0xFF)
-	return fmt.Sprintf("e-sp-%s", hexID)
+	return fmt.Sprintf("e-sp-%s", uniqueNameID())
 }
 
 // verifySpaceCNIConfigExists verifies CNI config file exists.
@@ -453,9 +480,7 @@ func verifySpaceExists(t *testing.T, host, realmName, spaceName string) bool {
 // generateUniqueStackName generates a unique stack name for tests.
 func generateUniqueStackName(t *testing.T) string {
 	t.Helper()
-	timestamp := time.Now().UnixNano()
-	hexID := fmt.Sprintf("%02x", timestamp&0xFF)
-	return fmt.Sprintf("e-st-%s", hexID)
+	return fmt.Sprintf("e-st-%s", uniqueNameID())
 }
 
 // verifyStackMetadataExists verifies stack metadata file exists.
@@ -557,17 +582,13 @@ func verifyStackExists(t *testing.T, host, realmName, spaceName, stackName strin
 // generateUniqueCellName generates a unique cell name for tests.
 func generateUniqueCellName(t *testing.T) string {
 	t.Helper()
-	timestamp := time.Now().UnixNano()
-	hexID := fmt.Sprintf("%02x", timestamp&0xFF)
-	return fmt.Sprintf("e-ce-%s", hexID)
+	return fmt.Sprintf("e-ce-%s", uniqueNameID())
 }
 
 // generateUniqueContainerName generates a unique container name for tests.
 func generateUniqueContainerName(t *testing.T) string {
 	t.Helper()
-	timestamp := time.Now().UnixNano()
-	hexID := fmt.Sprintf("%02x", timestamp&0xFF)
-	return fmt.Sprintf("e-co-%s", hexID)
+	return fmt.Sprintf("e-co-%s", uniqueNameID())
 }
 
 // verifyCellMetadataExists verifies cell metadata file exists.


### PR DESCRIPTION
## Summary
- The five e2e unique-name generators truncated `time.Now().UnixNano()` to its low byte (`& 0xFF`), giving only 256 possible values per kind. Under `t.Parallel()` on a shared host containerd, two tests routinely collided on the same `e-r-XX` realm name → same containerd namespace → one test's cleanup (`drainLeases` + `SynchronousDelete`) deleted a sibling's in-flight pull lease, surfacing as the spurious `lease does not exist: not found` flake.
- Replaced the per-kind truncation with a single process-wide monotonic `atomic.Uint64` counter shared by all five generators, so no two names allocated within one `go test` run can collide regardless of timing.
- Seeded the counter from a per-process `crypto/rand` 16-bit base (with a `UnixNano & 0xFFFF` fallback if the read fails) so a realm/namespace left behind by a crashed prior run won't collide with a fresh run's first-allocated name. Both the seed source and counter are documented inline.
- IDs are rendered in base36 (lowercase `0-9a-z`) to keep names valid containerd namespace labels and short — `e-r-<id>` is typically 3-4 id chars, only a couple longer than the old `e-r-XX`, staying within the namespace-label and `/opt/kukeon/data` metadata-path length budgets the harness already fights.

## Test plan
- [x] `make test` (test-root + test-kukebuild) — passes; the CI target excludes `/e2e`.
- [x] `go vet ./e2e/` and e2e test-binary compile (`go test -run xxxNONExxx ./e2e/`) — clean.
- [ ] Full e2e suite at default parallelism across repeated runs (AC bullet 4) — requires docker build + standalone containerd + daemon bring-up, not safely hostable here; deferred to CI/reviewer environment.

Closes #704