### PR TITLE
docs(del): fix copy-paste slip and stale kukeon.yaml in comments from #907

### DIFF
--- a/internal/controller/runner/delete_cell.go
+++ b/internal/controller/runner/delete_cell.go
@@ -216,11 +216,11 @@ func (r *Exec) deleteCellLocked(cell intmodel.Cell) error {
 	}
 
 	// Remove metadata directory completely. metadata.DeleteMetadata above
-	// removes the dir when empty (only the stack's own metadata.json + lock
+	// removes the dir when empty (only the cell's own metadata.json + lock
 	// were there), but the cell dir also owns peer artifacts — etc-hosts,
 	// etc-hostname, attachable socket directories — that the metadata
 	// sweeper doesn't reach. Surface any failure so the half-deleted state
-	// (kukeon.yaml gone, cell dir surviving) reported in issue #905 cannot
+	// (metadata.json gone, cell dir surviving) reported in issue #905 cannot
 	// be silently swallowed.
 	metadataRunPath := fs.CellMetadataDir(
 		r.opts.RunPath,

--- a/internal/controller/runner/delete_stack.go
+++ b/internal/controller/runner/delete_stack.go
@@ -151,7 +151,7 @@ func (r *Exec) DeleteStack(stack intmodel.Stack) error {
 
 	// Remove the now-residue-free stack metadata directory. metadata.DeleteMetadata
 	// above removes the dir when empty, so this typically no-ops; surface any
-	// error so the half-deleted state (kukeon.yaml gone, dir surviving)
+	// error so the half-deleted state (metadata.json gone, dir surviving)
 	// reported in issue #905 can never again be silently swallowed.
 	if err = os.RemoveAll(metadataRunPath); err != nil {
 		return fmt.Errorf("%w: failed to remove stack directory %s: %w", errdefs.ErrDeleteStack, metadataRunPath, err)


### PR DESCRIPTION
## Summary
- `delete_cell.go`: replace ``stack's own metadata.json + lock`` with ``cell's own metadata.json + lock`` (this is the cell delete path; the original phrasing was a copy-paste slip from `delete_stack.go`).
- Both `delete_cell.go` and `delete_stack.go`: replace `kukeon.yaml gone` with `metadata.json gone` to match the actual on-disk file (`consts.KukeonMetadataFile = "metadata.json"`); `kukeon.yaml` does not exist anywhere in the tree.

Comment-only — no behavior change. The fix surfaced by #907 is correct; only the surrounding prose needed to match it.

## Test plan
- [x] `git diff` shows only comment lines change
- [x] `grep -rn 'kukeon.yaml' --include='*.go' internal/ pkg/ cmd/` returns no hits

Closes #908