### PR TITLE
fix(stop/kill): preserve containerd container record + overlay snapshot

### DIFF
--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
@@ -157,28 +156,11 @@ func (r *Exec) killCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 			fields...,
 		)
 
-		// Delete container after killing
-		err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, containerID, ctr.ContainerDeleteOptions{
-			SnapshotCleanup: true,
-		})
-		if err != nil {
-			// Log warning but don't fail - container might already be deleted
-			fields = appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-			fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
-			r.logger.WarnContext(
-				r.ctx,
-				"failed to delete container, continuing",
-				fields...,
-			)
-		} else {
-			fields = appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-			fields = append(fields, "space", spaceID, "realm", realmID)
-			r.logger.InfoContext(
-				r.ctx,
-				"deleted container",
-				fields...,
-			)
-		}
+		// Issue #867: leave the containerd container record (and snapshot)
+		// in place. kill is the SIGKILL-escalated cousin of stop; the
+		// documented stop/kill/delete split (docs/cli-use-cases.md) only
+		// distinguishes the two on signal escalation, not on snapshot
+		// teardown. delete still owns record + snapshot teardown.
 	}
 
 	// Kill root container last and detach from CNI
@@ -224,28 +206,10 @@ func (r *Exec) killCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 		)
 	}
 
-	// Delete root container after killing
-	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, rootContainerID, ctr.ContainerDeleteOptions{
-		SnapshotCleanup: true,
-	})
-	if err != nil {
-		// Log warning but don't fail - container might already be deleted
-		fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
-		fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
-		r.logger.WarnContext(
-			r.ctx,
-			"failed to delete root container, continuing",
-			fields...,
-		)
-	} else {
-		fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
-		fields = append(fields, "space", spaceID, "realm", realmID)
-		r.logger.InfoContext(
-			r.ctx,
-			"deleted root container",
-			fields...,
-		)
-	}
+	// Issue #867: leave the root container record + snapshot in place — see
+	// the matching comment in the workload-container loop above. CNI cleanup
+	// below still runs so the IPAM reservation is released; without that, the
+	// next StartCell's CNI ADD would be rejected as a duplicate allocation.
 
 	// Always run comprehensive CNI cleanup after container deletion as a safety net
 	// This ensures IPAM allocations are cleaned up even if CNI DEL succeeded or failed
@@ -429,38 +393,9 @@ func (r *Exec) KillContainer(cell intmodel.Cell, containerID string) error {
 		fields...,
 	)
 
-	// Delete container after killing
-	err = r.ctrClient.DeleteContainer(internalRealm.Spec.Namespace, containerdID, ctr.ContainerDeleteOptions{
-		SnapshotCleanup: true,
-	})
-	if err != nil {
-		// Log warning but don't fail - container might already be deleted
-		fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-		fields = append(
-			fields,
-			"space",
-			spaceName,
-			"realm",
-			realmName,
-			"containerName",
-			containerID,
-			"err",
-			fmt.Sprintf("%v", err),
-		)
-		r.logger.WarnContext(
-			r.ctx,
-			"failed to delete container, continuing",
-			fields...,
-		)
-	} else {
-		fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-		fields = append(fields, "space", spaceName, "realm", realmName, "containerName", containerID)
-		r.logger.InfoContext(
-			r.ctx,
-			"deleted container",
-			fields...,
-		)
-	}
-
+	// Issue #867: leave the containerd container record (and snapshot) in
+	// place. The cell-wide cleanup comments in killCellLocked above carry
+	// the full rationale; the single-container `kuke kill container` verb
+	// mirrors the cell-wide kill verb's contract.
 	return nil
 }

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1510,7 +1510,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				cell.Spec.Containers[i] = containerSpec
 			}
 
-			rootLabels := buildRootContainerLabels(*cell)
+			rootLabels := stampSpecHashOnLabels(buildRootContainerLabels(*cell), containerSpec)
 			ctrContainerSpec := ctr.BuildRootContainerSpec(containerSpec, rootLabels, r.daemonDefaultBuildOpts()...)
 
 			createdContainer, createErr = r.ctrClient.CreateContainer(namespace, ctrContainerSpec, creds)
@@ -1574,6 +1574,9 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
 			buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
+			buildOpts = append(buildOpts, ctr.WithExtraLabels(map[string]string{
+				SpecHashLabelKey: ComputeContainerSpecHash(containerSpec),
+			}))
 			// Merge `kuke run --env` runtime env into the attachable
 			// container's spec env (issue #834). Returns containerSpec
 			// unchanged for non-attachable containers or when
@@ -1804,7 +1807,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		}
 		r.stampContainerRecreateRuntimeFields(&rootContainerSpec, cell)
 
-		rootLabels := buildRootContainerLabels(*cell)
+		rootLabels := stampSpecHashOnLabels(buildRootContainerLabels(*cell), rootContainerSpec)
 		containerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels, r.daemonDefaultBuildOpts()...)
 
 		var createErr error
@@ -2050,6 +2053,9 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
 			buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
+			buildOpts = append(buildOpts, ctr.WithExtraLabels(map[string]string{
+				SpecHashLabelKey: ComputeContainerSpecHash(containerSpec),
+			}))
 			createdContainer, containerCreateErr := r.ctrClient.CreateContainerFromSpec(
 				internalRealm.Spec.Namespace,
 				containerSpec,

--- a/internal/controller/runner/spec_hash.go
+++ b/internal/controller/runner/spec_hash.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// SpecHashLabelKey is the containerd container label that pins the OCI spec
+// to the CellSpec it was created from. StartCell's existing-container branch
+// reads the label, recomputes the hash from the on-disk CellSpec, and refuses
+// to resume a record whose hash diverges — the operator is told to reconcile
+// via `kuke apply -f`. The supported `kuke apply -f` flow re-stamps the label
+// inside the same RecreateCell / UpdateCell transaction that rewrites
+// containerd state, so steady-state restarts always match. Issue #867.
+const SpecHashLabelKey = "kukeon.io/spec-hash"
+
+// containerSpecHashPayload is the deterministic projection of an
+// intmodel.ContainerSpec that ComputeContainerSpecHash hashes. The field set
+// must match exactly what `apply.DiffCell` classifies as "requires containerd
+// recreate" — today that is image/command/args (the domain
+// `rootContainerSpecChanged` and `containerSpecChanged` both branch on). The
+// `TestSpecHashDomainPinsToDiffCellBreakingFields` test pins the two
+// definitions together so they cannot silently drift apart. Issue #867
+// AC #5 / #6.
+//
+// Args is normalized to a non-nil empty slice on the in-payload side so a
+// nil-vs-empty distinction in the source spec does not change the hash —
+// containerd treats both as "no args".
+type containerSpecHashPayload struct {
+	Image   string   `json:"image"`
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+// ComputeContainerSpecHash returns a hex-encoded SHA-256 over the
+// containerSpecHashPayload projection of spec. Pure function; no
+// containerd access. Same hash for root and non-root containers — the
+// domain is identical (see containerSpecHashPayload).
+func ComputeContainerSpecHash(spec intmodel.ContainerSpec) string {
+	args := spec.Args
+	if args == nil {
+		args = []string{}
+	}
+	payload := containerSpecHashPayload{
+		Image:   spec.Image,
+		Command: spec.Command,
+		Args:    args,
+	}
+	// json.Marshal on a struct with a fixed field order is deterministic.
+	// Errors are not possible here (payload is plain strings + []string).
+	buf, _ := json.Marshal(payload)
+	sum := sha256.Sum256(buf)
+	return hex.EncodeToString(sum[:])
+}
+
+// stampSpecHashOnLabels writes the SpecHashLabelKey into labels (allocating
+// the map if nil) and returns it. Used by every root-container create path
+// where the runner builds the labels map up front and passes it through
+// ctr.BuildRootContainerSpec.
+func stampSpecHashOnLabels(labels map[string]string, spec intmodel.ContainerSpec) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+	labels[SpecHashLabelKey] = ComputeContainerSpecHash(spec)
+	return labels
+}
+
+// reuseOrRefuseExistingChildContainer is the child-container counterpart of
+// the spec-hash guard StartCell applies inline for the root container. It
+// looks up the existing containerd record for ctrContainerID and:
+//
+//   - returns (false, nil) when the record is absent (caller takes the
+//     fresh-create path);
+//   - returns an error wrapping ErrCellSpecHashDrift when the record carries
+//     a kukeon.io/spec-hash label that disagrees with the desired spec hash;
+//   - returns (true, nil) on match or legacy-no-label, after dropping a
+//     stale Created/Stopped task so the caller's StartContainer can create
+//     a fresh task.
+//
+// Issue #867.
+func (r *Exec) reuseOrRefuseExistingChildContainer(
+	namespace, ctrContainerID, cellName string,
+	spec intmodel.ContainerSpec,
+) (bool, error) {
+	container, err := r.ctrClient.GetContainer(namespace, ctrContainerID)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrContainerNotFound) {
+			return false, nil
+		}
+		// Surface other errors to the caller so a transient lookup
+		// failure doesn't silently widen into a destructive recreate.
+		return false, fmt.Errorf("failed to check existing container %s: %w", ctrContainerID, err)
+	}
+	desiredHash := ComputeContainerSpecHash(spec)
+	nsCtx := namespaces.WithNamespace(r.ctx, namespace)
+	existingLabels, labelErr := container.Labels(nsCtx)
+	if labelErr != nil {
+		r.logger.WarnContext(r.ctx,
+			"failed to read existing container labels, treating as match for reuse",
+			"id", ctrContainerID, "cell", cellName, "err", labelErr.Error())
+	}
+	onDiskHash := existingLabels[SpecHashLabelKey]
+	if onDiskHash != "" && onDiskHash != desiredHash {
+		return false, fmt.Errorf(
+			"%w: cell %q: container %q carries spec-hash %q but cell spec hashes to %q — "+
+				"run `kuke apply -f` to reconcile",
+			errdefs.ErrCellSpecHashDrift, cellName, ctrContainerID, onDiskHash, desiredHash,
+		)
+	}
+	// Drop any stale task so StartContainer can create a fresh one. The
+	// container's snapshot is preserved across the call — only the task
+	// (a transient runtime entity) goes away.
+	if task, taskErr := container.Task(nsCtx, nil); taskErr == nil {
+		if _, deleteTaskErr := task.Delete(nsCtx, containerd.WithProcessKill); deleteTaskErr != nil {
+			r.logger.WarnContext(r.ctx,
+				"failed to delete stale task on existing container, continuing",
+				"id", ctrContainerID, "cell", cellName, "err", deleteTaskErr.Error())
+		}
+	}
+	r.logger.InfoContext(r.ctx,
+		"reusing existing container (spec-hash matched)",
+		"id", ctrContainerID, "cell", cellName, "spec-hash", desiredHash)
+	return true, nil
+}

