### PR TITLE
docs(cli-tests): fix RejectsCellSubcommand comments naming wrong cobra error

### DIFF
--- a/cmd/kuke/kill/kill_test.go
+++ b/cmd/kuke/kill/kill_test.go
@@ -155,7 +155,9 @@ func TestKillCmd(t *testing.T) {
 }
 
 // TestKillCmd_RejectsCellSubcommand pins the hard CLI break: `kuke kill cell <name>`
-// must fail with cobra's unknown-command error after the collapse.
+// must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
+// after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
+// subcommand list, so cobra's unknown-command path no longer fires.
 func TestKillCmd_RejectsCellSubcommand(t *testing.T) {
 	cmd := killpkg.NewKillCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/kuke/restart/restart_test.go
+++ b/cmd/kuke/restart/restart_test.go
@@ -351,7 +351,9 @@ func TestRestartCmd(t *testing.T) {
 }
 
 // TestRestartCmd_RejectsCellSubcommand pins the hard CLI break: `kuke restart cell <name>`
-// must fail with cobra's unknown-command error after the collapse.
+// must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
+// after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
+// subcommand list, so cobra's unknown-command path no longer fires.
 func TestRestartCmd_RejectsCellSubcommand(t *testing.T) {
 	cmd := restartpkg.NewRestartCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/kuke/start/start_test.go
+++ b/cmd/kuke/start/start_test.go
@@ -152,7 +152,9 @@ func TestStartCmd(t *testing.T) {
 }
 
 // TestStartCmd_RejectsCellSubcommand pins the hard CLI break: `kuke start cell <name>`
-// must fail with cobra's unknown-command error after the collapse.
+// must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
+// after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
+// subcommand list, so cobra's unknown-command path no longer fires.
 func TestStartCmd_RejectsCellSubcommand(t *testing.T) {
 	cmd := startpkg.NewStartCmd()
 	buf := &bytes.Buffer{}

--- a/cmd/kuke/stop/stop_test.go
+++ b/cmd/kuke/stop/stop_test.go
@@ -156,7 +156,9 @@ func TestStopCmd(t *testing.T) {
 }
 
 // TestStopCmd_RejectsCellSubcommand pins the hard CLI break: `kuke stop cell <name>`
-// must fail with cobra's unknown-command error after the collapse.
+// must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
+// after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
+// subcommand list, so cobra's unknown-command path no longer fires.
 func TestStopCmd_RejectsCellSubcommand(t *testing.T) {
 	cmd := stoppkg.NewStopCmd()
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
## Summary
- Reword the four `Test<Verb>Cmd_RejectsCellSubcommand` doc-comments (`start`, `stop`, `kill`, `restart`) to reference cobra's Args-validation error (`accepts 1 arg(s), received 2`) instead of the "unknown-command error" they previously named. Per #1033's AC-interpretation note, after the verb-collapse to a leaf with `cobra.ExactArgs(1)` and no subcommand list, cobra's unknown-command path no longer fires; the actual outcome is the Args-validation error.
- Test bodies are unchanged (they assert only `err != nil`); the wrong-error wording would have misled anyone tightening the assertion to match on the wrong string.

## Test plan
- [x] `make test` — clean (`go test ./...` plus `cmd/kukebuild`, `TEST-EXIT=0`).
- [x] Comment-only diff (4 files, +12/-4 lines); no executable code, test assertion, config, or behavior text changes. Qualifies for the trivial-edit shortcut per dev CLAUDE.md.

## Acceptance criteria
- [x] `cmd/kuke/start/start_test.go:154-156` doc-comment references cobra's Args-validation error.
- [x] `cmd/kuke/stop/stop_test.go:158-160` doc-comment references cobra's Args-validation error.
- [x] `cmd/kuke/kill/kill_test.go:157-159` doc-comment references cobra's Args-validation error.
- [x] `cmd/kuke/restart/restart_test.go:353-355` doc-comment references cobra's Args-validation error.

Closes #1040