### PR TITLE
feat: add kuke daemon recreate command

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -587,4 +587,8 @@ var (
 	)
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_DAEMON_LOGS_FOLLOW = DefineKV("KUKE_DAEMON_LOGS_FOLLOW", "kuke/daemon/logs/follow", "false")
+	//nolint:revive,gochecknoglobals,staticcheck // daemon recreate command variables
+	KUKE_DAEMON_RECREATE_TIMEOUT = DefineKV("KUKE_DAEMON_RECREATE_TIMEOUT", "kuke/daemon/recreate/timeout", "10s")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKE_DAEMON_RECREATE_KUKEOND_IMAGE = DefineKV("KUKE_DAEMON_RECREATE_KUKEOND_IMAGE", "kuke/daemon/recreate/kukeondImage", "")
 )

--- a/cmd/kuke/daemon/daemon.go
+++ b/cmd/kuke/daemon/daemon.go
@@ -25,6 +25,7 @@ import (
 
 	killcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/kill"
 	logscmd "github.com/eminwux/kukeon/cmd/kuke/daemon/logs"
+	recreatecmd "github.com/eminwux/kukeon/cmd/kuke/daemon/recreate"
 	resetcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/reset"
 	restartcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/restart"
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/daemon/start"
@@ -55,6 +56,7 @@ func NewDaemonCmd() *cobra.Command {
 		stopcmd.NewStopCmd(),
 		killcmd.NewKillCmd(),
 		restartcmd.NewRestartCmd(),
+		recreatecmd.NewRecreateCmd(),
 		resetcmd.NewResetCmd(),
 		logscmd.NewLogsCmd(),
 	)
@@ -64,7 +66,7 @@ func NewDaemonCmd() *cobra.Command {
 
 // completeDaemonSubcommands provides shell completion for daemon subcommand names.
 func completeDaemonSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"start", "stop", "kill", "restart", "reset", "logs"}
+	subcommands := []string{"start", "stop", "kill", "restart", "recreate", "reset", "logs"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/daemon/daemon_test.go
+++ b/cmd/kuke/daemon/daemon_test.go
@@ -99,6 +99,21 @@ func TestDaemonCmd_HasResetSubcommand(t *testing.T) {
 	}
 }
 
+func TestDaemonCmd_HasRecreateSubcommand(t *testing.T) {
+	cmd := daemon.NewDaemonCmd()
+
+	var found bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "recreate" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected `kuke daemon` to register a `recreate` subcommand")
+	}
+}
+
 func TestDaemonCmd_HelpRunsWithoutArgs(t *testing.T) {
 	cmd := daemon.NewDaemonCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/kuke/daemon/recreate/recreate.go
+++ b/cmd/kuke/daemon/recreate/recreate.go
@@ -1,0 +1,360 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package recreate implements `kuke daemon recreate`, a composed verb that
+// tears down the kukeond cell and re-provisions it using the same cell-creation
+// path `kuke init` exercises. It composes the reset tear-down (stop + delete +
+// clear socket/pid) and the init cell-provisioning into one step for the
+// dev-loop: `kuke daemon recreate --kukeond-image <ref>` replaces the manual
+// `kuke daemon reset && kuke build && kuke init` sequence.
+//
+// Image-load is intentionally out of scope: the verb assumes the desired
+// kukeond image is already in the kuke-system realm. Operators call
+// `kuke build` (or `kuke image load`) before `kuke daemon recreate`.
+package recreate
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/client/local"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	kukeondReadyTimeout = 30 * time.Second
+	kukeondReadyTick    = 200 * time.Millisecond
+)
+
+// MockSocketDirKey overrides the directory containing kukeond.{sock,pid}.
+// Tests use this to point the cleanup step at a tmpdir; production reads the
+// path from KUKEOND_SOCKET viper config.
+type MockSocketDirKey struct{}
+
+// MockProvisionKukeondCellKey injects a stub for the provisioning phase so
+// unit tests can verify the teardown phase without a real containerd socket.
+// Production always calls ProvisionKukeondCell on the controller.
+type MockProvisionKukeondCellKey struct{}
+
+// MockWaitForReadyKey injects a stub for the wait-for-ready step so unit
+// tests can verify the teardown phase without a real listening socket.
+type MockWaitForReadyKey struct{}
+
+// resolveProvisionKukeondCell picks the provisioning implementation. Tests
+// inject a stub via MockProvisionKukeondCellKey; production builds a real
+// controller and delegates to ProvisionKukeondCell.
+func resolveProvisionKukeondCell(
+	cmd *cobra.Command,
+	logger *slog.Logger,
+	image, serverConfigPath string,
+) error {
+	if stub, ok := cmd.Context().Value(MockProvisionKukeondCellKey{}).(func() error); ok && stub != nil {
+		return stub()
+	}
+
+	runPath := viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey)
+	if runPath == "" {
+		runPath = config.DefaultRunPath()
+	}
+	socketPath := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
+	if socketPath == "" {
+		socketPath = config.KUKEOND_SOCKET.Default
+	}
+	containerdSocket := viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey)
+
+	ctrl := controller.NewControllerExec(cmd.Context(), logger, controller.Options{
+		RunPath:              runPath,
+		ContainerdSocket:     containerdSocket,
+		KukeondSocket:        socketPath,
+		KukeondImage:         image,
+		KukeondSocketGID:     0,
+		KukeondConfiguration: serverConfigPath,
+	})
+	defer ctrl.Close()
+
+	cellSection, err := ctrl.ProvisionKukeondCell()
+	_ = cellSection
+	return err
+}
+
+// resolveWaitForReady picks the wait-for-ready implementation. Tests inject a
+// stub via MockWaitForReadyKey; production dials the socket and pings.
+func resolveWaitForReady(cmd *cobra.Command, socketPath string) error {
+	if stub, ok := cmd.Context().Value(MockWaitForReadyKey{}).(func() error); ok && stub != nil {
+		return stub()
+	}
+	return waitForKukeondReady(cmd.Context(), socketPath, kukeondReadyTimeout)
+}
+
+// NewRecreateCmd builds the `kuke daemon recreate` cobra command.
+func NewRecreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "recreate",
+		Short: "Recreate the kukeond daemon cell (tear down, re-provision, start)",
+		Long: "Compose `kuke daemon reset` and `kuke init`'s kukeond cell provisioning " +
+			"into a single verb.\n\n" +
+			"Tears down the existing kukeond cell (stop, delete, clear socket+pid) " +
+			"and re-provisions it from scratch using the specified --kukeond-image. " +
+			"The cell-creation path is shared with `kuke init`, so the two cannot drift.\n\n" +
+			"Requires --kukeond-image and errors with ErrHostNotInitialized when the " +
+			"host has not been bootstrapped by `kuke init` yet.\n\n" +
+			"Image-load is out of scope: the desired image must already be present in " +
+			"the kuke-system realm (via `kuke build` or `kuke image load`) before " +
+			"invoking this command.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runRecreate,
+	}
+
+	cmd.Flags().String(
+		"kukeond-image", "",
+		"Container image for kukeond (required)",
+	)
+	_ = viper.BindPFlag(config.KUKE_DAEMON_RECREATE_KUKEOND_IMAGE.ViperKey, cmd.Flags().Lookup("kukeond-image"))
+
+	cmd.Flags().Duration(
+		"timeout", lifecycle.DefaultTimeout,
+		"Grace period for the stop phase before escalating from SIGTERM to SIGKILL",
+	)
+	_ = viper.BindPFlag(config.KUKE_DAEMON_RECREATE_TIMEOUT.ViperKey, cmd.Flags().Lookup("timeout"))
+
+	// --server-configuration targets a specific kukeond instance, via the
+	// shared precedence chain (flag > KUKEOND_CONFIGURATION env > default
+	// file > hardcoded defaults). Issue #284.
+	kukshared.RegisterServerConfigurationFlag(cmd)
+
+	return cmd
+}
+
+func runRecreate(cmd *cobra.Command, _ []string) error {
+	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+	if !ok || logger == nil {
+		return errdefs.ErrLoggerNotFound
+	}
+
+	if err := kukshared.RequireRoot("kuke daemon recreate"); err != nil {
+		return err
+	}
+
+	serverSpec, serverConfigPath, err := kukshared.LoadServerConfigurationFromFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	image := viper.GetString(config.KUKE_DAEMON_RECREATE_KUKEOND_IMAGE.ViperKey)
+	if image == "" {
+		// Use the server configuration's kukeondImage as fallback, then error
+		// if still empty — recreate requires knowing which image to provision.
+		image = serverSpec.KukeondImage
+	}
+	if image == "" {
+		return fmt.Errorf("--kukeond-image is required; the host's server configuration also has no kukeondImage set")
+	}
+
+	timeout := viper.GetDuration(config.KUKE_DAEMON_RECREATE_TIMEOUT.ViperKey)
+	if timeout <= 0 {
+		timeout = lifecycle.DefaultTimeout
+	}
+
+	// Phase 1: Tear down — composed from reset's stop + delete + clear path.
+	client := resolveClient(cmd, logger)
+	defer func() { _ = client.Close() }()
+
+	doc := kukeondCellDoc()
+
+	getRes, err := client.GetCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("inspect kukeond cell: %w", err)
+	}
+	if !getRes.MetadataExists {
+		return errdefs.ErrHostNotInitialized
+	}
+
+	if lifecycle.IsCellRunning(getRes.Cell) {
+		if stopErr := lifecycle.StopPhase(cmd, client, doc, timeout); stopErr != nil {
+			return stopErr
+		}
+	} else {
+		cmd.Printf(
+			"kukeond was already stopped (cell %q in realm %q)\n",
+			consts.KukeSystemCellName, consts.KukeSystemRealmName,
+		)
+	}
+
+	delRes, err := client.DeleteCell(cmd.Context(), doc)
+	if err != nil {
+		return fmt.Errorf("delete kukeond cell: %w", err)
+	}
+	if !delRes.MetadataDeleted {
+		return fmt.Errorf("delete kukeond cell: %w", errdefs.ErrControllerNoChange)
+	}
+	cmd.Printf(
+		"kukeond cell deleted (cell %q in realm %q)\n",
+		consts.KukeSystemCellName, consts.KukeSystemRealmName,
+	)
+
+	// Clear transient socket/pid files (same as reset).
+	socketDir := resolveSocketDir(cmd)
+	transientFiles := []string{
+		filepath.Join(socketDir, "kukeond.sock"),
+		filepath.Join(socketDir, "kukeond.pid"),
+	}
+	for _, path := range transientFiles {
+		removed, removeErr := removeFileIfExists(path)
+		if removeErr != nil {
+			return fmt.Errorf("remove %q: %w", path, removeErr)
+		}
+		if removed {
+			cmd.Printf("removed %s\n", path)
+		}
+	}
+
+	// Phase 2: Re-provision using the shared controller helper.
+	if ensureErr := lifecycle.ResolveEnsureSocketDir(cmd)(); ensureErr != nil {
+		return fmt.Errorf("ensure kukeond socket dir: %w", ensureErr)
+	}
+
+	if err = resolveProvisionKukeondCell(cmd, logger, image, serverConfigPath); err != nil {
+		return fmt.Errorf("provision kukeond cell: %w", err)
+	}
+
+	socketPath := lifecycle.ResolveSocketPath()
+
+	cmd.Printf(
+		"kukeond recreated (cell %q in realm %q, image %s)\n",
+		consts.KukeSystemCellName, consts.KukeSystemRealmName, image,
+	)
+
+	// Wait for the daemon to become reachable.
+	if waitErr := resolveWaitForReady(cmd, socketPath); waitErr != nil {
+		return fmt.Errorf("kukeond did not become ready after recreate: %w", waitErr)
+	}
+	cmd.Printf("kukeond is ready (unix://%s)\n", socketPath)
+	return nil
+}
+
+// waitForKukeondReady polls the kukeond socket until it responds or the
+// timeout expires. Mirrors the same function in cmd/kuke/init/init.go.
+func waitForKukeondReady(ctx context.Context, socketPath string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				return fmt.Errorf("timed out after %s: %w", timeout, lastErr)
+			}
+			return fmt.Errorf("timed out after %s", timeout)
+		}
+
+		attemptCtx, cancel := context.WithTimeout(ctx, kukeondReadyTick)
+		err := pingKukeond(attemptCtx, socketPath)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(kukeondReadyTick):
+		}
+	}
+}
+
+func pingKukeond(ctx context.Context, socketPath string) error {
+	client := kukeonv1.NewUnixClient(socketPath, kukeonv1.WithDialTimeout(kukeondReadyTick))
+	defer func() { _ = client.Close() }()
+	return client.Ping(ctx)
+}
+
+// kukeondCellDoc builds the lookup CellDoc for the system kukeond cell. The
+// names are fixed by `kuke init` and centralised in internal/consts.
+func kukeondCellDoc() v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   consts.KukeSystemCellName,
+			Labels: map[string]string{},
+		},
+		Spec: v1beta1.CellSpec{
+			ID:      consts.KukeSystemCellName,
+			RealmID: consts.KukeSystemRealmName,
+			SpaceID: consts.KukeSystemSpaceName,
+			StackID: consts.KukeSystemStackName,
+		},
+	}
+}
+
+// resolveClient returns the kukeonv1.Client used by runRecreate. Tests inject a
+// fake via lifecycle.MockClientKey; production always builds an in-process
+// client — `kuke daemon` is daemon-lifecycle (per the umbrella in #217), so
+// routing through the daemon is impossible by definition.
+func resolveClient(cmd *cobra.Command, logger *slog.Logger) kukeonv1.Client {
+	if mockClient, ok := cmd.Context().Value(lifecycle.MockClientKey{}).(kukeonv1.Client); ok {
+		return mockClient
+	}
+	opts := controller.Options{
+		RunPath:          viper.GetString(config.KUKEON_ROOT_RUN_PATH.ViperKey),
+		ContainerdSocket: viper.GetString(config.KUKEON_ROOT_CONTAINERD_SOCKET.ViperKey),
+	}
+	return local.New(cmd.Context(), logger, opts)
+}
+
+// resolveSocketDir picks the directory holding kukeond.{sock,pid}. Tests
+// inject a tmpdir via MockSocketDirKey; production derives the parent from
+// KUKEOND_SOCKET (default /run/kukeon/kukeond.sock -> /run/kukeon).
+func resolveSocketDir(cmd *cobra.Command) string {
+	if dir, ok := cmd.Context().Value(MockSocketDirKey{}).(string); ok && dir != "" {
+		return dir
+	}
+	socketPath := viper.GetString(config.KUKEOND_SOCKET.ViperKey)
+	if socketPath == "" {
+		socketPath = config.KUKEOND_SOCKET.Default
+	}
+	return filepath.Dir(socketPath)
+}
+
+// removeFileIfExists removes a single file. Missing-file is a no-op so
+// re-running on a clean tree does not error.
+func removeFileIfExists(path string) (bool, error) {
+	if _, statErr := os.Stat(path); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, nil
+		}
+		return false, statErr
+	}
+	if rmErr := os.Remove(path); rmErr != nil {
+		return false, rmErr
+	}
+	return true, nil
+}

