### PR TITLE
fix(daemon): re-assert FORWARD admission chain on Serve startup

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -153,15 +153,15 @@ func (s *Server) Serve() error {
 	}
 
 	s.logger.InfoContext(s.ctx, "kukeond listening", "socket", s.opts.SocketPath)
-	if s.forwardAdmissionFn != nil {
-		if err := s.forwardAdmissionFn(); err != nil {
-			// Best-effort: a flushed/unavailable FORWARD admission chain must
-			// not block the daemon from serving. The next reboot self-heals
-			// here; durable per-space egress + Docker-churn handling is #953.
-			s.logger.WarnContext(s.ctx,
-				"forward admission re-assert failed on startup; continuing",
-				"error", err)
-		}
+	// NewServer always wires forwardAdmissionFn; call it unguarded to match the
+	// reconcileFn pattern (runReconcileOnce dereferences s.reconcileFn directly).
+	if err := s.forwardAdmissionFn(); err != nil {
+		// Best-effort: a flushed/unavailable FORWARD admission chain must
+		// not block the daemon from serving. The next reboot self-heals
+		// here; durable per-space egress + Docker-churn handling is #953.
+		s.logger.WarnContext(s.ctx,
+			"forward admission re-assert failed on startup; continuing",
+			"error", err)
 	}
 	s.startReconcileLoop()
 	s.acceptLoop(listener)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/eminwux/kukeon/internal/client/local"
 	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/firewall"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 )
 
@@ -72,6 +73,11 @@ type Server struct {
 	// it before Serve so they exercise the ticker without a real controller.
 	reconcileFn func() (controller.ReconcileResult, error)
 
+	// forwardAdmissionFn re-asserts the host FORWARD admission chain once on
+	// Serve startup. Defaults to reassertForwardAdmission; tests overwrite it
+	// before Serve so they exercise the startup hook without touching iptables.
+	forwardAdmissionFn func() error
+
 	// stopCh is closed by Stop to terminate the reconcile loop independently
 	// of s.ctx; loopWG lets Stop block until the loop exits, so core.Close
 	// never races an in-flight reconcile pass.
@@ -97,6 +103,7 @@ func NewServer(ctx context.Context, logger *slog.Logger, opts Options) *Server {
 		stopCh: make(chan struct{}),
 	}
 	srv.reconcileFn = srv.core.ReconcileCells
+	srv.forwardAdmissionFn = srv.reassertForwardAdmission
 	return srv
 }
 
@@ -146,8 +153,48 @@ func (s *Server) Serve() error {
 	}
 
 	s.logger.InfoContext(s.ctx, "kukeond listening", "socket", s.opts.SocketPath)
+	if s.forwardAdmissionFn != nil {
+		if err := s.forwardAdmissionFn(); err != nil {
+			// Best-effort: a flushed/unavailable FORWARD admission chain must
+			// not block the daemon from serving. The next reboot self-heals
+			// here; durable per-space egress + Docker-churn handling is #953.
+			s.logger.WarnContext(s.ctx,
+				"forward admission re-assert failed on startup; continuing",
+				"error", err)
+		}
+	}
 	s.startReconcileLoop()
 	s.acceptLoop(listener)
+	return nil
+}
+
+// reassertForwardAdmission re-installs the KUKEON-FORWARD admission chain and
+// its FORWARD jump on daemon startup so a host reboot — which flushes the
+// kernel's iptables and strips the chain installed by `kuke init` — self-heals
+// without a re-run of init. Without it, cells on a host whose FORWARD default
+// policy is DROP (e.g. when Docker is installed) lose egress after a reboot:
+// in-cell DNS times out, kuketty's boot stalls past the attach deadline, and
+// `kuke run` fails with "attach ping timed out".
+//
+// Idempotent — every install step does -C before -I/-A, so on a healthy host
+// this produces no rule churn. Best-effort: a missing iptables binary is a
+// WARN-and-skip (the host owner opted out of kukeon-managed admission), and a
+// transient iptables error is surfaced to the caller, which logs and continues
+// rather than aborting Serve. Per-space egress re-assertion and Docker-churn
+// ordering are out of scope here and tracked in #953.
+func (s *Server) reassertForwardAdmission() error {
+	if !firewall.IsIptablesAvailable() {
+		s.logger.WarnContext(s.ctx,
+			"iptables not found on PATH; skipping forward admission re-assert — "+
+				"kukeon-bridge traffic may be blocked if FORWARD default policy is DROP",
+			"chain", firewall.ForwardChainName)
+		return nil
+	}
+	if err := firewall.NewInstaller(s.logger).Install(s.ctx); err != nil {
+		return fmt.Errorf("re-assert forward admission chain: %w", err)
+	}
+	s.logger.InfoContext(s.ctx, "re-asserted forward admission chain on startup",
+		"chain", firewall.ForwardChainName)
 	return nil
 }
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -129,3 +129,56 @@ func TestServeWithoutSocketGIDLeavesGroupUnchanged(t *testing.T) {
 		t.Errorf("socket mode: got %#o want 0o600", got)
 	}
 }
