### PR TITLE
fix(init): recreate kukeond cell on image drift and verify post-stop reset

### DIFF
--- a/cmd/kuke/daemon/internal/lifecycle/lifecycle.go
+++ b/cmd/kuke/daemon/internal/lifecycle/lifecycle.go
@@ -165,7 +165,18 @@ func StopPhase(
 			"kukeond stopped (cell %q in realm %q)\n",
 			consts.KukeSystemCellName, consts.KukeSystemRealmName,
 		)
-		return nil
+		// StopCell can return Stopped=true while a container task survives —
+		// the runner's per-container StopContainer errors are logged-and-
+		// continue rather than aggregated into the StopCell result (see
+		// internal/controller/runner/stop.go), so a containerd shim that
+		// rejects SIGTERM or a stop call that returns before the task exits
+		// surfaces here as "successful stop" with a still-Ready container.
+		// `kuke daemon reset` would then proceed to DeleteCell against a
+		// surviving kukeond task, leaving the operator's daemon binary
+		// frozen on the prior build across a re-bootstrap. Issue #868.
+		// Verify the post-stop state and escalate to KillCell if a task
+		// remains.
+		return verifyStoppedOrEscalate(cmd, client, doc)
 	case <-time.After(timeout):
 		cancel()
 		killRes, killErr := client.KillCell(cmd.Context(), doc)
@@ -184,4 +195,54 @@ func StopPhase(
 		)
 		return nil
 	}
