### PR TITLE
fix(run): scope-narrow Config lookup so kuke run <config> finds Configs at deeper scopes

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -26,6 +26,7 @@ package run
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -927,43 +928,38 @@ func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags runFlag
 	return cellblueprint.MaterializeWithName(resolved, flags.nameOverride)
 }
 
-// loadFromConfig resolves the named CellConfig from daemon storage at the
-// scope named by --realm/--space/--stack, looks up the referenced Blueprint
-// from daemon storage (which may live in a different realm — cross-scope
-// references are explicitly allowed), and materializes the CellDoc via
-// cellconfig.Materialize: scalar values from the Config's spec, structural
-// slot fills (repo URLs, secret sources) applied, deterministic stable name
-// + kukeon.io/config back-ref label set. The resulting CellDoc carries the
-// Config's scope coordinates (not the blueprint's), so the cell is created
-// where the Config is bound.
+// loadFromConfig resolves the named CellConfig from daemon storage, looks up
+// the referenced Blueprint from daemon storage (which may live in a different
+// realm — cross-scope references are explicitly allowed), and materializes the
+// CellDoc via cellconfig.Materialize: scalar values from the Config's spec,
+// structural slot fills (repo URLs, secret sources) applied, deterministic
+// stable name + kukeon.io/config back-ref label set. The resulting CellDoc
+// carries the Config's scope coordinates (not the blueprint's), so the cell
+// is created where the Config is bound.
 //
-// The lookup scope follows the same explicit-coordinate rule as
-// loadFromBlueprint: --realm defaults to "default" if unset, but --space and
-// --stack stay empty unless the operator set them explicitly (via flag or
-// KUKE_RUN_SPACE / KUKE_RUN_STACK env). The session-default values in viper
-// would wrongly narrow every lookup to default/default and hide
-// realm-scoped Configs.
+// The lookup walks progressively shallower scopes (full → space-only →
+// realm-only) using pickLocation as the starting scope so the probe matches
+// where resolveCellLocation would place the materialised cell. A Config
+// stored at default/default/default would otherwise be invisible to a bare
+// `kuke run <config>` lookup that used ExplicitScope (empty space/stack
+// unless --space/--stack are set). Mirrors the daemon-side reconciler
+// (internal/controller/reconcile_outofsync.go lookupLineageConfig) and
+// the CLI-side restart path (cmd/kuke/restart/cell/cell.go
+// lookupLineageConfigCLI) so all three resolve the same Config regardless
+// of which scope it was originally bound at.
 func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (loadResult, error) {
-	lookup := v1beta1.CellConfigDoc{
-		APIVersion: v1beta1.APIVersionV1Beta1,
-		Kind:       v1beta1.KindCellConfig,
-		Metadata: v1beta1.CellConfigMetadata{
-			Name:  flags.configName,
-			Realm: kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM),
-			Space: kukshared.ExplicitScope(cmd, "space", &config.KUKE_RUN_SPACE),
-			Stack: kukshared.ExplicitScope(cmd, "stack", &config.KUKE_RUN_STACK),
-		},
-	}
+	realm := kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM)
+	space := pickLocation("", &config.KUKE_RUN_SPACE)
+	stack := pickLocation("", &config.KUKE_RUN_STACK)
 
-	cfgRes, err := client.GetConfig(cmd.Context(), lookup)
+	cfgRes, err := lookupConfigWithFallback(cmd.Context(), client, flags.configName, realm, space, stack)
 	if err != nil {
 		return loadResult{}, err
 	}
 	if !cfgRes.MetadataExists {
 		return loadResult{}, fmt.Errorf(
 			"%w (config %q in scope realm=%q space=%q stack=%q)",
-			errdefs.ErrConfigNotFound, lookup.Metadata.Name,
-			lookup.Metadata.Realm, lookup.Metadata.Space, lookup.Metadata.Stack,
+			errdefs.ErrConfigNotFound, flags.configName, realm, space, stack,
 		)
 	}
 
@@ -1058,6 +1054,54 @@ func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) 
 		return loadResult{}, materializeErr
 	}
 	return loadResult{Doc: doc, PreStarted: preStarted, StartResult: startResult}, nil
