### PR TITLE
fix(controller): reproduce runner-injected container fields in OutOfSync re-materialization

### DIFF
--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -45,12 +45,13 @@ type fakeRunner struct {
 	DeleteRealmFn                    func(realm intmodel.Realm) error
 
 	// Space methods
-	GetSpaceFn             func(space intmodel.Space) (intmodel.Space, error)
-	ListSpacesFn           func(realmName string) ([]intmodel.Space, error)
-	CreateSpaceFn          func(space intmodel.Space) (intmodel.Space, error)
-	EnsureSpaceFn          func(space intmodel.Space) (intmodel.Space, error)
-	ExistsSpaceCNIConfigFn func(space intmodel.Space) (bool, error)
-	DeleteSpaceFn          func(space intmodel.Space) error
+	GetSpaceFn                  func(space intmodel.Space) (intmodel.Space, error)
+	ListSpacesFn                func(realmName string) ([]intmodel.Space, error)
+	CreateSpaceFn               func(space intmodel.Space) (intmodel.Space, error)
+	EnsureSpaceFn               func(space intmodel.Space) (intmodel.Space, error)
+	ExistsSpaceCNIConfigFn      func(space intmodel.Space) (bool, error)
+	ResolveSpaceCNIConfigPathFn func(realmName, spaceName string) (string, error)
+	DeleteSpaceFn               func(space intmodel.Space) error
 
 	// Stack methods
 	GetStackFn    func(stack intmodel.Stack) (intmodel.Stack, error)
@@ -202,6 +203,13 @@ func (f *fakeRunner) GetSpace(space intmodel.Space) (intmodel.Space, error) {
 		return f.GetSpaceFn(space)
 	}
 	return intmodel.Space{}, errors.New("unexpected call to GetSpace")
+}
+
+func (f *fakeRunner) ResolveSpaceCNIConfigPath(realmName, spaceName string) (string, error) {
+	if f.ResolveSpaceCNIConfigPathFn != nil {
+		return f.ResolveSpaceCNIConfigPathFn(realmName, spaceName)
+	}
+	return "", errors.New("unexpected call to ResolveSpaceCNIConfigPath")
 }
 
 func (f *fakeRunner) ListSpaces(realmName string) ([]intmodel.Space, error) {

--- a/internal/controller/reconcile_outofsync.go
+++ b/internal/controller/reconcile_outofsync.go
@@ -255,7 +255,63 @@ func materializeCellFromConfig(
 	if convErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("convert materialized cell: %w", convErr)
 	}
+
+	// Reproduce the runner-injected, space-derived container fields the
+	// re-materialization does not, so apply.DiffCell does not report them as
+	// spurious drift (#1136).
+	if err := applyRunnerInjectedContainerFields(r, &desired); err != nil {
+		return intmodel.Cell{}, err
+	}
+
 	return desired, nil
+}
+
+// applyRunnerInjectedContainerFields re-applies the space-derived container
+// fields the runner bakes onto every persisted container spec at create/start
+// but cellconfig.MaterializeWithName (Config + Blueprint only) never
+// reproduces. Without this, apply.DiffCell flags those runner-injected values
+// as spurious drift and a Config-lineage cell sticks on a permanent OutOfSync
+// even though nothing actually changed (#1136). Two field classes are
+// reproduced, mirroring provision.go's create/start path:
+//
+//   - Space container defaults (user, readOnlyRootFilesystem, capabilities,
+//     securityOpts, tmpfs, resources) via ApplySpaceDefaultsToContainer — the
+//     same helper applyCellContainerDefaults funnels every create flow
+//     through. The `default` space declares no container defaults, so this is
+//     dormant today but closes the latent class the moment a space sets one.
+//   - The space/runtime-derived cniConfigPath, resolved by the same
+//     ResolveSpaceCNIConfigPath the runner uses, set only on containers that
+//     do not already carry an explicit one (mirroring the `if == ""` guard in
+//     provision.go). This is the field firing today.
+//
+// The cell's own realm/space drive the lookups, matching the scope the runner
+// resolved against at create time. A GetSpace / ResolveSpaceCNIConfigPath error
+// surfaces (via the caller) as an undecidable OutOfSync (OutOfSyncError), the
+// same class materialization errors already use; the runner-synthesized root
+// container is untouched because DiffCell skips it.
+func applyRunnerInjectedContainerFields(r runner.Runner, cell *intmodel.Cell) error {
+	realm, space := cell.Spec.RealmName, cell.Spec.SpaceName
+
+	parentSpace, err := r.GetSpace(intmodel.Space{
+		Metadata: intmodel.SpaceMetadata{Name: space},
+		Spec:     intmodel.SpaceSpec{RealmName: realm},
+	})
+	if err != nil {
+		return fmt.Errorf("resolve space %q defaults: %w", space, err)
+	}
+
+	cniConfigPath, err := r.ResolveSpaceCNIConfigPath(realm, space)
+	if err != nil {
+		return fmt.Errorf("resolve space %q cni config path: %w", space, err)
+	}
+
+	for i := range cell.Spec.Containers {
+		intmodel.ApplySpaceDefaultsToContainer(parentSpace, &cell.Spec.Containers[i])
+		if cell.Spec.Containers[i].CNIConfigPath == "" {
+			cell.Spec.Containers[i].CNIConfigPath = cniConfigPath
+		}
+	}
+	return nil
 }
 
 // outOfSyncSpecDifferReason renders the DiffCell verdict as a stable,

