### PR TITLE
feat(team): host-state layout + TeamEntry.teamDir + per-team provisioning

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -237,6 +237,17 @@ func composeTeam(
 		}
 	}
 
+	// Resolve the per-team root: an operator-supplied spec.teamDir on the
+	// existing drop-in entry overrides the default <base>/teams/<team>; an
+	// absent override falls back to the layout default. The resolved path
+	// is used for both the provisioning pass and the entry write below so
+	// the persisted record matches what was actually provisioned.
+	teamDir := resolveTeamDir(layout, project)
+
+	if provisionErr := provisionHost(out, teamDir, pt, bundle, dryRun); provisionErr != nil {
+		return provisionErr
+	}
+
 	if dryRun {
 		return emitDryRun(out, project, layout, res)
 	}
@@ -252,8 +263,9 @@ func composeTeam(
 		Kind:       model.KindTeamEntry,
 		Metadata:   model.Metadata{Name: project},
 		Spec: model.TeamEntrySpec{
-			Path:   projectDir,
-			Source: &source,
+			Path:    projectDir,
+			TeamDir: teamDir,
+			Source:  &source,
 		},
 	}
 	if writeErr := teamhost.WriteEntry(layout, entry); writeErr != nil {
@@ -267,6 +279,89 @@ func composeTeam(
 			len(res.Blueprints), len(res.Configs))
 	}
 	return nil
+}
+
+// resolveTeamDir returns the per-team host-state root for `project`. The
+// default is `Layout.TeamDir(project)`, but an existing drop-in entry's
+// `spec.teamDir` (set by the operator to relocate the team's state tree)
+// overrides the default so a re-init preserves the operator's relocation.
+// A missing or malformed entry — and an entry with an empty teamDir — both
+// fall back to the default so first-init keeps the well-known shape.
+func resolveTeamDir(layout teamhost.Layout, project string) string {
+	defaultDir := layout.TeamDir(project)
+	raw, err := os.ReadFile(layout.EntryPath(project))
+	if err != nil {
+		return defaultDir
+	}
+	var existing model.TeamEntry
+	if unmarshalErr := yaml.Unmarshal(raw, &existing); unmarshalErr != nil {
+		return defaultDir
+	}
+	if override := strings.TrimSpace(existing.Spec.TeamDir); override != "" {
+		return override
+	}
+	return defaultDir
+}
+
+// provisionHost runs the per-team host-state provisioning pass: per-(role
+// × harness) state dirs, harness seeds, and the one-shot host-config copy.
+// A harness-less roster (no harness defaults, no pairs) still flows through
+// teamhost.ProvisionTeam so the team root + a one-shot config seed are
+// materialized — `kuke team init` is the addressable point of contact for
+// every team, not just teams with rendered cells.
+func provisionHost(
+	out io.Writer, teamDir string,
+	pt *model.ProjectTeam, bundle *teamsource.Bundle, dryRun bool,
+) error {
+	pairs := rosterPairs(pt)
+	harnesses := map[string]*model.Harness{}
+	if bundle != nil {
+		harnesses = bundle.Harnesses
+	}
+	in := teamhost.ProvisionInputs{
+		TeamRoot:      teamDir,
+		Pairs:         pairs,
+		Harnesses:     harnesses,
+		HomeConfigDir: hostUserConfigDir(),
+		DryRun:        dryRun,
+		Out:           out,
+	}
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		return fmt.Errorf("provision team host state: %w", err)
+	}
+	return nil
+}
+
+// rosterPairs flattens pt.Spec.Roles × pt.Spec.Defaults.Harnesses into the
+// concrete (role × harness) pairs the provisioning pass materializes state
+// dirs for. A role-less or harness-less project produces an empty list.
+func rosterPairs(pt *model.ProjectTeam) []teamhost.SeedPair {
+	if pt == nil {
+		return nil
+	}
+	if len(pt.Spec.Roles) == 0 || len(pt.Spec.Defaults.Harnesses) == 0 {
+		return nil
+	}
+	pairs := make([]teamhost.SeedPair, 0, len(pt.Spec.Roles)*len(pt.Spec.Defaults.Harnesses))
+	for _, role := range pt.Spec.Roles {
+		for _, harness := range pt.Spec.Defaults.Harnesses {
+			pairs = append(pairs, teamhost.SeedPair{Role: role.Ref, Harness: harness})
+		}
+	}
+	return pairs
+}
+
+// hostUserConfigDir resolves the source of the one-shot config copy
+// (`$HOME/.config`) per the XDG-on-Linux convention. An unresolvable HOME
+// disables the copy by returning the empty string — ProvisionTeam treats
+// that as "no copy", which is the right behavior for a CI host that has no
+// operator config to seed.
+func hostUserConfigDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config")
 }
 
 // applyTeam marshals the rendered set and hands it to apply with the project

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -1038,6 +1038,227 @@ func TestComposeTeamBuildNotInvokedByDefault(t *testing.T) {
 	}
 }
 
