### PR TITLE
docs: surface containerdNamespaceSuffix and cgroupRoot in kuke.yaml example

### DIFF
--- a/docs/kuke.yaml
+++ b/docs/kuke.yaml
@@ -23,3 +23,9 @@ spec:
   containerdSocket: /run/containerd/containerd.sock
   # Client log level when `--verbose` is on (debug, info, warn, error).
   logLevel: info
+  # Suffix appended to every realm name to form its containerd namespace.
+  # Default: kukeon.io
+  containerdNamespaceSuffix: kukeon.io
+  # Cgroup root under which all realms / spaces / stacks / cells live.
+  # Default: /kukeon
+  cgroupRoot: /kukeon


### PR DESCRIPTION
## Summary
Best-effort documentation update applied from issue #909.
Mode: best-effort — the issue body identified the file and section but did not provide paste-ready Before/After wording, so wording was authored to match the issue's Proposal and Acceptance criteria.

## Files changed
- `docs/kuke.yaml` — `spec` section, after `logLevel`

## Editorial choices
- Used one-line descriptions condensed from the multi-line comments in `internal/clientconfig/clientconfig.go:99-111`, per the issue's "one-line description" guidance.
- Added `# Default: <value>` lines as the issue explicitly requests, even though the existing fields in `docs/kuke.yaml` do not currently carry them — the issue calls them out as part of the target style.
- Branch is named `doc/` rather than `docs/` because a ref collision with packed remote entries under `refs/remotes/origin/docs/` prevented creating a local `docs/` branch.

## Acceptance criteria check
- [x] `containerdNamespaceSuffix: kukeon.io` is present in `docs/kuke.yaml` with a header comment — done
- [x] `cgroupRoot: /kukeon` is present in `docs/kuke.yaml` with a header comment — done
- [x] Both fields are placed in the `spec` section consistent with the existing field layout — done
- [x] No out-of-scope sections touched — done

Closes #909