### PR TITLE
fix(kuketty): apply socket mode+GID at bind to close pre-Serve EACCES window

### DIFF
--- a/cmd/kuke/apply/testdata/attachable-cell-required-repo-unresolvable.yaml
+++ b/cmd/kuke/apply/testdata/attachable-cell-required-repo-unresolvable.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: test-cell
+spec:
+  id: test-cell
+  realmId: test-realm
+  spaceId: test-space
+  stackId: test-stack
+  containers:
+    - id: root
+      root: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: work
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+      attachable: true
+      # Required repo with an unresolvable hostname (RFC 6761 reserves
+      # .invalid for tests). kuketty's processRepos will fail and the
+      # workload task will go to Failed — but the per-container kuketty
+      # control socket is born inside claimSocketListener *before*
+      # processRepos runs. Issue #916 locks that the socket lands at
+      # 0o660 :kukeon at bind time, not deferred to sbshserver.Serve.
+      repos:
+        - name: unresolvable
+          target: /tmp/never-cloned
+          url: http://kukeon-test.invalid/never-exists.git
+          required: true

--- a/cmd/kuketty/main.go
+++ b/cmd/kuketty/main.go
@@ -40,11 +40,14 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
+	"sync"
 	"syscall"
 
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	sbshlogging "github.com/eminwux/sbsh/pkg/logging"
 	sbshserver "github.com/eminwux/sbsh/pkg/terminal/server"
+	"golang.org/x/sys/unix"
 )
 
 // defaultConfigPath is the fixed in-container path of the kukeond-rendered
@@ -124,7 +127,7 @@ func run(args []string) error {
 		return err
 	}
 
-	listener, err := claimSocketListener(spec.SocketFile)
+	listener, err := claimSocketListener(ctx, spec.SocketFile, spec.SocketMode, spec.SocketGID)
 	if err != nil {
 		return err
 	}
@@ -251,20 +254,93 @@ func openTerminalLogger(logfile, loglevel string) (*slog.Logger, func(), error) 
 	return fl.Logger, func() { _ = fl.File.Close() }, nil
 }
 
+// defaultSocketMode is the legacy owner-only mode applied when the spec
+// leaves SocketMode at its zero value. Mirrors sbsh's terminalrunner
+// defaultSocketMode so the two paths land at the same on-disk perms.
+const defaultSocketMode os.FileMode = 0o600
+
+// listenerUmaskMu serializes the umask save/set/Listen/restore sequence
+// in claimSocketListener against in-process concurrent callers. umask(2)
+// is process-wide (it lives in the kernel's shared fs_struct on Linux),
+// so two concurrent claims without this mutex could observe each other's
+// temporary umask. The mutex does not isolate the brief Listen window
+// from file creations in *other* packages that share this process —
+// that's an inherent cost of using umask to plug the bind-then-chmod
+// EACCES window. Mirrors sbsh's listenerUmaskMu rationale.
+//
+//nolint:gochecknoglobals // process-wide invariant guard, like the umask it serializes
+var listenerUmaskMu sync.Mutex
+
 // claimSocketListener removes any stale inode at the spec'd socket path
 // (a previous crash on the same in-container path would otherwise hit
