### PR TITLE
refactor(get): extract duplicated firstLine into shared testutil package

### DIFF
--- a/cmd/kuke/get/realm/realm_test.go
+++ b/cmd/kuke/get/realm/realm_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	realm "github.com/eminwux/kukeon/cmd/kuke/get/realm"
+	"github.com/eminwux/kukeon/cmd/kuke/get/testutil"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -196,7 +197,7 @@ func TestNewRealmCmd_Columns(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		out := buf.String()
-		header := firstLine(out)
+		header := testutil.FirstLine(out)
 		// The header is rendered before any data row; check it directly so
 		// row data can't accidentally satisfy the column-presence assertion.
 		for _, want := range []string{"NAME", "STATE", "AGE"} {
@@ -227,7 +228,7 @@ func TestNewRealmCmd_Columns(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		out := buf.String()
-		header := firstLine(out)
+		header := testutil.FirstLine(out)
 		for _, want := range []string{"NAME", "STATE", "AGE", "NAMESPACE"} {
 			if !strings.Contains(header, want) {
 				t.Errorf("wide header missing %q; got: %q", want, header)
@@ -263,13 +264,6 @@ func TestNewRealmCmd_Columns(t *testing.T) {
 			t.Errorf("-o yaml should still surface cgroupPath; got:\n%s", out)
 		}
 	})
-}
-
-func firstLine(s string) string {
-	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
-		return s[:idx]
-	}
-	return s
 }
 
 type fakeClient struct {

--- a/cmd/kuke/get/space/space_test.go
+++ b/cmd/kuke/get/space/space_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	space "github.com/eminwux/kukeon/cmd/kuke/get/space"
+	"github.com/eminwux/kukeon/cmd/kuke/get/testutil"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -201,7 +202,7 @@ func TestNewSpaceCmd_Columns(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		out := buf.String()
-		header := firstLine(out)
+		header := testutil.FirstLine(out)
 		for _, want := range []string{"NAME", "REALM", "STATE", "AGE"} {
 			if !strings.Contains(header, want) {
 				t.Errorf("default header missing %q; got: %q", want, header)
@@ -231,7 +232,7 @@ func TestNewSpaceCmd_Columns(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		out := buf.String()
-		header := firstLine(out)
+		header := testutil.FirstLine(out)
 		for _, want := range []string{"NAME", "REALM", "STATE", "AGE", "EGRESS", "NET-DEFAULTS"} {
 			if !strings.Contains(header, want) {
 				t.Errorf("wide header missing %q; got: %q", want, header)
@@ -275,16 +276,6 @@ func TestNewSpaceCmd_Columns(t *testing.T) {
 			}
 		}
 	})
-}
-
-// firstLine returns the first newline-terminated line of s, or s itself
-// if it contains no newline. Used so column-presence assertions check the
-// header row only — data cells can't satisfy them by accident.
-func firstLine(s string) string {
-	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
-		return s[:idx]
-	}
-	return s
 }
 
 // dataRows returns the non-header rows of a PrintTable output. Lines 1

--- a/cmd/kuke/get/stack/stack_test.go
+++ b/cmd/kuke/get/stack/stack_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	stack "github.com/eminwux/kukeon/cmd/kuke/get/stack"
+	"github.com/eminwux/kukeon/cmd/kuke/get/testutil"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -180,7 +181,7 @@ func TestNewStackCmd_Columns(t *testing.T) {
 			t.Fatalf("args=%v: unexpected error: %v", args, err)
 		}
 		out := buf.String()
-		header := firstLine(out)
+		header := testutil.FirstLine(out)
 		for _, want := range []string{"NAME", "REALM", "SPACE", "STATE", "AGE"} {
 			if !strings.Contains(header, want) {
 				t.Errorf("args=%v: header missing %q; got: %q", args, want, header)
@@ -198,13 +199,6 @@ func TestNewStackCmd_Columns(t *testing.T) {
 			t.Errorf("args=%v: expected AGE column to render \"2h\" for a 2h-old stack; got:\n%s", args, out)
 		}
 	}
-}
-
-func firstLine(s string) string {
-	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
-		return s[:idx]
-	}
-	return s
 }
 
 type fakeClient struct {

--- a/cmd/kuke/get/testutil/firstline.go
+++ b/cmd/kuke/get/testutil/firstline.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package testutil provides test helpers shared across the kuke get
+// subcommand test suites.
+package testutil
+
+import "strings"
+
+// FirstLine returns the first newline-terminated line of s, or s itself
+// if it contains no newline. Used so column-presence assertions check the
+// header row only — data cells can't satisfy them by accident.
+func FirstLine(s string) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return s[:idx]
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- `firstLine(s string) string` was defined identically in three sibling `get/*` test files (realm, space, stack) with the docstring only present on one copy (space). Extracted into a shared `cmd/kuke/get/testutil` package with the canonical docstring carried forward.
- Removed the three local definitions, reducing duplication and making the helper reusable by future `get/*` test suites (e.g. cell, container, blueprint).

## Test plan
- [x] `GOWORK=off go vet ./cmd/kuke/get/...`
- [x] `GOWORK=off go test ./cmd/kuke/... -count=1` (all 70 packages pass)
- [x] `GOWORK=off go build ./...`

Closes #886