### PR TITLE
feat: add CellConfig schema, storage, apply + slot-fill validation (phase 4.2.1)

### DIFF
--- a/internal/apischeme/cellconfig.go
+++ b/internal/apischeme/cellconfig.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme
+
+import (
+	"fmt"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// ConvertCellConfigDocToInternal converts an external CellConfigDoc to the
+// internal hub carrier (issue #624). The body is serialized verbatim into the
+// carrier's Document — the daemon stores and round-trips it without
+// interpreting it — while the scope coordinates are lifted onto the metadata so
+// the storage runner can resolve the on-disk path. The apiVersion/kind are
+// normalized on the way in so the stored document is always canonical.
+func ConvertCellConfigDocToInternal(in ext.CellConfigDoc) (intmodel.CellConfig, error) {
+	switch in.APIVersion {
+	case VersionV1Beta1, "": // default/empty treated as v1beta1
+		canonical := in
+		canonical.APIVersion = ext.APIVersionV1Beta1
+		canonical.Kind = ext.KindCellConfig
+		document, err := yaml.Marshal(canonical)
+		if err != nil {
+			return intmodel.CellConfig{}, fmt.Errorf("marshal CellConfig document: %w", err)
+		}
+		return intmodel.CellConfig{
+			Metadata: intmodel.CellConfigMetadata{
+				Name:  in.Metadata.Name,
+				Realm: in.Metadata.Realm,
+				Space: in.Metadata.Space,
+				Stack: in.Metadata.Stack,
+			},
+			Document: document,
+		}, nil
+	default:
+		return intmodel.CellConfig{}, fmt.Errorf("unsupported apiVersion for CellConfig: %s", in.APIVersion)
+	}
+}
+
+// NormalizeCellConfig takes an external CellConfigDoc request and returns an
+// internal carrier and the chosen apiVersion.
+func NormalizeCellConfig(req ext.CellConfigDoc) (intmodel.CellConfig, ext.Version, error) {
+	version := DefaultVersion(req.APIVersion)
+	internal, err := ConvertCellConfigDocToInternal(req)
+	if err != nil {
+		return intmodel.CellConfig{}, "", err
+	}
+	return internal, version, nil
+}
+
+// ConvertCellConfigToExternal reconstructs the external CellConfigDoc from the
+// internal carrier's stored Document (issue #624). It is the inverse of
+// ConvertCellConfigDocToInternal, used by ReconcileConfig to validate slot fills
+// against the referenced blueprint and (in #625) by `kuke run -c`.
+func ConvertCellConfigToExternal(in intmodel.CellConfig) (ext.CellConfigDoc, error) {
+	var doc ext.CellConfigDoc
+	if err := yaml.Unmarshal(in.Document, &doc); err != nil {
+		return ext.CellConfigDoc{}, fmt.Errorf("unmarshal CellConfig document: %w", err)
+	}
+	return doc, nil
+}

--- a/internal/apischeme/cellconfig_test.go
+++ b/internal/apischeme/cellconfig_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func sampleConfigDoc() ext.CellConfigDoc {
+	return ext.CellConfigDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCellConfig,
+		Metadata: ext.CellConfigMetadata{
+			Name:  "kukeon-dev",
+			Realm: "kuke-system",
+			Space: "default",
+		},
+		Spec: ext.CellConfigSpec{
+			Blueprint: ext.CellConfigBlueprintRef{Name: "dev", Realm: "kuke-system"},
+			Values:    map[string]string{"PROJECT_DIR": "kukeon"},
+			Repos: map[string]ext.CellConfigRepoFill{
+				"project": {URL: "git@github.com:eminwux/kukeon.git", Branch: "main"},
+			},
+			Secrets: map[string]ext.CellConfigSecretFill{
+				"anthropic-token": {SecretRef: &ext.ContainerSecretRef{Name: "anthropic", Realm: "kuke-system"}},
+			},
+		},
+	}
+}
+
+// TestCellConfigRoundTripV1Beta1 confirms the external doc survives the
+// to-internal / from-internal carrier hop verbatim: the daemon stores the body
+// opaquely in Document and reconstructs the same external shape on read-back.
+func TestCellConfigRoundTripV1Beta1(t *testing.T) {
+	in := sampleConfigDoc()
+
+	internal, version, err := apischeme.NormalizeCellConfig(in)
+	if err != nil {
+		t.Fatalf("NormalizeCellConfig() error = %v", err)
+	}
+	if version != ext.APIVersionV1Beta1 {
+		t.Errorf("version = %q, want v1beta1", version)
+	}
+	if internal.Metadata.Name != "kukeon-dev" || internal.Metadata.Realm != "kuke-system" ||
+		internal.Metadata.Space != "default" {
+		t.Errorf("carrier metadata = %+v, want name=kukeon-dev realm=kuke-system space=default", internal.Metadata)
+	}
+	if len(internal.Document) == 0 {
+		t.Fatal("carrier Document is empty, want serialized body")
+	}
+
+	out, err := apischeme.ConvertCellConfigToExternal(internal)
+	if err != nil {
+		t.Fatalf("ConvertCellConfigToExternal() error = %v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("round-trip mismatch:\n in = %+v\nout = %+v", in, out)
+	}
+}
+
+// TestConvertCellConfig_NormalizesKindAndVersion confirms an empty
+// apiVersion/kind on the way in is canonicalized in the stored document.
+func TestConvertCellConfig_NormalizesKindAndVersion(t *testing.T) {
+	in := sampleConfigDoc()
+	in.APIVersion = ""
+	in.Kind = ""
+
+	internal, _, err := apischeme.NormalizeCellConfig(in)
+	if err != nil {
+		t.Fatalf("NormalizeCellConfig() error = %v", err)
+	}
+	out, err := apischeme.ConvertCellConfigToExternal(internal)
+	if err != nil {
+		t.Fatalf("ConvertCellConfigToExternal() error = %v", err)
+	}
+	if out.APIVersion != ext.APIVersionV1Beta1 || out.Kind != ext.KindCellConfig {
+		t.Errorf("stored doc not canonicalized: apiVersion=%q kind=%q", out.APIVersion, out.Kind)
+	}
+}
+
+func TestConvertCellConfig_UnsupportedVersion(t *testing.T) {
+	in := sampleConfigDoc()
+	in.APIVersion = "v2"
+	if _, err := apischeme.ConvertCellConfigDocToInternal(in); err == nil {
+		t.Fatal("expected error for unsupported apiVersion, got nil")
+	}
+}

--- a/internal/apply/parser/config_test.go
+++ b/internal/apply/parser/config_test.go
@@ -1,0 +1,160 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func parseConfig(t *testing.T, yaml string) *parser.Document {
+	t.Helper()
+	doc, err := parser.ParseDocument(0, []byte(yaml))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v", err)
+	}
+	if doc.Kind != v1beta1.KindCellConfig {
+		t.Fatalf("kind = %q, want CellConfig", doc.Kind)
+	}
+	return doc
+}
+
+const validConfig = `apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: kukeon-dev
+  realm: kuke-system
+  space: default
+spec:
+  blueprint:
+    name: dev
+    realm: kuke-system
+  values:
+    PROJECT_DIR: kukeon
+  repos:
+    project:
+      url: git@github.com:eminwux/kukeon.git
+      branch: main
+  secrets:
+    anthropic-token:
+      secretRef:
+        name: anthropic
+        realm: kuke-system
+`
+
+func TestValidateDocument_Config_Valid(t *testing.T) {
+	doc := parseConfig(t, validConfig)
+	if err := parser.ValidateDocument(doc); err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+}
+
+func TestValidateDocument_Config_MissingName(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  realm: kuke-system
+spec:
+  blueprint:
+    name: dev
+    realm: kuke-system
+`
+	doc := parseConfig(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrConfigNameRequired)
+}
+
+func TestValidateDocument_Config_MissingRealm(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: kukeon-dev
+spec:
+  blueprint:
+    name: dev
+    realm: kuke-system
+`
+	doc := parseConfig(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrConfigRealmRequired)
+}
+
+func TestValidateDocument_Config_StackWithoutSpace(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: kukeon-dev
+  realm: kuke-system
+  stack: claude
+spec:
+  blueprint:
+    name: dev
+    realm: kuke-system
+`
+	doc := parseConfig(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrConfigScopeIncomplete)
+}
+
+func TestValidateDocument_Config_MissingBlueprintRef(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: kukeon-dev
+  realm: kuke-system
+spec:
+  blueprint:
+    name: dev
+`
+	doc := parseConfig(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrConfigBlueprintRefRequired)
+}
+
+func TestValidateDocument_Config_RepoFillMissingURL(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: kukeon-dev
+  realm: kuke-system
+spec:
+  blueprint:
+    name: dev
+    realm: kuke-system
+  repos:
+    project:
+      branch: main
+`
+	doc := parseConfig(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrConfigRepoFillURLRequired)
+}
+
+func TestValidateDocument_Config_SecretFillMissingRef(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: kukeon-dev
+  realm: kuke-system
+spec:
+  blueprint:
+    name: dev
+    realm: kuke-system
+  secrets:
+    anthropic-token: {}
+`
+	doc := parseConfig(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrConfigSecretFillRefRequired)
+}

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -43,6 +43,7 @@ type Document struct {
 	ContainerDoc     *v1beta1.ContainerDoc
 	SecretDoc        *v1beta1.SecretDoc
 	CellBlueprintDoc *v1beta1.CellBlueprintDoc
+	CellConfigDoc    *v1beta1.CellConfigDoc
 }
 
 // ValidationError represents a validation error for a specific document.
