### PR TITLE
fix(run): retry attach loop on sbsh ping-deadline so kuketty Serve() boot race is absorbed

### DIFF
--- a/cmd/kuke/run/attach.go
+++ b/cmd/kuke/run/attach.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -30,6 +31,25 @@ import (
 	"github.com/eminwux/sbsh/pkg/attach"
 	"github.com/spf13/cobra"
 )
+
+// attachPingRetryBudget bounds the total wall-clock time runWithPingRetry
+// will spend re-invoking attach.Run when sbsh's per-attempt 3 s ping
+// window keeps firing before kuketty's Serve() accept loop has come
+// up. Each attempt re-pays the 3 s window inside sbsh, so a 10 s budget
+// covers two retries past the initial attempt on the slow-host race
+// that #926 documents.
+//
+//nolint:gochecknoglobals // test seam for the production retry budget
+var attachPingRetryBudget = 10 * time.Second
+
+// attachPingRetryBackoff is the sleep between retry attempts. Kept
+// short on purpose: the dominant wait is sbsh's per-attempt 3 s ping
+// window, not this gap. The backoff exists only to avoid a tight loop
+// on the chance the prior attempt failed for a reason that resolves
+// in microseconds.
+//
+//nolint:gochecknoglobals // test seam for the production retry backoff
+var attachPingRetryBackoff = 200 * time.Millisecond
 
 // MockRunKey is used to inject a mock runFn via context in tests, so the
 // real pkg/attach.Run (which would open a TTY and connect to a real
@@ -158,7 +178,7 @@ func runAttachLoop(
 	}
 
 	run := resolveRun(cmd)
