### PR TITLE
feat(apply): add kuke apply -b/-c for Blueprint/Config reconciliation

### DIFF
--- a/cmd/kuke/apply/apply.go
+++ b/cmd/kuke/apply/apply.go
@@ -17,75 +17,465 @@
 package apply
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 
+	"github.com/eminwux/kukeon/cmd/config"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/cellprofile"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
+const (
+	outputFormatJSON = "json"
+	outputFormatYAML = "yaml"
+)
+
+// NewApplyCmd builds the `kuke apply` cobra command. `-f` reads a multi-document
+// YAML stream from disk or stdin (unchanged). `-b` resolves a daemon-stored
+// CellBlueprint by name + scope, substitutes `--param` values, and reconciles
+// the resulting cell against the live state. `-c` resolves a daemon-stored
+// CellConfig by name + scope and reconciles its materialised cell. The three
+// sources are mutually exclusive; exactly one is required.
 func NewApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "apply -f <file>",
-		Short:         "Apply resource definitions from YAML file",
-		Long:          "Apply resource definitions from a YAML file or stdin. Supports multi-document YAML separated by '---'.",
+		Use:   "apply (-f <file> | -b <blueprint> | -c <config>)",
+		Short: "Apply resource definitions from YAML or reconcile a daemon-stored Blueprint/Config",
+		Long: "Apply resource definitions from a YAML file or stdin (-f), reconcile a " +
+			"daemon-stored CellBlueprint by ref (-b), or reconcile a daemon-stored " +
+			"CellConfig by ref (-c). The -b/-c forms materialise a CellDoc the same way " +
+			"`kuke run -b/-c` does and reconcile it against the live cell: a missing cell " +
+			"is created and started; an identical live cell is a no-op; a divergent live " +
+			"cell is stopped, updated, and started (no attach). A live cell whose " +
+			"lineage label (kukeon.io/blueprint or kukeon.io/config) does not match the " +
+			"-b/-c source is refused, so apply never silently takes over an unrelated cell.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: false,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			file, err := cmd.Flags().GetString("file")
-			if err != nil {
-				return err
-			}
-			if file == "" {
-				return errors.New("file flag is required (use -f <file> or -f - for stdin)")
-			}
+		RunE:          runApply,
+	}
 
-			output, err := cmd.Flags().GetString("output")
-			if err != nil {
-				return err
-			}
+	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin); mutually exclusive with -b/-c")
+	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
 
-			reader, cleanup, err := kukshared.ReadFileOrStdin(file)
-			if err != nil {
-				return err
-			}
-			defer func() { _ = cleanup() }()
+	cmd.Flags().StringP("blueprint", "b", "",
+		"Daemon-stored CellBlueprint name to reconcile, resolved from the scope named by "+
+			"--realm/--space/--stack; mutually exclusive with -f/-c. Substitutes scalar "+
+			"--param values; without --name, materialises a fresh <prefix>-<6hex> cell name.")
+	cmd.Flags().StringP("config", "c", "",
+		"Daemon-stored CellConfig name to reconcile, resolved from the scope named by "+
+			"--realm/--space/--stack; mutually exclusive with -f/-b. The cell name is the "+
+			"Config's deterministic stable name unless --name overrides it. Rejects --param "+
+			"/ --param-file (edit the Config's spec.values instead).")
 
-			rawYAML, err := io.ReadAll(reader)
-			if err != nil {
-				return fmt.Errorf("failed to read input: %w", err)
-			}
+	cmd.Flags().String("name", "",
+		"Override the materialised cell name (default for -b: <prefix>-<6hex>; default for "+
+			"-c: the Config's stable name). Rejected with -f.")
+	cmd.Flags().StringArray("param", nil,
+		"Scalar parameter override as KEY=VALUE; repeatable. Valid with -b only. Each KEY "+
+			"must be declared in spec.parameters[]. Wins over the parameter's default and "+
+			"over --param-file when both set the same key.")
+	cmd.Flags().String("param-file", "",
+		"File of KEY=VALUE lines whose values seed scalar parameters; one per line, `#` "+
+			"starts a comment. Valid with -b only. CLI --param wins on duplicate keys.")
 
-			client, err := resolveClient(cmd)
-			if err != nil {
-				return err
-			}
-			defer func() { _ = client.Close() }()
+	cmd.Flags().String("realm", "", "Realm to resolve the Blueprint/Config from (default: default)")
+	cmd.Flags().String("space", "", "Space to resolve the Blueprint/Config from")
+	cmd.Flags().String("stack", "", "Stack to resolve the Blueprint/Config from")
 
