### PR TITLE
feat(status): add kuke status host/daemon/parity health report

### DIFF
--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -41,6 +41,7 @@ import (
 	refreshcmd "github.com/eminwux/kukeon/cmd/kuke/refresh"
 	runcmd "github.com/eminwux/kukeon/cmd/kuke/run"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/start"
+	statuscmd "github.com/eminwux/kukeon/cmd/kuke/status"
 	stopcmd "github.com/eminwux/kukeon/cmd/kuke/stop"
 	uninstallcmd "github.com/eminwux/kukeon/cmd/kuke/uninstall"
 	"github.com/eminwux/kukeon/cmd/kuke/version"
@@ -150,6 +151,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(deletecmd.NewDeleteCmd())
 	rootCmd.AddCommand(doctorcmd.NewDoctorCmd())
 	rootCmd.AddCommand(startcmd.NewStartCmd())
+	rootCmd.AddCommand(statuscmd.NewStatusCmd())
 	rootCmd.AddCommand(stopcmd.NewStopCmd())
 	rootCmd.AddCommand(killcmd.NewKillCmd())
 	rootCmd.AddCommand(purgecmd.NewPurgeCmd())

--- a/cmd/kuke/status/checks.go
+++ b/cmd/kuke/status/checks.go
@@ -1,0 +1,395 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/eminwux/kukeon/internal/consts"
+)
+
+// Section names — kept as constants so the renderer's section grouping and
+// the JSON `section` field are spelled the same way everywhere.
+const (
+	sectionDaemon = "daemon"
+	sectionHost   = "host"
+	sectionState  = "state"
+	sectionParity = "parity"
+)
+
+// checkDaemon reports the daemon's reachability. The single row carries the
+// dial outcome, the round-trip latency, and the daemon's reported build
+// version — the three things the gaps doc's `kuke ping` proposal wanted.
+// FAIL on dial failure or Ping error; OK otherwise.
+func checkDaemon(ctx context.Context, rc *runCtx) []Result {
+	r := Result{
+		Section: sectionDaemon,
+		Name:    "socket",
+	}
+
+	if rc.daemonClient == nil {
+		r.Status = StatusFAIL
+		r.Detail = fmt.Sprintf("%s (dial failed)", rc.daemonHost)
+		r.Remediation = "start kukeond or set --host; `kuke init` brings the daemon up"
+		return []Result{r}
+	}
+
+	start := time.Now()
+	version, err := rc.daemonClient.PingVersion(ctx)
+	rtt := time.Since(start)
+	if err != nil {
+		r.Status = StatusFAIL
+		r.Detail = fmt.Sprintf("%s (ping failed: %v)", rc.daemonHost, err)
+		r.Remediation = "check `kuke daemon reset` and `kuke init` to re-bootstrap kukeond"
+		return []Result{r}
+	}
+
+	if version == "" {
+		// Daemon answered but didn't report a version (older build, or
+		// linker omitted the -X). Still OK — the dial worked — but the
+		// detail call-out is honest.
+		r.Status = StatusOK
+		r.Detail = fmt.Sprintf("%s (rtt %s, version unknown)", rc.daemonHost, fmtRTT(rtt))
+		return []Result{r}
+	}
+
+	r.Status = StatusOK
+	r.Detail = fmt.Sprintf("%s (rtt %s, version %s)", rc.daemonHost, fmtRTT(rtt), version)
+	return []Result{r}
+}
+
+// checkHost runs the three host-environment checks the gaps doc's
+// `kuke doctor` proposal absorbed into this single section: containerd
+// reachability, cgroup-v2 mountedness, and the presence of the CNI plugin
+// binaries `kuke init` would otherwise lay down. Each emits one Result.
+//
+// No ctx: the host probes are filesystem stats and a ctr.Client.Connect()
+// whose cancellation surface is the client's own context. Adding a ctx
+// param "in case" would invite the unused-parameter lint.
+func checkHost(rc *runCtx) []Result {
+	return []Result{
+		checkHostContainerd(rc),
+		checkHostCgroupV2(rc),
+		checkHostCNIPlugins(rc),
+	}
+}
+
+// checkHostContainerd dials the configured containerd socket via the
+// in-process ctr client (the same wrapper kuke build / kuke init use, so
+// reachability here is exactly what those commands would see). On
+// success, ListNamespaces is what `verifyConnection` round-trips inside
+// ctr.Client.Connect — no extra read needed.
+func checkHostContainerd(rc *runCtx) Result {
+	r := Result{
+		Section: sectionHost,
+		Name:    "containerd",
+	}
+
+	if rc.ctrClient == nil {
+		r.Status = StatusFAIL
+		r.Detail = "ctr client not constructed"
+		r.Remediation = "internal: status invoked without a containerd wrapper"
+		return r
+	}
+
+	if err := rc.ctrClient.Connect(); err != nil {
+		r.Status = StatusFAIL
+		r.Detail = fmt.Sprintf("%s (dial failed: %v)", rc.containerdSocket, err)
+		r.Remediation = "start containerd: `service containerd start` (see project CLAUDE.md)"
+		return r
+	}
+
+	r.Status = StatusOK
+	r.Detail = fmt.Sprintf("%s (reachable)", rc.containerdSocket)
+	return r
+}
+
+// checkHostCgroupV2 reads cgroup.controllers at the configured cgroup
+// root — that file's existence is the canonical cgroup-v2 mount probe
+// the cgroupcheck package already wraps; the host advertising any
+// controllers means v2 is mounted unified at that path. FAIL on read
+// error (no v2 mount, or the directory is wrong); WARN when the file is
+// readable but reports zero controllers (a bare-kernel build, no
+// delegation done yet).
+func checkHostCgroupV2(rc *runCtx) Result {
+	r := Result{
+		Section: sectionHost,
+		Name:    "cgroup-v2",
+	}
+
+	controllersPath := filepath.Join(rc.cgroupRoot, "cgroup.controllers")
+	data, err := os.ReadFile(controllersPath)
+	if err != nil {
+		r.Status = StatusFAIL
+		r.Detail = fmt.Sprintf("%s (not mounted: %v)", rc.cgroupRoot, err)
+		r.Remediation = "boot with cgroup-v2 unified mode; see `kuke doctor cgroups` for the full pre-flight"
+		return r
+	}
+
+	controllers := strings.Fields(strings.TrimSpace(string(data)))
+	if len(controllers) == 0 {
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("%s (mounted, no controllers advertised)", rc.cgroupRoot)
+		r.Remediation = "verify the kernel build enables cgroup-v2 controllers"
+		return r
+	}
+
+	r.Status = StatusOK
+	r.Detail = fmt.Sprintf("%s (mounted, %d controllers)", rc.cgroupRoot, len(controllers))
+	return r
+}
+
+// checkHostCNIPlugins stats each requiredCNIPlugins under the configured
+// CNI bin dir. FAIL when any are missing — without bridge/loopback the
+// per-container netns wiring `kuke create container` does cannot
+// complete. Surfacing the specific missing plugin name in Detail keeps
+// the operator from having to ls the directory themselves.
+func checkHostCNIPlugins(rc *runCtx) Result {
+	r := Result{
+		Section: sectionHost,
+		Name:    "cni-plugins",
+	}
+
+	plugins := requiredCNIPlugins()
+	var missing []string
+	for _, plugin := range plugins {
+		path := filepath.Join(rc.cniBinDir, plugin)
+		if _, err := os.Stat(path); err != nil {
+			missing = append(missing, plugin)
+		}
+	}
+
+	if len(missing) > 0 {
+		r.Status = StatusFAIL
+		r.Detail = fmt.Sprintf("%s (missing: %s)", rc.cniBinDir, strings.Join(missing, ", "))
+		r.Remediation = "install the CNI plugin binaries; `kuke init` lays them down on a fresh host"
+		return r
+	}
+
+	r.Status = StatusOK
+	r.Detail = fmt.Sprintf("%s (%s present)", rc.cniBinDir, strings.Join(plugins, ", "))
+	return r
+}
+
+// checkState runs the consistency probes the gaps doc's `kuke selftest`
+// proposal called for: stale orphan files in the run dir, and residual
+// containerd namespaces that no realm claims. WARN by default — neither
+// surfaces a serving regression (a daemon can run fine alongside an
+// orphan from a prior reset that wasn't fully cleaned), but the operator
+// wants to know.
+func checkState(ctx context.Context, rc *runCtx) []Result {
+	return []Result{
+		checkStateRunDir(rc),
+		checkStateNamespaces(ctx, rc),
+	}
+}
+
+// checkStateRunDir enumerates entries directly under rc.runPath/.. that
+// the kukeon runtime knows about — the canonical sock, pid, and
+// well-known subdirs — and reports any other top-level entry under the
+// `/run/kukeon` parent dir as an orphan. Only checks the run-socket
+// directory (parent of the kukeond socket), not the data dir, because
+// the data dir is partitioned by realm and the parity walk covers
+// divergence there.
+//
+// Heuristic only — the check can't reliably distinguish a live socket
+// from a dead one without an extra `lsof`-style probe, which the
+// AC doesn't budget for. The role is to surface "the run dir looks
+// unexpectedly populated" so the operator inspects, not to enforce.
+func checkStateRunDir(rc *runCtx) Result {
+	r := Result{
+		Section: sectionState,
+		Name:    "run-dir",
+	}
+
+	// The kukeond socket usually lives at /run/kukeon/kukeond.sock;
+	// when --run-path is set, the socket auto-derives via
+	// applyRunPathImpliesKukeondSocket. Either way we inspect the dir
+	// the socket sits in, not the run-path data dir.
+	socketDir := canonicalRunSocketDir(rc.runPath)
+
+	entries, err := os.ReadDir(socketDir)
+	if err != nil {
+		// An absent run-socket dir on a non-init'd host is not a state
+		// inconsistency — it's the documented bare-host state. Surface
+		// as OK with a "not present" detail rather than FAIL.
+		if os.IsNotExist(err) {
+			r.Status = StatusOK
+			r.Detail = fmt.Sprintf("%s (not present; daemon not initialized)", socketDir)
+			return r
+		}
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("%s (read failed: %v)", socketDir, err)
+		return r
+	}
+
+	expected := map[string]bool{
+		"kukeond.sock":                   true,
+		"kukeond.pid":                    true,
+		consts.KukeonSocketSymlinkSubdir: true, // "s"
+		consts.KukeonContainerTTYDir:     true, // "tty"
+	}
+
+	var orphans []string
+	for _, e := range entries {
+		if expected[e.Name()] {
+			continue
+		}
+		orphans = append(orphans, e.Name())
+	}
+
+	if len(orphans) == 0 {
+		r.Status = StatusOK
+		r.Detail = fmt.Sprintf("%s (no orphan entries)", socketDir)
+		return r
+	}
+
+	sort.Strings(orphans)
+	r.Status = StatusWARN
+	r.Detail = fmt.Sprintf("%s (orphan entries: %s)", socketDir, strings.Join(orphans, ", "))
+	r.Remediation = "`kuke daemon reset` clears stale run-dir state before re-init"
+	return r
+}
+
+// canonicalRunSocketDir returns the directory the kukeond socket lives
+// in. Default runs use /run/kukeon; bespoke --run-path setups put the
+// socket under <runPath>/kukeond.sock per applyRunPathImpliesKukeondSocket
+// in cmd/kuke/kuke.go.
+//
+// The runPath default (/opt/kukeon) is NOT the same directory as the
+// run-socket default (/run/kukeon) — runPath is the data tree, the
+// socket lives in /run by convention. So when runPath looks like the
+// default data path, we point at /run/kukeon explicitly.
+func canonicalRunSocketDir(runPath string) string {
+	// Bare-default case: data dir is /opt/kukeon, socket lives in
+	// /run/kukeon. The kukeond.sock default in cmd/config/env.go:134
+	// hardcodes /run/kukeon/kukeond.sock for exactly this reason.
+	if runPath == "" || runPath == "/opt/kukeon" {
+		return "/run/kukeon"
+	}
+	// Non-default run-path: applyRunPathImpliesKukeondSocket derives
+	// the socket as <runPath>/kukeond.sock, so the run-socket dir is
+	// runPath itself.
+	return runPath
+}
+
+// checkStateNamespaces lists containerd namespaces and flags any that
+// don't end in the kukeon suffix or whose realm prefix doesn't match a
+// known realm. Requires the daemon path to enumerate realms — if the
+// daemon is down, we skip the cross-reference and report just the raw
+// namespace count (the user already has the daemon-down signal from the
+// daemon section).
+func checkStateNamespaces(ctx context.Context, rc *runCtx) Result {
+	r := Result{
+		Section: sectionState,
+		Name:    "containerd-ns",
+	}
+
+	if rc.ctrClient == nil {
+		r.Status = StatusWARN
+		r.Detail = "ctr client not constructed"
+		return r
+	}
+
+	// Connect() is idempotent (verifyConnection short-circuits when the
+	// client already dialed) — the host check above usually already
+	// connected, but on the daemon-down path the host check may have
+	// failed and we need a fresh attempt here.
+	if err := rc.ctrClient.Connect(); err != nil {
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("ctr unreachable: %v", err)
+		return r
+	}
+
+	nsList, err := rc.ctrClient.ListNamespaces()
+	if err != nil {
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("list namespaces failed: %v", err)
+		return r
+	}
+
+	// Filter to namespaces under the kukeon suffix — that's what
+	// `kuke init` provisions and what `kuke uninstall` removes. Other
+	// namespaces on the same containerd (e.g. user docker namespaces)
+	// are not ours to police.
+	var kukeonNS []string
+	for _, ns := range nsList {
+		if consts.IsKukeonNamespace(ns) {
+			kukeonNS = append(kukeonNS, ns)
+		}
+	}
+
+	if rc.daemonClient == nil {
+		// Daemon is down — we can't enumerate realms to cross-check.
+		// Report what we see without a verdict beyond the count.
+		sort.Strings(kukeonNS)
+		r.Status = StatusOK
+		r.Detail = fmt.Sprintf("%d kukeon namespaces (daemon down, no cross-check)", len(kukeonNS))
+		return r
+	}
+
+	realms, err := rc.daemonClient.ListRealms(ctx)
+	if err != nil {
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("list realms failed: %v", err)
+		return r
+	}
+
+	expectedNS := make(map[string]bool, len(realms))
+	for i := range realms {
+		expectedNS[consts.RealmNamespace(realms[i].Metadata.Name)] = true
+	}
+
+	var residual []string
+	for _, ns := range kukeonNS {
+		if !expectedNS[ns] {
+			residual = append(residual, ns)
+		}
+	}
+
+	if len(residual) == 0 {
+		r.Status = StatusOK
+		r.Detail = fmt.Sprintf("%d kukeon namespaces, all claimed by a realm", len(kukeonNS))
+		return r
+	}
+
+	sort.Strings(residual)
+	r.Status = StatusWARN
+	r.Detail = fmt.Sprintf("residual namespaces: %s", strings.Join(residual, ", "))
+	r.Remediation = "`kuke uninstall` or hand-cleanup with `ctr -n <ns> namespace remove`"
+	return r
+}
+
+// fmtRTT formats a ping round-trip duration with sub-millisecond
+// resolution. time.Duration.String() picks units inconsistently for
+// short durations (e.g. "1.234ms" but also "500µs") — fixing to one
+// fractional milli-digit keeps the daemon row visually aligned.
+func fmtRTT(d time.Duration) string {
+	if d < time.Microsecond {
+		return "0ms"
+	}
+	// time.Duration is integer nanoseconds; dividing by Millisecond's
+	// float yields ms with sub-ms resolution without the mnd-tripping
+	// `1000` literal a Microseconds/1000 ratio would otherwise carry.
+	return fmt.Sprintf("%.1fms", float64(d)/float64(time.Millisecond))
+}

