### PR TITLE
deps: bump sbsh to v0.12.1 + e2e regression for stopped→run EACCES race

### DIFF
--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -17,13 +17,19 @@
 package e2e_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/creack/pty"
 
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/util/fs"
@@ -425,4 +431,424 @@ func getCellIDNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName, c
 		return "", fmt.Errorf("cell %q has empty Spec.ID", cellName)
 	}
 	return cell.Spec.ID, nil
+}
+
+// runFromStoppedRaceIterations is how many Stopped → kuke run cycles
+// TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES drives. The issue
+// (#912) calls for ≥20 to catch the bind-then-chmod EACCES window even
+// after the upstream sbsh fix closed it — a future regression that
+// re-opens the window would surface on at least one of these dial
+// attempts in normal CI load. Per iteration cost is ~1 stop + ~1 start
+// + a short attach grace, so 20 iterations stay inside the e2e test's
+// 60s budget on a healthy runner.
+const runFromStoppedRaceIterations = 20
+
+// runFromStoppedAttachGrace is the wait between launching `kuke run`
+// (which races StartCell → attach internally) and sending the detach
+// keystroke. The attach phase enters the in-process pkg/attach loop
+// within tens of milliseconds on a healthy host; this grace is set so
+// the EACCES window, if it re-opens, is consumed by the dial before the
+// detach byte arrives. A v0.12.0 race would surface as a non-zero exit
+// with `permission denied` on stderr inside this window; a v0.12.1
+// healthy attach loop swallows the keystroke and exits cleanly.
+const runFromStoppedAttachGrace = 1 * time.Second
+
+// runFromStoppedExitTimeout caps the wait for a single `kuke run`
+// invocation to return after its detach keystroke. The healthy path
+// (post-v0.12.1) returns within a second; the cap is generous so a
+// genuinely stuck attach loop fails loudly instead of hanging the suite.
+const runFromStoppedExitTimeout = 20 * time.Second
+
+// TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES is the e2e
+// regression test that locks down eminwux/sbsh#361 (closed in sbsh
+// v0.12.1) from the kukeon side. The race lived inside sbsh's
+// OpenSocketCtrl: net.ListenConfig.Listen bound the unix socket at
+// mode 0o666 & ~umask (effectively 0o600 under kukeond's 0o077 umask),
+// then applySocketPerms chowned :kukeon and chmod'd 0o660 *after*
+// Listen returned. A non-root operator in the kukeon group that
+// dialed inside that window — which is exactly what `kuke run`
+// against a Stopped cell does, since StartCell returns once the work
+// task is Running and the client immediately attaches — saw EACCES.
+//
+// The test drives the original failure path verbatim: a kukeon-group
+// non-root caller launching `kuke run <Stopped cell>` 20 times in
+// succession. With sbsh ≥ v0.12.1 each iteration's dial sees the
+// socket at 0o660 :kukeon (the bind itself lands at the configured
+// mode now), the in-process pkg/attach loop enters normally, and the
+// PTY detach keystroke walks the loop back out with exit 0. A
+// regression that re-opens the bind/chmod window would resurface as
+// `permission denied` on stderr and a non-zero exit on at least one
+// of the iterations.
+//
+// Preconditions the test skips on (so the suite stays portable):
+//   - euid != 0 (the test must drop privilege to a non-root caller)
+//   - host has no `kukeon` system group (kuke init has not run, or the
+//     group was removed)
+//   - host has no `nobody` user (rare; only some minimal containers)
+//
+// Divergence from the issue body: #912 claimed the harness "has the
+// group plumbed — see harness_daemon_test.go". It did not at the time
+// — startKukeondDaemon dropped to socketModeRootOnly because no
+// --socket-gid was passed. This test ships its own daemon variant
+// (startKukeondDaemonWithSocketGID) and PTY launcher
+// (startPTYWithCredential) for the privilege drop, so the harness
+// gains the plumbing as part of this fix rather than depending on a
+// separately landed change.
+func TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES(t *testing.T) {
+	// Serial: the test drops privilege and chmods the runPath; it does
+	// not parallelise meaningfully and any t.Parallel sibling running
+	// as root inside the same runPath would muddy the EACCES signal.
+	if os.Geteuid() != 0 {
+		t.Skip("requires root to drop privilege to a non-root caller")
+	}
+
+	kukeonGrp, err := user.LookupGroup(consts.KukeonSystemGroup)
+	if err != nil {
+		t.Skipf("kukeon system group %q not present on host (run `kuke init` first): %v",
+			consts.KukeonSystemGroup, err)
+	}
+	kukeonGID64, err := strconv.ParseUint(kukeonGrp.Gid, 10, 32)
+	if err != nil {
+		t.Fatalf("parse kukeon GID %q: %v", kukeonGrp.Gid, err)
+	}
+	kukeonGID := uint32(kukeonGID64)
+
+	unpriv, err := user.Lookup("nobody")
+	if err != nil {
+		t.Skipf("nobody user not present on host: %v", err)
+	}
+	unprivUID64, err := strconv.ParseUint(unpriv.Uid, 10, 32)
+	if err != nil {
+		t.Fatalf("parse nobody UID %q: %v", unpriv.Uid, err)
+	}
+	unprivGID64, err := strconv.ParseUint(unpriv.Gid, 10, 32)
+	if err != nil {
+		t.Fatalf("parse nobody GID %q: %v", unpriv.Gid, err)
+	}
+	unprivCred := &syscall.Credential{
+		Uid:    uint32(unprivUID64),
+		Gid:    uint32(unprivGID64),
+		Groups: []uint32{kukeonGID},
+	}
+
+	runPath := getRandomRunPath(t)
+	// Make the runPath traversable for the unprivileged caller. The
+	// per-container TTY inode already lands at 0o660 root:kukeon (via
+	// the chown plumbing in #911), but every parent dir on the path
+	// from / down to the socket symlink must grant search to the
+	// caller or connect(2) ENOENTs out before the EACCES race could
+	// surface. The kukeon-group operator on a real host reaches the
+	// symlink via `/opt/kukeon/s/<id>` which is created by the daemon
+	// at 0o755; per-test runPaths under /tmp inherit 0o700 from
+	// MkdirTemp, so an explicit relax is needed here.
+	if chmodErr := os.Chmod(runPath, 0o755); chmodErr != nil {
+		t.Fatalf("chmod runPath %s: %v", runPath, chmodErr)
+	}
+
+	host := startKukeondDaemonWithSocketGID(t, runPath, int(kukeonGID))
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+	cellName := generateUniqueCellName(t)
+
+	t.Cleanup(func() {
+		cleanupCellNoDaemon(t, runPath, realmName, spaceName, stackName, cellName)
+		cleanupStackNoDaemon(t, runPath, realmName, spaceName, stackName)
+		cleanupSpaceNoDaemon(t, runPath, realmName, spaceName)
+		cleanupRealmNoDaemon(t, runPath, realmName)
+	})
+
+	runReturningBinary(t, nil, kuke,
+		append(buildKukeDaemonArgs(host), "create", "realm", realmName)...)
+	runReturningBinary(t, nil, kuke,
+		append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)...)
+	runReturningBinary(t, nil, kuke,
+		append(buildKukeDaemonArgs(host), "create", "stack", stackName,
+			"--realm", realmName, "--space", spaceName)...)
+
+	// Apply the attachable cell (sleep workload) to drive it to Ready.
+	applyAttachableCell(t, host, "attachable-cell.yaml", realmName, spaceName, stackName, cellName)
+
+	socketPath := fs.ContainerSocketSymlinkPath(runPath,
+		realmName, spaceName, stackName, cellName, "work")
+	waitForSocket(t, socketPath, 10*time.Second)
+
+	// Relax search bits on `<runPath>/s/` after the runner has created
+	// the symlink dir — the daemon creates it as root with the default
+	// umask, which is too restrictive for `nobody` to traverse.
+	symlinkDir := fs.ContainerSocketSymlinkDir(runPath)
+	if chmodErr := os.Chmod(symlinkDir, 0o755); chmodErr != nil {
+		t.Fatalf("chmod symlink dir %s: %v", symlinkDir, chmodErr)
+	}
+
+	stopArgs := append(buildKukeDaemonArgs(host),
+		"stop", "cell", cellName,
+		"--realm", realmName,
+		"--space", spaceName,
+		"--stack", stackName,
+	)
+	runArgs := append(buildKukeDaemonArgs(host),
+		"run", cellName,
+		"--realm", realmName,
+		"--space", spaceName,
+		"--stack", stackName,
+		"--container", "work",
+	)
+
+	for iter := 0; iter < runFromStoppedRaceIterations; iter++ {
+		// Drop the cell into Stopped so the next `kuke run` re-enters
+		// the StartCell → attach branch (the path that races).
+		runReturningBinary(t, nil, kuke, stopArgs...)
+
+		session := startPTYWithCredential(t, nil, unprivCred, kuke, runArgs...)
+
+		// Wait long enough for `kuke run`'s in-process pkg/attach loop
+		// to either succeed (sbsh ≥ v0.12.1) or surface EACCES (sbsh
+		// ≤ v0.12.0). A v0.12.0 race returns the error immediately;
+		// a v0.12.1 healthy attach blocks on stdin until the detach
+		// keystroke arrives.
+		time.Sleep(runFromStoppedAttachGrace)
+		if writeErr := session.Write(sbshDetachSequence); writeErr != nil {
+			// Best-effort: a session that has already exited (race
+			// fired) closes the PTY master and returns an error here.
+			// Don't fail the test on the write — let Wait surface the
+			// real failure mode below.
+			t.Logf("iter %d: write detach sequence: %v (proceeding to Wait)", iter, writeErr)
+		}
+
+		exitCode, output, waitErr := session.Wait(runFromStoppedExitTimeout)
+		if waitErr != nil && exitCode == -1 {
+			session.Close()
+			t.Fatalf("iter %d: kuke run did not exit within %s: %v\noutput:\n%s",
+				iter, runFromStoppedExitTimeout, waitErr, output)
+		}
+		if exitCode != 0 {
+			session.Close()
+			t.Fatalf("iter %d: kuke run exited %d (want 0); sbsh#361 race may have re-opened\noutput:\n%s",
+				iter, exitCode, output)
+		}
+		if strings.Contains(strings.ToLower(string(output)), "permission denied") {
+			session.Close()
+			t.Fatalf("iter %d: kuke run output contains 'permission denied'; sbsh#361 race re-opened\noutput:\n%s",
+				iter, output)
+		}
+		if !strings.Contains(string(output), "containers: started") {
+			session.Close()
+			t.Fatalf("iter %d: kuke run output missing 'containers: started'\noutput:\n%s",
+				iter, output)
+		}
+		session.Close()
+	}
+
+	// Final assertion: the per-container kuketty socket inode lands
+	// at mode 0o660 with gid=kukeon. This is the steady-state
+	// post-chmod shape; if a regression silently dropped the chown
+	// or the chmod, the iterations above might still pass if they
+	// raced just right (root-owned 0o600 succeeds for the root
+	// daemon), but this stat would catch it.
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat work socket %s: %v", socketPath, err)
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Errorf("work socket mode: got %#o want 0o660", got)
+	}
+	sysStat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("work socket stat: unexpected Sys() type %T", info.Sys())
+	}
+	if sysStat.Gid != kukeonGID {
+		t.Errorf("work socket gid: got %d want %d (kukeon)", sysStat.Gid, kukeonGID)
+	}
+	if sysStat.Uid != 0 {
+		t.Errorf("work socket uid: got %d want 0 (root)", sysStat.Uid)
+	}
+}
+
+// startKukeondDaemonWithSocketGID is the kukeon-group-aware variant of
+// startKukeondDaemon. It passes `--socket-gid <gid>` so the daemon
+// applies socketModeGroupReadable (0o660 :kukeon) to its listener
+// inode, making the socket dial-able by a non-root caller in the
+// kukeon group — required for the privilege-dropped client side of
+// TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES. The rest of the
+// startup (SUN_PATH-safe sockDir, sync wait on the socket file,
+// SIGTERM-then-SIGKILL cleanup) mirrors startKukeondDaemon; this
+// helper exists rather than threading a variadic arg through the
+// default startKukeondDaemon because the kukeon-group path is the only
+// caller and a single-purpose helper is easier to read at the test
+// site.
+func startKukeondDaemonWithSocketGID(t *testing.T, runPath string, socketGID int) string {
+	t.Helper()
+
+	binDir := os.Getenv("E2E_BIN_DIR")
+	if binDir == "" {
+		binDir = ".."
+	}
+	bin := filepath.Join(binDir, "kukeond")
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Skipf("kukeond binary %s not found, skipping daemon-mode test", bin)
+	}
+
+	sockDir, err := os.MkdirTemp("/tmp", "kd-") //nolint:usetesting // intentional shorter prefix; see startKukeondDaemon
+	if err != nil {
+		t.Fatalf("MkdirTemp(/tmp, kd-): %v", err)
+	}
+	// The sockDir parent must grant search to the unprivileged caller
+	// so connect(2) can resolve the socket basename. The default
+	// MkdirTemp mode (0o700) blocks `nobody`.
+	if chmodErr := os.Chmod(sockDir, 0o755); chmodErr != nil {
+		_ = os.RemoveAll(sockDir)
+		t.Fatalf("chmod sockDir %s: %v", sockDir, chmodErr)
+	}
+	sockPath := filepath.Join(sockDir, "k.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, bin,
+		"serve",
+		"--socket", sockPath,
+		"--socket-gid", strconv.Itoa(socketGID),
+		"--run-path", runPath,
+		"--reconcile-interval", "0",
+		"--configuration", filepath.Join(runPath, "kukeond.yaml"),
+	)
+	logFile, logErr := os.CreateTemp("", "kukeond-*.log")
+	if logErr != nil {
+		cancel()
+		t.Fatalf("CreateTemp kukeond log: %v", logErr)
+	}
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	if startErr := cmd.Start(); startErr != nil {
+		cancel()
+		_ = logFile.Close()
+		_ = os.RemoveAll(sockDir)
+		t.Fatalf("start kukeond serve: %v", startErr)
+	}
+
+	exit := make(chan error, 1)
+	go func() { exit <- cmd.Wait() }()
+
+	deadline := time.NewTimer(daemonStartupTimeout)
+	defer deadline.Stop()
+	poll := time.NewTicker(50 * time.Millisecond)
+	defer poll.Stop()
+
+	started := false
+	for !started {
+		if _, statErr := os.Stat(sockPath); statErr == nil {
+			started = true
+			continue
+		}
+		select {
+		case waitErr := <-exit:
+			cancel()
+			logBytes, _ := os.ReadFile(logFile.Name())
+			_ = logFile.Close()
+			_ = os.Remove(logFile.Name())
+			_ = os.RemoveAll(sockDir)
+			t.Fatalf(
+				"kukeond exited before socket %s appeared (wait=%v); daemon log:\n%s",
+				sockPath, waitErr, string(logBytes),
+			)
+		case <-deadline.C:
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+			<-exit
+			cancel()
+			logBytes, _ := os.ReadFile(logFile.Name())
+			_ = logFile.Close()
+			_ = os.Remove(logFile.Name())
+			_ = os.RemoveAll(sockDir)
+			t.Fatalf(
+				"kukeond did not create socket %s within %s; daemon log:\n%s",
+				sockPath, daemonStartupTimeout, string(logBytes),
+			)
+		case <-poll.C:
+		}
+	}
+
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case <-exit:
+		case <-time.After(daemonShutdownTimeout):
+			_ = cmd.Process.Signal(syscall.SIGKILL)
+			<-exit
+		}
+		cancel()
+		_ = logFile.Close()
+		_ = os.Remove(logFile.Name())
+		_ = os.RemoveAll(sockDir)
+	})
+
+	return fmt.Sprintf("unix://%s", sockPath)
+}
+
+// startPTYWithCredential is the privilege-dropping variant of startPTY.
+// The child process is exec'd inside a fresh PTY with the given
+// SysProcAttr.Credential applied — used by
+// TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES to launch `kuke
+// run` as a kukeon-group non-root caller. creack/pty's StartWithSize
+// preserves any pre-set SysProcAttr fields and only adds Setsid /
+// Setctty, so the Credential survives the fork; the PTY master/slave
+// pair is opened by the test (root) and inherited as the child's
+// stdio, which side-steps the slave-open DAC check.
+func startPTYWithCredential(
+	t *testing.T,
+	env []string,
+	cred *syscall.Credential,
+	command string,
+	args ...string,
+) *ptySession {
+	t.Helper()
+
+	dir := os.Getenv("E2E_BIN_DIR")
+	if dir == "" {
+		dir = ".."
+	}
+	bin := filepath.Join(dir, command)
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Skipf("binary %s not found, skipping", bin)
+	}
+
+	cmd := exec.Command(bin, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: cred}
+
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty.Start %s as uid=%d gid=%d groups=%v: %v",
+			bin, cred.Uid, cred.Gid, cred.Groups, err)
+	}
+
+	s := &ptySession{
+		t:        t,
+		cmd:      cmd,
+		pty:      ptmx,
+		waitDone: make(chan error, 1),
+	}
+
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := ptmx.Read(buf)
+			if n > 0 {
+				s.mu.Lock()
+				s.out.Write(buf[:n])
+				s.mu.Unlock()
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		s.waitDone <- cmd.Wait()
+	}()
+
+	return s
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.12.0
+	github.com/eminwux/sbsh v0.12.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.12.0 h1:vnWA6SNGA+BQGF4NrTcmgMqY7l9WyOal8svvPo5FL8E=
-github.com/eminwux/sbsh v0.12.0/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
+github.com/eminwux/sbsh v0.12.1 h1:G+3Dfb8t3nWe0SP0a1Z6oFouU+kAVYNl2bU8a+yXEA0=
+github.com/eminwux/sbsh v0.12.1/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Summary

