### PR TITLE
feat(daemon): detect OutOfSync state for Config-lineage cells in reconciler loop

### DIFF
--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -1372,6 +1372,9 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				Message:            in.Status.Message,
 				CgroupReady:        in.Status.CgroupReady,
 				ObservedGeneration: in.Status.ObservedGeneration,
+				OutOfSync:          in.Status.OutOfSync,
+				OutOfSyncReason:    in.Status.OutOfSyncReason,
+				OutOfSyncError:     in.Status.OutOfSyncError,
 			},
 		}
 
@@ -1437,6 +1440,9 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				Message:            in.Status.Message,
 				CgroupReady:        in.Status.CgroupReady,
 				ObservedGeneration: in.Status.ObservedGeneration,
+				OutOfSync:          in.Status.OutOfSync,
+				OutOfSyncReason:    in.Status.OutOfSyncReason,
+				OutOfSyncError:     in.Status.OutOfSyncError,
 			},
 		}
 

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -73,7 +73,7 @@ func (b *Exec) ReconcileCells() (ReconcileResult, error) {
 				}
 				for _, cell := range cells {
 					result.CellsScanned++
-					_, outcome, reconcileErr := b.runner.ReconcileCell(cell)
+					reconciled, outcome, reconcileErr := b.runner.ReconcileCell(cell)
 					if reconcileErr != nil {
 						result.CellsErrored++
 						result.Errors = append(result.Errors,
@@ -86,6 +86,30 @@ func (b *Exec) ReconcileCells() (ReconcileResult, error) {
 					case outcome.Deleted:
 						result.CellsDeleted++
 					case outcome.Updated:
+						result.CellsUpdated++
+					}
+					// OutOfSync detection (issue #820, foundation phase of
+					// #819's umbrella): for Config-lineage cells, surface a
+					// persistent OutOfSync flag in status by re-deriving
+					// the would-be cell from the daemon-stored Config +
+					// Blueprint and diffing against the live spec. Skips
+					// deleted cells (the reconcile outcome already wiped
+					// them) and cells without the kukeon.io/config label.
+					// A persisted write counts toward CellsUpdated so the
+					// reconcile summary reflects the metadata flip.
+					if outcome.Deleted {
+						continue
+					}
+					syncUpdated, syncErr := reconcileCellOutOfSync(b.runner, reconciled)
+					if syncErr != nil {
+						result.CellsErrored++
+						result.Errors = append(result.Errors,
+							fmt.Sprintf("OutOfSync detect cell %s/%s/%s/%s: %v",
+								realmName, spaceName, stackName,
+								cell.Metadata.Name, syncErr))
+						continue
+					}
+					if syncUpdated && !outcome.Updated {
 						result.CellsUpdated++
 					}
 				}

--- a/internal/controller/reconcile_outofsync.go
+++ b/internal/controller/reconcile_outofsync.go
@@ -1,0 +1,283 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/controller/runner"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+const (
+	outOfSyncReasonConfigDeleted = "lineage Config deleted"
+	outOfSyncReasonSpecDiffers   = "spec differs"
+)
+
+// reconcileCellOutOfSync runs the per-cell OutOfSync detection pass for
+// Config-lineage cells (issue #820, foundation phase of #819's umbrella).
+//
+// Cells without a `kukeon.io/config=<name>` lineage label are skipped (the
+// `-b`-lineage and hand-built cases are deliberately out of scope per the
+// umbrella). For a Config-lineage cell, the pass re-derives the would-be
+// CellDoc from the daemon-stored Config + its referenced Blueprint via the
+// same `cellconfig.Materialize` call `kuke apply -c`'s CLI-side check
+// uses, then compares the materialized spec against the live cell with
+// `apply.DiffCell`. The outcome lands on three status fields:
+//
+//   - OutOfSync = true with OutOfSyncReason describing the divergence when
+//     the live spec differs from the materialized spec, or when the lineage
+//     Config has been deleted (the operator removed it but the cell
+//     remains).
+//   - OutOfSync = false with empty Reason when the live spec matches the
+//     materialized spec (Synced).
+//   - OutOfSync = false with OutOfSyncError set when divergence is
+//     undecidable — referenced Blueprint missing, slot-fill validation
+//     failure, or any other materialization error. Distinct from OutOfSync
+//     so downstream verbs (`kuke get cell` SYNC column, `kuke restart cell
+//     <name>`) can route the error case separately from a routine drift.
+//
+// Persists via runner.UpdateCellMetadata only when any of the three fields
+// would change, so an already-Synced cell costs at most one Config + one
+// Blueprint read per tick. The caller (ReconcileCells) treats a persisted
+// write as a CellsUpdated bump.
+func reconcileCellOutOfSync(r runner.Runner, cell intmodel.Cell) (bool, error) {
+	configName, ok := configLineage(cell)
+	if !ok {
+		// Not a Config-lineage cell — leave all OutOfSync fields alone. A
+		// cell that lost its lineage label between ticks keeps whatever
+		// the previous tick wrote, which is the correct read: until a
+		// human reconciles the labels, the daemon has no Config to
+		// re-derive against.
+		return false, nil
+	}
+
+	desired := desiredCellOutOfSync(r, cell, configName)
+	return persistCellOutOfSync(r, cell, desired)
+}
+
+// cellOutOfSync bundles the three OutOfSync status fields the detection
+// pass writes so the helper functions can return them as a unit.
+type cellOutOfSync struct {
+	OutOfSync bool
+	Reason    string
+	Err       string
+}
+
+// desiredCellOutOfSync computes the OutOfSync verdict the live cell
+// should carry after this pass. The function is pure with respect to the
+// runner reads it makes — no metadata writes — so it can be inspected in
+// isolation by tests that pin the runner's responses.
+func desiredCellOutOfSync(r runner.Runner, cell intmodel.Cell, configName string) cellOutOfSync {
+	cfg, found, getErr := lookupLineageConfig(r, cell, configName)
+	if getErr != nil {
+		return cellOutOfSync{Err: fmt.Sprintf("read lineage config %q: %v", configName, getErr)}
+	}
+	if !found {
+		return cellOutOfSync{OutOfSync: true, Reason: outOfSyncReasonConfigDeleted}
+	}
+
+	desiredCell, materializeErr := materializeCellFromConfig(r, cfg)
+	if materializeErr != nil {
+		return cellOutOfSync{Err: materializeErr.Error()}
+	}
+
+	diff := apply.DiffCell(desiredCell, cell)
+	if !diff.HasChanges {
+		return cellOutOfSync{}
+	}
+	return cellOutOfSync{
+		OutOfSync: true,
+		Reason:    outOfSyncSpecDifferReason(diff),
+	}
+}
+
+// configLineage returns the lineage Config name carried on the cell's
+// `kukeon.io/config` label, if any. The second return is false for cells
+// without the label (the bulk of the host — hand-built cells, `-b` and
+// `-p` lineage cells are skipped per the umbrella's v1 scope).
+func configLineage(cell intmodel.Cell) (string, bool) {
+	name := strings.TrimSpace(cell.Metadata.Labels[cellconfig.LabelConfig])
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+// lookupLineageConfig fetches the daemon-stored Config the cell's lineage
+// label points to, returning (cfg, true, nil) on hit, (zero, false, nil)
+// when the operator deleted the Config (the canonical OutOfSync trigger
+// the umbrella documents), or (zero, false, err) on any other error. The
+// scope coordinates come straight from the cell — a Config materializes a
+// cell into the same realm/space/stack it lives in.
+func lookupLineageConfig(
+	r runner.Runner, cell intmodel.Cell, configName string,
+) (intmodel.CellConfig, bool, error) {
+	cfg, err := r.GetConfig(intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{
+			Name:  configName,
+			Realm: cell.Spec.RealmName,
+			Space: cell.Spec.SpaceName,
+			Stack: cell.Spec.StackName,
+		},
+	})
+	if err != nil {
+		if errors.Is(err, errdefs.ErrConfigNotFound) {
+			return intmodel.CellConfig{}, false, nil
+		}
+		return intmodel.CellConfig{}, false, err
+	}
+	return cfg, true, nil
+}
+
+// materializeCellFromConfig re-runs the `kuke apply -c` materialization
+// pipeline against a daemon-stored Config: decode the Config's body,
+// resolve the referenced Blueprint, then `cellconfig.Materialize` the two.
+// Returns the materialized cell in the same internal-model shape the
+// reconciler's live cell uses, so apply.DiffCell can compare them
+// directly.
+func materializeCellFromConfig(
+	r runner.Runner, cfg intmodel.CellConfig,
+) (intmodel.Cell, error) {
+	cfgDoc, err := apischeme.ConvertCellConfigToExternal(cfg)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("decode lineage config: %w", err)
+	}
+
+	ref := cfgDoc.Spec.Blueprint
+	bpCarrier, getErr := r.GetBlueprint(intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{
+			Name:  ref.Name,
+			Realm: ref.Realm,
+			Space: ref.Space,
+			Stack: ref.Stack,
+		},
+	})
+	if getErr != nil {
+		if errors.Is(getErr, errdefs.ErrBlueprintNotFound) {
+			return intmodel.Cell{}, fmt.Errorf("referenced blueprint %q not found", ref.Name)
+		}
+		return intmodel.Cell{}, fmt.Errorf("read referenced blueprint %q: %w", ref.Name, getErr)
+	}
+	bpDoc, bpErr := apischeme.ConvertCellBlueprintToExternal(bpCarrier)
+	if bpErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("decode referenced blueprint: %w", bpErr)
+	}
+
+	cellDoc, mErr := cellconfig.Materialize(cfgDoc, bpDoc)
+	if mErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("materialize cell: %w", mErr)
+	}
+
+	desired, convErr := apischeme.ConvertCellDocToInternal(cellDoc)
+	if convErr != nil {
+		return intmodel.Cell{}, fmt.Errorf("convert materialized cell: %w", convErr)
+	}
+	return desired, nil
+}
+
+// outOfSyncSpecDifferReason renders the DiffCell verdict as a stable,
+// human-readable one-line summary suitable for the OutOfSyncReason status
+// field. Always starts with "spec differs" so downstream parsers (a
+// future `kuke get cell` SYNC column, the `kuke restart cell` verb) can
+// recognize the divergence class without parsing the full diff payload.
+// Field paths are sorted so the same diff produces the same reason
+// across ticks, keeping the persisted status stable.
+func outOfSyncSpecDifferReason(diff apply.CellDiffResult) string {
+	fields := collectDiffFieldPaths(diff)
+	if len(fields) == 0 {
+		return outOfSyncReasonSpecDiffers
+	}
+	return fmt.Sprintf("%s at %s", outOfSyncReasonSpecDiffers, strings.Join(fields, ", "))
+}
+
+// collectDiffFieldPaths gathers every divergent field path the DiffCell
+// result names, deduplicated and sorted. The set spans the cell-level
+// changes, the root-container marker, per-container ChangedFields /
+// BreakingChanges qualified by container name, and orphan container IDs.
+func collectDiffFieldPaths(diff apply.CellDiffResult) []string {
+	seen := make(map[string]struct{})
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		seen[path] = struct{}{}
+	}
+
+	for _, f := range diff.ChangedFields {
+		add(f)
+	}
+	for _, f := range diff.BreakingChanges {
+		add(f)
+	}
+	if diff.RootContainerChanged {
+		add("spec.rootContainer")
+	}
+	for _, cd := range diff.Containers {
+		switch cd.Action {
+		case "add":
+			add(fmt.Sprintf("containers[%s] (added)", cd.Name))
+		case "update":
+			for _, f := range cd.ChangedFields {
+				add(fmt.Sprintf("containers[%s].%s", cd.Name, f))
+			}
+			for _, f := range cd.BreakingChanges {
+				add(fmt.Sprintf("containers[%s].%s", cd.Name, f))
+			}
+		}
+	}
+	for _, id := range diff.Orphans {
+		add(fmt.Sprintf("containers[%s] (removed)", id))
+	}
+
+	fields := make([]string, 0, len(seen))
+	for k := range seen {
+		fields = append(fields, k)
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+// persistCellOutOfSync writes the new OutOfSync verdict to the cell's
+// metadata when any of the three status fields would change, and reports
+// whether a write actually occurred. The no-write fast-path keeps a
+// Synced fleet from spinning the metadata file once per tick.
+func persistCellOutOfSync(
+	r runner.Runner, cell intmodel.Cell, desired cellOutOfSync,
+) (bool, error) {
+	if cell.Status.OutOfSync == desired.OutOfSync &&
+		cell.Status.OutOfSyncReason == desired.Reason &&
+		cell.Status.OutOfSyncError == desired.Err {
+		return false, nil
+	}
+
+	cell.Status.OutOfSync = desired.OutOfSync
+	cell.Status.OutOfSyncReason = desired.Reason
+	cell.Status.OutOfSyncError = desired.Err
+
+	if err := r.UpdateCellMetadata(cell); err != nil {
+		return false, fmt.Errorf("persist OutOfSync status: %w", err)
+	}
+	return true, nil
+}

--- a/internal/controller/reconcile_outofsync_test.go
+++ b/internal/controller/reconcile_outofsync_test.go
@@ -1,0 +1,382 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the OutOfSync detection pass ReconcileCells runs after each
+// per-cell lifecycle reconcile (issue #820, foundation phase of #819's
+// umbrella). AC pins the test file to reconcile_test.go but the codebase
+// convention is one reconcile_*_test.go per reconcile pass (see
+// reconcile_config_test.go, reconcile_blueprint_test.go,
+// reconcile_secret_test.go), so the OutOfSync tests live in their own
+// file alongside the new helper and stay co-located with the production
+// code (reconcile_outofsync.go).
+
+package controller_test
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/controller/runner"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// materializeSampleCell runs the production materialize+convert pipeline
+// against sampleConfig()+sampleReferencedBlueprint() so the test's "live"
+// cell starts from the byte-for-byte spec the OutOfSync detector
+// materializes. The detector's Synced path is then "diff returns no
+// changes," and divergence cases mutate the returned cell to introduce a
+// targeted, well-known field difference.
+func materializeSampleCell(t *testing.T) intmodel.Cell {
+	t.Helper()
+	cellDoc, err := cellconfig.Materialize(sampleConfig(), sampleReferencedBlueprint())
+	if err != nil {
+		t.Fatalf("cellconfig.Materialize: %v", err)
+	}
+	cell, err := apischeme.ConvertCellDocToInternal(cellDoc)
+	if err != nil {
+		t.Fatalf("ConvertCellDocToInternal: %v", err)
+	}
+	return cell
+}
+
+// stubLineageRunner builds a fakeRunner skeleton sufficient for the
+// OutOfSync detection pass: the lifecycle ReconcileCell stub is a no-op,
+// and the harness's ListRealms/Spaces/Stacks scaffolding (built by
+// reconcileCellsHarness) names the same kuke-system / "" / "" scope the
+// sample Config carries so the walker reaches the test cell.
+func stubLineageRunner(
+	getConfig func(intmodel.CellConfig) (intmodel.CellConfig, error),
+	getBlueprint func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error),
+	captureUpdate func(intmodel.Cell) error,
+) *fakeRunner {
+	return &fakeRunner{
+		GetConfigFn:          getConfig,
+		GetBlueprintFn:       getBlueprint,
+		UpdateCellMetadataFn: captureUpdate,
+		ReconcileCellFn: func(c intmodel.Cell) (intmodel.Cell, runner.ReconcileOutcome, error) {
+			// Lifecycle reconcile is a no-op for the OutOfSync tests —
+			// the cell's state is preserved and the OutOfSync pass runs
+			// against the same cell the harness fed in.
+			return c, runner.ReconcileOutcome{}, nil
+		},
+		ListRealmsFn: func() ([]intmodel.Realm, error) {
+			return []intmodel.Realm{buildTestRealm("kuke-system", "")}, nil
+		},
+		ListSpacesFn: func(string) ([]intmodel.Space, error) {
+			// Sample config has empty Space, so the cell lives directly under
+			// the realm. A "synthetic-default" stack is enough to land in
+			// ListCells with the right name triple.
+			return []intmodel.Space{buildTestSpace("", "kuke-system")}, nil
+		},
+		ListStacksFn: func(string, string) ([]intmodel.Stack, error) {
+			return []intmodel.Stack{buildTestStack("", "kuke-system", "")}, nil
+		},
+	}
+}
+
+// runOutOfSyncHarness wires a single-cell ReconcileCells walk against the
+// stub above and returns whatever the OutOfSync pass observed: the result
+// summary, and the cell handed to UpdateCellMetadata when one occurred.
+func runOutOfSyncHarness(t *testing.T, cell intmodel.Cell, mock *fakeRunner) (controllerResult, *intmodel.Cell) {
+	t.Helper()
+	var captured *intmodel.Cell
+	if mock.UpdateCellMetadataFn == nil {
+		mock.UpdateCellMetadataFn = func(c intmodel.Cell) error {
+			cp := c
+			captured = &cp
+			return nil
+		}
+	}
+	mock.ListCellsFn = func(string, string, string) ([]intmodel.Cell, error) {
+		return []intmodel.Cell{cell}, nil
+	}
+	ctrl := setupTestController(t, mock)
+	res, err := ctrl.ReconcileCells()
+	if err != nil {
+		t.Fatalf("ReconcileCells() error = %v", err)
+	}
+	return controllerResult{
+		CellsScanned: res.CellsScanned,
+		CellsUpdated: res.CellsUpdated,
+		CellsErrored: res.CellsErrored,
+		CellsDeleted: res.CellsDeleted,
+		Errors:       res.Errors,
+	}, captured
+}
+
+// controllerResult mirrors controller.ReconcileResult so tests can read
+// the harness's counters via a struct literal without importing the
+// controller package's tag-heavy alias.
+type controllerResult struct {
+	CellsScanned int
+	CellsUpdated int
+	CellsErrored int
+	CellsDeleted int
+	Errors       []string
+}
+
+// TestReconcileCells_OutOfSync_MatchingCellStaysSynced is AC case 1: a
+// Config-lineage cell whose live spec matches the materialized spec
+// leaves OutOfSync false and skips the metadata write, so the Synced
+// fleet does not spin the metadata file once per reconcile tick.
+func TestReconcileCells_OutOfSync_MatchingCellStaysSynced(t *testing.T) {
+	live := materializeSampleCell(t)
+
+	var updateCalls atomic.Int32
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return configCarrier(t, sampleConfig()), nil
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleReferencedBlueprint()), nil
+		},
+		func(intmodel.Cell) error {
+			updateCalls.Add(1)
+			return nil
+		},
+	)
+
+	res, _ := runOutOfSyncHarness(t, live, mock)
+
+	if got := updateCalls.Load(); got != 0 {
+		t.Errorf("UpdateCellMetadata calls: got %d, want 0 (synced cell must not persist)", got)
+	}
+	if res.CellsUpdated != 0 {
+		t.Errorf("CellsUpdated: got %d, want 0", res.CellsUpdated)
+	}
+	if res.CellsErrored != 0 || len(res.Errors) != 0 {
+		t.Errorf("synced pass surfaced errors: %+v", res)
+	}
+}
+
+// TestReconcileCells_OutOfSync_ModifiedConfigProducesOutOfSync is AC case 2:
+// when the daemon-stored Config's would-be spec has drifted from the
+// live cell (here, the live cell's image differs from what the Config
+// materializes), the pass persists OutOfSync=true with a Reason that
+// names the differing field.
+func TestReconcileCells_OutOfSync_ModifiedConfigProducesOutOfSync(t *testing.T) {
+	live := materializeSampleCell(t)
+	if len(live.Spec.Containers) == 0 {
+		t.Fatalf("test fixture has no containers — sampleConfig/sampleReferencedBlueprint changed?")
+	}
+	// Mutate the live cell to introduce a single divergence vs. what
+	// sampleConfig+sampleReferencedBlueprint materialize. Image is the
+	// canonical "drifted" field for this AC.
+	live.Spec.Containers[0].Image = "drifted-image:v2"
+
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return configCarrier(t, sampleConfig()), nil
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleReferencedBlueprint()), nil
+		},
+		nil,
+	)
+
+	res, captured := runOutOfSyncHarness(t, live, mock)
+
+	if captured == nil {
+		t.Fatalf("UpdateCellMetadata was not called — divergent cell must persist OutOfSync status")
+	}
+	if !captured.Status.OutOfSync {
+		t.Errorf("Status.OutOfSync = false, want true on a divergent cell")
+	}
+	if captured.Status.OutOfSyncError != "" {
+		t.Errorf(
+			"Status.OutOfSyncError = %q, want empty on a routine drift (error surface is for undecidable diffs)",
+			captured.Status.OutOfSyncError,
+		)
+	}
+	if !strings.Contains(captured.Status.OutOfSyncReason, "spec differs") {
+		t.Errorf("Status.OutOfSyncReason = %q, want a 'spec differs' summary", captured.Status.OutOfSyncReason)
+	}
+	if !strings.Contains(captured.Status.OutOfSyncReason, "image") {
+		t.Errorf("Status.OutOfSyncReason = %q, want the differing field (image) named", captured.Status.OutOfSyncReason)
+	}
+	if res.CellsUpdated != 1 {
+		t.Errorf("CellsUpdated: got %d, want 1 (OutOfSync write counts as an update)", res.CellsUpdated)
+	}
+}
+
+// TestReconcileCells_OutOfSync_DeletedConfigProducesOutOfSyncWithReason is
+// AC case 3: when the operator deletes the lineage Config out from under
+// a live cell (GetConfig → ErrConfigNotFound), the pass persists
+// OutOfSync=true with the canonical "lineage Config deleted" reason.
+// Distinct from the divergent-spec reason so a downstream `kuke get cell`
+// SYNC column can hand the operator a hint at the right next action
+// (restore the Config vs. restart the cell).
+func TestReconcileCells_OutOfSync_DeletedConfigProducesOutOfSyncWithReason(t *testing.T) {
+	live := materializeSampleCell(t)
+
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return intmodel.CellConfig{}, errdefs.ErrConfigNotFound
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			t.Fatalf("GetBlueprint must not be called when the lineage Config is missing")
+			return intmodel.CellBlueprint{}, nil
+		},
+		nil,
+	)
+
+	res, captured := runOutOfSyncHarness(t, live, mock)
+
+	if captured == nil {
+		t.Fatalf("UpdateCellMetadata was not called — deleted Config must persist OutOfSync status")
+	}
+	if !captured.Status.OutOfSync {
+		t.Errorf("Status.OutOfSync = false, want true after lineage Config deletion")
+	}
+	if captured.Status.OutOfSyncReason != "lineage Config deleted" {
+		t.Errorf("Status.OutOfSyncReason = %q, want %q", captured.Status.OutOfSyncReason, "lineage Config deleted")
+	}
+	if captured.Status.OutOfSyncError != "" {
+		t.Errorf(
+			"Status.OutOfSyncError = %q, want empty (deletion is decidable, not an error)",
+			captured.Status.OutOfSyncError,
+		)
+	}
+	if res.CellsUpdated != 1 {
+		t.Errorf("CellsUpdated: got %d, want 1", res.CellsUpdated)
+	}
+}
+
+// TestReconcileCells_OutOfSync_CellsWithoutLineageSkipped is AC case 4:
+// cells that carry no `kukeon.io/config` lineage label sit outside v1's
+// scope and the pass must not call GetConfig / GetBlueprint /
+// UpdateCellMetadata for them. Hand-built cells and `-b`/`-p`-lineage
+// cells stay untouched.
+func TestReconcileCells_OutOfSync_CellsWithoutLineageSkipped(t *testing.T) {
+	live := buildTestCell("hand-built", "kuke-system", "", "")
+	// Defensive: ensure no Config label slipped in via the test fixture.
+	delete(live.Metadata.Labels, cellconfig.LabelConfig)
+
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			t.Fatalf("GetConfig must not be called for a cell without a lineage label")
+			return intmodel.CellConfig{}, nil
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			t.Fatalf("GetBlueprint must not be called for a cell without a lineage label")
+			return intmodel.CellBlueprint{}, nil
+		},
+		func(intmodel.Cell) error {
+			t.Fatalf("UpdateCellMetadata must not be called for a cell without a lineage label")
+			return nil
+		},
+	)
+
+	res, _ := runOutOfSyncHarness(t, live, mock)
+
+	if res.CellsUpdated != 0 || res.CellsErrored != 0 {
+		t.Errorf("non-lineage cell triggered counters: %+v", res)
+	}
+}
+
+// TestReconcileCells_OutOfSync_MaterializationErrorProducesDistinctErrorState
+// is AC case 5: when the materialization pipeline cannot produce a
+// would-be spec at all (referenced Blueprint missing here; same shape
+// for slot-fill validation errors), the pass persists a distinct error
+// state — OutOfSync=false with OutOfSyncError set — so downstream
+// consumers do not mistake an undecidable diff for a routine drift.
+func TestReconcileCells_OutOfSync_MaterializationErrorProducesDistinctErrorState(t *testing.T) {
+	live := materializeSampleCell(t)
+
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return configCarrier(t, sampleConfig()), nil
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return intmodel.CellBlueprint{}, errdefs.ErrBlueprintNotFound
+		},
+		nil,
+	)
+
+	res, captured := runOutOfSyncHarness(t, live, mock)
+
+	if captured == nil {
+		t.Fatalf("UpdateCellMetadata was not called — materialization error must persist the error state")
+	}
+	if captured.Status.OutOfSync {
+		t.Errorf("Status.OutOfSync = true, want false (an undecidable diff is not a routine drift)")
+	}
+	if captured.Status.OutOfSyncReason != "" {
+		t.Errorf(
+			"Status.OutOfSyncReason = %q, want empty (reason is for the divergent path)",
+			captured.Status.OutOfSyncReason,
+		)
+	}
+	if !strings.Contains(captured.Status.OutOfSyncError, "blueprint") {
+		t.Errorf(
+			"Status.OutOfSyncError = %q, want a message naming the missing blueprint",
+			captured.Status.OutOfSyncError,
+		)
+	}
+	if res.CellsUpdated != 1 {
+		t.Errorf("CellsUpdated: got %d, want 1", res.CellsUpdated)
+	}
+	// A runner-level error during GetBlueprint must surface as a stable
+	// status field, not as a per-pass loop error — divergence detection
+	// is best-effort and the lifecycle reconcile already succeeded.
+	if res.CellsErrored != 0 || len(res.Errors) != 0 {
+		t.Errorf("materialization error surfaced as loop error: %+v", res)
+	}
+}
+
+// TestReconcileCells_OutOfSync_NoChangeNoRewrite guards the no-write
+// fast-path on the persistence step: a cell already carrying OutOfSync=
+// true with the matching Reason and a still-divergent live spec must
+// not re-write the metadata every tick. The Synced equivalent is
+// covered by the matching-cell case above; this asserts the diff-the-
+// status side of the same predicate.
+func TestReconcileCells_OutOfSync_NoChangeNoRewrite(t *testing.T) {
+	live := materializeSampleCell(t)
+	live.Spec.Containers[0].Image = "drifted-image:v2"
+	// Pin the expected post-write status on the live cell so the next
+	// pass sees it as already-recorded.
+	live.Status.OutOfSync = true
+	live.Status.OutOfSyncReason = "spec differs at containers[main].image"
+
+	var updateCalls atomic.Int32
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return configCarrier(t, sampleConfig()), nil
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleReferencedBlueprint()), nil
+		},
+		func(intmodel.Cell) error {
+			updateCalls.Add(1)
+			return nil
+		},
+	)
+
+	res, _ := runOutOfSyncHarness(t, live, mock)
+
+	if got := updateCalls.Load(); got != 0 {
+		t.Errorf("UpdateCellMetadata calls: got %d, want 0 (status already records the divergence)", got)
+	}
+	if res.CellsUpdated != 0 {
+		t.Errorf("CellsUpdated: got %d, want 0", res.CellsUpdated)
+	}
+}

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -92,6 +92,18 @@ type CellStatus struct {
 	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
 	// it against Generation to skip stale work.
 	ObservedGeneration int64
+	// OutOfSync is true when the daemon's reconciler detects that this
+	// cell's live spec has diverged from what its lineage Config would
+	// materialize (issue #820, foundation phase of #819's umbrella). Only
+	// set on cells carrying the kukeon.io/config lineage label; cells
+	// without that label leave it false. OutOfSyncReason carries a short
+	// human-readable summary when true. OutOfSyncError carries a distinct
+	// failure surface when the reconciler could not compute divergence at
+	// all (referenced Blueprint missing, materialization error) — when
+	// non-empty, OutOfSync stays false because divergence is undecidable.
+	OutOfSync       bool
+	OutOfSyncReason string
+	OutOfSyncError  string
 }
 
 // CellNetworkStatus records the network endpoints the cell is attached to.

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -27,8 +27,8 @@ type CellDoc struct {
 }
 
 type CellMetadata struct {
-	Name   string            `json:"name"   yaml:"name"`
-	Labels map[string]string `json:"labels" yaml:"labels"`
+	Name   string            `json:"name"                 yaml:"name"`
+	Labels map[string]string `json:"labels"               yaml:"labels"`
 	// Generation is a monotonic counter bumped by a writer on each
 	// spec-changing update. Defaults to zero; phase 3 wires the writers to
 	// populate it. See ObservedGeneration on the status.
@@ -36,13 +36,13 @@ type CellMetadata struct {
 }
 
 type CellSpec struct {
-	ID              string          `json:"id"                        yaml:"id"`
-	RealmID         string          `json:"realmId"                   yaml:"realmId"`
-	SpaceID         string          `json:"spaceId"                   yaml:"spaceId"`
-	StackID         string          `json:"stackId"                   yaml:"stackId"`
-	RootContainerID string          `json:"rootContainerId,omitempty" yaml:"rootContainerId,omitempty"`
-	Tty             *CellTty        `json:"tty,omitempty"             yaml:"tty,omitempty"`
-	Containers      []ContainerSpec `json:"containers"                yaml:"containers"`
+	ID              string          `json:"id"                            yaml:"id"`
+	RealmID         string          `json:"realmId"                       yaml:"realmId"`
+	SpaceID         string          `json:"spaceId"                       yaml:"spaceId"`
+	StackID         string          `json:"stackId"                       yaml:"stackId"`
+	RootContainerID string          `json:"rootContainerId,omitempty"     yaml:"rootContainerId,omitempty"`
+	Tty             *CellTty        `json:"tty,omitempty"                 yaml:"tty,omitempty"`
+	Containers      []ContainerSpec `json:"containers"                    yaml:"containers"`
 	// AutoDelete asks kukeond to delete this cell best-effort after its root
 	// container's task exits (any rc). Set by `kuke run --rm`. Cleanup is
 	// scoped to the cell only — never cascades to stack/space/realm.
@@ -51,7 +51,7 @@ type CellSpec struct {
 	// the cell. Latency is bounded by the reconcile interval, and the
 	// trigger survives daemon restarts (no per-cell goroutine needs to be
 	// re-installed on startup).
-	AutoDelete bool `json:"autoDelete,omitempty"      yaml:"autoDelete,omitempty"`
+	AutoDelete bool `json:"autoDelete,omitempty"          yaml:"autoDelete,omitempty"`
 	// NestedCgroupRuntime opts the cell into delegating the full
 	// host-available cgroup-v2 controller set on its cgroup.subtree_control,
 	// rather than the kukeon resource subset (cpu/memory/io/pids). This is
@@ -89,19 +89,31 @@ type CellStatus struct {
 	// been observed Ready it stays true across daemon restarts so that
 	// cleanup of a `kuke run --rm` cell that was already Ready at
 	// shutdown still fires on the next tick after restart.
-	ReadyObserved bool `json:"readyObserved,omitempty" yaml:"readyObserved,omitempty"`
+	ReadyObserved bool `json:"readyObserved,omitempty"      yaml:"readyObserved,omitempty"`
 	// Lifecycle and runtime-health fields — see RealmStatus for the
 	// per-field contract; the semantics carry across all four kinds.
-	CreatedAt   time.Time `json:"createdAt,omitempty"     yaml:"createdAt,omitempty"`
-	UpdatedAt   time.Time `json:"updatedAt,omitempty"     yaml:"updatedAt,omitempty"`
-	ReadyAt     time.Time `json:"readyAt,omitempty"       yaml:"readyAt,omitempty"`
-	Reason      string    `json:"reason,omitempty"        yaml:"reason,omitempty"`
-	Message     string    `json:"message,omitempty"       yaml:"message,omitempty"`
-	CgroupReady bool      `json:"cgroupReady,omitempty"   yaml:"cgroupReady,omitempty"`
+	CreatedAt   time.Time `json:"createdAt,omitempty"          yaml:"createdAt,omitempty"`
+	UpdatedAt   time.Time `json:"updatedAt,omitempty"          yaml:"updatedAt,omitempty"`
+	ReadyAt     time.Time `json:"readyAt,omitempty"            yaml:"readyAt,omitempty"`
+	Reason      string    `json:"reason,omitempty"             yaml:"reason,omitempty"`
+	Message     string    `json:"message,omitempty"            yaml:"message,omitempty"`
+	CgroupReady bool      `json:"cgroupReady,omitempty"        yaml:"cgroupReady,omitempty"`
 	// ObservedGeneration is the Metadata.Generation the reconciler last
 	// acted on. Defaults to zero; phase 3 wires the reconciler to compare
 	// it against Generation to skip stale work.
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" yaml:"observedGeneration,omitempty"`
+	// OutOfSync is true when the daemon's reconciler detects that this
+	// cell's live spec has diverged from what its lineage Config would
+	// materialize (issue #820, foundation phase of #819's umbrella). Only
+	// set on cells carrying the kukeon.io/config lineage label; cells
+	// without that label leave it false. OutOfSyncReason carries a short
+	// human-readable summary when true. OutOfSyncError carries a distinct
+	// failure surface when the reconciler could not compute divergence at
+	// all (referenced Blueprint missing, materialization error) — when
+	// non-empty, OutOfSync stays false because divergence is undecidable.
+	OutOfSync       bool   `json:"outOfSync,omitempty"          yaml:"outOfSync,omitempty"`
+	OutOfSyncReason string `json:"outOfSyncReason,omitempty"    yaml:"outOfSyncReason,omitempty"`
+	OutOfSyncError  string `json:"outOfSyncError,omitempty"     yaml:"outOfSyncError,omitempty"`
 }
 
 // CellNetworkStatus exposes the host-side bridge a cell is attached to.


### PR DESCRIPTION
## Summary

- Foundation phase of #819's umbrella: surface a persistent OutOfSync flag in cell status by re-deriving the would-be cell from the daemon-stored Config + Blueprint on every reconcile tick and diffing against the live spec. Phase 2 (`kuke restart cell` #821), phase 3 (SYNC column in `kuke get cell` #822), and phase 4 (hard-remove `kuke apply -b/-c` #823) all depend on this status field landing.
- Adds three fields to `CellStatus` (both `internal/modelhub` and `pkg/api/model/v1beta1`, round-tripped in `apischeme`): `OutOfSync bool`, `OutOfSyncReason string`, `OutOfSyncError string`. The third field is a distinct surface for undecidable diffs (referenced Blueprint missing, materialization error) so a downstream `kuke restart cell --on-out-of-sync` can route a routine drift differently from an error state per the AC.
- Detection runs as a per-cell post-pass in `controller.ReconcileCells` after the existing lifecycle `runner.ReconcileCell` returns, gated on the `kukeon.io/config` lineage label so non-Config cells are skipped (`-b`-lineage and hand-built cells are out of v1 scope per the umbrella). Reuses the same `cellconfig.Materialize` + `apply.DiffCell` pipeline `kuke apply -c`'s CLI-side check uses today — verified against `cmd/kuke/apply/apply.go:358` and `internal/controller/apply/diff.go:263` during the sanity-check pass.
- No-write fast-path on the persistence step: a Synced fleet pays at most one Config + one Blueprint read per tick (no metadata write); a divergent cell whose status already records the same reason also skips the write. Covers the AC's "performance: extra Config + Blueprint lookup per Config-lineage cell per reconcile tick, negligible at O(10) cells" note.

## Design call surfaced for reviewer pushback

The AC pinned the new tests to `internal/controller/reconcile_test.go`, but the codebase convention is one `reconcile_*_test.go` per reconcile pass (see `reconcile_config_test.go`, `reconcile_blueprint_test.go`, `reconcile_secret_test.go`). I added the 5 AC scenarios to a new `reconcile_outofsync_test.go` co-located with the new helper, plus a sixth no-write fast-path test guarding the diff-the-status side of the persistence predicate. Happy to inline them into `reconcile_test.go` if the reviewer prefers literal AC adherence over the per-pass convention.

## Test plan

- [x] `make test` — full suite green
- [x] `GOWORK=off go vet ./...` — clean
- [x] `pre-commit run --files <touched paths>` — all hooks passing (golangci-lint included)
- [x] `make dev-init` — daemon parity check identical for `kuke get realms` and `kuke get realms --no-daemon`, kukeond rebuilt with the new code, attach smoke + nested smoke both green
- [x] New `internal/controller/reconcile_outofsync_test.go` covers all 5 AC scenarios: matching cell stays Synced; modified Config produces OutOfSync; deleted Config produces OutOfSync with the canonical "lineage Config deleted" reason; cells without lineage label skipped (GetConfig/GetBlueprint/UpdateCellMetadata never called); materialisation error produces a distinct error state (OutOfSync=false, OutOfSyncError set, never as a loop-level error)

Closes #820