### PR TITLE
fix(ctr): re-materialize OutOfSync Config-lineage cells daemon-side on StartCell

### DIFF
--- a/cmd/kuke/restart/cell/cell.go
+++ b/cmd/kuke/restart/cell/cell.go
@@ -17,54 +17,43 @@
 package cell
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
-	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
 )
 
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
 // NewCellCmd builds the `kuke restart cell <name>` leaf. The verb is dual mode:
-// a Ready Synced cell is stop+start with the same spec; a Ready OutOfSync cell
-// is stop + spec re-materialised from its lineage Config + start (implicit
-// reconcile); a Stopped cell is equivalent to `kuke start cell <name>`; an
-// error/partial-state cell is refused with a `kuke delete cell` pointer.
+// a Ready cell is stop+start; a Stopped cell is equivalent to
+// `kuke start cell <name>`; an error/partial-state cell is refused with a
+// `kuke delete cell` pointer.
 //
-// The reconcile branch composes at CLI level over GetConfig + GetBlueprint +
-// ApplyDocuments rather than introducing a new daemon-side RPC — keeps this
-// change scoped to one CLI verb and avoids a wire-format addition. The daemon's
-// ApplyDocuments only bounces containers when image/command/args change (see
-// internal/controller/runner/update_cell.go:containerSpecChanged) — pure
-// env-var or metadata-only divergence is patched in place. To preserve the
-// "restart" verb's contract ("all running containers bounce"), the CLI follows
-// the ApplyDocuments call with an explicit StopCell + StartCell whenever the
-// reconcile did not itself bounce everything (root-container recreate or
-// from-Stopped rematerialize are the only paths that already bounce all
-// containers — see reconcileBouncedAll). The AC's user-facing contract holds
-// either way (per the issue's open-question note).
+// For a Config-lineage cell whose live spec has diverged from the daemon-stored
+// Config (Status.OutOfSync = true), the start step automatically re-materialises
+// from the Config so the restart is also a reconcile. That logic lives in the
+// daemon's controller.StartCell (internal/controller/start_cell.go) — restart
+// is just stop+start on top, and `kuke stop cell` + `kuke start cell` produces
+// the same end state as `kuke restart cell`. Issue #983.
 func NewCellCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cell [name]",
 		Aliases: []string{"ce"},
 		Short:   "Restart a cell (bounces the process; on OutOfSync also reconciles from Config)",
