### PR TITLE
fix(run): re-apply attach socket mode in no-op StartCell so old-kuketty wrong-mode socket is corrected

### DIFF
--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -586,6 +586,69 @@ func chownAttachableStaleChildren(root string, uid, gid int) error {
 	})
 }
 
+// attachableSocketReapplyMode is the mode the idempotent StartCell no-op
+// path (#935) re-asserts on a live per-container attach socket inode. It
+// mirrors ctr.AttachableSocketMode ("0660"): rw for the owning container
+// uid + rw for the kukeon group, no world. connect(2) on a Unix socket
+// requires write permission on the inode, so a socket an old kuketty
+// (pre-sbsh#361) bound with mode 0o640 (group-read only) is permanently
+// undialable by a kukeon-group member on the host. Re-chmod'ing the live
+// inode closes that window without bouncing the workload.
+const attachableSocketReapplyMode os.FileMode = 0o660
+
+// reapplyAttachableSocketPerms re-asserts the mode and group of every live
+// per-container attach socket on the StartCell idempotent no-op path (#935).
+//
+// When StartCell short-circuits because all container tasks are already
+// running, it skips the destructive recreate loop and with it
+// attachableBuildOpts + attachablePostCreateChown — so a socket an old
+// kuketty bound with the wrong mode (0o640 group-read only, the pre-sbsh#361
+// mode) is never corrected. A kukeon-group member on the host then dials
+// that live, listening socket and gets EACCES forever: the inode's mode
+// never changes during the attach retry window because nothing rewrites it
+// (the EACCES-retry fix from #933 only helps a socket about to be replaced
+// by a starting kuketty, not the permanent listener of a still-running one).
+//
+// The fix is a root-owned os.Chmod + os.Chown on the live socket inode:
+// idempotent when the mode is already correct (a post-#361 kuketty already
+// bound 0o660), and safe because it never restarts the workload. It is
+// best-effort — a per-container failure is logged and skipped rather than
+// failing the no-op StartCell, because the cell is already healthy and
+// running and a chmod miss must not regress the idempotent-skip contract.
+// A socket kuketty has not bound yet (ENOENT) is a benign no-op: the normal
+// startup chown path will set the mode when the listener appears.
+func (r *Exec) reapplyAttachableSocketPerms(cell intmodel.Cell) {
+	for i := range cell.Spec.Containers {
+		spec := cell.Spec.Containers[i]
+		if !spec.Attachable {
+			continue
+		}
+		socketPath := fs.ContainerSocketPath(
+			r.opts.RunPath,
+			spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+		)
+		if chmodErr := os.Chmod(socketPath, attachableSocketReapplyMode); chmodErr != nil {
+			if errors.Is(chmodErr, os.ErrNotExist) {
+				continue
+			}
+			r.logger.WarnContext(r.ctx,
+				"failed to re-chmod attachable socket on idempotent StartCell skip",
+				"socket", socketPath, "error", chmodErr)
+			continue
+		}
+		// Leave the owning uid untouched (-1); only re-assert the kukeon
+		// group when one is configured, mirroring attachablePostCreateChown.
+		if gid := r.opts.KukeonGroupGID; gid > 0 {
+			if chownErr := os.Chown(socketPath, -1, gid); chownErr != nil &&
+				!errors.Is(chownErr, os.ErrNotExist) {
+				r.logger.WarnContext(r.ctx,
+					"failed to re-chown attachable socket group on idempotent StartCell skip",
+					"socket", socketPath, "gid", gid, "error", chownErr)
+			}
+		}
+	}
+}
+
 // attachableSocketSymlinkDirMode is the mode applied to <RunPath>/s when
 // the runner stages it on first Attachable provision. 0o755 mirrors the
 // /opt/kukeon root layout: world-traversable so any process can resolve a

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -891,6 +891,137 @@ func TestRemoveAttachableSocketRuntimeArtifacts_SkipsNonAttachable(t *testing.T)
 	}
 }
 
