### PR TITLE
fix(reconcile): widen root-container diff to all spec fields

### DIFF
--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -340,15 +340,45 @@ func DiffCell(desired, actual intmodel.Cell) CellDiffResult {
 	desiredRoot := findRootContainer(desired.Spec.Containers)
 	actualRoot := findRootContainer(actual.Spec.Containers)
 
-	// Check if root container spec changed (breaking)
+	// Diff the root container spec field-by-field. Routing through
+	// `diffContainerSpec(rootContainer=true)` closes issue #990: prior to
+	// this, the root path checked only image/command/args via a dedicated
+	// 3-field comparator and silently dropped every other user-authored
+	// edit (Env, Volumes, Privileged, User, ReadOnlyRootFilesystem,
+	// Capabilities, SecurityOpts, Tmpfs, Resources, Secrets, Repos).
+	// `diffContainerSpec` carries per-field Breaking-vs-Compatible
+	// classification keyed off the `rootContainer` flag — see the inline
+	// classification comments at each field call site.
 	switch {
 	case desiredRoot != nil && actualRoot != nil:
-		if rootContainerSpecChanged(desiredRoot, actualRoot) {
+		rootDiff := diffContainerSpec(desiredRoot, actualRoot, true)
+		if rootDiff.HasChanges {
 			result.HasChanges = true
-			result.ChangeType = ChangeTypeBreaking
 			result.RootContainerChanged = true
-			result.BreakingChanges = append(result.BreakingChanges, "spec.rootContainer")
-			result.RootContainerDetails["rootContainer"] = "root container spec changed (image, command, or args)"
+			if rootDiff.ChangeType == ChangeTypeBreaking {
+				result.ChangeType = ChangeTypeBreaking
+			} else if result.ChangeType == ChangeTypeNone {
+				result.ChangeType = rootDiff.ChangeType
+			}
+			// Qualify each diverged field with the `rootContainer.` prefix
+			// so the cell-level readout and `OutOfSyncReason` distinguish
+			// root-container drift from same-named drift on a child
+			// container (the child path uses `containers[<id>].<field>`).
+			for _, field := range rootDiff.BreakingChanges {
+				result.BreakingChanges = append(
+					result.BreakingChanges,
+					"rootContainer."+field,
+				)
+			}
+			for _, field := range rootDiff.ChangedFields {
+				result.ChangedFields = append(
+					result.ChangedFields,
+					"rootContainer."+field,
+				)
+			}
+			for k, v := range rootDiff.Details {
+				result.RootContainerDetails[k] = v
+			}
 		}
 	case desiredRoot != nil && actualRoot == nil:
 		// Root container added
@@ -405,8 +435,9 @@ func DiffCell(desired, actual intmodel.Cell) CellDiffResult {
 			// are classified as in-place updateable (Compatible) here so
 			// UpdateCell stops, removes, recreates, and starts the affected
 			// child container instead of refusing the diff. The root
-			// container's image/command/args bypass diffContainerSpec via
-			// rootContainerSpecChanged above and stay on the recreate path.
+			// container's image/command/args are classified as Breaking by
+			// the same comparator (called from the root branch above with
+			// `rootContainer=true`) and stay on the RecreateCell path.
 			containerDiff := diffContainerSpec(desiredContainer, actualContainer, false)
 			if containerDiff.HasChanges {
 				result.HasChanges = true
@@ -514,169 +545,149 @@ func DiffContainer(desired, actual intmodel.Container) DiffResult {
 
 // diffContainerSpec compares two container specs.
 //
-// `rootContainer` controls whether image/command/args changes are
-// classified as breaking. Root containers cannot be updated in place — the
-// runner's StartCell path bakes the root spec into namespace setup, so any
-// change to image/command/args has to flow through RecreateCell. Non-root
-// containers can be stopped, removed, recreated, and started under the
-// existing cell namespaces; UpdateCell already implements that recreate
-// dance (the apply layer just needs to stop refusing the diff). Issue
-// #485.
+// `rootContainer` selects the per-field Breaking-vs-Compatible
+// classification for the diff. Root containers cannot be updated in place
+// — the runner's StartCell path bakes the root spec into cell-namespace
+// setup, so each field whose value is baked into the OCI runtime spec at
+// create time has to flow through RecreateCell. Non-root containers can
+// be stopped, removed, recreated, and started under the existing cell
+// namespaces; UpdateCell already implements that recreate dance.
+//
+// The classification call per field lives inline at each call site (the
+// `breakingOnRoot` argument to recordSpecFieldChange) so a reader landing
+// on any field knows immediately whether changing it on a root container
+// forces a cell recreate. Issues #485, #990.
 //
 // which needs a per-field diff branch. Splitting into smaller helpers per
 // field group (env/ports/volumes, privileged/user/readonly,
 // capabilities/securityOpts/tmpfs/resources) would obscure the spec-vs-spec
-// shape readers reach for when adding a new field. The image/command/args
-// trio already lives in recordImageCmdArgsChange because those three share
-// the only non-trivial classification branch (root vs. non-root).
+// shape readers reach for when adding a new field.
 //
-//nolint:funlen // The container spec is a flat list of ~12 fields, each of
+
 func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bool) DiffResult {
 	result := DiffResult{
 		Details: make(map[string]string),
 	}
 
+	// image/command/args — Breaking on root (baked into containerd
+	// snapshot + OCI Process at create), Compatible on non-root
+	// (UpdateCell stops, removes, recreates, and starts the child).
 	if desired.Image != actual.Image {
-		recordImageCmdArgsChange(&result, rootContainer, "image",
+		recordSpecFieldChange(&result, rootContainer, true, "image",
 			fmt.Sprintf("image changed from %q to %q", actual.Image, desired.Image))
 	}
-
 	if desired.Command != actual.Command {
-		recordImageCmdArgsChange(&result, rootContainer, "command",
+		recordSpecFieldChange(&result, rootContainer, true, "command",
 			fmt.Sprintf("command changed from %q to %q", actual.Command, desired.Command))
 	}
-
 	if !slicesEqual(desired.Args, actual.Args) {
-		recordImageCmdArgsChange(&result, rootContainer, "args", "args changed")
+		recordSpecFieldChange(&result, rootContainer, true, "args", "args changed")
 	}
 
-	// Compatible changes: env, ports, volumes, etc.
+	// env — Compatible on root and non-root. Env injection on the root
+	// container is rebuilt from spec at every start; an `env` edit can
+	// land on the next cell start without a recreate.
 	if !slicesEqual(desired.Env, actual.Env) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "env")
-		result.Details["env"] = "environment variables changed"
+		recordSpecFieldChange(&result, rootContainer, false, "env", "environment variables changed")
 	}
 
+	// ports — Compatible on root and non-root. Ports are documentary
+	// metadata in kukeon (no port-publishing layer); no OCI spec field
+	// is baked from them at create time.
 	if !slicesEqual(desired.Ports, actual.Ports) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "ports")
-		result.Details["ports"] = "ports changed"
+		recordSpecFieldChange(&result, rootContainer, false, "ports", "ports changed")
 	}
 
+	// volumes — Compatible on root and non-root. Root-container volume
+	// edits are treated as in-place updateable for now (the apply layer
+	// reports drift so the operator sees it; the runner's UpdateCell
+	// path applies the change on the next reconcile). If runner-side
+	// gaps surface, file a follow-up to widen the Breaking domain.
 	if !volumeMountsEqual(desired.Volumes, actual.Volumes) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "volumes")
-		result.Details["volumes"] = "volumes changed"
+		recordSpecFieldChange(&result, rootContainer, false, "volumes", "volumes changed")
 	}
 
+	// privileged — Breaking on root (the cap-set is baked into the cell
+	// root's OCI Process spec at StartCell; flipping it requires a
+	// recreate). Compatible on non-root.
 	if desired.Privileged != actual.Privileged {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "privileged")
-		result.Details["privileged"] = fmt.Sprintf(
-			"privileged changed from %v to %v",
-			actual.Privileged,
-			desired.Privileged,
-		)
+		recordSpecFieldChange(&result, rootContainer, true, "privileged",
+			fmt.Sprintf("privileged changed from %v to %v", actual.Privileged, desired.Privileged))
 	}
 
+	// user — Breaking on root (OCI Process.user is fixed at create).
+	// Compatible on non-root.
 	if desired.User != actual.User {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "user")
-		result.Details["user"] = fmt.Sprintf("user changed from %q to %q", actual.User, desired.User)
+		recordSpecFieldChange(&result, rootContainer, true, "user",
+			fmt.Sprintf("user changed from %q to %q", actual.User, desired.User))
 	}
 
