### PR TITLE
fix(attach): extend liveness guard to refuse non-Ready cell state

### DIFF
--- a/cmd/kuke/attach/attach.go
+++ b/cmd/kuke/attach/attach.go
@@ -110,6 +110,20 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = client.Close() }()
 
+	// Cell-level liveness guard (#683, #852): refuse to attach to a cell
+	// whose state is anything other than Ready+task-live. Runs before the
+	// container picker so a missing cell surfaces a "create it first"
+	// pointer instead of falling out of ListContainers with
+	// ErrAttachNoCandidate, and so a Stopped / Failed cell short-circuits
+	// before the attach loop dials a now-orphan socket inode.
+	cellGet, err := client.GetCell(cmd.Context(), buildCellDoc(cell, realm, space, stack))
+	if err != nil {
+		return err
+	}
+	if err := kukeshared.GuardCellTaskLiveness(cellGet, cell); err != nil {
+		return err
+	}
+
 	if container == "" {
 		container, err = kukeshared.PickContainer(cmd.Context(), client, realm, space, stack, cell,
 			func(spec v1beta1.ContainerSpec) bool {
@@ -118,19 +132,6 @@ func runAttach(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-	}
-
-	// Divergence guard (#683): refuse to attach to a cell whose metadata records
-	// it Ready but whose root-container task is gone from containerd (post-reboot
-	// divergence). Without this, attach hands back a socket backed by a dead task
-	// and the sbsh loop fails with `connection refused`. Shares the run path's
-	// guard so both entry points refuse identically.
-	cellGet, err := client.GetCell(cmd.Context(), buildCellDoc(cell, realm, space, stack))
-	if err != nil {
-		return err
-	}
-	if err := kukeshared.GuardCellTaskLiveness(cellGet, cell); err != nil {
-		return err
 	}
 
 	doc := buildContainerDoc(container, realm, space, stack, cell)

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -597,3 +597,151 @@ func TestAttach_MissingCellArg(t *testing.T) {
 		t.Errorf("error %q does not mention arg-count requirement", err.Error())
 	}
 }
+
+// TestAttach_NotCreated_PointsAtRun covers #852: the cell-level liveness
+// guard fires before ListContainers, so a cell that has never been
+// created surfaces the operator-actionable "create it first" pointer
+// instead of falling out of the container picker with the unhelpful
+// ErrAttachNoCandidate. Also verifies the guard short-circuits before
+// reaching AttachContainer.
+func TestAttach_NotCreated_PointsAtRun(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listCalls := 0
+	attachCalls := 0
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{MetadataExists: false}, nil
+		},
+		listContainersFn: func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+			listCalls++
+			return nil, nil
+		},
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			attachCalls++
+			return kukeonv1.AttachContainerResult{}, nil
+		},
+	}
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1", "kukeon-pm-0",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil on missing cell, want NotCreated error")
+	}
+	if got := err.Error(); !strings.Contains(got, "does not exist") {
+		t.Errorf("error %q missing %q wording", got, "does not exist")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke run") {
+		t.Errorf("error %q missing `kuke run` recovery pointer", got)
+	}
+	if listCalls != 0 {
+		t.Errorf("ListContainers called %d times, want 0 (guard must fire first)", listCalls)
+	}
+	if attachCalls != 0 {
+		t.Errorf("AttachContainer called %d times, want 0", attachCalls)
+	}
+	if run.calls != 0 {
+		t.Errorf("attach.Run called %d times, want 0", run.calls)
+	}
+}
+
+// TestAttach_Stopped_PointsAtStart covers #852's repro signature: the
+// wind-down flow leaves the cell at Stopped with an orphan socket
+// inode, and the previous guard short-circuited on any non-Ready state.
+// Attach must now refuse with the start-it-first pointer instead of
+// dialing through to `connection refused`.
+func TestAttach_Stopped_PointsAtStart(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	attachCalls := 0
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                v1beta1.CellDoc{Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped}},
+				MetadataExists:      true,
+				RootContainerExists: true,
+				// Wind-down may leave the root task still alive (long-lived
+				// `sleep infinity`); the workload task is gone and that is
+				// what makes the cell unattachable.
+				RootContainerTaskRunning: true,
+			}, nil
+		},
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			attachCalls++
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "kukeon-pm-0",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil on Stopped cell, want start-it-first error")
+	}
+	if got := err.Error(); !strings.Contains(got, "Stopped") {
+		t.Errorf("error %q missing %q state name", got, "Stopped")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke start cell kukeon-pm-0") {
+		t.Errorf("error %q missing `kuke start cell kukeon-pm-0` recovery pointer", got)
+	}
+	if attachCalls != 0 {
+		t.Errorf("AttachContainer called %d times, want 0 (must not dial dead socket)", attachCalls)
+	}
+	if run.calls != 0 {
+		t.Errorf("attach.Run called %d times, want 0", run.calls)
+	}
+}
+
+// TestAttach_Failed_PointsAtDelete covers the Failed branch of the
+// generalized guard. A Failed cell is sticky per the reconciler, so the
+// only recovery is delete-then-rerun — same pointer as the
+// Ready+task-dead divergence path.
+func TestAttach_Failed_PointsAtDelete(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	attachCalls := 0
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                v1beta1.CellDoc{Status: v1beta1.CellStatus{State: v1beta1.CellStateFailed}},
+				MetadataExists:      true,
+				RootContainerExists: true,
+			}, nil
+		},
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			attachCalls++
+			return kukeonv1.AttachContainerResult{HostSocketPath: testHostSocket}, nil
+		},
+	}
+	run := &runCapture{}
+	cmd := newCmdWithCtx(t, fc, run)
+	cmd.SetArgs([]string{
+		"--realm", "r1", "--space", "s1", "--stack", "st1",
+		"--container", "work", "c1",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute returned nil on Failed cell, want delete-it-first error")
+	}
+	if got := err.Error(); !strings.Contains(got, "Failed") {
+		t.Errorf("error %q missing %q state name", got, "Failed")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke delete cell c1") {
+		t.Errorf("error %q missing `kuke delete cell c1` recovery pointer", got)
+	}
+	if attachCalls != 0 {
+		t.Errorf("AttachContainer called %d times, want 0", attachCalls)
+	}
+	if run.calls != 0 {
+		t.Errorf("attach.Run called %d times, want 0", run.calls)
+	}
+}

