### PR TITLE
refactor(apply): remove kuke apply -b/-c — apply becomes -f only (#823)

### DIFF
--- a/cmd/kuke/apply/apply.go
+++ b/cmd/kuke/apply/apply.go
@@ -17,23 +17,14 @@
 package apply
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"strings"
 
-	"github.com/eminwux/kukeon/cmd/config"
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
-	"github.com/eminwux/kukeon/internal/cellblueprint"
-	"github.com/eminwux/kukeon/internal/cellconfig"
-	"github.com/eminwux/kukeon/internal/cellprofile"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
-	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
@@ -45,78 +36,31 @@ const (
 )
 
 // NewApplyCmd builds the `kuke apply` cobra command. `-f` reads a multi-document
-// YAML stream from disk or stdin (unchanged). `-b` resolves a daemon-stored
-// CellBlueprint by name + scope, substitutes `--param` values, and reconciles
-// the resulting cell against the live state. `-c` resolves a daemon-stored
-// CellConfig by name + scope and reconciles its materialised cell. The three
-// sources are mutually exclusive; exactly one is required.
+// YAML stream from disk or stdin — the sole shape `apply` supports. The
+// daemon-side reconcile-by-ref forms (`-b`/`-c`) were retired under #819; the
+// equivalent operator workflow is `kuke restart cell <name>` (which sees
+// OutOfSync on Config-lineage cells and reconciles implicitly).
 func NewApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "apply (-f <file> | -b <blueprint> | -c <config>)",
-		Short: "Apply resource definitions from YAML or reconcile a daemon-stored Blueprint/Config",
-		Long: "Apply resource definitions from a YAML file or stdin (-f), reconcile a " +
-			"daemon-stored CellBlueprint by ref (-b), or reconcile a daemon-stored " +
-			"CellConfig by ref (-c). The -b/-c forms materialise a CellDoc the same way " +
-			"`kuke run -b/-c` does and reconcile it against the live cell: a missing cell " +
-			"is created and started; an identical live cell is a no-op; a divergent live " +
-			"cell is stopped, updated, and started (no attach). A live cell whose " +
-			"lineage label (kukeon.io/blueprint or kukeon.io/config) does not match the " +
-			"-b/-c source is refused, so apply never silently takes over an unrelated cell.",
+		Use:           "apply -f <file>",
+		Short:         "Apply resource definitions from a YAML file or stdin",
+		Long:          "Apply resource definitions from a YAML file or stdin (-f).",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE:          runApply,
 	}
 
-	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin); mutually exclusive with -b/-c")
+	cmd.Flags().StringP("file", "f", "", "File to read YAML from (use - for stdin)")
 	cmd.Flags().StringP("output", "o", "", "Output format: json, yaml (default: human-readable)")
-
-	cmd.Flags().StringP("blueprint", "b", "",
-		"Daemon-stored CellBlueprint name to reconcile, resolved from the scope named by "+
-			"--realm/--space/--stack; mutually exclusive with -f/-c. Substitutes scalar "+
-			"--param values; without --name, materialises a fresh <prefix>-<6hex> cell name.")
-	cmd.Flags().StringP("config", "c", "",
-		"Daemon-stored CellConfig name to reconcile, resolved from the scope named by "+
-			"--realm/--space/--stack; mutually exclusive with -f/-b. The cell name is the "+
-			"Config's deterministic stable name unless --name overrides it. Rejects --param "+
-			"/ --param-file (edit the Config's spec.values instead).")
-
-	cmd.Flags().String("name", "",
-		"Override the materialised cell name (default for -b: <prefix>-<6hex>; default for "+
-			"-c: the Config's stable name). Rejected with -f.")
-	cmd.Flags().StringArray("param", nil,
-		"Scalar parameter override as KEY=VALUE; repeatable. Valid with -b only. Each KEY "+
-			"must be declared in spec.parameters[]. Wins over the parameter's default and "+
-			"over --param-file when both set the same key.")
-	cmd.Flags().String("param-file", "",
-		"File of KEY=VALUE lines whose values seed scalar parameters; one per line, `#` "+
-			"starts a comment. Valid with -b only. CLI --param wins on duplicate keys.")
-
-	cmd.Flags().String("realm", "", "Realm to resolve the Blueprint/Config from (default: default)")
-	cmd.Flags().String("space", "", "Space to resolve the Blueprint/Config from")
-	cmd.Flags().String("stack", "", "Stack to resolve the Blueprint/Config from")
-
-	cmd.MarkFlagsMutuallyExclusive("file", "blueprint", "config")
-	cmd.MarkFlagsOneRequired("file", "blueprint", "config")
-
-	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
-	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
-	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
-	_ = cmd.RegisterFlagCompletionFunc("blueprint", config.CompleteBlueprintNames)
-	_ = cmd.RegisterFlagCompletionFunc("config", config.CompleteConfigNames)
 
 	return cmd
 }
 
 // applyFlags is the validated bundle of flag values runApply consumes.
 type applyFlags struct {
-	file          string
-	blueprintName string
-	configName    string
-	output        string
-	nameOverride  string
-	paramArgs     []string
-	paramFile     string
+	file   string
+	output string
 }
 
 func parseApplyFlags(cmd *cobra.Command) (applyFlags, error) {
@@ -125,61 +69,12 @@ func parseApplyFlags(cmd *cobra.Command) (applyFlags, error) {
 	if flags.file, err = cmd.Flags().GetString("file"); err != nil {
 		return flags, err
 	}
-	if flags.blueprintName, err = cmd.Flags().GetString("blueprint"); err != nil {
-		return flags, err
-	}
-	if flags.configName, err = cmd.Flags().GetString("config"); err != nil {
-		return flags, err
-	}
 	if flags.output, err = cmd.Flags().GetString("output"); err != nil {
 		return flags, err
 	}
-	if flags.nameOverride, err = cmd.Flags().GetString("name"); err != nil {
-		return flags, err
-	}
-	if flags.paramArgs, err = cmd.Flags().GetStringArray("param"); err != nil {
-		return flags, err
-	}
-	if flags.paramFile, err = cmd.Flags().GetString("param-file"); err != nil {
-		return flags, err
-	}
-
-	flags.file = strings.TrimSpace(flags.file)
-	flags.blueprintName = strings.TrimSpace(flags.blueprintName)
-	flags.configName = strings.TrimSpace(flags.configName)
-	flags.output = strings.TrimSpace(flags.output)
-	flags.nameOverride = strings.TrimSpace(flags.nameOverride)
-	flags.paramFile = strings.TrimSpace(flags.paramFile)
 
 	if flags.output != "" && flags.output != outputFormatJSON && flags.output != outputFormatYAML {
 		return flags, fmt.Errorf("invalid --output %q: want json or yaml", flags.output)
-	}
-
-	if flags.file != "" {
-		// --name and --param* are template knobs that only make sense for the
-		// -b/-c refs; a -f stream carries metadata.name verbatim and a fully
-		// resolved spec.
-		if flags.nameOverride != "" {
-			return flags, errors.New("--name is only valid with -b/--blueprint or -c/--config")
-		}
-		if len(flags.paramArgs) > 0 {
-			return flags, errors.New("--param is only valid with -b/--blueprint")
-		}
-		if flags.paramFile != "" {
-			return flags, errors.New("--param-file is only valid with -b/--blueprint")
-		}
-	}
-	if flags.configName != "" {
-		// A CellConfig carries its own spec.values; --param would either
-		// silently shadow them or break the Config's idempotent identity.
-		if len(flags.paramArgs) > 0 {
-			return flags, errors.New(
-				"--param is not valid with -c/--config; edit the Config's spec.values instead")
-		}
-		if flags.paramFile != "" {
-			return flags, errors.New(
-				"--param-file is not valid with -c/--config; edit the Config's spec.values instead")
-		}
 	}
 	return flags, nil
 }
@@ -196,14 +91,11 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	}
 	defer func() { _ = client.Close() }()
 