@@ -179,6 +180,14 @@ func ParseDocument(index int, raw []byte) (*Document, error) {
 		doc.CellBlueprintDoc = &blueprintDoc
 		doc.APIVersion = blueprintDoc.APIVersion
 
+	case v1beta1.KindCellConfig:
+		var configDoc v1beta1.CellConfigDoc
+		if unmarshalErr := yaml.Unmarshal(raw, &configDoc); unmarshalErr != nil {
+			return nil, fmt.Errorf("document %d: failed to parse CellConfig: %w", index, unmarshalErr)
+		}
+		doc.CellConfigDoc = &configDoc
+		doc.APIVersion = configDoc.APIVersion
+
 	default:
 		return nil, fmt.Errorf("document %d: %w: %s", index, errdefs.ErrUnknownKind, kind)
 	}
@@ -206,7 +215,8 @@ func ValidateDocument(doc *Document) *ValidationError {
 	// Validate kind
 	switch doc.Kind {
 	case v1beta1.KindRealm, v1beta1.KindSpace, v1beta1.KindStack, v1beta1.KindCell,
-		v1beta1.KindContainer, v1beta1.KindSecret, v1beta1.KindCellBlueprint:
+		v1beta1.KindContainer, v1beta1.KindSecret, v1beta1.KindCellBlueprint,
+		v1beta1.KindCellConfig:
 		// Valid kind
 	default:
 		return &ValidationError{
@@ -447,6 +457,11 @@ func ValidateDocument(doc *Document) *ValidationError {
 		if validationErr := validateBlueprint(doc); validationErr != nil {
 			return validationErr
 		}
+
+	case v1beta1.KindCellConfig:
+		if validationErr := validateConfig(doc); validationErr != nil {
+			return validationErr
+		}
 	}
 
 	return nil
@@ -568,6 +583,84 @@ func validateBlueprintSecretSlots(slots []v1beta1.BlueprintSecretSlot) error {
 		default:
 			return fmt.Errorf("%w (secrets[%d] %q mode %q)", errdefs.ErrBlueprintSecretSlotMode, i, name, mode)
 		}
+	}
+	return nil
+}
+
+// validateConfig enforces the structural contract for a kind: CellConfig
+// document (issue #624): name + scope coordinates, a present blueprint
+// reference, and the shape of each repo/secret slot fill. The slot-fill match
+// against the *referenced blueprint's declared slots* (unknown slot, required
+// slot unfilled) runs at reconcile time, the same split the Blueprint/Secret
+// scope-reachability gate uses — only the daemon can read the stored blueprint.
+func validateConfig(doc *Document) *ValidationError {
+	if doc.CellConfigDoc == nil {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Err: errors.New("config document is nil")}
+	}
+	cfg := doc.CellConfigDoc
+	if strings.TrimSpace(cfg.Metadata.Name) == "" {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Err: errdefs.ErrConfigNameRequired}
+	}
+	if scopeErr := validateConfigScope(cfg.Metadata); scopeErr != nil {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: cfg.Metadata.Name, Err: scopeErr}
+	}
+	if refErr := validateConfigBlueprintRef(cfg.Spec.Blueprint); refErr != nil {
+		return &ValidationError{Index: doc.Index, Kind: doc.Kind, Name: cfg.Metadata.Name, Err: refErr}
+	}
+	for name, fill := range cfg.Spec.Repos {
+		if strings.TrimSpace(fill.URL) == "" {
+			return &ValidationError{
+				Index: doc.Index, Kind: doc.Kind, Name: cfg.Metadata.Name,
+				Err: fmt.Errorf("%w (repos[%q])", errdefs.ErrConfigRepoFillURLRequired, name),
+			}
+		}
+	}
+	for name, fill := range cfg.Spec.Secrets {
+		if fill.SecretRef == nil ||
+			strings.TrimSpace(fill.SecretRef.Name) == "" ||
+			strings.TrimSpace(fill.SecretRef.Realm) == "" {
+			return &ValidationError{
+				Index: doc.Index, Kind: doc.Kind, Name: cfg.Metadata.Name,
+				Err: fmt.Errorf("%w (secrets[%q])", errdefs.ErrConfigSecretFillRefRequired, name),
+			}
+		}
+	}
+	return nil
+}
+
+// validateConfigScope enforces the CellConfig scope-coordinate contract:
+// metadata.realm is always required, a deeper coordinate may only be set when
+// every shallower one is, and — like a Blueprint — a Config may not be
+// cell-scoped.
+func validateConfigScope(md v1beta1.CellConfigMetadata) error {
+	realm := strings.TrimSpace(md.Realm)
+	space := strings.TrimSpace(md.Space)
+	stack := strings.TrimSpace(md.Stack)
+
+	if realm == "" {
+		return errdefs.ErrConfigRealmRequired
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrConfigScopeIncomplete)
+	}
+	return nil
+}
+
+// validateConfigBlueprintRef enforces the referenced-blueprint shape: name and
+// realm are required, and the optional space/stack coordinates follow the same
+// deeper-requires-shallower contract. It does not check the blueprint exists on
+// the host — that reachability gate runs at reconcile time against the runner.
+func validateConfigBlueprintRef(ref v1beta1.CellConfigBlueprintRef) error {
+	name := strings.TrimSpace(ref.Name)
+	realm := strings.TrimSpace(ref.Realm)
+	space := strings.TrimSpace(ref.Space)
+	stack := strings.TrimSpace(ref.Stack)
+
+	if name == "" || realm == "" {
+		return errdefs.ErrConfigBlueprintRefRequired
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrConfigBlueprintRefScopeIncomplete)
 	}
 	return nil
 }

