### PR TITLE
fix: fail-fast in release-build loops to stop masking build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ kukebuild:
 
 release-build:
 	# Build for all OS and ARCH combinations
+	set -e; \
 	for OS in $(OS); do \
 		for ARCH in $(ARCHS); do \
 			GO111MODULE=on CGO_ENABLED=0 GOOS=$$OS GOARCH=$$ARCH \
@@ -113,6 +114,7 @@ release-build:
 # never needs the go-1.25 BuildKit closure.
 .PHONY: release-build-kukebuild
 release-build-kukebuild:
+	set -e; \
 	for OS in $(OS); do \
 		for ARCH in $(ARCHS); do \
 			cd $(CURDIR)/cmd/kukebuild && \


### PR DESCRIPTION
## Summary
- `release-build` (`Makefile:88`) and `release-build-kukebuild` (`Makefile:115`) run their per-OS/per-ARCH `for` loops in a single `/bin/sh -c` with commands chained by `;`. A non-final `go build` failure neither stopped the loop nor failed the recipe — the recipe's exit status was that of the *last* command, so the `RUN make release-build` step in the Dockerfile `builder` stage exited 0 despite producing no binary. BuildKit then cached that incomplete layer, surfacing the failure later as a misleading `COPY ... /workspace/kuke-linux-amd64: not found` that persisted across builds until the cache was manually busted.
- Prepended `set -e;` to both recipe bodies so any failed `go build`/`ln` aborts the recipe with a non-zero status, turning the masked failure into a clear, immediate `go build` error at the RUN step and preventing BuildKit from caching an incomplete builder layer.
- Fixed both recipes flagged in the issue (`release-build` and the audited `release-build-kukebuild`).

## Test plan
- [x] `make test` — passes (root module + kukebuild module).
- [x] `make release-build` happy path — exits 0, all six artifacts (`kuke`/`kukeond`/`kuketty` × `linux/amd64`,`linux/arm64`) produced.
- [x] Fail-fast verified via a standalone Makefile reproduction: with `set -e;`, a forced `false` in the loop body aborts at the first failure (`make ... Error 1`, exit 2) and the loop does not continue; without it the loop ran to completion and exited 0.

Closes #713