### PR TITLE
feat(reconcile): re-resolve from provenance; per-cell --env overrides survive (P5)

### DIFF
--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -415,7 +415,7 @@ func runFromConfig(cmd *cobra.Command, client kukeonv1.Client, flags createCellF
 	if err := finalizeCellName(cmd, client, &cellDoc, flags.name, cellconfig.Prefix(cfgRes.Config)); err != nil {
 		return err
 	}
-	applyEnvOverrides(&cellDoc, flags.envArgs)
+	cellconfig.ApplyEnvOverrides(&cellDoc, flags.envArgs)
 	applyIgnoreDiskPressure(&cellDoc, flags)
 
 	return materialiseAndPersist(cmd, client, cellDoc)
@@ -498,93 +498,6 @@ func overlayScope(doc *v1beta1.CellDoc, flags createCellFlags) {
 	if strings.TrimSpace(doc.Spec.StackID) == "" {
 		doc.Spec.StackID = flags.stack
 	}
-}
-
-// applyEnvOverrides bakes the validated `--env KEY=VALUE` per-cell overrides
-// into the materialised CellDoc (issue #1023). Two effects, mirroring the
-// `kuke run --env` provenance contract (#1021) but persisting rather than
-// riding the transport-only Spec.RuntimeEnv:
-//
-//   - the overrides are merged into the attachable container's persisted Env
-//     (resolveAttachableContainerIndex picks the target the same way
-//     `kuke run` would attach), winning over any value the Config's
-//     spec.values resolved for the same key — so the override survives the
-//     stopped-cell persist and takes effect on the later `kuke start`;
-//   - the same entries are recorded verbatim in Spec.Provenance.EnvOverrides,
-//     the P1 materialization-input record P4 re-resolves against.
-//
-// A nil/empty envArgs is a no-op. When no container is attachable the
-// overrides are still recorded in provenance (the operator's intent is
-// preserved) but have nowhere to bake, mirroring the runtime path's
-// silent no-op on a non-attachable cell.
-func applyEnvOverrides(doc *v1beta1.CellDoc, envArgs []string) {
-	if len(envArgs) == 0 {
-		return
-	}
-	if idx := resolveAttachableContainerIndex(doc.Spec); idx >= 0 {
-		doc.Spec.Containers[idx].Env = mergeEnv(doc.Spec.Containers[idx].Env, envArgs)
-	}
-	if doc.Spec.Provenance != nil {
-		doc.Spec.Provenance.EnvOverrides = append([]string(nil), envArgs...)
-	}
-}
-
-// resolveAttachableContainerIndex returns the index of the container `kuke run`
-// would attach to (issue #834's runtime-env target), or -1 when none qualifies.
-// Precedence mirrors the daemon-side resolveAttachableContainerID and the
-// CLI-side pickAttachTarget:
-//
-//  1. Spec.Tty.Default, when it names an existing non-root container;
-//  2. the first non-root container with Attachable=true, in declaration order;
-//  3. -1 when no container qualifies.
-func resolveAttachableContainerIndex(spec v1beta1.CellSpec) int {
-	if spec.Tty != nil {
-		if pref := strings.TrimSpace(spec.Tty.Default); pref != "" {
-			for i, c := range spec.Containers {
-				if !c.Root && c.ID == pref {
-					return i
-				}
-			}
-		}
-	}
-	for i, c := range spec.Containers {
-		if !c.Root && c.Attachable {
-			return i
-		}
-	}
-	return -1
-}
-
-// mergeEnv layers the validated env overrides on top of a container's existing
-// Env. For each KEY in envArgs, any specEnv entry with the same KEY is dropped
-// (the override wins); surviving spec entries keep their order, then the
-// override entries follow in their input order. Mirrors the runner-side
-// mergeRuntimeEnv merge semantics so a `create cell --env` override and a
-// `run --env` override resolve identically. Never mutates the input slices.
-func mergeEnv(specEnv, envArgs []string) []string {
-	if len(envArgs) == 0 {
-		return specEnv
-	}
-	overrideKeys := make(map[string]struct{}, len(envArgs))
-	for _, entry := range envArgs {
-		key, _, _ := strings.Cut(entry, "=")
-		overrideKeys[key] = struct{}{}
-	}
-	// Cap on len(specEnv) alone — not len(specEnv)+len(envArgs) — to
-	// keep CodeQL's go/allocation-size-overflow analysis silent on
-	// operator-tainted inputs. The envArgs tail is appended below and
-	// Go's append handles the tiny extra growth fine for typical kuke
-	// cells (<50 entries on either side). Mirrors the runner-side
-	// mergeRuntimeEnv cap in internal/controller/runner/cell_runtime_env.go.
-	merged := make([]string, 0, len(specEnv))
-	for _, entry := range specEnv {
-		key, _, _ := strings.Cut(entry, "=")
-		if _, override := overrideKeys[key]; override {
-			continue
-		}
-		merged = append(merged, entry)
-	}
-	return append(merged, envArgs...)
 }
 
 // parseEnvArgs validates the repeatable `--env KEY=VALUE` flag and returns the

--- a/cmd/kuke/create/cell/clone.go
+++ b/cmd/kuke/create/cell/clone.go
@@ -233,11 +233,11 @@ func cloneFromConfig(
 	}
 
 	// Copy the source's provenance verbatim (AC#1), then re-bake its env
-	// overrides plus any additional --env (AC#6). applyEnvOverrides reads
+	// overrides plus any additional --env (AC#6). ApplyEnvOverrides reads
 	// Spec.Provenance.EnvOverrides as the merged set, so set provenance first.
 	cellDoc.Spec.Provenance = v1beta1.CloneCellProvenance(srcProv)
-	mergedEnv := mergeEnv(srcProv.EnvOverrides, flags.envArgs)
-	applyEnvOverrides(&cellDoc, mergedEnv)
+	mergedEnv := cellconfig.MergeEnv(srcProv.EnvOverrides, flags.envArgs)
+	cellconfig.ApplyEnvOverrides(&cellDoc, mergedEnv)
 	return cellDoc, nil
 }
 

