### PR TITLE
docs(cli): drop "containers" from kuke start/stop/kill row

### DIFF
--- a/docs/site/cli/commands.md
+++ b/docs/site/cli/commands.md
@@ -21,7 +21,7 @@ Both are hard-linked to the same binary on install. Running `kuke` enters the cl
 | `kuke get`                     | List or describe resources (realm, space, stack, cell, container)     |
 | `kuke create`                  | Create a single resource imperatively                                 |
 | `kuke delete`                  | Delete a resource                                                     |
-| `kuke start` / `stop` / `kill` | Lifecycle operations on cells and containers                          |
+| `kuke start` / `stop` / `kill` | Lifecycle operations on cells                                         |
 | `kuke purge`                   | Delete with aggressive cleanup of residual state                      |
 | `kuke refresh`                 | Reconcile `.status` from live state without touching `.spec`          |
 | `kuke restart`                 | Restart a cell (bounces the process; on OutOfSync also reconciles)    |


### PR DESCRIPTION
## Summary
- `docs/site/cli/commands.md:24` still described `kuke start`/`stop`/`kill` as operating on "cells and containers"; the container-lifecycle verbs were retired by PR #1011 (epic:bye-container), so the row now reads "cells" only.

## Test plan
- [x] `git grep -n "cells and containers" docs/site/cli/commands.md` — no remaining matches
- [x] Visual check that column alignment in the table is preserved

Closes #1014