### PR TITLE
feat: add kuke run -c + identity state machine (phase 4.3)

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -461,6 +461,8 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_BLUEPRINT = DefineKV("KUKE_RUN_BLUEPRINT", "kuke/run/blueprint")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RUN_CONFIG = DefineKV("KUKE_RUN_CONFIG", "kuke/run/config")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_RM = DefineKV("KUKE_RUN_RM", "kuke/run/rm")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_NAME = DefineKV("KUKE_RUN_NAME", "kuke/run/name")

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -36,6 +36,7 @@ import (
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/apply/parser"
 	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/cellprofile"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -54,14 +55,21 @@ type MockControllerKey struct{}
 // `-d/--detach` opts out of the post-start attach.
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run (-f <file> | -p <profile> | -b <blueprint>)",
-		Short: "Create and start a single cell from a YAML file, a profile, or a daemon-stored blueprint",
+		Use:   "run (-f <file> | -p <profile> | -b <blueprint> | -c <config>)",
+		Short: "Create and start a single cell from a YAML file, a profile, a daemon-stored blueprint, or a daemon-stored config",
 		Long: "Create and start a single cell from a YAML file or stdin (-f), " +
 			"from a per-user profile under $HOME/.kuke/profiles.d/<name>.yaml (-p), " +
-			"or from a daemon-stored CellBlueprint (-b), resolved from the scope named by " +
-			"--realm/--space/--stack. -b substitutes scalar --param values and materializes " +
-			"a fresh <prefix>-<6hex> cell every invocation; structural slot fill (repo URLs, " +
-			"secret sources) requires a CellConfig and `kuke run -c` (#625). " +
+			"from a daemon-stored CellBlueprint (-b), or from a daemon-stored " +
+			"CellConfig (-c), resolved from the scope named by --realm/--space/--stack. " +
+			"-b substitutes scalar --param values and materializes a fresh " +
+			"<prefix>-<6hex> cell every invocation (always fresh). -c walks the " +
+			"identity state machine of a daemon-stored CellConfig: at most one live " +
+			"cell per Config, with a deterministic name (the Config's metadata.name), " +
+			"materialising from the referenced Blueprint with the Config's scalar " +
+			"values plus repo / secret slot fills the first time and attaching to the " +
+			"existing cell on subsequent runs (idempotent). When the live cell's spec " +
+			"differs from the materialisation of the current Config + Blueprint, -c " +
+			"warns to stderr and attaches to the live state rather than reconciling. " +
 			"-f is create-or-attach by metadata.name: a missing cell is created and " +
 			"attached; a Ready cell is attached as a no-op; a Stopped cell is started " +
 			"then attached; a divergent on-disk spec is refused (use `kuke apply -f` to " +
@@ -78,34 +86,45 @@ func NewRunCmd() *cobra.Command {
 	_ = viper.BindPFlag(config.KUKE_RUN_FILE.ViperKey, cmd.Flags().Lookup("file"))
 
 	cmd.Flags().StringP("profile", "p", "",
-		"Cell profile name to load from $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR); mutually exclusive with -f/-b. "+
+		"Cell profile name to load from $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR); mutually exclusive with -f/-b/-c. "+
 			"Deprecated: apply a kind: CellBlueprint and use -b/-c instead.")
 	_ = viper.BindPFlag(config.KUKE_RUN_PROFILE.ViperKey, cmd.Flags().Lookup("profile"))
 
 	cmd.Flags().StringP("blueprint", "b", "",
 		"Daemon-stored CellBlueprint name to run, resolved from the scope named by "+
-			"--realm/--space/--stack; mutually exclusive with -f/-p. Substitutes scalar --param "+
+			"--realm/--space/--stack; mutually exclusive with -f/-p/-c. Substitutes scalar --param "+
 			"values and materializes a fresh <prefix>-<6hex> cell.")
 	_ = viper.BindPFlag(config.KUKE_RUN_BLUEPRINT.ViperKey, cmd.Flags().Lookup("blueprint"))
 
+	cmd.Flags().StringP("config", "c", "",
+		"Daemon-stored CellConfig name to run, resolved from the scope named by "+
+			"--realm/--space/--stack; mutually exclusive with -f/-p/-b. The Config "+
+			"carries its own scalar values and structural slot fills (repos, secrets), "+
+			"so --param/--param-file/--name are rejected with -c. Idempotent: walks "+
+			"the identity state machine and attaches to the at-most-one live cell the "+
+			"Config owns by stable name.")
+	_ = viper.BindPFlag(config.KUKE_RUN_CONFIG.ViperKey, cmd.Flags().Lookup("config"))
+
 	cmd.Flags().String("name", "",
 		"Override the materialized cell name (default: <metadata.name>-<6hex>). "+
-			"Valid with -p/-b; rejected with -f, where metadata.name is the cell name verbatim.")
+			"Valid with -p/-b; rejected with -f, where metadata.name is the cell name "+
+			"verbatim, and with -c, whose name is the Config's deterministic stable name.")
 	_ = viper.BindPFlag(config.KUKE_RUN_NAME.ViperKey, cmd.Flags().Lookup("name"))
 
 	cmd.Flags().StringArray("param", nil,
 		"Scalar parameter override as KEY=VALUE; repeatable. Valid with -p/-b. "+
 			"Each KEY must be declared in spec.parameters[]. Wins over the parameter's "+
-			"default and over --param-file when both set the same key.")
+			"default and over --param-file when both set the same key. Rejected with -c: "+
+			"a CellConfig carries its own spec.values, edit the Config instead.")
 
 	cmd.Flags().String("param-file", "",
 		"File of KEY=VALUE lines whose values seed scalar parameters; one per line, "+
 			"`#` starts a comment. Same declaration rules as --param. CLI --param wins on "+
-			"duplicate keys.")
+			"duplicate keys. Rejected with -c (same reason as --param).")
 	_ = viper.BindPFlag(config.KUKE_RUN_PARAM_FILE.ViperKey, cmd.Flags().Lookup("param-file"))
 
-	cmd.MarkFlagsMutuallyExclusive("file", "profile", "blueprint")
-	cmd.MarkFlagsOneRequired("file", "profile", "blueprint")
+	cmd.MarkFlagsMutuallyExclusive("file", "profile", "blueprint", "config")
+	cmd.MarkFlagsOneRequired("file", "profile", "blueprint", "config")
 
 	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
 	_ = viper.BindPFlag(config.KUKE_RUN_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
@@ -143,6 +162,8 @@ func NewRunCmd() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
 	_ = cmd.RegisterFlagCompletionFunc("profile", config.CompleteProfileNames)
+	_ = cmd.RegisterFlagCompletionFunc("blueprint", config.CompleteBlueprintNames)
+	_ = cmd.RegisterFlagCompletionFunc("config", config.CompleteConfigNames)
 
 	return cmd
 }
