### PR TITLE
fix(apply): diff WorkingDir, host-ns toggles, networks, RestartPolicy, Attachable, Tty, Git on container spec

### DIFF
--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -667,6 +667,134 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bo
 		result.Details["repos"] = "repos changed"
 	}
 
+	if desired.WorkingDir != actual.WorkingDir {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "workingDir")
+		result.Details["workingDir"] = fmt.Sprintf(
+			"workingDir changed from %q to %q",
+			actual.WorkingDir,
+			desired.WorkingDir,
+		)
+	}
+
+	if !slicesEqual(desired.Networks, actual.Networks) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "networks")
+		result.Details["networks"] = "networks changed"
+	}
+
+	if !slicesEqual(desired.NetworksAliases, actual.NetworksAliases) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "networksAliases")
+		result.Details["networksAliases"] = "networksAliases changed"
+	}
+
+	// Host-namespace toggles change the parent cell's OCI namespace shape —
+	// the netns / pidns / cgroupns the root container sets up at cell-start
+	// time is inherited by child containers via JoinContainerNamespaces, so
+	// flipping any of these on an existing container cannot be applied
+	// in-place. Route through ChangeTypeBreaking so the apply layer drives
+	// RecreateCell instead of UpdateCell's child stop-remove-recreate-start
+	// path (which only re-enters the existing namespaces).
+	if desired.HostNetwork != actual.HostNetwork {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "hostNetwork")
+		result.Details["hostNetwork"] = fmt.Sprintf(
+			"hostNetwork changed from %v to %v (breaking)",
+			actual.HostNetwork,
+			desired.HostNetwork,
+		)
+	}
+
+	if desired.HostPID != actual.HostPID {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "hostPID")
+		result.Details["hostPID"] = fmt.Sprintf(
+			"hostPID changed from %v to %v (breaking)",
+			actual.HostPID,
+			desired.HostPID,
+		)
+	}
+
+	if desired.HostCgroup != actual.HostCgroup {
+		result.HasChanges = true
+		result.ChangeType = ChangeTypeBreaking
+		result.BreakingChanges = append(result.BreakingChanges, "hostCgroup")
+		result.Details["hostCgroup"] = fmt.Sprintf(
+			"hostCgroup changed from %v to %v (breaking)",
+			actual.HostCgroup,
+			desired.HostCgroup,
+		)
+	}
+
+	if desired.CNIConfigPath != actual.CNIConfigPath {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "cniConfigPath")
+		result.Details["cniConfigPath"] = fmt.Sprintf(
+			"cniConfigPath changed from %q to %q",
+			actual.CNIConfigPath,
+			desired.CNIConfigPath,
+		)
+	}
+
+	if desired.RestartPolicy != actual.RestartPolicy {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "restartPolicy")
+		result.Details["restartPolicy"] = fmt.Sprintf(
+			"restartPolicy changed from %q to %q",
+			actual.RestartPolicy,
+			desired.RestartPolicy,
+		)
+	}
+
+	if desired.Attachable != actual.Attachable {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "attachable")
+		result.Details["attachable"] = fmt.Sprintf(
+			"attachable changed from %v to %v",
+			actual.Attachable,
+			desired.Attachable,
+		)
+	}
+
+	if !ttyEqual(desired.Tty, actual.Tty) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "tty")
+		result.Details["tty"] = "tty changed"
+	}
+
+	if !gitEqual(desired.Git, actual.Git) {
+		result.HasChanges = true
+		if result.ChangeType == ChangeTypeNone {
+			result.ChangeType = ChangeTypeCompatible
+		}
+		result.ChangedFields = append(result.ChangedFields, "git")
+		result.Details["git"] = "git identity changed"
+	}
+
 	return result
 }
 
@@ -757,6 +885,77 @@ func int64PtrEqual(a, b *int64) bool {
 		return false
 	}
 	return *a == *b
