### PR TITLE
feat(team): kuke team init --validate one-pass render-contract check

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -134,7 +134,11 @@ func NewInitCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runInit(cmd, dryRun, build)
+			validate, err := cmd.Flags().GetBool("validate")
+			if err != nil {
+				return err
+			}
+			return runInit(cmd, dryRun, build, validate)
 		},
 	}
 
@@ -146,6 +150,13 @@ func NewInitCmd() *cobra.Command {
 		"build", false,
 		"Locally build the selected catalog images (kukebuild) into the target realm's containerd namespace; no registry push",
 	)
+	cmd.Flags().Bool(
+		"validate", false,
+		"Run every render-contract check (catalog, templates, partials, facts) once and print a single gap report; exit 1 on any gap. Applies nothing and writes nothing",
+	)
+	// --validate is a terminal contract-check mode; --build drives a local
+	// image build. They are mutually exclusive per #1116.
+	cmd.MarkFlagsMutuallyExclusive("build", "validate")
 
 	return cmd
 }
@@ -153,18 +164,79 @@ func NewInitCmd() *cobra.Command {
 // runInit gathers the cobra-coupled inputs (current directory, ~/.kuke layout,
 // git-config reader, project-repo-URL reader, daemon apply reader) and hands
 // them to composeTeam, which holds the testable lifecycle.
-func runInit(cmd *cobra.Command, dryRun, build bool) error {
+func runInit(cmd *cobra.Command, dryRun, build, validate bool) error {
 	projectDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("resolve current directory: %w", err)
 	}
 	layout := teamhost.NewLayout(config.DefaultKukeDir())
+	if validate {
+		return validateTeam(
+			cmd.Context(), cmd.OutOrStdout(), projectDir, layout,
+			gitConfigFromCmd(cmd), resolveFromCmd(cmd),
+		)
+	}
 	return composeTeam(
 		cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), projectDir, layout,
 		gitConfigFromCmd(cmd), projectRepoURLFromCmd(cmd), resolveFromCmd(cmd),
 		applyForTeamFromCmd(cmd), buildAllFromCmd(cmd),
 		dryRun, build,
 	)
+}
+
+// validateTeam runs the `kuke team init --validate` contract check: it reads
+// the project roster, loads (in-memory only — never scaffolds or writes) the
+// operator-global config so resolve can materialize the agents source under
+// the operator's identity, resolves the bundle, and hands it to
+// teamrender.Validate. The multi-section gap report is printed to out; a
+// non-empty gap set surfaces errdefs.ErrTeamValidateGaps so the command exits
+// non-zero. A harness-less roster has nothing to validate — the bundle is not
+// resolved (no clone) and the report is four empty sections (clean exit).
+//
+// validateTeam takes no cobra dependency so it is unit-testable with a temp
+// layout, a stub git-config reader, and a stub resolver — no live kukeond and
+// no network required.
+func validateTeam(
+	ctx context.Context,
+	out io.Writer,
+	projectDir string,
+	layout teamhost.Layout,
+	getGit GitConfigFunc,
+	resolve ResolveFunc,
+) error {
+	pt, err := readProjectTeam(projectDir)
+	if err != nil {
+		return err
+	}
+	project := strings.TrimSpace(pt.Metadata.Name)
+	if project == "" {
+		return errdefs.ErrTeamMetadataNameRequired
+	}
+
+	// dryRun=true holds the scaffold in memory: --validate must not write the
+	// operator-global facts file as a side effect of a read-only check.
+	tc, _, err := loadOrScaffoldGlobalConfig(ctx, layout, getGit, true)
+	if err != nil {
+		return err
+	}
+
+	var bundle *teamsource.Bundle
+	if len(pt.Spec.Defaults.Harnesses) > 0 && len(pt.Spec.Roles) > 0 {
+		cache := teamsource.NewCache(layout.CacheDir())
+		bundle, err = resolve(ctx, cache, tc, pt)
+		if err != nil {
+			return fmt.Errorf("resolve agents source: %w", err)
+		}
+	}
+
+	report := teamrender.Validate(bundle, pt)
+	if writeErr := report.Write(out); writeErr != nil {
+		return writeErr
+	}
+	if report.HasMiss() {
+		return fmt.Errorf("%w (%d)", errdefs.ErrTeamValidateGaps, report.MissCount())
+	}
+	return nil
 }
 
 // composeTeam runs the team-init lifecycle against explicit inputs:

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -1539,3 +1539,96 @@ func TestEmitSourceKind(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateTeamCleanExitsZero covers `kuke team init --validate` on a
+// roster whose catalog, templates, partials, and facts all check out: the gap
+// report prints all four section headers, validateTeam returns nil (exit 0),
+// and nothing is written to disk (no global config, no drop-in entry).
+func TestValidateTeamCleanExitsZero(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var out bytes.Buffer
+	if err := validateTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil), stubBundle(bundle),
+	); err != nil {
+		t.Fatalf("validateTeam: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{"== catalog ==", "== templates ==", "== partials ==", "== facts =="} {
+		if !strings.Contains(got, want) {
+			t.Errorf("report missing %q\n%s", want, got)
+		}
+	}
+	// Read-only: validate must not scaffold the global facts file or write the
+	// drop-in entry.
+	if _, err := os.Stat(layout.GlobalConfigPath()); !os.IsNotExist(err) {
+		t.Errorf("validate wrote global config (err=%v); must be read-only", err)
+	}
+	if _, err := os.Stat(layout.EntryPath("sbsh")); !os.IsNotExist(err) {
+		t.Errorf("validate wrote drop-in entry (err=%v); must be read-only", err)
+	}
+}
+
+// TestValidateTeamGapExitsNonZero covers the non-zero exit: a catalog gap
+// surfaces ErrTeamValidateGaps so the CLI exits 1, while the report still
+// prints.
+func TestValidateTeamGapExitsNonZero(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+	// Drop a capability the dev role needs (go,git) so SelectImage misses.
+	bundle.ImageCatalog.Spec.Images[0].Capabilities = []string{"go"}
+
+	var out bytes.Buffer
+	err := validateTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil), stubBundle(bundle),
+	)
+	if !errors.Is(err, errdefs.ErrTeamValidateGaps) {
+		t.Fatalf("err = %v, want ErrTeamValidateGaps", err)
+	}
+	if !strings.Contains(out.String(), `capability "git" not provided by any claude image`) {
+		t.Errorf("report should name the unmet capability:\n%s", out.String())
+	}
+}
+
+// TestValidateTeamHarnessLessRosterSkipsResolve covers the harness-less
+// roster: there is nothing to validate, so resolve is never called (a clone is
+// not triggered) and the four empty sections still render at exit 0.
+func TestValidateTeamHarnessLessRosterSkipsResolve(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamYAML) // no defaults.harnesses
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+
+	var out bytes.Buffer
+	if err := validateTeam(
+		context.Background(), &out, projectDir, layout,
+		stubGit(nil), stubResolveErr(), // resolve must not be called
+	); err != nil {
+		t.Fatalf("validateTeam: %v", err)
+	}
+	for _, want := range []string{"== catalog ==", "== templates ==", "== partials ==", "== facts =="} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("report missing %q\n%s", want, out.String())
+		}
+	}
+}
+
+// TestInitValidateBuildMutuallyExclusive covers the cobra-level guard: passing
+// both --build and --validate is rejected before any side effect runs.
+func TestInitValidateBuildMutuallyExclusive(t *testing.T) {
+	t.Parallel()
+	cmd := NewInitCmd()
+	cmd.SetArgs([]string{"--build", "--validate"})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected mutual-exclusion error for --build --validate, got nil")
+	}
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -695,4 +695,11 @@ var (
 	ErrTeamHarnessSeedPathEscapes = errors.New(
 		"harness seeds[].path escapes the per-team root after expansion",
 	)
+	// ErrTeamValidateGaps fires when `kuke team init --validate` finds one or
+	// more contract gaps (catalog miss, unresolved template path, unbound
+	// partial reference, or unbound fact reference). The gap report is printed
+	// to stdout; this sentinel drives the non-zero exit.
+	ErrTeamValidateGaps = errors.New(
+		"team validate found one or more contract gaps",
+	)
 )

