### PR TITLE
fix: roll back RecreateCell on partial create failure

### DIFF
--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -29,7 +29,7 @@ import (
 // RecreateCell stops all containers in the cell, deletes them, and recreates the cell
 // with the new root container spec. This is used when the root container spec changes
 // (image, command, or args).
-func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
+func (r *Exec) RecreateCell(desired intmodel.Cell) (_ intmodel.Cell, retErr error) {
 	defer r.lockCell(desired)()
 
 	// Get existing cell
@@ -37,6 +37,22 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	if err != nil {
 		return intmodel.Cell{}, fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
 	}
+
+	// Once the destructive recreate begins creating fresh containers, any later
+	// failure must roll the cell back — tear down the containers/IPAM already
+	// created and stamp Failed — so a half-recreated cell never lingers as Ready
+	// or Unknown (issue #718). Mirrors StartCell's provisionStarted gate (issue
+	// #407). Armed immediately before createCellContainers and disarmed before
+	// startCellLocked, which owns its own markCellFailed("StartCellFailed") for
+	// the start phase; leaving the gate armed across it would re-run a redundant
+	// kill cycle.
+	var provisionStarted bool
+	cellForCleanup := existing
+	defer func() {
+		if retErr != nil && provisionStarted {
+			r.markCellFailed(cellForCleanup, "RecreateCellFailed", retErr)
+		}
+	}()
 
 	// Stop all containers in the cell
 	_, stopErr := r.stopCellLocked(existing)
@@ -172,6 +188,10 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	// Preserve existing metadata and status where appropriate
 	desired.Status.CgroupPath = existing.Status.CgroupPath
 
+	// Past this point a failure has created fresh containers (and possibly an
+	// IPAM reservation); arm the rollback defer so they don't leak.
+	provisionStarted = true
+
 	// Recreate cell containers (this will create root container and all child containers)
 	_, err = r.createCellContainers(&desired)
 	if err != nil {
@@ -193,6 +213,10 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	// apply/reconcile.go (CreateCell -> StartCell). StartCell starts the tasks,
 	// runs CNI ADD against the deterministic root ID, and stamps + persists Ready
 	// only once the cell is actually up.
+	// startCellLocked owns its own failure cleanup (markCellFailed with reason
+	// "StartCellFailed", issue #407), so disarm the local gate to avoid a
+	// redundant kill cycle on the start path.
+	provisionStarted = false
 	started, startErr := r.startCellLocked(desired)
 	if startErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to start recreated cell: %w", startErr)

--- a/internal/controller/runner/recreate_cell_test.go
+++ b/internal/controller/runner/recreate_cell_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/eminwux/kukeon/internal/metadata"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
+	"github.com/eminwux/kukeon/internal/util/naming"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
@@ -51,10 +52,13 @@ func (t recreateCellTask) Pid() uint32 { return t.pid }
 
 // recreateCellFakeClient reuses deleteCellFakeClient for the bulk of the
 // ctr.Client surface and adds the StartContainer hook RecreateCell -> StartCell
-// needs (the embedded fake returns a nil task, which would panic at Pid()).
+// needs (the embedded fake returns a nil task, which would panic at Pid()), plus
+// a CreateContainerFromSpec hook so a non-root container creation can be made to
+// fail mid-recreate.
 type recreateCellFakeClient struct {
 	*deleteCellFakeClient
-	startContainerFn func(namespace string, spec ctr.ContainerSpec, taskSpec ctr.TaskSpec) (containerd.Task, error)
+	startContainerFn          func(namespace string, spec ctr.ContainerSpec, taskSpec ctr.TaskSpec) (containerd.Task, error)
+	createContainerFromSpecFn func(namespace string, spec intmodel.ContainerSpec, creds []ctr.RegistryCredentials, opts ...ctr.BuildOption) (containerd.Container, error)
 }
 
 func (c *recreateCellFakeClient) StartContainer(
@@ -64,6 +68,15 @@ func (c *recreateCellFakeClient) StartContainer(
 		return c.startContainerFn(namespace, spec, taskSpec)
 	}
 	return c.deleteCellFakeClient.StartContainer(namespace, spec, taskSpec)
+}
+
+func (c *recreateCellFakeClient) CreateContainerFromSpec(
+	namespace string, spec intmodel.ContainerSpec, creds []ctr.RegistryCredentials, opts ...ctr.BuildOption,
+) (containerd.Container, error) {
+	if c.createContainerFromSpecFn != nil {
+		return c.createContainerFromSpecFn(namespace, spec, creds, opts...)
+	}
+	return c.deleteCellFakeClient.CreateContainerFromSpec(namespace, spec, creds, opts...)
 }
 
 var _ ctr.Client = (*recreateCellFakeClient)(nil)
@@ -221,5 +234,103 @@ func TestRecreateCell_DoesNotStampReadyWhenStartFails(t *testing.T) {
 	}
 	if persisted.Status.State == intmodel.CellStateReady {
 		t.Error("cell persisted Ready after the root task failed to start (issue #682 AC #2)")
+	}
+}
+
+// recreateCellMultiContainerCell builds an existing (on-disk) multi-container
+// cell and the matching desired cell carrying a changed root image. Both the
+// host-network root and the single workload carry their deterministic
+// containerd IDs so the rollback's killCellLocked has concrete IDs to tear
+// down. The desired cell is a deep copy with the new image so RecreateCell's
+// leading GetCell reads the existing one back and createCellContainers
+// operates on the desired one.
+func recreateCellMultiContainerCell(
+	t *testing.T, realm, space, stack, name, oldImage, newImage string,
+) (existing, desired intmodel.Cell, rootID, workloadID string) {
+	t.Helper()
+	rootID, err := naming.BuildRootContainerdID(space, stack, name)
+	if err != nil {
+		t.Fatalf("BuildRootContainerdID: %v", err)
+	}
+	workloadID, err = naming.BuildContainerdID(space, stack, name, "app")
+	if err != nil {
+		t.Fatalf("BuildContainerdID: %v", err)
+	}
+	build := func(image string) intmodel.Cell {
+		return intmodel.Cell{
+			Metadata: intmodel.CellMetadata{Name: name},
+			Spec: intmodel.CellSpec{
+				ID:              name,
+				RealmName:       realm,
+				SpaceName:       space,
+				StackName:       stack,
+				RootContainerID: "root",
+				Containers: []intmodel.ContainerSpec{
+					{ID: "root", Root: true, HostNetwork: true, Image: image, ContainerdID: rootID},
+					{ID: "app", Image: "alpine:3.18", ContainerdID: workloadID},
+				},
+			},
+			Status: intmodel.CellStatus{State: intmodel.CellStatePending},
+		}
+	}
+	return build(oldImage), build(newImage), rootID, workloadID
+}
+
+// TestRecreateCell_RollsBackWhenContainerCreateFails is the regression guard
+// for issue #718: a createCellContainers failure on a later container used to
+// propagate the error with no rollback — the root container already created
+// leaked as an orphan and the cell metadata was never flipped to Failed. The
+// fix routes that path through markCellFailed("RecreateCellFailed"), which
+// tears the created containers/IPAM down and stamps the terminal Failed state.
+func TestRecreateCell_RollsBackWhenContainerCreateFails(t *testing.T) {
+	const (
+		realm = "default"
+		space = "default"
+		stack = "default"
+		cell  = "web"
+	)
+
+	createBoom := errors.New("workload container create refused")
+	fake := &recreateCellFakeClient{
+		deleteCellFakeClient: &deleteCellFakeClient{},
+		// Fail the non-root container creation inside createCellContainers so
+		// RecreateCell never reaches the start phase — the genuinely-unhandled
+		// rollback path the issue targets.
+		createContainerFromSpecFn: func(
+			_ string, _ intmodel.ContainerSpec, _ []ctr.RegistryCredentials, _ ...ctr.BuildOption,
+		) (containerd.Container, error) {
+			return nil, createBoom
+		},
+	}
+	existing, desired, _, _ := recreateCellMultiContainerCell(
+		t, realm, space, stack, cell, "alpine:3.18", "alpine:3.19",
+	)
+	r := newRecreateCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	seedRecreateCellSpace(t, r, realm, space)
+
+	existing.Status.State = intmodel.CellStateReady
+	if err := r.UpdateCellMetadata(existing); err != nil {
+		t.Fatalf("seed existing cell: %v", err)
+	}
+
+	if _, err := r.RecreateCell(desired); err == nil {
+		t.Fatal("RecreateCell returned nil error despite createCellContainers failing")
+	}
+
+	persisted, err := r.GetCell(desired)
+	if err != nil {
+		t.Fatalf("GetCell after failed RecreateCell: %v", err)
+	}
+	// State=Failed + Reason="RecreateCellFailed" is produced only by the new
+	// rollback defer, and markCellFailed unconditionally runs killCellLocked
+	// (the orphan-container + IPAM teardown, covered by kill_test.go) before
+	// stamping it — so this pair is the precise routing guard. Pre-fix the
+	// createCellContainers error propagated with the cell left Ready.
+	if persisted.Status.State != intmodel.CellStateFailed {
+		t.Errorf("cell State = %v, want Failed after createCellContainers failure (issue #718)", persisted.Status.State)
+	}
+	if persisted.Status.Reason != "RecreateCellFailed" {
+		t.Errorf("cell Reason = %q, want \"RecreateCellFailed\"", persisted.Status.Reason)
 	}
 }


### PR DESCRIPTION
## Summary
- `RecreateCell` (`internal/controller/runner/recreate_cell.go`) had no Failed-stamp or rollback on its `createCellContainers` failure path: a multi-container recreate that failed on a later container left the root container (and any IPAM reservation) created earlier as an orphan, and the cell metadata never flipped to `Failed`.
- Adds a `provisionStarted` gate + deferred `markCellFailed("RecreateCellFailed", retErr)` mirroring `StartCell`'s issue-#407 pattern. The gate is armed immediately before `createCellContainers` (where fresh containers/IPAM start being created) and disarmed before `startCellLocked`.

## Premise note (issue body partially rotted)
The issue lists **two** unhandled returns. Only one is genuinely unhandled today:
- `createCellContainers` failure (recreate_cell.go ~:192) — **genuinely unhandled**; this is what the fix addresses.
- `startCellLocked` failure (recreate_cell.go ~:217) — **already handled**: `startCellLocked` carries its own issue-#407 `markCellFailed("StartCellFailed")` defer (start.go:315-319, armed at start.go:430), and on the recreate path it always runs past the idempotent-skip guard (the freshly-created containers have no running tasks), so a start-phase failure already tears down and stamps `Failed`. To avoid a redundant double kill cycle, the new gate is **disarmed before `startCellLocked`**, leaving that phase's existing `"StartCellFailed"` reason intact. Net: every provisioning failure in a recreate now stamps `Failed` — `RecreateCellFailed` for the create phase, `StartCellFailed` for the start phase.

`markCellFailed` performs the orphan-container + IPAM teardown via `killCellLocked` (kill.go) before stamping the terminal state, satisfying the AC's "no orphan containers and no leaked IPAM".

## Test plan
- [x] `make test` (test-root + test-kukebuild) — all packages pass.
- [x] `go build ./...`, `go vet ./internal/controller/runner/` — clean.
- [x] New regression test `TestRecreateCell_RollsBackWhenContainerCreateFails` — a multi-container recreate whose non-root container creation fails now persists `State=Failed` / `Reason="RecreateCellFailed"` (pre-fix it propagated the error with the cell left `Ready`). Existing `TestRecreateCell_*` still pass.
- [ ] `make dev-init` smoke — N/A: change is `RecreateCell` failure-path rollback logic, not exercised by `kuke init`, and touches no build-path / realm-provisioning / `/opt/kukeon` bind-mount surface (the regression that smoke guards).

## Acceptance criteria
- [x] A multi-container recreate that fails on a later container leaves no orphan containers and no leaked IPAM (via `markCellFailed`→`killCellLocked`); cell metadata reflects `Failed`.

Closes #718