### PR TITLE
fix(teamsource): read role.yaml from agents source top level

### DIFF
--- a/internal/teamsource/teamsource.go
+++ b/internal/teamsource/teamsource.go
@@ -318,9 +318,14 @@ func sshKeyOf(tc *model.TeamsConfig) string {
 	return strings.TrimSpace(tc.Spec.Git.SSHKey)
 }
 
-// RolePath is the on-disk role.yaml location for ref under cacheDir.
+// RolePath is the on-disk role.yaml location for ref under cacheDir. Roles
+// live at the agents source's top level (<cacheDir>/<ref>/role.yaml) — the
+// asymmetry vs the `harnesses/`-nested HarnessPath / ImageCatalogPath layout
+// matches the canonical agents repo (github.com/eminwux/agents), which keeps
+// each role under its own top-level directory and groups harnesses (plus the
+// shared images.yaml) under a `harnesses/` umbrella.
 func RolePath(cacheDir, ref string) string {
-	return filepath.Join(cacheDir, "roles", ref, "role.yaml")
+	return filepath.Join(cacheDir, ref, "role.yaml")
 }
 
 // HarnessPath is the on-disk harness.yaml location for name under cacheDir.
@@ -333,9 +338,9 @@ func ImageCatalogPath(cacheDir string) string {
 	return filepath.Join(cacheDir, "harnesses", "images.yaml")
 }
 