-	if flags.blueprintName != "" || flags.configName != "" {
-		return runApplyRef(cmd, client, flags)
-	}
 	return runApplyFile(cmd, client, flags)
 }
 
-// runApplyFile is the unchanged `kuke apply -f` path: read YAML, send to the
-// daemon's ApplyDocuments, print result.
+// runApplyFile is the `kuke apply -f` path: read YAML, send to the daemon's
+// ApplyDocuments, print result.
 func runApplyFile(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) error {
 	if flags.file == "" {
 		return errors.New("file flag is required (use -f <file> or -f - for stdin)")
@@ -229,233 +121,6 @@ func runApplyFile(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) 
 		return printApplyResultJSON(cmd, result, flags.output)
 	}
 	return printApplyResult(cmd, result)
-}
-
-// runApplyRef handles the `-b`/`-c` form. It materialises a CellDoc from the
-// named Blueprint or Config, validates the lineage against any live cell at
-// the resolved name, and routes the marshaled doc through the daemon's
-// ApplyDocuments — which owns the missing/matches/differs reconciliation for
-// the Cell kind. Equivalent specs from -f, -b, or -c all converge on the same
-// daemon-side reconcile path.
-func runApplyRef(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) error {
-	cellDoc, err := loadCellRef(cmd, client, flags)
-	if err != nil {
-		return err
-	}
-	resolveCellLocation(cmd, &cellDoc)
-
-	if lineageErr := assertCellLineage(cmd.Context(), client, cellDoc, flags); lineageErr != nil {
-		return lineageErr
-	}
-
-	rawYAML, err := yaml.Marshal(&cellDoc)
-	if err != nil {
-		return fmt.Errorf("marshal materialised cell: %w", err)
-	}
-
-	result, err := client.ApplyDocuments(cmd.Context(), rawYAML)
-	if err != nil {
-		return err
-	}
-
-	if flags.output == outputFormatJSON || flags.output == outputFormatYAML {
-		return printApplyResultJSON(cmd, result, flags.output)
-	}
-	return printApplyResult(cmd, result)
-}
-
-// loadCellRef materialises the CellDoc for the -b or -c path. Mirrors
-// run.loadFromBlueprint / loadFromConfig (cmd/kuke/run/run.go) so equivalent
-// specs from `kuke run` and `kuke apply` compare equal under DiffCell.
-func loadCellRef(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) (v1beta1.CellDoc, error) {
-	switch {
-	case flags.configName != "":
-		return loadFromConfig(cmd, client, flags)
-	case flags.blueprintName != "":
-		return loadFromBlueprint(cmd, client, flags)
-	}
-	return v1beta1.CellDoc{}, errors.New("internal error: loadCellRef called without -b/-c")
-}
-
-func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) (v1beta1.CellDoc, error) {
-	cliParams, err := buildParamMap(flags)
-	if err != nil {
-		return v1beta1.CellDoc{}, err
-	}
-
-	lookup := v1beta1.CellBlueprintDoc{
-		Metadata: v1beta1.CellBlueprintMetadata{
-			Name:  flags.blueprintName,
-			Realm: kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM),
-			Space: kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
-			Stack: kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
-		},
-	}
-
-	res, err := client.GetBlueprint(cmd.Context(), lookup)
-	if err != nil {
-		return v1beta1.CellDoc{}, err
-	}
-	if !res.MetadataExists {
-		return v1beta1.CellDoc{}, fmt.Errorf(
-			"%w (blueprint %q in scope realm=%q space=%q stack=%q)",
-			errdefs.ErrBlueprintNotFound, lookup.Metadata.Name,
-			lookup.Metadata.Realm, lookup.Metadata.Space, lookup.Metadata.Stack,
-		)
-	}
-
-	resolved, err := cellblueprint.Resolve(res.Blueprint, cliParams, os.LookupEnv)
-	if err != nil {
-		return v1beta1.CellDoc{}, err
-	}
-	return cellblueprint.MaterializeWithName(resolved, flags.nameOverride)
-}
-
-func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags applyFlags) (v1beta1.CellDoc, error) {
-	lookup := v1beta1.CellConfigDoc{
-		APIVersion: v1beta1.APIVersionV1Beta1,
-		Kind:       v1beta1.KindCellConfig,
-		Metadata: v1beta1.CellConfigMetadata{
-			Name:  flags.configName,
-			Realm: kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM),
-			Space: kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
-			Stack: kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
-		},
-	}
-
-	cfgRes, err := client.GetConfig(cmd.Context(), lookup)
-	if err != nil {
-		return v1beta1.CellDoc{}, err
-	}
-	if !cfgRes.MetadataExists {
-		return v1beta1.CellDoc{}, fmt.Errorf(
-			"%w (config %q in scope realm=%q space=%q stack=%q)",
-			errdefs.ErrConfigNotFound, lookup.Metadata.Name,
-			lookup.Metadata.Realm, lookup.Metadata.Space, lookup.Metadata.Stack,
-		)
-	}
-
-	bpRef := cfgRes.Config.Spec.Blueprint
-	bpRes, err := client.GetBlueprint(cmd.Context(), v1beta1.CellBlueprintDoc{
-		Metadata: v1beta1.CellBlueprintMetadata{
-			Name:  bpRef.Name,
-			Realm: bpRef.Realm,
-			Space: bpRef.Space,
-			Stack: bpRef.Stack,
-		},
-	})
-	if err != nil {
-		return v1beta1.CellDoc{}, err
-	}
-	if !bpRes.MetadataExists {
-		return v1beta1.CellDoc{}, fmt.Errorf(
-			"%w (blueprint %q referenced by config %q in scope realm=%q space=%q stack=%q)",
-			errdefs.ErrBlueprintNotFound, bpRef.Name, cfgRes.Config.Metadata.Name,
-			bpRef.Realm, bpRef.Space, bpRef.Stack,
-		)
-	}
-
-	cellDoc, err := cellconfig.Materialize(cfgRes.Config, bpRes.Blueprint)
-	if err != nil {
-		return v1beta1.CellDoc{}, err
-	}
-	if flags.nameOverride != "" {
-		cellDoc.Metadata.Name = flags.nameOverride
-		cellDoc.Spec.ID = flags.nameOverride
-	}
-	return cellDoc, nil
-}
-
-// buildParamMap layers --param flags on top of --param-file contents, matching
-// `kuke run -b`'s precedence. Empty result is valid (the blueprint may use only
-// defaults).
-func buildParamMap(flags applyFlags) (map[string]string, error) {
-	var fileParams map[string]string
-	if flags.paramFile != "" {
-		fp, err := cellprofile.ParseParamFile(flags.paramFile)
-		if err != nil {
-			return nil, err
-		}
-		fileParams = fp
-	}
-	cliParams, err := cellprofile.ParseParamArgs(flags.paramArgs)
-	if err != nil {
-		return nil, err
-	}
-	return cellprofile.MergeParams(fileParams, cliParams), nil
-}
-
-// resolveCellLocation fills missing realm/space/stack on the materialised doc
-// from --realm/--space/--stack (or the KUKE_RUN_* env-var fallbacks the shared
-// helpers consume). The materialised doc usually carries the Blueprint/Config's
-// coordinates already; this only fills empties.
-func resolveCellLocation(cmd *cobra.Command, doc *v1beta1.CellDoc) {
-	if strings.TrimSpace(doc.Spec.RealmID) == "" {
-		doc.Spec.RealmID = kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM)
-	}
-	if strings.TrimSpace(doc.Spec.SpaceID) == "" {
-		doc.Spec.SpaceID = kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE)
-	}
-	if strings.TrimSpace(doc.Spec.StackID) == "" {
-		doc.Spec.StackID = kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK)
-	}
-}
-
-// assertCellLineage refuses to reconcile a live cell whose lineage label does
-// not match the source the operator named. The check protects hand-built cells
-// (no lineage label) and cells materialised from a different Blueprint/Config
-// (different label value) from silent takeover. A missing cell skips the
-// check — there is nothing to overwrite.
-func assertCellLineage(
-	ctx context.Context, client kukeonv1.Client, desired v1beta1.CellDoc, flags applyFlags,
-) error {
-	pre, err := client.GetCell(ctx, desired)
-	if err != nil {
-		if errors.Is(err, errdefs.ErrCellNotFound) {
-			return nil
-		}
-		return err
-	}
-	if !pre.MetadataExists {
-		return nil
-	}
-
-	labelKey, wantValue := lineageExpectation(flags)
-	gotValue := strings.TrimSpace(pre.Cell.Metadata.Labels[labelKey])
-
-	if gotValue == wantValue {
-		return nil
-	}
-	return lineageMismatchError(desired.Metadata.Name, labelKey, wantValue, pre.Cell.Metadata.Labels)
-}
-
-// lineageExpectation maps the active source flag to the (labelKey, wantValue)
-// pair the live cell must carry. The caller already verified exactly one of -b
-// or -c is set.
-func lineageExpectation(flags applyFlags) (string, string) {
-	if flags.configName != "" {
-		return cellconfig.LabelConfig, flags.configName
-	}
-	return cellblueprint.LabelBlueprint, flags.blueprintName
-}
-
-// lineageMismatchError formats the refusal so the operator sees both what
-// `apply` expected and the existing cell's source (if any). A hand-built cell
-// reports "no lineage label"; a sibling-source cell reports the other label.
-func lineageMismatchError(cellName, wantKey, wantValue string, got map[string]string) error {
-	var existingSource string
-	switch {
-	case strings.TrimSpace(got[cellconfig.LabelConfig]) != "":
-		existingSource = fmt.Sprintf("%s=%s", cellconfig.LabelConfig, got[cellconfig.LabelConfig])
-	case strings.TrimSpace(got[cellblueprint.LabelBlueprint]) != "":
-		existingSource = fmt.Sprintf("%s=%s", cellblueprint.LabelBlueprint, got[cellblueprint.LabelBlueprint])
-	default:
-		existingSource = "no lineage label"
-	}
-	return fmt.Errorf(
-		"cell %q exists with lineage %s; refusing to reconcile against %s=%s",
-		cellName, existingSource, wantKey, wantValue,
-	)
 }
 
 func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {

--- a/cmd/kuke/apply/apply_test.go
+++ b/cmd/kuke/apply/apply_test.go
@@ -29,11 +29,7 @@ import (
 
 	apply "github.com/eminwux/kukeon/cmd/kuke/apply"
 	"github.com/eminwux/kukeon/cmd/types"
-	"github.com/eminwux/kukeon/internal/cellblueprint"
-	"github.com/eminwux/kukeon/internal/cellconfig"
-	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
-	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 func writeTempYAML(t *testing.T, content string) string {
@@ -63,10 +59,10 @@ spec:
 		wantOutput string
 	}{
 		{
-			name:    "no source flag",
+			name:    "no file flag",
 			args:    []string{},
 			fake:    &fakeClient{},
-			wantErr: "at least one of the flags in the group [file blueprint config] is required",
+			wantErr: "file flag is required",
 		},
 		{
 			name: "success",
@@ -184,625 +180,70 @@ spec:
 	}
 }
 
-// blueprintDoc builds a minimal Blueprint with one param + one user (non-root)
-// container so apply -b has something to materialise. The fixture mirrors
-// run_test.blueprintDoc's shape so the round-trip behaviour stays comparable.
-func blueprintDoc() v1beta1.CellBlueprintDoc {
-	def := "latest"
-	return v1beta1.CellBlueprintDoc{
-		APIVersion: v1beta1.APIVersionV1Beta1,
-		Kind:       v1beta1.KindCellBlueprint,
-		Metadata: v1beta1.CellBlueprintMetadata{
-			Name:  "web",
-			Realm: "my-realm",
-			Space: "my-space",
-			Stack: "my-stack",
-		},
-		Spec: v1beta1.CellBlueprintSpec{
-			Prefix:     "web",
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
-			Cell: v1beta1.BlueprintCellSpec{
-				Containers: []v1beta1.BlueprintContainer{
-					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
-				},
-			},
-		},
-	}
-}
+// TestApply_BlueprintFlag_Removed pins #823's removal of `-b/--blueprint` from
+// `kuke apply`. The cobra-side response is the standard "unknown flag" error;
+// no fall-through to a no-op success.
+func TestApply_BlueprintFlag_Removed(t *testing.T) {
+	for _, args := range [][]string{
+		{"-b", "web"},
+		{"--blueprint", "web"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cmd := apply.NewApplyCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetArgs(args)
 
-// configDoc + configBlueprintDoc let -c tests round-trip through Materialize.
-// Slot fills are minimal (no secrets/repos) so Materialize succeeds without
-// auxiliary scope reads.
-func configBlueprintDoc() v1beta1.CellBlueprintDoc {
-	def := "latest"
-	return v1beta1.CellBlueprintDoc{
-		APIVersion: v1beta1.APIVersionV1Beta1,
-		Kind:       v1beta1.KindCellBlueprint,
-		Metadata: v1beta1.CellBlueprintMetadata{
-			Name:  "web",
-			Realm: "bp-realm",
-		},
-		Spec: v1beta1.CellBlueprintSpec{
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
-			Cell: v1beta1.BlueprintCellSpec{
-				Containers: []v1beta1.BlueprintContainer{
-					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
-				},
-			},
-		},
-	}
-}
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, apply.MockControllerKey{}, kukeonv1.Client(&fakeClient{}))
+			cmd.SetContext(ctx)
 
-func configDoc() v1beta1.CellConfigDoc {
-	return v1beta1.CellConfigDoc{
-		APIVersion: v1beta1.APIVersionV1Beta1,
-		Kind:       v1beta1.KindCellConfig,
-		Metadata: v1beta1.CellConfigMetadata{
-			Name:  "prod",
-			Realm: "cfg-realm",
-		},
-		Spec: v1beta1.CellConfigSpec{
-			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
-			Values:    map[string]string{"TAG": "v2"},
-		},
-	}
-}
-
-// runApplyRef is the test helper that builds a fake-backed apply.NewApplyCmd
-// and executes it with the given args. It returns the captured stdout/stderr
-// buffer plus the cobra Execute error.
-func runApplyRef(t *testing.T, fc *fakeClient, args []string) (string, error) {
-	t.Helper()
-	cmd := apply.NewApplyCmd()
-	buf := &bytes.Buffer{}
-	cmd.SetOut(buf)
-	cmd.SetErr(buf)
-
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, apply.MockControllerKey{}, kukeonv1.Client(fc))
-	cmd.SetContext(ctx)
-	cmd.SetArgs(args)
-	err := cmd.Execute()
-	return buf.String(), err
-}
-
-// TestApply_FromBlueprint_MissingCell_CreatesViaApplyDocuments covers the
-// "missing cell" leg of the -b reconciliation matrix: GetCell returns
-// ErrCellNotFound so the lineage check skips; ApplyDocuments fires with the
-// materialised YAML and the daemon reports "created".
-func TestApply_FromBlueprint_MissingCell_CreatesViaApplyDocuments(t *testing.T) {
-	fc := &fakeClient{
-		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			if doc.Metadata.Name != "web" {
-				t.Errorf("lookup name=%q want web", doc.Metadata.Name)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected unknown-flag error, got nil")
 			}
-			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
-		},
-		applyFn: func(raw []byte) (kukeonv1.ApplyDocumentsResult, error) {
-			if !strings.Contains(string(raw), "kukeon.io/blueprint: web") {
-				t.Errorf("materialised YAML missing lineage label; raw=\n%s", string(raw))
+			if !strings.Contains(err.Error(), "unknown") {
+				t.Errorf("err=%q want cobra's unknown-flag message", err.Error())
 			}
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{
-					{Kind: "Cell", Name: "myCell", Action: "created"},
-				},
-			}, nil
-		},
-	}
-
-	out, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "myCell", "--realm", "my-realm"})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !strings.Contains(out, `Cell "myCell": created`) {
-		t.Errorf("missing created line in output:\n%s", out)
-	}
-	if fc.applyCalls != 1 {
-		t.Errorf("ApplyDocuments calls=%d want 1", fc.applyCalls)
+		})
 	}
 }
 
