### PR TITLE
docs(cli): sweep kuke-get.md for AGE/SYNC/-l/-o wide revamp and CGROUP retirement

### DIFF
--- a/docs/site/cli/kuke-get.md
+++ b/docs/site/cli/kuke-get.md
@@ -11,9 +11,10 @@ Resources: `realm`, `space`, `stack`, `cell`, `container`, `image`, `blueprint`,
 
 ## Common flags
 
-| Flag             | Description                                                                                                                                                                                                   |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--output`, `-o` | Output format: `yaml`, `json`, `table`, `wide`. Default: `table` for list, `yaml` for a single resource. `wide` accepted by every `kuke get <kind>` for symmetry; per-kind wide columns vary (see each kind). |
+| Flag                | Description                                                                                                                                                                                                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--output`, `-o`    | Output format: `yaml`, `json`, `table`, `wide`. Default: `table` for list, `yaml` for a single resource. `wide` accepted by every `kuke get <kind>` for symmetry; per-kind wide columns vary (see each kind). |
+| `--selector`, `-l`  | Label selector (kubectl-style) to filter list results. Supports `=`, `==`, `!=`, existence (`key`), absence (`!key`), and comma-separated AND (e.g. `env=prod,tier!=db` or `env,!debug`). Rejected with a positional `NAME`. |
 
 Plus all [global flags](kuke.md). Every `kuke get <kind>` accepts the explicit `--no-daemon` flag to bypass the daemon (inherited as a persistent flag from the parent `get` command); `KUKEON_NO_DAEMON=true` and `--run-path /opt/kukeon` (which auto-promotes the command into in-process mode) work as well.
 
