### PR TITLE
feat(cell): persist materialization provenance; demote config label to lineage

### DIFF
--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -253,7 +253,7 @@ func runFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags createCe
 	if err != nil {
 		return err
 	}
-	cellDoc, err := cellblueprint.MaterializeWithName(resolved, flags.name)
+	cellDoc, err := cellblueprint.MaterializeWithName(resolved, flags.name, cliParams)
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,15 @@ func runFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags createCellF
 		)
 	}
 
-	cellDoc, err := cellconfig.MaterializeWithName(cfgRes.Config, bpRes.Blueprint, flags.name)
+	// The cell name is supplied here, not derived inside Materialize
+	// (epic:cell-identity #1021). Fall back to StableName when --name is
+	// absent so the create-cell config path keeps its historical stable
+	// identity; P2 replaces this with a dedicated name generator.
+	cellName := flags.name
+	if strings.TrimSpace(cellName) == "" {
+		cellName = cellconfig.StableName(cfgRes.Config.Metadata.Name)
+	}
+	cellDoc, err := cellconfig.MaterializeWithName(cfgRes.Config, bpRes.Blueprint, cellName)
 	if err != nil {
 		return err
 	}

--- a/cmd/kuke/run/divergence_idempotency_test.go
+++ b/cmd/kuke/run/divergence_idempotency_test.go
@@ -70,7 +70,7 @@ func TestDivergedFields_MaterializePersistMaterializeIsIdempotent(t *testing.T) 
 		t.Run(tc.name, func(t *testing.T) {
 			// Step 1: Materialize what `kuke restart` would push through
 			// ApplyDocuments.
-			cell1, err := cellconfig.Materialize(tc.cfg, tc.bp)
+			cell1, err := cellconfig.MaterializeWithName(tc.cfg, tc.bp, cellconfig.StableName(tc.cfg.Metadata.Name))
 			if err != nil {
 				t.Fatalf("Materialize (restart side): %v", err)
 			}
@@ -123,7 +123,7 @@ func TestDivergedFields_MaterializePersistMaterializeIsIdempotent(t *testing.T) 
 			}
 
 			// Step 4: Re-Materialize as the next `kuke run <config>` would.
-			cell2, err := cellconfig.Materialize(tc.cfg, tc.bp)
+			cell2, err := cellconfig.MaterializeWithName(tc.cfg, tc.bp, cellconfig.StableName(tc.cfg.Metadata.Name))
 			if err != nil {
 				t.Fatalf("Materialize (run side): %v", err)
 			}

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -558,6 +558,16 @@ func runRun(cmd *cobra.Command, args []string) error {
 	// last-wins across collisions) are owned by the runner-side mergeRuntimeEnv.
 	if len(flags.envArgs) > 0 {
 		cellDoc.Spec.RuntimeEnv = flags.envArgs
+		// Persist the same `--env` entries onto the provenance block
+		// (issue #1021). RuntimeEnv is transport-only (yaml:"-") and is
+		// dropped at write time; Spec.Provenance.EnvOverrides is the
+		// persisted record a later re-resolution reads. Provenance is set
+		// by the materialize path for `-b`/`-c`/`-p` runs; a manifest run
+		// (`kuke run -f`) carries no binding and so no provenance — guard
+		// for nil rather than fabricate one.
+		if cellDoc.Spec.Provenance != nil {
+			cellDoc.Spec.Provenance.EnvOverrides = append([]string(nil), flags.envArgs...)
+		}
 	}
 
 	if validateErr := validateResolvedCell(cellDoc); validateErr != nil {
@@ -985,7 +995,7 @@ func loadFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags runFlag
 	if err != nil {
 		return v1beta1.CellDoc{}, err
 	}
-	return cellblueprint.MaterializeWithName(resolved, flags.nameOverride)
+	return cellblueprint.MaterializeWithName(resolved, flags.nameOverride, cliParams)
 }
 
 // loadFromConfig resolves the named CellConfig from daemon storage, looks up
@@ -1109,7 +1119,16 @@ func loadFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags runFlags) 
 		}
 		nameOverride = generated
 	}
-	doc, materializeErr := cellconfig.MaterializeWithName(cfgRes.Config, bpRes.Blueprint, nameOverride)
+	// The cell name is supplied here, not derived inside Materialize
+	// (epic:cell-identity #1021 severed that assumption). The bare
+	// `<config>` form keeps its historical idempotent-attach identity via
+	// StableName; --name / --new supply their own name above. P2 replaces
+	// this derivation with a dedicated name generator.
+	cellName := nameOverride
+	if cellName == "" {
+		cellName = cellconfig.StableName(cfgRes.Config.Metadata.Name)
+	}
+	doc, materializeErr := cellconfig.MaterializeWithName(cfgRes.Config, bpRes.Blueprint, cellName)
 	if materializeErr != nil {
 		return loadResult{}, materializeErr
 	}

