### PR TITLE
feat(tty): render-time gate omitting done create stages (phase C2)

### DIFF
--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -103,7 +103,14 @@ func attachableTTYDirInitialPerms(kukeonGroupGID int) (os.FileMode, int) {
 // path `kuke init` sets up on /opt/kukeon. The owner is corrected to the
 // container's resolved uid by attachablePostCreateChown after
 // CreateContainerFromSpec runs.
-func (r *Exec) attachableBuildOpts(_ string, spec intmodel.ContainerSpec, _ []ctr.RegistryCredentials) ([]ctr.BuildOption, error) {
+//
+// priorStages carries the controller-side ContainerStatus.Stages snapshot
+// for this container (sourced from cell.Status.Containers at each call
+// site). The renderer threads it into writeKukettyDoc so the phase-C2 (#737)
+// render-time gate can omit already-done runOn: create stages from the next
+// boot's ContainerDoc. Pass nil on a fresh-create boot — every create stage
+// renders normally and runs on the next boot.
+func (r *Exec) attachableBuildOpts(_ string, spec intmodel.ContainerSpec, _ []ctr.RegistryCredentials, priorStages []intmodel.StageStatus) ([]ctr.BuildOption, error) {
 	if !spec.Attachable {
 		return nil, nil
 	}
@@ -152,7 +159,7 @@ func (r *Exec) attachableBuildOpts(_ string, spec intmodel.ContainerSpec, _ []ct
 	metadataPath := filepath.Join(containerDir, ctr.AttachableMetadataFile)
 	kukeonGID := r.opts.KukeonGroupGID
 	renderer := func(workloadArgv []string) error {
-		return r.writeKukettyDoc(metadataPath, spec, kukeonGID, workloadArgv)
+		return r.writeKukettyDoc(metadataPath, spec, kukeonGID, workloadArgv, priorStages)
 	}
 
 	return []ctr.BuildOption{
@@ -194,11 +201,22 @@ func (r *Exec) attachableBuildOpts(_ string, spec intmodel.ContainerSpec, _ []ct
 // Everything else the transform needs — the fixed in-container socket /
 // capture / log paths and their modes — are kukeon contract constants kuketty
 // knows directly, so they are not carried in the doc.
+//
+// priorStages is the controller-side ContainerStatus.Stages snapshot for this
+// container (after mergeStageStatuses has dropped stale-hash and non-done
+// entries). The render-time gate (applyStageRenderGate) consults its
+// State == "done" entries to clear the Script of any matching runOn: create
+// stage in the rendered OnInit, so kuketty's runStage no-ops the gated
+// execution — phase C2 (#737) of the run-once-per-cell-instance setup. The
+// rendered ContainerDoc is the render-time evidence the gate fired (gated
+// stages carry an empty Script in Spec.Tty.OnInit). A nil priorStages is a
+// fresh-create boot — every create stage renders normally and runs.
 func (r *Exec) writeKukettyDoc(
 	path string,
 	spec intmodel.ContainerSpec,
 	kukeonGroupGID int,
 	workloadArgv []string,
+	priorStages []intmodel.StageStatus,
 ) error {
 	extSpec := apischeme.BuildContainerSpecExternalFromInternal(spec)
 
@@ -226,6 +244,15 @@ func (r *Exec) writeKukettyDoc(
 		extSpec.Tty = &extmodel.ContainerTty{}
 	}
 	extSpec.Tty.LogLevel = resolvedLevel
+
+	// Phase C2 (#737) render-time gate: clear Script on any runOn: create
+	// stage whose content hash matches a prior State == "done" record so
+	// kuketty's pre-Serve executor no-ops the execution on this boot. The
+	// TtyStage entry stays at its position in the rendered OnInit so
+	// kuketty's createStages emits Stage.Index aligned with the live
+	// spec.Tty.OnInit position the daemon-side mergeStageStatuses anchors
+	// on. See applyStageRenderGate for the contract.
+	applyStageRenderGate(extSpec.Tty.OnInit, priorStages)
 
 	doc := extmodel.ContainerDoc{
 		APIVersion: extmodel.APIVersionV1Beta1,

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
 	extmodel "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -124,7 +125,7 @@ func TestWriteKukettyDoc_EmitsContainerDoc(t *testing.T) {
 	const kukeonGID = 986
 	workload := []string{"/bin/sh", "-c", "echo hello"}
 
-	if err := r.writeKukettyDoc(path, spec, kukeonGID, workload); err != nil {
+	if err := r.writeKukettyDoc(path, spec, kukeonGID, workload, nil); err != nil {
 		t.Fatalf("writeKukettyDoc: %v", err)
 	}
 
@@ -210,7 +211,7 @@ func TestWriteKukettyDoc_EmptyWorkloadClearsCommand(t *testing.T) {
 	path := filepath.Join(dir, "kuketty-metadata.json")
 	spec := intmodel.ContainerSpec{ID: "c1", Command: "/bin/leftover", Args: []string{"x"}}
 
-	if err := r.writeKukettyDoc(path, spec, 0, nil); err != nil {
+	if err := r.writeKukettyDoc(path, spec, 0, nil, nil); err != nil {
 		t.Fatalf("writeKukettyDoc: %v", err)
 	}
 	doc := readDoc(t, path)
@@ -246,7 +247,7 @@ func TestWriteKukettyDoc_LogLevelResolution(t *testing.T) {
 			dir := t.TempDir()
 			path := filepath.Join(dir, "kuketty-metadata.json")
 			spec := intmodel.ContainerSpec{ID: "c1", Tty: tc.tty}
-			if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}); err != nil {
+			if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}, nil); err != nil {
 				t.Fatalf("writeKukettyDoc: %v", err)
 			}
 			doc := readDoc(t, path)
@@ -272,7 +273,7 @@ func TestWriteKukettyDoc_LogFileOverridePreserved(t *testing.T) {
 	const override = "/var/log/sbsh-debug.log"
 	spec := intmodel.ContainerSpec{ID: "c1", Tty: &intmodel.ContainerTty{LogFile: override}}
 
-	if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}); err != nil {
+	if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}, nil); err != nil {
 		t.Fatalf("writeKukettyDoc: %v", err)
 	}
 	doc := readDoc(t, path)
@@ -374,6 +375,240 @@ func TestEnsureAttachableSocketSymlink_RefusesOverflow(t *testing.T) {
 	}
 	if _, statErr := os.Lstat(symlinkPath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Errorf("symlink %q exists (lstat err = %v), want ErrNotExist", symlinkPath, statErr)
+	}
+}
+
+// TestWriteKukettyDoc_RenderGate_OmitsDoneCreateStagesOnRestart locks AC #1:
+// on a subsequent boot, the rendered ContainerDoc gates already-done runOn:
+// create stages so kuketty's pre-Serve executor no-ops their execution. The
+// gate clears the Script of each gated stage (preserving the TtyStage entry
+// at its OnInit position so kuketty's createStages emits Stage.Index aligned
+// with the live spec.Tty.OnInit position the daemon-side merge anchors on);
+// non-create stages and create stages with no prior done record are
+// untouched. Phase C2 (#737).
+func TestWriteKukettyDoc_RenderGate_OmitsDoneCreateStagesOnRestart(t *testing.T) {
+	r := newTestRunner(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+
+	doneStage := intmodel.TtyStage{Script: "npm ci", RunOn: extmodel.RunOnCreate}
+	startStage := intmodel.TtyStage{Script: "echo welcome", RunOn: extmodel.RunOnStart}
+	freshStage := intmodel.TtyStage{Script: "db-seed", RunOn: extmodel.RunOnCreate}
+	doneHash := stageContentHash(toV1beta1Stage(doneStage))
+
+	spec := intmodel.ContainerSpec{
+		ID:         "c1",
+		Attachable: true,
+		Tty: &intmodel.ContainerTty{
+			OnInit: []intmodel.TtyStage{doneStage, startStage, freshStage},
+		},
+	}
+	priorStages := []intmodel.StageStatus{
+		{Index: 0, State: setupstatus.StageDone, Hash: doneHash},
+		// freshStage at Index 2 has no prior record — must render unchanged.
+	}
+
+	if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}, priorStages); err != nil {
+		t.Fatalf("writeKukettyDoc: %v", err)
+	}
+	doc := readDoc(t, path)
+	if doc.Spec.Tty == nil {
+		t.Fatalf("Spec.Tty is nil")
+	}
+	if len(doc.Spec.Tty.OnInit) != 3 {
+		t.Fatalf("len(Spec.Tty.OnInit) = %d, want 3 (slice length must be preserved so kuketty's Stage.Index aligns with spec position)", len(doc.Spec.Tty.OnInit))
+	}
+	// Gated create stage: Script cleared, RunOn preserved so kuketty's
+	// createStages still picks it up at the correct Index. The on-disk
+	// evidence the gate fired is the empty Script alongside an unchanged
+	// RunOn.
+	if doc.Spec.Tty.OnInit[0].Script != "" {
+		t.Errorf("OnInit[0].Script = %q, want empty (gate must clear done create stage's Script)", doc.Spec.Tty.OnInit[0].Script)
+	}
+	if doc.Spec.Tty.OnInit[0].RunOn != extmodel.RunOnCreate {
+		t.Errorf("OnInit[0].RunOn = %q, want %q (gate must not touch RunOn — preserving createStages selection)", doc.Spec.Tty.OnInit[0].RunOn, extmodel.RunOnCreate)
+	}
+	// Non-create stages are never gated.
+	if doc.Spec.Tty.OnInit[1].Script != startStage.Script {
+		t.Errorf("OnInit[1].Script = %q, want %q (runOn: start must not be touched)", doc.Spec.Tty.OnInit[1].Script, startStage.Script)
+	}
+	if doc.Spec.Tty.OnInit[1].RunOn != extmodel.RunOnStart {
+		t.Errorf("OnInit[1].RunOn = %q, want %q", doc.Spec.Tty.OnInit[1].RunOn, extmodel.RunOnStart)
+	}
+	// Create stage with no prior done record: unchanged.
+	if doc.Spec.Tty.OnInit[2].Script != freshStage.Script {
+		t.Errorf("OnInit[2].Script = %q, want %q (fresh create stage with no prior done must render unchanged)", doc.Spec.Tty.OnInit[2].Script, freshStage.Script)
+	}
+}
+
+// TestWriteKukettyDoc_RenderGate_EditedStageReRuns locks AC #2: an edited
+// runOn: create stage produces a new content hash that no longer matches the
+// prior done record, so the gate does not fire and the stage's Script is
+// rendered verbatim — kuketty's pre-Serve executor re-runs it. Phase C2
+// (#737).
+func TestWriteKukettyDoc_RenderGate_EditedStageReRuns(t *testing.T) {
+	r := newTestRunner(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+
+	priorStage := intmodel.TtyStage{Script: "npm ci", RunOn: extmodel.RunOnCreate}
+	editedStage := intmodel.TtyStage{Script: "npm ci --omit=dev", RunOn: extmodel.RunOnCreate}
+	priorHash := stageContentHash(toV1beta1Stage(priorStage))
+	editedHash := stageContentHash(toV1beta1Stage(editedStage))
+	if priorHash == editedHash {
+		t.Fatalf("test premise violated: edited stage hashes identically to prior")
+	}
+
+	spec := intmodel.ContainerSpec{
+		ID:         "c1",
+		Attachable: true,
+		Tty: &intmodel.ContainerTty{
+			OnInit: []intmodel.TtyStage{editedStage},
+		},
+	}
+	priorStages := []intmodel.StageStatus{
+		{Index: 0, State: setupstatus.StageDone, Hash: priorHash},
+	}
+
+	if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}, priorStages); err != nil {
+		t.Fatalf("writeKukettyDoc: %v", err)
+	}
+	doc := readDoc(t, path)
+	if doc.Spec.Tty == nil || len(doc.Spec.Tty.OnInit) != 1 {
+		t.Fatalf("Spec.Tty.OnInit = %+v, want single-entry", doc.Spec.Tty)
+	}
+	if doc.Spec.Tty.OnInit[0].Script != editedStage.Script {
+		t.Errorf("OnInit[0].Script = %q, want %q (edited hash must not match prior done — gate must not fire)",
+			doc.Spec.Tty.OnInit[0].Script, editedStage.Script)
+	}
+}
+
+// TestWriteKukettyDoc_RenderGate_ReconcileRollback locks AC #3 (#625 phase
+// 4.3 interaction): when reconcile drives a container back to a prior spec
+// version, the done-set's hashes either still match (gate fires — skip) or
+// no longer match (gate does not fire — re-run). The done-set is keyed on
+// content Hash, not OnInit position, so a rollback that re-orders or
+// reintroduces a stage with the same content still hits the gate at its new
+// position.
+//
+// Scenario: container originally had OnInit = [A_create]. Operator added a
+// new pre-step B_create at position 0 (OnInit = [B_create, A_create]), let
+// it run, then reconcile rolled the spec back to [A_create]. A's hash is in
+// the done-set; the rolled-back spec must render A's Script cleared at its
+// new position 0.
+func TestWriteKukettyDoc_RenderGate_ReconcileRollback(t *testing.T) {
+	r := newTestRunner(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+
+	stageA := intmodel.TtyStage{Script: "setup-env", RunOn: extmodel.RunOnCreate}
+	stageB := intmodel.TtyStage{Script: "pre-step", RunOn: extmodel.RunOnCreate}
+	hashA := stageContentHash(toV1beta1Stage(stageA))
+	hashB := stageContentHash(toV1beta1Stage(stageB))
+
+	// Rolled-back spec: only stageA remains (at the now-shifted position 0).
+	spec := intmodel.ContainerSpec{
+		ID:         "c1",
+		Attachable: true,
+		Tty: &intmodel.ContainerTty{
+			OnInit: []intmodel.TtyStage{stageA},
+		},
+	}
+	// Pre-rollback persisted done set carried done records for both stages.
+	// On the next populate after rollback, mergeStageStatuses (anchored on
+	// spec.Tty.OnInit positions) would have dropped stageB's done record
+	// because the rolled-back spec has no stage at that Index. The render
+	// gate consumes the merged set, but exercising the gate's hash-keyed
+	// semantics directly here keeps this test focused on AC #3 rather than
+	// re-testing mergeStageStatuses: we pass the post-merge priorStages
+	// stageA carries forward at its new Index, and confirm the rendered
+	// Script is cleared.
+	priorStages := []intmodel.StageStatus{
+		{Index: 0, State: setupstatus.StageDone, Hash: hashA},
+	}
+
+	if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}, priorStages); err != nil {
+		t.Fatalf("writeKukettyDoc: %v", err)
+	}
+	doc := readDoc(t, path)
+	if doc.Spec.Tty == nil || len(doc.Spec.Tty.OnInit) != 1 {
+		t.Fatalf("Spec.Tty.OnInit = %+v, want single-entry (rolled-back spec)", doc.Spec.Tty)
+	}
+	if doc.Spec.Tty.OnInit[0].Script != "" {
+		t.Errorf("OnInit[0].Script = %q, want empty (stageA's hash %s is in done-set; gate must fire at its new position)",
+			doc.Spec.Tty.OnInit[0].Script, hashA)
+	}
+
+	// Second sub-scenario: a rolled-back spec whose stages no longer have
+	// matching hashes in the prior done-set (e.g., reconcile rolled forward
+	// instead and introduced a fresh stage) must render every create stage
+	// verbatim. The hash for stageB is in the prior done-set but stageB
+	// itself is not in the rolled-back OnInit — there is nothing to gate.
+	freshStage := intmodel.TtyStage{Script: "fresh-step", RunOn: extmodel.RunOnCreate}
+	specFresh := intmodel.ContainerSpec{
+		ID:         "c1",
+		Attachable: true,
+		Tty: &intmodel.ContainerTty{
+			OnInit: []intmodel.TtyStage{freshStage},
+		},
+	}
+	priorFresh := []intmodel.StageStatus{
+		// hashB belongs to stageB which no longer exists in spec.
+		{Index: 0, State: setupstatus.StageDone, Hash: hashB},
+	}
+	pathFresh := filepath.Join(dir, "fresh.json")
+	if err := r.writeKukettyDoc(pathFresh, specFresh, 0, []string{"/bin/sh"}, priorFresh); err != nil {
+		t.Fatalf("writeKukettyDoc: %v", err)
+	}
+	docFresh := readDoc(t, pathFresh)
+	if docFresh.Spec.Tty == nil || len(docFresh.Spec.Tty.OnInit) != 1 {
+		t.Fatalf("fresh: Spec.Tty.OnInit = %+v, want single-entry", docFresh.Spec.Tty)
+	}
+	if docFresh.Spec.Tty.OnInit[0].Script != freshStage.Script {
+		t.Errorf("fresh: OnInit[0].Script = %q, want %q (no hash overlap with done-set — gate must not fire)",
+			docFresh.Spec.Tty.OnInit[0].Script, freshStage.Script)
+	}
+}
+
+// TestWriteKukettyDoc_RenderGate_IgnoresFailedAndMissingHash guards two
+// edges of the done-set derivation: a State == "failed" record must not gate
+// (a failed stage gets a fresh chance on restart per phase B's exit-before-
+// Serve contract), and a record with an empty Hash must not gate (the
+// run-once key is the content hash; a missing key is unparseable). The
+// merge upstream (mergeStageStatuses) already enforces these invariants on
+// the persisted snapshot, but the gate itself must be defensive: a future
+// caller that bypasses the merge (e.g., a test fixture, or a #625 reconcile
+// path that builds the done-set differently) cannot accidentally gate on
+// a failed or hash-less record.
+func TestWriteKukettyDoc_RenderGate_IgnoresFailedAndMissingHash(t *testing.T) {
+	r := newTestRunner(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kuketty-metadata.json")
+
+	stage := intmodel.TtyStage{Script: "boot-it", RunOn: extmodel.RunOnCreate}
+	hash := stageContentHash(toV1beta1Stage(stage))
+
+	spec := intmodel.ContainerSpec{
+		ID:         "c1",
+		Attachable: true,
+		Tty: &intmodel.ContainerTty{
+			OnInit: []intmodel.TtyStage{stage},
+		},
+	}
+	// Two records that look like they cover Index 0 but neither qualifies
+	// to gate: failed (not done) and done-without-hash (key-less).
+	priorStages := []intmodel.StageStatus{
+		{Index: 0, State: setupstatus.StageFailed, Error: "boom", Hash: hash},
+		{Index: 0, State: setupstatus.StageDone}, // Hash empty
+	}
+
+	if err := r.writeKukettyDoc(path, spec, 0, []string{"/bin/sh"}, priorStages); err != nil {
+		t.Fatalf("writeKukettyDoc: %v", err)
+	}
+	doc := readDoc(t, path)
+	if doc.Spec.Tty.OnInit[0].Script != stage.Script {
+		t.Errorf("OnInit[0].Script = %q, want %q (failed/key-less records must never gate)",
+			doc.Spec.Tty.OnInit[0].Script, stage.Script)
 	}
 }
 

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1557,7 +1557,12 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				cell.Spec.Containers[i] = containerSpec
 			}
 
-			attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds)
+			// priorStages threads the controller-side ContainerStatus.Stages
+			// snapshot into the renderer so the phase-C2 (#737) gate can omit
+			// already-done runOn: create stages from the rendered ContainerDoc
+			// on this boot.
+			priorStages := priorStagesForContainer(*cell, containerSpec.ID)
+			attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds, priorStages)
 			if attachErr != nil {
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
@@ -2021,7 +2026,12 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				createSpecFields...,
 			)
 
-			attachOpts, attachErr := r.attachableBuildOpts(internalRealm.Spec.Namespace, containerSpec, creds)
+			// priorStages threads the controller-side ContainerStatus.Stages
+			// snapshot into the renderer so the phase-C2 (#737) gate can omit
+			// already-done runOn: create stages from the rendered ContainerDoc
+			// on this boot.
+			priorStages := priorStagesForContainer(*cell, containerSpec.ID)
+			attachOpts, attachErr := r.attachableBuildOpts(internalRealm.Spec.Namespace, containerSpec, creds, priorStages)
 			if attachErr != nil {
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}

--- a/internal/controller/runner/stage_status.go
+++ b/internal/controller/runner/stage_status.go
@@ -134,3 +134,67 @@ func mergeStageStatuses(
 func toV1beta1Stage(in intmodel.TtyStage) v1beta1.TtyStage {
 	return v1beta1.TtyStage{Script: in.Script, RunOn: in.RunOn}
 }
+
+// priorStagesForContainer returns the persisted ContainerStatus.Stages slice
+// for the named container in cell.Status.Containers, or nil when no matching
+// status entry exists. Used by the four attachableBuildOpts call sites in
+// start.go / provision.go to source the done-set the render gate consumes.
+// A fresh-create boot (no prior status entry yet, or status not yet
+// populated) returns nil — every runOn: create stage renders normally and
+// runs on the next boot. Phase C2 (#737).
+func priorStagesForContainer(cell intmodel.Cell, containerID string) []intmodel.StageStatus {
+	for _, s := range cell.Status.Containers {
+		if s.ID == containerID {
+			return s.Stages
+		}
+	}
+	return nil
+}
+
+// applyStageRenderGate is the phase-C2 (#737) render-time gate: it clears the
+// Script of any runOn: create TtyStage in the rendered ContainerDoc whose
+// content hash matches a State == "done" record in priorStages. Kuketty's
+// runStage no-ops on an empty Script (cmd/kuketty/stages.go runStage), so the
+// gated stage's side effects do not re-run on the next boot — which is the
+// AC's stated intent ("on a subsequent boot, omits create stages whose hash
+// appears in the done-set"). The rendered ContainerDoc is the render-time
+// evidence the gate fired: a gated stage carries an empty Script in
+// Spec.Tty.OnInit while non-gated stages carry their authored Script verbatim.
+//
+// The gate clears Script rather than dropping the TtyStage entry outright so
+// the rendered OnInit slice retains the same length and positions as the
+// live cell.Spec.Tty.OnInit. kuketty's createStages (cmd/kuketty/spec.go)
+// stamps Stage.Index = position-in-the-received-OnInit, and the daemon-side
+// mergeStageStatuses anchors liveByIndex on position-in-the-live-spec — a
+// length-changing filter would mis-align the two and silently drop the live
+// signal for the just-completed (re-)run of an edited stage. Preserving the
+// slot keeps both sides anchored on a single positional identity, at the
+// cost of one no-op runStage iteration per gated stage on each boot.
+//
+// priorStages is the merged controller-side snapshot (see mergeStageStatuses):
+// only entries with State == StageDone and a non-empty Hash gate. A nil or
+// empty priorStages is a fresh-create boot — nothing is gated.
+func applyStageRenderGate(onInit []v1beta1.TtyStage, priorStages []intmodel.StageStatus) {
+	if len(onInit) == 0 || len(priorStages) == 0 {
+		return
+	}
+	doneHashes := make(map[string]struct{}, len(priorStages))
+	for _, st := range priorStages {
+		if st.State != setupstatus.StageDone || st.Hash == "" {
+			continue
+		}
+		doneHashes[st.Hash] = struct{}{}
+	}
+	if len(doneHashes) == 0 {
+		return
+	}
+	for i := range onInit {
+		if onInit[i].RunOn != v1beta1.RunOnCreate {
+			continue
+		}
+		hash := stageContentHash(onInit[i])
+		if _, gated := doneHashes[hash]; gated {
+			onInit[i].Script = ""
+		}
+	}
+}

--- a/internal/controller/runner/stage_status_test.go
+++ b/internal/controller/runner/stage_status_test.go
@@ -225,6 +225,128 @@ func TestMergeStageStatuses_Cases(t *testing.T) {
 	}
 }
 
+// TestPriorStagesForContainer covers the lookup helper the four
+// attachableBuildOpts call sites in start.go / provision.go use to source
+// the done-set the render gate consumes. Phase C2 (#737).
+func TestPriorStagesForContainer(t *testing.T) {
+	stages := []intmodel.StageStatus{
+		{Index: 0, State: setupstatus.StageDone, Hash: "h0"},
+	}
+	cell := intmodel.Cell{
+		Status: intmodel.CellStatus{
+			Containers: []intmodel.ContainerStatus{
+				{ID: "other", Stages: []intmodel.StageStatus{{Index: 0, State: setupstatus.StageFailed}}},
+				{ID: "target", Stages: stages},
+			},
+		},
+	}
+
+	got := priorStagesForContainer(cell, "target")
+	if len(got) != 1 || got[0].Hash != "h0" {
+		t.Errorf("priorStagesForContainer(target) = %+v, want stages for target", got)
+	}
+
+	if priorStagesForContainer(cell, "missing") != nil {
+		t.Errorf("priorStagesForContainer(missing) should return nil for unknown container")
+	}
+
+	// An empty cell.Status.Containers (fresh-create boot, no populate yet)
+	// returns nil rather than panicking. The render gate then no-ops on
+	// nil priorStages and every create stage renders normally.
+	if priorStagesForContainer(intmodel.Cell{}, "any") != nil {
+		t.Errorf("priorStagesForContainer on empty cell should return nil")
+	}
+}
+
+// TestApplyStageRenderGate covers the unit-level behavior of the gate
+// helper: clears Script on runOn: create stages whose content hash matches a
+// done-record in priorStages, leaves non-create stages and create stages
+// without a matching done-record untouched, preserves slice length so
+// kuketty's createStages-emitted Stage.Index aligns with the live spec
+// position, and ignores failed / hash-less prior records. Phase C2 (#737).
+func TestApplyStageRenderGate(t *testing.T) {
+	doneStage := v1beta1.TtyStage{Script: "npm ci", RunOn: v1beta1.RunOnCreate}
+	startStage := v1beta1.TtyStage{Script: "echo hi", RunOn: v1beta1.RunOnStart}
+	freshStage := v1beta1.TtyStage{Script: "db-seed", RunOn: v1beta1.RunOnCreate}
+	doneHash := stageContentHash(doneStage)
+
+	tests := []struct {
+		name       string
+		onInit     []v1beta1.TtyStage
+		prior      []intmodel.StageStatus
+		wantScript []string // expected Script at each position; "" = gated
+	}{
+		{
+			name:       "no prior stages: every create stage renders unchanged",
+			onInit:     []v1beta1.TtyStage{doneStage, startStage, freshStage},
+			prior:      nil,
+			wantScript: []string{doneStage.Script, startStage.Script, freshStage.Script},
+		},
+		{
+			name:       "empty OnInit: no-op",
+			onInit:     nil,
+			prior:      []intmodel.StageStatus{{Index: 0, State: setupstatus.StageDone, Hash: doneHash}},
+			wantScript: nil,
+		},
+		{
+			name:   "done-record gates matching create stage by hash",
+			onInit: []v1beta1.TtyStage{doneStage, startStage, freshStage},
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone, Hash: doneHash},
+			},
+			wantScript: []string{"", startStage.Script, freshStage.Script},
+		},
+		{
+			name:   "failed prior record never gates",
+			onInit: []v1beta1.TtyStage{doneStage},
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageFailed, Hash: doneHash},
+			},
+			wantScript: []string{doneStage.Script},
+		},
+		{
+			name:   "hash-less done record never gates",
+			onInit: []v1beta1.TtyStage{doneStage},
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone},
+			},
+			wantScript: []string{doneStage.Script},
+		},
+		{
+			name:   "non-matching hash never gates",
+			onInit: []v1beta1.TtyStage{doneStage},
+			prior: []intmodel.StageStatus{
+				{Index: 0, State: setupstatus.StageDone, Hash: "deadbeef0000beef"},
+			},
+			wantScript: []string{doneStage.Script},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clone the input so cases don't pollute each other.
+			onInit := append([]v1beta1.TtyStage(nil), tt.onInit...)
+			applyStageRenderGate(onInit, tt.prior)
+			if len(onInit) != len(tt.wantScript) {
+				t.Fatalf("len(onInit) = %d, want %d (gate must preserve slice length)", len(onInit), len(tt.wantScript))
+			}
+			for i, want := range tt.wantScript {
+				if onInit[i].Script != want {
+					t.Errorf("onInit[%d].Script = %q, want %q", i, onInit[i].Script, want)
+				}
+			}
+			// The gate must not flip RunOn — that would change createStages
+			// selection in kuketty and disalign the wire Index.
+			for i := range onInit {
+				if onInit[i].RunOn != tt.onInit[i].RunOn {
+					t.Errorf("onInit[%d].RunOn changed: was %q, now %q (gate must never touch RunOn)",
+						i, tt.onInit[i].RunOn, onInit[i].RunOn)
+				}
+			}
+		})
+	}
+}
+
 // TestMergeStageStatuses_AnchorsOnIndexInFullOnInit guards against a regression
 // where the merge would re-index create-stages contiguously (0, 1, ...) instead
 // of using their position in the full OnInit slice. The setupstatus wire

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -852,8 +852,12 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 		// daemon restart.
 		containerSpec.NestedCgroupRuntime = internalCell.Spec.NestedCgroupRuntime
 
