### PR TITLE
feat: add kuke get/delete config verbs (phase 4.2.2)

### DIFF
--- a/cmd/config/autocomplete.go
+++ b/cmd/config/autocomplete.go
@@ -646,6 +646,63 @@ func CompleteBlueprintNames(cmd *cobra.Command, args []string, toComplete string
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
+// CompleteConfigNames provides shell completion for config name args by listing
+// every CellConfig visible in the active scope filter (issue #644). A Config is
+// never cell-scoped, so the filter bottoms out at stack. Errors swallow to an
+// empty list so a down daemon never surfaces a noisy completion.
+func CompleteConfigNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) >= 1 && toComplete == "" {
+		if cmd.ValidArgsFunction != nil {
+			testArgs := make([]string, len(args), len(args)+1)
+			copy(testArgs, args)
+			testArgs = append(testArgs, "test")
+			if cmd.Args != nil {
+				if err := cmd.Args(cmd, testArgs); err != nil {
+					return []string{}, cobra.ShellCompDirectiveNoFileComp
+				}
+			}
+		}
+	}
+
+	client, err := completionClient(cmd)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer func() { _ = client.Close() }()
+
+	realmName := getFlagValueWithDefault(cmd, "realm", "default")
+	spaceName := getFlagValueWithDefault(cmd, "space", "")
+	stackName := getFlagValueWithDefault(cmd, "stack", "")
+
+	if cmd.ValidArgsFunction != nil && len(args) == 0 {
+		if realmName == "" {
+			return []string{}, cobra.ShellCompDirectiveNoFileComp
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), completionTimeout)
+	defer cancel()
+
+	configs, err := client.ListConfigs(ctx, realmName, spaceName, stackName)
+	if err != nil {
+		return []string{}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	seen := make(map[string]bool)
+	names := make([]string, 0, len(configs))
+	for _, cfg := range configs {
+		name := cfg.Metadata.Name
+		if toComplete == "" || strings.HasPrefix(name, toComplete) {
+			if !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
 // CompleteProfileNames provides shell completion for `-p/--profile` by listing
 // every CellProfile under the active profiles directory ($KUKE_PROFILES_DIR or
 // $HOME/.kuke/profiles.d). Errors swallow to an empty list — a fresh shell with

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -327,6 +327,14 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_BLUEPRINT_STACK = DefineKV("KUKE_GET_BLUEPRINT_STACK", "kuke/get/blueprint/stack")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_CONFIG_NAME = DefineKV("KUKE_GET_CONFIG_NAME", "kuke/get/config/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_CONFIG_REALM = DefineKV("KUKE_GET_CONFIG_REALM", "kuke/get/config/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_CONFIG_SPACE = DefineKV("KUKE_GET_CONFIG_SPACE", "kuke/get/config/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_GET_CONFIG_STACK = DefineKV("KUKE_GET_CONFIG_STACK", "kuke/get/config/stack")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_OUTPUT = DefineKV("KUKE_GET_OUTPUT", "kuke/get/output")
 
 	// Delete command variables
@@ -378,6 +386,14 @@ var (
 	KUKE_DELETE_BLUEPRINT_SPACE = DefineKV("KUKE_DELETE_BLUEPRINT_SPACE", "kuke/delete/blueprint/space")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DELETE_BLUEPRINT_STACK = DefineKV("KUKE_DELETE_BLUEPRINT_STACK", "kuke/delete/blueprint/stack")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_CONFIG_NAME = DefineKV("KUKE_DELETE_CONFIG_NAME", "kuke/delete/config/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_CONFIG_REALM = DefineKV("KUKE_DELETE_CONFIG_REALM", "kuke/delete/config/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_CONFIG_SPACE = DefineKV("KUKE_DELETE_CONFIG_SPACE", "kuke/delete/config/space")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DELETE_CONFIG_STACK = DefineKV("KUKE_DELETE_CONFIG_STACK", "kuke/delete/config/stack")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DELETE_FORCE = DefineKV("KUKE_DELETE_FORCE", "kuke/delete/force")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/delete/config/config.go
+++ b/cmd/kuke/delete/config/config.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewConfigCmd builds `kuke delete config <name>` (issue #644). It removes the
+// daemon-stored document for a single named, scoped CellConfig. The config is
+// identified by its name plus its binding scope (--realm/--space/--stack). A
+// Config is never cell-scoped, so there is no --cell flag.
+//
+// Deleting a Config does NOT delete the cell it materialized (that is
+// `kuke delete cell`). When a live cell still carries the back-reference label
+// to this config the command emits a one-line notice — never a refusal —
+// pointing the operator at `kuke delete cell <name>`.
+func NewConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "config [name]",
+		Aliases:       []string{"cfg"},
+		Short:         "Delete a kind: CellConfig",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := strings.TrimSpace(args[0])
+
+			realm := strings.TrimSpace(config.KUKE_DELETE_CONFIG_REALM.ValueOrDefault())
+			space := config.KUKE_DELETE_CONFIG_SPACE.ValueOrDefault()
+			stack := config.KUKE_DELETE_CONFIG_STACK.ValueOrDefault()
+			if realm == "" {
+				return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+			}
+
+			doc := v1beta1.CellConfigDoc{
+				APIVersion: v1beta1.APIVersionV1Beta1,
+				Kind:       v1beta1.KindCellConfig,
+				Metadata: v1beta1.CellConfigMetadata{
+					Name:  name,
+					Realm: realm,
+					Space: strings.TrimSpace(space),
+					Stack: strings.TrimSpace(stack),
+				},
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			result, err := client.DeleteConfig(cmd.Context(), doc)
+			if err != nil {
+				return err
+			}
+
+			configName := name
+			if result.Config.Metadata.Name != "" {
+				configName = result.Config.Metadata.Name
+			}
+			cmd.Printf("Deleted config %q\n", configName)
+			for _, cell := range result.BackRefCells {
+				cmd.Printf(
+					"Note: cell %q was materialized from this config and was not deleted; "+
+						"run 'kuke delete cell %s' to remove it.\n",
+					cell, name,
+				)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().String("realm", "", "Realm the config is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_CONFIG_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Space the config is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_CONFIG_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Stack the config is bound to")
+	_ = viper.BindPFlag(config.KUKE_DELETE_CONFIG_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+
+	cmd.ValidArgsFunction = config.CompleteConfigNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+
+	return cmd
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.DaemonClientFromCmd(cmd)
+}

--- a/cmd/kuke/delete/config/config_test.go
+++ b/cmd/kuke/delete/config/config_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	configcmd "github.com/eminwux/kukeon/cmd/kuke/delete/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestDeleteConfig(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name        string
+		args        []string
+		setup       func(t *testing.T, cmd *cobra.Command)
+		fake        *fakeClient
+		wantErr     string
+		wantScope   v1beta1.CellConfigMetadata
+		wantOutputs []string
+	}{
+		{
+			name: "success at realm scope",
+			args: []string{"web"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.DeleteConfigResult, error) {
+					return kukeonv1.DeleteConfigResult{Config: doc, Deleted: true}, nil
+				},
+			},
+			wantScope:   v1beta1.CellConfigMetadata{Name: "web", Realm: "r1"},
+			wantOutputs: []string{`Deleted config "web"`},
+		},
+		{
+			name: "success at stack scope passes full coordinates",
+			args: []string{"stack-cfg"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+				_ = cmd.Flags().Set("space", "s1")
+				_ = cmd.Flags().Set("stack", "st1")
+			},
+			fake: &fakeClient{
+				deleteConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.DeleteConfigResult, error) {
+					return kukeonv1.DeleteConfigResult{Config: doc, Deleted: true}, nil
+				},
+			},
+			wantScope:   v1beta1.CellConfigMetadata{Name: "stack-cfg", Realm: "r1", Space: "s1", Stack: "st1"},
+			wantOutputs: []string{`Deleted config "stack-cfg"`},
+		},
+		{
+			name: "back-ref cell emits notice not refusal",
+			args: []string{"web"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.DeleteConfigResult, error) {
+					return kukeonv1.DeleteConfigResult{
+						Config:       doc,
+						Deleted:      true,
+						BackRefCells: []string{"r1/s1/st1/web"},
+					}, nil
+				},
+			},
+			wantScope: v1beta1.CellConfigMetadata{Name: "web", Realm: "r1"},
+			wantOutputs: []string{
+				`Deleted config "web"`,
+				`r1/s1/st1/web`,
+				`kuke delete cell web`,
+			},
+		},
+		{
+			name: "not found surfaces error",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				deleteConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.DeleteConfigResult, error) {
+					return kukeonv1.DeleteConfigResult{}, errdefs.ErrConfigNotFound
+				},
+			},
+			wantErr: "config not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := configcmd.NewConfigCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, configcmd.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := tt.fake.gotDoc.Metadata; got.Name != tt.wantScope.Name ||
+				got.Realm != tt.wantScope.Realm ||
+				got.Space != tt.wantScope.Space ||
+				got.Stack != tt.wantScope.Stack {
+				t.Errorf("scope passed = %+v, want %+v", got, tt.wantScope)
+			}
+			for _, want := range tt.wantOutputs {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("output missing %q\nGot:\n%s", want, buf.String())
+				}
+			}
+		})
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	deleteConfigFn func(doc v1beta1.CellConfigDoc) (kukeonv1.DeleteConfigResult, error)
+	gotDoc         v1beta1.CellConfigDoc
+}
+
+func (f *fakeClient) DeleteConfig(
+	_ context.Context, doc v1beta1.CellConfigDoc,
+) (kukeonv1.DeleteConfigResult, error) {
+	f.gotDoc = doc
+	if f.deleteConfigFn == nil {
+		return kukeonv1.DeleteConfigResult{}, errors.New("unexpected DeleteConfig call")
+	}
+	return f.deleteConfigFn(doc)
+}

--- a/cmd/kuke/delete/delete.go
+++ b/cmd/kuke/delete/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/config"
 	blueprintdelete "github.com/eminwux/kukeon/cmd/kuke/delete/blueprint"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/cell"
+	configdelete "github.com/eminwux/kukeon/cmd/kuke/delete/config"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/container"
 	"github.com/eminwux/kukeon/cmd/kuke/delete/realm"
 	secretdelete "github.com/eminwux/kukeon/cmd/kuke/delete/secret"
@@ -49,7 +50,7 @@ func NewDeleteCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [name]",
 		Aliases: []string{"d"},
-		Short:   "Delete Kukeon resources (realm, space, stack, cell, container, secret, blueprint)",
+		Short:   "Delete Kukeon resources (realm, space, stack, cell, container, secret, blueprint, config)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Check if -f flag is provided
 			file, err := cmd.Flags().GetString("file")
@@ -93,6 +94,7 @@ func NewDeleteCmd() *cobra.Command {
 		container.NewContainerCmd(),
 		secretdelete.NewSecretCmd(),
 		blueprintdelete.NewBlueprintCmd(),
+		configdelete.NewConfigCmd(),
 	)
 
 	return cmd
@@ -100,7 +102,7 @@ func NewDeleteCmd() *cobra.Command {
 
 // completeDeleteSubcommands provides shell completion for delete subcommand names.
 func completeDeleteSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint"}
+	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint", "config"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/delete/delete_test.go
+++ b/cmd/kuke/delete/delete_test.go
@@ -50,7 +50,7 @@ func TestNewDeleteCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Delete Kukeon resources (realm, space, stack, cell, container, secret, blueprint)"
+				expected := "Delete Kukeon resources (realm, space, stack, cell, container, secret, blueprint, config)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -207,7 +207,7 @@ func TestNewDeleteCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint"}
+	expected := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint", "config"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}
@@ -227,7 +227,7 @@ func TestNewDeleteCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test prefix filtering
 	filtered, _ := cmd.ValidArgsFunction(cmd, []string{}, "c")
-	expectedFiltered := []string{"cell", "container"}
+	expectedFiltered := []string{"cell", "container", "config"}
 	if len(filtered) != len(expectedFiltered) {
 		t.Fatalf("expected %d filtered completions, got %d", len(expectedFiltered), len(filtered))
 	}

--- a/cmd/kuke/get/config/config.go
+++ b/cmd/kuke/get/config/config.go
@@ -1,0 +1,192 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewConfigCmd builds `kuke get config(s)` (issue #644). With a name it shows
+// one Config's full document (blueprint ref, values, repo/secret slot fills);
+// without one it lists every Config bound to the filter scope or any scope
+// nested within it (subtree-filter semantics, matching `kuke get blueprints`).
+// A Config is never cell-scoped, so there is no --cell flag — the scope bottoms
+// out at stack.
+func NewConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "config [name]",
+		Aliases:       []string{"configs", "cfg"},
+		Short:         "Get or list kind: CellConfig",
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			outputFormat, err := shared.ParseOutputFormat(cmd)
+			if err != nil {
+				return err
+			}
+
+			// List filters: an unset flag means "no filter" (ExplicitFlag),
+			// so `kuke get configs` with no flags lists the whole subtree.
+			realm := shared.ExplicitFlag(cmd, "realm", config.KUKE_GET_CONFIG_REALM.ViperKey)
+			space := shared.ExplicitFlag(cmd, "space", config.KUKE_GET_CONFIG_SPACE.ViperKey)
+			stack := shared.ExplicitFlag(cmd, "stack", config.KUKE_GET_CONFIG_STACK.ViperKey)
+
+			var name string
+			if len(args) > 0 {
+				name = strings.TrimSpace(args[0])
+			} else {
+				name = strings.TrimSpace(viper.GetString(config.KUKE_GET_CONFIG_NAME.ViperKey))
+			}
+
+			if name != "" {
+				// A single config is identified by its name plus its exact
+				// binding scope. Default the realm to the operator's current
+				// realm; deeper coordinates stay unset unless provided.
+				if realm == "" {
+					realm = strings.TrimSpace(config.KUKE_GET_CONFIG_REALM.ValueOrDefault())
+				}
+				if realm == "" {
+					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+				}
+				lookup := v1beta1.CellConfigDoc{
+					APIVersion: v1beta1.APIVersionV1Beta1,
+					Kind:       v1beta1.KindCellConfig,
+					Metadata: v1beta1.CellConfigMetadata{
+						Name:  name,
+						Realm: realm,
+						Space: space,
+						Stack: stack,
+					},
+				}
+				result, getErr := client.GetConfig(cmd.Context(), lookup)
+				if getErr != nil {
+					if errors.Is(getErr, errdefs.ErrConfigNotFound) {
+						return fmt.Errorf("config %q not found", name)
+					}
+					return getErr
+				}
+				if !result.MetadataExists {
+					return fmt.Errorf("config %q not found", name)
+				}
+				return printConfig(&result.Config, outputFormat)
+			}
+
+			configs, err := client.ListConfigs(cmd.Context(), realm, space, stack)
+			if err != nil {
+				return err
+			}
+			return printConfigs(cmd, configs, outputFormat)
+		},
+	}
+
+	cmd.Flags().String("realm", "", "Filter configs by realm name")
+	_ = viper.BindPFlag(config.KUKE_GET_CONFIG_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Filter configs by space name")
+	_ = viper.BindPFlag(config.KUKE_GET_CONFIG_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Filter configs by stack name")
+	_ = viper.BindPFlag(config.KUKE_GET_CONFIG_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+	cmd.Flags().
+		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
+	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+
+	cmd.ValidArgsFunction = config.CompleteConfigNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("output", config.CompleteOutputFormat)
+	_ = cmd.RegisterFlagCompletionFunc("o", config.CompleteOutputFormat)
+
+	return cmd
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.ClientFromCmd(cmd)
+}
+
+func printConfig(cfg *v1beta1.CellConfigDoc, format shared.OutputFormat) error {
+	switch format {
+	case shared.OutputFormatJSON:
+		return shared.PrintJSON(cfg)
+	case shared.OutputFormatYAML, shared.OutputFormatTable:
+		return shared.PrintYAML(cfg)
+	default:
+		return shared.PrintYAML(cfg)
+	}
+}
+
+func printConfigs(cmd *cobra.Command, configs []v1beta1.CellConfigDoc, format shared.OutputFormat) error {
+	switch format {
+	case shared.OutputFormatYAML:
+		return shared.PrintYAML(configs)
+	case shared.OutputFormatJSON:
+		return shared.PrintJSON(configs)
+	case shared.OutputFormatTable:
+		if len(configs) == 0 {
+			cmd.Println("No configs found.")
+			return nil
+		}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK"}
+		rows := make([][]string, 0, len(configs))
+		for i := range configs {
+			c := &configs[i]
+			rows = append(rows, []string{
+				c.Metadata.Name,
+				dashIfEmpty(c.Metadata.Realm),
+				dashIfEmpty(c.Metadata.Space),
+				dashIfEmpty(c.Metadata.Stack),
+			})
+		}
+		shared.PrintTable(cmd, headers, rows)
+		return nil
+	default:
+		return shared.PrintYAML(configs)
+	}
+}
+
+// dashIfEmpty renders an unset scope coordinate as "-" so the table column
+// never collapses to an unaligned blank cell.
+func dashIfEmpty(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/kuke/get/config/config_test.go
+++ b/cmd/kuke/get/config/config_test.go
@@ -1,0 +1,204 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	configcmd "github.com/eminwux/kukeon/cmd/kuke/get/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestNewConfigCmd(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func(t *testing.T, cmd *cobra.Command)
+		fake       *fakeClient
+		wantErr    string
+		wantOutput string
+	}{
+		{
+			// Single-resource get renders YAML to os.Stdout (not the command
+			// buffer), so this case only asserts the happy path returns no error.
+			name: "get single config",
+			args: []string{"web"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+				_ = cmd.Flags().Set("space", "s1")
+			},
+			fake: &fakeClient{
+				getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					return kukeonv1.GetConfigResult{
+						Config:         v1beta1.CellConfigDoc{Metadata: doc.Metadata},
+						MetadataExists: true,
+					}, nil
+				},
+			},
+		},
+		{
+			name: "get not found surfaces friendly error",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					return kukeonv1.GetConfigResult{}, errdefs.ErrConfigNotFound
+				},
+			},
+			wantErr: `config "missing" not found`,
+		},
+		{
+			name: "get not found via MetadataExists=false",
+			args: []string{"missing"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "r1")
+			},
+			fake: &fakeClient{
+				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: `config "missing" not found`,
+		},
+		{
+			name: "list empty",
+			fake: &fakeClient{
+				listConfigsFn: func(_, _, _ string) ([]v1beta1.CellConfigDoc, error) {
+					return nil, nil
+				},
+			},
+			wantOutput: "No configs found.",
+		},
+		{
+			name: "list table renders scope columns",
+			fake: &fakeClient{
+				listConfigsFn: func(_, _, _ string) ([]v1beta1.CellConfigDoc, error) {
+					return []v1beta1.CellConfigDoc{
+						{Metadata: v1beta1.CellConfigMetadata{Name: "realm-cfg", Realm: "default"}},
+						{
+							Metadata: v1beta1.CellConfigMetadata{
+								Name:  "stack-cfg",
+								Realm: "default",
+								Space: "s",
+								Stack: "st",
+							},
+						},
+					}, nil
+				},
+			},
+			wantOutput: "realm-cfg",
+		},
+		{
+			name: "list passes filter scope through (no cell coordinate)",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("realm", "default")
+				_ = cmd.Flags().Set("space", "team-a")
+			},
+			fake: &fakeClient{
+				listConfigsFn: func(realm, space, _ string) ([]v1beta1.CellConfigDoc, error) {
+					if realm != "default" || space != "team-a" {
+						return nil, errors.New("unexpected filter scope")
+					}
+					return []v1beta1.CellConfigDoc{
+						{Metadata: v1beta1.CellConfigMetadata{Name: "space-cfg", Realm: realm, Space: space}},
+					}, nil
+				},
+			},
+			wantOutput: "space-cfg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := configcmd.NewConfigCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, configcmd.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			cmd.SetContext(ctx)
+
+			if tt.setup != nil {
+				tt.setup(t, cmd)
+			}
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
+				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getConfigFn   func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error)
+	listConfigsFn func(realm, space, stack string) ([]v1beta1.CellConfigDoc, error)
+}
+
+func (f *fakeClient) GetConfig(
+	_ context.Context, doc v1beta1.CellConfigDoc,
+) (kukeonv1.GetConfigResult, error) {
+	if f.getConfigFn == nil {
+		return kukeonv1.GetConfigResult{}, errors.New("unexpected GetConfig call")
+	}
+	return f.getConfigFn(doc)
+}
+
+func (f *fakeClient) ListConfigs(
+	_ context.Context,
+	realm, space, stack string,
+) ([]v1beta1.CellConfigDoc, error) {
+	if f.listConfigsFn == nil {
+		return nil, errors.New("unexpected ListConfigs call")
+	}
+	return f.listConfigsFn(realm, space, stack)
+}

