### PR TITLE
docs(cli): cover kuke run -b/-c and get/delete blueprint+config

### DIFF
--- a/docs/site/cli/kuke-delete.md
+++ b/docs/site/cli/kuke-delete.md
@@ -53,6 +53,22 @@ kuke delete container <name> --realm <r> --space <s> --stack <t> --cell <c>
 
 `--cascade` does not apply to containers — they're already leaves.
 
+### kuke delete blueprint
+
+```
+kuke delete blueprint <name> --realm <r> [--space <s>] [--stack <t>] [--force]
+```
+
+Removes the daemon-stored CellBlueprint document bound to the named scope. Cells previously materialised from this blueprint are independent copies and are **not** affected. `--cascade` does not apply — a Blueprint has no children in the resource hierarchy.
+
+### kuke delete config
+
+```
+kuke delete config <name> --realm <r> [--space <s>] [--stack <t>] [--force]
+```
+
+Removes the daemon-stored CellConfig document bound to the named scope. The at-most-one live cell the Config materialised is **not** torn down — delete it separately with `kuke delete cell <name>`. When a live cell still carries the back-reference label to this Config, `kuke delete config` emits a one-line notice pointing at the cell to delete (never a refusal). `--cascade` does not apply — a Config has no children in the resource hierarchy.
+
 ## Behavior
 
 1. **Without `--cascade`**, delete fails if the resource has children. It refuses to leave orphaned subtrees behind.
@@ -73,6 +89,12 @@ sudo kuke delete container stuck --cell web --realm default --space blog --stack
 
 # Delete every resource listed in a manifest
 sudo kuke delete -f site.yaml
+
+# Remove a daemon-stored CellBlueprint (materialised cells are untouched)
+sudo kuke delete blueprint dev --realm kuke-system
+
+# Remove a daemon-stored CellConfig (the live cell it owns is not torn down)
+sudo kuke delete config kukeon-dev --realm kuke-system
 ```
 
 ## delete vs. purge

--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -7,7 +7,7 @@ kuke get <resource> [NAME] [flags]
 kuke g   <resource> [NAME] [flags]      # alias
 ```
 
-Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also accepts its plural (`realms`, `spaces`, …) and a short alias (`r`, `sp`, `st`, `ce`, `co`).
+Resources: `realm`, `space`, `stack`, `cell`, `container`, `blueprint`, `config`. Each subcommand also accepts its plural (`realms`, `spaces`, …, `blueprints`, `configs`) and a short alias (`r`, `sp`, `st`, `ce`, `co`, `bp`, `cfg`).
 
 ## Common flags
 
@@ -22,13 +22,15 @@ Plus all [global flags](kuke.md). Every `kuke get <kind>` accepts the explicit `
 
 Each subcommand takes the flags that scope the query:
 
-| Subcommand             | Scope flags                               |
-| ---------------------- | ----------------------------------------- |
-| `get realm [name]`     | none (realms are top-level)               |
-| `get space [name]`     | `--realm` (default `default`)             |
-| `get stack [name]`     | `--realm`, `--space`                      |
-| `get cell [name]`      | `--realm`, `--space`, `--stack`           |
-| `get container [name]` | `--realm`, `--space`, `--stack`, `--cell` |
+| Subcommand             | Scope flags                                      |
+| ---------------------- | ------------------------------------------------ |
+| `get realm [name]`     | none (realms are top-level)                      |
+| `get space [name]`     | `--realm` (default `default`)                    |
+| `get stack [name]`     | `--realm`, `--space`                             |
+| `get cell [name]`      | `--realm`, `--space`, `--stack`                  |
+| `get container [name]` | `--realm`, `--space`, `--stack`, `--cell`        |
+| `get blueprint [name]` | `--realm`, `--space`, `--stack` (no `--cell` — Blueprints are never cell-scoped) |
+| `get config [name]`    | `--realm`, `--space`, `--stack` (no `--cell` — Configs are never cell-scoped)    |
 
 All scope flags default to `default`. See the [realm default note](commands.md#convention-positional-arg--flags).
 
@@ -62,6 +64,12 @@ sudo kuke get containers --realm default --space default --stack default --cell 
 
 # Show which cgroup controllers are delegated to every realm
 sudo kuke get realms --show-controllers
+
+# List every daemon-stored CellBlueprint bound to the kuke-system realm
+sudo kuke get blueprints --realm kuke-system
+
+# Show one CellConfig as YAML
+sudo kuke get config kukeon-dev --realm kuke-system -o yaml
 ```
 
 ## `get` vs `refresh`