+}
+
+// lookupConfigWithFallback probes for the named Config from the operator's
+// effective scope (realm/space/stack) down to space-only and then realm-only,
+// returning the first hit. The starting scope comes from pickLocation (which
+// falls back to viper / env / "default") so a `kuke run <config>` against a
+// Config bound at default/default/default resolves without forcing the
+// operator to repeat --space default --stack default. Probes are deduplicated
+// when the space or stack is already empty (a realm-scoped lookup only takes
+// the one probe its own scope names). A real RPC error short-circuits the
+// walk so the operator sees the underlying failure instead of a misleading
+// "not found" at realm scope. The last miss is returned when every probe
+// reports MetadataExists=false so the caller can surface a single
+// ErrConfigNotFound with the full-scope coordinates.
+func lookupConfigWithFallback(
+	ctx context.Context, client kukeonv1.Client,
+	name, realm, space, stack string,
+) (kukeonv1.GetConfigResult, error) {
+	type probe struct{ space, stack string }
+	probes := []probe{{space, stack}}
+	if stack != "" {
+		probes = append(probes, probe{space, ""})
+	}
+	if space != "" {
+		probes = append(probes, probe{"", ""})
+	}
+
+	var lastMiss kukeonv1.GetConfigResult
+	for _, p := range probes {
+		res, err := client.GetConfig(ctx, v1beta1.CellConfigDoc{
+			APIVersion: v1beta1.APIVersionV1Beta1,
+			Kind:       v1beta1.KindCellConfig,
+			Metadata: v1beta1.CellConfigMetadata{
+				Name:  name,
+				Realm: realm,
+				Space: p.space,
+				Stack: p.stack,
+			},
+		})
+		if err != nil {
+			return kukeonv1.GetConfigResult{}, err
+		}
+		if res.MetadataExists {
+			return res, nil
+		}
+		lastMiss = res
+	}
+	return lastMiss, nil
 }
 
 // loadFromFile preserves the phase-1c -f path: read the file (or stdin),

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -3175,6 +3175,204 @@ func TestRun_FromConfig_NotFound_Errors(t *testing.T) {
 	}
 }
 
