### PR TITLE
feat(create): kuke create registry-credential — upsert realm pull credentials

### DIFF
--- a/cmd/kuke/create/create.go
+++ b/cmd/kuke/create/create.go
@@ -23,6 +23,7 @@ import (
 	cellcmd "github.com/eminwux/kukeon/cmd/kuke/create/cell"
 	configcmd "github.com/eminwux/kukeon/cmd/kuke/create/config"
 	realmcmd "github.com/eminwux/kukeon/cmd/kuke/create/realm"
+	registrycredentialcmd "github.com/eminwux/kukeon/cmd/kuke/create/registrycredential"
 	secretcmd "github.com/eminwux/kukeon/cmd/kuke/create/secret"
 	spacecmd "github.com/eminwux/kukeon/cmd/kuke/create/space"
 	stackcmd "github.com/eminwux/kukeon/cmd/kuke/create/stack"
@@ -36,7 +37,7 @@ func NewCreateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "create",
 		Aliases: []string{"c"},
-Short:   "Create Kukeon resources (realm, space, stack, cell, config, blueprint, secret)",
+		Short:   "Create Kukeon resources (realm, space, stack, cell, config, blueprint, secret, registry-credential)",
 		Run: func(cmd *cobra.Command, _ []string) {
 			_ = cmd.Help()
 		},
@@ -52,6 +53,7 @@ Short:   "Create Kukeon resources (realm, space, stack, cell, config, blueprint,
 		configcmd.NewConfigCmd(),
 		blueprintcmd.NewBlueprintCmd(),
 		secretcmd.NewSecretCmd(),
+		registrycredentialcmd.NewRegistryCredentialCmd(),
 	)
 
 	return cmd
