### PR TITLE
feat(daemon): per-team labeling + pruning apply for CellBlueprint/CellConfig

### DIFF
--- a/internal/apischeme/cellblueprint.go
+++ b/internal/apischeme/cellblueprint.go
@@ -42,10 +42,11 @@ func ConvertCellBlueprintDocToInternal(in ext.CellBlueprintDoc) (intmodel.CellBl
 		}
 		return intmodel.CellBlueprint{
 			Metadata: intmodel.CellBlueprintMetadata{
-				Name:  in.Metadata.Name,
-				Realm: in.Metadata.Realm,
-				Space: in.Metadata.Space,
-				Stack: in.Metadata.Stack,
+				Name:   in.Metadata.Name,
+				Realm:  in.Metadata.Realm,
+				Space:  in.Metadata.Space,
+				Stack:  in.Metadata.Stack,
+				Labels: copyLabels(in.Metadata.Labels),
 			},
 			Document: document,
 		}, nil
@@ -87,12 +88,29 @@ func ConvertCellBlueprintMetadataToExternal(in intmodel.CellBlueprint) ext.CellB
 		APIVersion: ext.APIVersionV1Beta1,
 		Kind:       ext.KindCellBlueprint,
 		Metadata: ext.CellBlueprintMetadata{
-			Name:  in.Metadata.Name,
-			Realm: in.Metadata.Realm,
-			Space: in.Metadata.Space,
-			Stack: in.Metadata.Stack,
+			Name:   in.Metadata.Name,
+			Realm:  in.Metadata.Realm,
+			Space:  in.Metadata.Space,
+			Stack:  in.Metadata.Stack,
+			Labels: copyLabels(in.Metadata.Labels),
 		},
 	}
+}
+
+// copyLabels returns an independent copy of labels so the internal carrier
+// and the external doc do not alias the same map (a later mutation on one
+// must not leak into the other). A nil or empty input returns nil so the
+// canonical YAML-marshalled shape omits `labels:` rather than emitting an
+// empty map.
+func copyLabels(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // ConvertCellBlueprintListToExternal maps a slice of internal CellBlueprints to

--- a/internal/apischeme/cellconfig.go
+++ b/internal/apischeme/cellconfig.go
@@ -42,10 +42,11 @@ func ConvertCellConfigDocToInternal(in ext.CellConfigDoc) (intmodel.CellConfig, 
 		}
 		return intmodel.CellConfig{
 			Metadata: intmodel.CellConfigMetadata{
-				Name:  in.Metadata.Name,
-				Realm: in.Metadata.Realm,
-				Space: in.Metadata.Space,
-				Stack: in.Metadata.Stack,
+				Name:   in.Metadata.Name,
+				Realm:  in.Metadata.Realm,
+				Space:  in.Metadata.Space,
+				Stack:  in.Metadata.Stack,
+				Labels: copyLabels(in.Metadata.Labels),
 			},
 			Document: document,
 		}, nil
@@ -87,10 +88,11 @@ func ConvertCellConfigMetadataToExternal(in intmodel.CellConfig) ext.CellConfigD
 		APIVersion: ext.APIVersionV1Beta1,
 		Kind:       ext.KindCellConfig,
 		Metadata: ext.CellConfigMetadata{
-			Name:  in.Metadata.Name,
-			Realm: in.Metadata.Realm,
-			Space: in.Metadata.Space,
-			Stack: in.Metadata.Stack,
+			Name:   in.Metadata.Name,
+			Realm:  in.Metadata.Realm,
+			Space:  in.Metadata.Space,
+			Stack:  in.Metadata.Stack,
+			Labels: copyLabels(in.Metadata.Labels),
 		},
 	}
 }

