### PR TITLE
fix(reconcile): scope-narrow lineage Config lookup so realm-scoped Configs bound to stack-placed cells resolve

### DIFF
--- a/cmd/kuke/restart/cell/cell.go
+++ b/cmd/kuke/restart/cell/cell.go
@@ -319,23 +319,19 @@ func restartStopped(
 
 // materialiseFromConfig re-runs the CellConfig materialisation pipeline
 // against the cell's lineage Config: GetConfig + GetBlueprint +
-// cellconfig.Materialize. The cell's stored realm/space/stack supply the
-// lookup scope — a Config materialises a cell into the scope it lives in,
-// matching the daemon's reconciler (internal/controller/reconcile_outofsync.go).
+// cellconfig.Materialize. The cell's stored realm/space/stack name the
+// lookup's deepest scope, but the `kukeon.io/config` lineage label records
+// only the Config name — a `kuke run <config>` against a realm-scoped
+// Config materializes a cell at realm=default / space=default /
+// stack=default (resolveCellLocation fills the session defaults), so the
+// lookup must probe progressively shallower scopes (full → space-only →
+// realm-only) and use the first hit. Mirrors the daemon's reconciler
+// (internal/controller/reconcile_outofsync.go lookupLineageConfig).
 func materialiseFromConfig(
 	ctx context.Context, client kukeonv1.Client,
 	cellDoc v1beta1.CellDoc, configName string,
 ) (v1beta1.CellDoc, error) {
-	cfgRes, err := client.GetConfig(ctx, v1beta1.CellConfigDoc{
-		APIVersion: v1beta1.APIVersionV1Beta1,
-		Kind:       v1beta1.KindCellConfig,
-		Metadata: v1beta1.CellConfigMetadata{
-			Name:  configName,
-			Realm: cellDoc.Spec.RealmID,
-			Space: cellDoc.Spec.SpaceID,
-			Stack: cellDoc.Spec.StackID,
-		},
-	})
+	cfgRes, err := lookupLineageConfigCLI(ctx, client, cellDoc, configName)
 	if err != nil {
 		return v1beta1.CellDoc{}, err
 	}
@@ -367,6 +363,56 @@ func materialiseFromConfig(
 	}
 
 	return cellconfig.Materialize(cfgRes.Config, bpRes.Blueprint)
+}
+
+// lookupLineageConfigCLI probes for the cell's lineage Config from the
+// cell's full scope (realm/space/stack) down to space-only and then
+// realm-only, returning the first hit. Mirrors the daemon-side
+// scope-narrowing rule (internal/controller/reconcile_outofsync.go
+// lookupLineageConfig) so the CLI and reconciler resolve the same Config
+// regardless of which scope it was originally bound at.
+//
+// Probes are deduplicated when the cell's space or stack is already
+// empty. A real RPC error (anything other than a MetadataExists==false
+// hit) short-circuits the walk so the operator sees the underlying
+// failure instead of a misleading "not found" at realm scope.
+func lookupLineageConfigCLI(
+	ctx context.Context, client kukeonv1.Client,
+	cellDoc v1beta1.CellDoc, configName string,
+) (kukeonv1.GetConfigResult, error) {
+	realm := cellDoc.Spec.RealmID
+	space, stack := cellDoc.Spec.SpaceID, cellDoc.Spec.StackID
+
+	type probe struct{ space, stack string }
+	probes := []probe{{space, stack}}
+	if stack != "" {
+		probes = append(probes, probe{space, ""})
+	}
+	if space != "" {
+		probes = append(probes, probe{"", ""})
+	}
+
+	var lastMiss kukeonv1.GetConfigResult
+	for _, p := range probes {
+		res, err := client.GetConfig(ctx, v1beta1.CellConfigDoc{
+			APIVersion: v1beta1.APIVersionV1Beta1,
+			Kind:       v1beta1.KindCellConfig,
+			Metadata: v1beta1.CellConfigMetadata{
+				Name:  configName,
+				Realm: realm,
+				Space: p.space,
+				Stack: p.stack,
+			},
+		})
+		if err != nil {
+			return kukeonv1.GetConfigResult{}, err
+		}
+		if res.MetadataExists {
+			return res, nil
+		}
+		lastMiss = res
+	}
+	return lastMiss, nil
 }
 
 // reportApplyFailures inspects an ApplyDocumentsResult for "failed" rows and

--- a/cmd/kuke/restart/cell/cell_test.go
+++ b/cmd/kuke/restart/cell/cell_test.go
@@ -775,6 +775,144 @@ func TestRestartCell_CmdSurface(t *testing.T) {
 	}
 }
 
