### PR TITLE
fix(team): validate ignores commented template actions; init exits non-zero on apply failure

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -335,28 +335,58 @@ func composeTeam(
 		return err
 	}
 
-	source := pt.Spec.Source
-	entry := &model.TeamEntry{
-		APIVersion: model.APIVersionV1,
-		Kind:       model.KindTeamEntry,
-		Metadata:   model.Metadata{Name: project},
-		Spec: model.TeamEntrySpec{
-			Path:    projectDir,
-			TeamDir: teamDir,
-			Source:  &source,
-		},
+	// Per-document apply failures do not surface as a non-nil err — apply only
+	// errors when the RPC itself fails; a blueprint whose scope does not exist
+	// lands as a `failed` action in the result instead. Count them so a
+	// scripted/CI `kuke team init` exits non-zero on any failure, and so a
+	// *total* failure (every applied document failed, nothing landed) skips the
+	// drop-in entry write — persisting an entry for a team with zero applied
+	// objects misleads later `kuke team` reads (#1123). A partial failure still
+	// writes the entry (the team partially exists) but exits non-zero.
+	failed := failedResourceCount(applyResult)
+	totalFailure := applied && failed > 0 && failed == len(applyResult.Resources)
+
+	if !totalFailure {
+		source := pt.Spec.Source
+		entry := &model.TeamEntry{
+			APIVersion: model.APIVersionV1,
+			Kind:       model.KindTeamEntry,
+			Metadata:   model.Metadata{Name: project},
+			Spec: model.TeamEntrySpec{
+				Path:    projectDir,
+				TeamDir: teamDir,
+				Source:  &source,
+			},
+		}
+		if writeErr := teamhost.WriteEntry(layout, entry); writeErr != nil {
+			return fmt.Errorf("write team entry: %w", writeErr)
+		}
+		fmt.Fprintf(out, "wrote team %q to %s\n", project, layout.EntryPath(project))
 	}
-	if writeErr := teamhost.WriteEntry(layout, entry); writeErr != nil {
-		return fmt.Errorf("write team entry: %w", writeErr)
-	}
-	fmt.Fprintf(out, "wrote team %q to %s\n", project, layout.EntryPath(project))
 	if applied {
 		emitApplySummary(out, project, applyResult, len(res.Secrets), len(res.Blueprints), len(res.Configs))
 	} else {
 		fmt.Fprintf(out, "rendered %d secret/%d blueprint/%d config object(s) (no apply: no (role × harness) pairs)\n",
 			len(res.Secrets), len(res.Blueprints), len(res.Configs))
 	}
+	if failed > 0 {
+		return fmt.Errorf("%w (%d of %d documents failed)", errdefs.ErrTeamApplyFailed, failed, len(applyResult.Resources))
+	}
 	return nil
+}
+
+// failedResourceCount returns the number of apply documents that came back with
+// a `failed` action. applyTeam's returned error covers transport/RPC failures;
+// a per-document failure (an unresolvable blueprint scope, say) lands here
+// instead, so `kuke team init` inspects the result to detect it.
+func failedResourceCount(result kukeonv1.ApplyDocumentsResult) int {
+	n := 0
+	for _, r := range result.Resources {
+		if r.Action == "failed" {
+			n++
+		}
+	}
+	return n
 }
 
 // resolveTeamDir returns the per-team host-state root for `project`. The

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -520,6 +520,75 @@ func TestComposeTeamRendersOnNonDryRun(t *testing.T) {
 	}
 }
 
