### PR TITLE
feat(dev-init): configurable podSubnetCIDR so nested dev-init avoids the parent's 10.88.0.0/16

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -121,6 +121,8 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEON_ROOT_CGROUP_ROOT = DefineKV("KUKEON_CGROUP_ROOT", "kukeon/cgroupRoot", "/kukeon")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	KUKEON_ROOT_POD_SUBNET_CIDR = DefineKV("KUKEON_POD_SUBNET_CIDR", "kukeon/podSubnetCIDR", "10.88.0.0/16")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEON_ROOT_HOST = DefineKV("KUKEON_HOST", "kukeon/host", "unix:///run/kukeon/kukeond.sock")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKEON_ROOT_NO_DAEMON = DefineKV("KUKEON_NO_DAEMON", "kukeon/noDaemon", "false")

--- a/cmd/kuke/clientconfig_test.go
+++ b/cmd/kuke/clientconfig_test.go
@@ -22,15 +22,17 @@ import (
 	"testing"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/consts"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/viper"
 )
 
-// restoreRuntimeGlobals snapshots the consts package runtime globals and
-// returns a cleanup that restores them. loadClientConfiguration calls
-// consts.ConfigureRuntime, which mutates these — tests that exercise it
-// must roll back so the next test starts on the in-binary defaults.
+// restoreRuntimeGlobals snapshots the consts package runtime globals and the
+// cni subnet allocator's process-global parent CIDR, and returns a cleanup
+// that restores them. loadClientConfiguration calls consts.ConfigureRuntime
+// and cni.ConfigureSubnetParentCIDR, which mutate these — tests that exercise
+// it must roll back so the next test starts on the in-binary defaults.
 func restoreRuntimeGlobals(t *testing.T) {
 	t.Helper()
 	prevSuffix := consts.RealmNamespaceSuffix
@@ -38,6 +40,7 @@ func restoreRuntimeGlobals(t *testing.T) {
 	t.Cleanup(func() {
 		consts.RealmNamespaceSuffix = prevSuffix //nolint:reassign // restore runtime-overridable global
 		consts.KukeonCgroupRoot = prevRoot       //nolint:reassign // restore runtime-overridable global
+		_ = cni.ConfigureSubnetParentCIDR(cni.DefaultSubnetParentCIDR)
 	})
 }
 
@@ -50,6 +53,7 @@ func bindKukeEnv(t *testing.T) {
 		config.KUKEON_ROOT_LOG_LEVEL,
 		config.KUKEON_ROOT_NAMESPACE_SUFFIX,
 		config.KUKEON_ROOT_CGROUP_ROOT,
+		config.KUKEON_ROOT_POD_SUBNET_CIDR,
 	} {
 		if err := v.BindEnv(); err != nil {
 			t.Fatalf("BindEnv %s: %v", v.EnvVar(), err)
@@ -85,6 +89,7 @@ func TestApplyClientConfigurationDefaultsLayered(t *testing.T) {
 		LogLevel:                  "warn",
 		ContainerdNamespaceSuffix: "dev.kukeon.io",
 		CgroupRoot:                "/kukeon-dev",
+		PodSubnetCIDR:             "10.89.0.0/16",
 	}
 	applyClientConfiguration(cmd, spec)
 
@@ -106,6 +111,9 @@ func TestApplyClientConfigurationDefaultsLayered(t *testing.T) {
 	}
 	if got := viper.GetString(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey); got != spec.CgroupRoot {
 		t.Errorf("CgroupRoot: got %q, want %q", got, spec.CgroupRoot)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey); got != spec.PodSubnetCIDR {
+		t.Errorf("PodSubnetCIDR: got %q, want %q", got, spec.PodSubnetCIDR)
 	}
 }
 
@@ -228,6 +236,7 @@ spec:
   logLevel: warn
   containerdNamespaceSuffix: dev.kukeon.io
   cgroupRoot: /kukeon-dev
+  podSubnetCIDR: 10.89.0.0/16
 `
 	if writeErr := os.WriteFile(path, []byte(content), 0o644); writeErr != nil {
 		t.Fatalf("WriteFile: %v", writeErr)
@@ -259,6 +268,12 @@ spec:
 	if got, want := consts.KukeonCgroupRoot, "/kukeon-dev"; got != want {
 		t.Errorf("consts.KukeonCgroupRoot: got %q, want %q "+
 			"(loadClientConfiguration must call ConfigureRuntime)", got, want)
+	}
+	// loadClientConfiguration must also call cni.ConfigureSubnetParentCIDR so
+	// --no-daemon in-process space creation carves the configured /16 (#1079).
+	if got, want := cni.NewDefaultSubnetAllocator("").ParentCIDR(), "10.89.0.0/16"; got != want {
+		t.Errorf("subnet allocator ParentCIDR: got %q, want %q "+
+			"(loadClientConfiguration must call ConfigureSubnetParentCIDR)", got, want)
 	}
 }
 

--- a/cmd/kuke/kuke.go
+++ b/cmd/kuke/kuke.go
@@ -49,6 +49,7 @@ import (
 	"github.com/eminwux/kukeon/cmd/kuke/version"
 	"github.com/eminwux/kukeon/cmd/types"
 	"github.com/eminwux/kukeon/internal/clientconfig"
+	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/internal/logging"
@@ -314,6 +315,13 @@ func loadClientConfiguration(cmd *cobra.Command) error {
 	if cfgErr := consts.ConfigureRuntime(suffix, cgroupRoot); cfgErr != nil {
 		return fmt.Errorf("configure runtime: %w", cfgErr)
 	}
+	podSubnetCIDR := viper.GetString(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey)
+	if podSubnetCIDR == "" {
+		podSubnetCIDR = config.KUKEON_ROOT_POD_SUBNET_CIDR.Default
+	}
+	if cfgErr := cni.ConfigureSubnetParentCIDR(podSubnetCIDR); cfgErr != nil {
+		return fmt.Errorf("configure pod subnet CIDR: %w", cfgErr)
+	}
 	return nil
 }
 
@@ -362,6 +370,11 @@ func applyClientConfiguration(cmd *cobra.Command, spec v1beta1.ClientConfigurati
 		!flagChanged(cmd, "cgroup-root") &&
 		!envSet(config.KUKEON_ROOT_CGROUP_ROOT) {
 		viper.Set(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey, spec.CgroupRoot)
+	}
+	if spec.PodSubnetCIDR != "" &&
+		!flagChanged(cmd, "pod-subnet-cidr") &&
+		!envSet(config.KUKEON_ROOT_POD_SUBNET_CIDR) {
+		viper.Set(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey, spec.PodSubnetCIDR)
 	}
 }
 

--- a/cmd/kuke/shared/serverconfig.go
+++ b/cmd/kuke/shared/serverconfig.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/serverconfig"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -109,6 +110,13 @@ func LoadServerConfigurationFromFlag(cmd *cobra.Command) (v1beta1.ServerConfigur
 	if cfgErr := consts.ConfigureRuntime(suffix, cgroupRoot); cfgErr != nil {
 		return doc.Spec, path, fmt.Errorf("configure runtime: %w", cfgErr)
 	}
+	podSubnetCIDR := viper.GetString(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey)
+	if podSubnetCIDR == "" {
+		podSubnetCIDR = config.KUKEON_ROOT_POD_SUBNET_CIDR.Default
+	}
+	if cfgErr := cni.ConfigureSubnetParentCIDR(podSubnetCIDR); cfgErr != nil {
+		return doc.Spec, path, fmt.Errorf("configure pod subnet CIDR: %w", cfgErr)
+	}
 	return doc.Spec, path, nil
 }
 
@@ -122,6 +130,7 @@ func LoadServerConfigurationFromFlag(cmd *cobra.Command) (v1beta1.ServerConfigur
 //   - logLevel (KUKEON_LOG_LEVEL)
 //   - containerdNamespaceSuffix (KUKEON_NAMESPACE_SUFFIX)
 //   - cgroupRoot (KUKEON_CGROUP_ROOT)
+//   - podSubnetCIDR (KUKEON_POD_SUBNET_CIDR)
 //
 // Precedence order: explicit `--flag` > env > ServerConfiguration > flag
 // default. The flag check skips fields whose `--flag` was changed; the env
@@ -155,6 +164,11 @@ func ApplyServerConfigurationCommonFields(cmd *cobra.Command, spec v1beta1.Serve
 		!flagChangedAny(cmd, "cgroup-root") &&
 		!envIsSet(config.KUKEON_ROOT_CGROUP_ROOT) {
 		viper.Set(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey, spec.CgroupRoot)
+	}
+	if spec.PodSubnetCIDR != "" &&
+		!flagChangedAny(cmd, "pod-subnet-cidr") &&
+		!envIsSet(config.KUKEON_ROOT_POD_SUBNET_CIDR) {
+		viper.Set(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey, spec.PodSubnetCIDR)
 	}
 }
 

--- a/cmd/kuke/shared/serverconfig_test.go
+++ b/cmd/kuke/shared/serverconfig_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/consts"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 	"github.com/spf13/cobra"
@@ -141,6 +142,9 @@ func TestLoadServerConfigurationFromFlag_NonDefaultSuffixIsAppliedRuntime(t *tes
 	t.Cleanup(func() {
 		consts.RealmNamespaceSuffix = prevSuffix //nolint:reassign // restore runtime-overridable global
 		consts.KukeonCgroupRoot = prevRoot       //nolint:reassign // restore runtime-overridable global
+		// Restore the cni allocator's process-global parent CIDR the loader
+		// mutated via cni.ConfigureSubnetParentCIDR.
+		_ = cni.ConfigureSubnetParentCIDR(cni.DefaultSubnetParentCIDR)
 		viper.Reset()
 	})
 	viper.Reset()
@@ -152,7 +156,8 @@ func TestLoadServerConfigurationFromFlag_NonDefaultSuffixIsAppliedRuntime(t *tes
 			"kind: ServerConfiguration\n" +
 			"spec:\n" +
 			"  containerdNamespaceSuffix: dev.kukeon.io\n" +
-			"  cgroupRoot: /kukeon-dev\n",
+			"  cgroupRoot: /kukeon-dev\n" +
+			"  podSubnetCIDR: 10.89.0.0/16\n",
 	)
 	if err := os.WriteFile(yamlPath, yaml, 0o600); err != nil {
 		t.Fatalf("write yaml: %v", err)
@@ -173,6 +178,12 @@ func TestLoadServerConfigurationFromFlag_NonDefaultSuffixIsAppliedRuntime(t *tes
 	}
 	if got, want := consts.KukeonCgroupRoot, "/kukeon-dev"; got != want {
 		t.Errorf("KukeonCgroupRoot = %q, want %q (loader must call ConfigureRuntime)", got, want)
+	}
+	// The loader must also drive cni.ConfigureSubnetParentCIDR so a parallel
+	// or nested instance's allocator carves the configured /16, not the
+	// default 10.88.0.0/16 (issue #1079). ParentCIDR() surfaces the global.
+	if got, want := cni.NewDefaultSubnetAllocator("").ParentCIDR(), "10.89.0.0/16"; got != want {
+		t.Errorf("subnet allocator ParentCIDR = %q, want %q (loader must call ConfigureSubnetParentCIDR)", got, want)
 	}
 
 	// IsKukeonNamespace now refuses default-suffix namespaces; this is the

--- a/cmd/kukeond/kukeond.go
+++ b/cmd/kukeond/kukeond.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	"github.com/eminwux/kukeon/internal/cni"
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/serverconfig"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
@@ -59,6 +60,11 @@ func NewKukeondCmd() (*cobra.Command, error) {
 				viper.GetString(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey),
 			); cfgErr != nil {
 				return fmt.Errorf("configure runtime: %w", cfgErr)
+			}
+			if cfgErr := cni.ConfigureSubnetParentCIDR(
+				viper.GetString(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey),
+			); cfgErr != nil {
+				return fmt.Errorf("configure pod subnet CIDR: %w", cfgErr)
 			}
 			return nil
 		},
@@ -166,6 +172,19 @@ func NewKukeondCmd() (*cobra.Command, error) {
 		return nil, err
 	}
 
+	cmd.PersistentFlags().String(
+		"pod-subnet-cidr", config.KUKEON_ROOT_POD_SUBNET_CIDR.Default,
+		"Parent CIDR the per-space CNI subnet allocator subdivides into /24s. "+
+			"Set to a non-overlapping block (e.g. 10.89.0.0/16) for a parallel "+
+			"or nested kukeon instance. (issue #1079)",
+	)
+	if err := viper.BindPFlag(
+		config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey,
+		cmd.PersistentFlags().Lookup("pod-subnet-cidr"),
+	); err != nil {
+		return nil, err
+	}
+
 	cmd.PersistentFlags().Int64(
 		"default-memory-limit-bytes", 0,
 		"Daemon-wide fallback memory cap (bytes) for any admitted container "+
@@ -239,6 +258,7 @@ func bindEnvVars() {
 		config.KUKEON_ROOT_LOG_LEVEL,
 		config.KUKEON_ROOT_NAMESPACE_SUFFIX,
 		config.KUKEON_ROOT_CGROUP_ROOT,
+		config.KUKEON_ROOT_POD_SUBNET_CIDR,
 		config.KUKEOND_SOCKET,
 		config.KUKEOND_SOCKET_GID,
 		config.KUKEOND_RECONCILE_INTERVAL,
@@ -289,6 +309,11 @@ func applyServerConfiguration(cmd *cobra.Command, spec v1beta1.ServerConfigurati
 		!flagChanged(cmd, "cgroup-root") &&
 		!envSet(config.KUKEON_ROOT_CGROUP_ROOT) {
 		viper.Set(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey, spec.CgroupRoot)
+	}
+	if spec.PodSubnetCIDR != "" &&
+		!flagChanged(cmd, "pod-subnet-cidr") &&
+		!envSet(config.KUKEON_ROOT_POD_SUBNET_CIDR) {
+		viper.Set(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey, spec.PodSubnetCIDR)
 	}
 	if spec.DefaultMemoryLimitBytes > 0 &&
 		!flagChanged(cmd, "default-memory-limit-bytes") &&
@@ -371,6 +396,7 @@ func currentResolvedSpec() v1beta1.ServerConfigurationSpec {
 		ReconcileInterval:         viper.GetString(config.KUKEOND_RECONCILE_INTERVAL.ViperKey),
 		ContainerdNamespaceSuffix: viper.GetString(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey),
 		CgroupRoot:                viper.GetString(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey),
+		PodSubnetCIDR:             viper.GetString(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey),
 		DefaultMemoryLimitBytes:   viper.GetInt64(config.KUKEOND_DEFAULT_MEMORY_LIMIT_BYTES.ViperKey),
 		KukettyLogLevel:           viper.GetString(config.KUKEOND_KUKETTY_LOG_LEVEL.ViperKey),
 	}

--- a/cmd/kukeond/kukeond_test.go
+++ b/cmd/kukeond/kukeond_test.go
@@ -57,6 +57,7 @@ func TestApplyServerConfigurationDefaultsLayered(t *testing.T) {
 		ReconcileInterval:         "45s",
 		ContainerdNamespaceSuffix: "dev.kukeon.io",
 		CgroupRoot:                "/kukeon-dev",
+		PodSubnetCIDR:             "10.89.0.0/16",
 		DefaultMemoryLimitBytes:   2 * 1024 * 1024 * 1024,
 	}
 	applyServerConfiguration(cmd, spec)
@@ -85,6 +86,9 @@ func TestApplyServerConfigurationDefaultsLayered(t *testing.T) {
 	}
 	if got := viper.GetString(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey); got != spec.CgroupRoot {
 		t.Errorf("CgroupRoot: got %q, want %q", got, spec.CgroupRoot)
+	}
+	if got := viper.GetString(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey); got != spec.PodSubnetCIDR {
+		t.Errorf("PodSubnetCIDR: got %q, want %q", got, spec.PodSubnetCIDR)
 	}
 	if got := viper.GetInt64(config.KUKEOND_DEFAULT_MEMORY_LIMIT_BYTES.ViperKey); got != spec.DefaultMemoryLimitBytes {
 		t.Errorf("DefaultMemoryLimitBytes: got %d, want %d", got, spec.DefaultMemoryLimitBytes)
@@ -336,6 +340,7 @@ func TestCurrentResolvedSpecReflectsViper(t *testing.T) {
 	viper.Set(config.KUKEOND_RECONCILE_INTERVAL.ViperKey, "45s")
 	viper.Set(config.KUKEON_ROOT_NAMESPACE_SUFFIX.ViperKey, "dev.kukeon.io")
 	viper.Set(config.KUKEON_ROOT_CGROUP_ROOT.ViperKey, "/kukeon-dev")
+	viper.Set(config.KUKEON_ROOT_POD_SUBNET_CIDR.ViperKey, "10.89.0.0/16")
 	viper.Set(config.KUKEOND_DEFAULT_MEMORY_LIMIT_BYTES.ViperKey, int64(2*1024*1024*1024))
 
 	spec := currentResolvedSpec()
@@ -363,6 +368,9 @@ func TestCurrentResolvedSpecReflectsViper(t *testing.T) {
 	}
 	if spec.CgroupRoot != "/kukeon-dev" {
 		t.Errorf("CgroupRoot: got %q", spec.CgroupRoot)
+	}
+	if spec.PodSubnetCIDR != "10.89.0.0/16" {
+		t.Errorf("PodSubnetCIDR: got %q", spec.PodSubnetCIDR)
 	}
 	if spec.DefaultMemoryLimitBytes != int64(2*1024*1024*1024) {
 		t.Errorf("DefaultMemoryLimitBytes: got %d", spec.DefaultMemoryLimitBytes)

--- a/docs/dev-init.md
+++ b/docs/dev-init.md
@@ -2,15 +2,29 @@
 
 `scripts/dev-init.sh` (the script `make dev-init` shells out to) runs in one of two modes, picked automatically at the top of the script by probing for `/.kukeon/bin/kuketty` — the canonical bind the daemon stages into every attachable cell (see `internal/ctr.AttachableBinaryPath`):
 
-| Mode                                  | Probe                          | Host socket                    | How it's steered                                                                                                    |
-| ------------------------------------- | ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **Bare host** (probe absent)          | `/.kukeon/bin/kuketty` missing | `/run/kukeon/kukeond.sock`     | Daemon's compiled-in default; no env vars exported.                                                                 |
-| **Nested in a kukeon-dev-root cell**  | `/.kukeon/bin/kuketty` present | `/run/kukeon-dev/kukeond.sock` | Script exports `KUKEON_HOST=unix:///run/kukeon-dev/kukeond.sock` and `KUKEOND_SOCKET=/run/kukeon-dev/kukeond.sock`. |
+| Mode                                 | Probe                          | Host socket                    | How it's steered                                                                                                    |
+| ------------------------------------ | ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| **Bare host** (probe absent)         | `/.kukeon/bin/kuketty` missing | `/run/kukeon/kukeond.sock`     | Daemon's compiled-in default; no env vars exported.                                                                 |
+| **Nested in a kukeon-dev-root cell** | `/.kukeon/bin/kuketty` present | `/run/kukeon-dev/kukeond.sock` | Script exports `KUKEON_HOST=unix:///run/kukeon-dev/kukeond.sock` and `KUKEOND_SOCKET=/run/kukeon-dev/kukeond.sock`. |
 
-`KUKEON_HOST` is read via viper in `cmd/kuke/kuke.go`'s `loadConfig` and steers every `kuke` client call. `KUKEOND_SOCKET` steers the daemon-side serve args `kuke init` seeds for the kukeond cell *and* the cleanup path in `kuke daemon reset`. Both flow into sudo'd children via `--preserve-env=KUKEON_HOST,KUKEOND_SOCKET` on every relevant invocation in the script.
+`KUKEON_HOST` is read via viper in `cmd/kuke/kuke.go`'s `loadConfig` and steers every `kuke` client call. `KUKEOND_SOCKET` steers the daemon-side serve args `kuke init` seeds for the kukeond cell _and_ the cleanup path in `kuke daemon reset`. Both flow into sudo'd children via `--preserve-env=KUKEON_HOST,KUKEOND_SOCKET` on every relevant invocation in the script.
 
 ## Why the nested-mode redirect
 
 The parent daemon bind-mounts `/run/kukeon/tty/<container>/` into the nested cell at `/run/kukeon/tty/`. A nested daemon publishing under `/run/kukeon/` would share that parent directory and break the host's `kuke attach <this-cell>` plumbing on script exit (issues #547, #545). Publishing under `/run/kukeon-dev/` keeps the two lifecycles disjoint. The script's `EXIT` trap (`verify_parent_attach_intact`) sha256-snapshots the parent's `/.kukeon/kuketty/metadata.json` up front and re-checks it on every exit path, so a botched re-bootstrap fails loud here rather than at the operator's next `kuke attach`.
 
-The source of truth for the probe and env-var contract is `scripts/dev-init.sh` lines 38-97.
+## Nested egress: the dev profile's pod-CIDR redirect (#1079)
+
+The socket redirect above is automatic and orthogonal to the **dev profile** (`KUKEON_PROFILE=dev`), which writes `./kukeond-dev.yaml` + `./kuke-dev.yaml` switching three more knobs off their defaults so a parallel or nested kukeon instance never collides with the host's canonical tree:
+
+| Knob                        | Default        | Dev profile     | Why a nested run needs it                                                          |
+| --------------------------- | -------------- | --------------- | ---------------------------------------------------------------------------------- |
+| `containerdNamespaceSuffix` | `kukeon.io`    | `dev.kukeon.io` | Disjoint containerd namespaces so nested workloads don't appear in the parent's.   |
+| `cgroupRoot`                | `/kukeon`      | `/kukeon-dev`   | Disjoint cgroup tree so nested cells don't re-anchor under the parent's hierarchy. |
+| `podSubnetCIDR`             | `10.88.0.0/16` | `10.89.0.0/16`  | Disjoint CNI pod subnet — see below.                                               |
+
+`podSubnetCIDR` is the egress fix. The per-space subnet allocator (`internal/cni.NewDefaultSubnetAllocator`) hands out `/24` chunks of this parent block, the first space getting `…0.0/24` with gateway `…0.1`. A nested daemon left on the default `10.88.0.0/16` reproduces the parent's exact `10.88.0.1` gateway — which is _also_ the dev-root cell's own default gateway. Once the nested bridge claims `10.88.0.1`, that address becomes a **local** address inside the cell and shadows the gateway: every outbound packet is delivered locally and the cell's egress drops to 100% loss. Redirecting the nested allocator to `10.89.0.0/16` keeps it clear of the parent's `/16`.
+
+The knob is plumbed exactly like `cgroupRoot`: `ServerConfiguration.spec.podSubnetCIDR` / `ClientConfiguration.spec.podSubnetCIDR`, the `KUKEON_POD_SUBNET_CIDR` env var, and the `kukeond --pod-subnet-cidr` flag, resolved into `cni.ConfigureSubnetParentCIDR` at process start. The canonical nested agent workflow runs `KUKEON_PROFILE=dev` (the parity tail expects `dev.kukeon.io` / `/kukeon-dev`), so the redirect lands automatically; a nested run _without_ the dev profile would also collide on namespace and cgroup, so it is not a supported configuration.
+
+The source of truth for the probe and env-var contract is `scripts/dev-init.sh` lines 38-97; the dev-profile config files are written further down under the `KUKEON_PROFILE=dev` gate.

--- a/internal/clientconfig/clientconfig.go
+++ b/internal/clientconfig/clientconfig.go
@@ -109,6 +109,14 @@ spec:
   # hierarchy (e.g. "/kukeon-dev" for a parallel dev instance).
   # Default: /kukeon
   cgroupRoot: /kukeon
+
+  # Parent CIDR the per-space CNI subnet allocator subdivides into /24 chunks.
+  # --no-daemon workload paths that create spaces in-process read this so a
+  # parallel or nested kukeon instance never lands on another instance's
+  # subnet (e.g. "10.89.0.0/16" for a nested dev instance avoiding the parent
+  # host's 10.88.0.0/16).
+  # Default: 10.88.0.0/16
+  podSubnetCIDR: 10.88.0.0/16
 `
 
 // WriteDefault writes the commented default ClientConfiguration to path when

--- a/internal/clientconfig/clientconfig_test.go
+++ b/internal/clientconfig/clientconfig_test.go
@@ -54,6 +54,7 @@ spec:
   logLevel: debug
   containerdNamespaceSuffix: dev.kukeon.io
   cgroupRoot: /kukeon-dev
+  podSubnetCIDR: 10.89.0.0/16
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
@@ -83,6 +84,9 @@ spec:
 	}
 	if doc.Spec.CgroupRoot != "/kukeon-dev" {
 		t.Errorf("CgroupRoot: got %q", doc.Spec.CgroupRoot)
+	}
+	if doc.Spec.PodSubnetCIDR != "10.89.0.0/16" {
+		t.Errorf("PodSubnetCIDR: got %q", doc.Spec.PodSubnetCIDR)
 	}
 }
 
@@ -193,6 +197,9 @@ func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 	if doc.Spec.CgroupRoot != "/kukeon" {
 		t.Errorf("Spec.CgroupRoot: got %q", doc.Spec.CgroupRoot)
 	}
+	if doc.Spec.PodSubnetCIDR != "10.88.0.0/16" {
+		t.Errorf("Spec.PodSubnetCIDR: got %q", doc.Spec.PodSubnetCIDR)
+	}
 
 	// AC: "Header comment explains each field's purpose and default."
 	raw, err := os.ReadFile(path)
@@ -210,6 +217,7 @@ func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 		"# Default: info",
 		"# Default: kukeon.io",
 		"# Default: /kukeon",
+		"# Default: 10.88.0.0/16",
 	} {
 		if !strings.Contains(rawStr, marker) {
 			t.Errorf("missing per-field default marker %q in dumped YAML", marker)

--- a/internal/cni/subnet.go
+++ b/internal/cni/subnet.go
@@ -126,15 +126,58 @@ func NewSubnetAllocator(runPath, parentCIDR string, prefixLen int) (*SubnetAlloc
 	}, nil
 }
 
+// configuredSubnetParentCIDR is the parent block NewDefaultSubnetAllocator
+// subdivides. It defaults to DefaultSubnetParentCIDR (10.88.0.0/16) and is
+// overridden once at process start by ConfigureSubnetParentCIDR when the
+// operator configures a non-default pod CIDR. The canonical use is nested
+// `make dev-init` (running inside a kukeon-dev-root cell): the nested kukeon
+// must not reuse the parent host's 10.88.0.0/16 + .1 gateway, which is the
+// cell's own default gateway — claiming .1 inside the cell shadows the
+// gateway and blackholes the cell's egress (issue #1079). Process-global,
+// mirroring consts.KukeonCgroupRoot / consts.RealmNamespaceSuffix, the
+// sibling per-instance redirect knobs. Set once before any runner is built,
+// then read-only — no lock needed.
+//
+//nolint:gochecknoglobals // process-wide runtime config, see godoc above.
+var configuredSubnetParentCIDR = DefaultSubnetParentCIDR
+
+// ConfigureSubnetParentCIDR overrides the parent CIDR NewDefaultSubnetAllocator
+// subdivides for this process. An empty cidr is a no-op that keeps the
+// default, so callers can pass a resolved-or-empty config value unconditionally.
+// A non-empty cidr is validated the same way NewSubnetAllocator validates its
+// parent (IPv4 CIDR wide enough for a /DefaultSubnetPrefixLen carve); an invalid
+// value returns an ErrInvalidSubnetCIDR-wrapped error so the caller can refuse
+// to start rather than panic later inside NewDefaultSubnetAllocator. The kukeond
+// daemon and `kuke init` call it once after loading their configuration,
+// alongside consts.ConfigureRuntime.
+func ConfigureSubnetParentCIDR(cidr string) error {
+	cidr = strings.TrimSpace(cidr)
+	if cidr == "" {
+		return nil
+	}
+	// Reuse NewSubnetAllocator as the validator — its constructor parses the
+	// CIDR and rejects a parent too narrow for the per-space prefix without
+	// touching disk, so a probe build with an empty runPath is side-effect
+	// free.
+	if _, err := NewSubnetAllocator("", cidr, DefaultSubnetPrefixLen); err != nil {
+		return err
+	}
+	configuredSubnetParentCIDR = cidr
+	return nil
+}
+
 // NewDefaultSubnetAllocator constructs the standard allocator: /24 chunks of
-// 10.88.0.0/16 persisted under runPath.
+// configuredSubnetParentCIDR (10.88.0.0/16 unless ConfigureSubnetParentCIDR
+// redirected it at process start) persisted under runPath.
 func NewDefaultSubnetAllocator(runPath string) *SubnetAllocator {
-	a, err := NewSubnetAllocator(runPath, DefaultSubnetParentCIDR, DefaultSubnetPrefixLen)
+	a, err := NewSubnetAllocator(runPath, configuredSubnetParentCIDR, DefaultSubnetPrefixLen)
 	if err != nil {
-		// The default arguments are constants, so this can never fail at
-		// runtime. Constructor returns *SubnetAllocator for ergonomic use at
-		// daemon startup; if the constants ever drift apart, a panic here
-		// surfaces the bug immediately rather than at first space-create.
+		// configuredSubnetParentCIDR is either the compile-time default
+		// constant or a value ConfigureSubnetParentCIDR already validated, so
+		// this can never fail at runtime. Constructor returns *SubnetAllocator
+		// for ergonomic use at daemon startup; if the constants ever drift
+		// apart, a panic here surfaces the bug immediately rather than at
+		// first space-create.
 		panic(fmt.Sprintf("kukeon: default subnet allocator misconfigured: %v", err))
 	}
 	return a

--- a/internal/cni/subnet_test.go
+++ b/internal/cni/subnet_test.go
@@ -313,3 +313,60 @@ func TestNewDefaultSubnetAllocator_UsesDefault10880016(t *testing.T) {
 		t.Errorf("default PrefixLen = %d, want 24", got)
 	}
 }
+
+// TestConfigureSubnetParentCIDR_OverridesDefault is the issue #1079 regression
+// guard: after ConfigureSubnetParentCIDR redirects the parent block, the
+// default allocator carves /24s from the configured /16 instead of the
+// hardcoded 10.88.0.0/16. The override is process-global, so the test restores
+// the default in cleanup to avoid leaking into sibling tests.
+func TestConfigureSubnetParentCIDR_OverridesDefault(t *testing.T) {
+	t.Cleanup(func() { _ = cni.ConfigureSubnetParentCIDR(cni.DefaultSubnetParentCIDR) })
+
+	if err := cni.ConfigureSubnetParentCIDR("10.89.0.0/16"); err != nil {
+		t.Fatalf("ConfigureSubnetParentCIDR(10.89.0.0/16): %v", err)
+	}
+	if got := cni.NewDefaultSubnetAllocator(t.TempDir()).ParentCIDR(); got != "10.89.0.0/16" {
+		t.Errorf("ParentCIDR after override = %q, want 10.89.0.0/16", got)
+	}
+
+	// A redirected allocator hands out its first /24 from the new block, so the
+	// nested gateway lands clear of the parent host's 10.88.0.1 (the collision
+	// that blackholed egress).
+	got, err := cni.NewDefaultSubnetAllocator(t.TempDir()).Allocate("default", "first")
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	if got != "10.89.0.0/24" {
+		t.Errorf("first allocation = %q, want 10.89.0.0/24", got)
+	}
+}
+
+// TestConfigureSubnetParentCIDR_EmptyIsNoop confirms an empty cidr keeps the
+// default, so callers can pass a resolved-or-empty config value unconditionally.
+func TestConfigureSubnetParentCIDR_EmptyIsNoop(t *testing.T) {
+	t.Cleanup(func() { _ = cni.ConfigureSubnetParentCIDR(cni.DefaultSubnetParentCIDR) })
+
+	if err := cni.ConfigureSubnetParentCIDR(""); err != nil {
+		t.Fatalf("ConfigureSubnetParentCIDR(\"\"): %v", err)
+	}
+	if got := cni.NewDefaultSubnetAllocator(t.TempDir()).ParentCIDR(); got != "10.88.0.0/16" {
+		t.Errorf("ParentCIDR after empty override = %q, want 10.88.0.0/16 (no-op)", got)
+	}
+}
+
+// TestConfigureSubnetParentCIDR_RejectsInvalid confirms a malformed or
+// too-narrow CIDR is rejected with ErrInvalidSubnetCIDR and leaves the default
+// untouched, so the caller can refuse to start rather than panic later inside
+// NewDefaultSubnetAllocator.
+func TestConfigureSubnetParentCIDR_RejectsInvalid(t *testing.T) {
+	t.Cleanup(func() { _ = cni.ConfigureSubnetParentCIDR(cni.DefaultSubnetParentCIDR) })
+
+	for _, bad := range []string{"not-a-cidr", "10.89.0.0/24", "::1/64"} {
+		if err := cni.ConfigureSubnetParentCIDR(bad); !errors.Is(err, errdefs.ErrInvalidSubnetCIDR) {
+			t.Errorf("ConfigureSubnetParentCIDR(%q): expected ErrInvalidSubnetCIDR, got %v", bad, err)
+		}
+		if got := cni.NewDefaultSubnetAllocator(t.TempDir()).ParentCIDR(); got != "10.88.0.0/16" {
+			t.Errorf("ParentCIDR after rejected %q = %q, want unchanged 10.88.0.0/16", bad, got)
+		}
+	}
+}

--- a/internal/serverconfig/serverconfig.go
+++ b/internal/serverconfig/serverconfig.go
@@ -139,6 +139,14 @@ spec:
   # Default: /kukeon
   cgroupRoot: {{printf "%q" .CgroupRoot}}
 
+  # Parent CIDR the per-space CNI subnet allocator subdivides into /24 chunks.
+  # Set to a non-overlapping block (e.g. "10.89.0.0/16") for a parallel or
+  # nested kukeon instance so its allocator never lands on another instance's
+  # subnet — a nested ` + "`make dev-init`" + ` must avoid the parent host's
+  # 10.88.0.0/16 + .1 gateway, which is the dev-root cell's own default gateway.
+  # Default: 10.88.0.0/16
+  podSubnetCIDR: {{printf "%q" .PodSubnetCIDR}}
+
   # Daemon-wide fallback memory limit (in bytes) applied to every admitted
   # container whose Resources.MemoryLimitBytes is unset or zero. An explicit
   # per-container limit always wins. Recommended on hosts without swap and

--- a/internal/serverconfig/serverconfig_test.go
+++ b/internal/serverconfig/serverconfig_test.go
@@ -186,6 +186,7 @@ func canonicalDefaultsSpec() v1beta1.ServerConfigurationSpec {
 		KukeondImage:              "",
 		ContainerdNamespaceSuffix: "kukeon.io",
 		CgroupRoot:                "/kukeon",
+		PodSubnetCIDR:             "10.88.0.0/16",
 		DefaultMemoryLimitBytes:   0,
 	}
 }
@@ -244,6 +245,9 @@ func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 	if doc.Spec.CgroupRoot != "/kukeon" {
 		t.Errorf("Spec.CgroupRoot: got %q, want %q", doc.Spec.CgroupRoot, "/kukeon")
 	}
+	if doc.Spec.PodSubnetCIDR != "10.88.0.0/16" {
+		t.Errorf("Spec.PodSubnetCIDR: got %q, want %q", doc.Spec.PodSubnetCIDR, "10.88.0.0/16")
+	}
 
 	// AC: "Header comment explains each field's purpose and default."
 	raw, err := os.ReadFile(path)
@@ -264,6 +268,7 @@ func TestWriteDefaultCreatesFileWithDefaults(t *testing.T) {
 		`# Default: ""`,
 		"# Default: kukeon.io",
 		"# Default: /kukeon",
+		"# Default: 10.88.0.0/16",
 	} {
 		if !strings.Contains(rawStr, marker) {
 			t.Errorf("missing per-field default marker %q in dumped YAML", marker)
@@ -318,6 +323,7 @@ func TestWriteDefaultRendersResolvedSpec(t *testing.T) {
 		KukeondImage:              "docker.io/library/kukeon:test",
 		ContainerdNamespaceSuffix: "dev.kukeon.io",
 		CgroupRoot:                "/kukeon-dev",
+		PodSubnetCIDR:             "10.89.0.0/16",
 		DefaultMemoryLimitBytes:   2 * 1024 * 1024 * 1024,
 	}
 
@@ -363,6 +369,9 @@ func TestWriteDefaultRendersResolvedSpec(t *testing.T) {
 	}
 	if doc.Spec.CgroupRoot != spec.CgroupRoot {
 		t.Errorf("Spec.CgroupRoot: got %q, want %q", doc.Spec.CgroupRoot, spec.CgroupRoot)
+	}
+	if doc.Spec.PodSubnetCIDR != spec.PodSubnetCIDR {
+		t.Errorf("Spec.PodSubnetCIDR: got %q, want %q", doc.Spec.PodSubnetCIDR, spec.PodSubnetCIDR)
 	}
 	if doc.Spec.DefaultMemoryLimitBytes != spec.DefaultMemoryLimitBytes {
 		t.Errorf("Spec.DefaultMemoryLimitBytes: got %d, want %d",

--- a/pkg/api/model/v1beta1/clientconfiguration.go
+++ b/pkg/api/model/v1beta1/clientconfiguration.go
@@ -66,4 +66,11 @@ type ClientConfigurationSpec struct {
 	// ServerConfiguration.spec.cgroupRoot on the daemon side.
 	// Default: /kukeon.
 	CgroupRoot string `json:"cgroupRoot,omitempty"                yaml:"cgroupRoot,omitempty"`
+	// PodSubnetCIDR is the parent block the per-space CNI subnet allocator
+	// subdivides into /24 chunks. `--no-daemon` workload paths that create
+	// spaces in-process read this field so a parallel or nested kukeon
+	// instance never lands on another instance's subnet; the parallel of
+	// ServerConfiguration.spec.podSubnetCIDR on the daemon side (issue
+	// #1079). Default: 10.88.0.0/16.
+	PodSubnetCIDR string `json:"podSubnetCIDR,omitempty"             yaml:"podSubnetCIDR,omitempty"`
 }

--- a/pkg/api/model/v1beta1/serverconfiguration.go
+++ b/pkg/api/model/v1beta1/serverconfiguration.go
@@ -74,6 +74,14 @@ type ServerConfigurationSpec struct {
 	// stacks / cells live (e.g. /kukeon-dev for a parallel dev instance on
 	// the same host). Default: /kukeon.
 	CgroupRoot string `json:"cgroupRoot,omitempty"                yaml:"cgroupRoot,omitempty"`
+	// PodSubnetCIDR is the parent block the per-space CNI subnet allocator
+	// subdivides into /24 chunks. Set it to a non-overlapping block (e.g.
+	// 10.89.0.0/16) when running a parallel or nested kukeon instance so its
+	// allocator never lands on another instance's subnet — in particular a
+	// nested `make dev-init` must avoid the parent host's 10.88.0.0/16 + .1
+	// gateway, which is the dev-root cell's own default gateway (issue
+	// #1079). Default: 10.88.0.0/16.
+	PodSubnetCIDR string `json:"podSubnetCIDR,omitempty"             yaml:"podSubnetCIDR,omitempty"`
 	// DefaultMemoryLimitBytes is the daemon-wide fallback memory limit
 	// applied to every admitted container whose
 	// ContainerSpec.Resources.MemoryLimitBytes is unset or zero. Closes the

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -176,7 +176,7 @@ verify_parent_attach_intact() {
 trap 'verify_parent_attach_intact || exit 1' EXIT
 
 if [ "${KUKEON_PROFILE}" = "dev" ]; then
-    step "KUKEON_PROFILE=dev: enabling dev-profile (suffix dev.kukeon.io, cgroup /kukeon-dev)"
+    step "KUKEON_PROFILE=dev: enabling dev-profile (suffix dev.kukeon.io, cgroup /kukeon-dev, pod CIDR 10.89.0.0/16)"
 
     # Write the dev-profile config files idempotently before any kuke
     # invocation. `-e` instead of `-f` so a broken symlink to a missing
@@ -190,12 +190,17 @@ if [ "${KUKEON_PROFILE}" = "dev" ]; then
         step "Write dev-profile server config to ${DEV_PROFILE_SERVER_CONFIG}"
         cat > "${DEV_PROFILE_SERVER_CONFIG}" <<'EOF'
 # kukeond ServerConfiguration — dev profile (#285 phase 3).
-# Switches containerdNamespaceSuffix and cgroupRoot off the defaults so a
-# parallel kukeon instance can coexist with the canonical kukeon.io / /kukeon
-# tree. socket / runPath are left at defaults — dev-init runs the only
-# kukeon instance on the host, so disjoint storage is unnecessary; the
-# multi-instance two-host-smoke is exercised by the issue's manual test
-# plan, not this script.
+# Switches containerdNamespaceSuffix, cgroupRoot, and podSubnetCIDR off the
+# defaults so a parallel or nested kukeon instance can coexist with the
+# canonical kukeon.io / /kukeon / 10.88.0.0/16 tree. socket / runPath are left
+# at defaults — dev-init runs the only kukeon instance on the host, so disjoint
+# storage is unnecessary; the multi-instance two-host-smoke is exercised by the
+# issue's manual test plan, not this script.
+#
+# podSubnetCIDR is the nested-mode egress fix (#1079): running `make dev-init`
+# inside a kukeon-dev-root cell, the nested allocator must not reuse the parent
+# host's 10.88.0.0/16 + .1 gateway — that .1 is the cell's own default gateway,
+# and claiming it inside the cell shadows the gateway and blackholes egress.
 apiVersion: v1beta1
 kind: ServerConfiguration
 metadata:
@@ -203,6 +208,7 @@ metadata:
 spec:
   containerdNamespaceSuffix: dev.kukeon.io
   cgroupRoot: /kukeon-dev
+  podSubnetCIDR: 10.89.0.0/16
 EOF
     fi
 
@@ -212,9 +218,11 @@ EOF
 # kuke ClientConfiguration — dev profile (#285 phase 3).
 # Read by every `kuke` invocation below via KUKE_CONFIGURATION. The
 # --no-daemon parity check below depends on this file to address the dev
-# instance's containerd namespaces (dev.kukeon.io) and cgroup tree
-# (/kukeon-dev) without a per-command --containerd-namespace-suffix /
-# --cgroup-root flag.
+# instance's containerd namespaces (dev.kukeon.io), cgroup tree (/kukeon-dev),
+# and pod subnet (10.89.0.0/16) without a per-command
+# --containerd-namespace-suffix / --cgroup-root / --pod-subnet-cidr flag.
+# podSubnetCIDR mirrors the server-side nested-mode egress fix (#1079) so
+# in-process `--no-daemon` space creation never lands on the parent's subnet.
 apiVersion: v1beta1
 kind: ClientConfiguration
 metadata:
@@ -222,6 +230,7 @@ metadata:
 spec:
   containerdNamespaceSuffix: dev.kukeon.io
   cgroupRoot: /kukeon-dev
+  podSubnetCIDR: 10.89.0.0/16
 EOF
     fi
 


### PR DESCRIPTION
## Summary

- Nested `make dev-init` (running inside a `kukeon-dev-root` cell) reused the parent host's `10.88.0.0/16` + `10.88.0.1` gateway for the nested kukeon's CNI allocator. Since `10.88.0.1` is the dev-root cell's own default gateway, the nested bridge claiming `.1` makes it a *local* address inside the cell, shadowing the gateway and blackholing all egress (issue #1079).
- Adds `podSubnetCIDR` as a **4th nested-redirect knob**, peer to the existing socket / `containerdNamespaceSuffix` / `cgroupRoot` redirects, plumbed end-to-end exactly like `cgroupRoot`:
  - `cni.ConfigureSubnetParentCIDR(cidr)` overrides the process-global parent block `NewDefaultSubnetAllocator` subdivides (validates the CIDR; empty = no-op keeping the `10.88.0.0/16` default).
  - `ServerConfiguration.spec.podSubnetCIDR` + `ClientConfiguration.spec.podSubnetCIDR`, `KUKEON_POD_SUBNET_CIDR` env var, and `kukeond --pod-subnet-cidr` flag. Resolved into `cni.ConfigureSubnetParentCIDR` at process start in all three `ConfigureRuntime` call sites (daemon `PersistentPreRunE`, `kuke` client config load, shared admin `LoadServerConfigurationFromFlag`).
  - WriteDefault templates (server + client) and `currentResolvedSpec` carry the new field.
- `scripts/dev-init.sh` dev profile (`KUKEON_PROFILE=dev`) now writes `podSubnetCIDR: 10.89.0.0/16` into both `kukeond-dev.yaml` and `kuke-dev.yaml`, alongside the existing `dev.kukeon.io` / `/kukeon-dev` redirects — so the nested allocator carves `10.89.0.0/16`, clear of the parent's `/16`.
- `docs/dev-init.md` gains a "Nested egress" section documenting the new redirect and the collision it fixes.

## Design notes (for reviewer)

- **Gate-vs-flip:** the historical default (`10.88.0.0/16`) is preserved for bare-host `make dev-init` and all production installs — the redirect is **opt-in** via the dev profile, matching how `cgroupRoot`/`namespaceSuffix` already behave (the lower-blast-radius reading per the AC's "alongside the … redirections it already performs"). A global flip of the default would break existing contributors, so it was avoided.
- **Where the knob lives:** the AC offered "extend the #131 collision guard *or* document a required pod-CIDR override." The override approach was chosen because it's the only one that actually restores egress (the #131 guard is within a single allocator; the parent↔nested collision is across two independent kukeon instances, which a within-instance guard cannot see). It also mirrors the established multi-instance config model.
- **Implementation home:** the override is a `cni`-package process-global (purely additive — no `consts.ConfigureRuntime` signature change, so no churn to its callers/tests), set once at startup before any runner is built, then read-only.
- **Nested-without-dev-profile** is out of scope: such a run already collides on namespace and cgroup, so it is not a supported configuration (noted in `docs/dev-init.md`).

## Test plan

- [x] `make test` (full CI target: `test-root` + `test-kukebuild`) — pass
- [x] `GOWORK=off go vet ./...` — pass
- [x] `pre-commit run --files <changed>` (trailing-whitespace, eof, go-fmt, go-mod-tidy, **golangci-lint**, prettier, addlicense) — pass
- [x] New unit tests: `cni.ConfigureSubnetParentCIDR` override / empty-no-op / invalid-rejected + first-allocation lands on `10.89.0.0/24`; server+client config round-trip and apply-path assertions for `podSubnetCIDR`; `LoadServerConfigurationFromFlag` / `loadClientConfiguration` drive `ConfigureSubnetParentCIDR`
- [ ] End-to-end nested `make dev-init` egress smoke (`ping 1.1.1.1` from inside a dev-root cell before/after) — not run: requires a `kukeon-dev-root` cell with a live parent daemon and standalone containerd, which the dev host can't provision without disturbing unrelated state. Covered by reasoning + the unit test asserting the first nested allocation is `10.89.0.0/24` (clear of the parent's `10.88.0.1`).

Closes #1079
