### PR TITLE
refactor(cli): require --from-blueprint or --from-config on kuke create cell (step 3)

### DIFF
--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -41,11 +41,10 @@ func NewCellCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cell [name]",
 		Aliases: []string{"ce"},
-		Short:   "Create a cell within a stack (empty shell, --from-blueprint, or --from-config)",
-		Long: "Create a cell within a stack. Three modes:\n\n" +
-			"  - `kuke create cell <name>` (no source flag) — creates an empty Cell " +
-			"shell (name + scope only, no containers). Workflow C: follow with " +
-			"`kuke create container -c <name> --image ...` and `kuke start <name>`.\n" +
+		Short:   "Create a cell within a stack from a Blueprint or Config",
+		Long: "Create a cell within a stack. Exactly one of --from-blueprint or " +
+			"--from-config is required; use `kuke apply -f <file>` to materialise " +
+			"a cell from a full manifest. Two modes:\n\n" +
 			"  - `kuke create cell <name> --from-blueprint <bp> [--param k=v] [--param-file path]` — " +
 			"resolves the daemon-stored CellBlueprint, applies scalar params, " +
 			"materialises the full Cell record (containers and all), and " +
@@ -134,13 +133,21 @@ type createCellFlags struct {
 
 // parseCreateCellFlags validates the flag combinations and trims values. The
 // cobra-side mutex enforces --from-blueprint vs --from-config; this routine
-// also rejects --param/--param-file when --from-config is set (a CellConfig
-// carries its own spec.values, parity with `kuke run -c`).
+// also requires exactly one of those flags (the empty-shell mode retired with
+// epic:bye-container step 3) and rejects --param/--param-file when
+// --from-config is set (a CellConfig carries its own spec.values, parity with
+// `kuke run -c`).
 func parseCreateCellFlags(cmd *cobra.Command, args []string) (createCellFlags, error) {
 	flags := createCellFlags{
 		blueprintName: strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_FROM_BLUEPRINT.ViperKey)),
 		configName:    strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_FROM_CONFIG.ViperKey)),
 		paramFile:     strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_PARAM_FILE.ViperKey)),
+	}
+
+	if flags.blueprintName == "" && flags.configName == "" {
+		return createCellFlags{}, errors.New(
+			"kuke create cell requires --from-blueprint or --from-config (use 'kuke apply -f <file>' for a full manifest)",
+		)
 	}
 
 	name, err := shared.RequireNameArgOrDefault(
@@ -202,36 +209,10 @@ func runCreateCell(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = client.Close() }()
 
-	switch {
-	case flags.blueprintName != "":
+	if flags.blueprintName != "" {
 		return runFromBlueprint(cmd, client, flags)
-	case flags.configName != "":
-		return runFromConfig(cmd, client, flags)
-	default:
-		return runEmptyShell(cmd, client, flags)
 	}
-}
-
-// runEmptyShell preserves the pre-#818 behavior: create an empty Cell
-// shell (name + scope only, no containers). The daemon's CreateCell is
-// idempotent on an existing empty cell, so no pre-check is needed.
-func runEmptyShell(cmd *cobra.Command, client kukeonv1.Client, flags createCellFlags) error {
-	doc := v1beta1.NewCellDoc(&v1beta1.CellDoc{
-		Metadata: v1beta1.CellMetadata{Name: flags.name},
-		Spec: v1beta1.CellSpec{
-			RealmID: flags.realm,
-			SpaceID: flags.space,
-			StackID: flags.stack,
-		},
-	})
-
-	result, err := client.CreateCell(cmd.Context(), *doc)
-	if err != nil {
-		return err
-	}
-
-	printCellResult(cmd, result)
-	return nil
+	return runFromConfig(cmd, client, flags)
 }
 
 // runFromBlueprint resolves the named Blueprint, applies --param/--param-file,

--- a/cmd/kuke/create/cell/cell_test.go
+++ b/cmd/kuke/create/cell/cell_test.go
@@ -205,219 +205,36 @@ func TestPrintCellResult(t *testing.T) {
 	}
 }
 
