### PR TITLE
cleanup(init): fold kukepause staged Printf wrapper

### DIFF
--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -561,7 +561,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 	}
 
 	printBootstrapReport(cmd, report, permsReport)
-	cmd.Println(fmt.Sprintf("  - kukepause staged: %s", kukepausePath))
+	cmd.Printf("  - kukepause staged: %s\n", kukepausePath)
 
 	if viper.GetBool(config.KUKE_INIT_NO_WAIT.ViperKey) {
 		return nil


### PR DESCRIPTION
## Summary
- Replace `cmd.Println(fmt.Sprintf("  - kukepause staged: %s", kukepausePath))` with `cmd.Printf("  - kukepause staged: %s\n", kukepausePath)` in `cmd/kuke/init/init.go` — the `fmt.Sprintf` wrap was redundant.

## Test plan
- [x] `make kuke` builds clean.
- [x] `GOWORK=off go vet ./cmd/kuke/init/...` passes.
- [x] `GOWORK=off go test ./cmd/kuke/init/...` passes.

Closes #975