### PR TITLE
fix(reconcile): heal wiped cell cgroup on the ReadyObserved latch

### DIFF
--- a/internal/controller/runner/delete_cell_test.go
+++ b/internal/controller/runner/delete_cell_test.go
@@ -45,14 +45,19 @@ import (
 // adding a new code path through ctr.Client doesn't require revisiting this
 // fake — the controller-level error assertions catch unintended behavior.
 // Also reused by container_state / reconcile tests that need ExistsContainer
-// + TaskStatus hooks (the post-reboot reproduction in #543).
+// + TaskStatus hooks (the post-reboot reproduction in #543), and by the
+// reconcile-heal tests (#855) that need NewCgroup +
+// EnsureSubtreeControllers hooks to observe the re-ensure pass.
 type deleteCellFakeClient struct {
-	deleteContainerFn func(namespace, id string, opts ctr.ContainerDeleteOptions) error
-	stopContainerFn   func(namespace, id string, opts ctr.StopContainerOptions) (*containerd.ExitStatus, error)
-	listContainersFn  func(namespace string, filters ...string) ([]containerd.Container, error)
-	existsContainerFn func(namespace, id string) (bool, error)
-	taskStatusFn      func(namespace, id string) (containerd.Status, error)
-	loadCgroupFn      func(group, mountpoint string) (*cgroup2.Manager, error)
+	deleteContainerFn          func(namespace, id string, opts ctr.ContainerDeleteOptions) error
+	stopContainerFn            func(namespace, id string, opts ctr.StopContainerOptions) (*containerd.ExitStatus, error)
+	listContainersFn           func(namespace string, filters ...string) ([]containerd.Container, error)
+	existsContainerFn          func(namespace, id string) (bool, error)
+	taskStatusFn               func(namespace, id string) (containerd.Status, error)
+	loadCgroupFn               func(group, mountpoint string) (*cgroup2.Manager, error)
+	newCgroupFn                func(spec ctr.CgroupSpec) (*cgroup2.Manager, error)
+	ensureSubtreeControllersFn func(group, mountpoint string, controllers []string) ([]string, error)
+	enableCellSubtreeFn        func(group, mountpoint string, controllers []string) ([]string, error)
 }
 
 func (c *deleteCellFakeClient) Connect() error { return nil }
@@ -72,7 +77,10 @@ func (c *deleteCellFakeClient) CleanupNamespaceResources(string, string) error {
 func (c *deleteCellFakeClient) GetCgroupMountpoint() string               { return "" }
 func (c *deleteCellFakeClient) GetCurrentCgroupPath() (string, error)     { return "", nil }
 func (c *deleteCellFakeClient) CgroupPath(string, string) (string, error) { return "", nil }
-func (c *deleteCellFakeClient) NewCgroup(ctr.CgroupSpec) (*cgroup2.Manager, error) {
+func (c *deleteCellFakeClient) NewCgroup(spec ctr.CgroupSpec) (*cgroup2.Manager, error) {
+	if c.newCgroupFn != nil {
+		return c.newCgroupFn(spec)
+	}
 	//nolint:nilnil // cgroup2.Manager has unexported fields; the test path discards the value
 	return nil, nil
 }
@@ -85,11 +93,21 @@ func (c *deleteCellFakeClient) LoadCgroup(group, mountpoint string) (*cgroup2.Ma
 	return nil, nil
 }
 func (c *deleteCellFakeClient) DeleteCgroup(string, string) error { return nil }
-func (c *deleteCellFakeClient) EnsureSubtreeControllers(string, string, []string) ([]string, error) {
+func (c *deleteCellFakeClient) EnsureSubtreeControllers(
+	group, mountpoint string, controllers []string,
+) ([]string, error) {
+	if c.ensureSubtreeControllersFn != nil {
+		return c.ensureSubtreeControllersFn(group, mountpoint, controllers)
+	}
 	return nil, nil
 }
 
-func (c *deleteCellFakeClient) EnableCellSubtreeControllers(string, string, []string) ([]string, error) {
+func (c *deleteCellFakeClient) EnableCellSubtreeControllers(
+	group, mountpoint string, controllers []string,
+) ([]string, error) {
+	if c.enableCellSubtreeFn != nil {
+		return c.enableCellSubtreeFn(group, mountpoint, controllers)
+	}
 	return nil, nil
 }
 

--- a/internal/controller/runner/reconcile_heal_test.go
+++ b/internal/controller/runner/reconcile_heal_test.go
@@ -126,6 +126,14 @@ func TestReconcileCell_HealsWipedCgroupWhenReadyObserved(t *testing.T) {
 	if !updatedCell.Status.ReadyObserved {
 		t.Errorf("Status.ReadyObserved = false, want true (the latch must survive the heal)")
 	}
+	// Pair with the #861 probe: the heal must ship cgroupReady:true in
+	// the same tick. Pre-fix the probe stamped false (cgroup absent)
+	// and ensureCellCgroup never touched the field, so the persisted
+	// snapshot carried cgroupReady:false for a cell whose cgroup is in
+	// fact present — exactly the stale-state surface #861 just closed.
+	if !updatedCell.Status.CgroupReady {
+		t.Errorf("Status.CgroupReady = false, want true after heal (heal must pair with the #861 probe so cgroupReady:true ships in the same tick, not next-pass)")
+	}
 }
 
 // TestReconcileCell_DoesNotHealHalfCreateCell is the regression guard for

--- a/internal/controller/runner/reconcile_heal_test.go
+++ b/internal/controller/runner/reconcile_heal_test.go
@@ -1,0 +1,243 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises the private heal path inside *Exec.ReconcileCell against an in-package ctr.Client fake
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	cgroup2 "github.com/containerd/cgroups/v2/cgroup2"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/metadata"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestReconcileCell_HealsWipedCgroupWhenReadyObserved is the headline #855
+// guard: a cell whose cgroup the host reboot wiped — metadata survives, the
+// ReadyObserved latch is still true — must have its cgroup re-created and
+// its subtree controllers re-asserted by the reconcile loop within one
+// tick, without an operator running `kuke start cell <name>` per cell.
+// Pre-fix the loop's ExistsCgroup result was discarded; only `kuke start
+// cell` could heal the missing cgroup.
+func TestReconcileCell_HealsWipedCgroupWhenReadyObserved(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	rootID := "root"
+	workloadID := "workload"
+	rootContainerdID := space + "_" + stack + "_" + cellName + "_" + rootID
+	workloadContainerdID := space + "_" + stack + "_" + cellName + "_" + workloadID
+
+	var newCgroupCalls int32
+	var enableSubtreeCalls int32
+	fake := &deleteCellFakeClient{
+		// Cgroup absent on every Load — exists.go's probe sees absent
+		// and the heal path's ensureCgroupInternal Load also sees absent
+		// and triggers the create branch.
+		loadCgroupFn: func(string, string) (*cgroup2.Manager, error) {
+			return nil, errors.New("cgroup path does not exist")
+		},
+		// NewCgroup must be called exactly once on the heal pass.
+		// Returns a non-nil zero-valued sentinel so ensureCgroupInternal's
+		// nil-manager check does not abort the heal pre-subtree-toggle.
+		newCgroupFn: func(ctr.CgroupSpec) (*cgroup2.Manager, error) {
+			atomic.AddInt32(&newCgroupCalls, 1)
+			return &cgroup2.Manager{}, nil
+		},
+		// EnableCellSubtreeControllers is the second half of the post-
+		// #314/#328 contract — the heal must re-assert subtree
+		// controllers in the same pass.
+		enableCellSubtreeFn: func(string, string, []string) ([]string, error) {
+			atomic.AddInt32(&enableSubtreeCalls, 1)
+			return nil, nil
+		},
+		// Containerd records survive the reboot — both root and non-root.
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		// Tasks are gone — the kernel side wiped them with the cgroup.
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{}, fmt.Errorf("%w: %w", errdefs.ErrTaskNotFound, errors.New("task: not found"))
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	seedPostRebootCell(t, r, realm, space, stack, cellName, rootID, workloadID, rootContainerdID, workloadContainerdID)
+
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			ID:        cellName,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+			Containers: []intmodel.ContainerSpec{
+				{ID: rootID, ContainerdID: rootContainerdID, Root: true},
+				{ID: workloadID, ContainerdID: workloadContainerdID, Root: false},
+			},
+		},
+		Status: intmodel.CellStatus{
+			State:         intmodel.CellStateReady,
+			ReadyObserved: true,
+		},
+	}
+
+	updatedCell, _, err := r.ReconcileCell(cell)
+	if err != nil {
+		t.Fatalf("ReconcileCell: unexpected error: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&newCgroupCalls); got != 1 {
+		t.Errorf(
+			"NewCgroup call count = %d, want 1 (the reconcile loop must re-create the wiped cgroup on the ReadyObserved cell — #855)",
+			got,
+		)
+	}
+	if got := atomic.LoadInt32(&enableSubtreeCalls); got != 1 {
+		t.Errorf(
+			"EnableCellSubtreeControllers call count = %d, want 1 (heal must re-assert subtree controllers on the same pass — post-#314/#328 contract)",
+			got,
+		)
+	}
+	if updatedCell.Status.CgroupPath == "" {
+		t.Errorf("Status.CgroupPath = %q, want non-empty after heal (ensureCgroupInternal must backfill it)", updatedCell.Status.CgroupPath)
+	}
+	if !updatedCell.Status.ReadyObserved {
+		t.Errorf("Status.ReadyObserved = false, want true (the latch must survive the heal)")
+	}
+}
+
+// TestReconcileCell_DoesNotHealHalfCreateCell is the regression guard for
+// the AC #4 case: a cell that has never reached Ready (a half-CreateCell
+// that crashed mid-way — cgroup may or may not exist on disk; ReadyObserved
+// is still false on the persisted metadata) must NOT be promoted by the
+// re-ensure pass. The in-flight CreateCell will finish its own
+// ensureCellCgroup path under the per-cell lock; the reconciler stepping
+// in would race that flow and double-write the cgroup metadata.
+func TestReconcileCell_DoesNotHealHalfCreateCell(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "halfcreate"
+
+	fake := &deleteCellFakeClient{
+		// Cgroup absent: the half-CreateCell crashed before
+		// ensureCellCgroup could complete.
+		loadCgroupFn: func(string, string) (*cgroup2.Manager, error) {
+			return nil, errors.New("cgroup path does not exist")
+		},
+		// Any NewCgroup call here is the regression — fail loudly so
+		// the gate change reads as a behavior change in the test
+		// surface, not a silent log-only divergence.
+		newCgroupFn: func(ctr.CgroupSpec) (*cgroup2.Manager, error) {
+			t.Errorf("NewCgroup called on a never-Ready cell — heal must be gated on the ReadyObserved latch (#855 AC#4)")
+			return nil, errors.New("must not be called")
+		},
+		enableCellSubtreeFn: func(string, string, []string) ([]string, error) {
+			t.Errorf("EnableCellSubtreeControllers called on a never-Ready cell — same gate as NewCgroup")
+			return nil, errors.New("must not be called")
+		},
+		// No containerd records yet for this cell — the CreateCell crash
+		// happened pre-container-registration. Derivation will read back
+		// NotCreated for the (missing) root, which the cell-state
+		// derivation maps to Stopped; the ReadyObserved=false on disk
+		// is the AutoDelete gate that prevents reaping.
+		existsContainerFn: func(_, _ string) (bool, error) { return false, nil },
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	seedNeverReadyCell(t, r, realm, space, stack, cellName)
+
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			ID:        cellName,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+			Containers: []intmodel.ContainerSpec{
+				{
+					ID:           "root",
+					ContainerdID: space + "_" + stack + "_" + cellName + "_root",
+					Root:         true,
+				},
+			},
+		},
+		Status: intmodel.CellStatus{
+			// State Pending and ReadyObserved false is the persisted
+			// snapshot a half-CreateCell leaves behind: the cgroup
+			// create may or may not have landed, but markCellReady
+			// never fired so the latch never closed.
+			State:         intmodel.CellStatePending,
+			ReadyObserved: false,
+		},
+	}
+
+	if _, _, err := r.ReconcileCell(cell); err != nil {
+		t.Fatalf("ReconcileCell: unexpected error: %v", err)
+	}
+	// Assertions live inside the fakes' t.Errorf paths above — the
+	// reconcile call returning is the negative-space proof that the
+	// heal gate held.
+}
+
+// seedNeverReadyCell writes a cell metadata doc shaped like the on-disk
+// snapshot a half-CreateCell leaves behind: ReadyObserved false (the
+// latch never closed), one root container with an explicit ContainerdID
+// so the reconciler's container-status pass can look it up.
+func seedNeverReadyCell(t *testing.T, r *Exec, realm, space, stack, cellName string) {
+	t.Helper()
+	rootContainerdID := space + "_" + stack + "_" + cellName + "_root"
+	doc := v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: cellName},
+		Spec: v1beta1.CellSpec{
+			ID:      cellName,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:           "root",
+					ContainerdID: rootContainerdID,
+					RealmID:      realm,
+					SpaceID:      space,
+					StackID:      stack,
+					CellID:       cellName,
+					Image:        "alpine:latest",
+					Root:         true,
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{
+			State:         v1beta1.CellStatePending,
+			ReadyObserved: false,
+		},
+	}
+	path := fs.CellMetadataPath(r.opts.RunPath, realm, space, stack, cellName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir cell metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write cell metadata: %v", err)
+	}
+}

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -629,6 +629,14 @@ func (r *Exec) refreshContainerStatus(cell intmodel.Cell, containerSpec *intmode
 // Errors during kill/delete are returned to the caller so the loop's
 // per-pass `Errors` slice records them and the cell is preserved for
 // retry on the next tick (best-effort, like the watcher it replaces).
+//
+// Post-reboot cgroup healing (#855): when the cgroup check returns
+// absent and the cell's persisted ReadyObserved latch is true (the cell
+// was ever Ready), the reconciler re-runs ensureCellCgroup to
+// re-create the cgroup directory and re-assert subtree controllers.
+// Cells that never reached Ready (a half-CreateCell that crashed
+// mid-way, gated by the same latch the wind-down path uses) are not
+// promoted by the re-ensure.
 func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcome, error) {
 	defer r.lockCell(cell)()
 
@@ -673,6 +681,29 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 	// stamped after a host reboot wipes the cgroup, and `kuke status`'s
 	// state-consistency check is silently bypassed (#853).
 	cell.Status.CgroupReady = cgroupErr == nil && cgroupExists
+
+	// Heal a wiped cell cgroup on the reconcile path so cells whose cgroup
+	// the host reboot wiped (#854) recover without an operator running
+	// `kuke start cell <name>` per cell. Gated on the persisted
+	// ReadyObserved latch so a half-CreateCell that crashed before the
+	// cell ever reached Ready is not promoted by the re-ensure — that
+	// in-flight CreateCell will finish its own ensureCellCgroup path under
+	// the per-cell lock. ensureCellCgroup is idempotent and already
+	// re-asserts subtree controllers via enableCellControllers, covering
+	// the second half of the post-#314/#328 contract. Heal failure is
+	// logged and the tick continues so the next pass retries (#855).
+	if cgroupErr == nil && !cgroupExists && originalStatus.ReadyObserved {
+		healedCell, healErr := r.ensureCellCgroup(cell)
+		if healErr != nil {
+			r.logger.WarnContext(r.ctx, "reconcile: failed to heal missing cell cgroup",
+				"cell", cell.Metadata.Name, "error", healErr)
+		} else {
+			cell = healedCell
+			r.logger.InfoContext(r.ctx, "reconcile: healed missing cell cgroup",
+				"cell", cell.Metadata.Name,
+				"path", cell.Status.CgroupPath)
+		}
+	}
 
 	// Populate container statuses up front so the non-root-driven
 	// derivation can read them from the snapshot. The root container

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -699,6 +699,12 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 				"cell", cell.Metadata.Name, "error", healErr)
 		} else {
 			cell = healedCell
+			// ensureCellCgroup writes CgroupPath / SubtreeControllers but
+			// not CgroupReady — pair the heal with the same truth the
+			// probe above stamps so a healed cell ships cgroupReady:true
+			// in the same tick instead of the false-then-true flip the
+			// next pass would otherwise correct (#861's invariant).
+			cell.Status.CgroupReady = true
 			r.logger.InfoContext(r.ctx, "reconcile: healed missing cell cgroup",
 				"cell", cell.Metadata.Name,
 				"path", cell.Status.CgroupPath)


### PR DESCRIPTION
## Summary

- Background reconciler now re-runs `ensureCellCgroup` when `ExistsCgroup` reports absent **and** the persisted `Status.ReadyObserved` latch is true, re-creating the wiped cgroup directory and re-asserting subtree controllers on the same pass.
- Closes the half-CreateCell gap explicitly: a crashed CreateCell that never reached Ready (latch still false on disk) is **not** promoted by the re-ensure — the in-flight CreateCell will finish its own `ensureCellCgroup` path under the per-cell lock, and the reconciler stepping in would race that flow.
- No behaviour change for cells whose cgroup is already present, or for cells with no metadata on disk.

This is option (b) from the issue's Proposal section — "re-ensure only when `Status.ReadyObserved == true`" — chosen because the AC's #4 ("no regression on cells that never reached Ready — the half-CreateCell case") directly names the latch as the discriminator.

## Implementation notes

- The reconcile loop's existing `ExistsCgroup` call discarded its boolean result. Captured it and gated the heal on `(cgroupErr == nil && !cgroupExists && originalStatus.ReadyObserved)`. On heal failure the warning is logged and the tick continues (best-effort, next pass retries); heal success swaps the in-memory cell for the one `ensureCellCgroup` returns so the downstream derivation and persist read `Status.CgroupPath` / `Status.SubtreeControllers` set by the heal.
- `ensureCellCgroup` already re-asserts subtree controllers via `enableCellControllers` on every ensure-pass (the post-#314/#328 contract); the heal path inherits that for free, closing the AC's third bullet.
- **Post-rebase fix-up (b99ccb1):** rebased onto current `main` to pick up #861 (now `0bf04aa`), which stamps `Status.CgroupReady = cgroupErr == nil && cgroupExists` immediately above this heal block. `ensureCellCgroup` writes `CgroupPath` / `SubtreeControllers` but not `CgroupReady`, so without an explicit write the heal would have shipped `cgroupReady:false` in the same tick the cgroup was re-created (next pass would re-probe and correct, but the false-then-true flip on disk is the kind of stale-state surface #861 just closed). The heal-success branch now sets `cell.Status.CgroupReady = true` and `TestReconcileCell_HealsWipedCgroupWhenReadyObserved` pins the invariant.
- The `deleteCellFakeClient` shared fake grew three overridable hooks (`newCgroupFn`, `ensureSubtreeControllersFn`, `enableCellSubtreeFn`) so the heal tests can observe `NewCgroup` + `EnableCellSubtreeControllers` calls without rewriting the fake.

## Note on AC #1's CLAUDE.md doc

The AC asks for the chosen behaviour to be documented in `CLAUDE.md`'s smoke-test contract. The dev role rule forbids `<project>/CLAUDE.md` edits in a code-fix PR (it travels as its own project issue + PR), so the doc work is deferred to #862 with the verbatim proposed wording in the issue body. Note that `make dev-init` does not exercise reboot recovery (per umbrella #854's Notes); the new `internal/controller/runner/reconcile_heal_test.go` regression guards cover both the heal-positive and half-CreateCell-negative paths.

## Test plan

- [x] `make test` (full project CI test target) — passes after rebase + fix-up, no regressions.
- [x] `make dev-init` (project smoke) — daemon-parity check shows both realms Ready with matching `/kukeon/<realm>` cgroup rows; attach smoke against `kuketty`-wrapped cell succeeds.
- [x] `go test ./internal/controller/runner/... -run 'TestReconcileCell_HealsWipedCgroupWhenReadyObserved|TestReconcileCell_DoesNotHealHalfCreateCell|TestReconcileCell_PostReboot'` — heal-positive (now pinning `CgroupReady=true` post-heal), half-CreateCell-negative, and post-reboot derivation guards pass.
- [ ] Live host-reboot smoke (reboot host, observe cgroups re-created on next reconcile tick) — not exercised by `make dev-init` per umbrella #854's Notes; covered by the unit tests above.

Closes #855