### PR TITLE
refactor: use shared.DaemonClientFromCmd in version command

### DIFF
--- a/cmd/kuke/version/version.go
+++ b/cmd/kuke/version/version.go
@@ -25,7 +25,6 @@ import (
 	"github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // daemonClient is the subset of kukeonv1.Client needed by the version command.
@@ -54,11 +53,7 @@ func NewVersionCmd() *cobra.Command {
 			if mockClient, ok := cmd.Context().Value(MockDaemonClientKey{}).(daemonClient); ok {
 				client = mockClient
 			} else {
-				host := viper.GetString(config.KUKEON_ROOT_HOST.ViperKey)
-				if host == "" {
-					host = config.KUKEON_ROOT_HOST.Default
-				}
-				c, err := kukeonv1.Dial(cmd.Context(), host)
+				c, err := shared.DaemonClientFromCmd(cmd)
 				if err != nil {
 					_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: daemon unreachable: %v\n", err)
 					return nil


### PR DESCRIPTION
## Summary
Replace the inline host-resolve + `kukeonv1.Dial` block in `cmd/kuke/version/version.go` with the shared helper `kukshared.DaemonClientFromCmd(cmd)`, removing the inline duplicate and the unused `viper` import.

The dial path now stays aligned with the ~20 other workload commands that use the shared helper, picking up future changes to `dialDaemon` (TLS, retries, instrumentation) automatically.

## Test plan
- [x] `GOWORK=off go build ./cmd/kuke/version/`
- [x] `GOWORK=off go vet ./cmd/kuke/version/`
- [x] `GOWORK=off go test ./cmd/kuke/version/ -v` — all 8 tests pass

Closes #897