### PR TITLE
fix(apply): diff cell-level Tty, AutoDelete, NestedCgroupRuntime fields

### DIFF
--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -336,6 +336,54 @@ func DiffCell(desired, actual intmodel.Cell) CellDiffResult {
 		result.Details["metadata.labels"] = labelsChangedMsg
 	}
 
+	// Compatible: cell-default TTY pointer. The runner re-resolves which
+	// container's TTY `kuke attach` lands on lazily from cell.Spec.Tty.Default,
+	// so an operator edit just needs to flow into UpdateCell rather than
+	// trigger a recreate. Without this branch the edit is persisted to cell
+	// metadata but apply reports "no changes" and never re-stamps. Issue #992.
+	if !cellTtyEqual(desired.Spec.Tty, actual.Spec.Tty) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "spec.tty")
+		result.Details["spec.tty"] = "tty default changed"
+	}
+
+	// Compatible: AutoDelete. The reaper consults cell.Spec.AutoDelete on the
+	// next reconcile pass, so toggling the flag does not require a recreate —
+	// but the apply layer must still surface the change so the operator does
+	// not see a misleading "no changes" verdict on a YAML that flipped it.
+	// Issue #992.
+	if desired.Spec.AutoDelete != actual.Spec.AutoDelete {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "spec.autoDelete")
+		result.Details["spec.autoDelete"] = fmt.Sprintf(
+			"autoDelete changed from %v to %v",
+			actual.Spec.AutoDelete,
+			desired.Spec.AutoDelete,
+		)
+	}
+
+	// Breaking: NestedCgroupRuntime. Flipping the flag re-runs the
+	// EnableCellAllSubtreeControllers delegation (#318) and recomputes the
+	// in-container /sys/fs/cgroup mount per BuildContainerSpec; the namespace
+	// setup baked into the existing cell cannot be re-stamped in place, so
+	// RecreateCell is the safe path. Issue #992.
+	if desired.Spec.NestedCgroupRuntime != actual.Spec.NestedCgroupRuntime {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "spec.nestedCgroupRuntime")
+		result.Details["spec.nestedCgroupRuntime"] = fmt.Sprintf(
+			"nestedCgroupRuntime changed from %v to %v (breaking)",
+			actual.Spec.NestedCgroupRuntime,
+			desired.Spec.NestedCgroupRuntime,
+		)
+	}
+
 	// Find root container in desired and actual
 	desiredRoot := findRootContainer(desired.Spec.Containers)
 	actualRoot := findRootContainer(actual.Spec.Containers)
@@ -686,6 +734,23 @@ func recordImageCmdArgsChange(result *DiffResult, rootContainer bool, field, det
 		result.ChangedFields = append(result.ChangedFields, field)
 	}
 	result.Details[field] = detail
+}
+
+// cellTtyEqual reports whether two *CellTty pointers describe the same
+// default-TTY pointer. A nil pointer is treated as equal to a zero-value
+// CellTty so adding or clearing an explicitly-empty `spec.tty` block does not
+// register as drift on a same-file re-apply.
+func cellTtyEqual(a, b *intmodel.CellTty) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil {
+		return b.Default == ""
+	}
+	if b == nil {
+		return a.Default == ""
+	}
+	return a.Default == b.Default
 }
 
 func capabilitiesEqual(a, b *intmodel.ContainerCapabilities) bool {

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -509,6 +509,155 @@ func TestDiffContainer_NonRootInPlace(t *testing.T) {
 	}
 }
 
