### PR TITLE
refactor(ctr): relocate root container pause target to /.kukeon/bin/kukepause

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ kuketty:
 # kukepause is the minimal PID 1 for every cell's root (pause) container
 # (issue #931). It is built static (CGO_ENABLED=0, no libc) and pre-staged on
 # the host by `kuke init` to /opt/kukeon/bin/kukepause, then bind-mounted into
-# each root container at /pause — it cannot ship inside the kukeond image like
+# each root container at /.kukeon/bin/kukepause — it cannot ship inside the kukeond image like
 # kuketty because root containers (including kukeond's own) exist before the
 # daemon is up. The version ldflags don't apply (it imports no cmd/config), so
 # it links with -s -w only.

--- a/cmd/kuke/init/init.go
+++ b/cmd/kuke/init/init.go
@@ -66,14 +66,14 @@ const (
 
 	// kukepauseBinaryName is the binary `kuke init` stages under <RunPath>/bin
 	// so every cell's root container — including kukeond's own — can bind-mount
-	// it at /pause as PID 1 (issue #931). It is pre-staged on the host because
+	// it at /.kukeon/bin/kukepause as PID 1 (issue #931). It is pre-staged on the host because
 	// root containers are created before kukeond is up, so it cannot be copied
 	// out of the daemon image the way kuketty is. Sourced from the ctr package
 	// so the staged name matches the root-container builder's bind source.
 	kukepauseBinaryName = ctr.RootContainerPauseBinaryName
 
 	// kukepauseStagedMode is the on-disk mode kukepause is staged with. It must
-	// carry an execute bit so the kernel can exec /pause through the root
+	// carry an execute bit so the kernel can exec the bind-mounted kukepause through the root
 	// container's read-only bind mount. The recursive RunPath chown in
 	// applyKukeonOwnership otherwise drops every file to kukeonRunPathFileMode
 	// (0o640, no exec), so runInit re-asserts this mode on the staged binary
@@ -374,7 +374,7 @@ func applyKukeonOwnership(
 
 // stageKukepause copies the kukepause binary into <runPath>/bin/kukepause and
 // returns the staged path. The staged copy is what every cell's root container
-// bind-mounts at /pause (issue #931). Mirrors the runner's stageKukettyBinary
+// bind-mounts at /.kukeon/bin/kukepause (issue #931). Mirrors the runner's stageKukettyBinary
 // contract: <RunPath>/bin destination, atomic tmp+rename copy, executable mode.
 func stageKukepause(runPath string) (string, error) {
 	src, err := resolveKukepauseSource()
@@ -521,7 +521,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 
 	// Pre-stage kukepause under <RunPath>/bin before Bootstrap creates the
 	// kukeond cell: that cell's root container bind-mounts the staged binary at
-	// /pause and execs it as PID 1, so it must exist on the host first (issue
+	// /.kukeon/bin/kukepause and execs it as PID 1, so it must exist on the host first (issue
 	// #931). All later user cells reuse the same staged copy.
 	kukepausePath, stageErr := stageKukepause(runPath)
 	if stageErr != nil {
@@ -553,7 +553,7 @@ func runInit(cmd *cobra.Command, _ []string) error {
 
 	// applyKukeonOwnership's recursive RunPath chown drops every file to 0o640,
 	// stripping kukepause's execute bit. Re-assert it root:kukeon 0o750 so root
-	// containers created after init can exec the bind-mounted /pause (issue
+	// containers created after init can exec the bind-mounted kukepause (issue
 	// #931). The kukeond cell created during Bootstrap already exec'd the
 	// pre-chown copy, so this only matters for subsequent cells.
 	if chmodErr := sysuser.ChownAndChmod(kukepausePath, 0, ensure.GID, kukepauseStagedMode); chmodErr != nil {

--- a/cmd/kukepause/main.go
+++ b/cmd/kukepause/main.go
@@ -30,7 +30,7 @@
 // signal channels so it consumes no CPU while idle.
 //
 // It is built CGO_ENABLED=0 (no libc dependency) and bind-mounted into each root
-// container at /pause; it cannot be staged from the kukeond image the way
+// container at /.kukeon/bin/kukepause; it cannot be staged from the kukeond image the way
 // kuketty is, because root containers — including kukeond's own — must exist
 // before kukeond is running, so `kuke init` pre-stages it on the host instead.
 package main

--- a/internal/controller/runner/kukepause.go
+++ b/internal/controller/runner/kukepause.go
@@ -38,7 +38,7 @@ const kukepauseSourcePathInsideDaemon = "/bin/" + ctr.RootContainerPauseBinaryNa
 // stageKukepauseBinary ensures a host-visible copy of the kukepause binary
 // exists at <RunPath>/bin/kukepause and returns that path. Mirrors
 // stageKukettyBinary's contract for the same reason: every default root
-// container bind-mounts the staged binary at /pause, so the daemon must
+// container bind-mounts the staged binary at /.kukeon/bin/kukepause, so the daemon must
 // self-heal when it provisions a cell whose RunPath was not previously
 // touched by `kuke init` — exactly the e2e suite's startKukeondDaemon path,
 // which boots `kukeond serve --run-path <tempdir>` without an `init` pass.

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -2194,7 +2194,7 @@ func (r *Exec) ensureCellRootContainerSpec(cell intmodel.Cell) (intmodel.Contain
 		// Create default root container spec
 		// Pass containerdID to set ContainerdID field, ID will be set to "root".
 		// The kukepause host path (<RunPath>/bin/kukepause) is bind-mounted at
-		// /pause as the root container's PID 1 (issue #931). Stage it now so
+		// /.kukeon/bin/kukepause as the root container's PID 1 (issue #931). Stage it now so
 		// daemon-only bootstrap paths (e2e `startKukeondDaemon`, and any future
 		// caller that runs `kukeond serve --run-path X` without a prior
 		// `kuke init`) self-heal — `kuke init` also stages it, but its copy is

--- a/internal/ctr/container_utils.go
+++ b/internal/ctr/container_utils.go
@@ -37,12 +37,12 @@ const (
 	// zombie reaper, then blocks on a Go select over those signal channels —
 	// replacing the previous `sleep infinity`, which ignored SIGTERM as PID 1
 	// and reaped nothing (issue #931).
-	RootContainerPauseBinaryTarget = "/pause"
+	RootContainerPauseBinaryTarget = "/.kukeon/bin/kukepause"
 
 	// RootContainerPauseBinaryName is the basename of the kukepause binary as
 	// staged under <RunPath>/bin by `kuke init`. It is the single source of
 	// truth shared by the init-time stager (the writer) and the root-container
-	// builder (which reads <RunPath>/bin/<name> as the /pause bind source) so
+	// builder (which reads <RunPath>/bin/<name> as the kukepause bind source) so
 	// the two never drift (issue #931).
 	RootContainerPauseBinaryName = "kukepause"
 
@@ -57,7 +57,8 @@ const (
 //
 // kukepauseHostPath is the host path of the staged kukepause binary
 // (<RunPath>/bin/kukepause, placed by `kuke init`). It is bind-mounted
-// read-only at /pause and exec'd as the root container's PID 1 in place of the
+// read-only at RootContainerPauseBinaryTarget (/.kukeon/bin/kukepause) and
+// exec'd as the root container's PID 1 in place of the
 // previous `sleep infinity` from busybox (issue #931). An empty path yields no
 // bind mount — the caller is responsible for staging the binary first.
 func DefaultRootContainerSpec(
@@ -265,7 +266,8 @@ func buildRootProcessArgs(rootSpec intmodel.ContainerSpec) []string {
 		// No command and no args: a user-supplied root container spec with
 		// neither falls through to its image's own entrypoint (empty process
 		// args means WithProcessArgs is not applied). The default root spec
-		// from DefaultRootContainerSpec always carries Command=/pause, so it
+		// from DefaultRootContainerSpec always carries
+		// Command=RootContainerPauseBinaryTarget, so it
 		// never reaches this branch (issue #931 retired the busybox
 		// sleep-infinity fallback that previously lived here).
 		return nil

--- a/internal/ctr/container_utils_test.go
+++ b/internal/ctr/container_utils_test.go
@@ -121,7 +121,7 @@ func TestDefaultRootContainerSpec(t *testing.T) {
 				t.Errorf("Image = %q, want %q", spec.Image, tt.wantImage)
 			}
 			// kukepause replaces the busybox `sleep infinity`: Command is the
-			// in-container /pause target and Args is cleared (issue #931).
+			// in-container kukepause target and Args is cleared (issue #931).
 			if spec.Command != ctr.RootContainerPauseBinaryTarget {
 				t.Errorf("Command = %q, want %q", spec.Command, ctr.RootContainerPauseBinaryTarget)
 			}
@@ -135,10 +135,10 @@ func TestDefaultRootContainerSpec(t *testing.T) {
 				t.Errorf("CNIConfigPath = %q, want %q", spec.CNIConfigPath, tt.cniConfigPath)
 			}
 			// A non-empty kukepause host path yields one read-only bind mount of
-			// that path at /pause; an empty path yields none.
+			// that path at the kukepause target; an empty path yields none.
 			if tt.wantVolume {
 				if len(spec.Volumes) != 1 {
-					t.Fatalf("Volumes = %v, want one /pause bind mount", spec.Volumes)
+					t.Fatalf("Volumes = %v, want one kukepause bind mount", spec.Volumes)
 				}
 				v := spec.Volumes[0]
 				if v.Kind != intmodel.VolumeKindBind ||
@@ -157,7 +157,7 @@ func TestDefaultRootContainerSpec(t *testing.T) {
 
 // TestBuildRootContainerSpec_PauseBindMount verifies the default root container
 // produced by DefaultRootContainerSpec flows the kukepause binary through to the
-// OCI spec as a read-only /pause bind mount and execs it as PID 1 (issue #931).
+// OCI spec as a read-only kukepause bind mount and execs it as PID 1 (issue #931).
 func TestBuildRootContainerSpec_PauseBindMount(t *testing.T) {
 	const kukepauseHostPath = "/opt/kukeon/bin/kukepause"
 	in := ctr.DefaultRootContainerSpec(
@@ -172,10 +172,10 @@ func TestBuildRootContainerSpec_PauseBindMount(t *testing.T) {
 		}
 		found = true
 		if m.Type != "bind" || m.Source != kukepauseHostPath {
-			t.Errorf("/pause mount = %+v, want bind from %q", m, kukepauseHostPath)
+			t.Errorf("kukepause mount = %+v, want bind from %q", m, kukepauseHostPath)
 		}
 		if !slices.Contains(m.Options, "ro") {
-			t.Errorf("/pause mount options = %v, want read-only (ro)", m.Options)
+			t.Errorf("kukepause mount options = %v, want read-only (ro)", m.Options)
 		}
 	}
 	if !found {
@@ -598,7 +598,7 @@ func TestBuildRootContainerSpec_Resources(t *testing.T) {
 // minimal SpecOpts shape after the parity fix.
 func TestBuildRootContainerSpec_DefaultsUnaffected(t *testing.T) {
 	// Empty kukepause host path so this guard stays focused on the minimal
-	// SpecOpts shape: the /pause bind mount is exercised separately in
+	// SpecOpts shape: the kukepause bind mount is exercised separately in
 	// TestDefaultRootContainerSpec / TestBuildRootContainerSpec_PauseBindMount.
 	spec := applyRootBuiltSpec(t, ctr.DefaultRootContainerSpec(
 		"containerd-root",


### PR DESCRIPTION
## Summary
- Relocates the in-container root (pause) bind-mount target from the top-level `/pause` to the kukeon-namespaced `/.kukeon/bin/kukepause` (issue #979).
- Single functional edit: the `RootContainerPauseBinaryTarget` constant in `internal/ctr/container_utils.go`. Both the OCI bind-mount `Target` and the root container's `Command` derive from it, so they move together; tests assert against the constant (not the literal), so they follow automatically.
- Remaining diff is doc-comment hygiene updating stale `/pause` references in `cmd/kuke/init/init.go`, `cmd/kukepause/main.go`, `internal/controller/runner/kukepause.go`, `internal/controller/runner/provision.go`, `internal/ctr/container_utils.go`, and `internal/ctr/container_utils_test.go` (comments only). The bind *source* basename (`RootContainerPauseBinaryName="kukepause"`, staged at `<RunPath>/bin/kukepause`) is decoupled and unchanged, per the issue's scope analysis.

## Recovery note
Recovered from a prior session that crashed after implementing the change but before committing (left uncommitted on `main`, branch unpushed). The operator confirmed no other agent was live before recovery. The diff matches the issue's stated scope exactly (6 files, +21/-19).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (root-module unit suite incl. `internal/ctr`, `internal/controller/runner`, all `cmd/*`, `cmd/kukepause`, plus the `kukebuild` module) — green with a short `TMPDIR`. The default long `/tmp/claude-*` path otherwise trips an unrelated `SUN_PATH > 107` limit in `attachable_test.go` (a known host-env constraint, not a regression from this change).
- [x] Tree-wide sweep for bare `/pause` literals outside `kukepause` paths — none remain.
- [ ] `make e2e` — not run: the e2e suite needs the docker-built local kukeond image + containerd harness, unavailable in this dev session. The e2e cases that exercise cell create/start/attach are the runtime path that confirms the nested mount; deferred to the reviewer's clean host.
- [ ] `make dev-init` smoke parity + nested-mount runtime checks (AC: default-root cell starts with kukepause as PID 1; nested `/.kukeon/bin/kukepause` target auto-created on stock busybox and on a `ReadOnlyRootFilesystem` root container) — not run: `make dev-init` is a destructive smoke that resets the live `kukeond` cell, and this session's tool-output observability was degraded; running it blind risked leaving the host daemon indeterminate. runc auto-creating the bind destination's parent dirs is the one path the unit tests don't cover and should be confirmed on a clean host.

Closes #979