+// TestRestartCell_RealmScopedConfigFoundForStackPlacedCell pins the issue
+// #921 fix on the CLI side: an OutOfSync cell at realm/space/stack whose
+// `kukeon.io/config` lineage label names a Config bound only at realm
+// scope must still drive a reconcile via ApplyDocuments. Without the
+// scope-narrowing walk, materialiseFromConfig calls GetConfig once at the
+// cell's full scope, sees MetadataExists==false, and falls through to a
+// vanilla restart with the "reconcile materialisation failed (config not
+// found …)" notice — never reconciling from the realm-scoped Config.
+func TestRestartCell_RealmScopedConfigFoundForStackPlacedCell(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+	viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "default")
+	viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "default")
+	viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "default")
+
+	type probeScope struct{ name, realm, space, stack string }
+	var probes []probeScope
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				MetadataExists: true,
+				Cell: v1beta1.CellDoc{
+					Metadata: v1beta1.CellMetadata{
+						Name:   "kukeon-dev-root-0",
+						Labels: map[string]string{cellconfig.LabelConfig: "kukeon-dev-root-0"},
+					},
+					Spec: v1beta1.CellSpec{
+						ID:      "kukeon-dev-root-0",
+						RealmID: "default",
+						SpaceID: "default",
+						StackID: "default",
+					},
+					Status: v1beta1.CellStatus{
+						State:           v1beta1.CellStateReady,
+						OutOfSync:       true,
+						OutOfSyncReason: "lineage Config deleted",
+					},
+				},
+			}, nil
+		},
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			probes = append(probes, probeScope{
+				name:  doc.Metadata.Name,
+				realm: doc.Metadata.Realm,
+				space: doc.Metadata.Space,
+				stack: doc.Metadata.Stack,
+			})
+			if doc.Metadata.Space == "" && doc.Metadata.Stack == "" {
+				return kukeonv1.GetConfigResult{
+					MetadataExists: true,
+					Config: v1beta1.CellConfigDoc{
+						APIVersion: v1beta1.APIVersionV1Beta1,
+						Kind:       v1beta1.KindCellConfig,
+						Metadata: v1beta1.CellConfigMetadata{
+							Name:  "kukeon-dev-root-0",
+							Realm: "default",
+						},
+						Spec: v1beta1.CellConfigSpec{
+							Blueprint: v1beta1.CellConfigBlueprintRef{Name: "dev", Realm: "default"},
+						},
+					},
+				}, nil
+			}
+			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+		},
+		getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{
+				MetadataExists: true,
+				Blueprint: v1beta1.CellBlueprintDoc{
+					APIVersion: v1beta1.APIVersionV1Beta1,
+					Kind:       v1beta1.KindCellBlueprint,
+					Metadata:   v1beta1.CellBlueprintMetadata{Name: "dev", Realm: "default"},
+					Spec: v1beta1.CellBlueprintSpec{
+						Cell: v1beta1.BlueprintCellSpec{
+							Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}},
+						},
+					},
+				},
+			}, nil
+		},
+		applyDocsFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
+			return kukeonv1.ApplyDocumentsResult{
+				Resources: []kukeonv1.ApplyResourceResult{
+					{Kind: "Cell", Name: "kukeon-dev-root-0", Action: "updated"},
+				},
+			}, nil
+		},
+		stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			return kukeonv1.StartCellResult{Cell: doc}, nil
+		},
+	}
+
+	cmd := cell.NewCellCmd()
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	cmd.SetOut(outBuf)
+	cmd.SetErr(errBuf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, cell.MockControllerKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"kukeon-dev-root-0"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantProbes := []probeScope{
+		{name: "kukeon-dev-root-0", realm: "default", space: "default", stack: "default"},
+		{name: "kukeon-dev-root-0", realm: "default", space: "default", stack: ""},
+		{name: "kukeon-dev-root-0", realm: "default", space: "", stack: ""},
+	}
+	if len(probes) != len(wantProbes) {
+		t.Fatalf("GetConfig probe count: got %d want %d (probes=%+v)", len(probes), len(wantProbes), probes)
+	}
+	for i, p := range probes {
+		if p != wantProbes[i] {
+			t.Errorf("probe[%d] = %+v, want %+v", i, p, wantProbes[i])
+		}
+	}
+	if fake.applyCalls != 1 {
+		t.Errorf(
+			"ApplyDocuments calls: got %d, want 1 (reconcile must run once the realm-scoped Config is found)",
+			fake.applyCalls,
+		)
+	}
+	if strings.Contains(errBuf.String(), "reconcile materialisation failed") {
+		t.Errorf(
+			"stderr surfaced 'reconcile materialisation failed' despite the realm-scoped Config being reachable: %s",
+			errBuf.String(),
+		)
+	}
+	if !strings.Contains(outBuf.String(), `reconciled from config "kukeon-dev-root-0"`) {
+		t.Errorf("stdout did not confirm reconcile path: %s", outBuf.String())
+	}
+}
+
 // fakeClient is a per-test stub kukeonv1.Client. Each RPC is dispatched
 // through an optional Fn field; nil means "fail the test if called". Call
 // counts let tests assert "Synced restart did not invoke ApplyDocuments" and

