### PR TITLE
feat: add kuke get/delete blueprint verbs (phase 4.1.2)

### DIFF
--- a/cmd/config/autocomplete.go
+++ b/cmd/config/autocomplete.go
@@ -589,6 +589,63 @@ func CompleteSecretNames(cmd *cobra.Command, args []string, toComplete string) (
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
+// CompleteBlueprintNames provides shell completion for blueprint name args by
+// listing every CellBlueprint visible in the active scope filter (issue #643).
+// A Blueprint is never cell-scoped, so the filter bottoms out at stack. Errors
+// swallow to an empty list so a down daemon never surfaces a noisy completion.
+func CompleteBlueprintNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) >= 1 && toComplete == "" {
+		if cmd.ValidArgsFunction != nil {
+			testArgs := make([]string, len(args), len(args)+1)
+			copy(testArgs, args)
+			testArgs = append(testArgs, "test")
+			if cmd.Args != nil {
+				if err := cmd.Args(cmd, testArgs); err != nil {
+					return []string{}, cobra.ShellCompDirectiveNoFileComp
+				}
+			}
+		}
+	}
+
+	client, err := completionClient(cmd)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer func() { _ = client.Close() }()
+
+	realmName := getFlagValueWithDefault(cmd, "realm", "default")
+	spaceName := getFlagValueWithDefault(cmd, "space", "")
+	stackName := getFlagValueWithDefault(cmd, "stack", "")
+
+	if cmd.ValidArgsFunction != nil && len(args) == 0 {
+		if realmName == "" {
+			return []string{}, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
+	blueprints, err := client.ListBlueprints(ctx, realmName, spaceName, stackName)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	seen := make(map[string]bool)
+	names := make([]string, 0, len(blueprints))
+	for _, bp := range blueprints {
+		name := bp.Metadata.Name
+		if toComplete == "" || strings.HasPrefix(name, toComplete) {
+			if !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
 // CompleteProfileNames provides shell completion for `-p/--profile` by listing
 // every CellProfile under the active profiles directory ($KUKE_PROFILES_DIR or
 // $HOME/.kuke/profiles.d). Errors swallow to an empty list — a fresh shell with

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -319,6 +319,14 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_SECRET_CELL = DefineKV("KUKE_GET_SECRET_CELL", "kuke/get/secret/cell")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_BLUEPRINT_NAME = DefineKV("KUKE_GET_BLUEPRINT_NAME", "kuke/get/blueprint/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_BLUEPRINT_REALM = DefineKV("KUKE_GET_BLUEPRINT_REALM", "kuke/get/blueprint/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_BLUEPRINT_SPACE = DefineKV("KUKE_GET_BLUEPRINT_SPACE", "kuke/get/blueprint/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_BLUEPRINT_STACK = DefineKV("KUKE_GET_BLUEPRINT_STACK", "kuke/get/blueprint/stack")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_OUTPUT = DefineKV("KUKE_GET_OUTPUT", "kuke/get/output")
 
 	// Delete command variables
@@ -362,6 +370,14 @@ var (
 	KUKE_DELETE_SECRET_STACK = DefineKV("KUKE_DELETE_SECRET_STACK", "kuke/delete/secret/stack")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DELETE_SECRET_CELL = DefineKV("KUKE_DELETE_SECRET_CELL", "kuke/delete/secret/cell")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_BLUEPRINT_NAME = DefineKV("KUKE_DELETE_BLUEPRINT_NAME", "kuke/delete/blueprint/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_BLUEPRINT_REALM = DefineKV("KUKE_DELETE_BLUEPRINT_REALM", "kuke/delete/blueprint/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_BLUEPRINT_SPACE = DefineKV("KUKE_DELETE_BLUEPRINT_SPACE", "kuke/delete/blueprint/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_BLUEPRINT_STACK = DefineKV("KUKE_DELETE_BLUEPRINT_STACK", "kuke/delete/blueprint/stack")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DELETE_FORCE = DefineKV("KUKE_DELETE_FORCE", "kuke/delete/force")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/delete/blueprint/blueprint.go
+++ b/cmd/kuke/delete/blueprint/blueprint.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blueprint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewBlueprintCmd builds `kuke delete blueprint <name>` (issue #643). It removes
+// the daemon-stored document for a single named, scoped CellBlueprint. The
+// blueprint is identified by its name plus its binding scope
+// (--realm/--space/--stack). A Blueprint is never cell-scoped, so there is no
+// --cell flag. Unlike `kuke delete secret` there is no live-reference gate:
+// cells materialized from a blueprint are independent copies (#620).
+func NewBlueprintCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "blueprint [name]",
+		Aliases:       []string{"bp"},
+		Short:         "Delete a kind: CellBlueprint",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+
+			realm := strings.TrimSpace(config.KUKE_DELETE_BLUEPRINT_REALM.ValueOrDefault())
+			space := config.KUKE_DELETE_BLUEPRINT_SPACE.ValueOrDefault()
+			stack := config.KUKE_DELETE_BLUEPRINT_STACK.ValueOrDefault()
+			if realm == "" {
+				return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+			}
+
+			doc := v1beta1.CellBlueprintDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindCellBlueprint,
+				Metadata: v1beta1.CellBlueprintMetadata{
+					Name:  name,
+					Realm: realm,
+					Space: strings.TrimSpace(space),
+					Stack: strings.TrimSpace(stack),
+				},
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			result, err := client.DeleteBlueprint(cmd.Context(), doc)
+			if err != nil {
+				return err
+			}
+
+			blueprintName := name
+			if result.Blueprint.Metadata.Name != "" {
+				blueprintName = result.Blueprint.Metadata.Name
+			}
+			cmd.Printf("Deleted blueprint %q\n", blueprintName)
+			return nil
+		},
+	}
+
+	cmd.Flags().String("realm", "", "Realm the blueprint is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_BLUEPRINT_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Space the blueprint is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_BLUEPRINT_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Stack the blueprint is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_BLUEPRINT_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+
+	cmd.ValidArgsFunction = config.CompleteBlueprintNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+
+	return cmd
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.DaemonClientFromCmd(cmd)
+}

--- a/cmd/kuke/delete/blueprint/blueprint_test.go
+++ b/cmd/kuke/delete/blueprint/blueprint_test.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blueprint_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	blueprint "github.com/eminwux/kukeon/cmd/kuke/delete/blueprint"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestDeleteBlueprint(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func(t *testing.T, cmd *cobra.Command)
+		fake       *fakeClient
+		wantErr    string
+		wantScope  v1beta1.CellBlueprintMetadata
+		wantOutput string
+	}{
+		{
+			name: "success at realm scope",
+			args: []string{"web"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.DeleteBlueprintResult, error) {
+					return kukeonv1.DeleteBlueprintResult{Blueprint: doc, Deleted: true}, nil
+				},
+			},
+			wantScope:  v1beta1.CellBlueprintMetadata{Name: "web", Realm: "r1"},
+			wantOutput: `Deleted blueprint "web"`,
+		},
+		{
+			name: "success at stack scope passes full coordinates",
+			args: []string{"stack-bp"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+				_ = cmd.Flags().Set("space", "s1")
+				_ = cmd.Flags().Set("stack", "st1")
+			},
+			fake: &fakeClient{
+				deleteBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.DeleteBlueprintResult, error) {
+					return kukeonv1.DeleteBlueprintResult{Blueprint: doc, Deleted: true}, nil
+				},
+			},
+			wantScope:  v1beta1.CellBlueprintMetadata{Name: "stack-bp", Realm: "r1", Space: "s1", Stack: "st1"},
+			wantOutput: `Deleted blueprint "stack-bp"`,
+		},
+		{
+			name: "not found surfaces error",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.DeleteBlueprintResult, error) {
+					return kukeonv1.DeleteBlueprintResult{}, errdefs.ErrBlueprintNotFound
+				},
+			},
+			wantErr: "blueprint not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := blueprint.NewBlueprintCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, blueprint.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := tt.fake.gotDoc.Metadata; got.Name != tt.wantScope.Name ||
+				got.Realm != tt.wantScope.Realm ||
+				got.Space != tt.wantScope.Space ||
+				got.Stack != tt.wantScope.Stack {
+				t.Errorf("scope passed = %+v, want %+v", got, tt.wantScope)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	deleteBlueprintFn func(doc v1beta1.CellBlueprintDoc) (kukeonv1.DeleteBlueprintResult, error)
+	gotDoc            v1beta1.CellBlueprintDoc
+}
+
+func (f *fakeClient) DeleteBlueprint(
+	_ context.Context, doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.DeleteBlueprintResult, error) {
+	f.gotDoc = doc
+	if f.deleteBlueprintFn == nil {
+		return kukeonv1.DeleteBlueprintResult{}, errors.New("unexpected DeleteBlueprint call")
+	}
+	return f.deleteBlueprintFn(doc)
+}

--- a/cmd/kuke/delete/delete.go
+++ b/cmd/kuke/delete/delete.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	blueprintdelete "github.com/eminwux/kukeon/cmd/kuke/delete/blueprint"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/cell"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/container"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/realm"
@@ -48,7 +49,7 @@ func NewDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [name]",
 		Aliases: []string{"d"},
-		Short:   "Delete Kukeon resources (realm, space, stack, cell, container, secret)",
+		Short:   "Delete Kukeon resources (realm, space, stack, cell, container, secret, blueprint)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if -f flag is provided
 			file, err := cmd.Flags().GetString("file")
@@ -91,6 +92,7 @@ func NewDeleteCmd() *cobra.Command {
 		cell.NewCellCmd(),
 		container.NewContainerCmd(),
 		secretdelete.NewSecretCmd(),
+		blueprintdelete.NewBlueprintCmd(),
 	)
 
 	return cmd
@@ -98,7 +100,7 @@ func NewDeleteCmd() *cobra.Command {
 
 // completeDeleteSubcommands provides shell completion for delete subcommand names.
 func completeDeleteSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret"}
+	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/delete/delete_test.go
+++ b/cmd/kuke/delete/delete_test.go
@@ -50,7 +50,7 @@ func TestNewDeleteCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Delete Kukeon resources (realm, space, stack, cell, container, secret)"
+				expected := "Delete Kukeon resources (realm, space, stack, cell, container, secret, blueprint)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -207,7 +207,7 @@ func TestNewDeleteCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container", "secret"}
+	expected := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}

--- a/cmd/kuke/get/blueprint/blueprint.go
+++ b/cmd/kuke/get/blueprint/blueprint.go
@@ -1,0 +1,192 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blueprint
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewBlueprintCmd builds `kuke get blueprint(s)` (issue #643). With a name it
+// shows one Blueprint's full document (parameters, slot declarations, cell
+// template); without one it lists every Blueprint bound to the filter scope or
+// any scope nested within it (subtree-filter semantics, matching
+// `kuke get secrets`). A Blueprint is never cell-scoped, so there is no --cell
+// flag — the scope bottoms out at stack.
+func NewBlueprintCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "blueprint [name]",
+		Aliases:       []string{"blueprints", "bp"},
+		Short:         "Get or list kind: CellBlueprint",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			outputFormat, err := shared.ParseOutputFormat(cmd)
+			if err != nil {
+				return err
+			}
+
+			// List filters: an unset flag means "no filter" (ExplicitFlag),
+			// so `kuke get blueprints` with no flags lists the whole subtree.
+			realm := shared.ExplicitFlag(cmd, "realm", config.KUKE_GET_BLUEPRINT_REALM.ViperKey)
+			space := shared.ExplicitFlag(cmd, "space", config.KUKE_GET_BLUEPRINT_SPACE.ViperKey)
+			stack := shared.ExplicitFlag(cmd, "stack", config.KUKE_GET_BLUEPRINT_STACK.ViperKey)
+
+			var name string
+			if len(args) > 0 {
+				name = strings.TrimSpace(args[0])
+			} else {
+				name = strings.TrimSpace(viper.GetString(config.KUKE_GET_BLUEPRINT_NAME.ViperKey))
+			}
+
+			if name != "" {
+				// A single blueprint is identified by its name plus its exact
+				// binding scope. Default the realm to the operator's current
+				// realm; deeper coordinates stay unset unless provided.
+				if realm == "" {
+					realm = strings.TrimSpace(config.KUKE_GET_BLUEPRINT_REALM.ValueOrDefault())
+				}
+				if realm == "" {
+					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+				}
+				lookup := v1beta1.CellBlueprintDoc{
+					APIVersion: v1beta1.APIVersionV1Beta1,
+					Kind:       v1beta1.KindCellBlueprint,
+					Metadata: v1beta1.CellBlueprintMetadata{
+						Name:  name,
+						Realm: realm,
+						Space: space,
+						Stack: stack,
+					},
+				}
+				result, getErr := client.GetBlueprint(cmd.Context(), lookup)
+				if getErr != nil {
+					if errors.Is(getErr, errdefs.ErrBlueprintNotFound) {
+						return fmt.Errorf("blueprint %q not found", name)
+					}
+					return getErr
+				}
+				if !result.MetadataExists {
+					return fmt.Errorf("blueprint %q not found", name)
+				}
+				return printBlueprint(&result.Blueprint, outputFormat)
+			}
+
+			blueprints, err := client.ListBlueprints(cmd.Context(), realm, space, stack)
+			if err != nil {
+				return err
+			}
+			return printBlueprints(cmd, blueprints, outputFormat)
+		},
+	}
+
+	cmd.Flags().String("realm", "", "Filter blueprints by realm name")
+	_ = viper.BindPFlag(config.KUKE_GET_BLUEPRINT_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Filter blueprints by space name")
+	_ = viper.BindPFlag(config.KUKE_GET_BLUEPRINT_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Filter blueprints by stack name")
+	_ = viper.BindPFlag(config.KUKE_GET_BLUEPRINT_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+	cmd.Flags().
+		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
+	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+
+	cmd.ValidArgsFunction = config.CompleteBlueprintNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("output", config.CompleteOutputFormat)
+	_ = cmd.RegisterFlagCompletionFunc("o", config.CompleteOutputFormat)
+
+	return cmd
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.ClientFromCmd(cmd)
+}
+
+func printBlueprint(blueprint *v1beta1.CellBlueprintDoc, format shared.OutputFormat) error {
+	switch format {
+	case shared.OutputFormatJSON:
+		return shared.PrintJSON(blueprint)
+	case shared.OutputFormatYAML, shared.OutputFormatTable:
+		return shared.PrintYAML(blueprint)
+	default:
+		return shared.PrintYAML(blueprint)
+	}
+}
+
+func printBlueprints(cmd *cobra.Command, blueprints []v1beta1.CellBlueprintDoc, format shared.OutputFormat) error {
+	switch format {
+	case shared.OutputFormatYAML:
+		return shared.PrintYAML(blueprints)
+	case shared.OutputFormatJSON:
+		return shared.PrintJSON(blueprints)
+	case shared.OutputFormatTable:
+		if len(blueprints) == 0 {
+			cmd.Println("No blueprints found.")
+			return nil
+		}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK"}
+		rows := make([][]string, 0, len(blueprints))
+		for i := range blueprints {
+			b := &blueprints[i]
+			rows = append(rows, []string{
+				b.Metadata.Name,
+				dashIfEmpty(b.Metadata.Realm),
+				dashIfEmpty(b.Metadata.Space),
+				dashIfEmpty(b.Metadata.Stack),
+			})
+		}
+		shared.PrintTable(cmd, headers, rows)
+		return nil
+	default:
+		return shared.PrintYAML(blueprints)
+	}
+}
+
+// dashIfEmpty renders an unset scope coordinate as "-" so the table column
+// never collapses to an unaligned blank cell.
+func dashIfEmpty(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/kuke/get/blueprint/blueprint_test.go
+++ b/cmd/kuke/get/blueprint/blueprint_test.go
@@ -1,0 +1,204 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blueprint_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	blueprint "github.com/eminwux/kukeon/cmd/kuke/get/blueprint"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestNewBlueprintCmd(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func(t *testing.T, cmd *cobra.Command)
+		fake       *fakeClient
+		wantErr    string
+		wantOutput string
+	}{
+		{
+			// Single-resource get renders YAML to os.Stdout (not the command
+			// buffer), so this case only asserts the happy path returns no error.
+			name: "get single blueprint",
+			args: []string{"web"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+				_ = cmd.Flags().Set("space", "s1")
+			},
+			fake: &fakeClient{
+				getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{
+						Blueprint:      v1beta1.CellBlueprintDoc{Metadata: doc.Metadata},
+						MetadataExists: true,
+					}, nil
+				},
+			},
+		},
+		{
+			name: "get not found surfaces friendly error",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{}, errdefs.ErrBlueprintNotFound
+				},
+			},
+			wantErr: `blueprint "missing" not found`,
+		},
+		{
+			name: "get not found via MetadataExists=false",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: `blueprint "missing" not found`,
+		},
+		{
+			name: "list empty",
+			fake: &fakeClient{
+				listBlueprintsFn: func(_, _, _ string) ([]v1beta1.CellBlueprintDoc, error) {
+					return nil, nil
+				},
+			},
+			wantOutput: "No blueprints found.",
+		},
+		{
+			name: "list table renders scope columns",
+			fake: &fakeClient{
+				listBlueprintsFn: func(_, _, _ string) ([]v1beta1.CellBlueprintDoc, error) {
+					return []v1beta1.CellBlueprintDoc{
+						{Metadata: v1beta1.CellBlueprintMetadata{Name: "realm-bp", Realm: "default"}},
+						{
+							Metadata: v1beta1.CellBlueprintMetadata{
+								Name:  "stack-bp",
+								Realm: "default",
+								Space: "s",
+								Stack: "st",
+							},
+						},
+					}, nil
+				},
+			},
+			wantOutput: "realm-bp",
+		},
+		{
+			name: "list passes filter scope through (no cell coordinate)",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "default")
+				_ = cmd.Flags().Set("space", "team-a")
+			},
+			fake: &fakeClient{
+				listBlueprintsFn: func(realm, space, _ string) ([]v1beta1.CellBlueprintDoc, error) {
+					if realm != "default" || space != "team-a" {
+						return nil, errors.New("unexpected filter scope")
+					}
+					return []v1beta1.CellBlueprintDoc{
+						{Metadata: v1beta1.CellBlueprintMetadata{Name: "space-bp", Realm: realm, Space: space}},
+					}, nil
+				},
+			},
+			wantOutput: "space-bp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := blueprint.NewBlueprintCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, blueprint.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getBlueprintFn   func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error)
+	listBlueprintsFn func(realm, space, stack string) ([]v1beta1.CellBlueprintDoc, error)
+}
+
+func (f *fakeClient) GetBlueprint(
+	_ context.Context, doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.GetBlueprintResult, error) {
+	if f.getBlueprintFn == nil {
+		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")
+	}
+	return f.getBlueprintFn(doc)
+}
+
+func (f *fakeClient) ListBlueprints(
+	_ context.Context,
+	realm, space, stack string,
+) ([]v1beta1.CellBlueprintDoc, error) {
+	if f.listBlueprintsFn == nil {
+		return nil, errors.New("unexpected ListBlueprints call")
+	}
+	return f.listBlueprintsFn(realm, space, stack)
+}

--- a/cmd/kuke/get/get.go
+++ b/cmd/kuke/get/get.go
@@ -19,6 +19,7 @@ package get
 import (
 	"strings"
 
+	blueprintcmd "github.com/eminwux/kukeon/cmd/kuke/get/blueprint"
 	cellcmd "github.com/eminwux/kukeon/cmd/kuke/get/cell"
 	containercmd "github.com/eminwux/kukeon/cmd/kuke/get/container"
 	realmcmd "github.com/eminwux/kukeon/cmd/kuke/get/realm"
@@ -36,7 +37,7 @@ func NewGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "get [name]",
 		Aliases: []string{"g"},
-		Short:   "Get or list Kukeon resources (realm, space, stack, cell, container, secret)",
+		Short:   "Get or list Kukeon resources (realm, space, stack, cell, container, secret, blueprint)",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
@@ -59,6 +60,7 @@ func NewGetCmd() *cobra.Command {
 		cellcmd.NewCellCmd(),
 		containercmd.NewContainerCmd(),
 		secretcmd.NewSecretCmd(),
+		blueprintcmd.NewBlueprintCmd(),
 	)
 
 	return cmd
@@ -66,7 +68,7 @@ func NewGetCmd() *cobra.Command {
 
 // completeGetSubcommands provides shell completion for get subcommand names.
 func completeGetSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret"}
+	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/get/get_test.go
+++ b/cmd/kuke/get/get_test.go
@@ -41,7 +41,7 @@ func TestNewGetCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Get or list Kukeon resources (realm, space, stack, cell, container, secret)"
+				expected := "Get or list Kukeon resources (realm, space, stack, cell, container, secret, blueprint)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -103,7 +103,7 @@ func TestNewGetCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container", "secret"}
+	expected := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}

--- a/internal/apischeme/cellblueprint.go
+++ b/internal/apischeme/cellblueprint.go
@@ -76,3 +76,34 @@ func ConvertCellBlueprintToExternal(in intmodel.CellBlueprint) (ext.CellBlueprin
 	}
 	return doc, nil
 }
+
+// ConvertCellBlueprintMetadataToExternal builds a metadata-only external
+// CellBlueprintDoc from the internal carrier's metadata (issue #643). Unlike
+// ConvertCellBlueprintToExternal it does not read the stored Document — the
+// list and delete verbs surface scope coordinates and name only, never the
+// template body.
+func ConvertCellBlueprintMetadataToExternal(in intmodel.CellBlueprint) ext.CellBlueprintDoc {
+	return ext.CellBlueprintDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCellBlueprint,
+		Metadata: ext.CellBlueprintMetadata{
+			Name:  in.Metadata.Name,
+			Realm: in.Metadata.Realm,
+			Space: in.Metadata.Space,
+			Stack: in.Metadata.Stack,
+		},
+	}
+}
+
+// ConvertCellBlueprintListToExternal maps a slice of internal CellBlueprints to
+// metadata-only external CellBlueprintDocs (issue #643).
+func ConvertCellBlueprintListToExternal(in []intmodel.CellBlueprint) []ext.CellBlueprintDoc {
+	if in == nil {
+		return nil
+	}
+	out := make([]ext.CellBlueprintDoc, len(in))
+	for i := range in {
+		out[i] = ConvertCellBlueprintMetadataToExternal(in[i])
+	}
+	return out
+}

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -443,6 +443,17 @@ func (c *Client) ListSecrets(
 	return apischeme.ConvertSecretListToExternal(secrets), nil
 }
 
+func (c *Client) ListBlueprints(
+	_ context.Context,
+	realmName, spaceName, stackName string,
+) ([]v1beta1.CellBlueprintDoc, error) {
+	blueprints, err := c.ctrl.ListBlueprints(realmName, spaceName, stackName)
+	if err != nil {
+		return nil, err
+	}
+	return apischeme.ConvertCellBlueprintListToExternal(blueprints), nil
+}
+
 // derefDocs converts a []*T returned by fs.Convert* helpers into the
 // wire-friendly []T form (pointer slices don't round-trip cleanly through
 // net/rpc+jsonrpc — jsonrpc would encode them correctly but gob couldn't,
@@ -693,6 +704,23 @@ func (c *Client) DeleteSecret(_ context.Context, doc v1beta1.SecretDoc) (kukeonv
 	return kukeonv1.DeleteSecretResult{
 		Secret:  apischeme.ConvertSecretToExternal(res.Secret),
 		Deleted: res.Deleted,
+	}, nil
+}
+
+func (c *Client) DeleteBlueprint(
+	_ context.Context, doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.DeleteBlueprintResult, error) {
+	internal, _, err := apischeme.NormalizeCellBlueprint(doc)
+	if err != nil {
+		return kukeonv1.DeleteBlueprintResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.DeleteBlueprint(internal)
+	if err != nil {
+		return kukeonv1.DeleteBlueprintResult{}, err
+	}
+	return kukeonv1.DeleteBlueprintResult{
+		Blueprint: apischeme.ConvertCellBlueprintMetadataToExternal(res.Blueprint),
+		Deleted:   res.Deleted,
 	}, nil
 }
 

--- a/internal/controller/blueprint.go
+++ b/internal/controller/blueprint.go
@@ -60,6 +60,52 @@ func (b *Exec) GetBlueprint(blueprint intmodel.CellBlueprint) (GetBlueprintResul
 	return res, nil
 }
 
+// DeleteBlueprintResult reports the outcome of removing a single CellBlueprint's
+// daemon-stored document file.
+type DeleteBlueprintResult struct {
+	Blueprint intmodel.CellBlueprint
+	Deleted   bool
+}
+
+// ListBlueprints lists the metadata of every CellBlueprint bound to the filter
+// scope or any scope nested within it (issue #643). An empty realm lists across
+// all realms; the filter coordinates must still be contiguous (no gap below a
+// set level), and — a Blueprint never being cell-scoped — there is no cell
+// coordinate.
+func (b *Exec) ListBlueprints(realmName, spaceName, stackName string) ([]intmodel.CellBlueprint, error) {
+	if err := validateBlueprintScopeFilter(realmName, spaceName, stackName); err != nil {
+		return nil, err
+	}
+	return b.runner.ListBlueprints(
+		strings.TrimSpace(realmName),
+		strings.TrimSpace(spaceName),
+		strings.TrimSpace(stackName),
+	)
+}
+
+// DeleteBlueprint removes a single named, scoped CellBlueprint's daemon-stored
+// document. Returns a "not found" error when the blueprint does not exist,
+// matching the DeleteSecret contract. There is no live-reference gate: cells
+// materialized from a blueprint are independent copies (#620).
+func (b *Exec) DeleteBlueprint(blueprint intmodel.CellBlueprint) (DeleteBlueprintResult, error) {
+	var res DeleteBlueprintResult
+
+	if err := validateBlueprintLookup(blueprint.Metadata); err != nil {
+		return res, err
+	}
+
+	if err := b.runner.DeleteBlueprint(blueprint); err != nil {
+		if errors.Is(err, errdefs.ErrBlueprintNotFound) {
+			return res, fmt.Errorf("blueprint %q not found", blueprint.Metadata.Name)
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrDeleteBlueprint, err)
+	}
+
+	res.Deleted = true
+	res.Blueprint = blueprint
+	return res, nil
+}
+
 // validateBlueprintLookup enforces the scope contract for a single-blueprint
 // get: name and realm are mandatory and the scope coordinates must be
 // contiguous, with the Blueprint-specific rule that a cell coordinate is never
@@ -72,6 +118,24 @@ func validateBlueprintLookup(md intmodel.CellBlueprintMetadata) error {
 		return errdefs.ErrBlueprintRealmRequired
 	}
 	if strings.TrimSpace(md.Stack) != "" && strings.TrimSpace(md.Space) == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrBlueprintScopeIncomplete)
+	}
+	return nil
+}
+
+// validateBlueprintScopeFilter enforces the scope contract for a list filter:
+// realm is optional (an empty realm lists across all realms), but a set deeper
+// coordinate still requires every shallower one. A Blueprint is never
+// cell-scoped, so the filter bottoms out at stack.
+func validateBlueprintScopeFilter(realm, space, stack string) error {
+	realm = strings.TrimSpace(realm)
+	space = strings.TrimSpace(space)
+	stack = strings.TrimSpace(stack)
+
+	if realm == "" && (space != "" || stack != "") {
+		return fmt.Errorf("%w (scope set without realm)", errdefs.ErrBlueprintScopeIncomplete)
+	}
+	if stack != "" && space == "" {
 		return fmt.Errorf("%w (stack set without space)", errdefs.ErrBlueprintScopeIncomplete)
 	}
 	return nil

--- a/internal/controller/blueprint_test.go
+++ b/internal/controller/blueprint_test.go
@@ -95,3 +95,101 @@ func TestGetBlueprint_ValidatesScope(t *testing.T) {
 		})
 	}
 }
