### PR TITLE
feat(get): add -l/--selector label filter on realm/space/stack/cell/container

### DIFF
--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -58,13 +58,12 @@ when needed.`,
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := resolveClient(cmd)
+			wide, outputFormat, err := resolveOutput(cmd)
 			if err != nil {
 				return err
 			}
-			defer func() { _ = client.Close() }()
 
-			wide, outputFormat, err := resolveOutput(cmd)
+			selector, err := shared.ParseLabelSelectorFlag(cmd)
 			if err != nil {
 				return err
 			}
@@ -79,6 +78,16 @@ when needed.`,
 			} else {
 				name = strings.TrimSpace(viper.GetString(config.KUKE_GET_CELL_NAME.ViperKey))
 			}
+
+			if name != "" && !selector.Empty() {
+				return errors.New("--selector cannot be combined with a resource name")
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
 
 			if name != "" {
 				if realm == "" {
@@ -124,6 +133,7 @@ when needed.`,
 			if err != nil {
 				return err
 			}
+			cells = filterCellsBySelector(cells, selector)
 			return printCells(cmd, cells, outputFormat, wide)
 		},
 	}
@@ -138,6 +148,8 @@ when needed.`,
 		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+
+	shared.RegisterLabelSelectorFlag(cmd)
 
 	cmd.ValidArgsFunction = config.CompleteCellNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -192,6 +204,22 @@ func renderBridge(c *v1beta1.CellDoc) string {
 		return name
 	}
 	return "-"
+}
+
+// filterCellsBySelector returns the subset of cells whose
+// Metadata.Labels satisfy selector. A nil or empty selector returns the
+// input slice unmodified so the common no-flag path skips the allocation.
+func filterCellsBySelector(cells []v1beta1.CellDoc, selector *shared.LabelSelector) []v1beta1.CellDoc {
+	if selector.Empty() {
+		return cells
+	}
+	out := make([]v1beta1.CellDoc, 0, len(cells))
+	for i := range cells {
+		if selector.Matches(cells[i].Metadata.Labels) {
+			out = append(out, cells[i])
+		}
+	}
+	return out
 }
 
 func printCell(cmd *cobra.Command, cell *v1beta1.CellDoc, format shared.OutputFormat) error {

--- a/cmd/kuke/get/cell/cell_test.go
+++ b/cmd/kuke/get/cell/cell_test.go
@@ -378,6 +378,94 @@ func TestNewCellCmd_YamlSurfacesStatus(t *testing.T) {
 	}
 }
 
+// TestNewCellCmd_Selector verifies the `-l`/`--selector` filter wiring on
+// `kuke get cell` (issue #614). Grammar coverage lives in the shared
+// selector_test.go; this test pins the per-verb wiring.
+func TestNewCellCmd_Selector(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_, _, _ string) ([]v1beta1.CellDoc, error) {
+		return []v1beta1.CellDoc{
+			{
+				Metadata: v1beta1.CellMetadata{
+					Name:   "prod-web",
+					Labels: map[string]string{"env": "prod", "role": "web"},
+				},
+				Spec: v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+			},
+			{
+				Metadata: v1beta1.CellMetadata{
+					Name:   "prod-db",
+					Labels: map[string]string{"env": "prod", "role": "db"},
+				},
+				Spec: v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+			},
+			{
+				Metadata: v1beta1.CellMetadata{
+					Name:   "dev-web",
+					Labels: map[string]string{"env": "dev", "role": "web"},
+				},
+				Spec: v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+			},
+		}, nil
+	}
+
+	t.Run("AND-combination filters by both labels", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := cell.NewCellCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), cell.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listCellsFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-l", "env=prod,role=web"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "prod-web") {
+			t.Errorf("expected 'prod-web' in output, got:\n%s", out)
+		}
+		for _, deny := range []string{"prod-db", "dev-web"} {
+			if strings.Contains(out, deny) {
+				t.Errorf("expected %q filtered out, got:\n%s", deny, out)
+			}
+		}
+	})
+
+	t.Run("malformed selector fails before listing", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := cell.NewCellCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		// No ListCells expected — selector parse fails first.
+		ctx := context.WithValue(context.Background(), cell.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-l", "env="})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "empty value") {
+			t.Fatalf("expected malformed-selector error, got: %v", err)
+		}
+	})
+
+	t.Run("selector + name is rejected", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := cell.NewCellCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		ctx := context.WithValue(context.Background(), cell.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"prod-web", "-l", "env=prod"})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--selector cannot be combined") {
+			t.Fatalf("expected --selector + name rejection, got: %v", err)
+		}
+	})
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -76,6 +76,8 @@ full container spec.`,
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
 
+	shared.RegisterLabelSelectorFlag(cmd)
+
 	cmd.ValidArgsFunction = config.CompleteContainerNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
@@ -88,13 +90,12 @@ full container spec.`,
 }
 
 func runContainerCmd(cmd *cobra.Command, args []string) error {
-	client, err := resolveClient(cmd)
+	wide, outputFormat, err := resolveOutput(cmd)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
 
-	wide, outputFormat, err := resolveOutput(cmd)
+	selector, err := shared.ParseLabelSelectorFlag(cmd)
 	if err != nil {
 		return err
 	}
@@ -110,6 +111,16 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 	} else {
 		name = strings.TrimSpace(viper.GetString(config.KUKE_GET_CONTAINER_NAME.ViperKey))
 	}