+}
+
+// ttyEqual reports whether two *ContainerTty describe the same kuketty
+// pre-Serve config. Nil and a zero-valued block compare equal so allocating
+// or clearing an explicitly-empty `tty:` does not register as drift — same
+// treatment resourcesEqual gives an empty resources block.
+func ttyEqual(a, b *intmodel.ContainerTty) bool {
+	if a.IsEmpty() && b.IsEmpty() {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Prompt != b.Prompt || a.LogFile != b.LogFile || a.LogLevel != b.LogLevel {
+		return false
+	}
+	if len(a.OnInit) != len(b.OnInit) {
+		return false
+	}
+	for i := range a.OnInit {
+		if a.OnInit[i] != b.OnInit[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// gitEqual reports whether two *ContainerGit describe the same declarative
+// git identity/signing block. Nil and a zero-valued block compare equal so
+// allocating or clearing an explicitly-empty `git:` does not register as
+// drift.
+func gitEqual(a, b *intmodel.ContainerGit) bool {
+	if gitIsZero(a) && gitIsZero(b) {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return gitIdentityEqual(a.Author, b.Author) &&
+		gitIdentityEqual(a.Committer, b.Committer) &&
+		a.SigningKey == b.SigningKey &&
+		a.AllowedSigners == b.AllowedSigners &&
+		slicesEqual(a.Sign, b.Sign)
+}
+
+func gitIsZero(g *intmodel.ContainerGit) bool {
+	if g == nil {
+		return true
+	}
+	return gitIdentityIsZero(g.Author) &&
+		gitIdentityIsZero(g.Committer) &&
+		g.SigningKey == "" &&
+		g.AllowedSigners == "" &&
+		len(g.Sign) == 0
+}
+
+func gitIdentityEqual(a, b *intmodel.GitIdentity) bool {
+	if gitIdentityIsZero(a) && gitIdentityIsZero(b) {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func gitIdentityIsZero(id *intmodel.GitIdentity) bool {
+	if id == nil {
+		return true
+	}
+	return id.Name == "" && id.Email == ""
 }
 
 // spaceDefaultsEqual reports whether two *SpaceDefaults describe the same

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -574,6 +574,128 @@ func TestDiffContainer_SecretsChange(t *testing.T) {
 	}
 }
 
+// TestDiffContainer_WorkingDirChange covers a Compatible-class field added by
+// issue #991: a non-root container `workingDir` edit must register as drift on
+// the in-place updateable path so the apply layer drives the spec change into
+// UpdateCell instead of returning "no changes" while the running container
+// keeps its prior process.cwd.
+func TestDiffContainer_WorkingDirChange(t *testing.T) {
+	desired := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "web"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "web",
+			RealmName: "default", SpaceName: "default", StackName: "default", CellName: "hello-world",
+			Image:      "nginx:1.27",
+			WorkingDir: "/opt/app",
+		},
+	}
+	actual := desired
+	actual.Spec.WorkingDir = "/srv"
+
+	diff := apply.DiffContainer(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible change for workingDir edit, got %v", diff.ChangeType)
+	}
+	if !hasChangedField(diff, "workingDir") {
+		t.Errorf("expected ChangedFields to include workingDir, got %v", diff.ChangedFields)
+	}
+	if len(diff.BreakingChanges) != 0 {
+		t.Errorf("workingDir is in-place updateable; BreakingChanges must be empty, got %v", diff.BreakingChanges)
+	}
+}
+
+// TestDiffContainer_HostNetworkChange covers a Breaking-class field added by
+// issue #991: host-namespace toggles change the cell's OCI namespace shape
+// (the root container sets up netns at cell-start, child containers join via
+// JoinContainerNamespaces) so flipping `hostNetwork` cannot be applied in
+// place — the diff must classify as breaking to route through RecreateCell.
+func TestDiffContainer_HostNetworkChange(t *testing.T) {
+	desired := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "web"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "web",
+			RealmName: "default", SpaceName: "default", StackName: "default", CellName: "hello-world",
+			Image:       "nginx:1.27",
+			HostNetwork: true,
+		},
+	}
+	actual := desired
+	actual.Spec.HostNetwork = false
+
+	diff := apply.DiffContainer(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Fatalf("expected breaking change for hostNetwork flip, got %v", diff.ChangeType)
+	}
+	found := false
+	for _, f := range diff.BreakingChanges {
+		if f == "hostNetwork" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected BreakingChanges to include hostNetwork, got %v", diff.BreakingChanges)
+	}
+}
+
+// TestDiffContainer_TtyChange exercises the *ContainerTty pointer-field
+// equality helper added by issue #991: a tty edit on the pointer-backed
+// stage list must register as drift, and an identical block (including a
+// populated OnInit slice) must not.
+func TestDiffContainer_TtyChange(t *testing.T) {
+	desired := intmodel.Container{
+		Metadata: intmodel.ContainerMetadata{Name: "web"},
+		Spec: intmodel.ContainerSpec{
+			ID:        "web",
+			RealmName: "default", SpaceName: "default", StackName: "default", CellName: "hello-world",
+			Image: "nginx:1.27",
+			Tty: &intmodel.ContainerTty{
+				Prompt: "[web] ",
+				OnInit: []intmodel.TtyStage{{Script: "echo hello", RunOn: "create"}},
+			},
+		},
+	}
+	actual := desired
+	// Same fields, different OnInit script — must register drift.
+	actual.Spec.Tty = &intmodel.ContainerTty{
+		Prompt: "[web] ",
+		OnInit: []intmodel.TtyStage{{Script: "echo bye", RunOn: "create"}},
+	}
+
+	diff := apply.DiffContainer(desired, actual)
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Fatalf("expected compatible change for tty edit, got %v", diff.ChangeType)
+	}
+	if !hasChangedField(diff, "tty") {
+		t.Errorf("expected ChangedFields to include tty, got %v", diff.ChangedFields)
+	}
+
+	// Identical Tty blocks (same pointer-shape, same content) must not drift.
+	sameDesired := desired
+	sameActual := desired
+	sameActual.Spec.Tty = &intmodel.ContainerTty{
+		Prompt: "[web] ",
+		OnInit: []intmodel.TtyStage{{Script: "echo hello", RunOn: "create"}},
+	}
+	noDiff := apply.DiffContainer(sameDesired, sameActual)
+	if noDiff.HasChanges {
+		t.Errorf("expected no drift on identical tty blocks, got %v", noDiff.ChangedFields)
+	}
+
+	// Nil vs. zero-valued *ContainerTty must compare equal (same treatment
+	// resourcesEqual gives an empty resources block).
+	nilSide := desired
+	nilSide.Spec.Tty = nil
+	zeroSide := desired
+	zeroSide.Spec.Tty = &intmodel.ContainerTty{}
+	nilDiff := apply.DiffContainer(nilSide, zeroSide)
+	for _, f := range nilDiff.ChangedFields {
+		if f == "tty" {
+			t.Errorf("nil and zero-valued tty must compare equal; got tty drift %v", nilDiff.Details["tty"])
+		}
+	}
+}
+
 // TestDiffContainer_ReposSecretsNoChange guards the equality helpers: identical
 // repos/secrets (including a populated SecretRef) must not register drift on a
 // same-spec re-apply.


### PR DESCRIPTION
## Summary

- Extends `diffContainerSpec` (`internal/controller/apply/diff.go`) with comparator branches for the 11 persisted, user-authored fields enumerated in the issue: `WorkingDir`, `Networks`, `NetworksAliases`, `HostNetwork`, `HostPID`, `HostCgroup`, `CNIConfigPath`, `RestartPolicy`, `Attachable`, `Tty`, `Git`. Without these, `kuke apply -f cell.yaml` returned a clean "no changes" on edits to any of them while the persisted spec drifted from the running OCI spec.
- Classification matches the issue proposal:
  - **Breaking** — `HostNetwork`, `HostPID`, `HostCgroup` (host-namespace toggles change the parent cell's OCI namespace shape; child containers inherit those namespaces via `JoinContainerNamespaces` at cell-start, so flipping them cannot be applied in place).
  - **Compatible** — the other eight, matching how `Env` / `Volumes` are handled today.
- Adds `ttyEqual` and `gitEqual` (with `gitIsZero`, `gitIdentityEqual`, `gitIdentityIsZero` helpers) following the `capabilitiesEqual` / `resourcesEqual` style. Both treat nil and a zero-valued block as equal so allocating or clearing an explicitly-empty block does not register as drift. `Networks` and `NetworksAliases` are plain `[]string`, so `slicesEqual` is reused directly — a separate `networksEqual` would be a one-line alias.
- Adds three `diff_test.go` cases: `TestDiffContainer_WorkingDirChange` (one Compatible field), `TestDiffContainer_HostNetworkChange` (one Breaking field), `TestDiffContainer_TtyChange` (the `*ContainerTty` pointer equality helper, plus nil-vs-zero-valued and same-content sub-cases).

## Runner re-stamp audit (AC4)

Verified each newly Compatible field for whether `BuildContainerSpec` / the runner's attach path re-reads it from `ContainerSpec` when the breaking trio (image/command/args) triggers UpdateCell's stop-remove-recreate-start:

| Field | Re-read at recreate? | Site |
|-------|----------------------|------|
| `WorkingDir` | ✅ | `internal/ctr/spec.go:370` (`oci.WithProcessCwd`) |
| `Attachable` | ✅ | `internal/ctr/spec.go:467` (`withAttachableMounts`/`withAttachableArgsWrap`) |
| `CNIConfigPath` | ✅ | `internal/ctr/spec.go:480` (returned in `ctr.ContainerSpec.CNIConfigPath`) |
| `Tty` | ✅ | `internal/controller/runner/attachable.go:242-255` (`reconcileAttachableExtSpec`) |
| `Git` | ✅ | `internal/ctr/spec.go:540` (via `gitEnv` in `kukeonContainerEnv`) |
| `HostNetwork` | ✅ | `internal/ctr/spec.go:391` (`oci.WithHostNamespace(NetworkNamespace)`) — breaking-classified |
| `HostPID` | ✅ | `internal/ctr/spec.go:399` — breaking-classified |
| `HostCgroup` | ✅ | `internal/ctr/spec.go:412` — breaking-classified |
| `Networks` | ⚠️ persisted only | runner has no CNI add path that consumes `Spec.Networks` — out-of-scope per the issue's "Out of scope" note |
| `NetworksAliases` | ⚠️ persisted only | same — out-of-scope per the issue |
| `RestartPolicy` | ⚠️ persisted only | runner has no start/restart consumer; only carried in `internal/apischeme/scheme.go` ⇄ `internal/modelhub/container.go` ⇄ `internal/cellblueprint`/`internal/cellconfig` plumbing |

The diff-side detection added here is the prerequisite for the runner-side runtime work the issue defers (`Out of scope` bullet). The `RestartPolicy` runtime-honoring gap is a sibling follow-up worth filing separately.

Separately verified that `UpdateCell` (`internal/controller/runner/update_cell.go:282-286`) currently only triggers the child-recreate dance for the breaking trio (image/command/args). Other compatible-classified fields (env, ports, volumes — and now the eight added here) get persisted to metadata but the running container's OCI spec is not re-stamped until an image/command/args change co-occurs. This is the existing runner shape called out by the AC and is the cross-cutting follow-up the issue's "Out of scope" implies.

## Test plan
- [x] `GOWORK=off go test ./internal/controller/apply/` — `ok 0.012s`
- [x] `make test-root` — entire root-module test suite passes
- [x] `make test-kukebuild` — kukebuild module tests pass
- [x] `pre-commit run --files internal/controller/apply/diff.go internal/controller/apply/diff_test.go` — all hooks pass (go-fmt, golangci-lint, addlicense, …)
- [ ] `make dev-init` — not run (no behavior-mutating runtime change; diff is pure data classification)

Closes #991