### PR TITLE
feat(run): accept CellConfig name as positional, drop -c/--config flag

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -457,8 +457,6 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_BLUEPRINT = DefineKV("KUKE_RUN_BLUEPRINT", "kuke/run/blueprint")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_RUN_CONFIG = DefineKV("KUKE_RUN_CONFIG", "kuke/run/config")
-	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_RM = DefineKV("KUKE_RUN_RM", "kuke/run/rm")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_NAME = DefineKV("KUKE_RUN_NAME", "kuke/run/name")

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -48,99 +48,100 @@ import (
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
-// NewRunCmd builds the `kuke run` cobra command. `-f` reads a single-cell
-// YAML doc; `-p` reads a per-user CellProfile and materializes the same
-// CellDoc shape. Exactly one of the two is required. By default, after the
-// cell starts the CLI drops the operator into the cell's attachable terminal;
-// `-d/--detach` opts out of the post-start attach.
+// NewRunCmd builds the `kuke run` cobra command. The optional positional arg
+// names a daemon-stored CellConfig; `-f` reads a single-cell YAML doc; `-p`
+// reads a per-user CellProfile; `-b` names a daemon-stored CellBlueprint.
+// Exactly one of the four is required. By default, after the cell starts the
+// CLI drops the operator into the cell's attachable terminal; `-d/--detach`
+// opts out of the post-start attach.
 func NewRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run (-f <file> | -p <profile> | -b <blueprint> | -c <config>)",
-		Short: "Create and start a single cell from a YAML file, a profile, a daemon-stored blueprint, or a daemon-stored config",
-		Long: "Create and start a single cell from a YAML file or stdin (-f), " +
-			"from a per-user profile under $HOME/.kuke/profiles.d/<name>.yaml (-p), " +
-			"from a daemon-stored CellBlueprint (-b), or from a daemon-stored " +
-			"CellConfig (-c), resolved from the scope named by --realm/--space/--stack. " +
-			"-b substitutes scalar --param values and materializes a fresh " +
-			"<prefix>-<6hex> cell every invocation (always fresh). -c walks the " +
-			"identity state machine of a daemon-stored CellConfig: at most one live " +
-			"cell per Config, with a deterministic name (the Config's metadata.name), " +
-			"materialising from the referenced Blueprint with the Config's scalar " +
-			"values plus repo / secret slot fills the first time and attaching to the " +
-			"existing cell on subsequent runs (idempotent). When the live cell's spec " +
-			"differs from the materialisation of the current Config + Blueprint, -c " +
-			"refuses to attach and points the operator at `kuke apply -c <config>` to " +
-			"reconcile (stops, updates, starts). -b with --name applies the same " +
-			"discipline against the pinned cell name, pointing at " +
-			"`kuke apply -b <bp> --name <cell>`. -c -g/--generate-name materializes " +
-			"a fresh <config-name>-<6hex> cell on every invocation instead — opt-in " +
-			"fire-and-forget sandboxes from a Config, preserving the kukeon.io/config " +
-			"lineage label. -f is create-or-attach by metadata.name: a missing cell " +
-			"is created and attached; a Ready cell is attached as a no-op; a Stopped " +
-			"cell is started then attached; a divergent on-disk spec is refused " +
-			"(use `kuke apply -f` to update); a cell in an error or partial state " +
-			"is refused with a `kuke delete cell <name>` pointer. To re-attach to an " +
-			"existing cell use `kuke attach <cell>`.",
-		Args:          cobra.NoArgs,
-		SilenceUsage:  true,
-		SilenceErrors: false,
-		RunE:          runRun,
+		Use:   "run [<config> | -f <file> | -p <profile> | -b <blueprint>]",
+		Short: "Create and start a single cell from a daemon-stored CellConfig (positional), a YAML file, a profile, or a daemon-stored blueprint",
+		Long: "Create and start a single cell from a daemon-stored CellConfig " +
+			"(positional `<config>` name), from a YAML file or stdin (-f), from a " +
+			"per-user profile under $HOME/.kuke/profiles.d/<name>.yaml (-p), or from " +
+			"a daemon-stored CellBlueprint (-b), resolved from the scope named by " +
+			"--realm/--space/--stack. The positional `<config>` is the highest-frequency " +
+			"path (daily dev-cell spawn-and-attach); the other sources stay flag-driven " +
+			"so the positional case is unambiguous. -b substitutes scalar --param values " +
+			"and materializes a fresh <prefix>-<6hex> cell every invocation (always " +
+			"fresh). The positional config path walks the identity state machine of " +
+			"the named CellConfig: at most one live cell per Config, with a " +
+			"deterministic name (the Config's metadata.name), materialising from the " +
+			"referenced Blueprint with the Config's scalar values plus repo / secret " +
+			"slot fills the first time and attaching to the existing cell on " +
+			"subsequent runs (idempotent). When the live cell's spec differs from the " +
+			"materialisation of the current Config + Blueprint, the positional config " +
+			"path refuses to attach and points the operator at " +
+			"`kuke apply -c <config>` to reconcile (stops, updates, starts). -b with " +
+			"--name applies the same discipline against the pinned cell name, pointing " +
+			"at `kuke apply -b <bp> --name <cell>`. -g/--generate-name on the " +
+			"positional config path materializes a fresh <config-name>-<6hex> cell on " +
+			"every invocation instead — opt-in fire-and-forget sandboxes from a " +
+			"Config, preserving the kukeon.io/config lineage label. -f is " +
+			"create-or-attach by metadata.name: a missing cell is created and " +
+			"attached; a Ready cell is attached as a no-op; a Stopped cell is started " +
+			"then attached; a divergent on-disk spec is refused (use `kuke apply -f` " +
+			"to update); a cell in an error or partial state is refused with a " +
+			"`kuke delete cell <name>` pointer. To re-attach to an existing cell use " +
+			"`kuke attach <cell>`.",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: config.CompleteConfigNames,
+		SilenceUsage:      true,
+		SilenceErrors:     false,
+		RunE:              runRun,
 	}
 