-		Long: "Restart a cell. By default bounces the cell's containers " +
-			"(stop + start with the same spec). When the cell carries a " +
-			"`kukeon.io/config=<name>` lineage label and the daemon has " +
-			"marked it OutOfSync, the start step uses the freshly " +
-			"materialised spec from the Config so the restart is also a " +
-			"reconcile. Severs any active attach session as a side effect " +
-			"of the stop step.",
+		Long: "Restart a cell. Bounces the cell's containers (stop + start). " +
+			"When the cell carries a `kukeon.io/config=<name>` lineage label " +
+			"and the daemon has marked it OutOfSync, the start step uses the " +
+			"freshly materialised spec from the Config so the restart is also " +
+			"a reconcile — equivalent to `kuke stop cell` + `kuke start cell`. " +
+			"Severs any active attach session as a side effect of the stop step.",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -131,9 +120,9 @@ func runRestartCell(cmd *cobra.Command, args []string) error {
 
 	switch pre.Cell.Status.State {
 	case v1beta1.CellStateReady:
-		return restartReady(cmd, client, doc, pre)
+		return restartInPlace(cmd, client, doc)
 	case v1beta1.CellStateStopped:
-		return restartStopped(cmd, client, doc, pre)
+		return restartStopped(cmd, client, doc)
 	case v1beta1.CellStatePending, v1beta1.CellStateFailed, v1beta1.CellStateUnknown:
 		// Same delete-then-rerun pointer as `kuke run` on a degraded cell
 		// (cmd/kuke/run/run.go:505-516). Restart does not reconcile a
@@ -146,130 +135,11 @@ func runRestartCell(cmd *cobra.Command, args []string) error {
 	return fmt.Errorf("cell %q exists in unrecognized state %d", name, pre.Cell.Status.State)
 }
 
-// restartReady handles the Ready cell path: vanilla stop+start for Synced
-// cells, or a Config-driven reconcile (stop + re-materialise + start) driven
-// by the daemon for OutOfSync cells. OutOfSyncError (divergence undecidable
-// — referenced Blueprint missing) and the "lineage Config deleted" reason
-// cannot drive a reconcile, so they fall through to vanilla restart with a
-// one-line stderr notice. Active attach sessions are severed by the daemon's
-// stop step in both branches.
-func restartReady(
-	cmd *cobra.Command, client kukeonv1.Client,
-	doc v1beta1.CellDoc, pre kukeonv1.GetCellResult,
-) error {
-	if pre.Cell.Status.OutOfSyncError != "" {
-		cmd.PrintErrf(
-			"notice: cell %q OutOfSync detection failed (%s); bouncing without reconcile\n",
-			doc.Metadata.Name, pre.Cell.Status.OutOfSyncError,
-		)
-		return restartInPlace(cmd, client, doc)
-	}
-	if !pre.Cell.Status.OutOfSync {
-		return restartInPlace(cmd, client, doc)
-	}
-
-	configName := strings.TrimSpace(pre.Cell.Metadata.Labels[cellconfig.LabelConfig])
-	if configName == "" {
-		// OutOfSync was set on a cell without a Config lineage label —
-		// nothing to reconcile against. Fall through to vanilla restart.
-		cmd.PrintErrf(
-			"notice: cell %q is OutOfSync but carries no %s label; bouncing without reconcile\n",
-			doc.Metadata.Name, cellconfig.LabelConfig,
-		)
-		return restartInPlace(cmd, client, doc)
-	}
-
-	cellDoc, err := materialiseFromConfig(cmd.Context(), client, doc, configName)
-	if err != nil {
-		// "lineage Config deleted" lands here (ErrConfigNotFound) and so
-		// does a missing Blueprint. Either way no reconcile is possible.
-		// Surface the cause and fall through to a vanilla restart so the
-		// cell's runtime is still bounced as the operator asked.
-		cmd.PrintErrf(
-			"notice: cell %q is OutOfSync but reconcile materialisation failed (%v); bouncing without reconcile\n",
-			doc.Metadata.Name, err,
-		)
-		return restartInPlace(cmd, client, doc)
-	}
-
-	rawYAML, marshalErr := yaml.Marshal(&cellDoc)
-	if marshalErr != nil {
-		return fmt.Errorf("marshal materialised cell: %w", marshalErr)
-	}
-	result, applyErr := client.ApplyDocuments(cmd.Context(), rawYAML)
-	if applyErr != nil {
-		return applyErr
-	}
-	if failErr := reportApplyFailures(result); failErr != nil {
-		return failErr
-	}
-	// Honor the restart contract: the daemon's reconcile only bounces
-	// containers when image/command/args change (update_cell.go
-	// containerSpecChanged), so pure env-var or metadata-only divergence
-	// leaves running containers untouched. Add an explicit StopCell +
-	// StartCell unless the reconcile already bounced every container (full
-	// root-container recreate or from-Stopped rematerialize), so the user's
-	// `kuke restart` invariant — running containers always bounce — holds
-	// across every divergence class. The double-bounce in the rare
-	// reconcile-already-bounced-everything case is acceptable: bouncing twice
-	// is still a restart; under-bouncing silently breaks the contract.
-	if !reconcileBouncedAll(result) {
-		if _, stopErr := client.StopCell(cmd.Context(), doc); stopErr != nil {
-			return stopErr
-		}
-		if _, startErr := client.StartCell(cmd.Context(), doc); startErr != nil {
-			return startErr
-		}
-	}
-	cmd.Printf("Restarted cell %q from stack %q (reconciled from config %q)\n",
-		doc.Metadata.Name, doc.Spec.StackID, configName)
-	return nil
-}
-
-// reconcileBouncedAll reports whether the daemon-side ApplyDocuments already
-// bounced every running container in the cell. The signals are intentionally
-// narrow: only full-cell paths qualify. A non-root container's image bump in
-// internal/controller/runner/update_cell.go does stop+delete+create+start on
-// that one container, but leaves the root and other containers running — that
-// is NOT "bounced all". The conservative default (anything not on this list)
-// triggers the follow-up StopCell + StartCell in restartReady so the restart
-// contract is preserved.
-func reconcileBouncedAll(result kukeonv1.ApplyDocumentsResult) bool {
-	for _, r := range result.Resources {
-		if r.Kind != string(v1beta1.KindCell) {
-			continue
-		}
-		// Action "created" cannot fire in the restart path (the cell already
-		// exists or we would have refused at the cell-not-found gate) but is
-		// listed for defensive parity — a fresh create starts every container.
-		if r.Action == "created" {
-			return true
-		}
-		for _, change := range r.Changes {
-			// "root container recreated" comes from reconcile.go's
-			// RecreateCell branch (diff.RootContainerChanged). RecreateCell
-			// tears down and rebuilds the entire cell, so every container is
-			// freshly started.
-			//
-			// "runtime stopped: containers re-materialized" comes from
-			// reconcile.go's rematerializeChanges, fired when the apply runs
-			// against a Stopped cell with no spec diff — StartCell brings
-			// every container up. This branch cannot fire in the restart
-			// path either (we route Stopped through restartStopped), but
-			// is listed for the same defensive parity.
-			if change == "root container recreated" ||
-				change == "runtime stopped: containers re-materialized" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// restartInPlace bounces the cell with the same stored spec: stop then start.
-// The CellDoc only needs name + scope — the daemon resolves both verbs from
-// the stored cell metadata, so spec.containers and friends do not need to be
-// re-supplied (preserving "all spec fields" is automatic).
+// restartInPlace bounces the cell: stop then start. The CellDoc only needs name
+// + scope — the daemon resolves both verbs from the stored cell metadata. When
+// the cell is Config-lineage and Status.OutOfSync = true, the daemon's
+// controller.StartCell re-materialises from the Config on the start step so
+// the running cell ends up with the freshly-materialised spec.
 func restartInPlace(cmd *cobra.Command, client kukeonv1.Client, doc v1beta1.CellDoc) error {
 	if _, err := client.StopCell(cmd.Context(), doc); err != nil {
 		return err
@@ -292,14 +162,9 @@ func restartInPlace(cmd *cobra.Command, client kukeonv1.Client, doc v1beta1.Cell
 }
 
 // restartStopped is the already-stopped path: equivalent to
-// `kuke start cell <name>`. AC pins this even for OutOfSync stopped cells —
-// reconcile happens only on the Ready+OutOfSync path; an operator wanting to
-// reconcile from Stopped starts the cell first and then re-runs
-// `kuke restart cell <name>` to trip the Ready+OutOfSync reconcile.
-func restartStopped(
-	cmd *cobra.Command, client kukeonv1.Client,
-	doc v1beta1.CellDoc, _ kukeonv1.GetCellResult,
-) error {
+// `kuke start cell <name>`. The daemon's controller.StartCell handles the
+// OutOfSync reapply uniformly with restartInPlace's start step.
+func restartStopped(cmd *cobra.Command, client kukeonv1.Client, doc v1beta1.CellDoc) error {
 	startRes, err := client.StartCell(cmd.Context(), doc)
 	if err != nil {
 		return err
@@ -314,118 +179,6 @@ func restartStopped(
 		stackName = doc.Spec.StackID
 	}
 	cmd.Printf("Started cell %q from stack %q\n", cellName, stackName)
-	return nil
-}
-
-// materialiseFromConfig re-runs the CellConfig materialisation pipeline
-// against the cell's lineage Config: GetConfig + GetBlueprint +
-// cellconfig.Materialize. The cell's stored realm/space/stack name the
-// lookup's deepest scope, but the `kukeon.io/config` lineage label records
-// only the Config name — a `kuke run <config>` against a realm-scoped
-// Config materializes a cell at realm=default / space=default /
-// stack=default (resolveCellLocation fills the session defaults), so the
-// lookup must probe progressively shallower scopes (full → space-only →
-// realm-only) and use the first hit. Mirrors the daemon's reconciler
-// (internal/controller/reconcile_outofsync.go lookupLineageConfig).
-func materialiseFromConfig(
-	ctx context.Context, client kukeonv1.Client,
-	cellDoc v1beta1.CellDoc, configName string,
-) (v1beta1.CellDoc, error) {
-	cfgRes, err := lookupLineageConfigCLI(ctx, client, cellDoc, configName)
-	if err != nil {
-		return v1beta1.CellDoc{}, err
-	}
-	if !cfgRes.MetadataExists {
-		return v1beta1.CellDoc{}, fmt.Errorf(
-			"%w (config %q in realm=%q space=%q stack=%q)",
-			errdefs.ErrConfigNotFound, configName,
-			cellDoc.Spec.RealmID, cellDoc.Spec.SpaceID, cellDoc.Spec.StackID,
-		)
-	}
-
-	bpRef := cfgRes.Config.Spec.Blueprint
-	bpRes, err := client.GetBlueprint(ctx, v1beta1.CellBlueprintDoc{
-		Metadata: v1beta1.CellBlueprintMetadata{
-			Name:  bpRef.Name,
-			Realm: bpRef.Realm,
-			Space: bpRef.Space,
-			Stack: bpRef.Stack,
-		},
-	})
-	if err != nil {
-		return v1beta1.CellDoc{}, err
-	}
-	if !bpRes.MetadataExists {
-		return v1beta1.CellDoc{}, fmt.Errorf(
-			"%w (blueprint %q referenced by config %q)",
-			errdefs.ErrBlueprintNotFound, bpRef.Name, configName,
-		)
-	}
-
-	return cellconfig.Materialize(cfgRes.Config, bpRes.Blueprint)
-}
-
-// lookupLineageConfigCLI probes for the cell's lineage Config from the
-// cell's full scope (realm/space/stack) down to space-only and then
-// realm-only, returning the first hit. Mirrors the daemon-side
-// scope-narrowing rule (internal/controller/reconcile_outofsync.go
-// lookupLineageConfig) so the CLI and reconciler resolve the same Config
-// regardless of which scope it was originally bound at.
-//
-// Probes are deduplicated when the cell's space or stack is already
-// empty. A real RPC error (anything other than a MetadataExists==false
-// hit) short-circuits the walk so the operator sees the underlying
-// failure instead of a misleading "not found" at realm scope.
-func lookupLineageConfigCLI(
-	ctx context.Context, client kukeonv1.Client,
-	cellDoc v1beta1.CellDoc, configName string,
-) (kukeonv1.GetConfigResult, error) {
-	realm := cellDoc.Spec.RealmID
-	space, stack := cellDoc.Spec.SpaceID, cellDoc.Spec.StackID
-
-	type probe struct{ space, stack string }
-	probes := []probe{{space, stack}}
-	if stack != "" {
-		probes = append(probes, probe{space, ""})
-	}
-	if space != "" {
-		probes = append(probes, probe{"", ""})
-	}
-
-	var lastMiss kukeonv1.GetConfigResult
-	for _, p := range probes {
-		res, err := client.GetConfig(ctx, v1beta1.CellConfigDoc{
-			APIVersion: v1beta1.APIVersionV1Beta1,
-			Kind:       v1beta1.KindCellConfig,
-			Metadata: v1beta1.CellConfigMetadata{
-				Name:  configName,
-				Realm: realm,
-				Space: p.space,
-				Stack: p.stack,
-			},
-		})
-		if err != nil {
-			return kukeonv1.GetConfigResult{}, err
-		}
-		if res.MetadataExists {
-			return res, nil
-		}
-		lastMiss = res
-	}
-	return lastMiss, nil
-}
-
-// reportApplyFailures inspects an ApplyDocumentsResult for "failed" rows and
-// returns a non-nil error so the CLI exits non-zero on a daemon-side
-// reconcile failure. Matches `kuke apply`'s behaviour
-// (cmd/kuke/apply/apply.go:468-495 printApplyResult).
-func reportApplyFailures(result kukeonv1.ApplyDocumentsResult) error {
-	for _, r := range result.Resources {
-		if r.Action == "failed" {
-			return fmt.Errorf("%w: reconcile failed for %s %q: %s",
-				errdefs.ErrConfig, r.Kind, r.Name, r.Error)
-		}
-	}
 	return nil
 }
 

--- a/cmd/kuke/restart/cell/cell_test.go
+++ b/cmd/kuke/restart/cell/cell_test.go
@@ -28,12 +28,10 @@ import (
 	"github.com/eminwux/kukeon/cmd/config"
 	cell "github.com/eminwux/kukeon/cmd/kuke/restart/cell"
 	"github.com/eminwux/kukeon/cmd/types"
-	"github.com/eminwux/kukeon/internal/cellconfig"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v3"
 )
 
 func TestRestartCell(t *testing.T) {
@@ -46,13 +44,17 @@ func TestRestartCell(t *testing.T) {
 		fake       *fakeClient
 		wantErr    string
 		wantOutput string
-		wantStderr string
 		// validate is run after a successful command for additional
 		// post-conditions the assertion knobs above don't cover.
 		validate func(t *testing.T, f *fakeClient)
 	}{
 		{
-			name: "synced ready cell: stop then start with same spec",
+			// Per #983, restart on a Ready cell is unconditionally stop+start.
+			// The daemon's controller.StartCell handles the OutOfSync reapply
+			// daemon-side, so the CLI no longer branches on OutOfSync — the
+			// same stop+start sequence works whether the cell is Synced or
+			// OutOfSync.
+			name: "ready cell: stop then start",
 			args: []string{"c1"},
 			setup: func() {
 				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
@@ -89,12 +91,22 @@ func TestRestartCell(t *testing.T) {
 						f.stopCalls, f.startCalls)
 				}
 				if f.applyCalls != 0 {
-					t.Fatalf("Synced restart must not call ApplyDocuments, got %d calls", f.applyCalls)
+					t.Fatalf("restart must not call ApplyDocuments, got %d calls", f.applyCalls)
+				}
+				if f.getConfigCnt != 0 || f.getBpCalls != 0 {
+					t.Fatalf(
+						"restart must not call GetConfig or GetBlueprint (daemon-side reapply owns it now), "+
+							"got getConfig=%d getBlueprint=%d",
+						f.getConfigCnt, f.getBpCalls,
+					)
 				}
 			},
 		},
 		{
-			name: "outofsync ready cell: reconciles via ApplyDocuments then explicitly bounces",
+			// Sanity check: the OutOfSync flag is transparent to the CLI now —
+			// stop+start runs unconditionally, and the daemon's StartCell is
+			// what re-materialises from the lineage Config.
+			name: "outofsync ready cell: stop then start (daemon-side reapply)",
 			args: []string{"prod"},
 			setup: func() {
 				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
@@ -106,11 +118,8 @@ func TestRestartCell(t *testing.T) {
 					return kukeonv1.GetCellResult{
 						MetadataExists: true,
 						Cell: v1beta1.CellDoc{
-							Metadata: v1beta1.CellMetadata{
-								Name:   "prod",
-								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
-							},
-							Spec: v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
+							Metadata: v1beta1.CellMetadata{Name: "prod"},
+							Spec:     v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
 							Status: v1beta1.CellStatus{
 								State:           v1beta1.CellStateReady,
 								OutOfSync:       true,
@@ -119,299 +128,24 @@ func TestRestartCell(t *testing.T) {
 						},
 					}, nil
 				},
-				getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-					if doc.Metadata.Name != "prod" || doc.Metadata.Realm != "r1" {
-						t.Errorf("GetConfig saw unexpected lookup: name=%q realm=%q",
-							doc.Metadata.Name, doc.Metadata.Realm)
-					}
-					return kukeonv1.GetConfigResult{
-						MetadataExists: true,
-						Config: v1beta1.CellConfigDoc{
-							APIVersion: v1beta1.APIVersionV1Beta1,
-							Kind:       v1beta1.KindCellConfig,
-							Metadata: v1beta1.CellConfigMetadata{
-								Name:  "prod",
-								Realm: "r1",
-								Space: "s1",
-								Stack: "st1",
-							},
-							Spec: v1beta1.CellConfigSpec{
-								Blueprint: v1beta1.CellConfigBlueprintRef{
-									Name:  "web",
-									Realm: "r1",
-									Space: "s1",
-									Stack: "st1",
-								},
-							},
-						},
-					}, nil
+				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{}, nil
 				},
-				getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-					if doc.Metadata.Name != "web" {
-						t.Errorf("GetBlueprint saw unexpected name=%q", doc.Metadata.Name)
-					}
-					return kukeonv1.GetBlueprintResult{
-						MetadataExists: true,
-						Blueprint: v1beta1.CellBlueprintDoc{
-							APIVersion: v1beta1.APIVersionV1Beta1,
-							Kind:       v1beta1.KindCellBlueprint,
-							Metadata: v1beta1.CellBlueprintMetadata{
-								Name:  "web",
-								Realm: "r1",
-								Space: "s1",
-								Stack: "st1",
-							},
-							Spec: v1beta1.CellBlueprintSpec{
-								Cell: v1beta1.BlueprintCellSpec{
-									Containers: []v1beta1.BlueprintContainer{
-										{ID: "main", Image: "nginx:latest"},
-									},
-								},
-							},
-						},
-					}, nil
-				},
-				applyDocsFn: func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
-					var sent v1beta1.CellDoc
-					if err := yaml.Unmarshal(rawYAML, &sent); err != nil {
-						t.Errorf("ApplyDocuments received un-unmarshalable YAML: %v", err)
-					}
-					if sent.Metadata.Name != "prod" {
-						t.Errorf("ApplyDocuments cell name=%q want %q", sent.Metadata.Name, "prod")
-					}
-					return kukeonv1.ApplyDocumentsResult{
-						Resources: []kukeonv1.ApplyResourceResult{
-							{Kind: "Cell", Name: "prod", Action: "updated"},
-						},
-					}, nil
-				},
-				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
 				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-					return kukeonv1.StartCellResult{Cell: doc}, nil
+					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
 				},
 			},
-			wantOutput: `Restarted cell "prod" from stack "st1" (reconciled from config "prod")`,
+			wantOutput: `Restarted cell "prod" from stack "st1"`,
 			validate: func(t *testing.T, f *fakeClient) {
-				if f.applyCalls != 1 {
-					t.Fatalf("want exactly 1 ApplyDocuments call, got %d", f.applyCalls)
-				}
-				// Apply alone does not guarantee a bounce — the daemon's
-				// reconcile only stops+starts containers on image/cmd/args
-				// changes. The CLI explicitly StopCell+StartCells afterwards
-				// to honor the "restart" verb's contract.
 				if f.stopCalls != 1 || f.startCalls != 1 {
-					t.Fatalf("OutOfSync restart must follow Apply with StopCell+StartCell, got stop=%d start=%d",
+					t.Fatalf("want exactly 1 StopCell + 1 StartCell, got stop=%d start=%d",
 						f.stopCalls, f.startCalls)
 				}
-			},
-		},
-		{
-			// Reviewer-requested coverage of the reconcile-no-bounce gap: a
-			// pure env-var divergence routes through UpdateCell's metadata
-			// path (containerSpecChanged returns false for non-image/cmd/args
-			// fields), so the daemon does NOT bounce containers. The CLI's
-			// follow-up StopCell+StartCell is what makes "kuke restart" on
-			// this divergence class actually bounce the running containers.
-			name: "outofsync env-var-only divergence: reconciles then explicitly bounces",
-			args: []string{"prod"},
-			setup: func() {
-				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
-				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
-				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
-			},
-			fake: &fakeClient{
-				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					return kukeonv1.GetCellResult{
-						MetadataExists: true,
-						Cell: v1beta1.CellDoc{
-							Metadata: v1beta1.CellMetadata{
-								Name:   "prod",
-								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
-							},
-							Spec: v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status: v1beta1.CellStatus{
-								State:           v1beta1.CellStateReady,
-								OutOfSync:       true,
-								OutOfSyncReason: "env vars differ",
-							},
-						},
-					}, nil
-				},
-				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-					return kukeonv1.GetConfigResult{
-						MetadataExists: true,
-						Config: v1beta1.CellConfigDoc{
-							APIVersion: v1beta1.APIVersionV1Beta1,
-							Kind:       v1beta1.KindCellConfig,
-							Metadata: v1beta1.CellConfigMetadata{
-								Name:  "prod",
-								Realm: "r1",
-								Space: "s1",
-								Stack: "st1",
-							},
-							Spec: v1beta1.CellConfigSpec{
-								Blueprint: v1beta1.CellConfigBlueprintRef{
-									Name:  "web",
-									Realm: "r1",
-									Space: "s1",
-									Stack: "st1",
-								},
-							},
-						},
-					}, nil
-				},
-				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-					return kukeonv1.GetBlueprintResult{
-						MetadataExists: true,
-						Blueprint: v1beta1.CellBlueprintDoc{
-							APIVersion: v1beta1.APIVersionV1Beta1,
-							Kind:       v1beta1.KindCellBlueprint,
-							Metadata: v1beta1.CellBlueprintMetadata{
-								Name:  "web",
-								Realm: "r1",
-								Space: "s1",
-								Stack: "st1",
-							},
-							Spec: v1beta1.CellBlueprintSpec{
-								Cell: v1beta1.BlueprintCellSpec{
-									Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}},
-								},
-							},
-						},
-					}, nil
-				},
-				applyDocsFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
-					// Mirrors what reconcile.go emits when only env vars
-					// changed: the container is "updated" with field list,
-					// but no "image|command|args" entries are present, so
-					// UpdateCell patched in place without bouncing.
-					return kukeonv1.ApplyDocumentsResult{
-						Resources: []kukeonv1.ApplyResourceResult{
-							{
-								Kind:    "Cell",
-								Name:    "prod",
-								Action:  "updated",
-								Changes: []string{`container "main" updated: env`},
-							},
-						},
-					}, nil
-				},
-				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-					return kukeonv1.StartCellResult{Cell: doc}, nil
-				},
-			},
-			wantOutput: `Restarted cell "prod" from stack "st1" (reconciled from config "prod")`,
-			validate: func(t *testing.T, f *fakeClient) {
-				if f.applyCalls != 1 {
-					t.Fatalf("want exactly 1 ApplyDocuments call, got %d", f.applyCalls)
-				}
-				if f.stopCalls != 1 || f.startCalls != 1 {
+				if f.applyCalls != 0 || f.getConfigCnt != 0 || f.getBpCalls != 0 {
 					t.Fatalf(
-						"env-var-only OutOfSync restart MUST follow Apply with StopCell+StartCell, got stop=%d start=%d",
-						f.stopCalls,
-						f.startCalls,
-					)
-				}
-			},
-		},
-		{
-			// The other half of the env-var-only test's contract: when the
-			// daemon's reconcile already bounced every container (full root
-			// recreate), the CLI must NOT add a redundant StopCell+StartCell.
-			// reconcileBouncedAll's signal "root container recreated" gates
-			// this branch.
-			name: "outofsync ready cell with root-container recreate: skips redundant bounce",
-			args: []string{"prod"},
-			setup: func() {
-				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
-				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
-				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
-			},
-			fake: &fakeClient{
-				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					return kukeonv1.GetCellResult{
-						MetadataExists: true,
-						Cell: v1beta1.CellDoc{
-							Metadata: v1beta1.CellMetadata{
-								Name:   "prod",
-								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
-							},
-							Spec: v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status: v1beta1.CellStatus{
-								State:           v1beta1.CellStateReady,
-								OutOfSync:       true,
-								OutOfSyncReason: "root image bumped",
-							},
-						},
-					}, nil
-				},
-				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-					return kukeonv1.GetConfigResult{
-						MetadataExists: true,
-						Config: v1beta1.CellConfigDoc{
-							APIVersion: v1beta1.APIVersionV1Beta1,
-							Kind:       v1beta1.KindCellConfig,
-							Metadata: v1beta1.CellConfigMetadata{
-								Name:  "prod",
-								Realm: "r1",
-								Space: "s1",
-								Stack: "st1",
-							},
-							Spec: v1beta1.CellConfigSpec{
-								Blueprint: v1beta1.CellConfigBlueprintRef{
-									Name:  "web",
-									Realm: "r1",
-									Space: "s1",
-									Stack: "st1",
-								},
-							},
-						},
-					}, nil
-				},
-				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-					return kukeonv1.GetBlueprintResult{
-						MetadataExists: true,
-						Blueprint: v1beta1.CellBlueprintDoc{
-							APIVersion: v1beta1.APIVersionV1Beta1,
-							Kind:       v1beta1.KindCellBlueprint,
-							Metadata: v1beta1.CellBlueprintMetadata{
-								Name:  "web",
-								Realm: "r1",
-								Space: "s1",
-								Stack: "st1",
-							},
-							Spec: v1beta1.CellBlueprintSpec{
-								Cell: v1beta1.BlueprintCellSpec{
-									Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}},
-								},
-							},
-						},
-					}, nil
-				},
-				applyDocsFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
-					return kukeonv1.ApplyDocumentsResult{
-						Resources: []kukeonv1.ApplyResourceResult{
-							{
-								Kind:    "Cell",
-								Name:    "prod",
-								Action:  "updated",
-								Changes: []string{"root container recreated"},
-							},
-						},
-					}, nil
-				},
-			},
-			wantOutput: `Restarted cell "prod" from stack "st1" (reconciled from config "prod")`,
-			validate: func(t *testing.T, f *fakeClient) {
-				if f.applyCalls != 1 {
-					t.Fatalf("want exactly 1 ApplyDocuments call, got %d", f.applyCalls)
-				}
-				if f.stopCalls != 0 || f.startCalls != 0 {
-					t.Fatalf(
-						"root-container recreate already bounced everything; CLI must NOT add a redundant StopCell+StartCell, got stop=%d start=%d",
-						f.stopCalls,
-						f.startCalls,
+						"OutOfSync reapply lives daemon-side; restart CLI must not call ApplyDocuments/GetConfig/GetBlueprint, "+
+							"got apply=%d getConfig=%d getBlueprint=%d",
+						f.applyCalls, f.getConfigCnt, f.getBpCalls,
 					)
 				}
 			},
