### PR TITLE
feat(dev-init): build local kukeond as kukeon.internal/kukeond, not docker.io/library

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ When run from inside a `kukeon-dev-root` cell (the canonical agent workflow), `m
 make dev-init
 ```
 
-`scripts/dev-init.sh` composes the full re-bootstrap loop: `make kuke kukebuild` + `kukeond` symlink, writes `./kukeond-dev.yaml` + `./kuke-dev.yaml` idempotently (guarded by `[ ! -e ]`) and threads `--server-configuration` (admin commands) + `KUKE_CONFIGURATION` (client + parity commands) through every invocation, `kuke daemon reset` of the prior cell, `kuke build -t kukeon-local:dev --realm kuke-system .` building the image straight into the `kuke-system` realm's containerd namespace, `kuke init --kukeond-image docker.io/library/kukeon-local:dev`, and the daemon-parity check below. The script is idempotent — re-running on a healthy host produces a clean re-bootstrap.
+`scripts/dev-init.sh` composes the full re-bootstrap loop: `make kuke kukebuild` + `kukeond` symlink, writes `./kukeond-dev.yaml` + `./kuke-dev.yaml` idempotently (guarded by `[ ! -e ]`) and threads `--server-configuration` (admin commands) + `KUKE_CONFIGURATION` (client + parity commands) through every invocation, `kuke daemon reset` of the prior cell, `kuke build -t kukeon.internal/kukeond:v0.0.0-dev --realm kuke-system .` building the image straight into the `kuke-system` realm's containerd namespace, `kuke init --kukeond-image kukeon.internal/kukeond:v0.0.0-dev`, and the daemon-parity check below. `kukeon.internal` is the ICANN-reserved, non-routable internal host the epic (#1063) adopts for every locally-built kukeon image — a stray pull of one fails fast against the reserved TLD instead of silently hitting Docker Hub. The published default (`KukeondImageRepo = ghcr.io/eminwux/kukeon` in `cmd/config/version.go`) is unchanged; only the local dev-loop ref moves. The script is idempotent — re-running on a healthy host produces a clean re-bootstrap.
 
 The daemon-parity tail of the output (the regression guard) must read:
 