@@ -39,6 +40,27 @@ All scope flags default to `default`. See the [realm default note](commands.md#c
 - **List** (no positional arg): returns every resource matching the scope flags. Default output is a table.
 - **Single** (positional arg): returns the one matching resource. Default output is YAML.
 
+## Default tables and `-o wide` columns
+
+Per-kind column contracts. The default table is what `kuke get <kind>` (no `-o wide`) emits; `-o wide` appends the listed extras.
+
+| Kind | Default columns | `-o wide` appends |
+| --- | --- | --- |
+| `realm` | `NAME STATE AGE` | `NAMESPACE` |
+| `space` | `NAME REALM STATE AGE` | `EGRESS NET-DEFAULTS` |
+| `stack` | `NAME REALM SPACE STATE AGE` | _(none — stack carries no wide-only signals)_ |
+| `cell` | `NAME REALM SPACE STACK STATE SYNC AGE` | `CONTAINERS BRIDGE DIVERGENCE` |
+| `container` | `NAME REALM SPACE STACK CELL STATE RESTARTS AGE` | `IMAGE EXIT` |
+| `image` | `NAME REALM CREATED` (cross-realm default) | `DIGEST` |
+| `blueprint` | `NAME REALM SPACE STACK AGE` | _(none)_ |
+| `config` | `NAME REALM SPACE STACK AGE` | _(none)_ |
+
+`SYNC` (`InSync`/`OutOfSync`/`-`) is computed for cells that carry a `kukeon.io/config=<name>` lineage label; non-lineage cells render `-`. The `-o wide` `DIVERGENCE` column expands an `OutOfSync` cell with a one-line summary of what diverged (image, env, mounts, …). See `kuke restart cell` for the reconcile verb.
+
+`-o wide` on `space` surfaces the egress allowlist (`EGRESS`) and the cell-default-deny posture (`NET-DEFAULTS yes/no`).
+
+`-o wide` on `container` surfaces the resolved container image reference (`IMAGE`) and the `<exitCode>/<exitSignal>` pair (`EXIT`) when either field is non-zero. The `RESTARTS` column lives in the default table; `CGROUP`, `ROOT`, and `IMAGE` (as defaults) were retired in v0.6.0 — see "Retired in v0.6.0" below.
+
 ```bash
 # Table of realms — the dev-init parity check expects this column shape
 sudo kuke get realms
@@ -63,8 +85,16 @@ sudo kuke get realm default -o json
 # Spaces in the default realm
 sudo kuke get spaces --realm default
 
-# Cells in a specific stack
+# Cells in a stack — SYNC column flags Config-lineage drift; OutOfSync points at `kuke restart cell`
 sudo kuke get cells --realm default --space default --stack default
+NAME           REALM    SPACE    STACK    STATE  SYNC       AGE
+-------------  -------  -------  -------  -----  ---------  ---
+work-001       default  default  default  Ready  InSync     12m
+work-002       default  default  default  Ready  OutOfSync  3m
+shell          default  default  default  Ready  -          1h
+
+# Containers — RESTARTS column (process bounces since cell start); -o wide adds IMAGE EXIT
+sudo kuke get containers --realm default --space default --stack default --cell work-001 -o wide
 
 # All containers in a cell
 sudo kuke get containers --realm default --space default --stack default --cell hello-world
@@ -85,9 +115,33 @@ sudo kuke get blueprints --realm kuke-system
 sudo kuke get config kukeon-dev --realm kuke-system -o yaml
 ```
 
+## Label selector (`-l`/`--selector`)
+
+Filter list results by label query. The flag is wired on every `kuke get <kind>` verb (realm, space, stack, cell, container).
+
+```bash
+# Cells labeled env=prod
+sudo kuke get cell -l env=prod
+
+# Cells with the `debug` label absent
+sudo kuke get cell -l '!debug'
+
+# Comma-separated AND
+sudo kuke get cell -l 'env=prod,tier!=db'
+```
+
+A positional `NAME` plus `-l` is rejected — a selector queries the list path, a name queries the single-resource path; mixing them is ambiguous. Malformed selectors fail before any controller call.
+
 ## `get` vs `refresh`
 
 `get` reads metadata. It does not reconcile or update `.status`. If you want the status to reflect the live runtime state (after a crash, or after containerd reported a change), run [`kuke refresh`](kuke-refresh.md) first.
+
+## Retired in v0.6.0
+
+- **`--show-controllers` / `CGROUP` column** — the cgroup-controllers signal on `-o wide` cell/container tables is gone. The state-of-cgroup-controllers check moved into `kuke status`'s host section and [`kuke doctor cgroups`](kuke-doctor.md).
+- **`IMAGE` as a default container column** — `IMAGE` is now an `-o wide` extension only. Use `kuke get container -o wide` or `-o yaml` to surface it.
+- **`ROOT` column** — retired entirely.
+- **`kuke image get` / `kuke image ls` / `kuke image list`** — folded into `kuke get image[s]` with no alias window. See the `kuke get image` examples below.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Closes #943.

Brings `docs/site/cli/kuke-get.md` in line with the v0.5.0→0.6.0 `kuke get` revamp:

- **Common flags table:** added `-l`/`--selector` row.
- **New § "Default tables and `-o wide` columns":** pins the per-kind default-table + `-o wide` contract for all eight kinds (realm, space, stack, cell, container, image, blueprint, config); explains `SYNC` lineage semantics, `DIVERGENCE`, `EGRESS`/`NET-DEFAULTS`, `IMAGE`/`EXIT`/`RESTARTS`.
- **Behavior examples:** added a cell listing showing `SYNC` (`InSync`/`OutOfSync`/`-`) and a container listing showing `RESTARTS` via `-o wide`.
- **New § "Label selector (`-l`/`--selector`)":** one example block covering equality, absence, comma-AND; documents `NAME` + `-l` rejection.
- **New § "Retired in v0.6.0":** pins removal of `--show-controllers`/`CGROUP` column, `IMAGE`-as-default, `ROOT` column, and `kuke image get`/`ls`/`list`.

## AC reinterpretation (heads-up posted on #943)

Two AC details required reinterpretation per CLAUDE.md §Sanity-check AC implementation specifics — full rationale on the [issue comment](https://github.com/eminwux/kukeon/issues/943#issuecomment-4582717212):

1. The verbatim wording linked `[kuke restart cell](kuke-restart.md)` and `[kuke status](kuke-status.md)`, neither of which exist as docs files. Demoted both to plain code spans so this PR doesn't introduce new `mkdocs --strict` warnings; the `[kuke doctor cgroups](kuke-doctor.md)` link is kept (target exists).
2. The AC's `rg --show-controllers|CGROUP` "only Retired section" check is unsatisfiable because the verbatim "Default tables" prose itself contains `CGROUP, ROOT, and IMAGE (as defaults) were retired ... see Retired in v0.6.0 below`. Both surviving hits are retirement-context (no live use).

`mkdocs build --strict` on `main` already aborts with 1 pre-existing warning (`proposals/agent-native-orchestration.md` → `faq.md#when-is-v10`); after this PR's edits the count stays at 1 (zero new warnings introduced).

## Test plan

- [x] `mkdocs build --strict` — 0 new warnings (1 pre-existing, unrelated)
- [x] `rg -n '\-\-show-controllers|CGROUP' docs/site/cli/kuke-get.md` returns only retirement-context hits (L62 forward-ref + L141 Retired bullet; no live use)
- [x] Common flags table has the `-l`/`--selector` row
- [x] New § "Default tables and `-o wide` columns" lists all eight kinds with default + wide contracts
- [x] Behavior examples include a cell listing showing `SYNC` and a container listing showing `RESTARTS`
- [x] New § "Label selector" carries equality + absence + comma-AND examples
- [x] New § "Retired in v0.6.0" pins `--show-controllers`/`CGROUP`, `IMAGE`-as-default, `ROOT`, and `kuke image get`/`ls`/`list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)