### PR TITLE
feat(apischeme): reject runOn: create when no persistent writable mount

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -689,7 +689,58 @@ func validateContainerTty(spec ext.ContainerSpec) error {
 			return fmt.Errorf("container %q: onInit[%d]: %w", spec.ID, i, err)
 		}
 	}
+	if err := validateContainerCreateStagePersistence(spec); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateContainerCreateStagePersistence enforces that a container declaring
+// runOn: create stages has at least one persistent writable mount. Without one,
+// the side effects of create stages (npm ci, DB seed, bootstrap) evaporate when
+// the container's writable layer is dropped on the next recreate while
+// ContainerStatus.Stages still reports State == "done" — the run-once gate
+// (phase C2, #737) would then silently skip a stage whose effect no longer
+// exists. TtyStage has no per-stage target field, so the reasoning is
+// container-scoped: any runOn: create stage on a container with no persistent
+// writable mount is at risk. Issue #738.
+//
+// A mount is treated as a persistent writable target when it is a VolumeMount
+// whose Kind is anything other than tmpfs (so VolumeKindBind, including the
+// empty back-compat default, plus any future persistent kind like a future
+// pvc:) and is not declared ReadOnly. ReadOnlyRootFilesystem alone does not
+// affect the decision — the test is solely the presence of at least one
+// persistent writable VolumeMount. ContainerSpec.Tmpfs entries are explicitly
+// ephemeral and never count.
+func validateContainerCreateStagePersistence(spec ext.ContainerSpec) error {
+	if spec.Tty == nil {
+		return nil
+	}
+	hasCreate := false
+	for _, s := range spec.Tty.OnInit {
+		if s.RunOn == ext.RunOnCreate {
+			hasCreate = true
+			break
+		}
+	}
+	if !hasCreate {
+		return nil
+	}
+	for _, v := range spec.Volumes {
+		if v.Kind == ext.VolumeKindTmpfs {
+			continue
+		}
+		if v.ReadOnly {
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf(
+		"container %q: tty.onInit has runOn: %q stages but the container has no persistent writable mount; "+
+			"declare a volumes: entry of kind bind covering the stage's write target so its side effects "+
+			"survive container recreate, or move the work into a runOn: %q stage",
+		spec.ID, ext.RunOnCreate, ext.RunOnStart,
+	)
 }
 
 // validateTtyLogLevel accepts the empty string (the daemon defaults to

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -1266,6 +1266,11 @@ func TestContainerTtyRoundTripV1Beta1(t *testing.T) {
 			RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
 			Image:      "alpine:latest",
 			Attachable: true,
+			// Bind mount satisfies the persistence guard for the
+			// runOn: create stage below (issue #738).
+			Volumes: []ext.VolumeMount{
+				{Kind: ext.VolumeKindBind, Source: "/srv/cache", Target: "/cache"},
+			},
 			Tty: &ext.ContainerTty{
 				Prompt: `"\[\e[1;36m\]claude \u@\h\[\e[0m\]:\w\$ "`,
 				OnInit: []ext.TtyStage{
@@ -1514,17 +1519,26 @@ func TestContainerTtyStageRunOnEnumValidation(t *testing.T) {
 	accepted := []string{"", ext.RunOnStart, ext.RunOnCreate}
 	for _, runOn := range accepted {
 		t.Run("accepted/"+runOn, func(t *testing.T) {
+			spec := ext.ContainerSpec{
+				ID:      "c",
+				RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+				Image:      "alpine:latest",
+				Attachable: true,
+				Tty:        &ext.ContainerTty{OnInit: []ext.TtyStage{{Script: "echo hi", RunOn: runOn}}},
+			}
+			// runOn: create requires a persistent writable mount per the
+			// phase-C3 validation guard (issue #738); add one so this
+			// subtest exercises only the enum check.
+			if runOn == ext.RunOnCreate {
+				spec.Volumes = []ext.VolumeMount{
+					{Kind: ext.VolumeKindBind, Source: "/srv/cache", Target: "/cache"},
+				}
+			}
 			input := ext.ContainerDoc{
 				APIVersion: ext.APIVersionV1Beta1,
 				Kind:       ext.KindContainer,
 				Metadata:   ext.ContainerMetadata{Name: "c"},
-				Spec: ext.ContainerSpec{
-					ID:      "c",
-					RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
-					Image:      "alpine:latest",
-					Attachable: true,
-					Tty:        &ext.ContainerTty{OnInit: []ext.TtyStage{{Script: "echo hi", RunOn: runOn}}},
-				},
+				Spec:       spec,
 			}
 			if _, _, err := apischeme.NormalizeContainer(input); err != nil {
 				t.Fatalf("NormalizeContainer rejected runOn %q: %v", runOn, err)
@@ -2288,4 +2302,173 @@ func TestNormalizeSecret_UnsupportedVersion(t *testing.T) {
 	if !strings.Contains(err.Error(), "unsupported apiVersion for Secret") {
 		t.Errorf("unexpected error: %v", err)
 	}
+}
+
+// TestContainerCreateStagePersistenceValidation covers the AC for #738
+// (phase C3): a container declaring runOn: create stages must carry at least
+// one persistent writable mount, otherwise the side effects evaporate on the
+// next recreate while the run-once gate continues to report State == "done".
+//
+// The matrix mirrors the AC checkboxes: all-tmpfs, readonly-rootfs without a
+// persistent mount, readonly-rootfs *with* a persistent mount, a mixed-mount
+// container (tmpfs + bind), and a persistent-only container.
+func TestContainerCreateStagePersistenceValidation(t *testing.T) {
+	createStage := []ext.TtyStage{{Script: "npm ci", RunOn: ext.RunOnCreate}}
+
+	cases := []struct {
+		name       string
+		volumes    []ext.VolumeMount
+		readOnly   bool
+		wantReject bool
+	}{
+		{
+			// AC: runOn: create on an all-tmpfs container is rejected.
+			name: "all-tmpfs/rejected",
+			volumes: []ext.VolumeMount{
+				{Kind: ext.VolumeKindTmpfs, Target: "/scratch"},
+				{Kind: ext.VolumeKindTmpfs, Target: "/cache"},
+			},
+			wantReject: true,
+		},
+		{
+			// AC: runOn: create on a readonly-rootfs container with no
+			// persistent volume mount is rejected.
+			name:       "readonly-rootfs-no-volumes/rejected",
+			volumes:    nil,
+			readOnly:   true,
+			wantReject: true,
+		},
+		{
+			// Sibling of the all-tmpfs case: a writable rootfs with no
+			// volume declarations is also ephemeral under kukeon's recreate
+			// model and must be rejected.
+			name:       "no-volumes-writable-rootfs/rejected",
+			volumes:    nil,
+			wantReject: true,
+		},
+		{
+			// AC complement: readonly-rootfs paired with a persistent bind
+			// is accepted — the bind covers the stage's write target.
+			name: "readonly-rootfs-with-bind/accepted",
+			volumes: []ext.VolumeMount{
+				{Kind: ext.VolumeKindBind, Source: "/srv/cache", Target: "/cache"},
+			},
+			readOnly: true,
+		},
+		{
+			// AC: at least one persistent writable mount (bind here) is
+			// accepted unchanged, even alongside tmpfs siblings.
+			name: "mixed-mounts/accepted",
+			volumes: []ext.VolumeMount{
+				{Kind: ext.VolumeKindTmpfs, Target: "/scratch"},
+				{Kind: ext.VolumeKindBind, Source: "/srv/data", Target: "/data"},
+			},
+		},
+		{
+			// AC: persistent-only is accepted unchanged.
+			name: "persistent-only/accepted",
+			volumes: []ext.VolumeMount{
+				{Kind: ext.VolumeKindBind, Source: "/srv/data", Target: "/data"},
+			},
+		},
+		{
+			// Empty Kind back-compat (defaults to bind) is treated as
+			// persistent, mirroring VolumeMount's documented default.
+			name: "empty-kind-default-bind/accepted",
+			volumes: []ext.VolumeMount{
+				{Source: "/srv/data", Target: "/data"},
+			},
+		},
+		{
+			// A bind volume marked ReadOnly is not a writable persistent
+			// target — the stage would fail at runtime instead of just
+			// silently evaporating, but the validation guards against it
+			// the same way.
+			name: "readonly-bind-only/rejected",
+			volumes: []ext.VolumeMount{
+				{Kind: ext.VolumeKindBind, Source: "/srv/cache", Target: "/cache", ReadOnly: true},
+			},
+			wantReject: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := ext.ContainerDoc{
+				APIVersion: ext.APIVersionV1Beta1,
+				Kind:       ext.KindContainer,
+				Metadata:   ext.ContainerMetadata{Name: "c"},
+				Spec: ext.ContainerSpec{
+					ID:      "c",
+					RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+					Image:                  "alpine:latest",
+					Attachable:             true,
+					ReadOnlyRootFilesystem: tc.readOnly,
+					Volumes:                tc.volumes,
+					Tty:                    &ext.ContainerTty{OnInit: createStage},
+				},
+			}
+			_, _, err := apischeme.NormalizeContainer(input)
+			if tc.wantReject {
+				if err == nil {
+					t.Fatalf("NormalizeContainer accepted %s; want validation error", tc.name)
+				}
+				if !strings.Contains(err.Error(), "persistent writable mount") {
+					t.Errorf("error %q does not mention persistent writable mount", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeContainer rejected %s: %v", tc.name, err)
+			}
+		})
+	}
+
+	t.Run("no-create-stage/start-only-accepted-on-ephemeral", func(t *testing.T) {
+		// A container with only runOn: start (or empty) stages is
+		// unaffected by the persistence guard, even with no mounts at all.
+		input := ext.ContainerDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindContainer,
+			Metadata:   ext.ContainerMetadata{Name: "c"},
+			Spec: ext.ContainerSpec{
+				ID:      "c",
+				RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+				Image:      "alpine:latest",
+				Attachable: true,
+				Tty: &ext.ContainerTty{OnInit: []ext.TtyStage{
+					{Script: "echo boot"},
+					{Script: "echo boot2", RunOn: ext.RunOnStart},
+				}},
+			},
+		}
+		if _, _, err := apischeme.NormalizeContainer(input); err != nil {
+			t.Fatalf("NormalizeContainer rejected ephemeral container with no create stage: %v", err)
+		}
+	})
+
+	t.Run("cell-doc-path/rejected", func(t *testing.T) {
+		// The same guard fires for ContainerSpecs embedded in a CellDoc.
+		cell := ext.CellDoc{
+			APIVersion: ext.APIVersionV1Beta1,
+			Kind:       ext.KindCell,
+			Metadata:   ext.CellMetadata{Name: "cl"},
+			Spec: ext.CellSpec{
+				ID:      "cl",
+				RealmID: "r", SpaceID: "s", StackID: "st",
+				Containers: []ext.ContainerSpec{
+					{
+						ID:      "c",
+						RealmID: "r", SpaceID: "s", StackID: "st", CellID: "cl",
+						Image:      "alpine:latest",
+						Attachable: true,
+						Tty:        &ext.ContainerTty{OnInit: createStage},
+					},
+				},
+			},
+		}
+		if _, _, err := apischeme.NormalizeCell(cell); err == nil {
+			t.Fatal("NormalizeCell accepted ephemeral runOn: create container; want validation error")
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Phase C3 of the run-once tty-stage series (#423 umbrella). Adds an apischeme validation pass that rejects a `ContainerSpec` declaring any `runOn: create` `TtyStage` when the container has no persistent writable mount, closing the silent-skip footgun the run-once gate (phase C2, #737) would otherwise have on ephemeral targets.
- A mount counts as "persistent writable" when it is a `VolumeMount` whose `Kind` is anything other than `tmpfs` (`bind`, plus the empty back-compat default, plus any future persistent kind such as a future `pvc:`) and is not declared `ReadOnly`. `ContainerSpec.Tmpfs` entries are explicitly ephemeral and never count. `ReadOnlyRootFilesystem` alone is not what gates the decision — only the absence of a persistent writable `VolumeMount`.
- Chose the **reject-by-default** gate per the issue's recommended option. The proposal's alternative `--force-create-on-ephemeral` opt-in is **not** added in this PR — no AC checkbox covers it, and shipping the opt-in adds CLI/spec surface that is best deferred until operators have a concrete ephemeral-bootstrap use case. Easy to layer on later as a separate spec-level annotation or CLI flag without changing the reject default.
- The new check is wired into the existing `validateContainerTty` after the per-stage `runOn` enum validation, so it fires on both the `ContainerDoc` and the nested-in-`CellDoc` paths without a second call-site touch. `CellBlueprintDoc` stores the spec as opaque YAML, so it is unaffected (validation happens when the materialized doc enters the normal `Normalize*` lane).

## Test plan
- [x] `make test` (project CI gate — `test-root` + `test-kukebuild`) — both green.
- [x] `make test-root` — verbose re-run to confirm every package in the apischeme dependency closure still passes after the new validation lands.
- [x] New unit-test matrix `TestContainerCreateStagePersistenceValidation` covers all four AC cases plus the cell-doc embedding path and the no-create-stage exemption: all-tmpfs (rejected), readonly-rootfs without volumes (rejected), no-volumes writable-rootfs (rejected — the writable container layer is also ephemeral under kukeon's recreate model), readonly-rootfs with a bind (accepted), mixed mounts tmpfs+bind (accepted), persistent-only (accepted), empty-`Kind` back-compat default (accepted as bind), readonly-bind-only (rejected — not writable), and start-only stages (unaffected).
- [x] Updated the existing `TestContainerTtyRoundTripV1Beta1` and `TestContainerTtyStageRunOnEnumValidation` so their `runOn: create` cases carry a bind mount — the round-trip and enum-validation tests still exercise only what they advertise, and would otherwise have been collateral failures.
- [ ] `make e2e` and the `make dev-init` smoke — not run; the change is pure declarative validation in the apischeme layer with no daemon, runtime, or build-path touch.

## Out of scope (filed as follow-ups)
- User-facing docs (`docs/site/manifests/container.md`) — the `runOn: create` reference text and YAML example will be updated to mention the persistent-writable-mount requirement. Repo convention (e.g. PRs #706, #687) keeps `docs(manifests):` updates in their own PR under the `documentation` label; filing as a docs follow-up alongside this PR.
- The optional `--force-create-on-ephemeral` opt-in mentioned in the issue's Proposal section (intentionally deferred — see PR summary).

Closes #738