--- a/internal/controller/runner/spec_hash_guard_test.go
+++ b/internal/controller/runner/spec_hash_guard_test.go
@@ -1,0 +1,288 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.reuseOrRefuseExistingChildContainer against an in-package fake
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	cgroup2 "github.com/containerd/cgroups/v2/cgroup2"
+	apitypes "github.com/containerd/containerd/api/types"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	containerderrdefs "github.com/containerd/errdefs"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// stubLabeledContainer is a minimal containerd.Container implementation used
+// to drive the spec-hash guard tests. Returns a configurable labels map from
+// Labels(); Task() returns containerd's NotFound so the guard's stale-task
+// drop is a no-op.
+type stubLabeledContainer struct {
+	containerd.Container
+
+	id     string
+	labels map[string]string
+}
+
+func (c stubLabeledContainer) ID() string { return c.id }
+
+func (c stubLabeledContainer) Labels(context.Context) (map[string]string, error) {
+	return c.labels, nil
+}
+
+func (c stubLabeledContainer) Task(context.Context, cio.Attach) (containerd.Task, error) {
+	// Mirror the real "no task" path so the guard skips its stale-task
+	// drop without panicking. The exact error wrapping matters: the guard
+	// recovers from any non-nil task error; surface a containerd-style
+	// NotFound to keep the intent obvious to readers.
+	return nil, containerderrdefs.ErrNotFound
+}
+
+// specHashFakeClient is a near-empty ctr.Client whose GetContainer returns a
+// configurable stubLabeledContainer or a NotFound error. Everything else
+// returns the zero value to satisfy the ctr.Client interface.
+type specHashFakeClient struct {
+	getContainerFn func(namespace, id string) (containerd.Container, error)
+}
+
+func (c *specHashFakeClient) Connect() error { return nil }
+func (c *specHashFakeClient) Close() error   { return nil }
+
+func (c *specHashFakeClient) CreateNamespace(string) error             { return nil }
+func (c *specHashFakeClient) DeleteNamespace(string) error             { return nil }
+func (c *specHashFakeClient) ListNamespaces() ([]string, error)        { return nil, nil }
+func (c *specHashFakeClient) GetNamespace(string) (string, error)      { return "", nil }
+func (c *specHashFakeClient) ExistsNamespace(string) (bool, error)     { return false, nil }
+func (c *specHashFakeClient) CleanupNamespaceResources(string, string) error {
+	return nil
+}
+
+func (c *specHashFakeClient) GetCgroupMountpoint() string                                { return "" }
+func (c *specHashFakeClient) GetCurrentCgroupPath() (string, error)                      { return "", nil }
+func (c *specHashFakeClient) CgroupPath(string, string) (string, error)                  { return "", nil }
+func (c *specHashFakeClient) NewCgroup(ctr.CgroupSpec) (*cgroup2.Manager, error)         { return nil, nil } //nolint:nilnil
+func (c *specHashFakeClient) LoadCgroup(string, string) (*cgroup2.Manager, error)        { return nil, nil } //nolint:nilnil
+func (c *specHashFakeClient) DeleteCgroup(string, string) error                          { return nil }
+func (c *specHashFakeClient) EnsureSubtreeControllers(string, string, []string) ([]string, error) {
+	return nil, nil
+}
+func (c *specHashFakeClient) EnableCellSubtreeControllers(string, string, []string) ([]string, error) {
+	return nil, nil
+}
+func (c *specHashFakeClient) EnableCellAllSubtreeControllers(string, string) ([]string, error) {
+	return nil, nil
+}
+func (c *specHashFakeClient) RelocateProcessesToLeaf(string, string, string) error { return nil }
+
+func (c *specHashFakeClient) CreateContainerFromSpec(
+	string, intmodel.ContainerSpec, []ctr.RegistryCredentials, ...ctr.BuildOption,
+) (containerd.Container, error) {
+	return nil, nil //nolint:nilnil
+}
+func (c *specHashFakeClient) CreateContainer(
+	string, ctr.ContainerSpec, []ctr.RegistryCredentials,
+) (containerd.Container, error) {
+	return nil, nil //nolint:nilnil
+}
+
+func (c *specHashFakeClient) GetContainer(namespace, id string) (containerd.Container, error) {
+	if c.getContainerFn != nil {
+		return c.getContainerFn(namespace, id)
+	}
+	return nil, errdefs.ErrContainerNotFound
+}
+
+func (c *specHashFakeClient) ListContainers(string, ...string) ([]containerd.Container, error) {
+	return nil, nil
+}
+func (c *specHashFakeClient) ExistsContainer(string, string) (bool, error) { return false, nil }
+func (c *specHashFakeClient) DeleteContainer(string, string, ctr.ContainerDeleteOptions) error {
+	return nil
+}
+func (c *specHashFakeClient) StartContainer(string, ctr.ContainerSpec, ctr.TaskSpec) (containerd.Task, error) {
+	return nil, nil //nolint:nilnil
+}
+func (c *specHashFakeClient) StopContainer(
+	string, string, ctr.StopContainerOptions,
+) (*containerd.ExitStatus, error) {
+	return nil, nil //nolint:nilnil
+}
+func (c *specHashFakeClient) TaskStatus(string, string) (containerd.Status, error) {
+	return containerd.Status{}, nil
+}
+func (c *specHashFakeClient) TaskMetrics(string, string) (*apitypes.Metric, error) {
+	return nil, nil //nolint:nilnil
+}
+func (c *specHashFakeClient) ContainerProcessUID(string, containerd.Container) (uint32, error) {
+	return 0, nil
+}
+func (c *specHashFakeClient) LoadImage(string, io.Reader) ([]string, error) { return nil, nil }
+func (c *specHashFakeClient) ListImages(string) ([]ctr.ImageInfo, error)    { return nil, nil }
+func (c *specHashFakeClient) GetImage(string, string) (ctr.ImageInfo, error) {
+	return ctr.ImageInfo{}, nil
+}
+func (c *specHashFakeClient) DeleteImage(string, string) error { return nil }
+
+var _ ctr.Client = (*specHashFakeClient)(nil)
+
+func newSpecHashTestExec(fake *specHashFakeClient) *Exec {
+	return &Exec{
+		ctx:       context.Background(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctrClient: fake,
+	}
+}
+
+// TestReuseOrRefuseExistingChildContainer_AbsentRecordFallsThrough locks the
+// fresh-create path: when GetContainer returns ErrContainerNotFound the
+// helper reports reuse=false with nil error so the caller proceeds to
+// CreateContainerFromSpec. Issue #867.
+func TestReuseOrRefuseExistingChildContainer_AbsentRecordFallsThrough(t *testing.T) {
+	fake := &specHashFakeClient{
+		getContainerFn: func(string, string) (containerd.Container, error) {
+			return nil, errdefs.ErrContainerNotFound
+		},
+	}
+	r := newSpecHashTestExec(fake)
+
+	reuse, err := r.reuseOrRefuseExistingChildContainer(
+		"ns", "id", "cell",
+		intmodel.ContainerSpec{Image: "alpine", Command: "sleep"},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error on absent record: %v", err)
+	}
+	if reuse {
+		t.Errorf("absent record must return reuse=false so caller takes fresh-create path; got reuse=true")
+	}
+}
+
+// TestReuseOrRefuseExistingChildContainer_MatchingHashReuses locks the happy
+// reuse path: an existing record whose label matches the freshly-computed
+// hash returns reuse=true and the caller's create call is skipped.
+func TestReuseOrRefuseExistingChildContainer_MatchingHashReuses(t *testing.T) {
+	spec := intmodel.ContainerSpec{Image: "alpine", Command: "sleep", Args: []string{"infinity"}}
+	matchingHash := ComputeContainerSpecHash(spec)
+	fake := &specHashFakeClient{
+		getContainerFn: func(_, id string) (containerd.Container, error) {
+			return stubLabeledContainer{
+				id:     id,
+				labels: map[string]string{SpecHashLabelKey: matchingHash},
+			}, nil
+		},
+	}
+	r := newSpecHashTestExec(fake)
+
+	reuse, err := r.reuseOrRefuseExistingChildContainer("ns", "id", "cell", spec)
+	if err != nil {
+		t.Fatalf("matching-hash reuse must not error; got %v", err)
+	}
+	if !reuse {
+		t.Errorf("matching spec-hash must return reuse=true (overlay preserved); got reuse=false")
+	}
+}
+
+// TestReuseOrRefuseExistingChildContainer_LegacyRecordReuses locks the
+// backward-compatibility branch: a record with no SpecHashLabelKey label
+// (created by pre-#867 kukeon) is treated as a match so the operator's first
+// restart after the upgrade does not refuse with ErrCellSpecHashDrift on a
+// healthy cell.
+func TestReuseOrRefuseExistingChildContainer_LegacyRecordReuses(t *testing.T) {
+	fake := &specHashFakeClient{
+		getContainerFn: func(_, id string) (containerd.Container, error) {
+			return stubLabeledContainer{
+				id:     id,
+				labels: map[string]string{"kukeon.io/cell": "demo"}, // unrelated label
+			}, nil
+		},
+	}
+	r := newSpecHashTestExec(fake)
+
+	reuse, err := r.reuseOrRefuseExistingChildContainer(
+		"ns", "id", "cell",
+		intmodel.ContainerSpec{Image: "alpine"},
+	)
+	if err != nil {
+		t.Fatalf("legacy record must not error; got %v", err)
+	}
+	if !reuse {
+		t.Errorf("legacy record (no kukeon.io/spec-hash label) must be treated as match (safe default for first post-upgrade restart); got reuse=false")
+	}
+}
+
+// TestReuseOrRefuseExistingChildContainer_DivergedHashRefuses is the
+// regression guard for AC #6 of issue #867: a containerd record whose
+// SpecHashLabelKey value disagrees with the freshly-computed hash must
+// refuse with ErrCellSpecHashDrift instead of silently resuming a stale
+// snapshot. The wrapped error must name both hashes and point at
+// `kuke apply -f` so the operator has an actionable next step.
+func TestReuseOrRefuseExistingChildContainer_DivergedHashRefuses(t *testing.T) {
+	desired := intmodel.ContainerSpec{Image: "alpine", Command: "sleep"}
+	staleHash := "deadbeef" // intentionally not the hash of desired
+	fake := &specHashFakeClient{
+		getContainerFn: func(_, id string) (containerd.Container, error) {
+			return stubLabeledContainer{
+				id:     id,
+				labels: map[string]string{SpecHashLabelKey: staleHash},
+			}, nil
+		},
+	}
+	r := newSpecHashTestExec(fake)
+
+	reuse, err := r.reuseOrRefuseExistingChildContainer("ns", "cell_stack_demo_child", "demo", desired)
+	if err == nil {
+		t.Fatalf("diverged spec-hash must error; got reuse=%v err=nil", reuse)
+	}
+	if !errors.Is(err, errdefs.ErrCellSpecHashDrift) {
+		t.Errorf("diverged hash error must wrap ErrCellSpecHashDrift so callers can branch on it; got %v", err)
+	}
+	if reuse {
+		t.Errorf("diverged hash must return reuse=false (refuse, do not silently recreate); got reuse=true")
+	}
+	// The operator-facing message must carry enough context to act on:
+	// the diverged hash pair + the `kuke apply -f` next step.
+	msg := err.Error()
+	if !contains(msg, staleHash) || !contains(msg, ComputeContainerSpecHash(desired)) {
+		t.Errorf("error message must name both hashes; got %q", msg)
+	}
+	if !contains(msg, "kuke apply -f") {
+		t.Errorf("error message must point at `kuke apply -f` as the reconcile next step; got %q", msg)
+	}
+}
+
+// contains is a thin substring helper used by the diverged-hash assertion.
+// Keeps the test self-contained without pulling in the `strings` package.
+func contains(haystack, needle string) bool {
+	if needle == "" {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/runner/spec_hash_test.go
+++ b/internal/controller/runner/spec_hash_test.go
@@ -1,0 +1,236 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner_test
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/controller/runner"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// ComputeContainerSpecHash is re-exported here as a short local alias so the
+// table-driven tests below stay readable. The hash itself lives in
+// internal/controller/runner/spec_hash.go.
+var ComputeContainerSpecHash = runner.ComputeContainerSpecHash
+
+// TestComputeContainerSpecHash_Deterministic locks that the hash function is
+// pure and stable across equal inputs. A hash that drifts across invocations
+// would surface as spurious StartCell refusals on every restart.
+func TestComputeContainerSpecHash_Deterministic(t *testing.T) {
+	spec := intmodel.ContainerSpec{
+		Image:   "docker.io/library/alpine:latest",
+		Command: "sleep",
+		Args:    []string{"infinity"},
+	}
+	got1 := ComputeContainerSpecHash(spec)
+	got2 := ComputeContainerSpecHash(spec)
+	if got1 != got2 {
+		t.Fatalf("ComputeContainerSpecHash is not deterministic: %q != %q", got1, got2)
+	}
+	if len(got1) != 64 {
+		t.Errorf("ComputeContainerSpecHash should return a 64-char hex SHA-256; got len=%d (%q)", len(got1), got1)
+	}
+}
+
+// TestComputeContainerSpecHash_NilEmptyArgsEqual locks that nil and zero-len
+// Args yield the same hash. containerd treats both as "no args"; a
+// nil-vs-empty hash divergence would cause a healthy restart to be misread as
+// drift on a CellSpec whose YAML omitted `args:` but whose actual spec was
+// `[]`.
+func TestComputeContainerSpecHash_NilEmptyArgsEqual(t *testing.T) {
+	specNil := intmodel.ContainerSpec{
+		Image:   "alpine",
+		Command: "sleep",
+		Args:    nil,
+	}
+	specEmpty := intmodel.ContainerSpec{
+		Image:   "alpine",
+		Command: "sleep",
+		Args:    []string{},
+	}
+	if ComputeContainerSpecHash(specNil) != ComputeContainerSpecHash(specEmpty) {
+		t.Errorf("nil and empty Args must hash identically; nil=%q empty=%q",
+			ComputeContainerSpecHash(specNil), ComputeContainerSpecHash(specEmpty))
+	}
+}
+
+// TestComputeContainerSpecHash_ImageCmdArgsChangeHash locks that each
+// breaking-domain field independently changes the hash. A field accidentally
+// dropped from containerSpecHashPayload would silently let a drifted CellSpec
+// pass the StartCell guard.
+func TestComputeContainerSpecHash_ImageCmdArgsChangeHash(t *testing.T) {
+	base := intmodel.ContainerSpec{
+		Image:   "alpine:1.0",
+		Command: "sleep",
+		Args:    []string{"60"},
+	}
+	baseHash := ComputeContainerSpecHash(base)
+
+	cases := []struct {
+		name string
+		mut  func(s *intmodel.ContainerSpec)
+	}{
+		{"image", func(s *intmodel.ContainerSpec) { s.Image = "alpine:2.0" }},
+		{"command", func(s *intmodel.ContainerSpec) { s.Command = "echo" }},
+		{"args", func(s *intmodel.ContainerSpec) { s.Args = []string{"120"} }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mut := base
+			tc.mut(&mut)
+			if ComputeContainerSpecHash(mut) == baseHash {
+				t.Errorf("changing %s must change the spec hash; base and mutated produced %q", tc.name, baseHash)
+			}
+		})
+	}
+}
+
+// TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash locks that
+// fields `apply.DiffCell` classifies as Compatible (env, ports, volumes,
+// privileged, user, capabilities, resources, ...) are *not* part of the hash.
+// Hashing them would force a recreate-or-refuse on every `kuke apply -f` that
+// only tweaked a compatible field, defeating the in-place UpdateCell path the
+// apply layer already exercises for those fields.
+func TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash(t *testing.T) {
+	base := intmodel.ContainerSpec{
+		Image:   "alpine",
+		Command: "sleep",
+		Args:    []string{"infinity"},
+	}
+	baseHash := ComputeContainerSpecHash(base)
+
+	cases := []struct {
+		name string
+		mut  func(s *intmodel.ContainerSpec)
+	}{
+		{"env", func(s *intmodel.ContainerSpec) { s.Env = []string{"FOO=bar"} }},
+		{"ports", func(s *intmodel.ContainerSpec) { s.Ports = []string{"8080:80"} }},
+		{"volumes", func(s *intmodel.ContainerSpec) {
+			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
+		}},
+		{"privileged", func(s *intmodel.ContainerSpec) { s.Privileged = true }},
+		{"user", func(s *intmodel.ContainerSpec) { s.User = "nobody" }},
+		{"readonly", func(s *intmodel.ContainerSpec) { s.ReadOnlyRootFilesystem = true }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mut := base
+			tc.mut(&mut)
+			if ComputeContainerSpecHash(mut) != baseHash {
+				t.Errorf("changing compatible field %s must NOT change the spec hash (apply.DiffCell handles it in-place); base=%q mutated=%q",
+					tc.name, baseHash, ComputeContainerSpecHash(mut))
+			}
+		})
+	}
+}
+
+// TestSpecHashDomainPinsToDiffCellBreakingFields is the regression guard that
+// keeps containerSpecHashPayload's field set in lock-step with
+// `apply.DiffCell`'s "requires containerd recreate" classification. If a
+// future change widens the apply-layer breaking domain (e.g., classifies
+// SecurityOpts as Breaking-on-root) without also extending
+// containerSpecHashPayload, this test fails: the apply layer would force a
+// recreate while StartCell silently resumes a stale snapshot.
+//
+// The shape: build a pair of cells that differ only in field X. Feed them
+// through DiffCell. Whenever DiffCell reports a Breaking change for the root
+// container, ComputeContainerSpecHash on the two root specs must differ. If
+// DiffCell reports Compatible or no change, ComputeContainerSpecHash must
+// match (the apply layer handles it in place, so the hash must not force a
+// refuse). Mirrors `apply.DiffCell`'s root-side `rootContainerSpecChanged`
+// branch in `internal/controller/apply/diff.go`.
+func TestSpecHashDomainPinsToDiffCellBreakingFields(t *testing.T) {
+	makeCell := func(root intmodel.ContainerSpec) intmodel.Cell {
+		root.Root = true
+		root.ID = "root"
+		return intmodel.Cell{
+			Metadata: intmodel.CellMetadata{Name: "c"},
+			Spec: intmodel.CellSpec{
+				ID:         "c",
+				RealmName:  "r",
+				SpaceName:  "s",
+				StackName:  "st",
+				Containers: []intmodel.ContainerSpec{root},
+			},
+		}
+	}
+
+	baseRoot := intmodel.ContainerSpec{
+		Image:   "alpine:1.0",
+		Command: "sleep",
+		Args:    []string{"60"},
+	}
+
+	cases := []struct {
+		name             string
+		mut              func(s *intmodel.ContainerSpec)
+		expectRootBreaks bool // DiffCell's classification for this field on the root container
+	}{
+		// Breaking-on-root domain — must change the hash.
+		{"image", func(s *intmodel.ContainerSpec) { s.Image = "alpine:2.0" }, true},
+		{"command", func(s *intmodel.ContainerSpec) { s.Command = "echo" }, true},
+		{"args", func(s *intmodel.ContainerSpec) { s.Args = []string{"120"} }, true},
+		// Compatible domain — must NOT change the hash.
+		{"env", func(s *intmodel.ContainerSpec) { s.Env = []string{"FOO=bar"} }, false},
+		{"ports", func(s *intmodel.ContainerSpec) { s.Ports = []string{"8080:80"} }, false},
+		{"volumes", func(s *intmodel.ContainerSpec) {
+			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
+		}, false},
+		{"privileged", func(s *intmodel.ContainerSpec) { s.Privileged = true }, false},
+		{"user", func(s *intmodel.ContainerSpec) { s.User = "nobody" }, false},
+		{"readOnlyRootFilesystem", func(s *intmodel.ContainerSpec) { s.ReadOnlyRootFilesystem = true }, false},
+		{"securityOpts", func(s *intmodel.ContainerSpec) { s.SecurityOpts = []string{"no-new-privileges"} }, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			desiredRoot := baseRoot
+			tc.mut(&desiredRoot)
+
+			desiredCell := makeCell(desiredRoot)
+			actualCell := makeCell(baseRoot)
+
+			diff := apply.DiffCell(desiredCell, actualCell)
+
+			// Did DiffCell flag the root container as breaking?
+			gotRootBreaks := diff.RootContainerChanged && diff.ChangeType == apply.ChangeTypeBreaking
+			if gotRootBreaks != tc.expectRootBreaks {
+				t.Fatalf("DiffCell classification drift on field %q: gotRootBreaks=%v want=%v (diff=%+v)",
+					tc.name, gotRootBreaks, tc.expectRootBreaks, diff)
+			}
+
+			hashBefore := ComputeContainerSpecHash(baseRoot)
+			hashAfter := ComputeContainerSpecHash(desiredRoot)
+
+			if tc.expectRootBreaks {
+				if hashBefore == hashAfter {
+					t.Errorf("field %q is Breaking-on-root in DiffCell but ComputeContainerSpecHash is unchanged — apply.DiffCell would force a recreate while StartCell silently resumes a stale snapshot; before=%q after=%q",
+						tc.name, hashBefore, hashAfter)
+				}
+			} else {
+				if hashBefore != hashAfter {
+					t.Errorf("field %q is Compatible in DiffCell but ComputeContainerSpecHash changed — StartCell would refuse to resume a record the apply layer would have updated in place; before=%q after=%q",
+						tc.name, hashBefore, hashAfter)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -608,10 +608,33 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 		return internalCell, nil
 	}
 
+	// Resolve rootContainerSpec early so we can compute the spec-hash and
+	// decide whether to reuse the existing containerd record (overlay
+	// preserved) or create a fresh one — issue #867.
+	rootContainerSpec, err := r.ensureCellRootContainerSpec(internalCell)
+	if err != nil {
+		return intmodel.Cell{}, fmt.Errorf("failed to get root container spec: %w", err)
+	}
+	desiredRootSpecHash := ComputeContainerSpecHash(rootContainerSpec)
+
 	// Past the idempotent-skip path: any subsequent error means we crashed
 	// mid-provisioning. Arm the defer above so the cell flips to Failed and
 	// any siblings already started get killed (issue #407).
 	provisionStarted = true
+
+	// reuseExistingRoot, when true, instructs the create block further down
+	// to skip ctr.BuildRootContainerSpec + CreateContainer and start a fresh
+	// task on the existing containerd record — preserving the snapshot
+	// across the stop/start transition. Issue #867.
+	var reuseExistingRoot bool
+
+	// fields is the per-call log-field accumulator threaded through the
+	// post-create CNI / non-root recreate blocks below. Pre-declared at
+	// function scope so the reuse-existing-root branch (which skips the
+	// originally-unconditional `fields := appendCellLogFields(...)` site
+	// at the CreateContainer log line) does not leave downstream uses
+	// undefined. Issue #867.
+	var fields []any
 
 	// Check if container exists and clean it up
 	container, err := r.ctrClient.GetContainer(namespace, containerID)
@@ -649,66 +672,57 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 			)
 		}
 	} else {
-		// Container exists: release its CNI/IPAM reservation, then delete it.
-		// The root is recreated below under the same deterministic containerd
-		// ID and re-attached via CNI ADD; without the release-before-delete
-		// ordering here, host-local IPAM rejects that re-ADD as a duplicate
-		// allocation (issue #630). releaseCNI must run while the task's netns
-		// is still valid, so it is sequenced before the task delete; purgeCNI
-		// scrubs the residual allocation file afterward as a safety net.
-		// Resolve the purge's network name deterministically from realm+space so
-		// the scrub runs even when space metadata is gone or corrupt (issue #685),
-		// matching the stop/kill/delete teardown paths.
+		// Container exists. Compare the `kukeon.io/spec-hash` label on the
+		// containerd record against the freshly-computed hash. Match (or
+		// legacy record with no label) → reuse the snapshot; mismatch →
+		// refuse with an actionable error pointing the operator at
+		// `kuke apply -f`. The supported mutation surface (`kuke apply -f`
+		// → RecreateCell / UpdateCell) re-stamps the label inside the same
+		// transaction that rewrites containerd state, so steady-state
+		// restarts always match and the snapshot survives stop/start.
+		// Issue #867 ACs #1, #4, #5, #6.
+		nsCtx := namespaces.WithNamespace(r.ctx, namespace)
+		existingLabels, labelErr := container.Labels(nsCtx)
+		if labelErr != nil {
+			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+			fields = append(fields, "space", spaceID, "realm", realmID, "err", labelErr.Error())
+			r.logger.WarnContext(r.ctx,
+				"failed to read existing root container labels, treating as match for reuse",
+				fields...)
+		}
+		onDiskRootHash := existingLabels[SpecHashLabelKey]
+		if onDiskRootHash != "" && onDiskRootHash != desiredRootSpecHash {
+			return intmodel.Cell{}, fmt.Errorf(
+				"%w: cell %q: containerd record carries spec-hash %q but cell spec hashes to %q — "+
+					"run `kuke apply -f` to reconcile",
+				internalerrdefs.ErrCellSpecHashDrift, cellName, onDiskRootHash, desiredRootSpecHash,
+			)
+		}
+		reuseExistingRoot = true
+		// Drop any stale task on the existing record. Reaching this branch
+		// implies the idempotent-skip path above already determined the
+		// task is not Running; a leftover Created/Stopped task would
+		// otherwise refuse the StartContainer below.
+		if task, taskErr := container.Task(nsCtx, nil); taskErr == nil {
+			if _, deleteTaskErr := task.Delete(nsCtx, containerd.WithProcessKill); deleteTaskErr != nil {
+				fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+				fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", deleteTaskErr))
+				r.logger.WarnContext(r.ctx, "failed to delete stale task on existing root container, continuing", fields...)
+			}
+		}
+		// Defense-in-depth CNI scrub. stop.go/kill.go already release the
+		// IPAM reservation pre-snapshot-preservation; a daemon crash
+		// mid-stop could leave a stale host-local file keyed to this
+		// deterministic root containerd ID. Scrub it so the CNI ADD below
+		// isn't rejected as a duplicate allocation (issue #630 / #649
+		// mirror for the reuse path).
 		networkName := r.buildRootCNINetworkName(realmID, spaceID)
-		_ = teardownRootContainerCNI(
-			func() {
-				r.detachRootContainerFromNetwork(
-					containerID, cniConfigPath, namespace, cellID, cellName, spaceID, realmID,
-				)
-			},
-			func() error {
-				// Delete the task (if any) then the container to remove stale spec.
-				nsCtx := namespaces.WithNamespace(r.ctx, namespace)
-				if task, taskErr := container.Task(nsCtx, nil); taskErr == nil {
-					if _, deleteTaskErr := task.Delete(nsCtx, containerd.WithProcessKill); deleteTaskErr != nil {
-						fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-						fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", deleteTaskErr))
-						r.logger.WarnContext(r.ctx, "failed to delete existing task, continuing", fields...)
-					}
-				}
-
-				delErr := r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
-					SnapshotCleanup: true,
-				})
-				switch {
-				case delErr == nil:
-					fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-					fields = append(fields, "space", spaceID, "realm", realmID)
-					r.logger.InfoContext(r.ctx, "deleted existing root container for recreation", fields...)
-				case errors.Is(delErr, internalerrdefs.ErrContainerNotFound):
-					// Might have been deleted between check and delete.
-					fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-					fields = append(fields, "space", spaceID, "realm", realmID)
-					r.logger.DebugContext(r.ctx, "root container already deleted, will create fresh", fields...)
-				default:
-					fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-					fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", delErr))
-					r.logger.WarnContext(r.ctx, "failed to delete existing container, continuing", fields...)
-				}
-				return delErr
-			},
-			func() {
-				if networkName != "" {
-					_ = r.purgeCNIForContainer(containerID, "", networkName)
-				}
-			},
-		)
-	}
-
-	// Recreate root container fresh
-	rootContainerSpec, err := r.ensureCellRootContainerSpec(internalCell)
-	if err != nil {
-		return intmodel.Cell{}, fmt.Errorf("failed to get root container spec: %w", err)
+		if networkName != "" {
+			_ = r.purgeCNIForContainer(containerID, "", networkName)
+		}
+		reuseFields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+		reuseFields = append(reuseFields, "space", spaceID, "realm", realmID, "spec-hash", desiredRootSpecHash)
+		r.logger.InfoContext(r.ctx, "reusing existing root container (spec-hash matched)", reuseFields...)
 	}
 
 	// CellCgroupPath: runtime-only injection — see setCellCgroupPath docs.
