### PR TITLE
feat(cli): add kuke create cell --from-blueprint and --from-config (materialise-without-start)

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -190,6 +190,12 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CELL_STACK = DefineKV("KUKE_CREATE_CELL_STACK", "kuke/create/cell/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CELL_FROM_BLUEPRINT = DefineKV("KUKE_CREATE_CELL_FROM_BLUEPRINT", "kuke/create/cell/from-blueprint")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CELL_FROM_CONFIG = DefineKV("KUKE_CREATE_CELL_FROM_CONFIG", "kuke/create/cell/from-config")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_CELL_PARAM_FILE = DefineKV("KUKE_CREATE_CELL_PARAM_FILE", "kuke/create/cell/param-file")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CONTAINER_NAME = DefineKV("KUKE_CREATE_CONTAINER_NAME", "kuke/create/container/name")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CONTAINER_REALM = DefineKV("KUKE_CREATE_CONTAINER_REALM", "kuke/create/container/realm", "default")

--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -17,12 +17,18 @@
 package cell
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/create/shared"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/cellprofile"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
@@ -34,9 +40,31 @@ type MockControllerKey struct{}
 
 func NewCellCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "cell [name]",
-		Aliases:       []string{"ce"},
-		Short:         "Create or reconcile a cell within a stack",
+		Use:     "cell [name]",
+		Aliases: []string{"ce"},
+		Short:   "Create a cell within a stack (empty shell, --from-blueprint, or --from-config)",
+		Long: "Create a cell within a stack. Three modes:\n\n" +
+			"  - `kuke create cell <name>` (no source flag) — creates an empty Cell " +
+			"shell (name + scope only, no containers). Workflow C: follow with " +
+			"`kuke create container -c <name> --image ...` and `kuke start <name>`.\n" +
+			"  - `kuke create cell <name> --from-blueprint <bp> [--param k=v] [--param-file path]` — " +
+			"resolves the daemon-stored CellBlueprint, applies scalar params, " +
+			"materialises the full Cell record (containers and all), and " +
+			"persists it in a **stopped** state. Run `kuke start <name>` to " +
+			"start it. Differs from `kuke run -b` (materialise + start + attach) " +
+			"and `kuke apply -b` (reconcile + start) by leaving the cell stopped " +
+			"for later inspection or hand-off.\n" +
+			"  - `kuke create cell <name> --from-config <cfg>` — resolves the " +
+			"daemon-stored CellConfig and its referenced Blueprint, applies the " +
+			"Config's spec.values + repo/secret slot fills, materialises the " +
+			"Cell record, and persists it in a **stopped** state. Run " +
+			"`kuke start <name>` to start it. Differs from `kuke run <cfg>` " +
+			"(materialise + start + attach) and `kuke apply -c <cfg>` (reconcile " +
+			"+ start) by leaving the cell stopped.\n\n" +
+			"--from-blueprint and --from-config are mutually exclusive. --param " +
+			"and --param-file are valid with --from-blueprint (mirroring " +
+			"`kuke run -b`); they are rejected with --from-config because a " +
+			"CellConfig carries its own values (edit the Config instead).",
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -52,15 +80,67 @@ func NewCellCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Stack that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_CREATE_CELL_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 
+	cmd.Flags().String("from-blueprint", "",
+		"Materialise the cell from a daemon-stored CellBlueprint, resolved from the scope named "+
+			"by --realm/--space/--stack. The cell record is persisted in a stopped state; run "+
+			"`kuke start <name>` to start it. Mutually exclusive with --from-config.")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CELL_FROM_BLUEPRINT.ViperKey, cmd.Flags().Lookup("from-blueprint"))
+
+	cmd.Flags().String("from-config", "",
+		"Materialise the cell from a daemon-stored CellConfig (resolves the Config's referenced "+
+			"Blueprint, applies the Config's spec.values and repo/secret slot fills). The cell "+
+			"record is persisted in a stopped state; run `kuke start <name>` to start it. "+
+			"Mutually exclusive with --from-blueprint.")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CELL_FROM_CONFIG.ViperKey, cmd.Flags().Lookup("from-config"))
+
+	cmd.Flags().StringArray("param", nil,
+		"Scalar parameter override as KEY=VALUE; repeatable. Valid with --from-blueprint. "+
+			"Each KEY must be declared in spec.parameters[]. Wins over the parameter's default "+
+			"and over --param-file when both set the same key. Rejected with --from-config: a "+
+			"CellConfig carries its own spec.values, edit the Config instead.")
+
+	cmd.Flags().String("param-file", "",
+		"File of KEY=VALUE lines whose values seed scalar parameters; one per line, "+
+			"`#` starts a comment. Same declaration rules as --param. CLI --param wins on "+
+			"duplicate keys. Rejected with --from-config (same reason as --param).")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CELL_PARAM_FILE.ViperKey, cmd.Flags().Lookup("param-file"))
+
+	cmd.MarkFlagsMutuallyExclusive("from-blueprint", "from-config")
+
 	// Register autocomplete functions for flags
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+	_ = cmd.RegisterFlagCompletionFunc("from-blueprint", config.CompleteBlueprintNames)
+	_ = cmd.RegisterFlagCompletionFunc("from-config", config.CompleteConfigNames)
 
 	return cmd
 }
 
