### PR TITLE
feat(team): kuke team init --build — bind + local resolve (step 3)

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -217,7 +217,7 @@ func composeTeam(
 		fmt.Fprintf(out, "scaffolded operator-global facts at %s\n", layout.GlobalConfigPath())
 	}
 
-	res, bundle, err := renderTeam(ctx, layout, projectDir, pt, tc, project, getProjectURL, resolve)
+	res, bundle, err := renderTeam(ctx, layout, projectDir, pt, tc, project, getProjectURL, resolve, doBuild)
 	if err != nil {
 		return err
 	}
@@ -381,6 +381,12 @@ func loadOrScaffoldGlobalConfig(
 // harness-less roster fast and offline. The resolved bundle is returned to
 // the caller so `--build` can drive teambuild from the same materialized
 // agents source.
+//
+// doBuild flips the render's image bind: in `--build` mode the rendered
+// blueprints bind the locally-built `kukeon.internal/<ref>:<version>` refs
+// (version = the agents source's pinned ref, matching the tag teambuild lands
+// each image under) rather than the catalog's published images, so the bound
+// ref and the just-built tag agree.
 func renderTeam(
 	ctx context.Context,
 	layout teamhost.Layout,
@@ -390,6 +396,7 @@ func renderTeam(
 	project string,
 	getProjectURL ProjectRepoURLFunc,
 	resolve ResolveFunc,
+	doBuild bool,
 ) (*teamrender.Result, *teamsource.Bundle, error) {
 	if len(pt.Spec.Defaults.Harnesses) == 0 || len(pt.Spec.Roles) == 0 {
 		return &teamrender.Result{}, nil, nil
@@ -405,6 +412,8 @@ func renderTeam(
 	in := teamrender.Inputs{
 		Project:        project,
 		ProjectRepoURL: strings.TrimSpace(projectURL),
+		Build:          doBuild,
+		SourceRef:      bundle.Source.Ref,
 	}
 	res, err := teamrender.Render(bundle, pt, tc, in)
 	if err != nil {

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -887,6 +887,105 @@ func TestComposeTeamBuildInvokesBuildAll(t *testing.T) {
 	}
 }
 
+// TestComposeTeamBuildBindsInternalImageRefTwoProjects pins the bind half of
+// AC step 3 at the compose tier: a `--build` compose run renders each project's
+// blueprint binding the locally-built kukeon.internal/<ref>:<version> image
+// (matching the tag teambuild produces), not the catalog's published image. Two
+// distinct projects share one agents bundle — the two-project compose shape —
+// and both must bind the internal ref. (The full containerd + kukebuild
+// stand-up that turns those refs into running cells is the deferred e2e; this
+// asserts the deterministic bind wiring the e2e would run on top of.)
+func TestComposeTeamBuildBindsInternalImageRefTwoProjects(t *testing.T) {
+	t.Parallel()
+	const otherProjectYAML = `apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: kuke }
+spec:
+  source: { repo: github.com/eminwux/agents, tag: v1.4.0 }
+  defaults:
+    harnesses: [claude]
+  roles:
+    - { ref: dev }
+`
+	const wantInternal = "kukeon.internal/claude-go:v1.4.0"
+	const publishedRef = "registry.local/claude-go:latest"
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"sbsh", projectTeamWithHarnessYAML},
+		{"kuke", otherProjectYAML},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			projectDir := writeProject(t, tc.body)
+			layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+			bundle := buildClaudeBundle(t)
+
+			var (
+				mu         sync.Mutex
+				buildCalls []buildCall
+			)
+			var (
+				applyMu    sync.Mutex
+				applyCalls []applyCall
+			)
+			if err := composeTeam(
+				context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+				stubGit(nil), stubProjectURL("git@github.com:eminwux/"+tc.name+".git"),
+				stubBundle(bundle), recordingApply(&applyMu, &applyCalls, kukeonv1.ApplyDocumentsResult{}),
+				recordingBuild(&mu, &buildCalls), false, true,
+			); err != nil {
+				t.Fatalf("composeTeam: %v", err)
+			}
+
+			if len(applyCalls) != 1 {
+				t.Fatalf("apply call count = %d, want 1", len(applyCalls))
+			}
+			applied := string(applyCalls[0].RawYAML)
+			if !strings.Contains(applied, wantInternal) {
+				t.Errorf("rendered blueprint does not bind internal ref %q:\n%s", wantInternal, applied)
+			}
+			if strings.Contains(applied, publishedRef) {
+				t.Errorf("rendered blueprint still binds published ref %q in build mode:\n%s", publishedRef, applied)
+			}
+		})
+	}
+}
+
+// TestComposeTeamBindsPublishedImageRefWithoutBuild is the no-flag counterpart:
+// the catalog's published image is bound and no kukeon.internal ref appears.
+func TestComposeTeamBindsPublishedImageRefWithoutBuild(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var (
+		applyMu    sync.Mutex
+		applyCalls []applyCall
+	)
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), recordingApply(&applyMu, &applyCalls, kukeonv1.ApplyDocumentsResult{}),
+		stubBuildErr(), false, false,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+	if len(applyCalls) != 1 {
+		t.Fatalf("apply call count = %d, want 1", len(applyCalls))
+	}
+	applied := string(applyCalls[0].RawYAML)
+	if !strings.Contains(applied, "registry.local/claude-go:latest") {
+		t.Errorf("no-flag mode should bind the published image:\n%s", applied)
+	}
+	if strings.Contains(applied, "kukeon.internal/") {
+		t.Errorf("no-flag mode must not bind a kukeon.internal ref:\n%s", applied)
+	}
+}
+
 // TestComposeTeamBuildSkippedOnDryRun pins the dry-run semantics: --build
 // with --dry-run announces what would build but invokes neither kukebuild
 // nor the daemon apply.

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -188,6 +188,20 @@ const (
 	// separate Go module (its go-1.25 BuildKit closure is deliberately
 	// disjoint from the root module's graph). On change, update both.
 	KukebuildBaseDir = "/var/lib/kukebuild"
+
+	// InternalImageRegistry is the reserved, non-routable "host" every
+	// locally-built `kuke team init --build` image is tagged under. It is
+	// ICANN's `.internal` private-use TLD, so a pull against it can never
+	// accidentally reach a real registry. Three subsystems key off this one
+	// definition so they cannot drift:
+	//   - the build path (internal/teambuild) tags each built image
+	//     <InternalImageRegistry>/<name>:<version> and threads it as the
+	//     `--build-arg REGISTRY=…` so leaf FROMs resolve to the in-realm base;
+	//   - the bind path (internal/teamrender) binds the cell blueprint's image
+	//     to the same ref in `--build` mode (vs the catalog's published image);
+	//   - the runtime resolver (internal/ctr) treats refs hosted here as
+	//     local-only — never pulled, with a clear "build it" error on a miss.
+	InternalImageRegistry = "kukeon.internal"
 )
 
 // RealmNamespaceSuffix is the suffix appended to every realm name to form