+
+	if name != "" && !selector.Empty() {
+		return errors.New("--selector cannot be combined with a resource name")
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
 
 	if name != "" {
 		if realm == "" {
@@ -178,6 +189,13 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// containerProbes carries per-container Metadata.Labels alongside state
+	// for the post-loop selector filter: ListContainers returns
+	// ContainerSpec (which carries no labels), so the filter has to wait
+	// until each container's ContainerDoc is in hand. When the GetContainer
+	// probe fails the labels stay nil — the selector then treats that
+	// container as "no labels", which is the same conservative call
+	// ContainerStateUnknown already makes for state.
 	containerProbes := make(map[string]containerProbe, len(specs))
 	for i := range specs {
 		spec := specs[i]
@@ -210,7 +228,18 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 			createdAt:    st.CreatedAt,
 			exitCode:     st.ExitCode,
 			exitSignal:   st.ExitSignal,
+			labels:       probeResult.Container.Metadata.Labels,
 		}
+	}
+
+	if !selector.Empty() {
+		filtered := make([]v1beta1.ContainerSpec, 0, len(specs))
+		for i := range specs {
+			if selector.Matches(containerProbes[specs[i].ID].labels) {
+				filtered = append(filtered, specs[i])
+			}
+		}
+		specs = filtered
 	}
 
 	return printContainersWithState(
@@ -225,13 +254,15 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 
 // containerProbe carries the per-container fields a list-path probe pulls
 // from GetContainer for the table renderer. State is the human-readable
-// label; the rest source the RESTARTS / AGE / EXIT columns.
+// label; the rest source the RESTARTS / AGE / EXIT columns. labels feeds
+// the post-loop selector filter — see runContainerCmd's probe loop.
 type containerProbe struct {
 	state        string
 	restartCount int
 	createdAt    time.Time
 	exitCode     int
 	exitSignal   string
+	labels       map[string]string
 }
 
 // buildEmptyResultMessage describes the queried filter set when zero rows

--- a/cmd/kuke/get/container/container_test.go
+++ b/cmd/kuke/get/container/container_test.go
@@ -597,6 +597,112 @@ func TestNewContainerCmd_AgeZeroRendersDash(t *testing.T) {
 	}
 }
 
+// TestNewContainerCmd_Selector verifies the `-l`/`--selector` filter
+// wiring on `kuke get container` (issue #614). ListContainers returns
+// ContainerSpec (no labels), so the per-container Metadata.Labels arrives
+// via the per-spec GetContainer probe that already populates state;
+// filtering happens after that loop. Grammar coverage lives in the
+// shared selector_test.go; this test pins the per-verb wiring.
+func TestNewContainerCmd_Selector(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_, _, _, _ string) ([]v1beta1.ContainerSpec, error) {
+		return []v1beta1.ContainerSpec{
+			{ID: "alpha", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "c1"},
+			{ID: "beta", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "c1"},
+			{ID: "gamma", RealmID: "r1", SpaceID: "s1", StackID: "st1", CellID: "c1"},
+		}, nil
+	}
+	// Labels live on ContainerDoc.Metadata, which arrives from GetContainer.
+	labelsByID := map[string]map[string]string{
+		"alpha": {"app": "web"},
+		"beta":  {"app": "db"},
+		"gamma": {"app": "web", "edge": "true"},
+	}
+	getFn := func(doc v1beta1.ContainerDoc) (kukeonv1.GetContainerResult, error) {
+		labels, ok := labelsByID[doc.Metadata.Name]
+		if !ok {
+			return kukeonv1.GetContainerResult{}, errdefs.ErrContainerNotFound
+		}
+		return kukeonv1.GetContainerResult{
+			Container: v1beta1.ContainerDoc{
+				Metadata: v1beta1.ContainerMetadata{
+					Name:   doc.Metadata.Name,
+					Labels: labels,
+				},
+				Spec: doc.Spec,
+				Status: v1beta1.ContainerStatus{
+					State: v1beta1.ContainerStateReady,
+				},
+			},
+			ContainerExists: true,
+		}, nil
+	}
+
+	t.Run("equality filters by label", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := container.NewContainerCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), container.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listContainersFn: listFn, getContainerFn: getFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-l", "app=web"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		for _, want := range []string{"alpha", "gamma"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q in output, got:\n%s", want, out)
+			}
+		}
+		if strings.Contains(out, "beta") {
+			t.Errorf("expected 'beta' filtered out, got:\n%s", out)
+		}
+	})
+
+	t.Run("AND-combination filters further", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := container.NewContainerCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), container.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listContainersFn: listFn, getContainerFn: getFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-l", "app=web,edge"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "gamma") {
+			t.Errorf("expected 'gamma' in output, got:\n%s", out)
+		}
+		for _, deny := range []string{"alpha", "beta"} {
+			if strings.Contains(out, deny) {
+				t.Errorf("expected %q filtered out, got:\n%s", deny, out)
+			}
+		}
+	})
+
+	t.Run("selector + name is rejected", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := container.NewContainerCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		ctx := context.WithValue(context.Background(), container.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"alpha", "-l", "app=web"})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--selector cannot be combined") {
+			t.Fatalf("expected --selector + name rejection, got: %v", err)
+		}
+	})
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/get/realm/realm.go
+++ b/cmd/kuke/get/realm/realm.go
@@ -44,13 +44,12 @@ func NewRealmCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := resolveClient(cmd)
+			outputFormat, err := shared.ParseOutputFormat(cmd)
 			if err != nil {
 				return err
 			}