-// EADDRINUSE on the first Listen) and binds a fresh listener. The
-// returned listener is owned by the caller — sbsh's server facade closes
-// it during shutdown via its underlying runner.
-func claimSocketListener(socketPath string) (net.Listener, error) {
+// EADDRINUSE on the first Listen) and binds a fresh listener at the
+// configured mode + group.
+//
+// The bind runs under a temporary umask of ^mode & 0o777 (with
+// runtime.LockOSThread) so the inode is born at mode and there is no
+// window during which a group-member client dialing the socket hits
+// EACCES because the daemon's umask masked off group access. A belt-
+// and-braces os.Chmod + os.Chown follow immediately so the on-disk
+// perms are correct even on the unlikely path where Listen returned
+// before the umask took effect. Mirrors sbsh's listenUnixWithMode +
+// applySocketPerms recipe (sbsh@v0.12.1/internal/terminal/terminalrunner/
+// sockets.go), which the sbsh-side facade only applies later inside
+// UseListener → bringUp — i.e. after kuketty's pre-Serve work
+// (processRepos, processStages) has already run, reopening the same
+// EACCES window for the duration of that work and indefinitely if
+// either pre-Serve step fails. Issue #916.
+//
+// mode == 0 falls back to defaultSocketMode so callers can pass the
+// raw spec field through without a guard. gid == nil leaves the
+// group unchanged (typical when no kukeon group is configured;
+// buildTerminalSpec already gates WithSocketGID on a non-zero GID).
+// The chown form is Chown(path, -1, gid) so the listener's uid stays
+// the owner; only the group is rewritten.
+//
+// The returned listener is owned by the caller — sbsh's server facade
+// closes it during shutdown via its underlying runner.
+func claimSocketListener(ctx context.Context, socketPath string, mode os.FileMode, gid *int) (net.Listener, error) {
 	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return nil, fmt.Errorf("remove stale socket %s: %w", socketPath, err)
 	}
-	l, err := net.Listen("unix", socketPath)
+	if mode == 0 {
+		mode = defaultSocketMode
+	}
+	l, err := listenUnixWithMode(ctx, socketPath, mode)
 	if err != nil {
 		return nil, fmt.Errorf("listen on %s: %w", socketPath, err)
 	}
+	if chmodErr := os.Chmod(socketPath, mode); chmodErr != nil {
+		_ = l.Close()
+		return nil, fmt.Errorf("chmod socket %s: %w", socketPath, chmodErr)
+	}
+	if gid != nil {
+		if chownErr := os.Chown(socketPath, -1, *gid); chownErr != nil {
+			_ = l.Close()
+			return nil, fmt.Errorf("chown socket %s: %w", socketPath, chownErr)
+		}
+	}
 	return l, nil
+}
+
+// listenUnixWithMode binds an AF_UNIX listener with the process umask
+// temporarily set so the socket inode is born at the configured mode,
+// not at (0o666 & ~processUmask). Mirrors sbsh's listenUnixWithMode
+// (sbsh@v0.12.1/internal/terminal/terminalrunner/sockets.go).
+//
+// runtime.LockOSThread pins the goroutine so the save/restore sequence
+// runs on a single OS thread; listenerUmaskMu serializes the temporary
+// umask against in-process concurrent callers.
+func listenUnixWithMode(ctx context.Context, socketPath string, mode os.FileMode) (net.Listener, error) {
+	listenerUmaskMu.Lock()
+	defer listenerUmaskMu.Unlock()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	//nolint:mnd // 0o777 is the standard permission-bit mask for umask(2)
+	prev := unix.Umask(int(^mode & 0o777))
+	defer unix.Umask(prev)
+	var lc net.ListenConfig
+	return lc.Listen(ctx, "unix", socketPath)
 }
 
 // isCleanShutdown reports whether the server.Serve terminating cause