-// LoadRole reads <cacheDir>/roles/<ref>/role.yaml, parses it via the
-// kuketeams parser, and returns the typed Role. A document of the wrong kind
-// surfaces ErrTeamRoleFileKind; parse errors carry the file path verbatim.
+// LoadRole reads <cacheDir>/<ref>/role.yaml, parses it via the kuketeams
+// parser, and returns the typed Role. A document of the wrong kind surfaces
+// ErrTeamRoleFileKind; parse errors carry the file path verbatim.
 func LoadRole(cacheDir, ref string) (*model.Role, error) {
 	path := RolePath(cacheDir, ref)
 	doc, err := parseFile(path)

--- a/internal/teamsource/teamsource_test.go
+++ b/internal/teamsource/teamsource_test.go
@@ -113,7 +113,7 @@ spec:
 // fixture-remote tag unless it overrides.
 func defaultFixtureFiles() []agentsFile {
 	return []agentsFile{
-		{path: "roles/dev/role.yaml", body: validRoleDevYAML},
+		{path: "dev/role.yaml", body: validRoleDevYAML},
 		{path: "harnesses/claude/harness.yaml", body: validHarnessClaudeYAML},
 		{path: "harnesses/images.yaml", body: validImageCatalogYAML},
 	}
@@ -288,7 +288,7 @@ func TestCache_MaterializeClones(t *testing.T) {
 	if dir != want {
 		t.Errorf("dir = %q, want %q", dir, want)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "roles", "dev", "role.yaml")); err != nil {
+	if _, err := os.Stat(filepath.Join(dir, "dev", "role.yaml")); err != nil {
 		t.Errorf("role.yaml not present in cache: %v", err)
 	}
 }
@@ -331,7 +331,7 @@ func TestCache_MaterializeRefetchesFloatingBranch(t *testing.T) {
 	// materialize — blind reuse would silently run a stale roster.
 	remote := t.TempDir()
 	gitRun(t, remote, "init")
-	rolePath := filepath.Join(remote, "roles", "dev", "role.yaml")
+	rolePath := filepath.Join(remote, "dev", "role.yaml")
 	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +367,7 @@ func TestCache_MaterializeRefetchesFloatingBranch(t *testing.T) {
 	if dir2 != dir {
 		t.Errorf("floating refetch path = %q, want %q", dir2, dir)
 	}
-	got, err := os.ReadFile(filepath.Join(dir, "roles", "dev", "role.yaml"))
+	got, err := os.ReadFile(filepath.Join(dir, "dev", "role.yaml"))
 	if err != nil {
 		t.Fatalf("read role.yaml: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestCache_MaterializePinsToVersion(t *testing.T) {
 	// v1.5.0 body.
 	src := t.TempDir()
 	gitRun(t, src, "init")
-	rolePath := filepath.Join(src, "roles", "dev", "role.yaml")
+	rolePath := filepath.Join(src, "dev", "role.yaml")
 	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -412,7 +412,7 @@ func TestCache_MaterializePinsToVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Materialize: %v", err)
 	}
-	got, err := os.ReadFile(filepath.Join(dir, "roles", "dev", "role.yaml"))
+	got, err := os.ReadFile(filepath.Join(dir, "dev", "role.yaml"))
 	if err != nil {
 		t.Fatalf("read role.yaml: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestCache_MaterializePinsToCommit(t *testing.T) {
 	// land that commit's body, not the branch tip's.
 	remote := t.TempDir()
 	gitRun(t, remote, "init")
-	rolePath := filepath.Join(remote, "roles", "dev", "role.yaml")
+	rolePath := filepath.Join(remote, "dev", "role.yaml")
 	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +455,7 @@ func TestCache_MaterializePinsToCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Materialize commit: %v", err)
 	}
-	got, err := os.ReadFile(filepath.Join(dir, "roles", "dev", "role.yaml"))
+	got, err := os.ReadFile(filepath.Join(dir, "dev", "role.yaml"))
 	if err != nil {
 		t.Fatalf("read role.yaml: %v", err)
 	}
@@ -537,7 +537,7 @@ func TestLoadRole_WrongKindNamesPath(t *testing.T) {
 	// — the parser dispatched on `kind:`, validated cleanly, but the loader
 	// expected a Role document.
 	dir := t.TempDir()
-	rolePath := filepath.Join(dir, "roles", "dev", "role.yaml")
+	rolePath := filepath.Join(dir, "dev", "role.yaml")
 	if err := os.MkdirAll(filepath.Dir(rolePath), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -659,7 +659,7 @@ func TestLoadRole_MissingFileNamesPath(t *testing.T) {
 	if err == nil {
 		t.Fatalf("want read error, got nil")
 	}
-	wantSub := filepath.Join(dir, "roles", "dev", "role.yaml")
+	wantSub := filepath.Join(dir, "dev", "role.yaml")
 	if !strings.Contains(err.Error(), wantSub) {
 		t.Errorf("err %q does not name role path %q", err, wantSub)
 	}


### PR DESCRIPTION
## Summary
- `RolePath` resolved to `<cacheDir>/roles/<ref>/role.yaml`, but the canonical agents source (`github.com/eminwux/agents` `main`) lays role definitions at the top level (`dev/role.yaml`, `pm/role.yaml`, …) with no `roles/` directory — so `kuke team init` against the project's `kuketeam.yaml` (shipped by #1070) errored on the first `LoadRole` with `roles/dev/role.yaml: no such file or directory`.
- Fix the resolver: `RolePath` now returns `<cacheDir>/<ref>/role.yaml`, matching the agents source's actual layout.
- Updated the `RolePath` docstring to document the asymmetry vs the `harnesses/`-nested `HarnessPath` / `ImageCatalogPath` — roles live at the top level, harnesses (plus the shared `images.yaml`) under `harnesses/` — matching the canonical agents repo's layout. `LoadRole`'s docstring tracks the new path. Resolves AC2's layout-documentation half.
- Test fixtures (`makeFixtureRemote`, the per-test inline remotes in `TestCache_MaterializeRefetchesFloatingBranch`, `TestCache_MaterializePinsToVersion`, `TestCache_MaterializePinsToCommit`, `TestLoadRole_*`) move role files to the top level so the suite continues to exercise the production path.

## Direction picked (project-owner's call)
The issue offered two options and called the choice "project-owner's call". No author comment overrode. Picked **fix the resolver** per dev CLAUDE.md's lower-blast-radius default — the issue itself flags this as the lower-blast-radius option (keeps the agents repo unchanged, single-repo diff, no consumer migration). Reviewer can push back if the symmetric agents-repo migration is preferred instead.

## Test plan
- [x] `make test` (root + kukebuild) green locally on the updated layout.
- [x] `go test ./internal/teamsource/...` green; the existing `TestCache_Materialize*` / `TestResolve_LoadsAllReferenced` / `TestLoadRole_*` suite now exercises the top-level role path end-to-end against a fixture remote.
- [ ] End-to-end `kuke team init` against the live `github.com/eminwux/agents` `main` — deferred. The dev host has no SSH credential for the agents repo, and `kuke team init` clones over SSH by default. The fixture-remote tests above exercise the same `Resolve` → `cache.Materialize` → `LoadRole` / `LoadHarness` / `LoadImageCatalog` chain end-to-end against the new layout; reviewer with SSH access can run `sudo ./kuke team init` against the real source to confirm AC1's render half.

Closes #1071