### PR TITLE
fix(ctr): DeleteImage triggers synchronous GC sweep to reclaim exclusive layers

### DIFF
--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -17,11 +17,13 @@
 package ctr
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/leases"
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/errdefs"
@@ -244,14 +246,45 @@ func (c *client) GetImage(namespace, ref string) (ImageInfo, error) {
 	return c.imageToInfo(namespace, img), nil
 }
 
-// DeleteImage removes the named image ref from the specified
-// containerd namespace. The kukeon ErrImageNotFound sentinel is returned
-// when containerd reports the ref absent so upper layers can map to a
-// clean error message; other errors are wrapped with ErrDeleteImage.
+// DeleteImage removes the named image ref from the specified containerd
+// namespace and triggers a synchronous content/snapshot GC sweep so layers
+// exclusive to the deleted image are reclaimed before the call returns
+// (#1037). Without the sweep, ImageService().Delete only unlinks the
+// metadata image bucket entry — exclusive layers stay pinned by GC
+// references the deleted image was their last root for, so the operator
+// sees no disk freed.
+//
+// images.SynchronousDelete() flips the image-service RPC's Sync flag,
+// which the containerd-side handler honors by calling ScheduleAndWait on
+// the GC scheduler after the metadata removal (containerd v2
+// plugins/services/images/local.go Delete). The sweep walks every GC root
+// (live images, leases, container snapshots) and reclaims content and
+// snapshots no surviving root references — so layers shared with another
+// tagged image or a running container survive on their own refcount,
+// satisfying the AC's "shared layers preserved" guarantee without any
+// per-layer accounting on our side.
+//
+// Mirrors the leases.SynchronousDelete pattern in drainLeases (see
+// CleanupNamespaceResources's GC-sweep rationale). The pull-time lease
+// pullImage creates is dropped by its own defer, so the regular pull
+// path leaves no orphaned lease for this sweep to step around;
+// kukebuild's build-time orphaned leases are tracked separately in
+// #1038 and would survive this sweep regardless.
+//
+// The kukeon ErrImageNotFound sentinel is returned when containerd
+// reports the ref absent so upper layers can map to a clean error
+// message; other errors are wrapped with ErrDeleteImage.
 func (c *client) DeleteImage(namespace, ref string) error {
 	nsCtx := c.namespaceCtx(namespace)
+	return c.deleteImage(nsCtx, namespace, ref, c.conn().ImageService())
+}
 