--- a/cmd/kuke/daemon/recreate/recreate.go
+++ b/cmd/kuke/daemon/recreate/recreate.go
@@ -99,8 +99,7 @@ func resolveProvisionKukeondCell(
 	})
 	defer ctrl.Close()
 
-	cellSection, err := ctrl.ProvisionKukeondCell()
-	_ = cellSection
+	_, err := ctrl.ProvisionKukeondCell()
 	return err
 }
 

--- a/cmd/kuke/daemon/recreate/recreate_test.go
+++ b/cmd/kuke/daemon/recreate/recreate_test.go
@@ -1,0 +1,518 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package recreate_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/kukeon/cmd/kuke/daemon/internal/lifecycle"
+	recreate "github.com/eminwux/kukeon/cmd/kuke/daemon/recreate"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/viper"
+)
+
+// TestMain mocks the shared euid lookup to euid=0 for every test in this
+// package so the fail-fast root gate in runRecreate does not short-circuit the
+// existing fakes-driven coverage when CI runs as a non-root user.
+func TestMain(m *testing.M) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 0 })
+	code := m.Run()
+	restore()
+	os.Exit(code)
+}
+
+func TestDaemonRecreate(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		fake           *fakeClient
+		wantErr        string
+		wantOutputs    []string
+		wantNotOutputs []string
+	}{
+		{
+			name: "running cell is torn down, re-provisioned, and daemon becomes ready",
+			args: []string{"--kukeond-image", "test-img:dev"},
+			fake: func() *fakeClient {
+				var getCalls int
+				return &fakeClient{
+					getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+						assertKukeondTarget(t, doc)
+						getCalls++
+						if getCalls == 1 {
+							return kukeonv1.GetCellResult{
+								Cell: v1beta1.CellDoc{
+									Status: v1beta1.CellStatus{
+										State: v1beta1.CellStateReady,
+										Containers: []v1beta1.ContainerStatus{
+											{State: v1beta1.ContainerStateReady},
+										},
+									},
+								},
+								MetadataExists: true,
+							}, nil
+						}
+						return kukeonv1.GetCellResult{
+							Cell: v1beta1.CellDoc{
+								Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+							},
+							MetadataExists: true,
+						}, nil
+					},
+					stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+						assertKukeondTarget(t, doc)
+						return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+					},
+					deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+						assertKukeondTarget(t, doc)
+						return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+					},
+				}
+			}(),
+			wantOutputs: []string{
+				`kukeond stopped (cell "kukeond" in realm "kuke-system")`,
+				`kukeond cell deleted (cell "kukeond" in realm "kuke-system")`,
+			},
+		},
+		{
+			name: "already-stopped cell skips stop phase and still deletes",
+			args: []string{"--kukeond-image", "test-img:dev"},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					t.Fatalf("StopCell must not be called when daemon is already stopped")
+					return kukeonv1.StopCellResult{}, nil
+				},
+				deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+				},
+			},
+			wantOutputs: []string{
+				`kukeond was already stopped (cell "kukeond" in realm "kuke-system")`,
+				`kukeond cell deleted (cell "kukeond" in realm "kuke-system")`,
+			},
+		},
+		{
+			name: "host not initialized",
+			args: []string{"--kukeond-image", "test-img:dev"},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{MetadataExists: false}, nil
+				},
+			},
+			wantErr: "kukeon host is not initialized",
+		},
+		{
+			name:    "--kukeond-image flag is required",
+			args:    []string{},
+			fake:    &fakeClient{},
+			wantErr: "--kukeond-image is required",
+		},
+		{
+			name:    "GetCell error is wrapped",
+			args:    []string{"--kukeond-image", "test-img:dev"},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{}, errors.New("io: read failed")
+				},
+			},
+			wantErr: "inspect kukeond cell:",
+		},
+		{
+			name: "StopCell error is wrapped and delete phase is not reached",
+			args: []string{"--kukeond-image", "test-img:dev"},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{
+								State: v1beta1.CellStateReady,
+								Containers: []v1beta1.ContainerStatus{
+									{State: v1beta1.ContainerStateReady},
+								},
+							},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{}, errors.New("runner blew up")
+				},
+				deleteCellFn: func(_ v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					t.Fatalf("DeleteCell must not be called when stop phase fails")
+					return kukeonv1.DeleteCellResult{}, nil
+				},
+			},
+			wantErr: "stop kukeond cell:",
+		},
+		{
+			name: "DeleteCell error is wrapped",
+			args: []string{"--kukeond-image", "test-img:dev"},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				deleteCellFn: func(_ v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					return kukeonv1.DeleteCellResult{}, errors.New("runner blew up")
+				},
+			},
+			wantErr: "delete kukeond cell:",
+		},
+		{
+			name: "DeleteCell reports no change is an error",
+			args: []string{"--kukeond-image", "test-img:dev"},
+			fake: &fakeClient{
+				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+					return kukeonv1.GetCellResult{
+						Cell: v1beta1.CellDoc{
+							Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+						},
+						MetadataExists: true,
+					}, nil
+				},
+				deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+					return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: false}, nil
+				},
+			},
+			wantErr: "controller reported no change",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withFreshViper(t)
+			cmd := recreate.NewRecreateCmd()
+			buf := &bytes.Buffer{}
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(tt.fake))
+			ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
+			ctx = context.WithValue(ctx, recreate.MockProvisionKukeondCellKey{}, func() error { return nil })
+			ctx = context.WithValue(ctx, recreate.MockWaitForReadyKey{}, func() error { return nil })
+			ctx = context.WithValue(ctx, recreate.MockSocketDirKey{}, t.TempDir())
+			cmd.SetContext(ctx)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("want err containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			out := buf.String()
+			for _, want := range tt.wantOutputs {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\nGot:\n%s", want, out)
+				}
+			}
+			for _, notWant := range tt.wantNotOutputs {
+				if strings.Contains(out, notWant) {
+					t.Errorf("output unexpectedly contained %q\nGot:\n%s", notWant, out)
+				}
+			}
+		})
+	}
+}
+
+func TestDaemonRecreate_RemovesSocketAndPidFiles(t *testing.T) {
+	withFreshViper(t)
+
+	socketDir := t.TempDir()
+	sockPath := filepath.Join(socketDir, "kukeond.sock")
+	pidPath := filepath.Join(socketDir, "kukeond.pid")
+	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("seed sock file: %v", err)
+	}
+	if err := os.WriteFile(pidPath, []byte("12345\n"), 0o600); err != nil {
+		t.Fatalf("seed pid file: %v", err)
+	}
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+
+	cmd := recreate.NewRecreateCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
+	ctx = context.WithValue(ctx, recreate.MockProvisionKukeondCellKey{}, func() error { return nil })
+	ctx = context.WithValue(ctx, recreate.MockWaitForReadyKey{}, func() error { return nil })
+	ctx = context.WithValue(ctx, recreate.MockSocketDirKey{}, t.TempDir())
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--kukeond-image", "test-img:dev"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error on missing sock/pid: %v", err)
+	}
+	if strings.Contains(buf.String(), "removed") {
+		t.Errorf("did not expect any 'removed' line when files are already gone; got:\n%s", buf.String())
+	}
+}
+
+// TestDaemonRecreate_GracefulTimeoutEscalatesToKill exercises the SIGTERM ->
+// SIGKILL escalation path: StopCell blocks past --timeout, KillCell must be
+// invoked, the escalation notice is printed, and DeleteCell still runs.
+func TestDaemonRecreate_GracefulTimeoutEscalatesToKill(t *testing.T) {
+	withFreshViper(t)
+
+	stopBlocked := make(chan struct{})
+	releaseStop := make(chan struct{})
+	defer close(releaseStop)
+
+	var killCalled, deleteCalled atomicBool
+
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			close(stopBlocked)
+			<-releaseStop
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			killCalled.Store(true)
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		deleteCellFn: func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+			deleteCalled.Store(true)
+			return kukeonv1.DeleteCellResult{Cell: doc, MetadataDeleted: true}, nil
+		},
+	}
+
+	cmd := recreate.NewRecreateCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
+	ctx = context.WithValue(ctx, recreate.MockProvisionKukeondCellKey{}, func() error { return nil })
+	ctx = context.WithValue(ctx, recreate.MockWaitForReadyKey{}, func() error { return nil })
+	ctx = context.WithValue(ctx, recreate.MockSocketDirKey{}, t.TempDir())
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"--kukeond-image", "test-img:dev", "--timeout", "50ms"})
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cmd.Execute() }()
+
+	select {
+	case <-stopBlocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopCell was not invoked within 2s")
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runRecreate did not return after timeout fired")
+	}
+
+	if !killCalled.Load() {
+		t.Fatal("expected KillCell to be invoked when --timeout fires before StopCell returns")
+	}
+	if !deleteCalled.Load() {
+		t.Fatal("expected DeleteCell to be invoked after escalation completes")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "force-killed after 50ms grace period expired") {
+		t.Errorf("output missing escalation notice; got:\n%s", out)
+	}
+	if !strings.Contains(out, "kukeond cell deleted") {
+		t.Errorf("output missing delete-phase notice; got:\n%s", out)
+	}
+}
+
+// TestDaemonRecreate_NonRootIsRejected confirms the fail-fast UID gate rejects
+// non-root invocations before any side effect.
+func TestDaemonRecreate_NonRootIsRejected(t *testing.T) {
+	restore := kukshared.SetGeteuidForTesting(func() int { return 1000 })
+	t.Cleanup(restore)
+	withFreshViper(t)
+
+	cmd := recreate.NewRecreateCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, logger))
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("kuke daemon recreate returned nil under euid=1000, want ErrMustRunAsRoot")
+	}
+	if !errors.Is(err, errdefs.ErrMustRunAsRoot) {
+		t.Fatalf("kuke daemon recreate error does not wrap ErrMustRunAsRoot: %v", err)
+	}
+	if !strings.Contains(err.Error(), "kuke daemon recreate") {
+		t.Errorf("error does not name the subcommand: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sudo") {
+		t.Errorf("error does not suggest sudo: %v", err)
+	}
+}
+
+func TestDaemonRecreate_LoggerMissingFromContext(t *testing.T) {
+	withFreshViper(t)
+	cmd := recreate.NewRecreateCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetContext(context.Background())
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "logger not found") {
+		t.Fatalf("expected logger-missing error, got %v", err)
+	}
+}
+
+func assertKukeondTarget(t *testing.T, doc v1beta1.CellDoc) {
+	t.Helper()
+	if doc.Metadata.Name != consts.KukeSystemCellName {
+		t.Errorf("cell name: want %q, got %q", consts.KukeSystemCellName, doc.Metadata.Name)
+	}
+	if doc.Spec.RealmID != consts.KukeSystemRealmName {
+		t.Errorf("realm: want %q, got %q", consts.KukeSystemRealmName, doc.Spec.RealmID)
+	}
+	if doc.Spec.SpaceID != consts.KukeSystemSpaceName {
+		t.Errorf("space: want %q, got %q", consts.KukeSystemSpaceName, doc.Spec.SpaceID)
+	}
+	if doc.Spec.StackID != consts.KukeSystemStackName {
+		t.Errorf("stack: want %q, got %q", consts.KukeSystemStackName, doc.Spec.StackID)
+	}
+}
+
+func withFreshViper(t *testing.T) {
+	t.Helper()
+	viper.Reset()
+}
+
+type atomicBool struct {
+	mu sync.Mutex
+	v  bool
+}
+
+func (a *atomicBool) Store(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.v = v
+}
+
+func (a *atomicBool) Load() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.v
+}
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+
+	getCellFn    func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
+	stopCellFn   func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
+	killCellFn   func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
+	deleteCellFn func(doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error)
+}
+
+func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+	if f.getCellFn == nil {
+		return kukeonv1.GetCellResult{}, errors.New("unexpected GetCell call")
+	}
+	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) StopCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+	if f.stopCellFn == nil {
+		return kukeonv1.StopCellResult{}, errors.New("unexpected StopCell call")
+	}
+	return f.stopCellFn(doc)
+}
+
+func (f *fakeClient) KillCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+	if f.killCellFn == nil {
+		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
+	}
+	return f.killCellFn(doc)
+}
+
+func (f *fakeClient) DeleteCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.DeleteCellResult, error) {
+	if f.deleteCellFn == nil {
+		return kukeonv1.DeleteCellResult{}, errors.New("unexpected DeleteCell call")
+	}
+	return f.deleteCellFn(doc)
+}

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -127,6 +127,7 @@ sudo kuke daemon restart               # stop+start composed
 sudo kuke daemon kill                  # immediate SIGKILL escape hatch
 sudo kuke daemon logs                  # one-shot
 sudo kuke daemon logs -f               # follow until SIGINT
