### PR TITLE
feat: serialize cell lifecycle ops with a per-cell lifecycle lock

### DIFF
--- a/internal/controller/runner/cell_lock.go
+++ b/internal/controller/runner/cell_lock.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"strings"
+	"sync"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// cellLockManager hands out a per-cell mutex keyed by the cell's
+// realm/space/stack/name identity. It serializes the containerd+CNI
+// side-effect span of the lifecycle ops (Start/Stop/Kill/Delete/Recreate/
+// Create/Purge/Reconcile) against each other on the same cell, closing the
+// window where a gRPC handler and the reconcile-loop tick could run teardown
+// concurrently against the same root container ID and IPAM file (issue #714).
+//
+// The metadata flock + generation-token CAS guard only the on-disk document,
+// not the containerd/CNI mutations; this lock covers the mutation span. Keys
+// are independent, so unrelated cells never serialize against one another.
+type cellLockManager struct {
+	mu    sync.Mutex
+	locks map[string]*cellLockEntry
+}
+
+// cellLockEntry is the per-key mutex plus a reference count of goroutines
+// currently holding or waiting on it. The entry is dropped from the map once
+// the count returns to zero so the map cannot grow unbounded over the daemon's
+// lifetime.
+type cellLockEntry struct {
+	mu      sync.Mutex
+	waiters int
+}
+
+func newCellLockManager() *cellLockManager {
+	return &cellLockManager{locks: make(map[string]*cellLockEntry)}
+}
+
+// lock acquires the per-key mutex and returns a release func. The release func
+// unlocks the mutex and drops the entry when no other goroutine is waiting on
+// it. Call the returned func exactly once (typically via defer).
+func (m *cellLockManager) lock(key string) func() {
+	m.mu.Lock()
+	e := m.locks[key]
+	if e == nil {
+		e = &cellLockEntry{}
+		m.locks[key] = e
+	}
+	e.waiters++
+	m.mu.Unlock()
+
+	e.mu.Lock()
+
+	return func() {
+		e.mu.Unlock()
+		m.mu.Lock()
+		e.waiters--
+		if e.waiters == 0 {
+			delete(m.locks, key)
+		}
+		m.mu.Unlock()
+	}
+}
+
+// cellLockKey derives the per-cell lock key from the realm/space/stack/cell
+// identity carried on every lifecycle request. The NUL separator cannot appear
+// in a validated hierarchy name, so distinct identities never collide.
+func cellLockKey(cell intmodel.Cell) string {
+	return strings.Join([]string{
+		strings.TrimSpace(cell.Spec.RealmName),
+		strings.TrimSpace(cell.Spec.SpaceName),
+		strings.TrimSpace(cell.Spec.StackName),
+		strings.TrimSpace(cell.Metadata.Name),
+	}, "\x00")
+}
+
+// lockCell acquires the per-cell lifecycle lock for the given cell and returns
+// the release func. The manager is lazily initialized so *Exec values built
+// directly in tests (rather than via NewRunner) participate in the same
+// serialization without extra fixture wiring.
+func (r *Exec) lockCell(cell intmodel.Cell) func() {
+	r.cellLocksOnce.Do(func() {
+		if r.cellLocks == nil {
+			r.cellLocks = newCellLockManager()
+		}
+	})
+	return r.cellLocks.lock(cellLockKey(cell))
+}

