### PR TITLE
feat(cli): add kuke restart cell with implicit reconcile on OutOfSync (step 2)

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -488,6 +488,14 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_LOG_FOLLOW = DefineKV("KUKE_LOG_FOLLOW", "kuke/log/follow", "false")
 
+	// Restart command variables
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RESTART_CELL_REALM = DefineKV("KUKE_RESTART_CELL_REALM", "kuke/restart/cell/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RESTART_CELL_SPACE = DefineKV("KUKE_RESTART_CELL_SPACE", "kuke/restart/cell/space", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_RESTART_CELL_STACK = DefineKV("KUKE_RESTART_CELL_STACK", "kuke/restart/cell/stack", "default")
+
 	// Stop command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_STOP_CELL_REALM = DefineKV("KUKE_STOP_CELL_REALM", "kuke/stop/cell/realm", "default")

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -39,6 +39,7 @@ import (
 	logcmd "github.com/eminwux/kukeon/cmd/kuke/log"
 	purgecmd "github.com/eminwux/kukeon/cmd/kuke/purge"
 	refreshcmd "github.com/eminwux/kukeon/cmd/kuke/refresh"
+	restartcmd "github.com/eminwux/kukeon/cmd/kuke/restart"
 	runcmd "github.com/eminwux/kukeon/cmd/kuke/run"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/start"
 	statuscmd "github.com/eminwux/kukeon/cmd/kuke/status"
@@ -156,6 +157,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(killcmd.NewKillCmd())
 	rootCmd.AddCommand(purgecmd.NewPurgeCmd())
 	rootCmd.AddCommand(refreshcmd.NewRefreshCmd())
+	rootCmd.AddCommand(restartcmd.NewRestartCmd())
 	rootCmd.AddCommand(runcmd.NewRunCmd())
 	rootCmd.AddCommand(attachcmd.NewAttachCmd())
 	rootCmd.AddCommand(logcmd.NewLogCmd())

--- a/cmd/kuke/kuke_test.go
+++ b/cmd/kuke/kuke_test.go
@@ -60,7 +60,7 @@ func TestNewKukeCmd(t *testing.T) {
 		t.Errorf("Short mismatch: got %q, want %q", cmd.Short, "Kukeon is a tool for managing Kukeon entities")
 	}
 
-	expectedSubcommands := []string{"init", "create", "get", "delete", "start", "stop", "kill", "purge", "version"}
+	expectedSubcommands := []string{"init", "create", "get", "delete", "start", "stop", "restart", "kill", "purge", "version"}
 	for _, subcmdName := range expectedSubcommands {
 		subcmd := cmd.Commands()
 		found := false
@@ -165,7 +165,7 @@ func TestSetupKukeCmd(t *testing.T) {
 		t.Fatalf("setupKukeCmd() error = %v, want nil", err)
 	}
 
-	expectedSubcommands := []string{"init", "create", "get", "delete", "start", "stop", "kill", "purge", "version"}
+	expectedSubcommands := []string{"init", "create", "get", "delete", "start", "stop", "restart", "kill", "purge", "version"}
 	commands := rootCmd.Commands()
 	commandMap := make(map[string]bool)
 	for _, cmd := range commands {

--- a/cmd/kuke/restart/cell/cell.go
+++ b/cmd/kuke/restart/cell/cell.go
@@ -42,11 +42,17 @@ type MockControllerKey struct{}
 // error/partial-state cell is refused with a `kuke delete cell` pointer.
 //
 // The reconcile branch composes at CLI level over GetConfig + GetBlueprint +
-// ApplyDocuments (which the daemon already wires to stop+update+start on a
-// divergent live cell) rather than introducing a new daemon-side RPC — keeps
-// this change scoped to one CLI verb and avoids a wire-format addition. The
-// AC's user-facing contract holds either way (per the issue's open-question
-// note).
+// ApplyDocuments rather than introducing a new daemon-side RPC — keeps this
+// change scoped to one CLI verb and avoids a wire-format addition. The daemon's
+// ApplyDocuments only bounces containers when image/command/args change (see
+// internal/controller/runner/update_cell.go:containerSpecChanged) — pure
+// env-var or metadata-only divergence is patched in place. To preserve the
+// "restart" verb's contract ("all running containers bounce"), the CLI follows
+// the ApplyDocuments call with an explicit StopCell + StartCell whenever the
+// reconcile did not itself bounce everything (root-container recreate or
+// from-Stopped rematerialize are the only paths that already bounce all
+// containers — see reconcileBouncedAll). The AC's user-facing contract holds
+// either way (per the issue's open-question note).
 func NewCellCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cell [name]",
@@ -194,9 +200,70 @@ func restartReady(
 	if applyErr != nil {
 		return applyErr
 	}
+	if failErr := reportApplyFailures(result); failErr != nil {
+		return failErr
+	}
+	// Honor the restart contract: the daemon's reconcile only bounces
+	// containers when image/command/args change (update_cell.go
+	// containerSpecChanged), so pure env-var or metadata-only divergence
+	// leaves running containers untouched. Add an explicit StopCell +
+	// StartCell unless the reconcile already bounced every container (full
+	// root-container recreate or from-Stopped rematerialize), so the user's
+	// `kuke restart` invariant — running containers always bounce — holds
+	// across every divergence class. The double-bounce in the rare
+	// reconcile-already-bounced-everything case is acceptable: bouncing twice
+	// is still a restart; under-bouncing silently breaks the contract.
+	if !reconcileBouncedAll(result) {
+		if _, stopErr := client.StopCell(cmd.Context(), doc); stopErr != nil {
+			return stopErr
+		}
+		if _, startErr := client.StartCell(cmd.Context(), doc); startErr != nil {
+			return startErr
+		}
+	}
 	cmd.Printf("Restarted cell %q from stack %q (reconciled from config %q)\n",
 		doc.Metadata.Name, doc.Spec.StackID, configName)
-	return reportApplyFailures(result)
+	return nil
+}
+
+// reconcileBouncedAll reports whether the daemon-side ApplyDocuments already
+// bounced every running container in the cell. The signals are intentionally
+// narrow: only full-cell paths qualify. A non-root container's image bump in
+// internal/controller/runner/update_cell.go does stop+delete+create+start on
+// that one container, but leaves the root and other containers running — that
+// is NOT "bounced all". The conservative default (anything not on this list)
+// triggers the follow-up StopCell + StartCell in restartReady so the restart
+// contract is preserved.
+func reconcileBouncedAll(result kukeonv1.ApplyDocumentsResult) bool {
+	for _, r := range result.Resources {
+		if r.Kind != string(v1beta1.KindCell) {
+			continue
+		}
+		// Action "created" cannot fire in the restart path (the cell already
+		// exists or we would have refused at the cell-not-found gate) but is
+		// listed for defensive parity — a fresh create starts every container.
+		if r.Action == "created" {
+			return true
+		}
+		for _, change := range r.Changes {
+			// "root container recreated" comes from reconcile.go's
+			// RecreateCell branch (diff.RootContainerChanged). RecreateCell
+			// tears down and rebuilds the entire cell, so every container is
+			// freshly started.
+			//
+			// "runtime stopped: containers re-materialized" comes from
+			// reconcile.go's rematerializeChanges, fired when the apply runs
+			// against a Stopped cell with no spec diff — StartCell brings
+			// every container up. This branch cannot fire in the restart
+			// path either (we route Stopped through restartStopped), but
+			// is listed for the same defensive parity.
+			if change == "root container recreated" ||
+				change == "runtime stopped: containers re-materialized" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // restartInPlace bounces the cell with the same stored spec: stop then start.

--- a/cmd/kuke/restart/cell/cell.go
+++ b/cmd/kuke/restart/cell/cell.go
@@ -1,0 +1,323 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cell
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewCellCmd builds the `kuke restart cell <name>` leaf. The verb is dual mode:
+// a Ready Synced cell is stop+start with the same spec; a Ready OutOfSync cell
+// is stop + spec re-materialised from its lineage Config + start (implicit
+// reconcile); a Stopped cell is equivalent to `kuke start cell <name>`; an
+// error/partial-state cell is refused with a `kuke delete cell` pointer.
+//
+// The reconcile branch composes at CLI level over GetConfig + GetBlueprint +
+// ApplyDocuments (which the daemon already wires to stop+update+start on a
+// divergent live cell) rather than introducing a new daemon-side RPC — keeps
+// this change scoped to one CLI verb and avoids a wire-format addition. The
+// AC's user-facing contract holds either way (per the issue's open-question
+// note).
+func NewCellCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "cell [name]",
+		Aliases: []string{"ce"},
+		Short:   "Restart a cell (bounces the process; on OutOfSync also reconciles from Config)",
+		Long: "Restart a cell. By default bounces the cell's containers " +
+			"(stop + start with the same spec). When the cell carries a " +
+			"`kukeon.io/config=<name>` lineage label and the daemon has " +
+			"marked it OutOfSync, the start step uses the freshly " +
+			"materialised spec from the Config so the restart is also a " +
+			"reconcile. Severs any active attach session as a side effect " +
+			"of the stop step.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runRestartCell,
+	}
+
+	cmd.Flags().String("realm", "", "Realm that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_RESTART_CELL_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+	cmd.Flags().String("space", "", "Space that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_RESTART_CELL_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+	cmd.Flags().String("stack", "", "Stack that owns the cell")
+	_ = viper.BindPFlag(config.KUKE_RESTART_CELL_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+
+	cmd.ValidArgsFunction = config.CompleteCellNames
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+
+	return cmd
+}
+
+func runRestartCell(cmd *cobra.Command, args []string) error {
+	name := strings.TrimSpace(args[0])
+	realm := strings.TrimSpace(viper.GetString(config.KUKE_RESTART_CELL_REALM.ViperKey))
+	space := strings.TrimSpace(viper.GetString(config.KUKE_RESTART_CELL_SPACE.ViperKey))
+	stack := strings.TrimSpace(viper.GetString(config.KUKE_RESTART_CELL_STACK.ViperKey))
+
+	if realm == "" {
+		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+	}
+	if space == "" {
+		return fmt.Errorf("%w (--space)", errdefs.ErrSpaceNameRequired)
+	}
+	if stack == "" {
+		return fmt.Errorf("%w (--stack)", errdefs.ErrStackNameRequired)
+	}
+
+	doc := v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: name, Labels: map[string]string{}},
+		Spec: v1beta1.CellSpec{
+			ID:      name,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+		},
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	pre, err := client.GetCell(cmd.Context(), doc)
+	if err != nil {
+		return err
+	}
+	if !pre.MetadataExists {
+		return fmt.Errorf("%w (cell %q in realm=%q space=%q stack=%q)",
+			errdefs.ErrCellNotFound, name, realm, space, stack)
+	}
+
+	switch pre.Cell.Status.State {
+	case v1beta1.CellStateReady:
+		return restartReady(cmd, client, doc, pre)
+	case v1beta1.CellStateStopped:
+		return restartStopped(cmd, client, doc, pre)
+	case v1beta1.CellStatePending, v1beta1.CellStateFailed, v1beta1.CellStateUnknown:
+		// Same delete-then-rerun pointer as `kuke run` on a degraded cell
+		// (cmd/kuke/run/run.go:505-516). Restart does not reconcile a
+		// degraded cell in place; the operator deletes and re-runs.
+		return fmt.Errorf(
+			"cell %q exists in %s state; delete it with `kuke delete cell %s` before restarting",
+			name, pre.Cell.Status.State.String(), name,
+		)
+	}
+	return fmt.Errorf("cell %q exists in unrecognized state %d", name, pre.Cell.Status.State)
+}
+
+// restartReady handles the Ready cell path: vanilla stop+start for Synced
+// cells, or an apply -c-style reconcile (stop + re-materialise + start)
+// driven by the daemon for OutOfSync cells. OutOfSyncError (divergence
+// undecidable — referenced Blueprint missing) and the "lineage Config
+// deleted" reason cannot drive a reconcile, so they fall through to vanilla
+// restart with a one-line stderr notice. Active attach sessions are severed
+// by the daemon's stop step in both branches.
+func restartReady(
+	cmd *cobra.Command, client kukeonv1.Client,
+	doc v1beta1.CellDoc, pre kukeonv1.GetCellResult,
+) error {
+	if pre.Cell.Status.OutOfSyncError != "" {
+		cmd.PrintErrf(
+			"notice: cell %q OutOfSync detection failed (%s); bouncing without reconcile\n",
+			doc.Metadata.Name, pre.Cell.Status.OutOfSyncError,
+		)
+		return restartInPlace(cmd, client, doc)
+	}
+	if !pre.Cell.Status.OutOfSync {
+		return restartInPlace(cmd, client, doc)
+	}
+
+	configName := strings.TrimSpace(pre.Cell.Metadata.Labels[cellconfig.LabelConfig])
+	if configName == "" {
+		// OutOfSync was set on a cell without a Config lineage label —
+		// nothing to reconcile against. Fall through to vanilla restart.
+		cmd.PrintErrf(
+			"notice: cell %q is OutOfSync but carries no %s label; bouncing without reconcile\n",
+			doc.Metadata.Name, cellconfig.LabelConfig,
+		)
+		return restartInPlace(cmd, client, doc)
+	}
+
+	cellDoc, err := materialiseFromConfig(cmd.Context(), client, doc, configName)
+	if err != nil {
+		// "lineage Config deleted" lands here (ErrConfigNotFound) and so
+		// does a missing Blueprint. Either way no reconcile is possible.
+		// Surface the cause and fall through to a vanilla restart so the
+		// cell's runtime is still bounced as the operator asked.
+		cmd.PrintErrf(
+			"notice: cell %q is OutOfSync but reconcile materialisation failed (%v); bouncing without reconcile\n",
+			doc.Metadata.Name, err,
+		)
+		return restartInPlace(cmd, client, doc)
+	}
+
+	rawYAML, marshalErr := yaml.Marshal(&cellDoc)
+	if marshalErr != nil {
+		return fmt.Errorf("marshal materialised cell: %w", marshalErr)
+	}
+	result, applyErr := client.ApplyDocuments(cmd.Context(), rawYAML)
+	if applyErr != nil {
+		return applyErr
+	}
+	cmd.Printf("Restarted cell %q from stack %q (reconciled from config %q)\n",
+		doc.Metadata.Name, doc.Spec.StackID, configName)
+	return reportApplyFailures(result)
+}
+
+// restartInPlace bounces the cell with the same stored spec: stop then start.
+// The CellDoc only needs name + scope — the daemon resolves both verbs from
+// the stored cell metadata, so spec.containers and friends do not need to be
+// re-supplied (preserving "all spec fields" is automatic).
+func restartInPlace(cmd *cobra.Command, client kukeonv1.Client, doc v1beta1.CellDoc) error {
+	if _, err := client.StopCell(cmd.Context(), doc); err != nil {
+		return err
+	}
+	startRes, err := client.StartCell(cmd.Context(), doc)
+	if err != nil {
+		return err
+	}
+
+	cellName := startRes.Cell.Metadata.Name
+	if cellName == "" {
+		cellName = doc.Metadata.Name
+	}
+	stackName := startRes.Cell.Spec.StackID
+	if stackName == "" {
+		stackName = doc.Spec.StackID
+	}
+	cmd.Printf("Restarted cell %q from stack %q\n", cellName, stackName)
+	return nil
+}
+
+// restartStopped is the already-stopped path: equivalent to
+// `kuke start cell <name>`. AC pins this even for OutOfSync stopped cells —
+// reconcile happens only on the Ready+OutOfSync path; an operator wanting to
+// reconcile from Stopped uses `kuke apply -c` directly.
+func restartStopped(
+	cmd *cobra.Command, client kukeonv1.Client,
+	doc v1beta1.CellDoc, _ kukeonv1.GetCellResult,
+) error {
+	startRes, err := client.StartCell(cmd.Context(), doc)
+	if err != nil {
+		return err
+	}
+
+	cellName := startRes.Cell.Metadata.Name
+	if cellName == "" {
+		cellName = doc.Metadata.Name
+	}
+	stackName := startRes.Cell.Spec.StackID
+	if stackName == "" {
+		stackName = doc.Spec.StackID
+	}
+	cmd.Printf("Started cell %q from stack %q\n", cellName, stackName)
+	return nil
+}
+
+// materialiseFromConfig re-runs the `kuke apply -c` materialisation pipeline
+// against the cell's lineage Config: GetConfig + GetBlueprint +
+// cellconfig.Materialize. The cell's stored realm/space/stack supply the
+// lookup scope — a Config materialises a cell into the scope it lives in,
+// matching the daemon's reconciler (internal/controller/reconcile_outofsync.go).
+func materialiseFromConfig(
+	ctx context.Context, client kukeonv1.Client,
+	cellDoc v1beta1.CellDoc, configName string,
+) (v1beta1.CellDoc, error) {
+	cfgRes, err := client.GetConfig(ctx, v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  configName,
+			Realm: cellDoc.Spec.RealmID,
+			Space: cellDoc.Spec.SpaceID,
+			Stack: cellDoc.Spec.StackID,
+		},
+	})
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !cfgRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (config %q in realm=%q space=%q stack=%q)",
+			errdefs.ErrConfigNotFound, configName,
+			cellDoc.Spec.RealmID, cellDoc.Spec.SpaceID, cellDoc.Spec.StackID,
+		)
+	}
+
+	bpRef := cfgRes.Config.Spec.Blueprint
+	bpRes, err := client.GetBlueprint(ctx, v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  bpRef.Name,
+			Realm: bpRef.Realm,
+			Space: bpRef.Space,
+			Stack: bpRef.Stack,
+		},
+	})
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !bpRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (blueprint %q referenced by config %q)",
+			errdefs.ErrBlueprintNotFound, bpRef.Name, configName,
+		)
+	}
+
+	return cellconfig.Materialize(cfgRes.Config, bpRes.Blueprint)
+}
+
+// reportApplyFailures inspects an ApplyDocumentsResult for "failed" rows and
+// returns a non-nil error so the CLI exits non-zero on a daemon-side
+// reconcile failure. Matches `kuke apply`'s behaviour
+// (cmd/kuke/apply/apply.go:468-495 printApplyResult).
+func reportApplyFailures(result kukeonv1.ApplyDocumentsResult) error {
+	for _, r := range result.Resources {
+		if r.Action == "failed" {
+			return fmt.Errorf("%w: reconcile failed for %s %q: %s",
+				errdefs.ErrConfig, r.Kind, r.Name, r.Error)
+		}
+	}
+	return nil
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.ClientFromCmd(cmd)
+}

