### PR TITLE
feat(cli): surface OutOfSync state in kuke get cell as SYNC column

### DIFF
--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -24,6 +24,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -31,14 +32,40 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	// syncStateSynced / syncStateOutOfSync are the SYNC column verdicts for
+	// Config-lineage cells. syncStateNone is the third state for cells that
+	// carry no kukeon.io/config lineage label (the bulk of the host —
+	// hand-built and `-b`-lineage cells are deliberately out of scope of the
+	// reconciler's OutOfSync detection per #819's umbrella) and follows the
+	// established `-` convention used by CgroupPath when empty.
+	syncStateSynced    = "Synced"
+	syncStateOutOfSync = "OutOfSync"
+	syncStateNone      = "-"
+)
+
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
 func NewCellCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "cell [name]",
-		Aliases:       []string{"cells", "ce"},
-		Short:         "Get or list cell information",
+		Use:     "cell [name]",
+		Aliases: []string{"cells", "ce"},
+		Short:   "Get or list cell information",
+		Long: `Get or list cell information.
+
+The default table includes a SYNC column showing the reconciler-detected
+sync state of each cell relative to its lineage Config:
+
+  Synced     - the live spec matches what the lineage Config materializes
+  OutOfSync  - divergence detected (or the lineage Config was deleted)
+  -          - the cell carries no kukeon.io/config lineage label, so the
+               Config reconciler does not track sync state for it
+
+Use ` + "`-o wide`" + ` to add a DIVERGENCE column with the short divergence
+summary (or the error message when the reconciler could not compute
+divergence). ` + "`-o yaml` / `-o json`" + ` surface the full
+outOfSync / outOfSyncReason / outOfSyncError status fields.`,
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -49,7 +76,7 @@ func NewCellCmd() *cobra.Command {
 			}
 			defer func() { _ = client.Close() }()
 
-			outputFormat, err := shared.ParseOutputFormat(cmd)
+			wide, outputFormat, err := resolveOutput(cmd)
 			if err != nil {
 				return err
 			}
@@ -110,7 +137,7 @@ func NewCellCmd() *cobra.Command {
 				return err
 			}
 			showControllers, _ := cmd.Flags().GetBool("show-controllers")
-			return printCells(cmd, cells, outputFormat, showControllers)
+			return printCells(cmd, cells, outputFormat, wide, showControllers)
 		},
 	}
 