+// TestDiffCell_Tty_CompatibleChange pins AC #1+#3 of issue #992: a change to
+// the cell-default TTY pointer (`Spec.Tty.Default`) must surface as a
+// Compatible diff with `spec.tty` in ChangedFields and a populated Details
+// entry — so `kuke apply` re-stamps the attach target instead of silently
+// dropping the edit.
+func TestDiffCell_Tty_CompatibleChange(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Tty:       &intmodel.CellTty{Default: "web"},
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "busybox:latest"},
+			},
+		},
+	}
+
+	actual := desired
+	actual.Spec.Tty = &intmodel.CellTty{Default: "root"}
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Fatal("expected changes for tty default edit")
+	}
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible change, got %v", diff.ChangeType)
+	}
+	if !hasChangedField(diff.DiffResult, "spec.tty") {
+		t.Errorf("expected ChangedFields to include spec.tty, got %v", diff.ChangedFields)
+	}
+	if diff.Details["spec.tty"] == "" {
+		t.Errorf("expected Details[spec.tty] to be populated, got empty")
+	}
+	if len(diff.BreakingChanges) != 0 {
+		t.Errorf("tty edit must not populate BreakingChanges, got %v", diff.BreakingChanges)
+	}
+}
+
+// TestDiffCell_Tty_NilEqualsZero exercises the cellTtyEqual helper's
+// nil-versus-zero-value contract: a same-file re-apply where one side carries
+// nil and the other an explicitly-empty CellTty must not register drift.
+func TestDiffCell_Tty_NilEqualsZero(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Tty:       nil,
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+			},
+		},
+	}
+
+	actual := desired
+	actual.Spec.Tty = &intmodel.CellTty{Default: ""}
+
+	diff := apply.DiffCell(desired, actual)
+	if diff.HasChanges {
+		t.Errorf("nil vs empty CellTty must not register drift, got changes: %+v", diff)
+	}
+}
+
+// TestDiffCell_AutoDelete_CompatibleChange pins AC #1+#3 of issue #992: a
+// toggle of `Spec.AutoDelete` must surface as a Compatible diff with
+// `spec.autoDelete` in ChangedFields and a populated Details entry.
+func TestDiffCell_AutoDelete_CompatibleChange(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName:  "default",
+			SpaceName:  "default",
+			StackName:  "default",
+			AutoDelete: true,
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+			},
+		},
+	}
+
+	actual := desired
+	actual.Spec.AutoDelete = false
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Fatal("expected changes for autoDelete toggle")
+	}
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible change, got %v", diff.ChangeType)
+	}
+	if !hasChangedField(diff.DiffResult, "spec.autoDelete") {
+		t.Errorf("expected ChangedFields to include spec.autoDelete, got %v", diff.ChangedFields)
+	}
+	if diff.Details["spec.autoDelete"] == "" {
+		t.Errorf("expected Details[spec.autoDelete] to be populated, got empty")
+	}
+	if len(diff.BreakingChanges) != 0 {
+		t.Errorf("autoDelete edit must not populate BreakingChanges, got %v", diff.BreakingChanges)
+	}
+}
+
+// TestDiffCell_NestedCgroupRuntime_BreakingChange pins AC #1+#2 of issue
+// #992: a toggle of `Spec.NestedCgroupRuntime` must classify as Breaking and
+// surface in BreakingChanges as `spec.nestedCgroupRuntime` — the runner's
+// cgroup-delegation and in-container /sys/fs/cgroup mount cannot be
+// re-stamped in place, so RecreateCell is the only safe path.
+func TestDiffCell_NestedCgroupRuntime_BreakingChange(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName:           "default",
+			SpaceName:           "default",
+			StackName:           "default",
+			NestedCgroupRuntime: true,
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+			},
+		},
+	}
+
+	actual := desired
+	actual.Spec.NestedCgroupRuntime = false
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Fatal("expected changes for nestedCgroupRuntime toggle")
+	}
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Fatalf("expected breaking change, got %v", diff.ChangeType)
+	}
+	found := false
+	for _, f := range diff.BreakingChanges {
+		if f == "spec.nestedCgroupRuntime" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected BreakingChanges to include spec.nestedCgroupRuntime, got %v", diff.BreakingChanges)
+	}
+	if diff.Details["spec.nestedCgroupRuntime"] == "" {
+		t.Errorf("expected Details[spec.nestedCgroupRuntime] to be populated, got empty")
+	}
+}
+
 func hasChangedField(diff apply.DiffResult, field string) bool {
 	for _, f := range diff.ChangedFields {
 		if f == field {


### PR DESCRIPTION
## Summary

- `DiffCell` previously only compared `Metadata.Name`, `Metadata.Labels`, `Spec.RealmName`, `Spec.SpaceName`, `Spec.StackName` at the cell level. Three user-authored persisted `CellSpec` fields had no comparator branch: `Tty`, `AutoDelete`, `NestedCgroupRuntime`. Edits to those fields were persisted to cell metadata but `kuke apply` reported "no changes" and never re-stamped the runtime.
- New branches placed between the labels check and the root-container handling:
  - `Spec.Tty` → Compatible (`spec.tty` in `ChangedFields`). Runner re-resolves the attach target lazily.
  - `Spec.AutoDelete` → Compatible (`spec.autoDelete` in `ChangedFields`). Reaper consults the persisted field on the next tick; emitting the diff entry surfaces the change in the apply-layer report.
  - `Spec.NestedCgroupRuntime` → Breaking (`spec.nestedCgroupRuntime` in `BreakingChanges`). Flipping the flag re-runs `EnableCellAllSubtreeControllers` (#318) and recomputes the in-container `/sys/fs/cgroup` mount per `BuildContainerSpec`; in-place toggle is not supported, RecreateCell is the safe path.
- New helper `cellTtyEqual` lives alongside the existing equality helpers (style match with `capabilitiesEqual` / `resourcesEqual`). Nil pointer is treated as equal to a zero-value `CellTty` so a same-file re-apply with one side nil and the other an explicitly-empty block does not register as drift.
- `OutOfSyncReason` on Config-lineage cells now picks up these field names automatically: `outOfSyncSpecDifferReason` / `collectDiffFieldPaths` in `internal/controller/reconcile_outofsync.go` aggregate over `ChangedFields` + `BreakingChanges`, so the new branches surface in the persisted reason string without any reconciler-side change.

## Test plan

- [x] `GOWORK=off go test ./internal/controller/apply/ -run TestDiffCell -v` — all DiffCell tests pass, including the four new ones (`TestDiffCell_Tty_CompatibleChange`, `TestDiffCell_Tty_NilEqualsZero`, `TestDiffCell_AutoDelete_CompatibleChange`, `TestDiffCell_NestedCgroupRuntime_BreakingChange`).
- [x] `GOWORK=off make test` — both root and `cmd/kukebuild` modules clean.
- [x] `GOWORK=off go build ./...` and `GOWORK=off go vet ./...` clean.
- [ ] `make dev-init` smoke — not run; this change is to a pure comparator function with no daemon/runtime side. The behavioral pivot is covered by the new unit tests against the in-process `DiffCell` surface that both `kuke apply` and `reconcileCellOutOfSync` call.

## Notes for reviewer

- The repo pins `go 1.24.5` in `go.mod` but the dev host only has `go 1.25.5` cached; `go.work` requires `>= 1.25.5`. `GOWORK=off` selects the per-module toolchain that the Dockerfile builder and CI see (the same guidance the `go.work` comment surfaces).
- Sibling issues #990 (root-container 3-field check) and #991 (`diffContainerSpec` per-container gaps) are explicitly out of scope per this issue's body; nothing in either of those paths was touched.

Closes #992