### PR TITLE
feat: add kuke create blueprint scaffolding subcommand

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -288,6 +288,14 @@ var (
 	KUKE_CREATE_CONFIG_STACK = DefineKV("KUKE_CREATE_CONFIG_STACK", "kuke/create/config/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CONFIG_BLUEPRINT = DefineKV("KUKE_CREATE_CONFIG_BLUEPRINT", "kuke/create/config/blueprint")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_BLUEPRINT_NAME = DefineKV("KUKE_CREATE_BLUEPRINT_NAME", "kuke/create/blueprint/name")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_BLUEPRINT_REALM = DefineKV("KUKE_CREATE_BLUEPRINT_REALM", "kuke/create/blueprint/realm", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_BLUEPRINT_SPACE = DefineKV("KUKE_CREATE_BLUEPRINT_SPACE", "kuke/create/blueprint/space", "default")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_CREATE_BLUEPRINT_STACK = DefineKV("KUKE_CREATE_BLUEPRINT_STACK", "kuke/create/blueprint/stack", "default")
 
 	// Get command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/create/blueprint/blueprint.go
+++ b/cmd/kuke/create/blueprint/blueprint.go
@@ -1,0 +1,213 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package blueprint implements `kuke create blueprint <name>` (issue #816,
+// child of the #814 epic:create umbrella). A CellBlueprint is declaratively
+// complex (containers, scalar parameters, repo/secret slots), so per the
+// umbrella's per-kind pattern selection this subcommand emits a starter YAML
+// to stdout — the operator edits in their preferred editor and pipes to
+// `kuke apply -f -`. Nothing is written to the daemon: pure scaffolding, not a
+// parallel write path.
+package blueprint
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/create/shared"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// NewBlueprintCmd builds `kuke create blueprint <name>`.
+func NewBlueprintCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "blueprint [name]",
+		Aliases: []string{"bp"},
+		Short:   "Scaffold a kind: CellBlueprint starter YAML (stdout)",
+		Long: `Scaffold a starter CellBlueprint YAML to stdout.
+
+Emits a syntactically-valid CellBlueprint document with a single placeholder
+container, the operator's --realm/--space/--stack as scope, and inline
+` + "`# TODO`" + ` markers on the required ` + "`image:`" + ` field plus comment markers for
+optional sections (parameters, ports, volumes, repos, secrets) so operators
+know what they can add.
+
+Operator workflow:
+
+  kuke create blueprint web > web.yaml
+  $EDITOR web.yaml          # fill image, add parameters/repos/secrets/...
+  kuke apply -f web.yaml
+
+No daemon call — pure stdout emission.`,
+		Args:          cobra.MaximumNArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runCreateBlueprint,
+	}
+
+	cmd.Flags().String("realm", "", "Realm that owns the blueprint")
+	_ = viper.BindPFlag(config.KUKE_CREATE_BLUEPRINT_REALM.ViperKey, cmd.Flags().Lookup("realm"))
+
+	cmd.Flags().String("space", "", "Space that owns the blueprint")
+	_ = viper.BindPFlag(config.KUKE_CREATE_BLUEPRINT_SPACE.ViperKey, cmd.Flags().Lookup("space"))
+
+	cmd.Flags().String("stack", "", "Stack that owns the blueprint")
+	_ = viper.BindPFlag(config.KUKE_CREATE_BLUEPRINT_STACK.ViperKey, cmd.Flags().Lookup("stack"))
+
+	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
+	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
+	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
+
+	return cmd
+}
+
+func runCreateBlueprint(cmd *cobra.Command, args []string) error {
+	name, err := shared.RequireNameArgOrDefault(
+		cmd,
+		args,
+		"blueprint",
+		viper.GetString(config.KUKE_CREATE_BLUEPRINT_NAME.ViperKey),
+	)
+	if err != nil {
+		return err
+	}
+
+	realm := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_BLUEPRINT_REALM.ViperKey))
+	if realm == "" {
+		realm = strings.TrimSpace(config.KUKE_CREATE_BLUEPRINT_REALM.ValueOrDefault())
+	}
+	space := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_BLUEPRINT_SPACE.ViperKey))
+	if space == "" {
+		space = strings.TrimSpace(config.KUKE_CREATE_BLUEPRINT_SPACE.ValueOrDefault())
+	}
+	stack := strings.TrimSpace(viper.GetString(config.KUKE_CREATE_BLUEPRINT_STACK.ViperKey))
+	if stack == "" {
+		stack = strings.TrimSpace(config.KUKE_CREATE_BLUEPRINT_STACK.ValueOrDefault())
+	}
+
+	return emitBlueprintYAML(cmd.OutOrStdout(), name, realm, space, stack)
+}
+
+// emitBlueprintYAML renders the CellBlueprint scaffold. The output is
+// hand-formatted (rather than yaml.Marshal'd from a CellBlueprintDoc) so it
+// can carry inline `# TODO` / `# optional` comments next to fields the
+// operator must fill or may opt into — yaml.v3's struct marshaler cannot
+// attach comments without dropping to its Node API, which would obscure the
+// simple shape we emit here. The same approach is used by `kuke create
+// config` (cmd/kuke/create/config/config.go).
+func emitBlueprintYAML(out io.Writer, name, realm, space, stack string) error {
+	var b strings.Builder
+
+	b.WriteString("apiVersion: ")
+	b.WriteString(string(v1beta1.APIVersionV1Beta1))
+	b.WriteString("\n")
+	b.WriteString("kind: ")
+	b.WriteString(string(v1beta1.KindCellBlueprint))
+	b.WriteString("\n")
+
+	b.WriteString("metadata:\n")
+	fmt.Fprintf(&b, "  name: %s\n", yamlScalar(name))
+	fmt.Fprintf(&b, "  realm: %s\n", yamlScalar(realm))
+	if space != "" {
+		fmt.Fprintf(&b, "  space: %s\n", yamlScalar(space))
+	}
+	if stack != "" {
+		fmt.Fprintf(&b, "  stack: %s\n", yamlScalar(stack))
+	}
+
+	b.WriteString("spec:\n")
+	b.WriteString(
+		"  # prefix: " + yamlScalar(
+			name,
+		) + "  # optional: cell-name prefix used by `kuke run -b` (defaults to metadata.name)\n",
+	)
+	b.WriteString("  # parameters:\n")
+	b.WriteString("  #   - name: KEY\n")
+	b.WriteString("  #     # description: short explanation shown in --help\n")
+	b.WriteString("  #     # default: <value>      # omit to require a value at run time\n")
+	b.WriteString("  #     # required: true        # fail fast if no default and no run-time override\n")
+	b.WriteString("  cell:\n")
+	b.WriteString("    containers:\n")
+	b.WriteString("      - id: main\n")
+	b.WriteString("        image: \"\" # TODO (required)\n")
+	b.WriteString("        # command: <entrypoint override>\n")
+	b.WriteString("        # args: []\n")
+	b.WriteString("        # env: [\"KEY=value\"]\n")
+	b.WriteString("        # ports: [\"8080/tcp\"]\n")
+	b.WriteString("        # volumes:\n")
+	b.WriteString("        #   - source: <host-path-or-named-volume>\n")
+	b.WriteString("        #     target: /in/container\n")
+	b.WriteString("        #     # readOnly: true\n")
+	b.WriteString("        # repos:\n")
+	b.WriteString(
+		"        #   - name: <slot-name>          # leave url empty to declare a fillable slot for CellConfig\n",
+	)
+	b.WriteString("        #     target: /src/app\n")
+	b.WriteString("        #     # url: <inline-url>        # set to bake the repo into the blueprint\n")
+	b.WriteString("        #     # required: true\n")
+	b.WriteString("        # secrets:\n")
+	b.WriteString("        #   - name: <slot-name>\n")
+	b.WriteString("        #     mode: env                  # or \"file\"\n")
+	b.WriteString("        #     envName: MY_ENV            # required when mode=env\n")
+	b.WriteString("        #     # mountPath: /run/secrets/foo  # required when mode=file\n")
+	b.WriteString("        #     # required: true\n")
+
+	_, err := io.WriteString(out, b.String())
+	return err
+}
+
+// yamlScalar formats a string scalar for the emitted YAML. Bare names made of
+// [A-Za-z0-9-_./] stay unquoted (matching how yaml.v3 round-trips them);
+// anything else — including reserved bare scalars like "true" or "null" that
+// YAML would type as bool/null — is double-quoted with strconv.Quote, whose
+// escape set (\\, \", \n, \t, \r, \uXXXX, \xHH) is a subset of YAML 1.2's
+// double-quoted scalar escapes. Mirrors the helper in cmd/kuke/create/config.
+func yamlScalar(s string) string {
+	if s == "" {
+		return `""`
+	}
+	if needsQuoting(s) {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+func needsQuoting(s string) bool {
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.' || r == '/':
+		default:
+			return true
+		}
+	}
+	return isReservedBareScalar(s)
+}
+
+func isReservedBareScalar(s string) bool {
+	switch strings.ToLower(s) {
+	case "true", "false", "yes", "no", "on", "off", "null", "~":
+		return true
+	}
+	return false
+}

