### PR TITLE
docs(claude.md): drop nonexistent cell-cgroup row claim from post-reboot recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ A host reboot wipes the cgroup tmpfs while cell metadata under `/opt/kukeon/data
 
 Half-CreateCell cells (a `kuke create cell` that crashed before `markCellReady` could close the `ReadyObserved` latch) are deliberately excluded from the heal: the in-flight CreateCell will finish its own `ensureCellCgroup` path under the per-cell lock, and the reconciler stepping in would race that flow.
 
-Consequence: after a reboot, `kuke status` for every previously-Ready cell converges to a passing cell-cgroup row within one reconcile tick — no operator-driven `kuke start cell <name>` is required per cell. The `make dev-init` smoke does not exercise this path; reboot recovery is covered by the unit tests under `internal/controller/runner/reconcile_heal_test.go`.
+Consequence: after a reboot, no operator-driven `kuke start cell <name>` is required per cell — the next reconcile tick re-creates each previously-Ready cell's cgroup automatically. The `make dev-init` smoke does not exercise this path; reboot recovery is covered by the unit tests under `internal/controller/runner/reconcile_heal_test.go`.
 
 ### Manual phases (fallback)
 


### PR DESCRIPTION
## Summary

#882 landed a "Post-reboot cgroup recovery" subsection in `CLAUDE.md` (deferring from #862). The closing "Consequence:" sentence claimed `kuke status` "converges to a passing **cell-cgroup row**" — but `kuke status` has no per-cell cgroup row.

Per `cmd/kuke/status/checks.go:137` (`cgroup-v2` is the host-mount probe, not a per-cell row) and `cmd/kuke/status/parity.go:99` (the `cells` parity row is **name-based**, not health-based — it would pass even if every cell's cgroup were absent), the actual rows `kuke status` emits are: `socket`, `containerd`, `cgroup-v2`, `cni-plugins`, `run-dir`, `containerd-ns`, plus per-resource-kind name parity walks. None reflect per-cell cgroup health.

This PR rewrites the affected sentence to drop the "cell-cgroup row" specificity while preserving both surviving claims:

- no operator-driven `kuke start cell <name>` is required per cell post-reboot,
- `make dev-init` does not exercise this path; the unit tests under `internal/controller/runner/reconcile_heal_test.go` do.

Adding a per-cell cgroup row to `kuke status` is a separate feature, intentionally out of scope here.

## Test plan

- [x] `git diff CLAUDE.md` — one-line replacement, no other content changes.
- [x] `pre-commit run --files CLAUDE.md` — trim trailing whitespace / end-of-files / prettier all pass.

This is a pure markdown text edit — eligible for the trivial-edit shortcut per `agents/dev/CLAUDE.md` §"Trivial-edit shortcut" — so tagging `ready-to-merge` directly.

Closes #891