+// seedAttachableSocket stages a plain file standing in for the bound
+// kuketty socket inode at the deep ContainerSocketPath, created with mode.
+// A regular file is sufficient: os.Chmod / os.Stat are inode-mode
+// operations and do not distinguish a socket from a file, the same way the
+// teardown tests above stand in a regular file for the bound socket.
+func seedAttachableSocket(t *testing.T, runPath string, spec intmodel.ContainerSpec, mode os.FileMode) string {
+	t.Helper()
+	socketPath := fs.ContainerSocketPath(
+		runPath, spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o755); err != nil {
+		t.Fatalf("mkdir socket parent: %v", err)
+	}
+	if err := os.WriteFile(socketPath, nil, mode); err != nil {
+		t.Fatalf("seed socket inode: %v", err)
+	}
+	// WriteFile honours the umask; force the exact bits the test asserts on.
+	if err := os.Chmod(socketPath, mode); err != nil {
+		t.Fatalf("chmod seed socket: %v", err)
+	}
+	return socketPath
+}
+
+// TestReapplyAttachableSocketPerms_CorrectsWrongMode locks the #935 fix:
+// the StartCell idempotent no-op path must re-chmod a live attach socket an
+// old kuketty bound with the pre-sbsh#361 group-read-only mode (0o640) up to
+// the connect(2)-able 0o660, without which a kukeon-group member on the host
+// dials the live listener with EACCES forever (the #933 retry never helps —
+// the inode's mode never changes during the retry window).
+func TestReapplyAttachableSocketPerms_CorrectsWrongMode(t *testing.T) {
+	r := newTestRunner(t)
+	runPath := t.TempDir()
+	r.opts.RunPath = runPath
+
+	spec := intmodel.ContainerSpec{
+		ID:         "work",
+		RealmName:  "r1",
+		SpaceName:  "s1",
+		StackName:  "st1",
+		CellName:   "c1",
+		Attachable: true,
+	}
+	socketPath := seedAttachableSocket(t, runPath, spec, 0o640)
+
+	cell := intmodel.Cell{Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{spec}}}
+	r.reapplyAttachableSocketPerms(cell)
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat socket after reapply: %v", err)
+	}
+	if got := info.Mode().Perm(); got != attachableSocketReapplyMode {
+		t.Errorf("socket mode = %o, want %o (no-op StartCell path must correct the pre-#361 0o640 socket)",
+			got, attachableSocketReapplyMode)
+	}
+}
+
+// TestReapplyAttachableSocketPerms_IdempotentOnCorrectMode locks the
+// idempotency contract: a socket a post-sbsh#361 kuketty already bound at
+// 0o660 is left at 0o660. The re-chmod is a safe no-op on every healthy
+// StartCell skip.
+func TestReapplyAttachableSocketPerms_IdempotentOnCorrectMode(t *testing.T) {
+	r := newTestRunner(t)
+	runPath := t.TempDir()
+	r.opts.RunPath = runPath
+
+	spec := intmodel.ContainerSpec{
+		ID: "work", RealmName: "r1", SpaceName: "s1", StackName: "st1", CellName: "c1",
+		Attachable: true,
+	}
+	socketPath := seedAttachableSocket(t, runPath, spec, 0o660)
+
+	cell := intmodel.Cell{Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{spec}}}
+	r.reapplyAttachableSocketPerms(cell)
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat socket after reapply: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Errorf("socket mode = %o, want 0660 (already-correct socket must be left untouched)", got)
+	}
+}
+
+// TestReapplyAttachableSocketPerms_SkipsNonAttachable locks the
+// !Attachable short-circuit: the helper iterates every container in the
+// cell spec, so a root or non-sbsh-wrapped workload's inode at the deep
+// socket path must be left untouched.
+func TestReapplyAttachableSocketPerms_SkipsNonAttachable(t *testing.T) {
+	r := newTestRunner(t)
+	runPath := t.TempDir()
+	r.opts.RunPath = runPath
+
+	spec := intmodel.ContainerSpec{
+		ID: "root", RealmName: "r1", SpaceName: "s1", StackName: "st1", CellName: "c1",
+		Root:       true,
+		Attachable: false,
+	}
+	socketPath := seedAttachableSocket(t, runPath, spec, 0o640)
+
+	cell := intmodel.Cell{Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{spec}}}
+	r.reapplyAttachableSocketPerms(cell)
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat socket after reapply: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Errorf("non-attachable socket mode = %o, want 0640 (helper must short-circuit on !Attachable)", got)
+	}
+}
+
+// TestReapplyAttachableSocketPerms_TolerantMissingSocket locks the
+// best-effort contract: an Attachable container whose kuketty has not yet
+// bound the socket (ENOENT at the deep path) must be a silent no-op, not a
+// panic or a failed StartCell skip.
+func TestReapplyAttachableSocketPerms_TolerantMissingSocket(t *testing.T) {
+	r := newTestRunner(t)
+	r.opts.RunPath = t.TempDir()
+
+	spec := intmodel.ContainerSpec{
+		ID: "work", RealmName: "r1", SpaceName: "s1", StackName: "st1", CellName: "c1",
+		Attachable: true,
+	}
+	cell := intmodel.Cell{Spec: intmodel.CellSpec{Containers: []intmodel.ContainerSpec{spec}}}
+
+	// No socket inode seeded — the deep path resolves to ENOENT. The call
+	// must complete without panicking; there is nothing on disk to assert.
+	r.reapplyAttachableSocketPerms(cell)
+}
+
 func readDoc(t *testing.T, path string) extmodel.ContainerDoc {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -598,6 +598,14 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 				"error", err)
 			// best-effort, fall through with the Ready state we already set
 		}