+	// readOnlyRootFilesystem — Breaking on root (OCI Root.readonly is
+	// fixed at create). Compatible on non-root.
 	if desired.ReadOnlyRootFilesystem != actual.ReadOnlyRootFilesystem {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "readOnlyRootFilesystem")
-		result.Details["readOnlyRootFilesystem"] = fmt.Sprintf(
-			"readOnlyRootFilesystem changed from %v to %v",
-			actual.ReadOnlyRootFilesystem,
-			desired.ReadOnlyRootFilesystem,
-		)
+		recordSpecFieldChange(&result, rootContainer, true, "readOnlyRootFilesystem",
+			fmt.Sprintf("readOnlyRootFilesystem changed from %v to %v",
+				actual.ReadOnlyRootFilesystem, desired.ReadOnlyRootFilesystem))
 	}
 
+	// capabilities — Breaking on root (OCI Process.capabilities bounding
+	// set is fixed at create). Compatible on non-root.
 	if !capabilitiesEqual(desired.Capabilities, actual.Capabilities) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "capabilities")
-		result.Details["capabilities"] = "capabilities changed"
+		recordSpecFieldChange(&result, rootContainer, true, "capabilities", "capabilities changed")
 	}
 
+	// securityOpts — Compatible on root and non-root. Most security-opt
+	// values (selinux/apparmor/seccomp profile names) round-trip through
+	// the runner without a baked OCI field that demands a fresh
+	// container; a stricter classification can land in a follow-up if
+	// runner gaps surface.
 	if !slicesEqual(desired.SecurityOpts, actual.SecurityOpts) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "securityOpts")
-		result.Details["securityOpts"] = "securityOpts changed"
+		recordSpecFieldChange(&result, rootContainer, false, "securityOpts", "securityOpts changed")
 	}
 
+	// tmpfs — Breaking on root (OCI Mounts table is fixed at create).
+	// Compatible on non-root.
 	if !tmpfsEqual(desired.Tmpfs, actual.Tmpfs) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "tmpfs")
