### PR TITLE
fix(reconcile): write Status.CgroupReady from ExistsCgroup result

### DIFF
--- a/internal/controller/runner/container_state_test.go
+++ b/internal/controller/runner/container_state_test.go
@@ -280,6 +280,7 @@ func seedPostRebootCell(
 		Status: v1beta1.CellStatus{
 			State:         v1beta1.CellStateReady,
 			ReadyObserved: true,
+			CgroupReady:   true,
 		},
 	}
 	path := fs.CellMetadataPath(r.opts.RunPath, realm, space, stack, cellName)
@@ -288,5 +289,96 @@ func seedPostRebootCell(
 	}
 	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
 		t.Fatalf("write cell metadata: %v", err)
+	}
+}
+
+// TestReconcileCell_PostReboot_FalsifiesCgroupReady is the headline #853
+// guard: the background reconcile loop must close the same loop the
+// on-demand `kuke refresh` path already does — when a host reboot wipes
+// the tmpfs-backed cgroup tree, a single reconcile tick must flip
+// Status.CgroupReady from true to false on every previously-Ready cell.
+// Without this, `cgroupReady: true` stays stamped post-reboot and
+// `kuke status`'s state-consistency check is silently bypassed.
+//
+// The complement (re-set to true once the cgroup re-materializes) is
+// already covered by TestReconcileCell_PostReboot_TransitionsToStopped
+// taking the cgroup-present branch elsewhere; here we exercise the
+// true → false direction the bug allowed to leak.
+func TestReconcileCell_PostReboot_FalsifiesCgroupReady(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	rootID := "root"
+	workloadID := "workload"
+	rootContainerdID := space + "_" + stack + "_" + cellName + "_" + rootID
+	workloadContainerdID := space + "_" + stack + "_" + cellName + "_" + workloadID
+
+	fake := &deleteCellFakeClient{
+		// Cgroup absent: the tmpfs-backed /sys/fs/cgroup/kukeon/... tree
+		// is wiped on reboot. ExistsCgroup translates this to (false, nil).
+		loadCgroupFn: func(string, string) (*cgroup2.Manager, error) {
+			return nil, errors.New("cgroup path does not exist")
+		},
+		// Containerd container records survive the reboot.
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{}, fmt.Errorf("%w: %w", errdefs.ErrTaskNotFound, errors.New("task: not found"))
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	seedPostRebootCell(t, r, realm, space, stack, cellName, rootID, workloadID, rootContainerdID, workloadContainerdID)
+
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			ID:        cellName,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+			Containers: []intmodel.ContainerSpec{
+				{ID: rootID, ContainerdID: rootContainerdID, Root: true},
+				{ID: workloadID, ContainerdID: workloadContainerdID, Root: false},
+			},
+		},
+		Status: intmodel.CellStatus{
+			State:         intmodel.CellStateReady,
+			ReadyObserved: true,
+			CgroupReady:   true,
+		},
+	}
+
+	updatedCell, outcome, err := r.ReconcileCell(cell)
+	if err != nil {
+		t.Fatalf("ReconcileCell: unexpected error: %v", err)
+	}
+	if !outcome.Updated {
+		t.Errorf(
+			"ReconcileCell outcome.Updated = false; want true (cgroupReady true → false flip must be reported as an update so the metadata write fires)",
+		)
+	}
+	if updatedCell.Status.CgroupReady {
+		t.Errorf(
+			"ReconcileCell cell.Status.CgroupReady = true; want false (#853: background reconciler must falsify cgroupReady once /sys/fs/cgroup/.../<cell> is gone)",
+		)
+	}
+
+	// Round-trip: read the persisted metadata back to confirm the diff
+	// predicate actually triggered the on-disk write — an in-memory flip
+	// that doesn't reach the metadata file leaves `kuke get cell -o yaml`
+	// reporting the stale value, which is exactly the user-visible bug.
+	persisted, err := r.GetCell(intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetCell after ReconcileCell: %v", err)
+	}
+	if persisted.Status.CgroupReady {
+		t.Errorf(
+			"persisted Status.CgroupReady = true; want false (the diff predicate at refresh.go:706-718 must include CgroupReady so the metadata write fires)",
+		)
 	}
 }

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -660,11 +660,19 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 		return cell, ReconcileOutcome{Updated: updated}, nil
 	}
 