+
+// TestListBlueprints_DelegatesAfterFilterValidation confirms the controller
+// validates the filter's scope contiguity and forwards the trimmed coordinates
+// to the runner (issue #643).
+func TestListBlueprints_DelegatesAfterFilterValidation(t *testing.T) {
+	var gotRealm, gotSpace, gotStack string
+	mockRunner := &fakeRunner{
+		ListBlueprintsFn: func(realm, space, stack string) ([]intmodel.CellBlueprint, error) {
+			gotRealm, gotSpace, gotStack = realm, space, stack
+			return []intmodel.CellBlueprint{
+				{Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: realm, Space: space}},
+			}, nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	got, err := ctrl.ListBlueprints("  default ", "team-a", "")
+	if err != nil {
+		t.Fatalf("ListBlueprints() error = %v", err)
+	}
+	if gotRealm != "default" || gotSpace != "team-a" || gotStack != "" {
+		t.Errorf("runner got (%q,%q,%q), want (default,team-a,)", gotRealm, gotSpace, gotStack)
+	}
+	if len(got) != 1 || got[0].Metadata.Name != "web" {
+		t.Errorf("ListBlueprints() = %+v, want one blueprint named web", got)
+	}
+}
+
+func TestListBlueprints_RejectsIncompleteFilter(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+
+	tests := []struct {
+		name                string
+		realm, space, stack string
+	}{
+		{"scope_without_realm", "", "team-a", ""},
+		{"stack_without_space", "default", "", "web"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ctrl.ListBlueprints(tt.realm, tt.space, tt.stack); !errors.Is(
+				err, errdefs.ErrBlueprintScopeIncomplete,
+			) {
+				t.Errorf("ListBlueprints() error = %v, want ErrBlueprintScopeIncomplete", err)
+			}
+		})
+	}
+}
+
+func TestDeleteBlueprint_NotFoundFriendlyError(t *testing.T) {
+	mockRunner := &fakeRunner{
+		DeleteBlueprintFn: func(intmodel.CellBlueprint) error {
+			return errdefs.ErrBlueprintNotFound
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	_, err := ctrl.DeleteBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "ghost", Realm: "default"},
+	})
+	if err == nil || err.Error() != `blueprint "ghost" not found` {
+		t.Errorf("DeleteBlueprint() error = %v, want `blueprint \"ghost\" not found`", err)
+	}
+}
+
+func TestDeleteBlueprint_SuccessReportsDeleted(t *testing.T) {
+	var gotMeta intmodel.CellBlueprintMetadata
+	mockRunner := &fakeRunner{
+		DeleteBlueprintFn: func(bp intmodel.CellBlueprint) error {
+			gotMeta = bp.Metadata
+			return nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.DeleteBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteBlueprint() error = %v", err)
+	}
+	if !res.Deleted {
+		t.Error("Deleted = false, want true")
+	}
+	if gotMeta.Name != "web" || gotMeta.Realm != "default" || gotMeta.Space != "team-a" {
+		t.Errorf("runner got metadata %+v, want web/default/team-a", gotMeta)
+	}
+}
+
+func TestDeleteBlueprint_ValidatesScope(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+
+	if _, err := ctrl.DeleteBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Realm: "default"},
+	}); !errors.Is(err, errdefs.ErrBlueprintNameRequired) {
+		t.Errorf("DeleteBlueprint() error = %v, want ErrBlueprintNameRequired", err)
+	}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -66,8 +66,10 @@ type fakeRunner struct {
 	DeleteSecretFn func(secret intmodel.Secret) error
 
 	// Blueprint methods
-	WriteBlueprintFn func(bp intmodel.CellBlueprint) (bool, error)
-	GetBlueprintFn   func(bp intmodel.CellBlueprint) (intmodel.CellBlueprint, error)
+	WriteBlueprintFn  func(bp intmodel.CellBlueprint) (bool, error)
+	GetBlueprintFn    func(bp intmodel.CellBlueprint) (intmodel.CellBlueprint, error)
+	ListBlueprintsFn  func(realmName, spaceName, stackName string) ([]intmodel.CellBlueprint, error)
+	DeleteBlueprintFn func(bp intmodel.CellBlueprint) error
 
 	// Cell methods
 	GetCellFn                 func(cell intmodel.Cell) (intmodel.Cell, error)
@@ -308,6 +310,20 @@ func (f *fakeRunner) GetBlueprint(bp intmodel.CellBlueprint) (intmodel.CellBluep
 		return f.GetBlueprintFn(bp)
 	}
 	return intmodel.CellBlueprint{}, errors.New("unexpected call to GetBlueprint")
+}
+
+func (f *fakeRunner) ListBlueprints(realmName, spaceName, stackName string) ([]intmodel.CellBlueprint, error) {
+	if f.ListBlueprintsFn != nil {
+		return f.ListBlueprintsFn(realmName, spaceName, stackName)
+	}
+	return nil, errors.New("unexpected call to ListBlueprints")
+}
+
+func (f *fakeRunner) DeleteBlueprint(bp intmodel.CellBlueprint) error {
+	if f.DeleteBlueprintFn != nil {
+		return f.DeleteBlueprintFn(bp)
+	}
+	return errors.New("unexpected call to DeleteBlueprint")
 }
 
 // Cell methods

