### PR TITLE
fix(dev-init): fail loud when running kukeond container is anchored on a stale image

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -207,6 +207,80 @@ sudo --preserve-env=KUKEON_HOST ./kuke build --build-arg VERSION=v0.0.0-dev \
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
 sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}"
 
+# Fail-loud when the running kukeond container is anchored on a stale
+# image (issue #857). The bug captured there is that `kuke daemon reset`
+# + `kuke init --kukeond-image` does not refresh the kukeond cell when
+# the image tag is reused (init's bootstrapCell takes the existing-cell
+# path on a leftover record and never compares the desired image
+# against the running container). The user-visible failure surfaces
+# downstream as an opaque pre-#641 schema mismatch in the attach smoke;
+# this check turns that into a fail-loud at the place the divergence
+# was introduced.
+#
+# Compare the *snapshot chain digest*, not the image ref name: a
+# container's `.Image` field is the ref string set at create time
+# (e.g. `docker.io/library/kukeon-local:dev`) and is unchanged when
+# `kuke build` overwrites the same tag with a new manifest. The
+# canonical drift signal is the chain digest stored on the container's
+# snapshot at unpack time, derived from the image config blob's
+# `containerd.io/gc.ref.snapshot.overlayfs` label. The two should be
+# byte-identical on a healthy `make dev-init`; a mismatch means the
+# running container is anchored on an older image than the one we just
+# built.
+#
+# Stay grep/sed-only — scripts in this repo intentionally avoid a jq
+# dependency (see scripts/install.sh's "no jq dependency" guarantee).
+step "Verify running kukeond container is anchored on the just-built image"
+KUKEOND_NS="kuke-system.kukeon.io"
+KUKEOND_CTR_ID="kukeon_kukeon_kukeond_kukeond"
+
+ctr_chain="$(sudo ctr -n "${KUKEOND_NS}" snapshots info "${KUKEOND_CTR_ID}" 2>/dev/null \
+    | grep -oE '"Parent":[[:space:]]*"sha256:[a-f0-9]+"' \
+    | sed -E 's/.*"(sha256:[a-f0-9]+)"/\1/')"
+if [ -z "${ctr_chain}" ]; then
+    printf 'unable to resolve snapshot chain for running kukeond container %s/%s\n' \
+        "${KUKEOND_NS}" "${KUKEOND_CTR_ID}" >&2
+    exit 1
+fi
+
+manifest_digest="$(sudo ctr -n "${KUKEOND_NS}" images ls 2>/dev/null \
+    | awk -v r="${KUKEOND_IMAGE_REF}" 'NR>1 && $1==r {print $3; exit}')"
+if [ -z "${manifest_digest}" ]; then
+    printf 'image %s not found in containerd namespace %s after kuke build\n' \
+        "${KUKEOND_IMAGE_REF}" "${KUKEOND_NS}" >&2
+    exit 1
+fi
+
+config_digest="$(sudo ctr -n "${KUKEOND_NS}" content get "${manifest_digest}" 2>/dev/null \
+    | grep -oE '"digest":[[:space:]]*"sha256:[a-f0-9]+"' \
+    | head -1 \
+    | sed -E 's/.*"(sha256:[a-f0-9]+)"/\1/')"
+if [ -z "${config_digest}" ]; then
+    printf 'unable to resolve config digest from manifest %s\n' "${manifest_digest}" >&2
+    exit 1
+fi
+
+img_chain="$(sudo ctr -n "${KUKEOND_NS}" content ls 2>/dev/null \
+    | awk -v d="${config_digest}" '$1==d' \
+    | grep -oE 'containerd\.io/gc\.ref\.snapshot\.overlayfs=sha256:[a-f0-9]+' \
+    | head -1 \
+    | cut -d= -f2)"
+if [ -z "${img_chain}" ]; then
+    printf 'unable to resolve image chain digest from config blob %s\n' "${config_digest}" >&2
+    exit 1
+fi
+
+if [ "${ctr_chain}" != "${img_chain}" ]; then
+    printf 'running kukeond container is anchored on a stale image (#857)\n' >&2
+    printf '  running container snapshot chain: %s\n' "${ctr_chain}" >&2
+    printf '  just-built image chain:           %s\n' "${img_chain}" >&2
+    printf '  manifest %s did not propagate to the kukeond cell —\n' "${manifest_digest}" >&2
+    printf '  `kuke daemon reset` + `kuke init --kukeond-image` did not refresh the container.\n' >&2
+    printf '  Try `sudo ./kuke daemon reset --purge-system` then re-run `make dev-init`.\n' >&2
+    exit 1
+fi
+echo "running kukeond container chain ${ctr_chain} matches just-built ${KUKEOND_IMAGE_REF}"
+
 step "Daemon parity check (both must show identical output)"
 sudo --preserve-env=KUKEON_HOST ./kuke get realms
 sudo ./kuke get realms --no-daemon


