### PR TITLE
feat(init): introduce kukepause binary as root container entrypoint

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,8 @@ jobs:
       - name: Generate sha256 checksums for release assets
         run: |
           for f in kuke-linux-amd64 kuke-linux-arm64 \
-                   kukeond-linux-amd64 kukeond-linux-arm64; do
+                   kukeond-linux-amd64 kukeond-linux-arm64 \
+                   kukepause-linux-amd64 kukepause-linux-arm64; do
             sha256sum "$f" > "$f.sha256"
           done
 
@@ -48,8 +49,10 @@ jobs:
           gh release create "${GITHUB_REF#refs/tags/}" \
           ./kuke-linux-amd64 ./kuke-linux-arm64 \
           ./kukeond-linux-amd64 ./kukeond-linux-arm64 \
+          ./kukepause-linux-amd64 ./kukepause-linux-arm64 \
           ./kuke-linux-amd64.sha256 ./kuke-linux-arm64.sha256 \
           ./kukeond-linux-amd64.sha256 ./kukeond-linux-arm64.sha256 \
+          ./kukepause-linux-amd64.sha256 ./kukepause-linux-arm64.sha256 \
           --title "${GITHUB_REF#refs/tags/}" \
           --generate-notes \
           --notes "Container images (multi-arch: linux/amd64, linux/arm64):

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ LDFLAGS := -s -w \
 	-X $(MODULE)/cmd/config.KukeondImageRepo=$(KUKEON_IMAGE_REPO)
 
 # ----- Build matrix -----
-BINS = kuke kukeond kuketty kukebuild
+BINS = kuke kukeond kuketty kukepause kukebuild
 OS = linux
 ARCHS = amd64 arm64
 
@@ -48,7 +48,7 @@ all: clean kill $(BINS)
 .PHONY: release
 release: release-build
 
-.PHONY: kuke kukeond kuketty kukebuild
+.PHONY: kuke kukeond kuketty kukepause kukebuild
 kuke:
 	go build \
 	-o kuke \
@@ -69,6 +69,19 @@ kuketty:
 	-o kuketty \
 	-ldflags="$(LDFLAGS)" \
 	./cmd/kuketty/
+
+# kukepause is the minimal PID 1 for every cell's root (pause) container
+# (issue #931). It is built static (CGO_ENABLED=0, no libc) and pre-staged on
+# the host by `kuke init` to /opt/kukeon/bin/kukepause, then bind-mounted into
+# each root container at /pause — it cannot ship inside the kukeond image like
+# kuketty because root containers (including kukeond's own) exist before the
+# daemon is up. The version ldflags don't apply (it imports no cmd/config), so
+# it links with -s -w only.
+kukepause:
+	CGO_ENABLED=0 go build \
+	-o kukepause \
+	-ldflags="-s -w" \
+	./cmd/kukepause/
 
 # kukebuild is the native image builder that embeds BuildKit as a library
 # (issue #522). It lives in its own Go module (cmd/kukebuild/go.mod, issue #655)
@@ -103,6 +116,12 @@ release-build:
 			-o kuketty-$$OS-$$ARCH \
 			-ldflags="$(LDFLAGS)" \
 			./cmd/kuketty; \
+			GO111MODULE=on CGO_ENABLED=0 GOOS=$$OS GOARCH=$$ARCH \
+			go build -a \
+			-trimpath \
+			-o kukepause-$$OS-$$ARCH \
+			-ldflags="-s -w" \
+			./cmd/kukepause; \
 		done \
 	done
 
