### PR TITLE
test(e2e): reuse attachConnectGrace for runFromStopped scenario

### DIFF
--- a/e2e/e2e_kuke_attach_test.go
+++ b/e2e/e2e_kuke_attach_test.go
@@ -443,16 +443,6 @@ func getCellIDNoDaemon(t *testing.T, runPath, realmName, spaceName, stackName, c
 // 60s budget on a healthy runner.
 const runFromStoppedRaceIterations = 20
 
-// runFromStoppedAttachGrace is the wait between launching `kuke run`
-// (which races StartCell → attach internally) and sending the detach
-// keystroke. The attach phase enters the in-process pkg/attach loop
-// within tens of milliseconds on a healthy host; this grace is set so
-// the EACCES window, if it re-opens, is consumed by the dial before the
-// detach byte arrives. A v0.12.0 race would surface as a non-zero exit
-// with `permission denied` on stderr inside this window; a v0.12.1
-// healthy attach loop swallows the keystroke and exits cleanly.
-const runFromStoppedAttachGrace = 1 * time.Second
-
 // runFromStoppedExitTimeout caps the wait for a single `kuke run`
 // invocation to return after its detach keystroke. The healthy path
 // (post-v0.12.1) returns within a second; the cap is generous so a
@@ -607,8 +597,13 @@ func TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES(t *testing.T) {
 		// to either succeed (sbsh ≥ v0.12.1) or surface EACCES (sbsh
 		// ≤ v0.12.0). A v0.12.0 race returns the error immediately;
 		// a v0.12.1 healthy attach blocks on stdin until the detach
-		// keystroke arrives.
-		time.Sleep(runFromStoppedAttachGrace)
+		// keystroke arrives. Reuses attachConnectGrace (the peer
+		// attach scenarios' grace): the 2s span covers both the dial
+		// (EACCES window) and the raw-mode + filter-wire setup that
+		// must complete before the detach keystroke is forwarded so
+		// the in-process pkg/attach filter triggers — both apply
+		// here since the loop dials AND consumes a detach byte.
+		time.Sleep(attachConnectGrace)
 		if writeErr := session.Write(sbshDetachSequence); writeErr != nil {
 			// Best-effort: a session that has already exited (race
 			// fired) closes the PTY master and returns an error here.


### PR DESCRIPTION
## Summary

`TestKuke_RunFromStopped_NonRootKukeonGroup_NoEACCES` defined its own `runFromStoppedAttachGrace = 1 * time.Second` to consume the EACCES window before sending the detach keystroke, but the scenario also depends on the in-process pkg/attach loop entering raw mode and wiring its keystroke filter — the *exact* race the peer `attachConnectGrace = 2 * time.Second` (used by `TestKuke_AttachDetach_KeepsTaskRunning`) was sized for. A 1s grace risks the detach byte arriving before the filter is live: the byte is forwarded verbatim, the workload never sees a detach signal, and the test would hang to the 20s exit timeout on a CI runner with no `permission denied` in output — attributing the failure to a non-existent regression.

Consolidate onto the existing `attachConnectGrace`. The constant's docstring ("complete the unix-socket handshake") already covers the dial-side concern (the EACCES window), so the longer 2s grace covers both purposes. At 20 iterations the added 1s/iter (20s total) stays well inside the e2e suite's 60s per-test budget on a healthy runner.

The use-site comment now spells out the dual-purpose so a future reader sees why this scenario reaches for the peer's grace.

Surfaced during review of #913.

## Test plan

- [x] `go vet ./e2e/` clean
- [x] `go test -c ./e2e/` compiles (e2e test binary builds)
- [ ] Full e2e suite — `make dev-init` smoke not run for this comment + sleep-duration tweak; deferred to PR-time CI

Closes #914