--- a/docs/site/cli/kuke-run.md
+++ b/docs/site/cli/kuke-run.md
@@ -1,22 +1,31 @@
 # kuke run
 
-Create and start a single cell from a YAML file or stdin (`-f`), or from a per-user profile under `$HOME/.kuke/profiles.d/<name>.yaml` (`-p`). Conceptually `kuke apply -f` (single-cell) plus `kuke start cell`, but refuses to update a divergent on-disk spec.
+Create and start a single cell from one of four sources:
+
+- `-f <file>` — a single-cell YAML doc (or `-` for stdin).
+- `-p <profile>` — a per-user profile under `$HOME/.kuke/profiles.d/<name>.yaml`. **Deprecated; will be removed in #626** — author new templates as `kind: CellBlueprint` and run them via `-b`/`-c` instead.
+- `-b <blueprint>` — a daemon-stored CellBlueprint, resolved from the scope named by `--realm`/`--space`/`--stack`. Substitutes scalar `--param` values and materializes a fresh `<prefix>-<6hex>` cell every invocation.
+- `-c <config>` — a daemon-stored CellConfig, resolved from the same scope. Stable-named and idempotent: walks the identity state machine and attaches to the at-most-one live cell the Config owns.
+
+Conceptually `kuke apply -f` (single-cell) plus `kuke start cell`, but refuses to update a divergent on-disk spec.
 
 ```
-kuke run (-f <file> | -p <profile>) [flags]
+kuke run (-f <file> | -p <profile> | -b <blueprint> | -c <config>) [flags]
 ```
 
 To re-attach to an existing cell, use [`kuke attach <cell>`](kuke-attach.md).
 
 ## Flags
 
-| Flag                | Default                   | Description                                                                                                                                                          |
-| ------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--file`, `-f`      | _(one of `-f`/`-p`)_      | YAML to read (path or `-` for stdin); mutually exclusive with `-p`                                                                                                   |
-| `--profile`, `-p`   | _(one of `-f`/`-p`)_      | Cell profile name to load from `$HOME/.kuke/profiles.d` (or `$KUKE_PROFILES_DIR`); mutually exclusive with `-f`                                                      |
-| `--name`            | `<metadata.name>-<6hex>`  | Override the materialized cell name. Only valid with `-p`; rejected with `-f`, where `metadata.name` is the cell name verbatim                                       |
-| `--param`           | (empty, repeatable)       | Profile parameter override as `KEY=VALUE`. Only valid with `-p`. Each `KEY` must be declared in `spec.parameters[]`. Wins over the default and over `--param-file`.   |
-| `--param-file`      | (empty)                   | File of `KEY=VALUE` lines whose values seed profile parameters; one per line, `#` starts a comment. Same declaration rules as `--param`. CLI `--param` wins on dups. |
+| Flag                | Default                          | Description                                                                                                                                                                                                                                                                                          |
+| ------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--file`, `-f`      | _(one of `-f`/`-p`/`-b`/`-c`)_   | YAML to read (path or `-` for stdin); mutually exclusive with `-p`/`-b`/`-c`                                                                                                                                                                                                                         |
+| `--profile`, `-p`   | _(one of `-f`/`-p`/`-b`/`-c`)_   | Cell profile name to load from `$HOME/.kuke/profiles.d` (or `$KUKE_PROFILES_DIR`); mutually exclusive with `-f`/`-b`/`-c`. **Deprecated; will be removed in #626** — use `-b`/`-c` instead                                                                                                           |
+| `--blueprint`, `-b` | _(one of `-f`/`-p`/`-b`/`-c`)_   | Daemon-stored CellBlueprint name to run, resolved from the scope named by `--realm`/`--space`/`--stack`; mutually exclusive with `-f`/`-p`/`-c`. Substitutes scalar `--param` values and materializes a fresh `<prefix>-<6hex>` cell                                                                |
+| `--config`, `-c`    | _(one of `-f`/`-p`/`-b`/`-c`)_   | Daemon-stored CellConfig name to run, resolved from the same scope; mutually exclusive with `-f`/`-p`/`-b`. The Config carries its own scalar values and structural slot fills (repos, secrets), so `--name`/`--param`/`--param-file` are rejected with `-c`. Idempotent: walks the identity state machine and attaches to the at-most-one live cell the Config owns by stable name |
+| `--name`            | `<metadata.name>-<6hex>`         | Override the materialized cell name. Valid with `-p`/`-b`; rejected with `-f` (where `metadata.name` is the cell name verbatim) and with `-c` (where the cell name is the Config's stable name)                                                                                                     |
+| `--param`           | (empty, repeatable)              | Scalar parameter override as `KEY=VALUE`. Valid with `-p`/`-b`. Each `KEY` must be declared in `spec.parameters[]`. Wins over the default and over `--param-file`. Rejected with `-c` — a CellConfig carries its own `spec.values`; edit the Config instead                                          |
+| `--param-file`      | (empty)                          | File of `KEY=VALUE` lines whose values seed scalar parameters; one per line, `#` starts a comment. Same declaration rules as `--param`. CLI `--param` wins on dups. Rejected with `-c` (same reason as `--param`)                                                                                    |
 | `--detach`, `-d`    | `false`                   | Return immediately after start without attaching                                                                                                                     |
 | `--container`       | (auto-pick)               | Container to attach to (attach mode only; rejected with `-d`). Precedence: `--container` > `cell.tty.default` > first attachable                                     |
 | `--rm`              | `false`                   | Best-effort delete the cell after it's no longer needed (any rc). See [Cleanup with `--rm`](#cleanup-with---rm).                                                     |
