### PR TITLE
fix(dev-init): remove dev-init-attach namespace after purge to make attach-smoke idempotent

### DIFF
--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -439,6 +439,11 @@ ATTACH_SMOKE_CONTAINER="work"
 ATTACH_SMOKE_BASE="${METADATA_ROOT}/${ATTACH_SMOKE_REALM}/${ATTACH_SMOKE_SPACE}/${ATTACH_SMOKE_STACK}/${ATTACH_SMOKE_CELL}/${ATTACH_SMOKE_CONTAINER}"
 ATTACH_SMOKE_SOCKET="${ATTACH_SMOKE_BASE}/tty/socket"
 ATTACH_SMOKE_METADATA="${ATTACH_SMOKE_BASE}/kuketty-metadata.json"
+# Pin to the same suffix the daemon resolves for the dev-init-attach realm
+# (defaults: kukeon.io; KUKEON_PROFILE=dev: dev.kukeon.io). KUKEOND_NS
+# encodes the active suffix as `kuke-system.<suffix>`; strip the
+# `kuke-system.` prefix to derive the attach-smoke realm's namespace.
+ATTACH_SMOKE_NS="${ATTACH_SMOKE_REALM}.${KUKEOND_NS#kuke-system.}"
 ATTACH_SMOKE_TMP="$(mktemp -d)"
 
 teardown_attach_smoke_state() {
@@ -449,6 +454,17 @@ teardown_attach_smoke_state() {
         --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}" 2>/dev/null || true
     sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke purge space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
     sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke purge realm "${ATTACH_SMOKE_REALM}" 2>/dev/null || true
+    # Backstop the kuke purge chain: `kuke purge realm` does call
+    # DeleteNamespace, but issue #919 surfaces a cross-run trap where the
+    # `dev-init-attach.kukeon.io` containerd namespace lingers empty after
+    # the purge and strands the next run's `kuke apply` image-pull→
+    # snapshot-unpack with "parent snapshot ... does not exist". Removing
+    # the namespace by hand makes the teardown idempotent across N runs.
+    # The attach smoke never targets this realm with `kuke build`, so no
+    # `/var/lib/kukebuild/<ns>/` cache exists to wipe alongside it
+    # (the #904 lane only applies to realms that have been a `kuke build`
+    # target).
+    sudo ctr namespaces remove "${ATTACH_SMOKE_NS}" 2>/dev/null || true
 }
 
 cleanup_attach_smoke() {


### PR DESCRIPTION
## Summary

- `scripts/dev-init.sh`'s `teardown_attach_smoke_state` purges the four `dev-init-attach` metadata resources via `kuke purge ... --cascade`, but the `dev-init-attach.kukeon.io` containerd namespace lingers empty after the purge chain. The next `make dev-init` then re-creates the realm against the surviving namespace, and `kuke apply`'s image-pull→snapshot-unpack fails with `parent snapshot ... does not exist` — `make dev-init` is no longer idempotent across runs, breaking the contract `CLAUDE.md`'s "Local smoke test" pins.
- Fix: at the tail of the purge chain, also `sudo ctr namespaces remove "${ATTACH_SMOKE_NS}"` to backstop whatever residual containerd state survives `runner.PurgeRealm`'s `DeleteNamespace` call. Idempotent (`2>/dev/null || true`) so a clean-state pre-emptive teardown is a silent no-op. `ATTACH_SMOKE_NS` is derived from `KUKEOND_NS` so the dev-profile suffix (`dev-init-attach.dev.kukeon.io`) is picked up automatically alongside the default (`dev-init-attach.kukeon.io`).
- No companion `/var/lib/kukebuild/<ns>/` wipe (the #904 sister lane): the attach smoke uses `kuke apply`, never `kuke build`, so the kukebuild BuildKit cache is never populated for this realm — verified locally (`sudo ls /var/lib/kukebuild/` contains only `kuke-system.kukeon.io`).

## Test plan

- [x] `make test` (root + kukebuild): all packages pass.
- [x] `GOWORK=off go build ./...`: clean compile.
- [x] `GOWORK=off go vet ./...` (excluding e2e per Makefile pattern): clean.
- [x] `bash -n scripts/dev-init.sh`: syntax OK.
- [x] `make dev-init` run #1 (clean state): attach-smoke succeeds, `kuke attach exited cleanly`, the daemon-parity tail still reads `default Ready / kuke-system Ready`.
- [x] `make dev-init` run #2 (no operator intervention between runs): attach-smoke succeeds again — the bug body's `Cell "cattach": failed` / `parent snapshot ... does not exist` repro from `origin/main` does **not** surface with this patch in place.
- [x] Post-run-2 namespace listing: `dev-init-attach.kukeon.io` is absent from `ctr namespaces ls` (the EXIT trap's `ctr namespaces remove` is doing the work).
- [ ] `make e2e`: not run — exercises a different daemon-bringing path that does not cover the dev-init attach-smoke teardown and would not catch this regression.

Closes #919