### PR TITLE
fix(team): bind role.needs.secrets fills regardless of tc.spec.secrets

### DIFF
--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -453,10 +453,11 @@ func scopeToProject(name, project string) string {
 // the `agents` slot — both only when the blueprint actually declares the
 // slot, so a template that doesn't carry the slot produces a config
 // without a stray fill. role.Spec.Needs.Secrets entries are matched
-// against the blueprint's BlueprintSecretSlot declarations and filled
-// from tc.spec.secrets — when the operator has a matching entry, an
-// in-realm ContainerSecretRef points the slot at it (the runtime
-// resolves the actual bytes via the Secret kind from #623).
+// against the blueprint's BlueprintSecretSlot declarations and, when the
+// blueprint declares the slot, filled with an in-realm ContainerSecretRef
+// pointing at the secret of the same name — the runtime resolves the
+// actual bytes via the Secret kind (#623) created out of the two-layer
+// secrets.env path (#1120).
 func BindConfig(
 	bp *v1beta1.CellBlueprintDoc,
 	r *model.Role,
@@ -509,12 +510,9 @@ func BindConfig(
 		}
 	}
 
-	if len(declaredSecrets) > 0 && r != nil && len(r.Spec.Needs.Secrets) > 0 && tc != nil {
+	if len(declaredSecrets) > 0 && r != nil && len(r.Spec.Needs.Secrets) > 0 {
 		for _, secretName := range r.Spec.Needs.Secrets {
 			if !declaredSecrets[secretName] {
-				continue
-			}
-			if _, ok := tc.Spec.Secrets[secretName]; !ok {
 				continue
 			}
 			if cfg.Spec.Secrets == nil {

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -41,8 +41,10 @@
 //     blueprint and carries (a) operator facts pulled from
 //     `~/.kuke/kuketeams.yaml` (git author/committer/signingKey/registry
 //     stamped into Values), (b) the project's cloned repo URL stamped
-//     into the `project` repo slot fill, and (c) any operator secret
-//     refs from `tc.spec.secrets` that the role declares it needs.
+//     into the `project` repo slot fill, and (c) for every secret the
+//     role declares it needs and the blueprint declares a slot for, an
+//     in-realm ContainerSecretRef pointing at the Secret of the same
+//     name (created out of `secrets.env`, #1120).
 //  5. label — every rendered CellBlueprint and CellConfig carries
 //     `metadata.labels[kukeon.io/team] = <project>` so the daemon-side
 //     prune-apply machinery from #1029 can converge the project's slice

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -810,6 +810,55 @@ func TestBindConfigStampsTeamLabelAndProjectRepoFill(t *testing.T) {
 	}
 }
 
+// TestBindConfigFillsSecretFromRoleNeedsWithoutTcSecrets is the #1145
+// regression guard: role.Needs.Secrets + a blueprint slot of the same
+// name must produce a CellConfig secret fill regardless of whether
+// tc.Spec.Secrets carries an entry. Production code (the secrets.env →
+// kind: Secret path from #1120) never populates tc.Spec.Secrets, so a
+// gate on it dropped every fill silently and no env var reached the
+// container.
+func TestBindConfigFillsSecretFromRoleNeedsWithoutTcSecrets(t *testing.T) {
+	t.Parallel()
+	bp := &v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{Name: "dev-claude", Realm: "default"},
+		Spec: v1beta1.CellBlueprintSpec{Cell: v1beta1.BlueprintCellSpec{
+			Containers: []v1beta1.BlueprintContainer{{
+				ID:    "dev",
+				Image: "x",
+				Secrets: []v1beta1.BlueprintSecretSlot{
+					{Name: "ANTHROPIC_API_KEY", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "ANTHROPIC_API_KEY"},
+				},
+			}},
+		}},
+	}
+	cfg := BindConfig(
+		bp,
+		minimalRole(),
+		"dev",
+		"claude",
+		&model.TeamsConfig{}, // no tc.spec.secrets — the production shape from #1120
+		teamsource.Source{},
+		Inputs{Project: "sbsh"},
+		"sbsh",
+		"default",
+		"default",
+		"default",
+	)
+	fill, ok := cfg.Spec.Secrets["ANTHROPIC_API_KEY"]
+	if !ok {
+		t.Fatalf("ANTHROPIC_API_KEY slot not filled: %+v", cfg.Spec.Secrets)
+	}
+	if fill.SecretRef == nil {
+		t.Fatalf("ANTHROPIC_API_KEY SecretRef nil: %+v", fill)
+	}
+	if fill.SecretRef.Name != "ANTHROPIC_API_KEY" {
+		t.Errorf("SecretRef.Name = %q, want ANTHROPIC_API_KEY", fill.SecretRef.Name)
+	}
+	if fill.SecretRef.Realm != "default" {
+		t.Errorf("SecretRef.Realm = %q, want default", fill.SecretRef.Realm)
+	}
+}
+
 func TestBindConfigSkipsUndeclaredSlots(t *testing.T) {
 	t.Parallel()
 	bp := &v1beta1.CellBlueprintDoc{


### PR DESCRIPTION
## Summary

- The `secrets.env` → `kind: Secret` apply path from #1120 stopped populating `tc.Spec.Secrets`, but `BindConfig` (left over from #1048) still gated the per-slot `CellConfigSecretFill` on `tc.Spec.Secrets[secretName]`. That gate is always false outside tests, so every rendered CellConfig came out with empty `spec.secrets` and no secret env var ever reached a cell started via `kuke run --from-config`.
- Drop the `tc.Spec.Secrets` presence check (and the now-vestigial `tc != nil` guard). Gate the fill solely on the role's `Needs.Secrets` intersected with the blueprint's `BlueprintSecretSlot` declarations — the same source of truth the creation side uses — so a role need + a blueprint slot is sufficient to produce a `ContainerSecretRef`.
- Refresh the `BindConfig` godoc paragraph that still described the old "filled from tc.spec.secrets" behavior so the contract reads correctly.

## Test plan

- [x] `go test ./internal/teamrender/` — covers the existing `TestBindConfigStampsTeamLabelAndProjectRepoFill` (still passes; `tc.Spec.Secrets` happens to be populated) plus the new `TestBindConfigFillsSecretFromRoleNeedsWithoutTcSecrets` regression that drives the production `&model.TeamsConfig{}` shape from #1120.
- [x] `make test` (full project test suite green).
- [ ] Live `kuke team init` smoke against an actual host — not run here; the unit test pins the byte-shape of the rendered `CellConfigSecretFill`, and `cmd/kuke/team` package tests pass.

Closes #1145