### PR TITLE
docs(cli): add kuke build CLI reference page

### DIFF
--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -25,6 +25,7 @@ Both are hard-linked to the same binary on install. Running `kuke` enters the cl
 | `kuke refresh`                 | Reconcile `.status` from live state without touching `.spec`          |
 | `kuke log`                     | Print a container's stdout/stderr (use `-f` to follow)                |
 | `kuke attach`                  | Attach to an Attachable container's `sbsh` terminal                   |
+| `kuke build`                   | Build an OCI image from a Dockerfile into a realm's containerd namespace |
 | `kuke image`                   | Manage container images in a realm's containerd namespace             |
 | `kuke daemon`                  | Manage the `kukeond` daemon cell lifecycle                            |
 | `kuke uninstall`               | Remove all kukeon runtime state from this host                        |
@@ -82,6 +83,7 @@ The positional argument is the resource's own name; the flags specify where in t
 - [kuke refresh](kuke-refresh.md)
 - [kuke log](kuke-log.md)
 - [kuke attach](kuke-attach.md)
+- [kuke build](kuke-build.md)
 - [kuke image](kuke-image.md)
 - [kuke daemon](kuke-daemon.md)
 - [kuke uninstall](kuke-uninstall.md)

--- a/docs/site/cli/kuke-build.md
+++ b/docs/site/cli/kuke-build.md
@@ -1,0 +1,45 @@
+# kuke build
+
+```
+kuke build [-f Dockerfile] [-t name:tag] [--realm <name>] [--build-arg K=V]... [--secret id=NAME,src=PATH]... [--cache-to type=local,dest=PATH]... [--cache-from type=local,src=PATH]... [--platform os/arch,...] [--push] <context>
+```
+
+Build an OCI image from a Dockerfile into a realm's containerd namespace.
+
+Build an OCI image from a Dockerfile using kukeon's native builder.
+
+`kuke build` is a thin shim: it locates the `kukebuild` binary on PATH and exec's it. `kukebuild` embeds BuildKit, builds the context with the Dockerfile frontend, and writes the resulting image into the containerd namespace mapped to `--realm` (`<realm>.kukeon.io`), ready for `kuke get image` and `kuke create`.
+
+No docker or standalone buildkitd is required — only a running host containerd.
+
+Build-time secrets: `--secret id=NAME,src=PATH` mounts a host file into the build at `/run/secrets/NAME`, consumed by a Dockerfile `RUN --mount=type=secret,id=NAME`. File-based secrets only; the flag is repeatable.
+
+Build cache: `--cache-to type=local,dest=PATH` exports the build cache to a local directory and `--cache-from type=local,src=PATH` imports it back, reusing layers across builds. Only `type=local` is supported; both flags are repeatable.
+
+Multi-platform: `--platform linux/amd64,linux/arm64` builds for each target arch and writes the result as a single manifest list — one image reference covering every arch, not per-arch tags (operators expecting `name:tag-amd64` / `-arm64` will not find them). `kuke get image --realm <name>` shows the list; each per-arch manifest is individually pullable. Distinct from a Dockerfile's `$BUILDPLATFORM` arg, which selects the build host's platform; `--platform` selects the output set.
+
+Registry push: `--push` pushes the built image to its tag's registry after a successful build. The tag must be a fully qualified registry reference (`REGISTRY/REPO:TAG`); a bare `name:tag` is rejected. Push is additive — the image is still written to the realm's containerd namespace. Credentials resolve in order: (1) `$DOCKER_CONFIG/config.json` when `DOCKER_CONFIG` is set, (2) `~/.docker/config.json`, (3) the `KUKEON_REGISTRY_AUTH` env var (base64 `user:pass`).
+
+## Flags
+
+| Flag                     | Default                  | Description                                                                                                                                                                                                            |
+| ------------------------ | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `<context>` (positional) | _(required)_             | Build context directory (Docker build context)                                                                                                                                                                         |
+| `--file`, `-f`           | `<context>/Dockerfile`   | Path to the Dockerfile                                                                                                                                                                                                 |
+| `--tag`, `-t`            | _(required)_             | Image reference for the built image, `name:tag`                                                                                                                                                                        |
+| `--realm`                | `default`                | Target realm; the image lands in `<realm>.kukeon.io`                                                                                                                                                                   |
+| `--build-arg`            | (empty, repeatable)      | Set a build-time variable `KEY=VALUE`                                                                                                                                                                                  |
+| `--kukeond-config`       | `/etc/kukeon/kukeond.yaml` | Path to `kukeond.yaml`; resolves the realm namespace suffix                                                                                                                                                          |
+| `--secret`               | (empty, repeatable)      | Expose a file secret to the build at `/run/secrets/NAME`: `id=NAME,src=PATH`                                                                                                                                           |
+| `--cache-to`             | (empty, repeatable)      | Export build cache: `type=local,dest=PATH`                                                                                                                                                                             |
+| `--cache-from`           | (empty, repeatable)      | Import build cache: `type=local,src=PATH`                                                                                                                                                                              |
+| `--platform`             | `""`                     | Comma-separated `os/arch[/variant]` targets (e.g. `linux/amd64,linux/arm64`); multiple targets produce a single manifest list, not per-arch tags                                                                       |
+| `--push`                 | `false`                  | After a successful build, push the image to its tag's registry (requires a fully qualified `REGISTRY/REPO:TAG`); credentials resolve from `$DOCKER_CONFIG/config.json`, then `~/.docker/config.json`, then `$KUKEON_REGISTRY_AUTH` |
+
+Plus all [global flags](kuke.md). The `--tag` flag is required; a missing or empty tag returns `errdefs.ErrImageTagRequired`. A missing `kukebuild` binary on PATH returns `errdefs.ErrKukebuildNotFound` with the remediation hint "install it (e.g. `make kukebuild` then put it on PATH)" — match `cmd/kuke/build/build.go:127-143`.
+
+## Related
+
+- [kuke image](kuke-image.md) — load tarballs into a realm's containerd namespace (the other in-realm image producer)
+- [kuke get image](kuke-get.md) — list / describe images written into a realm by `kuke build`
+- [kuke init](kuke-init.md) — uses a locally built `kuke-system` image during the dev-loop bootstrap

