### PR TITLE
feat(start,restart): -l <selector> fleet fan-out across matched cells

### DIFF
--- a/cmd/kuke/restart/restart.go
+++ b/cmd/kuke/restart/restart.go
@@ -17,10 +17,12 @@
 package restart
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	getshared "github.com/eminwux/kukeon/cmd/kuke/get/shared"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -45,16 +47,19 @@ type MockControllerKey struct{}
 // end state as `kuke restart`. Issue #983.
 func NewRestartCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "restart <name>",
+		Use:     "restart [name]",
 		Aliases: []string{"res"},
-		Short:   "Restart a cell (bounces the process; on OutOfSync also reconciles from Config)",
+		Short:   "Restart a cell (or a fleet via -l <selector>; on OutOfSync also reconciles from Config)",
 		Long: "Restart a cell. Bounces the cell's containers (stop + start). " +
 			"When the cell carries a `kukeon.io/config=<name>` lineage label " +
 			"and the daemon has marked it OutOfSync, the start step uses the " +
 			"freshly materialised spec from the Config so the restart is also " +
 			"a reconcile — equivalent to `kuke stop` + `kuke start`. " +
-			"Severs any active attach session as a side effect of the stop step.",
-		Args:          cobra.ExactArgs(1),
+			"Severs any active attach session as a side effect of the stop step. " +
+			"With `-l <selector>` (mutually exclusive with a positional name) the " +
+			"restart fans out across every cell whose labels match, reconciling " +
+			"each matched cell individually — unmatched cells are untouched.",
+		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		RunE:          runRestart,
@@ -67,6 +72,8 @@ func NewRestartCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Stack that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_RESTART_CELL_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 
+	getshared.RegisterLabelSelectorFlag(cmd)
+
 	cmd.ValidArgsFunction = config.CompleteCellNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