-			defer func() { _ = client.Close() }()
 
-			outputFormat, err := shared.ParseOutputFormat(cmd)
+			selector, err := shared.ParseLabelSelectorFlag(cmd)
 			if err != nil {
 				return err
 			}
@@ -61,6 +60,16 @@ func NewRealmCmd() *cobra.Command {
 			} else {
 				name = strings.TrimSpace(viper.GetString(config.KUKE_GET_REALM_NAME.ViperKey))
 			}
+
+			if name != "" && !selector.Empty() {
+				return errors.New("--selector cannot be combined with a resource name")
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
 
 			if name != "" {
 				doc := v1beta1.RealmDoc{
@@ -83,6 +92,7 @@ func NewRealmCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			realms = filterRealmsBySelector(realms, selector)
 			return printRealms(cmd, realms, outputFormat)
 		},
 	}
@@ -91,6 +101,8 @@ func NewRealmCmd() *cobra.Command {
 		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+
+	shared.RegisterLabelSelectorFlag(cmd)
 
 	// `--no-daemon` is inherited as a persistent flag from the parent `get`
 	// command (registered in cmd/kuke/get/get.go) — every `get <kind>`
@@ -110,6 +122,22 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 		return mockClient, nil
 	}
 	return kukeshared.ClientFromCmd(cmd)
+}
+
+// filterRealmsBySelector returns the subset of realms whose
+// Metadata.Labels satisfy selector. A nil or empty selector returns the
+// input slice unmodified so the common no-flag path skips the allocation.
+func filterRealmsBySelector(realms []v1beta1.RealmDoc, selector *shared.LabelSelector) []v1beta1.RealmDoc {
+	if selector.Empty() {
+		return realms
+	}
+	out := make([]v1beta1.RealmDoc, 0, len(realms))
+	for i := range realms {
+		if selector.Matches(realms[i].Metadata.Labels) {
+			out = append(out, realms[i])
+		}
+	}
+	return out
 }
 
 func printRealm(cmd *cobra.Command, realm *v1beta1.RealmDoc, format shared.OutputFormat) error {

--- a/cmd/kuke/get/realm/realm_test.go
+++ b/cmd/kuke/get/realm/realm_test.go
@@ -266,6 +266,134 @@ func TestNewRealmCmd_Columns(t *testing.T) {
 	})
 }
 