--- a/internal/cellconfig/cellconfig.go
+++ b/internal/cellconfig/cellconfig.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cellconfig holds the identity primitives for a daemon-stored
+// CellConfig (kind: CellConfig, issue #624, phase 4b-i of #423): the
+// back-reference label a materialized cell carries, the deterministic
+// stable-name derivation, and the slot-fill validation that checks a Config's
+// repo/secret fills against the referenced blueprint's declared structural
+// slots. It is the config analog of the cellblueprint package's materialization
+// helpers; the runtime state machine that consumes these primitives (and the
+// `kuke run -c` verb that drives it) lands in #625.
+package cellconfig
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// LabelConfig is the cell label recording the CellConfig a cell was
+// materialized from, the config analog of cellprofile.LabelProfile and
+// cellblueprint.LabelBlueprint. Set on the cell that `kuke run -c` materializes
+// (#625) so the state machine can find the at-most-one live cell a Config owns
+// (`kuke get cells -l kukeon.io/config=<name>`).
+const LabelConfig = "kukeon.io/config"
+
+// StableName derives the deterministic name of the cell a CellConfig
+// materializes from the config's metadata.name.
+//
+// Decision (issue #624 AC): the derivation is the config name *verbatim*, not
+// `<name>-<hash-of-values>`. The CellConfig contract is "one Config → at most
+// one live cell within scope" with a stable identity that survives edits to the
+// config's values; #625's divergent-spec warning explicitly attaches to the
+// existing live cell when the Config diverged since materialization. A
+// value-hashed suffix would change the derived name on every value edit,
+// spawning a fresh cell and orphaning the old one — defeating the idempotent
+// identity that distinguishes a Config (`run -c`) from a Blueprint's
+// always-fresh `<prefix>-<6hex>` (`run -b`). So the name is value-independent.
+func StableName(configName string) string {
+	return strings.TrimSpace(configName)
+}
+
+// ValidateSlotFill checks a CellConfig's structural slot fills against the slots
+// the referenced blueprint declares (issue #624). Matching is by slot name,
+// across all of the blueprint's containers:
+//
+//   - a repo slot is a blueprint repo with no inline url (a url'd repo is a
+//     scalar-mode value, not a fillable slot);
+//   - every blueprint secret slot is structural (the blueprint never carries
+//     the secret source).
+//
+// It enforces the AC's two gates: a Config that fills a slot the blueprint does
+// not declare is an error (ErrConfigUnknown{Repo,Secret}Slot), and a *required*
+// slot the blueprint declares that the Config leaves unfilled is an error
+// (ErrConfigRequiredSlotUnfilled). A slot is treated as required if any
+// declaration of that name across the blueprint's containers is required.
+func ValidateSlotFill(cfg v1beta1.CellConfigDoc, bp v1beta1.CellBlueprintDoc) error {
+	repoRequired := map[string]bool{}
+	secretRequired := map[string]bool{}
+	for _, c := range bp.Spec.Cell.Containers {
+		for _, r := range c.Repos {
+			if strings.TrimSpace(r.URL) != "" {
+				continue // scalar-mode repo, not a fillable slot
+			}
+			name := strings.TrimSpace(r.Name)
+			repoRequired[name] = repoRequired[name] || r.Required
+		}
+		for _, s := range c.Secrets {
+			name := strings.TrimSpace(s.Name)
+			secretRequired[name] = secretRequired[name] || s.Required
+		}
+	}
+
+	for name := range cfg.Spec.Repos {
+		if _, ok := repoRequired[strings.TrimSpace(name)]; !ok {
+			return fmt.Errorf("%w: repo slot %q", errdefs.ErrConfigUnknownRepoSlot, name)
+		}
+	}
+	for name := range cfg.Spec.Secrets {
+		if _, ok := secretRequired[strings.TrimSpace(name)]; !ok {
+			return fmt.Errorf("%w: secret slot %q", errdefs.ErrConfigUnknownSecretSlot, name)
+		}
+	}
+
+	for name, required := range repoRequired {
+		if required {
+			if _, ok := cfg.Spec.Repos[name]; !ok {
+				return fmt.Errorf("%w: repo slot %q", errdefs.ErrConfigRequiredSlotUnfilled, name)
+			}
+		}
+	}
+	for name, required := range secretRequired {
+		if required {
+			if _, ok := cfg.Spec.Secrets[name]; !ok {
+				return fmt.Errorf("%w: secret slot %q", errdefs.ErrConfigRequiredSlotUnfilled, name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/cellconfig/cellconfig_test.go
+++ b/internal/cellconfig/cellconfig_test.go
@@ -1,0 +1,165 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellconfig_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestStableName_Verbatim pins the issue #624 decision: the materialized cell
+// name is the config name verbatim (trimmed), value-independent so the identity
+// survives value edits.
+func TestStableName_Verbatim(t *testing.T) {
+	cases := map[string]string{
+		"kukeon-dev":   "kukeon-dev",
+		"  spaced  ":   "spaced",
+		"team-a-build": "team-a-build",
+	}
+	for in, want := range cases {
+		if got := cellconfig.StableName(in); got != want {
+			t.Errorf("StableName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// blueprintWithSlots builds a one-container blueprint declaring the given repo
+// slots (name→required, all url-empty/structural) and secret slots.
+func blueprintWithSlots(repos, secrets map[string]bool) v1beta1.CellBlueprintDoc {
+	var repoSlots []v1beta1.ContainerRepo
+	for name, required := range repos {
+		repoSlots = append(repoSlots, v1beta1.ContainerRepo{
+			Name: name, Target: "/work/" + name, Required: required,
+		})
+	}
+	var secretSlots []v1beta1.BlueprintSecretSlot
+	for name, required := range secrets {
+		secretSlots = append(secretSlots, v1beta1.BlueprintSecretSlot{
+			Name: name, Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "E_" + name, Required: required,
+		})
+	}
+	return v1beta1.CellBlueprintDoc{
+		Spec: v1beta1.CellBlueprintSpec{
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "main", Image: "img", Repos: repoSlots, Secrets: secretSlots},
+				},
+			},
+		},
+	}
+}
+
+func TestValidateSlotFill_AllFilled(t *testing.T) {
+	bp := blueprintWithSlots(
+		map[string]bool{"project": true},
+		map[string]bool{"token": true},
+	)
+	cfg := v1beta1.CellConfigDoc{
+		Spec: v1beta1.CellConfigSpec{
+			Repos:   map[string]v1beta1.CellConfigRepoFill{"project": {URL: "git@x:y.git"}},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "t", Realm: "r"}}},
+		},
+	}
+	if err := cellconfig.ValidateSlotFill(cfg, bp); err != nil {
+		t.Fatalf("ValidateSlotFill() error = %v, want nil", err)
+	}
+}
+
+func TestValidateSlotFill_RequiredRepoUnfilled(t *testing.T) {
+	bp := blueprintWithSlots(map[string]bool{"project": true}, nil)
+	cfg := v1beta1.CellConfigDoc{} // no fills
+	err := cellconfig.ValidateSlotFill(cfg, bp)
+	if !errors.Is(err, errdefs.ErrConfigRequiredSlotUnfilled) {
+		t.Fatalf("err = %v, want ErrConfigRequiredSlotUnfilled", err)
+	}
+}
+
+func TestValidateSlotFill_RequiredSecretUnfilled(t *testing.T) {
+	bp := blueprintWithSlots(nil, map[string]bool{"token": true})
+	cfg := v1beta1.CellConfigDoc{}
+	err := cellconfig.ValidateSlotFill(cfg, bp)
+	if !errors.Is(err, errdefs.ErrConfigRequiredSlotUnfilled) {
+		t.Fatalf("err = %v, want ErrConfigRequiredSlotUnfilled", err)
+	}
+}
+
+func TestValidateSlotFill_OptionalUnfilledOK(t *testing.T) {
+	bp := blueprintWithSlots(
+		map[string]bool{"project": false},
+		map[string]bool{"token": false},
+	)
+	if err := cellconfig.ValidateSlotFill(v1beta1.CellConfigDoc{}, bp); err != nil {
+		t.Fatalf("ValidateSlotFill() error = %v, want nil for optional unfilled slots", err)
+	}
+}
+
+func TestValidateSlotFill_UnknownRepoSlot(t *testing.T) {
+	bp := blueprintWithSlots(map[string]bool{"project": false}, nil)
+	cfg := v1beta1.CellConfigDoc{
+		Spec: v1beta1.CellConfigSpec{
+			Repos: map[string]v1beta1.CellConfigRepoFill{"typo": {URL: "git@x:y.git"}},
+		},
+	}
+	err := cellconfig.ValidateSlotFill(cfg, bp)
+	if !errors.Is(err, errdefs.ErrConfigUnknownRepoSlot) {
+		t.Fatalf("err = %v, want ErrConfigUnknownRepoSlot", err)
+	}
+}
+
+func TestValidateSlotFill_UnknownSecretSlot(t *testing.T) {
+	bp := blueprintWithSlots(nil, map[string]bool{"token": false})
+	cfg := v1beta1.CellConfigDoc{
+		Spec: v1beta1.CellConfigSpec{
+			Secrets: map[string]v1beta1.CellConfigSecretFill{"typo": {SecretRef: &v1beta1.ContainerSecretRef{Name: "t", Realm: "r"}}},
+		},
+	}
+	err := cellconfig.ValidateSlotFill(cfg, bp)
+	if !errors.Is(err, errdefs.ErrConfigUnknownSecretSlot) {
+		t.Fatalf("err = %v, want ErrConfigUnknownSecretSlot", err)
+	}
+}
+
+// TestValidateSlotFill_InlineRepoNotASlot confirms a blueprint repo with an
+// inline url is scalar-mode, not a fillable slot: a config that names it is an
+// unknown-slot error, not a match.
+func TestValidateSlotFill_InlineRepoNotASlot(t *testing.T) {
+	bp := v1beta1.CellBlueprintDoc{
+		Spec: v1beta1.CellBlueprintSpec{
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "main", Image: "img", Repos: []v1beta1.ContainerRepo{
+						{Name: "inlined", Target: "/work", URL: "git@x:y.git"},
+					}},
+				},
+			},
+		},
+	}
+	cfg := v1beta1.CellConfigDoc{
+		Spec: v1beta1.CellConfigSpec{
+			Repos: map[string]v1beta1.CellConfigRepoFill{"inlined": {URL: "git@a:b.git"}},
+		},
+	}
+	if err := cellconfig.ValidateSlotFill(cfg, bp); !errors.Is(err, errdefs.ErrConfigUnknownRepoSlot) {
+		t.Fatalf("err = %v, want ErrConfigUnknownRepoSlot (inline-url repo is not a slot)", err)
+	}
+}

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -55,6 +55,15 @@ const (
 	// (0o755 / 0o644).
 	KukeonBlueprintsSubdir = "blueprints"
 
+	// KukeonConfigsSubdir is the basename of the per-scope subdirectory that
+	// owns daemon-managed `kind: CellConfig` documents (issue #624). Like the
+	// blueprints subdir it lives inside the scope's metadata directory (e.g.
+	// <RunPath>/data/<realm>/configs/) so a scope teardown reclaims it, and like
+	// a blueprint a config carries only references (a blueprint name, repo URLs,
+	// secretRefs) — no credential bytes — so the directory and files are
+	// root-owned but world-readable (0o755 / 0o644).
+	KukeonConfigsSubdir = "configs"
+
 	// KukeonContainerTTYDir is the basename of the per-container directory
 	// that owns the sbsh terminal socket plus its capture and log siblings.
 	// kukeon bind-mounts this directory (not a single file) into the

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -236,6 +236,23 @@ func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
 			resourceResult.Name = blueprint.Metadata.Name
 			reconcileResult, reconcileErr = applypkg.ReconcileBlueprint(b.runner, blueprint)
 
+		case v1beta1.KindCellConfig:
+			if doc.CellConfigDoc == nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = errors.New("config document is nil")
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			config, _, err := apischeme.NormalizeCellConfig(*doc.CellConfigDoc)
+			if err != nil {
+				resourceResult.Action = actionFailed
+				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+				result.Resources = append(result.Resources, resourceResult)
+				continue
+			}
+			resourceResult.Name = config.Metadata.Name
+			reconcileResult, reconcileErr = applypkg.ReconcileConfig(b.runner, config)
+
 		default:
 			resourceResult.Action = actionFailed
 			resourceResult.Error = fmt.Errorf("%w: %s", errdefs.ErrUnknownKind, doc.Kind)

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/controller/runner"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -688,6 +690,112 @@ func blueprintScopeLookupError(err error, level, name string) error {
 		return fmt.Errorf("%w: %s %q", errdefs.ErrBlueprintScopeNotFound, level, name)
 	default:
 		return fmt.Errorf("failed to verify blueprint scope %s %q: %w", level, name, err)
+	}
+}
+
+// ReconcileConfig reconciles a desired `kind: CellConfig` by verifying its own
+// scope exists, resolving the referenced CellBlueprint from daemon storage,
+// validating the config's structural slot fills against that blueprint's
+// declared slots, and persisting the config document (issue #624). Like
+// ReconcileSecret/ReconcileBlueprint it never auto-creates a missing scope, and
+// the document is written write-through — re-applying overwrites and reports
+// "updated". The slot-fill match runs here (not at parse time) because only the
+// daemon can read the stored blueprint the config references.
+func ReconcileConfig(r runner.Runner, desired intmodel.CellConfig) (ReconcileResult, error) {
+	result := ReconcileResult{
+		Action: "unchanged",
+		Kind:   "CellConfig",
+		Name:   desired.Metadata.Name,
+	}
+
+	if err := ensureConfigScopeExists(r, desired.Metadata); err != nil {
+		return result, err
+	}
+
+	cfgDoc, err := apischeme.ConvertCellConfigToExternal(desired)
+	if err != nil {
+		return result, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+
+	ref := cfgDoc.Spec.Blueprint
+	bpCarrier, getErr := r.GetBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{
+			Name:  ref.Name,
+			Realm: ref.Realm,
+			Space: ref.Space,
+			Stack: ref.Stack,
+		},
+	})
+	if getErr != nil {
+		if errors.Is(getErr, errdefs.ErrBlueprintNotFound) {
+			return result, fmt.Errorf("%w: %q (realm %q)", errdefs.ErrConfigBlueprintNotFound, ref.Name, ref.Realm)
+		}
+		return result, fmt.Errorf("failed to read referenced blueprint %q: %w", ref.Name, getErr)
+	}
+	bpDoc, bpErr := apischeme.ConvertCellBlueprintToExternal(bpCarrier)
+	if bpErr != nil {
+		return result, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, bpErr)
+	}
+
+	if slotErr := cellconfig.ValidateSlotFill(cfgDoc, bpDoc); slotErr != nil {
+		return result, slotErr
+	}
+
+	created, writeErr := r.WriteConfig(desired)
+	if writeErr != nil {
+		return result, writeErr
+	}
+	if created {
+		result.Action = actionCreated
+	} else {
+		result.Action = actionUpdated
+	}
+	return result, nil
+}
+
+// ensureConfigScopeExists verifies every scope coordinate the config names is
+// reachable, deepest-first. A Config is scopable at realm/space/stack only
+// (never cell), so the walk stops at the stack. A NotFound is translated to
+// errdefs.ErrConfigScopeNotFound.
+func ensureConfigScopeExists(r runner.Runner, md intmodel.CellConfigMetadata) error {
+	if _, err := r.GetRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: md.Realm},
+	}); err != nil {
+		return configScopeLookupError(err, "realm", md.Realm)
+	}
+
+	if md.Space != "" {
+		if _, err := r.GetSpace(intmodel.Space{
+			Metadata: intmodel.SpaceMetadata{Name: md.Space},
+			Spec:     intmodel.SpaceSpec{RealmName: md.Realm},
+		}); err != nil {
+			return configScopeLookupError(err, "space", md.Space)
+		}
+	}
+
+	if md.Stack != "" {
+		if _, err := r.GetStack(intmodel.Stack{
+			Metadata: intmodel.StackMetadata{Name: md.Stack},
+			Spec:     intmodel.StackSpec{RealmName: md.Realm, SpaceName: md.Space},
+		}); err != nil {
+			return configScopeLookupError(err, "stack", md.Stack)
+		}
+	}
+
+	return nil
+}
+
+// configScopeLookupError maps a scope Get failure to a stable error. A NotFound
+// at any level becomes ErrConfigScopeNotFound; any other error is propagated
+// with context so it is not masked as a missing scope.
+func configScopeLookupError(err error, level, name string) error {
+	switch {
+	case errors.Is(err, errdefs.ErrRealmNotFound),
+		errors.Is(err, errdefs.ErrSpaceNotFound),
+		errors.Is(err, errdefs.ErrStackNotFound):
+		return fmt.Errorf("%w: %s %q", errdefs.ErrConfigScopeNotFound, level, name)
+	default:
+		return fmt.Errorf("failed to verify config scope %s %q: %w", level, name, err)
 	}
 }
 

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -71,6 +71,9 @@ type fakeRunner struct {
 	ListBlueprintsFn  func(realmName, spaceName, stackName string) ([]intmodel.CellBlueprint, error)
 	DeleteBlueprintFn func(bp intmodel.CellBlueprint) error
 
+	// Config methods
+	WriteConfigFn func(config intmodel.CellConfig) (bool, error)
+
 	// Cell methods
 	GetCellFn                 func(cell intmodel.Cell) (intmodel.Cell, error)
 	ListCellsFn               func(realmName, spaceName, stackName string) ([]intmodel.Cell, error)
@@ -324,6 +327,15 @@ func (f *fakeRunner) DeleteBlueprint(bp intmodel.CellBlueprint) error {
 		return f.DeleteBlueprintFn(bp)
 	}
 	return errors.New("unexpected call to DeleteBlueprint")
+}
+
+// Config methods
+
+func (f *fakeRunner) WriteConfig(config intmodel.CellConfig) (bool, error) {
+	if f.WriteConfigFn != nil {
+		return f.WriteConfigFn(config)
+	}
+	return false, errors.New("unexpected call to WriteConfig")
 }
 
 // Cell methods