-		result.Details["tmpfs"] = "tmpfs mounts changed"
+		recordSpecFieldChange(&result, rootContainer, true, "tmpfs", "tmpfs mounts changed")
 	}
 
+	// resources — Breaking on root (cgroup v2 limits are applied at the
+	// cell cgroup level when the root container creates the cell
+	// namespace; the cgroup-shape change requires a recreate).
+	// Compatible on non-root.
 	if !resourcesEqual(desired.Resources, actual.Resources) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "resources")
-		result.Details["resources"] = "resource limits changed"
+		recordSpecFieldChange(&result, rootContainer, true, "resources", "resource limits changed")
 	}
 
+	// secrets — Compatible on root and non-root. Secrets either flow as
+	// env (re-evaluated at start) or as bind-mounted files (the
+	// staged-file path can be re-staged before restart); no OCI field
+	// is permanently baked.
 	if !secretsEqual(desired.Secrets, actual.Secrets) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "secrets")
-		result.Details["secrets"] = "secrets changed"
+		recordSpecFieldChange(&result, rootContainer, false, "secrets", "secrets changed")
 	}
 
+	// repos — Compatible on root and non-root. Repos are handled by
+	// kuketty's pre-Serve clone/fetch step at start time, not at OCI
+	// spec creation; an edit takes effect on the next start.
 	if !reposEqual(desired.Repos, actual.Repos) {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "repos")
-		result.Details["repos"] = "repos changed"
+		recordSpecFieldChange(&result, rootContainer, false, "repos", "repos changed")
 	}
 
 	return result
 }
 
-// recordImageCmdArgsChange routes an image/command/args diff into either
-// BreakingChanges (root container) or ChangedFields (non-root, in-place
-// updateable). Lives outside diffContainerSpec so the latter stays within
-// funlen's statement budget. Issue #485.
-func recordImageCmdArgsChange(result *DiffResult, rootContainer bool, field, detail string) {
+// recordSpecFieldChange records a per-field divergence on the diff
+// result. Routes to BreakingChanges when `rootContainer && breakingOnRoot`
+// — those fields are baked into the cell's OCI runtime spec at
+// StartCell, so the apply layer must surface a recreate rather than an
+// in-place update — and to ChangedFields (Compatible) otherwise. Lives
+// outside diffContainerSpec so the latter stays within funlen's
+// statement budget. Generalizes the prior image/command/args-only
+// helper. Issues #485, #990.
+func recordSpecFieldChange(result *DiffResult, rootContainer, breakingOnRoot bool, field, detail string) {
 	result.HasChanges = true
-	if rootContainer {
+	if rootContainer && breakingOnRoot {
 		result.ChangeType = ChangeTypeBreaking
 		result.BreakingChanges = append(result.BreakingChanges, field)
 	} else {
@@ -933,12 +944,6 @@ func findRootContainer(containers []intmodel.ContainerSpec) *intmodel.ContainerS
 		}
 	}
 	return nil
-}
-
-func rootContainerSpecChanged(desired, actual *intmodel.ContainerSpec) bool {
-	return desired.Image != actual.Image ||
-		desired.Command != actual.Command ||
-		!slicesEqual(desired.Args, actual.Args)
 }
 
 // isBreakingChange returns true if the change type is breaking.

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -452,6 +452,158 @@ func TestDiffCell_RootContainerImage_StillBreaking(t *testing.T) {
 	}
 }
 
