### PR TITLE
feat(get): shared OutputFormatWide + AGE helper, retire --show-controllers/CGROUP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,13 @@ make dev-init
 The daemon-parity tail of the output (the regression guard) must read:
 
 ```
-NAME         NAMESPACE              STATE  CGROUP
------------  ---------------------  -----  -------------------
-default      default.kukeon.io      Ready  /kukeon/default
-kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+NAME         STATE  AGE
+-----------  -----  ---
+default      Ready  <age>
+kuke-system  Ready  <age>
 ```
 
-Both `kuke get realms` and `kuke get realms --no-daemon` must produce that output. If only the `--no-daemon` list is populated, the daemon's view of `/opt/kukeon` diverged from the in-process controller — that's the bind-mount regression this check catches.
+Both `kuke get realms` and `kuke get realms --no-daemon` must produce the same shape (same columns, same rows, same `STATE`); `AGE` may differ by ms between the two invocations but renders at second granularity, so a single re-run normally produces byte-identical output. `NAMESPACE` and `CGROUP` no longer appear in the default table (epic:get retires them); use `kuke get realms -o wide` to append `NAMESPACE`, or `-o yaml`/`-o json` to surface `cgroupPath`. If only the `--no-daemon` list is populated, the daemon's view of `/opt/kukeon` diverged from the in-process controller — that's the bind-mount regression this check catches.
 
 **If your change touches anything the daemon reads, this check must be in the PR's test plan.** Reviewer agent will flag PRs that miss it.
 

--- a/README.md
+++ b/README.md
@@ -139,16 +139,16 @@ Common workflows for working with realms, spaces, stacks, and cells.
 
 ```bash
 $ sudo kuke get realms
-NAME           NAMESPACE         STATE    CGROUP
-default        kukeon-default    Running  /kukeon/default
-kukeon-system  kukeon-system     Running  /kukeon/kukeon-system
+NAME           STATE    AGE
+default        Ready    <age>
+kukeon-system  Ready    <age>
 
 $ sudo kuke get spaces
-NAME     REALM    STATE    CGROUP
-default  default  Running  /kukeon/default/default
+NAME     REALM    STATE
+default  default  Ready
 ```
 