--- a/internal/controller/documents.go
+++ b/internal/controller/documents.go
@@ -52,6 +52,13 @@ func SortDocumentsByKind(docs []parser.Document, reverse bool) []parser.Document
 	// that targets it (reconcile rejects a blueprint whose scope does not yet
 	// exist). Evaluated after the Secret line so it lands one slot further out.
 	kindOrder[v1beta1.KindCellBlueprint] = len(kindOrder) + 1
+	// CellConfigs reference a CellBlueprint and validate their slot fills
+	// against it at reconcile time, so they sort after CellBlueprints: a
+	// blueprint bundled in the same apply file is written before a config that
+	// references it (reconcile rejects a config whose blueprint does not yet
+	// exist). Evaluated after the CellBlueprint line so it lands one slot
+	// further out.
+	kindOrder[v1beta1.KindCellConfig] = len(kindOrder) + 1
 
 	// Sort by kind order, then by original index
 	sort.Slice(sorted, func(i, j int) bool {

--- a/internal/controller/reconcile_config_test.go
+++ b/internal/controller/reconcile_config_test.go
@@ -1,0 +1,178 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	applypkg "github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// configCarrier serializes an external CellConfigDoc into the internal carrier
+// ReconcileConfig consumes.
+func configCarrier(t *testing.T, doc ext.CellConfigDoc) intmodel.CellConfig {
+	t.Helper()
+	carrier, err := apischeme.ConvertCellConfigDocToInternal(doc)
+	if err != nil {
+		t.Fatalf("ConvertCellConfigDocToInternal() error = %v", err)
+	}
+	return carrier
+}
+
+// blueprintCarrier serializes an external CellBlueprintDoc into the internal
+// carrier GetBlueprint hands back.
+func blueprintCarrier(t *testing.T, doc ext.CellBlueprintDoc) intmodel.CellBlueprint {
+	t.Helper()
+	carrier, err := apischeme.ConvertCellBlueprintDocToInternal(doc)
+	if err != nil {
+		t.Fatalf("ConvertCellBlueprintDocToInternal() error = %v", err)
+	}
+	return carrier
+}
+
+func sampleConfig() ext.CellConfigDoc {
+	return ext.CellConfigDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCellConfig,
+		Metadata:   ext.CellConfigMetadata{Name: "kukeon-dev", Realm: "kuke-system"},
+		Spec: ext.CellConfigSpec{
+			Blueprint: ext.CellConfigBlueprintRef{Name: "dev", Realm: "kuke-system"},
+			Repos: map[string]ext.CellConfigRepoFill{
+				"project": {URL: "git@github.com:eminwux/kukeon.git"},
+			},
+		},
+	}
+}
+
+func sampleReferencedBlueprint() ext.CellBlueprintDoc {
+	return ext.CellBlueprintDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCellBlueprint,
+		Metadata:   ext.CellBlueprintMetadata{Name: "dev", Realm: "kuke-system"},
+		Spec: ext.CellBlueprintSpec{
+			Cell: ext.BlueprintCellSpec{
+				Containers: []ext.BlueprintContainer{
+					{ID: "main", Image: "img", Repos: []ext.ContainerRepo{
+						{Name: "project", Target: "/work", Required: true},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// TestReconcileConfig_WritesWhenScopeAndBlueprintExist is the issue #624 happy
+// path: scope reachable, referenced blueprint resolves, required slot filled →
+// the document is written and the action is created.
+func TestReconcileConfig_WritesWhenScopeAndBlueprintExist(t *testing.T) {
+	var wrote []byte
+	f := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) { return realm, nil },
+		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleReferencedBlueprint()), nil
+		},
+		WriteConfigFn: func(c intmodel.CellConfig) (bool, error) {
+			wrote = c.Document
+			return true, nil
+		},
+	}
+
+	result, err := applypkg.ReconcileConfig(f, configCarrier(t, sampleConfig()))
+	if err != nil {
+		t.Fatalf("ReconcileConfig() error = %v", err)
+	}
+	if result.Action != "created" {
+		t.Errorf("action = %q, want created", result.Action)
+	}
+	if len(wrote) == 0 {
+		t.Error("WriteConfig got an empty document")
+	}
+}
+
+// TestReconcileConfig_RejectsMissingScope confirms the scope-reachability gate:
+// a realm-not-found surfaces ErrConfigScopeNotFound and WriteConfig is never
+// reached.
+func TestReconcileConfig_RejectsMissingScope(t *testing.T) {
+	var wrote bool
+	f := &fakeRunner{
+		GetRealmFn: func(intmodel.Realm) (intmodel.Realm, error) {
+			return intmodel.Realm{}, errdefs.ErrRealmNotFound
+		},
+		WriteConfigFn: func(intmodel.CellConfig) (bool, error) { wrote = true; return false, nil },
+	}
+
+	_, err := applypkg.ReconcileConfig(f, configCarrier(t, sampleConfig()))
+	if !errors.Is(err, errdefs.ErrConfigScopeNotFound) {
+		t.Fatalf("err = %v, want ErrConfigScopeNotFound", err)
+	}
+	if wrote {
+		t.Error("WriteConfig was called despite a missing scope")
+	}
+}
+
+// TestReconcileConfig_RejectsMissingBlueprint confirms an absent referenced
+// blueprint surfaces ErrConfigBlueprintNotFound and WriteConfig is never
+// reached.
+func TestReconcileConfig_RejectsMissingBlueprint(t *testing.T) {
+	var wrote bool
+	f := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) { return realm, nil },
+		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return intmodel.CellBlueprint{}, errdefs.ErrBlueprintNotFound
+		},
+		WriteConfigFn: func(intmodel.CellConfig) (bool, error) { wrote = true; return false, nil },
+	}
+
+	_, err := applypkg.ReconcileConfig(f, configCarrier(t, sampleConfig()))
+	if !errors.Is(err, errdefs.ErrConfigBlueprintNotFound) {
+		t.Fatalf("err = %v, want ErrConfigBlueprintNotFound", err)
+	}
+	if wrote {
+		t.Error("WriteConfig was called despite a missing blueprint")
+	}
+}
+
+// TestReconcileConfig_RejectsUnfilledRequiredSlot confirms slot-fill validation
+// runs against the referenced blueprint: a required slot the config leaves
+// unfilled surfaces ErrConfigRequiredSlotUnfilled, before any write.
+func TestReconcileConfig_RejectsUnfilledRequiredSlot(t *testing.T) {
+	var wrote bool
+	cfg := sampleConfig()
+	cfg.Spec.Repos = nil // leave the required "project" repo slot unfilled
+	f := &fakeRunner{
+		GetRealmFn: func(realm intmodel.Realm) (intmodel.Realm, error) { return realm, nil },
+		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleReferencedBlueprint()), nil
+		},
+		WriteConfigFn: func(intmodel.CellConfig) (bool, error) { wrote = true; return false, nil },
+	}
+
+	_, err := applypkg.ReconcileConfig(f, configCarrier(t, cfg))
+	if !errors.Is(err, errdefs.ErrConfigRequiredSlotUnfilled) {
+		t.Fatalf("err = %v, want ErrConfigRequiredSlotUnfilled", err)
+	}
+	if wrote {
+		t.Error("WriteConfig was called despite an unfilled required slot")
+	}
+}

