### PR TITLE
feat(create): add --clone <cell> source kind to fork a cell's recipe

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -213,6 +213,13 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CELL_FROM_CONFIG = DefineKV("KUKE_CREATE_CELL_FROM_CONFIG", "kuke/create/cell/from-config")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	// KUKE_CREATE_CELL_CLONE is the env-var twin of `kuke create cell --clone
+	// <src>` (epic:cell-identity #1073): the third source kind alongside
+	// --from-blueprint / --from-config. Forks the named source cell's recipe
+	// (its Spec.Provenance, with any per-cell --env/--param overrides) into a
+	// new cell.
+	KUKE_CREATE_CELL_CLONE = DefineKV("KUKE_CREATE_CELL_CLONE", "kuke/create/cell/clone")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_CREATE_CELL_PARAM_FILE = DefineKV("KUKE_CREATE_CELL_PARAM_FILE", "kuke/create/cell/param-file")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	// KUKE_CREATE_CELL_IGNORE_DISK_PRESSURE is the env-var twin of

--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -102,6 +102,16 @@ func NewCellCmd() *cobra.Command {
 			"Mutually exclusive with --from-blueprint.")
 	_ = viper.BindPFlag(config.KUKE_CREATE_CELL_FROM_CONFIG.ViperKey, cmd.Flags().Lookup("from-config"))
 
+	cmd.Flags().String("clone", "",
+		"Fork an existing cell's recipe into a new cell: read the source cell's "+
+			"Spec.Provenance (the binding it was materialised from plus any per-cell "+
+			"--param/--env overrides), re-materialise from that same binding, and persist a "+
+			"new stopped cell. The clone copies the source's Spec.Provenance verbatim, inherits "+
+			"its kukeon.io/config or kukeon.io/blueprint lineage label, and carries a "+
+			"kukeon.io/source-cell=<src> annotation. Omitted name → <source-name>-<6hex>; "+
+			"explicit name used verbatim. Mutually exclusive with --from-blueprint/--from-config.")
+	_ = viper.BindPFlag(config.KUKE_CREATE_CELL_CLONE.ViperKey, cmd.Flags().Lookup("clone"))
+
 	cmd.Flags().StringArray("param", nil,
 		"Scalar parameter override as KEY=VALUE; repeatable. Valid with --from-blueprint. "+
 			"Each KEY must be declared in spec.parameters[]. Wins over the parameter's default "+
@@ -131,7 +141,7 @@ func NewCellCmd() *cobra.Command {
 		cmd.Flags().Lookup("ignore-disk-pressure"),
 	)
 
-	cmd.MarkFlagsMutuallyExclusive("from-blueprint", "from-config")
+	cmd.MarkFlagsMutuallyExclusive("from-blueprint", "from-config", "clone")
 
 	// Register autocomplete functions for flags
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
@@ -139,6 +149,7 @@ func NewCellCmd() *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
 	_ = cmd.RegisterFlagCompletionFunc("from-blueprint", config.CompleteBlueprintNames)
 	_ = cmd.RegisterFlagCompletionFunc("from-config", config.CompleteConfigNames)
+	_ = cmd.RegisterFlagCompletionFunc("clone", config.CompleteCellNames)
 
 	return cmd
 }
@@ -152,8 +163,13 @@ type createCellFlags struct {
 	stack         string
 	blueprintName string
 	configName    string
-	paramArgs     []string
-	paramFile     string
+	// cloneSource is the source cell name passed via `--clone <src>` (the
+	// third source kind, epic:cell-identity #1073). When set, the cell is
+	// forked from the source cell's Spec.Provenance rather than resolved from a
+	// Blueprint/Config named on the CLI.
+	cloneSource string
+	paramArgs   []string
+	paramFile   string
 	// envArgs holds the validated `--env KEY=VALUE` per-cell overrides. Valid
 	// with --from-config only (parity with --param on --from-blueprint); baked
 	// into the attachable container's env and recorded in
@@ -182,25 +198,37 @@ func parseCreateCellFlags(cmd *cobra.Command, args []string) (createCellFlags, e
 	flags := createCellFlags{
 		blueprintName: strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_FROM_BLUEPRINT.ViperKey)),
 		configName:    strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_FROM_CONFIG.ViperKey)),
+		cloneSource:   strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_CLONE.ViperKey)),
 		paramFile:     strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_PARAM_FILE.ViperKey)),
 	}
 