-	_, cgroupErr := r.ExistsCgroup(cell)
+	cgroupExists, cgroupErr := r.ExistsCgroup(cell)
 	if cgroupErr != nil {
 		r.logger.DebugContext(r.ctx, "failed to check cell cgroup",
 			"cell", cell.Metadata.Name, "error", cgroupErr)
 	}
+	// Mirror RefreshCell (refresh.go:369-374): the background reconcile
+	// loop must close the same loop the on-demand `kuke refresh` path
+	// already does, so cgroupReady falsifies on every cell whose
+	// /sys/fs/cgroup/.../<cell> tree is gone (the post-reboot signature
+	// for tmpfs-backed cgroups). Without this, `cgroupReady: true` stays
+	// stamped after a host reboot wipes the cgroup, and `kuke status`'s
+	// state-consistency check is silently bypassed (#853).
+	cell.Status.CgroupReady = cgroupErr == nil && cgroupExists
 
 	// Populate container statuses up front so the non-root-driven
 	// derivation can read them from the snapshot. The root container
@@ -708,6 +716,9 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 		updated = true
 	}
 	if originalStatus.ReadyObserved != cell.Status.ReadyObserved {
+		updated = true
+	}
+	if originalStatus.CgroupReady != cell.Status.CgroupReady {
 		updated = true
 	}
 	if !containerStatusesEqual(originalStatus.Containers, cell.Status.Containers) {


### PR DESCRIPTION
## Summary
- The background reconcile loop (`ReconcileCell` at `internal/controller/runner/refresh.go:632`) called `r.ExistsCgroup(cell)` but only used the **error** return, never the **boolean**. `Status.CgroupReady` was therefore monotonic-write-once: set true at create time by `ensureCellCgroup` and never falsified. After a host reboot wipes the tmpfs-backed `/sys/fs/cgroup/.../<cell>` tree, every cell that was Ready before the reboot kept `cgroupReady: true` stamped on it forever, silently bypassing `kuke status`'s state-consistency check.
- Fix takes the boolean from `ExistsCgroup` too and writes `cell.Status.CgroupReady = cgroupErr == nil && cgroupExists`, mirroring exactly what the on-demand `RefreshCell` path already does at `refresh.go:369-374`. Also extends the `updated` diff predicate at `refresh.go:706-718` to include the `CgroupReady` flip so the metadata write fires.
- `RefreshCell`'s on-demand path is untouched (it was already correct).

## Test plan
- [x] `make test` — full project test suite green, including the new `TestReconcileCell_PostReboot_FalsifiesCgroupReady` and the existing `TestReconcileCell_PostReboot_TransitionsToStopped` (#543's complement).
- [x] New test seeds a cell with `cgroupReady: true` + no cgroup on disk, runs one `ReconcileCell` tick, asserts both the returned cell and the persisted metadata file flip `CgroupReady` to false — covering AC#4's round-trip.
- [ ] AC#1 / AC#2 host-level smoke (reboot the host, observe a single reconcile tick falsifies `cgroupReady` across surviving cells; then `kuke start cell` re-materializes the cgroup and the next tick re-sets `cgroupReady: true`) — deferred to a host with a real kernel reboot cycle. The unit test exercises the same code paths via the fake `ctr.Client`; in-package coverage gates the regression.

## Notes
- One-function change, ~9 lines + a new test. Mirrors the on-demand `RefreshCell` path exactly per the issue proposal.
- Part of the post-reboot recovery umbrella `epic:reboot` (#854), completing the loop #543 started (#543 added the post-reboot state-derivation fallback; #853 closes the matching probe-readiness write).

Closes #853