--- a/internal/controller/reconcile_outofsync_test.go
+++ b/internal/controller/reconcile_outofsync_test.go
@@ -82,6 +82,17 @@ func stubLineageRunner(
 			// against the same cell the harness fed in.
 			return c, runner.ReconcileOutcome{}, nil
 		},
+		// materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields (#1136). The sample cell carries no
+		// container defaults and an empty cniConfigPath, so the defaults below
+		// are no-ops that keep the materialized "desired" byte-identical to the
+		// materialized "live" sample cell; divergence tests override them.
+		GetSpaceFn: func(s intmodel.Space) (intmodel.Space, error) {
+			return s, nil
+		},
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) {
+			return "", nil
+		},
 		ListRealmsFn: func() ([]intmodel.Realm, error) {
 			return []intmodel.Realm{buildTestRealm("kuke-system", "")}, nil
 		},
@@ -242,6 +253,73 @@ func TestReconcileCells_OutOfSync_MatchingCellStaysSynced(t *testing.T) {
 	}
 	if res.CellsErrored != 0 || len(res.Errors) != 0 {
 		t.Errorf("synced pass surfaced errors: %+v", res)
+	}
+}
+
+// TestReconcileCells_OutOfSync_RunnerInjectedContainerFieldsStaySynced pins
+// the #1136 fix: the runner bakes a space/runtime-derived cniConfigPath — and,
+// when the space declares them, container defaults (user, …) — onto every
+// persisted container spec at create/start, but cellconfig.MaterializeWithName
+// reproduces neither. Before the fix apply.DiffCell saw `"" != "/opt/.../
+// network.conflist"` (and the analogous space-default mismatch) and the cell
+// stuck on a permanent spurious OutOfSync. The detector now re-applies both
+// classes against the cell's space, so a cell that has only the runner-injected
+// fields stays Synced and skips the metadata write.
+func TestReconcileCells_OutOfSync_RunnerInjectedContainerFieldsStaySynced(t *testing.T) {
+	live := materializeSampleCell(t)
+	if len(live.Spec.Containers) == 0 {
+		t.Fatalf("test fixture has no containers — sampleConfig/sampleReferencedBlueprint changed?")
+	}
+
+	const cniPath = "/opt/kukeon/data/default/default/network.conflist"
+	const spaceDefaultUser = "1000:1000"
+	// Mimic provision.go: bake the space-derived cniConfigPath plus a space
+	// container default onto every non-root container. The root container is
+	// runner-synthesized and skipped by DiffCell, so it is left alone.
+	for i := range live.Spec.Containers {
+		if live.Spec.Containers[i].Root {
+			continue
+		}
+		live.Spec.Containers[i].CNIConfigPath = cniPath
+		live.Spec.Containers[i].User = spaceDefaultUser
+	}
+
+	var updateCalls atomic.Int32
+	mock := stubLineageRunner(
+		func(intmodel.CellConfig) (intmodel.CellConfig, error) {
+			return configCarrier(t, sampleConfig()), nil
+		},
+		func(intmodel.CellBlueprint) (intmodel.CellBlueprint, error) {
+			return blueprintCarrier(t, sampleReferencedBlueprint()), nil
+		},
+		func(intmodel.Cell) error {
+			updateCalls.Add(1)
+			return nil
+		},
+	)
+	// Reproduce what the runner resolved at create time: the same cniConfigPath
+	// and the same space container default. The re-materialized desired must
+	// then match the live cell.
+	mock.ResolveSpaceCNIConfigPathFn = func(string, string) (string, error) {
+		return cniPath, nil
+	}
+	mock.GetSpaceFn = func(s intmodel.Space) (intmodel.Space, error) {
+		s.Spec.Defaults = &intmodel.SpaceDefaults{
+			Container: &intmodel.SpaceContainerDefaults{User: spaceDefaultUser},
+		}
+		return s, nil
+	}
+
+	res, _ := runOutOfSyncHarness(t, live, mock)
+
+	if got := updateCalls.Load(); got != 0 {
+		t.Errorf("UpdateCellMetadata calls: got %d, want 0 (runner-injected container fields must not produce spurious OutOfSync)", got)
+	}
+	if res.CellsUpdated != 0 {
+		t.Errorf("CellsUpdated: got %d, want 0", res.CellsUpdated)
+	}
+	if res.CellsErrored != 0 || len(res.Errors) != 0 {
+		t.Errorf("runner-injected-field pass surfaced errors: %+v", res)
 	}
 }
 

