### PR TITLE
feat(clientconfig): mirror suffix/cgroup root, switch dev-init to dev profile (phase 3)

### DIFF
--- a/cmd/kuke/clientconfig_test.go
+++ b/cmd/kuke/clientconfig_test.go
@@ -22,9 +22,24 @@ import (
 	"testing"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/internal/consts"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/viper"
 )
+
+// restoreRuntimeGlobals snapshots the consts package runtime globals and
+// returns a cleanup that restores them. loadClientConfiguration calls
+// consts.ConfigureRuntime, which mutates these — tests that exercise it
+// must roll back so the next test starts on the in-binary defaults.
+func restoreRuntimeGlobals(t *testing.T) {
+	t.Helper()
+	prevSuffix := consts.RealmNamespaceSuffix
+	prevRoot := consts.KukeonCgroupRoot
+	t.Cleanup(func() {
+		consts.RealmNamespaceSuffix = prevSuffix //nolint:reassign // restore runtime-overridable global
+		consts.KukeonCgroupRoot = prevRoot       //nolint:reassign // restore runtime-overridable global
+	})
+}
 
 func bindKukeEnv(t *testing.T) {
 	t.Helper()
@@ -33,6 +48,8 @@ func bindKukeEnv(t *testing.T) {
 		config.KUKEON_ROOT_RUN_PATH,
 		config.KUKEON_ROOT_CONTAINERD_SOCKET,
 		config.KUKEON_ROOT_LOG_LEVEL,
+		config.KUKEON_ROOT_NAMESPACE_SUFFIX,
+		config.KUKEON_ROOT_CGROUP_ROOT,
 	} {
 		if err := v.BindEnv(); err != nil {
 			t.Fatalf("BindEnv %s: %v", v.EnvVar(), err)
@@ -62,10 +79,12 @@ func TestApplyClientConfigurationDefaultsLayered(t *testing.T) {
 	}
 
 	spec := v1beta1.ClientConfigurationSpec{
-		Host:             "unix:///tmp/from-config.sock",
-		RunPath:          "/opt/kukeon-from-config",
-		ContainerdSocket: "/run/containerd/from-config.sock",
-		LogLevel:         "warn",
+		Host:                      "unix:///tmp/from-config.sock",
+		RunPath:                   "/opt/kukeon-from-config",
+		ContainerdSocket:          "/run/containerd/from-config.sock",
+		LogLevel:                  "warn",
+		ContainerdNamespaceSuffix: "dev.kukeon.io",
+		CgroupRoot:                "/kukeon-dev",
 	}
 	applyClientConfiguration(cmd, spec)
 
@@ -80,6 +99,13 @@ func TestApplyClientConfigurationDefaultsLayered(t *testing.T) {
 	}
 	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != spec.LogLevel {
 		t.Errorf("LogLevel: got %q, want %q", got, spec.LogLevel)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey); got != spec.ContainerdNamespaceSuffix {
+		t.Errorf("ContainerdNamespaceSuffix: got %q, want %q",
+			got, spec.ContainerdNamespaceSuffix)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey); got != spec.CgroupRoot {
+		t.Errorf("CgroupRoot: got %q, want %q", got, spec.CgroupRoot)
 	}
 }
 
@@ -163,6 +189,7 @@ func TestApplyClientConfigurationEmptyFieldsLeaveViperUntouched(t *testing.T) {
 
 func TestLoadClientConfigurationAbsentFileNoError(t *testing.T) {
 	t.Cleanup(viper.Reset)
+	restoreRuntimeGlobals(t)
 
 	viper.Reset()
 	cmd, err := NewKukeCmd()
@@ -182,6 +209,7 @@ func TestLoadClientConfigurationAbsentFileNoError(t *testing.T) {
 
 func TestLoadClientConfigurationSeedsViper(t *testing.T) {
 	t.Cleanup(viper.Reset)
+	restoreRuntimeGlobals(t)
 
 	viper.Reset()
 	cmd, err := NewKukeCmd()
@@ -198,6 +226,8 @@ metadata:
 spec:
   host: unix:///tmp/from-config.sock
   logLevel: warn
+  containerdNamespaceSuffix: dev.kukeon.io
+  cgroupRoot: /kukeon-dev
 `
 	if writeErr := os.WriteFile(path, []byte(content), 0o644); writeErr != nil {
 		t.Fatalf("WriteFile: %v", writeErr)
@@ -212,6 +242,23 @@ spec:
 	}
 	if got := viper.GetString(config.KUKEON_ROOT_LOG_LEVEL.ViperKey); got != "warn" {
 		t.Errorf("LogLevel: got %q, want %q", got, "warn")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey); got != "dev.kukeon.io" {
+		t.Errorf("ContainerdNamespaceSuffix: got %q, want %q", got, "dev.kukeon.io")
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey); got != "/kukeon-dev" {
+		t.Errorf("CgroupRoot: got %q, want %q", got, "/kukeon-dev")
+	}
+	// consts.ConfigureRuntime must observe the configured values so
+	// downstream RealmNamespace / KukeonCgroupRoot reads (in --no-daemon
+	// workload paths) follow the loaded client configuration.
+	if got, want := consts.RealmNamespaceSuffix, ".dev.kukeon.io"; got != want {
+		t.Errorf("consts.RealmNamespaceSuffix: got %q, want %q "+
+			"(loadClientConfiguration must call ConfigureRuntime)", got, want)
+	}
+	if got, want := consts.KukeonCgroupRoot, "/kukeon-dev"; got != want {
+		t.Errorf("consts.KukeonCgroupRoot: got %q, want %q "+
+			"(loadClientConfiguration must call ConfigureRuntime)", got, want)
 	}
 }
 

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -48,6 +48,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/kuke/version"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/clientconfig"
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/logging"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -294,6 +295,23 @@ func loadClientConfiguration(cmd *cobra.Command) error {
 		return fmt.Errorf("load client configuration: %w", err)
 	}
 	applyClientConfiguration(cmd, doc.Spec)
+	// Mirror the daemon-side LoadServerConfigurationFromFlag: drive
+	// consts.ConfigureRuntime from the configured (or default) suffix and
+	// cgroup root so --no-daemon workload paths read the same realm
+	// namespaces and cgroup tree the daemon side does. Admin verbs run
+	// LoadServerConfigurationFromFlag in their RunE; their later
+	// ConfigureRuntime call wins for those paths.
+	suffix := viper.GetString(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey)
+	if suffix == "" {
+		suffix = config.KUKEON_ROOT_NAMESPACE_SUFFIX.Default
+	}
+	cgroupRoot := viper.GetString(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey)
+	if cgroupRoot == "" {
+		cgroupRoot = config.KUKEON_ROOT_CGROUP_ROOT.Default
+	}
+	if cfgErr := consts.ConfigureRuntime(suffix, cgroupRoot); cfgErr != nil {
+		return fmt.Errorf("configure runtime: %w", cfgErr)
+	}
 	return nil
 }
 
@@ -332,6 +350,16 @@ func applyClientConfiguration(cmd *cobra.Command, spec v1beta1.ClientConfigurati
 	}
 	if spec.LogLevel != "" && !flagChanged(cmd, "log-level") && !envSet(config.KUKEON_ROOT_LOG_LEVEL) {
 		viper.Set(config.KUKEON_ROOT_LOG_LEVEL.ViperKey, spec.LogLevel)
+	}
+	if spec.ContainerdNamespaceSuffix != "" &&
+		!flagChanged(cmd, "containerd-namespace-suffix") &&
+		!envSet(config.KUKEON_ROOT_NAMESPACE_SUFFIX) {
+		viper.Set(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey, spec.ContainerdNamespaceSuffix)
+	}
+	if spec.CgroupRoot != "" &&
+		!flagChanged(cmd, "cgroup-root") &&
+		!envSet(config.KUKEON_ROOT_CGROUP_ROOT) {
+		viper.Set(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey, spec.CgroupRoot)
 	}
 }
 

--- a/e2e/e2e_kuke_apply_test.go
+++ b/e2e/e2e_kuke_apply_test.go
@@ -300,8 +300,15 @@ func TestKukeApply_Realm_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q (full path: %q) does not exist in filesystem", realm.Status.CgroupPath, fullPath)
 	}
 
-	// Verify expected cgroup path structure
-	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName
+	// Verify expected cgroup path structure: <configured-root>/{realmName}.
+	// Read the configured cgroup root from the daemon's realm response rather
+	// than from consts.KukeonCgroupRoot so the test passes against a non-default
+	// ClientConfiguration / ServerConfiguration profile (e.g. /kukeon-dev).
+	cgroupRoot, err := getCgroupRoot(t, host, realmName)
+	if err != nil {
+		t.Fatalf("getCgroupRoot: %v", err)
+	}
+	expectedCgroupPath := cgroupRoot + "/" + realmName
 	if !strings.HasSuffix(realm.Status.CgroupPath, expectedCgroupPath) {
 		t.Logf(
 			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",
@@ -380,8 +387,15 @@ func TestKukeApply_Space_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", space.Status.CgroupPath)
 	}
 
-	// Verify expected cgroup path structure
-	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName
+	// Verify expected cgroup path structure: <configured-root>/{realmName}/{spaceName}.
+	// Read the configured cgroup root from the daemon's realm response rather
+	// than from consts.KukeonCgroupRoot so the test passes against a non-default
+	// ClientConfiguration / ServerConfiguration profile (e.g. /kukeon-dev).
+	cgroupRoot, err := getCgroupRoot(t, host, realmName)
+	if err != nil {
+		t.Fatalf("getCgroupRoot: %v", err)
+	}
+	expectedCgroupPath := cgroupRoot + "/" + realmName + "/" + spaceName
 	if !strings.HasSuffix(space.Status.CgroupPath, expectedCgroupPath) {
 		t.Logf(
 			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",
@@ -473,8 +487,15 @@ func TestKukeApply_Stack_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", stack.Status.CgroupPath)
 	}
 
-	// Verify expected cgroup path structure
-	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName
+	// Verify expected cgroup path structure: <configured-root>/{realmName}/{spaceName}/{stackName}.
+	// Read the configured cgroup root from the daemon's realm response rather
+	// than from consts.KukeonCgroupRoot so the test passes against a non-default
+	// ClientConfiguration / ServerConfiguration profile (e.g. /kukeon-dev).
+	cgroupRoot, err := getCgroupRoot(t, host, realmName)
+	if err != nil {
+		t.Fatalf("getCgroupRoot: %v", err)
+	}
+	expectedCgroupPath := cgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName
 	if !strings.HasSuffix(stack.Status.CgroupPath, expectedCgroupPath) {
 		t.Logf(
 			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",
@@ -584,8 +605,16 @@ func TestKukeApply_Cell_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", cell.Status.CgroupPath)
 	}
 
-	// Verify expected cgroup path structure
-	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName + "/" + cellName
+	// Verify expected cgroup path structure:
+	// <configured-root>/{realmName}/{spaceName}/{stackName}/{cellName}. Read
+	// the configured cgroup root from the daemon's realm response rather than
+	// from consts.KukeonCgroupRoot so the test passes against a non-default
+	// ClientConfiguration / ServerConfiguration profile (e.g. /kukeon-dev).
+	cgroupRoot, err := getCgroupRoot(t, host, realmName)
+	if err != nil {
+		t.Fatalf("getCgroupRoot: %v", err)
+	}
+	expectedCgroupPath := cgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName + "/" + cellName
 	if !strings.HasSuffix(cell.Status.CgroupPath, expectedCgroupPath) {
 		t.Logf(
 			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",

--- a/e2e/e2e_kuke_cell_test.go
+++ b/e2e/e2e_kuke_cell_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eminwux/kukeon/internal/consts"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
@@ -171,8 +170,16 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", cell.Status.CgroupPath)
 	}
 
-	// Also verify expected cgroup path structure: /kukeon/{realmName}/{spaceName}/{stackName}/{cellName}
-	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName + "/" + cellName
+	// Also verify expected cgroup path structure:
+	// <configured-root>/{realmName}/{spaceName}/{stackName}/{cellName}. Read
+	// the configured cgroup root from the daemon's realm response rather than
+	// from consts.KukeonCgroupRoot so the test passes against a non-default
+	// ClientConfiguration / ServerConfiguration profile (e.g. /kukeon-dev).
+	cgroupRoot, err := getCgroupRoot(t, host, realmName)
+	if err != nil {
+		t.Fatalf("getCgroupRoot: %v", err)
+	}
+	expectedCgroupPath := cgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName + "/" + cellName
 	if !strings.HasSuffix(cell.Status.CgroupPath, expectedCgroupPath) {
 		t.Logf(
 			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",

--- a/e2e/e2e_kuke_realm_test.go
+++ b/e2e/e2e_kuke_realm_test.go
@@ -230,10 +230,17 @@ func TestKuke_CreateRealm_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q (full path: %q) does not exist in filesystem", realm.Status.CgroupPath, fullPath)
 	}
 
-	// Also verify expected cgroup path structure: /kukeon/{realmName}
-	// The actual path may include the current process's cgroup hierarchy before the kukeon path,
-	// so we check if the path ends with the expected pattern.
-	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName
+	// Also verify expected cgroup path structure: <configured-root>/{realmName}.
+	// The actual path may include the current process's cgroup hierarchy before
+	// the kukeon path, so we check if the path ends with the expected pattern.
+	// Read the configured cgroup root from the daemon's realm response rather
+	// than from consts.KukeonCgroupRoot so the test passes against a non-default
+	// ClientConfiguration / ServerConfiguration profile (e.g. /kukeon-dev).
+	cgroupRoot, err := getCgroupRoot(t, host, realmName)
+	if err != nil {
+		t.Fatalf("getCgroupRoot: %v", err)
+	}
+	expectedCgroupPath := cgroupRoot + "/" + realmName
 	if !strings.HasSuffix(realm.Status.CgroupPath, expectedCgroupPath) {
 		t.Logf(
 			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",

--- a/e2e/e2e_kuke_space_test.go
+++ b/e2e/e2e_kuke_space_test.go
@@ -119,10 +119,17 @@ func TestKuke_CreateSpace_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", space.Status.CgroupPath)
 	}
 
-	// Also verify expected cgroup path structure: /kukeon/{realmName}/{spaceName}
-	// The actual path may include the current process's cgroup hierarchy before the kukeon path,
-	// so we check if the path ends with the expected pattern.
-	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName
+	// Also verify expected cgroup path structure: <configured-root>/{realmName}/{spaceName}.
+	// The actual path may include the current process's cgroup hierarchy before
+	// the kukeon path, so we check if the path ends with the expected pattern.
+	// Read the configured cgroup root from the daemon's realm response rather
+	// than from consts.KukeonCgroupRoot so the test passes against a non-default
+	// ClientConfiguration / ServerConfiguration profile (e.g. /kukeon-dev).
+	cgroupRoot, err := getCgroupRoot(t, host, realmName)
+	if err != nil {
+		t.Fatalf("getCgroupRoot: %v", err)
+	}
+	expectedCgroupPath := cgroupRoot + "/" + realmName + "/" + spaceName
 	if !strings.HasSuffix(space.Status.CgroupPath, expectedCgroupPath) {
 		t.Logf(
 			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",

--- a/e2e/e2e_kuke_stack_test.go
+++ b/e2e/e2e_kuke_stack_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/eminwux/kukeon/internal/consts"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
@@ -149,10 +148,18 @@ func TestKuke_CreateStack_VerifyState(t *testing.T) {
 		t.Fatalf("cgroup path %q does not exist in filesystem", stack.Status.CgroupPath)
 	}
 
-	// Also verify expected cgroup path structure: /kukeon/{realmName}/{spaceName}/{stackName}
-	// The actual path may include the current process's cgroup hierarchy before the kukeon path,
-	// so we check if the path ends with the expected pattern.
-	expectedCgroupPath := consts.KukeonCgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName
+	// Also verify expected cgroup path structure:
+	// <configured-root>/{realmName}/{spaceName}/{stackName}. The actual path may
+	// include the current process's cgroup hierarchy before the kukeon path,
+	// so we check if the path ends with the expected pattern. Read the
+	// configured cgroup root from the daemon's realm response rather than from
+	// consts.KukeonCgroupRoot so the test passes against a non-default
+	// ClientConfiguration / ServerConfiguration profile (e.g. /kukeon-dev).
+	cgroupRoot, err := getCgroupRoot(t, host, realmName)
+	if err != nil {
+		t.Fatalf("getCgroupRoot: %v", err)
+	}
+	expectedCgroupPath := cgroupRoot + "/" + realmName + "/" + spaceName + "/" + stackName
 	if !strings.HasSuffix(stack.Status.CgroupPath, expectedCgroupPath) {
 		t.Logf(
 			"cgroup path %q does not end with expected pattern %q, but verifying it exists anyway",

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -706,6 +706,31 @@ func getRealmNamespace(t *testing.T, host, realmName string) (string, error) {
 	return realm.Spec.Namespace, nil
 }
 
+// getCgroupRoot returns the cgroup root the daemon is using, derived from
+// realmName's reported Status.CgroupPath. Mirrors the getRealmNamespace
+// pattern: ask the daemon for state rather than importing
+// consts.KukeonCgroupRoot, so the e2e helpers run unmodified against a
+// non-default ClientConfiguration / ServerConfiguration profile (e.g. the
+// dev-init dev profile under /kukeon-dev) — the daemon's response is the
+// authoritative source. The returned root retains any host
+// cgroup-hierarchy prefix kukeon's mount may sit under, so callers can
+// compare against a nested object's Status.CgroupPath via
+// strings.HasSuffix or by joining with the realm/space/stack/cell names.
+func getCgroupRoot(t *testing.T, host, realmName string) (string, error) {
+	t.Helper()
+
+	args := append(
+		buildKukeDaemonArgs(host),
+		"get", "realm", realmName, "--output", "json",
+	)
+	output := runReturningBinary(t, nil, kuke, args...)
+	realm, err := parseRealmJSON(t, output)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse realm JSON: %w", err)
+	}
+	return strings.TrimSuffix(realm.Status.CgroupPath, "/"+realm.Metadata.Name), nil
+}
+
 // verifyRootContainerExists verifies root container exists in containerd namespace.
 func verifyRootContainerExists(t *testing.T, namespace, containerID string) bool {
 	t.Helper()

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -95,6 +95,20 @@ spec:
   # Client log level when --verbose is on (debug, info, warn, error).
   # Default: info
   logLevel: info
+
+  # Suffix appended to every realm name to form its containerd namespace.
+  # Realm "default" + suffix "kukeon.io" -> namespace "default.kukeon.io".
+  # --no-daemon workload paths read this to address the right kukeon
+  # instance's containerd namespaces (e.g. "dev.kukeon.io" for a parallel
+  # dev instance on the same host).
+  # Default: kukeon.io
+  containerdNamespaceSuffix: kukeon.io
+
+  # Cgroup root under which all realms / spaces / stacks / cells live.
+  # --no-daemon workload paths use this for the in-process cgroup
+  # hierarchy (e.g. "/kukeon-dev" for a parallel dev instance).
+  # Default: /kukeon
+  cgroupRoot: /kukeon
 `
 
 // WriteDefault writes the commented default ClientConfiguration to path when

--- a/internal/clientconfig/clientconfig_test.go
+++ b/internal/clientconfig/clientconfig_test.go
@@ -52,6 +52,8 @@ spec:
   runPath: /opt/kukeon-test
   containerdSocket: /run/containerd/test.sock
   logLevel: debug
+  containerdNamespaceSuffix: dev.kukeon.io
+  cgroupRoot: /kukeon-dev
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
@@ -75,6 +77,12 @@ spec:
 	}
 	if doc.Spec.LogLevel != "debug" {
 		t.Errorf("LogLevel: got %q", doc.Spec.LogLevel)
+	}
+	if doc.Spec.ContainerdNamespaceSuffix != "dev.kukeon.io" {
+		t.Errorf("ContainerdNamespaceSuffix: got %q", doc.Spec.ContainerdNamespaceSuffix)
+	}
+	if doc.Spec.CgroupRoot != "/kukeon-dev" {
+		t.Errorf("CgroupRoot: got %q", doc.Spec.CgroupRoot)
 	}
 }
 
@@ -179,6 +187,12 @@ func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 	if doc.Spec.LogLevel != "info" {
 		t.Errorf("Spec.LogLevel: got %q", doc.Spec.LogLevel)
 	}
+	if doc.Spec.ContainerdNamespaceSuffix != "kukeon.io" {
+		t.Errorf("Spec.ContainerdNamespaceSuffix: got %q", doc.Spec.ContainerdNamespaceSuffix)
+	}
+	if doc.Spec.CgroupRoot != "/kukeon" {
+		t.Errorf("Spec.CgroupRoot: got %q", doc.Spec.CgroupRoot)
+	}
 
 	// AC: "Header comment explains each field's purpose and default."
 	raw, err := os.ReadFile(path)
@@ -194,6 +208,8 @@ func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 		"# Default: /opt/kukeon",
 		"# Default: /run/containerd/containerd.sock",
 		"# Default: info",
+		"# Default: kukeon.io",
+		"# Default: /kukeon",
 	} {
 		if !strings.Contains(rawStr, marker) {
 			t.Errorf("missing per-field default marker %q in dumped YAML", marker)

--- a/pkg/api/model/v1beta1/clientconfiguration.go
+++ b/pkg/api/model/v1beta1/clientconfiguration.go
@@ -41,14 +41,29 @@ type ClientConfigurationMetadata struct {
 type ClientConfigurationSpec struct {
 	// Host is the kukeond endpoint kuke dials by default
 	// (`unix:///run/kukeon/kukeond.sock` or `ssh://user@host`).
-	Host string `json:"host,omitempty"             yaml:"host,omitempty"`
+	Host string `json:"host,omitempty"                      yaml:"host,omitempty"`
 	// RunPath is the kukeon runtime root used by `--no-daemon` operations
 	// that read /opt/kukeon directly instead of going through kukeond.
-	RunPath string `json:"runPath,omitempty"          yaml:"runPath,omitempty"`
+	RunPath string `json:"runPath,omitempty"                   yaml:"runPath,omitempty"`
 	// ContainerdSocket is the containerd unix socket `--no-daemon`
 	// operations connect to.
-	ContainerdSocket string `json:"containerdSocket,omitempty" yaml:"containerdSocket,omitempty"`
+	ContainerdSocket string `json:"containerdSocket,omitempty"          yaml:"containerdSocket,omitempty"`
 	// LogLevel is the client log level when `--verbose` is on
 	// (debug, info, warn, error).
-	LogLevel string `json:"logLevel,omitempty"         yaml:"logLevel,omitempty"`
+	LogLevel string `json:"logLevel,omitempty"                  yaml:"logLevel,omitempty"`
+	// ContainerdNamespaceSuffix is the suffix appended to every realm name
+	// to form its containerd namespace. Realm "default" + suffix
+	// "kukeon.io" -> namespace "default.kukeon.io". `--no-daemon` workload
+	// paths run the controller in-process and read this field to address
+	// the correct kukeon instance's containerd namespaces — the parallel
+	// of ServerConfiguration.spec.containerdNamespaceSuffix on the daemon
+	// side. Default: kukeon.io.
+	ContainerdNamespaceSuffix string `json:"containerdNamespaceSuffix,omitempty" yaml:"containerdNamespaceSuffix,omitempty"`
+	// CgroupRoot is the cgroup root under which all realms / spaces /
+	// stacks / cells live (e.g. /kukeon-dev for a parallel dev instance on
+	// the same host). `--no-daemon` workload paths consult this field for
+	// the in-process cgroup hierarchy; the parallel of
+	// ServerConfiguration.spec.cgroupRoot on the daemon side.
+	// Default: /kukeon.
+	CgroupRoot string `json:"cgroupRoot,omitempty"                yaml:"cgroupRoot,omitempty"`
 }

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -29,6 +29,17 @@ METADATA_ROOT="/opt/kukeon/data"
 SYSTEM_REALM_DIR="${METADATA_ROOT}/kuke-system"
 KUKEOND_CELL_DIR="${SYSTEM_REALM_DIR}/kukeon/kukeon/kukeond"
 
+# Dev profile (phase 3, #285). dev-init exercises the multi-instance path
+# wired by phases 1 (#262, server-side suffix/cgroupRoot) and 2 (#284,
+# --server-configuration plumbed through admin commands). Phase 3 mirrors
+# the same two knobs on ClientConfigurationSpec so --no-daemon workload
+# paths read them through KUKE_CONFIGURATION instead of the package
+# constants. The two YAML files below are kept under .gitignore's /kuke*
+# rule so an operator's local edits are never overwritten — the write is
+# guarded by `[ ! -e ]` so re-running on a configured host is a no-op.
+DEV_PROFILE_SERVER_CONFIG="${REPO_ROOT}/kukeond-dev.yaml"
+DEV_PROFILE_CLIENT_CONFIG="${REPO_ROOT}/kuke-dev.yaml"
+
 step() {
     printf '\n==> %s\n' "$*"
 }
@@ -139,6 +150,60 @@ verify_parent_attach_intact() {
 # holds at every exit point in the script.
 trap 'verify_parent_attach_intact || exit 1' EXIT
 
+# Write the dev-profile config files idempotently before any kuke invocation
+# (#285 phase 3). `-e` instead of `-f` so a broken symlink to a missing
+# operator-curated config is detected; a regular file matches too. The
+# server-side config is consumed by `kuke init --server-configuration` and
+# `kuke daemon reset --server-configuration`; the client-side config is
+# consumed by every `kuke` subcommand below via the exported
+# KUKE_CONFIGURATION (the env name viper binds to `kuke/configuration` —
+# cmd/config/env.go's KUKE_CONFIGURATION).
+if [ ! -e "${DEV_PROFILE_SERVER_CONFIG}" ]; then
+    step "Write dev-profile server config to ${DEV_PROFILE_SERVER_CONFIG}"
+    cat > "${DEV_PROFILE_SERVER_CONFIG}" <<'EOF'
+# kukeond ServerConfiguration — dev profile (#285 phase 3).
+# Switches containerdNamespaceSuffix and cgroupRoot off the defaults so a
+# parallel kukeon instance can coexist with the canonical kukeon.io / /kukeon
+# tree. socket / runPath are left at defaults — dev-init runs the only
+# kukeon instance on the host, so disjoint storage is unnecessary; the
+# multi-instance two-host-smoke is exercised by the issue's manual test
+# plan, not this script.
+apiVersion: v1beta1
+kind: ServerConfiguration
+metadata:
+  name: dev
+spec:
+  containerdNamespaceSuffix: dev.kukeon.io
+  cgroupRoot: /kukeon-dev
+EOF
+fi
+
+if [ ! -e "${DEV_PROFILE_CLIENT_CONFIG}" ]; then
+    step "Write dev-profile client config to ${DEV_PROFILE_CLIENT_CONFIG}"
+    cat > "${DEV_PROFILE_CLIENT_CONFIG}" <<'EOF'
+# kuke ClientConfiguration — dev profile (#285 phase 3).
+# Read by every `kuke` invocation below via KUKE_CONFIGURATION. The
+# --no-daemon parity check below depends on this file to address the dev
+# instance's containerd namespaces (dev.kukeon.io) and cgroup tree
+# (/kukeon-dev) without a per-command --containerd-namespace-suffix /
+# --cgroup-root flag.
+apiVersion: v1beta1
+kind: ClientConfiguration
+metadata:
+  name: dev
+spec:
+  containerdNamespaceSuffix: dev.kukeon.io
+  cgroupRoot: /kukeon-dev
+EOF
+fi
+
+# KUKE_CONFIGURATION is bound to viper for every `kuke` subcommand
+# (KUKE_CONFIGURATION.BindEnv in cmd/kuke/kuke.go's loadConfig), so
+# exporting it here routes every client invocation below through the
+# dev-profile client config. sudo invocations must add KUKE_CONFIGURATION
+# to --preserve-env=... or the value is stripped at the sudo boundary.
+export KUKE_CONFIGURATION="${DEV_PROFILE_CLIENT_CONFIG}"
+
 step "Build kuke, kukebuild (and the kukeond symlink)"
 make kuke kukebuild
 ln -sf kuke kukeond
@@ -183,13 +248,16 @@ if [ ! -d "${SYSTEM_REALM_DIR}" ]; then
     # provisioning at the end of that pass may fail because the local image
     # is not yet built into containerd. Tolerate that — the second init
     # below recreates the cell after the build succeeds.
-    sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}" \
+    sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION ./kuke init \
+        --kukeond-image "${KUKEOND_IMAGE_REF}" \
+        --server-configuration "${DEV_PROFILE_SERVER_CONFIG}" \
         || echo "first-pass init returned non-zero (expected before image is staged); continuing"
 fi
 
 if [ -d "${KUKEOND_CELL_DIR}" ]; then
     step "Reset prior kukeond cell"
-    sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke daemon reset
+    sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION ./kuke daemon reset \
+        --server-configuration "${DEV_PROFILE_SERVER_CONFIG}"
 else
     step "No prior kukeond cell at ${KUKEOND_CELL_DIR}; skipping reset"
 fi
@@ -200,12 +268,14 @@ step "Build ${LOCAL_TAG} into the kuke-system realm"
 # daemon, no docker-private containerd, no `--from-docker` loader hop. The -t
 # short tag normalizes to docker.io/library/kukeon-local:dev (kukebuild's
 # normalizeImageName), the exact ref `kuke init --kukeond-image` resolves below.
-sudo --preserve-env=KUKEON_HOST ./kuke build --build-arg VERSION=v0.0.0-dev \
+sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke build --build-arg VERSION=v0.0.0-dev \
     -t "${LOCAL_TAG}" \
     --realm kuke-system .
 
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
-sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KUKEOND_IMAGE_REF}"
+sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION ./kuke init \
+    --kukeond-image "${KUKEOND_IMAGE_REF}" \
+    --server-configuration "${DEV_PROFILE_SERVER_CONFIG}"
 
 # Fail-loud when the running kukeond container is anchored on a stale
 # image (issue #857). The bug captured there is that `kuke daemon reset`
@@ -231,7 +301,11 @@ sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET ./kuke init --kukeond-image "${KU
 # Stay grep/sed-only — scripts in this repo intentionally avoid a jq
 # dependency (see scripts/install.sh's "no jq dependency" guarantee).
 step "Verify running kukeond container is anchored on the just-built image"
-KUKEOND_NS="kuke-system.kukeon.io"
+# Dev-profile suffix is `dev.kukeon.io` (#285 phase 3), so the kuke-system
+# realm's containerd namespace is `kuke-system.dev.kukeon.io` rather than
+# the default `kuke-system.kukeon.io`. A reviewer toggling the dev profile
+# back to defaults would need to revisit this literal.
+KUKEOND_NS="kuke-system.dev.kukeon.io"
 KUKEOND_CTR_ID="kukeon_kukeon_kukeond_kukeond"
 
 ctr_chain="$(sudo ctr -n "${KUKEOND_NS}" snapshots info "${KUKEOND_CTR_ID}" 2>/dev/null \
@@ -282,8 +356,22 @@ fi
 echo "running kukeond container chain ${ctr_chain} matches just-built ${KUKEOND_IMAGE_REF}"
 
 step "Daemon parity check (both must show identical output)"
-sudo --preserve-env=KUKEON_HOST ./kuke get realms
-sudo ./kuke get realms --no-daemon
+# `-o wide` appends NAMESPACE — the column epic:get retired from the
+# default table — so the dev profile's suffix is visible in the parity
+# tail (e.g. default.dev.kukeon.io, kuke-system.dev.kukeon.io). The
+# daemon-routed call is gated by KUKEON_HOST + the daemon's server
+# config; the --no-daemon call routes through KUKE_CONFIGURATION to read
+# the same suffix/cgroupRoot in-process. Both must show identical output.
+sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke get realms -o wide
+sudo --preserve-env=KUKE_CONFIGURATION ./kuke get realms -o wide --no-daemon
+
+# CGROUP no longer surfaces in the default or wide table (epic:get also
+# retired CGROUP); `-o yaml` is the supported way to read cgroupPath.
+# Surface the dev profile's cgroup root here so an operator skimming
+# `make dev-init` output sees /kukeon-dev anchored on the realms.
+step "Daemon parity: cgroupPath surfacing (dev profile expects /kukeon-dev/...)"
+sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke get realms -o yaml \
+    | grep -E 'cgroupPath:' || true
 
 # Phase 1b smoke (#410): the daemon's metadata-rendering path emits the
 # bind-mounted kuketty config consumed by kuketty's sbsh-backed RPC server.
@@ -309,13 +397,13 @@ ATTACH_SMOKE_METADATA="${ATTACH_SMOKE_BASE}/kuketty-metadata.json"
 ATTACH_SMOKE_TMP="$(mktemp -d)"
 
 teardown_attach_smoke_state() {
-    sudo --preserve-env=KUKEON_HOST ./kuke purge cell "${ATTACH_SMOKE_CELL}" \
+    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke purge cell "${ATTACH_SMOKE_CELL}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" --stack "${ATTACH_SMOKE_STACK}" \
         --cascade 2>/dev/null || true
-    sudo --preserve-env=KUKEON_HOST ./kuke purge stack "${ATTACH_SMOKE_STACK}" \
+    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke purge stack "${ATTACH_SMOKE_STACK}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" 2>/dev/null || true
-    sudo --preserve-env=KUKEON_HOST ./kuke purge space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
-    sudo --preserve-env=KUKEON_HOST ./kuke purge realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
+    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke purge space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
+    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke purge realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
 }
 
 cleanup_attach_smoke() {
@@ -336,9 +424,9 @@ trap cleanup_attach_smoke EXIT
 # left intact — only the on-disk realm/space/stack/cell state is wiped.
 teardown_attach_smoke_state
 
-sudo --preserve-env=KUKEON_HOST ./kuke create realm "${ATTACH_SMOKE_REALM}"
-sudo --preserve-env=KUKEON_HOST ./kuke create space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}"
-sudo --preserve-env=KUKEON_HOST ./kuke create stack "${ATTACH_SMOKE_STACK}" --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}"
+sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke create realm "${ATTACH_SMOKE_REALM}"
+sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke create space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}"
+sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke create stack "${ATTACH_SMOKE_STACK}" --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}"
 
 cat > "${ATTACH_SMOKE_TMP}/cell.yaml" <<EOF
 apiVersion: v1beta1
@@ -363,7 +451,7 @@ spec:
       attachable: true
 EOF
 
-sudo --preserve-env=KUKEON_HOST ./kuke apply -f "${ATTACH_SMOKE_TMP}/cell.yaml"
+sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke apply -f "${ATTACH_SMOKE_TMP}/cell.yaml"
 
 # Wait for kuketty to bind the per-container socket. The window covers
 # image pull + container start + sbsh server bring-up; a regression that
@@ -395,7 +483,7 @@ sudo grep -q '"kind": "Container"' "${ATTACH_SMOKE_METADATA}" \
 # pkg/attach speaks.
 ATTACH_LOG="${ATTACH_SMOKE_TMP}/attach.log"
 go run ./hack/attach-smoke --log "${ATTACH_LOG}" -- \
-    sudo --preserve-env=KUKEON_HOST ./kuke attach "${ATTACH_SMOKE_CELL}" \
+    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke attach "${ATTACH_SMOKE_CELL}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" \
         --stack "${ATTACH_SMOKE_STACK}" --container "${ATTACH_SMOKE_CONTAINER}"
 echo "kuke attach exited cleanly (see ${ATTACH_LOG} for the full transcript)"

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -29,16 +29,33 @@ METADATA_ROOT="/opt/kukeon/data"
 SYSTEM_REALM_DIR="${METADATA_ROOT}/kuke-system"
 KUKEOND_CELL_DIR="${SYSTEM_REALM_DIR}/kukeon/kukeon/kukeond"
 
-# Dev profile (phase 3, #285). dev-init exercises the multi-instance path
-# wired by phases 1 (#262, server-side suffix/cgroupRoot) and 2 (#284,
-# --server-configuration plumbed through admin commands). Phase 3 mirrors
-# the same two knobs on ClientConfigurationSpec so --no-daemon workload
-# paths read them through KUKE_CONFIGURATION instead of the package
-# constants. The two YAML files below are kept under .gitignore's /kuke*
-# rule so an operator's local edits are never overwritten — the write is
-# guarded by `[ ! -e ]` so re-running on a configured host is a no-op.
+# Profile gate (phase 3, #285). The default (KUKEON_PROFILE unset) leaves
+# containerdNamespaceSuffix and cgroupRoot at the package defaults
+# (kukeon.io / /kukeon), so a contributor running `make dev-init` to
+# install main against the host gets the canonical layout — the historical
+# behavior of this script. Set KUKEON_PROFILE=dev to exercise the
+# multi-instance path wired by phases 1 (#262, server-side suffix/cgroupRoot)
+# and 2 (#284, --server-configuration plumbed through admin commands):
+# dev-init then writes ./kukeond-dev.yaml + ./kuke-dev.yaml idempotently
+# (guarded by `[ ! -e ]`), routes admin commands through
+# --server-configuration, routes client commands through KUKE_CONFIGURATION,
+# and the parity tail expects the dev.kukeon.io suffix and /kukeon-dev
+# cgroup root. Phase 3 mirrors the same two knobs on ClientConfigurationSpec
+# so --no-daemon workload paths read them through KUKE_CONFIGURATION instead
+# of the package constants.
+KUKEON_PROFILE="${KUKEON_PROFILE:-}"
 DEV_PROFILE_SERVER_CONFIG="${REPO_ROOT}/kukeond-dev.yaml"
 DEV_PROFILE_CLIENT_CONFIG="${REPO_ROOT}/kuke-dev.yaml"
+
+# Defaults below match the historical script behavior: canonical
+# kuke-system.kukeon.io namespace for the staleness check, no
+# --server-configuration arg, and the original --preserve-env lists. The
+# dev-profile branch (after the EXIT trap is set, so YAML writes are
+# guarded too) overrides these.
+KUKEOND_NS="kuke-system.kukeon.io"
+SERVER_CONFIG_FLAGS=()
+PRESERVE_ENV_WORKLOAD="KUKEON_HOST"
+PRESERVE_ENV_ADMIN="KUKEON_HOST,KUKEOND_SOCKET"
 
 step() {
     printf '\n==> %s\n' "$*"
@@ -150,17 +167,20 @@ verify_parent_attach_intact() {
 # holds at every exit point in the script.
 trap 'verify_parent_attach_intact || exit 1' EXIT
 
-# Write the dev-profile config files idempotently before any kuke invocation
-# (#285 phase 3). `-e` instead of `-f` so a broken symlink to a missing
-# operator-curated config is detected; a regular file matches too. The
-# server-side config is consumed by `kuke init --server-configuration` and
-# `kuke daemon reset --server-configuration`; the client-side config is
-# consumed by every `kuke` subcommand below via the exported
-# KUKE_CONFIGURATION (the env name viper binds to `kuke/configuration` —
-# cmd/config/env.go's KUKE_CONFIGURATION).
-if [ ! -e "${DEV_PROFILE_SERVER_CONFIG}" ]; then
-    step "Write dev-profile server config to ${DEV_PROFILE_SERVER_CONFIG}"
-    cat > "${DEV_PROFILE_SERVER_CONFIG}" <<'EOF'
+if [ "${KUKEON_PROFILE}" = "dev" ]; then
+    step "KUKEON_PROFILE=dev: enabling dev-profile (suffix dev.kukeon.io, cgroup /kukeon-dev)"
+
+    # Write the dev-profile config files idempotently before any kuke
+    # invocation. `-e` instead of `-f` so a broken symlink to a missing
+    # operator-curated config is detected; a regular file matches too. The
+    # server-side config is consumed by `kuke init --server-configuration`
+    # and `kuke daemon reset --server-configuration`; the client-side
+    # config is consumed by every `kuke` subcommand below via the exported
+    # KUKE_CONFIGURATION (the env name viper binds to `kuke/configuration`
+    # — cmd/config/env.go's KUKE_CONFIGURATION).
+    if [ ! -e "${DEV_PROFILE_SERVER_CONFIG}" ]; then
+        step "Write dev-profile server config to ${DEV_PROFILE_SERVER_CONFIG}"
+        cat > "${DEV_PROFILE_SERVER_CONFIG}" <<'EOF'
 # kukeond ServerConfiguration — dev profile (#285 phase 3).
 # Switches containerdNamespaceSuffix and cgroupRoot off the defaults so a
 # parallel kukeon instance can coexist with the canonical kukeon.io / /kukeon
@@ -176,11 +196,11 @@ spec:
   containerdNamespaceSuffix: dev.kukeon.io
   cgroupRoot: /kukeon-dev
 EOF
-fi
+    fi
 
-if [ ! -e "${DEV_PROFILE_CLIENT_CONFIG}" ]; then
-    step "Write dev-profile client config to ${DEV_PROFILE_CLIENT_CONFIG}"
-    cat > "${DEV_PROFILE_CLIENT_CONFIG}" <<'EOF'
+    if [ ! -e "${DEV_PROFILE_CLIENT_CONFIG}" ]; then
+        step "Write dev-profile client config to ${DEV_PROFILE_CLIENT_CONFIG}"
+        cat > "${DEV_PROFILE_CLIENT_CONFIG}" <<'EOF'
 # kuke ClientConfiguration — dev profile (#285 phase 3).
 # Read by every `kuke` invocation below via KUKE_CONFIGURATION. The
 # --no-daemon parity check below depends on this file to address the dev
@@ -195,14 +215,23 @@ spec:
   containerdNamespaceSuffix: dev.kukeon.io
   cgroupRoot: /kukeon-dev
 EOF
-fi
+    fi
 
-# KUKE_CONFIGURATION is bound to viper for every `kuke` subcommand
-# (KUKE_CONFIGURATION.BindEnv in cmd/kuke/kuke.go's loadConfig), so
-# exporting it here routes every client invocation below through the
-# dev-profile client config. sudo invocations must add KUKE_CONFIGURATION
-# to --preserve-env=... or the value is stripped at the sudo boundary.
-export KUKE_CONFIGURATION="${DEV_PROFILE_CLIENT_CONFIG}"
+    # KUKE_CONFIGURATION is bound to viper for every `kuke` subcommand
+    # (KUKE_CONFIGURATION.BindEnv in cmd/kuke/kuke.go's loadConfig), so
+    # exporting it here routes every client invocation below through the
+    # dev-profile client config. sudo invocations must add KUKE_CONFIGURATION
+    # to --preserve-env=... or the value is stripped at the sudo boundary.
+    export KUKE_CONFIGURATION="${DEV_PROFILE_CLIENT_CONFIG}"
+
+    # Override the defaults set near the top so every sudo call below
+    # picks up the dev-profile suffix, cgroup root, and the server-config
+    # flag for admin commands.
+    KUKEOND_NS="kuke-system.dev.kukeon.io"
+    SERVER_CONFIG_FLAGS=(--server-configuration "${DEV_PROFILE_SERVER_CONFIG}")
+    PRESERVE_ENV_WORKLOAD="KUKEON_HOST,KUKE_CONFIGURATION"
+    PRESERVE_ENV_ADMIN="KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION"
+fi
 
 step "Build kuke, kukebuild (and the kukeond symlink)"
 make kuke kukebuild
@@ -248,16 +277,16 @@ if [ ! -d "${SYSTEM_REALM_DIR}" ]; then
     # provisioning at the end of that pass may fail because the local image
     # is not yet built into containerd. Tolerate that — the second init
     # below recreates the cell after the build succeeds.
-    sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION ./kuke init \
+    sudo --preserve-env="${PRESERVE_ENV_ADMIN}" ./kuke init \
         --kukeond-image "${KUKEOND_IMAGE_REF}" \
-        --server-configuration "${DEV_PROFILE_SERVER_CONFIG}" \
+        "${SERVER_CONFIG_FLAGS[@]}" \
         || echo "first-pass init returned non-zero (expected before image is staged); continuing"
 fi
 
 if [ -d "${KUKEOND_CELL_DIR}" ]; then
     step "Reset prior kukeond cell"
-    sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION ./kuke daemon reset \
-        --server-configuration "${DEV_PROFILE_SERVER_CONFIG}"
+    sudo --preserve-env="${PRESERVE_ENV_ADMIN}" ./kuke daemon reset \
+        "${SERVER_CONFIG_FLAGS[@]}"
 else
     step "No prior kukeond cell at ${KUKEOND_CELL_DIR}; skipping reset"
 fi
@@ -268,14 +297,14 @@ step "Build ${LOCAL_TAG} into the kuke-system realm"
 # daemon, no docker-private containerd, no `--from-docker` loader hop. The -t
 # short tag normalizes to docker.io/library/kukeon-local:dev (kukebuild's
 # normalizeImageName), the exact ref `kuke init --kukeond-image` resolves below.
-sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke build --build-arg VERSION=v0.0.0-dev \
+sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke build --build-arg VERSION=v0.0.0-dev \
     -t "${LOCAL_TAG}" \
     --realm kuke-system .
 
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
-sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION ./kuke init \
+sudo --preserve-env="${PRESERVE_ENV_ADMIN}" ./kuke init \
     --kukeond-image "${KUKEOND_IMAGE_REF}" \
-    --server-configuration "${DEV_PROFILE_SERVER_CONFIG}"
+    "${SERVER_CONFIG_FLAGS[@]}"
 
 # Fail-loud when the running kukeond container is anchored on a stale
 # image (issue #857). The bug captured there is that `kuke daemon reset`
@@ -301,11 +330,10 @@ sudo --preserve-env=KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION ./kuke init \
 # Stay grep/sed-only — scripts in this repo intentionally avoid a jq
 # dependency (see scripts/install.sh's "no jq dependency" guarantee).
 step "Verify running kukeond container is anchored on the just-built image"
-# Dev-profile suffix is `dev.kukeon.io` (#285 phase 3), so the kuke-system
-# realm's containerd namespace is `kuke-system.dev.kukeon.io` rather than
-# the default `kuke-system.kukeon.io`. A reviewer toggling the dev profile
-# back to defaults would need to revisit this literal.
-KUKEOND_NS="kuke-system.dev.kukeon.io"
+# KUKEOND_NS is set near the top of the script: the default profile uses
+# the canonical `kuke-system.kukeon.io`; KUKEON_PROFILE=dev overrides it
+# to `kuke-system.dev.kukeon.io` so the dev profile's suffix flows through
+# the snapshots/images/content ctr probes below without per-call edits.
 KUKEOND_CTR_ID="kukeon_kukeon_kukeond_kukeond"
 
 ctr_chain="$(sudo ctr -n "${KUKEOND_NS}" snapshots info "${KUKEOND_CTR_ID}" 2>/dev/null \
@@ -356,22 +384,30 @@ fi
 echo "running kukeond container chain ${ctr_chain} matches just-built ${KUKEOND_IMAGE_REF}"
 
 step "Daemon parity check (both must show identical output)"
-# `-o wide` appends NAMESPACE — the column epic:get retired from the
-# default table — so the dev profile's suffix is visible in the parity
-# tail (e.g. default.dev.kukeon.io, kuke-system.dev.kukeon.io). The
+# Default profile keeps the historical NAME / STATE / AGE tail (the
+# minimal pinned regression guard documented in AGENTS.md "Local smoke
+# test"). KUKEON_PROFILE=dev switches to `-o wide` so NAMESPACE surfaces
+# (the dev suffix is otherwise invisible at the default-table level —
+# epic:get retired NAMESPACE from the default table) and adds a
+# cgroupPath surfacing step so /kukeon-dev is visible too. The
 # daemon-routed call is gated by KUKEON_HOST + the daemon's server
 # config; the --no-daemon call routes through KUKE_CONFIGURATION to read
-# the same suffix/cgroupRoot in-process. Both must show identical output.
-sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke get realms -o wide
-sudo --preserve-env=KUKE_CONFIGURATION ./kuke get realms -o wide --no-daemon
+# the same suffix/cgroupRoot in-process.
+if [ "${KUKEON_PROFILE}" = "dev" ]; then
+    sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke get realms -o wide
+    sudo --preserve-env=KUKE_CONFIGURATION ./kuke get realms -o wide --no-daemon
 
-# CGROUP no longer surfaces in the default or wide table (epic:get also
-# retired CGROUP); `-o yaml` is the supported way to read cgroupPath.
-# Surface the dev profile's cgroup root here so an operator skimming
-# `make dev-init` output sees /kukeon-dev anchored on the realms.
-step "Daemon parity: cgroupPath surfacing (dev profile expects /kukeon-dev/...)"
-sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke get realms -o yaml \
-    | grep -E 'cgroupPath:' || true
+    # CGROUP no longer surfaces in the default or wide table (epic:get also
+    # retired CGROUP); `-o yaml` is the supported way to read cgroupPath.
+    # Surface the dev profile's cgroup root here so an operator skimming
+    # `make dev-init` output sees /kukeon-dev anchored on the realms.
+    step "Daemon parity: cgroupPath surfacing (dev profile expects /kukeon-dev/...)"
+    sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke get realms -o yaml \
+        | grep -E 'cgroupPath:' || true
+else
+    sudo --preserve-env=KUKEON_HOST ./kuke get realms
+    sudo ./kuke get realms --no-daemon
+fi
 
 # Phase 1b smoke (#410): the daemon's metadata-rendering path emits the
 # bind-mounted kuketty config consumed by kuketty's sbsh-backed RPC server.
@@ -397,13 +433,13 @@ ATTACH_SMOKE_METADATA="${ATTACH_SMOKE_BASE}/kuketty-metadata.json"
 ATTACH_SMOKE_TMP="$(mktemp -d)"
 
 teardown_attach_smoke_state() {
-    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke purge cell "${ATTACH_SMOKE_CELL}" \
+    sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke purge cell "${ATTACH_SMOKE_CELL}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" --stack "${ATTACH_SMOKE_STACK}" \
         --cascade 2>/dev/null || true
-    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke purge stack "${ATTACH_SMOKE_STACK}" \
+    sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke purge stack "${ATTACH_SMOKE_STACK}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" 2>/dev/null || true
-    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke purge space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
-    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke purge realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
+    sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke purge space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
+    sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke purge realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
 }
 
 cleanup_attach_smoke() {
@@ -424,9 +460,9 @@ trap cleanup_attach_smoke EXIT
 # left intact — only the on-disk realm/space/stack/cell state is wiped.
 teardown_attach_smoke_state
 
-sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke create realm "${ATTACH_SMOKE_REALM}"
-sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke create space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}"
-sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke create stack "${ATTACH_SMOKE_STACK}" --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}"
+sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke create realm "${ATTACH_SMOKE_REALM}"
+sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke create space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}"
+sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke create stack "${ATTACH_SMOKE_STACK}" --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}"
 
 cat > "${ATTACH_SMOKE_TMP}/cell.yaml" <<EOF
 apiVersion: v1beta1
@@ -451,7 +487,7 @@ spec:
       attachable: true
 EOF
 
-sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke apply -f "${ATTACH_SMOKE_TMP}/cell.yaml"
+sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke apply -f "${ATTACH_SMOKE_TMP}/cell.yaml"
 
 # Wait for kuketty to bind the per-container socket. The window covers
 # image pull + container start + sbsh server bring-up; a regression that
@@ -483,7 +519,7 @@ sudo grep -q '"kind": "Container"' "${ATTACH_SMOKE_METADATA}" \
 # pkg/attach speaks.
 ATTACH_LOG="${ATTACH_SMOKE_TMP}/attach.log"
 go run ./hack/attach-smoke --log "${ATTACH_LOG}" -- \
-    sudo --preserve-env=KUKEON_HOST,KUKE_CONFIGURATION ./kuke attach "${ATTACH_SMOKE_CELL}" \
+    sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke attach "${ATTACH_SMOKE_CELL}" \
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" \
         --stack "${ATTACH_SMOKE_STACK}" --container "${ATTACH_SMOKE_CONTAINER}"
 echo "kuke attach exited cleanly (see ${ATTACH_LOG} for the full transcript)"


### PR DESCRIPTION
## Summary

- Phase 3 of the multi-instance work (#262, #284): mirrors `ContainerdNamespaceSuffix` and `CgroupRoot` on `ClientConfigurationSpec` so `--no-daemon` workload paths address the right kukeon instance via `KUKE_CONFIGURATION` (no new flag on workload commands — `KUKE_CONFIGURATION=~/.kuke/dev.yaml` is the addressing mechanism).
- `defaultDocument` in `internal/clientconfig/clientconfig.go` surfaces both fields with header comments paralleling the server-side wording.
- `loadClientConfiguration` calls `consts.ConfigureRuntime(suffix, cgroupRoot)` after `applyClientConfiguration`, so in-process operations pick up the configured values; precedence stays `flag > env > YAML > default`.
- e2e helpers that hardcoded `consts.KukeonCgroupRoot` now read the configured root from the daemon's realm JSON via a new `getCgroupRoot(t, host, realm)` helper, mirroring the existing `getRealmNamespace` pattern. The remaining `consts.` references in e2e are `consts.CgroupFilesystemPath` (host-level `/sys/fs/cgroup`, unaffected) and `consts.RealmNamespace` (the suffix-aware namespace formatter).
- `scripts/dev-init.sh` gains a `KUKEON_PROFILE=dev` opt-in gate. The default (env unset) keeps the historical script behavior — canonical `kukeon.io` suffix, `/kukeon` cgroup root, no YAML files written, no `--server-configuration` plumbed through admin commands, the documented `NAME / STATE / AGE` parity tail. `KUKEON_PROFILE=dev` writes `./kukeond-dev.yaml` and `./kuke-dev.yaml` idempotently (guarded by `[ ! -e ]`), exports `KUKE_CONFIGURATION=./kuke-dev.yaml`, threads `--server-configuration ./kukeond-dev.yaml` through admin commands, expects the `kuke-system.dev.kukeon.io` staleness namespace, and switches the parity tail to `-o wide` plus a `-o yaml | grep cgroupPath` step so the dev suffix and `/kukeon-dev` cgroup root surface.

### Why gate dev-init on KUKEON_PROFILE=dev instead of switching by default

`make dev-init` is the canonical "install kukeon from main against this host" command for contributors; flipping it unconditionally to the dev profile would silently change the suffix and cgroup root under every contributor's existing default-profile install. The gate keeps the daily-driver path unchanged and makes the multi-instance smoke (the actual phase-3 deliverable) explicit opt-in.

Running both profiles concurrently on the same host is then `make dev-init` followed by `KUKEON_PROFILE=dev make dev-init`, which is closer to the AC's manual two-instance smoke than the original unconditional switch.

### Acceptance-criteria mapping

- The issue's AC parity tail (`NAME / NAMESPACE / STATE / CGROUP`) predates epic:get's retirement of `NAMESPACE` and `CGROUP` from the default `kuke get realms` table (project AGENTS.md "The two default realms"). Intent preserved via `KUKEON_PROFILE=dev`'s `-o wide` (surfaces NAMESPACE) and `-o yaml | grep cgroupPath` (surfaces `/kukeon-dev/...`), since `-o wide` no longer carries CGROUP either. Literal table shape diverges; AC intent is satisfied.
- `runPath` left at default. The issue's example client config switches `runPath` to `/opt/kukeon-dev`, but the dev profile in this PR only flips the two switchable knobs (suffix + cgroup root) — disjoint metadata storage is orthogonal to the AC and would force renaming `METADATA_ROOT`, `ATTACH_SMOKE_BASE`, and the `SYSTEM_REALM_DIR` probe. The dev YAMLs set only the two switchable knobs; defaults inherit.
- AGENTS.md "Local smoke test" stays accurate as written, since the default `make dev-init` path still prints the documented `NAME / STATE / AGE` parity tail. No follow-up doc edit needed.

## Test plan

- [x] `make test` (full test suite, no failures).
- [x] `GOWORK=off go vet ./...` clean.
- [x] `GOWORK=off go build ./...` clean.
- [x] `pre-commit run --files <changed>` — all hooks pass (go fmt, go-mod-tidy, golangci-lint, addlicense, trailing whitespace, eof, ssh secret scan).
- [x] `bash -n scripts/dev-init.sh` (syntax check on the gated script).
- [ ] `make e2e` — deferred to reviewer: requires standalone containerd + privileged ops the agent dev container can't safely host on the shared host.
- [ ] Default-profile `make dev-init` — deferred to reviewer: same environmental gating. Reviewer should confirm the parity tail prints `NAME / STATE / AGE` for both `kuke get realms` and `kuke get realms --no-daemon` (the AGENTS.md regression guard).
- [ ] Dev-profile `KUKEON_PROFILE=dev make dev-init` — deferred to reviewer. Reviewer should confirm the parity tail prints `default.dev.kukeon.io` / `kuke-system.dev.kukeon.io` and the cgroupPath step surfaces `/kukeon-dev/default` + `/kukeon-dev/kuke-system`.
- [ ] Manual two-instance smoke: `make dev-init` then `KUKEON_PROFILE=dev make dev-init` on the same host; dev-only uninstall preserves the prod realms, prod cgroup tree, and prod `/opt/kukeon` — deferred to reviewer: requires a clean host with both profiles live.

Closes #285