### PR TITLE
docs(manifests): note runOn: create needs a persistent writable mount

### DIFF
--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -228,9 +228,15 @@ Each entry in `tty.onInit` is a single init-script stage.
 | Field    | Type   | Required | Description                                                                                                                                                                                                                                                                                      |
 | -------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `script` | string | no       | Shell script body for the stage.                                                                                                                                                                                                                                                                 |
-| `runOn`  | string | no       | When the stage runs. Empty or `start` forwards the script to sbsh's onInit, so it runs in the wrapped shell on every boot. `create` routes the script into kuketty's pre-Serve executor, where it runs once to completion before the workload starts. Any other value is rejected at apply time. |
+| `runOn`  | string | no       | When the stage runs. Empty or `start` forwards the script to sbsh's onInit, so it runs in the wrapped shell on every boot. `create` routes the script into kuketty's pre-Serve executor, where it runs once to completion before the workload starts. A stage with `runOn: create` requires the container to declare at least one persistent writable mount (a `spec.volumes` entry of `kind: bind` that is not `readOnly`); otherwise the stage's side effects evaporate on the next recreate while the run-once gate would silently report `done`, and apischeme rejects the spec at apply time. Any other value is rejected at apply time. |
 
 ```yaml
+volumes:
+  - kind: bind
+    source: /srv/workspace
+    target: /workspace
+    # runOn: create stages below require a persistent writable mount so
+    # their side effects survive container recreate.
 tty:
   prompt: "claude> "
   onInit:


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #740.
Mode: best-effort — the issue body identified the file (`docs/site/manifests/container.md`) and section (§TtyStage) but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria.

## Files changed
- `docs/site/manifests/container.md` — `### TtyStage` (the `runOn` table row and the YAML example beneath it)

## Editorial choices
- The new sentence in the `runOn` table row preserves the existing row's "Any other value is rejected at apply time." closing and inserts the precondition + rationale before it, so the row keeps a single uniform voice. Wording leans on the issue's Proposal phrasing ("persistent writable mount … a `spec.volumes` entry of `kind: bind` that is not `readOnly`") rather than the broader apischeme definition (any non-`tmpfs` `kind`), to match the AC's specific framing.
- Extended the existing partial-snippet YAML (which previously showed only the `tty:` block) with a sibling `volumes:` entry rather than promoting it to a full top-level `ContainerSpec`. This keeps the example consistent with neighbouring partial snippets in the file (e.g. the `repos:`, `secrets:`, and `git:` examples) while still being shape-valid for the apischeme validator: a single `kind: bind`, non-`readOnly` mount satisfies the new check.
- Added an inline YAML comment on the `volumes:` entry to tie the example back to the table row, since the example is the operator's copy-paste path.
- AC3 ("any other doc reference to `runOn: create` carries the same precondition or links back to the TtyStage section") is satisfied vacuously: `grep -rn 'runOn' docs/site/` returns only the three lines on `docs/site/manifests/container.md` that this PR already touches (the table row plus the two YAML example lines). No other doc page references `runOn`.

## Acceptance criteria check
- [x] The TtyStage `runOn` reference text mentions the persistent-writable-mount precondition with a one-sentence rationale — done in the updated table row.
- [x] The YAML example next to the table is itself a valid `ContainerSpec` the new validator accepts (carries a `volumes:` entry with `kind: bind`) — done.
- [x] Any other doc reference to `runOn: create` carries the same precondition or links back to the TtyStage section — vacuously satisfied; no other doc references exist.

Closes #740