--- a/cmd/kuke/restart/cell/cell_test.go
+++ b/cmd/kuke/restart/cell/cell_test.go
@@ -65,8 +65,13 @@ func TestRestartCell(t *testing.T) {
 						MetadataExists: true,
 						Cell: v1beta1.CellDoc{
 							Metadata: v1beta1.CellMetadata{Name: doc.Metadata.Name},
-							Spec:     v1beta1.CellSpec{ID: doc.Metadata.Name, RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: false},
+							Spec: v1beta1.CellSpec{
+								ID:      doc.Metadata.Name,
+								RealmID: "r1",
+								SpaceID: "s1",
+								StackID: "st1",
+							},
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: false},
 						},
 					}, nil
 				},
@@ -89,7 +94,7 @@ func TestRestartCell(t *testing.T) {
 			},
 		},
 		{
-			name: "outofsync ready cell: reconciles via ApplyDocuments",
+			name: "outofsync ready cell: reconciles via ApplyDocuments then explicitly bounces",
 			args: []string{"prod"},
 			setup: func() {
 				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
@@ -105,8 +110,12 @@ func TestRestartCell(t *testing.T) {
 								Name:   "prod",
 								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
 							},
-							Spec:   v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status: v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: true, OutOfSyncReason: "spec differs"},
+							Spec: v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status: v1beta1.CellStatus{
+								State:           v1beta1.CellStateReady,
+								OutOfSync:       true,
+								OutOfSyncReason: "spec differs",
+							},
 						},
 					}, nil
 				},
