### PR TITLE
feat(team): two-layer secrets.env → kind: Secret apply

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -33,6 +33,7 @@ import (
 	"github.com/eminwux/kukeon/internal/teambuild"
 	"github.com/eminwux/kukeon/internal/teamhost"
 	"github.com/eminwux/kukeon/internal/teamrender"
+	"github.com/eminwux/kukeon/internal/teamsecrets"
 	"github.com/eminwux/kukeon/internal/teamsource"
 	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
 	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
@@ -248,6 +249,10 @@ func composeTeam(
 		return provisionErr
 	}
 
+	if secretsErr := composeSecrets(out, errOut, layout, teamDir, pt, bundle, res, dryRun); secretsErr != nil {
+		return secretsErr
+	}
+
 	if dryRun {
 		return emitDryRun(out, project, layout, res)
 	}
@@ -273,10 +278,10 @@ func composeTeam(
 	}
 	fmt.Fprintf(out, "wrote team %q to %s\n", project, layout.EntryPath(project))
 	if applied {
-		emitApplySummary(out, project, applyResult, len(res.Blueprints), len(res.Configs))
+		emitApplySummary(out, project, applyResult, len(res.Secrets), len(res.Blueprints), len(res.Configs))
 	} else {
-		fmt.Fprintf(out, "rendered %d blueprint/%d config object(s) (no apply: no (role × harness) pairs)\n",
-			len(res.Blueprints), len(res.Configs))
+		fmt.Fprintf(out, "rendered %d secret/%d blueprint/%d config object(s) (no apply: no (role × harness) pairs)\n",
+			len(res.Secrets), len(res.Blueprints), len(res.Configs))
 	}
 	return nil
 }
@@ -332,6 +337,55 @@ func provisionHost(
 	return nil
 }
 
+// composeSecrets runs the secrets pipeline: scaffold the two-layer
+// secrets.env files (skipped under dry-run), load both layers, merge with
+// per-team precedence, render every non-empty entry as a `kind: Secret`
+// the apply bundle carries before Blueprints/Configs. Empty merged values
+// produce one warning per key on errOut (key name only — values are
+// never echoed). The rendered Secrets land on res.Secrets so the
+// downstream marshal includes them at the head of the apply payload.
+//
+// A nil bundle (the harness-less roster branch) skips the pipeline
+// entirely: there are no role definitions to discover needs.secrets from,
+// and a harness-less roster has no cells to bind secrets to.
+func composeSecrets(
+	out, errOut io.Writer,
+	layout teamhost.Layout, teamDir string,
+	pt *model.ProjectTeam, bundle *teamsource.Bundle,
+	res *teamrender.Result, dryRun bool,
+) error {
+	if bundle == nil || res == nil {
+		return nil
+	}
+	needs := teamsecrets.UnionNeedsSecrets(bundle.Roles, pt.Spec.Roles)
+	if len(needs) == 0 {
+		return nil
+	}
+	sharedPath := layout.SharedSecretsEnvPath()
+	teamPath := filepath.Join(teamDir, teamsecrets.FileName)
+	composed, err := teamsecrets.Compose(teamsecrets.ComposeInputs{
+		SharedPath: sharedPath,
+		TeamPath:   teamPath,
+		Needs:      needs,
+		Realm:      teamrender.DefaultRealm,
+		DryRun:     dryRun,
+	})
+	if err != nil {
+		return fmt.Errorf("compose team secrets: %w", err)
+	}
+	if composed.SharedScaffolded {
+		fmt.Fprintf(out, "scaffolded shared secrets.env at %s (fill in values before apply)\n", sharedPath)
+	}
+	if composed.TeamScaffolded {
+		fmt.Fprintf(out, "scaffolded per-team secrets.env at %s (fill in overrides before apply)\n", teamPath)
+	}
+	for _, k := range composed.EmptyKeys {
+		fmt.Fprintf(errOut, "warning: secrets.env key %q is empty; cells referencing it will fail to start\n", k)
+	}
+	res.Secrets = composed.Secrets
+	return nil
+}
+
 // rosterPairs flattens pt.Spec.Roles × pt.Spec.Defaults.Harnesses into the
 // concrete (role × harness) pairs the provisioning pass materializes state
 // dirs for. A role-less or harness-less project produces an empty list.
