### PR TITLE
fix(cli): rewrite stale `kuke <verb> cell` pointers to positional form

### DIFF
--- a/cmd/kuke/apply/apply.go
+++ b/cmd/kuke/apply/apply.go
@@ -38,7 +38,7 @@ const (
 // NewApplyCmd builds the `kuke apply` cobra command. `-f` reads a multi-document
 // YAML stream from disk or stdin — the sole shape `apply` supports. The
 // daemon-side reconcile-by-ref forms (`-b`/`-c`) were retired under #819; the
-// equivalent operator workflow is `kuke restart cell <name>` (which sees
+// equivalent operator workflow is `kuke restart <name>` (which sees
 // OutOfSync on Config-lineage cells and reconciles implicitly).
 func NewApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/kuke/attach/attach_test.go
+++ b/cmd/kuke/attach/attach_test.go
@@ -689,8 +689,8 @@ func TestAttach_Stopped_PointsAtStart(t *testing.T) {
 	if got := err.Error(); !strings.Contains(got, "Stopped") {
 		t.Errorf("error %q missing %q state name", got, "Stopped")
 	}
-	if got := err.Error(); !strings.Contains(got, "kuke start cell kukeon-pm-0") {
-		t.Errorf("error %q missing `kuke start cell kukeon-pm-0` recovery pointer", got)
+	if got := err.Error(); !strings.Contains(got, "kuke start kukeon-pm-0") {
+		t.Errorf("error %q missing `kuke start kukeon-pm-0` recovery pointer", got)
 	}
 	if attachCalls != 0 {
 		t.Errorf("AttachContainer called %d times, want 0 (must not dial dead socket)", attachCalls)

--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -60,7 +60,7 @@ func NewCellCmd() *cobra.Command {
 			"`kuke start <name>` to start it. Differs from `kuke run <cfg>` " +
 			"(materialise + start + attach) by leaving the cell stopped; later " +
 			"reconcile against the lineage Config flows through " +
-			"`kuke restart cell <name>` (OutOfSync-driven, #821) once the cell is " +
+			"`kuke restart <name>` (OutOfSync-driven, #821) once the cell is " +
 			"started.\n\n" +
 			"--from-blueprint and --from-config are mutually exclusive. --param " +
 			"and --param-file are valid with --from-blueprint (mirroring " +
@@ -333,7 +333,7 @@ func materialiseAndPersist(cmd *cobra.Command, client kukeonv1.Client, cellDoc v
 		return fmt.Errorf(
 			"cell %q already exists in realm=%q space=%q stack=%q; "+
 				"delete it with `kuke delete cell %s` (or, for Config-lineage cells, "+
-				"reconcile via `kuke start cell %s` + `kuke restart cell %s`) before re-materialising",
+				"reconcile via `kuke start %s` + `kuke restart %s`) before re-materialising",
 			cellDoc.Metadata.Name,
 			cellDoc.Spec.RealmID, cellDoc.Spec.SpaceID, cellDoc.Spec.StackID,
 			cellDoc.Metadata.Name, cellDoc.Metadata.Name, cellDoc.Metadata.Name,

--- a/cmd/kuke/kill/kill_test.go
+++ b/cmd/kuke/kill/kill_test.go
@@ -154,7 +154,7 @@ func TestKillCmd(t *testing.T) {
 	}
 }
 
-// TestKillCmd_RejectsCellSubcommand pins the hard CLI break: `kuke kill cell <name>`
+// TestKillCmd_RejectsCellSubcommand pins the hard CLI break: the `kill cell <name>` subcommand form
 // must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
 // after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
 // subcommand list, so cobra's unknown-command path no longer fires.

--- a/cmd/kuke/restart/restart_test.go
+++ b/cmd/kuke/restart/restart_test.go
@@ -350,7 +350,7 @@ func TestRestartCmd(t *testing.T) {
 	}
 }
 
-// TestRestartCmd_RejectsCellSubcommand pins the hard CLI break: `kuke restart cell <name>`
+// TestRestartCmd_RejectsCellSubcommand pins the hard CLI break: the `restart cell <name>` subcommand form
 // must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
 // after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
 // subcommand list, so cobra's unknown-command path no longer fires.

--- a/cmd/kuke/run/divergence_idempotency_test.go
+++ b/cmd/kuke/run/divergence_idempotency_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // TestDivergedFields_MaterializePersistMaterializeIsIdempotent guards the
-// invariant that `kuke restart cell` writes a spec to disk that — when
+// invariant that `kuke restart` writes a spec to disk that — when
 // re-materialised by the next `kuke run <config>` — compares clean against
 // the persisted version (issue #984). The flow being asserted:
 //
@@ -68,7 +68,7 @@ func TestDivergedFields_MaterializePersistMaterializeIsIdempotent(t *testing.T) 
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Step 1: Materialize what `kuke restart cell` would push through
+			// Step 1: Materialize what `kuke restart` would push through
 			// ApplyDocuments.
 			cell1, err := cellconfig.Materialize(tc.cfg, tc.bp)
 			if err != nil {

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -85,12 +85,12 @@ func NewRunCmd() *cobra.Command {
 			"subsequent runs (idempotent). When the live cell's spec differs from the " +
 			"materialisation of the current Config + Blueprint, the positional config " +
 			"path refuses to attach and points the operator at " +
-			"`kuke restart cell <cell>` to reconcile (the daemon's OutOfSync detector " +
+			"`kuke restart <cell>` to reconcile (the daemon's OutOfSync detector " +
 			"picks up the Config divergence and the restart reconciles implicitly: " +
 			"stops, updates, starts). -b with --name applies the same divergence " +
 			"discipline against the pinned cell name, but -b-lineage cells have no " +
 			"implicit reconcile — the pointer is `kuke delete cell <cell>` + re-run " +
-			"(or promote to a CellConfig for `kuke restart cell` reconcile workflows). " +
+			"(or promote to a CellConfig for `kuke restart` reconcile workflows). " +
 			"--new on the " +
 			"positional config path materializes a fresh `<config-name>-<6hex>` cell on " +
 			"every invocation instead — opt-in fire-and-forget sandboxes from a " +
@@ -699,7 +699,7 @@ func runAfterReuseClaim(
 // --require-synced; the function then returns the pre-#986 refusal error
 // shape (same per-source pointer the notice cites).
 //
-// The pointer per source: `<config>` → `kuke restart cell <name>` (#821's
+// The pointer per source: `<config>` → `kuke restart <name>` (#821's
 // restart picks up the daemon-side OutOfSync detection #820 wires and
 // reconciles implicitly; the cell name is the Config's StableName), `-b --name
 // <cell>` → `kuke delete cell <cell>` + re-run (Blueprint-lineage cells have
@@ -735,13 +735,13 @@ func divergentSourcePointer(cellDoc v1beta1.CellDoc, flags runFlags) (source, po
 	switch {
 	case flags.configName != "" && !flags.newCell:
 		return fmt.Sprintf("CellConfig %q", flags.configName),
-			fmt.Sprintf("run `kuke restart cell %s` to reconcile (stops, updates, starts)",
+			fmt.Sprintf("run `kuke restart %s` to reconcile (stops, updates, starts)",
 				cellDoc.Metadata.Name)
 	case flags.blueprintName != "" && flags.nameOverride != "":
 		return fmt.Sprintf("CellBlueprint %q", flags.blueprintName),
 			fmt.Sprintf("-b cells have no in-place reconcile; delete it with "+
 				"`kuke delete cell %s` and re-run (or promote to a CellConfig for "+
-				"`kuke restart cell` reconcile workflows)", cellDoc.Metadata.Name)
+				"`kuke restart` reconcile workflows)", cellDoc.Metadata.Name)
 	default:
 		return "on-disk spec",
 			"use `kuke apply -f` to update"
@@ -1289,7 +1289,7 @@ func pickLocation(fromDoc string, kv *config.Var) string {
 // Each entry is shaped `<path> (actual=<v>, desired=<v>)` so the reject error
 // surfaces both sides verbatim — without this, an operator hitting a false
 // positive (e.g. issue #984 — `kuke run <config>` rejecting immediately after
-// a successful `kuke restart cell` per the OutOfSync reconcile path) has no
+// a successful `kuke restart` per the OutOfSync reconcile path) has no
 // way to tell which side of the comparison normalised differently from the
 // other. Test assertions on the field path itself (e.g.
 // `spec.containers["main"].image`) still match because the path prefix is

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1124,7 +1124,7 @@ func TestRun_ExistingCell_DivergingContainerSecrets_RequireSynced_RefusesAndPoin
 // on each conversion, so the YAML-decoded side and the daemon-persisted
 // side are always address-distinct even when value-equal — every
 // re-`kuke run` of a secretRef:-using cell tripped the divergence guard
-// and printed the `kuke restart cell ...` pointer.
+// and printed the `kuke restart ...` pointer.
 //
 // The sibling Diverging... test above only exercises FromFile (pointer-free
 // fields), so the pointer-identity bug escaped review. This test puts a
@@ -2768,7 +2768,7 @@ func TestRun_FromConfig_DivergentSpec_RequireSynced_RefusesAndPointsToApply(t *t
 	// Simulate divergence by returning a Ready cell whose container image
 	// disagrees with what Materialize(cfg, bp) would build. With
 	// --require-synced (#986) the -c contract reverts to the pre-#986
-	// default: refuse with a `kuke restart cell <name>` pointer (#844
+	// default: refuse with a `kuke restart <name>` pointer (#844
 	// retargeted the pointer onto the post-#823 surface), not warn-and-attach
 	// — CreateCell/StartCell must not fire. The default warn-and-attach
 	// behaviour is covered by TestRun_FromConfig_DivergentSpec_Default_WarnsAndAttaches.
@@ -2817,7 +2817,7 @@ func TestRun_FromConfig_DivergentSpec_RequireSynced_RefusesAndPointsToApply(t *t
 		`live cell "prod" spec differs from CellConfig "prod"`,
 		`spec.containers["main"].image`,
 		"refusing to attach (--require-synced)",
-		"kuke restart cell prod",
+		"kuke restart prod",
 		"reconcile",
 	} {
 		if !strings.Contains(err.Error(), want) {
@@ -2939,7 +2939,7 @@ func TestRun_FromConfig_DivergentSpec_Default_WarnsAndAttaches(t *testing.T) {
 		`notice: cell "prod" is OutOfSync with CellConfig "prod"`,
 		`spec.containers["main"].image`,
 		"attaching to current live state",
-		"kuke restart cell prod",
+		"kuke restart prod",
 	} {
 		if !strings.Contains(output, want) {
 			t.Errorf("output missing substring %q:\n%s", want, output)
@@ -2954,8 +2954,8 @@ func TestRun_FromConfig_DivergentSpec_Default_WarnsAndAttaches(t *testing.T) {
 // TestRun_FromBlueprint_NamedDivergent_Default_WarnsAndAttaches is the
 // `-b --name` half of the #986 warn-and-attach default. The notice cites
 // the CellBlueprint source and the delete-then-rerun pointer (Blueprint-
-// lineage cells have no in-place reconcile) instead of the `kuke restart
-// cell` pointer the `<config>` branch uses, but the fall-through behaviour
+// lineage cells have no in-place reconcile) instead of the `kuke restart`
+// pointer the `<config>` branch uses, but the fall-through behaviour
 // is identical: CreateCell/StartCell stay at 0 and the operator lands in
 // the live cell.
 func TestRun_FromBlueprint_NamedDivergent_Default_WarnsAndAttaches(t *testing.T) {

--- a/cmd/kuke/shared/cell_liveness.go
+++ b/cmd/kuke/shared/cell_liveness.go
@@ -44,7 +44,7 @@ import (
 //     containerd slate.
 //   - Stopped → the reconciler's wind-down (`refresh.go windDownCell`)
 //     has reaped the work container after its kuketty exited, so the
-//     attach socket inode is orphaned. Recovery is `kuke start cell` —
+//     attach socket inode is orphaned. Recovery is `kuke start` —
 //     the cell metadata is intact, so a restart re-binds kuketty
 //     against a fresh inode.
 //   - Pending / Failed / Unknown → no clean attach path. Same recovery
@@ -79,7 +79,7 @@ func GuardCellTaskLiveness(get kukeonv1.GetCellResult, cellName string) error {
 	case v1beta1.CellStateStopped:
 		return fmt.Errorf(
 			"cell %q is in state Stopped (no work container is running); "+
-				"start it first with `kuke start cell %s`",
+				"start it first with `kuke start %s`",
 			cellName, cellName,
 		)
 	default:

--- a/cmd/kuke/shared/cell_liveness_test.go
+++ b/cmd/kuke/shared/cell_liveness_test.go
@@ -85,7 +85,7 @@ func TestGuardCellTaskLiveness_NotCreated_PointsAtRun(t *testing.T) {
 // motivated #852: the wind-down flow leaves the cell at Stopped with an
 // orphan socket inode, and the guard previously short-circuited on any
 // non-Ready state. The new branch must surface the "start it first"
-// pointer so the operator's next move is `kuke start cell`, not
+// pointer so the operator's next move is `kuke start`, not
 // `connection refused` on the next dial.
 func TestGuardCellTaskLiveness_Stopped_PointsAtStart(t *testing.T) {
 	get := readyGet()
@@ -99,8 +99,8 @@ func TestGuardCellTaskLiveness_Stopped_PointsAtStart(t *testing.T) {
 	if got := err.Error(); !strings.Contains(got, "Stopped") {
 		t.Errorf("error %q missing %q state name", got, "Stopped")
 	}
-	if got := err.Error(); !strings.Contains(got, "kuke start cell kukeon-pm-0") {
-		t.Errorf("error %q missing `kuke start cell kukeon-pm-0` recovery pointer", got)
+	if got := err.Error(); !strings.Contains(got, "kuke start kukeon-pm-0") {
+		t.Errorf("error %q missing `kuke start kukeon-pm-0` recovery pointer", got)
 	}
 }
 

--- a/cmd/kuke/start/start_test.go
+++ b/cmd/kuke/start/start_test.go
@@ -151,7 +151,7 @@ func TestStartCmd(t *testing.T) {
 	}
 }
 
-// TestStartCmd_RejectsCellSubcommand pins the hard CLI break: `kuke start cell <name>`
+// TestStartCmd_RejectsCellSubcommand pins the hard CLI break: the `start cell <name>` subcommand form
 // must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
 // after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
 // subcommand list, so cobra's unknown-command path no longer fires.

--- a/cmd/kuke/stop/stop_test.go
+++ b/cmd/kuke/stop/stop_test.go
@@ -155,7 +155,7 @@ func TestStopCmd(t *testing.T) {
 	}
 }
 
-// TestStopCmd_RejectsCellSubcommand pins the hard CLI break: `kuke stop cell <name>`
+// TestStopCmd_RejectsCellSubcommand pins the hard CLI break: the `stop cell <name>` subcommand form
 // must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
 // after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
 // subcommand list, so cobra's unknown-command path no longer fires.

--- a/internal/cellconfig/cellconfig.go
+++ b/internal/cellconfig/cellconfig.go
@@ -57,7 +57,7 @@ const AnnotationSourceConfig = "kukeon.io/source-config"
 // config's values; #753's refuse-on-divergence behavior relies on the stable
 // name so `kuke run <config>` finds the same live cell across invocations
 // whether it attaches (clean spec match) or refuses with a
-// `kuke restart cell <name>` pointer. A value-hashed suffix would change the
+// `kuke restart <name>` pointer. A value-hashed suffix would change the
 // derived name on every value edit,
 // spawning a fresh cell and orphaning the old one — defeating the idempotent
 // identity that distinguishes a Config (`run -c`) from a Blueprint's

--- a/internal/controller/apply/reconcile.go
+++ b/internal/controller/apply/reconcile.go
@@ -349,7 +349,7 @@ func ReconcileCell(r runner.Runner, desired intmodel.Cell) (ReconcileResult, err
 	diff := DiffCell(desired, actual)
 	if !diff.HasChanges {
 		// Spec is in sync, but the cell's runtime may have been torn down
-		// out of band — typically by `kuke kill cell`, which leaves the
+		// out of band — typically by `kuke kill`, which leaves the
 		// cell document intact and flips Status.State to Stopped. Without
 		// this branch, apply walks away reporting "unchanged" and the cell
 		// stays Stopped forever (issue #486 — docs/cli-use-cases.md's
@@ -892,7 +892,7 @@ type ReconcileResult struct {
 // cellNeedsRematerialize reports whether a spec-equal cell still needs
 // runtime work because its containers were torn down out of band. Today
 // this fires for CellStateStopped — the state runner.KillCell persists
-// after `kuke kill cell` removes the cell's containers. Failed, Pending,
+// after `kuke kill` removes the cell's containers. Failed, Pending,
 // and Unknown intentionally do not trigger re-materialize: Failed is
 // sticky and signals a startup problem the user should investigate;
 // Pending and Unknown are mid-lifecycle states the daemon reconciler

--- a/internal/controller/apply_rematerialize_test.go
+++ b/internal/controller/apply_rematerialize_test.go
@@ -34,7 +34,7 @@ import (
 // the diff returns no changes and apply walks away with `unchanged` while
 // the cell stays Stopped forever — the divergent-state regression the
 // docs/cli-use-cases.md "apply (declarative, multi-document)" section
-// names by example (`kuke kill cell` then `kuke apply`).
+// names by example (`kuke kill` then `kuke apply`).
 func TestReconcileCell_RematerializesStoppedCell(t *testing.T) {
 	desired := buildTestCell("test-cell", "test-realm", "test-space", "test-stack")
 	desired.Spec.Containers = []intmodel.ContainerSpec{

--- a/internal/controller/create_cell.go
+++ b/internal/controller/create_cell.go
@@ -67,7 +67,7 @@ func (b *Exec) CreateCell(cell intmodel.Cell) (CreateCellResult, error) {
 // to start it. Used by the CLI's `kuke create cell --from-blueprint` and
 // `--from-config` scaffolding modes (#818) — distinct from `kuke run -b` /
 // `kuke run <cfg>` (materialise + start + attach) and (for Config-lineage
-// cells) `kuke restart cell <name>` (reconcile + start on OutOfSync).
+// cells) `kuke restart <name>` (reconcile + start on OutOfSync).
 func (b *Exec) MaterializeCell(cell intmodel.Cell) (CreateCellResult, error) {
 	return b.createCellInternal(cell, false)
 }

--- a/internal/controller/reconcile_outofsync.go
+++ b/internal/controller/reconcile_outofsync.go
@@ -55,7 +55,7 @@ const (
 //   - OutOfSync = false with OutOfSyncError set when divergence is
 //     undecidable — referenced Blueprint missing, slot-fill validation
 //     failure, or any other materialization error. Distinct from OutOfSync
-//     so downstream verbs (`kuke get cell` SYNC column, `kuke restart cell
+//     so downstream verbs (`kuke get cell` SYNC column, `kuke restart
 //     <name>`) can route the error case separately from a routine drift.
 //
 // Persists via runner.UpdateCellMetadata only when any of the three fields
@@ -227,7 +227,7 @@ func materializeCellFromConfig(
 // outOfSyncSpecDifferReason renders the DiffCell verdict as a stable,
 // human-readable one-line summary suitable for the OutOfSyncReason status
 // field. Always starts with "spec differs" so downstream parsers (a
-// future `kuke get cell` SYNC column, the `kuke restart cell` verb) can
+// future `kuke get cell` SYNC column, the `kuke restart` verb) can
 // recognize the divergence class without parsing the full diff payload.
 // Field paths are sorted so the same diff produces the same reason
 // across ticks, keeping the persisted status stable.

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -734,7 +734,7 @@ func removeAttachableSocketSymlink(runPath string, spec intmodel.ContainerSpec) 
 // symlink (under <RunPath>/s/) and the host-side socket inode (the deep
 // bind-mount source path kuketty binds inside the container) for an
 // Attachable container. Called on every clean teardown of a cell —
-// `kuke stop cell`, `kuke kill cell`, and the reconciler's wind-down
+// `kuke stop`, `kuke kill`, and the reconciler's wind-down
 // (#852). Defense-in-depth complement to the client- and server-side
 // task-liveness guards: when a kuketty exits and never restarts (cell
 // wound down, daemon restart, host reboot), the inode it bound persists

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -345,7 +345,7 @@ func (r *Exec) KillContainer(cell intmodel.Cell, containerID string) error {
 	// Root container cannot be killed directly - it must be killed by killing the cell
 	if foundContainerSpec.Root {
 		return fmt.Errorf(
-			"root container cannot be killed directly, kill the cell instead using 'kuke kill cell %s'",
+			"root container cannot be killed directly, kill the cell instead using 'kuke kill %s'",
 			cellName,
 		)
 	}

--- a/internal/controller/runner/reconcile_heal_test.go
+++ b/internal/controller/runner/reconcile_heal_test.go
@@ -41,9 +41,9 @@ import (
 // guard: a cell whose cgroup the host reboot wiped — metadata survives, the
 // ReadyObserved latch is still true — must have its cgroup re-created and
 // its subtree controllers re-asserted by the reconcile loop within one
-// tick, without an operator running `kuke start cell <name>` per cell.
-// Pre-fix the loop's ExistsCgroup result was discarded; only `kuke start
-// cell` could heal the missing cgroup.
+// tick, without an operator running `kuke start <name>` per cell.
+// Pre-fix the loop's ExistsCgroup result was discarded; only `kuke start`
+// could heal the missing cgroup.
 func TestReconcileCell_HealsWipedCgroupWhenReadyObserved(t *testing.T) {
 	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
 	rootID := "root"

--- a/internal/controller/runner/refresh.go
+++ b/internal/controller/runner/refresh.go
@@ -684,7 +684,7 @@ func (r *Exec) ReconcileCell(cell intmodel.Cell) (intmodel.Cell, ReconcileOutcom
 
 	// Heal a wiped cell cgroup on the reconcile path so cells whose cgroup
 	// the host reboot wiped (#854) recover without an operator running
-	// `kuke start cell <name>` per cell. Gated on the persisted
+	// `kuke start <name>` per cell. Gated on the persisted
 	// ReadyObserved latch so a half-CreateCell that crashed before the
 	// cell ever reached Ready is not promoted by the re-ensure — that
 	// in-flight CreateCell will finish its own ensureCellCgroup path under

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -1296,7 +1296,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	// Root container cannot be started directly - it must be started by starting the cell
 	if foundContainerSpec.Root {
 		return intmodel.Cell{}, fmt.Errorf(
-			"root container cannot be started directly, start the cell instead using 'kuke start cell %s'",
+			"root container cannot be started directly, start the cell instead using 'kuke start %s'",
 			cellName,
 		)
 	}
@@ -1318,7 +1318,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	if err != nil {
 		if errors.Is(err, internalerrdefs.ErrContainerNotFound) {
 			return intmodel.Cell{}, fmt.Errorf(
-				"root container %q does not exist, start the cell first using 'kuke start cell %s': %w",
+				"root container %q does not exist, start the cell first using 'kuke start %s': %w",
 				rootContainerID,
 				cellName,
 				err,
@@ -1333,7 +1333,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 		// Check if task doesn't exist
 		if errdefs.IsNotFound(err) {
 			return intmodel.Cell{}, fmt.Errorf(
-				"root container %q exists but has no task, start the cell first using 'kuke start cell %s': %w",
+				"root container %q exists but has no task, start the cell first using 'kuke start %s': %w",
 				rootContainerID,
 				cellName,
 				err,

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -374,7 +374,7 @@ func (r *Exec) StopContainer(cell intmodel.Cell, containerID string) error {
 	// Root container cannot be stopped directly - it must be stopped by stopping the cell
 	if foundContainerSpec.Root {
 		return fmt.Errorf(
-			"root container cannot be stopped directly, stop the cell instead using 'kuke stop cell %s'",
+			"root container cannot be stopped directly, stop the cell instead using 'kuke stop %s'",
 			cellName,
 		)
 	}

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -33,8 +33,8 @@ type StartCellResult struct {
 //
 // For a Config-lineage cell whose persisted Status.OutOfSync is true, StartCell
 // first re-materialises the cell's spec from its lineage Config + Blueprint and
-// rebuilds the containerd records, so `kuke stop cell` followed by `kuke start
-// cell` produces the same end state as `kuke restart cell` on an OutOfSync
+// rebuilds the containerd records, so `kuke stop` followed by `kuke start`
+// produces the same end state as `kuke restart` on an OutOfSync
 // cell — issue #983. The reapply is daemon-side so every client that issues
 // StartCell (CLI, future API consumers) gets the reconcile-on-start behaviour.
 func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {

--- a/internal/controller/start_cell_reapply_test.go
+++ b/internal/controller/start_cell_reapply_test.go
@@ -17,10 +17,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Tests for the daemon-side OutOfSync reapply on StartCell — issue #983.
-// `kuke stop cell` + `kuke start cell` on a Config-lineage OutOfSync cell must
-// produce the same end state as `kuke restart cell` on the same cell. The
+// `kuke stop` + `kuke start` on a Config-lineage OutOfSync cell must
+// produce the same end state as `kuke restart` on the same cell. The
 // reapply lives in controller.StartCell so every client that issues StartCell
-// (CLI `kuke start cell`, `kuke run` on existing-Stopped, future API
+// (CLI `kuke start`, `kuke run` on existing-Stopped, future API
 // consumers) inherits the reconcile-on-start behaviour.
 
 package controller_test
@@ -328,7 +328,7 @@ func TestStartCell_OutOfSyncReapply_LineageConfigDeletedFallsThrough(t *testing.
 // TestStartCell_OutOfSyncReapply_RecreateErrorFallsThrough covers the
 // graceful degradation: if RecreateCell fails (e.g. containerd unreachable),
 // reapply logs and falls back to the on-disk spec via runner.StartCell so the
-// operator's `kuke start cell` request is honored.
+// operator's `kuke start` request is honored.
 func TestStartCell_OutOfSyncReapply_RecreateErrorFallsThrough(t *testing.T) {
 	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
 


### PR DESCRIPTION
## Summary

- After #1033 collapsed the lifecycle verbs from `kuke <verb> cell <name>` to positional `kuke <verb> <name>`, several user-facing strings still recommended the dropped form — following them now fails with cobra's unknown-command / arg-count error. This sweeps every such stale **pointer** in `cmd/` + `internal/` to the positional form.
- Production strings rewritten: `kuke run --help` / `kuke create cell --help` Long text, the `kuke run` OutOfSync divergence notice (`kuke restart <name>`), the `kuke create cell` re-materialisation error, the Stopped-cell attach pointer (`cell_liveness.go`), and the root-container-direct start/stop/kill guidance errors (`runner/{start,stop,kill}.go`).
- Doc/test comments swept for grep + future-reader convergence; the two `run_test.go` assertions and the `cell_liveness_test.go`/`attach_test.go` recovery-pointer assertions that pinned the old notice text updated alongside the production strings.

## Scope deviation from the issue's enumerated list (documented per dev/CLAUDE.md)

The issue enumerated only `run.go` + `create/cell.go` production strings, but its verification AC requires `grep -n "kuke \(start\|stop\|kill\|restart\) cell" -- cmd/ internal/ pkg/` to return **zero** hits. Running that grep on `main` surfaced same-class stale pointers the enumeration omitted, plus four occurrences that legitimately document the *rejected* form. I posted a [heads-up comment](https://github.com/eminwux/kukeon/issues/1053#issuecomment-4623766419) and proceeded with the zero-hits-honoring reading:

- **Also rewritten (same bug class, not enumerated):** `cmd/kuke/shared/cell_liveness.go:82`, `internal/controller/runner/start.go:1299/1321/1336`, `runner/stop.go:377`, `runner/kill.go:348` — all production error strings that emitted now-broken commands.
- **`Test*Cmd_RejectsCellSubcommand` comments** (`cmd/kuke/{start,stop,kill,restart}/*_test.go`) quote `kuke <verb> cell <name>` as the form that *must fail*. Naively rewriting would invert their meaning, so they were minimally reworded to drop the `kuke ` prefix (`the \`start cell <name>\` subcommand form must fail …`) — still accurate, no longer a grep false-positive.
- **Out of scope (deliberately untouched):** `kuke delete cell` references — #1033 collapsed only start/stop/kill/restart; `delete cell` is still a valid form (own `cmd/kuke/delete/cell/` package, asserted by `cell_liveness_test.go`).

Post-fix, `grep -n "kuke \(start\|stop\|kill\|restart\) cell" -- cmd/ internal/ pkg/` returns **zero** hits (verified; tree-wide `git grep` over non-docs files also clean — docs are #1052's lane).

## Test plan

- [x] `make test` — exit 0, all packages pass (includes the updated assertions in `run_test.go`, `cell_liveness_test.go`, `attach_test.go`)
- [x] `GOWORK=off go build ./...` — exit 0
- [x] AC grep `grep -n "kuke \(start\|stop\|kill\|restart\) cell" -- cmd/ internal/ pkg/` returns zero hits
- [ ] `make dev-init` smoke — not run: this is a string-literal-only change (no build-path or daemon-logic change), and none of the rewritten error/help strings lie on the dev-init parity + attach happy path (they are root-container-direct ops, Stopped-cell attach, and OutOfSync-divergence paths). All changed strings are covered by the `make test` assertions above, which passed. No standalone containerd on the dev host.

Closes #1053