### PR TITLE
feat(cli): add kuke create config (scaffolding from --from-blueprint)

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -272,6 +272,16 @@ var (
 		"KUKE_CREATE_CONTAINER_PIDS_LIMIT",
 		"kuke/create/container/resources/pidsLimit",
 	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONFIG_NAME = DefineKV("KUKE_CREATE_CONFIG_NAME", "kuke/create/config/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONFIG_REALM = DefineKV("KUKE_CREATE_CONFIG_REALM", "kuke/create/config/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONFIG_SPACE = DefineKV("KUKE_CREATE_CONFIG_SPACE", "kuke/create/config/space", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONFIG_STACK = DefineKV("KUKE_CREATE_CONFIG_STACK", "kuke/create/config/stack", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CONFIG_BLUEPRINT = DefineKV("KUKE_CREATE_CONFIG_BLUEPRINT", "kuke/create/config/blueprint")
 
 	// Get command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/create/config/config.go
+++ b/cmd/kuke/create/config/config.go
@@ -1,0 +1,395 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package config implements `kuke create config <name> --from-blueprint <bp>`
+// (issue #817, child of the #814 epic:create umbrella). A CellConfig is always
+// derived from a CellBlueprint, so the subcommand reads the referenced
+// Blueprint from the daemon, introspects its declared scalar parameters and
+// structural repo/secret slots, and emits a starter Config YAML to stdout that
+// the operator fills and pipes to `kuke apply -f -`. Nothing is written to the
+// daemon — this is a scaffolding affordance, not a parallel write path.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/create/shared"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+// NewConfigCmd builds `kuke create config <name> --from-blueprint <bp>`. The
+// flag is required: a Config without a Blueprint reference is meaningless.
+func NewConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "config [name]",
+		Aliases: []string{"cfg"},
+		Short:   "Scaffold a kind: CellConfig from a CellBlueprint (stdout)",
+		Long: `Scaffold a CellConfig YAML from a CellBlueprint.
+
+Reads the referenced Blueprint from the daemon, introspects its declared scalar
+parameters and structural repo/secret slots, and emits a starter Config YAML to
+stdout with defaults pre-filled and TODO markers where the operator must fill
+required-no-default parameters and slot sources. The output is not written to
+the daemon — pipe it to ` + "`kuke apply -f -`" + ` after editing.`,
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runCreateConfig,
+	}
+
+	cmd.Flags().String("realm", "", "Realm that owns the config (also the default Blueprint lookup scope)")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONFIG_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+
+	cmd.Flags().String("space", "", "Space that owns the config (also the default Blueprint lookup scope)")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONFIG_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+
+	cmd.Flags().String("stack", "", "Stack that owns the config (also the default Blueprint lookup scope)")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONFIG_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+
+	cmd.Flags().String("from-blueprint", "", "Source CellBlueprint name (required)")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CONFIG_BLUEPRINT.ViperKey, cmd.Flags().Lookup("from-blueprint"))
+
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("from-blueprint", config.CompleteBlueprintNames)
+
+	return cmd
+}
+
+func runCreateConfig(cmd *cobra.Command, args []string) error {
+	name, err := shared.RequireNameArgOrDefault(
+		cmd,
+		args,
+		"config",
+		viper.GetString(config.KUKE_CREATE_CONFIG_NAME.ViperKey),
+	)
+	if err != nil {
+		return err
+	}
+
+	blueprintName := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CONFIG_BLUEPRINT.ViperKey))
+	if blueprintName == "" {
+		return errors.New("--from-blueprint is required (the source CellBlueprint to scaffold from)")
+	}
+
+	realm := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CONFIG_REALM.ViperKey))
+	if realm == "" {
+		realm = strings.TrimSpace(config.KUKE_CREATE_CONFIG_REALM.ValueOrDefault())
+	}
+	space := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CONFIG_SPACE.ViperKey))
+	if space == "" {
+		space = strings.TrimSpace(config.KUKE_CREATE_CONFIG_SPACE.ValueOrDefault())
+	}
+	stack := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CONFIG_STACK.ViperKey))
+	if stack == "" {
+		stack = strings.TrimSpace(config.KUKE_CREATE_CONFIG_STACK.ValueOrDefault())
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	lookup := v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  blueprintName,
+			Realm: realm,
+			Space: space,
+			Stack: stack,
+		},
+	}
+
+	res, err := client.GetBlueprint(cmd.Context(), lookup)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrBlueprintNotFound) {
+			return notFoundError(blueprintName, realm, space, stack)
+		}
+		return err
+	}
+	if !res.MetadataExists {
+		return notFoundError(blueprintName, realm, space, stack)
+	}
+
+	return emitConfigYAML(cmd.OutOrStdout(), name, realm, space, stack, &res.Blueprint)
+}
+
+func notFoundError(name, realm, space, stack string) error {
+	return fmt.Errorf(
+		"%w (blueprint %q in scope realm=%q space=%q stack=%q)",
+		errdefs.ErrBlueprintNotFound, name, realm, space, stack,
+	)
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.DaemonClientFromCmd(cmd)
+}
+
+// emitConfigYAML renders the CellConfig scaffold. The output is hand-formatted
+// (rather than yaml.Marshal'd from a CellConfigDoc) so it can carry inline
+// `# TODO` comments next to the fields the operator must fill — yaml.v3's
+// struct marshaler cannot attach comments without dropping to its Node API,
+// which would obscure the simple shape we emit here.
+func emitConfigYAML(out io.Writer, configName, realm, space, stack string, bp *v1beta1.CellBlueprintDoc) error {
+	var b strings.Builder
+
+	b.WriteString("apiVersion: ")
+	b.WriteString(string(v1beta1.APIVersionV1Beta1))
+	b.WriteString("\n")
+	b.WriteString("kind: ")
+	b.WriteString(string(v1beta1.KindCellConfig))
+	b.WriteString("\n")
+
+	b.WriteString("metadata:\n")
+	fmt.Fprintf(&b, "  name: %s\n", yamlScalar(configName))
+	fmt.Fprintf(&b, "  realm: %s\n", yamlScalar(realm))
+	if space != "" {
+		fmt.Fprintf(&b, "  space: %s\n", yamlScalar(space))
+	}
+	if stack != "" {
+		fmt.Fprintf(&b, "  stack: %s\n", yamlScalar(stack))
+	}
+
+	b.WriteString("spec:\n")
+
+	// Blueprint reference: copy the scope from the resolved Blueprint document
+	// so the emitted YAML records exactly where GetBlueprint resolved (and so a
+	// cross-scope reference is preserved verbatim — see CellConfigBlueprintRef's
+	// docstring: a Config may instantiate a Blueprint owned by another scope).
+	b.WriteString("  blueprint:\n")
+	fmt.Fprintf(&b, "    name: %s\n", yamlScalar(bp.Metadata.Name))
+	fmt.Fprintf(&b, "    realm: %s\n", yamlScalar(bp.Metadata.Realm))
+	if bp.Metadata.Space != "" {
+		fmt.Fprintf(&b, "    space: %s\n", yamlScalar(bp.Metadata.Space))
+	}
+	if bp.Metadata.Stack != "" {
+		fmt.Fprintf(&b, "    stack: %s\n", yamlScalar(bp.Metadata.Stack))
+	}
+
+	writeValues(&b, bp.Spec.Parameters)
+	writeRepoSlots(&b, bp.Spec.Cell.Containers)
+	writeSecretSlots(&b, bp.Spec.Cell.Containers)
+
+	_, err := io.WriteString(out, b.String())
+	return err
+}
+
+func writeValues(b *strings.Builder, params []v1beta1.CellProfileParameter) {
+	if len(params) == 0 {
+		b.WriteString("  values: {}\n")
+		return
+	}
+	b.WriteString("  values:\n")
+	for _, p := range params {
+		switch {
+		case p.Default != nil:
+			fmt.Fprintf(b, "    %s: %s\n", p.Name, yamlScalar(*p.Default))
+		case p.Required:
+			fmt.Fprintf(b, "    %s: \"\" # TODO (required, no default)\n", p.Name)
+		default:
+			fmt.Fprintf(b, "    %s: \"\" # optional (no default)\n", p.Name)
+		}
+	}
+}
+
+// repoSlot summarises one structural repo slot the Blueprint declares. The slot
+// is identified by name across all containers (ValidateSlotFill matches by
+// name, OR-ing required across declarations); we collapse same-named entries
+// the same way so the emitted Config has at most one fill per slot name.
+type repoSlot struct {
+	Name       string
+	Required   bool
+	Containers []string
+}
+
+func writeRepoSlots(b *strings.Builder, containers []v1beta1.BlueprintContainer) {
+	order, slots := collectRepoSlots(containers)
+	if len(order) == 0 {
+		return
+	}
+	b.WriteString("  repos:\n")
+	for _, name := range order {
+		s := slots[name]
+		fmt.Fprintf(b, "    %s: # %s repo slot (container %s)\n",
+			name, requiredLabel(s.Required), joinQuoted(s.Containers))
+		b.WriteString("      url: \"\" # TODO\n")
+	}
+}
+
+func collectRepoSlots(containers []v1beta1.BlueprintContainer) ([]string, map[string]*repoSlot) {
+	slots := map[string]*repoSlot{}
+	order := []string{}
+	for _, c := range containers {
+		for _, r := range c.Repos {
+			if strings.TrimSpace(r.URL) != "" {
+				continue // inline url is scalar-mode, not a fillable slot
+			}
+			name := strings.TrimSpace(r.Name)
+			if name == "" {
+				continue
+			}
+			if existing, ok := slots[name]; ok {
+				existing.Required = existing.Required || r.Required
+				existing.Containers = append(existing.Containers, c.ID)
+				continue
+			}
+			slots[name] = &repoSlot{Name: name, Required: r.Required, Containers: []string{c.ID}}
+			order = append(order, name)
+		}
+	}
+	return order, slots
+}
+
+type secretSlotEntry struct {
+	Name       string
+	Required   bool
+	Containers []string
+	// Mode/EnvName/MountPath capture the consumption side from the *first*
+	// declaration; later declarations of the same slot name across containers
+	// only widen Required (matching ValidateSlotFill's per-name aggregation).
+	Mode      string
+	EnvName   string
+	MountPath string
+}
+
+func writeSecretSlots(b *strings.Builder, containers []v1beta1.BlueprintContainer) {
+	order, slots := collectSecretSlots(containers)
+	if len(order) == 0 {
+		return
+	}
+	b.WriteString("  secrets:\n")
+	for _, name := range order {
+		s := slots[name]
+		fmt.Fprintf(b, "    %s: # %s secret slot (container %s, %s)\n",
+			name, requiredLabel(s.Required), joinQuoted(s.Containers), consumptionDescription(s))
+		b.WriteString("      secretRef:\n")
+		b.WriteString("        name: \"\" # TODO\n")
+		b.WriteString("        realm: \"\" # TODO\n")
+	}
+}
+
+func collectSecretSlots(containers []v1beta1.BlueprintContainer) ([]string, map[string]*secretSlotEntry) {
+	slots := map[string]*secretSlotEntry{}
+	order := []string{}
+	for _, c := range containers {
+		for _, s := range c.Secrets {
+			name := strings.TrimSpace(s.Name)
+			if name == "" {
+				continue
+			}
+			if existing, ok := slots[name]; ok {
+				existing.Required = existing.Required || s.Required
+				existing.Containers = append(existing.Containers, c.ID)
+				continue
+			}
+			slots[name] = &secretSlotEntry{
+				Name:       name,
+				Required:   s.Required,
+				Containers: []string{c.ID},
+				Mode:       s.Mode,
+				EnvName:    s.EnvName,
+				MountPath:  s.MountPath,
+			}
+			order = append(order, name)
+		}
+	}
+	return order, slots
+}
+
+func consumptionDescription(s *secretSlotEntry) string {
+	mode := s.Mode
+	if mode == "" {
+		mode = v1beta1.BlueprintSecretModeEnv
+	}
+	switch mode {
+	case v1beta1.BlueprintSecretModeFile:
+		return fmt.Sprintf("file mount %q", s.MountPath)
+	default:
+		return fmt.Sprintf("env %q", s.EnvName)
+	}
+}
+
+func requiredLabel(required bool) string {
+	if required {
+		return "required"
+	}
+	return "optional"
+}
+
+func joinQuoted(names []string) string {
+	parts := make([]string, len(names))
+	for i, n := range names {
+		parts[i] = fmt.Sprintf("%q", n)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// yamlScalar formats a string scalar for the emitted YAML. Bare names made of
+// [A-Za-z0-9-_./] stay unquoted (matching how yaml.v3 round-trips them);
+// anything else — including reserved bare scalars like "true" or "null" that
+// YAML would type as bool/null — is double-quoted with strconv.Quote, whose
+// escape set (\\, \", \n, \t, \r, \uXXXX, \xHH) is a subset of YAML 1.2's
+// double-quoted scalar escapes.
+func yamlScalar(s string) string {
+	if s == "" {
+		return `""`
+	}
+	if needsQuoting(s) {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+func needsQuoting(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.' || r == '/':
+		default:
+			return true
+		}
+	}
+	return isReservedBareScalar(s)
+}
+
+func isReservedBareScalar(s string) bool {
+	switch strings.ToLower(s) {
+	case "true", "false", "yes", "no", "on", "off", "null", "~":
+		return true
+	}
+	return false
+}

--- a/cmd/kuke/create/config/config_test.go
+++ b/cmd/kuke/create/config/config_test.go
@@ -1,0 +1,469 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	configcmd "github.com/eminwux/kukeon/cmd/kuke/create/config"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+func TestNewConfigCmd_RequiresFromBlueprint(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd := configcmd.NewConfigCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(ctxWithFake(t, &fakeClient{}))
+
+	cmd.SetArgs([]string{"myconfig"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--from-blueprint is required") {
+		t.Fatalf("expected --from-blueprint required error, got %v", err)
+	}
+}
+
+func TestNewConfigCmd_BlueprintNotFound(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cases := []struct {
+		name string
+		fake *fakeClient
+	}{
+		{
+			name: "ErrBlueprintNotFound sentinel",
+			fake: &fakeClient{
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{}, errdefs.ErrBlueprintNotFound
+				},
+			},
+		},
+		{
+			name: "MetadataExists=false",
+			fake: &fakeClient{
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := configcmd.NewConfigCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetContext(ctxWithFake(t, tc.fake))
+			_ = cmd.Flags().Set("from-blueprint", "missing")
+			_ = cmd.Flags().Set("realm", "r1")
+			_ = cmd.Flags().Set("space", "s1")
+			_ = cmd.Flags().Set("stack", "st1")
+
+			cmd.SetArgs([]string{"myconfig"})
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, errdefs.ErrBlueprintNotFound) {
+				t.Fatalf("expected ErrBlueprintNotFound, got %v", err)
+			}
+			for _, want := range []string{`"missing"`, `realm="r1"`, `space="s1"`, `stack="st1"`} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error message missing %q\nGot: %v", want, err)
+				}
+			}
+		})
+	}
+}
+
+func TestNewConfigCmd_LookupScope(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var captured v1beta1.CellBlueprintMetadata
+	fake := &fakeClient{
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			captured = doc.Metadata
+			return kukeonv1.GetBlueprintResult{
+				Blueprint:      v1beta1.CellBlueprintDoc{Metadata: doc.Metadata},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+
+	cmd := configcmd.NewConfigCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(ctxWithFake(t, fake))
+
+	_ = cmd.Flags().Set("from-blueprint", "bp")
+	_ = cmd.Flags().Set("realm", "production")
+	_ = cmd.Flags().Set("space", "team-a")
+	_ = cmd.Flags().Set("stack", "web")
+
+	cmd.SetArgs([]string{"myconfig"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if captured.Name != "bp" {
+		t.Errorf("lookup name = %q, want %q", captured.Name, "bp")
+	}
+	if captured.Realm != "production" || captured.Space != "team-a" || captured.Stack != "web" {
+		t.Errorf("lookup scope = %+v, want realm=production space=team-a stack=web", captured)
+	}
+}
+
+func TestNewConfigCmd_EmitsParsableYAML(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cases := []struct {
+		name             string
+		blueprint        v1beta1.CellBlueprintDoc
+		wantContains     []string
+		wantNotContains  []string
+		wantTODORequired []string // parameter names expected to render as "TODO (required, no default)"
+		wantTODOOptional []string // parameter names expected to render as "optional (no default)"
+		wantDefaults     map[string]string
+		wantValuesBlock  string // exact text the values block must contain, or "" to skip
+	}{
+		{
+			name: "no parameters emits empty values map",
+			blueprint: v1beta1.CellBlueprintDoc{
+				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
+				Spec: v1beta1.CellBlueprintSpec{
+					Cell: v1beta1.BlueprintCellSpec{
+						Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "alpine"}},
+					},
+				},
+			},
+			wantContains: []string{"values: {}"},
+		},
+		{
+			name: "required-no-default emits TODO marker",
+			blueprint: v1beta1.CellBlueprintDoc{
+				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
+				Spec: v1beta1.CellBlueprintSpec{
+					Parameters: []v1beta1.CellProfileParameter{
+						{Name: "TOKEN", Required: true},
+					},
+					Cell: v1beta1.BlueprintCellSpec{
+						Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "alpine"}},
+					},
+				},
+			},
+			wantTODORequired: []string{"TOKEN"},
+		},
+		{
+			name: "all-optional with defaults pre-fills",
+			blueprint: v1beta1.CellBlueprintDoc{
+				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
+				Spec: v1beta1.CellBlueprintSpec{
+					Parameters: []v1beta1.CellProfileParameter{
+						{Name: "PORT", Default: ptr("5432")},
+						{Name: "ENV", Default: ptr("production")},
+						{Name: "TAGS", Default: ptr("a,b c")},
+					},
+					Cell: v1beta1.BlueprintCellSpec{
+						Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "alpine"}},
+					},
+				},
+			},
+			wantDefaults: map[string]string{"PORT": "5432", "ENV": "production", "TAGS": `"a,b c"`},
+		},
+		{
+			name: "optional-no-default carries hint comment",
+			blueprint: v1beta1.CellBlueprintDoc{
+				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
+				Spec: v1beta1.CellBlueprintSpec{
+					Parameters: []v1beta1.CellProfileParameter{
+						{Name: "EXTRA"},
+					},
+					Cell: v1beta1.BlueprintCellSpec{
+						Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "alpine"}},
+					},
+				},
+			},
+			wantTODOOptional: []string{"EXTRA"},
+		},
+		{
+			name: "repo slot emits TODO under spec.repos",
+			blueprint: v1beta1.CellBlueprintDoc{
+				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
+				Spec: v1beta1.CellBlueprintSpec{
+					Cell: v1beta1.BlueprintCellSpec{
+						Containers: []v1beta1.BlueprintContainer{
+							{
+								ID:    "main",
+								Image: "alpine",
+								Repos: []v1beta1.ContainerRepo{
+									{Name: "project", Target: "/src/project", Required: true}, // url empty → slot
+									{
+										Name:   "vendored",
+										Target: "/src/vendored",
+										URL:    "git@x:y.git",
+									}, // inline url, not a slot
+								},
+							},
+						},
+					},
+				},
+			},
+			wantContains: []string{
+				"repos:",
+				"project: # required repo slot (container \"main\")",
+				`url: ""`,
+				"# TODO",
+			},
+			wantNotContains: []string{"vendored:"}, // inline-url repo is not a slot, must not appear
+		},
+		{
+			name: "secret slot emits TODO under spec.secrets with consumption hint",
+			blueprint: v1beta1.CellBlueprintDoc{
+				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
+				Spec: v1beta1.CellBlueprintSpec{
+					Cell: v1beta1.BlueprintCellSpec{
+						Containers: []v1beta1.BlueprintContainer{
+							{
+								ID:    "main",
+								Image: "alpine",
+								Secrets: []v1beta1.BlueprintSecretSlot{
+									{Name: "api-token", Mode: "env", EnvName: "API_TOKEN", Required: true},
+									{Name: "tls-cert", Mode: "file", MountPath: "/etc/tls/cert.pem"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantContains: []string{
+				"secrets:",
+				`api-token: # required secret slot (container "main", env "API_TOKEN")`,
+				`tls-cert: # optional secret slot (container "main", file mount "/etc/tls/cert.pem")`,
+				"secretRef:",
+				`name: "" # TODO`,
+				`realm: "" # TODO`,
+			},
+		},
+		{
+			name: "duplicate slot name across containers collapses to one entry (required wins)",
+			blueprint: v1beta1.CellBlueprintDoc{
+				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
+				Spec: v1beta1.CellBlueprintSpec{
+					Cell: v1beta1.BlueprintCellSpec{
+						Containers: []v1beta1.BlueprintContainer{
+							{
+								ID:    "first",
+								Image: "alpine",
+								Secrets: []v1beta1.BlueprintSecretSlot{
+									{Name: "shared", Mode: "env", EnvName: "SHARED"},
+								},
+							},
+							{
+								ID:    "second",
+								Image: "alpine",
+								Secrets: []v1beta1.BlueprintSecretSlot{
+									{Name: "shared", Mode: "env", EnvName: "SHARED", Required: true},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantContains: []string{
+				`shared: # required secret slot (container "first", "second", env "SHARED")`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			fake := &fakeClient{
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{Blueprint: tc.blueprint, MetadataExists: true}, nil
+				},
+			}
+
+			cmd := configcmd.NewConfigCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetContext(ctxWithFake(t, fake))
+			_ = cmd.Flags().Set("from-blueprint", tc.blueprint.Metadata.Name)
+			_ = cmd.Flags().Set("realm", tc.blueprint.Metadata.Realm)
+
+			cmd.SetArgs([]string{"myconfig"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			out := buf.String()
+
+			for _, want := range tc.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\nGot:\n%s", want, out)
+				}
+			}
+			for _, unwanted := range tc.wantNotContains {
+				if strings.Contains(out, unwanted) {
+					t.Errorf("output unexpectedly contains %q\nGot:\n%s", unwanted, out)
+				}
+			}
+			for _, name := range tc.wantTODORequired {
+				wantLine := name + ": \"\" # TODO (required, no default)"
+				if !strings.Contains(out, wantLine) {
+					t.Errorf("missing required-TODO marker for %q\nWanted line: %q\nGot:\n%s", name, wantLine, out)
+				}
+			}
+			for _, name := range tc.wantTODOOptional {
+				wantLine := name + ": \"\" # optional (no default)"
+				if !strings.Contains(out, wantLine) {
+					t.Errorf("missing optional hint for %q\nWanted line: %q\nGot:\n%s", name, wantLine, out)
+				}
+			}
+			for key, val := range tc.wantDefaults {
+				wantLine := "    " + key + ": " + val + "\n"
+				if !strings.Contains(out, wantLine) {
+					t.Errorf("missing default for %q\nWanted line: %q\nGot:\n%s", key, wantLine, out)
+				}
+			}
+
+			// Round-trip: every emitted scaffold must parse cleanly through the
+			// same loader `kuke apply -f` uses, as a CellConfig document.
+			doc, err := parser.ParseDocument(0, buf.Bytes())
+			if err != nil {
+				t.Fatalf("ParseDocument failed on emitted scaffold: %v\nYAML:\n%s", err, out)
+			}
+			if doc.Kind != v1beta1.KindCellConfig {
+				t.Fatalf("parsed kind = %q, want %q", doc.Kind, v1beta1.KindCellConfig)
+			}
+			if doc.CellConfigDoc == nil {
+				t.Fatalf("expected CellConfigDoc, got nil")
+			}
+			if doc.CellConfigDoc.Metadata.Name != "myconfig" {
+				t.Errorf("parsed metadata.name = %q, want %q", doc.CellConfigDoc.Metadata.Name, "myconfig")
+			}
+			if doc.CellConfigDoc.Spec.Blueprint.Name != tc.blueprint.Metadata.Name {
+				t.Errorf("parsed spec.blueprint.name = %q, want %q",
+					doc.CellConfigDoc.Spec.Blueprint.Name, tc.blueprint.Metadata.Name)
+			}
+			if doc.CellConfigDoc.Spec.Blueprint.Realm != tc.blueprint.Metadata.Realm {
+				t.Errorf("parsed spec.blueprint.realm = %q, want %q",
+					doc.CellConfigDoc.Spec.Blueprint.Realm, tc.blueprint.Metadata.Realm)
+			}
+		})
+	}
+}
+
+func TestNewConfigCmd_BlueprintRefMatchesResolvedScope(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// Cross-scope reference: operator asks --realm=consumer, but the Blueprint
+	// returned by GetBlueprint lives in realm=shared. The emitted spec.blueprint
+	// must record where the Blueprint actually lives (the resolved scope), not
+	// the lookup-request scope — see CellConfigBlueprintRef's docstring about
+	// cross-scope references.
+	bp := v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{Name: "shared-bp", Realm: "shared", Space: "platform"},
+		Spec: v1beta1.CellBlueprintSpec{
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "alpine"}},
+			},
+		},
+	}
+	fake := &fakeClient{
+		getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			// Daemon returns the canonical Blueprint with its own metadata scope.
+			return kukeonv1.GetBlueprintResult{Blueprint: bp, MetadataExists: true}, nil
+		},
+	}
+
+	cmd := configcmd.NewConfigCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(ctxWithFake(t, fake))
+	_ = cmd.Flags().Set("from-blueprint", "shared-bp")
+	_ = cmd.Flags().Set("realm", "consumer")
+
+	cmd.SetArgs([]string{"myconfig"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	doc, err := parser.ParseDocument(0, buf.Bytes())
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v\n%s", err, buf.String())
+	}
+
+	// Config's own scope is the operator's request.
+	if doc.CellConfigDoc.Metadata.Realm != "consumer" {
+		t.Errorf("metadata.realm = %q, want %q", doc.CellConfigDoc.Metadata.Realm, "consumer")
+	}
+	// Blueprint ref records the Blueprint's actual scope, not the request's.
+	if doc.CellConfigDoc.Spec.Blueprint.Realm != "shared" {
+		t.Errorf("spec.blueprint.realm = %q, want %q", doc.CellConfigDoc.Spec.Blueprint.Realm, "shared")
+	}
+	if doc.CellConfigDoc.Spec.Blueprint.Space != "platform" {
+		t.Errorf("spec.blueprint.space = %q, want %q", doc.CellConfigDoc.Spec.Blueprint.Space, "platform")
+	}
+}
+
+func ctxWithFake(t *testing.T, fake *fakeClient) context.Context {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	return context.WithValue(ctx, configcmd.MockControllerKey{}, kukeonv1.Client(fake))
+}
+
+func ptr(s string) *string { return &s }
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getBlueprintFn func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error)
+}
+
+func (f *fakeClient) GetBlueprint(
+	_ context.Context, doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.GetBlueprintResult, error) {
+	if f.getBlueprintFn == nil {
+		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")
+	}
+	return f.getBlueprintFn(doc)
+}

--- a/cmd/kuke/create/create.go
+++ b/cmd/kuke/create/create.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	cellcmd "github.com/eminwux/kukeon/cmd/kuke/create/cell"
+	configcmd "github.com/eminwux/kukeon/cmd/kuke/create/config"
 	containercmd "github.com/eminwux/kukeon/cmd/kuke/create/container"
 	realmcmd "github.com/eminwux/kukeon/cmd/kuke/create/realm"
 	spacecmd "github.com/eminwux/kukeon/cmd/kuke/create/space"
@@ -34,7 +35,7 @@ func NewCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Aliases: []string{"c"},
-		Short:   "Create Kukeon resources (realm, space, stack, cell, container)",
+		Short:   "Create Kukeon resources (realm, space, stack, cell, container, config)",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
@@ -48,6 +49,7 @@ func NewCreateCmd() *cobra.Command {
 		stackcmd.NewStackCmd(),
 		cellcmd.NewCellCmd(),
 		containercmd.NewContainerCmd(),
+		configcmd.NewConfigCmd(),
 	)
 
 	return cmd
@@ -55,7 +57,7 @@ func NewCreateCmd() *cobra.Command {
 
 // completeCreateSubcommands provides shell completion for create subcommand names.
 func completeCreateSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container"}
+	subcommands := []string{"realm", "space", "stack", "cell", "container", "config"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/create/create_test.go
+++ b/cmd/kuke/create/create_test.go
@@ -41,7 +41,7 @@ func TestNewCreateCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Create Kukeon resources (realm, space, stack, cell, container)"
+				expected := "Create Kukeon resources (realm, space, stack, cell, container, config)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -81,6 +81,7 @@ func TestNewCreateCmdRegistersSubcommands(t *testing.T) {
 		{name: "stack"},
 		{name: "cell"},
 		{name: "container"},
+		{name: "config"},
 	}
 
 	for _, tt := range tests {
@@ -103,7 +104,7 @@ func TestNewCreateCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container"}
+	expected := []string{"realm", "space", "stack", "cell", "container", "config"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}
@@ -123,7 +124,7 @@ func TestNewCreateCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test prefix filtering
 	filtered, _ := cmd.ValidArgsFunction(cmd, []string{}, "c")
-	expectedFiltered := []string{"cell", "container"}
+	expectedFiltered := []string{"cell", "container", "config"}
 	if len(filtered) != len(expectedFiltered) {
 		t.Fatalf("expected %d filtered completions, got %d", len(expectedFiltered), len(filtered))
 	}


### PR DESCRIPTION
## Summary

- New scaffolding subcommand `kuke create config <name> --from-blueprint <bp>` (umbrella #814 child).
- Reads the named CellBlueprint from daemon storage via `client.GetBlueprint` in the scope set by `--realm/--space/--stack`, introspects its declared scalar parameters and structural repo/secret slots, and emits a starter CellConfig YAML to stdout. No daemon writes — pipe to `kuke apply -f -` after editing.
- Pre-fills `spec.values` with each parameter's Blueprint default; required-no-default params render as `KEY: "" # TODO (required, no default)`, optional-no-default as `KEY: "" # optional (no default)`. Structural repo slots (a Blueprint repo with no inline `url`) and secret slots emit TODO entries under `spec.repos` / `spec.secrets`; the consumption side (`env "NAME"` vs `file mount "/path"`) is surfaced in the inline comment so the operator can author the source side without re-reading the Blueprint.
- Slot-name collisions across containers collapse to one Config entry per name (matching `cellconfig.ValidateSlotFill`'s by-name aggregation): containers are listed in the comment, required = OR of all declarations.
- `spec.blueprint` records the *resolved* Blueprint's scope (`bp.Metadata.Realm/Space/Stack`), not the lookup-request scope — preserves cross-scope refs verbatim per the `CellConfigBlueprintRef` docstring.
- Wires `--from-blueprint` shell completion to `CompleteBlueprintNames`; subcommand registered on the `kuke create` parent and in `completeCreateSubcommands`.

## Design notes

- **Hand-formatted YAML.** Emitted as `strings.Builder` output rather than `yaml.Marshal(CellConfigDoc{...})` so the inline `# TODO` markers land next to the right fields — yaml.v3's struct marshaler cannot attach comments without dropping to its Node API, which would obscure the simple shape. Every generated scaffold is round-tripped through `parser.ParseDocument` in tests to verify it parses cleanly as a `kind: CellConfig`.
- **Default scope mirrors `kuke create cell`.** New `KUKE_CREATE_CONFIG_*` env vars in `cmd/config/env.go` (realm/space/stack default to `"default"`; name and blueprint unset). If a Blueprint lives in a non-default scope, the operator passes `--realm`/`--space`/`--stack` to widen the lookup. The cell-style symmetric defaulting reads as "create config" looking like "create cell", at the cost of forcing explicit `--space=""` when scoping at realm level only — acceptable for a scaffolding affordance whose output is operator-edited anyway.
- **Slot fill shape for secrets.** Each emitted `spec.secrets.<slot>` entry stubs `secretRef: {name: "" # TODO, realm: "" # TODO}`. The fill ref is a `ContainerSecretRef`, which carries optional `space`/`stack`/`cell` coordinates as well; we emit only the always-required pair to keep the scaffold minimal and let the operator add deeper coordinates as needed.
- **Lookup error.** `ErrBlueprintNotFound` (or `MetadataExists=false`) renders as `"blueprint \"X\" not found (scope realm=... space=... stack=...)"` so the operator sees both the name and where we looked.

## Test plan

- [x] `make test` — full root + kukebuild test suites pass (GOWORK=off via Makefile).
- [x] `GOWORK=off go vet ./...` clean.
- [x] `GOWORK=off go build ./...` clean.
- [x] `pre-commit run --files <changed>` clean (gofmt, golangci-lint, addlicense, prettier).
- [x] `cmd/kuke/create/config/config_test.go` covers: `--from-blueprint` required; `ErrBlueprintNotFound` and `MetadataExists=false` both surface a friendly scoped error; lookup scope flows from `--realm/--space/--stack`; no parameters → `values: {}`; required-no-default → TODO marker; defaults pre-filled (including a value with a comma + space that triggers double-quoting); optional-no-default hint; repo slot emits TODO (inline-url repo excluded); secret slot emits TODO with consumption hint (env vs file); duplicate slot name across containers collapses with required = OR; cross-scope blueprint ref preserves the resolved scope, not the requested one. Each scaffold is round-tripped through `parser.ParseDocument` to assert it parses as `kind: CellConfig`.
- [x] `cmd/kuke/create/create_test.go` updated to include the new `config` subcommand in registration + autocomplete assertions.
- [x] `./kuke create config --help` renders the long description, the four flags (with `--from-blueprint` marked required in the description), and the `cfg` alias.
- [ ] `make dev-init` host smoke — not run; this change is purely client-side (CLI verb composing an existing `GetBlueprint` RPC), no daemon code or `/opt/kukeon` reads/writes change.

Closes #817