--- a/cmd/kuke/create/blueprint/blueprint_test.go
+++ b/cmd/kuke/create/blueprint/blueprint_test.go
@@ -1,0 +1,215 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blueprint_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	blueprintcmd "github.com/eminwux/kukeon/cmd/kuke/create/blueprint"
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+// runScaffold executes the subcommand with the given args/flags and returns
+// stdout. Centralizes the SetOut/SetErr boilerplate so individual cases stay
+// focused on the assertion they care about.
+func runScaffold(t *testing.T, args []string, flags map[string]string) string {
+	t.Helper()
+	t.Cleanup(viper.Reset)
+
+	cmd := blueprintcmd.NewBlueprintCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	for k, v := range flags {
+		if err := cmd.Flags().Set(k, v); err != nil {
+			t.Fatalf("set flag %s=%s: %v", k, v, err)
+		}
+	}
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v\nOutput: %s", err, buf.String())
+	}
+	return buf.String()
+}
+
+func TestNewBlueprintCmd_RequiresName(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	cmd := blueprintcmd.NewBlueprintCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatalf("expected name-required error, got nil")
+	}
+}
+
+func TestNewBlueprintCmd_DefaultsScope(t *testing.T) {
+	// No flags set — scope must default per cmd/config/env.go (realm/space/stack = "default").
+	out := runScaffold(t, []string{"web"}, nil)
+
+	doc, err := parser.ParseDocument(0, []byte(out))
+	if err != nil {
+		t.Fatalf("ParseDocument failed on default-scope scaffold: %v\nYAML:\n%s", err, out)
+	}
+	if doc.Kind != v1beta1.KindCellBlueprint {
+		t.Fatalf("parsed kind = %q, want %q", doc.Kind, v1beta1.KindCellBlueprint)
+	}
+	if doc.CellBlueprintDoc == nil {
+		t.Fatalf("expected CellBlueprintDoc, got nil")
+	}
+	md := doc.CellBlueprintDoc.Metadata
+	if md.Name != "web" {
+		t.Errorf("metadata.name = %q, want %q", md.Name, "web")
+	}
+	if md.Realm != "default" || md.Space != "default" || md.Stack != "default" {
+		t.Errorf("scope = %+v, want realm=default space=default stack=default", md)
+	}
+}
+
+func TestNewBlueprintCmd_RespectsScopeFlags(t *testing.T) {
+	out := runScaffold(t, []string{"web"}, map[string]string{
+		"realm": "production",
+		"space": "team-a",
+		"stack": "frontend",
+	})
+
+	doc, err := parser.ParseDocument(0, []byte(out))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v\nYAML:\n%s", err, out)
+	}
+	md := doc.CellBlueprintDoc.Metadata
+	if md.Realm != "production" || md.Space != "team-a" || md.Stack != "frontend" {
+		t.Errorf("scope = %+v, want realm=production space=team-a stack=frontend", md)
+	}
+}
+
+func TestNewBlueprintCmd_EmitsRequiredHeader(t *testing.T) {
+	out := runScaffold(t, []string{"web"}, nil)
+
+	wantLines := []string{
+		"apiVersion: " + string(v1beta1.APIVersionV1Beta1),
+		"kind: " + string(v1beta1.KindCellBlueprint),
+		"metadata:",
+		"  name: web",
+		"  realm: default",
+		"spec:",
+		"  cell:",
+		"    containers:",
+		"      - id: main",
+	}
+	for _, line := range wantLines {
+		if !strings.Contains(out, line) {
+			t.Errorf("output missing required line %q\nGot:\n%s", line, out)
+		}
+	}
+}
+
+func TestNewBlueprintCmd_EmitsImageTODO(t *testing.T) {
+	out := runScaffold(t, []string{"web"}, nil)
+
+	// The image field is the only required field per container; it must carry a
+	// `# TODO (required)` marker so the operator can't miss it.
+	if !strings.Contains(out, `image: "" # TODO (required)`) {
+		t.Errorf("scaffold missing required image TODO marker\nGot:\n%s", out)
+	}
+}
+
+func TestNewBlueprintCmd_EmitsOptionalCommentMarkers(t *testing.T) {
+	out := runScaffold(t, []string{"web"}, nil)
+
+	// AC: comment markers for parameters, ports, volumes (AC says "volumeMounts"
+	// but the model field is `volumes`), repos, secrets.
+	wantMarkers := []string{
+		"# parameters:",
+		"# ports:",
+		"# volumes:",
+		"# repos:",
+		"# secrets:",
+	}
+	for _, marker := range wantMarkers {
+		if !strings.Contains(out, marker) {
+			t.Errorf("output missing optional-section marker %q\nGot:\n%s", marker, out)
+		}
+	}
+}
+
+func TestNewBlueprintCmd_ScaffoldParsesAndValidates(t *testing.T) {
+	// The scaffold must parse cleanly via the same loader `kuke apply -f` uses.
+	// Empty image is acceptable at validate time for a Blueprint (validation is
+	// structural; the image-required check is enforced downstream at run time),
+	// so the scaffold itself satisfies both ParseDocument and ValidateDocument.
+	out := runScaffold(t, []string{"web"}, nil)
+
+	doc, err := parser.ParseDocument(0, []byte(out))
+	if err != nil {
+		t.Fatalf("ParseDocument failed: %v\nYAML:\n%s", err, out)
+	}
+	if vErr := parser.ValidateDocument(doc); vErr != nil {
+		t.Fatalf("ValidateDocument failed: %v\nYAML:\n%s", vErr, out)
+	}
+}
+
+func TestNewBlueprintCmd_RoundTripAfterFillingImage(t *testing.T) {
+	// AC round-trip: after the operator fills the required `image:` field, the
+	// scaffold must apply cleanly. Simulate the edit by string-substituting the
+	// TODO placeholder for a real image, then re-parse + re-validate.
+	out := runScaffold(t, []string{"web"}, nil)
+
+	filled := strings.Replace(out,
+		`image: "" # TODO (required)`,
+		`image: alpine:latest`,
+		1,
+	)
+	if filled == out {
+		t.Fatalf("test guard: image TODO line not found in scaffold; scaffold drift?\nGot:\n%s", out)
+	}
+
+	doc, err := parser.ParseDocument(0, []byte(filled))
+	if err != nil {
+		t.Fatalf("ParseDocument failed after image fill: %v\nYAML:\n%s", err, filled)
+	}
+	if vErr := parser.ValidateDocument(doc); vErr != nil {
+		t.Fatalf("ValidateDocument failed after image fill: %v\nYAML:\n%s", vErr, filled)
+	}
+	if got := doc.CellBlueprintDoc.Spec.Cell.Containers[0].Image; got != "alpine:latest" {
+		t.Errorf("container.image = %q, want %q", got, "alpine:latest")
+	}
+}
+
+func TestNewBlueprintCmd_QuotesUnsafeName(t *testing.T) {
+	// Names that aren't bare-YAML-safe must be double-quoted in the emitted
+	// document so they round-trip as strings (not parsed as bool/null/numeric).
+	out := runScaffold(t, []string{"name with spaces"}, nil)
+
+	if !strings.Contains(out, `name: "name with spaces"`) {
+		t.Errorf("expected quoted name in metadata\nGot:\n%s", out)
+	}
+
+	doc, err := parser.ParseDocument(0, []byte(out))
+	if err != nil {
+		t.Fatalf("ParseDocument failed on quoted-name scaffold: %v\nYAML:\n%s", err, out)
+	}
+	if doc.CellBlueprintDoc.Metadata.Name != "name with spaces" {
+		t.Errorf("metadata.name = %q, want %q", doc.CellBlueprintDoc.Metadata.Name, "name with spaces")
+	}
+}