--- a/cmd/kuketty/main_test.go
+++ b/cmd/kuketty/main_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -184,7 +185,7 @@ func TestClaimSocketListener_BindsAndUnlinksStale(t *testing.T) {
 	if err := os.WriteFile(sock, nil, 0o600); err != nil {
 		t.Fatalf("pre-create stale: %v", err)
 	}
-	l, err := claimSocketListener(sock)
+	l, err := claimSocketListener(context.Background(), sock, 0, nil)
 	if err != nil {
 		t.Fatalf("claimSocketListener: %v", err)
 	}
@@ -196,6 +197,75 @@ func TestClaimSocketListener_BindsAndUnlinksStale(t *testing.T) {
 	}
 	if info.Mode()&os.ModeSocket == 0 {
 		t.Errorf("path %s is not a socket: mode=%v", sock, info.Mode())
+	}
+}
+
+// TestClaimSocketListener_AppliesModeAndGID locks the bug fix for issue
+// #916: the on-disk socket mode and group must reflect the configured
+// SocketMode + SocketGID immediately after the helper returns —
+// *before* any sbsh involvement. Pre-fix, the inode was born at
+// 0o777 & ~umask (typically 0o755 under the container's 0o022 umask)
+// and stayed there for the duration of processRepos + processStages,
+// reopening the EACCES window for any group-member client that dialed
+// after the daemon reported "containers: started" but before
+// sbshserver.Serve ran applySocketPerms. The fix binds under a
+// temporary umask matching the spec mode and follows with
+// belt-and-braces chmod + chown so the socket is dial-ready by
+// matching peers the instant Listen returns.
+//
+// The test runs against the process's own primary GID so it does not
+// need elevated privileges. The umask path normally gets us there;
+// the explicit chmod is the belt that backs it up.
+func TestClaimSocketListener_AppliesModeAndGID(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "socket")
+	gid := os.Getgid()
+	mode := os.FileMode(0o660)
+
+	l, err := claimSocketListener(context.Background(), sock, mode, &gid)
+	if err != nil {
+		t.Fatalf("claimSocketListener: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	info, err := os.Stat(sock)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("path %s is not a socket: mode=%v", sock, info.Mode())
+	}
+	if got := info.Mode().Perm(); got != mode {
+		t.Errorf("socket mode = %#o, want %#o", got, mode)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("stat.Sys() not *syscall.Stat_t: %T", info.Sys())
+	}
+	if int(stat.Gid) != gid {
+		t.Errorf("socket gid = %d, want %d", stat.Gid, gid)
+	}
+}
+
+// TestClaimSocketListener_NilGIDLeavesGroupUnchanged exercises the
+// no-kukeon-group path: when SocketGID is nil (the cell has no
+// kukeon group configured, mirroring buildTerminalSpec's gate on a
+// non-zero GID), the helper must not chown. mode still applies — the
+// owner-only 0o600 default lands when the caller passes a zero mode.
+func TestClaimSocketListener_NilGIDLeavesGroupUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "socket")
+	l, err := claimSocketListener(context.Background(), sock, 0, nil)
+	if err != nil {
+		t.Fatalf("claimSocketListener: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	info, err := os.Stat(sock)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("socket mode = %#o, want 0o600 (defaultSocketMode)", got)
 	}
 }
 

--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -666,6 +666,118 @@ func TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES(t *testing.T) {
 	}
 }
 
