### PR TITLE
fix(dev-init): sudo the reset gate + recreate kukeond on image digest drift (#915)

### DIFF
--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -740,11 +740,24 @@ func printCellActions(cmd *cobra.Command, section controller.CellSection, image 
 		// Image drift on a surviving cell record (issue #868). Surfacing the
 		// prior → desired transition is what tells the operator the rebuild
 		// actually picked up their `kuke build` output instead of silently
-		// restarting the stale container.
-		cmd.Println(fmt.Sprintf(
-			"    - cell %q: recreated (image drift: %s → %s)",
-			section.CellName, section.CellPriorImage, image,
-		))
+		// restarting the stale container. When the prior and desired refs
+		// match byte-for-byte but bootstrapCell still routed through
+		// RecreateCell, the trigger is a content digest swap on the same
+		// ref (issue #915 defect 2: `kuke build` re-pointed the same tag
+		// at fresh layers). The ref-string transition would render as
+		// "kukeon-local:dev → kukeon-local:dev" which says nothing; the
+		// digest-drift label is the readable form.
+		if section.CellPriorImage == image {
+			cmd.Println(fmt.Sprintf(
+				"    - cell %q: recreated (image digest drift on %s)",
+				section.CellName, image,
+			))
+		} else {
+			cmd.Println(fmt.Sprintf(
+				"    - cell %q: recreated (image drift: %s → %s)",
+				section.CellName, section.CellPriorImage, image,
+			))
+		}
 	case section.CellCreated:
 		cmd.Println(fmt.Sprintf("    - cell %q: created (image %s)", section.CellName, image))
 	default:

--- a/cmd/kuke/init/init_test.go
+++ b/cmd/kuke/init/init_test.go
@@ -500,6 +500,58 @@ func TestPrintCellActions(t *testing.T) {
 			section:  controller.CellSection{},
 			expected: []string{"- cell: not provisioned"},
 		},
+		{
+			// Ref-string drift renders "prior → desired" — the existing
+			// #868 path. The transition is informative because the two
+			// strings differ.
+			name: "recreated-image-ref-drift",
+			section: controller.CellSection{
+				CellName:                     "kukeond",
+				CellMetadataExistsPre:        true,
+				CellMetadataExistsPost:       true,
+				CellCgroupExistsPre:          true,
+				CellCgroupExistsPost:         true,
+				CellRootContainerExistsPre:   true,
+				CellRootContainerExistsPost:  true,
+				CellRootContainerCreated:     true,
+				CellStartedPre:               true,
+				CellStartedPost:              true,
+				CellRecreatedDueToImageDrift: true,
+				CellPriorImage:               "ghcr.io/eminwux/kukeon:v0.9.0",
+			},
+			image: "ghcr.io/eminwux/kukeon:v1.0.0",
+			expected: []string{
+				"- cell \"kukeond\": recreated (image drift: ghcr.io/eminwux/kukeon:v0.9.0 → ghcr.io/eminwux/kukeon:v1.0.0)",
+				"- cell root container: created",
+			},
+		},
+		{
+			// Digest drift on the same ref: prior image string equals
+			// desired so "prior → desired" would render the same string
+			// twice — useless to the operator. The dedicated "image
+			// digest drift on <ref>" message is the readable form for
+			// the #915 defect-2 path.
+			name: "recreated-image-digest-drift",
+			section: controller.CellSection{
+				CellName:                     "kukeond",
+				CellMetadataExistsPre:        true,
+				CellMetadataExistsPost:       true,
+				CellCgroupExistsPre:          true,
+				CellCgroupExistsPost:         true,
+				CellRootContainerExistsPre:   true,
+				CellRootContainerExistsPost:  true,
+				CellRootContainerCreated:     true,
+				CellStartedPre:               true,
+				CellStartedPost:              true,
+				CellRecreatedDueToImageDrift: true,
+				CellPriorImage:               "docker.io/library/kukeon-local:dev",
+			},
+			image: "docker.io/library/kukeon-local:dev",
+			expected: []string{
+				"- cell \"kukeond\": recreated (image digest drift on docker.io/library/kukeon-local:dev)",
+				"- cell root container: created",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/eminwux/sbsh v0.12.1
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.21.0
@@ -56,7 +57,6 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/onsi/ginkgo/v2 v2.25.1 // indirect
 	github.com/onsi/gomega v1.38.1 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/opencontainers/selinux v1.13.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -680,12 +680,38 @@ func (b *Exec) bootstrapCell(section *CellSection, cellDoc *v1beta1.CellDoc) err
 	// #868. The drift comparison is keyed on the canonical kukeond container
 	// ID; a missing match on either side counts as drift so a corrupted /
 	// partial cell record forces a recreate rather than a half-baked ensure.
+	//
+	// Layer 1 (#868): ref-string comparison — catches `kuke init` with a
+	// different --kukeond-image value against the persisted cell.
+	// Layer 2 (#915 defect 2): chainID comparison — catches the common
+	// `make dev-init` re-run case where the ref string is unchanged but
+	// `kuke build` re-pointed the same tag at fresh content. The ref-string
+	// match would otherwise mask the swap, and EnsureCell+StartCell would
+	// restart the same anchored snapshot.
 	imageDrift := false
 	if section.CellMetadataExistsPre {
 		section.CellPriorImage = lookupContainerImage(internalCellPre, consts.KukeSystemContainerName)
 		desiredImage := lookupContainerImage(cell, consts.KukeSystemContainerName)
-		if section.CellPriorImage != desiredImage {
+		switch {
+		case section.CellPriorImage != desiredImage:
 			imageDrift = true
+		case section.CellRootContainerExistsPre && desiredImage != "":
+			drifted, dErr := b.kukeondContainerImageDigestDrifted(cell, desiredImage)
+			if dErr != nil {
+				// A probe failure (containerd unreachable, image absent,
+				// snapshot key missing) is not fatal — fall through to
+				// the EnsureCell+StartCell path so init can still bring
+				// the daemon up. Surface the reason so an operator can
+				// diagnose if the next iteration also reports drift.
+				b.logger.WarnContext(b.ctx,
+					"image digest drift probe failed; falling through to existing-cell path",
+					"cell", cell.Metadata.Name,
+					"image", desiredImage,
+					"error", dErr,
+				)
+			} else if drifted {
+				imageDrift = true
+			}
 		}
 	}
 
@@ -783,6 +809,49 @@ func lookupContainerImage(cell intmodel.Cell, containerID string) string {
 		}
 	}
 	return ""
+}
+
+// kukeondContainerImageDigestDrifted reports whether the running kukeond
+// container's anchored snapshot chain differs from the chain the image at
+// the desired ref would unpack to today. The probe is only meaningful
+// after the ref-string comparison has returned equal — equal ref + diverging
+// chainID is exactly the shape `kuke build` re-pointing the same tag at
+// fresh content produces (issue #915 defect 2), and the verifier at
+// scripts/dev-init.sh:332-384 already encodes the equivalent shell-level
+// check post-init.
+//
+// A probe error (containerd unreachable, image absent, snapshot key
+// missing) returns drifted=false plus the wrapped error so the caller can
+// log and fall through — init must still be able to bring the daemon up
+// from a degraded inspect path; the ref-string-equal path was the
+// pre-issue-#915 default and is the safe fallback.
+func (b *Exec) kukeondContainerImageDigestDrifted(
+	cell intmodel.Cell, desiredImage string,
+) (bool, error) {
+	namespace := consts.RealmNamespace(cell.Spec.RealmName)
+	containerdID, err := naming.BuildContainerdID(
+		cell.Spec.SpaceName, cell.Spec.StackName, cell.Metadata.Name, consts.KukeSystemContainerName,
+	)
+	if err != nil {
+		return false, fmt.Errorf("build kukeond containerd id: %w", err)
+	}
+	containerChainID, err := b.runner.ContainerRootChainID(namespace, containerdID)
+	if err != nil {
+		return false, fmt.Errorf("read kukeond snapshot chain (%s/%s): %w", namespace, containerdID, err)
+	}
+	imageChainID, err := b.runner.ImageChainID(namespace, desiredImage)
+	if err != nil {
+		return false, fmt.Errorf("read image chain (%s/%s): %w", namespace, desiredImage, err)
+	}
+	// An empty chainID on either side means "no comparable identity" —
+	// e.g. an image with zero layers, or a snapshot the snapshotter
+	// reports with no parent. Treat as no drift so the existing-cell
+	// path still runs; the alternative would be perpetual recreate
+	// loops on edge-case content.
+	if containerChainID == "" || imageChainID == "" {
+		return false, nil
+	}
+	return containerChainID != imageChainID, nil
 }
 
 func (b *Exec) bootstrapCNI(report BootstrapReport) (BootstrapReport, error) {

--- a/internal/controller/bootstrap_cell_drift_test.go
+++ b/internal/controller/bootstrap_cell_drift_test.go
@@ -19,6 +19,7 @@
 package controller_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/consts"
@@ -292,5 +293,326 @@ func TestBootstrapCell_NoPriorMetadataCreatesFresh(t *testing.T) {
 	}
 	if section.CellRecreatedDueToImageDrift {
 		t.Errorf("CellSection.CellRecreatedDueToImageDrift = true; want false (no prior metadata)")
+	}
+}
+
+// TestBootstrapCell_DigestDriftRecreatesCell covers issue #915 defect 2:
+// a persisted kukeond cell whose root container's anchored snapshot chain
+// has diverged from what the same image ref would unpack to today (because
+// `kuke build` re-pointed the tag at fresh layers between init runs) must
+// be torn down and rebuilt — the ref-string match alone is the trap the
+// pre-issue path fell into, and EnsureCell+StartCell would restart the
+// stale anchored snapshot.
+func TestBootstrapCell_DigestDriftRecreatesCell(t *testing.T) {
+	const image = "docker.io/library/kukeon-local:dev"
+	// containerd chainID for the kukeond container's existing snapshot.
+	const priorChain = "sha256:700a21b4fa4c2000000000000000000000000000000000000000000000000000"
+	// containerd chainID the freshly built image would unpack to today.
+	const freshChain = "sha256:23bbde593a4b0000000000000000000000000000000000000000000000000000"
+	// The exact containerd ID the runner would derive for the kukeond
+	// container (BuildContainerdID(space, stack, cell, container)). Asserted
+	// against the runner-call args so a future rename in
+	// internal/util/naming surfaces here instead of silently breaking the
+	// digest-drift probe.
+	const wantContainerdID = "kukeon_kukeon_kukeond_kukeond"
+	const wantNamespace = "kuke-system.kukeon.io"
+
+	var (
+		recreateCalled        bool
+		recreateImage         string
+		ensureCalled          bool
+		gotContainerNamespace string
+		gotContainerdID       string
+		gotImageNamespace     string
+		gotImageRef           string
+		startCallCount        int
+		containerChainCalled  int
+		imageChainCalled      int
+	)
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return persistedKukeondCell(image), nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		ContainerRootChainIDFn: func(ns, id string) (string, error) {
+			containerChainCalled++
+			gotContainerNamespace = ns
+			gotContainerdID = id
+			return priorChain, nil
+		},
+		ImageChainIDFn: func(ns, ref string) (string, error) {
+			imageChainCalled++
+			gotImageNamespace = ns
+			gotImageRef = ref
+			return freshChain, nil
+		},
+		EnsureCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			ensureCalled = true
+			return intmodel.Cell{}, nil
+		},
+		RecreateCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			if len(c.Spec.Containers) > 0 {
+				recreateImage = c.Spec.Containers[0].Image
+			}
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCallCount++
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(image)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if containerChainCalled != 1 {
+		t.Errorf("ContainerRootChainID call count = %d; want 1", containerChainCalled)
+	}
+	if imageChainCalled != 1 {
+		t.Errorf("ImageChainID call count = %d; want 1", imageChainCalled)
+	}
+	if gotContainerNamespace != wantNamespace {
+		t.Errorf("ContainerRootChainID namespace = %q; want %q", gotContainerNamespace, wantNamespace)
+	}
+	if gotContainerdID != wantContainerdID {
+		t.Errorf("ContainerRootChainID containerd id = %q; want %q", gotContainerdID, wantContainerdID)
+	}
+	if gotImageNamespace != wantNamespace {
+		t.Errorf("ImageChainID namespace = %q; want %q", gotImageNamespace, wantNamespace)
+	}
+	if gotImageRef != image {
+		t.Errorf("ImageChainID ref = %q; want %q", gotImageRef, image)
+	}
+	if !recreateCalled {
+		t.Fatalf("RecreateCell must be called on digest drift; got Ensure=%v", ensureCalled)
+	}
+	if ensureCalled {
+		t.Errorf("EnsureCell must not be called on the digest-drift branch (would restart the stale snapshot)")
+	}
+	if recreateImage != image {
+		t.Errorf("RecreateCell received image %q; want %q (the desired --kukeond-image)", recreateImage, image)
+	}
+	if startCallCount != 0 {
+		t.Errorf(
+			"StartCell must not be called on the drift branch (RecreateCell runs it internally); got %d calls",
+			startCallCount,
+		)
+	}
+	if !section.CellRecreatedDueToImageDrift {
+		t.Errorf("CellSection.CellRecreatedDueToImageDrift = false; want true")
+	}
+	if section.CellPriorImage != image {
+		t.Errorf(
+			"CellSection.CellPriorImage = %q; want %q (refs match on the digest-drift path)",
+			section.CellPriorImage,
+			image,
+		)
+	}
+	if !section.CellRootContainerCreated {
+		t.Errorf("CellSection.CellRootContainerCreated = false; want true (drift recreate is a rebuild)")
+	}
+}
+
+// TestBootstrapCell_MatchingDigestEnsuresInPlace confirms that when the
+// chainIDs match (the only-cell-stale path is genuinely not in play), the
+// idempotent EnsureCell+StartCell branch still runs. This pins the
+// digest-drift probe down so a false-positive recreate never replaces a
+// healthy daemon container.
+func TestBootstrapCell_MatchingDigestEnsuresInPlace(t *testing.T) {
+	const image = "docker.io/library/kukeon-local:dev"
+	const chain = "sha256:aaaaaaaa00000000000000000000000000000000000000000000000000000000"
+
+	var (
+		recreateCalled bool
+		ensureCalled   bool
+		startCalled    bool
+	)
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return persistedKukeondCell(image), nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		ContainerRootChainIDFn: func(string, string) (string, error) {
+			return chain, nil
+		},
+		ImageChainIDFn: func(string, string) (string, error) {
+			return chain, nil
+		},
+		EnsureCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			ensureCalled = true
+			return c, nil
+		},
+		RecreateCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCalled = true
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(image)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if recreateCalled {
+		t.Errorf("RecreateCell must not be called when chainIDs match")
+	}
+	if !ensureCalled {
+		t.Errorf("EnsureCell must be called on the idempotent path")
+	}
+	if !startCalled {
+		t.Errorf("StartCell must be called on the idempotent path")
+	}
+	if section.CellRecreatedDueToImageDrift {
+		t.Errorf("CellSection.CellRecreatedDueToImageDrift = true; want false (chainIDs match)")
+	}
+}
+
+// TestBootstrapCell_DigestProbeFailureFallsThrough confirms that a probe
+// error (containerd hiccup, image missing, snapshotter unreachable) does
+// not abort the init — the fallback is the existing-cell EnsureCell path
+// so the daemon can still come up. The probe error is a soft signal, not
+// a hard fail; the daemon's reconciler will re-derive on the next tick.
+func TestBootstrapCell_DigestProbeFailureFallsThrough(t *testing.T) {
+	const image = "docker.io/library/kukeon-local:dev"
+
+	var (
+		recreateCalled bool
+		ensureCalled   bool
+		startCalled    bool
+	)
+	probeErr := errors.New("snapshotter unreachable")
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return persistedKukeondCell(image), nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		ContainerRootChainIDFn: func(string, string) (string, error) {
+			return "", probeErr
+		},
+		// ImageChainIDFn is not set: the ContainerRootChainID error path
+		// short-circuits and never reaches the image probe. A second stub
+		// would be unreachable — leave it unset so the default "no stub"
+		// path on fakeRunner.ImageChainID returns "" + nil. Either way the
+		// drift branch never fires.
+		EnsureCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			ensureCalled = true
+			return c, nil
+		},
+		RecreateCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCalled = true
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(image)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if recreateCalled {
+		t.Errorf("RecreateCell must not be called when the probe errored")
+	}
+	if !ensureCalled {
+		t.Errorf("EnsureCell must be called on probe-failure fallback")
+	}
+	if !startCalled {
+		t.Errorf("StartCell must be called on probe-failure fallback")
+	}
+	if section.CellRecreatedDueToImageDrift {
+		t.Errorf("CellSection.CellRecreatedDueToImageDrift = true; want false (probe failed, drift undecided)")
+	}
+}
+
+// TestBootstrapCell_DigestProbeSkippedWhenRootAbsent confirms the digest
+// probe never runs when the root container record is missing — the
+// CellMetadataExistsPre branch in bootstrapCell already routes through
+// EnsureCell+StartCell (which provisions a fresh container against the
+// desired image), so a chainID comparison would be against a non-existent
+// snapshot. The guard also keeps the runner calls off the hot path when
+// they cannot return a meaningful answer.
+func TestBootstrapCell_DigestProbeSkippedWhenRootAbsent(t *testing.T) {
+	const image = "docker.io/library/kukeon-local:dev"
+
+	var (
+		containerChainCalled int
+		imageChainCalled     int
+		ensureCalled         bool
+	)
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return persistedKukeondCell(image), nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return false, nil
+		},
+		ContainerRootChainIDFn: func(string, string) (string, error) {
+			containerChainCalled++
+			return "", nil
+		},
+		ImageChainIDFn: func(string, string) (string, error) {
+			imageChainCalled++
+			return "", nil
+		},
+		EnsureCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			ensureCalled = true
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(image)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if containerChainCalled != 0 {
+		t.Errorf(
+			"ContainerRootChainID must not be called when the root container is absent; got %d",
+			containerChainCalled,
+		)
+	}
+	if imageChainCalled != 0 {
+		t.Errorf("ImageChainID must not be called when the root container is absent; got %d", imageChainCalled)
+	}
+	if !ensureCalled {
+		t.Errorf("EnsureCell must run when the metadata exists but the root container does not")
+	}
+	if section.CellRecreatedDueToImageDrift {
+		t.Errorf("CellSection.CellRecreatedDueToImageDrift = true; want false (probe skipped)")
 	}
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -133,10 +133,12 @@ type fakeRunner struct {
 	ReconcileCellFn func(cell intmodel.Cell) (intmodel.Cell, runner.ReconcileOutcome, error)
 
 	// Image methods
-	LoadImageFn   func(namespace string, reader io.Reader) ([]string, error)
-	ListImagesFn  func(namespace string) ([]ctr.ImageInfo, error)
-	GetImageFn    func(namespace, ref string) (ctr.ImageInfo, error)
-	DeleteImageFn func(namespace, ref string) error
+	LoadImageFn            func(namespace string, reader io.Reader) ([]string, error)
+	ListImagesFn           func(namespace string) ([]ctr.ImageInfo, error)
+	GetImageFn             func(namespace, ref string) (ctr.ImageInfo, error)
+	ImageChainIDFn         func(namespace, ref string) (string, error)
+	ContainerRootChainIDFn func(namespace, containerID string) (string, error)
+	DeleteImageFn          func(namespace, ref string) error
 }
 
 // Realm methods
