### PR TITLE
feat(team): add kuketeam.yaml roster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /zold/
 /kuke*
+!/kuketeam.yaml
 /kukeond
 # go.work is committed (wires the cmd/kukebuild module for editor / gopls
 # navigation, issue #655) but go.work.sum is not: builds run per-module

--- a/kuketeam.yaml
+++ b/kuketeam.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: kukeon }
+spec:
+  source: { repo: github.com/eminwux/agents, branch: main }
+  defaults: { harnesses: [claude, opencode] }
+  roles:
+    - { ref: dev, needs: { image: [go] } }
+    - { ref: pm }
+    - { ref: pr-reviewer }


### PR DESCRIPTION
## Summary
- Adds `kuketeam.yaml` at the repo root declaring kukeon's dev crew (dev/pm/pr-reviewer) using the **object `source` format** landed by #1069 (closes the #1066 dependency), with a floating `branch: main` tracking the agents `main` — no release tag required.
- `dev` carries the `go` image capability (kukeon is a Go project); harness defaults `claude`/`opencode`. The roster is reproduced verbatim from the issue proposal.
- Adds a `!/kuketeam.yaml` negation to `.gitignore`. **Non-obvious call:** the existing `/kuke*` pattern (line 2, ignoring the `kuke`/`kukeond`/`kukebuild` build artifacts and `kuke*-dev.yaml`) also matched the new `kuketeam.yaml`, so without the negation the file is invisible to git and cannot be committed. The negation is the minimal change needed to track the file the AC requires; the broad artifact-ignore pattern is left intact.

## Test plan
- [x] `make test` (full CI test target, `GOWORK=off` per Makefile) — exit 0.
- [x] `go test ./internal/kuketeams/... ./cmd/kuke/team/...` (`GOWORK=off`) — pass. (Bare `go test` hits the known `go.work` workspace toolchain-mismatch in `containerd/cgroups`; the Makefile exports `GOWORK=off`, which resolves it.)
- [x] AC1 — `kuketeam.yaml` added at repo root with the roster, parses + validates against the `ProjectTeam` schema (`pkg/api/model/kuketeams`, `internal/kuketeams/parser.go`): `apiVersion: kuketeams.io/v1`, `kind: ProjectTeam`, host-qualified `repo` + floating `branch`, role `needs.image` capability.
- [x] AC2 (source-resolution half) — built `./kuke` and ran `./kuke team init`: it parsed the file, printed `agents source: github.com/eminwux/agents @ branch=main (floating)`, scaffolded the facts file, and cloned the agents source into the resolve cache.
- [ ] AC2 (cell-render half) — **could not verify; blocked by a resolver/agents-layout integration gap outside this issue's scope.** `kuke team init` fails at the role-load step: the resolver reads `<cache>/roles/<ref>/role.yaml` (`internal/teamsource/teamsource.go:323`, `RolePath`), but `eminwux/agents` `main` lays roles out at the **top level** (`dev/role.yaml`, `pm/role.yaml`, `pr-reviewer/role.yaml`) with no `roles/` directory — verified against both the resolve cache and the agents repo on disk. Harnesses match (`harnesses/<name>/harness.yaml`, `harnesses/images.yaml` exist on both sides); only the roles path is mismatched. This is independent of the `kuketeam.yaml` content (the file resolves and clones correctly) and the correct fix direction (kuke resolver vs. agents layout) is a project-owner call, so it is deferred rather than worked around in this config-only PR. Filed as a follow-up: see References.

## References
- Depends on #1066 / shipped by #1069 (object `source` support) — landed on `main`.
- Mirrors sbsh's `kuketeam.yaml` (eminwux/sbsh#378), swapping the dev image capability for `go`.
- Follow-up bug for the AC2 render gap: #1071

Closes #1067