@@ -129,7 +148,7 @@ release-build-kukebuild:
 
 clean:
 	rm -rf $(HOME)/.kukeon/run/*
-	rm -rf kuke kukeond kuketty kukebuild
+	rm -rf kuke kukeond kuketty kukepause kukebuild
 
 kill:
 	(killall kukeond || true )
@@ -186,7 +205,7 @@ e2e: test-e2e
 #
 # Issue #284 collapsed KUKE_INIT_SERVER_CONFIGURATION into KUKEOND_CONFIGURATION
 # — one env var, one source of truth, the same path the daemon honours.
-test-e2e: kuke kukeond kuketty
+test-e2e: kuke kukeond kuketty kukepause
 	@echo "Building local kukeond image $(KUKEON_E2E_IMAGE_DOCKER_NAME) for e2e"
 	docker build --build-arg VERSION=v0.0.0-e2e -t $(KUKEON_E2E_IMAGE_DOCKER_NAME) .
 	@echo "Running e2e tests using binaries in project root"
@@ -215,20 +234,22 @@ dev-init:
 # dev workflow can't afford. argv[0] dispatch resolves `kukeond` to the
 # daemon entrypoint because the basename of the exec path is `kukeond`.
 #
-# kukebuild is symlinked only when it has been built (the `[ -f ]` guard), so
-# `kuke build` resolves it on PATH after `make dev-init` (which runs `make kuke
-# kukebuild` before this target) without imposing kukebuild's separate-module
-# build on a plain `make install-dev`. Routing it through INSTALL_PREFIX here
-# keeps a single PATH-placement mechanism instead of a second one in dev-init.sh.
+# kukebuild and kukepause are symlinked only when they have been built (the
+# `[ -f ]` guards), so `kuke build` resolves kukebuild on PATH and `kuke init`
+# resolves kukepause on PATH after `make dev-init` (which runs `make kuke
+# kukepause kukebuild` before this target) without imposing their builds on a
+# plain `make install-dev`. Routing them through INSTALL_PREFIX here keeps a
+# single PATH-placement mechanism instead of a second one in dev-init.sh.
 .PHONY: install-dev uninstall-dev
 install-dev: kuke
 	ln -sf kuke kukeond
 	sudo ln -sf $(CURDIR)/kuke $(INSTALL_PREFIX)/kuke
 	sudo ln -sf $(CURDIR)/kuke $(INSTALL_PREFIX)/kukeond
 	@[ -f $(CURDIR)/kukebuild ] && sudo ln -sf $(CURDIR)/kukebuild $(INSTALL_PREFIX)/kukebuild || true
+	@[ -f $(CURDIR)/kukepause ] && sudo ln -sf $(CURDIR)/kukepause $(INSTALL_PREFIX)/kukepause || true
 
 uninstall-dev:
-	sudo rm -f $(INSTALL_PREFIX)/kuke $(INSTALL_PREFIX)/kukeond $(INSTALL_PREFIX)/kukebuild
+	sudo rm -f $(INSTALL_PREFIX)/kuke $(INSTALL_PREFIX)/kukeond $(INSTALL_PREFIX)/kukebuild $(INSTALL_PREFIX)/kukepause
 
 # Publish the one-line installer through the mkdocs site: copy
 # `scripts/install.sh` (canonical source) into `docs/site/install.sh` so

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -19,8 +19,10 @@ package init
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller"
+	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/firewall"
 	"github.com/eminwux/kukeon/internal/instance"
@@ -60,6 +63,22 @@ const (
 	kukeonRunPathDirMode  os.FileMode = os.ModeSetgid | 0o750
 	kukeonRunPathFileMode os.FileMode = 0o640
 	kukeonSocketMode      os.FileMode = 0o660
+
+	// kukepauseBinaryName is the binary `kuke init` stages under <RunPath>/bin
+	// so every cell's root container — including kukeond's own — can bind-mount
+	// it at /pause as PID 1 (issue #931). It is pre-staged on the host because
+	// root containers are created before kukeond is up, so it cannot be copied
+	// out of the daemon image the way kuketty is. Sourced from the ctr package
+	// so the staged name matches the root-container builder's bind source.
+	kukepauseBinaryName = ctr.RootContainerPauseBinaryName
+
+	// kukepauseStagedMode is the on-disk mode kukepause is staged with. It must
+	// carry an execute bit so the kernel can exec /pause through the root
+	// container's read-only bind mount. The recursive RunPath chown in
+	// applyKukeonOwnership otherwise drops every file to kukeonRunPathFileMode
+	// (0o640, no exec), so runInit re-asserts this mode on the staged binary
+	// afterward.
+	kukepauseStagedMode os.FileMode = 0o750
 )
 
 func NewInitCmd() *cobra.Command {
@@ -353,6 +372,86 @@ func applyKukeonOwnership(
 	return r, nil
 }
 
+// stageKukepause copies the kukepause binary into <runPath>/bin/kukepause and
+// returns the staged path. The staged copy is what every cell's root container
+// bind-mounts at /pause (issue #931). Mirrors the runner's stageKukettyBinary
+// contract: <RunPath>/bin destination, atomic tmp+rename copy, executable mode.
+func stageKukepause(runPath string) (string, error) {
+	src, err := resolveKukepauseSource()
+	if err != nil {
+		return "", err
+	}
+	binDir := filepath.Join(runPath, "bin")
+	if err = os.MkdirAll(binDir, 0o750); err != nil {
+		return "", fmt.Errorf("create kukepause stage dir %q: %w", binDir, err)
+	}
+	dst := filepath.Join(binDir, kukepauseBinaryName)
+	if err = copyKukepauseAtomic(src, dst); err != nil {
+		return "", err
+	}
+	return dst, nil
+}
+
+// resolveKukepauseSource locates a kukepause binary on the host. Lookup order:
+// $PATH first (the installed / `make install-dev` layout, kukepause alongside
+// kuke), then a sibling of the running executable (dev runs of `./kuke` from the
+// repo root next to a freshly built `./kukepause`, and the e2e harness which
+// execs the repo-root kuke). The error names the install path so a "not found"
+// is actionable.
+func resolveKukepauseSource() (string, error) {
+	if p, err := exec.LookPath(kukepauseBinaryName); err == nil {
+		return p, nil
+	}
+	if self, err := os.Executable(); err == nil {
+		sibling := filepath.Join(filepath.Dir(self), kukepauseBinaryName)
+		if info, statErr := os.Stat(sibling); statErr == nil && !info.IsDir() {
+			return sibling, nil
+		}
+	}
+	return "", fmt.Errorf(
+		"%s not found on $PATH or alongside kuke; build it with `make kukepause` and install it (`make install-dev`)",
+		kukepauseBinaryName,
+	)
+}
+
+// copyKukepauseAtomic copies src over dst via a sibling tmp file + rename so a
+// concurrent reader never observes a partial binary. Mode carries the execute
+// bit through the root container's bind mount.
+func copyKukepauseAtomic(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open kukepause source %q: %w", src, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	tmp := dst + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, kukepauseStagedMode)
+	if err != nil {
+		return fmt.Errorf("create kukepause staged tmp %q: %w", tmp, err)
+	}
+	if _, err = io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("copy kukepause %q -> %q: %w", src, tmp, err)
+	}
+	if err = out.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close kukepause staged tmp %q: %w", tmp, err)
+	}
+	// O_CREATE applies the mode only on creation and is subject to umask; chmod
+	// guarantees the execute bit regardless of the caller's umask or a
+	// pre-existing tmp file.
+	if err = os.Chmod(tmp, kukepauseStagedMode); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("chmod kukepause staged tmp %q: %w", tmp, err)
+	}
+	if err = os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename kukepause staged %q -> %q: %w", tmp, dst, err)
+	}
+	return nil
+}
+
 func runInit(cmd *cobra.Command, _ []string) error {
 	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
 	if !ok || logger == nil {
@@ -420,6 +519,15 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return fwErr
 	}
 
+	// Pre-stage kukepause under <RunPath>/bin before Bootstrap creates the
+	// kukeond cell: that cell's root container bind-mounts the staged binary at
+	// /pause and execs it as PID 1, so it must exist on the host first (issue
+	// #931). All later user cells reuse the same staged copy.
+	kukepausePath, stageErr := stageKukepause(runPath)
+	if stageErr != nil {
+		return fmt.Errorf("stage kukepause: %w", stageErr)
+	}
+
 	opts := controller.Options{
 		RunPath:              runPath,
 		ContainerdSocket:     containerdSocket,
@@ -443,7 +551,17 @@ func runInit(cmd *cobra.Command, _ []string) error {
 		return ownErr
 	}
 
+	// applyKukeonOwnership's recursive RunPath chown drops every file to 0o640,
+	// stripping kukepause's execute bit. Re-assert it root:kukeon 0o750 so root
+	// containers created after init can exec the bind-mounted /pause (issue
+	// #931). The kukeond cell created during Bootstrap already exec'd the
+	// pre-chown copy, so this only matters for subsequent cells.
+	if chmodErr := sysuser.ChownAndChmod(kukepausePath, 0, ensure.GID, kukepauseStagedMode); chmodErr != nil {
+		return fmt.Errorf("restore kukepause exec bit %q: %w", kukepausePath, chmodErr)
+	}
+
 	printBootstrapReport(cmd, report, permsReport)
+	cmd.Println(fmt.Sprintf("  - kukepause staged: %s", kukepausePath))
 
 	if viper.GetBool(config.KUKE_INIT_NO_WAIT.ViperKey) {
 		return nil

--- a/cmd/kukepause/main.go
+++ b/cmd/kukepause/main.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// kukepause is the minimal PID 1 for every kukeon cell's root (pause)
+// container, replacing the previous `sleep infinity` from busybox (issue #931).
+//
+// `sleep` makes a poor PID 1 for two reasons: it installs no SIGTERM handler,
+// so the kernel's default-ignore-fatal-signals rule for PID 1 means a SIGTERM
+// sent during cell deletion is dropped and `StopContainer` burns its full
+// 10-second graceful-shutdown timeout before escalating to SIGKILL; and it does
+// not reap orphaned children, so any process re-parented to the cell's PID 1
+// lingers as a zombie.
+//
+// kukepause fixes both: it installs SIGTERM/SIGINT handlers that exit 0 (so cell
+// teardown completes in well under a second) and a SIGCHLD reaper that harvests
+// every re-parented child via wait4(2), then blocks on pause(2) so it consumes
+// no CPU while idle.
+//
+// It is built CGO_ENABLED=0 (no libc dependency) and bind-mounted into each root
+// container at /pause; it cannot be staged from the kukeond image the way
+// kuketty is, because root containers — including kukeond's own — must exist
+// before kukeond is running, so `kuke init` pre-stages it on the host instead.
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	// SIGTERM/SIGINT → graceful exit 0. Buffer size covers a burst of both
+	// signals arriving before the loop drains them; we exit on the first.
+	term := make(chan os.Signal, 2)
+	signal.Notify(term, syscall.SIGTERM, syscall.SIGINT)
+
+	// SIGCHLD → reap. Buffered so a coalesced delivery (the kernel collapses
+	// multiple pending SIGCHLDs into one) still wakes the reaper; reapZombies
+	// drains every exited child per wake, so a single slot is sufficient.
+	chld := make(chan os.Signal, 1)
+	signal.Notify(chld, syscall.SIGCHLD)
+
+	for {
+		select {
+		case <-term:
+			os.Exit(0)
+		case <-chld:
+			reapZombies()
+		}
+	}
+}
+
+// reapZombies harvests every child that has exited since the last wake. wait4
+// with WNOHANG returns pid 0 (no more reapable children) or -ECHILD (no
+// children at all); either ends the drain. A coalesced SIGCHLD can stand in for
+// several exits, so the loop must continue until one of those terminal results
+// rather than reaping a single child per signal.
+func reapZombies() {
+	for {
+		var status syscall.WaitStatus
+		pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+		if pid <= 0 || err != nil {
+			return
+		}
+	}
+}

--- a/cmd/kukepause/main_test.go
+++ b/cmd/kukepause/main_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestReapZombiesTerminatesWithNoChildren guards the drain loop's exit
+// condition: Wait4 returns -ECHILD (or pid 0) when there is nothing to reap, and
+// reapZombies must return on that rather than spin. A regression here would hang
+// PID 1 inside the SIGCHLD handler — the kind of bug that only shows up as a
+// wedged pause container, so assert termination directly. The test process has
+// no reapable children of its own (the Go runtime owns and reaps any it spawns),
+// so this exercises the empty-children path.
+func TestReapZombiesTerminatesWithNoChildren(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		reapZombies()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reapZombies did not return with no reapable children — drain loop may be spinning")
+	}
+}

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -363,7 +363,7 @@ func stageKukettyBinary(runPath string) (string, error) {
 		return "", fmt.Errorf("mkdir %q: %w", dstDir, err)
 	}
 
-	if err = copyBinaryAtomic(src, dst); err != nil {
+	if err = copyBinaryAtomic(src, dst, "kuketty"); err != nil {
 		return "", err
 	}
 	return dst, nil
@@ -432,31 +432,33 @@ func resolveKukettyBinary() (string, error) {
 // copyBinaryAtomic copies src to dst via a sibling tmp file, then renames
 // the tmp file over dst. Mode is 0o755 — the binary must be exec'able by
 // the workload's uid through the bind mount, which carries through unix
-// owner-x bits but not setgid-style elevations.
-func copyBinaryAtomic(src, dst string) error {
+// owner-x bits but not setgid-style elevations. The label string is woven
+// into every error so callers (kuketty, kukepause) get attributable
+// diagnostics when a stage trip fails.
+func copyBinaryAtomic(src, dst, label string) error {
 	in, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("open kuketty source %q: %w", src, err)
+		return fmt.Errorf("open %s source %q: %w", label, src, err)
 	}
 	defer func() { _ = in.Close() }()
 
 	tmp := dst + ".tmp"
 	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
 	if err != nil {
-		return fmt.Errorf("create kuketty staged tmp %q: %w", tmp, err)
+		return fmt.Errorf("create %s staged tmp %q: %w", label, tmp, err)
 	}
 	if _, err = io.Copy(out, in); err != nil {
 		_ = out.Close()
 		_ = os.Remove(tmp)
-		return fmt.Errorf("copy kuketty %q -> %q: %w", src, tmp, err)
+		return fmt.Errorf("copy %s %q -> %q: %w", label, src, tmp, err)
 	}
 	if err = out.Close(); err != nil {
 		_ = os.Remove(tmp)
-		return fmt.Errorf("close kuketty staged tmp %q: %w", tmp, err)
+		return fmt.Errorf("close %s staged tmp %q: %w", label, tmp, err)
 	}
 	if err = os.Rename(tmp, dst); err != nil {
 		_ = os.Remove(tmp)
-		return fmt.Errorf("rename kuketty staged %q -> %q: %w", tmp, dst, err)
+		return fmt.Errorf("rename %s staged %q -> %q: %w", label, tmp, dst, err)
 	}
 	return nil
 }

--- a/internal/controller/runner/kukepause.go
+++ b/internal/controller/runner/kukepause.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/eminwux/kukeon/internal/ctr"
+)
+
+// kukepauseSourcePathInsideDaemon is the path inside the kukeond container
+// image where a bundled kukepause binary would live (parallel to
+// /bin/kuketty). The kukeond image does not currently ship kukepause — the
+// canonical bootstrap is `kuke init` staging from the host before the
+// daemon's own cell is created — so this lookup is the most-preferred path
+// purely for symmetry with kuketty. If absent, resolveKukepauseBinary falls
+// through to the sibling-of-executable and $PATH lookups that the e2e
+// harness (./kukeond next to ./kukepause) and operator installs depend on.
+const kukepauseSourcePathInsideDaemon = "/bin/" + ctr.RootContainerPauseBinaryName
+
+// stageKukepauseBinary ensures a host-visible copy of the kukepause binary
+// exists at <RunPath>/bin/kukepause and returns that path. Mirrors
+// stageKukettyBinary's contract for the same reason: every default root
+// container bind-mounts the staged binary at /pause, so the daemon must
+// self-heal when it provisions a cell whose RunPath was not previously
+// touched by `kuke init` — exactly the e2e suite's startKukeondDaemon path,
+// which boots `kukeond serve --run-path <tempdir>` without an `init` pass.
+//
+// Idempotent: once the destination exists with non-zero size and an exec
+// bit, subsequent calls return its path without re-copying. This matters
+// because every CreateCell / StartCell trip lands here; doing the lstat
+// early avoids reading a multi-MiB binary off disk per cell.
+//
+// Atomicity is handled with a tmp+rename so two concurrent provisions on
+// the same RunPath never see a partial binary at the destination.
+func stageKukepauseBinary(runPath string) (string, error) {
+	dstDir := filepath.Join(runPath, kukettyBinaryStagedSubdir)
+	dst := filepath.Join(dstDir, ctr.RootContainerPauseBinaryName)
+
+	if ok, err := stagedBinaryUsable(dst); err != nil {
+		return "", err
+	} else if ok {
+		return dst, nil
+	}
+
+	src, err := resolveKukepauseBinary()
+	if err != nil {
+		return "", err
+	}
+
+	if err = os.MkdirAll(dstDir, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %q: %w", dstDir, err)
+	}
+
+	if err = copyBinaryAtomic(src, dst, ctr.RootContainerPauseBinaryName); err != nil {
+		return "", err
+	}
+	return dst, nil
+}
+
+// resolveKukepauseBinary locates a kukepause binary on the host. Lookup
+// order mirrors resolveKukettyBinary so operators familiar with one
+// reason about the other the same way:
+//
+//  1. /bin/kukepause — bundled-in-image path (currently unused, see the
+//     constant comment).
+//  2. Sibling of the currently-running executable — the e2e harness path
+//     (./kukeond exec'd from the repo root with ./kukepause next to it),
+//     also covered by `make install-dev` placing both binaries under
+//     /usr/local/bin.
+//  3. $PATH — operator installs that landed kukepause out-of-band.
+//
+// The error names every location tried so a "not found" miss is
+// debuggable end-to-end.
+func resolveKukepauseBinary() (string, error) {
+	tried := []string{kukepauseSourcePathInsideDaemon}
+	if ok, _ := stagedBinaryUsable(kukepauseSourcePathInsideDaemon); ok {
+		return kukepauseSourcePathInsideDaemon, nil
+	}
+
+	if self, err := os.Executable(); err == nil {
+		sibling := filepath.Join(filepath.Dir(self), ctr.RootContainerPauseBinaryName)
+		tried = append(tried, sibling)
+		if ok, _ := stagedBinaryUsable(sibling); ok {
+			return sibling, nil
+		}
+	}
+
+	if p, err := exec.LookPath(ctr.RootContainerPauseBinaryName); err == nil {
+		return p, nil
+	}
+	tried = append(tried, "$PATH/"+ctr.RootContainerPauseBinaryName)
+	return "", fmt.Errorf("%s binary not found in: %v", ctr.RootContainerPauseBinaryName, tried)
+}

--- a/internal/controller/runner/kukepause_test.go
+++ b/internal/controller/runner/kukepause_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/ctr"
+)
+
+// TestStageKukepauseBinary_ReusesExisting locks the idempotent-stage path:
+// when the destination is already a usable executable, the helper returns
+// without re-copying. Load-bearing because every CreateCell trip hits this
+// code path — re-copying the binary per cell would be wasted work.
+func TestStageKukepauseBinary_ReusesExisting(t *testing.T) {
+	runPath := t.TempDir()
+	dstDir := filepath.Join(runPath, kukettyBinaryStagedSubdir)
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dst := filepath.Join(dstDir, ctr.RootContainerPauseBinaryName)
+	if err := os.WriteFile(dst, []byte("\x7fELF stub"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	got, err := stageKukepauseBinary(runPath)
+	if err != nil {
+		t.Fatalf("stageKukepauseBinary: %v", err)
+	}
+	if got != dst {
+		t.Fatalf("stageKukepauseBinary = %q, want %q", got, dst)
+	}
+
+	data, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if string(data) != "\x7fELF stub" {
+		t.Fatalf("dst contents = %q, want stub (helper re-copied)", data)
+	}
+}

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -2192,7 +2192,10 @@ func (r *Exec) ensureCellRootContainerSpec(cell intmodel.Cell) (intmodel.Contain
 		}
 	} else {
 		// Create default root container spec
-		// Pass containerdID to set ContainerdID field, ID will be set to "root"
+		// Pass containerdID to set ContainerdID field, ID will be set to "root".
+		// The kukepause host path (<RunPath>/bin/kukepause, staged by
+		// `kuke init`) is bind-mounted at /pause as the root container's PID 1
+		// (issue #931).
 		rootSpec = ctr.DefaultRootContainerSpec(
 			containerdID,
 			cellID,
@@ -2200,6 +2203,7 @@ func (r *Exec) ensureCellRootContainerSpec(cell intmodel.Cell) (intmodel.Contain
 			spaceName,
 			stackName,
 			cniConfigPath,
+			filepath.Join(r.opts.RunPath, "bin", ctr.RootContainerPauseBinaryName),
 		)
 		// Propagate HostNetwork from any cell container to the default root
 		// container. Non-root containers join the root container's netns

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -2193,9 +2193,17 @@ func (r *Exec) ensureCellRootContainerSpec(cell intmodel.Cell) (intmodel.Contain
 	} else {
 		// Create default root container spec
 		// Pass containerdID to set ContainerdID field, ID will be set to "root".
-		// The kukepause host path (<RunPath>/bin/kukepause, staged by
-		// `kuke init`) is bind-mounted at /pause as the root container's PID 1
-		// (issue #931).
+		// The kukepause host path (<RunPath>/bin/kukepause) is bind-mounted at
+		// /pause as the root container's PID 1 (issue #931). Stage it now so
+		// daemon-only bootstrap paths (e2e `startKukeondDaemon`, and any future
+		// caller that runs `kukeond serve --run-path X` without a prior
+		// `kuke init`) self-heal — `kuke init` also stages it, but its copy is
+		// not the *only* writer the daemon can rely on. Idempotent: returns the
+		// existing path without re-copying when one is already there.
+		kukepauseHostPath, stageErr := stageKukepauseBinary(r.opts.RunPath)
+		if stageErr != nil {
+			return intmodel.ContainerSpec{}, fmt.Errorf("stage kukepause: %w", stageErr)
+		}
 		rootSpec = ctr.DefaultRootContainerSpec(
 			containerdID,
 			cellID,
@@ -2203,7 +2211,7 @@ func (r *Exec) ensureCellRootContainerSpec(cell intmodel.Cell) (intmodel.Contain
 			spaceName,
 			stackName,
 			cniConfigPath,
-			filepath.Join(r.opts.RunPath, "bin", ctr.RootContainerPauseBinaryName),
+			kukepauseHostPath,
 		)
 		// Propagate HostNetwork from any cell container to the default root
 		// container. Non-root containers join the root container's netns

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -25,10 +25,26 @@ import (
 )
 
 const (
-	// DefaultRootContainerImage is the image used when none is provided.
+	// DefaultRootContainerImage is the image used when none is provided. It is
+	// retained only as the root container's filesystem base — the pause process
+	// is the bind-mounted kukepause binary, not anything from busybox (#931).
 	DefaultRootContainerImage = "docker.io/library/busybox:latest"
-	defaultRootContainerCmd   = "sleep"
-	defaultRootContainerArg   = "infinity"
+
+	// RootContainerPauseBinaryTarget is the in-container path the host's
+	// kukepause binary is bind-mounted to and exec'd as PID 1 in every default
+	// root container. kukepause installs SIGTERM/SIGINT handlers (so cell
+	// teardown does not burn StopContainer's 10s graceful timeout) and a SIGCHLD
+	// zombie reaper, then blocks on pause(2) — replacing the previous
+	// `sleep infinity`, which ignored SIGTERM as PID 1 and reaped nothing
+	// (issue #931).
+	RootContainerPauseBinaryTarget = "/pause"
+
+	// RootContainerPauseBinaryName is the basename of the kukepause binary as
+	// staged under <RunPath>/bin by `kuke init`. It is the single source of
+	// truth shared by the init-time stager (the writer) and the root-container
+	// builder (which reads <RunPath>/bin/<name> as the /pause bind source) so
+	// the two never drift (issue #931).
+	RootContainerPauseBinaryName = "kukepause"
 
 	rootContainerLabelKey   = "kukeon.io/container-type"
 	rootContainerLabelValue = "root"
@@ -38,14 +54,32 @@ const (
 // the root container alive while other workload containers are managed.
 // containerdID is the hierarchical ID used for containerd operations.
 // The ID field will be set to "root" (base name).
+//
+// kukepauseHostPath is the host path of the staged kukepause binary
+// (<RunPath>/bin/kukepause, placed by `kuke init`). It is bind-mounted
+// read-only at /pause and exec'd as the root container's PID 1 in place of the
+// previous `sleep infinity` from busybox (issue #931). An empty path yields no
+// bind mount — the caller is responsible for staging the binary first.
 func DefaultRootContainerSpec(
 	containerdID,
 	cellID,
 	realmID,
 	spaceID,
 	stackID,
-	cniConfigPath string,
+	cniConfigPath,
+	kukepauseHostPath string,
 ) intmodel.ContainerSpec {
+	var volumes []intmodel.VolumeMount
+	if kukepauseHostPath != "" {
+		volumes = []intmodel.VolumeMount{
+			{
+				Kind:     intmodel.VolumeKindBind,
+				Source:   kukepauseHostPath,
+				Target:   RootContainerPauseBinaryTarget,
+				ReadOnly: true,
+			},
+		}
+	}
 	return intmodel.ContainerSpec{
 		ID:            "root",
 		ContainerdID:  containerdID,
@@ -55,8 +89,9 @@ func DefaultRootContainerSpec(
 		StackName:     stackID,
 		Root:          true,
 		Image:         DefaultRootContainerImage,
-		Command:       defaultRootContainerCmd,
-		Args:          []string{defaultRootContainerArg},
+		Command:       RootContainerPauseBinaryTarget,
+		Args:          nil,
+		Volumes:       volumes,
 		CNIConfigPath: cniConfigPath,
 	}
 }
@@ -227,7 +262,13 @@ func buildRootProcessArgs(rootSpec intmodel.ContainerSpec) []string {
 		copy(args, rootSpec.Args)
 		return args
 	default:
-		return []string{defaultRootContainerCmd, defaultRootContainerArg}
+		// No command and no args: a user-supplied root container spec with
+		// neither falls through to its image's own entrypoint (empty process
+		// args means WithProcessArgs is not applied). The default root spec
+		// from DefaultRootContainerSpec always carries Command=/pause, so it
+		// never reaches this branch (issue #931 retired the busybox
+		// sleep-infinity fallback that previously lived here).
+		return nil
 	}
 }
 

--- a/internal/ctr/container_utils_test.go
+++ b/internal/ctr/container_utils_test.go
@@ -18,6 +18,7 @@ package ctr_test
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	ctr "github.com/eminwux/kukeon/internal/ctr"
@@ -49,43 +50,46 @@ func applyRootBuiltSpec(
 
 func TestDefaultRootContainerSpec(t *testing.T) {
 	tests := []struct {
-		name          string
-		containerdID  string
-		cellID        string
-		realmID       string
-		spaceID       string
-		stackID       string
-		cniConfigPath string
-		wantID        string
-		wantImage     string
-		wantCommand   string
-		wantRoot      bool
+		name              string
+		containerdID      string
+		cellID            string
+		realmID           string
+		spaceID           string
+		stackID           string
+		cniConfigPath     string
+		kukepauseHostPath string
+		wantID            string
+		wantImage         string
+		wantRoot          bool
+		wantVolume        bool
 	}{
 		{
-			name:          "all parameters provided",
-			containerdID:  "containerd-123",
-			cellID:        "cell-1",
-			realmID:       "realm-1",
-			spaceID:       "space-1",
-			stackID:       "stack-1",
-			cniConfigPath: "/path/to/cni/config",
-			wantID:        "root",
-			wantImage:     ctr.DefaultRootContainerImage,
-			wantCommand:   "sleep",
-			wantRoot:      true,
+			name:              "all parameters provided",
+			containerdID:      "containerd-123",
+			cellID:            "cell-1",
+			realmID:           "realm-1",
+			spaceID:           "space-1",
+			stackID:           "stack-1",
+			cniConfigPath:     "/path/to/cni/config",
+			kukepauseHostPath: "/opt/kukeon/bin/kukepause",
+			wantID:            "root",
+			wantImage:         ctr.DefaultRootContainerImage,
+			wantRoot:          true,
+			wantVolume:        true,
 		},
 		{
-			name:          "empty parameters",
-			containerdID:  "",
-			cellID:        "",
-			realmID:       "",
-			spaceID:       "",
-			stackID:       "",
-			cniConfigPath: "",
-			wantID:        "root",
-			wantImage:     ctr.DefaultRootContainerImage,
-			wantCommand:   "sleep",
-			wantRoot:      true,
+			name:              "empty parameters",
+			containerdID:      "",
+			cellID:            "",
+			realmID:           "",
+			spaceID:           "",
+			stackID:           "",
+			cniConfigPath:     "",
+			kukepauseHostPath: "",
+			wantID:            "root",
+			wantImage:         ctr.DefaultRootContainerImage,
+			wantRoot:          true,
+			wantVolume:        false,
 		},
 	}
 
@@ -98,6 +102,7 @@ func TestDefaultRootContainerSpec(t *testing.T) {
 				tt.spaceID,
 				tt.stackID,
 				tt.cniConfigPath,
+				tt.kukepauseHostPath,
 			)
 
 			if spec.ID != tt.wantID {
@@ -115,19 +120,72 @@ func TestDefaultRootContainerSpec(t *testing.T) {
 			if spec.Image != tt.wantImage {
 				t.Errorf("Image = %q, want %q", spec.Image, tt.wantImage)
 			}
-			if spec.Command != tt.wantCommand {
-				t.Errorf("Command = %q, want %q", spec.Command, tt.wantCommand)
+			// kukepause replaces the busybox `sleep infinity`: Command is the
+			// in-container /pause target and Args is cleared (issue #931).
+			if spec.Command != ctr.RootContainerPauseBinaryTarget {
+				t.Errorf("Command = %q, want %q", spec.Command, ctr.RootContainerPauseBinaryTarget)
+			}
+			if len(spec.Args) != 0 {
+				t.Errorf("Args = %v, want empty", spec.Args)
 			}
 			if spec.Root != tt.wantRoot {
 				t.Errorf("Root = %v, want %v", spec.Root, tt.wantRoot)
 			}
-			if len(spec.Args) != 1 || spec.Args[0] != "infinity" {
-				t.Errorf("Args = %v, want [infinity]", spec.Args)
-			}
 			if spec.CNIConfigPath != tt.cniConfigPath {
 				t.Errorf("CNIConfigPath = %q, want %q", spec.CNIConfigPath, tt.cniConfigPath)
 			}
+			// A non-empty kukepause host path yields one read-only bind mount of
+			// that path at /pause; an empty path yields none.
+			if tt.wantVolume {
+				if len(spec.Volumes) != 1 {
+					t.Fatalf("Volumes = %v, want one /pause bind mount", spec.Volumes)
+				}
+				v := spec.Volumes[0]
+				if v.Kind != intmodel.VolumeKindBind ||
+					v.Source != tt.kukepauseHostPath ||
+					v.Target != ctr.RootContainerPauseBinaryTarget ||
+					!v.ReadOnly {
+					t.Errorf("Volumes[0] = %+v, want read-only bind %q -> %q",
+						v, tt.kukepauseHostPath, ctr.RootContainerPauseBinaryTarget)
+				}
+			} else if len(spec.Volumes) != 0 {
+				t.Errorf("Volumes = %v, want none for empty kukepause path", spec.Volumes)
+			}
 		})
+	}
+}
+
+// TestBuildRootContainerSpec_PauseBindMount verifies the default root container
+// produced by DefaultRootContainerSpec flows the kukepause binary through to the
+// OCI spec as a read-only /pause bind mount and execs it as PID 1 (issue #931).
+func TestBuildRootContainerSpec_PauseBindMount(t *testing.T) {
+	const kukepauseHostPath = "/opt/kukeon/bin/kukepause"
+	in := ctr.DefaultRootContainerSpec(
+		"containerd-root", "cell", "realm", "space", "stack", "", kukepauseHostPath,
+	)
+	spec := applyRootBuiltSpec(t, in, nil)
+
+	var found bool
+	for _, m := range spec.Mounts {
+		if m.Destination != ctr.RootContainerPauseBinaryTarget {
+			continue
+		}
+		found = true
+		if m.Type != "bind" || m.Source != kukepauseHostPath {
+			t.Errorf("/pause mount = %+v, want bind from %q", m, kukepauseHostPath)
+		}
+		if !slices.Contains(m.Options, "ro") {
+			t.Errorf("/pause mount options = %v, want read-only (ro)", m.Options)
+		}
+	}
+	if !found {
+		t.Fatalf("no %q bind mount in spec.Mounts = %+v",
+			ctr.RootContainerPauseBinaryTarget, spec.Mounts)
+	}
+
+	if spec.Process == nil || len(spec.Process.Args) == 0 ||
+		spec.Process.Args[0] != ctr.RootContainerPauseBinaryTarget {
+		t.Errorf("process args = %+v, want [%q]", spec.Process, ctr.RootContainerPauseBinaryTarget)
 	}
 }
 
@@ -539,12 +597,16 @@ func TestBuildRootContainerSpec_Resources(t *testing.T) {
 // root container path (no Volumes, no security fields) keeps its existing
 // minimal SpecOpts shape after the parity fix.
 func TestBuildRootContainerSpec_DefaultsUnaffected(t *testing.T) {
+	// Empty kukepause host path so this guard stays focused on the minimal
+	// SpecOpts shape: the /pause bind mount is exercised separately in
+	// TestDefaultRootContainerSpec / TestBuildRootContainerSpec_PauseBindMount.
 	spec := applyRootBuiltSpec(t, ctr.DefaultRootContainerSpec(
 		"containerd-root",
 		"cell",
 		"realm",
 		"space",
 		"stack",
+		"",
 		"",
 	), nil)
 

--- a/internal/ctr/spec_default_memory_test.go
+++ b/internal/ctr/spec_default_memory_test.go
@@ -180,7 +180,7 @@ func TestBuildContainerSpec_DefaultMemoryLimit_ZeroIsNoop(t *testing.T) {
 // spec with no Resources gets the daemon default written (#531).
 func TestBuildRootContainerSpec_DefaultMemoryLimit_AppliedWhenSpecHasNone(t *testing.T) {
 	const defaultBytes int64 = 2 * 1024 * 1024 * 1024
-	in := ctr.DefaultRootContainerSpec("containerd-root", "cell", "realm", "space", "stack", "")
+	in := ctr.DefaultRootContainerSpec("containerd-root", "cell", "realm", "space", "stack", "", "")
 
 	spec := applyRootWithBuildOpts(t, in, ctr.WithDefaultMemoryLimit(defaultBytes))
 
@@ -199,7 +199,7 @@ func TestBuildRootContainerSpec_DefaultMemoryLimit_AppliedWhenSpecHasNone(t *tes
 func TestBuildRootContainerSpec_DefaultMemoryLimit_ExplicitWins(t *testing.T) {
 	const defaultBytes int64 = 2 * 1024 * 1024 * 1024
 	explicit := int64(8 * 1024 * 1024 * 1024)
-	in := ctr.DefaultRootContainerSpec("containerd-root", "cell", "realm", "space", "stack", "")
+	in := ctr.DefaultRootContainerSpec("containerd-root", "cell", "realm", "space", "stack", "", "")
 	in.Resources = &intmodel.ContainerResources{MemoryLimitBytes: &explicit}
 
 	spec := applyRootWithBuildOpts(t, in, ctr.WithDefaultMemoryLimit(defaultBytes))
@@ -216,7 +216,7 @@ func TestBuildRootContainerSpec_DefaultMemoryLimit_ExplicitWins(t *testing.T) {
 // behavior preserving contract for root containers — no option, zero, or
 // negative value all leave memory.max unwritten.
 func TestBuildRootContainerSpec_DefaultMemoryLimit_ZeroIsNoop(t *testing.T) {
-	in := ctr.DefaultRootContainerSpec("containerd-root", "cell", "realm", "space", "stack", "")
+	in := ctr.DefaultRootContainerSpec("containerd-root", "cell", "realm", "space", "stack", "", "")
 	for _, tc := range []struct {
 		name string
 		opts []ctr.BuildOption

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -233,17 +233,19 @@ EOF
     PRESERVE_ENV_ADMIN="KUKEON_HOST,KUKEOND_SOCKET,KUKE_CONFIGURATION"
 fi
 
-step "Build kuke, kukebuild (and the kukeond symlink)"
-make kuke kukebuild
+step "Build kuke, kukepause, kukebuild (and the kukeond symlink)"
+make kuke kukepause kukebuild
 ln -sf kuke kukeond
 
 step "Install dev symlinks on PATH (make install-dev)"
-# install-dev symlinks kuke/kukeond and — because `make kuke kukebuild` above
-# has built it — kukebuild into INSTALL_PREFIX (/usr/local/bin by default). The
-# `kuke build` step below runs as `sudo ./kuke build`, a thin shim that resolves
-# `kukebuild` via PATH and exec's it, so kukebuild must sit on root's
-# secure_path; routing it through install-dev keeps a single PATH-placement
-# mechanism.
+# install-dev symlinks kuke/kukeond and — because `make kuke kukepause kukebuild`
+# above has built them — kukepause and kukebuild into INSTALL_PREFIX
+# (/usr/local/bin by default). The `kuke build` step below runs as
+# `sudo ./kuke build`, a thin shim that resolves `kukebuild` via PATH and exec's
+# it; the `kuke init` step resolves `kukepause` the same way to pre-stage it
+# under <RunPath>/bin before any root container is created (issue #931). Both
+# must sit on root's secure_path; routing them through install-dev keeps a
+# single PATH-placement mechanism.
 make install-dev
 
 # Pre-flight: catch missing host cgroup-v2 controller delegation BEFORE the


### PR DESCRIPTION
## Summary

Introduces `kukepause` — a minimal static Go binary that becomes PID 1 for every cell's root (pause) container, replacing the previous `sleep infinity` from busybox (#931).

`sleep` is a poor PID 1: it installs no SIGTERM handler, so the kernel's default-ignore rule for PID 1 drops the SIGTERM sent during cell deletion and `StopContainer` (`internal/ctr/container.go`) burns its full 10s graceful timeout before escalating to SIGKILL; it also reaps no orphaned children. `kukepause` installs SIGTERM/SIGINT handlers (exit 0) and a SIGCHLD `wait4` zombie-reaper, then blocks on `pause(2)`.

Because root containers — **including kukeond's own** — are created before kukeond is running, the binary cannot be staged from the daemon image the way kuketty is. It is pre-staged on the host by `kuke init` and bind-mounted read-only into each root container at `/pause`.

### Changes
- **`cmd/kukepause/main.go`** — the binary (`CGO_ENABLED=0`, no libc): SIGTERM/SIGINT → exit 0, SIGCHLD → reap via `syscall.Wait4`, loop on `syscall.Pause()`.
- **`Makefile`** — `kukepause` build target (`CGO_ENABLED=0`), added to `BINS`, `release-build`, `clean`, `install-dev` (PATH symlink), and the `test-e2e` deps.
- **`cmd/kuke/init/init.go`** — stages `kukepause` to `<RunPath>/bin/kukepause` (`0o750`) before `Bootstrap` creates the kukeond cell, then re-asserts the exec bit after the recursive RunPath chown (which otherwise drops files to `0o640`). Source resolves from `$PATH` then a sibling of the running `kuke`.
- **`internal/ctr/container_utils.go`** — `DefaultRootContainerSpec` now bind-mounts the staged kukepause at `/pause`, sets `Command=/pause`, `Args=nil`; removed the dead `defaultRootContainerCmd`/`defaultRootContainerArg` constants. busybox is retained only as the filesystem base.
- **`internal/controller/runner/provision.go`** — passes `<RunPath>/bin/kukepause` to the root spec builder.
- **`.github/workflows/release.yaml`** — uploads `kukepause-linux-amd64`/`arm64` (+ `.sha256`) as release assets.

### AC reinterpretation (flagged on the issue, [comment](https://github.com/eminwux/kukeon/issues/931#issuecomment-4583023795))
The spec names the staged path `/opt/kukeon/bin/kukepause`. To stay correct under a non-default `--run-path` (the e2e suite's `kuke init --run-path <tempdir>`, any operator-overridden RunPath), staging and the bind-mount source are wired to `<RunPath>/bin/kukepause` — identical to `/opt/kukeon/bin/kukepause` by default, and matching the established `<RunPath>/bin/kuketty` precedent in `internal/controller/runner/attachable.go`.

## Test plan
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `make test-root` (full root suite, e2e excluded) — green
- [x] `golangci-lint` on changed packages — clean (pre-existing `dupl` in unrelated files only)
- [x] New unit tests: `TestDefaultRootContainerSpec` (/pause command + bind mount), `TestBuildRootContainerSpec_PauseBindMount` (read-only `/pause` OCI mount + process args), `TestReapZombiesTerminatesWithNoChildren`
- [x] **AC: static binary** — `CGO_ENABLED=0` build, `ldd` → "not a dynamic executable"
- [x] **AC: SIGTERM exits root in < 1s** — staged `/opt/kukeon/bin/kukepause` exits 0 on SIGTERM and SIGINT in ~2ms
- [x] **AC: `make dev-init` smoke** — passed end-to-end (exit 0): kukeond cell root container came up running `/pause`, daemon ready, `kukepause staged: /opt/kukeon/bin/kukepause`, daemon-parity check byte-identical, `kuke attach` smoke against a daemon-created user cell attached + detached cleanly, parent attach plumbing intact. Staged binary verified `-rwxr-x--- root kukeon`.

Closes #931
