### PR TITLE
fix(start): probe task liveness before marking cell Ready

### DIFF
--- a/internal/controller/runner/recreate_cell_test.go
+++ b/internal/controller/runner/recreate_cell_test.go
@@ -151,10 +151,28 @@ func TestRecreateCell_StartsTasksBeforeReady(t *testing.T) {
 	)
 
 	var startContainerCalls int
+	started := map[string]bool{}
 	fake := &recreateCellFakeClient{
-		deleteCellFakeClient: &deleteCellFakeClient{},
-		startContainerFn: func(_ string, _ ctr.ContainerSpec, _ ctr.TaskSpec) (containerd.Task, error) {
+		deleteCellFakeClient: &deleteCellFakeClient{
+			// Track per-container task liveness across two StartCell guards:
+			// (1) cellTasksAllRunningFn's idempotency skip (issue #149) — must
+			// NOT short-circuit here, because the existing cell's root has
+			// never been "started" in this fake, so its TaskStatus returns
+			// zero-value (not Running); the test then exercises the
+			// destructive teardown-and-recreate path the AC pins.
+			// (2) verifyCellTasksLiveAfterStart's post-start liveness probe
+			// (issue #851) — once startContainerFn runs, the new root task
+			// should observe as Running so the probe lets markCellReady stamp.
+			taskStatusFn: func(_, id string) (containerd.Status, error) {
+				if started[id] {
+					return containerd.Status{Status: containerd.Running}, nil
+				}
+				return containerd.Status{}, nil
+			},
+		},
+		startContainerFn: func(_ string, spec ctr.ContainerSpec, _ ctr.TaskSpec) (containerd.Task, error) {
 			startContainerCalls++
+			started[spec.ID] = true
 			return recreateCellTask{pid: 4242}, nil
 		},
 	}

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -32,6 +33,182 @@ import (
 	"github.com/eminwux/kukeon/internal/util/fs"
 	"github.com/eminwux/kukeon/internal/util/naming"
 )
+
+// cellStartLivenessGraceWindow caps the post-start liveness check at
+// 300ms — long enough to catch a container whose process exits within
+// milliseconds (kuketty fails to open its log file, an onInit script
+// returns non-zero, runc returns success but the workload immediately
+// faults), short enough that a healthy start sees no operator-visible
+// latency. cellStartLivenessPollInterval picks the cadence inside the
+// window; 50ms gives ~6 polls per healthy start and keeps the per-poll
+// containerd round-trip cost cheap. Issue #851.
+const (
+	cellStartLivenessGraceWindow  = 300 * time.Millisecond
+	cellStartLivenessPollInterval = 50 * time.Millisecond
+)
+
+// liveCheckResult is the per-probe outcome of firstNonLiveContainer.
+// ContainerdID == "" means every probed task reported containerd.Running;
+// otherwise ContainerdID names the first task that was not Running and
+// Status / Err capture what was observed (Status is zero-valued when
+// statusFn itself errored). ContainerID is the cell-spec ID — used to
+// quote the operator-facing name in the wrapped failure message; empty
+// when the offender is the root container (whose cell-spec entry is
+// optional under the auto-default-root path).
+type liveCheckResult struct {
+	ContainerdID string
+	ContainerID  string
+	Status       containerd.ProcessStatus
+	Err          error
+}
+
+// firstNonLiveContainer probes statusFn once per container — root first,
+// then each non-root entry in nonRootSpecs — and returns the first task
+// observed to not be containerd.Running. A statusFn error counts the
+// same as a non-Running status: a freshly-started task whose record
+// vanished mid-check is exactly the wind-down-then-race condition the
+// caller is guarding against. An empty ContainerdID is reported back so
+// a misconfigured spec (no ContainerdID stamped) trips the guard rather
+// than silently passing — matches the cellTasksAllRunningFn idempotency
+// guard's defensive treatment of the same case. Pure (modulo statusFn)
+// so the per-AC cases land as table-driven unit tests with no live
+// containerd. Issue #851.
+func firstNonLiveContainer(
+	rootContainerdID string,
+	nonRootSpecs []intmodel.ContainerSpec,
+	statusFn func(id string) (containerd.Status, error),
+) liveCheckResult {
+	rs, rerr := statusFn(rootContainerdID)
+	if rerr != nil || rs.Status != containerd.Running {
+		return liveCheckResult{
+			ContainerdID: rootContainerdID,
+			ContainerID:  "",
+			Status:       rs.Status,
+			Err:          rerr,
+		}
+	}
+	for _, c := range nonRootSpecs {
+		if c.Root {
+			continue
+		}
+		cid := strings.TrimSpace(c.ContainerdID)
+		if cid == "" {
+			return liveCheckResult{ContainerdID: "", ContainerID: c.ID}
+		}
+		s, err := statusFn(cid)
+		if err != nil || s.Status != containerd.Running {
+			return liveCheckResult{
+				ContainerdID: cid,
+				ContainerID:  c.ID,
+				Status:       s.Status,
+				Err:          err,
+			}
+		}
+	}
+	return liveCheckResult{}
+}
+
+// formatLivenessFailure wraps result into an operator-facing error that
+// the existing markCellFailed("StartCellFailed", retErr) path picks up
+// via the provisionStarted defer. cellName is included so the surface
+// text reads cleanly in `kuke run` output even when the offender is the
+// auto-default root (whose ContainerID is empty); rootContainerdID is
+// quoted in that case so the operator can still cross-reference
+// containerd state. The "kuke log <cell>" pointer is the actionable
+// next step — the per-container log file already carries the process
+// stdout/stderr that explains the immediate exit (kuketty errors, onInit
+// failures, image entrypoint segfaults). Issue #851.
+func formatLivenessFailure(cellName string, result liveCheckResult) error {
+	if result.ContainerdID == "" && result.ContainerID == "" {
+		// Defensive: caller invoked this with an "all Running" result.
+		// Returning a nil-equivalent error would mask the bug — surface a
+		// clear sentinel instead so the test catches it.
+		return fmt.Errorf("%w: %s: liveness check reported success",
+			internalerrdefs.ErrCellWindDownImmediate, cellName)
+	}
+	var label string
+	switch {
+	case result.ContainerID != "":
+		label = fmt.Sprintf("container %q", result.ContainerID)
+	default:
+		label = fmt.Sprintf("root container %q", result.ContainerdID)
+	}
+	var statusFragment string
+	if result.Err != nil {
+		statusFragment = fmt.Sprintf("status probe failed: %v", result.Err)
+	} else {
+		statusFragment = fmt.Sprintf("task status=%s", string(result.Status))
+	}
+	suffix := "; run `kuke log " + cellName + "` for details"
+	if result.ContainerID != "" {
+		suffix = "; run `kuke log " + cellName + " --container " + result.ContainerID + "` for details"
+	}
+	return fmt.Errorf("%w: cell %q: %s exited within startup grace window (%s)%s",
+		internalerrdefs.ErrCellWindDownImmediate, cellName, label, statusFragment, suffix)
+}
+
+// nonRootContainerSpecsFromCell returns the cell's non-root container
+// specs in declaration order — the slice firstNonLiveContainer iterates.
+// Cells with no non-root entries (kukeond-style: the root *is* the
+// workload) return an empty slice and the caller only probes the root.
+func nonRootContainerSpecsFromCell(cell intmodel.Cell) []intmodel.ContainerSpec {
+	if len(cell.Spec.Containers) == 0 {
+		return nil
+	}
+	out := make([]intmodel.ContainerSpec, 0, len(cell.Spec.Containers))
+	for _, c := range cell.Spec.Containers {
+		if c.Root {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// verifyCellTasksLiveAfterStart polls statusFn over graceWindow and
+// returns a wrapped internalerrdefs.ErrCellWindDownImmediate the first
+// time a probed task is observed not-Running, or nil after the window
+// elapses with every probe confirming all-Running. cellName threads into
+// the wrapped failure message so the operator-facing error names the
+// affected cell.
+//
+// Fail-fast: the first probe that returns a non-live result wins —
+// continuing to poll a dead task only burns latency. The healthy path
+// pays graceWindow worth of polls; this is deliberate (we have to wait
+// the window to know the task survived it) and bounded by the
+// implementer-chosen constants above. Issue #851.
+//
+// Decoupled from *Exec's concrete containerd client (statusFn closure)
+// and from real time (nowFn/sleepFn) so the integration tests can drive
+// arbitrary status sequences and verify both the fail-fast and
+// observe-through-window branches without a live runtime — same shape
+// as cellTasksAllRunningFn / teardownRootContainerCNI (issue #149).
+func verifyCellTasksLiveAfterStart(
+	cellName, rootContainerdID string,
+	nonRootSpecs []intmodel.ContainerSpec,
+	statusFn func(id string) (containerd.Status, error),
+	graceWindow, pollInterval time.Duration,
+	nowFn func() time.Time,
+	sleepFn func(time.Duration),
+) error {
+	if graceWindow <= 0 {
+		// Caller disabled the guard — preserve the prior behavior so
+		// tests that don't care about the post-start probe can pass
+		// graceWindow=0 and skip the wait.
+		return nil
+	}
+	deadline := nowFn().Add(graceWindow)
+	for {
+		result := firstNonLiveContainer(rootContainerdID, nonRootSpecs, statusFn)
+		if result.ContainerdID != "" || result.ContainerID != "" {
+			return formatLivenessFailure(cellName, result)
+		}
+		if !nowFn().Before(deadline) {
+			return nil
+		}
+		sleepFn(pollInterval)
+	}
+}
 
 // containerLogTaskSpec returns a TaskSpec with cio.LogFile IO pointed at the
 // per-container log path for a non-Attachable container. Returns the zero
@@ -611,7 +788,17 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 	// dance for them.
 	if !rootContainerWantsCNI(rootContainerSpec) {
 		skipFields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-		skipFields = append(skipFields, "space", spaceID, "realm", realmID, "pid", rootPID, "hostNetwork", rootContainerSpec.HostNetwork)
+		skipFields = append(
+			skipFields,
+			"space",
+			spaceID,
+			"realm",
+			realmID,
+			"pid",
+			rootPID,
+			"hostNetwork",
+			rootContainerSpec.HostNetwork,
+		)
 		r.logger.InfoContext(
 			r.ctx,
 			"skipping CNI attach for host-network root container",
@@ -873,7 +1060,11 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 		priorStages := priorStagesForContainer(internalCell, containerSpec.ID)
 		attachOpts, attachErr := r.attachableBuildOpts(namespace, containerSpec, creds, priorStages)
 		if attachErr != nil {
-			return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", ctrContainerID, attachErr)
+			return intmodel.Cell{}, fmt.Errorf(
+				"failed to prepare attachable container %s: %w",
+				ctrContainerID,
+				attachErr,
+			)
 		}
 		buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
 		// `kuke run --env` runtime-env merge (issue #834). Same shape as the
@@ -945,6 +1136,41 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 			"started container",
 			fields...,
 		)
+	}
+
+	// Post-start liveness probe (issue #851). containerd accepting task
+	// creation is not the same signal as "the task survived its startup".
+	// A workload that exits within milliseconds (kuketty failing to open
+	// its log file, an onInit script returning non-zero, runc returning
+	// success but the entrypoint immediately faulting) would otherwise
+	// land on disk as cell state=Ready, then the next reconciler tick
+	// derives Stopped from the dead workload, shouldWindDownCell fires
+	// KillCell, and the operator's in-flight `kuke run --attach` races
+	// the teardown. Polling here over a bounded grace window catches the
+	// fast-exit before the Ready stamp; the existing provisionStarted
+	// defer routes the wrapped ErrCellWindDownImmediate through
+	// markCellFailed("StartCellFailed", retErr), keeping the failure on
+	// the same code path runc-level startup failures already use.
+	if liveErr := verifyCellTasksLiveAfterStart(
+		cellName,
+		containerID,
+		nonRootContainerSpecsFromCell(internalCell),
+		func(id string) (containerd.Status, error) {
+			return r.ctrClient.TaskStatus(namespace, id)
+		},
+		cellStartLivenessGraceWindow,
+		cellStartLivenessPollInterval,
+		time.Now,
+		time.Sleep,
+	); liveErr != nil {
+		liveFields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+		liveFields = append(liveFields, "space", spaceID, "realm", realmID, "err", liveErr.Error())
+		r.logger.ErrorContext(
+			r.ctx,
+			"post-start liveness check failed; cell will transition to Failed",
+			liveFields...,
+		)
+		return intmodel.Cell{}, liveErr
 	}
 
 	markCellReady(&internalCell)
@@ -1240,6 +1466,46 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	updatedCell, err := r.GetCell(lookupCell)
 	if err != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to retrieve cell after starting container: %w", err)
+	}
+
+	// Post-start liveness probe (issue #851) — same shape as StartCell's
+	// guard. Probes the just-started container *and* the root, so a root
+	// container that died between this StartContainer call and the
+	// markCellReady stamp below also surfaces as Failed instead of the
+	// misleading Ready→Stopped→reaped cycle. The single-container variant
+	// (`kuke start container`) is operator-reachable just like `kuke start
+	// cell`, and the underlying silent-success failure mode is identical.
+	livenessSpec := []intmodel.ContainerSpec{{ID: containerID, ContainerdID: containerdID}}
+	if liveErr := verifyCellTasksLiveAfterStart(
+		cellName,
+		rootContainerID,
+		livenessSpec,
+		func(id string) (containerd.Status, error) {
+			return r.ctrClient.TaskStatus(namespace, id)
+		},
+		cellStartLivenessGraceWindow,
+		cellStartLivenessPollInterval,
+		time.Now,
+		time.Sleep,
+	); liveErr != nil {
+		liveFields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
+		liveFields = append(
+			liveFields,
+			"space",
+			spaceName,
+			"realm",
+			realmName,
+			"containerName",
+			containerID,
+			"err",
+			liveErr.Error(),
+		)
+		r.logger.ErrorContext(
+			r.ctx,
+			"post-start liveness check failed; cell will transition to Failed",
+			liveFields...,
+		)
+		return intmodel.Cell{}, liveErr
 	}
 
 	markCellReady(&updatedCell)

--- a/internal/controller/runner/start_test.go
+++ b/internal/controller/runner/start_test.go
@@ -377,6 +377,466 @@ func TestPurgeStaleRootContainerCNI_CreateFreshSafetyNet(t *testing.T) {
 	})
 }
 
+// TestFirstNonLiveContainer is the per-probe decision the post-start
+// liveness guard relies on (issue #851). Verifies the per-AC expansion:
+//
+//   - root running + every non-root running: AllRunning (no offender).
+//   - any non-root in a non-Running state: that container is the offender
+//     (AC item (a) — work container exits with non-zero code immediately).
+//   - root in a non-Running state: root is the offender (AC item (c) —
+//     `deriveCellStateFromNonRootContainerStatuses` only checks non-root,
+//     so without this branch a dead root would slip through to
+//     markCellReady).
+//   - statusFn error on either probe counts the same as a non-Running
+//     result — a freshly-started task whose record vanished mid-check is
+//     exactly the wind-down-then-race condition we're guarding against.
+//   - empty ContainerdID on a non-root spec is defensive: matches the
+//     cellTasksAllRunningFn idempotency-guard treatment of the same case.
+//   - Root: true entries inside cell.Spec.Containers are skipped — the
+//     auto-default-root branch never stamps such an entry, but the
+//     explicit-root branch does, and probing it via the non-root
+//     ContainerdID would double-count the root.
+func TestFirstNonLiveContainer(t *testing.T) {
+	const rootID = "space_stack_cell_root"
+
+	statusOf := func(states map[string]containerd.ProcessStatus) func(string) (containerd.Status, error) {
+		return func(id string) (containerd.Status, error) {
+			s, ok := states[id]
+			if !ok {
+				return containerd.Status{}, fmt.Errorf("no task for %q", id)
+			}
+			return containerd.Status{Status: s}, nil
+		}
+	}
+
+	tests := []struct {
+		name           string
+		nonRoot        []intmodel.ContainerSpec
+		fn             func(string) (containerd.Status, error)
+		wantAllRunning bool
+		wantOffender   string // empty when wantAllRunning=true; matches ContainerdID for root, ContainerID for non-root
+	}{
+		{
+			name:           "root running, no non-root containers — all live",
+			nonRoot:        nil,
+			fn:             statusOf(map[string]containerd.ProcessStatus{rootID: containerd.Running}),
+			wantAllRunning: true,
+		},
+		{
+			name: "root running, all non-root running — all live",
+			nonRoot: []intmodel.ContainerSpec{
+				{ID: "a", ContainerdID: "cid_a"},
+				{ID: "b", ContainerdID: "cid_b"},
+			},
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID:  containerd.Running,
+				"cid_a": containerd.Running,
+				"cid_b": containerd.Running,
+			}),
+			wantAllRunning: true,
+		},
+		{
+			name: "non-root exits with stopped — flagged (AC (a))",
+			nonRoot: []intmodel.ContainerSpec{
+				{ID: "work", ContainerdID: "cid_work"},
+			},
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID:     containerd.Running,
+				"cid_work": containerd.Stopped,
+			}),
+			wantAllRunning: false,
+			wantOffender:   "work",
+		},
+		{
+			name:    "root stopped immediately — flagged (AC (c))",
+			nonRoot: nil,
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID: containerd.Stopped,
+			}),
+			wantAllRunning: false,
+			wantOffender:   rootID,
+		},
+		{
+			name: "root stopped wins even when non-root would also fail",
+			nonRoot: []intmodel.ContainerSpec{
+				{ID: "work", ContainerdID: "cid_work"},
+			},
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID:     containerd.Stopped,
+				"cid_work": containerd.Stopped,
+			}),
+			wantAllRunning: false,
+			wantOffender:   rootID,
+		},
+		{
+			name:           "root status probe errors — flagged",
+			nonRoot:        nil,
+			fn:             statusOf(map[string]containerd.ProcessStatus{}), // no entry => err
+			wantAllRunning: false,
+			wantOffender:   rootID,
+		},
+		{
+			name: "non-root status probe errors — flagged",
+			nonRoot: []intmodel.ContainerSpec{
+				{ID: "work", ContainerdID: "cid_work"},
+			},
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID: containerd.Running,
+				// cid_work intentionally missing — statusFn errors
+			}),
+			wantAllRunning: false,
+			wantOffender:   "work",
+		},
+		{
+			name: "non-root with empty ContainerdID is flagged (defensive)",
+			nonRoot: []intmodel.ContainerSpec{
+				{ID: "work", ContainerdID: ""},
+			},
+			fn:             statusOf(map[string]containerd.ProcessStatus{rootID: containerd.Running}),
+			wantAllRunning: false,
+			wantOffender:   "work",
+		},
+		{
+			name: "Root:true entry inside nonRoot slice is skipped",
+			nonRoot: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, ContainerdID: "ignored"},
+				{ID: "work", ContainerdID: "cid_work"},
+			},
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID:     containerd.Running,
+				"cid_work": containerd.Running,
+			}),
+			wantAllRunning: true,
+		},
+		{
+			name: "first stopped non-root wins; second one is not probed",
+			nonRoot: []intmodel.ContainerSpec{
+				{ID: "a", ContainerdID: "cid_a"},
+				{ID: "b", ContainerdID: "cid_b"},
+			},
+			fn: statusOf(map[string]containerd.ProcessStatus{
+				rootID:  containerd.Running,
+				"cid_a": containerd.Stopped,
+				// cid_b deliberately missing — must not be probed (a wins first)
+			}),
+			wantAllRunning: false,
+			wantOffender:   "a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := firstNonLiveContainer(rootID, tt.nonRoot, tt.fn)
+			gotAllRunning := got.ContainerdID == "" && got.ContainerID == ""
+			if gotAllRunning != tt.wantAllRunning {
+				t.Errorf(
+					"firstNonLiveContainer() AllRunning = %v, want %v; result=%+v",
+					gotAllRunning,
+					tt.wantAllRunning,
+					got,
+				)
+			}
+			if tt.wantAllRunning {
+				return
+			}
+			// Match offender by whichever field is populated for that spec shape.
+			gotOffender := got.ContainerdID
+			if got.ContainerID != "" {
+				gotOffender = got.ContainerID
+			}
+			if gotOffender != tt.wantOffender {
+				t.Errorf(
+					"firstNonLiveContainer() offender = %q, want %q (result=%+v)",
+					gotOffender,
+					tt.wantOffender,
+					got,
+				)
+			}
+		})
+	}
+}
+
+// TestVerifyCellTasksLiveAfterStart wraps the per-probe decision with
+// the time-bounded poll loop the StartCell / StartContainer call sites
+// invoke. Covers the three AC branches that depend on the loop, not the
+// pure check:
+//
+//   - (b) healthy start: every probe across the grace window observes
+//     all-Running, so the loop returns nil and StartCell's markCellReady
+//     stamp lands as today (no behavior change on the happy path).
+//   - (a) fast-exit: a probe within the window observes a Stopped task;
+//     the loop returns immediately (fail-fast) with a wrapped
+//     ErrCellWindDownImmediate so the existing provisionStarted defer in
+//     StartCell routes through markCellFailed.
+//   - bypass: graceWindow=0 disables the guard (useful for the no-real-
+//     containerd test fixtures elsewhere in the package).
+func TestVerifyCellTasksLiveAfterStart(t *testing.T) {
+	const (
+		cellName = "kukeon-pm-0"
+		rootID   = "space_stack_cell_root"
+		workID   = "cid_work"
+	)
+	nonRoot := []intmodel.ContainerSpec{{ID: "work", ContainerdID: workID}}
+
+	t.Run("all_running_through_window_returns_nil_AC_b", func(t *testing.T) {
+		probeCount := 0
+		statusFn := func(_ string) (containerd.Status, error) {
+			probeCount++
+			return containerd.Status{Status: containerd.Running}, nil
+		}
+		var elapsed time.Duration
+		now := func() time.Time { return time.Unix(0, 0).Add(elapsed) }
+		sleep := func(d time.Duration) { elapsed += d }
+
+		err := verifyCellTasksLiveAfterStart(
+			cellName, rootID, nonRoot,
+			statusFn,
+			100*time.Millisecond, // graceWindow
+			20*time.Millisecond,  // pollInterval
+			now, sleep,
+		)
+		if err != nil {
+			t.Fatalf("verifyCellTasksLiveAfterStart returned %v on all-Running, want nil (AC item (b))", err)
+		}
+		// At minimum we must probe twice: once at t=0 and once after the
+		// final sleep crosses the deadline. Anything less means the loop
+		// returned without paying the grace window.
+		if probeCount < 2 {
+			t.Errorf("probeCount = %d, want ≥ 2 (loop must probe across the grace window)", probeCount)
+		}
+	})
+
+	t.Run("fast_exit_caught_inside_window_AC_a", func(t *testing.T) {
+		// Flip the work container to Stopped on the 2nd probe — the loop
+		// must return immediately with a wrapped ErrCellWindDownImmediate.
+		probeCount := 0
+		statusFn := func(id string) (containerd.Status, error) {
+			if id == rootID {
+				return containerd.Status{Status: containerd.Running}, nil
+			}
+			probeCount++
+			if probeCount >= 2 {
+				return containerd.Status{Status: containerd.Stopped}, nil
+			}
+			return containerd.Status{Status: containerd.Running}, nil
+		}
+		var elapsed time.Duration
+		now := func() time.Time { return time.Unix(0, 0).Add(elapsed) }
+		sleep := func(d time.Duration) { elapsed += d }
+
+		err := verifyCellTasksLiveAfterStart(
+			cellName, rootID, nonRoot,
+			statusFn,
+			500*time.Millisecond,
+			20*time.Millisecond,
+			now, sleep,
+		)
+		if err == nil {
+			t.Fatal(
+				"verifyCellTasksLiveAfterStart returned nil on Stopped task, want wrapped ErrCellWindDownImmediate (AC item (a))",
+			)
+		}
+		if !errors.Is(err, internalerrdefs.ErrCellWindDownImmediate) {
+			t.Errorf("err = %v, want errors.Is(_, ErrCellWindDownImmediate)", err)
+		}
+		// Surface text must name the cell, the container, and the kuke log pointer.
+		msg := err.Error()
+		for _, want := range []string{cellName, `"work"`, "kuke log " + cellName, "--container work"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("error %q missing fragment %q", msg, want)
+			}
+		}
+		// Elapsed must be < graceWindow — fail-fast contract.
+		if elapsed >= 500*time.Millisecond {
+			t.Errorf("elapsed = %v, want < 500ms (fail-fast must not wait out the grace window)", elapsed)
+		}
+	})
+
+	t.Run("zero_grace_window_disables_guard", func(t *testing.T) {
+		probeCount := 0
+		statusFn := func(_ string) (containerd.Status, error) {
+			probeCount++
+			// Even a Stopped result must not surface when the guard is disabled.
+			return containerd.Status{Status: containerd.Stopped}, nil
+		}
+		now := func() time.Time { return time.Unix(0, 0) }
+		sleep := func(time.Duration) { t.Fatal("sleep must not be called when graceWindow=0") }
+
+		err := verifyCellTasksLiveAfterStart(
+			cellName, rootID, nonRoot,
+			statusFn,
+			0, 0, // graceWindow + pollInterval both zero
+			now, sleep,
+		)
+		if err != nil {
+			t.Errorf("verifyCellTasksLiveAfterStart returned %v with graceWindow=0, want nil", err)
+		}
+		if probeCount != 0 {
+			t.Errorf("probeCount = %d, want 0 (no probe should run when guard is disabled)", probeCount)
+		}
+	})
+
+	t.Run("root_dies_inside_window_AC_c", func(t *testing.T) {
+		// Root container exits after the first probe — exercises the
+		// "root container exits immediately (currently unhandled — the
+		// derivation loop only checks non-root)" path called out in AC (c).
+		probeCount := 0
+		statusFn := func(id string) (containerd.Status, error) {
+			if id != rootID {
+				return containerd.Status{Status: containerd.Running}, nil
+			}
+			probeCount++
+			if probeCount >= 2 {
+				return containerd.Status{Status: containerd.Stopped}, nil
+			}
+			return containerd.Status{Status: containerd.Running}, nil
+		}
+		var elapsed time.Duration
+		now := func() time.Time { return time.Unix(0, 0).Add(elapsed) }
+		sleep := func(d time.Duration) { elapsed += d }
+
+		err := verifyCellTasksLiveAfterStart(
+			cellName, rootID, nonRoot,
+			statusFn,
+			500*time.Millisecond,
+			20*time.Millisecond,
+			now, sleep,
+		)
+		if err == nil {
+			t.Fatal(
+				"verifyCellTasksLiveAfterStart returned nil on root Stopped, want wrapped ErrCellWindDownImmediate (AC item (c))",
+			)
+		}
+		if !errors.Is(err, internalerrdefs.ErrCellWindDownImmediate) {
+			t.Errorf("err = %v, want errors.Is(_, ErrCellWindDownImmediate)", err)
+		}
+		// Root-offender message variant must name the cell and reference
+		// the root containerd ID (no `--container` flag — operator looks
+		// at cell logs).
+		msg := err.Error()
+		for _, want := range []string{cellName, "root container", rootID, "kuke log " + cellName} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("error %q missing fragment %q", msg, want)
+			}
+		}
+	})
+}
+
+// TestVerifyCellTasksLiveAfterStart_SingleContainerVariant pins AC item
+// (d): the same liveness check covers `(*Exec).StartContainer` (single-
+// container variant at runner/start.go:968). The StartContainer wiring
+// builds its livenessSpec from the single just-started container plus
+// the root; this test exercises that shape so a regression that wires
+// only the cell-level path is caught.
+func TestVerifyCellTasksLiveAfterStart_SingleContainerVariant(t *testing.T) {
+	const (
+		cellName = "kukeon-pm-0"
+		rootID   = "space_stack_cell_root"
+		workID   = "cid_work"
+	)
+	// StartContainer's spec slice carries one entry: the container just
+	// brought up. Root is probed separately via rootContainerdID.
+	livenessSpec := []intmodel.ContainerSpec{{ID: "work", ContainerdID: workID}}
+
+	t.Run("single_container_running_returns_nil", func(t *testing.T) {
+		statusFn := func(_ string) (containerd.Status, error) {
+			return containerd.Status{Status: containerd.Running}, nil
+		}
+		var elapsed time.Duration
+		now := func() time.Time { return time.Unix(0, 0).Add(elapsed) }
+		sleep := func(d time.Duration) { elapsed += d }
+
+		err := verifyCellTasksLiveAfterStart(
+			cellName, rootID, livenessSpec,
+			statusFn,
+			60*time.Millisecond,
+			20*time.Millisecond,
+			now, sleep,
+		)
+		if err != nil {
+			t.Errorf("verifyCellTasksLiveAfterStart returned %v on healthy single-container start, want nil", err)
+		}
+	})
+
+	t.Run("single_container_exits_immediately_caught", func(t *testing.T) {
+		statusFn := func(id string) (containerd.Status, error) {
+			if id == rootID {
+				return containerd.Status{Status: containerd.Running}, nil
+			}
+			return containerd.Status{Status: containerd.Stopped}, nil
+		}
+		now := func() time.Time { return time.Unix(0, 0) }
+		sleep := func(time.Duration) {}
+
+		err := verifyCellTasksLiveAfterStart(
+			cellName, rootID, livenessSpec,
+			statusFn,
+			60*time.Millisecond,
+			20*time.Millisecond,
+			now, sleep,
+		)
+		if err == nil {
+			t.Fatal("verifyCellTasksLiveAfterStart returned nil on Stopped single-container task")
+		}
+		if !errors.Is(err, internalerrdefs.ErrCellWindDownImmediate) {
+			t.Errorf("err = %v, want errors.Is(_, ErrCellWindDownImmediate)", err)
+		}
+		if !strings.Contains(err.Error(), `"work"`) {
+			t.Errorf("err = %q, want it to name the offending container", err)
+		}
+	})
+}
+
+// TestNonRootContainerSpecsFromCell verifies the StartCell-side adapter
+// that flattens cell.Spec.Containers to the non-root subset the liveness
+// probe iterates. Two shapes matter: cells with no non-root entries
+// (kukeond-style — root *is* the workload) and cells with a mix of root
+// + non-root containers (the explicit-root branch stamps a Root: true
+// entry into Containers, which must be filtered out so the probe doesn't
+// double-count the root).
+func TestNonRootContainerSpecsFromCell(t *testing.T) {
+	tests := []struct {
+		name string
+		cell intmodel.Cell
+		want []string // IDs in expected order
+	}{
+		{
+			name: "no containers — empty",
+			cell: intmodel.Cell{},
+			want: nil,
+		},
+		{
+			name: "only root entries — empty",
+			cell: intmodel.Cell{Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{
+				{ID: "root1", Root: true},
+				{ID: "root2", Root: true},
+			}}},
+			want: nil,
+		},
+		{
+			name: "mix preserves declaration order",
+			cell: intmodel.Cell{Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{
+				{ID: "a"},
+				{ID: "root", Root: true},
+				{ID: "b"},
+			}}},
+			want: []string{"a", "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nonRootContainerSpecsFromCell(tt.cell)
+			gotIDs := make([]string, 0, len(got))
+			for _, c := range got {
+				gotIDs = append(gotIDs, c.ID)
+			}
+			if strings.Join(gotIDs, ",") != strings.Join(tt.want, ",") {
+				t.Errorf("nonRootContainerSpecsFromCell() = %v, want %v", gotIDs, tt.want)
+			}
+		})
+	}
+}
+
 // TestTruncateFailureMessage pins the single-line + length-bounded contract
 // markCellFailed relies on for Status.Message: long, multi-line wrapped
 // `fmt.Errorf("%w: %w", …)` chains must end up as a single, capped string

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -135,6 +135,20 @@ var (
 	ErrTaskNotFound      = errors.New("task not found")
 	ErrTaskNotRunning    = errors.New("task is not running")
 
+	// ErrCellWindDownImmediate fires when StartCell / StartContainer's
+	// post-start liveness check observes a just-started container task in a
+	// non-Running state within the startup grace window — i.e. the task
+	// failed (or exited cleanly) between containerd accepting task creation
+	// and the controller stamping the cell Ready. Without this sentinel the
+	// cell would briefly persist Ready, the next reconciler tick would
+	// derive Stopped from the dead workload, shouldWindDownCell would fire
+	// KillCell, and the operator's in-flight `kuke run --attach` would race
+	// the teardown — printing `containers: started` and then dialing a
+	// socket that no longer exists. Routed through markCellFailed via the
+	// existing provisionStarted defer so the cell lands at Failed instead
+	// of the misleading Ready→Stopped→reaped cycle. Issue #851.
+	ErrCellWindDownImmediate = errors.New("cell wound down immediately after start")
+
 	// Volume-related errors.
 
 	ErrVolumeSourceRequired    = errors.New("volume source is required")


### PR DESCRIPTION
## Summary

- StartCell / StartContainer used to call `markCellReady` immediately after `ctrClient.StartContainer` returned. A task that exits within milliseconds — kuketty failing to open its log file, an `onInit` script returning non-zero, runc returning success but the entrypoint immediately faulting — would still land on disk as `state: Ready`. The next reconciler tick (every few seconds) derives `Stopped` from the dead workload, `shouldWindDownCell` fires `KillCell`, and the operator's in-flight `kuke run --attach` races the teardown — printing `containers: started` and then dialing a socket that no longer exists.
- Add a bounded post-start liveness probe (300 ms grace window, 50 ms polls) that calls `ctrClient.TaskStatus` against the just-started root + non-root containers. The first probe that observes a task not in `containerd.Running` (or whose `TaskStatus` call errors) fails fast with a wrapped `errdefs.ErrCellWindDownImmediate`; the existing `provisionStarted` defer in `startCellLocked` / `StartContainer` then routes through `markCellFailed("StartCellFailed", retErr)` / `markCellFailed("StartContainerFailed", retErr)` — the same code path runc-level startup failures already use, so the cell lands at `Failed` instead of the misleading `Ready → Stopped → reaped` cycle.
- Cover the AC's root-container exit branch (item (c)) too: the existing `deriveCellStateFromNonRootContainerStatuses` reconciler derivation only walks non-root containers, so a dead root would otherwise slip past the wind-down guard. The new probe is the only place that catches it before `markCellReady`.

## Test plan

- [x] `make test` (test-root + test-kukebuild) — all green
- [x] `make dev-init` smoke — daemon parity check + nested `kuke attach` smoke both pass; expected two-realm tail observed
- [x] `pre-commit run --files <changed>` — passes
- [x] New unit coverage in `internal/controller/runner/start_test.go`:
  - `TestFirstNonLiveContainer` — table-driven per-probe decision matrix (AC items (a), (c), defensive empty-ContainerdID, Root: true skip, first-stopped-wins ordering, statusFn errors)
  - `TestVerifyCellTasksLiveAfterStart` — wraps the per-probe decision with the time-bounded poll loop: healthy start observes all-Running through the window (AC (b)), fast-exit returns inside the window with a wrapped `ErrCellWindDownImmediate` (AC (a)), root exit inside the window also flagged (AC (c)), `graceWindow=0` disables the guard
  - `TestVerifyCellTasksLiveAfterStart_SingleContainerVariant` — pins AC (d): the same probe shape covers `StartContainer`'s single-container slice + root pair
  - `TestNonRootContainerSpecsFromCell` — the adapter that strips `Root: true` entries before the probe
- [x] `TestRecreateCell_StartsTasksBeforeReady` (issue #682 regression guard) updated: the test's fake `ctr.Client` now tracks which container IDs have been "started" so its `TaskStatus` returns `Running` for the freshly-started root (so the new probe lets `markCellReady` stamp) while still returning zero-value for the pre-existing root (so the `cellTasksAllRunningFn` idempotency guard at `start.go:414` does *not* short-circuit and the destructive teardown-and-recreate path the AC pins still runs)

## Implementation notes for the reviewer

- `cellStartLivenessGraceWindow = 300ms` / `cellStartLivenessPollInterval = 50ms` are package-private constants (call-site immutable). The probe pays the full grace window on the happy path — bounded and the proposal says "implementer's choice"; 300 ms is small enough that it falls well inside the existing reconcile interval and the e2e suite's startup variance.
- `verifyCellTasksLiveAfterStart` is decoupled from real time (`nowFn` / `sleepFn`) and from `*Exec`'s concrete containerd client (`statusFn` closure), matching the shape of `cellTasksAllRunningFn` / `teardownRootContainerCNI` so both the fail-fast and observe-through-window branches are exercised without a live runtime.
- `firstNonLiveContainer` treats a `statusFn` error the same as a non-Running status — a freshly-started task whose record vanished mid-check is exactly the wind-down-then-race condition the guard is defending against. Also treats an empty `ContainerdID` on a non-root spec as not-live (defensive; matches `cellTasksAllRunningFn`'s treatment of the same case).
- The `StartContainer` (single-container variant) wiring deliberately probes the just-started container *and* the root: a root that died between the cell coming up and this `StartContainer` call would otherwise stamp `Ready` despite a dead root. Operator-reachable as `kuke start container`.
- Error message names the cell, the offending container (or `root container "<containerdID>"` for the auto-default-root case), the observed status / probe error, and points at `kuke log <cell> [--container <id>]`.

Closes #851