--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -957,7 +957,26 @@ func (c *Client) RefreshAll(_ context.Context) (kukeonv1.RefreshAllResult, error
 
 // ---- Apply ----
 
-func (c *Client) ApplyDocuments(_ context.Context, rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
+func (c *Client) ApplyDocuments(ctx context.Context, rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
+	return c.applyDocuments(ctx, rawYAML, "")
+}
+
+// ApplyDocumentsForTeam runs the in-process equivalent of the wire RPC
+// per-team prune-apply path (issue #1027). Empty team rejected at the
+// boundary so a caller cannot accidentally degrade into the historical
+// no-prune apply by passing "".
+func (c *Client) ApplyDocumentsForTeam(
+	ctx context.Context, rawYAML []byte, team string,
+) (kukeonv1.ApplyDocumentsResult, error) {
+	if team == "" {
+		return kukeonv1.ApplyDocumentsResult{}, errors.New("apply for team: team is required")
+	}
+	return c.applyDocuments(ctx, rawYAML, team)
+}
+
+func (c *Client) applyDocuments(
+	_ context.Context, rawYAML []byte, team string,
+) (kukeonv1.ApplyDocumentsResult, error) {
 	docs, validationErrors, err := parseAndValidate(rawYAML)
 	if err != nil {
 		return kukeonv1.ApplyDocumentsResult{}, err
@@ -969,7 +988,7 @@ func (c *Client) ApplyDocuments(_ context.Context, rawYAML []byte) (kukeonv1.App
 		return kukeonv1.ApplyDocumentsResult{}, errors.New("no valid documents found in input")
 	}
 
-	res, err := c.ctrl.ApplyDocuments(docs)
+	res, err := c.ctrl.ApplyDocuments(docs, team)
 	if err != nil {
 		return kukeonv1.ApplyDocumentsResult{}, err
 	}

--- a/internal/controller/apply.go
+++ b/internal/controller/apply.go
@@ -96,10 +96,23 @@ func (r ResourceResult) MarshalYAML() (interface{}, error) {
 // ApplyDocuments applies a set of resource documents in dependency order.
 // Documents are sorted: Realm → Space → Stack → Cell → Container.
 // Returns a summary of actions taken for each resource.
-func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
+//
+// When team is non-empty (issue #1027 per-team prune apply), the daemon
+// stamps `kukeon.io/team=<team>` on every applied CellBlueprint / CellConfig
+// before persistence, and after the apply loop enumerates daemon-stored
+// Blueprint / Config objects carrying the same team label, deleting those
+// not in the applied set. The empty-string team preserves the historical
+// no-stamp, no-prune behavior of `kuke apply -f`.
+func (b *Exec) ApplyDocuments(docs []parser.Document, team string) (ApplyResult, error) {
 	result := ApplyResult{
 		Resources: make([]ResourceResult, 0, len(docs)),
 	}
+
+	// applied{Blueprint,Config}s collect (realm,space,stack,name) tuples
+	// for every successfully-persisted Blueprint / Config in this apply,
+	// so the post-loop prune step (team != "") can delete the same-team
+	// daemon objects that fell out of the applied set.
+	var appliedBlueprints, appliedConfigs []scopedRef
 
 	// Sort documents by dependency order
 	sortedDocs := SortDocumentsByKind(docs, false)
@@ -226,7 +239,11 @@ func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
 				result.Resources = append(result.Resources, resourceResult)
 				continue
 			}
-			blueprint, _, err := apischeme.NormalizeCellBlueprint(*doc.CellBlueprintDoc)
+			bpDoc := *doc.CellBlueprintDoc
+			if team != "" {
+				bpDoc.Metadata.Labels = stampTeamLabel(bpDoc.Metadata.Labels, team)
+			}
+			blueprint, _, err := apischeme.NormalizeCellBlueprint(bpDoc)
 			if err != nil {
 				resourceResult.Action = actionFailed
 				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
@@ -235,6 +252,14 @@ func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
 			}
 			resourceResult.Name = blueprint.Metadata.Name
 			reconcileResult, reconcileErr = applypkg.ReconcileBlueprint(b.runner, blueprint)
+			if reconcileErr == nil {
+				appliedBlueprints = append(appliedBlueprints, scopedRefFromMetadata(
+					blueprint.Metadata.Name,
+					blueprint.Metadata.Realm,
+					blueprint.Metadata.Space,
+					blueprint.Metadata.Stack,
+				))
+			}
 
 		case v1beta1.KindCellConfig:
 			if doc.CellConfigDoc == nil {
@@ -243,7 +268,11 @@ func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
 				result.Resources = append(result.Resources, resourceResult)
 				continue
 			}
-			config, _, err := apischeme.NormalizeCellConfig(*doc.CellConfigDoc)
+			cfgDoc := *doc.CellConfigDoc
+			if team != "" {
+				cfgDoc.Metadata.Labels = stampTeamLabel(cfgDoc.Metadata.Labels, team)
+			}
+			config, _, err := apischeme.NormalizeCellConfig(cfgDoc)
 			if err != nil {
 				resourceResult.Action = actionFailed
 				resourceResult.Error = fmt.Errorf("%w: %w", errdefs.ErrConversionFailed, err)
@@ -252,6 +281,14 @@ func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
 			}
 			resourceResult.Name = config.Metadata.Name
 			reconcileResult, reconcileErr = applypkg.ReconcileConfig(b.runner, config)
+			if reconcileErr == nil {
+				appliedConfigs = append(appliedConfigs, scopedRefFromMetadata(
+					config.Metadata.Name,
+					config.Metadata.Realm,
+					config.Metadata.Space,
+					config.Metadata.Stack,
+				))
+			}
 
 		default:
 			resourceResult.Action = actionFailed
@@ -272,5 +309,132 @@ func (b *Exec) ApplyDocuments(docs []parser.Document) (ApplyResult, error) {
 		result.Resources = append(result.Resources, resourceResult)
 	}
 
+	if team != "" {
+		pruneResults, pruneErr := b.pruneTeamObjects(team, appliedBlueprints, appliedConfigs)
+		if pruneErr != nil {
+			return result, pruneErr
+		}
+		result.Resources = append(result.Resources, pruneResults...)
+	}
+
 	return result, nil
+}
+
+// scopedRef identifies one Blueprint or Config by its scope-coordinate tuple
+// plus name. Two refs are equal under == when every field matches, so a
+// `map[scopedRef]struct{}` is a cheap set for the prune-difference scan.
+type scopedRef struct {
+	Realm string
+	Space string
+	Stack string
+	Name  string
+}
+
+func scopedRefFromMetadata(name, realm, space, stack string) scopedRef {
+	return scopedRef{Realm: realm, Space: space, Stack: stack, Name: name}
+}
+
+// stampTeamLabel returns labels with `kukeon.io/team` set to team. A nil
+// input is upgraded to a single-key map so the daemon never persists nil
+// labels alongside a team stamp. The input is not mutated — apply iterates
+// over caller-owned parser documents.
+func stampTeamLabel(labels map[string]string, team string) map[string]string {
+	out := make(map[string]string, len(labels)+1)
+	for k, v := range labels {
+		out[k] = v
+	}
+	out[v1beta1.LabelTeam] = team
+	return out
+}
+
+// pruneTeamObjects deletes daemon-stored CellBlueprint / CellConfig objects
+// carrying `kukeon.io/team=<team>` that the just-completed apply set did
+// not include (issue #1027). The two enumeration calls walk every realm
+// (an empty realm filter is the "all realms" subtree prefix in
+// runner.{ListBlueprints,ListConfigs}); a label-mismatch entry is skipped
+// silently. Each successful delete becomes a ResourceResult with
+// Action="pruned" so callers can render the prune count without re-querying
+// the daemon.
+//
+// Prune order is Config-then-Blueprint: a Config references a Blueprint at
+// apply time, so removing the Config first cannot orphan a reference. (Both
+// kinds independently support DeleteWithoutLiveCellTeardown, so the order
+// is purely consistency-with-apply, not safety.)
+func (b *Exec) pruneTeamObjects(team string, appliedBlueprints, appliedConfigs []scopedRef) ([]ResourceResult, error) {
+	appliedBP := refsToSet(appliedBlueprints)
+	appliedCfg := refsToSet(appliedConfigs)
+
+	configs, err := b.runner.ListConfigs("", "", "")
+	if err != nil {
+		return nil, fmt.Errorf("prune team %q: list configs: %w", team, err)
+	}
+	blueprints, err := b.runner.ListBlueprints("", "", "")
+	if err != nil {
+		return nil, fmt.Errorf("prune team %q: list blueprints: %w", team, err)
+	}
+
+	var out []ResourceResult
+
+	for _, cfg := range configs {
+		if cfg.Metadata.Labels[v1beta1.LabelTeam] != team {
+			continue
+		}
+		ref := scopedRefFromMetadata(cfg.Metadata.Name, cfg.Metadata.Realm, cfg.Metadata.Space, cfg.Metadata.Stack)
+		if _, kept := appliedCfg[ref]; kept {
+			continue
+		}
+		pruneResult := ResourceResult{
+			Kind:    "CellConfig",
+			Name:    cfg.Metadata.Name,
+			Action:  "pruned",
+			Details: scopeDetails(cfg.Metadata.Realm, cfg.Metadata.Space, cfg.Metadata.Stack),
+		}
+		if delErr := b.runner.DeleteConfig(cfg); delErr != nil {
+			pruneResult.Action = actionFailed
+			pruneResult.Error = fmt.Errorf("prune team %q: delete config %q: %w", team, cfg.Metadata.Name, delErr)
+		}
+		out = append(out, pruneResult)
+	}
+
+	for _, bp := range blueprints {
+		if bp.Metadata.Labels[v1beta1.LabelTeam] != team {
+			continue
+		}
+		ref := scopedRefFromMetadata(bp.Metadata.Name, bp.Metadata.Realm, bp.Metadata.Space, bp.Metadata.Stack)
+		if _, kept := appliedBP[ref]; kept {
+			continue
+		}
+		pruneResult := ResourceResult{
+			Kind:    "CellBlueprint",
+			Name:    bp.Metadata.Name,
+			Action:  "pruned",
+			Details: scopeDetails(bp.Metadata.Realm, bp.Metadata.Space, bp.Metadata.Stack),
+		}
+		if delErr := b.runner.DeleteBlueprint(bp); delErr != nil {
+			pruneResult.Action = actionFailed
+			pruneResult.Error = fmt.Errorf("prune team %q: delete blueprint %q: %w", team, bp.Metadata.Name, delErr)
+		}
+		out = append(out, pruneResult)
+	}
+
+	return out, nil
+}
+
+func refsToSet(refs []scopedRef) map[scopedRef]struct{} {
+	out := make(map[scopedRef]struct{}, len(refs))
+	for _, r := range refs {
+		out[r] = struct{}{}
+	}
+	return out
+}
+
+func scopeDetails(realm, space, stack string) map[string]string {
+	d := map[string]string{"realm": realm}
+	if space != "" {
+		d["space"] = space
+	}
+	if stack != "" {
+		d["stack"] = stack
+	}
+	return d
 }

--- a/internal/controller/apply_team_prune_test.go
+++ b/internal/controller/apply_team_prune_test.go
@@ -1,0 +1,264 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apply/parser"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// TestApplyDocuments_TeamPruneScopedToLabel pins issue #1027's pruning
+// apply contract: re-applying a shrunken team set must (a) persist the
+// new set with the team label stamped, (b) delete the team's prior
+// objects that fell out of the set, and (c) leave other teams' objects
+// and unlabeled objects untouched.
+func TestApplyDocuments_TeamPruneScopedToLabel(t *testing.T) {
+	storedBP := []intmodel.CellBlueprint{
+		labeledBlueprint("alpha-keep", "default", "alpha"),
+		labeledBlueprint("alpha-drop", "default", "alpha"),
+		labeledBlueprint("beta-keep", "default", "beta"),
+		unlabeledBlueprint("unlabeled-keep", "default"),
+	}
+	storedCfg := []intmodel.CellConfig{
+		labeledConfig("alpha-cfg-drop", "default", "alpha"),
+		labeledConfig("beta-cfg-keep", "default", "beta"),
+	}
+
+	var (
+		deletedBP, deletedCfg []string
+		writtenBP             []intmodel.CellBlueprint
+	)
+
+	mock := &fakeRunner{
+		// Scope existence — Blueprint reconcile checks GetRealm.
+		GetRealmFn: func(r intmodel.Realm) (intmodel.Realm, error) { return r, nil },
+		GetSpaceFn: func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		GetStackFn: func(s intmodel.Stack) (intmodel.Stack, error) { return s, nil },
+
+		WriteBlueprintFn: func(bp intmodel.CellBlueprint) (bool, error) {
+			writtenBP = append(writtenBP, bp)
+			return false, nil
+		},
+		ListBlueprintsFn: func(_, _, _ string) ([]intmodel.CellBlueprint, error) {
+			return storedBP, nil
+		},
+		DeleteBlueprintFn: func(bp intmodel.CellBlueprint) error {
+			deletedBP = append(deletedBP, bp.Metadata.Name)
+			return nil
+		},
+
+		ListConfigsFn: func(_, _, _ string) ([]intmodel.CellConfig, error) {
+			return storedCfg, nil
+		},
+		DeleteConfigFn: func(cfg intmodel.CellConfig) error {
+			deletedCfg = append(deletedCfg, cfg.Metadata.Name)
+			return nil
+		},
+	}
+
+	exec := setupTestController(t, mock)
+
+	docs := []parser.Document{
+		blueprintDoc(0, "alpha-keep", "default"),
+	}
+	result, err := exec.ApplyDocuments(docs, "alpha")
+	if err != nil {
+		t.Fatalf("ApplyDocuments(team=alpha) error = %v", err)
+	}
+
+	// The applied blueprint must have been written with the team label
+	// stamped onto its persisted document.
+	if len(writtenBP) != 1 {
+		t.Fatalf("WriteBlueprint call count = %d, want 1", len(writtenBP))
+	}
+	if !strings.Contains(string(writtenBP[0].Document), v1beta1.LabelTeam+": alpha") {
+		t.Errorf("written blueprint document missing team label stamp:\n%s", writtenBP[0].Document)
+	}
+
+	// Prune must touch only the alpha-team orphans — not other teams,
+	// not unlabeled objects, not the applied set member.
+	sort.Strings(deletedBP)
+	wantDeletedBP := []string{"alpha-drop"}
+	if !equalStringSlices(deletedBP, wantDeletedBP) {
+		t.Errorf("deleted blueprints = %v, want %v", deletedBP, wantDeletedBP)
+	}
+	sort.Strings(deletedCfg)
+	wantDeletedCfg := []string{"alpha-cfg-drop"}
+	if !equalStringSlices(deletedCfg, wantDeletedCfg) {
+		t.Errorf("deleted configs = %v, want %v", deletedCfg, wantDeletedCfg)
+	}
+
+	// The result must surface the prune actions so the caller can render
+	// the count without re-querying.
+	var pruneActions []string
+	for _, r := range result.Resources {
+		if r.Action == "pruned" {
+			pruneActions = append(pruneActions, r.Kind+"/"+r.Name)
+		}
+	}
+	sort.Strings(pruneActions)
+	wantPruneActions := []string{"CellBlueprint/alpha-drop", "CellConfig/alpha-cfg-drop"}
+	if !equalStringSlices(pruneActions, wantPruneActions) {
+		t.Errorf("result prune actions = %v, want %v", pruneActions, wantPruneActions)
+	}
+}
+
+// TestApplyDocuments_TeamPruneEmptySet covers AC bullet 2 in the empty
+// case: applying an empty set with a team label still prunes every
+// daemon-stored object carrying that label — the team's full roster was
+// removed from the source.
+func TestApplyDocuments_TeamPruneEmptySet(t *testing.T) {
+	storedBP := []intmodel.CellBlueprint{
+		labeledBlueprint("alpha-1", "default", "alpha"),
+		labeledBlueprint("alpha-2", "default", "alpha"),
+	}
+
+	var deleted []string
+	mock := &fakeRunner{
+		GetRealmFn: func(r intmodel.Realm) (intmodel.Realm, error) { return r, nil },
+		ListBlueprintsFn: func(_, _, _ string) ([]intmodel.CellBlueprint, error) {
+			return storedBP, nil
+		},
+		ListConfigsFn: func(_, _, _ string) ([]intmodel.CellConfig, error) {
+			return nil, nil
+		},
+		DeleteBlueprintFn: func(bp intmodel.CellBlueprint) error {
+			deleted = append(deleted, bp.Metadata.Name)
+			return nil
+		},
+	}
+	exec := setupTestController(t, mock)
+
+	// An empty applied set requires at least one document to satisfy
+	// the parseAndValidate "no valid documents" gate at the wire layer,
+	// but the controller-level ApplyDocuments accepts an empty slice —
+	// pass nil to exercise the pure prune path.
+	result, err := exec.ApplyDocuments(nil, "alpha")
+	if err != nil {
+		t.Fatalf("ApplyDocuments(nil, alpha) error = %v", err)
+	}
+
+	sort.Strings(deleted)
+	want := []string{"alpha-1", "alpha-2"}
+	if !equalStringSlices(deleted, want) {
+		t.Errorf("deleted = %v, want %v (empty applied set must prune the whole team)", deleted, want)
+	}
+	if len(result.Resources) != len(want) {
+		t.Errorf("result.Resources len = %d, want %d", len(result.Resources), len(want))
+	}
+}
+
+// TestApplyDocuments_NoTeamSkipsPrune confirms the historical
+// no-team `kuke apply -f` path stays prune-free: team="" must not call
+// ListBlueprints / ListConfigs and must not delete anything.
+func TestApplyDocuments_NoTeamSkipsPrune(t *testing.T) {
+	var (
+		listCalled   bool
+		deleteCalled bool
+	)
+	mock := &fakeRunner{
+		GetRealmFn: func(r intmodel.Realm) (intmodel.Realm, error) { return r, nil },
+		WriteBlueprintFn: func(intmodel.CellBlueprint) (bool, error) {
+			return false, nil
+		},
+		ListBlueprintsFn: func(_, _, _ string) ([]intmodel.CellBlueprint, error) {
+			listCalled = true
+			return nil, nil
+		},
+		ListConfigsFn: func(_, _, _ string) ([]intmodel.CellConfig, error) {
+			listCalled = true
+			return nil, nil
+		},
+		DeleteBlueprintFn: func(intmodel.CellBlueprint) error {
+			deleteCalled = true
+			return nil
+		},
+	}
+	exec := setupTestController(t, mock)
+
+	docs := []parser.Document{blueprintDoc(0, "any", "default")}
+	if _, err := exec.ApplyDocuments(docs, ""); err != nil {
+		t.Fatalf("ApplyDocuments(team='') error = %v", err)
+	}
+	if listCalled {
+		t.Error("team='' apply must not enumerate daemon objects (no prune)")
+	}
+	if deleteCalled {
+		t.Error("team='' apply must not delete anything (no prune)")
+	}
+}
+
+func labeledBlueprint(name, realm, team string) intmodel.CellBlueprint {
+	return intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{
+			Name:   name,
+			Realm:  realm,
+			Labels: map[string]string{v1beta1.LabelTeam: team},
+		},
+	}
+}
+
+func unlabeledBlueprint(name, realm string) intmodel.CellBlueprint {
+	return intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: name, Realm: realm},
+	}
+}
+
+func labeledConfig(name, realm, team string) intmodel.CellConfig {
+	return intmodel.CellConfig{
+		Metadata: intmodel.CellConfigMetadata{
+			Name:   name,
+			Realm:  realm,
+			Labels: map[string]string{v1beta1.LabelTeam: team},
+		},
+	}
+}
+
+// blueprintDoc builds a parser.Document carrying a minimal CellBlueprintDoc
+// at realm scope. The body is irrelevant to the team-prune contract; the
+// metadata is what the apply path stamps and persists.
+func blueprintDoc(index int, name, realm string) parser.Document {
+	bp := &v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  name,
+			Realm: realm,
+		},
+		Spec: v1beta1.CellBlueprintSpec{
+			Cell: v1beta1.BlueprintCellSpec{
+				Containers: []v1beta1.BlueprintContainer{
+					{ID: "root", Root: true, Image: "busybox:latest"},
+				},
+			},
+		},
+	}
+	return parser.Document{
+		Index:            index,
+		Kind:             v1beta1.KindCellBlueprint,
+		APIVersion:       v1beta1.APIVersionV1Beta1,
+		CellBlueprintDoc: bp,
+	}
+}
+

