### PR TITLE
feat(status): add per-realm storage footprint section

### DIFF
--- a/cmd/kuke/status/checks.go
+++ b/cmd/kuke/status/checks.go
@@ -31,10 +31,11 @@ import (
 // Section names — kept as constants so the renderer's section grouping and
 // the JSON `section` field are spelled the same way everywhere.
 const (
-	sectionDaemon = "daemon"
-	sectionHost   = "host"
-	sectionState  = "state"
-	sectionParity = "parity"
+	sectionDaemon  = "daemon"
+	sectionHost    = "host"
+	sectionState   = "state"
+	sectionStorage = "storage"
+	sectionParity  = "parity"
 )
 
 // checkDaemon reports the daemon's reachability. The single row carries the

--- a/cmd/kuke/status/status.go
+++ b/cmd/kuke/status/status.go
@@ -83,6 +83,23 @@ type Result struct {
 	Status      Status `json:"status"`
 	Detail      string `json:"detail,omitempty"`
 	Remediation string `json:"remediation,omitempty"`
+	// Storage carries the structured per-realm counts the storage
+	// section surfaces — populated only on storage rows. CI tooling
+	// parses these to alert on accumulation before the data volume
+	// fills (issue #1039); the human Detail string carries the same
+	// figures pre-formatted.
+	Storage *StorageStats `json:"storage,omitempty"`
+}
+
+// StorageStats mirrors ctr.StorageStats on the wire — the per-realm
+// snapshot/lease/blob figures `kuke status` exposes for parsing. The
+// status package owns the JSON tags so a future internal/ctr struct
+// rename doesn't ripple into the public CLI contract.
+type StorageStats struct {
+	Snapshots  int   `json:"snapshots"`
+	Leases     int   `json:"leases"`
+	Blobs      int   `json:"blobs"`
+	BlobsBytes int64 `json:"blobsBytes"`
 }
 
 // Report is the full top-level payload — what --json marshals, and what the
@@ -122,14 +139,16 @@ type runCtx struct {
 }
 
 // ctrConn is the minimal ctr.Client subset status calls — the host's
-// containerd reachability check (Connect) and the state section's
-// residual-namespace probe (ListNamespaces). Close releases the dial.
-// internal/ctr's concrete *client satisfies this trivially; the test
-// mock implements only these three methods.
+// containerd reachability check (Connect), the state section's
+// residual-namespace probe (ListNamespaces), and the storage section's
+// per-namespace footprint probe (NamespaceStorage). Close releases the
+// dial. internal/ctr's concrete *client satisfies this trivially; the
+// test mock implements only these four methods.
 type ctrConn interface {
 	Connect() error
 	Close() error
 	ListNamespaces() ([]string, error)
+	NamespaceStorage(namespace string) (ctr.StorageStats, error)
 }
 
 // MockRunCtxKey is the context key tests use to inject a pre-built runCtx
@@ -302,6 +321,7 @@ func runChecks(ctx context.Context, rc *runCtx) Report {
 	results = append(results, checkDaemon(ctx, rc)...)
 	results = append(results, checkHost(rc)...)
 	results = append(results, checkState(ctx, rc)...)
+	results = append(results, checkStorage(ctx, rc)...)
 	results = append(results, checkParity(ctx, rc)...)
 
 	ok := true

--- a/cmd/kuke/status/status_test.go
+++ b/cmd/kuke/status/status_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
@@ -82,7 +83,7 @@ func TestRunChecks_AllHealthy(t *testing.T) {
 			t.Errorf("unexpected FAIL row: %+v", c)
 		}
 	}
-	for _, want := range []string{sectionDaemon, sectionHost, sectionState, sectionParity} {
+	for _, want := range []string{sectionDaemon, sectionHost, sectionState, sectionStorage, sectionParity} {
 		if !seenSections[want] {
 			t.Errorf("section %q not represented in report", want)
 		}
@@ -651,6 +652,15 @@ func (f *fakeClient) ListConfigs(_ context.Context, _, _, _ string) ([]v1beta1.C
 type fakeCtrClient struct {
 	connectErr error
 	namespaces []string
+	// storage seeds NamespaceStorage's response keyed by containerd
+	// namespace (e.g. "default.kukeon.io"). A missing key means
+	// NamespaceStorage returns a zero StorageStats for that namespace
+	// — the no-leak case the storage section reads as OK.
+	storage map[string]ctr.StorageStats
+	// storageErr seeds NamespaceStorage's error path; a non-nil value
+	// fails every call, mirroring the metadata-store-unreachable
+	// branch the storage check demotes to WARN.
+	storageErr error
 }
 
 func (f *fakeCtrClient) Connect() error { return f.connectErr }
@@ -660,4 +670,10 @@ func (f *fakeCtrClient) ListNamespaces() ([]string, error) {
 		return nil, f.connectErr
 	}
 	return f.namespaces, nil
+}
+func (f *fakeCtrClient) NamespaceStorage(ns string) (ctr.StorageStats, error) {
+	if f.storageErr != nil {
+		return ctr.StorageStats{}, f.storageErr
+	}
+	return f.storage[ns], nil
 }

--- a/cmd/kuke/status/storage.go
+++ b/cmd/kuke/status/storage.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/eminwux/kukeon/internal/consts"
+)
+
+// checkStorage emits one row per realm reporting its containerd
+// namespace's storage footprint — snapshot / lease / content-blob
+// counts plus summed blob bytes. The figures surface accumulation
+// before the data volume fills (issue #1039); the prior failure mode
+// was the leak surfacing only at ENOSPC several layers downstream.
+//
+// Realm enumeration prefers the daemon (ListRealms) for the realm-name
+// labels, with the ctr namespace list as a fallback so the section
+// stays populated when the daemon is down. Each probe is a
+// metadata-store read (boltdb iterator), so the call is cheap enough
+// for the status budget — see ctr.NamespaceStorage's doc for the
+// per-snapshot-disk-usage carve-out.
+func checkStorage(ctx context.Context, rc *runCtx) []Result {
+	if rc.ctrClient == nil {
+		return []Result{{
+			Section:     sectionStorage,
+			Name:        "ctr",
+			Status:      StatusWARN,
+			Detail:      "ctr client not constructed",
+			Remediation: "internal: status invoked without a containerd wrapper",
+		}}
+	}
+
+	// Connect() is idempotent (the host check above already dialed on
+	// the happy path); a dial failure here surfaces as a single WARN
+	// row rather than per-realm WARNs.
+	if err := rc.ctrClient.Connect(); err != nil {
+		return []Result{{
+			Section:     sectionStorage,
+			Name:        "ctr",
+			Status:      StatusWARN,
+			Detail:      fmt.Sprintf("ctr unreachable: %v", err),
+			Remediation: "the host containerd row above carries the underlying cause",
+		}}
+	}
+
+	realms := enumerateRealmsForStorage(ctx, rc)
+	if len(realms) == 0 {
+		return []Result{{
+			Section: sectionStorage,
+			Name:    "realms",
+			Status:  StatusOK,
+			Detail:  "no realms (host not initialized)",
+		}}
+	}
+
+	results := make([]Result, 0, len(realms))
+	for _, realm := range realms {
+		results = append(results, storageRowForRealm(rc, realm))
+	}
+	return results
+}
+
+// enumerateRealmsForStorage returns the realm names to probe. Prefers
+// the daemon's ListRealms (canonical source) and falls back to deriving
+// realm names from the ctr namespace list when the daemon is down or
+// listing fails — the section still has something to report, with the
+// daemon-down rationale surfacing on the daemon row above.
+func enumerateRealmsForStorage(ctx context.Context, rc *runCtx) []string {
+	if rc.daemonClient != nil {
+		realms, err := rc.daemonClient.ListRealms(ctx)
+		if err == nil {
+			out := make([]string, 0, len(realms))
+			for i := range realms {
+				out = append(out, realms[i].Metadata.Name)
+			}
+			sort.Strings(out)
+			return out
+		}
+	}
+
+	nsList, err := rc.ctrClient.ListNamespaces()
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(nsList))
+	for _, ns := range nsList {
+		if realm := consts.RealmFromNamespace(ns); realm != "" {
+			out = append(out, realm)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// storageRowForRealm probes one realm's containerd namespace and
+// formats the figures. Probe failures demote the row to WARN — a stuck
+// containerd metadata read shouldn't be a regression signal alongside
+// the parity walk's FAIL, and the operator already has the host
+// section's signal.
+func storageRowForRealm(rc *runCtx, realm string) Result {
+	r := Result{
+		Section: sectionStorage,
+		Name:    realm,
+	}
+
+	ns := consts.RealmNamespace(realm)
+	stats, err := rc.ctrClient.NamespaceStorage(ns)
+	if err != nil {
+		r.Status = StatusWARN
+		r.Detail = fmt.Sprintf("%s (probe failed: %v)", ns, err)
+		return r
+	}
+
+	r.Storage = &StorageStats{
+		Snapshots:  stats.Snapshots,
+		Leases:     stats.Leases,
+		Blobs:      stats.Blobs,
+		BlobsBytes: stats.BlobsBytes,
+	}
+	r.Status = StatusOK
+	r.Detail = fmt.Sprintf(
+		"%s (%d snapshots, %d leases, %d blobs, %s)",
+		ns, stats.Snapshots, stats.Leases, stats.Blobs, fmtBytes(stats.BlobsBytes),
+	)
+	return r
+}
+
+// fmtBytes renders a byte count with a binary-IEC unit suffix, picking
+// the largest unit at which the value reads >= 1. Kept here rather
+// than in a shared helper because the status report is the only call
+// site; pulling humanize-style helpers in for one row would be over-
+// engineering. Negative inputs are not expected (Size from
+// content.Info is unsigned in practice) but render through the same
+// path so a wrap doesn't crash the row.
+func fmtBytes(n int64) string {
+	const (
+		kib = int64(1024)
+		mib = kib * 1024
+		gib = mib * 1024
+		tib = gib * 1024
+	)
+	switch {
+	case n >= tib:
+		return fmt.Sprintf("%.1f TiB", float64(n)/float64(tib))
+	case n >= gib:
+		return fmt.Sprintf("%.1f GiB", float64(n)/float64(gib))
+	case n >= mib:
+		return fmt.Sprintf("%.1f MiB", float64(n)/float64(mib))
+	case n >= kib:
+		return fmt.Sprintf("%.1f KiB", float64(n)/float64(kib))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}

--- a/cmd/kuke/status/storage_test.go
+++ b/cmd/kuke/status/storage_test.go
@@ -1,0 +1,251 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package status
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/ctr"
+)
+
+// TestCheckStorage_PerRealmRow pins the happy-path contract: one row
+// per realm, each carrying the structured StorageStats payload and a
+// human Detail string that names the containerd namespace plus the
+// figures the AC requires (snapshots / leases / blobs + bytes).
+func TestCheckStorage_PerRealmRow(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: newFakeClient().withDefaultRealms(),
+		ctrClient: &fakeCtrClient{
+			namespaces: []string{"default.kukeon.io", "kuke-system.kukeon.io"},
+			storage: map[string]ctr.StorageStats{
+				"default.kukeon.io":     {Snapshots: 12, Leases: 49, Blobs: 24, BlobsBytes: 5 * 1024 * 1024},
+				"kuke-system.kukeon.io": {Snapshots: 157, Leases: 266, Blobs: 180, BlobsBytes: 700 * 1024 * 1024},
+			},
+		},
+	}
+
+	results := checkStorage(context.Background(), rc)
+	if len(results) != 2 {
+		t.Fatalf("expected one row per realm; got %d (%+v)", len(results), results)
+	}
+
+	byName := map[string]Result{}
+	for _, r := range results {
+		if r.Section != sectionStorage {
+			t.Errorf("row %q has section %q; want %q", r.Name, r.Section, sectionStorage)
+		}
+		byName[r.Name] = r
+	}
+
+	def, ok := byName["default"]
+	if !ok {
+		t.Fatalf("expected row for default realm; got %+v", byName)
+	}
+	if def.Status != StatusOK {
+		t.Errorf("default realm row should be OK; got %s (%s)", def.Status, def.Detail)
+	}
+	if def.Storage == nil {
+		t.Fatalf("default realm row missing Storage payload")
+	}
+	if def.Storage.Snapshots != 12 || def.Storage.Leases != 49 || def.Storage.Blobs != 24 {
+		t.Errorf("default storage figures mismatch: %+v", def.Storage)
+	}
+	if !strings.Contains(def.Detail, "default.kukeon.io") {
+		t.Errorf("default Detail should name the containerd namespace; got %q", def.Detail)
+	}
+	for _, want := range []string{"12 snapshots", "49 leases", "24 blobs"} {
+		if !strings.Contains(def.Detail, want) {
+			t.Errorf("default Detail missing %q; got %q", want, def.Detail)
+		}
+	}
+
+	sys, ok := byName["kuke-system"]
+	if !ok {
+		t.Fatalf("expected row for kuke-system realm; got %+v", byName)
+	}
+	if !strings.Contains(sys.Detail, "700.0 MiB") {
+		t.Errorf("kuke-system Detail should include MiB bytes total; got %q", sys.Detail)
+	}
+}
+
+// TestCheckStorage_DaemonDownFallsBackToNamespaces pins the degraded
+// path: a daemon-down run still surfaces per-namespace figures by
+// deriving realm names from the ctr namespace list. The section stays
+// populated so the JSON shape is stable.
+func TestCheckStorage_DaemonDownFallsBackToNamespaces(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: nil,
+		ctrClient: &fakeCtrClient{
+			namespaces: []string{"default.kukeon.io", "kuke-system.kukeon.io", "some-other.namespace"},
+			storage: map[string]ctr.StorageStats{
+				"default.kukeon.io":     {Snapshots: 1, Leases: 2, Blobs: 3, BlobsBytes: 4},
+				"kuke-system.kukeon.io": {Snapshots: 5, Leases: 6, Blobs: 7, BlobsBytes: 8},
+			},
+		},
+	}
+
+	results := checkStorage(context.Background(), rc)
+	if len(results) != 2 {
+		t.Fatalf("expected two rows (kukeon namespaces only); got %d", len(results))
+	}
+	names := []string{results[0].Name, results[1].Name}
+	for _, want := range []string{"default", "kuke-system"} {
+		if !containsStr(names, want) {
+			t.Errorf("expected fallback to include realm %q; got %v", want, names)
+		}
+	}
+	for _, r := range results {
+		if r.Status != StatusOK {
+			t.Errorf("fallback row %q should be OK; got %s", r.Name, r.Status)
+		}
+	}
+}
+
+// TestCheckStorage_CtrUnreachableIsWARN documents the dial-failure
+// path: a single WARN row at the section head rather than a per-realm
+// fan-out of WARNs, matching the host section's containerd-down
+// signal.
+func TestCheckStorage_CtrUnreachableIsWARN(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: newFakeClient().withDefaultRealms(),
+		ctrClient:    &fakeCtrClient{connectErr: errFakeDialFailed},
+	}
+
+	results := checkStorage(context.Background(), rc)
+	if len(results) != 1 {
+		t.Fatalf("expected single WARN row on dial failure; got %d", len(results))
+	}
+	if results[0].Status != StatusWARN {
+		t.Errorf("expected WARN; got %s (%s)", results[0].Status, results[0].Detail)
+	}
+	if !strings.Contains(results[0].Detail, "ctr unreachable") {
+		t.Errorf("Detail should name dial failure; got %q", results[0].Detail)
+	}
+}
+
+// TestCheckStorage_ProbeErrorDemotesRow pins the per-realm WARN path:
+// when NamespaceStorage returns an error for a realm, the row demotes
+// to WARN without taking down the rest of the section.
+func TestCheckStorage_ProbeErrorDemotesRow(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: newFakeClient().withDefaultRealms(),
+		ctrClient: &fakeCtrClient{
+			namespaces: []string{"default.kukeon.io", "kuke-system.kukeon.io"},
+			storageErr: errFakeProbeFailed,
+		},
+	}
+
+	results := checkStorage(context.Background(), rc)
+	if len(results) != 2 {
+		t.Fatalf("expected per-realm rows even on probe error; got %d", len(results))
+	}
+	for _, r := range results {
+		if r.Status != StatusWARN {
+			t.Errorf("row %q should be WARN on probe error; got %s", r.Name, r.Status)
+		}
+		if !strings.Contains(r.Detail, "probe failed") {
+			t.Errorf("row %q Detail should name probe failure; got %q", r.Name, r.Detail)
+		}
+	}
+}
+
+// TestCheckStorage_JSONShape confirms the JSON output surfaces the
+// structured Storage payload (the AC's "same figures in JSON output
+// shape" requirement) — not just the formatted Detail string.
+func TestCheckStorage_JSONShape(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: newFakeClient().withDefaultRealms(),
+		ctrClient: &fakeCtrClient{
+			namespaces: []string{"default.kukeon.io", "kuke-system.kukeon.io"},
+			storage: map[string]ctr.StorageStats{
+				"default.kukeon.io":     {Snapshots: 12, Leases: 49, Blobs: 24, BlobsBytes: 5 * 1024 * 1024},
+				"kuke-system.kukeon.io": {Snapshots: 157, Leases: 266, Blobs: 180, BlobsBytes: 700 * 1024 * 1024},
+			},
+		},
+	}
+
+	report := Report{OK: true, Checks: checkStorage(context.Background(), rc)}
+
+	var buf bytes.Buffer
+	if err := renderJSON(&buf, report); err != nil {
+		t.Fatalf("renderJSON: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("JSON malformed: %v\n%s", err, buf.String())
+	}
+	checks, _ := parsed["checks"].([]any)
+	if len(checks) != 2 {
+		t.Fatalf("expected 2 storage checks in JSON; got %d", len(checks))
+	}
+	for _, raw := range checks {
+		row, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("storage row is not an object: %v", raw)
+		}
+		storage, ok := row["storage"].(map[string]any)
+		if !ok {
+			t.Fatalf("storage row missing structured `storage` payload: %v", row)
+		}
+		for _, field := range []string{"snapshots", "leases", "blobs", "blobsBytes"} {
+			if _, present := storage[field]; !present {
+				t.Errorf("storage payload missing %q field: %v", field, storage)
+			}
+		}
+	}
+}
+
+// TestFmtBytes_UnitPicker spans the unit boundaries fmtBytes prints —
+// the rounding shape matters because operators eyeball the section to
+// catch slow growth, and a wrong unit on a borderline value would
+// hide a small leak under a rounded zero.
+func TestFmtBytes_UnitPicker(t *testing.T) {
+	cases := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{5 * 1024 * 1024, "5.0 MiB"},
+		{2 * 1024 * 1024 * 1024, "2.0 GiB"},
+		{3 * int64(1024) * 1024 * 1024 * 1024, "3.0 TiB"},
+	}
+	for _, c := range cases {
+		if got := fmtBytes(c.n); got != c.want {
+			t.Errorf("fmtBytes(%d): got %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+// errFake* are sentinel errors for the fake ctr client — wired up here
+// rather than via errors.New("...") inline so the tests assert the
+// detail surfaces the wrapped cause without depending on the exact
+// string literal in each helper.
+var (
+	errFakeDialFailed  = fakeError("dial failed: simulated")
+	errFakeProbeFailed = fakeError("metadata store unreachable")
+)
+
+type fakeError string
+
+func (e fakeError) Error() string { return string(e) }

--- a/docs/site/cli/kuke-status.md
+++ b/docs/site/cli/kuke-status.md
@@ -8,15 +8,15 @@ Report kukeon daemon, host, state, and parity health.
 
 Run the consolidated health report that replaces the manual `kuke get realms` vs `kuke get realms --no-daemon` diff ritual.
 
-Sections: daemon (socket dialable, round-trip, version), host (containerd, cgroup-v2, CNI plugins), state (orphan sockets, residual containerd namespaces), parity (every `kuke get <kind>` agrees daemon-side vs in-process). Each line is OK / WARN / FAIL with a one-line remediation hint when the status is not OK.
+Sections: daemon (socket dialable, round-trip, version), host (containerd, cgroup-v2, CNI plugins), state (orphan sockets, residual containerd namespaces), storage (per-realm snapshot / lease / content-blob footprint), parity (every `kuke get <kind>` agrees daemon-side vs in-process). Each line is OK / WARN / FAIL with a one-line remediation hint when the status is not OK.
 
 Exit code 0 when every check is OK or WARN; non-zero when any line is FAIL. The `--json` form is the machine-readable shape for CI integration; `--verbose` surfaces the remediation hint on OK rows too.
 
 ## Flags
 
-| Flag | Default | Description |
-| --- | --- | --- |
-| `--json` | `false` | emit a JSON document instead of the human-readable table |
+| Flag        | Default | Description                                                 |
+| ----------- | ------- | ----------------------------------------------------------- |
+| `--json`    | `false` | emit a JSON document instead of the human-readable table    |
 | `--verbose` | `false` | print the remediation hint on every row, not just WARN/FAIL |
 
 Plus all [global flags](kuke.md).
@@ -48,6 +48,10 @@ STATE
   run-dir     OK    /run/kukeon (no orphan sockets)
   namespaces  OK    no residual containerd namespaces
 
+STORAGE
+  default      OK    default.kukeon.io (12 snapshots, 49 leases, 24 blobs, 5.0 MiB)
+  kuke-system  OK    kuke-system.kukeon.io (157 snapshots, 266 leases, 180 blobs, 700.0 MiB)
+
 PARITY
   realms      OK    daemon view matches in-process view
   spaces      OK    daemon view matches in-process view
@@ -63,7 +67,7 @@ Status: OK
 
 ### JSON (`--json`)
 
-`--json` emits the same report as a 2-space-indented JSON document. The `status` field renders the human label (`"OK"` / `"WARN"` / `"FAIL"`) rather than an integer so the wire shape doesn't depend on enum order. The shape is the `Report` struct in [`cmd/kuke/status/status.go`](https://github.com/eminwux/kukeon/blob/main/cmd/kuke/status/status.go) — a top-level `ok` bool plus a flat `checks` array, with each row carrying `section`, `name`, `status`, `detail`, and an optional `remediation`.
+`--json` emits the same report as a 2-space-indented JSON document. The `status` field renders the human label (`"OK"` / `"WARN"` / `"FAIL"`) rather than an integer so the wire shape doesn't depend on enum order. The shape is the `Report` struct in [`cmd/kuke/status/status.go`](https://github.com/eminwux/kukeon/blob/main/cmd/kuke/status/status.go) — a top-level `ok` bool plus a flat `checks` array, with each row carrying `section`, `name`, `status`, `detail`, an optional `remediation`, and (on storage rows) an optional `storage` payload (`snapshots`, `leases`, `blobs`, `blobsBytes`) so CI tooling can alert on accumulation without parsing the human Detail string.
 
 ```json
 {
@@ -80,6 +84,18 @@ Status: OK
       "name": "containerd",
       "status": "OK",
       "detail": "/run/containerd/containerd.sock (reachable)"
+    },
+    {
+      "section": "storage",
+      "name": "default",
+      "status": "OK",
+      "detail": "default.kukeon.io (12 snapshots, 49 leases, 24 blobs, 5.0 MiB)",
+      "storage": {
+        "snapshots": 12,
+        "leases": 49,
+        "blobs": 24,
+        "blobsBytes": 5242880
+      }
     }
   ]
 }
@@ -89,12 +105,13 @@ A failing daemon dial yields `"status": "FAIL"` plus a populated `remediation` f
 
 ## What each section checks
 
-| Section | What it asserts |
-| ------- | --------------- |
-| `daemon` | The `kukeond` socket dials, an RPC round-trip returns the daemon's build version, and the round-trip latency is recorded. Replaces the original `kuke ping` proposal. |
-| `host` | `containerd` is reachable on the configured socket; cgroup-v2 is mounted on `/sys/fs/cgroup` with the controllers kukeon requires delegated (the same controller-set check as `kuke doctor cgroups`); the CNI binaries `kuke init` installs are present under `/opt/cni/bin`. |
-| `state` | The run-dir under `/run/kukeon` has no orphan sockets, and no residual containerd namespaces survive from a half-cleaned `kuke uninstall`. |
-| `parity` | For every resource kind (`realm`, `space`, `stack`, `cell`, `container`, `secret`, `blueprint`, `config`), the daemon's view and the in-process controller's view agree. This is the cross-kind generalization of the two-line `kuke get realms` diff the `make dev-init` smoke pins. |
+| Section   | What it asserts                                                                                                                                                                                                                                                                                                                                                                           |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `daemon`  | The `kukeond` socket dials, an RPC round-trip returns the daemon's build version, and the round-trip latency is recorded. Replaces the original `kuke ping` proposal.                                                                                                                                                                                                                     |
+| `host`    | `containerd` is reachable on the configured socket; cgroup-v2 is mounted on `/sys/fs/cgroup` with the controllers kukeon requires delegated (the same controller-set check as `kuke doctor cgroups`); the CNI binaries `kuke init` installs are present under `/opt/cni/bin`.                                                                                                             |
+| `state`   | The run-dir under `/run/kukeon` has no orphan sockets, and no residual containerd namespaces survive from a half-cleaned `kuke uninstall`.                                                                                                                                                                                                                                                |
+| `storage` | For every realm, the containerd namespace's snapshot count, lease count, and content-blob count plus summed byte size. Surfaces snapshot/lease/content accumulation early so a leak is visible before the data volume hits ENOSPC. Per-snapshot disk usage is intentionally omitted — the figures come from containerd metadata-store iterators (cheap), not an on-disk `du` (expensive). |
+| `parity`  | For every resource kind (`realm`, `space`, `stack`, `cell`, `container`, `secret`, `blueprint`, `config`), the daemon's view and the in-process controller's view agree. This is the cross-kind generalization of the two-line `kuke get realms` diff the `make dev-init` smoke pins.                                                                                                     |
 
 See [`CLAUDE.md` §"Post-init: `kuke status`"](https://github.com/eminwux/kukeon/blob/main/CLAUDE.md) for the operator narrative that positions this command inside the dev-init smoke loop; this page is the reference.
 

--- a/internal/controller/runner/delete_cell_test.go
+++ b/internal/controller/runner/delete_cell_test.go
@@ -207,6 +207,10 @@ func (c *deleteCellFakeClient) PruneImages(string) (ctr.PruneResult, error) {
 	return ctr.PruneResult{}, nil
 }
 
+func (c *deleteCellFakeClient) NamespaceStorage(string) (ctr.StorageStats, error) {
+	return ctr.StorageStats{}, nil
+}
+
 var _ ctr.Client = (*deleteCellFakeClient)(nil)
 
 // newDeleteCellTestExec builds a *Exec wired to the fake ctr.Client and an

--- a/internal/controller/runner/provision_subtree_test.go
+++ b/internal/controller/runner/provision_subtree_test.go
@@ -202,6 +202,10 @@ func (c *subtreeRecorderClient) PruneImages(string) (ctr.PruneResult, error) {
 	panic("unexpected")
 }
 
+func (c *subtreeRecorderClient) NamespaceStorage(string) (ctr.StorageStats, error) {
+	panic("unexpected")
+}
+
 // Compile-time: the stub satisfies the full Client surface.
 var _ ctr.Client = (*subtreeRecorderClient)(nil)
 

--- a/internal/controller/runner/spec_hash_guard_test.go
+++ b/internal/controller/runner/spec_hash_guard_test.go
@@ -174,6 +174,9 @@ func (c *specHashFakeClient) DeleteImage(string, string) error                  
 func (c *specHashFakeClient) PruneImages(string) (ctr.PruneResult, error) {
 	return ctr.PruneResult{}, nil
 }
+func (c *specHashFakeClient) NamespaceStorage(string) (ctr.StorageStats, error) {
+	return ctr.StorageStats{}, nil
+}
 
 var _ ctr.Client = (*specHashFakeClient)(nil)
 

--- a/internal/controller/runner/stop_kill_test.go
+++ b/internal/controller/runner/stop_kill_test.go
@@ -172,6 +172,10 @@ func (c *stopKillFakeClient) PruneImages(string) (ctr.PruneResult, error) {
 	return ctr.PruneResult{}, nil
 }
 
+func (c *stopKillFakeClient) NamespaceStorage(string) (ctr.StorageStats, error) {
+	return ctr.StorageStats{}, nil
+}
+
 var _ ctr.Client = (*stopKillFakeClient)(nil)
 
 func newStopKillTestExec(t *testing.T, fake *stopKillFakeClient) *Exec {

--- a/internal/ctr/client.go
+++ b/internal/ctr/client.go
@@ -167,6 +167,17 @@ type Client interface {
 	// images and the snapshots backing live containers untouched. Returns
 	// the count of leases released vs. retained.
 	PruneImages(namespace string) (PruneResult, error)
+
+	// NamespaceStorage returns the per-namespace storage footprint —
+	// snapshot count (across every registered snapshotter in
+	// KukeonKnownSnapshotters), lease count, and content-blob count plus
+	// summed byte size. Used by `kuke status` to surface accumulation
+	// before the data volume fills (issue #1039); the figures come from
+	// containerd's metadata stores (boltdb iterators), not an on-disk
+	// du, so the call stays cheap enough for the status command's
+	// budget. Per-snapshot disk usage is intentionally omitted — it
+	// would require walking the snapshotter's filesystem.
+	NamespaceStorage(namespace string) (StorageStats, error)
 }
 
 func NewClient(ctx context.Context, logger *slog.Logger, socket string) Client {

--- a/internal/ctr/storage.go
+++ b/internal/ctr/storage.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/errdefs"
+)
+
+// StorageStats is the per-namespace footprint NamespaceStorage returns —
+// the figures `kuke status`'s storage section surfaces so snapshot/lease/
+// content accumulation is observable before the data volume fills. All
+// counts are metadata-store reads (boltdb iterators), so the call stays
+// cheap. Snapshot disk usage is intentionally omitted: it would require
+// `du` against the snapshotter's filesystem and the status budget
+// doesn't fit it.
+type StorageStats struct {
+	// Snapshots is the total snapshot count across every registered
+	// snapshotter in KukeonKnownSnapshotters. Aggregated so the status
+	// row reads at-a-glance — a per-snapshotter breakdown would just
+	// noise the report when one snapshotter dominates in practice
+	// (overlayfs on real installs).
+	Snapshots int
+	// Leases is the total lease count from leases.Manager.List. Leases
+	// are containerd GC roots — accumulation past the live-image count
+	// is the leak signal issue #1039 surfaces.
+	Leases int
+	// Blobs is the count of content-store blobs (committed manifests,
+	// layers, configs).
+	Blobs int
+	// BlobsBytes is the summed Size field across the content-store
+	// walk — cheap because content.Info already carries the byte size,
+	// so no extra file stat is needed.
+	BlobsBytes int64
+}
+
+// NamespaceStorage returns StorageStats for the given namespace. Errors
+// from the underlying probes are wrapped with a leading label naming
+// which probe failed (leases / blobs / snapshots/<snapshotter>) so the
+// caller's report can name the failing class.
+func (c *client) NamespaceStorage(namespace string) (StorageStats, error) {
+	cc := c.conn()
+	if cc == nil {
+		if err := c.Connect(); err != nil {
+			return StorageStats{}, fmt.Errorf("failed to connect to containerd: %w", err)
+		}
+		cc = c.conn()
+	}
+
+	nsCtx := c.namespaceCtx(namespace)
+
+	var stats StorageStats
+
+	existingLeases, leaseErr := cc.LeasesService().List(nsCtx)
+	if leaseErr != nil {
+		return stats, fmt.Errorf("leases: %w", leaseErr)
+	}
+	stats.Leases = len(existingLeases)
+
+	blobErr := cc.ContentStore().Walk(nsCtx, func(info content.Info) error {
+		stats.Blobs++
+		stats.BlobsBytes += info.Size
+		return nil
+	})
+	if blobErr != nil {
+		return stats, fmt.Errorf("blobs: %w", blobErr)
+	}
+
+	for _, snapshotter := range KukeonKnownSnapshotters {
+		snapSvc := cc.SnapshotService(snapshotter)
+		if snapSvc == nil {
+			continue
+		}
+		count := 0
+		walkErr := snapSvc.Walk(nsCtx, func(_ context.Context, _ snapshots.Info) error {
+			count++
+			return nil
+		})
+		if walkErr != nil {
+			// An unregistered snapshotter on the host surfaces as
+			// errdefs.ErrNotFound (or a wrapped variant) — skip it
+			// rather than fail the whole probe. Real users only ever
+			// populate one snapshotter, so the rest are misses on
+			// every healthy host.
+			if errors.Is(walkErr, errdefs.ErrNotFound) {
+				continue
+			}
+			return stats, fmt.Errorf("snapshots/%s: %w", snapshotter, walkErr)
+		}
+		stats.Snapshots += count
+	}
+
+	return stats, nil
+}


### PR DESCRIPTION
## Summary

- Adds a `storage` section to `kuke status` reporting per-realm snapshot / lease / content-blob counts plus summed blob bytes, so accumulation is observable before the data volume hits ENOSPC — the prior failure mode (#1039 motivation) had the leak surfacing only as an attach timeout several layers downstream.
- New `ctr.Client.NamespaceStorage(namespace)` primitive returns the figures via containerd metadata-store iterators (boltdb-backed leases / content / per-snapshotter walks) — no on-disk `du`, so the call stays inside the status budget. Aggregates across `KukeonKnownSnapshotters` so the report doesn't depend on which snapshotter the host populates.
- JSON shape extended with an optional `storage` payload on storage rows (`snapshots`, `leases`, `blobs`, `blobsBytes`) so CI alerting parses figures directly instead of regexing the human Detail string.

## Design calls

- **Per-snapshot disk usage is intentionally omitted.** The AC budgets "(and disk usage where cheap to compute)" — counts and content-blob byte totals are cheap (metadata-store reads), but per-snapshot disk usage requires walking the snapshotter's filesystem, which would push `kuke status` past its budget. Documented in `ctr.StorageStats`'s godoc and in the `kuke status` reference.
- **Aggregated snapshot count, not per-snapshotter breakdown.** Real installs only populate one snapshotter (overlayfs); a per-snapshotter row would noise the report. Aggregation also keeps the section row count = realm count, matching how `state` reports namespaces.
- **Daemon-down fallback uses the ctr namespace list.** When `ListRealms` is unreachable, the section still surfaces figures by deriving realm names from kukeon containerd namespaces (same shape as `checkStateNamespaces`). The daemon row above carries the underlying cause.
- **Section ordering: state → storage → parity.** Storage is a host-state observation (alongside residual namespaces), so it sits next to `state`; `parity` stays last because it's the most expensive.
- **No automatic WARN thresholds.** Surfacing figures is enough; the operator decides when accumulation is too high. A future PR can add policy if needed.
- **Project `CLAUDE.md` not edited.** The narrative there is still accurate (it enumerates what `kuke status` is for, not the exact section names); per dev/CLAUDE.md no `<project>/CLAUDE.md` edits in a code-fix PR. The user-facing reference (`docs/site/cli/kuke-status.md`) is updated in this PR.

## Test plan

- [x] `make test` — full root + kukebuild test suites pass
- [x] `go vet ./...` clean
- [x] `pre-commit run --files <changed>` clean (govet shadow, prettier, end-of-file-fixer all pass)
- [x] New unit tests in `cmd/kuke/status/storage_test.go` cover: per-realm row + structured payload, daemon-down namespace fallback, ctr-unreachable single-WARN row, per-realm probe-error WARN, JSON shape carries the `storage` payload, `fmtBytes` unit-picker spans B/KiB/MiB/GiB/TiB boundaries
- [ ] `make dev-init` smoke not run — the diff is purely additive (new public method on `ctr.Client`, new read-only CLI section); it does not touch the build path, the daemon serve path, or anything under `/opt/kukeon`, so the smoke gate in the project `CLAUDE.md` does not apply

Closes #1039