### PR TITLE
feat(get): kuke get cell — trim default + -o wide CONTAINERS/BRIDGE

### DIFF
--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -20,28 +20,16 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
-	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-)
-
-const (
-	// syncStateSynced / syncStateOutOfSync are the SYNC column verdicts for
-	// Config-lineage cells. syncStateNone is the third state for cells that
-	// carry no kukeon.io/config lineage label (the bulk of the host —
-	// hand-built and `-b`-lineage cells are deliberately out of scope of the
-	// reconciler's OutOfSync detection per #819's umbrella) and follows the
-	// established `-` convention used by CgroupPath when empty.
-	syncStateSynced    = "Synced"
-	syncStateOutOfSync = "OutOfSync"
-	syncStateNone      = "-"
 )
 
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
@@ -54,18 +42,18 @@ func NewCellCmd() *cobra.Command {
 		Short:   "Get or list cell information",
 		Long: `Get or list cell information.
 
-The default table includes a SYNC column showing the reconciler-detected
-sync state of each cell relative to its lineage Config:
+The default table is ` + "`NAME REALM SPACE STACK STATE AGE`" + `.
+` + "`-o wide`" + ` appends two cell-only signals:
 
-  Synced     - the live spec matches what the lineage Config materializes
-  OutOfSync  - divergence detected (or the lineage Config was deleted)
-  -          - the cell carries no kukeon.io/config lineage label, so the
-               Config reconciler does not track sync state for it
+  CONTAINERS  ready/total — entries in status.containers whose
+              state == Ready over the total length
+  BRIDGE      status.network.bridgeName (the canonical k-{8hex}
+              form) or "-" when empty
 
-Use ` + "`-o wide`" + ` to add a DIVERGENCE column with the short divergence
-summary (or the error message when the reconciler could not compute
-divergence). ` + "`-o yaml` / `-o json`" + ` surface the full
-outOfSync / outOfSyncReason / outOfSyncError status fields.`,
+Reconciler-detected sync state (outOfSync / outOfSyncReason /
+outOfSyncError) and the cgroup path no longer appear in any
+` + "`kuke get cell`" + ` table — surface them with ` + "`-o yaml` / `-o json`" + `
+when needed.`,
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -182,49 +170,28 @@ func resolveOutput(cmd *cobra.Command) (bool, shared.OutputFormat, error) {
 	return false, format, err
 }
 
-// cellSyncState renders the SYNC column for a cell. The three values are
-// driven by the cell's lineage label and the reconciler-written OutOfSync
-// status fields (issue #820, populated by #830's detection loop). Cells
-// where OutOfSyncError is non-empty (divergence undecidable — Blueprint
-// missing or materialization failure) render as OutOfSync so the operator
-// gets one actionable "look at this cell" signal in the SYNC column; the
-// distinct error message surfaces in the DIVERGENCE column under -o wide
-// and in the outOfSyncError field under -o yaml/json.
-func cellSyncState(c *v1beta1.CellDoc) string {
-	if !hasConfigLineage(c) {
-		return syncStateNone
+// renderContainers returns the CONTAINERS column value (`ready/total`)
+// for a cell's status.containers slice — ready counts entries whose State
+// is ContainerStateReady, total is the slice length. Empty renders as "0/0".
+func renderContainers(c *v1beta1.CellDoc) string {
+	total := len(c.Status.Containers)
+	ready := 0
+	for i := range c.Status.Containers {
+		if c.Status.Containers[i].State == v1beta1.ContainerStateReady {
+			ready++
+		}
 	}
-	if c.Status.OutOfSync || c.Status.OutOfSyncError != "" {
-		return syncStateOutOfSync
-	}
-	return syncStateSynced
+	return fmt.Sprintf("%d/%d", ready, total)
 }
 
-// cellDivergence renders the DIVERGENCE column under -o wide. Synced or
-// no-lineage cells render `-` (matching the established CgroupPath empty
-// convention) so the column stays width-aligned. Reason takes precedence
-// over Error when both are set (the reconciler never sets both, but the
-// order is defensive).
-func cellDivergence(c *v1beta1.CellDoc) string {
-	if !hasConfigLineage(c) {
-		return syncStateNone
+// renderBridge returns the BRIDGE column value — the canonical k-{8hex}
+// bridge name from status.network.bridgeName, or "-" when empty (matching
+// the dash convention used elsewhere for unset table cells).
+func renderBridge(c *v1beta1.CellDoc) string {
+	if name := strings.TrimSpace(c.Status.Network.BridgeName); name != "" {
+		return name
 	}
-	if c.Status.OutOfSyncReason != "" {
-		return c.Status.OutOfSyncReason
-	}
-	if c.Status.OutOfSyncError != "" {
-		return "error: " + c.Status.OutOfSyncError
-	}
-	return syncStateNone
-}
-
-// hasConfigLineage matches the configLineage helper in
-// internal/controller/reconcile_outofsync.go: a cell is Config-lineage iff
-// it carries a non-empty kukeon.io/config label. Replicated inline rather
-// than imported to keep the CLI leaf free of an internal/controller
-// dependency.
-func hasConfigLineage(c *v1beta1.CellDoc) bool {
-	return strings.TrimSpace(c.Metadata.Labels[cellconfig.LabelConfig]) != ""
+	return "-"
 }
 
 func printCell(cmd *cobra.Command, cell *v1beta1.CellDoc, format shared.OutputFormat) error {
@@ -252,10 +219,11 @@ func printCells(
 			cmd.Println("No cells found.")
 			return nil
 		}
-		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "SYNC"}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "AGE"}
 		if wide {
-			headers = append(headers, "DIVERGENCE")
+			headers = append(headers, "CONTAINERS", "BRIDGE")
 		}
+		now := time.Now()
 		rows := make([][]string, 0, len(cells))
 		for i := range cells {
 			c := &cells[i]
@@ -266,10 +234,10 @@ func printCells(
 				c.Spec.SpaceID,
 				c.Spec.StackID,
 				state,
-				cellSyncState(c),
+				shared.RenderAge(c.Status.CreatedAt, now),
 			}
 			if wide {
-				row = append(row, cellDivergence(c))
+				row = append(row, renderContainers(c), renderBridge(c))
 			}
 			rows = append(rows, row)
 		}

--- a/cmd/kuke/get/cell/cell_test.go
+++ b/cmd/kuke/get/cell/cell_test.go
@@ -27,7 +27,6 @@ import (
 
 	cell "github.com/eminwux/kukeon/cmd/kuke/get/cell"
 	"github.com/eminwux/kukeon/cmd/types"
-	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -139,110 +138,147 @@ func TestNewCellCmd(t *testing.T) {
 	}
 }
 
-// TestNewCellCmd_SyncColumn covers the SYNC column the `kuke get cell`
-// default table acquired alongside #830's OutOfSync detection (issue #822).
-// Each subtest pins a single mock cell and asserts the rendered SYNC value
-// and (in -o wide) the DIVERGENCE value, plus that the SYNC header is
-// always present in the default table. The fourth case asserts the full
-// status fields land in -o yaml without an extra projection step — the
-// strict-omitempty serialization in pkg/api/model/v1beta1/cell.go means
-// non-default values surface automatically.
-func TestNewCellCmd_SyncColumn(t *testing.T) {
+// TestNewCellCmd_DefaultColumns pins the default `kuke get cell` column set
+// after the epic:get redefinition (issue #604): NAME REALM SPACE STACK STATE
+// AGE — six columns, no SYNC / CGROUP / CONTAINERS / BRIDGE / DIVERGENCE.
+func TestNewCellCmd_DefaultColumns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
-	configLineageLabels := map[string]string{cellconfig.LabelConfig: "prod"}
+	listFn := func(_, _, _ string) ([]v1beta1.CellDoc, error) {
+		return []v1beta1.CellDoc{{
+			Metadata: v1beta1.CellMetadata{Name: "ce1"},
+			Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+			Status: v1beta1.CellStatus{
+				State:      v1beta1.CellStateReady,
+				CgroupPath: "/kukeon/r1/s1/st1/ce1",
+				Network:    v1beta1.CellNetworkStatus{BridgeName: "k-1a2b3c4d"},
+				Containers: []v1beta1.ContainerStatus{
+					{Name: "root", State: v1beta1.ContainerStateReady},
+				},
+			},
+		}}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	cmd := cell.NewCellCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, cell.MockControllerKey{},
+		kukeonv1.Client(&fakeClient{listCellsFn: listFn}))
+	cmd.SetContext(ctx)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	for _, h := range []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "AGE"} {
+		if !strings.Contains(out, h) {
+			t.Errorf("default table missing header %q\nGot:\n%s", h, out)
+		}
+	}
+	for _, denied := range []string{"CGROUP", "CONTROLLERS", "SYNC", "DIVERGENCE", "CONTAINERS", "BRIDGE"} {
+		if strings.Contains(out, denied) {
+			t.Errorf("default table must NOT contain %q; got:\n%s", denied, out)
+		}
+	}
+}
+
+// TestNewCellCmd_WideColumns pins the `-o wide` column set after the
+// epic:get redefinition: NAME REALM SPACE STACK STATE AGE CONTAINERS BRIDGE
+// (8 cols). CGROUP, SYNC, DIVERGENCE must not appear.
+func TestNewCellCmd_WideColumns(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_, _, _ string) ([]v1beta1.CellDoc, error) {
+		return []v1beta1.CellDoc{{
+			Metadata: v1beta1.CellMetadata{Name: "ce1"},
+			Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+			Status: v1beta1.CellStatus{
+				State:   v1beta1.CellStateReady,
+				Network: v1beta1.CellNetworkStatus{BridgeName: "k-1a2b3c4d"},
+				Containers: []v1beta1.ContainerStatus{
+					{Name: "root", State: v1beta1.ContainerStateReady},
+					{Name: "side", State: v1beta1.ContainerStatePending},
+				},
+			},
+		}}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	cmd := cell.NewCellCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, cell.MockControllerKey{},
+		kukeonv1.Client(&fakeClient{listCellsFn: listFn}))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-o", "wide"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	for _, h := range []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "AGE", "CONTAINERS", "BRIDGE"} {
+		if !strings.Contains(out, h) {
+			t.Errorf("-o wide table missing header %q\nGot:\n%s", h, out)
+		}
+	}
+	for _, denied := range []string{"CGROUP", "CONTROLLERS", "SYNC", "DIVERGENCE"} {
+		if strings.Contains(out, denied) {
+			t.Errorf("-o wide table must NOT contain %q; got:\n%s", denied, out)
+		}
+	}
+	for _, sub := range []string{"ce1", "1/2", "k-1a2b3c4d"} {
+		if !strings.Contains(out, sub) {
+			t.Errorf("-o wide row missing %q\nGot:\n%s", sub, out)
+		}
+	}
+}
+
+// TestNewCellCmd_ContainersReadyTotal pins the ready/total rendering edge
+// cases enumerated in #604's AC: 0/0 (no containers), 0/1 (one pending),
+// 1/1 (one ready), and 2/3 (two of three ready). BRIDGE empty renders as
+// "-" — checked under the 0/0 case so a single subtest covers both
+// no-runtime fallbacks.
+func TestNewCellCmd_ContainersReadyTotal(t *testing.T) {
+	t.Cleanup(viper.Reset)
 
 	tests := []struct {
-		name        string
-		cells       []v1beta1.CellDoc
-		extraFlags  map[string]string
-		wantHeaders []string
-		wantRow     []string // substrings that must all appear on the cell's row
-		wantStatus  []string // substrings that must all appear in yaml output
+		name       string
+		containers []v1beta1.ContainerStatus
+		bridge     string
+		wantRow    []string
 	}{
 		{
-			name: "synced cell renders Synced in default table",
-			cells: []v1beta1.CellDoc{{
-				Metadata: v1beta1.CellMetadata{Name: "ce1", Labels: configLineageLabels},
-				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-				Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady},
-			}},
-			wantHeaders: []string{"SYNC"},
-			wantRow:     []string{"ce1", "Synced"},
+			name:       "empty list renders 0/0 and bridge dash",
+			containers: nil,
+			bridge:     "",
+			wantRow:    []string{"0/0", " - "},
 		},
 		{
-			name: "out-of-sync cell renders OutOfSync in default table",
-			cells: []v1beta1.CellDoc{{
-				Metadata: v1beta1.CellMetadata{Name: "ce2", Labels: configLineageLabels},
-				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-				Status: v1beta1.CellStatus{
-					State:           v1beta1.CellStateReady,
-					OutOfSync:       true,
-					OutOfSyncReason: "spec differs: image",
-				},
-			}},
-			wantHeaders: []string{"SYNC"},
-			wantRow:     []string{"ce2", "OutOfSync"},
+			name:       "single pending renders 0/1",
+			containers: []v1beta1.ContainerStatus{{Name: "root", State: v1beta1.ContainerStatePending}},
+			bridge:     "k-aaaaaaaa",
+			wantRow:    []string{"0/1", "k-aaaaaaaa"},
 		},
 		{
-			name: "no-lineage cell renders dash in SYNC column",
-			cells: []v1beta1.CellDoc{{
-				Metadata: v1beta1.CellMetadata{Name: "ce3"},
-				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-				Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady},
-			}},
-			wantHeaders: []string{"SYNC"},
-			// CGROUP retired in #827, so SYNC is now the last default column;
-			// the no-lineage row ends in "-" preceded by the col separator,
-			// which PrintTable's width-padded last column still surrounds
-			// with spaces — " - " stays a stable substring.
-			wantRow: []string{"ce3", " - "},
+			name:       "single ready renders 1/1",
+			containers: []v1beta1.ContainerStatus{{Name: "root", State: v1beta1.ContainerStateReady}},
+			bridge:     "k-bbbbbbbb",
+			wantRow:    []string{"1/1", "k-bbbbbbbb"},
 		},
 		{
-			name: "-o wide adds DIVERGENCE column with reason for out-of-sync cells",
-			cells: []v1beta1.CellDoc{{
-				Metadata: v1beta1.CellMetadata{Name: "ce4", Labels: configLineageLabels},
-				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-				Status: v1beta1.CellStatus{
-					State:           v1beta1.CellStateReady,
-					OutOfSync:       true,
-					OutOfSyncReason: "spec differs: image, env",
-				},
-			}},
-			extraFlags:  map[string]string{"output": "wide"},
-			wantHeaders: []string{"SYNC", "DIVERGENCE"},
-			wantRow:     []string{"ce4", "OutOfSync", "spec differs: image, env"},
-		},
-		{
-			name: "-o wide surfaces OutOfSyncError as error: <msg>",
-			cells: []v1beta1.CellDoc{{
-				Metadata: v1beta1.CellMetadata{Name: "ce5", Labels: configLineageLabels},
-				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-				Status: v1beta1.CellStatus{
-					State:          v1beta1.CellStateReady,
-					OutOfSyncError: `blueprint "web" not found`,
-				},
-			}},
-			extraFlags:  map[string]string{"output": "wide"},
-			wantHeaders: []string{"SYNC", "DIVERGENCE"},
-			// OutOfSyncError folds into the OutOfSync SYNC verdict; the
-			// distinct surface lives in DIVERGENCE so the operator sees
-			// the actionable signal in the column they're filtering on.
-			wantRow: []string{"ce5", "OutOfSync", `error: blueprint "web" not found`},
-		},
-		{
-			name: "-o yaml passes through outOfSync and outOfSyncReason fields",
-			cells: []v1beta1.CellDoc{{
-				Metadata: v1beta1.CellMetadata{Name: "ce6", Labels: configLineageLabels},
-				Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-				Status: v1beta1.CellStatus{
-					State:           v1beta1.CellStateReady,
-					OutOfSync:       true,
-					OutOfSyncReason: "lineage Config deleted",
-				},
-			}},
-			extraFlags: map[string]string{"output": "yaml"},
-			wantStatus: []string{"outOfSync: true", "outOfSyncReason: lineage Config deleted"},
+			name: "two of three ready renders 2/3",
+			containers: []v1beta1.ContainerStatus{
+				{Name: "root", State: v1beta1.ContainerStateReady},
+				{Name: "side", State: v1beta1.ContainerStateReady},
+				{Name: "boot", State: v1beta1.ContainerStateFailed},
+			},
+			bridge:  "k-cccccccc",
+			wantRow: []string{"2/3", "k-cccccccc"},
 		},
 	}
 
@@ -250,94 +286,94 @@ func TestNewCellCmd_SyncColumn(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Cleanup(viper.Reset)
 
-			cmd := cell.NewCellCmd()
+			listFn := func(_, _, _ string) ([]v1beta1.CellDoc, error) {
+				return []v1beta1.CellDoc{{
+					Metadata: v1beta1.CellMetadata{Name: "ce1"},
+					Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+					Status: v1beta1.CellStatus{
+						State:      v1beta1.CellStateReady,
+						Network:    v1beta1.CellNetworkStatus{BridgeName: tt.bridge},
+						Containers: tt.containers,
+					},
+				}}, nil
+			}
+
 			buf := &bytes.Buffer{}
+			cmd := cell.NewCellCmd()
 			cmd.SetOut(buf)
 			cmd.SetErr(buf)
-
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-			fake := &fakeClient{
-				listCellsFn: func(_, _, _ string) ([]v1beta1.CellDoc, error) {
-					return tt.cells, nil
-				},
-			}
-			ctx = context.WithValue(ctx, cell.MockControllerKey{}, kukeonv1.Client(fake))
+			ctx = context.WithValue(ctx, cell.MockControllerKey{},
+				kukeonv1.Client(&fakeClient{listCellsFn: listFn}))
 			cmd.SetContext(ctx)
-
-			for flag, val := range tt.extraFlags {
-				if err := cmd.Flags().Set(flag, val); err != nil {
-					t.Fatalf("set flag %s=%s: %v", flag, val, err)
-				}
-			}
-
+			cmd.SetArgs([]string{"-o", "wide"})
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			out := buf.String()
-			for _, h := range tt.wantHeaders {
-				if !strings.Contains(out, h) {
-					t.Errorf("table missing header %q\nGot:\n%s", h, out)
-				}
-			}
 			for _, sub := range tt.wantRow {
 				if !strings.Contains(out, sub) {
-					t.Errorf("row missing %q\nGot:\n%s", sub, out)
-				}
-			}
-			for _, sub := range tt.wantStatus {
-				if !strings.Contains(out, sub) {
-					t.Errorf("yaml output missing %q\nGot:\n%s", sub, out)
+					t.Errorf("-o wide row missing %q\nGot:\n%s", sub, out)
 				}
 			}
 		})
 	}
 }
 
-// TestNewCellCmd_NoCgroupOrControllers pins the epic:get step-1
-// cross-cutting cleanup for cells: the CGROUP column and the
-// --show-controllers flag must be gone in both default and -o wide
-// output (the SYNC and DIVERGENCE columns added by earlier work are
-// unaffected; -o wide still appends DIVERGENCE).
-func TestNewCellCmd_NoCgroupOrControllers(t *testing.T) {
-	t.Cleanup(viper.Reset)
-
+// TestNewCellCmd_NoShowControllersFlag pins the epic:get step-1 retirement
+// of `--show-controllers`: the flag must not be registered on the cell
+// command after #881 (issue #827).
+func TestNewCellCmd_NoShowControllersFlag(t *testing.T) {
 	if cell.NewCellCmd().Flags().Lookup("show-controllers") != nil {
 		t.Error("show-controllers flag must be removed (issue #827)")
 	}
+}
+
+// TestNewCellCmd_YamlSurfacesStatus pins the contract that the cell table
+// no longer surfaces sync state or cgroup info, but `-o yaml` still does —
+// operators who need those fields read them from the structured output.
+func TestNewCellCmd_YamlSurfacesStatus(t *testing.T) {
+	t.Cleanup(viper.Reset)
 
 	listFn := func(_, _, _ string) ([]v1beta1.CellDoc, error) {
 		return []v1beta1.CellDoc{{
 			Metadata: v1beta1.CellMetadata{Name: "ce1"},
 			Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
 			Status: v1beta1.CellStatus{
-				State:              v1beta1.CellStateReady,
-				CgroupPath:         "/kukeon/r1/s1/st1/ce1",
-				SubtreeControllers: []string{"cpu", "memory"},
+				State:           v1beta1.CellStateReady,
+				CgroupPath:      "/kukeon/r1/s1/st1/ce1",
+				OutOfSync:       true,
+				OutOfSyncReason: "lineage Config deleted",
 			},
 		}}, nil
 	}
 
-	for _, args := range [][]string{nil, {"-o", "wide"}} {
-		buf := &bytes.Buffer{}
-		cmd := cell.NewCellCmd()
-		cmd.SetOut(buf)
-		cmd.SetErr(buf)
-		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-		ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-		ctx = context.WithValue(ctx, cell.MockControllerKey{},
-			kukeonv1.Client(&fakeClient{listCellsFn: listFn}))
-		cmd.SetContext(ctx)
-		cmd.SetArgs(args)
-		if err := cmd.Execute(); err != nil {
-			t.Fatalf("args=%v: unexpected error: %v", args, err)
-		}
-		out := buf.String()
-		for _, denied := range []string{"CGROUP", "CONTROLLERS"} {
-			if strings.Contains(out, denied) {
-				t.Errorf("args=%v: output must NOT contain %q; got:\n%s", args, denied, out)
-			}
+	buf := &bytes.Buffer{}
+	cmd := cell.NewCellCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, cell.MockControllerKey{},
+		kukeonv1.Client(&fakeClient{listCellsFn: listFn}))
+	cmd.SetContext(ctx)
+	if err := cmd.Flags().Set("output", "yaml"); err != nil {
+		t.Fatalf("set output=yaml: %v", err)
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	for _, sub := range []string{
+		"cgroupPath: /kukeon/r1/s1/st1/ce1",
+		"outOfSync: true",
+		"outOfSyncReason: lineage Config deleted",
+	} {
+		if !strings.Contains(out, sub) {
+			t.Errorf("yaml output missing %q\nGot:\n%s", sub, out)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Default `kuke get cell` table is now `NAME REALM SPACE STACK STATE AGE` (6 cols). The SYNC column (added in #822, retained alongside #881's CGROUP retirement) drops to keep the default lean — operators who need sync state read it from `-o yaml` / `-o json`.
- `kuke get cell -o wide` is now `NAME REALM SPACE STACK STATE AGE CONTAINERS BRIDGE` (8 cols). `CONTAINERS` renders `ready/total` (numerator counts `Status.Containers` entries with `State == ContainerStateReady`, denominator is the slice length; empty list renders `0/0`). `BRIDGE` surfaces `Status.Network.BridgeName` (canonical `k-{8hex}`) or `-` when empty. The DIVERGENCE wide-only column drops alongside SYNC.
- `cellSyncState` / `cellDivergence` / `hasConfigLineage` helpers and the `syncStateSynced/OutOfSync/None` constants are removed — no longer referenced after the table redefinition. The internal `cellconfig` import drops as a consequence.
- Test file restructured: per-AC tests for default columns, wide columns, the ready/total edge cases (`0/0`, `0/1`, `1/1`, `2/3`), `--show-controllers` non-registration (preserved from #881), and a new yaml-passthrough test pinning that `outOfSync` / `outOfSyncReason` / `cgroupPath` still surface in `-o yaml`.

### Reading the AC against current main

#604's AC was written against pre-#881 baseline (default columns included `CGROUP`); #881 retired `CGROUP` before this issue picked up. The AC's "drops `CGROUP`" item is satisfied by #881 and pinned here via the explicit denylist (`CGROUP`, `CONTROLLERS`, `SYNC`, `DIVERGENCE`) in the default-columns test. The AC's enumerated 6 / 8-column composition also drops `SYNC` and `DIVERGENCE` — both columns lived in cell only (no other `kuke get <kind>` table has them), and the underlying status fields stay surfaced via `-o yaml` / `-o json`, so the trim is reversible by an operator who needs the signal. Documented here per the "premise has rotted but intent is still inferable" path in `agents/dev/CLAUDE.md`.

## Test plan

- [x] `GOWORK=off go test ./cmd/kuke/get/cell/...` — passes, all six tests (`TestNewCellCmd`, `TestNewCellCmd_DefaultColumns`, `TestNewCellCmd_WideColumns`, `TestNewCellCmd_ContainersReadyTotal` + 4 subtests, `TestNewCellCmd_NoShowControllersFlag`, `TestNewCellCmd_YamlSurfacesStatus`).
- [x] `make test` — full suite green.
- [x] `GOWORK=off go vet ./...` — clean.
- [x] `pre-commit run --files cmd/kuke/get/cell/cell.go cmd/kuke/get/cell/cell_test.go` — clean.
- [ ] `make dev-init` smoke / two-realm parity tail — not executed in this session (containerd daemon not running on this sandbox host and `kuke get cell` is read-only against in-memory mocks; the daemon-parity tail check pins realm columns, which this change does not touch).

Closes #604