### PR TITLE
fix: resolve teardown CNI purge network name deterministically

### DIFF
--- a/internal/controller/runner/delete_cell.go
+++ b/internal/controller/runner/delete_cell.go
@@ -81,20 +81,10 @@ func (r *Exec) DeleteCell(cell intmodel.Cell) error {
 		cellID = internalCell.Metadata.Name
 	}
 
-	// Get space for network name
-	lookupSpace := intmodel.Space{
-		Metadata: intmodel.SpaceMetadata{
-			Name: cellSpaceName,
-		},
-		Spec: intmodel.SpaceSpec{
-			RealmName: internalCell.Spec.RealmName,
-		},
-	}
-	space, spaceErr := r.GetSpace(lookupSpace)
-	var networkName string
-	if spaceErr == nil {
-		networkName, _ = r.getSpaceNetworkName(space)
-	}
+	// Resolve the network name deterministically from realm+space so the
+	// post-delete CNI/IPAM purge below runs even when space metadata is gone or
+	// corrupt (issue #685). The name is a pure function of (realm, space).
+	networkName := r.buildRootCNINetworkName(internalCell.Spec.RealmName, cellSpaceName)
 
 	// Aggregate container-deletion failures rather than swallow them. Issue
 	// #371: a single warn-and-continue on a non-NotFound DeleteContainer

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -473,6 +473,23 @@ func (r *Exec) resolveRootCNINetworkName(realmName, spaceName string) string {
 	return networkName
 }
 
+// buildRootCNINetworkName derives the CNI network name for a cell's space
+// deterministically from the realm and space names, without consulting space
+// metadata. Teardown paths (stop/kill/delete) use this for the post-delete
+// IPAM-file purge safety net (purgeCNIForContainer) so the purge runs even when
+// space metadata is gone or corrupt — the network name is a pure function of
+// (realm, space) per naming.BuildSpaceNetworkName, so the GetSpace round-trip
+// resolveRootCNINetworkName performs on the re-ADD side is unnecessary here and
+// its failure must not silently skip the purge (issue #685). Returns "" only
+// when realm/space are empty, which the teardown callers already guard against.
+func (r *Exec) buildRootCNINetworkName(realmName, spaceName string) string {
+	networkName, err := naming.BuildSpaceNetworkName(realmName, spaceName)
+	if err != nil {
+		return ""
+	}
+	return networkName
+}
+
 // detachRootContainerFromNetwork detaches a root container from the CNI network.
 // It gets the container's PID and network namespace path, then calls CNI DEL to detach it.
 // This should be called before killing or stopping the container to ensure the namespace is still valid.

--- a/internal/controller/runner/helpers_test.go
+++ b/internal/controller/runner/helpers_test.go
@@ -108,3 +108,24 @@ func TestResolveRootCNINetworkName_EmptyWhenSpaceMissing(t *testing.T) {
 		t.Errorf("resolveRootCNINetworkName() = %q, want \"\" when space metadata is absent", got)
 	}
 }
+
+// TestBuildRootCNINetworkName_DeterministicWhenSpaceMissing is the regression
+// guard for issue #685. The stop/kill/delete teardown sites used to resolve the
+// purge-target network name via GetSpace+getSpaceNetworkName and swallow the
+// GetSpace error, so when space metadata was gone or corrupt networkName stayed
+// "" and the post-delete CNI/IPAM purge (purgeCNIForContainer) was gated out —
+// leaking the root container's IPAM reservation at /var/lib/cni/networks/<net>/<ip>.
+// buildRootCNINetworkName derives the name deterministically from (realm, space)
+// so the purge gate is satisfied even with no space metadata on disk. Contrast
+// TestResolveRootCNINetworkName_EmptyWhenSpaceMissing above: the re-ADD helper
+// deliberately still returns "" so attach is skipped for a vanished space.
+func TestBuildRootCNINetworkName_DeterministicWhenSpaceMissing(t *testing.T) {
+	r := newMetadataTestExec(t, t.TempDir(), time.Now())
+	// No space metadata is seeded under the tmpdir RunPath, so GetSpace would
+	// fail here — the exact condition that used to leave networkName empty.
+	got := r.buildRootCNINetworkName("default", "nonexistent-space")
+	want := "default-nonexistent-space"
+	if got != want {
+		t.Errorf("buildRootCNINetworkName() = %q, want %q when space metadata is absent", got, want)
+	}
+}

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -178,20 +178,10 @@ func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, err
 	}
 
