### PR TITLE
feat(team): kuke team init --build — FROM-walk + per-leaf build (step 2)

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -30,6 +30,7 @@ import (
 	kukshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/kuketeams"
+	"github.com/eminwux/kukeon/internal/teambuild"
 	"github.com/eminwux/kukeon/internal/teamhost"
 	"github.com/eminwux/kukeon/internal/teamrender"
 	"github.com/eminwux/kukeon/internal/teamsource"
@@ -92,6 +93,23 @@ type ApplyForTeamFunc func(
 // MockApplyForTeamKey injects an ApplyForTeamFunc via context for tests.
 type MockApplyForTeamKey struct{}
 
+// BuildAllFunc runs the local-build path for `kuke team init --build`: it
+// walks the FROM directives of the selected catalog leaves under cacheDir,
+// derives the base-before-leaves order, and invokes kukebuild once per
+// image into the target realm's containerd namespace (no registry push).
+// The default implementation delegates to teambuild.BuildAll; tests inject a
+// stub via MockBuildAllKey so the build path can run without a kukebuild
+// binary on PATH.
+type BuildAllFunc func(
+	ctx context.Context,
+	cacheDir, sourceRef, realm string,
+	leaves []*model.ImageCatalogEntry,
+	progressW, stdout, stderr io.Writer,
+) error
+
+// MockBuildAllKey injects a BuildAllFunc via context for tests.
+type MockBuildAllKey struct{}
+
 // NewInitCmd builds the `kuke team init` subcommand. It reads the current
 // project's kuketeam.yaml roster, scaffolds the operator-global facts file on
 // first run, materializes the pinned agents source, renders the per-(role ×
@@ -111,13 +129,21 @@ func NewInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runInit(cmd, dryRun)
+			build, err := cmd.Flags().GetBool("build")
+			if err != nil {
+				return err
+			}
+			return runInit(cmd, dryRun, build)
 		},
 	}
 
 	cmd.Flags().Bool(
 		"dry-run", false,
 		"Render the project's blueprints/configs to stdout without writing the drop-in entry or applying to kukeond",
+	)
+	cmd.Flags().Bool(
+		"build", false,
+		"Locally build the selected catalog images (kukebuild) into the target realm's containerd namespace; no registry push",
 	)
 
 	return cmd
@@ -126,17 +152,17 @@ func NewInitCmd() *cobra.Command {
 // runInit gathers the cobra-coupled inputs (current directory, ~/.kuke layout,
 // git-config reader, project-repo-URL reader, daemon apply reader) and hands
 // them to composeTeam, which holds the testable lifecycle.
-func runInit(cmd *cobra.Command, dryRun bool) error {
+func runInit(cmd *cobra.Command, dryRun, build bool) error {
 	projectDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("resolve current directory: %w", err)
 	}
 	layout := teamhost.NewLayout(config.DefaultKukeDir())
 	return composeTeam(
-		cmd.Context(), cmd.OutOrStdout(), projectDir, layout,
+		cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), projectDir, layout,
 		gitConfigFromCmd(cmd), projectRepoURLFromCmd(cmd), resolveFromCmd(cmd),
-		applyForTeamFromCmd(cmd),
-		dryRun,
+		applyForTeamFromCmd(cmd), buildAllFromCmd(cmd),
+		dryRun, build,
 	)
 }
 