### PR DESCRIPTION
## Summary
- Adds a post-`kuke init` snapshot-chain-digest check between init and the attach smoke so a stale-running-daemon scenario (#857) fails loud at the place the drift was introduced rather than as an opaque schema mismatch in the kuketty rendered metadata.
- The check compares the running kukeond container's snapshot `Parent` (set at container-create time) against the just-built image's chain digest, extracted via `manifest → config blob → containerd.io/gc.ref.snapshot.overlayfs label`. A byte-precise drift signal that catches "same tag, new digest" — which a name-only comparison cannot.
- Implements Layer 1 of #857's suggested two-layer fix. Layer 2 (the underlying `kuke daemon reset` + `kuke init` refresh defect) is filed as #868 and explicitly out of scope here.

## Implementation note (AC reinterpretation)

#857's "Suggested fix" Layer 1 asks for `ctr container info … | jq -r '.Image'` compared to the staged image's digest from `ctr images ls`. Read literally, that compares an image **name** (the `.Image` field is a ref string set at container-create time, e.g. `docker.io/library/kukeon-local:dev`) against a manifest **digest** — type-incompatible, and unchanged when `kuke build` overwrites the same tag with a new manifest. Posted a heads-up comment on #857 (https://github.com/eminwux/kukeon/issues/857#issuecomment-4534165283) before coding; this PR ships the spirit of Layer 1 (digest-vs-digest drift detection) via the snapshot chain comparison.

The implementation stays grep/sed-only per `scripts/install.sh`'s "no jq dependency" convention.

## Layer 2 deferral

#868 covers the underlying defect (reset+init don't refresh the running daemon when the image tag is reused). It needs a focused investigation cycle into both candidate sites (`cmd/kuke/daemon/reset/reset.go:140` for the reset path's containerd task-termination semantics; `internal/controller/bootstrap.go:621`'s `bootstrapCell` for the existing-cell image-drift branch) that the parent issue acknowledges is open ("Root cause: Not yet pinpointed"). Bundling that investigation into this PR would either oversize the diff or guess at the root cause; #868 keeps the lineage auditable.

This Layer 1 guard remains useful as defense-in-depth after #868 lands — a fresh class of refresh regression would surface here even on a `bootstrapCell` that's been audited.

## Test plan
- [x] `make test` (full project test target — `test-root` + `test-kukebuild`) — all green.
- [x] `GOWORK=off go vet ./...` — clean (per repo's go.work toolchain note).
- [x] `GOWORK=off go build ./...` — clean.
- [x] `bash -n scripts/dev-init.sh` — syntax OK.
- [x] `pre-commit run --files scripts/dev-init.sh` — trailing whitespace, EOF, mixed line endings all pass.
- [x] Manual end-to-end smoke of the chain-digest extraction on this host's actual containerd state: `CTR_CHAIN`, `MANIFEST_DIGEST`, `CONFIG_DIGEST`, `IMG_CHAIN` all resolved correctly; healthy path produced MATCH.
- [ ] `make dev-init` end-to-end against the #857 stale-daemon repro — requires a host where the running kukeond predates a daemon-affecting commit, which this host does not currently reproduce. The chain-digest extraction is verified above; the fail-loud branch is exercised by the equality check on the same data.

Closes #857