--- a/internal/apischeme/provenance_test.go
+++ b/internal/apischeme/provenance_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package apischeme_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/apischeme"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+// provenanceFixture is a fully-populated provenance block exercising every
+// field (issue #1021).
+func provenanceFixture() *ext.CellProvenance {
+	return &ext.CellProvenance{
+		BindingKind:  ext.BindingKindConfig,
+		BindingRef:   ext.CellBindingRef{Name: "web", Realm: "default", Space: "team-a", Stack: "api"},
+		Params:       map[string]string{"TAG": "v2", "REPLICAS": "3"},
+		EnvOverrides: []string{"DEBUG=1", "LOG_LEVEL=info"},
+	}
+}
+
+// TestCellProvenance_ConversionRoundTrip pins issue #1021 AC1: the provenance
+// block survives the external → internal → external conversion (both directions
+// copy it, unlike the transport-only RuntimeEnv which the outbound builder
+// drops).
+func TestCellProvenance_ConversionRoundTrip(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "web"},
+		Spec: ext.CellSpec{
+			ID:         "web",
+			RealmID:    "default",
+			Containers: []ext.ContainerSpec{},
+			Provenance: provenanceFixture(),
+		},
+	}
+
+	internal, err := apischeme.ConvertCellDocToInternal(input)
+	if err != nil {
+		t.Fatalf("ConvertCellDocToInternal: %v", err)
+	}
+	if internal.Spec.Provenance == nil {
+		t.Fatalf("internal provenance dropped on inbound conversion")
+	}
+	if internal.Spec.Provenance.BindingKind != ext.BindingKindConfig {
+		t.Errorf("internal bindingKind=%q want %q",
+			internal.Spec.Provenance.BindingKind, ext.BindingKindConfig)
+	}
+
+	output, err := apischeme.BuildCellExternalFromInternal(internal, apischeme.VersionV1Beta1)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if !reflect.DeepEqual(output.Spec.Provenance, input.Spec.Provenance) {
+		t.Errorf("provenance not preserved across conversion round-trip\n got: %+v\nwant: %+v",
+			output.Spec.Provenance, input.Spec.Provenance)
+	}
+}
+
+// TestCellProvenance_PersistenceRoundTrip pins issue #1021 AC1 across the
+// on-disk persistence path: the daemon writes metadata.json via JSON marshal
+// and re-reads it via JSON unmarshal, and `kuke get cell -o yaml` renders via
+// YAML. The provenance block must survive both encodings (it carries no
+// yaml:"-", unlike RuntimeEnv).
+func TestCellProvenance_PersistenceRoundTrip(t *testing.T) {
+	doc := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "web"},
+		Spec: ext.CellSpec{
+			ID:         "web",
+			RealmID:    "default",
+			Containers: []ext.ContainerSpec{},
+			Provenance: provenanceFixture(),
+		},
+	}
+
+	t.Run("json", func(t *testing.T) {
+		raw, err := json.Marshal(doc)
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+		var got ext.CellDoc
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("json.Unmarshal: %v", err)
+		}
+		if !reflect.DeepEqual(got.Spec.Provenance, doc.Spec.Provenance) {
+			t.Errorf("provenance not preserved across JSON round-trip\n got: %+v\nwant: %+v",
+				got.Spec.Provenance, doc.Spec.Provenance)
+		}
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		raw, err := yaml.Marshal(doc)
+		if err != nil {
+			t.Fatalf("yaml.Marshal: %v", err)
+		}
+		var got ext.CellDoc
+		if err := yaml.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("yaml.Unmarshal: %v", err)
+		}
+		if !reflect.DeepEqual(got.Spec.Provenance, doc.Spec.Provenance) {
+			t.Errorf("provenance not preserved across YAML round-trip\n got: %+v\nwant: %+v",
+				got.Spec.Provenance, doc.Spec.Provenance)
+		}
+	})
+}
+
+// TestCellProvenance_NilOmitted confirms a hand-built cell with no provenance
+// round-trips as nil (the omitempty pointer keeps it out of the encoded
+// document entirely).
+func TestCellProvenance_NilOmitted(t *testing.T) {
+	doc := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata:   ext.CellMetadata{Name: "hand-built"},
+		Spec:       ext.CellSpec{ID: "hand-built", RealmID: "default", Containers: []ext.ContainerSpec{}},
+	}
+
+	internal, err := apischeme.ConvertCellDocToInternal(doc)
+	if err != nil {
+		t.Fatalf("ConvertCellDocToInternal: %v", err)
+	}
+	if internal.Spec.Provenance != nil {
+		t.Errorf("nil provenance materialized into %+v", internal.Spec.Provenance)
+	}
+	output, err := apischeme.BuildCellExternalFromInternal(internal, apischeme.VersionV1Beta1)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal: %v", err)
+	}
+	if output.Spec.Provenance != nil {
+		t.Errorf("nil provenance round-tripped to %+v", output.Spec.Provenance)
+	}
+}

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -1249,6 +1249,60 @@ func copyBoolPtr(in *bool) *bool {
 	return &out
 }
 
