### PR TITLE
refactor(runner): unify reserved-subdir exclusion across subtree walkers

### DIFF
--- a/internal/controller/runner/blueprint.go
+++ b/internal/controller/runner/blueprint.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -142,7 +141,7 @@ func (r *Exec) collectBlueprintSubtree(out *[]intmodel.CellBlueprint, realm, spa
 		}
 	}
 
-	spaces, err := r.blueprintChildScopeNames(fs.RealmMetadataDir(r.opts.RunPath, realm), space)
+	spaces, err := r.childScopeNames(fs.RealmMetadataDir(r.opts.RunPath, realm), space)
 	if err != nil {
 		return err
 	}
@@ -153,7 +152,7 @@ func (r *Exec) collectBlueprintSubtree(out *[]intmodel.CellBlueprint, realm, spa
 			}
 		}
 
-		stacks, stErr := r.blueprintChildScopeNames(fs.SpaceMetadataDir(r.opts.RunPath, realm, sp), stack)
+		stacks, stErr := r.childScopeNames(fs.SpaceMetadataDir(r.opts.RunPath, realm, sp), stack)
 		if stErr != nil {
 			return stErr
 		}
@@ -164,47 +163,6 @@ func (r *Exec) collectBlueprintSubtree(out *[]intmodel.CellBlueprint, realm, spa
 		}
 	}
 	return nil
-}
-
-// blueprintChildScopeNames returns the child-scope subdirectory names directly
-// under dir, excluding both reserved resource subdirectories (secrets/ and
-// blueprints/) so neither is mistaken for a child space or stack. When want is
-// non-empty it filters to that single child (returned only if it exists). A
-// missing dir yields no children, matching the list verbs' "no match ⇒ empty".
-func (r *Exec) blueprintChildScopeNames(dir, want string) ([]string, error) {
-	if strings.TrimSpace(want) != "" {
-		child := filepath.Join(dir, want)
-		info, err := os.Stat(child)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("failed to stat scope dir %q: %w", child, err)
-		}
-		if !info.IsDir() {
-			return nil, nil
-		}
-		return []string{want}, nil
-	}
-
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read scope dir %q: %w", dir, err)
-	}
-	var names []string
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		if entry.Name() == consts.KukeonSecretsSubdir || entry.Name() == consts.KukeonBlueprintsSubdir {
-			continue
-		}
-		names = append(names, entry.Name())
-	}
-	return names, nil
 }
 
 // collectBlueprintsInScope appends the metadata of every CellBlueprint stored

--- a/internal/controller/runner/blueprint_test.go
+++ b/internal/controller/runner/blueprint_test.go
@@ -259,21 +259,27 @@ func TestListBlueprints_SubtreeFilterSemantics(t *testing.T) {
 }
 
 // TestListBlueprints_IgnoresReservedSubdirs confirms the walk never mistakes a
-// sibling secrets/ or blueprints/ reserved subdirectory for a child space or
-// stack, and that an in-flight temp file is skipped.
+// sibling secrets/, blueprints/, or configs/ reserved subdirectory for a child
+// space or stack, and that an in-flight temp file is skipped. The configs/
+// exclusion is the case the old blueprintChildScopeNames missed (it predated
+// #624's configs/ subdir) — issue #734 unified all three walkers on the same
+// reserved-subdir set, so listing blueprints across the realm subtree must not
+// recurse into the realm's own configs/ dir as a phantom space.
 func TestListBlueprints_IgnoresReservedSubdirs(t *testing.T) {
 	runPath := t.TempDir()
 	r := newMetadataTestExec(t, runPath, time.Now())
 
 	seedBlueprint(t, r, "realm-bp", "default", "", "")
-	// A realm-scoped secret creates default/secrets/; a realm-scoped blueprint
-	// already created default/blueprints/. Neither must surface as a space.
+	// A realm-scoped secret creates default/secrets/; a realm-scoped config
+	// creates default/configs/; a realm-scoped blueprint already created
+	// default/blueprints/. None must surface as a child space.
 	if _, err := r.WriteSecret(intmodel.Secret{
 		Metadata: intmodel.SecretMetadata{Name: "tok", Realm: "default"},
 		Spec:     intmodel.SecretSpec{Data: "v"},
 	}); err != nil {
 		t.Fatalf("seed WriteSecret error = %v", err)
 	}
+	seedConfig(t, r, "cfg", "default", "", "")
 	// Drop an in-flight temp file alongside the realm blueprint; it must be
 	// skipped, not surfaced as a blueprint named ".blueprint-xyz.tmp".
 	tmpPath := fs.BlueprintPath(runPath, "default", "", "", ".blueprint-xyz.tmp")

--- a/internal/controller/runner/config.go
+++ b/internal/controller/runner/config.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -145,7 +144,7 @@ func (r *Exec) collectConfigSubtree(out *[]intmodel.CellConfig, realm, space, st
 		}
 	}
 