-	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin); mutually exclusive with -p")
+	cmd.Flags().
+		StringP("file", "f", "", "File to read YAML from (use - for stdin); mutually exclusive with the <config> positional and -p/-b")
 	_ = viper.BindPFlag(config.KUKE_RUN_FILE.ViperKey, cmd.Flags().Lookup("file"))
 
 	cmd.Flags().StringP("profile", "p", "",
-		"Cell profile name to load from $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR); mutually exclusive with -f/-b/-c. "+
-			"Deprecated: apply a kind: CellBlueprint and use -b/-c instead.")
+		"Cell profile name to load from $HOME/.kuke/profiles.d (or $KUKE_PROFILES_DIR); mutually exclusive with -f/-b and the <config> positional. "+
+			"Deprecated: apply a kind: CellBlueprint and use -b (or pass the <config> positional for a CellConfig) instead.")
 	_ = viper.BindPFlag(config.KUKE_RUN_PROFILE.ViperKey, cmd.Flags().Lookup("profile"))
 
 	cmd.Flags().StringP("blueprint", "b", "",
 		"Daemon-stored CellBlueprint name to run, resolved from the scope named by "+
-			"--realm/--space/--stack; mutually exclusive with -f/-p/-c. Substitutes scalar --param "+
+			"--realm/--space/--stack; mutually exclusive with -f/-p and the <config> positional. Substitutes scalar --param "+
 			"values and materializes a fresh <prefix>-<6hex> cell.")
 	_ = viper.BindPFlag(config.KUKE_RUN_BLUEPRINT.ViperKey, cmd.Flags().Lookup("blueprint"))
