### PR TITLE
docs: fix relative link to faq.md#when-is-v10 in agent-native-orchestration.md

### DIFF
--- a/docs/site/proposals/agent-native-orchestration.md
+++ b/docs/site/proposals/agent-native-orchestration.md
@@ -438,4 +438,4 @@ The proposal above was written before v0.4.0. Most of P0 and P1 has since shippe
 
 ### What this means for v1.0
 
-The agent-native gate — "give an agent a workspace, an egress-restricted network, a scoped credential, and a non-root sandbox by declaration" — is redeemed in v0.5.0 by the P0+P1-minus-Session set, and the [Section 6 success manifest](#6-what-success-looks-like) shape works today (substituting explicit `kuke apply` + `kuke delete` for the deferred `Session` kind). The remaining gaps to v1.0 are schema/runtime tracks not covered by this proposal — see the [FAQ on v1.0](faq.md#when-is-v10) for the gating issues.
+The agent-native gate — "give an agent a workspace, an egress-restricted network, a scoped credential, and a non-root sandbox by declaration" — is redeemed in v0.5.0 by the P0+P1-minus-Session set, and the [Section 6 success manifest](#6-what-success-looks-like) shape works today (substituting explicit `kuke apply` + `kuke delete` for the deferred `Session` kind). The remaining gaps to v1.0 are schema/runtime tracks not covered by this proposal — see the [FAQ on v1.0](../faq.md#when-is-v10) for the gating issues.


### PR DESCRIPTION
## Summary

Fix a broken relative link in `docs/site/proposals/agent-native-orchestration.md` that causes `mkdocs build --strict` to abort with exit 1.

The link on line 441 pointed to `faq.md#when-is-v10`. mkdocs resolves relative links from the source file's directory (`docs/site/proposals/`), so it looked for `proposals/faq.md` and failed. The FAQ actually lives at `docs/site/faq.md`. Changed the path to `../faq.md#when-is-v10`; the anchor (`when-is-v10`, rendered from `## When is v1.0?` at `docs/site/faq.md:68`) was already correct.

After this fix, `mkdocs build --strict` no longer fails on this warning, unblocking the strict-mode invariant other docs PR ACs rely on (e.g. #946).

## Test plan

- [x] Verified `docs/site/faq.md` exists and contains `## When is v1.0?` at line 68 (anchor matches)
- [x] Verified `docs/site/proposals/faq.md` does not exist (confirming the original path was broken)
- [x] Verified relative resolution: `docs/site/proposals/agent-native-orchestration.md` + `../faq.md` → `docs/site/faq.md` ✓
- [ ] `mkdocs build --strict` clean (deferred — `mkdocs`/`pip` not installed on dev host; CI exercises this path)

Closes #961