@@ -120,9 +129,19 @@ func TestRestartCell(t *testing.T) {
 						Config: v1beta1.CellConfigDoc{
 							APIVersion: v1beta1.APIVersionV1Beta1,
 							Kind:       v1beta1.KindCellConfig,
-							Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "r1", Space: "s1", Stack: "st1"},
+							Metadata: v1beta1.CellConfigMetadata{
+								Name:  "prod",
+								Realm: "r1",
+								Space: "s1",
+								Stack: "st1",
+							},
 							Spec: v1beta1.CellConfigSpec{
-								Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "r1", Space: "s1", Stack: "st1"},
+								Blueprint: v1beta1.CellConfigBlueprintRef{
+									Name:  "web",
+									Realm: "r1",
+									Space: "s1",
+									Stack: "st1",
+								},
 							},
 						},
 					}, nil
@@ -136,7 +155,12 @@ func TestRestartCell(t *testing.T) {
 						Blueprint: v1beta1.CellBlueprintDoc{
 							APIVersion: v1beta1.APIVersionV1Beta1,
 							Kind:       v1beta1.KindCellBlueprint,
-							Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "r1", Space: "s1", Stack: "st1"},
+							Metadata: v1beta1.CellBlueprintMetadata{
+								Name:  "web",
+								Realm: "r1",
+								Space: "s1",
+								Stack: "st1",
+							},
 							Spec: v1beta1.CellBlueprintSpec{
 								Cell: v1beta1.BlueprintCellSpec{
 									Containers: []v1beta1.BlueprintContainer{
@@ -161,6 +185,222 @@ func TestRestartCell(t *testing.T) {
 						},
 					}, nil
 				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc}, nil
+				},
+			},
+			wantOutput: `Restarted cell "prod" from stack "st1" (reconciled from config "prod")`,
+			validate: func(t *testing.T, f *fakeClient) {
+				if f.applyCalls != 1 {
+					t.Fatalf("want exactly 1 ApplyDocuments call, got %d", f.applyCalls)
+				}
+				// Apply alone does not guarantee a bounce — the daemon's
+				// reconcile only stops+starts containers on image/cmd/args
+				// changes. The CLI explicitly StopCell+StartCells afterwards
+				// to honor the "restart" verb's contract.
+				if f.stopCalls != 1 || f.startCalls != 1 {
+					t.Fatalf("OutOfSync restart must follow Apply with StopCell+StartCell, got stop=%d start=%d",
+						f.stopCalls, f.startCalls)
+				}
+			},
+		},
+		{
+			// Reviewer-requested coverage of the reconcile-no-bounce gap: a
+			// pure env-var divergence routes through UpdateCell's metadata
+			// path (containerSpecChanged returns false for non-image/cmd/args
+			// fields), so the daemon does NOT bounce containers. The CLI's
+			// follow-up StopCell+StartCell is what makes "kuke restart" on
+			// this divergence class actually bounce the running containers.
+			name: "outofsync env-var-only divergence: reconciles then explicitly bounces",
+			args: []string{"prod"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{
+								Name:   "prod",
+								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+							},
+							Spec: v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status: v1beta1.CellStatus{
+								State:           v1beta1.CellStateReady,
+								OutOfSync:       true,
+								OutOfSyncReason: "env vars differ",
+							},
+						},
+					}, nil
+				},
+				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					return kukeonv1.GetConfigResult{
+						MetadataExists: true,
+						Config: v1beta1.CellConfigDoc{
+							APIVersion: v1beta1.APIVersionV1Beta1,
+							Kind:       v1beta1.KindCellConfig,
+							Metadata: v1beta1.CellConfigMetadata{
+								Name:  "prod",
+								Realm: "r1",
+								Space: "s1",
+								Stack: "st1",
+							},
+							Spec: v1beta1.CellConfigSpec{
+								Blueprint: v1beta1.CellConfigBlueprintRef{
+									Name:  "web",
+									Realm: "r1",
+									Space: "s1",
+									Stack: "st1",
+								},
+							},
+						},
+					}, nil
+				},
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{
+						MetadataExists: true,
+						Blueprint: v1beta1.CellBlueprintDoc{
+							APIVersion: v1beta1.APIVersionV1Beta1,
+							Kind:       v1beta1.KindCellBlueprint,
+							Metadata: v1beta1.CellBlueprintMetadata{
+								Name:  "web",
+								Realm: "r1",
+								Space: "s1",
+								Stack: "st1",
+							},
+							Spec: v1beta1.CellBlueprintSpec{
+								Cell: v1beta1.BlueprintCellSpec{
+									Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}},
+								},
+							},
+						},
+					}, nil
+				},
+				applyDocsFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
+					// Mirrors what reconcile.go emits when only env vars
+					// changed: the container is "updated" with field list,
+					// but no "image|command|args" entries are present, so
+					// UpdateCell patched in place without bouncing.
+					return kukeonv1.ApplyDocumentsResult{
+						Resources: []kukeonv1.ApplyResourceResult{
+							{
+								Kind:    "Cell",
+								Name:    "prod",
+								Action:  "updated",
+								Changes: []string{`container "main" updated: env`},
+							},
+						},
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc}, nil
+				},
+			},
+			wantOutput: `Restarted cell "prod" from stack "st1" (reconciled from config "prod")`,
+			validate: func(t *testing.T, f *fakeClient) {
+				if f.applyCalls != 1 {
+					t.Fatalf("want exactly 1 ApplyDocuments call, got %d", f.applyCalls)
+				}
+				if f.stopCalls != 1 || f.startCalls != 1 {
+					t.Fatalf(
+						"env-var-only OutOfSync restart MUST follow Apply with StopCell+StartCell, got stop=%d start=%d",
+						f.stopCalls,
+						f.startCalls,
+					)
+				}
+			},
+		},
+		{
+			// The other half of the env-var-only test's contract: when the
+			// daemon's reconcile already bounced every container (full root
+			// recreate), the CLI must NOT add a redundant StopCell+StartCell.
+			// reconcileBouncedAll's signal "root container recreated" gates
+			// this branch.
+			name: "outofsync ready cell with root-container recreate: skips redundant bounce",
+			args: []string{"prod"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{
+								Name:   "prod",
+								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+							},
+							Spec: v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status: v1beta1.CellStatus{
+								State:           v1beta1.CellStateReady,
+								OutOfSync:       true,
+								OutOfSyncReason: "root image bumped",
+							},
+						},
+					}, nil
+				},
+				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					return kukeonv1.GetConfigResult{
+						MetadataExists: true,
+						Config: v1beta1.CellConfigDoc{
+							APIVersion: v1beta1.APIVersionV1Beta1,
+							Kind:       v1beta1.KindCellConfig,
+							Metadata: v1beta1.CellConfigMetadata{
+								Name:  "prod",
+								Realm: "r1",
+								Space: "s1",
+								Stack: "st1",
+							},
+							Spec: v1beta1.CellConfigSpec{
+								Blueprint: v1beta1.CellConfigBlueprintRef{
+									Name:  "web",
+									Realm: "r1",
+									Space: "s1",
+									Stack: "st1",
+								},
+							},
+						},
+					}, nil
+				},
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{
+						MetadataExists: true,
+						Blueprint: v1beta1.CellBlueprintDoc{
+							APIVersion: v1beta1.APIVersionV1Beta1,
+							Kind:       v1beta1.KindCellBlueprint,
+							Metadata: v1beta1.CellBlueprintMetadata{
+								Name:  "web",
+								Realm: "r1",
+								Space: "s1",
+								Stack: "st1",
+							},
+							Spec: v1beta1.CellBlueprintSpec{
+								Cell: v1beta1.BlueprintCellSpec{
+									Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}},
+								},
+							},
+						},
+					}, nil
+				},
+				applyDocsFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
+					return kukeonv1.ApplyDocumentsResult{
+						Resources: []kukeonv1.ApplyResourceResult{
+							{
+								Kind:    "Cell",
+								Name:    "prod",
+								Action:  "updated",
+								Changes: []string{"root container recreated"},
+							},
+						},
+					}, nil
+				},
 			},
 			wantOutput: `Restarted cell "prod" from stack "st1" (reconciled from config "prod")`,
 			validate: func(t *testing.T, f *fakeClient) {
@@ -168,8 +408,11 @@ func TestRestartCell(t *testing.T) {
 					t.Fatalf("want exactly 1 ApplyDocuments call, got %d", f.applyCalls)
 				}
 				if f.stopCalls != 0 || f.startCalls != 0 {
-					t.Fatalf("OutOfSync restart must not call StopCell/StartCell directly, got stop=%d start=%d",
-						f.stopCalls, f.startCalls)
+					t.Fatalf(
+						"root-container recreate already bounced everything; CLI must NOT add a redundant StopCell+StartCell, got stop=%d start=%d",
+						f.stopCalls,
+						f.startCalls,
+					)
 				}
 			},
 		},
