### PR TITLE
fix(del): surface cell subdir residue and os.RemoveAll errors on stack/cell delete

### DIFF
--- a/internal/controller/runner/delete_cell.go
+++ b/internal/controller/runner/delete_cell.go
@@ -215,7 +215,13 @@ func (r *Exec) deleteCellLocked(cell intmodel.Cell) error {
 		return fmt.Errorf("%w: failed to delete cell metadata: %w", errdefs.ErrDeleteCell, err)
 	}
 
-	// Remove metadata directory completely
+	// Remove metadata directory completely. metadata.DeleteMetadata above
+	// removes the dir when empty (only the stack's own metadata.json + lock
+	// were there), but the cell dir also owns peer artifacts — etc-hosts,
+	// etc-hostname, attachable socket directories — that the metadata
+	// sweeper doesn't reach. Surface any failure so the half-deleted state
+	// (kukeon.yaml gone, cell dir surviving) reported in issue #905 cannot
+	// be silently swallowed.
 	metadataRunPath := fs.CellMetadataDir(
 		r.opts.RunPath,
 		internalCell.Spec.RealmName,
@@ -223,7 +229,9 @@ func (r *Exec) deleteCellLocked(cell intmodel.Cell) error {
 		cellStackName,
 		internalCell.Metadata.Name,
 	)
-	_ = os.RemoveAll(metadataRunPath)
+	if err = os.RemoveAll(metadataRunPath); err != nil {
+		return fmt.Errorf("%w: failed to remove cell directory %s: %w", errdefs.ErrDeleteCell, metadataRunPath, err)
+	}
 
 	return nil
 }

--- a/internal/controller/runner/delete_stack.go
+++ b/internal/controller/runner/delete_stack.go
@@ -20,8 +20,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/metadata"
@@ -110,6 +112,32 @@ func (r *Exec) DeleteStack(stack intmodel.Stack) error {
 		// Continue with metadata deletion
 	}
 
