### PR TITLE
fix(attachable): unblock kuke run when host/image kukeon GID drift + reuse-path tty bind-mount chown is missed

### DIFF
--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -329,6 +329,11 @@ func (r *Exec) daemonDefaultBuildOpts() []ctr.BuildOption {
 	if r.opts.RunPath != "" {
 		opts = append(opts, ctr.WithSecretRunPath(r.opts.RunPath))
 	}
+	if r.opts.KukeonGroupGID > 0 {
+		//nolint:gosec // KukeonGroupGID is a real GID (uint16 territory); the
+		// runtime-spec field is uint32 so the conversion is widening.
+		opts = append(opts, ctr.WithKukeonGroupGID(uint32(r.opts.KukeonGroupGID)))
+	}
 	return opts
 }
 

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -1117,18 +1117,26 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 				"created container",
 				fields...,
 			)
-
-			if err = r.attachablePostCreateChown(namespace, containerSpec); err != nil {
-				return intmodel.Cell{}, fmt.Errorf(
-					"failed to chown attachable tty dir for %s: %w", ctrContainerID, err,
-				)
-			}
 		}
 		// On the reuse path the BuildOptions attachOpts returned aren't
 		// applied (the existing OCI spec already carries the attachable
 		// wrapping); the call is still made above for its side effects —
 		// kuketty binary staging, per-container metadata render, ttyDir
 		// chmod — which must run before the task starts.
+		//
+		// The post-create chown also runs on both paths: attachableBuildOpts
+		// resets ttyDir to root:kukeon mode 02750 every call, so without a
+		// matching chown-to-container-uid here the in-container process
+		// (claude:1000) cannot create the kuketty socket/log inside the
+		// bind-mounted tty dir on a reuse-path start. kuketty fails listen
+		// with EACCES and the work container exits within the startup grace
+		// window — caught by the post-start liveness check as
+		// StartCellFailed (#258 / #850 restart-path complement).
+		if attachErr = r.attachablePostCreateChown(namespace, containerSpec); attachErr != nil {
+			return intmodel.Cell{}, fmt.Errorf(
+				"failed to chown attachable tty dir for %s: %w", ctrContainerID, attachErr,
+			)
+		}
 
 		// Use container name with UUID for containerd operations
 		specWithNamespaces := ctr.JoinContainerNamespaces(
@@ -1417,18 +1425,23 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 			"created container",
 			fields...,
 		)
-
-		if err = r.attachablePostCreateChown(namespace, *foundContainerSpec); err != nil {
-			return intmodel.Cell{}, fmt.Errorf(
-				"failed to chown attachable tty dir for %s: %w", containerdID, err,
-			)
-		}
 	}
 	// On the reuse path the BuildOptions attachOpts returned aren't applied
 	// (the existing OCI spec already carries the attachable wrapping); the
 	// call above is still made for its side effects (kuketty binary staging,
 	// per-container metadata render, ttyDir chmod) which must run before the
 	// task starts.
+	//
+	// The post-create chown also runs on both paths so the in-container
+	// process (resolved uid from the OCI spec) can write into the tty
+	// bind-mount that attachableBuildOpts just reset to root:kukeon. See the
+	// matching StartCell hop above for the EACCES failure mode this closes
+	// (#258 / #850).
+	if attachErr = r.attachablePostCreateChown(namespace, *foundContainerSpec); attachErr != nil {
+		return intmodel.Cell{}, fmt.Errorf(
+			"failed to chown attachable tty dir for %s: %w", containerdID, attachErr,
+		)
+	}
 
 	// Start container with namespace paths
 	specWithNamespaces := ctr.JoinContainerNamespaces(

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -187,6 +187,13 @@ func BuildRootContainerSpec(
 
 	specOpts = append(specOpts, securitySpecOpts(rootSpec)...)
 
+	// Mirror BuildContainerSpec's kukeon-group-GID hop so a non-default root
+	// container that runs as a non-root user (a user-supplied RootContainerID
+	// image) can still reach kukeon-group-owned bind-mounts. Zero is a no-op.
+	if opts.kukeonGroupGID > 0 {
+		specOpts = append(specOpts, withKukeonGroupGIDSpecOpt(opts.kukeonGroupGID))
+	}
+
 	// Daemon-default memory cap: mirrors BuildContainerSpec so the same fallback
 	// reaches root containers when the daemon is configured with one (#531).
 	// The spec wins when it already carries a positive limit.

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -181,6 +181,7 @@ type buildOpts struct {
 	defaultMemoryLimitBytes int64
 	secretRunPath           string
 	extraLabels             map[string]string
+	kukeonGroupGID          uint32
 }
 
 // WithAttachableInjection configures the host-side paths used when wrapping
@@ -224,6 +225,52 @@ func WithExtraLabels(labels map[string]string) BuildOption {
 		for k, v := range labels {
 			o.extraLabels[k] = v
 		}
+	}
+}
+
+// WithKukeonGroupGID injects the host's `kukeon` group GID into the container
+// process's OCI Process.User.AdditionalGids. The kukeon-owned per-container
+// directories (the attachable tty bind-mount, secrets, etc.) are group-owned
+// on the host by this GID with mode 02750 — without world access, an in-
+// container process that does not belong to this numeric group cannot
+// read/write them. Without this hop, additionalGids are resolved by
+// containerd from the image's /etc/group; an image that happens to define
+// "kukeon" at a different numeric GID (or omits it entirely) silently
+// produces an unstartable cell because kuketty's listen / log open fails
+// with EACCES on the bind-mounted tty dir.
+//
+// Zero is a no-op so callers can pass r.opts.KukeonGroupGID unconditionally.
+// The opt appends to whatever AdditionalGids containerd's WithUser already
+// populated from the rootfs (it runs after securitySpecOpts), and dedupes so
+// a coincidentally-matching image GID is not duplicated.
+func WithKukeonGroupGID(gid uint32) BuildOption {
+	return func(o *buildOpts) {
+		if gid > 0 {
+			o.kukeonGroupGID = gid
+		}
+	}
+}
+
+// withKukeonGroupGIDSpecOpt returns the SpecOpts that appends the host's
+// kukeon GID to Process.User.AdditionalGids. Must run after any
+// oci.WithUser populated the slice from the rootfs — BuildContainerSpec /
+// BuildRootContainerSpec append it after securitySpecOpts to enforce that
+// order.
+func withKukeonGroupGIDSpecOpt(gid uint32) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *runtimespec.Spec) error {
+		if gid == 0 {
+			return nil
+		}
+		if s.Process == nil {
+			return nil
+		}
+		for _, existing := range s.Process.User.AdditionalGids {
+			if existing == gid {
+				return nil
+			}
+		}
+		s.Process.User.AdditionalGids = append(s.Process.User.AdditionalGids, gid)
+		return nil
 	}
 }
 