-
-	cmd.Flags().StringP("config", "c", "",
-		"Daemon-stored CellConfig name to run, resolved from the scope named by "+
-			"--realm/--space/--stack; mutually exclusive with -f/-p/-b. The Config "+
-			"carries its own scalar values and structural slot fills (repos, secrets), "+
-			"so --param/--param-file/--name are rejected with -c. Idempotent: walks "+
-			"the identity state machine and attaches to the at-most-one live cell the "+
-			"Config owns by stable name. Pass -g/--generate-name to opt out of the "+
-			"stable name and materialize a fresh <config-name>-<6hex> cell per invocation.")
-	_ = viper.BindPFlag(config.KUKE_RUN_CONFIG.ViperKey, cmd.Flags().Lookup("config"))
 
 	cmd.Flags().String("name", "",
 		"Override the materialized cell name (default: <metadata.name>-<6hex>). "+
 			"Valid with -p/-b; rejected with -f, where metadata.name is the cell name "+
-			"verbatim, and with -c, whose name is the Config's deterministic stable name "+
-			"(use -g/--generate-name on -c to opt into a generated <config-name>-<6hex>).")
+			"verbatim, and with the <config> positional, whose name is the Config's deterministic stable name "+
+			"(use -g/--generate-name with the <config> positional to opt into a generated <config-name>-<6hex>).")
 	_ = viper.BindPFlag(config.KUKE_RUN_NAME.ViperKey, cmd.Flags().Lookup("name"))
 
 	cmd.Flags().BoolP("generate-name", "g", false,
-		"Materialize a fresh `<config-name>-<6hex>` cell on every -c invocation instead "+
-			"of the Config's deterministic stable name. Each invocation produces a distinct "+
+		"Materialize a fresh `<config-name>-<6hex>` cell on every invocation of the <config> "+
+			"positional instead of the Config's deterministic stable name. Each invocation produces a distinct "+
 			"cell; the kukeon.io/config=<name> lineage label is preserved (operator can list "+
 			"all spawns: `kuke get cells -l kukeon.io/config=<name>`). Mutually exclusive "+
-			"with --name. Only valid with -c — rejected with -f (where metadata.name is the "+
+			"with --name. Only valid with the <config> positional — rejected with -f (where metadata.name is the "+
 			"cell name verbatim) and redundant for -p/-b (which already generate a fresh name).")
 	_ = viper.BindPFlag(config.KUKE_RUN_GENERATE_NAME.ViperKey, cmd.Flags().Lookup("generate-name"))
 
 	cmd.Flags().StringArray("param", nil,
 		"Scalar parameter override as KEY=VALUE; repeatable. Valid with -p/-b. "+
 			"Each KEY must be declared in spec.parameters[]. Wins over the parameter's "+
-			"default and over --param-file when both set the same key. Rejected with -c: "+
-			"a CellConfig carries its own spec.values, edit the Config instead.")
+			"default and over --param-file when both set the same key. Rejected with the "+
+			"<config> positional: a CellConfig carries its own spec.values, edit the Config instead.")
 
 	cmd.Flags().String("param-file", "",
 		"File of KEY=VALUE lines whose values seed scalar parameters; one per line, "+
 			"`#` starts a comment. Same declaration rules as --param. CLI --param wins on "+
-			"duplicate keys. Rejected with -c (same reason as --param).")
+			"duplicate keys. Rejected with the <config> positional (same reason as --param).")
 	_ = viper.BindPFlag(config.KUKE_RUN_PARAM_FILE.ViperKey, cmd.Flags().Lookup("param-file"))
 
-	cmd.MarkFlagsMutuallyExclusive("file", "profile", "blueprint", "config")
-	cmd.MarkFlagsOneRequired("file", "profile", "blueprint", "config")
+	// `config` is now a positional (see Args / ValidArgsFunction above), so the
+	// cobra-side mutex/required-one machinery covers only the remaining flag
+	// sources; parseRunFlags hand-rolls the positional-vs-flag mutex and the
+	// "exactly one source required" check (cobra has no MarkFlagsOneRequired
+	// equivalent that spans flags + positionals).
+	cmd.MarkFlagsMutuallyExclusive("file", "profile", "blueprint")
 	cmd.MarkFlagsMutuallyExclusive("name", "generate-name")
 
 	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
@@ -180,7 +181,8 @@ func NewRunCmd() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
 	_ = cmd.RegisterFlagCompletionFunc("profile", config.CompleteProfileNames)
 	_ = cmd.RegisterFlagCompletionFunc("blueprint", config.CompleteBlueprintNames)
-	_ = cmd.RegisterFlagCompletionFunc("config", config.CompleteConfigNames)
+	// The positional <config> is wired via ValidArgsFunction on the cobra
+	// command above (where `-c` previously routed flag completion).
 
 	return cmd
 }
@@ -203,18 +205,56 @@ type runFlags struct {
 	paramFile     string
 }
 