-func TestNewCellCmdRunE(t *testing.T) {
+func TestNewCellCmdRunE_RequiresSourceFlag(t *testing.T) {
+	// Parse-time rejection: with no --from-blueprint and no --from-config,
+	// the command must error before any client call. Empty-shell mode retired
+	// with epic:bye-container step 3 (#996).
 	t.Cleanup(viper.Reset)
 
 	tests := []struct {
-		name           string
-		args           []string
-		setup          func(t *testing.T, cmd *cobra.Command)
-		clientFn       func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error)
-		wantErr        string
-		wantCallCreate bool
-		wantDoc        v1beta1.CellDoc
-		wantOutput     []string
+		name  string
+		args  []string
+		setup func(t *testing.T, cmd *cobra.Command)
 	}{
 		{
-			name: "success: name from args with flags",
+			name: "name from positional, scope flags set",
 			args: []string{"test-cell"},
 			setup: func(t *testing.T, cmd *cobra.Command) {
 				setFlag(t, cmd, "realm", "realm-a")
 				setFlag(t, cmd, "space", "space-a")
 				setFlag(t, cmd, "stack", "stack-a")
 			},
-			clientFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{
-					Cell:                    doc,
-					Created:                 true,
-					MetadataExistsPost:      true,
-					CgroupCreated:           true,
-					CgroupExistsPost:        true,
-					RootContainerCreated:    true,
-					RootContainerExistsPost: true,
-					Started:                 true,
-				}, nil
-			},
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("test-cell", "realm-a", "space-a", "stack-a"),
-			wantOutput: []string{
-				`Cell "test-cell" (realm "realm-a", space "space-a", stack "stack-a")`,
-			},
 		},
 		{
-			name: "success: name from viper with flags",
+			name: "name from viper, scope flags set",
 			setup: func(t *testing.T, cmd *cobra.Command) {
 				viper.Set(config.KUKE_CREATE_CELL_NAME.ViperKey, "viper-cell")
 				setFlag(t, cmd, "realm", "realm-b")
-				setFlag(t, cmd, "space", "space-b")
-				setFlag(t, cmd, "stack", "stack-b")
-			},
-			clientFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{
-					Cell:                    doc,
-					Created:                 true,
-					MetadataExistsPost:      true,
-					CgroupCreated:           true,
-					CgroupExistsPost:        true,
-					RootContainerCreated:    true,
-					RootContainerExistsPost: true,
-					Started:                 true,
-				}, nil
-			},
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("viper-cell", "realm-b", "space-b", "stack-b"),
-			wantOutput: []string{
-				`Cell "viper-cell" (realm "realm-b", space "space-b", stack "stack-b")`,
 			},
 		},
 		{
-			name: "success: all from viper",
-			setup: func(_ *testing.T, _ *cobra.Command) {
-				viper.Set(config.KUKE_CREATE_CELL_NAME.ViperKey, "all-viper-cell")
-				viper.Set(config.KUKE_CREATE_CELL_REALM.ViperKey, "realm-c")
-				viper.Set(config.KUKE_CREATE_CELL_SPACE.ViperKey, "space-c")
-				viper.Set(config.KUKE_CREATE_CELL_STACK.ViperKey, "stack-c")
-			},
-			clientFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{
-					Cell:                    doc,
-					Created:                 false,
-					MetadataExistsPost:      true,
-					CgroupExistsPost:        true,
-					RootContainerExistsPost: true,
-					Started:                 false,
-				}, nil
-			},
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("all-viper-cell", "realm-c", "space-c", "stack-c"),
-			wantOutput: []string{
-				`Cell "all-viper-cell" (realm "realm-c", space "space-c", stack "stack-c")`,
-			},
-		},
-		{
-			name:           "error: missing name",
-			setup:          func(_ *testing.T, _ *cobra.Command) {},
-			wantErr:        "cell name is required",
-			wantCallCreate: false,
-		},
-		{
-			name: "uses default realm when realm flag not set",
-			args: []string{"test-cell"},
-			setup: func(t *testing.T, cmd *cobra.Command) {
-				setFlag(t, cmd, "space", "space-a")
-				setFlag(t, cmd, "stack", "stack-a")
-			},
-			clientFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{
-					Cell:                    doc,
-					Created:                 true,
-					MetadataExistsPost:      true,
-					CgroupCreated:           true,
-					CgroupExistsPost:        true,
-					RootContainerCreated:    true,
-					RootContainerExistsPost: true,
-				}, nil
-			},
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("test-cell", "default", "space-a", "stack-a"),
-		},
-		{
-			name: "uses default space when space flag not set",
-			args: []string{"test-cell"},
-			setup: func(t *testing.T, cmd *cobra.Command) {
-				setFlag(t, cmd, "realm", "realm-a")
-				setFlag(t, cmd, "stack", "stack-a")
-			},
-			clientFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{
-					Cell:                    doc,
-					Created:                 true,
-					MetadataExistsPost:      true,
-					CgroupCreated:           true,
-					CgroupExistsPost:        true,
-					RootContainerCreated:    true,
-					RootContainerExistsPost: true,
-				}, nil
-			},
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("test-cell", "realm-a", "default", "stack-a"),
-		},
-		{
-			name: "uses default stack when stack flag not set",
-			args: []string{"test-cell"},
-			setup: func(t *testing.T, cmd *cobra.Command) {
-				setFlag(t, cmd, "realm", "realm-a")
-				setFlag(t, cmd, "space", "space-a")
-			},
-			clientFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{
-					Cell:                    doc,
-					Created:                 true,
-					MetadataExistsPost:      true,
-					CgroupCreated:           true,
-					CgroupExistsPost:        true,
-					RootContainerCreated:    true,
-					RootContainerExistsPost: true,
-				}, nil
-			},
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("test-cell", "realm-a", "space-a", "default"),
-		},
-		{
-			name: "error: CreateCell fails",
-			args: []string{"test-cell"},
-			setup: func(t *testing.T, cmd *cobra.Command) {
-				setFlag(t, cmd, "realm", "realm-a")
-				setFlag(t, cmd, "space", "space-a")
-				setFlag(t, cmd, "stack", "stack-a")
-			},
-			clientFn: func(_ v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{}, errdefs.ErrCreateCell
-			},
-			wantErr:        "failed to create cell",
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("test-cell", "realm-a", "space-a", "stack-a"),
-		},
-		{
-			name: "error: realm with whitespace trimmed",
-			args: []string{"test-cell"},
-			setup: func(t *testing.T, cmd *cobra.Command) {
-				setFlag(t, cmd, "realm", "  ")
-				setFlag(t, cmd, "space", "space-a")
-				setFlag(t, cmd, "stack", "stack-a")
-			},
-			clientFn: func(_ v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{}, errors.New("unexpected call")
-			},
-			// With blank realm, local path short-circuits in the controller;
-			// but through the mock client we also see the empty RealmID get through
-			// since normalization runs server-side. Assert call path + empty realm.
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("test-cell", "", "space-a", "stack-a"),
-			wantErr:        "unexpected call",
-		},
-		{
-			name: "success: realm with whitespace trimmed",
-			args: []string{"test-cell"},
-			setup: func(t *testing.T, cmd *cobra.Command) {
-				setFlag(t, cmd, "realm", "  realm-a  ")
-				setFlag(t, cmd, "space", "  space-a  ")
-				setFlag(t, cmd, "stack", "  stack-a  ")
-			},
-			clientFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-				return kukeonv1.CreateCellResult{
-					Cell:                    doc,
-					Created:                 true,
-					MetadataExistsPost:      true,
-					CgroupCreated:           true,
-					CgroupExistsPost:        true,
-					RootContainerCreated:    true,
-					RootContainerExistsPost: true,
-					Started:                 true,
-				}, nil
-			},
-			wantCallCreate: true,
-			wantDoc:        newCellDoc("test-cell", "realm-a", "space-a", "stack-a"),
+			name:  "no name, no scope flags",
+			setup: func(_ *testing.T, _ *cobra.Command) {},
 		},
 	}
 
