### PR TITLE
docs(cli): add kuke daemon recreate; refresh kuke version daemon-query + mismatch

### DIFF
--- a/docs/site/cli/kuke-daemon.md
+++ b/docs/site/cli/kuke-daemon.md
@@ -10,14 +10,15 @@ These commands act on the `kukeond` cell provisioned by `kuke init` (`kuke-syste
 
 ## Subcommands
 
-| Command               | What it does                                                            |
-| --------------------- | ----------------------------------------------------------------------- |
-| `kuke daemon start`   | Start the kukeond daemon cell                                           |
-| `kuke daemon stop`    | Gracefully stop the kukeond cell (SIGTERM, escalating to SIGKILL)       |
-| `kuke daemon kill`    | Immediately SIGKILL the kukeond daemon cell                             |
-| `kuke daemon restart` | Stop then start the kukeond daemon cell                                 |
-| `kuke daemon reset`   | Stop, delete metadata + cgroups, clear `/run/kukeon/kukeond.{sock,pid}` |
-| `kuke daemon logs`    | Print the kukeond daemon's stdout/stderr (use `-f` to follow)           |
+| Command                | What it does                                                            |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `kuke daemon start`    | Start the kukeond daemon cell                                           |
+| `kuke daemon stop`     | Gracefully stop the kukeond cell (SIGTERM, escalating to SIGKILL)       |
+| `kuke daemon kill`     | Immediately SIGKILL the kukeond daemon cell                             |
+| `kuke daemon restart`  | Stop then start the kukeond daemon cell                                 |
+| `kuke daemon reset`    | Stop, delete metadata + cgroups, clear `/run/kukeon/kukeond.{sock,pid}` |
+| `kuke daemon recreate` | Recreate the kukeond daemon cell (tear down, re-provision, start)       |
+| `kuke daemon logs`     | Print the kukeond daemon's stdout/stderr (use `-f` to follow)           |
 
 All subcommands are idempotent: they succeed with a clear message when the daemon is already in the requested state.
 
@@ -55,6 +56,28 @@ Compose `kuke daemon stop` and `kuke daemon start` into a single verb. When the 
 | Flag        | Default | Description                                                               |
 | ----------- | ------- | ------------------------------------------------------------------------- |
 | `--timeout` | `10s`   | Grace period for the stop phase before escalating from SIGTERM to SIGKILL |
+
+## kuke daemon recreate
+
+```
+sudo kuke daemon recreate --kukeond-image <image> [--timeout <duration>] [--server-configuration <path>]
+```
+
+Recreate the kukeond daemon cell (tear down, re-provision, start).
+
+Compose `kuke daemon reset` and `kuke init`'s kukeond cell provisioning into a single verb.
+
+Tears down the existing kukeond cell (stop, delete, clear socket+pid) and re-provisions it from scratch using the specified `--kukeond-image`. The cell-creation path is shared with `kuke init`, so the two cannot drift.
+
+Requires `--kukeond-image` and errors with `ErrHostNotInitialized` when the host has not been bootstrapped by `kuke init` yet.
+
+Image-load is out of scope: the desired image must already be present in the `kuke-system` realm (via `kuke build` or `kuke image load`) before invoking this command.
+
+| Flag                     | Default                              | Description                                                                                                                                              |
+| ------------------------ | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--kukeond-image`        | _(required)_                         | Container image for kukeond. May be omitted if `kukeondImage` is set in `/etc/kukeon/kukeond.yaml`; otherwise required.                                  |
+| `--timeout`              | `10s` (`lifecycle.DefaultTimeout`)   | Grace period for the stop phase before escalating from SIGTERM to SIGKILL                                                                                |
+| `--server-configuration` | `/etc/kukeon/kukeond.yaml`           | Path to the kukeond server-configuration YAML (precedence chain: flag > `KUKEOND_CONFIGURATION` env > default file > hardcoded defaults)                 |
 
 ## kuke daemon reset
 
@@ -99,6 +122,9 @@ sudo kuke daemon kill
 # Dev loop: blow away the daemon cell and re-init
 sudo kuke daemon reset
 sudo kuke init --kukeond-image docker.io/library/kukeon-local:dev
+
+# Pick up a new kukeond image without a full kuke init
+sudo kuke daemon recreate --kukeond-image docker.io/library/kukeon-local:dev
 
 # Wipe /opt/kukeon/kuke-system too (user-realm data stays)
 sudo kuke daemon reset --purge-system

--- a/docs/site/cli/kuke-version.md
+++ b/docs/site/cli/kuke-version.md
@@ -1,22 +1,43 @@
 # kuke version
 
-Print the Kukeon version.
+Print client and daemon version strings; warn on mismatch.
 
 ```
-kuke version
+kuke version [--no-daemon] [--strict]
 ```
 
 ## Output
 
-A single line containing the version string:
+By default, `kuke version` prints the client version, then queries the daemon for its version and prints that on a second line. If the two strings differ, a warning is emitted on stderr; with `--strict`, the command also exits non-zero.
 
 ```
 $ kuke version
-v0.5.0
+Client: v0.6.0
+Daemon: v0.6.0
 ```
 
-For release builds, this is the semver tag. For dev builds, it's whatever `VERSION` was passed at build time (often `v0.0.0-dev` or empty).
+When the daemon is unreachable (socket missing, daemon down), the second line is replaced by a `Warning: daemon unreachable: <err>` on stderr; the client-version stdout line still prints and the exit code stays 0. Use `--no-daemon` to skip the daemon query entirely.
+
+```
+$ kuke version
+Client: v0.6.0
+Warning: daemon unreachable: dial unix:///run/kukeon/kukeond.sock: connect: no such file or directory
+
+$ kuke version --no-daemon
+Client: v0.6.0
+```
+
+For release builds, the version string is the semver tag. For dev builds, it's whatever `VERSION` was passed at build time (often `v0.0.0-dev` or empty).
 
 ## Flags
 
-None beyond the [global flags](kuke.md).
+| Flag          | Default | Description                                                                                                              |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `--no-daemon` | `false` | Skip the daemon query — print only `Client: <ver>`                                                                       |
+| `--strict`    | `false` | Exit with non-zero status on a client/daemon version mismatch (the warning on stderr is emitted in both modes)           |
+
+Plus all [global flags](kuke.md).
+
+## Daemon mismatch behavior
+
+`Warning: version mismatch (client: <c>, daemon: <d>)` is emitted on stderr whenever the two version strings differ. Without `--strict`, the exit code stays 0 (informational warning); with `--strict`, the exit code is non-zero. Pair `--strict` with CI guards on host-upgrade workflows where the operator wants a hard fail if `kuke` and `kukeond` drift.


### PR DESCRIPTION
## Summary

- `docs/site/cli/kuke-daemon.md`: add `recreate` row to § Subcommands, new `## kuke daemon recreate` section (synopsis, summary, flag table) between `restart` and `reset`, and a recreate example in § Examples next to the existing reset example.
- `docs/site/cli/kuke-version.md`: full rewrite — two-line `Client:`/`Daemon:` output, daemon-unreachable warning behavior, `--no-daemon` and `--strict` flag rows, and a new § Daemon mismatch behavior section.

## Divergences from the issue body

- The issue's verbatim `## kuke daemon recreate` flag table lists `--timeout` default as `30s (\`lifecycle.DefaultTimeout\`)`, but `lifecycle.DefaultTimeout` is `10 * time.Second` (cmd/kuke/internal/lifecycle/lifecycle.go:49), and the same page lists `10s` for the existing `stop`, `restart`, and `reset` rows. Treated the symbol reference (`lifecycle.DefaultTimeout`) as the binding intent and rendered `10s` for page-internal consistency. Heads-up posted on the issue: https://github.com/eminwux/kukeon/issues/946#issuecomment-4582581465.

## Test plan

- [x] `mkdocs build` on the branch produces zero new warnings on `cli/kuke-daemon.md` or `cli/kuke-version.md` (verified locally — the only WARNING is a pre-existing one in `proposals/agent-native-orchestration.md` that fails on plain `main` too; out of scope for this PR).
- [x] AC: § Subcommands lists `recreate`.
- [x] AC: `## kuke daemon recreate` section present with synopsis, summary, and flag table.
- [x] AC: § Examples has a recreate example.
- [x] AC: `kuke-version.md` shows the `Client:`/`Daemon:` two-line output, mismatch warning, `--no-daemon`/`--strict` flags.
- [ ] AC: `mkdocs build --strict` clean — **deferred**: strict-mode build already fails on `main` from an unrelated `proposals/agent-native-orchestration.md` broken link. Separate scope; not introduced or aggravated by this PR.

Closes #946