### PR TITLE
refactor(get/shared): pipe PrintYAML/PrintJSON through cmd.OutOrStdout

### DIFF
--- a/cmd/kuke/get/blueprint/blueprint.go
+++ b/cmd/kuke/get/blueprint/blueprint.go
@@ -103,7 +103,7 @@ func NewBlueprintCmd() *cobra.Command {
 				if !result.MetadataExists {
 					return fmt.Errorf("blueprint %q not found", name)
 				}
-				return printBlueprint(&result.Blueprint, outputFormat)
+				return printBlueprint(cmd, &result.Blueprint, outputFormat)
 			}
 
 			blueprints, err := client.ListBlueprints(cmd.Context(), realm, space, stack)
@@ -142,23 +142,23 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
-func printBlueprint(blueprint *v1beta1.CellBlueprintDoc, format shared.OutputFormat) error {
+func printBlueprint(cmd *cobra.Command, blueprint *v1beta1.CellBlueprintDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(blueprint)
+		return shared.PrintJSON(cmd, blueprint)
 	case shared.OutputFormatYAML, shared.OutputFormatTable:
-		return shared.PrintYAML(blueprint)
+		return shared.PrintYAML(cmd, blueprint)
 	default:
-		return shared.PrintYAML(blueprint)
+		return shared.PrintYAML(cmd, blueprint)
 	}
 }
 
 func printBlueprints(cmd *cobra.Command, blueprints []v1beta1.CellBlueprintDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatYAML:
-		return shared.PrintYAML(blueprints)
+		return shared.PrintYAML(cmd, blueprints)
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(blueprints)
+		return shared.PrintJSON(cmd, blueprints)
 	case shared.OutputFormatTable:
 		if len(blueprints) == 0 {
 			cmd.Println("No blueprints found.")
@@ -178,7 +178,7 @@ func printBlueprints(cmd *cobra.Command, blueprints []v1beta1.CellBlueprintDoc, 
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return shared.PrintYAML(blueprints)
+		return shared.PrintYAML(cmd, blueprints)
 	}
 }
 

--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -129,7 +129,7 @@ outOfSync / outOfSyncReason / outOfSyncError status fields.`,
 				if !result.MetadataExists {
 					return fmt.Errorf("cell %q not found in stack %q/%q/%q", name, realm, space, stack)
 				}
-				return printCell(&result.Cell, outputFormat)
+				return printCell(cmd, &result.Cell, outputFormat)
 			}
 
 			cells, err := client.ListCells(cmd.Context(), realm, space, stack)
@@ -232,12 +232,12 @@ func hasConfigLineage(c *v1beta1.CellDoc) bool {
 	return strings.TrimSpace(c.Metadata.Labels[cellconfig.LabelConfig]) != ""
 }
 
-func printCell(cell *v1beta1.CellDoc, format shared.OutputFormat) error {
+func printCell(cmd *cobra.Command, cell *v1beta1.CellDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(cell)
+		return shared.PrintJSON(cmd, cell)
 	default:
-		return shared.PrintYAML(cell)
+		return shared.PrintYAML(cmd, cell)
 	}
 }
 
@@ -250,9 +250,9 @@ func printCells(
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
-		return shared.PrintYAML(cells)
+		return shared.PrintYAML(cmd, cells)
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(cells)
+		return shared.PrintJSON(cmd, cells)
 	case shared.OutputFormatTable:
 		if len(cells) == 0 {
 			cmd.Println("No cells found.")
@@ -293,6 +293,6 @@ func printCells(
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return shared.PrintYAML(cells)
+		return shared.PrintYAML(cmd, cells)
 	}
 }

--- a/cmd/kuke/get/cell/cell_test.go
+++ b/cmd/kuke/get/cell/cell_test.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"os"
 	"strings"
 	"testing"
 
@@ -271,38 +270,8 @@ func TestNewCellCmd_SyncColumn(t *testing.T) {
 				}
 			}
 
-			var stdoutBuf *bytes.Buffer
-			if len(tt.wantStatus) > 0 {
-				// shared.PrintYAML / PrintJSON write directly to os.Stdout
-				// (the printer is shared across get subcommands and ignores
-				// cmd's stdout redirection). Capture via os.Pipe — same
-				// pattern the shared tests in cmd/kuke/get/shared use.
-				oldStdout := os.Stdout
-				r, w, pipeErr := os.Pipe()
-				if pipeErr != nil {
-					t.Fatalf("os.Pipe: %v", pipeErr)
-				}
-				os.Stdout = w
-				t.Cleanup(func() {
-					os.Stdout = oldStdout
-				})
-				stdoutBuf = &bytes.Buffer{}
-				done := make(chan struct{})
-				go func() {
-					_, _ = stdoutBuf.ReadFrom(r)
-					close(done)
-				}()
-				if err := cmd.Execute(); err != nil {
-					_ = w.Close()
-					<-done
-					t.Fatalf("unexpected error: %v", err)
-				}
-				_ = w.Close()
-				<-done
-			} else {
-				if err := cmd.Execute(); err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 
 			out := buf.String()
@@ -316,12 +285,9 @@ func TestNewCellCmd_SyncColumn(t *testing.T) {
 					t.Errorf("row missing %q\nGot:\n%s", sub, out)
 				}
 			}
-			if stdoutBuf != nil {
-				yamlOut := stdoutBuf.String()
-				for _, sub := range tt.wantStatus {
-					if !strings.Contains(yamlOut, sub) {
-						t.Errorf("yaml output missing %q\nGot:\n%s", sub, yamlOut)
-					}
+			for _, sub := range tt.wantStatus {
+				if !strings.Contains(out, sub) {
+					t.Errorf("yaml output missing %q\nGot:\n%s", sub, out)
 				}
 			}
 		})

--- a/cmd/kuke/get/config/config.go
+++ b/cmd/kuke/get/config/config.go
@@ -103,7 +103,7 @@ func NewConfigCmd() *cobra.Command {
 				if !result.MetadataExists {
 					return fmt.Errorf("config %q not found", name)
 				}
-				return printConfig(&result.Config, outputFormat)
+				return printConfig(cmd, &result.Config, outputFormat)
 			}
 
 			configs, err := client.ListConfigs(cmd.Context(), realm, space, stack)
@@ -142,23 +142,23 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
-func printConfig(cfg *v1beta1.CellConfigDoc, format shared.OutputFormat) error {
+func printConfig(cmd *cobra.Command, cfg *v1beta1.CellConfigDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(cfg)
+		return shared.PrintJSON(cmd, cfg)
 	case shared.OutputFormatYAML, shared.OutputFormatTable:
-		return shared.PrintYAML(cfg)
+		return shared.PrintYAML(cmd, cfg)
 	default:
-		return shared.PrintYAML(cfg)
+		return shared.PrintYAML(cmd, cfg)
 	}
 }
 
 func printConfigs(cmd *cobra.Command, configs []v1beta1.CellConfigDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatYAML:
-		return shared.PrintYAML(configs)
+		return shared.PrintYAML(cmd, configs)
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(configs)
+		return shared.PrintJSON(cmd, configs)
 	case shared.OutputFormatTable:
 		if len(configs) == 0 {
 			cmd.Println("No configs found.")
@@ -178,7 +178,7 @@ func printConfigs(cmd *cobra.Command, configs []v1beta1.CellConfigDoc, format sh
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return shared.PrintYAML(configs)
+		return shared.PrintYAML(cmd, configs)
 	}
 }
 

--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -39,20 +39,6 @@ type MockControllerKey struct{}
 
 const noContainersFoundMsg = "No containers found."
 
-type (
-	printObjectFunc  func(interface{}) error
-	tablePrinterFunc func(*cobra.Command, []string, [][]string)
-)
-
-var (
-	// YAMLPrinter is exported for testing.
-	YAMLPrinter printObjectFunc = shared.PrintYAML
-	// JSONPrinter is exported for testing.
-	JSONPrinter printObjectFunc = shared.PrintJSON
-	// TablePrinter is exported for testing.
-	TablePrinter tablePrinterFunc = shared.PrintTable
-)
-
 func NewContainerCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "container [name]",
@@ -89,16 +75,6 @@ func NewContainerCmd() *cobra.Command {
 }
 
 func runContainerCmd(cmd *cobra.Command, args []string) error {
-	return runContainerCmdWithDeps(cmd, args, YAMLPrinter, JSONPrinter, TablePrinter)
-}
-
-func runContainerCmdWithDeps(
-	cmd *cobra.Command,
-	args []string,
-	printYAML printObjectFunc,
-	printJSON printObjectFunc,
-	printTable tablePrinterFunc,
-) error {
 	client, err := resolveClient(cmd)
 	if err != nil {
 		return err
@@ -172,7 +148,7 @@ func runContainerCmdWithDeps(
 			return fmt.Errorf("container %q not found", name)
 		}
 
-		return printContainer(&result.Container, outputFormat, printYAML, printJSON)
+		return printContainer(cmd, &result.Container, outputFormat)
 	}
 
 	// List path — query each container's state by calling GetContainer.
@@ -223,9 +199,6 @@ func runContainerCmdWithDeps(
 		containerStates,
 		outputFormat,
 		emptyMsg,
-		printYAML,
-		printJSON,
-		printTable,
 	)
 }
 
@@ -335,17 +308,12 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
-func printContainer(
-	container interface{},
-	format shared.OutputFormat,
-	printYAML printObjectFunc,
-	printJSON printObjectFunc,
-) error {
+func printContainer(cmd *cobra.Command, container interface{}, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
-		return printJSON(container)
+		return shared.PrintJSON(cmd, container)
 	default:
-		return printYAML(container)
+		return shared.PrintYAML(cmd, container)
 	}
 }
 
@@ -355,15 +323,12 @@ func printContainersWithState(
 	containerStates map[string]string,
 	format shared.OutputFormat,
 	emptyMsg string,
-	printYAML printObjectFunc,
-	printJSON printObjectFunc,
-	printTable tablePrinterFunc,
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
-		return printYAML(containers)
+		return shared.PrintYAML(cmd, containers)
 	case shared.OutputFormatJSON:
-		return printJSON(containers)
+		return shared.PrintJSON(cmd, containers)
 	case shared.OutputFormatTable:
 		if len(containers) == 0 {
 			if emptyMsg == "" {
@@ -393,10 +358,10 @@ func printContainersWithState(
 				state,
 			})
 		}
-		printTable(cmd, headers, rows)
+		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return printYAML(containers)
+		return shared.PrintYAML(cmd, containers)
 	}
 }
 

--- a/cmd/kuke/get/image/image.go
+++ b/cmd/kuke/get/image/image.go
@@ -27,7 +27,6 @@ package image
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -46,7 +45,6 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
 )
 
 // MockControllerKey injects a fake Client via context for tests, mirroring
@@ -174,32 +172,14 @@ func resolveClient(cmd *cobra.Command) Client {
 	})
 }
 
-// encodeYAML / encodeJSON write structured output to the command's stdout
-// rather than os.Stdout so tests that wire `cmd.SetOut(buf)` can capture it.
-// The shared get printers in `cmd/kuke/get/shared` always target os.Stdout
-// — fine in production, opaque in tests — so this leaf opts out of them.
-func encodeYAML(cmd *cobra.Command, doc any) error {
-	const yamlIndent = 2
-	encoder := yaml.NewEncoder(cmd.OutOrStdout())
-	encoder.SetIndent(yamlIndent)
-	defer func() { _ = encoder.Close() }()
-	return encoder.Encode(doc)
-}
-
-func encodeJSON(cmd *cobra.Command, doc any) error {
-	encoder := json.NewEncoder(cmd.OutOrStdout())
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(doc)
-}
-
 func printImage(cmd *cobra.Command, img kukeonv1.ImageInfo, format getshared.OutputFormat) error {
 	switch format {
 	case getshared.OutputFormatJSON:
-		return encodeJSON(cmd, img)
+		return getshared.PrintJSON(cmd, img)
 	case getshared.OutputFormatYAML, getshared.OutputFormatTable:
-		return encodeYAML(cmd, img)
+		return getshared.PrintYAML(cmd, img)
 	default:
-		return encodeYAML(cmd, img)
+		return getshared.PrintYAML(cmd, img)
 	}
 }
 
@@ -211,9 +191,9 @@ func printImages(
 ) error {
 	switch format {
 	case getshared.OutputFormatYAML:
-		return encodeYAML(cmd, results)
+		return getshared.PrintYAML(cmd, results)
 	case getshared.OutputFormatJSON:
-		return encodeJSON(cmd, results)
+		return getshared.PrintJSON(cmd, results)
 	case getshared.OutputFormatTable:
 		total := 0
 		for _, r := range results {
@@ -241,7 +221,7 @@ func printImages(
 		getshared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return encodeYAML(cmd, results)
+		return getshared.PrintYAML(cmd, results)
 	}
 }
 

--- a/cmd/kuke/get/realm/realm.go
+++ b/cmd/kuke/get/realm/realm.go
@@ -75,7 +75,7 @@ func NewRealmCmd() *cobra.Command {
 				if !result.MetadataExists {
 					return fmt.Errorf("realm %q not found", name)
 				}
-				return printRealm(&result.Realm, outputFormat)
+				return printRealm(cmd, &result.Realm, outputFormat)
 			}
 
 			realms, err := client.ListRealms(cmd.Context())
@@ -116,12 +116,12 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
-func printRealm(realm *v1beta1.RealmDoc, format shared.OutputFormat) error {
+func printRealm(cmd *cobra.Command, realm *v1beta1.RealmDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(realm)
+		return shared.PrintJSON(cmd, realm)
 	default:
-		return shared.PrintYAML(realm)
+		return shared.PrintYAML(cmd, realm)
 	}
 }
 
@@ -133,9 +133,9 @@ func printRealms(
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
-		return shared.PrintYAML(realms)
+		return shared.PrintYAML(cmd, realms)
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(realms)
+		return shared.PrintJSON(cmd, realms)
 	case shared.OutputFormatTable:
 		if len(realms) == 0 {
 			cmd.Println("No realms found.")
@@ -162,6 +162,6 @@ func printRealms(
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return shared.PrintYAML(realms)
+		return shared.PrintYAML(cmd, realms)
 	}
 }

--- a/cmd/kuke/get/secret/secret.go
+++ b/cmd/kuke/get/secret/secret.go
@@ -104,7 +104,7 @@ func NewSecretCmd() *cobra.Command {
 				if !result.MetadataExists {
 					return fmt.Errorf("secret %q not found", name)
 				}
-				return printSecret(&result.Secret, outputFormat)
+				return printSecret(cmd, &result.Secret, outputFormat)
 			}
 
 			secrets, err := client.ListSecrets(cmd.Context(), realm, space, stack, cell)
@@ -146,23 +146,23 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
-func printSecret(secret *v1beta1.SecretDoc, format shared.OutputFormat) error {
+func printSecret(cmd *cobra.Command, secret *v1beta1.SecretDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(secret)
+		return shared.PrintJSON(cmd, secret)
 	case shared.OutputFormatYAML, shared.OutputFormatTable:
-		return shared.PrintYAML(secret)
+		return shared.PrintYAML(cmd, secret)
 	default:
-		return shared.PrintYAML(secret)
+		return shared.PrintYAML(cmd, secret)
 	}
 }
 
 func printSecrets(cmd *cobra.Command, secrets []v1beta1.SecretDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatYAML:
-		return shared.PrintYAML(secrets)
+		return shared.PrintYAML(cmd, secrets)
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(secrets)
+		return shared.PrintJSON(cmd, secrets)
 	case shared.OutputFormatTable:
 		if len(secrets) == 0 {
 			cmd.Println("No secrets found.")
@@ -183,7 +183,7 @@ func printSecrets(cmd *cobra.Command, secrets []v1beta1.SecretDoc, format shared
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return shared.PrintYAML(secrets)
+		return shared.PrintYAML(cmd, secrets)
 	}
 }
 

--- a/cmd/kuke/get/shared/shared.go
+++ b/cmd/kuke/get/shared/shared.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
@@ -84,17 +83,20 @@ func ParseOutputFormat(cmd *cobra.Command) (OutputFormat, error) {
 	}
 }
 
-// PrintYAML prints the resource as YAML.
-func PrintYAML(doc interface{}) error {
-	encoder := yaml.NewEncoder(os.Stdout)
+// PrintYAML prints the resource as YAML to cmd.OutOrStdout() so callers
+// can capture output via cobra's cmd.SetOut(buf) in tests. Matches the
+// shape PrintTable already takes.
+func PrintYAML(cmd *cobra.Command, doc any) error {
+	encoder := yaml.NewEncoder(cmd.OutOrStdout())
 	encoder.SetIndent(2)
-	defer encoder.Close()
+	defer func() { _ = encoder.Close() }()
 	return encoder.Encode(doc)
 }
 
-// PrintJSON prints the resource as JSON.
-func PrintJSON(doc interface{}) error {
-	encoder := json.NewEncoder(os.Stdout)
+// PrintJSON prints the resource as JSON to cmd.OutOrStdout() so callers
+// can capture output via cobra's cmd.SetOut(buf) in tests.
+func PrintJSON(cmd *cobra.Command, doc any) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(doc)
 }

--- a/cmd/kuke/get/shared/shared_test.go
+++ b/cmd/kuke/get/shared/shared_test.go
@@ -19,7 +19,6 @@ package shared_test
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -220,26 +219,8 @@ func TestPrintYAML(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldStdout := os.Stdout
-			r, w, err := os.Pipe()
-			if err != nil {
-				t.Fatalf("failed to create pipe: %v", err)
-			}
-			os.Stdout = w
-
-			errChan := make(chan error, 1)
-			go func() {
-				printErr := shared.PrintYAML(tt.doc)
-				w.Close()
-				errChan <- printErr
-			}()
-
-			var buf bytes.Buffer
-			io.Copy(&buf, r)
-			os.Stdout = oldStdout
-			r.Close()
-
-			err = <-errChan
+			cmd, buf := newOutputCommand()
+			err := shared.PrintYAML(cmd, tt.doc)
 			output := buf.String()
 
 			if tt.wantErr != "" {
@@ -315,26 +296,8 @@ func TestPrintJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldStdout := os.Stdout
-			r, w, err := os.Pipe()
-			if err != nil {
-				t.Fatalf("failed to create pipe: %v", err)
-			}
-			os.Stdout = w
-
-			errChan := make(chan error, 1)
-			go func() {
-				printErr := shared.PrintJSON(tt.doc)
-				w.Close()
-				errChan <- printErr
-			}()
-
-			var buf bytes.Buffer
-			io.Copy(&buf, r)
-			os.Stdout = oldStdout
-			r.Close()
-
-			err = <-errChan
+			cmd, buf := newOutputCommand()
+			err := shared.PrintJSON(cmd, tt.doc)
 			output := strings.TrimSpace(buf.String())
 
 			if tt.wantErr != "" {

--- a/cmd/kuke/get/space/space.go
+++ b/cmd/kuke/get/space/space.go
@@ -84,7 +84,7 @@ func NewSpaceCmd() *cobra.Command {
 				if !result.MetadataExists {
 					return fmt.Errorf("space %q not found in realm %q", name, realm)
 				}
-				return printSpace(&result.Space, outputFormat)
+				return printSpace(cmd, &result.Space, outputFormat)
 			}
 
 			spaces, err := client.ListSpaces(cmd.Context(), realm)
@@ -123,12 +123,12 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
-func printSpace(space *v1beta1.SpaceDoc, format shared.OutputFormat) error {
+func printSpace(cmd *cobra.Command, space *v1beta1.SpaceDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(space)
+		return shared.PrintJSON(cmd, space)
 	default:
-		return shared.PrintYAML(space)
+		return shared.PrintYAML(cmd, space)
 	}
 }
 
@@ -140,9 +140,9 @@ func printSpaces(
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
-		return shared.PrintYAML(spaces)
+		return shared.PrintYAML(cmd, spaces)
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(spaces)
+		return shared.PrintJSON(cmd, spaces)
 	case shared.OutputFormatTable:
 		if len(spaces) == 0 {
 			cmd.Println("No spaces found.")
@@ -169,6 +169,6 @@ func printSpaces(
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return shared.PrintYAML(spaces)
+		return shared.PrintYAML(cmd, spaces)
 	}
 }

--- a/cmd/kuke/get/stack/stack.go
+++ b/cmd/kuke/get/stack/stack.go
@@ -94,7 +94,7 @@ func NewStackCmd() *cobra.Command {
 				if !result.MetadataExists {
 					return fmt.Errorf("stack %q not found in realm %q, space %q", name, realm, space)
 				}
-				return printStack(&result.Stack, outputFormat)
+				return printStack(cmd, &result.Stack, outputFormat)
 			}
 
 			stacks, err := client.ListStacks(cmd.Context(), realm, space)
@@ -135,12 +135,12 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 	return kukeshared.ClientFromCmd(cmd)
 }
 
-func printStack(stack *v1beta1.StackDoc, format shared.OutputFormat) error {
+func printStack(cmd *cobra.Command, stack *v1beta1.StackDoc, format shared.OutputFormat) error {
 	switch format {
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(stack)
+		return shared.PrintJSON(cmd, stack)
 	default:
-		return shared.PrintYAML(stack)
+		return shared.PrintYAML(cmd, stack)
 	}
 }
 
@@ -152,9 +152,9 @@ func printStacks(
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
-		return shared.PrintYAML(stacks)
+		return shared.PrintYAML(cmd, stacks)
 	case shared.OutputFormatJSON:
-		return shared.PrintJSON(stacks)
+		return shared.PrintJSON(cmd, stacks)
 	case shared.OutputFormatTable:
 		if len(stacks) == 0 {
 			cmd.Println("No stacks found.")
@@ -181,6 +181,6 @@ func printStacks(
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
-		return shared.PrintYAML(stacks)
+		return shared.PrintYAML(cmd, stacks)
 	}
 }


### PR DESCRIPTION
## Summary

- Refactor `cmd/kuke/get/shared/shared.go`'s `PrintYAML` / `PrintJSON` to take `*cobra.Command` and write to `cmd.OutOrStdout()` instead of `os.Stdout`. Symmetric with the existing `PrintTable(cmd, …)` shape — went with Option B (cobra-coupled) per the issue body's two-option offer, since every caller already has `cmd` on hand and the symmetry keeps the call sites tight.
- Thread `cmd` through each leaf's single-doc `print<Kind>(…)` helper (`printRealm`, `printStack`, `printSpace`, `printCell`, `printSecret`, `printBlueprint`, `printConfig`, `printContainer`). The list-form `print<Kind>s(…)` helpers already took `cmd`.
- `cmd/kuke/get/container/`: drop the `printObjectFunc` / `tablePrinterFunc` types, the `YAMLPrinter` / `JSONPrinter` / `TablePrinter` package vars, and the `runContainerCmdWithDeps` injection seam. `printContainer` / `printContainersWithState` now call `shared.PrintYAML` / `PrintJSON` / `PrintTable` directly. Container tests already use `cmd.SetOut(buf)` capture and need no further changes.
- `cmd/kuke/get/image/image.go`: drop the inline `encodeYAML` / `encodeJSON` helpers (the #824 workaround) and call the shared printers directly. The `encoding/json` and `gopkg.in/yaml.v3` imports become unused and are dropped.
- `cmd/kuke/get/shared/shared_test.go`: replace the `os.Pipe` capture in `TestPrintYAML` / `TestPrintJSON` with the same `newOutputCommand()` + `cmd.SetOut(buf)` helper `TestPrintTable` already uses.
- `cmd/kuke/get/cell/cell_test.go`: drop the `os.Pipe` workaround in `TestNewCellCmd_SyncColumn`'s yaml subtests — yaml output now lands in `buf` alongside the table output, so the `wantStatus` substrings assert against the same buffer. The stale comment claiming `PrintYAML` writes to `os.Stdout` goes with it.

## Test plan

- [x] `make test` — full project test target green (root + `cmd/kukebuild`).
- [x] `GOWORK=off go build ./...` — clean compile.
- [x] `GOWORK=off go vet ./...` — no findings.
- [x] `GOWORK=off go test ./cmd/kuke/get/...` — every leaf (`shared`, `realm`, `space`, `stack`, `cell`, `container`, `image`, `secret`, `blueprint`, `config`) passes; no regressions from the threaded-`cmd` plumbing or the dropped override seam.
- [x] `pre-commit run --files <12 changed>` — trailing-whitespace, EOF, `go fmt`, `go-mod-tidy`, golangci-lint (`--new-from-rev HEAD --fix`), addlicense all green. Pre-commit's lint config is exactly the gating check the AC asks for — no new `gochecknoglobals` / `reassign` findings.
- [ ] `make dev-init` smoke — not run. Diff is pure CLI-side presentation logic; doesn't touch the daemon, the build path, or anything under `/opt/kukeon`, so the regression guard isn't materially exercised.

Closes #829