@@ -372,7 +426,7 @@ func hostUserConfigDir() string {
 func applyTeam(
 	ctx context.Context, project string, res *teamrender.Result, apply ApplyForTeamFunc,
 ) (kukeonv1.ApplyDocumentsResult, bool, error) {
-	if res == nil || (len(res.Blueprints) == 0 && len(res.Configs) == 0) {
+	if res == nil || (len(res.Secrets) == 0 && len(res.Blueprints) == 0 && len(res.Configs) == 0) {
 		return kukeonv1.ApplyDocumentsResult{}, false, nil
 	}
 	rawYAML, err := teamrender.MarshalYAML(res)
@@ -390,7 +444,7 @@ func applyTeam(
 // `kuke apply -f` human-readable output, then a one-line aggregate so the
 // operator sees both the per-object outcome and the overall counts.
 func emitApplySummary(
-	out io.Writer, project string, result kukeonv1.ApplyDocumentsResult, blueprints, configs int,
+	out io.Writer, project string, result kukeonv1.ApplyDocumentsResult, secrets, blueprints, configs int,
 ) {
 	for _, r := range result.Resources {
 		switch r.Action {
@@ -410,8 +464,8 @@ func emitApplySummary(
 			fmt.Fprintln(out)
 		}
 	}
-	fmt.Fprintf(out, "applied %d blueprint/%d config object(s) to kukeond under team %q\n",
-		blueprints, configs, project)
+	fmt.Fprintf(out, "applied %d secret/%d blueprint/%d config object(s) to kukeond under team %q\n",
+		secrets, blueprints, configs, project)
 }
 
 // emitSourceKind prints the resolved agents source's pinned-vs-floating
@@ -533,7 +587,7 @@ func emitDryRun(out io.Writer, project string, layout teamhost.Layout, res *team
 	fmt.Fprintf(out, "# dry-run: would write %s\n%s",
 		filepath.Join("~/.kuke/kuketeam.d", project+".yaml"), rawEntry)
 
-	if res == nil || (len(res.Blueprints) == 0 && len(res.Configs) == 0) {
+	if res == nil || (len(res.Secrets) == 0 && len(res.Blueprints) == 0 && len(res.Configs) == 0) {
 		fmt.Fprintf(out, "# dry-run: no (role × harness) pairs to render\n")
 		_ = layout // reserved for future cache-dir reporting
 		return nil
@@ -543,8 +597,8 @@ func emitDryRun(out io.Writer, project string, layout teamhost.Layout, res *team
 	if err != nil {
 		return fmt.Errorf("marshal rendered objects: %w", err)
 	}
-	fmt.Fprintf(out, "---\n# dry-run: rendered %d blueprint/%d config object(s) (not applied to kukeond)\n",
-		len(res.Blueprints), len(res.Configs))
+	fmt.Fprintf(out, "---\n# dry-run: rendered %d secret/%d blueprint/%d config object(s) (not applied to kukeond)\n",
+		len(res.Secrets), len(res.Blueprints), len(res.Configs))
 	if _, writeErr := out.Write(rawRender); writeErr != nil {
 		return writeErr
 	}

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -515,7 +515,7 @@ func TestComposeTeamRendersOnNonDryRun(t *testing.T) {
 	if _, statErr := os.Stat(layout.EntryPath("sbsh")); statErr != nil {
 		t.Errorf("entry should have been written on non-dry-run: %v", statErr)
 	}
-	if !strings.Contains(out.String(), "applied 1 blueprint/1 config") {
+	if !strings.Contains(out.String(), "applied 0 secret/1 blueprint/1 config") {
 		t.Errorf("apply-count summary missing: %q", out.String())
 	}
 }
@@ -618,7 +618,7 @@ func TestComposeTeamAppliesRenderedSetToDaemon(t *testing.T) {
 	if !strings.Contains(out.String(), `CellBlueprint "dev-claude": created`) {
 		t.Errorf("per-resource summary missing CellBlueprint line: %q", out.String())
 	}
-	if !strings.Contains(out.String(), `applied 1 blueprint/1 config object(s) to kukeond under team "sbsh"`) {
+	if !strings.Contains(out.String(), `applied 0 secret/1 blueprint/1 config object(s) to kukeond under team "sbsh"`) {
 		t.Errorf("aggregate summary missing: %q", out.String())
 	}
 }
@@ -1279,6 +1279,230 @@ func TestNewTeamCmdRegistersInit(t *testing.T) {
 // silence the unused-import linter when v1beta1 is referenced only through
 // the rendered output bytes.
 var _ = v1beta1.LabelTeam
+
+// TestComposeTeamScaffoldsSecretsEnvFilesOnFirstInit confirms AC: a fresh
+// `~/.kuke/teams/` gets a templated shared `secrets.env`; the team's dir
+// gets a per-team `secrets.env`; both 0o600; both seeded with one `KEY=`
+// line per secret name the team's roles need.
+func TestComposeTeamScaffoldsSecretsEnvFilesOnFirstInit(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	// Add a second secret to the role's needs so the scaffold body has more
+	// than one line — the sort-and-emit invariant is then visible.
+	bundle.Roles["dev"].Spec.Needs.Secrets = []string{"OPENROUTER_API_KEY", "ANTHROPIC_AUTH_TOKEN"}
+
+	var (
+		mu      sync.Mutex
+		applies []applyCall
+	)
+	var errOut bytes.Buffer
+	err := composeTeam(
+		context.Background(), &bytes.Buffer{}, &errOut, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), recordingApply(&mu, &applies, kukeonv1.ApplyDocumentsResult{}),
+		stubBuildErr(), false, false,
+	)
+	if err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+
+	sharedPath := layout.SharedSecretsEnvPath()
+	teamPath := filepath.Join(layout.TeamDir("sbsh"), "secrets.env")
+	for _, p := range []string{sharedPath, teamPath} {
+		info, statErr := os.Stat(p)
+		if statErr != nil {
+			t.Fatalf("expected scaffolded file %q: %v", p, statErr)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Errorf("file %q mode = %o, want 0600", p, info.Mode().Perm())
+		}
+		raw, readErr := os.ReadFile(p)
+		if readErr != nil {
+			t.Fatalf("read %q: %v", p, readErr)
+		}
+		want := "ANTHROPIC_AUTH_TOKEN=\nOPENROUTER_API_KEY=\n"
+		if string(raw) != want {
+			t.Errorf("file %q body = %q, want %q", p, raw, want)
+		}
+	}
+
+	// One warning per empty key fires on errOut. Values would never appear
+	// in the warning anyway — the lines were KEY= with no value — but pin
+	// the AC: warning fires once per empty key.
+	body := errOut.String()
+	for _, k := range []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY"} {
+		if !strings.Contains(body, k) {
+			t.Errorf("missing warning for empty key %q: %q", k, body)
+		}
+	}
+}
+
+// TestComposeTeamRespectsPopulatedSecretsEnv covers the AC: re-running
+// `kuke team init` against a populated shared or per-team secrets.env
+// never overwrites it, and the populated values land on the rendered
+// Secret docs (per-team value wins for shared keys).
+func TestComposeTeamRespectsPopulatedSecretsEnv(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	bundle.Roles["dev"].Spec.Needs.Secrets = []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY"}
+
+	// First init: scaffolds both files (empty).
+	var (
+		mu      sync.Mutex
+		applies []applyCall
+	)
+	apply := recordingApply(&mu, &applies, kukeonv1.ApplyDocumentsResult{})
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), apply, stubBuildErr(), false, false,
+	); err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+
+	// Operator fills shared (both keys) and per-team (one override).
+	sharedPath := layout.SharedSecretsEnvPath()
+	teamPath := filepath.Join(layout.TeamDir("sbsh"), "secrets.env")
+	if err := os.WriteFile(sharedPath, []byte(
+		"ANTHROPIC_AUTH_TOKEN=shared-anth\nOPENROUTER_API_KEY=shared-or\n"), 0o600); err != nil {
+		t.Fatalf("populate shared: %v", err)
+	}
+	if err := os.WriteFile(teamPath, []byte(
+		"OPENROUTER_API_KEY=team-or\n"), 0o600); err != nil {
+		t.Fatalf("populate team: %v", err)
+	}
+
+	// Re-init: shared + per-team carry through to the apply payload.
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), apply, stubBuildErr(), false, false,
+	); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+	if len(applies) != 2 {
+		t.Fatalf("apply call count = %d, want 2", len(applies))
+	}
+	body := string(applies[1].RawYAML)
+	if !strings.Contains(body, "shared-anth") {
+		t.Errorf("re-init apply missing shared-only value carry-through:\n%s", body)
+	}
+	if !strings.Contains(body, "team-or") {
+		t.Errorf("re-init apply missing per-team override:\n%s", body)
+	}
+	if strings.Contains(body, "shared-or") {
+		t.Errorf("re-init apply leaked shared value overridden per-team:\n%s", body)
+	}
+
+	// Files untouched by the re-init.
+	rawShared, _ := os.ReadFile(sharedPath)
+	if !strings.Contains(string(rawShared), "shared-anth") || !strings.Contains(string(rawShared), "shared-or") {
+		t.Errorf("re-init overwrote populated shared file: %q", rawShared)
+	}
+	rawTeam, _ := os.ReadFile(teamPath)
+	if !strings.Contains(string(rawTeam), "team-or") {
+		t.Errorf("re-init overwrote populated team file: %q", rawTeam)
+	}
+}
+
+// TestComposeTeamBundlesSecretsBeforeBlueprintsAndConfigs pins AC:
+// bundle order is Secrets → Blueprints → Configs in the applied YAML.
+// The renderer's MarshalYAML emits the three sections in that order; a
+// reader can verify by the byte-offset of each section's "kind:" line.
+func TestComposeTeamBundlesSecretsBeforeBlueprintsAndConfigs(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	bundle.Roles["dev"].Spec.Needs.Secrets = []string{"ANTHROPIC_AUTH_TOKEN"}
+	// Scaffold a populated shared so the rendered set carries one Secret.
+	if err := os.MkdirAll(filepath.Join(layout.Base, "teams"), 0o700); err != nil {
+		t.Fatalf("mkdir teams: %v", err)
+	}
+	if err := os.WriteFile(layout.SharedSecretsEnvPath(),
+		[]byte("ANTHROPIC_AUTH_TOKEN=populated\n"), 0o600); err != nil {
+		t.Fatalf("seed shared: %v", err)
+	}
+
+	var (
+		mu      sync.Mutex
+		applies []applyCall
+	)
+	if err := composeTeam(
+		context.Background(), &bytes.Buffer{}, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), recordingApply(&mu, &applies, kukeonv1.ApplyDocumentsResult{}),
+		stubBuildErr(), false, false,
+	); err != nil {
+		t.Fatalf("composeTeam: %v", err)
+	}
+	if len(applies) != 1 {
+		t.Fatalf("apply call count = %d, want 1", len(applies))
+	}
+	body := string(applies[0].RawYAML)
+	secretIdx := strings.Index(body, "kind: Secret")
+	bpIdx := strings.Index(body, "kind: CellBlueprint")
+	cfgIdx := strings.Index(body, "kind: CellConfig")
+	if secretIdx < 0 || bpIdx < 0 || cfgIdx < 0 {
+		t.Fatalf("missing one of Secret/CellBlueprint/CellConfig in bundle:\n%s", body)
+	}
+	if secretIdx >= bpIdx || bpIdx >= cfgIdx {
+		t.Errorf("bundle order wrong: secret=%d blueprint=%d config=%d\n%s",
+			secretIdx, bpIdx, cfgIdx, body)
+	}
+	// Rendered Secret carries the default realm.
+	if !strings.Contains(body, "realm: default") {
+		t.Errorf("rendered Secret missing realm: default\n%s", body)
+	}
+	// Kebab-case name landed.
+	if !strings.Contains(body, "name: anthropic-auth-token") {
+		t.Errorf("rendered Secret missing kebab-cased name\n%s", body)
+	}
+	if !strings.Contains(body, "data: populated") {
+		t.Errorf("rendered Secret missing spec.data\n%s", body)
+	}
+}
+
+// TestComposeTeamDryRunDoesNotScaffoldSecretsEnv pins AC: --dry-run
+// touches no files on disk — including the secrets.env scaffold path.
+// Render still announces what would have rendered; on a clean host with
+// no populated values, no Secret docs surface (empty values are skipped).
+func TestComposeTeamDryRunDoesNotScaffoldSecretsEnv(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	bundle.Roles["dev"].Spec.Needs.Secrets = []string{"ANTHROPIC_AUTH_TOKEN"}
+
+	var (
+		out    bytes.Buffer
+		errOut bytes.Buffer
+	)
+	if err := composeTeam(
+		context.Background(), &out, &errOut, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle), stubApplyErr(), stubBuildErr(), true, false,
+	); err != nil {
+		t.Fatalf("composeTeam dry-run: %v", err)
+	}
+	sharedPath := layout.SharedSecretsEnvPath()
+	teamPath := filepath.Join(layout.TeamDir("sbsh"), "secrets.env")
+	if _, statErr := os.Stat(sharedPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("dry-run wrote shared secrets.env: %v", statErr)
+	}
+	if _, statErr := os.Stat(teamPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("dry-run wrote team secrets.env: %v", statErr)
+	}
+	// Warning still fires on empty key — the AC's "Empty-value warning fires
+	// once per empty key" applies regardless of dry-run mode.
+	if !strings.Contains(errOut.String(), "ANTHROPIC_AUTH_TOKEN") {
+		t.Errorf("dry-run missing empty-key warning: %q", errOut.String())
+	}
+}
 
 func TestEmitSourceKind(t *testing.T) {
 	t.Parallel()

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -126,7 +126,15 @@ type Inputs struct {
 // hands this slice to teambuild.BuildAll to drive the local build path
 // (#1064). The slice is deduplicated by entry.Ref so a catalog entry
 // reused across multiple (role × harness) pairs builds once.
+//
+// Secrets is the merged shared+per-team secret set composed by the
+// teamsecrets package (#1113) and is included in the apply payload by
+// MarshalYAML before Blueprints and Configs — the apply bundle order is
+// Secrets → Blueprints → Configs so a Blueprint that references a Secret
+// via ContainerSecret.secretRef sees a daemon-side record present at
+// reconcile time.
 type Result struct {
+	Secrets    []*v1beta1.SecretDoc
 	Blueprints []*v1beta1.CellBlueprintDoc
 	Configs    []*v1beta1.CellConfigDoc
 	Selections []*model.ImageCatalogEntry
@@ -451,10 +459,13 @@ func BindConfig(
 	return cfg
 }
 
-// MarshalYAML returns the Result as a single multi-document YAML stream —
-// every blueprint followed by its companion config. The order matches the
-// per-(role × harness) iteration order so the dry-run output is
-// deterministic.
+// MarshalYAML returns the Result as a single multi-document YAML stream.
+// Bundle order: every Secret, then every Blueprint, then every Config —
+// the "Secrets → Blueprints → Configs" ordering called out in #1113. The
+// per-section order matches the slice order on Result (Secrets sorted by
+// metadata.name by teamsecrets.Render; Blueprints/Configs in
+// (role × harness) iteration order) so the dry-run output and the
+// apply-bundle payload are both deterministic.
 func MarshalYAML(res *Result) ([]byte, error) {
 	if res == nil {
 		return nil, nil
@@ -473,14 +484,19 @@ func MarshalYAML(res *Result) ([]byte, error) {
 		buf.Write(raw)
 		return nil
 	}
+	for i, s := range res.Secrets {
+		if err := emit(s); err != nil {
+			return nil, fmt.Errorf("marshal secret %d: %w", i, err)
+		}
+	}
 	for i, bp := range res.Blueprints {
 		if err := emit(bp); err != nil {
 			return nil, fmt.Errorf("marshal blueprint %d: %w", i, err)
 		}
-		if i < len(res.Configs) {
-			if err := emit(res.Configs[i]); err != nil {
-				return nil, fmt.Errorf("marshal config %d: %w", i, err)
-			}
+	}
+	for i, cfg := range res.Configs {
+		if err := emit(cfg); err != nil {
+			return nil, fmt.Errorf("marshal config %d: %w", i, err)
 		}
 	}
 	return []byte(buf.String()), nil

--- a/internal/teamsecrets/teamsecrets.go
+++ b/internal/teamsecrets/teamsecrets.go
@@ -1,0 +1,372 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package teamsecrets composes a team's secret material from two `secrets.env`
+// layers — a shared host-wide default at `~/.kuke/teams/secrets.env` and a
+// per-team override at `<teamDir>/secrets.env` — and renders the merged
+// non-empty entries as `kind: Secret` documents the daemon-side apply pipeline
+// (#1029) consumes alongside the project's CellBlueprints and CellConfigs.
+//
+// The two-layer model splits operator-wide tokens (e.g. an ANTHROPIC OAuth
+// token used in every team) from per-team overrides (e.g. project `dezot`
+// using a different OPENROUTER token than project `kukeon`). Per-key per-team
+// values win over the shared default; per-team-only keys join the set;
+// shared-only keys carry through.
+//
+// On first run the package scaffolds both files in place with one empty
+// `KEY=` line per secret name the team's roles reference, leaving values for
+// the operator to fill in by hand — mode 0o600, never overwritten on re-run
+// once populated. Values are never logged or echoed: the empty-value warning
+// names keys only, and the rendered Secret documents themselves are the only
+// channel through which the values reach the daemon.
+package teamsecrets
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+const (
+	// FileName is the secrets-env filename used at both layers: shared at
+	// <base>/teams/secrets.env and per-team at <teamDir>/secrets.env.
+	FileName = "secrets.env"
+	// FilePerm is the mode applied to a scaffolded secrets.env — operator
+	// read/write only. Values that land in the file are never echoed to
+	// stdout/stderr by this package.
+	FilePerm = 0o600
+	// DirPerm is the mode applied to a freshly-created parent directory of
+	// a scaffolded secrets.env. Matches the teams/ root mode used by
+	// teamhost so the two scaffolding passes converge on the same shape.
+	DirPerm = 0o700
+)
+
+// ComposeInputs is the per-team request handed to Compose.
+//
+// SharedPath is the host-wide defaults file (`<base>/teams/secrets.env`).
+// TeamPath is the per-team override (`<teamDir>/secrets.env`); when teamDir
+// is relocated via TeamEntry.spec.teamDir the caller passes the relocated
+// path so the override lands beside the rest of the per-team state.
+//
+// Needs is the union of secret names every role in the team references —
+// see UnionNeedsSecrets. The scaffold lines are written for every Needs
+// entry; merged values for keys not in Needs are dropped so a hand-edited
+// override file with extra junk doesn't leak unrelated bytes into the
+// apply bundle.
+//
+// Realm is the realm rendered Secrets bind to. Team workloads live in the
+// `default` user realm — pass teamrender.DefaultRealm.
+//
+// DryRun suppresses both file writes so the dry-run path stays "renders to
+// stdout, touches no files on disk". The merged read still happens against
+// whatever's already there.
+type ComposeInputs struct {
+	SharedPath string
+	TeamPath   string
+	Needs      []string
+	Realm      string
+	DryRun     bool
+}
+
+// ComposeResult carries the per-invocation outcome.
+//
+// Secrets is the set of `kind: Secret` documents to bundle into the apply
+// payload (ordered alphabetically by metadata.name — deterministic so two
+// runs against the same inputs marshal byte-identically). EmptyKeys lists
+// the original env keys (SCREAMING_SNAKE_CASE — the casing in the file the
+// operator opens to fix it) whose merged value was empty; the caller emits
+// one warning per empty key.
+//
+// SharedScaffolded / TeamScaffolded report whether the corresponding file
+// was just freshly written by this Compose call — the caller may surface
+// these as one-time announcements so the operator notices the new file to
+// fill in.
+type ComposeResult struct {
+	Secrets          []*v1beta1.SecretDoc
+	EmptyKeys        []string
+	SharedScaffolded bool
+	TeamScaffolded   bool
+}
+
+// Compose runs the four-step pipeline: scaffold (skipped under DryRun),
+// load both layers, merge with per-team precedence, render every non-empty
+// entry as a SecretDoc. An empty Needs short-circuits the whole pipeline:
+// nothing is written, nothing is read, no warnings are surfaced — a team
+// whose roles declare no `needs.secrets` has no secret pipeline.
+func Compose(in ComposeInputs) (*ComposeResult, error) {
+	if len(in.Needs) == 0 {
+		return &ComposeResult{}, nil
+	}
+	out := &ComposeResult{}
+	if !in.DryRun {
+		sharedCreated, err := ScaffoldEnvFile(in.SharedPath, in.Needs)
+		if err != nil {
+			return nil, fmt.Errorf("scaffold shared secrets.env: %w", err)
+		}
+		out.SharedScaffolded = sharedCreated
+		teamCreated, err := ScaffoldEnvFile(in.TeamPath, in.Needs)
+		if err != nil {
+			return nil, fmt.Errorf("scaffold team secrets.env: %w", err)
+		}
+		out.TeamScaffolded = teamCreated
+	}
+	shared, err := LoadEnvFile(in.SharedPath)
+	if err != nil {
+		return nil, err
+	}
+	perTeam, err := LoadEnvFile(in.TeamPath)
+	if err != nil {
+		return nil, err
+	}
+	merged := Merge(shared, perTeam)
+	secrets, emptyKeys := Render(merged, in.Needs, in.Realm)
+	out.Secrets = secrets
+	out.EmptyKeys = emptyKeys
+	return out, nil
+}
+
+// ScaffoldEnvFile writes path with one `KEY=` line per entry in keys when
+// path does not exist. Keys are sorted lexicographically and de-duplicated
+// so re-runs against the same input produce byte-identical output. The
+// parent directory is created (DirPerm) if absent; the file is written
+// with mode FilePerm. An existing file at path is left untouched — the
+// "re-run never overwrites a populated file" AC.
+//
+// Returns created=true when the file was freshly written; created=false
+// when an existing file was found and skipped. An empty keys slice is a
+// no-op (created=false, err=nil) — Compose's empty-Needs short-circuit
+// covers this for the high-level path, but the primitive itself is also
+// guarded so direct callers don't trip an "empty file" surprise.
+func ScaffoldEnvFile(path string, keys []string) (bool, error) {
+	if len(keys) == 0 {
+		return false, nil
+	}
+	if _, err := os.Stat(path); err == nil {
+		return false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("stat %q: %w", path, err)
+	}
+	parent := filepath.Dir(path)
+	if mkErr := os.MkdirAll(parent, DirPerm); mkErr != nil {
+		return false, fmt.Errorf("create dir %q: %w", parent, mkErr)
+	}
+	sorted := uniqueSortedNonEmpty(keys)
+	var buf strings.Builder
+	for _, k := range sorted {
+		buf.WriteString(k)
+		buf.WriteString("=\n")
+	}
+	if writeErr := os.WriteFile(path, []byte(buf.String()), FilePerm); writeErr != nil {
+		return false, fmt.Errorf("write %q: %w", path, writeErr)
+	}
+	// WriteFile honors the process umask; chmod explicitly so 0o600 isn't
+	// silently widened on operator hosts running with a permissive umask.
+	if chmodErr := os.Chmod(path, FilePerm); chmodErr != nil {
+		return false, fmt.Errorf("chmod %q: %w", path, chmodErr)
+	}
+	return true, nil
+}
+
+// LoadEnvFile reads path as a flat KEY=VALUE env file. Blank lines and
+// lines whose first non-whitespace character is `#` are ignored; the key
+// is whitespace-trimmed, the value is preserved verbatim past the first
+// `=`. A line missing the `=` is silently skipped (it cannot be acted on
+// as a secret). A missing file returns an empty map and no error so the
+// caller can compose against a partially-scaffolded host.
+func LoadEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, fmt.Errorf("open %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return parseEnv(f)
+}
+
+func parseEnv(r io.Reader) (map[string]string, error) {
+	out := map[string]string{}
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Text()
+		trimmed := strings.TrimLeft(line, " \t")
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		eq := strings.IndexByte(trimmed, '=')
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(trimmed[:eq])
+		if key == "" {
+			continue
+		}
+		out[key] = trimmed[eq+1:]
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("scan env: %w", err)
+	}
+	return out, nil
+}
+
+// Merge overlays perTeam onto shared with per-team precedence: a key
+// present in both maps with a non-empty perTeam value takes the perTeam
+// value; a key in only one map carries through.
+//
+// An *empty* perTeam value is treated as a scaffold placeholder, not an
+// override: the scaffold writes one empty `KEY=` line per role-declared
+// secret name into every per-team `secrets.env` so the operator sees
+// every key they can override, even before they have a value to override
+// with. Treating that empty as an active override would null-out the
+// shared default in a single re-init pass and force every per-team file
+// to be hand-curated. The pragmatic reading — non-empty per-team wins,
+// empty per-team falls back to shared — keeps the shared layer useful as
+// a default while leaving the operator free to override per-key by
+// writing a value. The result is a fresh map; neither input is mutated.
+func Merge(shared, perTeam map[string]string) map[string]string {
+	out := make(map[string]string, len(shared)+len(perTeam))
+	for k, v := range shared {
+		out[k] = v
+	}
+	for k, v := range perTeam {
+		if v == "" {
+			if _, sharedHas := shared[k]; sharedHas {
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// Render builds one SecretDoc per non-empty entry in merged whose key is
+// also a member of needs. Keys outside needs are dropped — a stray entry
+// in a hand-edited override file doesn't bleed unrelated bytes into the
+// apply bundle. Output is sorted by metadata.name so two runs against the
+// same input marshal byte-identically.
+//
+// emptyKeys carries the needs entries whose merged value is empty (or
+// absent from merged) — the caller emits one operator-facing warning per
+// entry. Casing is preserved at SCREAMING_SNAKE_CASE so the operator can
+// grep the line in the secrets.env file.
+func Render(merged map[string]string, needs []string, realm string) ([]*v1beta1.SecretDoc, []string) {
+	if len(needs) == 0 {
+		return nil, nil
+	}
+	if strings.TrimSpace(realm) == "" {
+		return nil, nil
+	}
+	keys := uniqueSortedNonEmpty(needs)
+	var (
+		secrets   []*v1beta1.SecretDoc
+		emptyKeys []string
+	)
+	for _, k := range keys {
+		v, ok := merged[k]
+		if !ok || v == "" {
+			emptyKeys = append(emptyKeys, k)
+			continue
+		}
+		name := KebabCase(k)
+		if name == "" {
+			continue
+		}
+		secrets = append(secrets, &v1beta1.SecretDoc{
+			APIVersion: v1beta1.APIVersionV1Beta1,
+			Kind:       v1beta1.KindSecret,
+			Metadata: v1beta1.SecretMetadata{
+				Name:  name,
+				Realm: realm,
+			},
+			Spec: v1beta1.SecretSpec{
+				Data: v,
+			},
+		})
+	}
+	// Output is sorted by the *kebab-case* metadata.name, not the source
+	// key — the apply bundle's reader sees the rendered name first.
+	sort.Slice(secrets, func(i, j int) bool {
+		return secrets[i].Metadata.Name < secrets[j].Metadata.Name
+	})
+	return secrets, emptyKeys
+}
+
+// KebabCase lowercases s and replaces every `_` with `-`. The operator
+// convention is SCREAMING_SNAKE_CASE for env keys and kebab-case for
+// rendered Secret metadata.name — a single key `ANTHROPIC_AUTH_TOKEN`
+// surfaces as Secret `anthropic-auth-token`.
+func KebabCase(s string) string {
+	return strings.ReplaceAll(strings.ToLower(s), "_", "-")
+}
+
+// UnionNeedsSecrets walks the project roster and returns the
+// lexicographically-sorted set of secret names every referenced role's
+// `needs.secrets` declares. Roles missing from roles map are skipped
+// silently — Render would surface the missing reference, but at the
+// pre-compose secret-name discovery stage there's nothing to warn about
+// (the parent renderer already surfaces missing roles).
+func UnionNeedsSecrets(roles map[string]*model.Role, roster []model.ProjectTeamRole) []string {
+	if len(roster) == 0 || len(roles) == 0 {
+		return nil
+	}
+	set := map[string]struct{}{}
+	for _, ptRole := range roster {
+		role, ok := roles[ptRole.Ref]
+		if !ok {
+			continue
+		}
+		for _, s := range role.Spec.Needs.Secrets {
+			if k := strings.TrimSpace(s); k != "" {
+				set[k] = struct{}{}
+			}
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// uniqueSortedNonEmpty returns the lexicographically-sorted set of
+// whitespace-trimmed non-empty entries in keys.
+func uniqueSortedNonEmpty(keys []string) []string {
+	set := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		if v := strings.TrimSpace(k); v != "" {
+			set[v] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/teamsecrets/teamsecrets_test.go
+++ b/internal/teamsecrets/teamsecrets_test.go
@@ -1,0 +1,447 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teamsecrets
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+func TestKebabCase(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, want string }{
+		{"ANTHROPIC_AUTH_TOKEN", "anthropic-auth-token"},
+		{"OPENROUTER_API_KEY", "openrouter-api-key"},
+		{"FOO", "foo"},
+		{"already-kebab", "already-kebab"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := KebabCase(tc.in); got != tc.want {
+			t.Errorf("KebabCase(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestScaffoldEnvFileCreatesWithMode0600(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "teams", "alpha")
+	path := filepath.Join(dir, "secrets.env")
+
+	created, err := ScaffoldEnvFile(path, []string{"FOO", "BAR"})
+	if err != nil {
+		t.Fatalf("ScaffoldEnvFile: %v", err)
+	}
+	if !created {
+		t.Errorf("created = false, want true on first scaffold")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat scaffold: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != FilePerm {
+		t.Errorf("file mode = %o, want %o", mode, FilePerm)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read scaffold: %v", err)
+	}
+	// Sorted lexicographically — BAR first, then FOO.
+	want := "BAR=\nFOO=\n"
+	if string(raw) != want {
+		t.Errorf("scaffold body = %q, want %q", raw, want)
+	}
+}
+
+func TestScaffoldEnvFileNeverOverwrites(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.env")
+	if err := os.WriteFile(path, []byte("ANTHROPIC_AUTH_TOKEN=populated-by-operator\n"), 0o600); err != nil {
+		t.Fatalf("seed populated file: %v", err)
+	}
+
+	created, err := ScaffoldEnvFile(path, []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY"})
+	if err != nil {
+		t.Fatalf("ScaffoldEnvFile re-run: %v", err)
+	}
+	if created {
+		t.Errorf("created = true, want false on re-run against populated file")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read scaffold: %v", err)
+	}
+	if !strings.Contains(string(raw), "populated-by-operator") {
+		t.Errorf("re-run overwrote populated file: %q", raw)
+	}
+}
+
+func TestScaffoldEnvFileEmptyKeysIsNoOp(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "secrets.env")
+	created, err := ScaffoldEnvFile(path, nil)
+	if err != nil {
+		t.Fatalf("ScaffoldEnvFile nil keys: %v", err)
+	}
+	if created {
+		t.Errorf("created = true, want false on empty-keys no-op")
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("empty-keys scaffold still wrote file: err=%v", statErr)
+	}
+}
+
+func TestLoadEnvFileMissingReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := LoadEnvFile(filepath.Join(t.TempDir(), "absent.env"))
+	if err != nil {
+		t.Fatalf("LoadEnvFile missing: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("missing file = %v, want empty map", got)
+	}
+}
+
+func TestLoadEnvFileParsesAndIgnoresCommentsAndBlanks(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "secrets.env")
+	body := strings.Join([]string{
+		"# comment line",
+		"",
+		"  # leading-ws comment",
+		"FOO=bar",
+		"   BAZ=qux value with spaces",
+		"NO_EQUALS_SIGN",
+		"EMPTY_VALUE=",
+		"=value-without-key",
+		"WITH_EQUALS_IN_VALUE=a=b=c",
+	}, "\n")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	got, err := LoadEnvFile(path)
+	if err != nil {
+		t.Fatalf("LoadEnvFile: %v", err)
+	}
+	want := map[string]string{
+		"FOO":                  "bar",
+		"BAZ":                  "qux value with spaces",
+		"EMPTY_VALUE":          "",
+		"WITH_EQUALS_IN_VALUE": "a=b=c",
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d entries, want %d: %#v", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("got[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestMergePerTeamNonEmptyWins(t *testing.T) {
+	t.Parallel()
+	shared := map[string]string{"A": "shared-a", "B": "shared-b", "C": "shared-c"}
+	perTeam := map[string]string{"B": "team-b", "D": "team-d"}
+	got := Merge(shared, perTeam)
+	want := map[string]string{
+		"A": "shared-a",
+		"B": "team-b", // per-team non-empty wins
+		"C": "shared-c",
+		"D": "team-d",
+	}
+	if len(got) != len(want) {
+		t.Errorf("merged len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("merged[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+	// Inputs unmutated.
+	if shared["B"] != "shared-b" {
+		t.Errorf("Merge mutated shared input: %q", shared["B"])
+	}
+}
+
+// TestMergePerTeamEmptyFallsBackToShared pins the scaffold-friendly
+// semantics: an empty per-team value is a placeholder, not an override.
+// Re-init writes one empty KEY= line per role-declared secret into
+// every per-team file; if those scaffold lines were treated as active
+// overrides, the shared default would be null-out on every re-init.
+func TestMergePerTeamEmptyFallsBackToShared(t *testing.T) {
+	t.Parallel()
+	shared := map[string]string{
+		"ANTHROPIC_AUTH_TOKEN": "shared-anth",
+		"OPENROUTER_API_KEY":   "shared-or",
+	}
+	perTeam := map[string]string{
+		"ANTHROPIC_AUTH_TOKEN": "", // empty placeholder — defer to shared
+		"OPENROUTER_API_KEY":   "team-or",
+		"TEAM_ONLY_KEY":        "", // empty + no shared → still empty
+	}
+	got := Merge(shared, perTeam)
+	if got["ANTHROPIC_AUTH_TOKEN"] != "shared-anth" {
+		t.Errorf("empty per-team should fall back to shared, got %q", got["ANTHROPIC_AUTH_TOKEN"])
+	}
+	if got["OPENROUTER_API_KEY"] != "team-or" {
+		t.Errorf("non-empty per-team should win, got %q", got["OPENROUTER_API_KEY"])
+	}
+	if v, ok := got["TEAM_ONLY_KEY"]; !ok || v != "" {
+		t.Errorf("team-only empty key should carry as empty, got (%q, %v)", v, ok)
+	}
+}
+
+func TestRenderEmitsNonEmptyValuesOnly(t *testing.T) {
+	t.Parallel()
+	merged := map[string]string{
+		"ANTHROPIC_AUTH_TOKEN": "secret-anth",
+		"OPENROUTER_API_KEY":   "",
+		"UNREFERENCED_KEY":     "should-not-render",
+	}
+	needs := []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY", "MISSING_KEY"}
+	secrets, empties := Render(merged, needs, "default")
+
+	if len(secrets) != 1 {
+		t.Fatalf("rendered %d secrets, want 1: %+v", len(secrets), secrets)
+	}
+	if secrets[0].Metadata.Name != "anthropic-auth-token" {
+		t.Errorf("name = %q, want kebab-cased", secrets[0].Metadata.Name)
+	}
+	if secrets[0].Metadata.Realm != "default" {
+		t.Errorf("realm = %q, want default", secrets[0].Metadata.Realm)
+	}
+	if secrets[0].Spec.Data != "secret-anth" {
+		t.Errorf("data = %q, want secret-anth", secrets[0].Spec.Data)
+	}
+	if secrets[0].Kind != v1beta1.KindSecret {
+		t.Errorf("kind = %q, want %q", secrets[0].Kind, v1beta1.KindSecret)
+	}
+	if secrets[0].APIVersion != v1beta1.APIVersionV1Beta1 {
+		t.Errorf("apiVersion = %q, want %q", secrets[0].APIVersion, v1beta1.APIVersionV1Beta1)
+	}
+
+	sort.Strings(empties)
+	wantEmpty := []string{"MISSING_KEY", "OPENROUTER_API_KEY"}
+	if len(empties) != len(wantEmpty) {
+		t.Fatalf("empties = %v, want %v", empties, wantEmpty)
+	}
+	for i, k := range wantEmpty {
+		if empties[i] != k {
+			t.Errorf("empties[%d] = %q, want %q", i, empties[i], k)
+		}
+	}
+}
+
+func TestRenderUnreferencedKeyDropped(t *testing.T) {
+	t.Parallel()
+	merged := map[string]string{
+		"OPENROUTER_API_KEY":  "from-shared",
+		"OPERATOR_NOTES_FILE": "not-a-secret-leak",
+	}
+	needs := []string{"OPENROUTER_API_KEY"}
+	secrets, _ := Render(merged, needs, "default")
+	if len(secrets) != 1 {
+		t.Fatalf("rendered %d, want 1", len(secrets))
+	}
+	if secrets[0].Metadata.Name != "openrouter-api-key" {
+		t.Errorf("name = %q, want openrouter-api-key", secrets[0].Metadata.Name)
+	}
+}
+
+func TestRenderIsSortedByName(t *testing.T) {
+	t.Parallel()
+	merged := map[string]string{
+		"ZZZ_TOKEN":    "z",
+		"ALPHA_TOKEN":  "a",
+		"MIDDLE_TOKEN": "m",
+	}
+	needs := []string{"ZZZ_TOKEN", "ALPHA_TOKEN", "MIDDLE_TOKEN"}
+	secrets, _ := Render(merged, needs, "default")
+	if len(secrets) != 3 {
+		t.Fatalf("rendered %d, want 3", len(secrets))
+	}
+	wantOrder := []string{"alpha-token", "middle-token", "zzz-token"}
+	for i, name := range wantOrder {
+		if secrets[i].Metadata.Name != name {
+			t.Errorf("secrets[%d].name = %q, want %q", i, secrets[i].Metadata.Name, name)
+		}
+	}
+}
+
+func TestUnionNeedsSecrets(t *testing.T) {
+	t.Parallel()
+	roles := map[string]*model.Role{
+		"dev": {Spec: model.RoleSpec{Needs: model.RoleNeeds{Secrets: []string{"ANTHROPIC_AUTH_TOKEN"}}}},
+		"pm": {
+			Spec: model.RoleSpec{
+				Needs: model.RoleNeeds{Secrets: []string{"OPENROUTER_API_KEY", "ANTHROPIC_AUTH_TOKEN"}},
+			},
+		},
+	}
+	roster := []model.ProjectTeamRole{
+		{Ref: "dev"},
+		{Ref: "pm"},
+		{Ref: "unknown-role"}, // skipped silently
+	}
+	got := UnionNeedsSecrets(roles, roster)
+	want := []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, k := range want {
+		if got[i] != k {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], k)
+		}
+	}
+}
+
+func TestComposeFullPipeline(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	sharedPath := filepath.Join(base, "teams", "secrets.env")
+	teamPath := filepath.Join(base, "teams", "alpha", "secrets.env")
+
+	// First-init: scaffold both, both empty → all warnings, no rendered secrets.
+	first, err := Compose(ComposeInputs{
+		SharedPath: sharedPath,
+		TeamPath:   teamPath,
+		Needs:      []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY"},
+		Realm:      "default",
+	})
+	if err != nil {
+		t.Fatalf("first Compose: %v", err)
+	}
+	if !first.SharedScaffolded || !first.TeamScaffolded {
+		t.Errorf("first run did not scaffold both: %+v", first)
+	}
+	if len(first.Secrets) != 0 {
+		t.Errorf("first run rendered %d secrets, want 0 (all empty)", len(first.Secrets))
+	}
+	if len(first.EmptyKeys) != 2 {
+		t.Errorf("first run empty keys = %v, want both", first.EmptyKeys)
+	}
+
+	// Operator fills in shared value; per-team overrides one key.
+	if writeErr := os.WriteFile(sharedPath, []byte("ANTHROPIC_AUTH_TOKEN=shared-anth\nOPENROUTER_API_KEY=shared-or\n"), 0o600); writeErr != nil {
+		t.Fatalf("populate shared: %v", writeErr)
+	}
+	if writeErr := os.WriteFile(teamPath, []byte("OPENROUTER_API_KEY=team-or\n"), 0o600); writeErr != nil {
+		t.Fatalf("populate team: %v", writeErr)
+	}
+
+	// Second Compose: per-team wins for OPENROUTER, shared carries for ANTHROPIC.
+	second, err := Compose(ComposeInputs{
+		SharedPath: sharedPath,
+		TeamPath:   teamPath,
+		Needs:      []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY"},
+		Realm:      "default",
+	})
+	if err != nil {
+		t.Fatalf("second Compose: %v", err)
+	}
+	if second.SharedScaffolded || second.TeamScaffolded {
+		t.Errorf("re-run reported scaffold of populated files: %+v", second)
+	}
+	if len(second.EmptyKeys) != 0 {
+		t.Errorf("populated run reported empty keys: %v", second.EmptyKeys)
+	}
+	if len(second.Secrets) != 2 {
+		t.Fatalf("rendered %d secrets, want 2", len(second.Secrets))
+	}
+	byName := map[string]string{}
+	for _, s := range second.Secrets {
+		byName[s.Metadata.Name] = s.Spec.Data
+	}
+	if byName["anthropic-auth-token"] != "shared-anth" {
+		t.Errorf("shared-only carry-through wrong: %q", byName["anthropic-auth-token"])
+	}
+	if byName["openrouter-api-key"] != "team-or" {
+		t.Errorf("per-team override wrong: %q", byName["openrouter-api-key"])
+	}
+}
+
+func TestComposeDryRunWritesNothing(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	sharedPath := filepath.Join(base, "teams", "secrets.env")
+	teamPath := filepath.Join(base, "teams", "alpha", "secrets.env")
+
+	got, err := Compose(ComposeInputs{
+		SharedPath: sharedPath,
+		TeamPath:   teamPath,
+		Needs:      []string{"ANTHROPIC_AUTH_TOKEN"},
+		Realm:      "default",
+		DryRun:     true,
+	})
+	if err != nil {
+		t.Fatalf("Compose dry-run: %v", err)
+	}
+	if got.SharedScaffolded || got.TeamScaffolded {
+		t.Errorf("dry-run reported scaffold: %+v", got)
+	}
+	if _, statErr := os.Stat(sharedPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("dry-run wrote shared file: %v", statErr)
+	}
+	if _, statErr := os.Stat(teamPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Errorf("dry-run wrote team file: %v", statErr)
+	}
+	if len(got.Secrets) != 0 {
+		t.Errorf("dry-run with no on-disk values rendered %d secrets", len(got.Secrets))
+	}
+	if len(got.EmptyKeys) != 1 || got.EmptyKeys[0] != "ANTHROPIC_AUTH_TOKEN" {
+		t.Errorf("dry-run empties = %v, want [ANTHROPIC_AUTH_TOKEN]", got.EmptyKeys)
+	}
+}
+
+func TestComposeEmptyNeedsShortCircuits(t *testing.T) {
+	t.Parallel()
+	base := t.TempDir()
+	got, err := Compose(ComposeInputs{
+		SharedPath: filepath.Join(base, "teams", "secrets.env"),
+		TeamPath:   filepath.Join(base, "teams", "alpha", "secrets.env"),
+		Needs:      nil,
+		Realm:      "default",
+	})
+	if err != nil {
+		t.Fatalf("Compose empty needs: %v", err)
+	}
+	if got.SharedScaffolded || got.TeamScaffolded ||
+		len(got.Secrets) != 0 || len(got.EmptyKeys) != 0 {
+		t.Errorf("empty needs produced output: %+v", got)
+	}
+}
+
+func TestRenderEmptyRealmReturnsNothing(t *testing.T) {
+	t.Parallel()
+	// Defense-in-depth: an empty realm would produce invalid Secrets (the
+	// parser requires metadata.realm). Render short-circuits so the caller
+	// can never accidentally apply schema-invalid output.
+	merged := map[string]string{"FOO": "bar"}
+	secrets, _ := Render(merged, []string{"FOO"}, "")
+	if len(secrets) != 0 {
+		t.Errorf("empty realm rendered %d secrets, want 0", len(secrets))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/teamsecrets` package: scaffolds the host-wide `~/.kuke/teams/secrets.env` and per-team `<teamDir>/secrets.env` (mode 0o600) on first run with one empty `KEY=` line per role-declared secret name, idempotent on re-run; loads + merges (per-team non-empty overrides shared) + renders each non-empty merged entry as a `kind: Secret` in realm `default` with a kebab-case `metadata.name` (`ANTHROPIC_AUTH_TOKEN` → `anthropic-auth-token`).
- Extend `teamrender.Result` with `Secrets` and reorder `MarshalYAML` to emit `Secrets → Blueprints → Configs` so the per-team apply bundle (per-team prune-apply contract from #1029) carries the secret material before the blueprint/config pair that references it.
- Wire the secrets pipeline into `cmd/kuke/team/init.go`'s `composeTeam`: discover the union of `needs.secrets` from every roster role, run `teamsecrets.Compose` (skipped scaffold under `--dry-run`), surface one warning-per-empty-key on stderr (key name only — values are never logged or echoed), update the apply-summary line to `applied N secret/M blueprint/K config object(s)`.

## Non-obvious design call

The AC says "per-team value wins for matching keys". A literal reading is footgunny: the scaffold writes one empty `KEY=` line per role-declared secret into the per-team file, so on the very first re-init after scaffold, **every** key in shared would be null-out by the empty per-team placeholder — the shared layer would become unreachable without hand-curation of every per-team file. The implementation reads "wins" as "non-empty wins": a per-team value with non-empty bytes overrides shared; an empty per-team value is a placeholder, not an override. This keeps the shared layer useful as a default while still letting the operator override per-key by writing a value. Pinned via `TestMergePerTeamEmptyFallsBackToShared`. Push back if you'd rather have strict "any-present-wins" semantics — the change is one-line in `Merge`.

## Test plan

- [x] `make test-root` — full `go test ./...` (excludes /e2e) passes locally.
- [x] `make test-kukebuild` — `cd cmd/kukebuild && go test ./...` passes locally.
- [x] `pre-commit run --files <touched>` — go fmt / go-mod-tidy / golangci-lint / addlicense all pass.
- [ ] `make dev-init` smoke test — skipped this round: the dev-init smoke is gated on a running containerd daemon, and only this branch's renderer surface changed; the smoke covers daemon liveness paths not touched here. The renderer/apply changes are covered by the new unit tests in `internal/teamsecrets/teamsecrets_test.go` and the bundle-ordering / scaffold / dry-run / populated-file integration tests in `cmd/kuke/team/init_test.go`.

## Acceptance criteria

- [x] Fresh `~/.kuke/teams/` gets a templated shared `secrets.env`; each team's dir gets a per-team `secrets.env` (both 0o600) — `TestComposeTeamScaffoldsSecretsEnvFilesOnFirstInit`.
- [x] Per-team non-empty value overrides shared for matching keys; per-team-only keys merge in; shared-only keys carry — `TestComposeTeamRespectsPopulatedSecretsEnv`, `TestMergePerTeamNonEmptyWins`, `TestMergePerTeamEmptyFallsBackToShared`.
- [x] Populated merged lines apply as `kind: Secret` (realm = `default`) — `TestComposeTeamBundlesSecretsBeforeBlueprintsAndConfigs`.
- [x] Empty-value warning fires once per empty key (key name only — value never echoed) — `TestComposeTeamScaffoldsSecretsEnvFilesOnFirstInit` + `TestComposeTeamDryRunDoesNotScaffoldSecretsEnv`.
- [x] Re-run does not overwrite a populated `secrets.env` (shared or per-team) — `TestComposeTeamRespectsPopulatedSecretsEnv` + `TestScaffoldEnvFileNeverOverwrites`.
- [x] `secrets.env` files created mode 0o600; values never logged or echoed — `TestScaffoldEnvFileCreatesWithMode0600` + the new warning text only carries key names.
- [x] `--dry-run` prints the rendered Secrets, applies nothing, writes nothing — `TestComposeTeamDryRunDoesNotScaffoldSecretsEnv` (covers the no-write side; the rendered output threads through `emitDryRun` → `MarshalYAML` which is itself covered by the bundle-order test).
- [x] Bundle order: Secrets → Blueprints → Configs — `TestComposeTeamBundlesSecretsBeforeBlueprintsAndConfigs` checks byte-offsets of each section's `kind:` line.

Closes #1113