### PR TITLE
test: add direct tests for purgeCNIForContainer and containsExactContainerID

### DIFF
--- a/internal/cni/types.go
+++ b/internal/cni/types.go
@@ -104,4 +104,6 @@ const (
 
 // CNINetworksDir is the standard directory where CNI stores network state and IPAM allocations.
 // This is the default location used by CNI plugins for host-local IPAM.
-const CNINetworksDir = "/var/lib/cni/networks"
+// It is a var rather than a const so tests can redirect the host-local IPAM
+// scan in purgeCNIForContainer at a temp dir; production never reassigns it.
+var CNINetworksDir = "/var/lib/cni/networks"

--- a/internal/controller/runner/helpers_test.go
+++ b/internal/controller/runner/helpers_test.go
@@ -20,11 +20,18 @@
 package runner
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -168,5 +175,145 @@ func TestBuildRootCNINetworkName_DeterministicWhenSpaceMissing(t *testing.T) {
 	want := "default-nonexistent-space"
 	if got != want {
 		t.Errorf("buildRootCNINetworkName() = %q, want %q when space metadata is absent", got, want)
+	}
+}
+
+// TestContainsExactContainerID covers the safety-net matcher every CNI/IPAM
+// leak fix in this subsystem relies on to decide whether a host-local IPAM
+// file belongs to the container being purged. The prefix false-positive case
+// is the load-bearing one: container IDs routinely share a common prefix, and
+// a substring match would purge a live sibling's reservation.
+func TestContainsExactContainerID(t *testing.T) {
+	const id = "cid-100"
+	tests := []struct {
+		name        string
+		content     string
+		containerID string
+		want        bool
+	}{
+		{
+			name:        "empty container ID never matches",
+			content:     "anything",
+			containerID: "",
+			want:        false,
+		},
+		{
+			name:        "exact match after trimming whitespace",
+			content:     id + "\n",
+			containerID: id,
+			want:        true,
+		},
+		{
+			name:        "host-local IPAM file with ifname line matches",
+			content:     id + "\neth0\n",
+			containerID: id,
+			want:        true,
+		},
+		{
+			name:        "container ID embedded in structured JSON matches",
+			content:     `{"containerID":"` + id + `"}`,
+			containerID: id,
+			want:        true,
+		},
+		{
+			name:        "shared-prefix sibling does not match",
+			content:     "cid-1000\neth0\n",
+			containerID: id,
+			want:        false,
+		},
+		{
+			name:        "shared-prefix suffix does not match",
+			content:     id + "extra\n",
+			containerID: id,
+			want:        false,
+		},
+		{
+			name:        "last_reserved_ip content without the ID does not match",
+			content:     "10.88.0.5\n",
+			containerID: id,
+			want:        false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsExactContainerID(tt.content, tt.containerID); got != tt.want {
+				t.Errorf("containsExactContainerID(%q, %q) = %v, want %v", tt.content, tt.containerID, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPurgeCNIForContainer_RemovesOnlyMatchingIPAMFile pins the core of the
+// post-delete IPAM purge safety net: scanning the host-local networks dir and
+// removing only the IPAM allocation file whose content names the container
+// being purged. The shared-prefix sibling and the last_reserved_ip bookkeeping
+// file must survive — purging either would leak or corrupt a live reservation.
+func TestPurgeCNIForContainer_RemovesOnlyMatchingIPAMFile(t *testing.T) {
+	const (
+		networkName  = "default-myspace"
+		containerID  = "cid-100"
+		matchingIP   = "10.88.0.5"
+		siblingIP    = "10.88.0.6"
+		siblingID    = "cid-1000"
+		reservedFile = "last_reserved_ip.0"
+	)
+
+	// Redirect the host-local IPAM scan at a temp dir; production never
+	// reassigns CNINetworksDir, so this is the only writer.
+	networksRoot := t.TempDir()
+	prevNetworksDir := cni.CNINetworksDir
+	cni.CNINetworksDir = networksRoot
+	t.Cleanup(func() { cni.CNINetworksDir = prevNetworksDir })
+
+	ipamDir := filepath.Join(networksRoot, networkName)
+	if err := os.MkdirAll(ipamDir, 0o755); err != nil {
+		t.Fatalf("mkdir ipam dir: %v", err)
+	}
+	writeFile := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(ipamDir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	// IP file whose content names our container — must be removed.
+	writeFile(matchingIP, containerID+"\neth0\n")
+	// Same-prefix sibling owned by a different container — must survive.
+	writeFile(siblingIP, siblingID+"\neth0\n")
+	// IPAM bookkeeping file holding an IP, not a container ID — must survive.
+	writeFile(reservedFile, matchingIP+"\n")
+
+	tmp := t.TempDir()
+	r := &Exec{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		// Empty conf dir makes findCNIConfigPath miss, so the CNI DEL block
+		// (which needs a real plugin chain) is skipped; the cache dir points
+		// at an empty temp dir so the cache scan finds nothing on the host.
+		cniConf: &cni.Conf{CniConfigDir: tmp, CniBinDir: tmp, CniCacheDir: tmp},
+	}
+
+	// Empty netnsPath: the dead/absent-task purge path the teardown sites hit.
+	if err := r.purgeCNIForContainer(containerID, "", networkName); err != nil {
+		t.Fatalf("purgeCNIForContainer returned error: %v", err)
+	}
+
+	entries, err := os.ReadDir(ipamDir)
+	if err != nil {
+		t.Fatalf("read ipam dir after purge: %v", err)
+	}
+	var remaining []string
+	for _, e := range entries {
+		remaining = append(remaining, e.Name())
+	}
+	sort.Strings(remaining)
+	want := []string{reservedFile, siblingIP}
+	sort.Strings(want)
+	if len(remaining) != len(want) {
+		t.Fatalf("remaining files = %v, want %v", remaining, want)
+	}
+	for i := range want {
+		if remaining[i] != want[i] {
+			t.Fatalf("remaining files = %v, want %v", remaining, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- `containsExactContainerID` (`internal/controller/runner/helpers.go:166`) and the host-local IPAM scan in `purgeCNIForContainer` (`helpers.go:42`) are the safety net every CNI/IPAM leak fix in this subsystem relies on, yet had no direct tests — `containsExactContainerID` had zero `*_test.go` references and `purgeCNIForContainer` was only exercised indirectly via DeleteCell tests where it deliberately no-ops.
- Added `TestContainsExactContainerID`: a table test asserting exact-trim match, host-local two-line (`<id>\neth0`) match, structured-JSON match, and the load-bearing **shared-prefix false-positive** cases (sibling `cid-1000` and suffix `cid-100extra` must not match `cid-100`), plus the `last_reserved_ip` content that holds an IP not a container ID.
- Added `TestPurgeCNIForContainer_RemovesOnlyMatchingIPAMFile`: lays out a temp `networks/<net>/` dir with a matching IP file (`<id>\neth0`), a same-prefix sibling, and a `last_reserved_ip.0`, then asserts only the matching file is removed — the sibling and bookkeeping file survive.

## Non-obvious implementation call
- The IPAM scan keys off `cni.CNINetworksDir`, which was a `const` hardcoded to `/var/lib/cni/networks` with no test seam. I converted it to a package-level `var` (default value unchanged) so the test can redirect the scan at a temp dir; production never reassigns it. All four call sites read it at runtime via `filepath.Join`, so there are no const-expression dependents and behavior is identical. Flagged here so the reviewer can push back if a different seam is preferred.

## Test plan
- [x] `make test` (CI target: `test-root` + `test-kukebuild`) — exit 0, 93 `ok`, no failures
- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go vet ./internal/controller/runner/ ./internal/cni/` — clean
- [x] `pre-commit run --files <changed>` — go fmt, go-mod-tidy, addlicense, etc. all pass
- [ ] `golangci-lint` pre-commit hook — panics with `package requires newer Go version go1.25 (application built with go1.24)`; the dev host's golangci-lint binary is built against go1.24 and can't analyze the go1.25 module via go.work. Environmental, not a finding; CI runs a compatible toolchain.

Closes #719