### PR TITLE
feat(team): resolve pinned source + cache + load role/harness/images (step 2)

### DIFF
--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -603,4 +603,22 @@ var (
 	ErrTeamImageCapabilitiesRequired = errors.New(
 		"imageCatalog images[].capabilities must be non-empty",
 	)
+	// ErrTeamSourceURLNotMapped fires when a project's `source` <owner>/<repo>
+	// key has no entry in TeamsConfig.spec.sources. The operator must add a
+	// clone URL mapping in ~/.kuke/kuketeams.yaml before init can materialize
+	// the agents source.
+	ErrTeamSourceURLNotMapped = errors.New(
+		"source key is not mapped in TeamsConfig.spec.sources",
+	)
+	// ErrTeamRoleFileKind fires when a per-role role.yaml parses to a kind
+	// other than Role.
+	ErrTeamRoleFileKind = errors.New("role file must be a Role document")
+	// ErrTeamHarnessFileKind fires when a per-harness harness.yaml parses to a
+	// kind other than Harness.
+	ErrTeamHarnessFileKind = errors.New("harness file must be a Harness document")
+	// ErrTeamImageCatalogFileKind fires when harnesses/images.yaml parses to a
+	// kind other than ImageCatalog.
+	ErrTeamImageCatalogFileKind = errors.New(
+		"image catalog file must be an ImageCatalog document",
+	)
 )