+
+// TestServeReassertsForwardAdmissionOnStartup guards the reboot regression: a
+// host reboot flushes the kernel's iptables, stripping the KUKEON-FORWARD
+// admission chain that `kuke init` installed. The daemon, which restarts on
+// its own, must re-assert that chain on Serve so kukeon-bridge cells regain
+// egress without a re-run of init. A failure of that step is best-effort and
+// must never block the daemon from serving.
+func TestServeReassertsForwardAdmissionOnStartup(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "kukeond.sock")
+
+	srv := NewServer(context.Background(), slog.New(slog.NewTextHandler(io.Discard, nil)), Options{
+		SocketPath: socketPath,
+		SocketMode: 0o600,
+	})
+
+	called := make(chan struct{}, 1)
+	srv.forwardAdmissionFn = func() error {
+		called <- struct{}{}
+		// Best-effort contract: even when the re-assert fails, Serve must
+		// still bring the socket up rather than aborting.
+		return errors.New("iptables unavailable")
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve() }()
+	t.Cleanup(func() {
+		_ = srv.Stop()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Serve did not return after Stop")
+		}
+	})
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not re-assert forward admission on startup")
+	}
+
+	// Despite the hook returning an error, the daemon must still come up.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(socketPath); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket did not appear after forward-admission error (Serve aborted?)")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Problem

A host reboot flushes the kernel's iptables, stripping the `KUKEON-FORWARD` admission chain and its `FORWARD` jump. That chain is installed in **exactly one place** today — `kuke init` (`cmd/kuke/init/init.go:322`), the only caller of `firewall.Install`. Nothing re-asserts it on daemon startup or in the reconcile loop.

On a host whose `FORWARD` default policy is `DROP` (anywhere Docker is installed — Docker sets `-P FORWARD DROP`), the result after a reboot is that **every cell loses egress**:

1. No `FORWARD` admission → cell bridge traffic is dropped → in-cell DNS (`1.1.1.1`) times out.
2. kuketty's boot-time required-repo `git fetch` stalls ~20s on the hung DNS.
3. That blows past the client's 10s attach retry budget (`cmd/kuke/run/attach.go`) → `kuke run <cell>` fails with `attach ping timed out: kuketty control socket bound but not yet serving`.
4. With no client attached, kuketty exits and the cell tears down.

Diagnosed live: after a reboot both `KUKEON-FORWARD` and `KUKEON-EGRESS` were absent; manually re-adding a `FORWARD` ACCEPT for the bridge restored in-cell DNS (rc 0) and `kuke run` attached.

## Fix

Re-assert the admission chain once on **daemon `Serve` startup**. The daemon restarts on its own after a reboot, so this self-heals the host without a re-run of `kuke init`.

- **Idempotent** — `firewall.Install` does `-C` before every `-I/-A` (`internal/firewall/forward.go:154`), so on a healthy host it produces no rule churn.
- **Best-effort** — a missing `iptables` binary is a WARN-and-skip (`IsIptablesAvailable` guard), and a transient `iptables` error is logged and swallowed so it never blocks the daemon from serving.
- **Works from the daemon** — kukeond already manipulates host iptables in host scope (it adds the CNI `nat/POSTROUTING` MASQUERADE during cell start; #96), so a startup `Install` lands on the host.
- Wired via a `forwardAdmissionFn` seam mirroring the existing `reconcileFn` pattern, so the test exercises the startup hook without touching iptables.

## Scope

Intentionally limited to host-global **admission** — the reboot case that takes cells offline. Per-space **egress** re-assertion (currently fail-open) and Docker-churn ordering (anchoring from `DOCKER-USER`) are the larger refactor tracked in the #953 umbrella; this is its P1 down-payment.

## Test plan

- [x] `GOWORK=off go test ./internal/daemon/ ./internal/firewall/` — pass (daemon builds against `go.mod`, not the kuketty `go.work`)
- [x] `gofmt` / `go vet` clean
- [x] New `TestServeReassertsForwardAdmissionOnStartup` asserts the hook runs on `Serve` and that a hook error does **not** abort startup (best-effort contract)
- [x] `make dev-init` — ran end-to-end (daemon startup code change). Daemon-parity tail byte-identical across `kuke get realms` and `--no-daemon` (`default`/`kuke-system` both `Ready`); the PTY `kuke attach` smoke against the kuketty-wrapped cell exited cleanly and the nested parent-attach plumbing stayed intact. This exercises the new `Serve`-startup `firewall.Install` re-assert on a healthy host (idempotent `-C`-before-`-I/-A`, no rule churn).

Refs #953
