### PR TITLE
fix(teamsource): strip URL credentials from runGit error wrapper

### DIFF
--- a/internal/teamsource/teamsource.go
+++ b/internal/teamsource/teamsource.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -323,12 +324,41 @@ func runGit(ctx context.Context, dir string, args ...string) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		trimmed := strings.TrimSpace(string(out))
+		// Scrub URL userinfo from args before joining into the wrapper — an
+		// operator may embed basic-auth credentials in a TeamsConfig source URL
+		// (e.g. https://x-token:ghp_xxx@host/repo.git) and a raw join would
+		// leak the token through any surface that prints this error.
+		scrubbed := strings.Join(scrubArgs(args), " ")
 		if trimmed != "" {
-			return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, trimmed)
+			return fmt.Errorf("git %s: %w: %s", scrubbed, err, trimmed)
 		}
-		return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+		return fmt.Errorf("git %s: %w", scrubbed, err)
 	}
 	return nil
+}
+
+// scrubArgs returns a copy of args with URL userinfo (basic-auth user:password
+// and bare tokens) redacted from any arg that parses as an absolute URL.
+// Non-URL args (flags, version refs, paths) pass through unchanged.
+func scrubArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		out[i] = scrubURLCredentials(a)
+	}
+	return out
+}
+
+// scrubURLCredentials strips the userinfo component from arg when it parses as
+// an absolute URL carrying one. Args that aren't URL-shaped (no scheme) or
+// carry no userinfo are returned verbatim — the goal is targeted redaction of
+// the http(s)/ssh credential-bearing surface, not aggressive rewriting.
+func scrubURLCredentials(arg string) string {
+	u, err := url.Parse(arg)
+	if err != nil || u.Scheme == "" || u.User == nil {
+		return arg
+	}
+	u.User = nil
+	return u.String()
 }
 
 // gitEnv returns the operator's environment augmented with non-interactive

--- a/internal/teamsource/teamsource_test.go
+++ b/internal/teamsource/teamsource_test.go
@@ -437,6 +437,63 @@ func TestLoadImageCatalog_WrongKindNamesPath(t *testing.T) {
 	}
 }
 
+func TestScrubURLCredentials(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "basic-auth-token",
+			in:   "https://x-token:ghp_xxx@github.com/owner/agents.git",
+			want: "https://github.com/owner/agents.git",
+		},
+		{
+			name: "user-only",
+			in:   "https://bob@github.com/owner/agents.git",
+			want: "https://github.com/owner/agents.git",
+		},
+		{
+			name: "ssh-with-password",
+			in:   "ssh://git:secret@github.com/owner/agents.git",
+			want: "ssh://github.com/owner/agents.git",
+		},
+		{
+			name: "https-no-userinfo-unchanged",
+			in:   "https://github.com/owner/agents.git",
+			want: "https://github.com/owner/agents.git",
+		},
+		{
+			name: "scp-style-unchanged",
+			in:   "git@github.com:owner/agents.git",
+			want: "git@github.com:owner/agents.git",
+		},
+		{
+			name: "flag-unchanged",
+			in:   "--depth=1",
+			want: "--depth=1",
+		},
+		{
+			name: "branch-name-unchanged",
+			in:   "v1.4.0",
+			want: "v1.4.0",
+		},
+		{
+			name: "file-url-unchanged",
+			in:   "file:///tmp/agents-fixture",
+			want: "file:///tmp/agents-fixture",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := scrubURLCredentials(tc.in); got != tc.want {
+				t.Errorf("scrubURLCredentials(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadRole_MissingFileNamesPath(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Scrub `userinfo` from URL-shaped args before joining them into `runGit`'s error wrapper, so a failed clone against a TeamsConfig source URL with embedded basic-auth credentials (e.g. `https://x-token:ghp_xxx@host/repo.git`) never leaks the token through whatever surface step 3 exposes (CLI stderr, log, daemon journal).
- New `scrubURLCredentials` helper uses `net/url`: an arg is rewritten only when it parses as an absolute URL (non-empty `Scheme`) and carries `userinfo`. Non-URL args (flags like `--depth=1`, version refs like `v1.4.0`, SCP-style refs like `git@github.com:owner/repo.git`) pass through unchanged.
- Stripping is total (`u.User = nil`) — drops both username and password rather than only the password, since usernames in tokenized URLs are routinely the secret-bearing field (`x-access-token`, `oauth2`) and there is no diagnostic value to preserving them in error text.

## Test plan
- [x] `make test` (root + kukebuild modules) — all green.
- [x] New `TestScrubURLCredentials` table covers: basic-auth + token, user-only, ssh-with-password, plain https (no userinfo, unchanged), SCP-style (unchanged), flag (unchanged), branch name (unchanged), `file://` URL (unchanged).
- [ ] Integration test driving `runGit` to a real failure with embedded credentials — deliberately omitted: git's stderr URL redaction varies by version (some versions print the user portion alongside an `x-oauth-basic`-style redacted password), which would make the assertion git-version-dependent without strengthening the scrub guarantee. The unit test covers the scrub logic; the wiring into `runGit` is a one-line call right at the wrapper site.

Closes #1047