### PR TITLE
chore(cellprofile): remove dead exported CloneNode and ParamRefRE

### DIFF
--- a/internal/cellprofile/params.go
+++ b/internal/cellprofile/params.go
@@ -331,20 +331,6 @@ func SubstituteScalars(node *yaml.Node, values map[string]string) {
 	substituteScalars(node, values)
 }
 
-// CloneNode returns a deep copy of n so substitutions don't mutate the input.
-// Exported for the CellBlueprint materialize path (issue #620).
-func CloneNode(n *yaml.Node) *yaml.Node {
-	return cloneNode(n)
-}
-
-// ParamRefRE returns the compiled `${KEY}` reference matcher shared by the
-// profile and blueprint substitution paths. Exposed so the blueprint resolver
-// can scan a template body for the parameter shape without re-deriving the
-// regex. Issue #620.
-func ParamRefRE() *regexp.Regexp {
-	return paramRefRE
-}
-
 // ParseParamArgs validates a slice of `KEY=VALUE` strings (from --param) and
 // returns the equivalent map. Empty values are allowed (`KEY=` → "");
 // missing `=` errors. Duplicate keys: last occurrence wins, matching `docker


### PR DESCRIPTION
## Summary
- `CloneNode` and `ParamRefRE` in `internal/cellprofile/params.go` were added in #702 with doc comments claiming they serve the CellBlueprint materialize path (#620), but the blueprint resolver (`internal/cellblueprint/cellblueprint.go`) uses only `cellprofile.SubstituteScalars` — it never clones nodes nor pre-scans a body for `${KEY}` refs.
- A tree-wide grep confirms zero callers of either exported wrapper anywhere (incl. tests, e2e, docs). The underlying private `cloneNode`/`paramRefRE` stay — both are still live within the package.
- Note: the original stall comment on #705 predated #702's merge; #702 has since merged (`3ebb9cd`) so the symbols now exist on `main` and the deletion is a real diff. The `stalled` label has been cleared; issue carries only `followup-nits`.

## Test plan
- [x] `make test` (test-root + test-kukebuild) — pass
- [x] `go vet ./internal/cellprofile/` — clean
- [x] tree-wide grep for `CloneNode`/`ParamRefRE` callers — none outside the deleted definitions

Closes #705