### PR TITLE
deps: bump sbsh to v0.12.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0
 	github.com/creack/pty v1.1.24
-	github.com/eminwux/sbsh v0.12.2
+	github.com/eminwux/sbsh v0.12.3
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/eminwux/sbsh v0.12.2 h1:2znrnwLWP/VI7pI5MmRlyWdnmDeUEKWYMB41ulE+RaM=
-github.com/eminwux/sbsh v0.12.2/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
+github.com/eminwux/sbsh v0.12.3 h1:0OBO2CFjTmRNJfKh5aegcCER7w93fBT/AO634A72x/4=
+github.com/eminwux/sbsh v0.12.3/go.mod h1:epv5XQTI+D68bTa+LTgJ9WsckiA/96bZOjHrsgC3UWU=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
## Summary
- Picks up sbsh v0.12.3 — notably the runtime fix that **never strands terminal state in-memory on metadata write failure** ([sbsh#374](https://github.com/eminwux/sbsh/pull/374)), which sits under kukeon's `pkg/attach`-driven attach loop in `cmd/kuke/attach` and `cmd/kuke/run`. Remaining v0.12.3 changes are sbsh-internal (test de-flake, kuketeam.yaml roster) and have no observable surface in kukeon.
- Patch bump only: `go.mod` + `go.sum`, no client/code changes; sbsh's `go.mod` hash is unchanged from v0.12.2, so the import surface this repo depends on is stable.

## Test plan
- [x] `make test-root` — root-module unit tests green (`internal/controller/runner/attachable*` + `cmd/kuke/{attach,run,log}` covered).
- [x] `make test-kukebuild` — kukebuild module green.
- [x] `make dev-init` smoke — full re-bootstrap, daemon-parity tail clean, PTY-driven `kuke attach` smoke against the kuketty-wrapped `dev-init-attach/ds/dks/cattach` cell exited cleanly on `^]^]`. This is the path that exercises the sbsh attach loop end-to-end.
- [ ] `make e2e` — not run locally; CI's `e2e` job covers it. Local host has live nested kukeond state from prior work and the e2e suite would reset shared `/opt/kukeon` artifacts.

Release notes: https://github.com/eminwux/sbsh/releases/tag/v0.12.3