@@ -285,8 +528,10 @@ func TestRestartCell(t *testing.T) {
 						},
 					}, nil
 				},
-				stopCellFn:  func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) { return kukeonv1.StartCellResult{Cell: doc}, nil },
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc}, nil
+				},
 			},
 			wantOutput: `Restarted cell "orphan" from stack "st1"`,
 			wantStderr: `notice: cell "orphan" is OutOfSync but carries no kukeon.io/config label`,
@@ -316,8 +561,10 @@ func TestRestartCell(t *testing.T) {
 						},
 					}, nil
 				},
-				stopCellFn:  func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) { return kukeonv1.StartCellResult{Cell: doc}, nil },
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc}, nil
+				},
 			},
 			wantOutput: `Restarted cell "degraded" from stack "st1"`,
 			wantStderr: `OutOfSync detection failed (referenced blueprint missing)`,
@@ -339,16 +586,22 @@ func TestRestartCell(t *testing.T) {
 								Name:   "orphan",
 								Labels: map[string]string{cellconfig.LabelConfig: "deleted-cfg"},
 							},
-							Spec:   v1beta1.CellSpec{ID: "orphan", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status: v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: true, OutOfSyncReason: "lineage Config deleted"},
+							Spec: v1beta1.CellSpec{ID: "orphan", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status: v1beta1.CellStatus{
+								State:           v1beta1.CellStateReady,
+								OutOfSync:       true,
+								OutOfSyncReason: "lineage Config deleted",
+							},
 						},
 					}, nil
 				},
 				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
 					return kukeonv1.GetConfigResult{MetadataExists: false}, nil
 				},
