### PR TITLE
docs(cli): extend kuke-create.md for blueprint/config/secret + cell --from-* modes

### DIFF
--- a/docs/site/cli/kuke-create.md
+++ b/docs/site/cli/kuke-create.md
@@ -7,7 +7,7 @@ kuke create <resource> [NAME] [flags]
 kuke c      <resource> [NAME] [flags]      # alias
 ```
 
-Resources: `realm`, `space`, `stack`, `cell`, `container`. Each subcommand also has a short alias (`r`, `sp`, `st`, `ce`, `co`).
+Resources: `realm`, `space`, `stack`, `cell`, `container`, `blueprint`, `config`, `secret`. Each subcommand also has a short alias (`r`, `sp`, `st`, `ce`, `co`, `bp`, `cfg`, and `secret` has none).
 
 ## kuke create realm
 
@@ -57,18 +57,40 @@ sudo kuke create stack wordpress --realm default --space blog
 
 ```
 kuke create cell [NAME] --realm <r> --space <s> --stack <t>
+                       [--from-blueprint <bp> [--param K=V]... [--param-file <path>]]
+                       [--from-config <cfg>]
 ```
 
-| Flag      | Default   | Description              |
-| --------- | --------- | ------------------------ |
+Three modes:
+
+- `kuke create cell <name>` (no source flag) — creates an empty Cell shell (name + scope only, no containers). Workflow C: follow with `kuke create container -c <name> --image ...` then `kuke start cell <name>`.
+- `kuke create cell <name> --from-blueprint <bp> [--param K=V]... [--param-file <path>]` — resolves the daemon-stored CellBlueprint, applies scalar params, materialises the full Cell record (containers and all), and persists it in a **stopped** state. Pair with `kuke start cell <name>`. Differs from [`kuke run -b`](kuke-run.md) (materialise + start + attach) by leaving the cell stopped for inspection or hand-off; `-b`-lineage cells have no in-place reconcile, so updates flow through delete-and-re-run (or promotion to a CellConfig).
+- `kuke create cell <name> --from-config <cfg>` — resolves the daemon-stored CellConfig and its referenced Blueprint, applies the Config's `spec.values` + repo/secret slot fills, materialises the Cell record, persists in **stopped** state. Pair with `kuke start cell <name>`. Differs from [`kuke run <config>`](kuke-run.md) (materialise + start + attach) by leaving the cell stopped; later reconcile against the lineage Config flows through [`kuke restart cell <name>`](kuke-restart.md) (OutOfSync-driven, #821) once the cell is started.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `<NAME>` (positional) | _(required)_ | The cell name |
 | `--realm` | `default` | Realm that owns the cell |
 | `--space` | `default` | Space that owns the cell |
 | `--stack` | `default` | Stack that owns the cell |
-
-`create cell` creates an empty cell (no containers). Use [`kuke apply`](kuke-apply.md) with a manifest to create a cell with its containers in one step, or [`kuke run`](kuke-run.md) for a one-shot create+start.
+| `--from-blueprint` | `""` | Daemon-stored CellBlueprint name. Mutually exclusive with `--from-config` |
+| `--from-config` | `""` | Daemon-stored CellConfig name. Mutually exclusive with `--from-blueprint` |
+| `--param` | (empty, repeatable) | Scalar parameter override `KEY=VALUE`. Valid with `--from-blueprint`; rejected with `--from-config` (a Config carries its own `spec.values`) |
+| `--param-file` | `""` | File of `KEY=VALUE` lines seeding scalar parameters. Same declaration rules as `--param`; `--param` wins on dups. Rejected with `--from-config` |
 
 ```bash
+# Empty shell
 sudo kuke create cell web --realm default --space blog --stack wordpress
