### PR TITLE
docs(cellconfig): refresh StableName comment to reflect #753 refuse-on-divergence

### DIFF
--- a/internal/cellconfig/cellconfig.go
+++ b/internal/cellconfig/cellconfig.go
@@ -45,8 +45,9 @@ const LabelConfig = "kukeon.io/config"
 // Decision (issue #624 AC): the derivation is the config name *verbatim*, not
 // `<name>-<hash-of-values>`. The CellConfig contract is "one Config → at most
 // one live cell within scope" with a stable identity that survives edits to the
-// config's values; #625's divergent-spec warning explicitly attaches to the
-// existing live cell when the Config diverged since materialization. A
+// config's values; #753's refuse-on-divergence behavior relies on the stable
+// name so `-c` finds the same live cell across invocations whether it attaches
+// (clean spec match) or refuses with a `kuke apply -c <config>` pointer. A
 // value-hashed suffix would change the derived name on every value edit,
 // spawning a fresh cell and orphaning the old one — defeating the idempotent
 // identity that distinguishes a Config (`run -c`) from a Blueprint's


### PR DESCRIPTION
## Summary

- Rewrites the `StableName` godoc (`internal/cellconfig/cellconfig.go:48`) so the value-independence rationale references #753's refuse-on-divergence semantics instead of #625's removed warn-and-attach branch. PR #802 (closing #753) made `kuke run -c` refuse on divergent live spec and point at `kuke apply -c`; the design rationale for a value-independent stable name still holds (one Config → one live cell across value edits), but the cited behavior in the comment no longer exists.
- Pure godoc/comment change — no behavioral surface, no test surface, no API surface. Trivial-edit shortcut applies.

## Test plan

- [x] `make test` — full suite passes
- [x] `GOWORK=off go build ./...` — clean compile
- [x] `GOWORK=off go vet ./internal/cellconfig/...` — clean
- [x] `pre-commit run --files internal/cellconfig/cellconfig.go` — all hooks pass (go fmt, go-mod-tidy, golangci-lint, addlicense)

Closes #807