+// TestNewRealmCmd_Selector pins the issue #614 contract for `kuke get
+// realm`: `-l <selector>` filters the listed realms against
+// Metadata.Labels using the kubectl-style grammar, malformed selectors
+// fail before any controller call, and combining `-l` with a positional
+// name argument is rejected up front.
+func TestNewRealmCmd_Selector(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func() ([]v1beta1.RealmDoc, error) {
+		return []v1beta1.RealmDoc{
+			{
+				Metadata: v1beta1.RealmMetadata{
+					Name:   "prod",
+					Labels: map[string]string{"env": "prod", "tier": "web"},
+				},
+			},
+			{
+				Metadata: v1beta1.RealmMetadata{
+					Name:   "staging",
+					Labels: map[string]string{"env": "staging", "tier": "web"},
+				},
+			},
+			{
+				Metadata: v1beta1.RealmMetadata{
+					Name:   "legacy",
+					Labels: map[string]string{"env": "prod", "debug": "yes"},
+				},
+			},
+		}, nil
+	}
+
+	type sub struct {
+		name        string
+		args        []string
+		wantInclude []string
+		wantExclude []string
+		wantErr     string
+	}
+	subs := []sub{
+		{
+			name:        "equality filters by label value",
+			args:        []string{"-l", "env=prod"},
+			wantInclude: []string{"prod", "legacy"},
+			wantExclude: []string{"staging"},
+		},
+		{
+			name:        "inequality matches absent and differing keys",
+			args:        []string{"-l", "env!=prod"},
+			wantInclude: []string{"staging"},
+			wantExclude: []string{"prod", "legacy"},
+		},
+		{
+			name:        "existence matches key presence",
+			args:        []string{"-l", "debug"},
+			wantInclude: []string{"legacy"},
+			wantExclude: []string{"prod", "staging"},
+		},
+		{
+			name:        "absence matches when key missing",
+			args:        []string{"-l", "!debug"},
+			wantInclude: []string{"prod", "staging"},
+			wantExclude: []string{"legacy"},
+		},
+		{
+			name:        "comma is logical AND",
+			args:        []string{"-l", "env=prod,tier=web"},
+			wantInclude: []string{"prod"},
+			wantExclude: []string{"staging", "legacy"},
+		},
+		{
+			name:        "no matches still exits 0 with header",
+			args:        []string{"-l", "env=nowhere"},
+			wantInclude: []string{"No realms found."},
+		},
+		{
+			name:    "malformed selector fails fast",
+			args:    []string{"-l", "env="},
+			wantErr: "empty value",
+		},
+		{
+			name:    "selector with positional name is rejected",
+			args:    []string{"prod", "-l", "env=prod"},
+			wantErr: "--selector cannot be combined with a resource name",
+		},
+	}
+
+	for _, s := range subs {
+		t.Run(s.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			cmd := realm.NewRealmCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			ctx := context.WithValue(context.Background(),
+				realm.MockControllerKey{},
+				kukeonv1.Client(&fakeClient{listRealmsFn: listFn}))
+			cmd.SetContext(ctx)
+			cmd.SetArgs(s.args)
+
+			err := cmd.Execute()
+			if s.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", s.wantErr)
+				}
+				if !strings.Contains(err.Error(), s.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", s.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			out := buf.String()
+			for _, want := range s.wantInclude {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\nGot:\n%s", want, out)
+				}
+			}
+			for _, deny := range s.wantExclude {
+				if strings.Contains(out, deny) {
+					t.Errorf("output unexpectedly contains %q\nGot:\n%s", deny, out)
+				}
+			}
+		})
+	}
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/get/shared/selector.go
+++ b/cmd/kuke/get/shared/selector.go
@@ -1,0 +1,193 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// LabelSelectorFlagName is the canonical long flag name for the
+// `-l`/`--selector` label query flag wired onto every `kuke get <kind>`
+// subcommand that supports label filtering.
+const LabelSelectorFlagName = "selector"
+
+// labelSelectorFlagUsage is the shared help text for `-l`/`--selector`.
+// One example covers equality, inequality, existence, and AND-comma so
+// the AC's "documents the flag with one example" requirement is met by
+// every verb that calls RegisterLabelSelectorFlag.
+const labelSelectorFlagUsage = "Selector (label query) to filter on, " +
+	"supports '=', '==', '!=', existence ('key'), absence ('!key'), " +
+	"and comma-separated AND (e.g. 'env=prod,tier!=db' or 'env,!debug')"
+
+// LabelSelector is a parsed kubectl-style label selector. The zero value
+// (nil receiver or no requirements) matches every label set, including
+// nil maps.
+type LabelSelector struct {
+	requirements []labelRequirement
+}
+
+type labelOp int
+
+const (
+	labelOpEquals labelOp = iota
+	labelOpNotEquals
+	labelOpExists
+	labelOpDoesNotExist
+)
+
+type labelRequirement struct {
+	key   string
+	op    labelOp
+	value string
+}
+
+// RegisterLabelSelectorFlag adds the standard `-l`/`--selector` flag to
+// cmd. Keeping the registration in one place ensures every `kuke get
+// <kind>` verb advertises the same long-name, short-name, and help text.
+func RegisterLabelSelectorFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP(LabelSelectorFlagName, "l", "", labelSelectorFlagUsage)
+}
+
+// ParseLabelSelectorFlag reads the `-l`/`--selector` flag from cmd and
+// returns the parsed selector. An unset or blank flag yields a non-nil
+// empty selector (matches every label set) so callers can pass it
+// through Matches unconditionally. Malformed selectors return a parse
+// error before any controller call — see the issue AC's "fail fast"
+// requirement.
+func ParseLabelSelectorFlag(cmd *cobra.Command) (*LabelSelector, error) {
+	if cmd == nil {
+		return &LabelSelector{}, nil
+	}
+	raw, _ := cmd.Flags().GetString(LabelSelectorFlagName)
+	return ParseLabelSelector(raw)
+}
+
+// ParseLabelSelector parses a kubectl-style label selector string into a
+// LabelSelector. Supported operators per clause:
+//
+//   - `key=value`   — label `key` equals `value`
+//   - `key==value`  — kubectl alias for `=`
+//   - `key!=value`  — label `key` not equal to `value` (or absent)
+//   - `key`         — label `key` exists (any value)
+//   - `!key`        — label `key` does not exist
+//
+// Clauses are comma-separated and logically ANDed. Whitespace around
+// commas and operands is trimmed. The empty string parses to a selector
+// that matches every label set.
+//
+// Set-based operators (`in`, `notin`) are explicitly out of scope per
+// issue #614 — feed them in as a follow-up if needed.
+func ParseLabelSelector(s string) (*LabelSelector, error) {
+	sel := &LabelSelector{}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return sel, nil
+	}
+	for _, part := range strings.Split(s, ",") {
+		clause := strings.TrimSpace(part)
+		if clause == "" {
+			return nil, fmt.Errorf("invalid selector %q: empty clause", s)
+		}
+		req, err := parseLabelRequirement(clause)
+		if err != nil {
+			return nil, err
+		}
+		sel.requirements = append(sel.requirements, req)
+	}
+	return sel, nil
+}
+
+func parseLabelRequirement(clause string) (labelRequirement, error) {
+	// `!=` is matched before `=` because `=` is a substring of `!=`.
+	if i := strings.Index(clause, "!="); i >= 0 {
+		key := strings.TrimSpace(clause[:i])
+		val := strings.TrimSpace(clause[i+2:])
+		if key == "" {
+			return labelRequirement{}, fmt.Errorf("invalid selector clause %q: empty key", clause)
+		}
+		if val == "" {
+			return labelRequirement{}, fmt.Errorf("invalid selector clause %q: empty value after '!='", clause)
+		}
+		return labelRequirement{key: key, op: labelOpNotEquals, value: val}, nil
+	}
+	if i := strings.Index(clause, "="); i >= 0 {
+		// Accept `==` as a kubectl-style alias for `=` by consuming an
+		// optional second `=` immediately after the first.
+		rhs := i + 1
+		if rhs < len(clause) && clause[rhs] == '=' {
+			rhs++
+		}
+		key := strings.TrimSpace(clause[:i])
+		val := strings.TrimSpace(clause[rhs:])
+		if key == "" {
+			return labelRequirement{}, fmt.Errorf("invalid selector clause %q: empty key", clause)
+		}
+		if val == "" {
+			return labelRequirement{}, fmt.Errorf("invalid selector clause %q: empty value after '='", clause)
+		}
+		return labelRequirement{key: key, op: labelOpEquals, value: val}, nil
+	}
+	// No operator — existence (`key`) or absence (`!key`) predicate.
+	if strings.HasPrefix(clause, "!") {
+		key := strings.TrimSpace(clause[1:])
+		if key == "" {
+			return labelRequirement{}, fmt.Errorf("invalid selector clause %q: empty key after '!'", clause)
+		}
+		return labelRequirement{key: key, op: labelOpDoesNotExist}, nil
+	}
+	return labelRequirement{key: clause, op: labelOpExists}, nil
+}
+
+// Matches reports whether every requirement in the selector is satisfied
+// by labels. A nil selector or one with zero requirements matches every
+// label set (including a nil map).
+func (s *LabelSelector) Matches(labels map[string]string) bool {
+	if s == nil {
+		return true
+	}
+	for _, r := range s.requirements {
+		if !r.matches(labels) {
+			return false
+		}
+	}
+	return true
+}
+
+// Empty reports whether the selector carries zero requirements — i.e.
+// it matches every label set. Useful for "did the user actually pass a
+// selector" gates without inspecting the raw flag value.
+func (s *LabelSelector) Empty() bool {
+	return s == nil || len(s.requirements) == 0
+}
+
+func (r labelRequirement) matches(labels map[string]string) bool {
+	v, ok := labels[r.key]
+	switch r.op {
+	case labelOpEquals:
+		return ok && v == r.value
+	case labelOpNotEquals:
+		return !ok || v != r.value
+	case labelOpExists:
+		return ok
+	case labelOpDoesNotExist:
+		return !ok
+	}
+	return false
+}