@@ -41,6 +50,8 @@ A clean `^]^]` detach exits the CLI but leaves the cell running so you can re-at
 
 ## Profiles
 
+> **Deprecated; will be removed in #626.** Author new templates as `kind: CellBlueprint` and run them via `-b`/`-c` (see [Blueprints and Configs](#blueprints-and-configs) below).
+
 Profiles are YAML files under `$HOME/.kuke/profiles.d/<name>.yaml` (or `$KUKE_PROFILES_DIR`). A profile is a cell spec template with declared `spec.parameters[]`. Each invocation materializes one cell with a unique name (`<metadata.name>-<6hex>` by default; override with `--name`).
 
 Parameters are resolved in this order, last-write-wins per key:
@@ -50,6 +61,30 @@ Parameters are resolved in this order, last-write-wins per key:
 3. Values from each `--param KEY=VALUE` on the CLI.
 
 Keys not declared in `spec.parameters[]` are rejected.
+
+## Blueprints and Configs
+
+`-b`/`--blueprint` and `-c`/`--config` both run daemon-stored templates instead of an on-disk file. They are resolved by name in the scope named by `--realm`/`--space`/`--stack` — the same lookup `kuke get blueprint <name>` / `kuke get config <name>` performs.
+
+The two verbs cover different operator workflows:
+
+- **`-b <blueprint>` — fresh cell per invocation.** A CellBlueprint is a template with declared `spec.parameters[]`. Each `kuke run -b` materializes a new cell with a `<prefix>-<6hex>` name; scalar `--param KEY=VALUE` (or `--param-file`) overrides the Blueprint's defaults. Behaves like `-p` did, but the template lives in the daemon's store rather than `$HOME/.kuke/profiles.d`.
+- **`-c <config>` — stable-named, idempotent.** A CellConfig binds a CellBlueprint reference to concrete scalar values plus structural slot fills (repo bindings, secret references). The cell name is the Config's `metadata.name`. `--param`/`--param-file`/`--name` are rejected with `-c` because the Config already owns its values — edit the Config instead.
+
+### Identity state machine for `-c`
+
+Each `kuke run -c <config>` walks the Config's identity state and converges:
+
+| Live cell state                 | Behavior                                                                                                                            |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| No cell with the Config's name  | Materialize from the referenced Blueprint with the Config's values + slot fills, create the cell, attach.                           |
+| Live and running                | Attach to the existing cell (no-op create).                                                                                         |
+| Live but stopped                | Start the existing cell, then attach.                                                                                               |
+| Live but in an error / partial state | Refuse with a `kuke delete cell <name>` pointer; do not attempt to recover by recreating.                                      |
+
+If the live cell's spec differs from the materialisation of the *current* Config + Blueprint (someone edited the Config or the underlying Blueprint after the cell was last materialised), `-c` emits a divergence warning to stderr and attaches to the live state — it does **not** reconcile the cell to the new spec. Use `kuke delete cell <name>` followed by `kuke run -c <name>` to pick up the new spec.
+
+See [`kind: CellBlueprint`](../manifests/blueprint.md) and [`kind: CellConfig`](../manifests/config.md) for the full manifest reference.
 
 ## Cleanup with `--rm`
 