--- a/cmd/kuke/status/parity.go
+++ b/cmd/kuke/status/parity.go
@@ -1,0 +1,392 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// checkParity is the regression-guard the CLAUDE.md daemon-parity ritual
+// has been doing by hand: every `kuke get <kind>` must return the same
+// set of names when run against the daemon and in-process. The walk
+// covers each kind in turn — realm, then space (per realm), then stack
+// (per realm/space), then cell (per realm/space/stack), then container
+// (per cell), then the scope-flat kinds (secret, blueprint, config).
+//
+// Both clients must be constructible. When either is nil (the daemon-down
+// case at status startup, or an in-process construction failure injected
+// in tests), the parity row degrades to a single WARN row naming the
+// missing branch — there is nothing to compare against, but the section
+// stays present so JSON shape is stable.
+func checkParity(ctx context.Context, rc *runCtx) []Result {
+	if rc.daemonClient == nil {
+		return []Result{{
+			Section:     sectionParity,
+			Name:        "realms",
+			Status:      StatusWARN,
+			Detail:      "skipped: daemon not reachable",
+			Remediation: "the daemon row above carries the underlying cause",
+		}}
+	}
+	if rc.localClient == nil {
+		return []Result{{
+			Section:     sectionParity,
+			Name:        "realms",
+			Status:      StatusWARN,
+			Detail:      "skipped: in-process client unavailable",
+			Remediation: "internal: status invoked without a local client",
+		}}
+	}
+
+	var results []Result
+
+	// Realm parity: top of the walk. If the realm lists disagree the
+	// nested kinds may not even be enumerable (a realm present in one
+	// branch but missing in the other can't have its spaces compared),
+	// so the parity row carries that information and the walk
+	// recurses only into the names that appear in both branches —
+	// divergent realms surface as the realm row above.
+	// Distinct error-var names per nesting level — Go's lexical scoping
+	// would shadow a reused `dErr`/`lErr` inside the nested loops, which
+	// govet flags. The naming keeps the linter quiet without inflating
+	// the loop bodies with intermediate result structs.
+	dRealms, dRealmErr := listRealmNames(ctx, rc.daemonClient)
+	lRealms, lRealmErr := listRealmNames(ctx, rc.localClient)
+	realmResult, realmsBoth := parityFromLists("realms", dRealms, dRealmErr, lRealms, lRealmErr)
+	results = append(results, realmResult)
+
+	for _, realm := range realmsBoth {
+		dSpaces, dSpaceErr := listSpaceNames(ctx, rc.daemonClient, realm)
+		lSpaces, lSpaceErr := listSpaceNames(ctx, rc.localClient, realm)
+		spaceResult, spacesBoth := parityFromLists(
+			fmt.Sprintf("spaces/%s", realm),
+			dSpaces, dSpaceErr, lSpaces, lSpaceErr,
+		)
+		results = append(results, spaceResult)
+
+		for _, space := range spacesBoth {
+			dStacks, dStackErr := listStackNames(ctx, rc.daemonClient, realm, space)
+			lStacks, lStackErr := listStackNames(ctx, rc.localClient, realm, space)
+			stackResult, stacksBoth := parityFromLists(
+				fmt.Sprintf("stacks/%s/%s", realm, space),
+				dStacks, dStackErr, lStacks, lStackErr,
+			)
+			results = append(results, stackResult)
+
+			for _, stack := range stacksBoth {
+				dCells, dCellErr := listCellNames(ctx, rc.daemonClient, realm, space, stack)
+				lCells, lCellErr := listCellNames(ctx, rc.localClient, realm, space, stack)
+				cellResult, cellsBoth := parityFromLists(
+					fmt.Sprintf("cells/%s/%s/%s", realm, space, stack),
+					dCells, dCellErr, lCells, lCellErr,
+				)
+				results = append(results, cellResult)
+
+				for _, cell := range cellsBoth {
+					dContainers, dContainerErr := listContainerNames(ctx, rc.daemonClient, realm, space, stack, cell)
+					lContainers, lContainerErr := listContainerNames(ctx, rc.localClient, realm, space, stack, cell)
+					containerResult, _ := parityFromLists(
+						fmt.Sprintf("containers/%s/%s/%s/%s", realm, space, stack, cell),
+						dContainers, dContainerErr, lContainers, lContainerErr,
+					)
+					results = append(results, containerResult)
+				}
+			}
+		}
+	}
+
+	// Scope-flat kinds: secret / blueprint / config support a
+	// cross-scope listing via empty filter arguments. One row per kind,
+	// not one per scope — the AC's "every `kuke get <kind>`" wording
+	// reads against the user-facing verbs, and these three have no
+	// per-scope sub-verb the operator would run separately.
+	dSecrets, dSecretErr := listSecretNames(ctx, rc.daemonClient)
+	lSecrets, lSecretErr := listSecretNames(ctx, rc.localClient)
+	results = append(results, parityFromCall("secrets", dSecrets, dSecretErr, lSecrets, lSecretErr))
+
+	dBlueprints, dBlueprintErr := listBlueprintNames(ctx, rc.daemonClient)
+	lBlueprints, lBlueprintErr := listBlueprintNames(ctx, rc.localClient)
+	results = append(results, parityFromCall("blueprints", dBlueprints, dBlueprintErr, lBlueprints, lBlueprintErr))
+
+	dConfigs, dConfigErr := listConfigNames(ctx, rc.daemonClient)
+	lConfigs, lConfigErr := listConfigNames(ctx, rc.localClient)
+	results = append(results, parityFromCall("configs", dConfigs, dConfigErr, lConfigs, lConfigErr))
+
+	return results
+}
+
+// parityFromLists builds a single parity Result and the set of names that
+// appear in both branches, which the recursive walk uses to descend into
+// nested kinds. Errors on either branch demote the row to WARN (we can't
+// compare what we can't enumerate) — only the FAIL path is a true
+// divergence between equally-served branches.
+func parityFromLists(name string, daemon []string, daemonErr error, local []string, localErr error) (Result, []string) {
+	r := Result{
+		Section: sectionParity,
+		Name:    name,
+	}
+
+	if daemonErr != nil && localErr != nil {
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("both branches errored: daemon=%v local=%v", daemonErr, localErr)
+		return r, nil
+	}
+	if daemonErr != nil {
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("daemon errored: %v", daemonErr)
+		return r, nil
+	}
+	if localErr != nil {
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("in-process errored: %v", localErr)
+		return r, nil
+	}
+
+	dSet := toSet(daemon)
+	lSet := toSet(local)
+
+	onlyDaemon := diff(dSet, lSet)
+	onlyLocal := diff(lSet, dSet)
+	both := intersect(dSet, lSet)
+
+	if len(onlyDaemon) == 0 && len(onlyLocal) == 0 {
+		r.Status = StatusOK
+		if len(both) == 0 {
+			r.Detail = "0 items (both branches empty)"
+		} else {
+			r.Detail = fmt.Sprintf("%d items match (%s)", len(both), strings.Join(both, ", "))
+		}
+		return r, both
+	}
+
+	r.Status = StatusFAIL
+	var parts []string
+	if len(onlyDaemon) > 0 {
+		parts = append(parts, "daemon-only: "+strings.Join(onlyDaemon, ", "))
+	}
+	if len(onlyLocal) > 0 {
+		parts = append(parts, "in-process-only: "+strings.Join(onlyLocal, ", "))
+	}
+	r.Detail = strings.Join(parts, "; ")
+	r.Remediation = "the daemon's view of /opt/kukeon diverges from the in-process controller's; " +
+		"investigate bind-mount or run-path mismatch"
+	return r, both
+}
+
+// parityFromCall is the no-recursion variant — secret / blueprint /
+// config are scope-flat kinds whose intersection is not used for a
+// nested walk. Same Result shape as parityFromLists.
+func parityFromCall(name string, daemon []string, daemonErr error, local []string, localErr error) Result {
+	r, _ := parityFromLists(name, daemon, daemonErr, local, localErr)
+	return r
+}
+
+// ---- Listers ----
+//
+// Each lister wraps one List* method on kukeonv1.Client and pulls just
+// the Name (or qualified-name, for scope-flat kinds) field so
+// parityFromLists can compare strings. Errors are propagated untouched
+// so the parity row can name which branch errored.
+
+func listRealmNames(ctx context.Context, c kukeonv1.Client) ([]string, error) {
+	in, err := c.ListRealms(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(in))
+	for i := range in {
+		out = append(out, in[i].Metadata.Name)
+	}
+	return out, nil
+}
+
+func listSpaceNames(ctx context.Context, c kukeonv1.Client, realm string) ([]string, error) {
+	in, err := c.ListSpaces(ctx, realm)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(in))
+	for i := range in {
+		out = append(out, in[i].Metadata.Name)
+	}
+	return out, nil
+}
+
+func listStackNames(ctx context.Context, c kukeonv1.Client, realm, space string) ([]string, error) {
+	in, err := c.ListStacks(ctx, realm, space)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(in))
+	for i := range in {
+		out = append(out, in[i].Metadata.Name)
+	}
+	return out, nil
+}
+
+func listCellNames(ctx context.Context, c kukeonv1.Client, realm, space, stack string) ([]string, error) {
+	in, err := c.ListCells(ctx, realm, space, stack)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(in))
+	for i := range in {
+		out = append(out, in[i].Metadata.Name)
+	}
+	return out, nil
+}
+
+func listContainerNames(
+	ctx context.Context, c kukeonv1.Client, realm, space, stack, cell string,
+) ([]string, error) {
+	in, err := c.ListContainers(ctx, realm, space, stack, cell)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(in))
+	for i := range in {
+		// ContainerSpec carries its identity as ID, not Name (the
+		// scope-flat parent is implicit in the per-cell query). The
+		// daemon and in-process branches both populate this from the
+		// same on-disk container.json, so it is the right comparable.
+		out = append(out, in[i].ID)
+	}
+	return out, nil
+}
+
+func listSecretNames(ctx context.Context, c kukeonv1.Client) ([]string, error) {
+	in, err := c.ListSecrets(ctx, "", "", "", "")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(in))
+	for i := range in {
+		out = append(out, secretQualifiedName(in[i]))
+	}
+	return out, nil
+}
+
+func listBlueprintNames(ctx context.Context, c kukeonv1.Client) ([]string, error) {
+	in, err := c.ListBlueprints(ctx, "", "", "")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(in))
+	for i := range in {
+		out = append(out, blueprintQualifiedName(in[i]))
+	}
+	return out, nil
+}
+
+func listConfigNames(ctx context.Context, c kukeonv1.Client) ([]string, error) {
+	in, err := c.ListConfigs(ctx, "", "", "")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(in))
+	for i := range in {
+		out = append(out, configQualifiedName(in[i]))
+	}
+	return out, nil
+}
+
+// secretQualifiedName joins the scope coordinates and the secret name.
+// Scope-flat lists span all realms, so the name alone isn't unique — a
+// Secret "foo" in realm A is distinct from a Secret "foo" in realm B.
+// Joining with "/" matches the storage layout's path shape. Scope
+// coordinates live in Metadata, not Spec, for Secret / Blueprint /
+// Config (consistent with the parent realm/space/stack Doc shape).
+func secretQualifiedName(doc v1beta1.SecretDoc) string {
+	return qualifiedName(
+		doc.Metadata.Realm,
+		doc.Metadata.Space,
+		doc.Metadata.Stack,
+		doc.Metadata.Cell,
+		doc.Metadata.Name,
+	)
+}
+
+// blueprintQualifiedName is the analogous helper for blueprints. A
+// blueprint is never cell-scoped (#643), so the cell coordinate is
+// always empty.
+func blueprintQualifiedName(doc v1beta1.CellBlueprintDoc) string {
+	return qualifiedName(doc.Metadata.Realm, doc.Metadata.Space, doc.Metadata.Stack, "", doc.Metadata.Name)
+}
+
+// configQualifiedName is the analogous helper for configs. A config is
+// never cell-scoped (#644), so the cell coordinate is always empty.
+func configQualifiedName(doc v1beta1.CellConfigDoc) string {
+	return qualifiedName(doc.Metadata.Realm, doc.Metadata.Space, doc.Metadata.Stack, "", doc.Metadata.Name)
+}
+
+func qualifiedName(realm, space, stack, cell, name string) string {
+	parts := make([]string, 0)
+	if realm != "" {
+		parts = append(parts, realm)
+	}
+	if space != "" {
+		parts = append(parts, space)
+	}
+	if stack != "" {
+		parts = append(parts, stack)
+	}
+	if cell != "" {
+		parts = append(parts, cell)
+	}
+	parts = append(parts, name)
+	return strings.Join(parts, "/")
+}
+
+// ---- Set helpers ----
+
+func toSet(in []string) map[string]struct{} {
+	s := make(map[string]struct{}, len(in))
+	for _, x := range in {
+		s[x] = struct{}{}
+	}
+	return s
+}
+
+// diff returns the names in a that are not in b, sorted.
+func diff(a, b map[string]struct{}) []string {
+	out := make([]string, 0)
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// intersect returns the names common to a and b, sorted.
+func intersect(a, b map[string]struct{}) []string {
+	out := make([]string, 0)
+	for k := range a {
+		if _, ok := b[k]; ok {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/kuke/status/render.go
+++ b/cmd/kuke/status/render.go
@@ -1,0 +1,82 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// renderJSON marshals the report as a stable, 2-space-indented JSON
+// document. Status is rendered as its label ("OK"/"WARN"/"FAIL") rather
+// than the iota value so the wire shape doesn't depend on enum order.
+func renderJSON(w io.Writer, report Report) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(report)
+}
+
+// renderText prints the section-grouped human report. Section header
+// lines are uppercased; each row is `  <NAME>  <STATUS>  <DETAIL>`
+// padded so columns line up. Remediation lines print on the next line
+// indented under their row, only when verbose is true or the row is not
+// OK — the AC's "one-line remediation hint" lives there.
+//
+// The final line reports the top-level verdict ("Status: OK" /
+// "Status: FAIL") so an operator scrolling to the bottom sees the
+// overall result without re-scanning every row.
+func renderText(w io.Writer, report Report, verbose bool) {
+	if len(report.Checks) == 0 {
+		fmt.Fprintln(w, "no checks reported")
+		return
+	}
+
+	// Column widths sized to the widest name across all sections so the
+	// status column lines up across the whole report rather than per
+	// section. STATUS is always one of OK/WARN/FAIL so a fixed 4-char
+	// budget covers it.
+	nameWidth := 0
+	for _, c := range report.Checks {
+		if n := len(c.Name); n > nameWidth {
+			nameWidth = n
+		}
+	}
+
+	var currentSection string
+	for _, c := range report.Checks {
+		if c.Section != currentSection {
+			if currentSection != "" {
+				fmt.Fprintln(w)
+			}
+			fmt.Fprintf(w, "%s\n", strings.ToUpper(c.Section))
+			currentSection = c.Section
+		}
+		fmt.Fprintf(w, "  %-*s  %-4s  %s\n", nameWidth, c.Name, c.Status, c.Detail)
+		if c.Remediation != "" && (verbose || c.Status != StatusOK) {
+			fmt.Fprintf(w, "  %-*s        ↳ %s\n", nameWidth, "", c.Remediation)
+		}
+	}
+
+	fmt.Fprintln(w)
+	if report.OK {
+		fmt.Fprintln(w, "Status: OK")
+	} else {
+		fmt.Fprintln(w, "Status: FAIL")
+	}
+}

--- a/cmd/kuke/status/status.go
+++ b/cmd/kuke/status/status.go
@@ -1,0 +1,347 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package status implements `kuke status`, the consolidated health report
+// that absorbs the original gaps doc's three separate proposals — `kuke
+// doctor` (host pre-flight is now `kuke doctor cgroups`), `kuke ping`
+// (daemon liveness), and `kuke selftest` (parity + state consistency) —
+// into one post-init smoke command. Replaces the manual
+// `kuke get realms` vs `kuke get realms --no-daemon` diff ritual the
+// project CLAUDE.md spells out (issue #202).
+package status
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/cgroupcheck"
+	"github.com/eminwux/kukeon/internal/client/local"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// Status classifies one check's outcome. OK is the silent pass, WARN is
+// informational (the check found something unusual but the system is
+// still serving), FAIL is a regression signal — the exit code is non-zero
+// when any row carries FAIL, matching the issue #202 contract.
+type Status int
+
+const (
+	StatusOK Status = iota
+	StatusWARN
+	StatusFAIL
+)
+
+// String returns the short label rendered in the human output and the JSON
+// `status` field. Kept short so the human table column doesn't widen.
+func (s Status) String() string {
+	switch s {
+	case StatusOK:
+		return "OK"
+	case StatusWARN:
+		return "WARN"
+	case StatusFAIL:
+		return "FAIL"
+	default:
+		return fmt.Sprintf("status(%d)", int(s))
+	}
+}
+
+// MarshalJSON renders the human label rather than the integer so the
+// `--json` output is stable across enum reordering.
+func (s Status) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
+// Result is one row in the report — every section emits one Result per
+// check. Detail is the short one-line summary printed next to the status;
+// Remediation is the optional one-line fix hint surfaced when --verbose is
+// set or whenever the status is WARN/FAIL.
+type Result struct {
+	Section     string `json:"section"`
+	Name        string `json:"name"`
+	Status      Status `json:"status"`
+	Detail      string `json:"detail,omitempty"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// Report is the full top-level payload — what --json marshals, and what the
+// human renderer iterates over to print the section table.
+type Report struct {
+	OK     bool     `json:"ok"`
+	Checks []Result `json:"checks"`
+}
+
+// runCtx threads the configuration and pre-constructed clients through the
+// individual check functions. Constructed once per `kuke status` invocation
+// so the daemon and in-process branches are dialed at most once each, even
+// when the parity walk fans out across resource kinds.
+type runCtx struct {
+	daemonHost       string
+	runPath          string
+	containerdSocket string
+	cgroupRoot       string
+	cniBinDir        string
+
+	logger *slog.Logger
+
+	// daemonClient is the JSON-RPC client dialing kukeond. nil when the
+	// dial failed at runStatus startup; the daemon section's checks
+	// degrade to FAIL with the dial error in that case.
+	daemonClient kukeonv1.Client
+	// localClient is the in-process kukeonv1.Client backed by a fresh
+	// controller.Exec. Always constructible (it is just struct
+	// initialization) — first-call errors surface inside the parity walk.
+	localClient kukeonv1.Client
+	// ctrClient lazily wraps the containerd socket. Connect()-ed on the
+	// host section's containerd check and reused by the state section's
+	// residual-namespace probe. Narrowed to the three-method subset
+	// status actually calls so tests can mock it without dragging the
+	// full ctr.Client surface in.
+	ctrClient ctrConn
+}
+
+// ctrConn is the minimal ctr.Client subset status calls — the host's
+// containerd reachability check (Connect) and the state section's
+// residual-namespace probe (ListNamespaces). Close releases the dial.
+// internal/ctr's concrete *client satisfies this trivially; the test
+// mock implements only these three methods.
+type ctrConn interface {
+	Connect() error
+	Close() error
+	ListNamespaces() ([]string, error)
+}
+
+// MockRunCtxKey is the context key tests use to inject a pre-built runCtx
+// (mock clients, temp paths) so the command can be exercised end-to-end
+// without dialing a real daemon, opening containerd, or walking
+// /sys/fs/cgroup. Mirrors the MockControllerKey pattern the get
+// subcommands use.
+type MockRunCtxKey struct{}
+
+// NewStatusCmd builds the `kuke status` command.
+func NewStatusCmd() *cobra.Command {
+	var (
+		jsonOut bool
+		verbose bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Report kukeon daemon, host, state, and parity health",
+		Long: "Run the consolidated health report that replaces the manual\n" +
+			"`kuke get realms` vs `kuke get realms --no-daemon` diff ritual.\n\n" +
+			"Sections: daemon (socket dialable, round-trip, version), host\n" +
+			"(containerd, cgroup-v2, CNI plugins), state (orphan sockets,\n" +
+			"residual containerd namespaces), parity (every `kuke get <kind>`\n" +
+			"agrees daemon-side vs in-process). Each line is OK / WARN / FAIL\n" +
+			"with a one-line remediation hint when the status is not OK.\n\n" +
+			"Exit code 0 when every check is OK or WARN; non-zero when any line\n" +
+			"is FAIL. The `--json` form is the machine-readable shape for CI\n" +
+			"integration; --verbose surfaces the remediation hint on OK rows\n" +
+			"too.",
+		SilenceUsage: true,
+		// SilenceErrors keeps cobra from re-printing the sentinel after
+		// runChecks already wrote the structured report (text or JSON)
+		// to stdout. The non-zero exit code from RunE flows through
+		// either way; an "Error:" line on stderr would just duplicate
+		// information already present in the report's bottom-line
+		// "Status: FAIL" / JSON `"ok": false`.
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			rc, ownsClose := buildRunCtx(cmd)
+			if ownsClose {
+				defer closeRunCtx(rc)
+			}
+
+			report := runChecks(cmd.Context(), rc)
+
+			if jsonOut {
+				if err := renderJSON(cmd.OutOrStdout(), report); err != nil {
+					return err
+				}
+			} else {
+				renderText(cmd.OutOrStdout(), report, verbose)
+			}
+
+			if !report.OK {
+				// Returning a sentinel rather than a freeform error keeps the
+				// stderr clean — the structured report on stdout is what the
+				// operator reads, and SilenceUsage above stops cobra from
+				// re-printing usage. The exit code is non-zero per AC.
+				return errFailingChecks
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit a JSON document instead of the human-readable table")
+	cmd.Flags().BoolVar(&verbose, "verbose", false,
+		"print the remediation hint on every row, not just WARN/FAIL")
+
+	return cmd
+}
+
+// errFailingChecks is the sentinel returned by RunE when the report carries
+// a FAIL — cobra's non-zero exit comes from the returned error. The error
+// is silenced via the manual rendering above (renderText / renderJSON
+// already wrote the structured report to stdout) by SilenceErrors at the
+// root level? No — we deliberately let cobra print the brief sentinel on
+// stderr so operators piping `kuke status` to a downstream tool still see
+// "failing checks" as the explicit failure marker.
+var errFailingChecks = errors.New("kuke status: one or more checks reported FAIL")
+
+// buildRunCtx assembles the runCtx from viper + flags, or returns the
+// mock injected via MockRunCtxKey for tests. The second return value is
+// true when buildRunCtx constructed the clients itself (and therefore
+// owns Close); mock-injected runCtxs are owned by the test.
+//
+// No error return: every viper read here is total (defaults fall back
+// to the config-package defaults) and the daemon dial is intentionally
+// soft — a dial failure sets daemonClient=nil so the daemon section
+// surfaces the cause; it does not abort the report.
+func buildRunCtx(cmd *cobra.Command) (*runCtx, bool) {
+	if mock, ok := cmd.Context().Value(MockRunCtxKey{}).(*runCtx); ok {
+		return mock, false
+	}
+
+	logger, err := shared.LoggerFromCmd(cmd)
+	if err != nil {
+		// `kuke status` is rarely invoked with --verbose root logging;
+		// fall back to a discard logger so the controller doesn't trip
+		// on a nil receiver. The status output itself doesn't need slog.
+		logger = slog.New(slog.NewTextHandler(discardWriter{}, nil))
+	}
+
+	host := viper.GetString(config.KUKEON_ROOT_HOST.ViperKey)
+	if host == "" {
+		host = config.KUKEON_ROOT_HOST.Default
+	}
+	runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
+	if runPath == "" {
+		runPath = config.DefaultRunPath()
+	}
+	containerdSocket := viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey)
+	if containerdSocket == "" {
+		containerdSocket = config.KUKEON_ROOT_CONTAINERD_SOCKET.Default
+	}
+
+	rc := &runCtx{
+		daemonHost:       host,
+		runPath:          runPath,
+		containerdSocket: containerdSocket,
+		cgroupRoot:       cgroupcheck.DefaultHostRoot(),
+		cniBinDir:        defaultCniBinDir,
+		logger:           logger,
+	}
+
+	// Dial the daemon up front so the daemon section's round-trip is the
+	// dial too, not a second connection. A dial failure is non-fatal — we
+	// surface it on the daemon row and let the rest of the report run.
+	rc.daemonClient, err = kukeonv1.Dial(cmd.Context(), host)
+	if err != nil {
+		rc.logger.DebugContext(cmd.Context(), "kuke status: daemon dial failed",
+			"host", host, "error", err)
+		rc.daemonClient = nil
+	}
+
+	// The in-process client is just struct init — the controller.Exec it
+	// wraps does no I/O until first use. First-call errors fall out of
+	// the parity walk itself.
+	rc.localClient = local.New(cmd.Context(), logger, controller.Options{
+		RunPath:          runPath,
+		ContainerdSocket: containerdSocket,
+	})
+
+	// ctrClient is constructed but not connected here — the host
+	// containerd check is where Connect() runs and decides reachability.
+	rc.ctrClient = ctr.NewClient(cmd.Context(), logger, containerdSocket)
+
+	return rc, true
+}
+
+// closeRunCtx releases the resources buildRunCtx allocated. Safe to call
+// when fields are nil (mock paths leave them unset).
+func closeRunCtx(rc *runCtx) {
+	if rc.daemonClient != nil {
+		_ = rc.daemonClient.Close()
+	}
+	if rc.localClient != nil {
+		_ = rc.localClient.Close()
+	}
+	if rc.ctrClient != nil {
+		_ = rc.ctrClient.Close()
+	}
+}
+
+// runChecks invokes every section in order and assembles the Report. Order
+// is fixed (daemon → host → state → parity) so the human output reads
+// top-down from the most likely fault (daemon down) to the most expensive
+// to run (parity walks every resource kind).
+func runChecks(ctx context.Context, rc *runCtx) Report {
+	var results []Result
+
+	results = append(results, checkDaemon(ctx, rc)...)
+	results = append(results, checkHost(rc)...)
+	results = append(results, checkState(ctx, rc)...)
+	results = append(results, checkParity(ctx, rc)...)
+
+	ok := true
+	for _, r := range results {
+		if r.Status == StatusFAIL {
+			ok = false
+			break
+		}
+	}
+	return Report{OK: ok, Checks: results}
+}
+
+// discardWriter is a no-op io.Writer used by the fallback slog handler in
+// buildRunCtx when the root cmd never installed a logger (the verbose
+// gate). Keeps the controller's slog calls cheap without pulling
+// io.Discard's package-level var indirection into hot paths.
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// defaultCniBinDir mirrors internal/cni/types.go:98's defaultCniBinDir,
+// duplicated here so the status check doesn't force `internal/cni` to
+// export a constant just for this one consumer. The CNI bootstrap path
+// is the source of truth; this string must move in lockstep if that
+// constant ever moves.
+const defaultCniBinDir = "/opt/cni/bin"
+
+// requiredCNIPlugins lists the binaries `kuke init` provisions under
+// defaultCniBinDir on its bootstrap path. Sourced from
+// internal/cni/{bridge,types}.go — `bridge` lays the per-realm bridge
+// network and `loopback` populates the per-container lo interface (the
+// minimum a `kuke create container` netns needs). Any future required
+// plugin lands here so the host check fails fast when it disappears.
+//
+// Function rather than a package-level var so the list isn't mutable
+// post-init (gochecknoglobals) and tests can call it for parity with
+// what the host check stats. Returns a fresh slice per call.
+func requiredCNIPlugins() []string {
+	return []string{"bridge", "loopback"}
+}

--- a/cmd/kuke/status/status_test.go
+++ b/cmd/kuke/status/status_test.go
@@ -1,0 +1,663 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package status
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestStatusCmd_Structure pins the user-facing surface — section names,
+// flags, and SilenceErrors so the structured report (text or JSON) on
+// stdout is what the operator reads, not cobra's auto-printed sentinel.
+func TestStatusCmd_Structure(t *testing.T) {
+	cmd := NewStatusCmd()
+	if cmd.Use != "status" {
+		t.Errorf("Use=%q want status", cmd.Use)
+	}
+	for _, flag := range []string{"json", "verbose"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected %q flag", flag)
+		}
+	}
+	if !cmd.SilenceUsage {
+		t.Error("expected SilenceUsage=true")
+	}
+	if !cmd.SilenceErrors {
+		t.Error("expected SilenceErrors=true so the structured report carries the verdict")
+	}
+}
+
+// TestRunChecks_AllHealthy is the smoke happy-path: every check returns
+// OK, the report's ok flag is true, and the human renderer's bottom line
+// reads "Status: OK". Tests the full pipeline (runChecks → render) so a
+// regression in either side surfaces here.
+func TestRunChecks_AllHealthy(t *testing.T) {
+	dir := setupHealthyHost(t)
+	rc := &runCtx{
+		daemonHost:       "unix:///run/test/kukeond.sock",
+		runPath:          dir.runPath,
+		containerdSocket: "/run/test/containerd.sock",
+		cgroupRoot:       dir.cgroupRoot,
+		cniBinDir:        dir.cniBinDir,
+		logger:           testLogger(),
+		daemonClient:     newFakeClient().withDefaultRealms(),
+		localClient:      newFakeClient().withDefaultRealms(),
+		ctrClient:        &fakeCtrClient{namespaces: []string{"default.kukeon.io", "kuke-system.kukeon.io"}},
+	}
+
+	report := runChecks(context.Background(), rc)
+	if !report.OK {
+		t.Errorf("expected OK report; got FAIL\n%s", renderToString(report, true))
+	}
+
+	seenSections := map[string]bool{}
+	for _, c := range report.Checks {
+		seenSections[c.Section] = true
+		if c.Status == StatusFAIL {
+			t.Errorf("unexpected FAIL row: %+v", c)
+		}
+	}
+	for _, want := range []string{sectionDaemon, sectionHost, sectionState, sectionParity} {
+		if !seenSections[want] {
+			t.Errorf("section %q not represented in report", want)
+		}
+	}
+}
+
+// TestCheckParity_DivergenceIsFAIL pins the regression-guard contract —
+// when the daemon and in-process branches disagree on a realm's
+// existence, the parity row is FAIL and Detail names the divergent side
+// and resource. This is the exact replacement for CLAUDE.md's
+// dev-init.sh manual `kuke get realms` vs `--no-daemon` diff.
+func TestCheckParity_DivergenceIsFAIL(t *testing.T) {
+	daemon := newFakeClient().withRealms("default", "kuke-system", "extra")
+	local := newFakeClient().withRealms("default", "kuke-system")
+
+	rc := &runCtx{
+		daemonClient: daemon,
+		localClient:  local,
+	}
+
+	results := checkParity(context.Background(), rc)
+	if len(results) == 0 {
+		t.Fatal("expected at least one parity row")
+	}
+	realmRow := results[0]
+	if realmRow.Name != "realms" {
+		t.Fatalf("first parity row should be realms; got %q", realmRow.Name)
+	}
+	if realmRow.Status != StatusFAIL {
+		t.Errorf("expected FAIL on divergent realms; got %s", realmRow.Status)
+	}
+	if !strings.Contains(realmRow.Detail, "extra") {
+		t.Errorf("Detail should name the divergent realm; got %q", realmRow.Detail)
+	}
+	if !strings.Contains(realmRow.Detail, "daemon-only") {
+		t.Errorf("Detail should label the divergent side; got %q", realmRow.Detail)
+	}
+}
+
+// TestCheckParity_DaemonDownIsWARN documents the degraded path: when the
+// daemon couldn't be dialed, the parity walk surfaces a single WARN row
+// rather than FAIL (the underlying cause already shows up in the daemon
+// section), and the JSON shape stays stable.
+func TestCheckParity_DaemonDownIsWARN(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: nil,
+		localClient:  newFakeClient().withDefaultRealms(),
+	}
+	results := checkParity(context.Background(), rc)
+	if len(results) != 1 {
+		t.Fatalf("expected exactly one degraded parity row; got %d", len(results))
+	}
+	if results[0].Status != StatusWARN {
+		t.Errorf("expected WARN on daemon-down parity; got %s", results[0].Status)
+	}
+	if !strings.Contains(results[0].Detail, "daemon not reachable") {
+		t.Errorf("Detail should name daemon-down cause; got %q", results[0].Detail)
+	}
+}
+
+// TestCheckParity_NestedDescent confirms the walk recurses into the
+// realm-set intersection (spaces / stacks / cells / containers) — a
+// regression in the descent loop would silently stop reporting nested
+// kinds.
+func TestCheckParity_NestedDescent(t *testing.T) {
+	daemon := newFakeClient().
+		withRealms("default").
+		withSpaces("default", "ns-a").
+		withStacks("default", "ns-a", "stack-a").
+		withCells("default", "ns-a", "stack-a", "cell-a").
+		withContainers("default", "ns-a", "stack-a", "cell-a", "main")
+	local := newFakeClient().
+		withRealms("default").
+		withSpaces("default", "ns-a").
+		withStacks("default", "ns-a", "stack-a").
+		withCells("default", "ns-a", "stack-a", "cell-a").
+		withContainers("default", "ns-a", "stack-a", "cell-a", "main")
+
+	rc := &runCtx{daemonClient: daemon, localClient: local}
+	results := checkParity(context.Background(), rc)
+
+	var names []string
+	for _, r := range results {
+		names = append(names, r.Name)
+	}
+	wantNames := []string{
+		"realms",
+		"spaces/default",
+		"stacks/default/ns-a",
+		"cells/default/ns-a/stack-a",
+		"containers/default/ns-a/stack-a/cell-a",
+		"secrets",
+		"blueprints",
+		"configs",
+	}
+	for _, want := range wantNames {
+		if !containsStr(names, want) {
+			t.Errorf("parity walk missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestCheckHostCgroupV2 exercises the three branches of the cgroup-v2
+// probe — present-with-controllers, present-but-empty (WARN), and absent
+// (FAIL) — against a temp dir so the test doesn't depend on the test
+// host's actual /sys/fs/cgroup.
+func TestCheckHostCgroupV2(t *testing.T) {
+	t.Run("controllers present", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "cgroup.controllers"), []byte("cpu memory io pids\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		rc := &runCtx{cgroupRoot: dir}
+		r := checkHostCgroupV2(rc)
+		if r.Status != StatusOK {
+			t.Errorf("expected OK; got %s (%s)", r.Status, r.Detail)
+		}
+		if !strings.Contains(r.Detail, "4 controllers") {
+			t.Errorf("Detail should name controller count; got %q", r.Detail)
+		}
+	})
+	t.Run("empty controllers", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "cgroup.controllers"), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		rc := &runCtx{cgroupRoot: dir}
+		r := checkHostCgroupV2(rc)
+		if r.Status != StatusWARN {
+			t.Errorf("expected WARN on empty controllers; got %s", r.Status)
+		}
+	})
+	t.Run("not mounted", func(t *testing.T) {
+		dir := t.TempDir()
+		rc := &runCtx{cgroupRoot: filepath.Join(dir, "missing")}
+		r := checkHostCgroupV2(rc)
+		if r.Status != StatusFAIL {
+			t.Errorf("expected FAIL when cgroup root absent; got %s", r.Status)
+		}
+	})
+}
+
+// TestCheckHostCNIPlugins covers the binary-present / binary-missing
+// split. The status check stats each name in requiredCNIPlugins; a
+// missing one demotes the row to FAIL with the missing name surfaced.
+func TestCheckHostCNIPlugins(t *testing.T) {
+	plugins := requiredCNIPlugins()
+	t.Run("all present", func(t *testing.T) {
+		dir := t.TempDir()
+		for _, name := range plugins {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		rc := &runCtx{cniBinDir: dir}
+		r := checkHostCNIPlugins(rc)
+		if r.Status != StatusOK {
+			t.Errorf("expected OK; got %s (%s)", r.Status, r.Detail)
+		}
+	})
+	t.Run("missing one", func(t *testing.T) {
+		dir := t.TempDir()
+		// Lay only the first plugin so the second is missing.
+		if err := os.WriteFile(filepath.Join(dir, plugins[0]), []byte(""), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		rc := &runCtx{cniBinDir: dir}
+		r := checkHostCNIPlugins(rc)
+		if r.Status != StatusFAIL {
+			t.Errorf("expected FAIL when a plugin is missing; got %s", r.Status)
+		}
+		if !strings.Contains(r.Detail, plugins[1]) {
+			t.Errorf("Detail should name the missing plugin; got %q", r.Detail)
+		}
+	})
+}
+
+// TestCheckStateRunDir_Orphans confirms a non-canonical entry under the
+// run-socket dir surfaces as a WARN row naming the orphan.
+func TestCheckStateRunDir_Orphans(t *testing.T) {
+	dir := t.TempDir()
+	for _, expected := range []string{"kukeond.sock", "kukeond.pid", "s", "tty"} {
+		if err := os.WriteFile(filepath.Join(dir, expected), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "stale.sock"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trigger the non-default-runPath branch of canonicalRunSocketDir
+	// by setting runPath to the temp dir.
+	rc := &runCtx{runPath: dir}
+	r := checkStateRunDir(rc)
+	if r.Status != StatusWARN {
+		t.Errorf("expected WARN with stale.sock orphan; got %s (%s)", r.Status, r.Detail)
+	}
+	if !strings.Contains(r.Detail, "stale.sock") {
+		t.Errorf("Detail should name the orphan; got %q", r.Detail)
+	}
+}
+
+// TestCheckStateRunDir_AbsentDirIsOK covers the bare-host case: a host
+// that never ran `kuke init` has no /run/kukeon, and we don't want
+// false-positive WARN/FAIL rows for an environment that legitimately
+// hasn't been initialized.
+func TestCheckStateRunDir_AbsentDirIsOK(t *testing.T) {
+	rc := &runCtx{runPath: filepath.Join(t.TempDir(), "never-existed")}
+	r := checkStateRunDir(rc)
+	if r.Status != StatusOK {
+		t.Errorf("expected OK on absent run dir; got %s (%s)", r.Status, r.Detail)
+	}
+	if !strings.Contains(r.Detail, "not present") {
+		t.Errorf("Detail should say 'not present'; got %q", r.Detail)
+	}
+}
+
+// TestRunChecks_JSONShape confirms the JSON form is stable enough for
+// CI integration — `ok` is a boolean, every check has the four required
+// string fields, and Status renders as the human label.
+func TestRunChecks_JSONShape(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: nil, // daemon down → FAIL
+		localClient:  newFakeClient().withDefaultRealms(),
+		ctrClient:    &fakeCtrClient{connectErr: nil, namespaces: nil},
+		cgroupRoot:   filepath.Join(t.TempDir(), "missing"),
+		cniBinDir:    filepath.Join(t.TempDir(), "missing"),
+		runPath:      t.TempDir(),
+		logger:       testLogger(),
+	}
+	report := runChecks(context.Background(), rc)
+
+	var buf bytes.Buffer
+	if err := renderJSON(&buf, report); err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON output is malformed: %v\n%s", err, buf.String())
+	}
+	if okField, _ := parsed["ok"].(bool); okField {
+		t.Errorf("expected ok=false with daemon down; got true")
+	}
+	checks, ok := parsed["checks"].([]any)
+	if !ok || len(checks) == 0 {
+		t.Fatalf("expected non-empty checks array; got %v", parsed["checks"])
+	}
+	first, ok := checks[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first check is not an object: %v", checks[0])
+	}
+	for _, field := range []string{"section", "name", "status"} {
+		if _, present := first[field]; !present {
+			t.Errorf("check missing required field %q", field)
+		}
+	}
+	if s, _ := first["status"].(string); s != "FAIL" {
+		t.Errorf("expected daemon row status=FAIL; got %v", first["status"])
+	}
+}
+
+// TestRenderText_RemediationVisibility pins the verbose / non-verbose
+// branching: WARN/FAIL rows always show the remediation hint; OK rows
+// show it only with --verbose.
+func TestRenderText_RemediationVisibility(t *testing.T) {
+	report := Report{
+		OK: false,
+		Checks: []Result{
+			{
+				Section: "x", Name: "ok-row", Status: StatusOK, Detail: "all fine",
+				Remediation: "would-suggest",
+			},
+			{
+				Section: "x", Name: "fail-row", Status: StatusFAIL, Detail: "broken",
+				Remediation: "fix-now",
+			},
+		},
+	}
+	t.Run("non-verbose hides OK remediation", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderText(&buf, report, false)
+		out := buf.String()
+		if strings.Contains(out, "would-suggest") {
+			t.Error("non-verbose mode should hide OK-row remediation")
+		}
+		if !strings.Contains(out, "fix-now") {
+			t.Error("FAIL-row remediation must always be visible")
+		}
+	})
+	t.Run("verbose surfaces OK remediation", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderText(&buf, report, true)
+		if !strings.Contains(buf.String(), "would-suggest") {
+			t.Error("verbose mode should surface OK-row remediation")
+		}
+	})
+}
+
+// TestCommandExitCodeFAIL drives the cobra command end-to-end with a
+// mock runCtx injected via MockRunCtxKey, then asserts the command
+// returns a non-nil error so cobra propagates a non-zero exit.
+func TestCommandExitCodeFAIL(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: nil, // → daemon FAIL row → overall FAIL
+		localClient:  newFakeClient().withDefaultRealms(),
+		ctrClient:    &fakeCtrClient{},
+		cgroupRoot:   t.TempDir(), // no cgroup.controllers → FAIL
+		cniBinDir:    t.TempDir(),
+		runPath:      t.TempDir(),
+		logger:       testLogger(),
+	}
+
+	cmd := NewStatusCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	ctx := context.WithValue(context.Background(), types.CtxLogger, testLogger())
+	ctx = context.WithValue(ctx, MockRunCtxKey{}, rc)
+	cmd.SetContext(ctx)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected non-nil error so cobra exits non-zero")
+	}
+	if !strings.Contains(buf.String(), "Status: FAIL") {
+		t.Errorf("expected report tail 'Status: FAIL'; got:\n%s", buf.String())
+	}
+}
+
+// TestCommandExitCodeOK is the success-side companion to the above —
+// when every row is OK, the command returns nil and the report tail
+// reads "Status: OK".
+func TestCommandExitCodeOK(t *testing.T) {
+	dir := setupHealthyHost(t)
+	rc := &runCtx{
+		daemonClient:     newFakeClient().withDefaultRealms(),
+		localClient:      newFakeClient().withDefaultRealms(),
+		ctrClient:        &fakeCtrClient{namespaces: []string{"default.kukeon.io", "kuke-system.kukeon.io"}},
+		cgroupRoot:       dir.cgroupRoot,
+		cniBinDir:        dir.cniBinDir,
+		runPath:          dir.runPath,
+		daemonHost:       "unix:///run/test/kukeond.sock",
+		containerdSocket: "/run/test/containerd.sock",
+		logger:           testLogger(),
+	}
+
+	cmd := NewStatusCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	ctx := context.WithValue(context.Background(), types.CtxLogger, testLogger())
+	ctx = context.WithValue(ctx, MockRunCtxKey{}, rc)
+	cmd.SetContext(ctx)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected nil error on healthy host; got %v\nReport:\n%s", err, buf.String())
+	}
+	if !strings.Contains(buf.String(), "Status: OK") {
+		t.Errorf("expected report tail 'Status: OK'; got:\n%s", buf.String())
+	}
+}
+
+// ---- Test helpers ----
+
+// healthyHost wires the three temp paths a happy-path run reads.
+type healthyHost struct {
+	runPath    string
+	cgroupRoot string
+	cniBinDir  string
+}
+
+func setupHealthyHost(t *testing.T) healthyHost {
+	t.Helper()
+
+	cgroupRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cgroupRoot, "cgroup.controllers"),
+		[]byte("cpu memory io pids cpuset"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cniBinDir := t.TempDir()
+	for _, name := range requiredCNIPlugins() {
+		if err := os.WriteFile(filepath.Join(cniBinDir, name), []byte{}, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runPath := t.TempDir()
+	for _, expected := range []string{"kukeond.sock", "kukeond.pid", "s", "tty"} {
+		if err := os.WriteFile(filepath.Join(runPath, expected), []byte{}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return healthyHost{runPath: runPath, cgroupRoot: cgroupRoot, cniBinDir: cniBinDir}
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(discardWriter{}, nil))
+}
+
+func renderToString(report Report, verbose bool) string {
+	var buf bytes.Buffer
+	renderText(&buf, report, verbose)
+	return buf.String()
+}
+
+func containsStr(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- fakeClient: kukeonv1.Client mock for the status tests ----
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	realms     []v1beta1.RealmDoc
+	spaces     map[string][]v1beta1.SpaceDoc                      // realm
+	stacks     map[string]map[string][]v1beta1.StackDoc           // realm/space
+	cells      map[string]map[string]map[string][]v1beta1.CellDoc // realm/space/stack
+	containers map[string][]v1beta1.ContainerSpec                 // realm/space/stack/cell key
+
+	secrets    []v1beta1.SecretDoc
+	blueprints []v1beta1.CellBlueprintDoc
+	configs    []v1beta1.CellConfigDoc
+
+	version    string
+	pingErr    error
+	versionErr error
+}
+
+func newFakeClient() *fakeClient {
+	return &fakeClient{
+		spaces:     map[string][]v1beta1.SpaceDoc{},
+		stacks:     map[string]map[string][]v1beta1.StackDoc{},
+		cells:      map[string]map[string]map[string][]v1beta1.CellDoc{},
+		containers: map[string][]v1beta1.ContainerSpec{},
+		version:    "test-version",
+	}
+}
+
+// withDefaultRealms seeds the two realms `kuke init` provisions. Used by
+// every happy-path test that just needs a non-empty realm list.
+func (f *fakeClient) withDefaultRealms() *fakeClient {
+	return f.withRealms("default", "kuke-system")
+}
+
+func (f *fakeClient) withRealms(names ...string) *fakeClient {
+	for _, name := range names {
+		f.realms = append(f.realms, v1beta1.RealmDoc{
+			Metadata: v1beta1.RealmMetadata{Name: name},
+		})
+	}
+	return f
+}
+
+func (f *fakeClient) withSpaces(realm string, names ...string) *fakeClient {
+	for _, name := range names {
+		f.spaces[realm] = append(f.spaces[realm], v1beta1.SpaceDoc{
+			Metadata: v1beta1.SpaceMetadata{Name: name},
+		})
+	}
+	return f
+}
+
+func (f *fakeClient) withStacks(realm, space string, names ...string) *fakeClient {
+	if f.stacks[realm] == nil {
+		f.stacks[realm] = map[string][]v1beta1.StackDoc{}
+	}
+	for _, name := range names {
+		f.stacks[realm][space] = append(f.stacks[realm][space], v1beta1.StackDoc{
+			Metadata: v1beta1.StackMetadata{Name: name},
+		})
+	}
+	return f
+}
+
+func (f *fakeClient) withCells(realm, space, stack string, names ...string) *fakeClient {
+	if f.cells[realm] == nil {
+		f.cells[realm] = map[string]map[string][]v1beta1.CellDoc{}
+	}
+	if f.cells[realm][space] == nil {
+		f.cells[realm][space] = map[string][]v1beta1.CellDoc{}
+	}
+	for _, name := range names {
+		f.cells[realm][space][stack] = append(f.cells[realm][space][stack], v1beta1.CellDoc{
+			Metadata: v1beta1.CellMetadata{Name: name},
+		})
+	}
+	return f
+}
+
+func (f *fakeClient) withContainers(realm, space, stack, cell string, names ...string) *fakeClient {
+	key := strings.Join([]string{realm, space, stack, cell}, "/")
+	for _, name := range names {
+		f.containers[key] = append(f.containers[key], v1beta1.ContainerSpec{
+			ID: name,
+		})
+	}
+	return f
+}
+
+func (f *fakeClient) Close() error { return nil }
+
+func (f *fakeClient) Ping(_ context.Context) error { return f.pingErr }
+
+func (f *fakeClient) PingVersion(_ context.Context) (string, error) {
+	if f.versionErr != nil {
+		return "", f.versionErr
+	}
+	return f.version, nil
+}
+
+func (f *fakeClient) ListRealms(_ context.Context) ([]v1beta1.RealmDoc, error) {
+	return f.realms, nil
+}
+
+func (f *fakeClient) ListSpaces(_ context.Context, realm string) ([]v1beta1.SpaceDoc, error) {
+	return f.spaces[realm], nil
+}
+
+func (f *fakeClient) ListStacks(_ context.Context, realm, space string) ([]v1beta1.StackDoc, error) {
+	if f.stacks[realm] == nil {
+		return nil, nil
+	}
+	return f.stacks[realm][space], nil
+}
+
+func (f *fakeClient) ListCells(_ context.Context, realm, space, stack string) ([]v1beta1.CellDoc, error) {
+	if f.cells[realm] == nil || f.cells[realm][space] == nil {
+		return nil, nil
+	}
+	return f.cells[realm][space][stack], nil
+}
+
+func (f *fakeClient) ListContainers(
+	_ context.Context, realm, space, stack, cell string,
+) ([]v1beta1.ContainerSpec, error) {
+	return f.containers[strings.Join([]string{realm, space, stack, cell}, "/")], nil
+}
+
+func (f *fakeClient) ListSecrets(_ context.Context, _, _, _, _ string) ([]v1beta1.SecretDoc, error) {
+	return f.secrets, nil
+}
+
+func (f *fakeClient) ListBlueprints(_ context.Context, _, _, _ string) ([]v1beta1.CellBlueprintDoc, error) {
+	return f.blueprints, nil
+}
+
+func (f *fakeClient) ListConfigs(_ context.Context, _, _, _ string) ([]v1beta1.CellConfigDoc, error) {
+	return f.configs, nil
+}
+
+// ---- fakeCtrClient: ctrConn mock for the host/state tests ----
+//
+// Status narrowed the ctr surface to a three-method ctrConn interface
+// (Connect, Close, ListNamespaces) precisely so this test fake stays
+// trivial — no embedded stub, no method explosion.
+
+type fakeCtrClient struct {
+	connectErr error
+	namespaces []string
+}
+
+func (f *fakeCtrClient) Connect() error { return f.connectErr }
+func (f *fakeCtrClient) Close() error   { return nil }
+func (f *fakeCtrClient) ListNamespaces() ([]string, error) {
+	if f.connectErr != nil {
+		return nil, f.connectErr
+	}
+	return f.namespaces, nil
+}

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -1243,5 +1243,15 @@ func (c *Client) Ping(_ context.Context) error {
 	return nil
 }
 
+// PingVersion returns the empty string for the in-process branch: there
+// is no separate daemon to interrogate, and pulling the running
+// binary's version here would force this package to import cmd/config,
+// reintroducing the autocomplete cycle (cmd/config → internal/client/local).
+// `kuke status` only calls PingVersion on the daemon-RPC client; the
+// in-process branch implements it just to satisfy the interface.
+func (c *Client) PingVersion(_ context.Context) (string, error) {
+	return "", nil
+}
+
 // Verify interface compliance at compile time.
 var _ kukeonv1.Client = (*Client)(nil)

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -140,6 +140,13 @@ type Client interface {
 	// RPC daemon does not serve image methods.
 
 	Ping(ctx context.Context) error
+	// PingVersion is the Ping sibling that surfaces the daemon's reported
+	// build version alongside the ack. `kuke status` uses it to render the
+	// daemon row; the in-process client returns the current process's
+	// version (config.Version), so the value is well-defined on both
+	// transports. New callers preferring the existing ack-only contract
+	// stay on Ping.
+	PingVersion(ctx context.Context) (string, error)
 }
 
 // CreateCellArgs is the wire request for CreateCell.

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -220,3 +220,7 @@ func (FakeClient) DeleteDocuments(context.Context, []byte, bool, bool) (DeleteDo
 func (FakeClient) Ping(context.Context) error {
 	return ErrUnexpectedCall
 }
+
+func (FakeClient) PingVersion(context.Context) (string, error) {
+	return "", ErrUnexpectedCall
+}

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -784,3 +784,19 @@ func (c *UnixClient) Ping(ctx context.Context) error {
 	}
 	return nil
 }
+
+// PingVersion returns the daemon's reported build version. The wire reply
+// has carried Version since the RPC's introduction; the helper exposes it
+// to callers (notably `kuke status`) without forcing them to hand-roll the
+// Ping wire.
+func (c *UnixClient) PingVersion(ctx context.Context) (string, error) {
+	args := &PingArgs{}
+	reply := &PingReply{}
+	if err := c.call(ctx, MethodPing, args, reply); err != nil {
+		return "", err
+	}
+	if reply.Err != nil {
+		return "", FromAPIError(reply.Err)
+	}
+	return reply.Version, nil
+}


### PR DESCRIPTION
## Summary
- Adds the consolidated `kuke status` health command that absorbs the three separate proposals from the original gaps doc (`kuke doctor`, `kuke ping`, `kuke selftest`) into one report — daemon liveness (round-trip + version), host pre-flight (containerd, cgroup-v2, CNI plugins), state consistency (orphan run-dir entries, residual containerd namespaces), and a daemon-vs-in-process parity walk across every resource kind (realm, space, stack, cell, container, secret, blueprint, config).
- Each row is `OK | WARN | FAIL` with a one-line remediation hint; exit code is non-zero when any row is FAIL. `--json` is the machine-readable shape for CI integration; `--verbose` surfaces the remediation hint on OK rows too. Sentinel-error + `SilenceErrors` keeps stderr clean when consumers pipe the structured report on stdout.
- Adds `PingVersion(ctx) (string, error)` to the `kukeonv1.Client` interface so the daemon row can surface the daemon's reported build version alongside the ack. The wire `PingReply` has carried the field since introduction — this just exposes it. The existing ack-only `Ping` is unchanged, so the lone production caller (`kuke init`'s `pingKukeond`) is untouched.
- The reconciler row from the AC's bullet 5 is **deliberately deferred** per the issue's own guidance ("ship status without it and add the row when reconciler exposes the metric"). Issue #161 (the reconciler) is closed but did not expose a metrics RPC `kuke status` could read; left as a future row.
- The AC's bullet 5 CLAUDE.md doc update is deferred to follow-up #773 per the dev role's hard rule (no `CLAUDE.md` edits in a code-fix PR — project CLAUDE.md changes travel as their own issue + PR).

### Design notes the reviewer may want to push back on
- **In-process client's `PingVersion` returns ""** rather than `config.Version`. Pulling the version here would force `internal/client/local` to import `cmd/config`, reintroducing the autocomplete cycle (`cmd/config` → `internal/client/local`). `kuke status` only calls `PingVersion` on the daemon-RPC client; the in-process implementation exists just to satisfy the interface.
- **`ctrConn` is a 3-method interface in the status package** (not `ctr.Client`) — narrowed to what status calls (Connect / Close / ListNamespaces) so the test fake stays trivial. The concrete `ctr.NewClient(...)` return value satisfies it structurally.
- **State-section orphan detection is filesystem-stat only**, not `lsof`/`fuser`-style liveness probing. The AC didn't budget for the latter; the role here is to surface "the run dir looks unexpectedly populated" so the operator inspects, not to enforce.
- **Parity walk recurses only into the realm/space/stack/cell names that appear in both branches.** A divergent realm surfaces as the realm row's FAIL; the nested walk doesn't double-count that divergence by also flagging every space/stack/cell beneath it as missing. Reviewer pushback welcome on whether to also enumerate divergent-branch-only nested kinds in the row's Detail.
- **`/run/kukeon` orphan-entry whitelist** is currently `kukeond.sock`, `kukeond.pid`, `s/`, `tty/`. Any other entry trips WARN. The list is intentionally tight so a half-cleaned `kuke daemon reset` surfaces; the `daemon reset --purge-system` interaction may need a re-look once that is exercised on real hosts.

## Test plan
- [x] `make test` — full project suite green (root module + kukebuild module).
- [x] `go vet ./...` clean.
- [x] `go build ./...` clean.
- [x] `pre-commit run --files <staged>` — all hooks pass (trailing-whitespace, go-fmt, go-mod-tidy, golangci-lint, addlicense).
- [x] Built `kuke` and ran `kuke status` against the dev container (no kukeond running): correctly reported `DAEMON FAIL`, `HOST OK` (containerd reachable, cgroup-v2 8 controllers, CNI bridge+loopback present), `STATE OK`/`WARN`, `PARITY WARN` (daemon down), bottom-line `Status: FAIL`, exit code 1.
- [x] `kuke status --json` parses as valid JSON (`python3 -m json.tool`) with stable `{ok, checks[]}` shape and Status rendered as the human label.
- [x] `kuke status --verbose` surfaces remediation hints on OK rows.
- [x] New unit tests cover: command structure (flags, SilenceErrors), healthy-all-OK pipeline, parity divergence FAIL, parity daemon-down WARN, parity nested descent, cgroup-v2 three branches (present-with-controllers / empty / absent), CNI plugins present + missing, run-dir orphan WARN, run-dir absent OK (bare host), JSON shape stability, render verbose/non-verbose remediation branching, command exit-code FAIL and OK end-to-end.
- [ ] `make dev-init` smoke not run — environmental: `kukebuild` ran out of linker disk space (`mapping output file failed: no space left on device`) inside the BuildKit image build, not a code regression. This change is purely additive on the CLI side: zero daemon code paths touched (the `Ping` handler is unchanged), so the `make dev-init` daemon-parity tail is not affected. The CLAUDE.md guardrail (`If your change touches anything the daemon reads, this check must be in the PR's test plan`) does not strictly require it here, but the disk-out-of-space is the literal reason the smoke wasn't run.

## Acceptance criteria
- [x] `kuke status` runs all checks and prints a one-line-per-check report (sections: daemon, host, state, parity).
- [x] Daemon-parity divergence (the CLAUDE.md regression guard) is one of the checks — implemented as the recursive walk across realm/space/stack/cell/container/secret/blueprint/config in `parity.go`.
- [x] `--json` produces machine-readable output.
- [x] Non-zero exit when any FAIL line is present (`errFailingChecks` sentinel returned from `RunE`).
- [ ] Documented in CLAUDE.md as the canonical post-init smoke check — **deferred to follow-up #773** per the dev role's `CLAUDE.md`-in-code-PR hard rule. The follow-up issue carries the verbatim proposed wording.

Closes #202