### PR TITLE
docs(CLAUDE.md): document kuke status as canonical post-init smoke check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,27 @@ Both `kuke get realms` and `kuke get realms --no-daemon` must produce that outpu
 
 **If your change touches anything the daemon reads, this check must be in the PR's test plan.** Reviewer agent will flag PRs that miss it.
 
+### Post-init: `kuke status`
+
+`kuke status` is the canonical equivalent of the manual diff ritual above —
+one command that runs daemon liveness (with round-trip ms and version),
+host pre-flight (containerd, cgroup-v2, CNI plugins under `/opt/cni/bin/`),
+state consistency (orphan run-dir entries, residual containerd namespaces),
+and the same daemon-parity walk above across **every** resource kind
+(realm, space, stack, cell, container, secret, blueprint, config), not just
+realms.
+
+Exit code is 0 when every check is OK / WARN, non-zero when any line is
+FAIL. `--json` is the machine-readable form for CI integration; `--verbose`
+surfaces the remediation hint on OK rows too.
+
+The two-line `kuke get realms` diff above stays the minimal pinned
+regression guard the `make dev-init` tail prints; `kuke status` is the
+broader smoke an operator runs after `kuke init` to surface anything the
+two-realm tail won't catch (cgroup delegation gone, CNI binaries gone,
+divergent secrets/blueprints/configs, residual containerd namespaces from
+a half-cleaned `kuke uninstall`).
+
 ### Manual phases (fallback)
 
 To run individual phases by hand — e.g. while debugging a single phase — invoke them in order:


### PR DESCRIPTION
## Summary

- Adds a **Post-init: `kuke status`** subsection under `## Local smoke test`, naming `kuke status` as the canonical equivalent of the manual `kuke get realms` vs `kuke get realms --no-daemon` diff ritual landed by #774 (the AC-deferred CLAUDE.md follow-up to #202).
- Names the OK/WARN/FAIL exit-code contract (0 / non-zero on FAIL), the `--json` and `--verbose` flags, and the broader sweep (host pre-flight, state consistency, full-resource parity walk) `kuke status` covers above what the two-realm regression tail catches.
- Keeps the two-line `kuke get realms` diff as the pinned regression-guard tail `make dev-init` prints — `kuke status` is the broader post-init smoke, not the replacement.

Placement note: the proposal's verbatim wording suggested inserting immediately after the bind-mount-regression line, which would have split the regression-guard block from its existing **"this check must be in the PR's test plan"** sentence. Placed the new `### Post-init` subsection as a structural peer (between the One-shot block and `### Manual phases (fallback)`) so each `###` reads as a sibling under `## Local smoke test`. AC2's must-haves (exit-code contract, `--json`/`--verbose`, regression-guard preservation) are unchanged.

## Test plan

- [x] `pre-commit run --files CLAUDE.md` — all hooks pass (prettier reformat clean).
- [x] Verified the wording's claims against the just-merged `cmd/kuke/status/`: `--json`/`--verbose` flags (`status.go:198,200`), exit-code contract (`status.go:213`, `errFailingChecks`), host pre-flight scope (containerd, cgroup-v2, CNI plugins; `checks.go:83`), parity walk across realm/space/stack/cell/container + secret/blueprint/config (`parity.go:32-34, 118-129`).
- [x] No code, test, or behavior change — pure markdown insertion in the project `CLAUDE.md`.

Closes #773