### PR TITLE
docs: sweep stale kuke apply -b/-c refs from kuke-apply.md and config.md

### DIFF
--- a/docs/site/cli/kuke-apply.md
+++ b/docs/site/cli/kuke-apply.md
@@ -1,51 +1,35 @@
 # kuke apply
 
-Reconcile the host to one of three source types:
-
-- `-f <file>` — a YAML manifest (or `-` for stdin), possibly multi-document. Kukeon reconciles each resource in the file.
-- `-b <blueprint>` — a daemon-stored CellBlueprint, resolved by name in the scope named by `--realm`/`--space`/`--stack`. Substitutes scalar `--param` values, materializes a cell spec, and reconciles it against the live cell.
-- `-c <config>` — a daemon-stored CellConfig, resolved from the same scope. Materializes the Config's cell spec (stable-named) and reconciles it against the live cell.
+Reconcile the host from a YAML manifest:
 
 ```
-kuke apply (-f <file> | -b <blueprint> | -c <config>) [flags]
+kuke apply -f <file> [flags]
 ```
 
-The `-b`/`-c` forms route the materialised cell through the same daemon-side reconcile path as `-f`: a missing cell is created and started; an identical live cell is a no-op; a divergent live cell is stopped, updated, and started (no attach). Equivalent specs from `-f`, `-b`, or `-c` all converge on the same diff. To create-and-attach instead of reconcile, use [`kuke run`](kuke-run.md).
+`kuke apply` reads a YAML manifest (possibly multi-document), reconciles each resource against the live cluster, and reports what changed. To create-and-attach instead of reconcile, use [`kuke run`](kuke-run.md).
 
 ## Flags
 
-| Flag                | Default                                                | Description                                                                                                                                                                                                                                                                                                 |
-| ------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--file`, `-f`      | _(one of `-f`/`-b`/`-c`)_                              | Path to a YAML file, or `-` for stdin; mutually exclusive with `-b`/`-c`                                                                                                                                                                                                                                    |
-| `--blueprint`, `-b` | _(one of `-f`/`-b`/`-c`)_                              | Daemon-stored CellBlueprint name to reconcile, resolved from the scope named by `--realm`/`--space`/`--stack`; mutually exclusive with `-f`/`-c`. Substitutes scalar `--param` values; without `--name`, materializes a fresh `<prefix>-<6hex>` cell name                                                   |
-| `--config`, `-c`    | _(one of `-f`/`-b`/`-c`)_                              | Daemon-stored CellConfig name to reconcile, resolved from the same scope; mutually exclusive with `-f`/`-b`. The cell name is the Config's deterministic stable name unless `--name` overrides it. Rejects `--param`/`--param-file` (edit the Config's `spec.values` instead)                               |
-| `--name`            | `<prefix>-<6hex>` (`-b`) / Config's stable name (`-c`) | Override the materialized cell name. Valid with `-b`/`-c`; rejected with `-f` (where `metadata.name` is the cell name verbatim)                                                                                                                                                                             |
-| `--param`           | (empty, repeatable)                                    | Scalar parameter override as `KEY=VALUE`. Valid with `-b` only. Each `KEY` must be declared in `spec.parameters[]`. Wins over the parameter's default and over `--param-file` on the same key. Rejected with `-c` — a CellConfig carries its own `spec.values`; edit the Config instead. Rejected with `-f` |
-| `--param-file`      | (empty)                                                | File of `KEY=VALUE` lines whose values seed scalar parameters; one per line, `#` starts a comment. Valid with `-b` only. CLI `--param` wins on duplicate keys. Rejected with `-c` (same reason as `--param`) and with `-f`                                                                                  |
-| `--realm`           | `default`                                              | Realm to resolve the Blueprint/Config from                                                                                                                                                                                                                                                                  |
-| `--space`           | (unset)                                                | Space to resolve the Blueprint/Config from                                                                                                                                                                                                                                                                  |
-| `--stack`           | (unset)                                                | Stack to resolve the Blueprint/Config from                                                                                                                                                                                                                                                                  |
-| `--output`, `-o`    | (human-readable)                                       | Output format: `json`, `yaml`                                                                                                                                                                                                                                                                               |
+| Flag             | Default          | Description                           |
+| ---------------- | ---------------- | ------------------------------------- |
+| `--file`, `-f`   | _(required)_     | Path to a YAML file, or `-` for stdin |
+| `--output`, `-o` | (human-readable) | Output format: `json`, `yaml`         |
 
 Plus all [global flags](kuke.md).
 
