### PR TITLE
deps: bump sbsh to v0.12.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.12.1
+	github.com/eminwux/sbsh v0.12.2
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.12.1 h1:G+3Dfb8t3nWe0SP0a1Z6oFouU+kAVYNl2bU8a+yXEA0=
-github.com/eminwux/sbsh v0.12.1/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
+github.com/eminwux/sbsh v0.12.2 h1:2znrnwLWP/VI7pI5MmRlyWdnmDeUEKWYMB41ulE+RaM=
+github.com/eminwux/sbsh v0.12.2/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Summary
- Bump `github.com/eminwux/sbsh` from `v0.12.1` to `v0.12.2` so the kukeon attach + kuketty path picks up the two upstream detach/teardown fixes:
  - parent terminal restore on client detach and process exit ([sbsh#367](https://github.com/eminwux/sbsh/pull/367))
  - parent terminal output-side DEC mode restore on teardown ([sbsh#369](https://github.com/eminwux/sbsh/pull/369))
- Pure patch bump — no new sbsh API surface, no call-site changes in kukeon.

## Test plan
- [x] `go.mod` now pins `github.com/eminwux/sbsh v0.12.2`; `go.sum` regenerated via `go mod tidy`.
- [x] `GOWORK=off go build ./...` succeeds (workspace builds are intentionally rejected per `go.work` and `Makefile`; `make`/CI run per-module with `GOWORK=off`).
- [x] `GOWORK=off go vet ./...` succeeds.
- [x] `make test` (both `test-root` and `test-kukebuild`) — all packages `ok`, no failures.
- [x] `make dev-init` completes cleanly end-to-end on this host, including the PTY-driven `kuke attach` smoke at the tail against `dev-init-attach/ds/dks/cattach` (JSON-RPC + SCM_RIGHTS handshake, clean `^]^]` detach, parent-host attach plumbing still live post-detach).
- [ ] After a `kuke attach` + detach cycle, the parent terminal is restored cleanly (no DEC mode residue, no stuck cooked/raw state) — manual verification on a local TTY. Not run: the PTY-driven `dev-init.sh` smoke exercises the JSON-RPC + SCM_RIGHTS detach handshake but cannot observe parent-TTY DEC-mode state from outside the wrapped PTY. Per `agents/dev/CLAUDE.md` §Verifying behavioral runtime fixes, the upstream fixes' visible-restoration property is left unverified rather than over-claimed; reviewer's local TTY is the right venue for the visual check.

Closes #1005