### PR TITLE
feat(team): structured ProjectTeam.source object with ref-aware cache

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -289,12 +289,8 @@ func emitSourceKind(out io.Writer, src model.TeamSource) {
 		return
 	}
 	host, ownerRepo := src.Normalized()
-	classification := "pinned"
-	if src.Floating() {
-		classification = "floating"
-	}
 	fmt.Fprintf(out, "agents source: %s/%s @ %s=%s (%s)\n",
-		host, ownerRepo, kind, value, classification)
+		host, ownerRepo, kind, value, src.KindLabel())
 }
 
 // loadOrScaffoldGlobalConfig returns the TeamsConfig the render pipeline

--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -180,6 +180,8 @@ func composeTeam(
 		return errdefs.ErrTeamMetadataNameRequired
 	}
 
+	emitSourceKind(out, pt.Spec.Source)
+
 	tc, scaffolded, err := loadOrScaffoldGlobalConfig(ctx, layout, getGit, dryRun)
 	if err != nil {
 		return err
@@ -202,13 +204,14 @@ func composeTeam(
 		return err
 	}
 
+	source := pt.Spec.Source
 	entry := &model.TeamEntry{
 		APIVersion: model.APIVersionV1,
 		Kind:       model.KindTeamEntry,
 		Metadata:   model.Metadata{Name: project},
 		Spec: model.TeamEntrySpec{
 			Path:   projectDir,
-			Source: strings.TrimSpace(pt.Spec.Source),
+			Source: &source,
 		},
 	}
 	if writeErr := teamhost.WriteEntry(layout, entry); writeErr != nil {
@@ -272,6 +275,26 @@ func emitApplySummary(
 	}
 	fmt.Fprintf(out, "applied %d blueprint/%d config object(s) to kukeond under team %q\n",
 		blueprints, configs, project)
+}
+
+// emitSourceKind prints the resolved agents source's pinned-vs-floating
+// classification, so a non-reproducible (floating-branch) roster is visible at
+// init time. The key name carries the intent — a tag/commit is pinned, a
+// branch floats — so this is derivable without interrogating git. A malformed
+// source (exactly-one-ref violated) prints nothing; the parser has already
+// rejected it upstream by the time render runs.
+func emitSourceKind(out io.Writer, src model.TeamSource) {
+	value, kind := src.Ref()
+	if kind == "" {
+		return
+	}
+	host, ownerRepo := src.Normalized()
+	classification := "pinned"
+	if src.Floating() {
+		classification = "floating"
+	}
+	fmt.Fprintf(out, "agents source: %s/%s @ %s=%s (%s)\n",
+		host, ownerRepo, kind, value, classification)
 }
 
 // loadOrScaffoldGlobalConfig returns the TeamsConfig the render pipeline

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -40,7 +40,7 @@ const projectTeamYAML = `apiVersion: kuketeams.io/v1
 kind: ProjectTeam
 metadata: { name: sbsh }
 spec:
-  source: eminwux/agents@v1.4.0
+  source: { repo: github.com/eminwux/agents, tag: v1.4.0 }
   roles:
     - { ref: dev }
 `
@@ -51,7 +51,7 @@ const projectTeamWithHarnessYAML = `apiVersion: kuketeams.io/v1
 kind: ProjectTeam
 metadata: { name: sbsh }
 spec:
-  source: eminwux/agents@v1.4.0
+  source: { repo: github.com/eminwux/agents, tag: v1.4.0 }
   defaults:
     harnesses: [claude]
   roles:
@@ -171,9 +171,11 @@ spec:
 	}
 	return &teamsource.Bundle{
 		Source: teamsource.Source{
-			Raw:       "eminwux/agents@v1.4.0",
+			Repo:      "github.com/eminwux/agents",
+			Host:      "github.com",
 			OwnerRepo: "eminwux/agents",
-			Version:   "v1.4.0",
+			Ref:       "v1.4.0",
+			Kind:      teamsource.RefTag,
 		},
 		CacheDir: cacheDir,
 		Roles: map[string]*model.Role{
@@ -300,11 +302,17 @@ func TestComposeTeamScaffoldsAndWrites(t *testing.T) {
 	if unmarshalErr := yaml.Unmarshal(rawEntry, &te); unmarshalErr != nil {
 		t.Fatalf("entry parse: %v", unmarshalErr)
 	}
-	if te.Metadata.Name != "sbsh" || te.Spec.Path != projectDir || te.Spec.Source != "eminwux/agents@v1.4.0" {
+	if te.Metadata.Name != "sbsh" || te.Spec.Path != projectDir || te.Spec.Source == nil ||
+		te.Spec.Source.Repo != "github.com/eminwux/agents" || te.Spec.Source.Tag != "v1.4.0" {
 		t.Errorf("entry content wrong: %+v", te)
 	}
 	if !strings.Contains(out.String(), "wrote team \"sbsh\"") {
 		t.Errorf("missing write confirmation in output: %q", out.String())
+	}
+	// The tag source is pinned — init must surface that so a non-reproducible
+	// (floating) roster would be visible.
+	if !strings.Contains(out.String(), "agents source: github.com/eminwux/agents @ tag=v1.4.0 (pinned)") {
+		t.Errorf("missing pinned-source line in output: %q", out.String())
 	}
 }
 
@@ -684,7 +692,7 @@ func TestComposeTeamTwoProjectsIndependent(t *testing.T) {
 kind: ProjectTeam
 metadata: { name: %s }
 spec:
-  source: eminwux/agents@v1.4.0
+  source: { repo: github.com/eminwux/agents, tag: v1.4.0 }
   defaults:
     harnesses: [claude]
   roles:
@@ -801,3 +809,39 @@ func TestNewTeamCmdRegistersInit(t *testing.T) {
 // silence the unused-import linter when v1beta1 is referenced only through
 // the rendered output bytes.
 var _ = v1beta1.LabelTeam
+
+func TestEmitSourceKind(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		src  model.TeamSource
+		want string
+	}{
+		{
+			"tag pinned",
+			model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
+			"agents source: github.com/eminwux/agents @ tag=v1.4.0 (pinned)\n",
+		},
+		{
+			"branch floating",
+			model.TeamSource{Repo: "eminwux/agents", Branch: "main"},
+			"agents source: github.com/eminwux/agents @ branch=main (floating)\n",
+		},
+		{
+			"commit pinned",
+			model.TeamSource{Repo: "gitlab.com/grp/repo", Commit: "9ae9606"},
+			"agents source: gitlab.com/grp/repo @ commit=9ae9606 (pinned)\n",
+		},
+		{"malformed prints nothing", model.TeamSource{Repo: "github.com/eminwux/agents"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var out bytes.Buffer
+			emitSourceKind(&out, tc.src)
+			if out.String() != tc.want {
+				t.Errorf("emitSourceKind = %q, want %q", out.String(), tc.want)
+			}
+		})
+	}
+}

--- a/docs/site/concepts/team.md
+++ b/docs/site/concepts/team.md
@@ -71,14 +71,31 @@ A `TeamsConfig.secrets` entry declares **where** its value is read from
 (`from: env` or `from: file`, plus a `key`), never an inline value. Secret bytes
 never live in a committed or operator file.
 
-### The version is the git pin, nothing else
+### The source ref is the version, nothing else
 
-Content versioning is carried **solely** by the `source: <owner>/<repo>@vX.Y.Z`
-git-tag pin. The `source` must be pinned to an exact version — a floating ref
-(`@main`) or a bare tag without a full version (`@v1`) is rejected. The agents
-kinds (`Role`, `Harness`, `ImageCatalog`) carry **no** in-file version field: it
-would be redundant with the pin, drift-prone, and per-release toil to bump
-across every role.
+Content versioning is carried **solely** by the structured `source` object: a
+host-explicit `repo` plus exactly one of `tag` / `branch` / `commit`. The key
+name **is** the intent — `tag` and `commit` pin to a reproducible ref, `branch`
+floats (it is refetched and reset to the branch tip on every `init`) — so
+pinned-vs-floating is unambiguous without interrogating git (a string `@ref`
+cannot tell a branch from a same-named tag). Exactly one of the three must be
+set; zero or multiple is a parse error, and the legacy
+`<owner>/<repo>@vX.Y.Z` **string** form is rejected with a migration error (no
+silent dual-parse). The agents kinds (`Role`, `Harness`, `ImageCatalog`) carry
+**no** in-file version field: it would be redundant with the ref, drift-prone,
+and per-release toil to bump across every role.
+
+`init` prints whether the resolved source is **pinned** or **floating**, so a
+non-reproducible roster is visible.
+
+### Transport: SSH by default, `sources` as an override
+
+The default clone transport is **SSH**: `repo: <host>/<owner>/<repo>` expands to
+`git@<host>:<owner>/<repo>.git`, cloned under `TeamsConfig.spec.git.sshKey` as
+the identity. A bare `<owner>/<repo>` defaults its host to `github.com`, but any
+host is expressible. `TeamsConfig.spec.sources` is **optional** — consult it only
+to override the transport (HTTPS/token, an internal mirror, a non-standard port);
+the common case needs no `sources` entry.
 
 ## The project is cloned, not mounted
 
@@ -90,8 +107,9 @@ clones the project fresh as a `ContainerRepo`. Consequences:
 - The project's clone URL is **not** declared in `kuketeam.yaml` — it is
   resolved from the local `git remote` at init time.
 - The project checks out **floating `main`** (it is the operator's own repo).
-  This is intentionally asymmetric with the **pinned-exact** agents `source`:
-  the roster travels with the project, the agents source is pinned.
+  The agents `source`, by contrast, declares its ref intent explicitly: a
+  pinned `tag`/`commit` for a reproducible roster, or a floating `branch` when
+  the project deliberately tracks a moving agents branch.
 - The operator's working tree is **not** mounted — uncommitted local work is
   invisible in the cell.
 
@@ -103,7 +121,7 @@ apiVersion: kuketeams.io/v1
 kind: ProjectTeam
 metadata: { name: sbsh }
 spec:
-  source: eminwux/agents@v1.4.0 # pinned exact
+  source: { repo: github.com/eminwux/agents, tag: v1.4.0 } # pinned (tag)
   defaults: { harnesses: [claude, opencode] }
   roles:
     - { ref: dev, needs: { image: [go] } }
@@ -121,11 +139,17 @@ spec:
     allowedSigners: ~/.ssh/allowed_signers
     sshKey: ~/.ssh/id_ed25519
   registry: registry.eminwux.com
+  # sources is an optional transport override (HTTPS mirror, token, custom port);
+  # the SSH default (git@github.com:eminwux/agents.git via git.sshKey) needs no entry.
   sources: { eminwux/agents: git@github.com:eminwux/agents.git }
   secrets:
     claude-code-oauth-token: { from: env, key: CLAUDE_CODE_OAUTH_TOKEN }
   teams:
-    - { name: sbsh, path: ~/src/sbsh, source: eminwux/agents@v1.4.0 }
+    - {
+        name: sbsh,
+        path: ~/src/sbsh,
+        source: { repo: github.com/eminwux/agents, tag: v1.4.0 },
+      }
 ---
 # role.yaml — in agents, per role
 apiVersion: kuketeams.io/v1

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -533,10 +533,17 @@ var (
 	// ErrTeamMetadataNameRequired fires when a ProjectTeam/Role/Harness omits
 	// metadata.name.
 	ErrTeamMetadataNameRequired = errors.New("metadata.name is required")
-	// ErrTeamSourceInvalid fires when a `source` field is not a pinned-exact
-	// `<owner>/<repo>@vX.Y.Z` reference (floating ref or bare tag rejected).
+	// ErrTeamSourceInvalid fires when a structured `source` object is malformed:
+	// a missing or non-host-qualifiable repo, or other than exactly one of
+	// tag/branch/commit.
 	ErrTeamSourceInvalid = errors.New(
-		"source must be <owner>/<repo>@<version> pinned to an exact version (e.g. eminwux/agents@v1.4.0)",
+		"source must carry a repo (<host>/<owner>/<repo> or <owner>/<repo>) and exactly one of tag/branch/commit",
+	)
+	// ErrTeamSourceStringForm fires when a `source` field is the legacy
+	// `<owner>/<repo>@vX.Y.Z` string instead of the structured object. The
+	// string form is no longer supported — there is no silent dual-parse.
+	ErrTeamSourceStringForm = errors.New(
+		"source is now a structured object (repo + one of tag/branch/commit); the `<owner>/<repo>@<version>` string form is no longer supported — migrate to e.g. `source:\n  repo: github.com/eminwux/agents\n  tag: v1.4.0`",
 	)
 	// ErrTeamRoleRefRequired fires when a ProjectTeam roles[] entry omits ref.
 	ErrTeamRoleRefRequired = errors.New("roles[].ref is required")
@@ -559,9 +566,11 @@ var (
 	ErrTeamSecretSourceInvalid = errors.New(
 		"secret must declare a source (from: env|file) and a key, never an inline value",
 	)
-	// ErrTeamSourceKeyInvalid fires when a TeamsConfig sources[] key is not in
-	// `<owner>/<repo>` form.
-	ErrTeamSourceKeyInvalid = errors.New("sources key must be in <owner>/<repo> form")
+	// ErrTeamSourceKeyInvalid fires when a TeamsConfig sources[] override key is
+	// not in `<owner>/<repo>` or host-qualified `<host>/<owner>/<repo>` form.
+	ErrTeamSourceKeyInvalid = errors.New(
+		"sources key must be in <owner>/<repo> or <host>/<owner>/<repo> form",
+	)
 	// ErrTeamEntryNameRequired fires when a TeamEntry omits metadata.name (the
 	// per-project drop-in filename key).
 	ErrTeamEntryNameRequired = errors.New("teamEntry metadata.name is required")
@@ -602,13 +611,6 @@ var (
 	// capabilities.
 	ErrTeamImageCapabilitiesRequired = errors.New(
 		"imageCatalog images[].capabilities must be non-empty",
-	)
-	// ErrTeamSourceURLNotMapped fires when a project's `source` <owner>/<repo>
-	// key has no entry in TeamsConfig.spec.sources. The operator must add a
-	// clone URL mapping in ~/.kuke/kuketeams.yaml before init can materialize
-	// the agents source.
-	ErrTeamSourceURLNotMapped = errors.New(
-		"source key is not mapped in TeamsConfig.spec.sources",
 	)
 	// ErrTeamRoleFileKind fires when a per-role role.yaml parses to a kind
 	// other than Role.

--- a/internal/kuketeams/parser.go
+++ b/internal/kuketeams/parser.go
@@ -49,16 +49,17 @@ type Document struct {
 	ImageCatalog *model.ImageCatalog
 }
 
-// sourceRefPattern matches a pinned-exact `<owner>/<repo>@vX.Y.Z` reference.
-// The version must be a full vMAJOR.MINOR.PATCH, optionally with a
-// prerelease/build suffix — floating refs (`@main`) and bare tags (`@v1`) are
-// rejected. Owner/repo allow the GitHub-name character class.
-var sourceRefPattern = regexp.MustCompile(
-	`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+@v\d+\.\d+\.\d+([-+][0-9A-Za-z.-]+)?$`,
-)
+// nameSegPattern matches a single owner/repo path segment (the GitHub-name
+// character class). The "." or ".." traversal segments are rejected separately
+// since they also match this class.
+var nameSegPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
-// ownerRepoPattern matches a bare `<owner>/<repo>` key (no version).
-var ownerRepoPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
+// hostSegPattern matches a leading host segment (`github.com`, `git.example:22`).
+// A host is distinguished from an owner segment by carrying a "." or ":".
+var hostSegPattern = regexp.MustCompile(`^[A-Za-z0-9.:_-]+$`)
+
+// ownerRepoSegments is the minimum owner/repo path-segment count (`<owner>/<repo>`).
+const ownerRepoSegments = 2
 
 // docSeparator splits a multi-document YAML stream on `---` lines.
 var docSeparator = regexp.MustCompile(`(?m)^\s*---\s*$`)
@@ -114,6 +115,9 @@ func Parse(raw []byte) (*Document, error) {
 	doc := &Document{APIVersion: h.APIVersion, Kind: h.Kind}
 	switch h.Kind {
 	case model.KindProjectTeam:
+		if err := rejectStringFormSource(raw); err != nil {
+			return nil, err
+		}
 		var v model.ProjectTeam
 		if err := yaml.Unmarshal(raw, &v); err != nil {
 			return nil, fmt.Errorf("parse ProjectTeam: %w", err)
@@ -132,6 +136,9 @@ func Parse(raw []byte) (*Document, error) {
 		}
 		doc.TeamsConfig = &v
 	case model.KindTeamEntry:
+		if err := rejectStringFormSource(raw); err != nil {
+			return nil, err
+		}
 		var v model.TeamEntry
 		if err := yaml.Unmarshal(raw, &v); err != nil {
 			return nil, fmt.Errorf("parse TeamEntry: %w", err)
@@ -184,8 +191,8 @@ func validateProjectTeam(pt *model.ProjectTeam) error {
 	if err := validateMetadataNameSafe(pt.Metadata.Name); err != nil {
 		return err
 	}
-	if !sourceRefPattern.MatchString(strings.TrimSpace(pt.Spec.Source)) {
-		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceInvalid, pt.Spec.Source)
+	if err := ValidateSource(pt.Spec.Source); err != nil {
+		return err
 	}
 	for _, h := range pt.Spec.Defaults.Harnesses {
 		if !model.IsKnownHarness(h) {
@@ -226,7 +233,7 @@ func validateTeamsConfig(tc *model.TeamsConfig) error {
 		}
 	}
 	for key := range tc.Spec.Sources {
-		if !ownerRepoPattern.MatchString(key) {
+		if validateRepo(strings.TrimSpace(key)) != nil {
 			return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceKeyInvalid, key)
 		}
 	}
@@ -236,7 +243,7 @@ func validateTeamsConfig(tc *model.TeamsConfig) error {
 // validateTeamEntry enforces the per-project drop-in contract: metadata.name
 // present and safe (it is the <project>.yaml filename key, so traversal
 // characters would let an attacker escape the drop-in directory), and source —
-// when set — pinned-exact to a `<owner>/<repo>@vX.Y.Z` agents reference.
+// when set — a well-formed structured agents reference.
 func validateTeamEntry(te *model.TeamEntry) error {
 	if strings.TrimSpace(te.Metadata.Name) == "" {
 		return errdefs.ErrTeamEntryNameRequired
@@ -244,9 +251,83 @@ func validateTeamEntry(te *model.TeamEntry) error {
 	if err := validateMetadataNameSafe(te.Metadata.Name); err != nil {
 		return err
 	}
-	if strings.TrimSpace(te.Spec.Source) != "" &&
-		!sourceRefPattern.MatchString(strings.TrimSpace(te.Spec.Source)) {
-		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceInvalid, te.Spec.Source)
+	if te.Spec.Source != nil {
+		if err := ValidateSource(*te.Spec.Source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateSource enforces the structured-source contract shared by ProjectTeam
+// and TeamEntry: repo is host-qualifiable (`<host>/<owner>/<repo>` or a bare
+// `<owner>/<repo>` defaulting to github.com), and exactly one of
+// tag/branch/commit carries the ref intent. Zero or multiple refs is a parse
+// error — the key name is the pinned-vs-floating signal, so ambiguity is not
+// tolerated.
+func ValidateSource(s model.TeamSource) error {
+	repo := strings.TrimSpace(s.Repo)
+	if repo == "" {
+		return fmt.Errorf("%w (repo is required)", errdefs.ErrTeamSourceInvalid)
+	}
+	if err := validateRepo(repo); err != nil {
+		return err
+	}
+	if _, kind := s.Ref(); kind == "" {
+		return fmt.Errorf(
+			"%w (got tag=%q branch=%q commit=%q)",
+			errdefs.ErrTeamSourceInvalid, s.Tag, s.Branch, s.Commit,
+		)
+	}
+	return nil
+}
+
+// validateRepo accepts a bare `<owner>/<repo>` (host defaults to github.com) or
+// a host-qualified `<host>/<owner>/<repo>[/...]` (first segment carrying a "."
+// or ":" is the host). Every owner/repo segment matches the GitHub-name class
+// and may not be a "." or ".." traversal segment — repo flows into the cache
+// directory name, so a traversal segment would escape the cache root.
+func validateRepo(repo string) error {
+	segs := strings.Split(repo, "/")
+	first := segs[0]
+	var ownerSegs []string
+	if first != "." && first != ".." && strings.ContainsAny(first, ".:") {
+		if !hostSegPattern.MatchString(first) {
+			return fmt.Errorf("%w (repo host %q is malformed)", errdefs.ErrTeamSourceInvalid, first)
+		}
+		ownerSegs = segs[1:]
+	} else {
+		ownerSegs = segs
+	}
+	if len(ownerSegs) < ownerRepoSegments {
+		return fmt.Errorf("%w (repo %q must include <owner>/<repo>)", errdefs.ErrTeamSourceInvalid, repo)
+	}
+	for _, seg := range ownerSegs {
+		if seg == "." || seg == ".." || !nameSegPattern.MatchString(seg) {
+			return fmt.Errorf("%w (repo %q has an invalid path segment %q)", errdefs.ErrTeamSourceInvalid, repo, seg)
+		}
+	}
+	return nil
+}
+
+// rejectStringFormSource probes raw for a scalar `spec.source` — the legacy
+// `<owner>/<repo>@vX.Y.Z` string form — and returns the migration error before
+// the typed unmarshal attempts (and fails cryptically) to decode a scalar into
+// the TeamSource struct. A mapping (object) source, an absent source, or an
+// empty scalar falls through to the normal parse + ValidateSource path, so
+// there is no silent dual-parse.
+func rejectStringFormSource(raw []byte) error {
+	var probe struct {
+		Spec struct {
+			Source yaml.Node `yaml:"source"`
+		} `yaml:"spec"`
+	}
+	// A failed probe-unmarshal leaves Source.Kind zero; the typed unmarshal
+	// downstream surfaces the structural error verbatim, so the probe error is
+	// deliberately ignored here.
+	_ = yaml.Unmarshal(raw, &probe)
+	if probe.Spec.Source.Kind == yaml.ScalarNode && strings.TrimSpace(probe.Spec.Source.Value) != "" {
+		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceStringForm, probe.Spec.Source.Value)
 	}
 	return nil
 }

--- a/internal/kuketeams/parser.go
+++ b/internal/kuketeams/parser.go
@@ -273,11 +273,39 @@ func ValidateSource(s model.TeamSource) error {
 	if err := validateRepo(repo); err != nil {
 		return err
 	}
-	if _, kind := s.Ref(); kind == "" {
+	value, kind := s.Ref()
+	if kind == "" {
 		return fmt.Errorf(
 			"%w (got tag=%q branch=%q commit=%q)",
 			errdefs.ErrTeamSourceInvalid, s.Tag, s.Branch, s.Commit,
 		)
+	}
+	if err := validateRef(value, kind); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateRef rejects ref values that would escape the cache subtree when
+// concatenated into the leaf directory name (`<host>/<owner>/<repo>@<ref>`):
+// a leading "/" or a "." / ".." path segment. Symmetric with validateRepo's
+// segment check — both halves of the cache key flow into the on-disk path.
+// Git's own refname rules reject most of these at clone time, but the cache's
+// MkdirAll(parent) runs before git ever does.
+func validateRef(value, kind string) error {
+	if strings.HasPrefix(value, "/") {
+		return fmt.Errorf("%w (%s %q has an invalid path segment)", errdefs.ErrTeamSourceInvalid, kind, value)
+	}
+	for _, seg := range strings.Split(value, "/") {
+		if seg == "." || seg == ".." {
+			return fmt.Errorf(
+				"%w (%s %q has an invalid path segment %q)",
+				errdefs.ErrTeamSourceInvalid,
+				kind,
+				value,
+				seg,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -515,6 +515,23 @@ func TestValidateSourceRejectsTraversalRepo(t *testing.T) {
 	}
 }
 
+func TestValidateSourceRejectsTraversalRef(t *testing.T) {
+	t.Parallel()
+	cases := []model.TeamSource{
+		{Repo: "eminwux/agents", Branch: "../../etc"},
+		{Repo: "eminwux/agents", Tag: ".."},
+		{Repo: "eminwux/agents", Tag: "/abs"},
+		{Repo: "eminwux/agents", Branch: "foo/../bar"},
+		{Repo: "eminwux/agents", Commit: "."},
+	}
+	for _, s := range cases {
+		err := ValidateSource(s)
+		if !errors.Is(err, errdefs.ErrTeamSourceInvalid) {
+			t.Errorf("ValidateSource(%+v) err = %v, want ErrTeamSourceInvalid", s, err)
+		}
+	}
+}
+
 func TestParseTeamsConfigAcceptsHostQualifiedSourceKey(t *testing.T) {
 	t.Parallel()
 	raw := "apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { sources: { \"github.com/eminwux/agents\": https://github.com/eminwux/agents.git } }\n"

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -30,7 +30,7 @@ apiVersion: kuketeams.io/v1
 kind: ProjectTeam
 metadata: { name: sbsh }
 spec:
-  source: eminwux/agents@v1.4.0
+  source: { repo: github.com/eminwux/agents, tag: v1.4.0 }
   defaults: { harnesses: [claude, opencode] }
   roles:
     - { ref: dev, needs: { image: [go] } }
@@ -59,7 +59,7 @@ const teamEntryHappy = `
 apiVersion: kuketeams.io/v1
 kind: TeamEntry
 metadata: { name: sbsh }
-spec: { path: /home/op/src/sbsh, source: eminwux/agents@v1.4.0 }
+spec: { path: /home/op/src/sbsh, source: { repo: github.com/eminwux/agents, tag: v1.4.0 } }
 `
 
 const roleHappy = `
@@ -158,8 +158,11 @@ func TestParseHappyPathFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProjectTeam: %v", err)
 	}
