### PR TITLE
fix(run): retry attach on EACCES/ENOENT so stale pre-fix tty socket does not block kuke run

### DIFF
--- a/cmd/kuke/run/attach.go
+++ b/cmd/kuke/run/attach.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 	"time"
 
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
@@ -33,11 +34,14 @@ import (
 )
 
 // attachPingRetryBudget bounds the total wall-clock time runWithPingRetry
-// will spend re-invoking attach.Run when sbsh's per-attempt 3 s ping
-// window keeps firing before kuketty's Serve() accept loop has come
-// up. Each attempt re-pays the 3 s window inside sbsh, so a 10 s budget
-// covers two retries past the initial attempt on the slow-host race
-// that #926 documents.
+// will spend re-invoking attach.Run while the failure looks like a
+// kuketty boot-race class — either sbsh's per-attempt 3 s ping window
+// firing (#926) or dial(2) returning EACCES/ENOENT against a stale
+// pre-fix tty socket (#933). Each ping-deadline attempt re-pays the
+// 3 s window inside sbsh, so a 10 s budget covers two retries past
+// the initial attempt on the slow-host race. The stale-socket window
+// is sub-second once kuketty is up, so the same budget comfortably
+// absorbs it.
 //
 //nolint:gochecknoglobals // test seam for the production retry budget
 var attachPingRetryBudget = 10 * time.Second
@@ -46,7 +50,8 @@ var attachPingRetryBudget = 10 * time.Second
 // short on purpose: the dominant wait is sbsh's per-attempt 3 s ping
 // window, not this gap. The backoff exists only to avoid a tight loop
 // on the chance the prior attempt failed for a reason that resolves
-// in microseconds.
+// in microseconds — including the stale-socket Remove→Listen gap
+// (#933), which is sub-millisecond in practice.
 //
 //nolint:gochecknoglobals // test seam for the production retry backoff
 var attachPingRetryBackoff = 200 * time.Millisecond
@@ -203,33 +208,39 @@ func resolveRun(cmd *cobra.Command) runFn {
 	return attach.Run
 }
 
-// runWithPingRetry retries run() while the failure looks like sbsh's
-// per-attempt 3 s control-socket ping deadline firing before kuketty
-// has entered Serve()'s Accept loop. The dial(2) succeeds as soon as
-// kuketty's bind(2) lands (the kernel queues the connect into the
-// listening socket's backlog), so the post-StartCell attach can race
-// kuketty's Serve() boot — a window distinct from the EACCES one
-// #918 closed (#926).
+// runWithPingRetry retries run() while the failure looks like a
+// kuketty boot-race class — either sbsh's per-attempt 3 s ping
+// deadline firing before kuketty has entered Serve()'s Accept loop
+// (#926), or dial(2) returning EACCES/ENOENT against a stale pre-fix
+// tty socket that the new kuketty has not yet unlinked and re-bound
+// (#933). Both classes share the same retry budget and backoff: the
+// post-StartCell attach can race either window, and a kuketty whose
+// stale socket has been replaced does not re-enter the EACCES window
+// on subsequent runs (the race window collapses to the sub-millisecond
+// Remove→Listen gap inside kuketty's init path).
 //
 // Behaviour:
-//   - non-ping-timeout errors propagate immediately; the existing
+//   - non-boot-race errors propagate immediately; the existing
 //     ClassifyAttachExit branch handles them.
-//   - ping-timeout errors are retried with attachPingRetryBackoff
+//   - boot-race errors are retried with attachPingRetryBackoff
 //     between attempts until either run() succeeds, the outer ctx
 //     is cancelled (returns ctx.Err), or attachPingRetryBudget is