@@ -673,6 +675,24 @@ func (f *fakeRunner) GetImage(namespace, ref string) (ctr.ImageInfo, error) {
 		return f.GetImageFn(namespace, ref)
 	}
 	return ctr.ImageInfo{}, errors.New("unexpected call to GetImage")
+}
+
+func (f *fakeRunner) ImageChainID(namespace, ref string) (string, error) {
+	if f.ImageChainIDFn != nil {
+		return f.ImageChainIDFn(namespace, ref)
+	}
+	// Default to empty chainID + nil so bootstrapCell tests that don't
+	// exercise the digest-drift branch keep working with no extra stub.
+	return "", nil
+}
+
+func (f *fakeRunner) ContainerRootChainID(namespace, containerID string) (string, error) {
+	if f.ContainerRootChainIDFn != nil {
+		return f.ContainerRootChainIDFn(namespace, containerID)
+	}
+	// Default to empty chainID + nil for the same reason as ImageChainID:
+	// the drift comparison treats "both empty" as "no drift".
+	return "", nil
 }
 
 func (f *fakeRunner) DeleteImage(namespace, ref string) error {

--- a/internal/controller/runner/delete_cell_test.go
+++ b/internal/controller/runner/delete_cell_test.go
@@ -193,6 +193,15 @@ func (c *deleteCellFakeClient) ListImages(string) ([]ctr.ImageInfo, error) {
 func (c *deleteCellFakeClient) GetImage(string, string) (ctr.ImageInfo, error) {
 	return ctr.ImageInfo{}, nil
 }
+
+func (c *deleteCellFakeClient) ImageChainID(string, string) (string, error) {
+	return "", nil
+}
+
+func (c *deleteCellFakeClient) ContainerRootChainID(string, string) (string, error) {
+	return "", nil
+}
+
 func (c *deleteCellFakeClient) DeleteImage(string, string) error { return nil }
 
 var _ ctr.Client = (*deleteCellFakeClient)(nil)

--- a/internal/controller/runner/image.go
+++ b/internal/controller/runner/image.go
@@ -57,6 +57,52 @@ func (r *Exec) GetImage(namespace, ref string) (ctr.ImageInfo, error) {
 	return r.ctrClient.GetImage(namespace, ref)
 }
 
+// ImageChainID returns the chainID the image at ref would unpack to today
+// in the given containerd namespace. Issue #915 defect 2: bootstrapCell
+// uses this to detect that an image tag has been re-pointed since the
+// kukeond cell was created (so the persisted ContainerSpec.Image ref
+// matches the desired one but the underlying content has changed) and
+// route through RecreateCell instead of EnsureCell+StartCell, which would
+// otherwise re-start the stale image.
+//
+// errdefs.ErrImageNotFound is propagated unchanged so callers can use
+// errors.Is for not-found detection.
+func (r *Exec) ImageChainID(namespace, ref string) (string, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return "", errdefs.ErrCheckNamespaceExists
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", errdefs.ErrImageNotFound
+	}
+	if err := r.ensureClientConnected(); err != nil {
+		return "", fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+	return r.ctrClient.ImageChainID(namespace, ref)
+}
+
+// ContainerRootChainID returns the chainID the container's root snapshot
+// is anchored on at the moment of the call, paired with ImageChainID by
+// bootstrapCell to detect image digest drift (issue #915 defect 2).
+//
+// errdefs.ErrContainerNotFound is propagated unchanged so callers can use
+// errors.Is for not-found detection.
+func (r *Exec) ContainerRootChainID(namespace, containerID string) (string, error) {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return "", errdefs.ErrCheckNamespaceExists
+	}
+	containerID = strings.TrimSpace(containerID)
+	if containerID == "" {
+		return "", errdefs.ErrContainerNotFound
+	}
+	if err := r.ensureClientConnected(); err != nil {
+		return "", fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+	return r.ctrClient.ContainerRootChainID(namespace, containerID)
+}
+
 // DeleteImage removes the named image ref from the given containerd
 // namespace. errdefs.ErrImageNotFound is propagated unchanged so callers
 // can use errors.Is for not-found detection.

--- a/internal/controller/runner/provision_subtree_test.go
+++ b/internal/controller/runner/provision_subtree_test.go
@@ -186,6 +186,14 @@ func (c *subtreeRecorderClient) GetImage(string, string) (ctr.ImageInfo, error) 
 	panic("unexpected")
 }
 
+func (c *subtreeRecorderClient) ImageChainID(string, string) (string, error) {
+	panic("unexpected")
+}
+
+func (c *subtreeRecorderClient) ContainerRootChainID(string, string) (string, error) {
+	panic("unexpected")
+}
+
 func (c *subtreeRecorderClient) DeleteImage(string, string) error {
 	panic("unexpected")
 }

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -213,6 +213,18 @@ type Runner interface {
 	// ref is absent.
 	GetImage(namespace, ref string) (ctr.ImageInfo, error)
 
+	// ImageChainID returns the chainID the image at ref would unpack to
+	// today in the given containerd namespace. bootstrapCell pairs it
+	// with ContainerRootChainID to catch the case where the
+	// persisted ContainerSpec.Image ref matches the desired image but
+	// the underlying content has been re-pointed (issue #915 defect 2).
+	ImageChainID(namespace, ref string) (string, error)
+
+	// ContainerRootChainID returns the chainID the container's root
+	// snapshot is anchored on, regardless of what the image ref by the
+	// same name resolves to today (issue #915 defect 2).
+	ContainerRootChainID(namespace, containerID string) (string, error)
+
 	// DeleteImage removes the named image ref from the given containerd
 	// namespace. Returns errdefs.ErrImageNotFound when the ref is absent.
 	DeleteImage(namespace, ref string) error

--- a/internal/controller/runner/spec_hash_guard_test.go
+++ b/internal/controller/runner/spec_hash_guard_test.go
@@ -71,27 +71,45 @@ type specHashFakeClient struct {
 func (c *specHashFakeClient) Connect() error { return nil }
 func (c *specHashFakeClient) Close() error   { return nil }
 
-func (c *specHashFakeClient) CreateNamespace(string) error             { return nil }
-func (c *specHashFakeClient) DeleteNamespace(string) error             { return nil }
-func (c *specHashFakeClient) ListNamespaces() ([]string, error)        { return nil, nil }
-func (c *specHashFakeClient) GetNamespace(string) (string, error)      { return "", nil }
-func (c *specHashFakeClient) ExistsNamespace(string) (bool, error)     { return false, nil }
+func (c *specHashFakeClient) CreateNamespace(string) error         { return nil }
+func (c *specHashFakeClient) DeleteNamespace(string) error         { return nil }
+func (c *specHashFakeClient) ListNamespaces() ([]string, error)    { return nil, nil }
+func (c *specHashFakeClient) GetNamespace(string) (string, error)  { return "", nil }
+func (c *specHashFakeClient) ExistsNamespace(string) (bool, error) { return false, nil }
 func (c *specHashFakeClient) CleanupNamespaceResources(string, string) error {
 	return nil
 }
 
-func (c *specHashFakeClient) GetCgroupMountpoint() string                                { return "" }
-func (c *specHashFakeClient) GetCurrentCgroupPath() (string, error)                      { return "", nil }
-func (c *specHashFakeClient) CgroupPath(string, string) (string, error)                  { return "", nil }
-func (c *specHashFakeClient) NewCgroup(ctr.CgroupSpec) (*cgroup2.Manager, error)         { return nil, nil } //nolint:nilnil
-func (c *specHashFakeClient) LoadCgroup(string, string) (*cgroup2.Manager, error)        { return nil, nil } //nolint:nilnil
-func (c *specHashFakeClient) DeleteCgroup(string, string) error                          { return nil }
+func (c *specHashFakeClient) GetCgroupMountpoint() string               { return "" }
+func (c *specHashFakeClient) GetCurrentCgroupPath() (string, error)     { return "", nil }
+func (c *specHashFakeClient) CgroupPath(string, string) (string, error) { return "", nil }
+
+// NewCgroup / LoadCgroup return nil, nil — cgroup2.Manager has unexported
+// fields so a zero value satisfies *Exec call sites the spec-hash guard
+// path never exercises. The //nolint:nilnil mute is required because
+// nolintlint is configured with require-explanation in .golangci.yml.
+func (c *specHashFakeClient) NewCgroup(
+	ctr.CgroupSpec,
+) (*cgroup2.Manager, error) {
+	return nil, nil //nolint:nilnil // unused stub satisfying ctr.Client
+}
+
+func (c *specHashFakeClient) LoadCgroup(
+	string,
+	string,
+) (*cgroup2.Manager, error) {
+	return nil, nil //nolint:nilnil // unused stub satisfying ctr.Client
+}
+func (c *specHashFakeClient) DeleteCgroup(string, string) error { return nil }
+
 func (c *specHashFakeClient) EnsureSubtreeControllers(string, string, []string) ([]string, error) {
 	return nil, nil
 }
+
 func (c *specHashFakeClient) EnableCellSubtreeControllers(string, string, []string) ([]string, error) {
 	return nil, nil
 }
+
 func (c *specHashFakeClient) EnableCellAllSubtreeControllers(string, string) ([]string, error) {
 	return nil, nil
 }
@@ -102,6 +120,7 @@ func (c *specHashFakeClient) CreateContainerFromSpec(
 ) (containerd.Container, error) {
 	return nil, nil //nolint:nilnil
 }
+
 func (c *specHashFakeClient) CreateContainer(
 	string, ctr.ContainerSpec, []ctr.RegistryCredentials,
 ) (containerd.Container, error) {
@@ -122,20 +141,25 @@ func (c *specHashFakeClient) ExistsContainer(string, string) (bool, error) { ret
 func (c *specHashFakeClient) DeleteContainer(string, string, ctr.ContainerDeleteOptions) error {
 	return nil
 }
+
 func (c *specHashFakeClient) StartContainer(string, ctr.ContainerSpec, ctr.TaskSpec) (containerd.Task, error) {
 	return nil, nil //nolint:nilnil
 }
+
 func (c *specHashFakeClient) StopContainer(
 	string, string, ctr.StopContainerOptions,
 ) (*containerd.ExitStatus, error) {
 	return nil, nil //nolint:nilnil
 }
+
 func (c *specHashFakeClient) TaskStatus(string, string) (containerd.Status, error) {
 	return containerd.Status{}, nil
 }
+
 func (c *specHashFakeClient) TaskMetrics(string, string) (*apitypes.Metric, error) {
 	return nil, nil //nolint:nilnil
 }
+
 func (c *specHashFakeClient) ContainerProcessUID(string, containerd.Container) (uint32, error) {
 	return 0, nil
 }
@@ -144,7 +168,9 @@ func (c *specHashFakeClient) ListImages(string) ([]ctr.ImageInfo, error)    { re
 func (c *specHashFakeClient) GetImage(string, string) (ctr.ImageInfo, error) {
 	return ctr.ImageInfo{}, nil
 }
-func (c *specHashFakeClient) DeleteImage(string, string) error { return nil }
+func (c *specHashFakeClient) ImageChainID(string, string) (string, error)         { return "", nil }
+func (c *specHashFakeClient) ContainerRootChainID(string, string) (string, error) { return "", nil }
+func (c *specHashFakeClient) DeleteImage(string, string) error                    { return nil }
 
 var _ ctr.Client = (*specHashFakeClient)(nil)
 
@@ -229,7 +255,9 @@ func TestReuseOrRefuseExistingChildContainer_LegacyRecordReuses(t *testing.T) {
 		t.Fatalf("legacy record must not error; got %v", err)
 	}
 	if !reuse {
-		t.Errorf("legacy record (no kukeon.io/spec-hash label) must be treated as match (safe default for first post-upgrade restart); got reuse=false")
+		t.Errorf(
+			"legacy record (no kukeon.io/spec-hash label) must be treated as match (safe default for first post-upgrade restart); got reuse=false",
+		)
 	}
 }
 

--- a/internal/controller/runner/stop_kill_test.go
+++ b/internal/controller/runner/stop_kill_test.go
@@ -56,11 +56,11 @@ type stopKillFakeClient struct {
 func (c *stopKillFakeClient) Connect() error { return nil }
 func (c *stopKillFakeClient) Close() error   { return nil }
 
-func (c *stopKillFakeClient) CreateNamespace(string) error             { return nil }
-func (c *stopKillFakeClient) DeleteNamespace(string) error             { return nil }
-func (c *stopKillFakeClient) ListNamespaces() ([]string, error)        { return nil, nil }
-func (c *stopKillFakeClient) GetNamespace(string) (string, error)      { return "", nil }
-func (c *stopKillFakeClient) ExistsNamespace(string) (bool, error)     { return false, nil }
+func (c *stopKillFakeClient) CreateNamespace(string) error         { return nil }
+func (c *stopKillFakeClient) DeleteNamespace(string) error         { return nil }
+func (c *stopKillFakeClient) ListNamespaces() ([]string, error)    { return nil, nil }
+func (c *stopKillFakeClient) GetNamespace(string) (string, error)  { return "", nil }
+func (c *stopKillFakeClient) ExistsNamespace(string) (bool, error) { return false, nil }
 func (c *stopKillFakeClient) CleanupNamespaceResources(string, string) error {
 	return nil
 }
@@ -158,6 +158,15 @@ func (c *stopKillFakeClient) ListImages(string) ([]ctr.ImageInfo, error) {
 func (c *stopKillFakeClient) GetImage(string, string) (ctr.ImageInfo, error) {
 	return ctr.ImageInfo{}, nil
 }
+
+func (c *stopKillFakeClient) ImageChainID(string, string) (string, error) {
+	return "", nil
+}
+
+func (c *stopKillFakeClient) ContainerRootChainID(string, string) (string, error) {
+	return "", nil
+}
+
 func (c *stopKillFakeClient) DeleteImage(string, string) error { return nil }
 
 var _ ctr.Client = (*stopKillFakeClient)(nil)

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -139,6 +139,23 @@ type Client interface {
 	// the ref is absent.
 	GetImage(namespace, ref string) (ImageInfo, error)
 
+	// ImageChainID returns the chainID the image at ref would unpack to
+	// today, computed from the current rootfs DiffIDs in the namespace's
+	// content store. Pair with ContainerRootChainID to detect that an
+	// image tag has been re-pointed since a container was created (the
+	// digest-drift signal missing from bootstrapCell's image comparison
+	// in issue #915 defect 2). Returns errdefs.ErrImageNotFound if the
+	// ref is absent.
+	ImageChainID(namespace, ref string) (string, error)
+
+	// ContainerRootChainID returns the chainID of the parent layer stack
+	// the container's root snapshot was committed against — i.e. the
+	// image content the container is anchored on at the moment of the
+	// call, regardless of what the image ref by the same name resolves
+	// to today. Returns errdefs.ErrContainerNotFound if the container is
+	// absent.
+	ContainerRootChainID(namespace, containerID string) (string, error)
+
 	// DeleteImage removes the named image ref from the specified
 	// containerd namespace. Returns errdefs.ErrImageNotFound if the ref
 	// is absent so callers can distinguish missing from operational

--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -23,9 +23,11 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/leases"
+	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
 	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/opencontainers/image-spec/identity"
 )
 
 // ImageInfo is the ctr-layer view of a containerd image. The fields are the
@@ -266,6 +268,78 @@ func (c *client) DeleteImage(namespace, ref string) error {
 		return fmt.Errorf("%w: %w", internalerrdefs.ErrDeleteImage, err)
 	}
 	return nil
+}
+
+// ImageChainID returns the chainID the image at ref would unpack to today,
+// computed from its current rootfs DiffIDs in the namespace's content store.
+// The chainID is the canonical content-addressed identity of the layer
+// stack a fresh container would be anchored on, so a difference between
+// this value and a container's existing snapshot Parent is a precise
+// signal that the image at ref has been re-pointed since the container
+// was created (the digest-drift signal #915 defect 2 was missing).
+//
+// Returns internalerrdefs.ErrImageNotFound when ref is absent in
+// namespace (matches GetImage's not-found mapping so upper layers stay
+// uniform); operational failures wrap internalerrdefs.ErrGetImage.
+func (c *client) ImageChainID(namespace, ref string) (string, error) {
+	nsCtx := c.namespaceCtx(namespace)
+
+	img, err := c.conn().GetImage(nsCtx, ref)
+	if err != nil {
+		if errdefs.IsNotFound(err) {
+			return "", fmt.Errorf("%w: %s", internalerrdefs.ErrImageNotFound, ref)
+		}
+		return "", fmt.Errorf("%w: %w", internalerrdefs.ErrGetImage, err)
+	}
+
+	diffIDs, err := img.RootFS(nsCtx)
+	if err != nil {
+		return "", fmt.Errorf("%w: rootfs for %s: %w", internalerrdefs.ErrGetImage, ref, err)
+	}
+	if len(diffIDs) == 0 {
+		return "", nil
+	}
+	return identity.ChainID(diffIDs).String(), nil
+}
+
+// ContainerRootChainID returns the chainID of the parent layer stack the
+// container's root snapshot was committed against — i.e. the image content
+// the container is anchored on at the moment of the call, regardless of
+// what the image ref by the same name resolves to today. Returned as a
+// string so callers comparing it against ImageChainID (issue #915 defect
+// 2) need no third-party type.
+//
+// The snapshotter key defaults to the container's ID (see container.go
+// CreateContainerFromSpec, which falls back to spec.ID when SnapshotKey is
+// unset); we honor the explicit field too in case a future caller customizes
+// it. Returns internalerrdefs.ErrContainerNotFound when the container is
+// absent in namespace.
+func (c *client) ContainerRootChainID(namespace, containerID string) (string, error) {
+	container, err := c.loadContainer(namespace, containerID)
+	if err != nil {
+		return "", err
+	}
+
+	nsCtx := c.namespaceCtx(namespace)
+	info, err := container.Info(nsCtx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get container info for %s: %w", containerID, err)
+	}
+
+	snapshotKey := info.SnapshotKey
+	if snapshotKey == "" {
+		snapshotKey = containerID
+	}
+	snapshotter := info.Snapshotter
+	if snapshotter == "" {
+		snapshotter = defaults.DefaultSnapshotter
+	}
+
+	snapInfo, err := c.conn().SnapshotService(snapshotter).Stat(nsCtx, snapshotKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat snapshot %s/%s: %w", snapshotter, snapshotKey, err)
+	}
+	return snapInfo.Parent, nil
 }
 
 // imageToInfo extracts the ImageInfo subset from a containerd Image. Size is

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -283,7 +283,16 @@ if [ ! -d "${SYSTEM_REALM_DIR}" ]; then
         || echo "first-pass init returned non-zero (expected before image is staged); continuing"
 fi
 
-if [ -d "${KUKEOND_CELL_DIR}" ]; then
+# sudo the directory test: after the post-init permission fix sets
+# /opt/kukeon to root:kukeon 0o2750, an invoking user not in the
+# kukeon group cannot traverse the tree and the unprivileged `[ -d ]`
+# test returns false even when the cell dir exists — silently skipping
+# reset on every re-run (issue #915 defect 1). Every other access to
+# KUKEOND_CELL_DIR in this script is already sudo'd; the gate must be
+# too. The matching `[ ! -d "${SYSTEM_REALM_DIR}" ]` probe at line 272
+# is the same anti-pattern but doesn't bite today — its first-pass init
+# is idempotent on a pre-bootstrapped host.
+if sudo test -d "${KUKEOND_CELL_DIR}"; then
     step "Reset prior kukeond cell"
     sudo --preserve-env="${PRESERVE_ENV_ADMIN}" ./kuke daemon reset \
         "${SERVER_CONFIG_FLAGS[@]}"


### PR DESCRIPTION
## Summary

Two defects exposed in #915 — both leave \`make dev-init\` shipping a stale daemon container after a re-run.

**Defect 1 — \`scripts/dev-init.sh\` reset gate is permission-blocked.** The \`[ -d \"\${KUKEOND_CELL_DIR}\" ]\` test ran unprivileged, but after the first \`kuke init\` the post-init permission fix sets \`/opt/kukeon\` to \`root:kukeon 0o2750\`. Any contributor not in the \`kukeon\` group can no longer traverse the tree, the test returns false, and every adjacent \`sudo --preserve-env=... ./kuke daemon reset\` call is silently skipped. Switched to \`sudo test -d\` to match every other access in the script. The sibling \`[ ! -d \"\${SYSTEM_REALM_DIR}\" ]\` probe at line 272 is the same anti-pattern but doesn't bite today because the first-pass init is idempotent on a pre-bootstrapped host — left alone per the issue's lower-blast-radius default.

**Defect 2 — \`bootstrapCell\` only compared image *ref strings*.** When \`kuke build\` re-points the same tag (\`kukeon-local:dev\`) at a new manifest, the persisted \`ContainerSpec.Image\` string still matches the desired \`--kukeond-image\` value. The existing #868 drift check returned equal, the existing-cell \`EnsureCell+StartCell\` path ran, and the daemon container kept its stale anchored snapshot. Extended \`bootstrapCell\`'s drift detection: when the ref strings match *and* the root container exists, query containerd for (a) the chainID the image at the ref would unpack to today and (b) the chainID the container's snapshot is anchored on. If they differ the existing \`RecreateCell\` path runs — the verifier #857 added (snapshot-chain comparison at \`scripts/dev-init.sh:332-384\`) already encoded the equivalent check, but only post-init; this lifts the same signal into \`kuke init\` so the swap happens before the verifier fires. Probe failures (containerd hiccup, image absent, snapshot key missing) fall through with a logged WARN so init is never gated on a transient inspect failure.

The two-layer fix matches the issue's suggested-fix structure. \`CellRecreatedDueToImageDrift\` is reused for both ref-drift and digest-drift; \`printCellActions\` now branches on \`CellPriorImage == image\` to render \"image digest drift on \<ref\>\" instead of the misleading \"\<ref\> → \<ref\>\".

New ctr/runner surface: \`ImageChainID(namespace, ref)\` returns the chainID via \`image.RootFS\` + \`identity.ChainID\`; \`ContainerRootChainID(namespace, containerID)\` returns the snapshot's Parent via \`container.Info\` + \`snapshotter.Stat\`. Five \`ctr.Client\` fakes in the runner test package got the same null stubs.

## Test plan

- [x] \`make test-root\` — all packages pass, including the four new \`TestBootstrapCell_Digest*\` / \`TestBootstrapCell_MatchingDigest*\` cases and the two new \`TestPrintCellActions\` subtests.
- [x] \`make test-kukebuild\` — passes.
- [x] \`pre-commit run --files \$(git diff --name-only HEAD)\` — go-fmt, go-mod-tidy, golangci-lint all green.
- [x] \`make dev-init\` end-to-end on this host (user \`inwx\` not in \`kukeon\` group, \`/opt/kukeon\` 0o2750). The reset gate fired (\`cell \"kukeond\": created\` instead of \"already existed\"), kukeond came up at \`unix:///run/kukeon/kukeond.sock\`, the post-init snapshot-chain verifier matched, and the daemon-parity tail printed identical \`-o wide\` / \`--no-daemon\` output. The downstream \`kuke attach\` smoke (\`cattach\`) fails on this host with an unrelated \`parent snapshot ... not found\` against \`registry.eminwux.com/busybox:latest\` — pre-existing environmental issue, not regressed by this change.
- [x] Reproduced defect 1 conditions: unprivileged \`[ -d /opt/kukeon/data/kuke-system/kukeon/kukeon/kukeond ]\` → false; \`sudo test -d ...\` → true. Confirmed the fix takes the reset branch.

Closes #915