+// TestDiffCell_RootContainerPrivileged_Breaking pins AC1/AC2/AC3/AC5 of
+// issue #990: a Privileged drift on the root container must classify as
+// Breaking (the OCI Process cap-set is baked at StartCell), surface the
+// qualified `rootContainer.privileged` field path on the cell-level
+// BreakingChanges, and toggle `RootContainerChanged`. Prior to #990, the
+// root-container diff only checked image/command/args and silently
+// dropped every other edit including security-posture changes.
+func TestDiffCell_RootContainerPrivileged_Breaking(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest", Privileged: true},
+			},
+		},
+	}
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest", Privileged: false},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Fatal("expected changes for root privileged toggle")
+	}
+	if !diff.RootContainerChanged {
+		t.Error("expected RootContainerChanged=true for root privileged toggle")
+	}
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Errorf("expected breaking change for root privileged toggle, got %v", diff.ChangeType)
+	}
+	foundBreaking := false
+	for _, f := range diff.BreakingChanges {
+		if f == "rootContainer.privileged" {
+			foundBreaking = true
+			break
+		}
+	}
+	if !foundBreaking {
+		t.Errorf("expected BreakingChanges to include %q, got %v", "rootContainer.privileged", diff.BreakingChanges)
+	}
+	if got := diff.RootContainerDetails["privileged"]; got == "" {
+		t.Errorf("expected RootContainerDetails[\"privileged\"] populated, got empty")
+	}
+}
+
+// TestDiffCell_RootContainerEnv_Compatible pins AC1/AC2/AC3/AC5 of issue
+// #990 on the Compatible-on-root branch: an Env edit on the root
+// container must surface as a Compatible change (not silently dropped,
+// not forced through RecreateCell) and qualify under
+// `rootContainer.env`. Env injection on the root is rebuilt at every
+// start, so a recreate is not warranted.
+func TestDiffCell_RootContainerEnv_Compatible(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest", Env: []string{"FOO=new"}},
+			},
+		},
+	}
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest", Env: []string{"FOO=old"}},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Fatal("expected changes for root env edit")
+	}
+	if !diff.RootContainerChanged {
+		t.Error("expected RootContainerChanged=true for root env edit")
+	}
+	if diff.ChangeType != apply.ChangeTypeCompatible {
+		t.Errorf("expected compatible change for root env edit, got %v", diff.ChangeType)
+	}
+	if len(diff.BreakingChanges) != 0 {
+		t.Errorf("root env edit must not populate BreakingChanges, got %v", diff.BreakingChanges)
+	}
+	foundChanged := false
+	for _, f := range diff.ChangedFields {
+		if f == "rootContainer.env" {
+			foundChanged = true
+			break
+		}
+	}
+	if !foundChanged {
+		t.Errorf("expected ChangedFields to include %q, got %v", "rootContainer.env", diff.ChangedFields)
+	}
+}
+
+// TestDiffCell_RootContainer_NoDriftOnEqualSpec guards against false
+// positives on the widened root-container diff: a same-spec re-apply on
+// every field diffContainerSpec now reads from the root container must
+// still produce zero changes. Issue #990.
+func TestDiffCell_RootContainer_NoDriftOnEqualSpec(t *testing.T) {
+	limit := int64(128 << 20)
+	root := intmodel.ContainerSpec{
+		ID:                     "root",
+		Root:                   true,
+		Image:                  "busybox:latest",
+		Command:                "/bin/sleep",
+		Args:                   []string{"60"},
+		Env:                    []string{"FOO=bar"},
+		Volumes:                []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}},
+		Privileged:             true,
+		User:                   "nobody",
+		ReadOnlyRootFilesystem: true,
+		Capabilities:           &intmodel.ContainerCapabilities{Add: []string{"CAP_NET_ADMIN"}},
+		SecurityOpts:           []string{"no-new-privileges"},
+		Tmpfs:                  []intmodel.ContainerTmpfsMount{{Path: "/tmp", SizeBytes: 1 << 20}},
+		Resources:              &intmodel.ContainerResources{MemoryLimitBytes: &limit},
+	}
+	cell := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName:  "default",
+			SpaceName:  "default",
+			StackName:  "default",
+			Containers: []intmodel.ContainerSpec{root},
+		},
+	}
+
+	diff := apply.DiffCell(cell, cell)
+	if diff.HasChanges {
+		t.Errorf("expected no changes for identical root container spec, got: %+v", diff)
+	}
+	if diff.RootContainerChanged {
+		t.Errorf("expected RootContainerChanged=false for identical root, got true")
+	}
+}
+
 // TestDiffContainer_RootStillBreaking ensures the single-container
 // reconcile path (ReconcileContainer) keeps the breaking-change
 // classification for root containers — the rootContainer flag flows

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -369,8 +369,17 @@ func ReconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, err
 		return result, nil
 	}
 
