### PR TITLE
refactor(api): rename CellProfileParameter to CellBlueprintParameter

### DIFF
--- a/cmd/kuke/create/cell/cell_test.go
+++ b/cmd/kuke/create/cell/cell_test.go
@@ -614,7 +614,7 @@ func blueprintDoc() v1beta1.CellBlueprintDoc {
 		},
 		Spec: v1beta1.CellBlueprintSpec{
 			Prefix:     "web",
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Parameters: []v1beta1.CellBlueprintParameter{{Name: "TAG", Default: &def}},
 			Cell: v1beta1.BlueprintCellSpec{
 				Containers: []v1beta1.BlueprintContainer{
 					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},

--- a/cmd/kuke/create/config/config.go
+++ b/cmd/kuke/create/config/config.go
@@ -206,7 +206,7 @@ func emitConfigYAML(out io.Writer, configName, realm, space, stack string, bp *v
 	return err
 }
 
-func writeValues(b *strings.Builder, params []v1beta1.CellProfileParameter) {
+func writeValues(b *strings.Builder, params []v1beta1.CellBlueprintParameter) {
 	if len(params) == 0 {
 		b.WriteString("  values: {}\n")
 		return

--- a/cmd/kuke/create/config/config_test.go
+++ b/cmd/kuke/create/config/config_test.go
@@ -177,7 +177,7 @@ func TestNewConfigCmd_EmitsParsableYAML(t *testing.T) {
 			blueprint: v1beta1.CellBlueprintDoc{
 				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
 				Spec: v1beta1.CellBlueprintSpec{
-					Parameters: []v1beta1.CellProfileParameter{
+					Parameters: []v1beta1.CellBlueprintParameter{
 						{Name: "TOKEN", Required: true},
 					},
 					Cell: v1beta1.BlueprintCellSpec{
@@ -192,7 +192,7 @@ func TestNewConfigCmd_EmitsParsableYAML(t *testing.T) {
 			blueprint: v1beta1.CellBlueprintDoc{
 				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
 				Spec: v1beta1.CellBlueprintSpec{
-					Parameters: []v1beta1.CellProfileParameter{
+					Parameters: []v1beta1.CellBlueprintParameter{
 						{Name: "PORT", Default: ptr("5432")},
 						{Name: "ENV", Default: ptr("production")},
 						{Name: "TAGS", Default: ptr("a,b c")},
@@ -209,7 +209,7 @@ func TestNewConfigCmd_EmitsParsableYAML(t *testing.T) {
 			blueprint: v1beta1.CellBlueprintDoc{
 				Metadata: v1beta1.CellBlueprintMetadata{Name: "bp", Realm: "r1"},
 				Spec: v1beta1.CellBlueprintSpec{
-					Parameters: []v1beta1.CellProfileParameter{
+					Parameters: []v1beta1.CellBlueprintParameter{
 						{Name: "EXTRA"},
 					},
 					Cell: v1beta1.BlueprintCellSpec{

--- a/cmd/kuke/run/divergence_idempotency_test.go
+++ b/cmd/kuke/run/divergence_idempotency_test.go
@@ -198,7 +198,7 @@ func minimalBlueprintForDivergence() v1beta1.CellBlueprintDoc {
 		Kind:       v1beta1.KindCellBlueprint,
 		Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "bp-realm"},
 		Spec: v1beta1.CellBlueprintSpec{
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Parameters: []v1beta1.CellBlueprintParameter{{Name: "TAG", Default: &def}},
 			Cell: v1beta1.BlueprintCellSpec{
 				Containers: []v1beta1.BlueprintContainer{
 					{ID: "root", Root: true, Image: "registry.example.com/root:latest"},
@@ -228,7 +228,7 @@ func richBlueprintForDivergence() v1beta1.CellBlueprintDoc {
 		Kind:       v1beta1.KindCellBlueprint,
 		Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "bp-realm"},
 		Spec: v1beta1.CellBlueprintSpec{
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Parameters: []v1beta1.CellBlueprintParameter{{Name: "TAG", Default: &def}},
 			Cell: v1beta1.BlueprintCellSpec{
 				Containers: []v1beta1.BlueprintContainer{
 					{ID: "root", Root: true, Image: "registry.example.com/root:latest"},

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -2417,7 +2417,7 @@ func blueprintDoc() v1beta1.CellBlueprintDoc {
 		},
 		Spec: v1beta1.CellBlueprintSpec{
 			Prefix:     "web",
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Parameters: []v1beta1.CellBlueprintParameter{{Name: "TAG", Default: &def}},
 			Cell: v1beta1.BlueprintCellSpec{
 				Containers: []v1beta1.BlueprintContainer{
 					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
@@ -2531,7 +2531,7 @@ func configBlueprintDoc() v1beta1.CellBlueprintDoc {
 			Realm: "bp-realm",
 		},
 		Spec: v1beta1.CellBlueprintSpec{
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Parameters: []v1beta1.CellBlueprintParameter{{Name: "TAG", Default: &def}},
 			Cell: v1beta1.BlueprintCellSpec{
 				Containers: []v1beta1.BlueprintContainer{
 					{

--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -90,7 +90,7 @@ func resolveValues(
 	cliParams map[string]string,
 	lookupEnv func(string) (string, bool),
 ) (map[string]string, error) {
-	declared := make(map[string]v1beta1.CellProfileParameter, len(doc.Spec.Parameters))
+	declared := make(map[string]v1beta1.CellBlueprintParameter, len(doc.Spec.Parameters))
 	for _, p := range doc.Spec.Parameters {
 		declared[p.Name] = p
 	}

--- a/internal/cellblueprint/cellblueprint_test.go
+++ b/internal/cellblueprint/cellblueprint_test.go
@@ -44,7 +44,7 @@ func baseDoc() v1beta1.CellBlueprintDoc {
 		},
 		Spec: v1beta1.CellBlueprintSpec{
 			Prefix: "web",
-			Parameters: []v1beta1.CellProfileParameter{
+			Parameters: []v1beta1.CellBlueprintParameter{
 				{Name: "TAG", Default: strptr("latest")},
 			},
 			Cell: v1beta1.BlueprintCellSpec{
@@ -82,7 +82,7 @@ func TestResolve_CliParamWins(t *testing.T) {
 
 func TestResolve_EnvFallback(t *testing.T) {
 	doc := baseDoc()
-	doc.Spec.Parameters = []v1beta1.CellProfileParameter{{Name: "TAG"}} // no default
+	doc.Spec.Parameters = []v1beta1.CellBlueprintParameter{{Name: "TAG"}} // no default
 	lookup := func(k string) (string, bool) {
 		if k == "TAG" {
 			return "from-env", true
@@ -107,7 +107,7 @@ func TestResolve_UndeclaredParamErrors(t *testing.T) {
 
 func TestResolve_RequiredUnsetErrors(t *testing.T) {
 	doc := baseDoc()
-	doc.Spec.Parameters = []v1beta1.CellProfileParameter{{Name: "TAG", Required: true}}
+	doc.Spec.Parameters = []v1beta1.CellBlueprintParameter{{Name: "TAG", Required: true}}
 	_, err := cellblueprint.Resolve(doc, nil, nil)
 	if !errors.Is(err, errdefs.ErrBlueprintInvalid) {
 		t.Fatalf("err = %v, want ErrBlueprintInvalid for required-unset param", err)

--- a/internal/cellconfig/materialize_test.go
+++ b/internal/cellconfig/materialize_test.go
@@ -38,7 +38,7 @@ func minimalBlueprint() v1beta1.CellBlueprintDoc {
 			Realm: "bp-realm",
 		},
 		Spec: v1beta1.CellBlueprintSpec{
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Default: &def}},
+			Parameters: []v1beta1.CellBlueprintParameter{{Name: "TAG", Default: &def}},
 			Cell: v1beta1.BlueprintCellSpec{
 				Containers: []v1beta1.BlueprintContainer{{
 					ID:    "main",
@@ -287,7 +287,7 @@ func TestMaterialize_PropagatesResolveError(t *testing.T) {
 		Kind:       v1beta1.KindCellBlueprint,
 		Metadata:   v1beta1.CellBlueprintMetadata{Name: "web", Realm: "bp-realm"},
 		Spec: v1beta1.CellBlueprintSpec{
-			Parameters: []v1beta1.CellProfileParameter{{Name: "TAG", Required: true}},
+			Parameters: []v1beta1.CellBlueprintParameter{{Name: "TAG", Required: true}},
 			Cell: v1beta1.BlueprintCellSpec{
 				Containers: []v1beta1.BlueprintContainer{{ID: "main", Image: "${TAG}"}},
 			},

--- a/pkg/api/model/v1beta1/cellblueprint.go
+++ b/pkg/api/model/v1beta1/cellblueprint.go
@@ -24,9 +24,8 @@ package v1beta1
 //
 // A Blueprint declares two fill channels (see #423 "L1↔L2 interface"):
 //
-//  1. Scalar parameters — `${KEY}` substitution using the CellProfileParameter
-//     shape (the name predates #626's CellProfile removal; the struct is now
-//     blueprint-only). Filled inline by `kuke run -b --param K=V`.
+//  1. Scalar parameters — `${KEY}` substitution using the CellBlueprintParameter
+//     shape. Filled inline by `kuke run -b --param K=V`.
 //  2. Structural slots — named repo/secret slots on each container that a
 //     CellConfig fills with structured values (repo URLs, secret sources).
 //     This kind ships the slot *declarations* only; the Config-side fill
@@ -64,27 +63,29 @@ type CellBlueprintMetadata struct {
 // metadata.name. Every run produces a fresh hex-suffixed cell — the
 // "Blueprint = always fresh" invariant.
 type CellBlueprintSpec struct {
-	Prefix     string                 `json:"prefix,omitempty"     yaml:"prefix,omitempty"`
-	Parameters []CellProfileParameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	Cell       BlueprintCellSpec      `json:"cell"                 yaml:"cell"`
+	Prefix     string                   `json:"prefix,omitempty"     yaml:"prefix,omitempty"`
+	Parameters []CellBlueprintParameter `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Cell       BlueprintCellSpec        `json:"cell"                 yaml:"cell"`
 }
 
-// CellProfileParameter declares one `${KEY}` substitution variable used by a
+// CellBlueprintParameter declares one `${KEY}` substitution variable used by a
 // CellBlueprint's body. Default is a pointer so YAML/JSON can distinguish "no
 // default" (nil) from an explicit empty default (""). The substitution engine
 // treats them differently: a missing default falls through to the env-var
 // lookup, while an explicit empty default short-circuits there.
-//
-// The name keeps its "CellProfile" prefix from before #626 removed the
-// CellProfile kind — the struct is now blueprint-only but renaming it would
-// break sibling projects (sbsh, sbcrew, …) that import this package. The
-// type's role moved; the wire identifier stayed put.
-type CellProfileParameter struct {
+type CellBlueprintParameter struct {
 	Name        string  `json:"name"                  yaml:"name"`
 	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Default     *string `json:"default,omitempty"     yaml:"default,omitempty"`
 	Required    bool    `json:"required,omitempty"    yaml:"required,omitempty"`
 }
+
+// CellProfileParameter is the pre-#986 name for CellBlueprintParameter, kept as
+// a deprecated alias for one release so sibling projects (sbsh, sbcrew, …) can
+// rename on their own cadence. The on-wire YAML/JSON shape is unchanged.
+//
+// Deprecated: use CellBlueprintParameter. Scheduled for removal in v0.7.0.
+type CellProfileParameter = CellBlueprintParameter
 
 // BlueprintCellSpec is the cell template body of a CellBlueprint. It mirrors
 // the runtime CellSpec's user-authorable surface but is a deliberately


### PR DESCRIPTION
## Summary

- Rename the Go identifier `CellProfileParameter` → `CellBlueprintParameter` in `pkg/api/model/v1beta1/cellblueprint.go`, drop the `// The name keeps its 'CellProfile' prefix` apology from the type comment, and update the prose reference at line 27.
- Update every in-repo call site (controller, materializer, parser, tests, `cmd/kuke/create/config/config.go:writeValues`) — 9 files total, including `cmd/kuke/run/divergence_idempotency_test.go` which the issue body did not enumerate (count drifted from 8 → 9 since filing; intent unchanged).
- **Migration choice: option (a) one-release deprecated alias.** Keep `type CellProfileParameter = CellBlueprintParameter` with a `// Deprecated:` doc comment in `pkg/api/model/v1beta1/cellblueprint.go` so sibling projects (sbsh, sbcrew, …) can rename on their own cadence. The deprecation comment names **v0.7.0** as the removal release (latest tag is v0.5.0, so the alias survives the v0.6.0 release window and is dropped before v0.7.0). Lower-blast-radius default per CLAUDE.md §Default mode.
- On-wire YAML/JSON for `CellBlueprintSpec.parameters[]` is unchanged: there is no kind discriminator on the struct, the field is referenced positionally, and the alias is a Go-side type identity (same wire shape, same JSON tags).

## Test plan

- [x] `GOTOOLCHAIN=go1.24.5 make test-root` — all packages green (root module's go.mod pins go 1.24.5; the host's Go 1.25.5 trips a pre-existing pre-existing `containerd/cgroups/v2` typing break on `main` itself, recoverable via the go.mod-required toolchain per CLAUDE.md §When the project's CI test target's toolchain isn't installed; CI uses `go-version-file: go.mod` so the green run reproduces in CI).
- [x] `GOTOOLCHAIN=go1.24.5 GOWORK=off go vet ./...` — clean.
- [x] `grep -rn 'CellProfileParameter' .` — only two matches, both in the deprecated-alias declaration in `pkg/api/model/v1beta1/cellblueprint.go` (doc comment + `type` line).
- [x] `gofmt -l pkg/api/model/v1beta1/cellblueprint.go internal/...` on touched files — clean.
- [ ] `make dev-init` smoke — not exercised; the rename is Go-source-identity-only with no wire-format, daemon, or `/opt/kukeon` impact. The two-realm tail wouldn't surface anything this PR could break.

Closes #986