@@ -154,6 +175,7 @@ type runFlags struct {
 	file          string
 	profileName   string
 	blueprintName string
+	configName    string
 	output        string
 	detach        bool
 	containerFlag string
@@ -168,6 +190,7 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		file:          strings.TrimSpace(viper.GetString(config.KUKE_RUN_FILE.ViperKey)),
 		profileName:   strings.TrimSpace(viper.GetString(config.KUKE_RUN_PROFILE.ViperKey)),
 		blueprintName: strings.TrimSpace(viper.GetString(config.KUKE_RUN_BLUEPRINT.ViperKey)),
+		configName:    strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONFIG.ViperKey)),
 		detach:        viper.GetBool(config.KUKE_RUN_DETACH.ViperKey),
 		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
 		autoDelete:    viper.GetBool(config.KUKE_RUN_RM.ViperKey),
@@ -215,6 +238,25 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 			return runFlags{}, errors.New("--param-file is only valid with -p/--profile or -b/--blueprint")
 		}
 	}
+	if flags.configName != "" {
+		// A CellConfig carries its own scalar values and a deterministic
+		// stable name (cellconfig.StableName). The template knobs would
+		// either silently shadow the Config's values or break the
+		// idempotent-identity contract that the -c verb exists to provide,
+		// so reject them rather than silently apply.
+		if flags.nameOverride != "" {
+			return runFlags{}, errors.New(
+				"--name is not valid with -c/--config; the cell name is the Config's stable name")
+		}
+		if len(flags.paramArgs) > 0 {
+			return runFlags{}, errors.New(
+				"--param is not valid with -c/--config; edit the Config's spec.values instead")
+		}
+		if flags.paramFile != "" {
+			return runFlags{}, errors.New(
+				"--param-file is not valid with -c/--config; edit the Config's spec.values instead")
+		}
+	}
 	return flags, nil
 }
 
@@ -256,14 +298,30 @@ func runRun(cmd *cobra.Command, args []string) error {
 	switch {
 	case getErr == nil && pre.MetadataExists:
 		if changed := divergedFields(pre.Cell.Spec, cellDoc.Spec); len(changed) > 0 {
-			return fmt.Errorf(
-				"cell %q exists with diverging spec (%s); use `kuke apply -f` to update",
-				cellDoc.Metadata.Name,
-				strings.Join(changed, ", "),
-			)
+			if flags.configName != "" {
+				// The -c verb attaches to live state on divergence rather than
+				// refusing: the divergent-spec warning in #625 explicitly
+				// directs the operator at a reconcile verb (`kuke apply -c`,
+				// out of scope here). The warning text is fixed by the AC; the
+				// reader sees only "differs" rather than the field list because
+				// the diff surfaces in `kuke get cell` and a one-line warning
+				// is more legible than an inline field dump.
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"live cell spec differs from CellConfig %s; attaching to live state — kuke apply -c %s to reconcile\n",
+					flags.configName, flags.configName,
+				)
+			} else {
+				return fmt.Errorf(
+					"cell %q exists with diverging spec (%s); use `kuke apply -f` to update",
+					cellDoc.Metadata.Name,
+					strings.Join(changed, ", "),
+				)
+			}
 		}
-		// A live cell whose on-disk spec matches the file: drive the
-		// create-or-attach state machine instead of re-entering CreateCell.
+		// A live cell whose on-disk spec matches the file (or, for -c, that
+		// is being attached-to despite divergence per the warning above):
+		// drive the create-or-attach state machine instead of re-entering
+		// CreateCell.
 		return runExistingCell(cmd, client, cellDoc, pre, flags)
 	case getErr != nil && !errors.Is(getErr, errdefs.ErrCellNotFound):
 		return getErr
@@ -441,19 +499,22 @@ func attachAfterRun(
 	return runAttachLoop(cmd, client, doc, target)
 }
 
-// loadCellDoc dispatches to the file, profile, or blueprint loader. Exactly
-// one of flags.file / flags.profileName / flags.blueprintName is non-empty (the
-// cobra mutex enforces this before the handler runs); --name and --param* are
-// template knobs already rejected against -f in parseRunFlags. The blueprint
-// path resolves over client; the file/profile paths ignore it.
+// loadCellDoc dispatches to the file, profile, blueprint, or config loader.
+// Exactly one of flags.file / flags.profileName / flags.blueprintName /
+// flags.configName is non-empty (the cobra mutex enforces this before the
+// handler runs); --name and --param* are template knobs already rejected
+// against -f and -c in parseRunFlags. The blueprint and config paths resolve
+// over client; the file/profile paths ignore it.
 func loadCellDoc(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (v1beta1.CellDoc, error) {
 	switch {
+	case flags.configName != "":
+		return loadFromConfig(cmd, client, flags)
 	case flags.blueprintName != "":
 		return loadFromBlueprint(cmd, client, flags)
 	case flags.profileName != "":
 		fmt.Fprintln(cmd.ErrOrStderr(),
 			"kuke run: -p/--profile is deprecated and will be removed (#626); "+
-				"apply a kind: CellBlueprint and use `kuke run -b` (or `kuke run -c` for a CellConfig, #625).")
+				"apply a kind: CellBlueprint and use `kuke run -b` (or `kuke run -c` for a CellConfig).")
 		return loadFromProfile(flags)
 	default:
 		return loadFromFile(flags.file)
@@ -508,6 +569,70 @@ func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags runFlag
 		return v1beta1.CellDoc{}, err
 	}
 	return cellblueprint.MaterializeWithName(resolved, flags.nameOverride)
+}
+
+// loadFromConfig resolves the named CellConfig from daemon storage at the
+// scope named by --realm/--space/--stack, looks up the referenced Blueprint
+// from daemon storage (which may live in a different realm — cross-scope
+// references are explicitly allowed), and materializes the CellDoc via
+// cellconfig.Materialize: scalar values from the Config's spec, structural
+// slot fills (repo URLs, secret sources) applied, deterministic stable name
+// + kukeon.io/config back-ref label set. The resulting CellDoc carries the
+// Config's scope coordinates (not the blueprint's), so the cell is created
+// where the Config is bound.
+//
+// The lookup scope follows the same explicit-coordinate rule as
+// loadFromBlueprint: --realm defaults to "default" if unset, but --space and
+// --stack stay empty unless the operator set them explicitly (via flag or
+// KUKE_RUN_SPACE / KUKE_RUN_STACK env). The session-default values in viper
+// would wrongly narrow every lookup to default/default and hide
+// realm-scoped Configs.
+func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (v1beta1.CellDoc, error) {
+	lookup := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  flags.configName,
+			Realm: pickLocation("", &config.KUKE_RUN_REALM),
+			Space: explicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
+			Stack: explicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
+		},
+	}
+
+	cfgRes, err := client.GetConfig(cmd.Context(), lookup)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !cfgRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (config %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrConfigNotFound, lookup.Metadata.Name,
+			lookup.Metadata.Realm, lookup.Metadata.Space, lookup.Metadata.Stack,
+		)
+	}
+
+	bpRef := cfgRes.Config.Spec.Blueprint
+	bpLookup := v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  bpRef.Name,
+			Realm: bpRef.Realm,
+			Space: bpRef.Space,
+			Stack: bpRef.Stack,
+		},
+	}
+	bpRes, err := client.GetBlueprint(cmd.Context(), bpLookup)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !bpRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (blueprint %q referenced by config %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrBlueprintNotFound, bpRef.Name, cfgRes.Config.Metadata.Name,
+			bpRef.Realm, bpRef.Space, bpRef.Stack,
+		)
+	}
+
+	return cellconfig.Materialize(cfgRes.Config, bpRes.Blueprint)
 }
 
 // loadFromFile preserves the phase-1c -f path: read the file (or stdin),

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -135,6 +135,7 @@ type fakeClient struct {
 	attachContainerFn func(doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error)
 	killCellFn        func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
 	getBlueprintFn    func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error)
