### PR TITLE
feat: durable ContainerStatus.Stages persistence + content-Hash done-key (phase C1)

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -1059,7 +1059,9 @@ func repoStatusesToExternal(in []intmodel.RepoStatus) []ext.RepoStatus {
 }
 
 // stageStatusesToInternal copies external per-stage status into the internal
-// model. Schema only this phase; populated in phase B (#689). Issue #635.
+// model. Phase B (#689) populates the field; phase C1 (#690) added the Hash
+// key the controller-side merge uses to carry done records across stop/start.
+// Issue #635.
 func stageStatusesToInternal(in []ext.StageStatus) []intmodel.StageStatus {
 	if len(in) == 0 {
 		return nil
@@ -1070,6 +1072,7 @@ func stageStatusesToInternal(in []ext.StageStatus) []intmodel.StageStatus {
 			Index: s.Index,
 			State: s.State,
 			Error: s.Error,
+			Hash:  s.Hash,
 		}
 	}
 	return out
@@ -1086,6 +1089,7 @@ func stageStatusesToExternal(in []intmodel.StageStatus) []ext.StageStatus {
 			Index: s.Index,
 			State: s.State,
 			Error: s.Error,
+			Hash:  s.Hash,
 		}
 	}
 	return out

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -1586,7 +1586,7 @@ func TestContainerStatusStagesRoundTrip(t *testing.T) {
 		t.Fatalf("NormalizeContainer: %v", err)
 	}
 	internal.Status.Stages = []intmodel.StageStatus{
-		{Index: 1, State: "ran"},
+		{Index: 1, State: "ran", Hash: "abc1234567890def"},
 		{Index: 3, State: "failed", Error: "boom"},
 	}
 	out, err := apischeme.BuildContainerExternalFromInternal(internal, version)
