### PR TITLE
docs(manifests): replace stale `kuke run -c` with `<config>` positional in blueprint.md and config.md

### DIFF
--- a/docs/site/manifests/blueprint.md
+++ b/docs/site/manifests/blueprint.md
@@ -77,7 +77,7 @@ Same shape as [ContainerRepo](container.md). Unlike a hand-written `Cell` / `Con
 
 #### `spec.cell.containers[].secrets[]` (list, optional)
 
-Slot-only channel: the blueprint declares the **consumption side** (where the resolved bytes land inside the container), and a `CellConfig` supplies the **source side** (which `kind: Secret` provides the bytes). Because a blueprint never carries the source, a blueprint that declares secret slots cannot run inline with `-b` — it requires `kuke run -c` with a `CellConfig` that fills the slots.
+Slot-only channel: the blueprint declares the **consumption side** (where the resolved bytes land inside the container), and a `CellConfig` supplies the **source side** (which `kind: Secret` provides the bytes). Because a blueprint never carries the source, a blueprint that declares secret slots cannot run inline with `-b` — it requires `kuke run <config>` (positional) with a `CellConfig` that fills the slots.
 
 | Field       | Type   | Required           | Description                                                                                                              |
 | ----------- | ------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
@@ -101,10 +101,10 @@ The `blueprints/` directory is `0755` and each blueprint document is `0644`, bot
 
 ## Invariants
 
-- **Always fresh.** Every `kuke run -b` materializes a cell named `<prefix>-<6hex>`, where the suffix is 3 bytes of entropy. A blueprint never identifies a singleton cell — that contract belongs to [`CellConfig`](config.md). For singleton workloads use `CellConfig` (and `kuke run -c`) rather than a blueprint plus an external pinning convention.
+- **Always fresh.** Every `kuke run -b` materializes a cell named `<prefix>-<6hex>`, where the suffix is 3 bytes of entropy. A blueprint never identifies a singleton cell — that contract belongs to [`CellConfig`](config.md). For singleton workloads use `CellConfig` (and the `kuke run <config>` positional) rather than a blueprint plus an external pinning convention.
 - **Back-reference.** Every materialized cell carries the `kukeon.io/blueprint=<name>` label, so an operator can list all instances of a blueprint with `kuke get cells -l kukeon.io/blueprint=<name>`.
 - **Scalar parameters declared.** A `${KEY}` in the body must appear in `spec.parameters[]`; otherwise the blueprint fails to load. Typos surface at apply time, not as a runtime mystery.
-- **Structural slots block inline.** A required repo slot (no inline `url`) or any required secret slot makes the blueprint un-runnable with `-b`; the run path refuses with a message naming the offenders and recommending `kuke run -c` with a `CellConfig` that fills them. Optional unfilled slots are dropped silently from the materialized container.
+- **Structural slots block inline.** A required repo slot (no inline `url`) or any required secret slot makes the blueprint un-runnable with `-b`; the run path refuses with a message naming the offenders and recommending `kuke run <config>` (positional) with a `CellConfig` that fills them. Optional unfilled slots are dropped silently from the materialized container.
 
 ## Minimal
 
@@ -127,4 +127,4 @@ spec:
           - MODEL=${MODEL}
 ```
 
-A realm-scoped blueprint named `claude-code` with one scalar parameter and one container. Run a fresh instance with `kuke run -b claude-code --realm kuke-system` (each invocation produces a new `claude-code-<6hex>` cell). For an idempotent, named instance, bind it via a [`CellConfig`](config.md) and run with `kuke run -c`.
+A realm-scoped blueprint named `claude-code` with one scalar parameter and one container. Run a fresh instance with `kuke run -b claude-code --realm kuke-system` (each invocation produces a new `claude-code-<6hex>` cell). For an idempotent, named instance, bind it via a [`CellConfig`](config.md) and run with `kuke run <config>` (positional).

--- a/docs/site/manifests/config.md
+++ b/docs/site/manifests/config.md
@@ -26,7 +26,7 @@ spec:
 
 A `CellConfig` binds a [`CellBlueprint`](blueprint.md) to a concrete, idempotent cell **identity**. Where a Blueprint answers _"what does this cell look like?"_, a Config answers _"which instance?"_: a name with a deterministic derivation, the scalar `values` filled into the blueprint's parameters, and the structural repo/secret slot fills keyed by the blueprint's slot names. A Config materializes at most one live cell per scope.
 
-See [`kuke run -c`](../cli/kuke-run.md) for the identity state machine that decides whether `kuke run -c <config>` materializes a fresh cell, attaches to an existing one, or refuses because the in-cluster cell diverged from the Config's current spec.
+See [`kuke run <config>`](../cli/kuke-run.md) for the identity state machine that decides whether `kuke run <config>` materializes a fresh cell, attaches to an existing one, or refuses because the in-cluster cell diverged from the Config's current spec.
 
 ## metadata
 
@@ -92,12 +92,12 @@ The two channels are independent: scalar `values` are blueprint-side parameters 
 
 ## Identity and stable name
 