-	// Check for breaking changes (root container spec change)
-	if diff.RootContainerChanged {
+	// Check for breaking changes (root container spec change). Only
+	// Breaking-on-root edits route through RecreateCell — Compatible-on-root
+	// fields (env, ports, volumes, securityOpts, secrets, repos) toggle
+	// `RootContainerChanged` so the diff surfaces them under
+	// `rootContainer.<field>`, but they can be re-evaluated at start or
+	// rebuilt from spec by UpdateCell and must not force a kill-and-recreate.
+	// The companion gate at internal/controller/runner/spec_hash_test.go's
+	// `TestSpecHashDomainPinsToDiffCellBreakingFields` keeps this AND in
+	// lockstep with the spec-hash domain so the apply layer and StartCell
+	// agree on which root edits are destructive.
+	if diff.RootContainerChanged && diff.ChangeType == ChangeTypeBreaking {
 		// Recreate cell with new root container spec
 		recreated, recreateErr := r.RecreateCell(desired)
 		if recreateErr != nil {

--- a/internal/controller/apply/reconcile_test.go
+++ b/internal/controller/apply/reconcile_test.go
@@ -1,0 +1,164 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apply_test
+
+import (
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/controller/apply"
+	"github.com/eminwux/kukeon/internal/controller/runner"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// reconcileFakeRunner is a focused fake satisfying runner.Runner for
+// ReconcileCell's root-container branch tests. The embedded interface is
+// nil, so any method not overridden here nil-derefs — that is intentional:
+// the test asserts which methods ReconcileCell calls *and* which it does
+// not, and an unexpected call surfaces as a panic the test catches.
+type reconcileFakeRunner struct {
+	runner.Runner
+
+	cellState intmodel.Cell
+
+	updateCellCalled   bool
+	recreateCellCalled bool
+}
+
+func (f *reconcileFakeRunner) GetRealm(realm intmodel.Realm) (intmodel.Realm, error) {
+	return realm, nil
+}
+
+func (f *reconcileFakeRunner) GetSpace(space intmodel.Space) (intmodel.Space, error) {
+	return space, nil
+}
+
+func (f *reconcileFakeRunner) GetStack(stack intmodel.Stack) (intmodel.Stack, error) {
+	return stack, nil
+}
+
+func (f *reconcileFakeRunner) GetCell(_ intmodel.Cell) (intmodel.Cell, error) {
+	return f.cellState, nil
+}
+
+func (f *reconcileFakeRunner) UpdateCell(cell intmodel.Cell) (intmodel.Cell, error) {
+	f.updateCellCalled = true
+	return cell, nil
+}
+
+func (f *reconcileFakeRunner) RecreateCell(cell intmodel.Cell) (intmodel.Cell, error) {
+	f.recreateCellCalled = true
+	return cell, nil
+}
+
+// TestReconcileCell_RootEnvCompatible_RoutesToUpdate pins the issue-#990
+// reconciler-gate fix: a Compatible-on-root edit (env) sets
+// `RootContainerChanged=true` so the diff readout qualifies the divergence
+// under `rootContainer.env`, but the reconciler must AND that flag with
+// `ChangeType == Breaking` before routing to RecreateCell. Without the AND,
+// `kuke apply -f` of an env edit on the root container triggers a full
+// kill-and-recreate, contradicting the PR's stated Compatible-on-root
+// semantics ("re-evaluated at start or rebuilt from spec") and the
+// `TestDiffCell_RootContainerEnv_Compatible` docstring ("not forced through
+// RecreateCell"). The companion gate at
+// `internal/controller/runner/spec_hash_test.go:252` already uses
+// `diff.RootContainerChanged && diff.ChangeType == ChangeTypeBreaking`;
+// the apply layer's reconciler must match.
+func TestReconcileCell_RootEnvCompatible_RoutesToUpdate(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest", Env: []string{"FOO=new"}},
+			},
+		},
+	}
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest", Env: []string{"FOO=old"}},
+			},
+		},
+	}
+
+	r := &reconcileFakeRunner{cellState: actual}
+	result, err := apply.ReconcileCell(r, desired)
+	if err != nil {
+		t.Fatalf("ReconcileCell returned unexpected error: %v", err)
+	}
+
+	if r.recreateCellCalled {
+		t.Error("Compatible-on-root env edit must not route through RecreateCell")
+	}
+	if !r.updateCellCalled {
+		t.Error("Compatible-on-root env edit must route through UpdateCell")
+	}
+	if result.Action != "updated" {
+		t.Errorf("expected result.Action=updated, got %q", result.Action)
+	}
+}
+
+// TestReconcileCell_RootImageBreaking_RoutesToRecreate is the positive
+// counterpart: a Breaking-on-root edit (image) must still route through
+// RecreateCell — the AND gate added for the Compatible case must not
+// regress the existing Breaking path.
+func TestReconcileCell_RootImageBreaking_RoutesToRecreate(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:1.36"},
+			},
+		},
+	}
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:1.35"},
+			},
+		},
+	}
+
+	r := &reconcileFakeRunner{cellState: actual}
+	result, err := apply.ReconcileCell(r, desired)
+	if err != nil {
+		t.Fatalf("ReconcileCell returned unexpected error: %v", err)
+	}
+
+	if !r.recreateCellCalled {
+		t.Error("Breaking-on-root image edit must route through RecreateCell")
+	}
+	if r.updateCellCalled {
+		t.Error("Breaking-on-root image edit must not also fall through to UpdateCell")
+	}
+	if result.Action != "updated" {
+		t.Errorf("expected result.Action=updated, got %q", result.Action)
+	}
+}

--- a/internal/controller/runner/spec_hash.go
+++ b/internal/controller/runner/spec_hash.go
@@ -41,19 +41,45 @@ const SpecHashLabelKey = "kukeon.io/spec-hash"
 // containerSpecHashPayload is the deterministic projection of an
 // intmodel.ContainerSpec that ComputeContainerSpecHash hashes. The field set
 // must match exactly what `apply.DiffCell` classifies as "requires containerd
-// recreate" — today that is image/command/args (the domain
-// `rootContainerSpecChanged` and `containerSpecChanged` both branch on). The
+// recreate" — the Breaking-on-root domain of `diffContainerSpec`. The
 // `TestSpecHashDomainPinsToDiffCellBreakingFields` test pins the two
-// definitions together so they cannot silently drift apart. Issue #867
-// AC #5 / #6.
+// definitions together so they cannot silently drift apart. Issues #867,
+// #990.
 //
 // Args is normalized to a non-nil empty slice on the in-payload side so a
 // nil-vs-empty distinction in the source spec does not change the hash —
-// containerd treats both as "no args".
+// containerd treats both as "no args". The Capabilities, Tmpfs, and
+// Resources projections normalize nil pointers / slices to zero values so
+// "field unset" and "field set to its zero value" hash identically
+// (matches the equality semantics in `internal/controller/apply/diff.go`'s
+// `capabilitiesEqual`, `tmpfsEqual`, and `resourcesEqual`).
 type containerSpecHashPayload struct {
-	Image   string   `json:"image"`
-	Command string   `json:"command"`
-	Args    []string `json:"args"`
+	Image                  string                  `json:"image"`
+	Command                string                  `json:"command"`
+	Args                   []string                `json:"args"`
+	Privileged             bool                    `json:"privileged"`
+	User                   string                  `json:"user"`
+	ReadOnlyRootFilesystem bool                    `json:"readOnlyRootFilesystem"`
+	Capabilities           capabilitiesHashPayload `json:"capabilities"`
+	Tmpfs                  []tmpfsHashPayload      `json:"tmpfs"`
+	Resources              resourcesHashPayload    `json:"resources"`
+}
+
+type capabilitiesHashPayload struct {
+	Add  []string `json:"add"`
+	Drop []string `json:"drop"`
+}
+
+type tmpfsHashPayload struct {
+	Path      string   `json:"path"`
+	SizeBytes int64    `json:"sizeBytes"`
+	Options   []string `json:"options"`
+}
+
+type resourcesHashPayload struct {
+	MemoryLimitBytes int64 `json:"memoryLimitBytes"`
+	CPUShares        int64 `json:"cpuShares"`
+	PidsLimit        int64 `json:"pidsLimit"`
 }
 
 // ComputeContainerSpecHash returns a hex-encoded SHA-256 over the