@@ -108,20 +108,20 @@ To run individual phases by hand — e.g. while debugging a single phase — inv
    (created by an earlier `kuke init` pass).
 
    ```bash
-   sudo ./kuke build --build-arg VERSION=v0.0.0-dev -t kukeon-local:dev --realm kuke-system .
-   sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon-local
+   sudo ./kuke build --build-arg VERSION=v0.0.0-dev -t kukeon.internal/kukeond:v0.0.0-dev --realm kuke-system .
+   sudo ctr -n kuke-system.kukeon.io images ls | grep kukeon.internal/kukeond
    ```
 
 4. **Run `kuke init`.**
 
    ```bash
-   sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
+   sudo ./kuke init --kukeond-image kukeon.internal/kukeond:v0.0.0-dev
    ```
 
    Expected tail:
 
    ```
-       - cell "kukeond": created (image docker.io/library/kukeon-local:dev)
+       - cell "kukeond": created (image kukeon.internal/kukeond:v0.0.0-dev)
        - cell cgroup: created
        - cell root container: created
        - cell containers: started

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -19,8 +19,16 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
-LOCAL_TAG="kukeon-local:dev"
-KUKEOND_IMAGE_REF="docker.io/library/${LOCAL_TAG}"
+# Local-only kukeond image ref. `kukeon.internal` is the ICANN-reserved,
+# non-routable internal host the epic (#1063) adopts for every locally-built
+# kukeon image — `kuke build` writes it into the realm's containerd namespace
+# before `kuke init` consumes it, and a stray pull attempt against the
+# reserved TLD fails fast instead of silently hitting Docker Hub (the failure
+# mode `docker.io/library/kukeon-local:dev` left open). The published default
+# `KukeondImageRepo = ghcr.io/eminwux/kukeon` (cmd/config/version.go) is
+# unchanged — only the local dev-loop ref moves.
+KUKEOND_VERSION="v0.0.0-dev"
+KUKEOND_IMAGE_REF="kukeon.internal/kukeond:${KUKEOND_VERSION}"
 # The on-disk metadata layout lives under /opt/kukeon/data/ — see
 # internal/consts.KukeonMetadataSubdir. Siblings of the data root (e.g.
 # /opt/kukeon/bin/kuketty staged by `kuke init`) intentionally fall outside
@@ -302,14 +310,15 @@ else
     step "No prior kukeond cell at ${KUKEOND_CELL_DIR}; skipping reset"
 fi
 
-step "Build ${LOCAL_TAG} into the kuke-system realm"
+step "Build ${KUKEOND_IMAGE_REF} into the kuke-system realm"
 # `kuke build` shells out to `kukebuild`, which embeds BuildKit and writes the
 # image straight into the kuke-system realm's containerd namespace — no docker
 # daemon, no docker-private containerd, no `--from-docker` loader hop. The -t
-# short tag normalizes to docker.io/library/kukeon-local:dev (kukebuild's
-# normalizeImageName), the exact ref `kuke init --kukeond-image` resolves below.
-sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke build --build-arg VERSION=v0.0.0-dev \
-    -t "${LOCAL_TAG}" \
+# tag is fully qualified (`kukeon.internal/kukeond:<version>`), so kukebuild's
+# normalizeImageName preserves it verbatim — no docker.io/library/ rewrite —
+# matching the exact ref `kuke init --kukeond-image` resolves below.
+sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke build --build-arg VERSION="${KUKEOND_VERSION}" \
+    -t "${KUKEOND_IMAGE_REF}" \
     --realm kuke-system .
 
 step "Run kuke init with --kukeond-image ${KUKEOND_IMAGE_REF}"
@@ -329,7 +338,7 @@ sudo --preserve-env="${PRESERVE_ENV_ADMIN}" ./kuke init \
 #
 # Compare the *snapshot chain digest*, not the image ref name: a
 # container's `.Image` field is the ref string set at create time
-# (e.g. `docker.io/library/kukeon-local:dev`) and is unchanged when
+# (e.g. `kukeon.internal/kukeond:v0.0.0-dev`) and is unchanged when
 # `kuke build` overwrites the same tag with a new manifest. The
 # canonical drift signal is the chain digest stored on the container's
 # snapshot at unpack time, derived from the image config blob's


### PR DESCRIPTION
## Summary

- Flip the local dev-loop kukeond image ref from `docker.io/library/kukeon-local:dev` to `kukeon.internal/kukeond:v0.0.0-dev` in `scripts/dev-init.sh` and the AGENTS.md (`CLAUDE.md` symlinks to it) build-path references.
- `kukeon.internal` is the ICANN-reserved, non-routable internal host the epic (#1063) adopts for every locally-built kukeon image. A stray pull attempt against the reserved TLD fails fast against DNS instead of silently hitting Docker Hub — closing the failure mode `docker.io/library/kukeon-local:dev` left open.
- The published default `KukeondImageRepo = ghcr.io/eminwux/kukeon` (`cmd/config/version.go`) is unchanged; only the local dev-loop ref moves. This is step 5 of `epic:b-team` (#1063), the kukeond local-ref analogue of the harness changes shared with #1064 (step 2) and agents#700 (step 4).

## Notes on the AC reading

- **AC 2 "treated as local-only (never pulled); a missing one fails with a clear build/init error":** Read against the umbrella's "ICANN-reserved, non-routable `.internal` host... a stray pull of a `kukeon.internal` ref fails fast and unambiguously instead of hanging on a real registry," the local-only behavior is achieved by the reserved TLD plus the existing GetImage-first short-circuit in `ctr.(*client).pullImage` — when `kuke build` writes `kukeon.internal/kukeond:v0.0.0-dev` into the realm's containerd namespace before `kuke init` consumes it (the happy path), `pullImage`'s GetImage succeeds and no network pull is attempted at all. On the missing-image path the Pull falls through to containerd's resolver, which fails against the reserved TLD with a clear "no such host" wrapped as "failed to pull image kukeon.internal/...". No explicit short-circuit was added in this PR — the design intent the umbrella documents is the natural fail-fast, not a dedicated code path. Happy to add an explicit `kukeon.internal/` prefix guard in `pullImage` if the reviewer prefers a strictly-typed sentinel over the resolver-level failure.
- **AC 4 "`docs/dev-init.md` references the `kukeon.internal/kukeond` form":** `docs/dev-init.md` is scoped to bare-host vs nested-mode execution (the `/.kukeon/bin/kuketty` probe and the `/run/kukeon-dev/` socket redirect) and does not currently reference any image ref — AC 4 is vacuously satisfied for that file. The AGENTS.md (`CLAUDE.md` symlink) reference is the one that needed flipping.
- **Out-of-scope refs left alone:** `docs/site/install/build-from-source.md`, `docs/site/guides/local-dev.md`, `docs/site/cli/kuke-{init,daemon,image}.md`, `README.md`, and unit-test fixtures under `internal/controller/*_test.go`, `cmd/kuke/init/init_test.go`, etc. still reference `docker.io/library/kukeon-local:dev`. Those are either alternative manual flows (docker-daemon-based bring-up, not the `make dev-init` build path the AC covers) or fixture data for unrelated unit tests. The AC restricts the sweep to "the build path" and "`CLAUDE.md` / `docs/dev-init.md`"; bundling the site-docs sweep would mix this PR with the broader Docker-daemon-default retirement that isn't part of #1063's step list.

## Test plan

- [x] `make test` — root-module unit tests + kukebuild tests, all `ok`.
- [x] `make dev-init` — full end-to-end smoke against this branch on a nested kukeon-dev cell. Build, `kuke init`, and the daemon-parity check all reference `kukeon.internal/kukeond:v0.0.0-dev`. Tail confirms:
  - `cell "kukeond": created (image kukeon.internal/kukeond:v0.0.0-dev)`
  - `running kukeond container chain sha256:806e... matches just-built kukeon.internal/kukeond:v0.0.0-dev` (the #857 digest-drift guard resolves the new ref into containerd correctly).
  - Daemon-parity `kuke get realms` shows `default` + `kuke-system` both `Ready`, byte-identical between the daemon-routed and `--no-daemon` invocations.
  - PTY-driven `kuke attach` smoke against the kuketty-wrapped `cattach` cell completes cleanly; parent attach plumbing post-flight verifies intact.

Closes #1065