-	if flags.blueprintName == "" && flags.configName == "" {
+	if flags.blueprintName == "" && flags.configName == "" && flags.cloneSource == "" {
 		return createCellFlags{}, errors.New(
-			"kuke create cell requires --from-blueprint or --from-config (use 'kuke apply -f <file>' for a full manifest)",
+			"kuke create cell requires --from-blueprint, --from-config, or --clone " +
+				"(use 'kuke apply -f <file>' for a full manifest)",
 		)
 	}
 
-	name, err := shared.RequireNameArgOrDefault(
-		cmd,
-		args,
-		"cell",
-		viper.GetString(config.KUKE_CREATE_CELL_NAME.ViperKey),
-	)
-	if err != nil {
-		return createCellFlags{}, err
+	// The clone source kind supports an omitted name (auto-generated
+	// `<source-name>-<6hex>`, AC#2 of #1073), so it does not require the
+	// positional/viper name the --from-blueprint / --from-config paths demand.
+	// finalizeCellName resolves the empty name to a generated one.
+	if flags.cloneSource != "" {
+		flags.name = optionalNameArgOrDefault(
+			args, viper.GetString(config.KUKE_CREATE_CELL_NAME.ViperKey),
+		)
+	} else {
+		name, err := shared.RequireNameArgOrDefault(
+			cmd,
+			args,
+			"cell",
+			viper.GetString(config.KUKE_CREATE_CELL_NAME.ViperKey),
+		)
+		if err != nil {
+			return createCellFlags{}, err
+		}
+		flags.name = name
 	}
-	flags.name = name
 
 	flags.realm = strings.TrimSpace(viper.GetString(config.KUKE_CREATE_CELL_REALM.ViperKey))
 	if flags.realm == "" {
@@ -267,10 +295,14 @@ func runCreateCell(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = client.Close() }()
 
-	if flags.blueprintName != "" {
+	switch {
+	case flags.cloneSource != "":
+		return runClone(cmd, client, flags)
+	case flags.blueprintName != "":
 		return runFromBlueprint(cmd, client, flags)
+	default:
+		return runFromConfig(cmd, client, flags)
 	}
-	return runFromConfig(cmd, client, flags)
 }
 
 // runFromBlueprint resolves the named Blueprint, applies --param/--param-file,

--- a/cmd/kuke/create/cell/cell_test.go
+++ b/cmd/kuke/create/cell/cell_test.go
@@ -259,10 +259,10 @@ func TestNewCellCmdRunE_RequiresSourceFlag(t *testing.T) {
 
 			err := cmd.Execute()
 			if err == nil {
-				t.Fatal("expected error when neither --from-blueprint nor --from-config is set")
+				t.Fatal("expected error when no source flag (--from-blueprint/--from-config/--clone) is set")
 			}
-			if !strings.Contains(err.Error(), "requires --from-blueprint or --from-config") {
-				t.Errorf("err=%v want 'requires --from-blueprint or --from-config'", err)
+			if !strings.Contains(err.Error(), "requires --from-blueprint, --from-config, or --clone") {
+				t.Errorf("err=%v want 'requires --from-blueprint, --from-config, or --clone'", err)
 			}
 			if !strings.Contains(err.Error(), "kuke apply -f") {
 				t.Errorf("err=%v should point at `kuke apply -f <file>`", err)
@@ -543,7 +543,7 @@ func TestNewCellCmd_AutocompleteRegistration(t *testing.T) {
 		t.Errorf("unexpected stack flag usage: %q", stackFlag.Usage)
 	}
 
-	for _, name := range []string{"from-blueprint", "from-config", "param", "param-file", "env"} {
+	for _, name := range []string{"from-blueprint", "from-config", "clone", "param", "param-file", "env"} {
 		if cmd.Flags().Lookup(name) == nil {
 			t.Errorf("expected %q flag to exist", name)
 		}

--- a/cmd/kuke/create/cell/clone.go
+++ b/cmd/kuke/create/cell/clone.go
@@ -1,0 +1,330 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cell
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+)
+
+// AnnotationSourceCell is the inert provenance annotation a clone carries,
+// recording the cell it was forked from (epic:cell-identity #1073). Distinct
+// from the load-bearing kukeon.io/config / kukeon.io/blueprint lineage labels:
+// no reconcile or selector path keys off it, DiffCell does not compare it, and
+// it pins no identity — it is debug/grooming metadata only. Stored under the
+// `kukeon.io/` prefix (not the `.kukeon.io` controller-managed suffix) so it
+// reads as cell-authored provenance.
+const AnnotationSourceCell = "kukeon.io/source-cell"
+
+// optionalNameArgOrDefault resolves an optional cell name from the positional
+// argument or the viper fallback, returning "" when neither is set. Unlike
+// shared.RequireNameArgOrDefault it does not error on an omitted name — the
+// clone source kind auto-generates `<source-name>-<6hex>` for an empty name
+// (AC#2 of #1073).
+func optionalNameArgOrDefault(args []string, fallback string) string {
+	if len(args) > 0 {
+		if name := strings.TrimSpace(args[0]); name != "" {
+			return name
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+// runClone implements the third source kind, `kuke create cell --clone <src>`
+// (epic:cell-identity #1073). It forks an existing cell's recipe into a new
+// cell:
+//
+//  1. Resolve the source cell at the operator's --realm/--space/--stack scope
+//     and read its Spec.Provenance — the persisted record (P1) of the binding
+//     it was materialised from plus any per-cell --param/--env overrides. A
+//     source with no provenance (a hand-built cell never materialised from a
+//     binding) cannot be cloned.
+//  2. Re-materialise a fresh spec from that same binding (the same Config /
+//     Blueprint materialisation the --from-config / --from-blueprint paths
+//     run), re-applying the source's recorded params/env overrides and stacking
+//     any additional --param/--env from the clone command on top
+//     (last-write-wins, AC#6). The per-path override symmetry from P3 holds:
+//     --env stacks on a config-lineage clone (--param rejected); --param stacks
+//     on a blueprint-lineage clone (--env rejected).
+//  3. Copy the source's Spec.Provenance onto the clone so a plain clone (no
+//     extra overrides) is byte-equal to the source's (AC#1); stacked overrides
+//     are merged into that copy.
+//  4. Inherit the lineage label (set by materialisation), stamp the
+//     kukeon.io/source-cell annotation, target the source cell's scope, and
+//     finalise the name (<source-name>-<6hex> when omitted; verbatim when
+//     explicit) before the collision-checked persist.
+func runClone(cmd *cobra.Command, client kukeonv1.Client, flags createCellFlags) error {
+	src, err := resolveSourceCell(cmd, client, flags)
+	if err != nil {
+		return err
+	}
+	srcProv := src.Spec.Provenance
+	if srcProv == nil {
+		return fmt.Errorf(
+			"cannot clone cell %q: it carries no materialization provenance "+
+				"(only cells created from a Blueprint or Config can be cloned)",
+			src.Metadata.Name,
+		)
+	}
+
+	var cellDoc v1beta1.CellDoc
+	switch srcProv.BindingKind {
+	case v1beta1.BindingKindConfig:
+		cellDoc, err = cloneFromConfig(cmd, client, flags, srcProv)
+	case v1beta1.BindingKindBlueprint:
+		cellDoc, err = cloneFromBlueprint(cmd, client, flags, srcProv)
+	default:
+		return fmt.Errorf(
+			"cannot clone cell %q: unrecognized provenance bindingKind %q",
+			src.Metadata.Name, srcProv.BindingKind,
+		)
+	}
+	if err != nil {
+		return err
+	}
+
+	// The clone targets the source cell's scope (realm/space/stack), not the
+	// binding's — cross-scope cloning is out of scope for #1073.
+	cellDoc.Spec.RealmID = src.Spec.RealmID
+	cellDoc.Spec.SpaceID = src.Spec.SpaceID
+	cellDoc.Spec.StackID = src.Spec.StackID
+
+	setSourceCellAnnotation(&cellDoc, src.Metadata.Name)
+
+	// Prefix derives from the source cell's metadata.name: a materialized cell
+	// carries no Spec.Prefix field (only the Blueprint/Config bindings do), so
+	// the proposal's `Spec.Prefix ?? metadata.name` collapses to metadata.name.
+	if err = finalizeCellName(cmd, client, &cellDoc, flags.name, src.Metadata.Name); err != nil {
+		return err
+	}
+	applyIgnoreDiskPressure(&cellDoc, flags)
+
+	return materialiseAndPersist(cmd, client, cellDoc)
+}
+
+// resolveSourceCell fetches the cell named by --clone at the operator's
+// --realm/--space/--stack scope. Unlike the from-blueprint / from-config
+// binding lookups (which use ExplicitScope so a realm-scoped binding stays
+// findable with empty space/stack), a cell always lives at a full
+// realm/space/stack, so the source lookup uses the defaulted flags scope
+// (default/default/default when the operator passes no coordinate). A missing
+// source cell is a clear ErrCellNotFound.
+func resolveSourceCell(
+	cmd *cobra.Command, client kukeonv1.Client, flags createCellFlags,
+) (v1beta1.CellDoc, error) {
+	lookup := v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: flags.cloneSource},
+		Spec: v1beta1.CellSpec{
+			RealmID: flags.realm,
+			SpaceID: flags.space,
+			StackID: flags.stack,
+		},
+	}
+	res, err := client.GetCell(cmd.Context(), lookup)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrCellNotFound) {
+			return v1beta1.CellDoc{}, fmt.Errorf(
+				"%w (source cell %q in scope realm=%q space=%q stack=%q)",
+				errdefs.ErrCellNotFound, lookup.Metadata.Name,
+				lookup.Spec.RealmID, lookup.Spec.SpaceID, lookup.Spec.StackID,
+			)
+		}
+		return v1beta1.CellDoc{}, err
+	}
+	if !res.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (source cell %q in scope realm=%q space=%q stack=%q)",
+			errdefs.ErrCellNotFound, lookup.Metadata.Name,
+			lookup.Spec.RealmID, lookup.Spec.SpaceID, lookup.Spec.StackID,
+		)
+	}
+	return res.Cell, nil
+}
+
+// cloneFromConfig re-materialises a config-lineage clone from the source's
+// provenance binding ref. --param/--param-file are rejected (the Config carries
+// its own spec.values, mirroring the --from-config path); --env stacks on top
+// of the source's recorded env overrides (last-write-wins). The returned doc's
+// Spec.Provenance is the source's copied verbatim, with the merged env
+// overrides recorded — byte-equal to the source when no extra --env is given.
+func cloneFromConfig(
+	cmd *cobra.Command, client kukeonv1.Client, flags createCellFlags, srcProv *v1beta1.CellProvenance,
+) (v1beta1.CellDoc, error) {
+	if len(flags.paramArgs) > 0 {
+		return v1beta1.CellDoc{}, errors.New(
+			"--param is not valid when cloning a Config-lineage cell; the lineage Config carries " +
+				"its own spec.values (edit the Config instead)",
+		)
+	}
+	if flags.paramFile != "" {
+		return v1beta1.CellDoc{}, errors.New(
+			"--param-file is not valid when cloning a Config-lineage cell; the lineage Config " +
+				"carries its own spec.values (edit the Config instead)",
+		)
+	}
+
+	ref := srcProv.BindingRef
+	cfgLookup := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata: v1beta1.CellConfigMetadata{
+			Name:  ref.Name,
+			Realm: ref.Realm,
+			Space: ref.Space,
+			Stack: ref.Stack,
+		},
+	}
+	cfgRes, err := client.GetConfig(cmd.Context(), cfgLookup)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !cfgRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (lineage config %q in scope realm=%q space=%q stack=%q referenced by clone source)",
+			errdefs.ErrConfigNotFound, ref.Name, ref.Realm, ref.Space, ref.Stack,
+		)
+	}
+
+	bpRef := cfgRes.Config.Spec.Blueprint
+	bpRes, err := client.GetBlueprint(cmd.Context(), v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  bpRef.Name,
+			Realm: bpRef.Realm,
+			Space: bpRef.Space,
+			Stack: bpRef.Stack,
+		},
+	})
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !bpRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (blueprint %q referenced by lineage config %q)",
+			errdefs.ErrBlueprintNotFound, bpRef.Name, cfgRes.Config.Metadata.Name,
+		)
+	}
+
+	cellDoc, err := cellconfig.MaterializeWithName(cfgRes.Config, bpRes.Blueprint, flags.name)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+
+	// Copy the source's provenance verbatim (AC#1), then re-bake its env
+	// overrides plus any additional --env (AC#6). applyEnvOverrides reads
+	// Spec.Provenance.EnvOverrides as the merged set, so set provenance first.
+	cellDoc.Spec.Provenance = v1beta1.CloneCellProvenance(srcProv)
+	mergedEnv := mergeEnv(srcProv.EnvOverrides, flags.envArgs)
+	applyEnvOverrides(&cellDoc, mergedEnv)
+	return cellDoc, nil
+}
+
+// cloneFromBlueprint re-materialises a blueprint-lineage clone from the
+// source's provenance binding ref. --env is rejected (its symmetric
+// counterpart, mirroring the --from-blueprint path); --param/--param-file stack
+// on top of the source's recorded params (last-write-wins). The returned doc's
+// Spec.Provenance is the source's copied verbatim, with the merged params
+// recorded — byte-equal to the source when no extra --param is given.
+func cloneFromBlueprint(
+	cmd *cobra.Command, client kukeonv1.Client, flags createCellFlags, srcProv *v1beta1.CellProvenance,
+) (v1beta1.CellDoc, error) {
+	if len(flags.envArgs) > 0 {
+		return v1beta1.CellDoc{}, errors.New(
+			"--env is not valid when cloning a Blueprint-lineage cell; clone a Config-lineage cell " +
+				"(or edit the Blueprint) to layer env overrides",
+		)
+	}
+
+	ref := srcProv.BindingRef
+	bpRes, err := client.GetBlueprint(cmd.Context(), v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{
+			Name:  ref.Name,
+			Realm: ref.Realm,
+			Space: ref.Space,
+			Stack: ref.Stack,
+		},
+	})
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	if !bpRes.MetadataExists {
+		return v1beta1.CellDoc{}, fmt.Errorf(
+			"%w (lineage blueprint %q in scope realm=%q space=%q stack=%q referenced by clone source)",
+			errdefs.ErrBlueprintNotFound, ref.Name, ref.Realm, ref.Space, ref.Stack,
+		)
+	}
+
+	// Stack additional --param/--param-file on top of the source's recorded
+	// params (last-write-wins via MergeParams' CLI-wins contract).
+	cliParams, err := buildParamMap(flags)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	mergedParams := mergeParamMaps(srcProv.Params, cliParams)
+
+	resolved, err := cellblueprint.Resolve(bpRes.Blueprint, mergedParams, os.LookupEnv)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+	cellDoc, err := cellblueprint.MaterializeWithName(resolved, flags.name, mergedParams)
+	if err != nil {
+		return v1beta1.CellDoc{}, err
+	}
+
+	// Copy the source's provenance verbatim (AC#1), then record the merged
+	// params (AC#6) — byte-equal to the source when no additional --param.
+	cellDoc.Spec.Provenance = v1beta1.CloneCellProvenance(srcProv)
+	if len(mergedParams) > 0 {
+		cellDoc.Spec.Provenance.Params = mergedParams
+	}
+	return cellDoc, nil
+}
+
+// mergeParamMaps layers override params on top of base params (override wins on
+// a key collision, last-write-wins per AC#6). Returns a fresh map; never
+// mutates either input. A nil/empty result stays nil so a no-override clone's
+// provenance is byte-equal to the source's.
+func mergeParamMaps(base, override map[string]string) map[string]string {
+	if len(base) == 0 && len(override) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(base)+len(override))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range override {
+		out[k] = v
+	}
+	return out
+}
+
+// setSourceCellAnnotation stamps the inert kukeon.io/source-cell provenance
+// annotation on the clone, recording the cell it was forked from (#1073).
+func setSourceCellAnnotation(doc *v1beta1.CellDoc, sourceName string) {
+	if doc.Metadata.Annotations == nil {
+		doc.Metadata.Annotations = map[string]string{}
+	}
+	doc.Metadata.Annotations[AnnotationSourceCell] = sourceName
+}

