### PR TITLE
docs(kukeonv1): document ErrAttachTaskNotRunning on AttachContainerResult

### DIFF
--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -722,8 +722,9 @@ type AttachContainerResult struct {
 	// HostSocketPath is the host path of the per-container sbsh terminal
 	// socket. Inside the container the same inode is reachable at
 	// /run/kukeon/tty/socket via the tty directory bind mount. Returned only
-	// when the target container has Attachable=true; otherwise the daemon
-	// errors with ErrAttachNotSupported.
+	// when the target container has Attachable=true and its task is Running;
+	// the daemon errors with ErrAttachNotSupported when the target is not
+	// Attachable, or ErrAttachTaskNotRunning when the task is not Running.
 	HostSocketPath string
 }
 


### PR DESCRIPTION
## Summary
- Extends the `HostSocketPath` docstring on `AttachContainerResult` to enumerate the second daemon-side error class (`ErrAttachTaskNotRunning`, added in PR #858 / issue #852) alongside the existing `ErrAttachNotSupported`. A library consumer reading the result type's docstring now discovers both sentinels without grepping `errdefs.go`.
- Pure docstring change — no behavior, tests, or wire-format touched. The typed error and wire mapping at `pkg/api/kukeonv1/errmap.go:61` already work; this is the public-schema doc omission flagged by the review.

## Test plan
- [x] `GOWORK=off go build ./pkg/api/kukeonv1/...`
- [x] `GOWORK=off go vet ./pkg/api/kukeonv1/...`
- [ ] Full `make test` — not run; docstring-only diff, no compilable surface changed (eligible for trivial-edit shortcut).

Closes #860