### PR TITLE
fix(kukebuild): drain buildkit/lease.temporary leases at shutdown

### DIFF
--- a/cmd/kukebuild/build.go
+++ b/cmd/kukebuild/build.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	ctd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/leases"
 	ctddefaults "github.com/containerd/containerd/v2/defaults"
 	"github.com/distribution/reference"
 	"github.com/moby/buildkit/cache/remotecache"
@@ -399,10 +400,35 @@ func newController(ctx context.Context, cfg *buildConfig, namespace string) (*co
 	}
 
 	cleanup := func() {
+		drainBuildkitTemporaryLeases(ctx, w.LeaseManager())
 		_ = historyDB.Close()
 		_ = wc.Close()
 	}
 	return ctrl, cleanup, nil
+}
+
+// drainBuildkitTemporaryLeases drops every `buildkit/lease.temporary` lease
+// from the worker's namespace. BuildKit's solver tags transient solve-time
+// leases with this label and relies on the next worker startup to sweep them
+// — `base.NewWorker` runs the exact List+Delete pass on every boot. Kukebuild
+// embeds BuildKit in a one-build-per-process model (#522), so the worker dies
+// after Solve returns and the next-startup sweep never runs, leaving the
+// temporary leases as GC roots that pin dangling content + snapshots against
+// containerd GC indefinitely (#1038). Mirrors the startup sweep at shutdown
+// so each kukebuild invocation cleans up after itself, on both success and
+// failure paths via the newController cleanup defer. ctx may already be
+// cancelled (SIGINT/SIGTERM through runBuild's signal handler) when cleanup
+// runs, so the drain uses a non-cancelable context to ensure the deletes
+// reach containerd.
+func drainBuildkitTemporaryLeases(ctx context.Context, lm leases.Manager) {
+	ctx = context.WithoutCancel(ctx)
+	existing, err := lm.List(ctx, `labels."buildkit/lease.temporary"`)
+	if err != nil {
+		return
+	}
+	for _, l := range existing {
+		_ = lm.Delete(ctx, l, leases.SynchronousDelete)
+	}
 }
 
 // newWorkerController builds a single-worker controller using BuildKit's

--- a/cmd/kukebuild/build_test.go
+++ b/cmd/kukebuild/build_test.go
@@ -17,9 +17,13 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/containerd/containerd/v2/core/leases"
 )
 
 // newSolveOptFixture writes a minimal build context (an empty Dockerfile) into
