### PR TITLE
feat: report create-stage outcomes over GetSetupStatus into ContainerStatus.Stages (phase B)

### DIFF
--- a/cmd/kuketty/main.go
+++ b/cmd/kuketty/main.go
@@ -151,18 +151,21 @@ func run(args []string) error {
 	// failed create stage returns here so kuketty exits non-zero before
 	// sbshserver.Serve and the daemon observes the task as Failed. runOn: start
 	// (and absent) stages are not run here — they were forwarded to sbsh's
-	// Stages.OnInit at buildTerminalSpec and run in-shell every boot. Reporting
-	// per-stage outcomes into ContainerStatus.Stages over the RPC is phase B
-	// (#689); this phase wires the executor only.
-	if err := processStages(ctx, createStages(doc.Spec.Tty), logger); err != nil {
+	// Stages.OnInit at buildTerminalSpec and run in-shell every boot. The
+	// per-stage outcomes feed the GetSetupStatus verb registered below (issue
+	// #689); on the failure path stageStatuses is discarded with the error and
+	// the verb is never reached.
+	stageStatuses, err := processStages(ctx, createStages(doc.Spec.Tty), logger)
+	if err != nil {
 		return err
 	}
 
 	// Register the GetSetupStatus verb on the same control socket the daemon
-	// dials for `kuke attach`, so kukeond can pull the repo outcomes post-Serve
-	// and write ContainerStatus.Repos (issue #642). ContainerStatus is the
-	// single source of truth — there is no status file in the container.
-	srv, err := sbshserver.New(spec, logger, setupStatusOption(repoStatuses)...)
+	// dials for `kuke attach`, so kukeond can pull the repo + create-stage
+	// outcomes post-Serve and write ContainerStatus.Repos / .Stages (issues
+	// #642, #689). ContainerStatus is the single source of truth — there is no
+	// status file in the container.
+	srv, err := sbshserver.New(spec, logger, setupStatusOption(repoStatuses, stageStatuses)...)
 	if err != nil {
 		return fmt.Errorf("server.New: %w", err)
 	}

--- a/cmd/kuketty/setupstatus.go
+++ b/cmd/kuketty/setupstatus.go
@@ -23,42 +23,45 @@ import (
 
 // setupStatusHandler is the receiver kuketty registers as a custom JSON-RPC
 // service on the sbsh control server (issue #642). It serves the per-repo
-// outcome of the pre-Serve clone/fetch step (issue #617) so kukeond can pull
-// it post-Serve and write ContainerStatus.Repos.
+// outcome of the pre-Serve clone/fetch step (issue #617) and the per-stage
+// outcome of the pre-Serve runOn: create execution (issue #689) so kukeond can
+// pull them post-Serve and write ContainerStatus.Repos / .Stages.
 //
 // The statuses are captured once, before Serve brings the control RPC live,
 // and never mutated afterward, so the read in GetSetupStatus needs no
-// synchronization — the slice is published happens-before the server goroutine
-// that serves the verb is started.
+// synchronization — the slices are published happens-before the server
+// goroutine that serves the verb is started.
 type setupStatusHandler struct {
-	repos []setupstatus.Repo
+	repos  []setupstatus.Repo
+	stages []setupstatus.Stage
 }
 
-// GetSetupStatus reports kuketty's pre-Serve repo outcomes. The wire method is
-// "<setupstatus.ServiceName>.GetSetupStatus" (see setupstatus.Method). The
-// net/rpc signature scheme requires (args, reply *T) error with exported
-// argument/reply types — satisfied by setupstatus.Args and setupstatus.Reply.
-// The error return is mandated by that signature even though this read-only
-// verb never fails; net/rpc would reject the method as an RPC handler without
-// it.
+// GetSetupStatus reports kuketty's pre-Serve repo + create-stage outcomes. The
+// wire method is "<setupstatus.ServiceName>.GetSetupStatus" (see
+// setupstatus.Method). The net/rpc signature scheme requires (args, reply *T)
+// error with exported argument/reply types — satisfied by setupstatus.Args and
+// setupstatus.Reply. The error return is mandated by that signature even though
+// this read-only verb never fails; net/rpc would reject the method as an RPC
+// handler without it.
 //
 //nolint:unparam // error return required by net/rpc's handler signature (see godoc above)
 func (h *setupStatusHandler) GetSetupStatus(_ setupstatus.Args, reply *setupstatus.Reply) error {
 	reply.Repos = h.repos
+	reply.Stages = h.stages
 	return nil
 }
 
 // setupStatusOption returns the sbsh server option that registers the
-// GetSetupStatus verb on the control socket, carrying the resolved repo
-// statuses. Returned as a slice so run() can splat it into server.New
-// uniformly whether or not there are repos to report — an empty repos[] still
-// registers the verb (kukeond gets an empty Reply rather than a dial error,
-// keeping the daemon-side pull a single code path).
-func setupStatusOption(repos []setupstatus.Repo) []sbshserver.Option {
+// GetSetupStatus verb on the control socket, carrying the resolved repo +
+// create-stage statuses. Returned as a slice so run() can splat it into
+// server.New uniformly whether or not there is anything to report — empty
+// repos[]/stages[] still register the verb (kukeond gets an empty Reply rather
+// than a dial error, keeping the daemon-side pull a single code path).
+func setupStatusOption(repos []setupstatus.Repo, stages []setupstatus.Stage) []sbshserver.Option {
 	return []sbshserver.Option{
 		sbshserver.WithHandlers(sbshserver.Handler{
 			Name:     setupstatus.ServiceName,
-			Receiver: &setupStatusHandler{repos: repos},
+			Receiver: &setupStatusHandler{repos: repos, stages: stages},
 		}),
 	}
 }

--- a/cmd/kuketty/setupstatus_test.go
+++ b/cmd/kuketty/setupstatus_test.go
@@ -22,12 +22,16 @@ import (
 	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
 )
 
-func TestSetupStatusHandler_ReturnsStoredRepos(t *testing.T) {
+func TestSetupStatusHandler_ReturnsStoredReposAndStages(t *testing.T) {
 	repos := []setupstatus.Repo{
 		{Name: "a", Target: "/work/a", State: setupstatus.StateCloned, Commit: "deadbeef"},
 		{Name: "b", Target: "/work/b", State: setupstatus.StateFailed, Error: "boom"},
 	}
-	h := &setupStatusHandler{repos: repos}
+	stages := []setupstatus.Stage{
+		{Index: 0, State: setupstatus.StageDone},
+		{Index: 2, State: setupstatus.StageFailed, Error: "stage 2: exit 1"},
+	}
+	h := &setupStatusHandler{repos: repos, stages: stages}
 
 	var reply setupstatus.Reply
 	if err := h.GetSetupStatus(setupstatus.Args{}, &reply); err != nil {
@@ -39,25 +43,34 @@ func TestSetupStatusHandler_ReturnsStoredRepos(t *testing.T) {
 	if reply.Repos[0] != repos[0] || reply.Repos[1] != repos[1] {
 		t.Errorf("reply.Repos = %+v, want %+v", reply.Repos, repos)
 	}
+	if len(reply.Stages) != 2 {
+		t.Fatalf("want 2 stages, got %d: %+v", len(reply.Stages), reply.Stages)
+	}
+	if reply.Stages[0] != stages[0] || reply.Stages[1] != stages[1] {
+		t.Errorf("reply.Stages = %+v, want %+v", reply.Stages, stages)
+	}
 }
 
-func TestSetupStatusHandler_EmptyReposIsEmptyReply(t *testing.T) {
-	h := &setupStatusHandler{repos: nil}
+func TestSetupStatusHandler_EmptyIsEmptyReply(t *testing.T) {
+	h := &setupStatusHandler{repos: nil, stages: nil}
 
 	var reply setupstatus.Reply
 	if err := h.GetSetupStatus(setupstatus.Args{}, &reply); err != nil {
 		t.Fatalf("GetSetupStatus: %v", err)
 	}
 	if len(reply.Repos) != 0 {
-		t.Errorf("want empty reply, got %+v", reply.Repos)
+		t.Errorf("want empty repos, got %+v", reply.Repos)
+	}
+	if len(reply.Stages) != 0 {
+		t.Errorf("want empty stages, got %+v", reply.Stages)
 	}
 }
 
 func TestSetupStatusOption_RegistersVerb(t *testing.T) {
 	// The option splat must always register exactly one handler under the
-	// agreed service name, even when there are no repos to report — kukeond's
+	// agreed service name, even when there is nothing to report — kukeond's
 	// pull is a single code path that expects the verb to exist.
-	opts := setupStatusOption(nil)
+	opts := setupStatusOption(nil, nil)
 	if len(opts) != 1 {
 		t.Fatalf("want exactly one server option, got %d", len(opts))
 	}

--- a/cmd/kuketty/stages.go
+++ b/cmd/kuketty/stages.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
@@ -44,22 +45,40 @@ var errRequiredStageFailed = errors.New("one or more required create stages fail
 // clones use), via `sh -c <script>`.
 //
 // An empty stage list is a no-op — the common case for a container with no
-// create stages. On the first failing stage processStages logs the outcome and
-// returns errRequiredStageFailed, so run() exits before Serve and the daemon
-// sees the task as Failed; subsequent stages do not run. Reporting per-stage
-// outcomes into ContainerStatus.Stages over the GetSetupStatus RPC is deferred
-// to phase B (#689); this phase wires the executor and routing only. Issue
-// #635.
-func processStages(ctx context.Context, stages []indexedStage, logger *slog.Logger) error {
+// create stages — and returns a nil status slice. processStages returns the
+// per-stage outcome in declaration order alongside the terminating error: each
+// completed stage is recorded StageDone, and on the first failing stage the
+// failed stage is recorded StageFailed (with the error detail), processStages
+// logs the outcome, and returns errRequiredStageFailed so run() exits before
+// Serve and the daemon sees the task as Failed; subsequent stages do not run.
+//
+// Because run() returns on a non-nil error before registering the
+// GetSetupStatus verb, the StageFailed entry is never served over RPC in
+// practice — a failed create stage is observed via the task-failed signal +
+// kuketty log, the same post-Serve-only path required repos take (AC #5 of
+// #617). The status slice is carried back regardless so the executor stays the
+// single source of per-stage truth and the failure path is unit-testable.
+// Issue #689 (phase B); the executor + routing landed in phase A (#635).
+func processStages(ctx context.Context, stages []indexedStage, logger *slog.Logger) ([]setupstatus.Stage, error) {
+	if len(stages) == 0 {
+		return nil, nil
+	}
+	statuses := make([]setupstatus.Stage, 0, len(stages))
 	for _, st := range stages {
 		logger.InfoContext(ctx, "running create stage", "index", st.Index)
 		if err := runStage(ctx, st.Stage); err != nil {
 			logger.WarnContext(ctx, "create stage failed", "index", st.Index, "error", err)
-			return fmt.Errorf("%w: stage %d: %v", errRequiredStageFailed, st.Index, err)
+			statuses = append(statuses, setupstatus.Stage{
+				Index: st.Index,
+				State: setupstatus.StageFailed,
+				Error: err.Error(),
+			})
+			return statuses, fmt.Errorf("%w: stage %d: %v", errRequiredStageFailed, st.Index, err)
 		}
+		statuses = append(statuses, setupstatus.Stage{Index: st.Index, State: setupstatus.StageDone})
 		logger.InfoContext(ctx, "create stage completed", "index", st.Index)
 	}
-	return nil
+	return statuses, nil
 }
 
 // runStage runs a single create stage's Script through `sh -c`, inheriting

--- a/cmd/kuketty/stages_test.go
+++ b/cmd/kuketty/stages_test.go
@@ -23,21 +23,31 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 func TestProcessStages_EmptyIsNoOp(t *testing.T) {
-	if err := processStages(context.Background(), nil, discardLogger()); err != nil {
+	statuses, err := processStages(context.Background(), nil, discardLogger())
+	if err != nil {
 		t.Fatalf("nil stages should be a no-op, got %v", err)
 	}
-	if err := processStages(context.Background(), []indexedStage{}, discardLogger()); err != nil {
+	if statuses != nil {
+		t.Errorf("nil stages should report nil statuses, got %+v", statuses)
+	}
+	statuses, err = processStages(context.Background(), []indexedStage{}, discardLogger())
+	if err != nil {
 		t.Fatalf("empty stages should be a no-op, got %v", err)
+	}
+	if statuses != nil {
+		t.Errorf("empty stages should report nil statuses, got %+v", statuses)
 	}
 }
 
 // TestProcessStages_RunsScriptsInOrder confirms the executor invokes each
 // create stage's Script: two stages each touch a marker file, asserted present
-// after processStages returns.
+// after processStages returns, and reports each as StageDone carrying its
+// declaration-order Index.
 func TestProcessStages_RunsScriptsInOrder(t *testing.T) {
 	dir := t.TempDir()
 	a := filepath.Join(dir, "a")
@@ -46,27 +56,42 @@ func TestProcessStages_RunsScriptsInOrder(t *testing.T) {
 		{Index: 1, Stage: v1beta1.TtyStage{Script: "touch " + a, RunOn: v1beta1.RunOnCreate}},
 		{Index: 3, Stage: v1beta1.TtyStage{Script: "touch " + b, RunOn: v1beta1.RunOnCreate}},
 	}
-	if err := processStages(context.Background(), stages, discardLogger()); err != nil {
+	statuses, err := processStages(context.Background(), stages, discardLogger())
+	if err != nil {
 		t.Fatalf("processStages: %v", err)
 	}
 	for _, f := range []string{a, b} {
-		if _, err := os.Stat(f); err != nil {
-			t.Errorf("expected marker %q to exist: %v", f, err)
+		if _, statErr := os.Stat(f); statErr != nil {
+			t.Errorf("expected marker %q to exist: %v", f, statErr)
+		}
+	}
+	want := []setupstatus.Stage{
+		{Index: 1, State: setupstatus.StageDone},
+		{Index: 3, State: setupstatus.StageDone},
+	}
+	if len(statuses) != len(want) {
+		t.Fatalf("want %d statuses, got %d: %+v", len(want), len(statuses), statuses)
+	}
+	for i := range want {
+		if statuses[i] != want[i] {
+			t.Errorf("status[%d] = %+v, want %+v", i, statuses[i], want[i])
 		}
 	}
 }
 
 // TestProcessStages_FailurePropagates: a failing create stage returns
 // errRequiredStageFailed (the required-failure contract) and stops before the
-// next stage runs.
+// next stage runs. The returned statuses record the completed stage as
+// StageDone and the failing stage as StageFailed; the never-run stage is absent.
 func TestProcessStages_FailurePropagates(t *testing.T) {
 	dir := t.TempDir()
 	after := filepath.Join(dir, "after")
 	stages := []indexedStage{
-		{Index: 0, Stage: v1beta1.TtyStage{Script: "exit 7", RunOn: v1beta1.RunOnCreate}},
-		{Index: 1, Stage: v1beta1.TtyStage{Script: "touch " + after, RunOn: v1beta1.RunOnCreate}},
+		{Index: 0, Stage: v1beta1.TtyStage{Script: "true", RunOn: v1beta1.RunOnCreate}},
+		{Index: 1, Stage: v1beta1.TtyStage{Script: "exit 7", RunOn: v1beta1.RunOnCreate}},
+		{Index: 2, Stage: v1beta1.TtyStage{Script: "touch " + after, RunOn: v1beta1.RunOnCreate}},
 	}
-	err := processStages(context.Background(), stages, discardLogger())
+	statuses, err := processStages(context.Background(), stages, discardLogger())
 	if err == nil {
 		t.Fatal("processStages: expected error for failing stage, got nil")
 	}
@@ -76,20 +101,36 @@ func TestProcessStages_FailurePropagates(t *testing.T) {
 	if _, statErr := os.Stat(after); statErr == nil {
 		t.Errorf("stage after the failing one ran; expected execution to stop")
 	}
+	if len(statuses) != 2 {
+		t.Fatalf("want 2 statuses (done + failed), got %d: %+v", len(statuses), statuses)
+	}
+	if statuses[0] != (setupstatus.Stage{Index: 0, State: setupstatus.StageDone}) {
+		t.Errorf("status[0] = %+v, want done stage at index 0", statuses[0])
+	}
+	if statuses[1].Index != 1 || statuses[1].State != setupstatus.StageFailed || statuses[1].Error == "" {
+		t.Errorf("status[1] = %+v, want failed stage at index 1 with error detail", statuses[1])
+	}
 }
 
 // TestProcessStages_CapturesOutputInError: a failing stage folds its combined
-// output into the returned error so the log line is actionable.
+// output into the returned error and into the StageFailed status's Error so the
+// log line and the reported status are both actionable.
 func TestProcessStages_CapturesOutputInError(t *testing.T) {
 	stages := []indexedStage{
 		{Index: 0, Stage: v1beta1.TtyStage{Script: "echo boom >&2; exit 1", RunOn: v1beta1.RunOnCreate}},
 	}
-	err := processStages(context.Background(), stages, discardLogger())
+	statuses, err := processStages(context.Background(), stages, discardLogger())
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if got := err.Error(); !contains(got, "boom") {
 		t.Errorf("error %q does not carry the stage's output", got)
+	}
+	if len(statuses) != 1 {
+		t.Fatalf("want 1 status, got %d: %+v", len(statuses), statuses)
+	}
+	if statuses[0].State != setupstatus.StageFailed || !contains(statuses[0].Error, "boom") {
+		t.Errorf("status[0] = %+v, want failed status carrying the stage output", statuses[0])
 	}
 }
 

--- a/internal/controller/get_container.go
+++ b/internal/controller/get_container.go
@@ -130,12 +130,14 @@ func (b *Exec) GetContainer(container intmodel.Container) (GetContainerResult, e
 				ID:    name,
 				State: actualState,
 				// GetCell populated per-container statuses, including the
-				// per-repo clone/fetch outcome pulled over the GetSetupStatus
-				// RPC (issue #642). Carry the Repos slice through so
-				// `kuke get container <name> -o yaml/json` surfaces it; the
+				// per-repo clone/fetch outcome and per-create-stage outcome
+				// pulled over the GetSetupStatus RPC (issues #642, #689). Carry
+				// the Repos / Stages slices through so
+				// `kuke get container <name> -o yaml/json` surfaces them; the
 				// rest of the status is rebuilt inline from the freshly-queried
 				// containerd state above.
-				Repos: repoStatusesForContainer(internalCell, name),
+				Repos:  repoStatusesForContainer(internalCell, name),
+				Stages: stageStatusesForContainer(internalCell, name),
 			},
 		}
 	} else {
@@ -157,6 +159,19 @@ func repoStatusesForContainer(cell intmodel.Cell, name string) []intmodel.RepoSt
 	for i := range cell.Status.Containers {
 		if cell.Status.Containers[i].ID == name {
 			return cell.Status.Containers[i].Repos
+		}
+	}
+	return nil
+}
+
+// stageStatusesForContainer returns the per-create-stage outcome that GetCell
+// pulled into the cell's container statuses (over the GetSetupStatus RPC, issue
+// #689) for the named container, or nil when the container has no stage status
+// (no runOn: create stages, not yet Ready, or the pull was unavailable).
+func stageStatusesForContainer(cell intmodel.Cell, name string) []intmodel.StageStatus {
+	for i := range cell.Status.Containers {
+		if cell.Status.Containers[i].ID == name {
+			return cell.Status.Containers[i].Stages
 		}
 	}
 	return nil

--- a/internal/controller/get_container_test.go
+++ b/internal/controller/get_container_test.go
@@ -824,6 +824,65 @@ func TestGetContainer_NameTrimming(t *testing.T) {
 	}
 }
 
+// TestGetContainer_SurfacesSetupStatuses confirms GetContainer carries the
+// per-repo and per-create-stage outcomes that GetCell pulled into the cell's
+// container statuses through into result.Container.Status, so
+// `kuke get container <name> -o yaml/json` renders them (issues #642, #689).
+func TestGetContainer_SurfacesSetupStatuses(t *testing.T) {
+	mockRunner := &fakeRunner{}
+
+	existingCell := buildTestCell("test-cell", "test-realm", "test-space", "test-stack")
+	existingCell.Spec.Containers = []intmodel.ContainerSpec{
+		{ID: "test-container", Image: "alpine:latest"},
+	}
+	// GetCell-populated per-container statuses, including the stage/repo outcomes
+	// pulled over the GetSetupStatus RPC.
+	existingCell.Status.Containers = []intmodel.ContainerStatus{
+		{
+			ID: "test-container",
+			Repos: []intmodel.RepoStatus{
+				{Name: "app", Target: "/work/app", State: "cloned", Commit: "abc123"},
+			},
+			Stages: []intmodel.StageStatus{
+				{Index: 0, State: "done"},
+				{Index: 2, State: "failed", Error: "stage 2: exit 1"},
+			},
+		},
+	}
+	mockRunner.GetCellFn = func(_ intmodel.Cell) (intmodel.Cell, error) {
+		return existingCell, nil
+	}
+	mockRunner.GetContainerStateFn = func(_ intmodel.Cell, _ string) (intmodel.ContainerState, error) {
+		return intmodel.ContainerStateReady, nil
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	container := buildTestContainer(
+		"test-container", "test-realm", "test-space", "test-stack", "test-cell", "alpine:latest",
+	)
+
+	result, err := ctrl.GetContainer(container)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gotRepos := result.Container.Status.Repos
+	if len(gotRepos) != 1 || gotRepos[0].Name != "app" || gotRepos[0].State != "cloned" {
+		t.Errorf("Status.Repos = %+v, want one cloned repo named app", gotRepos)
+	}
+
+	gotStages := result.Container.Status.Stages
+	if len(gotStages) != 2 {
+		t.Fatalf("Status.Stages = %+v, want 2 stages", gotStages)
+	}
+	if gotStages[0].Index != 0 || gotStages[0].State != "done" || gotStages[0].Error != "" {
+		t.Errorf("Status.Stages[0] = %+v, want done stage at index 0", gotStages[0])
+	}
+	if gotStages[1].Index != 2 || gotStages[1].State != "failed" || gotStages[1].Error != "stage 2: exit 1" {
+		t.Errorf("Status.Stages[1] = %+v, want failed stage at index 2 with detail", gotStages[1])
+	}
+}
+
 // TestListContainers_SuccessfulRetrieval tests successful retrieval of containers list.
 func TestListContainers_SuccessfulRetrieval(t *testing.T) {
 	tests := []struct {

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -34,6 +34,7 @@ import (
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
 	"github.com/eminwux/kukeon/internal/util/naming"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 // purgeCNIForContainer removes all CNI-related resources for a specific container.
@@ -728,11 +729,12 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 			ExitCode:     0,           // TODO: retrieve from containerd
 			ExitSignal:   "",          // TODO: retrieve from containerd
 		}
-		// Pull per-repo clone/fetch outcome over the kuketty control socket
-		// (issue #642). Best-effort: only Attachable containers that declared
-		// repos[] and are Ready can serve the verb, and any failure leaves
-		// Repos empty rather than blocking the status read.
-		status.Repos = r.repoStatuses(cell, containerSpec, state)
+		// Pull per-repo clone/fetch and per-create-stage outcomes over the
+		// kuketty control socket (issues #642, #689) in a single dial.
+		// Best-effort: only Attachable containers that declared repos[] or
+		// create stages and are Ready can serve the verb, and any failure leaves
+		// Repos/Stages empty rather than blocking the status read.
+		status.Repos, status.Stages = r.setupStatuses(cell, containerSpec, state)
 		statuses = append(statuses, status)
 	}
 
@@ -740,25 +742,31 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 	return nil
 }
 
-// repoStatuses pulls the per-repo clone/fetch outcome from a container's
-// kuketty control socket via the GetSetupStatus RPC (issue #642), mapping the
-// wire payload into the internal RepoStatus the controller persists in
-// ContainerStatus.Repos. ContainerStatus is the single source of truth — there
-// is no status file in the container.
+// setupStatuses pulls the per-repo clone/fetch outcome and the per-create-stage
+// outcome from a container's kuketty control socket via the GetSetupStatus RPC
+// (issues #642, #689) in a single dial, mapping the wire payload into the
+// internal RepoStatus / StageStatus the controller persists in
+// ContainerStatus.Repos / .Stages. ContainerStatus is the single source of
+// truth — there is no status file in the container.
 //
-// The pull is skipped (returns nil) unless the container is Attachable, has
-// declared repos[], and is Ready: a kuketty that has not reached Serve does
-// not yet serve the verb, and one that exited on a required-repo failure never
-// will (its outcome comes from the task-failed signal + kuketty log instead —
-// AC #5). Any dial/call error is logged at debug and yields nil so a wedged or
-// still-starting kuketty never stalls `kuke get`.
-func (r *Exec) repoStatuses(
+// The pull is skipped (returns nil, nil) unless the container is Attachable,
+// Ready, and declared at least one repo[] or runOn: create stage: a kuketty
+// that has not reached Serve does not yet serve the verb, one that exited on a
+// required-repo or create-stage failure never will (its outcome comes from the
+// task-failed signal + kuketty log instead — AC #5), and a container with
+// neither repos nor create stages has nothing to report. Any dial/call error is
+// logged at debug and yields nil so a wedged or still-starting kuketty never
+// stalls `kuke get`.
+func (r *Exec) setupStatuses(
 	cell *intmodel.Cell,
 	containerSpec intmodel.ContainerSpec,
 	state intmodel.ContainerState,
-) []intmodel.RepoStatus {
-	if !containerSpec.Attachable || len(containerSpec.Repos) == 0 || state != intmodel.ContainerStateReady {
-		return nil
+) ([]intmodel.RepoStatus, []intmodel.StageStatus) {
+	if !containerSpec.Attachable || state != intmodel.ContainerStateReady {
+		return nil, nil
+	}
+	if len(containerSpec.Repos) == 0 && !hasCreateStages(containerSpec) {
+		return nil, nil
 	}
 
 	socketPath := fs.ContainerSocketSymlinkPath(
@@ -766,15 +774,30 @@ func (r *Exec) repoStatuses(
 		cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name,
 		containerSpec.ID,
 	)
-	repos, err := pullSetupStatus(r.ctx, socketPath)
+	reply, err := pullSetupStatus(r.ctx, socketPath)
 	if err != nil {
-		r.logger.DebugContext(r.ctx, "failed to pull repo setup status",
+		r.logger.DebugContext(r.ctx, "failed to pull setup status",
 			"container", containerSpec.ID,
 			"socket", socketPath,
 			"error", err)
-		return nil
+		return nil, nil
 	}
-	return setupStatusToInternal(repos)
+	return repoStatusToInternal(reply.Repos), stageStatusToInternal(reply.Stages)
+}
+
+// hasCreateStages reports whether the container declares at least one runOn:
+// create TtyStage — the gate (alongside repos[]) for dialing kuketty's setup
+// status verb. Mirrors cmd/kuketty's createStages selection.
+func hasCreateStages(containerSpec intmodel.ContainerSpec) bool {
+	if containerSpec.Tty == nil {
+		return false
+	}
+	for _, s := range containerSpec.Tty.OnInit {
+		if s.RunOn == v1beta1.RunOnCreate {
+			return true
+		}
+	}
+	return false
 }
 
 // PopulateAndPersistCellContainerStatuses populates container statuses from containerd

--- a/internal/controller/runner/helpers_test.go
+++ b/internal/controller/runner/helpers_test.go
@@ -26,7 +26,48 @@ import (
 	"time"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
+
+// TestHasCreateStages covers the gate setupStatuses uses to decide whether a
+// container has anything stage-side worth dialing kuketty for.
+func TestHasCreateStages(t *testing.T) {
+	tests := []struct {
+		name string
+		spec intmodel.ContainerSpec
+		want bool
+	}{
+		{
+			name: "nil tty has no create stages",
+			spec: intmodel.ContainerSpec{Tty: nil},
+			want: false,
+		},
+		{
+			name: "tty with only start stages has no create stages",
+			spec: intmodel.ContainerSpec{Tty: &intmodel.ContainerTty{OnInit: []intmodel.TtyStage{
+				{Script: "echo hi", RunOn: v1beta1.RunOnStart},
+				{Script: "echo bye"},
+			}}},
+			want: false,
+		},
+		{
+			name: "tty with a create stage is detected",
+			spec: intmodel.ContainerSpec{Tty: &intmodel.ContainerTty{OnInit: []intmodel.TtyStage{
+				{Script: "echo hi", RunOn: v1beta1.RunOnStart},
+				{Script: "git clone ...", RunOn: v1beta1.RunOnCreate},
+			}}},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasCreateStages(tt.spec); got != tt.want {
+				t.Errorf("hasCreateStages = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestIsValidationError(t *testing.T) {
 	tests := []struct {

--- a/internal/controller/runner/setup_status_client.go
+++ b/internal/controller/runner/setup_status_client.go
@@ -30,24 +30,27 @@ import (
 
 // setupStatusDialTimeout bounds the connect + round-trip to a container's
 // kuketty control socket. The pull is a best-effort enrichment of a `kuke get`
-// read (see repoStatuses / populateCellContainerStatuses in helpers.go): a
+// read (see setupStatuses / populateCellContainerStatuses in helpers.go): a
 // slow or wedged kuketty must never stall the status read, so the call gives
-// up quickly and leaves Repos empty rather than blocking the operator's
+// up quickly and leaves Repos/Stages empty rather than blocking the operator's
 // `kuke get`.
 const setupStatusDialTimeout = 2 * time.Second
 
 // pullSetupStatus dials a container's kuketty control socket and invokes the
-// GetSetupStatus verb (issue #642), returning the per-repo clone/fetch outcome
-// kuketty reported after its pre-Serve step. The socket is the same one
-// `kuke attach` connects to; the verb is served over the same JSON-RPC codec,
-// so a stdlib net/rpc/jsonrpc client is wire-compatible for this non-FD method
-// (sbsh's own pkg/rpcclient uses the same codec for its non-FD verbs).
+// GetSetupStatus verb (issues #642, #689), returning the full Reply — the
+// per-repo clone/fetch outcome and the per-create-stage outcome kuketty
+// reported after its pre-Serve steps. One dial serves both: the socket is the
+// same one `kuke attach` connects to; the verb is served over the same
+// JSON-RPC codec, so a stdlib net/rpc/jsonrpc client is wire-compatible for
+// this non-FD method (sbsh's own pkg/rpcclient uses the same codec for its
+// non-FD verbs).
 //
 // The whole call is bounded by setupStatusDialTimeout. Callers treat any error
-// as "status not available yet" and proceed with an empty Repos — the verb is
-// only reachable once kuketty is past Serve (container Ready), and a container
-// that exited on a required-repo failure never serves it (AC #5).
-func pullSetupStatus(ctx context.Context, socketPath string) ([]setupstatus.Repo, error) {
+// as "status not available yet" and proceed with empty Repos/Stages — the verb
+// is only reachable once kuketty is past Serve (container Ready), and a
+// container that exited on a required-repo or create-stage failure never serves
+// it (AC #5).
+func pullSetupStatus(ctx context.Context, socketPath string) (*setupstatus.Reply, error) {
 	dialCtx, cancel := context.WithTimeout(ctx, setupStatusDialTimeout)
 	defer cancel()
 
@@ -71,14 +74,14 @@ func pullSetupStatus(ctx context.Context, socketPath string) ([]setupstatus.Repo
 	if callErr := client.Call(setupstatus.Method, setupstatus.Args{}, &reply); callErr != nil {
 		return nil, fmt.Errorf("call %s on %q: %w", setupstatus.Method, socketPath, callErr)
 	}
-	return reply.Repos, nil
+	return &reply, nil
 }
 
-// setupStatusToInternal maps the wire payload onto the internal RepoStatus
+// repoStatusToInternal maps the wire repo payload onto the internal RepoStatus
 // type the controller persists in ContainerStatus.Repos. Returns nil for an
 // empty input so a container with no repos[] reports a nil Repos (mirrors the
 // omitempty wire/YAML shape) rather than an empty slice.
-func setupStatusToInternal(repos []setupstatus.Repo) []intmodel.RepoStatus {
+func repoStatusToInternal(repos []setupstatus.Repo) []intmodel.RepoStatus {
 	if len(repos) == 0 {
 		return nil
 	}
@@ -90,6 +93,25 @@ func setupStatusToInternal(repos []setupstatus.Repo) []intmodel.RepoStatus {
 			State:  r.State,
 			Commit: r.Commit,
 			Error:  r.Error,
+		}
+	}
+	return out
+}
+
+// stageStatusToInternal maps the wire create-stage payload onto the internal
+// StageStatus type the controller persists in ContainerStatus.Stages. Returns
+// nil for an empty input so a container with no create stages reports a nil
+// Stages (mirrors the omitempty wire/YAML shape) rather than an empty slice.
+func stageStatusToInternal(stages []setupstatus.Stage) []intmodel.StageStatus {
+	if len(stages) == 0 {
+		return nil
+	}
+	out := make([]intmodel.StageStatus, len(stages))
+	for i, s := range stages {
+		out[i] = intmodel.StageStatus{
+			Index: s.Index,
+			State: s.State,
+			Error: s.Error,
 		}
 	}
 	return out

--- a/internal/controller/runner/setup_status_client_test.go
+++ b/internal/controller/runner/setup_status_client_test.go
@@ -34,11 +34,13 @@ import (
 // handler is served over (both are net/rpc + JSON-RPC for this non-FD verb),
 // without standing up a full sbsh server.
 type stubSetupService struct {
-	repos []setupstatus.Repo
+	repos  []setupstatus.Repo
+	stages []setupstatus.Stage
 }
 
 func (s *stubSetupService) GetSetupStatus(_ setupstatus.Args, reply *setupstatus.Reply) error {
 	reply.Repos = s.repos
+	reply.Stages = s.stages
 	return nil
 }
 
@@ -74,61 +76,96 @@ func serveStubSetup(t *testing.T, svc *stubSetupService) string {
 }
 
 func TestPullSetupStatus_RoundTrip(t *testing.T) {
-	want := []setupstatus.Repo{
+	wantRepos := []setupstatus.Repo{
 		{Name: "app", Target: "/work/app", State: setupstatus.StateCloned, Commit: "abc123"},
 		{Name: "lib", Target: "/work/lib", State: setupstatus.StateFailed, Error: "auth failed"},
 	}
-	socketPath := serveStubSetup(t, &stubSetupService{repos: want})
+	wantStages := []setupstatus.Stage{
+		{Index: 0, State: setupstatus.StageDone},
+		{Index: 1, State: setupstatus.StageFailed, Error: "stage 1: boom"},
+	}
+	socketPath := serveStubSetup(t, &stubSetupService{repos: wantRepos, stages: wantStages})
 
 	got, err := pullSetupStatus(context.Background(), socketPath)
 	if err != nil {
 		t.Fatalf("pullSetupStatus: %v", err)
 	}
-	if len(got) != len(want) {
-		t.Fatalf("want %d repos, got %d: %+v", len(want), len(got), got)
+	if len(got.Repos) != len(wantRepos) {
+		t.Fatalf("want %d repos, got %d: %+v", len(wantRepos), len(got.Repos), got.Repos)
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("repo[%d] = %+v, want %+v", i, got[i], want[i])
+	for i := range wantRepos {
+		if got.Repos[i] != wantRepos[i] {
+			t.Errorf("repo[%d] = %+v, want %+v", i, got.Repos[i], wantRepos[i])
+		}
+	}
+	if len(got.Stages) != len(wantStages) {
+		t.Fatalf("want %d stages, got %d: %+v", len(wantStages), len(got.Stages), got.Stages)
+	}
+	for i := range wantStages {
+		if got.Stages[i] != wantStages[i] {
+			t.Errorf("stage[%d] = %+v, want %+v", i, got.Stages[i], wantStages[i])
 		}
 	}
 }
 
 func TestPullSetupStatus_EmptyReply(t *testing.T) {
-	socketPath := serveStubSetup(t, &stubSetupService{repos: nil})
+	socketPath := serveStubSetup(t, &stubSetupService{repos: nil, stages: nil})
 
 	got, err := pullSetupStatus(context.Background(), socketPath)
 	if err != nil {
 		t.Fatalf("pullSetupStatus: %v", err)
 	}
-	if len(got) != 0 {
-		t.Errorf("want empty repos, got %+v", got)
+	if len(got.Repos) != 0 {
+		t.Errorf("want empty repos, got %+v", got.Repos)
+	}
+	if len(got.Stages) != 0 {
+		t.Errorf("want empty stages, got %+v", got.Stages)
 	}
 }
 
 func TestPullSetupStatus_DialError(t *testing.T) {
 	// No server listening at this path — the dial must fail fast (bounded by
 	// setupStatusDialTimeout) rather than block, so the caller falls back to
-	// an empty Repos.
+	// empty Repos/Stages.
 	missing := filepath.Join(t.TempDir(), "absent")
 	if _, err := pullSetupStatus(context.Background(), missing); err == nil {
 		t.Fatal("want a dial error for an absent socket, got nil")
 	}
 }
 
-func TestSetupStatusToInternal(t *testing.T) {
-	if got := setupStatusToInternal(nil); got != nil {
+func TestRepoStatusToInternal(t *testing.T) {
+	if got := repoStatusToInternal(nil); got != nil {
 		t.Errorf("nil input should map to nil, got %+v", got)
 	}
 	in := []setupstatus.Repo{
 		{Name: "app", Target: "/work/app", State: setupstatus.StateCloned, Commit: "abc123"},
 	}
-	got := setupStatusToInternal(in)
+	got := repoStatusToInternal(in)
 	if len(got) != 1 {
 		t.Fatalf("want 1, got %d", len(got))
 	}
 	if got[0].Name != "app" || got[0].Target != "/work/app" ||
 		got[0].State != setupstatus.StateCloned || got[0].Commit != "abc123" {
 		t.Errorf("unexpected mapping: %+v", got[0])
+	}
+}
+
+func TestStageStatusToInternal(t *testing.T) {
+	if got := stageStatusToInternal(nil); got != nil {
+		t.Errorf("nil input should map to nil, got %+v", got)
+	}
+	in := []setupstatus.Stage{
+		{Index: 0, State: setupstatus.StageDone},
+		{Index: 2, State: setupstatus.StageFailed, Error: "boom"},
+	}
+	got := stageStatusToInternal(in)
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %d", len(got))
+	}
+	if got[0].Index != 0 || got[0].State != setupstatus.StageDone || got[0].Error != "" {
+		t.Errorf("unexpected mapping for done stage: %+v", got[0])
+	}
+	if got[1].Index != 2 || got[1].State != setupstatus.StageFailed || got[1].Error != "boom" {
+		t.Errorf("unexpected mapping for failed stage: %+v", got[1])
 	}
 }

--- a/internal/kuketty/setupstatus/setupstatus.go
+++ b/internal/kuketty/setupstatus/setupstatus.go
@@ -51,10 +51,13 @@ const Method = ServiceName + "." + MethodName
 type Args struct{}
 
 // Reply is the GetSetupStatus response: the per-repo outcome of kuketty's
-// pre-Serve clone/fetch step, in the order the repos were declared on the
-// container spec. An empty Repos means the container declared no repos[].
+// pre-Serve clone/fetch step (Repos) plus the per-stage outcome of its
+// pre-Serve runOn: create execution (Stages), each in the order the items were
+// declared on the container spec. An empty Repos means the container declared
+// no repos[]; an empty Stages means it declared no runOn: create stages.
 type Reply struct {
-	Repos []Repo `json:"repos"`
+	Repos  []Repo  `json:"repos"`
+	Stages []Stage `json:"stages"`
 }
 
 // Repo is the resolved state of a single ContainerRepo after kuketty's
@@ -82,4 +85,34 @@ const (
 	StateFetched = "fetched"
 	// StateFailed means the clone/fetch failed; Error carries the detail.
 	StateFailed = "failed"
+)
+
+// Stage is the resolved state of a single runOn: create TtyStage after
+// kuketty's pre-Serve execution. Field set mirrors
+// api/model/v1beta1.StageStatus so the daemon can map it straight into
+// ContainerStatus.Stages. Index is the stage's 0-based position among the
+// container's create stages, in declaration order — the stable identity phase
+// A (#635) carries through (the run-once "done" key is settled in phase C,
+// #690).
+type Stage struct {
+	Index int `json:"index"`
+	// State is one of StageDone or StageFailed.
+	State string `json:"state"`
+	// Error is the failure detail when State == StageFailed; empty otherwise.
+	Error string `json:"error,omitempty"`
+}
+
+// Stage state values. Mirror the create-stage outcome set v1beta1.StageStatus
+// documents. A create stage carries no per-stage Required knob — every create
+// stage is implicitly required (see cmd/kuketty's errRequiredStageFailed) — so
+// kuketty exits before Serve on the first failure and the GetSetupStatus verb,
+// reachable only post-Serve, in practice only ever serves StageDone stages
+// (the same post-Serve-only path required repos take, AC #5 of #617).
+// StageFailed completes the wire contract and is exercised on the executor's
+// pre-Serve failure return.
+const (
+	// StageDone means the stage's Script ran to completion successfully.
+	StageDone = "done"
+	// StageFailed means the stage's Script failed; Error carries the detail.
+	StageFailed = "failed"
 )


### PR DESCRIPTION
## Summary

Phase B of the create-stage status pipeline (#689). Phase A (#635) landed the `TtyStage.RunOn` field, the create-stage pre-Serve executor, and the `ContainerStatus.Stages` *schema*. This phase wires the **reporting** half, mirroring exactly what #642 did for `repos[]`: per-stage outcomes now flow kuketty → daemon → `kuke get`.

- **Wire contract** (`internal/kuketty/setupstatus`): `Reply` gains `Stages []Stage`; new `Stage{Index, State, Error}` mirrors `RepoStatus`/`v1beta1.StageStatus`, with `StageDone`/`StageFailed` state constants.
- **kuketty executor** (`cmd/kuketty/stages.go`): `processStages` now returns `([]setupstatus.Stage, error)` — each completed stage recorded `StageDone`, the first failing one `StageFailed` with its error detail (then the required-failure return, unchanged).
- **kuketty handler/main**: `setupStatusHandler` carries `stages`, serves them on `GetSetupStatus`; `main` captures and registers them alongside repos.
- **Daemon pull** (`setup_status_client.go`): `pullSetupStatus` now returns the full `*Reply` so one dial serves both repos and stages; added `stageStatusToInternal` (and renamed the repo converter `setupStatusToInternal` → `repoStatusToInternal` for symmetry with the new one).
- **Status population** (`helpers.go`): `repoStatuses` → `setupStatuses` returns both slices from a single dial, gated on Attachable + Ready + (has repos **or** has create stages); new `hasCreateStages` helper supplies the stage half of that gate.
- **`kuke get`** (`get_container.go`): new `stageStatusesForContainer` carries `Status.Stages` through, mirroring `repoStatusesForContainer`.

### Decisions worth a reviewer's eye

- **State value set = `{done, failed}`.** The AC's prose says "create/done/failed", but the phase-A `StageStatus` docstring (`e.g. "ran" or "failed"`) explicitly defers the exact set to this phase. I read "create" as the *runOn class* (these are create-stages), not an observable state, so the outcome states are `done` (success — matches the AC's literal token) and `failed`. The phase-A apischeme round-trip test is value-agnostic, so no conflict.
- **`failed` is reachable only in the executor's return, not over RPC.** A create stage carries no per-stage `Required` knob (every create stage is implicitly required — see `errRequiredStageFailed`), so kuketty exits before `Serve` on the first failure and the `GetSetupStatus` verb (post-Serve only) in practice only ever serves `done` stages — the same AC #5 path required repos take. `StageFailed` completes the wire contract and is exercised by the executor's failure-path unit test.
- **No `cmd/kuke/get/container/container.go` change.** The Proposal lists it, but the repos chain it mirrors has *zero* repo-rendering code there: `kuke get container <name>` marshals the full container (spec + status) as YAML/JSON, so `ContainerStatus.Stages` surfaces automatically once populated (verified: status round-trips through `BuildContainerExternalFromInternal`, which already converts `Stages`). Adding stage-specific rendering would diverge from the repos UX. The AC checkbox ("visible in `kuke get`") is satisfied by the marshalled status; `TestGetContainer_SurfacesSetupStatuses` asserts it end-to-end.
- **Single dial, not two.** Changing `pullSetupStatus` to return `*Reply` (vs. a second parallel pull) avoids dialing each container's socket twice per `kuke get`.

## Test plan

- [x] `make test` (test-root + test-kukebuild) — green, incl. the 70s `internal/ctr` integration suite
- [x] `GOWORK=off go build ./...` / `go vet ./...`
- [x] New unit tests: wire round-trip (`TestPullSetupStatus_RoundTrip` now covers stages), status pull (`TestStageStatusToInternal`, `TestRepoStatusToInternal`), executor outcomes (`TestProcessStages_*`), handler (`TestSetupStatusHandler_*`), gate (`TestHasCreateStages`), `kuke get` rendering (`TestGetContainer_SurfacesSetupStatuses`)
- [ ] `make dev-init` daemon-parity smoke / `make e2e` — **not run: host disk capacity.** The shared host overlay is at 95% (90G used, ~5G free); a clean `kukebuild`/`docker build` of the kukeond image needs several GB (go-mod download + full rebuild) and fails with `no space left on device`. I freed the go-build cache (+2.4G) and busted a poisoned build-cache layer, but the remaining headroom on the shared disk is insufficient and not mine to reclaim. This change touches the daemon's RPC status-pull + rendering only — **not** realm provisioning, bind mounts, or the `/opt/kukeon` on-disk layout — so it cannot affect the bind-mount parity invariant the smoke guards. Reviewer should run the daemon-parity smoke on a host with disk headroom.

Closes #689