-// TestApply_FromBlueprint_LiveCellMatchingLineage_NoOpsViaUnchanged covers the
-// "exists, matches" leg: GetCell echoes the same cell back with the matching
-// blueprint label, ApplyDocuments delegates to the daemon's diff which returns
-// "unchanged". The lineage check passes; no refusal.
-func TestApply_FromBlueprint_LiveCellMatchingLineage_NoOpsViaUnchanged(t *testing.T) {
-	fc := &fakeClient{
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				Cell: v1beta1.CellDoc{
-					Metadata: v1beta1.CellMetadata{
-						Name:   doc.Metadata.Name,
-						Labels: map[string]string{cellblueprint.LabelBlueprint: "web"},
-					},
-				},
-				MetadataExists: true,
-			}, nil
-		},
-		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{
-					{Kind: "Cell", Name: "myCell", Action: "unchanged"},
-				},
-			}, nil
-		},
-	}
+// TestApply_ConfigFlag_Removed is the parallel guard for `-c/--config`.
+func TestApply_ConfigFlag_Removed(t *testing.T) {
+	for _, args := range [][]string{
+		{"-c", "prod"},
+		{"--config", "prod"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cmd := apply.NewApplyCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetArgs(args)
 
-	out, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "myCell", "--realm", "my-realm"})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !strings.Contains(out, `Cell "myCell": unchanged`) {
-		t.Errorf("missing unchanged line in output:\n%s", out)
-	}
-}
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, apply.MockControllerKey{}, kukeonv1.Client(&fakeClient{}))
+			cmd.SetContext(ctx)
 