@@ -233,5 +237,154 @@ func TestResolveBuildRootIsolatesNamespaces(t *testing.T) {
 	second := resolveBuildRoot(defaultBuildRoot, false, "kuke-system.kukeon.io")
 	if first == second {
 		t.Errorf("default roots for distinct namespaces collide: %q == %q", first, second)
+	}
+}
+
+// fakeLeaseManager satisfies leases.Manager with an in-memory store, capturing
+// the filter strings List was called with and the lease IDs Delete touched —
+// enough to drive drainBuildkitTemporaryLeases and assert it issued the same
+// filter base.NewWorker does at startup (worker/base/worker.go:214) and
+// synchronously deleted only the matching leases.
+type fakeLeaseManager struct {
+	leases       []leases.Lease
+	listFilters  []string
+	deletedIDs   []string
+	deleteSynced []bool
+	listErr      error
+}
+
+func (f *fakeLeaseManager) Create(_ context.Context, _ ...leases.Opt) (leases.Lease, error) {
+	return leases.Lease{}, errors.New("not implemented")
+}
+
+func (f *fakeLeaseManager) Delete(_ context.Context, l leases.Lease, opts ...leases.DeleteOpt) error {
+	do := &leases.DeleteOptions{}
+	for _, o := range opts {
+		_ = o(context.Background(), do)
+	}
+	f.deletedIDs = append(f.deletedIDs, l.ID)
+	f.deleteSynced = append(f.deleteSynced, do.Synchronous)
+	remaining := f.leases[:0]
+	for _, kept := range f.leases {
+		if kept.ID != l.ID {
+			remaining = append(remaining, kept)
+		}
+	}
+	f.leases = remaining
+	return nil
+}
+
+func (f *fakeLeaseManager) List(_ context.Context, filters ...string) ([]leases.Lease, error) {
+	f.listFilters = append(f.listFilters, filters...)
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	if len(filters) == 0 {
+		out := append([]leases.Lease(nil), f.leases...)
+		return out, nil
+	}
+	// The drain only ever passes the single buildkit/lease.temporary label
+	// filter; the fake mirrors a `labels."X"` predicate so a wrong filter
+	// string yields zero results and fails the assertion below.
+	const want = `labels."buildkit/lease.temporary"`
+	var out []leases.Lease
+	for _, l := range f.leases {
+		match := false
+		for _, fl := range filters {
+			if fl != want {
+				continue
+			}
+			if _, ok := l.Labels["buildkit/lease.temporary"]; ok {
+				match = true
+				break
+			}
+		}
+		if match {
+			out = append(out, l)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeLeaseManager) AddResource(_ context.Context, _ leases.Lease, _ leases.Resource) error {
+	return nil
+}
+
+func (f *fakeLeaseManager) DeleteResource(_ context.Context, _ leases.Lease, _ leases.Resource) error {
+	return nil
+}
+
+func (f *fakeLeaseManager) ListResources(_ context.Context, _ leases.Lease) ([]leases.Resource, error) {
+	return nil, nil
+}
+
+// drainBuildkitTemporaryLeases mirrors base.NewWorker's startup sweep
+// (worker/base/worker.go:214-220) at shutdown so kukebuild's one-build-per-
+// process model (#522) doesn't leak temp leases across builds (#1038). The
+// fake covers four invariants: the exact label filter is used, only matching
+// leases are deleted, gc.flat (a legit BuildKit cache pin) is preserved, and
+// SynchronousDelete is passed so containerd's GC scheduler runs the sweep
+// before Delete returns — matching internal/ctr/namespaces.go drainLeases.
+func TestDrainBuildkitTemporaryLeasesScopesToLabelAndSynchronous(t *testing.T) {
+	fake := &fakeLeaseManager{
+		leases: []leases.Lease{
+			{ID: "tmp-1", Labels: map[string]string{"buildkit/lease.temporary": "2026-06-04"}},
+			{ID: "tmp-2", Labels: map[string]string{"buildkit/lease.temporary": "2026-06-04"}},
+			{ID: "cache-1", Labels: map[string]string{"containerd.io/gc.flat": "2026-06-04"}},
+			{ID: "unrelated", Labels: nil},
+		},
+	}
+
+	drainBuildkitTemporaryLeases(context.Background(), fake)
+
+	if len(fake.listFilters) != 1 || fake.listFilters[0] != `labels."buildkit/lease.temporary"` {
+		t.Fatalf("listFilters = %q, want a single `labels.\"buildkit/lease.temporary\"`", fake.listFilters)
+	}
+	wantDeleted := map[string]bool{"tmp-1": true, "tmp-2": true}
+	if len(fake.deletedIDs) != len(wantDeleted) {
+		t.Fatalf("deletedIDs = %v, want exactly %v", fake.deletedIDs, wantDeleted)
+	}
+	for i, id := range fake.deletedIDs {
+		if !wantDeleted[id] {
+			t.Errorf("deleted unexpected lease %q", id)
+		}
+		if !fake.deleteSynced[i] {
+			t.Errorf("delete %q was async, want SynchronousDelete so containerd's GC sweep runs before return", id)
+		}
+	}
+	for _, l := range fake.leases {
+		if l.ID == "cache-1" || l.ID == "unrelated" {
+			continue
+		}
+		t.Errorf("leftover lease %q after drain", l.ID)
+	}
+}
+
+// A failed List must not panic and must not delete anything — the cleanup runs
+// best-effort. The session-survival rationale is the same as
+// internal/ctr/namespaces.go drainLeases's warn-and-return path.
+func TestDrainBuildkitTemporaryLeasesIgnoresListError(t *testing.T) {
+	fake := &fakeLeaseManager{listErr: errors.New("transient")}
+	drainBuildkitTemporaryLeases(context.Background(), fake)
+	if len(fake.deletedIDs) != 0 {
+		t.Errorf("deletedIDs = %v on list failure, want none", fake.deletedIDs)
+	}
+}
+
+// The cleanup defer in newController may fire with a cancelled ctx (SIGINT /
+// SIGTERM through runBuild's signal handler) — the drain must still reach
+// containerd. context.WithoutCancel decouples the request from the parent
+// cancellation chain.
+func TestDrainBuildkitTemporaryLeasesSurvivesCancelledCtx(t *testing.T) {
+	fake := &fakeLeaseManager{
+		leases: []leases.Lease{
+			{ID: "tmp-1", Labels: map[string]string{"buildkit/lease.temporary": "2026-06-04"}},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	drainBuildkitTemporaryLeases(ctx, fake)
+	if len(fake.deletedIDs) != 1 || fake.deletedIDs[0] != "tmp-1" {
+		t.Errorf("deletedIDs = %v, want [tmp-1] (drain must survive cancellation)", fake.deletedIDs)
 	}
 }


### PR DESCRIPTION
## Summary

- `kukebuild` embeds BuildKit in a one-build-per-process model (#522), so the worker dies after Solve returns. BuildKit's solver tags transient solve-time leases with `buildkit/lease.temporary` and relies on the *next* worker startup to sweep them (`worker/base/worker.go:214-220` runs the exact List+Delete pass on every boot). With no long-running buildkitd, that next-startup sweep never runs and the temp leases pile up as GC roots that pin dangling content + snapshots against containerd GC indefinitely (#1038).
- Mirror BuildKit's startup sweep at shutdown: `newController`'s cleanup defer now calls `drainBuildkitTemporaryLeases(ctx, w.LeaseManager())` before closing the worker, on both success and failure paths. Uses `leases.SynchronousDelete` so containerd's GC scheduler runs `ScheduleAndWait` before each Delete returns — same pattern `internal/ctr/namespaces.go` `drainLeases` already uses for the same reason.
- `context.WithoutCancel(ctx)` decouples the drain from the parent — the cleanup may fire with ctx already cancelled (SIGINT/SIGTERM through `runBuild`'s signal handler) and the deletes still need to reach containerd.

## Scope call

The issue title and Summary mention both `buildkit/lease.temporary` (5 lingering) and per-build `containerd.io/gc.flat` (187 roots). Acceptance criterion #2 names *only* temporary leases, and AC #1 (count doesn't grow unboundedly) is satisfied by removing the orphan source — `gc.flat` leases are BuildKit's cache pins (`cache/manager.go:243`, `:600`, `:805`, `:960`, `:410`, `:1494`), created per cache record so containerd doesn't GC the blob/snapshot the record references. They persist by design across builds; draining them would defeat caching (every build re-pulls layers). The issue's own References section points at #1036 (`kuke image prune`) as the cleanup path for accumulated state — \"this issue stops the bleed at the source; #1036 cleans up what already accumulated.\" Per dev/CLAUDE.md \"lower-blast-radius default when the AC leaves room\", this PR ships the temp-lease drain only; #1036 owns cache pruning.

## Test plan

- [x] `cd cmd/kukebuild && go test ./...` — 3 new unit tests (`TestDrainBuildkitTemporaryLeases{ScopesToLabelAndSynchronous,IgnoresListError,SurvivesCancelledCtx}`) cover the four invariants: exact label filter `labels.\"buildkit/lease.temporary\"`, `SynchronousDelete` flag, `gc.flat` cache pins preserved, and survival under cancelled parent ctx
- [x] `make test` — full per-module CI target, all packages pass (kukebuild + root tree)
- [x] `cd cmd/kukebuild && go vet ./...` — clean
- [x] `pre-commit run --files cmd/kukebuild/build.go cmd/kukebuild/build_test.go` — clean (golangci-lint, gofmt, addlicense, etc.)
- [ ] End-to-end \"lease count returns to baseline after N builds\" smoke against a real containerd — not runnable on this dev host without disturbing the standalone containerd serving the parent session, and the project has no `kuke build` e2e suite that would exercise the lease lifecycle today. Per CLAUDE.md §\"When a reviewer-blocking verification step can't safely run on the current host\", deferring to a clean reviewer environment; the unit-test layer pins the contract (filter, sync flag, gc.flat preservation) so the reviewer-side smoke only needs to confirm the observable lease count, not the implementation shape.

Closes #1038