### PR TITLE
fix(run): enrich divergent-spec error with actual+desired values

### DIFF
--- a/cmd/kuke/run/divergence_idempotency_test.go
+++ b/cmd/kuke/run/divergence_idempotency_test.go
@@ -1,0 +1,277 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// TestDivergedFields_MaterializePersistMaterializeIsIdempotent guards the
+// invariant that `kuke restart cell` writes a spec to disk that — when
+// re-materialised by the next `kuke run <config>` — compares clean against
+// the persisted version (issue #984). The flow being asserted:
+//
+//	Materialize(cfg, bp) → ApplyDocuments(persist) → GetCell → Materialize(cfg, bp)
+//	→ divergedFields(persisted.Spec, freshly-materialised.Spec) == nil
+//
+// The daemon-side ApplyDocuments + GetCell pair is simulated here via the
+// apischeme + JSON pipeline plus the mutations UpdateCell applies (parent
+// refs, ContainerdID, Space-defaults merge). A real daemon test would need a
+// containerd socket and a temp filesystem; the simulation captures the
+// normalisations divergedContainerFields is sensitive to (the Space-defaults
+// fields are deliberately excluded from that comparator, but the simulation
+// applies them anyway to verify the exclusion stays correct under realistic
+// inputs).
+//
+// If this test trips, divergedFields and the persistence pipeline have
+// drifted apart. Tighten either side per the issue's "Suggested fix" — make
+// Materialize deterministic, or grow divergedFields' exclusion set to match
+// a new normalisation introduced on the persist side.
+func TestDivergedFields_MaterializePersistMaterializeIsIdempotent(t *testing.T) {
+	cases := []struct {
+		name string
+		bp   v1beta1.CellBlueprintDoc
+		cfg  v1beta1.CellConfigDoc
+	}{
+		{
+			name: "minimal one-container",
+			bp:   minimalBlueprintForDivergence(),
+			cfg:  minimalConfigForDivergence(),
+		},
+		{
+			name: "rich container fields (env, ports, volumes, networks, git, repos, secrets)",
+			bp:   richBlueprintForDivergence(),
+			cfg:  richConfigForDivergence(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Step 1: Materialize what `kuke restart cell` would push through
+			// ApplyDocuments.
+			cell1, err := cellconfig.Materialize(tc.cfg, tc.bp)
+			if err != nil {
+				t.Fatalf("Materialize (restart side): %v", err)
+			}
+
+			// Step 2a: Mirror restart's `yaml.Marshal(&cellDoc)` + the
+			// daemon-side `yaml.Unmarshal(raw, &cellDoc)` parser step. A
+			// nil/empty slice round-trips through YAML differently than
+			// through direct in-memory copy, and the bug hypothesis cares
+			// about the disk-side normalisation specifically.
+			yamlBytes, err := yaml.Marshal(&cell1)
+			if err != nil {
+				t.Fatalf("yaml.Marshal: %v", err)
+			}
+			var parsed v1beta1.CellDoc
+			if unErr := yaml.Unmarshal(yamlBytes, &parsed); unErr != nil {
+				t.Fatalf("yaml.Unmarshal: %v", unErr)
+			}
+
+			// Step 2b: Simulate the daemon's ApplyDocuments → UpdateCell →
+			// UpdateCellMetadata write path:
+			//   external CellDoc → intmodel.Cell → daemon mutations →
+			//   JSON marshal (what UpdateCellMetadata writes to disk).
+			int1, err := apischeme.ConvertCellDocToInternal(parsed)
+			if err != nil {
+				t.Fatalf("ConvertCellDocToInternal: %v", err)
+			}
+			applyDaemonSideMutations(&int1)
+			ext1, err := apischeme.BuildCellExternalFromInternal(int1, apischeme.VersionV1Beta1)
+			if err != nil {
+				t.Fatalf("BuildCellExternalFromInternal: %v", err)
+			}
+			diskBytes, err := json.Marshal(ext1)
+			if err != nil {
+				t.Fatalf("json.Marshal (disk write): %v", err)
+			}
+
+			// Step 3: Simulate GetCell → readCellInternal → BuildExternal on
+			// the way back out to the RPC caller.
+			var diskDoc v1beta1.CellDoc
+			if unErr := json.Unmarshal(diskBytes, &diskDoc); unErr != nil {
+				t.Fatalf("json.Unmarshal (disk read): %v", unErr)
+			}
+			int2, err := apischeme.ConvertCellDocToInternal(diskDoc)
+			if err != nil {
+				t.Fatalf("ConvertCellDocToInternal (readback): %v", err)
+			}
+			persisted, err := apischeme.BuildCellExternalFromInternal(int2, apischeme.VersionV1Beta1)
+			if err != nil {
+				t.Fatalf("BuildCellExternalFromInternal (readback): %v", err)
+			}
+
+			// Step 4: Re-Materialize as the next `kuke run <config>` would.
+			cell2, err := cellconfig.Materialize(tc.cfg, tc.bp)
+			if err != nil {
+				t.Fatalf("Materialize (run side): %v", err)
+			}
+
+			// Step 5: Assert.
+			if diffs := divergedFields(persisted.Spec, cell2.Spec); len(diffs) > 0 {
+				t.Errorf(
+					"divergedFields after restart→run round-trip = %v want empty; "+
+						"the persistence pipeline normalised a field divergedFields still compares "+
+						"(see issue #984 — either tighten Materialize determinism or extend the "+
+						"divergedContainerFields exclusion list to match the new normalisation)",
+					diffs,
+				)
+			}
+		})
+	}
+}
+
+// applyDaemonSideMutations mirrors the in-place mutations UpdateCell +
+// ensureCellContainers apply to a freshly-normalised internal Cell before it
+// hits UpdateCellMetadata: per-container parent refs, ContainerdID, and the
+// Space-defaults merge. Space defaults here use a sentinel non-zero User so
+// the test exercises the divergedContainerFields exclusion rather than a
+// no-op merge.
+func applyDaemonSideMutations(cell *intmodel.Cell) {
+	for i := range cell.Spec.Containers {
+		c := &cell.Spec.Containers[i]
+		if c.RealmName == "" {
+			c.RealmName = cell.Spec.RealmName
+		}
+		if c.SpaceName == "" {
+			c.SpaceName = cell.Spec.SpaceName
+		}
+		if c.StackName == "" {
+			c.StackName = cell.Spec.StackName
+		}
+		if c.CellName == "" {
+			c.CellName = cell.Spec.ID
+			if c.CellName == "" {
+				c.CellName = cell.Metadata.Name
+			}
+		}
+		// ContainerdID is filled by ensureCellContainers when the container
+		// is created. A real daemon writes a stack-cell-id-derived value; the
+		// exact shape is irrelevant — the assertion is that divergedFields
+		// ignores it.
+		if c.ContainerdID == "" {
+			c.ContainerdID = "ctr-" + c.ID
+		}
+		// Simulate the Space-defaults merge with a sentinel non-zero User so
+		// the test fails loudly if divergedContainerFields ever starts
+		// comparing the Space-defaults envelope.
+		intmodel.ApplySpaceDefaultsToContainer(
+			intmodel.Space{
+				Spec: intmodel.SpaceSpec{
+					Defaults: &intmodel.SpaceDefaults{
+						Container: &intmodel.SpaceContainerDefaults{
+							User: "spaceuser",
+						},
+					},
+				},
+			},
+			c,
+		)
+	}
+}
+
+func minimalBlueprintForDivergence() v1beta1.CellBlueprintDoc {
+	def := "latest"
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "bp-realm"},
+		Spec: v1beta1.CellBlueprintSpec{
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "root", Root: true, Image: "registry.example.com/root:latest"},
+					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
+				},
+			},
+		},
+	}
+}
+
+func minimalConfigForDivergence() v1beta1.CellConfigDoc {
+	return v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Values:    map[string]string{"TAG": "v2"},
+		},
+	}
+}
+
+func richBlueprintForDivergence() v1beta1.CellBlueprintDoc {
+	def := "latest"
+	return v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "bp-realm"},
+		Spec: v1beta1.CellBlueprintSpec{
+			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "root", Root: true, Image: "registry.example.com/root:latest"},
+					{
+						ID:              "main",
+						Image:           "registry.example.com/web:${TAG}",
+						Attachable:      true,
+						Args:            []string{"--port", "8080"},
+						Env:             []string{"FOO=bar", "BAZ=qux"},
+						Ports:           []string{"8080/tcp"},
+						Volumes:         []v1beta1.VolumeMount{{Source: "/host/data", Target: "/data", ReadOnly: true, Mode: 0o644}},
+						Networks:        []string{"default"},
+						NetworksAliases: []string{"web"},
+						RestartPolicy:   "on-failure",
+						Repos:           []v1beta1.ContainerRepo{{Name: "src", Target: "/srv", Required: true}},
+						Secrets: []v1beta1.BlueprintSecretSlot{
+							{Name: "token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "TOKEN", Required: true},
+						},
+						Git: &v1beta1.ContainerGit{
+							Author: &v1beta1.GitIdentity{Name: "kuke", Email: "kuke@example.com"},
+						},
+						Tty: &v1beta1.ContainerTty{Prompt: "kuke> "},
+					},
+				},
+			},
+		},
+	}
+}
+
+func richConfigForDivergence() v1beta1.CellConfigDoc {
+	return v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Values:    map[string]string{"TAG": "v2"},
+			Repos: map[string]v1beta1.CellConfigRepoFill{
+				"src": {URL: "https://example.com/src.git"},
+			},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "api-token", Realm: "cfg-realm"}},
+			},
+		},
+	}
+}

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -1237,6 +1237,15 @@ func pickLocation(fromDoc string, kv *config.Var) string {
 // rewrite — including an image swap — must route through `kuke apply -f`
 // instead of silently no-opping under `kuke run -f`.
 //
+// Each entry is shaped `<path> (actual=<v>, desired=<v>)` so the reject error
+// surfaces both sides verbatim — without this, an operator hitting a false
+// positive (e.g. issue #984 — `kuke run <config>` rejecting immediately after
+// a successful `kuke restart cell` per the OutOfSync reconcile path) has no
+// way to tell which side of the comparison normalised differently from the
+// other. Test assertions on the field path itself (e.g.
+// `spec.containers["main"].image`) still match because the path prefix is
+// preserved verbatim before the `(actual=…)` suffix.
+//
 // Root containers are filtered out of the count/id-set comparison on both
 // sides. The runner synthesizes a root container during create if the YAML
 // omitted one (`docs/examples/hello-world.yaml` is the canonical case), so a
@@ -1258,13 +1267,16 @@ func divergedFields(actual, desired v1beta1.CellSpec) []string {
 	var diffs []string
 
 	if actual.RealmID != "" && actual.RealmID != desired.RealmID {
-		diffs = append(diffs, "spec.realmId")
+		diffs = append(diffs, fmt.Sprintf(
+			"spec.realmId (actual=%q, desired=%q)", actual.RealmID, desired.RealmID))
 	}
 	if actual.SpaceID != "" && actual.SpaceID != desired.SpaceID {
-		diffs = append(diffs, "spec.spaceId")
+		diffs = append(diffs, fmt.Sprintf(
+			"spec.spaceId (actual=%q, desired=%q)", actual.SpaceID, desired.SpaceID))
 	}
 	if actual.StackID != "" && actual.StackID != desired.StackID {
-		diffs = append(diffs, "spec.stackId")
+		diffs = append(diffs, fmt.Sprintf(
+			"spec.stackId (actual=%q, desired=%q)", actual.StackID, desired.StackID))
 	}
 
 	if len(actual.Containers) == 0 {
@@ -1293,7 +1305,8 @@ func divergedFields(actual, desired v1beta1.CellSpec) []string {
 			continue
 		}
 		if ac.Root != dc.Root {
-			diffs = append(diffs, fmt.Sprintf("spec.containers[%q].root", ac.ID))
+			diffs = append(diffs, fmt.Sprintf(
+				"spec.containers[%q].root (actual=%v, desired=%v)", ac.ID, ac.Root, dc.Root))
 		}
 		for _, field := range divergedContainerFields(ac, dc) {
 			diffs = append(diffs, fmt.Sprintf("spec.containers[%q].%s", ac.ID, field))
@@ -1316,57 +1329,84 @@ func divergedFields(actual, desired v1beta1.CellSpec) []string {
 func divergedContainerFields(actual, desired v1beta1.ContainerSpec) []string {
 	var fields []string
 	if actual.Image != desired.Image {
-		fields = append(fields, "image")
+		fields = append(fields, scalarDiff("image", actual.Image, desired.Image))
 	}
 	if actual.Command != desired.Command {
-		fields = append(fields, "command")
+		fields = append(fields, scalarDiff("command", actual.Command, desired.Command))
 	}
 	if !stringSlicesEqual(actual.Args, desired.Args) {
-		fields = append(fields, "args")
+		fields = append(fields, sliceDiff("args", actual.Args, desired.Args))
 	}
 	if actual.WorkingDir != desired.WorkingDir {
-		fields = append(fields, "workingDir")
+		fields = append(fields, scalarDiff("workingDir", actual.WorkingDir, desired.WorkingDir))
 	}
 	if !stringSlicesEqual(actual.Env, desired.Env) {
-		fields = append(fields, "env")
+		fields = append(fields, sliceDiff("env", actual.Env, desired.Env))
 	}
 	if !stringSlicesEqual(actual.Ports, desired.Ports) {
-		fields = append(fields, "ports")
+		fields = append(fields, sliceDiff("ports", actual.Ports, desired.Ports))
 	}
 	if !volumeMountsEqual(actual.Volumes, desired.Volumes) {
-		fields = append(fields, "volumes")
+		fields = append(fields, valueDiff("volumes", actual.Volumes, desired.Volumes))
 	}
 	if !stringSlicesEqual(actual.Networks, desired.Networks) {
-		fields = append(fields, "networks")
+		fields = append(fields, sliceDiff("networks", actual.Networks, desired.Networks))
 	}
 	if !stringSlicesEqual(actual.NetworksAliases, desired.NetworksAliases) {
-		fields = append(fields, "networksAliases")
+		fields = append(fields, sliceDiff("networksAliases", actual.NetworksAliases, desired.NetworksAliases))
 	}
 	if actual.Privileged != desired.Privileged {
-		fields = append(fields, "privileged")
+		fields = append(fields, boolDiff("privileged", actual.Privileged, desired.Privileged))
 	}
 	if actual.HostNetwork != desired.HostNetwork {
-		fields = append(fields, "hostNetwork")
+		fields = append(fields, boolDiff("hostNetwork", actual.HostNetwork, desired.HostNetwork))
 	}
 	if actual.HostPID != desired.HostPID {
-		fields = append(fields, "hostPID")
+		fields = append(fields, boolDiff("hostPID", actual.HostPID, desired.HostPID))
 	}
 	if actual.HostCgroup != desired.HostCgroup {
-		fields = append(fields, "hostCgroup")
+		fields = append(fields, boolDiff("hostCgroup", actual.HostCgroup, desired.HostCgroup))
 	}
 	if actual.Attachable != desired.Attachable {
-		fields = append(fields, "attachable")
+		fields = append(fields, boolDiff("attachable", actual.Attachable, desired.Attachable))
 	}
 	if actual.RestartPolicy != desired.RestartPolicy {
-		fields = append(fields, "restartPolicy")
+		fields = append(fields, scalarDiff("restartPolicy", actual.RestartPolicy, desired.RestartPolicy))
 	}
 	if !containerSecretsEqual(actual.Secrets, desired.Secrets) {
-		fields = append(fields, "secrets")
+		fields = append(fields, valueDiff("secrets", actual.Secrets, desired.Secrets))
 	}
 	if !containerTtysEqual(actual.Tty, desired.Tty) {
-		fields = append(fields, "tty")
+		fields = append(fields, valueDiff("tty", actual.Tty, desired.Tty))
 	}
 	return fields
+}
+
+// scalarDiff formats a single string field's actual/desired pair as
+// `<name> (actual=%q, desired=%q)`. Used by divergedContainerFields so the
+// reject error names both sides — see divergedFields' rationale.
+func scalarDiff(name, actual, desired string) string {
+	return fmt.Sprintf("%s (actual=%q, desired=%q)", name, actual, desired)
+}
+
+// boolDiff is scalarDiff's bool sibling — prints `actual=true desired=false`
+// rather than quoting the values.
+func boolDiff(name string, actual, desired bool) string {
+	return fmt.Sprintf("%s (actual=%v, desired=%v)", name, actual, desired)
+}
+
+// sliceDiff formats a string-slice's actual/desired pair via `%q` so each
+// entry stays quoted (`["a" "b"]`) and an embedded space is unambiguous.
+func sliceDiff(name string, actual, desired []string) string {
+	return fmt.Sprintf("%s (actual=%q, desired=%q)", name, actual, desired)
+}
+
+// valueDiff is the fallback formatter for non-string-slice composite fields
+// (Volumes, Secrets, Tty). Uses `%+v` so struct field names render alongside
+// their values — the reader needs to see e.g. `{Source:/host …}` to diagnose
+// the divergence, not a bare positional `{[…] …}`.
+func valueDiff(name string, actual, desired interface{}) string {
+	return fmt.Sprintf("%s (actual=%+v, desired=%+v)", name, actual, desired)
 }
 
 // containerSecretsEqual compares two ContainerSecret slices field-by-field.


### PR DESCRIPTION
## Summary

Closes #984.

`kuke run <config>` rejecting with the divergent-spec error immediately
after a successful `kuke restart cell` (which just wrote a
freshly-materialised spec to disk via the OutOfSync reconcile path) was
diagnostically opaque: the operator saw `spec differs at containers[…]` with
no way to tell which side of `divergedFields(pre.Cell.Spec, cellDoc.Spec)`
normalised differently.

This PR ships the two non-conditional items from the issue's "Suggested fix"
list — debug surface + regression guard — so the gap is observable the next
time it fires and a future PR can target it precisely.

- `divergedFields` / `divergedContainerFields` now embed actual+desired
  values into each returned entry (`spec.containers["main"].image
  (actual="registry.example.com/web:v1", desired="registry.example.com/web:v2")`).
  Path prefix preserved verbatim so existing `strings.Contains` test
  assertions still match.
- New `TestDivergedFields_MaterializePersistMaterializeIsIdempotent` in
  `cmd/kuke/run/` asserts the invariant: Materialize → daemon-persist
  simulation (yaml round-trip + apischeme convert + parent-ref / Space-defaults
  / ContainerdID mutations + JSON marshal/unmarshal + GetCell readback) →
  Materialize → `divergedFields == nil`. Passes on both a minimal cell and a
  rich one (env, ports, volumes, networks, git, repos, secrets, tty); the
  simulation does not reproduce the operator-reported false positive, which
  is consistent with the issue's "not yet reproduced in CI" note. Test is a
  regression guard against the persistence pipeline drifting from the
  comparator on future changes.

The third suggested fix (tighten Materialize determinism or
divergedContainerFields' exclusion set "once the gap is identified") is
deferred — the gap is still not identifiable from the current simulation,
and the enriched error from this PR is what enables the next live-host
encounter to pinpoint it.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] `go test ./cmd/kuke/run/` — new regression test passes; existing
  divergent-spec tests (`TestRun_FromConfig_DivergentSpec_RefusesAndPointsToApply`,
  `TestRun_FromBlueprint_NamedDivergent_RefusesAndPointsToApply`, the
  per-field secrets/tty/work tests) still match on path prefix
- [ ] `make dev-init` smoke — not applicable; change is CLI-side error
  formatting only, no daemon or `/opt/kukeon` touchpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)