### PR TITLE
docs(dev-init): document /etc/kukeon/kukeond.yaml masking of --run-path socket

### DIFF
--- a/docs/dev-init-troubleshooting.md
+++ b/docs/dev-init-troubleshooting.md
@@ -1,0 +1,19 @@
+# `kuke init` / `make dev-init` troubleshooting
+
+## `kuke init --run-path <path>` derives the wrong kukeond socket
+
+`kuke init --run-path X` derives `<X>/kukeond.sock` for the daemon socket (PR #569). If the resulting socket is `/run/kukeon/kukeond.sock` regardless of `X`, check for a leftover `/etc/kukeon/kukeond.yaml`:
+
+```bash
+ls -l /etc/kukeon/kukeond.yaml
+```
+
+`kukeond serve` writes this file on its first start via `internal/serverconfig.WriteDefault` (O_EXCL — first writer wins forever, no rewrite on subsequent starts). The file's `spec.socket` field flows back through `applyServerConfiguration`'s `viper.Set` on every subsequent `kuke init`, which (intentionally) trips `viper.IsSet(KUKEOND_SOCKET)` in `applyRunPathImpliesKukeondSocket` and skips the per-`--run-path` derivation. The behavior is correct for operators who pinned a YAML config; it surprises agents iterating on a fix when a prior `make dev-init` or e2e run left the file behind.
+
+Move it aside before re-running the local repro:
+
+```bash
+sudo mv /etc/kukeon/kukeond.yaml /tmp/kukeond.yaml.bak
+```
+
+`make dev-init` itself is unaffected because its expected socket is exactly the YAML's pinned `/run/kukeon/kukeond.sock`.


### PR DESCRIPTION
## Summary
- Adds a new `docs/dev-init-troubleshooting.md` documenting the `/etc/kukeon/kukeond.yaml` masking effect on `kuke init --run-path <path>` socket derivation: `kukeond serve` writes the file O_EXCL on first start (`internal/serverconfig.WriteDefault`), and its `spec.socket` flows back through `applyServerConfiguration`'s `viper.Set` on every subsequent `kuke init` — intentionally tripping `viper.IsSet(KUKEOND_SOCKET)` in `applyRunPathImpliesKukeondSocket` and skipping the per-`--run-path` derivation. One-line workaround: `sudo mv /etc/kukeon/kukeond.yaml /tmp/kukeond.yaml.bak`.

Pure-docs, single new file; eligible for the trivial-edit shortcut per dev/CLAUDE.md §Trivial-edit shortcut.

## Deviation from #580's AC

The issue's AC required the subsection in `kukeon/CLAUDE.md` (now an `AGENTS.md` symlink after #893) between `### Inspecting the running daemon` and `### Recovering from a failed kuke uninstall`. The issue author asked in chat to extract to a separate file — `AGENTS.md` is already at the 150-line cap on `main`, so any inline addition pushes it over. Honoring the author override: this PR leaves `AGENTS.md` unchanged and ships the friction note as a standalone doc instead. Discoverable by greppable terms (`kukeond.yaml`, `applyRunPathImpliesKukeondSocket`, `--run-path`).

## Test plan
- [x] `pre-commit run --files docs/dev-init-troubleshooting.md` — trim-trailing-whitespace, fix-end-of-files, mixed-line-ending, prettier all green.
- [x] Verified the symbols cited in the doc exist on `main`: `internal/serverconfig.WriteDefault` (`internal/serverconfig/serverconfig.go:168`, O_EXCL on `serverconfig.go:179`), `applyRunPathImpliesKukeondSocket` (`cmd/kuke/kuke.go:420`), `applyServerConfiguration` (`cmd/kuke/init/init.go:242`).
- [x] `wc -l AGENTS.md` is 150 (unchanged from `main`).

Closes #580