Closes #912.

- Bumps `github.com/eminwux/sbsh` from `v0.12.0` to `v0.12.1`. The upstream release ships eminwux/sbsh#362 (closes eminwux/sbsh#361), which closes the bind-then-chmod EACCES window in `OpenSocketCtrl` by setting the umask around `net.ListenConfig.Listen` so the socket inode is born at the configured mode rather than `0o666 & ~daemonUmask`. With the kukeon per-container TTY dir already `2750` `root:kukeon`, the setgid bit propagates the gid to the bound inode at bind time, so the dial as a kukeon-group non-root caller sees `0o660 root:kukeon` from the first packet — no follow-up chown race. `go.sum` refreshed via `go mod tidy`.

- Adds `TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES` in `e2e/e2e_kuke_attach_test.go` (peer of `TestKuke_AttachDetach_KeepsTaskRunning`). The test exercises the exact path that raced under v0.12.0 — a kukeon-group non-root caller invoking `kuke run` against a Stopped cell — and loops 20 iterations to catch the window even after the upstream fix narrowed it. Each iteration drops the cell into Stopped, launches `kuke run` via a real PTY with `SysProcAttr.Credential` swapping the child to `nobody:kukeon`, waits a 1s attach grace, then sends `Ctrl+]Ctrl+]` and asserts exit 0, no `permission denied` substring on the captured output, and the `containers: started` summary line. A final stat on the work container's symlink confirms steady-state mode `0o660 root:kukeon`. The test skips cleanly when run as non-root, when the host has no `kukeon` group (i.e. `kuke init` has not run), or when no `nobody` user is present.