+// convertCellProvenanceToInternal copies the external cell provenance block
+// (issue #1021) into its internal mirror, deep-cloning the params map and
+// env-override slice so the two model copies never alias. Returns nil for a
+// nil input (hand-built cells carry no provenance).
+func convertCellProvenanceToInternal(in *ext.CellProvenance) *intmodel.CellProvenance {
+	if in == nil {
+		return nil
+	}
+	out := &intmodel.CellProvenance{
+		BindingKind: in.BindingKind,
+		BindingRef: intmodel.CellBindingRef{
+			Name:  in.BindingRef.Name,
+			Realm: in.BindingRef.Realm,
+			Space: in.BindingRef.Space,
+			Stack: in.BindingRef.Stack,
+		},
+		EnvOverrides: cloneStringSlice(in.EnvOverrides),
+	}
+	if in.Params != nil {
+		params := make(map[string]string, len(in.Params))
+		for k, v := range in.Params {
+			params[k] = v
+		}
+		out.Params = params
+	}
+	return out
+}
+
+// buildCellProvenanceExternalFromInternal is the internal → external inverse
+// of convertCellProvenanceToInternal. Issue #1021.
+func buildCellProvenanceExternalFromInternal(in *intmodel.CellProvenance) *ext.CellProvenance {
+	if in == nil {
+		return nil
+	}
+	out := &ext.CellProvenance{
+		BindingKind: in.BindingKind,
+		BindingRef: ext.CellBindingRef{
+			Name:  in.BindingRef.Name,
+			Realm: in.BindingRef.Realm,
+			Space: in.BindingRef.Space,
+			Stack: in.BindingRef.Stack,
+		},
+		EnvOverrides: cloneStringSlice(in.EnvOverrides),
+	}
+	if in.Params != nil {
+		params := make(map[string]string, len(in.Params))
+		for k, v := range in.Params {
+			params[k] = v
+		}
+		out.Params = params
+	}
+	return out
+}
+
 func volumeMountsToInternal(in []ext.VolumeMount) []intmodel.VolumeMount {
 	if in == nil {
 		return nil
@@ -1366,6 +1420,10 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				// path and is dropped at persistence time by
 				// BuildCellExternalFromInternal → yaml.Marshal. Issue #834.
 				RuntimeEnv: cloneStringSlice(in.Spec.RuntimeEnv),
+				// Provenance is persisted lineage data (issue #1021), so it
+				// round-trips in both conversion directions — unlike
+				// RuntimeEnv, which the outbound builder drops.
+				Provenance: convertCellProvenanceToInternal(in.Spec.Provenance),
 			},
 			Status: intmodel.CellStatus{
 				State:              intmodel.CellState(in.Status.State),
@@ -1446,6 +1504,11 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				// operator always re-supplies --env on every invocation.
 				// The CLI → daemon direction in ConvertCellDocToInternal
 				// preserves it so the runner's OCI build sees the entries.
+				//
+				// Provenance, by contrast, IS copied here (issue #1021): it
+				// is persisted lineage data, so the disk-write doc and the RPC
+				// reply both carry it.
+				Provenance: buildCellProvenanceExternalFromInternal(in.Spec.Provenance),
 			},
 			Status: ext.CellStatus{
 				State:              ext.CellState(in.Status.State),

--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -132,16 +132,22 @@ func resolveValues(
 	return values, nil
 }
 
-// Materialize converts a resolved blueprint into a CellDoc. See
-// MaterializeWithName for the override-aware form.
+// Materialize converts a resolved blueprint into a CellDoc with a generated
+// name and no recorded params. See MaterializeWithName for the override- and
+// provenance-aware form.
 func Materialize(doc v1beta1.CellBlueprintDoc) (v1beta1.CellDoc, error) {
-	return MaterializeWithName(doc, "")
+	return MaterializeWithName(doc, "", nil)
 }
 
 // MaterializeWithName converts a (resolved) blueprint into a CellDoc named
 // `<prefix>-<6hex>` (prefix = spec.prefix or metadata.name), or nameOverride
 // verbatim when non-empty. The realm/space/stack triple comes from the
-// blueprint metadata. Every cell carries the kukeon.io/blueprint=<name> label.
+// blueprint metadata. Every cell carries the kukeon.io/blueprint=<name>
+// lineage label and a Spec.Provenance block recording the Blueprint binding it
+// was stamped from (issue #1021); params are the resolved `--param` map the
+// caller substituted into the blueprint (pass the same map handed to Resolve),
+// recorded verbatim so a later re-resolution does not depend on re-reading the
+// transient CLI invocation.
 //
 // Structural slots are resolved against the "scalar-only inline" contract:
 // a repo whose url is still empty after substitution, and every secret slot
@@ -149,7 +155,9 @@ func Materialize(doc v1beta1.CellBlueprintDoc) (v1beta1.CellDoc, error) {
 // unfilled. An unfilled *required* slot makes the blueprint un-runnable inline
 // and returns ErrBlueprintStructuralSlots naming the offenders; an unfilled
 // *optional* slot is dropped from the materialized container.
-func MaterializeWithName(doc v1beta1.CellBlueprintDoc, nameOverride string) (v1beta1.CellDoc, error) {
+func MaterializeWithName(
+	doc v1beta1.CellBlueprintDoc, nameOverride string, params map[string]string,
+) (v1beta1.CellDoc, error) {
 	cellName, err := resolveCellName(doc, nameOverride)
 	if err != nil {
 		return v1beta1.CellDoc{}, err
@@ -185,8 +193,34 @@ func MaterializeWithName(doc v1beta1.CellBlueprintDoc, nameOverride string) (v1b
 			Containers:          containers,
 			AutoDelete:          doc.Spec.Cell.AutoDelete,
 			NestedCgroupRuntime: doc.Spec.Cell.NestedCgroupRuntime,
+			Provenance:          blueprintProvenance(doc, params),
 		},
 	}, nil
+}
+
+// blueprintProvenance builds the Spec.Provenance block for a Blueprint-
+// materialized cell: bindingKind=blueprint, the Blueprint's scoped name as the
+// binding ref, and the resolved `--param` map as the recorded params.
+// EnvOverrides is left for the run-time caller to populate from `--env`.
+// Issue #1021.
+func blueprintProvenance(doc v1beta1.CellBlueprintDoc, params map[string]string) *v1beta1.CellProvenance {
+	prov := &v1beta1.CellProvenance{
+		BindingKind: v1beta1.BindingKindBlueprint,
+		BindingRef: v1beta1.CellBindingRef{
+			Name:  strings.TrimSpace(doc.Metadata.Name),
+			Realm: strings.TrimSpace(doc.Metadata.Realm),
+			Space: strings.TrimSpace(doc.Metadata.Space),
+			Stack: strings.TrimSpace(doc.Metadata.Stack),
+		},
+	}
+	if len(params) > 0 {
+		p := make(map[string]string, len(params))
+		for k, v := range params {
+			p[k] = v
+		}
+		prov.Params = p
+	}
+	return prov
 }
 
 // materializeContainer maps a BlueprintContainer to a runtime ContainerSpec and

--- a/internal/cellblueprint/cellblueprint_test.go
+++ b/internal/cellblueprint/cellblueprint_test.go
@@ -153,12 +153,52 @@ func TestMaterialize_FreshNameEachCall(t *testing.T) {
 
 func TestMaterialize_NameOverride(t *testing.T) {
 	resolved, _ := cellblueprint.Resolve(baseDoc(), nil, nil)
-	cell, err := cellblueprint.MaterializeWithName(resolved, "pinned")
+	cell, err := cellblueprint.MaterializeWithName(resolved, "pinned", nil)
 	if err != nil {
 		t.Fatalf("MaterializeWithName: %v", err)
 	}
 	if cell.Metadata.Name != "pinned" || cell.Spec.ID != "pinned" {
 		t.Fatalf("override not honored: name=%q id=%q", cell.Metadata.Name, cell.Spec.ID)
+	}
+}
+
+// TestMaterialize_StampsBlueprintProvenance pins issue #1021: a Blueprint-
+// materialized cell carries a Spec.Provenance block with bindingKind=blueprint,
+// the Blueprint's scoped name as the binding ref, and the resolved --param map
+// recorded verbatim so a later re-resolution does not depend on the transient
+// CLI invocation.
+func TestMaterialize_StampsBlueprintProvenance(t *testing.T) {
+	resolved, err := cellblueprint.Resolve(baseDoc(), map[string]string{"TAG": "v9"}, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	cell, err := cellblueprint.MaterializeWithName(resolved, "pinned", map[string]string{"TAG": "v9"})
+	if err != nil {
+		t.Fatalf("MaterializeWithName: %v", err)
+	}
+	prov := cell.Spec.Provenance
+	if prov == nil {
+		t.Fatalf("cell.Spec.Provenance = nil; want a blueprint provenance block")
+	}
+	if prov.BindingKind != v1beta1.BindingKindBlueprint {
+		t.Errorf("bindingKind=%q want %q", prov.BindingKind, v1beta1.BindingKindBlueprint)
+	}
+	wantRef := v1beta1.CellBindingRef{Name: "web", Realm: "default", Space: "agents", Stack: "claude"}
+	if prov.BindingRef != wantRef {
+		t.Errorf("bindingRef=%+v want %+v", prov.BindingRef, wantRef)
+	}
+	if got := prov.Params["TAG"]; got != "v9" {
+		t.Errorf("params[TAG]=%q want v9", got)
+	}
+	// Mutating the source param map must not leak into the stamped provenance.
+	src := map[string]string{"TAG": "orig"}
+	cell2, err := cellblueprint.MaterializeWithName(resolved, "pinned", src)
+	if err != nil {
+		t.Fatalf("MaterializeWithName: %v", err)
+	}
+	src["TAG"] = "mutated"
+	if got := cell2.Spec.Provenance.Params["TAG"]; got != "orig" {
+		t.Errorf("provenance params aliased source map: got %q want orig", got)
 	}
 }
 

--- a/internal/cellconfig/cellconfig.go
+++ b/internal/cellconfig/cellconfig.go
@@ -32,11 +32,17 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
-// LabelConfig is the cell label recording the CellConfig a cell was
+// LabelConfig is the cell *lineage* label recording the CellConfig a cell was
 // materialized from, the config analog of cellprofile.LabelProfile and
-// cellblueprint.LabelBlueprint. Set on the cell that `kuke run -c` materializes
-// (#625) so the state machine can find the at-most-one live cell a Config owns
-// (`kuke get cells -l kukeon.io/config=<name>`).
+// cellblueprint.LabelBlueprint. Set on every cell that `kuke run <config>`
+// materializes (#625) so operators can enumerate all of a Config's spawns with
+// `kuke get cells -l kukeon.io/config=<name>`.
+//
+// The relationship is 1:N, not identity (epic:cell-identity #1021): a single
+// Config may stamp many cells, and the cell's identity is its own name on the
+// CellDoc — not this label. The persisted Spec.Provenance block carries the
+// same binding reference in a typed, machine-readable form for re-resolution;
+// this label is the operator-facing, `-l`-selectable projection of it.
 const LabelConfig = "kukeon.io/config"
 
 // AnnotationSourceConfig is the metadata.annotations key a `kuke run <src>

--- a/internal/cellconfig/materialize.go
+++ b/internal/cellconfig/materialize.go
@@ -26,9 +26,10 @@ import (
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
-// Materialize converts a CellConfig + its referenced CellBlueprint into a
-// runtime CellDoc (issue #625). It is the config analog of
-// cellblueprint.Materialize, but the two channels differ:
+// MaterializeWithName converts a CellConfig + its referenced CellBlueprint into
+// a runtime CellDoc (issue #625), naming the cell `name` verbatim. It is the
+// config analog of cellblueprint.MaterializeWithName, but the two channels
+// differ:
 //
 //   - Scalar values come from cfg.Spec.Values (not --param CLI args); the env
 //     fallback is intentionally absent because a Config's values are the
@@ -38,29 +39,25 @@ import (
 //     required slots are rejected via ValidateSlotFill; optional unfilled slots
 //     are dropped from the materialized container.
 //
-// The materialized cell carries the cellconfig.LabelConfig back-reference (AC
-// of #625) plus every label the operator set on cfg.Metadata.Labels, and uses
-// the deterministic StableName(cfg.Metadata.Name) — the affordance that makes
-// `kuke run -c` idempotent (at most one live cell per Config). The cell's
-// scope coordinates come from the Config's metadata, not the blueprint's, so a
-// Config in one realm may instantiate a Blueprint in another (cross-realm
-// references are explicitly supported by CellConfigBlueprintRef).
-func Materialize(cfg v1beta1.CellConfigDoc, bp v1beta1.CellBlueprintDoc) (v1beta1.CellDoc, error) {
-	return MaterializeWithName(cfg, bp, "")
-}
-
-// MaterializeWithName is the Materialize variant that lets the caller pin a
-// non-stable cell name — the substrate for `kuke run <config> --new` (#833;
-// originally shipped as `-c --generate-name` in #754, renamed in #833).
-// When nameOverride is empty the cell uses StableName(cfg.Metadata.Name) and the
-// idempotent-attach identity contract from #742 holds; when non-empty the name
-// is used verbatim and the caller owns identity (the `kuke run <config> --new`
-// path supplies `<cfg.Metadata.Name>-<6hex>` for the bare --new form, or the
-// operator's `--name X` value for the `--new --name X` create-or-fail form,
-// leaving the kukeon.io/config back-reference label intact so `kuke get cells
-// -l kukeon.io/config=<name>` still enumerates every spawn).
+// The materialized cell carries the cellconfig.LabelConfig lineage label (AC
+// of #625) plus every label the operator set on cfg.Metadata.Labels, and a
+// Spec.Provenance block recording the Config binding it was stamped from
+// (issue #1021). The cell's scope coordinates come from the Config's metadata,
+// not the blueprint's, so a Config in one realm may instantiate a Blueprint in
+// another (cross-realm references are explicitly supported by
+// CellConfigBlueprintRef).
+//
+// The cell name is supplied by the caller — materialization no longer derives
+// it from cfg.Metadata.Name (epic:cell-identity #1021 severs that assumption;
+// the cell's identity is the CellDoc, and the Config name is demoted to
+// lineage). Callers that want the historical stable-name identity pass
+// StableName(cfg.Metadata.Name); `kuke run <config> --new` passes a generated
+// `<config>-<6hex>`; P2 will supply a dedicated name generator. An empty name
+// is the caller's responsibility (it yields an empty-named cell that fails
+// downstream validation) — materialization intentionally does not paper over
+// it by reaching back to the Config name.
 func MaterializeWithName(
-	cfg v1beta1.CellConfigDoc, bp v1beta1.CellBlueprintDoc, nameOverride string,
+	cfg v1beta1.CellConfigDoc, bp v1beta1.CellBlueprintDoc, name string,
 ) (v1beta1.CellDoc, error) {
 	if err := ValidateSlotFill(cfg, bp); err != nil {
 		return v1beta1.CellDoc{}, err
@@ -83,10 +80,7 @@ func MaterializeWithName(
 		containers = append(containers, cs)
 	}
 
-	cellName := strings.TrimSpace(nameOverride)
-	if cellName == "" {
-		cellName = StableName(cfg.Metadata.Name)
-	}
+	cellName := strings.TrimSpace(name)
 	return v1beta1.CellDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
 		Kind:       v1beta1.KindCell,
@@ -103,8 +97,34 @@ func MaterializeWithName(
 			Containers:          containers,
 			AutoDelete:          resolved.Spec.Cell.AutoDelete,
 			NestedCgroupRuntime: resolved.Spec.Cell.NestedCgroupRuntime,
+			Provenance:          configProvenance(cfg),
 		},
 	}, nil
+}
+
+// configProvenance builds the Spec.Provenance block for a Config-materialized
+// cell: bindingKind=config, the Config's scoped name as the binding ref, and
+// the Config's spec.values as the recorded params. EnvOverrides is left for
+// the run-time caller to populate from `--env` (the Config path's materialize
+// has no CLI env). Issue #1021.
+func configProvenance(cfg v1beta1.CellConfigDoc) *v1beta1.CellProvenance {
+	prov := &v1beta1.CellProvenance{
+		BindingKind: v1beta1.BindingKindConfig,
+		BindingRef: v1beta1.CellBindingRef{
+			Name:  strings.TrimSpace(cfg.Metadata.Name),
+			Realm: strings.TrimSpace(cfg.Metadata.Realm),
+			Space: strings.TrimSpace(cfg.Metadata.Space),
+			Stack: strings.TrimSpace(cfg.Metadata.Stack),
+		},
+	}
+	if len(cfg.Spec.Values) > 0 {
+		params := make(map[string]string, len(cfg.Spec.Values))
+		for k, v := range cfg.Spec.Values {
+			params[k] = v
+		}
+		prov.Params = params
+	}
+	return prov
 }
 
 // materializeContainer maps a (resolved) BlueprintContainer to a runtime
@@ -251,9 +271,12 @@ func materializeSecretSlot(
 }
 
 // mergeConfigLabel returns a label map combining the operator-authored labels
-// from the Config's metadata with the kukeon.io/config back-reference pointing
-// at the Config that materialized the cell. The back-reference wins on a
-// collision so a Config cannot accidentally shadow its own identity label.
+// from the Config's metadata with the kukeon.io/config lineage label pointing
+// at the Config that materialized the cell. The lineage label wins on a
+// collision so a Config cannot accidentally shadow its own provenance. The
+// relationship is 1:N — a single Config may stamp many cells (epic:cell-
+// identity #1021 demotes this label from identity to lineage); the cell's
+// identity is its own name, recorded on the CellDoc, not this label.
 func mergeConfigLabel(in map[string]string, configName string) map[string]string {
 	out := make(map[string]string, len(in)+1)
 	for k, v := range in {

--- a/internal/cellconfig/materialize_test.go
+++ b/internal/cellconfig/materialize_test.go
@@ -82,7 +82,7 @@ func TestMaterialize_HappyPath_FillsRepoAndSecretSlots(t *testing.T) {
 		},
 	}
 
-	cell, err := Materialize(cfg, bp)
+	cell, err := MaterializeWithName(cfg, bp, StableName(cfg.Metadata.Name))
 	if err != nil {
 		t.Fatalf("Materialize: %v", err)
 	}
@@ -181,7 +181,7 @@ func TestMaterialize_RequiredRepoSlotUnfilled_Errors(t *testing.T) {
 		},
 	}
 
-	_, err := Materialize(cfg, bp)
+	_, err := MaterializeWithName(cfg, bp, StableName(cfg.Metadata.Name))
 	if err == nil || !errors.Is(err, errdefs.ErrConfigRequiredSlotUnfilled) {
 		t.Fatalf("err=%v want ErrConfigRequiredSlotUnfilled", err)
 	}
@@ -205,7 +205,7 @@ func TestMaterialize_UnknownSlotFill_Errors(t *testing.T) {
 		},
 	}
 
-	_, err := Materialize(cfg, bp)
+	_, err := MaterializeWithName(cfg, bp, StableName(cfg.Metadata.Name))
 	if err == nil || !errors.Is(err, errdefs.ErrConfigUnknownRepoSlot) {
 		t.Fatalf("err=%v want ErrConfigUnknownRepoSlot", err)
 	}
@@ -229,7 +229,7 @@ func TestMaterialize_OptionalSlotUnfilled_Drops(t *testing.T) {
 		},
 	}
 
-	cell, err := Materialize(cfg, bp)
+	cell, err := MaterializeWithName(cfg, bp, StableName(cfg.Metadata.Name))
 	if err != nil {
 		t.Fatalf("Materialize: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestMaterialize_RepoFillRefCarriesThrough(t *testing.T) {
 			},
 		},
 	}
-	cell, err := Materialize(cfg, bp)
+	cell, err := MaterializeWithName(cfg, bp, StableName(cfg.Metadata.Name))
 	if err != nil {
 		t.Fatalf("Materialize: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestMaterialize_ScalarRepoPassesThrough(t *testing.T) {
 		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm"},
 		Spec:       v1beta1.CellConfigSpec{Blueprint: v1beta1.CellConfigBlueprintRef{Name: "lib", Realm: "bp-realm"}},
 	}
-	cell, err := Materialize(cfg, bp)
+	cell, err := MaterializeWithName(cfg, bp, StableName(cfg.Metadata.Name))
 	if err != nil {
 		t.Fatalf("Materialize: %v", err)
 	}
@@ -341,18 +341,17 @@ func TestMaterialize_PropagatesResolveError(t *testing.T) {
 		},
 	}
 
-	_, err := Materialize(cfg, bp)
+	_, err := MaterializeWithName(cfg, bp, StableName(cfg.Metadata.Name))
 	if err == nil || !errors.Is(err, errdefs.ErrBlueprintInvalid) {
 		t.Fatalf("err=%v want ErrBlueprintInvalid (required param TAG unset)", err)
 	}
 }
 
-// TestMaterializeWithName_OverrideWinsOverStableName pins the #754 escape hatch:
-// when the caller pins a name, the materialized cell uses it verbatim instead of
-// the StableName(cfg.Metadata.Name) used on the empty-override path. The
-// kukeon.io/config back-reference label still points at the Config (lineage
-// preserved across generated-name spawns).
-func TestMaterializeWithName_OverrideWinsOverStableName(t *testing.T) {
+// TestMaterializeWithName_UsesNameVerbatim pins that the caller-supplied name
+// is used verbatim for both metadata.name and spec.ID, and that the
+// kukeon.io/config lineage label still points at the Config (lineage preserved
+// independently of the cell name).
+func TestMaterializeWithName_UsesNameVerbatim(t *testing.T) {
 	bp := minimalBlueprint()
 	cfg := v1beta1.CellConfigDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
@@ -385,10 +384,13 @@ func TestMaterializeWithName_OverrideWinsOverStableName(t *testing.T) {
 	}
 }
 
-// TestMaterializeWithName_EmptyOverrideUsesStableName guards the no-regression
-// path: callers that pass "" still get the deterministic stable-name behavior
-// the #742 idempotent-attach contract depends on.
-func TestMaterializeWithName_EmptyOverrideUsesStableName(t *testing.T) {
+// TestMaterializeWithName_EmptyNameNotDerivedFromConfig pins the severed
+// assumption (epic:cell-identity #1021): materialization no longer reaches back
+// to cfg.Metadata.Name when the caller passes an empty name. The empty name is
+// the caller's responsibility — materialize must NOT silently substitute
+// StableName(cfg.Metadata.Name) the way the pre-#1021 path did. The lineage
+// label is still stamped regardless of the name.
+func TestMaterializeWithName_EmptyNameNotDerivedFromConfig(t *testing.T) {
 	bp := minimalBlueprint()
 	cfg := v1beta1.CellConfigDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
@@ -410,8 +412,53 @@ func TestMaterializeWithName_EmptyOverrideUsesStableName(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MaterializeWithName: %v", err)
 	}
-	if got := cell.Metadata.Name; got != "prod" {
-		t.Errorf("cell name=%q want prod (StableName fallback on empty override)", got)
+	if got := cell.Metadata.Name; got != "" {
+		t.Errorf("cell name=%q want \"\" (name not derived from config name post-#1021)", got)
+	}
+	if got := cell.Metadata.Labels[LabelConfig]; got != "prod" {
+		t.Errorf("LabelConfig=%q want prod (lineage stamped regardless of cell name)", got)
+	}
+}
+
+// TestMaterializeWithName_StampsConfigProvenance pins the provenance block a
+// Config-materialized cell carries (issue #1021): bindingKind=config, the
+// Config's scoped name as the binding ref, and the Config's spec.values as the
+// recorded params.
+func TestMaterializeWithName_StampsConfigProvenance(t *testing.T) {
+	bp := minimalBlueprint()
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "prod", Realm: "cfg-realm", Space: "team-a"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Values:    map[string]string{"TAG": "v2"},
+			Repos: map[string]v1beta1.CellConfigRepoFill{
+				"src": {URL: "https://example.com/src.git"},
+			},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "api-token", Realm: "cfg-realm"}},
+			},
+		},
+	}
+
+	cell, err := MaterializeWithName(cfg, bp, "prod")
+	if err != nil {
+		t.Fatalf("MaterializeWithName: %v", err)
+	}
+	prov := cell.Spec.Provenance
+	if prov == nil {
+		t.Fatalf("cell.Spec.Provenance = nil; want a config provenance block")
+	}
+	if prov.BindingKind != v1beta1.BindingKindConfig {
+		t.Errorf("bindingKind=%q want %q", prov.BindingKind, v1beta1.BindingKindConfig)
+	}
+	wantRef := v1beta1.CellBindingRef{Name: "prod", Realm: "cfg-realm", Space: "team-a"}
+	if prov.BindingRef != wantRef {
+		t.Errorf("bindingRef=%+v want %+v", prov.BindingRef, wantRef)
+	}
+	if got := prov.Params["TAG"]; got != "v2" {
+		t.Errorf("params[TAG]=%q want v2", got)
 	}
 }
 

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -604,6 +604,54 @@ func TestDiffCell_RootContainer_NoDriftOnEqualSpec(t *testing.T) {
 	}
 }
 
+// TestDiffCell_ProvenanceIgnored pins issue #1021 AC3: the Spec.Provenance
+// block is lineage/identity data, not a runtime spec field, so a cell that
+// differs from its would-be-materialized twin *only* in provenance must not
+// report any change. Were DiffCell to compare it, the reconciler would stamp a
+// permanent false OutOfSync on every Config-lineage cell.
+func TestDiffCell_ProvenanceIgnored(t *testing.T) {
+	root := intmodel.ContainerSpec{
+		ID:    "root",
+		Root:  true,
+		Image: "busybox:latest",
+	}
+	base := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName:  "default",
+			SpaceName:  "default",
+			StackName:  "default",
+			Containers: []intmodel.ContainerSpec{root},
+			Provenance: &intmodel.CellProvenance{
+				BindingKind: "config",
+				BindingRef:  intmodel.CellBindingRef{Name: "web", Realm: "default"},
+				Params:      map[string]string{"TAG": "v1"},
+			},
+		},
+	}
+
+	// actual carries a divergent provenance block (different params, a
+	// different binding ref) but an identical runtime spec.
+	actual := base
+	actual.Spec.Provenance = &intmodel.CellProvenance{
+		BindingKind:  "config",
+		BindingRef:   intmodel.CellBindingRef{Name: "web", Realm: "default", Space: "team-b"},
+		Params:       map[string]string{"TAG": "v2"},
+		EnvOverrides: []string{"DEBUG=1"},
+	}
+
+	if diff := apply.DiffCell(base, actual); diff.HasChanges {
+		t.Errorf("provenance-only difference reported changes: %+v", diff)
+	}
+
+	// A nil-vs-set provenance must likewise be a no-op.
+	noProv := base
+	noProv.Spec.Provenance = nil
+	if diff := apply.DiffCell(base, noProv); diff.HasChanges {
+		t.Errorf("nil-vs-set provenance reported changes: %+v", diff)
+	}
+}
+
 // TestDiffContainer_RootStillBreaking ensures the single-container
 // reconcile path (ReconcileContainer) keeps the breaking-change
 // classification for root containers — the rootContainer flag flows