-`-f`, `-b`, and `-c` are mutually exclusive; exactly one is required.
-
 ## Input
 
-- **Single document** (`-f`): one resource.
-- **Multi-document** (`-f`): any number of resources separated by `---`. Kukeon applies them in dependency order (realm → space → stack → cell → container), regardless of the order in the file.
+- **Single document**: one resource.
+- **Multi-document**: any number of resources separated by `---`. Kukeon applies them in dependency order (realm → space → stack → cell → container), regardless of the order in the file.
 - **Stdin** (`-f -`): reads the manifest from stdin, so piping works:
 
   ```bash
   cat cell.yaml | sudo kuke apply -f -
   ```
 
-- **Daemon-stored ref** (`-b`/`-c`): the daemon reads the named Blueprint or Config from its own store, materializes one Cell spec, and reconciles it. Equivalent to writing the materialized YAML to a file and running `kuke apply -f`, with the lineage check below applied on top.
-
 ## Per-resource outcome
 
-For each resource in the manifest (or for the single materialised cell on `-b`/`-c`), `apply` emits one of:
+For each resource in the manifest, `apply` emits one of:
 
 - `created` — resource didn't exist; created.
 - `updated` — resource existed with a different spec; reconciled. The printed diff follows.
@@ -63,38 +47,12 @@ Cell "wp": created
 
 ## Idempotence
 
