### PR TITLE
fix: issue best-effort CNI DEL when root task is already dead

### DIFF
--- a/internal/controller/runner/detach_network_test.go
+++ b/internal/controller/runner/detach_network_test.go
@@ -1,0 +1,164 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.detachRootContainerFromNetwork and its netns helper (unexported)
+package runner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// deadTaskContainer is a near-empty containerd.Container whose Task() reports
+// the post-reboot / OOM signature: the container record survives but its task
+// is gone. It models the exact dead-task path issue #715 cares about — distinct
+// from an absent container record (GetContainer error), which deleteCellFakeClient
+// already produces. Only Task() carries behavior; every other method returns a
+// zero value because rootContainerNetnsPath never calls them.
+type deadTaskContainer struct {
+	containerd.Container
+}
+
+func (c deadTaskContainer) Task(context.Context, cio.Attach) (containerd.Task, error) {
+	return nil, fmt.Errorf("%w: %w", errdefs.ErrTaskNotFound, errArtificialDeadTask)
+}
+
+var errArtificialDeadTask = fmt.Errorf("task: not found")
+
+// deadTaskClient returns a live container record whose task is gone, driving
+// rootContainerNetnsPath down its taskErr branch.
+type deadTaskClient struct {
+	deleteCellFakeClient
+}
+
+func (c *deadTaskClient) GetContainer(string, string) (containerd.Container, error) {
+	return deadTaskContainer{}, nil
+}
+
+// TestRootContainerNetnsPath_EmptyOnDeadOrAbsentTask pins the precondition the
+// #715 fix relies on: when the root task is dead (record present, task gone) or
+// the container record is absent, the resolved netns is "" — the input
+// detachRootContainerFromNetwork now issues a best-effort CNI DEL with, rather
+// than skipping the release entirely.
+func TestRootContainerNetnsPath_EmptyOnDeadOrAbsentTask(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("absent container record", func(t *testing.T) {
+		r := &Exec{ctx: context.Background(), logger: logger, ctrClient: &deleteCellFakeClient{}}
+		if got := r.rootContainerNetnsPath("default.kukeon.io", "root"); got != "" {
+			t.Errorf("rootContainerNetnsPath = %q, want \"\" when GetContainer fails", got)
+		}
+	})
+
+	t.Run("dead task on a surviving record", func(t *testing.T) {
+		r := &Exec{ctx: context.Background(), logger: logger, ctrClient: &deadTaskClient{}}
+		if got := r.rootContainerNetnsPath("default.kukeon.io", "root"); got != "" {
+			t.Errorf("rootContainerNetnsPath = %q, want \"\" when Task() reports the task is gone", got)
+		}
+	})
+}
+
+// writeFakeCNIPlugin drops an executable CNI plugin under binDir named
+// pluginType. On a DEL invocation it removes <storeDir>/<CNI_CONTAINERID>,
+// emulating a host-local IPAM release so a test can assert the reservation was
+// freed; VERSION returns the supported set libcni probes for; every other
+// command exits 0 with a minimal valid result. Using a self-provided fake
+// keeps the test independent of real /opt/cni/bin plugins (CI-safe) — the
+// same reason internal/cni/container_test.go avoids loaded-config plugin runs.
+func writeFakeCNIPlugin(t *testing.T, binDir, pluginType, storeDir string) {
+	t.Helper()
+	script := fmt.Sprintf(`#!/bin/sh
+case "$CNI_COMMAND" in
+  DEL) rm -f "%s/$CNI_CONTAINERID"; exit 0 ;;
+  VERSION) echo '{"cniVersion":"1.0.0","supportedVersions":["0.1.0","0.2.0","0.3.0","0.3.1","0.4.0","1.0.0"]}'; exit 0 ;;
+  *) echo '{"cniVersion":"0.4.0"}'; exit 0 ;;
+esac
+`, storeDir)
+	path := filepath.Join(binDir, pluginType)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil { //nolint:gosec // test-only executable fake plugin
+		t.Fatalf("write fake CNI plugin: %v", err)
+	}
+}
+
+// TestDetachRootContainerFromNetwork_DeadTaskReleasesReservation is the headline
+// #715 guard: a cell whose root task has already exited must still have its
+// CNI/IPAM reservation released on stop/kill. The old nested live-task / PID>0
+// guard made the dead-task path a silent no-op, so the clean plugin-chain DEL
+// never ran and only the post-delete file-purge safety net released the IPAM
+// file. Here the root task is absent (netns resolves to ""), and the fake
+// host-local-style plugin releases the reservation from a temp store on DEL —
+// asserting the release proves detach now issues CNI DEL even with an empty
+// netns.
+func TestDetachRootContainerFromNetwork_DeadTaskReleasesReservation(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	confDir := filepath.Join(tmp, "conf")
+	cacheDir := filepath.Join(tmp, "cache")
+	storeDir := filepath.Join(tmp, "store") // stand-in for the host-local store
+	for _, d := range []string{binDir, confDir, cacheDir, storeDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	const (
+		containerID = "kukeon_kukeon_web_root"
+		pluginType  = "kukeon-test-cni"
+	)
+
+	// Seed the reservation as the start-time CNI ADD would have left it.
+	reservation := filepath.Join(storeDir, containerID)
+	if err := os.WriteFile(reservation, []byte("10.88.0.5"), 0o600); err != nil {
+		t.Fatalf("seed reservation: %v", err)
+	}
+
+	writeFakeCNIPlugin(t, binDir, pluginType, storeDir)
+
+	confPath := filepath.Join(confDir, "kukeon-test.conflist")
+	conflist := fmt.Sprintf(`{"cniVersion":"0.4.0","name":"kukeon-test","plugins":[{"type":"%s"}]}`, pluginType)
+	if err := os.WriteFile(confPath, []byte(conflist), 0o600); err != nil {
+		t.Fatalf("write conflist: %v", err)
+	}
+
+	// Dead/absent root task: GetContainer fails, so the resolved netns is "".
+	r := &Exec{
+		ctx:       context.Background(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctrClient: &deleteCellFakeClient{},
+		cniConf:   &cni.Conf{CniBinDir: binDir, CniConfigDir: confDir, CniCacheDir: cacheDir},
+	}
+
+	r.detachRootContainerFromNetwork(containerID, confPath, "default.kukeon.io", "web", "web", "kukeon", "default")
+
+	if _, err := os.Stat(reservation); !os.IsNotExist(err) {
+		t.Fatalf(
+			"reservation %s not released on the dead-task path (stat err=%v); CNI DEL was not issued with an empty netns",
+			reservation, err,
+		)
+	}
+}

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -493,63 +493,70 @@ func (r *Exec) buildRootCNINetworkName(realmName, spaceName string) string {
 }
 
 // detachRootContainerFromNetwork detaches a root container from the CNI network.
-// It gets the container's PID and network namespace path, then calls CNI DEL to detach it.
-// This should be called before killing or stopping the container to ensure the namespace is still valid.
+// It resolves the root task's network namespace and calls CNI DEL to detach it.
+// This should be called before killing or stopping the container so a live netns
+// is used when one exists.
+//
+// The CNI DEL is issued unconditionally — with an empty netns when the root task
+// is already dead or absent (OOM, crash, host reboot left the container record
+// but no task). Previously the whole DEL was nested behind a live-task / PID>0
+// guard, so the dead-task path was a silent no-op and the clean plugin-chain
+// release never ran; only the post-delete IP-file purge safety net did (#715,
+// the clean-DEL residual of the file-purge fix #708). host-local IPAM DEL keys
+// off the container ID and tolerates a missing netns, and chained plugins are
+// required by the CNI spec to complete DEL without error when their resources
+// are already gone — so a best-effort empty-netns DEL still releases the
+// reservation rather than leaking it.
 func (r *Exec) detachRootContainerFromNetwork(
 	rootContainerID, cniConfigPath, namespace, cellID, cellName, spaceID, realmID string,
 ) {
-	var netnsPath string
-	rootContainer, err := r.ctrClient.GetContainer(namespace, rootContainerID)
-	if err == nil {
-		nsCtx := namespaces.WithNamespace(r.ctx, namespace)
-		rootTask, taskErr := rootContainer.Task(nsCtx, nil)
-		if taskErr == nil {
-			rootPID := rootTask.Pid()
-			if rootPID > 0 {
-				netnsPath = fmt.Sprintf("/proc/%d/ns/net", rootPID)
+	netnsPath := r.rootContainerNetnsPath(namespace, rootContainerID)
 
-				// Detach root container from CNI network BEFORE killing/stopping
-				// This ensures the namespace is still valid
-				cniMgr, mgrErr := cni.NewManager(
-					r.cniConf.CniBinDir,
-					r.cniConf.CniConfigDir,
-					r.cniConf.CniCacheDir,
-				)
-				if mgrErr == nil {
-					if loadErr := cniMgr.LoadNetworkConfigList(cniConfigPath); loadErr == nil {
-						if delErr := cniMgr.DelContainerFromNetwork(r.ctx, rootContainerID, netnsPath); delErr != nil {
-							// Log warning but continue - will try comprehensive cleanup after deletion
-							fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
-							fields = append(
-								fields,
-								"space",
-								spaceID,
-								"realm",
-								realmID,
-								"netns",
-								netnsPath,
-								"err",
-								fmt.Sprintf("%v", delErr),
-							)
-							r.logger.WarnContext(
-								r.ctx,
-								"failed to detach root container from network, will try comprehensive cleanup after deletion",
-								fields...,
-							)
-						} else {
-							fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
-							fields = append(fields, "space", spaceID, "realm", realmID, "netns", netnsPath)
-							r.logger.InfoContext(
-								r.ctx,
-								"detached root container from network",
-								fields...,
-							)
-						}
-					}
-				}
-			}
-		}
+	cniMgr, mgrErr := cni.NewManager(
+		r.cniConf.CniBinDir,
+		r.cniConf.CniConfigDir,
+		r.cniConf.CniCacheDir,
+	)
+	if mgrErr != nil {
+		return
 	}
+	if loadErr := cniMgr.LoadNetworkConfigList(cniConfigPath); loadErr != nil {
+		return
+	}
+
+	fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
+	fields = append(fields, "space", spaceID, "realm", realmID, "netns", netnsPath)
+	if delErr := cniMgr.DelContainerFromNetwork(r.ctx, rootContainerID, netnsPath); delErr != nil {
+		// Log warning but continue - will try comprehensive cleanup after deletion
+		fields = append(fields, "err", fmt.Sprintf("%v", delErr))
+		r.logger.WarnContext(
+			r.ctx,
+			"failed to detach root container from network, will try comprehensive cleanup after deletion",
+			fields...,
+		)
+		return
+	}
+	r.logger.InfoContext(r.ctx, "detached root container from network", fields...)
+}
+
+// rootContainerNetnsPath resolves the network-namespace path of a cell's root
+// task, or "" when the container record is absent, its task is already dead, or
+// the PID is unset. The "" cases are the dead/absent-task path detachRootContainerFromNetwork
+// still issues a best-effort CNI DEL on (#715).
+func (r *Exec) rootContainerNetnsPath(namespace, rootContainerID string) string {
+	rootContainer, err := r.ctrClient.GetContainer(namespace, rootContainerID)
+	if err != nil {
+		return ""
+	}
+	nsCtx := namespaces.WithNamespace(r.ctx, namespace)
+	rootTask, taskErr := rootContainer.Task(nsCtx, nil)
+	if taskErr != nil {
+		return ""
+	}
+	if rootPID := rootTask.Pid(); rootPID > 0 {
+		return fmt.Sprintf("/proc/%d/ns/net", rootPID)
+	}
+	return ""
 }
 
 func appendCellLogFields(fields []any, cellID, cellName string) []any {


### PR DESCRIPTION
## Summary
- `detachRootContainerFromNetwork` (`internal/controller/runner/helpers.go`) previously nested the in-netns CNI DEL behind container-exists → task-exists → `rootPID > 0` guards, so when the root task was already dead (OOM, crash, host reboot left the container record but no task) the whole block was a silent no-op and the clean plugin-chain release never ran — only the post-delete IP-file purge safety net did (the clean-DEL residual #708 left behind).
- Restructured so the CNI DEL is issued **unconditionally**, with an empty netns on the dead/absent-task path. `host-local` IPAM DEL keys off the container ID and tolerates a missing netns, and chained plugins are required by the CNI spec to complete DEL without error when their resources are already gone — so a best-effort empty-netns DEL releases the reservation rather than leaking it.
- Extracted the netns resolution into `rootContainerNetnsPath`, which returns `""` for the dead/absent-task cases — a testable seam.

**Design choice (issue offered two options):** took Option A (best-effort CNI DEL on the dead path) over Option B (document the file purge as authoritative and remove the dead branch). Option A is the only one that satisfies the AC's "fully released" requirement: the file-scrub safety net only removes the IPAM allocation file, whereas the plugin-chain DEL also releases any chained-plugin state (portmap/firewall/etc.) and is the proper release path. Option B would have been a behavior reduction.

## Test plan
- [x] `make test` (full CI target: `test-root` + `test-kukebuild`) — pass.
- [x] `go vet ./internal/controller/runner/ ./internal/cni/` — pass.
- [x] New unit test `TestRootContainerNetnsPath_EmptyOnDeadOrAbsentTask` — covers both the absent-record (`GetContainer` error) and dead-task (`Task()` reports gone) branches resolving to `""`.
- [x] New test `TestDetachRootContainerFromNetwork_DeadTaskReleasesReservation` — **the AC against a temp host-local store**: seeds a reservation in a temp store dir, runs detach on the dead-task path (netns `""`), and asserts a self-provided fake `host-local`-style CNI plugin releases the reservation on DEL. Uses a fake plugin script (not real `/opt/cni/bin`) so the test is CI-safe and deterministic, matching the precedent in `internal/cni/container_test.go` that loaded-config plugin runs are otherwise integration-only. Confirmed it fails without the fix (DEL is never issued on the dead path).
- [x] `make dev-init` smoke test — daemon-parity check identical for `kuke get realms` and `--no-daemon`; the attach/purge smoke (which exercises CNI teardown/release paths) completed cleanly.

Closes #715