### PR TITLE
refactor(create-cell): replace mergeParamMaps with cellblueprint.MergeParams

### DIFF
--- a/cmd/kuke/create/cell/clone.go
+++ b/cmd/kuke/create/cell/clone.go
@@ -281,7 +281,7 @@ func cloneFromBlueprint(
 	if err != nil {
 		return v1beta1.CellDoc{}, err
 	}
-	mergedParams := mergeParamMaps(srcProv.Params, cliParams)
+	mergedParams := cellblueprint.MergeParams(srcProv.Params, cliParams)
 
 	resolved, err := cellblueprint.Resolve(bpRes.Blueprint, mergedParams, os.LookupEnv)
 	if err != nil {
@@ -299,24 +299,6 @@ func cloneFromBlueprint(
 		cellDoc.Spec.Provenance.Params = mergedParams
 	}
 	return cellDoc, nil
-}
-
-// mergeParamMaps layers override params on top of base params (override wins on
-// a key collision, last-write-wins per AC#6). Returns a fresh map; never
-// mutates either input. A nil/empty result stays nil so a no-override clone's
-// provenance is byte-equal to the source's.
-func mergeParamMaps(base, override map[string]string) map[string]string {
-	if len(base) == 0 && len(override) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(base)+len(override))
-	for k, v := range base {
-		out[k] = v
-	}
-	for k, v := range override {
-		out[k] = v
-	}
-	return out
 }
 
 // setSourceCellAnnotation stamps the inert kukeon.io/source-cell provenance


### PR DESCRIPTION
## Summary
- Drop the private `mergeParamMaps` helper in `cmd/kuke/create/cell/clone.go` (lines 304–320) and route the only call site (line 284) through `cellblueprint.MergeParams` — same signature, same CLI-wins semantics, already named in the line-279 contract comment.
- Aligns with the in-package precedent: `buildParamMap` (`cell.go:651`) already calls `cellblueprint.MergeParams` directly.

## Notes
- `mergeParamMaps` returned `nil` when both inputs were empty; `cellblueprint.MergeParams` always returns a fresh allocated map. The AC#6 byte-equality (no-`--param` clone's provenance unchanged from the source's) is preserved by the existing `if len(mergedParams) > 0` gate at `clone.go:298`, which skips the provenance assignment when the merged map is empty regardless of nil-vs-non-nil. `Resolve`/`MaterializeWithName` accept either shape, so no caller observes the difference.

## Test plan
- [x] `make test-root` (passes; `cmd/kuke/create/cell` tests `ok`)
- [x] `make test-kukebuild` (passes)
- [x] `GOWORK=off go build ./cmd/kuke/create/cell/...` (clean)

Closes #1093