-Applying the same manifest twice is safe. The second run should report `unchanged` for every resource. The same holds for `-b` (with `--name` pinned) and for `-c` (whose stable name pins the cell identity automatically).
-
-## Blueprints and Configs
-
-`-b`/`--blueprint` and `-c`/`--config` reconcile a single Cell materialised from a daemon-stored template instead of from an on-disk file. They are resolved by name in the scope named by `--realm`/`--space`/`--stack` — the same lookup `kuke get blueprint <name>` / `kuke get config <name>` performs. `--realm` defaults to `default`; `--space` and `--stack` are unset by default, so a realm-scoped Blueprint/Config (no space or stack coordinate) is findable without flags.
-
-The two verbs cover different operator workflows:
-
-- **`-b <blueprint>` — reconcile from a template + params.** A CellBlueprint is a template with declared `spec.parameters[]`. `kuke apply -b` resolves the Blueprint, layers `--param-file` then `--param KEY=VALUE` over the parameter defaults, materializes a Cell, and reconciles it. Without `--name`, the materialized cell name is a fresh `<prefix>-<6hex>` — pin it with `--name` for idempotent re-apply.
-- **`-c <config>` — reconcile from a Config.** A CellConfig binds a CellBlueprint reference to concrete scalar values plus structural slot fills (repo bindings, secret references). The cell name is the Config's stable name. `--param`/`--param-file` are rejected with `-c` because the Config already owns its values — edit the Config instead. `--name` is permitted but the Config's stable name is the safe default.
-
-Unlike [`kuke run -c`](kuke-run.md#identity-state-machine-for--c), `kuke apply -c` does **not** attach to the live cell after reconciling, does **not** distinguish stopped from running (it converges spec, not lifecycle), and **does** rewrite a live cell whose spec differs from the current materialisation. To attach to the materialised cell after `apply`, use [`kuke attach <cell>`](kuke-attach.md).
-
-### Lineage check (refusing silent takeover)
-
-Before reconciling on `-b`/`-c`, `apply` reads the live cell at the materialised name and refuses to proceed unless its lineage matches the source the operator named:
-
-| Live cell                                                                                                 | Behavior                                                                                                                                |
-| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| No cell with that name                                                                                    | Nothing to overwrite — reconcile proceeds (create-and-start).                                                                           |
-| Carries the matching label (`kukeon.io/blueprint=<name>` for `-b`, or `kukeon.io/config=<name>` for `-c`) | Reconcile proceeds.                                                                                                                     |
-| Carries a different lineage label (a sibling Blueprint or Config)                                         | Refused: `cell "<name>" exists with lineage kukeon.io/{blueprint,config}=<other>; refusing to reconcile against <wantKey>=<wantValue>`. |
-| Carries no lineage label (hand-built cell)                                                                | Refused: `cell "<name>" exists with lineage no lineage label; refusing to reconcile against <wantKey>=<wantValue>`.                     |
-
-So `kuke apply -b/-c` never silently takes over an unrelated cell. To intentionally overwrite, delete the existing cell first (`kuke delete cell <name>`) and re-run `apply`.
-
-See [`kind: CellBlueprint`](../manifests/blueprint.md) and [`kind: CellConfig`](../manifests/config.md) for the full manifest reference.
+Applying the same manifest twice is safe. The second run should report `unchanged` for every resource.
 
 ## Exit codes
 
 - `0` — every resource succeeded.
-- non-zero — at least one resource failed (or the lineage check refused). Other resources may have succeeded; check the output.
+- non-zero — at least one resource failed. Other resources may have succeeded; check the output.
 
 ## Examples
 
@@ -123,12 +81,6 @@ EOF
 
 # JSON output for scripting
 sudo kuke apply -f cell.yaml -o json
-
-# Reconcile from a daemon-stored CellBlueprint with a scalar param override and a pinned name (idempotent)
-sudo kuke apply -b dev --realm kuke-system --name dev-shell --param PROJECT_DIR=kukeon
-
-# Reconcile from a daemon-stored CellConfig (stable-named; safe to re-run)
-sudo kuke apply -c kukeon-dev --realm kuke-system
 ```
 
 ## Related

--- a/docs/site/manifests/config.md
+++ b/docs/site/manifests/config.md
@@ -97,7 +97,7 @@ A `CellConfig` materializes **at most one** live cell within its scope. The cell
 The matching contract:
 
 - Every cell `kuke run -c` materializes carries the `kukeon.io/config=<name>` back-reference label. The runtime locates the at-most-one live cell a Config owns by listing cells in the Config's scope with that label.
-- When the in-cluster cell's spec diverges from the Config's current spec (after re-resolving scalar values and slot fills), `kuke run -c` refuses to attach and points at [`kuke apply -c <config>`](../cli/kuke-apply.md) to reconcile — `run` stays a pure read/materialize verb, and destructive updates (stop, update, start) route through `kuke apply -c`. The full identity state machine (no cell → materialize, running → attach, stopped → start-then-attach, divergent → refuse with `apply -c` pointer, error state → refuse with `kuke delete cell` pointer) lives in [`kuke run -c`](../cli/kuke-run.md).
+- When the in-cluster cell's spec diverges from the Config's current spec (after re-resolving scalar values and slot fills), `kuke run -c` refuses to attach and points at `kuke restart cell <name>` to reconcile — `run` stays a pure read/materialize verb, and destructive updates (stop, update, start) route through `kuke restart cell <name>`. The full identity state machine (no cell → materialize, running → attach, stopped → start-then-attach, divergent → refuse with `kuke restart cell <name>` pointer, error state → refuse with `kuke delete cell` pointer) lives in [`kuke run -c`](../cli/kuke-run.md).
 
 This is the structural contrast with a [`CellBlueprint`](blueprint.md): a blueprint is always-fresh (`<prefix>-<6hex>` per invocation), a config is always-named (`<configName>` per binding).
 


### PR DESCRIPTION
## Summary

Post-#845 cleanup: `kuke apply -b/-c` was removed in #845 (`kuke apply` is now `-f` only), but stale documentation references survived in two files:

- **`docs/site/cli/kuke-apply.md`** — restructured the page to describe `-f` only:
  - Removed the three-source-type preamble, synopsis line, and `-b`/`-c` paragraph
  - Reduced the Flags table to just `--file/-f` and `--output/-o`
  - Removed the mutual-exclusivity line
  - Removed the "Daemon-stored ref" input type
  - Removed the "or for the single materialised cell on -b/-c" qualifier
  - Removed the `-b`/`-c` idempotence paragraph extension
  - Removed the entire "Blueprints and Configs" section (including the lineage-check subsection)
  - Removed the `-b`/`-c` examples
  - Retargeted "lineage check refused" exit code reference to generic "at least one resource failed"

- **`docs/site/manifests/config.md`** (line 100) — retargeted the divergence-reconcile pointer from `kuke apply -c <config>` to `kuke restart cell <name>`, matching the wording PR #870 / #874 settled on

## Test plan

- [x] `pre-commit run --files` — trailing-whitespace, end-of-file-fixer, prettier, and other applicable hooks pass
- [x] Visual review of both `.md` files — no remaining `apply -b` or `apply -c` references

Closes #876