-func runCreateCell(cmd *cobra.Command, args []string) error {
+// createCellFlags is the validated bundle of flag values runCreateCell consumes
+// after parseCreateCellFlags.
+type createCellFlags struct {
+	name          string
+	realm         string
+	space         string
+	stack         string
+	blueprintName string
+	configName    string
+	paramArgs     []string
+	paramFile     string
+}
+
+// parseCreateCellFlags validates the flag combinations and trims values. The
+// cobra-side mutex enforces --from-blueprint vs --from-config; this routine
+// also rejects --param/--param-file when --from-config is set (a CellConfig
+// carries its own spec.values, parity with `kuke run -c`).
+func parseCreateCellFlags(cmd *cobra.Command, args []string) (createCellFlags, error) {
+	flags := createCellFlags{
+		blueprintName: strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_FROM_BLUEPRINT.ViperKey)),
+		configName:    strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_FROM_CONFIG.ViperKey)),
+		paramFile:     strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_PARAM_FILE.ViperKey)),
+	}
+
 	name, err := shared.RequireNameArgOrDefault(
 		cmd,
 		args,
@@ -68,38 +148,80 @@ func runCreateCell(cmd *cobra.Command, args []string) error {
 		viper.GetString(config.KUKE_CREATE_CELL_NAME.ViperKey),
 	)
 	if err != nil {
+		return createCellFlags{}, err
+	}
+	flags.name = name
+
+	flags.realm = strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_REALM.ViperKey))
+	if flags.realm == "" {
+		flags.realm = strings.TrimSpace(config.KUKE_CREATE_CELL_REALM.ValueOrDefault())
+	}
+
+	flags.space = strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_SPACE.ViperKey))
+	if flags.space == "" {
+		flags.space = strings.TrimSpace(config.KUKE_CREATE_CELL_SPACE.ValueOrDefault())
+	}
+
+	flags.stack = strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_STACK.ViperKey))
+	if flags.stack == "" {
+		flags.stack = strings.TrimSpace(config.KUKE_CREATE_CELL_STACK.ValueOrDefault())
+	}
+
+	paramArgs, err := cmd.Flags().GetStringArray("param")
+	if err != nil {
+		return createCellFlags{}, err
+	}
+	flags.paramArgs = paramArgs
+
+	if flags.configName != "" {
+		if len(flags.paramArgs) > 0 {
+			return createCellFlags{}, errors.New(
+				"--param is not valid with --from-config; a CellConfig carries its own spec.values (edit the Config instead)",
+			)
+		}
+		if flags.paramFile != "" {
+			return createCellFlags{}, errors.New(
+				"--param-file is not valid with --from-config; a CellConfig carries its own spec.values (edit the Config instead)",
+			)
+		}
+	}
+	return flags, nil
+}
+
+func runCreateCell(cmd *cobra.Command, args []string) error {
+	flags, err := parseCreateCellFlags(cmd, args)
+	if err != nil {
 		return err
 	}
-
-	realm := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_REALM.ViperKey))
-	if realm == "" {
-		realm = strings.TrimSpace(config.KUKE_CREATE_CELL_REALM.ValueOrDefault())
-	}
-
-	space := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_SPACE.ViperKey))
-	if space == "" {
-		space = strings.TrimSpace(config.KUKE_CREATE_CELL_SPACE.ValueOrDefault())
-	}
-
-	stack := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_STACK.ViperKey))
-	if stack == "" {
-		stack = strings.TrimSpace(config.KUKE_CREATE_CELL_STACK.ValueOrDefault())
-	}
-
-	doc := v1beta1.NewCellDoc(&v1beta1.CellDoc{
-		Metadata: v1beta1.CellMetadata{Name: name},
-		Spec: v1beta1.CellSpec{
-			RealmID: realm,
-			SpaceID: space,
-			StackID: stack,
-		},
-	})
 
 	client, err := resolveClient(cmd)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = client.Close() }()
+
+	switch {
+	case flags.blueprintName != "":
+		return runFromBlueprint(cmd, client, flags)
+	case flags.configName != "":
+		return runFromConfig(cmd, client, flags)
+	default:
+		return runEmptyShell(cmd, client, flags)
+	}
+}
+
+// runEmptyShell preserves the pre-#818 behavior: create an empty Cell
+// shell (name + scope only, no containers). The daemon's CreateCell is
+// idempotent on an existing empty cell, so no pre-check is needed.
+func runEmptyShell(cmd *cobra.Command, client kukeonv1.Client, flags createCellFlags) error {
+	doc := v1beta1.NewCellDoc(&v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: flags.name},
+		Spec: v1beta1.CellSpec{
+			RealmID: flags.realm,
+			SpaceID: flags.space,
+			StackID: flags.stack,
+		},
+	})
 
 	result, err := client.CreateCell(cmd.Context(), *doc)
 	if err != nil {
@@ -108,6 +230,176 @@ func runCreateCell(cmd *cobra.Command, args []string) error {
 
 	printCellResult(cmd, result)
 	return nil
+}
+
+// runFromBlueprint resolves the named Blueprint, applies --param/--param-file,
+// materialises the Cell record, refuses on name collision against an existing
+// cell, then persists via MaterializeCell (no start). The operator runs
+// `kuke start <name>` to start it.
+//
+// Lookup scope follows the explicit-coordinate rule from
+// kukeshared.PickLookupRealm / ExplicitScope so realm-scoped Blueprints stay
+// findable when --space/--stack are not set.
+func runFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags createCellFlags) error {
+	cliParams, err := buildParamMap(flags)
+	if err != nil {
+		return err
+	}
+
+	lookup := v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  flags.blueprintName,
+			Realm: kukeshared.PickLookupRealm(cmd, &config.KUKE_CREATE_CELL_REALM),
+			Space: kukeshared.ExplicitScope(cmd, "space", &config.KUKE_CREATE_CELL_SPACE),
+			Stack: kukeshared.ExplicitScope(cmd, "stack", &config.KUKE_CREATE_CELL_STACK),
+		},
+	}
+	bpRes, err := client.GetBlueprint(cmd.Context(), lookup)
+	if err != nil {
+		return err
+	}
+	if !bpRes.MetadataExists {
+		return fmt.Errorf(
+			"%w (blueprint %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrBlueprintNotFound, lookup.Metadata.Name,
+			lookup.Metadata.Realm, lookup.Metadata.Space, lookup.Metadata.Stack,
+		)
+	}
+
+	resolved, err := cellblueprint.Resolve(bpRes.Blueprint, cliParams, os.LookupEnv)
+	if err != nil {
+		return err
+	}
+	cellDoc, err := cellblueprint.MaterializeWithName(resolved, flags.name)
+	if err != nil {
+		return err
+	}
+	overlayScope(&cellDoc, flags)
+
+	return materialiseAndPersist(cmd, client, cellDoc)
+}
+
+// runFromConfig resolves the named Config and its referenced Blueprint,
+// materialises the Cell record via cellconfig.Materialize (which applies
+// spec.values, repo/secret slot fills, the kukeon.io/config back-reference
+// label, and the StableName), refuses on name collision, then persists via
+// MaterializeCell (no start). Mirrors runFromBlueprint's scope-resolution
+// strategy.
+func runFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags createCellFlags) error {
+	cfgLookup := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  flags.configName,
+			Realm: kukeshared.PickLookupRealm(cmd, &config.KUKE_CREATE_CELL_REALM),
+			Space: kukeshared.ExplicitScope(cmd, "space", &config.KUKE_CREATE_CELL_SPACE),
+			Stack: kukeshared.ExplicitScope(cmd, "stack", &config.KUKE_CREATE_CELL_STACK),
+		},
+	}
+	cfgRes, err := client.GetConfig(cmd.Context(), cfgLookup)
+	if err != nil {
+		return err
+	}
+	if !cfgRes.MetadataExists {
+		return fmt.Errorf(
+			"%w (config %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrConfigNotFound, cfgLookup.Metadata.Name,
+			cfgLookup.Metadata.Realm, cfgLookup.Metadata.Space, cfgLookup.Metadata.Stack,
+		)
+	}
+
+	bpRef := cfgRes.Config.Spec.Blueprint
+	bpLookup := v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  bpRef.Name,
+			Realm: bpRef.Realm,
+			Space: bpRef.Space,
+			Stack: bpRef.Stack,
+		},
+	}
+	bpRes, err := client.GetBlueprint(cmd.Context(), bpLookup)
+	if err != nil {
+		return err
+	}
+	if !bpRes.MetadataExists {
+		return fmt.Errorf(
+			"%w (blueprint %q referenced by config %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrBlueprintNotFound, bpRef.Name, cfgRes.Config.Metadata.Name,
+			bpRef.Realm, bpRef.Space, bpRef.Stack,
+		)
+	}
+
+	cellDoc, err := cellconfig.MaterializeWithName(cfgRes.Config, bpRes.Blueprint, flags.name)
+	if err != nil {
+		return err
+	}
+	overlayScope(&cellDoc, flags)
+
+	return materialiseAndPersist(cmd, client, cellDoc)
+}
+
+// materialiseAndPersist runs the existence pre-check and persists the
+// materialised cell via MaterializeCell. Refuses if a cell with the same name
+// already lives at the target scope — silent attach-to-existing would mask the
+// spec divergence between the operator's chosen Blueprint/Config and whatever
+// the existing cell was materialised from.
+func materialiseAndPersist(cmd *cobra.Command, client kukeonv1.Client, cellDoc v1beta1.CellDoc) error {
+	pre, err := client.GetCell(cmd.Context(), cellDoc)
+	switch {
+	case err == nil && pre.MetadataExists:
+		return fmt.Errorf(
+			"cell %q already exists in realm=%q space=%q stack=%q; "+
+				"delete it with `kuke delete cell %s` (or update with `kuke apply -b/-c`) before re-materialising",
+			cellDoc.Metadata.Name,
+			cellDoc.Spec.RealmID, cellDoc.Spec.SpaceID, cellDoc.Spec.StackID,
+			cellDoc.Metadata.Name,
+		)
+	case err != nil && !errors.Is(err, errdefs.ErrCellNotFound):
+		return err
+	}
+
+	result, err := client.MaterializeCell(cmd.Context(), cellDoc)
+	if err != nil {
+		return err
+	}
+	printCellResult(cmd, result)
+	return nil
+}
+
+// overlayScope fills realm/space/stack coordinates on the materialised cell
+// from the CLI's --realm/--space/--stack flags when the Blueprint/Config
+// metadata left them empty (e.g., a realm-only blueprint materialised into a
+// fully-specified scope). The doc wins when it sets a value — mirrors
+// run.resolveCellLocation but scoped to the create flags' viper keys.
+func overlayScope(doc *v1beta1.CellDoc, flags createCellFlags) {
+	if strings.TrimSpace(doc.Spec.RealmID) == "" {
+		doc.Spec.RealmID = flags.realm
+	}
+	if strings.TrimSpace(doc.Spec.SpaceID) == "" {
+		doc.Spec.SpaceID = flags.space
+	}
+	if strings.TrimSpace(doc.Spec.StackID) == "" {
+		doc.Spec.StackID = flags.stack
+	}
+}
+
+// buildParamMap layers --param flags on top of --param-file contents.
+// Mirrors cmd/kuke/run.buildParamMap; kept local to avoid a cross-package
+// import for ~10 lines.
+func buildParamMap(flags createCellFlags) (map[string]string, error) {
+	var fileParams map[string]string
+	if flags.paramFile != "" {
+		fp, err := cellprofile.ParseParamFile(flags.paramFile)
+		if err != nil {
+			return nil, err
+		}
+		fileParams = fp
+	}
+	cliParams, err := cellprofile.ParseParamArgs(flags.paramArgs)
+	if err != nil {
+		return nil, err
+	}
+	return cellprofile.MergeParams(fileParams, cliParams), nil
 }
 
 func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {

--- a/cmd/kuke/create/cell/cell_test.go
+++ b/cmd/kuke/create/cell/cell_test.go
@@ -501,7 +501,11 @@ func TestNewCellCmdRunE(t *testing.T) {
 type fakeClient struct {
 	kukeonv1.FakeClient
 
-	createCellFn func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
+	createCellFn      func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
+	materializeCellFn func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
+	getCellFn         func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	getBlueprintFn    func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error)
+	getConfigFn       func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error)
 }
 
 func (f *fakeClient) CreateCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
