### PR TITLE
fix(uninstall): reclaim per-namespace BuildKit cache to prevent stale snapshot/content references

### DIFF
--- a/cmd/kuke/uninstall/uninstall.go
+++ b/cmd/kuke/uninstall/uninstall.go
@@ -70,7 +70,14 @@ This is the global counterpart to "kuke purge" (which is per-resource). It:
      a Restart=on-failure unit cannot respawn kukeond mid-uninstall.
   2. Purges every realm with --cascade (drains spaces, stacks, cells,
      containers and their containerd tasks/containers, and deletes the
-     containerd namespaces created by kukeon).
+     containerd namespaces created by kukeon). For every realm whose
+     namespace was actually removed, also reclaims the matching per-
+     namespace BuildKit cache directory at /var/lib/kukebuild/<namespace>/
+     (the cache references containerd by snapshot ID and content digest, so
+     leaving it behind strands the next "kuke build" with "parent snapshot
+     does not exist" or "content digest ... not found"). After the sweep,
+     /var/lib/kukebuild/ itself is rmdir'd if empty — cousin instances'
+     caches under sibling subdirs are left in place.
   3. Removes /run/kukeon/ recursively.
   4. Removes the configured run path (default /opt/kukeon) recursively.
   5. Removes the kukeon system user and group (no-op if absent).
@@ -81,7 +88,9 @@ mounts on disk would strand the next "kuke init" with stale containerd state.
 The report flags every dir/account row as "skipped (realm purge failed)" so
 the half-cleaned host is visible without scrolling to the trailing error.
 Resolve the realm-purge failure (often: stop the live daemon, remove the
-residual containerd namespace by hand) and re-run the command.
+residual containerd namespace by hand, wipe the matching
+/var/lib/kukebuild/<namespace>/ left behind by the partial pass) and re-run
+the command.
 
 The /usr/local/bin/kuke binary and the kukeond symlink are NOT removed —
 uninstalling runtime state is not the same as uninstalling the binary.
@@ -268,6 +277,7 @@ func printReport(cmd *cobra.Command, report controller.UninstallReport) {
 			fmt.Fprintf(out, "  - realm %q (namespace %q): purged\n", r.Name, r.Namespace)
 		}
 	}
+	renderBuildCaches(out, report)
 	if report.CleanupSkipped {
 		fmt.Fprintf(out, "  - %s: %s\n", report.SocketDir, outcomeSkipped)
 		fmt.Fprintf(out, "  - %s: %s\n", report.RunPath, outcomeSkipped)
@@ -282,6 +292,49 @@ func printReport(cmd *cobra.Command, report controller.UninstallReport) {
 	fmt.Fprintf(out, "  - %s: %s\n", report.RunPath, dirOutcome(report.RunPathExists, report.RunPathRemove))
 	fmt.Fprintf(out, "  - user %q: %s\n", report.UserName, accountOutcome(report.UserExisted, report.UserRemoved))
 	fmt.Fprintf(out, "  - group %q: %s\n", report.GroupName, accountOutcome(report.GroupExisted, report.GroupRemoved))
+}
+
+// renderBuildCaches prints one row per per-namespace BuildKit cache the
+// uninstall pass reclaimed plus a trailing row for the base directory's
+// fate. Surfacing both lets the operator confirm the issue #904 follow-up
+// fired (the next `kuke build` into a freshly-reinstalled namespace will
+// no longer hit "parent snapshot does not exist" or "content digest ...
+// not found"). Quiet on hosts that never built into the namespace — an
+// absent per-namespace cache contributes no row, matching the report's
+// terse style on the no-daemon path.
+func renderBuildCaches(out io.Writer, report controller.UninstallReport) {
+	for _, c := range report.BuildCaches {
+		switch {
+		case c.Err != nil:
+			fmt.Fprintf(out, "  - build cache %s: FAILED: %v\n", c.Path, c.Err)
+		case c.Removed:
+			fmt.Fprintf(out, "  - build cache %s: removed\n", c.Path)
+		case c.Existed:
+			// Present-but-not-removed should never happen on the success path
+			// (RemoveAll either succeeds or returns an error captured above);
+			// rendered defensively so a regression surfaces instead of being
+			// silently dropped.
+			fmt.Fprintf(out, "  - build cache %s: remove failed\n", c.Path)
+		default:
+			fmt.Fprintf(out, "  - build cache %s: %s\n", c.Path, outcomeAbsent)
+		}
+	}
+	if report.BuildCacheBaseDir == "" {
+		return
+	}
+	switch {
+	case report.BuildCacheBaseRemoved:
+		fmt.Fprintf(out, "  - build cache %s: removed\n", report.BuildCacheBaseDir)
+	case report.BuildCacheBaseExisted:
+		// The base dir survived the rmdir because a cousin instance's cache
+		// is still under it — the scoped-uninstall invariant we wanted. Name
+		// the path so an operator who did want it gone knows what to wipe.
+		fmt.Fprintf(out, "  - build cache %s: kept (cousin instance caches present)\n", report.BuildCacheBaseDir)
+	default:
+		// Absent base directory on a host that never built — quiet skip
+		// rather than a noisy "absent" row, matching how the renderer treats
+		// a never-installed systemd unit.
+	}
 }
 
 // renderMountReleases prints one indented row per kukeon-owned bind mount

--- a/cmd/kuke/uninstall/uninstall_test.go
+++ b/cmd/kuke/uninstall/uninstall_test.go
@@ -598,5 +598,124 @@ func TestUninstall_SystemdFailureShortCircuits(t *testing.T) {
 	}
 }
 
