### PR TITLE
docs(runner): retarget stale resolveRootCNINetworkName docstring after #708

### DIFF
--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -452,11 +452,12 @@ func (r *Exec) getSpaceNetworkName(space intmodel.Space) (string, error) {
 }
 
 // resolveRootCNINetworkName resolves the CNI network name for a cell's space,
-// for use in the post-delete IPAM-file purge safety net (purgeCNIForContainer).
+// for use on the re-ADD/attach path (start.go, recreate_cell.go) that consults
+// space metadata before attaching the root container to its CNI network.
 // Best-effort: returns "" when the space can't be loaded or the name can't be
-// derived, mirroring the GetSpace+getSpaceNetworkName preamble that stop.go and
-// kill.go run before tearing the root container down. The empty result makes
-// purgeCNIForContainer a no-op rather than a panic.
+// derived, in which case the attach is intentionally skipped rather than run
+// against a wrong network. Teardown paths use buildRootCNINetworkName instead,
+// which derives the name deterministically without the GetSpace round-trip.
 func (r *Exec) resolveRootCNINetworkName(realmName, spaceName string) string {
 	lookupSpace := intmodel.Space{
 		Metadata: intmodel.SpaceMetadata{Name: spaceName},


### PR DESCRIPTION
## Summary
- After #708 split teardown CNI purge name resolution into `buildRootCNINetworkName`, the `resolveRootCNINetworkName` docstring still claimed it served the post-delete IPAM purge safety net and mirrored the stop.go/kill.go teardown preamble — misleading, since teardown now uses `buildRootCNINetworkName`.
- Verified the current callers: `resolveRootCNINetworkName` is used only by the re-ADD/attach path (`start.go:442,464`, `recreate_cell.go:122`); teardown (`stop.go:203`, `kill.go:184`, `delete_cell.go:87`) uses `buildRootCNINetworkName`.
- Retargeted the docstring to describe `resolveRootCNINetworkName` as the re-ADD/attach name resolver where the `""`-on-vanished-space contract intentionally skips attach.

## Test plan
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./internal/controller/runner/`
- [x] `GOWORK=off go test ./internal/controller/runner/`

Docstring-only change (no executable code, test, or behavior text touched) — routed via the trivial-edit shortcut.

Closes #710