@@ -510,178 +244,6 @@ func TestRestartCell(t *testing.T) {
 			wantErr: "realm name is required",
 		},
 		{
-			name: "outofsync cell with no lineage label: vanilla restart with notice",
-			args: []string{"orphan"},
-			setup: func() {
-				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
-				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
-				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
-			},
-			fake: &fakeClient{
-				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					return kukeonv1.GetCellResult{
-						MetadataExists: true,
-						Cell: v1beta1.CellDoc{
-							Metadata: v1beta1.CellMetadata{Name: "orphan", Labels: map[string]string{}},
-							Spec:     v1beta1.CellSpec{ID: "orphan", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status:   v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: true},
-						},
-					}, nil
-				},
-				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-					return kukeonv1.StartCellResult{Cell: doc}, nil
-				},
-			},
-			wantOutput: `Restarted cell "orphan" from stack "st1"`,
-			wantStderr: `notice: cell "orphan" is OutOfSync but carries no kukeon.io/config label`,
-		},
-		{
-			name: "outofsync ready cell with OutOfSyncError: vanilla restart with notice",
-			args: []string{"degraded"},
-			setup: func() {
-				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
-				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
-				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
-			},
-			fake: &fakeClient{
-				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					return kukeonv1.GetCellResult{
-						MetadataExists: true,
-						Cell: v1beta1.CellDoc{
-							Metadata: v1beta1.CellMetadata{
-								Name:   "degraded",
-								Labels: map[string]string{cellconfig.LabelConfig: "degraded"},
-							},
-							Spec: v1beta1.CellSpec{ID: "degraded", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status: v1beta1.CellStatus{
-								State:          v1beta1.CellStateReady,
-								OutOfSyncError: "referenced blueprint missing",
-							},
-						},
-					}, nil
-				},
-				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-					return kukeonv1.StartCellResult{Cell: doc}, nil
-				},
-			},
-			wantOutput: `Restarted cell "degraded" from stack "st1"`,
-			wantStderr: `OutOfSync detection failed (referenced blueprint missing)`,
-		},
-		{
-			name: "outofsync cell whose lineage Config was deleted: falls back to vanilla restart",
-			args: []string{"orphan"},
-			setup: func() {
-				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
-				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
-				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
-			},
-			fake: &fakeClient{
-				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					return kukeonv1.GetCellResult{
-						MetadataExists: true,
-						Cell: v1beta1.CellDoc{
-							Metadata: v1beta1.CellMetadata{
-								Name:   "orphan",
-								Labels: map[string]string{cellconfig.LabelConfig: "deleted-cfg"},
-							},
-							Spec: v1beta1.CellSpec{ID: "orphan", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status: v1beta1.CellStatus{
-								State:           v1beta1.CellStateReady,
-								OutOfSync:       true,
-								OutOfSyncReason: "lineage Config deleted",
-							},
-						},
-					}, nil
-				},
-				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-					return kukeonv1.GetConfigResult{MetadataExists: false}, nil
-				},
-				stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-					return kukeonv1.StartCellResult{Cell: doc}, nil
-				},
-			},
-			wantOutput: `Restarted cell "orphan" from stack "st1"`,
-			wantStderr: `reconcile materialisation failed`,
-		},
-		{
-			name: "ApplyDocuments returns a failed row: surfaces as error",
-			args: []string{"prod"},
-			setup: func() {
-				viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "r1")
-				viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "s1")
-				viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "st1")
-			},
-			fake: &fakeClient{
-				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					return kukeonv1.GetCellResult{
-						MetadataExists: true,
-						Cell: v1beta1.CellDoc{
-							Metadata: v1beta1.CellMetadata{
-								Name:   "prod",
-								Labels: map[string]string{cellconfig.LabelConfig: "prod"},
-							},
-							Spec:   v1beta1.CellSpec{ID: "prod", RealmID: "r1", SpaceID: "s1", StackID: "st1"},
-							Status: v1beta1.CellStatus{State: v1beta1.CellStateReady, OutOfSync: true},
-						},
-					}, nil
-				},
-				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-					return kukeonv1.GetConfigResult{
-						MetadataExists: true,
-						Config: v1beta1.CellConfigDoc{
-							APIVersion: v1beta1.APIVersionV1Beta1,
-							Kind:       v1beta1.KindCellConfig,
-							Metadata: v1beta1.CellConfigMetadata{
-								Name:  "prod",
-								Realm: "r1",
-								Space: "s1",
-								Stack: "st1",
-							},
-							Spec: v1beta1.CellConfigSpec{
-								Blueprint: v1beta1.CellConfigBlueprintRef{
-									Name:  "web",
-									Realm: "r1",
-									Space: "s1",
-									Stack: "st1",
-								},
-							},
-						},
-					}, nil
-				},
-				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-					return kukeonv1.GetBlueprintResult{
-						MetadataExists: true,
-						Blueprint: v1beta1.CellBlueprintDoc{
-							APIVersion: v1beta1.APIVersionV1Beta1,
-							Kind:       v1beta1.KindCellBlueprint,
-							Metadata: v1beta1.CellBlueprintMetadata{
-								Name:  "web",
-								Realm: "r1",
-								Space: "s1",
-								Stack: "st1",
-							},
-							Spec: v1beta1.CellBlueprintSpec{
-								Cell: v1beta1.BlueprintCellSpec{
-									Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}},
-								},
-							},
-						},
-					}, nil
-				},
-				applyDocsFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
-					return kukeonv1.ApplyDocumentsResult{
-						Resources: []kukeonv1.ApplyResourceResult{
-							{Kind: "Cell", Name: "prod", Action: "failed", Error: "containerd update rejected"},
-						},
-					}, nil
-				},
-			},
-			wantErr: "reconcile failed for Cell \"prod\"",
-		},
-		{
 			name: "stop step errors: surfaces and skips start",
 			args: []string{"c1"},
 			setup: func() {
@@ -742,9 +304,6 @@ func TestRestartCell(t *testing.T) {
 			if tt.wantOutput != "" && !strings.Contains(outBuf.String(), tt.wantOutput) {
 				t.Errorf("stdout missing %q\nGot:\n%s", tt.wantOutput, outBuf.String())
 			}
-			if tt.wantStderr != "" && !strings.Contains(errBuf.String(), tt.wantStderr) {
-				t.Errorf("stderr missing %q\nGot:\n%s", tt.wantStderr, errBuf.String())
-			}
 			if tt.validate != nil {
 				tt.validate(t, tt.fake)
 			}
@@ -768,155 +327,19 @@ func TestRestartCell_CmdSurface(t *testing.T) {
 	if cmd.ValidArgsFunction == nil {
 		t.Error("expected ValidArgsFunction to be set for cell-name completion")
 	}
-	// The help text must surface the dual-mode behaviour (vanilla restart +
-	// implicit reconcile) so operators see the contract without reading code.
+	// The help text must still describe the OutOfSync reconcile contract so
+	// operators know `kuke restart` doubles as a reconcile on OutOfSync cells
+	// (now via the daemon-side reapply in controller.StartCell — #983).
 	if !strings.Contains(cmd.Long, "reconcile") || !strings.Contains(cmd.Long, "OutOfSync") {
-		t.Errorf("expected Long help to describe dual mode (reconcile + OutOfSync), got: %s", cmd.Long)
-	}
-}
-
-// TestRestartCell_RealmScopedConfigFoundForStackPlacedCell pins the issue
-// #921 fix on the CLI side: an OutOfSync cell at realm/space/stack whose
-// `kukeon.io/config` lineage label names a Config bound only at realm
-// scope must still drive a reconcile via ApplyDocuments. Without the
-// scope-narrowing walk, materialiseFromConfig calls GetConfig once at the
-// cell's full scope, sees MetadataExists==false, and falls through to a
-// vanilla restart with the "reconcile materialisation failed (config not
-// found …)" notice — never reconciling from the realm-scoped Config.
-func TestRestartCell_RealmScopedConfigFoundForStackPlacedCell(t *testing.T) {
-	t.Cleanup(viper.Reset)
-	viper.Reset()
-	viper.Set(config.KUKE_RESTART_CELL_REALM.ViperKey, "default")
-	viper.Set(config.KUKE_RESTART_CELL_SPACE.ViperKey, "default")
-	viper.Set(config.KUKE_RESTART_CELL_STACK.ViperKey, "default")
-
-	type probeScope struct{ name, realm, space, stack string }
-	var probes []probeScope
-	fake := &fakeClient{
-		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				MetadataExists: true,
-				Cell: v1beta1.CellDoc{
-					Metadata: v1beta1.CellMetadata{
-						Name:   "kukeon-dev-root-0",
-						Labels: map[string]string{cellconfig.LabelConfig: "kukeon-dev-root-0"},
-					},
-					Spec: v1beta1.CellSpec{
-						ID:      "kukeon-dev-root-0",
-						RealmID: "default",
-						SpaceID: "default",
-						StackID: "default",
-					},
-					Status: v1beta1.CellStatus{
-						State:           v1beta1.CellStateReady,
-						OutOfSync:       true,
-						OutOfSyncReason: "lineage Config deleted",
-					},
-				},
-			}, nil
-		},
-		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
-			probes = append(probes, probeScope{
-				name:  doc.Metadata.Name,
-				realm: doc.Metadata.Realm,
-				space: doc.Metadata.Space,
-				stack: doc.Metadata.Stack,
-			})
-			if doc.Metadata.Space == "" && doc.Metadata.Stack == "" {
-				return kukeonv1.GetConfigResult{
-					MetadataExists: true,
-					Config: v1beta1.CellConfigDoc{
-						APIVersion: v1beta1.APIVersionV1Beta1,
-						Kind:       v1beta1.KindCellConfig,
-						Metadata: v1beta1.CellConfigMetadata{
-							Name:  "kukeon-dev-root-0",
-							Realm: "default",
-						},
-						Spec: v1beta1.CellConfigSpec{
-							Blueprint: v1beta1.CellConfigBlueprintRef{Name: "dev", Realm: "default"},
-						},
-					},
-				}, nil
-			}
-			return kukeonv1.GetConfigResult{MetadataExists: false}, nil
-		},
-		getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
-			return kukeonv1.GetBlueprintResult{
-				MetadataExists: true,
-				Blueprint: v1beta1.CellBlueprintDoc{
-					APIVersion: v1beta1.APIVersionV1Beta1,
-					Kind:       v1beta1.KindCellBlueprint,
-					Metadata:   v1beta1.CellBlueprintMetadata{Name: "dev", Realm: "default"},
-					Spec: v1beta1.CellBlueprintSpec{
-						Cell: v1beta1.BlueprintCellSpec{
-							Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "nginx:latest"}},
-						},
-					},
-				},
-			}, nil
-		},
-		applyDocsFn: func(_ []byte) (kukeonv1.ApplyDocumentsResult, error) {
-			return kukeonv1.ApplyDocumentsResult{
-				Resources: []kukeonv1.ApplyResourceResult{
-					{Kind: "Cell", Name: "kukeon-dev-root-0", Action: "updated"},
-				},
-			}, nil
-		},
-		stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) { return kukeonv1.StopCellResult{}, nil },
-		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-			return kukeonv1.StartCellResult{Cell: doc}, nil
-		},
-	}
-
-	cmd := cell.NewCellCmd()
-	outBuf := &bytes.Buffer{}
-	errBuf := &bytes.Buffer{}
-	cmd.SetOut(outBuf)
-	cmd.SetErr(errBuf)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-	ctx = context.WithValue(ctx, cell.MockControllerKey{}, kukeonv1.Client(fake))
-	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"kukeon-dev-root-0"})
-
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	wantProbes := []probeScope{
-		{name: "kukeon-dev-root-0", realm: "default", space: "default", stack: "default"},
-		{name: "kukeon-dev-root-0", realm: "default", space: "default", stack: ""},
-		{name: "kukeon-dev-root-0", realm: "default", space: "", stack: ""},
-	}
-	if len(probes) != len(wantProbes) {
-		t.Fatalf("GetConfig probe count: got %d want %d (probes=%+v)", len(probes), len(wantProbes), probes)
-	}
-	for i, p := range probes {
-		if p != wantProbes[i] {
-			t.Errorf("probe[%d] = %+v, want %+v", i, p, wantProbes[i])
-		}
-	}
-	if fake.applyCalls != 1 {
-		t.Errorf(
-			"ApplyDocuments calls: got %d, want 1 (reconcile must run once the realm-scoped Config is found)",
-			fake.applyCalls,
-		)
-	}
-	if strings.Contains(errBuf.String(), "reconcile materialisation failed") {
-		t.Errorf(
-			"stderr surfaced 'reconcile materialisation failed' despite the realm-scoped Config being reachable: %s",
-			errBuf.String(),
-		)
-	}
-	if !strings.Contains(outBuf.String(), `reconciled from config "kukeon-dev-root-0"`) {
-		t.Errorf("stdout did not confirm reconcile path: %s", outBuf.String())
+		t.Errorf("expected Long help to describe reconcile-on-OutOfSync, got: %s", cmd.Long)
 	}
 }
 
 // fakeClient is a per-test stub kukeonv1.Client. Each RPC is dispatched
 // through an optional Fn field; nil means "fail the test if called". Call