--- a/internal/controller/runner/blueprint.go
+++ b/internal/controller/runner/blueprint.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -98,6 +101,169 @@ func (r *Exec) GetBlueprint(blueprint intmodel.CellBlueprint) (intmodel.CellBlue
 	}
 
 	return intmodel.CellBlueprint{Metadata: md, Document: data}, nil
+}
+
+// ListBlueprints enumerates the metadata of every CellBlueprint bound to the
+// scope identified by the filter coordinates, plus every Blueprint bound to a
+// deeper scope nested within it (issue #643). The filter is a prefix: an empty
+// realmName lists across all realms; a set realmName with an empty spaceName
+// lists realm-scoped blueprints and everything under that realm; and so on.
+// This mirrors the subtree-filter semantics of ListSecrets, but bounded at
+// stack depth — a Blueprint is never cell-scoped (#620). The returned carriers
+// are metadata-only (Document nil): the scope coordinates come from the path
+// and the name from the file basename, so a list never parses every document.
+func (r *Exec) ListBlueprints(realmName, spaceName, stackName string) ([]intmodel.CellBlueprint, error) {
+	realmDirs, err := r.resolveRealmDirs(realmName)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errdefs.ErrListBlueprints, err)
+	}
+
+	var out []intmodel.CellBlueprint
+	for _, realmDir := range realmDirs {
+		realm := filepath.Base(realmDir)
+		if walkErr := r.collectBlueprintSubtree(&out, realm, spaceName, stackName); walkErr != nil {
+			return nil, fmt.Errorf("%w: %w", errdefs.ErrListBlueprints, walkErr)
+		}
+	}
+	return out, nil
+}
+
+// collectBlueprintSubtree appends the metadata of every CellBlueprint bound to
+// scope (realm, space, stack) — where a trailing coordinate that is "" marks
+// the filter floor — and every Blueprint in scopes nested within it. The rule
+// mirrors collectSecretSubtree: collect a level's own blueprints only when the
+// next-deeper filter coordinate is empty, and descend into a child only when it
+// matches a set filter coordinate or the filter is empty at that level. The
+// walk is bounded at stack depth, so cell directories are never descended.
+func (r *Exec) collectBlueprintSubtree(out *[]intmodel.CellBlueprint, realm, space, stack string) error {
+	if space == "" {
+		if err := r.collectBlueprintsInScope(out, realm, "", ""); err != nil {
+			return err
+		}
+	}
+
+	spaces, err := r.blueprintChildScopeNames(fs.RealmMetadataDir(r.opts.RunPath, realm), space)
+	if err != nil {
+		return err
+	}
+	for _, sp := range spaces {
+		if stack == "" {
+			if err = r.collectBlueprintsInScope(out, realm, sp, ""); err != nil {
+				return err
+			}
+		}
+
+		stacks, stErr := r.blueprintChildScopeNames(fs.SpaceMetadataDir(r.opts.RunPath, realm, sp), stack)
+		if stErr != nil {
+			return stErr
+		}
+		for _, st := range stacks {
+			if err = r.collectBlueprintsInScope(out, realm, sp, st); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// blueprintChildScopeNames returns the child-scope subdirectory names directly
+// under dir, excluding both reserved resource subdirectories (secrets/ and
+// blueprints/) so neither is mistaken for a child space or stack. When want is
+// non-empty it filters to that single child (returned only if it exists). A
+// missing dir yields no children, matching the list verbs' "no match ⇒ empty".
+func (r *Exec) blueprintChildScopeNames(dir, want string) ([]string, error) {
+	if strings.TrimSpace(want) != "" {
+		child := filepath.Join(dir, want)
+		info, err := os.Stat(child)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to stat scope dir %q: %w", child, err)
+		}
+		if !info.IsDir() {
+			return nil, nil
+		}
+		return []string{want}, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read scope dir %q: %w", dir, err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if entry.Name() == consts.KukeonSecretsSubdir || entry.Name() == consts.KukeonBlueprintsSubdir {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
+// collectBlueprintsInScope appends the metadata of every CellBlueprint stored
+// directly at the given scope (realm, space, stack). The in-flight
+// ".blueprint-*.tmp" temp files WriteBlueprint creates are skipped so a
+// concurrent apply never surfaces a half-written name.
+func (r *Exec) collectBlueprintsInScope(out *[]intmodel.CellBlueprint, realm, space, stack string) error {
+	dir := fs.BlueprintsDir(r.opts.RunPath, realm, space, stack)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read blueprints dir %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".blueprint-") && strings.HasSuffix(name, ".tmp") {
+			continue
+		}
+		*out = append(*out, intmodel.CellBlueprint{
+			Metadata: intmodel.CellBlueprintMetadata{
+				Name:  name,
+				Realm: realm,
+				Space: space,
+				Stack: stack,
+			},
+		})
+	}
+	return nil
+}
+
+// DeleteBlueprint removes the daemon-stored document file for a single named,
+// scoped CellBlueprint (issue #643). Returns errdefs.ErrBlueprintNotFound when
+// the file is absent so the caller can report a clear "not found" instead of a
+// silent success. Unlike DeleteSecret there is no live-reference gate: a cell
+// materialized by `kuke run -b` is a fresh, independent copy (#620), so
+// removing the blueprint never breaks a running cell.
+func (r *Exec) DeleteBlueprint(blueprint intmodel.CellBlueprint) error {
+	md := blueprint.Metadata
+	path := fs.BlueprintPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errdefs.ErrBlueprintNotFound
+		}
+		return fmt.Errorf("%w: %w", errdefs.ErrDeleteBlueprint, err)
+	}
+
+	r.logger.InfoContext(r.ctx, "blueprint deleted",
+		"name", md.Name,
+		"realm", md.Realm,
+		"space", md.Space,
+		"stack", md.Stack,
+	)
+	return nil
 }
 
 // atomicWriteFileMode writes data to path via a temp file in the same

