### PR TITLE
feat(get/stack): add AGE column, pin 5-col contract

### DIFF
--- a/cmd/kuke/get/stack/stack.go
+++ b/cmd/kuke/get/stack/stack.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
@@ -154,15 +155,21 @@ func printStacks(
 			cmd.Println("No stacks found.")
 			return nil
 		}
-		// Stack has no per-entity wide columns (#603 deliberately leaves
-		// -o wide rendering the same shape as default); this step only
-		// retires CGROUP/CONTROLLERS.
-		headers := []string{"NAME", "REALM", "SPACE", "STATE"}
+		// Stack has no per-entity wide columns — `-o wide` renders the
+		// same shape as default (#603). Investigation drops to -o yaml.
+		headers := []string{"NAME", "REALM", "SPACE", "STATE", "AGE"}
+		now := time.Now()
 		rows := make([][]string, 0, len(stacks))
 		for i := range stacks {
 			s := &stacks[i]
 			state := (&s.Status.State).String()
-			rows = append(rows, []string{s.Metadata.Name, s.Spec.RealmID, s.Spec.SpaceID, state})
+			rows = append(rows, []string{
+				s.Metadata.Name,
+				s.Spec.RealmID,
+				s.Spec.SpaceID,
+				state,
+				shared.RenderAge(s.Status.CreatedAt, now),
+			})
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil

--- a/cmd/kuke/get/stack/stack_test.go
+++ b/cmd/kuke/get/stack/stack_test.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	stack "github.com/eminwux/kukeon/cmd/kuke/get/stack"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -136,26 +137,30 @@ func TestNewStackCmd(t *testing.T) {
 	}
 }
 
-// TestNewStackCmd_NoCgroupOrControllers pins the epic:get step-1
-// cross-cutting cleanup for stacks: the CGROUP column and the
-// --show-controllers flag must be gone, and -o wide is accepted as a
-// valid output value (no error) while currently rendering the same
-// shape as default (sibling #603 leaves wide deliberately equal to
-// default for stacks).
-func TestNewStackCmd_NoCgroupOrControllers(t *testing.T) {
+// TestNewStackCmd_Columns pins the epic:get step-3 (#603) column
+// contract for `kuke get stack`: default and `-o wide` both emit
+// `NAME REALM SPACE STATE AGE` — stack carries no per-entity wide
+// columns beyond hierarchy pointers, so wide deliberately renders
+// the same shape as default. Also re-pins the cross-cutting epic
+// invariants from #827: the `CGROUP`/`CONTROLLERS` columns and the
+// `--show-controllers` flag stay gone.
+func TestNewStackCmd_Columns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
 	if stack.NewStackCmd().Flags().Lookup("show-controllers") != nil {
 		t.Error("show-controllers flag must be removed (issue #827)")
 	}
 
+	created := time.Now().Add(-2 * time.Hour)
 	listFn := func(_, _ string) ([]v1beta1.StackDoc, error) {
 		return []v1beta1.StackDoc{{
 			Metadata: v1beta1.StackMetadata{Name: "st1"},
 			Spec:     v1beta1.StackSpec{RealmID: "r1", SpaceID: "s1"},
 			Status: v1beta1.StackStatus{
+				State:              v1beta1.StackStateReady,
 				CgroupPath:         "/kukeon/r1/s1/st1",
 				SubtreeControllers: []string{"cpu", "memory"},
+				CreatedAt:          created,
 			},
 		}}, nil
 	}
@@ -175,12 +180,31 @@ func TestNewStackCmd_NoCgroupOrControllers(t *testing.T) {
 			t.Fatalf("args=%v: unexpected error: %v", args, err)
 		}
 		out := buf.String()
+		header := firstLine(out)
+		for _, want := range []string{"NAME", "REALM", "SPACE", "STATE", "AGE"} {
+			if !strings.Contains(header, want) {
+				t.Errorf("args=%v: header missing %q; got: %q", args, want, header)
+			}
+		}
 		for _, denied := range []string{"CGROUP", "CONTROLLERS"} {
 			if strings.Contains(out, denied) {
 				t.Errorf("args=%v: output must NOT contain %q; got:\n%s", args, denied, out)
 			}
 		}
+		// AGE value rendered against a 2h-old timestamp must surface
+		// the kubectl-style coarse duration (RenderAge floors to the
+		// largest unit), not the raw RFC3339 timestamp.
+		if !strings.Contains(out, "2h") {
+			t.Errorf("args=%v: expected AGE column to render \"2h\" for a 2h-old stack; got:\n%s", args, out)
+		}
 	}
+}
+
+func firstLine(s string) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return s[:idx]
+	}
+	return s
 }
 
 type fakeClient struct {

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -86,8 +86,8 @@ NAME    REALM        STATE
 kukeon  kuke-system  Ready
 
 $ kuke get stacks --realm kuke-system --space kukeon
-NAME    REALM        SPACE   STATE
-kukeon  kuke-system  kukeon  Ready
+NAME    REALM        SPACE   STATE  AGE
+kukeon  kuke-system  kukeon  Ready  <age>
 ```
 
 Add `-o wide` for per-kind extra columns (e.g. realm gains `NAMESPACE`), or `-o yaml` / `-o json` for full resource details (including `cgroupPath`).


### PR DESCRIPTION
## Summary
- Step 3 of `epic:get`: trims `kuke get stack` to the kubectl-style `NAME REALM SPACE STATE AGE` shape, building on the shared `OutputFormatWide` + `RenderAge` infra that landed in #881.
- `-o wide` is accepted as a valid output value but renders the same 5 columns as default — stack carries no per-entity spec beyond hierarchy pointers, so there's nothing meaningful to surface in a wide column without adding noise. Operators who want stack-level investigation drop to `-o yaml`/`-o json`.
- `cmd/kuke/get/stack/stack_test.go` swaps the prior `TestNewStackCmd_NoCgroupOrControllers` (which the `#603` body comment in code itself flagged as the wide-equals-default placeholder) for `TestNewStackCmd_Columns`, which now pins the full 5-col contract (header presence + `RenderAge` coarsening — a 2h-old `CreatedAt` must render as `2h`, not the raw timestamp) while re-pinning the `--show-controllers` / `CGROUP` / `CONTROLLERS` invariants from #827.
- `docs/site/getting-started.md` stack-table snippet updated to the new shape; the other stack references in `docs/cli-use-cases.md`, `docs/site/cli/kuke-get.md`, and `docs/site/concepts/stack.md` only mention the `kuke get stack` command (no rendered tables) and need no edit. The CLAUDE.md `make dev-init` regression-guard tail is realm-only, so it's untouched.

## Test plan
- [x] `GOWORK=off go vet ./cmd/kuke/get/stack/...`
- [x] `GOWORK=off go test ./cmd/kuke/get/stack/... -count=1` (passes; `TestNewStackCmd_Columns` covers both default and `-o wide`)
- [x] `make test` (whole-repo, all green; no regressions in sibling `get/*` packages)
- [x] `GOWORK=off go build ./...`
- [ ] `make dev-init` smoke test — not run; this change touches neither the build path nor the daemon nor `/opt/kukeon`, and the regression guard pins the realm table (not stack), so the smoke isn't affected.

Closes #603