### PR TITLE
fix(get): restore SYNC column to kuke get cell default table

### DIFF
--- a/cmd/kuke/get/cell/cell.go
+++ b/cmd/kuke/get/cell/cell.go
@@ -25,11 +25,22 @@ import (
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/cmd/kuke/get/shared"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+)
+
+const (
+	// syncStateSynced / syncStateOutOfSync / syncStateNone are the SYNC
+	// column verdicts. syncStateNone follows the established `-` convention
+	// for cells without kukeon.io/config lineage — the reconciler does not
+	// track sync state for hand-built or -b-lineage cells.
+	syncStateSynced    = "Synced"
+	syncStateOutOfSync = "OutOfSync"
+	syncStateNone      = "-"
 )
 
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
@@ -42,18 +53,27 @@ func NewCellCmd() *cobra.Command {
 		Short:   "Get or list cell information",
 		Long: `Get or list cell information.
 
-The default table is ` + "`NAME REALM SPACE STACK STATE AGE`" + `.
-` + "`-o wide`" + ` appends two cell-only signals:
+The default table is ` + "`NAME REALM SPACE STACK STATE SYNC AGE`" + `.
+The SYNC column carries the reconciler-detected sync verdict for each
+cell relative to its lineage Config:
+
+  Synced     - the live spec matches what the lineage Config materializes
+  OutOfSync  - divergence detected (or the lineage Config was deleted)
+  -          - the cell carries no kukeon.io/config lineage label, so the
+               Config reconciler does not track sync state for it
+
+` + "`-o wide`" + ` appends three cell-only signals:
 
   CONTAINERS  ready/total — entries in status.containers whose
               state == Ready over the total length
   BRIDGE      status.network.bridgeName (the canonical k-{8hex}
               form) or "-" when empty
+  DIVERGENCE  short divergence summary from status.outOfSyncReason
+              (blank for Synced or no-lineage rows)
 
-Reconciler-detected sync state (outOfSync / outOfSyncReason /
-outOfSyncError) and the cgroup path no longer appear in any
-` + "`kuke get cell`" + ` table — surface them with ` + "`-o yaml` / `-o json`" + `
-when needed.`,
+The full outOfSync / outOfSyncReason / outOfSyncError status fields
+remain on ` + "`-o yaml` / `-o json`" + ` and the cgroup path stays out of the
+table — surface it with ` + "`-o yaml` / `-o json`" + ` when needed.`,
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -206,6 +226,40 @@ func renderBridge(c *v1beta1.CellDoc) string {
 	return "-"
 }
 
+// renderSync returns the SYNC column verdict. Cells without
+// kukeon.io/config lineage render `-` (the reconciler does not track sync
+// state for them); Config-lineage cells render `Synced` or `OutOfSync`
+// from Status.OutOfSync. OutOfSyncError details surface separately under
+// `-o yaml` / `-o json`.
+func renderSync(c *v1beta1.CellDoc) string {
+	if !hasConfigLineage(c) {
+		return syncStateNone
+	}
+	if c.Status.OutOfSync {
+		return syncStateOutOfSync
+	}
+	return syncStateSynced
+}
+
+// renderDivergence returns the DIVERGENCE column value for `-o wide`.
+// Returns Status.OutOfSyncReason for OutOfSync rows, empty string for
+// Synced or no-lineage rows (the column stays width-aligned via the
+// header label).
+func renderDivergence(c *v1beta1.CellDoc) string {
+	if hasConfigLineage(c) && c.Status.OutOfSync {
+		return c.Status.OutOfSyncReason
+	}
+	return ""
+}
+
+// hasConfigLineage reports whether a cell carries the kukeon.io/config
+// back-reference label (mirroring the configLineage helper in
+// internal/controller/reconcile_outofsync.go). Replicated inline rather
+// than imported to keep the CLI leaf off internal/controller.
+func hasConfigLineage(c *v1beta1.CellDoc) bool {
+	return strings.TrimSpace(c.Metadata.Labels[cellconfig.LabelConfig]) != ""
+}
+
 // filterCellsBySelector returns the subset of cells whose
 // Metadata.Labels satisfy selector. A nil or empty selector returns the
 // input slice unmodified so the common no-flag path skips the allocation.
@@ -247,9 +301,9 @@ func printCells(
 			cmd.Println("No cells found.")
 			return nil
 		}
-		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "AGE"}
+		headers := []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "SYNC", "AGE"}
 		if wide {
-			headers = append(headers, "CONTAINERS", "BRIDGE")
+			headers = append(headers, "CONTAINERS", "BRIDGE", "DIVERGENCE")
 		}
 		now := time.Now()
 		rows := make([][]string, 0, len(cells))
@@ -262,10 +316,11 @@ func printCells(
 				c.Spec.SpaceID,
 				c.Spec.StackID,
 				state,
+				renderSync(c),
 				shared.RenderAge(c.Status.CreatedAt, now),
 			}
 			if wide {
-				row = append(row, renderContainers(c), renderBridge(c))
+				row = append(row, renderContainers(c), renderBridge(c), renderDivergence(c))
 			}
 			rows = append(rows, row)
 		}

--- a/cmd/kuke/get/cell/cell_test.go
+++ b/cmd/kuke/get/cell/cell_test.go
@@ -139,8 +139,8 @@ func TestNewCellCmd(t *testing.T) {
 }
 
 // TestNewCellCmd_DefaultColumns pins the default `kuke get cell` column set
-// after the epic:get redefinition (issue #604): NAME REALM SPACE STACK STATE
-// AGE — six columns, no SYNC / CGROUP / CONTAINERS / BRIDGE / DIVERGENCE.
+// after #929 restored SYNC: NAME REALM SPACE STACK STATE SYNC AGE — seven
+// columns, no CGROUP / CONTROLLERS / CONTAINERS / BRIDGE / DIVERGENCE.
 func TestNewCellCmd_DefaultColumns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
@@ -173,21 +173,22 @@ func TestNewCellCmd_DefaultColumns(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, h := range []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "AGE"} {
+	for _, h := range []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "SYNC", "AGE"} {
 		if !strings.Contains(out, h) {
 			t.Errorf("default table missing header %q\nGot:\n%s", h, out)
 		}
 	}
-	for _, denied := range []string{"CGROUP", "CONTROLLERS", "SYNC", "DIVERGENCE", "CONTAINERS", "BRIDGE"} {
+	for _, denied := range []string{"CGROUP", "CONTROLLERS", "DIVERGENCE", "CONTAINERS", "BRIDGE"} {
 		if strings.Contains(out, denied) {
 			t.Errorf("default table must NOT contain %q; got:\n%s", denied, out)
 		}
 	}
 }
 
-// TestNewCellCmd_WideColumns pins the `-o wide` column set after the
-// epic:get redefinition: NAME REALM SPACE STACK STATE AGE CONTAINERS BRIDGE
-// (8 cols). CGROUP, SYNC, DIVERGENCE must not appear.
+// TestNewCellCmd_WideColumns pins the `-o wide` column set after #929
+// restored SYNC + DIVERGENCE: NAME REALM SPACE STACK STATE SYNC AGE
+// CONTAINERS BRIDGE DIVERGENCE (10 cols). CGROUP / CONTROLLERS must not
+// appear.
 func TestNewCellCmd_WideColumns(t *testing.T) {
 	t.Cleanup(viper.Reset)
 
@@ -221,12 +222,15 @@ func TestNewCellCmd_WideColumns(t *testing.T) {
 	}
 
 	out := buf.String()
-	for _, h := range []string{"NAME", "REALM", "SPACE", "STACK", "STATE", "AGE", "CONTAINERS", "BRIDGE"} {
+	for _, h := range []string{
+		"NAME", "REALM", "SPACE", "STACK", "STATE", "SYNC", "AGE",
+		"CONTAINERS", "BRIDGE", "DIVERGENCE",
+	} {
 		if !strings.Contains(out, h) {
 			t.Errorf("-o wide table missing header %q\nGot:\n%s", h, out)
 		}
 	}
-	for _, denied := range []string{"CGROUP", "CONTROLLERS", "SYNC", "DIVERGENCE"} {
+	for _, denied := range []string{"CGROUP", "CONTROLLERS"} {
 		if strings.Contains(out, denied) {
 			t.Errorf("-o wide table must NOT contain %q; got:\n%s", denied, out)
 		}
@@ -235,6 +239,108 @@ func TestNewCellCmd_WideColumns(t *testing.T) {
 		if !strings.Contains(out, sub) {
 			t.Errorf("-o wide row missing %q\nGot:\n%s", sub, out)
 		}
+	}
+}
+
+// TestNewCellCmd_SyncColumn pins the three SYNC verdicts (issue #929):
+// no-lineage → `-`; Config-lineage + OutOfSync=false → `Synced`;
+// Config-lineage + OutOfSync=true → `OutOfSync`. Also covers the
+// DIVERGENCE column under `-o wide`: the reason string appears for
+// OutOfSync rows and is absent for Synced / no-lineage rows.
+func TestNewCellCmd_SyncColumn(t *testing.T) {
+	const reason = "image pin drift"
+
+	tests := []struct {
+		name         string
+		labels       map[string]string
+		outOfSync    bool
+		reason       string
+		wantSync     string
+		wantInWide   []string // substrings that must appear in -o wide output
+		denyFromWide []string // substrings that must NOT appear in -o wide output
+	}{
+		{
+			name:         "no lineage renders dash",
+			labels:       nil,
+			wantSync:     "-",
+			denyFromWide: []string{reason},
+		},
+		{
+			name:         "lineage + synced renders Synced",
+			labels:       map[string]string{"kukeon.io/config": "prod"},
+			outOfSync:    false,
+			wantSync:     "Synced",
+			denyFromWide: []string{reason},
+		},
+		{
+			name:       "lineage + out of sync renders OutOfSync and surfaces DIVERGENCE",
+			labels:     map[string]string{"kukeon.io/config": "prod"},
+			outOfSync:  true,
+			reason:     reason,
+			wantSync:   "OutOfSync",
+			wantInWide: []string{reason},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			listFn := func(_, _, _ string) ([]v1beta1.CellDoc, error) {
+				return []v1beta1.CellDoc{{
+					Metadata: v1beta1.CellMetadata{Name: "ce1", Labels: tt.labels},
+					Spec:     v1beta1.CellSpec{RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+					Status: v1beta1.CellStatus{
+						State:           v1beta1.CellStateReady,
+						OutOfSync:       tt.outOfSync,
+						OutOfSyncReason: tt.reason,
+					},
+				}}, nil
+			}
+
+			// Default table: SYNC verdict must render.
+			buf := &bytes.Buffer{}
+			cmd := cell.NewCellCmd()
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, cell.MockControllerKey{},
+				kukeonv1.Client(&fakeClient{listCellsFn: listFn}))
+			cmd.SetContext(ctx)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("default table: unexpected error: %v", err)
+			}
+			out := buf.String()
+			if !strings.Contains(out, tt.wantSync) {
+				t.Errorf("default table missing SYNC verdict %q\nGot:\n%s", tt.wantSync, out)
+			}
+
+			// -o wide: SYNC + DIVERGENCE behavior.
+			buf.Reset()
+			cmd = cell.NewCellCmd()
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"-o", "wide"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("-o wide: unexpected error: %v", err)
+			}
+			wide := buf.String()
+			if !strings.Contains(wide, "DIVERGENCE") {
+				t.Errorf("-o wide missing DIVERGENCE header\nGot:\n%s", wide)
+			}
+			for _, sub := range tt.wantInWide {
+				if !strings.Contains(wide, sub) {
+					t.Errorf("-o wide missing %q\nGot:\n%s", sub, wide)
+				}
+			}
+			for _, sub := range tt.denyFromWide {
+				if strings.Contains(wide, sub) {
+					t.Errorf("-o wide must NOT contain %q\nGot:\n%s", sub, wide)
+				}
+			}
+		})
 	}
 }
 
@@ -331,9 +437,11 @@ func TestNewCellCmd_NoShowControllersFlag(t *testing.T) {
 	}
 }
 
-// TestNewCellCmd_YamlSurfacesStatus pins the contract that the cell table
-// no longer surfaces sync state or cgroup info, but `-o yaml` still does —
-// operators who need those fields read them from the structured output.
+// TestNewCellCmd_YamlSurfacesStatus pins the contract that `-o yaml`
+// continues to surface the full sync state and cgroup info — the table's
+// SYNC column carries the verdict, but operators who need the underlying
+// fields (CgroupPath, OutOfSyncReason, OutOfSyncError) read them from
+// the structured output.
 func TestNewCellCmd_YamlSurfacesStatus(t *testing.T) {
 	t.Cleanup(viper.Reset)
 


### PR DESCRIPTION
## Summary

- Restores the `SYNC` column to the default `kuke get cell` table (placement: after `STATE`, before `AGE` — mirroring the layout originally landed by #841 before #885 dropped it via rebase).
- Adds `DIVERGENCE` to `-o wide` (after `BRIDGE`) showing the short divergence summary from `Status.OutOfSyncReason`.
- Updates the long help text on `cmd/kuke/get/cell/cell.go` — removes the stale "no longer appear in any `kuke get cell` table" sentence and documents the restored column.

Regression source: PR #885 closing #604 rebased over #841 and dropped `SYNC` without restoring it in the new default layout. Status fields (`Status.OutOfSync`, `Status.OutOfSyncReason`, `Status.OutOfSyncError`) on the model are intact and still populated by the reconciler; this fix is presentation-only.

SYNC verdict rules per #929's AC:
- `Synced` when the cell has `kukeon.io/config` lineage and `Status.OutOfSync == false`.
- `OutOfSync` when the cell has `kukeon.io/config` lineage and `Status.OutOfSync == true`.
- `-` when the cell has no `kukeon.io/config` lineage.

DIVERGENCE renders `Status.OutOfSyncReason` for OutOfSync rows and an empty string for Synced or no-lineage rows.

## Test plan

- [x] `make test-root` — full repo unit-test suite passes (`cmd/kuke/get/cell` covered).
- [x] `make kuke` — binary builds clean; `./kuke get cell --help` shows the updated long help text with the `SYNC` column block restored and the stale "no longer appear" sentence removed.
- [x] `cmd/kuke/get/cell/cell_test.go` covers: default table headers include `SYNC`; `-o wide` includes `DIVERGENCE`; Config-lineage + OutOfSync=false renders `Synced`; Config-lineage + OutOfSync=true renders `OutOfSync` and surfaces the reason under DIVERGENCE; no-lineage cell renders `-` and shows no DIVERGENCE text.
- [ ] `make dev-init` smoke — daemon-parity tail still byte-stable across `--no-daemon` (deferred to reviewer environment; this PR does not touch `cmd/kuke/get/realm` or the daemon-parity check itself).

Closes #929