--- a/cmd/kuke/create/create.go
+++ b/cmd/kuke/create/create.go
@@ -19,6 +19,7 @@ package create
 import (
 	"strings"
 
+	blueprintcmd "github.com/eminwux/kukeon/cmd/kuke/create/blueprint"
 	cellcmd "github.com/eminwux/kukeon/cmd/kuke/create/cell"
 	configcmd "github.com/eminwux/kukeon/cmd/kuke/create/config"
 	containercmd "github.com/eminwux/kukeon/cmd/kuke/create/container"
@@ -35,7 +36,7 @@ func NewCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Aliases: []string{"c"},
-		Short:   "Create Kukeon resources (realm, space, stack, cell, container, config)",
+		Short:   "Create Kukeon resources (realm, space, stack, cell, container, config, blueprint)",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
@@ -50,6 +51,7 @@ func NewCreateCmd() *cobra.Command {
 		cellcmd.NewCellCmd(),
 		containercmd.NewContainerCmd(),
 		configcmd.NewConfigCmd(),
+		blueprintcmd.NewBlueprintCmd(),
 	)
 
 	return cmd
@@ -57,7 +59,7 @@ func NewCreateCmd() *cobra.Command {
 
 // completeCreateSubcommands provides shell completion for create subcommand names.
 func completeCreateSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "container", "config"}
+	subcommands := []string{"realm", "space", "stack", "cell", "container", "config", "blueprint"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/create/create_test.go
+++ b/cmd/kuke/create/create_test.go
@@ -41,7 +41,7 @@ func TestNewCreateCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Create Kukeon resources (realm, space, stack, cell, container, config)"
+				expected := "Create Kukeon resources (realm, space, stack, cell, container, config, blueprint)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -82,6 +82,7 @@ func TestNewCreateCmdRegistersSubcommands(t *testing.T) {
 		{name: "cell"},
 		{name: "container"},
 		{name: "config"},
+		{name: "blueprint"},
 	}
 
 	for _, tt := range tests {
@@ -104,7 +105,7 @@ func TestNewCreateCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "container", "config"}
+	expected := []string{"realm", "space", "stack", "cell", "container", "config", "blueprint"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}


### PR DESCRIPTION
## Summary

- Add ` + "`kuke create blueprint <name>`" + ` — emits a starter CellBlueprint YAML to stdout for the operator to edit and pipe to `kuke apply -f -`. Pure scaffolding, no daemon call (sibling pattern to `kuke create config`, the daemon-backed scaffolder that ships from a Blueprint).
- Scope flags `--realm`/`--space`/`--stack` default to `default` per `cmd/config/env.go` (matching `KUKE_CREATE_CONFIG_*`). Metadata realm is always emitted; space/stack are emitted when non-empty.
- The scaffold's required `image:` field carries an inline `# TODO (required)` marker; optional sections (parameters, ports, volumes, repos, secrets) appear as `# ...` comment markers so operators know what's available.

## Notes (AC vs. codebase reinterpretations)

A heads-up comment was posted on #816 before coding: the AC's example template uses field names that don't match `pkg/api/model/v1beta1/cellblueprint.go`:
- Container's field is `id`, not `name` (`BlueprintContainer.ID`)
- Volume field is `volumes`, not `volumeMounts` (`BlueprintContainer.Volumes []VolumeMount`)
- `repos:` and `secrets:` are container-level (`BlueprintContainer.Repos` / `.Secrets`), not `spec.`-level
- `CellProfileParameter` has no `type` field — shape is `name`/`description`/`default`/`required`
- `apiVersion` is `v1beta1` (`APIVersionV1Beta1`), not `kukeon.io/v1beta1`

The implementation uses the actual model fields. AC intent — comment markers for optional sections, TODO marker on required `image:` — is preserved.

## Test plan

- [x] `make test` — full project test suite (cmd/kuke/create/blueprint + cmd/kuke/create with updated subcommand/completion lists)
- [x] `GOWORK=off go build ./...` and `GOWORK=off go vet ./...` (clean)
- [x] `pre-commit run --files ...` (clean after golangci-lint auto-fix on long lines)
- [x] Manual smoke: `./kuke create blueprint myapp` and `./kuke create blueprint myapp --realm production --space team-a` emit the expected YAML
- [x] Round-trip test in `blueprint_test.go` — scaffold parses and validates via `internal/apply/parser.ParseDocument` + `ValidateDocument`; same after string-substituting `image: ""` with `alpine:latest` (the operator-edit step the AC describes)
- [ ] `make dev-init` and live `kuke apply -f` round-trip — deferred to the reviewer's environment (this PR doesn't touch the daemon or the build path, so the dev-init smoke isn't gated by this diff)

## Acceptance criteria

- [x] New subcommand `cmd/kuke/create/blueprint/blueprint.go` registered in `cmd/kuke/create/create.go`
- [x] Emits a syntactically-valid CellBlueprint YAML to stdout (round-trip via `internal/apply/parser` covered in tests)
- [x] Uses operator's `--realm`/`--space`/`--stack` flags, defaulting per `cmd/config/env.go`
- [x] Comment markers (`# ...`) for optional sections (parameters, ports, volumes [model field; AC said volumeMounts], repos, secrets)
- [x] Required `image:` field carries a `# TODO (required)` marker
- [x] No daemon call — pure stdout emission
- [x] Round-trip parses cleanly after the operator fills `image:` (covered by `TestNewBlueprintCmd_RoundTripAfterFillingImage`)
- [x] Tests in `cmd/kuke/create/blueprint/blueprint_test.go` cover emission shape (field assertions + parse-back round trip)

Closes #816