@@ -394,6 +441,15 @@ func BuildContainerSpec(
 	}
 
 	specOpts = append(specOpts, securitySpecOpts(containerSpec)...)
+
+	// Host kukeon-group GID into Process.User.AdditionalGids. Runs after
+	// securitySpecOpts so it appends to whatever containerd's WithUser
+	// populated from the image's /etc/group, ensuring the in-container
+	// process can reach kukeon-group-owned bind-mounts regardless of how the
+	// image numbered its own kukeon group. Zero-GID is a no-op.
+	if opts.kukeonGroupGID > 0 {
+		specOpts = append(specOpts, withKukeonGroupGIDSpecOpt(opts.kukeonGroupGID))
+	}
 
 	// Daemon-default memory cap: applies only when the spec does not already
 	// carry a positive Resources.MemoryLimitBytes, so an explicit per-

--- a/internal/ctr/spec_test.go
+++ b/internal/ctr/spec_test.go
@@ -1290,6 +1290,96 @@ func assertEtcBindMounts(
 	}
 }
 
+// TestBuildContainerSpec_KukeonGroupGID asserts that WithKukeonGroupGID
+// appends the host's kukeon group GID to Process.User.AdditionalGids, dedupes
+// against an image-resolved entry of the same numeric value, and is a no-op
+// at zero. Pins the contract that closes the "image kukeon GID ≠ host kukeon
+// GID → kuketty EACCES on the tty bind-mount" startup failure.
+func TestBuildContainerSpec_KukeonGroupGID(t *testing.T) {
+	tests := []struct {
+		name       string
+		gid        uint32
+		seedAddGid []uint32
+		want       []uint32
+	}{
+		{name: "zero is no-op", gid: 0, seedAddGid: []uint32{1000}, want: []uint32{1000}},
+		{
+			name:       "appended when image had no kukeon entry",
+			gid:        989,
+			seedAddGid: []uint32{1000, 988},
+			want:       []uint32{1000, 988, 989},
+		},
+		{
+			name:       "deduped against pre-existing matching gid",
+			gid:        989,
+			seedAddGid: []uint32{1000, 989},
+			want:       []uint32{1000, 989},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ctr.BuildContainerSpec(intmodel.ContainerSpec{
+				ID:       "test-id",
+				Image:    "registry.eminwux.com/busybox:latest",
+				CellName: "c", SpaceName: "s", RealmName: "r", StackName: "st",
+			}, ctr.WithKukeonGroupGID(tt.gid))
+
+			ociSpec := &runtimespec.Spec{
+				Process: &runtimespec.Process{
+					User: runtimespec.User{
+						UID:            1000,
+						GID:            1000,
+						AdditionalGids: append([]uint32(nil), tt.seedAddGid...),
+					},
+				},
+			}
+			for _, opt := range spec.SpecOpts {
+				if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+					t.Fatalf("apply SpecOpts: %v", err)
+				}
+			}
+
+			if !reflect.DeepEqual(ociSpec.Process.User.AdditionalGids, tt.want) {
+				t.Errorf("AdditionalGids = %v, want %v",
+					ociSpec.Process.User.AdditionalGids, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildRootContainerSpec_KukeonGroupGID mirrors the user-container test
+// for the root-container builder so a non-default root that runs as a non-
+// root user gets the same hop.
+func TestBuildRootContainerSpec_KukeonGroupGID(t *testing.T) {
+	spec := ctr.BuildRootContainerSpec(intmodel.ContainerSpec{
+		ID:           "root",
+		ContainerdID: "root-id",
+		Image:        "registry.eminwux.com/busybox:latest",
+	}, nil, ctr.WithKukeonGroupGID(989))
+
+	ociSpec := &runtimespec.Spec{
+		Process: &runtimespec.Process{
+			User: runtimespec.User{
+				UID:            1000,
+				GID:            1000,
+				AdditionalGids: []uint32{1000, 988},
+			},
+		},
+	}
+	for _, opt := range spec.SpecOpts {
+		if err := opt(context.Background(), nil, nil, ociSpec); err != nil {
+			t.Fatalf("apply SpecOpts: %v", err)
+		}
+	}
+
+	want := []uint32{1000, 988, 989}
+	if !reflect.DeepEqual(ociSpec.Process.User.AdditionalGids, want) {
+		t.Errorf("AdditionalGids = %v, want %v",
+			ociSpec.Process.User.AdditionalGids, want)
+	}
+}
+
 // TestBuildRootContainerSpec_HostNetwork is the same assertion as
 // TestBuildContainerSpec_HostNetwork but for the root-container builder used
 // by the runner for the kukeond cell.


### PR DESCRIPTION
## Summary

`kuke run kukeon-pm` (and any cell with an attachable work container that
runs as a non-root image USER) fails inside the startup grace window with
`cell wound down immediately after start: ... container "work" exited within
startup grace window (task status=stopped)`. No output is captured: the
container's `tty/` dir under `/opt/kukeon/data/.../work/tty/` is empty —
not even `kuketty.log` — because kuketty exits before `openTerminalLogger`
opens it.

The wound-down container is kuketty failing `net.Listen("unix", "/run/kukeon/tty/socket")`
with EACCES on the kukeon-group-owned tty bind-mount. Two interlocking
causes:

1. **Host vs. image `kukeon` group GID drift.** `kuke init`'s
   `groupadd --system kukeon` lets the host pick a GID (989 here);
   `crew/images/crew-base-user/Dockerfile` hardcodes `groupadd -g 988
   kukeon`. The daemon creates the tty bind-mount `root:kukeon (989)`
   mode 02750, but `oci.WithUser("claude")` resolves the workload's
   AdditionalGids from the image's /etc/group, giving the process
   `additionalGids: [1000, 988]`. The bind-mount has no world bits, so
   the in-container process can't traverse it.

2. **`attachablePostCreateChown` skipped on the reuse-existing-child
   start path.** `attachableBuildOpts` chmods + chowns the tty dir back
   to `root:kukeon` on every call (it has to, in case the prior boot left
   it loose). `attachablePostCreateChown` then resets the owner to the
   container's resolved uid so the workload can write the socket /
   capture / log siblings. But the chown call was nested under
   `if !reuseExistingChild` in both StartCell (start.go) and
   StartContainer — so reuse-path starts left the dir root-owned even
   when the work container ran as uid 1000.

## Fix

- `ctr.WithKukeonGroupGID(gid)` BuildOption + SpecOpts appending the
  host's kukeon GID to `Process.User.AdditionalGids` (deduped, zero-GID
  is a no-op). Wired through `daemonDefaultBuildOpts` from
  `r.opts.KukeonGroupGID`, so the host GID flows into every container's
  process user regardless of how the image numbered (or omitted) its
  own kukeon group.
- Lift `attachablePostCreateChown` out of the `if !reuseExistingChild`
  block in StartCell and StartContainer. The chown is idempotent and
  the container exists on the reuse path by definition, so the call is
  safe on both paths.
- Unit tests in `internal/ctr/spec_test.go` pin the AdditionalGids
  contract: appended-on-miss, deduped-on-match, zero-is-no-op,
  mirrored for `BuildRootContainerSpec`.

## Test plan

- [x] `go test ./internal/ctr/ ./internal/controller/runner/` — green
  (70s + 0.9s).
- [x] `make dev-init` — bootstraps clean; daemon-parity tail prints
  both realms Ready.
- [x] `kuke delete cell kukeon-pm` + `kuke run kukeon-pm` —
  cell transitions to Ready (was `Failed` / `StartCellFailed` before);
  `tty/` dir is `inwx:kukeon 02750` with `socket`, `kuketty.log`,
  `capture`, `metadata.json` all present.
- [x] `sudo ctr -n default.kukeon.io container info default_default_kukeon-pm_work`
  reports `user: {'uid': 1000, 'gid': 1000, 'additionalGids': [1000, 988, 989]}`
  — image's 988 stays, host's 989 is appended.
- [ ] Reviewer: confirm the chown lift is safe on the recreate path
  where `attachableBuildOpts` was already side-effecting the dir
  before `CreateContainerFromSpec` — it is, because the chown reads
  the resolved uid out of containerd's OCI spec which is now persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)