--- a/internal/teamrender/validate.go
+++ b/internal/teamrender/validate.go
@@ -1,0 +1,567 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teamrender
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/template"
+	"text/template/parse"
+
+	"github.com/eminwux/kukeon/internal/teamsource"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+)
+
+// Section titles for the validate report. Exported so consumers (and tests)
+// can key off the canonical names rather than string literals.
+const (
+	SectionCatalog   = "catalog"
+	SectionTemplates = "templates"
+	SectionPartials  = "partials"
+	SectionFacts     = "facts"
+)
+
+// ReportLine is one outcome row in a validate section. OK distinguishes a
+// satisfied check from a gap; Detail carries the human-readable body the
+// report writer prints after the `ok`/`miss` status column.
+type ReportLine struct {
+	OK     bool
+	Detail string
+}
+
+// ReportSection groups the outcome lines for one of the four contract
+// checks. Title is one of the Section* constants.
+type ReportSection struct {
+	Title string
+	Lines []ReportLine
+}
+
+// ValidationReport is the full one-pass contract check produced by Validate:
+// four sections (catalog, templates, partials, facts), each carrying its
+// ok/miss lines in a stable order. Write renders it; HasMiss / MissCount
+// drive the caller's exit code.
+type ValidationReport struct {
+	Sections []ReportSection
+}
+
+// MissCount returns the total number of miss lines across every section.
+func (r *ValidationReport) MissCount() int {
+	n := 0
+	for _, s := range r.Sections {
+		for _, l := range s.Lines {
+			if !l.OK {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// HasMiss reports whether any section carries at least one miss line.
+func (r *ValidationReport) HasMiss() bool { return r.MissCount() > 0 }
+
+// Write renders the report to w as the multi-section gap report. Each section
+// is headed by `== <title> ==` and each line by a fixed-width `ok`/`miss`
+// status column, so the catalog/templates ok lines and the partials/facts
+// miss lines line up regardless of body width. Sections are separated by a
+// blank line; all four section headers are always emitted (a clean section is
+// just its header) so the operator can tell a passed check from a skipped one.
+func (r *ValidationReport) Write(w io.Writer) error {
+	for i, s := range r.Sections {
+		if i > 0 {
+			if _, err := fmt.Fprintln(w); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(w, "== %s ==\n", s.Title); err != nil {
+			return err
+		}
+		for _, l := range s.Lines {
+			status := "miss"
+			if l.OK {
+				status = "ok"
+			}
+			if _, err := fmt.Fprintf(w, "%-4s %s\n", status, l.Detail); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Validate runs the one-pass contract check across a resolved Bundle and a
+// project roster. Unlike Render — which fails fast on the first catalog miss
+// or template error — Validate visits every (role × harness) pair and every
+// selected harness, collecting all gaps into a single report so an operator
+// fixes the whole drift in one pass rather than one error per re-run.
+//
+// The four sections mirror the render pipeline's failure surfaces:
+//
+//  1. catalog   — for every (role × harness), does SelectImage find a match?
+//     ok lines name the selected catalog ref; miss lines name the first
+//     unmet capability (or the no-single-image case).
+//  2. templates — for every selected harness, does harness.Spec.Template
+//     resolve under the materialized cache (relative to the harness dir, per
+//     #1110)?
+//  3. partials  — parse every harness's blueprint template set; for every
+//     `{{ template "name" }}` invocation, does a matching `{{ define }}`
+//     exist in the harness's partial set?
+//  4. facts     — for every `{{ .operator.X }}` / `{{ .project.X }}`
+//     reference in any template body, does the render dot-context expose the
+//     key? (Checked against the known fact schema, not the populated subset —
+//     an unset-but-known fact renders empty, not a gap.)
+//
+// A nil or empty bundle (the harness-less roster) yields four empty sections
+// and no misses — there is nothing to validate. Validate writes nothing to
+// disk beyond reading the already-materialized template files, and never
+// returns an error for a gap: gaps live in the report (HasMiss / MissCount).
+//
+// The fact check is value-independent — it compares referenced keys against
+// the dot-context's key *schema*, not an operator's populated subset — so
+// Validate needs neither the TeamsConfig nor the per-run Inputs that Render
+// consumes.
+func Validate(
+	bundle *teamsource.Bundle,
+	pt *model.ProjectTeam,
+) *ValidationReport {
+	roles := map[string]*model.Role{}
+	harnessesByName := map[string]*model.Harness{}
+	var ic *model.ImageCatalog
+	cacheDir := ""
+	if bundle != nil {
+		roles = bundle.Roles
+		harnessesByName = bundle.Harnesses
+		ic = bundle.ImageCatalog
+		cacheDir = bundle.CacheDir
+	}
+
+	harnessNames := rosterHarnessNames(pt)
+
+	return &ValidationReport{
+		Sections: []ReportSection{
+			validateCatalog(pt, roles, ic),
+			validateTemplates(cacheDir, harnessNames, harnessesByName),
+			validatePartials(cacheDir, harnessNames, harnessesByName),
+			validateFacts(cacheDir, harnessNames, harnessesByName),
+		},
+	}
+}
+
+// rosterHarnessNames returns the deduplicated, lexicographically sorted set
+// of harness names the roster's defaults declare. Sorting pins a stable
+// section order independent of the (slice) declaration order.
+func rosterHarnessNames(pt *model.ProjectTeam) []string {
+	if pt == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(pt.Spec.Defaults.Harnesses))
+	for _, h := range pt.Spec.Defaults.Harnesses {
+		name := strings.TrimSpace(h)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// validateCatalog walks every (role × harness) pair and records whether
+// SelectImage finds a match. Lines are sorted by their `role × harness`
+// body so two runs against the same roster emit byte-identical output.
+func validateCatalog(
+	pt *model.ProjectTeam,
+	roles map[string]*model.Role,
+	ic *model.ImageCatalog,
+) ReportSection {
+	sec := ReportSection{Title: SectionCatalog}
+	if pt == nil {
+		return sec
+	}
+	harnessNames := rosterHarnessNames(pt)
+	for _, ptRole := range pt.Spec.Roles {
+		role := roles[ptRole.Ref]
+		var roleImageNeeds []string
+		if role != nil {
+			roleImageNeeds = role.Spec.Needs.Image
+		}
+		merged := MergeNeeds(roleImageNeeds, ptRoleImageNeeds(ptRole))
+		for _, hname := range harnessNames {
+			pair := fmt.Sprintf("%s × %s", ptRole.Ref, hname)
+			entry, err := SelectImage(ic, hname, merged)
+			if err == nil {
+				sec.Lines = append(sec.Lines, ReportLine{
+					OK:     true,
+					Detail: fmt.Sprintf("%s → %s", pair, entry.Ref),
+				})
+				continue
+			}
+			sec.Lines = append(sec.Lines, ReportLine{
+				OK:     false,
+				Detail: fmt.Sprintf("%s → %s", pair, catalogMissReason(ic, hname, merged)),
+			})
+		}
+	}
+	sortLines(sec.Lines)
+	return sec
+}
+
+// catalogMissReason produces the concise reason a (harness × needs) pick
+// failed: the empty-catalog case, the first capability no harness-matching
+// image provides, or the no-single-image-carries-all case. It mirrors
+// SelectImage's branching without the operator-actionable build/label hint
+// (the report header already frames the section as actionable gaps).
+func catalogMissReason(ic *model.ImageCatalog, harness string, needs []string) string {
+	if ic == nil || len(ic.Spec.Images) == 0 {
+		return fmt.Sprintf("no image in images.yaml for harness %q", harness)
+	}
+	if unmet := firstUnmet(ic, harness, needs); unmet != "" {
+		return fmt.Sprintf("capability %q not provided by any %s image", unmet, harness)
+	}
+	return fmt.Sprintf("no single %s image carries all of %v", harness, needs)
+}
+
+// validateTemplates checks that every selected harness's spec.template
+// resolves to a file under the materialized cache (relative to the harness
+// dir, per #1110). harnessNames is already sorted, so the lines are stable.
+func validateTemplates(
+	cacheDir string,
+	harnessNames []string,
+	harnesses map[string]*model.Harness,
+) ReportSection {
+	sec := ReportSection{Title: SectionTemplates}
+	for _, hname := range harnessNames {
+		h := harnesses[hname]
+		tmpl := ""
+		if h != nil {
+			tmpl = strings.TrimSpace(h.Spec.Template)
+		}
+		if tmpl == "" {
+			sec.Lines = append(sec.Lines, ReportLine{
+				OK:     false,
+				Detail: fmt.Sprintf("harnesses/%s — spec.template is empty", hname),
+			})
+			continue
+		}
+		rel := templateDisplayPath(hname, tmpl)
+		full := tplFullPath(cacheDir, hname, tmpl)
+		if _, err := os.Stat(full); err != nil {
+			sec.Lines = append(sec.Lines, ReportLine{
+				OK:     false,
+				Detail: fmt.Sprintf("%s — template: %s not found", rel, tmpl),
+			})
+			continue
+		}
+		sec.Lines = append(sec.Lines, ReportLine{OK: true, Detail: rel})
+	}
+	return sec
+}
+
+// validatePartials parses each selected harness's template set (main
+// blueprint + sibling *.tmpl.yaml partials) and verifies every
+// `{{ template "name" }}` invocation resolves to a `{{ define "name" }}` in
+// the set. A template that fails to read or parse is itself a miss. Only
+// miss lines are emitted — a resolved invocation is unremarkable and would
+// flood the report — so a clean section is just its header.
+func validatePartials(
+	cacheDir string,
+	harnessNames []string,
+	harnesses map[string]*model.Harness,
+) ReportSection {
+	sec := ReportSection{Title: SectionPartials}
+	for _, hname := range harnessNames {
+		h := harnesses[hname]
+		if h == nil || strings.TrimSpace(h.Spec.Template) == "" {
+			// Missing/empty template is reported by validateTemplates; nothing
+			// to parse here.
+			continue
+		}
+		tmpl := strings.TrimSpace(h.Spec.Template)
+		full := tplFullPath(cacheDir, hname, tmpl)
+		raw, err := os.ReadFile(full)
+		if err != nil {
+			// Unresolved path is reported by validateTemplates; skip.
+			continue
+		}
+		tpl, parseErr := parseBlueprintTemplate(full, raw)
+		if parseErr != nil {
+			sec.Lines = append(sec.Lines, ReportLine{
+				OK:     false,
+				Detail: fmt.Sprintf("%s — parse error: %v", templateDisplayPath(hname, tmpl), parseErr),
+			})
+			continue
+		}
+
+		defined := definedTemplateNames(tpl)
+		type ref struct{ name, loc string }
+		seen := map[ref]struct{}{}
+		var misses []ReportLine
+		for _, t := range tpl.Templates() {
+			if t.Tree == nil || t.Tree.Root == nil {
+				continue
+			}
+			loc := templateDisplayPath(hname, t.Name())
+			walkNodes(t.Tree.Root, func(n parse.Node) {
+				tn, ok := n.(*parse.TemplateNode)
+				if !ok {
+					return
+				}
+				if _, isDefined := defined[tn.Name]; isDefined {
+					return
+				}
+				key := ref{name: tn.Name, loc: loc}
+				if _, dup := seen[key]; dup {
+					return
+				}
+				seen[key] = struct{}{}
+				misses = append(misses, ReportLine{
+					OK: false,
+					Detail: fmt.Sprintf(
+						"%s uses template %q, no {{ define }} found", loc, tn.Name,
+					),
+				})
+			})
+		}
+		sortLines(misses)
+		sec.Lines = append(sec.Lines, misses...)
+	}
+	return sec
+}
+
+// validateFacts parses each selected harness's template set and verifies
+// every `{{ .operator.X }}` / `{{ .project.X }}` reference names a key the
+// render dot-context exposes. The known key sets are derived from
+// renderContextValues itself (see knownFactKeys) so the validator can never
+// drift from the renderer. Only miss lines are emitted, deduplicated by
+// (root, key, location) and stable-sorted.
+func validateFacts(
+	cacheDir string,
+	harnessNames []string,
+	harnesses map[string]*model.Harness,
+) ReportSection {
+	sec := ReportSection{Title: SectionFacts}
+	knownOperator, knownProject := knownFactKeys()
+
+	for _, hname := range harnessNames {
+		h := harnesses[hname]
+		if h == nil || strings.TrimSpace(h.Spec.Template) == "" {
+			continue
+		}
+		tmpl := strings.TrimSpace(h.Spec.Template)
+		full := tplFullPath(cacheDir, hname, tmpl)
+		raw, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+		tpl, parseErr := parseBlueprintTemplate(full, raw)
+		if parseErr != nil {
+			// Parse error already surfaces in the partials section.
+			continue
+		}
+
+		type ref struct{ root, key, loc string }
+		seen := map[ref]struct{}{}
+		var misses []ReportLine
+		for _, t := range tpl.Templates() {
+			if t.Tree == nil || t.Tree.Root == nil {
+				continue
+			}
+			loc := templateDisplayPath(hname, t.Name())
+			walkNodes(t.Tree.Root, func(n parse.Node) {
+				fn, ok := n.(*parse.FieldNode)
+				if !ok || len(fn.Ident) < 2 {
+					return
+				}
+				root := fn.Ident[0]
+				key := fn.Ident[1]
+				var known map[string]struct{}
+				switch root {
+				case "operator":
+					known = knownOperator
+				case "project":
+					known = knownProject
+				default:
+					return
+				}
+				if _, isKnown := known[key]; isKnown {
+					return
+				}
+				rk := ref{root: root, key: key, loc: loc}
+				if _, dup := seen[rk]; dup {
+					return
+				}
+				seen[rk] = struct{}{}
+				misses = append(misses, ReportLine{
+					OK: false,
+					Detail: fmt.Sprintf(
+						".%s.%s referenced in %s, not bound", root, key, loc,
+					),
+				})
+			})
+		}
+		sortLines(misses)
+		sec.Lines = append(sec.Lines, misses...)
+	}
+	return sec
+}
+
+// knownFactKeys returns the set of `.operator.*` and `.project.*` keys the
+// render dot-context can expose. It is derived by running renderContextValues
+// against a fully-saturated set of inputs (every conditionally-populated key
+// made non-empty so the renderer emits all of them) and reading the resulting
+// map keys — so the validator's known set is exactly what the renderer
+// produces, with no second hand-maintained list to drift. The keys depend
+// only on which inputs are present, not their values, so synthetic
+// placeholders suffice.
+func knownFactKeys() (map[string]struct{}, map[string]struct{}) {
+	satTC := &model.TeamsConfig{
+		Spec: model.TeamsConfigSpec{
+			Registry:  "_",
+			HomeDir:   "_",
+			RepoOwner: "_",
+		},
+	}
+	// Author is a promoted field from the embedded ContainerGit, so it is set
+	// by assignment rather than in the composite literal above.
+	satTC.Spec.Git = &model.TeamsConfigGit{}
+	satTC.Spec.Git.Author = &v1beta1.GitIdentity{Name: "_", Email: "_"}
+
+	satSrc := teamsource.Source{Host: "_", OwnerRepo: "_/_"}
+	satIn := Inputs{ProjectDir: "_", TeamDir: "_"}
+
+	ctx := renderContextValues("_", "_", nil, nil, nil, satTC, satSrc, satIn, "_", DefaultRealm)
+	op := keySet(ctx["operator"])
+	pr := keySet(ctx["project"])
+	return op, pr
+}
+
+// keySet returns the set of keys of v when v is a map[string]string (the
+// shape renderContextValues uses for the operator/project leaves), or an
+// empty set otherwise.
+func keySet(v any) map[string]struct{} {
+	out := map[string]struct{}{}
+	m, ok := v.(map[string]string)
+	if !ok {
+		return out
+	}
+	for k := range m {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+// definedTemplateNames returns the set of template names actually defined in
+// the parsed set — every associated template whose parse tree is non-nil.
+// An invoked-but-undefined `{{ template "x" }}` does not register a tree, so
+// it is absent here and reads as a partials miss.
+func definedTemplateNames(tpl *template.Template) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, t := range tpl.Templates() {
+		if t.Tree != nil {
+			out[t.Name()] = struct{}{}
+		}
+	}
+	return out
+}
+
+// tplFullPath resolves the on-disk path of a harness's blueprint template,
+// matching RenderBlueprint's resolution (harness-dir-relative, per #1110).
+func tplFullPath(cacheDir, harness, template string) string {
+	return teamsource.HarnessDir(cacheDir, harness) + "/" + template
+}
+
+// templateDisplayPath renders the report-facing path of a template body. For
+// the main blueprint and sibling partial files name is the filename, yielding
+// `harnesses/<h>/<file>`; for a `{{ define }}` block the name is the define
+// label, yielding `harnesses/<h>/<label>` — informative enough to locate the
+// reference without the renderer tracking per-node source positions.
+func templateDisplayPath(harness, name string) string {
+	return "harnesses/" + harness + "/" + name
+}
+
+// sortLines orders report lines by Detail so a section's output is stable
+// across runs regardless of map-iteration or discovery order.
+func sortLines(lines []ReportLine) {
+	sort.SliceStable(lines, func(i, j int) bool {
+		return lines[i].Detail < lines[j].Detail
+	})
+}
+
+// walkNodes visits node and every descendant, invoking visit on each. It
+// covers the template parse-tree node kinds the blueprint contract uses
+// (actions, pipelines, the if/range/with branches, template invocations, and
+// chained field access); leaf nodes (FieldNode, TextNode, …) are visited but
+// have no children to recurse into.
+func walkNodes(node parse.Node, visit func(parse.Node)) {
+	if node == nil {
+		return
+	}
+	visit(node)
+	switch n := node.(type) {
+	case *parse.ListNode:
+		if n == nil {
+			return
+		}
+		for _, c := range n.Nodes {
+			walkNodes(c, visit)
+		}
+	case *parse.ActionNode:
+		walkNodes(n.Pipe, visit)
+	case *parse.PipeNode:
+		if n == nil {
+			return
+		}
+		for _, c := range n.Cmds {
+			walkNodes(c, visit)
+		}
+	case *parse.CommandNode:
+		for _, a := range n.Args {
+			walkNodes(a, visit)
+		}
+	case *parse.IfNode:
+		walkBranch(n.Pipe, n.List, n.ElseList, visit)
+	case *parse.RangeNode:
+		walkBranch(n.Pipe, n.List, n.ElseList, visit)
+	case *parse.WithNode:
+		walkBranch(n.Pipe, n.List, n.ElseList, visit)
+	case *parse.TemplateNode:
+		walkNodes(n.Pipe, visit)
+	case *parse.ChainNode:
+		walkNodes(n.Node, visit)
+	}
+}
+
+// walkBranch recurses into the pipeline, body, and else-body of an
+// if/range/with node.
+func walkBranch(pipe *parse.PipeNode, list, elseList *parse.ListNode, visit func(parse.Node)) {
+	walkNodes(pipe, visit)
+	if list != nil {
+		walkNodes(list, visit)
+	}
+	if elseList != nil {
+		walkNodes(elseList, visit)
+	}
+}

--- a/internal/teamrender/validate_test.go
+++ b/internal/teamrender/validate_test.go
@@ -1,0 +1,412 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package teamrender
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/teamsource"
+	model "github.com/eminwux/kukeon/pkg/api/model/kuketeams"
+)
+
+// sectionByTitle returns the named section from a report, failing the test if
+// it is absent (every report must render all four).
+func sectionByTitle(t *testing.T, r *ValidationReport, title string) ReportSection {
+	t.Helper()
+	for _, s := range r.Sections {
+		if s.Title == title {
+			return s
+		}
+	}
+	t.Fatalf("report missing section %q", title)
+	return ReportSection{}
+}
+
+// hasMissContaining reports whether the section carries a miss line whose
+// Detail contains every one of subs.
+func hasMissContaining(s ReportSection, subs ...string) bool {
+	return hasLineContaining(s, false, subs...)
+}
+
+// hasOKContaining reports whether the section carries an ok line whose Detail
+// contains every one of subs.
+func hasOKContaining(s ReportSection, subs ...string) bool {
+	return hasLineContaining(s, true, subs...)
+}
+
+func hasLineContaining(s ReportSection, ok bool, subs ...string) bool {
+	for _, l := range s.Lines {
+		if l.OK != ok {
+			continue
+		}
+		all := true
+		for _, sub := range subs {
+			if !strings.Contains(l.Detail, sub) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}
+
+// twoHarnessBundle builds a bundle with a single "dev" role declaring the
+// given image needs, a claude harness + image that satisfies them, and an
+// opencode harness whose image is missing one capability — exercising one
+// catalog ok and one catalog miss in the same pass. claude's template is
+// always "blueprint.tmpl.yaml"; opencodeTmpl varies per test (use "" to leave
+// opencode's spec.template empty). The caller pre-writes the matching files
+// under cacheDir with writeHarnessFile.
+func twoHarnessBundle(
+	cacheDir string,
+	devNeeds []string,
+	opencodeTmpl string,
+) (*teamsource.Bundle, *model.ProjectTeam) {
+	const claudeTmpl = "blueprint.tmpl.yaml"
+	role := &model.Role{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindRole,
+		Metadata:   model.Metadata{Name: "dev"},
+		Spec: model.RoleSpec{
+			Needs: model.RoleNeeds{Image: devNeeds},
+		},
+	}
+	ic := &model.ImageCatalog{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindImageCatalog,
+		Spec: model.ImageCatalogSpec{
+			Images: []model.ImageCatalogEntry{
+				{
+					Ref:          "claude",
+					Harness:      "claude",
+					Image:        "registry.local/claude:latest",
+					Capabilities: devNeeds, // superset of itself → claude matches
+				},
+				{
+					Ref:          "opencode",
+					Harness:      "opencode",
+					Image:        "registry.local/opencode:latest",
+					Capabilities: []string{}, // provides nothing → first need unmet
+				},
+			},
+		},
+	}
+	bundle := &teamsource.Bundle{
+		Source:   teamsource.Source{Host: "github.com", OwnerRepo: "eminwux/agents", Ref: "v1"},
+		CacheDir: cacheDir,
+		Roles:    map[string]*model.Role{"dev": role},
+		Harnesses: map[string]*model.Harness{
+			"claude": {
+				APIVersion: model.APIVersionV1,
+				Kind:       model.KindHarness,
+				Metadata:   model.Metadata{Name: "claude"},
+				Spec:       model.HarnessSpec{Template: claudeTmpl},
+			},
+			"opencode": {
+				APIVersion: model.APIVersionV1,
+				Kind:       model.KindHarness,
+				Metadata:   model.Metadata{Name: "opencode"},
+				Spec:       model.HarnessSpec{Template: opencodeTmpl},
+			},
+		},
+		ImageCatalog: ic,
+	}
+	pt := &model.ProjectTeam{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindProjectTeam,
+		Metadata:   model.Metadata{Name: "proj"},
+		Spec: model.ProjectTeamSpec{
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude", "opencode"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	return bundle, pt
+}
+
+func TestValidateCatalogOKAndMiss(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	// Both harnesses get a present template so this test isolates the catalog
+	// section.
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	writeHarnessFile(t, cacheDir, "opencode", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go", "git"}, "blueprint.tmpl.yaml")
+
+	rep := Validate(bundle, pt)
+	cat := sectionByTitle(t, rep, SectionCatalog)
+
+	if !hasOKContaining(cat, "dev × claude", "→ claude") {
+		t.Errorf("catalog missing ok line for dev × claude: %+v", cat.Lines)
+	}
+	if !hasMissContaining(cat, "dev × opencode", `capability "git" not provided by any opencode image`) {
+		t.Errorf("catalog missing expected miss for dev × opencode: %+v", cat.Lines)
+	}
+	if !rep.HasMiss() {
+		t.Errorf("report should report a miss")
+	}
+}
+
+func TestValidateCatalogEmptyCatalog(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "blueprint.tmpl.yaml")
+	bundle.ImageCatalog = &model.ImageCatalog{
+		APIVersion: model.APIVersionV1, Kind: model.KindImageCatalog,
+		Spec: model.ImageCatalogSpec{},
+	}
+
+	rep := Validate(bundle, pt)
+	cat := sectionByTitle(t, rep, SectionCatalog)
+	if !hasMissContaining(cat, "dev × claude", "no image in images.yaml for harness") {
+		t.Errorf("expected empty-catalog miss reason: %+v", cat.Lines)
+	}
+}
+
+func TestValidateTemplatesOKAndMiss(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	// claude's template exists on disk; opencode's is declared but absent.
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "blueprint.tmpl.yaml")
+
+	rep := Validate(bundle, pt)
+	tmpls := sectionByTitle(t, rep, SectionTemplates)
+
+	if !hasOKContaining(tmpls, "harnesses/claude/blueprint.tmpl.yaml") {
+		t.Errorf("templates missing ok line for claude: %+v", tmpls.Lines)
+	}
+	if !hasMissContaining(tmpls, "harnesses/opencode/blueprint.tmpl.yaml", "template: blueprint.tmpl.yaml not found") {
+		t.Errorf("templates missing not-found miss for opencode: %+v", tmpls.Lines)
+	}
+}
+
+func TestValidateTemplatesEmptyTemplatePath(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	// opencode declares no template at all.
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "")
+
+	rep := Validate(bundle, pt)
+	tmpls := sectionByTitle(t, rep, SectionTemplates)
+	if !hasMissContaining(tmpls, "harnesses/opencode", "spec.template is empty") {
+		t.Errorf("expected empty-template miss for opencode: %+v", tmpls.Lines)
+	}
+}
+
+func TestValidatePartialsDetectsUnboundReference(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	// claude references a partial that is never defined; opencode references
+	// one that a sibling defines.
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml",
+		"kind: CellBlueprint\n{{ template \"mount_source\" . }}\n")
+	writeHarnessFile(t, cacheDir, "opencode", "blueprint.tmpl.yaml",
+		"kind: CellBlueprint\n{{ template \"mounts\" . }}\n")
+	writeHarnessFile(t, cacheDir, "opencode", "partials.tmpl.yaml",
+		"{{ define \"mounts\" }}m{{ end }}\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "blueprint.tmpl.yaml")
+
+	rep := Validate(bundle, pt)
+	partials := sectionByTitle(t, rep, SectionPartials)
+
+	if !hasMissContaining(
+		partials,
+		"harnesses/claude/blueprint.tmpl.yaml",
+		`uses template "mount_source"`,
+		"no {{ define }} found",
+	) {
+		t.Errorf("partials missing unbound-reference miss: %+v", partials.Lines)
+	}
+	// opencode's reference resolves → no miss naming it.
+	if hasMissContaining(partials, "opencode") {
+		t.Errorf("opencode partial reference is defined and must not be flagged: %+v", partials.Lines)
+	}
+}
+
+func TestValidatePartialsCleanWhenAllResolved(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml",
+		"kind: CellBlueprint\n{{ template \"x\" . }}\n")
+	writeHarnessFile(t, cacheDir, "claude", "partials.tmpl.yaml",
+		"{{ define \"x\" }}y{{ end }}\n")
+	// Single-harness roster keeps the focus on partials.
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "blueprint.tmpl.yaml")
+	writeHarnessFile(t, cacheDir, "opencode", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+
+	rep := Validate(bundle, pt)
+	partials := sectionByTitle(t, rep, SectionPartials)
+	for _, l := range partials.Lines {
+		if !l.OK {
+			t.Errorf("expected no partial misses, got: %q", l.Detail)
+		}
+	}
+}
+
+func TestValidateFactsDetectsUnboundKey(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	// References one known operator key, one known project key, and one
+	// unknown operator key — only the unknown is a miss.
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml",
+		"name: {{ .project.NAME }}\nuser: {{ .operator.GIT_USER_NAME }}\nbad: {{ .operator.UNKNOWN_KEY }}\n")
+	writeHarnessFile(t, cacheDir, "opencode", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "blueprint.tmpl.yaml")
+
+	rep := Validate(bundle, pt)
+	facts := sectionByTitle(t, rep, SectionFacts)
+
+	if !hasMissContaining(facts, ".operator.UNKNOWN_KEY", "harnesses/claude/blueprint.tmpl.yaml", "not bound") {
+		t.Errorf("facts missing unbound-key miss: %+v", facts.Lines)
+	}
+	if hasMissContaining(facts, "GIT_USER_NAME") || hasMissContaining(facts, "NAME") {
+		t.Errorf("known facts must not be flagged: %+v", facts.Lines)
+	}
+}
+
+func TestValidateFactsAllKnownKeysClean(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	knownOp, knownPr := knownFactKeys()
+	var b strings.Builder
+	b.WriteString("kind: CellBlueprint\n")
+	for k := range knownOp {
+		b.WriteString("o: {{ .operator." + k + " }}\n")
+	}
+	for k := range knownPr {
+		b.WriteString("p: {{ .project." + k + " }}\n")
+	}
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", b.String())
+	writeHarnessFile(t, cacheDir, "opencode", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "blueprint.tmpl.yaml")
+
+	rep := Validate(bundle, pt)
+	facts := sectionByTitle(t, rep, SectionFacts)
+	for _, l := range facts.Lines {
+		if !l.OK {
+			t.Errorf("known fact key flagged as unbound: %q", l.Detail)
+		}
+	}
+}
+
+// TestKnownFactKeysCoverRendererContract pins the fact schema the validator
+// checks against, so a future renderContextValues key add/remove that this
+// derivation misses is caught here rather than silently passing validate.
+func TestKnownFactKeysCoverRendererContract(t *testing.T) {
+	t.Parallel()
+	op, pr := knownFactKeys()
+	wantOp := []string{"REGISTRY", "GIT_USER_NAME", "GIT_USER_EMAIL", "TEAM_ROOT", "HOME_DIR", "REPO_OWNER"}
+	for _, k := range wantOp {
+		if _, ok := op[k]; !ok {
+			t.Errorf("known operator keys missing %q (have %v)", k, op)
+		}
+	}
+	wantPr := []string{"NAME", "PROJECT_DIR", "AGENTS_REPO"}
+	for _, k := range wantPr {
+		if _, ok := pr[k]; !ok {
+			t.Errorf("known project keys missing %q (have %v)", k, pr)
+		}
+	}
+}
+
+func TestValidateHarnessLessRosterEmptySections(t *testing.T) {
+	t.Parallel()
+	pt := &model.ProjectTeam{
+		APIVersion: model.APIVersionV1, Kind: model.KindProjectTeam,
+		Metadata: model.Metadata{Name: "proj"},
+		Spec:     model.ProjectTeamSpec{}, // no roles, no harnesses
+	}
+	rep := Validate(nil, pt)
+	if rep.HasMiss() {
+		t.Errorf("harness-less roster should have no misses: %d", rep.MissCount())
+	}
+	for _, title := range []string{SectionCatalog, SectionTemplates, SectionPartials, SectionFacts} {
+		s := sectionByTitle(t, rep, title)
+		if len(s.Lines) != 0 {
+			t.Errorf("section %q should be empty for harness-less roster: %+v", title, s.Lines)
+		}
+	}
+}
+
+func TestValidateReportWriteFormat(t *testing.T) {
+	t.Parallel()
+	rep := &ValidationReport{Sections: []ReportSection{
+		{Title: SectionCatalog, Lines: []ReportLine{
+			{OK: true, Detail: "dev × claude → claude"},
+			{OK: false, Detail: "pm × opencode → capability \"android\" not provided by any opencode image"},
+		}},
+		{Title: SectionTemplates},
+		{Title: SectionPartials},
+		{Title: SectionFacts},
+	}}
+	var b strings.Builder
+	if err := rep.Write(&b); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got := b.String()
+	for _, want := range []string{
+		"== catalog ==\n",
+		"ok   dev × claude → claude\n",
+		"miss pm × opencode → capability \"android\" not provided by any opencode image\n",
+		"== templates ==\n",
+		"== partials ==\n",
+		"== facts ==\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Write output missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+	// Sections are separated by a blank line.
+	if !strings.Contains(got, "image\n\n== templates ==") {
+		t.Errorf("expected blank line between sections:\n%s", got)
+	}
+}
+
+// TestValidateDeterministicOutput asserts two runs against the same inputs
+// produce byte-identical reports (the AC's stable-ordering requirement),
+// including across the map-iterated harness/fact discovery.
+func TestValidateDeterministicOutput(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	writeHarnessFile(
+		t,
+		cacheDir,
+		"claude",
+		"blueprint.tmpl.yaml",
+		"kind: CellBlueprint\na: {{ .operator.UNKNOWN_A }}\nb: {{ .operator.UNKNOWN_B }}\n{{ template \"undef_a\" . }}{{ template \"undef_b\" . }}\n",
+	)
+	writeHarnessFile(t, cacheDir, "opencode", "blueprint.tmpl.yaml",
+		"kind: CellBlueprint\nc: {{ .project.UNKNOWN_C }}\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go", "git"}, "blueprint.tmpl.yaml")
+
+	var first, second strings.Builder
+	if err := Validate(bundle, pt).Write(&first); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := Validate(bundle, pt).Write(&second); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if first.String() != second.String() {
+		t.Errorf("non-deterministic report:\n--- first ---\n%s\n--- second ---\n%s", first.String(), second.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `--validate` mode to `kuke team init` (step 8 of the **team2** epic, #1117) that runs every render-contract check once and prints a single gap report, instead of surfacing one drift error per re-run during render.
- `--validate` is mutually exclusive with `--build` (cobra `MarkFlagsMutuallyExclusive`); it applies nothing and writes nothing (the operator-global facts scaffold is held in memory only, the drop-in entry is never written).
- New `teamrender.Validate(bundle, pt) *ValidationReport` runs the four checks the issue specifies, reusing the existing render helpers (`SelectImage`/`firstUnmet`, `parseBlueprintTemplate`, `renderContextValues`, `HarnessDir`) so the validator can never drift from the renderer:
  1. **catalog** — every `(role × harness)` pair run through `SelectImage`; ok lines name the selected catalog ref, miss lines name the first unmet capability (or the no-single-image case).
  2. **templates** — every selected harness's `spec.template` resolved relative to the harness dir (per #1110).
  3. **partials** — each blueprint template set parsed; every `{{ template "name" }}` invocation checked against the set's `{{ define }}` blocks (parse-tree walk, not regex).
  4. **facts** — every `{{ .operator.X }}` / `{{ .project.X }}` reference checked against the dot-context key schema. The known-key set is **derived from `renderContextValues` itself** (saturated synthetic inputs), so a future renderer key add/remove can't silently diverge from the validator; `TestKnownFactKeysCoverRendererContract` pins it.
- Non-zero exit on any gap via new `errdefs.ErrTeamValidateGaps`; clean validate exits 0. Every section header always renders (a clean section is just its header).

## Design notes for the reviewer

- **Separate `validateTeam` dispatch rather than threading a `validate bool` through `composeTeam`.** `--validate` is a thin read-only path (resolve bundle → check → report); it needs neither the apply/provision/secrets/entry-write lifecycle nor a third bool across `composeTeam`'s ~20 test call sites. The flag is parsed in `init.go` and dispatches — the AC's "wires through `cmd/kuke/team/init.go`" is satisfied.
- **Facts are checked against the key *schema*, not an operator's populated subset.** A blueprint referencing a known-but-unset fact (e.g. `REGISTRY` when no registry is configured) renders empty at run time, not an error — so flagging it would be a false positive. `Validate` therefore needs neither `TeamsConfig` values nor per-run `Inputs`.
- **partials/facts emit miss-only lines** (a resolved reference is unremarkable and would flood the report); catalog/templates emit ok+miss. This matches the issue's example output. All sections are stable-sorted by line body so output is byte-identical across runs (`TestValidateDeterministicOutput`).
- Report line format: `== <section> ==` headers, fixed-width `ok`/`miss` status column, blank line between sections — matches the issue's example shape.

## Test plan

- [x] `make test-root` (full root CI target) — pass
- [x] `make test-kukebuild` — pass
- [x] `go vet` on touched packages — clean
- [x] `pre-commit run --files <changed>` (golangci-lint, go fmt, addlicense, …) — pass
- [x] New unit tests in `internal/teamrender/validate_test.go` cover each section's ok/miss detection, the known-fact-key schema, harness-less roster, report formatting, and deterministic ordering.
- [x] New cmd-level tests in `cmd/kuke/team/init_test.go` cover clean-exit-0 + read-only (no global config / drop-in written), gap-exit-non-zero, harness-less-roster-skips-resolve, and the `--build`/`--validate` mutual-exclusion guard.
- [x] Built `kuke` and confirmed `--validate` appears in `kuke team init --help` and `--build --validate` is rejected at the cobra layer with exit 1.
- [ ] `make dev-init` smoke — not run: this change touches neither the build path, the daemon, nor anything under `/opt/kukeon` (CLI render-contract logic only), so the smoke's trigger condition does not apply.

Closes #1116