### PR TITLE
feat(team): add kuketeams.io/v1 types + parser (ProjectTeam/TeamsConfig/Role/Harness/ImageCatalog)

### DIFF
--- a/docs/site/concepts/team.md
+++ b/docs/site/concepts/team.md
@@ -1,0 +1,169 @@
+# Teams
+
+A **team** is a roster of agent roles a project runs, composed in-repo from a
+pinned **agents source**. Kukeon's runtime owns the _schemas_ of the
+team-distribution contract; the _contents_ (roles, harnesses, images) live in a
+separate, version-pinned agents repository. This page describes the contract —
+the five document kinds, where each lives, and the disciplines the parser
+enforces. The CLI verb that renders and applies a team (`kuke team init`) is a
+later step; this page covers the declarative surface only.
+
+## Where the files live
+
+| File                     | Where        | Owner    | Holds                                                                              | Committed |
+| ------------------------ | ------------ | -------- | ---------------------------------------------------------------------------------- | --------- |
+| `kuke.yaml`              | host         | runtime  | kukeon runtime only (realm/space/stack, daemon). **No git/registry/teams.**        | n/a       |
+| `kuketeam.yaml`          | project repo | project  | roster: `source`, roles, harnesses, per-role `needs`                               | yes       |
+| `~/.kuke/kuketeams.yaml` | host         | operator | git identity + signing, registry, secret sources, source URLs + composed `teams[]` | no        |
+
+The agents source contributes three more kinds — `role.yaml`, `harness.yaml`,
+and `harnesses/images.yaml` — authored in the agents repo but deserialized by
+kukeon's parser.
+
+## The five kinds
+
+All five are GVK objects under one API group, `kuketeams.io/v1`, matching
+kukeon's parsed-document convention (every document carries `apiVersion` +
+`kind`). An unknown or empty `apiVersion`/`kind` pair is a parse error.
+
+- **`ProjectTeam`** (`kuketeam.yaml`, committed in each project repo) — the
+  per-project roster. Pins the agents `source`, declares harness defaults, lists
+  the roles the project runs.
+- **`TeamsConfig`** (`~/.kuke/kuketeams.yaml`, host, operator-owned) — operator
+  facts (git identity + signing, registry, source clone URLs, secret sources)
+  and the list of composed teams.
+- **`Role`** (`role.yaml`, in agents) — a role's skills, per-harness native
+  config, and `needs` (image capabilities, repos to clone, mounts to bind,
+  params, secrets).
+- **`Harness`** (`harness.yaml`, in agents) — a harness's base image, in-container
+  skill path, make target, and blueprint template.
+- **`ImageCatalog`** (`harnesses/images.yaml`, in agents) — the prebuilt
+  image → capability map, plus build provenance. The v1 image **selector**: a
+  role's capability names pick a hand-built image; there is no dynamic build.
+
+## Rendering onto the runtime
+
+The team-layer types are declarative sugar over the existing `v1beta1` runtime
+types:
+
+- `TeamsConfig.git` is a **strict superset** of `v1beta1.ContainerGit` — it
+  carries `author`, `committer`, `signingKey`, `sign`, and `allowedSigners`
+  unchanged, and adds the `sshKey` clone identity. (It embeds `ContainerGit`
+  directly, so any field added there is automatically carried.)
+- `Role.needs.repos` render to `[]v1beta1.ContainerRepo` (git clones).
+- `Role.needs.mounts` render to `[]v1beta1.VolumeMount` (bind mounts).
+
+## Disciplines the parser enforces
+
+Three disciplines keep the contract honest:
+
+### Capabilities are names, not image references
+
+A `needs.image` entry — and every `ImageCatalog` capability — is a bare
+**capability name** (`git`, `gh`, `go`), never an image tag or digest. The
+parser rejects any capability containing `/`, `:`, or `@`. Capabilities are the
+selector _input_; the `ImageCatalog` maps them to a concrete registry-qualified
+image.
+
+### Secrets declare a source, never a value
+
+A `TeamsConfig.secrets` entry declares **where** its value is read from
+(`from: env` or `from: file`, plus a `key`), never an inline value. Secret bytes
+never live in a committed or operator file.
+
+### The version is the git pin, nothing else
+
+Content versioning is carried **solely** by the `source: <owner>/<repo>@vX.Y.Z`
+git-tag pin. The `source` must be pinned to an exact version — a floating ref
+(`@main`) or a bare tag without a full version (`@v1`) is rejected. The agents
+kinds (`Role`, `Harness`, `ImageCatalog`) carry **no** in-file version field: it
+would be redundant with the pin, drift-prone, and per-release toil to bump
+across every role.
+
+## The project is cloned, not mounted
+
+`TeamsConfig.teams[].path` is an **init-time locator**, not a bind-mount source.
+At `init` time kukeon reads the project's committed `kuketeam.yaml` from that
+path and resolves the project's clone URL from its `git remote`; the cell then
+clones the project fresh as a `ContainerRepo`. Consequences:
+
+- The project's clone URL is **not** declared in `kuketeam.yaml` — it is
+  resolved from the local `git remote` at init time.
+- The project checks out **floating `main`** (it is the operator's own repo).
+  This is intentionally asymmetric with the **pinned-exact** agents `source`:
+  the roster travels with the project, the agents source is pinned.
+- The operator's working tree is **not** mounted — uncommitted local work is
+  invisible in the cell.
+
+## Example
+
+```yaml
+# kuketeam.yaml — committed in each project repo
+apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: sbsh }
+spec:
+  source: eminwux/agents@v1.4.0 # pinned exact
+  defaults: { harnesses: [claude, opencode] }
+  roles:
+    - { ref: dev, needs: { image: [go] } }
+    - { ref: pm }
+    - { ref: pr-reviewer }
+---
+# ~/.kuke/kuketeams.yaml — host, operator-owned
+apiVersion: kuketeams.io/v1
+kind: TeamsConfig
+spec:
+  git:
+    author: { name: "...", email: "..." }
+    signingKey: ~/.ssh/id_ed25519.pub
+    sign: [commits, tags]
+    allowedSigners: ~/.ssh/allowed_signers
+    sshKey: ~/.ssh/id_ed25519
+  registry: registry.eminwux.com
+  sources: { eminwux/agents: git@github.com:eminwux/agents.git }
+  secrets:
+    claude-code-oauth-token: { from: env, key: CLAUDE_CODE_OAUTH_TOKEN }
+  teams:
+    - { name: sbsh, path: ~/src/sbsh, source: eminwux/agents@v1.4.0 }
+---
+# role.yaml — in agents, per role
+apiVersion: kuketeams.io/v1
+kind: Role
+metadata: { name: dev }
+spec:
+  skills: [skills/, ../common/skills/]
+  harnesses:
+    claude: { settings: config/claude.settings.json }
+    codex: { sandbox: workspace-write, approval: on-request }
+    opencode: { permissions: skip }
+  needs:
+    image: [git, gh] # capability NAMES (selector input)
+    repos: [project, agents] # git clones → ContainerRepo
+    mounts: [ssh] # bind mounts → VolumeMount
+    params: [PROJECT_DIR, ANTHROPIC_MODEL]
+    secrets: [claude-code-oauth-token]
+---
+# harness.yaml — in agents, per harness
+apiVersion: kuketeams.io/v1
+kind: Harness
+metadata: { name: claude }
+spec:
+  {
+    baseImage: claude,
+    skillPath: /home/claude/.claude/skills,
+    makeTarget: claude,
+    template: blueprint.tmpl.yaml,
+  }
+---
+# harnesses/images.yaml — prebuilt image → capabilities
+apiVersion: kuketeams.io/v1
+kind: ImageCatalog
+spec:
+  images:
+    - ref: claude
+      harness: claude
+      image: registry.eminwux.com/claude:latest # registry-qualified
+      build: { context: harnesses/claude, dockerfile: Dockerfile }
+      capabilities: [git, gh, go, node, make]
+```

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -525,4 +525,67 @@ var (
 	// errdefs.ErrControllerNoChange)` so `errors.Is` works across the
 	// boundary without diverging the surface text.
 	ErrControllerNoChange = errors.New("controller reported no change")
+
+	// Team-distribution parse/validation errors (kuketeams.io/v1 kinds —
+	// ProjectTeam, TeamsConfig, Role, Harness, ImageCatalog). Issue #793,
+	// epic #792.
+
+	// ErrTeamMetadataNameRequired fires when a ProjectTeam/Role/Harness omits
+	// metadata.name.
+	ErrTeamMetadataNameRequired = errors.New("metadata.name is required")
+	// ErrTeamSourceInvalid fires when a `source` field is not a pinned-exact
+	// `<owner>/<repo>@vX.Y.Z` reference (floating ref or bare tag rejected).
+	ErrTeamSourceInvalid = errors.New(
+		"source must be <owner>/<repo>@<version> pinned to an exact version (e.g. eminwux/agents@v1.4.0)",
+	)
+	// ErrTeamRoleRefRequired fires when a ProjectTeam roles[] entry omits ref.
+	ErrTeamRoleRefRequired = errors.New("roles[].ref is required")
+	// ErrTeamImageCapabilityInvalid fires when an image capability entry looks
+	// like an image tag/digest instead of a bare capability name.
+	ErrTeamImageCapabilityInvalid = errors.New(
+		"image capability must be a bare capability name, not an image tag or digest",
+	)
+	// ErrTeamHarnessUnknown fires when a harness name is outside the known set.
+	ErrTeamHarnessUnknown = errors.New("unknown harness")
+	// ErrTeamGitIdentityIncomplete fires when a git author/committer identity is
+	// missing name or email.
+	ErrTeamGitIdentityIncomplete = errors.New("git identity requires both name and email")
+	// ErrTeamGitSignInvalid fires when a git.sign entry is not commits/tags.
+	ErrTeamGitSignInvalid = errors.New("git.sign entries must be one of: commits, tags")
+	// ErrTeamGitSignNeedsKey fires when git.sign is set without git.signingKey.
+	ErrTeamGitSignNeedsKey = errors.New("git.sign requires git.signingKey")
+	// ErrTeamSecretSourceInvalid fires when a TeamsConfig secret omits a valid
+	// source (from: env|file) or its key.
+	ErrTeamSecretSourceInvalid = errors.New(
+		"secret must declare a source (from: env|file) and a key, never an inline value",
+	)
+	// ErrTeamSourceKeyInvalid fires when a TeamsConfig sources[] key is not in
+	// `<owner>/<repo>` form.
+	ErrTeamSourceKeyInvalid = errors.New("sources key must be in <owner>/<repo> form")
+	// ErrTeamTeamNameRequired fires when a TeamsConfig teams[] entry omits name.
+	ErrTeamTeamNameRequired = errors.New("teams[].name is required")
+	// ErrTeamTeamNameDuplicate fires when two TeamsConfig teams[] share a name.
+	ErrTeamTeamNameDuplicate = errors.New("teams[].name must be unique")
+	// ErrTeamHarnessFieldRequired fires when a Harness omits skillPath,
+	// makeTarget, or template.
+	ErrTeamHarnessFieldRequired = errors.New(
+		"harness skillPath, makeTarget, and template are required",
+	)
+	// ErrTeamImageRefRequired fires when an ImageCatalog entry omits ref.
+	ErrTeamImageRefRequired = errors.New("imageCatalog images[].ref is required")
+	// ErrTeamImageImageRequired fires when an ImageCatalog entry's image is not
+	// registry-qualified.
+	ErrTeamImageImageRequired = errors.New(
+		"imageCatalog images[].image must be a registry-qualified reference",
+	)
+	// ErrTeamImageBuildRequired fires when an ImageCatalog entry omits
+	// build.context or build.dockerfile.
+	ErrTeamImageBuildRequired = errors.New(
+		"imageCatalog images[].build requires non-empty context and dockerfile",
+	)
+	// ErrTeamImageCapabilitiesRequired fires when an ImageCatalog entry has no
+	// capabilities.
+	ErrTeamImageCapabilitiesRequired = errors.New(
+		"imageCatalog images[].capabilities must be non-empty",
+	)
 )

--- a/internal/kuketeams/parser.go
+++ b/internal/kuketeams/parser.go
@@ -1,0 +1,350 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kuketeams parses and validates the team-distribution documents
+// (kuketeams.io/v1: ProjectTeam, TeamsConfig, Role, Harness, ImageCatalog;
+// issue #793, epic #792). It mirrors the internal/serverconfig +
+// internal/apply/parser split — the Go types live in
+// pkg/api/model/kuketeams; this package owns deserialization and the
+// validation rules. No CLI verb consumes it yet (the verbs land in #796 and
+// later), so it is deliberately a standalone parser rather than a registration
+// into the v1beta1 apply/get dispatch, which is group-scoped to v1beta1.
+package kuketeams
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	"gopkg.in/yaml.v3"
+)
+
+// Document is a parsed team-distribution document. Exactly one of the typed
+// pointers is non-nil, selected by Kind.
+type Document struct {
+	APIVersion   string
+	Kind         string
+	ProjectTeam  *model.ProjectTeam
+	TeamsConfig  *model.TeamsConfig
+	Role         *model.Role
+	Harness      *model.Harness
+	ImageCatalog *model.ImageCatalog
+}
+
+// sourceRefPattern matches a pinned-exact `<owner>/<repo>@vX.Y.Z` reference.
+// The version must be a full vMAJOR.MINOR.PATCH, optionally with a
+// prerelease/build suffix — floating refs (`@main`) and bare tags (`@v1`) are
+// rejected. Owner/repo allow the GitHub-name character class.
+var sourceRefPattern = regexp.MustCompile(
+	`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+@v\d+\.\d+\.\d+([-+][0-9A-Za-z.-]+)?$`,
+)
+
+// ownerRepoPattern matches a bare `<owner>/<repo>` key (no version).
+var ownerRepoPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
+
+// docSeparator splits a multi-document YAML stream on `---` lines.
+var docSeparator = regexp.MustCompile(`(?m)^\s*---\s*$`)
+
+// header is the GVK preamble read before dispatching to a typed parse.
+type header struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+}
+
+// ParseDocuments splits a multi-document YAML stream and parses+validates each
+// document, returning them in order. An empty stream is an error.
+func ParseDocuments(r io.Reader) ([]*Document, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read input: %w", err)
+	}
+	parts := docSeparator.Split(string(data), -1)
+	docs := make([]*Document, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		doc, parseErr := Parse([]byte(part))
+		if parseErr != nil {
+			return nil, fmt.Errorf("document %d: %w", len(docs), parseErr)
+		}
+		docs = append(docs, doc)
+	}
+	if len(docs) == 0 {
+		return nil, errors.New("no documents found in input")
+	}
+	return docs, nil
+}
+
+// Parse deserializes and validates a single team-distribution document. An
+// unknown or empty apiVersion/kind pair is a parse error, matching the kind
+// guard the v1beta1 surface enforces.
+func Parse(raw []byte) (*Document, error) {
+	var h header
+	if err := yaml.Unmarshal(raw, &h); err != nil {
+		return nil, fmt.Errorf("parse header: %w", err)
+	}
+	if h.APIVersion != model.APIVersionV1 {
+		return nil, fmt.Errorf(
+			"%w: %q (expected %s)",
+			errdefs.ErrUnsupportedAPIVersion,
+			h.APIVersion,
+			model.APIVersionV1,
+		)
+	}
+
+	doc := &Document{APIVersion: h.APIVersion, Kind: h.Kind}
+	switch h.Kind {
+	case model.KindProjectTeam:
+		var v model.ProjectTeam
+		if err := yaml.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("parse ProjectTeam: %w", err)
+		}
+		if err := validateProjectTeam(&v); err != nil {
+			return nil, err
+		}
+		doc.ProjectTeam = &v
+	case model.KindTeamsConfig:
+		var v model.TeamsConfig
+		if err := yaml.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("parse TeamsConfig: %w", err)
+		}
+		if err := validateTeamsConfig(&v); err != nil {
+			return nil, err
+		}
+		doc.TeamsConfig = &v
+	case model.KindRole:
+		var v model.Role
+		if err := yaml.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("parse Role: %w", err)
+		}
+		if err := validateRole(&v); err != nil {
+			return nil, err
+		}
+		doc.Role = &v
+	case model.KindHarness:
+		var v model.Harness
+		if err := yaml.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("parse Harness: %w", err)
+		}
+		if err := validateHarness(&v); err != nil {
+			return nil, err
+		}
+		doc.Harness = &v
+	case model.KindImageCatalog:
+		var v model.ImageCatalog
+		if err := yaml.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("parse ImageCatalog: %w", err)
+		}
+		if err := validateImageCatalog(&v); err != nil {
+			return nil, err
+		}
+		doc.ImageCatalog = &v
+	default:
+		return nil, fmt.Errorf("%w: %q", errdefs.ErrUnknownKind, h.Kind)
+	}
+	return doc, nil
+}
+
+// validateProjectTeam enforces the ProjectTeam contract: metadata.name present;
+// source pinned-exact; every roles[].ref non-empty; defaults/role harness names
+// known; project role image needs are capability names.
+func validateProjectTeam(pt *model.ProjectTeam) error {
+	if strings.TrimSpace(pt.Metadata.Name) == "" {
+		return errdefs.ErrTeamMetadataNameRequired
+	}
+	if !sourceRefPattern.MatchString(strings.TrimSpace(pt.Spec.Source)) {
+		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceInvalid, pt.Spec.Source)
+	}
+	for _, h := range pt.Spec.Defaults.Harnesses {
+		if !model.IsKnownHarness(h) {
+			return fmt.Errorf("%w: %q (defaults.harnesses)", errdefs.ErrTeamHarnessUnknown, h)
+		}
+	}
+	for i, role := range pt.Spec.Roles {
+		if strings.TrimSpace(role.Ref) == "" {
+			return fmt.Errorf("%w (roles[%d])", errdefs.ErrTeamRoleRefRequired, i)
+		}
+		if role.Needs != nil {
+			if err := validateCapabilityNames(role.Needs.Image, fmt.Sprintf("roles[%d].needs.image", i)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// validateTeamsConfig enforces the TeamsConfig contract: git identities
+// complete; git.sign entries valid and key-backed; secrets declare a source;
+// sources keys well-formed; teams names present and unique.
+func validateTeamsConfig(tc *model.TeamsConfig) error {
+	if tc.Spec.Git != nil {
+		if err := validateGit(tc.Spec.Git); err != nil {
+			return err
+		}
+	}
+	for name, secret := range tc.Spec.Secrets {
+		switch secret.From {
+		case model.SecretFromEnv, model.SecretFromFile:
+		default:
+			return fmt.Errorf("%w (secrets[%q])", errdefs.ErrTeamSecretSourceInvalid, name)
+		}
+		if strings.TrimSpace(secret.Key) == "" {
+			return fmt.Errorf("%w (secrets[%q])", errdefs.ErrTeamSecretSourceInvalid, name)
+		}
+	}
+	for key := range tc.Spec.Sources {
+		if !ownerRepoPattern.MatchString(key) {
+			return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceKeyInvalid, key)
+		}
+	}
+	seen := make(map[string]bool, len(tc.Spec.Teams))
+	for i, team := range tc.Spec.Teams {
+		name := strings.TrimSpace(team.Name)
+		if name == "" {
+			return fmt.Errorf("%w (teams[%d])", errdefs.ErrTeamTeamNameRequired, i)
+		}
+		if seen[name] {
+			return fmt.Errorf("%w (got %q)", errdefs.ErrTeamTeamNameDuplicate, name)
+		}
+		seen[name] = true
+		if strings.TrimSpace(team.Source) != "" &&
+			!sourceRefPattern.MatchString(strings.TrimSpace(team.Source)) {
+			return fmt.Errorf("%w (teams[%d] %q source %q)", errdefs.ErrTeamSourceInvalid, i, name, team.Source)
+		}
+	}
+	return nil
+}
+
+// validateGit enforces the git superset rules: each present identity carries
+// both name and email; sign entries are commits/tags and require a signingKey.
+func validateGit(git *model.TeamsConfigGit) error {
+	if git.Author != nil {
+		if strings.TrimSpace(git.Author.Name) == "" || strings.TrimSpace(git.Author.Email) == "" {
+			return fmt.Errorf("%w (git.author)", errdefs.ErrTeamGitIdentityIncomplete)
+		}
+	}
+	if git.Committer != nil {
+		if strings.TrimSpace(git.Committer.Name) == "" || strings.TrimSpace(git.Committer.Email) == "" {
+			return fmt.Errorf("%w (git.committer)", errdefs.ErrTeamGitIdentityIncomplete)
+		}
+	}
+	if len(git.Sign) > 0 {
+		if strings.TrimSpace(git.SigningKey) == "" {
+			return errdefs.ErrTeamGitSignNeedsKey
+		}
+		for _, s := range git.Sign {
+			switch s {
+			case model.GitSignCommits, model.GitSignTags:
+			default:
+				return fmt.Errorf("%w (got %q)", errdefs.ErrTeamGitSignInvalid, s)
+			}
+		}
+	}
+	return nil
+}
+
+// validateRole enforces the Role contract: metadata.name present; harness keys
+// known; needs.image entries are capability names.
+func validateRole(r *model.Role) error {
+	if strings.TrimSpace(r.Metadata.Name) == "" {
+		return errdefs.ErrTeamMetadataNameRequired
+	}
+	for h := range r.Spec.Harnesses {
+		if !model.IsKnownHarness(h) {
+			return fmt.Errorf("%w: %q (spec.harnesses)", errdefs.ErrTeamHarnessUnknown, h)
+		}
+	}
+	if err := validateCapabilityNames(r.Spec.Needs.Image, "spec.needs.image"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateHarness enforces the Harness contract: name known; skillPath,
+// makeTarget, template non-empty.
+func validateHarness(h *model.Harness) error {
+	if !model.IsKnownHarness(h.Metadata.Name) {
+		return fmt.Errorf("%w: %q (metadata.name)", errdefs.ErrTeamHarnessUnknown, h.Metadata.Name)
+	}
+	if strings.TrimSpace(h.Spec.SkillPath) == "" ||
+		strings.TrimSpace(h.Spec.MakeTarget) == "" ||
+		strings.TrimSpace(h.Spec.Template) == "" {
+		return errdefs.ErrTeamHarnessFieldRequired
+	}
+	return nil
+}
+
+// validateImageCatalog enforces the ImageCatalog contract per entry: ref
+// present; harness known; image registry-qualified; build complete;
+// capabilities non-empty.
+func validateImageCatalog(ic *model.ImageCatalog) error {
+	for i, entry := range ic.Spec.Images {
+		if strings.TrimSpace(entry.Ref) == "" {
+			return fmt.Errorf("%w (images[%d])", errdefs.ErrTeamImageRefRequired, i)
+		}
+		if !model.IsKnownHarness(entry.Harness) {
+			return fmt.Errorf("%w: %q (images[%d] %q)", errdefs.ErrTeamHarnessUnknown, entry.Harness, i, entry.Ref)
+		}
+		if !isRegistryQualified(entry.Image) {
+			return fmt.Errorf(
+				"%w (images[%d] %q image %q)",
+				errdefs.ErrTeamImageImageRequired,
+				i,
+				entry.Ref,
+				entry.Image,
+			)
+		}
+		if strings.TrimSpace(entry.Build.Context) == "" || strings.TrimSpace(entry.Build.Dockerfile) == "" {
+			return fmt.Errorf("%w (images[%d] %q)", errdefs.ErrTeamImageBuildRequired, i, entry.Ref)
+		}
+		if len(entry.Capabilities) == 0 {
+			return fmt.Errorf("%w (images[%d] %q)", errdefs.ErrTeamImageCapabilitiesRequired, i, entry.Ref)
+		}
+	}
+	return nil
+}
+
+// validateCapabilityNames rejects capability entries that look like image tags
+// or digests (a "/" path, a ":" tag, or an "@" digest) — capabilities are bare
+// selector names, never image references.
+func validateCapabilityNames(caps []string, field string) error {
+	for _, c := range caps {
+		if strings.TrimSpace(c) == "" ||
+			strings.ContainsAny(c, "/:@") {
+			return fmt.Errorf("%w: %q (%s)", errdefs.ErrTeamImageCapabilityInvalid, c, field)
+		}
+	}
+	return nil
+}
+
+// isRegistryQualified reports whether ref names a registry host explicitly: it
+// has at least one "/" and the first path component looks like a host (carries a
+// "." or a ":" port). This rejects bare ("claude") and docker-library
+// ("library/claude") shorthands the contract forbids.
+func isRegistryQualified(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	slash := strings.IndexByte(ref, '/')
+	if slash <= 0 {
+		return false
+	}
+	host := ref[:slash]
+	return strings.ContainsAny(host, ".:")
+}

--- a/internal/kuketeams/parser.go
+++ b/internal/kuketeams/parser.go
@@ -318,6 +318,9 @@ func validateImageCatalog(ic *model.ImageCatalog) error {
 		if len(entry.Capabilities) == 0 {
 			return fmt.Errorf("%w (images[%d] %q)", errdefs.ErrTeamImageCapabilitiesRequired, i, entry.Ref)
 		}
+		if err := validateCapabilityNames(entry.Capabilities, fmt.Sprintf("images[%d].capabilities", i)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -1,0 +1,392 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+)
+
+const projectTeamHappy = `
+apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: sbsh }
+spec:
+  source: eminwux/agents@v1.4.0
+  defaults: { harnesses: [claude, opencode] }
+  roles:
+    - { ref: dev, needs: { image: [go] } }
+    - { ref: pm }
+    - { ref: pr-reviewer }
+`
+
+const teamsConfigHappy = `
+apiVersion: kuketeams.io/v1
+kind: TeamsConfig
+spec:
+  git:
+    author:    { name: "A", email: "a@example.com" }
+    committer: { name: "B", email: "b@example.com" }
+    signingKey:     ~/.ssh/id_ed25519.pub
+    sign:           [commits, tags]
+    allowedSigners: ~/.ssh/allowed_signers
+    sshKey:         ~/.ssh/id_ed25519
+  registry: registry.eminwux.com
+  sources:  { eminwux/agents: git@github.com:eminwux/agents.git }
+  secrets:
+    claude-code-oauth-token: { from: env, key: CLAUDE_CODE_OAUTH_TOKEN }
+  teams:
+    - { name: sbsh, path: ~/src/sbsh, source: eminwux/agents@v1.4.0 }
+`
+
+const roleHappy = `
+apiVersion: kuketeams.io/v1
+kind: Role
+metadata: { name: dev }
+spec:
+  skills: [skills/, ../common/skills/]
+  harnesses:
+    claude:   { settings: config/claude.settings.json }
+    codex:    { sandbox: workspace-write, approval: on-request }
+    opencode: { permissions: skip }
+  needs:
+    image:   [git, gh]
+    repos:   [project, agents]
+    mounts:  [ssh]
+    params:  [PROJECT_DIR, ANTHROPIC_MODEL]
+    secrets: [claude-code-oauth-token]
+`
+
+const harnessHappy = `
+apiVersion: kuketeams.io/v1
+kind: Harness
+metadata: { name: claude }
+spec: { baseImage: claude, skillPath: /home/claude/.claude/skills, makeTarget: claude, template: blueprint.tmpl.yaml }
+`
+
+const imageCatalogHappy = `
+apiVersion: kuketeams.io/v1
+kind: ImageCatalog
+spec:
+  images:
+    - ref:          claude
+      harness:      claude
+      image:        registry.eminwux.com/claude:latest
+      build:        { context: harnesses/claude, dockerfile: Dockerfile }
+      capabilities: [git, gh, go, node, make]
+`
+
+func TestParseHappyPaths(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		raw  string
+		kind string
+		want func(*Document) bool
+	}{
+		{
+			"ProjectTeam",
+			projectTeamHappy,
+			model.KindProjectTeam,
+			func(d *Document) bool { return d.ProjectTeam != nil },
+		},
+		{
+			"TeamsConfig",
+			teamsConfigHappy,
+			model.KindTeamsConfig,
+			func(d *Document) bool { return d.TeamsConfig != nil },
+		},
+		{"Role", roleHappy, model.KindRole, func(d *Document) bool { return d.Role != nil }},
+		{"Harness", harnessHappy, model.KindHarness, func(d *Document) bool { return d.Harness != nil }},
+		{
+			"ImageCatalog",
+			imageCatalogHappy,
+			model.KindImageCatalog,
+			func(d *Document) bool { return d.ImageCatalog != nil },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			doc, err := Parse([]byte(tc.raw))
+			if err != nil {
+				t.Fatalf("Parse(%s) returned error: %v", tc.name, err)
+			}
+			if doc.Kind != tc.kind {
+				t.Fatalf("Kind = %q, want %q", doc.Kind, tc.kind)
+			}
+			if !tc.want(doc) {
+				t.Fatalf("typed pointer for %s not populated", tc.name)
+			}
+		})
+	}
+}
+
+func TestParseHappyPathFields(t *testing.T) {
+	t.Parallel()
+
+	pt, err := Parse([]byte(projectTeamHappy))
+	if err != nil {
+		t.Fatalf("ProjectTeam: %v", err)
+	}
+	if got := pt.ProjectTeam.Spec.Source; got != "eminwux/agents@v1.4.0" {
+		t.Errorf("source = %q", got)
+	}
+	if len(pt.ProjectTeam.Spec.Roles) != 3 {
+		t.Errorf("roles len = %d, want 3", len(pt.ProjectTeam.Spec.Roles))
+	}
+	if pt.ProjectTeam.Spec.Roles[0].Needs == nil ||
+		len(pt.ProjectTeam.Spec.Roles[0].Needs.Image) != 1 {
+		t.Errorf("roles[0].needs.image not parsed")
+	}
+
+	tc, err := Parse([]byte(teamsConfigHappy))
+	if err != nil {
+		t.Fatalf("TeamsConfig: %v", err)
+	}
+	// git is a strict superset of v1beta1.ContainerGit: embedded fields promote.
+	if tc.TeamsConfig.Spec.Git.Author.Email != "a@example.com" {
+		t.Errorf("embedded ContainerGit.Author.Email not promoted: %+v", tc.TeamsConfig.Spec.Git)
+	}
+	if tc.TeamsConfig.Spec.Git.SSHKey != "~/.ssh/id_ed25519" {
+		t.Errorf("git.sshKey = %q", tc.TeamsConfig.Spec.Git.SSHKey)
+	}
+	if len(tc.TeamsConfig.Spec.Git.Sign) != 2 {
+		t.Errorf("git.sign len = %d, want 2", len(tc.TeamsConfig.Spec.Git.Sign))
+	}
+
+	role, err := Parse([]byte(roleHappy))
+	if err != nil {
+		t.Fatalf("Role: %v", err)
+	}
+	// needs.repos and needs.mounts are distinct fields (repos vs mounts split).
+	if len(role.Role.Spec.Needs.Repos) != 2 || len(role.Role.Spec.Needs.Mounts) != 1 {
+		t.Errorf("needs repos/mounts split wrong: repos=%v mounts=%v",
+			role.Role.Spec.Needs.Repos, role.Role.Spec.Needs.Mounts)
+	}
+
+	ic, err := Parse([]byte(imageCatalogHappy))
+	if err != nil {
+		t.Fatalf("ImageCatalog: %v", err)
+	}
+	if ic.ImageCatalog.Spec.Images[0].Build.Context != "harnesses/claude" {
+		t.Errorf("imageCatalog build.context not parsed")
+	}
+}
+
+func TestParseFailureModes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr error
+	}{
+		// Cross-cutting.
+		{
+			"unknown kind",
+			"apiVersion: kuketeams.io/v1\nkind: Bogus\nspec: {}\n",
+			errdefs.ErrUnknownKind,
+		},
+		{
+			"wrong apiVersion",
+			"apiVersion: v1beta1\nkind: Role\nmetadata: { name: dev }\n",
+			errdefs.ErrUnsupportedAPIVersion,
+		},
+		{
+			"empty apiVersion",
+			"kind: Role\nmetadata: { name: dev }\n",
+			errdefs.ErrUnsupportedAPIVersion,
+		},
+		// ProjectTeam.
+		{
+			"ProjectTeam missing name",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamMetadataNameRequired,
+		},
+		{
+			"ProjectTeam floating source",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@main, roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamSourceInvalid,
+		},
+		{
+			"ProjectTeam bare-tag source",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1, roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamSourceInvalid,
+		},
+		{
+			"ProjectTeam empty role ref",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: \"\"}] }\n",
+			errdefs.ErrTeamRoleRefRequired,
+		},
+		{
+			"ProjectTeam unknown default harness",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1.4.0, defaults: {harnesses: [bogus]}, roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamHarnessUnknown,
+		},
+		{
+			"ProjectTeam role image is a tag",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: dev, needs: {image: [\"go:1.21\"]}}] }\n",
+			errdefs.ErrTeamImageCapabilityInvalid,
+		},
+		// TeamsConfig.
+		{
+			"TeamsConfig git author missing email",
+			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { git: { author: { name: A } } }\n",
+			errdefs.ErrTeamGitIdentityIncomplete,
+		},
+		{
+			"TeamsConfig sign without key",
+			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { git: { sign: [commits] } }\n",
+			errdefs.ErrTeamGitSignNeedsKey,
+		},
+		{
+			"TeamsConfig invalid sign entry",
+			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { git: { signingKey: k, sign: [pushes] } }\n",
+			errdefs.ErrTeamGitSignInvalid,
+		},
+		{
+			"TeamsConfig secret bad source",
+			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { secrets: { tok: { from: inline, key: X } } }\n",
+			errdefs.ErrTeamSecretSourceInvalid,
+		},
+		{
+			"TeamsConfig secret missing key",
+			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { secrets: { tok: { from: env } } }\n",
+			errdefs.ErrTeamSecretSourceInvalid,
+		},
+		{
+			"TeamsConfig bad sources key",
+			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { sources: { agents: git@x } }\n",
+			errdefs.ErrTeamSourceKeyInvalid,
+		},
+		{
+			"TeamsConfig duplicate team name",
+			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { teams: [{name: a}, {name: a}] }\n",
+			errdefs.ErrTeamTeamNameDuplicate,
+		},
+		{
+			"TeamsConfig missing team name",
+			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { teams: [{path: /x}] }\n",
+			errdefs.ErrTeamTeamNameRequired,
+		},
+		// Role.
+		{
+			"Role missing name",
+			"apiVersion: kuketeams.io/v1\nkind: Role\nspec: {}\n",
+			errdefs.ErrTeamMetadataNameRequired,
+		},
+		{
+			"Role unknown harness key",
+			"apiVersion: kuketeams.io/v1\nkind: Role\nmetadata: {name: dev}\nspec: { harnesses: { bogus: {} } }\n",
+			errdefs.ErrTeamHarnessUnknown,
+		},
+		{
+			"Role image is a digest",
+			"apiVersion: kuketeams.io/v1\nkind: Role\nmetadata: {name: dev}\nspec: { needs: { image: [\"go@sha256:abc\"] } }\n",
+			errdefs.ErrTeamImageCapabilityInvalid,
+		},
+		// Harness.
+		{
+			"Harness unknown name",
+			"apiVersion: kuketeams.io/v1\nkind: Harness\nmetadata: {name: bogus}\nspec: { skillPath: /s, makeTarget: m, template: t }\n",
+			errdefs.ErrTeamHarnessUnknown,
+		},
+		{
+			"Harness missing skillPath",
+			"apiVersion: kuketeams.io/v1\nkind: Harness\nmetadata: {name: claude}\nspec: { makeTarget: m, template: t }\n",
+			errdefs.ErrTeamHarnessFieldRequired,
+		},
+		// ImageCatalog.
+		{
+			"ImageCatalog missing ref",
+			"apiVersion: kuketeams.io/v1\nkind: ImageCatalog\nspec: { images: [{ harness: claude, image: r.io/c:1, build: {context: c, dockerfile: D}, capabilities: [git] }] }\n",
+			errdefs.ErrTeamImageRefRequired,
+		},
+		{
+			"ImageCatalog unknown harness",
+			"apiVersion: kuketeams.io/v1\nkind: ImageCatalog\nspec: { images: [{ ref: x, harness: bogus, image: r.io/c:1, build: {context: c, dockerfile: D}, capabilities: [git] }] }\n",
+			errdefs.ErrTeamHarnessUnknown,
+		},
+		{
+			"ImageCatalog bare image not registry-qualified",
+			"apiVersion: kuketeams.io/v1\nkind: ImageCatalog\nspec: { images: [{ ref: x, harness: claude, image: claude, build: {context: c, dockerfile: D}, capabilities: [git] }] }\n",
+			errdefs.ErrTeamImageImageRequired,
+		},
+		{
+			"ImageCatalog library image not registry-qualified",
+			"apiVersion: kuketeams.io/v1\nkind: ImageCatalog\nspec: { images: [{ ref: x, harness: claude, image: library/claude:1, build: {context: c, dockerfile: D}, capabilities: [git] }] }\n",
+			errdefs.ErrTeamImageImageRequired,
+		},
+		{
+			"ImageCatalog missing build context",
+			"apiVersion: kuketeams.io/v1\nkind: ImageCatalog\nspec: { images: [{ ref: x, harness: claude, image: r.io/c:1, build: {dockerfile: D}, capabilities: [git] }] }\n",
+			errdefs.ErrTeamImageBuildRequired,
+		},
+		{
+			"ImageCatalog empty capabilities",
+			"apiVersion: kuketeams.io/v1\nkind: ImageCatalog\nspec: { images: [{ ref: x, harness: claude, image: r.io/c:1, build: {context: c, dockerfile: D}, capabilities: [] }] }\n",
+			errdefs.ErrTeamImageCapabilitiesRequired,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Parse([]byte(tc.raw))
+			if err == nil {
+				t.Fatalf("Parse(%s) = nil error, want %v", tc.name, tc.wantErr)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Parse(%s) error = %v, want errors.Is %v", tc.name, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseDocumentsMultiDoc(t *testing.T) {
+	t.Parallel()
+	stream := strings.Join([]string{roleHappy, harnessHappy, imageCatalogHappy}, "\n---\n")
+	docs, err := ParseDocuments(strings.NewReader(stream))
+	if err != nil {
+		t.Fatalf("ParseDocuments: %v", err)
+	}
+	if len(docs) != 3 {
+		t.Fatalf("got %d docs, want 3", len(docs))
+	}
+	if docs[0].Role == nil || docs[1].Harness == nil || docs[2].ImageCatalog == nil {
+		t.Fatalf("multi-doc kinds not dispatched: %+v", docs)
+	}
+}
+
+func TestParseDocumentsEmpty(t *testing.T) {
+	t.Parallel()
+	if _, err := ParseDocuments(strings.NewReader("   \n")); err == nil {
+		t.Fatal("ParseDocuments(empty) = nil error, want error")
+	}
+}
+
+func TestParseDocumentsPropagatesValidation(t *testing.T) {
+	t.Parallel()
+	bad := "apiVersion: kuketeams.io/v1\nkind: Role\nspec: {}\n" // missing name
+	_, err := ParseDocuments(strings.NewReader(roleHappy + "\n---\n" + bad))
+	if !errors.Is(err, errdefs.ErrTeamMetadataNameRequired) {
+		t.Fatalf("error = %v, want ErrTeamMetadataNameRequired", err)
+	}
+}

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -345,6 +345,11 @@ func TestParseFailureModes(t *testing.T) {
 			"apiVersion: kuketeams.io/v1\nkind: ImageCatalog\nspec: { images: [{ ref: x, harness: claude, image: r.io/c:1, build: {context: c, dockerfile: D}, capabilities: [] }] }\n",
 			errdefs.ErrTeamImageCapabilitiesRequired,
 		},
+		{
+			"ImageCatalog capability looks like image tag",
+			"apiVersion: kuketeams.io/v1\nkind: ImageCatalog\nspec: { images: [{ ref: x, harness: claude, image: r.io/c:1, build: {context: c, dockerfile: D}, capabilities: [\"go:1.21\"] }] }\n",
+			errdefs.ErrTeamImageCapabilityInvalid,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - concepts/cgroups.md
       - concepts/system-realm.md
       - concepts/client-and-daemon.md
+      - concepts/team.md
   - Architecture:
       - architecture/overview.md
       - architecture/process-model.md

--- a/pkg/api/model/kuketeams/doc.go
+++ b/pkg/api/model/kuketeams/doc.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kuketeams holds the Go types for the team-distribution contract
+// (issue #793, epic #792). The five kinds — ProjectTeam, TeamsConfig, Role,
+// Harness, and ImageCatalog — model in-repo team composition:
+//
+//   - ProjectTeam (committed in each project repo, `kuketeam.yaml`) declares the
+//     roster: which pinned agents source, which roles, which harness defaults.
+//   - TeamsConfig (host, operator-owned, `~/.kuke/kuketeams.yaml`) carries
+//     operator facts — git identity/signing, registry, source clone URLs,
+//     secret sources — and the composition list of teams.
+//   - Role / Harness / ImageCatalog live in the pinned agents source. They
+//     declare, respectively, a role's skills + harness configs + needs, a
+//     harness's base image + skill path + make target, and the prebuilt
+//     image → capability map that is the v1 image selector input.
+//
+// All five kinds are GVK objects sharing one API group, kuketeams.io/v1. The
+// agents-side kinds (Role / Harness / ImageCatalog) are authored in the agents
+// repo but deserialized here — kukeon's parser owns the schema shape of all
+// five. Content versioning is carried solely by the `source: <owner>/<repo>@vX.Y.Z`
+// git-tag pin in ProjectTeam/TeamsConfig; the agents kinds carry no in-file
+// version field (it would be redundant with the pin and drift-prone).
+//
+// The team-layer types are declarative sugar that render onto the existing
+// v1beta1 runtime: TeamsConfig.git is a strict superset of v1beta1.ContainerGit,
+// Role.needs.repos render to []v1beta1.ContainerRepo, Role.needs.mounts render
+// to []v1beta1.VolumeMount. This package defines the parsed surface only; no
+// CLI verb consumes it yet (the verbs land in #796 and later).
+package kuketeams
+
+// APIVersionV1 is the canonical API version (group/version) shared by every
+// team-distribution kind. Unlike the v1beta1 runtime types, the team kinds use
+// a group-qualified apiVersion so they never collide with the apply/get surface.
+const APIVersionV1 = "kuketeams.io/v1"
+
+// Kinds.
+const (
+	// KindProjectTeam identifies the per-project roster committed as
+	// kuketeam.yaml in each project repo.
+	KindProjectTeam = "ProjectTeam"
+	// KindTeamsConfig identifies the host-side, operator-owned composition
+	// document (~/.kuke/kuketeams.yaml) maintained by `kuke team init`.
+	KindTeamsConfig = "TeamsConfig"
+	// KindRole identifies a per-role document (role.yaml) in the agents source.
+	KindRole = "Role"
+	// KindHarness identifies a per-harness document (harness.yaml) in the
+	// agents source.
+	KindHarness = "Harness"
+	// KindImageCatalog identifies the prebuilt-image → capability map
+	// (harnesses/images.yaml) in the agents source — the v1 selector input.
+	KindImageCatalog = "ImageCatalog"
+)
+
+// GitSignCommits and GitSignTags are the accepted entries in TeamsConfig.git.sign,
+// mirroring v1beta1's GitSignCommits/GitSignTags so the rendered git config keys
+// (commit.gpgsign / tag.gpgsign) stay aligned with the runtime contract.
+const (
+	GitSignCommits = "commits"
+	GitSignTags    = "tags"
+)
+
+// Secret source modes for TeamsConfig.secrets — a secret declares where its
+// value comes from, never an inline value.
+const (
+	// SecretFromEnv reads the secret value from a host environment variable
+	// named by the entry's Key.
+	SecretFromEnv = "env"
+	// SecretFromFile reads the secret value from a host file path named by the
+	// entry's Key.
+	SecretFromFile = "file"
+)
+
+// Metadata is the name-only metadata block carried by ProjectTeam, Role, and
+// Harness. The team kinds intentionally omit a version field — the source pin
+// (`<owner>/<repo>@vX.Y.Z`) is the version authority.
+type Metadata struct {
+	Name string `json:"name" yaml:"name"`
+}
+
+// KnownHarnesses is the set of harness names the v1 contract recognizes. Role
+// harness keys, Harness.metadata.name, and ImageCatalog images[].harness are all
+// validated against this set.
+//
+//nolint:gochecknoglobals // package-level membership set, read-only.
+var KnownHarnesses = map[string]bool{
+	"claude":   true,
+	"codex":    true,
+	"opencode": true,
+}
+
+// IsKnownHarness reports whether name is a recognized harness.
+func IsKnownHarness(name string) bool {
+	return KnownHarnesses[name]
+}

--- a/pkg/api/model/kuketeams/harness.go
+++ b/pkg/api/model/kuketeams/harness.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams
+
+// Harness is a per-harness document (harness.yaml) authored in the agents
+// source. It declares the base image, in-container skill path, make target, and
+// blueprint template a harness uses. metadata.name must be a known harness.
+type Harness struct {
+	APIVersion string      `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string      `json:"kind"       yaml:"kind"`
+	Metadata   Metadata    `json:"metadata"   yaml:"metadata"`
+	Spec       HarnessSpec `json:"spec"       yaml:"spec"`
+}
+
+// HarnessSpec carries the harness declaration.
+type HarnessSpec struct {
+	// BaseImage is the base image ref the harness builds on. Optional.
+	BaseImage string `json:"baseImage,omitempty" yaml:"baseImage,omitempty"`
+	// SkillPath is the in-container directory the harness loads skills from.
+	// Required.
+	SkillPath string `json:"skillPath"           yaml:"skillPath"`
+	// MakeTarget is the make target that builds the harness image. Required.
+	MakeTarget string `json:"makeTarget"          yaml:"makeTarget"`
+	// Template is the blueprint template file the harness renders cells from.
+	// Required.
+	Template string `json:"template"            yaml:"template"`
+}

--- a/pkg/api/model/kuketeams/imagecatalog.go
+++ b/pkg/api/model/kuketeams/imagecatalog.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams
+
+// ImageCatalog is the prebuilt-image → capability map (harnesses/images.yaml)
+// authored in the agents source. It is the v1 image selector input: a role's
+// needs.image capability names are matched against entries' capabilities to pick
+// the image. Each entry also carries build provenance so "how the image is
+// built" is defined at the contract layer. ImageCatalog is spec-only — it has no
+// metadata block.
+type ImageCatalog struct {
+	APIVersion string           `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string           `json:"kind"       yaml:"kind"`
+	Spec       ImageCatalogSpec `json:"spec"       yaml:"spec"`
+}
+
+// ImageCatalogSpec carries the image entries.
+type ImageCatalogSpec struct {
+	Images []ImageCatalogEntry `json:"images" yaml:"images"`
+}
+
+// ImageCatalogEntry is one prebuilt image and the capabilities it provides.
+type ImageCatalogEntry struct {
+	// Ref is the catalog-local identifier for the image (selector key).
+	Ref string `json:"ref"          yaml:"ref"`
+	// Harness is the harness this image is built for. Must be a known harness.
+	Harness string `json:"harness"      yaml:"harness"`
+	// Image is the registry-qualified image reference
+	// (e.g. registry.eminwux.com/claude:latest).
+	Image string `json:"image"        yaml:"image"`
+	// Build carries the build provenance (context + dockerfile) for the image.
+	Build ImageCatalogBuild `json:"build"        yaml:"build"`
+	// Capabilities is the non-empty list of capability names this image
+	// provides — the values matched against a role's needs.image.
+	Capabilities []string `json:"capabilities" yaml:"capabilities"`
+}
+
+// ImageCatalogBuild is the build provenance for a catalog image.
+type ImageCatalogBuild struct {
+	// Context is the build context directory (relative to the agents source).
+	Context string `json:"context"    yaml:"context"`
+	// Dockerfile is the Dockerfile path within the context.
+	Dockerfile string `json:"dockerfile" yaml:"dockerfile"`
+}

--- a/pkg/api/model/kuketeams/marshal_test.go
+++ b/pkg/api/model/kuketeams/marshal_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// TestTeamsConfigGitMarshalsContainerGitSuperset asserts the embedded
+// v1beta1.ContainerGit fields promote in both JSON and YAML, and the added
+// sshKey field round-trips — i.e. TeamsConfig.git is a strict superset of
+// ContainerGit on the wire, not just in Go.
+func TestTeamsConfigGitMarshalsContainerGitSuperset(t *testing.T) {
+	t.Parallel()
+	git := model.TeamsConfigGit{
+		ContainerGit: v1beta1.ContainerGit{
+			Author:         &v1beta1.GitIdentity{Name: "A", Email: "a@example.com"},
+			SigningKey:     "/k.pub",
+			Sign:           []string{model.GitSignCommits, model.GitSignTags},
+			AllowedSigners: "/allowed",
+		},
+		SSHKey: "/id_ed25519",
+	}
+
+	jsonBytes, err := json.Marshal(git)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	for _, key := range []string{`"author"`, `"signingKey"`, `"sign"`, `"allowedSigners"`, `"sshKey"`} {
+		if !strings.Contains(string(jsonBytes), key) {
+			t.Errorf("JSON missing promoted key %s: %s", key, jsonBytes)
+		}
+	}
+
+	yamlBytes, err := yaml.Marshal(git)
+	if err != nil {
+		t.Fatalf("yaml.Marshal: %v", err)
+	}
+	for _, key := range []string{"author:", "signingKey:", "sign:", "allowedSigners:", "sshKey:"} {
+		if !strings.Contains(string(yamlBytes), key) {
+			t.Errorf("YAML missing promoted key %q: %s", key, yamlBytes)
+		}
+	}
+}
+
+// TestRoundTripAllKinds round-trips each kind through JSON and YAML and checks
+// a representative field survives, exercising the JSON+YAML marshalling AC.
+func TestRoundTripAllKinds(t *testing.T) {
+	t.Parallel()
+
+	pt := model.ProjectTeam{
+		APIVersion: model.APIVersionV1, Kind: model.KindProjectTeam,
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec: model.ProjectTeamSpec{
+			Source:   "eminwux/agents@v1.4.0",
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev", Needs: &model.ProjectRoleNeeds{Image: []string{"go"}}}},
+		},
+	}
+	assertJSONYAML(t, "ProjectTeam", pt, func(got model.ProjectTeam) bool {
+		return got.Spec.Source == "eminwux/agents@v1.4.0" &&
+			len(got.Spec.Roles) == 1 && got.Spec.Roles[0].Needs.Image[0] == "go"
+	})
+
+	role := model.Role{
+		APIVersion: model.APIVersionV1, Kind: model.KindRole,
+		Metadata: model.Metadata{Name: "dev"},
+		Spec: model.RoleSpec{
+			Harnesses: map[string]model.RoleHarness{"claude": {Settings: "s.json"}},
+			Needs:     model.RoleNeeds{Repos: []string{"project", "agents"}, Mounts: []string{"ssh"}},
+		},
+	}
+	assertJSONYAML(t, "Role", role, func(got model.Role) bool {
+		return len(got.Spec.Needs.Repos) == 2 && len(got.Spec.Needs.Mounts) == 1 &&
+			got.Spec.Harnesses["claude"].Settings == "s.json"
+	})
+
+	h := model.Harness{
+		APIVersion: model.APIVersionV1, Kind: model.KindHarness,
+		Metadata: model.Metadata{Name: "claude"},
+		Spec:     model.HarnessSpec{SkillPath: "/s", MakeTarget: "claude", Template: "t.yaml"},
+	}
+	assertJSONYAML(t, "Harness", h, func(got model.Harness) bool {
+		return got.Spec.SkillPath == "/s" && got.Spec.MakeTarget == "claude"
+	})
+
+	ic := model.ImageCatalog{
+		APIVersion: model.APIVersionV1, Kind: model.KindImageCatalog,
+		Spec: model.ImageCatalogSpec{Images: []model.ImageCatalogEntry{{
+			Ref: "claude", Harness: "claude", Image: "registry.eminwux.com/claude:latest",
+			Build:        model.ImageCatalogBuild{Context: "harnesses/claude", Dockerfile: "Dockerfile"},
+			Capabilities: []string{"git", "gh"},
+		}}},
+	}
+	assertJSONYAML(t, "ImageCatalog", ic, func(got model.ImageCatalog) bool {
+		return len(got.Spec.Images) == 1 && got.Spec.Images[0].Build.Context == "harnesses/claude"
+	})
+}
+
+func assertJSONYAML[T any](t *testing.T, name string, in T, ok func(T) bool) {
+	t.Helper()
+	jb, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("%s json.Marshal: %v", name, err)
+	}
+	var fromJSON T
+	if unmarshalErr := json.Unmarshal(jb, &fromJSON); unmarshalErr != nil {
+		t.Fatalf("%s json.Unmarshal: %v", name, unmarshalErr)
+	}
+	if !ok(fromJSON) {
+		t.Errorf("%s JSON round-trip lost data: %s", name, jb)
+	}
+	yb, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("%s yaml.Marshal: %v", name, err)
+	}
+	var fromYAML T
+	if unmarshalErr := yaml.Unmarshal(yb, &fromYAML); unmarshalErr != nil {
+		t.Fatalf("%s yaml.Unmarshal: %v", name, unmarshalErr)
+	}
+	if !ok(fromYAML) {
+		t.Errorf("%s YAML round-trip lost data: %s", name, yb)
+	}
+}

--- a/pkg/api/model/kuketeams/projectteam.go
+++ b/pkg/api/model/kuketeams/projectteam.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams
+
+// ProjectTeam is the per-project roster, committed as kuketeam.yaml in each
+// project repo. It pins the agents source, declares harness defaults, and lists
+// the roles the project runs. It travels with the project — so its agents
+// `source` is pinned exact while the project repo itself is checked out at
+// floating `main` (the operator's own repo) when materialized.
+type ProjectTeam struct {
+	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string          `json:"kind"       yaml:"kind"`
+	Metadata   Metadata        `json:"metadata"   yaml:"metadata"`
+	Spec       ProjectTeamSpec `json:"spec"       yaml:"spec"`
+}
+
+// ProjectTeamSpec carries the roster.
+type ProjectTeamSpec struct {
+	// Source pins the agents repository as `<owner>/<repo>@<version>` with a
+	// pinned-exact version (e.g. eminwux/agents@v1.4.0). Floating refs and bare
+	// tags without a full version are rejected at parse time.
+	Source string `json:"source"             yaml:"source"`
+	// Defaults supplies project-wide harness defaults applied to every role
+	// that does not pin its own.
+	Defaults ProjectTeamDefaults `json:"defaults,omitempty" yaml:"defaults,omitempty"`
+	// Roles is the roster: each entry references a role declared in the agents
+	// source and may add project-specific capability needs.
+	Roles []ProjectTeamRole `json:"roles"              yaml:"roles"`
+}
+
+// ProjectTeamDefaults holds project-wide defaults.
+type ProjectTeamDefaults struct {
+	// Harnesses lists the harness names enabled by default for this project's
+	// roles. Entries must be known harnesses.
+	Harnesses []string `json:"harnesses,omitempty" yaml:"harnesses,omitempty"`
+}
+
+// ProjectTeamRole references a role from the agents source and optionally adds
+// project-specific capability needs on top of the role's own declaration.
+type ProjectTeamRole struct {
+	// Ref is the role name (matches a Role.metadata.name in the agents source).
+	Ref string `json:"ref"             yaml:"ref"`
+	// Needs adds project-specific image capabilities for this role in this
+	// project. The entries are capability NAMES (selector input), never image
+	// tags or digests.
+	Needs *ProjectRoleNeeds `json:"needs,omitempty" yaml:"needs,omitempty"`
+}
+
+// ProjectRoleNeeds is the project-side capability override for a role. Only the
+// image-capability dimension is project-tunable; repos/mounts/params/secrets are
+// declared by the role itself in the agents source.
+type ProjectRoleNeeds struct {
+	// Image lists additional capability names this project's instance of the
+	// role requires (e.g. [go]). Capability names, never image tags/digests.
+	Image []string `json:"image,omitempty" yaml:"image,omitempty"`
+}

--- a/pkg/api/model/kuketeams/role.go
+++ b/pkg/api/model/kuketeams/role.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams
+
+// Role is a per-role document (role.yaml) authored in the agents source. It
+// declares the role's skills, per-harness configuration, and the capabilities,
+// repos, mounts, params, and secrets the role needs. metadata is name-only: the
+// source pin is the version authority, so role.yaml carries no version field.
+type Role struct {
+	APIVersion string   `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string   `json:"kind"       yaml:"kind"`
+	Metadata   Metadata `json:"metadata"   yaml:"metadata"`
+	Spec       RoleSpec `json:"spec"       yaml:"spec"`
+}
+
+// RoleSpec carries the role declaration.
+type RoleSpec struct {
+	// Skills lists skill directories (relative paths) the role loads.
+	Skills []string `json:"skills,omitempty"    yaml:"skills,omitempty"`
+	// Harnesses maps a harness name to its per-role configuration. Keys must be
+	// known harnesses.
+	Harnesses map[string]RoleHarness `json:"harnesses,omitempty" yaml:"harnesses,omitempty"`
+	// Needs declares what the role depends on, split by kind so each dimension
+	// renders onto the right runtime type.
+	Needs RoleNeeds `json:"needs,omitempty"     yaml:"needs,omitempty"`
+}
+
+// RoleHarness is the per-role configuration of a single harness. Different
+// harnesses use different keys (claude reads Settings; codex reads
+// Sandbox/Approval; opencode reads Permissions), so this is a permissive union
+// of the recognized keys — an empty config (harness enabled with defaults) is
+// valid.
+type RoleHarness struct {
+	// Settings is the path to a harness settings file (claude).
+	Settings string `json:"settings,omitempty"    yaml:"settings,omitempty"`
+	// Sandbox selects the sandbox mode (codex, e.g. workspace-write).
+	Sandbox string `json:"sandbox,omitempty"     yaml:"sandbox,omitempty"`
+	// Approval selects the approval policy (codex, e.g. on-request).
+	Approval string `json:"approval,omitempty"    yaml:"approval,omitempty"`
+	// Permissions selects the permission mode (opencode, e.g. skip).
+	Permissions string `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+}
+
+// RoleNeeds separates the role's dependencies by kind. Each list holds NAMES
+// (selector inputs / identifiers), never inline values or image tags:
+//
+//   - Image: capability names (selector input for the ImageCatalog).
+//   - Repos: repo names rendered to []v1beta1.ContainerRepo (git clones).
+//     `project` and `agents` are repos.
+//   - Mounts: mount names rendered to []v1beta1.VolumeMount (bind mounts).
+//     `ssh` is a mount.
+//   - Params: parameter names supplied at materialization time.
+//   - Secrets: secret names resolved against TeamsConfig.secrets.
+type RoleNeeds struct {
+	Image   []string `json:"image,omitempty"   yaml:"image,omitempty"`
+	Repos   []string `json:"repos,omitempty"   yaml:"repos,omitempty"`
+	Mounts  []string `json:"mounts,omitempty"  yaml:"mounts,omitempty"`
+	Params  []string `json:"params,omitempty"  yaml:"params,omitempty"`
+	Secrets []string `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+}

--- a/pkg/api/model/kuketeams/teamsconfig.go
+++ b/pkg/api/model/kuketeams/teamsconfig.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams
+
+import (
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TeamsConfig is the host-side, operator-owned composition document, stored at
+// ~/.kuke/kuketeams.yaml and maintained by `kuke team init`. It carries the
+// operator facts (git identity/signing, registry, source clone URLs, secret
+// sources) and the list of composed teams.
+type TeamsConfig struct {
+	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string          `json:"kind"       yaml:"kind"`
+	Spec       TeamsConfigSpec `json:"spec"       yaml:"spec"`
+}
+
+// TeamsConfigSpec carries the operator-owned composition.
+type TeamsConfigSpec struct {
+	// Git is the operator's git identity + signing config rendered into every
+	// team cell. It is a strict superset of v1beta1.ContainerGit.
+	Git *TeamsConfigGit `json:"git,omitempty"      yaml:"git,omitempty"`
+	// Registry is the default container registry for resolving images.
+	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	// Sources maps `<owner>/<repo>` keys to clone URLs (e.g.
+	// eminwux/agents -> git@github.com:eminwux/agents.git).
+	Sources map[string]string `json:"sources,omitempty"  yaml:"sources,omitempty"`
+	// Secrets maps a secret name to its source declaration. A secret never
+	// carries an inline value — only where to read it from.
+	Secrets map[string]TeamsConfigSecret `json:"secrets,omitempty"  yaml:"secrets,omitempty"`
+	// Teams lists the composed teams. Each entry's path is an init-time
+	// LOCATOR (where to read kuketeam.yaml and resolve the project's clone URL
+	// from `git remote`), not a bind-mount source.
+	Teams []TeamsConfigTeam `json:"teams,omitempty"    yaml:"teams,omitempty"`
+}
+
+// TeamsConfigGit is a strict superset of v1beta1.ContainerGit — the embedded
+// runtime type contributes author, committer, signingKey, sign, and
+// allowedSigners — plus the SSHKey clone identity used to clone/push project and
+// agents repos. Embedding (rather than redeclaring) keeps it drift-proof: any
+// field added to ContainerGit is automatically carried here.
+type TeamsConfigGit struct {
+	v1beta1.ContainerGit `yaml:",inline"`
+
+	// SSHKey is the host path to the SSH private key used as the
+	// GIT_SSH_COMMAND identity for clone/push (distinct from the signing key,
+	// which signs commits/tags). Optional.
+	SSHKey string `json:"sshKey,omitempty" yaml:"sshKey,omitempty"`
+}
+
+// TeamsConfigSecret declares where a secret's value is read from. `From` is one
+// of env or file; `Key` is the environment-variable name or file path. The
+// value itself is never stored here.
+type TeamsConfigSecret struct {
+	From string `json:"from" yaml:"from"`
+	Key  string `json:"key"  yaml:"key"`
+}
+
+// TeamsConfigTeam is one composed team. Path is an init-time locator, not a
+// bind-mount source — the cell clones the project fresh from the URL resolved
+// from the project's `git remote` at init time.
+type TeamsConfigTeam struct {
+	Name   string `json:"name"   yaml:"name"`
+	Path   string `json:"path"   yaml:"path"`
+	Source string `json:"source" yaml:"source"`
+}


### PR DESCRIPTION
## Summary

Lands the team-distribution contract's Go types, parser, and validation (step 1 of epic #792) so `kuke team init` (#796) has something to read. **No verbs in this step** — this is the declarative surface only.

- **New types package `pkg/api/model/kuketeams/`** (one file per kind): `ProjectTeam`, `TeamsConfig`, `Role`, `Harness`, `ImageCatalog`. All five are GVK objects under one API group, `kuketeams.io/v1`, with full JSON+YAML marshalling.
- **`TeamsConfig.git` embeds `v1beta1.ContainerGit`** (`yaml:",inline"`) so it is a *literal* strict superset — author/committer/signingKey/sign/allowedSigners are carried verbatim and drift-proof, plus the added `sshKey` clone identity. Round-trip test asserts the embedded fields promote in both JSON and YAML.
- **`Role.needs` splits `repos` (→ `ContainerRepo`) from `mounts` (→ `VolumeMount`)** as distinct fields; `project`/`agents` are repos, `ssh` is a mount.
- **`ImageCatalog` entries carry build provenance** (`image` + `build.{context,dockerfile}`), not just `ref` → capabilities.
- **New parser `internal/kuketeams/`** deserializes + validates every rule in the issue (pinned-exact source refs, capability-names-not-tags, secret-source-not-value, known-harness set, registry-qualified images, unique team names, git identity/sign rules). Table-driven tests cover the happy path for each kind plus every failure mode. Validation sentinels added to `internal/errdefs`.
- **Docs:** `docs/site/concepts/team.md` describes the contract (the #792 file-ownership table), the capability-name / secret-source / version-is-the-pin disciplines, and the clone-not-mount project semantics; added to the mkdocs nav.

### Implementation calls (reviewer please push back)

- **Package placement:** new group `pkg/api/model/kuketeams/` rather than folding into `v1beta1`. The issue offered either; the new group matches the `kuketeams.io/v1` apiVersion, the "new types in their own package/files" AC, and the "no changes to existing schemas" AC.
- **"Register in the existing apply/get deserialization plumbing":** the issue body says this *and* "No verbs in this step." These kinds are a separate API group (`kuketeams.io/v1`, not `v1beta1`) and never go through `kuke apply`/`kuke get`, so I did **not** wire them into `internal/apply/parser` (which is group-scoped to `v1beta1` and would reject a foreign group). Instead I delivered a standalone parser package mirroring the established `internal/serverconfig` + `internal/apply/parser` split (types in `pkg`, parse/validate in `internal`). This is the lower-blast-radius reading consistent with the no-verbs constraint; the apply/get registration can follow when a verb actually consumes these kinds (#796).
- **`ProjectTeam.roles[].needs`** is modeled as a lightweight `{image}` override (the only field the schema shows for the project side); the full `needs` (repos/mounts/params/secrets) lives on the agents-side `Role`. Easy to widen if the project side grows more knobs.
- **"registry-qualified image"** is enforced as: has a `/` and the first path component carries a `.` or `:` (a host indicator) — rejecting bare (`claude`) and docker-library (`library/claude`) shorthands.

## Test plan
- [x] `make test-root` (full root-module CI target) — pass
- [x] `make test-kukebuild` — pass
- [x] `go vet ./pkg/api/model/kuketeams/ ./internal/kuketeams/` — clean
- [x] `pre-commit run --files <changed>` — go-fmt, golangci-lint, prettier, addlicense, go-mod-tidy all pass
- [x] New unit tests: happy path for all five kinds + each validation failure mode + JSON/YAML round-trip + ContainerGit-superset wire check

Closes #793