### PR TITLE
docs(setupstatus): correct Stage.Index docstring to OnInit-list position

### DIFF
--- a/internal/kuketty/setupstatus/setupstatus.go
+++ b/internal/kuketty/setupstatus/setupstatus.go
@@ -90,10 +90,10 @@ const (
 // Stage is the resolved state of a single runOn: create TtyStage after
 // kuketty's pre-Serve execution. Field set mirrors
 // api/model/v1beta1.StageStatus so the daemon can map it straight into
-// ContainerStatus.Stages. Index is the stage's 0-based position among the
-// container's create stages, in declaration order — the stable identity phase
-// A (#635) carries through (the run-once "done" key is settled in phase C,
-// #690).
+// ContainerStatus.Stages. Index is the stage's 0-based position within the
+// container's full Tty.OnInit list (not its position among create stages
+// alone), in declaration order — the stable identity phase A (#635) carries
+// through (the run-once "done" key is settled in phase C, #690).
 type Stage struct {
 	Index int `json:"index"`
 	// State is one of StageDone or StageFailed.


### PR DESCRIPTION
## Summary
- `setupstatus.Stage.Index` was documented as the stage's "0-based position among the container's create stages", but `createStages` (`cmd/kuketty/spec.go:254-256`) assigns `Index: i` from the full `Tty.OnInit` range — so a create stage preceded by a start (or absent-RunOn) stage reports its OnInit position, not its create-stage position. Reworded the docstring to "0-based position within the container's full `Tty.OnInit` list (not its position among create stages alone)".
- Documentation-only change at one site; the `indexedStage` docstring in `spec.go:262-264` already describes the OnInit-slice position correctly. Code behavior is unchanged. This matters for phase C (#690), which keys the run-once "done" identity on `Index`.

## Test plan
- [x] `GOWORK=off go build ./internal/kuketty/setupstatus/... ./cmd/kuketty/...` (exit 0)
- [ ] `make test` — not run; docstring-only change touches no executable code, test, or behavior text (trivial-edit shortcut).

Closes #720