--- a/docs/site/cli/kuke-image.md
+++ b/docs/site/cli/kuke-image.md
@@ -8,6 +8,8 @@ kuke image [command]
 
 Every realm maps to its own containerd namespace (`<realm>.kukeon.io`). `kuke image` loads and deletes images inside that namespace. The default realm is `default` (containerd namespace `default.kukeon.io`); pass `--realm kuke-system` to operate on the system realm where the `kukeond` image lives.
 
+Images land in a realm via one of two producers: [`kuke build`](kuke-build.md) builds an OCI image from a Dockerfile straight into the realm's containerd namespace, and `kuke image load` imports a pre-built OCI/docker tarball into the same namespace.
+
 Listing and describing images moved to the `kuke get` family in #824 — use [`kuke get image[s]`](kuke-get.md) for both the cross-realm default and the single-image describe form. The old `kuke image get` / `kuke image ls` / `kuke image list` aliases are gone (no deprecation window).
 
 ## Subcommands

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - cli/kuke-init.md
       - cli/kuke-doctor.md
       - cli/kuke-get.md
+      - cli/kuke-build.md
       - cli/kuke-create.md
       - cli/kuke-apply.md
       - cli/kuke-run.md


### PR DESCRIPTION
## Summary

- Adds `docs/site/cli/kuke-build.md` — the missing CLI reference page for `kuke build` (the verbs shipped in #652/#674/#675/#676). Synopsis, Long-description prose, and the flag table are verbatim per the issue.
- Wires the new page into the `mkdocs.yml` nav between `kuke-get.md` and `kuke-create.md`.
- Patches `docs/site/cli/kuke-image.md`'s intro to cross-link `kuke build` as the in-realm image producer paired with `kuke image load` for tarball import.
- Adds `kuke build` to the `docs/site/cli/commands.md` subcommand table and full-reference link list (natural cohesion fix: a page wired into the nav but absent from the CLI overview table is inconsistent — flagged here for reviewer audit since the issue's AC didn't explicitly enumerate it).

## Test plan

- [x] `mkdocs build --strict` — produces one warning, but it is **pre-existing on `main`** (`proposals/agent-native-orchestration.md` → `proposals/faq.md`); my diff adds zero new warnings (the transient `git-revision-date-localized-plugin … has no git logs` notes against the new file resolve after the commit lands on `main`). Verified by running strict against the baseline before applying changes; warning count identical.
- [x] Manual inspection of the rendered nav and cross-links via `mkdocs build` (non-strict) — `kuke-build.md` appears in the CLI Reference section, the `kuke-image.md` cross-link to `[kuke build](kuke-build.md)` resolves, and the `kuke build` row in `commands.md` is wired to the same target.
- [ ] `docs/cli-use-cases.md` audit — the existing `kuke build` mentions in the uninstall/teardown contexts (lines 70, 89) correctly name the verb; the "Image management" section deliberately scopes to `kuke image load` / `kuke image delete` / `kuke get image[s]` per the v0.5.0 dev-init refresh and is left untouched. No change required.

Closes #942