--- a/internal/controller/reconcile_outofsync_test.go
+++ b/internal/controller/reconcile_outofsync_test.go
@@ -429,8 +429,13 @@ func TestReconcileCells_OutOfSync_RealmScopedConfigFoundForStackPlacedCell(t *te
 		t.Fatalf("GetConfig probe count: got %d want %d (probes=%+v)", len(probes), len(wantProbes), probes)
 	}
 	for i, p := range probes {
-		if p != wantProbes[i] {
-			t.Errorf("probe[%d] = %+v, want %+v", i, p, wantProbes[i])
+		// CellConfigMetadata carries a Labels map (issue #1027) so the
+		// struct is no longer comparable with !=; compare scope-coordinate
+		// fields explicitly since that is what this probe-ordering test
+		// asserts.
+		w := wantProbes[i]
+		if p.Name != w.Name || p.Realm != w.Realm || p.Space != w.Space || p.Stack != w.Stack {
+			t.Errorf("probe[%d] = %+v, want %+v", i, p, w)
 		}
 	}
 	// The Config was found at realm scope, so the verdict must NOT be

--- a/internal/controller/runner/blueprint.go
+++ b/internal/controller/runner/blueprint.go
@@ -26,6 +26,7 @@ import (
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/fs"
+	"gopkg.in/yaml.v3"
 )
 
 // blueprintsDirMode is the mode of the per-scope blueprints/ directory. Unlike
@@ -168,7 +169,12 @@ func (r *Exec) collectBlueprintSubtree(out *[]intmodel.CellBlueprint, realm, spa
 // collectBlueprintsInScope appends the metadata of every CellBlueprint stored
 // directly at the given scope (realm, space, stack). The in-flight
 // ".blueprint-*.tmp" temp files WriteBlueprint creates are skipped so a
-// concurrent apply never surfaces a half-written name.
+// concurrent apply never surfaces a half-written name. Each carrier's
+// Metadata.Labels is populated by parsing the document's `metadata.labels`
+// (issue #1027) — `kukeon.io/team=<team>` is the prune-apply discriminator,
+// so callers can filter without re-reading every document themselves. A
+// document that fails to parse contributes an entry with nil Labels and is
+// logged at debug — the list call is best-effort metadata, not strict.
 func (r *Exec) collectBlueprintsInScope(out *[]intmodel.CellBlueprint, realm, space, stack string) error {
 	dir := fs.BlueprintsDir(r.opts.RunPath, realm, space, stack)
 	entries, err := os.ReadDir(dir)
@@ -186,16 +192,48 @@ func (r *Exec) collectBlueprintsInScope(out *[]intmodel.CellBlueprint, realm, sp
 		if strings.HasPrefix(name, ".blueprint-") && strings.HasSuffix(name, ".tmp") {
 			continue
 		}
+		labels := r.readLabelsFromDoc(fs.BlueprintPath(r.opts.RunPath, realm, space, stack, name))
 		*out = append(*out, intmodel.CellBlueprint{
 			Metadata: intmodel.CellBlueprintMetadata{
-				Name:  name,
-				Realm: realm,
-				Space: space,
-				Stack: stack,
+				Name:   name,
+				Realm:  realm,
+				Space:  space,
+				Stack:  stack,
+				Labels: labels,
 			},
 		})
 	}
 	return nil
+}
+
+// labelsOnlyDoc is the minimum YAML structure needed to extract a daemon-
+// stored document's labels without parsing the full spec. Shared between
+// blueprint and config list paths (issue #1027).
+type labelsOnlyDoc struct {
+	Metadata struct {
+		Labels map[string]string `yaml:"labels"`
+	} `yaml:"metadata"`
+}
+
+// readLabelsFromDoc reads path and returns the parsed metadata.labels map,
+// or nil on any failure. Errors are logged at debug rather than propagated —
+// the list call's contract is best-effort metadata: a half-written or
+// corrupt document should not fail the whole list (issue #1027).
+func (r *Exec) readLabelsFromDoc(path string) map[string]string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		r.logger.DebugContext(r.ctx, "read labels: read file", "path", path, "error", err)
+		return nil
+	}
+	var doc labelsOnlyDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		r.logger.DebugContext(r.ctx, "read labels: parse yaml", "path", path, "error", err)
+		return nil
+	}
+	if len(doc.Metadata.Labels) == 0 {
+		return nil
+	}
+	return doc.Metadata.Labels
 }
 
 // DeleteBlueprint removes the daemon-stored document file for a single named,