@@ -425,33 +242,167 @@ func TestNewCellCmdRunE(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Cleanup(viper.Reset)
 
-			var createCalled bool
-			var createDoc v1beta1.CellDoc
-
-			cmd := cell.NewCellCmd()
-			cmd.SetOut(&bytes.Buffer{})
-			cmd.SetErr(&bytes.Buffer{})
-
-			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-
-			if tt.clientFn != nil {
-				fake := &fakeClient{
-					createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-						createCalled = true
-						createDoc = doc
-						return tt.clientFn(doc)
-					},
-				}
-				ctx = context.WithValue(ctx, cell.MockControllerKey{}, kukeonv1.Client(fake))
+			fc := &fakeClient{
+				createCellFn: func(v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+					t.Fatal("CreateCell must not be called when source flag is missing")
+					return kukeonv1.CreateCellResult{}, nil
+				},
+				materializeCellFn: func(v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+					t.Fatal("MaterializeCell must not be called when source flag is missing")
+					return kukeonv1.CreateCellResult{}, nil
+				},
 			}
+			cmd, _ := newTestExecCmd(t, fc)
 
-			cmd.SetContext(ctx)
+			tt.setup(t, cmd)
+			cmd.SetArgs(tt.args)
 
-			if tt.setup != nil {
-				tt.setup(t, cmd)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("expected error when neither --from-blueprint nor --from-config is set")
 			}
+			if !strings.Contains(err.Error(), "requires --from-blueprint or --from-config") {
+				t.Errorf("err=%v want 'requires --from-blueprint or --from-config'", err)
+			}
+			if !strings.Contains(err.Error(), "kuke apply -f") {
+				t.Errorf("err=%v should point at `kuke apply -f <file>`", err)
+			}
+		})
+	}
+}
 