+	// Refuse to remove the stack while cell subdirectories survive under the
+	// stack metadata dir. ListCells silently skips a cell whose metadata.json
+	// is missing or unreadable (controller/runner/get.go), so the cascade
+	// loop in controller.deleteStackCascade can complete with zero handled
+	// cells while a partial cell subdir remains on disk. Removing the
+	// stack's own metadata here would orphan that subdir behind a stack the
+	// operator can no longer list — the failure surfaced as residue under
+	// /opt/kukeon/data/<realm>/<space>/<stack>/ after `kuke del stack
+	// --cascade` exited 0. Issue #905.
+	metadataRunPath := fs.StackMetadataDir(
+		r.opts.RunPath,
+		internalStack.Spec.RealmName,
+		internalStack.Spec.SpaceName,
+		internalStack.Metadata.Name,
+	)
+	residue, residueErr := scanStackDirCellResidue(metadataRunPath)
+	if residueErr != nil {
+		return fmt.Errorf("%w: scan stack dir %q: %w", errdefs.ErrDeleteStack, metadataRunPath, residueErr)
+	}
+	if len(residue) > 0 {
+		return fmt.Errorf(
+			"%w: cell subdirectory residue under %s — cascade did not remove %s; inspect and remove by hand before re-running",
+			errdefs.ErrDeleteStack, metadataRunPath, strings.Join(residue, ", "),
+		)
+	}
+
 	// Delete stack metadata file
 	metadataFilePath := fs.StackMetadataPath(
 		r.opts.RunPath,
@@ -121,14 +149,44 @@ func (r *Exec) DeleteStack(stack intmodel.Stack) error {
 		return fmt.Errorf("%w: failed to delete stack metadata: %w", errdefs.ErrDeleteStack, err)
 	}
 
-	// Remove metadata directory completely
-	metadataRunPath := fs.StackMetadataDir(
-		r.opts.RunPath,
-		internalStack.Spec.RealmName,
-		internalStack.Spec.SpaceName,
-		internalStack.Metadata.Name,
-	)
-	_ = os.RemoveAll(metadataRunPath)
+	// Remove the now-residue-free stack metadata directory. metadata.DeleteMetadata
+	// above removes the dir when empty, so this typically no-ops; surface any
+	// error so the half-deleted state (kukeon.yaml gone, dir surviving)
+	// reported in issue #905 can never again be silently swallowed.
+	if err = os.RemoveAll(metadataRunPath); err != nil {
+		return fmt.Errorf("%w: failed to remove stack directory %s: %w", errdefs.ErrDeleteStack, metadataRunPath, err)
+	}
 
 	return nil
+}
+
+// scanStackDirCellResidue returns the names of any subdirectories under
+// stackDir that look like surviving cell directories — anything that isn't
+// one of the known scope-bound subdirs (secrets/blueprints/configs) and
+// isn't the stack's own metadata.json or its lock sidecar. The names are
+// sorted for stable error messages. A missing stackDir returns nil, nil.
+func scanStackDirCellResidue(stackDir string) ([]string, error) {
+	entries, err := os.ReadDir(stackDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	metaFile := consts.KukeonMetadataFile
+	metaLock := metaFile + metadata.LockFileSuffix
+	var residue []string
+	for _, entry := range entries {
+		name := entry.Name()
+		switch name {
+		case metaFile, metaLock,
+			consts.KukeonSecretsSubdir,
+			consts.KukeonBlueprintsSubdir,
+			consts.KukeonConfigsSubdir:
+			continue
+		}
+		residue = append(residue, name)
+	}
+	sort.Strings(residue)
+	return residue, nil
 }

--- a/internal/controller/runner/delete_stack_test.go
+++ b/internal/controller/runner/delete_stack_test.go
@@ -1,0 +1,180 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.DeleteStack against an in-package ctr.Client fake
+package runner
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/metadata"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/fs"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// seedDeleteStackStack writes a minimal stack metadata.json so runner.GetStack
+// resolves the stack and runner.DeleteStack reaches the residue / removal
+// branches under test. Returns the on-disk path of the stack metadata file.
+func seedDeleteStackStack(t *testing.T, r *Exec, realm, space, stack string) string {
+	t.Helper()
+	doc := v1beta1.StackDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindStack,
+		Metadata:   v1beta1.StackMetadata{Name: stack},
+		Spec: v1beta1.StackSpec{
+			ID:      stack,
+			RealmID: realm,
+			SpaceID: space,
+		},
+	}
+	path := fs.StackMetadataPath(r.opts.RunPath, realm, space, stack)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir stack metadata dir: %v", err)
+	}
+	if err := metadata.WriteMetadata(r.ctx, r.logger, doc, path); err != nil {
+		t.Fatalf("write stack metadata: %v", err)
+	}
+	return path
+}
+
+func buildDeleteStackRequest(realm, space, stack string) intmodel.Stack {
+	return intmodel.Stack{
+		Metadata: intmodel.StackMetadata{Name: stack},
+		Spec: intmodel.StackSpec{
+			RealmName: realm,
+			SpaceName: space,
+		},
+	}
+}
+
+// TestDeleteStack_RefusesOnCellSubdirResidue is the regression guard for
+// issue #905. ListCells silently skips a cell whose metadata.json was
+// removed or corrupted by a partial earlier teardown; the cascade loop in
+// controller.deleteStackCascade therefore processed 0 cells, runner.DeleteStack
+// removed the stack's own metadata.json, and the swallowed os.RemoveAll
+// failed to recursively remove the surviving cell subdir — leaving residue
+// on disk while the CLI exited 0.
+//
+// The fixed runner.DeleteStack must refuse before removing the stack
+// metadata when a cell-shaped subdir survives, wrap the error under
+// ErrDeleteStack, and leave both the stack metadata and the cell subdir
+// intact so a re-run after manual cleanup can complete normally.
+func TestDeleteStack_RefusesOnCellSubdirResidue(t *testing.T) {
+	realm, space, stack := "default", "default", "web"
+	fake := &deleteCellFakeClient{}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	stackMetadataPath := seedDeleteStackStack(t, r, realm, space, stack)
+
+	// Seed a cell-shaped subdirectory that ListCells would silently skip
+	// (no metadata.json inside). This is the residue path #905 describes.
+	residueDir := filepath.Join(filepath.Dir(stackMetadataPath), "api")
+	if err := os.MkdirAll(residueDir, 0o755); err != nil {
+		t.Fatalf("mkdir residue cell dir: %v", err)
+	}
+
+	err := r.DeleteStack(buildDeleteStackRequest(realm, space, stack))
+	if err == nil {
+		t.Fatal("DeleteStack: want non-nil error on cell subdir residue, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrDeleteStack) {
+		t.Errorf("DeleteStack error must wrap ErrDeleteStack so the CLI exits non-zero; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "api") {
+		t.Errorf("DeleteStack error must name the residue subdir so the operator can find it; got %v", err)
+	}
+	if _, statErr := os.Stat(stackMetadataPath); statErr != nil {
+		t.Errorf(
+			"stack metadata must remain on disk when residue is detected, so the operator can re-run cleanup after manual repair; stat err=%v",
+			statErr,
+		)
+	}
+	if _, statErr := os.Stat(residueDir); statErr != nil {
+		t.Errorf(
+			"residue subdir must remain on disk for operator inspection; stat err=%v",
+			statErr,
+		)
+	}
+}
+
+// TestDeleteStack_AllowsKnownScopeSubdirs locks the residue check's
+// allowlist: the per-stack secrets / blueprints / configs subdirs are
+// legitimate children of the stack metadata dir (issue #619/#620/#624) and
+// must not trigger the residue refusal, otherwise every stack that ever
+// stamped a stack-scoped secret/blueprint/config would become un-deletable.
+// The post-delete cleanup currently relies on os.RemoveAll to reclaim them,
+// matching the pre-#905 behavior — the only contract this test pins is
+// that the residue check does not block the call.
+func TestDeleteStack_AllowsKnownScopeSubdirs(t *testing.T) {
+	realm, space, stack := "default", "default", "web"
+	fake := &deleteCellFakeClient{}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	stackMetadataPath := seedDeleteStackStack(t, r, realm, space, stack)
+
+	stackDir := filepath.Dir(stackMetadataPath)
+	for _, name := range []string{
+		consts.KukeonSecretsSubdir,
+		consts.KukeonBlueprintsSubdir,
+		consts.KukeonConfigsSubdir,
+	} {
+		if err := os.MkdirAll(filepath.Join(stackDir, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s subdir: %v", name, err)
+		}
+	}
+
+	if err := r.DeleteStack(buildDeleteStackRequest(realm, space, stack)); err != nil {
+		t.Fatalf("DeleteStack: unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(stackDir); !os.IsNotExist(statErr) {
+		t.Errorf("stack dir must be fully removed when only known scope subdirs are present; stat err=%v", statErr)
+	}
+}
+
+// TestDeleteStack_RemovesStackDirOnSuccess is the positive guard for the
+// symptom described in issue #905: a successful `kuke del stack --cascade`
+// must leave no trace of the stack's metadata dir on disk so a subsequent
+// `kuke create stack` with the same name does not collide with leftover
+// directories. Pre-fix, `_ = os.RemoveAll(metadataRunPath)` swallowed any
+// failure and the CLI exited 0 anyway; the fixed path surfaces failure and
+// the happy-path leaves the dir gone.
+func TestDeleteStack_RemovesStackDirOnSuccess(t *testing.T) {
+	realm, space, stack := "default", "default", "web"
+	fake := &deleteCellFakeClient{}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	stackMetadataPath := seedDeleteStackStack(t, r, realm, space, stack)
+	stackDir := filepath.Dir(stackMetadataPath)
+
+	if err := r.DeleteStack(buildDeleteStackRequest(realm, space, stack)); err != nil {
+		t.Fatalf("DeleteStack: unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(stackDir); !os.IsNotExist(statErr) {
+		t.Errorf(
+			"stack dir must be fully removed on success so kuke create stack with the same name does not collide; stat err=%v",
+			statErr,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- `kuke del stack <name> --cascade` could exit 0 while leaving the stack metadata
  dir on disk with surviving cell subdirectories — the operator then had to
  `rm -rf /opt/kukeon/data/<realm>/<space>/<stack>/` by hand before
  `kuke create stack` with the same name would succeed. Both contributor paths
  named in the issue are addressed.
- `runner.DeleteStack` now refuses to remove the stack metadata file when a
  cell-shaped subdirectory survives under the stack metadata dir. ListCells
  silently skips cells with unreadable/missing `metadata.json` (`get.go:437`),
  so the cascade loop in `controller.deleteStackCascade` could complete with 0
  handled cells while a partial cell subdir remained. The new pre-check scans
  for entries that aren't `metadata.json` / `.lock` / `secrets` / `blueprints`
  / `configs`, refuses with an `ErrDeleteStack`-wrapped error naming the
  residue, and leaves both the stack metadata and the residue in place so a
  re-run after manual repair completes cleanly.
- `runner.DeleteStack` and `runner.DeleteCell` no longer swallow
  `os.RemoveAll` errors via the `_ = os.RemoveAll(...)` pattern. Failures are
  wrapped under `errdefs.ErrDeleteStack` / `errdefs.ErrDeleteCell` so the CLI
  exits non-zero with a message naming the path that could not be removed.
- Three regression tests cover the residue refusal (named cell subdir
  preserved, error wraps `ErrDeleteStack`), the scope-subdir allowlist
  (`secrets`/`blueprints`/`configs` do not trigger refusal), and the happy
  path (stack dir fully removed on success — direct guard against the
  reported symptom).

Scope discipline: `purge_stack.go` and `delete_space.go` carry the same
`_ = os.RemoveAll(...)` pattern but were out of the issue's named scope and
are left for a follow-up.

Closes #905

## Test plan

- [x] `make test-root` — all packages green, including the new
      `TestDeleteStack_*` tests in `internal/controller/runner/`.
- [x] `make test-kukebuild` — green.
- [x] `GOWORK=off go build ./...` and `go vet ./...` — clean.
- [ ] `make dev-init` smoke (the daemon-parity guard) — not exercised; this
      change is to the runner's delete paths and does not touch the daemon
      build, the bootstrap, or anything `kukeond` reads at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)