-// TestApply_FromBlueprint_LiveCellDivergentSpec_UpdatesViaApplyDocuments covers
-// the "exists, differs" leg: the materialised YAML round-trips into the
-// daemon-side reconciler, which reports "updated" with the changed fields. The
-// CLI surfaces the per-field summary line.
-func TestApply_FromBlueprint_LiveCellDivergentSpec_UpdatesViaApplyDocuments(t *testing.T) {
-	fc := &fakeClient{
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				Cell: v1beta1.CellDoc{
-					Metadata: v1beta1.CellMetadata{
-						Name:   doc.Metadata.Name,
-						Labels: map[string]string{cellblueprint.LabelBlueprint: "web"},
-					},
-					Spec: v1beta1.CellSpec{
-						Containers: []v1beta1.ContainerSpec{
-							{ID: "main", Image: "registry.example.com/web:old"},
-						},
-					},
-				},
-				MetadataExists: true,
-			}, nil
-		},
-		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{
-					{
-						Kind:    "Cell",
-						Name:    "myCell",
-						Action:  "updated",
-						Changes: []string{`container "main" updated: image`},
-					},
-				},
-			}, nil
-		},
-	}
-
-	out, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "myCell", "--realm", "my-realm"})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !strings.Contains(out, `Cell "myCell": updated`) {
-		t.Errorf("missing updated header in output:\n%s", out)
-	}
-	if !strings.Contains(out, `container "main" updated: image`) {
-		t.Errorf("missing per-field diff line in output:\n%s", out)
-	}
-}
-
-// TestApply_FromBlueprint_LiveCellHandBuilt_RefusesLineageMismatch is the
-// safety gate the AC names: a hand-built cell (no kukeon.io/blueprint label) is
-// refused, never silently overwritten. The error names the existing cell's
-// source ("no lineage label") and the source apply tried to claim.
-func TestApply_FromBlueprint_LiveCellHandBuilt_RefusesLineageMismatch(t *testing.T) {
-	fc := &fakeClient{
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				Cell: v1beta1.CellDoc{
-					Metadata: v1beta1.CellMetadata{Name: doc.Metadata.Name},
-				},
-				MetadataExists: true,
-			}, nil
-		},
-	}
-
-	_, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "alice-handbuilt", "--realm", "my-realm"})
-	if err == nil {
-		t.Fatal("expected lineage-mismatch error, got nil")
-	}
-	if !strings.Contains(err.Error(), "no lineage label") {
-		t.Errorf("err=%q want mention of 'no lineage label'", err.Error())
-	}
-	if !strings.Contains(err.Error(), "kukeon.io/blueprint=web") {
-		t.Errorf("err=%q want mention of attempted lineage", err.Error())
-	}
-	if fc.applyCalls != 0 {
-		t.Errorf("ApplyDocuments fired %d times on lineage mismatch; want 0", fc.applyCalls)
-	}
-}
-
-// TestApply_FromBlueprint_CrossLineage_RefusesAgainstConfigCell ensures the
-// lineage check is strict in both directions: applying -b against a cell whose
-// lineage is a sibling CellConfig also refuses.
-func TestApply_FromBlueprint_CrossLineage_RefusesAgainstConfigCell(t *testing.T) {
-	fc := &fakeClient{
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				Cell: v1beta1.CellDoc{
-					Metadata: v1beta1.CellMetadata{
-						Name:   doc.Metadata.Name,
-						Labels: map[string]string{cellconfig.LabelConfig: "prod"},
-					},
-				},
-				MetadataExists: true,
-			}, nil
-		},
-	}
-
-	_, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "prod", "--realm", "my-realm"})
-	if err == nil {
-		t.Fatal("expected lineage-mismatch error, got nil")
-	}
-	if !strings.Contains(err.Error(), "kukeon.io/config=prod") {
-		t.Errorf("err=%q want existing-lineage detail", err.Error())
-	}
-}
-
-// TestApply_FromConfig_MissingCell_CreatesViaApplyDocuments covers the
-// "missing cell" leg of the -c reconciliation matrix. The materialised cell's
-// stable name comes from StableName(configName); the YAML carries the config
-// back-reference label.
-func TestApply_FromConfig_MissingCell_CreatesViaApplyDocuments(t *testing.T) {
-	fc := &fakeClient{
-		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-			if doc.Metadata.Name != "prod" {
-				t.Errorf("config lookup name=%q want prod", doc.Metadata.Name)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected unknown-flag error, got nil")
 			}
-			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
-		},
-		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			if doc.Metadata.Name != "web" || doc.Metadata.Realm != "bp-realm" {
-				t.Errorf("blueprint ref=%q/%q want web/bp-realm", doc.Metadata.Name, doc.Metadata.Realm)
+			if !strings.Contains(err.Error(), "unknown") {
+				t.Errorf("err=%q want cobra's unknown-flag message", err.Error())
 			}
-			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
-		},
-		applyFn: func(raw []byte) (kukeonv1.ApplyDocumentsResult, error) {
-			if !strings.Contains(string(raw), "kukeon.io/config: prod") {
-				t.Errorf("materialised YAML missing config lineage label; raw=\n%s", string(raw))
-			}
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{
-					{Kind: "Cell", Name: cellconfig.StableName("prod"), Action: "created"},
-				},
-			}, nil
-		},
-	}
-
-	out, err := runApplyRef(t, fc, []string{"-c", "prod", "--realm", "cfg-realm"})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !strings.Contains(out, "created") {
-		t.Errorf("missing created line in output:\n%s", out)
-	}
-}
-
-// TestApply_FromConfig_LiveCellMatchingLineage_NoOpsViaUnchanged covers the
-// "exists, matches" leg for -c.
-func TestApply_FromConfig_LiveCellMatchingLineage_NoOpsViaUnchanged(t *testing.T) {
-	fc := &fakeClient{
-		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
-		},
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				Cell: v1beta1.CellDoc{
-					Metadata: v1beta1.CellMetadata{
-						Name:   doc.Metadata.Name,
-						Labels: map[string]string{cellconfig.LabelConfig: "prod"},
-					},
-				},
-				MetadataExists: true,
-			}, nil
-		},
-		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{
-					{Kind: "Cell", Name: cellconfig.StableName("prod"), Action: "unchanged"},
-				},
-			}, nil
-		},
-	}
-
-	out, err := runApplyRef(t, fc, []string{"-c", "prod", "--realm", "cfg-realm"})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !strings.Contains(out, "unchanged") {
-		t.Errorf("missing unchanged line in output:\n%s", out)
-	}
-}
-
-// TestApply_FromConfig_LiveCellDivergentSpec_UpdatesViaApplyDocuments covers
-// the "exists, differs" leg for -c. The daemon-side reconciler is mocked to
-// return the per-field changes; the CLI surfaces them under the updated header.
-func TestApply_FromConfig_LiveCellDivergentSpec_UpdatesViaApplyDocuments(t *testing.T) {
-	fc := &fakeClient{
-		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
-		},
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				Cell: v1beta1.CellDoc{
-					Metadata: v1beta1.CellMetadata{
-						Name:   doc.Metadata.Name,
-						Labels: map[string]string{cellconfig.LabelConfig: "prod"},
-					},
-					Spec: v1beta1.CellSpec{
-						Containers: []v1beta1.ContainerSpec{
-							{ID: "main", Image: "registry.example.com/web:old"},
-						},
-					},
-				},
-				MetadataExists: true,
-			}, nil
-		},
-		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{
-					{
-						Kind:    "Cell",
-						Name:    cellconfig.StableName("prod"),
-						Action:  "updated",
-						Changes: []string{`container "main" updated: image`},
-					},
-				},
-			}, nil
-		},
-	}
-
-	out, err := runApplyRef(t, fc, []string{"-c", "prod", "--realm", "cfg-realm"})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !strings.Contains(out, "updated") {
-		t.Errorf("missing updated header in output:\n%s", out)
-	}
-	if !strings.Contains(out, `container "main" updated: image`) {
-		t.Errorf("missing per-field diff line in output:\n%s", out)
-	}
-}
-
-// TestApply_FromConfig_LiveCellHandBuilt_RefusesLineageMismatch is the parallel
-// safety gate for -c: a cell sitting at the Config's StableName with no
-// lineage label is refused.
-func TestApply_FromConfig_LiveCellHandBuilt_RefusesLineageMismatch(t *testing.T) {
-	fc := &fakeClient{
-		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
-		},
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				Cell:           v1beta1.CellDoc{Metadata: v1beta1.CellMetadata{Name: doc.Metadata.Name}},
-				MetadataExists: true,
-			}, nil
-		},
-	}
-
-	_, err := runApplyRef(t, fc, []string{"-c", "prod", "--realm", "cfg-realm"})
-	if err == nil {
-		t.Fatal("expected lineage-mismatch error, got nil")
-	}
-	if !strings.Contains(err.Error(), "no lineage label") {
-		t.Errorf("err=%q want mention of 'no lineage label'", err.Error())
-	}
-	if !strings.Contains(err.Error(), "kukeon.io/config=prod") {
-		t.Errorf("err=%q want mention of attempted lineage", err.Error())
-	}
-}
-
-// TestApply_FromConfig_RejectsParamFlags asserts the cobra-side guard: -c is
-// incompatible with --param / --param-file because a CellConfig owns its own
-// spec.values channel.
-func TestApply_FromConfig_RejectsParamFlags(t *testing.T) {
-	fc := &fakeClient{}
-	_, err := runApplyRef(t, fc, []string{"-c", "prod", "--param", "TAG=v3", "--realm", "cfg-realm"})
-	if err == nil || !strings.Contains(err.Error(), "--param is not valid with -c/--config") {
-		t.Fatalf("err=%v want rejection of --param with -c", err)
-	}
-}
-
-// TestApply_BlueprintNotFound_Errors covers the lookup-miss path: GetBlueprint
-// reports MetadataExists=false and the CLI surfaces ErrBlueprintNotFound
-// before any cell read or apply fires.
-func TestApply_BlueprintNotFound_Errors(t *testing.T) {
-	fc := &fakeClient{
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
-		},
-	}
-	_, err := runApplyRef(t, fc, []string{"-b", "ghost", "--realm", "my-realm"})
-	if err == nil || !errors.Is(err, errdefs.ErrBlueprintNotFound) {
-		t.Fatalf("err=%v want ErrBlueprintNotFound", err)
-	}
-	if fc.applyCalls != 0 {
-		t.Errorf("ApplyDocuments fired on lookup miss; want 0, got %d", fc.applyCalls)
-	}
-}
-
-// TestApply_ConfigNotFound_Errors is the -c counterpart: GetConfig reports
-// MetadataExists=false.
-func TestApply_ConfigNotFound_Errors(t *testing.T) {
-	fc := &fakeClient{
-		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
-		},
-	}
-	_, err := runApplyRef(t, fc, []string{"-c", "ghost", "--realm", "cfg-realm"})
-	if err == nil || !errors.Is(err, errdefs.ErrConfigNotFound) {
-		t.Fatalf("err=%v want ErrConfigNotFound", err)
-	}
-}
-
-// TestApply_FromBlueprint_EnvVarScopeFallback locks the symmetry with
-// `kuke run -b/-c`: when the operator pinned KUKE_RUN_REALM /
-// KUKE_RUN_SPACE / KUKE_RUN_STACK in their shell, `kuke apply -b` reads
-// the same scope, not the cobra default. Regression guard for #776 — the
-// pre-fix apply code path took --realm strictly from the flag and ignored
-// the env-var fallback `kuke run -b` honored via the shared helpers.
-func TestApply_FromBlueprint_EnvVarScopeFallback(t *testing.T) {
-	t.Setenv("KUKE_RUN_REALM", "from-env-realm")
-	t.Setenv("KUKE_RUN_SPACE", "from-env-space")
-	t.Setenv("KUKE_RUN_STACK", "from-env-stack")
-
-	gotLookup := v1beta1.CellBlueprintMetadata{}
-	fc := &fakeClient{
-		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			gotLookup = doc.Metadata
-			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
-		},
-		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{{Kind: "Cell", Name: "myCell", Action: "created"}},
-			}, nil
-		},
-	}
-
-	if _, err := runApplyRef(t, fc, []string{"-b", "web", "--name", "myCell"}); err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if gotLookup.Realm != "from-env-realm" {
-		t.Errorf("blueprint lookup realm=%q want from-env-realm (KUKE_RUN_REALM ignored)", gotLookup.Realm)
-	}
-	if gotLookup.Space != "from-env-space" {
-		t.Errorf("blueprint lookup space=%q want from-env-space (KUKE_RUN_SPACE ignored)", gotLookup.Space)
-	}
-	if gotLookup.Stack != "from-env-stack" {
-		t.Errorf("blueprint lookup stack=%q want from-env-stack (KUKE_RUN_STACK ignored)", gotLookup.Stack)
-	}
-}
-
-// TestApply_FromConfig_EnvVarScopeFallback is the -c counterpart of the
-// regression above. The Config lookup must also pick up KUKE_RUN_REALM /
-// SPACE / STACK from the operator's shell when no --realm/--space/--stack
-// flag is set.
-func TestApply_FromConfig_EnvVarScopeFallback(t *testing.T) {
-	t.Setenv("KUKE_RUN_REALM", "from-env-realm")
-	t.Setenv("KUKE_RUN_SPACE", "from-env-space")
-	t.Setenv("KUKE_RUN_STACK", "from-env-stack")
-
-	gotLookup := v1beta1.CellConfigMetadata{}
-	fc := &fakeClient{
-		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-			gotLookup = doc.Metadata
-			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
-		},
-		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
-		},
-		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{
-					{Kind: "Cell", Name: cellconfig.StableName("prod"), Action: "created"},
-				},
-			}, nil
-		},
-	}
-
-	if _, err := runApplyRef(t, fc, []string{"-c", "prod"}); err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if gotLookup.Realm != "from-env-realm" {
-		t.Errorf("config lookup realm=%q want from-env-realm", gotLookup.Realm)
-	}
-	if gotLookup.Space != "from-env-space" {
-		t.Errorf("config lookup space=%q want from-env-space", gotLookup.Space)
-	}
-	if gotLookup.Stack != "from-env-stack" {
-		t.Errorf("config lookup stack=%q want from-env-stack", gotLookup.Stack)
-	}
-}
-
-// TestApply_FromBlueprint_FlagWinsOverEnvVar pins the precedence: when
-// both --realm and KUKE_RUN_REALM are set, the flag wins. Same shape for
-// --space / --stack. Symmetric with the shared.ExplicitScope contract.
-func TestApply_FromBlueprint_FlagWinsOverEnvVar(t *testing.T) {
-	t.Setenv("KUKE_RUN_REALM", "from-env-realm")
-	t.Setenv("KUKE_RUN_SPACE", "from-env-space")
-	t.Setenv("KUKE_RUN_STACK", "from-env-stack")
-
-	gotLookup := v1beta1.CellBlueprintMetadata{}
-	fc := &fakeClient{
-		getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			gotLookup = doc.Metadata
-			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
-		},
-		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
-		},
-		applyFn: func([]byte) (kukeonv1.ApplyDocumentsResult, error) {
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{{Kind: "Cell", Name: "myCell", Action: "created"}},
-			}, nil
-		},
-	}
-
-	_, err := runApplyRef(t, fc, []string{
-		"-b", "web", "--name", "myCell",
-		"--realm", "flag-realm",
-		"--space", "flag-space",
-		"--stack", "flag-stack",
-	})
-	if err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if gotLookup.Realm != "flag-realm" {
-		t.Errorf("blueprint lookup realm=%q want flag-realm (env should not override flag)", gotLookup.Realm)
-	}
-	if gotLookup.Space != "flag-space" {
-		t.Errorf("blueprint lookup space=%q want flag-space", gotLookup.Space)
-	}
-	if gotLookup.Stack != "flag-stack" {
-		t.Errorf("blueprint lookup stack=%q want flag-stack", gotLookup.Stack)
+		})
 	}
 }
 
 type fakeClient struct {
 	kukeonv1.FakeClient
 
-	applyFn        func(raw []byte) (kukeonv1.ApplyDocumentsResult, error)
-	getCellFn      func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
-	getBlueprintFn func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error)
-	getConfigFn    func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error)
+	applyFn func(raw []byte) (kukeonv1.ApplyDocumentsResult, error)
 
 	applyCalls int
 }