-	if err := c.conn().ImageService().Delete(nsCtx, ref); err != nil {
+// deleteImage is the body of DeleteImage split out so unit tests can drive
+// the image-delete path with a fake images.Store that captures the
+// DeleteOpt set — the SynchronousDelete opt is load-bearing for layer
+// reclaim and is therefore asserted in TestDeleteImagePassesSynchronousDelete.
+func (c *client) deleteImage(nsCtx context.Context, namespace, ref string, store images.Store) error {
+	if err := store.Delete(nsCtx, ref, images.SynchronousDelete()); err != nil {
 		if errdefs.IsNotFound(err) {
 			return fmt.Errorf("%w: %s", internalerrdefs.ErrImageNotFound, ref)
 		}

--- a/internal/ctr/image_internal_test.go
+++ b/internal/ctr/image_internal_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	cerrdefs "github.com/containerd/errdefs"
+	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
+)
+
+// TestDeleteImagePassesSynchronousDelete is the regression guard for #1037 —
+// `kuke image delete <ref>` removed only the image's metadata tag and left
+// exclusive layers pinned by GC roots the deleted image was their last
+// owner for, so operators saw no disk freed. The fix is to pass
+// images.SynchronousDelete() so the containerd image-service handler runs
+// the GC scheduler's ScheduleAndWait sweep after the metadata removal,
+// reclaiming content/snapshots no surviving root references.
+//
+// The shared-layers preservation guarantee (AC item 2 — layers referenced
+// by another tagged image or live cell survive the sweep) is containerd's
+// GC refcount, not something this layer re-implements; this unit test
+// asserts only the contract dev controls (the SynchronousDelete opt
+// reaching the image store). Cross-image refcount behavior is exercised
+// by an e2e/integration test against a real containerd, which this repo
+// defers to a separate infra issue (no `kuke image` e2e suite exists
+// today).
+func TestDeleteImagePassesSynchronousDelete(t *testing.T) {
+	srv := newFakeServices()
+	srv.addImage("docker.io/library/alpine:latest", "sha256:manifest-alpine")
+
+	c := &client{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	err := c.deleteImage(
+		context.Background(),
+		"test-ns",
+		"docker.io/library/alpine:latest",
+		srv.ImageService(),
+	)
+	if err != nil {
+		t.Fatalf("deleteImage: unexpected error: %v", err)
+	}
+
+	if got := len(srv.imageList); got != 0 {
+		t.Errorf("image remained after delete: got %d, want 0", got)
+	}
+	if got := len(srv.imageDeleteSync); got != 1 {
+		t.Fatalf("expected one image-store Delete call, got %d (call log %v)", got, srv.callLog)
+	}
+	if !srv.imageDeleteSync[0] {
+		t.Errorf(
+			"DeleteImage did not pass images.SynchronousDelete(); GC sweep would not run, exclusive layers stay pinned (#1037)",
+		)
+	}
+}
+
+// TestDeleteImageNotFoundMapsToSentinel asserts that containerd's NotFound
+// error continues to map to the kukeon ErrImageNotFound sentinel so upper
+// layers (controller, CLI) keep surfacing a clean "image not found" message
+// after the SynchronousDelete refactor (#1037). Belongs in the internal
+// test file because it exercises the unexported deleteImage helper.
+func TestDeleteImageNotFoundMapsToSentinel(t *testing.T) {
+	srv := newFakeServices()
+	// No image added — fakeImageStore.Delete returns containerd's
+	// errdefs.ErrNotFound when the name is absent.
+
+	c := &client{
+		ctx:    context.Background(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	err := c.deleteImage(
+		context.Background(),
+		"test-ns",
+		"docker.io/library/missing:latest",
+		srv.ImageService(),
+	)
+	if err == nil {
+		t.Fatal("deleteImage: expected error for missing image, got nil")
+	}
+	if !errors.Is(err, internalerrdefs.ErrImageNotFound) {
+		t.Errorf("deleteImage: expected ErrImageNotFound, got %v", err)
+	}
+	if errors.Is(err, internalerrdefs.ErrDeleteImage) {
+		t.Errorf("deleteImage: NotFound mistakenly wrapped as ErrDeleteImage: %v", err)
+	}
+	// Sanity-check the precondition: the fake's underlying error really
+	// does satisfy containerd's IsNotFound (catches a stale-fake regression).
+	if !cerrdefs.IsNotFound(errImageNotFoundProbe()) {
+		t.Fatal("test precondition: containerd errdefs.IsNotFound rejected the fake's sentinel")
+	}
+}
+
+// errImageNotFoundProbe re-materializes the error fakeImageStore.Delete
+// returns for an absent name. Kept in this file so a future change to the
+// fake's error shape surfaces the mismatch here rather than as an opaque
+// failure in TestDeleteImageNotFoundMapsToSentinel.
+func errImageNotFoundProbe() error {
+	srv := newFakeServices()
+	return srv.ImageService().Delete(context.Background(), "absent")
+}

--- a/internal/ctr/namespaces_internal_test.go
+++ b/internal/ctr/namespaces_internal_test.go
@@ -128,6 +128,12 @@ type fakeServices struct {
 	imageList []images.Image
 	blobs     map[string]bool
 	callLog   []string
+
+	// imageDeleteSync records the DeleteOptions.Synchronous flag observed
+	// on each images.Store Delete call (one entry per call, in order).
+	// Load-bearing for TestDeleteImagePassesSynchronousDelete (#1037), which
+	// asserts the single-image delete path triggers a synchronous GC sweep.
+	imageDeleteSync []bool
 }
 
 type fakeSnapshot struct {
@@ -230,8 +236,15 @@ func (s *fakeImageStore) List(_ context.Context, _ ...string) ([]images.Image, e
 	return append([]images.Image(nil), s.f.imageList...), nil
 }
 
-func (s *fakeImageStore) Delete(_ context.Context, name string, _ ...images.DeleteOpt) error {
+func (s *fakeImageStore) Delete(ctx context.Context, name string, opts ...images.DeleteOpt) error {
 	s.f.callLog = append(s.f.callLog, "images.Delete("+name+")")
+	var do images.DeleteOptions
+	for _, opt := range opts {
+		if err := opt(ctx, &do); err != nil {
+			return err
+		}
+	}
+	s.f.imageDeleteSync = append(s.f.imageDeleteSync, do.Synchronous)
 	for i, img := range s.f.imageList {
 		if img.Name == name {
 			s.f.imageList = append(s.f.imageList[:i], s.f.imageList[i+1:]...)


### PR DESCRIPTION
## Summary

- `DeleteImage` only removed the metadata image bucket entry — exclusive layers stayed pinned by GC references the deleted image was their last root for, so `kuke image delete <ref>` freed no disk (#1037).
- Pass `images.SynchronousDelete()` so the containerd image-service handler runs the GC scheduler's `ScheduleAndWait` sweep after the metadata removal (containerd v2 `plugins/services/images/local.go` Delete). The sweep walks every surviving GC root (live images, leases, container snapshots) and reclaims content/snapshots no remaining root references.
- Layer-sharing preservation (AC item 2) falls out of containerd's GC refcount: layers still referenced by another tagged image or a live container survive the sweep on their own root, no per-layer accounting on our side. Mirrors the `leases.SynchronousDelete` pattern `drainLeases` already uses for the same purpose (see `CleanupNamespaceResources`'s GC-sweep rationale).
- Refactored the body into a private `deleteImage(nsCtx, namespace, ref, store)` helper that takes `images.Store` so the regression test can drive the path with a fake — matches the existing `drainNamespaceResources` / `containerdNamespaceServices` seam pattern in this package.
- Out of scope: the pull-time lease `pullImage` creates is already dropped by its own `defer`, so the regular pull path leaves no orphaned lease for this sweep to step around. Kukebuild's build-time orphaned leases are tracked separately in #1038 and would survive this sweep regardless — that issue is the right place to fix lease cleanup at the producer.

## Test plan

- [x] `GOWORK=off go test ./internal/ctr/...` — 71 s, all passing (`TestDeleteImagePassesSynchronousDelete` and `TestDeleteImageNotFoundMapsToSentinel` are the new regression guards)
- [x] `make test` — full per-module CI target, all packages pass
- [x] `GOWORK=off go vet ./...` — clean
- [x] `pre-commit run --files internal/ctr/image.go internal/ctr/image_internal_test.go internal/ctr/namespaces_internal_test.go` — clean (golangci-lint, gofmt, addlicense, etc.)
- [ ] e2e shared-layer assertion (AC item 3: "build two images sharing a base, delete one, assert only the non-shared layers are gone") — this repo has no `kuke image` e2e suite today (no test in `e2e/` references `kuke image`, `kuke build`, or image delete), and the assertion needs a real containerd + `kukebuild` to produce shared layers. Per CLAUDE.md §"When an AC requires a test tier the project can't execute anywhere", shipping the verifiable fix and surfacing the infra gap for PM follow-up rather than blocking on a missing harness. The shared-layers-survive guarantee itself is containerd's GC refcount (covered by upstream containerd's own tests); the contract dev controls — passing `images.SynchronousDelete()` — is asserted by the new unit test.

Closes #1037