@@ -59,7 +61,7 @@ Short:   "Create Kukeon resources (realm, space, stack, cell, config, blueprint,
 
 // completeCreateSubcommands provides shell completion for create subcommand names.
 func completeCreateSubcommands(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	subcommands := []string{"realm", "space", "stack", "cell", "config", "blueprint", "secret"}
+	subcommands := []string{"realm", "space", "stack", "cell", "config", "blueprint", "secret", "registry-credential"}
 
 	if toComplete == "" {
 		return subcommands, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/kuke/create/create_test.go
+++ b/cmd/kuke/create/create_test.go
@@ -41,7 +41,7 @@ func TestNewCreateCmdMetadata(t *testing.T) {
 		{
 			name: "short description",
 			check: func(t *testing.T, cmd *cobra.Command) {
-				expected := "Create Kukeon resources (realm, space, stack, cell, config, blueprint, secret)"
+				expected := "Create Kukeon resources (realm, space, stack, cell, config, blueprint, secret, registry-credential)"
 				if cmd.Short != expected {
 					t.Fatalf("expected Short to be %q, got %q", expected, cmd.Short)
 				}
@@ -83,6 +83,7 @@ func TestNewCreateCmdRegistersSubcommands(t *testing.T) {
 		{name: "config"},
 		{name: "blueprint"},
 		{name: "secret"},
+		{name: "registry-credential"},
 	}
 
 	for _, tt := range tests {
@@ -105,7 +106,7 @@ func TestNewCreateCmd_AutocompleteRegistration(t *testing.T) {
 
 	// Test the completion function directly
 	completions, _ := cmd.ValidArgsFunction(cmd, []string{}, "")
-	expected := []string{"realm", "space", "stack", "cell", "config", "blueprint", "secret"}
+	expected := []string{"realm", "space", "stack", "cell", "config", "blueprint", "secret", "registry-credential"}
 	if len(completions) != len(expected) {
 		t.Fatalf("expected %d completions, got %d", len(expected), len(completions))
 	}

--- a/cmd/kuke/create/registrycredential/registrycredential.go
+++ b/cmd/kuke/create/registrycredential/registrycredential.go
@@ -1,0 +1,261 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package registrycredential implements `kuke create registry-credential` — an
+// imperative path to attach pull credentials to an existing realm's
+// spec.registryCredentials without round-tripping through a hand-edited YAML
+// manifest. The token enters via stdin or a file only, never argv, mirroring
+// `kuke create secret --from-file`. The command reads the realm, upserts the
+// credential keyed by --server, and re-applies the realm through the daemon's
+// write-through apply path, which the reconciler converges as a compatible
+// change (no realm recreate, no cell disruption).
+package registrycredential
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/eminwux/kukeon/cmd/config"
+	kukeshared "github.com/eminwux/kukeon/cmd/kuke/shared"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// MockControllerKey is used to inject a mock kukeonv1.Client via context in tests.
+type MockControllerKey struct{}
+
+func NewRegistryCredentialCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "registry-credential <realm>",
+		Aliases: []string{"registry-cred", "regcred"},
+		Short:   "Attach pull credentials to a realm",
+		Long: "Attach private-registry pull credentials to an existing realm.\n\n" +
+			"Upserts an entry on the realm's spec.registryCredentials keyed by --server\n" +
+			"and re-applies the realm; the reconciler converges it as a compatible change\n" +
+			"(no realm recreate). Re-running with the same --server updates the entry in\n" +
+			"place rather than appending a duplicate.\n\n" +
+			"The token is read from stdin or a file only — never from an argv flag:\n\n" +
+			"  - kuke create registry-credential <realm> --server ghcr.io --username <u> --password-stdin\n" +
+			"  - kuke create registry-credential <realm> --server ghcr.io --username <u> --from-file <path>\n\n" +
+			"Exactly one of --password-stdin or --from-file is required.\n\n" +
+			"--server is the registry host the credential applies to (e.g. ghcr.io). It\n" +
+			"defaults to empty, which matches the registry extracted from the image\n" +
+			"reference at pull time.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: false,
+		RunE:          runCreateRegistryCredential,
+	}
+
+	cmd.Flags().String("server", "", "Registry server address the credential applies to (e.g. ghcr.io); empty matches the registry from the image reference")
+	cmd.Flags().String("username", "", "Registry username")
+	cmd.Flags().Bool("password-stdin", false, "Read the registry token from stdin (docker login style)")
+	cmd.Flags().String("from-file", "", "Read the registry token from a file")
+
+	cmd.ValidArgsFunction = config.CompleteRealmNames
+
+	return cmd
+}
+
+func runCreateRegistryCredential(cmd *cobra.Command, args []string) error {
+	flags, err := parseRegistryCredentialFlags(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	client, err := resolveClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = client.Close() }()
+
+	// Resolve the realm first so the upsert merges onto the live
+	// registryCredentials list rather than replacing it — the apply diff
+	// overwrites the field wholesale, so any existing entries must be carried
+	// forward in the desired doc.
+	current, err := client.GetRealm(cmd.Context(), v1beta1.RealmDoc{
+		Metadata: v1beta1.RealmMetadata{Name: flags.realm},
+	})
+	if err != nil {
+		return err
+	}
+	if !current.MetadataExists {
+		return fmt.Errorf("realm %q not found", flags.realm)
+	}
+
+	desired := current.Realm
+	desired.APIVersion = v1beta1.APIVersionV1Beta1
+	desired.Kind = v1beta1.KindRealm
+	desired.Status = v1beta1.RealmStatus{}
+	desired.Spec.RegistryCredentials = upsertCredential(
+		desired.Spec.RegistryCredentials,
+		v1beta1.RegistryCredentials{
+			Username:      flags.username,
+			Password:      flags.token,
+			ServerAddress: flags.server,
+		},
+	)
+
+	rawYAML, err := yaml.Marshal(desired)
+	if err != nil {
+		return fmt.Errorf("marshal realm document: %w", err)
+	}
+
+	result, err := client.ApplyDocuments(cmd.Context(), rawYAML)
+	if err != nil {
+		return err
+	}
+
+	return printApplyResult(cmd, flags, result)
+}
+
+// upsertCredential replaces an existing entry whose ServerAddress matches the
+// incoming credential's ServerAddress (username + password updated), or appends
+// a new entry when no match is found. Matching is exact on ServerAddress so the
+// empty-server default ("matches by image reference") upserts against itself.
+func upsertCredential(existing []v1beta1.RegistryCredentials, cred v1beta1.RegistryCredentials) []v1beta1.RegistryCredentials {
+	for i := range existing {
+		if existing[i].ServerAddress == cred.ServerAddress {
+			existing[i] = cred
+			return existing
+		}
+	}
+	return append(existing, cred)
+}
+
+type registryCredentialFlags struct {
+	realm    string
+	server   string
+	username string
+	token    string
+}
+
+func parseRegistryCredentialFlags(cmd *cobra.Command, args []string) (registryCredentialFlags, error) {
+	flags := registryCredentialFlags{}
+
+	flags.realm = strings.TrimSpace(args[0])
+	if flags.realm == "" {
+		return registryCredentialFlags{}, errors.New("realm name is required")
+	}
+
+	server, err := cmd.Flags().GetString("server")
+	if err != nil {
+		return registryCredentialFlags{}, err
+	}
+	flags.server = strings.TrimSpace(server)
+
+	username, err := cmd.Flags().GetString("username")
+	if err != nil {
+		return registryCredentialFlags{}, err
+	}
+	flags.username = strings.TrimSpace(username)
+	if flags.username == "" {
+		return registryCredentialFlags{}, errors.New("--username is required")
+	}
+
+	passwordStdin, err := cmd.Flags().GetBool("password-stdin")
+	if err != nil {
+		return registryCredentialFlags{}, err
+	}
+
+	fromFile, err := cmd.Flags().GetString("from-file")
+	if err != nil {
+		return registryCredentialFlags{}, err
+	}
+
+	switch {
+	case passwordStdin && fromFile != "":
+		return registryCredentialFlags{}, errors.New("only one of --password-stdin or --from-file may be specified")
+	case passwordStdin:
+		flags.token, err = readToken(cmd.InOrStdin())
+		if err != nil {
+			return registryCredentialFlags{}, fmt.Errorf("read token from stdin: %w", err)
+		}
+	case fromFile != "":
+		f, openErr := os.Open(fromFile)
+		if openErr != nil {
+			return registryCredentialFlags{}, fmt.Errorf("read --from-file %q: %w", fromFile, openErr)
+		}
+		defer func() { _ = f.Close() }()
+		flags.token, err = readToken(f)
+		if err != nil {
+			return registryCredentialFlags{}, fmt.Errorf("read --from-file %q: %w", fromFile, err)
+		}
+	default:
+		return registryCredentialFlags{}, errors.New("exactly one of --password-stdin or --from-file is required")
+	}
+
+	if flags.token == "" {
+		return registryCredentialFlags{}, errors.New("registry token is empty")
+	}
+
+	return flags, nil
+}
+
+// readToken reads a token from r and strips trailing newlines, mirroring
+// `kuke create secret --from-file` handling so a `password\n` from a file or a
+// piped heredoc lands without the trailing byte.
+func readToken(r io.Reader) (string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(data), "\r\n"), nil
+}
+
+func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
+	if mockClient, ok := cmd.Context().Value(MockControllerKey{}).(kukeonv1.Client); ok {
+		return mockClient, nil
+	}
+	return kukeshared.DaemonClientFromCmd(cmd)
+}
+
+func printApplyResult(cmd *cobra.Command, flags registryCredentialFlags, result kukeonv1.ApplyDocumentsResult) error {
+	server := flags.server
+	if server == "" {
+		server = "(default: image reference)"
+	}
+
+	for _, resource := range result.Resources {
+		if resource.Kind != string(v1beta1.KindRealm) {
+			continue
+		}
+		switch resource.Action {
+		case "failed":
+			if resource.Error != "" {
+				return fmt.Errorf("apply realm %q: %s", resource.Name, resource.Error)
+			}
+			return fmt.Errorf("apply realm %q failed", resource.Name)
+		default:
+			cmd.Printf(
+				"Registry credential for %s (user %q) applied to realm %q: %s\n",
+				server, flags.username, flags.realm, resource.Action,
+			)
+			return nil
+		}
+	}
+
+	cmd.Printf(
+		"Registry credential for %s (user %q) applied to realm %q\n",
+		server, flags.username, flags.realm,
+	)
+	return nil
+}

--- a/cmd/kuke/create/registrycredential/registrycredential_test.go
+++ b/cmd/kuke/create/registrycredential/registrycredential_test.go
@@ -1,0 +1,343 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package registrycredential_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/kukeon/cmd/kuke/create/registrycredential"
+	"github.com/eminwux/kukeon/cmd/types"
+	"github.com/eminwux/kukeon/pkg/api/kukeonv1"
+	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
+	"gopkg.in/yaml.v3"
+)
+
+type fakeClient struct {
+	kukeonv1.FakeClient
+	getRealmFn func(doc v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error)
+	applyFn    func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error)
+}
+
+func (f *fakeClient) GetRealm(_ context.Context, doc v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+	if f.getRealmFn == nil {
+		return kukeonv1.GetRealmResult{}, errors.New("unexpected GetRealm call")
+	}
+	return f.getRealmFn(doc)
+}
+
+func (f *fakeClient) ApplyDocuments(_ context.Context, rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
+	if f.applyFn == nil {
+		return kukeonv1.ApplyDocumentsResult{}, errors.New("unexpected ApplyDocuments call")
+	}
+	return f.applyFn(rawYAML)
+}
+
+func (f *fakeClient) Close() error { return nil }
+
+// existingRealm returns a GetRealm result for a realm that exists with the
+// supplied namespace and credentials.
+func existingRealm(namespace string, creds []v1beta1.RegistryCredentials) kukeonv1.GetRealmResult {
+	return kukeonv1.GetRealmResult{
+		MetadataExists: true,
+		Realm: v1beta1.RealmDoc{
+			Metadata: v1beta1.RealmMetadata{Name: "default"},
+			Spec: v1beta1.RealmSpec{
+				Namespace:           namespace,
+				RegistryCredentials: creds,
+			},
+		},
+	}
+}
+
+// applyOK echoes an "updated" Realm resource result and captures the applied
+// YAML into *captured so the test can assert the desired-spec shape.
+func applyOK(captured *[]byte) func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
+	return func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
+		*captured = append([]byte(nil), rawYAML...)
+		return kukeonv1.ApplyDocumentsResult{
+			Resources: []kukeonv1.ApplyResourceResult{
+				{Kind: string(v1beta1.KindRealm), Name: "default", Action: "updated"},
+			},
+		}, nil
+	}
+}
+
+func decodeRealm(t *testing.T, raw []byte) v1beta1.RealmDoc {
+	t.Helper()
+	var doc v1beta1.RealmDoc
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal applied YAML: %v", err)
+	}
+	return doc
+}
+
+func TestRegistryCredentialUpsert(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		stdin    string
+		getRealm func(doc v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error)
+		// assertApplied inspects the desired realm doc sent to ApplyDocuments.
+		assertApplied func(t *testing.T, doc v1beta1.RealmDoc)
+		wantErr       string
+		wantOut       string
+		wantNoApply   bool
+	}{
+		{
+			name:  "stdin happy path appends to empty list",
+			args:  []string{"default", "--server", "ghcr.io", "--username", "alice", "--password-stdin"},
+			stdin: "s3cr3t\n",
+			getRealm: func(_ v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+				return existingRealm("default.kukeon.io", nil), nil
+			},
+			assertApplied: func(t *testing.T, doc v1beta1.RealmDoc) {
+				if doc.Kind != v1beta1.KindRealm || doc.APIVersion != v1beta1.APIVersionV1Beta1 {
+					t.Errorf("apiVersion/kind not set: %q/%q", doc.APIVersion, doc.Kind)
+				}
+				if doc.Spec.Namespace != "default.kukeon.io" {
+					t.Errorf("namespace not preserved: %q", doc.Spec.Namespace)
+				}
+				if len(doc.Spec.RegistryCredentials) != 1 {
+					t.Fatalf("want 1 credential, got %d", len(doc.Spec.RegistryCredentials))
+				}
+				c := doc.Spec.RegistryCredentials[0]
+				if c.ServerAddress != "ghcr.io" || c.Username != "alice" || c.Password != "s3cr3t" {
+					t.Errorf("unexpected credential: %+v", c)
+				}
+			},
+			wantOut: `applied to realm "default"`,
+		},
+		{
+			name:  "upsert replaces matching server in place",
+			args:  []string{"default", "--server", "ghcr.io", "--username", "bob", "--password-stdin"},
+			stdin: "newtoken",
+			getRealm: func(_ v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+				return existingRealm("default.kukeon.io", []v1beta1.RegistryCredentials{
+					{ServerAddress: "ghcr.io", Username: "alice", Password: "old"},
+					{ServerAddress: "docker.io", Username: "carol", Password: "keep"},
+				}), nil
+			},
+			assertApplied: func(t *testing.T, doc v1beta1.RealmDoc) {
+				if len(doc.Spec.RegistryCredentials) != 2 {
+					t.Fatalf("want 2 credentials (no duplicate), got %d", len(doc.Spec.RegistryCredentials))
+				}
+				var ghcr, docker v1beta1.RegistryCredentials
+				for _, c := range doc.Spec.RegistryCredentials {
+					switch c.ServerAddress {
+					case "ghcr.io":
+						ghcr = c
+					case "docker.io":
+						docker = c
+					}
+				}
+				if ghcr.Username != "bob" || ghcr.Password != "newtoken" {
+					t.Errorf("ghcr.io not updated in place: %+v", ghcr)
+				}
+				if docker.Username != "carol" || docker.Password != "keep" {
+					t.Errorf("docker.io entry not preserved: %+v", docker)
+				}
+			},
+			wantOut: "updated",
+		},
+		{
+			name:  "appends when server differs",
+			args:  []string{"default", "--server", "ghcr.io", "--username", "bob", "--password-stdin"},
+			stdin: "tok",
+			getRealm: func(_ v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+				return existingRealm("default.kukeon.io", []v1beta1.RegistryCredentials{
+					{ServerAddress: "docker.io", Username: "carol", Password: "keep"},
+				}), nil
+			},
+			assertApplied: func(t *testing.T, doc v1beta1.RealmDoc) {
+				if len(doc.Spec.RegistryCredentials) != 2 {
+					t.Fatalf("want 2 credentials, got %d", len(doc.Spec.RegistryCredentials))
+				}
+			},
+			wantOut: "applied",
+		},
+		{
+			name:  "empty server upserts against itself",
+			args:  []string{"default", "--username", "bob", "--password-stdin"},
+			stdin: "tok2",
+			getRealm: func(_ v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+				return existingRealm("default.kukeon.io", []v1beta1.RegistryCredentials{
+					{ServerAddress: "", Username: "old", Password: "old"},
+				}), nil
+			},
+			assertApplied: func(t *testing.T, doc v1beta1.RealmDoc) {
+				if len(doc.Spec.RegistryCredentials) != 1 {
+					t.Fatalf("want 1 credential (in-place), got %d", len(doc.Spec.RegistryCredentials))
+				}
+				if doc.Spec.RegistryCredentials[0].Username != "bob" {
+					t.Errorf("empty-server entry not updated: %+v", doc.Spec.RegistryCredentials[0])
+				}
+			},
+			wantOut: "default: image reference",
+		},
+		{
+			name:  "unknown realm errors",
+			args:  []string{"ghost", "--server", "ghcr.io", "--username", "bob", "--password-stdin"},
+			stdin: "tok",
+			getRealm: func(_ v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+				return kukeonv1.GetRealmResult{MetadataExists: false}, nil
+			},
+			wantErr:     `realm "ghost" not found`,
+			wantNoApply: true,
+		},
+		{
+			name:        "both token sources rejected",
+			args:        []string{"default", "--username", "bob", "--password-stdin", "--from-file", "x"},
+			stdin:       "tok",
+			wantErr:     "only one of --password-stdin or --from-file may be specified",
+			wantNoApply: true,
+		},
+		{
+			name:        "no token source rejected",
+			args:        []string{"default", "--username", "bob"},
+			wantErr:     "exactly one of --password-stdin or --from-file is required",
+			wantNoApply: true,
+		},
+		{
+			name:        "missing username rejected",
+			args:        []string{"default", "--password-stdin"},
+			stdin:       "tok",
+			wantErr:     "--username is required",
+			wantNoApply: true,
+		},
+		{
+			name:        "empty token rejected",
+			args:        []string{"default", "--username", "bob", "--password-stdin"},
+			stdin:       "\n",
+			wantErr:     "registry token is empty",
+			wantNoApply: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := registrycredential.NewRegistryCredentialCmd()
+			out := &bytes.Buffer{}
+			cmd.SetOut(out)
+			cmd.SetErr(out)
+			cmd.SetIn(strings.NewReader(tt.stdin))
+
+			var captured []byte
+			applied := false
+			fake := &fakeClient{
+				getRealmFn: tt.getRealm,
+				applyFn: func(rawYAML []byte) (kukeonv1.ApplyDocumentsResult, error) {
+					applied = true
+					return applyOK(&captured)(rawYAML)
+				},
+			}
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+			ctx = context.WithValue(ctx, registrycredential.MockControllerKey{}, kukeonv1.Client(fake))
+			cmd.SetContext(ctx)
+
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tt.wantNoApply && applied {
+				t.Error("ApplyDocuments should not have been called")
+			}
+
+			if tt.assertApplied != nil {
+				if !applied {
+					t.Fatal("ApplyDocuments was not called")
+				}
+				tt.assertApplied(t, decodeRealm(t, captured))
+			}
+
+			if tt.wantOut != "" && !strings.Contains(out.String(), tt.wantOut) {
+				t.Errorf("expected output to contain %q, got %q", tt.wantOut, out.String())
+			}
+		})
+	}
+}
+
+func TestRegistryCredentialFromFile(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token.txt")
+	if err := os.WriteFile(tokenPath, []byte("file-token\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	cmd := registrycredential.NewRegistryCredentialCmd()
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+
+	var captured []byte
+	fake := &fakeClient{
+		getRealmFn: func(_ v1beta1.RealmDoc) (kukeonv1.GetRealmResult, error) {
+			return existingRealm("default.kukeon.io", nil), nil
+		},
+		applyFn: applyOK(&captured),
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, registrycredential.MockControllerKey{}, kukeonv1.Client(fake))
+	cmd.SetContext(ctx)
+
+	cmd.SetArgs([]string{"default", "--server", "ghcr.io", "--username", "alice", "--from-file", tokenPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	doc := decodeRealm(t, captured)
+	if len(doc.Spec.RegistryCredentials) != 1 {
+		t.Fatalf("want 1 credential, got %d", len(doc.Spec.RegistryCredentials))
+	}
+	if got := doc.Spec.RegistryCredentials[0].Password; got != "file-token" {
+		t.Errorf("token not read from file (trailing newline stripped): %q", got)
+	}
+}
+
+func TestRegistryCredentialNoPasswordFlag(t *testing.T) {
+	// The token must never be settable via an argv flag.
+	cmd := registrycredential.NewRegistryCredentialCmd()
+	if cmd.Flags().Lookup("password") != nil {
+		t.Error("a plaintext --password flag must not exist")
+	}
+	for _, name := range []string{"server", "username", "password-stdin", "from-file"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected %q flag to exist", name)
+		}
+	}
+}

--- a/docs/site/cli/kuke-create.md
+++ b/docs/site/cli/kuke-create.md
@@ -7,7 +7,7 @@ kuke create <resource> [NAME] [flags]
 kuke c      <resource> [NAME] [flags]      # alias
 ```
 
-Resources: `realm`, `space`, `stack`, `cell`, `blueprint`, `config`, `secret`. Each subcommand also has a short alias (`r`, `sp`, `st`, `ce`, `bp`, `cfg`, and `secret` has none).
+Resources: `realm`, `space`, `stack`, `cell`, `blueprint`, `config`, `secret`, `registry-credential`. Each subcommand also has a short alias (`r`, `sp`, `st`, `ce`, `bp`, `cfg`, `secret` has none, and `registry-credential` has `registry-cred`/`regcred`).
 
 ## kuke create realm
 
@@ -180,6 +180,45 @@ sudo kuke create secret api-key --from-literal=API_KEY=sk-... --realm default
 
 # From file
 sudo kuke create secret tls-cert --from-file=./tls.crt --realm default
+```
+
+## kuke create registry-credential
+
+```
+kuke create registry-credential <realm> --username <u> (--password-stdin | --from-file <path>)
+                                         [--server <host>]
+```
+
+Attach private-registry pull credentials to an **existing** realm. The command
+reads the realm, upserts an entry onto its `spec.registryCredentials` keyed by
+`--server`, and re-applies the realm. The reconciler converges the change as a
+*compatible* update — no realm recreate and no cell disruption — so cells in the
+realm can immediately pull images that previously returned `403 Forbidden`.
+
+Re-running with the same `--server` updates that entry in place (username +
+token) rather than appending a duplicate; a different `--server` appends a new
+entry. Existing entries for other servers are preserved.
+
+The token never enters argv: supply it via `--password-stdin` (read from stdin,
+docker-login style) or `--from-file` (read from a file). Exactly one of the two
+is required.
+
+| Flag                   | Default                     | Description                                                                  |
+| ---------------------- | --------------------------- | ---------------------------------------------------------------------------- |
+| `<realm>` (positional) | _(required)_                | The realm to attach the credential to                                        |
+| `--username`           | _(required)_                | Registry username                                                            |
+| `--password-stdin`     | `false`                     | Read the registry token from stdin                                           |
+| `--from-file`          | `""`                        | Read the registry token from a file                                          |
+| `--server`             | `""` (matches image's host) | Registry host the credential applies to (e.g. `ghcr.io`); empty matches the registry extracted from the image reference at pull time |
+
+```bash
+# Pipe a token in from stdin (no token in shell history)
+echo "$GHCR_TOKEN" | sudo kuke create registry-credential default \
+    --server ghcr.io --username my-user --password-stdin
+
+# Or read it from a file
+sudo kuke create registry-credential default \
+    --server ghcr.io --username my-user --from-file ./ghcr-token.txt
 ```
 
 ## Imperative vs. declarative


### PR DESCRIPTION
## Summary

- Adds `kuke create registry-credential <realm>` — a first-class imperative path to attach private-registry pull credentials to an existing realm, removing the need to hand-edit a YAML manifest (and leak the token into a file) just to set `spec.registryCredentials`.
- The command reads the realm (`GetRealm`), upserts an entry keyed by `--server`, and re-applies the full realm doc through the daemon's write-through `ApplyDocuments` path. The pre-existing realm reconciler converges `registryCredentials` as a *compatible* change (`internal/controller/apply/diff.go:115` → `update_realm.go`), so there is no realm recreate and no daemon-side work.
- Token never enters argv: `--password-stdin` (read from stdin) or `--from-file <path>` (read from a file); exactly one is required. No plaintext `--password` flag, mirroring `kuke create secret`.
- `--server` defaults to empty (matches the registry extracted from the image reference at pull time), documented in `--help`.
- Wired into the `create` parent (registration, `Short`, completion list) and documented in the user-facing `docs/site/cli/kuke-create.md`.

### Implementation notes (for reviewer push-back)

- **Why a GetRealm → merge → ApplyDocuments round-trip:** the apply diff overwrites `spec.registryCredentials` wholesale (`UpdateRealm`: `existing.Spec.RegistryCredentials = desired.Spec.RegistryCredentials`). Sending only the new entry would wipe existing credentials, so the command must read the live list and merge. The existing namespace is preserved verbatim in the desired doc — a changed namespace would be a *breaking* change and rejected by the reconciler.
- **Not-found detection:** `GetRealm` returns no error for a missing realm — it sets `MetadataExists=false` (`internal/controller/get_realm.go:61`). The command checks that flag and exits non-zero with `realm "<name>" not found` (AC: unknown realm → clear error).
- **Upsert key:** exact match on `ServerAddress`, so the empty-server default upserts against itself rather than appending duplicates.
- **Docs bundled:** the user-facing `kuke-create.md` reference is updated to document the new command (resources list, alias note, dedicated section). This documents *this* feature, not an unrelated cleanup. No `*/CLAUDE.md` edits.

## Test plan

- [x] `make test` (full CI suite: test-root + test-kukebuild) — passes (exit 0). Updated two pre-existing assertions in `cmd/kuke/create/create_test.go` (subcommand `Short` string + completion count) that enumerate the create subcommand set.
- [x] `GOWORK=off go vet ./cmd/kuke/create/...` — clean.
- [x] New unit tests `cmd/kuke/create/registrycredential/registrycredential_test.go` cover: stdin happy-path append, `--from-file`, in-place upsert (same server, no duplicate), append on different server, empty-server self-upsert, unknown-realm error, both-sources rejected, no-source rejected, missing-username rejected, empty-token rejected, and absence of a plaintext `--password` flag.
- [x] `./kuke create registry-credential --help` renders the command, both token-source flags, and the `--server` default.
- [ ] **End-to-end private-image pull** (AC: "a cell in that realm successfully pulls a private image that previously returned 403") — not run. This requires a live daemon plus real private-registry credentials, which the dev host cannot provide. The converge path the command relies on is pre-existing and exercised at the diff/reconcile layer; the new code is verified at the GetRealm→upsert→ApplyDocuments boundary in unit tests. Recommend the reviewer (or a smoke run with a real token) confirm the live pull. The change is client-CLI-only — it touches no daemon, build-path, or `/opt/kukeon` code — so the `make dev-init` two-realm regression guard is not implicated.

## Acceptance criteria

- [x] `--server <host> --username <u> --password-stdin` reads the token from stdin and upserts a `RegistryCredentials` entry on the named realm.
- [x] `--from-file <path>` accepted as an alternative; exactly one of `--password-stdin` / `--from-file` is required (error otherwise).
- [x] Token never passed as an argv flag and never logged.
- [x] Re-running with the same `--server` updates the existing entry in place (no duplicate).
- [ ] After the command, a cell pulls a previously-403 private image without a realm recreate — deferred to a live environment (see test plan).
- [x] Unknown realm → non-zero exit with a clear "realm not found" error.
- [x] `--help` documents the command, both token-source flags, and the `--server` default.

## Follow-up

Per the issue Notes, the thin `kuke team init` wiring (point this command at the `default` realm to resolve the team 403) should be filed as a separate `epic:team2` follow-up once this lands. Not included here.

Closes #1130