### Divergence from issue body

The issue described the harness as already having "the group plumbed — see `harness_daemon_test.go`". It did not: `startKukeondDaemon` defaulted to `socketModeRootOnly` because no `--socket-gid` was passed, and `startPTY` did not accept a `*syscall.Credential`. Both gaps are filled here in two new helpers in `e2e_kuke_attach_test.go`:

- `startKukeondDaemonWithSocketGID(t, runPath, gid)` mirrors `startKukeondDaemon` but adds `--socket-gid` so the daemon listener inode lands at `0o660 :kukeon`. The per-test SUN_PATH-safe sockDir is also chmoded `0o755` so the unprivileged caller can traverse to the socket basename.
- `startPTYWithCredential(t, env, cred, command, args...)` mirrors `startPTY` but sets `cmd.SysProcAttr.Credential` so the PTY child exec's as `uid=nobody`, `gid=nobody`, `supplementary={kukeon}`. `creack/pty.Start` preserves pre-set `SysProcAttr` fields, so the credential survives the fork; the PTY master/slave pair is opened by the root test process and inherited as the child's stdio, side-stepping the slave-open DAC check.

The test also relaxes `runPath` and `<runPath>/s/` to `0o755` after the daemon creates them so the unprivileged caller can traverse the path chain to the symlink — the per-test `MkdirTemp` defaults to `0o700`, which would block `nobody` before the EACCES race could surface.