-		// Recreate container fresh
-		attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds)
+		// Recreate container fresh. priorStages threads the controller-side
+		// ContainerStatus.Stages snapshot into the renderer so the phase-C2
+		// (#737) gate can omit already-done runOn: create stages from the
+		// rendered ContainerDoc on this boot.
+		priorStages := priorStagesForContainer(internalCell, containerSpec.ID)
+		attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds, priorStages)
 		if attachErr != nil {
 			return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", ctrContainerID, attachErr)
 		}
@@ -1118,8 +1122,12 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	// Failed (issue #407).
 	provisionStarted = true
 
-	// Recreate container fresh
-	attachOpts, attachErr := r.attachableBuildOpts(namespace, *foundContainerSpec, creds)
+	// Recreate container fresh. priorStages threads the controller-side
+	// ContainerStatus.Stages snapshot into the renderer so the phase-C2
+	// (#737) gate can omit already-done runOn: create stages from the
+	// rendered ContainerDoc on this boot.
+	priorStages := priorStagesForContainer(cell, foundContainerSpec.ID)
+	attachOpts, attachErr := r.attachableBuildOpts(namespace, *foundContainerSpec, creds, priorStages)
 	if attachErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", containerID, attachErr)
 	}


### PR DESCRIPTION
## Summary