--- a/internal/controller/runner/config.go
+++ b/internal/controller/runner/config.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// configsDirMode is the mode of the per-scope configs/ directory. Like the
+// blueprints/ directory and unlike the root-only secrets/ directory, a config
+// carries no credential bytes — only references — so it is world-readable
+// (issue #624).
+const configsDirMode os.FileMode = 0o755
+
+// configFileMode is the mode of an individual config document file: root-owned,
+// world-readable. References only, no secret material.
+const configFileMode os.FileMode = 0o644
+
+// WriteConfig persists a CellConfig's serialized document to
+// <RunPath>/data/<scope>/configs/<name>, root-owned and world-readable (issue
+// #624). The document is written atomically via a temp file + rename so a
+// reader never observes a partially-written config. Returns whether the file
+// was newly created (vs. overwritten). The caller (ReconcileConfig) is
+// responsible for having verified the scope exists and the referenced blueprint
+// resolves.
+func (r *Exec) WriteConfig(config intmodel.CellConfig) (bool, error) {
+	md := config.Metadata
+	dir := fs.ConfigsDir(r.opts.RunPath, md.Realm, md.Space, md.Stack)
+	path := fs.ConfigPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	if err := os.MkdirAll(dir, configsDirMode); err != nil {
+		return false, fmt.Errorf("%w: create configs dir: %w", errdefs.ErrWriteConfig, err)
+	}
+	// MkdirAll honors only the rwx bits and leaves a pre-existing directory's
+	// mode intact; chmod unconditionally so the world-readable contract holds
+	// even when a parent created the dir with tighter bits or the umask
+	// stripped them.
+	if err := os.Chmod(dir, configsDirMode); err != nil {
+		return false, fmt.Errorf("%w: chmod configs dir: %w", errdefs.ErrWriteConfig, err)
+	}
+
+	_, statErr := os.Stat(path)
+	created := errors.Is(statErr, os.ErrNotExist)
+	if statErr != nil && !created {
+		return false, fmt.Errorf("%w: stat config: %w", errdefs.ErrWriteConfig, statErr)
+	}
+
+	if err := atomicWriteFileMode(dir, path, ".config-*.tmp", config.Document, configFileMode); err != nil {
+		return false, fmt.Errorf("%w: %w", errdefs.ErrWriteConfig, err)
+	}
+
+	action := "updated"
+	if created {
+		action = "created"
+	}
+	r.logger.InfoContext(r.ctx, "config "+action,
+		"name", md.Name,
+		"realm", md.Realm,
+		"space", md.Space,
+		"stack", md.Stack,
+	)
+	return created, nil
+}