+// TestComposeTeamAutoFillsTeamDir confirms the AC: a clean init writes the
+// drop-in entry with spec.teamDir auto-populated from Layout.TeamDir(project).
+func TestComposeTeamAutoFillsTeamDir(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+	raw, err := os.ReadFile(layout.EntryPath("sbsh"))
+	if err != nil {
+		t.Fatalf("entry not written: %v", err)
+	}
+	var te model.TeamEntry
+	if unmarshalErr := yaml.Unmarshal(raw, &te); unmarshalErr != nil {
+		t.Fatalf("entry parse: %v", unmarshalErr)
+	}
+	if want := layout.TeamDir("sbsh"); te.Spec.TeamDir != want {
+		t.Errorf("entry.spec.teamDir = %q, want auto-filled %q", te.Spec.TeamDir, want)
+	}
+}
+
+// TestComposeTeamPreservesTeamDirOverride covers the AC: a hand-edited
+// spec.teamDir survives re-init. The test seeds an existing drop-in entry
+// with an override and asserts the re-write keeps it.
+func TestComposeTeamPreservesTeamDirOverride(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	// Seed an existing drop-in entry with an operator-relocated teamDir.
+	override := filepath.Join(t.TempDir(), "nfs-mounted", "sbsh")
+	prior := &model.TeamEntry{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindTeamEntry,
+		Metadata:   model.Metadata{Name: "sbsh"},
+		Spec: model.TeamEntrySpec{
+			Path:    projectDir,
+			TeamDir: override,
+			Source:  &model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
+		},
+	}
+	if err := teamhost.WriteEntry(layout, prior); err != nil {
+		t.Fatalf("seed prior entry: %v", err)
+	}
+
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL(""), stubResolveErr(), stubApplyErr(), stubBuildErr(), false, false,
+	); err != nil {
+		t.Fatalf("composeTeam re-init: %v", err)
+	}
+
+	raw, err := os.ReadFile(layout.EntryPath("sbsh"))
+	if err != nil {
+		t.Fatalf("entry not written: %v", err)
+	}
+	var te model.TeamEntry
+	if unmarshalErr := yaml.Unmarshal(raw, &te); unmarshalErr != nil {
+		t.Fatalf("entry parse: %v", unmarshalErr)
+	}
+	if te.Spec.TeamDir != override {
+		t.Errorf("entry.spec.teamDir = %q, want preserved override %q", te.Spec.TeamDir, override)
+	}
+
+	// State dir + per-team root land under the override path, not the
+	// layout default — the override governs provisioning too.
+	if _, statErr := os.Stat(override); statErr != nil {
+		t.Errorf("override teamDir not provisioned: %v", statErr)
+	}
+	if _, statErr := os.Stat(layout.TeamDir("sbsh")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("default teamDir leaked alongside override: err=%v", statErr)
+	}
+}
+
+// TestComposeTeamProvisionsRosterStateDirs covers the AC: every roster
+// (role × harness) pair gets a state dir under `~/.kuke/teams/<team>/`.
+func TestComposeTeamProvisionsRosterStateDirs(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	// Add a seed to the claude harness so the AC's "seeds applied" branch
+	// also fires alongside the state-dir mkdir.
+	bundle.Harnesses["claude"].Spec.Seeds = []model.HarnessSeed{
+		{Path: "${HARNESS}.json", Mode: 0o644, Content: "{}\n"},
+	}
+
+	var (
+		mu    sync.Mutex
+		calls []applyCall
+	)
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{}),
+		stubBuildErr(), false, false,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+
+	stateDir := layout.RoleHarnessStateDir("sbsh", "dev", "claude")
+	if info, err := os.Stat(stateDir); err != nil {
+		t.Errorf("state dir not created: %v", err)
+	} else if !info.IsDir() {
+		t.Errorf("%q is not a dir", stateDir)
+	}
+
+	seedPath := layout.HarnessSeedPath("sbsh", "claude", "")
+	if _, err := os.Stat(seedPath); err != nil {
+		t.Errorf("seed not written: %v", err)
+	}
+}
+
+// TestComposeTeamProvisionsTwoProjectsIsolated checks the AC's e2e
+// invariant at the composition layer: dezot and kukeon get isolated
+// state trees under one shared `~/.kuke/teams/` root.
+func TestComposeTeamProvisionsTwoProjectsIsolated(t *testing.T) {
+	t.Parallel()
+	const otherProjectYAML = `apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: kukeon }
+spec:
+  source: { repo: github.com/eminwux/agents, tag: v1.4.0 }
+  defaults:
+    harnesses: [claude]
+  roles:
+    - { ref: dev }
+`
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	bundle.Harnesses["claude"].Spec.Seeds = []model.HarnessSeed{
+		{Path: "${HARNESS}.json", Mode: 0o644, Content: "{}\n"},
+	}
+
+	var (
+		mu    sync.Mutex
+		calls []applyCall
+	)
+	apply := recordingApply(&mu, &calls, kukeonv1.ApplyDocumentsResult{})
+
+	for _, tc := range []struct{ name, body string }{
+		{"dezot", strings.ReplaceAll(otherProjectYAML, "kukeon", "dezot")},
+		{"kukeon", otherProjectYAML},
+	} {
+		dir := writeProject(t, tc.body)
+		if err := composeTeam(
+			context.Background(), &bytes.Buffer{}, io.Discard, dir, layout,
+			stubGit(nil), stubProjectURL("git@github.com:eminwux/"+tc.name+".git"),
+			stubBundle(bundle), apply, stubBuildErr(), false, false,
+		); err != nil {
+			t.Fatalf("composeTeam(%q): %v", tc.name, err)
+		}
+	}
+
+	for _, team := range []string{"dezot", "kukeon"} {
+		if _, err := os.Stat(layout.RoleHarnessStateDir(team, "dev", "claude")); err != nil {
+			t.Errorf("team %q state dir missing: %v", team, err)
+		}
+		if _, err := os.Stat(layout.HarnessSeedPath(team, "claude", "")); err != nil {
+			t.Errorf("team %q seed missing: %v", team, err)
+		}
+	}
+
+	// Tampering dezot's seed must not affect kukeon's.
+	dezotSeed := layout.HarnessSeedPath("dezot", "claude", "")
+	kukeonSeed := layout.HarnessSeedPath("kukeon", "claude", "")
+	kukeonBefore, err := os.ReadFile(kukeonSeed)
+	if err != nil {
+		t.Fatalf("read kukeon seed: %v", err)
+	}
+	if writeErr := os.WriteFile(dezotSeed, []byte("tampered\n"), 0o644); writeErr != nil {
+		t.Fatalf("tamper dezot: %v", writeErr)
+	}
+	kukeonAfter, err := os.ReadFile(kukeonSeed)
+	if err != nil {
+		t.Fatalf("read kukeon seed after tamper: %v", err)
+	}
+	if !bytes.Equal(kukeonBefore, kukeonAfter) {
+		t.Errorf("kukeon seed disturbed by dezot edit:\nbefore=%q\nafter=%q",
+			kukeonBefore, kukeonAfter)
+	}
+}
+
+// TestComposeTeamProvisionDryRunWritesNothing extends the existing
+// dry-run AC to the host-state provisioning pass: the announcements
+// land on stdout, but no per-team root materializes.
+func TestComposeTeamProvisionDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	bundle.Harnesses["claude"].Spec.Seeds = []model.HarnessSeed{
+		{Path: "${HARNESS}.json", Mode: 0o644, Content: "{}\n"},
+	}
+
+	var out bytes.Buffer
+	if err := composeTeam(
+		context.Background(), &out, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), stubApplyErr(), stubBuildErr(), true, false,
+	); err != nil {
+		t.Fatalf("composeTeam dry-run: %v", err)
+	}
+	if _, err := os.Stat(layout.TeamDir("sbsh")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("dry-run created team dir: stat err=%v", err)
+	}
+	body := out.String()
+	stateDir := layout.RoleHarnessStateDir("sbsh", "dev", "claude")
+	if !strings.Contains(body, stateDir) {
+		t.Errorf("dry-run output missing state dir %q:\n%s", stateDir, body)
+	}
+	if !strings.Contains(body, layout.HarnessSeedPath("sbsh", "claude", "")) {
+		t.Errorf("dry-run output missing seed path:\n%s", body)
+	}
+}
+
 func TestNewTeamCmdRegistersInit(t *testing.T) {
 	t.Parallel()
 	cmd := NewTeamCmd()

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -682,4 +682,17 @@ var (
 	ErrTeamBuildCycle = errors.New(
 		"Dockerfile FROM-graph cycle prevents base-before-leaves build ordering",
 	)
+	// ErrTeamHarnessSeedPathRequired fires when a Harness seed entry omits path.
+	ErrTeamHarnessSeedPathRequired = errors.New("harness seeds[].path is required")
+	// ErrTeamHarnessSeedModeInvalid fires when a Harness seed mode is outside
+	// the permitted 0..0o777 file-permission range.
+	ErrTeamHarnessSeedModeInvalid = errors.New(
+		"harness seeds[].mode must be a file-permission bit set (0..0o777)",
+	)
+	// ErrTeamHarnessSeedPathEscapes fires when a Harness seed path, after
+	// ${TEAM_ROOT}/${HARNESS} expansion, would write outside the per-team
+	// root.
+	ErrTeamHarnessSeedPathEscapes = errors.New(
+		"harness seeds[].path escapes the per-team root after expansion",
+	)
 )

--- a/internal/kuketeams/parser.go
+++ b/internal/kuketeams/parser.go
@@ -422,7 +422,8 @@ func validateRole(r *model.Role) error {
 }
 
 // validateHarness enforces the Harness contract: name known; skillPath,
-// makeTarget, template non-empty.
+// makeTarget, template non-empty; each declared seed has a non-empty path and
+// a permission-bit mode (0..0o777).
 func validateHarness(h *model.Harness) error {
 	if !model.IsKnownHarness(h.Metadata.Name) {
 		return fmt.Errorf("%w: %q (metadata.name)", errdefs.ErrTeamHarnessUnknown, h.Metadata.Name)
@@ -431,6 +432,14 @@ func validateHarness(h *model.Harness) error {
 		strings.TrimSpace(h.Spec.MakeTarget) == "" ||
 		strings.TrimSpace(h.Spec.Template) == "" {
 		return errdefs.ErrTeamHarnessFieldRequired
+	}
+	for i, s := range h.Spec.Seeds {
+		if strings.TrimSpace(s.Path) == "" {
+			return fmt.Errorf("%w (seeds[%d])", errdefs.ErrTeamHarnessSeedPathRequired, i)
+		}
+		if s.Mode < 0 || s.Mode > 0o777 {
+			return fmt.Errorf("%w (seeds[%d] mode=%#o)", errdefs.ErrTeamHarnessSeedModeInvalid, i, s.Mode)
+		}
 	}
 	return nil
 }

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -84,7 +84,18 @@ const harnessHappy = `
 apiVersion: kuketeams.io/v1
 kind: Harness
 metadata: { name: claude }
-spec: { baseImage: claude, skillPath: /home/claude/.claude/skills, makeTarget: claude, template: blueprint.tmpl.yaml }
+spec:
+  baseImage:  claude
+  skillPath:  /home/claude/.claude/skills
+  makeTarget: claude
+  template:   blueprint.tmpl.yaml
+  seeds:
+    - path: ${TEAM_ROOT}/${HARNESS}.json
+      mode: 0o644
+      content: "{}\n"
+    - path: ${HARNESS}.json-root
+      mode: 0o600
+      content: "{}\n"
 `
 
 const imageCatalogHappy = `
@@ -208,6 +219,22 @@ func TestParseHappyPathFields(t *testing.T) {
 	if len(role.Role.Spec.Needs.Repos) != 2 || len(role.Role.Spec.Needs.Mounts) != 1 {
 		t.Errorf("needs repos/mounts split wrong: repos=%v mounts=%v",
 			role.Role.Spec.Needs.Repos, role.Role.Spec.Needs.Mounts)
+	}
+
+	h, err := Parse([]byte(harnessHappy))
+	if err != nil {
+		t.Fatalf("Harness: %v", err)
+	}
+	seeds := h.Harness.Spec.Seeds
+	if len(seeds) != 2 {
+		t.Fatalf("harness seeds len = %d, want 2", len(seeds))
+	}
+	if seeds[0].Path != "${TEAM_ROOT}/${HARNESS}.json" || seeds[0].Mode != 0o644 ||
+		seeds[0].Content != "{}\n" {
+		t.Errorf("harness seeds[0] = %+v", seeds[0])
+	}
+	if seeds[1].Path != "${HARNESS}.json-root" || seeds[1].Mode != 0o600 {
+		t.Errorf("harness seeds[1] = %+v", seeds[1])
 	}
 
 	ic, err := Parse([]byte(imageCatalogHappy))
@@ -389,6 +416,16 @@ func TestParseFailureModes(t *testing.T) {
 			"Harness missing skillPath",
 			"apiVersion: kuketeams.io/v1\nkind: Harness\nmetadata: {name: claude}\nspec: { makeTarget: m, template: t }\n",
 			errdefs.ErrTeamHarnessFieldRequired,
+		},
+		{
+			"Harness seed missing path",
+			"apiVersion: kuketeams.io/v1\nkind: Harness\nmetadata: {name: claude}\nspec: { skillPath: /s, makeTarget: m, template: t, seeds: [{ mode: 0o644, content: \"{}\" }] }\n",
+			errdefs.ErrTeamHarnessSeedPathRequired,
+		},
+		{
+			"Harness seed invalid mode",
+			"apiVersion: kuketeams.io/v1\nkind: Harness\nmetadata: {name: claude}\nspec: { skillPath: /s, makeTarget: m, template: t, seeds: [{ path: a.json, mode: 0o1234 }] }\n",
+			errdefs.ErrTeamHarnessSeedModeInvalid,
 		},
 		// ImageCatalog.
 		{

--- a/internal/teamhost/provision.go
+++ b/internal/teamhost/provision.go
@@ -1,0 +1,305 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teamhost
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+)
+
+const (
+	// filePermissionMask is the rwxrwxrwx file-permission bit mask used to
+	// clamp a YAML-supplied seeds[].mode value before casting to FileMode.
+	filePermissionMask = 0o777
+	// defaultSeedMode is the FileMode applied to a seed entry whose YAML
+	// omits `mode` (rendered as 0 by Go's int zero value).
+	defaultSeedMode os.FileMode = 0o644
+)
+
+// SeedPair names one roster (role × harness) pair the provisioning pass
+// materializes a state dir + seed set for.
+type SeedPair struct {
+	Role    string
+	Harness string
+}
+
+// ProvisionInputs is the per-team provisioning request.
+//
+// TeamRoot is the resolved per-team root directory — `<base>/teams/<team>`
+// by default, or the operator-supplied TeamEntry.spec.teamDir override when
+// set. The provisioning pass anchors every state dir, seed write, and the
+// one-shot host-config copy under this path so a relocated TeamDir lands a
+// fully self-contained tree.
+//
+// Pairs lists the roster (role × harness) entries to mkdir state dirs for.
+// Harnesses maps each harness referenced by Pairs to its loaded Harness
+// document; ProvisionTeam reads `Spec.Seeds` off the corresponding entry to
+// write seed files. A harness referenced by Pairs but absent from Harnesses
+// gets a state dir but no seeds (the resolve layer would surface the
+// missing-harness error earlier — this is a defense-in-depth path).
+//
+// HomeConfigDir is the source of the one-shot `$HOME/.config/. →
+// HostConfigDir(team)` copy. The empty string disables the copy; a path that
+// does not exist on disk is treated the same as the empty string.
+type ProvisionInputs struct {
+	TeamRoot      string
+	Pairs         []SeedPair
+	Harnesses     map[string]*model.Harness
+	HomeConfigDir string
+	DryRun        bool
+	Out           io.Writer
+}
+
+// ProvisionTeam runs the per-team provisioning pass: it mkdir -p's each
+// roster pair's state dir, writes any harness seeds that are not already
+// present (hand-edited files survive), and performs the one-shot host
+// config copy on a clean per-team config dir. The pass is idempotent — a
+// re-run on a healthy host is a no-op.
+//
+// DryRun reports what would change to Out without touching disk; an empty
+// Out is treated as io.Discard.
+func ProvisionTeam(in ProvisionInputs) error {
+	teamRoot := strings.TrimSpace(in.TeamRoot)
+	if teamRoot == "" {
+		return errors.New("ProvisionTeam: TeamRoot is required")
+	}
+	out := in.Out
+	if out == nil {
+		out = io.Discard
+	}
+
+	if !in.DryRun {
+		if err := os.MkdirAll(teamRoot, TeamsRootPerm); err != nil {
+			return fmt.Errorf("create team root %q: %w", teamRoot, err)
+		}
+	}
+
+	if err := provisionStateDirs(out, teamRoot, in.Pairs, in.DryRun); err != nil {
+		return err
+	}
+	if err := provisionSeeds(out, teamRoot, in.Pairs, in.Harnesses, in.DryRun); err != nil {
+		return err
+	}
+	if err := provisionHostConfig(out, teamRoot, in.HomeConfigDir, in.DryRun); err != nil {
+		return err
+	}
+	return nil
+}
+
+func provisionStateDirs(out io.Writer, teamRoot string, pairs []SeedPair, dryRun bool) error {
+	for _, p := range pairs {
+		role := strings.TrimSpace(p.Role)
+		harness := strings.TrimSpace(p.Harness)
+		if role == "" || harness == "" {
+			continue
+		}
+		dir := filepath.Join(teamRoot, role+"-"+harness)
+		if dryRun {
+			fmt.Fprintf(out, "# dry-run: mkdir %s (mode %#o)\n", dir, TeamsRootPerm)
+			continue
+		}
+		if err := os.MkdirAll(dir, TeamsRootPerm); err != nil {
+			return fmt.Errorf("create state dir %q: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+func provisionSeeds(
+	out io.Writer, teamRoot string,
+	pairs []SeedPair, harnesses map[string]*model.Harness, dryRun bool,
+) error {
+	// Visit each harness at most once even when multiple roles select it —
+	// the seed set is harness-scoped, not pair-scoped.
+	seen := make(map[string]struct{}, len(pairs))
+	for _, p := range pairs {
+		h := strings.TrimSpace(p.Harness)
+		if h == "" {
+			continue
+		}
+		if _, ok := seen[h]; ok {
+			continue
+		}
+		seen[h] = struct{}{}
+		harness := harnesses[h]
+		if harness == nil {
+			continue
+		}
+		for _, seed := range harness.Spec.Seeds {
+			path, err := expandSeedPath(seed.Path, teamRoot, h)
+			if err != nil {
+				return fmt.Errorf("harness %q seed %q: %w", h, seed.Path, err)
+			}
+			if writeErr := writeSeedIfAbsent(out, path, seed, dryRun); writeErr != nil {
+				return writeErr
+			}
+		}
+	}
+	return nil
+}
+
+// expandSeedPath resolves a harness seed's spec.path template against the
+// per-team root. ${TEAM_ROOT} expands to teamRoot, ${HARNESS} to the harness
+// name; the resulting path is anchored under teamRoot when relative, and
+// must never escape teamRoot once cleaned.
+func expandSeedPath(raw, teamRoot, harness string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return "", errdefs.ErrTeamHarnessSeedPathRequired
+	}
+	expanded := strings.NewReplacer(
+		"${TEAM_ROOT}", teamRoot,
+		"${HARNESS}", harness,
+	).Replace(raw)
+	if !filepath.IsAbs(expanded) {
+		expanded = filepath.Join(teamRoot, expanded)
+	}
+	clean := filepath.Clean(expanded)
+	rootClean := filepath.Clean(teamRoot)
+	if clean != rootClean &&
+		!strings.HasPrefix(clean, rootClean+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w (got %q)", errdefs.ErrTeamHarnessSeedPathEscapes, clean)
+	}
+	return clean, nil
+}
+
+func writeSeedIfAbsent(out io.Writer, path string, seed model.HarnessSeed, dryRun bool) error {
+	if _, err := os.Stat(path); err == nil {
+		if dryRun {
+			fmt.Fprintf(out, "# dry-run: seed %s present (skip)\n", path)
+		}
+		return nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("stat seed %q: %w", path, err)
+	}
+	// Parser validation bounds seed.Mode to filePermissionMask, so the
+	// int→FileMode cast cannot overflow despite gosec's structural complaint.
+	mode := os.FileMode(uint32(seed.Mode & filePermissionMask)) //nolint:gosec // bounded by validateHarness
+	if mode == 0 {
+		mode = defaultSeedMode
+	}
+	if dryRun {
+		fmt.Fprintf(out, "# dry-run: write %s mode=%#o (%d byte(s))\n", path, mode, len(seed.Content))
+		return nil
+	}
+	parent := filepath.Dir(path)
+	if mkErr := os.MkdirAll(parent, TeamsRootPerm); mkErr != nil {
+		return fmt.Errorf("create seed parent %q: %w", parent, mkErr)
+	}
+	if writeErr := os.WriteFile(path, []byte(seed.Content), mode); writeErr != nil {
+		return fmt.Errorf("write seed %q: %w", path, writeErr)
+	}
+	// os.WriteFile honours the process umask; chmod explicitly so a 0o644
+	// declaration is not silently masked to 0o600 on operator hosts.
+	if chmodErr := os.Chmod(path, mode); chmodErr != nil {
+		return fmt.Errorf("chmod seed %q: %w", path, chmodErr)
+	}
+	return nil
+}
+
+// provisionHostConfig performs the one-shot `$HOME/.config/. →
+// HostConfigDir(team)` copy when the per-team config dir is empty AND
+// homeConfigDir exists. An already-populated config dir is left untouched
+// (the operator may have hand-edited it); a missing homeConfigDir is a
+// silent skip (operator may not have one yet).
+func provisionHostConfig(out io.Writer, teamRoot, homeConfigDir string, dryRun bool) error {
+	src := strings.TrimSpace(homeConfigDir)
+	if src == "" {
+		return nil
+	}
+	if _, err := os.Stat(src); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("stat host config source %q: %w", src, err)
+	}
+	dst := filepath.Join(teamRoot, hostConfigDirName)
+	if entries, err := os.ReadDir(dst); err == nil && len(entries) > 0 {
+		if dryRun {
+			fmt.Fprintf(out, "# dry-run: host config %s already populated (skip)\n", dst)
+		}
+		return nil
+	} else if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("read host config dir %q: %w", dst, err)
+	}
+	if dryRun {
+		fmt.Fprintf(out, "# dry-run: copy %s/. → %s\n", src, dst)
+		return nil
+	}
+	if err := os.MkdirAll(dst, TeamsRootPerm); err != nil {
+		return fmt.Errorf("create host config dir %q: %w", dst, err)
+	}
+	return copyTree(src, dst)
+}
+
+// copyTree mirrors src into dst preserving each entry's file mode bits.
+// Symlinks are skipped — the host-config copy is operator state that
+// should not span filesystem boundaries opaquely.
+func copyTree(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel == "." {
+			return nil
+		}
+		target := filepath.Join(dst, rel)
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		switch {
+		case d.IsDir():
+			return os.MkdirAll(target, info.Mode().Perm())
+		case info.Mode()&fs.ModeSymlink != 0:
+			return nil
+		default:
+			return copyFile(path, target, info.Mode().Perm())
+		}
+	})
+}
+
+func copyFile(src, dst string, mode fs.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %q: %w", src, err)
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("create %q: %w", dst, err)
+	}
+	defer func() { _ = out.Close() }()
+	if _, copyErr := io.Copy(out, in); copyErr != nil {
+		return fmt.Errorf("copy %q → %q: %w", src, dst, copyErr)
+	}
+	if chmodErr := os.Chmod(dst, mode); chmodErr != nil {
+		return fmt.Errorf("chmod %q: %w", dst, chmodErr)
+	}
+	return nil
+}