@@ -81,6 +116,15 @@ kuke run -p shell --name my-shell --detach
 
 # One-shot job that cleans itself up after the workload exits
 kuke run -p batch --rm
+
+# Run a daemon-stored CellBlueprint with a scalar param override (fresh cell)
+sudo kuke run -b dev --realm kuke-system --param PROJECT_DIR=kukeon
+
+# Run a daemon-stored CellConfig (stable-named; attaches if the cell already exists)
+sudo kuke run -c kukeon-dev --realm kuke-system
+
+# Same Config, but detach instead of attaching after start
+sudo kuke run -c kukeon-dev --realm kuke-system -d
 ```
 
 ## Related


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #748.
Mode: best-effort — the issue body identified files and sections but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria.

## Files changed
- `docs/site/cli/kuke-run.md` — synopsis, intro, flags table, new `## Blueprints and Configs` section (with the `-c` identity state machine subsection), three new examples; `## Profiles` heading carries a deprecation note pointing to `-b`/`-c`.
- `docs/site/cli/kuke-get.md` — resources line extended with `blueprint`/`config` (plus plurals and `bp`/`cfg` aliases); hierarchy-flags table gains rows for `get blueprint` and `get config`; two new examples.
- `docs/site/cli/kuke-delete.md` — added `### kuke delete blueprint` and `### kuke delete config` subsections after `### kuke delete container`, including the no-cascade note and the "delete config does not delete the cell" semantic that the per-resource Go source emits as a runtime notice; two new examples.

## Editorial choices
- `-b`/`-c` flags table rows phrased to mirror the `Use:` and flag-help strings in `cmd/kuke/run/run.go`, so the doc tracks the source's authoritative wording.
- The `-c` identity state machine surfaced as a four-row markdown table (no cell / live+running / live+stopped / live+error) rather than prose — easier to skim and maps 1:1 to the four cases the issue enumerates.
- The `## Profiles` section header got a one-line deprecation block (block quote) pointing to `-b`/`-c`; section body left intact per the issue's Notes block ("once #626 lands, a follow-up doc sweep can strip the deprecation note and remove the section — that cleanup is **not** part of this issue").
- Forward-links to `../manifests/blueprint.md` and `../manifests/config.md` — those pages landed on `main` in #749 during this branch's life (the companion issue the body referenced as "filed separately"), so the link is direct rather than deferred. After the rebase the references resolve cleanly.
- `kuke-delete.md`: the synopsis usage block was left unchanged per the issue ("the `<resource> <name>` shape as-is; the new subcommands fit the existing pattern").

## Acceptance criteria check
- [x] `docs/site/cli/kuke-run.md` documents `-b` and `-c` in the flags table with their mutual-exclusion and rejection semantics; the synopsis matches `cmd/kuke/run/run.go:58`; the new section covers the Blueprint-vs-Config distinction and the `-c` identity state machine; examples include at least one `-b` and one `-c` invocation. — done
- [x] `docs/site/cli/kuke-get.md` lists `blueprint` and `config` (plus their plurals and aliases) in the resources line; the hierarchy-flags table covers both; examples include at least one of each. — done
- [x] `docs/site/cli/kuke-delete.md` has a subsection per new resource with the correct scope flags and the no-cascade note; examples include both. — done
- [x] No reference to `--cell` on Blueprint or Config subcommands. — done (both `get` and `delete` rows omit `--cell` and call out why)
- [x] `docs/site/cli/kuke-run.md`'s mention of `-p` includes the "deprecated; will be removed in #626" note — done (intro bullet, flags table row, and `## Profiles` section header)
- [ ] `mkdocs build` is clean — **not verified locally** (mkdocs / pip / apt unavailable in this sandbox); cross-file links and same-page anchors were checked programmatically and resolve. Relying on CI for the strict build check.

Closes #748