--- a/cmd/kuke/get/shared/selector_test.go
+++ b/cmd/kuke/get/shared/selector_test.go
@@ -1,0 +1,235 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
+)
+
+func TestParseLabelSelector_Grammar(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		labels  map[string]string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:   "empty selector matches anything",
+			input:  "",
+			labels: map[string]string{"env": "prod"},
+			want:   true,
+		},
+		{
+			name:   "empty selector matches nil labels",
+			input:  "",
+			labels: nil,
+			want:   true,
+		},
+		{
+			name:   "equality match",
+			input:  "env=prod",
+			labels: map[string]string{"env": "prod"},
+			want:   true,
+		},
+		{
+			name:   "equality mismatch on value",
+			input:  "env=prod",
+			labels: map[string]string{"env": "dev"},
+			want:   false,
+		},
+		{
+			name:   "equality mismatch on missing key",
+			input:  "env=prod",
+			labels: map[string]string{"tier": "web"},
+			want:   false,
+		},
+		{
+			name:   "double-equals alias",
+			input:  "env==prod",
+			labels: map[string]string{"env": "prod"},
+			want:   true,
+		},
+		{
+			name:   "inequality matches when value differs",
+			input:  "env!=prod",
+			labels: map[string]string{"env": "dev"},
+			want:   true,
+		},
+		{
+			name:   "inequality matches when key absent",
+			input:  "env!=prod",
+			labels: map[string]string{"tier": "web"},
+			want:   true,
+		},
+		{
+			name:   "inequality fails when value equals",
+			input:  "env!=prod",
+			labels: map[string]string{"env": "prod"},
+			want:   false,
+		},
+		{
+			name:   "existence matches when key present (any value)",
+			input:  "env",
+			labels: map[string]string{"env": "dev"},
+			want:   true,
+		},
+		{
+			name:   "existence matches when value is empty string",
+			input:  "env",
+			labels: map[string]string{"env": ""},
+			want:   true,
+		},
+		{
+			name:   "existence fails when key absent",
+			input:  "env",
+			labels: map[string]string{"tier": "web"},
+			want:   false,
+		},
+		{
+			name:   "absence matches when key absent",
+			input:  "!debug",
+			labels: map[string]string{"env": "prod"},
+			want:   true,
+		},
+		{
+			name:   "absence matches against nil labels",
+			input:  "!debug",
+			labels: nil,
+			want:   true,
+		},
+		{
+			name:   "absence fails when key present",
+			input:  "!debug",
+			labels: map[string]string{"debug": "yes"},
+			want:   false,
+		},
+		{
+			name:   "AND-combination both clauses match",
+			input:  "env=prod,tier=web",
+			labels: map[string]string{"env": "prod", "tier": "web"},
+			want:   true,
+		},
+		{
+			name:   "AND-combination second clause fails",
+			input:  "env=prod,tier=web",
+			labels: map[string]string{"env": "prod", "tier": "db"},
+			want:   false,
+		},
+		{
+			name:   "AND-combination existence + inequality",
+			input:  "env,tier!=db",
+			labels: map[string]string{"env": "prod", "tier": "web"},
+			want:   true,
+		},
+		{
+			name:   "whitespace around clauses tolerated",
+			input:  "  env = prod ,  tier != db  ",
+			labels: map[string]string{"env": "prod", "tier": "web"},
+			want:   true,
+		},
+		{
+			name:    "malformed: empty key before =",
+			input:   "=value",
+			wantErr: true,
+		},
+		{
+			name:    "malformed: empty value after =",
+			input:   "key=",
+			wantErr: true,
+		},
+		{
+			name:    "malformed: empty value after !=",
+			input:   "key!=",
+			wantErr: true,
+		},
+		{
+			name:    "malformed: bang only",
+			input:   "!",
+			wantErr: true,
+		},
+		{
+			name:    "malformed: trailing comma",
+			input:   "env=prod,",
+			wantErr: true,
+		},
+		{
+			name:    "malformed: leading comma",
+			input:   ",env=prod",
+			wantErr: true,
+		},
+		{
+			name:    "malformed: double comma",
+			input:   "env=prod,,tier=web",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sel, err := shared.ParseLabelSelector(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParseLabelSelector(%q): expected error, got nil", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseLabelSelector(%q): unexpected error: %v", tc.input, err)
+			}
+			if got := sel.Matches(tc.labels); got != tc.want {
+				t.Fatalf("Matches(%v) for %q = %v, want %v", tc.labels, tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLabelSelector_Empty(t *testing.T) {
+	sel, err := shared.ParseLabelSelector("")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if !sel.Empty() {
+		t.Errorf("empty selector should report Empty() == true")
+	}
+	sel2, err := shared.ParseLabelSelector("env=prod")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if sel2.Empty() {
+		t.Errorf("non-empty selector should report Empty() == false")
+	}
+	var nilSel *shared.LabelSelector
+	if !nilSel.Empty() {
+		t.Errorf("nil selector should report Empty() == true")
+	}
+	if !nilSel.Matches(map[string]string{"any": "thing"}) {
+		t.Errorf("nil selector should match every label set")
+	}
+}
+
+func TestParseLabelSelector_ErrorMessage(t *testing.T) {
+	_, err := shared.ParseLabelSelector("env=prod,,tier=web")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "empty clause") {
+		t.Errorf("error message should mention 'empty clause'; got %v", err)
+	}
+}

--- a/cmd/kuke/get/space/space.go
+++ b/cmd/kuke/get/space/space.go
@@ -44,13 +44,12 @@ func NewSpaceCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := resolveClient(cmd)
+			outputFormat, err := shared.ParseOutputFormat(cmd)
 			if err != nil {
 				return err
 			}
-			defer func() { _ = client.Close() }()
 
-			outputFormat, err := shared.ParseOutputFormat(cmd)
+			selector, err := shared.ParseLabelSelectorFlag(cmd)
 			if err != nil {
 				return err
 			}
@@ -63,6 +62,16 @@ func NewSpaceCmd() *cobra.Command {
 			} else {
 				name = strings.TrimSpace(viper.GetString(config.KUKE_GET_SPACE_NAME.ViperKey))
 			}
+
+			if name != "" && !selector.Empty() {
+				return errors.New("--selector cannot be combined with a resource name")
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
 
 			if name != "" {
 				if realm == "" {
@@ -92,6 +101,7 @@ func NewSpaceCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			spaces = filterSpacesBySelector(spaces, selector)
 			return printSpaces(cmd, spaces, outputFormat)
 		},
 	}
@@ -103,6 +113,8 @@ func NewSpaceCmd() *cobra.Command {
 		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+
+	shared.RegisterLabelSelectorFlag(cmd)
 
 	cmd.ValidArgsFunction = config.CompleteSpaceNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -117,6 +129,22 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 		return mockClient, nil
 	}
 	return kukeshared.ClientFromCmd(cmd)
+}
+
+// filterSpacesBySelector returns the subset of spaces whose
+// Metadata.Labels satisfy selector. A nil or empty selector returns the
+// input slice unmodified so the common no-flag path skips the allocation.
+func filterSpacesBySelector(spaces []v1beta1.SpaceDoc, selector *shared.LabelSelector) []v1beta1.SpaceDoc {
+	if selector.Empty() {
+		return spaces
+	}
+	out := make([]v1beta1.SpaceDoc, 0, len(spaces))
+	for i := range spaces {
+		if selector.Matches(spaces[i].Metadata.Labels) {
+			out = append(out, spaces[i])
+		}
+	}
+	return out
 }
 
 func printSpace(cmd *cobra.Command, space *v1beta1.SpaceDoc, format shared.OutputFormat) error {

--- a/cmd/kuke/get/space/space_test.go
+++ b/cmd/kuke/get/space/space_test.go
@@ -347,6 +347,71 @@ func TestNewSpaceCmd_NoCgroupOrControllers(t *testing.T) {
 	}
 }
 
+// TestNewSpaceCmd_Selector verifies the `-l`/`--selector` filter wiring on
+// `kuke get space` (issue #614). Grammar coverage lives in the shared
+// selector_test.go; this test pins the per-verb wiring: the flag exists,
+// is parsed, applied against Metadata.Labels post-list, and combining it
+// with a positional name fails fast.
+func TestNewSpaceCmd_Selector(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_ string) ([]v1beta1.SpaceDoc, error) {
+		return []v1beta1.SpaceDoc{
+			{
+				Metadata: v1beta1.SpaceMetadata{
+					Name:   "web",
+					Labels: map[string]string{"tier": "web"},
+				},
+				Spec: v1beta1.SpaceSpec{RealmID: "r1"},
+			},
+			{
+				Metadata: v1beta1.SpaceMetadata{
+					Name:   "db",
+					Labels: map[string]string{"tier": "db"},
+				},
+				Spec: v1beta1.SpaceSpec{RealmID: "r1"},
+			},
+		}, nil
+	}
+
+	t.Run("equality filters by label", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := space.NewSpaceCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), space.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listSpacesFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-l", "tier=web"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "web") {
+			t.Errorf("expected 'web' in output, got:\n%s", out)
+		}
+		if strings.Contains(out, "db") {
+			t.Errorf("expected 'db' filtered out, got:\n%s", out)
+		}
+	})
+
+	t.Run("selector + name is rejected", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := space.NewSpaceCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		ctx := context.WithValue(context.Background(), space.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"web", "-l", "tier=web"})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--selector cannot be combined") {
+			t.Fatalf("expected --selector + name rejection, got: %v", err)
+		}
+	})
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/get/stack/stack.go
+++ b/cmd/kuke/get/stack/stack.go
@@ -44,13 +44,12 @@ func NewStackCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := resolveClient(cmd)
+			outputFormat, err := shared.ParseOutputFormat(cmd)
 			if err != nil {
 				return err
 			}