+// TestRun_FromConfig_NotFound_ProbeWalk pins the three-probe scope walk on
+// the bare `kuke run <config>` form (no --space/--stack). The probes go full
+// → space-only → realm-only with realm = "default" from the session default;
+// the not-found error reports the full-scope coordinates the operator's
+// effective scope started at (issue #923).
+func TestRun_FromConfig_NotFound_ProbeWalk(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var seen []v1beta1.CellConfigMetadata
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			seen = append(seen, doc.Metadata)
+			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"ghost", "-d"})
+
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, errdefs.ErrConfigNotFound) {
+		t.Fatalf("err=%v want ErrConfigNotFound", err)
+	}
+	if !strings.Contains(err.Error(), `realm="default" space="default" stack="default"`) {
+		t.Errorf("err message should report full-scope coords, got: %v", err)
+	}
+	wantProbes := []v1beta1.CellConfigMetadata{
+		{Name: "ghost", Realm: "default", Space: "default", Stack: "default"},
+		{Name: "ghost", Realm: "default", Space: "default", Stack: ""},
+		{Name: "ghost", Realm: "default", Space: "", Stack: ""},
+	}
+	if len(seen) != len(wantProbes) {
+		t.Fatalf("GetConfig probes=%d want %d (seen=%+v)", len(seen), len(wantProbes), seen)
+	}
+	for i, want := range wantProbes {
+		if seen[i].Name != want.Name || seen[i].Realm != want.Realm ||
+			seen[i].Space != want.Space || seen[i].Stack != want.Stack {
+			t.Errorf("probe[%d]={name=%q realm=%q space=%q stack=%q} want %+v",
+				i, seen[i].Name, seen[i].Realm, seen[i].Space, seen[i].Stack, want)
+		}
+	}
+}
+
+// TestRun_FromConfig_FullScopeProbe_Hits pins probe-1 of the walk: a Config
+// stored at default/default/default is found by a bare `kuke run <config>`
+// without --space/--stack. Reproduces the issue #923 bug.
+func TestRun_FromConfig_FullScopeProbe_Hits(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stored := configDoc()
+	stored.Metadata.Realm = "default"
+	stored.Metadata.Space = "default"
+	stored.Metadata.Stack = "default"
+
+	var probes int
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			probes++
+			if doc.Metadata.Realm == "default" &&
+				doc.Metadata.Space == "default" &&
+				doc.Metadata.Stack == "default" {
+				return kukeonv1.GetConfigResult{Config: stored, MetadataExists: true}, nil
+			}
+			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"prod", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if probes != 1 {
+		t.Errorf("GetConfig probes=%d want 1 (first probe should hit at full scope)", probes)
+	}
+	if fc.createCalls != 1 {
+		t.Errorf("CreateCell calls=%d want 1", fc.createCalls)
+	}
+}
+
+// TestRun_FromConfig_SpaceOnlyProbe_Hits pins probe-2: a Config stored at
+// realm=default / space=default / stack="" is found by a bare lookup after
+// the full-scope probe misses.
+func TestRun_FromConfig_SpaceOnlyProbe_Hits(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stored := configDoc()
+	stored.Metadata.Realm = "default"
+	stored.Metadata.Space = "default"
+	stored.Metadata.Stack = ""
+
+	var seen []v1beta1.CellConfigMetadata
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			seen = append(seen, doc.Metadata)
+			if doc.Metadata.Realm == "default" &&
+				doc.Metadata.Space == "default" &&
+				doc.Metadata.Stack == "" {
+				return kukeonv1.GetConfigResult{Config: stored, MetadataExists: true}, nil
+			}
+			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"prod", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(seen) != 2 {
+		t.Fatalf("GetConfig probes=%d want 2 (full miss then space-only hit), seen=%+v", len(seen), seen)
+	}
+	if seen[1].Space != "default" || seen[1].Stack != "" {
+		t.Errorf("probe[1]=%+v want space=default stack=\"\"", seen[1])
+	}
+}
+
+// TestRun_FromConfig_RealmOnlyProbe_Hits pins probe-3: a Config stored at
+// realm=default / space="" / stack="" is found by a bare lookup only after
+// the two narrower probes miss.
+func TestRun_FromConfig_RealmOnlyProbe_Hits(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	stored := configDoc()
+	stored.Metadata.Realm = "default"
+	stored.Metadata.Space = ""
+	stored.Metadata.Stack = ""
+
+	var seen []v1beta1.CellConfigMetadata
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			seen = append(seen, doc.Metadata)
+			if doc.Metadata.Realm == "default" &&
+				doc.Metadata.Space == "" &&
+				doc.Metadata.Stack == "" {
+				return kukeonv1.GetConfigResult{Config: stored, MetadataExists: true}, nil
+			}
+			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: configBlueprintDoc(), MetadataExists: true}, nil
+		},
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"prod", "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(seen) != 3 {
+		t.Fatalf("GetConfig probes=%d want 3 (walk down to realm-only), seen=%+v", len(seen), seen)
+	}
+	if seen[2].Space != "" || seen[2].Stack != "" {
+		t.Errorf("probe[2]=%+v want realm-only", seen[2])
+	}
+}
+
+// TestRun_FromConfig_RPCError_ShortCircuits pins that a real RPC error
+// (anything other than MetadataExists=false) aborts the probe walk so the
+// operator sees the underlying failure instead of a misleading not-found at
+// realm scope.
+func TestRun_FromConfig_RPCError_ShortCircuits(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	wantErr := errors.New("transport boom")
+	var probes int
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			probes++
+			return kukeonv1.GetConfigResult{}, wantErr
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"prod", "-d"})
+
+	err := cmd.Execute()
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("err=%v want %v", err, wantErr)
+	}
+	if probes != 1 {
+		t.Errorf("GetConfig probes=%d want 1 (RPC error must short-circuit)", probes)
+	}
+}
+
 func TestRun_FromConfig_BlueprintMissing_Errors(t *testing.T) {
 	t.Cleanup(viper.Reset)
 


### PR DESCRIPTION
## Summary
- `kuke run <config>` (and `kuke run <clone-name>`) now walks progressively shallower scopes — full (realm/space/stack) → space-only (realm/space) → realm-only (realm) — when resolving the daemon-stored CellConfig, mirroring the daemon reconciler (`internal/controller/reconcile_outofsync.go` `lookupLineageConfig`) and the CLI restart path (`cmd/kuke/restart/cell/cell.go` `lookupLineageConfigCLI`, landed in #922). The starting scope comes from `pickLocation` (viper-backed, defaults to `default`) instead of `ExplicitScope`, so a Config stored at `default/default/default` is found by a bare `kuke run <config>` without forcing `--space default --stack default`.
- Probes deduplicate when space/stack are already empty, and a real RPC error short-circuits the walk so the operator sees the underlying failure rather than a misleading realm-only not-found.
- The issue body cites `materialiseFromConfig` / `lookupLineageConfig` as already implementing this three-probe walk. That premise had rotted between issue filing and pick-up (those functions previously did single-scope lookups). #922 landed the walk in both before this PR, so the cited reference matches reality at merge time.

## Test plan
- [x] `make test-root` (existing run-package tests still pass; new tests cover all three probe positions, RPC short-circuit, and full-scope error message)
- [x] `make test-kukebuild`
- [x] `pre-commit run --files cmd/kuke/run/run.go cmd/kuke/run/run_test.go`
- [x] `make kuke` (binary builds; `./kuke run --help` still renders)
- [ ] `make dev-init` — not run; the change is CLI-only (no daemon-read or build-path edits), so the project CLAUDE.md's smoke gate ("change touches the build path, the daemon, or anything under `/opt/kukeon`") does not apply.

Closes #923