--- a/cmd/kuke/create/cell/clone_test.go
+++ b/cmd/kuke/create/cell/clone_test.go
@@ -1,0 +1,453 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cell_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	cell "github.com/eminwux/kukeon/cmd/kuke/create/cell"
+	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/cellconfig"
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// sourceConfigCell is a Config-lineage source cell the fake daemon hands back
+// for `--clone`: provenance points at the configDoc()/blueprintDoc() binding,
+// carries the kukeon.io/config lineage label, and records a per-cell env
+// override (P3) so byte-equality and env-stacking can be exercised.
+func sourceConfigCell() v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   "prod-a1b2c3",
+			Labels: map[string]string{cellconfig.LabelConfig: "prod"},
+		},
+		Spec: v1beta1.CellSpec{
+			ID:      "prod-a1b2c3",
+			RealmID: "cfg-realm",
+			SpaceID: "cfg-space",
+			StackID: "cfg-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "main", Image: "registry.example.com/web:stable", Env: []string{"FOO=stable"}, Attachable: true},
+			},
+			Provenance: &v1beta1.CellProvenance{
+				BindingKind: v1beta1.BindingKindConfig,
+				BindingRef: v1beta1.CellBindingRef{
+					Name: "prod", Realm: "cfg-realm", Space: "cfg-space", Stack: "cfg-stack",
+				},
+				Params:       map[string]string{"TAG": "stable"},
+				EnvOverrides: []string{"DEBUG=1"},
+			},
+		},
+	}
+}
+
+// sourceBlueprintCell is a Blueprint-lineage source cell: provenance points at
+// blueprintDoc(), carries the kukeon.io/blueprint lineage label, and records a
+// resolved --param (P1) so param-stacking can be exercised.
+func sourceBlueprintCell() v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata: v1beta1.CellMetadata{
+			Name:   "web-x9y8z7",
+			Labels: map[string]string{cellblueprint.LabelBlueprint: "web"},
+		},
+		Spec: v1beta1.CellSpec{
+			ID:      "web-x9y8z7",
+			RealmID: "bp-realm",
+			SpaceID: "bp-space",
+			StackID: "bp-stack",
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "main", Image: "registry.example.com/web:custom", Attachable: true},
+			},
+			Provenance: &v1beta1.CellProvenance{
+				BindingKind: v1beta1.BindingKindBlueprint,
+				BindingRef: v1beta1.CellBindingRef{
+					Name: "web", Realm: "bp-realm", Space: "bp-space", Stack: "bp-stack",
+				},
+				Params: map[string]string{"TAG": "custom"},
+			},
+		},
+	}
+}
+
+// cloneFakeClient wires a fake daemon for the clone path: GetCell returns the
+// source cell by name (and not-found for the would-be clone name, so the
+// pre-persist collision check and any auto-name probe see a clean slate),
+// GetConfig/GetBlueprint hand back the lineage binding, and MaterializeCell
+// captures the final doc.
+func cloneFakeClient(t *testing.T, src v1beta1.CellDoc, captured *v1beta1.CellDoc) *fakeClient {
+	t.Helper()
+	return &fakeClient{
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			if doc.Metadata.Name == src.Metadata.Name {
+				return kukeonv1.GetCellResult{Cell: src, MetadataExists: true}, nil
+			}
+			return kukeonv1.GetCellResult{MetadataExists: false}, errdefs.ErrCellNotFound
+		},
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			*captured = doc
+			return successResultFromDoc(doc), nil
+		},
+	}
+}
+
+func setSourceScope(t *testing.T, cmd *cobra.Command, src v1beta1.CellDoc) {
+	t.Helper()
+	setFlag(t, cmd, "realm", src.Spec.RealmID)
+	setFlag(t, cmd, "space", src.Spec.SpaceID)
+	setFlag(t, cmd, "stack", src.Spec.StackID)
+}
+
+// TestClone_FromConfigLineage_ExplicitName covers AC#1 (provenance byte-equal),
+// AC#2 (explicit name verbatim), AC#3 (inherits kukeon.io/config lineage
+// label), and AC#4 (kukeon.io/source-cell annotation).
+func TestClone_FromConfigLineage_ExplicitName(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceConfigCell()
+	var got v1beta1.CellDoc
+	fc := cloneFakeClient(t, src, &got)
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	cmd.SetArgs([]string{"myclone"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Metadata.Name != "myclone" {
+		t.Errorf("clone name = %q, want %q (explicit verbatim)", got.Metadata.Name, "myclone")
+	}
+	if got.Spec.ID != "myclone" {
+		t.Errorf("clone Spec.ID = %q, want %q", got.Spec.ID, "myclone")
+	}
+	// AC#1: provenance byte-equal to source's (the persisted/serialized form).
+	assertProvenanceByteEqual(t, got.Spec.Provenance, src.Spec.Provenance)
+	// AC#3: lineage label inherited (re-stamped by materialisation).
+	if got.Metadata.Labels[cellconfig.LabelConfig] != "prod" {
+		t.Errorf("clone missing kukeon.io/config=prod lineage label; labels=%v", got.Metadata.Labels)
+	}
+	// AC#4: source-cell annotation.
+	if got.Metadata.Annotations[cell.AnnotationSourceCell] != src.Metadata.Name {
+		t.Errorf("clone source-cell annotation = %q, want %q",
+			got.Metadata.Annotations[cell.AnnotationSourceCell], src.Metadata.Name)
+	}
+	// Clone targets the source cell's scope.
+	if got.Spec.RealmID != src.Spec.RealmID || got.Spec.SpaceID != src.Spec.SpaceID ||
+		got.Spec.StackID != src.Spec.StackID {
+		t.Errorf("clone scope = %s/%s/%s, want source scope %s/%s/%s",
+			got.Spec.RealmID, got.Spec.SpaceID, got.Spec.StackID,
+			src.Spec.RealmID, src.Spec.SpaceID, src.Spec.StackID)
+	}
+	// The source's env override is re-baked into the attachable container.
+	if !containerEnvHas(got, "main", "DEBUG=1") {
+		t.Errorf("clone container env missing source override DEBUG=1; got %v", got.Spec.Containers)
+	}
+}
+
+// TestClone_AutoName covers AC#2: an omitted name yields <source-name>-<6hex>.
+func TestClone_AutoName(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceConfigCell()
+	var got v1beta1.CellDoc
+	fc := cloneFakeClient(t, src, &got)
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	prefix := src.Metadata.Name + "-"
+	if !strings.HasPrefix(got.Metadata.Name, prefix) {
+		t.Fatalf("auto-name %q does not start with %q", got.Metadata.Name, prefix)
+	}
+	suffix := strings.TrimPrefix(got.Metadata.Name, prefix)
+	if len(suffix) != 6 {
+		t.Errorf("auto-name suffix %q is %d chars, want 6 hex", suffix, len(suffix))
+	}
+	if got.Spec.ID != got.Metadata.Name {
+		t.Errorf("Spec.ID %q != metadata.name %q", got.Spec.ID, got.Metadata.Name)
+	}
+}
+
+// TestClone_FromBlueprintLineage covers the blueprint source kind: provenance
+// byte-equal (AC#1), kukeon.io/blueprint lineage inherited (AC#3), source-cell
+// annotation (AC#4).
+func TestClone_FromBlueprintLineage(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceBlueprintCell()
+	var got v1beta1.CellDoc
+	fc := cloneFakeClient(t, src, &got)
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	cmd.SetArgs([]string{"bpclone"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertProvenanceByteEqual(t, got.Spec.Provenance, src.Spec.Provenance)
+	if got.Metadata.Labels[cellblueprint.LabelBlueprint] != "web" {
+		t.Errorf("clone missing kukeon.io/blueprint=web lineage label; labels=%v", got.Metadata.Labels)
+	}
+	if got.Metadata.Annotations[cell.AnnotationSourceCell] != src.Metadata.Name {
+		t.Errorf("clone source-cell annotation = %q, want %q",
+			got.Metadata.Annotations[cell.AnnotationSourceCell], src.Metadata.Name)
+	}
+}
+
+// TestClone_EnvStacking covers AC#6 on the config path: additional --env stacks
+// on top of the source's recorded overrides (last-write-wins).
+func TestClone_EnvStacking(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceConfigCell()
+	var got v1beta1.CellDoc
+	fc := cloneFakeClient(t, src, &got)
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	setFlag(t, cmd, "env", "DEBUG=2") // overrides source's DEBUG=1
+	setFlag(t, cmd, "env", "EXTRA=x") // new key stacks on top
+	cmd.SetArgs([]string{"stacked"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Spec.Provenance == nil {
+		t.Fatal("clone provenance is nil")
+	}
+	if !slicesContain(got.Spec.Provenance.EnvOverrides, "DEBUG=2") ||
+		!slicesContain(got.Spec.Provenance.EnvOverrides, "EXTRA=x") {
+		t.Errorf("provenance EnvOverrides = %v, want DEBUG=2 + EXTRA=x", got.Spec.Provenance.EnvOverrides)
+	}
+	if slicesContain(got.Spec.Provenance.EnvOverrides, "DEBUG=1") {
+		t.Errorf("provenance EnvOverrides still carries overridden DEBUG=1: %v", got.Spec.Provenance.EnvOverrides)
+	}
+	if !containerEnvHas(got, "main", "DEBUG=2") {
+		t.Errorf("clone container env missing stacked DEBUG=2; got %v", got.Spec.Containers)
+	}
+}
+
+// TestClone_ParamStacking covers AC#6 on the blueprint path: additional --param
+// stacks on top of the source's recorded params (last-write-wins).
+func TestClone_ParamStacking(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceBlueprintCell()
+	var got v1beta1.CellDoc
+	fc := cloneFakeClient(t, src, &got)
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	setFlag(t, cmd, "param", "TAG=override")
+	cmd.SetArgs([]string{"pclone"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Spec.Provenance == nil || got.Spec.Provenance.Params["TAG"] != "override" {
+		t.Errorf("provenance Params = %v, want TAG=override", got.Spec.Provenance.Params)
+	}
+	// The stacked param flows into the resolved image.
+	if !containerImageHas(got, "main", "override") {
+		t.Errorf("clone container image did not pick up TAG=override; got %v", got.Spec.Containers)
+	}
+}
+
+func TestClone_RejectsParamOnConfigLineage(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceConfigCell()
+	var got v1beta1.CellDoc
+	fc := cloneFakeClient(t, src, &got)
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	setFlag(t, cmd, "param", "TAG=x")
+	cmd.SetArgs([]string{"badclone"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--param is not valid when cloning a Config-lineage cell") {
+		t.Fatalf("err = %v, want --param rejection on config-lineage clone", err)
+	}
+}
+
+func TestClone_RejectsEnvOnBlueprintLineage(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceBlueprintCell()
+	var got v1beta1.CellDoc
+	fc := cloneFakeClient(t, src, &got)
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	setFlag(t, cmd, "env", "DEBUG=1")
+	cmd.SetArgs([]string{"badclone"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "--env is not valid when cloning a Blueprint-lineage cell") {
+		t.Fatalf("err = %v, want --env rejection on blueprint-lineage clone", err)
+	}
+}
+
+func TestClone_SourceNotFound(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	fc := &fakeClient{
+		getCellFn: func(v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{MetadataExists: false}, errdefs.ErrCellNotFound
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "realm", "cfg-realm")
+	setFlag(t, cmd, "clone", "ghost")
+	cmd.SetArgs([]string{"newclone"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "source cell") {
+		t.Fatalf("err = %v, want source-cell-not-found", err)
+	}
+}
+
+func TestClone_SourceNoProvenance(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceConfigCell()
+	src.Spec.Provenance = nil // hand-built cell, never materialised from a binding
+	var got v1beta1.CellDoc
+	fc := cloneFakeClient(t, src, &got)
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	cmd.SetArgs([]string{"newclone"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no materialization provenance") {
+		t.Fatalf("err = %v, want no-provenance rejection", err)
+	}
+}
+
+// TestClone_ExplicitNameCollisionErrors covers AC#2: an explicit name that
+// already exists in scope errors (not an idempotent attach).
+func TestClone_ExplicitNameCollisionErrors(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	src := sourceConfigCell()
+	fc := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			// Both the source lookup and the clone-name collision probe hit.
+			return kukeonv1.GetCellResult{Cell: src, MetadataExists: true}, nil
+		},
+		getConfigFn: func(v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			t.Fatal("MaterializeCell must not be called on a name collision")
+			return kukeonv1.CreateCellResult{}, nil
+		},
+	}
+	cmd, _ := newTestExecCmd(t, fc)
+	setSourceScope(t, cmd, src)
+	setFlag(t, cmd, "clone", src.Metadata.Name)
+	cmd.SetArgs([]string{"taken"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("err = %v, want already-exists collision error", err)
+	}
+}
+
+// TestClone_MutuallyExclusive covers AC#5: --clone with another source flag
+// errors at parse time (cobra mutex).
+func TestClone_MutuallyExclusive(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	fc := &fakeClient{}
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "clone", "src")
+	setFlag(t, cmd, "from-config", "prod")
+	cmd.SetArgs([]string{"newclone"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "if any flags in the group") {
+		t.Fatalf("err = %v, want cobra mutual-exclusivity error", err)
+	}
+}
+
+// assertProvenanceByteEqual compares the serialized (persisted) form of two
+// provenance blocks — the sense in which AC#1 means "byte-equal". JSON marshal
+// folds the cosmetic nil-vs-empty-slice difference CloneCellProvenance
+// introduces (both omitempty away), which reflect.DeepEqual would flag despite
+// identical on-disk metadata.json.
+func assertProvenanceByteEqual(t *testing.T, got, want *v1beta1.CellProvenance) {
+	t.Helper()
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal clone provenance: %v", err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal source provenance: %v", err)
+	}
+	if string(gotJSON) != string(wantJSON) {
+		t.Errorf("clone provenance not byte-equal to source's:\n got=%s\nwant=%s", gotJSON, wantJSON)
+	}
+}
+
+func containerEnvHas(doc v1beta1.CellDoc, containerID, entry string) bool {
+	for _, c := range doc.Spec.Containers {
+		if c.ID == containerID {
+			return slicesContain(c.Env, entry)
+		}
+	}
+	return false
+}
+
+func containerImageHas(doc v1beta1.CellDoc, containerID, substr string) bool {
+	for _, c := range doc.Spec.Containers {
+		if c.ID == containerID {
+			return strings.Contains(c.Image, substr)
+		}
+	}
+	return false
+}
+
+func slicesContain(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/apischeme/scheme.go
+++ b/internal/apischeme/scheme.go
@@ -1402,9 +1402,10 @@ func ConvertCellDocToInternal(in ext.CellDoc) (intmodel.Cell, error) {
 		}
 		cell := intmodel.Cell{
 			Metadata: intmodel.CellMetadata{
-				Name:       in.Metadata.Name,
-				Labels:     in.Metadata.Labels,
-				Generation: in.Metadata.Generation,
+				Name:        in.Metadata.Name,
+				Labels:      in.Metadata.Labels,
+				Annotations: in.Metadata.Annotations,
+				Generation:  in.Metadata.Generation,
 			},
 			Spec: intmodel.CellSpec{
 				ID:                  in.Spec.ID,
@@ -1485,9 +1486,10 @@ func BuildCellExternalFromInternal(in intmodel.Cell, apiVersion ext.Version) (ex
 			APIVersion: VersionV1Beta1,
 			Kind:       ext.KindCell,
 			Metadata: ext.CellMetadata{
-				Name:       in.Metadata.Name,
-				Labels:     in.Metadata.Labels,
-				Generation: in.Metadata.Generation,
+				Name:        in.Metadata.Name,
+				Labels:      in.Metadata.Labels,
+				Annotations: in.Metadata.Annotations,
+				Generation:  in.Metadata.Generation,
 			},
 			Spec: ext.CellSpec{
 				ID:                  in.Spec.ID,

--- a/internal/apischeme/scheme_test.go
+++ b/internal/apischeme/scheme_test.go
@@ -384,6 +384,46 @@ func TestCellRoundTripV1Beta1(t *testing.T) {
 	}
 }
 
+// TestCellRoundTripV1Beta1_Annotations covers epic:cell-identity #1073: the
+// cell metadata.Annotations map (carrying a clone's kukeon.io/source-cell
+// provenance annotation) survives the external→internal→external round-trip so
+// it persists to metadata.json and back.
+func TestCellRoundTripV1Beta1_Annotations(t *testing.T) {
+	input := ext.CellDoc{
+		APIVersion: ext.APIVersionV1Beta1,
+		Kind:       ext.KindCell,
+		Metadata: ext.CellMetadata{
+			Name:        "prod-d4e5f6",
+			Labels:      map[string]string{"kukeon.io/config": "prod"},
+			Annotations: map[string]string{"kukeon.io/source-cell": "prod-a1b2c3"},
+		},
+		Spec: ext.CellSpec{
+			ID:         "prod-d4e5f6",
+			RealmID:    "realm0",
+			SpaceID:    "space0",
+			StackID:    "stack0",
+			Containers: []ext.ContainerSpec{},
+		},
+		Status: ext.CellStatus{State: ext.CellStatePending},
+	}
+
+	internal, version, err := apischeme.NormalizeCell(input)
+	if err != nil {
+		t.Fatalf("NormalizeCell failed: %v", err)
+	}
+	if internal.Metadata.Annotations["kukeon.io/source-cell"] != "prod-a1b2c3" {
+		t.Fatalf("annotation lost on external→internal: %+v", internal.Metadata.Annotations)
+	}
+
+	output, err := apischeme.BuildCellExternalFromInternal(internal, version)
+	if err != nil {
+		t.Fatalf("BuildCellExternalFromInternal failed: %v", err)
+	}
+	if output.Metadata.Annotations["kukeon.io/source-cell"] != "prod-a1b2c3" {
+		t.Fatalf("annotation lost on internal→external: %+v", output.Metadata.Annotations)
+	}
+}
+
 // TestCellRoundTripV1Beta1_NetworkBridgeName covers AC for #168: the cell
 // status persists Network.BridgeName through the external→internal→external
 // round-trip so daemon restarts can recover the iface mapping from the

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -187,6 +187,49 @@ func TestDiffCell_ManagedLabels_NoChange(t *testing.T) {
 	}
 }
 
+// TestDiffCell_Annotations_NoChange pins the AC#4 guarantee of epic:cell-identity
+// #1073: a `kukeon.io/source-cell` annotation on a clone must never register as
+// drift. DiffCell does not compare metadata.Annotations at all, so a clone that
+// carries the inert provenance annotation (while its re-materialised desired
+// twin does not) stays Synced — no false OutOfSync for Config-lineage clones.
+func TestDiffCell_Annotations_NoChange(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name:   "prod-d4e5f6",
+			Labels: map[string]string{"kukeon.io/config": "prod"},
+		},
+		Spec: intmodel.CellSpec{
+			RealmName:  "default",
+			SpaceName:  "default",
+			StackName:  "default",
+			Containers: []intmodel.ContainerSpec{{ID: "web", Image: "busybox:latest"}},
+		},
+	}
+
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{
+			Name:   "prod-d4e5f6",
+			Labels: map[string]string{"kukeon.io/config": "prod", "cell.kukeon.io": "prod-d4e5f6"},
+			// The clone-only provenance annotation the desired twin lacks.
+			Annotations: map[string]string{"kukeon.io/source-cell": "prod-a1b2c3"},
+		},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+				{ID: "web", Image: "busybox:latest"},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if diff.HasChanges {
+		t.Errorf("expected no drift from a source-cell annotation difference, got: %+v", diff)
+	}
+}
+
 // TestDiffCell_UserLabels_StillDetectsDrift makes sure the managed-label
 // filter does not over-narrow: a real user-authored label change must still
 // register as drift.

--- a/internal/modelhub/cell.go
+++ b/internal/modelhub/cell.go
@@ -27,6 +27,11 @@ type Cell struct {
 type CellMetadata struct {
 	Name   string
 	Labels map[string]string
+	// Annotations mirror v1beta1.CellMetadata.Annotations: non-identifying
+	// metadata that round-trips through cell metadata but that no reconcile or
+	// selector path keys off, and that DiffCell does not compare. Carries a
+	// clone's `kukeon.io/source-cell` provenance annotation (#1073).
+	Annotations map[string]string
 	// Generation is a monotonic counter bumped by a writer on each
 	// spec-changing update. Defaults to zero; phase 3 wires the writers to
 	// populate it. See ObservedGeneration on the status.

--- a/pkg/api/model/v1beta1/cell.go
+++ b/pkg/api/model/v1beta1/cell.go
@@ -29,6 +29,13 @@ type CellDoc struct {
 type CellMetadata struct {
 	Name   string            `json:"name"                 yaml:"name"`
 	Labels map[string]string `json:"labels"               yaml:"labels"`
+	// Annotations carry non-identifying metadata about the cell. Unlike
+	// Labels, no reconcile or selector path keys off them, and DiffCell
+	// deliberately does not compare them — a clone's
+	// `kukeon.io/source-cell: <src>` provenance annotation must never trip a
+	// false OutOfSync (epic:cell-identity #1073). Mirrors the Annotations map
+	// CellConfig/CellBlueprint already carry.
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	// Generation is a monotonic counter bumped by a writer on each
 	// spec-changing update. Defaults to zero; phase 3 wires the writers to
 	// populate it. See ObservedGeneration on the status.
@@ -295,6 +302,14 @@ func NewCellDoc(from *CellDoc) *CellDoc {
 			labels[k] = v
 		}
 		out.Metadata.Labels = labels
+	}
+
+	if out.Metadata.Annotations != nil {
+		annotations := make(map[string]string, len(out.Metadata.Annotations))
+		for k, v := range out.Metadata.Annotations {
+			annotations[k] = v
+		}
+		out.Metadata.Annotations = annotations
 	}
 
 	if out.Spec.Containers == nil {


### PR DESCRIPTION
## Summary

Adds `--clone <cell>` as the third source kind on `kuke create cell`, alongside `--from-blueprint` and `--from-config` (epic:cell-identity P4, #1073). It closes the cell-forking gap left when P2 (#1022) retired the old `--clone <config>` `<src>-<N>`/`source-config` machinery: the "fork *this* tuned cell's recipe (with its per-cell overrides) into a new cell" use case survives the redesign and is now served natively.

**Mechanism** (per the issue's design): read the source cell's `Spec.Provenance` (P1) → re-materialise a fresh spec from that same binding (the exact `cellconfig`/`cellblueprint` materialisation the `--from-config`/`--from-blueprint` paths run) → copy the source's provenance onto the clone verbatim → inherit the lineage label, stamp the `kukeon.io/source-cell` annotation, target the source's scope, finalise the name via the unified P2 generator.

- Per-path override symmetry from P3 holds: `--env` stacks on a config-lineage clone (last-write-wins; `--param`/`--param-file` rejected); `--param`/`--param-file` stack on a blueprint-lineage clone (`--env` rejected).
- `--clone`, `--from-blueprint`, `--from-config` are mutually exclusive (cobra mutex).
- Clone logic lives in its own `cmd/kuke/create/cell/clone.go` (+ `clone_test.go`) to keep `cell.go` reviewable.

## Two AC-specifics that didn't match the cell model (heads-up posted on #1073; proceeded with the documented readings)

1. **Prefix source.** The AC derives the clone prefix from the source cell's `Spec.Prefix ?? metadata.name`, but a materialised cell (`v1beta1.CellSpec`) has **no `Prefix` field** — only `CellConfigSpec`/`CellBlueprintSpec` do, and `MaterializeWithName` never copies it onto the cell. So the `??` collapses to the source cell's `metadata.name`, which is what I use. **Consequence:** cloning an auto-named source `web-a1b2c3` yields `web-a1b2c3-<6hex>` (the prefix accumulates). I did not add suffix-stripping or a new `CellSpec.Prefix` field (both exceed the literal AC and are larger changes). If the intent was the *original* prefix, that needs an explicit decision.

2. **`kukeon.io/source-cell` annotation.** Cells carried only `metadata.Labels` — no `Annotations` map. A `source-cell` *label* would be compared by `DiffCell` (its `filterManagedLabels` drops only the `.kukeon.io` *suffix*, not the `kukeon.io/` *prefix*), tripping a false OutOfSync on config-lineage clones — exactly what AC#4 forbids. So I added an `Annotations map[string]string` field to the cell model (mirroring the existing `CellConfig`/`CellBlueprint` annotations), threaded through `apischeme` both directions. `DiffCell` ignores annotations by nature → no false-OutOfSync, "inert provenance metadata" intent preserved literally.

## Scope notes

- **`run --clone` is intentionally not wired here.** Per AC#7, `--clone` rides the shared `FlagSet` introduced by P6; until that lands, `run --clone` is unrecognised and `create cell --clone` is the supported entry point. This PR only registers `--clone` on `create cell`.
- **Stale `run --clone` docs left untouched.** `docs/cli-use-cases.md` and `docs/site/cli/kuke-run.md` still describe the P2-retired `run <config> --clone` `<src>-<N>`/`source-config` machinery. That is pre-existing P2 doc debt for a different (run-side) feature and belongs to the epic's docs step — out of scope here (no unrelated cleanups).

## Test plan

- [x] `make test` (test-root + test-kukebuild) — passes (`GOWORK=off`, the Makefile-exported env).
- [x] `go build ./...` + `go vet ./...` (`GOWORK=off`) — clean.
- [x] `pre-commit run` (go-fmt, golangci-lint, addlicense, …) on the change set — passes.
- [x] New unit tests in `cmd/kuke/create/cell/clone_test.go`: provenance byte-equal (AC#1), auto-name `<src>-<6hex>` + explicit-name verbatim + collision-errors (AC#2), lineage-label inheritance (AC#3), `source-cell` annotation (AC#4), mutual exclusivity (AC#5), env/param stacking last-write-wins (AC#6), source-not-found, source-without-provenance.
- [x] `internal/controller/apply/diff_test.go`: `TestDiffCell_Annotations_NoChange` pins AC#4's no-false-OutOfSync (annotation-only diff ⇒ Synced).
- [x] `internal/apischeme/scheme_test.go`: `TestCellRoundTripV1Beta1_Annotations` pins the annotation external→internal→external round-trip.
- [ ] `make dev-init` smoke — **deferred (environmental).** This host's `/var/lib/containerd` is a shared **4 GB tmpfs at 93 % full** (accumulated build leftovers from prior runs); the kukeond image build runs out of space (`no space left on device`), and aggressively pruning the *shared parent-host* containerd would risk unrelated parent `kuke attach` state. `kuke image prune` needs a running daemon (none is up post-reset). Marginal value here is low: the smoke never exercises the clone path, and the only daemon-read impact — the additive `Annotations` field — is covered by the apischeme round-trip + DiffCell unit tests, and `make test` compiles the daemon. Recommend running `make dev-init` on a clean host before merge.

## Acceptance criteria

- [x] `create cell --clone <src>` produces a new cell whose `Spec.Provenance` is byte-equal to the source's (run `--clone` deferred to P6's shared FlagSet per AC#7).
- [x] Omitted name → `<source-name>-<6hex>`; explicit name verbatim; in-scope collision errors (not idempotent-attach).
- [x] Clone inherits the source's `kukeon.io/config` / `kukeon.io/blueprint` lineage label.
- [x] Clone carries `kukeon.io/source-cell: <src>`; provenance excluded from `DiffCell` (no false OutOfSync) — verified by test.
- [x] `--clone`/`--from-blueprint`/`--from-config` mutually exclusive with a clear message.
- [x] Additional `--env`/`--param` merge on top of copied overrides (last-write-wins), per the P3 per-path symmetry.
- [x] `--clone` registered on `create cell` only; `run --clone` waits on P6's shared FlagSet (AC#7).
- [x] `go build ./...` + `go test ./...` clean; `make dev-init` smoke deferred (environmental — see Test plan).

Closes #1073