-	// Get space to resolve network name for fallback cleanup
-	var networkName string
-	lookupSpace := intmodel.Space{
-		Metadata: intmodel.SpaceMetadata{
-			Name: spaceID,
-		},
-		Spec: intmodel.SpaceSpec{
-			RealmName: realmID,
-		},
-	}
-	internalSpace, spaceErr := r.GetSpace(lookupSpace)
-	if spaceErr == nil {
-		networkName, _ = r.getSpaceNetworkName(internalSpace)
-	}
+	// Resolve the network name deterministically from realm+space so the
+	// post-delete CNI/IPAM purge below runs even when space metadata is gone or
+	// corrupt (issue #685). The name is a pure function of (realm, space).
+	networkName := r.buildRootCNINetworkName(realmID, spaceID)
 
 	// Detach root container from CNI network before killing (needed for CNI detach)
 	r.detachRootContainerFromNetwork(

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -197,20 +197,10 @@ func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, err
 	}
 
-	// Get space to resolve network name for fallback cleanup
-	var networkName string
-	lookupSpace := intmodel.Space{
-		Metadata: intmodel.SpaceMetadata{
-			Name: spaceName,
-		},
-		Spec: intmodel.SpaceSpec{
-			RealmName: realmName,
-		},
-	}
-	internalSpace, spaceErr := r.GetSpace(lookupSpace)
-	if spaceErr == nil {
-		networkName, _ = r.getSpaceNetworkName(internalSpace)
-	}
+	// Resolve the network name deterministically from realm+space so the
+	// post-delete CNI/IPAM purge below runs even when space metadata is gone or
+	// corrupt (issue #685). The name is a pure function of (realm, space).
+	networkName := r.buildRootCNINetworkName(realmName, spaceName)
 
 	// Detach root container from CNI network before stopping (needed for CNI detach)
 	r.detachRootContainerFromNetwork(


### PR DESCRIPTION
## Summary
- On stop/kill/delete, the file-level CNI purge safety net (`purgeCNIForContainer`) was gated on a non-empty `networkName`, but `networkName` was resolved via `GetSpace` → `getSpaceNetworkName` with the `GetSpace` error swallowed. When space metadata was gone or corrupt while a cell root still held an IPAM reservation, `networkName` stayed empty and the purge was skipped — leaking `/var/lib/cni/networks/<net>/<ip>`.
- The network name is a pure function of `(realm, space)` (`naming.BuildSpaceNetworkName` → `"<realm>-<space>"`), so the `GetSpace` round-trip is unnecessary for teardown. Added `buildRootCNINetworkName(realm, space)` (helpers.go) that resolves the name deterministically, and switched the three teardown sites (`stop.go`, `kill.go`, `delete_cell.go`) to it.
- Left `resolveRootCNINetworkName` (the re-ADD helper used by `start.go`/`recreate_cell.go`) untouched: that path intentionally returns `""` for a vanished space so attach is skipped, and `TestResolveRootCNINetworkName_EmptyWhenSpaceMissing` pins that contract. The teardown semantics are the opposite (purge regardless), hence a separate helper rather than a behavior change to the shared one.

## Scope note for the reviewer
AC #2 asks for a "stop/kill/delete with space metadata removed leaves no stranded `/var/lib/cni/networks/<net>/<ip>` file" test. `cni.CNINetworksDir` is a hardcoded `const` (`/var/lib/cni/networks`) — a root-owned system path — so a unit test cannot safely create/assert IPAM files there without touching real host state. The regression is precisely at the resolution boundary (empty `networkName` gated the purge out), so the added test pins it there: with no space metadata on disk, `buildRootCNINetworkName` returns the deterministic name where `resolveRootCNINetworkName` returns `""`. End-to-end on-disk verification belongs in the integration/e2e tier where the real CNI dir exists.

## Test plan
- [x] `make test` (full CI target: test-root + test-kukebuild) — pass
- [x] `GOWORK=off go build ./...` — pass
- [x] `GOWORK=off go vet ./internal/controller/runner/` — pass
- [x] `go test ./internal/controller/runner/ -run CNINetworkName -v` — both resolution-boundary tests pass
- [x] `pre-commit run --files <changed>` (golangci-lint skipped — go1.24 hook binary panics analyzing the go1.25 module via go.work, a known environmental issue; `go vet` covers the same surface)

Closes #685