-	spaces, err := r.configChildScopeNames(fs.RealmMetadataDir(r.opts.RunPath, realm), space)
+	spaces, err := r.childScopeNames(fs.RealmMetadataDir(r.opts.RunPath, realm), space)
 	if err != nil {
 		return err
 	}
@@ -156,7 +155,7 @@ func (r *Exec) collectConfigSubtree(out *[]intmodel.CellConfig, realm, space, st
 			}
 		}
 
-		stacks, stErr := r.configChildScopeNames(fs.SpaceMetadataDir(r.opts.RunPath, realm, sp), stack)
+		stacks, stErr := r.childScopeNames(fs.SpaceMetadataDir(r.opts.RunPath, realm, sp), stack)
 		if stErr != nil {
 			return stErr
 		}
@@ -167,50 +166,6 @@ func (r *Exec) collectConfigSubtree(out *[]intmodel.CellConfig, realm, space, st
 		}
 	}
 	return nil
-}
-
-// configChildScopeNames returns the child-scope subdirectory names directly
-// under dir, excluding all three reserved resource subdirectories (secrets/,
-// blueprints/, configs/) so none is mistaken for a child space or stack. When
-// want is non-empty it filters to that single child (returned only if it
-// exists). A missing dir yields no children, matching the list verbs' "no match
-// ⇒ empty". Note this excludes configs/ as well as secrets/blueprints — a
-// reserved subdir at any scope level is never a child scope.
-func (r *Exec) configChildScopeNames(dir, want string) ([]string, error) {
-	if strings.TrimSpace(want) != "" {
-		child := filepath.Join(dir, want)
-		info, err := os.Stat(child)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("failed to stat scope dir %q: %w", child, err)
-		}
-		if !info.IsDir() {
-			return nil, nil
-		}
-		return []string{want}, nil
-	}
-
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read scope dir %q: %w", dir, err)
-	}
-	var names []string
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		switch entry.Name() {
-		case consts.KukeonSecretsSubdir, consts.KukeonBlueprintsSubdir, consts.KukeonConfigsSubdir:
-			continue
-		}
-		names = append(names, entry.Name())
-	}
-	return names, nil
 }
 
 // collectConfigsInScope appends the metadata of every CellConfig stored

--- a/internal/controller/runner/scope_children.go
+++ b/internal/controller/runner/scope_children.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/consts"
+)
+
+// reservedScopeSubdirs is the single source of truth for the per-scope
+// subdirectory names that hold resources (not child scopes) under
+// <RunPath>/data/<realm>/[<space>/[<stack>/[<cell>/]]]: secrets/ (#619),
+// blueprints/ (#620), and configs/ (#624). The subtree-list walkers in
+// secret.go / blueprint.go / config.go enumerate child scopes by reading the
+// scope dir and must skip every entry in this set, otherwise a reserved
+// resource subdir would be mistaken for a phantom space/stack/cell.
+//
+// All three walkers consume this set via childScopeNames so a future reserved
+// subdir is added in exactly one place — the inconsistency that motivated
+// issue #734 (blueprintChildScopeNames missed configs/, secret childScopeNames
+// missed blueprints/ and configs/) reappears the moment any walker
+// re-implements its own exclusion list.
+var reservedScopeSubdirs = map[string]struct{}{
+	consts.KukeonSecretsSubdir:    {},
+	consts.KukeonBlueprintsSubdir: {},
+	consts.KukeonConfigsSubdir:    {},
+}
+
+// childScopeNames returns the child-scope subdirectory names directly under
+// dir, excluding every reserved resource subdirectory (see
+// reservedScopeSubdirs) so none is mistaken for a child space, stack, or cell.
+// When want is non-empty it is treated as a filter: only that child is
+// returned, and only if it exists as a directory. A missing dir yields no
+// children (graceful, matching the list verbs' "no filter match ⇒ empty"
+// contract).
+//
+// All three resource-subtree walkers (ListSecrets, ListBlueprints,
+// ListConfigs) share this implementation. The want filter is honored even
+// when it names a reserved subdir — that mirrors the prior behavior of the
+// three near-duplicate helpers and lets a future walker over a reserved
+// subdir reuse this same routine; an empty-want walk over a regular scope dir
+// never surfaces reserved subdirs.
+func (r *Exec) childScopeNames(dir, want string) ([]string, error) {
+	if strings.TrimSpace(want) != "" {
+		child := filepath.Join(dir, want)
+		info, err := os.Stat(child)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to stat scope dir %q: %w", child, err)
+		}
+		if !info.IsDir() {
+			return nil, nil
+		}
+		return []string{want}, nil
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read scope dir %q: %w", dir, err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, reserved := reservedScopeSubdirs[entry.Name()]; reserved {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}

--- a/internal/controller/runner/secret.go
+++ b/internal/controller/runner/secret.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -188,47 +187,6 @@ func (r *Exec) collectSecretSubtree(out *[]intmodel.Secret, realm, space, stack,
 		}
 	}
 	return nil
