### PR TITLE
chore: remove dead resolveRootCNINetworkName and its test

### DIFF
--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -452,38 +452,15 @@ func (r *Exec) getSpaceNetworkName(space intmodel.Space) (string, error) {
 	return naming.BuildSpaceNetworkName(realmName, space.Metadata.Name)
 }
 
-// resolveRootCNINetworkName resolves the CNI network name for a cell's space,
-// for use on the re-ADD/attach path (start.go, recreate_cell.go) that consults
-// space metadata before attaching the root container to its CNI network.
-// Best-effort: returns "" when the space can't be loaded or the name can't be
-// derived, in which case the attach is intentionally skipped rather than run
-// against a wrong network. Teardown paths use buildRootCNINetworkName instead,
-// which derives the name deterministically without the GetSpace round-trip.
-func (r *Exec) resolveRootCNINetworkName(realmName, spaceName string) string {
-	lookupSpace := intmodel.Space{
-		Metadata: intmodel.SpaceMetadata{Name: spaceName},
-		Spec:     intmodel.SpaceSpec{RealmName: realmName},
-	}
-	internalSpace, err := r.GetSpace(lookupSpace)
-	if err != nil {
-		return ""
-	}
-	networkName, err := r.getSpaceNetworkName(internalSpace)
-	if err != nil {
-		return ""
-	}
-	return networkName
-}
-
 // buildRootCNINetworkName derives the CNI network name for a cell's space
 // deterministically from the realm and space names, without consulting space
 // metadata. Teardown paths (stop/kill/delete) use this for the post-delete
 // IPAM-file purge safety net (purgeCNIForContainer) so the purge runs even when
 // space metadata is gone or corrupt — the network name is a pure function of
-// (realm, space) per naming.BuildSpaceNetworkName, so the GetSpace round-trip
-// resolveRootCNINetworkName performs on the re-ADD side is unnecessary here and
-// its failure must not silently skip the purge (issue #685). Returns "" only
-// when realm/space are empty, which the teardown callers already guard against.
+// (realm, space) per naming.BuildSpaceNetworkName, so a metadata-consulting
+// GetSpace round-trip is unnecessary here and its failure must not silently
+// skip the purge (issue #685). Returns "" only when realm/space are empty,
+// which the teardown callers already guard against.
 func (r *Exec) buildRootCNINetworkName(realmName, spaceName string) string {
 	networkName, err := naming.BuildSpaceNetworkName(realmName, spaceName)
 	if err != nil {

--- a/internal/controller/runner/helpers_test.go
+++ b/internal/controller/runner/helpers_test.go
@@ -145,18 +145,6 @@ func TestIsValidationError(t *testing.T) {
 	}
 }
 
-// TestResolveRootCNINetworkName_EmptyWhenSpaceMissing pins the best-effort
-// contract the issue #630 teardown sites rely on: when the space metadata
-// can't be loaded, resolveRootCNINetworkName returns "" rather than panicking,
-// which makes the downstream purgeCNIForContainer safety net a no-op instead
-// of dereferencing a nil network name.
-func TestResolveRootCNINetworkName_EmptyWhenSpaceMissing(t *testing.T) {
-	r := newMetadataTestExec(t, t.TempDir(), time.Now())
-	if got := r.resolveRootCNINetworkName("default", "nonexistent-space"); got != "" {
-		t.Errorf("resolveRootCNINetworkName() = %q, want \"\" when space metadata is absent", got)
-	}
-}
-
 // TestBuildRootCNINetworkName_DeterministicWhenSpaceMissing is the regression
 // guard for issue #685. The stop/kill/delete teardown sites used to resolve the
 // purge-target network name via GetSpace+getSpaceNetworkName and swallow the


### PR DESCRIPTION
## Summary
- `resolveRootCNINetworkName` lost its last production caller when #732 swapped the create-fresh re-ADD scrub over to `buildRootCNINetworkName`; only its dedicated unit test still referenced it.
- Delete the function, its test, and rewrite the dangling reference in `buildRootCNINetworkName`'s godoc (was naming the now-deleted function to explain why teardown skips the `GetSpace` round-trip).

## Test plan
- [x] `make test` (full root + kukebuild suites, exit 0)
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./internal/controller/runner/`
- [x] Repo-wide grep for `resolveRootCNINetworkName` returns zero matches post-edit.

Closes #735