### PR TITLE
feat(create): --param/--env symmetry baked into the CellDoc

### DIFF
--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -65,7 +65,15 @@ func NewCellCmd() *cobra.Command {
 			"--from-blueprint and --from-config are mutually exclusive. --param " +
 			"and --param-file are valid with --from-blueprint (mirroring " +
 			"`kuke run -b`); they are rejected with --from-config because a " +
-			"CellConfig carries its own values (edit the Config instead).",
+			"CellConfig carries its own values (edit the Config instead). " +
+			"Symmetrically, --env KEY=VALUE is valid with --from-config (a " +
+			"per-cell override layered on top of the Config's resolved values) " +
+			"and rejected with --from-blueprint. Override precedence on the " +
+			"--from-config path is binding values (the Config's spec.values) → " +
+			"blueprint parameter defaults → per-cell --env (overrides win); on " +
+			"the --from-blueprint path it is parameter defaults → per-cell " +
+			"--param (overrides win). Both override sets are baked into the " +
+			"materialised CellDoc and recorded in its Spec.Provenance block.",
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -106,6 +114,14 @@ func NewCellCmd() *cobra.Command {
 			"duplicate keys. Rejected with --from-config (same reason as --param).")
 	_ = viper.BindPFlag(config.KUKE_CREATE_CELL_PARAM_FILE.ViperKey, cmd.Flags().Lookup("param-file"))
 
+	cmd.Flags().StringArray("env", nil,
+		"Per-cell environment override as KEY=VALUE; repeatable. Valid with --from-config "+
+			"only (the symmetric counterpart of --param on --from-blueprint). Each entry is "+
+			"baked into the attachable container's env in the materialised CellDoc and recorded "+
+			"in Spec.Provenance.envOverrides, winning over any value the Config's spec.values "+
+			"resolved for the same key. Rejected with --from-blueprint: materialise from a "+
+			"Config (or edit the Blueprint) to layer env overrides.")
+
 	cmd.Flags().Bool("ignore-disk-pressure", false,
 		"Bypass kukeond's data-volume disk-pressure guard for this cell's "+
 			"creation. The daemon normally refuses to provision a new cell once "+
@@ -138,6 +154,11 @@ type createCellFlags struct {
 	configName    string
 	paramArgs     []string
 	paramFile     string
+	// envArgs holds the validated `--env KEY=VALUE` per-cell overrides. Valid
+	// with --from-config only (parity with --param on --from-blueprint); baked
+	// into the attachable container's env and recorded in
+	// Spec.Provenance.EnvOverrides. Issue #1023.
+	envArgs []string
 	// ignoreDiskPressure threads `kuke create cell --ignore-disk-pressure`
 	// onto the transport-only Spec.IgnoreDiskPressure field so the daemon's
 	// CreateCell guard is bypassed for this invocation. Issue #1035.
@@ -147,9 +168,16 @@ type createCellFlags struct {
 // parseCreateCellFlags validates the flag combinations and trims values. The
 // cobra-side mutex enforces --from-blueprint vs --from-config; this routine
 // also requires exactly one of those flags (the empty-shell mode retired with
-// epic:bye-container step 3) and rejects --param/--param-file when
-// --from-config is set (a CellConfig carries its own spec.values, parity with
-// `kuke run -c`).
+// epic:bye-container step 3) and enforces the per-path override symmetry
+// (issue #1023):
+//
+//   - --param/--param-file are rejected with --from-config (a CellConfig
+//     carries its own spec.values, parity with `kuke run -c`);
+//   - --env is rejected with --from-blueprint (its symmetric counterpart —
+//     materialise from a Config to layer env overrides).
+//
+// --env entries are validated here (parseEnvArgs) so a malformed override
+// fails before any daemon round-trip.
 func parseCreateCellFlags(cmd *cobra.Command, args []string) (createCellFlags, error) {
 	flags := createCellFlags{
 		blueprintName: strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_FROM_BLUEPRINT.ViperKey)),
@@ -195,6 +223,16 @@ func parseCreateCellFlags(cmd *cobra.Command, args []string) (createCellFlags, e
 	}
 	flags.paramArgs = paramArgs
 
+	rawEnv, err := cmd.Flags().GetStringArray("env")
+	if err != nil {
+		return createCellFlags{}, err
+	}
+	envArgs, err := parseEnvArgs(rawEnv)
+	if err != nil {
+		return createCellFlags{}, err
+	}
+	flags.envArgs = envArgs
+
 	flags.ignoreDiskPressure = viper.GetBool(config.KUKE_CREATE_CELL_IGNORE_DISK_PRESSURE.ViperKey)
 
 	if flags.configName != "" {
@@ -208,6 +246,11 @@ func parseCreateCellFlags(cmd *cobra.Command, args []string) (createCellFlags, e
 				"--param-file is not valid with --from-config; a CellConfig carries its own spec.values (edit the Config instead)",
 			)
 		}
+	}
+	if flags.blueprintName != "" && len(flags.envArgs) > 0 {
+		return createCellFlags{}, errors.New(
+			"--env is not valid with --from-blueprint; materialise from a Config (kuke create cell --from-config) to layer env overrides",
+		)
 	}
 	return flags, nil
 }
@@ -340,6 +383,7 @@ func runFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags createCellF
 	if err := finalizeCellName(cmd, client, &cellDoc, flags.name, cellconfig.Prefix(cfgRes.Config)); err != nil {
 		return err
 	}
+	applyEnvOverrides(&cellDoc, flags.envArgs)
 	applyIgnoreDiskPressure(&cellDoc, flags)
 
 	return materialiseAndPersist(cmd, client, cellDoc)
@@ -422,6 +466,124 @@ func overlayScope(doc *v1beta1.CellDoc, flags createCellFlags) {
 	if strings.TrimSpace(doc.Spec.StackID) == "" {
 		doc.Spec.StackID = flags.stack
 	}
+}
+
+// applyEnvOverrides bakes the validated `--env KEY=VALUE` per-cell overrides
+// into the materialised CellDoc (issue #1023). Two effects, mirroring the
+// `kuke run --env` provenance contract (#1021) but persisting rather than
+// riding the transport-only Spec.RuntimeEnv:
+//
+//   - the overrides are merged into the attachable container's persisted Env
+//     (resolveAttachableContainerIndex picks the target the same way
+//     `kuke run` would attach), winning over any value the Config's
+//     spec.values resolved for the same key — so the override survives the
+//     stopped-cell persist and takes effect on the later `kuke start`;
+//   - the same entries are recorded verbatim in Spec.Provenance.EnvOverrides,
+//     the P1 materialization-input record P4 re-resolves against.
+//
+// A nil/empty envArgs is a no-op. When no container is attachable the
+// overrides are still recorded in provenance (the operator's intent is
+// preserved) but have nowhere to bake, mirroring the runtime path's
+// silent no-op on a non-attachable cell.
+func applyEnvOverrides(doc *v1beta1.CellDoc, envArgs []string) {
+	if len(envArgs) == 0 {
+		return
+	}
+	if idx := resolveAttachableContainerIndex(doc.Spec); idx >= 0 {
+		doc.Spec.Containers[idx].Env = mergeEnv(doc.Spec.Containers[idx].Env, envArgs)
+	}
+	if doc.Spec.Provenance != nil {
+		doc.Spec.Provenance.EnvOverrides = append([]string(nil), envArgs...)
+	}
+}
+
+// resolveAttachableContainerIndex returns the index of the container `kuke run`
+// would attach to (issue #834's runtime-env target), or -1 when none qualifies.
+// Precedence mirrors the daemon-side resolveAttachableContainerID and the
+// CLI-side pickAttachTarget:
+//
+//  1. Spec.Tty.Default, when it names an existing non-root container;
+//  2. the first non-root container with Attachable=true, in declaration order;
+//  3. -1 when no container qualifies.
+func resolveAttachableContainerIndex(spec v1beta1.CellSpec) int {
+	if spec.Tty != nil {
+		if pref := strings.TrimSpace(spec.Tty.Default); pref != "" {
+			for i, c := range spec.Containers {
+				if !c.Root && c.ID == pref {
+					return i
+				}
+			}
+		}
+	}
+	for i, c := range spec.Containers {
+		if !c.Root && c.Attachable {
+			return i
+		}
+	}
+	return -1
+}
+
+// mergeEnv layers the validated env overrides on top of a container's existing
+// Env. For each KEY in envArgs, any specEnv entry with the same KEY is dropped
+// (the override wins); surviving spec entries keep their order, then the
+// override entries follow in their input order. Mirrors the runner-side
+// mergeRuntimeEnv merge semantics so a `create cell --env` override and a
+// `run --env` override resolve identically. Never mutates the input slices.
+func mergeEnv(specEnv, envArgs []string) []string {
+	if len(envArgs) == 0 {
+		return specEnv
+	}
+	overrideKeys := make(map[string]struct{}, len(envArgs))
+	for _, entry := range envArgs {
+		key, _, _ := strings.Cut(entry, "=")
+		overrideKeys[key] = struct{}{}
+	}
+	merged := make([]string, 0, len(specEnv)+len(envArgs))
+	for _, entry := range specEnv {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, override := overrideKeys[key]; override {
+			continue
+		}
+		merged = append(merged, entry)
+	}
+	return append(merged, envArgs...)
+}
+
+// parseEnvArgs validates the repeatable `--env KEY=VALUE` flag and returns the
+// normalized entries. Mirrors cmd/kuke/run.parseEnvArgs (issue #834); kept
+// local to avoid a cross-package import (parity with buildParamMap below).
+// Rules: each entry needs a `=`; the KEY (before the first `=`) must be
+// non-empty after trimming; the VALUE (after the first `=`) is preserved
+// verbatim including empty; a duplicate KEY with the same VALUE is collapsed,
+// a duplicate KEY with a different VALUE is rejected (no silent last-wins).
+func parseEnvArgs(args []string) ([]string, error) {
+	if len(args) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]string, len(args))
+	out := make([]string, 0, len(args))
+	for _, raw := range args {
+		key, value, ok := strings.Cut(raw, "=")
+		if !ok {
+			return nil, fmt.Errorf("--env requires KEY=VALUE (got: %q)", raw)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("--env KEY must be non-empty (got: %q)", raw)
+		}
+		if prior, dup := seen[key]; dup {
+			if prior != value {
+				return nil, fmt.Errorf(
+					"--env %s supplied twice with different values (%q vs %q); pick one",
+					key, prior, value,
+				)
+			}
+			continue
+		}
+		seen[key] = value
+		out = append(out, key+"="+value)
+	}
+	return out, nil
 }
 
 // buildParamMap layers --param flags on top of --param-file contents.

