### PR TITLE
docs(claude.md): note kuke attach smoke covers attachable socket pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ Both `kuke get realms` and `kuke get realms --no-daemon` must produce the same s
 
 **If your change touches anything the daemon reads, this check must be in the PR's test plan.** Reviewer agent will flag PRs that miss it.
 
+After the daemon-parity tail, `scripts/dev-init.sh` also runs a PTY-driven `kuke attach` smoke against a kuketty-wrapped cell (`dev-init-attach/ds/dks/cattach`) — this exercises the attachable + kuketty socket pipeline end-to-end (post-create chown, `0o660 root:kukeon` socket mode, JSON-RPC + SCM_RIGHTS handshake, clean `^]^]` detach). Changes touching `internal/controller/runner/attachable.go` or any attach/kuketty socket path are validated by this phase; the no-op-StartCell wrong-mode reapply branch (#935/#936) is unreachable from CLI verbs (the higher-level `controller.StartCell` rejects already-running cells), so its specific correction behavior is covered exclusively by the unit tests in `internal/controller/runner/attachable_test.go`.
+
 ### Post-init: `kuke status`
 
 `kuke status` is the canonical equivalent of the manual diff ritual above —


### PR DESCRIPTION
## Summary

Post-merge follow-up audit for #936. Ran `make dev-init` end-to-end on a non-shared host (nested kukeon-dev-root, socket redirected to `/run/kukeon-dev/`) — smoke stays green, daemon-parity tail matches the regression guard, kuketty-wrapped attach smoke exits cleanly, parent attach plumbing intact post-flight. No regression surfaces in the daemon path PR #936 introduced.

Codifies the audit's one durable finding: the kuketty-wrapped `kuke attach` smoke phase covers the broader attachable socket pipeline end-to-end, but the specific no-op-StartCell wrong-mode reapply branch (#935/#936) is unreachable from CLI verbs — `controller.StartCell` rejects already-running cells before reaching `runner.StartCell`'s no-op idempotency guard — so its correction behavior is covered exclusively by the unit tests in `attachable_test.go`. This is useful operator-facing context that the current AGENTS.md (the file `CLAUDE.md` symlinks to) lacked.

## Verification

- `make dev-init` end-to-end smoke: ran twice, green both times. Second run initially failed on a CNI bridge IP collision caused by my own probing scaffold (`dev-init-attach937` realm I created to try to manually trigger the no-op StartCell path) — purging that realm and re-running produced the same clean tail as the first run. Daemon-parity tail in both runs:
  ```
  NAME         STATE  AGE
  -----------  -----  ---
  default      Ready  <age>
  kuke-system  Ready  <age>
  ```
- Manually attempted to trigger the no-op StartCell + `reapplyAttachableSocketPerms` path via `kuke start cell c937` against an already-running attachable cell: rejected at the `controller.StartCell` layer with `"cell has running containers and must first be stopped"`. Confirms the path is only reachable from internal bootstrap/reconcile flows (which is what makes it pre-existing-kuketty-bug-specific) — and what motivates this docs note.

## Test plan

- [x] Docs-only change (two-paragraph addition to `AGENTS.md`, which `CLAUDE.md` symlinks to); no code touched, no build/vet/test impact.
- [x] `make dev-init` end-to-end smoke green (see Verification).

Closes #937