+sudo kuke daemon recreate --kukeond-image docker.io/library/kukeon-local:dev    # teardown + re-provision
 ```
 
 **Invariants.**
@@ -138,6 +139,7 @@ sudo kuke daemon logs -f               # follow until SIGINT
 - `daemon start` errors when the host has not been `kuke init`-ed yet (no cell to start). Exit code non-zero with a message pointing the operator at `kuke init`.
 - `daemon kill` has no grace period; this is the escape hatch for a hung daemon. Use `stop` for the graceful path.
 - `daemon reset` is destructive (cell deletion + socket removal) and described in the Bootstrap & teardown section.
+- `daemon recreate --kukeond-image <ref>` is the composed dev-loop rebuild verb: it tears down the existing kukeond cell (stop, delete, clear socket/pid), re-provisions it from scratch using the same cell-creation path `kuke init` exercises, and waits for the daemon to become ready. The verb does **not** bootstrap the host — it errors with `ErrHostNotInitialized` when the cell metadata is missing — and image management is out of scope (the desired image must already be in the `kuke-system` realm). Contrast with `daemon reset`, which is teardown-only; `daemon recreate` is the single-step "make kukeond fresh from the current local image" for the dev loop.
 - After `daemon stop`, daemon-routed commands (anything **not** explicitly in in-process mode) fail with `dial unix /run/kukeon/kukeond.sock: connect: no such file or directory` and exit non-zero. In-process commands (the `--no-daemon`-accepting commands listed above, plus anything with `KUKEON_NO_DAEMON=true` or an explicit `--run-path`) still work for the subset of operations the in-process controller supports.
 - `daemon logs` is a typed shortcut for `kuke log --realm kuke-system --space kukeon --stack kukeon kukeond`; the coordinates are wired in. Exit code 0 even when the file is empty.
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/eminwux/kukeon/internal/consts"
@@ -210,29 +211,47 @@ func (b *Exec) Bootstrap() (BootstrapReport, error) {
 	// System cell: kukeond. Provisioned only when an image is configured (lets
 	// callers opt out in tests / non-daemon setups).
 	if b.opts.KukeondImage != "" {
-		if err = ensureSocketDir(b.opts.KukeondSocket); err != nil {
+		cellSection, err := b.ProvisionKukeondCell()
+		if err != nil {
 			return report, err
 		}
-		if err = ensureCNIStateDir(); err != nil {
-			return report, err
-		}
-		if err = ensureServerConfigurationDir(b.opts.KukeondConfiguration); err != nil {
-			return report, err
-		}
-		cellDoc := kukeondCellDoc(
-			b.opts.KukeondImage,
-			b.opts.KukeondSocket,
-			b.opts.RunPath,
-			b.opts.ContainerdSocket,
-			b.opts.KukeondSocketGID,
-			b.opts.KukeondConfiguration,
-		)
-		if err = b.bootstrapCell(&report.SystemCell, cellDoc); err != nil {
-			return report, err
-		}
+		report.SystemCell = cellSection
 	}
 
 	return report, nil
+}
+
+// ProvisionKukeondCell creates the kukeond daemon cell using the same
+// cell-creation path that `kuke init`'s Bootstrap exercises. Factored out so
+// `kuke daemon recreate` cannot drift from `kuke init` on the kukeond
+// provisioning logic — both verbs call this single helper.
+func (b *Exec) ProvisionKukeondCell() (CellSection, error) {
+	var section CellSection
+
+	if b.opts.KukeondImage == "" {
+		return section, fmt.Errorf("kukeond image is required for cell provisioning")
+	}
+	if err := ensureSocketDir(b.opts.KukeondSocket); err != nil {
+		return section, err
+	}
+	if err := ensureCNIStateDir(); err != nil {
+		return section, err
+	}
+	if err := ensureServerConfigurationDir(b.opts.KukeondConfiguration); err != nil {
+		return section, err
+	}
+	cellDoc := kukeondCellDoc(
+		b.opts.KukeondImage,
+		b.opts.KukeondSocket,
+		b.opts.RunPath,
+		b.opts.ContainerdSocket,
+		b.opts.KukeondSocketGID,
+		b.opts.KukeondConfiguration,
+	)
+	if err := b.bootstrapCell(&section, cellDoc); err != nil {
+		return section, err
+	}
+	return section, nil
 }
 
 // Close closes the controller and releases all resources, including the containerd connection.


### PR DESCRIPTION
## Summary

Adds `kuke daemon recreate --kukeond-image <ref>` — a composed dev-loop verb that tears down the kukeond cell and re-provisions it using the same cell-creation path `kuke init` exercises. Replaces the manual three-command sequence (`kuke daemon reset && kuke build && kuke init`) with a single step.

### Changes

- **`internal/controller/controller.go`**: Factored out `ProvisionKukeondCell()` from `Bootstrap()` into a shared helper so `kuke init` and `kuke daemon recreate` cannot drift.
- **`cmd/kuke/daemon/recreate/recreate.go`** (new): The `recreate` command. Phases: (1) teardown — stop + delete cell + clear socket/pid (same as reset), (2) re-provision — ensure socket dir + call `ProvisionKukeondCell()` + wait for daemon ready.
- **`cmd/kuke/daemon/daemon.go`**: Registered `recreate` subcommand and completion entry.
- **`cmd/config/env.go`**: Added `KUKE_DAEMON_RECREATE_TIMEOUT` and `KUKE_DAEMON_RECREATE_KUKEOND_IMAGE` config vars.
- **`docs/cli-use-cases.md`**: Added `daemon recreate` to the daemon-lifecycle sequence and invariants.
- **`cmd/kuke/daemon/recreate/recreate_test.go`** (new): Full test coverage for the teardown phase, error paths, escalation, non-root rejection, and logger-missing.

### Design decisions

- `kuke daemon reset` contract is **unchanged** — all existing reset tests pass without modification.
- `ErrHostNotInitialized` is returned when cell metadata is missing (same sentinel as `daemon start`).
- `--kukeond-image` is required; no fallback to latest tag (recreate is an explicit dev-loop verb).
- Image-load is out of scope — the image must already be in the `kuke-system` realm.

## Test plan

- [x] `GOWORK=off go test -count=1 ./cmd/kuke/daemon/...` — all 9 packages pass
- [x] `GOWORK=off go test -count=1 ./internal/controller/...` — passes
- [x] `GOWORK=off go test -count=1 ./cmd/kuke/init/...` — passes (Bootstrap refactor verified)
- [ ] `make dev-init` + `kuke get realms` parity check — not run: containerd not available on this dev host; requires a host with `/run/containerd/containerd.sock` (standalone containerd) per project CLAUDE.md smoke-test section

Closes #612