-Add `-o yaml` or `-o json` for full resource details.
+Add `-o wide` for the per-kind extra columns (realm's wide appends `NAMESPACE`), or `-o yaml` / `-o json` for full resource details (including `cgroupPath`).
 
 ### Run a hello-world cell
 

--- a/cmd/config/autocomplete.go
+++ b/cmd/config/autocomplete.go
@@ -726,10 +726,10 @@ func CompleteProfileNames(_ *cobra.Command, _ []string, toComplete string) ([]st
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
-// CompleteOutputFormat provides shell completion for output format values (yaml, json, table).
+// CompleteOutputFormat provides shell completion for output format values (yaml, json, table, wide).
 // This function can be used for flag completion in commands that accept output format flags.
 func CompleteOutputFormat(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	formats := []string{"yaml", "json", "table"}
+	formats := []string{"yaml", "json", "table", "wide"}
 
 	names := make([]string, 0, len(formats))
 	for _, format := range formats {

--- a/cmd/config/autocomplete_test.go
+++ b/cmd/config/autocomplete_test.go
@@ -936,7 +936,7 @@ func TestCompleteOutputFormat(t *testing.T) {
 		{
 			name:       "success with all formats",
 			toComplete: "",
-			wantNames:  []string{"yaml", "json", "table"},
+			wantNames:  []string{"yaml", "json", "table", "wide"},
 		},
 		{
 			name:       "success with prefix filter 'y'",
@@ -954,6 +954,11 @@ func TestCompleteOutputFormat(t *testing.T) {
 			wantNames:  []string{"table"},
 		},
 		{
+			name:       "success with prefix filter 'w'",
+			toComplete: "w",
+			wantNames:  []string{"wide"},
+		},
+		{
 			name:       "success with prefix filter 'ya'",
 			toComplete: "ya",
 			wantNames:  []string{"yaml"},
@@ -964,6 +969,11 @@ func TestCompleteOutputFormat(t *testing.T) {
 			wantNames:  []string{"table"},
 		},
 		{
+			name:       "success with prefix filter 'wi'",
+			toComplete: "wi",
+			wantNames:  []string{"wide"},
+		},
+		{
 			name:       "success with no matches",
 			toComplete: "x",
 			wantNames:  []string{},
@@ -971,7 +981,7 @@ func TestCompleteOutputFormat(t *testing.T) {
 		{
 			name:       "works without logger in context",
 			toComplete: "",
-			wantNames:  []string{"yaml", "json", "table"},
+			wantNames:  []string{"yaml", "json", "table", "wide"},
 			noLogger:   true,
 		},
 	}

--- a/cmd/kuke/get/blueprint/blueprint.go
+++ b/cmd/kuke/get/blueprint/blueprint.go
@@ -121,7 +121,7 @@ func NewBlueprintCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Filter blueprints by stack name")
 	_ = viper.BindPFlag(config.KUKE_GET_BLUEPRINT_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -159,7 +159,7 @@ func printBlueprints(cmd *cobra.Command, blueprints []v1beta1.CellBlueprintDoc, 
 		return shared.PrintYAML(cmd, blueprints)
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, blueprints)
-	case shared.OutputFormatTable:
+	case shared.OutputFormatTable, shared.OutputFormatWide:
 		if len(blueprints) == 0 {
 			cmd.Println("No blueprints found.")
 			return nil

--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -136,8 +136,7 @@ outOfSync / outOfSyncReason / outOfSyncError status fields.`,
 			if err != nil {
 				return err
 			}
-			showControllers, _ := cmd.Flags().GetBool("show-controllers")
-			return printCells(cmd, cells, outputFormat, wide, showControllers)
+			return printCells(cmd, cells, outputFormat, wide)
 		},
 	}
 
@@ -151,10 +150,6 @@ outOfSync / outOfSyncReason / outOfSyncError status fields.`,
 		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
-	cmd.Flags().Bool(
-		"show-controllers", false,
-		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each cell's subtree (issue #328).",
-	)
 
 	cmd.ValidArgsFunction = config.CompleteCellNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -246,7 +241,6 @@ func printCells(
 	cells []v1beta1.CellDoc,
 	format shared.OutputFormat,
 	wide bool,
-	showControllers bool,
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
@@ -258,21 +252,14 @@ func printCells(
 			cmd.Println("No cells found.")
 			return nil
 		}
-		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "SYNC", "CGROUP"}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "SYNC"}
 		if wide {
 			headers = append(headers, "DIVERGENCE")
-		}
-		if showControllers {
-			headers = append(headers, "CONTROLLERS")
 		}
 		rows := make([][]string, 0, len(cells))
 		for i := range cells {
 			c := &cells[i]
 			state := (&c.Status.State).String()
-			cgroup := c.Status.CgroupPath
-			if cgroup == "" {
-				cgroup = "-"
-			}
 			row := []string{
 				c.Metadata.Name,
 				c.Spec.RealmID,
@@ -280,13 +267,9 @@ func printCells(
 				c.Spec.StackID,
 				state,
 				cellSyncState(c),
-				cgroup,
 			}
 			if wide {
 				row = append(row, cellDivergence(c))
-			}
-			if showControllers {
-				row = append(row, shared.FormatControllers(c.Status.SubtreeControllers))
 			}
 			rows = append(rows, row)
 		}

--- a/cmd/kuke/get/cell/cell_test.go
+++ b/cmd/kuke/get/cell/cell_test.go
@@ -192,9 +192,10 @@ func TestNewCellCmd_SyncColumn(t *testing.T) {
 				Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady},
 			}},
 			wantHeaders: []string{"SYNC"},
-			// "ce3 ... - ... -" — the SYNC dash is between STATE and CGROUP.
-			// PrintTable separates columns with two spaces, so the column
-			// reads as a standalone "-" token.
+			// CGROUP retired in #827, so SYNC is now the last default column;
+			// the no-lineage row ends in "-" preceded by the col separator,
+			// which PrintTable's width-padded last column still surrounds
+			// with spaces — " - " stays a stable substring.
 			wantRow: []string{"ce3", " - "},
 		},
 		{
@@ -291,6 +292,53 @@ func TestNewCellCmd_SyncColumn(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestNewCellCmd_NoCgroupOrControllers pins the epic:get step-1
+// cross-cutting cleanup for cells: the CGROUP column and the
+// --show-controllers flag must be gone in both default and -o wide
+// output (the SYNC and DIVERGENCE columns added by earlier work are
+// unaffected; -o wide still appends DIVERGENCE).
+func TestNewCellCmd_NoCgroupOrControllers(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	if cell.NewCellCmd().Flags().Lookup("show-controllers") != nil {
+		t.Error("show-controllers flag must be removed (issue #827)")
+	}
+
+	listFn := func(_, _, _ string) ([]v1beta1.CellDoc, error) {
+		return []v1beta1.CellDoc{{
+			Metadata: v1beta1.CellMetadata{Name: "ce1"},
+			Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+			Status: v1beta1.CellStatus{
+				State:              v1beta1.CellStateReady,
+				CgroupPath:         "/kukeon/r1/s1/st1/ce1",
+				SubtreeControllers: []string{"cpu", "memory"},
+			},
+		}}, nil
+	}
+
+	for _, args := range [][]string{nil, {"-o", "wide"}} {
+		buf := &bytes.Buffer{}
+		cmd := cell.NewCellCmd()
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+		ctx = context.WithValue(ctx, cell.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listCellsFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("args=%v: unexpected error: %v", args, err)
+		}
+		out := buf.String()
+		for _, denied := range []string{"CGROUP", "CONTROLLERS"} {
+			if strings.Contains(out, denied) {
+				t.Errorf("args=%v: output must NOT contain %q; got:\n%s", args, denied, out)
+			}
+		}
 	}
 }
 

--- a/cmd/kuke/get/config/config.go
+++ b/cmd/kuke/get/config/config.go
@@ -121,7 +121,7 @@ func NewConfigCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Filter configs by stack name")
 	_ = viper.BindPFlag(config.KUKE_GET_CONFIG_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -159,7 +159,7 @@ func printConfigs(cmd *cobra.Command, configs []v1beta1.CellConfigDoc, format sh
 		return shared.PrintYAML(cmd, configs)
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, configs)
-	case shared.OutputFormatTable:
+	case shared.OutputFormatTable, shared.OutputFormatWide:
 		if len(configs) == 0 {
 			cmd.Println("No configs found.")
 			return nil

--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -59,7 +59,7 @@ func NewContainerCmd() *cobra.Command {
 	cmd.Flags().String("cell", "", "Filter containers by cell name")
 	_ = viper.BindPFlag(config.KUKE_GET_CONTAINER_CELL.ViperKey, cmd.Flags().Lookup("cell"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -329,7 +329,7 @@ func printContainersWithState(
 		return shared.PrintYAML(cmd, containers)
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, containers)
-	case shared.OutputFormatTable:
+	case shared.OutputFormatTable, shared.OutputFormatWide:
 		if len(containers) == 0 {
 			if emptyMsg == "" {
 				emptyMsg = noContainersFoundMsg

--- a/cmd/kuke/get/realm/realm.go
+++ b/cmd/kuke/get/realm/realm.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
@@ -82,19 +83,14 @@ func NewRealmCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			showControllers, _ := cmd.Flags().GetBool("show-controllers")
-			return printRealms(cmd, realms, outputFormat, showControllers)
+			return printRealms(cmd, realms, outputFormat)
 		},
 	}
 
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
-	cmd.Flags().Bool(
-		"show-controllers", false,
-		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each realm's subtree (issue #328). Off by default to keep the default table the daemon-parity dev-init regression guard expects.",
-	)
 
 	// `--no-daemon` is inherited as a persistent flag from the parent `get`
 	// command (registered in cmd/kuke/get/get.go) — every `get <kind>`
@@ -129,33 +125,30 @@ func printRealms(
 	cmd *cobra.Command,
 	realms []v1beta1.RealmDoc,
 	format shared.OutputFormat,
-	showControllers bool,
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, realms)
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, realms)
-	case shared.OutputFormatTable:
+	case shared.OutputFormatTable, shared.OutputFormatWide:
 		if len(realms) == 0 {
 			cmd.Println("No realms found.")
 			return nil
 		}
-		headers := []string{"NAME", "NAMESPACE", "STATE", "CGROUP"}
-		if showControllers {
-			headers = append(headers, "CONTROLLERS")
+		wide := format == shared.OutputFormatWide
+		headers := []string{"NAME", "STATE", "AGE"}
+		if wide {
+			headers = append(headers, "NAMESPACE")
 		}
+		now := time.Now()
 		rows := make([][]string, 0, len(realms))
 		for i := range realms {
 			r := &realms[i]
 			state := (&r.Status.State).String()
-			cgroup := r.Status.CgroupPath
-			if cgroup == "" {
-				cgroup = "-"
-			}
-			row := []string{r.Metadata.Name, r.Spec.Namespace, state, cgroup}
-			if showControllers {
-				row = append(row, shared.FormatControllers(r.Status.SubtreeControllers))
+			row := []string{r.Metadata.Name, state, shared.RenderAge(r.Status.CreatedAt, now)}
+			if wide {
+				row = append(row, r.Spec.Namespace)
 			}
 			rows = append(rows, row)
 		}

--- a/cmd/kuke/get/realm/realm_test.go
+++ b/cmd/kuke/get/realm/realm_test.go
@@ -147,19 +147,16 @@ func TestNewRealmCmd_Structure(t *testing.T) {
 	if cmd.Flags().Lookup("output") == nil {
 		t.Fatal("expected output flag")
 	}
-	if cmd.Flags().Lookup("show-controllers") == nil {
-		t.Fatal("expected show-controllers flag (issue #328)")
+	if cmd.Flags().Lookup("show-controllers") != nil {
+		t.Error("show-controllers flag must be removed (issue #827)")
 	}
 }
 
-// TestNewRealmCmd_ShowControllers pins the issue #328 surfacing rule:
-//
-//   - default `kuke get realms` MUST omit the CONTROLLERS column so the
-//     dev-init daemon-parity tail (NAME NAMESPACE STATE CGROUP) stays
-//     byte-identical to what kukeon's CLAUDE.md regression guard expects.
-//   - `--show-controllers` adds the column with the comma-joined effective
-//     set, falling back to "-" when SubtreeControllers is empty.
-func TestNewRealmCmd_ShowControllers(t *testing.T) {
+// TestNewRealmCmd_Columns pins the epic:get step-1 column contract for
+// `kuke get realm`: default emits `NAME STATE AGE`, `-o wide` appends
+// `NAMESPACE`, and neither `CGROUP` nor `CONTROLLERS` ever appear in
+// any table output (they live in `-o yaml`/`-o json` only).
+func TestNewRealmCmd_Columns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
 	listFn := func() ([]v1beta1.RealmDoc, error) {
@@ -168,6 +165,7 @@ func TestNewRealmCmd_ShowControllers(t *testing.T) {
 				Metadata: v1beta1.RealmMetadata{Name: "default"},
 				Spec:     v1beta1.RealmSpec{Namespace: "default.kukeon.io"},
 				Status: v1beta1.RealmStatus{
+					State:              v1beta1.RealmStateReady,
 					CgroupPath:         "/kukeon/default",
 					SubtreeControllers: []string{"cpu", "memory", "io", "pids"},
 				},
@@ -176,13 +174,14 @@ func TestNewRealmCmd_ShowControllers(t *testing.T) {
 				Metadata: v1beta1.RealmMetadata{Name: "kuke-system"},
 				Spec:     v1beta1.RealmSpec{Namespace: "kuke-system.kukeon.io"},
 				Status: v1beta1.RealmStatus{
+					State:      v1beta1.RealmStateReady,
 					CgroupPath: "/kukeon/kuke-system",
 				},
 			},
 		}, nil
 	}
 
-	t.Run("default omits controllers column", func(t *testing.T) {
+	t.Run("default table is NAME STATE AGE", func(t *testing.T) {
 		t.Cleanup(viper.Reset)
 
 		cmd := realm.NewRealmCmd()
@@ -193,42 +192,84 @@ func TestNewRealmCmd_ShowControllers(t *testing.T) {
 			realm.MockControllerKey{},
 			kukeonv1.Client(&fakeClient{listRealmsFn: listFn}))
 		cmd.SetContext(ctx)
-		if err := cmd.Execute(); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if strings.Contains(buf.String(), "CONTROLLERS") {
-			t.Errorf("default output must NOT include CONTROLLERS column "+
-				"(issue #328 dev-init regression guard); got:\n%s", buf.String())
-		}
-	})
-
-	t.Run("flag appends controllers column", func(t *testing.T) {
-		t.Cleanup(viper.Reset)
-
-		cmd := realm.NewRealmCmd()
-		buf := &bytes.Buffer{}
-		cmd.SetOut(buf)
-		cmd.SetErr(buf)
-		ctx := context.WithValue(context.Background(),
-			realm.MockControllerKey{},
-			kukeonv1.Client(&fakeClient{listRealmsFn: listFn}))
-		cmd.SetContext(ctx)
-		cmd.SetArgs([]string{"--show-controllers"})
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		out := buf.String()
-		if !strings.Contains(out, "CONTROLLERS") {
-			t.Errorf("expected CONTROLLERS column with --show-controllers; got:\n%s", out)
+		header := firstLine(out)
+		// The header is rendered before any data row; check it directly so
+		// row data can't accidentally satisfy the column-presence assertion.
+		for _, want := range []string{"NAME", "STATE", "AGE"} {
+			if !strings.Contains(header, want) {
+				t.Errorf("default header missing %q; got: %q", want, header)
+			}
 		}
-		if !strings.Contains(out, "cpu,memory,io,pids") {
-			t.Errorf("expected joined controller list; got:\n%s", out)
-		}
-		// The empty-controllers row renders "-".
-		if !strings.Contains(out, "kuke-system") || !strings.Contains(out, " -") {
-			t.Errorf("expected empty controllers to render as '-'; got:\n%s", out)
+		for _, denied := range []string{"NAMESPACE", "CGROUP", "CONTROLLERS"} {
+			if strings.Contains(out, denied) {
+				t.Errorf("default output must NOT contain %q; got:\n%s", denied, out)
+			}
 		}
 	})
+
+	t.Run("-o wide appends NAMESPACE without resurrecting CGROUP/CONTROLLERS", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+
+		cmd := realm.NewRealmCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(),
+			realm.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listRealmsFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-o", "wide"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		header := firstLine(out)
+		for _, want := range []string{"NAME", "STATE", "AGE", "NAMESPACE"} {
+			if !strings.Contains(header, want) {
+				t.Errorf("wide header missing %q; got: %q", want, header)
+			}
+		}
+		for _, denied := range []string{"CGROUP", "CONTROLLERS"} {
+			if strings.Contains(out, denied) {
+				t.Errorf("-o wide output must NOT contain %q; got:\n%s", denied, out)
+			}
+		}
+		if !strings.Contains(out, "default.kukeon.io") {
+			t.Errorf("expected NAMESPACE value in -o wide rows; got:\n%s", out)
+		}
+	})
+
+	t.Run("-o yaml surfaces cgroupPath", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+
+		cmd := realm.NewRealmCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(),
+			realm.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listRealmsFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-o", "yaml"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "cgroupPath: /kukeon/default") {
+			t.Errorf("-o yaml should still surface cgroupPath; got:\n%s", out)
+		}
+	})
+}
+
+func firstLine(s string) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return s[:idx]
+	}
+	return s
 }
 
 type fakeClient struct {

--- a/cmd/kuke/get/secret/secret.go
+++ b/cmd/kuke/get/secret/secret.go
@@ -124,7 +124,7 @@ func NewSecretCmd() *cobra.Command {
 	cmd.Flags().String("cell", "", "Filter secrets by cell name")
 	_ = viper.BindPFlag(config.KUKE_GET_SECRET_CELL.ViperKey, cmd.Flags().Lookup("cell"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
@@ -163,7 +163,7 @@ func printSecrets(cmd *cobra.Command, secrets []v1beta1.SecretDoc, format shared
 		return shared.PrintYAML(cmd, secrets)
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, secrets)
-	case shared.OutputFormatTable:
+	case shared.OutputFormatTable, shared.OutputFormatWide:
 		if len(secrets) == 0 {
 			cmd.Println("No secrets found.")
 			return nil

--- a/cmd/kuke/get/shared/shared.go
+++ b/cmd/kuke/get/shared/shared.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	createshared "github.com/eminwux/kukeon/cmd/kuke/create/shared"
@@ -47,6 +48,7 @@ const (
 	OutputFormatYAML  OutputFormat = "yaml"
 	OutputFormatJSON  OutputFormat = "json"
 	OutputFormatTable OutputFormat = "table"
+	OutputFormatWide  OutputFormat = "wide"
 )
 
 // ParseOutputFormat resolves the output format using kuke's standard
@@ -76,10 +78,10 @@ func ParseOutputFormat(cmd *cobra.Command) (OutputFormat, error) {
 	}
 	format := OutputFormat(strings.ToLower(trimmed))
 	switch format {
-	case OutputFormatYAML, OutputFormatJSON, OutputFormatTable:
+	case OutputFormatYAML, OutputFormatJSON, OutputFormatTable, OutputFormatWide:
 		return format, nil
 	default:
-		return OutputFormatTable, fmt.Errorf("invalid output format: %s (supported: yaml, json, table)", output)
+		return OutputFormatTable, fmt.Errorf("invalid output format: %s (supported: yaml, json, table, wide)", output)
 	}
 }
 
@@ -162,15 +164,32 @@ func PrintTable(cmd *cobra.Command, headers []string, rows [][]string) {
 	}
 }
 
-// FormatControllers renders a Status.SubtreeControllers slice for the
-// CONTROLLERS table column emitted by `kuke get <kind> --show-controllers`
-// (issue #328). Empty input renders as "-" so the column never collapses
-// to an unaligned blank cell.
-func FormatControllers(controllers []string) string {
-	if len(controllers) == 0 {
+// RenderAge formats a CreatedAt timestamp as a kubectl-style coarse
+// duration ("5d", "2h", "30s") for the AGE column shared across every
+// `kuke get <kind>` table. The zero time renders as "-" so the column
+// stays width-aligned for resources that have not recorded a creation
+// timestamp yet. Granularity drops a unit at each step (>=1d shows days
+// only, >=1h shows hours only, etc.); sub-second values render as "0s".
+// `now` is injected so tests can pin the reference time.
+func RenderAge(t time.Time, now time.Time) string {
+	if t.IsZero() {
 		return "-"
 	}
-	return strings.Join(controllers, ",")
+	d := now.Sub(t)
+	if d < 0 {
+		d = 0
+	}
+	const day = 24 * time.Hour
+	switch {
+	case d >= day:
+		return fmt.Sprintf("%dd", int(d/day))
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	case d >= time.Minute:
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	default:
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	}
 }
 
 // ControllerFromCmd reuses the controller helper from create/shared.

--- a/cmd/kuke/get/shared/shared_test.go
+++ b/cmd/kuke/get/shared/shared_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
@@ -50,6 +51,11 @@ func TestParseOutputFormat(t *testing.T) {
 			name:       "table format",
 			flags:      map[string]string{"output": "table"},
 			wantFormat: shared.OutputFormatTable,
+		},
+		{
+			name:       "wide format",
+			flags:      map[string]string{"output": "wide"},
+			wantFormat: shared.OutputFormatWide,
 		},
 		{
 			name:       "default format when no flag",
@@ -454,6 +460,45 @@ func TestPrintTable(t *testing.T) {
 				if !foundSeparator {
 					t.Error("expected separator line with dashes, but not found")
 				}
+			}
+		})
+	}
+}
+
+// TestRenderAge pins the AGE helper at every kubectl-style coarse-unit
+// boundary the column reader cares about (days → hours → minutes →
+// seconds), plus the zero-value "-" rendering and the defensive clamp
+// for clocks reporting a CreatedAt slightly in the future. Sibling per-
+// kind issues (#602–#605) consume this helper directly; the contract is
+// fixed here.
+func TestRenderAge(t *testing.T) {
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{name: "zero time renders dash", t: time.Time{}, want: "-"},
+		{name: "negative duration clamps to 0s", t: now.Add(1 * time.Hour), want: "0s"},
+		{name: "0s for sub-second age", t: now.Add(-500 * time.Millisecond), want: "0s"},
+		{name: "30s", t: now.Add(-30 * time.Second), want: "30s"},
+		{name: "boundary: 59s stays in seconds", t: now.Add(-59 * time.Second), want: "59s"},
+		{name: "boundary: 1m promotes to minutes", t: now.Add(-1 * time.Minute), want: "1m"},
+		{name: "5m", t: now.Add(-5 * time.Minute), want: "5m"},
+		{name: "boundary: 59m stays in minutes", t: now.Add(-59 * time.Minute), want: "59m"},
+		{name: "boundary: 1h promotes to hours", t: now.Add(-1 * time.Hour), want: "1h"},
+		{name: "2h", t: now.Add(-2 * time.Hour), want: "2h"},
+		{name: "boundary: 23h59m stays in hours", t: now.Add(-23*time.Hour - 59*time.Minute), want: "23h"},
+		{name: "boundary: 24h promotes to days", t: now.Add(-24 * time.Hour), want: "1d"},
+		{name: "5d", t: now.Add(-5 * 24 * time.Hour), want: "5d"},
+		{name: "120d", t: now.Add(-120 * 24 * time.Hour), want: "120d"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shared.RenderAge(tt.t, now); got != tt.want {
+				t.Errorf("RenderAge(%v, %v) = %q, want %q", tt.t, now, got, tt.want)
 			}
 		})
 	}

--- a/cmd/kuke/get/space/space.go
+++ b/cmd/kuke/get/space/space.go
@@ -91,8 +91,7 @@ func NewSpaceCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			showControllers, _ := cmd.Flags().GetBool("show-controllers")
-			return printSpaces(cmd, spaces, outputFormat, showControllers)
+			return printSpaces(cmd, spaces, outputFormat)
 		},
 	}
 
@@ -100,13 +99,9 @@ func NewSpaceCmd() *cobra.Command {
 	_ = viper.BindPFlag(config.KUKE_GET_SPACE_REALM.ViperKey, cmd.Flags().Lookup("realm"))
 
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
-	cmd.Flags().Bool(
-		"show-controllers", false,
-		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each space's subtree (issue #328).",
-	)
 
 	cmd.ValidArgsFunction = config.CompleteSpaceNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -136,35 +131,27 @@ func printSpaces(
 	cmd *cobra.Command,
 	spaces []v1beta1.SpaceDoc,
 	format shared.OutputFormat,
-	showControllers bool,
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, spaces)
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, spaces)
-	case shared.OutputFormatTable:
+	case shared.OutputFormatTable, shared.OutputFormatWide:
 		if len(spaces) == 0 {
 			cmd.Println("No spaces found.")
 			return nil
 		}
-		headers := []string{"NAME", "REALM", "STATE", "CGROUP"}
-		if showControllers {
-			headers = append(headers, "CONTROLLERS")
-		}
+		// Per-entity wide columns (EGRESS, NET-DEFAULTS) land in #602; this
+		// step only retires CGROUP/CONTROLLERS so the wide table currently
+		// renders the same shape as the default. The shared OutputFormatWide
+		// enum value is still accepted for symmetry across kinds.
+		headers := []string{"NAME", "REALM", "STATE"}
 		rows := make([][]string, 0, len(spaces))
 		for i := range spaces {
 			s := &spaces[i]
 			state := (&s.Status.State).String()
-			cgroup := s.Status.CgroupPath
-			if cgroup == "" {
-				cgroup = "-"
-			}
-			row := []string{s.Metadata.Name, s.Spec.RealmID, state, cgroup}
-			if showControllers {
-				row = append(row, shared.FormatControllers(s.Status.SubtreeControllers))
-			}
-			rows = append(rows, row)
+			rows = append(rows, []string{s.Metadata.Name, s.Spec.RealmID, state})
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil

--- a/cmd/kuke/get/space/space_test.go
+++ b/cmd/kuke/get/space/space_test.go
@@ -137,6 +137,53 @@ func TestNewSpaceCmd(t *testing.T) {
 	}
 }
 
+// TestNewSpaceCmd_NoCgroupOrControllers pins the epic:get step-1
+// cross-cutting cleanup for spaces: the CGROUP column and the
+// --show-controllers flag must be gone, and -o wide must not resurrect
+// either (sibling #602 owns the per-entity wide columns).
+func TestNewSpaceCmd_NoCgroupOrControllers(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	if space.NewSpaceCmd().Flags().Lookup("show-controllers") != nil {
+		t.Error("show-controllers flag must be removed (issue #827)")
+	}
+
+	listFn := func(_ string) ([]v1beta1.SpaceDoc, error) {
+		return []v1beta1.SpaceDoc{
+			{
+				Metadata: v1beta1.SpaceMetadata{Name: "s1"},
+				Spec:     v1beta1.SpaceSpec{RealmID: "r1"},
+				Status: v1beta1.SpaceStatus{
+					CgroupPath:         "/kukeon/r1/s1",
+					SubtreeControllers: []string{"cpu", "memory"},
+				},
+			},
+		}, nil
+	}
+
+	for _, args := range [][]string{nil, {"-o", "wide"}} {
+		buf := &bytes.Buffer{}
+		cmd := space.NewSpaceCmd()
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+		ctx = context.WithValue(ctx, space.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listSpacesFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("args=%v: unexpected error: %v", args, err)
+		}
+		out := buf.String()
+		for _, denied := range []string{"CGROUP", "CONTROLLERS"} {
+			if strings.Contains(out, denied) {
+				t.Errorf("args=%v: output must NOT contain %q; got:\n%s", args, denied, out)
+			}
+		}
+	}
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/get/stack/stack.go
+++ b/cmd/kuke/get/stack/stack.go
@@ -101,8 +101,7 @@ func NewStackCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			showControllers, _ := cmd.Flags().GetBool("show-controllers")
-			return printStacks(cmd, stacks, outputFormat, showControllers)
+			return printStacks(cmd, stacks, outputFormat)
 		},
 	}
 
@@ -111,13 +110,9 @@ func NewStackCmd() *cobra.Command {
 	cmd.Flags().String("space", "", "Filter stacks by space name")
 	_ = viper.BindPFlag(config.KUKE_GET_STACK_SPACE.ViperKey, cmd.Flags().Lookup("space"))
 	cmd.Flags().
-		StringP("output", "o", "", "Output format (yaml, json, table). Default: table for list, yaml for single resource")
+		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
-	cmd.Flags().Bool(
-		"show-controllers", false,
-		"Append a CONTROLLERS column listing the cgroup-v2 controllers delegated on each stack's subtree (issue #328).",
-	)
 
 	cmd.ValidArgsFunction = config.CompleteStackNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -148,35 +143,26 @@ func printStacks(
 	cmd *cobra.Command,
 	stacks []v1beta1.StackDoc,
 	format shared.OutputFormat,
-	showControllers bool,
 ) error {
 	switch format {
 	case shared.OutputFormatYAML:
 		return shared.PrintYAML(cmd, stacks)
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, stacks)
-	case shared.OutputFormatTable:
+	case shared.OutputFormatTable, shared.OutputFormatWide:
 		if len(stacks) == 0 {
 			cmd.Println("No stacks found.")
 			return nil
 		}
-		headers := []string{"NAME", "REALM", "SPACE", "STATE", "CGROUP"}
-		if showControllers {
-			headers = append(headers, "CONTROLLERS")
-		}
+		// Stack has no per-entity wide columns (#603 deliberately leaves
+		// -o wide rendering the same shape as default); this step only
+		// retires CGROUP/CONTROLLERS.
+		headers := []string{"NAME", "REALM", "SPACE", "STATE"}
 		rows := make([][]string, 0, len(stacks))
 		for i := range stacks {
 			s := &stacks[i]
 			state := (&s.Status.State).String()
-			cgroup := s.Status.CgroupPath
-			if cgroup == "" {
-				cgroup = "-"
-			}
-			row := []string{s.Metadata.Name, s.Spec.RealmID, s.Spec.SpaceID, state, cgroup}
-			if showControllers {
-				row = append(row, shared.FormatControllers(s.Status.SubtreeControllers))
-			}
-			rows = append(rows, row)
+			rows = append(rows, []string{s.Metadata.Name, s.Spec.RealmID, s.Spec.SpaceID, state})
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil

--- a/cmd/kuke/get/stack/stack_test.go
+++ b/cmd/kuke/get/stack/stack_test.go
@@ -136,6 +136,53 @@ func TestNewStackCmd(t *testing.T) {
 	}
 }
 
+// TestNewStackCmd_NoCgroupOrControllers pins the epic:get step-1
+// cross-cutting cleanup for stacks: the CGROUP column and the
+// --show-controllers flag must be gone, and -o wide is accepted as a
+// valid output value (no error) while currently rendering the same
+// shape as default (sibling #603 leaves wide deliberately equal to
+// default for stacks).
+func TestNewStackCmd_NoCgroupOrControllers(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	if stack.NewStackCmd().Flags().Lookup("show-controllers") != nil {
+		t.Error("show-controllers flag must be removed (issue #827)")
+	}
+
+	listFn := func(_, _ string) ([]v1beta1.StackDoc, error) {
+		return []v1beta1.StackDoc{{
+			Metadata: v1beta1.StackMetadata{Name: "st1"},
+			Spec:     v1beta1.StackSpec{RealmID: "r1", SpaceID: "s1"},
+			Status: v1beta1.StackStatus{
+				CgroupPath:         "/kukeon/r1/s1/st1",
+				SubtreeControllers: []string{"cpu", "memory"},
+			},
+		}}, nil
+	}
+
+	for _, args := range [][]string{nil, {"-o", "wide"}} {
+		buf := &bytes.Buffer{}
+		cmd := stack.NewStackCmd()
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+		ctx = context.WithValue(ctx, stack.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listStacksFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("args=%v: unexpected error: %v", args, err)
+		}
+		out := buf.String()
+		for _, denied := range []string{"CGROUP", "CONTROLLERS"} {
+			if strings.Contains(out, denied) {
+				t.Errorf("args=%v: output must NOT contain %q; got:\n%s", args, denied, out)
+			}
+		}
+	}
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -160,15 +160,15 @@ kuke get image --realm <name>                    # narrow to one realm
 kuke get image <ref> --realm <name>              # describe a single image (yaml default)
 kuke get realm <name> -o yaml                    # full spec+status
 kuke get realm <name> -o json
-kuke get realms --show-controllers               # cgroup-v2 controllers column
+kuke get realms -o wide                          # default cols + NAMESPACE
 ```
 
 **Invariants.**
 
 - Exit code 0 even when the result set is empty; the CLI prints a brief "no resources found" line rather than failing.
-- Table output is the default for **lists**; YAML is the default for a **single named resource**. Both behaviors are overridable via `-o {yaml,json,table}`.
+- Table output is the default for **lists**; YAML is the default for a **single named resource**. Both behaviors are overridable via `-o {yaml,json,table,wide}`.
 - After `kuke init`, `kuke get realms` lists at least `default` and `kuke-system`. `kuke get realms --no-daemon` must produce the same row set — divergence is a regression (see CLAUDE.md daemon-parity guard).
-- `--show-controllers` appends a `CONTROLLERS` column; it is **off by default** so the default table matches the dev-init regression-guard tail in CLAUDE.md.
+- The realm default table is `NAME STATE AGE`; `-o wide` appends `NAMESPACE`. The retired `--show-controllers` flag and the `CGROUP` / `CONTROLLERS` columns are gone (epic:get) — surface `cgroupPath` / `subtreeControllers` via `-o yaml` or `-o json` when investigating.
 - `kuke get realms --no-daemon` works without `sudo` when `/opt/kukeon` is readable by the `kukeon` group; this is the supported escape hatch when the daemon is down.
 - `kuke get image[s]` lists across **every realm** by default; columns are `NAME REALM SIZE AGE`. `--realm <r>` narrows to one realm but keeps the `REALM` column for grep-ability. `-o wide` appends `CREATED` and `DIGEST`. `-o yaml` / `-o json` emit one `kukeonv1.ListImagesResult` per realm. With a positional `<ref>` the command describes a single image (yaml by default, `-o json` switches to json); `--realm` defaults to `default` on this path.
 - `kuke get image` is daemon-independent: image methods do not traverse the kukeond RPC (#226), so the persistent `--no-daemon` on `kuke get` is a no-op for this leaf — every invocation goes in-process via the containerd socket.

--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -11,10 +11,9 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`, `image`, `blueprint`,
 
 ## Common flags
 
-| Flag                 | Description                                                                                                                                                  |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--output`, `-o`     | Output format: `yaml`, `json`, `table`. Default: `table` for list, `yaml` for a single resource.                                                             |
-| `--show-controllers` | Append a `CONTROLLERS` column listing the cgroup-v2 controllers delegated on the subject's subtree. Off by default to keep the dev-init parity check stable. |
+| Flag             | Description                                                                                                                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--output`, `-o` | Output format: `yaml`, `json`, `table`, `wide`. Default: `table` for list, `yaml` for a single resource. `wide` accepted by every `kuke get <kind>` for symmetry; per-kind wide columns vary (see each kind). |
 
 Plus all [global flags](kuke.md). Every `kuke get <kind>` accepts the explicit `--no-daemon` flag to bypass the daemon (inherited as a persistent flag from the parent `get` command); `KUKEON_NO_DAEMON=true` and `--run-path /opt/kukeon` (which auto-promotes the command into in-process mode) work as well.
 
@@ -41,12 +40,19 @@ All scope flags default to `default`. See the [realm default note](commands.md#c
 - **Single** (positional arg): returns the one matching resource. Default output is YAML.
 
 ```bash
-# Table of realms — the dev-init parity check expects this exact shape
+# Table of realms — the dev-init parity check expects this column shape
 sudo kuke get realms
-NAME         NAMESPACE              STATE  CGROUP
------------  ---------------------  -----  -------------------
-default      default.kukeon.io      Ready  /kukeon/default
-kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+NAME         STATE  AGE
+-----------  -----  ---
+default      Ready  <age>
+kuke-system  Ready  <age>
+
+# Same data with the namespace surfaced
+sudo kuke get realms -o wide
+NAME         STATE  AGE  NAMESPACE
+-----------  -----  ---  ---------------------
+default      Ready  <a>  default.kukeon.io
+kuke-system  Ready  <a>  kuke-system.kukeon.io
 
 # Single realm as YAML
 sudo kuke get realm default -o yaml
@@ -71,9 +77,6 @@ sudo kuke get image --realm kuke-system -o wide
 
 # Describe a single image as YAML (defaults --realm to `default` on this path)
 sudo kuke get image docker.io/library/nginx:alpine -o yaml
-
-# Show which cgroup controllers are delegated to every realm
-sudo kuke get realms --show-controllers
 
 # List every daemon-stored CellBlueprint bound to the kuke-system realm
 sudo kuke get blueprints --realm kuke-system

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -71,9 +71,9 @@ List the realms `kuke init` just created:
 
 ```bash
 $ kuke get realms
-NAME         NAMESPACE              STATE  CGROUP
-default      default.kukeon.io      Ready  /kukeon/default
-kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+NAME         STATE  AGE
+default      Ready  <age>
+kuke-system  Ready  <age>
 ```
 
 `default` is your user-workload realm — `kuke create`, `kuke apply`, etc. land here when no `--realm` flag is given. `kuke-system` is reserved for Kukeon itself; the `kukeond` daemon runs as a cell inside `kuke-system / kukeon / kukeon / kukeond` (realm / space / stack / cell).
@@ -82,15 +82,15 @@ Spaces and stacks are only auto-created under `kuke-system` — the user-facing 
 
 ```bash
 $ kuke get spaces --realm kuke-system
-NAME    REALM        STATE  CGROUP
-kukeon  kuke-system  Ready  /kukeon/kuke-system/kukeon
+NAME    REALM        STATE
+kukeon  kuke-system  Ready
 
 $ kuke get stacks --realm kuke-system --space kukeon
-NAME    REALM        SPACE   STATE  CGROUP
-kukeon  kuke-system  kukeon  Ready  /kukeon/kuke-system/kukeon/kukeon
+NAME    REALM        SPACE   STATE
+kukeon  kuke-system  kukeon  Ready
 ```
 
-Add `-o yaml` or `-o json` for full resource details.
+Add `-o wide` for per-kind extra columns (e.g. realm gains `NAMESPACE`), or `-o yaml` / `-o json` for full resource details (including `cgroupPath`).
 
 ## 6. Run a hello-world cell
 

--- a/docs/site/guides/local-dev.md
+++ b/docs/site/guides/local-dev.md
@@ -24,11 +24,13 @@ make dev-init
 The parity tail must read:
 
 ```
-NAME         NAMESPACE              STATE  CGROUP
------------  ---------------------  -----  -------------------
-default      default.kukeon.io      Ready  /kukeon/default
-kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+NAME         STATE  AGE
+-----------  -----  ---
+default      Ready  <age>
+kuke-system  Ready  <age>
 ```
+
+`NAMESPACE` is now in `-o wide` and `CGROUP` is now in `-o yaml`/`-o json` only.
 
 If only `kuke get realms --no-daemon` returns that table but `kuke get realms` (daemon-routed) does not, the daemon's view of `/opt/kukeon` diverged from the in-process controller — usually a missing bind-mount in the `kukeond` cell spec. (Every `kuke get <kind>` keeps the `--no-daemon` flag; `KUKEON_NO_DAEMON=true` and `--run-path /opt/kukeon` work too.) See [Troubleshooting → `kuke get` and `kuke get --no-daemon` disagree](troubleshooting.md#kuke-get-and-kuke-get---no-daemon-disagree).
 
@@ -36,15 +38,15 @@ User data under `/opt/kukeon/default/**` is untouched across iterations; only th
 
 ## Make targets
 
-| Target               | What it does                                                                                                                  |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `make kuke`          | Build the `kuke` binary (same binary is dispatched as `kukeond` via `argv[0]`)                                                |
-| `make install-dev`   | Symlink the in-tree `kuke` and `kukeond` binaries into `$(INSTALL_PREFIX)` (default `/usr/local/bin`). Idempotent (`ln -sf`). |
-| `make uninstall-dev` | Remove both symlinks from `$(INSTALL_PREFIX)`.                                                                                |
-| `make dev-init`      | The full canonical loop above. Auto-invokes `install-dev` so `sudo kuke …` works from any directory.                          |
-| `make test`          | Run the Go unit test suite                                                                                                    |
+| Target               | What it does                                                                                                                                                                                                                                                                  |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `make kuke`          | Build the `kuke` binary (same binary is dispatched as `kukeond` via `argv[0]`)                                                                                                                                                                                                |
+| `make install-dev`   | Symlink the in-tree `kuke` and `kukeond` binaries into `$(INSTALL_PREFIX)` (default `/usr/local/bin`). Idempotent (`ln -sf`).                                                                                                                                                 |
+| `make uninstall-dev` | Remove both symlinks from `$(INSTALL_PREFIX)`.                                                                                                                                                                                                                                |
+| `make dev-init`      | The full canonical loop above. Auto-invokes `install-dev` so `sudo kuke …` works from any directory.                                                                                                                                                                          |
+| `make test`          | Run the Go unit test suite                                                                                                                                                                                                                                                    |
 | `make e2e`           | Run end-to-end tests against a real containerd (requires root). Supports both a clean host and a nested run inside a `kukeon-dev-root` cell — each test derives its socket from its own `--run-path <tempdir>` so the parent dev cell's `/run/kukeon/` plumbing is untouched. |
-| `make lint`          | Run `golangci-lint` with the repo's config                                                                                    |
+| `make lint`          | Run `golangci-lint` with the repo's config                                                                                                                                                                                                                                    |
 
 Override `INSTALL_PREFIX` for non-standard PATH layouts: `make install-dev INSTALL_PREFIX=$HOME/.local/bin`.
 

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -71,10 +71,12 @@ Kukeon daemon: hosts the kukeonv1 API over a unix socket
 
 ```bash
 $ sudo kuke get realms
-NAME         NAMESPACE              STATE  CGROUP
-default      default.kukeon.io      Ready  /kukeon/default
-kuke-system  kuke-system.kukeon.io  Ready  /kukeon/kuke-system
+NAME         STATE  AGE
+default      Ready  <age>
+kuke-system  Ready  <age>
 ```
+
+`kuke get realms -o wide` appends the containerd `NAMESPACE` column; `-o yaml` / `-o json` surface `cgroupPath` for the operator who wants to walk the cgroup-v2 hierarchy by hand.
 
 `default` is the user-workload realm — `kuke create …` lands here by default. `kuke-system` is owned by Kukeon itself and hosts the `kukeond` daemon cell.
 


### PR DESCRIPTION
## Summary

Foundation step under the `epic:get` umbrella (#601). Lands the shared infrastructure the per-kind sibling steps (#602–#605) consume, plus the cross-cutting cleanup that retires `--show-controllers` and the `CGROUP`/`CONTROLLERS` table columns across the four hierarchy kinds.

- `shared.OutputFormatWide` (`"wide"`) is now the fourth `OutputFormat` enum value accepted by `ParseOutputFormat`; default with no `-o` flag remains `table`.
- `shared.RenderAge(time.Time, time.Time)` renders kubectl-style coarse durations (`5d`, `2h`, `30s`, `-` for zero) for the AGE column the siblings will adopt; `now` is injected for deterministic tests.
- `shared.FormatControllers` is gone — no callers remain after the cross-cutting cleanup.
- `kuke get realm` default table now `NAME STATE AGE`; `-o wide` appends `NAMESPACE`. `CGROUP`/`CONTROLLERS` are no longer rendered in any table for any of the four kinds (still visible via `-o yaml`/`-o json` through `Status.CgroupPath` / `Status.SubtreeControllers`).
- `--show-controllers` removed from realm, space, stack, and cell commands; container never had it.
- Space/stack/cell tables only drop CGROUP in this PR — sibling per-kind issues (#602, #603, #604) introduce their AGE column and the per-kind wide-only fields (`EGRESS`/`NET-DEFAULTS`, `CONTAINERS`/`BRIDGE`, etc.); accepting `-o wide` is wired here so the enum is usable from the kuke get plane immediately.
- `-o wide` is also accepted on the four leaf gets (`container`, `blueprint`, `secret`, `config`) — output is currently identical to `-o table`, sibling per-kind issues add their wide-only columns. Help strings and `CompleteOutputFormat` shell completion enumerate `wide`.
- Docs updated: CLAUDE.md daemon-parity tail, `docs/cli-use-cases.md`, `docs/site/install/install-linux.md`, `docs/site/guides/local-dev.md`, `docs/site/cli/kuke-get.md`, `docs/site/getting-started.md`, plus the realm/space tables in the top-level `README.md` (not enumerated in the AC but visibly stale otherwise).

## Notes for the reviewer

- The AC item "`CGROUP` does not appear in any table output for any entity (verified by reading the four sibling command files — they should not reference `CgroupPath` in their table builders)" is read as a hard end-state for step 1: this PR drops `CGROUP` from all four hierarchy kinds rather than waiting for the per-kind siblings to do it. The Proposal's per-entity-realm bullet ("`CGROUP` never appears in any table; only in `-o yaml`/`-o json`") confirms the broader rule. Sibling steps then layer their own AGE / wide columns onto each.
- `cell.go` and `image.go` keep their local `resolveOutput` shim that pre-translates `wide → table+bool`; once `shared.OutputFormatWide` is in the enum they could switch to consuming it directly, but that refactor is out of scope here and naturally lands with their per-kind sibling issues.
- The AGE rendering for realm tables uses `time.Now()` inside `printRealms`; the shared `RenderAge` helper accepts an injected `now` for tests, but the production call site reads wall-clock — there is no controller-injected clock to thread through `cmd/kuke/get` today. Sibling per-kind tables follow the same call shape.

## Test plan

- [x] `make test-root` — full root-module test suite (`go test ./...`)
- [x] `make test-kukebuild` — kukebuild module test suite
- [x] `GOWORK=off go vet ./...` — clean
- [x] `pre-commit run --files $(git diff --name-only HEAD)` — all hooks pass (trailing-whitespace, end-of-file, go-fmt, go-mod-tidy, golangci-lint, prettier, addlicense)
- [x] `grep -rn 'show-controllers'` across the tree — only intentional history references (cli-use-cases.md retirement note) and negative-presence assertions in the four test files
- [ ] `make dev-init` end-to-end smoke + daemon-parity check — not run in this dev environment (no `kukeon-dev-root` parent host; the script's nested-mode probe would attempt to publish to `/run/kukeon-dev/` and is best exercised on a clean host). Daemon-parity expectation in CLAUDE.md updated to the new 3-col shape; the in-process test coverage in `cmd/kuke/get/realm` pins both default and `-o wide` column sets.

Closes #827