### PR TITLE
fix: deterministic CNI scrub network name on create-fresh path

### DIFF
--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -164,7 +164,7 @@ func teardownRootContainerCNI(releaseCNI func(), deleteContainer func() error, p
 // before CNI ADD on the ErrContainerNotFound branch, giving the create-fresh
 // path the same second line of defence the teardown branch already has.
 //
-// Best-effort and a no-op when networkName is "" (resolveRootCNINetworkName
+// Best-effort and a no-op when networkName is "" (buildRootCNINetworkName
 // couldn't derive a name), so a clean start with no stale reservation is
 // unaffected. Decoupled from the concrete CNI client — same rationale as
 // teardownRootContainerCNI — so the run/no-op decision is unit-testable.
@@ -447,7 +447,10 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 			// reservation keyed to this deterministic root-container ID. Scrub
 			// it before CNI ADD so the re-ADD isn't rejected as a duplicate
 			// allocation. Best-effort and a no-op when no stale file exists.
-			networkName := r.resolveRootCNINetworkName(realmID, spaceID)
+			// Resolve the network name deterministically from realm+space so
+			// the scrub runs even when space metadata is gone or corrupt
+			// (issue #685), matching the stop/kill/delete teardown paths.
+			networkName := r.buildRootCNINetworkName(realmID, spaceID)
 			purgeStaleRootContainerCNI(networkName, func() {
 				_ = r.purgeCNIForContainer(containerID, "", networkName)
 			})

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -357,7 +357,7 @@ func TestTeardownRootContainerCNI_OrderingAndSafetyNet(t *testing.T) {
 // runs — purgeStaleRootContainerCNI must scrub a stale host-local IPAM
 // reservation keyed to the deterministic root-container ID before CNI ADD so
 // the re-ADD isn't rejected as a duplicate allocation. The purge is best-effort
-// and must be a no-op when resolveRootCNINetworkName couldn't derive a name (""),
+// and must be a no-op when buildRootCNINetworkName couldn't derive a name (""),
 // leaving a clean start with no stale reservation unaffected.
 func TestPurgeStaleRootContainerCNI_CreateFreshSafetyNet(t *testing.T) {
 	t.Run("purge_runs_when_network_name_resolves", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- The create-fresh re-ADD branch (`ErrContainerNotFound`) at `internal/controller/runner/start.go` resolved the stale-reservation scrub's network name via the swallowing `resolveRootCNINetworkName`, which returns `""` when space metadata is gone or corrupt — silently skipping the scrub. That can leave a residual host-local IPAM allocation that gets the re-ADD rejected as a duplicate (#630).
- Swapped that single site to `buildRootCNINetworkName`, which derives the name deterministically from realm+space via `naming.BuildSpaceNetworkName`. This matches the stop/kill/delete teardown paths #730 fixed for the same #685 silent-skip class. The actual CNI ADD still resolves from `cniConfigPath` and is unaffected.
- Updated the two now-stale doc comments (the `purgeStaleRootContainerCNI` godoc and the `TestPurgeStaleRootContainerCNI_CreateFreshSafetyNet` comment) that named the old resolver as the source of the empty-name no-op.

`resolveRootCNINetworkName` is intentionally left in place — it retains dedicated unit coverage (`helpers_test.go`) and removing it would be an unrelated cleanup outside this nit's scope.

## Test plan
- [x] `make test` (test-root + test-kukebuild) — all packages pass
- [x] `GOWORK=off go build ./...` / `go vet ./internal/controller/runner/...`
- [x] `go test ./internal/controller/runner/...`
- [ ] `make dev-init` smoke — not run: this is a one-line CNI network-name resolver swap on the corrupt-metadata create-fresh edge path (covered by the unit tests above); dev-init's regression guard is realm/bind-mount parity, which this change does not touch, and the affected path requires a corrupt-space + stale-reservation state not reproducible on a clean re-bootstrap.

Closes #731