--- a/internal/controller/reconcile_outofsync.go
+++ b/internal/controller/reconcile_outofsync.go
@@ -128,27 +128,55 @@ func configLineage(cell intmodel.Cell) (string, bool) {
 // lookupLineageConfig fetches the daemon-stored Config the cell's lineage
 // label points to, returning (cfg, true, nil) on hit, (zero, false, nil)
 // when the operator deleted the Config (the canonical OutOfSync trigger
-// the umbrella documents), or (zero, false, err) on any other error. The
-// scope coordinates come straight from the cell — a Config materializes a
-// cell into the same realm/space/stack it lives in.
+// the umbrella documents), or (zero, false, err) on any other error.
+//
+// The `kukeon.io/config` lineage label records only the Config name, not
+// the scope it was bound at, so the lookup must probe progressively
+// shallower scopes: full (realm/space/stack) → space-only (realm/space) →
+// realm-only (realm). `kuke run <config>` resolves Config lookups via
+// cmd/kuke/shared.ExplicitScope (empty space/stack unless the operator
+// passed --space/--stack), so a `kuke run kukeon-dev-root-0` against a
+// realm-scoped Config materializes a cell at realm=default /
+// space=default / stack=default (resolveCellLocation fills the session
+// defaults). Without the widening here, that cell's reconciler tick
+// resolves to `/opt/kukeon/data/default/default/default/configs/<name>`
+// (which does not exist) and persists a permanent "lineage Config
+// deleted" OutOfSync verdict.
+//
+// Probes are deduplicated when the cell's space or stack is already empty
+// (a realm-scoped cell or a space-scoped cell only takes the one probe
+// its own scope names).
 func lookupLineageConfig(
 	r runner.Runner, cell intmodel.Cell, configName string,
 ) (intmodel.CellConfig, bool, error) {
-	cfg, err := r.GetConfig(intmodel.CellConfig{
-		Metadata: intmodel.CellConfigMetadata{
-			Name:  configName,
-			Realm: cell.Spec.RealmName,
-			Space: cell.Spec.SpaceName,
-			Stack: cell.Spec.StackName,
-		},
-	})
-	if err != nil {
-		if errors.Is(err, errdefs.ErrConfigNotFound) {
-			return intmodel.CellConfig{}, false, nil
-		}
-		return intmodel.CellConfig{}, false, err
+	realm, space, stack := cell.Spec.RealmName, cell.Spec.SpaceName, cell.Spec.StackName
+
+	type probe struct{ space, stack string }
+	probes := []probe{{space, stack}}
+	if stack != "" {
+		probes = append(probes, probe{space, ""})
 	}
-	return cfg, true, nil
+	if space != "" {
+		probes = append(probes, probe{"", ""})
+	}
+
+	for _, p := range probes {
+		cfg, err := r.GetConfig(intmodel.CellConfig{
+			Metadata: intmodel.CellConfigMetadata{
+				Name:  configName,
+				Realm: realm,
+				Space: p.space,
+				Stack: p.stack,
+			},
+		})
+		if err == nil {
+			return cfg, true, nil
+		}
+		if !errors.Is(err, errdefs.ErrConfigNotFound) {
+			return intmodel.CellConfig{}, false, err
+		}
+	}
+	return intmodel.CellConfig{}, false, nil
 }
 
 // materializeCellFromConfig re-runs the CellConfig materialization pipeline

--- a/internal/controller/reconcile_outofsync_test.go
+++ b/internal/controller/reconcile_outofsync_test.go
@@ -380,3 +380,101 @@ func TestReconcileCells_OutOfSync_NoChangeNoRewrite(t *testing.T) {
 		t.Errorf("CellsUpdated: got %d, want 0", res.CellsUpdated)
 	}
 }
+
+// TestReconcileCells_OutOfSync_RealmScopedConfigFoundForStackPlacedCell
+// pins the issue #921 fix: a cell at full scope (realm/space/stack) whose
+// `kukeon.io/config` lineage label names a Config bound only at realm
+// scope must not surface as "lineage Config deleted". The lookup probes
+// full → space-only → realm-only and uses the first hit, so the realm-
+// scoped Config is found even though the live cell sits two scope levels
+// below it. Without the fix, GetConfig is called once at the cell's full
+// scope, ErrConfigNotFound surfaces, and the cell sticks permanently on
+// the deleted-Config OutOfSync verdict.
+func TestReconcileCells_OutOfSync_RealmScopedConfigFoundForStackPlacedCell(t *testing.T) {
+	live := buildTestCell("kukeon-dev-root-0", "kuke-system", "default", "default")
+	live.Metadata.Labels[cellconfig.LabelConfig] = "kukeon-dev"
+
+	var probes []intmodel.CellConfigMetadata
+	mock := stubLineageRunner(
+		func(c intmodel.CellConfig) (intmodel.CellConfig, error) {
+			probes = append(probes, c.Metadata)
+			// Realm scope is the only hit; intermediate scopes miss.
+			if c.Metadata.Space == "" && c.Metadata.Stack == "" {
+				return configCarrier(t, sampleConfig()), nil
+			}
+			return intmodel.CellConfig{}, errdefs.ErrConfigNotFound
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleReferencedBlueprint()), nil
+		},
+		nil,
+	)
+	// Walk the realm/space/stack the live cell sits in so the harness reaches it.
+	mock.ListSpacesFn = func(string) ([]intmodel.Space, error) {
+		return []intmodel.Space{buildTestSpace("default", "kuke-system")}, nil
+	}
+	mock.ListStacksFn = func(string, string) ([]intmodel.Stack, error) {
+		return []intmodel.Stack{buildTestStack("default", "kuke-system", "default")}, nil
+	}
+
+	_, captured := runOutOfSyncHarness(t, live, mock)
+
+	// Probe ordering is deepest → shallowest, with no duplicates.
+	wantProbes := []intmodel.CellConfigMetadata{
+		{Name: "kukeon-dev", Realm: "kuke-system", Space: "default", Stack: "default"},
+		{Name: "kukeon-dev", Realm: "kuke-system", Space: "default", Stack: ""},
+		{Name: "kukeon-dev", Realm: "kuke-system", Space: "", Stack: ""},
+	}
+	if len(probes) != len(wantProbes) {
+		t.Fatalf("GetConfig probe count: got %d want %d (probes=%+v)", len(probes), len(wantProbes), probes)
+	}
+	for i, p := range probes {
+		if p != wantProbes[i] {
+			t.Errorf("probe[%d] = %+v, want %+v", i, p, wantProbes[i])
+		}
+	}
+	// The Config was found at realm scope, so the verdict must NOT be
+	// "lineage Config deleted". A scope-divergence reason or a Synced
+	// verdict are both acceptable — the bug being pinned is the lookup
+	// missing entirely.
+	if captured != nil && captured.Status.OutOfSyncReason == outOfSyncReasonConfigDeletedTest {
+		t.Errorf("OutOfSyncReason = %q, want anything but %q (Config found at realm scope)",
+			captured.Status.OutOfSyncReason, outOfSyncReasonConfigDeletedTest)
+	}
+}
+
+// TestReconcileCells_OutOfSync_RealmScopedCellSkipsRedundantProbes
+// confirms the dedupe rule: when the live cell sits at realm scope (no
+// space, no stack), only one GetConfig probe fires — the full and
+// narrowed scopes collapse to the same realm-only lookup.
+func TestReconcileCells_OutOfSync_RealmScopedCellSkipsRedundantProbes(t *testing.T) {
+	live := materializeSampleCell(t) // realm=kuke-system, space="", stack=""
+	live.Metadata.Labels[cellconfig.LabelConfig] = "kukeon-dev"
+
+	var probeCount int
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			probeCount++
+			return configCarrier(t, sampleConfig()), nil
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleReferencedBlueprint()), nil
+		},
+		nil,
+	)
+
+	runOutOfSyncHarness(t, live, mock)
+
+	if probeCount != 1 {
+		t.Errorf("GetConfig probe count: got %d want 1 (realm-only cell needs no narrowing)", probeCount)
+	}
+}
+
+// outOfSyncReasonConfigDeletedTest is a string-literal duplicate of the
+// production constant the controller package keeps unexported. Copied
+// here so the external test package can assert against the expected
+// value without exporting the constant — the assertion intent is
+// "anything but this", so a drift between this literal and the
+// production constant would soften the test (would still flag a true
+// regression as long as the production constant remains stable).
+const outOfSyncReasonConfigDeletedTest = "lineage Config deleted"