+func TestNewCellCmdRunE_FromBlueprint_ScopeHandling(t *testing.T) {
+	// Scope-flag handling on the from-blueprint path: positional + viper name
+	// resolution, default realm/space/stack fill-in, and whitespace trimming.
+	// These behaviours used to live on the empty-shell path; after step 3
+	// (#996) they're shared with the from-blueprint flow via parseCreateCellFlags.
+	t.Cleanup(viper.Reset)
+
+	tests := []struct {
+		name       string
+		args       []string
+		setup      func(t *testing.T, cmd *cobra.Command)
+		wantErr    string
+		wantDoc    v1beta1.CellDoc
+		wantOutput []string
+	}{
+		{
+			name: "name from args with scope flags",
+			args: []string{"test-cell"},
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				setFlag(t, cmd, "realm", "realm-a")
+				setFlag(t, cmd, "space", "space-a")
+				setFlag(t, cmd, "stack", "stack-a")
+				setFlag(t, cmd, "from-blueprint", "web")
+			},
+			wantDoc: newCellDoc("test-cell", "realm-a", "space-a", "stack-a"),
+			wantOutput: []string{
+				`Cell "test-cell" (realm "realm-a", space "space-a", stack "stack-a")`,
+			},
+		},
+		{
+			name: "name from viper with scope flags",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				viper.Set(config.KUKE_CREATE_CELL_NAME.ViperKey, "viper-cell")
+				setFlag(t, cmd, "realm", "realm-b")
+				setFlag(t, cmd, "space", "space-b")
+				setFlag(t, cmd, "stack", "stack-b")
+				setFlag(t, cmd, "from-blueprint", "web")
+			},
+			wantDoc: newCellDoc("viper-cell", "realm-b", "space-b", "stack-b"),
+			wantOutput: []string{
+				`Cell "viper-cell" (realm "realm-b", space "space-b", stack "stack-b")`,
+			},
+		},
+		{
+			name: "name and scope all from viper",
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				viper.Set(config.KUKE_CREATE_CELL_NAME.ViperKey, "all-viper-cell")
+				viper.Set(config.KUKE_CREATE_CELL_REALM.ViperKey, "realm-c")
+				viper.Set(config.KUKE_CREATE_CELL_SPACE.ViperKey, "space-c")
+				viper.Set(config.KUKE_CREATE_CELL_STACK.ViperKey, "stack-c")
+				setFlag(t, cmd, "from-blueprint", "web")
+			},
+			wantDoc: newCellDoc("all-viper-cell", "realm-c", "space-c", "stack-c"),
+		},
+		{
+			name: "missing name with source flag set",
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				setFlag(t, cmd, "from-blueprint", "web")
+			},
+			wantErr: "cell name is required",
+		},
+		{
+			name: "default realm when realm flag not set",
+			args: []string{"test-cell"},
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				setFlag(t, cmd, "space", "space-a")
+				setFlag(t, cmd, "stack", "stack-a")
+				setFlag(t, cmd, "from-blueprint", "web")
+			},
+			wantDoc: newCellDoc("test-cell", "default", "space-a", "stack-a"),
+		},
+		{
+			name: "default space when space flag not set",
+			args: []string{"test-cell"},
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				setFlag(t, cmd, "realm", "realm-a")
+				setFlag(t, cmd, "stack", "stack-a")
+				setFlag(t, cmd, "from-blueprint", "web")
+			},
+			wantDoc: newCellDoc("test-cell", "realm-a", "default", "stack-a"),
+		},
+		{
+			name: "default stack when stack flag not set",
+			args: []string{"test-cell"},
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				setFlag(t, cmd, "realm", "realm-a")
+				setFlag(t, cmd, "space", "space-a")
+				setFlag(t, cmd, "from-blueprint", "web")
+			},
+			wantDoc: newCellDoc("test-cell", "realm-a", "space-a", "default"),
+		},
+		{
+			name: "scope flags trimmed of whitespace",
+			args: []string{"test-cell"},
+			setup: func(t *testing.T, cmd *cobra.Command) {
+				setFlag(t, cmd, "realm", "  realm-a  ")
+				setFlag(t, cmd, "space", "  space-a  ")
+				setFlag(t, cmd, "stack", "  stack-a  ")
+				setFlag(t, cmd, "from-blueprint", "web")
+			},
+			wantDoc: newCellDoc("test-cell", "realm-a", "space-a", "stack-a"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+
+			var materializeCalled bool
+			var materializeDoc v1beta1.CellDoc
+
+			// Blueprint resolves under the operator-supplied scope; the
+			// materialised cell carries the scope from --realm/--space/--stack
+			// because the blueprint metadata leaves those fields empty here.
+			bp := blueprintDoc()
+			bp.Metadata.Realm = ""
+			bp.Metadata.Space = ""
+			bp.Metadata.Stack = ""
+
+			fc := &fakeClient{
+				getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{Blueprint: bp, MetadataExists: true}, nil
+				},
+				materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+					materializeCalled = true
+					materializeDoc = doc
+					return successResultFromDoc(doc), nil
+				},
+			}
+			cmd, out := newTestExecCmd(t, fc)
+
+			tt.setup(t, cmd)
 			cmd.SetArgs(tt.args)
 
 			err := cmd.Execute()