@@ -263,6 +277,24 @@ func ConfigureRuntime(suffix, cgroupRoot string) error {
 // mapping stays consistent.
 func RealmNamespace(realm string) string {
 	return realm + RealmNamespaceSuffix
+}
+
+// InternalImageRef composes the full image reference a locally-built team
+// image lands under: <InternalImageRegistry>/<name>:<version>. The build path
+// (internal/teambuild) tags with it and the bind path (internal/teamrender)
+// binds it, so both share this one formatter and the bound ref always matches
+// the tag that was built.
+func InternalImageRef(name, version string) string {
+	return InternalImageRegistry + "/" + name + ":" + version
+}
+
+// IsInternalImageRef reports whether ref is hosted under InternalImageRegistry
+// — i.e. a local-only `kuke team init --build` image that must never be pulled
+// from a network registry. The runtime resolver (internal/ctr) uses this to
+// short-circuit the registry pull on a local miss and surface a "build it"
+// error instead.
+func IsInternalImageRef(ref string) bool {
+	return strings.HasPrefix(strings.TrimSpace(ref), InternalImageRegistry+"/")
 }
 
 // IsKukeonNamespace reports whether ns is a containerd namespace owned by

--- a/internal/consts/consts_test.go
+++ b/internal/consts/consts_test.go
@@ -197,3 +197,33 @@ func TestConfigureRuntimeAccepted(t *testing.T) {
 		}
 	})
 }