--- a/internal/cellconfig/envoverlay.go
+++ b/internal/cellconfig/envoverlay.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cellconfig
+
+import (
+	"strings"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// ApplyEnvOverrides bakes the validated `--env KEY=VALUE` per-cell overrides
+// into the materialised CellDoc (issue #1023). Two effects, mirroring the
+// `kuke run --env` provenance contract (#1021) but persisting rather than
+// riding the transport-only Spec.RuntimeEnv:
+//
+//   - the overrides are merged into the attachable container's persisted Env
+//     (ResolveAttachableContainerIndex picks the target the same way
+//     `kuke run` would attach), winning over any value the Config's
+//     spec.values resolved for the same key — so the override survives the
+//     stopped-cell persist and takes effect on the later `kuke start`;
+//   - the same entries are recorded verbatim in Spec.Provenance.EnvOverrides,
+//     the P1 materialization-input record P5 re-resolves against.
+//
+// A nil/empty envArgs is a no-op. When no container is attachable the
+// overrides are still recorded in provenance (the operator's intent is
+// preserved) but have nowhere to bake, mirroring the runtime path's
+// silent no-op on a non-attachable cell.
+//
+// Shared by `kuke create cell --env`, the clone path, and the reconcile
+// re-resolve path (epic:cell-identity P5, #1024) so all three re-apply the
+// overlay through one precedence-identical helper.
+func ApplyEnvOverrides(doc *v1beta1.CellDoc, envArgs []string) {
+	if len(envArgs) == 0 {
+		return
+	}
+	if idx := ResolveAttachableContainerIndex(doc.Spec); idx >= 0 {
+		doc.Spec.Containers[idx].Env = MergeEnv(doc.Spec.Containers[idx].Env, envArgs)
+	}
+	if doc.Spec.Provenance != nil {
+		doc.Spec.Provenance.EnvOverrides = append([]string(nil), envArgs...)
+	}
+}
+
+// ResolveAttachableContainerIndex returns the index of the container `kuke run`
+// would attach to (issue #834's runtime-env target), or -1 when none qualifies.
+// Precedence mirrors the daemon-side resolveAttachableContainerID and the
+// CLI-side pickAttachTarget:
+//
+//  1. Spec.Tty.Default, when it names an existing non-root container;
+//  2. the first non-root container with Attachable=true, in declaration order;
+//  3. -1 when no container qualifies.
+func ResolveAttachableContainerIndex(spec v1beta1.CellSpec) int {
+	if spec.Tty != nil {
+		if pref := strings.TrimSpace(spec.Tty.Default); pref != "" {
+			for i, c := range spec.Containers {
+				if !c.Root && c.ID == pref {
+					return i
+				}
+			}
+		}
+	}
+	for i, c := range spec.Containers {
+		if !c.Root && c.Attachable {
+			return i
+		}
+	}
+	return -1
+}
+
+// MergeEnv layers the validated env overrides on top of a container's existing
+// Env. For each KEY in envArgs, any specEnv entry with the same KEY is dropped
+// (the override wins); surviving spec entries keep their order, then the
+// override entries follow in their input order. Mirrors the runner-side
+// mergeRuntimeEnv merge semantics so a `create cell --env` override and a
+// `run --env` override resolve identically. Never mutates the input slices.
+func MergeEnv(specEnv, envArgs []string) []string {
+	if len(envArgs) == 0 {
+		return specEnv
+	}
+	overrideKeys := make(map[string]struct{}, len(envArgs))
+	for _, entry := range envArgs {
+		key, _, _ := strings.Cut(entry, "=")
+		overrideKeys[key] = struct{}{}
+	}
+	// Cap on len(specEnv) alone — not len(specEnv)+len(envArgs) — to
+	// keep CodeQL's go/allocation-size-overflow analysis silent on
+	// operator-tainted inputs. The envArgs tail is appended below and
+	// Go's append handles the tiny extra growth fine for typical kuke
+	// cells (<50 entries on either side). Mirrors the runner-side
+	// mergeRuntimeEnv cap in internal/controller/runner/cell_runtime_env.go.
+	merged := make([]string, 0, len(specEnv))
+	for _, entry := range specEnv {
+		key, _, _ := strings.Cut(entry, "=")
+		if _, override := overrideKeys[key]; override {
+			continue
+		}
+		merged = append(merged, entry)
+	}
+	return append(merged, envArgs...)
+}

--- a/internal/cellconfig/envoverlay_test.go
+++ b/internal/cellconfig/envoverlay_test.go
@@ -1,0 +1,204 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the env-overlay helpers shared by the create, clone, and reconcile
+// re-resolve paths (epic:cell-identity P5, #1024). The helpers were extracted
+// from cmd/kuke/create/cell so all three paths re-apply per-cell --env overrides
+// through one precedence-identical implementation.
+
+package cellconfig
+
+import (
+	"reflect"
+	"testing"
+
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestMergeEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		specEnv []string
+		envArgs []string
+		want    []string
+	}{
+		{
+			name:    "empty override is a no-op returning the spec env",
+			specEnv: []string{"A=1", "B=2"},
+			envArgs: nil,
+			want:    []string{"A=1", "B=2"},
+		},
+		{
+			name:    "override wins on key collision and lands last",
+			specEnv: []string{"A=1", "B=2"},
+			envArgs: []string{"B=9"},
+			want:    []string{"A=1", "B=9"},
+		},
+		{
+			name:    "new key appends after surviving spec entries in order",
+			specEnv: []string{"A=1"},
+			envArgs: []string{"C=3"},
+			want:    []string{"A=1", "C=3"},
+		},
+		{
+			name:    "override into empty spec env",
+			specEnv: nil,
+			envArgs: []string{"A=1"},
+			want:    []string{"A=1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MergeEnv(tt.specEnv, tt.envArgs)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MergeEnv(%v, %v) = %v, want %v", tt.specEnv, tt.envArgs, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeEnv_DoesNotMutateInputs(t *testing.T) {
+	specEnv := []string{"A=1", "B=2"}
+	envArgs := []string{"B=9"}
+	_ = MergeEnv(specEnv, envArgs)
+	if !reflect.DeepEqual(specEnv, []string{"A=1", "B=2"}) {
+		t.Errorf("MergeEnv mutated specEnv: %v", specEnv)
+	}
+	if !reflect.DeepEqual(envArgs, []string{"B=9"}) {
+		t.Errorf("MergeEnv mutated envArgs: %v", envArgs)
+	}
+}
+
+func TestResolveAttachableContainerIndex(t *testing.T) {
+	tests := []struct {
+		name string
+		spec v1beta1.CellSpec
+		want int
+	}{
+		{
+			name: "no attachable container yields -1",
+			spec: v1beta1.CellSpec{Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "main"},
+			}},
+			want: -1,
+		},
+		{
+			name: "first non-root attachable container in declaration order",
+			spec: v1beta1.CellSpec{Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "a", Attachable: true},
+				{ID: "b", Attachable: true},
+			}},
+			want: 1,
+		},
+		{
+			name: "Tty.Default takes precedence over declaration order",
+			spec: v1beta1.CellSpec{
+				Tty: &v1beta1.CellTty{Default: "b"},
+				Containers: []v1beta1.ContainerSpec{
+					{ID: "a", Attachable: true},
+					{ID: "b", Attachable: true},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "a root container is never the attachable target",
+			spec: v1beta1.CellSpec{Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true, Attachable: true},
+				{ID: "main", Attachable: true},
+			}},
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolveAttachableContainerIndex(tt.spec); got != tt.want {
+				t.Errorf("ResolveAttachableContainerIndex() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplyEnvOverrides_BakesIntoAttachableAndRecordsProvenance(t *testing.T) {
+	doc := &v1beta1.CellDoc{
+		Spec: v1beta1.CellSpec{
+			Provenance: &v1beta1.CellProvenance{},
+			Containers: []v1beta1.ContainerSpec{
+				{ID: "root", Root: true},
+				{ID: "main", Attachable: true, Env: []string{"A=1"}},
+			},
+		},
+	}
+	ApplyEnvOverrides(doc, []string{"B=2"})
+
+	if got := doc.Spec.Containers[1].Env; !reflect.DeepEqual(got, []string{"A=1", "B=2"}) {
+		t.Errorf("attachable container Env = %v, want [A=1 B=2]", got)
+	}
+	if got := doc.Spec.Containers[0].Env; len(got) != 0 {
+		t.Errorf("root container Env = %v, want empty (override targets the attachable container only)", got)
+	}
+	if got := doc.Spec.Provenance.EnvOverrides; !reflect.DeepEqual(got, []string{"B=2"}) {
+		t.Errorf("provenance EnvOverrides = %v, want [B=2]", got)
+	}
+}
+
+func TestApplyEnvOverrides_EmptyArgsIsNoOp(t *testing.T) {
+	doc := &v1beta1.CellDoc{
+		Spec: v1beta1.CellSpec{
+			Provenance: &v1beta1.CellProvenance{},
+			Containers: []v1beta1.ContainerSpec{{ID: "main", Attachable: true, Env: []string{"A=1"}}},
+		},
+	}
+	ApplyEnvOverrides(doc, nil)
+	if got := doc.Spec.Containers[0].Env; !reflect.DeepEqual(got, []string{"A=1"}) {
+		t.Errorf("Env mutated by a no-op ApplyEnvOverrides: %v", got)
+	}
+	if doc.Spec.Provenance.EnvOverrides != nil {
+		t.Errorf("provenance EnvOverrides recorded on a no-op: %v", doc.Spec.Provenance.EnvOverrides)
+	}
+}
+
+func TestApplyEnvOverrides_NoAttachableStillRecordsProvenance(t *testing.T) {
+	doc := &v1beta1.CellDoc{
+		Spec: v1beta1.CellSpec{
+			Provenance: &v1beta1.CellProvenance{},
+			Containers: []v1beta1.ContainerSpec{{ID: "main"}}, // not attachable
+		},
+	}
+	ApplyEnvOverrides(doc, []string{"B=2"})
+	if got := doc.Spec.Containers[0].Env; len(got) != 0 {
+		t.Errorf("non-attachable container Env = %v, want empty (nowhere to bake)", got)
+	}
+	if got := doc.Spec.Provenance.EnvOverrides; !reflect.DeepEqual(got, []string{"B=2"}) {
+		t.Errorf("provenance EnvOverrides = %v, want [B=2] (intent preserved even with no bake target)", got)
+	}
+}
+
+func TestApplyEnvOverrides_NilProvenanceBakesWithoutPanic(t *testing.T) {
+	doc := &v1beta1.CellDoc{
+		Spec: v1beta1.CellSpec{
+			Containers: []v1beta1.ContainerSpec{{ID: "main", Attachable: true}},
+		},
+	}
+	ApplyEnvOverrides(doc, []string{"B=2"})
+	if got := doc.Spec.Containers[0].Env; !reflect.DeepEqual(got, []string{"B=2"}) {
+		t.Errorf("attachable container Env = %v, want [B=2]", got)
+	}
+}

--- a/internal/controller/reconcile_outofsync.go
+++ b/internal/controller/reconcile_outofsync.go
@@ -98,7 +98,7 @@ func desiredCellOutOfSync(r runner.Runner, cell intmodel.Cell, configName string
 		return cellOutOfSync{OutOfSync: true, Reason: outOfSyncReasonConfigDeleted}
 	}
 
-	desiredCell, materializeErr := materializeCellFromConfig(r, cfg, cell.Metadata.Name)
+	desiredCell, materializeErr := materializeCellFromConfig(r, cfg, cell.Metadata.Name, provenanceEnvOverrides(cell))
 	if materializeErr != nil {
 		return cellOutOfSync{Err: materializeErr.Error()}
 	}
@@ -111,6 +111,18 @@ func desiredCellOutOfSync(r runner.Runner, cell intmodel.Cell, configName string
 		OutOfSync: true,
 		Reason:    outOfSyncSpecDifferReason(diff),
 	}
+}
+
+// provenanceEnvOverrides returns the per-cell `--env` overrides recorded in the
+// cell's materialization provenance (P3 #1023), or nil for a cell with no
+// provenance (hand-built, or a pre-#1021 cell). Threaded into
+// materializeCellFromConfig so the re-resolve path re-applies the overrides the
+// live cell baked at create time (epic:cell-identity P5, #1024).
+func provenanceEnvOverrides(cell intmodel.Cell) []string {
+	if cell.Spec.Provenance == nil {
+		return nil
+	}
+	return cell.Spec.Provenance.EnvOverrides
 }
 
 // configLineage returns the lineage Config name carried on the cell's
@@ -191,8 +203,18 @@ func lookupLineageConfig(
 // detector compares *spec drift*, not identity. This keeps the detector
 // correct now that P2 (#1022) lands generated cell names that no longer match
 // the Config name (the legacy StableName pin, retired in P2).
+//
+// envOverrides carries the cell's recorded `Spec.Provenance.EnvOverrides` (the
+// per-cell `--env KEY=VALUE` baked at create time, P3 #1023). Re-resolving from
+// the Config alone re-runs `MaterializeWithName`, which never re-applies those
+// overrides — so without re-applying them here a cell created
+// `--from-config --env K=V` reports a spurious OutOfSync (the override is in the
+// live spec but not the freshly materialized one) and has it stripped on
+// reapply. ApplyEnvOverrides re-bakes them last (P3 precedence) through the same
+// helper the create and clone paths use (epic:cell-identity P5, #1024), so the
+// re-materialized spec matches the live cell's attachable-container Env.
 func materializeCellFromConfig(
-	r runner.Runner, cfg intmodel.CellConfig, cellName string,
+	r runner.Runner, cfg intmodel.CellConfig, cellName string, envOverrides []string,
 ) (intmodel.Cell, error) {
 	cfgDoc, err := apischeme.ConvertCellConfigToExternal(cfg)
 	if err != nil {
@@ -223,6 +245,11 @@ func materializeCellFromConfig(
 	if mErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("materialize cell: %w", mErr)
 	}
+
+	// Re-apply the cell's recorded per-cell --env overrides last (P3 precedence,
+	// #1023) so the re-materialized spec carries the same attachable-container
+	// Env the live cell baked at create time. A nil/empty slice is a no-op.
+	cellconfig.ApplyEnvOverrides(&cellDoc, envOverrides)
 
 	desired, convErr := apischeme.ConvertCellDocToInternal(cellDoc)
 	if convErr != nil {

--- a/internal/controller/reconcile_outofsync_test.go
+++ b/internal/controller/reconcile_outofsync_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/eminwux/kukeon/internal/controller/runner"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+	ext "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
 
 // materializeSampleCell runs the production materialize+convert pipeline
@@ -135,6 +136,79 @@ type controllerResult struct {
 	CellsErrored int
 	CellsDeleted int
 	Errors       []string
+}
+
+// sampleAttachableBlueprint mirrors sampleReferencedBlueprint but marks the
+// "main" container attachable, so the re-resolve path's ApplyEnvOverrides has a
+// container to bake the recorded per-cell --env override into
+// (epic:cell-identity P5, #1024).
+func sampleAttachableBlueprint() ext.CellBlueprintDoc {
+	bp := sampleReferencedBlueprint()
+	bp.Spec.Cell.Containers[0].Attachable = true
+	return bp
+}
+
+// TestReconcileCells_OutOfSync_EnvOverrideSurvivesNoSpuriousDrift pins AC2/AC3
+// of epic:cell-identity P5 (#1024): a Config-lineage cell created
+// `--from-config --env K=V` records the override in Spec.Provenance.EnvOverrides
+// (P3 #1023) and bakes it into the attachable container's Env. The re-resolve
+// path re-applies the recorded override last (P3 precedence), so the
+// materialized `desired` spec matches the live cell — no spurious OutOfSync and
+// no metadata write. Without the fix the materialized spec lacks the override,
+// the diff flags the env field, and the cell sticks on a spurious OutOfSync.
+func TestReconcileCells_OutOfSync_EnvOverrideSurvivesNoSpuriousDrift(t *testing.T) {
+	cellDoc, err := cellconfig.MaterializeWithName(
+		sampleConfig(), sampleAttachableBlueprint(), cellconfig.Prefix(sampleConfig()),
+	)
+	if err != nil {
+		t.Fatalf("cellconfig.MaterializeWithName: %v", err)
+	}
+	live, err := apischeme.ConvertCellDocToInternal(cellDoc)
+	if err != nil {
+		t.Fatalf("ConvertCellDocToInternal: %v", err)
+	}
+
+	// Simulate `--from-config --env APP_ENV=prod`: bake the override into the
+	// attachable container's Env and record it in provenance, as the create
+	// path (applyEnvOverrides, #1023) does.
+	idx := -1
+	for i, c := range live.Spec.Containers {
+		if !c.Root && c.Attachable {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatalf("test fixture has no attachable container — sampleAttachableBlueprint changed?")
+	}
+	live.Spec.Containers[idx].Env = append(live.Spec.Containers[idx].Env, "APP_ENV=prod")
+	live.Spec.Provenance = &intmodel.CellProvenance{EnvOverrides: []string{"APP_ENV=prod"}}
+
+	var updateCalls atomic.Int32
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return configCarrier(t, sampleConfig()), nil
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleAttachableBlueprint()), nil
+		},
+		func(intmodel.Cell) error {
+			updateCalls.Add(1)
+			return nil
+		},
+	)
+
+	res, _ := runOutOfSyncHarness(t, live, mock)
+
+	if got := updateCalls.Load(); got != 0 {
+		t.Errorf("UpdateCellMetadata calls: got %d, want 0 (recorded --env override must not produce spurious OutOfSync)", got)
+	}
+	if res.CellsUpdated != 0 {
+		t.Errorf("CellsUpdated: got %d, want 0", res.CellsUpdated)
+	}
+	if res.CellsErrored != 0 || len(res.Errors) != 0 {
+		t.Errorf("override-survival pass surfaced errors: %+v", res)
+	}
 }
 
 // TestReconcileCells_OutOfSync_MatchingCellStaysSynced is AC case 1: a

--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -158,7 +158,7 @@ func (b *Exec) reapplyOutOfSyncFromConfig(cell intmodel.Cell) (intmodel.Cell, bo
 		return intmodel.Cell{}, false, false
 	}
 
-	desired, err := materializeCellFromConfig(b.runner, cfg, cell.Metadata.Name)
+	desired, err := materializeCellFromConfig(b.runner, cfg, cell.Metadata.Name, provenanceEnvOverrides(cell))
 	if err != nil {
 		b.logger.WarnContext(b.ctx,
 			"OutOfSync reapply materialise failed; starting cell with on-disk spec",

--- a/internal/controller/start_cell_reapply_test.go
+++ b/internal/controller/start_cell_reapply_test.go
@@ -82,6 +82,33 @@ spec:
 	}
 }
 
+// reapplyAttachableBlueprint mirrors reapplySampleBlueprint but marks the
+// "main" container attachable, so the re-resolve path's ApplyEnvOverrides has a
+// container to bake the recorded per-cell --env override into (epic:cell-identity
+// P5, #1024). Image bumps to nginx:2.0 from the live cell's nginx:1.0 so a real
+// drift still drives RecreateCell.
+func reapplyAttachableBlueprint(realm string) intmodel.CellBlueprint {
+	doc := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: ` + realm + `
+spec:
+  cell:
+    containers:
+      - id: main
+        image: nginx:2.0
+        attachable: true
+`
+	return intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: realm,
+		},
+		Document: []byte(doc),
+	}
+}
+
 // reapplyLineageCell builds a stopped, OutOfSync, Config-lineage cell with the
 // given realm/space/stack scope. The cell's on-disk container image is
 // "nginx:1.0" — diverged from the Config's "nginx:2.0" — so the reapply path
@@ -178,6 +205,76 @@ func TestStartCell_OutOfSyncReapply_RecreatesFromConfig(t *testing.T) {
 	}
 	if res.Cell.Status.State != intmodel.CellStateReady {
 		t.Errorf("cell state = %v, want Ready after RecreateCell", res.Cell.Status.State)
+	}
+}
+
+// TestStartCell_OutOfSyncReapply_EnvOverridePreserved pins the AC3 reapply
+// half of epic:cell-identity P5 (#1024): a Config-lineage cell created
+// `--from-config --env K=V` records the override in Spec.Provenance.EnvOverrides
+// (P3 #1023). The reapply path re-materialises from the Config — which has no
+// knowledge of the per-cell override — so without re-applying provenance the
+// override is silently stripped on RecreateCell. With the fix, the desired cell
+// handed to RecreateCell carries the materialised Blueprint image *and* the
+// re-baked override (re-applied last, P3 precedence).
+func TestStartCell_OutOfSyncReapply_EnvOverridePreserved(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+	// Simulate a cell created `--from-config --env APP_ENV=prod`: the override
+	// is baked into the attachable container's Env and recorded in provenance.
+	live.Spec.Containers[0].Attachable = true
+	live.Spec.Containers[0].Env = []string{"APP_ENV=prod"}
+	live.Spec.Provenance = &intmodel.CellProvenance{
+		EnvOverrides: []string{"APP_ENV=prod"},
+	}
+
+	var recreateCalled bool
+	f := &fakeRunner{
+		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
+		},
+		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return reapplyAttachableBlueprint("test-realm"), nil
+		},
+		RecreateCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			var main intmodel.ContainerSpec
+			for _, c := range cell.Spec.Containers {
+				if c.ID == "main" {
+					main = c
+					break
+				}
+			}
+			if main.Image != "nginx:2.0" {
+				t.Errorf("RecreateCell main image = %q, want nginx:2.0 (materialised from Blueprint)", main.Image)
+			}
+			// The recorded override must survive re-resolve, not be stripped.
+			found := false
+			for _, e := range main.Env {
+				if e == "APP_ENV=prod" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("RecreateCell main Env = %v, want it to retain APP_ENV=prod (provenance override stripped)", main.Env)
+			}
+			cell.Status.State = intmodel.CellStateReady
+			return cell, nil
+		},
+		StartCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			return intmodel.Cell{}, errors.New("StartCell must not run after RecreateCell brought the cell Ready")
+		},
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	if _, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack")); err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if !recreateCalled {
+		t.Error("RecreateCell was not called; reapply path was skipped")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fifth step of epic:cell-identity (umbrella #1020), narrowed at re-size to the **re-resolve correctness foundation** (AC1, AC2). The selector fan-out (P6, #1094) and Compatible-in-place / Breaking-recreate apply behaviour (P7, #1095) ship as their own steps.

The re-resolve path `materializeCellFromConfig` re-materialised `desired` from the lineage Config but never re-applied the cell's recorded `Spec.Provenance.EnvOverrides`. Since P3 (#1023) bakes `--env` overrides into the live container *and* records them in provenance, a cell created `--from-config --env K=V` reported a **spurious `OutOfSync`** on the next reconcile tick and had the override **stripped** on reapply (`RecreateCell`).

- Extracted the env-overlay helpers (`ApplyEnvOverrides` / `MergeEnv` / `ResolveAttachableContainerIndex`) out of `cmd/kuke/create/cell` into `internal/cellconfig` (new `envoverlay.go`), so the create, clone, and re-resolve paths all re-apply the overlay through one precedence-identical implementation. The create call site and clone (`cloneFromConfig`) now call the shared exported helpers; no behaviour change on those paths.
- Threaded the cell's recorded `Spec.Provenance.EnvOverrides` through `materializeCellFromConfig` (new `provenanceEnvOverrides` accessor), re-applying them **last** (P3 precedence) after `MaterializeWithName`. Both callers — the OutOfSync detector (`reconcile_outofsync.go`) and the start-time reapply (`start_cell.go`) — now produce a `desired` whose attachable-container `Env` matches the live cell.
- Re-resolve still diffs via the existing `apply.DiffCell` — no new diff machinery (AC1).

This slice is unit-testable with **no runner changes**.

## Notes for the reviewer

- **Config-lineage only / `--param` scope.** `materializeCellFromConfig` is reached only for `kukeon.io/config`-lineage cells (`configLineage`), and `--param` is rejected on the Config path (the Config carries its own `spec.values`). So the override that needs re-applying on this path is `--env`; the issue's "(and recorded `--param`)" mention covers the Blueprint-lineage path, which has no OutOfSync/reapply detector in the tree today. Documented here so the reviewer can confirm the narrowed scope.
- **`ApplyEnvOverrides` on the re-resolve path** also re-records `Provenance.EnvOverrides` on the freshly-materialised doc; `DiffCell` ignores provenance (lineage data, not a runtime spec field), so this is inert for the diff and only keeps the materialised doc internally consistent.

## Test plan

- [x] `GOWORK=off go build ./...` — clean (bare `go build` trips a pre-existing `containerd/cgroups` workspace-resolution break unrelated to this change; the Makefile exports `GOWORK=off`).
- [x] `GOWORK=off go vet ./internal/cellconfig/... ./internal/controller/... ./cmd/kuke/create/cell/...` — clean.
- [x] `GOWORK=off go test $(go list ./... | grep -v /e2e)` — full root suite green (the `make test` target).
- [x] New unit tests:
  - `internal/cellconfig/envoverlay_test.go` — `MergeEnv` precedence/no-mutate, `ResolveAttachableContainerIndex` (Tty.Default, declaration order, root-skip), `ApplyEnvOverrides` (bake + provenance record, no-op, non-attachable, nil-provenance).
  - `reconcile_outofsync_test.go` — a `--from-config --env K=V` cell no longer produces a spurious `OutOfSync` (no metadata write) on re-resolve (AC2/AC3).
  - `start_cell_reapply_test.go` — the recorded override is re-baked into the `RecreateCell` desired spec, not stripped, on the start-time reapply (AC3).

## Acceptance criteria

- [x] Re-resolving a cell computes `desired` from its recorded provenance against the current binding and diffs via the existing `DiffCell` (no new diff machinery).
- [x] Per-cell `--env`/`--param` overrides survive re-resolve (re-applied last, P3 precedence). — `--env` on the Config-lineage re-resolve path; see reviewer note on `--param` scope.
- [x] A cell created `--from-config --env K=V` no longer reports a spurious `OutOfSync`, and the override is not stripped on reapply.
- [x] `go build ./...` + `go test ./...` clean (under `GOWORK=off`, per the Makefile).

Closes #1024