### PR TITLE
feat(get): kuke get container — trim default + -o wide IMAGE/EXIT, add RESTARTS/AGE

### DIFF
--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
@@ -41,9 +42,21 @@ const noContainersFoundMsg = "No containers found."
 
 func NewContainerCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "container [name]",
-		Aliases:       []string{"containers", "co"},
-		Short:         "Get or list container information",
+		Use:     "container [name]",
+		Aliases: []string{"containers", "co"},
+		Short:   "Get or list container information",
+		Long: `Get or list container information.
+
+The default table is ` + "`NAME REALM SPACE STACK CELL STATE RESTARTS AGE`" + `.
+` + "`-o wide`" + ` appends two container-only signals:
+
+  IMAGE  spec.image (the resolved container image reference)
+  EXIT   ` + "`<exitCode>/<exitSignal>`" + ` when either field is non-zero/
+         non-empty; "-" otherwise — most meaningful on Stopped/Failed.
+
+CGROUP, ROOT (as a column), and IMAGE (as a default column) no longer
+appear in the default table — use ` + "`-o yaml` / `-o json`" + ` for the
+full container spec.`,
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -81,7 +94,7 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = client.Close() }()
 
-	outputFormat, err := shared.ParseOutputFormat(cmd)
+	wide, outputFormat, err := resolveOutput(cmd)
 	if err != nil {
 		return err
 	}
@@ -165,7 +178,7 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	containerStates := make(map[string]string, len(specs))
+	containerProbes := make(map[string]containerProbe, len(specs))
 	for i := range specs {
 		spec := specs[i]
 		if spec.RealmID == "" {
@@ -187,19 +200,38 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 		probeResult, err := client.GetContainer(cmd.Context(), probe)
 		if err != nil {
 			cmd.PrintErrln("Warning: failed to get container state for", spec.ID, ":", err)
-			containerStates[spec.ID] = "Unknown"
+			containerProbes[spec.ID] = containerProbe{state: "Unknown"}
 			continue
 		}
-		containerStates[spec.ID] = containerStateToString(probeResult.Container.Status.State)
+		st := probeResult.Container.Status
+		containerProbes[spec.ID] = containerProbe{
+			state:        containerStateToString(st.State),
+			restartCount: st.RestartCount,
+			createdAt:    st.CreatedAt,
+			exitCode:     st.ExitCode,
+			exitSignal:   st.ExitSignal,
+		}
 	}
 
 	return printContainersWithState(
 		cmd,
 		specs,
-		containerStates,
+		containerProbes,
 		outputFormat,
+		wide,
 		emptyMsg,
 	)
+}
+
+// containerProbe carries the per-container fields a list-path probe pulls
+// from GetContainer for the table renderer. State is the human-readable
+// label; the rest source the RESTARTS / AGE / EXIT columns.
+type containerProbe struct {
+	state        string
+	restartCount int
+	createdAt    time.Time
+	exitCode     int
+	exitSignal   string
 }
 
 // buildEmptyResultMessage describes the queried filter set when zero rows
