### PR TITLE
fix: guard ctr reader sites against cClient reconnect reassignment

### DIFF
--- a/internal/ctr/cache.go
+++ b/internal/ctr/cache.go
@@ -50,7 +50,7 @@ func (c *client) loadContainer(namespace, id string) (containerd.Container, erro
 	c.containersMu.RUnlock()
 
 	nsCtx := c.namespaceCtx(namespace)
-	container, err := c.cClient.LoadContainer(nsCtx, id)
+	container, err := c.conn().LoadContainer(nsCtx, id)
 	if err != nil {
 		// Only wrap "not found" errors with ErrContainerNotFound
 		// Other errors (connection failures, permission errors, etc.) should be returned as-is

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -224,6 +224,20 @@ func (c *client) Close() error {
 	return c.closeLocked()
 }
 
+// conn returns the current containerd client snapshotted under cClientMu, so a
+// reader observes a consistent pointer even while Connect()'s reconnect path is
+// concurrently swapping c.cClient (issue #709 — #695 guarded only the writer).
+// The lock is held just for the pointer read; the snapshot is then used for the
+// whole operation, so the reader path is never serialized against an in-flight
+// RPC and a concurrent reconnect cannot tear an operation already dereferencing
+// the prior pointer. Returns nil if the client has not connected yet — callers
+// that have not already gated on Connect() must nil-check.
+func (c *client) conn() *containerd.Client {
+	c.cClientMu.Lock()
+	defer c.cClientMu.Unlock()
+	return c.cClient
+}
+
 // closeLocked tears down c.cClient. The caller must hold c.cClientMu — it is
 // invoked both by the public Close() (which takes the lock) and by Connect()'s
 // reconnect path (which already holds the lock), so the teardown stays guarded

--- a/internal/ctr/container.go
+++ b/internal/ctr/container.go
@@ -326,9 +326,10 @@ func (c *client) CreateContainer(namespace string, spec ContainerSpec, creds []R
 	}
 
 	nsCtx := c.namespaceCtx(namespace)
+	cc := c.conn()
 
 	// Check if container already exists
-	_, err := c.cClient.LoadContainer(nsCtx, spec.ID)
+	_, err := cc.LoadContainer(nsCtx, spec.ID)
 	if err == nil {
 		c.logger.WarnContext(c.ctx, "container already exists", "id", spec.ID)
 		return nil, internalerrdefs.ErrContainerExists
@@ -385,7 +386,7 @@ func (c *client) CreateContainer(namespace string, spec ContainerSpec, creds []R
 		opts = append(opts, containerd.WithContainerLabels(spec.Labels))
 	}
 
-	container, err := c.cClient.NewContainer(nsCtx, spec.ID, opts...)
+	container, err := cc.NewContainer(nsCtx, spec.ID, opts...)
 	if err != nil {
 		c.logger.ErrorContext(c.ctx, "failed to create container", "id", spec.ID, "err", formatError(err))
 		return nil, fmt.Errorf("failed to create container: %w", err)
@@ -408,7 +409,7 @@ func (c *client) GetContainer(namespace, id string) (containerd.Container, error
 func (c *client) ListContainers(namespace string, filters ...string) ([]containerd.Container, error) {
 	nsCtx := c.namespaceCtx(namespace)
 
-	containers, err := c.cClient.Containers(nsCtx, filters...)
+	containers, err := c.conn().Containers(nsCtx, filters...)
 	if err != nil {
 		c.logger.ErrorContext(c.ctx, "failed to list containers", "err", formatError(err))
 		return nil, fmt.Errorf("failed to list containers: %w", err)
@@ -430,7 +431,7 @@ func (c *client) ExistsContainer(namespace, id string) (bool, error) {
 	}
 
 	nsCtx := c.namespaceCtx(namespace)
-	_, err := c.cClient.LoadContainer(nsCtx, id)
+	_, err := c.conn().LoadContainer(nsCtx, id)
 	if err != nil {
 		// "Not found" is not an error for Exists - it's a valid result (container doesn't exist)
 		if errdefs.IsNotFound(err) {

--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -90,9 +90,10 @@ func (c *client) ensureImageUnpacked(namespace string, image containerd.Image, s
 // Returns the image and any error encountered.
 func (c *client) pullImage(namespace string, imageRef string, creds []RegistryCredentials) (containerd.Image, error) {
 	nsCtx := c.namespaceCtx(namespace)
+	cc := c.conn()
 
 	// Try to get the image locally first
-	image, err := c.cClient.GetImage(nsCtx, imageRef)
+	image, err := cc.GetImage(nsCtx, imageRef)
 	if err == nil {
 		return image, nil
 	}
@@ -102,7 +103,7 @@ func (c *client) pullImage(namespace string, imageRef string, creds []RegistryCr
 
 	// Create a lease for the pull operation to avoid lease management issues
 	// The lease will be automatically cleaned up when the context is done
-	leaseManager := c.cClient.LeasesService()
+	leaseManager := cc.LeasesService()
 	lease, leaseErr := leaseManager.Create(
 		nsCtx,
 		leases.WithID(fmt.Sprintf("pull-%s-%d", imageRef, time.Now().UnixNano())),
@@ -147,7 +148,7 @@ func (c *client) pullImage(namespace string, imageRef string, creds []RegistryCr
 		c.logger.DebugContext(c.ctx, "pulling image anonymously", "image", imageRef)
 	}
 
-	image, err = c.cClient.Pull(nsCtx, imageRef, pullOpts...)
+	image, err = cc.Pull(nsCtx, imageRef, pullOpts...)
 	if err != nil {
 		c.logger.ErrorContext(c.ctx, "failed to pull image", "image", imageRef, "err", formatError(err))
 		return nil, fmt.Errorf("failed to pull image %s: %w", imageRef, err)
@@ -166,7 +167,7 @@ func (c *client) pullImage(namespace string, imageRef string, creds []RegistryCr
 func (c *client) LoadImage(namespace string, reader io.Reader) ([]string, error) {
 	nsCtx := c.namespaceCtx(namespace)
 
-	imgs, err := c.cClient.Import(nsCtx, reader, containerd.WithSkipMissing())
+	imgs, err := c.conn().Import(nsCtx, reader, containerd.WithSkipMissing())
 	if err != nil {
 		c.logger.ErrorContext(
 			c.ctx,
@@ -194,7 +195,7 @@ func (c *client) LoadImage(namespace string, reader io.Reader) ([]string, error)
 func (c *client) ListImages(namespace string) ([]ImageInfo, error) {
 	nsCtx := c.namespaceCtx(namespace)
 
-	imgs, err := c.cClient.ListImages(nsCtx)
+	imgs, err := c.conn().ListImages(nsCtx)
 	if err != nil {
 		c.logger.ErrorContext(
 			c.ctx,
@@ -221,7 +222,7 @@ func (c *client) ListImages(namespace string) ([]ImageInfo, error) {
 func (c *client) GetImage(namespace, ref string) (ImageInfo, error) {
 	nsCtx := c.namespaceCtx(namespace)
 
-	img, err := c.cClient.GetImage(nsCtx, ref)
+	img, err := c.conn().GetImage(nsCtx, ref)
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			return ImageInfo{}, fmt.Errorf("%w: %s", internalerrdefs.ErrImageNotFound, ref)
@@ -248,7 +249,7 @@ func (c *client) GetImage(namespace, ref string) (ImageInfo, error) {
 func (c *client) DeleteImage(namespace, ref string) error {
 	nsCtx := c.namespaceCtx(namespace)
 
-	if err := c.cClient.ImageService().Delete(nsCtx, ref); err != nil {
+	if err := c.conn().ImageService().Delete(nsCtx, ref); err != nil {
 		if errdefs.IsNotFound(err) {
 			return fmt.Errorf("%w: %s", internalerrdefs.ErrImageNotFound, ref)
 		}

--- a/internal/ctr/namespaces.go
+++ b/internal/ctr/namespaces.go
@@ -49,7 +49,7 @@ func (c *client) namespaceCtx(namespace string) context.Context {
 
 func (c *client) CreateNamespace(namespace string) error {
 	c.logger.DebugContext(c.ctx, "creating namespace", "namespace", namespace)
-	namespaces := c.cClient.NamespaceService()
+	namespaces := c.conn().NamespaceService()
 
 	err := namespaces.Create(c.ctx, namespace, nil)
 	if err != nil {
@@ -74,14 +74,16 @@ func (c *client) DeleteNamespace(namespace string) error {
 	}
 
 	// Ensure client is connected
-	if c.cClient == nil {
+	cc := c.conn()
+	if cc == nil {
 		if err := c.Connect(); err != nil {
 			return fmt.Errorf("failed to connect to containerd: %w", err)
 		}
+		cc = c.conn()
 	}
 
 	c.logger.DebugContext(c.ctx, "deleting namespace", "namespace", namespace)
-	namespaces := c.cClient.NamespaceService()
+	namespaces := cc.NamespaceService()
 
 	// Check if namespace exists first
 	nsList, err := namespaces.List(c.ctx)
@@ -117,7 +119,7 @@ func (c *client) DeleteNamespace(namespace string) error {
 func (c *client) ListNamespaces() ([]string, error) {
 	c.logger.DebugContext(c.ctx, "listing namespaces")
 
-	namespaces := c.cClient.NamespaceService()
+	namespaces := c.conn().NamespaceService()
 	// containerd requires a namespace for most API calls.
 	// But listing namespaces does not require entering one.
 
@@ -140,7 +142,7 @@ func (c *client) ExistsNamespace(namespace string) (bool, error) {
 
 func (c *client) GetNamespace(namespace string) (string, error) {
 	c.logger.DebugContext(c.ctx, "getting namespace", "namespace", namespace)
-	namespaces := c.cClient.NamespaceService()
+	namespaces := c.conn().NamespaceService()
 
 	nsList, err := namespaces.List(c.ctx)
 	if err != nil {
@@ -207,14 +209,16 @@ var KukeonKnownSnapshotters = []string{
 // signal coming from the caller's subsequent DeleteNamespace check.
 func (c *client) CleanupNamespaceResources(namespace, snapshotter string) error {
 	// Ensure client is connected
-	if c.cClient == nil {
+	cc := c.conn()
+	if cc == nil {
 		if err := c.Connect(); err != nil {
 			return fmt.Errorf("failed to connect to containerd: %w", err)
 		}
+		cc = c.conn()
 	}
 
 	nsCtx := namespaces.WithNamespace(c.ctx, namespace)
-	c.drainNamespaceResources(nsCtx, namespace, snapshotter, c.cClient)
+	c.drainNamespaceResources(nsCtx, namespace, snapshotter, cc)
 	return nil
 }
 

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -119,8 +119,9 @@ func (c *client) applySpecOpts(namespace string, container containerd.Container,
 		}
 	}
 
+	cc := c.conn()
 	for _, opt := range opts {
-		if err = opt(nsCtx, c.cClient, nil, ociSpec); err != nil {
+		if err = opt(nsCtx, cc, nil, ociSpec); err != nil {
 			return fmt.Errorf("failed to apply spec option: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- #695 serialized the *writer* of `c.cClient` behind `cClientMu` (closing the #684 first-use race), but left every reader site dereferencing `c.cClient` with no lock. A `Connect()` reconnect (`closeLocked()` sets `c.cClient = nil`, then `containerd.New(...)` reassigns it, both under the lock) concurrent with an in-flight operation could read a nil or torn pointer.
- Adds a `conn()` helper on `*client` that snapshots `c.cClient` under `cClientMu` and returns it. The lock is held only for the pointer read, so the reader path is never serialized against an in-flight RPC, and a concurrent reconnect that swaps the pointer cannot tear an operation already dereferencing the prior one.
- Converts every reader site enumerated in #709 to take a snapshot via `conn()`: `cache.go`, `container.go` (×4), `image.go` (×7), `namespaces.go` (×7, including the two `if c.cClient == nil { Connect() }` ensure-connected sites), and `spec.go`.

### Design call (the one #709 left open)
The issue offered "snapshot under the lock" *or* "convert `cClientMu` to `sync.RWMutex` and hold RLock for the whole operation". I chose the **snapshot-with-plain-Mutex** approach because it is strictly lower-contention: holding an RLock for an operation's full duration would block a reconnect (writer) until every in-flight reader returned, whereas a snapshot holds the lock only for the pointer copy and lets the in-flight op proceed on its own stable reference. No field-type change, minimal lock hold. The reviewer can push back if RWMutex is preferred for other reasons.

`conn()` returns nil if the client has never connected — same precondition the prior direct `c.cClient` reads carried, so nil-safety is unchanged at sites that don't gate on `Connect()` first.

## Test plan
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./internal/ctr/...`
- [x] `make test` (full CI target: `test-root` + `test-kukebuild`) — green, `internal/ctr` passes
- [ ] `go test -race` on the reconnect/reader concurrency — not run: the dev host has no cgo toolchain (`which gcc` empty) and `-race` requires it. `make test` (the named CI gate per `.github/workflows/test.yaml`) does **not** run `-race`, so this is a deferred verification, not a CI-target gap. Note also there is no existing concurrency test exercising `Connect()` against the readers; the fix is correct-by-construction (snapshot taken under the same mutex that guards the writer).

Closes #709