-A `CellConfig` materializes **at most one** live cell within its scope. The cell's deterministic name is `metadata.name` verbatim — not `<name>-<hash-of-values>` and not `<name>-<6hex>`. The derivation is value-independent on purpose: editing `spec.values` keeps the same cell identity so subsequent `kuke run -c` invocations attach to the existing cell rather than spawning a fresh one and orphaning the old.
+A `CellConfig` materializes **at most one** live cell within its scope. The cell's deterministic name is `metadata.name` verbatim — not `<name>-<hash-of-values>` and not `<name>-<6hex>`. The derivation is value-independent on purpose: editing `spec.values` keeps the same cell identity so subsequent `kuke run <config>` invocations attach to the existing cell rather than spawning a fresh one and orphaning the old.
 
 The matching contract:
 
-- Every cell `kuke run -c` materializes carries the `kukeon.io/config=<name>` back-reference label. The runtime locates the at-most-one live cell a Config owns by listing cells in the Config's scope with that label.
-- When the in-cluster cell's spec diverges from the Config's current spec (after re-resolving scalar values and slot fills), `kuke run -c` refuses to attach and points at `kuke restart cell <name>` to reconcile — `run` stays a pure read/materialize verb, and destructive updates (stop, update, start) route through `kuke restart cell <name>`. The full identity state machine (no cell → materialize, running → attach, stopped → start-then-attach, divergent → refuse with `kuke restart cell <name>` pointer, error state → refuse with `kuke delete cell` pointer) lives in [`kuke run -c`](../cli/kuke-run.md).
+- Every cell `kuke run <config>` materializes carries the `kukeon.io/config=<name>` back-reference label. The runtime locates the at-most-one live cell a Config owns by listing cells in the Config's scope with that label.
+- When the in-cluster cell's spec diverges from the Config's current spec (after re-resolving scalar values and slot fills), `kuke run <config>` refuses to attach and points at `kuke restart cell <name>` to reconcile — `run` stays a pure read/materialize verb, and destructive updates (stop, update, start) route through `kuke restart cell <name>`. The full identity state machine (no cell → materialize, running → attach, stopped → start-then-attach, divergent → refuse with `kuke restart cell <name>` pointer, error state → refuse with `kuke delete cell` pointer) lives in [`kuke run <config>`](../cli/kuke-run.md).
 
 This is the structural contrast with a [`CellBlueprint`](blueprint.md): a blueprint is always-fresh (`<prefix>-<6hex>` per invocation), a config is always-named (`<configName>` per binding).
 
@@ -115,7 +115,7 @@ The `configs/` directory is `0755` and each config document is `0644`, both owne
 
 ## Invariants
 
-- **One Config → at most one live cell within scope.** The deterministic stable name is `metadata.name` verbatim; subsequent `kuke run -c` invocations attach to the existing cell or refuse on divergence rather than spawning a duplicate.
+- **One Config → at most one live cell within scope.** The deterministic stable name is `metadata.name` verbatim; subsequent `kuke run <config>` invocations attach to the existing cell or refuse on divergence rather than spawning a duplicate.
 - **Back-reference.** Every materialized cell carries the `kukeon.io/config=<name>` label, so an operator can find a Config's live cell with `kuke get cells -l kukeon.io/config=<name>`.
 - **Apply-time slot validation.** A Config that fills an undeclared slot, or that leaves a required slot unfilled, errors at apply time against the referenced blueprint's current shape — not at run time.
 - **Cross-scope references.** A Config may reference a Blueprint in a different scope; the same is true of the `secretRef` inside each secret slot fill.
@@ -144,4 +144,4 @@ spec:
         realm: kuke-system
 ```
 
-A realm-scoped Config named `prod` that instantiates the `claude-code` blueprint (also realm-scoped), overrides the `MODEL` scalar parameter, fills the `workspace` repo slot, and fills the `anthropic-token` secret slot from the existing `kind: Secret` of the same name. Run with `sudo kuke run -c prod --realm kuke-system`; re-running attaches to the same cell.
+A realm-scoped Config named `prod` that instantiates the `claude-code` blueprint (also realm-scoped), overrides the `MODEL` scalar parameter, fills the `workspace` repo slot, and fills the `anthropic-token` secret slot from the existing `kind: Secret` of the same name. Run with `sudo kuke run prod --realm kuke-system`; re-running attaches to the same cell.


### PR DESCRIPTION
## Summary

- Sweeps the nine residual `kuke run -c` references in `docs/site/manifests/blueprint.md` (4) and `docs/site/manifests/config.md` (5) to the positional `<config>` form introduced in #825. `docs/site/cli/kuke-run.md` was already refreshed; these two manifest reference pages were the residual gap.
- Replacements are verbatim per the issue body: `kuke run -c` → `kuke run <config>` (and the L147 binding-named example → `kuke run prod`).
- Link targets at `config.md` L29 and L100 are unchanged (`(../cli/kuke-run.md)` carried no anchor before or after), so no broken anchors are introduced.

## Test plan

- [x] `rg -n 'kuke run -c' docs/site/manifests/` → 0 hits.
- [x] `rg -n 'kuke run -c' docs/` → 0 hits.
- [ ] `mkdocs build --strict` — toolchain not installable in the agent dev environment (no `pip`), deferred to CI. The diff is text-only inside prose and link-text positions; no link `href` changed (the unanchored `(../cli/kuke-run.md)` references at L29/L100 are preserved verbatim), so the strict-mode anchor concern called out in the AC cannot materialize from this diff.

Closes #944