-func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
+// validateSourceMutex enforces the "exactly one source" contract across the
+// four `kuke run` inputs after issue #813 moved CellConfig from `-c/--config`
+// to the positional `<config>` argument. Cobra's MarkFlagsMutuallyExclusive
+// / MarkFlagsOneRequired only span flags, so this check hand-rolls the
+// positional-vs-flag mutex and the at-least-one-source guard; the
+// flag-vs-flag mutex among `-f`/`-p`/`-b` stays cobra-side in NewRunCmd.
+// Pulling the branches out of parseRunFlags keeps gocyclo within its
+// budget for the larger validator.
+func validateSourceMutex(flags runFlags) error {
+	if flags.configName != "" {
+		switch {
+		case flags.file != "":
+			return errors.New(
+				"the <config> positional is mutually exclusive with -f/--file " +
+					"(pick one source: <config>, -f, -p, or -b)")
+		case flags.profileName != "":
+			return errors.New(
+				"the <config> positional is mutually exclusive with -p/--profile " +
+					"(pick one source: <config>, -f, -p, or -b)")
+		case flags.blueprintName != "":
+			return errors.New(
+				"the <config> positional is mutually exclusive with -b/--blueprint " +
+					"(pick one source: <config>, -f, -p, or -b)")
+		}
+	}
+	if flags.configName == "" && flags.file == "" && flags.profileName == "" && flags.blueprintName == "" {
+		return errors.New(
+			"at least one of <config> (positional), -f/--file, -p/--profile, or -b/--blueprint is required")
+	}
+	return nil
+}
+
+func parseRunFlags(cmd *cobra.Command, args []string) (runFlags, error) {
 	flags := runFlags{
 		file:          strings.TrimSpace(viper.GetString(config.KUKE_RUN_FILE.ViperKey)),
 		profileName:   strings.TrimSpace(viper.GetString(config.KUKE_RUN_PROFILE.ViperKey)),
 		blueprintName: strings.TrimSpace(viper.GetString(config.KUKE_RUN_BLUEPRINT.ViperKey)),
-		configName:    strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONFIG.ViperKey)),
 		detach:        viper.GetBool(config.KUKE_RUN_DETACH.ViperKey),
 		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
 		autoDelete:    viper.GetBool(config.KUKE_RUN_RM.ViperKey),
 		nameOverride:  strings.TrimSpace(viper.GetString(config.KUKE_RUN_NAME.ViperKey)),
 		generateName:  viper.GetBool(config.KUKE_RUN_GENERATE_NAME.ViperKey),
 		paramFile:     strings.TrimSpace(viper.GetString(config.KUKE_RUN_PARAM_FILE.ViperKey)),
+	}
+
+	if len(args) == 1 {
+		flags.configName = strings.TrimSpace(args[0])
+	}
+	if err := validateSourceMutex(flags); err != nil {
+		return runFlags{}, err
 	}
 
 	paramArgs, err := cmd.Flags().GetStringArray("param")
@@ -258,35 +298,36 @@ func parseRunFlags(cmd *cobra.Command, _ []string) (runFlags, error) {
 		}
 		if flags.generateName {
 			return runFlags{}, errors.New(
-				"--generate-name is only valid with -c/--config; -f uses metadata.name verbatim")
+				"--generate-name is only valid with the <config> positional; -f uses metadata.name verbatim")
 		}
 	}
-	// -g/--generate-name is a -c-only knob. With -p/-b the default already
+	// -g/--generate-name is a CellConfig-only knob (only the <config> positional
+	// reaches the daemon-stored CellConfig path). With -p/-b the default already
 	// generates a fresh <prefix>-<6hex> per invocation, so accepting -g there
 	// would silently no-op and seed the mental model that -g toggles a default
 	// that isn't actually flipped — reject so the operator notices.
 	if flags.generateName && flags.configName == "" && flags.file == "" {
 		return runFlags{}, errors.New(
-			"--generate-name is only valid with -c/--config; -p and -b already materialize a " +
+			"--generate-name is only valid with the <config> positional; -p and -b already materialize a " +
 				"fresh <prefix>-<6hex> cell per invocation")
 	}
 	if flags.configName != "" {
 		// A CellConfig carries its own scalar values and a deterministic
 		// stable name (cellconfig.StableName). The template knobs would
 		// either silently shadow the Config's values or break the
-		// idempotent-identity contract that the -c verb exists to provide,
-		// so reject them rather than silently apply.
+		// idempotent-identity contract the positional <config> path exists to
+		// provide, so reject them rather than silently apply.
 		if flags.nameOverride != "" {
 			return runFlags{}, errors.New(
-				"--name is not valid with -c/--config; the cell name is the Config's stable name")
+				"--name is not valid with the <config> positional; the cell name is the Config's stable name")
 		}
 		if len(flags.paramArgs) > 0 {
 			return runFlags{}, errors.New(
-				"--param is not valid with -c/--config; edit the Config's spec.values instead")
+				"--param is not valid with the <config> positional; edit the Config's spec.values instead")
 		}
 		if flags.paramFile != "" {
 			return runFlags{}, errors.New(
-				"--param-file is not valid with -c/--config; edit the Config's spec.values instead")
+				"--param-file is not valid with the <config> positional; edit the Config's spec.values instead")
 		}
 	}
 	return flags, nil