+// TestComposeTeamApplyTotalFailureExitsNonZeroSkipsEntry confirms that when
+// every applied document comes back `failed`, composeTeam exits non-zero
+// (ErrTeamApplyFailed) and does not persist the drop-in entry for a team with
+// zero applied objects (#1123).
+func TestComposeTeamApplyTotalFailureExitsNonZeroSkipsEntry(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var (
+		mu    sync.Mutex
+		calls []applyCall
+	)
+	allFailed := kukeonv1.ApplyDocumentsResult{Resources: []kukeonv1.ApplyResourceResult{
+		{Index: 0, Kind: "CellBlueprint", Name: "dev-claude", Action: "failed", Error: "scope does not exist"},
+		{Index: 1, Kind: "CellConfig", Name: "dev-claude", Action: "failed", Error: "scope does not exist"},
+	}}
+	var out bytes.Buffer
+	err := composeTeam(
+		context.Background(), &out, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle),
+		recordingApply(&mu, &calls, allFailed), stubBuildErr(), false, false,
+	)
+	if !errors.Is(err, errdefs.ErrTeamApplyFailed) {
+		t.Fatalf("err = %v, want ErrTeamApplyFailed", err)
+	}
+	if _, statErr := os.Stat(layout.EntryPath("sbsh")); statErr == nil {
+		t.Errorf("entry must not be written when every document failed")
+	}
+	if strings.Contains(out.String(), "wrote team") {
+		t.Errorf("must not print entry-write line on total failure: %q", out.String())
+	}
+}
+
+// TestComposeTeamApplyPartialFailureExitsNonZeroWritesEntry confirms that a
+// partial apply (some documents succeed, some fail) still persists the entry —
+// the team partially exists — but exits non-zero so a scripted init detects
+// the gap (#1123).
+func TestComposeTeamApplyPartialFailureExitsNonZeroWritesEntry(t *testing.T) {
+	t.Parallel()
+	projectDir := writeProject(t, projectTeamWithHarnessYAML)
+	layout := teamhost.NewLayout(filepath.Join(t.TempDir(), ".kuke"))
+	bundle := buildClaudeBundle(t)
+
+	var (
+		mu    sync.Mutex
+		calls []applyCall
+	)
+	partial := kukeonv1.ApplyDocumentsResult{Resources: []kukeonv1.ApplyResourceResult{
+		{Index: 0, Kind: "CellBlueprint", Name: "dev-claude", Action: "created"},
+		{Index: 1, Kind: "CellConfig", Name: "dev-claude", Action: "failed", Error: "scope does not exist"},
+	}}
+	var out bytes.Buffer
+	err := composeTeam(
+		context.Background(), &out, io.Discard, projectDir, layout,
+		stubGit(nil), stubProjectURL("git@github.com:eminwux/sbsh.git"),
+		stubBundle(bundle),
+		recordingApply(&mu, &calls, partial), stubBuildErr(), false, false,
+	)
+	if !errors.Is(err, errdefs.ErrTeamApplyFailed) {
+		t.Fatalf("err = %v, want ErrTeamApplyFailed", err)
+	}
+	if _, statErr := os.Stat(layout.EntryPath("sbsh")); statErr != nil {
+		t.Errorf("entry should be written on partial apply: %v", statErr)
+	}
+}
+
 // TestComposeTeamImageSelectHardError confirms a missing capability hits
 // the operator-actionable error path with the unmet capability named.
 func TestComposeTeamImageSelectHardError(t *testing.T) {

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -702,4 +702,12 @@ var (
 	ErrTeamValidateGaps = errors.New(
 		"team validate found one or more contract gaps",
 	)
+	// ErrTeamApplyFailed fires when `kuke team init` applies its rendered
+	// secret/blueprint/config set and one or more documents come back with a
+	// `failed` action. The per-document failures are printed to stdout; this
+	// sentinel drives the non-zero exit a scripted/CI init relies on to detect
+	// a partial or total apply failure.
+	ErrTeamApplyFailed = errors.New(
+		"team init: one or more documents failed to apply",
+	)
 )

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -594,9 +594,26 @@ func templateFuncs() template.FuncMap {
 // `{{ define "name" }}…{{ end }}` block defined in any sibling without
 // the renderer owning a partials directory layout of its own.
 func parseBlueprintTemplate(tplPath string, raw []byte) (*template.Template, error) {
+	return parseBlueprintTemplateBody(tplPath, raw, nil)
+}
+
+// parseBlueprintTemplateBody is parseBlueprintTemplate with an optional
+// pre-parse transform applied to the main body and to every sibling partial
+// before each is handed to text/template. A nil transform is identity — the
+// render path (RenderBlueprint) uses it so the generated YAML keeps its
+// documentation comments verbatim. The validate path passes stripYAMLComments
+// so a `{{ ... }}` action a template *documents* inside a YAML `#` comment is
+// dropped before the parser turns it into a live FieldNode / TemplateNode that
+// validateFacts / validatePartials would flag as a spurious gap (#1123).
+func parseBlueprintTemplateBody(
+	tplPath string, raw []byte, transform func([]byte) []byte,
+) (*template.Template, error) {
+	if transform == nil {
+		transform = func(b []byte) []byte { return b }
+	}
 	mainName := filepath.Base(tplPath)
 	tpl := template.New(mainName).Funcs(templateFuncs())
-	if _, err := tpl.Parse(string(raw)); err != nil {
+	if _, err := tpl.Parse(string(transform(raw))); err != nil {
 		return nil, fmt.Errorf("parse blueprint template %q: %w", tplPath, err)
 	}
 
@@ -617,7 +634,7 @@ func parseBlueprintTemplate(tplPath string, raw []byte) (*template.Template, err
 		if readErr != nil {
 			return nil, fmt.Errorf("read partial %q: %w", sib, readErr)
 		}
-		if _, parseErr := tpl.New(filepath.Base(sib)).Parse(string(sibRaw)); parseErr != nil {
+		if _, parseErr := tpl.New(filepath.Base(sib)).Parse(string(transform(sibRaw))); parseErr != nil {
 			return nil, fmt.Errorf("parse partial %q: %w", sib, parseErr)
 		}
 	}

--- a/internal/teamrender/validate.go
+++ b/internal/teamrender/validate.go
@@ -306,7 +306,7 @@ func validatePartials(
 			// Unresolved path is reported by validateTemplates; skip.
 			continue
 		}
-		tpl, parseErr := parseBlueprintTemplate(full, raw)
+		tpl, parseErr := parseBlueprintTemplateBody(full, raw, stripYAMLComments)
 		if parseErr != nil {
 			sec.Lines = append(sec.Lines, ReportLine{
 				OK:     false,
@@ -376,7 +376,7 @@ func validateFacts(
 		if err != nil {
 			continue
 		}
-		tpl, parseErr := parseBlueprintTemplate(full, raw)
+		tpl, parseErr := parseBlueprintTemplateBody(full, raw, stripYAMLComments)
 		if parseErr != nil {
 			// Parse error already surfaces in the partials section.
 			continue
@@ -564,4 +564,55 @@ func walkBranch(pipe *parse.PipeNode, list, elseList *parse.ListNode, visit func
 	if elseList != nil {
 		walkNodes(elseList, visit)
 	}
+}
+
+// stripYAMLComments blanks the YAML `#`-comment tail of every line in a
+// blueprint template body, preserving line structure (and therefore parser
+// line numbers) by keeping each newline and dropping only the commented
+// remainder. Go's text/template parser does not honor YAML `#` comments, so a
+// template that *documents* its fact contract with `{{ .operator.X }}` inside a
+// comment would otherwise parse as a live FieldNode and surface as a spurious
+// fact/partial gap (#1123). Used only by the validate path; the renderer keeps
+// comments verbatim so the generated YAML is unchanged.
+func stripYAMLComments(raw []byte) []byte {
+	lines := strings.Split(string(raw), "\n")
+	for i, line := range lines {
+		if idx := yamlCommentIndex(line); idx >= 0 {
+			lines[i] = line[:idx]
+		}
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+// yamlCommentIndex returns the byte index at which a YAML `#` comment begins on
+// line, or -1 when the line carries none. A `#` starts a comment when it sits
+// at line start or follows whitespace and is not inside a single- or
+// double-quoted scalar — the YAML rule — so a `{{ ... }}` action inside a
+// quoted value that happens to contain `#` survives rather than being clipped.
+func yamlCommentIndex(line string) int {
+	var inSingle, inDouble bool
+	for i := 0; i < len(line); i++ {
+		switch c := line[i]; {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			}
+		case inDouble:
+			switch c {
+			case '\\':
+				i++ // skip the escaped char
+			case '"':
+				inDouble = false
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == '#':
+			if i == 0 || line[i-1] == ' ' || line[i-1] == '\t' {
+				return i
+			}
+		}
+	}
+	return -1
 }

--- a/internal/teamrender/validate_test.go
+++ b/internal/teamrender/validate_test.go
@@ -309,6 +309,84 @@ func TestValidateFactsAllKnownKeysClean(t *testing.T) {
 	}
 }
 
+// TestYAMLCommentIndex locks the quote-aware `#`-comment detection that the
+// validate-path comment strip relies on: a `#` at line start or after
+// whitespace begins a comment, but a `#` inside a quoted scalar (or one glued
+// to a preceding non-space char, as in a URL fragment) does not (#1123).
+func TestYAMLCommentIndex(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		line string
+		want int
+	}{
+		{"# whole line", 0},
+		{"key: value # trailing", 11},
+		{"key: value\t# tab-led", 11},
+		{"no comment here", -1},
+		{"url: http://x#frag", -1},                       // glued # is not a comment
+		{`note: "a # b" {{ .operator.REAL }}`, -1},       // # inside double quotes
+		{`note: 'a # b' after`, -1},                      // # inside single quotes
+		{`name: {{ .x }} # doc {{ .operator.X }}`, 15},   // comment after a live action
+		{`msg: "escaped \" # still in string" tail`, -1}, // escaped quote keeps string open
+	}
+	for _, tc := range cases {
+		if got := yamlCommentIndex(tc.line); got != tc.want {
+			t.Errorf("yamlCommentIndex(%q) = %d, want %d", tc.line, got, tc.want)
+		}
+	}
+}
+
+// TestValidateFactsIgnoresCommentedReferences confirms a template that
+// documents its fact contract with `{{ .operator.X }}` / `{{ .project.X }}`
+// inside YAML `#` comments produces no facts misses — the comment-stripping
+// pass drops those actions before the parser sees them (#1123). A real
+// unbound reference on a live (non-comment) line still surfaces.
+func TestValidateFactsIgnoresCommentedReferences(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml",
+		"#   - {{ .operator.X }} pulls from TeamsConfig (REGISTRY, HOME_DIR, ...).\n"+
+			"#   - {{ .project.X }}  pulls from ProjectTeam (AGENTS_REPO, PROJECT_DIR).\n"+
+			"kind: CellBlueprint\n"+
+			"name: {{ .project.NAME }}  # {{ .operator.ALSO_COMMENTED }} ignored\n"+
+			"bad: {{ .operator.REAL_GAP }}\n")
+	writeHarnessFile(t, cacheDir, "opencode", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "blueprint.tmpl.yaml")
+
+	rep := Validate(bundle, pt)
+	facts := sectionByTitle(t, rep, SectionFacts)
+
+	for _, commented := range []string{".operator.X", ".project.X", ".operator.ALSO_COMMENTED"} {
+		if hasMissContaining(facts, commented) {
+			t.Errorf("commented reference %q must not be flagged: %+v", commented, facts.Lines)
+		}
+	}
+	// The genuine gap on a live line still surfaces.
+	if !hasMissContaining(facts, ".operator.REAL_GAP", "not bound") {
+		t.Errorf("live unbound reference must still be flagged: %+v", facts.Lines)
+	}
+}
+
+// TestValidatePartialsIgnoresCommentedTemplateInvocation confirms a
+// `{{ template "name" }}` invocation documented inside a YAML `#` comment is
+// not flagged as an unbound partial reference — the same comment-stripping pass
+// applies to the partials walk (#1123).
+func TestValidatePartialsIgnoresCommentedTemplateInvocation(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml",
+		"# e.g. {{ template \"mount_source\" . }} wires a repo mount\n"+
+			"kind: CellBlueprint\n")
+	writeHarnessFile(t, cacheDir, "opencode", "blueprint.tmpl.yaml", "kind: CellBlueprint\n")
+	bundle, pt := twoHarnessBundle(cacheDir, []string{"go"}, "blueprint.tmpl.yaml")
+
+	rep := Validate(bundle, pt)
+	partials := sectionByTitle(t, rep, SectionPartials)
+	if hasMissContaining(partials, "mount_source") {
+		t.Errorf("commented template invocation must not be flagged: %+v", partials.Lines)
+	}
+}
+
 // TestKnownFactKeysCoverRendererContract pins the fact schema the validator
 // checks against, so a future renderContextValues key add/remove that this
 // derivation misses is caught here rather than silently passing validate.


### PR DESCRIPTION
## Summary
- **Defect 1 — `--validate` false positives on `{{ ... }}` inside YAML `#` comments.** Go's `text/template` parser does not honor YAML `#` comments, so a blueprint that documents its fact contract in a comment (e.g. `#   - {{ .operator.X }} pulls from TeamsConfig`) parsed `{{ .operator.X }}` as a live `FieldNode` and `validateFacts` reported `.operator.X`/`.project.X` as unbound — making `--validate` unusable as a gate/CI check against real templates. Fixed holistically at the validate parse boundary: the validate path now strips YAML comment tails before parsing, so both `validateFacts` and `validatePartials` (which share `walkNodes`) stop flagging comment-documented actions.
- **Defect 2 — `kuke team init` exited 0 when every applied document failed.** Per-document failures land as `failed` actions in `applyResult`, not as a non-nil error, so `init` wrote the drop-in entry, printed the summary, and returned nil → exit 0 despite `applied 0/N`. Now `composeTeam` counts `failed` documents, exits non-zero (`errdefs.ErrTeamApplyFailed`) on any failure, and skips the entry write entirely on a *total* failure (every document failed, nothing landed).

## Implementation notes
- **Render path is untouched.** `parseBlueprintTemplate` is shared with `RenderBlueprint`; stripping comments there would alter the generated YAML. Added `parseBlueprintTemplateBody(tplPath, raw, transform)` — `nil` transform (identity) for render, `stripYAMLComments` for validate only.
- **Comment detection is quote-aware** (`yamlCommentIndex`): a `#` begins a comment only at line start or after whitespace and outside single/double-quoted scalars, so a `{{ ... }}` inside a quoted value containing `#` survives rather than being clipped. Line structure is preserved (newlines kept, only the commented tail blanked) so parser line numbers don't shift.
- **Gate-vs-flip / blast-radius call on defect 2:** the issue's fix direction asked to "reconsider whether the team entry should be written when 0 objects applied." I chose: *total* failure (0 applied) skips the entry write; a *partial* failure (some applied, some failed) still writes the entry (the team partially exists) but exits non-zero. Reviewer can push back if partial failures should also skip the write.
- New sentinel `errdefs.ErrTeamApplyFailed` mirrors the existing `ErrTeamValidateGaps` pattern (and `kuke apply -f`'s `ErrConfig`-driven non-zero exit on `failed` resources).
- Left `emitApplySummary`'s "applied N …" wording unchanged (it prints the per-object `failed` lines above the aggregate) — rewording it is out of scope for this AC.

## Test plan
- [x] `make test` (full CI suite, `GOWORK=off`) — exit 0
- [x] `GOWORK=off go vet ./internal/teamrender/... ./cmd/kuke/team/... ./internal/errdefs/...` — clean
- [x] New `internal/teamrender` tests: `TestYAMLCommentIndex` (quote-aware detection table), `TestValidateFactsIgnoresCommentedReferences` (commented `.operator.X`/`.project.X` not flagged; live gap still surfaces), `TestValidatePartialsIgnoresCommentedTemplateInvocation`
- [x] New `cmd/kuke/team` tests: `TestComposeTeamApplyTotalFailureExitsNonZeroSkipsEntry`, `TestComposeTeamApplyPartialFailureExitsNonZeroWritesEntry`

Note: the repo-wide `go build ./...` fails on a pre-existing transitive dep break (`containerd/cgroups/v2` under the merged `go.work` graph) unrelated to this change; building/testing with `GOWORK=off` (as the Makefile and CI do) is clean.

Closes #1123