### PR TITLE
feat(get): kuke get space adds AGE, -o wide appends EGRESS NET-DEFAULTS

### DIFF
--- a/cmd/kuke/get/space/space.go
+++ b/cmd/kuke/get/space/space.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
@@ -142,20 +143,47 @@ func printSpaces(
 			cmd.Println("No spaces found.")
 			return nil
 		}
-		// Per-entity wide columns (EGRESS, NET-DEFAULTS) land in #602; this
-		// step only retires CGROUP/CONTROLLERS so the wide table currently
-		// renders the same shape as the default. The shared OutputFormatWide
-		// enum value is still accepted for symmetry across kinds.
-		headers := []string{"NAME", "REALM", "STATE"}
+		wide := format == shared.OutputFormatWide
+		headers := []string{"NAME", "REALM", "STATE", "AGE"}
+		if wide {
+			headers = append(headers, "EGRESS", "NET-DEFAULTS")
+		}
+		now := time.Now()
 		rows := make([][]string, 0, len(spaces))
 		for i := range spaces {
 			s := &spaces[i]
 			state := (&s.Status.State).String()
-			rows = append(rows, []string{s.Metadata.Name, s.Spec.RealmID, state})
+			row := []string{s.Metadata.Name, s.Spec.RealmID, state, shared.RenderAge(s.Status.CreatedAt, now)}
+			if wide {
+				row = append(row, egressDefault(s.Spec.Network), netDefaults(s.Spec.Defaults))
+			}
+			rows = append(rows, row)
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
 		return shared.PrintYAML(cmd, spaces)
 	}
+}
+
+// egressDefault renders the EGRESS column for `-o wide`. Returns "-" when
+// the space has no egress policy declared (Spec.Network or
+// Spec.Network.Egress nil); otherwise renders the policy default ("allow"
+// or "deny") as-is. An empty Default string also renders as "-" so a
+// half-populated EgressPolicy doesn't print a blank cell.
+func egressDefault(n *v1beta1.SpaceNetwork) string {
+	if n == nil || n.Egress == nil || n.Egress.Default == "" {
+		return "-"
+	}
+	return string(n.Egress.Default)
+}
+
+// netDefaults renders the NET-DEFAULTS column for `-o wide`. "yes" when
+// Spec.Defaults is non-nil (the space carries container-level defaults
+// that get inherited by containers in it); "-" otherwise.
+func netDefaults(d *v1beta1.SpaceDefaults) string {
+	if d == nil {
+		return "-"
+	}
+	return "yes"
 }

--- a/cmd/kuke/get/space/space_test.go
+++ b/cmd/kuke/get/space/space_test.go
@@ -137,6 +137,178 @@ func TestNewSpaceCmd(t *testing.T) {
 	}
 }
 