-			result, err := client.ApplyDocuments(cmd.Context(), rawYAML)
-			if err != nil {
-				return err
-			}
+	cmd.MarkFlagsMutuallyExclusive("file", "blueprint", "config")
+	cmd.MarkFlagsOneRequired("file", "blueprint", "config")
 
-			if output == "json" || output == "yaml" {
-				return printApplyResultJSON(cmd, result, output)
-			}
-			return printApplyResult(cmd, result)
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("blueprint", config.CompleteBlueprintNames)
+	_ = cmd.RegisterFlagCompletionFunc("config", config.CompleteConfigNames)
+
+	return cmd
+}
+
+// applyFlags is the validated bundle of flag values runApply consumes.
+type applyFlags struct {
+	file          string
+	blueprintName string
+	configName    string
+	output        string
+	nameOverride  string
+	paramArgs     []string
+	paramFile     string
+}
+
+func parseApplyFlags(cmd *cobra.Command) (applyFlags, error) {
+	flags := applyFlags{}
+	var err error
+	if flags.file, err = cmd.Flags().GetString("file"); err != nil {
+		return flags, err
+	}
+	if flags.blueprintName, err = cmd.Flags().GetString("blueprint"); err != nil {
+		return flags, err
+	}
+	if flags.configName, err = cmd.Flags().GetString("config"); err != nil {
+		return flags, err
+	}
+	if flags.output, err = cmd.Flags().GetString("output"); err != nil {
+		return flags, err
+	}
+	if flags.nameOverride, err = cmd.Flags().GetString("name"); err != nil {
+		return flags, err
+	}
+	if flags.paramArgs, err = cmd.Flags().GetStringArray("param"); err != nil {
+		return flags, err
+	}
+	if flags.paramFile, err = cmd.Flags().GetString("param-file"); err != nil {
+		return flags, err
+	}
+
+	flags.file = strings.TrimSpace(flags.file)
+	flags.blueprintName = strings.TrimSpace(flags.blueprintName)
+	flags.configName = strings.TrimSpace(flags.configName)
+	flags.output = strings.TrimSpace(flags.output)
+	flags.nameOverride = strings.TrimSpace(flags.nameOverride)
+	flags.paramFile = strings.TrimSpace(flags.paramFile)
+
+	if flags.output != "" && flags.output != outputFormatJSON && flags.output != outputFormatYAML {
+		return flags, fmt.Errorf("invalid --output %q: want json or yaml", flags.output)
+	}
+
+	if flags.file != "" {
+		// --name and --param* are template knobs that only make sense for the
+		// -b/-c refs; a -f stream carries metadata.name verbatim and a fully
+		// resolved spec.
+		if flags.nameOverride != "" {
+			return flags, errors.New("--name is only valid with -b/--blueprint or -c/--config")
+		}
+		if len(flags.paramArgs) > 0 {
+			return flags, errors.New("--param is only valid with -b/--blueprint")
+		}
+		if flags.paramFile != "" {
+			return flags, errors.New("--param-file is only valid with -b/--blueprint")
+		}
+	}
+	if flags.configName != "" {
+		// A CellConfig carries its own spec.values; --param would either
+		// silently shadow them or break the Config's idempotent identity.
+		if len(flags.paramArgs) > 0 {
+			return flags, errors.New(
+				"--param is not valid with -c/--config; edit the Config's spec.values instead")
+		}
+		if flags.paramFile != "" {
+			return flags, errors.New(
+				"--param-file is not valid with -c/--config; edit the Config's spec.values instead")
+		}
+	}
+	return flags, nil
+}
+
+func runApply(cmd *cobra.Command, _ []string) error {
+	flags, err := parseApplyFlags(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if flags.blueprintName != "" || flags.configName != "" {
+		return runApplyRef(cmd, client, flags)
+	}
+	return runApplyFile(cmd, client, flags)
+}
+
+// runApplyFile is the unchanged `kuke apply -f` path: read YAML, send to the
+// daemon's ApplyDocuments, print result.
+func runApplyFile(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) error {
+	if flags.file == "" {
+		return errors.New("file flag is required (use -f <file> or -f - for stdin)")
+	}
+
+	reader, cleanup, err := kukshared.ReadFileOrStdin(flags.file)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cleanup() }()
+
+	rawYAML, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	result, err := client.ApplyDocuments(cmd.Context(), rawYAML)
+	if err != nil {
+		return err
+	}
+
+	if flags.output == outputFormatJSON || flags.output == outputFormatYAML {
+		return printApplyResultJSON(cmd, result, flags.output)
+	}
+	return printApplyResult(cmd, result)
+}
+
+// runApplyRef handles the `-b`/`-c` form. It materialises a CellDoc from the
+// named Blueprint or Config, validates the lineage against any live cell at
+// the resolved name, and routes the marshaled doc through the daemon's
+// ApplyDocuments — which owns the missing/matches/differs reconciliation for
+// the Cell kind. Equivalent specs from -f, -b, or -c all converge on the same
+// daemon-side reconcile path.
+func runApplyRef(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) error {
+	cellDoc, err := loadCellRef(cmd, client, flags)
+	if err != nil {
+		return err
+	}
+	resolveCellLocation(cmd, &cellDoc)
+
+	if lineageErr := assertCellLineage(cmd.Context(), client, cellDoc, flags); lineageErr != nil {
+		return lineageErr
+	}
+
+	rawYAML, err := yaml.Marshal(&cellDoc)
+	if err != nil {
+		return fmt.Errorf("marshal materialised cell: %w", err)
+	}
+
+	result, err := client.ApplyDocuments(cmd.Context(), rawYAML)
+	if err != nil {
+		return err
+	}
+
+	if flags.output == outputFormatJSON || flags.output == outputFormatYAML {
+		return printApplyResultJSON(cmd, result, flags.output)
+	}
+	return printApplyResult(cmd, result)
+}
+
+// loadCellRef materialises the CellDoc for the -b or -c path. Mirrors
+// run.loadFromBlueprint / loadFromConfig (cmd/kuke/run/run.go) so equivalent
+// specs from `kuke run` and `kuke apply` compare equal under DiffCell.
+func loadCellRef(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) (v1beta1.CellDoc, error) {
+	switch {
+	case flags.configName != "":
+		return loadFromConfig(cmd, client, flags)
+	case flags.blueprintName != "":
+		return loadFromBlueprint(cmd, client, flags)
+	}
+	return v1beta1.CellDoc{}, errors.New("internal error: loadCellRef called without -b/-c")
+}
+
+func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) (v1beta1.CellDoc, error) {
+	cliParams, err := buildParamMap(flags)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+
+	lookup := v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  flags.blueprintName,
+			Realm: pickRealm(cmd),
+			Space: explicitScope(cmd, "space"),
+			Stack: explicitScope(cmd, "stack"),
 		},
 	}
 