-			defer func() { _ = client.Close() }()
 
-			outputFormat, err := shared.ParseOutputFormat(cmd)
+			selector, err := shared.ParseLabelSelectorFlag(cmd)
 			if err != nil {
 				return err
 			}
@@ -64,6 +63,16 @@ func NewStackCmd() *cobra.Command {
 			} else {
 				name = strings.TrimSpace(viper.GetString(config.KUKE_GET_STACK_NAME.ViperKey))
 			}
+
+			if name != "" && !selector.Empty() {
+				return errors.New("--selector cannot be combined with a resource name")
+			}
+
+			client, err := resolveClient(cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
 
 			if name != "" {
 				if realm == "" {
@@ -102,6 +111,7 @@ func NewStackCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			stacks = filterStacksBySelector(stacks, selector)
 			return printStacks(cmd, stacks, outputFormat)
 		},
 	}
@@ -114,6 +124,8 @@ func NewStackCmd() *cobra.Command {
 		StringP("output", "o", "", "Output format (yaml, json, table, wide). Default: table for list, yaml for single resource")
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("output"))
 	_ = viper.BindPFlag(config.KUKE_GET_OUTPUT.ViperKey, cmd.Flags().Lookup("o"))
+
+	shared.RegisterLabelSelectorFlag(cmd)
 
 	cmd.ValidArgsFunction = config.CompleteStackNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -129,6 +141,22 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 		return mockClient, nil
 	}
 	return kukeshared.ClientFromCmd(cmd)