@@ -1596,7 +1596,10 @@ func TestContainerStatusStagesRoundTrip(t *testing.T) {
 	if len(out.Status.Stages) != 2 {
 		t.Fatalf("output status stages len = %d, want 2", len(out.Status.Stages))
 	}
-	if out.Status.Stages[0] != (ext.StageStatus{Index: 1, State: "ran"}) {
+	// Hash round-trips end-to-end (phase C1, #690): the durable run-once key
+	// the controller stamps must survive the internal -> external build so
+	// `kuke get container -o yaml` renders it.
+	if out.Status.Stages[0] != (ext.StageStatus{Index: 1, State: "ran", Hash: "abc1234567890def"}) {
 		t.Errorf("status stage[0] = %+v", out.Status.Stages[0])
 	}
 	if out.Status.Stages[1] != (ext.StageStatus{Index: 3, State: "failed", Error: "boom"}) {

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -681,10 +681,29 @@ func (r *Exec) processOrphanedContainers(ctx context.Context, namespace string, 
 
 // populateCellContainerStatuses queries containerd for the status of all containers
 // in a cell and populates cell.Status.Containers array.
+//
+// Stage carry-forward (phase C1, #690): per-create-stage done records are
+// merged with the previously-persisted Stages snapshot before the overwrite,
+// so a stop -> start cycle preserves the run-once "done" set the
+// (phase C2, #737) render gate consumes — the live pull is empty while a
+// container is non-Ready and would otherwise wipe the records on every stop
+// (see mergeStageStatuses for the Index + Hash gate). The merge is anchored
+// on the live cell.Spec, so an edited create stage's prior done drops on the
+// next populate.
 func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 	if len(cell.Spec.Containers) == 0 {
 		cell.Status.Containers = []intmodel.ContainerStatus{}
 		return nil
+	}
+
+	// Snapshot prior Stages keyed by container ID so the post-pull merge can
+	// re-thread done records across a stop -> start. The unconditional
+	// cell.Status.Containers overwrite at the end of this function would
+	// otherwise drop them whenever the live pull returns nil (container not
+	// Ready, or pull failed) and strand phase C2's render gate.
+	priorStages := make(map[string][]intmodel.StageStatus, len(cell.Status.Containers))
+	for _, prev := range cell.Status.Containers {
+		priorStages[prev.ID] = prev.Stages
 	}
 
 	statuses := make([]intmodel.ContainerStatus, 0, len(cell.Spec.Containers))
@@ -718,7 +737,12 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 		// Best-effort: only Attachable containers that declared repos[] or
 		// create stages and are Ready can serve the verb, and any failure leaves
 		// Repos/Stages empty rather than blocking the status read.
-		status.Repos, status.Stages = r.setupStatuses(cell, containerSpec, state)
+		var liveStages []intmodel.StageStatus
+		status.Repos, liveStages = r.setupStatuses(cell, containerSpec, state)
+		// Merge live + prior stages against the current spec so done
+		// records survive stop/start and edited stages drop their prior
+		// done. See mergeStageStatuses for the Index + Hash contract.
+		status.Stages = mergeStageStatuses(containerSpec, priorStages[containerSpec.ID], liveStages)
 		statuses = append(statuses, status)
 	}
 

--- a/internal/controller/runner/setup_status_client.go
+++ b/internal/controller/runner/setup_status_client.go
@@ -102,6 +102,12 @@ func repoStatusToInternal(repos []setupstatus.Repo) []intmodel.RepoStatus {
 // StageStatus type the controller persists in ContainerStatus.Stages. Returns
 // nil for an empty input so a container with no create stages reports a nil
 // Stages (mirrors the omitempty wire/YAML shape) rather than an empty slice.
+//
+// Hash is intentionally not copied from the wire shape here — kuketty does
+// not stamp it today (the wire payload always carries an empty Hash; see
+// setupstatus.Stage). The daemon-side merge stamps Hash from the live
+// container spec at the matching Index, so populating it here would only
+// shadow the merge's authoritative computation. Phase C1 (#690).
 func stageStatusToInternal(stages []setupstatus.Stage) []intmodel.StageStatus {
 	if len(stages) == 0 {
 		return nil

--- a/internal/controller/runner/stage_status.go
+++ b/internal/controller/runner/stage_status.go
@@ -1,0 +1,136 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// stageHashLen is the prefix of the SHA-256 hex digest kept as the stage's
+// content Hash. 16 hex chars (64 bits of entropy) keeps the persisted
+// ContainerStatus.Stages compact in `kuke get -o yaml` while leaving
+// collision probability well below the population of create stages any cell
+// will ever carry. Same byte-budget rationale as the metadata-dir basename
+// in internal/util/fs/metadata.go.
+const stageHashLen = 16
+
+// stageContentHash returns the run-once "done" key for a TtyStage. The key
+// is a SHA-256 over the stage's Script and RunOn (delimited so a stage with
+// the script "a\x00b" can never collide with two scripts "a" / "b"), truncated
+// to stageHashLen hex characters. Same hash for the same content, anchored on
+// the (Index, Hash) tuple by the merge below.
+//
+// The hash spans Script + RunOn rather than Script alone so a stage that flips
+// from runOn: start to runOn: create (a real edit to the create-stage set) is
+// treated as a content change, dropping any prior done record at the same
+// Index instead of silently carrying it forward.
+func stageContentHash(stage v1beta1.TtyStage) string {
+	h := sha256.New()
+	// NUL-delimited fields so concatenated payloads can never alias —
+	// {"a", "b"} and {"a\x00b", ""} hash to distinct digests.
+	_, _ = h.Write([]byte(stage.Script))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(stage.RunOn))
+	sum := h.Sum(nil)
+	return hex.EncodeToString(sum)[:stageHashLen]
+}
+
+// mergeStageStatuses returns the durable per-create-stage status for the
+// container, computed from the current spec, the prior persisted Stages
+// snapshot (carried from the previous populate, possibly across a stop/start
+// cycle), and the live pull from kuketty (when available).
+//
+// For each runOn: create stage in spec.Tty.OnInit (anchored on its position
+// in the full OnInit slice — the Index identity cmd/kuketty's createStages
+// emits — and stamped with the current spec's content Hash), the merge picks:
+//
+//   - the live entry at the matching Index, when present: the just-completed
+//     run is authoritative and its Hash is restamped from the current spec
+//     so a wire payload that omits Hash (kuketty does not stamp it today)
+//     still surfaces the daemon-computed key for the next populate's merge.
+//   - otherwise, the prior persisted entry at the same Index — but only when
+//     its Hash still matches the current spec's stage Hash and its State is
+//     "done": this is the run-once carry-forward across stop/start. A failed
+//     prior entry does not carry (the next boot gets a fresh chance), and a
+//     prior entry whose Hash no longer matches the current stage is dropped
+//     so an edited create stage re-runs on the next boot.
+//   - otherwise, nothing — the stage has not run yet for the current content.
+//
+// Returns nil rather than an empty slice so a container with no create stages
+// (or one whose every prior done was invalidated by edits) round-trips through
+// the omitempty wire/YAML shape unchanged. Phase C1 (#690).
+func mergeStageStatuses(
+	spec intmodel.ContainerSpec,
+	prior []intmodel.StageStatus,
+	live []intmodel.StageStatus,
+) []intmodel.StageStatus {
+	if spec.Tty == nil {
+		return nil
+	}
+	liveByIndex := make(map[int]intmodel.StageStatus, len(live))
+	for _, s := range live {
+		liveByIndex[s.Index] = s
+	}
+	priorByIndex := make(map[int]intmodel.StageStatus, len(prior))
+	for _, s := range prior {
+		priorByIndex[s.Index] = s
+	}
+
+	var out []intmodel.StageStatus
+	for i, stage := range spec.Tty.OnInit {
+		if stage.RunOn != v1beta1.RunOnCreate {
+			continue
+		}
+		hash := stageContentHash(toV1beta1Stage(stage))
+		// Live wins; restamp Hash from the current spec (kuketty does not
+		// stamp it on the wire today; see setupstatus.Stage doc).
+		if liveStat, ok := liveByIndex[i]; ok {
+			liveStat.Hash = hash
+			out = append(out, liveStat)
+			continue
+		}
+		// Prior done entry carries forward only when its Hash still matches
+		// the current spec's stage Hash — an edited stage drops here.
+		if priorStat, ok := priorByIndex[i]; ok &&
+			priorStat.Hash == hash &&
+			priorStat.State == setupstatus.StageDone {
+			out = append(out, priorStat)
+			continue
+		}
+		// Otherwise: pending on the next boot — leave the slot empty so the
+		// (phase C2, #737) render gate sees the missing record and the
+		// stage runs again.
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// toV1beta1Stage adapts an internal modelhub.TtyStage to the v1beta1 shape
+// the hash helper consumes. The two structs are byte-equivalent — both carry
+// Script + RunOn — and the hash function lives against v1beta1 so cmd/kuketty
+// (which only imports v1beta1) could share it in a later phase without
+// reaching into the internal model.
+func toV1beta1Stage(in intmodel.TtyStage) v1beta1.TtyStage {
+	return v1beta1.TtyStage{Script: in.Script, RunOn: in.RunOn}
+}

--- a/internal/controller/runner/stage_status_test.go
+++ b/internal/controller/runner/stage_status_test.go
@@ -1,0 +1,255 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises the unexported merge/hash helpers
+package runner
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestStageContentHash_Deterministic locks the run-once "done" key: the same
+// stage content always hashes to the same digest, and any change to Script or
+// RunOn flips it. The merge gate downstream uses this — a stable digest is
+// what makes prior done records survive stop/start; a changing digest is what
+// drops them on edit. Phase C1 (#690).
+func TestStageContentHash_Deterministic(t *testing.T) {
+	stage := v1beta1.TtyStage{Script: "echo hi", RunOn: v1beta1.RunOnCreate}
+	first := stageContentHash(stage)
+	second := stageContentHash(stage)
+	if first != second {
+		t.Errorf("stageContentHash not deterministic: %q vs %q", first, second)
+	}
+	if len(first) != stageHashLen {
+		t.Errorf("stageContentHash len = %d, want %d", len(first), stageHashLen)
+	}
+}
+
+// TestStageContentHash_DetectsEdits is the load-bearing edit-detection
+// guarantee the AC restates: an edited stage's hash must differ so the
+// merge drops the prior done. Covers both Script edits and RunOn flips
+// (a stage that turns from runOn: start to runOn: create is a real edit
+// to the create-stage set — see toV1beta1Stage / stageContentHash).
+func TestStageContentHash_DetectsEdits(t *testing.T) {
+	base := v1beta1.TtyStage{Script: "echo hi", RunOn: v1beta1.RunOnCreate}
+	editedScript := v1beta1.TtyStage{Script: "echo bye", RunOn: v1beta1.RunOnCreate}
+	editedRunOn := v1beta1.TtyStage{Script: "echo hi", RunOn: v1beta1.RunOnStart}
+
+	baseHash := stageContentHash(base)
+	if stageContentHash(editedScript) == baseHash {
+		t.Errorf("stageContentHash collided after Script edit")
+	}
+	if stageContentHash(editedRunOn) == baseHash {
+		t.Errorf("stageContentHash collided after RunOn edit")
+	}
+}
+
+// TestStageContentHash_NoFieldAliasing pins the NUL-delimited concat: a Script
+// whose tail aliases the RunOn field (or vice versa) must not collide with the
+// "natural" stage that carries the same bytes split across the two fields.
+// Without the delimiter, {"a", "b"} and {"ab", ""} would hash to the same
+// digest — a real source of merge mis-carry once kuketty grows scripts that
+// contain literal "create"/"start" suffixes.
+func TestStageContentHash_NoFieldAliasing(t *testing.T) {
+	concat := v1beta1.TtyStage{Script: "abcreate"}
+	split := v1beta1.TtyStage{Script: "ab", RunOn: "create"}
+	if stageContentHash(concat) == stageContentHash(split) {
+		t.Errorf("stageContentHash aliased on field-boundary concat: %q vs %q",
+			stageContentHash(concat), stageContentHash(split))
+	}
+}
+
+// TestMergeStageStatuses_Cases walks the merge contract documented on
+// mergeStageStatuses — the (Index, Hash)-keyed carry of done records across
+// stop/start, the live-pull supersedes path, the edited-hash drop, and the
+// reset-on-recreate (empty prior). Each case mirrors one AC item from #690.
+func TestMergeStageStatuses_Cases(t *testing.T) {
+	stage0 := intmodel.TtyStage{Script: "git clone", RunOn: v1beta1.RunOnCreate}
+	stage0Edited := intmodel.TtyStage{Script: "git clone --depth 1", RunOn: v1beta1.RunOnCreate}
+	startStage := intmodel.TtyStage{Script: "echo hello", RunOn: v1beta1.RunOnStart}
+	stage2 := intmodel.TtyStage{Script: "npm ci", RunOn: v1beta1.RunOnCreate}
+
+	hash0 := stageContentHash(toV1beta1Stage(stage0))
+	hash2 := stageContentHash(toV1beta1Stage(stage2))
+	// The post-edit hash isn't directly asserted (mergeStageStatuses recomputes
+	// from the spec internally) — what matters in the edit case is that the
+	// prior entry carries the pre-edit Hash, which no longer matches.
+	if stageContentHash(toV1beta1Stage(stage0Edited)) == hash0 {
+		t.Fatalf("stage0Edited should hash differently than stage0; got identical")
+	}
+
+	specWithTwoCreate := intmodel.ContainerSpec{
+		Tty: &intmodel.ContainerTty{
+			OnInit: []intmodel.TtyStage{stage0, startStage, stage2},
+		},
+	}
+	specWithEditedStage0 := intmodel.ContainerSpec{
+		Tty: &intmodel.ContainerTty{
+			OnInit: []intmodel.TtyStage{stage0Edited, startStage, stage2},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		spec  intmodel.ContainerSpec
+		prior []intmodel.StageStatus
+		live  []intmodel.StageStatus
+		want  []intmodel.StageStatus
+	}{
+		{
+			// AC: "Done-record (State == 'done') survives kuke stop -> kuke start".
+			// Live pull is empty (container not Ready while stopped); the prior
+			// done records carry forward verbatim because Hash still matches.
+			name: "survives stop: live empty, prior done at matching hash carries",
+			spec: specWithTwoCreate,
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone, Hash: hash0},
+				{Index: 2, State: setupstatus.StageDone, Hash: hash2},
+			},
+			live: nil,
+			want: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone, Hash: hash0},
+				{Index: 2, State: setupstatus.StageDone, Hash: hash2},
+			},
+		},
+		{
+			// AC: "Done-record resets on kuke delete -> recreate: Stages is
+			// empty on the new instance". The recreate path arrives here with
+			// no prior status (fresh ContainerStatus). Live empty too (not
+			// Ready yet) yields nil — phase C2's render gate then runs every
+			// stage.
+			name:  "reset on recreate: no prior, no live yields nil",
+			spec:  specWithTwoCreate,
+			prior: nil,
+			live:  nil,
+			want:  nil,
+		},
+		{
+			// AC: "Edited create stage (new content hash) drops the prior
+			// done-record on the next populate." Index 0's content changed
+			// (script edit -> new Hash); the prior done at Index 0 no longer
+			// matches and drops, while the untouched Index 2 carries forward.
+			name: "edited stage drops prior done; sibling carries",
+			spec: specWithEditedStage0,
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone, Hash: hash0}, // stale
+				{Index: 2, State: setupstatus.StageDone, Hash: hash2},
+			},
+			live: nil,
+			want: []intmodel.StageStatus{
+				// Index 0 absent — it will run again on the next boot.
+				{Index: 2, State: setupstatus.StageDone, Hash: hash2},
+			},
+		},
+		{
+			// Live wins, and Hash is restamped from the current spec because
+			// kuketty does not stamp it on the wire today. A live entry with
+			// no Hash must still surface the daemon-computed key for the
+			// next populate's merge.
+			name: "live wins and Hash is restamped from spec",
+			spec: specWithTwoCreate,
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone, Hash: hash0},
+			},
+			live: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone}, // wire payload has no Hash
+				{Index: 2, State: setupstatus.StageFailed, Error: "boom"},
+			},
+			want: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone, Hash: hash0},
+				{Index: 2, State: setupstatus.StageFailed, Error: "boom", Hash: hash2},
+			},
+		},
+		{
+			// Failed prior records do not carry — only done. Phase C2's gate
+			// must give a failed stage a fresh chance on restart, not gate it
+			// out forever on the failed marker.
+			name: "prior failed does not carry across stop",
+			spec: specWithTwoCreate,
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageFailed, Error: "boom", Hash: hash0},
+				{Index: 2, State: setupstatus.StageDone, Hash: hash2},
+			},
+			live: nil,
+			want: []intmodel.StageStatus{
+				// Index 0 dropped: failed never carries.
+				{Index: 2, State: setupstatus.StageDone, Hash: hash2},
+			},
+		},
+		{
+			// Container declares no Tty (no create stages) -> nil, regardless
+			// of prior junk. The merge is anchored on spec.Tty.OnInit; an
+			// absent Tty block means no create stages exist in the live spec.
+			name: "nil tty yields nil",
+			spec: intmodel.ContainerSpec{Tty: nil},
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone, Hash: hash0},
+			},
+			live: nil,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeStageStatuses(tt.spec, tt.prior, tt.live)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(got) = %d, want %d (got=%+v want=%+v)",
+					len(got), len(tt.want), got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("stage[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestMergeStageStatuses_AnchorsOnIndexInFullOnInit guards against a regression
+// where the merge would re-index create-stages contiguously (0, 1, ...) instead
+// of using their position in the full OnInit slice. The setupstatus wire
+// protocol and cmd/kuketty's createStages both emit Index relative to
+// Tty.OnInit, so a contiguous re-index would silently mis-align prior records
+// against live entries.
+func TestMergeStageStatuses_AnchorsOnIndexInFullOnInit(t *testing.T) {
+	startStage := intmodel.TtyStage{Script: "echo s", RunOn: v1beta1.RunOnStart}
+	createStage := intmodel.TtyStage{Script: "npm ci", RunOn: v1beta1.RunOnCreate}
+
+	// Create stage sits at OnInit index 1, not 0 — the start stage at 0 must
+	// not consume the create-slot.
+	spec := intmodel.ContainerSpec{
+		Tty: &intmodel.ContainerTty{OnInit: []intmodel.TtyStage{startStage, createStage}},
+	}
+	hash1 := stageContentHash(toV1beta1Stage(createStage))
+
+	prior := []intmodel.StageStatus{
+		{Index: 1, State: setupstatus.StageDone, Hash: hash1},
+	}
+	got := mergeStageStatuses(spec, prior, nil)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1 (got=%+v)", len(got), got)
+	}
+	if got[0].Index != 1 || got[0].Hash != hash1 || got[0].State != setupstatus.StageDone {
+		t.Errorf("stage[0] = %+v, want Index=1 Hash=%q State=done", got[0], hash1)
+	}
+}