@@ -320,8 +352,9 @@ func printContainer(cmd *cobra.Command, container interface{}, format shared.Out
 func printContainersWithState(
 	cmd *cobra.Command,
 	containers []v1beta1.ContainerSpec,
-	containerStates map[string]string,
+	probes map[string]containerProbe,
 	format shared.OutputFormat,
+	wide bool,
 	emptyMsg string,
 ) error {
 	switch format {
@@ -329,7 +362,7 @@ func printContainersWithState(
 		return shared.PrintYAML(cmd, containers)
 	case shared.OutputFormatJSON:
 		return shared.PrintJSON(cmd, containers)
-	case shared.OutputFormatTable, shared.OutputFormatWide:
+	case shared.OutputFormatTable:
 		if len(containers) == 0 {
 			if emptyMsg == "" {
 				emptyMsg = noContainersFoundMsg
@@ -337,32 +370,62 @@ func printContainersWithState(
 			cmd.Println(emptyMsg)
 			return nil
 		}
-		headers := []string{"NAME", "REALM", "SPACE", "STACK", "CELL", "ROOT", "IMAGE", "STATE"}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK", "CELL", "STATE", "RESTARTS", "AGE"}
+		if wide {
+			headers = append(headers, "IMAGE", "EXIT")
+		}
+		now := time.Now()
 		rows := make([][]string, 0, len(containers))
 		for i := range containers {
 			c := &containers[i]
-			state := "Unknown"
-			if containerStates != nil {
-				if s, ok := containerStates[c.ID]; ok {
-					state = s
-				}
+			p, ok := probes[c.ID]
+			if !ok {
+				p = containerProbe{state: "Unknown"}
 			}
-			rows = append(rows, []string{
+			row := []string{
 				containerDisplayName(c),
 				c.RealmID,
 				c.SpaceID,
 				c.StackID,
 				c.CellID,
-				strconv.FormatBool(c.Root),
-				c.Image,
-				state,
-			})
+				p.state,
+				strconv.Itoa(p.restartCount),
+				shared.RenderAge(p.createdAt, now),
+			}
+			if wide {
+				row = append(row, c.Image, renderExit(p.exitCode, p.exitSignal))
+			}
+			rows = append(rows, row)
 		}
 		shared.PrintTable(cmd, headers, rows)
 		return nil
 	default:
 		return shared.PrintYAML(cmd, containers)
 	}
+}
+
+// resolveOutput sits between the cobra flag and ParseOutputFormat so the
+// `wide` value is normalised to `table` plus a bool, leaving the shared
+// yaml/json/table parser untouched. Mirrors the helper in cmd/kuke/get/cell.
+func resolveOutput(cmd *cobra.Command) (bool, shared.OutputFormat, error) {
+	raw := strings.TrimSpace(cmd.Flag("output").Value.String())
+	if strings.EqualFold(raw, "wide") {
+		_ = cmd.Flags().Set("output", "table")
+		format, err := shared.ParseOutputFormat(cmd)
+		return true, format, err
+	}
+	format, err := shared.ParseOutputFormat(cmd)
+	return false, format, err
+}
+
+// renderExit returns the EXIT column value — `<code>/<signal>` when either
+// field is non-zero/non-empty, "-" when both are at their zero values.
+// Most meaningful on Stopped/Failed states. Issue #605.
+func renderExit(code int, signal string) string {
+	if code == 0 && signal == "" {
+		return "-"
+	}
+	return fmt.Sprintf("%d/%s", code, signal)
 }
 
 func containerStateToString(state v1beta1.ContainerState) string {

--- a/cmd/kuke/get/container/container_test.go
+++ b/cmd/kuke/get/container/container_test.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	container "github.com/eminwux/kukeon/cmd/kuke/get/container"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -338,6 +339,261 @@ func TestGetContainer_NotFound_SurfacesSentinel(t *testing.T) {
 	err := cmd.Execute()
 	if !errors.Is(err, errdefs.ErrContainerNotFound) {
 		t.Fatalf("error %v does not unwrap to ErrContainerNotFound", err)
+	}
+}
+
+// TestNewContainerCmd_DefaultColumns pins the default `kuke get container`
+// column set after the epic:get redefinition (issue #605): NAME REALM SPACE
+// STACK CELL STATE RESTARTS AGE — eight columns. ROOT (as a column), IMAGE
+// (as a default column), and CGROUP must NOT appear.
+func TestNewContainerCmd_DefaultColumns(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+		return []v1beta1.ContainerSpec{
+			{ID: "co1", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "ce1", Image: "img"},
+		}, nil
+	}
+	getFn := func(_ v1beta1.ContainerDoc) (kukeonv1.GetContainerResult, error) {
+		return kukeonv1.GetContainerResult{
+			Container: v1beta1.ContainerDoc{
+				Status: v1beta1.ContainerStatus{
+					State:        v1beta1.ContainerStateReady,
+					RestartCount: 3,
+					CreatedAt:    time.Now().Add(-2 * time.Hour),
+				},
+			},
+			ContainerExists: true,
+		}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	cmd := container.NewContainerCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, container.MockControllerKey{},
+		kukeonv1.Client(&fakeClient{listContainersFn: listFn, getContainerFn: getFn}))
+	cmd.SetContext(ctx)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	for _, h := range []string{"NAME", "REALM", "SPACE", "STACK", "CELL", "STATE", "RESTARTS", "AGE"} {
+		if !strings.Contains(out, h) {
+			t.Errorf("default table missing header %q\nGot:\n%s", h, out)
+		}
+	}
+	for _, denied := range []string{"ROOT", "IMAGE", "EXIT", "CGROUP"} {
+		if strings.Contains(out, denied) {
+			t.Errorf("default table must NOT contain %q; got:\n%s", denied, out)
+		}
+	}
+	// RESTARTS column carries the integer literally.
+	if !strings.Contains(out, " 3 ") {
+		t.Errorf("default row missing RESTARTS=3\nGot:\n%s", out)
+	}
+}
+
+// TestNewContainerCmd_WideColumns pins the `-o wide` column set after the
+// epic:get redefinition: NAME REALM SPACE STACK CELL STATE RESTARTS AGE
+// IMAGE EXIT — ten columns. CGROUP / ROOT must NOT appear.
+func TestNewContainerCmd_WideColumns(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+		return []v1beta1.ContainerSpec{
+			{ID: "co1", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "ce1", Image: "nginx:alpine"},
+		}, nil
+	}
+	getFn := func(_ v1beta1.ContainerDoc) (kukeonv1.GetContainerResult, error) {
+		return kukeonv1.GetContainerResult{
+			Container: v1beta1.ContainerDoc{
+				Status: v1beta1.ContainerStatus{
+					State:        v1beta1.ContainerStateStopped,
+					RestartCount: 1,
+					CreatedAt:    time.Now().Add(-30 * time.Minute),
+					ExitCode:     137,
+					ExitSignal:   "SIGKILL",
+				},
+			},
+			ContainerExists: true,
+		}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	cmd := container.NewContainerCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, container.MockControllerKey{},
+		kukeonv1.Client(&fakeClient{listContainersFn: listFn, getContainerFn: getFn}))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-o", "wide"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	for _, h := range []string{"NAME", "REALM", "SPACE", "STACK", "CELL", "STATE", "RESTARTS", "AGE", "IMAGE", "EXIT"} {
+		if !strings.Contains(out, h) {
+			t.Errorf("-o wide table missing header %q\nGot:\n%s", h, out)
+		}
+	}
+	for _, denied := range []string{"ROOT", "CGROUP"} {
+		if strings.Contains(out, denied) {
+			t.Errorf("-o wide table must NOT contain %q; got:\n%s", denied, out)
+		}
+	}
+	for _, sub := range []string{"co1", "nginx:alpine", "137/SIGKILL"} {
+		if !strings.Contains(out, sub) {
+			t.Errorf("-o wide row missing %q\nGot:\n%s", sub, out)
+		}
+	}
+}
+
+// TestNewContainerCmd_ExitRendering pins the EXIT column edge cases from
+// #605's AC: `<code>/<signal>` when either field is non-zero/non-empty;
+// "-" when both are zero. Cases: both zero -> "-"; code only -> "139/";
+// signal only -> "0/SIGTERM"; both -> "137/SIGKILL". Most meaningful on
+// Stopped/Failed.
+func TestNewContainerCmd_ExitRendering(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		exitCode   int
+		exitSignal string
+		wantSub    string
+	}{
+		{"both zero renders dash", 0, "", " - "},
+		{"code only", 139, "", "139/"},
+		{"signal only", 0, "SIGTERM", "0/SIGTERM"},
+		{"both set", 137, "SIGKILL", "137/SIGKILL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			listFn := func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+				return []v1beta1.ContainerSpec{
+					{ID: "co1", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "ce1", Image: "img"},
+				}, nil
+			}
+			getFn := func(_ v1beta1.ContainerDoc) (kukeonv1.GetContainerResult, error) {
+				return kukeonv1.GetContainerResult{
+					Container: v1beta1.ContainerDoc{
+						Status: v1beta1.ContainerStatus{
+							State:      v1beta1.ContainerStateStopped,
+							ExitCode:   tt.exitCode,
+							ExitSignal: tt.exitSignal,
+						},
+					},
+					ContainerExists: true,
+				}, nil
+			}
+
+			buf := &bytes.Buffer{}
+			cmd := container.NewContainerCmd()
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, container.MockControllerKey{},
+				kukeonv1.Client(&fakeClient{listContainersFn: listFn, getContainerFn: getFn}))
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"-o", "wide"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(buf.String(), tt.wantSub) {
+				t.Errorf("EXIT cell missing %q\nGot:\n%s", tt.wantSub, buf.String())
+			}
+		})
+	}
+}
+
+// TestNewContainerCmd_NameRendersRootForRootContainer pins the existing
+// containerDisplayName behavior: a container with Spec.Root == true renders
+// as "root" in the NAME column rather than its ID. Carried into #605's new
+// column set unchanged.
+func TestNewContainerCmd_NameRendersRootForRootContainer(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+		return []v1beta1.ContainerSpec{
+			{ID: "rootco", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "ce1", Root: true, Image: "img"},
+		}, nil
+	}
+	getFn := func(_ v1beta1.ContainerDoc) (kukeonv1.GetContainerResult, error) {
+		return kukeonv1.GetContainerResult{
+			Container:       v1beta1.ContainerDoc{Status: v1beta1.ContainerStatus{State: v1beta1.ContainerStateReady}},
+			ContainerExists: true,
+		}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	cmd := container.NewContainerCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, container.MockControllerKey{},
+		kukeonv1.Client(&fakeClient{listContainersFn: listFn, getContainerFn: getFn}))
+	cmd.SetContext(ctx)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "root ") {
+		t.Errorf("expected NAME to render 'root' for Spec.Root==true; got:\n%s", out)
+	}
+	if strings.Contains(out, "rootco ") {
+		t.Errorf("NAME column should hide ID 'rootco' under Root override; got:\n%s", out)
+	}
+}
+
+// TestNewContainerCmd_AgeZeroRendersDash pins that a container with a zero
+// CreatedAt (not yet observed by the controller, or pre-#605 persisted
+// state) renders AGE as "-" via shared.RenderAge rather than a stale value.
+func TestNewContainerCmd_AgeZeroRendersDash(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+		return []v1beta1.ContainerSpec{
+			{ID: "co1", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "ce1", Image: "img"},
+		}, nil
+	}
+	getFn := func(_ v1beta1.ContainerDoc) (kukeonv1.GetContainerResult, error) {
+		return kukeonv1.GetContainerResult{
+			Container: v1beta1.ContainerDoc{
+				Status: v1beta1.ContainerStatus{State: v1beta1.ContainerStateReady},
+			},
+			ContainerExists: true,
+		}, nil
+	}
+
+	buf := &bytes.Buffer{}
+	cmd := container.NewContainerCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, container.MockControllerKey{},
+		kukeonv1.Client(&fakeClient{listContainersFn: listFn, getContainerFn: getFn}))
+	cmd.SetContext(ctx)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// AGE column should render "-" — a single dash bracketed by spaces.
+	if !strings.Contains(buf.String(), " - ") {
+		t.Errorf("expected zero CreatedAt to render AGE as '-'; got:\n%s", buf.String())
 	}
 }
 

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -431,6 +431,7 @@ func ConvertContainerDocToInternal(in ext.ContainerDoc) (intmodel.Container, err
 			Status: intmodel.ContainerStatus{
 				Name:         in.Status.Name,
 				ID:           in.Status.ID,
+				CreatedAt:    in.Status.CreatedAt,
 				State:        intmodel.ContainerState(in.Status.State),
 				RestartCount: in.Status.RestartCount,
 				RestartTime:  in.Status.RestartTime,
@@ -495,6 +496,7 @@ func BuildContainerExternalFromInternal(in intmodel.Container, apiVersion ext.Ve
 			Status: ext.ContainerStatus{
 				Name:         in.Status.Name,
 				ID:           in.Status.ID,
+				CreatedAt:    in.Status.CreatedAt,
 				State:        ext.ContainerState(in.Status.State),
 				RestartCount: in.Status.RestartCount,
 				RestartTime:  in.Status.RestartTime,
@@ -1291,6 +1293,7 @@ func convertContainerStatusesToInternal(in []ext.ContainerStatus) []intmodel.Con
 		result[i] = intmodel.ContainerStatus{
 			Name:         status.Name,
 			ID:           status.ID,
+			CreatedAt:    status.CreatedAt,
 			State:        intmodel.ContainerState(status.State),
 			RestartCount: status.RestartCount,
 			RestartTime:  status.RestartTime,
@@ -1313,6 +1316,7 @@ func buildContainerStatusesExternalFromInternal(in []intmodel.ContainerStatus) [
 		result[i] = ext.ContainerStatus{
 			Name:         status.Name,
 			ID:           status.ID,
+			CreatedAt:    status.CreatedAt,
 			State:        ext.ContainerState(status.State),
 			RestartCount: status.RestartCount,
 			RestartTime:  status.RestartTime,

--- a/internal/controller/get_container.go
+++ b/internal/controller/get_container.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -135,9 +136,13 @@ func (b *Exec) GetContainer(container intmodel.Container) (GetContainerResult, e
 				// the Repos / Stages slices through so
 				// `kuke get container <name> -o yaml/json` surfaces them; the
 				// rest of the status is rebuilt inline from the freshly-queried
-				// containerd state above.
-				Repos:  repoStatusesForContainer(internalCell, name),
-				Stages: stageStatusesForContainer(internalCell, name),
+				// containerd state above. CreatedAt likewise rides through from
+				// the cell's per-container status so the AGE column on
+				// `kuke get container` lists picks up the controller-stamped
+				// observation time (issue #605).
+				CreatedAt: containerCreatedAtForContainer(internalCell, name),
+				Repos:     repoStatusesForContainer(internalCell, name),
+				Stages:    stageStatusesForContainer(internalCell, name),
 			},
 		}
 	} else {
@@ -149,6 +154,20 @@ func (b *Exec) GetContainer(container intmodel.Container) (GetContainerResult, e
 	}
 
 	return res, nil
+}
+
+// containerCreatedAtForContainer returns the controller-stamped CreatedAt
+// for the named container from the cell's persisted per-container statuses
+// (populated and preserved by populateCellContainerStatuses). Returns the
+// zero time when the cell has no status entry for the name yet, which
+// renders as "-" via shared.RenderAge. Issue #605.
+func containerCreatedAtForContainer(cell intmodel.Cell, name string) time.Time {
+	for i := range cell.Status.Containers {
+		if cell.Status.Containers[i].ID == name {
+			return cell.Status.Containers[i].CreatedAt
+		}
+	}
+	return time.Time{}
 }
 
 // repoStatusesForContainer returns the per-repo clone/fetch outcome that

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -702,11 +702,17 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 	// otherwise drop them whenever the live pull returns nil (container not
 	// Ready, or pull failed) and strand phase C2's render gate.
 	priorStages := make(map[string][]intmodel.StageStatus, len(cell.Status.Containers))
+	// Snapshot prior CreatedAt by container ID so the AGE column on
+	// `kuke get container` survives the unconditional overwrite below.
+	// Issue #605.
+	priorCreatedAt := make(map[string]time.Time, len(cell.Status.Containers))
 	for _, prev := range cell.Status.Containers {
 		priorStages[prev.ID] = prev.Stages
+		priorCreatedAt[prev.ID] = prev.CreatedAt
 	}
 
 	statuses := make([]intmodel.ContainerStatus, 0, len(cell.Spec.Containers))
+	now := r.nowUTC()
 
 	for _, containerSpec := range cell.Spec.Containers {
 		// Get container state from containerd
@@ -719,11 +725,20 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 			state = intmodel.ContainerStateUnknown
 		}
 
+		// CreatedAt: stamp on the first observation, preserve thereafter.
+		// Mirrors the realm/space/stack/cell lifecycle-stamp pattern in
+		// metadata.go's stamp*Lifecycle helpers. Issue #605.
+		createdAt := priorCreatedAt[containerSpec.ID]
+		if createdAt.IsZero() {
+			createdAt = now
+		}
+
 		// TODO: Get additional status fields (RestartCount, StartTime, etc.) from containerd
 		// For now, populate with basic state
 		status := intmodel.ContainerStatus{
 			Name:         containerSpec.ID,
 			ID:           containerSpec.ID,
+			CreatedAt:    createdAt,
 			State:        state,
 			RestartCount: 0,           // TODO: retrieve from containerd
 			RestartTime:  time.Time{}, // TODO: retrieve from containerd

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -263,8 +263,13 @@ type ContainerResources struct {
 }
 
 type ContainerStatus struct {
-	Name         string // Container name/ID
-	ID           string // Container ID (same as Name)
+	Name string // Container name/ID
+	ID   string // Container ID (same as Name)
+	// CreatedAt is the wall-clock time of the first time the controller
+	// observed this container in cell.Spec.Containers. Stamped on the
+	// first populateCellContainerStatuses pass and preserved across
+	// reconciliations. Sources the AGE column on `kuke get container`.
+	CreatedAt    time.Time
 	State        ContainerState
 	RestartCount int
 	RestartTime  time.Time

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -160,11 +160,11 @@ type ContainerTty struct {
 	// Prompt is the literal prompt expression sbsh stamps onto
 	// TerminalSpec.Prompt and flips SetPrompt on for. Empty leaves
 	// SetPrompt off (sbsh's wrapper skips PS1 injection).
-	Prompt string `json:"prompt,omitempty"  yaml:"prompt,omitempty"`
+	Prompt string `json:"prompt,omitempty"   yaml:"prompt,omitempty"`
 	// OnInit are scripts run once when the wrapped shell starts, in
 	// order. Forwarded to TerminalSpec.Stages.OnInit via sbsh's
 	// WithOnInit; an empty slice leaves Stages.OnInit zero.
-	OnInit []TtyStage `json:"onInit,omitempty"  yaml:"onInit,omitempty"`
+	OnInit []TtyStage `json:"onInit,omitempty"   yaml:"onInit,omitempty"`
 	// LogFile is an optional operator override for the in-container path
 	// the kuketty wrapper writes its slog output to. Empty (the default)
 	// makes the daemon stamp ctr.AttachableKukettyLogPath
@@ -176,7 +176,7 @@ type ContainerTty struct {
 	// AttachableLogFileMode and the kukeon-group GID, gated on the
 	// kukeon group being configured (matches socket/capture treatment).
 	// Issue #599.
-	LogFile string `json:"logFile,omitempty" yaml:"logFile,omitempty"`
+	LogFile string `json:"logFile,omitempty"  yaml:"logFile,omitempty"`
 	// LogLevel controls the verbosity of the kuketty wrapper's own slog
 	// output. Accepted values: "debug", "info", "warn", "error". Empty
 	// falls through to the daemon-wide kuketty.logLevel set on
@@ -202,7 +202,7 @@ type TtyStage struct {
 	// run-once-per-cell-instance setup (the run-once render gate itself lands
 	// in phase C, #690; this phase adds the field + routing + executor). Any
 	// other value is rejected at apply time by validateContainerTty. Issue #635.
-	RunOn string `json:"runOn,omitempty" yaml:"runOn,omitempty"`
+	RunOn string `json:"runOn,omitempty"  yaml:"runOn,omitempty"`
 }
 
 // TtyStage.RunOn values. Empty deserializes as RunOnStart.
@@ -402,27 +402,33 @@ type ContainerResources struct {
 }
 
 type ContainerStatus struct {
-	Name         string         `json:"name"            yaml:"name"`
-	ID           string         `json:"id"              yaml:"id"`
-	State        ContainerState `json:"state"           yaml:"state"`
-	RestartCount int            `json:"restartCount"    yaml:"restartCount"`
-	RestartTime  time.Time      `json:"restartTime"     yaml:"restartTime"`
-	StartTime    time.Time      `json:"startTime"       yaml:"startTime"`
-	FinishTime   time.Time      `json:"finishTime"      yaml:"finishTime"`
-	ExitCode     int            `json:"exitCode"        yaml:"exitCode"`
-	ExitSignal   string         `json:"exitSignal"      yaml:"exitSignal"`
+	Name  string         `json:"name"                yaml:"name"`
+	ID    string         `json:"id"                  yaml:"id"`
+	State ContainerState `json:"state"               yaml:"state"`
+	// CreatedAt is the wall-clock time of the first time the controller
+	// observed this container in cell.Spec.Containers. Stamped on the
+	// first populateCellContainerStatuses pass and preserved across
+	// reconciliations (mirrors realm/space/stack/cell.Status.CreatedAt).
+	// Sources the AGE column on `kuke get container`. Issue #605.
+	CreatedAt    time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	RestartCount int       `json:"restartCount"        yaml:"restartCount"`
+	RestartTime  time.Time `json:"restartTime"         yaml:"restartTime"`
+	StartTime    time.Time `json:"startTime"           yaml:"startTime"`
+	FinishTime   time.Time `json:"finishTime"          yaml:"finishTime"`
+	ExitCode     int       `json:"exitCode"            yaml:"exitCode"`
+	ExitSignal   string    `json:"exitSignal"          yaml:"exitSignal"`
 	// Repos reports the per-repo outcome of kuketty's pre-Serve clone/fetch
 	// step for an Attachable container's Spec.Repos. Empty for containers
 	// with no repos[] or that have not yet been provisioned. Populated over
 	// the GetSetupStatus RPC in phase 1b (#642); phase 1a lands the schema
 	// only. Issue #617.
-	Repos []RepoStatus `json:"repos,omitempty" yaml:"repos,omitempty"`
+	Repos []RepoStatus `json:"repos,omitempty"     yaml:"repos,omitempty"`
 	// Stages reports the per-stage outcome of kuketty's pre-Serve execution of
 	// the container's runOn: create TtyStages, in declaration order. Empty for
 	// containers with no create stages or that have not yet been provisioned.
 	// Populated over the GetSetupStatus RPC in phase B (#689); this phase (#635)
 	// lands the schema only. Issue #635.
-	Stages []StageStatus `json:"stages,omitempty" yaml:"stages,omitempty"`
+	Stages []StageStatus `json:"stages,omitempty"    yaml:"stages,omitempty"`
 }
 
 // RepoStatus is the resolved state of a single ContainerRepo after kuketty's


### PR DESCRIPTION
## Summary

- Trim the default `kuke get container` table to the epic:get scan-friendly set: `NAME REALM SPACE STACK CELL STATE RESTARTS AGE` (8 cols). Drops `ROOT` and `IMAGE` from the default; `CGROUP` was already absent.
- Add `-o wide` that appends `IMAGE` and `EXIT` for 10 cols. `IMAGE` is the resolved `spec.image`; `EXIT` renders `<exitCode>/<exitSignal>` when either field is non-zero/non-empty, "-" otherwise.
- `NAME` continues to substitute `root` for `Spec.Root == true` (unchanged `containerDisplayName` behavior).
- Updates the long help string to document the new table contract.

## Why this PR touches the model + runner (out-of-issue-scope read)

The umbrella (#601) sources AGE from `Status.CreatedAt`, but `ContainerStatus` did not carry one — its existing time fields are `StartTime`/`RestartTime`/`FinishTime`, all currently TODO-zeroed in `populateCellContainerStatuses`. Per CLAUDE.md §"Sanity-check AC implementation specifics against the codebase" and the heads-up comment on the issue (#605), this PR extends the schema rather than rendering AGE as a permanent `-`:

- Add `CreatedAt time.Time` to `pkg/api/model/v1beta1/ContainerStatus` and `internal/modelhub/ContainerStatus`.
- Plumb through `internal/apischeme/scheme.go` (the four conversion sites — `ConvertContainerDocToInternal`, `BuildContainerExternalFromInternal`, `convertContainerStatusesToInternal`, `buildContainerStatusesExternalFromInternal`).
- Stamp it in `internal/controller/runner/helpers.go::populateCellContainerStatuses` using the same `priorStages`-style preservation pattern already in place (lines 704–707 pre-PR): snapshot prior `CreatedAt` by container ID, stamp `r.nowUTC()` on first observation, preserve thereafter. Mirrors the realm/space/stack/cell lifecycle-stamp helpers in `metadata.go`.
- Surface through `GetContainer` via a `containerCreatedAtForContainer` helper that parallels `repoStatusesForContainer` / `stageStatusesForContainer`.

This is the minimum plumbing needed for AGE to render meaningful values (`18s`, `2h`, `5d`) instead of `-` for every row. Reviewer can push back if the schema extension should land separately — the alternative is a permanently-dashed AGE column on container, which would fail the spirit of the AC even when it satisfies the letter.

`Status.RestartCount` / `Status.ExitCode` / `Status.ExitSignal` are existing model fields; the runner TODO at `helpers.go:728` still hardcodes them to zero values — out of scope here. The PR renders whatever the controller reports (today: `0` / `-` / `-` for healthy containers), matching how RESTARTS rendered `0` on every other entity's table before its runner populator landed.

## Test plan

- [x] `make test` (full project test suite, post-fmt)
- [x] `make dev-init` smoke — two-realm parity tail unchanged
- [x] Manual: `sudo ./kuke get container --host unix:///run/kukeon-dev/kukeond.sock` renders the new 8-col default table with `AGE=18s` for the just-stamped kukeond + root containers
- [x] Manual: `sudo ./kuke get container --host unix:///run/kukeon-dev/kukeond.sock -o wide` renders the 10-col table with `IMAGE` resolved (`docker.io/library/kukeon-local:dev`) and `EXIT=-` for Ready containers
- [x] Manual: `kuke get container <name> ... -o yaml` surfaces `status.createdAt` for `-o yaml` consumers
- [x] New unit tests in `cmd/kuke/get/container/container_test.go`:
  - `TestNewContainerCmd_DefaultColumns` pins the 8-col contract + denies ROOT/IMAGE/EXIT/CGROUP
  - `TestNewContainerCmd_WideColumns` pins the 10-col contract + renders `137/SIGKILL`
  - `TestNewContainerCmd_ExitRendering` covers all four EXIT edge cases (`0`/`""` → `-`, code-only, signal-only, both)
  - `TestNewContainerCmd_NameRendersRootForRootContainer` pins the carried-over `Spec.Root` → `"root"` rendering
  - `TestNewContainerCmd_AgeZeroRendersDash` pins the zero-`CreatedAt` → `-` fallback
- [x] `pre-commit run --files <touched files>` (gofmt + golangci-lint + addlicense)

Closes #605