+		// #935: this idempotent-skip path bypasses the destructive recreate
+		// below and with it attachableBuildOpts + attachablePostCreateChown,
+		// so a per-container attach socket an old kuketty bound with the wrong
+		// mode (pre-sbsh#361, 0o640 group-read only) is never corrected and
+		// `kuke run` dials the live listener with EACCES forever. Re-assert the
+		// socket mode/group on the live inode — idempotent when already correct
+		// and safe because it never restarts the running workload.
+		r.reapplyAttachableSocketPerms(internalCell)
 		skipFields := appendCellLogFields([]any{"id", containerID}, cellID, cellName)
 		skipFields = append(skipFields, "space", spaceID, "realm", realmID)
 		r.logger.InfoContext(


### PR DESCRIPTION
## Summary

- `kuke run <cell>` failed permanently with `connect: permission denied` when the cell's kuketty process was still running from before a `make dev-init` that updated the binary (#935). The old kuketty (pre-sbsh#361) bound its control socket with mode `0o640` (group-read only); `connect(2)` needs group-**write**, so a kukeon-group member on the host got EACCES forever. The #933 EACCES-retry never helped — the live listener's inode mode never changes during the retry window.
- Root cause: `StartCell` short-circuits when all container tasks are already running (`start.go:591`, "cell tasks already running, StartCell is a no-op") and that path skips `attachableBuildOpts` + `attachablePostCreateChown` entirely, so the wrong-mode socket is never corrected.
- Fix (issue's **approach #1** — the root-cause fix): in the idempotent no-op path, re-assert the live socket inode's mode (`0o660`, mirroring `ctr.AttachableSocketMode`) and the kukeon group on every Attachable container, via a new `reapplyAttachableSocketPerms`. A root-owned `os.Chmod` + `os.Chown` on the live inode is idempotent when the mode is already correct (a post-#361 kuketty already bound `0o660`) and never restarts the workload. This makes `kuke run` succeed against the still-running cell, satisfying the issue's "**Expected:** attach succeeds" terminal state.

### Note on the issue's two approaches

The issue lists two complementary approaches. I implemented **#1** (correct the socket in the daemon's no-op path) as the complete, root-cause fix — it makes attach actually succeed, which is the primary Expected outcome. I deliberately **deferred #2** (a client-side heuristic in `runWithPingRetry` to surface a clearer error after N persistent-EACCES retries):

- #1 resolves the reported failure entirely, so #2's clearer-error fallback is unreachable in the reported scenario.
- #2 is in direct tension with #933: the client cannot distinguish a *transient* EACCES (a starting kuketty about to re-bind the socket — must keep retrying for the full budget) from a *permanent* one (a still-running old kuketty) without a host-side heuristic. Cutting the EACCES budget short to surface an error would regress #933's transient case.

Documenting the call here so the reviewer can push back if #2 should also land (it would be a separable follow-up, not a blocker for the reported bug).

### Best-effort contract

`reapplyAttachableSocketPerms` is best-effort: a per-container chmod/chown failure is logged and skipped rather than failing the no-op StartCell, because the cell is already healthy and running and a chmod miss must not regress the idempotent-skip contract. A socket kuketty has not yet bound (ENOENT) is a benign no-op — the normal startup chown path sets the mode when the listener appears.

## Test plan

- [x] `go test ./internal/controller/runner/ -run ReapplyAttachableSocketPerms` — 4 new tests pass (corrects wrong mode → `0o660`; idempotent on already-correct `0o660`; skips non-Attachable; tolerant of missing socket).
- [x] Full CI `test-root` target (`go test $(go list ./... | grep -v /e2e)`) — exit 0, 0 failures.
- [x] `test-kukebuild` target (`cd cmd/kukebuild && go test ./...`) — exit 0.
- [x] `go build ./...` + `go vet ./internal/controller/runner/` — clean (run with `GOWORK=off GOTOOLCHAIN=go1.24.5` to match CI's go.mod-pinned toolchain; the agent dev host's go.work forces go 1.25.5, under which the vendored `containerd/cgroups` dep fails to compile — environmental, unrelated to this change).
- [x] `pre-commit` (incl. `golangci-lint --new-from-rev HEAD`) — **0 issues**. Note: the lint hook was OOM-killed (SIGKILL/-9, no diagnostics) on first runs because a concurrent agent session held a 4.8G RAM-backed tmpfs dir on this shared host; re-running with `GOGC=20 GOMEMLIMIT=450MiB GOMAXPROCS=1` fit it in available memory and it passed clean. The commit's own hook invocation passed with the same budget.
- [ ] `make dev-init` end-to-end smoke — not run: requires a destructive daemon re-bootstrap (`kuke daemon reset`) on the shared dev host, which would disrupt other concurrent agent sessions' running cells. The change only adds an idempotent chmod/chown in a daemon code path fully covered by the new unit tests; the daemon-parity tail is unaffected.

Closes #935