### PR TITLE
feat(team): render pipeline (needs-merge, image-select, bind) (step 3)

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -30,6 +30,8 @@ import (
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/kuketeams"
 	"github.com/eminwux/kukeon/internal/teamhost"
+	"github.com/eminwux/kukeon/internal/teamrender"
+	"github.com/eminwux/kukeon/internal/teamsource"
 	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
@@ -50,12 +52,38 @@ type GitConfigFunc func(ctx context.Context, key string) (string, bool)
 // MockGitConfigKey injects a GitConfigFunc via context for tests.
 type MockGitConfigKey struct{}
 
+// ProjectRepoURLFunc resolves the clone URL of the project repo whose
+// kuketeam.yaml is at projectDir. The default implementation runs
+// `git -C <projectDir> remote get-url origin`; tests inject a stub via
+// MockProjectRepoURLKey so the render path stays hermetic. A missing
+// remote returns ok=false; the render pipeline then leaves the project
+// repo slot unfilled rather than failing the whole `kuke team init`
+// (the operator may be init-ing a project that has not yet been pushed).
+type ProjectRepoURLFunc func(ctx context.Context, projectDir string) (string, bool)
+
+// MockProjectRepoURLKey injects a ProjectRepoURLFunc via context for tests.
+type MockProjectRepoURLKey struct{}
+
+// ResolveFunc materializes the agents source and loads the role/harness/image
+// documents the project's roster references. The default implementation
+// delegates to teamsource.Resolve against a real on-disk cache; tests inject
+// a stub via MockResolveKey so the render path can run without cloning git.
+type ResolveFunc func(
+	ctx context.Context,
+	cache teamsource.Cache,
+	tc *model.TeamsConfig,
+	pt *model.ProjectTeam,
+) (*teamsource.Bundle, error)
+
+// MockResolveKey injects a ResolveFunc via context for tests.
+type MockResolveKey struct{}
+
 // NewInitCmd builds the `kuke team init` subcommand. It reads the current
 // project's kuketeam.yaml roster, scaffolds the operator-global facts file on
-// first run, and writes the per-project drop-in entry. Source resolution,
-// render, and apply land in steps 2–4 — `--dry-run` is reserved for step 3's
-// render output; in step 1 it prints the per-project entry that would be
-// written and touches no files on disk.
+// first run, writes the per-project drop-in entry, materializes the pinned
+// agents source, and renders the per-(role × harness) CellBlueprint/CellConfig
+// pairs. `--dry-run` stops after render, prints the rendered objects to
+// stdout, and touches no files on disk (apply lands in step 4 #1043).
 func NewInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "init",
@@ -74,15 +102,15 @@ func NewInitCmd() *cobra.Command {
 
 	cmd.Flags().Bool(
 		"dry-run", false,
-		"Print the per-project entry that would be written without touching disk (full render lands in a later step)",
+		"Render the project's blueprints/configs to stdout without writing the drop-in entry or applying to kukeond",
 	)
 
 	return cmd
 }
 
 // runInit gathers the cobra-coupled inputs (current directory, ~/.kuke layout,
-// git-config reader) and hands them to composeTeam, which holds the testable
-// lifecycle.
+// git-config reader, project-repo-URL reader) and hands them to composeTeam,
+// which holds the testable lifecycle.
 func runInit(cmd *cobra.Command, dryRun bool) error {
 	projectDir, err := os.Getwd()
 	if err != nil {
@@ -90,22 +118,34 @@ func runInit(cmd *cobra.Command, dryRun bool) error {
 	}
 	layout := teamhost.NewLayout(config.DefaultKukeDir())
 	return composeTeam(
-		cmd.Context(), cmd.OutOrStdout(), projectDir, layout, gitConfigFromCmd(cmd), dryRun,
+		cmd.Context(), cmd.OutOrStdout(), projectDir, layout,
+		gitConfigFromCmd(cmd), projectRepoURLFromCmd(cmd), resolveFromCmd(cmd),
+		dryRun,
 	)
 }
 
-// composeTeam runs the team-init lifecycle against explicit inputs: read the
-// project roster, scaffold the operator-global facts on first run, and write
-// the per-project drop-in entry. `--dry-run` prints the entry that would be
-// written and touches no files (full render lands in step 3). It takes no
-// cobra dependency so it is unit-testable with a temp layout and a stub
-// git-config reader, no live kukeond required.
+// composeTeam runs the team-init lifecycle against explicit inputs:
+//
+//  1. Read the project roster from <projectDir>/kuketeam.yaml.
+//  2. Load (or scaffold-and-load) the operator-global facts file.
+//  3. Resolve the pinned agents source into the on-disk cache and load every
+//     Role / Harness / ImageCatalog the roster references.
+//  4. Render the per-(role × harness) CellBlueprint/CellConfig pairs.
+//  5. Either print the rendered objects to stdout (--dry-run) or write the
+//     per-project drop-in entry (step 4 in #1043 will apply the rendered
+//     objects to kukeond after this point).
+//
+// composeTeam takes no cobra dependency so it is unit-testable with a temp
+// layout, stub git-config / project-repo-URL readers, and a stub resolver, no
+// live kukeond required.
 func composeTeam(
 	ctx context.Context,
 	out io.Writer,
 	projectDir string,
 	layout teamhost.Layout,
 	getGit GitConfigFunc,
+	getProjectURL ProjectRepoURLFunc,
+	resolve ResolveFunc,
 	dryRun bool,
 ) error {
 	pt, err := readProjectTeam(projectDir)
@@ -120,6 +160,23 @@ func composeTeam(
 		return errdefs.ErrTeamMetadataNameRequired
 	}
 
+	tc, scaffolded, err := loadOrScaffoldGlobalConfig(ctx, layout, getGit, dryRun)
+	if err != nil {
+		return err
+	}
+	if scaffolded {
+		fmt.Fprintf(out, "scaffolded operator-global facts at %s\n", layout.GlobalConfigPath())
+	}
+
+	res, err := renderTeam(ctx, layout, projectDir, pt, tc, project, getProjectURL, resolve)
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		return emitDryRun(out, project, layout, res)
+	}
+
 	entry := &model.TeamEntry{
 		APIVersion: model.APIVersionV1,
 		Kind:       model.KindTeamEntry,
@@ -129,29 +186,122 @@ func composeTeam(
 			Source: strings.TrimSpace(pt.Spec.Source),
 		},
 	}
-
-	if dryRun {
-		raw, marshalErr := yaml.Marshal(entry)
-		if marshalErr != nil {
-			return fmt.Errorf("marshal team entry: %w", marshalErr)
-		}
-		fmt.Fprintf(out, "# dry-run: would write %s\n%s",
-			filepath.Join("~/.kuke/kuketeam.d", project+".yaml"), raw)
-		return nil
-	}
-
-	created, err := teamhost.EnsureGlobalConfig(layout, buildGlobalConfig(ctx, getGit))
-	if err != nil {
-		return fmt.Errorf("ensure global config: %w", err)
-	}
-	if created {
-		fmt.Fprintf(out, "scaffolded operator-global facts at %s\n", layout.GlobalConfigPath())
-	}
-
 	if writeErr := teamhost.WriteEntry(layout, entry); writeErr != nil {
 		return fmt.Errorf("write team entry: %w", writeErr)
 	}
 	fmt.Fprintf(out, "wrote team %q to %s\n", project, layout.EntryPath(project))
+	fmt.Fprintf(out, "rendered %d blueprint/%d config object(s) (apply lands in step 4)\n",
+		len(res.Blueprints), len(res.Configs))
+	return nil
+}
+
+// loadOrScaffoldGlobalConfig returns the TeamsConfig the render pipeline
+// consumes. When the file already exists, it is parsed off disk and
+// returned with scaffolded=false. When it is absent, a scaffold is
+// composed from the operator's git config + KUKEON_REGISTRY; in non-dry-run
+// mode it is written to disk (scaffolded=true), in dry-run mode it is held
+// only in memory (scaffolded=false) so dry-run honors the AC's "neither
+// applies nor writes" contract.
+func loadOrScaffoldGlobalConfig(
+	ctx context.Context,
+	layout teamhost.Layout,
+	getGit GitConfigFunc,
+	dryRun bool,
+) (*model.TeamsConfig, bool, error) {
+	path := layout.GlobalConfigPath()
+	raw, readErr := os.ReadFile(path)
+	if readErr == nil {
+		doc, parseErr := kuketeams.Parse(raw)
+		if parseErr != nil {
+			return nil, false, fmt.Errorf("parse %q: %w", path, parseErr)
+		}
+		if doc.TeamsConfig == nil {
+			return nil, false, fmt.Errorf("%s: expected TeamsConfig, got kind %q", path, doc.Kind)
+		}
+		return doc.TeamsConfig, false, nil
+	}
+	if !errors.Is(readErr, os.ErrNotExist) {
+		return nil, false, fmt.Errorf("read %q: %w", path, readErr)
+	}
+
+	cfg := buildGlobalConfig(ctx, getGit)
+	if dryRun {
+		return cfg, false, nil
+	}
+	created, err := teamhost.EnsureGlobalConfig(layout, cfg)
+	if err != nil {
+		return nil, false, fmt.Errorf("ensure global config: %w", err)
+	}
+	return cfg, created, nil
+}
+
+// renderTeam resolves the bundle and runs the per-(role × harness) render.
+// When the project declares no harness defaults there is nothing to render
+// and the bundle is not resolved — keeping `kuke team init` against a
+// harness-less roster fast and offline.
+func renderTeam(
+	ctx context.Context,
+	layout teamhost.Layout,
+	projectDir string,
+	pt *model.ProjectTeam,
+	tc *model.TeamsConfig,
+	project string,
+	getProjectURL ProjectRepoURLFunc,
+	resolve ResolveFunc,
+) (*teamrender.Result, error) {
+	if len(pt.Spec.Defaults.Harnesses) == 0 || len(pt.Spec.Roles) == 0 {
+		return &teamrender.Result{}, nil
+	}
+
+	cache := teamsource.NewCache(layout.CacheDir())
+	bundle, err := resolve(ctx, cache, tc, pt)
+	if err != nil {
+		return nil, fmt.Errorf("resolve agents source: %w", err)
+	}
+
+	projectURL, _ := getProjectURL(ctx, projectDir)
+	in := teamrender.Inputs{
+		Project:        project,
+		ProjectRepoURL: strings.TrimSpace(projectURL),
+	}
+	res, err := teamrender.Render(bundle, pt, tc, in)
+	if err != nil {
+		return nil, fmt.Errorf("render team: %w", err)
+	}
+	return res, nil
+}
+
+// emitDryRun prints the rendered objects to out as a multi-document YAML
+// stream prefixed by a dry-run header. It writes nothing to disk.
+func emitDryRun(out io.Writer, project string, layout teamhost.Layout, res *teamrender.Result) error {
+	entry := &model.TeamEntry{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindTeamEntry,
+		Metadata:   model.Metadata{Name: project},
+		Spec:       model.TeamEntrySpec{},
+	}
+	rawEntry, err := yaml.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshal team entry: %w", err)
+	}
+	fmt.Fprintf(out, "# dry-run: would write %s\n%s",
+		filepath.Join("~/.kuke/kuketeam.d", project+".yaml"), rawEntry)
+
+	if res == nil || (len(res.Blueprints) == 0 && len(res.Configs) == 0) {
+		fmt.Fprintf(out, "# dry-run: no (role × harness) pairs to render\n")
+		_ = layout // reserved for future cache-dir reporting
+		return nil
+	}
+
+	rawRender, err := teamrender.MarshalYAML(res)
+	if err != nil {
+		return fmt.Errorf("marshal rendered objects: %w", err)
+	}
+	fmt.Fprintf(out, "---\n# dry-run: rendered %d blueprint/%d config object(s) (apply lands in step 4)\n",
+		len(res.Blueprints), len(res.Configs))
+	if _, writeErr := out.Write(rawRender); writeErr != nil {
+		return writeErr
+	}
 	return nil
 }
 