--- a/internal/kuketty/setupstatus/setupstatus.go
+++ b/internal/kuketty/setupstatus/setupstatus.go
@@ -93,13 +93,23 @@ const (
 // ContainerStatus.Stages. Index is the stage's 0-based position within the
 // container's full Tty.OnInit list (not its position among create stages
 // alone), in declaration order — the stable identity phase A (#635) carries
-// through (the run-once "done" key is settled in phase C, #690).
+// through. The run-once "done" key is the content Hash (phase C1, #690).
 type Stage struct {
 	Index int `json:"index"`
 	// State is one of StageDone or StageFailed.
 	State string `json:"state"`
 	// Error is the failure detail when State == StageFailed; empty otherwise.
 	Error string `json:"error,omitempty"`
+	// Hash is the content hash of the stage's TtyStage (Script + RunOn),
+	// computed by the daemon at record time and used by the controller-side
+	// merge to carry done records across stop/start (an entry preserves only
+	// when its Hash still matches the live spec's stage Hash at the same
+	// Index). Always empty on the wire today: kuketty does not stamp it; the
+	// daemon re-derives the Hash from cell.Spec when mapping wire→internal
+	// (see internal/controller/runner mergeStageStatuses). The field exists on
+	// the wire shape so a future kuketty-side change could populate it without
+	// a wire break — no producer change ships in this phase. Phase C1 (#690).
+	Hash string `json:"hash,omitempty"`
 }
 
 // Stage state values. Mirror the create-stage outcome set v1beta1.StageStatus

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -291,11 +291,16 @@ type RepoStatus struct {
 	Error  string
 }
 
-// StageStatus mirrors the v1beta1 StageStatus payload. Issue #635.
+// StageStatus mirrors the v1beta1 StageStatus payload. Phase C1 (#690) adds
+// the Hash key the controller-side merge uses to carry done records across
+// stop/start. Issue #635.
 type StageStatus struct {
 	Index int
 	State string
 	Error string
+	// Hash is the content hash of the stage at record time — the run-once
+	// "done" key. See the v1beta1 type for the merge contract.
+	Hash string
 }
 
 type ContainerState int

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -439,20 +439,27 @@ type RepoStatus struct {
 }
 
 // StageStatus is the resolved state of a single runOn: create TtyStage after
-// kuketty's pre-Serve execution. Populated in phase B (#689); this phase
-// (#635) lands the schema only. The stage-identity / run-once "done" key (e.g.
-// a content hash) is settled in phase C (#690), where the render gate that
-// consumes it lands — until then Index (declaration order among create stages)
-// is the only identity carried. Issue #635.
+// kuketty's pre-Serve execution. Populated in phase B (#689). Phase C1 (#690)
+// adds the durable Hash key + merge that carries done records across
+// stop/start; phase C2 (#737) lands the render-time gate that consumes them.
+// Issue #635.
 type StageStatus struct {
-	// Index is the 0-based position of the stage among the container's create
-	// stages, in declaration order.
+	// Index is the 0-based position of the stage within the container's full
+	// Tty.OnInit list (not its position among create stages alone), in
+	// declaration order.
 	Index int `json:"index"           yaml:"index"`
-	// State is the resolved outcome (e.g. "ran" or "failed"); the exact value
-	// set is defined by the phase-B populator (#689).
+	// State is the resolved outcome ("done" or "failed"); the daemon-side
+	// populator (phase B, #689) sets it from the wire payload.
 	State string `json:"state"           yaml:"state"`
 	// Error is the failure detail when State reports a failure.
 	Error string `json:"error,omitempty" yaml:"error,omitempty"`
+	// Hash is the content hash of the stage at record time — the run-once
+	// "done" key. The daemon stamps it from the live spec and the controller
+	// preserves a done entry across stop/start only when its Hash still
+	// matches the current spec's stage Hash at the same Index, so an edited
+	// stage (new content) drops its prior done record on the next populate.
+	// Phase C1 (#690).
+	Hash string `json:"hash,omitempty"  yaml:"hash,omitempty"`
 }
 
 type ContainerState int


### PR DESCRIPTION
## Summary

- **Schema:** add `Hash string` to `StageStatus` in v1beta1, modelhub, and the `setupstatus.Stage` wire payload, plus the scheme conversion both directions. Hash is the run-once "done" key the phase C2 (#737) render gate will consume.
- **Producer:** unchanged — kuketty does not stamp Hash on the wire. The daemon-side merge stamps it from the live container spec at the matching `Index` when recording a live entry. The wire field exists for forward-compat (a future kuketty could populate it without a wire break).
- **Merge / carry-forward:** `populateCellContainerStatuses` now snapshots prior `Stages` per container ID before its unconditional overwrite, then merges per spec-defined create stage: live wins (with Hash restamped from the spec), otherwise a prior `done` entry whose Hash still matches the current spec carries forward, otherwise the slot is empty.
- **Hash function:** SHA-256 over `Script + "\x00" + RunOn`, truncated to 16 hex chars (same byte budget as `internal/util/fs/metadata.go`). NUL-delimited so a script edit, a runOn flip, or a field-boundary alias all flip the digest.

## Design notes for the reviewer

- **Merge anchors on `spec.Tty.OnInit` index, not stage ordinal.** The wire `Stage.Index` is the position in the full OnInit slice (per `setupstatus.go` doc), matching `cmd/kuketty/spec.go:createStages`. The merge mirrors that — a regression test pins it (`TestMergeStageStatuses_AnchorsOnIndexInFullOnInit`).
- **Failed prior entries do not carry across stop.** AC #2 only mandates that `State == "done"` survives stop→start; carrying a failed marker would defeat phase C2's "give the stage a fresh chance on restart" semantics. Documented inline.
- **Hash is restamped on live entries.** The wire payload always carries an empty Hash today, but the daemon-side merge stamps it from the current spec so the next populate's gate has authoritative data.
- **Reset on `kuke delete` → recreate falls out for free.** The recreate path arrives at populate with a freshly-zero `cell.Status.Containers`, so the prior-snapshot map is empty and nothing carries — no special-case code required.
- **Hash field in `setupstatus.Stage` is wire-compatible.** `json:"hash,omitempty"` means today's kuketty (which omits it) keeps emitting the same wire bytes; phase C2 and future kuketty changes can populate it without a wire break.

## Acceptance criteria

- [x] `StageStatus.Hash` added in both `v1beta1` and `modelhub` packages, with scheme conversion (`stageStatusesToInternal` / `stageStatusesToExternal`) and the `setupstatus.Stage` wire payload carrying the field; daemon stamps it at record time in `mergeStageStatuses`.
- [x] Done-record (`State == "done"`) survives `kuke stop` → `kuke start`: unit-covered by `TestMergeStageStatuses_Cases/survives_stop` — live empty + prior done at matching Hash carries verbatim.
- [x] Done-record resets on `kuke delete` → recreate: unit-covered by `TestMergeStageStatuses_Cases/reset_on_recreate` — no prior, no live yields nil (and recreate hands populate a zero `cell.Status.Containers`, so prior is empty).
- [x] Edited `create` stage (new content hash) drops the prior done-record on the next populate: unit-covered by `TestMergeStageStatuses_Cases/edited_stage_drops_prior_done`.
- [x] Unit tests: hash determinism, edit-detection, field-aliasing, the merge cases above, full-OnInit-Index anchoring.

## Test plan

- [x] `make test` — full repo unit suite, green.
- [x] `GOWORK=off go vet ./...` — clean.
- [x] `make dev-init` — smoke test rebuild + re-init + daemon-parity check (both `kuke get realms` views identical, two realms Ready) + nested `kuke attach` smoke. Daemon reads the merged `cell.Status.Containers`, so this is the load-bearing schema check CLAUDE.md flags.
- [x] `pre-commit run --files <changed>` — all hooks pass except the pre-existing `golangci-lint` panic (go1.24 binary cannot analyze the go1.25 kukebuild module via go.work; environmental, not a real finding — same status as on `main`).

Closes #690