### PR TITLE
feat(cli): unify kuke apply -b/-c scope resolution with kuke run via shared helpers

### DIFF
--- a/cmd/kuke/apply/apply.go
+++ b/cmd/kuke/apply/apply.go
@@ -286,9 +286,9 @@ func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags applyFl
 	lookup := v1beta1.CellBlueprintDoc{
 		Metadata: v1beta1.CellBlueprintMetadata{
 			Name:  flags.blueprintName,
-			Realm: pickRealm(cmd),
-			Space: explicitScope(cmd, "space"),
-			Stack: explicitScope(cmd, "stack"),
+			Realm: kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM),
+			Space: kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
+			Stack: kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
 		},
 	}
 
@@ -317,9 +317,9 @@ func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags
 		Kind:       v1beta1.KindCellConfig,
 		Metadata: v1beta1.CellConfigMetadata{
 			Name:  flags.configName,
-			Realm: pickRealm(cmd),
-			Space: explicitScope(cmd, "space"),
-			Stack: explicitScope(cmd, "stack"),
+			Realm: kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM),
+			Space: kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
+			Stack: kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
 		},
 	}
 
@@ -386,39 +386,19 @@ func buildParamMap(flags applyFlags) (map[string]string, error) {
 }
 
 // resolveCellLocation fills missing realm/space/stack on the materialised doc
-// from --realm/--space/--stack. The materialised doc usually carries the
-// Blueprint/Config's coordinates already; this only fills empties.
+// from --realm/--space/--stack (or the KUKE_RUN_* env-var fallbacks the shared
+// helpers consume). The materialised doc usually carries the Blueprint/Config's
+// coordinates already; this only fills empties.
 func resolveCellLocation(cmd *cobra.Command, doc *v1beta1.CellDoc) {
 	if strings.TrimSpace(doc.Spec.RealmID) == "" {
-		doc.Spec.RealmID = pickRealm(cmd)
+		doc.Spec.RealmID = kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM)
 	}
 	if strings.TrimSpace(doc.Spec.SpaceID) == "" {
-		doc.Spec.SpaceID = explicitScope(cmd, "space")
+		doc.Spec.SpaceID = kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE)
 	}
 	if strings.TrimSpace(doc.Spec.StackID) == "" {
-		doc.Spec.StackID = explicitScope(cmd, "stack")
+		doc.Spec.StackID = kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK)
 	}
-}
-
-// pickRealm returns the --realm value if set, falling back to "default" so the
-// lookup always names a realm (parity with `kuke run`'s default).
-func pickRealm(cmd *cobra.Command) string {
-	if v, _ := cmd.Flags().GetString("realm"); strings.TrimSpace(v) != "" {
-		return strings.TrimSpace(v)
-	}
-	return "default"
-}
-
-// explicitScope returns the named scope flag only when the operator set it
-// explicitly. Mirrors run.explicitScope so realm-scoped Blueprints/Configs (no
-// space or stack coordinate) are findable; the cobra flag default of "" stays
-// "do not constrain this coordinate".
-func explicitScope(cmd *cobra.Command, flagName string) string {
-	if !cmd.Flags().Changed(flagName) {
-		return ""
-	}
-	v, _ := cmd.Flags().GetString(flagName)
-	return strings.TrimSpace(v)
 }
 
 // assertCellLineage refuses to reconcile a live cell whose lineage label does

--- a/cmd/kuke/apply/apply_test.go
+++ b/cmd/kuke/apply/apply_test.go
@@ -667,6 +667,135 @@ func TestApply_ConfigNotFound_Errors(t *testing.T) {
 	}
 }
 
