### PR TITLE
feat(teamrender): text/template engine, relative paths, sibling partials

### DIFF
--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -193,16 +193,16 @@ func buildClaudeBundle(t *testing.T) *teamsource.Bundle {
 	tpl := `apiVersion: v1beta1
 kind: CellBlueprint
 metadata:
-  name: ${ROLE}-${HARNESS}
+  name: {{ .role.name }}-{{ .harness }}
 spec:
   cell:
     containers:
-      - id: ${ROLE}
-        image: ${IMAGE}
+      - id: {{ .role.name }}
+        image: {{ .image }}
         env:
-          - "ROLE=${ROLE}"
-          - "NEEDS=${NEEDS}"
-          - "SETTINGS=${SETTINGS}"
+          - "ROLE={{ .role.name }}"
+          - "NEEDS={{ range $i, $n := .needs.image }}{{ if $i }},{{ end }}{{ $n }}{{ end }}"
+          - "SETTINGS={{ (index .harnesses .harness).settings }}"
         repos:
           - { name: project, target: /src/project }
         secrets:
@@ -244,7 +244,10 @@ spec:
 				Spec: model.HarnessSpec{
 					SkillPath:  "/.claude/skills",
 					MakeTarget: "harness-claude",
-					Template:   "harnesses/claude/blueprint.tmpl.yaml",
+					// Bare filename — the renderer resolves it relative to the
+					// harness's own dir (harnesses/claude/), matching the
+					// agents-repo canonical layout (#1110).
+					Template: "blueprint.tmpl.yaml",
 				},
 			},
 		},

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -28,13 +28,15 @@
 //     surfaces errdefs.ErrTeamImageNoMatch naming the first unmet
 //     capability + the operator-actionable "build/label an image" hint.
 //  3. render — load the harness's blueprint template (relative to the
-//     materialized cache dir), substitute `${KEY}` placeholders for
-//     `${ROLE}`, `${HARNESS}`, `${IMAGE}`, `${NEEDS}`, and the role's
-//     native per-harness config knobs (`${SETTINGS}` for claude,
-//     `${SANDBOX}`/`${APPROVAL}` for codex, `${PERMISSIONS}` for
-//     opencode), then yaml-parse into a CellBlueprintDoc. Per the
-//     umbrella's key decision the role's native per-harness config is
-//     wired verbatim — no transpile.
+//     harness's own directory under the materialized cache, see #1110),
+//     parse it as a Go text/template against a typed dot-context
+//     (`.role`, `.harness`, `.needs`, `.harnesses`, `.operator`,
+//     `.project`, `.image`, `.realm`/`.space`/`.stack`), pull in every
+//     sibling `*.tmpl.yaml` partial in the same dir so `{{ template
+//     "name" . }}` calls resolve against them, execute, and yaml-parse
+//     the result into a CellBlueprintDoc. Per the umbrella's key decision
+//     the role's native per-harness config is wired verbatim — no
+//     transpile.
 //  4. bind — produce a CellConfig that references the just-rendered
 //     blueprint and carries (a) operator facts pulled from
 //     `~/.kuke/kuketeams.yaml` (git author/committer/signingKey/registry
@@ -54,13 +56,14 @@
 package teamrender
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
+	"text/template"
 
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -88,6 +91,13 @@ const ProjectRepoSlotName = "project"
 // `TeamsConfig.spec.sources[<owner/repo>]` mapping when the blueprint
 // declares the slot.
 const AgentsRepoSlotName = "agents"
+
+// partialGlob is the pattern teamrender scans the blueprint template's
+// directory with to discover sibling partials. Every match (other than the
+// main template itself) is parsed into the same template set so a
+// `{{ template "name" . }}` call in the blueprint resolves against a
+// `{{ define "name" }}…{{ end }}` block in any sibling.
+const partialGlob = "*.tmpl.yaml"
 
 // Inputs collects the per-project facts that vary by `kuke team init`
 // invocation. Project is the rendered objects' team label and the basis
@@ -171,7 +181,7 @@ func Render(
 
 			bp, renderErr := RenderBlueprint(
 				bundle.CacheDir, harness, role, hname, ptRole.Ref,
-				merged, entry, project, realm, in.Build, in.SourceRef,
+				merged, entry, tc, project, realm, in.Build, in.SourceRef,
 			)
 			if renderErr != nil {
 				return nil, fmt.Errorf(
@@ -266,18 +276,37 @@ func SelectImage(
 	)
 }
 
-// RenderBlueprint loads the harness's blueprint template (resolved
-// relative to cacheDir), substitutes `${KEY}` placeholders for the
-// `(role × harness)` pair's facts, and yaml-parses into a
-// CellBlueprintDoc. The blueprint's metadata.labels are populated with
+// RenderBlueprint loads the harness's blueprint template, parses it as a
+// Go text/template (alongside every sibling `*.tmpl.yaml` partial in the
+// same directory), executes it against the typed dot-context the agents
+// repo's published blueprints are authored against, and yaml-parses the
+// result into a CellBlueprintDoc.
+//
+// Template path resolution: harness.Spec.Template resolves relative to the
+// harness's own directory (`<cacheDir>/harnesses/<harness>/`), not the
+// cache root. The agents repo's `harnesses/<name>/harness.yaml` declares
+// `template: blueprint.tmpl.yaml` as a sibling, so the bare-filename form
+// is the canonical shape.
+//
+// Sibling partials: every `*.tmpl.yaml` in the resolved template's
+// directory is parsed into the same `*template.Template` set so a
+// blueprint's `{{ template "mount_source" . }}` call resolves against a
+// `{{ define "mount_source" }}…{{ end }}` block in any sibling
+// (`partials.tmpl.yaml`, `mounts.tmpl.yaml`, …) without the renderer
+// owning a partials directory of its own.
+//
+// Dot-context: see renderContextValues for the full shape. The
+// `.operator.*` and `.project.*` leaves are partially bound here and
+// completed in #1115. The metadata.labels are populated with
 // `kukeon.io/team = project`. metadata.realm is forced to realm (the
 // template need not pre-fill it). If the template did not supply
 // metadata.name, the default `<role>-<harness>` is stamped so the
 // blueprint and its companion config share a deterministic identity.
 //
-// build + sourceRef drive the `${IMAGE}` bind decision (see blueprintVars):
-// in build mode the locally-built `kukeon.internal/<ref>:<sourceRef>` image is
-// bound; otherwise the catalog entry's published Image is.
+// build + sourceRef drive the `.image` bind decision (see
+// renderContextValues): in build mode the locally-built
+// `kukeon.internal/<ref>:<sourceRef>` image is bound; otherwise the
+// catalog entry's published Image is.
 func RenderBlueprint(
 	cacheDir string,
 	h *model.Harness,
@@ -285,6 +314,7 @@ func RenderBlueprint(
 	harness, roleRef string,
 	needs []string,
 	image *model.ImageCatalogEntry,
+	tc *model.TeamsConfig,
 	project, realm string,
 	build bool,
 	sourceRef string,
@@ -295,7 +325,8 @@ func RenderBlueprint(
 			errdefs.ErrTeamBlueprintTemplateMissing, harness,
 		)
 	}
-	tplPath := filepath.Join(cacheDir, h.Spec.Template)
+	harnessDir := teamsource.HarnessDir(cacheDir, harness)
+	tplPath := filepath.Join(harnessDir, h.Spec.Template)
 	raw, err := os.ReadFile(tplPath)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -303,11 +334,19 @@ func RenderBlueprint(
 		)
 	}
 
-	vars := blueprintVars(roleRef, harness, image, needs, r, build, sourceRef)
-	rendered := substitute(string(raw), vars)
+	tpl, err := parseBlueprintTemplate(tplPath, raw)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := renderContextValues(roleRef, harness, image, needs, r, tc, project, realm, build, sourceRef)
+	var buf bytes.Buffer
+	if execErr := tpl.ExecuteTemplate(&buf, filepath.Base(tplPath), ctx); execErr != nil {
+		return nil, fmt.Errorf("execute blueprint template %q: %w", tplPath, execErr)
+	}
 
 	var bp v1beta1.CellBlueprintDoc
-	if unmarshalErr := yaml.Unmarshal([]byte(rendered), &bp); unmarshalErr != nil {
+	if unmarshalErr := yaml.Unmarshal(buf.Bytes(), &bp); unmarshalErr != nil {
 		return nil, fmt.Errorf("parse rendered blueprint %q: %w", tplPath, unmarshalErr)
 	}
 
@@ -505,77 +544,209 @@ func firstUnmet(ic *model.ImageCatalog, harness string, needs []string) string {
 	return ""
 }
 
-// substitutionPattern matches a `${KEY}` placeholder. KEY is the standard
-// shell-style identifier: a leading letter or underscore followed by
-// letters/digits/underscores. Unknown placeholders pass through verbatim
-// rather than substituting empty — a CellBlueprint may legitimately carry
-// $-prefixed literals (env-var defaults, shell snippets), and the
-// downstream CellBlueprintParameter resolver surfaces a truly missing var
-// at apply time with a clearer error than a silent empty.
-var substitutionPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
-
-// substitute applies render-time `${KEY}` substitution. The function
-// looks up keys in vars; an unknown key passes through the original
-// `${KEY}` literal unchanged.
-func substitute(in string, vars map[string]string) string {
-	return substitutionPattern.ReplaceAllStringFunc(in, func(match string) string {
-		key := match[2 : len(match)-1]
-		if v, ok := vars[key]; ok {
-			return v
-		}
-		return match
-	})
+// templateFuncs is the function map exposed to harness blueprint
+// templates. Kept small — a sprig subset (upper, replace) — to keep the
+// renderer's surface narrow per the umbrella's "no full sprig" decision.
+// `replace` mirrors sprig's `(old, new, src)` arg order so the pipe idiom
+// `{{ . | upper | replace "-" "_" }}` flows the chained value into src as
+// the last positional, matching what published blueprints expect.
+func templateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"upper":   strings.ToUpper,
+		"replace": func(from, to, src string) string { return strings.ReplaceAll(src, from, to) },
+	}
 }
 
-// blueprintVars builds the `${KEY}` substitution dict the harness's
-// blueprint template is rendered against. The role's native per-harness
-// config is wired verbatim — a role that has no per-harness config for
-// `harness` still gets the per-harness keys, just bound to empty strings,
-// so a template that always references `${SETTINGS}` does not break for
-// roles that omit it.
+// parseBlueprintTemplate parses the blueprint at tplPath (already-read raw
+// body) as a Go text/template and pulls in every sibling *.tmpl.yaml in
+// the same directory as additional members of the template set. The
+// blueprint can then call `{{ template "name" . }}` against a
+// `{{ define "name" }}…{{ end }}` block defined in any sibling without
+// the renderer owning a partials directory layout of its own.
+func parseBlueprintTemplate(tplPath string, raw []byte) (*template.Template, error) {
+	mainName := filepath.Base(tplPath)
+	tpl := template.New(mainName).Funcs(templateFuncs())
+	if _, err := tpl.Parse(string(raw)); err != nil {
+		return nil, fmt.Errorf("parse blueprint template %q: %w", tplPath, err)
+	}
+
+	siblings, err := filepath.Glob(filepath.Join(filepath.Dir(tplPath), partialGlob))
+	if err != nil {
+		return nil, fmt.Errorf("scan partials next to %q: %w", tplPath, err)
+	}
+	// Deterministic order so a multi-partial set parses the same way every
+	// run — filepath.Glob already returns lexicographically sorted matches,
+	// but pinning the contract here makes the intent explicit for future
+	// readers.
+	sort.Strings(siblings)
+	for _, sib := range siblings {
+		if sib == tplPath {
+			continue
+		}
+		sibRaw, readErr := os.ReadFile(sib)
+		if readErr != nil {
+			return nil, fmt.Errorf("read partial %q: %w", sib, readErr)
+		}
+		if _, parseErr := tpl.New(filepath.Base(sib)).Parse(string(sibRaw)); parseErr != nil {
+			return nil, fmt.Errorf("parse partial %q: %w", sib, parseErr)
+		}
+	}
+	return tpl, nil
+}
+
+// renderContextValues builds the dot-context the harness blueprint template
+// is rendered against. The top-level shape (lowercase keys) matches the
+// `.role`, `.harness`, `.needs`, `.harnesses`, `.operator`, `.project`,
+// `.image`, `.image_ref`, `.realm`, `.space`, `.stack` contract the
+// agents-side blueprints reference. Inner leaves keep their authored case:
+// `.needs.repos` etc. stay lowercase (role.yaml field names), while
+// `.operator.GIT_USER_NAME` etc. stay uppercase (env-var protocol).
 //
-// The `${IMAGE}` bind is mode-dependent: in `--build` mode (build && a
-// non-empty sourceRef) it is the locally-built `kukeon.internal/<ref>:
-// <sourceRef>` ref — byte-identical to the tag teambuild produces, so the
-// runtime resolves the in-realm image without a network pull — otherwise it
-// is the catalog entry's published, registry-qualified `Image`. `${IMAGE_REF}`
-// always carries the catalog-local selector key (`image.Ref`) regardless of
-// mode; only the bound image reference flips.
-func blueprintVars(
+// All leaves are exposed as maps rather than typed structs because Go
+// text/template's struct-field lookup is case-sensitive against exported
+// (uppercase) field names, which would force every blueprint to write
+// `.Needs.Repos` instead of the lowercase `.needs.repos` the agents repo
+// templates are authored with.
+//
+// The `.image` bind is mode-dependent: in `--build` mode (build && a
+// non-empty sourceRef) it is the locally-built
+// `kukeon.internal/<ref>:<sourceRef>` ref — byte-identical to the tag
+// teambuild produces, so the runtime resolves the in-realm image without a
+// network pull — otherwise it is the catalog entry's published,
+// registry-qualified Image. `.image_ref` always carries the catalog-local
+// selector key (`image.Ref`) regardless of mode.
+//
+// The `.operator.*` and `.project.*` leaves are partially bound here and
+// completed in #1115 — the keys already backed by the operator's
+// TeamsConfig (GIT_USER_NAME, GIT_USER_EMAIL, REGISTRY) are populated;
+// the not-yet-bound keys (TEAM_ROOT, HOME_DIR, REPO_OWNER, PROJECT_DIR,
+// AGENTS_REPO) wait for that follow-up. A blueprint referencing an
+// unbound key gets an empty string at render time (Go template's default
+// for a missing map key), not an error.
+func renderContextValues(
 	roleRef, harness string,
 	image *model.ImageCatalogEntry,
 	needs []string,
 	r *model.Role,
+	tc *model.TeamsConfig,
+	project, realm string,
 	build bool,
 	sourceRef string,
-) map[string]string {
-	vars := map[string]string{
-		"ROLE":    roleRef,
-		"HARNESS": harness,
-		"NEEDS":   strings.Join(needs, ","),
-	}
+) map[string]any {
+	img := ""
+	imgRef := ""
 	if image != nil {
-		img := image.Image
+		img = image.Image
 		if build && strings.TrimSpace(sourceRef) != "" {
 			img = consts.InternalImageRef(image.Ref, sourceRef)
 		}
-		vars["IMAGE"] = img
-		vars["IMAGE_REF"] = image.Ref
+		imgRef = image.Ref
 	}
+
+	// .needs.image is the merged role+project capability set the renderer
+	// just used to pick an image; .needs.{repos,mounts,params,secrets} are
+	// the role.yaml-authored selector lists the agents-side blueprints
+	// iterate to wire repo and mount slots.
+	needsView := map[string]any{
+		"image":   needs,
+		"repos":   roleNeedsRepos(r),
+		"mounts":  roleNeedsMounts(r),
+		"params":  roleNeedsParams(r),
+		"secrets": roleNeedsSecrets(r),
+	}
+
+	// .harnesses.<h>.{settings,sandbox,approval,permissions} mirrors
+	// role.yaml's harnesses map verbatim — a blueprint may switch behaviour
+	// per harness (claude reads Settings; codex reads Sandbox/Approval;
+	// opencode reads Permissions) without the renderer transpiling.
+	harnessesView := map[string]map[string]string{}
 	if r != nil {
-		if rh, ok := r.Spec.Harnesses[harness]; ok {
-			vars["SETTINGS"] = rh.Settings
-			vars["SANDBOX"] = rh.Sandbox
-			vars["APPROVAL"] = rh.Approval
-			vars["PERMISSIONS"] = rh.Permissions
-		} else {
-			vars["SETTINGS"] = ""
-			vars["SANDBOX"] = ""
-			vars["APPROVAL"] = ""
-			vars["PERMISSIONS"] = ""
+		for name, rh := range r.Spec.Harnesses {
+			harnessesView[name] = map[string]string{
+				"settings":    rh.Settings,
+				"sandbox":     rh.Sandbox,
+				"approval":    rh.Approval,
+				"permissions": rh.Permissions,
+			}
 		}
 	}
-	return vars
+
+	operatorView := map[string]string{}
+	if tc != nil {
+		if v := strings.TrimSpace(tc.Spec.Registry); v != "" {
+			operatorView["REGISTRY"] = v
+		}
+		if tc.Spec.Git != nil && tc.Spec.Git.Author != nil {
+			if v := strings.TrimSpace(tc.Spec.Git.Author.Name); v != "" {
+				operatorView["GIT_USER_NAME"] = v
+			}
+			if v := strings.TrimSpace(tc.Spec.Git.Author.Email); v != "" {
+				operatorView["GIT_USER_EMAIL"] = v
+			}
+		}
+	}
+
+	projectView := map[string]string{
+		"NAME": project,
+	}
+
+	roleView := map[string]any{
+		"name": roleRef,
+		"ref":  roleRef,
+	}
+
+	return map[string]any{
+		"role":      roleView,
+		"harness":   harness,
+		"needs":     needsView,
+		"harnesses": harnessesView,
+		"operator":  operatorView,
+		"project":   projectView,
+		"image":     img,
+		"image_ref": imgRef,
+		"realm":     realm,
+		"space":     "",
+		"stack":     "",
+	}
+}
+
+// roleNeedsRepos, roleNeedsMounts, roleNeedsParams, roleNeedsSecrets
+// return the matching role.yaml needs slice, or an empty slice (never
+// nil) so a `{{ range .needs.<x> }}` over an absent slot iterates zero
+// times rather than tripping a nil-deref in the template engine.
+func roleNeedsRepos(r *model.Role) []string {
+	if r == nil {
+		return []string{}
+	}
+	return appendNonNil(r.Spec.Needs.Repos)
+}
+
+func roleNeedsMounts(r *model.Role) []string {
+	if r == nil {
+		return []string{}
+	}
+	return appendNonNil(r.Spec.Needs.Mounts)
+}
+
+func roleNeedsParams(r *model.Role) []string {
+	if r == nil {
+		return []string{}
+	}
+	return appendNonNil(r.Spec.Needs.Params)
+}
+
+func roleNeedsSecrets(r *model.Role) []string {
+	if r == nil {
+		return []string{}
+	}
+	return appendNonNil(r.Spec.Needs.Secrets)
+}
+
+func appendNonNil(in []string) []string {
+	if in == nil {
+		return []string{}
+	}
+	return in
 }
 
 // operatorValues builds the CellConfig.Values scalar map from operator

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -174,36 +174,47 @@ func TestSelectImageDistinguishesMultiImagePartialCoverage(t *testing.T) {
 	}
 }
 
-// buildClaudeTemplate writes a minimal claude blueprint template into
-// cacheDir/harnesses/claude/blueprint.tmpl.yaml.
-func buildClaudeTemplate(t *testing.T, cacheDir string) {
+// writeHarnessFile writes a file under <cacheDir>/harnesses/<name>/<file>
+// (the standard agents-source harness directory layout teamsource.HarnessDir
+// resolves to) so tests can colocate a blueprint template and its sibling
+// partials the way the renderer expects.
+func writeHarnessFile(t *testing.T, cacheDir, harnessName, filename, body string) {
 	t.Helper()
-	p := filepath.Join(cacheDir, "harnesses", "claude", "blueprint.tmpl.yaml")
+	p := filepath.Join(teamsource.HarnessDir(cacheDir, harnessName), filename)
 	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// buildClaudeTemplate writes a minimal claude blueprint template into
+// <cacheDir>/harnesses/claude/blueprint.tmpl.yaml using the Go
+// text/template dot-context the agents repo's published blueprints are
+// authored against (per AC: relative-to-harness-dir, text/template engine).
+func buildClaudeTemplate(t *testing.T, cacheDir string) {
+	t.Helper()
 	body := `apiVersion: v1beta1
 kind: CellBlueprint
 metadata:
-  name: ${ROLE}-${HARNESS}
+  name: {{ .role.name }}-{{ .harness }}
 spec:
   cell:
     containers:
-      - id: ${ROLE}
-        image: ${IMAGE}
+      - id: {{ .role.name }}
+        image: {{ .image }}
         env:
-          - "ROLE=${ROLE}"
-          - "NEEDS=${NEEDS}"
-          - "SETTINGS=${SETTINGS}"
+          - "ROLE={{ .role.name }}"
+          - "NEEDS={{ range $i, $n := .needs.image }}{{ if $i }},{{ end }}{{ $n }}{{ end }}"
+          - "SETTINGS={{ (index .harnesses .harness).settings }}"
         repos:
           - { name: project, target: /src/project }
           - { name: agents, target: /src/agents }
         secrets:
           - { name: ANTHROPIC_API_KEY, mode: env, envName: ANTHROPIC_API_KEY }
 `
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
 }
 
 // minimalRole returns a role declaring the listed image-needs plus an
@@ -220,6 +231,7 @@ func minimalRole() *model.Role {
 			},
 			Needs: model.RoleNeeds{
 				Image:   []string{"go", "git"},
+				Repos:   []string{"project", "agents"},
 				Secrets: []string{"ANTHROPIC_API_KEY"},
 			},
 		},
@@ -235,7 +247,7 @@ func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
 		APIVersion: model.APIVersionV1,
 		Kind:       model.KindHarness,
 		Metadata:   model.Metadata{Name: "claude"},
-		Spec:       model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"},
+		Spec:       model.HarnessSpec{Template: "blueprint.tmpl.yaml"},
 	}
 	image := &model.ImageCatalogEntry{
 		Ref:          "claude-base",
@@ -251,6 +263,7 @@ func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
 		"dev",
 		[]string{"git", "go"},
 		image,
+		nil,
 		"sbsh",
 		"default",
 		false,
@@ -296,7 +309,7 @@ func TestRenderBlueprintBindsInternalRefInBuildMode(t *testing.T) {
 		APIVersion: model.APIVersionV1,
 		Kind:       model.KindHarness,
 		Metadata:   model.Metadata{Name: "claude"},
-		Spec:       model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"},
+		Spec:       model.HarnessSpec{Template: "blueprint.tmpl.yaml"},
 	}
 	image := &model.ImageCatalogEntry{
 		Ref:          "claude-base",
@@ -312,6 +325,7 @@ func TestRenderBlueprintBindsInternalRefInBuildMode(t *testing.T) {
 		"dev",
 		[]string{"git", "go"},
 		image,
+		nil,
 		"sbsh",
 		"default",
 		true,
@@ -333,7 +347,7 @@ func TestRenderBlueprintBindsPublishedRefWithoutBuild(t *testing.T) {
 	cacheDir := t.TempDir()
 	buildClaudeTemplate(t, cacheDir)
 	r := minimalRole()
-	h := &model.Harness{Spec: model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"}}
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
 	image := &model.ImageCatalogEntry{
 		Ref:          "claude-base",
 		Harness:      "claude",
@@ -360,6 +374,7 @@ func TestRenderBlueprintBindsPublishedRefWithoutBuild(t *testing.T) {
 				"dev",
 				[]string{"git", "go"},
 				image,
+				nil,
 				"sbsh",
 				"default",
 				tc.build,
@@ -379,8 +394,8 @@ func TestRenderBlueprintMissingTemplate(t *testing.T) {
 	t.Parallel()
 	cacheDir := t.TempDir()
 	r := minimalRole()
-	h := &model.Harness{Spec: model.HarnessSpec{Template: "harnesses/missing/blueprint.tmpl.yaml"}}
-	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, "sbsh", "default", false, "")
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+	_, err := RenderBlueprint(cacheDir, h, r, "missing", "dev", nil, nil, nil, "sbsh", "default", false, "")
 	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
 		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
 	}
@@ -391,42 +406,208 @@ func TestRenderBlueprintEmptyTemplatePathRejected(t *testing.T) {
 	cacheDir := t.TempDir()
 	r := minimalRole()
 	h := &model.Harness{Spec: model.HarnessSpec{}}
-	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, "sbsh", "default", false, "")
+	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, nil, "sbsh", "default", false, "")
 	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
 		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
 	}
 }
 
-// TestRenderBlueprintWiresCodexConfigVerbatim confirms the codex
-// sandbox/approval knobs land in the substitution dict verbatim — covers
-// the AC's "codex sandbox/approval knobs" wiring path.
-func TestRenderBlueprintWiresCodexConfigVerbatim(t *testing.T) {
+// TestRenderBlueprintResolvesTemplateRelativeToHarnessDir confirms the
+// bare-filename form (the agents repo's canonical layout: harness.yaml +
+// blueprint.tmpl.yaml as siblings under harnesses/<name>/) resolves under
+// the harness dir rather than the cache root. Regression guard for the
+// path-resolution AC: a template that references `blueprint.tmpl.yaml`
+// (no leading `harnesses/<name>/` prefix) must still render.
+func TestRenderBlueprintResolvesTemplateRelativeToHarnessDir(t *testing.T) {
 	t.Parallel()
 	cacheDir := t.TempDir()
-	p := filepath.Join(cacheDir, "harnesses", "codex", "blueprint.tmpl.yaml")
-	if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
-		t.Fatalf("mkdir: %v", err)
+	buildClaudeTemplate(t, cacheDir)
+	// Deliberately *no* harnesses/claude/blueprint.tmpl.yaml at cache root —
+	// the file lives at <cacheDir>/harnesses/claude/blueprint.tmpl.yaml and
+	// Spec.Template names the bare sibling.
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{
+		Ref:          "claude-base",
+		Harness:      "claude",
+		Image:        "registry.local/claude:latest",
+		Capabilities: []string{"go", "git"},
 	}
-	body := `apiVersion: v1beta1
+	bp, err := RenderBlueprint(
+		cacheDir, h, minimalRole(), "claude", "dev",
+		[]string{"git", "go"}, image, nil, "sbsh", "default", false, "",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint with bare-filename template: %v", err)
+	}
+	if bp.Spec.Cell.Containers[0].Image != "registry.local/claude:latest" {
+		t.Errorf("image = %q, want resolved-via-harness-dir image",
+			bp.Spec.Cell.Containers[0].Image)
+	}
+}
+
+// TestRenderBlueprintLoadsSiblingPartials covers AC: a blueprint that calls
+// `{{ template "mount_source" . }}` against a sibling partial that defines
+// it renders successfully. The renderer must pick up every *.tmpl.yaml in
+// the same dir as the resolved template.
+func TestRenderBlueprintLoadsSiblingPartials(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	mainBody := `apiVersion: v1beta1
 kind: CellBlueprint
 metadata:
-  name: ${ROLE}-${HARNESS}
+  name: {{ .role.name }}-{{ .harness }}
 spec:
   cell:
     containers:
-      - id: ${ROLE}
-        image: ${IMAGE}
+      - id: {{ .role.name }}
+        image: {{ .image }}
         env:
-          - "SANDBOX=${SANDBOX}"
-          - "APPROVAL=${APPROVAL}"
+          - "MOUNT_SOURCE={{ template "mount_source" .role.name }}"
 `
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
+	partialBody := `{{- define "mount_source" -}}
+/srv/{{ . | upper | replace "-" "_" }}
+{{- end -}}
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", mainBody)
+	writeHarnessFile(t, cacheDir, "claude", "partials.tmpl.yaml", partialBody)
+
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{Image: "registry.local/claude:latest"}
+	bp, err := RenderBlueprint(
+		cacheDir, h, minimalRole(), "claude", "my-dev",
+		[]string{"go"}, image, nil, "sbsh", "default", false, "",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint with sibling partials: %v", err)
 	}
+	wantEnv := []string{"MOUNT_SOURCE=/srv/MY_DEV"}
+	if !reflect.DeepEqual(bp.Spec.Cell.Containers[0].Env, wantEnv) {
+		t.Errorf("env = %v, want %v (partial + upper/replace funcs)",
+			bp.Spec.Cell.Containers[0].Env, wantEnv)
+	}
+}
+
+// TestRenderBlueprintNeedsAndOperatorContext covers the AC's fixture-template
+// requirement: `{{ range .needs.repos }}` and `{{ .operator.GIT_USER_NAME }}`
+// round-trip to a valid CellBlueprint. Both keys are wired by #1110 — the
+// renderer must iterate role.yaml's needs.repos and expose
+// tc.Spec.Git.Author.Name under .operator.GIT_USER_NAME.
+func TestRenderBlueprintNeedsAndOperatorContext(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+  labels:
+    kukeon.io/operator: {{ .operator.GIT_USER_NAME }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        repos:
+{{- range .needs.repos }}
+          - { name: {{ . }}, target: /src/{{ . }} }
+{{- end }}
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{Image: "registry.local/claude:latest"}
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{
+		Git: &model.TeamsConfigGit{
+			ContainerGit: v1beta1.ContainerGit{
+				Author: &v1beta1.GitIdentity{Name: "Operator Name", Email: "op@example.com"},
+			},
+		},
+	}}
+	bp, err := RenderBlueprint(
+		cacheDir, h, minimalRole(), "claude", "dev",
+		[]string{"go"}, image, tc, "sbsh", "default", false, "",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	if got := bp.Metadata.Labels["kukeon.io/operator"]; got != "Operator Name" {
+		t.Errorf("operator label = %q, want %q", got, "Operator Name")
+	}
+	c := bp.Spec.Cell.Containers[0]
+	if len(c.Repos) != 2 {
+		t.Fatalf("repos = %d, want 2 (one per .needs.repos entry)", len(c.Repos))
+	}
+	wantRepos := map[string]string{"project": "/src/project", "agents": "/src/agents"}
+	for _, repo := range c.Repos {
+		want, ok := wantRepos[repo.Name]
+		if !ok {
+			t.Errorf("unexpected repo: %+v", repo)
+			continue
+		}
+		if repo.Target != want {
+			t.Errorf("repo %q target = %q, want %q", repo.Name, repo.Target, want)
+		}
+	}
+}
+
+// TestRenderBlueprintRunsUpperReplaceFuncs covers AC: `upper` and `replace`
+// template functions are wired and compose cleanly via the sprig-style pipe
+// idiom (`{{ . | upper | replace "-" "_" }}`).
+func TestRenderBlueprintRunsUpperReplaceFuncs(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        env:
+          - "ENV_NAME={{ .role.name | upper | replace "-" "_" }}"
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{Image: "x"}
+	bp, err := RenderBlueprint(
+		cacheDir, h, minimalRole(), "claude", "pr-reviewer",
+		nil, image, nil, "sbsh", "default", false, "",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	wantEnv := []string{"ENV_NAME=PR_REVIEWER"}
+	if !reflect.DeepEqual(bp.Spec.Cell.Containers[0].Env, wantEnv) {
+		t.Errorf("env = %v, want %v", bp.Spec.Cell.Containers[0].Env, wantEnv)
+	}
+}
+
+// TestRenderBlueprintWiresCodexConfigVerbatim confirms the codex
+// sandbox/approval knobs land in the dot-context verbatim — covers the AC's
+// "codex sandbox/approval knobs" wiring path.
+func TestRenderBlueprintWiresCodexConfigVerbatim(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        env:
+          - "SANDBOX={{ (index .harnesses .harness).sandbox }}"
+          - "APPROVAL={{ (index .harnesses .harness).approval }}"
+`
+	writeHarnessFile(t, cacheDir, "codex", "blueprint.tmpl.yaml", body)
 	r := minimalRole()
-	h := &model.Harness{Spec: model.HarnessSpec{Template: "harnesses/codex/blueprint.tmpl.yaml"}}
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
 	image := &model.ImageCatalogEntry{Image: "registry.local/codex:latest"}
-	bp, err := RenderBlueprint(cacheDir, h, r, "codex", "dev", nil, image, "sbsh", "default", false, "")
+	bp, err := RenderBlueprint(cacheDir, h, r, "codex", "dev", nil, image, nil, "sbsh", "default", false, "")
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
 	}
@@ -559,16 +740,15 @@ func TestRenderEndToEnd(t *testing.T) {
 	t.Parallel()
 	cacheDir := t.TempDir()
 	buildClaudeTemplate(t, cacheDir)
-	// Codex template — minimal.
-	codexPath := filepath.Join(cacheDir, "harnesses", "codex", "blueprint.tmpl.yaml")
-	if err := os.MkdirAll(filepath.Dir(codexPath), 0o700); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(codexPath, []byte(
-		"apiVersion: v1beta1\nkind: CellBlueprint\nmetadata: { name: \"${ROLE}-${HARNESS}\" }\nspec:\n  cell:\n    containers:\n      - { id: \"${ROLE}\", image: \"${IMAGE}\" }\n",
-	), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	// Codex template — minimal, mirrors the published agents-side text/template
+	// shape (sibling of harness.yaml, dot-context references).
+	writeHarnessFile(
+		t,
+		cacheDir,
+		"codex",
+		"blueprint.tmpl.yaml",
+		"apiVersion: v1beta1\nkind: CellBlueprint\nmetadata: { name: \"{{ .role.name }}-{{ .harness }}\" }\nspec:\n  cell:\n    containers:\n      - { id: \"{{ .role.name }}\", image: \"{{ .image }}\" }\n",
+	)
 	bundle := &teamsource.Bundle{
 		Source: teamsource.Source{
 			Repo:      "github.com/eminwux/agents",
@@ -580,8 +760,8 @@ func TestRenderEndToEnd(t *testing.T) {
 		CacheDir: cacheDir,
 		Roles:    map[string]*model.Role{"dev": minimalRole()},
 		Harnesses: map[string]*model.Harness{
-			"claude": {Spec: model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"}},
-			"codex":  {Spec: model.HarnessSpec{Template: "harnesses/codex/blueprint.tmpl.yaml"}},
+			"claude": {Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}},
+			"codex":  {Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}},
 		},
 		ImageCatalog: &model.ImageCatalog{
 			Spec: model.ImageCatalogSpec{
@@ -650,7 +830,7 @@ func TestRenderProjectPerRoleNeedsOverrideUnions(t *testing.T) {
 		CacheDir: cacheDir,
 		Roles:    map[string]*model.Role{"dev": role},
 		Harnesses: map[string]*model.Harness{
-			"claude": {Spec: model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"}},
+			"claude": {Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}},
 		},
 		ImageCatalog: &model.ImageCatalog{Spec: model.ImageCatalogSpec{Images: []model.ImageCatalogEntry{
 			// First image has only go+git — should NOT satisfy go+git+rust merged needs.
@@ -770,7 +950,7 @@ func TestRenderDefaultRealmFallback(t *testing.T) {
 		CacheDir: cacheDir,
 		Roles:    map[string]*model.Role{"dev": minimalRole()},
 		Harnesses: map[string]*model.Harness{
-			"claude": {Spec: model.HarnessSpec{Template: "harnesses/claude/blueprint.tmpl.yaml"}},
+			"claude": {Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}},
 		},
 		ImageCatalog: minimalClaudeCatalog("go", "git"),
 	}

--- a/internal/teamsource/teamsource.go
+++ b/internal/teamsource/teamsource.go
@@ -330,7 +330,15 @@ func RolePath(cacheDir, ref string) string {
 
 // HarnessPath is the on-disk harness.yaml location for name under cacheDir.
 func HarnessPath(cacheDir, name string) string {
-	return filepath.Join(cacheDir, "harnesses", name, "harness.yaml")
+	return filepath.Join(HarnessDir(cacheDir, name), "harness.yaml")
+}
+
+// HarnessDir is the on-disk directory the named harness's harness.yaml lives
+// in. teamrender resolves harness.Spec.Template relative to this directory
+// and scans it for sibling *.tmpl.yaml partials, so the renderer and the
+// loader agree on the layout without each open-coding the path.
+func HarnessDir(cacheDir, name string) string {
+	return filepath.Join(cacheDir, "harnesses", name)
 }
 
 // ImageCatalogPath is the on-disk harnesses/images.yaml location under cacheDir.


### PR DESCRIPTION
## Summary

- Replace `RenderBlueprint`'s flat `${KEY}` envsubst with a Go `text/template` engine executed against a typed dot-context (`.role`, `.harness`, `.needs`, `.harnesses`, `.operator`, `.project`, `.image`, `.image_ref`, `.realm`, `.space`, `.stack`). The published agents-repo blueprints (`{{ range .needs.repos }}`, `{{ template "mount_source" . }}`, `{{ .operator.GIT_USER_NAME }}`, `{{ . | upper | replace "-" "_" }}`) now parse and render end-to-end instead of failing `yaml.Unmarshal` at the first `{{ range }}` block.
- Resolve `harness.Spec.Template` relative to the harness's own directory (`<cacheDir>/harnesses/<name>/`) rather than the cache root, so the agents-repo canonical layout (`harnesses/<name>/blueprint.tmpl.yaml` as a sibling of `harness.yaml`, named bare in `harness.yaml`'s `spec.template`) works as authored. Added `teamsource.HarnessDir` as the shared layout helper.
- Auto-discover sibling `*.tmpl.yaml` partials in the resolved template's directory and parse them into the same `*text/template.Template` set, so a blueprint's `{{ template "mount_source" . }}` resolves against a `{{ define "mount_source" }}…{{ end }}` block in any sibling (`partials.tmpl.yaml`, `mounts.tmpl.yaml`, …) without the renderer owning a partials directory layout of its own.
- Wire a minimal sprig subset (`upper`, `replace`) so the published pipe idiom composes cleanly — no full sprig per the umbrella's "keep the surface small" decision.
- Plumb `tc *model.TeamsConfig` into `RenderBlueprint` so the `.operator.*` leaves the agents-repo blueprints reference (`GIT_USER_NAME`, `GIT_USER_EMAIL`, `REGISTRY`) bind at render time. The remaining `.operator.*` / `.project.*` leaves (`TEAM_ROOT`, `HOME_DIR`, `REPO_OWNER`, `PROJECT_DIR`, `AGENTS_REPO`) wait for #1115 — a blueprint referencing an unbound key gets the empty-string default at render time, not an error.

### Design notes

- The dot-context is exposed as nested `map[string]any` / `map[string]string` rather than typed Go structs. Go `text/template`'s struct-field lookup is case-sensitive against exported field names; the agents-repo templates are authored with lowercase top-level keys (`.role`, `.needs`, `.harnesses`) and per-leaf casing (`.needs.repos` lowercase, `.operator.GIT_USER_NAME` env-var style). A typed-struct approach would force every blueprint to write `.Needs.Repos`, breaking the published shape — maps preserve it.
- Clean break from `${KEY}` render-time substitution per the umbrella's call (no published template depends on it for iteration sites). The runtime `CellBlueprintParameter` `${KEY}` substitution is a separate layer applied at apply time and is unaffected: Go template treats `${KEY}` as literal text, so a blueprint can mix `{{ .image }}` (render-time) and `${ANTHROPIC_API_KEY}` (apply-time) freely.

## Test plan

- [x] `make test-root` — full root-module unit-test suite, including the migrated `internal/teamrender` and `cmd/kuke/team` test fixtures.
- [x] `make test-kukebuild` — kukebuild module tests.
- [x] `pre-commit run --files <changed files>` — `go-fmt`, `golangci-lint`, `addlicense`, end-of-file/trailing-whitespace hooks all green.
- [x] `internal/teamrender/teamrender_test.go` carries new tests for the AC's three load-path branches: `TestRenderBlueprintResolvesTemplateRelativeToHarnessDir` (bare-filename → harness-dir resolution), `TestRenderBlueprintLoadsSiblingPartials` (`{{ template "mount_source" . }}` against a sibling `partials.tmpl.yaml`), `TestRenderBlueprintNeedsAndOperatorContext` (the AC's fixture-template clause: `{{ range .needs.repos }}` + `{{ .operator.GIT_USER_NAME }}`), and `TestRenderBlueprintRunsUpperReplaceFuncs` (sprig-style pipe).
- [x] Existing `teamrender_test.go` and `cmd/kuke/team/init_test.go` fixtures migrated to bare-filename `Spec.Template` + text/template syntax (AC: existing fixtures migrated).
- [ ] `make dev-init` smoke — not touched here; the change is to in-memory rendering and the `kuke get realms` two-realm tail is unaffected by the renderer (it exercises `kuke init`, not `kuke team init`).

Closes #1110