+}
+
+// filterStacksBySelector returns the subset of stacks whose
+// Metadata.Labels satisfy selector. A nil or empty selector returns the
+// input slice unmodified so the common no-flag path skips the allocation.
+func filterStacksBySelector(stacks []v1beta1.StackDoc, selector *shared.LabelSelector) []v1beta1.StackDoc {
+	if selector.Empty() {
+		return stacks
+	}
+	out := make([]v1beta1.StackDoc, 0, len(stacks))
+	for i := range stacks {
+		if selector.Matches(stacks[i].Metadata.Labels) {
+			out = append(out, stacks[i])
+		}
+	}
+	return out
 }
 
 func printStack(cmd *cobra.Command, stack *v1beta1.StackDoc, format shared.OutputFormat) error {

--- a/cmd/kuke/get/stack/stack_test.go
+++ b/cmd/kuke/get/stack/stack_test.go
@@ -201,6 +201,69 @@ func TestNewStackCmd_Columns(t *testing.T) {
 	}
 }
 
+// TestNewStackCmd_Selector verifies the `-l`/`--selector` filter wiring on
+// `kuke get stack` (issue #614). Grammar coverage lives in the shared
+// selector_test.go; this test pins the per-verb wiring.
+func TestNewStackCmd_Selector(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	listFn := func(_, _ string) ([]v1beta1.StackDoc, error) {
+		return []v1beta1.StackDoc{
+			{
+				Metadata: v1beta1.StackMetadata{
+					Name:   "frontend",
+					Labels: map[string]string{"app": "frontend"},
+				},
+				Spec: v1beta1.StackSpec{RealmID: "r1", SpaceID: "s1"},
+			},
+			{
+				Metadata: v1beta1.StackMetadata{
+					Name:   "backend",
+					Labels: map[string]string{"app": "backend"},
+				},
+				Spec: v1beta1.StackSpec{RealmID: "r1", SpaceID: "s1"},
+			},
+		}, nil
+	}
+
+	t.Run("equality filters by label", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := stack.NewStackCmd()
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		ctx := context.WithValue(context.Background(), stack.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{listStacksFn: listFn}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"-l", "app=frontend"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "frontend") {
+			t.Errorf("expected 'frontend' in output, got:\n%s", out)
+		}
+		if strings.Contains(out, "backend") {
+			t.Errorf("expected 'backend' filtered out, got:\n%s", out)
+		}
+	})
+
+	t.Run("selector + name is rejected", func(t *testing.T) {
+		t.Cleanup(viper.Reset)
+		cmd := stack.NewStackCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		ctx := context.WithValue(context.Background(), stack.MockControllerKey{},
+			kukeonv1.Client(&fakeClient{}))
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"backend", "-l", "app=frontend"})
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "--selector cannot be combined") {
+			t.Fatalf("expected --selector + name rejection, got: %v", err)
+		}
+	})
+}
+
 type fakeClient struct {
 	kukeonv1.FakeClient
 


### PR DESCRIPTION
## Summary

- Adds `-l`/`--selector` to `kuke get realm/space/stack/cell/container` (kubectl-style label query); selector filter applied to each verb's list path against `Metadata.Labels`, single-resource fetch is unaffected.
- Grammar: `key=value`, `key==value` (kubectl alias), `key!=value`, `key` (exists), `!key` (absent), comma-separated AND. Set-based operators (`in`, `notin`) deferred per issue #614's explicit out-of-scope note.
- Reusable parser lives at `cmd/kuke/get/shared/selector.go` so future selector-supporting verbs can consume it (issue AC: "lives in a reusable helper").
- Malformed selectors fail before any controller call (issue AC: "fail fast"). Empty result still exits 0 with the standard "No <kind> found." line.
- Help text shipped via `shared.RegisterLabelSelectorFlag` so every verb advertises the same one-line example.

## Implementation notes

- Container's list path was the only awkward case: `ListContainers` returns `ContainerSpec` (no labels), but each container's `Metadata.Labels` arrives via the per-spec `GetContainer` probe the verb already issues for the STATE column. The selector filter piggybacks on that loop — no extra round-trips.
- Combining `-l` with a positional name argument is rejected up front on every verb (`--selector cannot be combined with a resource name`). kubectl behaves the same way; gives a cleaner error than silently ignoring one or the other.
- `docs/cli-use-cases.md:286` already advertised `kuke get cells -l kukeon.io/config=<name>` as the canonical way to enumerate `kuke run --new` spawns — this PR makes that documented invocation actually work; no docs change needed for that line.

## Test plan

- [x] `make test` (full project suite — green post-rebase against current origin/main)
- [x] `go vet ./...` clean
- [x] `pre-commit run --files <staged>` clean (incl. golangci-lint)
- [x] Per-verb selector tests (realm/space/stack/cell/container) exercise equality, inequality, existence, absence, AND-combination, malformed-input fail-fast, no-match, and name+selector rejection. Grammar coverage lives in `cmd/kuke/get/shared/selector_test.go` (each operator, AND, whitespace tolerance, malformed inputs).
- [x] Built `./cmd/` and confirmed help text + fail-fast on every verb (`kuke get <kind> -l env=` errors before any controller dial).

Closes #614