--- a/internal/controller/runner/config_test.go
+++ b/internal/controller/runner/config_test.go
@@ -1,0 +1,132 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // tests the unexported WriteConfig path against a temp RunPath
+package runner
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
+
+// TestWriteConfig_CreatesWorldReadableFile pins the issue #624 storage contract:
+// the document lands at <RunPath>/data/<scope>/configs/<name>, the file is 0o644
+// and the configs/ dir is 0o755 (world-readable, like blueprints and unlike the
+// root-only secrets path), and the first write reports created=true.
+func TestWriteConfig_CreatesWorldReadableFile(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	cfg := intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "kukeon-dev", Realm: "kuke-system"},
+		Document: []byte("apiVersion: v1beta1\nkind: CellConfig\n"),
+	}
+
+	created, err := r.WriteConfig(cfg)
+	if err != nil {
+		t.Fatalf("WriteConfig() error = %v", err)
+	}
+	if !created {
+		t.Errorf("created = false, want true on first write")
+	}
+
+	path := fs.ConfigPath(runPath, "kuke-system", "", "", "kukeon-dev")
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written config: %v", err)
+	}
+	if string(got) != string(cfg.Document) {
+		t.Errorf("config bytes = %q, want %q", got, cfg.Document)
+	}
+
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat config file: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0o644 {
+		t.Errorf("config file mode = %o, want 644 (world-readable)", perm)
+	}
+
+	dirInfo, err := os.Stat(fs.ConfigsDir(runPath, "kuke-system", "", ""))
+	if err != nil {
+		t.Fatalf("stat configs dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o755 {
+		t.Errorf("configs dir mode = %o, want 755 (world-readable)", perm)
+	}
+}
+
+// TestWriteConfig_OverwriteReportsUpdated confirms a re-apply overwrites the
+// document and reports created=false.
+func TestWriteConfig_OverwriteReportsUpdated(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	cfg := intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "kukeon-dev", Realm: "kuke-system"},
+		Document: []byte("v1"),
+	}
+	if _, err := r.WriteConfig(cfg); err != nil {
+		t.Fatalf("first WriteConfig() error = %v", err)
+	}
+
+	cfg.Document = []byte("v2")
+	created, err := r.WriteConfig(cfg)
+	if err != nil {
+		t.Fatalf("second WriteConfig() error = %v", err)
+	}
+	if created {
+		t.Errorf("created = true, want false on overwrite")
+	}
+
+	got, err := os.ReadFile(fs.ConfigPath(runPath, "kuke-system", "", "", "kukeon-dev"))
+	if err != nil {
+		t.Fatalf("reading overwritten config: %v", err)
+	}
+	if string(got) != "v2" {
+		t.Errorf("config bytes = %q, want v2", got)
+	}
+}
+
+// TestWriteConfig_DeeperScopeNestsUnderScopeDir confirms a space-scoped config
+// lands under the space metadata dir, not the realm dir.
+func TestWriteConfig_DeeperScopeNestsUnderScopeDir(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	cfg := intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "dev", Realm: "kuke-system", Space: "team-a"},
+		Document: []byte("x"),
+	}
+	if _, err := r.WriteConfig(cfg); err != nil {
+		t.Fatalf("WriteConfig() error = %v", err)
+	}
+
+	spaceScoped := fs.ConfigPath(runPath, "kuke-system", "team-a", "", "dev")
+	if _, err := os.Stat(spaceScoped); err != nil {
+		t.Errorf("space-scoped config not found at %s: %v", spaceScoped, err)
+	}
+	realmScoped := fs.ConfigPath(runPath, "kuke-system", "", "", "dev")
+	if _, err := os.Stat(realmScoped); !os.IsNotExist(err) {
+		t.Errorf("config leaked into realm scope at %s (err=%v)", realmScoped, err)
+	}
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -142,6 +142,13 @@ type Runner interface {
 	// errdefs.ErrBlueprintNotFound when the file is absent.
 	DeleteBlueprint(blueprint intmodel.CellBlueprint) error
 
+	// WriteConfig persists a `kind: CellConfig`'s serialized document to the
+	// daemon-managed, root-owned, world-readable file under the scope's metadata
+	// tree (issue #624). Returns whether the file was newly created (vs.
+	// overwritten). The caller (ReconcileConfig) is responsible for having
+	// verified the config's scope exists and the referenced blueprint resolves.
+	WriteConfig(config intmodel.CellConfig) (created bool, err error)
+
 	ExistsCgroup(doc any) (bool, error)
 
 	PurgeRealm(realm intmodel.Realm) (namespaceRemoved bool, err error)

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -375,6 +375,48 @@ var (
 		"blueprint secret slot with mode \"file\" requires an absolute mountPath",
 	)
 
+	// CellConfig kind (kind: CellConfig) errors (issue #624, phase 4b-i of #423).
+
+	ErrConfigNameRequired  = errors.New("config metadata.name is required")
+	ErrConfigRealmRequired = errors.New("config metadata.realm is required")
+	// ErrConfigScopeIncomplete fires when a deeper scope coordinate is set
+	// without every shallower one. A Config is scopable at realm/space/stack
+	// only, so a set cell coordinate is itself a violation.
+	ErrConfigScopeIncomplete = errors.New(
+		"config scope is incomplete: a deeper scope coordinate requires all shallower ones (and a Config may not be cell-scoped)",
+	)
+	// ErrConfigBlueprintRefRequired fires when spec.blueprint omits the
+	// referenced blueprint's name or realm — both are required to resolve it.
+	ErrConfigBlueprintRefRequired = errors.New("config spec.blueprint requires name and realm")
+	// ErrConfigBlueprintRefScopeIncomplete fires when the referenced blueprint's
+	// scope coordinates are incomplete (a deeper coordinate without a shallower).
+	ErrConfigBlueprintRefScopeIncomplete = errors.New(
+		"config spec.blueprint scope is incomplete: a deeper coordinate requires all shallower ones",
+	)
+	// ErrConfigRepoFillURLRequired fires when a spec.repos fill omits its url —
+	// the fill exists to supply the clone source the blueprint left open.
+	ErrConfigRepoFillURLRequired = errors.New("config repo slot fill requires url")
+	// ErrConfigSecretFillRefRequired fires when a spec.secrets fill omits its
+	// secretRef (name + realm) — the fill exists to supply the secret source.
+	ErrConfigSecretFillRefRequired = errors.New("config secret slot fill requires secretRef name and realm")
+	// ErrConfigBlueprintNotFound fires at apply time when the referenced
+	// blueprint cannot be read from daemon storage at its named scope.
+	ErrConfigBlueprintNotFound = errors.New("config references a blueprint that does not exist")
+	// ErrConfigUnknownRepoSlot fires when spec.repos names a slot the referenced
+	// blueprint does not declare as a structural repo slot.
+	ErrConfigUnknownRepoSlot = errors.New("config fills a repo slot the blueprint does not declare")
+	// ErrConfigUnknownSecretSlot fires when spec.secrets names a slot the
+	// referenced blueprint does not declare.
+	ErrConfigUnknownSecretSlot = errors.New("config fills a secret slot the blueprint does not declare")
+	// ErrConfigRequiredSlotUnfilled fires when a required structural slot the
+	// blueprint declares is not filled by the config.
+	ErrConfigRequiredSlotUnfilled = errors.New("config leaves a required blueprint slot unfilled")
+	// ErrConfigScopeNotFound fires when the config's own scope (realm/space/
+	// stack) does not exist on the host at apply time.
+	ErrConfigScopeNotFound = errors.New("config scope does not exist")
+	// ErrWriteConfig wraps a failure to persist a CellConfig document.
+	ErrWriteConfig = errors.New("failed to write config document")
+
 	// ErrMustRunAsRoot is returned by direct-write subcommands (kuke init,
 	// kuke daemon reset, kuke image load, kuke doctor cgroups --probe)
 	// when invoked with a non-zero effective UID. Wrapped errors must

--- a/internal/modelhub/cellconfig.go
+++ b/internal/modelhub/cellconfig.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package modelhub
+
+// CellConfig is the internal carrier for a daemon-stored cell identity (kind:
+// CellConfig, issue #624). Like CellBlueprint it has no Status and the daemon
+// never interprets its body for storage: the canonical CellConfigDoc travels as
+// an opaque serialized Document — the daemon writes it under the scope and
+// reads it back. Scope coordinates are lifted onto the metadata so the storage
+// runner can resolve the on-disk path without parsing the body. Apply-time
+// slot-fill validation (which does need the body and the referenced blueprint)
+// re-derives the typed view from Document via apischeme.
+type CellConfig struct {
+	Metadata CellConfigMetadata
+	Document []byte
+}
+
+// CellConfigMetadata identifies a Config by name and the scope it binds to. A
+// Config is scopable at realm, space, or stack only — never cell. The scope is
+// the deepest non-empty coordinate; a deeper coordinate requires every
+// shallower one. See external v1beta1.CellConfigMetadata for the full contract.
+type CellConfigMetadata struct {
+	Name  string
+	Realm string
+	Space string
+	Stack string
+}

--- a/internal/util/fs/metadata.go
+++ b/internal/util/fs/metadata.go
@@ -311,6 +311,42 @@ func BlueprintPath(baseRunPath, realmName, spaceName, stackName, blueprintName s
 	)
 }
 