+// TestApply_FromBlueprint_EnvVarScopeFallback locks the symmetry with
+// `kuke run -b/-c`: when the operator pinned KUKE_RUN_REALM /
+// KUKE_RUN_SPACE / KUKE_RUN_STACK in their shell, `kuke apply -b` reads
+// the same scope, not the cobra default. Regression guard for #776 — the
+// pre-fix apply code path took --realm strictly from the flag and ignored
+// the env-var fallback `kuke run -b` honored via the shared helpers.
+func TestApply_FromBlueprint_EnvVarScopeFallback(t *testing.T) {
+	t.Setenv("KUKE_RUN_REALM", "from-env-realm")
+	t.Setenv("KUKE_RUN_SPACE", "from-env-space")
+	t.Setenv("KUKE_RUN_STACK", "from-env-stack")
+
+	gotLookup := v1beta1.CellBlueprintMetadata{}
+	fc := &fakeClient{
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			gotLookup = doc.Metadata
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
+		},
+		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{{Kind: "Cell", Name: "myCell", Action: "created"}},
+			}, nil
+		},
+	}
+
+	if _, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "myCell"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotLookup.Realm != "from-env-realm" {
+		t.Errorf("blueprint lookup realm=%q want from-env-realm (KUKE_RUN_REALM ignored)", gotLookup.Realm)
+	}
+	if gotLookup.Space != "from-env-space" {
+		t.Errorf("blueprint lookup space=%q want from-env-space (KUKE_RUN_SPACE ignored)", gotLookup.Space)
+	}
+	if gotLookup.Stack != "from-env-stack" {
+		t.Errorf("blueprint lookup stack=%q want from-env-stack (KUKE_RUN_STACK ignored)", gotLookup.Stack)
+	}
+}
+
+// TestApply_FromConfig_EnvVarScopeFallback is the -c counterpart of the
+// regression above. The Config lookup must also pick up KUKE_RUN_REALM /
+// SPACE / STACK from the operator's shell when no --realm/--space/--stack
+// flag is set.
+func TestApply_FromConfig_EnvVarScopeFallback(t *testing.T) {
+	t.Setenv("KUKE_RUN_REALM", "from-env-realm")
+	t.Setenv("KUKE_RUN_SPACE", "from-env-space")
+	t.Setenv("KUKE_RUN_STACK", "from-env-stack")
+
+	gotLookup := v1beta1.CellConfigMetadata{}
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			gotLookup = doc.Metadata
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
+		},
+		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{Kind: "Cell", Name: cellconfig.StableName("prod"), Action: "created"},
+				},
+			}, nil
+		},
+	}
+
+	if _, err := runApplyRef(t, fc, []string{"-c", "prod"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotLookup.Realm != "from-env-realm" {
+		t.Errorf("config lookup realm=%q want from-env-realm", gotLookup.Realm)
+	}
+	if gotLookup.Space != "from-env-space" {
+		t.Errorf("config lookup space=%q want from-env-space", gotLookup.Space)
+	}
+	if gotLookup.Stack != "from-env-stack" {
+		t.Errorf("config lookup stack=%q want from-env-stack", gotLookup.Stack)
+	}
+}
+
+// TestApply_FromBlueprint_FlagWinsOverEnvVar pins the precedence: when
+// both --realm and KUKE_RUN_REALM are set, the flag wins. Same shape for
+// --space / --stack. Symmetric with the shared.ExplicitScope contract.
+func TestApply_FromBlueprint_FlagWinsOverEnvVar(t *testing.T) {
+	t.Setenv("KUKE_RUN_REALM", "from-env-realm")
+	t.Setenv("KUKE_RUN_SPACE", "from-env-space")
+	t.Setenv("KUKE_RUN_STACK", "from-env-stack")
+
+	gotLookup := v1beta1.CellBlueprintMetadata{}
+	fc := &fakeClient{
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			gotLookup = doc.Metadata
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
+		},
+		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{{Kind: "Cell", Name: "myCell", Action: "created"}},
+			}, nil
+		},
+	}
+
+	_, err := runApplyRef(t, fc, []string{
+		"-b", "web", "--name", "myCell",
+		"--realm", "flag-realm",
+		"--space", "flag-space",
+		"--stack", "flag-stack",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if gotLookup.Realm != "flag-realm" {
+		t.Errorf("blueprint lookup realm=%q want flag-realm (env should not override flag)", gotLookup.Realm)
+	}
+	if gotLookup.Space != "flag-space" {
+		t.Errorf("blueprint lookup space=%q want flag-space", gotLookup.Space)
+	}
+	if gotLookup.Stack != "flag-stack" {
+		t.Errorf("blueprint lookup stack=%q want flag-stack", gotLookup.Stack)
+	}
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -533,10 +533,11 @@ func loadCellDoc(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (v1
 // the KUKE_RUN_SPACE/STACK env var. The session default for those keys is
 // "default" (DefineKV calls viper.SetDefault), so reading them through viper
 // would wrongly narrow every lookup to default/default and hide realm-scoped
-// blueprints; explicitScope reads the raw flag/env instead. A blueprint that
-// declares structural slots the inline path cannot fill (secret slots, required
-// repo slots with no url) is refused by Materialize with a pointer to
-// `kuke run -c`.
+// blueprints; cmd/kuke/shared.ExplicitScope reads the raw flag/env instead,
+// and `kuke apply -b/-c` consumes the same helper for symmetric scope
+// resolution. A blueprint that declares structural slots the inline path
+// cannot fill (secret slots, required repo slots with no url) is refused by
+// Materialize with a pointer to `kuke run -c`.
 func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (v1beta1.CellDoc, error) {
 	cliParams, err := buildParamMap(flags)
 	if err != nil {
@@ -546,9 +547,9 @@ func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags runFlag
 	lookup := v1beta1.CellBlueprintDoc{
 		Metadata: v1beta1.CellBlueprintMetadata{
 			Name:  flags.blueprintName,
-			Realm: pickLocation("", &config.KUKE_RUN_REALM),
-			Space: explicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
-			Stack: explicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
+			Realm: kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM),
+			Space: kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
+			Stack: kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
 		},
 	}
 
@@ -593,9 +594,9 @@ func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) 
 		Kind:       v1beta1.KindCellConfig,
 		Metadata: v1beta1.CellConfigMetadata{
 			Name:  flags.configName,
-			Realm: pickLocation("", &config.KUKE_RUN_REALM),
-			Space: explicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
-			Stack: explicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
+			Realm: kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM),
+			Space: kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
+			Stack: kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
 		},
 	}
 
@@ -766,24 +767,14 @@ func resolveCellLocation(doc *v1beta1.CellDoc) {
 	doc.Spec.StackID = pickLocation(doc.Spec.StackID, &config.KUKE_RUN_STACK)
 }
 
-// explicitScope returns a blueprint-lookup scope coordinate only when the
-// operator set it explicitly — the cobra flag was changed on this invocation,
-// or the backing env var (kv.Key) is present in the environment. It deliberately
-// bypasses viper.GetString: DefineKV registers a viper default of "default" for
-// the run space/stack keys, so viper would report "default" for an unset
-// coordinate and narrow every lookup to default/default, hiding realm-scoped
-// blueprints. An empty return means "don't constrain this coordinate".
-func explicitScope(cmd *cobra.Command, flagName string, kv *config.Var) string {
-	if cmd.Flags().Changed(flagName) {
-		v, _ := cmd.Flags().GetString(flagName)
-		return strings.TrimSpace(v)
-	}
-	if v, ok := os.LookupEnv(kv.Key); ok {
-		return strings.TrimSpace(v)
-	}
-	return ""
-}
-
+// pickLocation fills a realm/space/stack coordinate on the materialised cell
+// doc itself. The doc wins when it sets a value; otherwise viper.GetString
+// (bound to the cobra flag in NewRunCmd) provides the operator's per-session
+// pin; otherwise kv.ValueOrDefault walks env → default. Lookup-side scope
+// resolution lives in cmd/kuke/shared.PickLookupRealm / ExplicitScope —
+// those bypass viper for the IsSet-trip reason their commentary explains;
+// pickLocation here is the materialised-cell fill path that does want the
+// viper-backed session pin.
 func pickLocation(fromDoc string, kv *config.Var) string {
 	if v := strings.TrimSpace(fromDoc); v != "" {
 		return v

--- a/cmd/kuke/shared/scope.go
+++ b/cmd/kuke/shared/scope.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"os"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/spf13/cobra"
+)
+
+// PickLookupRealm returns the realm coordinate for a `kuke run` /
+// `kuke apply` blueprint or config lookup. Precedence: --realm flag → env
+// var named by kv.Key → "default". The realm always resolves to a
+// non-empty value because the daemon's blueprint/config namespace is
+// realm-scoped — an empty realm name has no lookup meaning.
+//
+// Bypasses viper deliberately. DefineKV(.., "default") on KUKE_RUN_REALM
+// registers a viper.SetDefault, which trips viper.IsSet on the bound key
+// in viper v1.21 (see config/env.go's DefineKVNoViperDefault commentary).
+// A viper-aware fallback would silently swallow the env-var step below
+// and narrow every lookup to "default" even when the operator set
+// KUKE_RUN_REALM in their shell.
+func PickLookupRealm(cmd *cobra.Command, kv *config.Var) string {
+	if v, _ := cmd.Flags().GetString("realm"); strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	if v, ok := os.LookupEnv(kv.Key); ok && strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	return "default"
+}
+
+// ExplicitScope returns the named space/stack coordinate for a `kuke run`
+// / `kuke apply` blueprint or config lookup, but only when the operator
+// set it explicitly — via the named cobra flag or the kv.Key env var.
+// Returns "" otherwise so realm-scoped Blueprints/Configs (no space/stack
+// coordinate) stay findable; a missing flag must not narrow the lookup to
+// space="default" / stack="default" or it would hide realm-scoped
+// resources.
+//
+// Bypasses viper for the same reason as PickLookupRealm: DefineKV's
+// SetDefault on KUKE_RUN_SPACE / KUKE_RUN_STACK trips viper.IsSet, so a
+// viper-aware fallback would report "default" for an unset coordinate
+// even when the operator left the flag and env var empty.
+func ExplicitScope(cmd *cobra.Command, flagName string, kv *config.Var) string {
+	if cmd.Flags().Changed(flagName) {
+		v, _ := cmd.Flags().GetString(flagName)
+		return strings.TrimSpace(v)
+	}
+	if v, ok := os.LookupEnv(kv.Key); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}

--- a/cmd/kuke/shared/scope_test.go
+++ b/cmd/kuke/shared/scope_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/spf13/cobra"
+)
+
+// newScopeCmd builds a bare cobra command with --realm/--space/--stack
+// pflags so the helpers can read flag state. Mirrors the surface
+// NewRunCmd / NewApplyCmd register on their commands without dragging in
+// the rest of those packages' wiring.
+func newScopeCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("realm", "", "")
+	cmd.Flags().String("space", "", "")
+	cmd.Flags().String("stack", "", "")
+	return cmd
+}
+
+func TestPickLookupRealm_Precedence(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		flagSet   bool
+		env       string
+		envSet    bool
+		want      string
+	}{
+		{name: "no flag, no env → default", want: "default"},
+		{name: "env only → env", env: "from-env", envSet: true, want: "from-env"},
+		{name: "flag only → flag", flagValue: "from-flag", flagSet: true, want: "from-flag"},
+		{
+			name:      "flag wins over env",
+			flagValue: "from-flag",
+			flagSet:   true,
+			env:       "from-env",
+			envSet:    true,
+			want:      "from-flag",
+		},
+		{name: "whitespace env ignored", env: "   ", envSet: true, want: "default"},
+		{
+			name:      "whitespace flag ignored, env wins",
+			flagValue: "   ",
+			flagSet:   true,
+			env:       "from-env",
+			envSet:    true,
+			want:      "from-env",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envSet {
+				t.Setenv(config.KUKE_RUN_REALM.Key, tc.env)
+			}
+			cmd := newScopeCmd()
+			if tc.flagSet {
+				if err := cmd.Flags().Set("realm", tc.flagValue); err != nil {
+					t.Fatalf("flag set: %v", err)
+				}
+			}
+			if got := PickLookupRealm(cmd, &config.KUKE_RUN_REALM); got != tc.want {
+				t.Errorf("PickLookupRealm=%q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExplicitScope_Precedence(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagValue string
+		flagSet   bool
+		env       string
+		envSet    bool
+		kv        *config.Var
+		flag      string
+		want      string
+	}{
+		{name: "space: no flag, no env → empty", flag: "space", kv: &config.KUKE_RUN_SPACE, want: ""},
+		{
+			name:   "space: env only → env",
+			flag:   "space",
+			kv:     &config.KUKE_RUN_SPACE,
+			env:    "eng",
+			envSet: true,
+			want:   "eng",
+		},
+		{
+			name:      "space: flag only → flag",
+			flag:      "space",
+			kv:        &config.KUKE_RUN_SPACE,
+			flagValue: "platform",
+			flagSet:   true,
+			want:      "platform",
+		},
+		{
+			name:      "space: flag wins over env",
+			flag:      "space",
+			kv:        &config.KUKE_RUN_SPACE,
+			flagValue: "platform",
+			flagSet:   true,
+			env:       "eng",
+			envSet:    true,
+			want:      "platform",
+		},
+		{
+			name:   "stack: env only → env",
+			flag:   "stack",
+			kv:     &config.KUKE_RUN_STACK,
+			env:    "core",
+			envSet: true,
+			want:   "core",
+		},
+		{
+			name:      "stack: empty flag set explicitly → empty (flag wins)",
+			flag:      "stack",
+			kv:        &config.KUKE_RUN_STACK,
+			flagValue: "",
+			flagSet:   true,
+			env:       "core",
+			envSet:    true,
+			want:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envSet {
+				t.Setenv(tc.kv.Key, tc.env)
+			}
+			cmd := newScopeCmd()
+			if tc.flagSet {
+				if err := cmd.Flags().Set(tc.flag, tc.flagValue); err != nil {
+					t.Fatalf("flag set: %v", err)
+				}
+			}
+			if got := ExplicitScope(cmd, tc.flag, tc.kv); got != tc.want {
+				t.Errorf("ExplicitScope(%s)=%q want %q", tc.flag, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `kuke apply -b/-c` now honors `KUKE_RUN_REALM` / `KUKE_RUN_SPACE` / `KUKE_RUN_STACK` env-var fallbacks, matching `kuke run -b/-c`. The pre-fix apply path read scope strictly from cobra flags, so an operator who pinned `KUKE_RUN_REALM=foo` for their `kuke run` workflow found `kuke apply -b web` silently looked up in `realm=default` instead.
- Extracts the scope-resolution helpers into `cmd/kuke/shared/scope.go` (`PickLookupRealm`, `ExplicitScope`) and points both `kuke apply -b/-c` and `kuke run -b/-c` at them. One precedence chain, one source of truth, one test surface — addresses the AC's "test coverage for both subcommands lives in one place after the helper extraction."
- Precedence: `--realm`/`--space`/`--stack` flag → `KUKE_RUN_*` env var → `"default"` (realm) / `""` (space, stack — `""` keeps realm-scoped Blueprints/Configs findable). Both helpers bypass viper deliberately; the inline godoc explains why (the existing run-side `explicitScope` comment surfaced the same `SetDefault`-trips-`IsSet` reason).
- `run.go`'s local `explicitScope` is deleted (replaced by the shared helper). `run.go`'s local `pickLocation` stays because the **fill** path on the materialised cell doc still wants the viper-backed session pin — the lookup path is the only one that needs to bypass viper.
- `apply.go`'s `resolveCellLocation` now also picks up the env-var fallbacks via the shared helpers, so the materialised cell's `Spec.RealmID`/`SpaceID`/`StackID` matches the lookup scope when the doc itself left them empty.

### Scope notes

- The issue's "Suggested fix" floated waiting on the divergent-reject phase (#753 → PR #802) before extracting helpers. That PR is still in flight; this change extracts the narrow lookup helpers now so the env-var symmetry isn't blocked on it. The divergent-reject phase can consume the same `cmd/kuke/shared` namespace when it lands — no helper-shape collision.
- Did not rename `KUKE_RUN_*` to a CLI-wide umbrella (`KUKE_*` or similar). The issue body flagged it as a separate decision with backwards-compat implications and explicitly out of scope here. Operators continue to set `KUKE_RUN_REALM` and both subcommands consume it.

## Test plan

- [x] `make test` — full repo + `cmd/kukebuild` module pass.
- [x] `GOWORK=off go vet ./...` — clean.
- [x] `GOWORK=off go build ./...` — clean compile.
- [x] `pre-commit run --files <changed>` — go fmt / golangci-lint / addlicense all pass. golangci-lint rewrote `scope_test.go` to wrap long table-driven test cases; re-staged and re-ran clean.
- [x] New `cmd/kuke/shared/scope_test.go` covers `PickLookupRealm` and `ExplicitScope` precedence (no-flag/no-env → default; env only; flag only; flag wins over env; whitespace trim).
- [x] New `cmd/kuke/apply/apply_test.go` regressions: `TestApply_FromBlueprint_EnvVarScopeFallback` and `TestApply_FromConfig_EnvVarScopeFallback` verify `KUKE_RUN_REALM`/`SPACE`/`STACK` feed the BP / Config lookup; `TestApply_FromBlueprint_FlagWinsOverEnvVar` pins the flag-over-env precedence.
- [x] Existing `cmd/kuke/run` tests still pass — the run-side lookup wiring swap is behavior-preserving (the new shared helper returns the same flag → env → default chain the prior `pickLocation("", &kv)` + `explicitScope` pair produced).
- [ ] `make dev-init` smoke — not run; this change is scoped to a CLI-side helper extraction (cmd/kuke only), with no build path, daemon, or `/opt/kukeon` touch points. The `kuke status` parity guard would only be re-confirming an untouched code path.

Closes #776