@@ -729,38 +743,46 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 	}
 	r.stampContainerRecreateRuntimeFields(&rootContainerSpec, &internalCell)
 
-	rootLabels := buildRootContainerLabels(internalCell)
-	ctrContainerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels, r.daemonDefaultBuildOpts()...)
+	// Build the OCI spec + CreateContainer only when we're not reusing an
+	// existing record. The reuse path keeps the on-disk OCI spec — its
+	// bind-mounts still point at the cell's /etc files this routine just
+	// re-rendered, and any runtime-only fields (CellCgroupPath, etc.) are
+	// already baked into the existing record from the prior create. Issue
+	// #867 AC #4.
+	if !reuseExistingRoot {
+		rootLabels := stampSpecHashOnLabels(buildRootContainerLabels(internalCell), rootContainerSpec)
+		ctrContainerSpec := ctr.BuildRootContainerSpec(rootContainerSpec, rootLabels, r.daemonDefaultBuildOpts()...)
 
-	_, err = r.ctrClient.CreateContainer(namespace, ctrContainerSpec, creds)
-	if err != nil {
+		_, err = r.ctrClient.CreateContainer(namespace, ctrContainerSpec, creds)
+		if err != nil {
+			fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+			fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
+			r.logger.ErrorContext(
+				r.ctx,
+				"failed to create root container",
+				fields...,
+			)
+			return intmodel.Cell{}, fmt.Errorf("failed to create root container %s: %w", containerID, err)
+		}
+
 		fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-		fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
-		r.logger.ErrorContext(
+		fields = append(fields, "space", spaceID, "realm", realmID)
+		r.logger.InfoContext(
 			r.ctx,
-			"failed to create root container",
+			"created root container",
 			fields...,
 		)
-		return intmodel.Cell{}, fmt.Errorf("failed to create root container %s: %w", containerID, err)
 	}
-
-	fields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-	fields = append(fields, "space", spaceID, "realm", realmID)
-	r.logger.InfoContext(
-		r.ctx,
-		"created root container",
-		fields...,
-	)
 
 	// Start root container
 	rootTask, err := r.ctrClient.StartContainer(namespace, ctr.ContainerSpec{ID: containerID}, ctr.TaskSpec{})
 	if err != nil {
-		fields = appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-		fields = append(fields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
+		startErrFields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
+		startErrFields = append(startErrFields, "space", spaceID, "realm", realmID, "err", fmt.Sprintf("%v", err))
 		r.logger.ErrorContext(
 			r.ctx,
 			"failed to start root container",
-			fields...,
+			startErrFields...,
 		)
 		return intmodel.Cell{}, fmt.Errorf("failed to start root container %s: %w", containerID, err)
 	}
@@ -1012,30 +1034,17 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 			startFields...,
 		)
 
-		// Delete container if it exists (idempotent - DeleteContainer handles non-existent containers gracefully)
-		// This ensures any stale container specs and tasks are cleaned up before recreation
-		err = r.ctrClient.DeleteContainer(namespace, ctrContainerID, ctr.ContainerDeleteOptions{
-			SnapshotCleanup: true,
-		})
-		if err != nil {
-			// Log warning but continue - DeleteContainer is idempotent, so errors here are unexpected
-			fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
-			fields = append(
-				fields,
-				"space",
-				spaceID,
-				"realm",
-				realmID,
-				"containerName",
-				containerSpec.ID,
-				"err",
-				fmt.Sprintf("%v", err),
-			)
-			r.logger.WarnContext(
-				r.ctx,
-				"failed to delete existing container, continuing with recreation",
-				fields...,
-			)
+		// Issue #867: same spec-hash guard as the root container above. If
+		// the existing record's `kukeon.io/spec-hash` label matches the
+		// freshly-computed hash, drop any stale task and reuse the snapshot;
+		// if it diverges, refuse with the operator-actionable
+		// ErrCellSpecHashDrift; if the record is absent, fall through to
+		// the create path.
+		reuseExistingChild, reuseErr := r.reuseOrRefuseExistingChildContainer(
+			namespace, ctrContainerID, cellName, containerSpec,
+		)
+		if reuseErr != nil {
+			return intmodel.Cell{}, reuseErr
 		}
 
 		// CellCgroupPath: runtime-only injection — see the comment at the
@@ -1066,50 +1075,60 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 				attachErr,
 			)
 		}
-		buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
-		// `kuke run --env` runtime-env merge (issue #834). Same shape as the
-		// CreateCell-side merge in provision.go: returns containerSpec
-		// unchanged for non-attachable containers or when RuntimeEnv is
-		// empty, otherwise emits a copy whose Env carries the override-on-
-		// key merge. internalCell.Spec.RuntimeEnv is repopulated above (after
-		// r.GetCell) from the inbound RPC cell so this path sees the
-		// per-invocation env even after the disk read stripped it.
-		ociSpec := mergeRuntimeEnvForContainer(containerSpec, attachableID, internalCell.Spec.RuntimeEnv)
-		_, err = r.ctrClient.CreateContainerFromSpec(namespace, ociSpec, creds, buildOpts...)
-		if err != nil {
+		if !reuseExistingChild {
+			buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
+			buildOpts = append(buildOpts, ctr.WithExtraLabels(map[string]string{
+				SpecHashLabelKey: ComputeContainerSpecHash(containerSpec),
+			}))
+			// `kuke run --env` runtime-env merge (issue #834). Same shape as the
+			// CreateCell-side merge in provision.go: returns containerSpec
+			// unchanged for non-attachable containers or when RuntimeEnv is
+			// empty, otherwise emits a copy whose Env carries the override-on-
+			// key merge. internalCell.Spec.RuntimeEnv is repopulated above (after
+			// r.GetCell) from the inbound RPC cell so this path sees the
+			// per-invocation env even after the disk read stripped it.
+			ociSpec := mergeRuntimeEnvForContainer(containerSpec, attachableID, internalCell.Spec.RuntimeEnv)
+			_, err = r.ctrClient.CreateContainerFromSpec(namespace, ociSpec, creds, buildOpts...)
+			if err != nil {
+				fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
+				fields = append(
+					fields,
+					"space",
+					spaceID,
+					"realm",
+					realmID,
+					"containerName",
+					containerSpec.ID,
+					"err",
+					fmt.Sprintf("%v", err),
+				)
+				r.logger.ErrorContext(
+					r.ctx,
+					"failed to create container",
+					fields...,
+				)
+				return intmodel.Cell{}, fmt.Errorf("failed to create container %s: %w", ctrContainerID, err)
+			}
+
 			fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
-			fields = append(
-				fields,
-				"space",
-				spaceID,
-				"realm",
-				realmID,
-				"containerName",
-				containerSpec.ID,
-				"err",
-				fmt.Sprintf("%v", err),
-			)
-			r.logger.ErrorContext(
+			fields = append(fields, "space", spaceID, "realm", realmID, "containerName", containerSpec.ID)
+			r.logger.InfoContext(
 				r.ctx,
-				"failed to create container",
+				"created container",
 				fields...,
 			)
-			return intmodel.Cell{}, fmt.Errorf("failed to create container %s: %w", ctrContainerID, err)
-		}
 
-		fields = appendCellLogFields([]any{"id", ctrContainerID}, cellID, cellName)
-		fields = append(fields, "space", spaceID, "realm", realmID, "containerName", containerSpec.ID)
-		r.logger.InfoContext(
-			r.ctx,
-			"created container",
-			fields...,
-		)
-
-		if err = r.attachablePostCreateChown(namespace, containerSpec); err != nil {
-			return intmodel.Cell{}, fmt.Errorf(
-				"failed to chown attachable tty dir for %s: %w", ctrContainerID, err,
-			)
+			if err = r.attachablePostCreateChown(namespace, containerSpec); err != nil {
+				return intmodel.Cell{}, fmt.Errorf(
+					"failed to chown attachable tty dir for %s: %w", ctrContainerID, err,
+				)
+			}
 		}
+		// On the reuse path the BuildOptions attachOpts returned aren't
+		// applied (the existing OCI spec already carries the attachable
+		// wrapping); the call is still made above for its side effects —
+		// kuketty binary staging, per-container metadata render, ttyDir
+		// chmod — which must run before the task starts.
 
 		// Use container name with UUID for containerd operations
 		specWithNamespaces := ctr.JoinContainerNamespaces(
@@ -1319,30 +1338,15 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 		UTS: fmt.Sprintf("/proc/%d/ns/uts", rootPID),
 	}
 
-	// Delete container if it exists (idempotent - DeleteContainer handles non-existent containers gracefully)
-	// This ensures any stale container specs and tasks are cleaned up before recreation
-	err = r.ctrClient.DeleteContainer(namespace, containerdID, ctr.ContainerDeleteOptions{
-		SnapshotCleanup: true,
-	})
-	if err != nil {
-		// Log warning but continue - DeleteContainer is idempotent, so errors here are unexpected
-		fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-		fields = append(
-			fields,
-			"space",
-			spaceName,
-			"realm",
-			realmName,
-			"containerName",
-			containerID,
-			"err",
-			fmt.Sprintf("%v", err),
-		)
-		r.logger.WarnContext(
-			r.ctx,
-			"failed to delete existing container, continuing with recreation",
-			fields...,
-		)
+	// Issue #867: spec-hash guard instead of an unconditional destructive
+	// recreate. Match → reuse the snapshot, mismatch → refuse with
+	// ErrCellSpecHashDrift pointing the operator at `kuke apply -f`,
+	// absent → fall through to create.
+	reuseExistingChild, reuseErr := r.reuseOrRefuseExistingChildContainer(
+		namespace, containerdID, cellName, *foundContainerSpec,
+	)
+	if reuseErr != nil {
+		return intmodel.Cell{}, reuseErr
 	}
 
 	// CellCgroupPath: runtime-only injection — fill from cell.Status.CgroupPath
@@ -1379,42 +1383,52 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	if attachErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to prepare attachable container %s: %w", containerID, attachErr)
 	}
-	buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
-	_, err = r.ctrClient.CreateContainerFromSpec(namespace, *foundContainerSpec, creds, buildOpts...)
-	if err != nil {
+	if !reuseExistingChild {
+		buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
+		buildOpts = append(buildOpts, ctr.WithExtraLabels(map[string]string{
+			SpecHashLabelKey: ComputeContainerSpecHash(*foundContainerSpec),
+		}))
+		_, err = r.ctrClient.CreateContainerFromSpec(namespace, *foundContainerSpec, creds, buildOpts...)
+		if err != nil {
+			fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
+			fields = append(
+				fields,
+				"space",
+				spaceName,
+				"realm",
+				realmName,
+				"containerName",
+				containerID,
+				"err",
+				fmt.Sprintf("%v", err),
+			)
+			r.logger.ErrorContext(
+				r.ctx,
+				"failed to create container",
+				fields...,
+			)
+			return intmodel.Cell{}, fmt.Errorf("failed to create container %s: %w", containerID, err)
+		}
+
 		fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-		fields = append(
-			fields,
-			"space",
-			spaceName,
-			"realm",
-			realmName,
-			"containerName",
-			containerID,
-			"err",
-			fmt.Sprintf("%v", err),
-		)
-		r.logger.ErrorContext(
+		fields = append(fields, "space", spaceName, "realm", realmName, "containerName", containerID)
+		r.logger.InfoContext(
 			r.ctx,
-			"failed to create container",
+			"created container",
 			fields...,
 		)
-		return intmodel.Cell{}, fmt.Errorf("failed to create container %s: %w", containerID, err)
-	}
 
-	fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-	fields = append(fields, "space", spaceName, "realm", realmName, "containerName", containerID)
-	r.logger.InfoContext(
-		r.ctx,
-		"created container",
-		fields...,
-	)
-
-	if err = r.attachablePostCreateChown(namespace, *foundContainerSpec); err != nil {
-		return intmodel.Cell{}, fmt.Errorf(
-			"failed to chown attachable tty dir for %s: %w", containerdID, err,
-		)
+		if err = r.attachablePostCreateChown(namespace, *foundContainerSpec); err != nil {
+			return intmodel.Cell{}, fmt.Errorf(
+				"failed to chown attachable tty dir for %s: %w", containerdID, err,
+			)
+		}
 	}
+	// On the reuse path the BuildOptions attachOpts returned aren't applied
+	// (the existing OCI spec already carries the attachable wrapping); the
+	// call above is still made for its side effects (kuketty binary staging,
+	// per-container metadata render, ttyDir chmod) which must run before the
+	// task starts.
 
 	// Start container with namespace paths
 	specWithNamespaces := ctr.JoinContainerNamespaces(
@@ -1424,9 +1438,9 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 
 	_, err = r.ctrClient.StartContainer(namespace, specWithNamespaces, r.containerLogTaskSpec(*foundContainerSpec))
 	if err != nil {
-		fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-		fields = append(
-			fields,
+		startErrFields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
+		startErrFields = append(
+			startErrFields,
 			"space",
 			spaceName,
 			"realm",
@@ -1439,17 +1453,17 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 		r.logger.ErrorContext(
 			r.ctx,
 			"failed to start container",
-			fields...,
+			startErrFields...,
 		)
 		return intmodel.Cell{}, fmt.Errorf("failed to start container %s: %w", containerID, err)
 	}
 
-	fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-	fields = append(fields, "space", spaceName, "realm", realmName, "containerName", containerID)
+	startedFields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
+	startedFields = append(startedFields, "space", spaceName, "realm", realmName, "containerName", containerID)
 	r.logger.InfoContext(
 		r.ctx,
 		"started container",
-		fields...,
+		startedFields...,
 	)
 
 	// Get the cell again to ensure we have the latest state

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -175,28 +175,12 @@ func (r *Exec) stopCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 			fields...,
 		)
 
-		// Delete container after stopping
-		err = r.ctrClient.DeleteContainer(namespace, containerID, ctr.ContainerDeleteOptions{
-			SnapshotCleanup: true,
-		})
-		if err != nil {
-			// Log warning but don't fail - container might already be deleted
-			fields = appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-			fields = append(fields, "space", spaceName, "realm", realmName, "err", fmt.Sprintf("%v", err))
-			r.logger.WarnContext(
-				r.ctx,
-				"failed to delete container, continuing",
-				fields...,
-			)
-		} else {
-			fields = appendCellLogFields([]any{"id", containerID}, cellID, cellName)
-			fields = append(fields, "space", spaceName, "realm", realmName)
-			r.logger.InfoContext(
-				r.ctx,
-				"deleted container",
-				fields...,
-			)
-		}
+		// Issue #867: leave the containerd container record (and snapshot)
+		// in place. The documented stop/kill/delete split (docs/cli-use-
+		// cases.md) has stop tear down the task only; delete owns the
+		// record + snapshot teardown. The old DeleteContainer{Snapshot
+		// Cleanup: true} call here violated that split and silently broke
+		// the `--reuse` overlay-preservation contract from #835 / #848.
 	}
 
 	// Stop root container last (after all workload containers are stopped)
@@ -246,28 +230,10 @@ func (r *Exec) stopCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 		)
 	}
 
-	// Delete root container after stopping
-	err = r.ctrClient.DeleteContainer(namespace, rootContainerID, ctr.ContainerDeleteOptions{
-		SnapshotCleanup: true,
-	})
-	if err != nil {
-		// Log warning but don't fail - container might already be deleted
-		fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
-		fields = append(fields, "space", spaceName, "realm", realmName, "err", fmt.Sprintf("%v", err))
-		r.logger.WarnContext(
-			r.ctx,
-			"failed to delete root container, continuing",
-			fields...,
-		)
-	} else {
-		fields := appendCellLogFields([]any{"id", rootContainerID}, cellID, cellName)
-		fields = append(fields, "space", spaceName, "realm", realmName)
-		r.logger.InfoContext(
-			r.ctx,
-			"deleted root container",
-			fields...,
-		)
-	}
+	// Issue #867: leave the root container record + snapshot in place — see
+	// the matching comment in the workload-container loop above. CNI cleanup
+	// below still runs so the IPAM reservation is released; without that, the
+	// next StartCell's CNI ADD would be rejected as a duplicate allocation.
 
 	// Always run comprehensive CNI cleanup after container deletion as a safety net
 	// This ensures IPAM allocations are cleaned up even if CNI DEL succeeded or failed
@@ -460,38 +426,9 @@ func (r *Exec) StopContainer(cell intmodel.Cell, containerID string) error {
 		fields...,
 	)
 
-	// Delete container after stopping
-	err = r.ctrClient.DeleteContainer(namespace, containerdID, ctr.ContainerDeleteOptions{
-		SnapshotCleanup: true,
-	})
-	if err != nil {
-		// Log warning but don't fail - container might already be deleted
-		fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-		fields = append(
-			fields,
-			"space",
-			spaceName,
-			"realm",
-			realmName,
-			"containerName",
-			containerID,
-			"err",
-			fmt.Sprintf("%v", err),
-		)
-		r.logger.WarnContext(
-			r.ctx,
-			"failed to delete container, continuing",
-			fields...,
-		)
-	} else {
-		fields = appendCellLogFields([]any{"id", containerdID}, cellID, cellName)
-		fields = append(fields, "space", spaceName, "realm", realmName, "containerName", containerID)
-		r.logger.InfoContext(
-			r.ctx,
-			"deleted container",
-			fields...,
-		)
-	}
-
+	// Issue #867: leave the containerd container record (and snapshot) in
+	// place. The cell-wide cleanup comments in stopCellLocked above carry
+	// the full rationale; the single-container `kuke stop container` verb
+	// mirrors the cell-wide stop verb's contract.
 	return nil
 }

--- a/internal/controller/runner/stop_kill_test.go
+++ b/internal/controller/runner/stop_kill_test.go
@@ -1,0 +1,365 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.StopCell / *Exec.KillCell against an in-package ctr.Client fake
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	cgroup2 "github.com/containerd/cgroups/v2/cgroup2"
+	apitypes "github.com/containerd/containerd/api/types"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/ctr"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/metadata"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// stopKillFakeClient is the minimal ctr.Client fake used by the StopCell /
+// KillCell snapshot-preservation regression guards. Only the methods StopCell
+// / KillCell exercise are non-trivial; everything else returns the zero value
+// to satisfy the ctr.Client interface.
+type stopKillFakeClient struct {
+	stopContainerFn       func(namespace, id string, opts ctr.StopContainerOptions) (*containerd.ExitStatus, error)
+	killContainerTaskFn   func(namespace, id string) error
+	deleteContainerCalls  int64
+	stopContainerCalls    int64
+	killContainerTaskHits int64
+}
+
+func (c *stopKillFakeClient) Connect() error { return nil }
+func (c *stopKillFakeClient) Close() error   { return nil }
+
+func (c *stopKillFakeClient) CreateNamespace(string) error             { return nil }
+func (c *stopKillFakeClient) DeleteNamespace(string) error             { return nil }
+func (c *stopKillFakeClient) ListNamespaces() ([]string, error)        { return nil, nil }
+func (c *stopKillFakeClient) GetNamespace(string) (string, error)      { return "", nil }
+func (c *stopKillFakeClient) ExistsNamespace(string) (bool, error)     { return false, nil }
+func (c *stopKillFakeClient) CleanupNamespaceResources(string, string) error {
+	return nil
+}
+
+func (c *stopKillFakeClient) GetCgroupMountpoint() string               { return "" }
+func (c *stopKillFakeClient) GetCurrentCgroupPath() (string, error)     { return "", nil }
+func (c *stopKillFakeClient) CgroupPath(string, string) (string, error) { return "", nil }
+func (c *stopKillFakeClient) NewCgroup(ctr.CgroupSpec) (*cgroup2.Manager, error) {
+	//nolint:nilnil // cgroup2.Manager has unexported fields; the test path discards the value
+	return nil, nil
+}
+func (c *stopKillFakeClient) LoadCgroup(string, string) (*cgroup2.Manager, error) {
+	//nolint:nilnil // same as NewCgroup
+	return nil, nil
+}
+func (c *stopKillFakeClient) DeleteCgroup(string, string) error { return nil }
+func (c *stopKillFakeClient) EnsureSubtreeControllers(string, string, []string) ([]string, error) {
+	return nil, nil
+}
+func (c *stopKillFakeClient) EnableCellSubtreeControllers(string, string, []string) ([]string, error) {
+	return nil, nil
+}
+func (c *stopKillFakeClient) EnableCellAllSubtreeControllers(string, string) ([]string, error) {
+	return nil, nil
+}
+func (c *stopKillFakeClient) RelocateProcessesToLeaf(string, string, string) error { return nil }
+
+func (c *stopKillFakeClient) CreateContainerFromSpec(
+	string, intmodel.ContainerSpec, []ctr.RegistryCredentials, ...ctr.BuildOption,
+) (containerd.Container, error) {
+	//nolint:nilnil // not invoked by StopCell / KillCell
+	return nil, nil
+}
+
+func (c *stopKillFakeClient) CreateContainer(
+	string, ctr.ContainerSpec, []ctr.RegistryCredentials,
+) (containerd.Container, error) {
+	//nolint:nilnil // not invoked by StopCell / KillCell
+	return nil, nil
+}
+
+func (c *stopKillFakeClient) GetContainer(string, string) (containerd.Container, error) {
+	return nil, errdefs.ErrContainerNotFound
+}
+
+func (c *stopKillFakeClient) ListContainers(string, ...string) ([]containerd.Container, error) {
+	return nil, nil
+}
+
+func (c *stopKillFakeClient) ExistsContainer(string, string) (bool, error) {
+	return false, nil
+}
+
+func (c *stopKillFakeClient) DeleteContainer(string, string, ctr.ContainerDeleteOptions) error {
+	atomic.AddInt64(&c.deleteContainerCalls, 1)
+	return nil
+}
+
+func (c *stopKillFakeClient) StartContainer(
+	string, ctr.ContainerSpec, ctr.TaskSpec,
+) (containerd.Task, error) {
+	//nolint:nilnil // not invoked by StopCell / KillCell
+	return nil, nil
+}
+
+func (c *stopKillFakeClient) StopContainer(
+	namespace, id string, opts ctr.StopContainerOptions,
+) (*containerd.ExitStatus, error) {
+	atomic.AddInt64(&c.stopContainerCalls, 1)
+	if c.stopContainerFn != nil {
+		return c.stopContainerFn(namespace, id, opts)
+	}
+	return nil, nil
+}
+
+func (c *stopKillFakeClient) TaskStatus(string, string) (containerd.Status, error) {
+	return containerd.Status{}, nil
+}
+
+func (c *stopKillFakeClient) TaskMetrics(string, string) (*apitypes.Metric, error) {
+	//nolint:nilnil // not invoked by StopCell / KillCell
+	return nil, nil
+}
+
+func (c *stopKillFakeClient) ContainerProcessUID(string, containerd.Container) (uint32, error) {
+	return 0, nil
+}
+
+func (c *stopKillFakeClient) LoadImage(string, io.Reader) ([]string, error) {
+	return nil, nil
+}
+func (c *stopKillFakeClient) ListImages(string) ([]ctr.ImageInfo, error) {
+	return nil, nil
+}
+func (c *stopKillFakeClient) GetImage(string, string) (ctr.ImageInfo, error) {
+	return ctr.ImageInfo{}, nil
+}
+func (c *stopKillFakeClient) DeleteImage(string, string) error { return nil }
+
+var _ ctr.Client = (*stopKillFakeClient)(nil)
+
+func newStopKillTestExec(t *testing.T, fake *stopKillFakeClient) *Exec {
+	t.Helper()
+	cniCacheDir := t.TempDir()
+	return &Exec{
+		ctx:       context.Background(),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ctrClient: fake,
+		opts:      Options{RunPath: t.TempDir()},
+		cniConf:   &cni.Conf{CniCacheDir: cniCacheDir},
+	}
+}
+
+func seedStopKillRealm(t *testing.T, r *Exec, realmName string) {
+	t.Helper()
+	doc := v1beta1.RealmDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindRealm,
+		Metadata:   v1beta1.RealmMetadata{Name: realmName},
+		Spec:       v1beta1.RealmSpec{Namespace: realmName + ".kukeon.io"},
+	}
+	path := fs.RealmMetadataPath(r.opts.RunPath, realmName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir realm metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write realm metadata: %v", err)
+	}
+}
+
+func seedStopKillSpace(t *testing.T, r *Exec, realm, space string) {
+	t.Helper()
+	doc := v1beta1.SpaceDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindSpace,
+		Metadata:   v1beta1.SpaceMetadata{Name: space},
+		// An explicit CNIConfigPath short-circuits the default-path build in
+		// resolveSpaceCNIConfigPath; the file is never read because the
+		// stop/kill paths only forward it to detach calls the fake ignores.
+		Spec: v1beta1.SpaceSpec{RealmID: realm, CNIConfigPath: filepath.Join(t.TempDir(), "cni.conflist")},
+	}
+	path := fs.SpaceMetadataPath(r.opts.RunPath, realm, space)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir space metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write space metadata: %v", err)
+	}
+}
+
+func seedStopKillCell(t *testing.T, r *Exec, realm, space, stack, cellName string) {
+	t.Helper()
+	containerdID := space + "_" + stack + "_" + cellName + "_workload"
+	rootContainerdID := space + "_" + stack + "_" + cellName + "_root"
+	doc := v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: cellName},
+		Spec: v1beta1.CellSpec{
+			ID:              cellName,
+			RealmID:         realm,
+			SpaceID:         space,
+			StackID:         stack,
+			RootContainerID: "root",
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:           "root",
+					ContainerdID: rootContainerdID,
+					RealmID:      realm,
+					SpaceID:      space,
+					StackID:      stack,
+					CellID:       cellName,
+					Image:        "alpine:latest",
+					Root:         true,
+				},
+				{
+					ID:           "workload",
+					ContainerdID: containerdID,
+					RealmID:      realm,
+					SpaceID:      space,
+					StackID:      stack,
+					CellID:       cellName,
+					Image:        "alpine:latest",
+				},
+			},
+		},
+	}
+	path := fs.CellMetadataPath(r.opts.RunPath, realm, space, stack, cellName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir cell metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write cell metadata: %v", err)
+	}
+}
+
+func buildStopKillCellRequest(realm, space, stack, cellName string) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: cellName},
+		Spec: intmodel.CellSpec{
+			ID:        cellName,
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+		},
+	}
+}
+
+// TestStopCell_PreservesContainerRecord is the issue #867 regression guard
+// for the stop verb. Pre-fix, stopCellLocked followed every task-shutdown
+// step with DeleteContainer{SnapshotCleanup: true}, silently wiping the
+// containerd container record (and its overlay snapshot) — the exact
+// teardown delete is supposed to own exclusively. The fix removes those
+// calls, leaving the record + snapshot in place so the next StartCell can
+// resume the task on the preserved overlay (the marker-file invariant the
+// issue's `--reuse` AC depends on).
+func TestStopCell_PreservesContainerRecord(t *testing.T) {
+	realm, space, stack, cellName := "kuke-system", "kukeon", "kukeon", "demo"
+	fake := &stopKillFakeClient{}
+	r := newStopKillTestExec(t, fake)
+	seedStopKillRealm(t, r, realm)
+	seedStopKillSpace(t, r, realm, space)
+	seedStopKillCell(t, r, realm, space, stack, cellName)
+
+	if _, err := r.StopCell(buildStopKillCellRequest(realm, space, stack, cellName)); err != nil {
+		t.Fatalf("StopCell: unexpected error: %v", err)
+	}
+
+	if got := atomic.LoadInt64(&fake.deleteContainerCalls); got != 0 {
+		t.Errorf(
+			"StopCell must not call DeleteContainer (issue #867: stop owns task teardown only, delete owns record+snapshot); got %d calls",
+			got,
+		)
+	}
+	if got := atomic.LoadInt64(&fake.stopContainerCalls); got == 0 {
+		t.Errorf("StopCell must still call StopContainer to tear down the task; got 0 calls")
+	}
+}
+
+// TestKillCell_PreservesContainerRecord is the issue #867 regression guard
+// for the kill verb. kill is the SIGKILL-escalated cousin of stop; the
+// documented stop/kill/delete split distinguishes them on signal escalation,
+// not on snapshot teardown. Pre-fix, killCellLocked also called
+// DeleteContainer{SnapshotCleanup: true}, wiping the overlay on every kill;
+// after the fix, kill leaves the record + snapshot in place.
+func TestKillCell_PreservesContainerRecord(t *testing.T) {
+	realm, space, stack, cellName := "kuke-system", "kukeon", "kukeon", "demo"
+	fake := &stopKillFakeClient{
+		stopContainerFn: func(_, _ string, _ ctr.StopContainerOptions) (*containerd.ExitStatus, error) {
+			// KillCell calls StopContainer with Force=true via killContainerTask;
+			// the per-task SIGKILL surface is the only stop-equivalent the fake
+			// needs to acknowledge.
+			return nil, nil
+		},
+	}
+	r := newStopKillTestExec(t, fake)
+	seedStopKillRealm(t, r, realm)
+	seedStopKillSpace(t, r, realm, space)
+	seedStopKillCell(t, r, realm, space, stack, cellName)
+
+	if _, err := r.KillCell(buildStopKillCellRequest(realm, space, stack, cellName)); err != nil {
+		t.Fatalf("KillCell: unexpected error: %v", err)
+	}
+
+	if got := atomic.LoadInt64(&fake.deleteContainerCalls); got != 0 {
+		t.Errorf(
+			"KillCell must not call DeleteContainer (issue #867: kill is stop-with-SIGKILL, not stop+delete); got %d calls",
+			got,
+		)
+	}
+}
+
+// TestStopContainer_PreservesContainerRecord is the per-container counterpart
+// of TestStopCell_PreservesContainerRecord. `kuke stop container` is the
+// single-container verb the issue's AC also covers; pre-fix StopContainer
+// matched stopCellLocked's destructive teardown.
+func TestStopContainer_PreservesContainerRecord(t *testing.T) {
+	realm, space, stack, cellName := "kuke-system", "kukeon", "kukeon", "demo"
+	fake := &stopKillFakeClient{}
+	r := newStopKillTestExec(t, fake)
+	seedStopKillRealm(t, r, realm)
+	seedStopKillSpace(t, r, realm, space)
+	seedStopKillCell(t, r, realm, space, stack, cellName)
+
+	// Reuse the seeded workload container ID — StopContainer looks the spec
+	// up by base ID, not by ContainerdID.
+	cell, err := r.GetCell(buildStopKillCellRequest(realm, space, stack, cellName))
+	if err != nil {
+		t.Fatalf("GetCell: %v", err)
+	}
+	if stopErr := r.StopContainer(cell, "workload"); stopErr != nil &&
+		!errors.Is(stopErr, errdefs.ErrTaskNotFound) {
+		t.Fatalf("StopContainer: unexpected error: %v", stopErr)
+	}
+
+	if got := atomic.LoadInt64(&fake.deleteContainerCalls); got != 0 {
+		t.Errorf(
+			"StopContainer must not call DeleteContainer (issue #867: stop-container verb mirrors the cell-wide stop contract); got %d calls",
+			got,
+		)
+	}
+}

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -180,6 +180,7 @@ type buildOpts struct {
 	attachable              AttachableInjection
 	defaultMemoryLimitBytes int64
 	secretRunPath           string
+	extraLabels             map[string]string
 }
 
 // WithAttachableInjection configures the host-side paths used when wrapping
