### PR TITLE
feat(kukeond): warn on data-volume disk pressure + guard new cell creation

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -154,6 +154,23 @@ var (
 	KUKEOND_KUKETTY_LOG_LEVEL = DefineKV(
 		"KUKEOND_KUKETTY_LOG_LEVEL", "kukeond/kukettyLogLevel", "info",
 	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	// KUKEOND_DISK_PRESSURE_WARN_PCT is the data-volume usage percentage above
+	// which kukeond's reconcile loop emits a rate-limited WARN naming the realm
+	// and current usage. Nothing is deleted. 0 (or negative) disables the
+	// warning. Issue #1035.
+	KUKEOND_DISK_PRESSURE_WARN_PCT = DefineKV(
+		"KUKEOND_DISK_PRESSURE_WARN_PCT", "kukeond/diskPressureWarnPct", "85",
+	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	// KUKEOND_DISK_PRESSURE_BLOCK_PCT is the data-volume usage percentage at or
+	// above which kukeond refuses to provision a new cell (CreateCell fails
+	// fast) so a snapshot does not push the volume to 100%. `kuke create cell`
+	// / `kuke run --ignore-disk-pressure` bypasses the guard. 0 (or negative)
+	// disables the guard. Issue #1035.
+	KUKEOND_DISK_PRESSURE_BLOCK_PCT = DefineKV(
+		"KUKEOND_DISK_PRESSURE_BLOCK_PCT", "kukeond/diskPressureBlockPct", "95",
+	)
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_INIT_REALM = DefineKV("KUKE_INIT_REALM", "kuke/init/realm")
@@ -195,6 +212,13 @@ var (
 	KUKE_CREATE_CELL_FROM_CONFIG = DefineKV("KUKE_CREATE_CELL_FROM_CONFIG", "kuke/create/cell/from-config")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CELL_PARAM_FILE = DefineKV("KUKE_CREATE_CELL_PARAM_FILE", "kuke/create/cell/param-file")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	// KUKE_CREATE_CELL_IGNORE_DISK_PRESSURE is the env-var twin of
+	// `kuke create cell --ignore-disk-pressure` (issue #1035): bypasses
+	// kukeond's data-volume disk-pressure creation guard for this invocation.
+	KUKE_CREATE_CELL_IGNORE_DISK_PRESSURE = DefineKV(
+		"KUKE_CREATE_CELL_IGNORE_DISK_PRESSURE", "kuke/create/cell/ignore-disk-pressure", "false",
+	)
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CONFIG_NAME = DefineKV("KUKE_CREATE_CONFIG_NAME", "kuke/create/config/name")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
@@ -407,6 +431,13 @@ var (
 	KUKE_RUN_ENV = DefineKV("KUKE_RUN_ENV", "kuke/run/env")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_RUN_REQUIRE_SYNCED = DefineKV("KUKE_RUN_REQUIRE_SYNCED", "kuke/run/require-synced")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	// KUKE_RUN_IGNORE_DISK_PRESSURE is the env-var twin of
+	// `kuke run --ignore-disk-pressure` (issue #1035): bypasses kukeond's
+	// data-volume disk-pressure creation guard for this invocation.
+	KUKE_RUN_IGNORE_DISK_PRESSURE = DefineKV(
+		"KUKE_RUN_IGNORE_DISK_PRESSURE", "kuke/run/ignore-disk-pressure", "false",
+	)
 
 	// Attach command variables
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -106,6 +106,15 @@ func NewCellCmd() *cobra.Command {
 			"duplicate keys. Rejected with --from-config (same reason as --param).")
 	_ = viper.BindPFlag(config.KUKE_CREATE_CELL_PARAM_FILE.ViperKey, cmd.Flags().Lookup("param-file"))
 
+	cmd.Flags().Bool("ignore-disk-pressure", false,
+		"Bypass kukeond's data-volume disk-pressure guard for this cell's "+
+			"creation. The daemon normally refuses to provision a new cell once "+
+			"the data volume crosses the hard threshold. (issue #1035)")
+	_ = viper.BindPFlag(
+		config.KUKE_CREATE_CELL_IGNORE_DISK_PRESSURE.ViperKey,
+		cmd.Flags().Lookup("ignore-disk-pressure"),
+	)
+
 	cmd.MarkFlagsMutuallyExclusive("from-blueprint", "from-config")
 
 	// Register autocomplete functions for flags
@@ -129,6 +138,10 @@ type createCellFlags struct {
 	configName    string
 	paramArgs     []string
 	paramFile     string
+	// ignoreDiskPressure threads `kuke create cell --ignore-disk-pressure`
+	// onto the transport-only Spec.IgnoreDiskPressure field so the daemon's
+	// CreateCell guard is bypassed for this invocation. Issue #1035.
+	ignoreDiskPressure bool
 }
 
 // parseCreateCellFlags validates the flag combinations and trims values. The
@@ -181,6 +194,8 @@ func parseCreateCellFlags(cmd *cobra.Command, args []string) (createCellFlags, e
 		return createCellFlags{}, err
 	}
 	flags.paramArgs = paramArgs
+
+	flags.ignoreDiskPressure = viper.GetBool(config.KUKE_CREATE_CELL_IGNORE_DISK_PRESSURE.ViperKey)
 
 	if flags.configName != "" {
 		if len(flags.paramArgs) > 0 {
@@ -258,6 +273,7 @@ func runFromBlueprint(cmd *cobra.Command, client kukeonv1.Client, flags createCe
 		return err
 	}
 	overlayScope(&cellDoc, flags)
+	applyIgnoreDiskPressure(&cellDoc, flags)
 
 	return materialiseAndPersist(cmd, client, cellDoc)
 }
@@ -325,6 +341,7 @@ func runFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags createCellF
 		return err
 	}
 	overlayScope(&cellDoc, flags)
+	applyIgnoreDiskPressure(&cellDoc, flags)
 
 	return materialiseAndPersist(cmd, client, cellDoc)
 }
@@ -356,6 +373,16 @@ func materialiseAndPersist(cmd *cobra.Command, client kukeonv1.Client, cellDoc v
 	}
 	printCellResult(cmd, result)
 	return nil
+}
+
+// applyIgnoreDiskPressure threads `--ignore-disk-pressure` onto the
+// transport-only Spec.IgnoreDiskPressure field (yaml:"-" — never persisted) so
+// the daemon's CreateCell guard is bypassed for this invocation. The flag only
+// ever sets the override true. Issue #1035.
+func applyIgnoreDiskPressure(doc *v1beta1.CellDoc, flags createCellFlags) {
+	if flags.ignoreDiskPressure {
+		doc.Spec.IgnoreDiskPressure = true
+	}
 }
 
 // overlayScope fills realm/space/stack coordinates on the materialised cell

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -287,6 +287,16 @@ func NewRunCmd() *cobra.Command {
 			"than firing the instant the trigger fires.")
 	_ = viper.BindPFlag(config.KUKE_RUN_RM.ViperKey, cmd.Flags().Lookup("rm"))
 
+	cmd.Flags().Bool("ignore-disk-pressure", false,
+		"Bypass kukeond's data-volume disk-pressure guard for this run. The "+
+			"daemon normally refuses to provision a new cell once the data "+
+			"volume crosses the hard threshold; pass this when you know there "+
+			"is enough headroom. (issue #1035)")
+	_ = viper.BindPFlag(
+		config.KUKE_RUN_IGNORE_DISK_PRESSURE.ViperKey,
+		cmd.Flags().Lookup("ignore-disk-pressure"),
+	)
+
 	// `--clone ↔ --rm` mutex (#839): a persistent clone Config whose cell is
 	// removed on exit is operationally messy; `kuke apply -f <clone-spec>`
 	// is the right path if you want the slot without an attached cell. Must
@@ -352,6 +362,10 @@ type runFlags struct {
 	// produced so CI/scripted callers that opt in retain the exit-non-zero
 	// drift signal. See the flag commentary in NewRunCmd.
 	requireSynced bool
+	// ignoreDiskPressure threads `kuke run --ignore-disk-pressure` onto the
+	// transport-only Spec.IgnoreDiskPressure field so the daemon's CreateCell
+	// guard is bypassed for this invocation. Issue #1035.
+	ignoreDiskPressure bool
 }
 
 // validateSourceMutex enforces the "exactly one source" contract across the
@@ -384,17 +398,18 @@ func validateSourceMutex(flags runFlags) error {
 
 func parseRunFlags(cmd *cobra.Command, args []string) (runFlags, error) {
 	flags := runFlags{
-		file:          strings.TrimSpace(viper.GetString(config.KUKE_RUN_FILE.ViperKey)),
-		blueprintName: strings.TrimSpace(viper.GetString(config.KUKE_RUN_BLUEPRINT.ViperKey)),
-		detach:        viper.GetBool(config.KUKE_RUN_DETACH.ViperKey),
-		containerFlag: strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
-		autoDelete:    viper.GetBool(config.KUKE_RUN_RM.ViperKey),
-		nameOverride:  strings.TrimSpace(viper.GetString(config.KUKE_RUN_NAME.ViperKey)),
-		newCell:       viper.GetBool(config.KUKE_RUN_NEW.ViperKey),
-		clone:         viper.GetBool(config.KUKE_RUN_CLONE.ViperKey),
-		reuse:         viper.GetBool(config.KUKE_RUN_REUSE.ViperKey),
-		paramFile:     strings.TrimSpace(viper.GetString(config.KUKE_RUN_PARAM_FILE.ViperKey)),
-		requireSynced: viper.GetBool(config.KUKE_RUN_REQUIRE_SYNCED.ViperKey),
+		file:               strings.TrimSpace(viper.GetString(config.KUKE_RUN_FILE.ViperKey)),
+		blueprintName:      strings.TrimSpace(viper.GetString(config.KUKE_RUN_BLUEPRINT.ViperKey)),
+		detach:             viper.GetBool(config.KUKE_RUN_DETACH.ViperKey),
+		containerFlag:      strings.TrimSpace(viper.GetString(config.KUKE_RUN_CONTAINER.ViperKey)),
+		autoDelete:         viper.GetBool(config.KUKE_RUN_RM.ViperKey),
+		nameOverride:       strings.TrimSpace(viper.GetString(config.KUKE_RUN_NAME.ViperKey)),
+		newCell:            viper.GetBool(config.KUKE_RUN_NEW.ViperKey),
+		clone:              viper.GetBool(config.KUKE_RUN_CLONE.ViperKey),
+		reuse:              viper.GetBool(config.KUKE_RUN_REUSE.ViperKey),
+		paramFile:          strings.TrimSpace(viper.GetString(config.KUKE_RUN_PARAM_FILE.ViperKey)),
+		requireSynced:      viper.GetBool(config.KUKE_RUN_REQUIRE_SYNCED.ViperKey),
+		ignoreDiskPressure: viper.GetBool(config.KUKE_RUN_IGNORE_DISK_PRESSURE.ViperKey),
 	}
 
 	if len(args) == 1 {
@@ -568,6 +583,14 @@ func runRun(cmd *cobra.Command, args []string) error {
 		if cellDoc.Spec.Provenance != nil {
 			cellDoc.Spec.Provenance.EnvOverrides = append([]string(nil), flags.envArgs...)
 		}
+	}
+
+	// --ignore-disk-pressure (#1035): thread the override onto the
+	// transport-only Spec.IgnoreDiskPressure field (yaml:"-" — never
+	// persisted). The flag is the imperative knob; it only ever sets the
+	// override true, never clears a value loaded from a manifest.
+	if flags.ignoreDiskPressure {
+		cellDoc.Spec.IgnoreDiskPressure = true
 	}
 
 	if validateErr := validateResolvedCell(cellDoc); validateErr != nil {

--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -21,6 +21,7 @@ package kukeond
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/eminwux/kukeon/cmd/config"
 	"github.com/eminwux/kukeon/internal/consts"
@@ -192,6 +193,34 @@ func NewKukeondCmd() (*cobra.Command, error) {
 		return nil, err
 	}
 
+	diskPressureWarnDefault, _ := strconv.Atoi(config.KUKEOND_DISK_PRESSURE_WARN_PCT.Default)
+	cmd.PersistentFlags().Int(
+		"disk-pressure-warn-percent", diskPressureWarnDefault,
+		"Data-volume usage percentage above which the reconcile loop emits a "+
+			"rate-limited WARN naming the realm and usage (nothing is deleted). "+
+			"0 disables. (issue #1035)",
+	)
+	if err := viper.BindPFlag(
+		config.KUKEOND_DISK_PRESSURE_WARN_PCT.ViperKey,
+		cmd.PersistentFlags().Lookup("disk-pressure-warn-percent"),
+	); err != nil {
+		return nil, err
+	}
+
+	diskPressureBlockDefault, _ := strconv.Atoi(config.KUKEOND_DISK_PRESSURE_BLOCK_PCT.Default)
+	cmd.PersistentFlags().Int(
+		"disk-pressure-block-percent", diskPressureBlockDefault,
+		"Data-volume usage percentage at or above which a new cell's creation "+
+			"is refused (no deletion); `--ignore-disk-pressure` bypasses it. "+
+			"0 disables. (issue #1035)",
+	)
+	if err := viper.BindPFlag(
+		config.KUKEOND_DISK_PRESSURE_BLOCK_PCT.ViperKey,
+		cmd.PersistentFlags().Lookup("disk-pressure-block-percent"),
+	); err != nil {
+		return nil, err
+	}
+
 	bindEnvVars()
 
 	cmd.AddCommand(newServeCmd())
@@ -215,6 +244,8 @@ func bindEnvVars() {
 		config.KUKEOND_RECONCILE_INTERVAL,
 		config.KUKEOND_DEFAULT_MEMORY_LIMIT_BYTES,
 		config.KUKEOND_KUKETTY_LOG_LEVEL,
+		config.KUKEOND_DISK_PRESSURE_WARN_PCT,
+		config.KUKEOND_DISK_PRESSURE_BLOCK_PCT,
 	} {
 		_ = v.BindEnv()
 	}

--- a/cmd/kukeond/serve.go
+++ b/cmd/kukeond/serve.go
@@ -109,6 +109,9 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		kukettyLogLevel = config.KUKEOND_KUKETTY_LOG_LEVEL.Default
 	}
 
+	diskPressureWarnPct := viper.GetInt(config.KUKEOND_DISK_PRESSURE_WARN_PCT.ViperKey)
+	diskPressureBlockPct := viper.GetInt(config.KUKEOND_DISK_PRESSURE_BLOCK_PCT.ViperKey)
+
 	opts := daemon.Options{
 		SocketPath:        socketPath,
 		SocketMode:        socketMode,
@@ -131,6 +134,11 @@ func runServe(cmd *cobra.Command, _ []string) error {
 			// trip sbsh's NewFileLogger inside the container at attach time
 			// (issue #599), so the empty-resolved case above pins "info".
 			KukettyLogLevel: kukettyLogLevel,
+			// Data-volume disk-pressure observability (reconcile-loop WARN) and
+			// the CreateCell guard (issue #1035). Both are observation-only —
+			// the guard refuses new cell creation but never deletes data.
+			DiskPressureWarnPercent:  diskPressureWarnPct,
+			DiskPressureBlockPercent: diskPressureBlockPct,
 		},
 	}
 

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -1424,6 +1424,12 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 				// round-trips in both conversion directions — unlike
 				// RuntimeEnv, which the outbound builder drops.
 				Provenance: convertCellProvenanceToInternal(in.Spec.Provenance),
+				// IgnoreDiskPressure is transport-only (v1beta1 carries
+				// yaml:"-") on the same inbound RPC path as RuntimeEnv; the
+				// CreateCell guard reads it and BuildCellExternalFromInternal
+				// drops it so the per-invocation override never persists.
+				// Issue #1035.
+				IgnoreDiskPressure: in.Spec.IgnoreDiskPressure,
 			},
 			Status: intmodel.CellStatus{
 				State:              intmodel.CellState(in.Status.State),
@@ -1509,6 +1515,12 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 				// is persisted lineage data, so the disk-write doc and the RPC
 				// reply both carry it.
 				Provenance: buildCellProvenanceExternalFromInternal(in.Spec.Provenance),
+				// IgnoreDiskPressure is likewise NOT copied here (issue
+				// #1035): it is a per-invocation creation override, not cell
+				// state. Persisting it would silently exempt the cell's future
+				// rematerializations from the disk-pressure guard. The CLI →
+				// daemon direction in ConvertCellDocToInternal preserves it so
+				// the CreateCell guard sees the override.
 			},
 			Status: ext.CellStatus{
 				State:              ext.CellState(in.Status.State),

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -20,11 +20,19 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/controller/runner"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/diskpressure"
 )
+
+// diskPressureWarnInterval bounds how often the reconcile loop re-emits the
+// data-volume disk-pressure WARN for a given realm. Chosen well above the
+// default 30s reconcile interval so a host that sits over the high-water mark
+// logs once every few minutes rather than every tick. Issue #1035.
+const diskPressureWarnInterval = 5 * time.Minute
 
 type Controller interface {
 	Bootstrap() (BootstrapReport, error)
@@ -65,6 +73,15 @@ type Exec struct {
 	logger *slog.Logger
 	opts   Options
 	runner runner.Runner
+	// diskWarner rate-limits the per-realm data-volume disk-pressure WARN the
+	// reconcile loop emits so a short reconcile interval does not log every
+	// tick while a volume stays over the high-water mark. Issue #1035.
+	diskWarner *diskpressure.Warner
+	// diskSampler samples filesystem usage for the reconcile-loop WARN. nil
+	// falls through to diskpressure.Sample; tests override it to exercise the
+	// warn/threshold/rate-limit branches without a real full volume. Issue
+	// #1035.
+	diskSampler func(string) (diskpressure.Usage, error)
 }
 
 type Options struct {
@@ -105,6 +122,17 @@ type Options struct {
 	// Empty falls through to the hardcoded "info" default inside the renderer.
 	// Issue #599.
 	KukettyLogLevel string
+	// DiskPressureWarnPercent, when > 0, is the data-volume usage percentage
+	// above which the reconcile loop emits a rate-limited WARN naming the realm
+	// and current usage (no deletion). Surfaces via
+	// `kukeond serve --disk-pressure-warn-percent` / KUKEOND_DISK_PRESSURE_WARN_PCT.
+	// Zero disables the warning. Issue #1035.
+	DiskPressureWarnPercent int
+	// DiskPressureBlockPercent, when > 0, is the data-volume usage percentage
+	// at or above which CreateCell refuses to provision a new cell. Surfaces
+	// via `kukeond serve --disk-pressure-block-percent` /
+	// KUKEOND_DISK_PRESSURE_BLOCK_PCT. Zero disables the guard. Issue #1035.
+	DiskPressureBlockPercent int
 }
 
 func NewControllerExec(ctx context.Context, logger *slog.Logger, opts Options) *Exec {
@@ -113,13 +141,15 @@ func NewControllerExec(ctx context.Context, logger *slog.Logger, opts Options) *
 		logger: logger,
 		opts:   opts,
 		runner: runner.NewRunner(ctx, logger, runner.Options{
-			ContainerdSocket:        opts.ContainerdSocket,
-			RunPath:                 opts.RunPath,
-			ForceRegenerateCNI:      opts.ForceRegenerateCNI,
-			KukeonGroupGID:          opts.KukeondSocketGID,
-			DefaultMemoryLimitBytes: opts.DefaultMemoryLimitBytes,
-			KukettyLogLevel:         opts.KukettyLogLevel,
+			ContainerdSocket:         opts.ContainerdSocket,
+			RunPath:                  opts.RunPath,
+			ForceRegenerateCNI:       opts.ForceRegenerateCNI,
+			KukeonGroupGID:           opts.KukeondSocketGID,
+			DefaultMemoryLimitBytes:  opts.DefaultMemoryLimitBytes,
+			KukettyLogLevel:          opts.KukettyLogLevel,
+			DiskPressureBlockPercent: opts.DiskPressureBlockPercent,
 		}),
+		diskWarner: diskpressure.NewWarner(diskPressureWarnInterval),
 	}
 }
 
@@ -127,10 +157,11 @@ func NewControllerExec(ctx context.Context, logger *slog.Logger, opts Options) *
 // This function is exported for testing purposes only.
 func NewControllerExecForTesting(ctx context.Context, logger *slog.Logger, opts Options, r runner.Runner) *Exec {
 	return &Exec{
-		ctx:    ctx,
-		logger: logger,
-		opts:   opts,
-		runner: r,
+		ctx:        ctx,
+		logger:     logger,
+		opts:       opts,
+		runner:     r,
+		diskWarner: diskpressure.NewWarner(diskPressureWarnInterval),
 	}
 }
 

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -16,7 +16,13 @@
 
 package controller
 
-import "fmt"
+import (
+	"fmt"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/diskpressure"
+	"github.com/eminwux/kukeon/internal/util/fs"
+)
 
 // ReconcileResult summarizes a single pass of the daemon's background
 // cell-reconciliation loop. Counts are scoped to cells (v1 of #161 is
@@ -45,6 +51,12 @@ func (b *Exec) ReconcileCells() (ReconcileResult, error) {
 		result.Errors = append(result.Errors, fmt.Sprintf("list realms: %v", err))
 		return result, nil
 	}
+
+	// Make disk pressure visible before doing per-cell work. Observation-only:
+	// this never deletes, reaps, or mutates anything — it only logs a
+	// rate-limited WARN when a realm's data volume crosses the high-water mark
+	// (issue #1035).
+	b.checkDiskPressure(realms)
 
 	for _, realm := range realms {
 		realmName := realm.Metadata.Name
@@ -118,4 +130,44 @@ func (b *Exec) ReconcileCells() (ReconcileResult, error) {
 	}
 
 	return result, nil
+}
+
+// checkDiskPressure samples the data volume backing each realm's metadata tree
+// and emits a rate-limited WARN for any realm whose usage is at or above the
+// configured warn threshold. It deletes nothing — the WARN is the entire
+// action. Disabled when DiskPressureWarnPercent <= 0. Realms that share one
+// filesystem each warn under their own rate-limit key; a statfs failure is
+// logged at debug and skipped so a monitoring hiccup never disrupts the
+// reconcile pass. Issue #1035.
+func (b *Exec) checkDiskPressure(realms []intmodel.Realm) {
+	if b.opts.DiskPressureWarnPercent <= 0 {
+		return
+	}
+	sample := b.diskSampler
+	if sample == nil {
+		sample = diskpressure.Sample
+	}
+	for _, realm := range realms {
+		realmName := realm.Metadata.Name
+		dir := fs.RealmMetadataDir(b.opts.RunPath, realmName)
+		usage, err := sample(dir)
+		if err != nil {
+			b.logger.DebugContext(b.ctx, "disk-pressure sample failed",
+				"realm", realmName, "path", dir, "error", err)
+			continue
+		}
+		if usage.UsedPercent < float64(b.opts.DiskPressureWarnPercent) {
+			continue
+		}
+		if b.diskWarner != nil && !b.diskWarner.ShouldWarn(realmName) {
+			continue
+		}
+		b.logger.WarnContext(b.ctx, "data volume under disk pressure",
+			"realm", realmName,
+			"path", dir,
+			"usedPercent", fmt.Sprintf("%.1f", usage.UsedPercent),
+			"warnPercent", b.opts.DiskPressureWarnPercent,
+			"totalBytes", usage.TotalBytes,
+			"availBytes", usage.AvailBytes)
+	}
 }

--- a/internal/controller/reconcile_disk_pressure_test.go
+++ b/internal/controller/reconcile_disk_pressure_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/diskpressure"
+)
+
+func diskPressureControllerExec(
+	buf *bytes.Buffer,
+	warnPct int,
+	sample func(string) (diskpressure.Usage, error),
+) *Exec {
+	return &Exec{
+		ctx:         context.Background(),
+		logger:      slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		opts:        Options{RunPath: "/run/kukeon-test", DiskPressureWarnPercent: warnPct},
+		diskWarner:  diskpressure.NewWarner(5 * time.Minute),
+		diskSampler: sample,
+	}
+}
+
+func twoRealms() []intmodel.Realm {
+	return []intmodel.Realm{
+		{Metadata: intmodel.RealmMetadata{Name: "default"}},
+		{Metadata: intmodel.RealmMetadata{Name: "kuke-system"}},
+	}
+}
+
+func TestCheckDiskPressure_WarnsOverThreshold(t *testing.T) {
+	var buf bytes.Buffer
+	r := diskPressureControllerExec(&buf, 85, func(string) (diskpressure.Usage, error) {
+		return diskpressure.Usage{UsedPercent: 90, TotalBytes: 1000, AvailBytes: 100}, nil
+	})
+
+	r.checkDiskPressure(twoRealms())
+
+	out := buf.String()
+	if !strings.Contains(out, "data volume under disk pressure") {
+		t.Fatalf("expected disk-pressure WARN, got: %q", out)
+	}
+	if !strings.Contains(out, "default") || !strings.Contains(out, "kuke-system") {
+		t.Errorf("expected both realms named in WARNs, got: %q", out)
+	}
+	if !strings.Contains(out, "usedPercent=90.0") {
+		t.Errorf("expected usedPercent in WARN, got: %q", out)
+	}
+}
+
+func TestCheckDiskPressure_SilentBelowThreshold(t *testing.T) {
+	var buf bytes.Buffer
+	r := diskPressureControllerExec(&buf, 85, func(string) (diskpressure.Usage, error) {
+		return diskpressure.Usage{UsedPercent: 50}, nil
+	})
+
+	r.checkDiskPressure(twoRealms())
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no WARN below threshold, got: %q", buf.String())
+	}
+}
+
+func TestCheckDiskPressure_DisabledWhenThresholdZero(t *testing.T) {
+	var buf bytes.Buffer
+	called := false
+	r := diskPressureControllerExec(&buf, 0, func(string) (diskpressure.Usage, error) {
+		called = true
+		return diskpressure.Usage{UsedPercent: 99}, nil
+	})
+
+	r.checkDiskPressure(twoRealms())
+
+	if called {
+		t.Error("disabled warn sampled the volume; expected an early return")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no WARN when disabled, got: %q", buf.String())
+	}
+}
+
+func TestCheckDiskPressure_RateLimitedAcrossPasses(t *testing.T) {
+	var buf bytes.Buffer
+	r := diskPressureControllerExec(&buf, 85, func(string) (diskpressure.Usage, error) {
+		return diskpressure.Usage{UsedPercent: 99}, nil
+	})
+
+	r.checkDiskPressure(twoRealms())
+	first := strings.Count(buf.String(), "data volume under disk pressure")
+	if first != 2 {
+		t.Fatalf("first pass: got %d WARNs, want 2 (one per realm)", first)
+	}
+
+	// A second pass inside the rate-limit window must not re-emit.
+	r.checkDiskPressure(twoRealms())
+	total := strings.Count(buf.String(), "data volume under disk pressure")
+	if total != 2 {
+		t.Errorf("second pass within window re-warned: got %d total WARNs, want 2", total)
+	}
+}

--- a/internal/controller/runner/create_cell.go
+++ b/internal/controller/runner/create_cell.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/diskpressure"
+	"github.com/eminwux/kukeon/internal/util/fs"
 	"github.com/eminwux/kukeon/internal/util/naming"
 )
 
@@ -123,6 +125,17 @@ func (r *Exec) CreateCell(cell intmodel.Cell) (intmodel.Cell, error) {
 		return ensuredCell, nil
 	}
 
+	// Cell not found — this is a genuinely new cell. Guard against creating it
+	// when the realm's data volume is already under hard disk pressure, so a
+	// fresh snapshot does not push the volume to 100% (issue #1035). The guard
+	// is observation-only: it never deletes anything, and `--ignore-disk-pressure`
+	// (cell.Spec.IgnoreDiskPressure) bypasses it. The existing-cell branch above
+	// (EnsureCell) is deliberately not guarded — ensuring resources for a cell
+	// that already exists is not "digging the hole deeper".
+	if err = r.guardDiskPressure(cell); err != nil {
+		return intmodel.Cell{}, err
+	}
+
 	// Cell not found, create new cell
 	resultCell, err := r.provisionNewCell(cell)
 	if err != nil {
@@ -142,6 +155,43 @@ func (r *Exec) CreateCell(cell intmodel.Cell) (intmodel.Cell, error) {
 	}
 
 	return resultCell, nil
+}
+
+// guardDiskPressure fails fast with errdefs.ErrDiskPressure when the data
+// volume backing the cell's realm is at or above the configured block
+// threshold, unless the threshold is disabled (<= 0) or the cell carries the
+// IgnoreDiskPressure override (`--ignore-disk-pressure`). It never deletes
+// anything. A statfs failure is logged and treated as "allow" — a monitoring
+// hiccup must never wedge all cell creation. Issue #1035.
+func (r *Exec) guardDiskPressure(cell intmodel.Cell) error {
+	if r.opts.DiskPressureBlockPercent <= 0 {
+		return nil
+	}
+	if cell.Spec.IgnoreDiskPressure {
+		r.logger.DebugContext(r.ctx, "disk-pressure guard bypassed via --ignore-disk-pressure",
+			"cell", cell.Metadata.Name, "realm", cell.Spec.RealmName)
+		return nil
+	}
+
+	sample := r.diskSampler
+	if sample == nil {
+		sample = diskpressure.Sample
+	}
+	dir := fs.RealmMetadataDir(r.opts.RunPath, cell.Spec.RealmName)
+	usage, err := sample(dir)
+	if err != nil {
+		r.logger.WarnContext(r.ctx, "disk-pressure guard: statfs failed; allowing creation",
+			"cell", cell.Metadata.Name, "realm", cell.Spec.RealmName, "path", dir, "error", err)
+		return nil
+	}
+
+	if usage.UsedPercent >= float64(r.opts.DiskPressureBlockPercent) {
+		return fmt.Errorf(
+			"%w: data volume %s is at %.1f%% (block threshold %d%%); "+
+				"free space or pass --ignore-disk-pressure",
+			errdefs.ErrDiskPressure, dir, usage.UsedPercent, r.opts.DiskPressureBlockPercent)
+	}
+	return nil
 }
 
 // EnsureCell ensures that all required resources for a cell exist.

--- a/internal/controller/runner/create_cell_disk_pressure_test.go
+++ b/internal/controller/runner/create_cell_disk_pressure_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	"github.com/eminwux/kukeon/internal/util/diskpressure"
+)
+
+func diskPressureTestExec(blockPct int, sample func(string) (diskpressure.Usage, error)) *Exec {
+	return &Exec{
+		ctx:         context.Background(),
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		opts:        Options{RunPath: "/run/kukeon-test", DiskPressureBlockPercent: blockPct},
+		diskSampler: sample,
+	}
+}
+
+func cellForGuard(ignore bool) intmodel.Cell {
+	return intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "c1"},
+		Spec:     intmodel.CellSpec{RealmName: "default", IgnoreDiskPressure: ignore},
+	}
+}
+
+func TestGuardDiskPressure_BlocksAtOrAboveThreshold(t *testing.T) {
+	r := diskPressureTestExec(95, func(string) (diskpressure.Usage, error) {
+		return diskpressure.Usage{UsedPercent: 96, TotalBytes: 100, AvailBytes: 4}, nil
+	})
+	err := r.guardDiskPressure(cellForGuard(false))
+	if !errors.Is(err, errdefs.ErrDiskPressure) {
+		t.Fatalf("guardDiskPressure at 96%% (block 95%%): got %v, want ErrDiskPressure", err)
+	}
+}
+
+func TestGuardDiskPressure_AllowsBelowThreshold(t *testing.T) {
+	r := diskPressureTestExec(95, func(string) (diskpressure.Usage, error) {
+		return diskpressure.Usage{UsedPercent: 80}, nil
+	})
+	if err := r.guardDiskPressure(cellForGuard(false)); err != nil {
+		t.Fatalf("guardDiskPressure at 80%% (block 95%%): got %v, want nil", err)
+	}
+}
+
+func TestGuardDiskPressure_OverrideBypasses(t *testing.T) {
+	r := diskPressureTestExec(95, func(string) (diskpressure.Usage, error) {
+		return diskpressure.Usage{UsedPercent: 99}, nil
+	})
+	if err := r.guardDiskPressure(cellForGuard(true)); err != nil {
+		t.Fatalf("guardDiskPressure with IgnoreDiskPressure at 99%%: got %v, want nil", err)
+	}
+}
+
+func TestGuardDiskPressure_DisabledWhenThresholdZero(t *testing.T) {
+	called := false
+	r := diskPressureTestExec(0, func(string) (diskpressure.Usage, error) {
+		called = true
+		return diskpressure.Usage{UsedPercent: 99}, nil
+	})
+	if err := r.guardDiskPressure(cellForGuard(false)); err != nil {
+		t.Fatalf("guardDiskPressure with block threshold 0: got %v, want nil", err)
+	}
+	if called {
+		t.Error("disabled guard sampled the volume; expected an early return before statfs")
+	}
+}
+
+func TestGuardDiskPressure_SampleErrorAllowsCreation(t *testing.T) {
+	r := diskPressureTestExec(95, func(string) (diskpressure.Usage, error) {
+		return diskpressure.Usage{}, errors.New("statfs boom")
+	})
+	if err := r.guardDiskPressure(cellForGuard(false)); err != nil {
+		t.Fatalf("guardDiskPressure on sample error: got %v, want nil (fail-open)", err)
+	}
+}

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/eminwux/kukeon/internal/ctr"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/netpolicy"
+	"github.com/eminwux/kukeon/internal/util/diskpressure"
 )
 
 // ReconcileOutcome describes the per-cell effect of a single reconcile pass.