-// counts let tests assert "Synced restart did not invoke ApplyDocuments" and
-// the equivalent path-specific assertions.
+// counts let tests assert "restart did not invoke ApplyDocuments / GetConfig
+// / GetBlueprint" — the OutOfSync reapply lives daemon-side now (#983), so
+// none of those RPCs should fire from the restart CLI.
 type fakeClient struct {
 	kukeonv1.FakeClient
 

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -1003,10 +1003,10 @@ func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags runFlag
 // stored at default/default/default would otherwise be invisible to a bare
 // `kuke run <config>` lookup that used ExplicitScope (empty space/stack
 // unless --space/--stack are set). Mirrors the daemon-side reconciler
-// (internal/controller/reconcile_outofsync.go lookupLineageConfig) and
-// the CLI-side restart path (cmd/kuke/restart/cell/cell.go
-// lookupLineageConfigCLI) so all three resolve the same Config regardless
-// of which scope it was originally bound at.
+// (internal/controller/reconcile_outofsync.go lookupLineageConfig), which
+// is also re-used by controller.StartCell's OutOfSync reapply (#983), so
+// all paths resolve the same Config regardless of which scope it was
+// originally bound at.
 func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) (loadResult, error) {
 	realm := kukshared.PickLookupRealm(cmd, &config.KUKE_RUN_REALM)
 	space := pickLocation("", &config.KUKE_RUN_SPACE)

--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -411,22 +411,26 @@ sudo kuke purge cell <name> --realm <r> --space <s> --stack <st>
 
 **Intent.** Pick up a Config-lineage cell whose stored spec has diverged from the daemon-stored CellConfig (someone edited the Config — or the underlying Blueprint — after the cell was last materialised) and bring it back in sync, bouncing the running containers as a side effect. This is the operator pair to the daemon's reconciler-driven `SYNC` column on `kuke get cell`.
 
-**Sequence.**
+**Sequence.** Any of these produce the same end state — the reapply lives daemon-side in `controller.StartCell`, so every CLI start path inherits it:
 
 ```bash
 sudo kuke get cell <name> --realm <r> --space <s> --stack <st> -o wide   # SYNC=OutOfSync?
-sudo kuke restart cell <name> --realm <r> --space <s> --stack <st>       # re-materialise + bounce
+sudo kuke restart cell <name> --realm <r> --space <s> --stack <st>       # stop + start (reapply on start)
+# or, equivalently:
+sudo kuke stop cell <name> --realm <r> --space <s> --stack <st>
+sudo kuke start cell <name> --realm <r> --space <s> --stack <st>         # reapply on start
 sudo kuke get cell <name> --realm <r> --space <s> --stack <st> -o wide   # SYNC=InSync
 ```
 
 **Invariants.**
 
-- Reconcile fires only on the `Ready` + OutOfSync + `kukeon.io/config=<name>` label combination. A `Stopped` cell is started in place (no reconcile); a `Ready` + InSync cell is a pure bounce (`StopCell` + `StartCell` with the on-disk spec); a `Ready` + OutOfSync cell with no lineage label is a pure bounce with a `notice:` to stderr — there is nothing to reconcile against.
-- On the reconcile branch, the CLI composes `GetConfig` + `GetBlueprint` + `ApplyDocuments` (at CLI level — no new daemon RPC), then issues an explicit `StopCell` + `StartCell` unless `ApplyDocuments` already bounced every container (root-container recreate). The daemon's reconcile path only bounces containers on image / command / args divergence, so the explicit stop + start preserves the `kuke restart` contract that every container in the cell bounces — even on env-only or metadata-only divergence classes. The double-bounce in the rare full-recreate case is acceptable; under-bouncing would silently break the contract.
+- Reconcile fires on any `StartCell` against an OutOfSync + `kukeon.io/config=<name>` cell — `kuke restart cell`'s start step, `kuke start cell` directly, and `kuke run <config>` on an existing Stopped cell all trigger the reapply. `kuke stop cell` + `kuke start cell` therefore produces the same end state as `kuke restart cell` (#983).
+- A Synced cell is a pure bounce: stop + start with the on-disk spec. A cell with no lineage label, with `Status.OutOfSyncError` set (divergence undecidable — referenced Blueprint missing), or whose lineage Config has been deleted starts with the on-disk spec — the runtime still bounces as the operator asked.
+- On the reapply branch the daemon re-materialises from `GetConfig` + `GetBlueprint`, computes the diff, and rebuilds via `RecreateCell` (tears down stale containerd records, recreates fresh containers with the materialised spec, ends in Ready). The CLI restart path is just `StopCell` + `StartCell` — no `GetConfig` / `GetBlueprint` / `ApplyDocuments` RPCs from the client.
 - A degraded cell (`Pending` / `Failed` / `Unknown`) refuses with a `kuke delete cell <name>` pointer; restart does not reconcile a degraded cell in place.
-- Lineage Config resolution probes the cell's full scope (realm/space/stack) → space-only → realm-only and uses the first hit — mirrors the daemon's reconciler so the CLI and reconciler resolve the same Config regardless of which scope it was bound at. A missing Config or Blueprint surfaces a `notice:` and falls through to a vanilla in-place bounce — the runtime still bounces as the operator asked.
-- Active attach sessions on the target cell are severed by the stop step in both branches.
-- Running clones of the source Config (`kuke run <config> --clone` or `--reuse` siblings, identified by `metadata.annotations.kukeon.io/source-config: <source>`) are unaffected by this command — each clone is its own cell and needs its own `kuke restart cell <clone-name>` to reconcile. The reconcile is per-cell, not per-Config.
+- Lineage Config resolution probes the cell's full scope (realm/space/stack) → space-only → realm-only and uses the first hit — mirrors the daemon's reconciler so the resolution matches across all three call sites (reconciler tick, start-time reapply, `kuke run <config>` on existing Stopped). If RecreateCell itself fails, the start falls back to the on-disk spec so the runtime still bounces.
+- Active attach sessions on the target cell are severed by the stop step in the restart flow (and by the explicit `kuke stop cell` in the stop+start flow).
+- Running clones of the source Config (`kuke run <config> --clone` or `--reuse` siblings, identified by `metadata.annotations.kukeon.io/source-config: <source>`) are unaffected by this command — each clone is its own cell and needs its own `kuke restart cell <clone-name>` (or stop+start) to reconcile. The reconcile is per-cell, not per-Config.
 
 ### Refresh runtime status
 

--- a/docs/site/cli/kuke-restart.md
+++ b/docs/site/cli/kuke-restart.md
@@ -6,7 +6,7 @@ kuke restart cell <name> [--realm <name>] [--space <name>] [--stack <name>]
 
 Restart Kukeon resources (cell).
 
-Restart a Kukeon resource: bounces the running process by default and, on a Config-lineage cell whose live spec has diverged from the daemon-stored Config (OutOfSync), uses the freshly-materialised spec on start so the restart is also a reconcile.
+Restart a Kukeon resource: bounces the running process. When the cell is a Config-lineage cell that the daemon has marked OutOfSync, the start step automatically re-materialises the spec from the Config (daemon-side, in `controller.StartCell` — issue #983), so the restart is also a reconcile.
 
 ## kuke restart cell
 
@@ -16,7 +16,7 @@ kuke restart cell <name> [--realm <name>] [--space <name>] [--stack <name>]
 
 Restart a cell (bounces the process; on OutOfSync also reconciles from Config).
 
-Restart a cell. By default bounces the cell's containers (stop + start with the same spec). When the cell carries a `kukeon.io/config=<name>` lineage label and the daemon has marked it OutOfSync, the start step uses the freshly materialised spec from the Config so the restart is also a reconcile. Severs any active attach session as a side effect of the stop step.
+Restart a cell. Bounces the cell's containers (stop + start). When the cell carries a `kukeon.io/config=<name>` lineage label and the daemon has marked it OutOfSync, the daemon's `StartCell` reapplies the freshly materialised spec from the lineage Config before bringing the cell back up — equivalent to `kuke stop cell <name>` + `kuke start cell <name>`. Severs any active attach session as a side effect of the stop step.
 
 ### Flags
 
@@ -33,12 +33,11 @@ Plus all [global flags](kuke.md). Realm/space/stack are required (no default fal
 
 `kuke restart cell` dispatches on the cell's `Status.State` at the moment the command runs:
 
-| State                       | Behavior                                                                                                                                                                      |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Ready` + in-sync           | Pure bounce: `StopCell` then `StartCell` with the spec already on disk. No reconcile.                                                                                         |
-| `Ready` + OutOfSync (lineage) | Re-materialise the spec from the cell's lineage Config (`GetConfig` + `GetBlueprint` + `Materialize`), `ApplyDocuments` to write the new spec, then `StopCell` + `StartCell` unless `ApplyDocuments` already bounced every container (root-container recreate). |
-| `Stopped`                   | Equivalent to `kuke start cell <name>`. Honours OutOfSync only on the `Ready`-path; an OutOfSync `Stopped` cell starts with its on-disk spec, then a follow-up `kuke restart cell` from `Ready` reconciles. |
-| `Pending` / `Failed` / `Unknown` | Refused with `cell "<name>" exists in <state> state; delete it with \`kuke delete cell <name>\` before restarting`. Exit code non-zero. Restart does not reconcile a degraded cell in place. |
+| State                            | Behavior                                                                                                                                                                                                                                                  |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Ready`                          | Pure bounce: `StopCell` then `StartCell`. The daemon's `StartCell` re-materialises and rebuilds the cell from the lineage Config when `Status.OutOfSync` is set on a Config-lineage cell — otherwise it just starts the on-disk spec.                       |
+| `Stopped`                        | Equivalent to `kuke start cell <name>`. The daemon-side OutOfSync reapply also fires here, so `kuke stop cell` + `kuke start cell` produces the same end state as `kuke restart cell` on the same cell (#983).                                            |
+| `Pending` / `Failed` / `Unknown` | Refused with `cell "<name>" exists in <state> state; delete it with \`kuke delete cell <name>\` before restarting`. Exit code non-zero. Restart does not reconcile a degraded cell in place.                                                                  |
 
 ### OutOfSync detection
 
@@ -46,11 +45,11 @@ The OutOfSync flag on a cell is set by the daemon's reconciler loop when a cell 
 
 ### Side effects
 
-- Active attach sessions are severed by the stop step in both the pure-bounce and reconcile branches.
-- The reconcile branch issues an explicit `StopCell` + `StartCell` after `ApplyDocuments` unless `ApplyDocuments` already bounced every container (root-container recreate). The daemon's reconcile path only bounces containers on image / command / args divergence (env-only or metadata-only changes patch in place), so the explicit stop + start preserves the `kuke restart` contract that every running container in the cell bounces — across every divergence class. The double-bounce in the rare full-recreate case is acceptable; under-bouncing would silently break the contract.
-- The CLI composes `GetConfig` + `GetBlueprint` + `ApplyDocuments` against the cell's lineage Config at CLI level rather than issuing a new daemon RPC. Lineage Config resolution probes progressively shallower scopes (full → space-only → realm-only) to mirror the daemon's reconciler and find the Config regardless of which scope it was originally bound at.
-- A reconcile that fails to materialise (lineage Config deleted, referenced Blueprint missing, OutOfSync detection itself failed) prints a one-line `notice:` to stderr and falls through to a vanilla in-place restart — the runtime still bounces as the operator asked.
-- Running clones of the source Config are unaffected by a `kuke restart cell` on one cell; each clone needs its own `kuke restart cell <clone-name>` to pick up the new spec.
+- Active attach sessions are severed by the stop step.
+- The reapply lives in the daemon's `controller.StartCell` (`internal/controller/start_cell.go`), so every code path that issues `StartCell` — `kuke restart cell`'s start step, `kuke start cell` directly, and `kuke run <config>` on an existing Stopped cell — inherits the reconcile-on-start behaviour. The CLI restart command itself no longer composes `GetConfig` + `GetBlueprint` + `ApplyDocuments`; those calls happen daemon-side.
+- On the reapply branch the daemon resolves the lineage Config (probing the cell's full scope → space-only → realm-only, mirroring the reconciler), materialises the cell from Config + Blueprint, and rebuilds via `RecreateCell` — tearing down the stale containerd records (post-#867 stop leaves them in place with the old spec-hash) and starting fresh containers with the new spec.
+- A reapply that fails to materialise (lineage Config deleted, referenced Blueprint missing, OutOfSync detection itself errored, `RecreateCell` failure) falls back to starting the cell with the on-disk spec — the runtime still bounces as the operator asked. Diagnostics are logged daemon-side (`kukeond` slog stream) rather than printed to the CLI.
+- Running clones of the source Config are unaffected by a `kuke restart cell` on one cell; each clone needs its own `kuke restart cell <clone-name>` (or stop+start) to pick up the new spec.
 
 ### Example session
 
@@ -60,19 +59,27 @@ NAME  STATE  SYNC        AGE  ...
 foo   Ready  OutOfSync   12m  ...
 
 $ kuke restart cell foo --realm default --space default --stack default
-Restarted cell "foo" from stack "default" (reconciled from config "foo")
+Restarted cell "foo" from stack "default"
 
 $ kuke get cell foo --realm default --space default --stack default -o wide
 NAME  STATE  SYNC    AGE  ...
 foo   Ready  InSync  3s   ...
 ```
 
-For a cell with no lineage label or with `SYNC=InSync`, the same invocation reports `Restarted cell "<name>" from stack "<stack>"` (no reconcile suffix) and the `SYNC` column is unchanged.
+The same end state is reachable via the explicit stop+start pair:
+
+```
+$ kuke stop cell foo --realm default --space default --stack default
+Stopped cell "foo" from stack "default"
+
+$ kuke start cell foo --realm default --space default --stack default
+Started cell "foo" from stack "default"
+```
 
 ## Related
 
-- [kuke start / stop / kill](kuke-lifecycle.md) — primitive lifecycle verbs `kuke restart cell` composes.
+- [kuke start / stop / kill](kuke-lifecycle.md) — primitive lifecycle verbs `kuke restart cell` composes; the OutOfSync reapply also fires from `kuke start cell` directly.
 - [kuke get](kuke-get.md) — read the `SYNC` column on `kuke get cell -o wide` to spot OutOfSync ahead of `restart`.
-- [kuke run](kuke-run.md) — divergent-spec warn-and-attach on the `<config>` and `-b --name` paths (`--require-synced` for the opt-in refusal) cites `kuke restart cell <name>` as the reconcile pointer.
-- [`kind: CellConfig`](../manifests/config.md) — the lineage source the OutOfSync reconcile re-materialises from.
-- [`kind: CellBlueprint`](../manifests/blueprint.md) — referenced by the Config, looked up via `GetBlueprint` on the reconcile path.
+- [kuke run](kuke-run.md) — divergent-spec warn-and-attach on the `<config>` and `-b --name` paths (`--require-synced` for the opt-in refusal) cites `kuke restart cell <name>` as the reconcile pointer; the `<config>` path on an existing Stopped cell also triggers the daemon-side reapply.
+- [`kind: CellConfig`](../manifests/config.md) — the lineage source the OutOfSync reapply re-materialises from.
+- [`kind: CellBlueprint`](../manifests/blueprint.md) — referenced by the Config, looked up via `GetBlueprint` on the reapply path.

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"fmt"
 
+	"github.com/eminwux/kukeon/internal/controller/apply"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
@@ -29,6 +30,13 @@ type StartCellResult struct {
 }
 
 // StartCell starts all containers in a cell and updates the cell metadata state.
+//
+// For a Config-lineage cell whose persisted Status.OutOfSync is true, StartCell
+// first re-materialises the cell's spec from its lineage Config + Blueprint and
+// rebuilds the containerd records, so `kuke stop cell` followed by `kuke start
+// cell` produces the same end state as `kuke restart cell` on an OutOfSync
+// cell — issue #983. The reapply is daemon-side so every client that issues
+// StartCell (CLI, future API consumers) gets the reconcile-on-start behaviour.
 func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 	var res StartCellResult
 
@@ -74,6 +82,19 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 		)
 	}
 
+	// Reapply the lineage Config when the persisted OutOfSync flag is set, so
+	// the start runs against the freshly materialised spec — see #983. If the
+	// reapply already brought the cell back to Ready (RecreateCell path), the
+	// caller is done; otherwise fall through to the regular runner.StartCell.
+	if reapplied, started, ok := b.reapplyOutOfSyncFromConfig(internalCell); ok {
+		internalCell = reapplied
+		if started {
+			res.Cell = internalCell
+			res.Started = true
+			return res, nil
+		}
+	}
+
 	// Start all containers in the cell
 	internalCell, err = b.runner.StartCell(internalCell)
 	if err != nil {
@@ -88,4 +109,104 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 	res.Cell = internalCell
 	res.Started = true
 	return res, nil
+}
+
+// reapplyOutOfSyncFromConfig re-materialises the cell from its lineage Config
+// and rebuilds the on-disk + containerd state when the persisted OutOfSync
+// flag is set on a Config-lineage cell. Returns:
+//
+//   - (cell, true,  true)  : reapply rebuilt the cell; runner.RecreateCell
+//     already brought it to Ready, the caller should
+//     skip its runner.StartCell pass.
+//   - (cell, false, true)  : reapply ran, but the materialised spec matched
+//     the on-disk spec or only metadata diverged — the
+//     caller continues with the regular start pass.
+//   - (zero, false, false) : reapply did not run (no lineage label, OutOfSync
+//     flag clear, OutOfSyncError set, lineage Config /
+//     Blueprint missing, materialise error). Caller
+//     continues with the on-disk spec — the runtime is
+//     still bounced as the operator asked, matching the
+//     CLI restart fall-through (cmd/kuke/restart/cell).
+func (b *Exec) reapplyOutOfSyncFromConfig(cell intmodel.Cell) (intmodel.Cell, bool, bool) {
+	if !cell.Status.OutOfSync || cell.Status.OutOfSyncError != "" {
+		return intmodel.Cell{}, false, false
+	}
+
+	configName, hasLineage := configLineage(cell)
+	if !hasLineage {
+		return intmodel.Cell{}, false, false
+	}
+
+	cfg, found, err := lookupLineageConfig(b.runner, cell, configName)
+	if err != nil {
+		b.logger.WarnContext(b.ctx,
+			"OutOfSync reapply lookup failed; starting cell with on-disk spec",
+			"cell", cell.Metadata.Name,
+			"config", configName,
+			"error", err,
+		)
+		return intmodel.Cell{}, false, false
+	}
+	if !found {
+		// Lineage Config deleted — nothing to materialise from.
+		b.logger.InfoContext(b.ctx,
+			"OutOfSync reapply skipped: lineage config deleted",
+			"cell", cell.Metadata.Name,
+			"config", configName,
+		)
+		return intmodel.Cell{}, false, false
+	}
+
+	desired, err := materializeCellFromConfig(b.runner, cfg)
+	if err != nil {
+		b.logger.WarnContext(b.ctx,
+			"OutOfSync reapply materialise failed; starting cell with on-disk spec",
+			"cell", cell.Metadata.Name,
+			"config", configName,
+			"error", err,
+		)
+		return intmodel.Cell{}, false, false
+	}
+
+	// The materialised cell carries the Config's view of identity; the live
+	// cell's persisted identity is authoritative for the on-disk lookup
+	// (RecreateCell's GetCell + UpdateCellMetadata both key on it).
+	desired.Metadata.Name = cell.Metadata.Name
+	desired.Spec.ID = cell.Spec.ID
+	desired.Spec.RealmName = cell.Spec.RealmName
+	desired.Spec.SpaceName = cell.Spec.SpaceName
+	desired.Spec.StackName = cell.Spec.StackName
+	desired.Spec.RuntimeEnv = cell.Spec.RuntimeEnv
+
+	diff := apply.DiffCell(desired, cell)
+	if !diff.HasChanges {
+		// Reconciler stamped OutOfSync but the live spec already matches
+		// the materialised one — nothing to rebuild. The next reconciler
+		// tick clears the stale OutOfSync flag.
+		return intmodel.Cell{}, false, false
+	}
+
+	// Rebuild the cell from the materialised spec. RecreateCell tears down the
+	// containerd records (post-#867 stop leaves them in place with the old
+	// spec-hash, which would otherwise make startCellLocked refuse the new
+	// spec), recreates fresh containers, and ends by calling startCellLocked
+	// so the cell lands in Ready. Mirrors the restart CLI's
+	// ApplyDocuments+StopCell+StartCell sequence for a Stopped cell.
+	recreated, err := b.runner.RecreateCell(desired)
+	if err != nil {
+		b.logger.WarnContext(b.ctx,
+			"OutOfSync reapply RecreateCell failed; falling back to on-disk spec",
+			"cell", cell.Metadata.Name,
+			"config", configName,
+			"error", err,
+		)
+		return intmodel.Cell{}, false, false
+	}
+
+	b.logger.InfoContext(b.ctx,
+		"reapplied OutOfSync cell from lineage config on start",
+		"cell", cell.Metadata.Name,
+		"config", configName,
+	)
+	return recreated, true, true
 }

--- a/internal/controller/start_cell_reapply_test.go
+++ b/internal/controller/start_cell_reapply_test.go
@@ -1,0 +1,364 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the daemon-side OutOfSync reapply on StartCell — issue #983.
+// `kuke stop cell` + `kuke start cell` on a Config-lineage OutOfSync cell must
+// produce the same end state as `kuke restart cell` on the same cell. The
+// reapply lives in controller.StartCell so every client that issues StartCell
+// (CLI `kuke start cell`, `kuke run` on existing-Stopped, future API
+// consumers) inherits the reconcile-on-start behaviour.
+
+package controller_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// reapplySampleCellConfig builds a Config whose Blueprint reference and
+// materialised spec match the reapplySampleBlueprint below. Realm matches the
+// test cell's realm so lookupLineageConfig finds it on the first probe.
+func reapplySampleCellConfig(realm, space, stack string) intmodel.CellConfig {
+	doc := `apiVersion: v1beta1
+kind: CellConfig
+metadata:
+  name: prod
+  realm: ` + realm + `
+  space: ` + space + `
+  stack: ` + stack + `
+spec:
+  blueprint:
+    name: web
+    realm: ` + realm + `
+`
+	return intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{
+			Name:  "prod",
+			Realm: realm,
+			Space: space,
+			Stack: stack,
+		},
+		Document: []byte(doc),
+	}
+}
+
+func reapplySampleBlueprint(realm string) intmodel.CellBlueprint {
+	doc := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: ` + realm + `
+spec:
+  cell:
+    containers:
+      - id: main
+        image: nginx:2.0
+`
+	return intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: realm,
+		},
+		Document: []byte(doc),
+	}
+}
+
+// reapplyLineageCell builds a stopped, OutOfSync, Config-lineage cell with the
+// given realm/space/stack scope. The cell's on-disk container image is
+// "nginx:1.0" — diverged from the Config's "nginx:2.0" — so the reapply path
+// has something to do.
+func reapplyLineageCell(realm, space, stack string) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name:   "prod",
+			Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+		},
+		Spec: intmodel.CellSpec{
+			ID:        "prod",
+			RealmName: realm,
+			SpaceName: space,
+			StackName: stack,
+			Containers: []intmodel.ContainerSpec{
+				{ID: "main", Image: "nginx:1.0"},
+			},
+		},
+		Status: intmodel.CellStatus{
+			State:           intmodel.CellStateStopped,
+			OutOfSync:       true,
+			OutOfSyncReason: "spec differs at containers[main].image",
+		},
+	}
+}
+
+func TestStartCell_OutOfSyncReapply_RecreatesFromConfig(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+
+	var recreateCalled bool
+	var startCellCalled bool
+	f := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return live, nil
+		},
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		GetConfigFn: func(c intmodel.CellConfig) (intmodel.CellConfig, error) {
+			if c.Metadata.Name != "prod" || c.Metadata.Realm != "test-realm" {
+				t.Errorf("GetConfig lookup = %+v, want name=prod realm=test-realm", c.Metadata)
+			}
+			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
+		},
+		GetBlueprintFn: func(b intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			if b.Metadata.Name != "web" {
+				t.Errorf("GetBlueprint name = %q, want web", b.Metadata.Name)
+			}
+			return reapplySampleBlueprint("test-realm"), nil
+		},
+		RecreateCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			// The desired cell must carry the materialised spec — image bumped
+			// to nginx:2.0 from the Blueprint — and the live cell's identity.
+			if cell.Metadata.Name != "prod" {
+				t.Errorf("RecreateCell name = %q, want prod", cell.Metadata.Name)
+			}
+			if cell.Spec.RealmName != "test-realm" {
+				t.Errorf("RecreateCell realm = %q, want test-realm", cell.Spec.RealmName)
+			}
+			gotImage := ""
+			for _, c := range cell.Spec.Containers {
+				if c.ID == "main" {
+					gotImage = c.Image
+					break
+				}
+			}
+			if gotImage != "nginx:2.0" {
+				t.Errorf("RecreateCell main image = %q, want nginx:2.0 (materialised from Blueprint)", gotImage)
+			}
+			cell.Status.State = intmodel.CellStateReady
+			return cell, nil
+		},
+		StartCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			startCellCalled = true
+			return intmodel.Cell{}, errors.New("runner.StartCell must not be called after RecreateCell already brought the cell to Ready")
+		},
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	res, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack"))
+	if err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if !recreateCalled {
+		t.Error("RecreateCell was not called; reapply path was skipped")
+	}
+	if startCellCalled {
+		t.Error("runner.StartCell was called after RecreateCell — double-start")
+	}
+	if !res.Started {
+		t.Error("Started = false, want true after successful reapply")
+	}
+	if res.Cell.Status.State != intmodel.CellStateReady {
+		t.Errorf("cell state = %v, want Ready after RecreateCell", res.Cell.Status.State)
+	}
+}
+
+func TestStartCell_OutOfSyncReapply_NoLineageLabelSkipsReapply(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+	delete(live.Metadata.Labels, cellconfig.LabelConfig) // strip the lineage
+
+	var recreateCalled bool
+	var startCellCalled bool
+	f := &fakeRunner{
+		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return intmodel.Cell{}, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCellCalled = true
+			c.Status.State = intmodel.CellStateReady
+			return c, nil
+		},
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	if _, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack")); err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if recreateCalled {
+		t.Error("RecreateCell was called for a cell with no lineage label; reapply must skip")
+	}
+	if !startCellCalled {
+		t.Error("runner.StartCell was not called; the normal start path was skipped")
+	}
+}
+
+func TestStartCell_OutOfSyncReapply_OutOfSyncErrorSkipsReapply(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+	live.Status.OutOfSyncError = "referenced blueprint missing"
+	live.Status.OutOfSync = false // detector blocked on the error
+
+	var recreateCalled, getConfigCalled bool
+	f := &fakeRunner{
+		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			getConfigCalled = true
+			return intmodel.CellConfig{}, nil
+		},
+		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return intmodel.Cell{}, nil
+		},
+		StartCellFn:          func(c intmodel.Cell) (intmodel.Cell, error) { c.Status.State = intmodel.CellStateReady; return c, nil },
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	if _, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack")); err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if getConfigCalled {
+		t.Error("GetConfig was called despite OutOfSyncError being set; reapply must skip")
+	}
+	if recreateCalled {
+		t.Error("RecreateCell was called despite OutOfSyncError being set")
+	}
+}
+
+func TestStartCell_OutOfSyncReapply_OutOfSyncFalseSkipsReapply(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+	live.Status.OutOfSync = false
+	live.Status.OutOfSyncReason = ""
+
+	var getConfigCalled, recreateCalled bool
+	f := &fakeRunner{
+		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			getConfigCalled = true
+			return intmodel.CellConfig{}, nil
+		},
+		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return intmodel.Cell{}, nil
+		},
+		StartCellFn:          func(c intmodel.Cell) (intmodel.Cell, error) { c.Status.State = intmodel.CellStateReady; return c, nil },
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	if _, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack")); err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if getConfigCalled {
+		t.Error("GetConfig was called for a Synced cell; reapply must skip")
+	}
+	if recreateCalled {
+		t.Error("RecreateCell was called for a Synced cell")
+	}
+}
+
+// TestStartCell_OutOfSyncReapply_LineageConfigDeletedFallsThrough covers the
+// "lineage Config deleted" case — the reconciler keeps the OutOfSync flag set
+// with reason "lineage Config deleted", but the lookup returns MetadataExists
+// = false. Reapply must fall through to a vanilla runner.StartCell so the
+// runtime is still bounced as the operator asked.
+func TestStartCell_OutOfSyncReapply_LineageConfigDeletedFallsThrough(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+
+	var recreateCalled, startCellCalled bool
+	f := &fakeRunner{
+		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			// The scope-narrowing walk probes (space, stack), (space, ""), ("", "").
+			// All three miss on a deleted Config.
+			return intmodel.CellConfig{}, errdefs.ErrConfigNotFound
+		},
+		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return intmodel.Cell{}, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCellCalled = true
+			c.Status.State = intmodel.CellStateReady
+			return c, nil
+		},
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	if _, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack")); err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if recreateCalled {
+		t.Error("RecreateCell was called despite lineage Config being deleted")
+	}
+	if !startCellCalled {
+		t.Error("runner.StartCell was not called; cell would never start under deleted-Config fall-through")
+	}
+}
+
+// TestStartCell_OutOfSyncReapply_RecreateErrorFallsThrough covers the
+// graceful degradation: if RecreateCell fails (e.g. containerd unreachable),
+// reapply logs and falls back to the on-disk spec via runner.StartCell so the
+// operator's `kuke start cell` request is honored.
+func TestStartCell_OutOfSyncReapply_RecreateErrorFallsThrough(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+
+	var startCellCalled bool
+	f := &fakeRunner{
+		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
+		},
+		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return reapplySampleBlueprint("test-realm"), nil
+		},
+		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			return intmodel.Cell{}, errors.New("containerd unreachable")
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCellCalled = true
+			c.Status.State = intmodel.CellStateReady
+			return c, nil
+		},
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	if _, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack")); err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if !startCellCalled {
+		t.Error("runner.StartCell was not called after RecreateCell failure; cell would never start")
+	}
+}


### PR DESCRIPTION
## Summary

- Issue #983: `kuke stop cell` + `kuke start cell` on a Config-lineage OutOfSync cell no longer leaves the cell on the previous spec — `controller.StartCell` (`internal/controller/start_cell.go`) now re-materialises from the lineage Config + Blueprint and rebuilds via `RecreateCell` before the cell comes back up. Every code path that issues `StartCell` (CLI `kuke start cell`, `kuke run <config>` on existing-Stopped, future API consumers) inherits the reconcile-on-start behaviour for free.
- `kuke restart cell` collapses to plain `StopCell` + `StartCell` on `Ready`/`Stopped` paths — the OutOfSync materialise + apply branch in `cmd/kuke/restart/cell/cell.go` is gone (CLI no longer composes `GetConfig` + `GetBlueprint` + `ApplyDocuments`). Behavioural equivalence: `kuke stop cell <n>` + `kuke start cell <n>` now produces the same end state as `kuke restart cell <n>`.
- Docs updated: `docs/cli-use-cases.md` "Reconcile an OutOfSync cell to its Config" and `docs/site/cli/kuke-restart.md` describe the new daemon-side reapply and explicitly call out the stop+start equivalence. The `kuke run` lineage-lookup comment also points at the now-shared `lookupLineageConfig` daemon helper.

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go vet ./...` — clean
- [x] `GOWORK=off go test ./internal/controller/...` — new `start_cell_reapply_test.go` covers RecreatesFromConfig / no lineage / OutOfSyncError / OutOfSync=false / lineage Config deleted / RecreateCell error fall-through; existing controller / apply / runner suites green
- [x] `GOWORK=off go test ./cmd/kuke/restart/...` — restart CLI tests rewritten to match the new "stop+start, daemon handles reapply" contract; both Synced-Ready and OutOfSync-Ready cells produce the same stop+start RPC trace
- [x] `GOWORK=off go test $(go list ./... | grep -v /e2e)` — full non-e2e suite green
- [ ] Smoke: `make dev-init` (skipped — local containerd unavailable in this dev container, see CLAUDE.md preconditions; no changes touch `make dev-init`'s build path or daemon-parity tail)
- [ ] Repro from the issue body (apply CellConfig, image-bump the CellConfig, `kuke stop cell` + `kuke start cell` — confirm cell comes back on the new image and `kuke get cell -o wide` reports `SYNC=InSync`): exercises the wire path end-to-end; the unit tests above cover the same code paths against the `fakeRunner`, but the live-daemon repro depends on a working containerd which isn't available in this CI/dev environment

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)