--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -538,7 +538,13 @@ func mergeEnv(specEnv, envArgs []string) []string {
 		key, _, _ := strings.Cut(entry, "=")
 		overrideKeys[key] = struct{}{}
 	}
-	merged := make([]string, 0, len(specEnv)+len(envArgs))
+	// Cap on len(specEnv) alone — not len(specEnv)+len(envArgs) — to
+	// keep CodeQL's go/allocation-size-overflow analysis silent on
+	// operator-tainted inputs. The envArgs tail is appended below and
+	// Go's append handles the tiny extra growth fine for typical kuke
+	// cells (<50 entries on either side). Mirrors the runner-side
+	// mergeRuntimeEnv cap in internal/controller/runner/cell_runtime_env.go.
+	merged := make([]string, 0, len(specEnv))
 	for _, entry := range specEnv {
 		key, _, _ := strings.Cut(entry, "=")
 		if _, override := overrideKeys[key]; override {

--- a/cmd/kuke/create/cell/cell_test.go
+++ b/cmd/kuke/create/cell/cell_test.go
@@ -543,7 +543,7 @@ func TestNewCellCmd_AutocompleteRegistration(t *testing.T) {
 		t.Errorf("unexpected stack flag usage: %q", stackFlag.Usage)
 	}
 
-	for _, name := range []string{"from-blueprint", "from-config", "param", "param-file"} {
+	for _, name := range []string{"from-blueprint", "from-config", "param", "param-file", "env"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("expected %q flag to exist", name)
 		}
@@ -552,7 +552,9 @@ func TestNewCellCmd_AutocompleteRegistration(t *testing.T) {
 
 // blueprintDoc returns a minimal CellBlueprintDoc the fake daemon can hand
 // back from GetBlueprint. One TAG parameter substitutes into the container
-// image so --param coverage has something to verify.
+// image (so --param coverage has something to verify) and into a FOO env entry
+// (so --env precedence — override wins over the resolved binding value — has a
+// baked value to override).
 func blueprintDoc() v1beta1.CellBlueprintDoc {
 	def := "latest"
 	return v1beta1.CellBlueprintDoc{
@@ -569,7 +571,12 @@ func blueprintDoc() v1beta1.CellBlueprintDoc {
 			Parameters: []v1beta1.CellBlueprintParameter{{Name: "TAG", Default: &def}},
 			Cell: v1beta1.BlueprintCellSpec{
 				Containers: []v1beta1.BlueprintContainer{
-					{ID: "main", Image: "registry.example.com/web:${TAG}", Attachable: true},
+					{
+						ID:         "main",
+						Image:      "registry.example.com/web:${TAG}",
+						Env:        []string{"FOO=${TAG}"},
+						Attachable: true,
+					},
 				},
 			},
 		},
@@ -840,4 +847,213 @@ func TestCreateCell_NameCollision_Errors(t *testing.T) {
 	if !strings.Contains(err.Error(), "kuke delete cell taken-name") {
 		t.Errorf("err=%v should point at `kuke delete cell taken-name`", err)
 	}
+}
+
+// TestCreateCell_FromBlueprint_ParamBakedAndRecorded pins AC item 1: a --param
+// override is both baked into the materialised CellDoc (image/env substitution)
+// and recorded in the Spec.Provenance.Params block.
+func TestCreateCell_FromBlueprint_ParamBakedAndRecorded(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var materializeDoc v1beta1.CellDoc
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			materializeDoc = doc
+			return successResultFromDoc(doc), nil
+		},
+	}
+
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "bp-realm")
+	setFlag(t, cmd, "from-blueprint", "web")
+	setFlag(t, cmd, "param", "TAG=v9")
+	cmd.SetArgs([]string{"web-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Baked: ${TAG} substituted into both image and env.
+	if got := materializeDoc.Spec.Containers[0].Image; got != "registry.example.com/web:v9" {
+		t.Errorf("image=%q want ${TAG} substituted to v9", got)
+	}
+	if !containsEnv(materializeDoc.Spec.Containers[0].Env, "FOO=v9") {
+		t.Errorf("env=%v want FOO=v9 (${TAG} baked)", materializeDoc.Spec.Containers[0].Env)
+	}
+	// Recorded: provenance carries the resolved param.
+	prov := materializeDoc.Spec.Provenance
+	if prov == nil {
+		t.Fatal("Spec.Provenance = nil; want a blueprint provenance block")
+	}
+	if got := prov.Params["TAG"]; got != "v9" {
+		t.Errorf("Provenance.Params[TAG]=%q want v9", got)
+	}
+}
+
+// TestCreateCell_FromConfig_EnvBakedAndRecorded pins AC items 2 and 4: --env on
+// the --from-config path is accepted (the old refusal is gone), baked into the
+// attachable container's env, and recorded in Spec.Provenance.EnvOverrides.
+func TestCreateCell_FromConfig_EnvBakedAndRecorded(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var materializeDoc v1beta1.CellDoc
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			materializeDoc = doc
+			return successResultFromDoc(doc), nil
+		},
+	}
+
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "cfg-realm")
+	setFlag(t, cmd, "from-config", "prod")
+	setFlag(t, cmd, "env", "BAR=baz")
+	cmd.SetArgs([]string{"prod-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Baked: BAR=baz appended to the attachable container's env.
+	if !containsEnv(materializeDoc.Spec.Containers[0].Env, "BAR=baz") {
+		t.Errorf("env=%v want BAR=baz baked into the attachable container", materializeDoc.Spec.Containers[0].Env)
+	}
+	// Recorded: provenance carries the env override (distinct from the
+	// non-persisted Spec.RuntimeEnv path — RuntimeEnv stays empty).
+	prov := materializeDoc.Spec.Provenance
+	if prov == nil {
+		t.Fatal("Spec.Provenance = nil; want a config provenance block")
+	}
+	if len(prov.EnvOverrides) != 1 || prov.EnvOverrides[0] != "BAR=baz" {
+		t.Errorf("Provenance.EnvOverrides=%v want [BAR=baz]", prov.EnvOverrides)
+	}
+	if len(materializeDoc.Spec.RuntimeEnv) != 0 {
+		t.Errorf("Spec.RuntimeEnv=%v want empty (override persists, not the runtime form)", materializeDoc.Spec.RuntimeEnv)
+	}
+}
+
+// TestCreateCell_FromConfig_EnvOverridePrecedence pins AC item 3: the merge
+// order is binding values → blueprint params → per-cell --env (override wins).
+// The Config's spec.values resolve FOO=stable into the container env; --env
+// FOO=override then wins for the same key, with no duplicate FOO entry left.
+func TestCreateCell_FromConfig_EnvOverridePrecedence(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var materializeDoc v1beta1.CellDoc
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			materializeDoc = doc
+			return successResultFromDoc(doc), nil
+		},
+	}
+
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "cfg-realm")
+	setFlag(t, cmd, "from-config", "prod")
+	setFlag(t, cmd, "env", "FOO=override")
+	cmd.SetArgs([]string{"prod-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	env := materializeDoc.Spec.Containers[0].Env
+	if !containsEnv(env, "FOO=override") {
+		t.Errorf("env=%v want FOO=override (per-cell --env wins over the resolved binding value)", env)
+	}
+	if containsEnv(env, "FOO=stable") {
+		t.Errorf("env=%v still carries the pre-override FOO=stable; the override must replace it", env)
+	}
+	if n := countEnvKey(env, "FOO"); n != 1 {
+		t.Errorf("env=%v has %d FOO entries; want exactly 1 (override-on-key, not append)", env, n)
+	}
+}
+
+// TestCreateCell_EnvRejectedWithFromBlueprint pins the symmetry counterpart of
+// TestCreateCell_ParamRejectedWithFromConfig: --env is invalid with
+// --from-blueprint and must fail before any client call.
+func TestCreateCell_EnvRejectedWithFromBlueprint(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			t.Fatal("GetBlueprint must not be called when --env + --from-blueprint is rejected")
+			return kukeonv1.GetBlueprintResult{}, nil
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "from-blueprint", "web")
+	setFlag(t, cmd, "env", "K=V")
+	cmd.SetArgs([]string{"x"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --env + --from-blueprint combination")
+	}
+	if !strings.Contains(err.Error(), "--env is not valid with --from-blueprint") {
+		t.Errorf("err=%v want '--env is not valid with --from-blueprint'", err)
+	}
+}
+
+// TestCreateCell_EnvMalformed_Errors pins parse-time --env validation: a
+// missing `=` is rejected before any daemon round-trip.
+func TestCreateCell_EnvMalformed_Errors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	fc := &fakeClient{
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			t.Fatal("GetConfig must not be called when --env is malformed")
+			return kukeonv1.GetConfigResult{}, nil
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "from-config", "prod")
+	setFlag(t, cmd, "env", "NOEQUALS")
+	cmd.SetArgs([]string{"x"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for malformed --env entry")
+	}
+	if !strings.Contains(err.Error(), "--env requires KEY=VALUE") {
+		t.Errorf("err=%v want '--env requires KEY=VALUE'", err)
+	}
+}
+
+// containsEnv reports whether entry appears verbatim in env.
+func containsEnv(env []string, entry string) bool {
+	for _, e := range env {
+		if e == entry {
+			return true
+		}
+	}
+	return false
+}
+
+// countEnvKey counts how many entries in env have the given KEY (substring
+// before the first `=`).
+func countEnvKey(env []string, key string) int {
+	n := 0
+	for _, e := range env {
+		k, _, _ := strings.Cut(e, "=")
+		if k == key {
+			n++
+		}
+	}
+	return n
 }


### PR DESCRIPTION
## Summary

Third step of epic:cell-identity (umbrella #1020). Makes `kuke create cell` carry symmetric per-source override flags, both baked into the materialised CellDoc and recorded as P1 materialization inputs in `Spec.Provenance`:

- `--from-blueprint … --param K=V` — already resolved `${KEY}` into the CellDoc and recorded the resolved map in `Provenance.Params`; this PR adds explicit end-to-end coverage of the bake-and-record contract.
- `--from-config … --env K=V` — **new.** The 1:1-era refusal is replaced by a symmetric one: `--env` is now accepted with `--from-config` and rejected with `--from-blueprint` (the mirror of the existing `--param` rejection with `--from-config`). Each entry is baked into the attachable container's persisted `Env` (so the override survives the stopped-cell persist and takes effect on the later `kuke start`, *unlike* the transport-only `Spec.RuntimeEnv` runtime form `kuke run --env` uses) and recorded in `Provenance.EnvOverrides`.
- **Precedence** (documented inline on the command's Long help, the flag usage, and `applyEnvOverrides`/`mergeEnv` godoc): binding values (Config `spec.values`) → blueprint parameter defaults → per-cell `--env`/`--param` (overrides win, override-on-key). This mirrors the runner-side `mergeRuntimeEnv` merge so a `create cell --env` and a `run --env` resolve identically.

### Implementation notes / non-obvious calls

- **Premise drift:** the issue cited the refusal at `cell.go:181`; downstream churn had moved it to the `if flags.configName != ""` block (lines ~200–211). Implemented against the actual location; the `--param`/`--param-file` refusals there are unchanged, and the new `--env`-with-`--from-blueprint` refusal sits alongside.
- **`--env` targets the attachable container only**, matching the established `kuke run --env` (#834) semantics the issue points at as the existing plumbing. `resolveAttachableContainerIndex` mirrors the daemon-side `resolveAttachableContainerID` precedence (tty.default → first attachable). When no container is attachable the override is still recorded in provenance (operator intent preserved) but has nowhere to bake — same silent no-op as the runtime path.
- **`parseEnvArgs` is duplicated locally** (mirrors `cmd/kuke/run.parseEnvArgs`), following the existing in-package `buildParamMap` precedent ("kept local to avoid a cross-package import").
- Rebased onto current `origin/main`; resolved a conflict with #1089's `finalizeCellName` (both the name-resolution and env-overlay steps now run after `overlayScope` on the config path).

## Test plan

- [x] `make test` (full CI target, `GOWORK=off` test-root + test-kukebuild) — green on the rebased tree.
- [x] `make dev-init` smoke — green: daemon-parity tail shows both realms `Ready` in the daemon and `--no-daemon` views, `kukeond is ready`, attach smoke (`cattach`) created + purged cleanly.
- [x] New unit tests in `cmd/kuke/create/cell/cell_test.go`:
  - `--param` baked (image + env `${TAG}` substitution) and recorded in `Provenance.Params`.
  - `--env` accepted with `--from-config`, baked into the attachable container, recorded in `Provenance.EnvOverrides`, and `Spec.RuntimeEnv` left empty (persists, not the runtime form).
  - precedence: `--env FOO=override` wins over the Config-resolved `FOO=stable`, exactly one `FOO` entry (override-on-key).
  - `--env` rejected with `--from-blueprint`; malformed `--env` rejected at parse time.

## Acceptance criteria

- [x] `--from-blueprint --param K=V` bakes params into the CellDoc and records them in provenance.
- [x] `--from-config --env K=V` is accepted (old refusal removed), baked, and recorded.
- [x] Override precedence (binding → params → per-cell env/param) documented inline and covered by a test.
- [x] Per-cell overrides persist (distinct from the non-persisted `Spec.RuntimeEnv` runtime path).
- [x] `go build ./...` + `go test ./...` clean (`GOWORK=off`); `make dev-init` smoke passes.

Closes #1023