--- a/internal/teamhost/teamhost.go
+++ b/internal/teamhost/teamhost.go
@@ -44,6 +44,9 @@ const (
 	globalConfigName = "kuketeams.yaml"
 	// dropInDirName is the per-project drop-in directory under Base.
 	dropInDirName = "kuketeam.d"
+	// cacheDirName is the materialized-source cache under Base — each pinned
+	// `<owner>/<repo>@vX.Y.Z` agents reference clones into its own subdirectory.
+	cacheDirName = "cache"
 
 	// dropInDirPerm is the drop-in directory mode: operator-only (the files
 	// reference secret sources and signing keys).
@@ -78,6 +81,11 @@ func (l Layout) DropInDir() string {
 // EntryPath is the per-project file (<base>/kuketeam.d/<project>.yaml).
 func (l Layout) EntryPath(project string) string {
 	return filepath.Join(l.DropInDir(), project+".yaml")
+}
+
+// CacheDir is the materialized-source cache root (<base>/cache).
+func (l Layout) CacheDir() string {
+	return filepath.Join(l.Base, cacheDirName)
 }
 
 // EnsureGlobalConfig writes cfg to the global facts path only when no file is

--- a/internal/teamsource/teamsource.go
+++ b/internal/teamsource/teamsource.go
@@ -1,0 +1,346 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package teamsource resolves a kuketeams.io/v1 ProjectTeam's pinned `source`
+// reference to a local clone of the agents repo and loads the Role, Harness,
+// and ImageCatalog documents the project's roster references (epic #792, step
+// 2 #1041). Materialization is cache-keyed by the pinned
+// `<owner>/<repo>@vX.Y.Z` reference: an existing cache directory at the pinned
+// version is reused without re-cloning, and a missing cache is cloned via
+// `git clone --depth=1 --branch <version> --no-tags` into the pinned ref
+// exactly. Document loading delegates to the existing kuketeams parser, so
+// parse errors carry the offending file path verbatim. No daemon is required —
+// the package is unit-testable against a local fixture remote.
+package teamsource
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/kuketeams"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+)
+
+// sourcePattern matches a pinned-exact `<owner>/<repo>@vX.Y.Z` reference,
+// mirroring internal/kuketeams's parser pattern. Floating refs (`@main`) and
+// bare tags (`@v1`) are rejected.
+var sourcePattern = regexp.MustCompile(
+	`^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)@(v\d+\.\d+\.\d+([-+][0-9A-Za-z.-]+)?)$`,
+)
+
+// cacheDirPerm is the cache root and per-source clone mode — operator-only,
+// matching teamhost's drop-in directory perm. Secret material never lives in
+// the cache (the agents source is the operator's own public repo at a pinned
+// tag), but keeping the perm consistent avoids surprise for an operator
+// inspecting ~/.kuke.
+const cacheDirPerm = 0o700
+
+// Source is a parsed pinned-exact agents reference.
+type Source struct {
+	// Raw is the original `<owner>/<repo>@vX.Y.Z` string, trimmed.
+	Raw string
+	// OwnerRepo is the `<owner>/<repo>` half — the lookup key against
+	// TeamsConfig.spec.sources.
+	OwnerRepo string
+	// Version is the `vX.Y.Z[<+|->suffix]` half — the ref the cache directory
+	// pins to and the value passed to `git clone --branch`.
+	Version string
+}
+
+// ParseSource parses raw into a Source. The input is trimmed and matched
+// against the pinned-exact `<owner>/<repo>@vX.Y.Z` pattern. Floating refs and
+// bare tags surface errdefs.ErrTeamSourceInvalid so callers reuse the same
+// sentinel the parser uses.
+func ParseSource(raw string) (Source, error) {
+	trimmed := strings.TrimSpace(raw)
+	m := sourcePattern.FindStringSubmatch(trimmed)
+	if m == nil {
+		return Source{}, fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceInvalid, raw)
+	}
+	return Source{Raw: trimmed, OwnerRepo: m[1], Version: m[2]}, nil
+}
+
+// CloneURL returns the clone URL for src by looking up its `<owner>/<repo>`
+// key in tc.spec.sources. An unmapped or blank-value key surfaces
+// errdefs.ErrTeamSourceURLNotMapped with the missing key named in the wrapper
+// — the AC's "hard-error naming the missing key" contract.
+func CloneURL(tc *model.TeamsConfig, src Source) (string, error) {
+	if tc == nil {
+		return "", fmt.Errorf("%w: %q", errdefs.ErrTeamSourceURLNotMapped, src.OwnerRepo)
+	}
+	url, ok := tc.Spec.Sources[src.OwnerRepo]
+	if !ok || strings.TrimSpace(url) == "" {
+		return "", fmt.Errorf("%w: %q", errdefs.ErrTeamSourceURLNotMapped, src.OwnerRepo)
+	}
+	return strings.TrimSpace(url), nil
+}
+
+// Cache is the on-disk cache root for materialized agents sources. Each pinned
+// `<owner>/<repo>@vX.Y.Z` reference lives at <Base>/<owner>/<repo>@<version>,
+// so the version is encoded in the leaf directory name and the existence of
+// that directory is sufficient to decide reuse — the cache key is the pinned
+// reference itself.
+type Cache struct {
+	Base string
+}
+
+// NewCache returns a Cache rooted at base. Pair with teamhost.Layout.CacheDir
+// for the standard ~/.kuke/cache location.
+func NewCache(base string) Cache {
+	return Cache{Base: base}
+}
+
+// Path returns the on-disk directory for src under this cache.
+func (c Cache) Path(src Source) string {
+	return filepath.Join(c.Base, src.OwnerRepo+"@"+src.Version)
+}
+
+// Materialize ensures src is present at its cache path and returns that path.
+// An existing cache directory at the pinned reference is reused as-is; a
+// missing one is cloned via `git clone --depth=1 --branch <version> --no-tags
+// <cloneURL> <tmp>` into a sibling temp directory and renamed into place
+// atomically, so an interrupted clone never leaves a half-materialized cache
+// dir behind. The non-interactive git env (GIT_TERMINAL_PROMPT=0,
+// StrictHostKeyChecking=accept-new BatchMode=yes SSH) mirrors kuketty's
+// processRepos so a first-time clone of an unseen host never hangs.
+func (c Cache) Materialize(ctx context.Context, src Source, cloneURL string) (string, error) {
+	dst := c.Path(src)
+	if _, err := os.Stat(dst); err == nil {
+		return dst, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("stat cache dir %q: %w", dst, err)
+	}
+
+	parent := filepath.Dir(dst)
+	if err := os.MkdirAll(parent, cacheDirPerm); err != nil {
+		return "", fmt.Errorf("create cache parent %q: %w", parent, err)
+	}
+
+	// Reserve a unique temp name as a sibling of dst (so the rename stays on
+	// the same filesystem), then remove it so `git clone` creates the
+	// directory itself — `git clone <url> <dir>` requires the target to not
+	// exist or to be empty, and an empty dir works on every platform.
+	tmp, err := os.MkdirTemp(parent, ".clone-*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("create temp clone dir in %q: %w", parent, err)
+	}
+	if rmErr := os.Remove(tmp); rmErr != nil {
+		return "", fmt.Errorf("clear temp clone dir %q: %w", tmp, rmErr)
+	}
+
+	if cloneErr := runGit(ctx, "", "clone",
+		"--depth=1", "--no-tags",
+		"--branch", src.Version,
+		cloneURL, tmp,
+	); cloneErr != nil {
+		_ = os.RemoveAll(tmp)
+		return "", fmt.Errorf("clone %s@%s: %w", src.OwnerRepo, src.Version, cloneErr)
+	}
+
+	if renameErr := os.Rename(tmp, dst); renameErr != nil {
+		_ = os.RemoveAll(tmp)
+		return "", fmt.Errorf("rename temp clone %q to %q: %w", tmp, dst, renameErr)
+	}
+	return dst, nil
+}
+
+// Bundle is the materialized agents source plus the Role / Harness /
+// ImageCatalog documents the project's roster references.
+type Bundle struct {
+	// Source is the parsed pinned reference (raw, owner/repo, version).
+	Source Source
+	// CacheDir is the on-disk clone root — passed to step 3's render pipeline
+	// when it needs to read blueprint templates or other repo-relative paths.
+	CacheDir string
+	// Roles maps the role ref (ProjectTeam.spec.roles[].ref) to its loaded Role.
+	Roles map[string]*model.Role
+	// Harnesses maps the harness name (ProjectTeam.spec.defaults.harnesses[])
+	// to its loaded Harness.
+	Harnesses map[string]*model.Harness
+	// ImageCatalog is the single harnesses/images.yaml in the agents source.
+	ImageCatalog *model.ImageCatalog
+}
+
+// Resolve parses pt.Spec.Source, looks up the clone URL in tc.spec.sources,
+// materializes the agents source under cache, and loads every Role referenced
+// by pt.Spec.Roles, every Harness referenced by pt.Spec.Defaults.Harnesses,
+// and the ImageCatalog. Parse errors surface with the offending file path —
+// the AC's "surface parse errors with the offending file path" contract.
+func Resolve(
+	ctx context.Context,
+	cache Cache,
+	tc *model.TeamsConfig,
+	pt *model.ProjectTeam,
+) (*Bundle, error) {
+	src, err := ParseSource(pt.Spec.Source)
+	if err != nil {
+		return nil, err
+	}
+	url, err := CloneURL(tc, src)
+	if err != nil {
+		return nil, err
+	}
+	dir, err := cache.Materialize(ctx, src, url)
+	if err != nil {
+		return nil, err
+	}
+
+	b := &Bundle{
+		Source:    src,
+		CacheDir:  dir,
+		Roles:     make(map[string]*model.Role, len(pt.Spec.Roles)),
+		Harnesses: make(map[string]*model.Harness, len(pt.Spec.Defaults.Harnesses)),
+	}
+
+	for _, r := range pt.Spec.Roles {
+		role, loadErr := LoadRole(dir, r.Ref)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		b.Roles[r.Ref] = role
+	}
+	for _, h := range pt.Spec.Defaults.Harnesses {
+		harness, loadErr := LoadHarness(dir, h)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		b.Harnesses[h] = harness
+	}
+	ic, loadErr := LoadImageCatalog(dir)
+	if loadErr != nil {
+		return nil, loadErr
+	}
+	b.ImageCatalog = ic
+	return b, nil
+}
+
+// RolePath is the on-disk role.yaml location for ref under cacheDir.
+func RolePath(cacheDir, ref string) string {
+	return filepath.Join(cacheDir, "roles", ref, "role.yaml")
+}
+
+// HarnessPath is the on-disk harness.yaml location for name under cacheDir.
+func HarnessPath(cacheDir, name string) string {
+	return filepath.Join(cacheDir, "harnesses", name, "harness.yaml")
+}
+
+// ImageCatalogPath is the on-disk harnesses/images.yaml location under cacheDir.
+func ImageCatalogPath(cacheDir string) string {
+	return filepath.Join(cacheDir, "harnesses", "images.yaml")
+}
+
+// LoadRole reads <cacheDir>/roles/<ref>/role.yaml, parses it via the
+// kuketeams parser, and returns the typed Role. A document of the wrong kind
+// surfaces ErrTeamRoleFileKind; parse errors carry the file path verbatim.
+func LoadRole(cacheDir, ref string) (*model.Role, error) {
+	path := RolePath(cacheDir, ref)
+	doc, err := parseFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if doc.Role == nil {
+		return nil, fmt.Errorf("%w (got kind %q in %q)", errdefs.ErrTeamRoleFileKind, doc.Kind, path)
+	}
+	return doc.Role, nil
+}
+
+// LoadHarness reads <cacheDir>/harnesses/<name>/harness.yaml and returns the
+// typed Harness. A document of the wrong kind surfaces ErrTeamHarnessFileKind.
+func LoadHarness(cacheDir, name string) (*model.Harness, error) {
+	path := HarnessPath(cacheDir, name)
+	doc, err := parseFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if doc.Harness == nil {
+		return nil, fmt.Errorf("%w (got kind %q in %q)", errdefs.ErrTeamHarnessFileKind, doc.Kind, path)
+	}
+	return doc.Harness, nil
+}
+
+// LoadImageCatalog reads <cacheDir>/harnesses/images.yaml and returns the
+// typed ImageCatalog. A document of the wrong kind surfaces
+// ErrTeamImageCatalogFileKind.
+func LoadImageCatalog(cacheDir string) (*model.ImageCatalog, error) {
+	path := ImageCatalogPath(cacheDir)
+	doc, err := parseFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if doc.ImageCatalog == nil {
+		return nil, fmt.Errorf("%w (got kind %q in %q)", errdefs.ErrTeamImageCatalogFileKind, doc.Kind, path)
+	}
+	return doc.ImageCatalog, nil
+}
+
+// parseFile reads path and parses it via kuketeams.Parse. Read and parse
+// errors are wrapped with the file path so the operator sees which document in
+// the cloned tree is broken.
+func parseFile(path string) (*kuketeams.Document, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %q: %w", path, err)
+	}
+	doc, err := kuketeams.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse %q: %w", path, err)
+	}
+	return doc, nil
+}
+
+// runGit invokes git with the operator's environment plus non-interactive
+// guards (GIT_TERMINAL_PROMPT=0 and a StrictHostKeyChecking=accept-new
+// BatchMode=yes GIT_SSH_COMMAND), mirroring kuketty's processRepos guards so
+// a first-time clone of an unseen host never blocks on an interactive
+// yes/no prompt. dir is the working directory ("" for the process cwd).
+// Combined output is folded into the error for actionable diagnostics.
+func runGit(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Env = gitEnv()
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(out))
+		if trimmed != "" {
+			return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, trimmed)
+		}
+		return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+// gitEnv returns the operator's environment augmented with non-interactive
+// guards. Both guards yield to a value the operator already set: an env that
+// pre-seeds known_hosts and exports its own GIT_SSH_COMMAND wins.
+func gitEnv() []string {
+	env := os.Environ()
+	if _, ok := os.LookupEnv("GIT_TERMINAL_PROMPT"); !ok {
+		env = append(env, "GIT_TERMINAL_PROMPT=0")
+	}
+	if _, ok := os.LookupEnv("GIT_SSH_COMMAND"); !ok {
+		env = append(env, "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes")
+	}
+	return env
+}