@@ -569,7 +610,7 @@ func loadCellDoc(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (v1
 	case flags.profileName != "":
 		fmt.Fprintln(cmd.ErrOrStderr(),
 			"kuke run: -p/--profile is deprecated and will be removed (#626); "+
-				"apply a kind: CellBlueprint and use `kuke run -b` (or `kuke run -c` for a CellConfig).")
+				"apply a kind: CellBlueprint and use `kuke run -b` (or `kuke run <config>` for a CellConfig).")
 		return loadFromProfile(flags)
 	default:
 		return loadFromFile(flags.file)

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1225,12 +1225,16 @@ func TestRun_MissingFileAndProfile_Errors(t *testing.T) {
 	cmd.SetArgs([]string{})
 
 	err := cmd.Execute()
-	// MarkFlagsOneRequired produces "at least one of the flags in the group
-	// [file profile blueprint config] is required" — match on the stable
-	// group listing rather than the exact wording so a cobra phrasing change
-	// doesn't break the test.
-	if err == nil || !strings.Contains(err.Error(), "[file profile blueprint config]") {
-		t.Fatalf("err=%v want one-of error naming the file/profile/blueprint/config group", err)
+	// Issue #813: the cobra MarkFlagsOneRequired group no longer spans the
+	// CellConfig source (now positional), so parseRunFlags hand-rolls the
+	// at-least-one check. Match on the stable phrasing it emits — naming all
+	// four sources — rather than the prior cobra group listing.
+	if err == nil ||
+		!strings.Contains(err.Error(), "<config>") ||
+		!strings.Contains(err.Error(), "-f/--file") ||
+		!strings.Contains(err.Error(), "-p/--profile") ||
+		!strings.Contains(err.Error(), "-b/--blueprint") {
+		t.Fatalf("err=%v want one-of error naming the <config>/-f/-p/-b sources", err)
 	}
 }
 
@@ -1252,6 +1256,16 @@ func TestNewRunCmd_AutocompleteRegistration(t *testing.T) {
 	outputFlag := cmd.Flags().Lookup("output")
 	if outputFlag == nil || outputFlag.Shorthand != "o" {
 		t.Errorf("expected -o/--output flag, got %+v", outputFlag)
+	}
+	// Issue #813: the CellConfig source moved from `-c/--config` to the
+	// optional positional argument. Assert the flag is gone and the positional
+	// completer is wired so a regression that re-adds `-c` or drops the
+	// completer wiring fails this test.
+	if f := cmd.Flags().Lookup("config"); f != nil {
+		t.Errorf("`config` flag must be removed (#813); got %+v", f)
+	}
+	if cmd.ValidArgsFunction == nil {
+		t.Error("ValidArgsFunction must be wired to CompleteConfigNames for the positional <config> arg")
 	}
 }
 
@@ -2831,7 +2845,7 @@ func TestRun_FromConfig_CreatesWithStableNameAndBackRef(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "--realm", "cfg-realm", "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -2906,7 +2920,7 @@ func TestRun_FromConfig_LiveReadyCell_AttachesWithoutCreate(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "--realm", "cfg-realm", "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -2939,7 +2953,7 @@ func TestRun_FromConfig_LiveStoppedCell_StartsThenAttaches(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "--realm", "cfg-realm", "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -2972,7 +2986,7 @@ func TestRun_FromConfig_LiveFailedCell_RefusesWithDeletePointer(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "--realm", "cfg-realm", "-d"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -3024,7 +3038,7 @@ func TestRun_FromConfig_DivergentSpec_RefusesAndPointsToApply(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "--realm", "cfg-realm", "-d"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -3117,7 +3131,7 @@ func TestRun_FromConfig_NotFound_Errors(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "ghost", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"ghost", "--realm", "cfg-realm", "-d"})
 
 	err := cmd.Execute()
 	if err == nil || !errors.Is(err, errdefs.ErrConfigNotFound) {
@@ -3140,7 +3154,7 @@ func TestRun_FromConfig_BlueprintMissing_Errors(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "--realm", "cfg-realm", "-d"})
 
 	err := cmd.Execute()
 	if err == nil || !errors.Is(err, errdefs.ErrBlueprintNotFound) {
@@ -3159,9 +3173,21 @@ func TestRun_FromConfig_RejectsParamFlags(t *testing.T) {
 		args []string
 		want string
 	}{
-		{"--param", []string{"-c", "prod", "--param", "K=V", "-d"}, "--param is not valid with -c"},
-		{"--param-file", []string{"-c", "prod", "--param-file", "/tmp/p", "-d"}, "--param-file is not valid with -c"},
-		{"--name", []string{"-c", "prod", "--name", "pinned", "-d"}, "--name is not valid with -c"},
+		{
+			"--param",
+			[]string{"prod", "--param", "K=V", "-d"},
+			"--param is not valid with the <config> positional",
+		},
+		{
+			"--param-file",
+			[]string{"prod", "--param-file", "/tmp/p", "-d"},
+			"--param-file is not valid with the <config> positional",
+		},
+		{
+			"--name",
+			[]string{"prod", "--name", "pinned", "-d"},
+			"--name is not valid with the <config> positional",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Cleanup(viper.Reset)
@@ -3176,20 +3202,61 @@ func TestRun_FromConfig_RejectsParamFlags(t *testing.T) {
 	}
 }
 
-func TestRun_RunVerbMutex_RejectsCAndB(t *testing.T) {
-	t.Cleanup(viper.Reset)
+// TestRun_PositionalConfig_MutexWithFlagSources covers issue #813's AC: the
+// <config> positional is rejected when combined with -b/-f/-p; the rejection
+// message names all four sources so the operator sees the full set without
+// re-running with --help.
+func TestRun_PositionalConfig_MutexWithFlagSources(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			"-b conflicts with positional",
+			[]string{"prod", "-b", "web", "--realm", "cfg-realm", "-d"},
+			"the <config> positional is mutually exclusive with -b/--blueprint",
+		},
+		{
+			"-f conflicts with positional",
+			[]string{"prod", "-f", "/tmp/never-read.yaml", "-d"},
+			"the <config> positional is mutually exclusive with -f/--file",
+		},
+		{
+			"-p conflicts with positional",
+			[]string{"prod", "-p", "shell", "-d"},
+			"the <config> positional is mutually exclusive with -p/--profile",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			fc := &fakeClient{}
+			cmd, _ := newCmd(t, fc)
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err=%v want substring %q", err, tc.want)
+			}
+		})
+	}
+}
 
+// TestRun_PositionalConfig_TooManyArgs covers the cobra.MaximumNArgs(1) gate:
+// the operator can pass at most one positional. A second positional must be
+// rejected so a stray argument is surfaced rather than silently dropped.
+func TestRun_PositionalConfig_TooManyArgs(t *testing.T) {
+	t.Cleanup(viper.Reset)
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "-b", "web", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "stray", "-d"})
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatalf("Execute err=nil want mutex rejection of -c with -b")
+		t.Fatalf("Execute err=nil want cobra rejection of >1 positional arg")
 	}
 }
 
 // TestRun_FromConfig_GenerateName_FreshCellPerInvocation covers AC #1+#2 of #754:
-// `kuke run -c <config> -g` materializes a fresh <config-name>-<6hex> cell on
+// `kuke run <config> -g` materializes a fresh <config-name>-<6hex> cell on
 // each invocation, and the cell carries the kukeon.io/config=<config-name>
 // lineage label so `kuke get cells -l kukeon.io/config=<name>` still enumerates
 // every spawn.
@@ -3230,7 +3297,7 @@ func TestRun_FromConfig_GenerateName_FreshCellPerInvocation(t *testing.T) {
 			createCellFn: createCell,
 		}
 		cmd, _ := newCmd(t, fc)
-		cmd.SetArgs([]string{"-c", "prod", "-g", "--realm", "cfg-realm", "-d"})
+		cmd.SetArgs([]string{"prod", "-g", "--realm", "cfg-realm", "-d"})
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Execute (iteration %d): %v", i, err)
 		}
@@ -3286,7 +3353,7 @@ func TestRun_FromConfig_NoGenerateName_UsesStableName(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "--realm", "cfg-realm", "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -3303,7 +3370,7 @@ func TestRun_FromConfig_GenerateNameAndName_MutuallyExclusive(t *testing.T) {
 
 	fc := &fakeClient{}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "-g", "--name", "pinned", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "-g", "--name", "pinned", "--realm", "cfg-realm", "-d"})
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatalf("Execute err=nil want mutex rejection of --name with --generate-name")
@@ -3341,7 +3408,7 @@ func TestRun_FromConfig_GenerateNameWithRm_SetsAutoDelete(t *testing.T) {
 		},
 	}
 	cmd, _ := newCmd(t, fc)