@@ -159,14 +185,15 @@ func runInit(cmd *cobra.Command, dryRun bool) error {
 // stub apply, no live kukeond required.
 func composeTeam(
 	ctx context.Context,
-	out io.Writer,
+	out, errOut io.Writer,
 	projectDir string,
 	layout teamhost.Layout,
 	getGit GitConfigFunc,
 	getProjectURL ProjectRepoURLFunc,
 	resolve ResolveFunc,
 	apply ApplyForTeamFunc,
-	dryRun bool,
+	build BuildAllFunc,
+	dryRun, doBuild bool,
 ) error {
 	pt, err := readProjectTeam(projectDir)
 	if err != nil {
@@ -190,9 +217,24 @@ func composeTeam(
 		fmt.Fprintf(out, "scaffolded operator-global facts at %s\n", layout.GlobalConfigPath())
 	}
 
-	res, err := renderTeam(ctx, layout, projectDir, pt, tc, project, getProjectURL, resolve)
+	res, bundle, err := renderTeam(ctx, layout, projectDir, pt, tc, project, getProjectURL, resolve)
 	if err != nil {
 		return err
+	}
+
+	if doBuild {
+		if dryRun {
+			fmt.Fprintf(out, "# dry-run: --build skipped (no kukebuild invocation); %d catalog leaf(s) selected\n",
+				len(res.Selections))
+		} else if bundle != nil && len(res.Selections) > 0 {
+			realm := teamrender.DefaultRealm
+			if buildErr := build(
+				ctx, bundle.CacheDir, bundle.Source.Ref, realm,
+				res.Selections, out, out, errOut,
+			); buildErr != nil {
+				return fmt.Errorf("build team images: %w", buildErr)
+			}
+		}
 	}
 
 	if dryRun {
@@ -336,7 +378,9 @@ func loadOrScaffoldGlobalConfig(
 // renderTeam resolves the bundle and runs the per-(role × harness) render.
 // When the project declares no harness defaults there is nothing to render
 // and the bundle is not resolved — keeping `kuke team init` against a
-// harness-less roster fast and offline.
+// harness-less roster fast and offline. The resolved bundle is returned to
+// the caller so `--build` can drive teambuild from the same materialized
+// agents source.
 func renderTeam(
 	ctx context.Context,
 	layout teamhost.Layout,
@@ -346,15 +390,15 @@ func renderTeam(
 	project string,
 	getProjectURL ProjectRepoURLFunc,
 	resolve ResolveFunc,
-) (*teamrender.Result, error) {
+) (*teamrender.Result, *teamsource.Bundle, error) {
 	if len(pt.Spec.Defaults.Harnesses) == 0 || len(pt.Spec.Roles) == 0 {
-		return &teamrender.Result{}, nil
+		return &teamrender.Result{}, nil, nil
 	}
 
 	cache := teamsource.NewCache(layout.CacheDir())
 	bundle, err := resolve(ctx, cache, tc, pt)
 	if err != nil {
-		return nil, fmt.Errorf("resolve agents source: %w", err)
+		return nil, nil, fmt.Errorf("resolve agents source: %w", err)
 	}
 
 	projectURL, _ := getProjectURL(ctx, projectDir)
@@ -364,9 +408,9 @@ func renderTeam(
 	}
 	res, err := teamrender.Render(bundle, pt, tc, in)
 	if err != nil {
-		return nil, fmt.Errorf("render team: %w", err)
+		return nil, nil, fmt.Errorf("render team: %w", err)
 	}
-	return res, nil
+	return res, bundle, nil
 }
 
 // emitDryRun prints the rendered objects to out as a multi-document YAML
@@ -539,6 +583,15 @@ func applyForTeamFromCmd(cmd *cobra.Command) ApplyForTeamFunc {
 		defer func() { _ = client.Close() }()
 		return client.ApplyDocumentsForTeam(ctx, rawYAML, team)
 	}
+}
+
+// buildAllFromCmd returns the BuildAllFunc the init flow uses — the test
+// mock from context when present, otherwise teambuild.BuildAll.
+func buildAllFromCmd(cmd *cobra.Command) BuildAllFunc {
+	if mock, ok := cmd.Context().Value(MockBuildAllKey{}).(BuildAllFunc); ok && mock != nil {
+		return mock
+	}
+	return teambuild.BuildAll
 }
 
 // realGitConfig reads a single `git config --global <key>` value. A non-zero

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -90,6 +91,47 @@ func stubResolveErr() ResolveFunc {
 func stubApplyErr() ApplyForTeamFunc {
 	return func(_ context.Context, _ []byte, _ string) (kukeonv1.ApplyDocumentsResult, error) {
 		return kukeonv1.ApplyDocumentsResult{}, errors.New("apply must not be called")
+	}
+}
+
+// stubBuildErr returns a BuildAllFunc that fails on any call — used by tests
+// where --build is not set, so the build path must never fire.
+func stubBuildErr() BuildAllFunc {
+	return func(
+		_ context.Context, _, _, _ string,
+		_ []*model.ImageCatalogEntry, _, _, _ io.Writer,
+	) error {
+		return errors.New("build must not be called")
+	}
+}
+
+// buildCall captures one composeTeam → BuildAllFunc invocation so tests can
+// assert which catalog leaves were handed to kukebuild and against which
+// cache dir / source ref / realm.
+type buildCall struct {
+	CacheDir, SourceRef, Realm string
+	Leaves                     []*model.ImageCatalogEntry
+}
+
+// recordingBuild returns a BuildAllFunc that appends every invocation to
+// *calls under a mutex (so two-project tests can share one recorder) and
+// returns nil. The recorder copies the leaves slice so the caller's mutations
+// to the catalog do not race with later assertions.
+func recordingBuild(mu *sync.Mutex, calls *[]buildCall) BuildAllFunc {
+	return func(
+		_ context.Context,
+		cacheDir, sourceRef, realm string,
+		leaves []*model.ImageCatalogEntry,
+		_, _, _ io.Writer,
+	) error {
+		mu.Lock()
+		defer mu.Unlock()
+		cp := make([]*model.ImageCatalogEntry, len(leaves))
+		copy(cp, leaves)
+		*calls = append(*calls, buildCall{
+			CacheDir: cacheDir, SourceRef: sourceRef, Realm: realm, Leaves: cp,
+		})
+		return nil
 	}
 }
 
@@ -229,8 +271,8 @@ func TestComposeTeamNoProjectFile(t *testing.T) {
 	emptyDir := t.TempDir()
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 	err := composeTeam(
-		context.Background(), &bytes.Buffer{}, emptyDir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
+		context.Background(), &bytes.Buffer{}, io.Discard, emptyDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
 	)
 	if !errors.Is(err, errdefs.ErrTeamProjectFileNotFound) {
 		t.Fatalf("err = %v, want ErrTeamProjectFileNotFound", err)
@@ -242,8 +284,8 @@ func TestComposeTeamWrongKind(t *testing.T) {
 	dir := writeProject(t, "apiVersion: kuketeams.io/v1\nkind: TeamsConfig\nspec: {}\n")
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 	err := composeTeam(
-		context.Background(), &bytes.Buffer{}, dir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
+		context.Background(), &bytes.Buffer{}, io.Discard, dir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
 	)
 	if !errors.Is(err, errdefs.ErrTeamProjectFileKind) {
 		t.Fatalf("err = %v, want ErrTeamProjectFileKind", err)
@@ -265,8 +307,8 @@ func TestComposeTeamScaffoldsAndWrites(t *testing.T) {
 
 	var out bytes.Buffer
 	if err := composeTeam(
-		context.Background(), &out, projectDir, layout,
-		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
+		context.Background(), &out, io.Discard, projectDir, layout,
+		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
@@ -323,8 +365,8 @@ func TestComposeTeamReRunDoesNotRescaffold(t *testing.T) {
 	git := stubGit(map[string]string{"user.name": "A", "user.email": "a@example.com"})
 
 	if err := composeTeam(
-		context.Background(), &bytes.Buffer{}, projectDir, layout,
-		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("first composeTeam: %v", err)
 	}
@@ -336,8 +378,8 @@ func TestComposeTeamReRunDoesNotRescaffold(t *testing.T) {
 	}
 	var out bytes.Buffer
 	if err := composeTeam(
-		context.Background(), &out, projectDir, layout,
-		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
+		context.Background(), &out, io.Discard, projectDir, layout,
+		git, stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("second composeTeam: %v", err)
 	}
@@ -359,8 +401,8 @@ func TestComposeTeamNoGitIdentityOmitsGitBlock(t *testing.T) {
 	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
 
 	if err := composeTeam(
-		context.Background(), &bytes.Buffer{}, projectDir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
@@ -384,8 +426,8 @@ func TestComposeTeamDryRunWritesNothing(t *testing.T) {
 
 	var out bytes.Buffer
 	if err := composeTeam(
-		context.Background(), &out, projectDir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), true,
+		context.Background(), &out, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), true, false,
 	); err != nil {
 		t.Fatalf("composeTeam dry-run: %v", err)
 	}
@@ -410,10 +452,10 @@ func TestComposeTeamDryRunRendersToStdout(t *testing.T) {
 
 	var out bytes.Buffer
 	err := composeTeam(
-		context.Background(), &out, projectDir, layout,
+		context.Background(), &out, io.Discard, projectDir, layout,
 		stubGit(map[string]string{"user.name": "Op", "user.email": "op@example.com"}),
 		stubProjectURL("git@github.com:eminwux/sbsh.git"),
-		stubBundle(bundle), stubApplyErr(), true,
+		stubBundle(bundle), stubApplyErr(), stubBuildErr(), true, false,
 	)
 	if err != nil {
 		t.Fatalf("composeTeam dry-run: %v", err)
@@ -457,12 +499,11 @@ func TestComposeTeamRendersOnNonDryRun(t *testing.T) {
 	)
 	var out bytes.Buffer
 	err := composeTeam(
-		context.Background(), &out, projectDir, layout,
+		context.Background(), &out, io.Discard, projectDir, layout,
 		stubGit(nil),
 		stubProjectURL("git@github.com:eminwux/sbsh.git"),
 		stubBundle(bundle),
-		recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{}),
-		false,
+		recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{}), stubBuildErr(), false, false,
 	)
 	if err != nil {
 		t.Fatalf("composeTeam: %v", err)
@@ -488,9 +529,9 @@ func TestComposeTeamImageSelectHardError(t *testing.T) {
 	bundle.ImageCatalog.Spec.Images[0].Capabilities = []string{"go"}
 
 	err := composeTeam(
-		context.Background(), &bytes.Buffer{}, projectDir, layout,
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
 		stubGit(nil), stubProjectURL(""),
-		stubBundle(bundle), stubApplyErr(), false,
+		stubBundle(bundle), stubApplyErr(), stubBuildErr(), false, false,
 	)
 	if !errors.Is(err, errdefs.ErrTeamImageNoMatch) {
 		t.Fatalf("err = %v, want ErrTeamImageNoMatch", err)
@@ -514,9 +555,9 @@ func TestComposeTeamProjectRepoURLFilledIntoConfig(t *testing.T) {
 
 	var out bytes.Buffer
 	err := composeTeam(
-		context.Background(), &out, projectDir, layout,
+		context.Background(), &out, io.Discard, projectDir, layout,
 		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
-		stubBundle(bundle), stubApplyErr(), true,
+		stubBundle(bundle), stubApplyErr(), stubBuildErr(), true, false,
 	)
 	if err != nil {
 		t.Fatalf("composeTeam: %v", err)
@@ -549,9 +590,9 @@ func TestComposeTeamAppliesRenderedSetToDaemon(t *testing.T) {
 	}
 	var out bytes.Buffer
 	if err := composeTeam(
-		context.Background(), &out, projectDir, layout,
+		context.Background(), &out, io.Discard, projectDir, layout,
 		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
-		stubBundle(bundle), recordingApply(&mu, &calls, result), false,
+		stubBundle(bundle), recordingApply(&mu, &calls, result), stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
@@ -590,9 +631,9 @@ func TestComposeTeamDryRunSkipsApply(t *testing.T) {
 	// stubApplyErr would error if invoked — composeTeam must not reach it.
 	var out bytes.Buffer
 	if err := composeTeam(
-		context.Background(), &out, projectDir, layout,
+		context.Background(), &out, io.Discard, projectDir, layout,
 		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
-		stubBundle(bundle), stubApplyErr(), true,
+		stubBundle(bundle), stubApplyErr(), stubBuildErr(), true, false,
 	); err != nil {
 		t.Fatalf("composeTeam dry-run: %v", err)
 	}
@@ -610,8 +651,8 @@ func TestComposeTeamHarnessLessRosterSkipsApply(t *testing.T) {
 
 	var out bytes.Buffer
 	if err := composeTeam(
-		context.Background(), &out, projectDir, layout,
-		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), false,
+		context.Background(), &out, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
@@ -640,8 +681,8 @@ func TestComposeTeamApplyFailureBlocksDropInWrite(t *testing.T) {
 	}
 
 	err := composeTeam(
-		context.Background(), &bytes.Buffer{}, projectDir, layout,
-		stubGit(nil), stubProjectURL(""), stubBundle(bundle), apply, false,
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubBundle(bundle), apply, stubBuildErr(), false, false,
 	)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("err = %v, want it to wrap %v", err, wantErr)
@@ -665,9 +706,9 @@ func TestComposeTeamWritesNothingUnderRendered(t *testing.T) {
 		calls []applyCall
 	)
 	if err := composeTeam(
-		context.Background(), &bytes.Buffer{}, projectDir, layout,
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
 		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
-		stubBundle(bundle), recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{}), false,
+		stubBundle(bundle), recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{}), stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("composeTeam: %v", err)
 	}
@@ -711,17 +752,17 @@ spec:
 
 	// Init alpha.
 	if err := composeTeam(
-		context.Background(), &bytes.Buffer{}, alphaDir, layout,
+		context.Background(), &bytes.Buffer{}, io.Discard, alphaDir, layout,
 		stubGit(nil), stubProjectURL("git@github.com:eminwux/alpha.git"),
-		stubBundle(bundle), apply, false,
+		stubBundle(bundle), apply, stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("alpha init: %v", err)
 	}
 	// Init beta.
 	if err := composeTeam(
-		context.Background(), &bytes.Buffer{}, betaDir, layout,
+		context.Background(), &bytes.Buffer{}, io.Discard, betaDir, layout,
 		stubGit(nil), stubProjectURL("git@github.com:eminwux/beta.git"),
-		stubBundle(bundle), apply, false,
+		stubBundle(bundle), apply, stubBuildErr(), false, false,
 	); err != nil {
 		t.Fatalf("beta init: %v", err)
 	}
@@ -746,9 +787,9 @@ spec:
 		t.Fatalf("read beta entry: %v", readErr)
 	}
 	if reErr := composeTeam(
-		context.Background(), &bytes.Buffer{}, alphaDir, layout,
+		context.Background(), &bytes.Buffer{}, io.Discard, alphaDir, layout,
 		stubGit(nil), stubProjectURL("git@github.com:eminwux/alpha.git"),
-		stubBundle(bundle), apply, false,
+		stubBundle(bundle), apply, stubBuildErr(), false, false,
 	); reErr != nil {
 		t.Fatalf("alpha re-init: %v", reErr)
 	}
@@ -784,8 +825,114 @@ func TestNewInitCmdParsesDryRunFlag(t *testing.T) {
 	if cmd.Flags().Lookup("dry-run") == nil {
 		t.Fatalf("--dry-run flag not registered")
 	}
+	if cmd.Flags().Lookup("build") == nil {
+		t.Fatalf("--build flag not registered")
+	}
 	if cmd.Name() != "init" {
 		t.Errorf("init cmd name = %q", cmd.Name())
+	}
+}
+
+// TestComposeTeamBuildInvokesBuildAll pins AC 2: `kuke team init --build`
+// invokes the build-set runner against the bundle's cache dir, the source's
+// pinned ref, the default realm, and the catalog leaves teamrender selected
+// for the (role × harness) pairs.
+func TestComposeTeamBuildInvokesBuildAll(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var (
+		mu         sync.Mutex
+		buildCalls []buildCall
+	)
+	build := recordingBuild(&mu, &buildCalls)
+
+	var (
+		applyMu    sync.Mutex
+		applyCalls []applyCall
+	)
+	apply := recordingApply(&applyMu, &applyCalls, kukeonv1.ApplyDocumentsResult{})
+
+	var out bytes.Buffer
+	if err := composeTeam(
+		context.Background(), &out, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), apply, build, false, true,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+
+	if len(buildCalls) != 1 {
+		t.Fatalf("build call count = %d, want 1", len(buildCalls))
+	}
+	call := buildCalls[0]
+	if call.CacheDir != bundle.CacheDir {
+		t.Errorf("build cacheDir = %q, want %q", call.CacheDir, bundle.CacheDir)
+	}
+	if call.SourceRef != bundle.Source.Ref {
+		t.Errorf("build sourceRef = %q, want %q", call.SourceRef, bundle.Source.Ref)
+	}
+	if call.Realm != "default" {
+		t.Errorf("build realm = %q, want %q", call.Realm, "default")
+	}
+	if len(call.Leaves) != 1 || call.Leaves[0].Ref != "claude-go" {
+		t.Errorf("build leaves = %+v, want one entry ref=claude-go", call.Leaves)
+	}
+
+	// Build runs alongside the apply path — both fire.
+	if len(applyCalls) != 1 {
+		t.Errorf("apply call count = %d, want 1 (build does not gate apply)", len(applyCalls))
+	}
+}
+
+// TestComposeTeamBuildSkippedOnDryRun pins the dry-run semantics: --build
+// with --dry-run announces what would build but invokes neither kukebuild
+// nor the daemon apply.
+func TestComposeTeamBuildSkippedOnDryRun(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var out bytes.Buffer
+	if err := composeTeam(
+		context.Background(), &out, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), stubApplyErr(), stubBuildErr(), true, true,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "--build skipped") {
+		t.Errorf("dry-run output missing --build skip marker: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "1 catalog leaf(s) selected") {
+		t.Errorf("dry-run output missing selection count: %q", out.String())
+	}
+}
+
+// TestComposeTeamBuildNotInvokedByDefault pins the inversion: --build off
+// (default) → BuildAllFunc never called. The stubBuildErr would error if it
+// were.
+func TestComposeTeamBuildNotInvokedByDefault(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var (
+		applyMu    sync.Mutex
+		applyCalls []applyCall
+	)
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), recordingApply(&applyMu, &applyCalls, kukeonv1.ApplyDocumentsResult{}),
+		stubBuildErr(), false, false,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
 	}
 }
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -641,4 +641,21 @@ var (
 	ErrTeamBlueprintTemplateMissing = errors.New(
 		"harness blueprint template not found under cache dir",
 	)
+	// ErrTeamBuildContextMissing fires when an ImageCatalog entry's resolved
+	// build.context dir or Dockerfile path does not exist in the materialized
+	// agents source — `kuke team init --build` cannot build the image.
+	ErrTeamBuildContextMissing = errors.New(
+		"build context or dockerfile missing under materialized agents source",
+	)
+	// ErrTeamBuildBaseMissing fires when a leaf Dockerfile's FROM references an
+	// in-repo (kukeon.internal/...) base whose Dockerfile is not present at
+	// `harnesses/<name>/Dockerfile` in the materialized agents source.
+	ErrTeamBuildBaseMissing = errors.New(
+		"in-repo base Dockerfile referenced by FROM is missing",
+	)
+	// ErrTeamBuildCycle fires when the FROM-walk's topo sort cannot place every
+	// build target — i.e. the cloned source's Dockerfile graph contains a cycle.
+	ErrTeamBuildCycle = errors.New(
+		"Dockerfile FROM-graph cycle prevents base-before-leaves build ordering",
+	)
 )

--- a/internal/teambuild/teambuild.go
+++ b/internal/teambuild/teambuild.go
@@ -1,0 +1,519 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package teambuild orchestrates the local `kuke team init --build` path: it
+// walks the FROM directives of the catalog entries a project selected, derives
+// the transitive base-before-leaves build order (the bases base/base-user/
+// base-root are intermediates that live in the agents source tree, not in
+// images.yaml), and invokes the standalone kukebuild binary once per image
+// into the target realm's containerd namespace. Each image is tagged
+// `kukeon.internal/<name>:<version>` and the `REGISTRY=kukeon.internal`
+// build-arg is threaded so leaf FROMs of the form `${REGISTRY}/base-user:latest`
+// resolve to the just-built in-realm base rather than a real registry pull.
+//
+// The kukebuild invocation is deliberately distinct from cmd/kuke/build's
+// `kuke build` CLI shim: that shim replaces the process via syscall.Exec so
+// kukebuild's exit code reaches the operator unmediated. The orchestrator
+// here must build N images and then return to the caller (which proceeds to
+// render and apply), so it spawns kukebuild with os/exec and waits for each
+// to complete — exec-and-return, not exec-and-replace.
+//
+// Step 2 of the build-and-supply epic (#1063, this issue #1064): the
+// build-invoke half. The bind decision (binding the locally-built
+// `kukeon.internal/<name>:<version>` refs into the CellBlueprints instead of
+// the published `entry.Image`) plus the runtime no-pull path for
+// `kukeon.internal/...` refs are step 3 (#1068) and depend on this step's
+// in-realm images.
+package teambuild
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+)
+
+// InternalRegistry is the reserved, non-routable "host" every locally-built
+// kuke image is tagged under. It is ICANN's `.internal` private-use TLD —
+// pulling from it can never accidentally hit a real registry. Leaf Dockerfiles
+// `FROM ${REGISTRY}/base-user:latest` are threaded with this value via
+// `--build-arg REGISTRY=kukeon.internal` so the FROM resolves to the in-realm
+// base just built, rather than the agents source's published default.
+const InternalRegistry = "kukeon.internal"
+
+// baseImageDefaultTag is the tag a base image is built with when its leaf's
+// FROM line did not supply one. The agents convention is `:latest` for the
+// non-versioned bases (base/base-user/base-root), so an absent FROM tag falls
+// through to this default.
+const baseImageDefaultTag = "latest"
+
+// kukebuildBinary is the binary name resolved on PATH. Matches cmd/kuke/build's
+// constant.
+const kukebuildBinary = "kukebuild"
+
+// harnessesDir is the conventional subdir of a cloned agents source under
+// which both leaf catalog entries' build.context paths and the intermediate
+// bases live (e.g. `harnesses/base-user/Dockerfile`). Surfaced as a package
+// constant so the FROM-walk's base lookup and any future relocation stay in
+// one place.
+const harnessesDir = "harnesses"
+
+// lookPath / runStep are indirected as package vars so tests can drive the
+// PATH-lookup and the kukebuild invocation without a real binary on disk. The
+// production paths resolve kukebuild via exec.LookPath and shell it out via
+// os/exec — exec-and-return, never replacing the parent process (that
+// behaviour is reserved for the `kuke build` CLI shim).
+//
+//nolint:gochecknoglobals // test seams for the production PATH lookup + exec
+var (
+	lookPath = exec.LookPath
+	runStep  = realRunStep
+)
+
+// Step is one image kukebuild builds: the resolved on-disk inputs (context
+// dir + Dockerfile path), the tag the result lands under in the realm
+// namespace, and the build-arg map passed to the Dockerfile frontend. Steps
+// flow base-before-leaves through Plan.
+type Step struct {
+	// Name is the image's logical identifier — the catalog entry's ref for a
+	// leaf, or the base directory name (e.g. `base-user`) for an intermediate.
+	// Surfaces in progress logs and the resolved Tag's repo component.
+	Name string
+	// Version is the tag suffix (e.g. `v1.4.0`, `latest`). For leaves it is
+	// the agents source's pinned ref so step 3's bind decision carries a
+	// versioned ref into the CellBlueprint; for bases it mirrors the literal
+	// tag the leaves' FROM line referenced (typically `latest`).
+	Version string
+	// Tag is the full image reference the build is tagged with —
+	// `kukeon.internal/<Name>:<Version>` — passed to kukebuild's `--tag` flag.
+	Tag string
+	// Context is the absolute on-disk path to the build context root passed
+	// as kukebuild's positional argument.
+	Context string
+	// Dockerfile is the absolute on-disk path to the Dockerfile. Passed to
+	// kukebuild's `--file` flag when set.
+	Dockerfile string
+	// BuildArgs is the `--build-arg KEY=VALUE` set forwarded verbatim. Plan
+	// always seeds `REGISTRY=kukeon.internal` so leaf FROMs of the form
+	// `${REGISTRY}/base-user:latest` resolve to the in-realm base.
+	BuildArgs map[string]string
+	// IsLeaf records whether this step is a catalog leaf (vs. a transitive
+	// base intermediate). Diagnostic only — the build invocation is identical.
+	IsLeaf bool
+}
+
+// Plan resolves the build set for a project's selected catalog entries. For
+// each leaf entry the planner reads its build.context + build.dockerfile,
+// parses the Dockerfile's FROM directives, substitutes ${REGISTRY} with the
+// kukeon.internal host, and follows any FROM that lands under
+// `kukeon.internal/<name>:<tag>` as a transitive in-repo base
+// (`<cacheDir>/harnesses/<name>/Dockerfile`). The walk is iterative and
+// dedupes by image name so a base referenced by N leaves builds once. The
+// returned slice is topologically ordered base-before-leaves so a kukebuild
+// loop building it in order satisfies every FROM by the time the leaf builds.
+//
+// sourceRef is the agents source's pinned ref (tag/branch/commit value) used
+// as the leaf images' `<version>` tag suffix. cacheDir is the materialized
+// agents source root teamsource produced.
+//
+// External FROMs (anything not under kukeon.internal — debian:bookworm,
+// docker.io/library/ubuntu, etc.) are pulled by kukebuild from their real
+// registries at build time; the planner records them as inputs but does not
+// produce a Step for them.
+func Plan(
+	cacheDir, sourceRef string,
+	leaves []*model.ImageCatalogEntry,
+) ([]Step, error) {
+	if strings.TrimSpace(cacheDir) == "" {
+		return nil, errors.New("teambuild.Plan: cacheDir is required")
+	}
+	if strings.TrimSpace(sourceRef) == "" {
+		return nil, errors.New("teambuild.Plan: sourceRef is required")
+	}
+
+	// Iterative BFS over the FROM graph. `nodes` carries the discovered build
+	// targets keyed by Step.Name (so a base referenced by multiple leaves
+	// dedupes); `deps` carries the parent→child edges used for topo-sort.
+	nodes := map[string]*Step{}
+	deps := map[string]map[string]struct{}{}
+
+	addEdge := func(parent, child string) {
+		if deps[parent] == nil {
+			deps[parent] = map[string]struct{}{}
+		}
+		deps[parent][child] = struct{}{}
+	}
+
+	// Seed with the leaves. Each leaf's Step uses entry.Ref for Name and
+	// sourceRef for Version per AC 3 — the leaf gets a versioned tag the
+	// step-3 bind decision can rely on.
+	queue := make([]string, 0, len(leaves))
+	for _, e := range leaves {
+		if e == nil {
+			continue
+		}
+		ref := strings.TrimSpace(e.Ref)
+		if ref == "" {
+			return nil, fmt.Errorf("%w: catalog entry missing ref", errdefs.ErrTeamImageRefRequired)
+		}
+		if _, dup := nodes[ref]; dup {
+			continue
+		}
+		ctxDir, dockerfile, err := resolveLeafPaths(cacheDir, e)
+		if err != nil {
+			return nil, err
+		}
+		nodes[ref] = &Step{
+			Name:       ref,
+			Version:    sourceRef,
+			Tag:        formatTag(ref, sourceRef),
+			Context:    ctxDir,
+			Dockerfile: dockerfile,
+			BuildArgs:  defaultBuildArgs(),
+			IsLeaf:     true,
+		}
+		queue = append(queue, ref)
+	}
+
+	// Walk each known step's FROM directives. A FROM that lands under
+	// kukeon.internal is an in-repo dep — look it up at
+	// `harnesses/<name>/Dockerfile`, record an edge, and enqueue if new.
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		step := nodes[name]
+
+		froms, err := readFromRefs(step.Dockerfile)
+		if err != nil {
+			return nil, err
+		}
+		for _, f := range froms {
+			child, childTag, internal := resolveInternalDep(f)
+			if !internal {
+				// External base — kukebuild pulls it from its real registry
+				// during the leaf build. No step needed.
+				continue
+			}
+			addEdge(name, child)
+			if _, seen := nodes[child]; seen {
+				continue
+			}
+			baseCtx := filepath.Join(cacheDir, harnessesDir, child)
+			baseDockerfile := filepath.Join(baseCtx, "Dockerfile")
+			if _, statErr := os.Stat(baseDockerfile); statErr != nil {
+				return nil, fmt.Errorf(
+					"%w: %q references in-repo base %q but %q is missing: %w",
+					errdefs.ErrTeamBuildBaseMissing, step.Dockerfile, child, baseDockerfile, statErr,
+				)
+			}
+			nodes[child] = &Step{
+				Name:       child,
+				Version:    childTag,
+				Tag:        formatTag(child, childTag),
+				Context:    baseCtx,
+				Dockerfile: baseDockerfile,
+				BuildArgs:  defaultBuildArgs(),
+				IsLeaf:     false,
+			}
+			queue = append(queue, child)
+		}
+	}
+
+	return topoSort(nodes, deps)
+}
+
+// resolveLeafPaths resolves a catalog entry's build.context + build.dockerfile
+// to absolute paths under cacheDir. A missing context or Dockerfile is a hard
+// error: the leaf cannot build and the operator should know which agents-tree
+// path is broken.
+func resolveLeafPaths(cacheDir string, e *model.ImageCatalogEntry) (string, string, error) {
+	ctxRel := strings.TrimSpace(e.Build.Context)
+	dfRel := strings.TrimSpace(e.Build.Dockerfile)
+	if ctxRel == "" || dfRel == "" {
+		return "", "", fmt.Errorf(
+			"%w: catalog entry %q missing build.context or build.dockerfile",
+			errdefs.ErrTeamBuildContextMissing, e.Ref,
+		)
+	}
+	ctxDir := filepath.Join(cacheDir, ctxRel)
+	if _, err := os.Stat(ctxDir); err != nil {
+		return "", "", fmt.Errorf(
+			"%w: %q: %w", errdefs.ErrTeamBuildContextMissing, ctxDir, err,
+		)
+	}
+	dockerfile := filepath.Join(ctxDir, dfRel)
+	if _, err := os.Stat(dockerfile); err != nil {
+		return "", "", fmt.Errorf(
+			"%w: %q: %w", errdefs.ErrTeamBuildContextMissing, dockerfile, err,
+		)
+	}
+	return ctxDir, dockerfile, nil
+}
+
+// fromPattern matches a Dockerfile `FROM` directive: optional `--platform=…`,
+// the image reference, optional `AS <stage>`. Case-insensitive on `FROM`/`AS`.
+var fromPattern = regexp.MustCompile(`(?i)^\s*FROM\s+(?:--platform=\S+\s+)?(\S+)(?:\s+AS\s+\S+)?\s*$`)
+
+// readFromRefs parses path's FROM directives. The reader is intentionally
+// minimal — no support for line continuations (`\` at end of line) since the
+// agents harness Dockerfiles do not split FROMs that way, and no parsing of
+// the rest of the Dockerfile. Each FROM ref is returned in source order.
+func readFromRefs(path string) ([]string, error) {
+	f, err := os.Open(path) //nolint:gosec // path was resolved + stat-checked by Plan
+	if err != nil {
+		return nil, fmt.Errorf("read Dockerfile %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var refs []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Strip leading whitespace then a comment so `# FROM …` is ignored.
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		m := fromPattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		refs = append(refs, m[1])
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan Dockerfile %q: %w", path, err)
+	}
+	return refs, nil
+}
+
+// registryVarPattern matches `${REGISTRY}` or `$REGISTRY` in a Dockerfile
+// FROM ref. Only the REGISTRY var is substituted — other build-args are
+// passed through to kukebuild verbatim and resolved at build time.
+var registryVarPattern = regexp.MustCompile(`\$\{REGISTRY\}|\$REGISTRY`)
+
+// resolveInternalDep classifies a Dockerfile FROM ref. The REGISTRY var is
+// substituted with kukeon.internal so a `FROM ${REGISTRY}/base-user:latest`
+// becomes `kukeon.internal/base-user:latest`. If the substituted ref starts
+// with kukeon.internal/, the second return is the base's logical name and
+// the third return is true; the dep is an in-repo intermediate. Otherwise
+// the FROM is external (debian:bookworm, docker.io/...) and is not built.
+func resolveInternalDep(rawFrom string) (name, tag string, internal bool) {
+	resolved := registryVarPattern.ReplaceAllString(rawFrom, InternalRegistry)
+	if !strings.HasPrefix(resolved, InternalRegistry+"/") {
+		return "", "", false
+	}
+	repoTag := strings.TrimPrefix(resolved, InternalRegistry+"/")
+	repo, t, hasTag := strings.Cut(repoTag, ":")
+	if !hasTag {
+		return repo, baseImageDefaultTag, true
+	}
+	if strings.TrimSpace(t) == "" {
+		return repo, baseImageDefaultTag, true
+	}
+	return repo, t, true
+}
+
+// formatTag composes the full image reference for a build step.
+func formatTag(name, version string) string {
+	return InternalRegistry + "/" + name + ":" + version
+}
+
+// defaultBuildArgs returns the build-arg map every step is seeded with — the
+// REGISTRY=kukeon.internal threading per AC 3. Returned fresh each call so a
+// caller-side mutation cannot leak into a sibling step's args.
+func defaultBuildArgs() map[string]string {
+	return map[string]string{"REGISTRY": InternalRegistry}
+}
+
+// topoSort produces a base-before-leaves ordering of nodes given the
+// parent→child edges in deps. A child must build before any parent that
+// FROMs it. Ties break by Name so the output is byte-stable across runs.
+//
+// In-degree-zero seeds are the bases nothing depends on; the walk emits each
+// then removes its outgoing edges, exposing the next layer. A cycle (a
+// Dockerfile cycle in the agents source) surfaces as
+// ErrTeamBuildCycle naming the residual edges.
+func topoSort(nodes map[string]*Step, deps map[string]map[string]struct{}) ([]Step, error) {
+	// Reverse the parent→child edges into child→parents so we can compute
+	// in-degree on the build-order graph (a parent depends on its children;
+	// children must build first).
+	indeg := make(map[string]int, len(nodes))
+	for name := range nodes {
+		indeg[name] = 0
+	}
+	for parent := range deps {
+		for child := range deps[parent] {
+			// child is a build-prereq of parent, so parent's in-degree on
+			// the build graph (edges child→parent) is +1.
+			indeg[parent]++
+			_ = child
+		}
+	}
+
+	// Ready set = nodes with no unresolved prereq.
+	ready := make([]string, 0)
+	for name, d := range indeg {
+		if d == 0 {
+			ready = append(ready, name)
+		}
+	}
+	sort.Strings(ready)
+
+	out := make([]Step, 0, len(nodes))
+	for len(ready) > 0 {
+		// Pop the lexicographically smallest ready node for byte-stable output.
+		name := ready[0]
+		ready = ready[1:]
+		out = append(out, *nodes[name])
+
+		// Remove the just-emitted node from every parent's deps set;
+		// parents whose deps drop to zero become ready.
+		for parent, children := range deps {
+			if _, ok := children[name]; !ok {
+				continue
+			}
+			delete(deps[parent], name)
+			indeg[parent]--
+			if indeg[parent] == 0 {
+				ready = append(ready, parent)
+			}
+		}
+		sort.Strings(ready)
+	}
+
+	if len(out) != len(nodes) {
+		var residual []string
+		for name, d := range indeg {
+			if d != 0 {
+				residual = append(residual, name)
+			}
+		}
+		sort.Strings(residual)
+		return nil, fmt.Errorf(
+			"%w: residual %v", errdefs.ErrTeamBuildCycle, residual,
+		)
+	}
+	return out, nil
+}
+
+// Run invokes kukebuild for a single step. It looks the binary up on PATH,
+// composes the argv, and spawns it via os/exec with the parent's environment
+// — exec-and-return semantics so the team-init lifecycle can continue after
+// each build. Stdout/stderr are forwarded to the supplied writers (typically
+// the operator's terminal) so kukebuild's progress is visible inline.
+func Run(ctx context.Context, step Step, realm string, stdout, stderr io.Writer) error {
+	binPath, err := lookPath(kukebuildBinary)
+	if err != nil {
+		return fmt.Errorf(
+			"%w: `kuke team init --build` shells out to `%s`, which was not found on PATH — "+
+				"install it (e.g. `make kukebuild` then put it on PATH)",
+			errdefs.ErrKukebuildNotFound, kukebuildBinary,
+		)
+	}
+	argv := BuildArgv(step, realm)
+	return runStep(ctx, binPath, argv, stdout, stderr)
+}
+
+// BuildArgv composes the kukebuild argv for a step. argv[0] is the binary
+// name by exec convention. The forwarded flags match cmd/kuke/build's
+// buildArgv shape — `--tag`, `--realm`, `--file`, repeated `--build-arg`s,
+// and the positional context — so the kukebuild surface stays single.
+// build-arg keys are emitted in sorted order so the argv is byte-stable
+// across runs (golang map iteration is randomized).
+func BuildArgv(step Step, realm string) []string {
+	argv := []string{
+		kukebuildBinary,
+		"--tag", step.Tag,
+		"--realm", realm,
+	}
+	if strings.TrimSpace(step.Dockerfile) != "" {
+		argv = append(argv, "--file", step.Dockerfile)
+	}
+	keys := make([]string, 0, len(step.BuildArgs))
+	for k := range step.BuildArgs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		argv = append(argv, "--build-arg", k+"="+step.BuildArgs[k])
+	}
+	argv = append(argv, step.Context)
+	return argv
+}
+
+// realRunStep is the production runStep — spawn kukebuild via os/exec and
+// wait for it to complete. The exit code and stderr text from kukebuild
+// surface as the wrapped error.
+func realRunStep(ctx context.Context, binPath string, argv []string, stdout, stderr io.Writer) error {
+	// argv[0] is the binary name (exec convention); pass argv[1:] as the real
+	// args to exec.CommandContext, which fills argv[0] from binPath itself.
+	cmd := exec.CommandContext(ctx, binPath, argv[1:]...) //nolint:gosec // binPath is from lookPath; argv is built by BuildArgv
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("kukebuild %s: %w", strings.Join(argv[1:], " "), err)
+	}
+	return nil
+}
+
+// BuildAll plans the build set and runs each step in order, halting on the
+// first failure. The caller hands the bundle's CacheDir, the source's
+// pinned ref, the target realm, the selected catalog entries, and stdout/
+// stderr writers; BuildAll handles the FROM-walk, per-step kukebuild
+// invocation, and progress messaging. progressW receives one line per step
+// announcing what is being built before the kukebuild progress stream
+// begins, so an interrupted multi-image build is debuggable from the log.
+//
+// An empty leaves slice is a no-op — a roster with no harnesses selects no
+// images, so there is nothing to build.
+func BuildAll(
+	ctx context.Context,
+	cacheDir, sourceRef, realm string,
+	leaves []*model.ImageCatalogEntry,
+	progressW, stdout, stderr io.Writer,
+) error {
+	if len(leaves) == 0 {
+		return nil
+	}
+	steps, err := Plan(cacheDir, sourceRef, leaves)
+	if err != nil {
+		return err
+	}
+	for _, step := range steps {
+		if progressW != nil {
+			kind := "base"
+			if step.IsLeaf {
+				kind = "leaf"
+			}
+			fmt.Fprintf(progressW, "building %s %s (context=%s)\n", kind, step.Tag, step.Context)
+		}
+		if runErr := Run(ctx, step, realm, stdout, stderr); runErr != nil {
+			return fmt.Errorf("build %s: %w", step.Tag, runErr)
+		}
+	}
+	return nil
+}

--- a/internal/teambuild/teambuild_test.go
+++ b/internal/teambuild/teambuild_test.go
@@ -1,0 +1,491 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teambuild
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+)
+
+// fixtureFile carries one on-disk artifact a fixture cache tree must
+// materialize: a path relative to cacheDir + its contents.
+type fixtureFile struct {
+	path, body string
+}
+
+// writeFixture writes every entry under a fresh cache dir and returns it.
+func writeFixture(t *testing.T, files ...fixtureFile) string {
+	t.Helper()
+	cacheDir := t.TempDir()
+	for _, f := range files {
+		abs := filepath.Join(cacheDir, f.path)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o700); err != nil {
+			t.Fatalf("mkdir %q: %v", filepath.Dir(abs), err)
+		}
+		if err := os.WriteFile(abs, []byte(f.body), 0o600); err != nil {
+			t.Fatalf("write %q: %v", abs, err)
+		}
+	}
+	return cacheDir
+}
+
+// claudeChainFixture builds a four-level FROM chain mirroring the agents
+// repo's harness layout: leaf claude → base-user → base → debian. The
+// intermediate bases live under harnesses/<name>/Dockerfile; the leaf carries
+// a build.context + build.dockerfile.
+func claudeChainFixture(t *testing.T) (string, *model.ImageCatalogEntry) {
+	t.Helper()
+	cacheDir := writeFixture(t,
+		fixtureFile{
+			path: "harnesses/claude/Dockerfile",
+			body: "ARG REGISTRY=docker.io\n" +
+				"FROM ${REGISTRY}/base-user:latest\n" +
+				"RUN echo claude\n",
+		},
+		fixtureFile{
+			path: "harnesses/base-user/Dockerfile",
+			body: "ARG REGISTRY=docker.io\n" +
+				"FROM ${REGISTRY}/base:latest\n" +
+				"RUN echo base-user\n",
+		},
+		fixtureFile{
+			path: "harnesses/base/Dockerfile",
+			body: "FROM debian:bookworm\nRUN echo base\n",
+		},
+	)
+	entry := &model.ImageCatalogEntry{
+		Ref:     "claude",
+		Harness: "claude",
+		Image:   "registry.local/claude:latest",
+		Build: model.ImageCatalogBuild{
+			Context:    "harnesses/claude",
+			Dockerfile: "Dockerfile",
+		},
+		Capabilities: []string{"go", "git"},
+	}
+	return cacheDir, entry
+}
+
+func TestPlanBaseBeforeLeaves(t *testing.T) {
+	t.Parallel()
+	cacheDir, entry := claudeChainFixture(t)
+
+	steps, err := Plan(cacheDir, "v1.4.0", []*model.ImageCatalogEntry{entry})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+
+	wantOrder := []string{"base", "base-user", "claude"}
+	gotOrder := make([]string, len(steps))
+	for i, s := range steps {
+		gotOrder[i] = s.Name
+	}
+	if !reflect.DeepEqual(gotOrder, wantOrder) {
+		t.Fatalf("Plan order = %v, want %v (bases must appear before leaves)", gotOrder, wantOrder)
+	}
+
+	// IsLeaf flag mirrors topology.
+	for _, s := range steps {
+		want := s.Name == "claude"
+		if s.IsLeaf != want {
+			t.Errorf("step %q IsLeaf = %v, want %v", s.Name, s.IsLeaf, want)
+		}
+	}
+
+	// Leaf gets the source ref as its tag suffix per AC 3; intermediates
+	// inherit the literal tag carried in the leaves' FROM line (`latest`).
+	tags := map[string]string{}
+	for _, s := range steps {
+		tags[s.Name] = s.Tag
+	}
+	if got, want := tags["claude"], "kukeon.internal/claude:v1.4.0"; got != want {
+		t.Errorf("leaf tag = %q, want %q", got, want)
+	}
+	if got, want := tags["base-user"], "kukeon.internal/base-user:latest"; got != want {
+		t.Errorf("base-user tag = %q, want %q", got, want)
+	}
+	if got, want := tags["base"], "kukeon.internal/base:latest"; got != want {
+		t.Errorf("base tag = %q, want %q", got, want)
+	}
+
+	// Every step is seeded with REGISTRY=kukeon.internal so leaf FROMs of the
+	// form `${REGISTRY}/base-user:latest` resolve to the in-realm base.
+	for _, s := range steps {
+		if got, want := s.BuildArgs["REGISTRY"], InternalRegistry; got != want {
+			t.Errorf("step %q REGISTRY build-arg = %q, want %q", s.Name, got, want)
+		}
+	}
+}
+
+func TestPlanDedupesSharedBase(t *testing.T) {
+	t.Parallel()
+	// Two leaves both FROM the same in-repo base; the base must appear in
+	// the output exactly once and must precede both leaves.
+	cacheDir := writeFixture(t,
+		fixtureFile{
+			path: "harnesses/alpha/Dockerfile",
+			body: "FROM ${REGISTRY}/base:latest\n",
+		},
+		fixtureFile{
+			path: "harnesses/beta/Dockerfile",
+			body: "FROM ${REGISTRY}/base:latest\n",
+		},
+		fixtureFile{
+			path: "harnesses/base/Dockerfile",
+			body: "FROM debian:bookworm\n",
+		},
+	)
+	leaves := []*model.ImageCatalogEntry{
+		{
+			Ref: "alpha", Harness: "alpha", Image: "registry.local/alpha:latest",
+			Build: model.ImageCatalogBuild{Context: "harnesses/alpha", Dockerfile: "Dockerfile"},
+		},
+		{
+			Ref: "beta", Harness: "beta", Image: "registry.local/beta:latest",
+			Build: model.ImageCatalogBuild{Context: "harnesses/beta", Dockerfile: "Dockerfile"},
+		},
+	}
+
+	steps, err := Plan(cacheDir, "v2", leaves)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	gotOrder := make([]string, len(steps))
+	for i, s := range steps {
+		gotOrder[i] = s.Name
+	}
+	want := []string{"base", "alpha", "beta"}
+	if !reflect.DeepEqual(gotOrder, want) {
+		t.Fatalf("dedup order = %v, want %v (base before both leaves, lex tiebreak)", gotOrder, want)
+	}
+}
+
+func TestPlanMissingBaseSurfacesErrdefs(t *testing.T) {
+	t.Parallel()
+	// Leaf's FROM points at an in-repo base whose Dockerfile is absent —
+	// must surface ErrTeamBuildBaseMissing.
+	cacheDir := writeFixture(t,
+		fixtureFile{
+			path: "harnesses/leaf/Dockerfile",
+			body: "FROM ${REGISTRY}/base-missing:latest\n",
+		},
+	)
+	leaves := []*model.ImageCatalogEntry{
+		{
+			Ref: "leaf", Harness: "leaf", Image: "registry.local/leaf:latest",
+			Build: model.ImageCatalogBuild{Context: "harnesses/leaf", Dockerfile: "Dockerfile"},
+		},
+	}
+
+	_, err := Plan(cacheDir, "v1", leaves)
+	if !errors.Is(err, errdefs.ErrTeamBuildBaseMissing) {
+		t.Fatalf("Plan err = %v, want ErrTeamBuildBaseMissing", err)
+	}
+}
+
+func TestPlanMissingContextSurfacesErrdefs(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	leaves := []*model.ImageCatalogEntry{
+		{
+			Ref: "leaf", Harness: "leaf", Image: "registry.local/leaf:latest",
+			Build: model.ImageCatalogBuild{
+				Context: "harnesses/nonexistent", Dockerfile: "Dockerfile",
+			},
+		},
+	}
+
+	_, err := Plan(cacheDir, "v1", leaves)
+	if !errors.Is(err, errdefs.ErrTeamBuildContextMissing) {
+		t.Fatalf("Plan err = %v, want ErrTeamBuildContextMissing", err)
+	}
+}
+
+func TestPlanExternalFROMNotBuilt(t *testing.T) {
+	t.Parallel()
+	cacheDir := writeFixture(t,
+		fixtureFile{
+			path: "harnesses/leaf/Dockerfile",
+			body: "FROM debian:bookworm\nRUN echo leaf\n",
+		},
+	)
+	leaves := []*model.ImageCatalogEntry{
+		{
+			Ref: "leaf", Harness: "leaf", Image: "registry.local/leaf:latest",
+			Build: model.ImageCatalogBuild{Context: "harnesses/leaf", Dockerfile: "Dockerfile"},
+		},
+	}
+
+	steps, err := Plan(cacheDir, "v1", leaves)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(steps) != 1 || steps[0].Name != "leaf" {
+		t.Fatalf("steps = %+v, want a single leaf step", steps)
+	}
+}
+
+func TestPlanEmptyLeavesIsEmpty(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	steps, err := Plan(cacheDir, "v1", nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(steps) != 0 {
+		t.Fatalf("steps = %v, want empty slice", steps)
+	}
+}
+
+func TestBuildArgvShape(t *testing.T) {
+	t.Parallel()
+	step := Step{
+		Name:       "claude",
+		Version:    "v1.4.0",
+		Tag:        "kukeon.internal/claude:v1.4.0",
+		Context:    "/cache/harnesses/claude",
+		Dockerfile: "/cache/harnesses/claude/Dockerfile",
+		BuildArgs: map[string]string{
+			"REGISTRY": "kukeon.internal",
+			"VERSION":  "v1.4.0",
+		},
+	}
+
+	argv := BuildArgv(step, "kuke-system")
+
+	want := []string{
+		"kukebuild",
+		"--tag", "kukeon.internal/claude:v1.4.0",
+		"--realm", "kuke-system",
+		"--file", "/cache/harnesses/claude/Dockerfile",
+		"--build-arg", "REGISTRY=kukeon.internal",
+		"--build-arg", "VERSION=v1.4.0",
+		"/cache/harnesses/claude",
+	}
+	if !reflect.DeepEqual(argv, want) {
+		t.Fatalf("BuildArgv = %v\n want %v", argv, want)
+	}
+}
+
+func TestBuildArgvBuildArgsSorted(t *testing.T) {
+	t.Parallel()
+	// Go map iteration order is randomized — verify the sorted emission
+	// produces byte-stable output by running BuildArgv many times and
+	// asserting the build-arg order is always alphabetical.
+	step := Step{
+		Name: "leaf", Version: "v1", Tag: "kukeon.internal/leaf:v1",
+		Context:    "/cache/leaf",
+		Dockerfile: "/cache/leaf/Dockerfile",
+		BuildArgs: map[string]string{
+			"ZETA": "z", "ALPHA": "a", "GAMMA": "g", "BETA": "b",
+		},
+	}
+	for i := 0; i < 32; i++ {
+		argv := BuildArgv(step, "default")
+		// Pull the build-arg keys in argv order.
+		var keys []string
+		for j := 0; j < len(argv)-1; j++ {
+			if argv[j] == "--build-arg" {
+				keys = append(keys, strings.SplitN(argv[j+1], "=", 2)[0])
+			}
+		}
+		want := []string{"ALPHA", "BETA", "GAMMA", "ZETA"}
+		if !reflect.DeepEqual(keys, want) {
+			t.Fatalf("iter %d build-arg keys = %v, want %v", i, keys, want)
+		}
+	}
+}
+
+func TestRunSpawnsBinaryViaRunStep(t *testing.T) {
+	// Mutates package-level lookPath/runStep seams; cannot run in parallel
+	// with the other seam-mutating tests.
+	// Override the test seams so Run never resolves a real binary or spawns a
+	// process. The captured argv must mirror BuildArgv's shape.
+	origLook, origRun := lookPath, runStep
+	t.Cleanup(func() { lookPath, runStep = origLook, origRun })
+
+	lookPath = func(name string) (string, error) {
+		if name != kukebuildBinary {
+			t.Fatalf("lookPath(%q): want %q", name, kukebuildBinary)
+		}
+		return "/fake/path/" + name, nil
+	}
+
+	var (
+		mu      sync.Mutex
+		gotBin  string
+		gotArgv []string
+	)
+	runStep = func(_ context.Context, binPath string, argv []string, _, _ io.Writer) error {
+		mu.Lock()
+		defer mu.Unlock()
+		gotBin = binPath
+		gotArgv = append([]string(nil), argv...)
+		return nil
+	}
+
+	step := Step{
+		Name: "leaf", Version: "v1", Tag: "kukeon.internal/leaf:v1",
+		Context:    "/cache/leaf",
+		Dockerfile: "/cache/leaf/Dockerfile",
+		BuildArgs:  map[string]string{"REGISTRY": InternalRegistry},
+	}
+	if err := Run(context.Background(), step, "default", io.Discard, io.Discard); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if gotBin != "/fake/path/kukebuild" {
+		t.Errorf("binPath = %q, want %q", gotBin, "/fake/path/kukebuild")
+	}
+	wantArgv := BuildArgv(step, "default")
+	if !reflect.DeepEqual(gotArgv, wantArgv) {
+		t.Errorf("argv = %v, want %v", gotArgv, wantArgv)
+	}
+}
+
+func TestRunMissingBinarySurfacesErrdefs(t *testing.T) {
+	// Mutates package-level lookPath/runStep seams; cannot run in parallel.
+	origLook, origRun := lookPath, runStep
+	t.Cleanup(func() { lookPath, runStep = origLook, origRun })
+
+	lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	runStep = func(context.Context, string, []string, io.Writer, io.Writer) error {
+		t.Fatalf("runStep must not be called when kukebuild is missing")
+		return nil
+	}
+
+	step := Step{Name: "leaf", Tag: "kukeon.internal/leaf:v1", Context: "/cache/leaf"}
+	err := Run(context.Background(), step, "default", io.Discard, io.Discard)
+	if !errors.Is(err, errdefs.ErrKukebuildNotFound) {
+		t.Fatalf("Run err = %v, want ErrKukebuildNotFound", err)
+	}
+}
+
+func TestBuildAllInvokesPerStepInOrder(t *testing.T) {
+	// Mutates package-level lookPath/runStep seams; cannot run in parallel.
+	cacheDir, entry := claudeChainFixture(t)
+
+	origLook, origRun := lookPath, runStep
+	t.Cleanup(func() { lookPath, runStep = origLook, origRun })
+
+	lookPath = func(string) (string, error) { return "/fake/kukebuild", nil }
+
+	var (
+		mu    sync.Mutex
+		calls []string
+	)
+	runStep = func(_ context.Context, _ string, argv []string, _, _ io.Writer) error {
+		mu.Lock()
+		defer mu.Unlock()
+		// argv carries `--tag <tag>` at positions 1/2.
+		var tag string
+		for i := 0; i < len(argv)-1; i++ {
+			if argv[i] == "--tag" {
+				tag = argv[i+1]
+				break
+			}
+		}
+		calls = append(calls, tag)
+		return nil
+	}
+
+	var progress bytes.Buffer
+	err := BuildAll(
+		context.Background(), cacheDir, "v1.4.0", "default",
+		[]*model.ImageCatalogEntry{entry},
+		&progress, io.Discard, io.Discard,
+	)
+	if err != nil {
+		t.Fatalf("BuildAll: %v", err)
+	}
+
+	wantTags := []string{
+		"kukeon.internal/base:latest",
+		"kukeon.internal/base-user:latest",
+		"kukeon.internal/claude:v1.4.0",
+	}
+	if !reflect.DeepEqual(calls, wantTags) {
+		t.Fatalf("kukebuild call order = %v, want %v", calls, wantTags)
+	}
+
+	// Progress writer must announce every step before kukebuild fires.
+	for _, tag := range wantTags {
+		if !strings.Contains(progress.String(), tag) {
+			t.Errorf("progress output missing %q; got:\n%s", tag, progress.String())
+		}
+	}
+}
+
+func TestBuildAllEmptyLeavesIsNoop(t *testing.T) {
+	// Mutates package-level lookPath/runStep seams; cannot run in parallel.
+	origLook, origRun := lookPath, runStep
+	t.Cleanup(func() { lookPath, runStep = origLook, origRun })
+
+	lookPath = func(string) (string, error) {
+		t.Fatalf("lookPath must not be called on empty leaves")
+		return "", nil
+	}
+	runStep = func(context.Context, string, []string, io.Writer, io.Writer) error {
+		t.Fatalf("runStep must not be called on empty leaves")
+		return nil
+	}
+
+	if err := BuildAll(
+		context.Background(), t.TempDir(), "v1", "default",
+		nil, io.Discard, io.Discard, io.Discard,
+	); err != nil {
+		t.Fatalf("BuildAll on empty leaves: %v", err)
+	}
+}
+
+func TestResolveInternalDep(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in           string
+		wantName     string
+		wantTag      string
+		wantInternal bool
+	}{
+		{"${REGISTRY}/base-user:latest", "base-user", "latest", true},
+		{"$REGISTRY/base:v1", "base", "v1", true},
+		{"kukeon.internal/base-user:latest", "base-user", "latest", true},
+		{"kukeon.internal/leaf", "leaf", "latest", true},
+		{"debian:bookworm", "", "", false},
+		{"docker.io/library/ubuntu:24.04", "", "", false},
+		{"registry.local/leaf:latest", "", "", false},
+	}
+	for _, c := range cases {
+		name, tag, internal := resolveInternalDep(c.in)
+		if name != c.wantName || tag != c.wantTag || internal != c.wantInternal {
+			t.Errorf(
+				"resolveInternalDep(%q) = (%q,%q,%v), want (%q,%q,%v)",
+				c.in, name, tag, internal, c.wantName, c.wantTag, c.wantInternal,
+			)
+		}
+	}
+}

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -102,9 +102,15 @@ type Inputs struct {
 // Result carries the rendered objects from one project's roster. Each
 // CellBlueprint at index i has its companion CellConfig at the same
 // index in Configs, simplifying the apply loop in step 4 (#1043).
+// Selections carries the ImageCatalog entry that satisfied each
+// (role × harness) pair at the same index — `kuke team init --build`
+// hands this slice to teambuild.BuildAll to drive the local build path
+// (#1064). The slice is deduplicated by entry.Ref so a catalog entry
+// reused across multiple (role × harness) pairs builds once.
 type Result struct {
 	Blueprints []*v1beta1.CellBlueprintDoc
 	Configs    []*v1beta1.CellConfigDoc
+	Selections []*model.ImageCatalogEntry
 }
 
 // Render runs the full per-(role × harness) pipeline against a loaded
@@ -134,6 +140,7 @@ func Render(
 	}
 
 	res := &Result{}
+	seenSelections := map[string]struct{}{}
 	for _, ptRole := range pt.Spec.Roles {
 		role, ok := bundle.Roles[ptRole.Ref]
 		if !ok {
@@ -166,6 +173,12 @@ func Render(
 
 			res.Blueprints = append(res.Blueprints, bp)
 			res.Configs = append(res.Configs, cfg)
+			if entry != nil {
+				if _, seen := seenSelections[entry.Ref]; !seen {
+					seenSelections[entry.Ref] = struct{}{}
+					res.Selections = append(res.Selections, entry)
+				}
+			}
 		}
 	}
 	return res, nil


### PR DESCRIPTION
## Summary
- Adds `internal/teambuild` package: walks Dockerfile `FROM`s in the materialized agents source to compute a base-before-leaves build plan, then invokes `kukebuild` per step into the target realm's containerd namespace (exec-and-return via `os/exec`, distinct from `cmd/kuke/build`'s `syscall.Exec` shim).
- Threads `--build-arg REGISTRY=kukeon.internal` through every step; in-repo bases and leaves are tagged `kukeon.internal/<name>:<version>`, no registry push.
- Wires a new `--build` flag through `kuke team init` → `composeTeam` → render → build. `--dry-run --build` announces the leaf count but does not invoke `kukebuild`; standard runs invoke after `Render` and before `Apply`.
- Adds `teamrender.Result.Selections` (dedup'd by entry.Ref) so two roles selecting the same image build once.
- Adds three errdefs sentinels: `ErrTeamBuildContextMissing`, `ErrTeamBuildBaseMissing`, `ErrTeamBuildCycle`.

## Design notes
- Build is invoked at the CLI layer (between Render and Apply) rather than inside `renderTeam`, so the test seam stays a single `BuildAllFunc` package var (`MockBuildAllKey` context value) and dry-run can announce without spawning `kukebuild`.
- Lower-level unit-test seams (`lookPath`, `runStep` package vars in `teambuild`) cover argv composition and ordering without a real `kukebuild` on PATH. Tests that mutate these seams do not run `t.Parallel()`.
- Topological sort uses lexicographic tiebreak for byte-stable build-step ordering.

## Test plan
- [x] `make test` — 104 packages OK (including new `internal/teambuild`).
- [x] `gofmt -l` clean on all modified/created files.
- [x] `git grep -n` swept for removed/renamed literals (none in this diff).
- [ ] `pre-commit run --files …` — host has no network reachability to `github.com` for hook fetch; covered by `gofmt -l` + `make test`.
- [ ] `make dev-init` end-to-end smoke — this PR does not change build paths, daemon code, or `/opt/kukeon` layout; only adds a new package + a new opt-in CLI flag wired through team init. The two-realm regression tail is unchanged.

Closes #1064