@@ -121,7 +148,7 @@ func NewCellCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Filter cells by stack name")
 	_ = viper.BindPFlag(config.KUKE_GET_CELL_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 	cmd.Flags().Bool(
@@ -146,6 +173,65 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
+// resolveOutput sits between the cobra flag and ParseOutputFormat so the
+// `wide` value is normalised to `table` plus a bool, leaving the shared
+// yaml/json/table parser untouched. Mirrors the helper in cmd/kuke/get/image.
+func resolveOutput(cmd *cobra.Command) (bool, shared.OutputFormat, error) {
+	raw := strings.TrimSpace(cmd.Flag("output").Value.String())
+	if strings.EqualFold(raw, "wide") {
+		_ = cmd.Flags().Set("output", "table")
+		format, err := shared.ParseOutputFormat(cmd)
+		return true, format, err
+	}
+	format, err := shared.ParseOutputFormat(cmd)
+	return false, format, err
+}
+
+// cellSyncState renders the SYNC column for a cell. The three values are
+// driven by the cell's lineage label and the reconciler-written OutOfSync
+// status fields (issue #820, populated by #830's detection loop). Cells
+// where OutOfSyncError is non-empty (divergence undecidable — Blueprint
+// missing or materialization failure) render as OutOfSync so the operator
+// gets one actionable "look at this cell" signal in the SYNC column; the
+// distinct error message surfaces in the DIVERGENCE column under -o wide
+// and in the outOfSyncError field under -o yaml/json.
+func cellSyncState(c *v1beta1.CellDoc) string {
+	if !hasConfigLineage(c) {
+		return syncStateNone
+	}
+	if c.Status.OutOfSync || c.Status.OutOfSyncError != "" {
+		return syncStateOutOfSync
+	}
+	return syncStateSynced
+}
+
+// cellDivergence renders the DIVERGENCE column under -o wide. Synced or
+// no-lineage cells render `-` (matching the established CgroupPath empty
+// convention) so the column stays width-aligned. Reason takes precedence
+// over Error when both are set (the reconciler never sets both, but the
+// order is defensive).
+func cellDivergence(c *v1beta1.CellDoc) string {
+	if !hasConfigLineage(c) {
+		return syncStateNone
+	}
+	if c.Status.OutOfSyncReason != "" {
+		return c.Status.OutOfSyncReason
+	}
+	if c.Status.OutOfSyncError != "" {
+		return "error: " + c.Status.OutOfSyncError
+	}
+	return syncStateNone
+}
+
+// hasConfigLineage matches the configLineage helper in
+// internal/controller/reconcile_outofsync.go: a cell is Config-lineage iff
+// it carries a non-empty kukeon.io/config label. Replicated inline rather
+// than imported to keep the CLI leaf free of an internal/controller
+// dependency.
+func hasConfigLineage(c *v1beta1.CellDoc) bool {
+	return strings.TrimSpace(c.Metadata.Labels[cellconfig.LabelConfig]) != ""
+}
+
 func printCell(cell *v1beta1.CellDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
@@ -155,7 +241,13 @@ func printCell(cell *v1beta1.CellDoc, format shared.OutputFormat) error {
 	}
 }
 
-func printCells(cmd *cobra.Command, cells []v1beta1.CellDoc, format shared.OutputFormat, showControllers bool) error {
+func printCells(
+	cmd *cobra.Command,
+	cells []v1beta1.CellDoc,
+	format shared.OutputFormat,
+	wide bool,
+	showControllers bool,
+) error {
 	switch format {
 	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cells)
@@ -166,7 +258,10 @@ func printCells(cmd *cobra.Command, cells []v1beta1.CellDoc, format shared.Outpu
 			cmd.Println("No cells found.")
 			return nil
 		}
-		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "CGROUP"}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "SYNC", "CGROUP"}
+		if wide {
+			headers = append(headers, "DIVERGENCE")
+		}
 		if showControllers {
 			headers = append(headers, "CONTROLLERS")
 		}
@@ -178,7 +273,18 @@ func printCells(cmd *cobra.Command, cells []v1beta1.CellDoc, format shared.Outpu
 			if cgroup == "" {
 				cgroup = "-"
 			}
-			row := []string{c.Metadata.Name, c.Spec.RealmID, c.Spec.SpaceID, c.Spec.StackID, state, cgroup}
+			row := []string{
+				c.Metadata.Name,
+				c.Spec.RealmID,
+				c.Spec.SpaceID,
+				c.Spec.StackID,
+				state,
+				cellSyncState(c),
+				cgroup,
+			}
+			if wide {
+				row = append(row, cellDivergence(c))
+			}
 			if showControllers {
 				row = append(row, shared.FormatControllers(c.Status.SubtreeControllers))
 			}

--- a/cmd/kuke/get/cell/cell_test.go
+++ b/cmd/kuke/get/cell/cell_test.go
@@ -22,11 +22,13 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
 	cell "github.com/eminwux/kukeon/cmd/kuke/get/cell"
 	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -133,6 +135,194 @@ func TestNewCellCmd(t *testing.T) {
 			}
 			if tt.wantOutput != "" && !strings.Contains(buf.String(), tt.wantOutput) {
 				t.Errorf("output missing %q\nGot:\n%s", tt.wantOutput, buf.String())
+			}
+		})
+	}
+}
+
+// TestNewCellCmd_SyncColumn covers the SYNC column the `kuke get cell`
+// default table acquired alongside #830's OutOfSync detection (issue #822).
+// Each subtest pins a single mock cell and asserts the rendered SYNC value
+// and (in -o wide) the DIVERGENCE value, plus that the SYNC header is
+// always present in the default table. The fourth case asserts the full
+// status fields land in -o yaml without an extra projection step — the
+// strict-omitempty serialization in pkg/api/model/v1beta1/cell.go means
+// non-default values surface automatically.
+func TestNewCellCmd_SyncColumn(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	configLineageLabels := map[string]string{cellconfig.LabelConfig: "prod"}
+
+	tests := []struct {
+		name        string
+		cells       []v1beta1.CellDoc
+		extraFlags  map[string]string
+		wantHeaders []string
+		wantRow     []string // substrings that must all appear on the cell's row
+		wantStatus  []string // substrings that must all appear in yaml output
+	}{
+		{
+			name: "synced cell renders Synced in default table",
+			cells: []v1beta1.CellDoc{{
+				Metadata: v1beta1.CellMetadata{Name: "ce1", Labels: configLineageLabels},
+				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+				Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady},
+			}},
+			wantHeaders: []string{"SYNC"},
+			wantRow:     []string{"ce1", "Synced"},
+		},
+		{
+			name: "out-of-sync cell renders OutOfSync in default table",
+			cells: []v1beta1.CellDoc{{
+				Metadata: v1beta1.CellMetadata{Name: "ce2", Labels: configLineageLabels},
+				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+				Status: v1beta1.CellStatus{
+					State:           v1beta1.CellStateReady,
+					OutOfSync:       true,
+					OutOfSyncReason: "spec differs: image",
+				},
+			}},
+			wantHeaders: []string{"SYNC"},
+			wantRow:     []string{"ce2", "OutOfSync"},
+		},
+		{
+			name: "no-lineage cell renders dash in SYNC column",
+			cells: []v1beta1.CellDoc{{
+				Metadata: v1beta1.CellMetadata{Name: "ce3"},
+				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+				Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady},
+			}},
+			wantHeaders: []string{"SYNC"},
+			// "ce3 ... - ... -" — the SYNC dash is between STATE and CGROUP.
+			// PrintTable separates columns with two spaces, so the column
+			// reads as a standalone "-" token.
+			wantRow: []string{"ce3", " - "},
+		},
+		{
+			name: "-o wide adds DIVERGENCE column with reason for out-of-sync cells",
+			cells: []v1beta1.CellDoc{{
+				Metadata: v1beta1.CellMetadata{Name: "ce4", Labels: configLineageLabels},
+				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+				Status: v1beta1.CellStatus{
+					State:           v1beta1.CellStateReady,
+					OutOfSync:       true,
+					OutOfSyncReason: "spec differs: image, env",
+				},
+			}},
+			extraFlags:  map[string]string{"output": "wide"},
+			wantHeaders: []string{"SYNC", "DIVERGENCE"},
+			wantRow:     []string{"ce4", "OutOfSync", "spec differs: image, env"},
+		},
+		{
+			name: "-o wide surfaces OutOfSyncError as error: <msg>",
+			cells: []v1beta1.CellDoc{{
+				Metadata: v1beta1.CellMetadata{Name: "ce5", Labels: configLineageLabels},
+				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+				Status: v1beta1.CellStatus{
+					State:          v1beta1.CellStateReady,
+					OutOfSyncError: `blueprint "web" not found`,
+				},
+			}},
+			extraFlags:  map[string]string{"output": "wide"},
+			wantHeaders: []string{"SYNC", "DIVERGENCE"},
+			// OutOfSyncError folds into the OutOfSync SYNC verdict; the
+			// distinct surface lives in DIVERGENCE so the operator sees
+			// the actionable signal in the column they're filtering on.
+			wantRow: []string{"ce5", "OutOfSync", `error: blueprint "web" not found`},
+		},
+		{
+			name: "-o yaml passes through outOfSync and outOfSyncReason fields",
+			cells: []v1beta1.CellDoc{{
+				Metadata: v1beta1.CellMetadata{Name: "ce6", Labels: configLineageLabels},
+				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+				Status: v1beta1.CellStatus{
+					State:           v1beta1.CellStateReady,
+					OutOfSync:       true,
+					OutOfSyncReason: "lineage Config deleted",
+				},
+			}},
+			extraFlags: map[string]string{"output": "yaml"},
+			wantStatus: []string{"outOfSync: true", "outOfSyncReason: lineage Config deleted"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := cell.NewCellCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			fake := &fakeClient{
+				listCellsFn: func(_, _, _ string) ([]v1beta1.CellDoc, error) {
+					return tt.cells, nil
+				},
+			}
+			ctx = context.WithValue(ctx, cell.MockControllerKey{}, kukeonv1.Client(fake))
+			cmd.SetContext(ctx)
+
+			for flag, val := range tt.extraFlags {
+				if err := cmd.Flags().Set(flag, val); err != nil {
+					t.Fatalf("set flag %s=%s: %v", flag, val, err)
+				}
+			}
+
+			var stdoutBuf *bytes.Buffer
+			if len(tt.wantStatus) > 0 {
+				// shared.PrintYAML / PrintJSON write directly to os.Stdout
+				// (the printer is shared across get subcommands and ignores
+				// cmd's stdout redirection). Capture via os.Pipe — same
+				// pattern the shared tests in cmd/kuke/get/shared use.
+				oldStdout := os.Stdout
+				r, w, pipeErr := os.Pipe()
+				if pipeErr != nil {
+					t.Fatalf("os.Pipe: %v", pipeErr)
+				}
+				os.Stdout = w
+				t.Cleanup(func() {
+					os.Stdout = oldStdout
+				})
+				stdoutBuf = &bytes.Buffer{}
+				done := make(chan struct{})
+				go func() {
+					_, _ = stdoutBuf.ReadFrom(r)
+					close(done)
+				}()
+				if err := cmd.Execute(); err != nil {
+					_ = w.Close()
+					<-done
+					t.Fatalf("unexpected error: %v", err)
+				}
+				_ = w.Close()
+				<-done
+			} else {
+				if err := cmd.Execute(); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			out := buf.String()
+			for _, h := range tt.wantHeaders {
+				if !strings.Contains(out, h) {
+					t.Errorf("table missing header %q\nGot:\n%s", h, out)
+				}
+			}
+			for _, sub := range tt.wantRow {
+				if !strings.Contains(out, sub) {
+					t.Errorf("row missing %q\nGot:\n%s", sub, out)
+				}
+			}
+			if stdoutBuf != nil {
+				yamlOut := stdoutBuf.String()
+				for _, sub := range tt.wantStatus {
+					if !strings.Contains(yamlOut, sub) {
+						t.Errorf("yaml output missing %q\nGot:\n%s", sub, yamlOut)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds a `SYNC` column to the default `kuke get cell` table — renders `Synced` / `OutOfSync` for Config-lineage cells (those carrying the `kukeon.io/config` label), `-` for cells without lineage where the reconciler's OutOfSync detection (#830) does not apply.
- Adds a `DIVERGENCE` column under a new `-o wide` mode showing the short divergence summary string (`OutOfSyncReason`) for OutOfSync cells. Mirrors the `-o wide` precedent in `kuke get image` so the CLI surface stays consistent.
- `-o yaml` / `-o json` already pass the full cell status through `shared.PrintYAML` / `shared.PrintJSON`, so the new `outOfSync` / `outOfSyncReason` / `outOfSyncError` fields surface without an extra projection step. The strict `omitempty` serialization keeps the no-lineage cells visually clean.
- Long help text on the command now documents the three SYNC values, the `-o wide` DIVERGENCE column, and the structured-output fields.

### Calls flagged for review

- **Four states, three SYNC values.** #830 introduced a fourth observable state alongside `Synced` / `OutOfSync` / no-lineage: `OutOfSyncError != ""` means divergence is undecidable (Blueprint missing, materialization error). The AC enumerates three values literally, and `internal/controller/reconcile_outofsync.go:55-59` says the SYNC column and `kuke restart cell` together "route the error case separately from a routine drift". I folded the error case into `OutOfSync` in the SYNC column (one actionable "look at this cell" signal) and surfaced the distinct error message as `error: <msg>` in the DIVERGENCE column under `-o wide`, plus `outOfSyncError` under `-o yaml/json`. Easy to lift to a fourth `Unknown` state if that read is wrong.
- **DIVERGENCE empty for non-OutOfSync cells renders as `-`.** AC says "empty for Synced or `-` cells" — I matched the established `cgroup == "" → "-"` convention used elsewhere in the same table so the column stays width-aligned. Trivial to switch to a true empty string if intended literally.
- **`-o wide` not added to `CompleteOutputFormat` autocomplete.** Consistent with how `kuke get image` documented `wide` in flag help text but did not extend the shared completion helper. Out of scope for this PR.
- **No coordination needed with #604.** That sibling (`-o wide` for `CONTAINERS (ready/total)` and `BRIDGE`) is open with no in-flight PR at this PR's filing time. Column placement here: SYNC sits between STATE and CGROUP in default; DIVERGENCE appends at the end of `-o wide`. #604's column additions can drop in alongside.

## Test plan

- [x] `make test` passes (full project test suite — exit 0).
- [x] `GOWORK=off go vet ./...` clean.
- [x] `GOWORK=off go build ./...` clean.
- [x] New test `TestNewCellCmd_SyncColumn` covers all AC cases:
  - Synced cell renders `Synced`; OutOfSync renders `OutOfSync`; no-lineage cell renders `-`.
  - `-o wide` adds the DIVERGENCE column with the reason string for OutOfSync cells.
  - `-o wide` surfaces `OutOfSyncError` as `error: <msg>`.
  - `-o yaml` passes `outOfSync: true` and `outOfSyncReason: ...` through unchanged.
- [ ] `make dev-init` smoke not run — diff is CLI-only (no daemon, build path, or `/opt/kukeon` changes), so the regression guard does not apply per CLAUDE.md.
- [ ] `golangci-lint` pre-commit hook deferred to CI — hook fails to build itself locally due to sandbox `proxy.golang.org` connectivity (documented env issue, see `env_golangci_lint_go125.md`); skipped with `SKIP=golangci-lint` (targeted, not `--no-verify`). CI will run it cleanly.

Closes #822