### PR TITLE
feat(reconcile): in-place apply for Compatible OutOfSync diffs, recreate for Breaking (P7)

### DIFF
--- a/internal/controller/start_cell.go
+++ b/internal/controller/start_cell.go
@@ -84,9 +84,11 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 	}
 
 	// Reapply the lineage Config when the persisted OutOfSync flag is set, so
-	// the start runs against the freshly materialised spec — see #983. If the
-	// reapply already brought the cell back to Ready (RecreateCell path), the
-	// caller is done; otherwise fall through to the regular runner.StartCell.
+	// the start runs against the freshly materialised spec — see #983. A
+	// Breaking diff recreates the cell; a Compatible diff is applied in place
+	// with the container overlay preserved (epic:cell-identity P7, #1095). If
+	// the reapply already brought the cell back to Ready, the caller is done;
+	// otherwise fall through to the regular runner.StartCell.
 	if reapplied, started, ok := b.reapplyOutOfSyncFromConfig(internalCell); ok {
 		internalCell = reapplied
 		if started {
@@ -113,21 +115,36 @@ func (b *Exec) StartCell(cell intmodel.Cell) (StartCellResult, error) {
 }
 
 // reapplyOutOfSyncFromConfig re-materialises the cell from its lineage Config
-// and rebuilds the on-disk + containerd state when the persisted OutOfSync
-// flag is set on a Config-lineage cell. Returns:
+// and reconciles the on-disk + containerd state when the persisted OutOfSync
+// flag is set on a Config-lineage cell. The materialised diff is routed by
+// change class (epic:cell-identity P7, #1095):
 //
-//   - (cell, true,  true)  : reapply rebuilt the cell; runner.RecreateCell
-//     already brought it to Ready, the caller should
-//     skip its runner.StartCell pass.
-//   - (cell, false, true)  : reapply ran, but the materialised spec matched
-//     the on-disk spec or only metadata diverged — the
-//     caller continues with the regular start pass.
-//   - (zero, false, false) : reapply did not run (no lineage label, OutOfSync
-//     flag clear, OutOfSyncError set, lineage Config /
-//     Blueprint missing, materialise error). Caller
-//     continues with the on-disk spec — the runtime is
-//     still bounced as the operator asked, matching the
-//     CLI restart fall-through (cmd/kuke/restart).
+//   - Breaking diff → runner.RecreateCell. The diverged field is baked into
+//     the cell's OCI runtime spec at create (root image/command/args, a
+//     host-namespace toggle, …), so the cell must be torn down and rebuilt;
+//     the container overlay is wiped (volume-backed memory survives once
+//     #1015 lands).
+//   - Compatible / Additive diff → in-place apply with the root overlay
+//     preserved: runner.StartCell restarts the cell on its existing
+//     containerd snapshot (issue #867), then runner.UpdateCell re-persists the
+//     compatible metadata (env/ports/volumes) and stop-remove-recreate-starts
+//     any non-root child whose image/command/args changed. UpdateCell cannot
+//     run on a stopped cell — non-root children join the root's pid/net/ipc
+//     namespaces — so the StartCell-then-UpdateCell ordering is load-bearing.
+//
+// Returns:
+//
+//   - (cell, true,  true)  : reapply rebuilt or in-place-reconciled the cell
+//     and brought it to Ready; the caller should skip
+//     its runner.StartCell pass.
+//   - (zero, false, false) : reapply did not run or could not complete its
+//     runtime step (no lineage label, OutOfSync flag
+//     clear, OutOfSyncError set, lineage Config /
+//     Blueprint missing, materialise error, no diff, or
+//     a RecreateCell/StartCell failure). Caller continues
+//     with the on-disk spec — the runtime is still bounced
+//     as the operator asked, matching the CLI restart
+//     fall-through (cmd/kuke/restart).
 func (b *Exec) reapplyOutOfSyncFromConfig(cell intmodel.Cell) (intmodel.Cell, bool, bool) {
 	if !cell.Status.OutOfSync || cell.Status.OutOfSyncError != "" {
 		return intmodel.Cell{}, false, false
@@ -187,12 +204,24 @@ func (b *Exec) reapplyOutOfSyncFromConfig(cell intmodel.Cell) (intmodel.Cell, bo
 		return intmodel.Cell{}, false, false
 	}
 
-	// Rebuild the cell from the materialised spec. RecreateCell tears down the
-	// containerd records (post-#867 stop leaves them in place with the old
-	// spec-hash, which would otherwise make startCellLocked refuse the new
-	// spec), recreates fresh containers, and ends by calling startCellLocked
-	// so the cell lands in Ready. Mirrors the restart CLI's
-	// ApplyDocuments+StopCell+StartCell sequence for a Stopped cell.
+	// Route by change class. A Breaking diff (the RecreateCell domain
+	// apply.ReconcileCell uses — root-container baked fields, host-namespace
+	// toggles) sets diff.ChangeType to Breaking; anything else (Compatible or
+	// Additive) is applied in place with the overlay preserved.
+	if diff.ChangeType == apply.ChangeTypeBreaking {
+		return b.reapplyBreaking(cell, desired, configName)
+	}
+	return b.reapplyCompatibleInPlace(cell, desired, configName)
+}
+
+// reapplyBreaking rebuilds the cell from the materialised spec via
+// RecreateCell. RecreateCell tears down the containerd records (post-#867 stop
+// leaves them in place with the old spec-hash, which would otherwise make
+// startCellLocked refuse the new spec), recreates fresh containers — wiping the
+// container overlay — and ends by calling startCellLocked so the cell lands in
+// Ready. Mirrors the restart CLI's ApplyDocuments+StopCell+StartCell sequence
+// for a Stopped cell. On failure the caller falls back to the on-disk spec.
+func (b *Exec) reapplyBreaking(cell, desired intmodel.Cell, configName string) (intmodel.Cell, bool, bool) {
 	recreated, err := b.runner.RecreateCell(desired)
 	if err != nil {
 		b.logger.WarnContext(b.ctx,
@@ -205,9 +234,57 @@ func (b *Exec) reapplyOutOfSyncFromConfig(cell intmodel.Cell) (intmodel.Cell, bo
 	}
 
 	b.logger.InfoContext(b.ctx,
-		"reapplied OutOfSync cell from lineage config on start",
+		"reapplied OutOfSync cell from lineage config on start (breaking diff; recreated)",
 		"cell", cell.Metadata.Name,
 		"config", configName,
 	)
 	return recreated, true, true
+}
+
+// reapplyCompatibleInPlace applies a Compatible/Additive diff without wiping
+// the container overlay. The cell is started on its existing (on-disk) spec
+// first — StartCell's spec-hash reuse path (issue #867) restarts the root
+// container on its existing containerd snapshot, so the workload's writable
+// overlay survives. Starting from `desired` instead would trip
+// ErrCellSpecHashDrift the moment a non-root child's image/command/args
+// changed; that change is applied by UpdateCell afterwards, which stops,
+// removes, recreates, and starts only the affected child (the root container —
+// and its overlay — is never touched). UpdateCell needs the root running
+// because non-root children join its namespaces, so the ordering is
+// load-bearing.
+func (b *Exec) reapplyCompatibleInPlace(
+	cell, desired intmodel.Cell, configName string,
+) (intmodel.Cell, bool, bool) {
+	started, err := b.runner.StartCell(cell)
+	if err != nil {
+		b.logger.WarnContext(b.ctx,
+			"OutOfSync reapply StartCell failed; falling back to on-disk spec",
+			"cell", cell.Metadata.Name,
+			"config", configName,
+			"error", err,
+		)
+		return intmodel.Cell{}, false, false
+	}
+
+	updated, err := b.runner.UpdateCell(desired)
+	if err != nil {
+		// The cell is already Ready from StartCell above; the persisted
+		// OutOfSync flag stays set so the next start retries the in-place
+		// apply. Honour the operator's start request with the running,
+		// not-yet-reconciled cell rather than failing.
+		b.logger.WarnContext(b.ctx,
+			"OutOfSync reapply UpdateCell failed; cell started on the on-disk spec but not reconciled",
+			"cell", cell.Metadata.Name,
+			"config", configName,
+			"error", err,
+		)
+		return started, true, true
+	}
+
+	b.logger.InfoContext(b.ctx,
+		"reapplied OutOfSync cell from lineage config on start (compatible diff; in-place, overlay preserved)",
+		"cell", cell.Metadata.Name,
+		"config", configName,
+	)
+	return updated, true, true
 }

--- a/internal/controller/start_cell_reapply_test.go
+++ b/internal/controller/start_cell_reapply_test.go
@@ -109,6 +109,46 @@ spec:
 	}
 }
 
+// reapplyBreakingBlueprint materialises the "main" container with
+// hostNetwork:true — a host-namespace toggle apply.DiffCell classifies as
+// Breaking even on a non-root child (the netns shape is baked into the cell at
+// start). The live cell's main carries hostNetwork:false, so this is the sole
+// diff and it drives the RecreateCell (overlay-wiping) path. Image stays
+// nginx:1.0 so hostNetwork is the only divergence.
+func reapplyBreakingBlueprint(realm string) intmodel.CellBlueprint {
+	doc := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: web
+  realm: ` + realm + `
+spec:
+  cell:
+    containers:
+      - id: main
+        image: nginx:1.0
+        hostNetwork: true
+`
+	return intmodel.CellBlueprint{
+		Metadata: intmodel.CellBlueprintMetadata{
+			Name:  "web",
+			Realm: realm,
+		},
+		Document: []byte(doc),
+	}
+}
+
+// reapplyContainerImage returns the image of the container with the given ID in
+// the cell, or "" when absent. Used by the in-place reapply tests to assert
+// which spec (on-disk vs materialised) each runner method receives.
+func reapplyContainerImage(cell intmodel.Cell, id string) string {
+	for _, c := range cell.Spec.Containers {
+		if c.ID == id {
+			return c.Image
+		}
+	}
+	return ""
+}
+
 // reapplyLineageCell builds a stopped, OutOfSync, Config-lineage cell with the
 // given realm/space/stack scope. The cell's on-disk container image is
 // "nginx:1.0" — diverged from the Config's "nginx:2.0" — so the reapply path
@@ -136,11 +176,15 @@ func reapplyLineageCell(realm, space, stack string) intmodel.Cell {
 	}
 }
 
-func TestStartCell_OutOfSyncReapply_RecreatesFromConfig(t *testing.T) {
+// TestStartCell_OutOfSyncReapply_CompatibleAppliesInPlace pins AC1 of
+// epic:cell-identity P7 (#1095): a Compatible diff (here a non-root child image
+// bump nginx:1.0 → nginx:2.0) is applied in place — StartCell restarts the cell
+// on its existing snapshot so the overlay survives, then UpdateCell applies the
+// materialised drift. RecreateCell (which would wipe the overlay) must not run.
+func TestStartCell_OutOfSyncReapply_CompatibleAppliesInPlace(t *testing.T) {
 	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
 
-	var recreateCalled bool
-	var startCellCalled bool
+	var recreateCalled, startCellCalled, updateCellCalled bool
 	f := &fakeRunner{
 		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
 			return live, nil
@@ -159,32 +203,110 @@ func TestStartCell_OutOfSyncReapply_RecreatesFromConfig(t *testing.T) {
 			}
 			return reapplySampleBlueprint("test-realm"), nil
 		},
+		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			recreateCalled = true
+			return intmodel.Cell{}, errors.New(
+				"RecreateCell must not run for a Compatible diff — the overlay would be wiped",
+			)
+		},
+		StartCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			startCellCalled = true
+			// The in-place path starts on the live (on-disk) spec so the root
+			// snapshot is reused; the materialised image bump is applied by
+			// UpdateCell, not here. Starting from the materialised spec would
+			// trip ErrCellSpecHashDrift on the changed child.
+			if got := reapplyContainerImage(cell, "main"); got != "nginx:1.0" {
+				t.Errorf("StartCell main image = %q, want nginx:1.0 (on-disk spec, snapshot reuse)", got)
+			}
+			cell.Status.State = intmodel.CellStateReady
+			return cell, nil
+		},
+		UpdateCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			updateCellCalled = true
+			// UpdateCell receives the materialised spec — image bumped to
+			// nginx:2.0 — and the live cell's identity.
+			if cell.Metadata.Name != "prod" {
+				t.Errorf("UpdateCell name = %q, want prod", cell.Metadata.Name)
+			}
+			if cell.Spec.RealmName != "test-realm" {
+				t.Errorf("UpdateCell realm = %q, want test-realm", cell.Spec.RealmName)
+			}
+			if got := reapplyContainerImage(cell, "main"); got != "nginx:2.0" {
+				t.Errorf("UpdateCell main image = %q, want nginx:2.0 (materialised from Blueprint)", got)
+			}
+			cell.Status.State = intmodel.CellStateReady
+			return cell, nil
+		},
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	res, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack"))
+	if err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if recreateCalled {
+		t.Error("RecreateCell was called for a Compatible diff; the in-place path must be used")
+	}
+	if !startCellCalled {
+		t.Error("runner.StartCell was not called; the in-place reapply was skipped")
+	}
+	if !updateCellCalled {
+		t.Error("runner.UpdateCell was not called; the Compatible drift was not applied in place")
+	}
+	if !res.Started {
+		t.Error("Started = false, want true after successful in-place reapply")
+	}
+	if res.Cell.Status.State != intmodel.CellStateReady {
+		t.Errorf("cell state = %v, want Ready after in-place reapply", res.Cell.Status.State)
+	}
+}
+
+// TestStartCell_OutOfSyncReapply_BreakingRecreates pins AC2 of
+// epic:cell-identity P7 (#1095): a Breaking diff (here a hostNetwork toggle on
+// the child, baked into the cell's netns at start) drives RecreateCell — the
+// overlay-wiping path — not the in-place StartCell/UpdateCell pair.
+func TestStartCell_OutOfSyncReapply_BreakingRecreates(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+
+	var recreateCalled, startCellCalled, updateCellCalled bool
+	f := &fakeRunner{
+		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
+		},
+		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return reapplyBreakingBlueprint("test-realm"), nil
+		},
 		RecreateCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
 			recreateCalled = true
-			// The desired cell must carry the materialised spec — image bumped
-			// to nginx:2.0 from the Blueprint — and the live cell's identity.
 			if cell.Metadata.Name != "prod" {
 				t.Errorf("RecreateCell name = %q, want prod", cell.Metadata.Name)
 			}
-			if cell.Spec.RealmName != "test-realm" {
-				t.Errorf("RecreateCell realm = %q, want test-realm", cell.Spec.RealmName)
-			}
-			gotImage := ""
+			var hostNet bool
 			for _, c := range cell.Spec.Containers {
 				if c.ID == "main" {
-					gotImage = c.Image
+					hostNet = c.HostNetwork
 					break
 				}
 			}
-			if gotImage != "nginx:2.0" {
-				t.Errorf("RecreateCell main image = %q, want nginx:2.0 (materialised from Blueprint)", gotImage)
+			if !hostNet {
+				t.Error("RecreateCell main hostNetwork = false, want true (materialised from Blueprint)")
 			}
 			cell.Status.State = intmodel.CellStateReady
 			return cell, nil
 		},
 		StartCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
 			startCellCalled = true
-			return intmodel.Cell{}, errors.New("runner.StartCell must not be called after RecreateCell already brought the cell to Ready")
+			return intmodel.Cell{}, errors.New(
+				"runner.StartCell must not run for a Breaking diff — RecreateCell owns the start",
+			)
+		},
+		UpdateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			updateCellCalled = true
+			return intmodel.Cell{}, errors.New("runner.UpdateCell must not run for a Breaking diff")
 		},
 		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
 	}
@@ -195,27 +317,32 @@ func TestStartCell_OutOfSyncReapply_RecreatesFromConfig(t *testing.T) {
 		t.Fatalf("StartCell returned error: %v", err)
 	}
 	if !recreateCalled {
-		t.Error("RecreateCell was not called; reapply path was skipped")
+		t.Error("RecreateCell was not called for a Breaking diff; reapply routed in-place instead")
 	}
 	if startCellCalled {
-		t.Error("runner.StartCell was called after RecreateCell — double-start")
+		t.Error("runner.StartCell was called for a Breaking diff — double-start")
+	}
+	if updateCellCalled {
+		t.Error("runner.UpdateCell was called for a Breaking diff")
 	}
 	if !res.Started {
-		t.Error("Started = false, want true after successful reapply")
+		t.Error("Started = false, want true after successful Breaking reapply")
 	}
 	if res.Cell.Status.State != intmodel.CellStateReady {
 		t.Errorf("cell state = %v, want Ready after RecreateCell", res.Cell.Status.State)
 	}
 }
 
-// TestStartCell_OutOfSyncReapply_EnvOverridePreserved pins the AC3 reapply
-// half of epic:cell-identity P5 (#1024): a Config-lineage cell created
+// TestStartCell_OutOfSyncReapply_EnvOverridePreserved pins the reapply half of
+// epic:cell-identity P5 (#1024): a Config-lineage cell created
 // `--from-config --env K=V` records the override in Spec.Provenance.EnvOverrides
 // (P3 #1023). The reapply path re-materialises from the Config — which has no
 // knowledge of the per-cell override — so without re-applying provenance the
-// override is silently stripped on RecreateCell. With the fix, the desired cell
-// handed to RecreateCell carries the materialised Blueprint image *and* the
-// re-baked override (re-applied last, P3 precedence).
+// override is silently stripped. This is a Compatible diff (a non-root child
+// image bump + env), so post-P7 (#1095) it flows through the in-place
+// UpdateCell path; the desired cell handed to UpdateCell must carry the
+// materialised Blueprint image *and* the re-baked override (re-applied last,
+// P3 precedence).
 func TestStartCell_OutOfSyncReapply_EnvOverridePreserved(t *testing.T) {
 	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
 	// Simulate a cell created `--from-config --env APP_ENV=prod`: the override
@@ -226,7 +353,7 @@ func TestStartCell_OutOfSyncReapply_EnvOverridePreserved(t *testing.T) {
 		EnvOverrides: []string{"APP_ENV=prod"},
 	}
 
-	var recreateCalled bool
+	var updateCellCalled bool
 	f := &fakeRunner{
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
@@ -237,8 +364,15 @@ func TestStartCell_OutOfSyncReapply_EnvOverridePreserved(t *testing.T) {
 		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
 			return reapplyAttachableBlueprint("test-realm"), nil
 		},
-		RecreateCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
-			recreateCalled = true
+		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			return intmodel.Cell{}, errors.New("RecreateCell must not run for a Compatible diff")
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			c.Status.State = intmodel.CellStateReady
+			return c, nil
+		},
+		UpdateCellFn: func(cell intmodel.Cell) (intmodel.Cell, error) {
+			updateCellCalled = true
 			var main intmodel.ContainerSpec
 			for _, c := range cell.Spec.Containers {
 				if c.ID == "main" {
@@ -247,7 +381,7 @@ func TestStartCell_OutOfSyncReapply_EnvOverridePreserved(t *testing.T) {
 				}
 			}
 			if main.Image != "nginx:2.0" {
-				t.Errorf("RecreateCell main image = %q, want nginx:2.0 (materialised from Blueprint)", main.Image)
+				t.Errorf("UpdateCell main image = %q, want nginx:2.0 (materialised from Blueprint)", main.Image)
 			}
 			// The recorded override must survive re-resolve, not be stripped.
 			found := false
@@ -258,13 +392,13 @@ func TestStartCell_OutOfSyncReapply_EnvOverridePreserved(t *testing.T) {
 				}
 			}
 			if !found {
-				t.Errorf("RecreateCell main Env = %v, want it to retain APP_ENV=prod (provenance override stripped)", main.Env)
+				t.Errorf(
+					"UpdateCell main Env = %v, want it to retain APP_ENV=prod (provenance override stripped)",
+					main.Env,
+				)
 			}
 			cell.Status.State = intmodel.CellStateReady
 			return cell, nil
-		},
-		StartCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
-			return intmodel.Cell{}, errors.New("StartCell must not run after RecreateCell brought the cell Ready")
 		},
 		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
 	}
@@ -273,8 +407,58 @@ func TestStartCell_OutOfSyncReapply_EnvOverridePreserved(t *testing.T) {
 	if _, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack")); err != nil {
 		t.Fatalf("StartCell returned error: %v", err)
 	}
-	if !recreateCalled {
-		t.Error("RecreateCell was not called; reapply path was skipped")
+	if !updateCellCalled {
+		t.Error("UpdateCell was not called; the in-place reapply path was skipped")
+	}
+}
+
+// TestStartCell_OutOfSyncReapply_CompatibleUpdateErrorStillReady covers the
+// in-place degradation path: StartCell brought the cell to Ready on its
+// existing snapshot, but UpdateCell failed (e.g. an image pull error). The
+// operator's start request is still honoured with the running cell, and the
+// persisted OutOfSync flag stays set so the next start retries the apply.
+func TestStartCell_OutOfSyncReapply_CompatibleUpdateErrorStillReady(t *testing.T) {
+	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
+
+	var startCellCalled, updateCellCalled bool
+	f := &fakeRunner{
+		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
+		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
+		},
+		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return reapplySampleBlueprint("test-realm"), nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			startCellCalled = true
+			c.Status.State = intmodel.CellStateReady
+			return c, nil
+		},
+		UpdateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
+			updateCellCalled = true
+			return intmodel.Cell{}, errors.New("image pull failed")
+		},
+		UpdateCellMetadataFn: func(intmodel.Cell) error { return nil },
+	}
+
+	ctrl := setupTestController(t, f)
+	res, err := ctrl.StartCell(buildTestCell("prod", "test-realm", "test-space", "test-stack"))
+	if err != nil {
+		t.Fatalf("StartCell returned error: %v", err)
+	}
+	if !startCellCalled {
+		t.Error("runner.StartCell was not called; the in-place reapply was skipped")
+	}
+	if !updateCellCalled {
+		t.Error("runner.UpdateCell was not called; the Compatible drift was not attempted")
+	}
+	if !res.Started {
+		t.Error("Started = false, want true — the cell is Ready from StartCell even though UpdateCell failed")
+	}
+	if res.Cell.Status.State != intmodel.CellStateReady {
+		t.Errorf("cell state = %v, want Ready (degraded: started but not reconciled)", res.Cell.Status.State)
 	}
 }
 
@@ -423,9 +607,11 @@ func TestStartCell_OutOfSyncReapply_LineageConfigDeletedFallsThrough(t *testing.
 }
 
 // TestStartCell_OutOfSyncReapply_RecreateErrorFallsThrough covers the
-// graceful degradation: if RecreateCell fails (e.g. containerd unreachable),
-// reapply logs and falls back to the on-disk spec via runner.StartCell so the
-// operator's `kuke start` request is honored.
+// graceful degradation on the Breaking path: if RecreateCell fails (e.g.
+// containerd unreachable), reapply logs and falls back to the on-disk spec via
+// the caller's runner.StartCell so the operator's `kuke start` request is
+// honored. Uses a Breaking blueprint (hostNetwork toggle) so RecreateCell is
+// the path under test.
 func TestStartCell_OutOfSyncReapply_RecreateErrorFallsThrough(t *testing.T) {
 	live := reapplyLineageCell("test-realm", "test-space", "test-stack")
 
@@ -438,7 +624,7 @@ func TestStartCell_OutOfSyncReapply_RecreateErrorFallsThrough(t *testing.T) {
 			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
 		},
 		GetBlueprintFn: func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
-			return reapplySampleBlueprint("test-realm"), nil
+			return reapplyBreakingBlueprint("test-realm"), nil
 		},
 		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
 			return intmodel.Cell{}, errors.New("containerd unreachable")


### PR DESCRIPTION
## Summary

- Restructures the daemon-side OutOfSync reapply path (`reapplyOutOfSyncFromConfig` in `internal/controller/start_cell.go`) so a `kuke start`/`kuke restart` of an OutOfSync Config-lineage cell routes by **diff class** instead of always recreating:
  - **Breaking diff** (root-container baked fields, host-namespace toggles — the `RecreateCell` domain `apply.ReconcileCell` already uses) → `RecreateCell`, which tears down and rebuilds the cell. The container overlay is wiped (volume-backed memory survives once #1015 lands).
  - **Compatible / Additive diff** → in-place apply with the root overlay **preserved**: `StartCell` restarts the cell on its existing containerd snapshot (issue #867 spec-hash reuse), then `UpdateCell` re-persists the compatible metadata (env/ports/volumes) and stop-remove-recreate-starts any non-root child whose image/command/args changed.
- The `StartCell`-then-`UpdateCell` ordering is load-bearing and called out in the godoc: `UpdateCell` cannot run on a stopped cell (non-root children join the root's pid/net/ipc namespaces), and starting from the *materialised* spec would trip `ErrCellSpecHashDrift` on a changed child — so the cell is started on its on-disk spec first (reusing the snapshot) and the drift is applied afterward, leaving the root container and its overlay untouched.
- **AC3 (OutOfSync stays informational; no background auto-heal):** verified, no code change. `reconcileCellOutOfSync` (`internal/controller/reconcile_outofsync.go`) only detects and persists the flag via `UpdateCellMetadata`; the sole caller in the reconcile loop (`reconcile.go:115`) does not chain into any `StartCell`/`RecreateCell` heal. Healing fires only on explicit `StartCell`.

## Implementation notes

- The pre-existing reapply unit tests exercised a **non-root child image bump** (`nginx:1.0 → nginx:2.0`), which `apply.DiffCell` classifies as **Compatible** (image is breaking only on the *root* container). Those tests asserted `RecreateCell` was called — exactly the behavior AC1 changes. They are updated to assert the new in-place routing, and a new Breaking-path test uses a `hostNetwork` toggle (breaking even on a non-root child) to drive `RecreateCell`.
- `diff.ChangeType == apply.ChangeTypeBreaking` is the sole branch condition: a root-container breaking change and any other breaking change both set `ChangeType` to Breaking, so this subsumes `ReconcileCell`'s two-part breaking check for the reapply path.
- Graceful degradation preserved: a `RecreateCell`/`StartCell` failure falls back to the caller's on-disk `StartCell` (cell still bounced as the operator asked); a Compatible-path `UpdateCell` failure leaves the cell Ready (started on the on-disk spec) with the OutOfSync flag still set so the next start retries.

## Test plan

- [x] `make test` (full CI test target, `GOWORK=off`) — green, exit 0.
- [x] `go build ./internal/controller/...` + `go vet ./internal/controller/...` (`GOWORK=off`) — clean.
- [x] `pre-commit run --files <changed>` — passes (golangci-lint, go fmt, addlicense, …).
- [x] New/updated unit tests for the routing: `TestStartCell_OutOfSyncReapply_CompatibleAppliesInPlace`, `_BreakingRecreates`, `_CompatibleUpdateErrorStillReady`, `_EnvOverridePreserved` (now asserts the override survives the in-place `UpdateCell`), `_RecreateErrorFallsThrough` (now Breaking-path).
- [ ] `make dev-init` smoke — **blocked, environmental (not code).** The kukeond image build fails with `no space left on device` inside the BuildKit sandbox: this host's containerd store (`/var/lib/containerd`) is a **4 GB tmpfs at 93% full**, too small for the full `-a` Go rebuild the image build runs. `make test` (which covers the same daemon code) is green. The smoke should pass on a clean host / CI with adequate disk.
- [ ] On-device verification that a Compatible reapply preserves the overlay and a Breaking reapply recreates — **deferred to a clean host.** Depends on `make dev-init` standing up the daemon (blocked above). The Breaking-vs-Compatible **routing** (which runner method runs per diff class) is verified by the unit tests; the byte-on-disk overlay survival is a downstream consequence of `StartCell`'s #867 snapshot-reuse vs `RecreateCell`'s teardown (each already covered) and is the one observable left unverified in this environment.

Closes #1095