### PR TITLE
feat(repos): add ContainerRepo.ref for immutable tag/commit pins

### DIFF
--- a/cmd/kuketty/repos.go
+++ b/cmd/kuketty/repos.go
@@ -116,8 +116,17 @@ func resolveRepo(ctx context.Context, repo v1beta1.ContainerRepo, logger *slog.L
 	return status
 }
 
-// cloneRepo clones repo.URL into repo.Target, optionally pinned to repo.Branch.
+// cloneRepo clones repo.URL into repo.Target. When repo.Ref is set the clone
+// fetches the default branch (plus all refs/tags) and then detaches HEAD at
+// the pinned ref — supports both a tag name and a full commit SHA. Otherwise
+// repo.Branch (if set) is forwarded to `git clone --branch`.
 func cloneRepo(ctx context.Context, repo v1beta1.ContainerRepo) error {
+	if repo.Ref != "" {
+		if err := runGit(ctx, "", "clone", repo.URL, repo.Target); err != nil {
+			return err
+		}
+		return runGit(ctx, repo.Target, "checkout", "--detach", repo.Ref)
+	}
 	args := []string{"clone"}
 	if repo.Branch != "" {
 		args = append(args, "--branch", repo.Branch)
@@ -126,10 +135,19 @@ func cloneRepo(ctx context.Context, repo v1beta1.ContainerRepo) error {
 	return runGit(ctx, "", args...)
 }
 
-// fetchRepo updates an existing checkout: fetch the remote, then (when a branch
-// is requested) check it out and fast-forward. A non-fast-forwardable local
-// state surfaces as an error rather than a silent divergence.
+// fetchRepo updates an existing checkout. For a Ref-pinned repo (immutable tag
+// or commit SHA) the path is fetch-tags + checkout --detach, with no
+// fast-forward — `git pull --ff-only` on a detached HEAD has no upstream and
+// would error, so a tag pin only survived a fresh clone before this branch
+// (#1034). For a branch-tracking repo the prior fetch + checkout + ff-only
+// path is preserved.
 func fetchRepo(ctx context.Context, repo v1beta1.ContainerRepo) error {
+	if repo.Ref != "" {
+		if err := runGit(ctx, repo.Target, "fetch", "--prune", "--tags", "origin"); err != nil {
+			return err
+		}
+		return runGit(ctx, repo.Target, "checkout", "--detach", repo.Ref)
+	}
 	if err := runGit(ctx, repo.Target, "fetch", "--prune", "origin"); err != nil {
 		return err
 	}

--- a/cmd/kuketty/repos_test.go
+++ b/cmd/kuketty/repos_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/kuketty/setupstatus"
@@ -45,6 +46,7 @@ func gitRun(t *testing.T, dir string, args ...string) {
 		"-c", "user.name=kukeon test",
 		"-c", "init.defaultBranch=main",
 		"-c", "commit.gpgsign=false",
+		"-c", "tag.gpgsign=false",
 	}, args...)
 	cmd := exec.Command("git", full...)
 	cmd.Dir = dir
@@ -191,6 +193,108 @@ func TestProcessRepos_NonRequiredFailureDoesNotPropagate(t *testing.T) {
 	}
 	if len(statuses) != 1 || statuses[0].State != setupstatus.StateFailed {
 		t.Fatalf("a non-required failure should still be reported as a failed status, got %+v", statuses)
+	}
+}
+
+// gitCapture runs git in dir with the hermetic identity and returns trimmed
+// stdout. Used to read out commit SHAs without polluting host config.
+func gitCapture(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	full := append([]string{
+		"-c", "user.email=test@kukeon.invalid",
+		"-c", "user.name=kukeon test",
+		"-c", "init.defaultBranch=main",
+		"-c", "commit.gpgsign=false",
+		"-c", "tag.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v in %q: %v", args, dir, err)
+	}
+	return string(out)
+}
+
+// TestProcessRepos_RefPinsCloneAndSurvivesRestart exercises the AC for #1034:
+// a Ref-pinned repo clones at a detached HEAD on first boot, and a fetch path
+// re-run (existing .git → in-place restart) stays idempotent — the prior
+// `git pull --ff-only` on a detached HEAD aborted required-repo container
+// start.
+func TestProcessRepos_RefPinsCloneAndSurvivesRestart(t *testing.T) {
+	src := makeSourceRepo(t, "README.md")
+	gitRun(t, src, "tag", "v0.1.0")
+	tagSHA := strings.TrimSpace(gitCapture(t, src, "rev-parse", "v0.1.0^{commit}"))
+
+	target := filepath.Join(t.TempDir(), "checkout")
+	repos := []v1beta1.ContainerRepo{
+		{Name: "pinned", Target: target, Ref: "v0.1.0", URL: src, Required: true},
+	}
+
+	// First pass: clone at the tag (detached HEAD).
+	statuses, err := processRepos(context.Background(), repos, discardLogger())
+	if err != nil {
+		t.Fatalf("first processRepos (clone): %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].State != setupstatus.StateCloned {
+		t.Fatalf("want a single cloned status, got %+v", statuses)
+	}
+	if statuses[0].Commit != tagSHA {
+		t.Errorf("clone HEAD = %q, want tag commit %q", statuses[0].Commit, tagSHA)
+	}
+
+	// Push a new commit on main upstream so a branch-tracking pull would
+	// advance HEAD — a Ref pin must ignore it.
+	if writeErr := os.WriteFile(filepath.Join(src, "second.txt"), []byte("more\n"), 0o644); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "second")
+
+	// Second pass: fetch path — must NOT error on detached HEAD (the
+	// pre-fix `git pull --ff-only` did), and must stay on the tag.
+	statuses, err = processRepos(context.Background(), repos, discardLogger())
+	if err != nil {
+		t.Fatalf("second processRepos (fetch on detached HEAD): %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].State != setupstatus.StateFetched {
+		t.Fatalf("want a single fetched status, got %+v", statuses)
+	}
+	if statuses[0].Commit != tagSHA {
+		t.Errorf("fetch HEAD = %q, want tag commit %q (Ref pin should not advance)", statuses[0].Commit, tagSHA)
+	}
+	if _, statErr := os.Stat(filepath.Join(target, "second.txt")); statErr == nil {
+		t.Errorf("Ref-pinned repo should not pull the upstream second commit")
+	}
+}
+
+// TestProcessRepos_RefPinAcceptsCommitSHA verifies that Ref also accepts a
+// full commit SHA (not just tag names) — the AC's "tag or full SHA" wording.
+func TestProcessRepos_RefPinAcceptsCommitSHA(t *testing.T) {
+	src := makeSourceRepo(t, "README.md")
+	firstSHA := strings.TrimSpace(gitCapture(t, src, "rev-parse", "HEAD"))
+	// Add a second commit so HEAD ≠ pinned SHA: if the clone did not detach,
+	// HEAD would land on the newer commit.
+	if err := os.WriteFile(filepath.Join(src, "second.txt"), []byte("more\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, src, "add", ".")
+	gitRun(t, src, "commit", "-m", "second")
+
+	target := filepath.Join(t.TempDir(), "checkout")
+	repos := []v1beta1.ContainerRepo{
+		{Name: "pinned", Target: target, Ref: firstSHA, URL: src, Required: true},
+	}
+	statuses, err := processRepos(context.Background(), repos, discardLogger())
+	if err != nil {
+		t.Fatalf("processRepos: %v", err)
+	}
+	if len(statuses) != 1 || statuses[0].Commit != firstSHA {
+		t.Fatalf("want clone pinned at %q, got %+v", firstSHA, statuses)
+	}
+	if _, statErr := os.Stat(filepath.Join(target, "second.txt")); statErr == nil {
+		t.Errorf("commit-SHA pin should not contain files from later commits")
 	}
 }
 

--- a/docs/site/manifests/config.md
+++ b/docs/site/manifests/config.md
@@ -65,10 +65,11 @@ Structural repo slot fills, keyed by the blueprint's repo slot `name`. Each entr
 
 #### CellConfigRepoFill
 
-| Field    | Type   | Required | Description                                                 |
-| -------- | ------ | -------- | ----------------------------------------------------------- |
-| `url`    | string | yes      | The clone URL filling the slot.                             |
-| `branch` | string | no       | The branch to check out. Empty clones the remote's default. |
+| Field    | Type   | Required | Description                                                                                                                                                        |
+| -------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `url`    | string | yes      | The clone URL filling the slot.                                                                                                                                    |
+| `branch` | string | no       | The branch to check out (moving target). Empty clones the remote's default. Mutually exclusive with `ref`.                                                         |
+| `ref`    | string | no       | Immutable pin — tag name or full commit SHA. Survives in-place restarts (see [ContainerRepo `ref`](container.md#containerrepo)). Mutually exclusive with `branch`. |
 
 ### `spec.secrets` (map[string][SecretFill](#cellconfigsecretfill), optional)
 

--- a/docs/site/manifests/container.md
+++ b/docs/site/manifests/container.md
@@ -62,31 +62,31 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 
 ## spec
 
-| Field             | Type                       | Required | Description                                                                                                                                            |
-| ----------------- | -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `id`              | string                     | yes      | Container identifier (matches `metadata.name`)                                                                                                         |
-| `containerdId`    | string                     | no       | Populated by Kukeon with the containerd-level container id                                                                                             |
-| `realmId`         | string                     | yes      | Realm that owns the container                                                                                                                          |
-| `spaceId`         | string                     | yes      | Space that owns the container                                                                                                                          |
-| `stackId`         | string                     | yes      | Stack that owns the container                                                                                                                          |
-| `cellId`          | string                     | yes      | Cell that owns the container                                                                                                                           |
-| `root`            | bool                       | no       | Mark this as the cell's root container (owns the network namespace)                                                                                    |
-| `image`           | string                     | yes      | OCI image reference. Kukeon passes this to containerd's image pull.                                                                                    |
-| `command`         | string                     | no       | Command to run. If omitted, the image's `ENTRYPOINT` is used.                                                                                          |
-| `args`            | array of string            | no       | Arguments. Combined with `command`.                                                                                                                    |
-| `env`             | array of string            | no       | `KEY=VALUE` environment variables                                                                                                                      |
-| `ports`           | array of string            | no       | Reserved — port mapping semantics are not finalized                                                                                                    |
-| `volumes`         | array of `VolumeMount`     | no       | Bind-mount host paths into the container (see [VolumeMount](#volumemount))                                                                             |
-| `networks`        | array of string            | no       | Additional CNI networks to join beyond the cell's default                                                                                              |
-| `networksAliases` | array of string            | no       | DNS aliases for the container within its CNI networks                                                                                                  |
-| `privileged`      | bool                       | no       | Run privileged (full capabilities, access to `/dev`, etc.)                                                                                             |
-| `hostCgroup`      | bool                       | no       | Opt the container into its parent's cgroup namespace (see [Host cgroup mode](#host-cgroup-mode))                                                       |
-| `secrets`         | array of `ContainerSecret` | no       | Inject credentials resolved by the daemon — never written to status or YAML (see [ContainerSecret](#containersecret))                                  |
-| `repos`           | array of `ContainerRepo`   | no       | Git repos the kuketty wrapper clones before the workload starts — requires `attachable: true` (see [ContainerRepo](#containerrepo))                    |
-| `git`             | `ContainerGit`             | no       | Declarative git identity + signing, expanded into `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`GIT_CONFIG_*` env before start (see [ContainerGit](#containergit)) |
-| `cniConfigPath`   | string                     | no       | Override the CNI config directory for this container                                                                                                   |
+| Field             | Type                       | Required | Description                                                                                                                                                                                     |
+| ----------------- | -------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`              | string                     | yes      | Container identifier (matches `metadata.name`)                                                                                                                                                  |
+| `containerdId`    | string                     | no       | Populated by Kukeon with the containerd-level container id                                                                                                                                      |
+| `realmId`         | string                     | yes      | Realm that owns the container                                                                                                                                                                   |
+| `spaceId`         | string                     | yes      | Space that owns the container                                                                                                                                                                   |
+| `stackId`         | string                     | yes      | Stack that owns the container                                                                                                                                                                   |
+| `cellId`          | string                     | yes      | Cell that owns the container                                                                                                                                                                    |
+| `root`            | bool                       | no       | Mark this as the cell's root container (owns the network namespace)                                                                                                                             |
+| `image`           | string                     | yes      | OCI image reference. Kukeon passes this to containerd's image pull.                                                                                                                             |
+| `command`         | string                     | no       | Command to run. If omitted, the image's `ENTRYPOINT` is used.                                                                                                                                   |
+| `args`            | array of string            | no       | Arguments. Combined with `command`.                                                                                                                                                             |
+| `env`             | array of string            | no       | `KEY=VALUE` environment variables                                                                                                                                                               |
+| `ports`           | array of string            | no       | Reserved — port mapping semantics are not finalized                                                                                                                                             |
+| `volumes`         | array of `VolumeMount`     | no       | Bind-mount host paths into the container (see [VolumeMount](#volumemount))                                                                                                                      |
+| `networks`        | array of string            | no       | Additional CNI networks to join beyond the cell's default                                                                                                                                       |
+| `networksAliases` | array of string            | no       | DNS aliases for the container within its CNI networks                                                                                                                                           |
+| `privileged`      | bool                       | no       | Run privileged (full capabilities, access to `/dev`, etc.)                                                                                                                                      |
+| `hostCgroup`      | bool                       | no       | Opt the container into its parent's cgroup namespace (see [Host cgroup mode](#host-cgroup-mode))                                                                                                |
+| `secrets`         | array of `ContainerSecret` | no       | Inject credentials resolved by the daemon — never written to status or YAML (see [ContainerSecret](#containersecret))                                                                           |
+| `repos`           | array of `ContainerRepo`   | no       | Git repos the kuketty wrapper clones before the workload starts — requires `attachable: true` (see [ContainerRepo](#containerrepo))                                                             |
+| `git`             | `ContainerGit`             | no       | Declarative git identity + signing, expanded into `GIT_AUTHOR_*`/`GIT_COMMITTER_*`/`GIT_CONFIG_*` env before start (see [ContainerGit](#containergit))                                          |
+| `cniConfigPath`   | string                     | no       | Override the CNI config directory for this container                                                                                                                                            |
 | `restartPolicy`   | string                     | no       | Per-container reap policy at the cell wind-down / auto-delete gate. One of `always`, `on-failure`, `never`. Empty defaults to `always` for back-compat (see [Restart policy](#restart-policy)). |
-| `tty`             | `ContainerTty`             | no       | Shell-UX config for the kuketty wrapper (prompt, init scripts, logging) — requires `attachable: true` (see [ContainerTty](#containertty))              |
+| `tty`             | `ContainerTty`             | no       | Shell-UX config for the kuketty wrapper (prompt, init scripts, logging) — requires `attachable: true` (see [ContainerTty](#containertty))                                                       |
 
 !!! warning "Fields marked reserved"
 `ports` is accepted by the schema today but its semantics are still being designed. Values round-trip (you can read back what you applied), but the controller does not act on them. See [GitHub Issues](https://github.com/eminwux/kukeon/issues) for the backlog.
@@ -95,12 +95,12 @@ See [Concepts → Container](../concepts/container.md) for what a container is.
 
 `spec.restartPolicy` selects whether the cell wind-down / auto-delete reconciler reaps a cell after one of its non-root containers exits. The runner evaluates the policy per container at the wind-down gate; the cell-level decision is the intersection across every terminally-exited non-root container, so a single `never` blocks the wind-down.
 
-| Value        | Behavior at wind-down                                                                                                                              |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| empty/unset  | Treated as `always` for back-compat. Pre-#1003 wind-down behavior — every non-root container exit can trigger a cell-level wind-down.              |
-| `always`     | Wind-down / auto-delete proceeds whenever the container terminally exits, regardless of exit code.                                                 |
-| `on-failure` | Wind-down / auto-delete proceeds only when the container's last exit code is non-zero. A zero-exit (clean shutdown) keeps the cell in place.       |
-| `never`      | Wind-down / auto-delete is skipped — the cell stays in `Stopped` until an operator tears it down explicitly (`kuke delete` / `kuke purge`).        |
+| Value        | Behavior at wind-down                                                                                                                        |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| empty/unset  | Treated as `always` for back-compat. Pre-#1003 wind-down behavior — every non-root container exit can trigger a cell-level wind-down.        |
+| `always`     | Wind-down / auto-delete proceeds whenever the container terminally exits, regardless of exit code.                                           |
+| `on-failure` | Wind-down / auto-delete proceeds only when the container's last exit code is non-zero. A zero-exit (clean shutdown) keeps the cell in place. |
+| `never`      | Wind-down / auto-delete is skipped — the cell stays in `Stopped` until an operator tears it down explicitly (`kuke delete` / `kuke purge`).  |
 
 Only the root container is exempt: the root's exit drives cell-level lifecycle decisions independently and is not subject to this gate.
 
@@ -173,13 +173,16 @@ File-mount mode stages secrets under `/run/kukeon/secrets/<containerdId>/<name>`
 
 Each entry in `spec.repos` declares a git repository the kuketty wrapper clones (or fetches) into `target` before the workload starts, replacing hand-rolled `git clone` blocks in `onInit` scripts. Has no effect unless `spec.attachable` is `true`. Per-repo clone outcome surfaces in `status.repos`.
 
-| Field      | Type   | Required | Description                                                                                                                                         |
-| ---------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`     | string | yes      | Operator-facing identifier for the repo, echoed back in per-repo status                                                                             |
-| `target`   | string | yes      | Absolute in-container path the repo is cloned into                                                                                                  |
-| `url`      | string | yes      | Clone URL                                                                                                                                           |
-| `branch`   | string | no       | Branch to check out. Empty clones the remote's default branch.                                                                                      |
-| `required` | bool   | no       | When `true`, a clone/fetch failure makes the container fail before start. When `false` (default), the failure is logged and the container proceeds. |
+| Field      | Type   | Required | Description                                                                                                                                                                                                            |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`     | string | yes      | Operator-facing identifier for the repo, echoed back in per-repo status                                                                                                                                                |
+| `target`   | string | yes      | Absolute in-container path the repo is cloned into                                                                                                                                                                     |
+| `url`      | string | yes      | Clone URL                                                                                                                                                                                                              |
+| `branch`   | string | no       | Branch to check out (moving target). Empty clones the remote's default branch. Mutually exclusive with `ref`.                                                                                                          |
+| `ref`      | string | no       | Immutable pin — tag name or full commit SHA. Clones at detached HEAD; on restart fetches `--tags` and re-detaches without `pull --ff-only`, so an in-place restart stays idempotent. Mutually exclusive with `branch`. |
+| `required` | bool   | no       | When `true`, a clone/fetch failure makes the container fail before start. When `false` (default), the failure is logged and the container proceeds.                                                                    |
+
+Pick `branch` for "track the latest commit on this branch" (fetch + fast-forward on restart) or `ref` for "pin to this exact tag/commit forever" (no fast-forward, no divergence). Both keep the on-disk checkout across `kuke stop`/`kuke start`; setting both is rejected at apply time.
 
 ```yaml
 repos:
@@ -187,6 +190,11 @@ repos:
     url: https://github.com/example/app.git
     target: /workspace/app
     branch: main
+    required: true
+  - name: vendored
+    url: https://github.com/example/vendored.git
+    target: /workspace/vendored
+    ref: v1.4.2 # tag — or a full commit SHA
     required: true
 ```
 
@@ -238,9 +246,9 @@ git:
 
 Each entry in `tty.onInit` is a single init-script stage.
 
-| Field    | Type   | Required | Description                                                                                                                                                                                                                                                                                      |
-| -------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `script` | string | no       | Shell script body for the stage.                                                                                                                                                                                                                                                                 |
+| Field    | Type   | Required | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `script` | string | no       | Shell script body for the stage.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `runOn`  | string | no       | When the stage runs. Empty or `start` forwards the script to sbsh's onInit, so it runs in the wrapped shell on every boot. `create` routes the script into kuketty's pre-Serve executor, where it runs once to completion before the workload starts. A stage with `runOn: create` requires the container to declare at least one persistent writable mount (a `spec.volumes` entry of `kind: bind` that is not `readOnly`); otherwise the stage's side effects evaporate on the next recreate while the run-once gate would silently report `done`, and apischeme rejects the spec at apply time. Any other value is rejected at apply time. |
 
 ```yaml

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -998,6 +998,7 @@ func reposToInternal(in []ext.ContainerRepo) []intmodel.ContainerRepo {
 			Name:     r.Name,
 			Target:   r.Target,
 			Branch:   r.Branch,
+			Ref:      r.Ref,
 			URL:      r.URL,
 			Required: r.Required,
 		}
@@ -1016,6 +1017,7 @@ func reposToExternal(in []intmodel.ContainerRepo) []ext.ContainerRepo {
 			Name:     r.Name,
 			Target:   r.Target,
 			Branch:   r.Branch,
+			Ref:      r.Ref,
 			URL:      r.URL,
 			Required: r.Required,
 		}

--- a/internal/apply/parser/blueprint_test.go
+++ b/internal/apply/parser/blueprint_test.go
@@ -149,6 +149,27 @@ spec:
 	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrRepoTargetNotAbsolute)
 }
 
+func TestValidateDocument_Blueprint_RepoSlotBranchAndRefMutuallyExclusive(t *testing.T) {
+	yaml := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: default
+spec:
+  cell:
+    containers:
+      - id: main
+        image: alpine:latest
+        repos:
+          - name: app
+            target: /workspace/app
+            branch: main
+            ref: v0.1.0
+`
+	doc := parseBlueprint(t, yaml)
+	requireValidationErr(t, parser.ValidateDocument(doc), errdefs.ErrRepoBranchRefMutex)
+}
+
 func TestValidateDocument_Blueprint_SecretSlotEnvMissingEnvName(t *testing.T) {
 	yaml := `apiVersion: v1beta1
 kind: CellBlueprint

--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -567,6 +567,9 @@ func validateBlueprintRepos(repos []v1beta1.ContainerRepo) error {
 		if !filepath.IsAbs(target) {
 			return fmt.Errorf("%w (repos[%d] %q target %q)", errdefs.ErrRepoTargetNotAbsolute, i, name, target)
 		}
+		if strings.TrimSpace(r.Branch) != "" && strings.TrimSpace(r.Ref) != "" {
+			return fmt.Errorf("%w (repos[%d] %q)", errdefs.ErrRepoBranchRefMutex, i, name)
+		}
 	}
 	return nil
 }
@@ -624,6 +627,12 @@ func validateConfig(doc *Document) *ValidationError {
 			return &ValidationError{
 				Index: doc.Index, Kind: doc.Kind, Name: cfg.Metadata.Name,
 				Err: fmt.Errorf("%w (repos[%q])", errdefs.ErrConfigRepoFillURLRequired, name),
+			}
+		}
+		if strings.TrimSpace(fill.Branch) != "" && strings.TrimSpace(fill.Ref) != "" {
+			return &ValidationError{
+				Index: doc.Index, Kind: doc.Kind, Name: cfg.Metadata.Name,
+				Err: fmt.Errorf("%w (repos[%q])", errdefs.ErrRepoBranchRefMutex, name),
 			}
 		}
 	}
@@ -735,6 +744,9 @@ func validateRepos(repos []v1beta1.ContainerRepo) error {
 		}
 		if strings.TrimSpace(r.URL) == "" {
 			return fmt.Errorf("%w (repos[%d] %q)", errdefs.ErrRepoURLRequired, i, name)
+		}
+		if strings.TrimSpace(r.Branch) != "" && strings.TrimSpace(r.Ref) != "" {
+			return fmt.Errorf("%w (repos[%d] %q)", errdefs.ErrRepoBranchRefMutex, i, name)
 		}
 	}
 	return nil

--- a/internal/apply/parser/parser_test.go
+++ b/internal/apply/parser/parser_test.go
@@ -661,6 +661,16 @@ spec:
 			repoYAML: "    - name: project\n      target: /home/claude/project\n      branch: main\n      url: https://example.com/p.git\n      required: true\n",
 			wantErr:  nil,
 		},
+		{
+			name:     "valid ref pin",
+			repoYAML: "    - name: pinned\n      target: /home/claude/pinned\n      ref: v0.1.0\n      url: https://example.com/p.git\n      required: true\n",
+			wantErr:  nil,
+		},
+		{
+			name:     "branch and ref both set",
+			repoYAML: "    - name: pinned\n      target: /home/claude/pinned\n      branch: main\n      ref: v0.1.0\n      url: https://example.com/p.git\n",
+			wantErr:  errdefs.ErrRepoBranchRefMutex,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cellconfig/materialize.go
+++ b/internal/cellconfig/materialize.go
@@ -143,6 +143,9 @@ func materializeContainer(
 		if branch := strings.TrimSpace(fill.Branch); branch != "" {
 			filled.Branch = branch
 		}
+		if ref := strings.TrimSpace(fill.Ref); ref != "" {
+			filled.Ref = ref
+		}
 		repos = append(repos, filled)
 	}
 

--- a/internal/cellconfig/materialize_test.go
+++ b/internal/cellconfig/materialize_test.go
@@ -242,6 +242,44 @@ func TestMaterialize_OptionalSlotUnfilled_Drops(t *testing.T) {
 	}
 }
 
+func TestMaterialize_RepoFillRefCarriesThrough(t *testing.T) {
+	// A CellConfig repo fill with `ref` (immutable pin) must carry the ref
+	// into the materialized ContainerRepo so kuketty's clone path detaches
+	// HEAD at the pinned tag/SHA (#1034).
+	bp := minimalBlueprint()
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Repos: map[string]v1beta1.CellConfigRepoFill{
+				"src": {URL: "https://example.com/src.git", Ref: "v0.1.0"},
+			},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "t", Realm: "cfg-realm"}},
+			},
+		},
+	}
+	cell, err := Materialize(cfg, bp)
+	if err != nil {
+		t.Fatalf("Materialize: %v", err)
+	}
+	c := cell.Spec.Containers[0]
+	var src v1beta1.ContainerRepo
+	for _, r := range c.Repos {
+		if r.Name == "src" {
+			src = r
+		}
+	}
+	if src.Ref != "v0.1.0" {
+		t.Errorf("src repo Ref=%q want v0.1.0 (fill ref must carry through)", src.Ref)
+	}
+	if src.Branch != "" {
+		t.Errorf("src repo Branch=%q want empty (only ref was filled)", src.Branch)
+	}
+}
+
 func TestMaterialize_ScalarRepoPassesThrough(t *testing.T) {
 	// A blueprint repo with an inline URL is scalar-mode (not a fillable slot);
 	// the Config must not be required to mention it, and Materialize must keep

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -407,6 +407,12 @@ var (
 	ErrRepoTargetRequired    = errors.New("repo target is required")
 	ErrRepoTargetNotAbsolute = errors.New("repo target must be an absolute container path")
 	ErrRepoURLRequired       = errors.New("repo url is required")
+	// ErrRepoBranchRefMutex fires when a ContainerRepo declares both
+	// `branch` (moving target) and `ref` (immutable tag or commit SHA).
+	// The two have different fetch-path semantics — `ref` skips the
+	// fast-forward step that breaks on a detached HEAD — so the spec must
+	// pick one (#1034).
+	ErrRepoBranchRefMutex = errors.New("repo cannot set both branch and ref")
 
 	// CellBlueprint kind (kind: CellBlueprint) storage-primitive errors
 	// (issue #620, phase 4a-i of #423).

--- a/internal/modelhub/container.go
+++ b/internal/modelhub/container.go
@@ -210,6 +210,7 @@ type ContainerRepo struct {
 	Name     string
 	Target   string
 	Branch   string
+	Ref      string
 	URL      string
 	Required bool
 }

--- a/pkg/api/model/v1beta1/cellconfig.go
+++ b/pkg/api/model/v1beta1/cellconfig.go
@@ -105,7 +105,11 @@ type CellConfigRepoFill struct {
 	// URL is the clone URL filling the slot. Required.
 	URL string `json:"url"              yaml:"url"`
 	// Branch is the branch to check out. Empty clones the remote's default.
+	// Mutually exclusive with Ref.
 	Branch string `json:"branch,omitempty" yaml:"branch,omitempty"`
+	// Ref is an immutable pin (tag or full commit SHA) — see
+	// ContainerRepo.Ref. Mutually exclusive with Branch.
+	Ref string `json:"ref,omitempty"    yaml:"ref,omitempty"`
 }
 
 // CellConfigSecretFill fills a structural secret slot the referenced blueprint

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -319,9 +319,15 @@ type ContainerRepo struct {
 	// Target is the absolute in-container path the repo is cloned into.
 	// Required.
 	Target string `json:"target"             yaml:"target"`
-	// Branch is the branch to check out. Empty clones the remote's default
-	// branch.
+	// Branch is the branch to check out (moving target). Empty clones the
+	// remote's default branch. Mutually exclusive with Ref.
 	Branch string `json:"branch,omitempty"   yaml:"branch,omitempty"`
+	// Ref is an immutable pin — a tag name or full commit SHA. When set,
+	// kuketty checks out a detached HEAD at the resolved ref and skips the
+	// fast-forward step on subsequent restarts, so an in-place restart of
+	// an already-cloned cell stays idempotent instead of failing on
+	// `git pull` against a detached HEAD. Mutually exclusive with Branch.
+	Ref string `json:"ref,omitempty"      yaml:"ref,omitempty"`
 	// URL is the clone URL. In phases 1–3 it is supplied via scalar
 	// ${PARAM} substitution; phase 4 (#423) enables structural slot fill
 	// from a CellConfig. Required.


### PR DESCRIPTION
## Summary

- Adds a first-class `ref` field on `ContainerRepo` (tag name or full commit SHA) alongside the existing `branch:`, so a clone can be pinned to an immutable revision rather than abusing `--branch` for tags.
- Rewrites `cmd/kuketty/repos.go` so the fetch path is ref-aware: a Ref-pinned repo runs `git fetch --prune --tags origin` + `git checkout --detach <ref>` and **skips `git pull --ff-only`** — the prior `pull --ff-only` on a detached HEAD errored (`You are not currently on a branch...`) and aborted required-repo container start, so a tag pin only survived a fresh clone, not an in-place restart (#1034).
- Wires Ref through the v1beta1 + internal model, `CellConfigRepoFill` (so a CellConfig can also pin a slot to a ref), the apischeme conversions, and `cellconfig.Materialize`.
- Apply-time validation rejects setting both `branch` and `ref` on the same repo — they have different fetch semantics, so the spec must pick one.
- Updates `docs/site/manifests/container.md` (and the matching `RepoFill` section in `config.md`) with the new field and the branch-vs-ref distinction.

## Test plan

- [x] `make test` (full `test-root` + `test-kukebuild`).
- [x] `GOWORK=off go vet ./...`.
- [x] New tests:
  - `TestProcessRepos_RefPinsCloneAndSurvivesRestart` — clones at the tag's detached HEAD, then re-runs the fetch path after a new upstream commit and asserts the pin holds (this is the AC regression — would fail against `main`'s `pull --ff-only`).
  - `TestProcessRepos_RefPinAcceptsCommitSHA` — same idempotence for a full commit SHA.
  - `TestValidateDocument_Container_RepoValidation` adds a `valid ref pin` row and a `branch and ref both set` row asserting `ErrRepoBranchRefMutex`.
  - `TestValidateDocument_Blueprint_RepoSlotBranchAndRefMutuallyExclusive` mirrors the gate for blueprint repo slots.
  - `TestMaterialize_RepoFillRefCarriesThrough` confirms a `CellConfigRepoFill.ref` is propagated into the materialized `ContainerRepo.Ref`.
- [x] `pre-commit run --files $(git diff --name-only HEAD~)` — gofmt, go-mod-tidy, golangci-lint, prettier, addlicense all green.

Closes #1034