--- a/cmd/kuke/shared/cell_liveness.go
+++ b/cmd/kuke/shared/cell_liveness.go
@@ -23,34 +23,70 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
-// GuardCellTaskLiveness refuses to attach to a cell whose on-disk metadata
-// records it Ready but whose root-container task is gone from containerd. This
-// is the post-reboot divergence (#654, #683): containerd container *records*
-// survive a host/daemon restart while the backing tasks do not, so a
-// record-existence check passes even though attaching would land on a dead
-// socket. The guard keys on task liveness (the root task is Running) rather
-// than record existence.
+// GuardCellTaskLiveness refuses to attach to a cell whose persisted state
+// is anything other than "Ready with a live root-container task". It is
+// the single shared guard backing `kuke run`'s Ready short-circuit and
+// `kuke attach` — both entry points hand a host socket path to the
+// in-process sbsh attach loop, and both must refuse the same divergence
+// classes.
 //
-// It is scoped to Ready: a legitimately Stopped cell has no live task by
-// design, and the run path's Stopped branch starts it before attaching.
-// Returns nil when the cell is not Ready or its root task is live; otherwise
-// the diverged-state error with a delete-then-rerun pointer.
+// Five terminal answers, each with a state-appropriate operator pointer:
 //
-// Both `kuke run` (Ready short-circuit) and `kuke attach` call this before
-// handing a host socket path to the in-process sbsh attach loop — the single
-// shared guard backing both entry points.
+//   - !MetadataExists → the cell has never been created (or has already
+//     been deleted). Direct the operator at `kuke run` with the standard
+//     profile + name flags so attach is preceded by a creation, not by
+//     a confusing ListContainers empty.
+//   - Ready + RootContainerTaskRunning → nil (attach proceeds).
+//   - Ready + !RootContainerTaskRunning → the post-reboot divergence
+//     #683 was originally written for: the on-disk metadata records
+//     Ready but containerd has lost the backing task. Recovery is a
+//     delete-then-rerun so the next CreateCell starts from a clean
+//     containerd slate.
+//   - Stopped → the reconciler's wind-down (`refresh.go windDownCell`)
+//     has reaped the work container after its kuketty exited, so the
+//     attach socket inode is orphaned. Recovery is `kuke start cell` —
+//     the cell metadata is intact, so a restart re-binds kuketty
+//     against a fresh inode.
+//   - Pending / Failed / Unknown → no clean attach path. Same recovery
+//     as Ready+task-dead (delete-then-rerun); a Failed cell is sticky
+//     per the reconciler so only a delete clears it.
+//
+// `kuke run`'s switch in runExistingCell calls this from the Ready
+// branch only — its Stopped / Failed / Unknown branches route the
+// operator through their own verbs (StartCell, or the
+// delete-then-rerun pointer) — so the broader switch here is a
+// strict superset that only `kuke attach` exercises in full.
 func GuardCellTaskLiveness(get kukeonv1.GetCellResult, cellName string) error {
-	if get.Cell.Status.State != v1beta1.CellStateReady {
-		return nil
+	if !get.MetadataExists {
+		return fmt.Errorf(
+			"cell %q does not exist; create it first with "+
+				"`kuke run -p <profile> --name %s`",
+			cellName, cellName,
+		)
 	}
-	if get.RootContainerTaskRunning {
-		return nil
+	switch get.Cell.Status.State {
+	case v1beta1.CellStateReady:
+		if get.RootContainerTaskRunning {
+			return nil
+		}
+		return fmt.Errorf(
+			"cell %q is recorded Ready but its containers are gone from containerd "+
+				"(kukeon metadata and containerd have diverged); "+
+				"delete it with `kuke delete cell %s` before re-running",
+			cellName,
+			cellName,
+		)
+	case v1beta1.CellStateStopped:
+		return fmt.Errorf(
+			"cell %q is in state Stopped (no work container is running); "+
+				"start it first with `kuke start cell %s`",
+			cellName, cellName,
+		)
+	default:
+		return fmt.Errorf(
+			"cell %q is in state %s; "+
+				"delete it with `kuke delete cell %s` before re-running",
+			cellName, get.Cell.Status.State.String(), cellName,
+		)
 	}
-	return fmt.Errorf(
-		"cell %q is recorded Ready but its containers are gone from containerd "+
-			"(kukeon metadata and containerd have diverged); "+
-			"delete it with `kuke delete cell %s` before re-running",
-		cellName,
-		cellName,
-	)
 }

--- a/cmd/kuke/shared/cell_liveness_test.go
+++ b/cmd/kuke/shared/cell_liveness_test.go
@@ -1,0 +1,165 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared_test
+
+import (
+	"strings"
+	"testing"
+
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// readyGet builds a healthy Ready+task-live GetCellResult — the only
+// passing input to the guard. Helper isolates the boilerplate so each
+// state-specific case below only diffs the field it cares about.
+func readyGet() kukeonv1.GetCellResult {
+	return kukeonv1.GetCellResult{
+		Cell:                     v1beta1.CellDoc{Status: v1beta1.CellStatus{State: v1beta1.CellStateReady}},
+		MetadataExists:           true,
+		RootContainerExists:      true,
+		RootContainerTaskRunning: true,
+	}
+}
+
+func TestGuardCellTaskLiveness_ReadyTaskLive_Passes(t *testing.T) {
+	if err := kukeshared.GuardCellTaskLiveness(readyGet(), "c1"); err != nil {
+		t.Fatalf("guard returned %v on healthy Ready+task-live cell, want nil", err)
+	}
+}
+
+// TestGuardCellTaskLiveness_ReadyTaskDead_DivergedError pins #683's
+// existing message verbatim — operator muscle memory keys on "diverged"
+// and "kuke delete cell". The generalized #852 guard must not regress
+// this branch when broadening to non-Ready states.
+func TestGuardCellTaskLiveness_ReadyTaskDead_DivergedError(t *testing.T) {
+	get := readyGet()
+	get.RootContainerTaskRunning = false
+
+	err := kukeshared.GuardCellTaskLiveness(get, "c1")
+	if err == nil {
+		t.Fatal("guard returned nil on Ready+task-dead, want divergence error")
+	}
+	if got := err.Error(); !strings.Contains(got, "diverged") {
+		t.Errorf("error %q missing %q wording", got, "diverged")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke delete cell c1") {
+		t.Errorf("error %q missing `kuke delete cell c1` recovery pointer", got)
+	}
+}
+
+func TestGuardCellTaskLiveness_NotCreated_PointsAtRun(t *testing.T) {
+	get := kukeonv1.GetCellResult{MetadataExists: false}
+
+	err := kukeshared.GuardCellTaskLiveness(get, "kukeon-pm-0")
+	if err == nil {
+		t.Fatal("guard returned nil on !MetadataExists, want NotCreated error")
+	}
+	if got := err.Error(); !strings.Contains(got, "does not exist") {
+		t.Errorf("error %q missing %q wording", got, "does not exist")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke run") {
+		t.Errorf("error %q missing `kuke run` recovery pointer", got)
+	}
+	if got := err.Error(); !strings.Contains(got, "--name kukeon-pm-0") {
+		t.Errorf("error %q missing `--name kukeon-pm-0` recovery pointer", got)
+	}
+}
+
+// TestGuardCellTaskLiveness_Stopped_PointsAtStart is the regression that
+// motivated #852: the wind-down flow leaves the cell at Stopped with an
+// orphan socket inode, and the guard previously short-circuited on any
+// non-Ready state. The new branch must surface the "start it first"
+// pointer so the operator's next move is `kuke start cell`, not
+// `connection refused` on the next dial.
+func TestGuardCellTaskLiveness_Stopped_PointsAtStart(t *testing.T) {
+	get := readyGet()
+	get.Cell.Status.State = v1beta1.CellStateStopped
+	get.RootContainerTaskRunning = false
+
+	err := kukeshared.GuardCellTaskLiveness(get, "kukeon-pm-0")
+	if err == nil {
+		t.Fatal("guard returned nil on Stopped cell, want start-it-first error")
+	}
+	if got := err.Error(); !strings.Contains(got, "Stopped") {
+		t.Errorf("error %q missing %q state name", got, "Stopped")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke start cell kukeon-pm-0") {
+		t.Errorf("error %q missing `kuke start cell kukeon-pm-0` recovery pointer", got)
+	}
+}
+
+// TestGuardCellTaskLiveness_Failed_PointsAtDelete covers the Failed
+// branch's delete-then-rerun pointer (parity with Ready+task-dead). A
+// Failed cell is sticky per the reconciler so only a delete clears it.
+func TestGuardCellTaskLiveness_Failed_PointsAtDelete(t *testing.T) {
+	get := readyGet()
+	get.Cell.Status.State = v1beta1.CellStateFailed
+	get.RootContainerTaskRunning = false
+
+	err := kukeshared.GuardCellTaskLiveness(get, "c1")
+	if err == nil {
+		t.Fatal("guard returned nil on Failed cell, want delete-it-first error")
+	}
+	if got := err.Error(); !strings.Contains(got, "Failed") {
+		t.Errorf("error %q missing %q state name", got, "Failed")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke delete cell c1") {
+		t.Errorf("error %q missing `kuke delete cell c1` recovery pointer", got)
+	}
+}
+
+// TestGuardCellTaskLiveness_Unknown_PointsAtDelete covers the Unknown
+// branch (transient containerd hiccup or a missing cgroup with surviving
+// container records). The pointer is the same delete-then-rerun as
+// Failed — there is no clean attach path either way.
+func TestGuardCellTaskLiveness_Unknown_PointsAtDelete(t *testing.T) {
+	get := readyGet()
+	get.Cell.Status.State = v1beta1.CellStateUnknown
+	get.RootContainerTaskRunning = false
+
+	err := kukeshared.GuardCellTaskLiveness(get, "c1")
+	if err == nil {
+		t.Fatal("guard returned nil on Unknown cell, want delete-it-first error")
+	}
+	if got := err.Error(); !strings.Contains(got, "Unknown") {
+		t.Errorf("error %q missing %q state name", got, "Unknown")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke delete cell c1") {
+		t.Errorf("error %q missing `kuke delete cell c1` recovery pointer", got)
+	}
+}
+
+// TestGuardCellTaskLiveness_Pending_PointsAtDelete: Pending is the
+// reconciler's transient "mid-creation" label; from the operator's
+// perspective at attach time it means the cell is not yet usable. Treat
+// it like Failed/Unknown — point at delete-then-rerun rather than wait
+// indefinitely for a state transition that may never come.
+func TestGuardCellTaskLiveness_Pending_PointsAtDelete(t *testing.T) {
+	get := readyGet()
+	get.Cell.Status.State = v1beta1.CellStatePending
+	get.RootContainerTaskRunning = false
+
+	err := kukeshared.GuardCellTaskLiveness(get, "c1")
+	if err == nil {
+		t.Fatal("guard returned nil on Pending cell, want delete-it-first error")
+	}
+	if got := err.Error(); !strings.Contains(got, "kuke delete cell c1") {
+		t.Errorf("error %q missing `kuke delete cell c1` recovery pointer", got)
+	}
+}

--- a/internal/client/local/attach_guard_test.go
+++ b/internal/client/local/attach_guard_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// containerWith builds a minimal intmodel.Container with the named
+// state so each guard case below only diffs the field it cares about.
+// The cell/container identity strings flow into the error message and
+// are asserted in the negative cases.
+func containerWith(state intmodel.ContainerState) intmodel.Container {
+	return intmodel.Container{
+		Spec: intmodel.ContainerSpec{
+			ID:       "work",
+			CellName: "kukeon-pm-0",
+		},
+		Status: intmodel.ContainerStatus{State: state},
+	}
+}
+
+// TestGuardAttachableTaskLiveness_Ready_Passes pins the only passing
+// input to the server-side gate: the container's task must be Ready
+// (Running) for AttachContainer to hand back a socket path.
+func TestGuardAttachableTaskLiveness_Ready_Passes(t *testing.T) {
+	if err := guardAttachableTaskLiveness(containerWith(intmodel.ContainerStateReady)); err != nil {
+		t.Fatalf("guard returned %v on Ready task, want nil", err)
+	}
+}
+
+// TestGuardAttachableTaskLiveness_NonReady_RefusesWithTypedError covers
+// the #852 server-side check: every non-Ready state must surface
+// errdefs.ErrAttachTaskNotRunning so that any consumer bypassing the
+// CLI guard (raw RPC clients, scripts, in-process callers in
+// alternative branches) still gets a typed refusal instead of a socket
+// path that resolves to a dead inode.
+func TestGuardAttachableTaskLiveness_NonReady_RefusesWithTypedError(t *testing.T) {
+	cases := []struct {
+		name  string
+		state intmodel.ContainerState
+		// wantStateText is the substring the error must include so the
+		// operator can see which actual state triggered the refusal —
+		// distinguishing a Stopped container (expected post-wind-down)
+		// from a Failed one (sticky terminal) without reading server
+		// logs.
+		wantStateText string
+	}{
+		{"Stopped", intmodel.ContainerStateStopped, "Stopped"},
+		{"Failed", intmodel.ContainerStateFailed, "Failed"},
+		{"Unknown", intmodel.ContainerStateUnknown, "Unknown"},
+		{"Pending", intmodel.ContainerStatePending, "Pending"},
+		{"NotCreated", intmodel.ContainerStateNotCreated, "NotCreated"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := guardAttachableTaskLiveness(containerWith(tc.state))
+			if err == nil {
+				t.Fatalf("guard returned nil on %s container, want ErrAttachTaskNotRunning", tc.name)
+			}
+			if !errors.Is(err, errdefs.ErrAttachTaskNotRunning) {
+				t.Fatalf("error %v does not unwrap to ErrAttachTaskNotRunning", err)
+			}
+			if got := err.Error(); !strings.Contains(got, tc.wantStateText) {
+				t.Errorf("error %q missing state-name %q", got, tc.wantStateText)
+			}
+			if got := err.Error(); !strings.Contains(got, "work") {
+				t.Errorf("error %q missing container ID %q", got, "work")
+			}
+			if got := err.Error(); !strings.Contains(got, "kukeon-pm-0") {
+				t.Errorf("error %q missing cell name %q", got, "kukeon-pm-0")
+			}
+		})
+	}
+}

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -1185,10 +1185,10 @@ func controllerImageToWire(img controller.ImageInfo) kukeonv1.ImageInfo {
 
 // ---- Attach ----
 
-// AttachContainer enforces the Attachable gate and resolves the host-side
-// sbsh control-socket path. Bytes never traverse this RPC — the caller
-// (`kuke attach`) opens HostSocketPath directly and runs the sbsh client
-// loop against it.
+// AttachContainer enforces the Attachable gate, the server-side task-
+// liveness gate, and resolves the host-side sbsh control-socket path.
+// Bytes never traverse this RPC — the caller (`kuke attach`) opens
+// HostSocketPath directly and runs the sbsh client loop against it.
 //
 // Returns the SUN_PATH-safe symlink path (fs.ContainerSocketSymlinkPath)
 // rather than the deep socket inode path so `connect(2)` never sees a
@@ -1196,17 +1196,52 @@ func controllerImageToWire(img controller.ImageInfo) kukeonv1.ImageInfo {
 // metadata layout is (issue #521). The runner stages the symlink at
 // provision time so a re-derived path on a freshly-spawned `kuke attach`
 // is always pre-materialised.
+//
+// Task-liveness gate (#852): the in-CLI cmd/kuke/shared.GuardCellTaskLiveness
+// catches the common case, but any consumer that bypasses the CLI (raw
+// RPC clients, scripts, in-process callers in alternative branches) would
+// otherwise receive a socket path backed by nothing whenever the target
+// container's task is not Running. Refuse with ErrAttachTaskNotRunning
+// instead, mirroring the client-side guard's predicate at the server
+// boundary so every caller — CLI or not — gets the same typed refusal.
 func (c *Client) AttachContainer(_ context.Context, doc v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
-	spec, err := c.resolveAttachable(doc)
+	container, err := c.resolveAttachable(doc)
 	if err != nil {
 		return kukeonv1.AttachContainerResult{}, err
 	}
+	if err := guardAttachableTaskLiveness(container); err != nil {
+		return kukeonv1.AttachContainerResult{}, err
+	}
+	spec := container.Spec
 	return kukeonv1.AttachContainerResult{
 		HostSocketPath: fs.ContainerSocketSymlinkPath(
 			c.ctrl.RunPath(),
 			spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
 		),
 	}, nil
+}
+
+// guardAttachableTaskLiveness is the server-side task-liveness gate for
+// AttachContainer (#852): refuses to hand back a socket path when the
+// target container's task is not Running. Extracted so the predicate is
+// unit-testable without a controller.Exec round-trip. Mirrors the
+// client-side cmd/kuke/shared.GuardCellTaskLiveness predicate at the
+// per-attachable-container granularity that's natural at the server
+// boundary (the container's own task is what binds the kuketty socket).
+func guardAttachableTaskLiveness(container intmodel.Container) error {
+	if container.Status.State == intmodel.ContainerStateReady {
+		return nil
+	}
+	// ContainerState ordinals are kept in lockstep with the v1beta1 enum
+	// (see modelhub.ContainerState's doc); cast for the String() method.
+	state := v1beta1.ContainerState(container.Status.State)
+	return fmt.Errorf(
+		"%w: container %q in cell %q has state %s",
+		errdefs.ErrAttachTaskNotRunning,
+		container.Spec.ID,
+		container.Spec.CellName,
+		state.String(),
+	)
 }
 
 // ---- Log ----
@@ -1252,28 +1287,31 @@ func (c *Client) LogContainer(_ context.Context, doc v1beta1.ContainerDoc) (kuke
 	}, nil
 }
 
-// resolveAttachable normalizes doc, looks up the container, and returns its
-// internal spec only when Attachable=true. It surfaces ErrConversionFailed
-// for malformed docs, ErrContainerNotFound when the container does not
-// exist, and ErrAttachNotSupported for non-Attachable targets — the
-// invariants both AttachContainer and LogContainer require before handing a
-// host path back to the caller.
-func (c *Client) resolveAttachable(doc v1beta1.ContainerDoc) (intmodel.ContainerSpec, error) {
+// resolveAttachable normalizes doc, looks up the container, and returns
+// the full intmodel.Container (spec + freshly-queried status) only when
+// Attachable=true. It surfaces ErrConversionFailed for malformed docs,
+// ErrContainerNotFound when the container does not exist, and
+// ErrAttachNotSupported for non-Attachable targets — the invariants both
+// AttachContainer and LogContainer require before handing a host path
+// back to the caller. AttachContainer also inspects Status.State to gate
+// on task liveness (#852); LogContainer ignores Status since reading a
+// per-container log file does not require a live task.
+func (c *Client) resolveAttachable(doc v1beta1.ContainerDoc) (intmodel.Container, error) {
 	internal, _, err := apischeme.NormalizeContainer(doc)
 	if err != nil {
-		return intmodel.ContainerSpec{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
+		return intmodel.Container{}, fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
 	}
 	res, err := c.ctrl.GetContainer(internal)
 	if err != nil {
-		return intmodel.ContainerSpec{}, err
+		return intmodel.Container{}, err
 	}
 	if !res.ContainerExists {
-		return intmodel.ContainerSpec{}, errdefs.ErrContainerNotFound
+		return intmodel.Container{}, errdefs.ErrContainerNotFound
 	}
 	if !res.Container.Spec.Attachable {
-		return intmodel.ContainerSpec{}, errdefs.ErrAttachNotSupported
+		return intmodel.Container{}, errdefs.ErrAttachNotSupported
 	}
-	return res.Container.Spec, nil
+	return res.Container, nil
 }
 
 // ---- Ping ----

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -664,3 +664,40 @@ func removeAttachableSocketSymlink(runPath string, spec intmodel.ContainerSpec) 
 	}
 	return nil
 }
+
+// removeAttachableSocketRuntimeArtifacts unlinks both the SUN_PATH-safe
+// symlink (under <RunPath>/s/) and the host-side socket inode (the deep
+// bind-mount source path kuketty binds inside the container) for an
+// Attachable container. Called on every clean teardown of a cell —
+// `kuke stop cell`, `kuke kill cell`, and the reconciler's wind-down
+// (#852). Defense-in-depth complement to the client- and server-side
+// task-liveness guards: when a kuketty exits and never restarts (cell
+// wound down, daemon restart, host reboot), the inode it bound persists
+// across the host, so the next `kuke attach` that slips past the guards
+// dials a dead socket and surfaces `connection refused`. Unlinking on
+// the way down means the next `connect(2)` sees ENOENT instead — a
+// cleaner error class regardless of which guard race surfaced it.
+//
+// Both deletions are best-effort: a missing path (idempotent under
+// repeated stops or a delete that already RemoveAll'd the metadata
+// tree) is not an error, and a non-NotExist failure on one path does
+// not abort the other — the goal is to leave the host with no orphan
+// inode for the next `kuke attach` to dial. Skips non-Attachable specs
+// so cell-level teardown can call it unconditionally per container.
+func removeAttachableSocketRuntimeArtifacts(runPath string, spec intmodel.ContainerSpec) error {
+	if !spec.Attachable {
+		return nil
+	}
+	var errs []error
+	if err := removeAttachableSocketSymlink(runPath, spec); err != nil {
+		errs = append(errs, err)
+	}
+	socketPath := fs.ContainerSocketPath(
+		runPath,
+		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		errs = append(errs, fmt.Errorf("remove socket inode %q: %w", socketPath, err))
+	}
+	return errors.Join(errs...)
+}

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -760,6 +760,137 @@ func newTestRunner(t *testing.T) *Exec {
 	}
 }
 
+// TestRemoveAttachableSocketRuntimeArtifacts_RemovesBothInodes covers
+// the #852 teardown hook: on every clean stop / kill / wind-down, both
+// the SUN_PATH-safe symlink at <RunPath>/s/<hash> and the deep socket
+// inode at <ContainerTTYDir>/socket must be unlinked so the next
+// `kuke attach` that slips past the cell-state liveness guard gets
+// ENOENT instead of `connection refused` from a dead inode.
+func TestRemoveAttachableSocketRuntimeArtifacts_RemovesBothInodes(t *testing.T) {
+	runPath := t.TempDir()
+	spec := intmodel.ContainerSpec{
+		ID:         "work",
+		RealmName:  "r1",
+		SpaceName:  "s1",
+		StackName:  "st1",
+		CellName:   "c1",
+		Attachable: true,
+	}
+
+	// Stage the symlink the way ensureAttachableSocketSymlink would on
+	// provision: the helper this test exercises is the symmetric
+	// teardown counterpart, so the seed must mirror what's actually on
+	// disk after a healthy boot.
+	if err := ensureAttachableSocketSymlink(runPath, spec); err != nil {
+		t.Fatalf("ensureAttachableSocketSymlink: %v", err)
+	}
+
+	// Stage the deep socket inode kuketty would bind inside the
+	// container. A plain file is fine for the unlink test — the kernel
+	// distinguishes socket inodes at connect(2) time, not at unlink(2)
+	// time, so a regular file standing in for the bound socket is
+	// indistinguishable to os.Remove.
+	socketPath := fs.ContainerSocketPath(
+		runPath, spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
+		t.Fatalf("mkdir socket parent: %v", err)
+	}
+	if err := os.WriteFile(socketPath, nil, 0o600); err != nil {
+		t.Fatalf("seed socket inode: %v", err)
+	}
+
+	if err := removeAttachableSocketRuntimeArtifacts(runPath, spec); err != nil {
+		t.Fatalf("removeAttachableSocketRuntimeArtifacts: %v", err)
+	}
+
+	symlinkPath := fs.ContainerSocketSymlinkPath(
+		runPath, spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if _, err := os.Lstat(symlinkPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("symlink %q still exists (lstat err = %v), want ErrNotExist", symlinkPath, err)
+	}
+	if _, err := os.Lstat(socketPath); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("socket inode %q still exists (lstat err = %v), want ErrNotExist", socketPath, err)
+	}
+}
+
+// TestRemoveAttachableSocketRuntimeArtifacts_Idempotent locks the
+// best-effort contract: a second call against the same spec (or a
+// first call against a never-provisioned spec) must succeed silently.
+// killCellLocked / stopCellLocked call this on every workload
+// container per teardown, and the wind-down path can race them — a
+// non-NotExist error on a missing path would otherwise spam warnings
+// and obscure real failures.
+func TestRemoveAttachableSocketRuntimeArtifacts_Idempotent(t *testing.T) {
+	runPath := t.TempDir()
+	spec := intmodel.ContainerSpec{
+		ID:         "work",
+		RealmName:  "r1",
+		SpaceName:  "s1",
+		StackName:  "st1",
+		CellName:   "c1",
+		Attachable: true,
+	}
+
+	// First call against a never-provisioned spec: both paths absent →
+	// must return nil.
+	if err := removeAttachableSocketRuntimeArtifacts(runPath, spec); err != nil {
+		t.Fatalf("first call against absent paths returned %v, want nil", err)
+	}
+
+	if err := ensureAttachableSocketSymlink(runPath, spec); err != nil {
+		t.Fatalf("ensureAttachableSocketSymlink: %v", err)
+	}
+	if err := removeAttachableSocketRuntimeArtifacts(runPath, spec); err != nil {
+		t.Fatalf("call after symlink-only seed returned %v, want nil", err)
+	}
+	// Repeat: nothing on disk now, still must return nil.
+	if err := removeAttachableSocketRuntimeArtifacts(runPath, spec); err != nil {
+		t.Fatalf("second call against absent paths returned %v, want nil", err)
+	}
+}
+
+// TestRemoveAttachableSocketRuntimeArtifacts_SkipsNonAttachable
+// locks the !Attachable short-circuit: kill/stopCellLocked iterate
+// over every container in the cell spec and call this unconditionally,
+// so the helper must no-op for root and non-Attachable workloads.
+// Otherwise it would surface confusing remove-errors on cells whose
+// containers were never sbsh-wrapped.
+func TestRemoveAttachableSocketRuntimeArtifacts_SkipsNonAttachable(t *testing.T) {
+	runPath := t.TempDir()
+	spec := intmodel.ContainerSpec{
+		ID:         "root",
+		RealmName:  "r1",
+		SpaceName:  "s1",
+		StackName:  "st1",
+		CellName:   "c1",
+		Root:       true,
+		Attachable: false,
+	}
+
+	// Seed a file at the deep socket path even though !Attachable: a
+	// future refactor that drops the short-circuit must not unlink
+	// state that doesn't belong to it.
+	socketPath := fs.ContainerSocketPath(
+		runPath, spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
+		t.Fatalf("mkdir socket parent: %v", err)
+	}
+	if err := os.WriteFile(socketPath, nil, 0o600); err != nil {
+		t.Fatalf("seed socket inode: %v", err)
+	}
+
+	if err := removeAttachableSocketRuntimeArtifacts(runPath, spec); err != nil {
+		t.Fatalf("removeAttachableSocketRuntimeArtifacts returned %v, want nil", err)
+	}
+	if _, err := os.Stat(socketPath); err != nil {
+		t.Errorf("unrelated socket inode %q was removed (stat err = %v); helper must short-circuit on !Attachable",
+			socketPath, err)
+	}
+}
+
 func readDoc(t *testing.T, path string) extmodel.ContainerDoc {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -292,6 +292,26 @@ func (r *Exec) killCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 	// Update cell state in internal model
 	internalCell.Status.State = intmodel.CellStateStopped
 
+	// Unlink each Attachable container's host-side socket artifacts (the
+	// SUN_PATH-safe symlink under <RunPath>/s/ and the deep socket inode
+	// kuketty bound). Defense-in-depth for #852: without this the next
+	// `kuke attach` that slips past the cell-state liveness guard would
+	// dial a now-orphan inode and surface `connection refused`. Removing
+	// here means the next connect(2) sees ENOENT instead. Best-effort —
+	// errors are logged and we continue, matching the rest of this
+	// function's "log warning but don't fail" cleanup discipline.
+	for _, containerSpec := range internalCell.Spec.Containers {
+		if symlinkErr := removeAttachableSocketRuntimeArtifacts(r.opts.RunPath, containerSpec); symlinkErr != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to remove attach socket runtime artifacts",
+				"container", containerSpec.ID,
+				"cell", cellName,
+				"error", symlinkErr,
+			)
+		}
+	}
+
 	// Populate container statuses after killing cell and persist them
 	if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
 		r.logger.WarnContext(r.ctx, "failed to populate container statuses",

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -314,6 +314,26 @@ func (r *Exec) stopCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 	// Update cell state in internal model
 	internalCell.Status.State = intmodel.CellStateStopped
 
+	// Unlink each Attachable container's host-side socket artifacts (the
+	// SUN_PATH-safe symlink under <RunPath>/s/ and the deep socket inode
+	// kuketty bound). Defense-in-depth for #852: without this the next
+	// `kuke attach` that slips past the cell-state liveness guard would
+	// dial a now-orphan inode and surface `connection refused`. Removing
+	// here means the next connect(2) sees ENOENT instead. Best-effort —
+	// errors are logged and we continue, matching the rest of this
+	// function's "log warning but don't fail" cleanup discipline.
+	for _, containerSpec := range internalCell.Spec.Containers {
+		if symlinkErr := removeAttachableSocketRuntimeArtifacts(r.opts.RunPath, containerSpec); symlinkErr != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to remove attach socket runtime artifacts",
+				"container", containerSpec.ID,
+				"cell", cellName,
+				"error", symlinkErr,
+			)
+		}
+	}
+
 	// Populate container statuses after stopping cell and persist them
 	if err = r.PopulateAndPersistCellContainerStatuses(&internalCell); err != nil {
 		r.logger.WarnContext(r.ctx, "failed to populate container statuses",

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -244,6 +244,16 @@ var (
 	// non-root attachable containers.
 	ErrAttachNoCandidate = errors.New("no attachable container in cell")
 
+	// ErrAttachTaskNotRunning is returned by the daemon's AttachContainer
+	// endpoint when the target attachable container exists in the cell spec
+	// and is Attachable but its containerd task is not Running. Server-side
+	// complement to cmd/kuke/shared.GuardCellTaskLiveness: any consumer that
+	// bypasses the CLI guard (RPC clients, scripts, future API consumers,
+	// in-process callers in alternative run-path branches) still gets a
+	// typed refusal instead of an unbacked socket path that would surface
+	// as `connection refused` at `connect(2)` time (#852).
+	ErrAttachTaskNotRunning = errors.New("container task is not running; cannot attach to a dead socket")
+
 	// ErrSocketPathTooLong fires when the resolved host-side path of a
 	// per-container kuketty control socket would overflow Linux's
 	// sockaddr_un.sun_path buffer (consts.KukeonMaxSocketPath bytes plus

--- a/pkg/api/kukeonv1/errmap.go
+++ b/pkg/api/kukeonv1/errmap.go
@@ -58,6 +58,7 @@ var kindToSentinel = map[string]error{
 	"ContainerExists":         errdefs.ErrContainerExists,
 	"ConversionFailed":        errdefs.ErrConversionFailed,
 	"AttachNotSupported":      errdefs.ErrAttachNotSupported,
+	"AttachTaskNotRunning":    errdefs.ErrAttachTaskNotRunning,
 	"ImageNotFound":           errdefs.ErrImageNotFound,
 	"ConfigNotFound":          errdefs.ErrConfigNotFound,
 	"ConfigExists":            errdefs.ErrConfigExists,


### PR DESCRIPTION
## Summary

- Generalize `GuardCellTaskLiveness` (`cmd/kuke/shared/cell_liveness.go`) to refuse on every non-Ready cell state — `NotCreated` (`!MetadataExists`), `Stopped`, `Pending`, `Failed`, `Unknown` — each with a state-appropriate recovery pointer (`kuke run` for NotCreated, `kuke start cell` for Stopped, `kuke delete cell` for Failed/Unknown/Pending). The `Ready` + `RootContainerTaskRunning` happy path is unchanged, and the `Ready` + task-dead branch keeps #683's "diverged" wording verbatim.
- Reorder `kuke attach` (`cmd/kuke/attach/attach.go`) to call the cell-liveness guard **before** `PickContainer`, so a missing cell surfaces "create it first" instead of falling out of the picker with `ErrAttachNoCandidate`.
- Unlink the host-side attach socket inode **and** the SUN_PATH-safe symlink on every clean teardown — `KillCell`, `StopCell`, and (transitively) the reconciler's `windDownCell` — via a new `removeAttachableSocketRuntimeArtifacts` helper next to the existing `removeAttachableSocketSymlink`. Defense-in-depth so any consumer that slips past the guards gets `ENOENT` instead of `connection refused` from a dead inode.
- Add a server-side task-liveness check inside `(*local.Client).AttachContainer` (`internal/client/local/local.go`) — refuses with a new typed `errdefs.ErrAttachTaskNotRunning` (wired through `kukeonv1/errmap.go` so it survives the wire round-trip) when the target container's task is not `Running`. Catches RPC clients, scripts, and in-process callers that bypass the CLI guard.
- Tests cover the four cell states (Ready+live, Ready+dead-task, Stopped, Failed, plus NotCreated/Unknown/Pending for completeness) on both the shared guard and the `kuke attach` CLI plumbing, the server-side `guardAttachableTaskLiveness` predicate (Ready passes; Stopped/Failed/Unknown/Pending/NotCreated all return `ErrAttachTaskNotRunning`), and the post-teardown socket cleanup (both inodes removed; idempotent on repeat; short-circuits on non-Attachable specs).

## Test plan

- [x] \`make test\` (full repo + kukebuild) — all packages pass.
- [x] \`GOWORK=off go vet ./...\` — clean.
- [x] Targeted: \`go test ./cmd/kuke/shared/... ./cmd/kuke/attach/... ./internal/client/local/... ./internal/controller/runner/...\` — all new cases pass.
- [ ] \`make dev-init\` smoke not run — the change is contained to the attach guard / teardown cleanup / server-side liveness check and does not touch the daemon bootstrap path, the build path, or anything under \`/opt/kukeon\` provisioning. Reviewer can re-run the project's smoke on a host with containerd available if they want the daemon-parity tail re-checked.
- [ ] Manual repro of the issue's end-to-end \`kuke attach <stopped-cell>\` scenario not run on this host (no live cell in a wound-down state to attach to). The behavior is covered by the new \`TestAttach_Stopped_PointsAtStart\` unit case driving the same code path.

## Notes

- AC #3 specifies the server-side check should "mirror the client-side guard's predicates (task is Running)". The client-side guard checks the **cell's root** task liveness as a proxy for the cell being alive; the server-side check operates at the **attachable container's own** task level — that's the more precise predicate at the per-`AttachContainer` boundary (the kuketty process that binds the socket runs inside that specific container, not the cell's root). Documented in `local.go`'s `guardAttachableTaskLiveness` doc.
- The unlink helper removes both the symlink (`<RunPath>/s/<hash>`) and the deep socket inode (`<ContainerTTYDir>/socket`) — the AC mentions "host-side attach socket inode" specifically; removing the symlink alone would give ENOENT at `connect(2)` time, but removing the inode too keeps the cell's bind-mount source clean for the next kuketty boot (kuketty's `claimSocketListener` removes-then-binds either way, so unlinking ahead of the next start is safe).
- `Pending` is folded into the "delete it" branch alongside Failed/Unknown. The reconciler labels `Pending` transiently mid-creation; from the attach caller's perspective at attach time it means the cell is not yet usable, and there's no clean "wait for it" pointer that fits — the operator deletes and re-runs.

Closes #852