+}
+
+// verifyStoppedOrEscalate re-reads the cell after a successful StopCell, and
+// if a container task is still Ready, drives the SIGKILL escalation that
+// would otherwise have fired on grace-period timeout. The post-kill GetCell
+// is the second gate: if the task remains Ready even after KillCell claimed
+// to terminate it, the caller must surface a hard error rather than allow
+// the subsequent DeleteCell to race against a live shim.
+func verifyStoppedOrEscalate(
+	cmd *cobra.Command,
+	client kukeonv1.Client,
+	doc v1beta1.CellDoc,
+) error {
+	getRes, getErr := client.GetCell(cmd.Context(), doc)
+	if getErr != nil {
+		return fmt.Errorf("re-inspect kukeond cell after stop: %w", getErr)
+	}
+	if !getRes.MetadataExists || !IsCellRunning(getRes.Cell) {
+		return nil
+	}
+
+	killRes, killErr := client.KillCell(cmd.Context(), doc)
+	if killErr != nil {
+		return fmt.Errorf(
+			"escalate to kill kukeond cell after stop returned success but task survived: %w",
+			killErr,
+		)
+	}
+	if !killRes.Killed {
+		return fmt.Errorf(
+			"escalate to kill kukeond cell after stop returned success but task survived: %w",
+			errdefs.ErrControllerNoChange,
+		)
+	}
+
+	verifyRes, verifyErr := client.GetCell(cmd.Context(), doc)
+	if verifyErr != nil {
+		return fmt.Errorf("re-inspect kukeond cell after escalated kill: %w", verifyErr)
+	}
+	if verifyRes.MetadataExists && IsCellRunning(verifyRes.Cell) {
+		return fmt.Errorf(
+			"kukeond cell %q in realm %q still reports a running container after stop and escalated kill",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+	}
+	cmd.Printf(
+		"kukeond force-killed after stop returned success but task survived (cell %q in realm %q)\n",
+		consts.KukeSystemCellName, consts.KukeSystemRealmName,
+	)
+	return nil
 }

--- a/cmd/kuke/daemon/internal/lifecycle/lifecycle_test.go
+++ b/cmd/kuke/daemon/internal/lifecycle/lifecycle_test.go
@@ -92,10 +92,108 @@ func TestStopPhase_GracefulSuccess(t *testing.T) {
 			t.Fatal("KillCell must not run when StopCell succeeds within the grace period")
 			return kukeonv1.KillCellResult{}, nil
 		},
+		// Post-stop verification (issue #868) re-reads the cell to confirm
+		// the task is actually gone; returning Stopped clears the gate so
+		// the escalation path is not taken.
+		getCellFn: func(_ context.Context, _ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
 	}
 	cmd := newCmdWithContext(context.Background(), t)
 	if err := lifecycle.StopPhase(cmd, fc, v1beta1.CellDoc{}, time.Second); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestStopPhase_GracefulSuccessButTaskSurvivesEscalates covers issue #868:
+// when StopCell returns Stopped=true but the post-stop GetCell still
+// reports a Ready container, StopPhase must escalate to KillCell rather
+// than declare the stop successful and let the caller race a live task.
+func TestStopPhase_GracefulSuccessButTaskSurvivesEscalates(t *testing.T) {
+	killCalled := atomicBool{}
+	var getCalls int
+	fc := &fakeClient{
+		stopCellFn: func(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			killCalled.Store(true)
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		getCellFn: func(_ context.Context, _ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			getCalls++
+			// First call: post-stop verification sees survivor.
+			// Second call: post-kill verification confirms it's gone.
+			if getCalls == 1 {
+				return kukeonv1.GetCellResult{
+					Cell: v1beta1.CellDoc{
+						Status: v1beta1.CellStatus{
+							State: v1beta1.CellStateReady,
+							Containers: []v1beta1.ContainerStatus{
+								{State: v1beta1.ContainerStateReady},
+							},
+						},
+					},
+					MetadataExists: true,
+				}, nil
+			}
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+	cmd := newCmdWithContext(context.Background(), t)
+	if err := lifecycle.StopPhase(cmd, fc, v1beta1.CellDoc{}, time.Second); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !killCalled.Load() {
+		t.Fatal("KillCell must run when post-stop verification still sees a Ready container")
+	}
+}
+
+// TestStopPhase_PostKillVerificationStillRunningErrors covers the hard
+// failure surface of issue #868's verification: when even KillCell cannot
+// remove the surviving task, StopPhase must surface a clear error so the
+// caller can refuse the subsequent DeleteCell rather than race a live shim.
+func TestStopPhase_PostKillVerificationStillRunningErrors(t *testing.T) {
+	fc := &fakeClient{
+		stopCellFn: func(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		// Both post-stop and post-kill GetCell return Ready — the task
+		// refuses to die.
+		getCellFn: func(_ context.Context, _ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+	}
+	cmd := newCmdWithContext(context.Background(), t)
+	err := lifecycle.StopPhase(cmd, fc, v1beta1.CellDoc{}, time.Second)
+	if err == nil {
+		t.Fatal("StopPhase must error when post-kill verification still sees a Ready container")
+	}
+	if !strings.Contains(err.Error(), "still reports a running container") {
+		t.Errorf("error must surface the survivor; got %v", err)
 	}
 }
 
@@ -327,6 +425,7 @@ type fakeClient struct {
 
 	stopCellFn func(context.Context, v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
 	killCellFn func(context.Context, v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
+	getCellFn  func(context.Context, v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
 }
 
 func (f *fakeClient) StopCell(ctx context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
@@ -341,4 +440,11 @@ func (f *fakeClient) KillCell(ctx context.Context, doc v1beta1.CellDoc) (kukeonv
 		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
 	}
 	return f.killCellFn(ctx, doc)
+}
+
+func (f *fakeClient) GetCell(ctx context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errors.New("unexpected GetCell call")
+	}
+	return f.getCellFn(ctx, doc)
 }

--- a/cmd/kuke/daemon/reset/reset_test.go
+++ b/cmd/kuke/daemon/reset/reset_test.go
@@ -67,30 +67,46 @@ func TestDaemonReset(t *testing.T) {
 	}{
 		{
 			name: "running cell is gracefully stopped, deleted, sock+pid cleared",
-			fake: &fakeClient{
-				getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					assertKukeondTarget(t, doc)
-					return kukeonv1.GetCellResult{
-						Cell: v1beta1.CellDoc{
-							Status: v1beta1.CellStatus{
-								State: v1beta1.CellStateReady,
-								Containers: []v1beta1.ContainerStatus{
-									{State: v1beta1.ContainerStateReady},
+			fake: func() *fakeClient {
+				// GetCell is called twice on this path: once by runReset to
+				// pick the stop branch (returns Ready), and once by
+				// lifecycle.StopPhase's post-stop verification (issue #868)
+				// to confirm the task is actually gone (returns Stopped).
+				var getCalls int
+				return &fakeClient{
+					getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+						assertKukeondTarget(t, doc)
+						getCalls++
+						if getCalls == 1 {
+							return kukeonv1.GetCellResult{
+								Cell: v1beta1.CellDoc{
+									Status: v1beta1.CellStatus{
+										State: v1beta1.CellStateReady,
+										Containers: []v1beta1.ContainerStatus{
+											{State: v1beta1.ContainerStateReady},
+										},
+									},
 								},
+								MetadataExists: true,
+							}, nil
+						}
+						return kukeonv1.GetCellResult{
+							Cell: v1beta1.CellDoc{
+								Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
 							},
-						},
-						MetadataExists: true,
-					}, nil
-				},
-				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
-					assertKukeondTarget(t, doc)
-					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
-				},
-				deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
-					assertKukeondTarget(t, doc)
-					return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
-				},
-			},
+							MetadataExists: true,
+						}, nil
+					},
+					stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+						assertKukeondTarget(t, doc)
+						return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+					},
+					deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+						assertKukeondTarget(t, doc)
+						return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+					},
+				}
+			}(),
 			wantOutputs: []string{
 				`kukeond stopped (cell "kukeond" in realm "kuke-system")`,
 				`kukeond cell deleted (cell "kukeond" in realm "kuke-system")`,
@@ -660,6 +676,146 @@ func TestDaemonReset_GracefulTimeoutEscalatesToKill(t *testing.T) {
 	}
 	if !strings.Contains(out, "kukeond cell deleted") {
 		t.Errorf("output missing delete-phase notice; got:\n%s", out)
+	}
+}
+
+// TestDaemonReset_StopSucceedsButTaskSurvivesEscalatesToKill covers issue
+// #868's reset-path AC: when StopCell returns Stopped=true but a container
+// task remains Ready (the soft-fail mode where the runner's per-container
+// StopContainer errors are logged-and-continue rather than aggregated into
+// the StopCell result), the verb must escalate to KillCell before
+// DeleteCell — otherwise the subsequent `kuke init --kukeond-image <new>`
+// races a surviving daemon task and silently restarts the stale binary.
+func TestDaemonReset_StopSucceedsButTaskSurvivesEscalatesToKill(t *testing.T) {
+	withFreshViper(t)
+
+	var (
+		killCalled   atomicBool
+		deleteCalled atomicBool
+		getCalls     int
+	)
+
+	fake := &fakeClient{
+		// Pre-stop GetCell #1 returns Ready (drives the StopPhase branch).
+		// Post-stop GetCell #2 still returns Ready — the StopCell call
+		// "succeeded" but the task never went away. Post-kill GetCell #3
+		// returns Stopped so the verification gate clears.
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			getCalls++
+			if getCalls < 3 {
+				return kukeonv1.GetCellResult{
+					Cell: v1beta1.CellDoc{
+						Status: v1beta1.CellStatus{
+							State: v1beta1.CellStateReady,
+							Containers: []v1beta1.ContainerStatus{
+								{State: v1beta1.ContainerStateReady},
+							},
+						},
+					},
+					MetadataExists: true,
+				}, nil
+			}
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			killCalled.Store(true)
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			deleteCalled.Store(true)
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	cmd.SetContext(ctx)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !killCalled.Load() {
+		t.Fatal("KillCell must be escalated when post-stop verification still sees a Ready container")
+	}
+	if !deleteCalled.Load() {
+		t.Fatal("DeleteCell must run after the escalation clears the surviving task")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "force-killed after stop returned success but task survived") {
+		t.Errorf("output missing escalation notice; got:\n%s", out)
+	}
+	if !strings.Contains(out, "kukeond cell deleted") {
+		t.Errorf("output missing delete-phase notice; got:\n%s", out)
+	}
+}
+
+// TestDaemonReset_StopSucceedsAndKillCannotClearSurvivor covers the hard
+// failure path of the post-stop verification: if even KillCell cannot kill
+// the surviving task, the verb must surface a clear error so the operator
+// is told that DeleteCell would race a live shim instead of proceeding
+// blind to it. Issue #868.
+func TestDaemonReset_StopSucceedsAndKillCannotClearSurvivor(t *testing.T) {
+	withFreshViper(t)
+
+	fake := &fakeClient{
+		// Every GetCell returns Ready — the survivor refuses to die.
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		deleteCellFn: func(_ v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			t.Fatal("DeleteCell must not be reached when post-kill verification still sees a Ready container")
+			return kukeonv1.DeleteCellResult{}, nil
+		},
+	}
+
+	cmd := reset.NewResetCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, reset.MockSocketDirKey{}, t.TempDir())
+	ctx = context.WithValue(ctx, reset.MockRunPathKey{}, t.TempDir())
+	cmd.SetContext(ctx)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("reset must error when post-kill verification still sees a Ready container")
+	}
+	if !strings.Contains(err.Error(), "still reports a running container after stop and escalated kill") {
+		t.Errorf("error does not surface the survivor; got %v", err)
 	}
 }
 

--- a/cmd/kuke/daemon/restart/restart_test.go
+++ b/cmd/kuke/daemon/restart/restart_test.go
@@ -71,34 +71,49 @@ func TestDaemonRestart(t *testing.T) {
 	}{
 		{
 			name: "running cell is gracefully stopped then started",
-			fake: &fakeClient{
-				getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					assertKukeondTarget(t, doc)
-					return kukeonv1.GetCellResult{
-						Cell: v1beta1.CellDoc{
-							Status: v1beta1.CellStatus{
-								State: v1beta1.CellStateReady,
-								Containers: []v1beta1.ContainerStatus{
-									{State: v1beta1.ContainerStateReady},
+			fake: func() *fakeClient {
+				// GetCell #1: runRestart sees Ready and picks StopPhase.
+				// GetCell #2: StopPhase's post-stop verification (issue
+				// #868) returns Stopped so the escalation path is not taken.
+				var getCalls int
+				return &fakeClient{
+					getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+						assertKukeondTarget(t, doc)
+						getCalls++
+						if getCalls == 1 {
+							return kukeonv1.GetCellResult{
+								Cell: v1beta1.CellDoc{
+									Status: v1beta1.CellStatus{
+										State: v1beta1.CellStateReady,
+										Containers: []v1beta1.ContainerStatus{
+											{State: v1beta1.ContainerStateReady},
+										},
+									},
 								},
+								MetadataExists: true,
+							}, nil
+						}
+						return kukeonv1.GetCellResult{
+							Cell: v1beta1.CellDoc{
+								Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
 							},
-						},
-						MetadataExists: true,
-					}, nil
-				},
-				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
-					assertKukeondTarget(t, doc)
-					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
-				},
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-					assertKukeondTarget(t, doc)
-					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
-				},
-				killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
-					t.Fatalf("KillCell must not be called when graceful stop succeeds")
-					return kukeonv1.KillCellResult{}, nil
-				},
-			},
+							MetadataExists: true,
+						}, nil
+					},
+					stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+						assertKukeondTarget(t, doc)
+						return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+					},
+					startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+						assertKukeondTarget(t, doc)
+						return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+					},
+					killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+						t.Fatalf("KillCell must not be called when graceful stop succeeds")
+						return kukeonv1.KillCellResult{}, nil
+					},
+				}
+			}(),
 			wantOutputs: []string{
 				`kukeond stopped (cell "kukeond" in realm "kuke-system")`,
 				`kukeond started (cell "kukeond" in realm "kuke-system")`,
@@ -235,27 +250,42 @@ func TestDaemonRestart(t *testing.T) {
 		},
 		{
 			name: "StartCell error after successful stop is wrapped",
-			fake: &fakeClient{
-				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					return kukeonv1.GetCellResult{
-						Cell: v1beta1.CellDoc{
-							Status: v1beta1.CellStatus{
-								State: v1beta1.CellStateReady,
-								Containers: []v1beta1.ContainerStatus{
-									{State: v1beta1.ContainerStateReady},
+			fake: func() *fakeClient {
+				// GetCell #1: runRestart sees Ready → StopPhase.
+				// GetCell #2: StopPhase post-stop verification sees Stopped
+				// so StartCell is reached and its error is what surfaces.
+				var getCalls int
+				return &fakeClient{
+					getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+						getCalls++
+						if getCalls == 1 {
+							return kukeonv1.GetCellResult{
+								Cell: v1beta1.CellDoc{
+									Status: v1beta1.CellStatus{
+										State: v1beta1.CellStateReady,
+										Containers: []v1beta1.ContainerStatus{
+											{State: v1beta1.ContainerStateReady},
+										},
+									},
 								},
+								MetadataExists: true,
+							}, nil
+						}
+						return kukeonv1.GetCellResult{
+							Cell: v1beta1.CellDoc{
+								Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
 							},
-						},
-						MetadataExists: true,
-					}, nil
-				},
-				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
-					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
-				},
-				startCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-					return kukeonv1.StartCellResult{}, errors.New("runner blew up")
-				},
-			},
+							MetadataExists: true,
+						}, nil
+					},
+					stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+						return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+					},
+					startCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+						return kukeonv1.StartCellResult{}, errors.New("runner blew up")
+					},
+				}
+			}(),
 			wantErr: "start kukeond cell:",
 		},
 		{

--- a/cmd/kuke/daemon/stop/stop_test.go
+++ b/cmd/kuke/daemon/stop/stop_test.go
@@ -70,30 +70,45 @@ func TestDaemonStop(t *testing.T) {
 	}{
 		{
 			name: "running cell is gracefully stopped",
-			fake: &fakeClient{
-				getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					assertKukeondTarget(t, doc)
-					return kukeonv1.GetCellResult{
-						Cell: v1beta1.CellDoc{
-							Status: v1beta1.CellStatus{
-								State: v1beta1.CellStateReady,
-								Containers: []v1beta1.ContainerStatus{
-									{State: v1beta1.ContainerStateReady},
+			fake: func() *fakeClient {
+				// GetCell #1: runStop's branch picker sees Ready.
+				// GetCell #2: StopPhase's post-stop verification (issue #868)
+				// returns Stopped so the escalation path is not taken.
+				var getCalls int
+				return &fakeClient{
+					getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+						assertKukeondTarget(t, doc)
+						getCalls++
+						if getCalls == 1 {
+							return kukeonv1.GetCellResult{
+								Cell: v1beta1.CellDoc{
+									Status: v1beta1.CellStatus{
+										State: v1beta1.CellStateReady,
+										Containers: []v1beta1.ContainerStatus{
+											{State: v1beta1.ContainerStateReady},
+										},
+									},
 								},
+								MetadataExists: true,
+							}, nil
+						}
+						return kukeonv1.GetCellResult{
+							Cell: v1beta1.CellDoc{
+								Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
 							},
-						},
-						MetadataExists: true,
-					}, nil
-				},
-				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
-					assertKukeondTarget(t, doc)
-					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
-				},
-				killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
-					t.Fatalf("KillCell must not be called when graceful stop succeeds")
-					return kukeonv1.KillCellResult{}, nil
-				},
-			},
+							MetadataExists: true,
+						}, nil
+					},
+					stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+						assertKukeondTarget(t, doc)
+						return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+					},
+					killCellFn: func(_ v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+						t.Fatalf("KillCell must not be called when graceful stop succeeds")
+						return kukeonv1.KillCellResult{}, nil
+					},
+				}
+			}(),
 			wantOutput: `kukeond stopped (cell "kukeond" in realm "kuke-system")`,
 		},
 		{

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -735,9 +735,19 @@ func printCellActions(cmd *cobra.Command, section controller.CellSection, image 
 		cmd.Println("    - cell: not provisioned")
 		return
 	}
-	if section.CellCreated {
+	switch {
+	case section.CellRecreatedDueToImageDrift:
+		// Image drift on a surviving cell record (issue #868). Surfacing the
+		// prior → desired transition is what tells the operator the rebuild
+		// actually picked up their `kuke build` output instead of silently
+		// restarting the stale container.
+		cmd.Println(fmt.Sprintf(
+			"    - cell %q: recreated (image drift: %s → %s)",
+			section.CellName, section.CellPriorImage, image,
+		))
+	case section.CellCreated:
 		cmd.Println(fmt.Sprintf("    - cell %q: created (image %s)", section.CellName, image))
-	} else {
+	default:
 		cmd.Println(fmt.Sprintf("    - cell %q: already existed", section.CellName))
 	}
 	printCgroupAction(

--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -86,6 +86,19 @@ type CellSection struct {
 	CellStartedPre              bool
 	CellStartedPost             bool
 	CellStarted                 bool
+	// CellRecreatedDueToImageDrift is true when bootstrapCell observed a
+	// persisted cell whose root container image diverged from the desired
+	// image and dropped into a stop+delete+recreate branch instead of the
+	// idempotent EnsureCell+StartCell path. Issue #868: without this branch,
+	// `kuke init --kukeond-image <new>` would silently keep starting the
+	// stale container record left behind by a prior reset, and the running
+	// daemon binary would never refresh across a `make dev-init` re-bootstrap.
+	CellRecreatedDueToImageDrift bool
+	// CellPriorImage carries the persisted root container image observed at
+	// drift detection time, so the init report can render
+	// "recreated (image drift: <old> → <new>)" instead of the misleading
+	// "already existed" line on the recreate branch.
+	CellPriorImage string
 }
 
 type BootstrapReport struct {
@@ -658,21 +671,54 @@ func (b *Exec) bootstrapCell(section *CellSection, cellDoc *v1beta1.CellDoc) err
 		section.CellStartedPre = false
 	}
 
-	var ensuredCell intmodel.Cell
+	// When the cell record survives from a prior `kuke init` (or a
+	// `kuke daemon reset` that didn't actually purge it) and the operator
+	// re-runs init against a freshly built image, the persisted root
+	// container spec must be reconciled against the desired one — otherwise
+	// EnsureCell+StartCell below would happily restart the stale image and
+	// leave the running daemon binary frozen on the previous build. Issue
+	// #868. The drift comparison is keyed on the canonical kukeond container
+	// ID; a missing match on either side counts as drift so a corrupted /
+	// partial cell record forces a recreate rather than a half-baked ensure.
+	imageDrift := false
 	if section.CellMetadataExistsPre {
+		section.CellPriorImage = lookupContainerImage(internalCellPre, consts.KukeSystemContainerName)
+		desiredImage := lookupContainerImage(cell, consts.KukeSystemContainerName)
+		if section.CellPriorImage != desiredImage {
+			imageDrift = true
+		}
+	}
+
+	var ensuredCell intmodel.Cell
+	startCellAfterEnsure := true
+	switch {
+	case imageDrift:
+		// RecreateCell stops + deletes the stale root container, rebuilds it
+		// against the desired spec, and runs StartCell internally — so the
+		// post-switch StartCell below is suppressed to avoid a redundant
+		// start cycle.
+		ensuredCell, err = b.runner.RecreateCell(cell)
+		if err != nil {
+			return fmt.Errorf("recreate kukeond cell on image drift: %w", err)
+		}
+		section.CellRecreatedDueToImageDrift = true
+		startCellAfterEnsure = false
+	case section.CellMetadataExistsPre:
 		ensuredCell, err = b.runner.EnsureCell(internalCellPre)
 		if err != nil {
 			return fmt.Errorf("%w: %w", errdefs.ErrCreateCell, err)
 		}
-	} else {
+	default:
 		ensuredCell, err = b.runner.CreateCell(cell)
 		if err != nil {
 			return fmt.Errorf("%w: %w", errdefs.ErrCreateCell, err)
 		}
 	}
 
-	if _, err = b.runner.StartCell(ensuredCell); err != nil {
-		return fmt.Errorf("failed to start cell containers: %w", err)
+	if startCellAfterEnsure {
+		if _, err = b.runner.StartCell(ensuredCell); err != nil {
+			return fmt.Errorf("failed to start cell containers: %w", err)
+		}
 	}
 
 	lookupCellPost := intmodel.Cell{
@@ -709,10 +755,34 @@ func (b *Exec) bootstrapCell(section *CellSection, cellDoc *v1beta1.CellDoc) err
 
 	section.CellCreated = !section.CellMetadataExistsPre && section.CellMetadataExistsPost
 	section.CellCgroupCreated = !section.CellCgroupExistsPre && section.CellCgroupExistsPost
-	section.CellRootContainerCreated = !section.CellRootContainerExistsPre && section.CellRootContainerExistsPost
+	// On the image-drift recreate branch the persisted record survived
+	// (CellMetadataExistsPre stays true) but the root container itself was
+	// torn down and rebuilt under the new image — surface that as "created"
+	// rather than "already existed" so printContainerAction renders the
+	// rebuild instead of misleading the operator into thinking the stale
+	// container was re-used.
+	if section.CellRecreatedDueToImageDrift {
+		section.CellRootContainerCreated = true
+	} else {
+		section.CellRootContainerCreated = !section.CellRootContainerExistsPre &&
+			section.CellRootContainerExistsPost
+	}
 	section.CellStarted = !section.CellStartedPre && section.CellStartedPost
 
 	return nil
+}
+
+// lookupContainerImage returns the Image of the container in cell whose ID
+// matches containerID. An empty string signals either "container not present"
+// or "container present but image empty" — both count as drift against any
+// non-empty desired image in bootstrapCell's comparison.
+func lookupContainerImage(cell intmodel.Cell, containerID string) string {
+	for _, c := range cell.Spec.Containers {
+		if c.ID == containerID {
+			return c.Image
+		}
+	}
+	return ""
 }
 
 func (b *Exec) bootstrapCNI(report BootstrapReport) (BootstrapReport, error) {

--- a/internal/controller/bootstrap_cell_drift_test.go
+++ b/internal/controller/bootstrap_cell_drift_test.go
@@ -1,0 +1,296 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// kukeondCellDocForTest builds a minimal CellDoc carrying a single root
+// container with the supplied image, matching the spec keys (realm/space/
+// stack/cell + KukeSystemContainerName) that bootstrapCell looks up. Mirrors
+// the shape of the production kukeondCellDoc without dragging in the bind-
+// mount plumbing the drift test does not exercise.
+func kukeondCellDocForTest(image string) *v1beta1.CellDoc {
+	return &v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{
+			Name: consts.KukeSystemCellName,
+			Labels: map[string]string{
+				consts.KukeonRealmLabelKey: consts.KukeSystemRealmName,
+				consts.KukeonSpaceLabelKey: consts.KukeSystemSpaceName,
+				consts.KukeonStackLabelKey: consts.KukeSystemStackName,
+				consts.KukeonCellLabelKey:  consts.KukeSystemCellName,
+			},
+		},
+		Spec: v1beta1.CellSpec{
+			ID:      consts.KukeSystemCellName,
+			RealmID: consts.KukeSystemRealmName,
+			SpaceID: consts.KukeSystemSpaceName,
+			StackID: consts.KukeSystemStackName,
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      consts.KukeSystemContainerName,
+					RealmID: consts.KukeSystemRealmName,
+					SpaceID: consts.KukeSystemSpaceName,
+					StackID: consts.KukeSystemStackName,
+					CellID:  consts.KukeSystemCellName,
+					Image:   image,
+					Command: "/bin/kukeond",
+				},
+			},
+		},
+	}
+}
+
+// persistedKukeondCell builds the intmodel.Cell that fakeRunner.GetCell
+// returns on the pre-lookup, simulating a cell record left behind by a prior
+// `kuke init` (or a `kuke daemon reset` that didn't actually purge it). The
+// image is parameterized so individual tests can stage drift against a
+// freshly built `kuke build` output.
+func persistedKukeondCell(image string) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name: consts.KukeSystemCellName,
+		},
+		Spec: intmodel.CellSpec{
+			ID:        consts.KukeSystemCellName,
+			RealmName: consts.KukeSystemRealmName,
+			SpaceName: consts.KukeSystemSpaceName,
+			StackName: consts.KukeSystemStackName,
+			Containers: []intmodel.ContainerSpec{
+				{
+					ID:        consts.KukeSystemContainerName,
+					RealmName: consts.KukeSystemRealmName,
+					SpaceName: consts.KukeSystemSpaceName,
+					StackName: consts.KukeSystemStackName,
+					CellName:  consts.KukeSystemCellName,
+					Root:      true,
+					Image:     image,
+				},
+			},
+		},
+	}
+}
+
+// TestBootstrapCell_ImageDriftRecreatesCell covers issue #868: a persisted
+// kukeond cell whose root container image diverges from the desired
+// `--kukeond-image` must be torn down and rebuilt rather than re-used in
+// place via EnsureCell+StartCell.
+func TestBootstrapCell_ImageDriftRecreatesCell(t *testing.T) {
+	const priorImage = "docker.io/library/kukeon-local:dev@stale"
+	const desiredImage = "docker.io/library/kukeon-local:dev@fresh"
+
+	var (
+		recreateCalled bool
+		recreateImage  string
+		ensureCalled   bool
+		createCalled   bool
+		startCallCount int
+	)
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return persistedKukeondCell(priorImage), nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		EnsureCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			ensureCalled = true
+			return intmodel.Cell{}, nil
+		},
+		CreateCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			createCalled = true
+			return intmodel.Cell{}, nil
+		},
+		RecreateCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			if len(c.Spec.Containers) > 0 {
+				recreateImage = c.Spec.Containers[0].Image
+			}
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCallCount++
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(desiredImage)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if !recreateCalled {
+		t.Fatalf("RecreateCell must be called on image drift; got Ensure=%v Create=%v",
+			ensureCalled, createCalled)
+	}
+	if ensureCalled {
+		t.Errorf("EnsureCell must not be called on the drift branch (would restart the stale image)")
+	}
+	if createCalled {
+		t.Errorf("CreateCell must not be called when metadata already exists")
+	}
+	if recreateImage != desiredImage {
+		t.Errorf("RecreateCell received image %q; want %q (the desired --kukeond-image)",
+			recreateImage, desiredImage)
+	}
+	if startCallCount != 0 {
+		t.Errorf(
+			"StartCell must not be called on the drift branch (RecreateCell runs it internally); got %d calls",
+			startCallCount,
+		)
+	}
+	if !section.CellRecreatedDueToImageDrift {
+		t.Errorf("CellSection.CellRecreatedDueToImageDrift = false; want true")
+	}
+	if section.CellPriorImage != priorImage {
+		t.Errorf("CellSection.CellPriorImage = %q; want %q", section.CellPriorImage, priorImage)
+	}
+	if !section.CellRootContainerCreated {
+		t.Errorf("CellSection.CellRootContainerCreated = false; want true (drift recreate is a rebuild)")
+	}
+}
+
+// TestBootstrapCell_SameImageEnsuresInPlace confirms the non-drift idempotent
+// path is preserved: matching persisted and desired images route through
+// EnsureCell+StartCell, no RecreateCell call.
+func TestBootstrapCell_SameImageEnsuresInPlace(t *testing.T) {
+	const image = "docker.io/library/kukeon-local:dev"
+
+	var (
+		recreateCalled bool
+		ensureCalled   bool
+		startCalled    bool
+	)
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return persistedKukeondCell(image), nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		EnsureCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			ensureCalled = true
+			return c, nil
+		},
+		RecreateCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCalled = true
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(image)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if recreateCalled {
+		t.Errorf("RecreateCell must not be called when images match")
+	}
+	if !ensureCalled {
+		t.Errorf("EnsureCell must be called on the idempotent path")
+	}
+	if !startCalled {
+		t.Errorf("StartCell must be called on the idempotent path")
+	}
+	if section.CellRecreatedDueToImageDrift {
+		t.Errorf("CellSection.CellRecreatedDueToImageDrift = true; want false (images match)")
+	}
+}
+
+// TestBootstrapCell_NoPriorMetadataCreatesFresh confirms the fresh-create
+// path is untouched: an absent persisted cell record routes through
+// CreateCell+StartCell, no drift comparison.
+func TestBootstrapCell_NoPriorMetadataCreatesFresh(t *testing.T) {
+	const image = "docker.io/library/kukeon-local:dev"
+
+	var (
+		recreateCalled bool
+		ensureCalled   bool
+		createCalled   bool
+		startCalled    bool
+	)
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return intmodel.Cell{}, errdefs.ErrCellNotFound
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return false, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return false, nil
+		},
+		CreateCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			createCalled = true
+			return c, nil
+		},
+		EnsureCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			ensureCalled = true
+			return c, nil
+		},
+		RecreateCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCalled = true
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(image)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if !createCalled {
+		t.Errorf("CreateCell must be called when no prior metadata exists")
+	}
+	if ensureCalled {
+		t.Errorf("EnsureCell must not be called when no prior metadata exists")
+	}
+	if recreateCalled {
+		t.Errorf("RecreateCell must not be called when no prior metadata exists")
+	}
+	if !startCalled {
+		t.Errorf("StartCell must be called on the fresh-create path")
+	}
+	if section.CellRecreatedDueToImageDrift {
+		t.Errorf("CellSection.CellRecreatedDueToImageDrift = true; want false (no prior metadata)")
+	}
+}