--- a/internal/controller/reconcile_outofsync.go
+++ b/internal/controller/reconcile_outofsync.go
@@ -42,8 +42,8 @@ const (
 // `-b`-lineage and hand-built cases are deliberately out of scope per the
 // umbrella). For a Config-lineage cell, the pass re-derives the would-be
 // CellDoc from the daemon-stored Config + its referenced Blueprint via the
-// same `cellconfig.Materialize` call the CellConfig materialisation path
-// uses, then compares the materialized spec against the live cell with
+// same `cellconfig.MaterializeWithName` call the CellConfig materialisation
+// path uses, then compares the materialized spec against the live cell with
 // `apply.DiffCell`. The outcome lands on three status fields:
 //
 //   - OutOfSync = true with OutOfSyncReason describing the divergence when
@@ -98,7 +98,7 @@ func desiredCellOutOfSync(r runner.Runner, cell intmodel.Cell, configName string
 		return cellOutOfSync{OutOfSync: true, Reason: outOfSyncReasonConfigDeleted}
 	}
 
-	desiredCell, materializeErr := materializeCellFromConfig(r, cfg)
+	desiredCell, materializeErr := materializeCellFromConfig(r, cfg, cell.Metadata.Name)
 	if materializeErr != nil {
 		return cellOutOfSync{Err: materializeErr.Error()}
 	}
@@ -181,11 +181,18 @@ func lookupLineageConfig(
 
 // materializeCellFromConfig re-runs the CellConfig materialization pipeline
 // against a daemon-stored Config: decode the Config's body, resolve the
-// referenced Blueprint, then `cellconfig.Materialize` the two. Returns the
-// materialized cell in the same internal-model shape the reconciler's live
+// referenced Blueprint, then `cellconfig.MaterializeWithName` the two. Returns
+// the materialized cell in the same internal-model shape the reconciler's live
 // cell uses, so apply.DiffCell can compare them directly.
+//
+// The live cell's own name is threaded through as the materialized name so the
+// diff never trips on metadata.name — materialization no longer derives the
+// name from the Config name (epic:cell-identity #1021), and the OutOfSync
+// detector compares *spec drift*, not identity. This keeps the detector
+// correct once P2 lands generated cell names that no longer match
+// StableName(configName).
 func materializeCellFromConfig(
-	r runner.Runner, cfg intmodel.CellConfig,
+	r runner.Runner, cfg intmodel.CellConfig, cellName string,
 ) (intmodel.Cell, error) {
 	cfgDoc, err := apischeme.ConvertCellConfigToExternal(cfg)
 	if err != nil {
@@ -212,7 +219,7 @@ func materializeCellFromConfig(
 		return intmodel.Cell{}, fmt.Errorf("decode referenced blueprint: %w", bpErr)
 	}
 
-	cellDoc, mErr := cellconfig.Materialize(cfgDoc, bpDoc)
+	cellDoc, mErr := cellconfig.MaterializeWithName(cfgDoc, bpDoc, cellName)
 	if mErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("materialize cell: %w", mErr)
 	}

--- a/internal/controller/reconcile_outofsync_test.go
+++ b/internal/controller/reconcile_outofsync_test.go
@@ -47,9 +47,12 @@ import (
 // targeted, well-known field difference.
 func materializeSampleCell(t *testing.T) intmodel.Cell {
 	t.Helper()
-	cellDoc, err := cellconfig.Materialize(sampleConfig(), sampleReferencedBlueprint())
+	cellDoc, err := cellconfig.MaterializeWithName(
+		sampleConfig(), sampleReferencedBlueprint(),
+		cellconfig.StableName(sampleConfig().Metadata.Name),
+	)
 	if err != nil {
-		t.Fatalf("cellconfig.Materialize: %v", err)
+		t.Fatalf("cellconfig.MaterializeWithName: %v", err)
 	}
 	cell, err := apischeme.ConvertCellDocToInternal(cellDoc)
 	if err != nil {

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -157,7 +157,7 @@ func (b *Exec) reapplyOutOfSyncFromConfig(cell intmodel.Cell) (intmodel.Cell, bo
 		return intmodel.Cell{}, false, false
 	}
 
-	desired, err := materializeCellFromConfig(b.runner, cfg)
+	desired, err := materializeCellFromConfig(b.runner, cfg, cell.Metadata.Name)
 	if err != nil {
 		b.logger.WarnContext(b.ctx,
 			"OutOfSync reapply materialise failed; starting cell with on-disk spec",

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -61,6 +61,53 @@ type CellSpec struct {
 	// inbound RPC cell onto the disk-read cell before the OCI build. See
 	// runner.startCellLocked and Exec.createCellInternal. Issue #834.
 	RuntimeEnv []string
+	// Provenance mirrors v1beta1.CellSpec.Provenance: the persisted record of
+	// the binding (Config or Blueprint) and the scalar params / env overrides
+	// this cell was materialized from. Unlike RuntimeEnv it round-trips
+	// through cell metadata so the reconciler can re-resolve the binding after
+	// a restart. Nil for hand-built cells. DiffCell ignores it (lineage data,
+	// not a runtime spec field). Issue #1021.
+	Provenance *CellProvenance
+}
+
+// CellProvenance mirrors v1beta1.CellProvenance. See that type for the
+// field-by-field contract. Issue #1021.
+type CellProvenance struct {
+	BindingKind  string
+	BindingRef   CellBindingRef
+	Params       map[string]string
+	EnvOverrides []string
+}
+
+// CellBindingRef mirrors v1beta1.CellBindingRef. Issue #1021.
+type CellBindingRef struct {
+	Name  string
+	Realm string
+	Space string
+	Stack string
+}
+
+// CloneCellProvenance deep-copies a *CellProvenance, returning nil for a nil
+// input. Issue #1021.
+func CloneCellProvenance(in *CellProvenance) *CellProvenance {
+	if in == nil {
+		return nil
+	}
+	out := &CellProvenance{
+		BindingKind: in.BindingKind,
+		BindingRef:  in.BindingRef,
+	}
+	if in.Params != nil {
+		params := make(map[string]string, len(in.Params))
+		for k, v := range in.Params {
+			params[k] = v
+		}
+		out.Params = params
+	}
+	if in.EnvOverrides != nil {
+		out.EnvOverrides = append([]string(nil), in.EnvOverrides...)
+	}
+	return out
 }
 
 // CellTty mirrors the v1beta1 CellTty payload. See the v1beta1 type for

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -82,6 +82,83 @@ type CellSpec struct {
 	//
 	// Issue #834.
 	RuntimeEnv []string `json:"runtimeEnv,omitempty"          yaml:"-"`
+	// Provenance records the materialization inputs this cell was stamped
+	// from — the binding it was instantiated against (a Blueprint or a
+	// Config), the scoped reference to that binding, and the scalar params /
+	// env overrides supplied at materialization time. It is the persisted
+	// record P4 re-runs to recompute the would-be desired spec for the
+	// OutOfSync diff, and the binding reference P2's name generator reads for
+	// the cell-name prefix (epic:cell-identity, umbrella #1020).
+	//
+	// Unlike RuntimeEnv (transport-only, yaml:"-"), Provenance IS persisted:
+	// it carries no yaml:"-" so it survives both the JSON metadata.json write
+	// and a `kuke get cell -o yaml` round-trip. It is identity/lineage data,
+	// not a runtime spec field, so DiffCell deliberately does not compare it
+	// (a provenance-only difference must never report a cell OutOfSync). A
+	// hand-built cell that was never materialized from a binding carries a
+	// nil Provenance. Issue #1021.
+	Provenance *CellProvenance `json:"provenance,omitempty"          yaml:"provenance,omitempty"`
+}
+
+// Binding-kind discriminants for CellProvenance.BindingKind. A cell is
+// materialized either from a Config (`kuke run <config>`) or directly from a
+// Blueprint (`kuke run -b`); the kind tells P4 which binding channel to
+// re-resolve against.
+const (
+	BindingKindConfig    = "config"
+	BindingKindBlueprint = "blueprint"
+)
+
+// CellProvenance is the typed record of the inputs a cell was materialized
+// from. See CellSpec.Provenance for the lifecycle contract. Issue #1021.
+type CellProvenance struct {
+	// BindingKind is "config" or "blueprint" (see BindingKind* constants).
+	BindingKind string `json:"bindingKind"            yaml:"bindingKind"`
+	// BindingRef is the scoped name of the Config or Blueprint this cell was
+	// materialized from — the lineage back-reference P4 re-resolves against.
+	BindingRef CellBindingRef `json:"bindingRef"            yaml:"bindingRef"`
+	// Params are the scalar values resolved into the binding at
+	// materialization time (a Config's spec.values, or a Blueprint's
+	// resolved --param map). Persisted verbatim so re-resolution does not
+	// depend on re-reading transient CLI state.
+	Params map[string]string `json:"params,omitempty"      yaml:"params,omitempty"`
+	// EnvOverrides are the `--env KEY=VALUE` entries supplied at run time.
+	// Mirrors the values RuntimeEnv carries transiently, but persisted here
+	// so a later re-resolution sees the same overrides the operator chose.
+	EnvOverrides []string `json:"envOverrides,omitempty" yaml:"envOverrides,omitempty"`
+}
+
+// CellBindingRef is a scoped reference to the Config or Blueprint a cell was
+// materialized from. The scope coordinates follow the same realm/space/stack
+// contract every scoped kind uses (realm always set; a deeper coordinate
+// requires every shallower one). Issue #1021.
+type CellBindingRef struct {
+	Name  string `json:"name"            yaml:"name"`
+	Realm string `json:"realm"           yaml:"realm"`
+	Space string `json:"space,omitempty" yaml:"space,omitempty"`
+	Stack string `json:"stack,omitempty" yaml:"stack,omitempty"`
+}
+
+// CloneCellProvenance deep-copies a *CellProvenance so mutations on a
+// materialized cell (or a converted copy) cannot leak back into a shared
+// source. Returns nil for a nil input. Issue #1021.
+func CloneCellProvenance(in *CellProvenance) *CellProvenance {
+	if in == nil {
+		return nil
+	}
+	out := &CellProvenance{
+		BindingKind:  in.BindingKind,
+		BindingRef:   in.BindingRef,
+		EnvOverrides: cloneSlice(in.EnvOverrides),
+	}
+	if in.Params != nil {
+		params := make(map[string]string, len(in.Params))
+		for k, v := range in.Params {
+			params[k] = v
+		}
+		out.Params = params
+	}
+	return out
 }
 
 // CellTty is cell-level tty/attach config. Kept intentionally minimal: only
@@ -225,6 +302,8 @@ func NewCellDoc(from *CellDoc) *CellDoc {
 		}
 		out.Spec.Containers = containers
 	}
+
+	out.Spec.Provenance = CloneCellProvenance(out.Spec.Provenance)
 
 	return &out
 }


### PR DESCRIPTION
## Summary

First step (P1) of **epic:cell-identity** (umbrella #1020). Moves cell *identity* off the CellConfig and onto the CellDoc, and records the materialization inputs every cell needs to re-resolve from its binding later.

- **New persisted `Spec.Provenance` block** (`pkg/api/model/v1beta1/cell.go`, mirrored in `internal/modelhub/cell.go`): a typed `CellProvenance{BindingKind, BindingRef{Name,Realm,Space,Stack}, Params, EnvOverrides}`. Unlike the transport-only `RuntimeEnv` (`yaml:"-"`, dropped on the outbound builder), provenance is **persisted** — it round-trips through both the JSON `metadata.json` write and a `kuke get cell -o yaml` render, and is copied in **both** conversion directions in `internal/apischeme/scheme.go`. A hand-built cell carries `nil` provenance.
- **Both materialization paths stamp it.** `internal/cellconfig/materialize.go` → `bindingKind=config`, ref from the Config metadata, `params` from `spec.values`. `internal/cellblueprint/cellblueprint.go` → `bindingKind=blueprint`, ref from the Blueprint metadata, `params` from the resolved `--param` map (threaded into `MaterializeWithName`). `EnvOverrides` is populated from `kuke run --env` at `cmd/kuke/run/run.go` alongside `RuntimeEnv` (guarded on `Provenance != nil`, so a manifest run with no binding never fabricates one).
- **`kukeon.io/config` demoted to lineage (1:N), not identity** — docstrings on `LabelConfig` and `mergeConfigLabel` updated. `kukeon.io/blueprint` was already stamped on blueprint-materialized cells (`cellblueprint.LabelBlueprint`); confirmed it covers the AC.
- **Provenance excluded from `DiffCell`** — it is lineage data, not a runtime spec field. `DiffCell` only compares named spec fields, so a new field is ignored by construction; `TestDiffCell_ProvenanceIgnored` pins that a provenance-only (and nil-vs-set) difference reports no change, so the reconciler never stamps a false `OutOfSync`.
- **Materialization no longer derives the cell name from the Config name.** `cellconfig.MaterializeWithName` now uses the caller-supplied name verbatim (the `StableName` fallback and the assumption-laden 2-arg `Materialize` wrapper are removed). Callers that want the historical identity pass `StableName(cfg.Metadata.Name)` at the call site; the OutOfSync reconciler threads the **live cell's own name** through (`materializeCellFromConfig`), which is the correct, P2-forward behavior — the detector compares *spec drift*, not identity.

### Scoping / non-obvious calls (reviewer please push back)

- **AC4 — hard sever (literal reading).** I removed the name derivation from the materialization *layer* and moved `StableName` to each caller (run, create-cell) as a temporary stand-in until P2 supplies the name generator. The reconciler now passes the live cell's name, decoupling the diff from `StableName(configName)` so it stays correct once P2 lands generated names. This is the literal AC; the call sites that previously relied on the fallback are updated and tested.
- **`EnvOverrides` population.** Defined + round-tripping (AC1's requirement) and populated for the `kuke run --env` path. `create cell` has no `--env`, so its cells carry no env overrides — expected.
- **Blueprint provenance.** Stamped even though the only current OutOfSync consumer is config-lineage (blueprint cells are out of scope for the reconciler per the umbrella). Done so the `{bindingKind: blueprint}` half of the model is real and round-trips now rather than being retrofitted.

## Test plan

- [x] `make test` (full CI target, `GOWORK=off`) — exit 0, no FAIL/panic.
- [x] `GOWORK=off go build ./...` + `go vet ./...` — clean.
- [x] New unit tests: provenance JSON/YAML/conversion round-trip + nil-omitted (`internal/apischeme/provenance_test.go`); `DiffCell` ignores provenance (`internal/controller/apply/diff_test.go`); config + blueprint provenance stamping and name-not-derived-from-config (`internal/cellconfig`, `internal/cellblueprint`).
- [x] `make dev-init` smoke — exit 0; daemon-parity tail shows both realms `Ready` in daemon and `--no-daemon` views with identical shape; kukeond anchored on the just-built image; `kuke attach` smoke exited cleanly.

Closes #1021