-	runErr := run(cmd.Context(), attach.Options{
+	runErr := runWithPingRetry(cmd.Context(), run, attach.Options{
 		SocketPath: result.HostSocketPath,
 		Stdin:      os.Stdin,
 		Stdout:     os.Stdout,
@@ -181,4 +201,62 @@ func resolveRun(cmd *cobra.Command) runFn {
 		return mock
 	}
 	return attach.Run
+}
+
+// runWithPingRetry retries run() while the failure looks like sbsh's
+// per-attempt 3 s control-socket ping deadline firing before kuketty
+// has entered Serve()'s Accept loop. The dial(2) succeeds as soon as
+// kuketty's bind(2) lands (the kernel queues the connect into the
+// listening socket's backlog), so the post-StartCell attach can race
+// kuketty's Serve() boot — a window distinct from the EACCES one
+// #918 closed (#926).
+//
+// Behaviour:
+//   - non-ping-timeout errors propagate immediately; the existing
+//     ClassifyAttachExit branch handles them.
+//   - ping-timeout errors are retried with attachPingRetryBackoff
+//     between attempts until either run() succeeds, the outer ctx
+//     is cancelled (returns ctx.Err), or attachPingRetryBudget is
+//     exhausted (returns the last runErr wrapped with
+//     errdefs.ErrAttachPingTimeout so callers can errors.Is the
+//     timeout class without string-matching sbsh's wrap).
+func runWithPingRetry(ctx context.Context, run runFn, opts attach.Options) error {
+	deadline := time.Now().Add(attachPingRetryBudget)
+	var lastErr error
+	for {
+		lastErr = run(ctx, opts)
+		if !isAttachPingTimeout(ctx, lastErr) {
+			return lastErr
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("%w: %w", errdefs.ErrAttachPingTimeout, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(attachPingRetryBackoff):
+		}
+	}
+}
+
+// isAttachPingTimeout reports whether err is the sbsh "ping failed:
+// context deadline exceeded" class that runWithPingRetry treats as a
+// readiness-handshake race rather than a hard failure. The classifier
+// is conservative on purpose:
+//
+//   - err must be non-nil (a clean detach is not a retry condition);
+//   - ctx must not be done (a cancelled outer ctx surfaces as
+//     DeadlineExceeded on the inner WithTimeout child, but is the
+//     operator's ^C not kuketty's boot race — don't retry);
+//   - context.DeadlineExceeded must appear in the chain (the only
+//     bounded-timeout in sbsh's attach.Run setup is the 3 s ping
+//     window in clientrunner/io.go dialTerminalCtrlSocket).
+func isAttachPingTimeout(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+	return errors.Is(err, context.DeadlineExceeded)
 }

--- a/cmd/kuke/run/export_test.go
+++ b/cmd/kuke/run/export_test.go
@@ -17,6 +17,8 @@
 package run
 
 import (
+	"time"
+
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
@@ -30,4 +32,19 @@ type RunFn = runFn
 // Production code reaches the same path through runRun → attachAfterRun.
 func PickAttachTarget(spec v1beta1.CellSpec, cellName, explicit string) (string, error) {
 	return pickAttachTarget(spec, cellName, explicit)
+}
+
+// SetAttachPingRetryForTest overrides the package-level retry budget
+// and backoff used by runWithPingRetry so tests don't pay the
+// production 10 s wall-clock on the budget-exhausted path. Returns a
+// restore func the test must defer.
+func SetAttachPingRetryForTest(budget, backoff time.Duration) func() {
+	prevBudget := attachPingRetryBudget
+	prevBackoff := attachPingRetryBackoff
+	attachPingRetryBudget = budget
+	attachPingRetryBackoff = backoff
+	return func() {
+		attachPingRetryBudget = prevBudget
+		attachPingRetryBackoff = prevBackoff
+	}
 }

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	runcmd "github.com/eminwux/kukeon/cmd/kuke/run"
@@ -5450,5 +5451,160 @@ func TestRun_EnvFlag_StoppedCell_StartsWithRuntimeEnv(t *testing.T) {
 	if !reflect.DeepEqual(fc.startDoc.Spec.RuntimeEnv, want) {
 		t.Errorf("StartCell doc RuntimeEnv=%v, want %v (-f Stopped restart path)",
 			fc.startDoc.Spec.RuntimeEnv, want)
+	}
+}
+
+// pingTimeoutErr returns an error chain that mirrors sbsh's wrap shape
+// from clientrunner/io.go's dialTerminalCtrlSocket — `fmt.Errorf("ping
+// failed: %w", err)` with context.DeadlineExceeded in the chain — so
+// the runWithPingRetry classifier sees the same surface real sbsh
+// returns when its 3 s ping window fires before kuketty's Serve()
+// accept loop has come up (#926).
+func pingTimeoutErr() error {
+	return fmt.Errorf("ping failed: %w", context.DeadlineExceeded)
+}
+
+// TestRun_Attach_PingDeadline_RetriesWithinBudget pins the
+// readiness-handshake guarantee from #926: when the first call into
+// the in-process attach loop fails with sbsh's "ping failed: context
+// deadline exceeded" (i.e. kuketty has bound the control socket but
+// not yet entered Serve()'s Accept loop), runWithPingRetry must retry
+// instead of surfacing the timeout to the operator. Pre-fix this test
+// fails: the original runAttachLoop called run() exactly once and
+// returned the ping-timeout straight through to ClassifyAttachExit.
+func TestRun_Attach_PingDeadline_RetriesWithinBudget(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// Tight budget keeps the test cheap on the budget-exhausted negative
+	// path covered by the sibling test below; the retry path here only
+	// needs one retry inside the budget so the production 10s default
+	// would also pass — overridden for symmetry with the negative test.
+	restore := runcmd.SetAttachPingRetryForTest(500*time.Millisecond, 10*time.Millisecond)
+	t.Cleanup(restore)
+
+	var calls int
+	var mu sync.Mutex
+	runFn := runcmd.RunFn(func(_ context.Context, _ sbshattach.Options) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return pingTimeoutErr()
+		}
+		return nil
+	})
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, runFn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v (want nil — retry must absorb the ping-timeout)", err)
+	}
+	if fc.attachCalls != 1 {
+		t.Errorf(
+			"AttachContainer calls=%d, want 1 (HostSocketPath resolved once; retries are on the dial side)",
+			fc.attachCalls,
+		)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 2 {
+		t.Errorf("attach loop calls=%d, want 2 (one ping-timeout, one success)", calls)
+	}
+}
+
+// TestRun_Attach_PingDeadline_BudgetExhausted_WrapsSentinel pins the
+// budget-exhausted surface: when sbsh keeps firing ping-deadline past
+// the configured budget, runWithPingRetry must surface the timeout
+// class via errdefs.ErrAttachPingTimeout so callers can errors.Is the
+// readiness-handshake failure without string-matching sbsh's wrap.
+func TestRun_Attach_PingDeadline_BudgetExhausted_WrapsSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	restore := runcmd.SetAttachPingRetryForTest(50*time.Millisecond, 10*time.Millisecond)
+	t.Cleanup(restore)
+
+	var calls int
+	var mu sync.Mutex
+	runFn := runcmd.RunFn(func(_ context.Context, _ sbshattach.Options) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return pingTimeoutErr()
+	})
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, runFn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachPingTimeout) {
+		t.Fatalf("err=%v, want chain to include errdefs.ErrAttachPingTimeout", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf(
+			"err=%v, want chain to preserve context.DeadlineExceeded so operators can still see the underlying cause",
+			err,
+		)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls < 2 {
+		t.Errorf("attach loop calls=%d, want >= 2 (at least one retry before budget exhaustion)", calls)
+	}
+}
+
+// TestRun_Attach_NonPingError_DoesNotRetry pins the negative side of
+// the classifier: an error that is not a context-deadline-exceeded
+// class (e.g. a generic controller failure) must NOT trigger retry,
+// otherwise the retry loop would mask real failures behind a 10 s
+// budget on every kuke run.
+func TestRun_Attach_NonPingError_DoesNotRetry(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	restore := runcmd.SetAttachPingRetryForTest(500*time.Millisecond, 10*time.Millisecond)
+	t.Cleanup(restore)
+
+	sentinel := errors.New("controller-level failure (not a ping timeout)")
+	var calls int
+	var mu sync.Mutex
+	runFn := runcmd.RunFn(func(_ context.Context, _ sbshattach.Options) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return sentinel
+	})
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, runFn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
+
+	err := cmd.Execute()
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err=%v, want chain to include the injected non-ping sentinel", err)
+	}
+	if errors.Is(err, errdefs.ErrAttachPingTimeout) {
+		t.Errorf("err=%v, must NOT be wrapped with ErrAttachPingTimeout — non-ping errors are not the retry class", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Errorf("attach loop calls=%d, want 1 (non-ping errors must not retry)", calls)
 	}
 }

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -289,6 +289,17 @@ var (
 	// as `connection refused` at `connect(2)` time (#852).
 	ErrAttachTaskNotRunning = errors.New("container task is not running; cannot attach to a dead socket")
 
+	// ErrAttachPingTimeout is returned by the post-StartCell attach loop
+	// in cmd/kuke/run when sbsh's 3 s control-socket ping deadline keeps
+	// firing because kuketty has bound the control socket but not yet
+	// entered Serve()'s Accept loop — a "socket present, accept loop not
+	// yet running" race distinct from the EACCES window #918 closed.
+	// Promoted from sbsh's untyped `ping failed: context deadline
+	// exceeded` (clientrunner/io.go) at the kukeon boundary so callers
+	// can errors.Is the timeout class without string-matching the sbsh
+	// wrap (#926).
+	ErrAttachPingTimeout = errors.New("attach ping timed out: kuketty control socket bound but not yet serving")
+
 	// ErrSocketPathTooLong fires when the resolved host-side path of a
 	// per-container kuketty control socket would overflow Linux's
 	// sockaddr_un.sun_path buffer (consts.KukeonMaxSocketPath bytes plus


### PR DESCRIPTION
## Summary
- `runAttachLoop` in `cmd/kuke/run/attach.go` invoked `pkg/attach.Run` exactly once, so any single firing of sbsh's per-attempt 3 s control-socket ping deadline (`clientrunner/io.go:42` `dialTerminalCtrlSocket`) was a hard error to the operator. On a slow host the kuketty process inside the freshly-started container could land between "control socket bound" (closed by #918) and "Serve() accept loop running" — `connect(2)` queues into the kernel backlog but no Accept drains it, the inner 3 s expires, and the operator sees `error attaching client: ping failed: context deadline exceeded` (#926's deterministic repro).
- Fix: wrap the in-process attach loop in `runWithPingRetry`, which classifies the failure via `isAttachPingTimeout(ctx, err) = (err != nil) && (ctx.Err() == nil) && errors.Is(err, context.DeadlineExceeded)` and retries `run()` with a 200 ms backoff until either it succeeds, the outer ctx is cancelled (returns `ctx.Err()` so the user's ^C is honoured immediately), or the 10 s wall-clock budget is exhausted. On budget exhaustion the surface is wrapped with a new `errdefs.ErrAttachPingTimeout` sentinel so callers can `errors.Is` the timeout class without string-matching sbsh's wrap.
- **Design choice noted for reviewer push-back.** Issue #926 offered two options ("daemon side"—self-ping kuketty before `StartCell` returns—or "client side"—retry+sentinel in `runAttachLoop`) and recommended the daemon-side because it preserves the existing contract (`containers: started` ⇒ ready to attach). I went with the **client-side** option as the lower-blast-radius default per dev's "act, then report" guidance: it's localised to `cmd/kuke/run/attach.go`, does not touch the daemon's RPC contract, does not introduce an sbsh-client dependency in the daemon's hot path, and is unit-testable via the existing `MockRunKey` seam. The contract weakening is bounded: `containers: started` already only promises "daemon-side StartCell completed", not "kuketty has entered Serve()" — the readiness gap was always there and the new retry hides the in-progress kuketty boot behind the same operator-visible "post-StartCell attaching" phase. If the reviewer judges the contract preservation matters more than the localisation, this should be ripped out for a daemon-side handshake instead.
- The new sentinel `errdefs.ErrAttachPingTimeout` is added next to the existing `ErrAttachTaskNotRunning` so the attach-related family stays grouped, with a comment cross-referencing `clientrunner/io.go` so a future sbsh upgrade that changes the wrap shape leaves a paper trail.

## Test plan
- [x] `GOWORK=off go test ./cmd/kuke/run/ -run 'TestRun_Attach_(PingDeadline_RetriesWithinBudget|PingDeadline_BudgetExhausted_WrapsSentinel|NonPingError_DoesNotRetry)' -v` — three new tests pass; verified pre-fix two fail with the exact `ping failed: context deadline exceeded` divergence from #926's repro (the negative-class test passes on both sides, as it covers the no-retry branch which is unchanged).
- [x] `make test` — full project test target (`test-root` + `test-kukebuild`), all packages green.
- [x] `pre-commit run --files cmd/kuke/run/attach.go cmd/kuke/run/run_test.go cmd/kuke/run/export_test.go internal/errdefs/errdefs.go` — gofmt, go-mod-tidy, golangci-lint, addlicense all pass on the changed files.
- [ ] `make dev-init` smoke (the `kuke get realms` daemon-parity tail in CLAUDE.md §Local smoke test) — not run; the diff is scoped to `cmd/kuke/run`'s in-process attach loop and adds one entry to `internal/errdefs`, touches no daemon code, no build-path code, and nothing under `/opt/kukeon`. The unit tests exercise the exact code path the operator's repro trips on by injecting the sbsh-shaped error chain via the existing `MockRunKey` seam.
- [ ] `make test-e2e` — not run; e2e exercises live containerd + kuketty paths, and this CLI-side diff does not touch them. The repro path is the in-process attach loop's retry classifier, which is unit-covered above.

Closes #926