### PR TITLE
fix(run): point -p removal pointer and create-cell help at current --from-blueprint/--from-config forms

### DIFF
--- a/cmd/kuke/create/blueprint/blueprint.go
+++ b/cmd/kuke/create/blueprint/blueprint.go
@@ -137,7 +137,7 @@ func emitBlueprintYAML(out io.Writer, name, realm, space, stack string) error {
 	b.WriteString(
 		"  # prefix: " + yamlScalar(
 			name,
-		) + "  # optional: cell-name prefix used by `kuke run -b` (defaults to metadata.name)\n",
+		) + "  # optional: cell-name prefix used by `kuke run --from-blueprint` (defaults to metadata.name)\n",
 	)
 	b.WriteString("  # parameters:\n")
 	b.WriteString("  #   - name: KEY\n")

--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -49,22 +49,23 @@ func NewCellCmd() *cobra.Command {
 			"resolves the daemon-stored CellBlueprint, applies scalar params, " +
 			"materialises the full Cell record (containers and all), and " +
 			"persists it in a **stopped** state. Run `kuke start <name>` to " +
-			"start it. Differs from `kuke run -b` (materialise + start + attach) " +
-			"by leaving the cell stopped for later inspection or hand-off; " +
-			"-b-lineage cells have no in-place reconcile, so updates flow through " +
-			"delete-and-re-run (or promotion to a CellConfig).\n" +
+			"start it. Differs from `kuke run --from-blueprint` (materialise + " +
+			"start + attach) by leaving the cell stopped for later inspection or " +
+			"hand-off; blueprint-lineage cells have no in-place reconcile, so " +
+			"updates flow through delete-and-re-run (or promotion to a " +
+			"CellConfig).\n" +
 			"  - `kuke create cell <name> --from-config <cfg>` — resolves the " +
 			"daemon-stored CellConfig and its referenced Blueprint, applies the " +
 			"Config's spec.values + repo/secret slot fills, materialises the " +
 			"Cell record, and persists it in a **stopped** state. Run " +
-			"`kuke start <name>` to start it. Differs from `kuke run <cfg>` " +
+			"`kuke start <name>` to start it. Differs from `kuke run --from-config` " +
 			"(materialise + start + attach) by leaving the cell stopped; later " +
 			"reconcile against the lineage Config flows through " +
 			"`kuke restart <name>` (OutOfSync-driven, #821) once the cell is " +
 			"started.\n\n" +
 			"--from-blueprint and --from-config are mutually exclusive. --param " +
 			"and --param-file are valid with --from-blueprint (mirroring " +
-			"`kuke run -b`); they are rejected with --from-config because a " +
+			"`kuke run --from-blueprint`); they are rejected with --from-config because a " +
 			"CellConfig carries its own values (edit the Config instead). " +
 			"Symmetrically, --env KEY=VALUE is valid with --from-config (a " +
 			"per-cell override layered on top of the Config's resolved values) " +

--- a/cmd/kuke/run/divergence_idempotency_test.go
+++ b/cmd/kuke/run/divergence_idempotency_test.go
@@ -29,7 +29,7 @@ import (
 
 // TestDivergedFields_MaterializePersistMaterializeIsIdempotent guards the
 // invariant that `kuke restart` writes a spec to disk that — when
-// re-materialised by the next `kuke run <config>` — compares clean against
+// re-materialised by the next `kuke run --from-config <cfg>` — compares clean against
 // the persisted version (issue #984). The flow being asserted:
 //
 //	Materialize(cfg, bp) → ApplyDocuments(persist) → GetCell → Materialize(cfg, bp)
@@ -122,7 +122,7 @@ func TestDivergedFields_MaterializePersistMaterializeIsIdempotent(t *testing.T) 
 				t.Fatalf("BuildCellExternalFromInternal (readback): %v", err)
 			}
 
-			// Step 4: Re-Materialize as the next `kuke run <config>` would.
+			// Step 4: Re-Materialize as the next `kuke run --from-config <cfg>` would.
 			cell2, err := cellconfig.MaterializeWithName(tc.cfg, tc.bp, cellconfig.Prefix(tc.cfg))
 			if err != nil {
 				t.Fatalf("Materialize (run side): %v", err)

--- a/cmd/kuke/run/env_test.go
+++ b/cmd/kuke/run/env_test.go
@@ -38,7 +38,7 @@ func TestParseEnvArgs_HappyPath(t *testing.T) {
 	}
 }
 
-// TestParseEnvArgs_EmptyInput is the no-flag case — `kuke run <cfg>` with
+// TestParseEnvArgs_EmptyInput is the no-flag case — `kuke run --from-config <cfg>` with
 // no --env flags must produce nil so cellDoc.Spec.RuntimeEnv stays its
 // zero value and the divergent-spec check sees an unchanged spec.
 func TestParseEnvArgs_EmptyInput(t *testing.T) {

--- a/cmd/kuke/run/run.go
+++ b/cmd/kuke/run/run.go
@@ -51,8 +51,9 @@ import (
 // flag. Defined once so tests can match on it via errors.Is.
 var errRemovedProfileFlag = errors.New(
 	"kuke run: -p/--profile (CellProfile) was removed in #626 — apply a " +
-		"kind: CellBlueprint and use `kuke run -b <name>` (or `kuke run <config>` " +
-		"for a daemon-stored CellConfig); see docs/site/guides/migrate-cellprofile-to-blueprint.md",
+		"kind: CellBlueprint and use `kuke run --from-blueprint <name>` (or " +
+		"`kuke run --from-config <cfg>` for a daemon-stored CellConfig); " +
+		"see docs/site/guides/migrate-cellprofile-to-blueprint.md",
 )
 
 // MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
@@ -860,7 +861,7 @@ func pickLocation(fromDoc string, kv *config.Var) string {
 //
 // Each entry is shaped `<path> (actual=<v>, desired=<v>)` so the reject error
 // surfaces both sides verbatim — without this, an operator hitting a false
-// positive (e.g. issue #984 — `kuke run <config>` rejecting immediately after
+// positive (e.g. issue #984 — `kuke run --from-config <cfg>` rejecting immediately after
 // a successful `kuke restart` per the OutOfSync reconcile path) has no
 // way to tell which side of the comparison normalised differently from the
 // other. Test assertions on the field path itself (e.g.

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -1438,8 +1438,8 @@ func TestRun_ProfileFlag_RemovedWithMigrationPointer(t *testing.T) {
 			if !strings.Contains(err.Error(), "-p/--profile (CellProfile) was removed") {
 				t.Errorf("err %q must name the removed flag", err)
 			}
-			if !strings.Contains(err.Error(), "kuke run -b") {
-				t.Errorf("err %q must point at the -b replacement", err)
+			if !strings.Contains(err.Error(), "kuke run --from-blueprint") {
+				t.Errorf("err %q must point at the --from-blueprint replacement", err)
 			}
 			if fc.createCalls != 0 {
 				t.Errorf("CreateCell called; flag removal must reject before RPC")


### PR DESCRIPTION
## Summary
- `cmd/kuke/run/run.go:52` — `errRemovedProfileFlag` now names `kuke run --from-blueprint <name>` and `kuke run --from-config <cfg>`; the prior `kuke run -b <name>` / `kuke run <config>` text was leftover from before #1099 / #1025 retired those forms, so typing the migration pointer's commands errors with cobra's `unknown flag`.
- `cmd/kuke/create/cell/cell.go` — the `Long` help's three references to `kuke run -b` / `kuke run <cfg>` are rewritten to name `kuke run --from-blueprint` / `kuke run --from-config`.
- Scope-extension flagged for reviewer: AC3's `git grep -n 'run -b\|run <config>\|run <cfg>' cmd/` is broader than the Proposal section's two-file list. To make AC3 return zero hits, this PR also updates `cmd/kuke/create/blueprint/blueprint.go:140` (a generated YAML template comment), `cmd/kuke/run/run.go:863` (a code comment in the divergent-spec error doc), and three test-file comments + one test assertion in `cmd/kuke/run/{run_test.go,env_test.go,divergence_idempotency_test.go}`. The `run_test.go:1441` assertion was checking that the error text contains `kuke run -b`; updated to check for `kuke run --from-blueprint` to match the new pointer.
- The stable-prefix assertion at `cmd/kuke/run/run_test.go:1438` (matches `"-p/--profile (CellProfile) was removed"`) is unchanged and still passes.
- Out of scope: matches outside `cmd/` (in `internal/`, `pkg/`) — `internal/apply/parser/parser.go:199` is an operator-facing error message that still names the retired forms and is worth a follow-up; the rest are internal code comments. AC3 explicitly scopes the grep to `cmd/`, so this PR honours that scope and leaves the rest for PM to triage.

## Test plan
- [x] `git grep -n 'run -b\|run <config>\|run <cfg>' cmd/` returns zero hits (AC3).
- [x] `make test-root` — exit 0 (background task `bo87bfzz4`).
- [x] `GOWORK=off go test ./cmd/kuke/run/... ./cmd/kuke/create/cell/... ./cmd/kuke/create/blueprint/...` — all `ok` (incl. the `run_test.go:1438` prefix assertion and the updated `:1441` `--from-blueprint` assertion).
- [x] `GOWORK=off go vet ./cmd/...` — clean.
- [x] `GOWORK=off go build ./...` — clean.

Closes #1102