### PR TITLE
feat(team): kuke team init skeleton + TeamEntry drop-in lifecycle (step 1)

### DIFF
--- a/cmd/config/defaults.go
+++ b/cmd/config/defaults.go
@@ -71,14 +71,23 @@ func DefaultServerConfigurationFile() string {
 	return filepath.Join("/", "etc", "kukeon", "kukeond.yaml")
 }
 
-// DefaultClientConfigurationFile is the on-disk path the `kuke` client reads
-// when the user does not pass `--configuration`. An absent file is not an
-// error — the client falls back to its hardcoded defaults.
-func DefaultClientConfigurationFile() string {
+// DefaultKukeDir is the per-operator kuke state directory (~/.kuke) holding
+// the client configuration, the team-distribution global-facts file
+// (kuketeams.yaml), and the per-project drop-in directory (kuketeam.d/). Falls
+// back to "tmp" when the home directory cannot be determined, matching the
+// other default-path helpers.
+func DefaultKukeDir() string {
 	base, err := os.UserHomeDir()
 	if err != nil {
 		// fallback to tmp if home dir cannot be determined
 		base = "tmp"
 	}
-	return filepath.Join(base, ".kuke", "kuke.yaml")
+	return filepath.Join(base, ".kuke")
+}
+
+// DefaultClientConfigurationFile is the on-disk path the `kuke` client reads
+// when the user does not pass `--configuration`. An absent file is not an
+// error — the client falls back to its hardcoded defaults.
+func DefaultClientConfigurationFile() string {
+	return filepath.Join(DefaultKukeDir(), "kuke.yaml")
 }

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -44,6 +44,7 @@ import (
 	startcmd "github.com/eminwux/kukeon/cmd/kuke/start"
 	statuscmd "github.com/eminwux/kukeon/cmd/kuke/status"
 	stopcmd "github.com/eminwux/kukeon/cmd/kuke/stop"
+	teamcmd "github.com/eminwux/kukeon/cmd/kuke/team"
 	uninstallcmd "github.com/eminwux/kukeon/cmd/kuke/uninstall"
 	"github.com/eminwux/kukeon/cmd/kuke/version"
 	"github.com/eminwux/kukeon/cmd/types"
@@ -155,6 +156,7 @@ func SetupKukeCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(startcmd.NewStartCmd())
 	rootCmd.AddCommand(statuscmd.NewStatusCmd())
 	rootCmd.AddCommand(stopcmd.NewStopCmd())
+	rootCmd.AddCommand(teamcmd.NewTeamCmd())
 	rootCmd.AddCommand(killcmd.NewKillCmd())
 	rootCmd.AddCommand(purgecmd.NewPurgeCmd())
 	rootCmd.AddCommand(refreshcmd.NewRefreshCmd())

--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -1,0 +1,263 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package team
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/kuketeams"
+	"github.com/eminwux/kukeon/internal/teamhost"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// projectFileName is the per-project roster committed in each project repo.
+const projectFileName = "kuketeam.yaml"
+
+// registryEnv seeds TeamsConfig.spec.registry on first-run scaffold.
+const registryEnv = "KUKEON_REGISTRY"
+
+// GitConfigFunc reads a single `git config --global <key>` value, reporting
+// whether the key was set. Injected via MockGitConfigKey in tests so the
+// scaffold is hermetic and does not read the host operator's real git config.
+type GitConfigFunc func(ctx context.Context, key string) (string, bool)
+
+// MockGitConfigKey injects a GitConfigFunc via context for tests.
+type MockGitConfigKey struct{}
+
+// NewInitCmd builds the `kuke team init` subcommand. It reads the current
+// project's kuketeam.yaml roster, scaffolds the operator-global facts file on
+// first run, and writes the per-project drop-in entry. Source resolution,
+// render, and apply land in steps 2–4 — `--dry-run` is reserved for step 3's
+// render output; in step 1 it prints the per-project entry that would be
+// written and touches no files on disk.
+func NewInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:           "init",
+		Short:         "Compose this project's team into the host ~/.kuke drop-in",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			dryRun, err := cmd.Flags().GetBool("dry-run")
+			if err != nil {
+				return err
+			}
+			return runInit(cmd, dryRun)
+		},
+	}
+
+	cmd.Flags().Bool(
+		"dry-run", false,
+		"Print the per-project entry that would be written without touching disk (full render lands in a later step)",
+	)
+
+	return cmd
+}
+
+// runInit gathers the cobra-coupled inputs (current directory, ~/.kuke layout,
+// git-config reader) and hands them to composeTeam, which holds the testable
+// lifecycle.
+func runInit(cmd *cobra.Command, dryRun bool) error {
+	projectDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve current directory: %w", err)
+	}
+	layout := teamhost.NewLayout(config.DefaultKukeDir())
+	return composeTeam(
+		cmd.Context(), cmd.OutOrStdout(), projectDir, layout, gitConfigFromCmd(cmd), dryRun,
+	)
+}
+
+// composeTeam runs the team-init lifecycle against explicit inputs: read the
+// project roster, scaffold the operator-global facts on first run, and write
+// the per-project drop-in entry. `--dry-run` prints the entry that would be
+// written and touches no files (full render lands in step 3). It takes no
+// cobra dependency so it is unit-testable with a temp layout and a stub
+// git-config reader, no live kukeond required.
+func composeTeam(
+	ctx context.Context,
+	out io.Writer,
+	projectDir string,
+	layout teamhost.Layout,
+	getGit GitConfigFunc,
+	dryRun bool,
+) error {
+	pt, err := readProjectTeam(projectDir)
+	if err != nil {
+		return err
+	}
+
+	project := strings.TrimSpace(pt.Metadata.Name)
+	if project == "" {
+		// Defensive: the parser already rejects an empty metadata.name, but
+		// guard the filename key explicitly.
+		return errdefs.ErrTeamMetadataNameRequired
+	}
+
+	entry := &model.TeamEntry{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindTeamEntry,
+		Metadata:   model.Metadata{Name: project},
+		Spec: model.TeamEntrySpec{
+			Path:   projectDir,
+			Source: strings.TrimSpace(pt.Spec.Source),
+		},
+	}
+
+	if dryRun {
+		raw, marshalErr := yaml.Marshal(entry)
+		if marshalErr != nil {
+			return fmt.Errorf("marshal team entry: %w", marshalErr)
+		}
+		fmt.Fprintf(out, "# dry-run: would write %s\n%s",
+			filepath.Join("~/.kuke/kuketeam.d", project+".yaml"), raw)
+		return nil
+	}
+
+	created, err := teamhost.EnsureGlobalConfig(layout, buildGlobalConfig(ctx, getGit))
+	if err != nil {
+		return fmt.Errorf("ensure global config: %w", err)
+	}
+	if created {
+		fmt.Fprintf(out, "scaffolded operator-global facts at %s\n", layout.GlobalConfigPath())
+	}
+
+	if writeErr := teamhost.WriteEntry(layout, entry); writeErr != nil {
+		return fmt.Errorf("write team entry: %w", writeErr)
+	}
+	fmt.Fprintf(out, "wrote team %q to %s\n", project, layout.EntryPath(project))
+	return nil
+}
+
+// readProjectTeam loads <projectDir>/kuketeam.yaml and returns the parsed
+// ProjectTeam. A missing file surfaces ErrTeamProjectFileNotFound; a parsed
+// document of the wrong kind surfaces ErrTeamProjectFileKind.
+func readProjectTeam(projectDir string) (*model.ProjectTeam, error) {
+	path := filepath.Join(projectDir, projectFileName)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w (looked in %q)", errdefs.ErrTeamProjectFileNotFound, projectDir)
+		}
+		return nil, fmt.Errorf("read %q: %w", path, err)
+	}
+	doc, err := kuketeams.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse %q: %w", path, err)
+	}
+	if doc.ProjectTeam == nil {
+		return nil, fmt.Errorf("%w (got kind %q in %q)", errdefs.ErrTeamProjectFileKind, doc.Kind, path)
+	}
+	return doc.ProjectTeam, nil
+}
+
+// buildGlobalConfig assembles the operator-global TeamsConfig scaffolded on
+// first run: git identity/signing seeded from `git config --global`, registry
+// from the KUKEON_REGISTRY env. Sources and secrets are left empty for the
+// operator to fill in (no interactive prompt — the verb is non-interactive).
+func buildGlobalConfig(ctx context.Context, getGit GitConfigFunc) *model.TeamsConfig {
+	cfg := &model.TeamsConfig{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindTeamsConfig,
+		Spec:       model.TeamsConfigSpec{},
+	}
+
+	if reg := strings.TrimSpace(os.Getenv(registryEnv)); reg != "" {
+		cfg.Spec.Registry = reg
+	}
+
+	if git := seedGit(ctx, getGit); git != nil {
+		cfg.Spec.Git = git
+	}
+
+	return cfg
+}
+
+// seedGit builds a TeamsConfigGit from the operator's global git config. It
+// returns nil when no usable identity is present, so the scaffold omits the git
+// block entirely rather than emitting a half-populated one. Sign entries are
+// only seeded when a signing key is present, keeping the scaffold valid against
+// the parser's git.sign-requires-signingKey rule.
+func seedGit(ctx context.Context, getGit GitConfigFunc) *model.TeamsConfigGit {
+	name, hasName := getGit(ctx, "user.name")
+	email, hasEmail := getGit(ctx, "user.email")
+	signingKey, _ := getGit(ctx, "user.signingkey")
+	allowedSigners, _ := getGit(ctx, "gpg.ssh.allowedSignersFile")
+
+	git := &model.TeamsConfigGit{}
+	populated := false
+
+	if hasName && hasEmail && strings.TrimSpace(name) != "" && strings.TrimSpace(email) != "" {
+		id := &v1beta1.GitIdentity{Name: strings.TrimSpace(name), Email: strings.TrimSpace(email)}
+		git.Author = id
+		git.Committer = id
+		populated = true
+	}
+	if s := strings.TrimSpace(signingKey); s != "" {
+		git.SigningKey = s
+		populated = true
+		var sign []string
+		if v, _ := getGit(ctx, "commit.gpgsign"); strings.EqualFold(strings.TrimSpace(v), "true") {
+			sign = append(sign, model.GitSignCommits)
+		}
+		if v, _ := getGit(ctx, "tag.gpgsign"); strings.EqualFold(strings.TrimSpace(v), "true") {
+			sign = append(sign, model.GitSignTags)
+		}
+		git.Sign = sign
+	}
+	if a := strings.TrimSpace(allowedSigners); a != "" {
+		git.AllowedSigners = a
+		populated = true
+	}
+
+	if !populated {
+		return nil
+	}
+	return git
+}
+
+// gitConfigFromCmd returns the GitConfigFunc the init flow uses — the test
+// mock from context when present, otherwise the real `git config --global`
+// reader.
+func gitConfigFromCmd(cmd *cobra.Command) GitConfigFunc {
+	if mock, ok := cmd.Context().Value(MockGitConfigKey{}).(GitConfigFunc); ok && mock != nil {
+		return mock
+	}
+	return realGitConfig
+}
+
+// realGitConfig reads a single `git config --global <key>` value. A non-zero
+// exit (key unset) reports ok=false; the value is whitespace-trimmed.
+func realGitConfig(ctx context.Context, key string) (string, bool) {
+	out, err := exec.CommandContext(ctx, "git", "config", "--global", key).Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
+}