-	if got := pt.ProjectTeam.Spec.Source; got != "eminwux/agents@v1.4.0" {
-		t.Errorf("source = %q", got)
+	if got := pt.ProjectTeam.Spec.Source; got.Repo != "github.com/eminwux/agents" || got.Tag != "v1.4.0" {
+		t.Errorf("source = %+v", got)
+	}
+	if pt.ProjectTeam.Spec.Source.Floating() {
+		t.Errorf("tag source should be pinned, not floating")
 	}
 	if len(pt.ProjectTeam.Spec.Roles) != 3 {
 		t.Errorf("roles len = %d, want 3", len(pt.ProjectTeam.Spec.Roles))
@@ -191,7 +194,9 @@ func TestParseHappyPathFields(t *testing.T) {
 	if te.TeamEntry.Metadata.Name != "sbsh" {
 		t.Errorf("teamEntry name = %q, want sbsh", te.TeamEntry.Metadata.Name)
 	}
-	if te.TeamEntry.Spec.Path != "/home/op/src/sbsh" || te.TeamEntry.Spec.Source != "eminwux/agents@v1.4.0" {
+	if te.TeamEntry.Spec.Path != "/home/op/src/sbsh" || te.TeamEntry.Spec.Source == nil ||
+		te.TeamEntry.Spec.Source.Repo != "github.com/eminwux/agents" ||
+		te.TeamEntry.Spec.Source.Tag != "v1.4.0" {
 		t.Errorf("teamEntry spec = %+v", te.TeamEntry.Spec)
 	}
 
@@ -240,32 +245,42 @@ func TestParseFailureModes(t *testing.T) {
 		// ProjectTeam.
 		{
 			"ProjectTeam missing name",
-			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: dev}] }\n",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, roles: [{ref: dev}] }\n",
 			errdefs.ErrTeamMetadataNameRequired,
 		},
 		{
-			"ProjectTeam floating source",
-			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@main, roles: [{ref: dev}] }\n",
+			"ProjectTeam legacy string source",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamSourceStringForm,
+		},
+		{
+			"ProjectTeam source no ref",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents}, roles: [{ref: dev}] }\n",
 			errdefs.ErrTeamSourceInvalid,
 		},
 		{
-			"ProjectTeam bare-tag source",
-			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1, roles: [{ref: dev}] }\n",
+			"ProjectTeam source two refs",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents, tag: v1.4.0, branch: main}, roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamSourceInvalid,
+		},
+		{
+			"ProjectTeam source missing owner",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: agents, tag: v1.4.0}, roles: [{ref: dev}] }\n",
 			errdefs.ErrTeamSourceInvalid,
 		},
 		{
 			"ProjectTeam empty role ref",
-			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: \"\"}] }\n",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, roles: [{ref: \"\"}] }\n",
 			errdefs.ErrTeamRoleRefRequired,
 		},
 		{
 			"ProjectTeam unknown default harness",
-			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1.4.0, defaults: {harnesses: [bogus]}, roles: [{ref: dev}] }\n",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, defaults: {harnesses: [bogus]}, roles: [{ref: dev}] }\n",
 			errdefs.ErrTeamHarnessUnknown,
 		},
 		{
 			"ProjectTeam role image is a tag",
-			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: dev, needs: {image: [\"go:1.21\"]}}] }\n",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, roles: [{ref: dev, needs: {image: [\"go:1.21\"]}}] }\n",
 			errdefs.ErrTeamImageCapabilityInvalid,
 		},
 		// TeamsConfig.
@@ -306,8 +321,13 @@ func TestParseFailureModes(t *testing.T) {
 			errdefs.ErrTeamEntryNameRequired,
 		},
 		{
-			"TeamEntry non-pinned source",
-			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: a }\nspec: { path: /x, source: eminwux/agents@main }\n",
+			"TeamEntry legacy string source",
+			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: a }\nspec: { path: /x, source: eminwux/agents@v1.4.0 }\n",
+			errdefs.ErrTeamSourceStringForm,
+		},
+		{
+			"TeamEntry malformed source",
+			"apiVersion: kuketeams.io/v1\nkind: TeamEntry\nmetadata: { name: a }\nspec: { path: /x, source: {repo: eminwux/agents} }\n",
 			errdefs.ErrTeamSourceInvalid,
 		},
 		{
@@ -340,7 +360,7 @@ func TestParseFailureModes(t *testing.T) {
 			// committed kuketeam.yaml), and metadata.name from that file
 			// becomes the TeamEntry's metadata.name verbatim in `kuke team init`.
 			"ProjectTeam name traverses parent",
-			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: { name: \"../kuketeams\" }\nspec: { source: eminwux/agents@v1.4.0, roles: [{ref: dev}] }\n",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: { name: \"../kuketeams\" }\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, roles: [{ref: dev}] }\n",
 			errdefs.ErrTeamMetadataNameUnsafe,
 		},
 		// Role.
@@ -449,5 +469,56 @@ func TestParseDocumentsPropagatesValidation(t *testing.T) {
 	_, err := ParseDocuments(strings.NewReader(roleHappy + "\n---\n" + bad))
 	if !errors.Is(err, errdefs.ErrTeamMetadataNameRequired) {
 		t.Fatalf("error = %v, want ErrTeamMetadataNameRequired", err)
+	}
+}
+
+func TestParseProjectTeamAcceptsSourceForms(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		source       string
+		wantFloating bool
+	}{
+		{"host-qualified tag", "{repo: github.com/eminwux/agents, tag: v1.4.0}", false},
+		{"bare owner/repo defaults host", "{repo: eminwux/agents, tag: v1.4.0}", false},
+		{"floating branch", "{repo: github.com/eminwux/agents, branch: main}", true},
+		{"pinned commit", "{repo: github.com/eminwux/agents, commit: 9ae9606}", false},
+		{"non-github host", "{repo: gitlab.com/group/sub/repo, branch: trunk}", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			raw := "apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: " +
+				tc.source + ", roles: [{ref: dev}] }\n"
+			doc, err := Parse([]byte(raw))
+			if err != nil {
+				t.Fatalf("Parse(%s): %v", tc.name, err)
+			}
+			if got := doc.ProjectTeam.Spec.Source.Floating(); got != tc.wantFloating {
+				t.Errorf("Floating() = %v, want %v", got, tc.wantFloating)
+			}
+		})
+	}
+}
+
+func TestValidateSourceRejectsTraversalRepo(t *testing.T) {
+	t.Parallel()
+	for _, repo := range []string{
+		"../etc/passwd",
+		"github.com/../../etc",
+		"eminwux/..",
+	} {
+		err := ValidateSource(model.TeamSource{Repo: repo, Tag: "v1.4.0"})
+		if !errors.Is(err, errdefs.ErrTeamSourceInvalid) {
+			t.Errorf("ValidateSource(repo=%q) err = %v, want ErrTeamSourceInvalid", repo, err)
+		}
+	}
+}
+
+func TestParseTeamsConfigAcceptsHostQualifiedSourceKey(t *testing.T) {
+	t.Parallel()
+	raw := "apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: { sources: { \"github.com/eminwux/agents\": https://github.com/eminwux/agents.git } }\n"
+	if _, err := Parse([]byte(raw)); err != nil {
+		t.Fatalf("Parse host-qualified sources key: %v", err)
 	}
 }

--- a/internal/teamhost/teamhost.go
+++ b/internal/teamhost/teamhost.go
@@ -44,8 +44,8 @@ const (
 	globalConfigName = "kuketeams.yaml"
 	// dropInDirName is the per-project drop-in directory under Base.
 	dropInDirName = "kuketeam.d"
-	// cacheDirName is the materialized-source cache under Base — each pinned
-	// `<owner>/<repo>@vX.Y.Z` agents reference clones into its own subdirectory.
+	// cacheDirName is the materialized-source cache under Base — each agents
+	// reference clones into its own `<host>/<owner>/<repo>@<ref>` subdirectory.
 	cacheDirName = "cache"
 
 	// dropInDirPerm is the drop-in directory mode: operator-only (the files

--- a/internal/teamhost/teamhost_test.go
+++ b/internal/teamhost/teamhost_test.go
@@ -41,7 +41,10 @@ func teamEntry(name string) *model.TeamEntry {
 		APIVersion: model.APIVersionV1,
 		Kind:       model.KindTeamEntry,
 		Metadata:   model.Metadata{Name: name},
-		Spec:       model.TeamEntrySpec{Path: "/home/op/src/" + name, Source: "eminwux/agents@v1.4.0"},
+		Spec: model.TeamEntrySpec{
+			Path:   "/home/op/src/" + name,
+			Source: &model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
+		},
 	}
 }
 
@@ -113,7 +116,8 @@ func TestWriteEntryCreatesDirAndFileWithPerms(t *testing.T) {
 		t.Fatalf("entry does not round-trip: %v", unmarshalErr)
 	}
 	if got.Kind != model.KindTeamEntry || got.Metadata.Name != "sbsh" ||
-		got.Spec.Source != "eminwux/agents@v1.4.0" {
+		got.Spec.Source == nil || got.Spec.Source.Repo != "github.com/eminwux/agents" ||
+		got.Spec.Source.Tag != "v1.4.0" {
 		t.Errorf("entry content lost on disk: %+v", got)
 	}
 }

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -584,20 +584,17 @@ func operatorValues(tc *model.TeamsConfig, roleRef, harness, project string) map
 	return vals
 }
 
-// agentsCloneURL returns the clone URL of the materialized agents source
-// when tc.spec.sources carries an entry for src.OwnerRepo, or the empty
-// string otherwise. The render pipeline already used the same lookup in
-// teamsource.CloneURL to clone the cache; reusing it here keeps the
-// agents-side slot fill consistent with the bundle that produced it.
+// agentsCloneURL returns the clone URL of the materialized agents source —
+// the SSH default expanded from src.Host/src.OwnerRepo, or a tc.spec.sources
+// transport override when one is present. It reuses teamsource.CloneURL so the
+// agents-side slot fill stays consistent with the bundle that produced it. A
+// zero Source (no resolved agents repo) yields the empty string so an
+// undeclared slot is never filled with a garbage URL.
 func agentsCloneURL(tc *model.TeamsConfig, src teamsource.Source) string {
-	if tc == nil || src.OwnerRepo == "" {
+	if src.OwnerRepo == "" || src.Host == "" {
 		return ""
 	}
-	url, ok := tc.Spec.Sources[src.OwnerRepo]
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(url)
+	return teamsource.CloneURL(tc, src)
 }
 
 // collectRepoSlots returns the set of repo slot names declared by bp's

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -362,7 +362,13 @@ func TestBindConfigStampsTeamLabelAndProjectRepoFill(t *testing.T) {
 			"ANTHROPIC_API_KEY": {From: model.SecretFromEnv, Key: "ANTHROPIC_API_KEY"},
 		},
 	}}
-	src := teamsource.Source{Raw: "eminwux/agents@v1.4.0", OwnerRepo: "eminwux/agents", Version: "v1.4.0"}
+	src := teamsource.Source{
+		Repo:      "github.com/eminwux/agents",
+		Host:      "github.com",
+		OwnerRepo: "eminwux/agents",
+		Ref:       "v1.4.0",
+		Kind:      teamsource.RefTag,
+	}
 	in := Inputs{Project: "sbsh", ProjectRepoURL: "git@github.com:eminwux/sbsh.git"}
 
 	cfg := BindConfig(bp, role, "dev", "claude", tc, src, in, "sbsh", "default")
@@ -430,7 +436,13 @@ func TestBindConfigFillsAgentsSlotFromTeamsConfigSources(t *testing.T) {
 	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{
 		Sources: map[string]string{"eminwux/agents": "git@github.com:eminwux/agents.git"},
 	}}
-	src := teamsource.Source{Raw: "eminwux/agents@v1.4.0", OwnerRepo: "eminwux/agents", Version: "v1.4.0"}
+	src := teamsource.Source{
+		Repo:      "github.com/eminwux/agents",
+		Host:      "github.com",
+		OwnerRepo: "eminwux/agents",
+		Ref:       "v1.4.0",
+		Kind:      teamsource.RefTag,
+	}
 	cfg := BindConfig(bp, minimalRole(), "dev", "claude", tc, src, Inputs{Project: "sbsh"}, "sbsh", "default")
 	if got := cfg.Spec.Repos["agents"].URL; got != "git@github.com:eminwux/agents.git" {
 		t.Errorf("agents slot fill URL = %q, want agents.git", got)
@@ -455,7 +467,13 @@ func TestRenderEndToEnd(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	bundle := &teamsource.Bundle{
-		Source:   teamsource.Source{OwnerRepo: "eminwux/agents", Version: "v1.4.0"},
+		Source: teamsource.Source{
+			Repo:      "github.com/eminwux/agents",
+			Host:      "github.com",
+			OwnerRepo: "eminwux/agents",
+			Ref:       "v1.4.0",
+			Kind:      teamsource.RefTag,
+		},
 		CacheDir: cacheDir,
 		Roles:    map[string]*model.Role{"dev": minimalRole()},
 		Harnesses: map[string]*model.Harness{
@@ -484,7 +502,7 @@ func TestRenderEndToEnd(t *testing.T) {
 	pt := &model.ProjectTeam{
 		Metadata: model.Metadata{Name: "sbsh"},
 		Spec: model.ProjectTeamSpec{
-			Source:   "eminwux/agents@v1.4.0",
+			Source:   model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
 			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude", "codex"}},
 			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
 		},
@@ -519,7 +537,13 @@ func TestRenderProjectPerRoleNeedsOverrideUnions(t *testing.T) {
 	buildClaudeTemplate(t, cacheDir)
 	role := minimalRole() // image needs: go, git
 	bundle := &teamsource.Bundle{
-		Source:   teamsource.Source{OwnerRepo: "eminwux/agents", Version: "v1.4.0"},
+		Source: teamsource.Source{
+			Repo:      "github.com/eminwux/agents",
+			Host:      "github.com",
+			OwnerRepo: "eminwux/agents",
+			Ref:       "v1.4.0",
+			Kind:      teamsource.RefTag,
+		},
 		CacheDir: cacheDir,
 		Roles:    map[string]*model.Role{"dev": role},
 		Harnesses: map[string]*model.Harness{
@@ -545,7 +569,7 @@ func TestRenderProjectPerRoleNeedsOverrideUnions(t *testing.T) {
 	pt := &model.ProjectTeam{
 		Metadata: model.Metadata{Name: "sbsh"},
 		Spec: model.ProjectTeamSpec{
-			Source:   "eminwux/agents@v1.4.0",
+			Source:   model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
 			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
 			Roles: []model.ProjectTeamRole{{
 				Ref:   "dev",

--- a/internal/teamsource/teamsource.go
+++ b/internal/teamsource/teamsource.go
@@ -84,15 +84,6 @@ type Source struct {
 // init). Pinned tag/commit sources return false.
 func (s Source) Floating() bool { return s.Kind == RefBranch }
 
-// KindLabel returns "floating" for a branch and "pinned" for a tag/commit —
-// the operator-facing pinned-vs-floating signal `kuke team init` prints.
-func (s Source) KindLabel() string {
-	if s.Floating() {
-		return "floating"
-	}
-	return "pinned"
-}
-
 // FromModel validates and normalizes a model.TeamSource into a resolved
 // Source: the repo host is defaulted to github.com when bare, and the single
 // tag/branch/commit ref is extracted. A malformed source surfaces

--- a/internal/teamsource/teamsource.go
+++ b/internal/teamsource/teamsource.go
@@ -14,16 +14,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package teamsource resolves a kuketeams.io/v1 ProjectTeam's pinned `source`
-// reference to a local clone of the agents repo and loads the Role, Harness,
-// and ImageCatalog documents the project's roster references (epic #792, step
-// 2 #1041). Materialization is cache-keyed by the pinned
-// `<owner>/<repo>@vX.Y.Z` reference: an existing cache directory at the pinned
-// version is reused without re-cloning, and a missing cache is cloned via
-// `git clone --depth=1 --branch <version> --no-tags` into the pinned ref
-// exactly. Document loading delegates to the existing kuketeams parser, so
-// parse errors carry the offending file path verbatim. No daemon is required —
-// the package is unit-testable against a local fixture remote.
+// Package teamsource resolves a kuketeams.io/v1 ProjectTeam's structured
+// `source` reference to a local clone of the agents repo and loads the Role,
+// Harness, and ImageCatalog documents the project's roster references (epic
+// #792). The source is host-explicit (`repo: <host>/<owner>/<repo>`) and
+// carries exactly one ref intent: a pinned `tag`/`commit` (reproducible — the
+// cache is cloned once and reused as-is) or a floating `branch` (refetched and
+// reset to the branch tip on every init, so a stale roster is never silently
+// reused). The default clone transport is SSH (`git@<host>:<owner>/<repo>.git`)
+// using TeamsConfig.spec.git.sshKey as the clone identity; TeamsConfig.spec.
+// sources is consulted only as an optional per-repo transport override (HTTPS,
+// internal mirror, non-standard port). Document loading delegates to the
+// existing kuketeams parser, so parse errors carry the offending file path
+// verbatim. No daemon is required — the package is unit-testable against a
+// local fixture remote.
 package teamsource
 
 import (
@@ -34,7 +38,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -42,65 +45,95 @@ import (
 	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
 )
 
-// sourcePattern matches a pinned-exact `<owner>/<repo>@vX.Y.Z` reference,
-// mirroring internal/kuketeams's parser pattern. Floating refs (`@main`) and
-// bare tags (`@v1`) are rejected.
-var sourcePattern = regexp.MustCompile(
-	`^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)@(v\d+\.\d+\.\d+([-+][0-9A-Za-z.-]+)?)$`,
-)
-
 // cacheDirPerm is the cache root and per-source clone mode — operator-only,
 // matching teamhost's drop-in directory perm. Secret material never lives in
-// the cache (the agents source is the operator's own public repo at a pinned
-// tag), but keeping the perm consistent avoids surprise for an operator
-// inspecting ~/.kuke.
+// the cache (the agents source is the operator's own repo at a tag/branch),
+// but keeping the perm consistent avoids surprise for an operator inspecting
+// ~/.kuke.
 const cacheDirPerm = 0o700
 
-// Source is a parsed pinned-exact agents reference.
+// RefKind classifies a source ref's reuse semantics.
+type RefKind string
+
+const (
+	// RefTag is a pinned tag — cloned once, reused as-is.
+	RefTag RefKind = "tag"
+	// RefBranch is a floating branch — refetched + reset on every init.
+	RefBranch RefKind = "branch"
+	// RefCommit is a pinned commit — fetched once, reused as-is.
+	RefCommit RefKind = "commit"
+)
+
+// Source is a resolved, host-explicit agents reference.
 type Source struct {
-	// Raw is the original `<owner>/<repo>@vX.Y.Z` string, trimmed.
-	Raw string
-	// OwnerRepo is the `<owner>/<repo>` half — the lookup key against
-	// TeamsConfig.spec.sources.
+	// Repo is the normalized host-qualified `<host>/<owner>/<repo>` — the
+	// cache-directory key (with @ref appended) and override-lookup key.
+	Repo string
+	// Host is the git host (`github.com`, `git.example:22`).
+	Host string
+	// OwnerRepo is the `<owner>/<repo>` (or `<group>/<sub>/<repo>`) half — the
+	// SSH path and the bare override-lookup key.
 	OwnerRepo string
-	// Version is the `vX.Y.Z[<+|->suffix]` half — the ref the cache directory
-	// pins to and the value passed to `git clone --branch`.
-	Version string
+	// Ref is the single tag/branch/commit value.
+	Ref string
+	// Kind is the ref classification (tag/branch/commit) driving reuse.
+	Kind RefKind
 }
 
-// ParseSource parses raw into a Source. The input is trimmed and matched
-// against the pinned-exact `<owner>/<repo>@vX.Y.Z` pattern. Floating refs and
-// bare tags surface errdefs.ErrTeamSourceInvalid so callers reuse the same
-// sentinel the parser uses.
-func ParseSource(raw string) (Source, error) {
-	trimmed := strings.TrimSpace(raw)
-	m := sourcePattern.FindStringSubmatch(trimmed)
-	if m == nil {
-		return Source{}, fmt.Errorf("%w (got %q)", errdefs.ErrTeamSourceInvalid, raw)
+// Floating reports whether the source is a floating branch (refetched every
+// init). Pinned tag/commit sources return false.
+func (s Source) Floating() bool { return s.Kind == RefBranch }
+
+// KindLabel returns "floating" for a branch and "pinned" for a tag/commit —
+// the operator-facing pinned-vs-floating signal `kuke team init` prints.
+func (s Source) KindLabel() string {
+	if s.Floating() {
+		return "floating"
 	}
-	return Source{Raw: trimmed, OwnerRepo: m[1], Version: m[2]}, nil
+	return "pinned"
 }
 
-// CloneURL returns the clone URL for src by looking up its `<owner>/<repo>`
-// key in tc.spec.sources. An unmapped or blank-value key surfaces
-// errdefs.ErrTeamSourceURLNotMapped with the missing key named in the wrapper
-// — the AC's "hard-error naming the missing key" contract.
-func CloneURL(tc *model.TeamsConfig, src Source) (string, error) {
-	if tc == nil {
-		return "", fmt.Errorf("%w: %q", errdefs.ErrTeamSourceURLNotMapped, src.OwnerRepo)
+// FromModel validates and normalizes a model.TeamSource into a resolved
+// Source: the repo host is defaulted to github.com when bare, and the single
+// tag/branch/commit ref is extracted. A malformed source surfaces
+// errdefs.ErrTeamSourceInvalid via the shared parser validation.
+func FromModel(m model.TeamSource) (Source, error) {
+	if err := kuketeams.ValidateSource(m); err != nil {
+		return Source{}, err
 	}
-	url, ok := tc.Spec.Sources[src.OwnerRepo]
-	if !ok || strings.TrimSpace(url) == "" {
-		return "", fmt.Errorf("%w: %q", errdefs.ErrTeamSourceURLNotMapped, src.OwnerRepo)
-	}
-	return strings.TrimSpace(url), nil
+	host, ownerRepo := m.Normalized()
+	value, kind := m.Ref()
+	return Source{
+		Repo:      host + "/" + ownerRepo,
+		Host:      host,
+		OwnerRepo: ownerRepo,
+		Ref:       value,
+		Kind:      RefKind(kind),
+	}, nil
 }
 
-// Cache is the on-disk cache root for materialized agents sources. Each pinned
-// `<owner>/<repo>@vX.Y.Z` reference lives at <Base>/<owner>/<repo>@<version>,
-// so the version is encoded in the leaf directory name and the existence of
-// that directory is sufficient to decide reuse — the cache key is the pinned
-// reference itself.
+// CloneURL returns the clone URL for src. The default transport is SSH —
+// `git@<host>:<owner>/<repo>.git`, cloned under the sshKey identity (threaded
+// separately into the git env). TeamsConfig.spec.sources is consulted only as
+// an optional transport override: an entry keyed by the host-qualified repo or
+// the bare `<owner>/<repo>` (in that order) with a non-blank value replaces the
+// SSH default. The common case needs no sources entry.
+func CloneURL(tc *model.TeamsConfig, src Source) string {
+	if tc != nil {
+		for _, key := range []string{src.Repo, src.OwnerRepo} {
+			if u, ok := tc.Spec.Sources[key]; ok && strings.TrimSpace(u) != "" {
+				return strings.TrimSpace(u)
+			}
+		}
+	}
+	return "git@" + src.Host + ":" + src.OwnerRepo + ".git"
+}
+
+// Cache is the on-disk cache root for materialized agents sources. Each
+// reference lives at <Base>/<host>/<owner>/<repo>@<ref>, so the ref is encoded
+// in the leaf directory name. For a pinned tag/commit the existence of that
+// directory is sufficient to decide reuse; a floating branch refetches the
+// branch tip in place on every materialize.
 type Cache struct {
 	Base string
 }
@@ -113,23 +146,43 @@ func NewCache(base string) Cache {
 
 // Path returns the on-disk directory for src under this cache.
 func (c Cache) Path(src Source) string {
-	return filepath.Join(c.Base, src.OwnerRepo+"@"+src.Version)
+	return filepath.Join(c.Base, src.Repo+"@"+src.Ref)
 }
 
-// Materialize ensures src is present at its cache path and returns that path.
-// An existing cache directory at the pinned reference is reused as-is; a
-// missing one is cloned via `git clone --depth=1 --branch <version> --no-tags
-// <cloneURL> <tmp>` into a sibling temp directory and renamed into place
-// atomically, so an interrupted clone never leaves a half-materialized cache
-// dir behind. The non-interactive git env (GIT_TERMINAL_PROMPT=0,
-// StrictHostKeyChecking=accept-new BatchMode=yes SSH) mirrors kuketty's
-// processRepos so a first-time clone of an unseen host never hangs.
-func (c Cache) Materialize(ctx context.Context, src Source, cloneURL string) (string, error) {
+// Materialize ensures src is present at its cache path and returns that path,
+// honoring the ref kind:
+//
+//   - pinned (tag/commit): an existing cache directory is reused as-is; a
+//     missing one is cloned into a sibling temp directory and renamed into
+//     place atomically, so an interrupted clone never leaves a
+//     half-materialized cache dir behind.
+//   - floating (branch): an existing cache directory is refetched (`git fetch`)
+//     and hard-reset to the branch tip on every call — blind reuse of a
+//     floating branch would silently run stale agents. A missing one is cloned
+//     like the pinned path.
+//
+// sshKey, when non-empty, is wired into GIT_SSH_COMMAND (`-i <key>
+// -o IdentitiesOnly=yes`) so the SSH-default transport clones under the
+// operator's declared identity. The non-interactive git env
+// (GIT_TERMINAL_PROMPT=0, StrictHostKeyChecking=accept-new BatchMode=yes SSH)
+// mirrors kuketty's processRepos so a first-time clone of an unseen host never
+// hangs.
+func (c Cache) Materialize(ctx context.Context, src Source, cloneURL, sshKey string) (string, error) {
 	dst := c.Path(src)
-	if _, err := os.Stat(dst); err == nil {
+	_, statErr := os.Stat(dst)
+	exists := statErr == nil
+	if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+		return "", fmt.Errorf("stat cache dir %q: %w", dst, statErr)
+	}
+
+	if exists {
+		if src.Floating() {
+			if err := refreshFloating(ctx, dst, src, sshKey); err != nil {
+				return "", err
+			}
+		}
+		// Pinned refs reuse the existing cache dir as-is.
 		return dst, nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return "", fmt.Errorf("stat cache dir %q: %w", dst, err)
 	}
 
 	parent := filepath.Dir(dst)
@@ -138,9 +191,8 @@ func (c Cache) Materialize(ctx context.Context, src Source, cloneURL string) (st
 	}
 
 	// Reserve a unique temp name as a sibling of dst (so the rename stays on
-	// the same filesystem), then remove it so `git clone` creates the
-	// directory itself — `git clone <url> <dir>` requires the target to not
-	// exist or to be empty, and an empty dir works on every platform.
+	// the same filesystem), then remove it so the clone path creates the
+	// directory itself.
 	tmp, err := os.MkdirTemp(parent, ".clone-*.tmp")
 	if err != nil {
 		return "", fmt.Errorf("create temp clone dir in %q: %w", parent, err)
@@ -149,13 +201,9 @@ func (c Cache) Materialize(ctx context.Context, src Source, cloneURL string) (st
 		return "", fmt.Errorf("clear temp clone dir %q: %w", tmp, rmErr)
 	}
 
-	if cloneErr := runGit(ctx, "", "clone",
-		"--depth=1", "--no-tags",
-		"--branch", src.Version,
-		cloneURL, tmp,
-	); cloneErr != nil {
+	if cloneErr := cloneInto(ctx, tmp, cloneURL, sshKey, src); cloneErr != nil {
 		_ = os.RemoveAll(tmp)
-		return "", fmt.Errorf("clone %s@%s: %w", src.OwnerRepo, src.Version, cloneErr)
+		return "", fmt.Errorf("clone %s@%s: %w", src.Repo, src.Ref, cloneErr)
 	}
 
 	if renameErr := os.Rename(tmp, dst); renameErr != nil {
@@ -165,13 +213,49 @@ func (c Cache) Materialize(ctx context.Context, src Source, cloneURL string) (st
 	return dst, nil
 }
 
+// cloneInto clones src into the empty dst directory. Tags and branches use a
+// shallow `git clone --branch <ref>`; a commit cannot be `--branch`-cloned, so
+// it is fetched by SHA into a fresh repo and checked out detached.
+func cloneInto(ctx context.Context, dst, cloneURL, sshKey string, src Source) error {
+	if src.Kind == RefCommit {
+		if err := runGit(ctx, "", sshKey, "init", "-q", dst); err != nil {
+			return err
+		}
+		if err := runGit(ctx, dst, sshKey, "remote", "add", "origin", cloneURL); err != nil {
+			return err
+		}
+		if err := runGit(ctx, dst, sshKey, "fetch", "--depth=1", "origin", src.Ref); err != nil {
+			return err
+		}
+		return runGit(ctx, dst, sshKey, "checkout", "-q", "--detach", "FETCH_HEAD")
+	}
+	return runGit(ctx, "", sshKey,
+		"clone", "--depth=1", "--no-tags",
+		"--branch", src.Ref,
+		cloneURL, dst,
+	)
+}
+
+// refreshFloating refetches a floating branch's tip into the existing cache
+// dir and hard-resets the worktree to it, so a re-init always runs the current
+// branch HEAD rather than a stale clone.
+func refreshFloating(ctx context.Context, dir string, src Source, sshKey string) error {
+	if err := runGit(ctx, dir, sshKey, "fetch", "--depth=1", "origin", src.Ref); err != nil {
+		return fmt.Errorf("refetch floating %s@%s: %w", src.Repo, src.Ref, err)
+	}
+	if err := runGit(ctx, dir, sshKey, "reset", "--hard", "FETCH_HEAD"); err != nil {
+		return fmt.Errorf("reset floating %s@%s: %w", src.Repo, src.Ref, err)
+	}
+	return nil
+}
+
 // Bundle is the materialized agents source plus the Role / Harness /
 // ImageCatalog documents the project's roster references.
 type Bundle struct {
-	// Source is the parsed pinned reference (raw, owner/repo, version).
+	// Source is the resolved reference (repo, host, owner/repo, ref, kind).
 	Source Source
-	// CacheDir is the on-disk clone root — passed to step 3's render pipeline
-	// when it needs to read blueprint templates or other repo-relative paths.
+	// CacheDir is the on-disk clone root — passed to the render pipeline when
+	// it needs to read blueprint templates or other repo-relative paths.
 	CacheDir string
 	// Roles maps the role ref (ProjectTeam.spec.roles[].ref) to its loaded Role.
 	Roles map[string]*model.Role
@@ -182,26 +266,24 @@ type Bundle struct {
 	ImageCatalog *model.ImageCatalog
 }
 
-// Resolve parses pt.Spec.Source, looks up the clone URL in tc.spec.sources,
-// materializes the agents source under cache, and loads every Role referenced
-// by pt.Spec.Roles, every Harness referenced by pt.Spec.Defaults.Harnesses,
-// and the ImageCatalog. Parse errors surface with the offending file path —
-// the AC's "surface parse errors with the offending file path" contract.
+// Resolve validates pt.Spec.Source, derives the clone URL (SSH default, with
+// tc.spec.sources as an optional override), materializes the agents source
+// under cache using tc.spec.git.sshKey as the clone identity, and loads every
+// Role referenced by pt.Spec.Roles, every Harness referenced by
+// pt.Spec.Defaults.Harnesses, and the ImageCatalog. Parse errors surface with
+// the offending file path.
 func Resolve(
 	ctx context.Context,
 	cache Cache,
 	tc *model.TeamsConfig,
 	pt *model.ProjectTeam,
 ) (*Bundle, error) {
-	src, err := ParseSource(pt.Spec.Source)
+	src, err := FromModel(pt.Spec.Source)
 	if err != nil {
 		return nil, err
 	}
-	url, err := CloneURL(tc, src)
-	if err != nil {
-		return nil, err
-	}
-	dir, err := cache.Materialize(ctx, src, url)
+	cloneURL := CloneURL(tc, src)
+	dir, err := cache.Materialize(ctx, src, cloneURL, sshKeyOf(tc))
 	if err != nil {
 		return nil, err
 	}
@@ -233,6 +315,16 @@ func Resolve(
 	}
 	b.ImageCatalog = ic
 	return b, nil
+}
+
+// sshKeyOf returns the operator's SSH clone identity from the TeamsConfig git
+// block, or "" when none is configured (the default SSH agent identity is then
+// used by git).
+func sshKeyOf(tc *model.TeamsConfig) string {
+	if tc == nil || tc.Spec.Git == nil {
+		return ""
+	}
+	return strings.TrimSpace(tc.Spec.Git.SSHKey)
 }
 
 // RolePath is the on-disk role.yaml location for ref under cacheDir.
@@ -313,11 +405,12 @@ func parseFile(path string) (*kuketeams.Document, error) {
 // guards (GIT_TERMINAL_PROMPT=0 and a StrictHostKeyChecking=accept-new
 // BatchMode=yes GIT_SSH_COMMAND), mirroring kuketty's processRepos guards so
 // a first-time clone of an unseen host never blocks on an interactive
-// yes/no prompt. dir is the working directory ("" for the process cwd).
-// Combined output is folded into the error for actionable diagnostics.
-func runGit(ctx context.Context, dir string, args ...string) error {
+// yes/no prompt. dir is the working directory ("" for the process cwd); sshKey,
+// when non-empty, is added as the SSH clone identity. Combined output is folded
+// into the error for actionable diagnostics.
+func runGit(ctx context.Context, dir, sshKey string, args ...string) error {
 	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Env = gitEnv()
+	cmd.Env = gitEnv(sshKey)
 	if dir != "" {
 		cmd.Dir = dir
 	}
@@ -363,14 +456,20 @@ func scrubURLCredentials(arg string) string {
 
 // gitEnv returns the operator's environment augmented with non-interactive
 // guards. Both guards yield to a value the operator already set: an env that
-// pre-seeds known_hosts and exports its own GIT_SSH_COMMAND wins.
-func gitEnv() []string {
+// pre-seeds known_hosts and exports its own GIT_SSH_COMMAND wins. When sshKey
+// is non-empty and the operator has not exported GIT_SSH_COMMAND, the key is
+// wired in as the clone identity with IdentitiesOnly so only it is offered.
+func gitEnv(sshKey string) []string {
 	env := os.Environ()
 	if _, ok := os.LookupEnv("GIT_TERMINAL_PROMPT"); !ok {
 		env = append(env, "GIT_TERMINAL_PROMPT=0")
 	}
 	if _, ok := os.LookupEnv("GIT_SSH_COMMAND"); !ok {
-		env = append(env, "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes")
+		ssh := "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
+		if sshKey != "" {
+			ssh += fmt.Sprintf(" -i %q -o IdentitiesOnly=yes", sshKey)
+		}
+		env = append(env, "GIT_SSH_COMMAND="+ssh)
 	}
 	return env
 }

--- a/internal/teamsource/teamsource_test.go
+++ b/internal/teamsource/teamsource_test.go
@@ -50,6 +50,25 @@ func gitRun(t *testing.T, dir string, args ...string) {
 	}
 }
 
+// gitOutput runs git in dir with the same hermetic identity as gitRun and
+// returns its stdout — used to read a fixture commit's SHA.
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{
+		"-c", "user.email=test@kukeon.invalid",
+		"-c", "user.name=kukeon test",
+		"-c", "init.defaultBranch=main",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v in %q: %v", args, dir, err)
+	}
+	return string(out)
+}
+
 // agentsFile is one document the fixture remote should carry. Path is relative
 // to the agents repo root.
 type agentsFile struct {
@@ -121,83 +140,137 @@ func makeFixtureRemote(t *testing.T, version string, files []agentsFile) string 
 	return "file://" + src
 }
 
-func TestParseSource_Valid(t *testing.T) {
-	t.Parallel()
-	src, err := ParseSource("  eminwux/agents@v1.4.0  ")
+// tagSrc is the resolved test source for the fixture remote's v1.4.0 tag.
+func tagSrc(t *testing.T) Source {
+	t.Helper()
+	s, err := FromModel(model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"})
 	if err != nil {
-		t.Fatalf("ParseSource: %v", err)
+		t.Fatalf("FromModel: %v", err)
 	}
-	if src.OwnerRepo != "eminwux/agents" || src.Version != "v1.4.0" || src.Raw != "eminwux/agents@v1.4.0" {
-		t.Errorf("parsed src = %+v", src)
+	return s
+}
+
+func TestFromModel_Forms(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		in            model.TeamSource
+		wantOwnerRepo string
+		wantHost      string
+		wantRef       string
+		wantKind      RefKind
+	}{
+		{
+			"host tag",
+			model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
+			"eminwux/agents",
+			"github.com",
+			"v1.4.0",
+			RefTag,
+		},
+		{
+			"bare defaults host",
+			model.TeamSource{Repo: "eminwux/agents", Tag: "v1.4.0"},
+			"eminwux/agents",
+			"github.com",
+			"v1.4.0",
+			RefTag,
+		},
+		{
+			"floating branch",
+			model.TeamSource{Repo: "github.com/eminwux/agents", Branch: "main"},
+			"eminwux/agents",
+			"github.com",
+			"main",
+			RefBranch,
+		},
+		{
+			"pinned commit",
+			model.TeamSource{Repo: "github.com/eminwux/agents", Commit: "9ae9606"},
+			"eminwux/agents",
+			"github.com",
+			"9ae9606",
+			RefCommit,
+		},
+		{
+			"nested host path",
+			model.TeamSource{Repo: "gitlab.com/grp/sub/repo", Branch: "trunk"},
+			"grp/sub/repo",
+			"gitlab.com",
+			"trunk",
+			RefBranch,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s, err := FromModel(tc.in)
+			if err != nil {
+				t.Fatalf("FromModel: %v", err)
+			}
+			if s.OwnerRepo != tc.wantOwnerRepo || s.Host != tc.wantHost || s.Ref != tc.wantRef ||
+				s.Kind != tc.wantKind {
+				t.Errorf("FromModel = %+v", s)
+			}
+			if s.Floating() != (tc.wantKind == RefBranch) {
+				t.Errorf("Floating() = %v, kind = %v", s.Floating(), tc.wantKind)
+			}
+		})
 	}
 }
 
-func TestParseSource_Rejects(t *testing.T) {
+func TestFromModel_Rejects(t *testing.T) {
 	t.Parallel()
-	for _, raw := range []string{
-		"eminwux/agents@main",        // floating ref
-		"eminwux/agents@v1",          // bare tag
-		"eminwux/agents",             // missing version
-		"eminwux@v1.4.0",             // missing repo
-		"eminwux/agents@1.4.0",       // missing v prefix
-		"eminwux/agents@v1.4",        // not pinned-exact
-		"",                           // empty
-		"eminwux/agents@v1.4.0/path", // extra path
+	for _, in := range []model.TeamSource{
+		{Repo: "github.com/eminwux/agents"},                            // no ref
+		{Repo: "github.com/eminwux/agents", Tag: "v1", Branch: "main"}, // two refs
+		{Repo: "agents", Tag: "v1.4.0"},                                // missing owner
+		{Tag: "v1.4.0"},                                                // missing repo
 	} {
-		if _, err := ParseSource(raw); !errors.Is(err, errdefs.ErrTeamSourceInvalid) {
-			t.Errorf("ParseSource(%q) err = %v, want ErrTeamSourceInvalid", raw, err)
+		if _, err := FromModel(in); !errors.Is(err, errdefs.ErrTeamSourceInvalid) {
+			t.Errorf("FromModel(%+v) err = %v, want ErrTeamSourceInvalid", in, err)
 		}
 	}
 }
 
-func TestCloneURL_Mapped(t *testing.T) {
+func TestCloneURL_SSHDefault(t *testing.T) {
 	t.Parallel()
-	tc := &model.TeamsConfig{
-		Spec: model.TeamsConfigSpec{
-			Sources: map[string]string{
-				"eminwux/agents": "  git@github.com:eminwux/agents.git  ",
-			},
-		},
+	src := tagSrc(t)
+	if got := CloneURL(nil, src); got != "git@github.com:eminwux/agents.git" {
+		t.Errorf("CloneURL(nil) = %q, want SSH default", got)
 	}
-	url, err := CloneURL(tc, Source{OwnerRepo: "eminwux/agents"})
-	if err != nil {
-		t.Fatalf("CloneURL: %v", err)
-	}
-	if url != "git@github.com:eminwux/agents.git" {
-		t.Errorf("CloneURL = %q", url)
+	if got := CloneURL(&model.TeamsConfig{}, src); got != "git@github.com:eminwux/agents.git" {
+		t.Errorf("CloneURL(empty) = %q, want SSH default", got)
 	}
 }
 
-func TestCloneURL_Unmapped(t *testing.T) {
+func TestCloneURL_OverrideByOwnerRepo(t *testing.T) {
 	t.Parallel()
-	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{Sources: map[string]string{}}}
-	_, err := CloneURL(tc, Source{OwnerRepo: "eminwux/agents"})
-	if !errors.Is(err, errdefs.ErrTeamSourceURLNotMapped) {
-		t.Fatalf("err = %v, want ErrTeamSourceURLNotMapped", err)
-	}
-	if !strings.Contains(err.Error(), "eminwux/agents") {
-		t.Errorf("err %q does not name the missing key", err)
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{
+		Sources: map[string]string{"eminwux/agents": "  https://internal.mirror/eminwux/agents.git  "},
+	}}
+	if got := CloneURL(tc, tagSrc(t)); got != "https://internal.mirror/eminwux/agents.git" {
+		t.Errorf("CloneURL = %q, want trimmed override", got)
 	}
 }
 
-func TestCloneURL_BlankValueIsUnmapped(t *testing.T) {
+func TestCloneURL_OverrideByHostQualifiedRepo(t *testing.T) {
 	t.Parallel()
-	tc := &model.TeamsConfig{
-		Spec: model.TeamsConfigSpec{
-			Sources: map[string]string{"eminwux/agents": "   "},
-		},
-	}
-	_, err := CloneURL(tc, Source{OwnerRepo: "eminwux/agents"})
-	if !errors.Is(err, errdefs.ErrTeamSourceURLNotMapped) {
-		t.Fatalf("err = %v, want ErrTeamSourceURLNotMapped on blank value", err)
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{
+		Sources: map[string]string{"github.com/eminwux/agents": "https://internal.mirror/agents.git"},
+	}}
+	if got := CloneURL(tc, tagSrc(t)); got != "https://internal.mirror/agents.git" {
+		t.Errorf("CloneURL = %q, want host-qualified override", got)
 	}
 }
 
-func TestCloneURL_NilTeamsConfig(t *testing.T) {
+func TestCloneURL_BlankOverrideFallsBackToSSH(t *testing.T) {
 	t.Parallel()
-	_, err := CloneURL(nil, Source{OwnerRepo: "eminwux/agents"})
-	if !errors.Is(err, errdefs.ErrTeamSourceURLNotMapped) {
-		t.Fatalf("err = %v, want ErrTeamSourceURLNotMapped on nil TeamsConfig", err)
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{
+		Sources: map[string]string{"eminwux/agents": "   "},
+	}}
+	if got := CloneURL(tc, tagSrc(t)); got != "git@github.com:eminwux/agents.git" {
+		t.Errorf("CloneURL = %q, want SSH default on blank override", got)
 	}
 }
 
@@ -205,13 +278,13 @@ func TestCache_MaterializeClones(t *testing.T) {
 	t.Parallel()
 	url := makeFixtureRemote(t, "v1.4.0", defaultFixtureFiles())
 	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
-	src, _ := ParseSource("eminwux/agents@v1.4.0")
+	src := tagSrc(t)
 
-	dir, err := cache.Materialize(context.Background(), src, url)
+	dir, err := cache.Materialize(context.Background(), src, url, "")
 	if err != nil {
 		t.Fatalf("Materialize: %v", err)
 	}
-	want := filepath.Join(cache.Base, "eminwux/agents@v1.4.0")
+	want := filepath.Join(cache.Base, "github.com/eminwux/agents@v1.4.0")
 	if dir != want {
 		t.Errorf("dir = %q, want %q", dir, want)
 	}
@@ -220,26 +293,26 @@ func TestCache_MaterializeClones(t *testing.T) {
 	}
 }
 
-func TestCache_MaterializeReusesExisting(t *testing.T) {
+func TestCache_MaterializeReusesPinned(t *testing.T) {
 	t.Parallel()
 	url := makeFixtureRemote(t, "v1.4.0", defaultFixtureFiles())
 	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
-	src, _ := ParseSource("eminwux/agents@v1.4.0")
+	src := tagSrc(t)
 
-	dir, err := cache.Materialize(context.Background(), src, url)
+	dir, err := cache.Materialize(context.Background(), src, url, "")
 	if err != nil {
 		t.Fatalf("first Materialize: %v", err)
 	}
-	// Plant a sentinel inside the cache dir. A re-Materialize must not re-clone
-	// (which would wipe the sentinel) — the AC's "existing cache dir at the
-	// pinned version is reused (no re-clone)" contract.
+	// Plant a sentinel inside the cache dir. A re-Materialize of a pinned tag
+	// must not re-clone (which would wipe the sentinel) — the AC's "pinned
+	// refs are reused as-is" contract.
 	sentinel := filepath.Join(dir, ".reuse-sentinel")
 	if err := os.WriteFile(sentinel, []byte("kept"), 0o600); err != nil {
 		t.Fatalf("plant sentinel: %v", err)
 	}
 	// Point the second call at a bogus URL — if Materialize tried to clone, it
 	// would fail loudly, proving reuse is broken.
-	dir2, err := cache.Materialize(context.Background(), src, "file:///nonexistent")
+	dir2, err := cache.Materialize(context.Background(), src, "file:///nonexistent", "")
 	if err != nil {
 		t.Fatalf("second Materialize: %v", err)
 	}
@@ -249,6 +322,57 @@ func TestCache_MaterializeReusesExisting(t *testing.T) {
 	got, err := os.ReadFile(sentinel)
 	if err != nil || string(got) != "kept" {
 		t.Errorf("sentinel lost on reuse: data=%q err=%v", got, err)
+	}
+}
+
+func TestCache_MaterializeRefetchesFloatingBranch(t *testing.T) {
+	t.Parallel()
+	// A floating branch must refetch + reset to the branch tip on every
+	// materialize — blind reuse would silently run a stale roster.
+	remote := t.TempDir()
+	gitRun(t, remote, "init")
+	rolePath := filepath.Join(remote, "roles", "dev", "role.yaml")
+	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rolePath, []byte(validRoleDevYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, remote, "add", ".")
+	gitRun(t, remote, "commit", "-m", "v1")
+	url := "file://" + remote
+
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	src, err := FromModel(model.TeamSource{Repo: "github.com/eminwux/agents", Branch: "main"})
+	if err != nil {
+		t.Fatalf("FromModel: %v", err)
+	}
+
+	dir, err := cache.Materialize(context.Background(), src, url, "")
+	if err != nil {
+		t.Fatalf("first Materialize: %v", err)
+	}
+	// Advance the branch tip with a new commit changing the role body.
+	v2Role := strings.Replace(validRoleDevYAML, "image: [base]", "image: [base, go]", 1)
+	if werr := os.WriteFile(rolePath, []byte(v2Role), 0o644); werr != nil {
+		t.Fatal(werr)
+	}
+	gitRun(t, remote, "add", ".")
+	gitRun(t, remote, "commit", "-m", "v2")
+
+	dir2, err := cache.Materialize(context.Background(), src, url, "")
+	if err != nil {
+		t.Fatalf("second Materialize: %v", err)
+	}
+	if dir2 != dir {
+		t.Errorf("floating refetch path = %q, want %q", dir2, dir)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "roles", "dev", "role.yaml"))
+	if err != nil {
+		t.Fatalf("read role.yaml: %v", err)
+	}
+	if !strings.Contains(string(got), "go") {
+		t.Errorf("floating branch not refetched to tip; body=%q", got)
 	}
 }
 
@@ -283,8 +407,8 @@ func TestCache_MaterializePinsToVersion(t *testing.T) {
 	url := "file://" + src
 
 	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
-	srcRef, _ := ParseSource("eminwux/agents@v1.4.0")
-	dir, err := cache.Materialize(context.Background(), srcRef, url)
+	srcRef := tagSrc(t)
+	dir, err := cache.Materialize(context.Background(), srcRef, url, "")
 	if err != nil {
 		t.Fatalf("Materialize: %v", err)
 	}
@@ -297,14 +421,60 @@ func TestCache_MaterializePinsToVersion(t *testing.T) {
 	}
 }
 
+func TestCache_MaterializePinsToCommit(t *testing.T) {
+	t.Parallel()
+	// Two commits on the default branch; pinning the first commit's SHA must
+	// land that commit's body, not the branch tip's.
+	remote := t.TempDir()
+	gitRun(t, remote, "init")
+	rolePath := filepath.Join(remote, "roles", "dev", "role.yaml")
+	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(rolePath, []byte(validRoleDevYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, remote, "add", ".")
+	gitRun(t, remote, "commit", "-m", "c1")
+	sha := strings.TrimSpace(gitOutput(t, remote, "rev-parse", "HEAD"))
+	// Advance the tip so the pinned SHA is no longer HEAD.
+	v2Role := strings.Replace(validRoleDevYAML, "image: [base]", "image: [base, go]", 1)
+	if werr := os.WriteFile(rolePath, []byte(v2Role), 0o644); werr != nil {
+		t.Fatal(werr)
+	}
+	gitRun(t, remote, "add", ".")
+	gitRun(t, remote, "commit", "-m", "c2")
+	url := "file://" + remote
+
+	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	src, err := FromModel(model.TeamSource{Repo: "github.com/eminwux/agents", Commit: sha})
+	if err != nil {
+		t.Fatalf("FromModel: %v", err)
+	}
+	dir, err := cache.Materialize(context.Background(), src, url, "")
+	if err != nil {
+		t.Fatalf("Materialize commit: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "roles", "dev", "role.yaml"))
+	if err != nil {
+		t.Fatalf("read role.yaml: %v", err)
+	}
+	if strings.Contains(string(got), "go") {
+		t.Errorf("commit pin landed on tip, not c1; body=%q", got)
+	}
+}
+
 func TestCache_MaterializeMissingTagSurfaces(t *testing.T) {
 	t.Parallel()
 	url := makeFixtureRemote(t, "v1.4.0", defaultFixtureFiles())
 	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
-	src, _ := ParseSource("eminwux/agents@v9.9.9") // tag does not exist
+	src, err := FromModel(model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v9.9.9"})
+	if err != nil {
+		t.Fatalf("FromModel: %v", err)
+	}
 
 	dir := cache.Path(src)
-	if _, err := cache.Materialize(context.Background(), src, url); err == nil {
+	if _, merr := cache.Materialize(context.Background(), src, url, ""); merr == nil {
 		t.Fatalf("Materialize: want clone error for missing tag, got nil")
 	}
 	// Atomic-rename guarantee: a failed clone leaves no half-materialized dir.
@@ -317,6 +487,8 @@ func TestResolve_LoadsAllReferenced(t *testing.T) {
 	t.Parallel()
 	url := makeFixtureRemote(t, "v1.4.0", defaultFixtureFiles())
 	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
+	// Default transport is SSH; an override points the resolver at the local
+	// fixture remote without a live SSH host.
 	tc := &model.TeamsConfig{
 		Spec: model.TeamsConfigSpec{
 			Sources: map[string]string{"eminwux/agents": url},
@@ -324,7 +496,7 @@ func TestResolve_LoadsAllReferenced(t *testing.T) {
 	}
 	pt := &model.ProjectTeam{
 		Spec: model.ProjectTeamSpec{
-			Source:   "eminwux/agents@v1.4.0",
+			Source:   model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
 			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
 			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
 		},
@@ -344,26 +516,12 @@ func TestResolve_LoadsAllReferenced(t *testing.T) {
 	}
 }
 
-func TestResolve_UnmappedSourceErrors(t *testing.T) {
-	t.Parallel()
-	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{}}
-	pt := &model.ProjectTeam{
-		Spec: model.ProjectTeamSpec{
-			Source: "eminwux/agents@v1.4.0",
-		},
-	}
-	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
-	_, err := Resolve(context.Background(), cache, tc, pt)
-	if !errors.Is(err, errdefs.ErrTeamSourceURLNotMapped) {
-		t.Fatalf("Resolve err = %v, want ErrTeamSourceURLNotMapped", err)
-	}
-}
-
 func TestResolve_InvalidSourceErrors(t *testing.T) {
 	t.Parallel()
 	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{}}
 	pt := &model.ProjectTeam{
-		Spec: model.ProjectTeamSpec{Source: "eminwux/agents@main"},
+		// No ref set — exactly-one-of violated.
+		Spec: model.ProjectTeamSpec{Source: model.TeamSource{Repo: "github.com/eminwux/agents"}},
 	}
 	cache := NewCache(filepath.Join(t.TempDir(), "cache"))
 	_, err := Resolve(context.Background(), cache, tc, pt)

--- a/pkg/api/model/kuketeams/doc.go
+++ b/pkg/api/model/kuketeams/doc.go
@@ -34,9 +34,10 @@
 // All five kinds are GVK objects sharing one API group, kuketeams.io/v1. The
 // agents-side kinds (Role / Harness / ImageCatalog) are authored in the agents
 // repo but deserialized here — kukeon's parser owns the schema shape of all
-// five. Content versioning is carried solely by the `source: <owner>/<repo>@vX.Y.Z`
-// git-tag pin in ProjectTeam/TeamsConfig; the agents kinds carry no in-file
-// version field (it would be redundant with the pin and drift-prone).
+// five. Content versioning is carried solely by the structured `source`
+// reference (TeamSource: repo + one of tag/branch/commit) in
+// ProjectTeam/TeamEntry; the agents kinds carry no in-file version field (it
+// would be redundant with the ref and drift-prone).
 //
 // The team-layer types are declarative sugar that render onto the existing
 // v1beta1 runtime: TeamsConfig.git is a strict superset of v1beta1.ContainerGit,
@@ -92,8 +93,8 @@ const (
 )
 
 // Metadata is the name-only metadata block carried by ProjectTeam, Role, and
-// Harness. The team kinds intentionally omit a version field — the source pin
-// (`<owner>/<repo>@vX.Y.Z`) is the version authority.
+// Harness. The team kinds intentionally omit a version field — the structured
+// source ref (repo + one of tag/branch/commit) is the version authority.
 type Metadata struct {
 	Name string `json:"name" yaml:"name"`
 }

--- a/pkg/api/model/kuketeams/marshal_test.go
+++ b/pkg/api/model/kuketeams/marshal_test.go
@@ -72,24 +72,27 @@ func TestRoundTripAllKinds(t *testing.T) {
 		APIVersion: model.APIVersionV1, Kind: model.KindProjectTeam,
 		Metadata: model.Metadata{Name: "sbsh"},
 		Spec: model.ProjectTeamSpec{
-			Source:   "eminwux/agents@v1.4.0",
+			Source:   model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
 			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
 			Roles:    []model.ProjectTeamRole{{Ref: "dev", Needs: &model.ProjectRoleNeeds{Image: []string{"go"}}}},
 		},
 	}
 	assertJSONYAML(t, "ProjectTeam", pt, func(got model.ProjectTeam) bool {
-		return got.Spec.Source == "eminwux/agents@v1.4.0" &&
+		return got.Spec.Source.Repo == "github.com/eminwux/agents" && got.Spec.Source.Tag == "v1.4.0" &&
 			len(got.Spec.Roles) == 1 && got.Spec.Roles[0].Needs.Image[0] == "go"
 	})
 
 	te := model.TeamEntry{
 		APIVersion: model.APIVersionV1, Kind: model.KindTeamEntry,
 		Metadata: model.Metadata{Name: "sbsh"},
-		Spec:     model.TeamEntrySpec{Path: "/home/op/src/sbsh", Source: "eminwux/agents@v1.4.0"},
+		Spec: model.TeamEntrySpec{
+			Path:   "/home/op/src/sbsh",
+			Source: &model.TeamSource{Repo: "github.com/eminwux/agents", Branch: "main"},
+		},
 	}
 	assertJSONYAML(t, "TeamEntry", te, func(got model.TeamEntry) bool {
 		return got.Metadata.Name == "sbsh" && got.Spec.Path == "/home/op/src/sbsh" &&
-			got.Spec.Source == "eminwux/agents@v1.4.0"
+			got.Spec.Source != nil && got.Spec.Source.Branch == "main" && got.Spec.Source.Floating()
 	})
 
 	role := model.Role{

--- a/pkg/api/model/kuketeams/projectteam.go
+++ b/pkg/api/model/kuketeams/projectteam.go
@@ -19,8 +19,8 @@ package kuketeams
 // ProjectTeam is the per-project roster, committed as kuketeam.yaml in each
 // project repo. It pins the agents source, declares harness defaults, and lists
 // the roles the project runs. It travels with the project — so its agents
-// `source` is pinned exact while the project repo itself is checked out at
-// floating `main` (the operator's own repo) when materialized.
+// `source` carries an explicit ref intent (a pinned tag/commit for a
+// reproducible roster, or a floating branch tracked across inits).
 type ProjectTeam struct {
 	APIVersion string          `json:"apiVersion" yaml:"apiVersion"`
 	Kind       string          `json:"kind"       yaml:"kind"`
@@ -30,10 +30,11 @@ type ProjectTeam struct {
 
 // ProjectTeamSpec carries the roster.
 type ProjectTeamSpec struct {
-	// Source pins the agents repository as `<owner>/<repo>@<version>` with a
-	// pinned-exact version (e.g. eminwux/agents@v1.4.0). Floating refs and bare
-	// tags without a full version are rejected at parse time.
-	Source string `json:"source"             yaml:"source"`
+	// Source is the structured agents-repository reference (host-explicit repo
+	// plus exactly one of tag/branch/commit). See TeamSource. The legacy
+	// `<owner>/<repo>@vX.Y.Z` string form is rejected at parse time with a
+	// migration error.
+	Source TeamSource `json:"source"             yaml:"source"`
 	// Defaults supplies project-wide harness defaults applied to every role
 	// that does not pin its own.
 	Defaults ProjectTeamDefaults `json:"defaults,omitempty" yaml:"defaults,omitempty"`

--- a/pkg/api/model/kuketeams/source.go
+++ b/pkg/api/model/kuketeams/source.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kuketeams
+
+import "strings"
+
+// DefaultSourceHost is the git host assumed when TeamSource.Repo is a bare
+// `<owner>/<repo>` with no host segment.
+const DefaultSourceHost = "github.com"
+
+// TeamSource is the structured agents-source reference shared by ProjectTeam
+// and TeamEntry. It replaces the former `<owner>/<repo>@vX.Y.Z` string form:
+// `repo` is host-explicit and exactly one of `tag`/`branch`/`commit` carries
+// the ref intent. The key name IS the intent — `tag`/`commit` pin to a
+// reproducible ref, `branch` floats (refetched on every init) — so
+// pinned-vs-floating is unambiguous without interrogating git (a string `@ref`
+// cannot distinguish a branch from a same-named tag).
+type TeamSource struct {
+	// Repo is the host-qualified repository, `<host>/<owner>/<repo>` (e.g.
+	// github.com/eminwux/agents). A bare `<owner>/<repo>` defaults its host to
+	// DefaultSourceHost, but any host may be expressed explicitly.
+	Repo string `json:"repo"             yaml:"repo"`
+	// Tag pins to an exact tag (reproducible). Mutually exclusive with Branch
+	// and Commit.
+	Tag string `json:"tag,omitempty"    yaml:"tag,omitempty"`
+	// Branch floats: the branch tip is refetched and reset on every init.
+	// Mutually exclusive with Tag and Commit.
+	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
+	// Commit pins to an exact commit SHA (reproducible). Mutually exclusive
+	// with Tag and Branch.
+	Commit string `json:"commit,omitempty" yaml:"commit,omitempty"`
+}
+
+// Ref returns the single set ref value and its kind ("tag"/"branch"/"commit").
+// When zero or more than one of Tag/Branch/Commit is set it returns ("", "")
+// — callers treat that as the exactly-one-ref violation the parser rejects.
+func (s TeamSource) Ref() (string, string) {
+	var value, kind string
+	n := 0
+	if v := strings.TrimSpace(s.Tag); v != "" {
+		n++
+		value, kind = v, "tag"
+	}
+	if v := strings.TrimSpace(s.Branch); v != "" {
+		n++
+		value, kind = v, "branch"
+	}
+	if v := strings.TrimSpace(s.Commit); v != "" {
+		n++
+		value, kind = v, "commit"
+	}
+	if n != 1 {
+		return "", ""
+	}
+	return value, kind
+}
+
+// Floating reports whether the source is a floating branch (refetched every
+// init). Tag/commit refs are pinned and return false.
+func (s TeamSource) Floating() bool {
+	_, kind := s.Ref()
+	return kind == "branch"
+}
+
+// Normalized splits Repo into its host and `<owner>/<repo>` halves, applying
+// the DefaultSourceHost default for a bare `<owner>/<repo>`. A segment is
+// treated as a host when it carries a "." or ":" (port) — so `github.com/...`
+// is host-qualified while `eminwux/agents` is bare. The owner/repo half is
+// everything after the host. The first return is the host, the second the
+// owner/repo path.
+func (s TeamSource) Normalized() (string, string) {
+	repo := strings.TrimSpace(s.Repo)
+	first, rest, found := strings.Cut(repo, "/")
+	if !found {
+		// Malformed (no "/"); return as-is so validation can reject it.
+		return DefaultSourceHost, repo
+	}
+	if first != "." && first != ".." && strings.ContainsAny(first, ".:") {
+		return first, rest
+	}
+	return DefaultSourceHost, repo
+}

--- a/pkg/api/model/kuketeams/source.go
+++ b/pkg/api/model/kuketeams/source.go
@@ -76,6 +76,15 @@ func (s TeamSource) Floating() bool {
 	return kind == "branch"
 }
 
+// KindLabel returns "floating" for a branch and "pinned" for a tag/commit —
+// the operator-facing pinned-vs-floating signal `kuke team init` prints.
+func (s TeamSource) KindLabel() string {
+	if s.Floating() {
+		return "floating"
+	}
+	return "pinned"
+}
+
 // Normalized splits Repo into its host and `<owner>/<repo>` halves, applying
 // the DefaultSourceHost default for a bare `<owner>/<repo>`. A segment is
 // treated as a host when it carries a "." or ":" (port) — so `github.com/...`

--- a/pkg/api/model/kuketeams/teamentry.go
+++ b/pkg/api/model/kuketeams/teamentry.go
@@ -32,9 +32,9 @@ type TeamEntry struct {
 // TeamEntrySpec carries the per-project locator + agents pin. Path is an
 // init-time LOCATOR (where the project's kuketeam.yaml was read and from where
 // its clone URL is resolved via `git remote`), not a bind-mount source. Source
-// pins the agents repository as `<owner>/<repo>@vX.Y.Z`, copied from the
-// project's kuketeam.yaml at init time.
+// is the structured agents-repository reference (the same TeamSource struct
+// ProjectTeam carries), copied from the project's kuketeam.yaml at init time.
 type TeamEntrySpec struct {
-	Path   string `json:"path"             yaml:"path"`
-	Source string `json:"source,omitempty" yaml:"source,omitempty"`
+	Path   string      `json:"path"             yaml:"path"`
+	Source *TeamSource `json:"source,omitempty" yaml:"source,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Replaces `ProjectTeamSpec.Source string` (the `<owner>/<repo>@vX.Y.Z` pinned-exact string from #1028/#1046) with a structured `TeamSource` object — host-explicit `repo` plus exactly one of `tag`/`branch`/`commit`. `TeamEntry` adopts the **same shared struct** (`*TeamSource`). This is the live implementation of the object-source spec that was folded into closed #1041 but never shipped (which merged as the string form).
- The key name **is** the intent: `tag`/`commit` → pinned (reproducible), `branch` → floating. Pinned-vs-floating is now unambiguous without git interrogation.
- **Unblocks the motivating need:** the string form's pinned-exact rule rejected `@main`, so no project could reference an agents source that only exists on `main` (the `v0.1.0` tag predates the `harnesses/` layout). `branch: main` now works.

### What changed

- **Model** (`pkg/api/model/kuketeams/source.go`, new): `TeamSource` struct + `Ref()`/`Floating()`/`Normalized()` helpers. `ProjectTeamSpec.Source` → `TeamSource` (value, required); `TeamEntrySpec.Source` → `*TeamSource` (omitempty).
- **Parser** (`internal/kuketeams/parser.go`): drops `sourceRefPattern`/`ownerRepoPattern` string matching; adds exported `ValidateSource` (repo host-qualification + exactly-one-ref) used by both `validateProjectTeam` and `validateTeamEntry`. `@main`-style floating accepted via `branch`. Repo path segments are guarded against `.`/`..` traversal (repo flows into the cache dir name). `TeamsConfig.spec.sources` keys now accept bare or host-qualified form.
- **Migration** (no silent dual-parse): a scalar `spec.source` (the legacy string form) is detected via a `yaml.Node` probe before the typed unmarshal and rejected with `ErrTeamSourceStringForm` carrying the migration hint.
- **Resolver/transport** (`internal/teamsource/teamsource.go`): `FromModel` replaces `ParseSource`. Default transport is **SSH** — `repo: <host>/<owner>/<repo>` → `git@<host>:<owner>/<repo>.git`, cloned under `git.sshKey` (`-i <key> -o IdentitiesOnly=yes` in `GIT_SSH_COMMAND`). `CloneURL` consults `spec.sources` only as an optional override (keyed by host-qualified repo or bare owner/repo); it no longer errors (`ErrTeamSourceURLNotMapped` removed as dead).
- **Cache** (ref-aware): path is `<base>/<host>/<owner>/<repo>@<ref>`. Pinned tag/commit reuse the cache as-is (commit fetched-by-SHA + detached checkout since `--branch` can't take a SHA); floating branch refetches + `reset --hard FETCH_HEAD` on **every** materialize.
- **init** (`cmd/kuke/team/init.go`): prints `agents source: <repo> @ <kind>=<ref> (pinned|floating)` so a non-reproducible roster is visible; writes the structured source into the drop-in `TeamEntry`.
- **Docs** (`docs/site/concepts/team.md`) and package doc-comments updated to the structured contract.

### Implementation notes for the reviewer

- **TeamEntry pointer vs value**: `TeamEntry.Source` is `*TeamSource` (it was `omitempty`); `ProjectTeam.Source` is a value (required). Both reference the one shared `TeamSource` — satisfies the AC's "same shared struct".
- **`sources` key compatibility**: the lookup tries the host-qualified repo first, then bare `<owner>/<repo>`, so a pre-existing `eminwux/agents` override key still resolves.
- **agents repo slot fill** (`teamrender.agentsCloneURL`) now returns the SSH-default URL (not just a mapped override), consistent with SSH-always; still gated on the blueprint declaring the slot.
- **dev-init smoke not run**: this change is host-side `kuke team init` source resolution — it touches none of the build path, the daemon, or `/opt/kukeon`, so the `make dev-init` regression guard does not apply here.

## Test plan

- [x] `make test` (full CI target, `GOWORK=off go test ./... + cmd/kukebuild`) — passes, EXIT=0
- [x] `GOWORK=off go build ./...` and `GOWORK=off go vet ./...` — clean
- [x] `pre-commit run --files <changed>` — all hooks pass (golangci-lint, prettier, addlicense, go-fmt, go-mod-tidy)
- [x] New unit coverage: `FromModel` forms/rejects, `CloneURL` SSH-default + owner-repo/host-qualified/blank overrides, cache pinned-reuse / floating-refetch / commit-pin / missing-tag, parser accepted-forms (tag/branch/commit/host-default/nested-host) + traversal rejection + string-form migration error (ProjectTeam & TeamEntry) + host-qualified sources key, `emitSourceKind` pinned/floating/commit/malformed
- [x] Tree-wide `git grep` confirms removed symbols (`sourceRefPattern`, `ownerRepoPattern`, `ErrTeamSourceURLNotMapped`, `ParseSource`) have no remaining references

Closes #1066