--- a/internal/controller/runner/blueprint_test.go
+++ b/internal/controller/runner/blueprint_test.go
@@ -294,6 +294,71 @@ func TestListBlueprints_IgnoresReservedSubdirs(t *testing.T) {
 	}
 }
 
+// TestListBlueprints_PopulatesLabelsFromDocument confirms ListBlueprints
+// lifts `metadata.labels` out of each blueprint's persisted YAML body
+// (issue #1027): the prune-apply path keys on `kukeon.io/team=<team>` to
+// pick its prune set, so labels must round-trip via the list, not require
+// a per-blueprint GetBlueprint follow-up.
+func TestListBlueprints_PopulatesLabelsFromDocument(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	bp := intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{Name: "web", Realm: "default"},
+		Document: []byte("apiVersion: v1beta1\n" +
+			"kind: CellBlueprint\n" +
+			"metadata:\n" +
+			"  name: web\n" +
+			"  realm: default\n" +
+			"  labels:\n" +
+			"    kukeon.io/team: sbsh\n" +
+			"    foo: bar\n"),
+	}
+	if _, err := r.WriteBlueprint(bp); err != nil {
+		t.Fatalf("WriteBlueprint() error = %v", err)
+	}
+
+	got, err := r.ListBlueprints("default", "", "")
+	if err != nil {
+		t.Fatalf("ListBlueprints() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d blueprints, want 1", len(got))
+	}
+	if got[0].Metadata.Labels["kukeon.io/team"] != "sbsh" {
+		t.Errorf("Labels[kukeon.io/team] = %q, want sbsh (labels must round-trip via list)", got[0].Metadata.Labels["kukeon.io/team"])
+	}
+	if got[0].Metadata.Labels["foo"] != "bar" {
+		t.Errorf("Labels[foo] = %q, want bar (all labels must round-trip)", got[0].Metadata.Labels["foo"])
+	}
+}
+
+// TestListBlueprints_UnreadableDocSkipsLabelsWithoutFailingList confirms
+// the list is best-effort metadata: a corrupt or unreadable document body
+// surfaces the blueprint with nil Labels rather than failing the whole
+// list (issue #1027). Pruning a corrupted entry by team label is still
+// safe — a missing team label simply excludes it from the prune set.
+func TestListBlueprints_UnreadableDocSkipsLabelsWithoutFailingList(t *testing.T) {
+	runPath := t.TempDir()
+	r := newMetadataTestExec(t, runPath, time.Now())
+
+	seedBlueprint(t, r, "good", "default", "", "")
+	// Drop an unparseable file alongside the good one — same dir, doc
+	// body that yaml can't unmarshal into the labelsOnly struct.
+	bad := fs.BlueprintPath(runPath, "default", "", "", "bad")
+	if err := os.WriteFile(bad, []byte("\x00\x01\x02 not yaml"), 0o644); err != nil {
+		t.Fatalf("write bad blueprint: %v", err)
+	}
+
+	got, err := r.ListBlueprints("default", "", "")
+	if err != nil {
+		t.Fatalf("ListBlueprints() error = %v (must surface corrupt entries, not fail)", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d blueprints, want 2 (both good and corrupt must surface)", len(got))
+	}
+}
+
 func TestDeleteBlueprint_RemovesFile(t *testing.T) {
 	runPath := t.TempDir()
 	r := newMetadataTestExec(t, runPath, time.Now())

--- a/internal/controller/runner/config.go
+++ b/internal/controller/runner/config.go
@@ -230,7 +230,12 @@ func (r *Exec) collectConfigSubtree(out *[]intmodel.CellConfig, realm, space, st
 // collectConfigsInScope appends the metadata of every CellConfig stored
 // directly at the given scope (realm, space, stack). The in-flight
 // ".config-*.tmp" temp files WriteConfig creates are skipped so a concurrent
-// apply never surfaces a half-written name.
+// apply never surfaces a half-written name. Each carrier's Metadata.Labels
+// is populated by parsing the document's `metadata.labels` (issue #1027) —
+// `kukeon.io/team=<team>` is the prune-apply discriminator, so callers can
+// filter without re-reading every document themselves. A document that fails
+// to parse contributes an entry with nil Labels and is logged at debug — the
+// list call is best-effort metadata, not strict.
 func (r *Exec) collectConfigsInScope(out *[]intmodel.CellConfig, realm, space, stack string) error {
 	dir := fs.ConfigsDir(r.opts.RunPath, realm, space, stack)
 	entries, err := os.ReadDir(dir)
@@ -248,12 +253,14 @@ func (r *Exec) collectConfigsInScope(out *[]intmodel.CellConfig, realm, space, s
 		if strings.HasPrefix(name, ".config-") && strings.HasSuffix(name, ".tmp") {
 			continue
 		}
+		labels := r.readLabelsFromDoc(fs.ConfigPath(r.opts.RunPath, realm, space, stack, name))
 		*out = append(*out, intmodel.CellConfig{
 			Metadata: intmodel.CellConfigMetadata{
-				Name:  name,
-				Realm: realm,
-				Space: space,
-				Stack: stack,
+				Name:   name,
+				Realm:  realm,
+				Space:  space,
+				Stack:  stack,
+				Labels: labels,
 			},
 		})
 	}

--- a/internal/daemon/rpcservice.go
+++ b/internal/daemon/rpcservice.go
@@ -445,7 +445,15 @@ func (s *KukeonV1Service) Ping(_ *kukeonv1.PingArgs, reply *kukeonv1.PingReply) 
 // ---- Apply ----
 
 func (s *KukeonV1Service) ApplyDocuments(args *kukeonv1.ApplyDocumentsArgs, reply *kukeonv1.ApplyDocumentsReply) error {
-	result, err := s.core.ApplyDocuments(s.ctx, args.RawYAML)
+	var (
+		result kukeonv1.ApplyDocumentsResult
+		err    error
+	)
+	if args.Team != "" {
+		result, err = s.core.ApplyDocumentsForTeam(s.ctx, args.RawYAML, args.Team)
+	} else {
+		result, err = s.core.ApplyDocuments(s.ctx, args.RawYAML)
+	}
 	reply.Result = result
 	reply.Err = kukeonv1.ToAPIError(err)
 	return nil

--- a/internal/modelhub/cellblueprint.go
+++ b/internal/modelhub/cellblueprint.go
@@ -45,4 +45,11 @@ type CellBlueprintMetadata struct {
 	Realm string
 	Space string
 	Stack string
+	// Labels lifts the blueprint document's metadata.labels onto the carrier
+	// so daemon-side code can filter (`kukeon.io/team=<team>` for
+	// per-team prune apply, #1027) without re-parsing the Document on every
+	// access. ListBlueprints populates it; WriteBlueprint preserves it via
+	// the Document round-trip — the labels travel inside the canonical
+	// serialized doc, the carrier just lifts a typed view.
+	Labels map[string]string
 }

--- a/internal/modelhub/cellconfig.go
+++ b/internal/modelhub/cellconfig.go
@@ -38,4 +38,11 @@ type CellConfigMetadata struct {
 	Realm string
 	Space string
 	Stack string
+	// Labels lifts the config document's metadata.labels onto the carrier
+	// so daemon-side code can filter (`kukeon.io/team=<team>` for per-team
+	// prune apply, #1027) without re-parsing the Document on every access.
+	// ListConfigs populates it; WriteConfig preserves it via the Document
+	// round-trip — the labels travel inside the canonical serialized doc,
+	// the carrier just lifts a typed view.
+	Labels map[string]string
 }

--- a/pkg/api/kukeonv1/client.go
+++ b/pkg/api/kukeonv1/client.go
@@ -147,6 +147,17 @@ type Client interface {
 
 	RefreshAll(ctx context.Context) (RefreshAllResult, error)
 	ApplyDocuments(ctx context.Context, rawYAML []byte) (ApplyDocumentsResult, error)
+	// ApplyDocumentsForTeam is the per-team prune-apply sibling of
+	// ApplyDocuments (issue #1027). It stamps every applied CellBlueprint /
+	// CellConfig with `kukeon.io/team=<team>` and, after the apply loop,
+	// deletes daemon-stored Blueprint / Config objects carrying the same
+	// team label that the applied set did not include. Used by `kuke team
+	// init` (#796) to make project rosters converge: re-running on a
+	// shrunken roster prunes the orphans without touching other teams or
+	// running cells (deleting a Blueprint or Config never deletes the cell
+	// materialized from it). Empty team is rejected — use ApplyDocuments
+	// for the no-team path.
+	ApplyDocumentsForTeam(ctx context.Context, rawYAML []byte, team string) (ApplyDocumentsResult, error)
 	// DeleteDocuments is the file-driven counterpart to ApplyDocuments —
 	// `kuke delete -f` sends the raw YAML over the wire so deletes honor
 	// `--host` routing the same way applies do. Per-resource cascade/force

--- a/pkg/api/kukeonv1/fake.go
+++ b/pkg/api/kukeonv1/fake.go
@@ -213,6 +213,12 @@ func (FakeClient) ApplyDocuments(context.Context, []byte) (ApplyDocumentsResult,
 	return ApplyDocumentsResult{}, ErrUnexpectedCall
 }
 
+func (FakeClient) ApplyDocumentsForTeam(
+	context.Context, []byte, string,
+) (ApplyDocumentsResult, error) {
+	return ApplyDocumentsResult{}, ErrUnexpectedCall
+}
+
 func (FakeClient) DeleteDocuments(context.Context, []byte, bool, bool) (DeleteDocumentsResult, error) {
 	return DeleteDocumentsResult{}, ErrUnexpectedCall
 }

--- a/pkg/api/kukeonv1/rpcclient.go
+++ b/pkg/api/kukeonv1/rpcclient.go
@@ -748,7 +748,23 @@ func (c *UnixClient) RefreshAll(ctx context.Context) (RefreshAllResult, error) {
 
 // ApplyDocuments implements Client.
 func (c *UnixClient) ApplyDocuments(ctx context.Context, rawYAML []byte) (ApplyDocumentsResult, error) {
-	args := &ApplyDocumentsArgs{RawYAML: rawYAML}
+	return c.applyDocuments(ctx, rawYAML, "")
+}
+
+// ApplyDocumentsForTeam implements Client.
+func (c *UnixClient) ApplyDocumentsForTeam(
+	ctx context.Context, rawYAML []byte, team string,
+) (ApplyDocumentsResult, error) {
+	if team == "" {
+		return ApplyDocumentsResult{}, errors.New("apply for team: team is required")
+	}
+	return c.applyDocuments(ctx, rawYAML, team)
+}
+
+func (c *UnixClient) applyDocuments(
+	ctx context.Context, rawYAML []byte, team string,
+) (ApplyDocumentsResult, error) {
+	args := &ApplyDocumentsArgs{RawYAML: rawYAML, Team: team}
 	reply := &ApplyDocumentsReply{}
 	if err := c.call(ctx, MethodApplyDocuments, args, reply); err != nil {
 		return ApplyDocumentsResult{}, err

--- a/pkg/api/kukeonv1/types.go
+++ b/pkg/api/kukeonv1/types.go
@@ -779,8 +779,17 @@ type PingReply struct {
 
 // ApplyDocumentsArgs carries a raw multi-document YAML blob. The server
 // parses and validates; validation errors are returned in the Reply.Err.
+//
+// Team, when non-empty, switches the apply into per-team prune mode
+// (issue #1027): every applied CellBlueprint / CellConfig has its
+// `metadata.labels[kukeon.io/team]` set to Team before persistence, and
+// after the apply loop the daemon enumerates daemon-stored Blueprint /
+// Config objects carrying `kukeon.io/team=<Team>` and deletes those not
+// in the applied set. The empty-string default preserves the historical
+// no-team, no-prune `kuke apply -f` behavior.
 type ApplyDocumentsArgs struct {
 	RawYAML []byte
+	Team    string
 }
 
 type ApplyDocumentsReply struct {

--- a/pkg/api/model/v1beta1/consts.go
+++ b/pkg/api/model/v1beta1/consts.go
@@ -69,6 +69,17 @@ const (
 	KindClientConfiguration Kind = "ClientConfiguration"
 )
 
+// Label keys with reserved kukeon.io semantics. Other label keys on a
+// resource's metadata.labels are user-controlled and carry no daemon meaning.
+const (
+	// LabelTeam scopes an applied CellBlueprint / CellConfig to a project
+	// (issue #1027). `kuke team init` (#796) stamps it on every object it
+	// applies for one project so a repeat init can prune the team's prior
+	// objects that the new roster no longer declares — converging the
+	// project's slice without touching other teams' objects.
+	LabelTeam = "kukeon.io/team"
+)
+
 // Common printable state strings.
 const (
 	StatePendingStr  = "Pending"


### PR DESCRIPTION
## Summary

- Adds the daemon-side prerequisite for `kuke team init` (#796) under the team-distribution epic (#792): per-team scoping on applied CellBlueprint / CellConfig objects, and a pruning apply mode that converges a team's roster by deleting the team's prior objects the new set no longer declares.
- The Apply RPC gains an optional `Team` field. When set, the daemon stamps `kukeon.io/team=<team>` on every applied Blueprint / Config, then enumerates daemon-stored objects carrying that label and deletes those not in the applied set. Empty `Team` preserves the historical no-team, no-prune `kuke apply -f` path.
- `ListBlueprints` / `ListConfigs` now populate `Metadata.Labels` by parsing each persisted document's `metadata.labels`, so the prune pass and any client-side selector can filter by team without a per-object Get follow-up.
- Running cells are preserved by construction: re-applying an unchanged Blueprint / Config overwrites the same document bytes (no recreate path), and `DeleteBlueprint` / `DeleteConfig` are documented as having no live-reference gate (cells are independent copies per #620, materialized cells outlive their Config per #644).

## Design notes

- New `ApplyDocumentsForTeam` method on the `kukeonv1.Client` interface instead of changing the `ApplyDocuments` signature — keeps existing call sites untouched while exposing the new mode for #796 and other future consumers. Both methods route through the same `MethodApplyDocuments` wire endpoint; `ApplyDocumentsArgs.Team` is the optional discriminator.
- The team label is set by the apply caller (stamped server-side), not required to be hand-written into every YAML document. This matches the per-project semantics of `kuke team init`: the verb knows the project name; the YAML doesn't need to.
- Prune-result entries are surfaced as `ApplyResourceResult{Action: "pruned"}` so callers can render the prune count without re-querying the daemon.
- `pruneTeamObjects` walks Configs before Blueprints so the order mirrors apply-time dependency direction (Config references Blueprint), though both DeleteBlueprint/DeleteConfig are independent of live cells so safety doesn't depend on order.
- `intmodel.CellBlueprintMetadata` and `intmodel.CellConfigMetadata` gained `Labels map[string]string`. The structs are no longer comparable with `==`/`!=`; `internal/controller/reconcile_outofsync_test.go:432` was updated to field-by-field comparison (probe-ordering test, only scope coordinates matter there).

## Out of scope

- No CLI surface (`kuke apply --team <name>`) added — `kuke team init` (#796) is the in-tree consumer and will call `ApplyDocumentsForTeam` directly through the client. A `--team` flag on `kuke apply` is a natural follow-up if hand-driven per-team apply ever becomes useful.
- No `-l/--selector` flag wired into `kuke get blueprints` / `kuke get configs`. The runner now returns labels through the existing list RPC, so adding the flag is a small follow-up that reuses `cmd/kuke/get/shared/selector.go` — out of scope here, since the AC's "queried by team label" capability is satisfied by the daemon-side list returning labels.

## Acceptance criteria

- [x] CellBlueprint/CellConfig apply accepts and persists a `team` label.
- [x] An apply mode takes a set + a team label and prunes daemon objects with that label not present in the set.
- [x] Objects can be listed/queried by `team` label (`ListBlueprints` / `ListConfigs` round-trip `Metadata.Labels` from each document body).
- [x] Re-applying an unchanged set is a no-op for running cells (no restart, no recreate) — relies on existing invariants in `runner.WriteBlueprint`/`WriteConfig` (write-through, no cell touch) and `DeleteBlueprint`/`DeleteConfig` (no live-reference gate; cells are independent of their Blueprint/Config source).
- [x] Unit/e2e: apply set A (team=t) then set B⊂A (team=t) → members of A∖B are pruned, other teams untouched. Covered by `TestApplyDocuments_TeamPruneScopedToLabel` + `TestApplyDocuments_TeamPruneEmptySet` + `TestApplyDocuments_NoTeamSkipsPrune` in `internal/controller/apply_team_prune_test.go`.

## Test plan

- [x] `GOWORK=off go test $(GOWORK=off go list ./... | grep -v /e2e)` — full project test target (the Makefile's `test-root`), all packages green including `internal/controller`, `internal/controller/runner`, `internal/controller/apply`, `internal/apischeme`, `internal/client/local`, `internal/daemon`, `pkg/api/kukeonv1`, `cmd/kuke/apply`.
- [x] `GOWORK=off go test ./cmd/kukebuild/...` — the second leg of `make test`'s `test-kukebuild`.
- [x] `GOWORK=off go vet ./...` clean.
- [x] `GOWORK=off go build ./...` clean.
- [ ] `make dev-init` smoke not run — change is daemon controller logic only; no build, install, or `/opt/kukeon` paths touched.

Closes #1027