### PR TITLE
docs(manifests): add CellBlueprint + CellConfig reference pages

### DIFF
--- a/docs/site/manifests/blueprint.md
+++ b/docs/site/manifests/blueprint.md
@@ -1,0 +1,130 @@
+# CellBlueprint manifest
+
+```yaml
+apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: claude-code
+  realm: kuke-system # scope coordinates; deepest non-empty wins
+  # space: team-a    # optional — space-scoped
+  # stack: agents    # optional — stack-scoped (requires space)
+spec:
+  prefix: cc           # cell-name prefix; defaults to metadata.name
+  parameters:          # scalar ${KEY} substitutions
+    - name: MODEL
+      default: claude-sonnet-4-6
+  cell:
+    containers:
+      - id: agent
+        root: true
+        image: ghcr.io/example/agent:latest
+        # ... full container template ...
+```
+
+A `CellBlueprint` is a daemon-stored, parametrized cell template. It is the daemon-side analog of the user-local `CellProfile`: where a profile is materialized client-side by `kuke run -p`, a blueprint is written to daemon storage by `kuke apply` and run with `kuke run -b`, so it can be applied, scoped, listed, and referenced by a [`CellConfig`](config.md). A blueprint declares the cell template plus two fill channels — scalar `${KEY}` parameters resolved at run time and structural repo/secret slots a Config fills.
+
+See [`kuke run -b`](../cli/kuke-run.md) for the run-side verb and [`CellConfig`](config.md) for the identity binding that lets a blueprint stand up an idempotent, named cell rather than a fresh `<prefix>-<6hex>` one each invocation.
+
+## metadata
+
+A Blueprint is scopable at realm, space, or stack — never cell. A template scoped to a single cell is nonsensical: the blueprint exists to materialize cells, not to live inside one. The scope is the deepest non-empty coordinate, and a deeper coordinate may only be set when every shallower one is.
+
+| Field    | Type              | Required | Description                                                                |
+| -------- | ----------------- | -------- | -------------------------------------------------------------------------- |
+| `name`   | string            | yes      | The blueprint's name, unique within its scope.                             |
+| `realm`  | string            | yes      | The always-required top-level scope coordinate.                            |
+| `space`  | string            | no       | When set, scopes the blueprint to a space within `realm`.                  |
+| `stack`  | string            | no       | When set, scopes the blueprint to a stack within `space` (requires space). |
+| `labels` | map[string]string | no       | Copied onto every cell materialized from this blueprint, in addition to the `kukeon.io/blueprint` back-reference label. |
+
+## spec
+
+### `spec.prefix` (string, optional)
+
+Cell-name prefix used when generating the `<prefix>-<6hex>` name on each `kuke run -b`. Defaults to `metadata.name` when unset.
+
+### `spec.parameters[]` (list, optional)
+
+Declared `${KEY}` substitution variables the cell body references. `kuke run -b` resolves each parameter against `--param K=V`, the parameter's `default`, and (when permitted) the caller's environment, in that order. An undeclared `--param` errors at call time so typos surface immediately. A `required: true` parameter that resolves to no value errors.
+
+| Field         | Type   | Required | Description                                                       |
+| ------------- | ------ | -------- | ----------------------------------------------------------------- |
+| `name`        | string | yes      | The substitution variable's name (referenced as `${name}`).       |
+| `description` | string | no       | Free-form documentation.                                          |
+| `default`     | string | no       | Default value when `--param` is not supplied. Empty string is a valid default and short-circuits the env-fallback. |
+| `required`    | bool   | no       | When `true`, the blueprint fails to run if the parameter resolves to no value. |
+
+### `spec.cell` (object, required)
+
+The cell template body. It mirrors a [`Cell`](cell.md) manifest's user-authorable surface, but each container additionally carries structural slot declarations — repo slots with no inline `url`, and secret slots — that a [`CellConfig`](config.md) fills.
+
+| Field                       | Type                | Required | Description                                                  |
+| --------------------------- | ------------------- | -------- | ------------------------------------------------------------ |
+| `tty`                       | object              | no       | Cell-level TTY configuration; see [Cell](cell.md).           |
+| `containers[]`              | list                | yes      | The cell's containers; see below.                            |
+| `autoDelete`                | bool                | no       | When `true`, the materialized cell auto-deletes on exit.     |
+| `nestedCgroupRuntime`       | bool                | no       | Opts the cell into full controller delegation for a nested runtime (e.g. an inner kukeond). See [Cell](cell.md). |
+
+### `spec.cell.containers[]` (list, required)
+
+Each container carries the user-authorable subset of [ContainerSpec](container.md) — `id`, `image`, `command`, `args`, `env`, `volumes`, `networks`, `ports`, `resources`, `git`, `tty`, the host-namespace toggles, capability sets, and `restartPolicy`. Daemon-stamped identity fields (`containerdId`, `realmId`, `spaceId`, `stackId`, `cellId`) are intentionally absent: materialization fills them from the blueprint's metadata and the generated cell name.
+
+In addition to the regular container fields, a blueprint container declares two slot channels:
+
+#### `spec.cell.containers[].repos[]` (list, optional)
+
+Same shape as [ContainerRepo](container.md). Unlike a hand-written `Cell` / `Container`, `url` is **not** required at apply time. A repo with no `url` is a structural slot a `CellConfig` fills; a repo whose `url` is supplied inline (directly or via a `${KEY}` parameter) runs as-is under `kuke run -b`. The slot's `name` is the identity a `CellConfig` matches on.
+
+#### `spec.cell.containers[].secrets[]` (list, optional)
+
+Slot-only channel: the blueprint declares the **consumption side** (where the resolved bytes land inside the container), and a `CellConfig` supplies the **source side** (which `kind: Secret` provides the bytes). Because a blueprint never carries the source, a blueprint that declares secret slots cannot run inline with `-b` — it requires `kuke run -c` with a `CellConfig` that fills the slots.
+
+| Field        | Type   | Required                   | Description                                                                |
+| ------------ | ------ | -------------------------- | -------------------------------------------------------------------------- |
+| `name`       | string | yes                        | The slot's identity, unique within the container; a `CellConfig` matches by this name. |
+| `mode`       | string | no (default `env`)         | `env` injects an environment variable named `envName`; `file` stages a read-only mount at `mountPath`. |
+| `envName`    | string | when `mode: env`           | Environment variable name. Independent of the slot `name`, so the consumption side can change without renaming the slot. |
+| `mountPath`  | string | when `mode: file`          | Absolute in-container path for the read-only file mount.                   |
+| `required`   | bool   | no                         | When `true`, a `CellConfig` must fill the slot. Required slots also block inline `-b`. |
+
+## Storage layout
+
+The daemon writes the blueprint document to a root-owned, world-readable file under the scope's metadata tree:
+
+```
+<runPath>/data/<realm>/blueprints/<name>                         # realm-scoped
+<runPath>/data/<realm>/<space>/blueprints/<name>                 # space-scoped
+<runPath>/data/<realm>/<space>/<stack>/blueprints/<name>         # stack-scoped
+```
+
+The `blueprints/` directory is `0755` and each blueprint document is `0644`, both owned by root. A blueprint carries only template references — no credential bytes — so the directory is world-readable, unlike `secrets/`. Because `blueprints/` nests inside the scope's metadata directory, the same teardown that reclaims a scope (`kuke purge` / `kuke delete`) reclaims its blueprints.
+
+## Invariants
+
+- **Always fresh.** Every `kuke run -b` materializes a cell named `<prefix>-<6hex>`, where the suffix is 3 bytes of entropy. A blueprint never identifies a singleton cell — that contract belongs to [`CellConfig`](config.md). For singleton workloads use `CellConfig` (and `kuke run -c`) rather than a blueprint plus an external pinning convention.
+- **Back-reference.** Every materialized cell carries the `kukeon.io/blueprint=<name>` label, so an operator can list all instances of a blueprint with `kuke get cells -l kukeon.io/blueprint=<name>`.
+- **Scalar parameters declared.** A `${KEY}` in the body must appear in `spec.parameters[]`; otherwise the blueprint fails to load. Typos surface at apply time, not as a runtime mystery.
+- **Structural slots block inline.** A required repo slot (no inline `url`) or any required secret slot makes the blueprint un-runnable with `-b`; the run path refuses with a message naming the offenders and recommending `kuke run -c` with a `CellConfig` that fills them. Optional unfilled slots are dropped silently from the materialized container.
+
+## Minimal
+
+```yaml
+apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: claude-code
+  realm: kuke-system
+spec:
+  parameters:
+    - name: MODEL
+      default: claude-sonnet-4-6
+  cell:
+    containers:
+      - id: agent
+        root: true
+        image: ghcr.io/example/claude-code:latest
+        env:
+          - MODEL=${MODEL}
+```
+
+A realm-scoped blueprint named `claude-code` with one scalar parameter and one container. Run a fresh instance with `kuke run -b claude-code --realm kuke-system` (each invocation produces a new `claude-code-<6hex>` cell). For an idempotent, named instance, bind it via a [`CellConfig`](config.md) and run with `kuke run -c`.