@@ -509,6 +513,40 @@ func (f *fakeClient) CreateCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv
 		return kukeonv1.CreateCellResult{}, errors.New("unexpected CreateCell call")
 	}
 	return f.createCellFn(doc)
+}
+
+func (f *fakeClient) MaterializeCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+	if f.materializeCellFn == nil {
+		return kukeonv1.CreateCellResult{}, errors.New("unexpected MaterializeCell call")
+	}
+	return f.materializeCellFn(doc)
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn == nil {
+		// Default to "not found" so the existence pre-check sees a clean slate
+		// when a test doesn't care about it.
+		return kukeonv1.GetCellResult{MetadataExists: false}, errdefs.ErrCellNotFound
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) GetBlueprint(
+	_ context.Context, doc v1beta1.CellBlueprintDoc,
+) (kukeonv1.GetBlueprintResult, error) {
+	if f.getBlueprintFn == nil {
+		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")
+	}
+	return f.getBlueprintFn(doc)
+}
+
+func (f *fakeClient) GetConfig(
+	_ context.Context, doc v1beta1.CellConfigDoc,
+) (kukeonv1.GetConfigResult, error) {
+	if f.getConfigFn == nil {
+		return kukeonv1.GetConfigResult{}, errors.New("unexpected GetConfig call")
+	}
+	return f.getConfigFn(doc)
 }
 
 func newTestCommand() (*cobra.Command, *bytes.Buffer) {
@@ -551,5 +589,342 @@ func TestNewCellCmd_AutocompleteRegistration(t *testing.T) {
 	}
 	if stackFlag.Usage != "Stack that owns the cell" {
 		t.Errorf("unexpected stack flag usage: %q", stackFlag.Usage)
+	}
+
+	for _, name := range []string{"from-blueprint", "from-config", "param", "param-file"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected %q flag to exist", name)
+		}
+	}
+}
+
+// blueprintDoc returns a minimal CellBlueprintDoc the fake daemon can hand
+// back from GetBlueprint. One TAG parameter substitutes into the container
+// image so --param coverage has something to verify.
+func blueprintDoc() v1beta1.CellBlueprintDoc {
+	def := "latest"
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: "bp-realm",
+			Space: "bp-space",
+			Stack: "bp-stack",
+		},
+		Spec: v1beta1.CellBlueprintSpec{
+			Prefix:     "web",
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
+				},
+			},
+		},
+	}
+}
+
+// configDoc returns a CellConfigDoc that references the blueprint above with
+// one spec.values override. Same minimal shape used by cmd/kuke/run tests.
+func configDoc() v1beta1.CellConfigDoc {
+	return v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  "prod",
+			Realm: "cfg-realm",
+			Space: "cfg-space",
+			Stack: "cfg-stack",
+		},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{
+				Name:  "web",
+				Realm: "bp-realm",
+				Space: "bp-space",
+				Stack: "bp-stack",
+			},
+			Values: map[string]string{"TAG": "stable"},
+		},
+	}
+}
+
+// successResultFromDoc echoes the input doc back as a "successfully created
+// stopped cell" result for the MaterializeCell fake. Started=false mirrors
+// what the daemon-side controller.MaterializeCell produces.
+func successResultFromDoc(doc v1beta1.CellDoc) kukeonv1.CreateCellResult {
+	return kukeonv1.CreateCellResult{
+		Cell: doc, Created: true, MetadataExistsPost: true,
+		CgroupCreated: true, CgroupExistsPost: true,
+		RootContainerCreated: true, RootContainerExistsPost: true,
+		Started: false,
+		Containers: []kukeonv1.ContainerCreationOutcome{
+			{Name: "main", ExistsPost: true, Created: true},
+		},
+	}
+}
+
+func newTestExecCmd(t *testing.T, fc *fakeClient) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	cmd := cell.NewCellCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(&bytes.Buffer{})
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, cell.MockControllerKey{}, kukeonv1.Client(fc))
+	cmd.SetContext(ctx)
+	return cmd, out
+}
+
+func TestCreateCell_FromBlueprint_HappyPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var materializeCalled bool
+	var materializeDoc v1beta1.CellDoc
+	fc := &fakeClient{
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			if doc.Metadata.Name != "web" {
+				t.Errorf("GetBlueprint name=%q want web", doc.Metadata.Name)
+			}
+			if doc.Metadata.Realm != "bp-realm" {
+				t.Errorf("GetBlueprint realm=%q want bp-realm", doc.Metadata.Realm)
+			}
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			materializeCalled = true
+			materializeDoc = doc
+			return successResultFromDoc(doc), nil
+		},
+	}
+
+	cmd, out := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "bp-realm")
+	setFlag(t, cmd, "from-blueprint", "web")
+	setFlag(t, cmd, "param", "TAG=v9")
+	cmd.SetArgs([]string{"web-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !materializeCalled {
+		t.Fatal("MaterializeCell was not called")
+	}
+	if materializeDoc.Metadata.Name != "web-1" {
+		t.Errorf("materialised name=%q want web-1 (cell name pinned to positional arg)", materializeDoc.Metadata.Name)
+	}
+	if materializeDoc.Spec.RealmID != "bp-realm" {
+		t.Errorf("RealmID=%q want bp-realm (blueprint metadata wins)", materializeDoc.Spec.RealmID)
+	}
+	if got := materializeDoc.Spec.Containers[0].Image; got != "registry.example.com/web:v9" {
+		t.Errorf("image=%q want ${TAG} substituted to v9", got)
+	}
+	if !strings.Contains(out.String(), "containers: not started") {
+		t.Errorf("expected 'containers: not started' in output (materialise-but-don't-start); got:\n%s", out.String())
+	}
+}
+
+func TestCreateCell_FromBlueprint_NotFound_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "bp-realm")
+	setFlag(t, cmd, "from-blueprint", "ghost")
+	cmd.SetArgs([]string{"missing-cell"})
+
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, errdefs.ErrBlueprintNotFound) {
+		t.Fatalf("err=%v want ErrBlueprintNotFound", err)
+	}
+}
+
+func TestCreateCell_FromConfig_HappyPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var materializeCalled bool
+	var materializeDoc v1beta1.CellDoc
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			if doc.Metadata.Name != "prod" {
+				t.Errorf("GetConfig name=%q want prod", doc.Metadata.Name)
+			}
+			if doc.Metadata.Realm != "cfg-realm" {
+				t.Errorf("GetConfig realm=%q want cfg-realm", doc.Metadata.Realm)
+			}
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			if doc.Metadata.Name != "web" || doc.Metadata.Realm != "bp-realm" {
+				t.Errorf("GetBlueprint=%+v want web@bp-realm", doc.Metadata)
+			}
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			materializeCalled = true
+			materializeDoc = doc
+			return successResultFromDoc(doc), nil
+		},
+	}
+
+	cmd, out := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "cfg-realm")
+	setFlag(t, cmd, "from-config", "prod")
+	cmd.SetArgs([]string{"prod-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !materializeCalled {
+		t.Fatal("MaterializeCell was not called")
+	}
+	if materializeDoc.Metadata.Name != "prod-1" {
+		t.Errorf("materialised name=%q want prod-1", materializeDoc.Metadata.Name)
+	}
+	if materializeDoc.Spec.RealmID != "cfg-realm" {
+		t.Errorf("RealmID=%q want cfg-realm (Config metadata wins)", materializeDoc.Spec.RealmID)
+	}
+	if got := materializeDoc.Spec.Containers[0].Image; got != "registry.example.com/web:stable" {
+		t.Errorf("image=%q want ${TAG} substituted to stable from Config values", got)
+	}
+	if !strings.Contains(out.String(), "containers: not started") {
+		t.Errorf("expected 'containers: not started' in output; got:\n%s", out.String())
+	}
+}
+
+func TestCreateCell_FromConfig_NotFound_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "cfg-realm")
+	setFlag(t, cmd, "from-config", "ghost")
+	cmd.SetArgs([]string{"missing-cell"})
+
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, errdefs.ErrConfigNotFound) {
+		t.Fatalf("err=%v want ErrConfigNotFound", err)
+	}
+}
+
+func TestCreateCell_MutualExclusion_FromBlueprintAndFromConfig(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	cmd, _ := newTestExecCmd(t, &fakeClient{})
+	setFlag(t, cmd, "from-blueprint", "web")
+	setFlag(t, cmd, "from-config", "prod")
+	cmd.SetArgs([]string{"x"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --from-blueprint + --from-config combination")
+	}
+	// Cobra's MarkFlagsMutuallyExclusive emits "if any flags in the group ...
+	// none of the others can be" — anchor on the stable substring rather than
+	// the verbatim message so a cobra wording tweak doesn't false-flag this.
+	if !strings.Contains(err.Error(), "from-blueprint") || !strings.Contains(err.Error(), "from-config") {
+		t.Errorf("err=%v should name both --from-blueprint and --from-config", err)
+	}
+}
+
+func TestCreateCell_ParamRejectedWithFromConfig(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			t.Fatal("GetConfig must not be called when --param + --from-config is rejected")
+			return kukeonv1.GetConfigResult{}, nil
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "from-config", "prod")
+	setFlag(t, cmd, "param", "K=V")
+	cmd.SetArgs([]string{"x"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --param + --from-config combination")
+	}
+	if !strings.Contains(err.Error(), "--param is not valid with --from-config") {
+		t.Errorf("err=%v want '--param is not valid with --from-config'", err)
+	}
+}
+
+func TestCreateCell_NameCollision_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{MetadataExists: true}, nil
+		},
+		materializeCellFn: func(v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			t.Fatal("MaterializeCell must not be called when cell already exists")
+			return kukeonv1.CreateCellResult{}, nil
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "bp-realm")
+	setFlag(t, cmd, "from-blueprint", "web")
+	cmd.SetArgs([]string{"taken-name"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when cell name collides with existing cell")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("err=%v should mention the cell already exists", err)
+	}
+	if !strings.Contains(err.Error(), "kuke delete cell taken-name") {
+		t.Errorf("err=%v should point at `kuke delete cell taken-name`", err)
+	}
+}
+
+func TestCreateCell_EmptyShell_StillUsesCreateCell(t *testing.T) {
+	// Regression guard for AC #1: the empty-shell path (no --from-* flag)
+	// must continue to call CreateCell — *not* MaterializeCell — so the
+	// daemon's idempotent start step still runs for the pre-#818 workflow C
+	// (create cell → create container → start).
+	t.Cleanup(viper.Reset)
+
+	var createCalled bool
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			createCalled = true
+			if doc.Metadata.Name != "empty-1" {
+				t.Errorf("CreateCell name=%q want empty-1", doc.Metadata.Name)
+			}
+			return kukeonv1.CreateCellResult{
+				Cell: doc, Created: true, MetadataExistsPost: true,
+				CgroupCreated: true, CgroupExistsPost: true,
+				RootContainerCreated: true, RootContainerExistsPost: true, Started: true,
+			}, nil
+		},
+		materializeCellFn: func(v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			t.Fatal("empty-shell path must not call MaterializeCell")
+			return kukeonv1.CreateCellResult{}, nil
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "r")
+	setFlag(t, cmd, "space", "s")
+	setFlag(t, cmd, "stack", "k")
+	cmd.SetArgs([]string{"empty-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !createCalled {
+		t.Fatal("CreateCell was not called on the empty-shell path")
 	}
 }

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -150,14 +150,34 @@ func (c *Client) CreateStack(_ context.Context, doc v1beta1.StackDoc) (kukeonv1.
 }
 
 // CreateCell normalizes the external doc, delegates to the controller, and