+	getConfigFn       func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error)
 
 	getCalls    int
 	createCalls int
@@ -202,6 +203,16 @@ func (f *fakeClient) GetBlueprint(
 		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")
 	}
 	return f.getBlueprintFn(doc)
+}
+
+func (f *fakeClient) GetConfig(
+	_ context.Context,
+	doc v1beta1.CellConfigDoc,
+) (kukeonv1.GetConfigResult, error) {
+	if f.getConfigFn == nil {
+		return kukeonv1.GetConfigResult{}, errors.New("unexpected GetConfig call")
+	}
+	return f.getConfigFn(doc)
 }
 
 // runCapture records the Options passed to the in-process attach loop. By
@@ -1215,11 +1226,11 @@ func TestRun_MissingFileAndProfile_Errors(t *testing.T) {
 
 	err := cmd.Execute()
 	// MarkFlagsOneRequired produces "at least one of the flags in the group
-	// [file profile blueprint] is required" — match on the stable group
-	// listing rather than the exact wording so a cobra phrasing change doesn't
-	// break the test.
-	if err == nil || !strings.Contains(err.Error(), "[file profile blueprint]") {
-		t.Fatalf("err=%v want one-of error naming the file/profile/blueprint group", err)
+	// [file profile blueprint config] is required" — match on the stable
+	// group listing rather than the exact wording so a cobra phrasing change
+	// doesn't break the test.
+	if err == nil || !strings.Contains(err.Error(), "[file profile blueprint config]") {
+		t.Fatalf("err=%v want one-of error naming the file/profile/blueprint/config group", err)
 	}
 }
 
@@ -2725,5 +2736,384 @@ func TestRun_Profile_EmitsDeprecationNotice(t *testing.T) {
 
 	if !strings.Contains(out.String(), "-p/--profile is deprecated") {
 		t.Errorf("expected -p deprecation notice, got:\n%s", out.String())
+	}
+}
+
+// configBlueprintDoc returns a minimal CellBlueprintDoc the fake daemon can
+// hand back over GetBlueprint to a -c run, with one parameter, one structural
+// repo slot, and one env-mode secret slot. The blueprint carries a root
+// container plus a user (non-root) container so the divergent-spec check
+// (which excludes the runner-synthesised root, see divergedFields' rationale)
+// has at least one user-container to compare against.
+func configBlueprintDoc() v1beta1.CellBlueprintDoc {
+	def := "latest"
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: "bp-realm",
+		},
+		Spec: v1beta1.CellBlueprintSpec{
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{
+						ID:    "root",
+						Root:  true,
+						Image: "registry.example.com/root:latest",
+					},
+					{
+						ID:         "main",
+						Image:      "registry.example.com/web:${TAG}",
+						Attachable: true,
+						Repos: []v1beta1.ContainerRepo{
+							{Name: "src", Target: "/srv", Required: true},
+						},
+						Secrets: []v1beta1.BlueprintSecretSlot{
+							{Name: "token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "TOKEN", Required: true},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// configDoc returns a CellConfigDoc that fills configBlueprintDoc()'s slots.
+func configDoc() v1beta1.CellConfigDoc {
+	return v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  "prod",
+			Realm: "cfg-realm",
+		},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Values:    map[string]string{"TAG": "v2"},
+			Repos: map[string]v1beta1.CellConfigRepoFill{
+				"src": {URL: "https://example.com/src.git"},
+			},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "api-token", Realm: "cfg-realm"}},
+			},
+		},
+	}
+}
+
+func TestRun_FromConfig_CreatesWithStableNameAndBackRef(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			if doc.Metadata.Name != "prod" {
+				t.Errorf("GetConfig name=%q want prod", doc.Metadata.Name)
+			}
+			if doc.Metadata.Realm != "cfg-realm" {
+				t.Errorf("GetConfig realm=%q want cfg-realm", doc.Metadata.Realm)
+			}
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			if doc.Metadata.Name != "web" || doc.Metadata.Realm != "bp-realm" {
+				t.Errorf("GetBlueprint=%+v want web@bp-realm", doc.Metadata)
+			}
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return kukeonv1.CreateCellResult{
+				Cell: doc, Created: true, MetadataExistsPost: true,
+				CgroupCreated: true, CgroupExistsPost: true,
+				RootContainerCreated: true, RootContainerExistsPost: true, Started: true,
+				Containers: []kukeonv1.ContainerCreationOutcome{{Name: "main", ExistsPost: true, Created: true}},
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 1 {
+		t.Fatalf("CreateCell calls=%d want 1", fc.createCalls)
+	}
+	// Deterministic name (no hex suffix) — that is the -c idempotent contract.
+	if got := fc.createDoc.Metadata.Name; got != "prod" {
+		t.Errorf("cell name=%q want prod (StableName)", got)
+	}
+	// Back-reference label points at the Config.
+	if got := fc.createDoc.Metadata.Labels["kukeon.io/config"]; got != "prod" {
+		t.Errorf("kukeon.io/config label=%q want prod", got)
+	}
+	// Scope from the Config, not the blueprint.
+	if got := fc.createDoc.Spec.RealmID; got != "cfg-realm" {
+		t.Errorf("RealmID=%q want cfg-realm", got)
+	}
+	// Slot fills + scalar substitution applied to the user container.
+	// configBlueprintDoc declares root + main; match by ID rather than index
+	// so this stays resilient to container ordering.
+	if len(fc.createDoc.Spec.Containers) != 2 {
+		t.Fatalf("containers=%d want 2 (root + main)", len(fc.createDoc.Spec.Containers))
+	}
+	var main *v1beta1.ContainerSpec
+	for i := range fc.createDoc.Spec.Containers {
+		if fc.createDoc.Spec.Containers[i].ID == "main" {
+			main = &fc.createDoc.Spec.Containers[i]
+		}
+	}
+	if main == nil {
+		t.Fatalf("main container missing from materialized cell; got %+v", fc.createDoc.Spec.Containers)
+	}
+	if main.Image != "registry.example.com/web:v2" {
+		t.Errorf("image=%q want ${TAG} substituted to v2", main.Image)
+	}
+	if len(main.Repos) != 1 || main.Repos[0].URL != "https://example.com/src.git" {
+		t.Errorf("repos=%+v want src filled", main.Repos)
+	}
+	if len(main.Secrets) != 1 || main.Secrets[0].Name != "TOKEN" {
+		t.Errorf("secrets=%+v want TOKEN env-mode secret", main.Secrets)
+	}
+}
+
+func TestRun_FromConfig_LiveReadyCell_AttachesWithoutCreate(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// The deterministic name is the Config's name verbatim. A live Ready cell
+	// with a matching spec must NOT call CreateCell — the idempotent identity
+	// contract of -c is "at most one live cell per Config".
+	cfg := configDoc()
+	bp := configBlueprintDoc()
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: cfg, MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: bp, MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			if doc.Metadata.Name != "prod" {
+				t.Errorf("GetCell name=%q want prod", doc.Metadata.Name)
+			}
+			// Echo the desired spec back so divergedFields reports no drift.
+			live := doc
+			live.Status.State = v1beta1.CellStateReady
+			return kukeonv1.GetCellResult{
+				Cell: live, MetadataExists: true, CgroupExists: true,
+				RootContainerExists: true, RootContainerTaskRunning: true,
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (live Ready cell)", fc.createCalls)
+	}
+	if fc.startCalls != 0 {
+		t.Errorf("StartCell calls=%d want 0 (live Ready cell)", fc.startCalls)
+	}
+}
+
+func TestRun_FromConfig_LiveStoppedCell_StartsThenAttaches(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			live := doc
+			live.Status.State = v1beta1.CellStateStopped
+			return kukeonv1.GetCellResult{Cell: live, MetadataExists: true}, nil
+		},
+		startCellFn: func(v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			return kukeonv1.StartCellResult{Started: true}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (Stopped cell goes through StartCell)", fc.createCalls)
+	}
+	if fc.startCalls != 1 {
+		t.Errorf("StartCell calls=%d want 1", fc.startCalls)
+	}
+	if got := fc.startDoc.Metadata.Name; got != "prod" {
+		t.Errorf("StartCell name=%q want prod", got)
+	}
+}
+
+func TestRun_FromConfig_LiveFailedCell_RefusesWithDeletePointer(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			live := doc
+			live.Status.State = v1beta1.CellStateFailed
+			return kukeonv1.GetCellResult{Cell: live, MetadataExists: true}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute err=nil want refusal on Failed state")
+	}
+	if !strings.Contains(err.Error(), "kuke delete cell prod") {
+		t.Errorf("err=%q want `kuke delete cell prod` pointer", err)
+	}
+	if fc.createCalls != 0 || fc.startCalls != 0 {
+		t.Errorf("CreateCell=%d StartCell=%d want both 0", fc.createCalls, fc.startCalls)
+	}
+}
+
+func TestRun_FromConfig_DivergentSpec_WarnsAndAttaches(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// Simulate divergence by returning a Ready cell whose container image
+	// disagrees with what Materialize(cfg, bp) would build. The warning text
+	// must match the AC verbatim and CreateCell/StartCell must not fire — the
+	// -c contract is attach-with-warning, not reconcile.
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			// Deep-copy the containers so the test mutation does not also
+			// rewrite the desired CellDoc that runRun is about to compare
+			// against — both sides share the same backing slice when we
+			// shallow-copy `doc`.
+			live := doc
+			live.Spec.Containers = append([]v1beta1.ContainerSpec(nil), doc.Spec.Containers...)
+			// Diverge on the user container's image (divergedFields excludes
+			// the runner-synthesised root). Match by ID rather than index so
+			// the test stays resilient to container ordering.
+			for i := range live.Spec.Containers {
+				if live.Spec.Containers[i].ID == "main" {
+					live.Spec.Containers[i].Image = "registry.example.com/web:v1"
+					break
+				}
+			}
+			live.Status.State = v1beta1.CellStateReady
+			return kukeonv1.GetCellResult{
+				Cell: live, MetadataExists: true,
+				RootContainerExists: true, RootContainerTaskRunning: true,
+			}, nil
+		},
+	}
+	cmd, out := newCmd(t, fc)
+	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute err=%v want nil (warn-only on divergence)", err)
+	}
+	want := "live cell spec differs from CellConfig prod; attaching to live state — kuke apply -c prod to reconcile"
+	if !strings.Contains(out.String(), want) {
+		t.Errorf("expected divergent-spec warning to contain %q, got:\n%s", want, out.String())
+	}
+	if fc.createCalls != 0 || fc.startCalls != 0 {
+		t.Errorf("CreateCell=%d StartCell=%d want both 0 (warn-only)", fc.createCalls, fc.startCalls)
+	}
+}
+
+func TestRun_FromConfig_NotFound_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-c", "ghost", "--realm", "cfg-realm", "-d"})
+
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, errdefs.ErrConfigNotFound) {
+		t.Fatalf("err=%v want ErrConfigNotFound", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 on config-not-found", fc.createCalls)
+	}
+}
+
+func TestRun_FromConfig_BlueprintMissing_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, errdefs.ErrBlueprintNotFound) {
+		t.Fatalf("err=%v want ErrBlueprintNotFound (referenced blueprint missing)", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 on missing referenced blueprint", fc.createCalls)
+	}
+}
+
+func TestRun_FromConfig_RejectsParamFlags(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"--param", []string{"-c", "prod", "--param", "K=V", "-d"}, "--param is not valid with -c"},
+		{"--param-file", []string{"-c", "prod", "--param-file", "/tmp/p", "-d"}, "--param-file is not valid with -c"},
+		{"--name", []string{"-c", "prod", "--name", "pinned", "-d"}, "--name is not valid with -c"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			fc := &fakeClient{}
+			cmd, _ := newCmd(t, fc)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRun_RunVerbMutex_RejectsCAndB(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-c", "prod", "-b", "web", "--realm", "cfg-realm", "-d"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("Execute err=nil want mutex rejection of -c with -b")
 	}
 }