@@ -463,31 +414,32 @@ func TestNewCellCmdRunE(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
 				}
-			} else if err != nil {
+				if materializeCalled {
+					t.Error("MaterializeCell must not be called on parse-time error")
+				}
+				return
+			}
+			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			if createCalled != tt.wantCallCreate {
-				t.Errorf("CreateCell called=%v want=%v", createCalled, tt.wantCallCreate)
+			if !materializeCalled {
+				t.Fatal("MaterializeCell was not called")
 			}
-
-			if tt.wantCallCreate {
-				if createDoc.Metadata.Name != tt.wantDoc.Metadata.Name {
-					t.Errorf("CreateCell Name=%q want=%q", createDoc.Metadata.Name, tt.wantDoc.Metadata.Name)
-				}
-				if createDoc.Spec.RealmID != tt.wantDoc.Spec.RealmID {
-					t.Errorf("CreateCell RealmID=%q want=%q", createDoc.Spec.RealmID, tt.wantDoc.Spec.RealmID)
-				}
-				if createDoc.Spec.SpaceID != tt.wantDoc.Spec.SpaceID {
-					t.Errorf("CreateCell SpaceID=%q want=%q", createDoc.Spec.SpaceID, tt.wantDoc.Spec.SpaceID)
-				}
-				if createDoc.Spec.StackID != tt.wantDoc.Spec.StackID {
-					t.Errorf("CreateCell StackID=%q want=%q", createDoc.Spec.StackID, tt.wantDoc.Spec.StackID)
-				}
+			if materializeDoc.Metadata.Name != tt.wantDoc.Metadata.Name {
+				t.Errorf("Name=%q want=%q", materializeDoc.Metadata.Name, tt.wantDoc.Metadata.Name)
+			}
+			if materializeDoc.Spec.RealmID != tt.wantDoc.Spec.RealmID {
+				t.Errorf("RealmID=%q want=%q", materializeDoc.Spec.RealmID, tt.wantDoc.Spec.RealmID)
+			}
+			if materializeDoc.Spec.SpaceID != tt.wantDoc.Spec.SpaceID {
+				t.Errorf("SpaceID=%q want=%q", materializeDoc.Spec.SpaceID, tt.wantDoc.Spec.SpaceID)
+			}
+			if materializeDoc.Spec.StackID != tt.wantDoc.Spec.StackID {
+				t.Errorf("StackID=%q want=%q", materializeDoc.Spec.StackID, tt.wantDoc.Spec.StackID)
 			}
 
 			if tt.wantOutput != nil {
-				output := cmd.OutOrStdout().(*bytes.Buffer).String()
+				output := out.String()
 				for _, expected := range tt.wantOutput {
 					if !strings.Contains(output, expected) {
 						t.Errorf("output missing expected string %q\nGot output:\n%s", expected, output)
@@ -887,44 +839,5 @@ func TestCreateCell_NameCollision_Errors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "kuke delete cell taken-name") {
 		t.Errorf("err=%v should point at `kuke delete cell taken-name`", err)
-	}
-}
-
-func TestCreateCell_EmptyShell_StillUsesCreateCell(t *testing.T) {
-	// Regression guard for AC #1: the empty-shell path (no --from-* flag)
-	// must continue to call CreateCell — *not* MaterializeCell — so the
-	// daemon's idempotent start step still runs for the pre-#818 workflow C
-	// (create cell → create container → start).
-	t.Cleanup(viper.Reset)
-
-	var createCalled bool
-	fc := &fakeClient{
-		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-			createCalled = true
-			if doc.Metadata.Name != "empty-1" {
-				t.Errorf("CreateCell name=%q want empty-1", doc.Metadata.Name)
-			}
-			return kukeonv1.CreateCellResult{
-				Cell: doc, Created: true, MetadataExistsPost: true,
-				CgroupCreated: true, CgroupExistsPost: true,
-				RootContainerCreated: true, RootContainerExistsPost: true, Started: true,
-			}, nil
-		},
-		materializeCellFn: func(v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
-			t.Fatal("empty-shell path must not call MaterializeCell")
-			return kukeonv1.CreateCellResult{}, nil
-		},
-	}
-	cmd, _ := newTestExecCmd(t, fc)
-	setFlag(t, cmd, "realm", "r")
-	setFlag(t, cmd, "space", "s")
-	setFlag(t, cmd, "stack", "k")
-	cmd.SetArgs([]string{"empty-1"})
-
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute: %v", err)
-	}
-	if !createCalled {
-		t.Fatal("CreateCell was not called on the empty-shell path")
 	}
 }

--- a/e2e/e2e_kuke_cell_test.go
+++ b/e2e/e2e_kuke_cell_test.go
@@ -25,6 +25,20 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
+// applyTestCell materialises a cell via `kuke apply -f cell.yaml`. The
+// no-source-flag `kuke create cell` path was retired in epic:bye-container
+// step 3 (#996), so lifecycle tests that previously created an empty cell
+// shell via the CLI now apply the standard cell.yaml fixture instead.
+func applyTestCell(t *testing.T, host, realmName, spaceName, stackName, cellName string) {
+	t.Helper()
+	applyYAMLFile(t, host, "cell.yaml", map[string]string{
+		"test-cell":  cellName,
+		"test-realm": realmName,
+		"test-space": spaceName,
+		"test-stack": stackName,
+	})
+}
+
 // cleanupCell deletes a cell with cascade through the per-test daemon.
 // Register after startKukeondDaemon so t.Cleanup's LIFO order runs delete
 // before the daemon is signaled.
@@ -108,20 +122,8 @@ func TestKuke_CreateCell_VerifyState(t *testing.T) {
 	)
 	runReturningBinary(t, nil, kuke, args...)
 
-	// Step 4: Create cell
-	args = append(
-		buildKukeDaemonArgs(host),
-		"create",
-		"cell",
-		cellName,
-		"--realm",
-		realmName,
-		"--space",
-		spaceName,
-		"--stack",
-		stackName,
-	)
-	runReturningBinary(t, nil, kuke, args...)
+	// Step 4: Apply cell.yaml to materialise the cell
+	applyTestCell(t, host, realmName, spaceName, stackName, cellName)
 
 	// Step 5: Verify cell metadata file exists
 	if !verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {
@@ -270,20 +272,8 @@ func TestKuke_DeleteCell_VerifyState(t *testing.T) {
 	)
 	runReturningBinary(t, nil, kuke, args...)
 
-	// Step 4: Create cell (prerequisite for deletion test)
-	args = append(
-		buildKukeDaemonArgs(host),
-		"create",
-		"cell",
-		cellName,
-		"--realm",
-		realmName,
-		"--space",
-		spaceName,
-		"--stack",
-		stackName,
-	)
-	runReturningBinary(t, nil, kuke, args...)
+	// Step 4: Apply cell.yaml to materialise the cell (prerequisite for deletion test)
+	applyTestCell(t, host, realmName, spaceName, stackName, cellName)
 
 	// Step 5: Verify cell exists initially (establish baseline)
 	if !verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {
@@ -463,20 +453,9 @@ func TestKuke_StartCell_VerifyState(t *testing.T) {
 	)
 	runReturningBinary(t, nil, kuke, args...)
 
-	// Step 4: Create cell (cell should be in Pending state after creation)
-	args = append(
-		buildKukeDaemonArgs(host),
-		"create",
-		"cell",
-		cellName,
-		"--realm",
-		realmName,
-		"--space",
-		spaceName,
-		"--stack",
-		stackName,
-	)
-	runReturningBinary(t, nil, kuke, args...)
+	// Step 4: Apply cell.yaml to materialise the cell (cell may already be Ready
+	// after apply; the Step-8 conditional handles either Pending or Ready)
+	applyTestCell(t, host, realmName, spaceName, stackName, cellName)
 
 	// Step 5: Get realm namespace and cell ID for container verification
 	realmNamespace, err := getRealmNamespace(t, host, realmName)
@@ -618,20 +597,8 @@ func TestKuke_StopCell_VerifyState(t *testing.T) {
 	)
 	runReturningBinary(t, nil, kuke, args...)
 
-	// Step 4: Create cell (containers auto-start on creation, so cell is Ready)
-	args = append(
-		buildKukeDaemonArgs(host),
-		"create",
-		"cell",
-		cellName,
-		"--realm",
-		realmName,
-		"--space",
-		spaceName,
-		"--stack",
-		stackName,
-	)
-	runReturningBinary(t, nil, kuke, args...)
+	// Step 4: Apply cell.yaml to materialise the cell (containers auto-start, so cell is Ready)
+	applyTestCell(t, host, realmName, spaceName, stackName, cellName)
 
 	// Step 5: Get realm namespace and cell ID for container verification
 	realmNamespace, err := getRealmNamespace(t, host, realmName)
@@ -785,20 +752,8 @@ func TestKuke_KillCell_VerifyState(t *testing.T) {
 	)
 	runReturningBinary(t, nil, kuke, args...)
 
-	// Step 4: Create cell (containers auto-start on creation, so cell is Ready)
-	args = append(
-		buildKukeDaemonArgs(host),
-		"create",
-		"cell",
-		cellName,
-		"--realm",
-		realmName,
-		"--space",
-		spaceName,
-		"--stack",
-		stackName,
-	)
-	runReturningBinary(t, nil, kuke, args...)
+	// Step 4: Apply cell.yaml to materialise the cell (containers auto-start, so cell is Ready)
+	applyTestCell(t, host, realmName, spaceName, stackName, cellName)
 
 	// Step 5: Get realm namespace and cell ID for container verification
 	realmNamespace, err := getRealmNamespace(t, host, realmName)
@@ -952,20 +907,8 @@ func TestKuke_PurgeCell_VerifyState(t *testing.T) {
 	)
 	runReturningBinary(t, nil, kuke, args...)
 
-	// Step 4: Create cell (prerequisite for purge test)
-	args = append(
-		buildKukeDaemonArgs(host),
-		"create",
-		"cell",
-		cellName,
-		"--realm",
-		realmName,
-		"--space",
-		spaceName,
-		"--stack",
-		stackName,
-	)
-	runReturningBinary(t, nil, kuke, args...)
+	// Step 4: Apply cell.yaml to materialise the cell (prerequisite for purge test)
+	applyTestCell(t, host, realmName, spaceName, stackName, cellName)
 
 	// Step 5: Verify cell exists initially (establish baseline)
 	if !verifyCellMetadataExists(t, runPath, realmName, spaceName, stackName, cellName) {

--- a/e2e/e2e_kuke_invalid_names_test.go
+++ b/e2e/e2e_kuke_invalid_names_test.go
@@ -17,6 +17,8 @@
 package e2e_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -111,14 +113,33 @@ func TestKuke_CreateCell_RejectsInvalidNames(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			args := append(buildKukeDaemonArgs(host),
-				"create", "cell", tt.cellName,
-				"--realm", "default", "--space", "default", "--stack", "default")
-			exitCode, _, stderr := runBinary(t, nil, kuke, args...)
+
+			// The no-source-flag `kuke create cell` path was retired in
+			// epic:bye-container step 3 (#996); exercise the cell-name
+			// validation via `kuke apply -f` against a substituted cell.yaml
+			// so the daemon's normalizeCellInputs check still fires.
+			yamlContent := readTestdataYAML(t, "cell.yaml")
+			yamlContent = strings.ReplaceAll(yamlContent, "test-cell", tt.cellName)
+			yamlContent = strings.ReplaceAll(yamlContent, "test-realm", "default")
+			yamlContent = strings.ReplaceAll(yamlContent, "test-space", "default")
+			yamlContent = strings.ReplaceAll(yamlContent, "test-stack", "default")
+
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "cell.yaml")
+			if err := os.WriteFile(tmpFile, []byte(yamlContent), 0o644); err != nil {
+				t.Fatalf("failed to write temporary YAML file: %v", err)
+			}
+
+			args := append(buildKukeDaemonArgs(host), "apply", "-f", tmpFile)
+			exitCode, stdout, stderr := runBinary(t, nil, kuke, args...)
 			if exitCode == 0 {
 				t.Fatalf("expected non-zero exit rejecting cell name %q", tt.cellName)
 			}
-			combined := string(stderr)
+			// `kuke apply` writes the daemon's per-resource error to stdout
+			// (printApplyResult's "  Error: ..." line) and returns a generic
+			// "config error: some resources failed to apply" on stderr; check
+			// both streams so the assertion sees the name-validation message.
+			combined := string(stdout) + string(stderr)
 			if !strings.Contains(combined, "cell") || !strings.Contains(combined, tt.cellName) {
 				t.Errorf("expected error mentioning kind=cell and name %q, got:\n%s", tt.cellName, combined)
 			}

--- a/e2e/e2e_kuke_test.go
+++ b/e2e/e2e_kuke_test.go
@@ -965,13 +965,9 @@ func TestKuke_Uninstall_VerifyState(t *testing.T) {
 			exit, string(out), string(errOut))
 	}
 
-	args = append(buildKukeDaemonArgs(host),
-		"create", "cell", cellName,
-		"--realm", defaultRealm, "--space", defaultSpace, "--stack", stackName)
-	if exit, out, errOut := runBinary(t, nil, kuke, args...); exit != 0 {
-		t.Fatalf("create cell failed: code=%d stdout=%s stderr=%s",
-			exit, string(out), string(errOut))
-	}
+	// Apply cell.yaml via the e2e helper; the no-source-flag `kuke create cell`
+	// path was retired in epic:bye-container step 3 (#996).
+	applyTestCell(t, host, defaultRealm, defaultSpace, stackName, cellName)
 
 	// Step 3: uninstall. Tears down systemd unit (no-op on dev hosts),
 	// every realm cascade, /run/kukeon, /opt/kukeon, kukeon user/group.


### PR DESCRIPTION
## Summary

Step 3 of [epic:bye-container (#993)](https://github.com/eminwux/kukeon/issues/993): retire the empty-shell mode of `kuke create cell`. After step 2 (#1030) removed `kuke create container`, the no-source-flag branch became dead code — the operator could create a Cell shell but had no CLI verb to add containers to it.

`kuke create cell <name>` now requires exactly one of `--from-blueprint` or `--from-config`. The model-consistent paths for a full-cell materialisation remain unchanged: `kuke apply -f <file>` (declarative), `kuke create cell --from-blueprint|--from-config` (templated), or `kuke run` (templated + start + attach).

This is CLI-only — the daemon-side `CreateCell` RPC retains its current behaviour; the in-process client and daemon-side callers can still construct a containers-less `CellSpec` directly. The CLI just no longer offers a flag-driven path to that state.

## Changes

- `cmd/kuke/create/cell/cell.go`:
  - `parseCreateCellFlags` rejects the no-source-flag invocation with the AC's prescribed error message and pointer to `kuke apply -f <file>`.
  - `runEmptyShell` deleted; `runCreateCell` collapses the three-mode switch to a `--from-blueprint`-vs-`--from-config` binary.
  - `Short`/`Long` help text rewritten to describe two modes (Blueprint, Config), drop the empty-shell + workflow C references, and state the source-flag requirement up front.
- `cmd/kuke/create/cell/cell_test.go`:
  - `TestCreateCell_EmptyShell_StillUsesCreateCell` removed (the regression it guarded is the path being retired).
  - `TestNewCellCmdRunE` split into:
    - `TestNewCellCmdRunE_RequiresSourceFlag` — new parse-time-rejection coverage (positional + viper name, with and without scope flags).
    - `TestNewCellCmdRunE_FromBlueprint_ScopeHandling` — name resolution, default realm/space/stack fill-in, whitespace trimming, missing-name validation, re-anchored on the `--from-blueprint` path so the shared `parseCreateCellFlags` behaviour stays covered.
- `e2e/e2e_kuke_cell_test.go`, `e2e/e2e_kuke_invalid_names_test.go`, `e2e/e2e_kuke_test.go` (added in `46ea4b6`):
  - Cell-lifecycle tests (create/delete/start/stop/kill/purge + uninstall + invalid-names) previously used the empty-shell `kuke create cell <name>` to materialise the test cell. That path is gone, so each test now applies the standard `cell.yaml` fixture via a new `applyTestCell` helper (or directly via `kuke apply -f` for the name-validation test, where the bad name needs substitution into the YAML).
  - `make test-root` deliberately excludes `/e2e`, so the original PR push didn't catch these — this fix-up addresses the `make e2e` CI failure.

Docs (`docs/site/cli/kuke-create.md`, `docs/cli-use-cases.md`) and the `kuke create container` doc section are left untouched — that's step 4 (#997)'s lane.

## Test plan

- [x] `make test-root` (full `go test $(go list ./... | grep -v /e2e)`) — passes locally.
- [x] `make test-kukebuild` — passes locally.
- [x] `make dev-init` smoke — passes; daemon-parity tail shows both realms `Ready` and the `kuke attach` smoke completes cleanly.
- [x] `make e2e` — all 9 cell-lifecycle / invalid-names tests touched by this PR pass locally (`TestKuke_NoCells`, `TestKuke_CreateCell_VerifyState`, `TestKuke_DeleteCell_VerifyState`, `TestKuke_StartCell_VerifyState`, `TestKuke_StopCell_VerifyState`, `TestKuke_KillCell_VerifyState`, `TestKuke_PurgeCell_VerifyState`, `TestKuke_Uninstall_VerifyState`, `TestKuke_CreateCell_RejectsInvalidNames`).
- [ ] Two `RunFromStopped*_NoEACCES` tests (in `e2e_kuke_attach_test.go`, unmodified by this PR) fail locally on this dev host for env-only reasons unrelated to the diff: `NonRootKukeonGroup_NoEACCES` exits with `fork/exec /root/kukeon/kuke: permission denied` because the test drops to uid 65534 and `/root` is `0700`; `RequiredRepoUnresolvable_NoEACCES` hits a DNS timeout on `registry.eminwux.com` (used as the cell's image registry, not the unresolvable `.invalid` repo the test is exercising). CI on `main` at `fcbcabf` is green for both; CI's runner has registry reachability and binary execution paths this dev host doesn't.
- [x] `kuke create cell <name>` (no source flag) errors with `kuke create cell requires --from-blueprint or --from-config (use 'kuke apply -f <file>' for a full manifest)` and writes no Cell record (covered by `TestNewCellCmdRunE_RequiresSourceFlag`).
- [x] `kuke create cell <name> --from-blueprint <bp>` and `kuke create cell <name> --from-config <cfg>` continue to work (existing `TestCreateCell_FromBlueprint_HappyPath` / `TestCreateCell_FromConfig_HappyPath` + scope-handling table tests).
- [x] `kuke create cell --help` text reflects the new requirement (one source flag required; updated `Short` + `Long`).
- [x] `kuke apply -f cell.yaml` path unchanged (no daemon/RPC/parser code touched).

Closes #996
