### PR TITLE
docs(kukepause): correct idle-block mechanism — Go select, not pause(2)

### DIFF
--- a/cmd/kukepause/main.go
+++ b/cmd/kukepause/main.go
@@ -26,8 +26,8 @@
 //
 // kukepause fixes both: it installs SIGTERM/SIGINT handlers that exit 0 (so cell
 // teardown completes in well under a second) and a SIGCHLD reaper that harvests
-// every re-parented child via wait4(2), then blocks on pause(2) so it consumes
-// no CPU while idle.
+// every re-parented child via wait4(2), then blocks on a Go select over those
+// signal channels so it consumes no CPU while idle.
 //
 // It is built CGO_ENABLED=0 (no libc dependency) and bind-mounted into each root
 // container at /pause; it cannot be staged from the kukeond image the way

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -34,9 +34,9 @@ const (
 	// kukepause binary is bind-mounted to and exec'd as PID 1 in every default
 	// root container. kukepause installs SIGTERM/SIGINT handlers (so cell
 	// teardown does not burn StopContainer's 10s graceful timeout) and a SIGCHLD
-	// zombie reaper, then blocks on pause(2) — replacing the previous
-	// `sleep infinity`, which ignored SIGTERM as PID 1 and reaped nothing
-	// (issue #931).
+	// zombie reaper, then blocks on a Go select over those signal channels —
+	// replacing the previous `sleep infinity`, which ignored SIGTERM as PID 1
+	// and reaped nothing (issue #931).
 	RootContainerPauseBinaryTarget = "/pause"
 
 	// RootContainerPauseBinaryName is the basename of the kukepause binary as


### PR DESCRIPTION
## Summary

- Issue #976 nit on PR #974: `cmd/kukepause/main.go`'s package doc claimed the binary "blocks on `pause(2)` so it consumes no CPU while idle", but the implementation is a Go `select` loop over `term`/`chld` signal channels. Behaviorally equivalent (the goroutine parks until a signal), but the doc misrepresents the mechanism.
- Reworded the package doc to "blocks on a Go select over those signal channels so it consumes no CPU while idle".
- Applied the same correction to the parallel mention in `internal/ctr/container_utils.go` (the `RootContainerPauseBinaryTarget` const doc), which carried the identical wrong claim about the same binary.

## Test plan

- [x] `go build ./cmd/kukepause/...` — clean (comment-only change).
- [x] `git diff` confirms only the two doc strings shifted; no code change.

Closes #976