### PR TITLE
docs: sweep stale 'kuke <verb> cell <name>' pointers in repo-root docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ A host reboot wipes the cgroup tmpfs while cell metadata under `/opt/kukeon/data
 
 Half-CreateCell cells (a `kuke create cell` that crashed before `markCellReady` could close the `ReadyObserved` latch) are deliberately excluded from the heal: the in-flight CreateCell will finish its own `ensureCellCgroup` path under the per-cell lock, and the reconciler stepping in would race that flow.
 
-Consequence: after a reboot, no operator-driven `kuke start cell <name>` is required per cell — the next reconcile tick re-creates each previously-Ready cell's cgroup automatically. The `make dev-init` smoke does not exercise this path; reboot recovery is covered by the unit tests under `internal/controller/runner/reconcile_heal_test.go`.
+Consequence: after a reboot, no operator-driven `kuke start <name>` is required per cell — the next reconcile tick re-creates each previously-Ready cell's cgroup automatically. The `make dev-init` smoke does not exercise this path; reboot recovery is covered by the unit tests under `internal/controller/runner/reconcile_heal_test.go`.
 
 ### Manual phases (fallback)
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ sudo ./kuke init --kukeond-image docker.io/library/kukeon-local:dev
 To iterate after a change, tear down just the kukeond cell (user data under `/opt/kukeon/default` is left intact) and repeat steps 2–5:
 
 ```bash
-sudo kuke kill cell kukeond \
+sudo kuke kill kukeond \
     --realm kuke-system --space kukeon --stack kukeon --run-path /opt/kukeon
 sudo kuke delete cell kukeond \
     --realm kuke-system --space kukeon --stack kukeon --run-path /opt/kukeon


### PR DESCRIPTION
## Summary
- #1052 swept the docs surface for the post-#1033 positional-verb form, but two repo-root docs still emitted the pre-collapse `kuke <verb> cell <name>` form (cobra: `unknown command "cell"`).
- `AGENTS.md:86` reboot-recovery prose: `kuke start cell <name>` → `kuke start <name>`.
- `README.md:252` full bootstrap example: `sudo kuke kill cell kukeond` → `sudo kuke kill kukeond`.
- #1060's AC grep was scoped to `cmd/`/`internal/`/`pkg/`; these repo-root docs were outside #1052's sweep.

## Test plan
- [x] `git grep -nE "kuke (start|stop|kill|restart) cell"` returns no hits after the sweep.

Closes #1061