### PR TITLE
fix(cellconfig): tolerate undeclared spec.values keys via lenient ResolveConfig

### DIFF
--- a/internal/cellblueprint/cellblueprint.go
+++ b/internal/cellblueprint/cellblueprint.go
@@ -55,7 +55,41 @@ func Resolve(
 	cliParams map[string]string,
 	lookupEnv func(string) (string, bool),
 ) (v1beta1.CellBlueprintDoc, error) {
-	values, err := resolveValues(doc, cliParams, lookupEnv)
+	return resolve(doc, cliParams, lookupEnv, false)
+}
+
+// ResolveConfig is the lenient resolution entrypoint for the machine-generated
+// CellConfig.Values channel (issue #1124). It behaves exactly like Resolve —
+// same cliParams[k] > parameters[k].default > lookupEnv(k) order, same
+// required-parameter enforcement — except it does *not* reject value keys that
+// are absent from spec.parameters[]:
+//
+//   - undeclared keys do not error (the typo-strictness Resolve applies is
+//     correct for a human typing `--param FOO=…`, but wrong for a generated
+//     artifact: a rendered CellConfig carries operator facts — ROLE, GIT_*,
+//     HARNESS, PROJECT — that the blueprint never declares as parameters);
+//   - undeclared keys are still substituted into the body, so a `${ROLE}` the
+//     blueprint body references but never declares as a parameter resolves to
+//     the supplied value rather than surviving as a literal.
+//
+// A declared parameter the values map does not supply still follows the strict
+// rule (default → env → required-error), so a genuinely missing required
+// parameter is still caught.
+func ResolveConfig(
+	doc v1beta1.CellBlueprintDoc,
+	values map[string]string,
+	lookupEnv func(string) (string, bool),
+) (v1beta1.CellBlueprintDoc, error) {
+	return resolve(doc, values, lookupEnv, true)
+}
+
+func resolve(
+	doc v1beta1.CellBlueprintDoc,
+	cliParams map[string]string,
+	lookupEnv func(string) (string, bool),
+	lenient bool,
+) (v1beta1.CellBlueprintDoc, error) {
+	values, err := resolveValues(doc, cliParams, lookupEnv, lenient)
 	if err != nil {
 		return v1beta1.CellBlueprintDoc{}, err
 	}
@@ -85,26 +119,37 @@ func Resolve(
 // the substitution value map. The substitution leaves `default` declarations
 // themselves untouched (substituteScalars rewrites every scalar, but a missing
 // key is left literal; declared params are always in the map).
+//
+// When lenient is true (the CellConfig.Values channel, #1124) an undeclared key
+// is not an error and is carried into the value map so it still substitutes;
+// when false (the interactive `--param` channel) an undeclared key errors.
 func resolveValues(
 	doc v1beta1.CellBlueprintDoc,
 	cliParams map[string]string,
 	lookupEnv func(string) (string, bool),
+	lenient bool,
 ) (map[string]string, error) {
 	declared := make(map[string]v1beta1.CellBlueprintParameter, len(doc.Spec.Parameters))
 	for _, p := range doc.Spec.Parameters {
 		declared[p.Name] = p
 	}
 
-	for k := range cliParams {
-		if _, ok := declared[k]; !ok {
+	values := make(map[string]string, len(declared)+len(cliParams))
+	for k, v := range cliParams {
+		if _, ok := declared[k]; ok {
+			continue
+		}
+		if !lenient {
 			return nil, fmt.Errorf(
 				"blueprint %q: --param %q is not declared in spec.parameters[]: %w",
 				doc.Metadata.Name, k, errdefs.ErrBlueprintInvalid,
 			)
 		}
+		// Lenient: carry the undeclared key through so a `${KEY}` the body
+		// references but never declares still resolves.
+		values[k] = v
 	}
 
-	values := make(map[string]string, len(declared))
 	for _, p := range doc.Spec.Parameters {
 		if v, ok := cliParams[p.Name]; ok {
 			values[p.Name] = v

--- a/internal/cellblueprint/cellblueprint_test.go
+++ b/internal/cellblueprint/cellblueprint_test.go
@@ -114,6 +114,56 @@ func TestResolve_RequiredUnsetErrors(t *testing.T) {
 	}
 }
 
+// TestResolveConfig_ToleratesUndeclaredKeys is the #1124 regression: the
+// machine-generated CellConfig.Values channel carries operator facts the
+// blueprint never declares as parameters; ResolveConfig must not reject them
+// the way the interactive --param path (Resolve) does.
+func TestResolveConfig_ToleratesUndeclaredKeys(t *testing.T) {
+	out, err := cellblueprint.ResolveConfig(baseDoc(), map[string]string{
+		"TAG":                 "v3",
+		"ROLE":                "dev",
+		"GIT_ALLOWED_SIGNERS": "/keys/allowed_signers",
+		"HARNESS":             "claude",
+		"PROJECT":             "kukeon",
+	}, nil)
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+	// The declared parameter still resolves from the supplied value.
+	if got := out.Spec.Cell.Containers[0].Image; got != "registry.example.com/web:v3" {
+		t.Fatalf("image = %q, want declared param substituted", got)
+	}
+}
+
+// TestResolveConfig_SubstitutesUndeclaredBodyRef proves an undeclared key the
+// blueprint *body* references (a `${ROLE}` with no spec.parameters[] entry, as
+// the team-rendered dev-claude blueprint carries) is substituted rather than
+// left literal — dropping it would re-break the artifact a different way.
+func TestResolveConfig_SubstitutesUndeclaredBodyRef(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Cell.Containers[0].WorkingDir = "/work/${ROLE}"
+	out, err := cellblueprint.ResolveConfig(doc, map[string]string{"ROLE": "dev"}, nil)
+	if err != nil {
+		t.Fatalf("ResolveConfig: %v", err)
+	}
+	if got := out.Spec.Cell.Containers[0].WorkingDir; got != "/work/dev" {
+		t.Fatalf("workingDir = %q, want undeclared ${ROLE} substituted", got)
+	}
+}
+
+// TestResolveConfig_StillEnforcesRequired confirms the lenient channel only
+// relaxes undeclared-key rejection — a declared-required parameter the values
+// map does not supply is still an error (the #1124 "second wall" stays a real
+// failure; its agents-repo template fix is out of scope here).
+func TestResolveConfig_StillEnforcesRequired(t *testing.T) {
+	doc := baseDoc()
+	doc.Spec.Parameters = []v1beta1.CellBlueprintParameter{{Name: "TAG", Required: true}}
+	_, err := cellblueprint.ResolveConfig(doc, map[string]string{"ROLE": "dev"}, nil)
+	if !errors.Is(err, errdefs.ErrBlueprintInvalid) {
+		t.Fatalf("err = %v, want ErrBlueprintInvalid for required-unset param", err)
+	}
+}
+
 var hexSuffixRE = regexp.MustCompile(`^web-[0-9a-f]{6}$`)
 
 func TestMaterialize_GeneratedNameAndScope(t *testing.T) {

--- a/internal/cellconfig/materialize.go
+++ b/internal/cellconfig/materialize.go
@@ -32,7 +32,11 @@ import (
 //
 //   - Scalar values come from cfg.Spec.Values (not --param CLI args); the env
 //     fallback is intentionally absent because a Config's values are the
-//     persistent record of what the operator chose at apply time.
+//     persistent record of what the operator chose at apply time. Resolution
+//     goes through cellblueprint.ResolveConfig (the lenient channel, #1124):
+//     a machine-generated Config carries operator facts the blueprint never
+//     declares as parameters, so undeclared keys are tolerated and substituted
+//     rather than rejected with the interactive `--param` typo-strictness.
 //   - Structural slot fills (repo URLs, secret sources) come from cfg.Spec.Repos
 //     and cfg.Spec.Secrets, keyed by slot name. Unknown fills and unfilled
 //     required slots are rejected via ValidateSlotFill; optional unfilled slots
@@ -62,7 +66,7 @@ func MaterializeWithName(
 		return v1beta1.CellDoc{}, err
 	}
 
-	resolved, err := cellblueprint.Resolve(bp, cfg.Spec.Values, nil)
+	resolved, err := cellblueprint.ResolveConfig(bp, cfg.Spec.Values, nil)
 	if err != nil {
 		return v1beta1.CellDoc{}, fmt.Errorf(
 			"config %q: resolve blueprint %q: %w",
@@ -295,4 +299,3 @@ func cloneCellTty(in *v1beta1.CellTty) *v1beta1.CellTty {
 	out := *in
 	return &out
 }
-

--- a/internal/cellconfig/materialize_test.go
+++ b/internal/cellconfig/materialize_test.go
@@ -461,3 +461,47 @@ func TestMaterializeWithName_StampsConfigProvenance(t *testing.T) {
 		t.Errorf("params[TAG]=%q want v2", got)
 	}
 }
+
+// TestMaterialize_ToleratesUndeclaredValues is the #1124 end-to-end
+// regression: a team-rendered CellConfig carries operator facts (ROLE, GIT_*,
+// HARNESS, PROJECT) that the blueprint never declares as spec.parameters[].
+// Before the fix the first undeclared key aborted materialization with
+// ErrBlueprintInvalid, making every team-init config un-instantiable. The
+// Config channel now resolves leniently: undeclared keys are tolerated, the
+// declared param still substitutes, and an undeclared ${ROLE} the body
+// references resolves rather than surviving literal.
+func TestMaterialize_ToleratesUndeclaredValues(t *testing.T) {
+	bp := minimalBlueprint()
+	// Drop the structural slots so this test isolates the values channel.
+	bp.Spec.Cell.Containers[0].Repos = nil
+	bp.Spec.Cell.Containers[0].Secrets = nil
+	bp.Spec.Cell.Containers[0].WorkingDir = "/work/${ROLE}"
+
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "dev-claude", Realm: "cfg-realm"},
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web", Realm: "bp-realm"},
+			Values: map[string]string{
+				"TAG":                 "v2",
+				"ROLE":                "dev",
+				"HARNESS":             "claude",
+				"PROJECT":             "kukeon",
+				"GIT_ALLOWED_SIGNERS": "/keys/allowed_signers",
+			},
+		},
+	}
+
+	cell, err := MaterializeWithName(cfg, bp, "dev-claude")
+	if err != nil {
+		t.Fatalf("MaterializeWithName: %v (undeclared values must not abort the Config channel)", err)
+	}
+	c := cell.Spec.Containers[0]
+	if c.Image != "registry.example.com/web:v2" {
+		t.Errorf("image=%q want declared ${TAG} substituted to v2", c.Image)
+	}
+	if c.WorkingDir != "/work/dev" {
+		t.Errorf("workingDir=%q want undeclared ${ROLE} substituted to dev", c.WorkingDir)
+	}
+}


### PR DESCRIPTION
## Summary

- `kuke team init` emits `CellConfig`s that **cannot create a cell**: every team-rendered config dead-ends at `--param "GIT_ALLOWED_SIGNERS" is not declared in spec.parameters[]: blueprint is invalid`. The artifact a successful team init produces is unusable (#1124).
- Root cause is a contract mismatch on the `CellConfig.Values` channel: `cellconfig.MaterializeWithName` fed `cfg.Spec.Values` straight into `cellblueprint.Resolve`, whose `resolveValues` hard-errors on **any** value key not declared in the blueprint's `spec.parameters[]`. That typo-strictness is correct for a human typing `kuke create cell --param FOO=…`, but wrong for a **machine-generated** config that carries operator facts (`ROLE`, `GIT_*`, `HARNESS`, `PROJECT`) the blueprint never declares as parameters.
- Fix (issue's **Option 1**, the consumer-side fix): add a lenient entrypoint `cellblueprint.ResolveConfig` that does not reject undeclared keys, and route the `CellConfig` → cell path through it. The interactive `--param` path keeps strict `Resolve` unchanged.

## Why Option 1 over Option 2

Option 1 is the **necessary and sufficient** fix and the lower-blast-radius default: it fixes un-instantiability for *every* machine-generated config, not just teamrender's current output. Option 2 (have `teamrender` emit only declared keys) is **insufficient alone** — the blueprint body references `${ROLE}` ×6 yet does not declare `ROLE` as a parameter, so a pure-prune approach would still trip the rejection (or, if it dropped `ROLE`, leave `${ROLE}` literal). `ResolveConfig` therefore *also substitutes* undeclared keys (not just tolerates them), so a `${ROLE}` the body references but never declares resolves correctly rather than surviving literal.

The issue notes `operatorValues` emitting `GIT_*`/`HARNESS`/`PROJECT` is "dead output worth pruning regardless." That producer-side cleanup is deliberately **not** bundled here (it does not affect correctness once the channel is lenient, and bundling a producer prune with a consumer contract fix is scope creep). It can be filed as a follow-up if desired.

## Scope note — the "second wall" is agents-repo

Per the issue, even with undeclared-key rejection fixed, the team-rendered `dev-claude` config still cannot fully materialize because the role's `needs.params` (`PROMPT`, `AGENT_NAME`, …) are emitted by the **agents** template as `required: true` while `spec.values` supplies none. That is the agents-repo template duplication filed separately. This PR scopes to the kukeon contract bug (the first wall) and **keeps** required-parameter enforcement on the lenient channel — `TestResolveConfig_StillEnforcesRequired` pins that the lenient mode only relaxes undeclared-key rejection.

## Test plan

- [x] `make test-root` (full root test suite, `GOWORK=off`) — exit 0
- [x] `go test ./internal/cellblueprint/... ./internal/cellconfig/...` — pass
- [x] `go vet ./internal/cellblueprint/... ./internal/cellconfig/...` — clean
- [x] New `cellblueprint` tests: `TestResolveConfig_ToleratesUndeclaredKeys`, `TestResolveConfig_SubstitutesUndeclaredBodyRef`, `TestResolveConfig_StillEnforcesRequired`
- [x] New `cellconfig` end-to-end test: `TestMaterialize_ToleratesUndeclaredValues` (a config carrying `ROLE`/`GIT_*`/`HARNESS`/`PROJECT` now materializes; `${TAG}` and undeclared `${ROLE}` both substitute)
- [x] Existing `TestResolve_UndeclaredParamErrors` unchanged — strict `--param` path still rejects undeclared keys

Note: `go build ./...` without `GOWORK=off` surfaces an unrelated vendored `containerd/cgroups` type mismatch (go.work workspace mismatch, per project CLAUDE.md); the project's `GOWORK=off` build/test env (what CI runs) is clean.

Closes #1124