-//     exhausted (returns the last runErr wrapped with
-//     errdefs.ErrAttachPingTimeout so callers can errors.Is the
-//     timeout class without string-matching sbsh's wrap).
+//     exhausted (returns the last runErr wrapped with the matching
+//     sentinel — errdefs.ErrAttachPingTimeout for the ping-deadline
+//     class, errdefs.ErrAttachStaleSocket for the EACCES/ENOENT
+//     class — so callers can errors.Is either class without
+//     string-matching sbsh's wrap or sniffing for raw errno values).
 func runWithPingRetry(ctx context.Context, run runFn, opts attach.Options) error {
 	deadline := time.Now().Add(attachPingRetryBudget)
 	var lastErr error
 	for {
 		lastErr = run(ctx, opts)
-		if !isAttachPingTimeout(ctx, lastErr) {
+		sentinel := attachBootRaceSentinel(ctx, lastErr)
+		if sentinel == nil {
 			return lastErr
 		}
 		if !time.Now().Before(deadline) {
-			return fmt.Errorf("%w: %w", errdefs.ErrAttachPingTimeout, lastErr)
+			return fmt.Errorf("%w: %w", sentinel, lastErr)
 		}
 		select {
 		case <-ctx.Done():
@@ -239,24 +250,34 @@ func runWithPingRetry(ctx context.Context, run runFn, opts attach.Options) error
 	}
 }
 
-// isAttachPingTimeout reports whether err is the sbsh "ping failed:
-// context deadline exceeded" class that runWithPingRetry treats as a
-// readiness-handshake race rather than a hard failure. The classifier
-// is conservative on purpose:
+// attachBootRaceSentinel classifies err as one of the kuketty boot-race
+// classes runWithPingRetry treats as a readiness handshake rather than
+// a hard failure, returning the matching errdefs sentinel — or nil
+// when err is not retryable. The classifier is conservative on purpose:
 //
 //   - err must be non-nil (a clean detach is not a retry condition);
 //   - ctx must not be done (a cancelled outer ctx surfaces as
 //     DeadlineExceeded on the inner WithTimeout child, but is the
 //     operator's ^C not kuketty's boot race — don't retry);
-//   - context.DeadlineExceeded must appear in the chain (the only
-//     bounded-timeout in sbsh's attach.Run setup is the 3 s ping
-//     window in clientrunner/io.go dialTerminalCtrlSocket).
-func isAttachPingTimeout(ctx context.Context, err error) bool {
+//   - context.DeadlineExceeded in the chain maps to ErrAttachPingTimeout
+//     (the only bounded-timeout in sbsh's attach.Run setup is the 3 s
+//     ping window in clientrunner/io.go dialTerminalCtrlSocket);
+//   - syscall.EACCES / syscall.ENOENT in the chain map to
+//     ErrAttachStaleSocket (the stale pre-fix tty socket window —
+//     EACCES against a 0o640 stale inode, or ENOENT against the
+//     Remove→Listen gap inside kuketty's init path; #933).
+func attachBootRaceSentinel(ctx context.Context, err error) error {
 	if err == nil {
-		return false
+		return nil
 	}
 	if ctx.Err() != nil {
-		return false
+		return nil
 	}
-	return errors.Is(err, context.DeadlineExceeded)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return errdefs.ErrAttachPingTimeout
+	}
+	if errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.ENOENT) {
+		return errdefs.ErrAttachStaleSocket
+	}
+	return nil
 }

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -29,6 +29,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -5706,5 +5707,162 @@ func TestRun_Attach_NonPingError_DoesNotRetry(t *testing.T) {
 	defer mu.Unlock()
 	if calls != 1 {
 		t.Errorf("attach loop calls=%d, want 1 (non-ping errors must not retry)", calls)
+	}
+}
+
+// staleSocketErr returns an error chain that mirrors the surface
+// `kuke run` sees when sbsh's pkg/attach dial(2) hits a stale pre-fix
+// kuketty tty socket — `ping failed: dial unix /opt/kukeon/s/<hash>:
+// connect: permission denied`. The chain carries syscall.EACCES so
+// the runWithPingRetry classifier sees the same surface real sbsh
+// returns through net.OpError → os.SyscallError → syscall.Errno
+// (#933).
+func staleSocketErr() error {
+	return fmt.Errorf("ping failed: dial unix /opt/kukeon/s/abc: connect: %w", syscall.EACCES)
+}
+
+// staleSocketENOENTErr returns an error chain that mirrors the
+// sub-millisecond Remove→Listen gap inside new kuketty's init path —
+// the stale inode has been unlinked but the replacement bind(2) has
+// not landed, so dial(2) returns ENOENT. Defense-in-depth path
+// alongside the dominant EACCES window (#933).
+func staleSocketENOENTErr() error {
+	return fmt.Errorf("ping failed: dial unix /opt/kukeon/s/abc: connect: %w", syscall.ENOENT)
+}
+
+// TestRun_Attach_StaleSocket_EACCES_RetriesWithinBudget pins the
+// stale-socket guarantee from #933: when the first call into the
+// in-process attach loop fails with EACCES against a stale pre-fix
+// kuketty tty socket (mode 0o640, group-read only), runWithPingRetry
+// must retry instead of surfacing `connect: permission denied` to the
+// operator. Pre-fix this test fails: the original classifier matched
+// only context.DeadlineExceeded, so EACCES propagated straight through.
+func TestRun_Attach_StaleSocket_EACCES_RetriesWithinBudget(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	restore := runcmd.SetAttachPingRetryForTest(500*time.Millisecond, 10*time.Millisecond)
+	t.Cleanup(restore)
+
+	var calls int
+	var mu sync.Mutex
+	runFn := runcmd.RunFn(func(_ context.Context, _ sbshattach.Options) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return staleSocketErr()
+		}
+		return nil
+	})
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, runFn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v (want nil — retry must absorb the stale-socket EACCES)", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 2 {
+		t.Errorf("attach loop calls=%d, want 2 (one EACCES, one success)", calls)
+	}
+}
+
+// TestRun_Attach_StaleSocket_EACCES_BudgetExhausted_WrapsSentinel pins
+// the budget-exhausted surface for the stale-socket class: when dial(2)
+// keeps firing EACCES past the budget, runWithPingRetry must surface
+// the readiness-race class via errdefs.ErrAttachStaleSocket so callers
+// can errors.Is the stale-socket failure without sniffing for raw
+// syscall.EACCES (#933).
+func TestRun_Attach_StaleSocket_EACCES_BudgetExhausted_WrapsSentinel(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	restore := runcmd.SetAttachPingRetryForTest(50*time.Millisecond, 10*time.Millisecond)
+	t.Cleanup(restore)
+
+	var calls int
+	var mu sync.Mutex
+	runFn := runcmd.RunFn(func(_ context.Context, _ sbshattach.Options) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return staleSocketErr()
+	})
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, runFn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachStaleSocket) {
+		t.Fatalf("err=%v, want chain to include errdefs.ErrAttachStaleSocket", err)
+	}
+	if !errors.Is(err, syscall.EACCES) {
+		t.Errorf(
+			"err=%v, want chain to preserve syscall.EACCES so operators can still see the underlying cause",
+			err,
+		)
+	}
+	if errors.Is(err, errdefs.ErrAttachPingTimeout) {
+		t.Errorf("err=%v, must NOT be wrapped with ErrAttachPingTimeout — EACCES is the stale-socket class, not ping-timeout", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls < 2 {
+		t.Errorf("attach loop calls=%d, want >= 2 (at least one retry before budget exhaustion)", calls)
+	}
+}
+
+// TestRun_Attach_StaleSocket_ENOENT_RetriesWithinBudget pins the
+// defense-in-depth ENOENT retry: the sub-millisecond gap between
+// kuketty's os.Remove of the stale inode and its listenUnixWithMode
+// bind(2) on the replacement surfaces as ENOENT from dial(2), and
+// runWithPingRetry must absorb that window the same way it absorbs
+// the dominant EACCES one (#933).
+func TestRun_Attach_StaleSocket_ENOENT_RetriesWithinBudget(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	restore := runcmd.SetAttachPingRetryForTest(500*time.Millisecond, 10*time.Millisecond)
+	t.Cleanup(restore)
+
+	var calls int
+	var mu sync.Mutex
+	runFn := runcmd.RunFn(func(_ context.Context, _ sbshattach.Options) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return staleSocketENOENTErr()
+		}
+		return nil
+	})
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: attachSuccessFn(),
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, runFn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v (want nil — retry must absorb the stale-socket ENOENT)", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 2 {
+		t.Errorf("attach loop calls=%d, want 2 (one ENOENT, one success)", calls)
 	}
 }

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -300,6 +300,19 @@ var (
 	// wrap (#926).
 	ErrAttachPingTimeout = errors.New("attach ping timed out: kuketty control socket bound but not yet serving")
 
+	// ErrAttachStaleSocket is returned by the post-StartCell attach loop
+	// in cmd/kuke/run when dial(2) keeps failing with EACCES (or ENOENT)
+	// past the retry budget because a stale tty socket from a kuketty
+	// binary predating sbsh#361 still occupies the path with mode 0o640
+	// (or has been unlinked but not yet re-bound). New kuketty's
+	// listenUnixWithMode landed in v0.12.1 and closes the *new-socket*
+	// EACCES race, but the *stale-socket* race remains until the new
+	// kuketty inside the cell finishes its os.Remove + listenUnixWithMode
+	// init path. Promoted from raw syscall.EACCES / syscall.ENOENT at the
+	// kukeon boundary so callers can errors.Is the readiness-race class
+	// without sniffing for raw errno values (#933).
+	ErrAttachStaleSocket = errors.New("attach stale socket: kuketty has not yet unlinked the pre-fix tty socket")
+
 	// ErrSocketPathTooLong fires when the resolved host-side path of a
 	// per-container kuketty control socket would overflow Linux's
 	// sockaddr_un.sun_path buffer (consts.KukeonMaxSocketPath bytes plus


### PR DESCRIPTION
## Summary

- Extend `runWithPingRetry` / classifier in `cmd/kuke/run/attach.go` to also treat `syscall.EACCES` and `syscall.ENOENT` as kuketty boot-race classes, alongside the existing `context.DeadlineExceeded` (ping-deadline) path. Both share the same `attachPingRetryBudget` / `attachPingRetryBackoff`.
- Add `errdefs.ErrAttachStaleSocket` for the EACCES/ENOENT class so callers can `errors.Is` the stale-socket failure without sniffing for raw errno values; budget-exhausted wraps the matching sentinel (`ErrAttachPingTimeout` for the ping class, `ErrAttachStaleSocket` for the stale-socket class).
- Rename internal classifier `isAttachPingTimeout` → `attachBootRaceSentinel` (returns the matching sentinel or nil) to reflect the broader scope.

## Root cause

Per the issue: on a host where the kuketty binary has just been upgraded across sbsh#361, a cell that was last started by the pre-fix binary leaves a stale tty socket at mode `0o640` (group read, no write). `kuke run <stopped-cell>` calls `StartCell`, waits the 300 ms post-start liveness probe, then dials the symlink — at which point new-kuketty (inside the container) is still in its init path and has not yet called `os.Remove` + `listenUnixWithMode` to replace the stale inode. `connect(2)` returns `EACCES` against the stale 0o640 socket, and the previous `runWithPingRetry` only matched `context.DeadlineExceeded`, so the failure propagated immediately. Once kuketty unlinks the stale socket and binds the replacement at `0o660`, the retry succeeds; after the first post-upgrade start, the race window collapses to the sub-millisecond Remove→Listen gap inside kuketty's init (the `ENOENT` defense-in-depth path).

## Test plan

- [x] `GOWORK=off GOTOOLCHAIN=go1.24.5 go test ./cmd/kuke/run/ -run 'TestRun_Attach_StaleSocket' -count=1 -v` — three new tests cover EACCES retry-within-budget, EACCES budget-exhausted wrapping `ErrAttachStaleSocket` (and preserving `syscall.EACCES` in the chain, and NOT wrapping `ErrAttachPingTimeout`), and ENOENT retry-within-budget.
- [x] `GOWORK=off GOTOOLCHAIN=go1.24.5 go test ./cmd/kuke/run/ -count=1` — full package green; the pre-existing `TestRun_Attach_PingDeadline_*` and `TestRun_Attach_NonPingError_DoesNotRetry` still pass under the renamed classifier.
- [x] `GOWORK=off GOTOOLCHAIN=go1.24.5 make test-root` — full root-module suite green.
- [x] `GOWORK=off GOTOOLCHAIN=go1.24.5 go vet ./cmd/kuke/run/ ./internal/errdefs/` — clean.
- [ ] `make dev-init` — not exercised; this change is client-side only (no daemon, build-path, or `/opt/kukeon` touch), so the daemon-parity smoke does not apply per CLAUDE.md.

Closes #933

## Related

- #928 — retry on ping-deadline (kuketty `Serve()` boot race; the path this PR extends)
- #918 — closed the new-socket EACCES race upstream; this PR closes the stale-socket EACCES race that the new-kuketty's first post-upgrade start cannot avoid
- sbsh#361 / sbsh v0.12.1 — upstream `listenUnixWithMode` fix