--- a/cmd/kuke/get/get.go
+++ b/cmd/kuke/get/get.go
@@ -21,6 +21,7 @@ import (
 
 	blueprintcmd "github.com/eminwux/kukeon/cmd/kuke/get/blueprint"
 	cellcmd "github.com/eminwux/kukeon/cmd/kuke/get/cell"
+	configcmd "github.com/eminwux/kukeon/cmd/kuke/get/config"
 	containercmd "github.com/eminwux/kukeon/cmd/kuke/get/container"
 	realmcmd "github.com/eminwux/kukeon/cmd/kuke/get/realm"
 	secretcmd "github.com/eminwux/kukeon/cmd/kuke/get/secret"
@@ -37,7 +38,7 @@ func NewGetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "get [name]",
 		Aliases: []string{"g"},
-		Short:   "Get or list Kukeon resources (realm, space, stack, cell, container, secret, blueprint)",
+		Short:   "Get or list Kukeon resources (realm, space, stack, cell, container, secret, blueprint, config)",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
@@ -61,6 +62,7 @@ func NewGetCmd() *cobra.Command {
 		containercmd.NewContainerCmd(),
 		secretcmd.NewSecretCmd(),
 		blueprintcmd.NewBlueprintCmd(),
+		configcmd.NewConfigCmd(),
 	)
 
 	return cmd
@@ -68,7 +70,7 @@ func NewGetCmd() *cobra.Command {
 
 // completeGetSubcommands provides shell completion for get subcommand names.
 func completeGetSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint"}
+	subcommands := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint", "config"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/get/get_test.go
+++ b/cmd/kuke/get/get_test.go
@@ -41,7 +41,7 @@ func TestNewGetCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Get or list Kukeon resources (realm, space, stack, cell, container, secret, blueprint)"
+				expected := "Get or list Kukeon resources (realm, space, stack, cell, container, secret, blueprint, config)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -81,6 +81,7 @@ func TestNewGetCmdRegistersSubcommands(t *testing.T) {
 		{name: "stack"},
 		{name: "cell"},
 		{name: "container"},
+		{name: "config"},
 	}
 
 	for _, tt := range tests {
@@ -103,7 +104,7 @@ func TestNewGetCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint"}
+	expected := []string{"realm", "space", "stack", "cell", "container", "secret", "blueprint", "config"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}
@@ -123,7 +124,7 @@ func TestNewGetCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test prefix filtering
 	filtered, _ := cmd.ValidArgsFunction(cmd, []string{}, "c")
-	expectedFiltered := []string{"cell", "container"}
+	expectedFiltered := []string{"cell", "container", "config"}
 	if len(filtered) != len(expectedFiltered) {
 		t.Fatalf("expected %d filtered completions, got %d", len(expectedFiltered), len(filtered))
 	}

--- a/internal/apischeme/cellconfig.go
+++ b/internal/apischeme/cellconfig.go
@@ -76,3 +76,34 @@ func ConvertCellConfigToExternal(in intmodel.CellConfig) (ext.CellConfigDoc, err
 	}
 	return doc, nil
 }
+
+// ConvertCellConfigMetadataToExternal builds a metadata-only external
+// CellConfigDoc from the internal carrier's metadata (issue #644). Unlike
+// ConvertCellConfigToExternal it does not read the stored Document — the list
+// and delete verbs surface scope coordinates and name only, never the config
+// body (blueprint ref, values, slot fills).
+func ConvertCellConfigMetadataToExternal(in intmodel.CellConfig) ext.CellConfigDoc {
+	return ext.CellConfigDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCellConfig,
+		Metadata: ext.CellConfigMetadata{
+			Name:  in.Metadata.Name,
+			Realm: in.Metadata.Realm,
+			Space: in.Metadata.Space,
+			Stack: in.Metadata.Stack,
+		},
+	}
+}
+
+// ConvertCellConfigListToExternal maps a slice of internal CellConfigs to
+// metadata-only external CellConfigDocs (issue #644).
+func ConvertCellConfigListToExternal(in []intmodel.CellConfig) []ext.CellConfigDoc {
+	if in == nil {
+		return nil
+	}
+	out := make([]ext.CellConfigDoc, len(in))
+	for i := range in {
+		out[i] = ConvertCellConfigMetadataToExternal(in[i])
+	}
+	return out
+}

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -367,6 +367,30 @@ func (c *Client) GetBlueprint(
 	}, nil
 }
 
