### PR TITLE
docs(concepts): drop stale --cascade from kuke delete cell example

### DIFF
--- a/docs/site/concepts/cell.md
+++ b/docs/site/concepts/cell.md
@@ -78,8 +78,8 @@ sudo kuke start mycell --realm main --space default --stack default
 sudo kuke stop  mycell --realm main --space default --stack default
 sudo kuke kill  mycell --realm main --space default --stack default
 
-# Delete (with cascade to remove child containers)
-sudo kuke delete cell mycell --realm main --space default --stack default --cascade
+# Delete (removes the cell and its materialised containers as a single unit)
+sudo kuke delete cell mycell --realm main --space default --stack default
 ```
 
 ## Related concepts


### PR DESCRIPTION
## Summary
- `docs/site/concepts/cell.md:81`'s example invoked `kuke delete cell <name> --cascade`, but per `docs/site/cli/kuke-delete.md` cascade walks `realm → spaces → stacks → cells` and stops at the cell — so `--cascade` on `kuke delete cell` is a no-op.
- Drops `--cascade` from the example invocation and rewords the inline comment to describe what cell-level delete actually does: removes the cell and its materialised containers as a single unit.

## Test plan
- [x] Diff is comment-and-flag-removal only in `docs/site/concepts/cell.md`; no executable code, test, or behavior text changes.
- [x] `pre-commit run --files docs/site/concepts/cell.md` — Passed (prettier + whitespace).
- [x] `git grep -n 'kuke delete cell.*--cascade' -- docs/site/concepts/cell.md` returns no results post-edit.

Other `--cascade` mentions in `docs/site/architecture/storage-layout.md`, `docs/site/guides/run-claude-code.md`, and `docs/site/guides/troubleshooting.md` are deliberately left untouched — this PR's scope is the single follow-up nit named in #1054 (`concepts/cell.md:81`). Per dev/CLAUDE.md "no unrelated cleanups bundled into fix-up commits or feature PRs."

Closes #1054