### PR TITLE
fix: deterministic CNI network name on RecreateCell + start teardown purge

### DIFF
--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -135,9 +135,13 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (_ intmodel.Cell, retErr erro
 	// host-local IPAM rejects the re-ADD as a duplicate allocation (issue #630).
 	// releaseCNI runs before the stop/delete so the netns is still valid for CNI
 	// DEL where applicable; purgeCNI scrubs the residual allocation file afterward.
+	// Resolve the purge's network name deterministically from realm+space so the
+	// scrub runs even when space metadata is gone or corrupt (issue #685), matching
+	// the stop/kill/delete teardown paths; the name is a pure function of (realm,
+	// space).
 	cellName := strings.TrimSpace(existing.Metadata.Name)
 	cniConfigPath, _ := r.resolveSpaceCNIConfigPath(realmName, spaceName)
-	networkName := r.resolveRootCNINetworkName(realmName, spaceName)
+	networkName := r.buildRootCNINetworkName(realmName, spaceName)
 	_ = teardownRootContainerCNI(
 		func() {
 			r.detachRootContainerFromNetwork(

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -469,7 +469,10 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 		// allocation (issue #630). releaseCNI must run while the task's netns
 		// is still valid, so it is sequenced before the task delete; purgeCNI
 		// scrubs the residual allocation file afterward as a safety net.
-		networkName := r.resolveRootCNINetworkName(realmID, spaceID)
+		// Resolve the purge's network name deterministically from realm+space so
+		// the scrub runs even when space metadata is gone or corrupt (issue #685),
+		// matching the stop/kill/delete teardown paths.
+		networkName := r.buildRootCNINetworkName(realmID, spaceID)
 		_ = teardownRootContainerCNI(
 			func() {
 				r.detachRootContainerFromNetwork(


### PR DESCRIPTION
## Summary
- Two teardown purge sites were still resolving the CNI network name via the swallowing `resolveRootCNINetworkName`, which returns `""` (gating out the IPAM-file purge) whenever `GetSpace`/`getSpaceNetworkName` fails — leaking the reservation when space metadata is gone or corrupt. #708 fixed the equivalent swallow on stop/kill/delete; these two were missed.
- `recreate_cell.go:140` (release-before-recreate teardown) and `start.go:472` (container-exists release-before-delete branch, #630) now use the deterministic `buildRootCNINetworkName(realm, space)`, matching `stop.go` / `kill.go` / `delete_cell.go`. The network name is a pure function of (realm, space), so the purge runs even when space metadata is unreadable (issue #685 rationale).

## start.go:442/450 decision (the explicit call the issue asked for)
- **Kept on `resolveRootCNINetworkName`.** That site is the *create-fresh* re-ADD safety net (`ErrContainerNotFound` branch), not a teardown — no existing container to release; it pre-emptively scrubs a *potential* stale reservation before CNI ADD. It runs at cell start, where the space is expected present, a different risk profile than teardown (which can run after a cascade space deletion). This matches the `buildRootCNINetworkName` docstring's documented teardown-vs-re-ADD boundary and the issue author's note that metadata "is expected present" there.
- **Finding for reviewer (push back if you disagree):** verified that `networkName` at both `start.go:450` and `:472` feeds *only* `purgeCNIForContainer` — the actual CNI ADD at `start.go:677` resolves its network from `cniConfigPath`, independent of this string. So `start.go:450`'s purge would, in principle, suffer the same silent-skip-on-missing-metadata behavior. I left it on the resolver to keep the diff scoped to the AC's two teardown sites and to preserve `resolveRootCNINetworkName`'s sole remaining production caller rather than orphaning the function in a bug-fix PR. A reviewer who wants the create-fresh scrub deterministic too can say so and it's a one-line follow-up.

## Test plan
- [x] `make test` (test-root + test-kukebuild) — pass
- [x] `make kuke` build — pass
- [x] `go vet ./internal/controller/runner/` — clean
- [x] `go test ./internal/controller/runner/` — pass (both resolver unit tests in `helpers_test.go` still valid; both functions retained)
- [ ] `make dev-init` daemon smoke — not run: the change is confined to in-process teardown network-name *string* resolution; it does not touch the build path, daemon socket plumbing, or `/opt/kukeon` bind-mount reads the daemon-parity guard targets, and the corrupt-space path it fixes is not exercised by dev-init's happy-path bootstrap.

Closes #717