### PR TITLE
docs(cli): add kuke status reference page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,16 +65,10 @@ After the daemon-parity tail, `scripts/dev-init.sh` also runs a PTY-driven `kuke
 ### Post-init: `kuke status`
 
 `kuke status` is the canonical equivalent of the manual diff ritual above —
-one command that runs daemon liveness (with round-trip ms and version),
-host pre-flight (containerd, cgroup-v2, CNI plugins under `/opt/cni/bin/`),
-state consistency (orphan run-dir entries, residual containerd namespaces),
-and the same daemon-parity walk above across **every** resource kind
-(realm, space, stack, cell, container, secret, blueprint, config), not just
-realms.
-
-Exit code is 0 when every check is OK / WARN, non-zero when any line is
-FAIL. `--json` is the machine-readable form for CI integration; `--verbose`
-surfaces the remediation hint on OK rows too.
+one command covering daemon liveness, host pre-flight, state consistency,
+and the daemon-parity walk across every resource kind. See
+[`docs/site/cli/kuke-status.md`](docs/site/cli/kuke-status.md) for the full
+reference (sections, flag table, exit codes, JSON shape).
 
 The two-line `kuke get realms` diff above stays the minimal pinned
 regression guard the `make dev-init` tail prints; `kuke status` is the

--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -15,6 +15,7 @@ Both are hard-linked to the same binary on install. Running `kuke` enters the cl
 | ------------------------------ | --------------------------------------------------------------------- |
 | `kuke init`                    | Bootstrap or reconcile a host                                         |
 | `kuke doctor`                  | Host pre-flight checks (cgroup-v2 delegation) before `kuke init`      |
+| `kuke status`                  | Consolidated post-`kuke init` daemon/host/state/parity health report  |
 | `kuke apply`                   | Apply resource definitions from YAML (multi-document supported)       |
 | `kuke run`                     | Create and start a single cell from a file or per-user profile        |
 | `kuke get`                     | List or describe resources (realm, space, stack, cell, container)     |
@@ -72,6 +73,7 @@ The positional argument is the resource's own name; the flags specify where in t
 - [kuke (root)](kuke.md)
 - [kuke init](kuke-init.md)
 - [kuke doctor](kuke-doctor.md)
+- [kuke status](kuke-status.md)
 - [kuke get](kuke-get.md)
 - [kuke create](kuke-create.md)
 - [kuke apply](kuke-apply.md)

--- a/docs/site/cli/kuke-status.md
+++ b/docs/site/cli/kuke-status.md
@@ -1,0 +1,109 @@
+# kuke status
+
+```
+kuke status [--json] [--verbose]
+```
+
+Report kukeon daemon, host, state, and parity health.
+
+Run the consolidated health report that replaces the manual `kuke get realms` vs `kuke get realms --no-daemon` diff ritual.
+
+Sections: daemon (socket dialable, round-trip, version), host (containerd, cgroup-v2, CNI plugins), state (orphan sockets, residual containerd namespaces), parity (every `kuke get <kind>` agrees daemon-side vs in-process). Each line is OK / WARN / FAIL with a one-line remediation hint when the status is not OK.
+
+Exit code 0 when every check is OK or WARN; non-zero when any line is FAIL. The `--json` form is the machine-readable shape for CI integration; `--verbose` surfaces the remediation hint on OK rows too.
+
+## Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--json` | `false` | emit a JSON document instead of the human-readable table |
+| `--verbose` | `false` | print the remediation hint on every row, not just WARN/FAIL |
+
+Plus all [global flags](kuke.md).
+
+## Exit codes
+
+- `0` — every row is OK, or OK mixed with WARN.
+- non-zero — at least one row is FAIL. The structured report on stdout (text or JSON) is the operator-visible failure marker; the non-zero exit code is the CI-visible one.
+
+The contract is set in [`cmd/kuke/status/status.go`](https://github.com/eminwux/kukeon/blob/main/cmd/kuke/status/status.go) — see the `errFailingChecks` sentinel and the `RunE` body that returns it on `!report.OK`.
+
+## Output shape
+
+### Human-readable (default)
+
+Each section prints as an uppercased header followed by one row per check, padded so the `STATUS` column lines up across the whole report. A `↳ <hint>` line under a row carries the remediation — printed whenever the row is WARN or FAIL, and on OK rows too when `--verbose` is set. A bottom-line `Status: OK` or `Status: FAIL` mirrors the exit code.
+
+```
+$ kuke status
+DAEMON
+  socket  OK    unix:///run/kukeon/kukeond.sock (rtt 2ms, version v0.6.0)
+
+HOST
+  containerd  OK    /run/containerd/containerd.sock (reachable)
+  cgroup-v2   OK    /sys/fs/cgroup (cgroup2 mounted; required controllers delegated)
+  cni         OK    /opt/cni/bin (bridge, loopback present)
+
+STATE
+  run-dir     OK    /run/kukeon (no orphan sockets)
+  namespaces  OK    no residual containerd namespaces
+
+PARITY
+  realms      OK    daemon view matches in-process view
+  spaces      OK    daemon view matches in-process view
+  stacks      OK    daemon view matches in-process view
+  cells       OK    daemon view matches in-process view
+  containers  OK    daemon view matches in-process view
+  secrets     OK    daemon view matches in-process view
+  blueprints  OK    daemon view matches in-process view
+  configs     OK    daemon view matches in-process view
+
+Status: OK
+```
+
+### JSON (`--json`)
+
+`--json` emits the same report as a 2-space-indented JSON document. The `status` field renders the human label (`"OK"` / `"WARN"` / `"FAIL"`) rather than an integer so the wire shape doesn't depend on enum order. The shape is the `Report` struct in [`cmd/kuke/status/status.go`](https://github.com/eminwux/kukeon/blob/main/cmd/kuke/status/status.go) — a top-level `ok` bool plus a flat `checks` array, with each row carrying `section`, `name`, `status`, `detail`, and an optional `remediation`.
+
+```json
+{
+  "ok": true,
+  "checks": [
+    {
+      "section": "daemon",
+      "name": "socket",
+      "status": "OK",
+      "detail": "unix:///run/kukeon/kukeond.sock (rtt 2ms, version v0.6.0)"
+    },
+    {
+      "section": "host",
+      "name": "containerd",
+      "status": "OK",
+      "detail": "/run/containerd/containerd.sock (reachable)"
+    }
+  ]
+}
+```
+
+A failing daemon dial yields `"status": "FAIL"` plus a populated `remediation` field on the affected row, and `"ok": false` at the top level.
+
+## What each section checks
+
+| Section | What it asserts |
+| ------- | --------------- |
+| `daemon` | The `kukeond` socket dials, an RPC round-trip returns the daemon's build version, and the round-trip latency is recorded. Replaces the original `kuke ping` proposal. |
+| `host` | `containerd` is reachable on the configured socket; cgroup-v2 is mounted on `/sys/fs/cgroup` with the controllers kukeon requires delegated (the same controller-set check as `kuke doctor cgroups`); the CNI binaries `kuke init` installs are present under `/opt/cni/bin`. |
+| `state` | The run-dir under `/run/kukeon` has no orphan sockets, and no residual containerd namespaces survive from a half-cleaned `kuke uninstall`. |
+| `parity` | For every resource kind (`realm`, `space`, `stack`, `cell`, `container`, `secret`, `blueprint`, `config`), the daemon's view and the in-process controller's view agree. This is the cross-kind generalization of the two-line `kuke get realms` diff the `make dev-init` smoke pins. |
+
+See [`CLAUDE.md` §"Post-init: `kuke status`"](https://github.com/eminwux/kukeon/blob/main/CLAUDE.md) for the operator narrative that positions this command inside the dev-init smoke loop; this page is the reference.
+
+## When to use vs `kuke doctor cgroups` and the realm-parity diff
+
+`kuke status` is the umbrella health command — one invocation covers the daemon, the host pre-flight, run-dir state, and the cross-kind daemon-vs-in-process parity walk. `kuke doctor cgroups` is a narrower pre-`kuke init` host check focused on cgroup-v2 controller delegation; `kuke status` includes the same controller-set assertion in its `host` section, so once the daemon is up `kuke status` subsumes `kuke doctor cgroups` for the cgroup signal specifically. The two-line `kuke get realms` vs `kuke get realms --no-daemon` diff `make dev-init` prints stays the minimal pinned regression guard the smoke test exits on; `kuke status` is the broader post-`kuke init` sweep an operator runs to surface anything that two-realm tail won't catch (cgroup delegation gone, CNI binaries gone, divergent secrets/blueprints/configs, residual containerd namespaces from a half-cleaned `kuke uninstall`).
+
+## Related
+
+- [kuke init](kuke-init.md) — bootstrap step `kuke status` smoke-tests after
+- [kuke doctor](kuke-doctor.md) — the narrower cgroup-only pre-`kuke init` check
+- [kuke get](kuke-get.md) — the per-kind list/describe commands whose daemon-vs-in-process parity the `parity` section walks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
       - cli/kuke.md
       - cli/kuke-init.md
       - cli/kuke-doctor.md
+      - cli/kuke-status.md
       - cli/kuke-get.md
       - cli/kuke-create.md
       - cli/kuke-apply.md


### PR DESCRIPTION
## Summary

- Adds `docs/site/cli/kuke-status.md` — synopsis + summary stanzas, flag table, exit codes, JSON/human output shape, per-section semantics, and the layering paragraph vs `kuke doctor cgroups` / the realm-parity diff.
- `mkdocs.yml` nav inserts `cli/kuke-status.md` next to the other "health" verb pages (after `cli/kuke-doctor.md`), matching the existing convention the issue points to ("not strictly alphabetical — sits with the health verbs, near `kuke-doctor.md` and `kuke-version.md`"). The "After" example in the issue body places it immediately after `kuke-doctor.md`; this PR matches.
- `docs/site/cli/commands.md` gets a `kuke status` row in the verb index and a bullet in the full-reference list (the existing index follows the same convention; the issue body's "if one exists; otherwise skip" clause is satisfied here).
- `CLAUDE.md` (`AGENTS.md` is the canonical file; `CLAUDE.md` is a symlink to it) §"Post-init: \`kuke status\`" — the inline command-surface prose is replaced with a one-line pointer to the new reference page; the layering paragraph that positions `kuke status` against the `make dev-init` realm-parity tail is preserved (operator narrative, not command-surface).

## Notes on divergence from the issue body

- **`--json`/`--verbose` backticking.** The issue body's "verbatim from cmd source" stanza puts both `--json` and `--verbose` in backticks. The actual `Long:` string at `cmd/kuke/status/status.go:158-162` only backticks `--json`. The reference page follows the issue body (consistent rendering across both flags); the source's Long string is unchanged.
- **JSON shape — `sections[]` vs `checks[]`.** The issue body's "best-effort" section describes the JSON as `ok` bool + `sections[]` (each section nested), but the actual `Report` struct at `cmd/kuke/status/status.go:90-93` is `ok` bool + a flat `checks[]` array where each row carries its own `section` field. The reference page describes the actual struct (flat array, per-row `section` field) and includes a representative JSON sample matching it. Per CLAUDE.md's rotted-premise rule, intent is still inferable (JSON shape is the `Report` struct in source) so this PR proceeds rather than stalling.

## mkdocs build --strict

`mkdocs build --strict` was run locally. It aborts with exactly the same pre-existing warning that origin/main produces — `proposals/agent-native-orchestration.md` links a `faq.md#when-is-v10` anchor that does not exist. Confirmed pre-existing by stashing the diff and re-running; the count stayed at 1 warning. This PR introduces 0 new strict warnings. The pre-existing warning is out of scope for this docs-only page-add.

## Test plan

- [x] `mkdocs build --strict` introduces no new warnings (the 1 pre-existing warning on origin/main is unchanged).
- [x] Nav block lists `cli/kuke-status.md` between `cli/kuke-doctor.md` and `cli/kuke-get.md`, matching the "After" example in the issue body.
- [x] `cli/commands.md` verb-index table gets a `kuke status` row; the full-reference list at the bottom gets a `kuke-status.md` bullet.
- [x] `CLAUDE.md` §"Post-init: \`kuke status\`" cross-links to the new reference page rather than describing the command surface inline; the `make dev-init`-layering paragraph survives unchanged.

Closes #940