--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -214,9 +214,11 @@ func seedGit(ctx context.Context, getGit GitConfigFunc) *model.TeamsConfigGit {
 	populated := false
 
 	if hasName && hasEmail && strings.TrimSpace(name) != "" && strings.TrimSpace(email) != "" {
-		id := &v1beta1.GitIdentity{Name: strings.TrimSpace(name), Email: strings.TrimSpace(email)}
-		git.Author = id
-		git.Committer = id
+		// Construct two distinct values: a future load → mutate → write path in
+		// step 2/3/4 must not silently couple author and committer through a
+		// shared pointer.
+		git.Author = &v1beta1.GitIdentity{Name: strings.TrimSpace(name), Email: strings.TrimSpace(email)}
+		git.Committer = &v1beta1.GitIdentity{Name: strings.TrimSpace(name), Email: strings.TrimSpace(email)}
 		populated = true
 	}
 	if s := strings.TrimSpace(signingKey); s != "" {

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -1,0 +1,234 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package team
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/teamhost"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	"gopkg.in/yaml.v3"
+)
+
+const projectTeamYAML = `apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: sbsh }
+spec:
+  source: eminwux/agents@v1.4.0
+  roles:
+    - { ref: dev }
+`
+
+// stubGit returns a GitConfigFunc backed by m.
+func stubGit(m map[string]string) GitConfigFunc {
+	return func(_ context.Context, key string) (string, bool) {
+		v, ok := m[key]
+		return v, ok
+	}
+}
+
+// writeProject creates a project dir with a kuketeam.yaml and returns its path.
+func writeProject(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, projectFileName), []byte(body), 0o600); err != nil {
+		t.Fatalf("write project file: %v", err)
+	}
+	return dir
+}
+
+func TestComposeTeamNoProjectFile(t *testing.T) {
+	t.Parallel()
+	emptyDir := t.TempDir()
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	err := composeTeam(context.Background(), &bytes.Buffer{}, emptyDir, layout, stubGit(nil), false)
+	if !errors.Is(err, errdefs.ErrTeamProjectFileNotFound) {
+		t.Fatalf("err = %v, want ErrTeamProjectFileNotFound", err)
+	}
+}
+
+func TestComposeTeamWrongKind(t *testing.T) {
+	t.Parallel()
+	dir := writeProject(t, "apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: {}\n")
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	err := composeTeam(context.Background(), &bytes.Buffer{}, dir, layout, stubGit(nil), false)
+	if !errors.Is(err, errdefs.ErrTeamProjectFileKind) {
+		t.Fatalf("err = %v, want ErrTeamProjectFileKind", err)
+	}
+}
+
+func TestComposeTeamScaffoldsAndWrites(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	git := stubGit(map[string]string{
+		"user.name":                  "Op Erator",
+		"user.email":                 "op@example.com",
+		"user.signingkey":            "/home/op/.ssh/id_ed25519.pub",
+		"commit.gpgsign":             "true",
+		"tag.gpgsign":                "true",
+		"gpg.ssh.allowedSignersFile": "/home/op/.ssh/allowed_signers",
+	})
+
+	var out bytes.Buffer
+	if err := composeTeam(context.Background(), &out, projectDir, layout, git, false); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+
+	// Global facts scaffolded with seeded git identity + signing.
+	rawGlobal, err := os.ReadFile(layout.GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("global config not written: %v", err)
+	}
+	var gc model.TeamsConfig
+	if unmarshalErr := yaml.Unmarshal(rawGlobal, &gc); unmarshalErr != nil {
+		t.Fatalf("global config parse: %v", unmarshalErr)
+	}
+	if gc.Spec.Git == nil || gc.Spec.Git.Author == nil || gc.Spec.Git.Author.Email != "op@example.com" {
+		t.Fatalf("git identity not seeded: %+v", gc.Spec.Git)
+	}
+	if gc.Spec.Git.SigningKey != "/home/op/.ssh/id_ed25519.pub" {
+		t.Errorf("signing key not seeded: %q", gc.Spec.Git.SigningKey)
+	}
+	if len(gc.Spec.Git.Sign) != 2 {
+		t.Errorf("git.sign = %v, want [commits tags]", gc.Spec.Git.Sign)
+	}
+	if gc.Spec.Git.AllowedSigners != "/home/op/.ssh/allowed_signers" {
+		t.Errorf("allowedSigners not seeded: %q", gc.Spec.Git.AllowedSigners)
+	}
+
+	// Per-project entry written with locator + source.
+	rawEntry, err := os.ReadFile(layout.EntryPath("sbsh"))
+	if err != nil {
+		t.Fatalf("entry not written: %v", err)
+	}
+	var te model.TeamEntry
+	if unmarshalErr := yaml.Unmarshal(rawEntry, &te); unmarshalErr != nil {
+		t.Fatalf("entry parse: %v", unmarshalErr)
+	}
+	if te.Metadata.Name != "sbsh" || te.Spec.Path != projectDir || te.Spec.Source != "eminwux/agents@v1.4.0" {
+		t.Errorf("entry content wrong: %+v", te)
+	}
+	if !strings.Contains(out.String(), "wrote team \"sbsh\"") {
+		t.Errorf("missing write confirmation in output: %q", out.String())
+	}
+}
+
+func TestComposeTeamReRunDoesNotRescaffold(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	git := stubGit(map[string]string{"user.name": "A", "user.email": "a@example.com"})
+
+	if err := composeTeam(context.Background(), &bytes.Buffer{}, projectDir, layout, git, false); err != nil {
+		t.Fatalf("first composeTeam: %v", err)
+	}
+	// Tamper the global facts; a re-run must leave them untouched.
+	if err := os.WriteFile(layout.GlobalConfigPath(), []byte("sentinel: kept\n"), 0o600); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+	var out bytes.Buffer
+	if err := composeTeam(context.Background(), &out, projectDir, layout, git, false); err != nil {
+		t.Fatalf("second composeTeam: %v", err)
+	}
+	got, err := os.ReadFile(layout.GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("read global after re-run: %v", err)
+	}
+	if string(got) != "sentinel: kept\n" {
+		t.Errorf("re-run re-scaffolded global facts: %q", got)
+	}
+	if strings.Contains(out.String(), "scaffolded") {
+		t.Errorf("re-run printed a scaffold message: %q", out.String())
+	}
+}
+
+func TestComposeTeamNoGitIdentityOmitsGitBlock(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	if err := composeTeam(context.Background(), &bytes.Buffer{}, projectDir, layout, stubGit(nil), false); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+	raw, err := os.ReadFile(layout.GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("global config not written: %v", err)
+	}
+	var gc model.TeamsConfig
+	if unmarshalErr := yaml.Unmarshal(raw, &gc); unmarshalErr != nil {
+		t.Fatalf("parse: %v", unmarshalErr)
+	}
+	if gc.Spec.Git != nil {
+		t.Errorf("git block seeded with no identity available: %+v", gc.Spec.Git)
+	}
+}
+
+func TestComposeTeamDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	var out bytes.Buffer
+	if err := composeTeam(context.Background(), &out, projectDir, layout, stubGit(nil), true); err != nil {
+		t.Fatalf("composeTeam dry-run: %v", err)
+	}
+	if _, err := os.Stat(layout.GlobalConfigPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("dry-run wrote global config: err=%v", err)
+	}
+	if _, err := os.Stat(layout.EntryPath("sbsh")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("dry-run wrote entry file: err=%v", err)
+	}
+	if !strings.Contains(out.String(), "dry-run") || !strings.Contains(out.String(), "sbsh") {
+		t.Errorf("dry-run output missing expected content: %q", out.String())
+	}
+}
+
+func TestNewInitCmdParsesDryRunFlag(t *testing.T) {
+	t.Parallel()
+	cmd := NewInitCmd()
+	if cmd.Flags().Lookup("dry-run") == nil {
+		t.Fatalf("--dry-run flag not registered")
+	}
+	if cmd.Name() != "init" {
+		t.Errorf("init cmd name = %q", cmd.Name())
+	}
+}
+
+func TestNewTeamCmdRegistersInit(t *testing.T) {
+	t.Parallel()
+	cmd := NewTeamCmd()
+	if cmd.Name() != "team" {
+		t.Errorf("team cmd name = %q", cmd.Name())
+	}
+	var found bool
+	for _, c := range cmd.Commands() {
+		if c.Name() == "init" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("team init subcommand not registered")
+	}
+}