--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -172,7 +172,7 @@ func MaterializeWithName(doc v1beta1.CellBlueprintDoc, nameOverride string) (v1b
 	}
 	if len(blockers) > 0 {
 		return v1beta1.CellDoc{}, fmt.Errorf(
-			"%w (blueprint %q: %s); use `kuke run -c` once CellConfig lands (#625)",
+			"%w (blueprint %q: %s); use `kuke run -c <config>` with a CellConfig that fills the slots",
 			errdefs.ErrBlueprintStructuralSlots, doc.Metadata.Name, strings.Join(blockers, ", "),
 		)
 	}

--- a/internal/cellconfig/materialize.go
+++ b/internal/cellconfig/materialize.go
@@ -1,0 +1,252 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellconfig
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// Materialize converts a CellConfig + its referenced CellBlueprint into a
+// runtime CellDoc (issue #625). It is the config analog of
+// cellblueprint.Materialize, but the two channels differ:
+//
+//   - Scalar values come from cfg.Spec.Values (not --param CLI args); the env
+//     fallback is intentionally absent because a Config's values are the
+//     persistent record of what the operator chose at apply time.
+//   - Structural slot fills (repo URLs, secret sources) come from cfg.Spec.Repos
+//     and cfg.Spec.Secrets, keyed by slot name. Unknown fills and unfilled
+//     required slots are rejected via ValidateSlotFill; optional unfilled slots
+//     are dropped from the materialized container.
+//
+// The materialized cell carries the cellconfig.LabelConfig back-reference (AC
+// of #625) plus every label the operator set on cfg.Metadata.Labels, and uses
+// the deterministic StableName(cfg.Metadata.Name) — the affordance that makes
+// `kuke run -c` idempotent (at most one live cell per Config). The cell's
+// scope coordinates come from the Config's metadata, not the blueprint's, so a
+// Config in one realm may instantiate a Blueprint in another (cross-realm
+// references are explicitly supported by CellConfigBlueprintRef).
+func Materialize(cfg v1beta1.CellConfigDoc, bp v1beta1.CellBlueprintDoc) (v1beta1.CellDoc, error) {
+	if err := ValidateSlotFill(cfg, bp); err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+
+	resolved, err := cellblueprint.Resolve(bp, cfg.Spec.Values, nil)
+	if err != nil {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"config %q: resolve blueprint %q: %w",
+			cfg.Metadata.Name, bp.Metadata.Name, err,
+		)
+	}
+
+	containers := make([]v1beta1.ContainerSpec, 0, len(resolved.Spec.Cell.Containers))
+	for _, bc := range resolved.Spec.Cell.Containers {
+		cs, fillErr := materializeContainer(bc, cfg)
+		if fillErr != nil {
+			return v1beta1.CellDoc{}, fillErr
+		}
+		containers = append(containers, cs)
+	}
+
+	cellName := StableName(cfg.Metadata.Name)
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   cellName,
+			Labels: mergeConfigLabel(cfg.Metadata.Labels, cfg.Metadata.Name),
+		},
+		Spec: v1beta1.CellSpec{
+			ID:                  cellName,
+			RealmID:             strings.TrimSpace(cfg.Metadata.Realm),
+			SpaceID:             strings.TrimSpace(cfg.Metadata.Space),
+			StackID:             strings.TrimSpace(cfg.Metadata.Stack),
+			Tty:                 cloneCellTty(resolved.Spec.Cell.Tty),
+			Containers:          containers,
+			AutoDelete:          resolved.Spec.Cell.AutoDelete,
+			NestedCgroupRuntime: resolved.Spec.Cell.NestedCgroupRuntime,
+		},
+	}, nil
+}
+
+// materializeContainer maps a (resolved) BlueprintContainer to a runtime
+// ContainerSpec, applying the Config's repo and secret slot fills. Repos with
+// an inline URL pass through (scalar mode); repos with an empty URL whose slot
+// the Config fills get the fill's URL/Branch; optional unfilled slots drop.
+// Every blueprint secret slot is structural, so a filled slot produces a
+// ContainerSecret keyed by the slot's mode (env → env var named EnvName; file
+// → read-only mount at MountPath); optional unfilled secret slots drop.
+//
+// ValidateSlotFill is the gate for "required slot must be filled" / "fill must
+// match a declared slot", so this function trusts those invariants and treats
+// any still-unfilled required slot here as an internal error rather than a
+// user-facing one.
+func materializeContainer(
+	bc v1beta1.BlueprintContainer, cfg v1beta1.CellConfigDoc,
+) (v1beta1.ContainerSpec, error) {
+	repos := make([]v1beta1.ContainerRepo, 0, len(bc.Repos))
+	for _, r := range bc.Repos {
+		if strings.TrimSpace(r.URL) != "" {
+			repos = append(repos, r)
+			continue
+		}
+		fill, ok := cfg.Spec.Repos[strings.TrimSpace(r.Name)]
+		if !ok {
+			if r.Required {
+				return v1beta1.ContainerSpec{}, fmt.Errorf(
+					"%w: container %q repo slot %q",
+					errdefs.ErrConfigRequiredSlotUnfilled, bc.ID, r.Name,
+				)
+			}
+			continue
+		}
+		filled := r
+		filled.URL = strings.TrimSpace(fill.URL)
+		if branch := strings.TrimSpace(fill.Branch); branch != "" {
+			filled.Branch = branch
+		}
+		repos = append(repos, filled)
+	}
+
+	secrets := make([]v1beta1.ContainerSecret, 0, len(bc.Secrets))
+	for _, slot := range bc.Secrets {
+		fill, ok := cfg.Spec.Secrets[strings.TrimSpace(slot.Name)]
+		if !ok {
+			if slot.Required {
+				return v1beta1.ContainerSpec{}, fmt.Errorf(
+					"%w: container %q secret slot %q",
+					errdefs.ErrConfigRequiredSlotUnfilled, bc.ID, slot.Name,
+				)
+			}
+			continue
+		}
+		cs, err := materializeSecretSlot(bc.ID, slot, fill)
+		if err != nil {
+			return v1beta1.ContainerSpec{}, err
+		}
+		secrets = append(secrets, cs)
+	}
+
+	cs := v1beta1.ContainerSpec{
+		ID:                     bc.ID,
+		Root:                   bc.Root,
+		Image:                  bc.Image,
+		Command:                bc.Command,
+		Args:                   bc.Args,
+		WorkingDir:             bc.WorkingDir,
+		Env:                    bc.Env,
+		Ports:                  bc.Ports,
+		Volumes:                bc.Volumes,
+		Networks:               bc.Networks,
+		NetworksAliases:        bc.NetworksAliases,
+		Privileged:             bc.Privileged,
+		HostNetwork:            bc.HostNetwork,
+		HostPID:                bc.HostPID,
+		HostCgroup:             bc.HostCgroup,
+		User:                   bc.User,
+		ReadOnlyRootFilesystem: bc.ReadOnlyRootFilesystem,
+		Capabilities:           bc.Capabilities,
+		SecurityOpts:           bc.SecurityOpts,
+		Tmpfs:                  bc.Tmpfs,
+		Resources:              bc.Resources,
+		Repos:                  repos,
+		Git:                    bc.Git,
+		RestartPolicy:          bc.RestartPolicy,
+		Attachable:             bc.Attachable,
+		Tty:                    bc.Tty,
+		Secrets:                secrets,
+	}
+	if len(repos) == 0 {
+		cs.Repos = nil
+	}
+	if len(secrets) == 0 {
+		cs.Secrets = nil
+	}
+	return cs, nil
+}
+
+// materializeSecretSlot translates a (slot, fill) pair into a runtime
+// ContainerSecret. The blueprint owns the consumption side (mode + env-var name
+// or mount path); the Config supplies the source (which kind: Secret provides
+// the bytes). Mode "env" (the default when empty) emits an env-var-mode
+// ContainerSecret keyed by EnvName; mode "file" emits a file-mode
+// ContainerSecret mounted at MountPath. The slot's own Name carries through as
+// the ContainerSecret's Name for file mode (used as the staged filename and
+// the back-trace label); env mode replaces it with EnvName because
+// ContainerSecret.Name doubles as the env-var name when MountPath is empty.
+func materializeSecretSlot(
+	containerID string, slot v1beta1.BlueprintSecretSlot, fill v1beta1.CellConfigSecretFill,
+) (v1beta1.ContainerSecret, error) {
+	if fill.SecretRef == nil {
+		return v1beta1.ContainerSecret{}, fmt.Errorf(
+			"%w: container %q secret slot %q (fill has no secretRef)",
+			errdefs.ErrConfigRequiredSlotUnfilled, containerID, slot.Name,
+		)
+	}
+	ref := *fill.SecretRef
+
+	mode := strings.TrimSpace(slot.Mode)
+	if mode == "" {
+		mode = v1beta1.BlueprintSecretModeEnv
+	}
+	switch mode {
+	case v1beta1.BlueprintSecretModeEnv:
+		return v1beta1.ContainerSecret{
+			Name:      strings.TrimSpace(slot.EnvName),
+			SecretRef: &ref,
+		}, nil
+	case v1beta1.BlueprintSecretModeFile:
+		return v1beta1.ContainerSecret{
+			Name:      strings.TrimSpace(slot.Name),
+			SecretRef: &ref,
+			MountPath: strings.TrimSpace(slot.MountPath),
+		}, nil
+	default:
+		return v1beta1.ContainerSecret{}, fmt.Errorf(
+			"%w: container %q secret slot %q mode %q",
+			errdefs.ErrBlueprintInvalid, containerID, slot.Name, mode,
+		)
+	}
+}
+
+// mergeConfigLabel returns a label map combining the operator-authored labels
+// from the Config's metadata with the kukeon.io/config back-reference pointing
+// at the Config that materialized the cell. The back-reference wins on a
+// collision so a Config cannot accidentally shadow its own identity label.
+func mergeConfigLabel(in map[string]string, configName string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+	for k, v := range in {
+		out[k] = v
+	}
+	out[LabelConfig] = configName
+	return out
+}
+
+// cloneCellTty deep-copies a *CellTty so mutations on the materialized cell do
+// not leak back into the blueprint document. Mirrors
+// cellblueprint.cloneCellTty's contract.
+func cloneCellTty(in *v1beta1.CellTty) *v1beta1.CellTty {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}