+// TestUninstall_RendersBuildCacheRows pins the issue #904 renderer half:
+// every BuildCachePurgeOutcome on the report renders as a "build cache <path>:
+// <outcome>" row, and a removable base dir gets its own trailing row. Without
+// these rows, an operator running uninstall on a host with stale BuildKit
+// state would see no signal that the cache was reclaimed and would have to
+// shell-grep `/var/lib/kukebuild/` to confirm.
+func TestUninstall_RendersBuildCacheRows(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stub := &stubController{
+		uninstallFn: func(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+			return controller.UninstallReport{
+				Realms: []controller.RealmPurgeOutcome{
+					{Name: "default", Namespace: "default.kukeon.io", Purged: true, NamespaceRemoved: true},
+					{Name: "kuke-system", Namespace: "kuke-system.kukeon.io", Purged: true, NamespaceRemoved: true},
+				},
+				BuildCaches: []controller.BuildCachePurgeOutcome{
+					{Namespace: "default.kukeon.io", Path: "/var/lib/kukebuild/default.kukeon.io", Existed: true, Removed: true},
+					{Namespace: "kuke-system.kukeon.io", Path: "/var/lib/kukebuild/kuke-system.kukeon.io", Existed: true, Removed: true},
+				},
+				BuildCacheBaseDir:     "/var/lib/kukebuild",
+				BuildCacheBaseExisted: true,
+				BuildCacheBaseRemoved: true,
+				SocketDir:             opts.SocketDir,
+				RunPath:               "/opt/kukeon",
+				UserName:              "kukeon",
+				GroupName:             "kukeon",
+			}, nil
+		},
+	}
+	out, err := runCmd(t, stub, "", "--yes")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	wantRows := []string{
+		"build cache /var/lib/kukebuild/default.kukeon.io: removed",
+		"build cache /var/lib/kukebuild/kuke-system.kukeon.io: removed",
+		"build cache /var/lib/kukebuild: removed",
+	}
+	for _, want := range wantRows {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestUninstall_RendersBuildCacheKeptOnScopedUninstall pins the "base dir
+// survives because a cousin instance's cache is still under it" branch — the
+// scoped-uninstall invariant where `--server-configuration` narrowed the
+// realm enumeration to one suffix. The operator must see why the base dir
+// stayed so the report is not misread as a partial failure.
+func TestUninstall_RendersBuildCacheKeptOnScopedUninstall(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stub := &stubController{
+		uninstallFn: func(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+			return controller.UninstallReport{
+				Realms: []controller.RealmPurgeOutcome{
+					{Name: "default", Namespace: "default.dev.kukeon.io", Purged: true, NamespaceRemoved: true},
+				},
+				BuildCaches: []controller.BuildCachePurgeOutcome{
+					{Namespace: "default.dev.kukeon.io", Path: "/var/lib/kukebuild/default.dev.kukeon.io", Existed: true, Removed: true},
+				},
+				BuildCacheBaseDir:     "/var/lib/kukebuild",
+				BuildCacheBaseExisted: true,
+				// Removed=false: prod instance's caches under /var/lib/kukebuild/*.kukeon.io
+				// kept the base non-empty so the rmdir was a no-op.
+				BuildCacheBaseRemoved: false,
+				SocketDir:             opts.SocketDir,
+				RunPath:               "/opt/kukeon",
+				UserName:              "kukeon",
+				GroupName:             "kukeon",
+			}, nil
+		},
+	}
+	out, err := runCmd(t, stub, "", "--yes")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	wantSubstr := "build cache /var/lib/kukebuild: kept (cousin instance caches present)"
+	if !strings.Contains(out, wantSubstr) {
+		t.Errorf("expected output to contain %q; got:\n%s", wantSubstr, out)
+	}
+}
+
+// TestUninstall_RendersBuildCacheAbsentRowsQuietly pins the clean-host case:
+// a report with no BuildCaches and an absent base dir must produce no build-
+// cache rows at all (no "absent" spam, no trailing base-dir row). Matches the
+// renderer's quiet style for systemd units that were never installed.
+func TestUninstall_RendersBuildCacheAbsentRowsQuietly(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stub := &stubController{
+		uninstallFn: func(opts controller.UninstallOptions) (controller.UninstallReport, error) {
+			return controller.UninstallReport{
+				Realms: []controller.RealmPurgeOutcome{
+					{Name: "default", Namespace: "default.kukeon.io", Purged: true, NamespaceRemoved: true},
+				},
+				// BuildCaches empty (host never built into this namespace);
+				// BuildCacheBaseDir set but Existed=false (the base dir was
+				// never created either).
+				BuildCacheBaseDir:     "/var/lib/kukebuild",
+				BuildCacheBaseExisted: false,
+				SocketDir:             opts.SocketDir,
+				RunPath:               "/opt/kukeon",
+				UserName:              "kukeon",
+				GroupName:             "kukeon",
+			}, nil
+		},
+	}
+	out, err := runCmd(t, stub, "", "--yes")
+	if err != nil {
+		t.Fatalf("Execute returned: %v\noutput:\n%s", err, out)
+	}
+	if strings.Contains(out, "build cache") {
+		t.Errorf("clean-host report unexpectedly rendered a build-cache row:\n%s", out)
+	}
+}
+
 // Compile-time assertion: stubController must satisfy controller.Controller.
 var _ controller.Controller = (*stubController)(nil)

--- a/cmd/kukebuild/main.go
+++ b/cmd/kukebuild/main.go
@@ -208,6 +208,11 @@ const defaultContainerdSocket = "/run/containerd/containerd.sock"
 // effective default root is scoped per target namespace beneath this base
 // (<defaultBuildRoot>/<namespace>, see resolveBuildRoot) so each namespace's
 // cache stays isolated (issue #663).
+//
+// Must mirror `KukebuildBaseDir` in internal/consts/consts.go (the constant
+// `kuke uninstall` walks to reclaim per-namespace BuildKit caches — issue
+// #904). The two cannot be a single source of truth because cmd/kukebuild
+// is a separate Go module from the root module; on change, update both.
 const defaultBuildRoot = "/var/lib/kukebuild"
 
 // defaultRealm matches the convention in cmd/kuke/image: the user-owned

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -67,7 +67,7 @@ sudo kuke uninstall -y       # non-interactive (scripts)
 **Invariants.**
 
 - Without `-y`, the command prints a destructive-action prompt naming every artifact it will remove and waits on stdin. EOF or a non-`yes` answer aborts with non-zero exit and no destructive side effect.
-- With `-y`, exit code 0 on success. Side effect: the `kukeond` systemd unit (if installed) is stopped, disabled, and removed; every realm purged with `--cascade`; `/run/kukeon` and the configured run path (default `/opt/kukeon`) removed; the `kukeon` system user/group removed if present.
+- With `-y`, exit code 0 on success. Side effect: the `kukeond` systemd unit (if installed) is stopped, disabled, and removed; every realm purged with `--cascade`; for every realm whose containerd namespace was actually removed, the matching `kukebuild` cache at `/var/lib/kukebuild/<namespace>/` is reclaimed in the same pass (issue #904 — the cache holds layer→snapshot and layer→content mappings into the now-gone namespace, so leaving it strands the next `kuke build` with "parent snapshot does not exist" or "content digest ... not found"); `/run/kukeon` and the configured run path (default `/opt/kukeon`) removed; the `kukeon` system user/group removed if present. `/var/lib/kukebuild/` itself is rmdir'd only when empty after the per-namespace sweep — cousin instances' caches under sibling subdirs (a scoped uninstall via `--server-configuration`) are left intact.
 - `kuke uninstall` accepts `--server-configuration <path>` (default `/etc/kukeon/kukeond.yaml`) to target a specific kukeond instance. Precedence: `--flag > KUKEOND_CONFIGURATION env > /etc/kukeon/kukeond.yaml > hardcoded defaults`. The loaded `containerdNamespaceSuffix` scopes the realm enumeration — `sudo kuke uninstall --server-configuration ./kukeond-dev.yaml` enumerates and purges only `*.dev.kukeon.io` namespaces and never touches the default-instance ones. Same flag on `kuke init` and `kuke daemon …`.
 - The binary at `/usr/local/bin/kuke` and the `kukeond` symlink are **never** removed — uninstalling runtime state is not the same as uninstalling the binary.
 - The systemd-unit teardown is a no-op (silent, no row in the report) on hosts where `systemctl` is absent or `/etc/systemd/system/kukeond.service` was never installed (e.g. `make dev-init` hosts).
@@ -86,7 +86,8 @@ This is the half-cleaned-host guard added in #287: tearing out `/opt/kukeon` whi
 To recover:
 
 1. Inspect the residual namespace — e.g. `ctr -n <namespace> snapshots ls`, `ctr -n <namespace> containers ls` — and clean it up by hand or via `ctr namespace remove <namespace>` once the namespace is empty.
-2. Re-run `kuke uninstall --yes`. The realm-purge step will now succeed and the gated cleanup steps (2–4) will run normally.
+2. Wipe the matching per-namespace BuildKit state directory — `sudo rm -rf /var/lib/kukebuild/<namespace>/` — so a follow-up `kuke build` into the recreated namespace does not hit a stale `cache.db` referencing snapshots/content that the manual cleanup just removed. Skipping this step is the issue #904 trap: the namespace looks fresh in `ctr` but the next build fails with "parent snapshot does not exist" or "content digest ... not found". The follow-up `kuke uninstall --yes` only sweeps caches for realms it successfully purges in *its* pass — caches stranded by a previous half-cleaned uninstall are the operator's to wipe.
+3. Re-run `kuke uninstall --yes`. The realm-purge step will now succeed and the gated cleanup steps (2–4) will run normally.
 
 A successful re-run produces the familiar tail (`/opt/kukeon: removed`, `user 'kukeon': removed`, etc.) with no `skipped` lines.
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -172,6 +172,22 @@ const (
 	// under which all realms / spaces / stacks / cells live. Operators
 	// override it via ServerConfiguration.spec.cgroupRoot.
 	DefaultKukeonCgroupRoot = "/kukeon"
+
+	// KukebuildBaseDir is the directory under which `kukebuild` keeps its
+	// per-namespace BuildKit state (`cache.db`, `history.db`, snapshot
+	// metadata) — one subdirectory per containerd namespace it has built
+	// into, at <KukebuildBaseDir>/<namespace>. `kuke uninstall` removes the
+	// matching subdir for every realm it successfully purges; the BuildKit
+	// cache references containerd by snapshot ID and content digest, so a
+	// purged namespace whose cache survives strands the next `kuke build`
+	// with "parent snapshot does not exist" or "content digest ... not
+	// found" (issue #904).
+	//
+	// Must mirror the `defaultBuildRoot` constant in cmd/kukebuild/main.go;
+	// the two cannot be a single source of truth because cmd/kukebuild is a
+	// separate Go module (its go-1.25 BuildKit closure is deliberately
+	// disjoint from the root module's graph). On change, update both.
+	KukebuildBaseDir = "/var/lib/kukebuild"
 )
 
 // RealmNamespaceSuffix is the suffix appended to every realm name to form

--- a/internal/controller/uninstall.go
+++ b/internal/controller/uninstall.go
@@ -18,11 +18,13 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"syscall"
 	"time"
 
 	"github.com/eminwux/kukeon/internal/consts"
@@ -75,6 +77,11 @@ type UninstallOptions struct {
 	// reading /proc/self/mounts + syscall.Unmount); tests inject a stub so
 	// they do not have to provision real mounts.
 	MountReleaser MountReleaser
+	// BuildCacheBaseDir overrides the directory under which `kukebuild`
+	// keeps its per-namespace BuildKit state (issue #904). Empty falls
+	// back to consts.KukebuildBaseDir; tests pin t.TempDir() so they do
+	// not have to write under /var/lib.
+	BuildCacheBaseDir string
 }
 
 // RealmPurgeOutcome reports the result of purging a single realm.
@@ -90,6 +97,24 @@ type RealmPurgeOutcome struct {
 	Purged           bool
 	NamespaceRemoved bool
 	Err              error
+}
+
+// BuildCachePurgeOutcome reports the result of reclaiming one realm's
+// per-namespace BuildKit state directory at <BuildCacheBaseDir>/<namespace>
+// (issue #904). The reclaim only runs for realms whose containerd namespace
+// was actually removed (NamespaceRemoved=true); a residual namespace's cache
+// is intentionally left in place so a follow-up `kuke uninstall` still has
+// the BuildKit metadata to drive its own teardown.
+//
+// Existed is "did we find the per-namespace dir before removal" — the
+// renderer's analog of the dirOutcome existed/removed pair used for the
+// socket and run-path rows.
+type BuildCachePurgeOutcome struct {
+	Namespace string
+	Path      string
+	Existed   bool
+	Removed   bool
+	Err       error
 }
 
 // UninstallReport summarizes what Uninstall did.
@@ -127,6 +152,27 @@ type UninstallReport struct {
 	GroupName     string
 	GroupExisted  bool
 	GroupRemoved  bool
+	// BuildCaches records the per-namespace BuildKit state directories the
+	// uninstall pass reclaimed (issue #904). One entry per realm whose
+	// containerd namespace was successfully removed; ordered to match
+	// Realms. A realm whose namespace survived contributes no entry —
+	// leaving its cache in place is intentional, see BuildCachePurgeOutcome.
+	BuildCaches []BuildCachePurgeOutcome
+	// BuildCacheBaseDir is the directory the renderer attempted to rmdir
+	// after the per-namespace sweep. Empty when no BuildKit cache was
+	// touched (no realm purged with NamespaceRemoved=true).
+	BuildCacheBaseDir string
+	// BuildCacheBaseExisted reports whether BuildCacheBaseDir existed at
+	// the start of the rmdir step (after the per-namespace sweep). Lets the
+	// renderer distinguish "absent" from "kept".
+	BuildCacheBaseExisted bool
+	// BuildCacheBaseRemoved reports whether BuildCacheBaseDir was rmdir'd.
+	// Only true when the base directory was empty after the per-namespace
+	// sweep — a scoped uninstall (`--server-configuration` narrowing the
+	// realm set) leaves cousin-instance caches untouched and the base dir
+	// stays. Plain `os.Remove`, not `RemoveAll`: stomping on another
+	// instance's cache would be a regression of the scoping invariant.
+	BuildCacheBaseRemoved bool
 }
 
 // Uninstall performs a comprehensive teardown of all kukeon runtime state.
@@ -145,6 +191,14 @@ type UninstallReport struct {
 //     path) still get their namespaces cleaned up. The two well-known
 //     realms (`default`, `kuke-system`) are kept as a safety floor so a
 //     containerd-list failure cannot strand them.
+//
+//     For every realm whose containerd namespace was actually removed, also
+//     reclaim the matching per-namespace BuildKit cache directory at
+//     <BuildCacheBaseDir>/<namespace> (default consts.KukebuildBaseDir). The
+//     cache references containerd by snapshot ID and content digest; a
+//     surviving cache after a successful namespace drop strands the next
+//     `kuke build` with "parent snapshot does not exist" or "content digest
+//     ... not found" — issue #904.
 //  2. Release live kukeon-owned bind mounts under SocketDir, then RemoveAll
 //     on SocketDir (typically /run/kukeon). The unmount step is what makes a
 //     post-attach uninstall succeed: kuketty leaves a /run/kukeon/tty bind
@@ -154,12 +208,19 @@ type UninstallReport struct {
 //     stragglers holding it open.
 //  3. The same release + RemoveAll for the run path (typically /opt/kukeon).
 //  4. Remove the kukeon system user and group (no-op if absent).
+//  5. After the per-namespace cache sweep, try a plain rmdir on
+//     BuildCacheBaseDir — only succeeds when it is empty so a scoped
+//     uninstall (`--server-configuration` narrowing realm enumeration to one
+//     suffix) leaves cousin instances' caches under sibling subdirs intact.
 //
 // Steps 2–4 are gated on every realm reporting NamespaceRemoved=true. When at
 // least one realm fails to drop its containerd namespace, the report's
 // CleanupSkipped flag is set and the filesystem + user/group teardown is left
 // for a follow-up run — see issue #287 for the half-cleaned-host failure
-// mode this prevents.
+// mode this prevents. The per-namespace BuildKit cache sweep (the cache
+// reclaim half of step 1) is **not** gated on that flag: a namespace that
+// was actually removed should have its cache reclaimed even when a sibling
+// realm's purge failed.
 //
 // Any step's error is recorded in the report. The first non-nil step error
 // is returned so callers can surface "uninstall failed at step X" without
@@ -242,6 +303,11 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 		)
 	}
 
+	buildCacheBase := opts.BuildCacheBaseDir
+	if buildCacheBase == "" {
+		buildCacheBase = consts.KukebuildBaseDir
+	}
+
 	allNamespacesRemoved := true
 	for _, realm := range realms {
 		outcome := RealmPurgeOutcome{
@@ -260,6 +326,39 @@ func (b *Exec) Uninstall(opts UninstallOptions) (UninstallReport, error) {
 			allNamespacesRemoved = false
 		}
 		report.Realms = append(report.Realms, outcome)
+
+		// Reclaim the per-namespace BuildKit cache directory only when the
+		// containerd namespace was actually removed. Pairing the cache wipe
+		// with the namespace wipe keeps the BuildKit cache from referencing
+		// snapshots or content blobs that no longer exist in the (now empty
+		// or absent) namespace — issue #904. A realm whose namespace
+		// survived is intentionally skipped so the operator's follow-up
+		// recovery has the same cache metadata available that the previous
+		// builds saw.
+		if outcome.NamespaceRemoved && realm.Spec.Namespace != "" {
+			cacheOutcome := reclaimNamespaceBuildCache(buildCacheBase, realm.Spec.Namespace)
+			report.BuildCaches = append(report.BuildCaches, cacheOutcome)
+			if cacheOutcome.Err != nil {
+				recordErr(fmt.Errorf(
+					"remove build cache %q: %w", cacheOutcome.Path, cacheOutcome.Err,
+				))
+			}
+		}
+	}
+
+	// Step 5 (early): try to rmdir the BuildKit cache base directory. A plain
+	// os.Remove fails with ENOTEMPTY when a cousin instance's cache is still
+	// under it, which is the right behavior for a scoped uninstall — the
+	// renderer prints "kept (not empty)" instead of "removed" and the operator
+	// sees the base dir survived for a reason. Done before the half-cleaned-
+	// host gate returns so the BuildKit cache rows surface in the report even
+	// when the SocketDir/RunPath teardown is suppressed.
+	report.BuildCacheBaseDir = buildCacheBase
+	rmBaseExisted, rmBaseRemoved, rmBaseErr := rmdirIfEmpty(buildCacheBase)
+	report.BuildCacheBaseExisted = rmBaseExisted
+	report.BuildCacheBaseRemoved = rmBaseRemoved
+	if rmBaseErr != nil {
+		recordErr(fmt.Errorf("remove build cache base %q: %w", buildCacheBase, rmBaseErr))
 	}
 
 	// Half-cleaned-host gate (issue #287): if any realm failed to drop its
@@ -460,6 +559,59 @@ func releaseAndRecord(
 		}
 	}
 	return attempts, firstResidual
+}
+
+// reclaimNamespaceBuildCache removes the per-namespace BuildKit state
+// directory at <baseDir>/<namespace>. Returns a BuildCachePurgeOutcome
+// populated with Existed / Removed / Err so the renderer can surface what
+// happened. A missing directory is the absent-on-clean-host case and is
+// reported as Existed=false, Removed=false, Err=nil. Issue #904.
+func reclaimNamespaceBuildCache(baseDir, namespace string) BuildCachePurgeOutcome {
+	path := filepath.Join(baseDir, namespace)
+	outcome := BuildCachePurgeOutcome{
+		Namespace: namespace,
+		Path:      path,
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return outcome
+		}
+		outcome.Err = statErr
+		return outcome
+	}
+	outcome.Existed = true
+	if rmErr := os.RemoveAll(path); rmErr != nil {
+		outcome.Err = rmErr
+		return outcome
+	}
+	outcome.Removed = true
+	return outcome
+}
+
+// rmdirIfEmpty attempts a plain rmdir (not RemoveAll) on path and reports
+// whether it existed and whether it was removed. ENOTEMPTY is the expected
+// no-op when a scoped uninstall has left cousin-instance caches under the
+// base dir — it returns (existed=true, removed=false, err=nil) so the
+// renderer can print "kept (not empty)" instead of misreporting a failure.
+// All other errors (permission, missing parent on the way to a nested rmdir,
+// etc.) propagate as err.
+func rmdirIfEmpty(path string) (bool, bool, error) {
+	if _, statErr := os.Stat(path); statErr != nil {
+		if os.IsNotExist(statErr) {
+			return false, false, nil
+		}
+		return false, false, statErr
+	}
+	if rmErr := os.Remove(path); rmErr != nil {
+		// ENOTEMPTY (and the BSD-aliased ENOTEMPTY=EEXIST on some systems)
+		// is the "other instance's cache is still here" case; it is not an
+		// error from the caller's perspective. Anything else is real.
+		if errors.Is(rmErr, syscall.ENOTEMPTY) || errors.Is(rmErr, syscall.EEXIST) {
+			return true, false, nil
+		}
+		return true, false, rmErr
+	}
+	return true, true, nil
 }
 
 // removePathIfExists is a thin wrapper around os.RemoveAll that reports

--- a/internal/controller/uninstall_test.go
+++ b/internal/controller/uninstall_test.go
@@ -74,8 +74,9 @@ func TestUninstall_PurgesWellKnownRealmsAndCleansFilesystem(t *testing.T) {
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
 	report, uninstallErr := ctrl.Uninstall(controller.UninstallOptions{
-		SocketDir:     tmpSocketDir,
-		SkipUserGroup: true,
+		SocketDir:         tmpSocketDir,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	})
 	if uninstallErr != nil {
 		t.Fatalf("Uninstall returned error: %v", uninstallErr)
@@ -117,8 +118,9 @@ func TestUninstall_IsIdempotent(t *testing.T) {
 	// First run on a never-existed install: must not error, nothing exists
 	// to clean up but the realms still get a defensive purge call.
 	report, err := ctrl.Uninstall(controller.UninstallOptions{
-		SocketDir:     tmpSocketDir,
-		SkipUserGroup: true,
+		SocketDir:         tmpSocketDir,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("first Uninstall errored: %v", err)
@@ -134,8 +136,9 @@ func TestUninstall_IsIdempotent(t *testing.T) {
 
 	// Re-run: still no error.
 	if _, repeatErr := ctrl.Uninstall(controller.UninstallOptions{
-		SocketDir:     tmpSocketDir,
-		SkipUserGroup: true,
+		SocketDir:         tmpSocketDir,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	}); repeatErr != nil {
 		t.Fatalf("repeat Uninstall errored: %v", repeatErr)
 	}
@@ -154,7 +157,8 @@ func TestUninstall_MergesListedRealmsWithWellKnown(t *testing.T) {
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
 	if _, err := ctrl.Uninstall(controller.UninstallOptions{
-		SkipUserGroup: true,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	}); err != nil {
 		t.Fatalf("Uninstall errored: %v", err)
 	}
@@ -201,8 +205,9 @@ func TestUninstall_PurgeFailureGatesFilesystemCleanup(t *testing.T) {
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
 	report, err := ctrl.Uninstall(controller.UninstallOptions{
-		SocketDir:     tmpSocketDir,
-		SkipUserGroup: true,
+		SocketDir:         tmpSocketDir,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	})
 	if err == nil {
 		t.Fatalf("expected error from failing realm purge, got nil")
@@ -269,6 +274,237 @@ func TestUninstall_PurgeFailureGatesFilesystemCleanup(t *testing.T) {
 	}
 	if !foundOK {
 		t.Errorf("expected successful default realm in report; got %+v", report.Realms)
+	}
+}
+
+// TestUninstall_ReclaimsBuildCachePerNamespace pins the issue #904 fix: for
+// every realm whose containerd namespace was actually removed, Uninstall
+// reclaims the matching per-namespace BuildKit state directory at
+// <BuildCacheBaseDir>/<namespace>. Leaving the cache behind strands the next
+// `kuke build` with "parent snapshot does not exist" or "content digest ...
+// not found" because cache.db references containerd by snapshot ID and
+// content digest into a namespace that no longer exists.
+func TestUninstall_ReclaimsBuildCachePerNamespace(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+	cacheBase := t.TempDir()
+
+	// Seed a populated per-namespace cache dir for each well-known realm so
+	// we can prove RemoveAll fired (not just os.Remove of an empty dir).
+	for _, ns := range []string{
+		consts.RealmNamespace(consts.KukeonDefaultRealmName),
+		consts.RealmNamespace(consts.KukeSystemRealmName),
+	} {
+		nsDir := filepath.Join(cacheBase, ns)
+		if err := os.MkdirAll(filepath.Join(nsDir, "buildkit"), 0o700); err != nil {
+			t.Fatalf("seed cache %q: %v", nsDir, err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(nsDir, "cache.db"), []byte("seeded"), 0o600,
+		); err != nil {
+			t.Fatalf("seed cache.db under %q: %v", nsDir, err)
+		}
+	}
+
+	f := uninstallNoopRunner(nil)
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:         tmpSocketDir,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: cacheBase,
+	})
+	if err != nil {
+		t.Fatalf("Uninstall returned error: %v", err)
+	}
+
+	// One BuildCachePurgeOutcome per well-known realm, each with Existed +
+	// Removed true and no error. Ordering must match Realms.
+	if len(report.BuildCaches) != 2 {
+		t.Fatalf("BuildCaches len=%d, want 2 (one per well-known realm); got %+v",
+			len(report.BuildCaches), report.BuildCaches)
+	}
+	wantNamespaces := map[string]bool{
+		consts.RealmNamespace(consts.KukeonDefaultRealmName): false,
+		consts.RealmNamespace(consts.KukeSystemRealmName):    false,
+	}
+	for _, c := range report.BuildCaches {
+		if !c.Existed || !c.Removed || c.Err != nil {
+			t.Errorf("cache outcome for %q = %+v; want Existed:true Removed:true Err:nil",
+				c.Namespace, c)
+		}
+		wantPath := filepath.Join(cacheBase, c.Namespace)
+		if c.Path != wantPath {
+			t.Errorf("cache outcome Path=%q, want %q", c.Path, wantPath)
+		}
+		if _, ok := wantNamespaces[c.Namespace]; !ok {
+			t.Errorf("unexpected namespace in BuildCaches: %q", c.Namespace)
+			continue
+		}
+		wantNamespaces[c.Namespace] = true
+	}
+	for ns, seen := range wantNamespaces {
+		if !seen {
+			t.Errorf("expected BuildCache row for namespace %q; got %+v",
+				ns, report.BuildCaches)
+		}
+	}
+
+	// The per-namespace dirs must actually be gone from disk.
+	for ns := range wantNamespaces {
+		nsDir := filepath.Join(cacheBase, ns)
+		if _, statErr := os.Stat(nsDir); !os.IsNotExist(statErr) {
+			t.Errorf("cache dir %q survived uninstall: %v", nsDir, statErr)
+		}
+	}
+
+	// Base dir was emptied by the per-namespace sweep, so the rmdir must
+	// have succeeded — issue #904's "rmdir base if empty" branch.
+	if !report.BuildCacheBaseExisted {
+		t.Errorf("BuildCacheBaseExisted=false; seeded base was not seen")
+	}
+	if !report.BuildCacheBaseRemoved {
+		t.Errorf("BuildCacheBaseRemoved=false; empty base must be rmdir'd")
+	}
+	if _, statErr := os.Stat(cacheBase); !os.IsNotExist(statErr) {
+		t.Errorf("base cache dir %q survived after rmdir-when-empty: %v", cacheBase, statErr)
+	}
+}
+
+// TestUninstall_BuildCacheSkippedOnNamespaceFailure pins the gate: a realm
+// whose containerd namespace was NOT removed (the issue #193 partial-state
+// path) must keep its BuildKit cache on disk. Wiping it would prevent the
+// follow-up `kuke uninstall` from having the same cache metadata to reason
+// about — and the cache references are still meaningful while the namespace
+// survives.
+func TestUninstall_BuildCacheSkippedOnNamespaceFailure(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+	cacheBase := t.TempDir()
+
+	// Seed caches for both well-known realms.
+	defaultNs := consts.RealmNamespace(consts.KukeonDefaultRealmName)
+	systemNs := consts.RealmNamespace(consts.KukeSystemRealmName)
+	for _, ns := range []string{defaultNs, systemNs} {
+		if err := os.MkdirAll(filepath.Join(cacheBase, ns), 0o700); err != nil {
+			t.Fatalf("seed cache %q: %v", ns, err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(cacheBase, ns, "cache.db"), []byte("x"), 0o600,
+		); err != nil {
+			t.Fatalf("seed cache.db: %v", err)
+		}
+	}
+
+	f := uninstallNoopRunner(nil)
+	failure := errors.New("synthetic purge failure")
+	f.PurgeRealmFn = func(r intmodel.Realm) (bool, error) {
+		// kuke-system reports NamespaceRemoved=false (PurgeRealm returns
+		// false + err); default reports NamespaceRemoved=true.
+		if r.Metadata.Name == consts.KukeSystemRealmName {
+			return false, failure
+		}
+		return true, nil
+	}
+
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, _ := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:         tmpSocketDir,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: cacheBase,
+	})
+
+	// Exactly one cache row: the realm that successfully dropped its
+	// namespace. The realm whose namespace survived contributes no row.
+	if len(report.BuildCaches) != 1 {
+		t.Fatalf("BuildCaches len=%d, want 1 (only the successfully purged realm); got %+v",
+			len(report.BuildCaches), report.BuildCaches)
+	}
+	got := report.BuildCaches[0]
+	if got.Namespace != defaultNs {
+		t.Errorf("BuildCaches[0].Namespace=%q, want %q", got.Namespace, defaultNs)
+	}
+	if !got.Removed {
+		t.Errorf("default-realm cache should be Removed=true; got %+v", got)
+	}
+
+	// kuke-system's cache must survive on disk so the operator's follow-up
+	// recovery has the same metadata available.
+	if _, statErr := os.Stat(filepath.Join(cacheBase, systemNs)); statErr != nil {
+		t.Errorf("kuke-system cache dir wiped despite namespace survival: %v", statErr)
+	}
+
+	// Base dir must NOT be rmdir'd — kuke-system's subdir keeps it non-empty.
+	if report.BuildCacheBaseRemoved {
+		t.Errorf("BuildCacheBaseRemoved=true with surviving cousin subdir; rmdir must have stayed a no-op")
+	}
+	if _, statErr := os.Stat(cacheBase); statErr != nil {
+		t.Errorf("base cache dir wiped despite non-empty rmdir: %v", statErr)
+	}
+}
+
+// TestUninstall_BuildCacheBaseAbsent pins the "host never built" path: a
+// clean install where /var/lib/kukebuild was never created must still
+// produce a no-op exit (no error, no spurious rows) — uninstall idempotency
+// extends to the cache reclaim half.
+func TestUninstall_BuildCacheBaseAbsent(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+	// Point at a never-created path under a tmp dir so the test cannot
+	// accidentally touch /var/lib/kukebuild on the dev host.
+	cacheBase := filepath.Join(t.TempDir(), "never-built")
+
+	f := uninstallNoopRunner(nil)
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, err := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:         tmpSocketDir,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: cacheBase,
+	})
+	if err != nil {
+		t.Fatalf("Uninstall on host with no BuildKit cache errored: %v", err)
+	}
+
+	// Every cache outcome should be Existed=false / Removed=false / no err.
+	for _, c := range report.BuildCaches {
+		if c.Existed || c.Removed || c.Err != nil {
+			t.Errorf("cache outcome on absent base should be all-false: %+v", c)
+		}
+	}
+
+	if report.BuildCacheBaseExisted {
+		t.Errorf("BuildCacheBaseExisted=true for never-created dir %q", cacheBase)
+	}
+	if report.BuildCacheBaseRemoved {
+		t.Errorf("BuildCacheBaseRemoved=true for never-created dir %q", cacheBase)
+	}
+}
+
+// TestUninstall_BuildCacheBaseDefaultsToConst pins the production-code path:
+// when UninstallOptions leaves BuildCacheBaseDir empty (the CLI's default),
+// the controller falls back to consts.KukebuildBaseDir rather than a silent
+// no-op. The fallback is reported on the UninstallReport so the renderer can
+// label the row. Pointing at a host path is undesirable in tests, so this
+// guard only asserts the BuildCacheBaseDir field gets surfaced — verifying
+// the constant flows through.
+func TestUninstall_BuildCacheBaseDefaultsToConst(t *testing.T) {
+	tmpRunPath := t.TempDir()
+	tmpSocketDir := t.TempDir()
+
+	// Stand in a fakeRunner that always returns NamespaceRemoved=false so
+	// no per-namespace cache reclaim fires — the test is about the base-dir
+	// default surfacing only, not about touching /var/lib/kukebuild.
+	f := uninstallNoopRunner(nil)
+	f.PurgeRealmFn = func(_ intmodel.Realm) (bool, error) { return false, nil }
+
+	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
+	report, _ := ctrl.Uninstall(controller.UninstallOptions{
+		SocketDir:     tmpSocketDir,
+		SkipUserGroup: true,
+		// BuildCacheBaseDir deliberately empty — exercise the default.
+	})
+	if report.BuildCacheBaseDir != consts.KukebuildBaseDir {
+		t.Errorf("BuildCacheBaseDir=%q, want default %q",
+			report.BuildCacheBaseDir, consts.KukebuildBaseDir)
 	}
 }
 
@@ -345,6 +581,7 @@ func TestUninstall_DaemonStopStep_PIDPresent(t *testing.T) {
 		DaemonStopper:         stopper,
 		DaemonStopGracePeriod: 250 * time.Millisecond,
 		SkipUserGroup:         true,
+		BuildCacheBaseDir:     t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("Uninstall returned error: %v", err)
@@ -407,9 +644,10 @@ func TestUninstall_DaemonStopStep_PIDAbsent(t *testing.T) {
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
 	report, err := ctrl.Uninstall(controller.UninstallOptions{
-		SocketDir:     tmpSocketDir,
-		DaemonStopper: stopper,
-		SkipUserGroup: true,
+		SocketDir:         tmpSocketDir,
+		DaemonStopper:     stopper,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("Uninstall returned error: %v", err)
@@ -463,7 +701,8 @@ func TestUninstall_SuffixEnumeratorPurgesKukeonNamespacesOnly(t *testing.T) {
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
 	if _, err := ctrl.Uninstall(controller.UninstallOptions{
-		SkipUserGroup: true,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	}); err != nil {
 		t.Fatalf("Uninstall returned error: %v", err)
 	}
@@ -553,7 +792,8 @@ func TestUninstall_SuffixIsolationAcrossInstances(t *testing.T) {
 
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
 	if _, err := ctrl.Uninstall(controller.UninstallOptions{
-		SkipUserGroup: true,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	}); err != nil {
 		t.Fatalf("Uninstall returned error: %v", err)
 	}
@@ -635,9 +875,10 @@ func TestUninstall_ReleasesBindMountsBeforeRmdir(t *testing.T) {
 	f := uninstallNoopRunner(nil)
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
 	report, err := ctrl.Uninstall(controller.UninstallOptions{
-		SocketDir:     tmpSocketDir,
-		MountReleaser: releaser,
-		SkipUserGroup: true,
+		SocketDir:         tmpSocketDir,
+		MountReleaser:     releaser,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	})
 	if err != nil {
 		t.Fatalf("Uninstall returned err=%v", err)
@@ -687,9 +928,10 @@ func TestUninstall_ResidualMountSurfacesInReportAndError(t *testing.T) {
 	f := uninstallNoopRunner(nil)
 	ctrl := setupTestControllerWithRunPath(t, f, tmpRunPath)
 	report, err := ctrl.Uninstall(controller.UninstallOptions{
-		SocketDir:     tmpSocketDir,
-		MountReleaser: releaser,
-		SkipUserGroup: true,
+		SocketDir:         tmpSocketDir,
+		MountReleaser:     releaser,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	})
 
 	if err == nil {
@@ -748,7 +990,8 @@ func TestUninstall_DefaultPIDFileResolvesToSocketDir(t *testing.T) {
 		DaemonStopper: stopper,
 		// KukeondPIDFile deliberately empty — the whole point is to exercise
 		// the controller's default-resolution path.
-		SkipUserGroup: true,
+		SkipUserGroup:     true,
+		BuildCacheBaseDir: t.TempDir(),
 	}); err != nil {
 		t.Fatalf("Uninstall returned error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Wires `kuke uninstall` to reclaim `/var/lib/kukebuild/<namespace>/` for every realm whose containerd namespace was successfully removed in the same pass. The BuildKit cache references containerd by snapshot ID and content digest, so a surviving cache after a namespace drop strands the next `kuke build` with `parent snapshot does not exist` or `content digest ... not found` (issue #904).
- Adds a shared `consts.KukebuildBaseDir` constant (mirrors `defaultBuildRoot` in `cmd/kukebuild/main.go`; the two cannot be a single source of truth because `cmd/kukebuild` is a separate Go module — cross-references added on both sides).
- Adds per-namespace `BuildCachePurgeOutcome` rows and a trailing `build cache <base>: removed | kept (cousin instance caches present)` row to the uninstall report. Base dir is rmdir'd only when empty after the per-namespace sweep, so a scoped uninstall (`--server-configuration`) leaves cousin instances' caches under sibling subdirs intact.
- Updates `uninstallLongDesc` and the half-cleaned-host remediation in `docs/cli-use-cases.md` so operators recovering a partial uninstall know to wipe the matching `/var/lib/kukebuild/<namespace>/` (the partial-cleanup path is the operator's; the follow-up `kuke uninstall` only sweeps caches it successfully purges in *its* pass).

The cache reclaim is intentionally **not** gated on `CleanupSkipped`: a namespace that was actually removed in a partial uninstall should still have its cache reclaimed even when a sibling realm's purge failed. A realm whose namespace survived contributes no row so its cache stays on disk for the follow-up recovery to reason about.

Closes #904

## Test plan

- [x] `make test` — full root + `cmd/kukebuild` module suites pass.
- [x] `go vet ./...` on both modules.
- [x] New `internal/controller` tests cover: reclaim path (per-namespace dirs removed + base rmdir'd when empty), gated path (namespace-survive → cache survives → base not rmdir'd), absent-base idempotency, and the empty-`BuildCacheBaseDir` → `consts.KukebuildBaseDir` default fallback.
- [x] New `cmd/kuke/uninstall` renderer tests cover: three-row "removed" output, "kept (cousin instance caches present)" on a scoped uninstall, and quiet no-row output on a never-built host.
- [ ] **Not run on this CI:** `make dev-init` smoke. The change is uninstall-only — it does not touch the build path, the daemon serve path, or the runtime container state — so the `kuke get realms` daemon-parity guard at the tail of `make dev-init` is unaffected. The full operator round-trip (`kuke uninstall` → `kuke init` → `kuke build`) is what exercises the fix end-to-end and is the natural smoke for the next operator-driven dev loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)