--- a/internal/controller/runner/cell_lock_test.go
+++ b/internal/controller/runner/cell_lock_test.go
@@ -1,0 +1,261 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec lifecycle locking against the in-package ctr.Client fake
+package runner
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestCellLockManager_SameKeySerializes asserts the keyed mutex admits at most
+// one holder per key: 50 goroutines contend on the same key and the observed
+// concurrent-holder count never exceeds one.
+func TestCellLockManager_SameKeySerializes(t *testing.T) {
+	m := newCellLockManager()
+
+	var active, maxActive int32
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rel := m.lock("same")
+			defer rel()
+			n := atomic.AddInt32(&active, 1)
+			for {
+				old := atomic.LoadInt32(&maxActive)
+				if n <= old || atomic.CompareAndSwapInt32(&maxActive, old, n) {
+					break
+				}
+			}
+			time.Sleep(time.Millisecond)
+			atomic.AddInt32(&active, -1)
+		}()
+	}
+	wg.Wait()
+
+	if maxActive != 1 {
+		t.Fatalf("max concurrent holders of one key = %d, want 1 (issue #714 keyed mutex must be exclusive per key)", maxActive)
+	}
+}
+
+// TestCellLockManager_DifferentKeysDoNotSerialize asserts that holding one key
+// never blocks acquisition of a different key — the lock must be per-cell, not
+// global (issue #714 acceptance criterion).
+func TestCellLockManager_DifferentKeysDoNotSerialize(t *testing.T) {
+	m := newCellLockManager()
+
+	relA := m.lock("a")
+	defer relA()
+
+	done := make(chan struct{})
+	go func() {
+		relB := m.lock("b")
+		relB()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("acquiring a second key blocked while a different key was held; the lock must not serialize unrelated cells (issue #714)")
+	}
+}
+
+// TestCellLockManager_ReclaimsIdleEntries asserts the entry map does not grow
+// unbounded: an entry is dropped once its last holder releases.
+func TestCellLockManager_ReclaimsIdleEntries(t *testing.T) {
+	m := newCellLockManager()
+
+	rel := m.lock("k")
+	rel()
+
+	m.mu.Lock()
+	n := len(m.locks)
+	m.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("locks map size = %d after the only holder released, want 0 (entries must be reclaimed)", n)
+	}
+}
+
+// TestCellLockKey_DistinguishesIdentity asserts the key folds the full
+// realm/space/stack/cell identity: any single differing component yields a
+// distinct key, and identical identities collide.
+func TestCellLockKey_DistinguishesIdentity(t *testing.T) {
+	base := func() intmodel.Cell {
+		return intmodel.Cell{
+			Metadata: intmodel.CellMetadata{Name: "cell"},
+			Spec:     intmodel.CellSpec{RealmName: "realm", SpaceName: "space", StackName: "stack"},
+		}
+	}
+
+	if cellLockKey(base()) != cellLockKey(base()) {
+		t.Fatal("identical cell identities must produce the same lock key")
+	}
+
+	mutations := map[string]func(*intmodel.Cell){
+		"realm": func(c *intmodel.Cell) { c.Spec.RealmName = "other" },
+		"space": func(c *intmodel.Cell) { c.Spec.SpaceName = "other" },
+		"stack": func(c *intmodel.Cell) { c.Spec.StackName = "other" },
+		"name":  func(c *intmodel.Cell) { c.Metadata.Name = "other" },
+	}
+	baseKey := cellLockKey(base())
+	for field, mutate := range mutations {
+		c := base()
+		mutate(&c)
+		if cellLockKey(c) == baseKey {
+			t.Errorf("changing %s did not change the lock key; distinct cells must not collide", field)
+		}
+	}
+}
+
+// gateExistsContainer builds an existsContainerFn that signals each gate entry
+// on entered (non-blocking) and then parks the caller until release is closed.
+// Because the first ExistsContainer call in a given lifecycle op parks here, a
+// single op contributes exactly one entered signal before blocking — so the
+// number of signals received equals the number of ops that ran their
+// containerd-touching span concurrently.
+func gateExistsContainer(entered chan struct{}, release chan struct{}) func(string, string) (bool, error) {
+	return func(string, string) (bool, error) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release
+		return false, nil
+	}
+}
+
+func oneContainerCell(realm, space, stack, name string) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: name},
+		Spec: intmodel.CellSpec{
+			ID:        name,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+			Containers: []intmodel.ContainerSpec{
+				{ID: "workload", ContainerdID: space + "_" + stack + "_" + name + "_workload", Root: false},
+			},
+		},
+	}
+}
+
+// TestCellLifecycleLock_StartCellWaitsForReconcile drives a concurrent
+// ReconcileCell + StartCell on the same cell and asserts they cannot interleave
+// their containerd/CNI side-effect spans: while ReconcileCell holds the per-cell
+// lock (parked in ExistsContainer), StartCell must block at lock acquisition and
+// only proceed once ReconcileCell releases. This is the headline #714 guard —
+// without the lock the two ops race teardown against the same root container ID
+// and IPAM file.
+func TestCellLifecycleLock_StartCellWaitsForReconcile(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	fake := &deleteCellFakeClient{existsContainerFn: gateExistsContainer(entered, release)}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	// The cell metadata is deliberately NOT seeded: ReconcileCell reaches the
+	// gated ExistsContainer off the in-memory cell arg (it needs only the
+	// realm), while StartCell fails fast at its early GetCell (a filesystem
+	// read, not gated) the moment it acquires the lock. That makes "StartCell
+	// returned" a clean signal that it got past lock acquisition — without the
+	// lock it would return near-instantly rather than waiting on ReconcileCell.
+
+	cell := oneContainerCell(realm, space, stack, cellName)
+
+	// G1: ReconcileCell acquires the per-cell lock, then parks in the gated
+	// ExistsContainer while still holding it.
+	recDone := make(chan struct{})
+	go func() {
+		_, _, _ = r.ReconcileCell(cell)
+		close(recDone)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ReconcileCell never reached the ExistsContainer gate; cannot exercise the lock")
+	}
+
+	// G2: StartCell on the same cell must block on the per-cell lock G1 holds.
+	startDone := make(chan struct{})
+	go func() {
+		_, _ = r.StartCell(cell)
+		close(startDone)
+	}()
+
+	select {
+	case <-startDone:
+		t.Fatal("StartCell returned while ReconcileCell held the per-cell lifecycle lock; same-cell lifecycle ops were not serialized (issue #714)")
+	case <-time.After(300 * time.Millisecond):
+		// Expected: StartCell is parked at lock acquisition.
+	}
+
+	close(release) // ReconcileCell finishes and drops the lock.
+
+	select {
+	case <-startDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("StartCell did not proceed after ReconcileCell released the per-cell lock; the lock was not handed off")
+	}
+	<-recDone
+}
+
+// TestCellLifecycleLock_DifferentCellsRunConcurrently is the per-cell-keying
+// counterpart: two ReconcileCell ops on distinct cells must run their
+// side-effect spans concurrently. Both reach the gate while neither has
+// released, so two entry signals arrive — a global lock would admit only one.
+func TestCellLifecycleLock_DifferentCellsRunConcurrently(t *testing.T) {
+	realm, space, stack := "default", "kukeon", "kukeon"
+
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	fake := &deleteCellFakeClient{existsContainerFn: gateExistsContainer(entered, release)}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	seedDeleteCellCell(t, r, realm, space, stack, "web-a")
+	seedDeleteCellCell(t, r, realm, space, stack, "web-b")
+
+	cellA := oneContainerCell(realm, space, stack, "web-a")
+	cellB := oneContainerCell(realm, space, stack, "web-b")
+
+	doneA := make(chan struct{})
+	doneB := make(chan struct{})
+	go func() { _, _, _ = r.ReconcileCell(cellA); close(doneA) }()
+	go func() { _, _, _ = r.ReconcileCell(cellB); close(doneB) }()
+
+	for range 2 {
+		select {
+		case <-entered:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected both ReconcileCell ops on distinct cells to enter their side-effect span concurrently; the per-cell lock must not serialize unrelated cells (issue #714)")
+		}
+	}
+
+	close(release)
+	<-doneA
+	<-doneB
+}

--- a/internal/controller/runner/create_cell.go
+++ b/internal/controller/runner/create_cell.go
@@ -27,6 +27,8 @@ import (
 )
 
 func (r *Exec) CreateCell(cell intmodel.Cell) (intmodel.Cell, error) {
+	defer r.lockCell(cell)()
+
 	if err := r.ensureClientConnected(); err != nil {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}

--- a/internal/controller/runner/delete_cell.go
+++ b/internal/controller/runner/delete_cell.go
@@ -31,6 +31,15 @@ import (
 )
 
 func (r *Exec) DeleteCell(cell intmodel.Cell) error {
+	defer r.lockCell(cell)()
+	return r.deleteCellLocked(cell)
+}
+
+// deleteCellLocked is the body of DeleteCell. The caller must hold the per-cell
+// lifecycle lock (the DeleteCell wrapper, or a nesting op such as ReconcileCell's
+// auto-delete or PurgeCell that already holds it). It must not be called without
+// the lock held.
+func (r *Exec) deleteCellLocked(cell intmodel.Cell) error {
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
 		return errdefs.ErrCellNameRequired

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -29,6 +29,15 @@ import (
 // KillCell immediately force-kills all containers in a cell (workload containers first, then root container).
 // It detaches the root container from the CNI network before killing it.
 func (r *Exec) KillCell(cell intmodel.Cell) (intmodel.Cell, error) {
+	defer r.lockCell(cell)()
+	return r.killCellLocked(cell)
+}
+
+// killCellLocked is the body of KillCell. The caller must hold the per-cell
+// lifecycle lock (the KillCell wrapper, or a nesting op such as StartCell's
+// failure cleanup or ReconcileCell's wind-down/auto-delete that already holds
+// it). It must not be called without the lock held.
+func (r *Exec) killCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
 		return intmodel.Cell{}, errdefs.ErrCellNameRequired

--- a/internal/controller/runner/purge_cell.go
+++ b/internal/controller/runner/purge_cell.go
@@ -31,6 +31,8 @@ import (
 
 // PurgeCell performs comprehensive cleanup of a cell, including CNI resources and orphaned containers.
 func (r *Exec) PurgeCell(cell intmodel.Cell) error {
+	defer r.lockCell(cell)()
+
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
 		return errdefs.ErrCellNameRequired
@@ -49,7 +51,7 @@ func (r *Exec) PurgeCell(cell intmodel.Cell) error {
 	}
 
 	// First, perform standard delete
-	if err := r.DeleteCell(cell); err != nil {
+	if err := r.deleteCellLocked(cell); err != nil {
 		// Log but continue with purge even if delete fails
 		r.logger.WarnContext(r.ctx, "delete failed, continuing with purge", "error", err)
 	}

--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -30,6 +30,8 @@ import (
 // with the new root container spec. This is used when the root container spec changes
 // (image, command, or args).
 func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
+	defer r.lockCell(desired)()
+
 	// Get existing cell
 	existing, err := r.GetCell(desired)
 	if err != nil {
@@ -37,7 +39,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	}
 
 	// Stop all containers in the cell
-	_, stopErr := r.StopCell(existing)
+	_, stopErr := r.stopCellLocked(existing)
 	if stopErr != nil {
 		r.logger.WarnContext(
 			r.ctx,
@@ -191,7 +193,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	// apply/reconcile.go (CreateCell -> StartCell). StartCell starts the tasks,
 	// runs CNI ADD against the deterministic root ID, and stamps + persists Ready
 	// only once the cell is actually up.
-	started, startErr := r.StartCell(desired)
+	started, startErr := r.startCellLocked(desired)
 	if startErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to start recreated cell: %w", startErr)
 	}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -630,6 +630,8 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 // per-pass `Errors` slice records them and the cell is preserved for
 // retry on the next tick (best-effort, like the watcher it replaces).
 func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcome, error) {
+	defer r.lockCell(cell)()
+
 	originalStatus := cell.Status
 
 	// CellStateFailed is terminal (issue #407): once a cell has been marked
@@ -744,7 +746,7 @@ func (r *Exec) windDownCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcome
 		"stack", cell.Spec.StackName,
 		"state", cell.Status.State)
 
-	updatedCell, err := r.KillCell(cell)
+	updatedCell, err := r.killCellLocked(cell)
 	if err != nil {
 		return cell, ReconcileOutcome{}, fmt.Errorf("wind-down: kill cell: %w", err)
 	}
@@ -766,10 +768,10 @@ func (r *Exec) autoDeleteCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutco
 		"stack", cell.Spec.StackName,
 		"state", cell.Status.State)
 
-	if _, err := r.KillCell(cell); err != nil {
+	if _, err := r.killCellLocked(cell); err != nil {
 		return cell, ReconcileOutcome{}, fmt.Errorf("auto-delete: kill cell: %w", err)
 	}
-	if err := r.DeleteCell(cell); err != nil {
+	if err := r.deleteCellLocked(cell); err != nil {
 		return cell, ReconcileOutcome{}, fmt.Errorf("auto-delete: delete cell: %w", err)
 	}
 	return cell, ReconcileOutcome{Deleted: true}, nil

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -212,6 +212,14 @@ type Exec struct {
 	// to freeze the clock override the function via the runner_test
 	// hook (see metadata_test.go).
 	nowFn func() time.Time
+
+	// cellLocks serializes the containerd+CNI side-effect span of the cell
+	// lifecycle ops against each other on the same cell (issue #714). Keyed
+	// per realm/space/stack/cell so unrelated cells never serialize. Lazily
+	// built via cellLocksOnce so *Exec values constructed directly in tests
+	// (not via NewRunner) share the same lock semantics.
+	cellLocks     *cellLockManager
+	cellLocksOnce sync.Once
 }
 
 type Options struct {

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -257,7 +257,7 @@ func (r *Exec) markCellFailed(cell intmodel.Cell, reason string, cause error) {
 			"cell", cellName, "cause", cause.Error(), "error", preStampErr.Error())
 	}
 
-	if _, killErr := r.KillCell(cell); killErr != nil {
+	if _, killErr := r.killCellLocked(cell); killErr != nil {
 		r.logger.WarnContext(r.ctx,
 			"failed to kill siblings while transitioning cell to Failed",
 			"cell", cellName, "cause", cause.Error(), "error", killErr.Error())
@@ -294,7 +294,15 @@ func (r *Exec) markCellFailed(cell intmodel.Cell, reason string, cause error) {
 // any containers that did start are killed — issue #407. Errors raised before
 // the provisioning phase (input validation, realm lookup, idempotent-skip
 // path) leave the cell's persisted state alone.
-func (r *Exec) StartCell(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
+func (r *Exec) StartCell(cell intmodel.Cell) (intmodel.Cell, error) {
+	defer r.lockCell(cell)()
+	return r.startCellLocked(cell)
+}
+
+// startCellLocked is the body of StartCell. The caller must hold the per-cell
+// lifecycle lock (the StartCell wrapper, or a nesting op such as RecreateCell
+// that already holds it). It must not be called without the lock held.
+func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr error) {
 	// provisionStarted gates the defer below: only flip the cell to Failed
 	// when we've already entered the destructive recreate path. Validation
 	// errors (missing cell name, missing realm) and the idempotent-skip

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -32,6 +32,14 @@ import (
 // is still valid. If detachment fails or the container is already stopped, fallback cleanup removes
 // IPAM allocations directly.
 func (r *Exec) StopCell(cell intmodel.Cell) (intmodel.Cell, error) {
+	defer r.lockCell(cell)()
+	return r.stopCellLocked(cell)
+}
+
+// stopCellLocked is the body of StopCell. The caller must hold the per-cell
+// lifecycle lock (the StopCell wrapper, or a nesting op such as RecreateCell
+// that already holds it). It must not be called without the lock held.
+func (r *Exec) stopCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
 		return intmodel.Cell{}, errdefs.ErrCellNameRequired


### PR DESCRIPTION
## Summary
- Adds a per-cell keyed mutex (`cellLockManager`, keyed by realm/space/stack/cell) on `Exec` and holds it across the containerd+CNI side-effect span of every cell lifecycle op: `StartCell`, `StopCell`, `KillCell`, `DeleteCell`, `RecreateCell`, `CreateCell`, `PurgeCell`, and `ReconcileCell`. This closes the window (issue #714) where a gRPC handler and the reconcile-loop tick could run teardown concurrently against the same root container ID and IPAM file. The metadata flock + generation-token CAS guard only the on-disk document, not the containerd/CNI mutations — this lock covers the mutation span.
- Keys are independent, so unrelated cells never serialize against one another (per-cell, not global).
- The lock is non-reentrant, but several lifecycle ops nest others (`RecreateCell`→`StopCell`/`StartCell`, `StartCell` failure-cleanup→`KillCell`, `ReconcileCell` wind-down/auto-delete→`KillCell`/`DeleteCell`, `PurgeCell`→`DeleteCell`). To avoid self-deadlock, each nested-callee public method (`Start`/`Stop`/`Kill`/`Delete`) is split into a thin locking wrapper plus an unexported `*Locked` body; the outermost op acquires the lock once and nested calls route to the `*Locked` variants. The four top-level-only ops (`Create`/`Recreate`/`Reconcile`/`Purge`) acquire the lock at entry and call the `*Locked` variants internally.
- The lock manager is ref-counted: an entry is dropped from the map once its last holder releases, so the map cannot grow unbounded over the daemon's lifetime. It is lazily initialized via `sync.Once` so `*Exec` values built directly in tests (not via `NewRunner`) share the same serialization without extra fixture wiring.

## Implementation notes (for reviewer)
- **Scope beyond the AC's named handlers:** the AC enumerates `StartCell`/`StopCell`/`KillCell`/`DeleteCell`/`RecreateCell` + `ReconcileCell`. I also locked `CreateCell` and `PurgeCell` because both touch containerd/CNI on the same cell and would otherwise race the locked ops — consistent with the AC's "every lifecycle op" intent. Push back if you'd rather scope them out.
- The negative test was verified by hand: with the `StartCell` lock disabled, `TestCellLifecycleLock_StartCellWaitsForReconcile` fails (StartCell returns while ReconcileCell holds the lock); with it restored, it passes.

## Test plan
- [x] `make test` (full CI target; 93 packages green, GOWORK=off)
- [x] `go build ./...` and `go vet ./internal/controller/runner/...`
- [x] New unit tests on the keyed mutex (`TestCellLockManager_*`, `TestCellLockKey_*`): same-key mutual exclusion, different-key concurrency, idle-entry reclaim, identity-folding.
- [x] New concurrency tests on the wired methods: `TestCellLifecycleLock_StartCellWaitsForReconcile` (same-cell StartCell + ReconcileCell cannot interleave — AC #1) and `TestCellLifecycleLock_DifferentCellsRunConcurrently` (distinct cells run concurrently — AC #2).
- [x] Negative verification: same-cell test fails with the lock removed, passes with it restored.
- [x] `make dev-init` smoke (nested mode): full re-bootstrap green, attach smoke clean, parent attach plumbing intact, and the daemon-parity guard (`kuke get realms` vs `--no-daemon`) shows identical Ready output for both realms.

Closes #714