--- a/docs/site/manifests/config.md
+++ b/docs/site/manifests/config.md
@@ -1,0 +1,147 @@
+# CellConfig manifest
+
+```yaml
+apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: prod                # also the deterministic name of the materialized cell
+  realm: kuke-system        # scope coordinates; deepest non-empty wins
+  # space: team-a           # optional — space-scoped
+  # stack: agents           # optional — stack-scoped (requires space)
+spec:
+  blueprint:
+    name: claude-code       # cross-scope reference; deeper coordinates optional
+    realm: kuke-system
+  values:                   # scalar ${KEY} fills for the blueprint's parameters
+    MODEL: claude-opus-4-7
+  repos:                    # structural repo slot fills, keyed by slot name
+    workspace:
+      url: https://github.com/example/repo
+  secrets:                  # structural secret slot fills, keyed by slot name
+    anthropic-token:
+      secretRef:
+        name: anthropic-token
+        realm: kuke-system
+```
+
+A `CellConfig` binds a [`CellBlueprint`](blueprint.md) to a concrete, idempotent cell **identity**. Where a Blueprint answers *"what does this cell look like?"*, a Config answers *"which instance?"*: a name with a deterministic derivation, the scalar `values` filled into the blueprint's parameters, and the structural repo/secret slot fills keyed by the blueprint's slot names. A Config materializes at most one live cell per scope.
+
+See [`kuke run -c`](../cli/kuke-run.md) for the identity state machine that decides whether `kuke run -c <config>` materializes a fresh cell, attaches to an existing one, or refuses because the in-cluster cell diverged from the Config's current spec.
+
+## metadata
+
+A Config is scopable at realm, space, or stack — never cell. A Config materializes a cell; scoping it to a single cell is nonsensical. The scope is the deepest non-empty coordinate, and a deeper coordinate may only be set when every shallower one is.
+
+| Field    | Type              | Required | Description                                                              |
+| -------- | ----------------- | -------- | ------------------------------------------------------------------------ |
+| `name`   | string            | yes      | The config's name, unique within its scope. Also the deterministic name of the materialized cell — see [Identity and stable name](#identity-and-stable-name). |
+| `realm`  | string            | yes      | The always-required top-level scope coordinate.                          |
+| `space`  | string            | no       | When set, scopes the config to a space within `realm`.                   |
+| `stack`  | string            | no       | When set, scopes the config to a stack within `space` (requires space).  |
+| `labels` | map[string]string | no       | Copied onto the materialized cell, in addition to the `kukeon.io/config` back-reference label. |
+
+## spec
+
+### `spec.blueprint` (object, required)
+
+Cross-scope reference to the [`CellBlueprint`](blueprint.md) this Config instantiates.
+
+| Field   | Type   | Required | Description                                                                |
+| ------- | ------ | -------- | -------------------------------------------------------------------------- |
+| `name`  | string | yes      | The referenced blueprint's name within its scope.                          |
+| `realm` | string | yes      | The blueprint's always-required top-level scope coordinate.                |
+| `space` | string | no       | When set, scopes the reference to a space within `realm`.                  |
+| `stack` | string | no       | When set, scopes the reference to a stack within `space`.                  |
+
+The reference may cross scopes: a Config in one realm may instantiate a Blueprint owned by another (for example, a `default`-realm Config referencing a `kuke-system`-scoped template), the same cross-scope freedom a `secretRef` has.
+
+### `spec.values` (map[string]string, optional)
+
+Scalar fills for the blueprint's `${KEY}` parameters. Stored verbatim; resolution happens at run time. An undeclared key in `values` errors at apply time (typos surface immediately).
+
+### `spec.repos` (map[string][RepoFill](#cellconfigrepofill), optional)
+
+Structural repo slot fills, keyed by the blueprint's repo slot `name`. Each entry supplies the clone URL the blueprint deliberately left open.
+
+#### CellConfigRepoFill
+
+| Field    | Type   | Required | Description                                                  |
+| -------- | ------ | -------- | ------------------------------------------------------------ |
+| `url`    | string | yes      | The clone URL filling the slot.                              |
+| `branch` | string | no       | The branch to check out. Empty clones the remote's default.  |
+
+### `spec.secrets` (map[string][SecretFill](#cellconfigsecretfill), optional)
+
+Structural secret slot fills, keyed by the blueprint's secret slot `name`. The blueprint owns the consumption side (env var or file mount) declared on the slot; this map supplies the source side — which `kind: Secret` provides the bytes.
+
+#### CellConfigSecretFill
+
+| Field       | Type                | Required | Description                                                        |
+| ----------- | ------------------- | -------- | ------------------------------------------------------------------ |
+| `secretRef` | object              | yes      | Points at the `kind: Secret` that provides the slot's bytes. Same shape as [Container `secretRef`](container.md) — `name` + `realm` (required), `space` / `stack` / `cell` (optional, deepest-non-empty wins). |
+
+## Slot fills
+
+A `CellConfig` fills the structural slots a [`CellBlueprint`](blueprint.md) declares. Slot matching is by **name**, across all of the blueprint's containers — the same slot name on two containers shares a single Config-side entry. The validation gates are:
+
+- A Config that fills a slot the blueprint does not declare is an apply-time error (unknown repo slot / unknown secret slot).
+- A *required* slot the blueprint declares that the Config leaves unfilled is an apply-time error. A slot is treated as required if **any** declaration of that name across the blueprint's containers is required.
+- Optional unfilled slots are dropped silently from the materialized container.
+
+The two channels are independent: scalar `values` are blueprint-side parameters resolved at run time (see the blueprint's [`spec.parameters[]`](blueprint.md)), while `repos:` and `secrets:` are structural slot fills validated at apply time. A `${KEY}` parameter is not a slot, and a slot is not a `${KEY}` parameter.
+
+## Identity and stable name
+
+A `CellConfig` materializes **at most one** live cell within its scope. The cell's deterministic name is `metadata.name` verbatim — not `<name>-<hash-of-values>` and not `<name>-<6hex>`. The derivation is value-independent on purpose: editing `spec.values` keeps the same cell identity so subsequent `kuke run -c` invocations attach to the existing cell rather than spawning a fresh one and orphaning the old.
+
+The matching contract:
+
+- Every cell `kuke run -c` materializes carries the `kukeon.io/config=<name>` back-reference label. The runtime locates the at-most-one live cell a Config owns by listing cells in the Config's scope with that label.
+- A divergent-spec warning fires when the in-cluster cell's spec disagrees with the Config's current spec (after re-resolving scalar values and slot fills). The state machine that drives materialise / attach / refuse on divergence lives in [`kuke run -c`](../cli/kuke-run.md).
+
+This is the structural contrast with a [`CellBlueprint`](blueprint.md): a blueprint is always-fresh (`<prefix>-<6hex>` per invocation), a config is always-named (`<configName>` per binding).
+
+## Storage layout
+
+The daemon writes the config document to a root-owned, world-readable file under the scope's metadata tree:
+
+```
+<runPath>/data/<realm>/configs/<name>                         # realm-scoped
+<runPath>/data/<realm>/<space>/configs/<name>                 # space-scoped
+<runPath>/data/<realm>/<space>/<stack>/configs/<name>         # stack-scoped
+```
+
+The `configs/` directory is `0755` and each config document is `0644`, both owned by root. A config carries only references (a blueprint name, repo URLs, secretRefs) — no credential bytes — so the directory is world-readable, unlike `secrets/`. Because `configs/` nests inside the scope's metadata directory, the same teardown that reclaims a scope (`kuke purge` / `kuke delete`) reclaims its configs.
+
+## Invariants
+
+- **One Config → at most one live cell within scope.** The deterministic stable name is `metadata.name` verbatim; subsequent `kuke run -c` invocations attach to the existing cell or refuse on divergence rather than spawning a duplicate.
+- **Back-reference.** Every materialized cell carries the `kukeon.io/config=<name>` label, so an operator can find a Config's live cell with `kuke get cells -l kukeon.io/config=<name>`.
+- **Apply-time slot validation.** A Config that fills an undeclared slot, or that leaves a required slot unfilled, errors at apply time against the referenced blueprint's current shape — not at run time.
+- **Cross-scope references.** A Config may reference a Blueprint in a different scope; the same is true of the `secretRef` inside each secret slot fill.
+
+## Minimal
+
+```yaml
+apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: prod
+  realm: kuke-system
+spec:
+  blueprint:
+    name: claude-code
+    realm: kuke-system
+  values:
+    MODEL: claude-opus-4-7
+  repos:
+    workspace:
+      url: https://github.com/example/repo
+  secrets:
+    anthropic-token:
+      secretRef:
+        name: anthropic-token
+        realm: kuke-system
+```
+
+A realm-scoped Config named `prod` that instantiates the `claude-code` blueprint (also realm-scoped), overrides the `MODEL` scalar parameter, fills the `workspace` repo slot, and fills the `anthropic-token` secret slot from the existing `kind: Secret` of the same name. Run with `sudo kuke run -c prod --realm kuke-system`; re-running attaches to the same cell.

--- a/docs/site/manifests/overview.md
+++ b/docs/site/manifests/overview.md
@@ -4,7 +4,7 @@ Every resource in Kukeon has a YAML schema. All manifests share the same shape:
 
 ```yaml
 apiVersion: v1beta1
-kind: <Realm|Space|Stack|Cell|Container|Secret>
+kind: <Realm|Space|Stack|Cell|Container|Secret|CellBlueprint|CellConfig>
 metadata:
   name: <string>
   labels:
@@ -37,6 +37,8 @@ If you're moving from v0.3.0 or v0.4.0, the per-kind pages below are the source 
 - [Cell](cell.md) — pod-like group of containers
 - [Container](container.md) — OCI container
 - [Secret](secret.md) — named, scoped, daemon-managed credential
+- [CellBlueprint](blueprint.md) — daemon-stored parametrized cell template
+- [CellConfig](config.md) — daemon-stored binding of a Blueprint to a named, idempotent cell identity
 
 ## Common fields
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,8 @@ nav:
       - manifests/cell.md
       - manifests/container.md
       - manifests/secret.md
+      - manifests/blueprint.md
+      - manifests/config.md
   - Tutorials:
       - tutorials/hello-world.md
       - tutorials/first-stack.md


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #747.
Mode: best-effort — the issue body identified files and sections but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria. Distilled from the Go-struct doc comments on `pkg/api/model/v1beta1/cellblueprint.go` and `pkg/api/model/v1beta1/cellconfig.go`, the storage-path constants in `internal/consts/consts.go` + `internal/util/fs/metadata.go`, and the identity primitives in `internal/cellblueprint/` and `internal/cellconfig/`.

## Files changed
- `docs/site/manifests/blueprint.md` — new page (CellBlueprint reference)
- `docs/site/manifests/config.md` — new page (CellConfig reference)
- `docs/site/manifests/overview.md` — Kinds list + skeleton `kind:` line updated
- `mkdocs.yml` — nav entries added under Manifest Reference

## Editorial choices
- Mirrored `manifests/secret.md`'s page shape (top-level YAML skeleton → one-paragraph intro → `## metadata` table → per-field `## spec` subsections → `## Storage layout` → `## Invariants` → `## Minimal`). The two new pages add a couple of kind-specific subsections beyond that skeleton — `## Slot fills` and `## Identity and stable name` on `config.md`, per the issue's acceptance criteria.
- Field tables (rather than dense prose) for each `metadata` / `spec` subsection, matching the existing `cell.md` / `container.md` / `secret.md` voice.
- The cell-template body in `blueprint.md` does not re-list every container field — instead it links forward to [`container.md`](container.md) for the user-authorable subset and only enumerates the kind-specific additions (`repos[]` slot semantics, `secrets[]` slot semantics). Avoids drift between this page and the container reference.
- `config.md` cross-links forward to `cli/kuke-run.md` for the `kuke run -c` identity state machine, per the AC. The state-machine details themselves are not duplicated on the manifest page — the manifest page documents the on-wire shape and the invariants the daemon validates at apply time; the run-side state machine is the CLI page's lane.
- `## Storage layout` paths use `<runPath>` (matching `secret.md`'s convention), and call out the `0755 / 0644` root-owned-but-world-readable mode set documented in `internal/consts/consts.go` — explicitly contrasted with the `secrets/` directory's `0700 / 0600`.
- `blueprint.md` invariants surface the "Blueprint = always fresh" `<prefix>-<6hex>` contract enforced by `internal/cellblueprint.MaterializeWithName` and explicitly steer the reader to `CellConfig` for singleton workloads.
- `config.md` `## Identity and stable name` pins the verbatim-name decision (`StableName(configName) = strings.TrimSpace(configName)`) and explains *why* it is value-independent (idempotent identity that survives `values:` edits — the contrast with a Blueprint's always-fresh suffix). Cites the back-reference label literal so the `kuke get cells -l kukeon.io/config=<name>` recipe is reproducible.

## Acceptance criteria check
- [x] `docs/site/manifests/blueprint.md` exists — documents top-level shape (`apiVersion: v1beta1`, `kind: CellBlueprint`, `metadata`, `spec`), the realm/space/stack scope contract (no cell scope), `spec.prefix`, `spec.parameters[]` (reusing `CellProfileParameter`), `spec.cell` container template, the two fill channels (scalar `${KEY}` params, structural repo/secret slots), and the "Blueprint = always fresh" `<prefix>-<6hex>` invariant that `kuke run -b` enforces. Includes a `## Minimal` example.
- [x] `docs/site/manifests/config.md` exists — documents top-level shape, the realm/space/stack scope contract (no cell scope), `spec.blueprint` cross-scope reference, `spec.values`, `spec.repos`/`spec.secrets` slot fills keyed by Blueprint slot name, the deterministic stable-name derivation, the back-ref label, and apply-time slot-fill validation against the referenced Blueprint. Includes a `## Minimal` example showing a Config that references a Blueprint and fills one repo slot + one secret slot. Cross-links forward to `cli/kuke-run.md` for the `kuke run -c` identity state machine.
- [x] `docs/site/manifests/overview.md` Kinds list has the two new entries; the skeleton YAML's `kind:` line includes `CellBlueprint` and `CellConfig`.
- [x] `mkdocs.yml` nav has both new pages under Manifest Reference.
- [ ] `mkdocs build` clean — could not run locally (`mkdocs` not installed in the apply environment). Cross-links use plain page references (`blueprint.md`, `config.md`, `container.md`, `cell.md`, `secret.md`, `../cli/kuke-run.md`, `../architecture/api-versioning.md`-style — though I did not introduce a new one of the latter), all of which resolve to files present in the diff or already in the tree. Worth a CI / local `mkdocs build --strict` pass on review.

Closes #747