### PR TITLE
feat(team): apply-with-prune + two-project compose e2e (step 4)

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -27,11 +27,13 @@ import (
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/kuketeams"
 	"github.com/eminwux/kukeon/internal/teamhost"
 	"github.com/eminwux/kukeon/internal/teamrender"
 	"github.com/eminwux/kukeon/internal/teamsource"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
@@ -78,16 +80,29 @@ type ResolveFunc func(
 // MockResolveKey injects a ResolveFunc via context for tests.
 type MockResolveKey struct{}
 
+// ApplyForTeamFunc applies a per-(role × harness) rendered set to kukeond
+// under the project's team label, pruning that team's stale objects in the
+// same call (the per-team prune-apply contract from #1029). The default
+// implementation dials kukeond and invokes ApplyDocumentsForTeam; tests
+// inject a stub via MockApplyForTeamKey so the apply path can run hermetically.
+type ApplyForTeamFunc func(
+	ctx context.Context, rawYAML []byte, team string,
+) (kukeonv1.ApplyDocumentsResult, error)
+
+// MockApplyForTeamKey injects an ApplyForTeamFunc via context for tests.
+type MockApplyForTeamKey struct{}
+
 // NewInitCmd builds the `kuke team init` subcommand. It reads the current
 // project's kuketeam.yaml roster, scaffolds the operator-global facts file on
-// first run, writes the per-project drop-in entry, materializes the pinned
-// agents source, and renders the per-(role × harness) CellBlueprint/CellConfig
-// pairs. `--dry-run` stops after render, prints the rendered objects to
-// stdout, and touches no files on disk (apply lands in step 4 #1043).
+// first run, materializes the pinned agents source, renders the per-(role ×
+// harness) CellBlueprint/CellConfig pairs, applies them to kukeond under the
+// project's team label (per-team prune via #1029), and writes the per-project
+// drop-in entry. `--dry-run` stops after render, prints the rendered objects
+// to stdout, applies nothing, and touches no files on disk.
 func NewInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "init",
-		Short:         "Compose this project's team into the host ~/.kuke drop-in",
+		Short:         "Compose this project's team into the host ~/.kuke drop-in and apply to kukeond",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -109,8 +124,8 @@ func NewInitCmd() *cobra.Command {
 }
 
 // runInit gathers the cobra-coupled inputs (current directory, ~/.kuke layout,
-// git-config reader, project-repo-URL reader) and hands them to composeTeam,
-// which holds the testable lifecycle.
+// git-config reader, project-repo-URL reader, daemon apply reader) and hands
+// them to composeTeam, which holds the testable lifecycle.
 func runInit(cmd *cobra.Command, dryRun bool) error {
 	projectDir, err := os.Getwd()
 	if err != nil {
@@ -120,6 +135,7 @@ func runInit(cmd *cobra.Command, dryRun bool) error {
 	return composeTeam(
 		cmd.Context(), cmd.OutOrStdout(), projectDir, layout,
 		gitConfigFromCmd(cmd), projectRepoURLFromCmd(cmd), resolveFromCmd(cmd),
+		applyForTeamFromCmd(cmd),
 		dryRun,
 	)
 }
@@ -131,13 +147,16 @@ func runInit(cmd *cobra.Command, dryRun bool) error {
 //  3. Resolve the pinned agents source into the on-disk cache and load every
 //     Role / Harness / ImageCatalog the roster references.
 //  4. Render the per-(role × harness) CellBlueprint/CellConfig pairs.
-//  5. Either print the rendered objects to stdout (--dry-run) or write the
-//     per-project drop-in entry (step 4 in #1043 will apply the rendered
-//     objects to kukeond after this point).
+//  5. Either print the rendered objects to stdout (--dry-run, nothing is
+//     applied and no files are written) or apply the labeled set to kukeond
+//     via ApplyDocumentsForTeam (per-team prune via #1029) and then write
+//     the per-project drop-in entry. Nothing is written under
+//     ~/.kuke/rendered/ — the on-disk record of an applied team is the
+//     drop-in entry alone; the daemon owns the persisted blueprints/configs.
 //
 // composeTeam takes no cobra dependency so it is unit-testable with a temp
-// layout, stub git-config / project-repo-URL readers, and a stub resolver, no
-// live kukeond required.
+// layout, stub git-config / project-repo-URL readers, a stub resolver, and a
+// stub apply, no live kukeond required.
 func composeTeam(
 	ctx context.Context,
 	out io.Writer,
@@ -146,6 +165,7 @@ func composeTeam(
 	getGit GitConfigFunc,
 	getProjectURL ProjectRepoURLFunc,
 	resolve ResolveFunc,
+	apply ApplyForTeamFunc,
 	dryRun bool,
 ) error {
 	pt, err := readProjectTeam(projectDir)
@@ -177,6 +197,11 @@ func composeTeam(
 		return emitDryRun(out, project, layout, res)
 	}
 
+	applyResult, applied, err := applyTeam(ctx, project, res, apply)
+	if err != nil {
+		return err
+	}
+
 	entry := &model.TeamEntry{
 		APIVersion: model.APIVersionV1,
 		Kind:       model.KindTeamEntry,
@@ -190,9 +215,63 @@ func composeTeam(
 		return fmt.Errorf("write team entry: %w", writeErr)
 	}
 	fmt.Fprintf(out, "wrote team %q to %s\n", project, layout.EntryPath(project))
-	fmt.Fprintf(out, "rendered %d blueprint/%d config object(s) (apply lands in step 4)\n",
-		len(res.Blueprints), len(res.Configs))
+	if applied {
+		emitApplySummary(out, project, applyResult, len(res.Blueprints), len(res.Configs))
+	} else {
+		fmt.Fprintf(out, "rendered %d blueprint/%d config object(s) (no apply: no (role × harness) pairs)\n",
+			len(res.Blueprints), len(res.Configs))
+	}
 	return nil
+}
+
+// applyTeam marshals the rendered set and hands it to apply with the project
+// as the team label. Returns applied=false (with a zero result) when there is
+// nothing to render — harness-less rosters skip the apply hop. A non-nil
+// error from apply propagates verbatim so the drop-in entry write upstream
+// only fires on a successful apply.
+func applyTeam(
+	ctx context.Context, project string, res *teamrender.Result, apply ApplyForTeamFunc,
+) (kukeonv1.ApplyDocumentsResult, bool, error) {
+	if res == nil || (len(res.Blueprints) == 0 && len(res.Configs) == 0) {
+		return kukeonv1.ApplyDocumentsResult{}, false, nil
+	}
+	rawYAML, err := teamrender.MarshalYAML(res)
+	if err != nil {
+		return kukeonv1.ApplyDocumentsResult{}, false, fmt.Errorf("marshal rendered objects: %w", err)
+	}
+	applyResult, err := apply(ctx, rawYAML, project)
+	if err != nil {
+		return kukeonv1.ApplyDocumentsResult{}, false, fmt.Errorf("apply team %q to kukeond: %w", project, err)
+	}
+	return applyResult, true, nil
+}
+
+// emitApplySummary prints one line per applied resource, mirroring the
+// `kuke apply -f` human-readable output, then a one-line aggregate so the
+// operator sees both the per-object outcome and the overall counts.
+func emitApplySummary(
+	out io.Writer, project string, result kukeonv1.ApplyDocumentsResult, blueprints, configs int,
+) {
+	for _, r := range result.Resources {
+		switch r.Action {
+		case "created":
+			fmt.Fprintf(out, "  %s %q: created\n", r.Kind, r.Name)
+		case "updated":
+			fmt.Fprintf(out, "  %s %q: updated\n", r.Kind, r.Name)
+		case "unchanged":
+			fmt.Fprintf(out, "  %s %q: unchanged\n", r.Kind, r.Name)
+		case "pruned":
+			fmt.Fprintf(out, "  %s %q: pruned\n", r.Kind, r.Name)
+		case "failed":
+			fmt.Fprintf(out, "  %s %q: failed", r.Kind, r.Name)
+			if r.Error != "" {
+				fmt.Fprintf(out, " (%s)", r.Error)
+			}
+			fmt.Fprintln(out)
+		}
+	}
+	fmt.Fprintf(out, "applied %d blueprint/%d config object(s) to kukeond under team %q\n",
+		blueprints, configs, project)
 }
 
 // loadOrScaffoldGlobalConfig returns the TeamsConfig the render pipeline
@@ -297,7 +376,7 @@ func emitDryRun(out io.Writer, project string, layout teamhost.Layout, res *team
 	if err != nil {
 		return fmt.Errorf("marshal rendered objects: %w", err)
 	}
-	fmt.Fprintf(out, "---\n# dry-run: rendered %d blueprint/%d config object(s) (apply lands in step 4)\n",
+	fmt.Fprintf(out, "---\n# dry-run: rendered %d blueprint/%d config object(s) (not applied to kukeond)\n",
 		len(res.Blueprints), len(res.Configs))
 	if _, writeErr := out.Write(rawRender); writeErr != nil {
 		return writeErr
@@ -422,6 +501,25 @@ func resolveFromCmd(cmd *cobra.Command) ResolveFunc {
 		return mock
 	}
 	return realResolve
+}
+
+// applyForTeamFromCmd returns the ApplyForTeamFunc the init flow uses — the
+// test mock from context when present, otherwise a function that dials
+// kukeond per invocation and forwards to ApplyDocumentsForTeam. The dial
+// happens on call (rather than eagerly at command-setup time) so a roster
+// with no (role × harness) pairs never opens the daemon connection.
+func applyForTeamFromCmd(cmd *cobra.Command) ApplyForTeamFunc {
+	if mock, ok := cmd.Context().Value(MockApplyForTeamKey{}).(ApplyForTeamFunc); ok && mock != nil {
+		return mock
+	}
+	return func(ctx context.Context, rawYAML []byte, team string) (kukeonv1.ApplyDocumentsResult, error) {
+		client, err := kukshared.DaemonClientFromCmd(cmd)
+		if err != nil {
+			return kukeonv1.ApplyDocumentsResult{}, err
+		}
+		defer func() { _ = client.Close() }()
+		return client.ApplyDocumentsForTeam(ctx, rawYAML, team)
+	}
 }
 
 // realGitConfig reads a single `git config --global <key>` value. A non-zero

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -20,14 +20,17 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/teamhost"
 	"github.com/eminwux/kukeon/internal/teamsource"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"gopkg.in/yaml.v3"
@@ -78,6 +81,41 @@ func stubProjectURL(url string) ProjectRepoURLFunc {
 func stubResolveErr() ResolveFunc {
 	return func(_ context.Context, _ teamsource.Cache, _ *model.TeamsConfig, _ *model.ProjectTeam) (*teamsource.Bundle, error) {
 		return nil, errors.New("resolve must not be called")
+	}
+}
+
+// stubApplyErr returns an ApplyForTeamFunc that fails on any call — used by
+// tests that should never reach the apply step (dry-run, harness-less roster,
+// pre-render failure paths).
+func stubApplyErr() ApplyForTeamFunc {
+	return func(_ context.Context, _ []byte, _ string) (kukeonv1.ApplyDocumentsResult, error) {
+		return kukeonv1.ApplyDocumentsResult{}, errors.New("apply must not be called")
+	}
+}
+
+// applyCall captures one composeTeam → apply invocation so a test can
+// assert which team each project's apply targeted and what YAML it sent.
+type applyCall struct {
+	Team    string
+	RawYAML []byte
+}
+
+// recordingApply returns an ApplyForTeamFunc that appends every invocation
+// to *calls under a mutex (composeTeam itself is single-goroutine, but the
+// recorder is shared across composeTeam calls in two-project tests) and
+// returns the given result. Use nil result for an "ack with no per-resource
+// detail" reply — composeTeam treats the empty Resources slice as a clean
+// apply with zero individual lines to print.
+func recordingApply(
+	mu *sync.Mutex, calls *[]applyCall, result kukeonv1.ApplyDocumentsResult,
+) ApplyForTeamFunc {
+	return func(_ context.Context, rawYAML []byte, team string) (kukeonv1.ApplyDocumentsResult, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		buf := make([]byte, len(rawYAML))
+		copy(buf, rawYAML)
+		*calls = append(*calls, applyCall{Team: team, RawYAML: buf})
+		return result, nil
 	}
 }
 
@@ -190,7 +228,7 @@ func TestComposeTeamNoProjectFile(t *testing.T) {
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 	err := composeTeam(
 		context.Background(), &bytes.Buffer{}, emptyDir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), false,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
 	)
 	if !errors.Is(err, errdefs.ErrTeamProjectFileNotFound) {
 		t.Fatalf("err = %v, want ErrTeamProjectFileNotFound", err)
@@ -203,7 +241,7 @@ func TestComposeTeamWrongKind(t *testing.T) {
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 	err := composeTeam(
 		context.Background(), &bytes.Buffer{}, dir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), false,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
 	)
 	if !errors.Is(err, errdefs.ErrTeamProjectFileKind) {
 		t.Fatalf("err = %v, want ErrTeamProjectFileKind", err)
@@ -226,7 +264,7 @@ func TestComposeTeamScaffoldsAndWrites(t *testing.T) {
 	var out bytes.Buffer
 	if err := composeTeam(
 		context.Background(), &out, projectDir, layout,
-		git, stubProjectURL(""), stubResolveErr(), false,
+		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
 	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
@@ -278,7 +316,7 @@ func TestComposeTeamReRunDoesNotRescaffold(t *testing.T) {
 
 	if err := composeTeam(
 		context.Background(), &bytes.Buffer{}, projectDir, layout,
-		git, stubProjectURL(""), stubResolveErr(), false,
+		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
 	); err != nil {
 		t.Fatalf("first composeTeam: %v", err)
 	}
@@ -291,7 +329,7 @@ func TestComposeTeamReRunDoesNotRescaffold(t *testing.T) {
 	var out bytes.Buffer
 	if err := composeTeam(
 		context.Background(), &out, projectDir, layout,
-		git, stubProjectURL(""), stubResolveErr(), false,
+		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
 	); err != nil {
 		t.Fatalf("second composeTeam: %v", err)
 	}
@@ -314,7 +352,7 @@ func TestComposeTeamNoGitIdentityOmitsGitBlock(t *testing.T) {
 
 	if err := composeTeam(
 		context.Background(), &bytes.Buffer{}, projectDir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), false,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
 	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
@@ -339,7 +377,7 @@ func TestComposeTeamDryRunWritesNothing(t *testing.T) {
 	var out bytes.Buffer
 	if err := composeTeam(
 		context.Background(), &out, projectDir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), true,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), true,
 	); err != nil {
 		t.Fatalf("composeTeam dry-run: %v", err)
 	}
@@ -367,7 +405,7 @@ func TestComposeTeamDryRunRendersToStdout(t *testing.T) {
 		context.Background(), &out, projectDir, layout,
 		stubGit(map[string]string{"user.name": "Op", "user.email": "op@example.com"}),
 		stubProjectURL("git@github.com:eminwux/sbsh.git"),
-		stubBundle(bundle), true,
+		stubBundle(bundle), stubApplyErr(), true,
 	)
 	if err != nil {
 		t.Fatalf("composeTeam dry-run: %v", err)
@@ -405,12 +443,18 @@ func TestComposeTeamRendersOnNonDryRun(t *testing.T) {
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 	bundle := buildClaudeBundle(t)
 
+	var (
+		mu    sync.Mutex
+		calls []applyCall
+	)
 	var out bytes.Buffer
 	err := composeTeam(
 		context.Background(), &out, projectDir, layout,
 		stubGit(nil),
 		stubProjectURL("git@github.com:eminwux/sbsh.git"),
-		stubBundle(bundle), false,
+		stubBundle(bundle),
+		recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{}),
+		false,
 	)
 	if err != nil {
 		t.Fatalf("composeTeam: %v", err)
@@ -419,8 +463,8 @@ func TestComposeTeamRendersOnNonDryRun(t *testing.T) {
 	if _, statErr := os.Stat(layout.EntryPath("sbsh")); statErr != nil {
 		t.Errorf("entry should have been written on non-dry-run: %v", statErr)
 	}
-	if !strings.Contains(out.String(), "rendered 1 blueprint/1 config") {
-		t.Errorf("render-count summary missing: %q", out.String())
+	if !strings.Contains(out.String(), "applied 1 blueprint/1 config") {
+		t.Errorf("apply-count summary missing: %q", out.String())
 	}
 }
 
@@ -438,7 +482,7 @@ func TestComposeTeamImageSelectHardError(t *testing.T) {
 	err := composeTeam(
 		context.Background(), &bytes.Buffer{}, projectDir, layout,
 		stubGit(nil), stubProjectURL(""),
-		stubBundle(bundle), false,
+		stubBundle(bundle), stubApplyErr(), false,
 	)
 	if !errors.Is(err, errdefs.ErrTeamImageNoMatch) {
 		t.Fatalf("err = %v, want ErrTeamImageNoMatch", err)
@@ -464,13 +508,265 @@ func TestComposeTeamProjectRepoURLFilledIntoConfig(t *testing.T) {
 	err := composeTeam(
 		context.Background(), &out, projectDir, layout,
 		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
-		stubBundle(bundle), true,
+		stubBundle(bundle), stubApplyErr(), true,
 	)
 	if err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
 	if !strings.Contains(out.String(), "git@github.com:eminwux/sbsh.git") {
 		t.Errorf("project clone URL not stamped into rendered config: %q", out.String())
+	}
+}
+
+// TestComposeTeamAppliesRenderedSetToDaemon pins the AC: the project's
+// labeled set is handed to ApplyDocumentsForTeam with the project as the
+// team. The YAML the stub captures carries both kinds and the team label
+// teamrender stamped onto every object — the same payload the daemon
+// prunes against in #1029.
+func TestComposeTeamAppliesRenderedSetToDaemon(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var (
+		mu    sync.Mutex
+		calls []applyCall
+	)
+	result := kukeonv1.ApplyDocumentsResult{
+		Resources: []kukeonv1.ApplyResourceResult{
+			{Kind: "CellBlueprint", Name: "dev-claude", Action: "created"},
+			{Kind: "CellConfig", Name: "dev-claude", Action: "created"},
+		},
+	}
+	var out bytes.Buffer
+	if err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), recordingApply(&mu, &calls, result), false,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("apply call count = %d, want 1", len(calls))
+	}
+	call := calls[0]
+	if call.Team != "sbsh" {
+		t.Errorf("apply team = %q, want %q", call.Team, "sbsh")
+	}
+	body := string(call.RawYAML)
+	if !strings.Contains(body, "kind: CellBlueprint") || !strings.Contains(body, "kind: CellConfig") {
+		t.Errorf("applied YAML missing kinds: %q", body)
+	}
+	if !strings.Contains(body, v1beta1.LabelTeam+": sbsh") {
+		t.Errorf("applied YAML missing team label %q: %q", v1beta1.LabelTeam, body)
+	}
+	// The daemon's per-resource report flows through to the human output.
+	if !strings.Contains(out.String(), `CellBlueprint "dev-claude": created`) {
+		t.Errorf("per-resource summary missing CellBlueprint line: %q", out.String())
+	}
+	if !strings.Contains(out.String(), `applied 1 blueprint/1 config object(s) to kukeond under team "sbsh"`) {
+		t.Errorf("aggregate summary missing: %q", out.String())
+	}
+}
+
+// TestComposeTeamDryRunSkipsApply covers the AC inversion: --dry-run prints
+// rendered objects to stdout but does not call into the daemon.
+func TestComposeTeamDryRunSkipsApply(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	// stubApplyErr would error if invoked — composeTeam must not reach it.
+	var out bytes.Buffer
+	if err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), stubApplyErr(), true,
+	); err != nil {
+		t.Fatalf("composeTeam dry-run: %v", err)
+	}
+	if !strings.Contains(out.String(), "not applied to kukeond") {
+		t.Errorf("dry-run output missing skip-apply marker: %q", out.String())
+	}
+}
+
+// TestComposeTeamHarnessLessRosterSkipsApply covers the harness-less branch:
+// no (role × harness) pairs → nothing to apply, no daemon hop.
+func TestComposeTeamHarnessLessRosterSkipsApply(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	var out bytes.Buffer
+	if err := composeTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+	if !strings.Contains(out.String(), "no apply: no (role × harness) pairs") {
+		t.Errorf("harness-less output missing skip-apply marker: %q", out.String())
+	}
+	// Drop-in entry still written so future re-runs (and future verbs like
+	// `kuke team list`) see the project — apply-skip is not entry-skip.
+	if _, statErr := os.Stat(layout.EntryPath("sbsh")); statErr != nil {
+		t.Errorf("entry should still be written even with no apply: %v", statErr)
+	}
+}
+
+// TestComposeTeamApplyFailureBlocksDropInWrite covers the failure ordering:
+// apply runs before the drop-in entry write, so a daemon-side failure does
+// not leave a half-recorded team behind. The next re-run sees a clean tree.
+func TestComposeTeamApplyFailureBlocksDropInWrite(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	wantErr := errors.New("daemon refused: kukeond not running")
+	apply := func(_ context.Context, _ []byte, _ string) (kukeonv1.ApplyDocumentsResult, error) {
+		return kukeonv1.ApplyDocumentsResult{}, wantErr
+	}
+
+	err := composeTeam(
+		context.Background(), &bytes.Buffer{}, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubBundle(bundle), apply, false,
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want it to wrap %v", err, wantErr)
+	}
+	if _, statErr := os.Stat(layout.EntryPath("sbsh")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("drop-in entry written despite apply failure: err=%v", statErr)
+	}
+}
+
+// TestComposeTeamWritesNothingUnderRendered covers the explicit AC: nothing
+// is written under ~/.kuke/rendered/. After a full init the layout base
+// holds only kuketeams.yaml + kuketeam.d/, never a rendered/ sibling.
+func TestComposeTeamWritesNothingUnderRendered(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var (
+		mu    sync.Mutex
+		calls []applyCall
+	)
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{}), false,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(layout.Base, "rendered")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("rendered/ directory should not exist after init: stat err=%v", statErr)
+	}
+}
+
+// TestComposeTeamTwoProjectsIndependent covers the AC's e2e check at the
+// composition layer: `kuke team init` in two project directories sharing
+// one ~/.kuke applies each labeled set under its own team, and re-running
+// one project re-applies only that project's set — the second project's
+// apply is not re-invoked, its drop-in file is untouched, and removing one
+// project's drop-in file leaves the other readable.
+func TestComposeTeamTwoProjectsIndependent(t *testing.T) {
+	t.Parallel()
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	mkProject := func(name string) string {
+		body := fmt.Sprintf(`apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: %s }
+spec:
+  source: eminwux/agents@v1.4.0
+  defaults:
+    harnesses: [claude]
+  roles:
+    - { ref: dev }
+`, name)
+		return writeProject(t, body)
+	}
+	alphaDir := mkProject("alpha")
+	betaDir := mkProject("beta")
+
+	var (
+		mu    sync.Mutex
+		calls []applyCall
+	)
+	apply := recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{})
+
+	// Init alpha.
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, alphaDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/alpha.git"),
+		stubBundle(bundle), apply, false,
+	); err != nil {
+		t.Fatalf("alpha init: %v", err)
+	}
+	// Init beta.
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, betaDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/beta.git"),
+		stubBundle(bundle), apply, false,
+	); err != nil {
+		t.Fatalf("beta init: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("apply call count after two-project init = %d, want 2", len(calls))
+	}
+	if calls[0].Team != "alpha" || calls[1].Team != "beta" {
+		t.Errorf("apply teams = %q,%q, want alpha,beta", calls[0].Team, calls[1].Team)
+	}
+
+	// Per-project drop-in files written, independent of each other.
+	for _, project := range []string{"alpha", "beta"} {
+		if _, statErr := os.Stat(layout.EntryPath(project)); statErr != nil {
+			t.Errorf("entry %q not written: %v", project, statErr)
+		}
+	}
+
+	// Re-init alpha → one more apply for alpha; beta's apply is not
+	// re-invoked, beta's drop-in stays put.
+	betaEntryBefore, readErr := os.ReadFile(layout.EntryPath("beta"))
+	if readErr != nil {
+		t.Fatalf("read beta entry: %v", readErr)
+	}
+	if reErr := composeTeam(
+		context.Background(), &bytes.Buffer{}, alphaDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/alpha.git"),
+		stubBundle(bundle), apply, false,
+	); reErr != nil {
+		t.Fatalf("alpha re-init: %v", reErr)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("apply call count after re-init alpha = %d, want 3", len(calls))
+	}
+	if calls[2].Team != "alpha" {
+		t.Errorf("re-init apply team = %q, want alpha", calls[2].Team)
+	}
+	betaEntryAfter, readErr2 := os.ReadFile(layout.EntryPath("beta"))
+	if readErr2 != nil {
+		t.Fatalf("read beta entry after alpha re-init: %v", readErr2)
+	}
+	if !bytes.Equal(betaEntryBefore, betaEntryAfter) {
+		t.Errorf("beta drop-in entry changed by alpha re-init:\n--- before ---\n%s\n--- after ---\n%s",
+			betaEntryBefore, betaEntryAfter)
+	}
+
+	// Removing one project's drop-in does not disturb the other — the
+	// per-project file layout (the resized step-1 "kuketeam.d/" decision)
+	// makes this trivially true; the test pins the invariant.
+	if rmErr := os.Remove(layout.EntryPath("alpha")); rmErr != nil {
+		t.Fatalf("remove alpha drop-in: %v", rmErr)
+	}
+	if _, statErr := os.Stat(layout.EntryPath("beta")); statErr != nil {
+		t.Errorf("beta drop-in disturbed by alpha removal: %v", statErr)
 	}
 }
 

--- a/cmd/kuke/team/team.go
+++ b/cmd/kuke/team/team.go
@@ -14,14 +14,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package team hosts the `kuke team` parent command and its subcommands. Step 1
-// (#796, epic team-distribution #792) lands `init`: it reads the project's
-// committed kuketeam.yaml roster, scaffolds the operator-global facts file
-// (~/.kuke/kuketeams.yaml) on first run, and writes a per-project drop-in entry
-// (~/.kuke/kuketeam.d/<project>.yaml). Source resolution, render, and apply land
-// in steps 2–4 (#1041/#1042/#1043). Every `kuke team *` verb is host-local and
-// daemon-independent — they manipulate ~/.kuke files, not /opt/kukeon state — so
-// none require a live kukeond.
+// Package team hosts the `kuke team` parent command and its subcommands. The
+// team-distribution epic (#792) lands `init` across four steps: skeleton +
+// drop-in lifecycle (#796), pinned-source resolve + cache + role/harness/image
+// load (#1041), render pipeline (needs-merge / image-select / bind) (#1042),
+// and apply-with-prune to kukeond (#1043). After step 4, `kuke team init`
+// reads the project's committed kuketeam.yaml roster, scaffolds the operator-
+// global facts file (~/.kuke/kuketeams.yaml) on first run, renders the per-
+// (role × harness) CellBlueprint/CellConfig pairs labeled with the project,
+// applies that labeled set to kukeond (per-team prune via #1029 — re-running
+// in one project prunes only that project's stale objects and leaves every
+// other project untouched), and writes a per-project drop-in entry
+// (~/.kuke/kuketeam.d/<project>.yaml). Nothing is written under
+// ~/.kuke/rendered/ — the daemon owns the persisted blueprints/configs and
+// the drop-in entry is the only host-side record of an applied team.
 package team
 
 import (


### PR DESCRIPTION
## Summary

- Wires the rendered, labeled CellBlueprint/CellConfig set into `kukeond` via `ApplyDocumentsForTeam` (the per-team prune-apply path from #1029): `kuke team init` now applies its project's labeled slice on every run, pruning that project's stale objects while leaving other teams' objects untouched.
- Ordering: render → apply → drop-in write. Apply runs *before* the per-project drop-in entry is written, so a daemon-side failure cannot leave a half-recorded team behind — the next re-run sees a clean tree. Harness-less rosters (no `(role × harness)` pairs) skip the daemon hop entirely, matching the existing render-skip; the drop-in entry is still written so future verbs (`kuke team list`) see the project.
- `--dry-run` keeps the "render-to-stdout, touch nothing" contract — the stub apply in the dry-run unit test fails on call, asserting `composeTeam` never reaches the daemon under `--dry-run`.
- Nothing is written under `~/.kuke/rendered/` — the drop-in entry is the only host-side record; the daemon owns the persisted blueprints/configs. A unit test pins the negative-existence invariant.
- Apply is injected via context (`MockApplyForTeamKey{}` + `ApplyForTeamFunc`), matching the existing `MockResolveKey` / `MockProjectRepoURLKey` / `MockGitConfigKey` pattern, so the new tests run hermetically without a live `kukeond`. The production binding dials the daemon per call via `kukshared.DaemonClientFromCmd`, so a harness-less roster never opens the daemon connection.
- Cleanup: `team.go` package doc now describes the four landed steps (and drops the "every `kuke team *` verb is daemon-independent" claim, now stale since `init` talks to `kukeond`); `init.go` cobra-cmd doc and the `--dry-run` stdout marker stop referencing "step 4 #1043" as a future event.

## Test plan

- [x] `make test` — full CI test target (`test-root` + `test-kukebuild`).
- [x] `GOWORK=off go test ./cmd/kuke/team/ -v` — all 17 tests pass, including the new `TestComposeTeamAppliesRenderedSetToDaemon`, `TestComposeTeamDryRunSkipsApply`, `TestComposeTeamHarnessLessRosterSkipsApply`, `TestComposeTeamApplyFailureBlocksDropInWrite`, `TestComposeTeamWritesNothingUnderRendered`, `TestComposeTeamTwoProjectsIndependent`.
- [x] `pre-commit run --files cmd/kuke/team/init.go cmd/kuke/team/init_test.go cmd/kuke/team/team.go` — fmt/vet/golangci-lint/addlicense clean.
- [x] `GOWORK=off go build ./...` and `GOWORK=off go vet ./...` clean.
- [ ] `make dev-init` — not run; this PR is purely client-side (`cmd/kuke/team/*`) and does not touch the build path, the daemon, or `/opt/kukeon`. The daemon-side per-team prune-apply path was already covered by `internal/controller/apply_team_prune_test.go` when #1029 landed, and `scripts/dev-init.sh` does not exercise `kuke team init` (no team smoke phase). The two-project compose e2e the AC names runs at the `composeTeam` boundary via `TestComposeTeamTwoProjectsIndependent`, which exercises the wiring contract (project label per apply, per-project drop-in independence, re-init of one project does not re-apply the other) without a live `kukeond`.

## Acceptance criteria

- [x] `kuke team init` applies the project's labeled set to `kukeond` via `ApplyDocumentsForTeam` with prune — `TestComposeTeamAppliesRenderedSetToDaemon` pins the captured call's team label and YAML payload (both kinds + `kukeon.io/team: <project>` stamp); the per-team prune itself is the daemon-side contract pinned by #1029's `TestApplyDocuments_TeamPruneScopedToLabel`.
- [x] Re-running `init` for a project prunes that project's stale objects only; other teams' objects are untouched — `TestComposeTeamTwoProjectsIndependent` asserts re-init of `alpha` (a) issues a third apply with `team="alpha"`, (b) does *not* re-invoke `beta`'s apply, (c) leaves `beta`'s drop-in entry byte-identical. The daemon-side prune-scoping is #1029's invariant.
- [x] No files are written under `~/.kuke/rendered/` — `TestComposeTeamWritesNothingUnderRendered` pins that no `rendered/` sibling appears under `layout.Base` after a full apply.
- [x] e2e: `init` in two projects composes both in `kukeond`; re-init one, the other is unaffected — and each project's `~/.kuke/kuketeam.d/<project>.yaml` is independent (removing one project's file does not disturb the other) — `TestComposeTeamTwoProjectsIndependent` covers all three: two-project compose with distinct team labels, re-init of one keeping the other's drop-in untouched, and `os.Remove(layout.EntryPath("alpha"))` leaving `beta`'s entry readable.

Closes #1043