+// ConfigScopeDir returns the metadata directory of the scope a
+// `kind: CellConfig` is bound to (issue #624). Like a CellBlueprint a Config is
+// scopable at realm/space/stack only — never cell — so the deepest coordinate
+// this resolves is the stack dir. The caller is responsible for having
+// validated coordinate completeness.
+func ConfigScopeDir(baseRunPath, realmName, spaceName, stackName string) string {
+	switch {
+	case stackName != "":
+		return StackMetadataDir(baseRunPath, realmName, spaceName, stackName)
+	case spaceName != "":
+		return SpaceMetadataDir(baseRunPath, realmName, spaceName)
+	default:
+		return RealmMetadataDir(baseRunPath, realmName)
+	}
+}
+
+// ConfigsDir returns the per-scope configs directory — the root-owned,
+// world-readable (0o755) directory under the scope's metadata tree that owns
+// daemon-managed config documents (issue #624). Nested inside the scope dir so
+// scope teardown reclaims it.
+func ConfigsDir(baseRunPath, realmName, spaceName, stackName string) string {
+	return filepath.Join(
+		ConfigScopeDir(baseRunPath, realmName, spaceName, stackName),
+		consts.KukeonConfigsSubdir,
+	)
+}
+
+// ConfigPath returns the host-side path of a single daemon-managed config
+// document: <scope>/configs/<name>, root-owned and 0o644.
+func ConfigPath(baseRunPath, realmName, spaceName, stackName, configName string) string {
+	return filepath.Join(
+		ConfigsDir(baseRunPath, realmName, spaceName, stackName),
+		configName,
+	)
+}
+
 type metadataHeader struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`

--- a/pkg/api/model/v1beta1/cellconfig.go
+++ b/pkg/api/model/v1beta1/cellconfig.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+// CellConfigDoc is the top-level document for a daemon-stored cell *identity*
+// (kind: CellConfig, issue #624, phase 4b-i of #423). Where a CellBlueprint is
+// the parametrized template (the "what"), a CellConfig binds that template to a
+// concrete instance (the "which one"): it references a Blueprint by name+scope,
+// supplies the scalar `values` and the structural repo/secret slot fills, and
+// owns the deterministic name of the at-most-one live cell it materializes.
+//
+// This kind ships the schema, daemon storage, `kuke apply`, slot-fill
+// validation against the referenced Blueprint, and the stable-name + back-ref
+// identity primitives. The runtime state machine that drives
+// materialise/attach/start/refuse — and the `kuke run -c` verb it serves —
+// lands in #625; a Config carries no Status because it has no runtime here.
+type CellConfigDoc struct {
+	APIVersion Version            `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind               `json:"kind"       yaml:"kind"`
+	Metadata   CellConfigMetadata `json:"metadata"   yaml:"metadata"`
+	Spec       CellConfigSpec     `json:"spec"       yaml:"spec"`
+}
+
+// CellConfigMetadata identifies a Config by name and the scope it is bound to.
+// Like a CellBlueprint (and unlike a Secret) a Config is scopable at realm,
+// space, or stack only — never cell: a Config materializes a cell, so scoping
+// it to a single cell is nonsensical. The scope is the deepest non-empty
+// coordinate; a deeper coordinate requires every shallower one. Realm is always
+// required. Labels are copied onto the materialized cell in addition to the
+// kukeon.io/config back-reference label.
+type CellConfigMetadata struct {
+	// Name is the config's name, unique within its scope. It is also the
+	// deterministic name of the cell this config materializes (see #625) — see
+	// internal/cellconfig.StableName for the derivation.
+	Name string `json:"name"             yaml:"name"`
+	// Realm is the always-required top-level scope coordinate.
+	Realm string `json:"realm"            yaml:"realm"`
+	// Space, when set, scopes the config to a space within Realm.
+	Space string `json:"space,omitempty"  yaml:"space,omitempty"`
+	// Stack, when set, scopes the config to a stack within Space.
+	Stack string `json:"stack,omitempty"  yaml:"stack,omitempty"`
+	// Labels are copied onto the cell materialized from this config, in
+	// addition to the kukeon.io/config back-reference label.
+	Labels map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// CellConfigSpec binds a referenced Blueprint to a concrete instance: the
+// scalar `values` filled into the blueprint's `${KEY}` parameters, and the
+// structural repo/secret slot fills keyed by the blueprint's slot names. Values
+// are stored verbatim and resolved at run time (#625); the repo/secret maps are
+// validated against the referenced blueprint's declared slots at apply time.
+type CellConfigSpec struct {
+	// Blueprint references the CellBlueprint this config instantiates.
+	Blueprint CellConfigBlueprintRef `json:"blueprint"         yaml:"blueprint"`
+	// Values fill the referenced blueprint's `${KEY}` scalar parameters. Stored
+	// verbatim here; resolution happens at run time (#625).
+	Values map[string]string `json:"values,omitempty"  yaml:"values,omitempty"`
+	// Repos fills the blueprint's structural repo slots, keyed by slot name.
+	Repos map[string]CellConfigRepoFill `json:"repos,omitempty"   yaml:"repos,omitempty"`
+	// Secrets fills the blueprint's structural secret slots, keyed by slot name.
+	Secrets map[string]CellConfigSecretFill `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+}
+
+// CellConfigBlueprintRef references a CellBlueprint by name and scope. Name and
+// Realm are required; Space/Stack are optional and follow the blueprint
+// scope-coordinate contract (a deeper coordinate requires every shallower one).
+// The reference may cross scopes — a Config in one realm may instantiate a
+// Blueprint owned by another (e.g. a `default`-realm Config referencing a
+// `kuke-system`-scoped template), the same cross-scope freedom a secretRef has.
+type CellConfigBlueprintRef struct {
+	// Name is the referenced CellBlueprint's name within its scope. Required.
+	Name string `json:"name"            yaml:"name"`
+	// Realm is the always-required top-level scope coordinate of the blueprint.
+	Realm string `json:"realm"           yaml:"realm"`
+	// Space, when set, scopes the reference to a space within Realm.
+	Space string `json:"space,omitempty" yaml:"space,omitempty"`
+	// Stack, when set, scopes the reference to a stack within Space.
+	Stack string `json:"stack,omitempty" yaml:"stack,omitempty"`
+}
+
+// CellConfigRepoFill fills a structural repo slot the referenced blueprint
+// declared (a BlueprintContainer repo with no inline url). It supplies the
+// clone source the blueprint deliberately left open. URL is required.
+type CellConfigRepoFill struct {
+	// URL is the clone URL filling the slot. Required.
+	URL string `json:"url"              yaml:"url"`
+	// Branch is the branch to check out. Empty clones the remote's default.
+	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
+}
+
+// CellConfigSecretFill fills a structural secret slot the referenced blueprint
+// declared (a BlueprintSecretSlot). The blueprint owns the consumption side
+// (env var or file mount); this supplies the source side — which kind: Secret
+// provides the bytes. SecretRef is required.
+type CellConfigSecretFill struct {
+	// SecretRef points at the kind: Secret that provides the slot's bytes.
+	// Required.
+	SecretRef *ContainerSecretRef `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+}

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -50,6 +50,15 @@ const (
 	// `<prefix>-<6hex>` cell. The get/delete verbs (#643), CellConfig (#624),
 	// and `kuke run -c` (#625) build on this foundation.
 	KindCellBlueprint Kind = "CellBlueprint"
+	// KindCellConfig identifies a daemon-stored cell identity that binds a
+	// CellBlueprint to a concrete instance (issue #624, phase 4b-i of #423). A
+	// CellConfig references a Blueprint by name+scope, supplies the scalar
+	// values and the structural repo/secret slot fills, and owns the
+	// deterministic name of the at-most-one live cell it materializes.
+	// `kuke apply` writes it to a root-owned, world-readable file under the
+	// scope's metadata tree; the `kuke run -c` verb + identity state machine
+	// that runs it land in #625, and the get/delete verbs in #644.
+	KindCellConfig Kind = "CellConfig"
 	// KindServerConfiguration identifies the kukeond daemon's configuration
 	// document loaded via `kukeond --configuration` (and consumed by
 	// `kuke init --server-configuration`). Not a server-side resource —


### PR DESCRIPTION
## Summary

Phase 4b-i of #423: introduces `kind: CellConfig` — the daemon-stored resource that binds a `CellBlueprint` to a concrete instance and owns the identity of the at-most-one live cell it materializes. Mirrors the established `CellBlueprint` (#620) / `Secret` (#619) wiring across every layer.

- **Schema + kind**: `CellConfigDoc` (`pkg/api/model/v1beta1/cellconfig.go`) — `metadata` (realm/space/stack scope, never cell, like a Blueprint) + `spec.{blueprint,values,repos,secrets}`. Registered as `KindCellConfig` in `consts.go`.
- **Storage**: root-owned, world-readable `/opt/kukeon/<scope>/configs/<name>` (references only, like blueprints). New `KukeonConfigsSubdir`, `fs.ConfigScopeDir/ConfigsDir/ConfigPath`, and `runner.WriteConfig` (atomic temp-file+rename, 0o755/0o644).
- **`kuke apply`**: parser dispatch + parse-time validation (name, scope, blueprint-ref shape, repo/secret fill shape); `ReconcileConfig` + `apply.go` branch; sorts after `CellBlueprint` in `documents.go` so a bundled blueprint is written before a config that references it.
- **Slot-fill validation** (`internal/cellconfig.ValidateSlotFill`, run at reconcile time because only the daemon can read the referenced blueprint): required slot unfilled → error; unknown slot in config → error; missing referenced blueprint → `ErrConfigBlueprintNotFound`. A repo slot is a blueprint repo with no inline url; every secret slot is structural. Matched by slot name across all containers.
- **Identity primitives** (`internal/cellconfig`, the package #625 will consume): `LabelConfig = "kukeon.io/config"` back-ref label, and `StableName`.

### Design decisions (documented for reviewer push-back)

- **Stable-name = config name verbatim** (not `<name>-<hash-of-values>`). The CellConfig contract is "one Config → at most one live cell with a stable identity that survives value edits"; #625's divergent-spec warning explicitly attaches to the existing live cell when the Config diverged. A value-hashed suffix would spawn a fresh cell on every value edit, defeating the idempotent identity that distinguishes `run -c` from a Blueprint's always-fresh `run -b`. So the name is value-independent. `StableName` is intentionally trivial — the *decision* (and a single call site for #625) is the deliverable.
- **Blueprint reference requires explicit `name`+`realm`** (no scope inheritance from the config). A Config and its Blueprint legitimately live in different scopes (the issue's own example, and the cross-scope freedom `secretRef` already has), so an explicit, unambiguous reference is the clearer contract.
- **Slot-fill validation lives in `ReconcileConfig`, not parse time** — it must read the referenced blueprint from daemon storage, the same parse/reconcile split `Secret`/`Blueprint` use for the scope-reachability gate. `ReconcileConfig` re-derives the typed config/blueprint views from the stored documents via `apischeme` (the apply package now imports `apischeme` + `cellconfig`; verified no import cycle).
- **State machine is out of scope** (AC) — no run/lifecycle code changed; `kuke run -c` + the materialise/attach/start/refuse machine land in #625, and get/delete verbs in #644.

## Test plan

- [x] `make test` (root + kukebuild modules) — pass
- [x] `GOWORK=off go build ./...` — pass
- [x] `GOWORK=off go vet ./internal/... ./pkg/...` — pass
- [x] New colocated tests: `internal/cellconfig` (StableName + slot-fill cases), `internal/apischeme` (round-trip), `internal/apply/parser` (parse+validate), `internal/controller` (reconcile happy path / missing scope / missing blueprint / unfilled required slot), `internal/controller/runner` (WriteConfig storage + mode + scope nesting)
- [x] `pre-commit run --files <changed>` — all hooks pass **except** `golangci-lint`, which panics environmentally (`package requires newer Go version go1.25 (application built with go1.24)`); this is a known dev-host toolchain mismatch, not a lint finding. `go fmt` / `go vet` / `make test` are clean.
- [ ] Smoke test (`make dev-init`) — not run; this change touches no build-path/daemon-runtime/`/opt/kukeon`-layout code the daemon-parity check guards (pure additive schema + apply path), and the new storage path is exercised by `WriteConfig` unit tests.

Closes #624