### PR TITLE
chore: scope pre-commit golangci-lint to root module via GOWORK=off

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,14 @@ repos:
     rev: v2.6.2
     hooks:
       - id: golangci-lint
+        # cmd/kukebuild lives in its own go 1.25 module (#662 module split).
+        # v2.6.2's binary is built with go 1.24; with go.work enabled, the
+        # workspace package loader pulls kukebuild into analysis and the
+        # type checker panics ("package requires newer Go version go1.25").
+        # Disable workspace mode so the hook only sees the root module
+        # (go 1.24.5). cmd/kukebuild stays unlinted by pre-commit until
+        # golangci-lint is bumped to a release built with go 1.25+ (#693).
+        entry: env GOWORK=off golangci-lint run --new-from-rev HEAD --fix
         args: ["./..."]
 
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
## Summary

- `.pre-commit-config.yaml`'s golangci-lint hook (pinned at v2.6.2, built with go 1.24) was crashing the type checker with `package requires newer Go version go1.25 (application built with go1.24)` whenever it was invoked on any change while `go.work` was enabled. The workspace package loader was pulling `cmd/kukebuild` (go 1.25.5, #662 module split) into analysis even though `./...` from the root module doesn't list those packages.
- Closest to the issue's **option 3** (exclude `cmd/kukebuild/`). The mechanism is "disable workspace mode" (`env GOWORK=off`) rather than enumerating root packages, because explicit package enumeration still panics — the workspace loader pulls kukebuild in transitively even when only root patterns are passed. `GOWORK=off` is the smallest change that actually stops the analyzer walking into the go 1.25 module.
- Inline comment in the hook references the #662 module split and points at #693 for the upgrade path (bump golangci-lint to a release built with go 1.25+, then drop `GOWORK=off` and add a second hook for kukebuild).
- Root-module lint behavior is unchanged: same binary, same args, same `./...`, same `.golangci.yml` config — only the workspace mode bit flips.
- The `entry:` override drifts from upstream's `golangci-lint run --new-from-rev HEAD --fix` if that string ever changes; the comment block makes the divergence obvious to the next reader.
- This is dev-loop friction only: `.github/workflows/test.yaml`'s `paths:` filter excludes `.pre-commit-config.yaml`, so this PR will not trigger CI.

## Test plan

- [x] `pre-commit run golangci-lint --files cmd/kukebuild/build.go` exits cleanly (AC1) — was a multi-thousand-line panic stack, now `Passed` in ~5s.
- [x] `pre-commit run golangci-lint --files cmd/kuke/apply/apply.go` still `Passed` (root-module lint unchanged, AC3).
- [x] `pre-commit run golangci-lint --all-files` `Passed` (no new findings surfaced anywhere).
- [x] Approach documented inline in `.pre-commit-config.yaml` referencing #662 (AC2).
- [ ] `make test` / `make e2e` not run — `.pre-commit-config.yaml` is not on CI's `paths:` trigger list and the diff touches zero Go code; the four pre-commit checks above cover the AC.

Closes #693