+// TestNewSpaceCmd_Columns pins the epic:get step-2 column contract for
+// `kuke get space` (issue #602): default emits `NAME REALM STATE AGE`
+// (4 cols); `-o wide` appends `EGRESS NET-DEFAULTS` (6 cols). EGRESS
+// renders `allow`/`deny`/`-` across the nil-cases for Spec.Network and
+// Spec.Network.Egress; NET-DEFAULTS renders `yes`/`-` boolean of whether
+// Spec.Defaults != nil. CGROUP/CONTROLLERS never appear in any table.
+func TestNewSpaceCmd_Columns(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_ string) ([]v1beta1.SpaceDoc, error) {
+		return []v1beta1.SpaceDoc{
+			{
+				// No network policy, no defaults — both wide cols render "-".
+				Metadata: v1beta1.SpaceMetadata{Name: "plain"},
+				Spec:     v1beta1.SpaceSpec{RealmID: "r1"},
+			},
+			{
+				// Explicit allow + defaults set.
+				Metadata: v1beta1.SpaceMetadata{Name: "open"},
+				Spec: v1beta1.SpaceSpec{
+					RealmID: "r1",
+					Network: &v1beta1.SpaceNetwork{
+						Egress: &v1beta1.EgressPolicy{Default: v1beta1.EgressDefaultAllow},
+					},
+					Defaults: &v1beta1.SpaceDefaults{},
+				},
+			},
+			{
+				// Explicit deny, no defaults.
+				Metadata: v1beta1.SpaceMetadata{Name: "locked"},
+				Spec: v1beta1.SpaceSpec{
+					RealmID: "r1",
+					Network: &v1beta1.SpaceNetwork{
+						Egress: &v1beta1.EgressPolicy{Default: v1beta1.EgressDefaultDeny},
+					},
+				},
+			},
+			{
+				// Spec.Network set but Egress nil — EGRESS renders "-".
+				Metadata: v1beta1.SpaceMetadata{Name: "netonly"},
+				Spec: v1beta1.SpaceSpec{
+					RealmID: "r1",
+					Network: &v1beta1.SpaceNetwork{},
+				},
+			},
+		}, nil
+	}
+
+	t.Run("default table is NAME REALM STATE AGE", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+
+		cmd := space.NewSpaceCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+		ctx = context.WithValue(ctx, space.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listSpacesFn: listFn}))
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		header := firstLine(out)
+		for _, want := range []string{"NAME", "REALM", "STATE", "AGE"} {
+			if !strings.Contains(header, want) {
+				t.Errorf("default header missing %q; got: %q", want, header)
+			}
+		}
+		for _, denied := range []string{"EGRESS", "NET-DEFAULTS", "CGROUP", "CONTROLLERS"} {
+			if strings.Contains(out, denied) {
+				t.Errorf("default output must NOT contain %q; got:\n%s", denied, out)
+			}
+		}
+	})
+
+	t.Run("-o wide appends EGRESS NET-DEFAULTS", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+
+		cmd := space.NewSpaceCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+		ctx = context.WithValue(ctx, space.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listSpacesFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-o", "wide"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		header := firstLine(out)
+		for _, want := range []string{"NAME", "REALM", "STATE", "AGE", "EGRESS", "NET-DEFAULTS"} {
+			if !strings.Contains(header, want) {
+				t.Errorf("wide header missing %q; got: %q", want, header)
+			}
+		}
+		for _, denied := range []string{"CGROUP", "CONTROLLERS"} {
+			if strings.Contains(out, denied) {
+				t.Errorf("-o wide output must NOT contain %q; got:\n%s", denied, out)
+			}
+		}
+
+		// Per-row EGRESS / NET-DEFAULTS rendering. Each row is identified
+		// by its NAME prefix; the assertion checks the row's cell values.
+		rows := dataRows(out)
+		cases := map[string]struct {
+			egress   string
+			defaults string
+		}{
+			"plain":   {egress: "-", defaults: "-"},
+			"open":    {egress: "allow", defaults: "yes"},
+			"locked":  {egress: "deny", defaults: "-"},
+			"netonly": {egress: "-", defaults: "-"},
+		}
+		for name, want := range cases {
+			row := findRow(rows, name)
+			if row == "" {
+				t.Errorf("row for %q not found in:\n%s", name, out)
+				continue
+			}
+			fields := strings.Fields(row)
+			// Columns: NAME REALM STATE AGE EGRESS NET-DEFAULTS = 6 fields.
+			if len(fields) != 6 {
+				t.Errorf("row %q: expected 6 fields, got %d (%q)", name, len(fields), row)
+				continue
+			}
+			if fields[4] != want.egress {
+				t.Errorf("row %q: EGRESS = %q, want %q", name, fields[4], want.egress)
+			}
+			if fields[5] != want.defaults {
+				t.Errorf("row %q: NET-DEFAULTS = %q, want %q", name, fields[5], want.defaults)
+			}
+		}
+	})
+}
+
+// firstLine returns the first newline-terminated line of s, or s itself
+// if it contains no newline. Used so column-presence assertions check the
+// header row only — data cells can't satisfy them by accident.
+func firstLine(s string) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return s[:idx]
+	}
+	return s
+}
+
+// dataRows returns the non-header rows of a PrintTable output. Lines 1
+// (header) and 2 (separator "---") are skipped; the remainder are data.
+func dataRows(s string) []string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) < 3 {
+		return nil
+	}
+	return lines[2:]
+}
+
+// findRow returns the first row whose first whitespace-delimited field
+// equals name, or "" when no row matches.
+func findRow(rows []string, name string) string {
+	for _, r := range rows {
+		fields := strings.Fields(r)
+		if len(fields) > 0 && fields[0] == name {
+			return r
+		}
+	}
+	return ""
+}
+
 // TestNewSpaceCmd_NoCgroupOrControllers pins the epic:get step-1
 // cross-cutting cleanup for spaces: the CGROUP column and the
 // --show-controllers flag must be gone, and -o wide must not resurrect

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -82,8 +82,8 @@ Spaces and stacks are only auto-created under `kuke-system` — the user-facing 
 
 ```bash
 $ kuke get spaces --realm kuke-system
-NAME    REALM        STATE
-kukeon  kuke-system  Ready
+NAME    REALM        STATE  AGE
+kukeon  kuke-system  Ready  <age>
 
 $ kuke get stacks --realm kuke-system --space kukeon
 NAME    REALM        SPACE   STATE


### PR DESCRIPTION
## Summary

- `kuke get space` default table is now `NAME REALM STATE AGE` (4 cols). The AGE column reuses the shared `RenderAge` helper #601 (PR #881) added.
- `kuke get space -o wide` now renders `NAME REALM STATE AGE EGRESS NET-DEFAULTS` (6 cols):
  - `EGRESS` = `Spec.Network.Egress.Default`, rendered as `allow` / `deny` / `-`. The dash also covers nil `Spec.Network`, nil `Spec.Network.Egress`, and an empty `Default` string (so a half-populated `EgressPolicy` doesn't print a blank cell).
  - `NET-DEFAULTS` = `yes` / `-` boolean of whether `Spec.Defaults != nil` — surfaces whether containers in this space inherit isolation policy.
- `docs/site/getting-started.md` space-table snippet updated to the 4-col shape with an `<age>` placeholder.

## Notes for reviewer

- **Issue body's parenthetical premise was stale, intent inferable.** The AC's note on `docs/site/getting-started.md` line 85 read `(NAME REALM STATE CGROUP)`, but #601 (PR #881) had already retired the `CGROUP` column from that snippet before this issue was picked up — the snippet at HEAD read `NAME REALM STATE` (3 cols). The intent — switch to the new 4-col shape — was unambiguous, so this PR applies the AC's spirit (4-col `NAME REALM STATE AGE`) rather than literally restoring `CGROUP` to drop it again. Per CLAUDE.md §"When the issue body's premise has rotted but intent is still inferable".
- **No `cli-use-cases.md` invariant added for spaces.** PR #881 added a realm-shape invariant at `docs/cli-use-cases.md:171` post-#601; the analogous space-shape invariant is not part of this issue's AC. Keeping scope tight — adding a fresh contract clause beyond the AC would be scope creep. PM can pull that thread separately if desired.
- **No project smoke (`make dev-init` daemon-parity).** The diff touches only the CLI's space-table rendering path — no daemon, no build path, no `/opt/kukeon`. Per CLAUDE.md "When a change touches the build path, the daemon, or anything under `/opt/kukeon`", the smoke is not a precondition here.

## Test plan

- [x] `GOWORK=off go build ./...` — clean.
- [x] `GOWORK=off go vet ./...` — clean.
- [x] `GOWORK=off go test ./cmd/kuke/get/space/...` — `TestNewSpaceCmd_Columns` (default + wide subtests covering all four EGRESS nil-cases, both NET-DEFAULTS branches) and the existing `TestNewSpaceCmd_NoCgroupOrControllers` pass.
- [x] `make test` — full suite green.
- [x] `pre-commit run --files <staged>` — clean (after one gofmt rewrite of an aligned struct literal).
- [ ] `make dev-init` daemon-parity guard — N/A; the diff does not touch the build path, the daemon, or anything under `/opt/kukeon` (CLI table-render only).

Closes #602