### PR TITLE
feat(team): add root capability to dev role image needs

### DIFF
--- a/kuketeam.yaml
+++ b/kuketeam.yaml
@@ -5,6 +5,6 @@ spec:
   source: { repo: github.com/eminwux/agents, branch: main }
   defaults: { harnesses: [claude, opencode] }
   roles:
-    - { ref: dev, needs: { image: [go] } }
+    - { ref: dev, needs: { image: [go, root] } }
     - { ref: pm }
     - { ref: pr-reviewer }


### PR DESCRIPTION
## Summary
- The `dev` role in `kuketeam.yaml` declared `needs.image: [go]`, which the team-init selector satisfies with the rootless `claude`/`opencode` images. The dev loop needs root for the local smoke test (`make dev-init`, `sudo ./kuke ...`, containerd/cgroup operations), so the role should select a root-capable image.
- Add `root` to the dev role's `needs.image` set. The merged `[go, root]` capability set now selects the `-root` image variants (`claude-root`, `opencode-root`), both of which exist in the source-repo catalog (`github.com/eminwux/agents` `harnesses/images.yaml`) and match the team's `defaults.harnesses: [claude, opencode]`.

## Notes
- Verified against the catalog at `github.com/eminwux/agents` `harnesses/images.yaml`: `root` is a valid capability provided by `claude-root` (`[git, gh, go, node, make, root]`) and `opencode-root` (same), so the `[go, root]` selector resolves for both declared harnesses. No image-selection hard-error is introduced.
- Config-only change to the committed roster; no Go code touched.
- No backing issue — filed at the user's direct request.

## Test plan
- [x] `make test` (full CI test target) — pass (exit 0)