### PR TITLE
fix(runner): gate wind-down/auto-delete on per-container RestartPolicy

### DIFF
--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -85,11 +85,24 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 | `repos`           | array of `ContainerRepo`   | no       | Git repos the kuketty wrapper clones before the workload starts — requires `attachable: true` (see [ContainerRepo](#containerrepo))                    |
 | `git`             | `ContainerGit`             | no       | Declarative git identity + signing, expanded into `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`GIT_CONFIG_*` env before start (see [ContainerGit](#containergit)) |
 | `cniConfigPath`   | string                     | no       | Override the CNI config directory for this container                                                                                                   |
-| `restartPolicy`   | string                     | no       | Restart policy. Reserved — restart semantics are not finalized.                                                                                        |
+| `restartPolicy`   | string                     | no       | Per-container reap policy at the cell wind-down / auto-delete gate. One of `always`, `on-failure`, `never`. Empty defaults to `always` for back-compat (see [Restart policy](#restart-policy)). |
 | `tty`             | `ContainerTty`             | no       | Shell-UX config for the kuketty wrapper (prompt, init scripts, logging) — requires `attachable: true` (see [ContainerTty](#containertty))              |
 
 !!! warning "Fields marked reserved"
-`ports` and `restartPolicy` are accepted by the schema today but their semantics are still being designed. Values round-trip (you can read back what you applied), but the controller does not act on them. See [GitHub Issues](https://github.com/eminwux/kukeon/issues) for the backlog.
+`ports` is accepted by the schema today but its semantics are still being designed. Values round-trip (you can read back what you applied), but the controller does not act on them. See [GitHub Issues](https://github.com/eminwux/kukeon/issues) for the backlog.
+
+### Restart policy
+
+`spec.restartPolicy` selects whether the cell wind-down / auto-delete reconciler reaps a cell after one of its non-root containers exits. The runner evaluates the policy per container at the wind-down gate; the cell-level decision is the intersection across every terminally-exited non-root container, so a single `never` blocks the wind-down.
+
+| Value        | Behavior at wind-down                                                                                                                              |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| empty/unset  | Treated as `always` for back-compat. Pre-#1003 wind-down behavior — every non-root container exit can trigger a cell-level wind-down.              |
+| `always`     | Wind-down / auto-delete proceeds whenever the container terminally exits, regardless of exit code.                                                 |
+| `on-failure` | Wind-down / auto-delete proceeds only when the container's last exit code is non-zero. A zero-exit (clean shutdown) keeps the cell in place.       |
+| `never`      | Wind-down / auto-delete is skipped — the cell stays in `Stopped` until an operator tears it down explicitly (`kuke delete` / `kuke purge`).        |
+
+Only the root container is exempt: the root's exit drives cell-level lifecycle decisions independently and is not subject to this gate.
 
 ### VolumeMount
 

--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -28,39 +28,62 @@ import (
 	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
+// ContainerObservation bundles the slice of containerd task state the runner
+// needs to surface in ContainerStatus and drive lifecycle decisions: the
+// internal-state mapping plus the exit code reported by the task. ExitCode is
+// only meaningful on the TaskStatus-success branch — on every other branch
+// (NotCreated, ErrTaskNotFound, transient error, fallback Unknown) it stays
+// zero.
+type ContainerObservation struct {
+	State    intmodel.ContainerState
+	ExitCode int
+}
+
 // GetContainerState queries containerd for the actual task status of a container
-// and converts it to the internal ContainerState.
+// and converts it to the internal ContainerState. Thin wrapper around
+// GetContainerObservation for callers that only need the state column.
 func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmodel.ContainerState, error) {
+	obs, err := r.GetContainerObservation(cell, containerID)
+	return obs.State, err
+}
+
+// GetContainerObservation is GetContainerState plus the task's exit code.
+// Behaves identically on the existence/namespace/task-not-found edges so
+// callers can swap from GetContainerState without observability gaps; the
+// ExitCode field is only populated on the TaskStatus-success branch (every
+// other return path leaves it zero).
+func (r *Exec) GetContainerObservation(cell intmodel.Cell, containerID string) (ContainerObservation, error) {
 	containerID = strings.TrimSpace(containerID)
 	if containerID == "" {
-		return intmodel.ContainerStateUnknown, errors.New("container ID is required")
+		return ContainerObservation{State: intmodel.ContainerStateUnknown}, errors.New("container ID is required")
 	}
 
 	cellName := strings.TrimSpace(cell.Metadata.Name)
 	if cellName == "" {
-		return intmodel.ContainerStateUnknown, errdefs.ErrCellNotFound
+		return ContainerObservation{State: intmodel.ContainerStateUnknown}, errdefs.ErrCellNotFound
 	}
 
 	realmName := strings.TrimSpace(cell.Spec.RealmName)
 	if realmName == "" {
-		return intmodel.ContainerStateUnknown, errdefs.ErrRealmNameRequired
+		return ContainerObservation{State: intmodel.ContainerStateUnknown}, errdefs.ErrRealmNameRequired
 	}
 
 	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
 	if spaceName == "" {
-		return intmodel.ContainerStateUnknown, errdefs.ErrSpaceNameRequired
+		return ContainerObservation{State: intmodel.ContainerStateUnknown}, errdefs.ErrSpaceNameRequired
 	}
 
 	stackName := strings.TrimSpace(cell.Spec.StackName)
 	if stackName == "" {
-		return intmodel.ContainerStateUnknown, errdefs.ErrStackNameRequired
+		return ContainerObservation{State: intmodel.ContainerStateUnknown}, errdefs.ErrStackNameRequired
 	}
 
 	if err := r.ensureClientConnected(); err != nil {
 		r.logger.InfoContext(r.ctx, "failed to connect to containerd",
 			"container", containerID,
 			"error", err)
-		return intmodel.ContainerStateUnknown, fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+		return ContainerObservation{State: intmodel.ContainerStateUnknown},
+			fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
 	}
 
 	// Get realm to access namespace
@@ -75,7 +98,8 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"container", containerID,
 			"realm", realmName,
 			"error", err)
-		return intmodel.ContainerStateUnknown, fmt.Errorf("failed to get realm: %w", err)
+		return ContainerObservation{State: intmodel.ContainerStateUnknown},
+			fmt.Errorf("failed to get realm: %w", err)
 	}
 
 	namespace := internalRealm.Spec.Namespace
@@ -101,7 +125,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"container", containerID,
 			"cell", cellName,
 			"containersInCell", len(cell.Spec.Containers))
-		return intmodel.ContainerStateUnknown, nil
+		return ContainerObservation{State: intmodel.ContainerStateUnknown}, nil
 	}
 
 	// Get cell ID (use Spec.ID if available, otherwise fall back to Metadata.Name)
@@ -110,7 +134,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 		cellID = strings.TrimSpace(cell.Metadata.Name)
 	}
 	if cellID == "" {
-		return intmodel.ContainerStateUnknown, errdefs.ErrCellIDRequired
+		return ContainerObservation{State: intmodel.ContainerStateUnknown}, errdefs.ErrCellIDRequired
 	}
 
 	// Get containerd ID
@@ -132,7 +156,8 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			)
 		}
 		if err != nil {
-			return intmodel.ContainerStateUnknown, fmt.Errorf("failed to build containerd ID: %w", err)
+			return ContainerObservation{State: intmodel.ContainerStateUnknown},
+				fmt.Errorf("failed to build containerd ID: %w", err)
 		}
 	}
 
@@ -148,7 +173,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"container", containerID,
 			"containerdID", containerdID,
 			"error", err)
-		return intmodel.ContainerStateUnknown, nil
+		return ContainerObservation{State: intmodel.ContainerStateUnknown}, nil
 	}
 
 	if !containerExists {
@@ -162,21 +187,27 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"container", containerID,
 			"containerdID", containerdID,
 			"namespace", namespace)
-		return intmodel.ContainerStateNotCreated, nil
+		return ContainerObservation{State: intmodel.ContainerStateNotCreated}, nil
 	}
 
 	// Get container state using TaskStatus from ctr package
 	taskStatus, taskStatusErr := r.ctrClient.TaskStatus(namespace, containerdID)
 	if taskStatusErr == nil {
-		// TaskStatus succeeded - convert and return
+		// TaskStatus succeeded - convert and return. ExitStatus is the
+		// uint32 exit code containerd records for the task; it is only
+		// meaningful on Stopped tasks (Running/Created/Paused leave the
+		// field unobserved) but the value is safe to surface unconditionally
+		// — non-terminal callers read the State column and ignore ExitCode.
 		state := ctr.ConvertContainerdStatusToContainerState(taskStatus)
+		exitCode := int(taskStatus.ExitStatus)
 		r.logger.InfoContext(r.ctx, "container state determined via TaskStatus",
 			"container", containerID,
 			"containerdID", containerdID,
 			"namespace", namespace,
 			"taskStatus", taskStatus.Status,
-			"internalState", state)
-		return state, nil
+			"internalState", state,
+			"exitCode", exitCode)
+		return ContainerObservation{State: state, ExitCode: exitCode}, nil
 	}
 
 	// TaskStatus failed against an existing container: the container record
@@ -194,7 +225,7 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 			"containerdID", containerdID,
 			"namespace", namespace,
 			"error", taskStatusErr)
-		return intmodel.ContainerStateStopped, nil
+		return ContainerObservation{State: intmodel.ContainerStateStopped}, nil
 	}
 
 	// TaskStatus failed - return Unknown since we can't determine the state
@@ -203,5 +234,5 @@ func (r *Exec) GetContainerState(cell intmodel.Cell, containerID string) (intmod
 		"containerdID", containerdID,
 		"namespace", namespace,
 		"error", taskStatusErr)
-	return intmodel.ContainerStateUnknown, nil
+	return ContainerObservation{State: intmodel.ContainerStateUnknown}, nil
 }

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -715,14 +715,18 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 	now := r.nowUTC()
 
 	for _, containerSpec := range cell.Spec.Containers {
-		// Get container state from containerd
-		state, err := r.GetContainerState(*cell, containerSpec.ID)
+		// Get container observation (state + exit code) from containerd.
+		// ExitCode flows into ContainerStatus so the RestartPolicy gate in
+		// refresh.go can distinguish clean exits (0) from failures on
+		// `on-failure` policy. The state-only failure mode is preserved —
+		// any error here zeros both fields and we log + continue, same as
+		// the pre-#1003 behavior.
+		obs, err := r.GetContainerObservation(*cell, containerSpec.ID)
 		if err != nil {
-			// Log error but continue with other containers
-			r.logger.DebugContext(r.ctx, "failed to get container state",
+			r.logger.DebugContext(r.ctx, "failed to get container observation",
 				"container", containerSpec.ID,
 				"error", err)
-			state = intmodel.ContainerStateUnknown
+			obs = ContainerObservation{State: intmodel.ContainerStateUnknown}
 		}
 
 		// CreatedAt: stamp on the first observation, preserve thereafter.
@@ -734,18 +738,18 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 		}
 
 		// TODO: Get additional status fields (RestartCount, StartTime, etc.) from containerd
-		// For now, populate with basic state
+		// For now, populate with basic state + exit code
 		status := intmodel.ContainerStatus{
 			Name:         containerSpec.ID,
 			ID:           containerSpec.ID,
 			CreatedAt:    createdAt,
-			State:        state,
+			State:        obs.State,
 			RestartCount: 0,           // TODO: retrieve from containerd
 			RestartTime:  time.Time{}, // TODO: retrieve from containerd
 			StartTime:    time.Time{}, // TODO: retrieve from containerd
 			FinishTime:   time.Time{}, // TODO: retrieve from containerd
-			ExitCode:     0,           // TODO: retrieve from containerd
-			ExitSignal:   "",          // TODO: retrieve from containerd
+			ExitCode:     obs.ExitCode,
+			ExitSignal:   "", // TODO: retrieve from containerd
 		}
 		// Pull per-repo clone/fetch and per-create-stage outcomes over the
 		// kuketty control socket (issues #642, #689) in a single dial.
@@ -753,7 +757,7 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 		// create stages and are Ready can serve the verb, and any failure leaves
 		// Repos/Stages empty rather than blocking the status read.
 		var liveStages []intmodel.StageStatus
-		status.Repos, liveStages = r.setupStatuses(cell, containerSpec, state)
+		status.Repos, liveStages = r.setupStatuses(cell, containerSpec, obs.State)
 		// Merge live + prior stages against the current spec so done
 		// records survive stop/start and edited stages drop their prior
 		// done. See mergeStageStatuses for the Index + Hash contract.

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -740,11 +740,19 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 	cell.Status.ReadyObserved = latchReadyObserved(
 		originalStatus.ReadyObserved, originalStatus.State, newState)
 
-	if shouldAutoDeleteCell(cell.Spec.AutoDelete, newState, cell.Status.ReadyObserved) {
+	// RestartPolicy gate (#1003): per-container restartPolicy can veto both
+	// the auto-delete and the wind-down kill so a workload authored with
+	// `restartPolicy: never` (or `on-failure` that exited cleanly) is left
+	// in Stopped state instead of disappearing under the next tick.
+	// Permissive default (empty/Always) preserves the pre-#1003 behavior
+	// for cells that never set the field. See restartPolicyPermitsCellReap.
+	restartReap := restartPolicyPermitsCellReap(cell)
+
+	if restartReap && shouldAutoDeleteCell(cell.Spec.AutoDelete, newState, cell.Status.ReadyObserved) {
 		return r.autoDeleteCell(cell)
 	}
 
-	if shouldWindDownCell(cell, newState) {
+	if restartReap && shouldWindDownCell(cell, newState) {
 		return r.windDownCell(cell)
 	}
 
@@ -911,6 +919,88 @@ func shouldWindDownCell(cell intmodel.Cell, newState intmodel.CellState) bool {
 		return false
 	}
 	return rootContainerStillRunning(rootSpec.ID, cell.Status.Containers)
+}
+
+// restartPolicyPermitsCellReap reports whether every terminally-exited
+// non-root container in the cell carries a RestartPolicy that permits
+// the cell-level wind-down / auto-delete to fire (#1003). The reconciler
+// asks this gate before both shouldAutoDeleteCell and shouldWindDownCell —
+// a single container's `never` (or `on-failure` with a clean exit) blocks
+// the cell-level reap, preserving the workload in Stopped state so the
+// operator can decide explicitly.
+//
+// Decision per terminally-exited non-root container, keyed on its
+// ContainerStatus.ExitCode (populated by GetContainerObservation):
+//
+//   - "" or "always"  → permit reap. Empty is the back-compat default so
+//     cells that pre-date #1003 keep the wind-down behavior they have today.
+//   - "on-failure"    → permit reap only when ExitCode != 0; a clean exit
+//     (0) means the workload completed successfully and the cell stays.
+//   - "never"         → never permit reap.
+//
+// Unknown values fall through to the permissive default to mirror the
+// pre-#1003 behavior — typos and future-spec values do not silently
+// strand cells in Stopped.
+//
+// Containers in non-terminal states (Ready/Pending/Paused/Unknown) are
+// ignored: the cell-state derivation already gates on "every non-root
+// terminal" before this function runs, so a non-terminal container being
+// "permitted to reap" is meaningless.
+func restartPolicyPermitsCellReap(cell intmodel.Cell) bool {
+	statusByID := make(map[string]intmodel.ContainerStatus, len(cell.Status.Containers))
+	for i := range cell.Status.Containers {
+		statusByID[cell.Status.Containers[i].ID] = cell.Status.Containers[i]
+	}
+	for i := range cell.Spec.Containers {
+		spec := cell.Spec.Containers[i]
+		if spec.Root {
+			continue
+		}
+		status, ok := statusByID[spec.ID]
+		if !ok {
+			continue
+		}
+		if !containerStateIsTerminal(status.State) {
+			continue
+		}
+		if !restartPolicyPermitsContainerReap(spec.RestartPolicy, status.ExitCode) {
+			return false
+		}
+	}
+	return true
+}
+
+// restartPolicyPermitsContainerReap is the per-container half of
+// restartPolicyPermitsCellReap. Pulled out so it can be exercised
+// directly without building a full cell snapshot. See
+// restartPolicyPermitsCellReap for the policy table.
+func restartPolicyPermitsContainerReap(policy string, exitCode int) bool {
+	switch policy {
+	case "", intmodel.RestartPolicyAlways:
+		return true
+	case intmodel.RestartPolicyOnFailure:
+		return exitCode != 0
+	case intmodel.RestartPolicyNever:
+		return false
+	default:
+		return true
+	}
+}
+
+// containerStateIsTerminal reports whether the state means "the task
+// is no longer running and will not run again on its own". Used by
+// restartPolicyPermitsCellReap to scope its policy check to containers
+// the reconciler is about to reap. Stopped, Failed, and NotCreated all
+// count — the cell-state derivation already treats them equivalently
+// (see deriveCellStateFromNonRootContainerStatuses).
+func containerStateIsTerminal(s intmodel.ContainerState) bool {
+	switch s {
+	case intmodel.ContainerStateStopped,
+		intmodel.ContainerStateFailed,
+		intmodel.ContainerStateNotCreated:
+		return true
+	}
+	return false
 }
 
 // rootContainerStillRunning answers the "is the root task still

--- a/internal/controller/runner/restart_policy_test.go
+++ b/internal/controller/runner/restart_policy_test.go
@@ -1,0 +1,308 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises unexported restart-policy predicates and the GetContainerObservation exit-code plumbing
+package runner
+
+import (
+	"testing"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestRestartPolicyPermitsContainerReap pins the per-container half of
+// the #1003 reap gate. The decision table:
+//
+//   - "" or "always"  → permit reap regardless of exit code (back-compat
+//     and explicit Always both default to today's wind-down behavior).
+//   - "on-failure"    → permit reap iff exit code is non-zero; clean exits
+//     (0) preserve the cell.
+//   - "never"         → never permit reap.
+//   - unknown values  → permissive fallback so a typo or a future spec
+//     value does not silently strand cells.
+func TestRestartPolicyPermitsContainerReap(t *testing.T) {
+	cases := []struct {
+		name     string
+		policy   string
+		exitCode int
+		want     bool
+	}{
+		{"empty_back_compat_clean_exit_permits", "", 0, true},
+		{"empty_back_compat_failed_exit_permits", "", 1, true},
+		{"always_clean_exit_permits", intmodel.RestartPolicyAlways, 0, true},
+		{"always_failed_exit_permits", intmodel.RestartPolicyAlways, 137, true},
+		{"on_failure_clean_exit_blocks", intmodel.RestartPolicyOnFailure, 0, false},
+		{"on_failure_failed_exit_permits", intmodel.RestartPolicyOnFailure, 1, true},
+		{"on_failure_signal_exit_permits", intmodel.RestartPolicyOnFailure, 137, true},
+		{"never_clean_exit_blocks", intmodel.RestartPolicyNever, 0, false},
+		{"never_failed_exit_blocks", intmodel.RestartPolicyNever, 1, false},
+		{"unknown_policy_permits_default", "no-such-policy", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := restartPolicyPermitsContainerReap(tc.policy, tc.exitCode); got != tc.want {
+				t.Errorf("restartPolicyPermitsContainerReap(%q, %d) = %v, want %v",
+					tc.policy, tc.exitCode, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestContainerStateIsTerminal locks the terminal-state set the
+// RestartPolicy gate scopes its check to. Stopped / Failed / NotCreated
+// are terminal — they map to "the task is no longer running and will not
+// run again on its own". The running and transient states are not.
+func TestContainerStateIsTerminal(t *testing.T) {
+	cases := []struct {
+		state intmodel.ContainerState
+		want  bool
+	}{
+		{intmodel.ContainerStateStopped, true},
+		{intmodel.ContainerStateFailed, true},
+		{intmodel.ContainerStateNotCreated, true},
+		{intmodel.ContainerStateReady, false},
+		{intmodel.ContainerStatePending, false},
+		{intmodel.ContainerStatePaused, false},
+		{intmodel.ContainerStatePausing, false},
+		{intmodel.ContainerStateUnknown, false},
+	}
+	for _, tc := range cases {
+		if got := containerStateIsTerminal(tc.state); got != tc.want {
+			t.Errorf("containerStateIsTerminal(%v) = %v, want %v", tc.state, got, tc.want)
+		}
+	}
+}
+
+// TestRestartPolicyPermitsCellReap pins the cell-level aggregation: a
+// single non-root container that says "do not reap" must block the
+// whole cell, but only terminal containers participate in the decision.
+// Root containers are ignored — the wind-down kills the root anyway.
+func TestRestartPolicyPermitsCellReap(t *testing.T) {
+	cell := func(specs []intmodel.ContainerSpec, statuses []intmodel.ContainerStatus) intmodel.Cell {
+		return intmodel.Cell{
+			Spec:   intmodel.CellSpec{Containers: specs},
+			Status: intmodel.CellStatus{Containers: statuses},
+		}
+	}
+
+	cases := []struct {
+		name string
+		cell intmodel.Cell
+		want bool
+	}{
+		{
+			name: "empty_policy_terminal_stopped_permits_back_compat",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+					{ID: "work", Root: false, RestartPolicy: ""},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+					{ID: "work", State: intmodel.ContainerStateStopped, ExitCode: 0},
+				},
+			),
+			want: true,
+		},
+		{
+			name: "never_policy_terminal_blocks",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+					{ID: "work", Root: false, RestartPolicy: intmodel.RestartPolicyNever},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+					{ID: "work", State: intmodel.ContainerStateStopped, ExitCode: 0},
+				},
+			),
+			want: false,
+		},
+		{
+			name: "on_failure_clean_exit_blocks",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+					{ID: "work", Root: false, RestartPolicy: intmodel.RestartPolicyOnFailure},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+					{ID: "work", State: intmodel.ContainerStateStopped, ExitCode: 0},
+				},
+			),
+			want: false,
+		},
+		{
+			name: "on_failure_failed_exit_permits",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+					{ID: "work", Root: false, RestartPolicy: intmodel.RestartPolicyOnFailure},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+					{ID: "work", State: intmodel.ContainerStateStopped, ExitCode: 137},
+				},
+			),
+			want: true,
+		},
+		{
+			name: "any_never_in_multi_container_blocks_cell",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+					{ID: "worker", Root: false, RestartPolicy: intmodel.RestartPolicyAlways},
+					{ID: "sidecar", Root: false, RestartPolicy: intmodel.RestartPolicyNever},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+					{ID: "worker", State: intmodel.ContainerStateStopped, ExitCode: 0},
+					{ID: "sidecar", State: intmodel.ContainerStateStopped, ExitCode: 0},
+				},
+			),
+			want: false,
+		},
+		{
+			name: "non_terminal_container_ignored_for_policy_decision",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+					{ID: "still-running", Root: false, RestartPolicy: intmodel.RestartPolicyNever},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+					{ID: "still-running", State: intmodel.ContainerStateReady},
+				},
+			),
+			want: true,
+		},
+		{
+			name: "root_policy_ignored",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true, RestartPolicy: intmodel.RestartPolicyNever},
+					{ID: "work", Root: false, RestartPolicy: ""},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateStopped, ExitCode: 0},
+					{ID: "work", State: intmodel.ContainerStateStopped, ExitCode: 0},
+				},
+			),
+			want: true,
+		},
+		{
+			name: "container_with_no_status_ignored",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+					{ID: "work", Root: false, RestartPolicy: intmodel.RestartPolicyNever},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+				},
+			),
+			want: true,
+		},
+		{
+			name: "on_failure_notcreated_treated_as_clean_blocks",
+			cell: cell(
+				[]intmodel.ContainerSpec{
+					{ID: "root", Root: true},
+					{ID: "work", Root: false, RestartPolicy: intmodel.RestartPolicyOnFailure},
+				},
+				[]intmodel.ContainerStatus{
+					{ID: "root", State: intmodel.ContainerStateReady},
+					{ID: "work", State: intmodel.ContainerStateNotCreated, ExitCode: 0},
+				},
+			),
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := restartPolicyPermitsCellReap(tc.cell); got != tc.want {
+				t.Errorf("restartPolicyPermitsCellReap(...) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGetContainerObservation_PopulatesExitCode confirms the
+// GetContainerObservation plumbing wires containerd.Status.ExitStatus
+// into the ContainerObservation.ExitCode column. Without this, the
+// OnFailure gate in restartPolicyPermitsCellReap reads ExitCode=0
+// from every stopped container and the gate collapses to Never.
+func TestGetContainerObservation_PopulatesExitCode(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{Status: containerd.Stopped, ExitStatus: 42}, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+
+	obs, err := r.GetContainerObservation(cell, containerID)
+	if err != nil {
+		t.Fatalf("GetContainerObservation: unexpected error: %v", err)
+	}
+	if obs.State != intmodel.ContainerStateStopped {
+		t.Errorf("GetContainerObservation State = %v, want Stopped", obs.State)
+	}
+	if obs.ExitCode != 42 {
+		t.Errorf(
+			"GetContainerObservation ExitCode = %d, want 42 (the OnFailure policy gate keys on this — a zeroed exit code collapses on-failure to never)",
+			obs.ExitCode,
+		)
+	}
+}
+
+// TestGetContainerObservation_ZeroExitOnNonTerminalBranches locks the
+// non-TaskStatus-success branches (NotCreated + ErrTaskNotFound) at
+// ExitCode=0. The contract: ExitCode is only meaningful when TaskStatus
+// returned successfully; every other return path leaves it zero so the
+// OnFailure gate falls back to its "clean exit blocks reap" branch.
+func TestGetContainerObservation_ZeroExitOnNonTerminalBranches(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return false, nil },
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+
+	obs, err := r.GetContainerObservation(cell, containerID)
+	if err != nil {
+		t.Fatalf("GetContainerObservation: unexpected error: %v", err)
+	}
+	if obs.State != intmodel.ContainerStateNotCreated {
+		t.Errorf("GetContainerObservation State = %v, want NotCreated", obs.State)
+	}
+	if obs.ExitCode != 0 {
+		t.Errorf("GetContainerObservation ExitCode = %d, want 0 on the NotCreated branch", obs.ExitCode)
+	}
+}

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -77,6 +77,13 @@ type ContainerSpec struct {
 	// See the v1beta1 type for field semantics. Issue #618.
 	Git           *ContainerGit
 	CNIConfigPath string
+	// RestartPolicy is the user-authored restart policy applied to the
+	// container when its task exits. See the RestartPolicy* constants
+	// below for the canonical values; the runner's wind-down/auto-delete
+	// gate (refresh.go:restartPolicyPermitsCellReap) is the only consumer
+	// today. Empty/unset is treated as RestartPolicyAlways for
+	// back-compat — the pre-#1003 wind-down behavior, where every
+	// non-root container exit can trigger a cell-level wind-down.
 	RestartPolicy string
 	Attachable    bool
 	Tty           *ContainerTty
@@ -313,4 +320,13 @@ const (
 	// gone). Appended last to keep the ordinals in lockstep with the v1beta1
 	// ContainerState enum, which scheme.go converts by direct int cast.
 	ContainerStateNotCreated
+)
+
+// RestartPolicy values for ContainerSpec.RestartPolicy. Empty/unset is
+// treated as RestartPolicyAlways at the runner gate — see ContainerSpec
+// for the back-compat contract.
+const (
+	RestartPolicyAlways    = "always"
+	RestartPolicyOnFailure = "on-failure"
+	RestartPolicyNever     = "never"
 )


### PR DESCRIPTION
## Summary

- The reconciler now honors the per-container ` + "`RestartPolicy`" + ` field on the wind-down / auto-delete trigger. Empty / ` + "`always`" + ` keeps the pre-#1003 behavior; ` + "`on-failure`" + ` only reaps when a terminally-exited non-root container had a non-zero exit code; ` + "`never`" + ` keeps the cell in Stopped state for the operator to tear down explicitly. Any single non-root container that says "do not reap" blocks the cell-level wind-down, so a multi-container cell only winds down when every terminally-exited non-root container's policy permits it.
- ` + "`ContainerStatus.ExitCode`" + ` is no longer hardcoded to 0 — a new ` + "`GetContainerObservation`" + ` thin-wraps ` + "`GetContainerState`" + ` so ` + "`populateCellContainerStatuses`" + ` can carry the containerd ` + "`Status.ExitStatus`" + ` value into the persisted status snapshot. Without this, the ` + "`on-failure`" + ` gate collapses to ` + "`never`" + ` (every Stopped container reads back ExitCode=0). ` + "`GetContainerState`" + ` keeps its existing signature so no call site or interface change is needed.
- Adds canonical ` + "`RestartPolicyAlways`" + ` / ` + "`RestartPolicyOnFailure`" + ` / ` + "`RestartPolicyNever`" + ` constants in ` + "`internal/modelhub/container.go`" + ` next to the field declaration so the runner gate and any future consumer share one source of truth on the string spelling.

## Premise note — issue body has rotted

The issue claims "the reconciler's restart loop always re-starts a stopped container regardless of the field's value." Reading the runner today, there is no automatic restart loop — when non-root containers exit the reconciler either auto-deletes the cell (` + "`Spec.AutoDelete=true`" + `) or kills-and-preserves it (` + "`Spec.AutoDelete=false`" + `, via ` + "`windDownCell`" + `). The field has been purely cosmetic — ` + "`docs/site/manifests/container.md:92`" + ` even calls this out ("accepted by the schema today but the controller does not act on them"). PR #1000 added diff detection for the field, this PR makes the runner act on it.

Given there is no restart loop to gate, I read the AC as targeting the closest existing analog — the wind-down / auto-delete reap — and wired the three policy modes onto that gate. Documented in-code on ` + "`ContainerSpec.RestartPolicy`" + ` and ` + "`restartPolicyPermitsCellReap`" + `; please push back if a real restart loop (re-issue ` + "`StartContainer`" + ` on a stopped task) is the intended scope instead. That would land as a separate follow-up and be a substantially bigger change.

## Test plan

- [x] ` + "`make test`" + ` (full repo test target — both root and kukebuild modules pass)
- [x] ` + "`make dev-init`" + ` smoke (both realms Ready, kuke attach smoke clean)
- [x] New unit tests in ` + "`internal/controller/runner/restart_policy_test.go`" + ` cover the per-container gate decision table, the cell-level aggregation (any-` + "`never`" + `-blocks, root ignored, non-terminal ignored, missing-status ignored), and the ` + "`GetContainerObservation`" + ` exit-code plumbing on both the TaskStatus-success and NotCreated branches

## Acceptance criteria

- [x] ` + "`Always`" + ` (or empty for back-compat) → current wind-down behavior preserved (` + "`TestRestartPolicyPermitsContainerReap/empty_back_compat_*`" + `, ` + "`always_*`" + `)
- [x] ` + "`OnFailure`" + ` → reap only when prior ` + "`Status.ExitCode != 0`" + ` (` + "`TestRestartPolicyPermitsContainerReap/on_failure_*`" + ` + ` + "`TestGetContainerObservation_PopulatesExitCode`" + `)
- [x] ` + "`Never`" + ` → leave the container in Stopped state, surfaced via the cell-level wind-down skip (` + "`TestRestartPolicyPermitsContainerReap/never_*`" + ` + ` + "`TestRestartPolicyPermitsCellReap/never_policy_terminal_blocks`" + `). Note: the AC suggested surfacing as a "cell-level condition" — ` + "`CellStatus`" + ` has no Conditions API today, only ` + "`Reason`" + ` / ` + "`Message`" + `; the persisted observation is the per-container ` + "`Stopped`" + ` state plus the cell staying out of wind-down (no Reason stamp added in this PR to avoid widening scope)

Closes #1003