-				stopCellFn:  func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) { return kukeonv1.StartCellResult{Cell: doc}, nil },
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc}, nil
+				},
 			},
 			wantOutput: `Restarted cell "orphan" from stack "st1"`,
 			wantStderr: `reconcile materialisation failed`,
@@ -381,9 +634,19 @@ func TestRestartCell(t *testing.T) {
 						Config: v1beta1.CellConfigDoc{
 							APIVersion: v1beta1.APIVersionV1Beta1,
 							Kind:       v1beta1.KindCellConfig,
-							Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "r1", Space: "s1", Stack: "st1"},
+							Metadata: v1beta1.CellConfigMetadata{
+								Name:  "prod",
+								Realm: "r1",
+								Space: "s1",
+								Stack: "st1",
+							},
 							Spec: v1beta1.CellConfigSpec{
-								Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "r1", Space: "s1", Stack: "st1"},
+								Blueprint: v1beta1.CellConfigBlueprintRef{
+									Name:  "web",
+									Realm: "r1",
+									Space: "s1",
+									Stack: "st1",
+								},
 							},
 						},
 					}, nil
@@ -394,9 +657,16 @@ func TestRestartCell(t *testing.T) {
 						Blueprint: v1beta1.CellBlueprintDoc{
 							APIVersion: v1beta1.APIVersionV1Beta1,
 							Kind:       v1beta1.KindCellBlueprint,
-							Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "r1", Space: "s1", Stack: "st1"},
+							Metadata: v1beta1.CellBlueprintMetadata{
+								Name:  "web",
+								Realm: "r1",
+								Space: "s1",
+								Stack: "st1",
+							},
 							Spec: v1beta1.CellBlueprintSpec{
-								Cell: v1beta1.BlueprintCellSpec{Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}}},
+								Cell: v1beta1.BlueprintCellSpec{
+									Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}},
+								},
 							},
 						},
 					}, nil
@@ -519,12 +789,12 @@ type fakeClient struct {
 	startCellFn    func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
 	applyDocsFn    func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error)
 
-	getCellCalls  int
-	stopCalls     int
-	startCalls    int
-	getConfigCnt  int
-	getBpCalls    int
-	applyCalls    int
+	getCellCalls int
+	stopCalls    int
+	startCalls   int
+	getConfigCnt int
+	getBpCalls   int
+	applyCalls   int
 }
 
 func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
@@ -543,7 +813,10 @@ func (f *fakeClient) GetConfig(_ context.Context, doc v1beta1.CellConfigDoc) (ku
 	return f.getConfigFn(doc)
 }
 