--- a/internal/controller/export_bootstrap_test.go
+++ b/internal/controller/export_bootstrap_test.go
@@ -1,0 +1,26 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+
+// BootstrapCellForTest invokes the unexported bootstrapCell on the system
+// kukeond cell path so external tests can drive the image-drift branch
+// without running the entire Bootstrap pipeline. Issue #868.
+func (b *Exec) BootstrapCellForTest(section *CellSection, doc *v1beta1.CellDoc) error {
+	return b.bootstrapCell(section, doc)
+}


### PR DESCRIPTION
## Summary

- `bootstrapCell` now compares the persisted kukeond root container image against the desired `--kukeond-image` and routes through a `RecreateCell` (stop + delete + rebuild root container) branch on drift instead of the idempotent `EnsureCell + StartCell` path that would silently restart the stale image. The init output renders `cell "kukeond": recreated (image drift: <old> → <new>)` so the operator sees the rebuild rather than the misleading "already existed" line.
- `lifecycle.StopPhase` now runs a post-stop verification after `StopCell` returns `Stopped=true`: a follow-up `GetCell` confirms no container task remains `Ready`. If one does (the runner's per-container `StopContainer` errors are logged-and-continue rather than aggregated into the `StopCell` result, so a soft-fail surfaces here), `KillCell` is escalated and the cell is re-checked. A surviving task even after kill surfaces a hard error so the caller (`kuke daemon reset`) refuses to proceed to `DeleteCell` against a live shim, addressing #868's reset-path AC.

## Scope notes

- **Drift detection is ref-string-based, not digest-based.** A persisted image of `docker.io/library/kukeon-local:dev` matched against a desired `docker.io/library/kukeon-local:dev@<different-sha>` (the canonical `make dev-init` rebuild-the-same-tag case) does **not** trip the recreate branch — the strings match. PR #869 (Layer 1) is the chain-digest defense for this scenario at the script layer. The init-side digest-aware comparison would need a runner method to inspect the running container's resolved image digest and is left to a follow-up; the reset-path fix below is what unsticks #857's `make dev-init` repro in practice.
- The reset-path verification reuses the existing `KillCell` escalation — no new RPC surface; only the call flow inside `StopPhase` changed. The escalation notice prints `"force-killed after stop returned success but task survived"` so the operator distinguishes it from the existing `"force-killed after <timeout> grace period expired"` path.
- The post-stop verification is shared across `kuke daemon stop`/`restart`/`reset` (all of which call `StopPhase`); the corresponding table-driven tests were updated to make their fake `getCellFn` stateful (Ready on the pre-stop branch-picker call, Stopped on the post-stop verify) so the existing assertions on the success path still hold.

## Test plan

- [x] `make test` — full suite passes locally (cached after the first run).
- [x] `go vet ./...` clean.
- [x] `make dev-init` — full bootstrap loop passes including the daemon-parity check, the chain-digest guard (`running kukeond container chain ... matches just-built`), the kuke attach smoke against a kuketty-wrapped cell, and the nested-mode parent attach plumbing preservation check.
- [x] Direct repro of the same-image idempotent path (`sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev` on a warm host): renders `cell "kukeond": already existed`, no spurious recreate.
- [x] New unit tests: `TestBootstrapCell_ImageDriftRecreatesCell`, `TestBootstrapCell_SameImageEnsuresInPlace`, `TestBootstrapCell_NoPriorMetadataCreatesFresh`, `TestStopPhase_GracefulSuccessButTaskSurvivesEscalates`, `TestStopPhase_PostKillVerificationStillRunningErrors`, `TestDaemonReset_StopSucceedsButTaskSurvivesEscalatesToKill`, `TestDaemonReset_StopSucceedsAndKillCannotClearSurvivor`.

Closes #868