--- a/internal/teamhost/provision_test.go
+++ b/internal/teamhost/provision_test.go
@@ -1,0 +1,386 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teamhost_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/errdefs"
+	"github.com/eminwux/kukeon/internal/teamhost"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+)
+
+func claudeHarness(seeds []model.HarnessSeed) *model.Harness {
+	return &model.Harness{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindHarness,
+		Metadata:   model.Metadata{Name: "claude"},
+		Spec: model.HarnessSpec{
+			SkillPath:  "/skills",
+			MakeTarget: "claude",
+			Template:   "blueprint.tmpl.yaml",
+			Seeds:      seeds,
+		},
+	}
+}
+
+func defaultSeedHarness() *model.Harness {
+	return claudeHarness([]model.HarnessSeed{
+		{Path: "${TEAM_ROOT}/${HARNESS}.json", Mode: 0o644, Content: "{}\n"},
+		{Path: "${HARNESS}.json-root", Mode: 0o644, Content: "{}\n"},
+	})
+}
+
+// TestProvisionTeamCreatesStateDirsAndSeeds is the AC's clean-host case:
+// every roster pair gets a state dir, every harness seed is written, and
+// the per-team root materializes with mode 0o700.
+func TestProvisionTeamCreatesStateDirsAndSeeds(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	teamRoot := l.TeamDir("dezot")
+	in := teamhost.ProvisionInputs{
+		TeamRoot: teamRoot,
+		Pairs: []teamhost.SeedPair{
+			{Role: "dev", Harness: "claude"},
+			{Role: "pm", Harness: "claude"},
+		},
+		Harnesses: map[string]*model.Harness{"claude": defaultSeedHarness()},
+	}
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		t.Fatalf("ProvisionTeam: %v", err)
+	}
+
+	for _, role := range []string{"dev", "pm"} {
+		dir := l.RoleHarnessStateDir("dezot", role, "claude")
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Errorf("state dir %q not created: %v", dir, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%q is not a dir", dir)
+		}
+		if perm := info.Mode().Perm(); perm != 0o700 {
+			t.Errorf("state dir %q perm = %#o, want 0o700", dir, perm)
+		}
+	}
+
+	for _, want := range []string{
+		l.HarnessSeedPath("dezot", "claude", ""),
+		l.HarnessSeedPath("dezot", "claude", "root"),
+	} {
+		info, err := os.Stat(want)
+		if err != nil {
+			t.Errorf("seed %q not written: %v", want, err)
+			continue
+		}
+		if perm := info.Mode().Perm(); perm != 0o644 {
+			t.Errorf("seed %q perm = %#o, want 0o644", want, perm)
+		}
+		got, readErr := os.ReadFile(want)
+		if readErr != nil {
+			t.Errorf("read seed %q: %v", want, readErr)
+		}
+		if string(got) != "{}\n" {
+			t.Errorf("seed %q content = %q, want %q", want, got, "{}\n")
+		}
+	}
+}
+
+// TestProvisionTeamIdempotent re-runs ProvisionTeam against an already-
+// provisioned tree and checks that hand-edited seed files survive — the
+// AC's "re-running is a no-op for state dirs and seeds; hand-edited seed
+// files are never overwritten" invariant.
+func TestProvisionTeamIdempotent(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	teamRoot := l.TeamDir("dezot")
+	in := teamhost.ProvisionInputs{
+		TeamRoot: teamRoot,
+		Pairs:    []teamhost.SeedPair{{Role: "dev", Harness: "claude"}},
+		Harnesses: map[string]*model.Harness{"claude": claudeHarness([]model.HarnessSeed{
+			{Path: "${TEAM_ROOT}/${HARNESS}.json", Mode: 0o644, Content: "{}\n"},
+		})},
+	}
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		t.Fatalf("first ProvisionTeam: %v", err)
+	}
+
+	seedPath := l.HarnessSeedPath("dezot", "claude", "")
+	const sentinel = `{"oauth_token": "edited-by-operator"}`
+	if err := os.WriteFile(seedPath, []byte(sentinel), 0o644); err != nil {
+		t.Fatalf("seed hand-edit: %v", err)
+	}
+
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		t.Fatalf("re-run ProvisionTeam: %v", err)
+	}
+	got, err := os.ReadFile(seedPath)
+	if err != nil {
+		t.Fatalf("read seed after re-run: %v", err)
+	}
+	if string(got) != sentinel {
+		t.Errorf("re-run overwrote hand-edited seed: %q", got)
+	}
+
+	// State dir still readable after re-run.
+	if _, statErr := os.Stat(l.RoleHarnessStateDir("dezot", "dev", "claude")); statErr != nil {
+		t.Errorf("state dir lost on re-run: %v", statErr)
+	}
+}
+
+// TestProvisionTeamTwoProjectsIsolated covers the AC: dezot and kukeon
+// running provisioning against the same layout get isolated state trees
+// with no cross-contamination.
+func TestProvisionTeamTwoProjectsIsolated(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	h := defaultSeedHarness()
+
+	for _, team := range []string{"dezot", "kukeon"} {
+		in := teamhost.ProvisionInputs{
+			TeamRoot:  l.TeamDir(team),
+			Pairs:     []teamhost.SeedPair{{Role: "dev", Harness: "claude"}},
+			Harnesses: map[string]*model.Harness{"claude": h},
+		}
+		if err := teamhost.ProvisionTeam(in); err != nil {
+			t.Fatalf("ProvisionTeam(%q): %v", team, err)
+		}
+	}
+
+	for _, team := range []string{"dezot", "kukeon"} {
+		stateDir := l.RoleHarnessStateDir(team, "dev", "claude")
+		if _, err := os.Stat(stateDir); err != nil {
+			t.Errorf("%q state dir not created: %v", team, err)
+		}
+		if _, err := os.Stat(l.HarnessSeedPath(team, "claude", "")); err != nil {
+			t.Errorf("%q claude.json not seeded: %v", team, err)
+		}
+	}
+
+	// Tamper one team's seed; the other's must remain byte-identical.
+	const tampered = "tampered-by-test\n"
+	dezotSeed := l.HarnessSeedPath("dezot", "claude", "")
+	kukeonSeedBefore, err := os.ReadFile(l.HarnessSeedPath("kukeon", "claude", ""))
+	if err != nil {
+		t.Fatalf("read kukeon seed: %v", err)
+	}
+	if writeErr := os.WriteFile(dezotSeed, []byte(tampered), 0o644); writeErr != nil {
+		t.Fatalf("tamper dezot seed: %v", writeErr)
+	}
+	kukeonSeedAfter, err := os.ReadFile(l.HarnessSeedPath("kukeon", "claude", ""))
+	if err != nil {
+		t.Fatalf("read kukeon seed after tamper: %v", err)
+	}
+	if !bytes.Equal(kukeonSeedBefore, kukeonSeedAfter) {
+		t.Errorf("kukeon seed disturbed by dezot edit:\nbefore=%q\nafter=%q",
+			kukeonSeedBefore, kukeonSeedAfter)
+	}
+}
+
+// TestProvisionTeamDryRunWritesNothing pins the dry-run inversion: nothing
+// hits disk, the announcement is on Out.
+func TestProvisionTeamDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	teamRoot := l.TeamDir("dezot")
+	var out bytes.Buffer
+	in := teamhost.ProvisionInputs{
+		TeamRoot:  teamRoot,
+		Pairs:     []teamhost.SeedPair{{Role: "dev", Harness: "claude"}},
+		Harnesses: map[string]*model.Harness{"claude": defaultSeedHarness()},
+		DryRun:    true,
+		Out:       &out,
+	}
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		t.Fatalf("ProvisionTeam dry-run: %v", err)
+	}
+
+	if _, err := os.Stat(teamRoot); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("dry-run created team root: stat err=%v", err)
+	}
+	body := out.String()
+	for _, want := range []string{
+		filepath.Join(teamRoot, "dev-claude"),
+		l.HarnessSeedPath("dezot", "claude", ""),
+		l.HarnessSeedPath("dezot", "claude", "root"),
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("dry-run output missing path %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestProvisionTeamHostConfigCopiesOnce covers the per-team config seed:
+// the first run copies $HOME/.config/. → HostConfigDir(team); a re-run
+// against a populated config dir is a no-op even if the source has new
+// files.
+func TestProvisionTeamHostConfigCopiesOnce(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	teamRoot := l.TeamDir("dezot")
+
+	homeConfig := filepath.Join(t.TempDir(), ".config")
+	if err := os.MkdirAll(filepath.Join(homeConfig, "kuke"), 0o755); err != nil {
+		t.Fatalf("seed home config: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(homeConfig, "kuke", "settings.yaml"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	in := teamhost.ProvisionInputs{
+		TeamRoot:      teamRoot,
+		HomeConfigDir: homeConfig,
+	}
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		t.Fatalf("first ProvisionTeam: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(l.HostConfigDir("dezot"), "kuke", "settings.yaml"))
+	if err != nil {
+		t.Fatalf("config file not copied: %v", err)
+	}
+	if string(got) != "hello\n" {
+		t.Errorf("copied content = %q", got)
+	}
+
+	// Add a new file in $HOME/.config; the re-run must NOT copy it (target
+	// dir is no longer empty).
+	if writeErr := os.WriteFile(filepath.Join(homeConfig, "kuke", "extra.yaml"), []byte("extra\n"), 0o644); writeErr != nil {
+		t.Fatalf("add extra: %v", writeErr)
+	}
+	if rerunErr := teamhost.ProvisionTeam(in); rerunErr != nil {
+		t.Fatalf("re-run ProvisionTeam: %v", rerunErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(l.HostConfigDir("dezot"), "kuke", "extra.yaml")); !errors.Is(
+		statErr,
+		os.ErrNotExist,
+	) {
+		t.Errorf("re-run copied a new file into a populated config dir: err=%v", statErr)
+	}
+}
+
+// TestProvisionTeamHostConfigMissingSourceSilentSkip pins the silent-skip
+// invariant: a CI host without a $HOME/.config produces no error and no
+// per-team config dir.
+func TestProvisionTeamHostConfigMissingSourceSilentSkip(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	teamRoot := l.TeamDir("dezot")
+
+	in := teamhost.ProvisionInputs{
+		TeamRoot:      teamRoot,
+		HomeConfigDir: filepath.Join(t.TempDir(), "absent"),
+	}
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		t.Fatalf("ProvisionTeam: %v", err)
+	}
+	if _, statErr := os.Stat(l.HostConfigDir("dezot")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("config dir created without a source: err=%v", statErr)
+	}
+}
+
+// TestProvisionTeamSeedPathEscapeRejected confirms the defense-in-depth
+// guard: a harness seed whose expanded path escapes the per-team root is
+// refused via ErrTeamHarnessSeedPathEscapes — the seed is never written.
+func TestProvisionTeamSeedPathEscapeRejected(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	teamRoot := l.TeamDir("dezot")
+
+	in := teamhost.ProvisionInputs{
+		TeamRoot: teamRoot,
+		Pairs:    []teamhost.SeedPair{{Role: "dev", Harness: "claude"}},
+		Harnesses: map[string]*model.Harness{"claude": claudeHarness([]model.HarnessSeed{
+			{Path: "../escape.json", Mode: 0o644, Content: "{}"},
+		})},
+	}
+	err := teamhost.ProvisionTeam(in)
+	if !errors.Is(err, errdefs.ErrTeamHarnessSeedPathEscapes) {
+		t.Fatalf("err = %v, want ErrTeamHarnessSeedPathEscapes", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(filepath.Dir(teamRoot), "escape.json")); !errors.Is(
+		statErr,
+		os.ErrNotExist,
+	) {
+		t.Errorf("escape seed was written: err=%v", statErr)
+	}
+}
+
+// TestProvisionTeamSeedDefaultMode pins the AC's "mode defaults to 0o644"
+// behaviour — a seed with no explicit Mode is still written at 0o644
+// regardless of process umask.
+func TestProvisionTeamSeedDefaultMode(t *testing.T) {
+	t.Parallel()
+	old := syscall.Umask(0o022)
+	defer syscall.Umask(old)
+
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	teamRoot := l.TeamDir("dezot")
+	in := teamhost.ProvisionInputs{
+		TeamRoot: teamRoot,
+		Pairs:    []teamhost.SeedPair{{Role: "dev", Harness: "claude"}},
+		Harnesses: map[string]*model.Harness{"claude": claudeHarness([]model.HarnessSeed{
+			{Path: "${HARNESS}.json", Content: "{}"},
+		})},
+	}
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		t.Fatalf("ProvisionTeam: %v", err)
+	}
+	info, err := os.Stat(l.HarnessSeedPath("dezot", "claude", ""))
+	if err != nil {
+		t.Fatalf("seed not written: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("seed perm = %#o, want 0o644 (default)", perm)
+	}
+}
+
+// TestProvisionTeamEmptyTeamRoot guards the precondition: an empty
+// TeamRoot is a programmer error and surfaces as a top-level error.
+func TestProvisionTeamEmptyTeamRoot(t *testing.T) {
+	t.Parallel()
+	err := teamhost.ProvisionTeam(teamhost.ProvisionInputs{TeamRoot: ""})
+	if err == nil {
+		t.Fatal("ProvisionTeam(\"\") returned nil error")
+	}
+}
+
+// TestProvisionTeamUnknownHarnessSkippedSeeds covers the defense-in-depth
+// path: a roster pair referencing a harness absent from Harnesses still
+// gets a state dir but no seeds (no panic).
+func TestProvisionTeamUnknownHarnessSkippedSeeds(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	teamRoot := l.TeamDir("dezot")
+	in := teamhost.ProvisionInputs{
+		TeamRoot:  teamRoot,
+		Pairs:     []teamhost.SeedPair{{Role: "dev", Harness: "ghost"}},
+		Harnesses: map[string]*model.Harness{}, // empty
+	}
+	if err := teamhost.ProvisionTeam(in); err != nil {
+		t.Fatalf("ProvisionTeam: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(teamRoot, "dev-ghost")); statErr != nil {
+		t.Errorf("state dir not created for unknown harness: %v", statErr)
+	}
+}

--- a/internal/teamhost/teamhost.go
+++ b/internal/teamhost/teamhost.go
@@ -47,6 +47,13 @@ const (
 	// cacheDirName is the materialized-source cache under Base — each agents
 	// reference clones into its own `<host>/<owner>/<repo>@<ref>` subdirectory.
 	cacheDirName = "cache"
+	// teamsRootName is the shared root under Base that holds per-team
+	// host-state subtrees and the host-wide secrets.env default.
+	teamsRootName = "teams"
+	// hostConfigDirName is the per-team config dir name under TeamDir(team).
+	hostConfigDirName = "config"
+	// secretsEnvFileName is the shared/team secrets-env filename.
+	secretsEnvFileName = "secrets.env"
 
 	// dropInDirPerm is the drop-in directory mode: operator-only (the files
 	// reference secret sources and signing keys).
@@ -54,6 +61,9 @@ const (
 	// configFilePerm is the mode for the global facts file and each per-project
 	// entry — operator read/write only.
 	configFilePerm = 0o600
+	// TeamsRootPerm is the shared mode used for the teams/ root, each
+	// TeamDir(team), and the per-(role × harness) state subdirs.
+	TeamsRootPerm = 0o700
 )
 
 // Layout resolves the team-distribution file paths under a base directory
@@ -86,6 +96,63 @@ func (l Layout) EntryPath(project string) string {
 // CacheDir is the materialized-source cache root (<base>/cache).
 func (l Layout) CacheDir() string {
 	return filepath.Join(l.Base, cacheDirName)
+}
+
+// TeamsRoot is the shared root under Base that holds per-team host-state
+// subtrees and the host-wide secrets.env default (<base>/teams). The
+// directory is operator-only (mode 0o700) when materialized.
+func (l Layout) TeamsRoot() string {
+	return filepath.Join(l.Base, teamsRootName)
+}
+
+// TeamDir is the per-team host-state root (<base>/teams/<team>). The
+// operator may relocate this via TeamEntry.spec.teamDir; callers that need
+// the override path should consult the persisted entry, not this method.
+func (l Layout) TeamDir(team string) string {
+	return filepath.Join(l.TeamsRoot(), team)
+}
+
+// RoleHarnessStateDir is the per-(role × harness) state directory under
+// TeamDir(team): `<base>/teams/<team>/<role>-<harness>/`. The provisioning
+// pass mkdir -p's this for every roster pair.
+func (l Layout) RoleHarnessStateDir(team, role, harness string) string {
+	return filepath.Join(l.TeamDir(team), role+"-"+harness)
+}
+
+// HarnessSeedPath is the canonical seed-file path for a harness under
+// TeamDir(team): `<base>/teams/<team>/<harness>.json` when variant is
+// empty, or `<base>/teams/<team>/<harness>.json-<variant>` when set
+// (e.g. variant="root" → "<harness>.json-root"). The provisioning pass
+// resolves a harness seed's spec.path template against this canonical
+// shape — this method exists so callers (tests, future verbs) can
+// address the path without re-deriving the layout.
+func (l Layout) HarnessSeedPath(team, harness, variant string) string {
+	name := harness + ".json"
+	if v := strings.TrimSpace(variant); v != "" {
+		name += "-" + v
+	}
+	return filepath.Join(l.TeamDir(team), name)
+}
+
+// HostConfigDir is the per-team host config dir (<base>/teams/<team>/config),
+// the destination of the one-shot `$HOME/.config/. → HostConfigDir(team)`
+// copy the provisioning pass performs on first init.
+func (l Layout) HostConfigDir(team string) string {
+	return filepath.Join(l.TeamDir(team), hostConfigDirName)
+}
+
+// SharedSecretsEnvPath is the host-wide secrets.env default
+// (<base>/teams/secrets.env). It carries operator-global defaults shared
+// across every team and is operator-only (mode 0o600).
+func (l Layout) SharedSecretsEnvPath() string {
+	return filepath.Join(l.TeamsRoot(), secretsEnvFileName)
+}
+
+// TeamSecretsEnvPath is the per-team secrets.env override
+// (<base>/teams/<team>/secrets.env). Per-team values override the shared
+// defaults and the file is operator-only (mode 0o600).
+func (l Layout) TeamSecretsEnvPath(team string) string {
+	return filepath.Join(l.TeamDir(team), secretsEnvFileName)
 }
 
 // EnsureGlobalConfig writes cfg to the global facts path only when no file is

--- a/internal/teamhost/teamhost_test.go
+++ b/internal/teamhost/teamhost_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/errdefs"
@@ -217,5 +218,68 @@ func TestLayoutPaths(t *testing.T) {
 	}
 	if got, want := l.EntryPath("sbsh"), "/base/.kuke/kuketeam.d/sbsh.yaml"; got != want {
 		t.Errorf("EntryPath = %q, want %q", got, want)
+	}
+}
+
+func TestLayoutTeamsPaths(t *testing.T) {
+	t.Parallel()
+	l := teamhost.NewLayout("/base/.kuke")
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"TeamsRoot", l.TeamsRoot(), "/base/.kuke/teams"},
+		{"TeamDir", l.TeamDir("dezot"), "/base/.kuke/teams/dezot"},
+		{
+			"RoleHarnessStateDir",
+			l.RoleHarnessStateDir("dezot", "dev", "claude"),
+			"/base/.kuke/teams/dezot/dev-claude",
+		},
+		{
+			"HarnessSeedPath bare",
+			l.HarnessSeedPath("dezot", "claude", ""),
+			"/base/.kuke/teams/dezot/claude.json",
+		},
+		{
+			"HarnessSeedPath variant",
+			l.HarnessSeedPath("dezot", "claude", "root"),
+			"/base/.kuke/teams/dezot/claude.json-root",
+		},
+		{"HostConfigDir", l.HostConfigDir("dezot"), "/base/.kuke/teams/dezot/config"},
+		{"SharedSecretsEnvPath", l.SharedSecretsEnvPath(), "/base/.kuke/teams/secrets.env"},
+		{"TeamSecretsEnvPath", l.TeamSecretsEnvPath("dezot"), "/base/.kuke/teams/dezot/secrets.env"},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestLayoutTeamsPathsRootedUnderTempBase exercises the AC's "rooted under a
+// temp <base>" testability check: every team path must be reachable from a
+// temp base so unit tests can run hermetically without touching the
+// operator's real ~/.kuke.
+func TestLayoutTeamsPathsRootedUnderTempBase(t *testing.T) {
+	t.Parallel()
+	base := filepath.Join(t.TempDir(), ".kuke")
+	l := teamhost.NewLayout(base)
+
+	paths := []string{
+		l.TeamsRoot(),
+		l.TeamDir("alpha"),
+		l.RoleHarnessStateDir("alpha", "dev", "claude"),
+		l.HarnessSeedPath("alpha", "claude", ""),
+		l.HarnessSeedPath("alpha", "claude", "root"),
+		l.HostConfigDir("alpha"),
+		l.SharedSecretsEnvPath(),
+		l.TeamSecretsEnvPath("alpha"),
+	}
+	prefix := base + string(filepath.Separator) + "teams"
+	for _, p := range paths {
+		if !strings.HasPrefix(p, prefix) {
+			t.Errorf("path %q not rooted under %q", p, prefix)
+		}
 	}
 }

--- a/pkg/api/model/kuketeams/harness.go
+++ b/pkg/api/model/kuketeams/harness.go
@@ -38,4 +38,20 @@ type HarnessSpec struct {
 	// Template is the blueprint template file the harness renders cells from.
 	// Required.
 	Template string `json:"template"            yaml:"template"`
+	// Seeds declares per-(team,harness) state files the provisioning pass
+	// writes when absent. Hand-edited files are never overwritten — a seed
+	// that already exists is left untouched. Optional.
+	Seeds []HarnessSeed `json:"seeds,omitempty"     yaml:"seeds,omitempty"`
+}
+
+// HarnessSeed declares one state file the provisioning pass writes when
+// absent. Path supports `${TEAM_ROOT}` and `${HARNESS}` substitution
+// (relative paths are anchored under the per-team root). A bare `${HARNESS}`
+// expands to the harness's metadata.name. Mode is the on-disk file mode
+// (octal in YAML — `0o644`); the zero value defaults to 0o644. Content is
+// written verbatim.
+type HarnessSeed struct {
+	Path    string `json:"path"              yaml:"path"`
+	Mode    int    `json:"mode,omitempty"    yaml:"mode,omitempty"`
+	Content string `json:"content,omitempty" yaml:"content,omitempty"`
 }

--- a/pkg/api/model/kuketeams/marshal_test.go
+++ b/pkg/api/model/kuketeams/marshal_test.go
@@ -86,12 +86,14 @@ func TestRoundTripAllKinds(t *testing.T) {
 		APIVersion: model.APIVersionV1, Kind: model.KindTeamEntry,
 		Metadata: model.Metadata{Name: "sbsh"},
 		Spec: model.TeamEntrySpec{
-			Path:   "/home/op/src/sbsh",
-			Source: &model.TeamSource{Repo: "github.com/eminwux/agents", Branch: "main"},
+			Path:    "/home/op/src/sbsh",
+			TeamDir: "/home/op/.kuke/teams/sbsh",
+			Source:  &model.TeamSource{Repo: "github.com/eminwux/agents", Branch: "main"},
 		},
 	}
 	assertJSONYAML(t, "TeamEntry", te, func(got model.TeamEntry) bool {
 		return got.Metadata.Name == "sbsh" && got.Spec.Path == "/home/op/src/sbsh" &&
+			got.Spec.TeamDir == "/home/op/.kuke/teams/sbsh" &&
 			got.Spec.Source != nil && got.Spec.Source.Branch == "main" && got.Spec.Source.Floating()
 	})
 
@@ -111,10 +113,21 @@ func TestRoundTripAllKinds(t *testing.T) {
 	h := model.Harness{
 		APIVersion: model.APIVersionV1, Kind: model.KindHarness,
 		Metadata: model.Metadata{Name: "claude"},
-		Spec:     model.HarnessSpec{SkillPath: "/s", MakeTarget: "claude", Template: "t.yaml"},
+		Spec: model.HarnessSpec{
+			SkillPath:  "/s",
+			MakeTarget: "claude",
+			Template:   "t.yaml",
+			Seeds: []model.HarnessSeed{
+				{Path: "${TEAM_ROOT}/${HARNESS}.json", Mode: 0o644, Content: "{}"},
+			},
+		},
 	}
 	assertJSONYAML(t, "Harness", h, func(got model.Harness) bool {
-		return got.Spec.SkillPath == "/s" && got.Spec.MakeTarget == "claude"
+		return got.Spec.SkillPath == "/s" && got.Spec.MakeTarget == "claude" &&
+			len(got.Spec.Seeds) == 1 &&
+			got.Spec.Seeds[0].Path == "${TEAM_ROOT}/${HARNESS}.json" &&
+			got.Spec.Seeds[0].Mode == 0o644 &&
+			got.Spec.Seeds[0].Content == "{}"
 	})
 
 	ic := model.ImageCatalog{

--- a/pkg/api/model/kuketeams/teamentry.go
+++ b/pkg/api/model/kuketeams/teamentry.go
@@ -34,7 +34,14 @@ type TeamEntry struct {
 // its clone URL is resolved via `git remote`), not a bind-mount source. Source
 // is the structured agents-repository reference (the same TeamSource struct
 // ProjectTeam carries), copied from the project's kuketeam.yaml at init time.
+//
+// TeamDir is the per-team host-state root (typically
+// `<base>/teams/<team>/`). `kuke team init` auto-populates it from
+// Layout.TeamDir(metadata.name) when omitted, and preserves an
+// operator-supplied override across re-init so the operator can relocate
+// the team's state tree (e.g. to a shared NFS dev environment).
 type TeamEntrySpec struct {
-	Path   string      `json:"path"             yaml:"path"`
-	Source *TeamSource `json:"source,omitempty" yaml:"source,omitempty"`
+	Path    string      `json:"path"              yaml:"path"`
+	TeamDir string      `json:"teamDir,omitempty" yaml:"teamDir,omitempty"`
+	Source  *TeamSource `json:"source,omitempty"  yaml:"source,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Adds the seven Layout methods that root `~/.kuke/teams/<team>/…` host-state under `internal/teamhost`: `TeamsRoot`, `TeamDir`, `RoleHarnessStateDir`, `HarnessSeedPath` (with optional `<variant>` suffix), `HostConfigDir`, `SharedSecretsEnvPath`, `TeamSecretsEnvPath`. Each is testable against a temp `<base>`.
- Adds `TeamEntrySpec.TeamDir` (optional string), auto-populated by `kuke team init` from `Layout.TeamDir(metadata.name)` and preserved across re-init when the operator hand-edits the drop-in entry — an override governs both the persisted record and the provisioning pass.
- Adds `HarnessSpec.Seeds []HarnessSeed{Path, Mode, Content}` with `${TEAM_ROOT}` / `${HARNESS}` substitution; parser rejects empty paths and modes outside 0..0o777.
- Adds `teamhost.ProvisionTeam(ProvisionInputs{...})`: mkdir -p's per-(role × harness) state dirs (mode 0o700), writes harness seeds if absent (hand-edited files survive), and performs the one-shot `$HOME/.config/. → HostConfigDir(team)` copy when the per-team config dir is empty. `--dry-run` reports the would-create set without writing.
- Wires the provisioning pass into `composeTeam` between render and apply; harness-less rosters still get a materialized team root + optional config seed.

Per the issue's note, this absorbs the closed #1109 foundation step (Layout + `TeamEntry.TeamDir` field, unit-tested); the substantive #1109 ACs are satisfied in this PR's diff.

## Test plan
- [x] `make test` — full suite green (touches `internal/teamhost`, `pkg/api/model/kuketeams`, `internal/kuketeams`, `cmd/kuke/team`).
- [x] `GOWORK=off go vet ./...` clean.
- [x] `pre-commit run --files ...` clean across all touched paths (`golangci-lint` `gosec`/`mnd`/`govet`/`shadow` all green).
- [x] New unit coverage in `internal/teamhost/teamhost_test.go` pins the seven Layout paths under a temp `<base>`.
- [x] `internal/teamhost/provision_test.go` covers: clean-host provisioning (state dirs at 0o700, seeds at declared/default 0o644), idempotent re-run (hand-edited seeds survive), two-project isolation (`dezot` vs `kukeon`), `--dry-run` writes nothing, host-config one-shot copy, missing `$HOME/.config` silent skip, seed-path traversal rejection (`ErrTeamHarnessSeedPathEscapes`), default-mode-from-umask, empty-TeamRoot guard, unknown-harness defense-in-depth.
- [x] `internal/kuketeams/parser_test.go` round-trips a multi-seed `Harness` happy-path (with `${TEAM_ROOT}` / `${HARNESS}` placeholders) and rejects empty seed paths + out-of-range modes.
- [x] `pkg/api/model/kuketeams/marshal_test.go` round-trips `TeamEntrySpec.TeamDir` and `HarnessSpec.Seeds` via both JSON and YAML.
- [x] `cmd/kuke/team/init_test.go` adds: auto-fill of `spec.teamDir` on clean init; override preservation on re-init (with state dir provisioned at the override path, not the layout default); per-roster state dirs + harness seeds materialized end-to-end; two-project isolation at the composition tier; `--dry-run` writes nothing.

Closes #1112