@@ -201,6 +202,27 @@ func WithDefaultMemoryLimit(bytes int64) BuildOption {
 	return func(o *buildOpts) {
 		if bytes > 0 {
 			o.defaultMemoryLimitBytes = bytes
+		}
+	}
+}
+
+// WithExtraLabels merges additional containerd container labels into the
+// built spec's label map (existing keys overwritten on collision). Used by
+// the runner to stamp `kukeon.io/spec-hash` at container-create time without
+// threading the value through every Build option; root containers receive
+// the same label via the labels argument BuildRootContainerSpec already
+// accepts. Empty input is a no-op so callers can pass it unconditionally.
+// Issue #867.
+func WithExtraLabels(labels map[string]string) BuildOption {
+	return func(o *buildOpts) {
+		if len(labels) == 0 {
+			return
+		}
+		if o.extraLabels == nil {
+			o.extraLabels = make(map[string]string, len(labels))
+		}
+		for k, v := range labels {
+			o.extraLabels[k] = v
 		}
 	}
 }
@@ -259,6 +281,12 @@ func BuildContainerSpec(
 	labels["kukeon.io/space"] = spaceID
 	labels["kukeon.io/realm"] = realmID
 	labels["kukeon.io/stack"] = stackID
+	// Merge caller-supplied extras last so a runner-injected
+	// `kukeon.io/spec-hash` (issue #867) and any future extras win over the
+	// canonical block on intentional key collisions.
+	for k, v := range opts.extraLabels {
+		labels[k] = v
+	}
 
 	// Build OCI spec options
 	specOpts := []oci.SpecOpts{

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -149,6 +149,19 @@ var (
 	// of the misleading Ready→Stopped→reaped cycle. Issue #851.
 	ErrCellWindDownImmediate = errors.New("cell wound down immediately after start")
 
+	// ErrCellSpecHashDrift is the StartCell sentinel raised when the
+	// existing containerd container record carries a `kukeon.io/spec-hash`
+	// label whose value disagrees with the SHA-256 over the on-disk
+	// CellSpec's "requires containerd recreate" field set (image, command,
+	// args). Mismatch is only reachable via crash-mid-apply or an
+	// unsupported hand-edit of `metadata.yaml` — the supported `kuke apply
+	// -f` flow re-stamps the label inside the same RecreateCell /
+	// UpdateCell transaction that rewrites containerd state. The sentinel
+	// keeps the operator-facing error parseable while the wrapping
+	// message names the diverged hash pair and points at `kuke apply -f`.
+	// Issue #867.
+	ErrCellSpecHashDrift = errors.New("cell spec hash diverges from containerd record")
+
 	// Volume-related errors.
 
 	ErrVolumeSourceRequired    = errors.New("volume source is required")


### PR DESCRIPTION
## Summary

- `kuke stop cell` / `kuke kill cell` / `kuke stop container` / `kuke kill container` no longer tear down the containerd container record (and overlay snapshot) — that work is left to the `delete` verb, restoring the documented stop/kill/delete split (`docs/cli-use-cases.md:374`). The headline operator-visible consequence is that a `stop → start` cycle now preserves anything written to the writable overlay (cloned repos from an `onInit`, installed packages, marker files), which is the invariant `--reuse` (#835 / #848) silently failed.
- Adds a `kukeon.io/spec-hash` label stamped on every kukeon-managed containerd container record at create time. The hash is a SHA-256 over the CellSpec field set `apply.DiffCell` classifies as "requires containerd recreate" (image, command, args — both root via `rootContainerSpecChanged` and non-root via `update_cell.go::containerSpecChanged`). A unit test pins the hash domain to `DiffCell`'s breaking-field set so the two cannot silently drift apart (issue AC #5 / #6).
- `StartCell` / `StartContainer` no longer wipe the existing containerd record on the happy path. Instead, they read the `kukeon.io/spec-hash` label, compare it to the freshly-computed hash, and:
  - **match** → drop any stale task and resume on the preserved snapshot;
  - **mismatch** → refuse with `errdefs.ErrCellSpecHashDrift` naming both hashes and pointing the operator at `kuke apply -f` (the supported mutation surface re-stamps the label inside the same `RecreateCell` / `UpdateCell` transaction that rewrites containerd state);
  - **legacy record with no label** → treated as match for backward compat so the first restart after this upgrade does not refuse a healthy cell.

## Hash-domain interpretation (reviewer pushback welcome)

The issue body lists "image, command, args, env, mounts, security context, resources" as the hash payload but also says the domain must equal what `apply.DiffCell` classifies as "requires containerd recreate". Those two are inconsistent — `DiffCell` classifies env / mounts / security / resources as Compatible (the apply layer handles them via in-place `UpdateCell`, not recreate). I read the AC's "pin the hash domain to `DiffCell`'s breaking-field set" as binding and went with the narrow domain (image, command, args). A wider hash would force `ErrCellSpecHashDrift` on every `kuke apply -f` that tweaked a Compatible field, defeating `UpdateCell` entirely. The pinning test catches a future widening of `DiffCell` so the two stay in lock-step. Happy to switch to the wider domain if the reviewer prefers the literal AC text.

## AC carve-out: child containers on the StartCell hot path

Issue AC #4 cites the root-container code window (`start.go:651-705`) for the destructive recreate removal. The same destructive `DeleteContainer{SnapshotCleanup: true}` pattern existed for child containers in the StartCell loop (`start.go:1015-1019`) and in single-container `StartContainer` (`start.go:1322-1326`); both are extended with the same spec-hash guard. Otherwise a `stop cell` + `start cell` would preserve the root overlay but wipe child overlays, which would not satisfy the marker-file behavioral check the issue is asking for.

## Test plan

- [x] `GOWORK=off make test` — full repo unit + integration suite, all green
- [x] `GOWORK=off go vet ./...` — clean
- [x] New `internal/controller/runner/spec_hash_test.go`: determinism, nil-vs-empty args parity, image/command/args change the hash, compatible fields don't, **pinning to `apply.DiffCell` breaking-field set** (AC #5)
- [x] New `internal/controller/runner/stop_kill_test.go`: `StopCell` / `KillCell` / `StopContainer` no longer call `DeleteContainer` (issue ACs #1, #2)
- [x] New `internal/controller/runner/spec_hash_guard_test.go`: `reuseOrRefuseExistingChildContainer` happy / mismatch / legacy-label / absent-record matrix; the diverged-hash error wraps `ErrCellSpecHashDrift` and surfaces both hashes + `kuke apply -f`
- [x] e2e suite compiles (`go test -run XXX ./e2e/`)
- [ ] `make dev-init` (containerd-on-host) two-realm parity check — **deferred to reviewer's environment**: the dev host has no `kuke daemon` running and `make dev-init` requires a privileged containerd + cgroup-v2 host, which the agent sandbox cannot provide safely. The marker-file `stop → write → start` invariant (`echo X > /work/marker; kuke stop cell; kuke start cell; cat /work/marker`) is the headline behavioral check this PR enables and should be exercised on a real cell before merge.
- [ ] e2e suite run — **deferred to reviewer's environment**: same containerd-host dependency as `make dev-init`

Closes #867