-func (f *fakeClient) GetBlueprint(_ context.Context, doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+func (f *fakeClient) GetBlueprint(
+	_ context.Context,
+	doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.GetBlueprintResult, error) {
 	f.getBpCalls++
 	if f.getBlueprintFn == nil {
 		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")

--- a/cmd/kuke/restart/cell/cell_test.go
+++ b/cmd/kuke/restart/cell/cell_test.go
@@ -1,0 +1,581 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cell_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	cell "github.com/eminwux/kukeon/cmd/kuke/restart/cell"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+func TestRestartCell(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func()
+		fake       *fakeClient
+		wantErr    string
+		wantOutput string
+		wantStderr string
+		// validate is run after a successful command for additional
+		// post-conditions the assertion knobs above don't cover.
+		validate func(t *testing.T, f *fakeClient)
+	}{
+		{
+			name: "synced ready cell: stop then start with same spec",
+			args: []string{"c1"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{Name: doc.Metadata.Name},
+							Spec:     v1beta1.CellSpec{ID: doc.Metadata.Name, RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: false},
+						},
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{}, nil
+				},
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+				},
+			},
+			wantOutput: `Restarted cell "c1" from stack "st1"`,
+			validate: func(t *testing.T, f *fakeClient) {
+				if f.stopCalls != 1 || f.startCalls != 1 {
+					t.Fatalf("want exactly 1 StopCell + 1 StartCell, got stop=%d start=%d",
+						f.stopCalls, f.startCalls)
+				}
+				if f.applyCalls != 0 {
+					t.Fatalf("Synced restart must not call ApplyDocuments, got %d calls", f.applyCalls)
+				}
+			},
+		},
+		{
+			name: "outofsync ready cell: reconciles via ApplyDocuments",
+			args: []string{"prod"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{
+								Name:   "prod",
+								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+							},
+							Spec:   v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: true, OutOfSyncReason: "spec differs"},
+						},
+					}, nil
+				},
+				getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					if doc.Metadata.Name != "prod" || doc.Metadata.Realm != "r1" {
+						t.Errorf("GetConfig saw unexpected lookup: name=%q realm=%q",
+							doc.Metadata.Name, doc.Metadata.Realm)
+					}
+					return kukeonv1.GetConfigResult{
+						MetadataExists: true,
+						Config: v1beta1.CellConfigDoc{
+							APIVersion: v1beta1.APIVersionV1Beta1,
+							Kind:       v1beta1.KindCellConfig,
+							Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "r1", Space: "s1", Stack: "st1"},
+							Spec: v1beta1.CellConfigSpec{
+								Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "r1", Space: "s1", Stack: "st1"},
+							},
+						},
+					}, nil
+				},
+				getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					if doc.Metadata.Name != "web" {
+						t.Errorf("GetBlueprint saw unexpected name=%q", doc.Metadata.Name)
+					}
+					return kukeonv1.GetBlueprintResult{
+						MetadataExists: true,
+						Blueprint: v1beta1.CellBlueprintDoc{
+							APIVersion: v1beta1.APIVersionV1Beta1,
+							Kind:       v1beta1.KindCellBlueprint,
+							Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "r1", Space: "s1", Stack: "st1"},
+							Spec: v1beta1.CellBlueprintSpec{
+								Cell: v1beta1.BlueprintCellSpec{
+									Containers: []v1beta1.BlueprintContainer{
+										{ID: "main", Image: "nginx:latest"},
+									},
+								},
+							},
+						},
+					}, nil
+				},
+				applyDocsFn: func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
+					var sent v1beta1.CellDoc
+					if err := yaml.Unmarshal(rawYAML, &sent); err != nil {
+						t.Errorf("ApplyDocuments received un-unmarshalable YAML: %v", err)
+					}
+					if sent.Metadata.Name != "prod" {
+						t.Errorf("ApplyDocuments cell name=%q want %q", sent.Metadata.Name, "prod")
+					}
+					return kukeonv1.ApplyDocumentsResult{
+						Resources: []kukeonv1.ApplyResourceResult{
+							{Kind: "Cell", Name: "prod", Action: "updated"},
+						},
+					}, nil
+				},
+			},
+			wantOutput: `Restarted cell "prod" from stack "st1" (reconciled from config "prod")`,
+			validate: func(t *testing.T, f *fakeClient) {
+				if f.applyCalls != 1 {
+					t.Fatalf("want exactly 1 ApplyDocuments call, got %d", f.applyCalls)
+				}
+				if f.stopCalls != 0 || f.startCalls != 0 {
+					t.Fatalf("OutOfSync restart must not call StopCell/StartCell directly, got stop=%d start=%d",
+						f.stopCalls, f.startCalls)
+				}
+			},
+		},
+		{
+			name: "stopped cell: equivalent to kuke start cell",
+			args: []string{"c1"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{Name: "c1"},
+							Spec:     v1beta1.CellSpec{ID: "c1", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status:   v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+					}, nil
+				},
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+				},
+			},
+			wantOutput: `Started cell "c1" from stack "st1"`,
+			validate: func(t *testing.T, f *fakeClient) {
+				if f.stopCalls != 0 || f.startCalls != 1 {
+					t.Fatalf("Stopped restart must call StartCell only, got stop=%d start=%d",
+						f.stopCalls, f.startCalls)
+				}
+			},
+		},
+		{
+			name: "failed cell: refused with kuke delete pointer",
+			args: []string{"broken"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{Name: "broken"},
+							Status:   v1beta1.CellStatus{State: v1beta1.CellStateFailed},
+						},
+					}, nil
+				},
+			},
+			wantErr: "kuke delete cell broken",
+		},
+		{
+			name: "pending cell: refused with kuke delete pointer",
+			args: []string{"halfborn"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{Name: "halfborn"},
+							Status:   v1beta1.CellStatus{State: v1beta1.CellStatePending},
+						},
+					}, nil
+				},
+			},
+			wantErr: "kuke delete cell halfborn",
+		},
+		{
+			name: "missing cell: returns ErrCellNotFound",
+			args: []string{"nope"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: "cell not found",
+		},
+		{
+			name:    "missing realm",
+			args:    []string{"c1"},
+			wantErr: "realm name is required",
+		},
+		{
+			name: "outofsync cell with no lineage label: vanilla restart with notice",
+			args: []string{"orphan"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{Name: "orphan", Labels: map[string]string{}},
+							Spec:     v1beta1.CellSpec{ID: "orphan", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: true},
+						},
+					}, nil
+				},
+				stopCellFn:  func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) { return kukeonv1.StartCellResult{Cell: doc}, nil },
+			},
+			wantOutput: `Restarted cell "orphan" from stack "st1"`,
+			wantStderr: `notice: cell "orphan" is OutOfSync but carries no kukeon.io/config label`,
+		},
+		{
+			name: "outofsync ready cell with OutOfSyncError: vanilla restart with notice",
+			args: []string{"degraded"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{
+								Name:   "degraded",
+								Labels: map[string]string{cellconfig.LabelConfig: "degraded"},
+							},
+							Spec: v1beta1.CellSpec{ID: "degraded", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status: v1beta1.CellStatus{
+								State:          v1beta1.CellStateReady,
+								OutOfSyncError: "referenced blueprint missing",
+							},
+						},
+					}, nil
+				},
+				stopCellFn:  func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) { return kukeonv1.StartCellResult{Cell: doc}, nil },
+			},
+			wantOutput: `Restarted cell "degraded" from stack "st1"`,
+			wantStderr: `OutOfSync detection failed (referenced blueprint missing)`,
+		},
+		{
+			name: "outofsync cell whose lineage Config was deleted: falls back to vanilla restart",
+			args: []string{"orphan"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{
+								Name:   "orphan",
+								Labels: map[string]string{cellconfig.LabelConfig: "deleted-cfg"},
+							},
+							Spec:   v1beta1.CellSpec{ID: "orphan", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: true, OutOfSyncReason: "lineage Config deleted"},
+						},
+					}, nil
+				},
+				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+				},
+				stopCellFn:  func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) { return kukeonv1.StartCellResult{Cell: doc}, nil },
+			},
+			wantOutput: `Restarted cell "orphan" from stack "st1"`,
+			wantStderr: `reconcile materialisation failed`,
+		},
+		{
+			name: "ApplyDocuments returns a failed row: surfaces as error",
+			args: []string{"prod"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{
+								Name:   "prod",
+								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+							},
+							Spec:   v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: true},
+						},
+					}, nil
+				},
+				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					return kukeonv1.GetConfigResult{
+						MetadataExists: true,
+						Config: v1beta1.CellConfigDoc{
+							APIVersion: v1beta1.APIVersionV1Beta1,
+							Kind:       v1beta1.KindCellConfig,
+							Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "r1", Space: "s1", Stack: "st1"},
+							Spec: v1beta1.CellConfigSpec{
+								Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "r1", Space: "s1", Stack: "st1"},
+							},
+						},
+					}, nil
+				},
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{
+						MetadataExists: true,
+						Blueprint: v1beta1.CellBlueprintDoc{
+							APIVersion: v1beta1.APIVersionV1Beta1,
+							Kind:       v1beta1.KindCellBlueprint,
+							Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "r1", Space: "s1", Stack: "st1"},
+							Spec: v1beta1.CellBlueprintSpec{
+								Cell: v1beta1.BlueprintCellSpec{Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}}},
+							},
+						},
+					}, nil
+				},
+				applyDocsFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
+					return kukeonv1.ApplyDocumentsResult{
+						Resources: []kukeonv1.ApplyResourceResult{
+							{Kind: "Cell", Name: "prod", Action: "failed", Error: "containerd update rejected"},
+						},
+					}, nil
+				},
+			},
+			wantErr: "reconcile failed for Cell \"prod\"",
+		},
+		{
+			name: "stop step errors: surfaces and skips start",
+			args: []string{"c1"},
+			setup: func() {
+				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
+				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
+				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
+			},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						MetadataExists: true,
+						Cell: v1beta1.CellDoc{
+							Metadata: v1beta1.CellMetadata{Name: "c1"},
+							Spec:     v1beta1.CellSpec{ID: "c1", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady},
+						},
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{}, errors.New("boom")
+				},
+			},
+			wantErr: "boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			viper.Reset()
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			cmd := cell.NewCellCmd()
+			outBuf := &bytes.Buffer{}
+			errBuf := &bytes.Buffer{}
+			cmd.SetOut(outBuf)
+			cmd.SetErr(errBuf)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			if tt.fake != nil {
+				ctx = context.WithValue(ctx, cell.MockControllerKey{}, kukeonv1.Client(tt.fake))
+			}
+			cmd.SetContext(ctx)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantOutput != "" && !strings.Contains(outBuf.String(), tt.wantOutput) {
+				t.Errorf("stdout missing %q\nGot:\n%s", tt.wantOutput, outBuf.String())
+			}
+			if tt.wantStderr != "" && !strings.Contains(errBuf.String(), tt.wantStderr) {
+				t.Errorf("stderr missing %q\nGot:\n%s", tt.wantStderr, errBuf.String())
+			}
+			if tt.validate != nil {
+				tt.validate(t, tt.fake)
+			}
+		})
+	}
+}
+
+// TestRestartCell_CmdSurface pins the user-facing CLI shape: positional arg,
+// scope flags, completion. Catches accidental flag renames or arg-count drift.
+func TestRestartCell_CmdSurface(t *testing.T) {
+	cmd := cell.NewCellCmd()
+
+	if !cmd.HasAlias("ce") {
+		t.Errorf("expected alias %q", "ce")
+	}
+	for _, f := range []string{"realm", "space", "stack"} {
+		if cmd.Flag(f) == nil {
+			t.Errorf("expected flag --%s to be registered", f)
+		}
+	}
+	if cmd.ValidArgsFunction == nil {
+		t.Error("expected ValidArgsFunction to be set for cell-name completion")
+	}
+	// The help text must surface the dual-mode behaviour (vanilla restart +
+	// implicit reconcile) so operators see the contract without reading code.
+	if !strings.Contains(cmd.Long, "reconcile") || !strings.Contains(cmd.Long, "OutOfSync") {
+		t.Errorf("expected Long help to describe dual mode (reconcile + OutOfSync), got: %s", cmd.Long)
+	}
+}
+
+// fakeClient is a per-test stub kukeonv1.Client. Each RPC is dispatched
+// through an optional Fn field; nil means "fail the test if called". Call
+// counts let tests assert "Synced restart did not invoke ApplyDocuments" and
+// the equivalent path-specific assertions.
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getCellFn      func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	getConfigFn    func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error)
+	getBlueprintFn func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error)
+	stopCellFn     func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
+	startCellFn    func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
+	applyDocsFn    func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error)
+
+	getCellCalls  int
+	stopCalls     int
+	startCalls    int
+	getConfigCnt  int
+	getBpCalls    int
+	applyCalls    int
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	f.getCellCalls++
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errors.New("unexpected GetCell call")
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) GetConfig(_ context.Context, doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+	f.getConfigCnt++
+	if f.getConfigFn == nil {
+		return kukeonv1.GetConfigResult{}, errors.New("unexpected GetConfig call")
+	}
+	return f.getConfigFn(doc)
+}
+
+func (f *fakeClient) GetBlueprint(_ context.Context, doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+	f.getBpCalls++
+	if f.getBlueprintFn == nil {
+		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")
+	}
+	return f.getBlueprintFn(doc)
+}
+
+func (f *fakeClient) StopCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+	f.stopCalls++
+	if f.stopCellFn == nil {
+		return kukeonv1.StopCellResult{}, errors.New("unexpected StopCell call")
+	}
+	return f.stopCellFn(doc)
+}
+
+func (f *fakeClient) StartCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+	f.startCalls++
+	if f.startCellFn == nil {
+		return kukeonv1.StartCellResult{}, errors.New("unexpected StartCell call")
+	}
+	return f.startCellFn(doc)
+}
+
+func (f *fakeClient) ApplyDocuments(_ context.Context, rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
+	f.applyCalls++
+	if f.applyDocsFn == nil {
+		return kukeonv1.ApplyDocumentsResult{}, errors.New("unexpected ApplyDocuments call")
+	}
+	return f.applyDocsFn(rawYAML)
+}
+
+// Sanity guard that the sentinel error in errdefs is still the one we
+// reference — if it gets renamed, this fails at compile time rather than
+// silently slipping into a string-match assertion.
+var _ = errdefs.ErrCellNotFound