@@ -813,29 +254,4 @@ func (f *fakeClient) ApplyDocuments(_ context.Context, raw []byte) (kukeonv1.App
 		return kukeonv1.ApplyDocumentsResult{}, errors.New("unexpected ApplyDocuments call")
 	}
 	return f.applyFn(raw)
-}
-
-func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-	if f.getCellFn == nil {
-		return kukeonv1.GetCellResult{}, errdefs.ErrCellNotFound
-	}
-	return f.getCellFn(doc)
-}
-
-func (f *fakeClient) GetBlueprint(
-	_ context.Context, doc v1beta1.CellBlueprintDoc,
-) (kukeonv1.GetBlueprintResult, error) {
-	if f.getBlueprintFn == nil {
-		return kukeonv1.GetBlueprintResult{}, errors.New("unexpected GetBlueprint call")
-	}
-	return f.getBlueprintFn(doc)
-}
-
-func (f *fakeClient) GetConfig(
-	_ context.Context, doc v1beta1.CellConfigDoc,
-) (kukeonv1.GetConfigResult, error) {
-	if f.getConfigFn == nil {
-		return kukeonv1.GetConfigResult{}, errors.New("unexpected GetConfig call")
-	}
-	return f.getConfigFn(doc)
 }


### PR DESCRIPTION
## Summary

