### PR TITLE
refactor(errdefs): hoist --selector+name conflict into ErrSelectorWithName

### DIFF
--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -80,7 +80,7 @@ when needed.`,
 			}
 
 			if name != "" && !selector.Empty() {
-				return errors.New("--selector cannot be combined with a resource name")
+				return errdefs.ErrSelectorWithName
 			}
 
 			client, err := resolveClient(cmd)

--- a/cmd/kuke/get/container/container.go
+++ b/cmd/kuke/get/container/container.go
@@ -113,7 +113,7 @@ func runContainerCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if name != "" && !selector.Empty() {
-		return errors.New("--selector cannot be combined with a resource name")
+		return errdefs.ErrSelectorWithName
 	}
 
 	client, err := resolveClient(cmd)

--- a/cmd/kuke/get/realm/realm.go
+++ b/cmd/kuke/get/realm/realm.go
@@ -62,7 +62,7 @@ func NewRealmCmd() *cobra.Command {
 			}
 
 			if name != "" && !selector.Empty() {
-				return errors.New("--selector cannot be combined with a resource name")
+				return errdefs.ErrSelectorWithName
 			}
 
 			client, err := resolveClient(cmd)

--- a/cmd/kuke/get/space/space.go
+++ b/cmd/kuke/get/space/space.go
@@ -64,7 +64,7 @@ func NewSpaceCmd() *cobra.Command {
 			}
 
 			if name != "" && !selector.Empty() {
-				return errors.New("--selector cannot be combined with a resource name")
+				return errdefs.ErrSelectorWithName
 			}
 
 			client, err := resolveClient(cmd)

--- a/cmd/kuke/get/stack/stack.go
+++ b/cmd/kuke/get/stack/stack.go
@@ -65,7 +65,7 @@ func NewStackCmd() *cobra.Command {
 			}
 
 			if name != "" && !selector.Empty() {
-				return errors.New("--selector cannot be combined with a resource name")
+				return errdefs.ErrSelectorWithName
 			}
 
 			client, err := resolveClient(cmd)

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -103,8 +103,16 @@ var (
 	ErrRootContainerMismatch = errors.New(
 		"rootContainerId disagrees with container marked root: true",
 	)
-	ErrCellNameRequired        = errors.New("cell name is required")
-	ErrContainerNameRequired   = errors.New("container name is required")
+	ErrCellNameRequired      = errors.New("cell name is required")
+	ErrContainerNameRequired = errors.New("container name is required")
+	// ErrSelectorWithName fires from every `kuke get <kind>` verb when the
+	// caller supplies both a positional resource name and -l/--selector.
+	// The two paths are mutually exclusive (a name targets exactly one
+	// resource; a selector filters a list), so the verb refuses up front
+	// instead of silently honouring one and dropping the other. Shared so
+	// future selector-aware verbs (`kuke describe`, `kuke delete`) reuse
+	// the same surface text and errors.Is identity.
+	ErrSelectorWithName        = errors.New("--selector cannot be combined with a resource name")
 	ErrInvalidName             = errors.New("name is invalid")
 	ErrInvalidImage            = errors.New("invalid image reference")
 	ErrDeleteRealm             = errors.New("failed to delete realm")


### PR DESCRIPTION
## Summary
- Hoists the copy-pasted `errors.New("--selector cannot be combined with a resource name")` literal out of the five `kuke get` verbs into a single `errdefs.ErrSelectorWithName` sentinel, per the CLAUDE.md *shared error sentinels* rule.
- Future selector-aware verbs (`kuke describe`, `kuke delete`, …) reuse the same surface text and `errors.Is` identity without re-declaring the literal.

## Test plan
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./...`
- [x] `make test` (full project suite)
- [x] `pre-commit run --files …` on the six touched paths (gofmt re-aligned the errdefs var block after the insertion; re-run clean)
- [x] Verified the five `cmd/kuke/get/{cell,container,realm,space,stack}` test files still pass — they assert on the message string (`strings.Contains "--selector cannot be combined"` and one full-string match in `realm_test.go:351`), and the sentinel's `errors.New(...)` text is identical to the old literal, so behavior is preserved.

Closes #894