--- a/cmd/kuke/team/team.go
+++ b/cmd/kuke/team/team.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package team hosts the `kuke team` parent command and its subcommands. Step 1
+// (#796, epic team-distribution #792) lands `init`: it reads the project's
+// committed kuketeam.yaml roster, scaffolds the operator-global facts file
+// (~/.kuke/kuketeams.yaml) on first run, and writes a per-project drop-in entry
+// (~/.kuke/kuketeam.d/<project>.yaml). Source resolution, render, and apply land
+// in steps 2–4 (#1041/#1042/#1043). Every `kuke team *` verb is host-local and
+// daemon-independent — they manipulate ~/.kuke files, not /opt/kukeon state — so
+// none require a live kukeond.
+package team
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewTeamCmd builds the `kuke team` parent command and registers its
+// subcommands. Persistent flags on the root kuke command are inherited
+// automatically.
+func NewTeamCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "team",
+		Short: "Compose per-project agent teams from the in-repo kuketeam.yaml roster",
+		Run: func(cmd *cobra.Command, _ []string) {
+			_ = cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(NewInitCmd())
+
+	return cmd
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -565,6 +565,16 @@ var (
 	// ErrTeamEntryNameRequired fires when a TeamEntry omits metadata.name (the
 	// per-project drop-in filename key).
 	ErrTeamEntryNameRequired = errors.New("teamEntry metadata.name is required")
+	// ErrTeamMetadataNameUnsafe guards every ProjectTeam/TeamEntry metadata.name
+	// that flows into Layout.EntryPath against path traversal: a "/" or "\"
+	// separator, a NUL byte, a ".." substring, or a leading "." would let
+	// filepath.Join escape the drop-in directory and overwrite the operator's
+	// own global facts file (e.g. metadata.name "../kuketeams" resolves to
+	// ~/.kuke/kuketeams.yaml). Enforced at the parser layer and as
+	// defense-in-depth in teamhost.WriteEntry.
+	ErrTeamMetadataNameUnsafe = errors.New(
+		"metadata.name must not contain path separators, NUL, '..', or a leading '.'",
+	)
 	// ErrTeamProjectFileNotFound fires when `kuke team init` finds no
 	// kuketeam.yaml in the current project directory.
 	ErrTeamProjectFileNotFound = errors.New("no kuketeam.yaml found in the current directory")

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -527,8 +527,8 @@ var (
 	ErrControllerNoChange = errors.New("controller reported no change")
 
 	// Team-distribution parse/validation errors (kuketeams.io/v1 kinds —
-	// ProjectTeam, TeamsConfig, Role, Harness, ImageCatalog). Issue #793,
-	// epic #792.
+	// ProjectTeam, TeamsConfig, TeamEntry, Role, Harness, ImageCatalog).
+	// Issue #793, epic #792.
 
 	// ErrTeamMetadataNameRequired fires when a ProjectTeam/Role/Harness omits
 	// metadata.name.
@@ -562,10 +562,15 @@ var (
 	// ErrTeamSourceKeyInvalid fires when a TeamsConfig sources[] key is not in
 	// `<owner>/<repo>` form.
 	ErrTeamSourceKeyInvalid = errors.New("sources key must be in <owner>/<repo> form")
-	// ErrTeamTeamNameRequired fires when a TeamsConfig teams[] entry omits name.
-	ErrTeamTeamNameRequired = errors.New("teams[].name is required")
-	// ErrTeamTeamNameDuplicate fires when two TeamsConfig teams[] share a name.
-	ErrTeamTeamNameDuplicate = errors.New("teams[].name must be unique")
+	// ErrTeamEntryNameRequired fires when a TeamEntry omits metadata.name (the
+	// per-project drop-in filename key).
+	ErrTeamEntryNameRequired = errors.New("teamEntry metadata.name is required")
+	// ErrTeamProjectFileNotFound fires when `kuke team init` finds no
+	// kuketeam.yaml in the current project directory.
+	ErrTeamProjectFileNotFound = errors.New("no kuketeam.yaml found in the current directory")
+	// ErrTeamProjectFileKind fires when the project file parses but is not a
+	// ProjectTeam document.
+	ErrTeamProjectFileKind = errors.New("project file must be a ProjectTeam document")
 	// ErrTeamHarnessFieldRequired fires when a Harness omits skillPath,
 	// makeTarget, or template.
 	ErrTeamHarnessFieldRequired = errors.New(

--- a/internal/kuketeams/parser.go
+++ b/internal/kuketeams/parser.go
@@ -173,12 +173,16 @@ func Parse(raw []byte) (*Document, error) {
 	return doc, nil
 }
 
-// validateProjectTeam enforces the ProjectTeam contract: metadata.name present;
-// source pinned-exact; every roles[].ref non-empty; defaults/role harness names
-// known; project role image needs are capability names.
+// validateProjectTeam enforces the ProjectTeam contract: metadata.name present
+// and safe as a drop-in filename key; source pinned-exact; every roles[].ref
+// non-empty; defaults/role harness names known; project role image needs are
+// capability names.
 func validateProjectTeam(pt *model.ProjectTeam) error {
 	if strings.TrimSpace(pt.Metadata.Name) == "" {
 		return errdefs.ErrTeamMetadataNameRequired
+	}
+	if err := validateMetadataNameSafe(pt.Metadata.Name); err != nil {
+		return err
 	}
 	if !sourceRefPattern.MatchString(strings.TrimSpace(pt.Spec.Source)) {
 		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceInvalid, pt.Spec.Source)
@@ -230,15 +234,35 @@ func validateTeamsConfig(tc *model.TeamsConfig) error {
 }
 
 // validateTeamEntry enforces the per-project drop-in contract: metadata.name
-// present (it is the <project>.yaml filename key), and source — when set —
-// pinned-exact to a `<owner>/<repo>@vX.Y.Z` agents reference.
+// present and safe (it is the <project>.yaml filename key, so traversal
+// characters would let an attacker escape the drop-in directory), and source —
+// when set — pinned-exact to a `<owner>/<repo>@vX.Y.Z` agents reference.
 func validateTeamEntry(te *model.TeamEntry) error {
 	if strings.TrimSpace(te.Metadata.Name) == "" {
 		return errdefs.ErrTeamEntryNameRequired
 	}
+	if err := validateMetadataNameSafe(te.Metadata.Name); err != nil {
+		return err
+	}
 	if strings.TrimSpace(te.Spec.Source) != "" &&
 		!sourceRefPattern.MatchString(strings.TrimSpace(te.Spec.Source)) {
 		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceInvalid, te.Spec.Source)
+	}
+	return nil
+}
+
+// validateMetadataNameSafe rejects any ProjectTeam/TeamEntry metadata.name that
+// would let teamhost.Layout.EntryPath escape the drop-in directory: path
+// separators ('/' or '\'), a NUL byte, a ".." substring, or a leading '.'.
+// The classic escape is metadata.name "../kuketeams", which makes the rename
+// target resolve to ~/.kuke/kuketeams.yaml — the operator's own global facts
+// file. Callers must check for empty-name first so their kind-specific
+// "required" sentinel surfaces rather than the unsafe-name one.
+func validateMetadataNameSafe(name string) error {
+	trimmed := strings.TrimSpace(name)
+	if strings.ContainsAny(trimmed, "/\\") || strings.ContainsRune(trimmed, 0) ||
+		strings.Contains(trimmed, "..") || strings.HasPrefix(trimmed, ".") {
+		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamMetadataNameUnsafe, name)
 	}
 	return nil
 }

--- a/internal/kuketeams/parser.go
+++ b/internal/kuketeams/parser.go
@@ -43,6 +43,7 @@ type Document struct {
 	Kind         string
 	ProjectTeam  *model.ProjectTeam
 	TeamsConfig  *model.TeamsConfig
+	TeamEntry    *model.TeamEntry
 	Role         *model.Role
 	Harness      *model.Harness
 	ImageCatalog *model.ImageCatalog
@@ -130,6 +131,15 @@ func Parse(raw []byte) (*Document, error) {
 			return nil, err
 		}
 		doc.TeamsConfig = &v
+	case model.KindTeamEntry:
+		var v model.TeamEntry
+		if err := yaml.Unmarshal(raw, &v); err != nil {
+			return nil, fmt.Errorf("parse TeamEntry: %w", err)
+		}
+		if err := validateTeamEntry(&v); err != nil {
+			return nil, err
+		}
+		doc.TeamEntry = &v
 	case model.KindRole:
 		var v model.Role
 		if err := yaml.Unmarshal(raw, &v); err != nil {
@@ -193,7 +203,8 @@ func validateProjectTeam(pt *model.ProjectTeam) error {
 
 // validateTeamsConfig enforces the TeamsConfig contract: git identities
 // complete; git.sign entries valid and key-backed; secrets declare a source;
-// sources keys well-formed; teams names present and unique.
+// sources keys well-formed. Per-project composition is no longer carried here —
+// it moved to the TeamEntry drop-in (validateTeamEntry).
 func validateTeamsConfig(tc *model.TeamsConfig) error {
 	if tc.Spec.Git != nil {
 		if err := validateGit(tc.Spec.Git); err != nil {
@@ -215,20 +226,19 @@ func validateTeamsConfig(tc *model.TeamsConfig) error {
 			return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceKeyInvalid, key)
 		}
 	}
-	seen := make(map[string]bool, len(tc.Spec.Teams))
-	for i, team := range tc.Spec.Teams {
-		name := strings.TrimSpace(team.Name)
-		if name == "" {
-			return fmt.Errorf("%w (teams[%d])", errdefs.ErrTeamTeamNameRequired, i)
-		}
-		if seen[name] {
-			return fmt.Errorf("%w (got %q)", errdefs.ErrTeamTeamNameDuplicate, name)
-		}
-		seen[name] = true
-		if strings.TrimSpace(team.Source) != "" &&
-			!sourceRefPattern.MatchString(strings.TrimSpace(team.Source)) {
-			return fmt.Errorf("%w (teams[%d] %q source %q)", errdefs.ErrTeamSourceInvalid, i, name, team.Source)
-		}
+	return nil
+}
+
+// validateTeamEntry enforces the per-project drop-in contract: metadata.name
+// present (it is the <project>.yaml filename key), and source — when set —
+// pinned-exact to a `<owner>/<repo>@vX.Y.Z` agents reference.
+func validateTeamEntry(te *model.TeamEntry) error {
+	if strings.TrimSpace(te.Metadata.Name) == "" {
+		return errdefs.ErrTeamEntryNameRequired
+	}
+	if strings.TrimSpace(te.Spec.Source) != "" &&
+		!sourceRefPattern.MatchString(strings.TrimSpace(te.Spec.Source)) {
+		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceInvalid, te.Spec.Source)
 	}
 	return nil
 }

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -310,6 +310,39 @@ func TestParseFailureModes(t *testing.T) {
 			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: a }\nspec: { path: /x, source: eminwux/agents@main }\n",
 			errdefs.ErrTeamSourceInvalid,
 		},
+		{
+			// Path-traversal: an unbounded metadata.name flows into
+			// teamhost.Layout.EntryPath via filepath.Join, so a name like
+			// "../kuketeams" would clobber ~/.kuke/kuketeams.yaml. The parser
+			// must refuse before that name reaches host code.
+			"TeamEntry name traverses parent",
+			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: \"../kuketeams\" }\nspec: { path: /x }\n",
+			errdefs.ErrTeamMetadataNameUnsafe,
+		},
+		{
+			"TeamEntry name has path separator",
+			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: \"a/b\" }\nspec: { path: /x }\n",
+			errdefs.ErrTeamMetadataNameUnsafe,
+		},
+		{
+			"TeamEntry name has backslash",
+			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: \"a\\\\b\" }\nspec: { path: /x }\n",
+			errdefs.ErrTeamMetadataNameUnsafe,
+		},
+		{
+			"TeamEntry name is leading dot",
+			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: \".kuke\" }\nspec: { path: /x }\n",
+			errdefs.ErrTeamMetadataNameUnsafe,
+		},
+		{
+			// Same guard applies on the ProjectTeam side — the per-project
+			// roster is itself untrusted input (parsed from each project's
+			// committed kuketeam.yaml), and metadata.name from that file
+			// becomes the TeamEntry's metadata.name verbatim in `kuke team init`.
+			"ProjectTeam name traverses parent",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: { name: \"../kuketeams\" }\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamMetadataNameUnsafe,
+		},
 		// Role.
 		{
 			"Role missing name",

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -53,8 +53,13 @@ spec:
   sources:  { eminwux/agents: git@github.com:eminwux/agents.git }
   secrets:
     claude-code-oauth-token: { from: env, key: CLAUDE_CODE_OAUTH_TOKEN }
-  teams:
-    - { name: sbsh, path: ~/src/sbsh, source: eminwux/agents@v1.4.0 }
+`
+
+const teamEntryHappy = `
+apiVersion: kuketeams.io/v1
+kind: TeamEntry
+metadata: { name: sbsh }
+spec: { path: /home/op/src/sbsh, source: eminwux/agents@v1.4.0 }
 `
 
 const roleHappy = `
@@ -114,6 +119,12 @@ func TestParseHappyPaths(t *testing.T) {
 			model.KindTeamsConfig,
 			func(d *Document) bool { return d.TeamsConfig != nil },
 		},
+		{
+			"TeamEntry",
+			teamEntryHappy,
+			model.KindTeamEntry,
+			func(d *Document) bool { return d.TeamEntry != nil },
+		},
 		{"Role", roleHappy, model.KindRole, func(d *Document) bool { return d.Role != nil }},
 		{"Harness", harnessHappy, model.KindHarness, func(d *Document) bool { return d.Harness != nil }},
 		{
@@ -171,6 +182,17 @@ func TestParseHappyPathFields(t *testing.T) {
 	}
 	if len(tc.TeamsConfig.Spec.Git.Sign) != 2 {
 		t.Errorf("git.sign len = %d, want 2", len(tc.TeamsConfig.Spec.Git.Sign))
+	}
+
+	te, err := Parse([]byte(teamEntryHappy))
+	if err != nil {
+		t.Fatalf("TeamEntry: %v", err)
+	}
+	if te.TeamEntry.Metadata.Name != "sbsh" {
+		t.Errorf("teamEntry name = %q, want sbsh", te.TeamEntry.Metadata.Name)
+	}
+	if te.TeamEntry.Spec.Path != "/home/op/src/sbsh" || te.TeamEntry.Spec.Source != "eminwux/agents@v1.4.0" {
+		t.Errorf("teamEntry spec = %+v", te.TeamEntry.Spec)
 	}
 
 	role, err := Parse([]byte(roleHappy))
@@ -277,15 +299,16 @@ func TestParseFailureModes(t *testing.T) {
 			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { sources: { agents: git@x } }\n",
 			errdefs.ErrTeamSourceKeyInvalid,
 		},
+		// TeamEntry.
 		{
-			"TeamsConfig duplicate team name",
-			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { teams: [{name: a}, {name: a}] }\n",
-			errdefs.ErrTeamTeamNameDuplicate,
+			"TeamEntry missing name",
+			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nspec: { path: /x }\n",
+			errdefs.ErrTeamEntryNameRequired,
 		},
 		{
-			"TeamsConfig missing team name",
-			"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { teams: [{path: /x}] }\n",
-			errdefs.ErrTeamTeamNameRequired,
+			"TeamEntry non-pinned source",
+			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: a }\nspec: { path: /x, source: eminwux/agents@main }\n",
+			errdefs.ErrTeamSourceInvalid,
 		},
 		// Role.
 		{

--- a/internal/teamhost/teamhost.go
+++ b/internal/teamhost/teamhost.go
@@ -104,11 +104,19 @@ func EnsureGlobalConfig(l Layout, cfg *model.TeamsConfig) (bool, error) {
 // WriteEntry persists entry to its per-project path, creating the drop-in
 // directory (0o700) if absent. Only the named project's file is touched, so
 // rewriting one project's entry never disturbs another's. The write is atomic
-// (temp file + rename) and the resulting file is 0o600.
+// (temp file + rename) and the resulting file is 0o600. The name is also
+// re-checked for path-traversal characters as defense-in-depth — the parser
+// already rejects unsafe names, but callers that build a TeamEntry directly
+// (without going through the parser) must not be able to escape the drop-in
+// directory.
 func WriteEntry(l Layout, entry *model.TeamEntry) error {
 	project := strings.TrimSpace(entry.Metadata.Name)
 	if project == "" {
 		return errdefs.ErrTeamEntryNameRequired
+	}
+	if strings.ContainsAny(project, "/\\") || strings.ContainsRune(project, 0) ||
+		strings.Contains(project, "..") || strings.HasPrefix(project, ".") {
+		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamMetadataNameUnsafe, entry.Metadata.Name)
 	}
 	dir := l.DropInDir()
 	if err := os.MkdirAll(dir, dropInDirPerm); err != nil {

--- a/internal/teamhost/teamhost.go
+++ b/internal/teamhost/teamhost.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package teamhost owns the host-side, on-disk lifecycle of the
+// team-distribution config maintained by `kuke team init` (epic #792, step 1
+// #796): the operator-global facts file (~/.kuke/kuketeams.yaml) and the
+// per-project drop-in directory (~/.kuke/kuketeam.d/<project>.yaml).
+//
+// The drop-in layout (the systemd/sudoers.d pattern) replaces a single shared
+// teams[] array: each project owns one file, so a corrupt or partial write —
+// which can happen on every init — touches one project rather than the whole
+// roster, and two concurrent `kuke team init` runs never race on a shared
+// array. The Base directory is injected (rather than resolved from $HOME here)
+// so the lifecycle is unit-testable against a temp dir with no live kukeond.
+package teamhost
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// globalConfigName is the operator-global facts file under Base.
+	globalConfigName = "kuketeams.yaml"
+	// dropInDirName is the per-project drop-in directory under Base.
+	dropInDirName = "kuketeam.d"
+
+	// dropInDirPerm is the drop-in directory mode: operator-only (the files
+	// reference secret sources and signing keys).
+	dropInDirPerm = 0o700
+	// configFilePerm is the mode for the global facts file and each per-project
+	// entry — operator read/write only.
+	configFilePerm = 0o600
+)
+
+// Layout resolves the team-distribution file paths under a base directory
+// (normally ~/.kuke). The zero value is unusable; construct with NewLayout.
+type Layout struct {
+	// Base is the directory holding kuketeams.yaml and kuketeam.d/.
+	Base string
+}
+
+// NewLayout returns a Layout rooted at base.
+func NewLayout(base string) Layout {
+	return Layout{Base: base}
+}
+
+// GlobalConfigPath is the operator-global facts file (<base>/kuketeams.yaml).
+func (l Layout) GlobalConfigPath() string {
+	return filepath.Join(l.Base, globalConfigName)
+}
+
+// DropInDir is the per-project drop-in directory (<base>/kuketeam.d).
+func (l Layout) DropInDir() string {
+	return filepath.Join(l.Base, dropInDirName)
+}
+
+// EntryPath is the per-project file (<base>/kuketeam.d/<project>.yaml).
+func (l Layout) EntryPath(project string) string {
+	return filepath.Join(l.DropInDir(), project+".yaml")
+}
+
+// EnsureGlobalConfig writes cfg to the global facts path only when no file is
+// already present, returning created=true when it scaffolded the file and
+// false when one already existed (the re-run case — its contents are left
+// untouched). The parent directory is created (0o700) if absent.
+func EnsureGlobalConfig(l Layout, cfg *model.TeamsConfig) (bool, error) {
+	path := l.GlobalConfigPath()
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("stat global config %q: %w", path, err)
+	}
+
+	if mkErr := os.MkdirAll(l.Base, dropInDirPerm); mkErr != nil {
+		return false, fmt.Errorf("create config dir %q: %w", l.Base, mkErr)
+	}
+	if err := writeYAML(path, cfg); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// WriteEntry persists entry to its per-project path, creating the drop-in
+// directory (0o700) if absent. Only the named project's file is touched, so
+// rewriting one project's entry never disturbs another's. The write is atomic
+// (temp file + rename) and the resulting file is 0o600.
+func WriteEntry(l Layout, entry *model.TeamEntry) error {
+	project := strings.TrimSpace(entry.Metadata.Name)
+	if project == "" {
+		return errdefs.ErrTeamEntryNameRequired
+	}
+	dir := l.DropInDir()
+	if err := os.MkdirAll(dir, dropInDirPerm); err != nil {
+		return fmt.Errorf("create drop-in dir %q: %w", dir, err)
+	}
+	return writeYAML(l.EntryPath(project), entry)
+}
+
+// writeYAML marshals doc to YAML and writes it atomically to path (temp file in
+// the same directory + rename), leaving the file 0o600. Writing into the target
+// directory keeps the rename on the same filesystem so it is atomic.
+func writeYAML(path string, doc any) error {
+	raw, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal %q: %w", path, err)
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".kuketeam-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file in %q: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename succeeds
+
+	if _, writeErr := tmp.Write(raw); writeErr != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file %q: %w", tmpName, writeErr)
+	}
+	if closeErr := tmp.Close(); closeErr != nil {
+		return fmt.Errorf("close temp file %q: %w", tmpName, closeErr)
+	}
+	if chmodErr := os.Chmod(tmpName, configFilePerm); chmodErr != nil {
+		return fmt.Errorf("chmod temp file %q: %w", tmpName, chmodErr)
+	}
+	if renameErr := os.Rename(tmpName, path); renameErr != nil {
+		return fmt.Errorf("rename %q to %q: %w", tmpName, path, renameErr)
+	}
+	return nil
+}

--- a/internal/teamhost/teamhost_test.go
+++ b/internal/teamhost/teamhost_test.go
@@ -1,0 +1,181 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teamhost_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/teamhost"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	"gopkg.in/yaml.v3"
+)
+
+func globalConfig() *model.TeamsConfig {
+	return &model.TeamsConfig{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindTeamsConfig,
+		Spec:       model.TeamsConfigSpec{Registry: "registry.example.com"},
+	}
+}
+
+func teamEntry(name string) *model.TeamEntry {
+	return &model.TeamEntry{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindTeamEntry,
+		Metadata:   model.Metadata{Name: name},
+		Spec:       model.TeamEntrySpec{Path: "/home/op/src/" + name, Source: "eminwux/agents@v1.4.0"},
+	}
+}
+
+func TestEnsureGlobalConfigScaffoldsThenSkips(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	created, err := teamhost.EnsureGlobalConfig(l, globalConfig())
+	if err != nil {
+		t.Fatalf("first EnsureGlobalConfig: %v", err)
+	}
+	if !created {
+		t.Fatalf("first call created = false, want true")
+	}
+	if _, statErr := os.Stat(l.GlobalConfigPath()); statErr != nil {
+		t.Fatalf("global config not written: %v", statErr)
+	}
+
+	// Mutate on disk, then re-run: a re-run must NOT overwrite existing content.
+	if writeErr := os.WriteFile(l.GlobalConfigPath(), []byte("sentinel: kept\n"), 0o600); writeErr != nil {
+		t.Fatalf("seed sentinel: %v", writeErr)
+	}
+	created, err = teamhost.EnsureGlobalConfig(l, globalConfig())
+	if err != nil {
+		t.Fatalf("second EnsureGlobalConfig: %v", err)
+	}
+	if created {
+		t.Errorf("second call created = true, want false (file already present)")
+	}
+	got, readErr := os.ReadFile(l.GlobalConfigPath())
+	if readErr != nil {
+		t.Fatalf("read after second call: %v", readErr)
+	}
+	if string(got) != "sentinel: kept\n" {
+		t.Errorf("re-run overwrote existing global config: %q", got)
+	}
+}
+
+func TestWriteEntryCreatesDirAndFileWithPerms(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	if err := teamhost.WriteEntry(l, teamEntry("sbsh")); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+
+	dirInfo, err := os.Stat(l.DropInDir())
+	if err != nil {
+		t.Fatalf("drop-in dir not created: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o700 {
+		t.Errorf("drop-in dir perm = %o, want 700", perm)
+	}
+
+	fileInfo, err := os.Stat(l.EntryPath("sbsh"))
+	if err != nil {
+		t.Fatalf("entry file not created: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0o600 {
+		t.Errorf("entry file perm = %o, want 600", perm)
+	}
+
+	raw, err := os.ReadFile(l.EntryPath("sbsh"))
+	if err != nil {
+		t.Fatalf("read entry: %v", err)
+	}
+	var got model.TeamEntry
+	if unmarshalErr := yaml.Unmarshal(raw, &got); unmarshalErr != nil {
+		t.Fatalf("entry does not round-trip: %v", unmarshalErr)
+	}
+	if got.Kind != model.KindTeamEntry || got.Metadata.Name != "sbsh" ||
+		got.Spec.Source != "eminwux/agents@v1.4.0" {
+		t.Errorf("entry content lost on disk: %+v", got)
+	}
+}
+
+// TestWriteEntryIsolatesProjects is the AC's failure-isolation guarantee: each
+// project owns one file, so rewriting one or removing one leaves the others
+// untouched.
+func TestWriteEntryIsolatesProjects(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	if err := teamhost.WriteEntry(l, teamEntry("alpha")); err != nil {
+		t.Fatalf("write alpha: %v", err)
+	}
+	if err := teamhost.WriteEntry(l, teamEntry("beta")); err != nil {
+		t.Fatalf("write beta: %v", err)
+	}
+
+	// Rewrite alpha; beta's file must be byte-identical afterwards.
+	betaBefore, err := os.ReadFile(l.EntryPath("beta"))
+	if err != nil {
+		t.Fatalf("read beta before: %v", err)
+	}
+	if rwErr := teamhost.WriteEntry(l, teamEntry("alpha")); rwErr != nil {
+		t.Fatalf("rewrite alpha: %v", rwErr)
+	}
+	betaAfter, err := os.ReadFile(l.EntryPath("beta"))
+	if err != nil {
+		t.Fatalf("read beta after: %v", err)
+	}
+	if string(betaBefore) != string(betaAfter) {
+		t.Errorf("rewriting alpha disturbed beta: before=%q after=%q", betaBefore, betaAfter)
+	}
+
+	// Removing alpha leaves beta intact.
+	if rmErr := os.Remove(l.EntryPath("alpha")); rmErr != nil {
+		t.Fatalf("remove alpha: %v", rmErr)
+	}
+	if _, statErr := os.Stat(l.EntryPath("beta")); statErr != nil {
+		t.Errorf("removing alpha affected beta: %v", statErr)
+	}
+}
+
+func TestWriteEntryEmptyNameErrors(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	err := teamhost.WriteEntry(l, teamEntry("   "))
+	if !errors.Is(err, errdefs.ErrTeamEntryNameRequired) {
+		t.Errorf("err = %v, want ErrTeamEntryNameRequired", err)
+	}
+}
+
+func TestLayoutPaths(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout("/base/.kuke")
+	if got, want := l.GlobalConfigPath(), "/base/.kuke/kuketeams.yaml"; got != want {
+		t.Errorf("GlobalConfigPath = %q, want %q", got, want)
+	}
+	if got, want := l.DropInDir(), "/base/.kuke/kuketeam.d"; got != want {
+		t.Errorf("DropInDir = %q, want %q", got, want)
+	}
+	if got, want := l.EntryPath("sbsh"), "/base/.kuke/kuketeam.d/sbsh.yaml"; got != want {
+		t.Errorf("EntryPath = %q, want %q", got, want)
+	}
+}

--- a/internal/teamhost/teamhost_test.go
+++ b/internal/teamhost/teamhost_test.go
@@ -166,6 +166,42 @@ func TestWriteEntryEmptyNameErrors(t *testing.T) {
 	}
 }
 
+// TestWriteEntryUnsafeNameRefused is the defense-in-depth guard against path
+// traversal: the parser already rejects unsafe metadata.name values, but a
+// caller building a TeamEntry directly (no parser hop) must not be able to
+// escape the drop-in directory and clobber the operator's global facts file.
+func TestWriteEntryUnsafeNameRefused(t *testing.T) {
+	t.Parallel()
+	base := filepath.Join(t.TempDir(), ".kuke")
+	l := teamhost.NewLayout(base)
+
+	// Pre-seed the global facts file so the traversal target would clobber a
+	// real, distinguishable byte sequence on a successful escape.
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		t.Fatalf("mkdir base: %v", err)
+	}
+	const sentinel = "sentinel: kept\n"
+	if err := os.WriteFile(l.GlobalConfigPath(), []byte(sentinel), 0o600); err != nil {
+		t.Fatalf("seed global: %v", err)
+	}
+
+	cases := []string{"../kuketeams", "a/b", "a\\b", ".hidden", ".."}
+	for _, name := range cases {
+		err := teamhost.WriteEntry(l, teamEntry(name))
+		if !errors.Is(err, errdefs.ErrTeamMetadataNameUnsafe) {
+			t.Errorf("WriteEntry(%q) err = %v, want ErrTeamMetadataNameUnsafe", name, err)
+		}
+	}
+
+	got, err := os.ReadFile(l.GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("read global after refusal: %v", err)
+	}
+	if string(got) != sentinel {
+		t.Errorf("global facts file was clobbered: %q", got)
+	}
+}
+
 func TestLayoutPaths(t *testing.T) {
 	t.Parallel()
 	l := teamhost.NewLayout("/base/.kuke")

--- a/pkg/api/model/kuketeams/doc.go
+++ b/pkg/api/model/kuketeams/doc.go
@@ -15,14 +15,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package kuketeams holds the Go types for the team-distribution contract
-// (issue #793, epic #792). The five kinds — ProjectTeam, TeamsConfig, Role,
-// Harness, and ImageCatalog — model in-repo team composition:
+// (issue #793, epic #792). The kinds — ProjectTeam, TeamsConfig, TeamEntry,
+// Role, Harness, and ImageCatalog — model in-repo team composition:
 //
 //   - ProjectTeam (committed in each project repo, `kuketeam.yaml`) declares the
 //     roster: which pinned agents source, which roles, which harness defaults.
 //   - TeamsConfig (host, operator-owned, `~/.kuke/kuketeams.yaml`) carries
-//     operator facts — git identity/signing, registry, source clone URLs,
-//     secret sources — and the composition list of teams.
+//     operator facts only — git identity/signing, registry, source clone URLs,
+//     secret sources.
+//   - TeamEntry (host, `~/.kuke/kuketeam.d/<project>.yaml`, one per project)
+//     carries the per-project composition record `kuke team init` writes — a
+//     drop-in directory so a corrupt write touches one project, not all (#796).
 //   - Role / Harness / ImageCatalog live in the pinned agents source. They
 //     declare, respectively, a role's skills + harness configs + needs, a
 //     harness's base image + skill path + make target, and the prebuilt
@@ -52,9 +55,13 @@ const (
 	// KindProjectTeam identifies the per-project roster committed as
 	// kuketeam.yaml in each project repo.
 	KindProjectTeam = "ProjectTeam"
-	// KindTeamsConfig identifies the host-side, operator-owned composition
+	// KindTeamsConfig identifies the host-side, operator-owned global-facts
 	// document (~/.kuke/kuketeams.yaml) maintained by `kuke team init`.
 	KindTeamsConfig = "TeamsConfig"
+	// KindTeamEntry identifies a host-side, per-project composition record
+	// (~/.kuke/kuketeam.d/<project>.yaml) written by `kuke team init` — one
+	// document per project file.
+	KindTeamEntry = "TeamEntry"
 	// KindRole identifies a per-role document (role.yaml) in the agents source.
 	KindRole = "Role"
 	// KindHarness identifies a per-harness document (harness.yaml) in the

--- a/pkg/api/model/kuketeams/marshal_test.go
+++ b/pkg/api/model/kuketeams/marshal_test.go
@@ -82,6 +82,16 @@ func TestRoundTripAllKinds(t *testing.T) {
 			len(got.Spec.Roles) == 1 && got.Spec.Roles[0].Needs.Image[0] == "go"
 	})
 
+	te := model.TeamEntry{
+		APIVersion: model.APIVersionV1, Kind: model.KindTeamEntry,
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec:     model.TeamEntrySpec{Path: "/home/op/src/sbsh", Source: "eminwux/agents@v1.4.0"},
+	}
+	assertJSONYAML(t, "TeamEntry", te, func(got model.TeamEntry) bool {
+		return got.Metadata.Name == "sbsh" && got.Spec.Path == "/home/op/src/sbsh" &&
+			got.Spec.Source == "eminwux/agents@v1.4.0"
+	})
+
 	role := model.Role{
 		APIVersion: model.APIVersionV1, Kind: model.KindRole,
 		Metadata: model.Metadata{Name: "dev"},

--- a/pkg/api/model/kuketeams/teamentry.go
+++ b/pkg/api/model/kuketeams/teamentry.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams
+
+// TeamEntry is the host-side, per-project composition record written by
+// `kuke team init` to ~/.kuke/kuketeam.d/<project>.yaml — one document per
+// file. It replaces the former TeamsConfig.spec.teams[] array: a drop-in
+// directory (the systemd/sudoers.d pattern) keeps each project isolated, so a
+// corrupt or partial write touches one project and two concurrent inits never
+// race on a shared array.
+type TeamEntry struct {
+	APIVersion string        `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string        `json:"kind"       yaml:"kind"`
+	Metadata   Metadata      `json:"metadata"   yaml:"metadata"`
+	Spec       TeamEntrySpec `json:"spec"       yaml:"spec"`
+}
+
+// TeamEntrySpec carries the per-project locator + agents pin. Path is an
+// init-time LOCATOR (where the project's kuketeam.yaml was read and from where
+// its clone URL is resolved via `git remote`), not a bind-mount source. Source
+// pins the agents repository as `<owner>/<repo>@vX.Y.Z`, copied from the
+// project's kuketeam.yaml at init time.
+type TeamEntrySpec struct {
+	Path   string `json:"path"             yaml:"path"`
+	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+}

--- a/pkg/api/model/kuketeams/teamsconfig.go
+++ b/pkg/api/model/kuketeams/teamsconfig.go
@@ -20,10 +20,13 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
-// TeamsConfig is the host-side, operator-owned composition document, stored at
+// TeamsConfig is the host-side, operator-owned global-facts document, stored at
 // ~/.kuke/kuketeams.yaml and maintained by `kuke team init`. It carries the
-// operator facts (git identity/signing, registry, source clone URLs, secret
-// sources) and the list of composed teams.
+// operator facts only — git identity/signing, registry, source clone URLs, and
+// secret sources. Per-project composition lives in its own TeamEntry document
+// under the ~/.kuke/kuketeam.d/ drop-in directory (one file per project), so a
+// corrupt or partial write touches a single project rather than the shared
+// roster.
 type TeamsConfig struct {
 	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
 	Kind       string          `json:"kind"       yaml:"kind"`
@@ -43,10 +46,6 @@ type TeamsConfigSpec struct {
 	// Secrets maps a secret name to its source declaration. A secret never
 	// carries an inline value — only where to read it from.
 	Secrets map[string]TeamsConfigSecret `json:"secrets,omitempty"  yaml:"secrets,omitempty"`
-	// Teams lists the composed teams. Each entry's path is an init-time
-	// LOCATOR (where to read kuketeam.yaml and resolve the project's clone URL
-	// from `git remote`), not a bind-mount source.
-	Teams []TeamsConfigTeam `json:"teams,omitempty"    yaml:"teams,omitempty"`
 }
 
 // TeamsConfigGit is a strict superset of v1beta1.ContainerGit — the embedded
@@ -69,13 +68,4 @@ type TeamsConfigGit struct {
 type TeamsConfigSecret struct {
 	From string `json:"from" yaml:"from"`
 	Key  string `json:"key"  yaml:"key"`
-}
-
-// TeamsConfigTeam is one composed team. Path is an init-time locator, not a
-// bind-mount source — the cell clones the project fresh from the URL resolved
-// from the project's `git remote` at init time.
-type TeamsConfigTeam struct {
-	Name   string `json:"name"   yaml:"name"`
-	Path   string `json:"path"   yaml:"path"`
-	Source string `json:"source" yaml:"source"`
 }


### PR DESCRIPTION
## Summary

Step 1 of the **team-distribution** epic (#792, umbrella) per the resized AC on #796 — lands the `kuke team init` command skeleton + host-config lifecycle. Source resolution, render, and apply remain steps 2–4 (#1041/#1042/#1043).

- **Command skeleton** — net-new `cmd/kuke/team/` package: `kuke team` parent + `init` subcommand, registered in `cmd/kuke/kuke.go`. `init` reads the project's committed `./kuketeam.yaml` roster; a missing file errors clearly (`ErrTeamProjectFileNotFound`), a wrong-kind file errors with `ErrTeamProjectFileKind`.
- **Global-facts scaffold** — first run writes `~/.kuke/kuketeams.yaml` (operator facts only): git identity/signing seeded from `git config --global`, registry from `KUKEON_REGISTRY` env. Re-runs never overwrite an existing file.
- **Per-project drop-in** — each `init` writes `~/.kuke/kuketeam.d/<project>.yaml` (a new `TeamEntry` kind) via atomic temp+rename. Drop-in dir is `0o700`, files `0o600`. One file per project, so a corrupt/partial write touches one project and concurrent inits don't race a shared array.
- **Type adjustment to #1028's `TeamsConfig`** — dropped `Teams []TeamsConfigTeam` from `TeamsConfigSpec`; promoted the per-project entry to the new `kuketeams.io/v1` `TeamEntry` kind (`metadata.name` + `spec.path`/`spec.source`), wired into the `internal/kuketeams` parser `Document`/`Parse` dispatch with validation.
- New host-side lifecycle package `internal/teamhost` (path layout + scaffold + atomic entry write), kept free of cobra so it's unit-testable against a temp dir.

### Non-obvious calls (reviewer, please push back)

- **Kind name `TeamEntry`** — the issue suggested it and left final naming to dev's call; adopted as-is.
- **`name` in `metadata`, `path`/`source` in `spec`** — matches the GVK shape of the sibling kinds (ProjectTeam/Role/Harness use `Metadata.Name`); the old flat `TeamsConfigTeam{Name,Path,Source}` is gone.
- **`--dry-run` semantics** — the AC reserves `--dry-run` for step 3's render output. Registered the flag now (AC: "parse flags") with a forward-compatible step-1 behavior: it prints the `TeamEntry` that would be written and touches no disk. Step 3 extends it to full render output.
- **Registry/secrets seeding** — AC says "registry/secrets from env/prompt". The verb is non-interactive (cron contract), so there is no prompt: registry is seeded from `KUKEON_REGISTRY` env; secrets are left empty for the operator to fill in. Documented here so step 2/3 can revisit if a richer seed is wanted.
- **Removed sentinels** — `ErrTeamTeamNameRequired`/`ErrTeamTeamNameDuplicate` (only used by the dropped `teams[]` loop) replaced by `ErrTeamEntryNameRequired`; duplicate-name is no longer meaningful (the filename is the uniqueness key). Tree-wide `git grep` confirms no other references.
- **Stale triage comment** — #796 carries an older dev-triage "too broad, requesting re-size" comment. PM has since resized the issue body to this step-1 scope; the comment is superseded and the current body is authoritative.

## Test plan

- [x] `make test` (the named CI target; `GOWORK=off` exported by the Makefile) — passes.
- [x] `GOWORK=off go build ./...` — passes. (Bare `go build ./...` fails on a pre-existing workspace-mode dep mismatch in `containerd/cgroups`, unrelated to this diff — the Makefile exports `GOWORK=off` for exactly this; see project CLAUDE.md.)
- [x] `GOWORK=off go vet` on all touched packages — clean.
- [x] New unit tests: `internal/teamhost` (scaffold-once, atomic write, per-project isolation, perms), `cmd/kuke/team` (missing/wrong-kind project file, scaffold+write, re-run no-rescaffold, git-identity seeding incl. sign entries, no-identity omits git block, dry-run writes nothing, command registration), `internal/kuketeams` (TeamEntry parse happy + failure modes), `pkg/api/model/kuketeams` (TeamEntry JSON/YAML round-trip).
- [ ] `make dev-init` smoke — **not run, not required**: this change is host-local (writes `~/.kuke` files) and daemon-independent. It does not touch the build path, the daemon, or `/opt/kukeon`, and no daemon code reads the team kinds yet (the parser is standalone, per its package doc). Per project CLAUDE.md the smoke is required only when a change touches something the daemon reads.

Closes #796