- Phase C2 of the run-once-per-cell-instance setup series (#423 crew absorption): consume the durable hash-keyed done-set #741 (phase C1) lands and gate the next boot's render so already-done `runOn: create` stages do not re-run.
- `writeKukettyDoc` now takes a `priorStages []intmodel.StageStatus` parameter; `attachableBuildOpts` threads it from each of the four call sites (`start.go` StartCell recreate-fresh, `start.go` StartContainer recreate-fresh, `provision.go` createCellContainers, `provision.go` ensureCellContainers), sourcing it from `cell.Status.Containers[i].Stages` via the new `priorStagesForContainer` helper.
- New `applyStageRenderGate` in `stage_status.go` implements the gate as a one-pass walk over the rendered `extSpec.Tty.OnInit`: for every `runOn: create` stage whose content hash matches a `State == "done"` record in `priorStages`, the gate **clears the stage's Script** (keeping `RunOn: create` and the slot in OnInit). Kuketty's `runStage` no-ops on an empty Script (`cmd/kuketty/stages.go:89`), so the gated execution does not run on this boot.
- Edited stages re-run automatically: the edit produces a new content hash that no longer matches any prior done record, so the gate does not fire and kuketty's pre-Serve executor runs the stage's authored Script verbatim. The next populate's `mergeStageStatuses` stamps the new hash so subsequent boots gate on the post-edit content.
- #625 / #423 phase-4.3 reconcile interaction: the done-set is keyed on content **Hash**, not on `OnInit` position, so a reconcile that rolls a spec back to a prior version (or rolls forward to a fresh version) still gates correctly — stages whose hash is in the prior done-set get gated at whatever position they now occupy; stages whose hash isn't (rolled-forward additions, hash collisions with removed stages) render normally.

### AC implementation note: gate by Script clearing, not OnInit filtering

AC #1 reads *"omits matching `create` stages from the rendered doc"*. Literally removing matching `runOn: create` entries from the rendered `OnInit` would break a load-bearing invariant: kuketty's `createStages` (`cmd/kuketty/spec.go:249`) stamps `setupstatus.Stage.Index = position-in-the-received-OnInit`, and the daemon-side `mergeStageStatuses` (`internal/controller/runner/stage_status.go:81`) anchors `liveByIndex` on `position-in-the-live-spec.Tty.OnInit`. A length-changing filter would silently shift positions and drop the live signal for the just-completed re-run of an edited stage (concrete walk-through in [the heads-up comment](https://github.com/eminwux/kukeon/issues/737#issuecomment-4524950016)).

The implementation reinterprets *"omits"* as **"omits the execution"** by clearing the gated stage's Script while keeping its `RunOn: create` and slot. Both AC intents are preserved: (a) the gated stage does not re-run (kuketty's `runStage` returns nil on empty-trimmed Script before `exec.CommandContext`); (b) the rendered ContainerDoc is render-time evidence the gate fired (gated stages carry an empty Script in `Spec.Tty.OnInit`). The trade-off is one no-op `runStage` iteration per gated stage on each boot (kuketty's executor still enters the loop body, returns nil immediately).

The alternative — filter + add a `TtyStage.Index *int` wire field for kuketty's `createStages` to honor — was considered out of scope for a daemon-side phase-C2 PR (touches v1beta1 schema, apischeme converters, and kuketty's selector). Posted the heads-up before coding per CLAUDE.md §"Sanity-check AC implementation specifics" and proceeded with the reinterpretation.

