### PR TITLE
fix(run): deref *ContainerSecretRef in containerSecretsEqual to suppress false-positive secrets divergence

### DIFF
--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -1353,18 +1353,35 @@ func divergedContainerFields(actual, desired v1beta1.ContainerSpec) []string {
 // containerSecretsEqual compares two ContainerSecret slices field-by-field.
 // nil and empty are treated as equal so YAML that omits secrets does not
 // register as drift against on-disk metadata that persisted it as nil.
-// ContainerSecret carries only scalar string fields, so a direct == on each
-// element is enough.
+// ContainerSecret carries a *ContainerSecretRef pointer; struct == on it
+// would compare that pointer by identity, and the apischeme round-trip
+// allocates a fresh *ContainerSecretRef on each conversion, so YAML-decoded
+// and daemon-persisted sides are always address-distinct even when
+// value-equal. Issue #920.
 func containerSecretsEqual(a, b []v1beta1.ContainerSecret) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if a[i] != b[i] {
+		if a[i].Name != b[i].Name ||
+			a[i].FromFile != b[i].FromFile ||
+			a[i].FromEnv != b[i].FromEnv ||
+			a[i].MountPath != b[i].MountPath ||
+			!secretRefEqual(a[i].SecretRef, b[i].SecretRef) {
 			return false
 		}
 	}
 	return true
+}
+
+// secretRefEqual compares two *ContainerSecretRef by deref'd value, treating
+// matching nil-ness as equal. ContainerSecretRef is all scalar strings, so a
+// direct == on the dereferenced struct is safe.
+func secretRefEqual(a, b *v1beta1.ContainerSecretRef) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // containerTtysEqual compares two ContainerTty pointers. Empty values on

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1100,6 +1100,106 @@ func TestRun_ExistingCell_DivergingContainerSecrets_RefusesAndPointsToApply(t *t
 	}
 }
 
+// TestRun_ExistingCell_EqualSecretRefByValue_DoesNotRefuse pins the
+// regression from #920: containerSecretsEqual used to compare
+// []ContainerSecret element-by-element with struct ==, which on a struct
+// holding a *ContainerSecretRef pointer field compares the pointer by
+// identity. The apischeme round-trip allocates a fresh *ContainerSecretRef
+// on each conversion, so the YAML-decoded side and the daemon-persisted
+// side are always address-distinct even when value-equal — every
+// re-`kuke run` of a secretRef:-using cell tripped the divergence guard
+// and printed the `kuke restart cell ...` pointer.
+//
+// The sibling Diverging... test above only exercises FromFile (pointer-free
+// fields), so the pointer-identity bug escaped review. This test puts a
+// SecretRef equal by value on both sides and asserts `kuke run` does not
+// refuse.
+func TestRun_ExistingCell_EqualSecretRefByValue_DoesNotRefuse(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	const yamlWithSecretRef = `apiVersion: v1beta1
+kind: Cell
+metadata:
+  name: my-cell
+spec:
+  id: my-cell
+  realmId: my-realm
+  spaceId: my-space
+  stackId: my-stack
+  containers:
+    - id: root
+      root: true
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+    - id: work
+      image: registry.eminwux.com/busybox:latest
+      command: sleep
+      args:
+        - "3600"
+      secrets:
+        - name: claude-code-oauth-token
+          secretRef:
+            name: claude-code-oauth-token
+            realm: default
+`
+
+	existing := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: "my-cell"},
+		Spec: v1beta1.CellSpec{
+			RealmID: "my-realm",
+			SpaceID: "my-space",
+			StackID: "my-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{
+					ID:      "root",
+					Root:    true,
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+				},
+				{
+					ID:      "work",
+					Image:   "registry.eminwux.com/busybox:latest",
+					Command: "sleep",
+					Args:    []string{"3600"},
+					Secrets: []v1beta1.ContainerSecret{
+						{
+							Name: "claude-code-oauth-token",
+							SecretRef: &v1beta1.ContainerSecretRef{
+								Name:  "claude-code-oauth-token",
+								Realm: "default",
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1beta1.CellStatus{State: v1beta1.CellStateReady},
+	}
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell:                     existing,
+				MetadataExists:           true,
+				CgroupExists:             true,
+				RootContainerExists:      true,
+				RootContainerTaskRunning: true,
+			}, nil
+		},
+	}
+	cmd, _ := newCmd(t, fc)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, yamlWithSecretRef), "-d"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute returned %v, want nil (equal-by-value SecretRef must not register as drift)", err)
+	}
+	if fc.createCalls != 0 {
+		t.Errorf("CreateCell calls=%d want 0 (Ready cell with matching spec is a no-op)", fc.createCalls)
+	}
+}
+
 // TestRun_ExistingCell_DivergingContainerTty_RefusesAndPointsToApply
 // exercises the tty branch of divergedContainerFields. ContainerTty is
 // user-authored shell-UX config the daemon persists verbatim and never