--- a/internal/teamsource/teamsource_test.go
+++ b/internal/teamsource/teamsource_test.go
@@ -1,0 +1,451 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teamsource
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+)
+
+// gitRun runs git in dir with a hermetic identity so the test never depends on
+// (or mutates) the host operator's global git config. Mirrors the pattern in
+// cmd/kuketty/repos_test.go.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	full := append([]string{
+		"-c", "user.email=test@kukeon.invalid",
+		"-c", "user.name=kukeon test",
+		"-c", "init.defaultBranch=main",
+		"-c", "commit.gpgsign=false",
+		"-c", "tag.gpgsign=false",
+		"-c", "tag.forceSignAnnotated=false",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %q: %v\n%s", args, dir, err, out)
+	}
+}
+
+// agentsFile is one document the fixture remote should carry. Path is relative
+// to the agents repo root.
+type agentsFile struct {
+	path string
+	body string
+}
+
+// validRoleDevYAML is a minimal Role document the parser accepts.
+const validRoleDevYAML = `apiVersion: kuketeams.io/v1
+kind: Role
+metadata: { name: dev }
+spec:
+  needs:
+    image: [base]
+`
+
+// validHarnessClaudeYAML is a minimal Harness document the parser accepts.
+const validHarnessClaudeYAML = `apiVersion: kuketeams.io/v1
+kind: Harness
+metadata: { name: claude }
+spec:
+  skillPath: /opt/claude/skills
+  makeTarget: claude
+  template: harnesses/claude/blueprint.tmpl.yaml
+`
+
+// validImageCatalogYAML is a minimal ImageCatalog the parser accepts.
+const validImageCatalogYAML = `apiVersion: kuketeams.io/v1
+kind: ImageCatalog
+spec:
+  images:
+    - ref: claude-base
+      harness: claude
+      image: registry.example.com/claude:latest
+      build:
+        context: harnesses/claude
+        dockerfile: Dockerfile
+      capabilities: [base]
+`
+
+// defaultFixtureFiles is the file set every test in this file pins at the
+// fixture-remote tag unless it overrides.
+func defaultFixtureFiles() []agentsFile {
+	return []agentsFile{
+		{path: "roles/dev/role.yaml", body: validRoleDevYAML},
+		{path: "harnesses/claude/harness.yaml", body: validHarnessClaudeYAML},
+		{path: "harnesses/images.yaml", body: validImageCatalogYAML},
+	}
+}
+
+// makeFixtureRemote creates a non-bare git repo with the given files, commits,
+// and tags it as version. Returns the file:// URL usable as a clone source.
+func makeFixtureRemote(t *testing.T, version string, files []agentsFile) string {
+	t.Helper()
+	src := t.TempDir()
+	gitRun(t, src, "init")
+	for _, f := range files {
+		full := filepath.Join(src, f.path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %q: %v", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(f.body), 0o644); err != nil {
+			t.Fatalf("write %q: %v", full, err)
+		}
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "fixture")
+	gitRun(t, src, "tag", version)
+	return "file://" + src
+}
+
+func TestParseSource_Valid(t *testing.T) {
+	t.Parallel()
+	src, err := ParseSource("  eminwux/agents@v1.4.0  ")
+	if err != nil {
+		t.Fatalf("ParseSource: %v", err)
+	}
+	if src.OwnerRepo != "eminwux/agents" || src.Version != "v1.4.0" || src.Raw != "eminwux/agents@v1.4.0" {
+		t.Errorf("parsed src = %+v", src)
+	}
+}
+
+func TestParseSource_Rejects(t *testing.T) {
+	t.Parallel()
+	for _, raw := range []string{
+		"eminwux/agents@main",        // floating ref
+		"eminwux/agents@v1",          // bare tag
+		"eminwux/agents",             // missing version
+		"eminwux@v1.4.0",             // missing repo
+		"eminwux/agents@1.4.0",       // missing v prefix
+		"eminwux/agents@v1.4",        // not pinned-exact
+		"",                           // empty
+		"eminwux/agents@v1.4.0/path", // extra path
+	} {
+		if _, err := ParseSource(raw); !errors.Is(err, errdefs.ErrTeamSourceInvalid) {
+			t.Errorf("ParseSource(%q) err = %v, want ErrTeamSourceInvalid", raw, err)
+		}
+	}
+}
+
+func TestCloneURL_Mapped(t *testing.T) {
+	t.Parallel()
+	tc := &model.TeamsConfig{
+		Spec: model.TeamsConfigSpec{
+			Sources: map[string]string{
+				"eminwux/agents": "  git@github.com:eminwux/agents.git  ",
+			},
+		},
+	}
+	url, err := CloneURL(tc, Source{OwnerRepo: "eminwux/agents"})
+	if err != nil {
+		t.Fatalf("CloneURL: %v", err)
+	}
+	if url != "git@github.com:eminwux/agents.git" {
+		t.Errorf("CloneURL = %q", url)
+	}
+}
+
+func TestCloneURL_Unmapped(t *testing.T) {
+	t.Parallel()
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{Sources: map[string]string{}}}
+	_, err := CloneURL(tc, Source{OwnerRepo: "eminwux/agents"})
+	if !errors.Is(err, errdefs.ErrTeamSourceURLNotMapped) {
+		t.Fatalf("err = %v, want ErrTeamSourceURLNotMapped", err)
+	}
+	if !strings.Contains(err.Error(), "eminwux/agents") {
+		t.Errorf("err %q does not name the missing key", err)
+	}
+}
+
+func TestCloneURL_BlankValueIsUnmapped(t *testing.T) {
+	t.Parallel()
+	tc := &model.TeamsConfig{
+		Spec: model.TeamsConfigSpec{
+			Sources: map[string]string{"eminwux/agents": "   "},
+		},
+	}
+	_, err := CloneURL(tc, Source{OwnerRepo: "eminwux/agents"})
+	if !errors.Is(err, errdefs.ErrTeamSourceURLNotMapped) {
+		t.Fatalf("err = %v, want ErrTeamSourceURLNotMapped on blank value", err)
+	}
+}
+
+func TestCloneURL_NilTeamsConfig(t *testing.T) {
+	t.Parallel()
+	_, err := CloneURL(nil, Source{OwnerRepo: "eminwux/agents"})
+	if !errors.Is(err, errdefs.ErrTeamSourceURLNotMapped) {
+		t.Fatalf("err = %v, want ErrTeamSourceURLNotMapped on nil TeamsConfig", err)
+	}
+}
+
+func TestCache_MaterializeClones(t *testing.T) {
+	t.Parallel()
+	url := makeFixtureRemote(t, "v1.4.0", defaultFixtureFiles())
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	src, _ := ParseSource("eminwux/agents@v1.4.0")
+
+	dir, err := cache.Materialize(context.Background(), src, url)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	want := filepath.Join(cache.Base, "eminwux/agents@v1.4.0")
+	if dir != want {
+		t.Errorf("dir = %q, want %q", dir, want)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "roles", "dev", "role.yaml")); err != nil {
+		t.Errorf("role.yaml not present in cache: %v", err)
+	}
+}
+
+func TestCache_MaterializeReusesExisting(t *testing.T) {
+	t.Parallel()
+	url := makeFixtureRemote(t, "v1.4.0", defaultFixtureFiles())
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	src, _ := ParseSource("eminwux/agents@v1.4.0")
+
+	dir, err := cache.Materialize(context.Background(), src, url)
+	if err != nil {
+		t.Fatalf("first Materialize: %v", err)
+	}
+	// Plant a sentinel inside the cache dir. A re-Materialize must not re-clone
+	// (which would wipe the sentinel) — the AC's "existing cache dir at the
+	// pinned version is reused (no re-clone)" contract.
+	sentinel := filepath.Join(dir, ".reuse-sentinel")
+	if err := os.WriteFile(sentinel, []byte("kept"), 0o600); err != nil {
+		t.Fatalf("plant sentinel: %v", err)
+	}
+	// Point the second call at a bogus URL — if Materialize tried to clone, it
+	// would fail loudly, proving reuse is broken.
+	dir2, err := cache.Materialize(context.Background(), src, "file:///nonexistent")
+	if err != nil {
+		t.Fatalf("second Materialize: %v", err)
+	}
+	if dir2 != dir {
+		t.Errorf("reuse path = %q, want %q", dir2, dir)
+	}
+	got, err := os.ReadFile(sentinel)
+	if err != nil || string(got) != "kept" {
+		t.Errorf("sentinel lost on reuse: data=%q err=%v", got, err)
+	}
+}
+
+func TestCache_MaterializePinsToVersion(t *testing.T) {
+	t.Parallel()
+	// Build a fixture remote with two distinct commits at two version tags so
+	// HEAD on the wrong tag would surface a different role body. The pinned
+	// ref check is then: the role at v1.4.0 carries the v1.4.0 body, not the
+	// v1.5.0 body.
+	src := t.TempDir()
+	gitRun(t, src, "init")
+	rolePath := filepath.Join(src, "roles", "dev", "role.yaml")
+	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// v1.4.0 commit: role needs [base].
+	if err := os.WriteFile(rolePath, []byte(validRoleDevYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "v1.4.0")
+	gitRun(t, src, "tag", "v1.4.0")
+	// v1.5.0 commit: rewrite role needs to [base, go] so a clone landing here
+	// would carry the second-image capability.
+	v15Role := strings.Replace(validRoleDevYAML, "image: [base]", "image: [base, go]", 1)
+	if err := os.WriteFile(rolePath, []byte(v15Role), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "v1.5.0")
+	gitRun(t, src, "tag", "v1.5.0")
+	url := "file://" + src
+
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	srcRef, _ := ParseSource("eminwux/agents@v1.4.0")
+	dir, err := cache.Materialize(context.Background(), srcRef, url)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "roles", "dev", "role.yaml"))
+	if err != nil {
+		t.Fatalf("read role.yaml: %v", err)
+	}
+	if strings.Contains(string(got), "go") {
+		t.Errorf("clone landed on v1.5.0, not v1.4.0; body=%q", got)
+	}
+}
+
+func TestCache_MaterializeMissingTagSurfaces(t *testing.T) {
+	t.Parallel()
+	url := makeFixtureRemote(t, "v1.4.0", defaultFixtureFiles())
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	src, _ := ParseSource("eminwux/agents@v9.9.9") // tag does not exist
+
+	dir := cache.Path(src)
+	if _, err := cache.Materialize(context.Background(), src, url); err == nil {
+		t.Fatalf("Materialize: want clone error for missing tag, got nil")
+	}
+	// Atomic-rename guarantee: a failed clone leaves no half-materialized dir.
+	if _, err := os.Stat(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("failed clone left %q on disk: stat err = %v", dir, err)
+	}
+}
+
+func TestResolve_LoadsAllReferenced(t *testing.T) {
+	t.Parallel()
+	url := makeFixtureRemote(t, "v1.4.0", defaultFixtureFiles())
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	tc := &model.TeamsConfig{
+		Spec: model.TeamsConfigSpec{
+			Sources: map[string]string{"eminwux/agents": url},
+		},
+	}
+	pt := &model.ProjectTeam{
+		Spec: model.ProjectTeamSpec{
+			Source:   "eminwux/agents@v1.4.0",
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	b, err := Resolve(context.Background(), cache, tc, pt)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if b.Roles["dev"] == nil || b.Roles["dev"].Metadata.Name != "dev" {
+		t.Errorf("role dev not loaded: %+v", b.Roles)
+	}
+	if b.Harnesses["claude"] == nil || b.Harnesses["claude"].Metadata.Name != "claude" {
+		t.Errorf("harness claude not loaded: %+v", b.Harnesses)
+	}
+	if b.ImageCatalog == nil || len(b.ImageCatalog.Spec.Images) != 1 {
+		t.Errorf("image catalog not loaded: %+v", b.ImageCatalog)
+	}
+}
+
+func TestResolve_UnmappedSourceErrors(t *testing.T) {
+	t.Parallel()
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{}}
+	pt := &model.ProjectTeam{
+		Spec: model.ProjectTeamSpec{
+			Source: "eminwux/agents@v1.4.0",
+		},
+	}
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	_, err := Resolve(context.Background(), cache, tc, pt)
+	if !errors.Is(err, errdefs.ErrTeamSourceURLNotMapped) {
+		t.Fatalf("Resolve err = %v, want ErrTeamSourceURLNotMapped", err)
+	}
+}
+
+func TestResolve_InvalidSourceErrors(t *testing.T) {
+	t.Parallel()
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{}}
+	pt := &model.ProjectTeam{
+		Spec: model.ProjectTeamSpec{Source: "eminwux/agents@main"},
+	}
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	_, err := Resolve(context.Background(), cache, tc, pt)
+	if !errors.Is(err, errdefs.ErrTeamSourceInvalid) {
+		t.Fatalf("Resolve err = %v, want ErrTeamSourceInvalid", err)
+	}
+}
+
+func TestLoadRole_WrongKindNamesPath(t *testing.T) {
+	t.Parallel()
+	// A role.yaml that parses successfully as a different kind (a valid
+	// Harness document here) triggers ErrTeamRoleFileKind at the loader layer
+	// — the parser dispatched on `kind:`, validated cleanly, but the loader
+	// expected a Role document.
+	dir := t.TempDir()
+	rolePath := filepath.Join(dir, "roles", "dev", "role.yaml")
+	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rolePath, []byte(validHarnessClaudeYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadRole(dir, "dev")
+	if !errors.Is(err, errdefs.ErrTeamRoleFileKind) {
+		t.Fatalf("err = %v, want ErrTeamRoleFileKind", err)
+	}
+	if !strings.Contains(err.Error(), rolePath) {
+		t.Errorf("err %q does not name role path %q", err, rolePath)
+	}
+}
+
+func TestLoadHarness_ParseErrorNamesPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	hp := filepath.Join(dir, "harnesses", "claude", "harness.yaml")
+	if err := os.MkdirAll(filepath.Dir(hp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Invalid YAML: surfaces a parse error wrapped with the file path.
+	if err := os.WriteFile(hp, []byte("apiVersion: kuketeams.io/v1\nkind: Harness\nspec: { skillPath: [bad}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadHarness(dir, "claude")
+	if err == nil {
+		t.Fatalf("want parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), hp) {
+		t.Errorf("err %q does not name harness path %q", err, hp)
+	}
+}
+
+func TestLoadImageCatalog_WrongKindNamesPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	ip := filepath.Join(dir, "harnesses", "images.yaml")
+	if err := os.MkdirAll(filepath.Dir(ip), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Plant a valid Role document at the image-catalog path: the parser
+	// validates it cleanly, the loader catches the kind mismatch and surfaces
+	// ErrTeamImageCatalogFileKind with the path named.
+	if err := os.WriteFile(ip, []byte(validRoleDevYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadImageCatalog(dir)
+	if !errors.Is(err, errdefs.ErrTeamImageCatalogFileKind) {
+		t.Fatalf("err = %v, want ErrTeamImageCatalogFileKind", err)
+	}
+	if !strings.Contains(err.Error(), ip) {
+		t.Errorf("err %q does not name catalog path %q", err, ip)
+	}
+}
+
+func TestLoadRole_MissingFileNamesPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	_, err := LoadRole(dir, "dev")
+	if err == nil {
+		t.Fatalf("want read error, got nil")
+	}
+	wantSub := filepath.Join(dir, "roles", "dev", "role.yaml")
+	if !strings.Contains(err.Error(), wantSub) {
+		t.Errorf("err %q does not name role path %q", err, wantSub)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/teamsource`: parses a `ProjectTeam.spec.source` pinned-exact `<owner>/<repo>@vX.Y.Z` reference, resolves the clone URL via `TeamsConfig.spec.sources`, materializes the agents repo under `~/.kuke/cache/<owner>/<repo>@<version>/` (clone-once / reuse-on-existing), and loads the `Role`, `Harness`, and `ImageCatalog` documents the project's roster references via the existing `internal/kuketeams` parser. The package is the building block step 3 (#1042) consumes for the render pipeline.
- Atomic clone-then-rename guarantees an interrupted `git clone` never leaves a half-materialized cache dir. `git clone --depth=1 --no-tags --branch <version>` pins the checkout to the requested tag exactly.
- Non-interactive git env guards (`GIT_TERMINAL_PROMPT=0`, `StrictHostKeyChecking=accept-new BatchMode=yes`) mirror `cmd/kuketty/repos.go` so a first-time clone of an unseen host never blocks.
- `teamhost.Layout.CacheDir()` returns `<base>/cache` so the verb wiring in step 3 has a single place to derive the cache root.
- Errdefs added: `ErrTeamSourceURLNotMapped` (unmapped sources key, names the missing key — AC's hard-error contract), `ErrTeamRoleFileKind` / `ErrTeamHarnessFileKind` / `ErrTeamImageCatalogFileKind` (loader-layer kind mismatches; parser-layer parse errors stay wrapped with the offending file path).

## Scope note: no `kuke team init` wiring this step

The AC describes the building block (parse / clone / load), not its placement in the verb. Wiring the materialize step into `composeTeam` would force every existing step-1 test in `cmd/kuke/team/init_test.go` to grow a sources map + git fixture remote even though the entry-write behavior under test is unchanged. Step 3 (#1042) integrates the loader into the render pipeline naturally — the render is the first caller that actually needs the loaded `Role` / `Harness` / `ImageCatalog` documents. Open to flipping this if the reviewer prefers the materialize gate land here.

## Test plan

- [x] `make test-root` — full root-module suite passes (includes the new `internal/teamsource` tests).
- [x] `make test-kukebuild` — passes.
- [x] `GOWORK=off go vet ./...` — clean.
- [x] Unit tests under `internal/teamsource/` exercise the AC end-to-end against a local fixture remote (built with `git init` + commit + lightweight tag): parse-source validation (pinned-exact / floating / bare-tag rejections), `CloneURL` mapped / unmapped / blank-value / nil-TeamsConfig, `Materialize` clones into cache, reuses existing dir (sentinel survives a re-Materialize against a bogus URL), pins to the requested tag exactly (two commits at `v1.4.0` vs `v1.5.0`, the v1.4.0 body — not v1.5.0's — is what lands on disk), missing-tag clone failure leaves no half-materialized dir, `Resolve` loads every roster-referenced Role / Harness + the ImageCatalog, parse errors at the loader / parser layers carry the offending file path.
- [ ] `make dev-init` smoke not run — change is host-side library + tests only; no daemon-read path, `kuke` CLI surface, or `/opt/kukeon/*` layout is touched (the step-1 verb is unchanged this step). The daemon-parity check is unaffected.

Closes #1041