Step 4 of #819 — the final slice. Hard-removes `kuke apply -b/-c` (daemon-side reconcile-by-ref) so `kuke apply` is `apply -f <file>` only. With `kuke restart cell <name>` (#821) providing the reconcile path for Config-lineage workflows and OutOfSync surfaced in `kuke get cell` (#822), the apply-side reconcile-by-ref forms no longer have a unique role. No deprecation cycle per umbrella scope (no production kukeon yet).

### What ships

- **Flag definitions removed** from `cmd/kuke/apply/apply.go`: `-b/--blueprint`, `-c/--config`, `--name`, `--param`, `--param-file`, `--realm`, `--space`, `--stack`. The `-f/--file` and `-o/--output` flags remain. `cobra.MarkFlagsMutuallyExclusive` / `MarkFlagsOneRequired` calls drop — there is now exactly one source.
- **Code paths deleted**: `runApplyRef`, `loadCellRef`, `loadFromBlueprint`, `loadFromConfig`, `buildParamMap`, `resolveCellLocation`, `assertCellLineage`, `lineageExpectation`, `lineageMismatchError`. `runApply` now routes unconditionally to `runApplyFile`. `applyFlags` collapses to `{file, output}`.
- **Imports trimmed**: `cmd/config`, `internal/cellblueprint`, `internal/cellconfig`, `internal/cellprofile`, `pkg/api/model/v1beta1`, `gopkg.in/yaml.v3`, `os`, `strings`, `context` — all dropped from `apply.go`.
- **`Use:` / `Long` rewritten**: `Use: "apply -f <file>"`, `Short` / `Long` describe `-f` only with a one-line nod to `kuke restart cell` for Config reconciliation.
- **Shell completion registrations removed**: the `cmd.RegisterFlagCompletionFunc` calls for `realm`/`space`/`stack`/`blueprint`/`config` all came in alongside `-b/-c` and go away with them.
- **Tests in `cmd/kuke/apply/apply_test.go`**: every `-b`/`-c` test (`TestApply_FromBlueprint_*`, `TestApply_FromConfig_*`, `TestApply_BlueprintNotFound_Errors`, `TestApply_ConfigNotFound_Errors`, `TestApply_FromBlueprint_EnvVarScopeFallback`, `TestApply_FromConfig_EnvVarScopeFallback`, `TestApply_FromBlueprint_FlagWinsOverEnvVar`) deleted. The `TestApplyRunE` "no source flag" case retargets to "no file flag" against the new `file flag is required` error path. Added `TestApply_BlueprintFlag_Removed` and `TestApply_ConfigFlag_Removed` as removal-regression guards (asserts cobra's "unknown flag" error for `-b`/`--blueprint`/`-c`/`--config`).
- **`fakeClient` simplified**: only `ApplyDocuments` stays; `GetCell` / `GetBlueprint` / `GetConfig` fakes drop with their tests.

### Viper keys — verification per AC

The AC says "verify before deleting — some may be shared with run-side and need to stay or be split". Grep result: **no `KUKE_APPLY_BLUEPRINT` / `KUKE_APPLY_CONFIG` / `KUKE_APPLY_*` keys exist in `cmd/config/env.go` to begin with**. The apply code referenced `config.KUKE_RUN_REALM` / `KUKE_RUN_SPACE` / `KUKE_RUN_STACK` (the shared scope-lookup env vars that `kuke run -b/-c` also consumed). Those stay — they're still used by `kuke run -b/-c`. Nothing apply-side to retire.

### Out of scope (deliberately deferred)

- **Stale `kuke apply -c` / `kuke apply -b --name` migration pointers in `cmd/kuke/run/run.go`**. The cobra `Long:` help text (lines 77–79) and `rejectDivergentNamedCell` error messages (lines 459–481) point operators at the now-removed commands; godoc comments in `cmd/kuke/run/run.go`, `cmd/kuke/restart/cell/cell.go`, `internal/controller/reconcile_outofsync.go`, `internal/cellconfig/cellconfig.go`, and `pkg/api/model/v1beta1/cellblueprint.go` also reference them. Updating these touches `kuke run` UX surface and requires a UX call for the `-b --name` divergence case (umbrella: "not directly supported. Operator creates a Config..."). Filed as #844 (`chore: enhancement priority:B`). The doc-port phase of umbrella #819 (pm's `/plan-release-doc`) covers the `.md`-side references.
- **`kuke run -b/-c` reconcile-by-ref behaviour** — unaffected per the AC's "Out of scope" section.

### Test plan

- [x] `make test` — full root + kukebuild test suites pass (0 failures).
- [x] `GOWORK=off go build ./...` — clean compile.
- [x] `GOWORK=off go vet ./...` — no findings.
- [x] `pre-commit run --files cmd/kuke/apply/apply.go cmd/kuke/apply/apply_test.go` — go fmt / go-mod-tidy / golangci-lint / prettier / addlicense all green (golangci-lint auto-removed a redundant `args := args` shadow declaration on the first run; second pass is clean).
- [x] Removal verified via test: `TestApply_BlueprintFlag_Removed` and `TestApply_ConfigFlag_Removed` assert that `kuke apply -b`/`--blueprint`/`-c`/`--config` all exit with cobra's "unknown flag" error.
- [x] Viper-key audit: `grep -rn "KUKE_APPLY" /root/kukeon/ --include="*.go"` produced no matches — no apply-side viper keys to retire.
- [ ] `make dev-init` smoke — not run. This change is pure CLI surface (cobra flag definitions + their consumers in `cmd/kuke/apply/apply.go`); the daemon, build path, and `/opt/kukeon` are untouched. Per the project CLAUDE.md, the daemon-parity smoke is required when the change touches "the build path, the daemon, or anything under /opt/kukeon" — none apply here.

Closes #823