-	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin)")
-	_ = cmd.MarkFlagRequired("file")
-	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
+	res, err := client.GetBlueprint(cmd.Context(), lookup)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !res.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (blueprint %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrBlueprintNotFound, lookup.Metadata.Name,
+			lookup.Metadata.Realm, lookup.Metadata.Space, lookup.Metadata.Stack,
+		)
+	}
 
-	return cmd
+	resolved, err := cellblueprint.Resolve(res.Blueprint, cliParams, os.LookupEnv)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	return cellblueprint.MaterializeWithName(resolved, flags.nameOverride)
+}
+
+func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) (v1beta1.CellDoc, error) {
+	lookup := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  flags.configName,
+			Realm: pickRealm(cmd),
+			Space: explicitScope(cmd, "space"),
+			Stack: explicitScope(cmd, "stack"),
+		},
+	}
+
+	cfgRes, err := client.GetConfig(cmd.Context(), lookup)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !cfgRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (config %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrConfigNotFound, lookup.Metadata.Name,
+			lookup.Metadata.Realm, lookup.Metadata.Space, lookup.Metadata.Stack,
+		)
+	}
+
+	bpRef := cfgRes.Config.Spec.Blueprint
+	bpRes, err := client.GetBlueprint(cmd.Context(), v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  bpRef.Name,
+			Realm: bpRef.Realm,
+			Space: bpRef.Space,
+			Stack: bpRef.Stack,
+		},
+	})
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !bpRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (blueprint %q referenced by config %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrBlueprintNotFound, bpRef.Name, cfgRes.Config.Metadata.Name,
+			bpRef.Realm, bpRef.Space, bpRef.Stack,
+		)
+	}
+
+	cellDoc, err := cellconfig.Materialize(cfgRes.Config, bpRes.Blueprint)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if flags.nameOverride != "" {
+		cellDoc.Metadata.Name = flags.nameOverride
+		cellDoc.Spec.ID = flags.nameOverride
+	}
+	return cellDoc, nil
+}
+
+// buildParamMap layers --param flags on top of --param-file contents, matching
+// `kuke run -b`'s precedence. Empty result is valid (the blueprint may use only
+// defaults).
+func buildParamMap(flags applyFlags) (map[string]string, error) {
+	var fileParams map[string]string
+	if flags.paramFile != "" {
+		fp, err := cellprofile.ParseParamFile(flags.paramFile)
+		if err != nil {
+			return nil, err
+		}
+		fileParams = fp
+	}
+	cliParams, err := cellprofile.ParseParamArgs(flags.paramArgs)
+	if err != nil {
+		return nil, err
+	}
+	return cellprofile.MergeParams(fileParams, cliParams), nil
+}
+
+// resolveCellLocation fills missing realm/space/stack on the materialised doc
+// from --realm/--space/--stack. The materialised doc usually carries the
+// Blueprint/Config's coordinates already; this only fills empties.
+func resolveCellLocation(cmd *cobra.Command, doc *v1beta1.CellDoc) {
+	if strings.TrimSpace(doc.Spec.RealmID) == "" {
+		doc.Spec.RealmID = pickRealm(cmd)
+	}
+	if strings.TrimSpace(doc.Spec.SpaceID) == "" {
+		doc.Spec.SpaceID = explicitScope(cmd, "space")
+	}
+	if strings.TrimSpace(doc.Spec.StackID) == "" {
+		doc.Spec.StackID = explicitScope(cmd, "stack")
+	}
+}
+
+// pickRealm returns the --realm value if set, falling back to "default" so the
+// lookup always names a realm (parity with `kuke run`'s default).
+func pickRealm(cmd *cobra.Command) string {
+	if v, _ := cmd.Flags().GetString("realm"); strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	return "default"
+}
+
+// explicitScope returns the named scope flag only when the operator set it
+// explicitly. Mirrors run.explicitScope so realm-scoped Blueprints/Configs (no
+// space or stack coordinate) are findable; the cobra flag default of "" stays
+// "do not constrain this coordinate".
+func explicitScope(cmd *cobra.Command, flagName string) string {
+	if !cmd.Flags().Changed(flagName) {
+		return ""
+	}
+	v, _ := cmd.Flags().GetString(flagName)
+	return strings.TrimSpace(v)
+}
+
+// assertCellLineage refuses to reconcile a live cell whose lineage label does
+// not match the source the operator named. The check protects hand-built cells
+// (no lineage label) and cells materialised from a different Blueprint/Config
+// (different label value) from silent takeover. A missing cell skips the
+// check — there is nothing to overwrite.
+func assertCellLineage(
+	ctx context.Context, client kukeonv1.Client, desired v1beta1.CellDoc, flags applyFlags,
+) error {
+	pre, err := client.GetCell(ctx, desired)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrCellNotFound) {
+			return nil
+		}
+		return err
+	}
+	if !pre.MetadataExists {
+		return nil
+	}
+
+	labelKey, wantValue := lineageExpectation(flags)
+	gotValue := strings.TrimSpace(pre.Cell.Metadata.Labels[labelKey])
+
+	if gotValue == wantValue {
+		return nil
+	}
+	return lineageMismatchError(desired.Metadata.Name, labelKey, wantValue, pre.Cell.Metadata.Labels)
+}
+
+// lineageExpectation maps the active source flag to the (labelKey, wantValue)
+// pair the live cell must carry. The caller already verified exactly one of -b
+// or -c is set.
+func lineageExpectation(flags applyFlags) (string, string) {
+	if flags.configName != "" {
+		return cellconfig.LabelConfig, flags.configName
+	}
+	return cellblueprint.LabelBlueprint, flags.blueprintName
+}
+
+// lineageMismatchError formats the refusal so the operator sees both what
+// `apply` expected and the existing cell's source (if any). A hand-built cell
+// reports "no lineage label"; a sibling-source cell reports the other label.
+func lineageMismatchError(cellName, wantKey, wantValue string, got map[string]string) error {
+	var existingSource string
+	switch {
+	case strings.TrimSpace(got[cellconfig.LabelConfig]) != "":
+		existingSource = fmt.Sprintf("%s=%s", cellconfig.LabelConfig, got[cellconfig.LabelConfig])
+	case strings.TrimSpace(got[cellblueprint.LabelBlueprint]) != "":
+		existingSource = fmt.Sprintf("%s=%s", cellblueprint.LabelBlueprint, got[cellblueprint.LabelBlueprint])
+	default:
+		existingSource = "no lineage label"
+	}
+	return fmt.Errorf(
+		"cell %q exists with lineage %s; refusing to reconcile against %s=%s",
+		cellName, existingSource, wantKey, wantValue,
+	)
 }
 
 func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {

--- a/cmd/kuke/apply/apply_test.go
+++ b/cmd/kuke/apply/apply_test.go
@@ -29,7 +29,11 @@ import (
 
 	apply "github.com/eminwux/kukeon/cmd/kuke/apply"
 	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 func writeTempYAML(t *testing.T, content string) string {
@@ -54,16 +58,15 @@ spec:
 	tests := []struct {
 		name       string
 		args       []string
-		stdin      string
 		fake       *fakeClient
 		wantErr    string
 		wantOutput string
 	}{
 		{
-			name:    "missing file flag",
+			name:    "no source flag",
 			args:    []string{},
 			fake:    &fakeClient{},
-			wantErr: "required flag",
+			wantErr: "at least one of the flags in the group [file blueprint config] is required",
 		},
 		{
 			name: "success",
@@ -181,15 +184,529 @@ spec:
 	}
 }
 
+// blueprintDoc builds a minimal Blueprint with one param + one user (non-root)
+// container so apply -b has something to materialise. The fixture mirrors
+// run_test.blueprintDoc's shape so the round-trip behaviour stays comparable.
+func blueprintDoc() v1beta1.CellBlueprintDoc {
+	def := "latest"
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: "my-realm",
+			Space: "my-space",
+			Stack: "my-stack",
+		},
+		Spec: v1beta1.CellBlueprintSpec{
+			Prefix:     "web",
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
+				},
+			},
+		},
+	}
+}
+
+// configDoc + configBlueprintDoc let -c tests round-trip through Materialize.
+// Slot fills are minimal (no secrets/repos) so Materialize succeeds without
+// auxiliary scope reads.
+func configBlueprintDoc() v1beta1.CellBlueprintDoc {
+	def := "latest"
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: "bp-realm",
+		},
+		Spec: v1beta1.CellBlueprintSpec{
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
+				},
+			},
+		},
+	}
+}
+
+func configDoc() v1beta1.CellConfigDoc {
+	return v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  "prod",
+			Realm: "cfg-realm",
+		},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Values:    map[string]string{"TAG": "v2"},
+		},
+	}
+}
+
+// runApplyRef is the test helper that builds a fake-backed apply.NewApplyCmd
+// and executes it with the given args. It returns the captured stdout/stderr
+// buffer plus the cobra Execute error.
+func runApplyRef(t *testing.T, fc *fakeClient, args []string) (string, error) {
+	t.Helper()
+	cmd := apply.NewApplyCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, apply.MockControllerKey{}, kukeonv1.Client(fc))
+	cmd.SetContext(ctx)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// TestApply_FromBlueprint_MissingCell_CreatesViaApplyDocuments covers the
+// "missing cell" leg of the -b reconciliation matrix: GetCell returns
+// ErrCellNotFound so the lineage check skips; ApplyDocuments fires with the
+// materialised YAML and the daemon reports "created".
+func TestApply_FromBlueprint_MissingCell_CreatesViaApplyDocuments(t *testing.T) {
+	fc := &fakeClient{
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			if doc.Metadata.Name != "web" {
+				t.Errorf("lookup name=%q want web", doc.Metadata.Name)
+			}
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
+		},
+		applyFn: func(raw []byte) (kukeonv1.ApplyDocumentsResult, error) {
+			if !strings.Contains(string(raw), "kukeon.io/blueprint: web") {
+				t.Errorf("materialised YAML missing lineage label; raw=\n%s", string(raw))
+			}
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{Kind: "Cell", Name: "myCell", Action: "created"},
+				},
+			}, nil
+		},
+	}
+
+	out, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "myCell", "--realm", "my-realm"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, `Cell "myCell": created`) {
+		t.Errorf("missing created line in output:\n%s", out)
+	}
+	if fc.applyCalls != 1 {
+		t.Errorf("ApplyDocuments calls=%d want 1", fc.applyCalls)
+	}
+}
+
+// TestApply_FromBlueprint_LiveCellMatchingLineage_NoOpsViaUnchanged covers the
+// "exists, matches" leg: GetCell echoes the same cell back with the matching
+// blueprint label, ApplyDocuments delegates to the daemon's diff which returns
+// "unchanged". The lineage check passes; no refusal.
+func TestApply_FromBlueprint_LiveCellMatchingLineage_NoOpsViaUnchanged(t *testing.T) {
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Metadata: v1beta1.CellMetadata{
+						Name:   doc.Metadata.Name,
+						Labels: map[string]string{cellblueprint.LabelBlueprint: "web"},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{Kind: "Cell", Name: "myCell", Action: "unchanged"},
+				},
+			}, nil
+		},
+	}
+
+	out, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "myCell", "--realm", "my-realm"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, `Cell "myCell": unchanged`) {
+		t.Errorf("missing unchanged line in output:\n%s", out)
+	}
+}
+
+// TestApply_FromBlueprint_LiveCellDivergentSpec_UpdatesViaApplyDocuments covers
+// the "exists, differs" leg: the materialised YAML round-trips into the
+// daemon-side reconciler, which reports "updated" with the changed fields. The
+// CLI surfaces the per-field summary line.
+func TestApply_FromBlueprint_LiveCellDivergentSpec_UpdatesViaApplyDocuments(t *testing.T) {
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Metadata: v1beta1.CellMetadata{
+						Name:   doc.Metadata.Name,
+						Labels: map[string]string{cellblueprint.LabelBlueprint: "web"},
+					},
+					Spec: v1beta1.CellSpec{
+						Containers: []v1beta1.ContainerSpec{
+							{ID: "main", Image: "registry.example.com/web:old"},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{
+						Kind:    "Cell",
+						Name:    "myCell",
+						Action:  "updated",
+						Changes: []string{`container "main" updated: image`},
+					},
+				},
+			}, nil
+		},
+	}
+
+	out, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "myCell", "--realm", "my-realm"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, `Cell "myCell": updated`) {
+		t.Errorf("missing updated header in output:\n%s", out)
+	}
+	if !strings.Contains(out, `container "main" updated: image`) {
+		t.Errorf("missing per-field diff line in output:\n%s", out)
+	}
+}
+
+// TestApply_FromBlueprint_LiveCellHandBuilt_RefusesLineageMismatch is the
+// safety gate the AC names: a hand-built cell (no kukeon.io/blueprint label) is
+// refused, never silently overwritten. The error names the existing cell's
+// source ("no lineage label") and the source apply tried to claim.
+func TestApply_FromBlueprint_LiveCellHandBuilt_RefusesLineageMismatch(t *testing.T) {
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Metadata: v1beta1.CellMetadata{Name: doc.Metadata.Name},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	_, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "alice-handbuilt", "--realm", "my-realm"})
+	if err == nil {
+		t.Fatal("expected lineage-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no lineage label") {
+		t.Errorf("err=%q want mention of 'no lineage label'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "kukeon.io/blueprint=web") {
+		t.Errorf("err=%q want mention of attempted lineage", err.Error())
+	}
+	if fc.applyCalls != 0 {
+		t.Errorf("ApplyDocuments fired %d times on lineage mismatch; want 0", fc.applyCalls)
+	}
+}
+
+// TestApply_FromBlueprint_CrossLineage_RefusesAgainstConfigCell ensures the
+// lineage check is strict in both directions: applying -b against a cell whose
+// lineage is a sibling CellConfig also refuses.
+func TestApply_FromBlueprint_CrossLineage_RefusesAgainstConfigCell(t *testing.T) {
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Metadata: v1beta1.CellMetadata{
+						Name:   doc.Metadata.Name,
+						Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	_, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "prod", "--realm", "my-realm"})
+	if err == nil {
+		t.Fatal("expected lineage-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "kukeon.io/config=prod") {
+		t.Errorf("err=%q want existing-lineage detail", err.Error())
+	}
+}
+
+// TestApply_FromConfig_MissingCell_CreatesViaApplyDocuments covers the
+// "missing cell" leg of the -c reconciliation matrix. The materialised cell's
+// stable name comes from StableName(configName); the YAML carries the config
+// back-reference label.
+func TestApply_FromConfig_MissingCell_CreatesViaApplyDocuments(t *testing.T) {
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			if doc.Metadata.Name != "prod" {
+				t.Errorf("config lookup name=%q want prod", doc.Metadata.Name)
+			}
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			if doc.Metadata.Name != "web" || doc.Metadata.Realm != "bp-realm" {
+				t.Errorf("blueprint ref=%q/%q want web/bp-realm", doc.Metadata.Name, doc.Metadata.Realm)
+			}
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
+		},
+		applyFn: func(raw []byte) (kukeonv1.ApplyDocumentsResult, error) {
+			if !strings.Contains(string(raw), "kukeon.io/config: prod") {
+				t.Errorf("materialised YAML missing config lineage label; raw=\n%s", string(raw))
+			}
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{Kind: "Cell", Name: cellconfig.StableName("prod"), Action: "created"},
+				},
+			}, nil
+		},
+	}
+
+	out, err := runApplyRef(t, fc, []string{"-c", "prod", "--realm", "cfg-realm"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "created") {
+		t.Errorf("missing created line in output:\n%s", out)
+	}
+}
+
+// TestApply_FromConfig_LiveCellMatchingLineage_NoOpsViaUnchanged covers the
+// "exists, matches" leg for -c.
+func TestApply_FromConfig_LiveCellMatchingLineage_NoOpsViaUnchanged(t *testing.T) {
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Metadata: v1beta1.CellMetadata{
+						Name:   doc.Metadata.Name,
+						Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{Kind: "Cell", Name: cellconfig.StableName("prod"), Action: "unchanged"},
+				},
+			}, nil
+		},
+	}
+
+	out, err := runApplyRef(t, fc, []string{"-c", "prod", "--realm", "cfg-realm"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "unchanged") {
+		t.Errorf("missing unchanged line in output:\n%s", out)
+	}
+}
+
+// TestApply_FromConfig_LiveCellDivergentSpec_UpdatesViaApplyDocuments covers
+// the "exists, differs" leg for -c. The daemon-side reconciler is mocked to
+// return the per-field changes; the CLI surfaces them under the updated header.
+func TestApply_FromConfig_LiveCellDivergentSpec_UpdatesViaApplyDocuments(t *testing.T) {
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Metadata: v1beta1.CellMetadata{
+						Name:   doc.Metadata.Name,
+						Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+					},
+					Spec: v1beta1.CellSpec{
+						Containers: []v1beta1.ContainerSpec{
+							{ID: "main", Image: "registry.example.com/web:old"},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{
+						Kind:    "Cell",
+						Name:    cellconfig.StableName("prod"),
+						Action:  "updated",
+						Changes: []string{`container "main" updated: image`},
+					},
+				},
+			}, nil
+		},
+	}
+
+	out, err := runApplyRef(t, fc, []string{"-c", "prod", "--realm", "cfg-realm"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "updated") {
+		t.Errorf("missing updated header in output:\n%s", out)
+	}
+	if !strings.Contains(out, `container "main" updated: image`) {
+		t.Errorf("missing per-field diff line in output:\n%s", out)
+	}
+}
+
+// TestApply_FromConfig_LiveCellHandBuilt_RefusesLineageMismatch is the parallel
+// safety gate for -c: a cell sitting at the Config's StableName with no
+// lineage label is refused.
+func TestApply_FromConfig_LiveCellHandBuilt_RefusesLineageMismatch(t *testing.T) {
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:           v1beta1.CellDoc{Metadata: v1beta1.CellMetadata{Name: doc.Metadata.Name}},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	_, err := runApplyRef(t, fc, []string{"-c", "prod", "--realm", "cfg-realm"})
+	if err == nil {
+		t.Fatal("expected lineage-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no lineage label") {
+		t.Errorf("err=%q want mention of 'no lineage label'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "kukeon.io/config=prod") {
+		t.Errorf("err=%q want mention of attempted lineage", err.Error())
+	}
+}
+
+// TestApply_FromConfig_RejectsParamFlags asserts the cobra-side guard: -c is
+// incompatible with --param / --param-file because a CellConfig owns its own
+// spec.values channel.
+func TestApply_FromConfig_RejectsParamFlags(t *testing.T) {
+	fc := &fakeClient{}
+	_, err := runApplyRef(t, fc, []string{"-c", "prod", "--param", "TAG=v3", "--realm", "cfg-realm"})
+	if err == nil || !strings.Contains(err.Error(), "--param is not valid with -c/--config") {
+		t.Fatalf("err=%v want rejection of --param with -c", err)
+	}
+}
+
+// TestApply_BlueprintNotFound_Errors covers the lookup-miss path: GetBlueprint
+// reports MetadataExists=false and the CLI surfaces ErrBlueprintNotFound
+// before any cell read or apply fires.
+func TestApply_BlueprintNotFound_Errors(t *testing.T) {
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
+		},
+	}
+	_, err := runApplyRef(t, fc, []string{"-b", "ghost", "--realm", "my-realm"})
+	if err == nil || !errors.Is(err, errdefs.ErrBlueprintNotFound) {
+		t.Fatalf("err=%v want ErrBlueprintNotFound", err)
+	}
+	if fc.applyCalls != 0 {
+		t.Errorf("ApplyDocuments fired on lookup miss; want 0, got %d", fc.applyCalls)
+	}
+}
+
+// TestApply_ConfigNotFound_Errors is the -c counterpart: GetConfig reports
+// MetadataExists=false.
+func TestApply_ConfigNotFound_Errors(t *testing.T) {
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+		},
+	}
+	_, err := runApplyRef(t, fc, []string{"-c", "ghost", "--realm", "cfg-realm"})
+	if err == nil || !errors.Is(err, errdefs.ErrConfigNotFound) {
+		t.Fatalf("err=%v want ErrConfigNotFound", err)
+	}
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 
-	applyFn func(raw []byte) (kukeonv1.ApplyDocumentsResult, error)
+	applyFn        func(raw []byte) (kukeonv1.ApplyDocumentsResult, error)
+	getCellFn      func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	getBlueprintFn func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error)
+	getConfigFn    func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error)
+
+	applyCalls int
 }
 
 func (f *fakeClient) ApplyDocuments(_ context.Context, raw []byte) (kukeonv1.ApplyDocumentsResult, error) {
+	f.applyCalls++
 	if f.applyFn == nil {
 		return kukeonv1.ApplyDocumentsResult{}, errors.New("unexpected ApplyDocuments call")
 	}
 	return f.applyFn(raw)
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) GetBlueprint(
+	_ context.Context, doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.GetBlueprintResult, error) {
+	if f.getBlueprintFn == nil {
+		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")
+	}
+	return f.getBlueprintFn(doc)
+}
+
+func (f *fakeClient) GetConfig(
+	_ context.Context, doc v1beta1.CellConfigDoc,
+) (kukeonv1.GetConfigResult, error) {
+	if f.getConfigFn == nil {
+		return kukeonv1.GetConfigResult{}, errors.New("unexpected GetConfig call")
+	}
+	return f.getConfigFn(doc)
 }