-	cmd.SetArgs([]string{"-c", "prod", "-g", "--rm", "--realm", "cfg-realm", "-d"})
+	cmd.SetArgs([]string{"prod", "-g", "--rm", "--realm", "cfg-realm", "-d"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -3359,7 +3426,8 @@ func TestRun_FromConfig_GenerateNameWithRm_SetsAutoDelete(t *testing.T) {
 }
 
 // TestRun_GenerateName_OnlyValidWithConfig covers the defensive UX guard: -g
-// is a -c-only flag. Allowing it silently on -f (where metadata.name is
+// is a CellConfig-only knob (only the <config> positional reaches the daemon-
+// stored CellConfig path). Allowing it silently on -f (where metadata.name is
 // authoritative) or -p/-b (which already generate <prefix>-<6hex>) would seed
 // a wrong mental model that -g toggles a default that isn't actually flipped.
 func TestRun_GenerateName_OnlyValidWithConfig(t *testing.T) {
@@ -3371,17 +3439,17 @@ func TestRun_GenerateName_OnlyValidWithConfig(t *testing.T) {
 		{
 			"-f rejects -g",
 			[]string{"-f", "/tmp/never-read.yaml", "-g", "-d"},
-			"--generate-name is only valid with -c/--config",
+			"--generate-name is only valid with the <config> positional",
 		},
 		{
 			"-p rejects -g",
 			[]string{"-p", "shell", "-g", "-d"},
-			"--generate-name is only valid with -c/--config",
+			"--generate-name is only valid with the <config> positional",
 		},
 		{
 			"-b rejects -g",
 			[]string{"-b", "web", "-g", "-d"},
-			"--generate-name is only valid with -c/--config",
+			"--generate-name is only valid with the <config> positional",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -172,7 +172,7 @@ func MaterializeWithName(doc v1beta1.CellBlueprintDoc, nameOverride string) (v1b
 	}
 	if len(blockers) > 0 {
 		return v1beta1.CellDoc{}, fmt.Errorf(
-			"%w (blueprint %q: %s); use `kuke run -c <config>` with a CellConfig that fills the slots",
+			"%w (blueprint %q: %s); use `kuke run <config>` with a CellConfig that fills the slots",
 			errdefs.ErrBlueprintStructuralSlots, doc.Metadata.Name, strings.Join(blockers, ", "),
 		)
 	}


### PR DESCRIPTION
## Summary

- Move `kuke run`'s CellConfig source from `-c/--config` to the optional positional `<config>` argument so the highest-frequency invocation drops the flag: `kuke run kukeon-dev-0` replaces `kuke run -c kukeon-dev-0`, and `kuke run kukeon-dev-0 -g` replaces the `-g` variant. `-f`/`-p`/`-b` stay flag-driven to keep the positional case unambiguous.
- Hand-roll the source-mutex check (positional vs `-f`/`-p`/`-b`) in `parseRunFlags` because cobra's `MarkFlagsMutuallyExclusive` / `MarkFlagsOneRequired` only span flags. The flag-vs-flag mutex among `-f`/`-p`/`-b` stays cobra-side. The `<config>` positional rejects combination with each of `-f`/`-p`/`-b` with a clear message naming all four sources; the no-source case errors with the same enumeration.
- Wire `config.CompleteConfigNames` as `ValidArgsFunction` on the cobra command so shell completion attaches to the positional rather than the (now-gone) `--config` flag.
- Retire `KUKE_RUN_CONFIG` from `cmd/config/env.go` — no flag binding consumes it anymore.
- Rewrite the `Use:` line, `Long` help text, and the affected flag help strings (`--name`, `-g/--generate-name`, `--param`, `--param-file`) so the positional shape replaces the prior `-c` references; update the user-facing structural-slots error in `internal/cellblueprint/cellblueprint.go` to point at `kuke run <config>`.
- Tests: positional-only happy path covered by repurposed existing `-c` tests (now passing `"prod"` as positional); add `TestRun_PositionalConfig_MutexWithFlagSources` covering positional + `-b`/`-f`/`-p` rejections; add `TestRun_PositionalConfig_TooManyArgs` covering the `cobra.MaximumNArgs(1)` gate. The autocomplete-registration test now also asserts `config` flag is gone and `ValidArgsFunction` is wired.

Per the issue's out-of-scope note, `docs/cli-use-cases.md` and `docs/site/cli/kuke-run.md` are not touched in this PR — pm will land the docs follow-up via `/plan-release-doc` once this merges, so the verbatim Before/After can pin to merged help text. Issue #811 is mentioned for post-merge re-evaluation.

`kuke apply -c <config>` is intentionally unchanged (issue's "out of scope" call): the operator gain is small on `apply` and the divergent-spec error pointer in `run` still says ``kuke apply -c <config>``, which remains the correct invocation.

## Test plan
- [x] `make test` — full go test ./... + cmd/kukebuild tests; all packages pass.
- [x] `pre-commit run --files cmd/config/env.go cmd/kuke/run/run.go cmd/kuke/run/run_test.go internal/cellblueprint/cellblueprint.go` — go fmt, go-mod-tidy, golangci-lint, addlicense all pass.
- [x] Built `kuke` binary and exercised: `kuke run --help` shows the new `Use:` line and the rewritten flag help; `kuke run` (no args) errors with the new at-least-one-source message; `kuke run prod stray` errors via `cobra.MaximumNArgs(1)`; `kuke run prod -b web` errors with the positional+flag mutex message.
- [x] Literal-flag-string grep per CLAUDE.md §PR creation — no remaining `kuke run -c`/`--config` flag invocations in the tree (matches in `cmd/kuke/apply/...` and `sh -c`/`git -c`/etc. are unrelated and expected).
- [ ] `make dev-init` — not run; this PR touches only `kuke run`'s CLI parsing (no build path, no daemon, nothing under `/opt/kukeon`), so the bind-mount regression guard the smoke test catches cannot regress here.

## Acceptance criteria

- [x] `kuke run <name>` resolves `<name>` as a CellConfig and behaves identically to the prior `kuke run -c <name>` (idempotent attach by stable name).
- [x] `kuke run <name> -g` behaves identically to `kuke run -c <name> -g` (fresh `<config-name>-<6hex>`, lineage label preserved).
- [x] `-c/--config` flag removed from `cmd/kuke/run/run.go`; `KUKE_RUN_CONFIG` retired from `cmd/config/env.go`.
- [x] Mutual exclusion enforced: positional rejected when combined with `-b`/`-f`/`-p`; the error message names all four sources.
- [x] Validation: no positional and no `-b`/`-f`/`-p` errors with the same source-enumeration phrasing.
- [x] Shell completion: `CompleteConfigNames` attached via `ValidArgsFunction` (asserted by the autocomplete-registration test).
- [x] Tests in `cmd/kuke/run/run_test.go` cover: positional-only happy path; positional + `-g`; positional + `-b`/`-f`/`-p` rejection; no-positional-no-flag rejection.
- [x] The `Long` help text rewritten so the prior `-c` paragraph describes the positional shape instead.
- [x] The `Use:` line surfaces the positional alternative: `run [<config> | -f <file> | -p <profile> | -b <blueprint>]`.

Closes #813