--- a/internal/controller/runner/blueprint_test.go
+++ b/internal/controller/runner/blueprint_test.go
@@ -22,6 +22,7 @@ package runner
 import (
 	"errors"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -170,4 +171,163 @@ func TestWriteBlueprint_DeeperScopeNestsUnderScopeDir(t *testing.T) {
 	if _, err := os.Stat(realmScoped); !os.IsNotExist(err) {
 		t.Errorf("blueprint leaked into realm scope at %s (err=%v)", realmScoped, err)
 	}
+}
+
+// blueprintScopeKey is a stable identity for a listed blueprint, used to
+// compare ListBlueprints output independent of walk order.
+func blueprintScopeKey(bp intmodel.CellBlueprint) string {
+	return bp.Metadata.Realm + "/" + bp.Metadata.Space + "/" + bp.Metadata.Stack + "/" + bp.Metadata.Name
+}
+
+func listedKeys(t *testing.T, r *Exec, realm, space, stack string) []string {
+	t.Helper()
+	got, err := r.ListBlueprints(realm, space, stack)
+	if err != nil {
+		t.Fatalf("ListBlueprints(%q,%q,%q) error = %v", realm, space, stack, err)
+	}
+	keys := make([]string, 0, len(got))
+	for _, bp := range got {
+		keys = append(keys, blueprintScopeKey(bp))
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// seedBlueprint writes a metadata-only blueprint at the given scope for list/
+// delete walk tests; the document body is irrelevant to those paths.
+func seedBlueprint(t *testing.T, r *Exec, name, realm, space, stack string) {
+	t.Helper()
+	bp := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: name, Realm: realm, Space: space, Stack: stack},
+		Document: []byte("x"),
+	}
+	if _, err := r.WriteBlueprint(bp); err != nil {
+		t.Fatalf("seed WriteBlueprint(%q @ %s/%s/%s) error = %v", name, realm, space, stack, err)
+	}
+}
+
+// TestListBlueprints_SubtreeFilterSemantics pins the issue #643 list contract:
+// an empty filter lists the whole subtree, a realm filter scopes to that realm,
+// and a deeper coordinate excludes shallower scopes — mirroring ListSecrets but
+// bounded at stack (a Blueprint is never cell-scoped).
+func TestListBlueprints_SubtreeFilterSemantics(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seedBlueprint(t, r, "realm-bp", "default", "", "")
+	seedBlueprint(t, r, "space-bp", "default", "team-a", "")
+	seedBlueprint(t, r, "stack-bp", "default", "team-a", "web")
+	seedBlueprint(t, r, "other-realm-bp", "prod", "", "")
+
+	all := listedKeys(t, r, "", "", "")
+	wantAll := []string{
+		"default///realm-bp",
+		"default/team-a//space-bp",
+		"default/team-a/web/stack-bp",
+		"prod///other-realm-bp",
+	}
+	if !equalStrings(all, wantAll) {
+		t.Errorf("ListBlueprints(all) = %v, want %v", all, wantAll)
+	}
+
+	realmFiltered := listedKeys(t, r, "default", "", "")
+	wantRealm := []string{
+		"default///realm-bp",
+		"default/team-a//space-bp",
+		"default/team-a/web/stack-bp",
+	}
+	if !equalStrings(realmFiltered, wantRealm) {
+		t.Errorf("ListBlueprints(default) = %v, want %v", realmFiltered, wantRealm)
+	}
+
+	// A set space coordinate excludes the realm-scoped blueprint.
+	spaceFiltered := listedKeys(t, r, "default", "team-a", "")
+	wantSpace := []string{
+		"default/team-a//space-bp",
+		"default/team-a/web/stack-bp",
+	}
+	if !equalStrings(spaceFiltered, wantSpace) {
+		t.Errorf("ListBlueprints(default,team-a) = %v, want %v", spaceFiltered, wantSpace)
+	}
+
+	// A set stack coordinate excludes the realm- and space-scoped blueprints.
+	stackFiltered := listedKeys(t, r, "default", "team-a", "web")
+	wantStack := []string{"default/team-a/web/stack-bp"}
+	if !equalStrings(stackFiltered, wantStack) {
+		t.Errorf("ListBlueprints(default,team-a,web) = %v, want %v", stackFiltered, wantStack)
+	}
+}
+
+// TestListBlueprints_IgnoresReservedSubdirs confirms the walk never mistakes a
+// sibling secrets/ or blueprints/ reserved subdirectory for a child space or
+// stack, and that an in-flight temp file is skipped.
+func TestListBlueprints_IgnoresReservedSubdirs(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seedBlueprint(t, r, "realm-bp", "default", "", "")
+	// A realm-scoped secret creates default/secrets/; a realm-scoped blueprint
+	// already created default/blueprints/. Neither must surface as a space.
+	if _, err := r.WriteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+		Spec:     intmodel.SecretSpec{Data: "v"},
+	}); err != nil {
+		t.Fatalf("seed WriteSecret error = %v", err)
+	}
+	// Drop an in-flight temp file alongside the realm blueprint; it must be
+	// skipped, not surfaced as a blueprint named ".blueprint-xyz.tmp".
+	tmpPath := fs.BlueprintPath(runPath, "default", "", "", ".blueprint-xyz.tmp")
+	if err := os.WriteFile(tmpPath, []byte("partial"), 0o644); err != nil {
+		t.Fatalf("seed temp file error = %v", err)
+	}
+
+	got := listedKeys(t, r, "", "", "")
+	want := []string{"default///realm-bp"}
+	if !equalStrings(got, want) {
+		t.Errorf("ListBlueprints(all) = %v, want %v (reserved subdirs + temp file must be ignored)", got, want)
+	}
+}
+
+func TestDeleteBlueprint_RemovesFile(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seedBlueprint(t, r, "web", "default", "team-a", "")
+	path := fs.BlueprintPath(runPath, "default", "team-a", "", "web")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("precondition: blueprint not seeded: %v", err)
+	}
+
+	if err := r.DeleteBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	}); err != nil {
+		t.Fatalf("DeleteBlueprint() error = %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("blueprint file still present after delete (err=%v)", err)
+	}
+}
+
+func TestDeleteBlueprint_NotFound(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	err := r.DeleteBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "ghost", Realm: "default"},
+	})
+	if !errors.Is(err, errdefs.ErrBlueprintNotFound) {
+		t.Errorf("DeleteBlueprint() error = %v, want ErrBlueprintNotFound", err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -131,6 +131,16 @@ type Runner interface {
 	// `kuke run -b` can materialize it. Returns errdefs.ErrBlueprintNotFound
 	// when the file is absent.
 	GetBlueprint(blueprint intmodel.CellBlueprint) (intmodel.CellBlueprint, error)
+	// ListBlueprints enumerates the metadata of every CellBlueprint bound to
+	// the filter scope or any scope nested within it (issue #643). An empty
+	// realmName lists across all realms; the filter is a subtree prefix
+	// bounded at stack depth (a Blueprint is never cell-scoped). The returned
+	// carriers are metadata-only — the document is not read.
+	ListBlueprints(realmName, spaceName, stackName string) ([]intmodel.CellBlueprint, error)
+	// DeleteBlueprint removes the daemon-stored document file for a single
+	// named, scoped CellBlueprint (issue #643). Returns
+	// errdefs.ErrBlueprintNotFound when the file is absent.
+	DeleteBlueprint(blueprint intmodel.CellBlueprint) error
 
 	ExistsCgroup(doc any) (bool, error)
 

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -208,6 +208,15 @@ func (s *KukeonV1Service) ListSecrets(args *kukeonv1.ListSecretsArgs, reply *kuk
 	return nil
 }
 
+func (s *KukeonV1Service) ListBlueprints(
+	args *kukeonv1.ListBlueprintsArgs, reply *kukeonv1.ListBlueprintsReply,
+) error {
+	blueprints, err := s.core.ListBlueprints(s.ctx, args.RealmName, args.SpaceName, args.StackName)
+	reply.Blueprints = blueprints
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
 // ---- Lifecycle ----
 
 func (s *KukeonV1Service) StartCell(args *kukeonv1.StartCellArgs, reply *kukeonv1.StartCellReply) error {
@@ -325,6 +334,15 @@ func (s *KukeonV1Service) DeleteContainer(
 
 func (s *KukeonV1Service) DeleteSecret(args *kukeonv1.DeleteSecretArgs, reply *kukeonv1.DeleteSecretReply) error {
 	result, err := s.core.DeleteSecret(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
+func (s *KukeonV1Service) DeleteBlueprint(
+	args *kukeonv1.DeleteBlueprintArgs, reply *kukeonv1.DeleteBlueprintReply,
+) error {
+	result, err := s.core.DeleteBlueprint(s.ctx, args.Doc)
 	reply.Result = result
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -352,6 +352,8 @@ var (
 	ErrWriteBlueprint         = errors.New("failed to write blueprint document")
 	ErrBlueprintNotFound      = errors.New("blueprint not found")
 	ErrGetBlueprint           = errors.New("failed to get blueprint")
+	ErrListBlueprints         = errors.New("failed to list blueprints")
+	ErrDeleteBlueprint        = errors.New("failed to delete blueprint document")
 	// ErrBlueprintStructuralSlots fires when `kuke run -b` is asked to run a
 	// blueprint that declares structural slots (secret slots, or repo slots
 	// with no url) the inline scalar-param path cannot fill. Such blueprints

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -66,6 +66,11 @@ type Client interface {
 	// filter scope or any scope nested within it (issue #622). An empty
 	// realmName lists across all realms. spec.data is never echoed.
 	ListSecrets(ctx context.Context, realmName, spaceName, stackName, cellName string) ([]v1beta1.SecretDoc, error)
+	// ListBlueprints enumerates the metadata of every CellBlueprint bound to
+	// the filter scope or any scope nested within it (issue #643). An empty
+	// realmName lists across all realms. A Blueprint is never cell-scoped, so
+	// there is no cell coordinate. The spec is not populated for a list.
+	ListBlueprints(ctx context.Context, realmName, spaceName, stackName string) ([]v1beta1.CellBlueprintDoc, error)
 
 	StartCell(ctx context.Context, doc v1beta1.CellDoc) (StartCellResult, error)
 	StartContainer(ctx context.Context, doc v1beta1.ContainerDoc) (StartContainerResult, error)
@@ -92,6 +97,10 @@ type Client interface {
 	// DeleteSecret removes a single named, scoped Secret's daemon-stored
 	// file (issue #622). The live-reference safety gate ships in phase 3c.
 	DeleteSecret(ctx context.Context, doc v1beta1.SecretDoc) (DeleteSecretResult, error)
+	// DeleteBlueprint removes a single named, scoped CellBlueprint's
+	// daemon-stored document (issue #643). No live-reference gate: cells
+	// materialized from a blueprint are independent copies (#620).
+	DeleteBlueprint(ctx context.Context, doc v1beta1.CellBlueprintDoc) (DeleteBlueprintResult, error)
 
 	PurgeRealm(ctx context.Context, doc v1beta1.RealmDoc, force, cascade bool) (PurgeRealmResult, error)
 	PurgeSpace(ctx context.Context, doc v1beta1.SpaceDoc, force, cascade bool) (PurgeSpaceResult, error)
@@ -184,6 +193,7 @@ const (
 	MethodListCells      = ServiceName + ".ListCells"
 	MethodListContainers = ServiceName + ".ListContainers"
 	MethodListSecrets    = ServiceName + ".ListSecrets"
+	MethodListBlueprints = ServiceName + ".ListBlueprints"
 
 	MethodStartCell       = ServiceName + ".StartCell"
 	MethodStartContainer  = ServiceName + ".StartContainer"
@@ -200,6 +210,7 @@ const (
 	MethodDeleteCell      = ServiceName + ".DeleteCell"
 	MethodDeleteContainer = ServiceName + ".DeleteContainer"
 	MethodDeleteSecret    = ServiceName + ".DeleteSecret"
+	MethodDeleteBlueprint = ServiceName + ".DeleteBlueprint"
 
 	MethodPurgeRealm     = ServiceName + ".PurgeRealm"
 	MethodPurgeSpace     = ServiceName + ".PurgeSpace"

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -109,6 +109,10 @@ func (FakeClient) ListSecrets(context.Context, string, string, string, string) (
 	return nil, ErrUnexpectedCall
 }
 
+func (FakeClient) ListBlueprints(context.Context, string, string, string) ([]v1beta1.CellBlueprintDoc, error) {
+	return nil, ErrUnexpectedCall
+}
+
 func (FakeClient) StartCell(context.Context, v1beta1.CellDoc) (StartCellResult, error) {
 	return StartCellResult{}, ErrUnexpectedCall
 }
@@ -163,6 +167,10 @@ func (FakeClient) DeleteContainer(context.Context, v1beta1.ContainerDoc) (Delete
 
 func (FakeClient) DeleteSecret(context.Context, v1beta1.SecretDoc) (DeleteSecretResult, error) {
 	return DeleteSecretResult{}, ErrUnexpectedCall
+}
+
+func (FakeClient) DeleteBlueprint(context.Context, v1beta1.CellBlueprintDoc) (DeleteBlueprintResult, error) {
+	return DeleteBlueprintResult{}, ErrUnexpectedCall
 }
 
 func (FakeClient) PurgeRealm(context.Context, v1beta1.RealmDoc, bool, bool) (PurgeRealmResult, error) {

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -375,6 +375,22 @@ func (c *UnixClient) ListSecrets(
 	return reply.Secrets, nil
 }
 
+// ListBlueprints implements Client.
+func (c *UnixClient) ListBlueprints(
+	ctx context.Context,
+	realmName, spaceName, stackName string,
+) ([]v1beta1.CellBlueprintDoc, error) {
+	args := &ListBlueprintsArgs{RealmName: realmName, SpaceName: spaceName, StackName: stackName}
+	reply := &ListBlueprintsReply{}
+	if err := c.call(ctx, MethodListBlueprints, args, reply); err != nil {
+		return nil, err
+	}
+	if reply.Err != nil {
+		return reply.Blueprints, FromAPIError(reply.Err)
+	}
+	return reply.Blueprints, nil
+}
+
 // StartCell implements Client.
 func (c *UnixClient) StartCell(ctx context.Context, doc v1beta1.CellDoc) (StartCellResult, error) {
 	args := &StartCellArgs{Doc: doc}
@@ -568,6 +584,21 @@ func (c *UnixClient) DeleteSecret(ctx context.Context, doc v1beta1.SecretDoc) (D
 	reply := &DeleteSecretReply{}
 	if err := c.call(ctx, MethodDeleteSecret, args, reply); err != nil {
 		return DeleteSecretResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
+// DeleteBlueprint implements Client.
+func (c *UnixClient) DeleteBlueprint(
+	ctx context.Context, doc v1beta1.CellBlueprintDoc,
+) (DeleteBlueprintResult, error) {
+	args := &DeleteBlueprintArgs{Doc: doc}
+	reply := &DeleteBlueprintReply{}
+	if err := c.call(ctx, MethodDeleteBlueprint, args, reply); err != nil {
+		return DeleteBlueprintResult{}, err
 	}
 	if reply.Err != nil {
 		return reply.Result, FromAPIError(reply.Err)

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -300,6 +300,19 @@ type ListSecretsReply struct {
 	Err     *APIError
 }
 
+type ListBlueprintsArgs struct {
+	RealmName string
+	SpaceName string
+	StackName string
+}
+
+// ListBlueprintsReply carries metadata-only CellBlueprintDocs — the spec (cell
+// template, parameters, slots) is never populated for a list (issue #643).
+type ListBlueprintsReply struct {
+	Blueprints []v1beta1.CellBlueprintDoc
+	Err        *APIError
+}
+
 // ---- Lifecycle (Start/Stop/Kill) ----
 
 type StartCellArgs struct {
@@ -479,6 +492,22 @@ type DeleteSecretReply struct {
 type DeleteSecretResult struct {
 	Secret  v1beta1.SecretDoc
 	Deleted bool
+}
+
+type DeleteBlueprintArgs struct {
+	Doc v1beta1.CellBlueprintDoc
+}
+
+type DeleteBlueprintReply struct {
+	Result DeleteBlueprintResult
+	Err    *APIError
+}
+
+// DeleteBlueprintResult reports the removed Blueprint (metadata only) and
+// whether the file existed to delete.
+type DeleteBlueprintResult struct {
+	Blueprint v1beta1.CellBlueprintDoc
+	Deleted   bool
 }
 
 type DeleteContainerArgs struct {


### PR DESCRIPTION
## Summary

Phase 4a-ii of #423. Phase 4a-i (#620) shipped `kind: CellBlueprint` + daemon store + `kuke apply` + `kuke run -b`; operators could apply and run a Blueprint but not list or delete one. This adds the read and delete verbs, modelled on the Secret get/delete precedent (#622):

- `kuke get blueprints [--realm/--space/--stack] [-o json]` — subtree-filtered list (metadata-only: name + scope, no template body read).
- `kuke get blueprint <name> [--scope ...] [-o json]` — full document view (parameters + slot declarations + cell template), via the existing `GetBlueprint` RPC.
- `kuke delete blueprint <name> [--scope ...]` — removes the file at `/opt/kukeon/<scope>/blueprints/<name>`.

The vertical adds `ListBlueprints`/`DeleteBlueprint` across every layer the sibling Secret verbs use: runner (disk subtree-walk + unlink), controller (scope-filter validation + delegation), `kukeonv1.Client` interface + method constants, `UnixClient`, the daemon RPC service, the in-process local client, and the `FakeClient`.

### Design notes (for reviewer push-back)
- **No live-reference delete gate** (unlike `delete secret`'s #623 `secretRef` guard). `kuke run -b` materializes a *fresh, independent* cell (the "Blueprint = always fresh" invariant from #620), so removing a blueprint never breaks a running cell. Delete is a plain unlink.
- **Blueprint scope bottoms out at stack** — a Blueprint is never cell-scoped (#620), so there is no `--cell` flag and the list filter is realm/space/stack only.
- **List is metadata-only.** The walk surfaces name + scope coordinates from the path; it never parses each document. The single-get is the only path that reads the full template body. Matches `ListSecrets`.
- **The list subtree-walk excludes both reserved subdirs** (`secrets/` and `blueprints/`) so neither is mistaken for a child space/stack, and skips in-flight `.blueprint-*.tmp` temp files.

## Test plan
- [x] `make test` — full CI target (test-root + test-kukebuild), both modules green. (go1.25.5 toolchain fetched for the kukebuild module.)
- [x] `go build ./...` / `go vet ./...` — clean.
- [x] New unit tests: runner (subtree-filter semantics, reserved-subdir/temp-file skip, delete + not-found), controller (filter validation, delegation, not-found friendly error, scope validation), and both CLI commands (table/json/yaml output, scope passthrough, not-found).
- [x] `make dev-init` smoke — exit 0, daemon-parity regression guard identical for `kuke get realms` and `--no-daemon`.
- [x] End-to-end against the live daemon: `kuke apply -f` a blueprint, then `get blueprints` (table), `get blueprint <name>` (yaml, full spec), `get blueprints -o json` (metadata-only), `get blueprint <missing>` (not-found error), `delete blueprint <name>` (removed), list-after-delete empty, `delete <missing>` (not-found error).

Closes #643