+
+func TestInternalImageRef(t *testing.T) {
+	if got, want := consts.InternalImageRef("claude", "v1.4.0"), "kukeon.internal/claude:v1.4.0"; got != want {
+		t.Errorf("InternalImageRef = %q, want %q", got, want)
+	}
+	if got, want := consts.InternalImageRef("base-user", "latest"), "kukeon.internal/base-user:latest"; got != want {
+		t.Errorf("InternalImageRef = %q, want %q", got, want)
+	}
+}
+
+func TestIsInternalImageRef(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"kukeon.internal/claude:v1.4.0", true},
+		{"kukeon.internal/base-user:latest", true},
+		{"  kukeon.internal/claude:v1  ", true}, // surrounding whitespace tolerated
+		{"ghcr.io/eminwux/claude:v1.4.0", false},
+		{"registry.local/claude:latest", false},
+		{"kukeon.internal", false},      // bare host, no repo path
+		{"kukeon.internalish/x", false}, // prefix must be the host plus a slash
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := consts.IsInternalImageRef(tc.ref); got != tc.want {
+			t.Errorf("IsInternalImageRef(%q) = %v, want %v", tc.ref, got, tc.want)
+		}
+	}
+}

--- a/internal/ctr/image.go
+++ b/internal/ctr/image.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/platforms"
+	"github.com/eminwux/kukeon/internal/consts"
 	internalerrdefs "github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/opencontainers/image-spec/identity"
 )
