### PR TITLE
chore(run): update kuke apply -c/-b migration pointers after #823 removal

### DIFF
--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -52,15 +52,18 @@ func NewCellCmd() *cobra.Command {
 			"materialises the full Cell record (containers and all), and " +
 			"persists it in a **stopped** state. Run `kuke start <name>` to " +
 			"start it. Differs from `kuke run -b` (materialise + start + attach) " +
-			"and `kuke apply -b` (reconcile + start) by leaving the cell stopped " +
-			"for later inspection or hand-off.\n" +
+			"by leaving the cell stopped for later inspection or hand-off; " +
+			"-b-lineage cells have no in-place reconcile, so updates flow through " +
+			"delete-and-re-run (or promotion to a CellConfig).\n" +
 			"  - `kuke create cell <name> --from-config <cfg>` — resolves the " +
 			"daemon-stored CellConfig and its referenced Blueprint, applies the " +
 			"Config's spec.values + repo/secret slot fills, materialises the " +
 			"Cell record, and persists it in a **stopped** state. Run " +
 			"`kuke start <name>` to start it. Differs from `kuke run <cfg>` " +
-			"(materialise + start + attach) and `kuke apply -c <cfg>` (reconcile " +
-			"+ start) by leaving the cell stopped.\n\n" +
+			"(materialise + start + attach) by leaving the cell stopped; later " +
+			"reconcile against the lineage Config flows through " +
+			"`kuke restart cell <name>` (OutOfSync-driven, #821) once the cell is " +
+			"started.\n\n" +
 			"--from-blueprint and --from-config are mutually exclusive. --param " +
 			"and --param-file are valid with --from-blueprint (mirroring " +
 			"`kuke run -b`); they are rejected with --from-config because a " +
@@ -349,10 +352,11 @@ func materialiseAndPersist(cmd *cobra.Command, client kukeonv1.Client, cellDoc v
 	case err == nil && pre.MetadataExists:
 		return fmt.Errorf(
 			"cell %q already exists in realm=%q space=%q stack=%q; "+
-				"delete it with `kuke delete cell %s` (or update with `kuke apply -b/-c`) before re-materialising",
+				"delete it with `kuke delete cell %s` (or, for Config-lineage cells, "+
+				"reconcile via `kuke start cell %s` + `kuke restart cell %s`) before re-materialising",
 			cellDoc.Metadata.Name,
 			cellDoc.Spec.RealmID, cellDoc.Spec.SpaceID, cellDoc.Spec.StackID,
-			cellDoc.Metadata.Name,
+			cellDoc.Metadata.Name, cellDoc.Metadata.Name, cellDoc.Metadata.Name,
 		)
 	case err != nil && !errors.Is(err, errdefs.ErrCellNotFound):
 		return err

--- a/cmd/kuke/restart/cell/cell.go
+++ b/cmd/kuke/restart/cell/cell.go
@@ -147,12 +147,12 @@ func runRestartCell(cmd *cobra.Command, args []string) error {
 }
 
 // restartReady handles the Ready cell path: vanilla stop+start for Synced
-// cells, or an apply -c-style reconcile (stop + re-materialise + start)
-// driven by the daemon for OutOfSync cells. OutOfSyncError (divergence
-// undecidable — referenced Blueprint missing) and the "lineage Config
-// deleted" reason cannot drive a reconcile, so they fall through to vanilla
-// restart with a one-line stderr notice. Active attach sessions are severed
-// by the daemon's stop step in both branches.
+// cells, or a Config-driven reconcile (stop + re-materialise + start) driven
+// by the daemon for OutOfSync cells. OutOfSyncError (divergence undecidable
+// — referenced Blueprint missing) and the "lineage Config deleted" reason
+// cannot drive a reconcile, so they fall through to vanilla restart with a
+// one-line stderr notice. Active attach sessions are severed by the daemon's
+// stop step in both branches.
 func restartReady(
 	cmd *cobra.Command, client kukeonv1.Client,
 	doc v1beta1.CellDoc, pre kukeonv1.GetCellResult,
@@ -294,7 +294,8 @@ func restartInPlace(cmd *cobra.Command, client kukeonv1.Client, doc v1beta1.Cell
 // restartStopped is the already-stopped path: equivalent to
 // `kuke start cell <name>`. AC pins this even for OutOfSync stopped cells —
 // reconcile happens only on the Ready+OutOfSync path; an operator wanting to
-// reconcile from Stopped uses `kuke apply -c` directly.
+// reconcile from Stopped starts the cell first and then re-runs
+// `kuke restart cell <name>` to trip the Ready+OutOfSync reconcile.
 func restartStopped(
 	cmd *cobra.Command, client kukeonv1.Client,
 	doc v1beta1.CellDoc, _ kukeonv1.GetCellResult,
@@ -316,7 +317,7 @@ func restartStopped(
 	return nil
 }
 
-// materialiseFromConfig re-runs the `kuke apply -c` materialisation pipeline
+// materialiseFromConfig re-runs the CellConfig materialisation pipeline
 // against the cell's lineage Config: GetConfig + GetBlueprint +
 // cellconfig.Materialize. The cell's stored realm/space/stack supply the
 // lookup scope — a Config materialises a cell into the scope it lives in,

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -74,9 +74,13 @@ func NewRunCmd() *cobra.Command {
 			"subsequent runs (idempotent). When the live cell's spec differs from the " +
 			"materialisation of the current Config + Blueprint, the positional config " +
 			"path refuses to attach and points the operator at " +
-			"`kuke apply -c <config>` to reconcile (stops, updates, starts). -b with " +
-			"--name applies the same discipline against the pinned cell name, pointing " +
-			"at `kuke apply -b <bp> --name <cell>`. --new on the " +
+			"`kuke restart cell <cell>` to reconcile (the daemon's OutOfSync detector " +
+			"picks up the Config divergence and the restart reconciles implicitly: " +
+			"stops, updates, starts). -b with --name applies the same divergence " +
+			"discipline against the pinned cell name, but -b-lineage cells have no " +
+			"implicit reconcile — the pointer is `kuke delete cell <cell>` + re-run " +
+			"(or promote to a CellConfig for `kuke restart cell` reconcile workflows). " +
+			"--new on the " +
 			"positional config path materializes a fresh `<config-name>-<6hex>` cell on " +
 			"every invocation instead — opt-in fire-and-forget sandboxes from a " +
 			"Config, preserving the kukeon.io/config lineage label. `--new --name X` " +
@@ -638,34 +642,38 @@ func runAfterReuseClaim(
 // rejectDivergentNamedCell refuses to attach when a named live cell's spec
 // diverges from the materialization the operator just asked us to run. Every
 // `kuke run` source that pins a deterministic cell name (`-f`, `<config>`
-// without `--new`, and `-b --name`) routes destructive updates through
-// `kuke apply` instead — `run` is a pure read-and-materialize verb, so a
-// divergent target is the operator's signal to either reconcile via `apply` or
-// delete and re-run. The error pointer is shaped to match the source:
-// `<config>` → `kuke apply -c <config>` (cell name is the Config's stable
-// name, `apply -c` recomputes it), `-b --name <cell>` →
-// `kuke apply -b <bp> --name <cell>` (the operator pinned the name, so
-// `apply` needs the same pin), and the bare `-f` / `-p` fallback keeps the
-// original `kuke apply -f` pointer because those paths carry the spec on
-// disk. The `--new` path never reaches this function: it takes a separate
-// branch in runRun that treats any existing cell as a hard collision (no
-// divergence reconcile pointer makes sense — `apply -c` would reconcile to
-// the Config's stable name, not to the `--new` cell's generated/pinned name).
+// without `--new`, and `-b --name`) routes destructive updates away from
+// `run` — `run` is a pure read-and-materialize verb, so a divergent target is
+// the operator's signal to either reconcile (Config-lineage cells) or delete
+// and re-run (Blueprint-lineage and bare `-f`/`-p` cells). The error pointer
+// is shaped to match the source: `<config>` → `kuke restart cell <name>`
+// (#821's restart picks up the daemon-side OutOfSync detection #820 wires and
+// reconciles implicitly; the cell name is the Config's StableName), `-b
+// --name <cell>` → `kuke delete cell <cell>` + re-run (Blueprint-lineage cells
+// have no implicit reconcile per #819's umbrella; the operator promotes to a
+// CellConfig for restart-driven reconcile workflows), and the bare `-f` / `-p`
+// fallback keeps the `kuke apply -f` pointer because those paths carry the
+// spec on disk. The `--new` path never reaches this function: it takes a
+// separate branch in runRun that treats any existing cell as a hard collision
+// (no divergence reconcile pointer makes sense — `restart cell` would
+// reconcile against the Config's stable name, not the `--new` cell's
+// generated/pinned name).
 func rejectDivergentNamedCell(cellDoc v1beta1.CellDoc, changed []string, flags runFlags) error {
 	fields := strings.Join(changed, ", ")
 	switch {
 	case flags.configName != "" && !flags.newCell:
 		return fmt.Errorf(
 			"live cell %q spec differs from CellConfig %q (%s) — refusing to attach; "+
-				"use `kuke apply -c %s` to reconcile (stops, updates, starts)",
-			cellDoc.Metadata.Name, flags.configName, fields, flags.configName,
+				"use `kuke restart cell %s` to reconcile (stops, updates, starts)",
+			cellDoc.Metadata.Name, flags.configName, fields, cellDoc.Metadata.Name,
 		)
 	case flags.blueprintName != "" && flags.nameOverride != "":
 		return fmt.Errorf(
 			"live cell %q spec differs from CellBlueprint %q (%s) — refusing to attach; "+
-				"use `kuke apply -b %s --name %s` to reconcile (stops, updates, starts)",
-			cellDoc.Metadata.Name, flags.blueprintName, fields,
-			flags.blueprintName, cellDoc.Metadata.Name,
+				"-b cells have no in-place reconcile; delete it with "+
+				"`kuke delete cell %s` and re-run (or promote to a CellConfig for "+
+				"`kuke restart cell` reconcile workflows)",
+			cellDoc.Metadata.Name, flags.blueprintName, fields, cellDoc.Metadata.Name,
 		)
 	default:
 		return fmt.Errorf(
@@ -881,11 +889,10 @@ func loadCellDoc(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (lo
 // the KUKE_RUN_SPACE/STACK env var. The session default for those keys is
 // "default" (DefineKV calls viper.SetDefault), so reading them through viper
 // would wrongly narrow every lookup to default/default and hide realm-scoped
-// blueprints; cmd/kuke/shared.ExplicitScope reads the raw flag/env instead,
-// and `kuke apply -b/-c` consumes the same helper for symmetric scope
-// resolution. A blueprint that declares structural slots the inline path
-// cannot fill (secret slots, required repo slots with no url) is refused by
-// Materialize with a pointer to `kuke run -c`.
+// blueprints; cmd/kuke/shared.ExplicitScope reads the raw flag/env instead.
+// A blueprint that declares structural slots the inline path cannot fill
+// (secret slots, required repo slots with no url) is refused by Materialize
+// with a pointer to the CellConfig workflow.
 func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (v1beta1.CellDoc, error) {
 	cliParams, err := buildParamMap(flags)
 	if err != nil {

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -3033,8 +3033,10 @@ func TestRun_FromConfig_DivergentSpec_RefusesAndPointsToApply(t *testing.T) {
 
 	// Simulate divergence by returning a Ready cell whose container image
 	// disagrees with what Materialize(cfg, bp) would build. Per #753 the -c
-	// contract on divergence is to refuse with a `kuke apply -c` pointer, not
-	// warn-and-attach — CreateCell/StartCell must not fire.
+	// contract on divergence is to refuse with a `kuke restart cell <name>`
+	// pointer (#844 retargeted the pointer onto the post-#823 surface; the
+	// removed apply-side reconcile-by-ref form lived behind a single short
+	// flag), not warn-and-attach — CreateCell/StartCell must not fire.
 	fc := &fakeClient{
 		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
 			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
@@ -3080,7 +3082,7 @@ func TestRun_FromConfig_DivergentSpec_RefusesAndPointsToApply(t *testing.T) {
 		`live cell "prod" spec differs from CellConfig "prod"`,
 		`spec.containers["main"].image`,
 		"refusing to attach",
-		"kuke apply -c prod",
+		"kuke restart cell prod",
 		"reconcile",
 	} {
 		if !strings.Contains(err.Error(), want) {
@@ -3095,11 +3097,13 @@ func TestRun_FromConfig_DivergentSpec_RefusesAndPointsToApply(t *testing.T) {
 // TestRun_FromBlueprint_NamedDivergent_RefusesAndPointsToApply covers #753's
 // -b --name addition: a pinned-name `kuke run -b <bp> --name <cell>` against a
 // live cell whose spec has diverged from the materialisation must refuse with
-// a `kuke apply -b <bp> --name <cell>` pointer (mirroring the -c reject), not
-// silently attach to the diverged state. The generated-name path
-// (`kuke run -b <bp>` without --name) is unaffected because each invocation
-// materialises a fresh `<prefix>-<6hex>` cell, so a collision against an
-// existing cell is statistically negligible.
+// a `kuke delete cell <cell>` + re-run pointer (#844 retargeted the pointer
+// onto the post-#823 surface — Blueprint-lineage cells have no implicit
+// reconcile per #819's umbrella, so the message routes to delete-and-re-run
+// rather than a reconcile verb), not silently attach to the diverged state.
+// The generated-name path (`kuke run -b <bp>` without --name) is unaffected
+// because each invocation materialises a fresh `<prefix>-<6hex>` cell, so a
+// collision against an existing cell is statistically negligible.
 func TestRun_FromBlueprint_NamedDivergent_RefusesAndPointsToApply(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
@@ -3138,8 +3142,9 @@ func TestRun_FromBlueprint_NamedDivergent_RefusesAndPointsToApply(t *testing.T) 
 		`live cell "pinned" spec differs from CellBlueprint "web"`,
 		`spec.containers["main"].image`,
 		"refusing to attach",
-		"kuke apply -b web --name pinned",
-		"reconcile",
+		"kuke delete cell pinned",
+		"-b cells have no in-place reconcile",
+		"CellConfig",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("err=%q missing substring %q", err, want)

--- a/internal/cellconfig/cellconfig.go
+++ b/internal/cellconfig/cellconfig.go
@@ -55,9 +55,10 @@ const AnnotationSourceConfig = "kukeon.io/source-config"
 // `<name>-<hash-of-values>`. The CellConfig contract is "one Config → at most
 // one live cell within scope" with a stable identity that survives edits to the
 // config's values; #753's refuse-on-divergence behavior relies on the stable
-// name so `-c` finds the same live cell across invocations whether it attaches
-// (clean spec match) or refuses with a `kuke apply -c <config>` pointer. A
-// value-hashed suffix would change the derived name on every value edit,
+// name so `kuke run <config>` finds the same live cell across invocations
+// whether it attaches (clean spec match) or refuses with a
+// `kuke restart cell <name>` pointer. A value-hashed suffix would change the
+// derived name on every value edit,
 // spawning a fresh cell and orphaning the old one — defeating the idempotent
 // identity that distinguishes a Config (`run -c`) from a Blueprint's
 // always-fresh `<prefix>-<6hex>` (`run -b`). So the name is value-independent.

--- a/internal/controller/create_cell.go
+++ b/internal/controller/create_cell.go
@@ -65,8 +65,9 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 // resources exist) without starting any container tasks. The resulting cell
 // is left in a stopped/created state; the operator runs `kuke start <name>`
 // to start it. Used by the CLI's `kuke create cell --from-blueprint` and
-// `--from-config` scaffolding modes (#818) — distinct from `kuke run -b/-c`
-// (materialise + start + attach) and `kuke apply -b/-c` (reconcile + start).
+// `--from-config` scaffolding modes (#818) — distinct from `kuke run -b` /
+// `kuke run <cfg>` (materialise + start + attach) and (for Config-lineage
+// cells) `kuke restart cell <name>` (reconcile + start on OutOfSync).
 func (b *Exec) MaterializeCell(cell intmodel.Cell) (CreateCellResult, error) {
 	return b.createCellInternal(cell, false)
 }

--- a/internal/controller/reconcile_outofsync.go
+++ b/internal/controller/reconcile_outofsync.go
@@ -42,7 +42,7 @@ const (
 // `-b`-lineage and hand-built cases are deliberately out of scope per the
 // umbrella). For a Config-lineage cell, the pass re-derives the would-be
 // CellDoc from the daemon-stored Config + its referenced Blueprint via the
-// same `cellconfig.Materialize` call `kuke apply -c`'s CLI-side check
+// same `cellconfig.Materialize` call the CellConfig materialisation path
 // uses, then compares the materialized spec against the live cell with
 // `apply.DiffCell`. The outcome lands on three status fields:
 //
@@ -151,12 +151,11 @@ func lookupLineageConfig(
 	return cfg, true, nil
 }
 
-// materializeCellFromConfig re-runs the `kuke apply -c` materialization
-// pipeline against a daemon-stored Config: decode the Config's body,
-// resolve the referenced Blueprint, then `cellconfig.Materialize` the two.
-// Returns the materialized cell in the same internal-model shape the
-// reconciler's live cell uses, so apply.DiffCell can compare them
-// directly.
+// materializeCellFromConfig re-runs the CellConfig materialization pipeline
+// against a daemon-stored Config: decode the Config's body, resolve the
+// referenced Blueprint, then `cellconfig.Materialize` the two. Returns the
+// materialized cell in the same internal-model shape the reconciler's live
+// cell uses, so apply.DiffCell can compare them directly.
 func materializeCellFromConfig(
 	r runner.Runner, cfg intmodel.CellConfig,
 ) (intmodel.Cell, error) {


### PR DESCRIPTION
## Summary
- Retarget the user-facing migration pointers that `#823` left stale: `kuke apply -c <cfg>` → `kuke restart cell <name>` (picks up #821's OutOfSync-driven reconcile on the Ready+OutOfSync path); `kuke apply -b <bp> --name <cell>` → `kuke delete cell <cell>` + re-run (Blueprint-lineage cells have no implicit reconcile per #819's umbrella; promotion to a CellConfig is the persistent-reconcile path).
- Scrub `kuke apply -b/-c` from the cobra `Long:` help on `kuke run`, `rejectDivergentNamedCell`'s error messages and godoc, the related godoc references in `cmd/kuke/restart/cell/cell.go`, `internal/controller/reconcile_outofsync.go`, and `internal/cellconfig/cellconfig.go`, plus the `kuke run` blueprint-loader's stale "apply -b/-c uses the same helper" aside.
- Update `run_test.go`'s `TestRun_FromConfig_DivergentSpec_RefusesAndPointsToApply` and `TestRun_FromBlueprint_NamedDivergent_RefusesAndPointsToApply` to assert the new pointer wording.
- **Scope note (broadened beyond the issue's enumeration to satisfy AC #5):** AC #5's no-literal-strings invariant pulled in two extra files not in the proposal's enumerated godoc list — `internal/controller/create_cell.go:69` (`MaterializeCell` godoc) and `cmd/kuke/create/cell/cell.go` (the `kuke create cell --from-blueprint`/`--from-config` cobra `Long:` plus the `materialiseAndPersist` already-exists error at `:352`). Both still pointed operators at `kuke apply -b/-c`; updated to the post-#823 surface in the same style as the rest. Per CLAUDE.md §Sanity-check AC implementation specifics: surfacing the divergence in the PR body so the reviewer can push back if the broadened scope oversteps. Out of scope per the issue: `docs/site/...` and `docs/cli-use-cases.md` (pm's `/plan-release-doc` lane per umbrella #819).
- **`-b --name` design call:** the issue left the new pointer wording open ("delete and re-run, or promote to a CellConfig"). Went with both — the error message names `kuke delete cell <cell>` as the immediate action and notes that promotion to a CellConfig is the persistent-reconcile path. Mirrors the umbrella's stated migration ("Named cell from Blueprint with persistent params — not directly supported. Operator creates a Config carrying those params and uses Config workflows").
- **Stale `kuke restart cell` Stopped-path comment:** `restartStopped`'s godoc previously said "an operator wanting to reconcile from Stopped uses `kuke apply -c` directly" — post-#823 there's no `apply -c`, so updated to "starts the cell first and then re-runs `kuke restart cell <name>`" (Ready+OutOfSync reconcile). Surfacing here in case the reviewer prefers a different phrasing of the workaround.

## Test plan
- [x] `make test` — all package tests pass, including the updated `TestRun_FromConfig_DivergentSpec_RefusesAndPointsToApply` and `TestRun_FromBlueprint_NamedDivergent_RefusesAndPointsToApply`.
- [x] `pre-commit run --files <changed>` — `go fmt`, `go-mod-tidy`, `golangci-lint`, `addlicense`, end-of-file, whitespace checks all pass.
- [x] `grep -rn "kuke apply -[bc]" --include="*.go"` returns no matches — AC #5's no-literal-strings invariant holds across all Go sources (the apply package's removal-guard tests `TestApply_BlueprintFlag_Removed`/`TestApply_ConfigFlag_Removed` test the flag literals like `"-b"`/`"--blueprint"`, not the pointer text, so they aren't affected).
- [ ] `make dev-init` smoke — no daemon/build-path code touched (godoc + error-string-only diff in `cmd/`+`internal/`), so the regression guard isn't materially exercised; deferring to the reviewer's environment.

Closes #844