@@ -61,20 +87,72 @@ type containerSpecHashPayload struct {
 // containerd access. Same hash for root and non-root containers — the
 // domain is identical (see containerSpecHashPayload).
 func ComputeContainerSpecHash(spec intmodel.ContainerSpec) string {
-	args := spec.Args
-	if args == nil {
-		args = []string{}
-	}
 	payload := containerSpecHashPayload{
-		Image:   spec.Image,
-		Command: spec.Command,
-		Args:    args,
+		Image:                  spec.Image,
+		Command:                spec.Command,
+		Args:                   normalizeStrings(spec.Args),
+		Privileged:             spec.Privileged,
+		User:                   spec.User,
+		ReadOnlyRootFilesystem: spec.ReadOnlyRootFilesystem,
+		Capabilities:           projectCapabilities(spec.Capabilities),
+		Tmpfs:                  projectTmpfs(spec.Tmpfs),
+		Resources:              projectResources(spec.Resources),
 	}
 	// json.Marshal on a struct with a fixed field order is deterministic.
-	// Errors are not possible here (payload is plain strings + []string).
+	// Errors are not possible here (payload is plain comparable types).
 	buf, _ := json.Marshal(payload)
 	sum := sha256.Sum256(buf)
 	return hex.EncodeToString(sum[:])
+}
+
+// normalizeStrings replaces a nil slice with a non-nil empty slice so the
+// JSON projection produces `[]` rather than `null` regardless of source
+// nilness.
+func normalizeStrings(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func projectCapabilities(c *intmodel.ContainerCapabilities) capabilitiesHashPayload {
+	if c == nil {
+		return capabilitiesHashPayload{Add: []string{}, Drop: []string{}}
+	}
+	return capabilitiesHashPayload{
+		Add:  normalizeStrings(c.Add),
+		Drop: normalizeStrings(c.Drop),
+	}
+}
+
+func projectTmpfs(t []intmodel.ContainerTmpfsMount) []tmpfsHashPayload {
+	out := make([]tmpfsHashPayload, len(t))
+	for i := range t {
+		out[i] = tmpfsHashPayload{
+			Path:      t[i].Path,
+			SizeBytes: t[i].SizeBytes,
+			Options:   normalizeStrings(t[i].Options),
+		}
+	}
+	return out
+}
+
+func projectResources(r *intmodel.ContainerResources) resourcesHashPayload {
+	if r == nil {
+		return resourcesHashPayload{}
+	}
+	return resourcesHashPayload{
+		MemoryLimitBytes: derefInt64(r.MemoryLimitBytes),
+		CPUShares:        derefInt64(r.CPUShares),
+		PidsLimit:        derefInt64(r.PidsLimit),
+	}
+}
+
+func derefInt64(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
 }
 
 // stampSpecHashOnLabels writes the SpecHashLabelKey into labels (allocating

--- a/internal/controller/runner/spec_hash_test.go
+++ b/internal/controller/runner/spec_hash_test.go
@@ -72,11 +72,13 @@ func TestComputeContainerSpecHash_NilEmptyArgsEqual(t *testing.T) {
 	}
 }
 
-// TestComputeContainerSpecHash_ImageCmdArgsChangeHash locks that each
-// breaking-domain field independently changes the hash. A field accidentally
+// TestComputeContainerSpecHash_BreakingFieldsChangeHash locks that each
+// Breaking-on-root field independently changes the hash. A field accidentally
 // dropped from containerSpecHashPayload would silently let a drifted CellSpec
-// pass the StartCell guard.
-func TestComputeContainerSpecHash_ImageCmdArgsChangeHash(t *testing.T) {
+// pass the StartCell guard. The set mirrors `apply.DiffCell`'s Breaking-on-root
+// classification — see `diffContainerSpec` in
+// `internal/controller/apply/diff.go`. Issues #867, #990.
+func TestComputeContainerSpecHash_BreakingFieldsChangeHash(t *testing.T) {
 	base := intmodel.ContainerSpec{
 		Image:   "alpine:1.0",
 		Command: "sleep",
@@ -91,6 +93,19 @@ func TestComputeContainerSpecHash_ImageCmdArgsChangeHash(t *testing.T) {
 		{"image", func(s *intmodel.ContainerSpec) { s.Image = "alpine:2.0" }},
 		{"command", func(s *intmodel.ContainerSpec) { s.Command = "echo" }},
 		{"args", func(s *intmodel.ContainerSpec) { s.Args = []string{"120"} }},
+		{"privileged", func(s *intmodel.ContainerSpec) { s.Privileged = true }},
+		{"user", func(s *intmodel.ContainerSpec) { s.User = "nobody" }},
+		{"readOnlyRootFilesystem", func(s *intmodel.ContainerSpec) { s.ReadOnlyRootFilesystem = true }},
+		{"capabilities", func(s *intmodel.ContainerSpec) {
+			s.Capabilities = &intmodel.ContainerCapabilities{Add: []string{"CAP_NET_ADMIN"}}
+		}},
+		{"tmpfs", func(s *intmodel.ContainerSpec) {
+			s.Tmpfs = []intmodel.ContainerTmpfsMount{{Path: "/tmp", SizeBytes: 1 << 20}}
+		}},
+		{"resources", func(s *intmodel.ContainerSpec) {
+			limit := int64(64 << 20)
+			s.Resources = &intmodel.ContainerResources{MemoryLimitBytes: &limit}
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -105,9 +120,9 @@ func TestComputeContainerSpecHash_ImageCmdArgsChangeHash(t *testing.T) {
 
 // TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash locks that
 // fields `apply.DiffCell` classifies as Compatible (env, ports, volumes,
-// privileged, user, capabilities, resources, ...) are *not* part of the hash.
-// Hashing them would force a recreate-or-refuse on every `kuke apply -f` that
-// only tweaked a compatible field, defeating the in-place UpdateCell path the
+// securityOpts, secrets, repos) are *not* part of the hash. Hashing them
+// would force a recreate-or-refuse on every `kuke apply -f` that only
+// tweaked a compatible field, defeating the in-place UpdateCell path the
 // apply layer already exercises for those fields.
 func TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash(t *testing.T) {
 	base := intmodel.ContainerSpec{
@@ -126,9 +141,15 @@ func TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash(t *testing.T) 
 		{"volumes", func(s *intmodel.ContainerSpec) {
 			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
 		}},
-		{"privileged", func(s *intmodel.ContainerSpec) { s.Privileged = true }},
-		{"user", func(s *intmodel.ContainerSpec) { s.User = "nobody" }},
-		{"readonly", func(s *intmodel.ContainerSpec) { s.ReadOnlyRootFilesystem = true }},
+		{"securityOpts", func(s *intmodel.ContainerSpec) {
+			s.SecurityOpts = []string{"no-new-privileges"}
+		}},
+		{"secrets", func(s *intmodel.ContainerSpec) {
+			s.Secrets = []intmodel.ContainerSecret{{Name: "db", FromEnv: "DB_PASS"}}
+		}},
+		{"repos", func(s *intmodel.ContainerSpec) {
+			s.Repos = []intmodel.ContainerRepo{{Name: "app", URL: "https://example.com/app.git", Target: "/src"}}
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -155,8 +176,9 @@ func TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash(t *testing.T) 
 // container, ComputeContainerSpecHash on the two root specs must differ. If
 // DiffCell reports Compatible or no change, ComputeContainerSpecHash must
 // match (the apply layer handles it in place, so the hash must not force a
-// refuse). Mirrors `apply.DiffCell`'s root-side `rootContainerSpecChanged`
-// branch in `internal/controller/apply/diff.go`.
+// refuse). Mirrors `apply.DiffCell`'s root-side classification — see
+// `diffContainerSpec`'s per-field Breaking-vs-Compatible calls in
+// `internal/controller/apply/diff.go`. Issues #867, #990.
 func TestSpecHashDomainPinsToDiffCellBreakingFields(t *testing.T) {
 	makeCell := func(root intmodel.ContainerSpec) intmodel.Cell {
 		root.Root = true
@@ -188,16 +210,32 @@ func TestSpecHashDomainPinsToDiffCellBreakingFields(t *testing.T) {
 		{"image", func(s *intmodel.ContainerSpec) { s.Image = "alpine:2.0" }, true},
 		{"command", func(s *intmodel.ContainerSpec) { s.Command = "echo" }, true},
 		{"args", func(s *intmodel.ContainerSpec) { s.Args = []string{"120"} }, true},
+		{"privileged", func(s *intmodel.ContainerSpec) { s.Privileged = true }, true},
+		{"user", func(s *intmodel.ContainerSpec) { s.User = "nobody" }, true},
+		{"readOnlyRootFilesystem", func(s *intmodel.ContainerSpec) { s.ReadOnlyRootFilesystem = true }, true},
+		{"capabilities", func(s *intmodel.ContainerSpec) {
+			s.Capabilities = &intmodel.ContainerCapabilities{Add: []string{"CAP_NET_ADMIN"}}
+		}, true},
+		{"tmpfs", func(s *intmodel.ContainerSpec) {
+			s.Tmpfs = []intmodel.ContainerTmpfsMount{{Path: "/tmp", SizeBytes: 1 << 20}}
+		}, true},
+		{"resources", func(s *intmodel.ContainerSpec) {
+			limit := int64(64 << 20)
+			s.Resources = &intmodel.ContainerResources{MemoryLimitBytes: &limit}
+		}, true},
 		// Compatible domain — must NOT change the hash.
 		{"env", func(s *intmodel.ContainerSpec) { s.Env = []string{"FOO=bar"} }, false},
 		{"ports", func(s *intmodel.ContainerSpec) { s.Ports = []string{"8080:80"} }, false},
 		{"volumes", func(s *intmodel.ContainerSpec) {
 			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
 		}, false},
-		{"privileged", func(s *intmodel.ContainerSpec) { s.Privileged = true }, false},
-		{"user", func(s *intmodel.ContainerSpec) { s.User = "nobody" }, false},
-		{"readOnlyRootFilesystem", func(s *intmodel.ContainerSpec) { s.ReadOnlyRootFilesystem = true }, false},
 		{"securityOpts", func(s *intmodel.ContainerSpec) { s.SecurityOpts = []string{"no-new-privileges"} }, false},
+		{"secrets", func(s *intmodel.ContainerSpec) {
+			s.Secrets = []intmodel.ContainerSecret{{Name: "db", FromEnv: "DB_PASS"}}
+		}, false},
+		{"repos", func(s *intmodel.ContainerSpec) {
+			s.Repos = []intmodel.ContainerRepo{{Name: "app", URL: "https://example.com/app.git", Target: "/src"}}
+		}, false},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Closes #990. Before this, `DiffCell`'s root-container path routed through a 3-field `rootContainerSpecChanged(image, command, args)` comparator and silently dropped every other user-authored edit — Env, Volumes, Privileged, User, ReadOnlyRootFilesystem, Capabilities, SecurityOpts, Tmpfs, Resources, Secrets, Repos. Operators editing `spec.containers[<root>]` on a Config-lineage cell got a clean "in sync" verdict on every change except image/command/args.
- Replaces the 3-field comparator with `diffContainerSpec(rootContainer=true)`, threading per-field Breaking-vs-Compatible classification through the same comparator non-root containers use. Each new field call site carries an inline classification comment (AC #3).
- Qualifies each root-container divergence with a `rootContainer.<field>` prefix on `BreakingChanges` / `ChangedFields`, so `OutOfSyncReason` populates with the changed field name on a Config-lineage cell whose root drifts from materialized spec (AC #4) and distinguishes root drift from same-named drift on a child container (`containers[<id>].<field>`).
- Widens `containerSpecHashPayload` to include the new Breaking-on-root fields (`privileged`, `user`, `readOnlyRootFilesystem`, `capabilities`, `tmpfs`, `resources`). `TestSpecHashDomainPinsToDiffCellBreakingFields` is the regression guard that keeps the spec-hash domain in lockstep with the apply layer (issue #867); the test's own comment anticipates this update.
- Tightens the reconciler gate at `internal/controller/apply/reconcile.go` so `RecreateCell` only fires on `RootContainerChanged && ChangeType == Breaking` — matching the spec-hash test's existing gate. Without the AND, a Compatible-on-root edit (env, ports, volumes, securityOpts, secrets, repos) toggles `RootContainerChanged=true` for diff-readout purposes but would have triggered a full kill-and-recreate, contradicting the PR's stated Compatible-on-root semantics. New `TestReconcileCell_RootEnvCompatible_RoutesToUpdate` pins env-on-root to the UpdateCell branch; `TestReconcileCell_RootImageBreaking_RoutesToRecreate` pins image-on-root to RecreateCell so the AND doesn't regress the Breaking path.

### Design call: Breaking vs Compatible on root

The issue body proposes a split but explicitly notes "the split needs a design decision". The lower-blast-radius classification I shipped:

- **Breaking on root** (cannot in-place update — baked into the cell's OCI runtime spec at StartCell): `image`, `command`, `args`, `privileged`, `user`, `readOnlyRootFilesystem`, `capabilities`, `tmpfs`, `resources`.
- **Compatible on root** (re-evaluated at start or rebuilt from spec): `env`, `ports`, `volumes`, `securityOpts`, `secrets`, `repos`.

The issue's proposal listed `volumes` and `securityOpts` only in the "silently lost edits" set without explicitly classifying them; this PR keeps them Compatible on root for now (drift is at least detected, recreate cost avoided). If runner-side UpdateCell gaps surface on `volumes`/`securityOpts` for root containers, a follow-up can widen the Breaking-on-root set without further changes to the apply layer.

### Out of scope (per the issue body)

- Runtime-only fields stamped by the runner (`CellCgroupPath`, `EtcHostsPath`, `EtcHostnamePath`).
- Companion `diffContainerSpec` gaps for `WorkingDir` / host namespaces / networking (sibling issue).
- Cell-level `Spec.Tty` / `Spec.AutoDelete` / `Spec.NestedCgroupRuntime` (PR #999, issue #992).

## Test plan

- [x] `GOWORK=off GOTOOLCHAIN=go1.24.5 go test $(go list ./... | grep -v /e2e)` — full project test target, all packages pass.
- [x] `GOWORK=off GOTOOLCHAIN=go1.24.5 go vet ./...` — clean.
- [x] `pre-commit run --files <changed>` — go-fmt, go-mod-tidy, golangci-lint, addlicense all pass.
- [x] New `TestDiffCell_RootContainerPrivileged_Breaking` (Breaking-on-root field), `TestDiffCell_RootContainerEnv_Compatible` (Compatible-on-root field), `TestDiffCell_RootContainer_NoDriftOnEqualSpec` (no false-positive regression).
- [x] Updated `TestSpecHashDomainPinsToDiffCellBreakingFields` and `TestComputeContainerSpecHash_{BreakingFieldsChangeHash,CompatibleFieldsDoNotChangeHash}` to reflect the widened Breaking-on-root domain.
- [x] New `TestReconcileCell_RootEnvCompatible_RoutesToUpdate` (asserts RecreateCell is *not* called for env-on-root, UpdateCell *is*) and `TestReconcileCell_RootImageBreaking_RoutesToRecreate` (asserts the Breaking path stays on RecreateCell).
- [ ] `make dev-init` smoke — not executed; no daemon code path touched (this is a pure apply-layer + spec-hash change), no `/opt/kukeon` or runner-build path change. The unit tests above pin the behavior end-to-end against the persisted-status consumer (`reconcileCellOutOfSync` via the existing OutOfSync test suite — all 8 still pass).

Closes #990