--- a/internal/controller/runner/delete_space.go
+++ b/internal/controller/runner/delete_space.go
@@ -100,7 +100,7 @@ func (r *Exec) DeleteSpace(space intmodel.Space) error {
 	if err != nil {
 		r.logger.WarnContext(r.ctx, "failed to build network name, skipping CNI config deletion", "error", err)
 	} else {
-		confPath, _ := r.resolveSpaceCNIConfigPath(realmName, internalSpace.Metadata.Name)
+		confPath, _ := r.ResolveSpaceCNIConfigPath(realmName, internalSpace.Metadata.Name)
 		// teardownSpaceCNI reads the bridge name from confPath BEFORE removing
 		// the conflist, then deletes the bridge link. Safe when confPath is "".
 		r.teardownSpaceCNI(networkName, confPath)

--- a/internal/controller/runner/kill.go
+++ b/internal/controller/runner/kill.go
@@ -90,7 +90,7 @@ func (r *Exec) killCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 		return intmodel.Cell{}, errdefs.ErrStackNameRequired
 	}
 
-	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmID, spaceID)
+	cniConfigPath, cniErr := r.ResolveSpaceCNIConfigPath(realmID, spaceID)
 	if cniErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
 	}

--- a/internal/controller/runner/lifecycle.go
+++ b/internal/controller/runner/lifecycle.go
@@ -138,7 +138,13 @@ func (r *Exec) killContainerTask(realmNamespace, containerID string) error {
 	return nil
 }
 
-func (r *Exec) resolveSpaceCNIConfigPath(realmID, spaceID string) (string, error) {
+// ResolveSpaceCNIConfigPath resolves the CNI conflist path the runner bakes
+// onto every container spec it provisions in the given realm/space: the
+// space's explicit spec.cniConfigPath when set, otherwise the conventional
+// per-space default under the run path. Exported so the OutOfSync detector's
+// re-materialization (reconcile_outofsync.go) can reproduce the same
+// runner-injected value and avoid a spurious drift (#1136).
+func (r *Exec) ResolveSpaceCNIConfigPath(realmID, spaceID string) (string, error) {
 	lookupSpace := intmodel.Space{
 		Metadata: intmodel.SpaceMetadata{
 			Name: spaceID,

--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1373,7 +1373,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, err
 	}
 
-	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmName, spaceName)
+	cniConfigPath, cniErr := r.ResolveSpaceCNIConfigPath(realmName, spaceName)
 	if cniErr != nil {
 		return nil, fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
 	}
@@ -1683,7 +1683,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 		return nil, err
 	}
 
-	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmName, spaceName)
+	cniConfigPath, cniErr := r.ResolveSpaceCNIConfigPath(realmName, spaceName)
 	if cniErr != nil {
 		return nil, fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
 	}