+
+# Materialise from Blueprint, stopped
+sudo kuke create cell web --from-blueprint web-template --param IMAGE=nginx:1.27 \
+    --realm default --space blog --stack wordpress
+sudo kuke start cell web --realm default --space blog --stack wordpress
+
+# Materialise from Config, stopped
+sudo kuke create cell prod --from-config prod-config \
+    --realm default --space blog --stack wordpress
+sudo kuke start cell prod --realm default --space blog --stack wordpress
 ```
 
 ## kuke create container
@@ -117,6 +139,83 @@ sudo kuke create container nginx \
 
 !!! warning "The `--image` default"
     If you don't pass `--image`, Kukeon uses `docker.io/library/debian:latest`. Always pass `--image` explicitly when you care what runs.
+
+## kuke create blueprint
+
+```
+kuke create blueprint [NAME] [--realm <r>] [--space <s>] [--stack <t>]
+```
+
+Scaffold a `kind: CellBlueprint` starter YAML to stdout. Emits a syntactically-valid Blueprint document with a single placeholder container, the operator's `--realm`/`--space`/`--stack` as scope, and inline `# TODO` markers on the required `image:` field plus comment markers for optional sections (parameters, ports, volumes, repos, secrets) so operators know what they can add.
+
+No daemon call — pure stdout emission.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `<NAME>` (positional) | _(required)_ | The blueprint name |
+| `--realm` | `default` | Realm that owns the blueprint |
+| `--space` | `default` | Space that owns the blueprint |
+| `--stack` | `default` | Stack that owns the blueprint |
+
+```bash
+kuke create blueprint web > web.yaml
+$EDITOR web.yaml          # fill image, add parameters/repos/secrets/...
+sudo kuke apply -f web.yaml
+```
+
+## kuke create config
+
+```
+kuke create config [NAME] --from-blueprint <bp> [--realm <r>] [--space <s>] [--stack <t>]
+```
+
+Scaffold a `kind: CellConfig` YAML from a CellBlueprint. Reads the referenced Blueprint from the daemon, introspects its declared scalar parameters and structural repo/secret slots, and emits a starter Config YAML to stdout with defaults pre-filled and `# TODO` markers where the operator must fill required-no-default parameters and slot sources. The output is not written to the daemon — pipe it to `kuke apply -f -` after editing.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `<NAME>` (positional) | _(required)_ | The config name |
+| `--from-blueprint` | _(required)_ | Source CellBlueprint name |
+| `--realm` | `default` | Realm that owns the config (also the default Blueprint lookup scope) |
+| `--space` | `default` | Space that owns the config (also the default Blueprint lookup scope) |
+| `--stack` | `default` | Stack that owns the config (also the default Blueprint lookup scope) |
+
+```bash
+kuke create config prod --from-blueprint web > prod-config.yaml
+$EDITOR prod-config.yaml  # fill required slot sources, override defaults
+sudo kuke apply -f prod-config.yaml
+sudo kuke run prod        # idempotent attach to the at-most-one cell prod owns
+```
+
+## kuke create secret
+
+```
+kuke create secret [NAME] (--from-literal=KEY=VAL... | --from-file=<path>)
+                          [--realm <r>] [--space <s>] [--stack <t>]
+```
+
+Create a `kind: Secret` within a scope. Two source modes:
+
+- `kuke create secret <name> --from-literal=KEY=VAL` — inline value, repeatable. Multiple values are joined by newline.
+- `kuke create secret <name> --from-file=<path>` — read value from file.
+
+At least one of `--from-literal` or `--from-file` is required. The Secret is written to daemon storage and is referenceable via `ContainerSecret.secretRef` from a `CellConfig`'s slot fill.
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `<NAME>` (positional) | _(required)_ | The secret name |
+| `--realm` | `default` | Realm that owns the secret |
+| `--space` | `default` | Space that owns the secret |
+| `--stack` | `default` | Stack that owns the secret |
+| `--from-literal` | (empty, repeatable) | Specify a key-value pair as `KEY=VAL` |
+| `--from-file` | `""` | Read the secret value from a file |
+
+```bash
+# Inline value
+sudo kuke create secret api-key --from-literal=API_KEY=sk-... --realm default
+
+# From file
+sudo kuke create secret tls-cert --from-file=./tls.crt --realm default
+```
 
 ## Imperative vs. declarative
 


### PR DESCRIPTION
## Summary

- Extends `docs/site/cli/kuke-create.md` to cover the three new `kuke create` resources (blueprint, config, secret) shipped between v0.5.0 and 0.6.0 (#842, #843, #879, #880) plus the materialise-without-start modes on `kuke create cell`.
- Lead resource list now enumerates `blueprint`, `config`, `secret` and their aliases (`bp`, `cfg`, none).
- Existing `## kuke create cell` block rewritten for three modes: empty shell, `--from-blueprint [--param/--param-file]`, and `--from-config` — including the materialise-but-don't-start contract and the cross-references to `kuke run` and `kuke restart cell`.
- Adds three new sections (`## kuke create blueprint`, `## kuke create config`, `## kuke create secret`), each with synopsis fenced block + flag table + bash example, matching the existing per-kind section template.

All wording is taken verbatim from the issue body. Flag names, defaults, aliases, and mutual-exclusion rules were cross-checked against `cmd/kuke/create/{blueprint,config,secret,cell}/*.go` (`Use`/`Aliases`/`Flags()`) before drafting.

The forward-reference to `kuke-restart.md` in the `--from-config` blurb is acknowledged in the issue AC ("resolve once that file lands (sibling issue, this release)"); the link will go live once the sibling kuke-restart docs page lands.

Closes #945

## Test plan

- [x] Lead resource list includes `blueprint`, `config`, `secret` and aliases (`bp`, `cfg`, none).
- [x] `kuke create cell` section documents empty-shell, `--from-blueprint`, and `--from-config` modes with `--param`/`--param-file` rules and the materialise-but-don't-start contract.
- [x] Three new sections exist (`## kuke create blueprint`, `## kuke create config`, `## kuke create secret`), each with synopsis + flag table + bash example.
- [ ] `mkdocs build --strict` clean — not runnable in this environment (no `pip`/`mkdocs` toolchain available; project's CI runs `mkdocs gh-deploy --force`, not `--strict`). The one expected warning is the acknowledged forward-ref to `kuke-restart.md` per the issue AC; that link resolves once the sibling page lands. Reviewer to validate locally.
- [ ] Flag tables match source — spot-checked against `cmd/kuke/create/{blueprint,config,secret,cell}/*.go` and `cmd/kuke/create/create.go` (resource enumeration + aliases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)