### PR TITLE
fix(team): default rendered Config space/stack to default to stop spurious OutOfSync

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -666,6 +666,9 @@ func renderTeam(
 		ProjectRepoURL: strings.TrimSpace(projectURL),
 		ProjectDir:     projectDir,
 		TeamDir:        teamDir,
+		Realm:          pt.Spec.Realm,
+		Space:          pt.Spec.Space,
+		Stack:          pt.Spec.Stack,
 		Build:          doBuild,
 		SourceRef:      bundle.Source.Ref,
 	}

--- a/internal/cellconfig/materialize.go
+++ b/internal/cellconfig/materialize.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/cellblueprint"
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	v1beta1 "github.com/eminwux/kukeon/pkg/api/model/v1beta1"
 )
@@ -93,9 +94,9 @@ func MaterializeWithName(
 		},
 		Spec: v1beta1.CellSpec{
 			ID:                  cellName,
-			RealmID:             strings.TrimSpace(cfg.Metadata.Realm),
-			SpaceID:             strings.TrimSpace(cfg.Metadata.Space),
-			StackID:             strings.TrimSpace(cfg.Metadata.Stack),
+			RealmID:             defaultScope(cfg.Metadata.Realm, consts.KukeonDefaultRealmName),
+			SpaceID:             defaultScope(cfg.Metadata.Space, consts.KukeonDefaultSpaceName),
+			StackID:             defaultScope(cfg.Metadata.Stack, consts.KukeonDefaultStackName),
 			Tty:                 cloneCellTty(resolved.Spec.Cell.Tty),
 			Containers:          containers,
 			AutoDelete:          resolved.Spec.Cell.AutoDelete,
@@ -287,6 +288,21 @@ func mergeConfigLabel(in map[string]string, configName string) map[string]string
 	}
 	out[LabelConfig] = configName
 	return out
+}
+
+// defaultScope returns the trimmed scope coordinate, or def when it is empty.
+// The CLI create path (cmd/kuke/run/run.go) defaults an omitted realm/space/
+// stack to `default` before persisting the cell, so a Config that carries an
+// empty coordinate must materialize to the same `default` here — otherwise the
+// reconciler's re-materialization yields `"" != "default"` against the live
+// cell and apply.DiffCell reports a permanent spurious OutOfSync (#1133). This
+// hardens the reconcile path at its source, independent of whichever binding
+// produced the Config.
+func defaultScope(v, def string) string {
+	if trimmed := strings.TrimSpace(v); trimmed != "" {
+		return trimmed
+	}
+	return def
 }
 
 // cloneCellTty deep-copies a *CellTty so mutations on the materialized cell do

--- a/internal/cellconfig/materialize_test.go
+++ b/internal/cellconfig/materialize_test.go
@@ -166,6 +166,44 @@ func TestMaterialize_HappyPath_FillsRepoAndSecretSlots(t *testing.T) {
 	}
 }
 