-// reshapes the result back into external v1beta1 types.
+// reshapes the result back into external v1beta1 types. Starts the cell's
+// containers after creation; see MaterializeCell for the don't-start variant.
 func (c *Client) CreateCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+	return c.createCell(doc, c.ctrl.CreateCell)
+}
+
+// MaterializeCell normalizes the external doc, delegates to the controller's
+// MaterializeCell (which skips the StartCell step), and reshapes the result
+// back into external v1beta1 types. See kukeonv1.Client.MaterializeCell for
+// the contract.
+func (c *Client) MaterializeCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+	return c.createCell(doc, c.ctrl.MaterializeCell)
+}
+
+// createCell is the shared body for CreateCell and MaterializeCell. The
+// controllerFn argument picks between the start-after-create variant
+// (CreateCell) and the don't-start variant (MaterializeCell); the doc
+// normalisation and result reshape are identical for both.
+func (c *Client) createCell(
+	doc v1beta1.CellDoc,
+	controllerFn func(intmodel.Cell) (controller.CreateCellResult, error),
+) (kukeonv1.CreateCellResult, error) {
 	internal, version, err := apischeme.NormalizeCell(doc)
 	if err != nil {
 		return kukeonv1.CreateCellResult{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
 	}
 
-	res, err := c.ctrl.CreateCell(internal)
+	res, err := controllerFn(internal)
 	if err != nil {
 		return kukeonv1.CreateCellResult{}, err
 	}

--- a/internal/controller/create_cell.go
+++ b/internal/controller/create_cell.go
@@ -54,35 +54,53 @@ type ContainerCreationOutcome struct {
 	Created    bool
 }
 
-// CreateCell creates a new cell or ensures an existing cell's resources exist.
-// It returns a CreateCellResult and an error.
-// The CreateCellResult reports the state of cell resources before and after the operation,
-// indicating what was created vs what already existed, including container-level outcomes.
-// The error is returned if the cell name is required, the realm name is required,
-// the space name is required, the stack name is required, the cell cgroup does not exist,
-// the root container does not exist, or the cell creation fails.
+// CreateCell creates a new cell or ensures an existing cell's resources exist,
+// then starts the cell's containers. See createCellInternal for the full
+// contract.
 func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
-	var res CreateCellResult
+	return b.createCellInternal(cell, true)
+}
 
+// MaterializeCell creates a new cell record (or ensures an existing cell's
+// resources exist) without starting any container tasks. The resulting cell
+// is left in a stopped/created state; the operator runs `kuke start <name>`
+// to start it. Used by the CLI's `kuke create cell --from-blueprint` and
+// `--from-config` scaffolding modes (#818) — distinct from `kuke run -b/-c`
+// (materialise + start + attach) and `kuke apply -b/-c` (reconcile + start).
+func (b *Exec) MaterializeCell(cell intmodel.Cell) (CreateCellResult, error) {
+	return b.createCellInternal(cell, false)
+}
+
+// normalizeCellInputs validates the cell's required identity fields (name,
+// realm, space, stack, container IDs), trims them in place, applies the
+// default scope/cell labels when unset, and ensures Spec.ID + per-container
+// ownership are filled. The returned name/realm/space/stack are the trimmed
+// values used by the caller; the cell argument is mutated to carry the
+// normalised body.
+//
+// Extracted from createCellInternal to keep the latter's cyclomatic
+// complexity under the gocyclo budget after #818's startAfterCreate branch
+// was added.
+func normalizeCellInputs(cell *intmodel.Cell) (string, string, string, string, error) {
 	name := strings.TrimSpace(cell.Metadata.Name)
 	if name == "" {
-		return res, errdefs.ErrCellNameRequired
+		return "", "", "", "", errdefs.ErrCellNameRequired
 	}
 	if err := naming.ValidateHierarchyName("cell", name); err != nil {
-		return res, err
+		return "", "", "", "", err
 	}
 	cell.Metadata.Name = name
 	realm := strings.TrimSpace(cell.Spec.RealmName)
 	if realm == "" {
-		return res, errdefs.ErrRealmNameRequired
+		return "", "", "", "", errdefs.ErrRealmNameRequired
 	}
 	space := strings.TrimSpace(cell.Spec.SpaceName)
 	if space == "" {
-		return res, errdefs.ErrSpaceNameRequired
+		return "", "", "", "", errdefs.ErrSpaceNameRequired
 	}
 	stack := strings.TrimSpace(cell.Spec.StackName)
 	if stack == "" {
-		return res, errdefs.ErrStackNameRequired
+		return "", "", "", "", errdefs.ErrStackNameRequired
 	}
 
 	// Validate container names embedded in the cell spec so a malformed
@@ -91,30 +109,15 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 	for i := range cell.Spec.Containers {
 		id := strings.TrimSpace(cell.Spec.Containers[i].ID)
 		if id == "" {
-			return res, errdefs.ErrContainerNameRequired
+			return "", "", "", "", errdefs.ErrContainerNameRequired
 		}
 		if err := naming.ValidateHierarchyName("container", id); err != nil {
-			return res, err
+			return "", "", "", "", err
 		}
 		cell.Spec.Containers[i].ID = id
 	}
 
-	// Ensure default labels are set
-	if cell.Metadata.Labels == nil {
-		cell.Metadata.Labels = make(map[string]string)
-	}
-	if _, exists := cell.Metadata.Labels[consts.KukeonRealmLabelKey]; !exists {
-		cell.Metadata.Labels[consts.KukeonRealmLabelKey] = realm
-	}
-	if _, exists := cell.Metadata.Labels[consts.KukeonSpaceLabelKey]; !exists {
-		cell.Metadata.Labels[consts.KukeonSpaceLabelKey] = space
-	}
-	if _, exists := cell.Metadata.Labels[consts.KukeonStackLabelKey]; !exists {
-		cell.Metadata.Labels[consts.KukeonStackLabelKey] = stack
-	}
-	if _, exists := cell.Metadata.Labels[consts.KukeonCellLabelKey]; !exists {
-		cell.Metadata.Labels[consts.KukeonCellLabelKey] = name
-	}
+	applyDefaultCellLabels(cell, realm, space, stack, name)
 
 	// Ensure Spec.ID is set
 	if cell.Spec.ID == "" {
@@ -123,6 +126,99 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 
 	// Ensure container ownership (work with internal types)
 	cell.Spec.Containers = ensureContainerOwnershipInternal(cell.Spec.Containers, realm, space, stack, name)
+
+	return name, realm, space, stack, nil
+}
+
+// applyDefaultCellLabels sets the four scope/cell labels on the cell when
+// the operator did not author them explicitly. Extracted from
+// normalizeCellInputs to keep that function under the funlen budget.
+func applyDefaultCellLabels(cell *intmodel.Cell, realm, space, stack, name string) {
+	if cell.Metadata.Labels == nil {
+		cell.Metadata.Labels = make(map[string]string)
+	}
+	for key, value := range map[string]string{
+		consts.KukeonRealmLabelKey: realm,
+		consts.KukeonSpaceLabelKey: space,
+		consts.KukeonStackLabelKey: stack,
+		consts.KukeonCellLabelKey:  name,
+	} {
+		if _, exists := cell.Metadata.Labels[key]; !exists {
+			cell.Metadata.Labels[key] = value
+		}
+	}
+}
+
+// acquireOrCreateCell branches on whether the cell record already exists.
+// On the "not found" path, runner.CreateCell creates a fresh record. On the
+// "found" path, the cell's pre-state (cgroup/root-container existence,
+// container ID set) is recorded into res and preContainerExists, then
+// runner.EnsureCell reconciles any missing resources. The bool return is
+// wasCreated — true for the fresh-record path, false for the existing path.
+//
+// Extracted from createCellInternal to keep that function under the funlen
+// budget after #818's startAfterCreate branch was added.
+func (b *Exec) acquireOrCreateCell(
+	cell, lookupCell intmodel.Cell,
+	res *CreateCellResult,
+	preContainerExists map[string]bool,
+) (intmodel.Cell, bool, error) {
+	internalCellPre, getErr := b.runner.GetCell(lookupCell)
+	if getErr != nil {
+		if !errors.Is(getErr, errdefs.ErrCellNotFound) {
+			return intmodel.Cell{}, false, fmt.Errorf("%w: %w", errdefs.ErrGetCell, getErr)
+		}
+		res.MetadataExistsPre = false
+		resultCell, createErr := b.runner.CreateCell(cell)
+		if createErr != nil {
+			return intmodel.Cell{}, false, fmt.Errorf("%w: %w", errdefs.ErrCreateCell, createErr)
+		}
+		return resultCell, true, nil
+	}
+
+	res.MetadataExistsPre = true
+	cgroupExists, cgErr := b.runner.ExistsCgroup(internalCellPre)
+	if cgErr != nil {
+		return intmodel.Cell{}, false, fmt.Errorf("failed to check if cell cgroup exists: %w", cgErr)
+	}
+	res.CgroupExistsPre = cgroupExists
+	rootExists, rcErr := b.runner.ExistsCellRootContainer(internalCellPre)
+	if rcErr != nil {
+		return intmodel.Cell{}, false, fmt.Errorf("failed to check root container: %w", rcErr)
+	}
+	res.RootContainerExistsPre = rootExists
+	for _, container := range internalCellPre.Spec.Containers {
+		id := strings.TrimSpace(container.ID)
+		if id != "" {
+			preContainerExists[id] = true
+		}
+	}
+	res.StartedPre = false
+
+	resultCell, ensureErr := b.runner.EnsureCell(internalCellPre)
+	if ensureErr != nil {
+		return intmodel.Cell{}, false, fmt.Errorf("%w: %w", errdefs.ErrCreateCell, ensureErr)
+	}
+	return resultCell, false, nil
+}
+
+// createCellInternal is the shared implementation behind CreateCell and
+// MaterializeCell. When startAfterCreate is true, the cell's containers are
+// started before the result is built; when false, the cell is left stopped.
+//
+// The CreateCellResult reports the state of cell resources before and after
+// the operation, indicating what was created vs what already existed,
+// including container-level outcomes. An error is returned if the cell name
+// is required, the realm name is required, the space name is required, the
+// stack name is required, the cell cgroup does not exist, the root container
+// does not exist, or the cell creation fails.
+func (b *Exec) createCellInternal(cell intmodel.Cell, startAfterCreate bool) (CreateCellResult, error) {
+	var res CreateCellResult
+
+	name, realm, space, stack, err := normalizeCellInputs(&cell)
+	if err != nil {
+		return res, err
+	}
 
 	preContainerExists := make(map[string]bool)
 
@@ -138,58 +234,19 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 		},
 	}
 
-	// Check if cell already exists
-	internalCellPre, err := b.runner.GetCell(lookupCell)
-	var resultCell intmodel.Cell
-	var wasCreated bool
-
+	resultCell, wasCreated, err := b.acquireOrCreateCell(cell, lookupCell, &res, preContainerExists)
 	if err != nil {
-		// Cell not found, create new cell
-		if errors.Is(err, errdefs.ErrCellNotFound) {
-			res.MetadataExistsPre = false
-		} else {
-			return res, fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
-		}
-
-		// Create new cell
-		resultCell, err = b.runner.CreateCell(cell)
-		if err != nil {
-			return res, fmt.Errorf("%w: %w", errdefs.ErrCreateCell, err)
-		}
-
-		wasCreated = true
-	} else {
-		// Cell found, check pre-state for result reporting (EnsureCell will also check internally)
-		res.MetadataExistsPre = true
-		res.CgroupExistsPre, err = b.runner.ExistsCgroup(internalCellPre)
-		if err != nil {
-			return res, fmt.Errorf("failed to check if cell cgroup exists: %w", err)
-		}
-		res.RootContainerExistsPre, err = b.runner.ExistsCellRootContainer(internalCellPre)
-		if err != nil {
-			return res, fmt.Errorf("failed to check root container: %w", err)
-		}
-		for _, container := range internalCellPre.Spec.Containers {
-			id := strings.TrimSpace(container.ID)
-			if id != "" {
-				preContainerExists[id] = true
-			}
-		}
-		res.StartedPre = false
-
-		// Ensure resources exist (EnsureCell checks/ensures internally)
-		resultCell, err = b.runner.EnsureCell(internalCellPre)
-		if err != nil {
-			return res, fmt.Errorf("%w: %w", errdefs.ErrCreateCell, err)
-		}
-
-		wasCreated = false
+		return res, err
 	}
 
-	// Start cell containers (both new and existing cells need to be started)
-	resultCell, err = b.runner.StartCell(resultCell)
-	if err != nil {
-		return res, fmt.Errorf("failed to start cell containers: %w", err)
+	// Start cell containers when the caller asked for it. MaterializeCell
+	// (#818) skips this step so the cell record is left in a stopped state for
+	// the operator to start explicitly with `kuke start <name>`.
+	if startAfterCreate {
+		resultCell, err = b.runner.StartCell(resultCell)
+		if err != nil {
+			return res, fmt.Errorf("failed to start cell containers: %w", err)
+		}
 	}
 
 	// Build post-container existence map from resultCell directly
@@ -207,18 +264,18 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 	// After CreateCell/EnsureCell, cgroup and root container are guaranteed to exist
 	res.CgroupExistsPost = true
 	res.RootContainerExistsPost = true
-	res.StartedPost = true
+	res.StartedPost = startAfterCreate
 	res.Created = wasCreated
 	if wasCreated {
 		// New cell: all resources were created
 		res.CgroupCreated = true
 		res.RootContainerCreated = true
-		res.Started = true
+		res.Started = startAfterCreate
 	} else {
 		// Existing cell: resources were created only if they didn't exist before
 		res.CgroupCreated = !res.CgroupExistsPre
 		res.RootContainerCreated = !res.RootContainerExistsPre
-		res.Started = !res.StartedPre
+		res.Started = startAfterCreate && !res.StartedPre
 	}
 
 	// Build container creation outcomes

--- a/internal/controller/materialize_cell_test.go
+++ b/internal/controller/materialize_cell_test.go
@@ -1,0 +1,115 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestMaterializeCell_NewCell_SkipsStart confirms the daemon-side contract
+// MaterializeCell adds for #818: same create path as CreateCell, but the
+// runner.StartCell step is never invoked. The CLI's `kuke create cell
+// --from-blueprint` / `--from-config` modes depend on this for the
+// "materialise-but-don't-start" semantics.
+func TestMaterializeCell_NewCell_SkipsStart(t *testing.T) {
+	var startCalled bool
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return intmodel.Cell{}, errdefs.ErrCellNotFound
+		},
+		CreateCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return buildTestCell("mz-cell", "test-realm", "test-space", "test-stack"), nil
+		},
+		StartCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			startCalled = true
+			return cell, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	cell := buildTestCell("mz-cell", "test-realm", "test-space", "test-stack")
+
+	result, err := ctrl.MaterializeCell(cell)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if startCalled {
+		t.Fatal("runner.StartCell must not be invoked by MaterializeCell")
+	}
+	if !result.Created {
+		t.Error("expected Created to be true (cell record was created)")
+	}
+	if result.Started {
+		t.Error("expected Started to be false (start step was skipped)")
+	}
+	if result.StartedPost {
+		t.Error("expected StartedPost to be false (start step was skipped)")
+	}
+	if !result.MetadataExistsPost {
+		t.Error("expected MetadataExistsPost to be true")
+	}
+}
+
+// TestMaterializeCell_ExistingCell_SkipsStart confirms the same contract on
+// the EnsureCell branch: when a cell record already exists, MaterializeCell
+// still routes through EnsureCell (idempotent resource-existence check) but
+// never reaches StartCell.
+func TestMaterializeCell_ExistingCell_SkipsStart(t *testing.T) {
+	existingCell := buildTestCell("mz-cell", "test-realm", "test-space", "test-stack")
+	var startCalled bool
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return existingCell, nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		EnsureCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			return cell, nil
+		},
+		StartCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			startCalled = true
+			return cell, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+
+	result, err := ctrl.MaterializeCell(existingCell)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if startCalled {
+		t.Fatal("runner.StartCell must not be invoked by MaterializeCell on the existing-cell branch")
+	}
+	if result.Created {
+		t.Error("expected Created to be false (cell record already existed)")
+	}
+	if result.Started {
+		t.Error("expected Started to be false (start step was skipped)")
+	}
+}

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -99,6 +99,23 @@ func (s *KukeonV1Service) CreateCell(args *kukeonv1.CreateCellArgs, reply *kukeo
 	return nil
 }
 
