### PR TITLE
refactor(naming): extract shared <prefix>-<6hex> random-suffix helper

### DIFF
--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -25,13 +25,12 @@
 package cellblueprint
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/cellprofile"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/util/naming"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"gopkg.in/yaml.v3"
 )
@@ -41,10 +40,6 @@ import (
 // every cell produced by `kuke run -b` so operators can list all instances
 // with `kuke get cells -l kukeon.io/blueprint=<name>`.
 const LabelBlueprint = "kukeon.io/blueprint"
-
-// nameSuffixBytes is the entropy width for the `<prefix>-<6hex>` suffix —
-// 3 bytes → 6 lowercase hex chars, matching cellprofile.
-const nameSuffixBytes = 3
 
 // Resolve substitutes `${KEY}` scalar parameters in the blueprint body against
 // the resolution order cliParams[k] > parameters[k].default > lookupEnv(k),
@@ -268,19 +263,11 @@ func resolveCellName(doc v1beta1.CellBlueprintDoc, nameOverride string) (string,
 	if prefix == "" {
 		prefix = doc.Metadata.Name
 	}
-	suffix, err := randomHexSuffix()
+	suffix, err := naming.RandomHexSuffix(naming.DefaultCellNameSuffixBytes)
 	if err != nil {
 		return "", fmt.Errorf("generate name suffix for blueprint %q: %w", doc.Metadata.Name, err)
 	}
 	return prefix + "-" + suffix, nil
-}
-
-func randomHexSuffix() (string, error) {
-	b := make([]byte, nameSuffixBytes)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b), nil
 }
 
 func cloneCellTty(in *v1beta1.CellTty) *v1beta1.CellTty {

--- a/internal/cellconfig/materialize.go
+++ b/internal/cellconfig/materialize.go
@@ -17,21 +17,14 @@
 package cellconfig
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/cellblueprint"
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/util/naming"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
-
-// nameSuffixBytes is the entropy width for the `<config-name>-<6hex>` suffix
-// used by `kuke run -c --generate-name` (#754) — 3 bytes → 6 lowercase hex
-// chars, matching cellblueprint's `<prefix>-<6hex>` shape so the generated
-// `-c` cells are visually indistinguishable from `-b`/`-p` generated cells.
-const nameSuffixBytes = 3
 
 // Materialize converts a CellConfig + its referenced CellBlueprint into a
 // runtime CellDoc (issue #625). It is the config analog of
@@ -282,9 +275,9 @@ func cloneCellTty(in *v1beta1.CellTty) *v1beta1.CellTty {
 // visually indistinguishable from generated-cell-per-invocation spawns of the
 // other run verbs while preserving the kukeon.io/config back-reference label.
 func GenerateName(configName string) (string, error) {
-	b := make([]byte, nameSuffixBytes)
-	if _, err := rand.Read(b); err != nil {
+	suffix, err := naming.RandomHexSuffix(naming.DefaultCellNameSuffixBytes)
+	if err != nil {
 		return "", fmt.Errorf("config %q: generate cell name suffix: %w", configName, err)
 	}
-	return strings.TrimSpace(configName) + "-" + hex.EncodeToString(b), nil
+	return strings.TrimSpace(configName) + "-" + suffix, nil
 }

--- a/internal/cellprofile/cellprofile.go
+++ b/internal/cellprofile/cellprofile.go
@@ -20,8 +20,6 @@
 package cellprofile
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/util/naming"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"gopkg.in/yaml.v3"
 )
@@ -37,12 +36,6 @@ import (
 // materialized from. Set on every cell produced by Materialize so operators
 // can list all instances with `kuke get cells -l kukeon.io/profile=<name>`.
 const LabelProfile = "kukeon.io/profile"
-
-// nameSuffixBytes is the entropy width for the suffix appended to every
-// generated cell name. 3 bytes → 6 lowercase hex chars; matches K8s
-// `generateName`'s suffix shape closely enough that the names read familiar
-// at a glance.
-const nameSuffixBytes = 3
 
 // EnvProfilesDir is the env var that overrides the default user profiles
 // directory. Picked up by ResolveDir; takes precedence over $HOME/.kuke/profiles.d.
@@ -268,19 +261,11 @@ func resolveCellName(profile *v1beta1.CellProfileDoc, nameOverride string) (stri
 	if prefix == "" {
 		prefix = profile.Metadata.Name
 	}
-	suffix, err := randomHexSuffix()
+	suffix, err := naming.RandomHexSuffix(naming.DefaultCellNameSuffixBytes)
 	if err != nil {
 		return "", fmt.Errorf("generate name suffix for profile %q: %w", profile.Metadata.Name, err)
 	}
 	return prefix + "-" + suffix, nil
-}
-
-func randomHexSuffix() (string, error) {
-	b := make([]byte, nameSuffixBytes)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(b), nil
 }
 
 func mergeLabels(in map[string]string, k, v string) map[string]string {

--- a/internal/util/naming/randomsuffix.go
+++ b/internal/util/naming/randomsuffix.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package naming
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// DefaultCellNameSuffixBytes is the canonical entropy width for the
+// `<prefix>-<6hex>` suffix appended to generated cell names by `kuke run -b`,
+// `-p`, and `-c -g`. 3 bytes → 6 lowercase hex chars; matches K8s
+// `generateName`'s suffix shape closely enough that the names read familiar
+// at a glance.
+const DefaultCellNameSuffixBytes = 3
+
+// RandomHexSuffix returns n cryptographically-random bytes hex-encoded as a
+// lowercase string of length 2n, suitable as a name suffix. Callers wrap any
+// error with their own context (which document the suffix is for).
+func RandomHexSuffix(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/util/naming/randomsuffix_test.go
+++ b/internal/util/naming/randomsuffix_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package naming_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/util/naming"
+)
+
+func TestRandomHexSuffixLengthAndAlphabet(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+	}{
+		{name: "default cell-name width (3 bytes)", n: naming.DefaultCellNameSuffixBytes},
+		{name: "one byte", n: 1},
+		{name: "eight bytes", n: 8},
+		{name: "zero bytes", n: 0},
+	}
+
+	re := regexp.MustCompile(`^[0-9a-f]*$`)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := naming.RandomHexSuffix(tt.n)
+			if err != nil {
+				t.Fatalf("RandomHexSuffix(%d) = _, %v, want nil err", tt.n, err)
+			}
+			if want := 2 * tt.n; len(got) != want {
+				t.Errorf("RandomHexSuffix(%d) length = %d, want %d", tt.n, len(got), want)
+			}
+			if !re.MatchString(got) {
+				t.Errorf("RandomHexSuffix(%d) = %q, want lowercase hex only", tt.n, got)
+			}
+		})
+	}
+}
+
+func TestRandomHexSuffixUnique(t *testing.T) {
+	const samples = 256
+	seen := make(map[string]struct{}, samples)
+	for i := range samples {
+		s, err := naming.RandomHexSuffix(naming.DefaultCellNameSuffixBytes)
+		if err != nil {
+			t.Fatalf("RandomHexSuffix: %v", err)
+		}
+		if _, dup := seen[s]; dup {
+			t.Fatalf("collision on iteration %d (%q); RNG should not repeat at this sample size", i, s)
+		}
+		seen[s] = struct{}{}
+	}
+}
+
+func TestDefaultCellNameSuffixBytes(t *testing.T) {
+	if naming.DefaultCellNameSuffixBytes != 3 {
+		t.Errorf(
+			"DefaultCellNameSuffixBytes = %d, want 3 (canonical width shared by -b/-p/-c -g)",
+			naming.DefaultCellNameSuffixBytes,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- Three packages — `internal/cellblueprint`, `internal/cellprofile`, `internal/cellconfig` — each carried an independent copy of the `3-byte / crypto/rand / hex.EncodeToString` machinery for the `<prefix>-<6hex>` cell-name suffix used by `kuke run -b`, `-p`, and `-c -g`. Three places to change the suffix width, the encoding, or the RNG source.
- Adds `internal/util/naming.RandomHexSuffix(n int) (string, error)` and `naming.DefaultCellNameSuffixBytes = 3`; rewires the three call sites to use it. The canonical width and the per-site error-wrapping context are unchanged — each caller still wraps with its own document-flavored message ("blueprint %q", "profile %q", "config %q").
- The private `randomHexSuffix` helpers in cellblueprint/cellprofile were only used in a single call site each, so they're inlined to the call rather than kept as thin re-export wrappers — fewer hops to read.

## Test plan

- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./...`
- [x] `GOWORK=off go test ./internal/util/naming/ ./internal/cellblueprint/ ./internal/cellprofile/ ./internal/cellconfig/` (new `randomsuffix_test.go`: length+alphabet table, 256-sample uniqueness, canonical-width pin)
- [x] `make test`
- [x] `pre-commit run --files <staged>` (golangci-lint auto-applied a `range samples` rewrite + one Errorf line wrap in the new test; both re-staged)

Closes #808