+// TestMaterialize_EmptyScopeDefaultsToDefault is the reconcile-path half of the
+// #1133 fix: a Config carrying empty realm/space/stack (e.g. one written before
+// the team renderer stamped explicit scope) must materialize the cell at
+// `default/default/default` — matching what the CLI create path persists — so a
+// reconcile re-materialization does not report a permanent spurious OutOfSync on
+// spec.spaceName / spec.stackName.
+func TestMaterialize_EmptyScopeDefaultsToDefault(t *testing.T) {
+	bp := minimalBlueprint()
+	cfg := v1beta1.CellConfigDoc{
+		APIVersion: v1beta1.APIVersionV1Beta1,
+		Kind:       v1beta1.KindCellConfig,
+		Metadata:   v1beta1.CellConfigMetadata{Name: "team-cell"}, // realm/space/stack empty
+		Spec: v1beta1.CellConfigSpec{
+			Blueprint: v1beta1.CellConfigBlueprintRef{Name: "web"},
+			Repos: map[string]v1beta1.CellConfigRepoFill{
+				"src": {URL: "https://example.com/src.git"},
+			},
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "api-token"}},
+			},
+		},
+	}
+
+	cell, err := MaterializeWithName(cfg, bp, "team-cell")
+	if err != nil {
+		t.Fatalf("MaterializeWithName: %v", err)
+	}
+	if got := cell.Spec.RealmID; got != "default" {
+		t.Errorf("RealmID=%q want default (empty config realm defaulted)", got)
+	}
+	if got := cell.Spec.SpaceID; got != "default" {
+		t.Errorf("SpaceID=%q want default (empty config space defaulted)", got)
+	}
+	if got := cell.Spec.StackID; got != "default" {
+		t.Errorf("StackID=%q want default (empty config stack defaulted)", got)
+	}
+}
+
 func TestMaterialize_RequiredRepoSlotUnfilled_Errors(t *testing.T) {
 	bp := minimalBlueprint()
 	cfg := v1beta1.CellConfigDoc{

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -79,6 +79,20 @@ import (
 // `kuke-system`.
 const DefaultRealm = "default"
 
+// DefaultSpace and DefaultStack are the space/stack rendered objects bind
+// to when Inputs.Space / Inputs.Stack are empty. They mirror DefaultRealm
+// and the `default/default/default` coordinates the CLI create path
+// defaults an omitted scope to (cmd/kuke/run/run.go). Defaulting all three
+// here — rather than copying the (usually empty) template values — keeps
+// the rendered Config's scope identical to the live cell's persisted scope,
+// so the reconciler's re-materialization (internal/cellconfig/materialize.go)
+// produces matching spec.spaceName / spec.stackName and DiffCell reports no
+// spurious OutOfSync (#1133).
+const (
+	DefaultSpace = "default"
+	DefaultStack = "default"
+)
+
 // ProjectRepoSlotName is the convention for the structural repo slot that
 // carries the project's clone URL. The umbrella (epic #792) names `project`
 // and `agents` as the two repos a team cell typically clones; this package
@@ -117,7 +131,16 @@ type Inputs struct {
 	// blueprint templates as `.operator.TEAM_ROOT`. Per-team-scoped: two teams
 	// running on the same operator host see two different TEAM_ROOT values.
 	TeamDir string
-	Realm   string
+	// Realm, Space, and Stack are the scope coordinates the rendered
+	// Blueprints/Configs bind to. Each defaults to `default` when empty (see
+	// DefaultRealm / DefaultSpace / DefaultStack) so the rendered Config
+	// records an explicit scope matching the live cell the CLI create path
+	// persists, closing the defaulting asymmetry that caused spurious
+	// OutOfSync (#1133). Sourced from the project's kuketeam.yaml
+	// (ProjectTeamSpec) when declared.
+	Realm string
+	Space string
+	Stack string
 	// Build is true under `kuke team init --build`: the rendered blueprint
 	// binds the locally-built `kukeon.internal/<ref>:<version>` image (the tag
 	// teambuild produces) instead of the catalog entry's published `Image`.
@@ -175,6 +198,14 @@ func Render(
 	if realm == "" {
 		realm = DefaultRealm
 	}
+	space := strings.TrimSpace(in.Space)
+	if space == "" {
+		space = DefaultSpace
+	}
+	stack := strings.TrimSpace(in.Stack)
+	if stack == "" {
+		stack = DefaultStack
+	}
 
 	res := &Result{}
 	seenSelections := map[string]struct{}{}
@@ -199,14 +230,14 @@ func Render(
 
 			bp, renderErr := RenderBlueprint(
 				bundle.CacheDir, harness, role, hname, ptRole.Ref,
-				merged, entry, tc, bundle.Source, in, project, realm,
+				merged, entry, tc, bundle.Source, in, project, realm, space, stack,
 			)
 			if renderErr != nil {
 				return nil, fmt.Errorf(
 					"render %s/%s: %w", ptRole.Ref, hname, renderErr,
 				)
 			}
-			cfg := BindConfig(bp, role, ptRole.Ref, hname, tc, bundle.Source, in, project, realm)
+			cfg := BindConfig(bp, role, ptRole.Ref, hname, tc, bundle.Source, in, project, realm, space, stack)
 
 			res.Blueprints = append(res.Blueprints, bp)
 			res.Configs = append(res.Configs, cfg)
@@ -320,10 +351,13 @@ func SelectImage(
 // in.ProjectDir and in.TeamDir surface as `.project.PROJECT_DIR` and
 // `.operator.TEAM_ROOT` respectively; tc.spec.homeDir (or `$HOME` when
 // unset) fills `.operator.HOME_DIR`. The metadata.labels are populated
-// with `kukeon.io/team = project`. metadata.realm is forced to realm (the
-// template need not pre-fill it). If the template did not supply
-// metadata.name, the default `<role>-<harness>` is stamped so the
-// blueprint and its companion config share a deterministic identity.
+// with `kukeon.io/team = project`. metadata.realm/space/stack are forced to
+// the (defaulted) realm/space/stack scope (the template need not pre-fill
+// them) so the rendered Config records the same explicit scope the live
+// cell persists — closing the defaulting asymmetry behind the spurious
+// OutOfSync in #1133. If the template did not supply metadata.name, the
+// default `<role>-<harness>` is stamped so the blueprint and its companion
+// config share a deterministic identity.
 //
 // in.Build + in.SourceRef drive the `.image` bind decision (see
 // renderContextValues): in build mode the locally-built
@@ -339,7 +373,7 @@ func RenderBlueprint(
 	tc *model.TeamsConfig,
 	src teamsource.Source,
 	in Inputs,
-	project, realm string,
+	project, realm, space, stack string,
 ) (*v1beta1.CellBlueprintDoc, error) {
 	if h == nil || strings.TrimSpace(h.Spec.Template) == "" {
 		return nil, fmt.Errorf(
@@ -361,7 +395,7 @@ func RenderBlueprint(
 		return nil, err
 	}
 
-	ctx := renderContextValues(roleRef, harness, image, needs, r, tc, src, in, project, realm)
+	ctx := renderContextValues(roleRef, harness, image, needs, r, tc, src, in, project, realm, space, stack)
 	var buf bytes.Buffer
 	if execErr := tpl.ExecuteTemplate(&buf, filepath.Base(tplPath), ctx); execErr != nil {
 		return nil, fmt.Errorf("execute blueprint template %q: %w", tplPath, execErr)
@@ -382,6 +416,8 @@ func RenderBlueprint(
 		bp.Spec.Prefix = scopeToProject(p, project)
 	}
 	bp.Metadata.Realm = realm
+	bp.Metadata.Space = space
+	bp.Metadata.Stack = stack
 	if bp.Metadata.Labels == nil {
 		bp.Metadata.Labels = map[string]string{}
 	}
@@ -428,7 +464,7 @@ func BindConfig(
 	tc *model.TeamsConfig,
 	src teamsource.Source,
 	in Inputs,
-	project, realm string,
+	project, realm, space, stack string,
 ) *v1beta1.CellConfigDoc {
 	cfg := &v1beta1.CellConfigDoc{
 		APIVersion: v1beta1.APIVersionV1Beta1,
@@ -436,8 +472,8 @@ func BindConfig(
 		Metadata: v1beta1.CellConfigMetadata{
 			Name:  bp.Metadata.Name,
 			Realm: realm,
-			Space: bp.Metadata.Space,
-			Stack: bp.Metadata.Stack,
+			Space: space,
+			Stack: stack,
 			Labels: map[string]string{
 				v1beta1.LabelTeam: project,
 			},
@@ -446,8 +482,8 @@ func BindConfig(
 			Blueprint: v1beta1.CellConfigBlueprintRef{
 				Name:  bp.Metadata.Name,
 				Realm: realm,
-				Space: bp.Metadata.Space,
-				Stack: bp.Metadata.Stack,
+				Space: space,
+				Stack: stack,
 			},
 			Values: operatorValues(tc, roleRef, harness, project),
 		},
@@ -705,7 +741,7 @@ func renderContextValues(
 	tc *model.TeamsConfig,
 	src teamsource.Source,
 	in Inputs,
-	project, realm string,
+	project, realm, space, stack string,
 ) map[string]any {
 	img := ""
 	imgRef := ""
@@ -794,8 +830,8 @@ func renderContextValues(
 		"image":     img,
 		"image_ref": imgRef,
 		"realm":     realm,
-		"space":     "",
-		"stack":     "",
+		"space":     space,
+		"stack":     stack,
 	}
 }
 

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -268,6 +268,8 @@ func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
 		Inputs{},
 		"sbsh",
 		"default",
+		"default",
+		"default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -335,7 +337,7 @@ spec:
 	}
 	image := &model.ImageCatalogEntry{Ref: "claude-base", Harness: "claude", Image: "registry.local/claude:latest"}
 
-	bp, err := RenderBlueprint(cacheDir, h, r, "claude", "pm", nil, image, nil, teamsource.Source{}, Inputs{}, "kukeon", "default")
+	bp, err := RenderBlueprint(cacheDir, h, r, "claude", "pm", nil, image, nil, teamsource.Source{}, Inputs{}, "kukeon", "default", "default", "default")
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
 	}
@@ -360,7 +362,7 @@ spec:
         image: {{ .image }}
 `
 	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", idempotent)
-	bp2, err := RenderBlueprint(cacheDir, h, r, "claude", "pm", nil, image, nil, teamsource.Source{}, Inputs{}, "kukeon", "default")
+	bp2, err := RenderBlueprint(cacheDir, h, r, "claude", "pm", nil, image, nil, teamsource.Source{}, Inputs{}, "kukeon", "default", "default", "default")
 	if err != nil {
 		t.Fatalf("RenderBlueprint (idempotent): %v", err)
 	}
@@ -404,6 +406,8 @@ func TestRenderBlueprintBindsInternalRefInBuildMode(t *testing.T) {
 		teamsource.Source{},
 		Inputs{Build: true, SourceRef: "v1.4.0"},
 		"sbsh",
+		"default",
+		"default",
 		"default",
 	)
 	if err != nil {
@@ -454,6 +458,8 @@ func TestRenderBlueprintBindsPublishedRefWithoutBuild(t *testing.T) {
 				Inputs{Build: tc.build, SourceRef: tc.sourceRef},
 				"sbsh",
 				"default",
+				"default",
+				"default",
 			)
 			if err != nil {
 				t.Fatalf("RenderBlueprint: %v", err)
@@ -483,6 +489,8 @@ func TestRenderBlueprintMissingTemplate(t *testing.T) {
 		Inputs{},
 		"sbsh",
 		"default",
+		"default",
+		"default",
 	)
 	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
 		t.Fatalf("err = %v, want ErrTeamBlueprintTemplateMissing", err)
@@ -506,6 +514,8 @@ func TestRenderBlueprintEmptyTemplatePathRejected(t *testing.T) {
 		teamsource.Source{},
 		Inputs{},
 		"sbsh",
+		"default",
+		"default",
 		"default",
 	)
 	if !errors.Is(err, errdefs.ErrTeamBlueprintTemplateMissing) {
@@ -536,6 +546,8 @@ func TestRenderBlueprintResolvesTemplateRelativeToHarnessDir(t *testing.T) {
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "dev",
 		[]string{"git", "go"}, image, nil, teamsource.Source{}, Inputs{}, "sbsh", "default",
+		"default",
+		"default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint with bare-filename template: %v", err)
@@ -577,6 +589,8 @@ spec:
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "my-dev",
 		[]string{"go"}, image, nil, teamsource.Source{}, Inputs{}, "sbsh", "default",
+		"default",
+		"default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint with sibling partials: %v", err)
@@ -626,6 +640,8 @@ spec:
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "dev",
 		[]string{"go"}, image, tc, teamsource.Source{}, Inputs{}, "sbsh", "default",
+		"default",
+		"default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -675,6 +691,8 @@ spec:
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "pr-reviewer",
 		nil, image, nil, teamsource.Source{}, Inputs{}, "sbsh", "default",
+		"default",
+		"default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -720,6 +738,8 @@ spec:
 		teamsource.Source{},
 		Inputs{},
 		"sbsh",
+		"default",
+		"default",
 		"default",
 	)
 	if err != nil {
@@ -769,7 +789,7 @@ func TestBindConfigStampsTeamLabelAndProjectRepoFill(t *testing.T) {
 	}
 	in := Inputs{Project: "sbsh", ProjectRepoURL: "git@github.com:eminwux/sbsh.git"}
 
-	cfg := BindConfig(bp, role, "dev", "claude", tc, src, in, "sbsh", "default")
+	cfg := BindConfig(bp, role, "dev", "claude", tc, src, in, "sbsh", "default", "default", "default")
 	if cfg.Metadata.Labels[v1beta1.LabelTeam] != "sbsh" {
 		t.Errorf("team label = %q, want sbsh", cfg.Metadata.Labels[v1beta1.LabelTeam])
 	}
@@ -809,6 +829,8 @@ func TestBindConfigSkipsUndeclaredSlots(t *testing.T) {
 		in,
 		"sbsh",
 		"default",
+		"default",
+		"default",
 	)
 	if len(cfg.Spec.Repos) != 0 {
 		t.Errorf("repos should stay empty when template declares no slots: %+v", cfg.Spec.Repos)
@@ -841,7 +863,7 @@ func TestBindConfigFillsAgentsSlotFromTeamsConfigSources(t *testing.T) {
 		Ref:       "v1.4.0",
 		Kind:      teamsource.RefTag,
 	}
-	cfg := BindConfig(bp, minimalRole(), "dev", "claude", tc, src, Inputs{Project: "sbsh"}, "sbsh", "default")
+	cfg := BindConfig(bp, minimalRole(), "dev", "claude", tc, src, Inputs{Project: "sbsh"}, "sbsh", "default", "default", "default")
 	if got := cfg.Spec.Repos["agents"].URL; got != "git@github.com:eminwux/agents.git" {
 		t.Errorf("agents slot fill URL = %q, want agents.git", got)
 	}
@@ -1101,6 +1123,8 @@ spec:
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "dev",
 		[]string{"go"}, image, tc, src, in, "sbsh", "default",
+		"default",
+		"default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -1144,6 +1168,8 @@ spec:
 	bp, err := RenderBlueprint(
 		cacheDir, h, minimalRole(), "claude", "dev",
 		[]string{"go"}, image, tc, src, Inputs{Project: "sbsh"}, "sbsh", "default",
+		"default",
+		"default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -1182,6 +1208,8 @@ spec:
 		cacheDir, h, minimalRole(), "claude", "dev",
 		[]string{"go"}, image, &model.TeamsConfig{}, teamsource.Source{},
 		Inputs{Project: "sbsh"}, "sbsh", "default",
+		"default",
+		"default",
 	)
 	if err != nil {
 		t.Fatalf("RenderBlueprint: %v", err)
@@ -1277,5 +1305,94 @@ func TestRenderDefaultRealmFallback(t *testing.T) {
 	}
 	if res.Blueprints[0].Metadata.Realm != DefaultRealm {
 		t.Errorf("realm = %q, want %q", res.Blueprints[0].Metadata.Realm, DefaultRealm)
+	}
+}
+
+// TestRenderDefaultsSpaceStackOnBlueprintAndConfig is the regression guard for
+// #1133: with Inputs leaving space/stack empty, the rendered Blueprint AND its
+// companion Config (metadata + Spec.Blueprint ref) must all stamp an explicit
+// `default` space/stack — not the template's empty values — so the persisted
+// Config scope matches the live cell the CLI create path defaults to
+// `default/default/default`, and DiffCell reports no spurious OutOfSync.
+func TestRenderDefaultsSpaceStackOnBlueprintAndConfig(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	buildClaudeTemplate(t, cacheDir)
+	bundle := &teamsource.Bundle{
+		CacheDir: cacheDir,
+		Roles:    map[string]*model.Role{"dev": minimalRole()},
+		Harnesses: map[string]*model.Harness{
+			"claude": {Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}},
+		},
+		ImageCatalog: minimalClaudeCatalog("go", "git"),
+	}
+	pt := &model.ProjectTeam{
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec: model.ProjectTeamSpec{
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	// Inputs carries no Realm/Space/Stack — exercises the all-defaults path.
+	res, err := Render(bundle, pt, nil, Inputs{Project: "sbsh"})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	bp := res.Blueprints[0]
+	if bp.Metadata.Space != DefaultSpace || bp.Metadata.Stack != DefaultStack {
+		t.Errorf("blueprint space/stack = %q/%q, want %q/%q",
+			bp.Metadata.Space, bp.Metadata.Stack, DefaultSpace, DefaultStack)
+	}
+	cfg := res.Configs[0]
+	if cfg.Metadata.Realm != DefaultRealm || cfg.Metadata.Space != DefaultSpace || cfg.Metadata.Stack != DefaultStack {
+		t.Errorf("config metadata realm/space/stack = %q/%q/%q, want %q/%q/%q",
+			cfg.Metadata.Realm, cfg.Metadata.Space, cfg.Metadata.Stack,
+			DefaultRealm, DefaultSpace, DefaultStack)
+	}
+	ref := cfg.Spec.Blueprint
+	if ref.Realm != DefaultRealm || ref.Space != DefaultSpace || ref.Stack != DefaultStack {
+		t.Errorf("config blueprint ref realm/space/stack = %q/%q/%q, want %q/%q/%q",
+			ref.Realm, ref.Space, ref.Stack, DefaultRealm, DefaultSpace, DefaultStack)
+	}
+}
+
+// TestRenderHonorsInputsScope confirms explicit Inputs.Realm/Space/Stack
+// (sourced from kuketeam.yaml's ProjectTeamSpec) flow through to both the
+// Blueprint and Config scope coordinates rather than being overridden by the
+// defaults.
+func TestRenderHonorsInputsScope(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	buildClaudeTemplate(t, cacheDir)
+	bundle := &teamsource.Bundle{
+		CacheDir: cacheDir,
+		Roles:    map[string]*model.Role{"dev": minimalRole()},
+		Harnesses: map[string]*model.Harness{
+			"claude": {Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}},
+		},
+		ImageCatalog: minimalClaudeCatalog("go", "git"),
+	}
+	pt := &model.ProjectTeam{
+		Metadata: model.Metadata{Name: "sbsh"},
+		Spec: model.ProjectTeamSpec{
+			Defaults: model.ProjectTeamDefaults{Harnesses: []string{"claude"}},
+			Roles:    []model.ProjectTeamRole{{Ref: "dev"}},
+		},
+	}
+	res, err := Render(bundle, pt, nil, Inputs{
+		Project: "sbsh", Realm: "prod", Space: "platform", Stack: "agents",
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	bp := res.Blueprints[0]
+	if bp.Metadata.Realm != "prod" || bp.Metadata.Space != "platform" || bp.Metadata.Stack != "agents" {
+		t.Errorf("blueprint realm/space/stack = %q/%q/%q, want prod/platform/agents",
+			bp.Metadata.Realm, bp.Metadata.Space, bp.Metadata.Stack)
+	}
+	cfg := res.Configs[0]
+	if cfg.Metadata.Realm != "prod" || cfg.Metadata.Space != "platform" || cfg.Metadata.Stack != "agents" {
+		t.Errorf("config realm/space/stack = %q/%q/%q, want prod/platform/agents",
+			cfg.Metadata.Realm, cfg.Metadata.Space, cfg.Metadata.Stack)
 	}
 }

--- a/internal/teamrender/validate.go
+++ b/internal/teamrender/validate.go
@@ -452,7 +452,7 @@ func knownFactKeys() (map[string]struct{}, map[string]struct{}) {
 	satSrc := teamsource.Source{Host: "_", OwnerRepo: "_/_"}
 	satIn := Inputs{ProjectDir: "_", TeamDir: "_"}
 
-	ctx := renderContextValues("_", "_", nil, nil, nil, satTC, satSrc, satIn, "_", DefaultRealm)
+	ctx := renderContextValues("_", "_", nil, nil, nil, satTC, satSrc, satIn, "_", DefaultRealm, DefaultSpace, DefaultStack)
 	op := keySet(ctx["operator"])
 	pr := keySet(ctx["project"])
 	return op, pr

--- a/pkg/api/model/kuketeams/projectteam.go
+++ b/pkg/api/model/kuketeams/projectteam.go
@@ -35,6 +35,14 @@ type ProjectTeamSpec struct {
 	// `<owner>/<repo>@vX.Y.Z` string form is rejected at parse time with a
 	// migration error.
 	Source TeamSource `json:"source"             yaml:"source"`
+	// Realm, Space, and Stack are the optional scope coordinates the team's
+	// rendered cells bind to. Each defaults to `default` when omitted (the
+	// renderer stamps the defaulted value onto every rendered Blueprint/Config
+	// so the persisted Config scope matches the live cell — see teamrender
+	// DefaultRealm / DefaultSpace / DefaultStack and #1133).
+	Realm string `json:"realm,omitempty"    yaml:"realm,omitempty"`
+	Space string `json:"space,omitempty"    yaml:"space,omitempty"`
+	Stack string `json:"stack,omitempty"    yaml:"stack,omitempty"`
 	// Defaults supplies project-wide harness defaults applied to every role
 	// that does not pin its own.
 	Defaults ProjectTeamDefaults `json:"defaults,omitempty" yaml:"defaults,omitempty"`


### PR DESCRIPTION
## Summary

- `teamrender` defaulted only the **realm** of rendered Blueprints/Configs to `default`, leaving **space**/**stack** as the (usually empty) template values. The CLI create path then defaults the empty space/stack to `default` and persists them on the live cell, while the daemon's reconciler re-materializes from the Config with the empty values verbatim — so `apply.DiffCell` saw `"" != "default"` and reported a permanent spurious `OutOfSync` on `spec.spaceName` / `spec.stackName` (#1133). This undermined the `epic:reconcile` drift signal.
- Fix closes the defaulting asymmetry at both ends:
  - **`internal/teamrender/teamrender.go`** — added `DefaultSpace` / `DefaultStack` consts; default `Inputs.Space` / `Inputs.Stack` alongside realm in `Render`; thread the defaulted space/stack through `RenderBlueprint` (stamped onto `bp.Metadata.Space`/`.Stack`), `BindConfig` (Config `Metadata` + `Spec.Blueprint` ref now use the defaulted values, not the empty template ones), and `renderContextValues` (the `.space`/`.stack` dot-context leaves now carry the real scope instead of `""`).
  - **`pkg/api/model/kuketeams/projectteam.go`** — surfaced optional `realm`/`space`/`stack` on `ProjectTeamSpec` so `kuketeam.yaml` can declare them (Expected-behavior item 1). Plumbed through `teamrender.Inputs` in **`cmd/kuke/team/init.go`**. The loader uses plain `yaml.Unmarshal` (not strict), so existing kuketeam.yaml files are unaffected.
  - **`internal/cellconfig/materialize.go`** (belt-and-suspenders, recommended by the issue) — `MaterializeWithName` now defaults an empty realm/space/stack to `default` (via `consts.KukeonDefault*Name`), hardening the reconcile re-materialization path against any Config that carries an empty coordinate, matching what the CLI create path persists.

Implementation note (lower-blast-radius call): I implemented both Expected-behavior items — the consistent defaulting (item 2, the actual bug fix) and the `kuketeam.yaml` realm/space/stack surfacing (item 1, marked "Optionally" in the proposed fix) — plus the recommended materialize hardening. I did **not** add `kuke team init` CLI flags for scope (the proposed fix offered them as an alternative to the kuketeam.yaml field); the committed-file field is the lower-blast-radius surface and matches how the rest of the roster is declared. The reviewer can push back if CLI flags are wanted too.

Note on pre-existing Configs: as the issue calls out, Configs already written without space/stack will still report drift until re-applied — the materialize defaulting now papers over that too, so a reconcile alone heals them.

## Test plan
- [x] `make test` (full CI target: `test-root` + `test-kukebuild`) — pass
- [x] `GOWORK=off go vet ./internal/teamrender/ ./internal/cellconfig/ ./cmd/kuke/team/ ./pkg/api/model/kuketeams/` — clean
- [x] New regression tests: `TestRenderDefaultsSpaceStackOnBlueprintAndConfig`, `TestRenderHonorsInputsScope` (teamrender), `TestMaterialize_EmptyScopeDefaultsToDefault` (cellconfig)

Closes #1133