### PR TITLE
feat(team): .operator/.project fact contract + crew→team comment refresh

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -218,7 +218,15 @@ func composeTeam(
 		fmt.Fprintf(out, "scaffolded operator-global facts at %s\n", layout.GlobalConfigPath())
 	}
 
-	res, bundle, err := renderTeam(ctx, layout, projectDir, pt, tc, project, getProjectURL, resolve, doBuild)
+	// Resolve the per-team root before rendering: an operator-supplied
+	// spec.teamDir on the existing drop-in entry overrides the default
+	// <base>/teams/<team>; an absent override falls back to the layout
+	// default. The resolved path is used by Render to populate
+	// `.operator.TEAM_ROOT`, by the provisioning pass below, and by the
+	// entry write so all three see the same path.
+	teamDir := resolveTeamDir(layout, project)
+
+	res, bundle, err := renderTeam(ctx, layout, projectDir, teamDir, pt, tc, project, getProjectURL, resolve, doBuild)
 	if err != nil {
 		return err
 	}
@@ -237,13 +245,6 @@ func composeTeam(
 			}
 		}
 	}
-
-	// Resolve the per-team root: an operator-supplied spec.teamDir on the
-	// existing drop-in entry overrides the default <base>/teams/<team>; an
-	// absent override falls back to the layout default. The resolved path
-	// is used for both the provisioning pass and the entry write below so
-	// the persisted record matches what was actually provisioned.
-	teamDir := resolveTeamDir(layout, project)
 
 	if provisionErr := provisionHost(out, teamDir, pt, bundle, dryRun); provisionErr != nil {
 		return provisionErr
@@ -539,7 +540,7 @@ func loadOrScaffoldGlobalConfig(
 func renderTeam(
 	ctx context.Context,
 	layout teamhost.Layout,
-	projectDir string,
+	projectDir, teamDir string,
 	pt *model.ProjectTeam,
 	tc *model.TeamsConfig,
 	project string,
@@ -561,6 +562,8 @@ func renderTeam(
 	in := teamrender.Inputs{
 		Project:        project,
 		ProjectRepoURL: strings.TrimSpace(projectURL),
+		ProjectDir:     projectDir,
+		TeamDir:        teamDir,
 		Build:          doBuild,
 		SourceRef:      bundle.Source.Ref,
 	}

--- a/docs/site/cli/kuke-team-init.md
+++ b/docs/site/cli/kuke-team-init.md
@@ -1,0 +1,91 @@
+# kuke team init
+
+```
+kuke team init [--dry-run] [--build]
+```
+
+Compose the project's agent team from its committed `kuketeam.yaml` roster.
+
+`kuke team init` reads the project's roster (`kuketeam.yaml` in the current
+directory), scaffolds the operator-global facts file
+(`~/.kuke/kuketeams.yaml`) on first run, resolves the pinned agents source
+into the on-disk cache, renders per-(role × harness) CellBlueprint /
+CellConfig pairs labeled with the project, applies that labeled set to
+kukeond, provisions the per-team host-state tree, and writes a per-project
+drop-in entry under `~/.kuke/kuketeam.d/<project>.yaml`. Nothing is written
+under `~/.kuke/rendered/` — the daemon owns the persisted blueprints /
+configs and the drop-in entry is the only host-side record of an applied
+team. See [`docs/site/concepts/team.md`](../concepts/team.md) for the
+declarative-surface contract behind the verb.
+
+## Flags
+
+| Flag        | Default | Description                                                              |
+| ----------- | ------- | ------------------------------------------------------------------------ |
+| `--dry-run` | `false` | print the rendered objects to stdout instead of applying them to kukeond |
+| `--build`   | `false` | build each selected image locally before apply; bind the local tag       |
+
+Plus all [global flags](kuke.md).
+
+## Operator / project fact contract
+
+The harness blueprint templates published in the agents source are rendered
+against a typed dot-context (see
+[`internal/teamrender/teamrender.go`](https://github.com/eminwux/kukeon/blob/main/internal/teamrender/teamrender.go)
+`renderContextValues`). The `.operator.*` and `.project.*` leaves carry the
+full operator / project fact contract a published blueprint may reference;
+a blueprint that references a key the operator did not set gets the empty
+string (Go text/template's default for a missing map key), not an error.
+
+### `.operator.*` — operator-host facts
+
+Operator-host scope: the value is the operator's identity / paths / agents
+context. `GIT_USER_NAME`, `GIT_USER_EMAIL`, and `REGISTRY` are bound
+directly from `~/.kuke/kuketeams.yaml`. `TEAM_ROOT` is **per-team-scoped**
+— it is resolved per render call from the team's
+`TeamEntry.spec.teamDir` (auto-filled to `Layout.TeamDir(team)` by `kuke
+team init` when omitted, or the operator override when relocated). Two
+teams running on the same operator host see two different `TEAM_ROOT`
+values; there is no host-wide TeamsConfig field for it.
+
+| Key              | Source                                                                  | Default                                                                |
+| ---------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `GIT_USER_NAME`  | `~/.kuke/kuketeams.yaml` `spec.git.author.name`                         | empty                                                                  |
+| `GIT_USER_EMAIL` | `~/.kuke/kuketeams.yaml` `spec.git.author.email`                        | empty                                                                  |
+| `REGISTRY`       | `~/.kuke/kuketeams.yaml` `spec.registry`                                | empty                                                                  |
+| `TEAM_ROOT`      | per-team `TeamEntry.spec.teamDir` (operator override or layout default) | `~/.kuke/teams/<team>` (`Layout.TeamDir(team)`)                        |
+| `HOME_DIR`       | `~/.kuke/kuketeams.yaml` `spec.homeDir` (override)                      | `$HOME` from the calling process                                       |
+| `REPO_OWNER`     | `~/.kuke/kuketeams.yaml` `spec.repoOwner` (override)                    | owner segment of the agents source's `<owner>/<repo>` (e.g. `eminwux`) |
+
+`HOME_DIR` and `REPO_OWNER` carry an explicit override on `TeamsConfigSpec`
+so an operator whose `$HOME` is not the natural reference point — or whose
+identity differs from the agents source owner (e.g., forked agents) — can
+pin the value; the scaffolded global config stays minimal and the common
+single-owner case needs no entry.
+
+### `.project.*` — per-project facts
+
+Per-project scope: the value is the team-label / on-disk source-tree path /
+agents-source path the current `kuke team init` invocation is composing
+for.
+
+| Key           | Source                                               | Default               |
+| ------------- | ---------------------------------------------------- | --------------------- |
+| `NAME`        | `kuketeam.yaml` `metadata.name`                      | empty (validated)     |
+| `PROJECT_DIR` | `composeTeam`'s `projectDir` argument (`os.Getwd()`) | the calling cwd       |
+| `AGENTS_REPO` | resolved agents source's `<owner>/<repo>` path       | empty when unresolved |
+
+## Exit codes
+
+- `0` — the team was rendered and applied (or the dry-run completed
+  cleanly) and the drop-in entry was written. `--build` flips this to
+  include the local image-build step.
+- non-zero — a hard error before apply: roster parse failure, agents
+  source resolve failure, missing required CellBlueprintParameter, or an
+  ApplyDocumentsForTeam transport failure. The drop-in entry is **not**
+  written on the apply-failure path so a re-run sees the prior state.
+
+The contract is set in
+[`cmd/kuke/team/init.go`](https://github.com/eminwux/kukeon/blob/main/cmd/kuke/team/init.go)
+and [`internal/teamrender/`](https://github.com/eminwux/kukeon/blob/main/internal/teamrender/) — see
+`composeTeam` and `Render` for the full lifecycle.

--- a/internal/ctr/spec.go
+++ b/internal/ctr/spec.go
@@ -587,10 +587,10 @@ func kukeonDefaultEnv(spec intmodel.ContainerSpec) []string {
 
 // gitEnv expands a container's git identity/signing sugar (ContainerSpec.Git)
 // into the GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_* env-var block git
-// reads natively, replacing the hand-rolled block crew templates duplicate
-// per cell today. Returns nil when git is unset. The GIT_CONFIG_* signing
-// pairs are emitted in crew's canonical order — user.signingkey, gpg.format,
-// commit.gpgsign, tag.gpgsign, gpg.ssh.allowedSignersFile — with
+// reads natively, replacing the hand-rolled block team blueprint templates
+// duplicate per cell today. Returns nil when git is unset. The GIT_CONFIG_*
+// signing pairs are emitted in the canonical order — user.signingkey,
+// gpg.format, commit.gpgsign, tag.gpgsign, gpg.ssh.allowedSignersFile — with
 // GIT_CONFIG_COUNT tracking the live pair count, so a block that omits signing
 // renders no GIT_CONFIG_* entries at all. gpg.format=ssh is implied by a
 // non-empty signingKey (kukeon signs with SSH keys). The returned entries are

--- a/internal/ctr/spec_git_env_test.go
+++ b/internal/ctr/spec_git_env_test.go
@@ -23,9 +23,10 @@ import (
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
-// fullGitSpec mirrors crew's git block: author + committer identity, an SSH
-// signing key, commit + tag signing, and an allowed-signers file. This is the
-// 15-var rendering (GIT_CONFIG_COUNT=5) the live crew templates emit today.
+// fullGitSpec mirrors the canonical team blueprint git block: author +
+// committer identity, an SSH signing key, commit + tag signing, and an
+// allowed-signers file. This is the 15-var rendering (GIT_CONFIG_COUNT=5)
+// the live team blueprint templates emit today.
 func fullGitSpec() *intmodel.ContainerGit {
 	return &intmodel.ContainerGit{
 		Author:         &intmodel.GitIdentity{Name: "Emiliano Spinella", Email: "dev@eminwux.com"},
@@ -37,8 +38,9 @@ func fullGitSpec() *intmodel.ContainerGit {
 }
 
 // TestBuildContainerSpec_GitEnv asserts the full git block expands to the
-// exact GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_* env-var set crew emits
-// by hand today, including gpg.format=ssh implied by signingKey. Issue #618.
+// exact GIT_AUTHOR_* / GIT_COMMITTER_* / GIT_CONFIG_* env-var set the team
+// blueprint templates emit by hand today, including gpg.format=ssh implied
+// by signingKey. Issue #618.
 func TestBuildContainerSpec_GitEnv(t *testing.T) {
 	spec := applyBuiltSpec(t, intmodel.ContainerSpec{
 		ID:    "work",

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -107,7 +107,17 @@ const partialGlob = "*.tmpl.yaml"
 type Inputs struct {
 	Project        string
 	ProjectRepoURL string
-	Realm          string
+	// ProjectDir is the on-host directory the project's kuketeam.yaml was read
+	// from (composeTeam's os.Getwd()). Exposed to blueprint templates as
+	// `.project.PROJECT_DIR` so the operator can reference the source-tree
+	// path without bouncing it through a CellConfig parameter.
+	ProjectDir string
+	// TeamDir is the per-team host-state root resolved by composeTeam
+	// (TeamEntry.spec.teamDir override, else Layout.TeamDir(team)). Exposed to
+	// blueprint templates as `.operator.TEAM_ROOT`. Per-team-scoped: two teams
+	// running on the same operator host see two different TEAM_ROOT values.
+	TeamDir string
+	Realm   string
 	// Build is true under `kuke team init --build`: the rendered blueprint
 	// binds the locally-built `kukeon.internal/<ref>:<version>` image (the tag
 	// teambuild produces) instead of the catalog entry's published `Image`.
@@ -189,7 +199,7 @@ func Render(
 
 			bp, renderErr := RenderBlueprint(
 				bundle.CacheDir, harness, role, hname, ptRole.Ref,
-				merged, entry, tc, project, realm, in.Build, in.SourceRef,
+				merged, entry, tc, bundle.Source, in, project, realm,
 			)
 			if renderErr != nil {
 				return nil, fmt.Errorf(
@@ -304,14 +314,18 @@ func SelectImage(
 // owning a partials directory of its own.
 //
 // Dot-context: see renderContextValues for the full shape. The
-// `.operator.*` and `.project.*` leaves are partially bound here and
-// completed in #1115. The metadata.labels are populated with
-// `kukeon.io/team = project`. metadata.realm is forced to realm (the
+// `.operator.*` and `.project.*` leaves are bound from tc, src, and in:
+// the agents source's owner/repo path drives `.operator.REPO_OWNER` (when
+// no tc.spec.repoOwner override is set) and `.project.AGENTS_REPO`;
+// in.ProjectDir and in.TeamDir surface as `.project.PROJECT_DIR` and
+// `.operator.TEAM_ROOT` respectively; tc.spec.homeDir (or `$HOME` when
+// unset) fills `.operator.HOME_DIR`. The metadata.labels are populated
+// with `kukeon.io/team = project`. metadata.realm is forced to realm (the
 // template need not pre-fill it). If the template did not supply
 // metadata.name, the default `<role>-<harness>` is stamped so the
 // blueprint and its companion config share a deterministic identity.
 //
-// build + sourceRef drive the `.image` bind decision (see
+// in.Build + in.SourceRef drive the `.image` bind decision (see
 // renderContextValues): in build mode the locally-built
 // `kukeon.internal/<ref>:<sourceRef>` image is bound; otherwise the
 // catalog entry's published Image is.
@@ -323,9 +337,9 @@ func RenderBlueprint(
 	needs []string,
 	image *model.ImageCatalogEntry,
 	tc *model.TeamsConfig,
+	src teamsource.Source,
+	in Inputs,
 	project, realm string,
-	build bool,
-	sourceRef string,
 ) (*v1beta1.CellBlueprintDoc, error) {
 	if h == nil || strings.TrimSpace(h.Spec.Template) == "" {
 		return nil, fmt.Errorf(
@@ -347,7 +361,7 @@ func RenderBlueprint(
 		return nil, err
 	}
 
-	ctx := renderContextValues(roleRef, harness, image, needs, r, tc, project, realm, build, sourceRef)
+	ctx := renderContextValues(roleRef, harness, image, needs, r, tc, src, in, project, realm)
 	var buf bytes.Buffer
 	if execErr := tpl.ExecuteTemplate(&buf, filepath.Base(tplPath), ctx); execErr != nil {
 		return nil, fmt.Errorf("execute blueprint template %q: %w", tplPath, execErr)
@@ -624,37 +638,41 @@ func parseBlueprintTemplate(tplPath string, raw []byte) (*template.Template, err
 // `.Needs.Repos` instead of the lowercase `.needs.repos` the agents repo
 // templates are authored with.
 //
-// The `.image` bind is mode-dependent: in `--build` mode (build && a
-// non-empty sourceRef) it is the locally-built
+// The `.image` bind is mode-dependent: in `--build` mode (in.Build && a
+// non-empty in.SourceRef) it is the locally-built
 // `kukeon.internal/<ref>:<sourceRef>` ref — byte-identical to the tag
 // teambuild produces, so the runtime resolves the in-realm image without a
 // network pull — otherwise it is the catalog entry's published,
 // registry-qualified Image. `.image_ref` always carries the catalog-local
 // selector key (`image.Ref`) regardless of mode.
 //
-// The `.operator.*` and `.project.*` leaves are partially bound here and
-// completed in #1115 — the keys already backed by the operator's
-// TeamsConfig (GIT_USER_NAME, GIT_USER_EMAIL, REGISTRY) are populated;
-// the not-yet-bound keys (TEAM_ROOT, HOME_DIR, REPO_OWNER, PROJECT_DIR,
-// AGENTS_REPO) wait for that follow-up. A blueprint referencing an
-// unbound key gets an empty string at render time (Go template's default
-// for a missing map key), not an error.
+// The `.operator.*` and `.project.*` leaves are the full fact contract the
+// published blueprints reference. Operator-side: GIT_USER_NAME /
+// GIT_USER_EMAIL / REGISTRY come from tc; TEAM_ROOT is per-team
+// (in.TeamDir, resolved from TeamEntry.spec.teamDir or the Layout default
+// for this render call); HOME_DIR is tc.spec.homeDir or `$HOME` when
+// unset; REPO_OWNER is tc.spec.repoOwner or the owner segment of the
+// agents source's `<owner>/<repo>` when unset. Project-side: NAME is the
+// team label; PROJECT_DIR is in.ProjectDir (composeTeam's os.Getwd());
+// AGENTS_REPO is the agents source's `<owner>/<repo>` path. A blueprint
+// referencing an unbound key gets an empty string at render time (Go
+// template's default for a missing map key), not an error.
 func renderContextValues(
 	roleRef, harness string,
 	image *model.ImageCatalogEntry,
 	needs []string,
 	r *model.Role,
 	tc *model.TeamsConfig,
+	src teamsource.Source,
+	in Inputs,
 	project, realm string,
-	build bool,
-	sourceRef string,
 ) map[string]any {
 	img := ""
 	imgRef := ""
 	if image != nil {
 		img = image.Image
-		if build && strings.TrimSpace(sourceRef) != "" {
-			img = consts.InternalImageRef(image.Ref, sourceRef)
+		if in.Build && strings.TrimSpace(in.SourceRef) != "" {
+			img = consts.InternalImageRef(image.Ref, in.SourceRef)
 		}
 		imgRef = image.Ref
 	}
@@ -701,9 +719,24 @@ func renderContextValues(
 			}
 		}
 	}
+	if v := strings.TrimSpace(in.TeamDir); v != "" {
+		operatorView["TEAM_ROOT"] = v
+	}
+	if v := resolveHomeDir(tc); v != "" {
+		operatorView["HOME_DIR"] = v
+	}
+	if v := resolveRepoOwner(tc, src); v != "" {
+		operatorView["REPO_OWNER"] = v
+	}
 
 	projectView := map[string]string{
 		"NAME": project,
+	}
+	if v := strings.TrimSpace(in.ProjectDir); v != "" {
+		projectView["PROJECT_DIR"] = v
+	}
+	if v := strings.TrimSpace(src.OwnerRepo); v != "" {
+		projectView["AGENTS_REPO"] = v
 	}
 
 	roleView := map[string]any{
@@ -724,6 +757,36 @@ func renderContextValues(
 		"space":     "",
 		"stack":     "",
 	}
+}
+
+// resolveHomeDir returns the `.operator.HOME_DIR` fact: tc.spec.homeDir
+// when the operator set it, else the process's `$HOME` env var. Empty when
+// both are unset (a blueprint that references HOME_DIR then renders the
+// empty string — Go template's default for a missing map key).
+func resolveHomeDir(tc *model.TeamsConfig) string {
+	if tc != nil {
+		if v := strings.TrimSpace(tc.Spec.HomeDir); v != "" {
+			return v
+		}
+	}
+	return strings.TrimSpace(os.Getenv("HOME"))
+}
+
+// resolveRepoOwner returns the `.operator.REPO_OWNER` fact: tc.spec.repoOwner
+// when the operator set it, else the owner segment of the agents source's
+// `<owner>/<repo>` path (the segment before the first `/`). The common
+// single-owner case (operator owns both the agents source and their
+// projects) needs no override.
+func resolveRepoOwner(tc *model.TeamsConfig, src teamsource.Source) string {
+	if tc != nil {
+		if v := strings.TrimSpace(tc.Spec.RepoOwner); v != "" {
+			return v
+		}
+	}
+	if owner, _, ok := strings.Cut(strings.TrimSpace(src.OwnerRepo), "/"); ok {
+		return owner
+	}
+	return ""
 }
 
 // roleNeedsRepos, roleNeedsMounts, roleNeedsParams, roleNeedsSecrets

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -264,10 +264,10 @@ func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
 		[]string{"git", "go"},
 		image,
 		nil,
+		teamsource.Source{},
+		Inputs{},
 		"sbsh",
 		"default",
-		false,
-		"",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -326,10 +326,10 @@ func TestRenderBlueprintBindsInternalRefInBuildMode(t *testing.T) {
 		[]string{"git", "go"},
 		image,
 		nil,
+		teamsource.Source{},
+		Inputs{Build: true, SourceRef: "v1.4.0"},
 		"sbsh",
 		"default",
-		true,
-		"v1.4.0",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -375,10 +375,10 @@ func TestRenderBlueprintBindsPublishedRefWithoutBuild(t *testing.T) {
 				[]string{"git", "go"},
 				image,
 				nil,
+				teamsource.Source{},
+				Inputs{Build: tc.build, SourceRef: tc.sourceRef},
 				"sbsh",
 				"default",
-				tc.build,
-				tc.sourceRef,
 			)
 			if err != nil {
 				t.Fatalf("RenderBlueprint: %v", err)
@@ -395,7 +395,20 @@ func TestRenderBlueprintMissingTemplate(t *testing.T) {
 	cacheDir := t.TempDir()
 	r := minimalRole()
 	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
-	_, err := RenderBlueprint(cacheDir, h, r, "missing", "dev", nil, nil, nil, "sbsh", "default", false, "")
+	_, err := RenderBlueprint(
+		cacheDir,
+		h,
+		r,
+		"missing",
+		"dev",
+		nil,
+		nil,
+		nil,
+		teamsource.Source{},
+		Inputs{},
+		"sbsh",
+		"default",
+	)
 	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
 		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
 	}
@@ -406,7 +419,20 @@ func TestRenderBlueprintEmptyTemplatePathRejected(t *testing.T) {
 	cacheDir := t.TempDir()
 	r := minimalRole()
 	h := &model.Harness{Spec: model.HarnessSpec{}}
-	_, err := RenderBlueprint(cacheDir, h, r, "claude", "dev", nil, nil, nil, "sbsh", "default", false, "")
+	_, err := RenderBlueprint(
+		cacheDir,
+		h,
+		r,
+		"claude",
+		"dev",
+		nil,
+		nil,
+		nil,
+		teamsource.Source{},
+		Inputs{},
+		"sbsh",
+		"default",
+	)
 	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
 		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
 	}
@@ -434,7 +460,7 @@ func TestRenderBlueprintResolvesTemplateRelativeToHarnessDir(t *testing.T) {
 	}
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "dev",
-		[]string{"git", "go"}, image, nil, "sbsh", "default", false, "",
+		[]string{"git", "go"}, image, nil, teamsource.Source{}, Inputs{}, "sbsh", "default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint with bare-filename template: %v", err)
@@ -475,7 +501,7 @@ spec:
 	image := &model.ImageCatalogEntry{Image: "registry.local/claude:latest"}
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "my-dev",
-		[]string{"go"}, image, nil, "sbsh", "default", false, "",
+		[]string{"go"}, image, nil, teamsource.Source{}, Inputs{}, "sbsh", "default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint with sibling partials: %v", err)
@@ -524,7 +550,7 @@ spec:
 	}}
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "dev",
-		[]string{"go"}, image, tc, "sbsh", "default", false, "",
+		[]string{"go"}, image, tc, teamsource.Source{}, Inputs{}, "sbsh", "default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -573,7 +599,7 @@ spec:
 	image := &model.ImageCatalogEntry{Image: "x"}
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "pr-reviewer",
-		nil, image, nil, "sbsh", "default", false, "",
+		nil, image, nil, teamsource.Source{}, Inputs{}, "sbsh", "default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -607,7 +633,20 @@ spec:
 	r := minimalRole()
 	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
 	image := &model.ImageCatalogEntry{Image: "registry.local/codex:latest"}
-	bp, err := RenderBlueprint(cacheDir, h, r, "codex", "dev", nil, image, nil, "sbsh", "default", false, "")
+	bp, err := RenderBlueprint(
+		cacheDir,
+		h,
+		r,
+		"codex",
+		"dev",
+		nil,
+		image,
+		nil,
+		teamsource.Source{},
+		Inputs{},
+		"sbsh",
+		"default",
+	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
 	}
@@ -937,6 +976,202 @@ func TestMarshalYAMLProducesMultiDocStream(t *testing.T) {
 	}
 	if !strings.Contains(body, "---") {
 		t.Errorf("missing multi-doc separator: %q", body)
+	}
+}
+
+// TestRenderBlueprintBindsOperatorAndProjectFacts confirms a blueprint
+// that references every new fact key (TEAM_ROOT / HOME_DIR / REPO_OWNER
+// under .operator; PROJECT_DIR / AGENTS_REPO under .project) renders to
+// the expected concrete values. Covers AC: "Unit tests verify a blueprint
+// that references each of the new keys renders to the expected concrete
+// value.".
+func TestRenderBlueprintBindsOperatorAndProjectFacts(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        env:
+          - "TEAM_ROOT={{ .operator.TEAM_ROOT }}"
+          - "HOME_DIR={{ .operator.HOME_DIR }}"
+          - "REPO_OWNER={{ .operator.REPO_OWNER }}"
+          - "PROJECT_DIR={{ .project.PROJECT_DIR }}"
+          - "AGENTS_REPO={{ .project.AGENTS_REPO }}"
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{Image: "registry.local/claude:latest"}
+	tc := &model.TeamsConfig{Spec: model.TeamsConfigSpec{
+		HomeDir:   "/home/op",
+		RepoOwner: "ovr-owner",
+	}}
+	src := teamsource.Source{
+		Repo:      "github.com/eminwux/agents",
+		Host:      "github.com",
+		OwnerRepo: "eminwux/agents",
+		Ref:       "v1.4.0",
+		Kind:      teamsource.RefTag,
+	}
+	in := Inputs{
+		Project:    "sbsh",
+		ProjectDir: "/srv/sbsh",
+		TeamDir:    "/var/kuke/teams/sbsh",
+	}
+	bp, err := RenderBlueprint(
+		cacheDir, h, minimalRole(), "claude", "dev",
+		[]string{"go"}, image, tc, src, in, "sbsh", "default",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	wantEnv := []string{
+		"TEAM_ROOT=/var/kuke/teams/sbsh",
+		"HOME_DIR=/home/op",
+		"REPO_OWNER=ovr-owner",
+		"PROJECT_DIR=/srv/sbsh",
+		"AGENTS_REPO=eminwux/agents",
+	}
+	if !reflect.DeepEqual(bp.Spec.Cell.Containers[0].Env, wantEnv) {
+		t.Errorf("env = %v, want %v", bp.Spec.Cell.Containers[0].Env, wantEnv)
+	}
+}
+
+// TestRenderBlueprintRepoOwnerDerivesFromAgentsSource confirms the
+// REPO_OWNER fallback: when tc.spec.repoOwner is empty, the renderer
+// derives the owner segment from the agents source's `<owner>/<repo>`
+// path. The common single-owner case needs no override.
+func TestRenderBlueprintRepoOwnerDerivesFromAgentsSource(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        env:
+          - "REPO_OWNER={{ .operator.REPO_OWNER }}"
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{Image: "registry.local/claude:latest"}
+	tc := &model.TeamsConfig{} // no RepoOwner override
+	src := teamsource.Source{OwnerRepo: "eminwux/agents", Host: "github.com"}
+	bp, err := RenderBlueprint(
+		cacheDir, h, minimalRole(), "claude", "dev",
+		[]string{"go"}, image, tc, src, Inputs{Project: "sbsh"}, "sbsh", "default",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	wantEnv := []string{"REPO_OWNER=eminwux"}
+	if !reflect.DeepEqual(bp.Spec.Cell.Containers[0].Env, wantEnv) {
+		t.Errorf("env = %v, want %v (derived owner from src.OwnerRepo)",
+			bp.Spec.Cell.Containers[0].Env, wantEnv)
+	}
+}
+
+// TestRenderBlueprintHomeDirFallsBackToEnv confirms the HOME_DIR fallback:
+// when tc.spec.homeDir is empty, the renderer reads `$HOME` from the
+// process environment (the scaffolded global config stays minimal).
+func TestRenderBlueprintHomeDirFallsBackToEnv(t *testing.T) {
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        env:
+          - "HOME_DIR={{ .operator.HOME_DIR }}"
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+	h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+	image := &model.ImageCatalogEntry{Image: "registry.local/claude:latest"}
+	// Pin HOME to a known value; t.Setenv restores after the test (cannot run
+	// in parallel — env mutation is process-wide).
+	t.Setenv("HOME", "/home/sentinel")
+	bp, err := RenderBlueprint(
+		cacheDir, h, minimalRole(), "claude", "dev",
+		[]string{"go"}, image, &model.TeamsConfig{}, teamsource.Source{},
+		Inputs{Project: "sbsh"}, "sbsh", "default",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	wantEnv := []string{"HOME_DIR=/home/sentinel"}
+	if !reflect.DeepEqual(bp.Spec.Cell.Containers[0].Env, wantEnv) {
+		t.Errorf("env = %v, want %v ($HOME fallback)", bp.Spec.Cell.Containers[0].Env, wantEnv)
+	}
+}
+
+// TestRenderTwoTeamsDistinctTeamRoot covers the AC's per-team TEAM_ROOT
+// scope: two teams with different TeamDir Inputs render to two different
+// `.operator.TEAM_ROOT` values, confirming TEAM_ROOT is per-team-context
+// rather than a host-wide TeamsConfig field.
+func TestRenderTwoTeamsDistinctTeamRoot(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        env:
+          - "TEAM_ROOT={{ .operator.TEAM_ROOT }}"
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+	bundle := &teamsource.Bundle{
+		Source: teamsource.Source{
+			Repo: "github.com/eminwux/agents", Host: "github.com",
+			OwnerRepo: "eminwux/agents", Ref: "v1.4.0", Kind: teamsource.RefTag,
+		},
+		CacheDir: cacheDir,
+		Roles:    map[string]*model.Role{"dev": minimalRole()},
+		Harnesses: map[string]*model.Harness{
+			"claude": {Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}},
+		},
+		ImageCatalog: minimalClaudeCatalog("go", "git"),
+	}
+	pt := &model.ProjectTeam{
+		Metadata: model.Metadata{Name: "team"},
+		Spec: model.ProjectTeamSpec{
+			Source:   model.TeamSource{Repo: "github.com/eminwux/agents", Tag: "v1.4.0"},
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	tc := &model.TeamsConfig{}
+
+	alpha, err := Render(bundle, pt, tc, Inputs{Project: "alpha", TeamDir: "/var/kuke/teams/alpha"})
+	if err != nil {
+		t.Fatalf("Render alpha: %v", err)
+	}
+	beta, err := Render(bundle, pt, tc, Inputs{Project: "beta", TeamDir: "/var/kuke/teams/beta"})
+	if err != nil {
+		t.Fatalf("Render beta: %v", err)
+	}
+	if got := alpha.Blueprints[0].Spec.Cell.Containers[0].Env[0]; got != "TEAM_ROOT=/var/kuke/teams/alpha" {
+		t.Errorf("alpha TEAM_ROOT = %q, want /var/kuke/teams/alpha", got)
+	}
+	if got := beta.Blueprints[0].Spec.Cell.Containers[0].Env[0]; got != "TEAM_ROOT=/var/kuke/teams/beta" {
+		t.Errorf("beta TEAM_ROOT = %q, want /var/kuke/teams/beta", got)
 	}
 }
 

--- a/pkg/api/model/kuketeams/marshal_test.go
+++ b/pkg/api/model/kuketeams/marshal_test.go
@@ -143,6 +143,27 @@ func TestRoundTripAllKinds(t *testing.T) {
 	})
 }
 
+// TestTeamsConfigSpecRoundTripsHomeDirAndRepoOwner asserts the
+// .spec.homeDir / .spec.repoOwner override fields (added with the
+// .operator.HOME_DIR / .operator.REPO_OWNER blueprint facts) survive a
+// JSON/YAML round-trip — both default to derived values at render time,
+// but the explicit override must marshal in both encodings.
+func TestTeamsConfigSpecRoundTripsHomeDirAndRepoOwner(t *testing.T) {
+	t.Parallel()
+	tc := model.TeamsConfig{
+		APIVersion: model.APIVersionV1, Kind: model.KindTeamsConfig,
+		Spec: model.TeamsConfigSpec{
+			Registry:  "registry.local",
+			HomeDir:   "/home/op",
+			RepoOwner: "eminwux",
+		},
+	}
+	assertJSONYAML(t, "TeamsConfig+HomeDir+RepoOwner", tc, func(got model.TeamsConfig) bool {
+		return got.Spec.HomeDir == "/home/op" && got.Spec.RepoOwner == "eminwux" &&
+			got.Spec.Registry == "registry.local"
+	})
+}
+
 func assertJSONYAML[T any](t *testing.T, name string, in T, ok func(T) bool) {
 	t.Helper()
 	jb, err := json.Marshal(in)

--- a/pkg/api/model/kuketeams/teamsconfig.go
+++ b/pkg/api/model/kuketeams/teamsconfig.go
@@ -37,15 +37,26 @@ type TeamsConfig struct {
 type TeamsConfigSpec struct {
 	// Git is the operator's git identity + signing config rendered into every
 	// team cell. It is a strict superset of v1beta1.ContainerGit.
-	Git *TeamsConfigGit `json:"git,omitempty"      yaml:"git,omitempty"`
+	Git *TeamsConfigGit `json:"git,omitempty"       yaml:"git,omitempty"`
 	// Registry is the default container registry for resolving images.
-	Registry string `json:"registry,omitempty" yaml:"registry,omitempty"`
+	Registry string `json:"registry,omitempty"  yaml:"registry,omitempty"`
+	// HomeDir is an explicit override for the `.operator.HOME_DIR` blueprint
+	// fact. Optional; when unset the renderer falls back to `$HOME` at render
+	// time so the scaffolded global config stays minimal. Distinct from the
+	// per-team Layout root (which is per-team and carried on TeamEntry).
+	HomeDir string `json:"homeDir,omitempty"   yaml:"homeDir,omitempty"`
+	// RepoOwner is an explicit override for the `.operator.REPO_OWNER`
+	// blueprint fact (the owner segment of `<owner>/<repo>`). Optional; when
+	// unset the renderer derives it from the agents source's owner segment so
+	// the common single-owner case needs no entry. Set this when the operator's
+	// identity differs from the agents source owner (e.g., forked agents).
+	RepoOwner string `json:"repoOwner,omitempty" yaml:"repoOwner,omitempty"`
 	// Sources maps `<owner>/<repo>` keys to clone URLs (e.g.
 	// eminwux/agents -> git@github.com:eminwux/agents.git).
-	Sources map[string]string `json:"sources,omitempty"  yaml:"sources,omitempty"`
+	Sources map[string]string `json:"sources,omitempty"   yaml:"sources,omitempty"`
 	// Secrets maps a secret name to its source declaration. A secret never
 	// carries an inline value — only where to read it from.
-	Secrets map[string]TeamsConfigSecret `json:"secrets,omitempty"  yaml:"secrets,omitempty"`
+	Secrets map[string]TeamsConfigSecret `json:"secrets,omitempty"   yaml:"secrets,omitempty"`
 }
 
 // TeamsConfigGit is a strict superset of v1beta1.ContainerGit — the embedded

--- a/pkg/api/model/v1beta1/container.go
+++ b/pkg/api/model/v1beta1/container.go
@@ -308,10 +308,11 @@ type VolumeMount struct {
 
 // ContainerRepo declares a git repository the container depends on. kuketty
 // clones (or fetches) it into Target before the workload starts, replacing the
-// hand-rolled `if [ ! -d $DIR/.git ]; then git clone …; fi` blocks that crew
-// templates duplicate in onInit scripts today. The clone state becomes daemon-
-// observable via ContainerStatus.Repos (reported over RPC in phase 1b, #642)
-// rather than buried in attach stderr. Issue #617, phase 1a of #423.
+// hand-rolled `if [ ! -d $DIR/.git ]; then git clone …; fi` blocks that team
+// blueprint templates duplicate in onInit scripts today. The clone state
+// becomes daemon-observable via ContainerStatus.Repos (reported over RPC in
+// phase 1b, #642) rather than buried in attach stderr. Issue #617, phase 1a of
+// #423.
 type ContainerRepo struct {
 	// Name is the operator-facing identifier for the repo, echoed back in
 	// per-repo status. Required.
@@ -374,8 +375,9 @@ type ContainerGit struct {
 	Sign []string `json:"sign,omitempty"           yaml:"sign,omitempty"`
 	// AllowedSigners is the absolute in-container path to git's SSH
 	// allowed-signers file (gpg.ssh.allowedSignersFile), used to verify
-	// signatures. Optional; rendered only when set. Crew sets this today, so
-	// the field exists for the env block to be a strict superset of crew's.
+	// signatures. Optional; rendered only when set. Team blueprint templates
+	// set this today, so the field exists for the env block to be a strict
+	// superset of what those templates render.
 	AllowedSigners string `json:"allowedSigners,omitempty" yaml:"allowedSigners,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- Add `.operator.TEAM_ROOT` (per-team), `.operator.HOME_DIR`, `.operator.REPO_OWNER`, `.project.PROJECT_DIR`, and `.project.AGENTS_REPO` to the blueprint-template dot-context the published agents-side blueprints reference. The kukeon-side counterpart of the agents-side `CREW_ROOT → TEAM_ROOT` rename (eminwux/agents#718) — `CREW_ROOT` retires here and the per-team scope is wired here.
- Extend `TeamsConfigSpec` with optional `HomeDir` / `RepoOwner` overrides; auto-default at render time (`\$HOME` and the agents source's owner segment) so the scaffolded global config stays minimal.
- Thread `composeTeam`'s already-resolved `projectDir` + `teamDir` into `teamrender.Inputs` so `.operator.TEAM_ROOT` and `.project.PROJECT_DIR` are populated per-render, and pass `bundle.Source` so `.project.AGENTS_REPO` / `.operator.REPO_OWNER` derive from the resolved agents source.
- Refresh present-tense `crew` vocabulary in source comments to the now-canonical `team` pipeline at `internal/ctr/spec.go`, `pkg/api/model/v1beta1/container.go`, and `internal/ctr/spec_git_env_test.go` (the listed test sibling, same rule). Three intentional history-note `crew` references remain (`cmd/kuketty/spec.go:69`, `internal/controller/runner/attachable.go:266`, `pkg/api/model/v1beta1/cellblueprint.go:84` — the `sbcrew` sibling-project name) per the issue's "leave history-note comments alone" carve-out.

## Notes for reviewer

- `RenderBlueprint`'s signature swaps trailing `project, realm, build, sourceRef` for `src teamsource.Source, in Inputs, project, realm` — mirrors the existing `BindConfig` shape and lets the new `.operator.TEAM_ROOT` / `.project.PROJECT_DIR` / `.project.AGENTS_REPO` keys flow through a single `Inputs` rather than five new positional params. All in-tree callers updated.
- `composeTeam` now resolves `teamDir` *before* `renderTeam` (was after); the resolved path drives `.operator.TEAM_ROOT` at render and the provisioning pass + drop-in-entry write below, so all three see the same path. No behavior change at the apply / provision / entry-write boundaries.
- The issue's "Possible scope extension" (eminwux/agents#719 decision-gated `Mounts`/`Repos` lookup fields) is deferred — the decision has not been made, so no schema extension lands here. The current `Sources` map continues to handle agents-source clone-URL overrides as before.
- Inlined the operator / project contract in a new `docs/site/cli/kuke-team-init.md` reference page (no existing per-verb doc for \`kuke team init\`); cross-links to \`docs/site/concepts/team.md\` for the declarative-surface contract.

## Test plan

- [x] \`make test\` (full root + kukebuild test suite) — passes
- [x] \`git grep -in 'crew' -- '*.go'\` — returns only three intentional history-note references (named above)
- [x] \`GOWORK=off go test ./internal/teamrender/... ./pkg/api/model/kuketeams/...\` — new unit tests pass:
  - blueprint that references each new \`.operator.*\` / \`.project.*\` key renders to the expected concrete value
  - REPO_OWNER falls back to the agents source's owner segment when no override is set
  - HOME_DIR falls back to \`\$HOME\` when no override is set
  - two Render() calls with different \`Inputs.TeamDir\` produce two different \`.operator.TEAM_ROOT\` values (the per-team-scope AC)
  - \`TeamsConfig.spec.homeDir\` / \`spec.repoOwner\` round-trip through JSON and YAML

Closes #1115