@@ -2156,7 +2156,7 @@ func (r *Exec) ensureCellRootContainerSpec(cell intmodel.Cell) (intmodel.Contain
 	}
 
 	// Resolve CNI config path
-	cniConfigPath, err := r.resolveSpaceCNIConfigPath(realmName, spaceName)
+	cniConfigPath, err := r.ResolveSpaceCNIConfigPath(realmName, spaceName)
 	if err != nil {
 		return intmodel.ContainerSpec{}, fmt.Errorf("failed to resolve space CNI config: %w", err)
 	}

--- a/internal/controller/runner/recreate_cell.go
+++ b/internal/controller/runner/recreate_cell.go
@@ -140,7 +140,7 @@ func (r *Exec) RecreateCell(desired intmodel.Cell) (_ intmodel.Cell, retErr erro
 	// the stop/kill/delete teardown paths; the name is a pure function of (realm,
 	// space).
 	cellName := strings.TrimSpace(existing.Metadata.Name)
-	cniConfigPath, _ := r.resolveSpaceCNIConfigPath(realmName, spaceName)
+	cniConfigPath, _ := r.ResolveSpaceCNIConfigPath(realmName, spaceName)
 	networkName := r.buildRootCNINetworkName(realmName, spaceName)
 	_ = teardownRootContainerCNI(
 		func() {

--- a/internal/controller/runner/recreate_cell_test.go
+++ b/internal/controller/runner/recreate_cell_test.go
@@ -101,7 +101,7 @@ func seedRecreateCellSpace(t *testing.T, r *Exec, realm, space string) {
 		APIVersion: v1beta1.APIVersionV1Beta1,
 		Kind:       v1beta1.KindSpace,
 		Metadata:   v1beta1.SpaceMetadata{Name: space},
-		// An explicit CNIConfigPath short-circuits resolveSpaceCNIConfigPath's
+		// An explicit CNIConfigPath short-circuits ResolveSpaceCNIConfigPath's
 		// default-path build; the path is never read because the root is
 		// host-network (CNI ADD is skipped).
 		Spec: v1beta1.SpaceSpec{RealmID: realm, CNIConfigPath: filepath.Join(t.TempDir(), "cni.conflist")},

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -67,6 +67,13 @@ type Runner interface {
 	EnsureSpace(space intmodel.Space) (intmodel.Space, error)
 	UpdateSpace(space intmodel.Space) (intmodel.Space, error)
 	ExistsSpaceCNIConfig(space intmodel.Space) (bool, error)
+	// ResolveSpaceCNIConfigPath resolves the CNI conflist path the runner
+	// bakes onto every container spec it provisions in the given realm/space
+	// (space spec.cniConfigPath when set, else the per-space default under the
+	// run path). Exported for the OutOfSync detector so its re-materialization
+	// reproduces the same runner-injected value rather than flagging it as
+	// spurious drift (#1136).
+	ResolveSpaceCNIConfigPath(realmName, spaceName string) (string, error)
 	DeleteSpace(space intmodel.Space) error
 
 	GetCell(cell intmodel.Cell) (intmodel.Cell, error)

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -545,7 +545,7 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 	spaceID := cellSpec.SpaceName
 	stackID := cellSpec.StackName
 
-	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmID, spaceID)
+	cniConfigPath, cniErr := r.ResolveSpaceCNIConfigPath(realmID, spaceID)
 	if cniErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
 	}

--- a/internal/controller/runner/stop.go
+++ b/internal/controller/runner/stop.go
@@ -91,7 +91,7 @@ func (r *Exec) stopCellLocked(cell intmodel.Cell) (intmodel.Cell, error) {
 		stackName = specStack
 	}
 
-	cniConfigPath, cniErr := r.resolveSpaceCNIConfigPath(realmName, spaceName)
+	cniConfigPath, cniErr := r.ResolveSpaceCNIConfigPath(realmName, spaceName)
 	if cniErr != nil {
 		return intmodel.Cell{}, fmt.Errorf("failed to resolve space CNI config: %w", cniErr)
 	}

--- a/internal/controller/runner/stop_kill_test.go
+++ b/internal/controller/runner/stop_kill_test.go
@@ -214,7 +214,7 @@ func seedStopKillSpace(t *testing.T, r *Exec, realm, space string) {
 		Kind:       v1beta1.KindSpace,
 		Metadata:   v1beta1.SpaceMetadata{Name: space},
 		// An explicit CNIConfigPath short-circuits the default-path build in
-		// resolveSpaceCNIConfigPath; the file is never read because the
+		// ResolveSpaceCNIConfigPath; the file is never read because the
 		// stop/kill paths only forward it to detach calls the fake ignores.
 		Spec: v1beta1.SpaceSpec{RealmID: realm, CNIConfigPath: filepath.Join(t.TempDir(), "cni.conflist")},
 	}

--- a/internal/controller/start_cell_reapply_test.go
+++ b/internal/controller/start_cell_reapply_test.go
@@ -191,6 +191,13 @@ func TestStartCell_OutOfSyncReapply_CompatibleAppliesInPlace(t *testing.T) {
 		},
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		GetConfigFn: func(c intmodel.CellConfig) (intmodel.CellConfig, error) {
 			if c.Metadata.Name != "prod" || c.Metadata.Realm != "test-realm" {
 				t.Errorf("GetConfig lookup = %+v, want name=prod realm=test-realm", c.Metadata)
@@ -274,6 +281,13 @@ func TestStartCell_OutOfSyncReapply_BreakingRecreates(t *testing.T) {
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
 			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
 		},
@@ -358,6 +372,13 @@ func TestStartCell_OutOfSyncReapply_EnvOverridePreserved(t *testing.T) {
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
 			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
 		},
@@ -425,6 +446,13 @@ func TestStartCell_OutOfSyncReapply_CompatibleUpdateErrorStillReady(t *testing.T
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
 			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
 		},
@@ -472,6 +500,13 @@ func TestStartCell_OutOfSyncReapply_NoLineageLabelSkipsReapply(t *testing.T) {
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		RecreateCellFn: func(intmodel.Cell) (intmodel.Cell, error) {
 			recreateCalled = true
 			return intmodel.Cell{}, nil
@@ -506,6 +541,13 @@ func TestStartCell_OutOfSyncReapply_OutOfSyncErrorSkipsReapply(t *testing.T) {
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
 			getConfigCalled = true
 			return intmodel.CellConfig{}, nil
@@ -540,6 +582,13 @@ func TestStartCell_OutOfSyncReapply_OutOfSyncFalseSkipsReapply(t *testing.T) {
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
 			getConfigCalled = true
 			return intmodel.CellConfig{}, nil
@@ -577,6 +626,13 @@ func TestStartCell_OutOfSyncReapply_LineageConfigDeletedFallsThrough(t *testing.
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
 			// The scope-narrowing walk probes (space, stack), (space, ""), ("", "").
 			// All three miss on a deleted Config.
@@ -620,6 +676,13 @@ func TestStartCell_OutOfSyncReapply_RecreateErrorFallsThrough(t *testing.T) {
 		GetCellFn:                 func(_ intmodel.Cell) (intmodel.Cell, error) { return live, nil },
 		ExistsCgroupFn:            func(_ any) (bool, error) { return true, nil },
 		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) { return true, nil },
+		// #1136: materializeCellFromConfig now reproduces the runner-injected
+		// space-derived container fields. The reapply fixtures' containers carry
+		// neither an explicit cniConfigPath nor space defaults, so these stubs
+		// return empties — keeping the materialised desired diff to the intended
+		// image/hostNetwork drift only.
+		GetSpaceFn:                  func(s intmodel.Space) (intmodel.Space, error) { return s, nil },
+		ResolveSpaceCNIConfigPathFn: func(string, string) (string, error) { return "", nil },
 		GetConfigFn: func(intmodel.CellConfig) (intmodel.CellConfig, error) {
 			return reapplySampleCellConfig("test-realm", "test-space", "test-stack"), nil
 		},


### PR DESCRIPTION
## Summary
- Config-lineage cells were reported permanently `OutOfSync` with reason `spec differs at containers[<name>].cniConfigPath` even when nothing drifted (#1136). The runner bakes a space/runtime-derived `cniConfigPath` (and, when a space declares them, container defaults) onto every persisted container spec at create/start, but the reconciler's re-materialization (`cellconfig.MaterializeWithName`, Config + Blueprint only) reproduced neither — so `apply.DiffCell` always saw `"" != "/opt/.../network.conflist"`.
- Same bug class as #1133/#1134, one level down at the container spec. Applies the **preferred** fix from the issue: re-derive the runner-injected fields in `materializeCellFromConfig` (which holds the runner `r`), closing both the active `cniConfigPath` drift and the latent space-defaults class (`user`, `readOnlyRootFilesystem`, `capabilities`, `securityOpts`, `tmpfs`, `resources`) in one shot.

## Changes
- `internal/controller/reconcile_outofsync.go`: new `applyRunnerInjectedContainerFields(r, &desired)`, called at the tail of `materializeCellFromConfig`. It fetches the cell's parent Space and runs `ApplySpaceDefaultsToContainer` per container, then sets the resolved `cniConfigPath` on each container that lacks an explicit one — mirroring `provision.go`'s `applyCellContainerDefaults` and the `if == ""` guard. The runner-synthesized root container is untouched because `DiffCell` already skips it. A `GetSpace`/resolve error surfaces as the existing undecidable-`OutOfSyncError` state.
- `internal/controller/runner/lifecycle.go` + `runner.go`: exported the existing `resolveSpaceCNIConfigPath` as `ResolveSpaceCNIConfigPath` and added it to the `Runner` interface, so the detector resolves the path through the **same** single source of truth the runner uses (the default-path branch needs the runner's run-path, which is not otherwise reachable through the interface). Internal callers (`start.go`, `provision.go`, `kill.go`, `stop.go`, `delete_space.go`, `recreate_cell.go`) updated to the exported name.
- `materializeCellFromConfig` is also used by the `StartCell` OutOfSync reapply path (`start_cell.go`), so the fix benefits that path too; its tests' `fakeRunner` fixtures gained the two new dependency stubs (returning empties, so the intended image/hostNetwork drift remains the only diff).

## Implementation notes
- **Gate-vs-flip / blast radius:** chose the issue's *preferred* approach over the narrower "skip empty `desired.CNIConfigPath` in `diffContainerSpec`" alternative because the latter leaves the latent space-defaults class unfixed; the preferred approach reuses the runner's own resolver so the desired value is byte-identical to what was persisted.
- The cell's own realm/space drive the lookups, matching the scope the runner resolved at create time (consistent with #1134's `default`-scope defaulting, so the materialized scope equals the live cell's).

## Test plan
- [x] `make test` (full CI target: `test-root` + `test-kukebuild`) — green.
- [x] New `TestReconcileCells_OutOfSync_RunnerInjectedContainerFieldsStaySynced` — a cell carrying only the runner-injected `cniConfigPath` + a space-default `user` now stays Synced with no metadata write (fails before the fix).
- [x] Existing `OutOfSync` + `StartCell_OutOfSyncReapply` suites — green after wiring the new stubs.
- [x] `GOWORK=off go build ./...` / `go vet ./internal/controller/...` — clean.
- [x] Interface-implementor sweep: `Runner` implementors are `*Exec` (production) and `fakeRunner` (tests); `reconcileFakeRunner` embeds the interface. All carry the new method.
- [x] Tree-wide `git grep resolveSpaceCNIConfigPath` — no stale lowercase references remain.

Closes #1136