### PR DESCRIPTION
## Summary

- Extends `kuke apply` to accept daemon-stored Blueprint (`-b`) and Config (`-c`) refs, the apply analogues of `kuke run -b/-c`. The materialised CellDoc is round-tripped through the daemon's existing `ApplyDocuments` so the per-cell reconciliation (create on missing, no-op on match, daemon-side stop/update/start on divergence) reuses the path `kuke apply -f` already drives.
- Adds the lineage-mismatch refusal the issue calls out: before applying, `assertCellLineage` reads the live cell and refuses when its `kukeon.io/blueprint` / `kukeon.io/config` label does not match the named source (hand-built cells or sibling-source cells are surfaced explicitly so the cron never silently overwrites Alice's work).
- Mirrors `kuke run`'s flag grammar: `-f` / `-b` / `-c` are mutually exclusive and exactly one is required; `--name`, `--param`, `--param-file` are rejected with `-f`; `--param`, `--param-file` are rejected with `-c` (Config owns its values); `--realm`, `--space`, `--stack` constrain the Blueprint/Config lookup.
- No attach loop: `apply` is pure reconciliation. Matches `apply -f`'s existing shape.

## Notes for the reviewer

- The `-f` path is behaviourally unchanged. The cobra-error wording for "no source" shifts from `required flag` to `at least one of the flags in the group [file blueprint config] is required` (the `MarkFlagsOneRequired` form replaces `MarkFlagRequired("file")`); the existing test for that case was updated to match.
- I duplicated the Blueprint/Config loaders that already live in `cmd/kuke/run/run.go` (`loadFromBlueprint`, `loadFromConfig`, `buildParamMap`, `pickRealm` / `explicitScope`, `resolveCellLocation`) rather than extracting them into a shared package — the run-side helpers are unexported and lifting them into a new shared package felt like scope creep against the issue's "extend `kuke apply`" framing. The duplication is small (~90 lines) and the next phase that touches `kuke run -b/-c --name` divergent-reject behaviour (issue body's notes) is a natural moment to factor them out.
- Reconciliation work is delegated to `client.ApplyDocuments` on the marshalled CellDoc, so the daemon-side `ReconcileCell` / `UpdateCell` path owns the per-container Stop → recreate → Start sequence already exercised by `apply -f`. The CLI side only adds the lineage gate (which the daemon doesn't enforce).
- `docs/site/cli/kuke-apply.md` does not yet mention `-b`/`-c`. Following the pattern of PR #750 (docs for `run -b/-c` landed separately after the feature in #742), I've left the doc update for a follow-up PR; happy to bundle if preferred.

## Test plan

- [x] `GOWORK=off go test ./cmd/kuke/apply/...` (covers the seven new -b/-c cases plus the four existing -f cases)
- [x] `make test` (full root + kukebuild suite; all green)
- [x] `pre-commit run --files cmd/kuke/apply/apply.go cmd/kuke/apply/apply_test.go`
- [x] `GOWORK=off go build ./...`
- [ ] `make dev-init` smoke not run — change is CLI-only (no daemon, build path, or `/opt/kukeon` reads touched), so the regression guard the smoke catches does not apply here.

Closes #752