+func (c *Client) GetConfig(
+	_ context.Context, doc v1beta1.CellConfigDoc,
+) (kukeonv1.GetConfigResult, error) {
+	internal, _, err := apischeme.NormalizeCellConfig(doc)
+	if err != nil {
+		return kukeonv1.GetConfigResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.GetConfig(internal)
+	if err != nil {
+		return kukeonv1.GetConfigResult{}, err
+	}
+	if !res.MetadataExists {
+		return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+	}
+	ext, err := apischeme.ConvertCellConfigToExternal(res.Config)
+	if err != nil {
+		return kukeonv1.GetConfigResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	return kukeonv1.GetConfigResult{
+		Config:         ext,
+		MetadataExists: true,
+	}, nil
+}
+
 // ---- List ----
 
 func (c *Client) ListRealms(_ context.Context) ([]v1beta1.RealmDoc, error) {
@@ -452,6 +476,17 @@ func (c *Client) ListBlueprints(
 		return nil, err
 	}
 	return apischeme.ConvertCellBlueprintListToExternal(blueprints), nil
+}
+
+func (c *Client) ListConfigs(
+	_ context.Context,
+	realmName, spaceName, stackName string,
+) ([]v1beta1.CellConfigDoc, error) {
+	configs, err := c.ctrl.ListConfigs(realmName, spaceName, stackName)
+	if err != nil {
+		return nil, err
+	}
+	return apischeme.ConvertCellConfigListToExternal(configs), nil
 }
 
 // derefDocs converts a []*T returned by fs.Convert* helpers into the
@@ -721,6 +756,24 @@ func (c *Client) DeleteBlueprint(
 	return kukeonv1.DeleteBlueprintResult{
 		Blueprint: apischeme.ConvertCellBlueprintMetadataToExternal(res.Blueprint),
 		Deleted:   res.Deleted,
+	}, nil
+}
+
+func (c *Client) DeleteConfig(
+	_ context.Context, doc v1beta1.CellConfigDoc,
+) (kukeonv1.DeleteConfigResult, error) {
+	internal, _, err := apischeme.NormalizeCellConfig(doc)
+	if err != nil {
+		return kukeonv1.DeleteConfigResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+	}
+	res, err := c.ctrl.DeleteConfig(internal)
+	if err != nil {
+		return kukeonv1.DeleteConfigResult{}, err
+	}
+	return kukeonv1.DeleteConfigResult{
+		Config:       apischeme.ConvertCellConfigMetadataToExternal(res.Config),
+		Deleted:      res.Deleted,
+		BackRefCells: res.BackRefCells,
 	}, nil
 }
 

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -1,0 +1,199 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// GetConfigResult reports the full document view of a single `kind: CellConfig`
+// (issue #644). Unlike a Secret, a Config carries no credential bytes — only a
+// blueprint reference, scalar values, and repo/secret slot fills — so the whole
+// document is returned for `kuke get config` to surface.
+type GetConfigResult struct {
+	Config         intmodel.CellConfig
+	MetadataExists bool
+}
+
+// DeleteConfigResult reports the outcome of removing a single CellConfig's
+// daemon-stored document file (issue #644). BackRefCells lists the scope paths
+// of every live cell that still carries the kukeon.io/config back-reference
+// label to this config. It is informational, never a refusal: deleting a Config
+// does not delete the cell it materialized (that is `kuke delete cell`), so the
+// CLI surfaces a one-line notice pointing the operator there.
+type DeleteConfigResult struct {
+	Config       intmodel.CellConfig
+	Deleted      bool
+	BackRefCells []string
+}
+
+// GetConfig reads one named, scoped CellConfig's document. The scope
+// coordinates are validated for completeness (a deeper coordinate requires
+// every shallower one; a Config may not be cell-scoped); realm and name are
+// mandatory. Returns MetadataExists=false (no error) when the config is absent,
+// mirroring GetBlueprint's "report, don't error on not-found" shape.
+func (b *Exec) GetConfig(config intmodel.CellConfig) (GetConfigResult, error) {
+	var res GetConfigResult
+
+	if err := validateConfigLookup(config.Metadata); err != nil {
+		return res, err
+	}
+
+	got, err := b.runner.GetConfig(config)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrConfigNotFound) {
+			res.MetadataExists = false
+			return res, nil
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrGetConfig, err)
+	}
+
+	res.MetadataExists = true
+	res.Config = got
+	return res, nil
+}
+
+// ListConfigs lists the metadata of every CellConfig bound to the filter scope
+// or any scope nested within it (issue #644). An empty realm lists across all
+// realms; the filter coordinates must still be contiguous (no gap below a set
+// level), and — a Config never being cell-scoped — there is no cell coordinate.
+func (b *Exec) ListConfigs(realmName, spaceName, stackName string) ([]intmodel.CellConfig, error) {
+	if err := validateConfigScopeFilter(realmName, spaceName, stackName); err != nil {
+		return nil, err
+	}
+	return b.runner.ListConfigs(
+		strings.TrimSpace(realmName),
+		strings.TrimSpace(spaceName),
+		strings.TrimSpace(stackName),
+	)
+}
+
+// DeleteConfig removes a single named, scoped CellConfig's daemon-stored
+// document. Returns a "not found" error when the config does not exist, matching
+// the DeleteBlueprint contract.
+//
+// Back-reference notice (issue #644 AC): deleting a Config does NOT delete the
+// cell it materialized. Before unlinking, scan every persisted cell for the
+// kukeon.io/config back-reference label pointing at this config and report the
+// matches in the result so the CLI can emit a one-line notice pointing at
+// `kuke delete cell <name>`. Unlike DeleteSecret's live-reference gate this is
+// informational only — it never refuses the delete.
+func (b *Exec) DeleteConfig(config intmodel.CellConfig) (DeleteConfigResult, error) {
+	var res DeleteConfigResult
+
+	if err := validateConfigLookup(config.Metadata); err != nil {
+		return res, err
+	}
+
+	refs, err := b.configBackRefCells(config.Metadata)
+	if err != nil {
+		return res, fmt.Errorf("%w: check back-references: %w", errdefs.ErrDeleteConfig, err)
+	}
+
+	if err := b.runner.DeleteConfig(config); err != nil {
+		if errors.Is(err, errdefs.ErrConfigNotFound) {
+			return res, fmt.Errorf("config %q not found", config.Metadata.Name)
+		}
+		return res, fmt.Errorf("%w: %w", errdefs.ErrDeleteConfig, err)
+	}
+
+	res.Deleted = true
+	res.Config = config
+	res.BackRefCells = refs
+	return res, nil
+}
+
+// configBackRefCells returns the scope paths of every persisted cell that
+// carries the kukeon.io/config back-reference label (cellconfig.LabelConfig)
+// pointing at this config, within the config's own scope. A Config materializes
+// at most one live cell within scope (see internal/cellconfig.StableName), so
+// this is normally zero or one entry; it stays a slice to surface every match
+// without guessing. The match is by label value == config name plus a scope
+// prefix (the cell's realm always matches; space/stack match only when the
+// config sets them) so a same-named config in a sibling scope never produces a
+// false positive. The label is set by `kuke run -c` (#625); until that lands no
+// cell carries it and this is a no-op.
+func (b *Exec) configBackRefCells(md intmodel.CellConfigMetadata) ([]string, error) {
+	cells, err := b.runner.ListCells("", "", "")
+	if err != nil {
+		return nil, err
+	}
+
+	realm := strings.TrimSpace(md.Realm)
+	space := strings.TrimSpace(md.Space)
+	stack := strings.TrimSpace(md.Stack)
+
+	var refs []string
+	for _, cell := range cells {
+		if cell.Metadata.Labels[cellconfig.LabelConfig] != md.Name {
+			continue
+		}
+		if cell.Spec.RealmName != realm {
+			continue
+		}
+		if space != "" && cell.Spec.SpaceName != space {
+			continue
+		}
+		if stack != "" && cell.Spec.StackName != stack {
+			continue
+		}
+		refs = append(refs, fmt.Sprintf("%s/%s/%s/%s",
+			cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name))
+	}
+	return refs, nil
+}
+
+// validateConfigLookup enforces the scope contract for a single-config get or
+// delete: name and realm are mandatory and the scope coordinates must be
+// contiguous, with the Config-specific rule that a cell coordinate is never
+// valid (a Config is realm/space/stack-scoped only).
+func validateConfigLookup(md intmodel.CellConfigMetadata) error {
+	if strings.TrimSpace(md.Name) == "" {
+		return errdefs.ErrConfigNameRequired
+	}
+	if strings.TrimSpace(md.Realm) == "" {
+		return errdefs.ErrConfigRealmRequired
+	}
+	if strings.TrimSpace(md.Stack) != "" && strings.TrimSpace(md.Space) == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrConfigScopeIncomplete)
+	}
+	return nil
+}
+
+// validateConfigScopeFilter enforces the scope contract for a list filter:
+// realm is optional (an empty realm lists across all realms), but a set deeper
+// coordinate still requires every shallower one. A Config is never cell-scoped,
+// so the filter bottoms out at stack.
+func validateConfigScopeFilter(realm, space, stack string) error {
+	realm = strings.TrimSpace(realm)
+	space = strings.TrimSpace(space)
+	stack = strings.TrimSpace(stack)
+
+	if realm == "" && (space != "" || stack != "") {
+		return fmt.Errorf("%w (scope set without realm)", errdefs.ErrConfigScopeIncomplete)
+	}
+	if stack != "" && space == "" {
+		return fmt.Errorf("%w (stack set without space)", errdefs.ErrConfigScopeIncomplete)
+	}
+	return nil
+}

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -1,0 +1,252 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestGetConfig_ReportsNotFoundWithoutError pins the GetBlueprint-shaped
+// contract: an absent config yields MetadataExists=false and a nil error.
+func TestGetConfig_ReportsNotFoundWithoutError(t *testing.T) {
+	mockRunner := &fakeRunner{
+		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return intmodel.CellConfig{}, errdefs.ErrConfigNotFound
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.GetConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "web", Realm: "default"},
+	})
+	if err != nil {
+		t.Fatalf("GetConfig() error = %v, want nil", err)
+	}
+	if res.MetadataExists {
+		t.Errorf("MetadataExists = true, want false for absent config")
+	}
+}
+
+// TestGetConfig_ReturnsFullDocument confirms a present config surfaces its full
+// document (a Config carries no credential bytes, so the body is safe to read).
+func TestGetConfig_ReturnsFullDocument(t *testing.T) {
+	mockRunner := &fakeRunner{
+		GetConfigFn: func(c intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return intmodel.CellConfig{Metadata: c.Metadata, Document: []byte("body")}, nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.GetConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("GetConfig() error = %v", err)
+	}
+	if !res.MetadataExists {
+		t.Fatal("MetadataExists = false, want true")
+	}
+	if string(res.Config.Document) != "body" {
+		t.Errorf("Document = %q, want body", res.Config.Document)
+	}
+}
+
+func TestGetConfig_ValidatesScope(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+
+	tests := []struct {
+		name string
+		md   intmodel.CellConfigMetadata
+		want error
+	}{
+		{"missing_name", intmodel.CellConfigMetadata{Realm: "default"}, errdefs.ErrConfigNameRequired},
+		{"missing_realm", intmodel.CellConfigMetadata{Name: "web"}, errdefs.ErrConfigRealmRequired},
+		{
+			"stack_without_space",
+			intmodel.CellConfigMetadata{Name: "web", Realm: "default", Stack: "st"},
+			errdefs.ErrConfigScopeIncomplete,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ctrl.GetConfig(intmodel.CellConfig{Metadata: tt.md}); !errors.Is(err, tt.want) {
+				t.Errorf("GetConfig() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+// TestListConfigs_DelegatesAfterFilterValidation confirms the controller
+// validates the filter's scope contiguity and forwards the trimmed coordinates
+// to the runner (issue #644).
+func TestListConfigs_DelegatesAfterFilterValidation(t *testing.T) {
+	var gotRealm, gotSpace, gotStack string
+	mockRunner := &fakeRunner{
+		ListConfigsFn: func(realm, space, stack string) ([]intmodel.CellConfig, error) {
+			gotRealm, gotSpace, gotStack = realm, space, stack
+			return []intmodel.CellConfig{
+				{Metadata: intmodel.CellConfigMetadata{Name: "web", Realm: realm, Space: space}},
+			}, nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	got, err := ctrl.ListConfigs("  default ", "team-a", "")
+	if err != nil {
+		t.Fatalf("ListConfigs() error = %v", err)
+	}
+	if gotRealm != "default" || gotSpace != "team-a" || gotStack != "" {
+		t.Errorf("runner got (%q,%q,%q), want (default,team-a,)", gotRealm, gotSpace, gotStack)
+	}
+	if len(got) != 1 || got[0].Metadata.Name != "web" {
+		t.Errorf("ListConfigs() = %+v, want one config named web", got)
+	}
+}
+
+func TestListConfigs_RejectsIncompleteFilter(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+
+	tests := []struct {
+		name                string
+		realm, space, stack string
+	}{
+		{"scope_without_realm", "", "team-a", ""},
+		{"stack_without_space", "default", "", "web"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ctrl.ListConfigs(tt.realm, tt.space, tt.stack); !errors.Is(
+				err, errdefs.ErrConfigScopeIncomplete,
+			) {
+				t.Errorf("ListConfigs() error = %v, want ErrConfigScopeIncomplete", err)
+			}
+		})
+	}
+}
+
+func TestDeleteConfig_NotFoundFriendlyError(t *testing.T) {
+	mockRunner := &fakeRunner{
+		ListCellsFn: func(string, string, string) ([]intmodel.Cell, error) { return nil, nil },
+		DeleteConfigFn: func(intmodel.CellConfig) error {
+			return errdefs.ErrConfigNotFound
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	_, err := ctrl.DeleteConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "ghost", Realm: "default"},
+	})
+	if err == nil || err.Error() != `config "ghost" not found` {
+		t.Errorf("DeleteConfig() error = %v, want `config \"ghost\" not found`", err)
+	}
+}
+
+func TestDeleteConfig_SuccessReportsDeleted(t *testing.T) {
+	var gotMeta intmodel.CellConfigMetadata
+	mockRunner := &fakeRunner{
+		ListCellsFn: func(string, string, string) ([]intmodel.Cell, error) { return nil, nil },
+		DeleteConfigFn: func(c intmodel.CellConfig) error {
+			gotMeta = c.Metadata
+			return nil
+		},
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.DeleteConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteConfig() error = %v", err)
+	}
+	if !res.Deleted {
+		t.Error("Deleted = false, want true")
+	}
+	if len(res.BackRefCells) != 0 {
+		t.Errorf("BackRefCells = %v, want empty", res.BackRefCells)
+	}
+	if gotMeta.Name != "web" || gotMeta.Realm != "default" || gotMeta.Space != "team-a" {
+		t.Errorf("runner got metadata %+v, want web/default/team-a", gotMeta)
+	}
+}
+
+// TestDeleteConfig_ReportsBackRefCells pins the AC's back-reference notice: a
+// live cell carrying the kukeon.io/config label to this config (within scope)
+// is surfaced in BackRefCells — informational, never a refusal, so the delete
+// still succeeds.
+func TestDeleteConfig_ReportsBackRefCells(t *testing.T) {
+	mockRunner := &fakeRunner{
+		ListCellsFn: func(string, string, string) ([]intmodel.Cell, error) {
+			return []intmodel.Cell{
+				{
+					Metadata: intmodel.CellMetadata{
+						Name:   "web",
+						Labels: map[string]string{cellconfig.LabelConfig: "web"},
+					},
+					Spec: intmodel.CellSpec{
+						RealmName: "default", SpaceName: "team-a", StackName: "api",
+					},
+				},
+				{ // different config name — must not match
+					Metadata: intmodel.CellMetadata{
+						Name:   "other",
+						Labels: map[string]string{cellconfig.LabelConfig: "elsewhere"},
+					},
+					Spec: intmodel.CellSpec{RealmName: "default", SpaceName: "team-a", StackName: "api"},
+				},
+				{ // right label value, wrong realm — out of scope, must not match
+					Metadata: intmodel.CellMetadata{
+						Name:   "web",
+						Labels: map[string]string{cellconfig.LabelConfig: "web"},
+					},
+					Spec: intmodel.CellSpec{RealmName: "other-realm", SpaceName: "team-a", StackName: "api"},
+				},
+			}, nil
+		},
+		DeleteConfigFn: func(intmodel.CellConfig) error { return nil },
+	}
+	ctrl := setupTestController(t, mockRunner)
+
+	res, err := ctrl.DeleteConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("DeleteConfig() error = %v", err)
+	}
+	if !res.Deleted {
+		t.Error("Deleted = false, want true (notice is informational, never a refusal)")
+	}
+	if len(res.BackRefCells) != 1 || res.BackRefCells[0] != "default/team-a/api/web" {
+		t.Errorf("BackRefCells = %v, want [default/team-a/api/web]", res.BackRefCells)
+	}
+}
+
+func TestDeleteConfig_ValidatesScope(t *testing.T) {
+	ctrl := setupTestController(t, &fakeRunner{})
+
+	if _, err := ctrl.DeleteConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Realm: "default"},
+	}); !errors.Is(err, errdefs.ErrConfigNameRequired) {
+		t.Errorf("DeleteConfig() error = %v, want ErrConfigNameRequired", err)
+	}
+}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -72,7 +72,10 @@ type fakeRunner struct {
 	DeleteBlueprintFn func(bp intmodel.CellBlueprint) error
 
 	// Config methods
-	WriteConfigFn func(config intmodel.CellConfig) (bool, error)
+	WriteConfigFn  func(config intmodel.CellConfig) (bool, error)
+	GetConfigFn    func(config intmodel.CellConfig) (intmodel.CellConfig, error)
+	ListConfigsFn  func(realmName, spaceName, stackName string) ([]intmodel.CellConfig, error)
+	DeleteConfigFn func(config intmodel.CellConfig) error
 
 	// Cell methods
 	GetCellFn                 func(cell intmodel.Cell) (intmodel.Cell, error)
@@ -336,6 +339,27 @@ func (f *fakeRunner) WriteConfig(config intmodel.CellConfig) (bool, error) {
 		return f.WriteConfigFn(config)
 	}
 	return false, errors.New("unexpected call to WriteConfig")
+}
+
+func (f *fakeRunner) GetConfig(config intmodel.CellConfig) (intmodel.CellConfig, error) {
+	if f.GetConfigFn != nil {
+		return f.GetConfigFn(config)
+	}
+	return intmodel.CellConfig{}, errors.New("unexpected call to GetConfig")
+}
+
+func (f *fakeRunner) ListConfigs(realmName, spaceName, stackName string) ([]intmodel.CellConfig, error) {
+	if f.ListConfigsFn != nil {
+		return f.ListConfigsFn(realmName, spaceName, stackName)
+	}
+	return nil, errors.New("unexpected call to ListConfigs")
+}
+
+func (f *fakeRunner) DeleteConfig(config intmodel.CellConfig) error {
+	if f.DeleteConfigFn != nil {
+		return f.DeleteConfigFn(config)
+	}
+	return errors.New("unexpected call to DeleteConfig")
 }
 
 // Cell methods

--- a/internal/controller/runner/config.go
+++ b/internal/controller/runner/config.go
@@ -20,7 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -80,4 +83,191 @@ func (r *Exec) WriteConfig(config intmodel.CellConfig) (bool, error) {
 		"stack", md.Stack,
 	)
 	return created, nil
+}
+
+// GetConfig reads a single named, scoped CellConfig's document off disk (issue
+// #644). Like GetBlueprint — and unlike GetSecret — the full document is read
+// back and returned: a Config carries only a blueprint reference, scalar
+// values, and slot fills (no credential bytes), so the whole document is safe
+// to surface for `kuke get config`. Returns errdefs.ErrConfigNotFound when the
+// file is absent.
+func (r *Exec) GetConfig(config intmodel.CellConfig) (intmodel.CellConfig, error) {
+	md := config.Metadata
+	path := fs.ConfigPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return intmodel.CellConfig{}, errdefs.ErrConfigNotFound
+		}
+		return intmodel.CellConfig{}, fmt.Errorf("%w: %w", errdefs.ErrGetConfig, err)
+	}
+
+	return intmodel.CellConfig{Metadata: md, Document: data}, nil
+}
+
+// ListConfigs enumerates the metadata of every CellConfig bound to the scope
+// identified by the filter coordinates, plus every Config bound to a deeper
+// scope nested within it (issue #644). The filter is a prefix: an empty
+// realmName lists across all realms; a set realmName with an empty spaceName
+// lists realm-scoped configs and everything under that realm; and so on. This
+// mirrors the subtree-filter semantics of ListBlueprints, bounded at stack
+// depth — a Config is never cell-scoped (#624). The returned carriers are
+// metadata-only (Document nil): the scope coordinates come from the path and
+// the name from the file basename, so a list never parses every document.
+func (r *Exec) ListConfigs(realmName, spaceName, stackName string) ([]intmodel.CellConfig, error) {
+	realmDirs, err := r.resolveRealmDirs(realmName)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errdefs.ErrListConfigs, err)
+	}
+
+	var out []intmodel.CellConfig
+	for _, realmDir := range realmDirs {
+		realm := filepath.Base(realmDir)
+		if walkErr := r.collectConfigSubtree(&out, realm, spaceName, stackName); walkErr != nil {
+			return nil, fmt.Errorf("%w: %w", errdefs.ErrListConfigs, walkErr)
+		}
+	}
+	return out, nil
+}
+
+// collectConfigSubtree appends the metadata of every CellConfig bound to scope
+// (realm, space, stack) — where a trailing coordinate that is "" marks the
+// filter floor — and every Config in scopes nested within it. The rule mirrors
+// collectBlueprintSubtree: collect a level's own configs only when the
+// next-deeper filter coordinate is empty, and descend into a child only when it
+// matches a set filter coordinate or the filter is empty at that level. The
+// walk is bounded at stack depth, so cell directories are never descended.
+func (r *Exec) collectConfigSubtree(out *[]intmodel.CellConfig, realm, space, stack string) error {
+	if space == "" {
+		if err := r.collectConfigsInScope(out, realm, "", ""); err != nil {
+			return err
+		}
+	}
+
+	spaces, err := r.configChildScopeNames(fs.RealmMetadataDir(r.opts.RunPath, realm), space)
+	if err != nil {
+		return err
+	}
+	for _, sp := range spaces {
+		if stack == "" {
+			if err = r.collectConfigsInScope(out, realm, sp, ""); err != nil {
+				return err
+			}
+		}
+
+		stacks, stErr := r.configChildScopeNames(fs.SpaceMetadataDir(r.opts.RunPath, realm, sp), stack)
+		if stErr != nil {
+			return stErr
+		}
+		for _, st := range stacks {
+			if err = r.collectConfigsInScope(out, realm, sp, st); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// configChildScopeNames returns the child-scope subdirectory names directly
+// under dir, excluding all three reserved resource subdirectories (secrets/,
+// blueprints/, configs/) so none is mistaken for a child space or stack. When
+// want is non-empty it filters to that single child (returned only if it
+// exists). A missing dir yields no children, matching the list verbs' "no match
+// ⇒ empty". Note this excludes configs/ as well as secrets/blueprints — a
+// reserved subdir at any scope level is never a child scope.
+func (r *Exec) configChildScopeNames(dir, want string) ([]string, error) {
+	if strings.TrimSpace(want) != "" {
+		child := filepath.Join(dir, want)
+		info, err := os.Stat(child)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to stat scope dir %q: %w", child, err)
+		}
+		if !info.IsDir() {
+			return nil, nil
+		}
+		return []string{want}, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read scope dir %q: %w", dir, err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		switch entry.Name() {
+		case consts.KukeonSecretsSubdir, consts.KukeonBlueprintsSubdir, consts.KukeonConfigsSubdir:
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
+// collectConfigsInScope appends the metadata of every CellConfig stored
+// directly at the given scope (realm, space, stack). The in-flight
+// ".config-*.tmp" temp files WriteConfig creates are skipped so a concurrent
+// apply never surfaces a half-written name.
+func (r *Exec) collectConfigsInScope(out *[]intmodel.CellConfig, realm, space, stack string) error {
+	dir := fs.ConfigsDir(r.opts.RunPath, realm, space, stack)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read configs dir %q: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".config-") && strings.HasSuffix(name, ".tmp") {
+			continue
+		}
+		*out = append(*out, intmodel.CellConfig{
+			Metadata: intmodel.CellConfigMetadata{
+				Name:  name,
+				Realm: realm,
+				Space: space,
+				Stack: stack,
+			},
+		})
+	}
+	return nil
+}
+
+// DeleteConfig removes the daemon-stored document file for a single named,
+// scoped CellConfig (issue #644). Returns errdefs.ErrConfigNotFound when the
+// file is absent so the caller can report a clear "not found" instead of a
+// silent success. Deleting a Config never touches the cell it materialized —
+// that is `kuke delete cell` — so there is no live-reference gate here; the
+// back-reference notice is computed and surfaced by the controller layer.
+func (r *Exec) DeleteConfig(config intmodel.CellConfig) error {
+	md := config.Metadata
+	path := fs.ConfigPath(r.opts.RunPath, md.Realm, md.Space, md.Stack, md.Name)
+
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return errdefs.ErrConfigNotFound
+		}
+		return fmt.Errorf("%w: %w", errdefs.ErrDeleteConfig, err)
+	}
+
+	r.logger.InfoContext(r.ctx, "config deleted",
+		"name", md.Name,
+		"realm", md.Realm,
+		"space", md.Space,
+		"stack", md.Stack,
+	)
+	return nil
 }

