### PR TITLE
fix(errors): point operator-facing error messages at current --from-blueprint/--from-config forms

### DIFF
--- a/internal/apply/parser/parser.go
+++ b/internal/apply/parser/parser.go
@@ -196,7 +196,7 @@ func ParseDocument(index int, raw []byte) (*Document, error) {
 		if kind == "CellProfile" {
 			return nil, fmt.Errorf(
 				"document %d: %w: %s (the CellProfile kind was removed in #626 — "+
-					"convert to kind: CellBlueprint and use `kuke run -b` / `kuke run <config>`; "+
+					"convert to kind: CellBlueprint and use `kuke run --from-blueprint` / `kuke run --from-config`; "+
 					"see docs/site/guides/migrate-cellprofile-to-blueprint.md)",
 				index, errdefs.ErrUnknownKind, kind,
 			)

--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -172,7 +172,7 @@ func MaterializeWithName(
 	}
 	if len(blockers) > 0 {
 		return v1beta1.CellDoc{}, fmt.Errorf(
-			"%w (blueprint %q: %s); use `kuke run <config>` with a CellConfig that fills the slots",
+			"%w (blueprint %q: %s); use `kuke run --from-config` with a CellConfig that fills the slots",
 			errdefs.ErrBlueprintStructuralSlots, doc.Metadata.Name, strings.Join(blockers, ", "),
 		)
 	}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -443,7 +443,7 @@ var (
 	// with no url) the inline scalar-param path cannot fill. Such blueprints
 	// require a CellConfig and `kuke run -c` (#625).
 	ErrBlueprintStructuralSlots = errors.New(
-		"blueprint declares structural slots that require a CellConfig: inline `kuke run -b` fills scalar parameters only",
+		"blueprint declares structural slots that require a CellConfig: inline `kuke run --from-blueprint` fills scalar parameters only",
 	)
 	// ErrBlueprintInvalid is returned when `kuke run -b` / `kuke apply -b`
 	// cannot resolve a blueprint's scalar parameters (an undeclared --param


### PR DESCRIPTION
## Summary
- `internal/apply/parser/parser.go:199` — CellProfile-removal `fmt.Errorf` now names `kuke run --from-blueprint` / `kuke run --from-config`; the prior `kuke run -b` / `kuke run <config>` text pointed operators at flag forms #1099 / #1025 retired.
- `internal/cellblueprint/cellblueprint.go:175` — structural-slot `fmt.Errorf` wrap now names `kuke run --from-config`.
- `internal/errdefs/errdefs.go:446` — `ErrBlueprintStructuralSlots` sentinel message itself now names `kuke run --from-blueprint`. This text surfaces verbatim to operators via every `errors.Is` / `%w`-wrap site.
- Out of scope (per the issue body): the ~20 pure code comments in `internal/`/`pkg/` that still mention the retired forms; the comment block at `internal/errdefs/errdefs.go:441`/`:448` documenting the sentinels is one of those, and is intentionally left as-is.

## Test plan
- [x] `git grep -nE 'run -b|run <config>|run <cfg>' internal/ pkg/` — only `//` code comments remain; the three operator-facing strings are gone.
- [x] `make test-root` — exit 0 (background task `bke8urhiy`).
- [x] `make test-kukebuild` — exit 0 (background task `bzjodf7lb`).
- [x] `GOWORK=off go build ./...` — clean (bare `go build` trips the workspace-mode incompatibility documented in CLAUDE.md §"When the project's CI test target's toolchain isn't installed" step 4; the Makefile is the project's named build path).
- [x] `GOWORK=off go test ./internal/apply/parser/... ./internal/cellblueprint/... ./internal/errdefs/...` — all `ok`. Existing tests use `errors.Is` (not text matching), so the sentinel-message edit is unobserved by assertions; the parser test only checks for `CellBlueprint` and `#626` substrings, both retained.

Closes #1106