### PR DESCRIPTION
## Summary

- `lookupLineageConfig` (daemon reconciler) and `materialiseFromConfig` (`kuke restart cell` CLI) both used the cell's full `realm/space/stack` to resolve its `kukeon.io/config` lineage Config. The label records only the Config **name**, not its scope, so a `kuke run kukeon-dev-root-0` against a realm-scoped Config materialized a cell at `default/default/default` and every later lookup at full scope missed — the reconciler persisted a permanent `outOfSyncReason: lineage Config deleted` and `kuke restart cell <name>` printed `reconcile materialisation failed (config not found …)`, falling back to a bounce-only path.
- Both lookups now probe progressively shallower scopes — full → space-only → realm-only — and use the first hit, mirroring the `kuke run` side that already does this via `cmd/kuke/shared.ExplicitScope`. Probes are deduplicated when the cell's space or stack is already empty.

## Test plan

- [x] `make test` (full root + kukebuild test suite)
- [x] `make dev-init` (rebuild + re-bootstrap; daemon parity tail prints identical `default` / `kuke-system` rows; `kuke attach` smoke green)
- [x] New regression test `TestReconcileCells_OutOfSync_RealmScopedConfigFoundForStackPlacedCell` pins the daemon-side probe walk (full → space-only → realm-only) and the corresponding non-`lineage Config deleted` verdict
- [x] New regression test `TestReconcileCells_OutOfSync_RealmScopedCellSkipsRedundantProbes` pins the dedupe rule (no narrowing when the cell already sits at realm scope)
- [x] New regression test `TestRestartCell_RealmScopedConfigFoundForStackPlacedCell` pins the same probe walk + reconcile path on the CLI side

Closes #921