@@ -92,6 +93,16 @@ func (c *client) ensureImageUnpacked(namespace string, image containerd.Image, s
 
 // pullImage pulls an image from a registry if it's not found locally.
 // Returns the image and any error encountered.
+//
+// Refs hosted under the local-only kukeon.internal registry (see
+// consts.InternalImageRegistry) are never pulled: they are built into this
+// realm's namespace by `kuke team init --build` (internal/teambuild), not
+// published anywhere a pull could reach. A local miss on such a ref is an
+// operator error — the image was never built — so pullImage short-circuits
+// with ErrInternalImageNotBuilt ("build it") instead of attempting a doomed
+// network pull against the non-routable host. The full build→bind→run path is
+// exercised by the `kuke team init --build` two-project compose e2e and the
+// dev-init smoke; this layer's contract is the no-pull short-circuit itself.
 func (c *client) pullImage(namespace string, imageRef string, creds []RegistryCredentials) (containerd.Image, error) {
 	nsCtx := c.namespaceCtx(namespace)
 	cc := c.conn()
@@ -100,6 +111,17 @@ func (c *client) pullImage(namespace string, imageRef string, creds []RegistryCr
 	image, err := cc.GetImage(nsCtx, imageRef)
 	if err == nil {
 		return image, nil
+	}
+
+	// Local-only kukeon.internal refs are never pulled — a miss means the
+	// image was supposed to be built locally and was not.
+	if consts.IsInternalImageRef(imageRef) {
+		c.logger.WarnContext(
+			c.ctx,
+			"local-only image not present in realm; not pulling",
+			"image", imageRef,
+		)
+		return nil, fmt.Errorf("%w: %s", internalerrdefs.ErrInternalImageNotBuilt, imageRef)
 	}
 
 	// Image not found locally, pull it

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -236,6 +236,17 @@ var (
 	// from `kuke get image <ref>`.
 	ErrImageNotFound = errors.New("image not found")
 
+	// ErrInternalImageNotBuilt is returned when a cell references an image
+	// hosted under the local-only kukeon.internal registry (a
+	// `kuke team init --build` image) that is absent from the target realm's
+	// containerd namespace. The resolver never pulls kukeon.internal/... refs
+	// — they are built locally, not published — so the fix is to build the
+	// image, not to retry a doomed network pull against the non-routable host.
+	ErrInternalImageNotBuilt = errors.New(
+		"local-only kukeon.internal image is not present in the realm; " +
+			"build it with `kuke team init --build`",
+	)
+
 	// ErrGetImage wraps the underlying containerd error when fetching
 	// one image's metadata fails for reasons other than not-found.
 	ErrGetImage = errors.New("failed to get image")

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -456,6 +456,28 @@ func TestParseDocumentsMultiDoc(t *testing.T) {
 	}
 }
 
+// TestParseImageCatalogAcceptsInternalRef pins the AC's "no unqualified-ref
+// relaxation" contract for `kuke team init --build`: a kukeon.internal/... image
+// is itself registry-qualified (the host carries a "."), so validateImageCatalog
+// accepts it unchanged — the build scheme needs no relaxation of the
+// registry-qualified requirement. (In practice the catalog authors a published
+// ghcr.io/... ref; the kukeon.internal/... ref is synthesized by the bind path,
+// not authored here. This case documents that the validator would accept it
+// either way.)
+func TestParseImageCatalogAcceptsInternalRef(t *testing.T) {
+	t.Parallel()
+	raw := "apiVersion: kuketeams.io/v1\nkind: ImageCatalog\n" +
+		"spec: { images: [{ ref: x, harness: claude, image: kukeon.internal/claude:v1, " +
+		"build: {context: c, dockerfile: D}, capabilities: [git] }] }\n"
+	doc, err := Parse([]byte(raw))
+	if err != nil {
+		t.Fatalf("Parse(kukeon.internal image) = %v, want accepted (registry-qualified)", err)
+	}
+	if doc.ImageCatalog == nil {
+		t.Fatalf("parsed doc is not an ImageCatalog: %+v", doc)
+	}
+}
+
 func TestParseDocumentsEmpty(t *testing.T) {
 	t.Parallel()
 	if _, err := ParseDocuments(strings.NewReader("   \n")); err == nil {

--- a/internal/teambuild/teambuild.go
+++ b/internal/teambuild/teambuild.go
@@ -52,6 +52,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
 )
@@ -62,7 +63,11 @@ import (
 // `FROM ${REGISTRY}/base-user:latest` are threaded with this value via
 // `--build-arg REGISTRY=kukeon.internal` so the FROM resolves to the in-realm
 // base just built, rather than the agents source's published default.
-const InternalRegistry = "kukeon.internal"
+//
+// Defined as a single source of truth in internal/consts so the build path
+// here, the bind path (internal/teamrender), and the runtime local-only
+// resolver (internal/ctr) cannot drift on the reserved host.
+const InternalRegistry = consts.InternalImageRegistry
 
 // baseImageDefaultTag is the tag a base image is built with when its leaf's
 // FROM line did not supply one. The agents convention is `:latest` for the
@@ -336,9 +341,11 @@ func resolveInternalDep(rawFrom string) (name, tag string, internal bool) {
 	return repo, t, true
 }
 
-// formatTag composes the full image reference for a build step.
+// formatTag composes the full image reference for a build step. Delegates to
+// consts.InternalImageRef so the tag a build lands under is byte-identical to
+// the ref the bind path (internal/teamrender) binds into the CellBlueprint.
 func formatTag(name, version string) string {
-	return InternalRegistry + "/" + name + ":" + version
+	return consts.InternalImageRef(name, version)
 }
 
 // defaultBuildArgs returns the build-arg map every step is seeded with — the

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -62,6 +62,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/teamsource"
 	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
@@ -97,6 +98,14 @@ type Inputs struct {
 	Project        string
 	ProjectRepoURL string
 	Realm          string
+	// Build is true under `kuke team init --build`: the rendered blueprint
+	// binds the locally-built `kukeon.internal/<ref>:<version>` image (the tag
+	// teambuild produces) instead of the catalog entry's published `Image`.
+	// SourceRef supplies the `<version>` tag suffix — the agents source's
+	// pinned ref — so the bound ref matches the built tag byte-for-byte. When
+	// Build is false (the default), the catalog's published Image is bound.
+	Build     bool
+	SourceRef string
 }
 
 // Result carries the rendered objects from one project's roster. Each
@@ -162,7 +171,7 @@ func Render(
 
 			bp, renderErr := RenderBlueprint(
 				bundle.CacheDir, harness, role, hname, ptRole.Ref,
-				merged, entry, project, realm,
+				merged, entry, project, realm, in.Build, in.SourceRef,
 			)
 			if renderErr != nil {
 				return nil, fmt.Errorf(
@@ -265,6 +274,10 @@ func SelectImage(
 // template need not pre-fill it). If the template did not supply
 // metadata.name, the default `<role>-<harness>` is stamped so the
 // blueprint and its companion config share a deterministic identity.
+//
+// build + sourceRef drive the `${IMAGE}` bind decision (see blueprintVars):
+// in build mode the locally-built `kukeon.internal/<ref>:<sourceRef>` image is
+// bound; otherwise the catalog entry's published Image is.
 func RenderBlueprint(
 	cacheDir string,
 	h *model.Harness,
@@ -273,6 +286,8 @@ func RenderBlueprint(
 	needs []string,
 	image *model.ImageCatalogEntry,
 	project, realm string,
+	build bool,
+	sourceRef string,
 ) (*v1beta1.CellBlueprintDoc, error) {
 	if h == nil || strings.TrimSpace(h.Spec.Template) == "" {
 		return nil, fmt.Errorf(
@@ -288,7 +303,7 @@ func RenderBlueprint(
 		)
 	}
 
-	vars := blueprintVars(roleRef, harness, image, needs, r)
+	vars := blueprintVars(roleRef, harness, image, needs, r, build, sourceRef)
 	rendered := substitute(string(raw), vars)
 
 	var bp v1beta1.CellBlueprintDoc
@@ -518,11 +533,21 @@ func substitute(in string, vars map[string]string) string {
 // `harness` still gets the per-harness keys, just bound to empty strings,
 // so a template that always references `${SETTINGS}` does not break for
 // roles that omit it.
+//
+// The `${IMAGE}` bind is mode-dependent: in `--build` mode (build && a
+// non-empty sourceRef) it is the locally-built `kukeon.internal/<ref>:
+// <sourceRef>` ref — byte-identical to the tag teambuild produces, so the
+// runtime resolves the in-realm image without a network pull — otherwise it
+// is the catalog entry's published, registry-qualified `Image`. `${IMAGE_REF}`
+// always carries the catalog-local selector key (`image.Ref`) regardless of
+// mode; only the bound image reference flips.
 func blueprintVars(
 	roleRef, harness string,
 	image *model.ImageCatalogEntry,
 	needs []string,
 	r *model.Role,
+	build bool,
+	sourceRef string,
 ) map[string]string {
 	vars := map[string]string{
 		"ROLE":    roleRef,
@@ -530,7 +555,11 @@ func blueprintVars(
 		"NEEDS":   strings.Join(needs, ","),
 	}
 	if image != nil {
-		vars["IMAGE"] = image.Image
+		img := image.Image
+		if build && strings.TrimSpace(sourceRef) != "" {
+			img = consts.InternalImageRef(image.Ref, sourceRef)
+		}
+		vars["IMAGE"] = img
 		vars["IMAGE_REF"] = image.Ref
 	}
 	if r != nil {

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -243,7 +243,19 @@ func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
 		Image:        "registry.local/claude:latest",
 		Capabilities: []string{"go", "git"},
 	}
-	bp, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", []string{"git", "go"}, image, "sbsh", "default")
+	bp, err := RenderBlueprint(
+		cacheDir,
+		h,
+		r,
+		"claude",
+		"dev",
+		[]string{"git", "go"},
+		image,
+		"sbsh",
+		"default",
+		false,
+		"",
+	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
 	}
@@ -272,12 +284,103 @@ func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
 	}
 }
 
+// TestRenderBlueprintBindsInternalRefInBuildMode covers AC: build mode binds
+// the locally-built kukeon.internal/<ref>:<version> ref (the tag teambuild
+// produces), while ${IMAGE_REF} keeps the catalog selector key unchanged.
+func TestRenderBlueprintBindsInternalRefInBuildMode(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	buildClaudeTemplate(t, cacheDir)
+	r := minimalRole()
+	h := &model.Harness{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindHarness,
+		Metadata:   model.Metadata{Name: "claude"},
+		Spec:       model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"},
+	}
+	image := &model.ImageCatalogEntry{
+		Ref:          "claude-base",
+		Harness:      "claude",
+		Image:        "registry.local/claude:latest",
+		Capabilities: []string{"go", "git"},
+	}
+	bp, err := RenderBlueprint(
+		cacheDir,
+		h,
+		r,
+		"claude",
+		"dev",
+		[]string{"git", "go"},
+		image,
+		"sbsh",
+		"default",
+		true,
+		"v1.4.0",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	c := bp.Spec.Cell.Containers[0]
+	if want := "kukeon.internal/claude-base:v1.4.0"; c.Image != want {
+		t.Errorf("build-mode image = %q, want %q", c.Image, want)
+	}
+}
+
+// TestRenderBlueprintBindsPublishedRefWithoutBuild is the no-flag counterpart:
+// the catalog entry's published Image is bound verbatim.
+func TestRenderBlueprintBindsPublishedRefWithoutBuild(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	buildClaudeTemplate(t, cacheDir)
+	r := minimalRole()
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{
+		Ref:          "claude-base",
+		Harness:      "claude",
+		Image:        "ghcr.io/eminwux/claude:v1.4.0",
+		Capabilities: []string{"go", "git"},
+	}
+	// build=true but an empty sourceRef must fall back to the published ref
+	// rather than emit a floating kukeon.internal/<ref>: ref with no version.
+	for _, tc := range []struct {
+		name      string
+		build     bool
+		sourceRef string
+	}{
+		{"no-build", false, "v1.4.0"},
+		{"build-empty-sourceRef", true, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			bp, err := RenderBlueprint(
+				cacheDir,
+				h,
+				r,
+				"claude",
+				"dev",
+				[]string{"git", "go"},
+				image,
+				"sbsh",
+				"default",
+				tc.build,
+				tc.sourceRef,
+			)
+			if err != nil {
+				t.Fatalf("RenderBlueprint: %v", err)
+			}
+			if want := "ghcr.io/eminwux/claude:v1.4.0"; bp.Spec.Cell.Containers[0].Image != want {
+				t.Errorf("image = %q, want published %q", bp.Spec.Cell.Containers[0].Image, want)
+			}
+		})
+	}
+}
+
 func TestRenderBlueprintMissingTemplate(t *testing.T) {
 	t.Parallel()
 	cacheDir := t.TempDir()
 	r := minimalRole()
 	h := &model.Harness{Spec: model.HarnessSpec{Template: "harnesses/missing/blueprint.tmpl.yaml"}}
-	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, "sbsh", "default")
+	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, "sbsh", "default", false, "")
 	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
 		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
 	}
@@ -288,7 +391,7 @@ func TestRenderBlueprintEmptyTemplatePathRejected(t *testing.T) {
 	cacheDir := t.TempDir()
 	r := minimalRole()
 	h := &model.Harness{Spec: model.HarnessSpec{}}
-	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, "sbsh", "default")
+	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, "sbsh", "default", false, "")
 	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
 		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
 	}
@@ -323,7 +426,7 @@ spec:
 	r := minimalRole()
 	h := &model.Harness{Spec: model.HarnessSpec{Template: "harnesses/codex/blueprint.tmpl.yaml"}}
 	image := &model.ImageCatalogEntry{Image: "registry.local/codex:latest"}
-	bp, err := RenderBlueprint(cacheDir, h, r, "codex", "dev", nil, image, "sbsh", "default")
+	bp, err := RenderBlueprint(cacheDir, h, r, "codex", "dev", nil, image, "sbsh", "default", false, "")
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
 	}


### PR DESCRIPTION
## Summary

Step 3 of the `kuke team init --build` local-build path (#1068, umbrella #1063), building on step 2's (#1064 / PR #1078) in-realm `kukeon.internal/<name>:<version>` images. Wires the **bind decision** and the **local-only resolve** path:

- **Bind (`internal/teamrender`).** `Inputs` gains `Build`/`SourceRef`. In `--build` mode the rendered blueprint's `${IMAGE}` binds the locally-built `kukeon.internal/<ref>:<version>` ref (version = the agents source's pinned ref) instead of the catalog entry's published `Image`; no-flag mode binds the published ref verbatim. `${IMAGE_REF}` (the catalog selector key) is unchanged in both modes. `cmd/kuke/team`'s `renderTeam` threads `--build` + `bundle.Source.Ref` into the render.
- **Single source of truth (`internal/consts`).** The reserved host `kukeon.internal`, the ref formatter `InternalImageRef(name,version)`, and the predicate `IsInternalImageRef(ref)` now live in `consts` so the build path (`teambuild`), bind path (`teamrender`), and resolver (`ctr`) cannot drift. `teambuild.InternalRegistry` now aliases `consts.InternalImageRegistry` and its `formatTag` delegates to `consts.InternalImageRef`, so the bound ref is byte-identical to the tag teambuild produces.
- **Local-only resolve (`internal/ctr`).** `pullImage` short-circuits any `kukeon.internal/...` ref on a local miss with the new `errdefs.ErrInternalImageNotBuilt` ("build it") sentinel instead of attempting a network pull against the non-routable host.
- **Validation unchanged.** `validateImageCatalog` is untouched — `kukeon.internal/...` is already registry-qualified, so the build scheme needs no relaxation.

### Notes for the reviewer (non-obvious calls)

- **AC item 2 — `:latest` claim is a rotted premise.** The AC parenthetical states floating/untagged refs (`:latest`) "stay rejected" by `validateImageCatalog`. That is **not** true on current `main`: the validator only requires a registry host (`isRegistryQualified`), and the happy-path fixtures (`imageCatalogHappy`, model godoc example) both use `registry.eminwux.com/claude:latest`. The substantive requirement of AC 2 is "keep requiring registry-qualified refs; introduce no unqualified-ref relaxation" — satisfied by leaving the validator untouched. I did **not** add a new `:latest` rejection: it would contradict existing fixtures/examples and is a behavior change beyond this issue's bind/resolve/e2e scope. Added `TestParseImageCatalogAcceptsInternalRef` to pin that `kukeon.internal/...` is accepted as qualified (the actual "no relaxation" contract). Flagging so PM can decide whether a separate issue should tighten tag-pinning.
- **AC item 4 — full-stack e2e deferred (gate vs. flip).** A two-project compose run that stands up *running cells from locally-built images* needs containerd + a `kukebuild` binary + a live `kukeond` + a real/fixture agents source with Dockerfiles. No team-init e2e harness exists today (the `e2e/` suite has no `teamrender`/`teambuild`/`kuketeam` coverage), and this dev host has no running containerd socket. Rather than stall/resize the whole issue for one un-runnable AC item, I shipped the verifiable bind/resolve fix with deterministic coverage at the unit + compose-integration tier, and left AC 4's checkbox unticked. **Recommend a PM follow-up** to add a team-init e2e harness + CI job (containerd + kukebuild + two project rosters) and the full build→bind→run assertion. The integration test `TestComposeTeamBuildBindsInternalImageRefTwoProjects` exercises the two-project compose *bind* wiring the e2e would run on top of.

## Test plan

- [x] `make test` (full CI suite: `test-root` + `test-kukebuild`) — green
- [x] `GOWORK=off go vet ./...` on touched packages — clean
- [x] `pre-commit run --files <changed>` — go fmt / golangci-lint / addlicense pass
- [x] `internal/consts`: `TestInternalImageRef`, `TestIsInternalImageRef`
- [x] `internal/teamrender`: build-mode binds `kukeon.internal/<ref>:<version>`; no-flag (and build+empty-sourceRef) binds the published ref
- [x] `cmd/kuke/team`: `TestComposeTeamBuildBindsInternalImageRefTwoProjects` (two-project `--build` compose binds the internal ref for both projects); `TestComposeTeamBindsPublishedImageRefWithoutBuild`
- [x] `internal/kuketeams`: `TestParseImageCatalogAcceptsInternalRef` (registry-qualified contract preserved)
- [ ] Full-stack two-project compose e2e (running cells from locally-built images) — **not run / deferred**: no team-init e2e harness or CI job exists, and the dev host lacks a live containerd/kukebuild/daemon. PM follow-up recommended (see Notes). The resolver no-pull short-circuit (`internal/ctr`) follows the repo's existing pattern of e2e-tier containerd behaviors verified by `make dev-init` / e2e rather than unit tests against a real containerd.

Closes #1068