--- a/internal/cellconfig/materialize_test.go
+++ b/internal/cellconfig/materialize_test.go
@@ -1,0 +1,310 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellconfig
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// minimalBlueprint returns a CellBlueprintDoc with a single container declaring
+// one scalar param, one structural repo slot, one optional repo slot, and one
+// required + one optional env-mode secret slot. The shape exercises every
+// branch in materializeContainer.
+func minimalBlueprint() v1beta1.CellBlueprintDoc {
+	def := "latest"
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: "bp-realm",
+		},
+		Spec: v1beta1.CellBlueprintSpec{
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{{
+					ID:    "main",
+					Image: "registry.example.com/web:${TAG}",
+					Repos: []v1beta1.ContainerRepo{
+						{Name: "src", Target: "/srv", Required: true}, // required slot
+						{Name: "extra", Target: "/extra"},             // optional slot
+					},
+					Secrets: []v1beta1.BlueprintSecretSlot{
+						{Name: "token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "TOKEN", Required: true},
+						{Name: "ca", Mode: v1beta1.BlueprintSecretModeFile, MountPath: "/etc/ca.pem"},
+					},
+				}},
+			},
+		},
+	}
+}
+
+func TestMaterialize_HappyPath_FillsRepoAndSecretSlots(t *testing.T) {
+	bp := minimalBlueprint()
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:   "prod",
+			Realm:  "cfg-realm",
+			Space:  "cfg-space",
+			Labels: map[string]string{"app": "web"},
+		},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Values:    map[string]string{"TAG": "v2"},
+			Repos: map[string]v1beta1.CellConfigRepoFill{
+				"src":   {URL: "https://example.com/src.git", Branch: "main"},
+				"extra": {URL: "https://example.com/extra.git"},
+			},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "api-token", Realm: "cfg-realm"}},
+				"ca":    {SecretRef: &v1beta1.ContainerSecretRef{Name: "ca-bundle", Realm: "cfg-realm"}},
+			},
+		},
+	}
+
+	cell, err := Materialize(cfg, bp)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+
+	// Deterministic name + back-ref label.
+	if got := cell.Metadata.Name; got != "prod" {
+		t.Errorf("cell name=%q want prod (StableName(config.Name))", got)
+	}
+	if got := cell.Metadata.Labels[LabelConfig]; got != "prod" {
+		t.Errorf("LabelConfig=%q want prod", got)
+	}
+	if got := cell.Metadata.Labels["app"]; got != "web" {
+		t.Errorf("operator label app=%q want web (copied from cfg.Metadata.Labels)", got)
+	}
+
+	// Cell scope is the Config's, not the blueprint's.
+	if got := cell.Spec.RealmID; got != "cfg-realm" {
+		t.Errorf("RealmID=%q want cfg-realm (config scope wins)", got)
+	}
+	if got := cell.Spec.SpaceID; got != "cfg-space" {
+		t.Errorf("SpaceID=%q want cfg-space", got)
+	}
+
+	if len(cell.Spec.Containers) != 1 {
+		t.Fatalf("containers=%d want 1", len(cell.Spec.Containers))
+	}
+	c := cell.Spec.Containers[0]
+
+	// Scalar substitution ran (${TAG} → v2).
+	if c.Image != "registry.example.com/web:v2" {
+		t.Errorf("image=%q want ${TAG} substituted to v2", c.Image)
+	}
+
+	// Both repo slots filled — required + optional.
+	if len(c.Repos) != 2 {
+		t.Fatalf("repos=%d want 2", len(c.Repos))
+	}
+	repoByName := map[string]v1beta1.ContainerRepo{}
+	for _, r := range c.Repos {
+		repoByName[r.Name] = r
+	}
+	if got := repoByName["src"].URL; got != "https://example.com/src.git" {
+		t.Errorf("src repo URL=%q", got)
+	}
+	if got := repoByName["src"].Branch; got != "main" {
+		t.Errorf("src repo Branch=%q want main", got)
+	}
+	if got := repoByName["extra"].URL; got != "https://example.com/extra.git" {
+		t.Errorf("extra repo URL=%q", got)
+	}
+
+	// Both secret slots translated to ContainerSecret.
+	if len(c.Secrets) != 2 {
+		t.Fatalf("secrets=%d want 2", len(c.Secrets))
+	}
+	secretByMountOrEnv := map[string]v1beta1.ContainerSecret{}
+	for _, s := range c.Secrets {
+		// env-mode key uses Name (== env var name); file-mode key uses MountPath.
+		if s.MountPath != "" {
+			secretByMountOrEnv[s.MountPath] = s
+		} else {
+			secretByMountOrEnv["env:"+s.Name] = s
+		}
+	}
+	envSecret, ok := secretByMountOrEnv["env:TOKEN"]
+	if !ok {
+		t.Fatalf("token env secret (Name=TOKEN, MountPath=\"\") not emitted; got %+v", c.Secrets)
+	}
+	if envSecret.SecretRef == nil || envSecret.SecretRef.Name != "api-token" {
+		t.Errorf("token secretRef=%+v want api-token", envSecret.SecretRef)
+	}
+	fileSecret, ok := secretByMountOrEnv["/etc/ca.pem"]
+	if !ok {
+		t.Fatalf("ca file secret (MountPath=/etc/ca.pem) not emitted; got %+v", c.Secrets)
+	}
+	if fileSecret.Name != "ca" {
+		t.Errorf("ca secret Name=%q want ca (slot name for file mode)", fileSecret.Name)
+	}
+	if fileSecret.SecretRef == nil || fileSecret.SecretRef.Name != "ca-bundle" {
+		t.Errorf("ca secretRef=%+v want ca-bundle", fileSecret.SecretRef)
+	}
+}
+
+func TestMaterialize_RequiredRepoSlotUnfilled_Errors(t *testing.T) {
+	bp := minimalBlueprint()
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			// "src" required slot deliberately unfilled.
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "t", Realm: "cfg-realm"}},
+			},
+		},
+	}
+
+	_, err := Materialize(cfg, bp)
+	if err == nil || !errors.Is(err, errdefs.ErrConfigRequiredSlotUnfilled) {
+		t.Fatalf("err=%v want ErrConfigRequiredSlotUnfilled", err)
+	}
+}
+
+func TestMaterialize_UnknownSlotFill_Errors(t *testing.T) {
+	bp := minimalBlueprint()
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Repos: map[string]v1beta1.CellConfigRepoFill{
+				"src":     {URL: "https://example.com/src.git"},
+				"nonsuch": {URL: "https://example.com/x.git"}, // not declared by blueprint
+			},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "t", Realm: "cfg-realm"}},
+			},
+		},
+	}
+
+	_, err := Materialize(cfg, bp)
+	if err == nil || !errors.Is(err, errdefs.ErrConfigUnknownRepoSlot) {
+		t.Fatalf("err=%v want ErrConfigUnknownRepoSlot", err)
+	}
+}
+
+func TestMaterialize_OptionalSlotUnfilled_Drops(t *testing.T) {
+	bp := minimalBlueprint()
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Repos: map[string]v1beta1.CellConfigRepoFill{
+				"src": {URL: "https://example.com/src.git"}, // required; "extra" left unfilled
+			},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "t", Realm: "cfg-realm"}},
+				// "ca" optional, left unfilled
+			},
+		},
+	}
+
+	cell, err := Materialize(cfg, bp)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	c := cell.Spec.Containers[0]
+	if len(c.Repos) != 1 || c.Repos[0].Name != "src" {
+		t.Errorf("repos=%+v want only src (extra is optional, dropped)", c.Repos)
+	}
+	if len(c.Secrets) != 1 || c.Secrets[0].Name != "TOKEN" {
+		t.Errorf("secrets=%+v want only TOKEN (ca is optional, dropped)", c.Secrets)
+	}
+}
+
+func TestMaterialize_ScalarRepoPassesThrough(t *testing.T) {
+	// A blueprint repo with an inline URL is scalar-mode (not a fillable slot);
+	// the Config must not be required to mention it, and Materialize must keep
+	// it in the runtime ContainerSpec.Repos.
+	bp := v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata:   v1beta1.CellBlueprintMetadata{Name: "lib", Realm: "bp-realm"},
+		Spec: v1beta1.CellBlueprintSpec{
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{{
+					ID:    "main",
+					Image: "scratch",
+					Repos: []v1beta1.ContainerRepo{
+						{Name: "vendored", Target: "/v", URL: "https://example.com/v.git"},
+					},
+				}},
+			},
+		},
+	}
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec:       v1beta1.CellConfigSpec{Blueprint: v1beta1.CellConfigBlueprintRef{Name: "lib", Realm: "bp-realm"}},
+	}
+	cell, err := Materialize(cfg, bp)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	c := cell.Spec.Containers[0]
+	if len(c.Repos) != 1 || c.Repos[0].URL != "https://example.com/v.git" {
+		t.Errorf("repos=%+v want scalar-mode vendored repo carried through", c.Repos)
+	}
+}
+
+func TestMaterialize_PropagatesResolveError(t *testing.T) {
+	// A blueprint with a required parameter the Config does not fill should
+	// surface a blueprint-resolve error, not silently succeed with an empty
+	// substitution.
+	bp := v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "bp-realm"},
+		Spec: v1beta1.CellBlueprintSpec{
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Required: true}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "${TAG}"}},
+			},
+		},
+	}
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			// Values: TAG deliberately absent.
+		},
+	}
+
+	_, err := Materialize(cfg, bp)
+	if err == nil || !errors.Is(err, errdefs.ErrBlueprintInvalid) {
+		t.Fatalf("err=%v want ErrBlueprintInvalid (required param TAG unset)", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `kuke run -c <config>` as the daemon-stored, idempotent counterpart to `-b`: the at-most-one live cell per Config that the CellConfig contract promises (#624, #423 phase 4c).
- New `internal/cellconfig.Materialize(cfg, bp)` resolves the referenced Blueprint with the Config's scalar values, applies the Config's repo / secret slot fills, stamps the deterministic `StableName(cfg.Metadata.Name)`, and attaches the `kukeon.io/config=<name>` back-reference label.
- Wires `-c` into the run mutex group alongside `-f`/`-p`/`-b`, with `--param`/`--param-file`/`--name` rejected on `-c` (a Config carries its own values and a stable identity).
- Drops the `(#625)` markers from `-p`'s deprecation hint and the `cellblueprint.MaterializeWithName` structural-slot error now that the verb is shipping.

## Identity state machine

After materialisation, `runRun` calls `client.GetCell(cellDoc)` against the deterministic name:

- **No live cell** → `CreateCell` + attach (no-op when `-d`).
- **Live cell, Ready** → no-op summary, attach.
- **Live cell, Stopped** → `StartCell` + attach.
- **Live cell, Pending / Failed / Unknown** → refuse with `kuke delete cell <name>` pointer.
- **Live cell whose spec diverges from `Materialize(cfg, bp)`** → emit the AC's one-line warning to stderr and attach to live state; do **not** refuse or reconcile.

The Ready/Stopped/error transitions reuse `runExistingCell` so the `-f` and `-c` paths share the same liveness-guard (#683) and CNI re-entry (#630) semantics. The `-c` branch differs only at the divergence check: `-f` refuses with a `kuke apply -f` pointer; `-c` warns and continues (per the AC).

## Non-obvious calls (reviewer push-back welcome)

- **Lookup scope flags.** The issue body sketches `--scope realm=<r>` but the AC's binding constraints don't require that syntax. `-c` reuses the existing `--realm`/`--space`/`--stack` flags (consistent with `-b`'s lookup-scope semantics via `explicitScope`); the AC's "joins the run mutual-exclusivity / one-required flag group" wording is satisfied.
- **Labels on the materialized cell.** AC #3 names only the `kukeon.io/config` back-reference. `Materialize` sets exactly that plus any labels the operator put on `cfg.Metadata.Labels`; it does **not** also stamp `kukeon.io/blueprint` (a Config-materialized cell is identified by its Config, and the Config itself records the blueprint ref). Trade-off: `kuke get cells -l kukeon.io/blueprint=<name>` won't surface `-c` runs of a referenced blueprint. Easy to add if reviewer disagrees.
- **Divergence detection.** Uses the existing `divergedFields` helper. It deliberately excludes the runner-synthesised root container (per #437) and the space-default fields the runner re-merges at create time, so a root-only image swap on a `-c` cell wouldn't fire the warning. The AC accepts "spec or content hash"; the looser check matches the existing `-f` rule and keeps the warning informational. A more thorough check (or full content hash) is a candidate follow-up for the reconcile verb the warning advertises.
- **`-p` deprecation pointer.** Stripped the `#625` callout from `loadCellDoc`'s deprecation print since `-c` now exists; the message points the operator at `kuke run -b`/`kuke run -c` directly.

## Acceptance criteria

- [x] `kuke run -c <name>` CLI verb; resolves CellConfig from `/opt/kukeon/<scope>/configs/<name>` (via `client.GetConfig` on `kukeond`).
- [x] Identity state machine: no-cell → materialise+create+attach; Ready → attach; Stopped → start+attach; error → refuse with `kuke delete cell` pointer. Uses `cellconfig.StableName` for the deterministic name and the `kukeon.io/config` back-reference label.
- [x] Materialised cell carries the back-reference label (`kukeon.io/config=<name>`) to its Config; Config-authored labels also copied onto the cell.
- [x] Divergent-spec one-line warning matches the umbrella body verbatim and the path attaches to live state rather than reconciling.
- [x] `-c` joins the run mutex / one-required group; help text distinguishes `-b` (always fresh) from `-c` (idempotent) and notes `-p` as deprecated.
- [x] Errors name the responsible resource — `ErrConfigNotFound` (Config), `ErrBlueprintNotFound` (referenced Blueprint), `ErrConfigRequiredSlotUnfilled` (missing slot fill), `ErrConfigUnknownRepoSlot`/`ErrConfigUnknownSecretSlot` (stale slot fill).

## Test plan

- [x] `make test` — full root + kukebuild suites, 98 packages, 0 failures pre- and post-rebase onto `origin/main`.
- [x] `go test ./internal/cellconfig/... ./cmd/kuke/run/...` — new `Materialize` unit tests (happy path, required-slot-unfilled, unknown-slot, optional-slot drop, scalar repo pass-through, blueprint-resolve error propagation) plus eight new `-c` CLI tests (stable-name + back-ref, live Ready / Stopped / Failed, divergent-spec warning, ConfigNotFound, BlueprintNotFound, `--param`/`--param-file`/`--name` rejection, mutex with `-b`).
- [x] `go vet ./...` clean.
- [x] `gofmt -l` clean on changed files.
- [x] Pre-commit run on changed files: every hook except `golangci-lint` Passed; `golangci-lint` Skipped per the documented go1.24-binary-on-go1.25-module panic (environmental, not a real finding).
- [ ] `make dev-init` — not run. This PR touches no daemon, no build-path, and nothing under `/opt/kukeon`; it consumes the existing `GetConfig` RPC shipped in phase 4.2.2 (#733) without modifying the daemon side. Per CLAUDE.md the smoke test is required only when those surfaces change.

Closes #625