--- a/internal/controller/runner/config_test.go
+++ b/internal/controller/runner/config_test.go
@@ -20,10 +20,13 @@
 package runner
 
 import (
+	"errors"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
 )
@@ -128,5 +131,193 @@ func TestWriteConfig_DeeperScopeNestsUnderScopeDir(t *testing.T) {
 	realmScoped := fs.ConfigPath(runPath, "kuke-system", "", "", "dev")
 	if _, err := os.Stat(realmScoped); !os.IsNotExist(err) {
 		t.Errorf("config leaked into realm scope at %s (err=%v)", realmScoped, err)
+	}
+}
+
+// TestGetConfig_ReturnsFullDocument confirms GetConfig reads the full document
+// back (like GetBlueprint, a Config carries no credential bytes) and reports
+// ErrConfigNotFound for an absent name.
+func TestGetConfig_ReturnsFullDocument(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	stored := intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "web", Realm: "default", Space: "team-a"},
+		Document: []byte("the-config-body"),
+	}
+	if _, err := r.WriteConfig(stored); err != nil {
+		t.Fatalf("WriteConfig() error = %v", err)
+	}
+
+	got, err := r.GetConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	})
+	if err != nil {
+		t.Fatalf("GetConfig() error = %v", err)
+	}
+	if string(got.Document) != "the-config-body" {
+		t.Errorf("Document = %q, want the-config-body (full body must round-trip)", got.Document)
+	}
+}
+
+func TestGetConfig_NotFound(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	_, err := r.GetConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "ghost", Realm: "default"},
+	})
+	if !errors.Is(err, errdefs.ErrConfigNotFound) {
+		t.Errorf("GetConfig() error = %v, want ErrConfigNotFound", err)
+	}
+}
+
+// configScopeKey is a stable identity for a listed config, used to compare
+// ListConfigs output independent of walk order.
+func configScopeKey(c intmodel.CellConfig) string {
+	return c.Metadata.Realm + "/" + c.Metadata.Space + "/" + c.Metadata.Stack + "/" + c.Metadata.Name
+}
+
+func listedConfigKeys(t *testing.T, r *Exec, realm, space, stack string) []string {
+	t.Helper()
+	got, err := r.ListConfigs(realm, space, stack)
+	if err != nil {
+		t.Fatalf("ListConfigs(%q,%q,%q) error = %v", realm, space, stack, err)
+	}
+	keys := make([]string, 0, len(got))
+	for _, c := range got {
+		keys = append(keys, configScopeKey(c))
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// seedConfig writes a metadata-only config at the given scope for list/delete
+// walk tests; the document body is irrelevant to those paths.
+func seedConfig(t *testing.T, r *Exec, name, realm, space, stack string) {
+	t.Helper()
+	cfg := intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: name, Realm: realm, Space: space, Stack: stack},
+		Document: []byte("x"),
+	}
+	if _, err := r.WriteConfig(cfg); err != nil {
+		t.Fatalf("seed WriteConfig(%q @ %s/%s/%s) error = %v", name, realm, space, stack, err)
+	}
+}
+
+// TestListConfigs_SubtreeFilterSemantics pins the issue #644 list contract: an
+// empty filter lists the whole subtree, a realm filter scopes to that realm,
+// and a deeper coordinate excludes shallower scopes — mirroring ListBlueprints,
+// bounded at stack (a Config is never cell-scoped).
+func TestListConfigs_SubtreeFilterSemantics(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seedConfig(t, r, "realm-cfg", "default", "", "")
+	seedConfig(t, r, "space-cfg", "default", "team-a", "")
+	seedConfig(t, r, "stack-cfg", "default", "team-a", "web")
+	seedConfig(t, r, "other-realm-cfg", "prod", "", "")
+
+	all := listedConfigKeys(t, r, "", "", "")
+	wantAll := []string{
+		"default///realm-cfg",
+		"default/team-a//space-cfg",
+		"default/team-a/web/stack-cfg",
+		"prod///other-realm-cfg",
+	}
+	if !equalStrings(all, wantAll) {
+		t.Errorf("ListConfigs(all) = %v, want %v", all, wantAll)
+	}
+
+	realmFiltered := listedConfigKeys(t, r, "default", "", "")
+	wantRealm := []string{
+		"default///realm-cfg",
+		"default/team-a//space-cfg",
+		"default/team-a/web/stack-cfg",
+	}
+	if !equalStrings(realmFiltered, wantRealm) {
+		t.Errorf("ListConfigs(default) = %v, want %v", realmFiltered, wantRealm)
+	}
+
+	spaceFiltered := listedConfigKeys(t, r, "default", "team-a", "")
+	wantSpace := []string{
+		"default/team-a//space-cfg",
+		"default/team-a/web/stack-cfg",
+	}
+	if !equalStrings(spaceFiltered, wantSpace) {
+		t.Errorf("ListConfigs(default,team-a) = %v, want %v", spaceFiltered, wantSpace)
+	}
+
+	stackFiltered := listedConfigKeys(t, r, "default", "team-a", "web")
+	wantStack := []string{"default/team-a/web/stack-cfg"}
+	if !equalStrings(stackFiltered, wantStack) {
+		t.Errorf("ListConfigs(default,team-a,web) = %v, want %v", stackFiltered, wantStack)
+	}
+}
+
+// TestListConfigs_IgnoresReservedSubdirs confirms the walk never mistakes a
+// sibling secrets/, blueprints/, or configs/ reserved subdirectory for a child
+// space or stack, and that an in-flight temp file is skipped. The configs/
+// exclusion is the case the blueprint walker misses (it predates #624's configs
+// subdir); listing configs across the realm subtree must not recurse into the
+// realm's own configs/ dir as a phantom space.
+func TestListConfigs_IgnoresReservedSubdirs(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seedConfig(t, r, "realm-cfg", "default", "", "")
+	// A realm-scoped secret creates default/secrets/; a realm-scoped blueprint
+	// creates default/blueprints/; the seeded config already created
+	// default/configs/. None must surface as a child space.
+	if _, err := r.WriteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
+		Spec:     intmodel.SecretSpec{Data: "v"},
+	}); err != nil {
+		t.Fatalf("seed WriteSecret error = %v", err)
+	}
+	seedBlueprint(t, r, "bp", "default", "", "")
+	// Drop an in-flight temp file alongside the realm config; it must be
+	// skipped, not surfaced as a config named ".config-xyz.tmp".
+	tmpPath := fs.ConfigPath(runPath, "default", "", "", ".config-xyz.tmp")
+	if err := os.WriteFile(tmpPath, []byte("partial"), 0o644); err != nil {
+		t.Fatalf("seed temp file error = %v", err)
+	}
+
+	got := listedConfigKeys(t, r, "", "", "")
+	want := []string{"default///realm-cfg"}
+	if !equalStrings(got, want) {
+		t.Errorf("ListConfigs(all) = %v, want %v (reserved subdirs + temp file must be ignored)", got, want)
+	}
+}
+
+func TestDeleteConfig_RemovesFile(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seedConfig(t, r, "web", "default", "team-a", "")
+	path := fs.ConfigPath(runPath, "default", "team-a", "", "web")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("precondition: config not seeded: %v", err)
+	}
+
+	if err := r.DeleteConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "web", Realm: "default", Space: "team-a"},
+	}); err != nil {
+		t.Fatalf("DeleteConfig() error = %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("config file still present after delete (err=%v)", err)
+	}
+}
+
+func TestDeleteConfig_NotFound(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	err := r.DeleteConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{Name: "ghost", Realm: "default"},
+	})
+	if !errors.Is(err, errdefs.ErrConfigNotFound) {
+		t.Errorf("DeleteConfig() error = %v, want ErrConfigNotFound", err)
 	}
 }

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -149,6 +149,22 @@ type Runner interface {
 	// verified the config's scope exists and the referenced blueprint resolves.
 	WriteConfig(config intmodel.CellConfig) (created bool, err error)
 
+	// GetConfig reads a single named, scoped CellConfig's document off disk
+	// (issue #644). Like GetBlueprint the full document is returned — a Config
+	// carries only a blueprint ref, scalar values, and slot fills, no credential
+	// bytes. Returns errdefs.ErrConfigNotFound when the file is absent.
+	GetConfig(config intmodel.CellConfig) (intmodel.CellConfig, error)
+	// ListConfigs enumerates the metadata of every CellConfig bound to the
+	// filter scope or any scope nested within it (issue #644). An empty
+	// realmName lists across all realms; the filter is a subtree prefix bounded
+	// at stack depth (a Config is never cell-scoped). The returned carriers are
+	// metadata-only — the document is not read.
+	ListConfigs(realmName, spaceName, stackName string) ([]intmodel.CellConfig, error)
+	// DeleteConfig removes the daemon-stored document file for a single named,
+	// scoped CellConfig (issue #644). Returns errdefs.ErrConfigNotFound when the
+	// file is absent. Deleting a Config never touches the cell it materialized.
+	DeleteConfig(config intmodel.CellConfig) error
+
 	ExistsCgroup(doc any) (bool, error)
 
 	PurgeRealm(realm intmodel.Realm) (namespaceRemoved bool, err error)

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -164,6 +164,13 @@ func (s *KukeonV1Service) GetBlueprint(args *kukeonv1.GetBlueprintArgs, reply *k
 	return nil
 }
 
+func (s *KukeonV1Service) GetConfig(args *kukeonv1.GetConfigArgs, reply *kukeonv1.GetConfigReply) error {
+	result, err := s.core.GetConfig(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
 // ---- List ----
 
 func (s *KukeonV1Service) ListRealms(_ *kukeonv1.ListRealmsArgs, reply *kukeonv1.ListRealmsReply) error {
@@ -213,6 +220,15 @@ func (s *KukeonV1Service) ListBlueprints(
 ) error {
 	blueprints, err := s.core.ListBlueprints(s.ctx, args.RealmName, args.SpaceName, args.StackName)
 	reply.Blueprints = blueprints
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
+func (s *KukeonV1Service) ListConfigs(
+	args *kukeonv1.ListConfigsArgs, reply *kukeonv1.ListConfigsReply,
+) error {
+	configs, err := s.core.ListConfigs(s.ctx, args.RealmName, args.SpaceName, args.StackName)
+	reply.Configs = configs
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil
 }
@@ -343,6 +359,15 @@ func (s *KukeonV1Service) DeleteBlueprint(
 	args *kukeonv1.DeleteBlueprintArgs, reply *kukeonv1.DeleteBlueprintReply,
 ) error {
 	result, err := s.core.DeleteBlueprint(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	return nil
+}
+
+func (s *KukeonV1Service) DeleteConfig(
+	args *kukeonv1.DeleteConfigArgs, reply *kukeonv1.DeleteConfigReply,
+) error {
+	result, err := s.core.DeleteConfig(s.ctx, args.Doc)
 	reply.Result = result
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -417,6 +417,16 @@ var (
 	// ErrWriteConfig wraps a failure to persist a CellConfig document.
 	ErrWriteConfig = errors.New("failed to write config document")
 
+	// CellConfig read/delete-verb errors (issue #644, phase 4b-ii of #423).
+	// Get returns the full document; list returns metadata only; delete
+	// removes the daemon-stored file (and emits a back-reference notice, never
+	// a refusal, when a live cell still carries the kukeon.io/config label).
+
+	ErrConfigNotFound = errors.New("config not found")
+	ErrGetConfig      = errors.New("failed to get config")
+	ErrListConfigs    = errors.New("failed to list configs")
+	ErrDeleteConfig   = errors.New("failed to delete config document")
+
 	// ErrMustRunAsRoot is returned by direct-write subcommands (kuke init,
 	// kuke daemon reset, kuke image load, kuke doctor cgroups --probe)
 	// when invoked with a non-zero effective UID. Wrapped errors must

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -53,6 +53,12 @@ type Client interface {
 	// so `kuke run -b` can materialize it. The input doc carries the name and
 	// scope coordinates only; the spec is ignored.
 	GetBlueprint(ctx context.Context, doc v1beta1.CellBlueprintDoc) (GetBlueprintResult, error)
+	// GetConfig reads one named, scoped `kind: CellConfig`'s full document
+	// from daemon storage (issue #644). Like GetBlueprint the whole document
+	// is returned — a Config carries no credential bytes — so the blueprint
+	// ref, values, and slot fills surface to `kuke get config`. The input doc
+	// carries the name and scope coordinates only; the spec is ignored.
+	GetConfig(ctx context.Context, doc v1beta1.CellConfigDoc) (GetConfigResult, error)
 
 	ListRealms(ctx context.Context) ([]v1beta1.RealmDoc, error)
 	ListSpaces(ctx context.Context, realmName string) ([]v1beta1.SpaceDoc, error)
@@ -71,6 +77,11 @@ type Client interface {
 	// realmName lists across all realms. A Blueprint is never cell-scoped, so
 	// there is no cell coordinate. The spec is not populated for a list.
 	ListBlueprints(ctx context.Context, realmName, spaceName, stackName string) ([]v1beta1.CellBlueprintDoc, error)
+	// ListConfigs enumerates the metadata of every CellConfig bound to the
+	// filter scope or any scope nested within it (issue #644). An empty
+	// realmName lists across all realms. A Config is never cell-scoped, so
+	// there is no cell coordinate. The spec is not populated for a list.
+	ListConfigs(ctx context.Context, realmName, spaceName, stackName string) ([]v1beta1.CellConfigDoc, error)
 
 	StartCell(ctx context.Context, doc v1beta1.CellDoc) (StartCellResult, error)
 	StartContainer(ctx context.Context, doc v1beta1.ContainerDoc) (StartContainerResult, error)
@@ -101,6 +112,11 @@ type Client interface {
 	// daemon-stored document (issue #643). No live-reference gate: cells
 	// materialized from a blueprint are independent copies (#620).
 	DeleteBlueprint(ctx context.Context, doc v1beta1.CellBlueprintDoc) (DeleteBlueprintResult, error)
+	// DeleteConfig removes a single named, scoped CellConfig's daemon-stored
+	// document (issue #644). No live-reference gate: deleting a Config never
+	// deletes the cell it materialized. The result reports any live cells that
+	// still carry the back-reference label so the caller can emit a notice.
+	DeleteConfig(ctx context.Context, doc v1beta1.CellConfigDoc) (DeleteConfigResult, error)
 
 	PurgeRealm(ctx context.Context, doc v1beta1.RealmDoc, force, cascade bool) (PurgeRealmResult, error)
 	PurgeSpace(ctx context.Context, doc v1beta1.SpaceDoc, force, cascade bool) (PurgeSpaceResult, error)
@@ -186,6 +202,7 @@ const (
 	MethodGetContainer = ServiceName + ".GetContainer"
 	MethodGetSecret    = ServiceName + ".GetSecret"
 	MethodGetBlueprint = ServiceName + ".GetBlueprint"
+	MethodGetConfig    = ServiceName + ".GetConfig"
 
 	MethodListRealms     = ServiceName + ".ListRealms"
 	MethodListSpaces     = ServiceName + ".ListSpaces"
@@ -194,6 +211,7 @@ const (
 	MethodListContainers = ServiceName + ".ListContainers"
 	MethodListSecrets    = ServiceName + ".ListSecrets"
 	MethodListBlueprints = ServiceName + ".ListBlueprints"
+	MethodListConfigs    = ServiceName + ".ListConfigs"
 
 	MethodStartCell       = ServiceName + ".StartCell"
 	MethodStartContainer  = ServiceName + ".StartContainer"
@@ -211,6 +229,7 @@ const (
 	MethodDeleteContainer = ServiceName + ".DeleteContainer"
 	MethodDeleteSecret    = ServiceName + ".DeleteSecret"
 	MethodDeleteBlueprint = ServiceName + ".DeleteBlueprint"
+	MethodDeleteConfig    = ServiceName + ".DeleteConfig"
 
 	MethodPurgeRealm     = ServiceName + ".PurgeRealm"
 	MethodPurgeSpace     = ServiceName + ".PurgeSpace"

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -85,6 +85,10 @@ func (FakeClient) GetBlueprint(context.Context, v1beta1.CellBlueprintDoc) (GetBl
 	return GetBlueprintResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) GetConfig(context.Context, v1beta1.CellConfigDoc) (GetConfigResult, error) {
+	return GetConfigResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) ListRealms(context.Context) ([]v1beta1.RealmDoc, error) {
 	return nil, ErrUnexpectedCall
 }
@@ -110,6 +114,10 @@ func (FakeClient) ListSecrets(context.Context, string, string, string, string) (
 }
 
 func (FakeClient) ListBlueprints(context.Context, string, string, string) ([]v1beta1.CellBlueprintDoc, error) {
+	return nil, ErrUnexpectedCall
+}
+
+func (FakeClient) ListConfigs(context.Context, string, string, string) ([]v1beta1.CellConfigDoc, error) {
 	return nil, ErrUnexpectedCall
 }
 
@@ -171,6 +179,10 @@ func (FakeClient) DeleteSecret(context.Context, v1beta1.SecretDoc) (DeleteSecret
 
 func (FakeClient) DeleteBlueprint(context.Context, v1beta1.CellBlueprintDoc) (DeleteBlueprintResult, error) {
 	return DeleteBlueprintResult{}, ErrUnexpectedCall
+}
+
+func (FakeClient) DeleteConfig(context.Context, v1beta1.CellConfigDoc) (DeleteConfigResult, error) {
+	return DeleteConfigResult{}, ErrUnexpectedCall
 }
 
 func (FakeClient) PurgeRealm(context.Context, v1beta1.RealmDoc, bool, bool) (PurgeRealmResult, error) {

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -291,6 +291,21 @@ func (c *UnixClient) GetBlueprint(
 	return reply.Result, nil
 }
 
+// GetConfig implements Client.
+func (c *UnixClient) GetConfig(
+	ctx context.Context, doc v1beta1.CellConfigDoc,
+) (GetConfigResult, error) {
+	args := &GetConfigArgs{Doc: doc}
+	reply := &GetConfigReply{}
+	if err := c.call(ctx, MethodGetConfig, args, reply); err != nil {
+		return GetConfigResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // ListRealms implements Client.
 func (c *UnixClient) ListRealms(ctx context.Context) ([]v1beta1.RealmDoc, error) {
 	args := &ListRealmsArgs{}
@@ -389,6 +404,22 @@ func (c *UnixClient) ListBlueprints(
 		return reply.Blueprints, FromAPIError(reply.Err)
 	}
 	return reply.Blueprints, nil
+}
+
+// ListConfigs implements Client.
+func (c *UnixClient) ListConfigs(
+	ctx context.Context,
+	realmName, spaceName, stackName string,
+) ([]v1beta1.CellConfigDoc, error) {
+	args := &ListConfigsArgs{RealmName: realmName, SpaceName: spaceName, StackName: stackName}
+	reply := &ListConfigsReply{}
+	if err := c.call(ctx, MethodListConfigs, args, reply); err != nil {
+		return nil, err
+	}
+	if reply.Err != nil {
+		return reply.Configs, FromAPIError(reply.Err)
+	}
+	return reply.Configs, nil
 }
 
 // StartCell implements Client.
@@ -599,6 +630,21 @@ func (c *UnixClient) DeleteBlueprint(
 	reply := &DeleteBlueprintReply{}
 	if err := c.call(ctx, MethodDeleteBlueprint, args, reply); err != nil {
 		return DeleteBlueprintResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
+// DeleteConfig implements Client.
+func (c *UnixClient) DeleteConfig(
+	ctx context.Context, doc v1beta1.CellConfigDoc,
+) (DeleteConfigResult, error) {
+	args := &DeleteConfigArgs{Doc: doc}
+	reply := &DeleteConfigReply{}
+	if err := c.call(ctx, MethodDeleteConfig, args, reply); err != nil {
+		return DeleteConfigResult{}, err
 	}
 	if reply.Err != nil {
 		return reply.Result, FromAPIError(reply.Err)

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -236,6 +236,24 @@ type GetBlueprintResult struct {
 	MetadataExists bool
 }
 
+type GetConfigArgs struct {
+	Doc v1beta1.CellConfigDoc
+}
+
+type GetConfigReply struct {
+	Result GetConfigResult
+	Err    *APIError
+}
+
+// GetConfigResult carries the full CellConfigDoc read from daemon storage
+// (issue #644). Unlike GetSecretResult the whole document is populated — a
+// Config carries only a blueprint ref, scalar values, and slot fills, no
+// credential bytes — so `kuke get config` can surface the binding.
+type GetConfigResult struct {
+	Config         v1beta1.CellConfigDoc
+	MetadataExists bool
+}
+
 // ---- List ----
 
 type ListRealmsArgs struct{}
@@ -311,6 +329,19 @@ type ListBlueprintsArgs struct {
 type ListBlueprintsReply struct {
 	Blueprints []v1beta1.CellBlueprintDoc
 	Err        *APIError
+}
+
+type ListConfigsArgs struct {
+	RealmName string
+	SpaceName string
+	StackName string
+}
+
+// ListConfigsReply carries metadata-only CellConfigDocs — the spec (blueprint
+// ref, values, slot fills) is never populated for a list (issue #644).
+type ListConfigsReply struct {
+	Configs []v1beta1.CellConfigDoc
+	Err     *APIError
 }
 
 // ---- Lifecycle (Start/Stop/Kill) ----
@@ -508,6 +539,26 @@ type DeleteBlueprintReply struct {
 type DeleteBlueprintResult struct {
 	Blueprint v1beta1.CellBlueprintDoc
 	Deleted   bool
+}
+
+type DeleteConfigArgs struct {
+	Doc v1beta1.CellConfigDoc
+}
+
+type DeleteConfigReply struct {
+	Result DeleteConfigResult
+	Err    *APIError
+}
+
+// DeleteConfigResult reports the removed Config (metadata only), whether the
+// file existed to delete, and the scope paths of any live cells that still
+// carry the kukeon.io/config back-reference label (issue #644). BackRefCells is
+// informational — deleting a Config never deletes the cell it materialized — so
+// the CLI surfaces a one-line notice pointing at `kuke delete cell <name>`.
+type DeleteConfigResult struct {
+	Config       v1beta1.CellConfigDoc
+	Deleted      bool
+	BackRefCells []string
 }
 
 type DeleteContainerArgs struct {


### PR DESCRIPTION
## Summary

- Adds the read and delete verbs for the daemon-stored `kind: CellConfig` resource (#624 / phase 4.2.1 shipped the schema + store + `kuke apply`):
  - `kuke get configs [--realm/--space/--stack] [-o json]` — subtree-filtered list.
  - `kuke get config <name> [--realm/--space/--stack] [-o json]` — full document (blueprint ref, values, slot fills).
  - `kuke delete config <name> [--realm/--space/--stack]` — removes the file at `/opt/kukeon/<scope>/configs/<name>`.
- Wired end-to-end through the existing layering, mirroring the Blueprint get/delete siblings (#643): runner storage → controller (`internal/controller/config.go`) → `kukeonv1.Client` interface + RPC (`UnixClient`, daemon service handler, `FakeClient`) → in-process `--no-daemon` client → cobra commands + completion + env vars.

### Notes / non-obvious calls (please push back if any oversteps)

- **`--scope` reading.** The issue body sketches `--scope realm=<r>|space=<s>|stack=<t>`, but the AC also requires output "consistent with existing `kuke get`/`delete` verbs", and every sibling (secret, blueprint) uses separate `--realm/--space/--stack` flags. I mirrored the siblings (separate flags) rather than introduce a one-off `--scope key=value` parser. Documented here so the reviewer can redirect if a literal `--scope` flag was intended.
- **Back-reference notice (AC 4).** `kuke delete config` emits a one-line *notice* (never a refusal) when a live cell still carries the `kukeon.io/config` back-ref label to the deleted config, pointing at `kuke delete cell <name>`. The controller computes the referencing cells (scoped by label value == config name plus a realm/space/stack prefix match) and returns them in `DeleteConfigResult.BackRefCells`; the CLI prints the notice. The label is only set by `kuke run -c` (#625, not yet shipped), so this is a no-op against today's cells — but the detection + notice path is unit-tested at both the controller and CLI layers so #625 lands into working plumbing.
- **Config list walker excludes all three reserved subdirs.** `configChildScopeNames` skips `secrets/`, `blueprints/`, **and** `configs/` when enumerating child scopes, so a reserved subdir at any scope level is never mistaken for a phantom space/stack. The existing blueprint walker (excludes secrets+blueprints, misses configs) and secret walker (excludes secrets only) have the same latent omission since #624 added `configs/`; both are benign today (the phantom descent finds no matching resource subdir) but asymmetric. Filing a separate consistency follow-up — out of scope for this additive PR.

## Test plan

- [x] `make test` (test-root + test-kukebuild) — green. New colocated tests: runner get/list/delete + reserved-subdir exclusion (`internal/controller/runner/config_test.go`), controller get/list/delete + back-ref notice (`internal/controller/config_test.go`), CLI get + delete incl. notice (`cmd/kuke/get/config`, `cmd/kuke/delete/config`). Updated the get/delete parent-command metadata + autocomplete assertions for the new `config` subcommand.
- [x] `GOWORK=off go vet ./...` — clean.
- [x] `make dev-init` smoke — daemon-parity check passes (identical `kuke get realms` vs `--no-daemon`), attach + nested smoke green.
- [x] Live end-to-end round-trip against the dev daemon: `apply` a blueprint + config, then `get configs` (table), `get config <name>` (yaml shows blueprint ref + values), `delete config <name>` ("Deleted config"), `get configs` ("No configs found."). Also verified `-o json` and the `delete config <ghost>` not-found error, via both the daemon socket and `--no-daemon`.

Closes #644