@@ -76,7 +83,33 @@ func NewRestartCmd() *cobra.Command {
 }
 
 func runRestart(cmd *cobra.Command, args []string) error {
-	name := strings.TrimSpace(args[0])
+	selector, err := getshared.ParseLabelSelectorFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	var name string
+	if len(args) > 0 {
+		name = strings.TrimSpace(args[0])
+	}
+
+	if name != "" && !selector.Empty() {
+		return errdefs.ErrSelectorWithName
+	}
+	if name == "" && selector.Empty() {
+		return errdefs.ErrCellNameRequired
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if !selector.Empty() {
+		return restartBySelector(cmd, client, selector)
+	}
+
 	realm := strings.TrimSpace(viper.GetString(config.KUKE_RESTART_CELL_REALM.ViperKey))
 	space := strings.TrimSpace(viper.GetString(config.KUKE_RESTART_CELL_SPACE.ViperKey))
 	stack := strings.TrimSpace(viper.GetString(config.KUKE_RESTART_CELL_STACK.ViperKey))
@@ -103,11 +136,78 @@ func runRestart(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	client, err := resolveClient(cmd)
+	return restartOne(cmd, client, doc)
+}
+
+// restartBySelector lists cells in the (optionally realm/space/stack-scoped)
+// fleet, keeps those whose labels match selector, and restarts each one
+// individually by looping the per-cell verb. Realm/space/stack flags act as
+// list filters here (unset = no filter), mirroring `kuke get cell`; the scope
+// of each restart comes from the matched cell's own spec. A per-cell failure
+// is collected and the loop continues so one bad cell does not abort the rest
+// of the fleet rollout.
+func restartBySelector(cmd *cobra.Command, client kukeonv1.Client, selector *getshared.LabelSelector) error {
+	realm := getshared.ExplicitFlag(cmd, "realm", config.KUKE_RESTART_CELL_REALM.ViperKey)
+	space := getshared.ExplicitFlag(cmd, "space", config.KUKE_RESTART_CELL_SPACE.ViperKey)
+	stack := getshared.ExplicitFlag(cmd, "stack", config.KUKE_RESTART_CELL_STACK.ViperKey)
+
+	cells, err := client.ListCells(cmd.Context(), realm, space, stack)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = client.Close() }()
+	matched := filterCellsBySelector(cells, selector)
+	if len(matched) == 0 {
+		cmd.Println("No cells matched the selector.")
+		return nil
+	}
+
+	var errs []error
+	for i := range matched {
+		c := &matched[i]
+		doc := v1beta1.CellDoc{
+			APIVersion: v1beta1.APIVersionV1Beta1,
+			Kind:       v1beta1.KindCell,
+			Metadata:   v1beta1.CellMetadata{Name: c.Metadata.Name, Labels: map[string]string{}},
+			Spec: v1beta1.CellSpec{
+				ID:      c.Metadata.Name,
+				RealmID: c.Spec.RealmID,
+				SpaceID: c.Spec.SpaceID,
+				StackID: c.Spec.StackID,
+			},
+		}
+		if err := restartOne(cmd, client, doc); err != nil {
+			errs = append(errs, fmt.Errorf("restart cell %q: %w", c.Metadata.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// filterCellsBySelector returns the subset of cells whose Metadata.Labels
+// satisfy selector. A nil or empty selector returns the input slice
+// unmodified. Replicated inline (mirroring `kuke get cell`) rather than
+// importing the get/cell leaf, keeping the lifecycle verb off that package.
+func filterCellsBySelector(cells []v1beta1.CellDoc, selector *getshared.LabelSelector) []v1beta1.CellDoc {
+	if selector.Empty() {
+		return cells
+	}
+	out := make([]v1beta1.CellDoc, 0, len(cells))
+	for i := range cells {
+		if selector.Matches(cells[i].Metadata.Labels) {
+			out = append(out, cells[i])
+		}
+	}
+	return out
+}
+
+// restartOne runs the dual-mode restart state machine for a single cell
+// described by doc: a Ready cell is stop+start, a Stopped cell is start, and a
+// degraded cell is refused with a delete pointer. Shared by the positional-name
+// path and the per-match loop in restartBySelector.
+func restartOne(cmd *cobra.Command, client kukeonv1.Client, doc v1beta1.CellDoc) error {
+	name := doc.Metadata.Name
+	realm := doc.Spec.RealmID
+	space := doc.Spec.SpaceID
+	stack := doc.Spec.StackID
 
 	pre, err := client.GetCell(cmd.Context(), doc)
 	if err != nil {

--- a/cmd/kuke/restart/restart_test.go
+++ b/cmd/kuke/restart/restart_test.go
@@ -37,8 +37,8 @@ import (
 func TestNewRestartCmdMetadata(t *testing.T) {
 	cmd := restartpkg.NewRestartCmd()
 
-	if cmd.Use != "restart <name>" {
-		t.Errorf("Use mismatch: got %q want %q", cmd.Use, "restart <name>")
+	if cmd.Use != "restart [name]" {
+		t.Errorf("Use mismatch: got %q want %q", cmd.Use, "restart [name]")
 	}
 	if !strings.HasPrefix(cmd.Short, "Restart a cell") {
 		t.Errorf("Short mismatch: got %q", cmd.Short)
@@ -49,10 +49,13 @@ func TestNewRestartCmdMetadata(t *testing.T) {
 	if cmd.Args == nil {
 		t.Errorf("expected Args validator on positional leaf, got nil")
 	}
-	for _, f := range []string{"realm", "space", "stack"} {
+	for _, f := range []string{"realm", "space", "stack", "selector"} {
 		if cmd.Flag(f) == nil {
 			t.Errorf("expected flag --%s to be registered", f)
 		}
+	}
+	if cmd.Flag("selector").Shorthand != "l" {
+		t.Errorf("expected --selector shorthand -l, got %q", cmd.Flag("selector").Shorthand)
 	}
 	if cmd.ValidArgsFunction == nil {
 		t.Error("expected ValidArgsFunction to be set for cell-name completion")
@@ -303,9 +306,26 @@ func TestRestartCmd(t *testing.T) {
 			wantErr: "boom",
 		},
 		{
-			name:    "missing positional",
+			name:    "no name and no selector",
 			args:    []string{},
-			wantErr: "accepts 1 arg",
+			wantErr: "cell name is required",
+		},
+		{
+			name:    "name and selector are mutually exclusive",
+			args:    []string{"c1", "-l", "env=prod"},
+			wantErr: "--selector cannot be combined with a resource name",
+		},
+		{
+			name: "selector matching nothing reports no match",
+			args: []string{"-l", "env=staging"},
+			fake: &fakeClient{
+				listCellsFn: func() ([]v1beta1.CellDoc, error) {
+					return []v1beta1.CellDoc{
+						cellWithLabels("c1", "r1", "s1", "st1", map[string]string{"env": "prod"}),
+					}, nil
+				},
+			},
+			wantOutput: "No cells matched the selector.",
 		},
 	}
 
@@ -351,9 +371,10 @@ func TestRestartCmd(t *testing.T) {
 }
 
 // TestRestartCmd_RejectsCellSubcommand pins the hard CLI break: the `restart cell <name>` subcommand form
-// must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
-// after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
-// subcommand list, so cobra's unknown-command path no longer fires.
+// must fail with cobra's Args-validation error (`accepts at most 1 arg(s), received 2`)
+// after the collapse — the verb is now a leaf with `cobra.MaximumNArgs(1)` (a bare
+// name or a bare `-l` selector, never two positionals) and no subcommand list, so
+// cobra's unknown-command path no longer fires.
 func TestRestartCmd_RejectsCellSubcommand(t *testing.T) {
 	cmd := restartpkg.NewRestartCmd()
 	buf := &bytes.Buffer{}
@@ -364,6 +385,66 @@ func TestRestartCmd_RejectsCellSubcommand(t *testing.T) {
 	err := cmd.Execute()
 	if err == nil {
 		t.Fatal("expected error invoking removed `restart cell` subcommand, got nil")
+	}
+}
+
+// TestRestartCmd_SelectorFanOutIndividual pins AC #1: `-l` re-resolves every
+// matched cell individually (running the per-cell state machine on each) and
+// leaves unmatched cells untouched — only matched cells reach GetCell/StartCell.
+func TestRestartCmd_SelectorFanOutIndividual(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+
+	fake := &fakeClient{
+		listCellsFn: func() ([]v1beta1.CellDoc, error) {
+			return []v1beta1.CellDoc{
+				cellWithLabels("c1", "r1", "s1", "st1", map[string]string{"env": "prod"}),
+				cellWithLabels("c2", "r1", "s1", "st1", map[string]string{"env": "dev"}),
+				cellWithLabels("c3", "r2", "s2", "st2", map[string]string{"env": "prod"}),
+			}, nil
+		},
+		// Matched cells are Stopped, so the per-cell path is GetCell → StartCell
+		// (the restartStopped branch) — no StopCell needed.
+		getCellFn: func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			cell := doc
+			cell.Status.State = v1beta1.CellStateStopped
+			return kukeonv1.GetCellResult{MetadataExists: true, Cell: cell}, nil
+		},
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+		},
+	}
+
+	cmd := restartpkg.NewRestartCmd()
+	outBuf := &bytes.Buffer{}
+	cmd.SetOut(outBuf)
+	cmd.SetErr(outBuf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, restartpkg.MockControllerKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-l", "env=prod"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"c1", "c3"}
+	if len(fake.getCellNames) != len(want) {
+		t.Fatalf("GetCell called on %v, want %v", fake.getCellNames, want)
+	}
+	for i, name := range want {
+		if fake.getCellNames[i] != name {
+			t.Errorf("getCellNames[%d] = %q, want %q (%v)", i, fake.getCellNames[i], name, fake.getCellNames)
+		}
+	}
+	for _, name := range fake.getCellNames {
+		if name == "c2" {
+			t.Errorf("unmatched cell c2 was reconciled; fan-out must leave it untouched")
+		}
+	}
+	if fake.startCalls != 2 {
+		t.Errorf("StartCell called %d times, want 2 (one per matched cell)", fake.startCalls)
 	}
 }
 
@@ -381,6 +462,7 @@ type fakeClient struct {
 	stopCellFn     func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
 	startCellFn    func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
 	applyDocsFn    func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error)
+	listCellsFn    func() ([]v1beta1.CellDoc, error)
 
 	getCellCalls int
 	stopCalls    int
@@ -388,14 +470,37 @@ type fakeClient struct {
 	getConfigCnt int
 	getBpCalls   int
 	applyCalls   int
+	getCellNames []string
 }
 
 func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
 	f.getCellCalls++
+	f.getCellNames = append(f.getCellNames, doc.Metadata.Name)
 	if f.getCellFn == nil {
 		return kukeonv1.GetCellResult{}, errors.New("unexpected GetCell call")
 	}
 	return f.getCellFn(doc)
+}
+
+func (f *fakeClient) ListCells(_ context.Context, _, _, _ string) ([]v1beta1.CellDoc, error) {
+	if f.listCellsFn == nil {
+		return nil, errors.New("unexpected ListCells call")
+	}
+	return f.listCellsFn()
+}
+
+// cellWithLabels builds a minimal CellDoc carrying the given scope and labels
+// for selector fan-out tests.
+func cellWithLabels(name, realm, space, stack string, labels map[string]string) v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: name, Labels: labels},
+		Spec: v1beta1.CellSpec{
+			ID:      name,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+		},
+	}
 }
 
 func (f *fakeClient) GetConfig(_ context.Context, doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {

--- a/cmd/kuke/start/start.go
+++ b/cmd/kuke/start/start.go
@@ -17,10 +17,12 @@
 package start
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/eminwux/kukeon/cmd/config"
+	getshared "github.com/eminwux/kukeon/cmd/kuke/get/shared"
 	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
@@ -32,66 +34,20 @@ import (
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
 type MockControllerKey struct{}
 
-// NewStartCmd builds the `kuke start <name>` leaf command. Cell is the only
-// resource this verb targets, so the noun is implied by the verb.
+// NewStartCmd builds the `kuke start [name]` leaf command. Cell is the only
+// resource this verb targets, so the noun is implied by the verb. A bare name
+// starts one cell; `-l <selector>` fans the start out across every cell whose
+// labels match (mutually exclusive with a positional name), reconciling each
+// matched cell individually — unmatched cells are untouched.
 func NewStartCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "start <name>",
+		Use:           "start [name]",
 		Aliases:       []string{"sta"},
-		Short:         "Start a cell",
-		Args:          cobra.ExactArgs(1),
+		Short:         "Start a cell (or a fleet via -l <selector>)",
+		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			name := strings.TrimSpace(args[0])
-			realm := strings.TrimSpace(viper.GetString(config.KUKE_START_CELL_REALM.ViperKey))
-			space := strings.TrimSpace(viper.GetString(config.KUKE_START_CELL_SPACE.ViperKey))
-			stack := strings.TrimSpace(viper.GetString(config.KUKE_START_CELL_STACK.ViperKey))
-
-			if realm == "" {
-				return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
-			}
-			if space == "" {
-				return fmt.Errorf("%w (--space)", errdefs.ErrSpaceNameRequired)
-			}
-			if stack == "" {
-				return fmt.Errorf("%w (--stack)", errdefs.ErrStackNameRequired)
-			}
-
-			doc := v1beta1.CellDoc{
-				APIVersion: v1beta1.APIVersionV1Beta1,
-				Kind:       v1beta1.KindCell,
-				Metadata:   v1beta1.CellMetadata{Name: name, Labels: map[string]string{}},
-				Spec: v1beta1.CellSpec{
-					ID:      name,
-					RealmID: realm,
-					SpaceID: space,
-					StackID: stack,
-				},
-			}
-
-			client, err := resolveClient(cmd)
-			if err != nil {
-				return err
-			}
-			defer func() { _ = client.Close() }()
-
-			result, err := client.StartCell(cmd.Context(), doc)
-			if err != nil {
-				return err
-			}
-
-			cellName := result.Cell.Metadata.Name
-			if cellName == "" {
-				cellName = name
-			}
-			stackName := result.Cell.Spec.StackID
-			if stackName == "" {
-				stackName = stack
-			}
-			cmd.Printf("Started cell %q from stack %q\n", cellName, stackName)
-			return nil
-		},
+		RunE:          runStart,
 	}
 
 	cmd.Flags().String("realm", "", "Realm that owns the cell")
@@ -101,12 +57,152 @@ func NewStartCmd() *cobra.Command {
 	cmd.Flags().String("stack", "", "Stack that owns the cell")
 	_ = viper.BindPFlag(config.KUKE_START_CELL_STACK.ViperKey, cmd.Flags().Lookup("stack"))
 
+	getshared.RegisterLabelSelectorFlag(cmd)
+
 	cmd.ValidArgsFunction = config.CompleteCellNames
 	_ = cmd.RegisterFlagCompletionFunc("realm", config.CompleteRealmNames)
 	_ = cmd.RegisterFlagCompletionFunc("space", config.CompleteSpaceNames)
 	_ = cmd.RegisterFlagCompletionFunc("stack", config.CompleteStackNames)
 
 	return cmd
+}
+
+func runStart(cmd *cobra.Command, args []string) error {
+	selector, err := getshared.ParseLabelSelectorFlag(cmd)
+	if err != nil {
+		return err
+	}
+
+	var name string
+	if len(args) > 0 {
+		name = strings.TrimSpace(args[0])
+	}
+
+	if name != "" && !selector.Empty() {
+		return errdefs.ErrSelectorWithName
+	}
+	if name == "" && selector.Empty() {
+		return errdefs.ErrCellNameRequired
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	if !selector.Empty() {
+		return startBySelector(cmd, client, selector)
+	}
+
+	realm := strings.TrimSpace(viper.GetString(config.KUKE_START_CELL_REALM.ViperKey))
+	space := strings.TrimSpace(viper.GetString(config.KUKE_START_CELL_SPACE.ViperKey))
+	stack := strings.TrimSpace(viper.GetString(config.KUKE_START_CELL_STACK.ViperKey))
+
+	if realm == "" {
+		return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
+	}
+	if space == "" {
+		return fmt.Errorf("%w (--space)", errdefs.ErrSpaceNameRequired)
+	}
+	if stack == "" {
+		return fmt.Errorf("%w (--stack)", errdefs.ErrStackNameRequired)
+	}
+
+	doc := v1beta1.CellDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCell,
+		Metadata:   v1beta1.CellMetadata{Name: name, Labels: map[string]string{}},
+		Spec: v1beta1.CellSpec{
+			ID:      name,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+		},
+	}
+
+	return startOne(cmd, client, doc)
+}
+
+// startOne starts a single cell described by doc and prints the per-cell
+// confirmation line. Shared by the positional-name path and the per-match
+// loop in startBySelector so both paths render identical output.
+func startOne(cmd *cobra.Command, client kukeonv1.Client, doc v1beta1.CellDoc) error {
+	result, err := client.StartCell(cmd.Context(), doc)
+	if err != nil {
+		return err
+	}
+
+	cellName := result.Cell.Metadata.Name
+	if cellName == "" {
+		cellName = doc.Metadata.Name
+	}
+	stackName := result.Cell.Spec.StackID
+	if stackName == "" {
+		stackName = doc.Spec.StackID
+	}
+	cmd.Printf("Started cell %q from stack %q\n", cellName, stackName)
+	return nil
+}
+
+// startBySelector lists cells in the (optionally realm/space/stack-scoped)
+// fleet, keeps those whose labels match selector, and starts each one
+// individually by looping the per-cell verb. Realm/space/stack flags act as
+// list filters here (unset = no filter), mirroring `kuke get cell`; the scope
+// of each StartCell call comes from the matched cell's own spec. A per-cell
+// failure is collected and the loop continues so one bad cell does not abort
+// the rest of the fleet rollout.
+func startBySelector(cmd *cobra.Command, client kukeonv1.Client, selector *getshared.LabelSelector) error {
+	realm := getshared.ExplicitFlag(cmd, "realm", config.KUKE_START_CELL_REALM.ViperKey)
+	space := getshared.ExplicitFlag(cmd, "space", config.KUKE_START_CELL_SPACE.ViperKey)
+	stack := getshared.ExplicitFlag(cmd, "stack", config.KUKE_START_CELL_STACK.ViperKey)
+
+	cells, err := client.ListCells(cmd.Context(), realm, space, stack)
+	if err != nil {
+		return err
+	}
+	matched := filterCellsBySelector(cells, selector)
+	if len(matched) == 0 {
+		cmd.Println("No cells matched the selector.")
+		return nil
+	}
+
+	var errs []error
+	for i := range matched {
+		c := &matched[i]
+		doc := v1beta1.CellDoc{
+			APIVersion: v1beta1.APIVersionV1Beta1,
+			Kind:       v1beta1.KindCell,
+			Metadata:   v1beta1.CellMetadata{Name: c.Metadata.Name, Labels: map[string]string{}},
+			Spec: v1beta1.CellSpec{
+				ID:      c.Metadata.Name,
+				RealmID: c.Spec.RealmID,
+				SpaceID: c.Spec.SpaceID,
+				StackID: c.Spec.StackID,
+			},
+		}
+		if err := startOne(cmd, client, doc); err != nil {
+			errs = append(errs, fmt.Errorf("start cell %q: %w", c.Metadata.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// filterCellsBySelector returns the subset of cells whose Metadata.Labels
+// satisfy selector. A nil or empty selector returns the input slice
+// unmodified. Replicated inline (mirroring `kuke get cell`) rather than
+// importing the get/cell leaf, keeping the lifecycle verb off that package.
+func filterCellsBySelector(cells []v1beta1.CellDoc, selector *getshared.LabelSelector) []v1beta1.CellDoc {
+	if selector.Empty() {
+		return cells
+	}
+	out := make([]v1beta1.CellDoc, 0, len(cells))
+	for i := range cells {
+		if selector.Matches(cells[i].Metadata.Labels) {
+			out = append(out, cells[i])
+		}
+	}
+	return out
 }
 
 func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {

--- a/cmd/kuke/start/start_test.go
+++ b/cmd/kuke/start/start_test.go
@@ -37,10 +37,10 @@ import (
 func TestNewStartCmdMetadata(t *testing.T) {
 	cmd := startpkg.NewStartCmd()
 
-	if cmd.Use != "start <name>" {
-		t.Errorf("Use mismatch: got %q want %q", cmd.Use, "start <name>")
+	if cmd.Use != "start [name]" {
+		t.Errorf("Use mismatch: got %q want %q", cmd.Use, "start [name]")
 	}
-	if cmd.Short != "Start a cell" {
+	if cmd.Short != "Start a cell (or a fleet via -l <selector>)" {
 		t.Errorf("Short mismatch: got %q", cmd.Short)
 	}
 	if !cmd.HasAlias("sta") {
@@ -49,10 +49,13 @@ func TestNewStartCmdMetadata(t *testing.T) {
 	if cmd.Args == nil {
 		t.Errorf("expected Args validator on positional leaf, got nil")
 	}
-	for _, f := range []string{"realm", "space", "stack"} {
+	for _, f := range []string{"realm", "space", "stack", "selector"} {
 		if cmd.Flag(f) == nil {
 			t.Errorf("expected flag --%s to be registered", f)
 		}
+	}
+	if cmd.Flag("selector").Shorthand != "l" {
+		t.Errorf("expected --selector shorthand -l, got %q", cmd.Flag("selector").Shorthand)
 	}
 	if cmd.ValidArgsFunction == nil {
 		t.Error("expected ValidArgsFunction to be set for cell-name completion")
@@ -109,9 +112,43 @@ func TestStartCmd(t *testing.T) {
 			wantErr: "cell not found",
 		},
 		{
-			name:    "missing positional",
+			name:    "no name and no selector",
 			args:    []string{},
-			wantErr: "accepts 1 arg",
+			wantErr: "cell name is required",
+		},
+		{
+			name:    "name and selector are mutually exclusive",
+			args:    []string{"c1", "-l", "env=prod"},
+			wantErr: "--selector cannot be combined with a resource name",
+		},
+		{
+			name: "selector fan-out starts every matched cell",
+			args: []string{"-l", "env=prod"},
+			fake: &fakeClient{
+				listCellsFn: func() ([]v1beta1.CellDoc, error) {
+					return []v1beta1.CellDoc{
+						cellWithLabels("c1", "r1", "s1", "st1", map[string]string{"env": "prod"}),
+						cellWithLabels("c2", "r1", "s1", "st1", map[string]string{"env": "dev"}),
+						cellWithLabels("c3", "r2", "s2", "st2", map[string]string{"env": "prod"}),
+					}, nil
+				},
+				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+				},
+			},
+			wantOutput: `Started cell "c1" from stack "st1"`,
+		},
+		{
+			name: "selector matching nothing reports no match",
+			args: []string{"-l", "env=staging"},
+			fake: &fakeClient{
+				listCellsFn: func() ([]v1beta1.CellDoc, error) {
+					return []v1beta1.CellDoc{
+						cellWithLabels("c1", "r1", "s1", "st1", map[string]string{"env": "prod"}),
+					}, nil
+				},
+			},
+			wantOutput: "No cells matched the selector.",
 		},
 	}
 	for _, tt := range tests {
@@ -152,9 +189,10 @@ func TestStartCmd(t *testing.T) {
 }
 
 // TestStartCmd_RejectsCellSubcommand pins the hard CLI break: the `start cell <name>` subcommand form
-// must fail with cobra's Args-validation error (`accepts 1 arg(s), received 2`)
-// after the collapse — the verb is now a leaf with `cobra.ExactArgs(1)` and no
-// subcommand list, so cobra's unknown-command path no longer fires.
+// must fail with cobra's Args-validation error (`accepts at most 1 arg(s), received 2`)
+// after the collapse — the verb is now a leaf with `cobra.MaximumNArgs(1)` (a bare
+// name or a bare `-l` selector, never two positionals) and no subcommand list, so
+// cobra's unknown-command path no longer fires.
 func TestStartCmd_RejectsCellSubcommand(t *testing.T) {
 	cmd := startpkg.NewStartCmd()
 	buf := &bytes.Buffer{}
@@ -172,11 +210,84 @@ type fakeClient struct {
 	kukeonv1.FakeClient
 
 	startCellFn func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
+	listCellsFn func() ([]v1beta1.CellDoc, error)
+	started     []string
 }
 
 func (f *fakeClient) StartCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
 	if f.startCellFn == nil {
 		return kukeonv1.StartCellResult{}, errors.New("unexpected StartCell call")
 	}
+	f.started = append(f.started, doc.Metadata.Name)
 	return f.startCellFn(doc)
+}
+
+func (f *fakeClient) ListCells(_ context.Context, _, _, _ string) ([]v1beta1.CellDoc, error) {
+	if f.listCellsFn == nil {
+		return nil, errors.New("unexpected ListCells call")
+	}
+	return f.listCellsFn()
+}
+
+// cellWithLabels builds a minimal CellDoc carrying the given scope and labels
+// for selector fan-out tests.
+func cellWithLabels(name, realm, space, stack string, labels map[string]string) v1beta1.CellDoc {
+	return v1beta1.CellDoc{
+		Metadata: v1beta1.CellMetadata{Name: name, Labels: labels},
+		Spec: v1beta1.CellSpec{
+			ID:      name,
+			RealmID: realm,
+			SpaceID: space,
+			StackID: stack,
+		},
+	}
+}
+
+// TestStartCmd_SelectorFanOutIndividual pins AC #1: `-l` re-resolves every
+// matched cell individually and leaves unmatched cells untouched.
+func TestStartCmd_SelectorFanOutIndividual(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+
+	fake := &fakeClient{
+		listCellsFn: func() ([]v1beta1.CellDoc, error) {
+			return []v1beta1.CellDoc{
+				cellWithLabels("c1", "r1", "s1", "st1", map[string]string{"env": "prod"}),
+				cellWithLabels("c2", "r1", "s1", "st1", map[string]string{"env": "dev"}),
+				cellWithLabels("c3", "r2", "s2", "st2", map[string]string{"env": "prod"}),
+			}, nil
+		},
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+		},
+	}
+
+	cmd := startpkg.NewStartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, startpkg.MockControllerKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-l", "env=prod"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"c1", "c3"}
+	if len(fake.started) != len(want) {
+		t.Fatalf("started %v, want %v", fake.started, want)
+	}
+	for i, name := range want {
+		if fake.started[i] != name {
+			t.Errorf("started[%d] = %q, want %q (started=%v)", i, fake.started[i], name, fake.started)
+		}
+	}
+	for _, name := range fake.started {
+		if name == "c2" {
+			t.Errorf("unmatched cell c2 was started; fan-out must leave it untouched")
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Sixth step of **epic:cell-identity** (umbrella #1020). Adds `-l <selector>` to `kuke start` and `kuke restart` so a binding edit can be rolled out across an entire lineage-labelled fleet in one command, instead of one cell per invocation.
- Reuses the established selector idiom exactly as `kuke get cell` does: `getshared.RegisterLabelSelectorFlag` / `ParseLabelSelectorFlag` + `client.ListCells` + an inline `filterCellsBySelector`. The leaves switch from `cobra.ExactArgs(1)` to `cobra.MaximumNArgs(1)` so a bare `-l` (no positional) is valid.
- Matched cells reconcile **individually** by looping the existing per-cell verb (`startOne` / `restartOne`, both extracted from the prior inline bodies) — no implicit fan-out to unmatched cells; predictable blast radius. A per-cell failure is collected (`errors.Join`) and the loop continues so one bad cell does not abort the rest of the rollout.
- A cell name and `-l` supplied together errors with `errdefs.ErrSelectorWithName` (mutually exclusive, like `kuke get cell`). A bare invocation with neither errors with `errdefs.ErrCellNameRequired`.
- No new `reconcile` verb — the trigger stays on the existing lifecycle verbs. No reconcile-engine changes (this is a pure CLI-surface delta, as the issue notes when it sliced this out of P5/#1024).

## Implementation notes (for reviewer push-back)

- **Realm/space/stack on the selector path** are treated as list *filters* via `getshared.ExplicitFlag` (unset = no filter = fleet-wide), mirroring `kuke get cell`'s list path — the scope of each individual `StartCell`/restart comes from the matched cell's own spec. The single-name path keeps its existing required-realm/space/stack behaviour unchanged.
- **`filterCellsBySelector` is replicated inline** in each leaf rather than imported from the `get/cell` package, matching that package's own precedent (it replicates `hasConfigLineage` inline) and keeping the lifecycle verbs off the `get/cell` leaf.
- Updated two now-stale `cobra.ExactArgs(1)` doc-comments in the existing `*_RejectsCellSubcommand` tests, since the diff changes that exact validator to `MaximumNArgs(1)` (the 2-positional rejection still holds).

## Test plan

- [x] \`GOTOOLCHAIN=go1.24.5 GOWORK=off go build ./...\` (root module) — clean
- [x] \`GOTOOLCHAIN=go1.24.5 GOWORK=off go vet ./cmd/kuke/start/... ./cmd/kuke/restart/...\` — clean
- [x] \`make test\` (root module `test-root` under go1.24.5: **0 failures**; `cmd/kukebuild` submodule under its required go1.25.5: **ok**). The two submodules declare divergent Go-version requirements (root pins ≤1.24.x for the `containerd/cgroups` dep; `cmd/kukebuild` requires 1.25.5), so a single `make test` invocation can't satisfy both toolchains at once — CI runs them as separate named steps (per the `Makefile` comment) and each is green. `cmd/kukebuild` is untouched by this diff.
- [x] New unit tests: selector fan-out reconciles only matched cells and leaves unmatched cells untouched (`TestStartCmd_SelectorFanOutIndividual`, `TestRestartCmd_SelectorFanOutIndividual`); name+`-l` mutual exclusion; no-name-no-selector error; empty-match reports "No cells matched the selector."

## Acceptance criteria

- [x] \`kuke start -l <selector>\` and \`kuke restart -l <selector>\` re-resolve every matched cell individually; unmatched cells are untouched.
- [x] Supplying both a cell name and \`-l\` errors.
- [x] No new \`reconcile\` verb is added — lifecycle verbs carry the trigger.
- [x] \`go build ./...\` + \`go test ./...\` clean (per the submodule-toolchain note above).

Docs (P9 — #1026) are out of scope for this step per the issue.

Closes #1094