+// MaterializeCell is the net/rpc method for KukeonV1.MaterializeCell (#818).
+// Mirrors CreateCell, but the daemon-side controller skips the StartCell
+// step so the resulting cell is left in a stopped state — the substrate for
+// `kuke create cell --from-blueprint` / `--from-config` scaffolding.
+func (s *KukeonV1Service) MaterializeCell(
+	args *kukeonv1.MaterializeCellArgs,
+	reply *kukeonv1.MaterializeCellReply,
+) error {
+	result, err := s.core.MaterializeCell(s.ctx, args.Doc)
+	reply.Result = result
+	reply.Err = kukeonv1.ToAPIError(err)
+	if err != nil {
+		s.logger.DebugContext(s.ctx, "MaterializeCell returned error", "error", err)
+	}
+	return nil
+}
+
 // CreateContainer is the net/rpc method for KukeonV1.CreateContainer.
 func (s *KukeonV1Service) CreateContainer(
 	args *kukeonv1.CreateContainerArgs,

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -36,6 +36,15 @@ type Client interface {
 	CreateSpace(ctx context.Context, doc v1beta1.SpaceDoc) (CreateSpaceResult, error)
 	CreateStack(ctx context.Context, doc v1beta1.StackDoc) (CreateStackResult, error)
 	CreateCell(ctx context.Context, doc v1beta1.CellDoc) (CreateCellResult, error)
+	// MaterializeCell creates a cell record (or ensures an existing cell's
+	// resources exist) without starting any container tasks (#818). The
+	// resulting cell is left stopped; the operator runs `kuke start <name>`
+	// to start it. Distinct from CreateCell (which always starts) — used by
+	// `kuke create cell --from-blueprint` / `--from-config` for the
+	// materialise-but-don't-start scaffolding modes. Result shape matches
+	// CreateCell so the same printer renders the outcome (Started will be
+	// false because the start step was skipped).
+	MaterializeCell(ctx context.Context, doc v1beta1.CellDoc) (CreateCellResult, error)
 	CreateContainer(ctx context.Context, doc v1beta1.ContainerDoc) (CreateContainerResult, error)
 
 	GetRealm(ctx context.Context, doc v1beta1.RealmDoc) (GetRealmResult, error)
@@ -161,6 +170,22 @@ type CreateCellReply struct {
 	Err    *APIError
 }
 
+// MaterializeCellArgs is the wire request for MaterializeCell. The same
+// CellDoc shape as CreateCellArgs — the difference is purely server-side
+// (the daemon skips the StartCell step). Kept as a distinct type so the
+// wire-method dispatch stays unambiguous and the JSON-RPC server's
+// reflection-based registration picks it up alongside the other methods.
+type MaterializeCellArgs struct {
+	Doc v1beta1.CellDoc
+}
+
+// MaterializeCellReply is the wire response for MaterializeCell. Mirrors
+// CreateCellReply so the same printer renders the outcome.
+type MaterializeCellReply struct {
+	Result CreateCellResult
+	Err    *APIError
+}
+
 // CreateCellResult mirrors internal/controller.CreateCellResult using
 // external v1beta1 types, so it is safe to serialize and return to
 // non-privileged callers.
@@ -200,6 +225,7 @@ const (
 	MethodCreateSpace     = ServiceName + ".CreateSpace"
 	MethodCreateStack     = ServiceName + ".CreateStack"
 	MethodCreateCell      = ServiceName + ".CreateCell"
+	MethodMaterializeCell = ServiceName + ".MaterializeCell"
 	MethodCreateContainer = ServiceName + ".CreateContainer"
 
 	MethodGetRealm     = ServiceName + ".GetRealm"

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -53,6 +53,10 @@ func (FakeClient) CreateCell(context.Context, v1beta1.CellDoc) (CreateCellResult
 	return CreateCellResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) MaterializeCell(context.Context, v1beta1.CellDoc) (CreateCellResult, error) {
+	return CreateCellResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) CreateContainer(context.Context, v1beta1.ContainerDoc) (CreateContainerResult, error) {
 	return CreateContainerResult{}, ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -185,6 +185,19 @@ func (c *UnixClient) CreateCell(ctx context.Context, doc v1beta1.CellDoc) (Creat
 	return reply.Result, nil
 }
 
+// MaterializeCell implements Client.
+func (c *UnixClient) MaterializeCell(ctx context.Context, doc v1beta1.CellDoc) (CreateCellResult, error) {
+	args := &MaterializeCellArgs{Doc: doc}
+	reply := &MaterializeCellReply{}
+	if err := c.call(ctx, MethodMaterializeCell, args, reply); err != nil {
+		return CreateCellResult{}, err
+	}
+	if reply.Err != nil {
+		return reply.Result, FromAPIError(reply.Err)
+	}
+	return reply.Result, nil
+}
+
 // CreateContainer implements Client.
 func (c *UnixClient) CreateContainer(ctx context.Context, doc v1beta1.ContainerDoc) (CreateContainerResult, error) {
 	args := &CreateContainerArgs{Doc: doc}


### PR DESCRIPTION
## Summary

- Adds two new modes to `kuke create cell` that materialise a Cell record from a daemon-stored Blueprint or Config without starting it — the gap between `kuke run -b/-c` (materialise + start + attach) and `kuke apply -b/-c` (reconcile + start). The empty-shell `kuke create cell <name>` path (workflow C) is unchanged.
- The Blueprint path accepts `--param`/`--param-file` (mirroring `kuke run -b`); the Config path rejects them because a `CellConfig` carries its own `spec.values`. Name collision against an existing cell is refused with a `kuke delete cell <name>` pointer rather than silently attaching to a divergent existing cell.
- Adds a sibling daemon RPC `MaterializeCell` (alongside `CreateCell`) that runs the same create-or-EnsureCell flow but skips the trailing `runner.StartCell` step — the persistent contract that lets the new CLI modes leave the cell stopped. `CreateCell`'s behaviour is byte-equivalent to before the refactor.

## Daemon-API scope expansion

Per the issue's "Verify before implementation" note, confirmed `controller.CreateCell` always invokes `runner.StartCell` (`internal/controller/create_cell.go`) — today's empty-shell `kuke create cell` only appears stopped because there are no containers to start. The materialise-but-don't-start contract genuinely requires a daemon-side opt-out, so this PR includes that work as anticipated by the issue's Notes. See [issue heads-up comment](https://github.com/eminwux/kukeon/issues/818#issuecomment-4526970815) for the design discussion.

Approach: a sibling `MaterializeCell` RPC method rather than a `Skip Start` field on `CreateCellArgs` or an options struct on `controller.Exec.CreateCell`. The sibling keeps every existing CreateCell caller's signature untouched and the JSON-RPC server's reflection-based registration picks the new method up automatically. The controller refactor extracts a shared `createCellInternal(cell, startAfterCreate bool)` helper from `CreateCell` and gates the start call on the bool; `CreateCell` calls with `true`, `MaterializeCell` with `false`. Reviewer can push back on the sibling-method choice if a different shape is preferred.

## Acceptance criteria

- [x] `kuke create cell <name>` (no source flag) continues to work as today — empty Cell shell, scope flags only (regression test: `TestCreateCell_EmptyShell_StillUsesCreateCell`).
- [x] `kuke create cell <name> --from-blueprint <bp>` resolves the Blueprint, applies `--param`/`--param-file`, materialises via `cellblueprint.MaterializeWithName`, persists via `client.MaterializeCell` (re-read per the heads-up — see §"Daemon-API scope expansion" above).
- [x] `kuke create cell <name> --from-config <cfg>` resolves the Config, materialises via `cellconfig.MaterializeWithName` (same path `cmd/kuke/apply/apply.go` uses), persists via `client.MaterializeCell`.
- [x] In both `--from-*` modes the cell is left stopped — `MaterializeCell` skips `runner.StartCell` (controller test: `TestMaterializeCell_NewCell_SkipsStart`, `TestMaterializeCell_ExistingCell_SkipsStart`).
- [x] Mutual exclusion via cobra's `MarkFlagsMutuallyExclusive("from-blueprint", "from-config")`.
- [x] `--param`/`--param-file` valid with `--from-blueprint`; rejected with `--from-config` (test: `TestCreateCell_ParamRejectedWithFromConfig`).
- [x] `--from-blueprint` completion via `CompleteBlueprintNames`; `--from-config` via `CompleteConfigNames`.
- [x] Tests cover the AC: empty-shell unchanged, both `--from-*` happy paths, mutual exclusion, `--param` rejection with `--from-config`, name collision against existing cell.
- [x] Help text (`Long`/`Short`) rewritten to describe all three modes.

## Test plan

- [x] `make test` — all packages pass uncached.
- [x] `pre-commit run --files <changed>` — go fmt, go vet, golangci-lint, addlicense all clean.
- [x] `make dev-init` — daemon-parity tail shows both realms `Ready`; `kuke init` and the nested kuke-attach smoke complete cleanly. Confirms the controller refactor preserves `CreateCell` semantics.
- [x] `cmd/kuke/create/cell` package tests pass uncached.
- [x] `internal/controller` package tests pass uncached (including the new `MaterializeCell` tests).
- [ ] Docs port — explicitly out of scope per the issue; pm files via `/plan-release-doc` after merge.

Closes #818