@@ -254,6 +404,26 @@ func gitConfigFromCmd(cmd *cobra.Command) GitConfigFunc {
 	return realGitConfig
 }
 
+// projectRepoURLFromCmd returns the ProjectRepoURLFunc the init flow uses
+// — the test mock from context when present, otherwise the real
+// `git -C <projectDir> remote get-url origin` reader.
+func projectRepoURLFromCmd(cmd *cobra.Command) ProjectRepoURLFunc {
+	if mock, ok := cmd.Context().Value(MockProjectRepoURLKey{}).(ProjectRepoURLFunc); ok && mock != nil {
+		return mock
+	}
+	return realProjectRepoURL
+}
+
+// resolveFromCmd returns the ResolveFunc the init flow uses — the test
+// mock from context when present, otherwise teamsource.Resolve against the
+// real layout's cache.
+func resolveFromCmd(cmd *cobra.Command) ResolveFunc {
+	if mock, ok := cmd.Context().Value(MockResolveKey{}).(ResolveFunc); ok && mock != nil {
+		return mock
+	}
+	return realResolve
+}
+
 // realGitConfig reads a single `git config --global <key>` value. A non-zero
 // exit (key unset) reports ok=false; the value is whitespace-trimmed.
 func realGitConfig(ctx context.Context, key string) (string, bool) {
@@ -262,4 +432,28 @@ func realGitConfig(ctx context.Context, key string) (string, bool) {
 		return "", false
 	}
 	return strings.TrimSpace(string(out)), true
+}
+
+// realProjectRepoURL reads the project's clone URL via
+// `git -C <projectDir> remote get-url origin`. A non-zero exit (no remote
+// configured, not a git repo) reports ok=false; the value is
+// whitespace-trimmed.
+func realProjectRepoURL(ctx context.Context, projectDir string) (string, bool) {
+	out, err := exec.CommandContext(ctx, "git", "-C", projectDir, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+// realResolve materializes the agents source via teamsource.Resolve against
+// the given cache, mirroring the production path step 4's apply phase will
+// consume.
+func realResolve(
+	ctx context.Context,
+	cache teamsource.Cache,
+	tc *model.TeamsConfig,
+	pt *model.ProjectTeam,
+) (*teamsource.Bundle, error) {
+	return teamsource.Resolve(ctx, cache, tc, pt)
 }

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -27,7 +27,9 @@ import (
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/teamhost"
+	"github.com/eminwux/kukeon/internal/teamsource"
 	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"gopkg.in/yaml.v3"
 )
 
@@ -40,11 +42,51 @@ spec:
     - { ref: dev }
 `
 
+// projectTeamWithHarnessYAML carries a harness default so the render
+// pipeline produces at least one (role × harness) pair.
+const projectTeamWithHarnessYAML = `apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: sbsh }
+spec:
+  source: eminwux/agents@v1.4.0
+  defaults:
+    harnesses: [claude]
+  roles:
+    - { ref: dev }
+`
+
 // stubGit returns a GitConfigFunc backed by m.
 func stubGit(m map[string]string) GitConfigFunc {
 	return func(_ context.Context, key string) (string, bool) {
 		v, ok := m[key]
 		return v, ok
+	}
+}
+
+// stubProjectURL returns a ProjectRepoURLFunc that always reports url.
+func stubProjectURL(url string) ProjectRepoURLFunc {
+	return func(_ context.Context, _ string) (string, bool) {
+		if url == "" {
+			return "", false
+		}
+		return url, true
+	}
+}
+
+// stubResolveErr returns a ResolveFunc that always fails — used by tests
+// that should never reach the resolve step.
+func stubResolveErr() ResolveFunc {
+	return func(_ context.Context, _ teamsource.Cache, _ *model.TeamsConfig, _ *model.ProjectTeam) (*teamsource.Bundle, error) {
+		return nil, errors.New("resolve must not be called")
+	}
+}
+
+// stubBundle returns a ResolveFunc that yields a pre-built bundle. The
+// bundle's cacheDir is a tempdir the test writes a single harness blueprint
+// template into so RenderBlueprint can read it.
+func stubBundle(b *teamsource.Bundle) ResolveFunc {
+	return func(_ context.Context, _ teamsource.Cache, _ *model.TeamsConfig, _ *model.ProjectTeam) (*teamsource.Bundle, error) {
+		return b, nil
 	}
 }
 
@@ -58,11 +100,98 @@ func writeProject(t *testing.T, body string) string {
 	return dir
 }
 
+// buildClaudeBundle writes a minimal claude harness blueprint template,
+// role, and image catalog into a fresh temp dir and returns a bundle that
+// points at it.
+func buildClaudeBundle(t *testing.T) *teamsource.Bundle {
+	t.Helper()
+	cacheDir := t.TempDir()
+	tplPath := filepath.Join(cacheDir, "harnesses", "claude", "blueprint.tmpl.yaml")
+	if err := os.MkdirAll(filepath.Dir(tplPath), 0o700); err != nil {
+		t.Fatalf("mkdir tpl: %v", err)
+	}
+	tpl := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: ${ROLE}-${HARNESS}
+spec:
+  cell:
+    containers:
+      - id: ${ROLE}
+        image: ${IMAGE}
+        env:
+          - "ROLE=${ROLE}"
+          - "NEEDS=${NEEDS}"
+          - "SETTINGS=${SETTINGS}"
+        repos:
+          - { name: project, target: /src/project }
+        secrets:
+          - { name: ANTHROPIC_API_KEY, mode: env, envName: ANTHROPIC_API_KEY }
+`
+	if err := os.WriteFile(tplPath, []byte(tpl), 0o600); err != nil {
+		t.Fatalf("write tpl: %v", err)
+	}
+	return &teamsource.Bundle{
+		Source: teamsource.Source{
+			Raw:       "eminwux/agents@v1.4.0",
+			OwnerRepo: "eminwux/agents",
+			Version:   "v1.4.0",
+		},
+		CacheDir: cacheDir,
+		Roles: map[string]*model.Role{
+			"dev": {
+				APIVersion: model.APIVersionV1,
+				Kind:       model.KindRole,
+				Metadata:   model.Metadata{Name: "dev"},
+				Spec: model.RoleSpec{
+					Harnesses: map[string]model.RoleHarness{
+						"claude": {Settings: "agents/dev/settings.json"},
+					},
+					Needs: model.RoleNeeds{
+						Image:   []string{"go", "git"},
+						Secrets: []string{"ANTHROPIC_API_KEY"},
+					},
+				},
+			},
+		},
+		Harnesses: map[string]*model.Harness{
+			"claude": {
+				APIVersion: model.APIVersionV1,
+				Kind:       model.KindHarness,
+				Metadata:   model.Metadata{Name: "claude"},
+				Spec: model.HarnessSpec{
+					SkillPath:  "/.claude/skills",
+					MakeTarget: "harness-claude",
+					Template:   "harnesses/claude/blueprint.tmpl.yaml",
+				},
+			},
+		},
+		ImageCatalog: &model.ImageCatalog{
+			APIVersion: model.APIVersionV1,
+			Kind:       model.KindImageCatalog,
+			Spec: model.ImageCatalogSpec{
+				Images: []model.ImageCatalogEntry{
+					{
+						Ref:          "claude-go",
+						Harness:      "claude",
+						Image:        "registry.local/claude-go:latest",
+						Build:        model.ImageCatalogBuild{Context: "harnesses/claude", Dockerfile: "Dockerfile"},
+						Capabilities: []string{"go", "git", "make"},
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestComposeTeamNoProjectFile(t *testing.T) {
 	t.Parallel()
 	emptyDir := t.TempDir()
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
-	err := composeTeam(context.Background(), &bytes.Buffer{}, emptyDir, layout, stubGit(nil), false)
+	err := composeTeam(
+		context.Background(), &bytes.Buffer{}, emptyDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), false,
+	)
 	if !errors.Is(err, errdefs.ErrTeamProjectFileNotFound) {
 		t.Fatalf("err = %v, want ErrTeamProjectFileNotFound", err)
 	}
@@ -72,7 +201,10 @@ func TestComposeTeamWrongKind(t *testing.T) {
 	t.Parallel()
 	dir := writeProject(t, "apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: {}\n")
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
-	err := composeTeam(context.Background(), &bytes.Buffer{}, dir, layout, stubGit(nil), false)
+	err := composeTeam(
+		context.Background(), &bytes.Buffer{}, dir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), false,
+	)
 	if !errors.Is(err, errdefs.ErrTeamProjectFileKind) {
 		t.Fatalf("err = %v, want ErrTeamProjectFileKind", err)
 	}
@@ -92,7 +224,10 @@ func TestComposeTeamScaffoldsAndWrites(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	if err := composeTeam(context.Background(), &out, projectDir, layout, git, false); err != nil {
+	if err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		git, stubProjectURL(""), stubResolveErr(), false,
+	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
 
@@ -141,22 +276,30 @@ func TestComposeTeamReRunDoesNotRescaffold(t *testing.T) {
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 	git := stubGit(map[string]string{"user.name": "A", "user.email": "a@example.com"})
 
-	if err := composeTeam(context.Background(), &bytes.Buffer{}, projectDir, layout, git, false); err != nil {
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, projectDir, layout,
+		git, stubProjectURL(""), stubResolveErr(), false,
+	); err != nil {
 		t.Fatalf("first composeTeam: %v", err)
 	}
 	// Tamper the global facts; a re-run must leave them untouched.
-	if err := os.WriteFile(layout.GlobalConfigPath(), []byte("sentinel: kept\n"), 0o600); err != nil {
+	if err := os.WriteFile(layout.GlobalConfigPath(), []byte(
+		"apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec:\n  registry: sentinel.example.com\n",
+	), 0o600); err != nil {
 		t.Fatalf("seed sentinel: %v", err)
 	}
 	var out bytes.Buffer
-	if err := composeTeam(context.Background(), &out, projectDir, layout, git, false); err != nil {
+	if err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		git, stubProjectURL(""), stubResolveErr(), false,
+	); err != nil {
 		t.Fatalf("second composeTeam: %v", err)
 	}
 	got, err := os.ReadFile(layout.GlobalConfigPath())
 	if err != nil {
 		t.Fatalf("read global after re-run: %v", err)
 	}
-	if string(got) != "sentinel: kept\n" {
+	if !strings.Contains(string(got), "sentinel.example.com") {
 		t.Errorf("re-run re-scaffolded global facts: %q", got)
 	}
 	if strings.Contains(out.String(), "scaffolded") {
@@ -169,7 +312,10 @@ func TestComposeTeamNoGitIdentityOmitsGitBlock(t *testing.T) {
 	projectDir := writeProject(t, projectTeamYAML)
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 
-	if err := composeTeam(context.Background(), &bytes.Buffer{}, projectDir, layout, stubGit(nil), false); err != nil {
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), false,
+	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
 	raw, err := os.ReadFile(layout.GlobalConfigPath())
@@ -191,7 +337,10 @@ func TestComposeTeamDryRunWritesNothing(t *testing.T) {
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 
 	var out bytes.Buffer
-	if err := composeTeam(context.Background(), &out, projectDir, layout, stubGit(nil), true); err != nil {
+	if err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), true,
+	); err != nil {
 		t.Fatalf("composeTeam dry-run: %v", err)
 	}
 	if _, err := os.Stat(layout.GlobalConfigPath()); !errors.Is(err, os.ErrNotExist) {
@@ -202,6 +351,126 @@ func TestComposeTeamDryRunWritesNothing(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "dry-run") || !strings.Contains(out.String(), "sbsh") {
 		t.Errorf("dry-run output missing expected content: %q", out.String())
+	}
+}
+
+// TestComposeTeamDryRunRendersToStdout covers the AC: "--dry-run renders
+// to stdout and neither applies nor writes kuketeam.d/<project>.yaml".
+func TestComposeTeamDryRunRendersToStdout(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var out bytes.Buffer
+	err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(map[string]string{"user.name": "Op", "user.email": "op@example.com"}),
+		stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), true,
+	)
+	if err != nil {
+		t.Fatalf("composeTeam dry-run: %v", err)
+	}
+
+	// No drop-in entry, no global config — dry-run touches no files.
+	if _, statErr := os.Stat(layout.EntryPath("sbsh")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("dry-run wrote entry: err=%v", statErr)
+	}
+	if _, statErr := os.Stat(layout.GlobalConfigPath()); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("dry-run wrote global config: err=%v", statErr)
+	}
+
+	body := out.String()
+	if !strings.Contains(body, "kind: CellBlueprint") {
+		t.Errorf("dry-run output missing rendered CellBlueprint: %q", body)
+	}
+	if !strings.Contains(body, "kind: CellConfig") {
+		t.Errorf("dry-run output missing rendered CellConfig: %q", body)
+	}
+	if !strings.Contains(body, "registry.local/claude-go:latest") {
+		t.Errorf("rendered output missing selected image: %q", body)
+	}
+	if !strings.Contains(body, "kukeon.io/team: sbsh") {
+		t.Errorf("rendered output missing team label: %q", body)
+	}
+}
+
+// TestComposeTeamRendersOnNonDryRun confirms the render pipeline runs on
+// the non-dry-run path too (validating image-select before the drop-in
+// entry is written), and that the drop-in entry IS written then.
+func TestComposeTeamRendersOnNonDryRun(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var out bytes.Buffer
+	err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil),
+		stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), false,
+	)
+	if err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+
+	if _, statErr := os.Stat(layout.EntryPath("sbsh")); statErr != nil {
+		t.Errorf("entry should have been written on non-dry-run: %v", statErr)
+	}
+	if !strings.Contains(out.String(), "rendered 1 blueprint/1 config") {
+		t.Errorf("render-count summary missing: %q", out.String())
+	}
+}
+
+// TestComposeTeamImageSelectHardError confirms a missing capability hits
+// the operator-actionable error path with the unmet capability named.
+func TestComposeTeamImageSelectHardError(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	// Drop the role's `git` from images' capability set so the merged needs
+	// can't be satisfied — leaving a single unmet capability.
+	bundle.ImageCatalog.Spec.Images[0].Capabilities = []string{"go"}
+
+	err := composeTeam(
+		context.Background(), &bytes.Buffer{}, projectDir, layout,
+		stubGit(nil), stubProjectURL(""),
+		stubBundle(bundle), false,
+	)
+	if !errors.Is(err, errdefs.ErrTeamImageNoMatch) {
+		t.Fatalf("err = %v, want ErrTeamImageNoMatch", err)
+	}
+	if !strings.Contains(err.Error(), "git") {
+		t.Errorf("error should name unmet capability 'git', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "build or label") {
+		t.Errorf("error should carry build-or-label hint, got: %v", err)
+	}
+}
+
+// TestComposeTeamProjectRepoURLFilledIntoConfig confirms the bind step
+// stamps the project clone URL into the CellConfig's `project` repo slot
+// fill — the AC's "project's cloned repo URL → CellConfig" check.
+func TestComposeTeamProjectRepoURLFilledIntoConfig(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var out bytes.Buffer
+	err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), true,
+	)
+	if err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+	if !strings.Contains(out.String(), "git@github.com:eminwux/sbsh.git") {
+		t.Errorf("project clone URL not stamped into rendered config: %q", out.String())
 	}
 }
 
@@ -232,3 +501,7 @@ func TestNewTeamCmdRegistersInit(t *testing.T) {
 		t.Errorf("team init subcommand not registered")
 	}
 }
+
+// silence the unused-import linter when v1beta1 is referenced only through
+// the rendered output bytes.
+var _ = v1beta1.LabelTeam

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -621,4 +621,22 @@ var (
 	ErrTeamImageCatalogFileKind = errors.New(
 		"image catalog file must be an ImageCatalog document",
 	)
+	// ErrTeamImageNoMatch fires when no ImageCatalog entry's capabilities
+	// superset a (role × harness)'s merged needs. The error message names the
+	// first unmet capability + the operator-actionable "build/label an image"
+	// hint, per #1042's hard-error contract.
+	ErrTeamImageNoMatch = errors.New(
+		"no image in ImageCatalog satisfies the role's merged needs",
+	)
+	// ErrTeamRoleNotLoaded fires when the render pipeline references a role
+	// the resolved Bundle did not load (resolve/render contract drift).
+	ErrTeamRoleNotLoaded = errors.New("role not loaded in bundle")
+	// ErrTeamHarnessNotLoaded fires when the render pipeline references a
+	// harness the resolved Bundle did not load.
+	ErrTeamHarnessNotLoaded = errors.New("harness not loaded in bundle")
+	// ErrTeamBlueprintTemplateMissing fires when a harness's spec.template path
+	// does not resolve under the materialized cache directory.
+	ErrTeamBlueprintTemplateMissing = errors.New(
+		"harness blueprint template not found under cache dir",
+	)
 )

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -1,0 +1,643 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package teamrender renders a project's ProjectTeam roster into a set of
+// CellBlueprint and CellConfig documents — one (CellBlueprint, CellConfig)
+// pair per `(role × harness)` (epic #792, step 3 #1042). For each pair the
+// pipeline:
+//
+//  1. needs-merge — `union(role.yaml.needs.image ⊕ kuketeam per-role
+//     needs.image)`, deduplicated and lexicographically sorted so two runs
+//     against the same inputs produce byte-identical output.
+//  2. image-select — match the merged capability set against the agents
+//     source's ImageCatalog, picking the first entry whose `harness`
+//     matches and whose `capabilities` superset the merged needs. A miss
+//     surfaces errdefs.ErrTeamImageNoMatch naming the first unmet
+//     capability + the operator-actionable "build/label an image" hint.
+//  3. render — load the harness's blueprint template (relative to the
+//     materialized cache dir), substitute `${KEY}` placeholders for
+//     `${ROLE}`, `${HARNESS}`, `${IMAGE}`, `${NEEDS}`, and the role's
+//     native per-harness config knobs (`${SETTINGS}` for claude,
+//     `${SANDBOX}`/`${APPROVAL}` for codex, `${PERMISSIONS}` for
+//     opencode), then yaml-parse into a CellBlueprintDoc. Per the
+//     umbrella's key decision the role's native per-harness config is
+//     wired verbatim — no transpile.
+//  4. bind — produce a CellConfig that references the just-rendered
+//     blueprint and carries (a) operator facts pulled from
+//     `~/.kuke/kuketeams.yaml` (git author/committer/signingKey/registry
+//     stamped into Values), (b) the project's cloned repo URL stamped
+//     into the `project` repo slot fill, and (c) any operator secret
+//     refs from `tc.spec.secrets` that the role declares it needs.
+//  5. label — every rendered CellBlueprint and CellConfig carries
+//     `metadata.labels[kukeon.io/team] = <project>` so the daemon-side
+//     prune-apply machinery from #1029 can converge the project's slice
+//     in step 4 (#1043) without touching other teams' objects.
+//
+// The package writes nothing to disk and runs no external commands — it
+// reads the materialized template files prepared by teamsource (#1041) and
+// produces in-memory v1beta1 documents. `--dry-run` consumers marshal the
+// Result to YAML; the apply path in step 4 (#1043) hands the same Result
+// straight to ApplyDocumentsForTeam.
+package teamrender
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/teamsource"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultRealm is the realm rendered objects bind to when Inputs.Realm is
+// empty. Matches the `default` user realm provisioned by `kuke init`
+// (see internal/consts) — team workloads live in the user realm, not in
+// `kuke-system`.
+const DefaultRealm = "default"
+
+// ProjectRepoSlotName is the convention for the structural repo slot that
+// carries the project's clone URL. The umbrella (epic #792) names `project`
+// and `agents` as the two repos a team cell typically clones; this package
+// owns the contract that blueprint templates declare the slot with this
+// name, and `BindConfig` fills it from `Inputs.ProjectRepoURL`.
+const ProjectRepoSlotName = "project"
+
+// AgentsRepoSlotName mirrors ProjectRepoSlotName for the pinned agents
+// source clone. `BindConfig` fills it from the operator's
+// `TeamsConfig.spec.sources[<owner/repo>]` mapping when the blueprint
+// declares the slot.
+const AgentsRepoSlotName = "agents"
+
+// Inputs collects the per-project facts that vary by `kuke team init`
+// invocation. Project is the rendered objects' team label and the basis
+// for the blueprint/config name when the template did not supply one.
+// ProjectRepoURL is the clone URL for the project repo — typically read
+// from `git -C <projectDir> remote get-url origin` by the caller.
+type Inputs struct {
+	Project        string
+	ProjectRepoURL string
+	Realm          string
+}
+
+// Result carries the rendered objects from one project's roster. Each
+// CellBlueprint at index i has its companion CellConfig at the same
+// index in Configs, simplifying the apply loop in step 4 (#1043).
+type Result struct {
+	Blueprints []*v1beta1.CellBlueprintDoc
+	Configs    []*v1beta1.CellConfigDoc
+}
+
+// Render runs the full per-(role × harness) pipeline against a loaded
+// Bundle. The outer loop is project-deterministic: roles are visited in
+// the order pt.Spec.Roles declares them and harnesses in the order
+// pt.Spec.Defaults.Harnesses declares them, so the same inputs always
+// produce the same output ordering.
+func Render(
+	bundle *teamsource.Bundle,
+	pt *model.ProjectTeam,
+	tc *model.TeamsConfig,
+	in Inputs,
+) (*Result, error) {
+	if bundle == nil {
+		return nil, errors.New("teamrender.Render: nil bundle")
+	}
+	if pt == nil {
+		return nil, errors.New("teamrender.Render: nil ProjectTeam")
+	}
+	project := strings.TrimSpace(in.Project)
+	if project == "" {
+		return nil, errors.New("teamrender.Render: project name required")
+	}
+	realm := strings.TrimSpace(in.Realm)
+	if realm == "" {
+		realm = DefaultRealm
+	}
+
+	res := &Result{}
+	for _, ptRole := range pt.Spec.Roles {
+		role, ok := bundle.Roles[ptRole.Ref]
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", errdefs.ErrTeamRoleNotLoaded, ptRole.Ref)
+		}
+		for _, hname := range pt.Spec.Defaults.Harnesses {
+			harness, hok := bundle.Harnesses[hname]
+			if !hok {
+				return nil, fmt.Errorf("%w: %q", errdefs.ErrTeamHarnessNotLoaded, hname)
+			}
+
+			merged := MergeNeeds(role.Spec.Needs.Image, ptRoleImageNeeds(ptRole))
+			entry, selErr := SelectImage(bundle.ImageCatalog, hname, merged)
+			if selErr != nil {
+				return nil, fmt.Errorf(
+					"render %s/%s: %w", ptRole.Ref, hname, selErr,
+				)
+			}
+
+			bp, renderErr := RenderBlueprint(
+				bundle.CacheDir, harness, role, hname, ptRole.Ref,
+				merged, entry, project, realm,
+			)
+			if renderErr != nil {
+				return nil, fmt.Errorf(
+					"render %s/%s: %w", ptRole.Ref, hname, renderErr,
+				)
+			}
+			cfg := BindConfig(bp, role, ptRole.Ref, hname, tc, bundle.Source, in, project, realm)
+
+			res.Blueprints = append(res.Blueprints, bp)
+			res.Configs = append(res.Configs, cfg)
+		}
+	}
+	return res, nil
+}
+
+// MergeNeeds returns the lexicographically sorted union of a and b. Empty
+// and whitespace-only entries are dropped, so a per-role override that
+// repeats a role.yaml capability yields a single entry rather than a
+// duplicate. The output is a fresh slice — callers may mutate it without
+// affecting the inputs.
+func MergeNeeds(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for _, s := range a {
+		if v := strings.TrimSpace(s); v != "" {
+			seen[v] = struct{}{}
+		}
+	}
+	for _, s := range b {
+		if v := strings.TrimSpace(s); v != "" {
+			seen[v] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// SelectImage picks the ImageCatalog entry whose `harness` matches and
+// whose `capabilities` superset every entry in needs. Catalog order is
+// the tiebreaker — the first matching entry wins. A miss surfaces
+// errdefs.ErrTeamImageNoMatch naming the first capability no
+// harness-matching image provides + the operator-actionable hint. Empty
+// needs match any image carrying the requested harness; an empty catalog
+// is always a miss (the operator must populate images.yaml).
+func SelectImage(
+	ic *model.ImageCatalog,
+	harness string,
+	needs []string,
+) (*model.ImageCatalogEntry, error) {
+	if ic == nil || len(ic.Spec.Images) == 0 {
+		return nil, fmt.Errorf(
+			"%w: empty ImageCatalog for harness=%q "+
+				"(build or label an image in harnesses/images.yaml that provides %v)",
+			errdefs.ErrTeamImageNoMatch, harness, needs,
+		)
+	}
+
+	for i := range ic.Spec.Images {
+		e := &ic.Spec.Images[i]
+		if e.Harness != harness {
+			continue
+		}
+		if hasAll(e.Capabilities, needs) {
+			return e, nil
+		}
+	}
+
+	unmet := firstUnmet(ic, harness, needs)
+	if unmet == "" {
+		// Every needed capability is provided by *some* harness-matching
+		// image, but no single image carries all of them. Name the merged
+		// set so the operator knows what to consolidate.
+		return nil, fmt.Errorf(
+			"%w: harness=%q needs=%v (no single image in images.yaml carries all "+
+				"capabilities; build or label one that does)",
+			errdefs.ErrTeamImageNoMatch, harness, needs,
+		)
+	}
+	return nil, fmt.Errorf(
+		"%w: harness=%q capability=%q (build or label an image in "+
+			"harnesses/images.yaml that provides %q)",
+		errdefs.ErrTeamImageNoMatch, harness, unmet, unmet,
+	)
+}
+
+// RenderBlueprint loads the harness's blueprint template (resolved
+// relative to cacheDir), substitutes `${KEY}` placeholders for the
+// `(role × harness)` pair's facts, and yaml-parses into a
+// CellBlueprintDoc. The blueprint's metadata.labels are populated with
+// `kukeon.io/team = project`. metadata.realm is forced to realm (the
+// template need not pre-fill it). If the template did not supply
+// metadata.name, the default `<role>-<harness>` is stamped so the
+// blueprint and its companion config share a deterministic identity.
+func RenderBlueprint(
+	cacheDir string,
+	h *model.Harness,
+	r *model.Role,
+	harness, roleRef string,
+	needs []string,
+	image *model.ImageCatalogEntry,
+	project, realm string,
+) (*v1beta1.CellBlueprintDoc, error) {
+	if h == nil || strings.TrimSpace(h.Spec.Template) == "" {
+		return nil, fmt.Errorf(
+			"%w: harness=%q (spec.template is empty)",
+			errdefs.ErrTeamBlueprintTemplateMissing, harness,
+		)
+	}
+	tplPath := filepath.Join(cacheDir, h.Spec.Template)
+	raw, err := os.ReadFile(tplPath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: %q: %w", errdefs.ErrTeamBlueprintTemplateMissing, tplPath, err,
+		)
+	}
+
+	vars := blueprintVars(roleRef, harness, image, needs, r)
+	rendered := substitute(string(raw), vars)
+
+	var bp v1beta1.CellBlueprintDoc
+	if unmarshalErr := yaml.Unmarshal([]byte(rendered), &bp); unmarshalErr != nil {
+		return nil, fmt.Errorf("parse rendered blueprint %q: %w", tplPath, unmarshalErr)
+	}
+
+	bp.APIVersion = v1beta1.APIVersionV1Beta1
+	bp.Kind = v1beta1.KindCellBlueprint
+	if strings.TrimSpace(bp.Metadata.Name) == "" {
+		bp.Metadata.Name = defaultObjectName(roleRef, harness)
+	}
+	bp.Metadata.Realm = realm
+	if bp.Metadata.Labels == nil {
+		bp.Metadata.Labels = map[string]string{}
+	}
+	bp.Metadata.Labels[v1beta1.LabelTeam] = project
+	return &bp, nil
+}
+
+// BindConfig produces a CellConfig referencing bp. The operator-fact
+// values (git author/committer/signingKey/allowedSigners/registry) land
+// in Values keyed by the same `${KEY}` names the blueprint may declare as
+// CellBlueprintParameters; the daemon resolves them at run time per the
+// CellConfig contract. The project's clone URL fills the `project` repo
+// slot; the agents source URL (from tc.spec.sources[<owner/repo>]) fills
+// the `agents` slot — both only when the blueprint actually declares the
+// slot, so a template that doesn't carry the slot produces a config
+// without a stray fill. role.Spec.Needs.Secrets entries are matched
+// against the blueprint's BlueprintSecretSlot declarations and filled
+// from tc.spec.secrets — when the operator has a matching entry, an
+// in-realm ContainerSecretRef points the slot at it (the runtime
+// resolves the actual bytes via the Secret kind from #623).
+func BindConfig(
+	bp *v1beta1.CellBlueprintDoc,
+	r *model.Role,
+	roleRef, harness string,
+	tc *model.TeamsConfig,
+	src teamsource.Source,
+	in Inputs,
+	project, realm string,
+) *v1beta1.CellConfigDoc {
+	cfg := &v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  bp.Metadata.Name,
+			Realm: realm,
+			Space: bp.Metadata.Space,
+			Stack: bp.Metadata.Stack,
+			Labels: map[string]string{
+				v1beta1.LabelTeam: project,
+			},
+		},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{
+				Name:  bp.Metadata.Name,
+				Realm: realm,
+				Space: bp.Metadata.Space,
+				Stack: bp.Metadata.Stack,
+			},
+			Values: operatorValues(tc, roleRef, harness, project),
+		},
+	}
+
+	declaredRepos := collectRepoSlots(bp)
+	declaredSecrets := collectSecretSlots(bp)
+
+	if in.ProjectRepoURL != "" && declaredRepos[ProjectRepoSlotName] {
+		if cfg.Spec.Repos == nil {
+			cfg.Spec.Repos = map[string]v1beta1.CellConfigRepoFill{}
+		}
+		cfg.Spec.Repos[ProjectRepoSlotName] = v1beta1.CellConfigRepoFill{
+			URL: in.ProjectRepoURL,
+		}
+	}
+	if agentsURL := agentsCloneURL(tc, src); agentsURL != "" && declaredRepos[AgentsRepoSlotName] {
+		if cfg.Spec.Repos == nil {
+			cfg.Spec.Repos = map[string]v1beta1.CellConfigRepoFill{}
+		}
+		cfg.Spec.Repos[AgentsRepoSlotName] = v1beta1.CellConfigRepoFill{
+			URL: agentsURL,
+		}
+	}
+
+	if len(declaredSecrets) > 0 && r != nil && len(r.Spec.Needs.Secrets) > 0 && tc != nil {
+		for _, secretName := range r.Spec.Needs.Secrets {
+			if !declaredSecrets[secretName] {
+				continue
+			}
+			if _, ok := tc.Spec.Secrets[secretName]; !ok {
+				continue
+			}
+			if cfg.Spec.Secrets == nil {
+				cfg.Spec.Secrets = map[string]v1beta1.CellConfigSecretFill{}
+			}
+			cfg.Spec.Secrets[secretName] = v1beta1.CellConfigSecretFill{
+				SecretRef: &v1beta1.ContainerSecretRef{
+					Name:  secretName,
+					Realm: realm,
+				},
+			}
+		}
+	}
+
+	return cfg
+}
+
+// MarshalYAML returns the Result as a single multi-document YAML stream —
+// every blueprint followed by its companion config. The order matches the
+// per-(role × harness) iteration order so the dry-run output is
+// deterministic.
+func MarshalYAML(res *Result) ([]byte, error) {
+	if res == nil {
+		return nil, nil
+	}
+	var buf strings.Builder
+	first := true
+	emit := func(doc any) error {
+		raw, err := yaml.Marshal(doc)
+		if err != nil {
+			return err
+		}
+		if !first {
+			buf.WriteString("---\n")
+		}
+		first = false
+		buf.Write(raw)
+		return nil
+	}
+	for i, bp := range res.Blueprints {
+		if err := emit(bp); err != nil {
+			return nil, fmt.Errorf("marshal blueprint %d: %w", i, err)
+		}
+		if i < len(res.Configs) {
+			if err := emit(res.Configs[i]); err != nil {
+				return nil, fmt.Errorf("marshal config %d: %w", i, err)
+			}
+		}
+	}
+	return []byte(buf.String()), nil
+}
+
+// ptRoleImageNeeds returns the project-side image-capability overrides for
+// ptRole, or nil when the role declared no overrides. Encapsulates the
+// pointer nilness so MergeNeeds receives a plain slice.
+func ptRoleImageNeeds(ptRole model.ProjectTeamRole) []string {
+	if ptRole.Needs == nil {
+		return nil
+	}
+	return ptRole.Needs.Image
+}
+
+// hasAll reports whether haystack contains every entry of needles
+// (string set semantics, order-insensitive).
+func hasAll(haystack, needles []string) bool {
+	if len(needles) == 0 {
+		return true
+	}
+	set := make(map[string]struct{}, len(haystack))
+	for _, h := range haystack {
+		set[h] = struct{}{}
+	}
+	for _, n := range needles {
+		if _, ok := set[n]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// firstUnmet walks needs in iteration order and returns the first
+// capability no harness-matching ImageCatalog entry provides. Returns the
+// empty string when every needed capability is provided by some image but
+// no single image carries all of them — the caller renders a different
+// error message for that case.
+func firstUnmet(ic *model.ImageCatalog, harness string, needs []string) string {
+	for _, n := range needs {
+		provided := false
+		for i := range ic.Spec.Images {
+			e := &ic.Spec.Images[i]
+			if e.Harness != harness {
+				continue
+			}
+			for _, c := range e.Capabilities {
+				if c == n {
+					provided = true
+					break
+				}
+			}
+			if provided {
+				break
+			}
+		}
+		if !provided {
+			return n
+		}
+	}
+	return ""
+}
+
+// substitutionPattern matches a `${KEY}` placeholder. KEY is the standard
+// shell-style identifier: a leading letter or underscore followed by
+// letters/digits/underscores. Unknown placeholders pass through verbatim
+// rather than substituting empty — a CellBlueprint may legitimately carry
+// $-prefixed literals (env-var defaults, shell snippets), and the
+// downstream CellBlueprintParameter resolver surfaces a truly missing var
+// at apply time with a clearer error than a silent empty.
+var substitutionPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// substitute applies render-time `${KEY}` substitution. The function
+// looks up keys in vars; an unknown key passes through the original
+// `${KEY}` literal unchanged.
+func substitute(in string, vars map[string]string) string {
+	return substitutionPattern.ReplaceAllStringFunc(in, func(match string) string {
+		key := match[2 : len(match)-1]
+		if v, ok := vars[key]; ok {
+			return v
+		}
+		return match
+	})
+}
+
+// blueprintVars builds the `${KEY}` substitution dict the harness's
+// blueprint template is rendered against. The role's native per-harness
+// config is wired verbatim — a role that has no per-harness config for
+// `harness` still gets the per-harness keys, just bound to empty strings,
+// so a template that always references `${SETTINGS}` does not break for
+// roles that omit it.
+func blueprintVars(
+	roleRef, harness string,
+	image *model.ImageCatalogEntry,
+	needs []string,
+	r *model.Role,
+) map[string]string {
+	vars := map[string]string{
+		"ROLE":    roleRef,
+		"HARNESS": harness,
+		"NEEDS":   strings.Join(needs, ","),
+	}
+	if image != nil {
+		vars["IMAGE"] = image.Image
+		vars["IMAGE_REF"] = image.Ref
+	}
+	if r != nil {
+		if rh, ok := r.Spec.Harnesses[harness]; ok {
+			vars["SETTINGS"] = rh.Settings
+			vars["SANDBOX"] = rh.Sandbox
+			vars["APPROVAL"] = rh.Approval
+			vars["PERMISSIONS"] = rh.Permissions
+		} else {
+			vars["SETTINGS"] = ""
+			vars["SANDBOX"] = ""
+			vars["APPROVAL"] = ""
+			vars["PERMISSIONS"] = ""
+		}
+	}
+	return vars
+}
+
+// operatorValues builds the CellConfig.Values scalar map from operator
+// facts. The keys mirror the GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL / etc.
+// env-var protocol so a blueprint that declares those names as
+// CellBlueprintParameters resolves them at apply time without any
+// per-blueprint translation. Empty operator facts are omitted (the
+// blueprint's parameter default, if any, wins).
+func operatorValues(tc *model.TeamsConfig, roleRef, harness, project string) map[string]string {
+	vals := map[string]string{
+		"ROLE":    roleRef,
+		"HARNESS": harness,
+		"PROJECT": project,
+	}
+	if tc == nil {
+		return vals
+	}
+	if g := tc.Spec.Git; g != nil {
+		if g.Author != nil {
+			if g.Author.Name != "" {
+				vals["GIT_AUTHOR_NAME"] = g.Author.Name
+			}
+			if g.Author.Email != "" {
+				vals["GIT_AUTHOR_EMAIL"] = g.Author.Email
+			}
+		}
+		if g.Committer != nil {
+			if g.Committer.Name != "" {
+				vals["GIT_COMMITTER_NAME"] = g.Committer.Name
+			}
+			if g.Committer.Email != "" {
+				vals["GIT_COMMITTER_EMAIL"] = g.Committer.Email
+			}
+		}
+		if g.SigningKey != "" {
+			vals["GIT_SIGNING_KEY"] = g.SigningKey
+		}
+		if g.AllowedSigners != "" {
+			vals["GIT_ALLOWED_SIGNERS"] = g.AllowedSigners
+		}
+		if g.SSHKey != "" {
+			vals["GIT_SSH_KEY"] = g.SSHKey
+		}
+	}
+	if tc.Spec.Registry != "" {
+		vals["REGISTRY"] = tc.Spec.Registry
+	}
+	return vals
+}
+
+// agentsCloneURL returns the clone URL of the materialized agents source
+// when tc.spec.sources carries an entry for src.OwnerRepo, or the empty
+// string otherwise. The render pipeline already used the same lookup in
+// teamsource.CloneURL to clone the cache; reusing it here keeps the
+// agents-side slot fill consistent with the bundle that produced it.
+func agentsCloneURL(tc *model.TeamsConfig, src teamsource.Source) string {
+	if tc == nil || src.OwnerRepo == "" {
+		return ""
+	}
+	url, ok := tc.Spec.Sources[src.OwnerRepo]
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(url)
+}
+
+// collectRepoSlots returns the set of repo slot names declared by bp's
+// containers — a repo entry with an empty URL is a structural slot a
+// CellConfig fills (per BlueprintContainer.Repos contract). Inline-URL
+// repos are not slots and never appear here.
+func collectRepoSlots(bp *v1beta1.CellBlueprintDoc) map[string]bool {
+	out := map[string]bool{}
+	if bp == nil {
+		return out
+	}
+	for _, c := range bp.Spec.Cell.Containers {
+		for _, repo := range c.Repos {
+			if strings.TrimSpace(repo.URL) == "" {
+				out[repo.Name] = true
+			}
+		}
+	}
+	return out
+}
+
+// collectSecretSlots returns the set of BlueprintSecretSlot names
+// declared by bp's containers.
+func collectSecretSlots(bp *v1beta1.CellBlueprintDoc) map[string]bool {
+	out := map[string]bool{}
+	if bp == nil {
+		return out
+	}
+	for _, c := range bp.Spec.Cell.Containers {
+		for _, s := range c.Secrets {
+			out[s.Name] = true
+		}
+	}
+	return out
+}
+
+// defaultObjectName is the CellBlueprint/CellConfig name used when the
+// template did not set metadata.name. Kept simple and predictable so the
+// blueprint and its companion config share an identity in `kuke get`
+// output.
+func defaultObjectName(roleRef, harness string) string {
+	return roleRef + "-" + harness
+}

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -1,0 +1,664 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teamrender
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/teamsource"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestMergeNeedsSortsAndDedupes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a, b []string
+		want []string
+	}{
+		{"empty inputs", nil, nil, []string{}},
+		{"single side", []string{"go"}, nil, []string{"go"}},
+		{"both sides", []string{"go"}, []string{"git"}, []string{"git", "go"}},
+		{"dedupes overlap", []string{"go", "git"}, []string{"git", "make"}, []string{"git", "go", "make"}},
+		{"trims and drops blanks", []string{" go ", ""}, []string{"\tgit\t", "  "}, []string{"git", "go"}},
+		{"already sorted reproducible", []string{"a", "b"}, []string{"a", "b"}, []string{"a", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := MergeNeeds(tc.a, tc.b)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("MergeNeeds(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeNeedsDeterministicAcrossCalls(t *testing.T) {
+	t.Parallel()
+	a := []string{"go", "git", "make"}
+	b := []string{"docker", "make"}
+	first := MergeNeeds(a, b)
+	second := MergeNeeds(a, b)
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("non-deterministic output: %v vs %v", first, second)
+	}
+}
+
+// minimalClaudeCatalog returns a catalog with one claude image carrying the
+// listed capabilities. Helper for the SelectImage tests; tests that need a
+// different harness mutate the returned catalog's images directly (see
+// TestSelectImageHonoursHarnessFilter).
+func minimalClaudeCatalog(caps ...string) *model.ImageCatalog {
+	return &model.ImageCatalog{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindImageCatalog,
+		Spec: model.ImageCatalogSpec{
+			Images: []model.ImageCatalogEntry{
+				{
+					Ref:          "claude-base",
+					Harness:      "claude",
+					Image:        "registry.local/claude:latest",
+					Build:        model.ImageCatalogBuild{Context: "harnesses/claude", Dockerfile: "Dockerfile"},
+					Capabilities: caps,
+				},
+			},
+		},
+	}
+}
+
+func TestSelectImagePicksFirstMatch(t *testing.T) {
+	t.Parallel()
+	ic := minimalClaudeCatalog("go", "git", "make")
+	entry, err := SelectImage(ic, "claude", []string{"go", "git"})
+	if err != nil {
+		t.Fatalf("SelectImage error = %v", err)
+	}
+	if entry.Image != "registry.local/claude:latest" {
+		t.Errorf("entry.Image = %q, want claude:latest", entry.Image)
+	}
+}
+
+func TestSelectImageHonoursHarnessFilter(t *testing.T) {
+	t.Parallel()
+	ic := minimalClaudeCatalog("go")
+	// Adding a codex image with the right capability set should not satisfy
+	// a claude request, since the harness keys differ.
+	ic.Spec.Images = append(ic.Spec.Images, model.ImageCatalogEntry{
+		Ref:          "codex-base",
+		Harness:      "codex",
+		Image:        "registry.local/codex:latest",
+		Build:        model.ImageCatalogBuild{Context: "harnesses/codex", Dockerfile: "Dockerfile"},
+		Capabilities: []string{"go", "git", "make"},
+	})
+	if _, err := SelectImage(ic, "claude", []string{"git"}); !errors.Is(err, errdefs.ErrTeamImageNoMatch) {
+		t.Errorf("err = %v, want ErrTeamImageNoMatch (codex image must not satisfy claude need)", err)
+	}
+}
+
+func TestSelectImageEmptyNeedsMatchesFirstHarnessImage(t *testing.T) {
+	t.Parallel()
+	ic := minimalClaudeCatalog() // zero capabilities
+	entry, err := SelectImage(ic, "claude", nil)
+	if err != nil {
+		t.Fatalf("empty needs should match any harness image: %v", err)
+	}
+	if entry.Harness != "claude" {
+		t.Errorf("matched wrong harness: %q", entry.Harness)
+	}
+}
+
+func TestSelectImageNilCatalogHardErrors(t *testing.T) {
+	t.Parallel()
+	_, err := SelectImage(nil, "claude", []string{"go"})
+	if !errors.Is(err, errdefs.ErrTeamImageNoMatch) {
+		t.Fatalf("err = %v, want ErrTeamImageNoMatch", err)
+	}
+	if !strings.Contains(err.Error(), "build or label") {
+		t.Errorf("error missing build-or-label hint: %v", err)
+	}
+}
+
+func TestSelectImageNamesFirstUnmetCapability(t *testing.T) {
+	t.Parallel()
+	ic := minimalClaudeCatalog("go")
+	_, err := SelectImage(ic, "claude", []string{"git", "go"})
+	if !errors.Is(err, errdefs.ErrTeamImageNoMatch) {
+		t.Fatalf("err = %v, want ErrTeamImageNoMatch", err)
+	}
+	if !strings.Contains(err.Error(), `capability="git"`) {
+		t.Errorf("error should name first-unmet capability 'git', got: %v", err)
+	}
+}
+
+func TestSelectImageDistinguishesMultiImagePartialCoverage(t *testing.T) {
+	t.Parallel()
+	// Each capability is provided by *some* image, but no single image
+	// carries both — the renderer should surface a different message than
+	// the single-unmet path.
+	ic := minimalClaudeCatalog("go")
+	ic.Spec.Images = append(ic.Spec.Images, model.ImageCatalogEntry{
+		Ref:          "claude-git",
+		Harness:      "claude",
+		Image:        "registry.local/claude-git:latest",
+		Build:        model.ImageCatalogBuild{Context: "harnesses/claude", Dockerfile: "Dockerfile"},
+		Capabilities: []string{"git"},
+	})
+	_, err := SelectImage(ic, "claude", []string{"go", "git"})
+	if !errors.Is(err, errdefs.ErrTeamImageNoMatch) {
+		t.Fatalf("err = %v, want ErrTeamImageNoMatch", err)
+	}
+	if !strings.Contains(err.Error(), "no single image") {
+		t.Errorf("error should distinguish the consolidation case, got: %v", err)
+	}
+}
+
+// buildClaudeTemplate writes a minimal claude blueprint template into
+// cacheDir/harnesses/claude/blueprint.tmpl.yaml.
+func buildClaudeTemplate(t *testing.T, cacheDir string) {
+	t.Helper()
+	p := filepath.Join(cacheDir, "harnesses", "claude", "blueprint.tmpl.yaml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: ${ROLE}-${HARNESS}
+spec:
+  cell:
+    containers:
+      - id: ${ROLE}
+        image: ${IMAGE}
+        env:
+          - "ROLE=${ROLE}"
+          - "NEEDS=${NEEDS}"
+          - "SETTINGS=${SETTINGS}"
+        repos:
+          - { name: project, target: /src/project }
+          - { name: agents, target: /src/agents }
+        secrets:
+          - { name: ANTHROPIC_API_KEY, mode: env, envName: ANTHROPIC_API_KEY }
+`
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// minimalRole returns a role declaring the listed image-needs plus an
+// ANTHROPIC_API_KEY secret need and a claude-Settings per-harness config.
+func minimalRole() *model.Role {
+	return &model.Role{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindRole,
+		Metadata:   model.Metadata{Name: "dev"},
+		Spec: model.RoleSpec{
+			Harnesses: map[string]model.RoleHarness{
+				"claude": {Settings: "agents/dev/settings.json"},
+				"codex":  {Sandbox: "workspace-write", Approval: "on-request"},
+			},
+			Needs: model.RoleNeeds{
+				Image:   []string{"go", "git"},
+				Secrets: []string{"ANTHROPIC_API_KEY"},
+			},
+		},
+	}
+}
+
+func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	buildClaudeTemplate(t, cacheDir)
+	r := minimalRole()
+	h := &model.Harness{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindHarness,
+		Metadata:   model.Metadata{Name: "claude"},
+		Spec:       model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"},
+	}
+	image := &model.ImageCatalogEntry{
+		Ref:          "claude-base",
+		Harness:      "claude",
+		Image:        "registry.local/claude:latest",
+		Capabilities: []string{"go", "git"},
+	}
+	bp, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", []string{"git", "go"}, image, "sbsh", "default")
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	if bp.Metadata.Name != "dev-claude" {
+		t.Errorf("blueprint name = %q, want dev-claude", bp.Metadata.Name)
+	}
+	if bp.Metadata.Realm != "default" {
+		t.Errorf("realm = %q, want default", bp.Metadata.Realm)
+	}
+	if bp.Metadata.Labels[v1beta1.LabelTeam] != "sbsh" {
+		t.Errorf("team label = %q, want sbsh", bp.Metadata.Labels[v1beta1.LabelTeam])
+	}
+	if len(bp.Spec.Cell.Containers) == 0 {
+		t.Fatalf("no containers in rendered blueprint")
+	}
+	c := bp.Spec.Cell.Containers[0]
+	if c.ID != "dev" {
+		t.Errorf("container id = %q, want dev (substitution failed)", c.ID)
+	}
+	if c.Image != "registry.local/claude:latest" {
+		t.Errorf("container image = %q, want substituted IMAGE", c.Image)
+	}
+	wantEnv := []string{"ROLE=dev", "NEEDS=git,go", "SETTINGS=agents/dev/settings.json"}
+	if !reflect.DeepEqual(c.Env, wantEnv) {
+		t.Errorf("env = %v, want %v (verbatim per-harness config wiring)", c.Env, wantEnv)
+	}
+}
+
+func TestRenderBlueprintMissingTemplate(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	r := minimalRole()
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "harnesses/missing/blueprint.tmpl.yaml"}}
+	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, "sbsh", "default")
+	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
+		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
+	}
+}
+
+func TestRenderBlueprintEmptyTemplatePathRejected(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	r := minimalRole()
+	h := &model.Harness{Spec: model.HarnessSpec{}}
+	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, "sbsh", "default")
+	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
+		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
+	}
+}
+
+// TestRenderBlueprintWiresCodexConfigVerbatim confirms the codex
+// sandbox/approval knobs land in the substitution dict verbatim — covers
+// the AC's "codex sandbox/approval knobs" wiring path.
+func TestRenderBlueprintWiresCodexConfigVerbatim(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	p := filepath.Join(cacheDir, "harnesses", "codex", "blueprint.tmpl.yaml")
+	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: ${ROLE}-${HARNESS}
+spec:
+  cell:
+    containers:
+      - id: ${ROLE}
+        image: ${IMAGE}
+        env:
+          - "SANDBOX=${SANDBOX}"
+          - "APPROVAL=${APPROVAL}"
+`
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	r := minimalRole()
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "harnesses/codex/blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{Image: "registry.local/codex:latest"}
+	bp, err := RenderBlueprint(cacheDir, h, r, "codex", "dev", nil, image, "sbsh", "default")
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	wantEnv := []string{"SANDBOX=workspace-write", "APPROVAL=on-request"}
+	if !reflect.DeepEqual(bp.Spec.Cell.Containers[0].Env, wantEnv) {
+		t.Errorf("env = %v, want %v", bp.Spec.Cell.Containers[0].Env, wantEnv)
+	}
+}
+
+func TestBindConfigStampsTeamLabelAndProjectRepoFill(t *testing.T) {
+	t.Parallel()
+	bp := &v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{Name: "dev-claude", Realm: "default"},
+		Spec: v1beta1.CellBlueprintSpec{Cell: v1beta1.BlueprintCellSpec{
+			Containers: []v1beta1.BlueprintContainer{{
+				ID:    "dev",
+				Image: "x",
+				Repos: []v1beta1.ContainerRepo{
+					{Name: "project", Target: "/src/project"}, // empty URL → structural slot
+				},
+				Secrets: []v1beta1.BlueprintSecretSlot{
+					{Name: "ANTHROPIC_API_KEY", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "ANTHROPIC_API_KEY"},
+				},
+			}},
+		}},
+	}
+	role := minimalRole()
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{
+		Git: &model.TeamsConfigGit{
+			ContainerGit: v1beta1.ContainerGit{
+				Author: &v1beta1.GitIdentity{Name: "Op", Email: "op@example.com"},
+			},
+		},
+		Registry: "registry.local",
+		Secrets: map[string]model.TeamsConfigSecret{
+			"ANTHROPIC_API_KEY": {From: model.SecretFromEnv, Key: "ANTHROPIC_API_KEY"},
+		},
+	}}
+	src := teamsource.Source{Raw: "eminwux/agents@v1.4.0", OwnerRepo: "eminwux/agents", Version: "v1.4.0"}
+	in := Inputs{Project: "sbsh", ProjectRepoURL: "git@github.com:eminwux/sbsh.git"}
+
+	cfg := BindConfig(bp, role, "dev", "claude", tc, src, in, "sbsh", "default")
+	if cfg.Metadata.Labels[v1beta1.LabelTeam] != "sbsh" {
+		t.Errorf("team label = %q, want sbsh", cfg.Metadata.Labels[v1beta1.LabelTeam])
+	}
+	if cfg.Spec.Blueprint.Name != "dev-claude" {
+		t.Errorf("blueprint ref = %+v, want name=dev-claude", cfg.Spec.Blueprint)
+	}
+	if got := cfg.Spec.Repos["project"].URL; got != "git@github.com:eminwux/sbsh.git" {
+		t.Errorf("project repo fill URL = %q, want sbsh.git", got)
+	}
+	if got := cfg.Spec.Values["GIT_AUTHOR_NAME"]; got != "Op" {
+		t.Errorf("Values[GIT_AUTHOR_NAME] = %q, want Op", got)
+	}
+	if got := cfg.Spec.Values["REGISTRY"]; got != "registry.local" {
+		t.Errorf("Values[REGISTRY] = %q, want registry.local", got)
+	}
+	if cfg.Spec.Secrets["ANTHROPIC_API_KEY"].SecretRef == nil {
+		t.Errorf("ANTHROPIC_API_KEY secret slot not filled: %+v", cfg.Spec.Secrets)
+	}
+}
+
+func TestBindConfigSkipsUndeclaredSlots(t *testing.T) {
+	t.Parallel()
+	bp := &v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{Name: "dev-claude", Realm: "default"},
+		Spec: v1beta1.CellBlueprintSpec{Cell: v1beta1.BlueprintCellSpec{
+			Containers: []v1beta1.BlueprintContainer{{ID: "dev", Image: "x"}},
+		}},
+	}
+	in := Inputs{Project: "sbsh", ProjectRepoURL: "git@github.com:eminwux/sbsh.git"}
+	cfg := BindConfig(
+		bp,
+		minimalRole(),
+		"dev",
+		"claude",
+		&model.TeamsConfig{},
+		teamsource.Source{},
+		in,
+		"sbsh",
+		"default",
+	)
+	if len(cfg.Spec.Repos) != 0 {
+		t.Errorf("repos should stay empty when template declares no slots: %+v", cfg.Spec.Repos)
+	}
+	if len(cfg.Spec.Secrets) != 0 {
+		t.Errorf("secrets should stay empty: %+v", cfg.Spec.Secrets)
+	}
+}
+
+func TestBindConfigFillsAgentsSlotFromTeamsConfigSources(t *testing.T) {
+	t.Parallel()
+	bp := &v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{Name: "dev-claude", Realm: "default"},
+		Spec: v1beta1.CellBlueprintSpec{Cell: v1beta1.BlueprintCellSpec{
+			Containers: []v1beta1.BlueprintContainer{{
+				ID: "dev", Image: "x",
+				Repos: []v1beta1.ContainerRepo{
+					{Name: "agents", Target: "/src/agents"},
+				},
+			}},
+		}},
+	}
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{
+		Sources: map[string]string{"eminwux/agents": "git@github.com:eminwux/agents.git"},
+	}}
+	src := teamsource.Source{Raw: "eminwux/agents@v1.4.0", OwnerRepo: "eminwux/agents", Version: "v1.4.0"}
+	cfg := BindConfig(bp, minimalRole(), "dev", "claude", tc, src, Inputs{Project: "sbsh"}, "sbsh", "default")
+	if got := cfg.Spec.Repos["agents"].URL; got != "git@github.com:eminwux/agents.git" {
+		t.Errorf("agents slot fill URL = %q, want agents.git", got)
+	}
+}
+
+// TestRenderEndToEnd covers the per-(role × harness) outer loop: a
+// project with two harness defaults produces two pairs whose blueprints
+// + configs carry the team label.
+func TestRenderEndToEnd(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	buildClaudeTemplate(t, cacheDir)
+	// Codex template — minimal.
+	codexPath := filepath.Join(cacheDir, "harnesses", "codex", "blueprint.tmpl.yaml")
+	if err := os.MkdirAll(filepath.Dir(codexPath), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(codexPath, []byte(
+		"apiVersion: v1beta1\nkind: CellBlueprint\nmetadata: { name: \"${ROLE}-${HARNESS}\" }\nspec:\n  cell:\n    containers:\n      - { id: \"${ROLE}\", image: \"${IMAGE}\" }\n",
+	), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	bundle := &teamsource.Bundle{
+		Source:   teamsource.Source{OwnerRepo: "eminwux/agents", Version: "v1.4.0"},
+		CacheDir: cacheDir,
+		Roles:    map[string]*model.Role{"dev": minimalRole()},
+		Harnesses: map[string]*model.Harness{
+			"claude": {Spec: model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"}},
+			"codex":  {Spec: model.HarnessSpec{Template: "harnesses/codex/blueprint.tmpl.yaml"}},
+		},
+		ImageCatalog: &model.ImageCatalog{
+			Spec: model.ImageCatalogSpec{
+				Images: []model.ImageCatalogEntry{
+					{
+						Ref:          "claude-base",
+						Harness:      "claude",
+						Image:        "registry.local/claude:latest",
+						Capabilities: []string{"go", "git"},
+					},
+					{
+						Ref:          "codex-base",
+						Harness:      "codex",
+						Image:        "registry.local/codex:latest",
+						Capabilities: []string{"go", "git"},
+					},
+				},
+			},
+		},
+	}
+	pt := &model.ProjectTeam{
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec: model.ProjectTeamSpec{
+			Source:   "eminwux/agents@v1.4.0",
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude", "codex"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	res, err := Render(bundle, pt, &model.TeamsConfig{}, Inputs{Project: "sbsh"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(res.Blueprints) != 2 || len(res.Configs) != 2 {
+		t.Fatalf("expected 2 (role × harness) pairs, got %d/%d", len(res.Blueprints), len(res.Configs))
+	}
+	for i, bp := range res.Blueprints {
+		if bp.Metadata.Labels[v1beta1.LabelTeam] != "sbsh" {
+			t.Errorf("blueprint[%d] missing team label: %+v", i, bp.Metadata.Labels)
+		}
+		if res.Configs[i].Metadata.Labels[v1beta1.LabelTeam] != "sbsh" {
+			t.Errorf("config[%d] missing team label: %+v", i, res.Configs[i].Metadata.Labels)
+		}
+		if res.Configs[i].Metadata.Name != bp.Metadata.Name {
+			t.Errorf("config name %q != blueprint name %q at index %d",
+				res.Configs[i].Metadata.Name, bp.Metadata.Name, i)
+		}
+	}
+}
+
+// TestRenderProjectPerRoleNeedsOverrideUnions confirms the project-side
+// per-role image override is unioned with the role's own needs at image
+// selection time — the AC's "union" branch.
+func TestRenderProjectPerRoleNeedsOverrideUnions(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	buildClaudeTemplate(t, cacheDir)
+	role := minimalRole() // image needs: go, git
+	bundle := &teamsource.Bundle{
+		Source:   teamsource.Source{OwnerRepo: "eminwux/agents", Version: "v1.4.0"},
+		CacheDir: cacheDir,
+		Roles:    map[string]*model.Role{"dev": role},
+		Harnesses: map[string]*model.Harness{
+			"claude": {Spec: model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"}},
+		},
+		ImageCatalog: &model.ImageCatalog{Spec: model.ImageCatalogSpec{Images: []model.ImageCatalogEntry{
+			// First image has only go+git — should NOT satisfy go+git+rust merged needs.
+			{
+				Ref:          "claude-base",
+				Harness:      "claude",
+				Image:        "registry.local/claude:base",
+				Capabilities: []string{"go", "git"},
+			},
+			// Second has go+git+rust — should win.
+			{
+				Ref:          "claude-rust",
+				Harness:      "claude",
+				Image:        "registry.local/claude:rust",
+				Capabilities: []string{"go", "git", "rust"},
+			},
+		}}},
+	}
+	pt := &model.ProjectTeam{
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec: model.ProjectTeamSpec{
+			Source:   "eminwux/agents@v1.4.0",
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles: []model.ProjectTeamRole{{
+				Ref:   "dev",
+				Needs: &model.ProjectRoleNeeds{Image: []string{"rust"}},
+			}},
+		},
+	}
+	res, err := Render(bundle, pt, &model.TeamsConfig{}, Inputs{Project: "sbsh"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got := res.Blueprints[0].Spec.Cell.Containers[0].Image
+	if got != "registry.local/claude:rust" {
+		t.Errorf("merged needs picked wrong image: %q (want rust-bearing image)", got)
+	}
+}
+
+func TestRenderRejectsMissingRoleInBundle(t *testing.T) {
+	t.Parallel()
+	bundle := &teamsource.Bundle{
+		Roles:        map[string]*model.Role{},
+		Harnesses:    map[string]*model.Harness{},
+		ImageCatalog: minimalClaudeCatalog("go"),
+	}
+	pt := &model.ProjectTeam{
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec: model.ProjectTeamSpec{
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	_, err := Render(bundle, pt, nil, Inputs{Project: "sbsh"})
+	if !errors.Is(err, errdefs.ErrTeamRoleNotLoaded) {
+		t.Fatalf("err = %v, want ErrTeamRoleNotLoaded", err)
+	}
+}
+
+func TestRenderRejectsMissingHarnessInBundle(t *testing.T) {
+	t.Parallel()
+	bundle := &teamsource.Bundle{
+		Roles:        map[string]*model.Role{"dev": minimalRole()},
+		Harnesses:    map[string]*model.Harness{},
+		ImageCatalog: minimalClaudeCatalog("go", "git"),
+	}
+	pt := &model.ProjectTeam{
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec: model.ProjectTeamSpec{
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	_, err := Render(bundle, pt, nil, Inputs{Project: "sbsh"})
+	if !errors.Is(err, errdefs.ErrTeamHarnessNotLoaded) {
+		t.Fatalf("err = %v, want ErrTeamHarnessNotLoaded", err)
+	}
+}
+
+func TestMarshalYAMLProducesMultiDocStream(t *testing.T) {
+	t.Parallel()
+	bp := &v1beta1.CellBlueprintDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellBlueprint,
+		Metadata:   v1beta1.CellBlueprintMetadata{Name: "dev-claude", Realm: "default"},
+	}
+	cfg := &v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "dev-claude", Realm: "default"},
+	}
+	raw, err := MarshalYAML(
+		&Result{Blueprints: []*v1beta1.CellBlueprintDoc{bp}, Configs: []*v1beta1.CellConfigDoc{cfg}},
+	)
+	if err != nil {
+		t.Fatalf("MarshalYAML: %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, "kind: CellBlueprint") {
+		t.Errorf("missing CellBlueprint: %q", body)
+	}
+	if !strings.Contains(body, "kind: CellConfig") {
+		t.Errorf("missing CellConfig: %q", body)
+	}
+	if !strings.Contains(body, "---") {
+		t.Errorf("missing multi-doc separator: %q", body)
+	}
+}
+
+// TestRenderDefaultRealmFallback confirms the default realm is `default`
+// when Inputs.Realm is empty.
+func TestRenderDefaultRealmFallback(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	buildClaudeTemplate(t, cacheDir)
+	bundle := &teamsource.Bundle{
+		CacheDir: cacheDir,
+		Roles:    map[string]*model.Role{"dev": minimalRole()},
+		Harnesses: map[string]*model.Harness{
+			"claude": {Spec: model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"}},
+		},
+		ImageCatalog: minimalClaudeCatalog("go", "git"),
+	}
+	pt := &model.ProjectTeam{
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec: model.ProjectTeamSpec{
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	res, err := Render(bundle, pt, nil, Inputs{Project: "sbsh"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if res.Blueprints[0].Metadata.Realm != DefaultRealm {
+		t.Errorf("realm = %q, want %q", res.Blueprints[0].Metadata.Realm, DefaultRealm)
+	}
+}


### PR DESCRIPTION
## Summary

- Step 3 of \`kuke team init\` (epic team-distribution #792): turns the materialized agents source from step 2 (#1046) into in-memory \`CellBlueprint\` / \`CellConfig\` objects ready for step 4 (#1043) to apply with prune.
- New \`internal/teamrender\` package owns the per-\`(role × harness)\` pipeline — needs-merge → image-select → render → bind → label \`kukeon.io/team=<project>\`. Tested directly against tempdir fixtures so the package is hermetic.
- \`cmd/kuke/team/init.go\` wires the resolver (\`teamsource.Resolve\` from #1046) and the renderer end-to-end. Injectable via context keys so the existing init tests stay offline.
- \`--dry-run\` now stops after render and prints the multi-doc YAML (entry + blueprints + configs) to stdout. It writes nothing — neither \`~/.kuke/kuketeams.yaml\`, nor \`~/.kuke/kuketeam.d/<project>.yaml\`, nor anywhere under \`~/.kuke/rendered/\`.

## Pipeline shape

For each \`(role × harness)\`:

1. **needs-merge** — \`union(role.spec.needs.image ⊕ ptRole.needs.image)\`, dedup + lex-sort. Same inputs → byte-identical output.
2. **image-select** — match merged caps against \`ImageCatalog\` entries whose \`harness\` matches; first matching entry wins. Misses surface \`errdefs.ErrTeamImageNoMatch\` naming the first unmet capability + the build-or-label hint (umbrella key decision: selection only, no Dockerfile build, no LLM).
3. **render** — load \`harnesses/<h>/blueprint.tmpl.yaml\` relative to the cache dir, substitute \`\${ROLE}\`, \`\${HARNESS}\`, \`\${IMAGE}\`, \`\${NEEDS}\`, plus the role's native per-harness config knobs (\`\${SETTINGS}\` for claude, \`\${SANDBOX}\`/\`\${APPROVAL}\` for codex, \`\${PERMISSIONS}\` for opencode) — wired verbatim per the umbrella's no-transpile decision. Unknown placeholders pass through so blueprints can carry literal \$-prefixed env-var defaults.
4. **bind** — produce a \`CellConfig\` referencing the rendered blueprint:
   - Operator facts from \`~/.kuke/kuketeams.yaml\` (\`git.author.{name,email}\`, \`committer\`, \`signingKey\`, \`allowedSigners\`, \`sshKey\`, \`registry\`) land in \`spec.values\` keyed by \`GIT_AUTHOR_NAME\`/etc. so blueprints declaring those as \`CellBlueprintParameter\`s resolve them at apply time.
   - \`Inputs.ProjectRepoURL\` (from \`git -C <projectDir> remote get-url origin\`) fills the \`project\` structural repo slot when the blueprint declares one.
   - \`tc.spec.sources[<owner/repo>]\` fills the \`agents\` slot the same way.
   - \`role.spec.needs.secrets\` entries that have a matching \`tc.spec.secrets\` entry **and** a declared blueprint secret slot get filled with an in-realm \`ContainerSecretRef\` (runtime resolves the bytes via the \`Secret\` kind from #623).
5. **label** — every rendered blueprint and config carries \`metadata.labels[kukeon.io/team] = <project>\`, matching the prune-apply discriminator from #1029.

## Scope notes

- Apply lands in step 4 (#1043). The non-dry-run path here still scaffolds the operator-global facts + writes the per-project drop-in entry as today, plus runs the render pipeline so image-select misses fail the verb at \`init\` time (not lazily at apply time). The render result is built but not yet applied.
- The realm defaults to \`default\` (user realm provisioned by \`kuke init\`). Templates that need a different scope can stamp it; the renderer overrides \`metadata.realm\` to the configured one.
- \`Render(...)\` runs in deterministic outer-loop order: \`pt.Spec.Roles\` × \`pt.Spec.Defaults.Harnesses\`, so the multi-doc dry-run output is reproducible.
- \`ProjectRepoSlotName\` / \`AgentsRepoSlotName\` constants establish the convention that blueprint templates declare those slot names — this PR owns that contract.
- Empty \`pt.Spec.Defaults.Harnesses\` short-circuits the resolver entirely, keeping the existing harness-less init tests offline + fast.

## Test plan

- [x] \`make test\` (full \`test-root\` + \`test-kukebuild\` per the Makefile carve-out) — 60+ packages pass, including the new \`internal/teamrender\` suite and the updated \`cmd/kuke/team\` suite.
- [x] \`GOWORK=off go vet ./...\` — clean.
- [x] \`pre-commit run --files <diff>\` — \`go-fmt\`, \`go-mod-tidy\`, \`golangci-lint\`, \`addlicense\` all pass after the shadow/tparallel/unparam fixes.
- [x] \`teamrender\` unit tests cover each AC checkbox: MergeNeeds dedup + lex-sort + determinism; SelectImage harness-filter + first-unmet vs no-single-image error messages; RenderBlueprint substitution + missing-template error + verbatim per-harness config wiring (claude Settings + codex sandbox/approval); BindConfig project + agents slot fills, operator-fact Values, secret-slot fills, undeclared-slot skip; end-to-end \`Render\` for two-harness rosters with deterministic ordering.
- [x] \`cmd/kuke/team\` integration tests cover the AC paths: dry-run renders to stdout and writes nothing; non-dry-run renders + writes drop-in + reports render counts; image-select hard-error propagates through \`composeTeam\`; project repo URL lands in the rendered \`CellConfig\`.
- [ ] Local \`make dev-init\` smoke (build path + daemon rebuild) — not run; this PR adds no new daemon-touching code (no \`cmd/kukeond/...\`, no \`/opt/kukeon\` change, no Makefile target change) and the \`kuke team init\` verb is host-local per the package doc. The daemon-parity tail is unchanged.

Closes #1042