### PR TITLE
docs(blog): replace ghost `-c` with `<config>` positional in dev-containers post footer

### DIFF
--- a/docs/site/blog/posts/kuke-run-as-a-docker-compatible-workflow-for-dev-containers.md
+++ b/docs/site/blog/posts/kuke-run-as-a-docker-compatible-workflow-for-dev-containers.md
@@ -134,5 +134,5 @@ The trade is honest: you write more YAML up-front than you write `docker run` fl
 ## Where to go next
 
 - For the full agent-runner shape — building a custom image, the Attachable cell pattern, and the parametrized `CellBlueprint` for one-shot prompts — see [Run Claude Code in a kukeon cell](../../guides/run-claude-code.md). The cell-spec pattern this post uses is the same one that guide walks through end-to-end.
-- For the full surface of `kuke run -f` (including `-b` blueprint mode, `-c` config mode, `--rm` auto-delete, and the `-d/--detach` flag), see the [`kuke run` reference](../../cli/kuke-run.md).
+- For the full surface of `kuke run -f` (including `-b` blueprint mode, `<config>` positional for CellConfig, `--rm` auto-delete, and the `-d/--detach` flag), see the [`kuke run` reference](../../cli/kuke-run.md).
 - For everything `kuke apply`, `kuke attach`, `kuke delete`, and `kuke purge` will and won't do — exit codes, side effects, error paths — `docs/cli-use-cases.md` in the repo is the workflow-oriented source of truth.


### PR DESCRIPTION
## Summary

- Fix the lone surviving `-c` ghost reference in `docs/site/blog/posts/kuke-run-as-a-docker-compatible-workflow-for-dev-containers.md`'s "Where to go next" footer, replacing `\`-c\` config mode` with `` `<config>` positional for CellConfig`` to match the canonical surface documented in `docs/site/cli/kuke-run.md` after PR #809 (which retired the `-c`/`--config` flag in #813).
- One-line markdown edit; the bullet's link target (`kuke-run.md`) was already correct.

## Test plan

- [x] Diff is one line in one blog post — markdown only; no code paths touched.
- [x] Phrasing (`<config>` positional) matches `docs/site/cli/kuke-run.md:5–7,21` vocabulary.

## Out-of-scope note for follow-up

While confirming the AC I greppped `kuke run -c` across `docs/` and found surviving instances in **`docs/site/manifests/blueprint.md`** (3 hits) and **`docs/site/manifests/config.md`** (5 hits). Per scope discipline I did **not** expand this PR — issue #957 is narrowly scoped to the blog footer. Operator may want to file a follow-up sweep issue for `docs/site/manifests/{blueprint,config}.md`.

Closes #957