+// TestKuke_RunFromStopped_RequiredRepoUnresolvable_NoEACCES locks issue
+// #916: kuketty's claimSocketListener must apply the configured mode +
+// GID at bind time, *before* sbshserver.Serve runs applySocketPerms.
+// sbsh v0.12.1 (issue #912 / sbsh#361) closed the bind→chmod window
+// inside its own OpenSocketCtrl, but kuketty pre-binds via
+// claimSocketListener and hands the listener to sbsh through
+// UseListener — sbsh's UseListener → bringUp → applySocketPerms only
+// fires inside sbshserver.Serve, after kuketty's pre-Serve work
+// (processRepos #617, processStages #635) has already run. Pre-fix,
+// the socket lived at 0o777 & ~umask (typically 0o755 under the
+// container's 0o022 umask) for the entire pre-Serve window, so a
+// kukeon-group operator dialing the socket after the daemon reported
+// "containers: started" — exactly what `kuke run` does against a
+// Stopped cell — saw EACCES.
+//
+// The cell fixture declares a required=true repo with an unresolvable
+// hostname (RFC 6761 reserves .invalid). DNS yields NXDOMAIN, git
+// clone fails, kuketty exits non-zero in processRepos — but the
+// socket inode is born inside claimSocketListener *before*
+// processRepos runs. The test polls for the socket to appear (the
+// bind happens) and stats it immediately. With the fix, mode is
+// 0o660 and group is kukeon — the on-disk shape that admits a
+// kukeon-group dial during the pre-Serve window. Pre-fix, this stat
+// would show 0o755 group=kukeon (group ownership came from the SGID
+// parent dir, mode was wrong).
+//
+// Preconditions mirror TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES
+// (euid 0, kukeon system group present). The test does not need a
+// privilege-dropped client because asserting the inode mode/gid
+// directly is a stronger and more deterministic signal than racing a
+// dial against the brief pre-Serve window.
+func TestKuke_RunFromStopped_RequiredRepoUnresolvable_NoEACCES(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for kukeon-group --socket-gid daemon mode")
+	}
+
+	kukeonGrp, err := user.LookupGroup(consts.KukeonSystemGroup)
+	if err != nil {
+		t.Skipf("kukeon system group %q not present on host (run `kuke init` first): %v",
+			consts.KukeonSystemGroup, err)
+	}
+	kukeonGID64, err := strconv.ParseUint(kukeonGrp.Gid, 10, 32)
+	if err != nil {
+		t.Fatalf("parse kukeon GID %q: %v", kukeonGrp.Gid, err)
+	}
+	kukeonGID := uint32(kukeonGID64)
+
+	runPath := getRandomRunPath(t)
+	if chmodErr := os.Chmod(runPath, 0o755); chmodErr != nil {
+		t.Fatalf("chmod runPath %s: %v", runPath, chmodErr)
+	}
+
+	host := startKukeondDaemonWithSocketGID(t, runPath, int(kukeonGID))
+
+	realmName := generateUniqueRealmName(t)
+	spaceName := generateUniqueSpaceName(t)
+	stackName := generateUniqueStackName(t)
+	cellName := generateUniqueCellName(t)
+
+	t.Cleanup(func() {
+		cleanupCellNoDaemon(t, runPath, realmName, spaceName, stackName, cellName)
+		cleanupStackNoDaemon(t, runPath, realmName, spaceName, stackName)
+		cleanupSpaceNoDaemon(t, runPath, realmName, spaceName)
+		cleanupRealmNoDaemon(t, runPath, realmName)
+	})
+
+	runReturningBinary(t, nil, kuke,
+		append(buildKukeDaemonArgs(host), "create", "realm", realmName)...)
+	runReturningBinary(t, nil, kuke,
+		append(buildKukeDaemonArgs(host), "create", "space", spaceName, "--realm", realmName)...)
+	runReturningBinary(t, nil, kuke,
+		append(buildKukeDaemonArgs(host), "create", "stack", stackName,
+			"--realm", realmName, "--space", spaceName)...)
+
+	applyAttachableCell(t, host, "attachable-cell-required-repo-unresolvable.yaml",
+		realmName, spaceName, stackName, cellName)
+
+	socketPath := fs.ContainerSocketSymlinkPath(runPath,
+		realmName, spaceName, stackName, cellName, "work")
+
+	// Poll for the socket to appear. kuketty binds it inside
+	// claimSocketListener — the moment the post-#916 bind site applies
+	// mode + gid — *before* entering processRepos. The unresolvable
+	// .invalid host yields NXDOMAIN quickly, so kuketty exits within a
+	// second or two; the wait+stat loop succeeds the first iteration
+	// the bind completes, which is well before that exit.
+	waitForSocket(t, socketPath, 15*time.Second)
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat work socket %s during pre-Serve window: %v", socketPath, err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("path %s is not a socket: mode=%v", socketPath, info.Mode())
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Errorf("pre-Serve work socket mode: got %#o want 0o660 — #916 race re-opened",
+			got)
+	}
+	sysStat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("work socket stat: unexpected Sys() type %T", info.Sys())
+	}
+	if sysStat.Gid != kukeonGID {
+		t.Errorf("pre-Serve work socket gid: got %d want %d (kukeon) — #916 race re-opened",
+			sysStat.Gid, kukeonGID)
+	}
+	if sysStat.Uid != 0 {
+		t.Errorf("pre-Serve work socket uid: got %d want 0 (root)", sysStat.Uid)
+	}
+}
+
 // startKukeondDaemonWithSocketGID is the kukeon-group-aware variant of
 // startKukeondDaemon. It passes `--socket-gid <gid>` so the daemon
 // applies socketModeGroupReadable (0o660 :kukeon) to its listener

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.21.0
+	golang.org/x/sys v0.39.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -78,7 +79,6 @@ require (
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/net v0.48.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect


### PR DESCRIPTION
## Summary

- `cmd/kuketty/main.go` `claimSocketListener` now applies the configured `SocketMode` + `SocketGID` at bind time (umask-controlled `net.Listen` plus belt-and-braces `os.Chmod` / `os.Chown`), so the per-container kuketty control socket is born at the operator-visible mode and group instead of deferring those perms to `sbshserver.Serve → bringUp → applySocketPerms` later in the boot path.
- Closes the EACCES window a kukeon-group non-root operator hit when `kuke run`'s daemon-side `StartCell` returned "containers: started" while kuketty was still inside the pre-Serve work — `processRepos` (#617) or `processStages` (#635) — and the host client dialed the socket before sbsh's chmod landed. With a `required=true` repo that fails DNS, kuketty exits in `processRepos` and `sbshserver.New` is never reached, so the pre-fix code left the socket at `0o755` for its entire lifetime; with healthy DNS it was the same race but over a shorter window. Distinct from #912 / sbsh#361 (closed by #913 / sbsh v0.12.1) — that fix lives inside sbsh's `OpenSocketCtrl`, which kuketty does not use (kuketty pre-binds and hands the listener to sbsh via `UseListener`).
- Mirrors sbsh's `listenUnixWithMode` recipe (`runtime.LockOSThread` + process-wide `listenerUmaskMu` around a temporary `unix.Umask(^mode & 0o777)`), so the late `applySocketPerms` inside `Serve` becomes an idempotent re-chmod — both paths land at the same on-disk perms.

Closes #916

## Test plan

- [x] `cmd/kuketty/` unit tests — `TestClaimSocketListener_AppliesModeAndGID` asserts `0o660` + configured GID on the inode immediately after the helper returns (before any sbsh involvement); `TestClaimSocketListener_NilGIDLeavesGroupUnchanged` covers the no-kukeon-group fallback (`0o600` owner-only); `TestClaimSocketListener_BindsAndUnlinksStale` was updated for the new signature and continues to lock the unlink-then-listen sequence.
- [x] `make test-root` — `go test ./...` minus `/e2e` — green.
- [x] `make dev-init` smoke — clean end-to-end after a `--purge-system` reset (a prior local run had accumulated stale `dev-init-attach.kukeon.io` containerd snapshot state from repeated `dev-init` invocations, unrelated to this change — removing the namespace via `ctr namespaces remove` and re-running produces a clean pass, including the kuketty-wrapped `kuke attach` smoke which exercises this fix in the real OCI path).
- [x] `go vet` on the changed packages (`./cmd/kuketty/...`, `./e2e/...`) — clean.
- [ ] `go vet ./...` repo-wide — pre-existing failure in `github.com/containerd/cgroups/v2@v2.0.0-20221109034041` (third-party `pids.Limit` type mismatch) reproduces on `origin/main` HEAD without this change applied; not introduced here.
- [x] e2e — new `TestKuke_RunFromStopped_RequiredRepoUnresolvable_NoEACCES` covers the AC test plan: a cell fixture (`attachable-cell-required-repo-unresolvable.yaml`) declares a `required=true` repo with an unresolvable hostname (`.invalid` per RFC 6761), `applyAttachableCell` auto-starts the workload, and the test stats the per-container socket the moment it appears (inside the pre-Serve window, *before* sbsh's `Serve` would have run `applySocketPerms`) and asserts mode `0o660` + group=kukeon. The test compiles cleanly (`go test -run NoTestMatchesAtAll ./e2e/...`); the full e2e suite was not driven locally since it needs the `kukeon-local:e2e` docker image (`make test-e2e` runs the full bring-up).