@@ -280,6 +281,12 @@ type Exec struct {
 	// (not via NewRunner) share the same lock semantics.
 	cellLocks     *cellLockManager
 	cellLocksOnce sync.Once
+
+	// diskSampler samples filesystem usage for the CreateCell disk-pressure
+	// guard (issue #1035). nil falls through to diskpressure.Sample; tests
+	// override it to exercise the guard's block/allow branches without a real
+	// full volume.
+	diskSampler func(string) (diskpressure.Usage, error)
 }
 
 type Options struct {
@@ -310,6 +317,13 @@ type Options struct {
 	// fixtures that build the runner directly with zero-value Options).
 	// Issue #599.
 	KukettyLogLevel string
+	// DiskPressureBlockPercent, when > 0, is the data-volume usage percentage
+	// at or above which CreateCell refuses to provision a new cell — failing
+	// fast with errdefs.ErrDiskPressure instead of creating a snapshot that
+	// pushes the volume toward 100%. A cell whose Spec.IgnoreDiskPressure is
+	// set bypasses the guard. Zero (the default) disables it. Plumbed from
+	// controller.Options of the same name. Issue #1035.
+	DiskPressureBlockPercent int
 }
 
 func NewRunner(ctx context.Context, logger *slog.Logger, opts Options) Runner {

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -78,6 +78,7 @@ var (
 	ErrCellIDRequired         = errors.New("cell id is required")
 	ErrGetCell                = errors.New("failed to get cell")
 	ErrCreateCell             = errors.New("failed to create cell")
+	ErrDiskPressure           = errors.New("data volume is under disk pressure")
 	ErrCreateRootContainer    = errors.New("failed to create root container")
 	ErrNetworkConfigNotLoaded = errors.New("network config not loaded")
 	// ErrExplicitRootHostNetworkMismatch fires when a cell pins its root via

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -68,6 +68,13 @@ type CellSpec struct {
 	// a restart. Nil for hand-built cells. DiffCell ignores it (lineage data,
 	// not a runtime spec field). Issue #1021.
 	Provenance *CellProvenance
+	// IgnoreDiskPressure mirrors v1beta1.CellSpec.IgnoreDiskPressure. The wire
+	// side carries `kuke create cell`/`kuke run --ignore-disk-pressure` from
+	// the CLI; the runner's CreateCell guard reads it to bypass the data-volume
+	// disk-pressure block. NOT persisted (v1beta1 has yaml:"-") — the override
+	// is per-invocation, so the disk-read paths return cells with it false.
+	// Issue #1035.
+	IgnoreDiskPressure bool
 }
 
 // CellProvenance mirrors v1beta1.CellProvenance. See that type for the

--- a/internal/util/diskpressure/diskpressure.go
+++ b/internal/util/diskpressure/diskpressure.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package diskpressure samples filesystem usage for the volume backing a given
+// path and rate-limits the warnings kukeond emits when a data volume crosses a
+// high-water mark. It is intentionally observation-only: nothing in this
+// package deletes, reaps, or mutates on-disk state. The daemon uses it to make
+// disk pressure visible (reconcile-loop WARN) and to refuse to dig the hole
+// deeper (a CreateCell guard) without ever removing operator data (issue
+// #1035).
+package diskpressure
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// percentScale converts a [0,1] fraction to a percentage.
+const percentScale = 100
+
+// Usage is a point-in-time snapshot of a filesystem's capacity, derived from a
+// single statfs(2) call against a path on that filesystem.
+type Usage struct {
+	// TotalBytes is the filesystem's total capacity (f_blocks * f_bsize).
+	TotalBytes uint64
+	// AvailBytes is the space available to unprivileged writers
+	// (f_bavail * f_bsize) — the headroom that matters for "will the next
+	// write succeed".
+	AvailBytes uint64
+	// UsedBytes is TotalBytes minus the free space (f_bfree * f_bsize).
+	UsedBytes uint64
+	// UsedPercent is the fraction of capacity consumed, expressed as used /
+	// (used + available) * 100 — matching df(1)'s Use% so the number lines up
+	// with what an operator sees. Reserved-for-root blocks (f_bfree - f_bavail)
+	// are excluded from the denominator, so a volume an unprivileged process
+	// can no longer write to reports 100% even though root has a sliver left.
+	UsedPercent float64
+}
+
+// Sample runs statfs(2) on path and returns the backing filesystem's usage.
+// The path need only exist; it resolves to whatever filesystem it lives on.
+func Sample(path string) (Usage, error) {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return Usage{}, fmt.Errorf("statfs %s: %w", path, err)
+	}
+
+	bsize := uint64(st.Bsize) //nolint:gosec // f_bsize is non-negative; uint64 is the arithmetic type
+	total := st.Blocks * bsize
+	avail := st.Bavail * bsize
+	used := (st.Blocks - st.Bfree) * bsize
+
+	var pct float64
+	if denom := used + avail; denom > 0 {
+		pct = float64(used) / float64(denom) * percentScale
+	}
+
+	return Usage{
+		TotalBytes:  total,
+		AvailBytes:  avail,
+		UsedBytes:   used,
+		UsedPercent: pct,
+	}, nil
+}
+
+// Warner rate-limits warnings per key (e.g. per realm) so a daemon whose
+// reconcile interval is short does not emit a WARN every tick while a volume
+// stays over the high-water mark. ShouldWarn returns true at most once per
+// window per key. The zero value is not usable; construct with NewWarner.
+type Warner struct {
+	mu     sync.Mutex
+	last   map[string]time.Time
+	window time.Duration
+	nowFn  func() time.Time
+}
+
+// NewWarner returns a Warner that lets a given key fire at most once per
+// window. A non-positive window disables rate-limiting (every ShouldWarn call
+// returns true).
+func NewWarner(window time.Duration) *Warner {
+	return &Warner{
+		last:   make(map[string]time.Time),
+		window: window,
+	}
+}
+
+// now returns the Warner's clock, defaulting to time.Now when no test hook is
+// installed.
+func (w *Warner) now() time.Time {
+	if w.nowFn != nil {
+		return w.nowFn()
+	}
+	return time.Now()
+}
+
+// ShouldWarn reports whether a warning for key should be emitted now, recording
+// the decision so a subsequent call within the window returns false. Safe for
+// concurrent use.
+func (w *Warner) ShouldWarn(key string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.window <= 0 {
+		return true
+	}
+
+	now := w.now()
+	if last, ok := w.last[key]; ok && now.Sub(last) < w.window {
+		return false
+	}
+	w.last[key] = now
+	return true
+}

--- a/internal/util/diskpressure/diskpressure_test.go
+++ b/internal/util/diskpressure/diskpressure_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package diskpressure
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSample_RealPath(t *testing.T) {
+	// statfs on a path that always exists. We can't assert exact numbers
+	// (they depend on the host volume) but the invariants must hold.
+	u, err := Sample(t.TempDir())
+	if err != nil {
+		t.Fatalf("Sample returned error: %v", err)
+	}
+	if u.TotalBytes == 0 {
+		t.Error("TotalBytes = 0, want > 0 for a mounted filesystem")
+	}
+	if u.UsedPercent < 0 || u.UsedPercent > 100 {
+		t.Errorf("UsedPercent = %v, want in [0,100]", u.UsedPercent)
+	}
+	if u.AvailBytes > u.TotalBytes {
+		t.Errorf("AvailBytes (%d) > TotalBytes (%d)", u.AvailBytes, u.TotalBytes)
+	}
+}
+
+func TestSample_MissingPathErrors(t *testing.T) {
+	if _, err := Sample("/no/such/path/should/exist/for/kukeon/test"); err == nil {
+		t.Fatal("Sample on a non-existent path: got nil error, want non-nil")
+	}
+}
+
+func TestWarner_RateLimitsPerKey(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	now := base
+	w := NewWarner(5 * time.Minute)
+	w.nowFn = func() time.Time { return now }
+
+	if !w.ShouldWarn("default") {
+		t.Fatal("first ShouldWarn(default) = false, want true")
+	}
+	// Within the window: suppressed.
+	now = base.Add(4 * time.Minute)
+	if w.ShouldWarn("default") {
+		t.Error("ShouldWarn(default) within window = true, want false")
+	}
+	// A different key is tracked independently.
+	if !w.ShouldWarn("kuke-system") {
+		t.Error("first ShouldWarn(kuke-system) = false, want true")
+	}
+	// After the window elapses: allowed again.
+	now = base.Add(6 * time.Minute)
+	if !w.ShouldWarn("default") {
+		t.Error("ShouldWarn(default) after window = false, want true")
+	}
+}
+
+func TestWarner_ZeroWindowAlwaysWarns(t *testing.T) {
+	w := NewWarner(0)
+	for i := range 3 {
+		if !w.ShouldWarn("default") {
+			t.Errorf("ShouldWarn call %d with zero window = false, want true", i)
+		}
+	}
+}

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -98,6 +98,16 @@ type CellSpec struct {
 	// hand-built cell that was never materialized from a binding carries a
 	// nil Provenance. Issue #1021.
 	Provenance *CellProvenance `json:"provenance,omitempty"          yaml:"provenance,omitempty"`
+	// IgnoreDiskPressure bypasses kukeond's data-volume disk-pressure guard for
+	// this cell's creation (issue #1035). Set by `kuke create cell` /
+	// `kuke run --ignore-disk-pressure`. Transport-only with the same two
+	// boundary contracts as RuntimeEnv: the `yaml:"-"` tag keeps it out of any
+	// YAML-author surface, and JSON-RPC carries it CLI → daemon where the
+	// CreateCell guard reads it. The daemon → CLI direction in
+	// apischeme.BuildCellExternalFromInternal deliberately drops it so the
+	// per-invocation override never persists into the stored cell spec; each
+	// `kuke create`/`kuke run` re-supplies its own.
+	IgnoreDiskPressure bool `json:"ignoreDiskPressure,omitempty"  yaml:"-"`
 }
 
 // Binding-kind discriminants for CellProvenance.BindingKind. A cell is


### PR DESCRIPTION
## Summary

kukeond could fill its data volume to 100% with no warning and no guard, then fail downstream in confusing ways (the ENOSPC that triggered the sbsh#373 attach wedge). This makes disk pressure **visible** and makes the daemon **refuse to dig the hole deeper**, without ever deleting operator data.

- **Warn on disk pressure (reconcile loop).** Each reconcile pass samples every realm's data volume (`statfs` on `<RunPath>/data/<realm>`) and emits a rate-limited WARN naming the realm + usage when usage is at/above `KUKEOND_DISK_PRESSURE_WARN_PCT` (default 85). Nothing is deleted. Rate-limited per-realm at a 5-minute window so a 30s reconcile interval doesn't log every tick.
- **Guard new cell creation.** `runner.CreateCell` fails fast with a new `errdefs.ErrDiskPressure` (naming the volume + usage) when usage is at/above `KUKEOND_DISK_PRESSURE_BLOCK_PCT` (default 95), *before* provisioning the snapshot. The guard sits on the genuinely-new-cell branch only — `EnsureCell` (existing cells) is not guarded, so ensuring resources for a cell that already exists is never blocked. Covers both `kuke run` and `kuke create cell` (both reach `runner.CreateCell` via `acquireOrCreateCell`).
- **Opt-out flag.** `kuke create cell` / `kuke run --ignore-disk-pressure` bypasses the guard. Threaded as a **transport-only** `CellSpec.IgnoreDiskPressure` field (`json` + `yaml:"-"`), mirroring the existing `RuntimeEnv` (#834) pattern: carried CLI → daemon over JSON-RPC, copied in `ConvertCellDocToInternal`, and **dropped** in `BuildCellExternalFromInternal` so the per-invocation override never persists into the stored cell spec.
- **No deletion anywhere.** The reconcile WARN only logs; the guard only refuses. Auto-reaping `Stopped` cells is explicitly out of scope (operator's job via `kuke run --rm` / `kuke delete`).

### Notable design calls (reviewer please confirm)

- **Transport-only override, not a persisted spec field.** `IgnoreDiskPressure` is a per-invocation creation directive, so it follows `RuntimeEnv`'s `yaml:"-"` no-persist contract rather than the `AutoDelete` persisted-spec pattern — persisting it would silently exempt a cell's future rematerializations from the guard. Documented inline at both conversion sites.
- **Per-realm sampling, deduped by rate-limit key.** The WARN samples each realm's data dir so it "names the realm" per the AC and tolerates a future where realms live on different mounts. Realms sharing one filesystem each warn under their own rate-limit key (≤ one WARN per realm per window).
- **Config surface is env-var + flag only** (not ServerConfiguration), matching the issue's named knobs `KUKEOND_DISK_PRESSURE_WARN_PCT` / `KUKEOND_DISK_PRESSURE_BLOCK_PCT`; also exposed as `kukeond serve --disk-pressure-warn-percent` / `--disk-pressure-block-percent` for parity with the existing `--default-memory-limit-bytes` knob.
- **Fail-open on sample error.** A `statfs` failure in the guard logs a WARN and allows creation — a monitoring hiccup must never wedge all cell creation.
- No new disk-usage helper duplicates #1085's `internal/ctr/storage.go`: that measures per-realm containerd *content* size; this `diskpressure` package measures filesystem free space via `statfs`. Distinct concepts.

## Test plan

- [x] `make test` (full CI test target, `GOWORK=off`) — passes.
- [x] `go vet ./...` (`GOWORK=off`) — clean.
- [x] `pre-commit run --files` over the changed set (gofmt, golangci-lint, addlicense, go-mod-tidy) — passes.
- [x] New unit tests: `internal/util/diskpressure` (Sample invariants + Warner rate-limiting), runner `guardDiskPressure` (block / allow / override / disabled / sample-error-fail-open), controller `checkDiskPressure` (warn-over-threshold naming the realm / silent-below / disabled / rate-limited-across-passes).
- [x] `make dev-init` end-to-end smoke (daemon-touching change) — exit 0; daemon-parity tail identical across daemon and `--no-daemon` views (both realms `Ready`), running kukeond anchored on the just-built image, and the `kuke attach` smoke passed. Host disk at 45% so the default 95% guard / 85% warn did not interfere with `kuke init`.

Closes #1035