### Upstream→downstream chain

- Upstream issue: eminwux/sbsh#361 (closed)
- Upstream fix: eminwux/sbsh#362 (Option A: `runtime.LockOSThread` + `syscall.Umask` around `Listen`)
- Upstream release: eminwux/sbsh `v0.12.1`
- Downstream bump (this PR): `go.mod` `v0.12.0 → v0.12.1`
- Downstream regression test (this PR): `TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES`

### Out of scope (per issue)

- No CLI-side EACCES retry in `cmd/kuke/run/attach.go` — the race is fixed at the bind site upstream; a retry would mask the real bug.

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go vet ./...` — clean
- [x] `GOWORK=off go test -c -o /dev/null ./e2e/...` — e2e package compiles
- [x] `make test` — full unit suite passes (test-root + test-kukebuild)
- [x] `make dev-init` smoke — daemon-parity tail shows identical `default` / `kuke-system` Ready rows, attach smoke + nested-mode plumbing checks all green
- [ ] `make e2e` with kukeon group + nobody user present — runs the new `TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES` 20-iteration loop. The agent dev environment cannot exercise this (the e2e harness needs a built kukeon image plus `kuke init`-provisioned host); the test is written to skip cleanly outside that environment, so the e2e job on a CI runner with the standard host provisioning will be the first run of the new test.