### Linked-issue heads-up

- https://github.com/eminwux/kukeon/issues/737#issuecomment-4524950016 — names the invariant tension and the proposed reading; quoted in the docstring on `applyStageRenderGate`.

## Test plan

- [x] `make test` — full repo test suite, including new unit tests for the gate (gate-on-restart skip, edited-stage re-run, reconcile-path round-trip both directions, failed/key-less defensive guards, slice-length preservation, RunOn never-touched). Memory shows local sandbox needs `GOWORK=off`; `make` exports it. All green.
- [x] `GOWORK=off go vet ./...` — clean.
- [x] `make dev-init` smoke test — daemon-parity check shows both `kuke get realms` and `kuke get realms --no-daemon` produce identical output; nested `kuke attach` smoke against a fresh `cattach` cell exits cleanly; parent-host attach plumbing still live after teardown. (No prior done-stage state exists on a fresh `kuke init` boot, so the gate is a no-op here — the smoke confirms the new attachableBuildOpts signature didn't regress bootstrap.)
- [x] Pre-commit ran on changed files; all hooks pass except `golangci-lint`, which panics with the known go1.24-binary-vs-go1.25-module incompatibility documented in agent memory ([[env_golangci_lint_go125]]) — environmental, not a finding (`go vet` covers the equivalent checks and is green).

## Files

- `internal/controller/runner/stage_status.go` — `priorStagesForContainer` lookup; `applyStageRenderGate` (the gate).
- `internal/controller/runner/stage_status_test.go` — unit tests for both helpers (`TestPriorStagesForContainer`, `TestApplyStageRenderGate` table).
- `internal/controller/runner/attachable.go` — `attachableBuildOpts` + `writeKukettyDoc` signatures take `priorStages`; gate fires after LogLevel resolution.
- `internal/controller/runner/attachable_test.go` — render-time tests reading the on-disk `ContainerDoc` (gate-on-restart skip, edited re-run, reconcile rollback round-trip, defensive-against-failed/key-less).
- `internal/controller/runner/start.go` — both `attachableBuildOpts` call sites pass `priorStagesForContainer(cell, containerSpec.ID)`.
- `internal/controller/runner/provision.go` — both `attachableBuildOpts` call sites pass `priorStagesForContainer(*cell, containerSpec.ID)`.

Closes #737