--- a/cmd/kuke/restart/restart.go
+++ b/cmd/kuke/restart/restart.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package restart
+
+import (
+	"strings"
+
+	cellcmd "github.com/eminwux/kukeon/cmd/kuke/restart/cell"
+	"github.com/spf13/cobra"
+)
+
+// NewRestartCmd builds the `kuke restart` parent command and registers all
+// resource restart subcommands. Persistent flags defined on the root kuke
+// command are inherited automatically via Cobra's command tree.
+func NewRestartCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "restart [name]",
+		Aliases: []string{"res"},
+		Short:   "Restart Kukeon resources (cell)",
+		Long: "Restart a Kukeon resource: bounces the running process by " +
+			"default and, on a Config-lineage cell whose live spec has " +
+			"diverged from the daemon-stored Config (OutOfSync), uses the " +
+			"freshly-materialised spec on start so the restart is also a " +
+			"reconcile.",
+		Run: func(cmd *cobra.Command, _ []string) {
+			_ = cmd.Help()
+		},
+	}
+
+	cmd.ValidArgsFunction = completeRestartSubcommands
+
+	cmd.AddCommand(
+		cellcmd.NewCellCmd(),
+	)
+
+	return cmd
+}
+
+// completeRestartSubcommands provides shell completion for restart subcommand
+// names.
+func completeRestartSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	subcommands := []string{"cell"}
+
+	if toComplete == "" {
+		return subcommands, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	matches := make([]string, 0, len(subcommands))
+	for _, subcmd := range subcommands {
+		if strings.HasPrefix(subcmd, toComplete) {
+			matches = append(matches, subcmd)
+		}
+	}
+
+	return matches, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/kuke/restart/restart_test.go
+++ b/cmd/kuke/restart/restart_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package restart_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	restartpkg "github.com/eminwux/kukeon/cmd/kuke/restart"
+	"github.com/spf13/cobra"
+)
+
+func TestNewRestartCmdMetadata(t *testing.T) {
+	cmd := restartpkg.NewRestartCmd()
+
+	if cmd.Use != "restart [name]" {
+		t.Errorf("Use mismatch: got %q want %q", cmd.Use, "restart [name]")
+	}
+	if cmd.Short != "Restart Kukeon resources (cell)" {
+		t.Errorf("Short mismatch: got %q", cmd.Short)
+	}
+	if !cmd.HasAlias("res") {
+		t.Errorf("expected alias %q to be registered", "res")
+	}
+}
+
+func TestNewRestartCmdRegistersCellSubcommand(t *testing.T) {
+	cmd := restartpkg.NewRestartCmd()
+	if findSubCommand(cmd, "cell") == nil {
+		t.Fatalf("expected %q subcommand to be registered", "cell")
+	}
+}
+
+func TestNewRestartCmdHelp(t *testing.T) {
+	cmd := restartpkg.NewRestartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	cmd.Run(cmd, nil)
+
+	if !strings.Contains(buf.String(), "Usage:") {
+		t.Fatalf("expected help output to include %q, got:\n%s", "Usage:", buf.String())
+	}
+}
+
+func TestNewRestartCmd_AutocompleteRegistration(t *testing.T) {
+	cmd := restartpkg.NewRestartCmd()
+	if cmd.ValidArgsFunction == nil {
+		t.Fatal("expected ValidArgsFunction to be set for subcommand completion")
+	}
+}
+
+func findSubCommand(cmd *cobra.Command, name string) *cobra.Command {
+	for _, sc := range cmd.Commands() {
+		if sc.Name() == name || sc.HasAlias(name) {
+			return sc
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- New verb `kuke restart cell <name>` mirroring `kuke start cell` / `kuke stop cell`'s surface (positional name, `--realm/--space/--stack` scope flags, completion).
- Dual-mode behaviour:
  - **Synced Ready cell** → vanilla `StopCell + StartCell` with the same daemon-stored spec.
  - **OutOfSync Ready cell** → re-materialise from the lineage Config (`kukeon.io/config=<name>` label) via `GetConfig + GetBlueprint + cellconfig.Materialize`, route through `ApplyDocuments` to reconcile the spec, then explicitly `StopCell + StartCell` unless the reconcile already bounced every container (root-container recreate or from-Stopped rematerialize).
  - **Stopped cell** → equivalent to `kuke start cell <name>` (no reconcile, per AC).
  - **Pending/Failed/Unknown cell** → refuse with a `kuke delete cell <name>` pointer (same pattern as `cmd/kuke/run/run.go:505-516`).
- Implements the umbrella's step 2 (Closes #821), builds on the #830 OutOfSync detection foundation shipped in step 1.

## Design notes

- **CLI-level composition vs. new RPC.** The issue's open implementation question called out two options for the OutOfSync atomic stop+update+start: a new daemon RPC, or composing at CLI level over the existing primitives. I went with the CLI-level path (`GetConfig + GetBlueprint + Materialize + ApplyDocuments`) because no wire-format addition is needed. The AC's user-facing contract holds either way (per the issue's note).
- **Reconcile-no-bounce gap (addressed in fix-up 8ef685a).** The daemon's `ApplyDocuments` only bounces containers when image/command/args change (`internal/controller/runner/update_cell.go:containerSpecChanged`) — pure env-var or metadata-only divergence is patched in place by `UpdateCell` with no container bounce. To preserve `kuke restart`'s contract ("all running containers bounce"), the CLI now follows the `ApplyDocuments` call with an explicit `StopCell + StartCell` unless the reconcile already bounced every container (`reconcileBouncedAll` detects the full-bounce signals: `Action == "created"`, `"root container recreated"`, `"runtime stopped: containers re-materialized"`). The rare double-bounce in the already-bounced-everything case is acceptable; under-bouncing silently breaks the contract.
- **`OutOfSyncError` and "lineage Config deleted" reasons.** Neither case can drive a reconcile (divergence is undecidable or the source is gone). Both fall through to a vanilla restart with a one-line stderr notice so the cell's runtime still bounces as the operator asked and the operator sees the cause. Same fall-through for an OutOfSync cell that somehow lost its lineage label.
- **Attach severing** is a side effect of the daemon's existing `StopCell` behaviour (the container task is killed, which closes any attach session). The CLI does not need to do anything extra; both the vanilla and reconcile branches go through that stop step.
- **`ClientFromCmd` (not `DaemonClientFromCmd`)** matches the sibling lifecycle verbs `start`/`stop`; `local.Client` implements all the methods used here (`GetCell`, `StopCell`, `StartCell`, `GetConfig`, `GetBlueprint`, `ApplyDocuments`).
- The new help text describes the dual mode so operators see the contract without reading code (per AC: "Help text describes the dual mode").

## Test plan

- [x] `make test` — full root + kukebuild module test target passes (cached after first run).
- [x] `GOWORK=off go vet ./...` clean on root module.
- [x] `GOWORK=off go build ./...` clean.
- [x] `pre-commit run --files cmd/kuke/restart/cell/cell.go cmd/kuke/restart/cell/cell_test.go` clean (gofmt, golangci-lint, addlicense).
- [x] `./kuke restart --help` / `./kuke restart cell --help` render the dual-mode help text and the expected flags.
- [x] `cmd/kuke/restart/cell/cell_test.go` covers: Synced restart preserves spec (no `ApplyDocuments` call); OutOfSync restart reconciles then explicitly bounces (asserts `ApplyDocuments` *and* `StopCell + StartCell` called); **env-var-only OutOfSync divergence reconciles then explicitly bounces** (reviewer-requested coverage of the no-bounce gap — Apply returns `container "main" updated: env`, asserts the follow-up `StopCell + StartCell`); **root-container-recreate OutOfSync skips the redundant bounce** (Apply returns `root container recreated`, asserts `stopCalls == 0` and `startCalls == 0`); Stopped restart calls `StartCell` only; Pending/Failed cells refused with `kuke delete cell` pointer; missing cell returns `ErrCellNotFound`; missing realm refused; OutOfSync-without-lineage-label, OutOfSyncError, and deleted-Config edge cases each fall through to vanilla restart with a stderr notice; `ApplyDocuments` failed-row surfaces as error; `StopCell` error skips `StartCell`.
- [x] Attach-severing is exercised by the `StopCell`-was-called assertion in the Synced and reconcile-fallback paths (daemon owns the actual sever step).
- [ ] `make dev-init` host smoke — not run; this change is purely client-side (CLI verb composing existing RPCs), no daemon code or `/opt/kukeon` reads/writes change.

Closes #821