### PR DESCRIPTION
## Summary
- `containerSecretsEqual` in `cmd/kuke/run/run.go` compared `[]ContainerSecret` elements with struct `==`. `ContainerSecret` carries a `*ContainerSecretRef` pointer field, so struct `==` compares the pointer by identity. The apischeme round-trip (`secretRefToInternal` / `secretRefToExternal`) allocates a fresh `*ContainerSecretRef` on each conversion, so YAML-decoded and daemon-persisted sides were always address-distinct even when value-equal — every re-`kuke run` of a `secretRef:`-using cell tripped the divergence guard and printed `kuke restart cell …` (#920 Bug 1, deterministic repro).
- Fix: keep the comment trail explaining *why* struct `==` is unsafe here, and replace the inner compare with a field-by-field check plus a new `secretRefEqual` helper that deref's the pointer when both sides are non-nil and treats matching nil-ness as equal. `ContainerSecretRef` is all scalar strings, so a direct `==` on the dereferenced value is safe.
- Adds `TestRun_ExistingCell_EqualSecretRefByValue_DoesNotRefuse` as a sibling to the existing `…DivergingContainerSecrets_RefusesAndPointsToApply` — puts an equal-by-value `SecretRef` on both the YAML side and the GetCell stub side, and asserts `kuke run` does *not* refuse. Pre-fix this test fails with the exact `cell "my-cell" exists with diverging spec (spec.containers["work"].secrets)` message the operator sees in the issue's repro; the existing Diverging test only exercised `FromFile` (pointer-free), which is how the bug escaped review.
- Bug 2 from #920 (attach ping context-deadline-exceeded from the post-`StartCell` Serve()-readiness race) is **deliberately not included** — the issue body itself defers it ("Bug 2 (bigger; carve out its own PR)") and the design space (daemon-side handshake vs. client-side retry budget) is independent. Filed as #926 so the deferral remains visible after #920 auto-closes on this merge.

## Test plan
- [x] `GOWORK=off go test ./cmd/kuke/run/ -run 'TestRun_ExistingCell_(DivergingContainerSecrets|EqualSecretRefByValue)' -v` — both pass on this branch; the new test fails (with the issue's exact divergence error) when the fix is stashed.
- [x] `make test-root` — full root-module suite, all packages green.
- [x] `GOWORK=off go vet ./cmd/kuke/run/...` — clean.
- [x] `pre-commit run --files cmd/kuke/run/run.go cmd/kuke/run/run_test.go` — all hooks pass (gofmt, addlicense, golangci-lint scoped on the changed files).
- [ ] `make dev-init` smoke (the `kuke get realms` daemon-parity tail in CLAUDE.md §Local smoke test) — not run; the diff is scoped to `cmd/kuke/run`'s in-memory diff helper, touches no daemon code, no build-path code, and nothing under `/opt/kukeon`. The unit test exercises the exact code path the operator's repro trips on.
- [ ] `make e2e` — not run; e2e exercises live containerd + kuketty paths, which this CLI-side diff does not touch. The repro path (`kuke run` re-tick against a Ready cell) is unit-covered.

Closes #920