-}
-
-// childScopeNames returns the child-resource subdirectory names directly under
-// dir, excluding the reserved secrets/ subdirectory. When want is non-empty it
-// is treated as a filter: only that child is returned, and only if it exists.
-// A missing dir yields no children (graceful, matching the list verbs' "no
-// filter match ⇒ empty" contract).
-func (r *Exec) childScopeNames(dir, want string) ([]string, error) {
-	if strings.TrimSpace(want) != "" {
-		child := filepath.Join(dir, want)
-		info, err := os.Stat(child)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("failed to stat scope dir %q: %w", child, err)
-		}
-		if !info.IsDir() {
-			return nil, nil
-		}
-		return []string{want}, nil
-	}
-
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to read scope dir %q: %w", dir, err)
-	}
-	var names []string
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		if entry.Name() == consts.KukeonSecretsSubdir {
-			continue
-		}
-		names = append(names, entry.Name())
-	}
-	return names, nil
 }
 
 // collectSecretsInScope appends the metadata of every Secret stored directly at

--- a/internal/controller/runner/secret_test.go
+++ b/internal/controller/runner/secret_test.go
@@ -298,6 +298,50 @@ func TestListSecrets_SkipsTempFiles(t *testing.T) {
 	}
 }
 
+// TestListSecrets_IgnoresReservedSubdirs confirms the walk never mistakes a
+// sibling secrets/, blueprints/, or configs/ reserved subdirectory for a child
+// space, stack, or cell. The blueprints/ and configs/ exclusions are the cases
+// the old secret childScopeNames missed (it only skipped secrets/); issue #734
+// unified all three walkers on the same reserved-subdir set, so a phantom
+// "blueprints" or "configs" space must never surface from the realm subtree
+// walk.
+func TestListSecrets_IgnoresReservedSubdirs(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	// A realm-scoped secret creates default/secrets/; a realm-scoped blueprint
+	// creates default/blueprints/; a realm-scoped config creates
+	// default/configs/. None must surface as a child space.
+	if _, err := r.WriteSecret(intmodel.Secret{
+		Metadata: intmodel.SecretMetadata{Name: "realm-tok", Realm: "default"},
+		Spec:     intmodel.SecretSpec{Data: "v"},
+	}); err != nil {
+		t.Fatalf("seed WriteSecret error = %v", err)
+	}
+	seedBlueprint(t, r, "bp", "default", "", "")
+	seedConfig(t, r, "cfg", "default", "", "")
+	// Drop an in-flight temp file alongside the realm secret; it must be
+	// skipped, not surfaced as a secret named ".secret-xyz.tmp".
+	dir := fs.SecretsDir(runPath, "default", "", "", "")
+	if err := os.WriteFile(dir+"/.secret-xyz.tmp", []byte("partial"), 0o600); err != nil {
+		t.Fatalf("seed temp file error = %v", err)
+	}
+
+	out, err := r.ListSecrets("", "", "", "")
+	if err != nil {
+		t.Fatalf("ListSecrets() error = %v", err)
+	}
+	got := make([]string, 0, len(out))
+	for _, s := range out {
+		got = append(got, s.Metadata.Realm+"/"+s.Metadata.Space+"/"+s.Metadata.Stack+"/"+s.Metadata.Cell+"/"+s.Metadata.Name)
+	}
+	sort.Strings(got)
+	want := []string{"default////realm-tok"}
+	if !equalStrings(got, want) {
+		t.Errorf("ListSecrets(all) = %v, want %v (reserved subdirs + temp file must be ignored)", got, want)
+	}
+}
+
 // TestDeleteSecret removes the bytes file and reports ErrSecretNotFound on a
 // second delete of the same name (issue #622).
 func TestDeleteSecret(t *testing.T) {


### PR DESCRIPTION
## Summary

- Collapses the three near-duplicate child-scope walkers (`childScopeNames` in `secret.go`, `blueprintChildScopeNames` in `blueprint.go`, `configChildScopeNames` in `config.go`) onto a single shared `(r *Exec) childScopeNames(dir, want)` in a new `internal/controller/runner/scope_children.go`, with one `reservedScopeSubdirs` set as the source of truth for the per-scope reserved resource subdirectories to skip.
- Fixes the inconsistency #734 named: the blueprint walker missed `configs/` (predated #624's configs/ subdir); the secret walker missed both `blueprints/` and `configs/`. Both now exclude all three.
- Refactor only — behavior previously was benign in steady state (a phantom descent finds nothing since the reserved dirs hold files, not the walker's own resource subdir), but the inconsistency was a latent trap for a future reserved subdir or a layout change that nested matching subdirs. After this, a fourth reserved resource is added in exactly one place: `reservedScopeSubdirs`.

## Test plan

- [x] `make test` — full repo suite, including the new + broadened regression tests:
  - **new** `TestListSecrets_IgnoresReservedSubdirs` — seeds a realm secret, blueprint, and config; asserts `ListSecrets("")` yields only the secret (the blueprints/ + configs/ subdirs were previously fall-through to a phantom space).
  - **broadened** `TestListBlueprints_IgnoresReservedSubdirs` — now also seeds a realm config so the configs/ exclusion is pinned by `ListBlueprints` (was the case the old `blueprintChildScopeNames` missed).
  - **unchanged** `TestListConfigs_IgnoresReservedSubdirs` — the original reference case from #644, still passing.
- [x] `GOWORK=off go build ./...` — clean.
- [x] `GOWORK=off go vet ./...` — clean.
- [x] `pre-commit run --files <changed>` — all hooks pass except `golangci-lint`, which panics with the known go1.24-binary-vs-go1.25-module incompatibility documented in agent memory; environmental, not a finding (`go vet` covers the equivalent checks and is green).
- [ ] `make dev-init` smoke test — not run; this is a pure internal refactor of subtree-list walkers (no build path, daemon, or `/opt/kukeon` touch), so CLAUDE.md's smoke-when-touching-daemon-or-build clause does not apply.

## AC mapping

- [x] `blueprintChildScopeNames` excludes `configs/` — folded into the shared helper.
- [x] secret `childScopeNames` excludes `blueprints/` and `configs/` — folded into the shared helper.
- [x] The three walkers share one exclusion helper (`reservedScopeSubdirs` + `(r *Exec) childScopeNames`).
- [x] Regression tests for `kuke get secrets` / `kuke get blueprints` against sibling reserved subdirs.

## Files

- `internal/controller/runner/scope_children.go` — **new**; `reservedScopeSubdirs` map and the shared `(r *Exec) childScopeNames(dir, want)` method.
- `internal/controller/runner/secret.go` — deletes the local `childScopeNames`; drops the now-unused `consts` import. Call sites in `collectSecretSubtree` resolve to the shared method by name.
- `internal/controller/runner/blueprint.go` — deletes `blueprintChildScopeNames`; updates the two call sites in `collectBlueprintSubtree` to `r.childScopeNames`; drops the now-unused `consts` import.
- `internal/controller/runner/config.go` — deletes `configChildScopeNames`; updates the two call sites in `collectConfigSubtree` to `r.childScopeNames`; drops the now-unused `consts` import.
- `internal/controller/runner/secret_test.go` — adds `TestListSecrets_IgnoresReservedSubdirs`.
- `internal/controller/runner/blueprint_test.go` — broadens `TestListBlueprints_IgnoresReservedSubdirs` to also seed a realm config (pinning the configs/ exclusion the old helper missed).

Closes #734