### PR TITLE
fix(runner): populate StartTime/FinishTime/ExitSignal in container status

### DIFF
--- a/internal/controller/runner/container_state.go
+++ b/internal/controller/runner/container_state.go
@@ -20,23 +20,57 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 	"github.com/eminwux/kukeon/internal/util/naming"
+	"golang.org/x/sys/unix"
 )
+
+// exitSignalCodeBase is the offset runc/containerd (following the shell
+// convention) adds to a signal number when a task is terminated by a signal:
+// an exit code of 128+signum means the process was killed by signum. SIGKILL
+// (9) therefore surfaces as 137.
+const exitSignalCodeBase = 128
+
+// maxSignalNumber bounds the signal range exitSignalName will translate. Linux
+// real-time signals run up to SIGRTMAX (typically 64); anything past 128+64 is
+// an ordinary exit code that merely happens to be large, not a signal.
+const maxSignalNumber = 64
+
+// exitSignalName maps a containerd task exit code to the name of the signal
+// that terminated the task, or "" for an ordinary (non-signal) exit. runc and
+// containerd encode a signal-terminated task as 128+signum (the shell
+// convention), so an exit code in (128, 128+64] carries the signal number in
+// its low bits — e.g. 137 -> SIGKILL, 143 -> SIGTERM. The name is rendered via
+// unix.SignalName, which itself returns "" for an unrecognized signal number,
+// so an out-of-table value collapses to the no-signal result.
+func exitSignalName(exitCode int) string {
+	signum := exitCode - exitSignalCodeBase
+	if signum <= 0 || signum > maxSignalNumber {
+		return ""
+	}
+	return unix.SignalName(syscall.Signal(signum))
+}
 
 // ContainerObservation bundles the slice of containerd task state the runner
 // needs to surface in ContainerStatus and drive lifecycle decisions: the
-// internal-state mapping plus the exit code reported by the task. ExitCode is
-// only meaningful on the TaskStatus-success branch — on every other branch
-// (NotCreated, ErrTaskNotFound, transient error, fallback Unknown) it stays
-// zero.
+// internal-state mapping plus the exit code and exit time reported by the task.
+// ExitCode and ExitTime are only meaningful on the TaskStatus-success branch —
+// on every other branch (NotCreated, ErrTaskNotFound, transient error, fallback
+// Unknown) they stay zero. containerd's task status carries no start time, so
+// StartTime is stamped by observe-and-preserve in populateCellContainerStatuses
+// rather than read here (issue #1137).
 type ContainerObservation struct {
 	State    intmodel.ContainerState
 	ExitCode int
+	// ExitTime is the wall-clock time containerd recorded the task's death,
+	// surfaced as ContainerStatus.FinishTime. Zero until the task is Stopped.
+	ExitTime time.Time
 }
 
 // GetContainerState queries containerd for the actual task status of a container
@@ -206,8 +240,12 @@ func (r *Exec) GetContainerObservation(cell intmodel.Cell, containerID string) (
 			"namespace", namespace,
 			"taskStatus", taskStatus.Status,
 			"internalState", state,
-			"exitCode", exitCode)
-		return ContainerObservation{State: state, ExitCode: exitCode}, nil
+			"exitCode", exitCode,
+			"exitTime", taskStatus.ExitTime)
+		// ExitTime is only stamped by containerd once the task is Stopped; on a
+		// Running/Created/Paused task it is the zero time, which surfaces as a
+		// zero FinishTime (the container has not finished). Issue #1137.
+		return ContainerObservation{State: state, ExitCode: exitCode, ExitTime: taskStatus.ExitTime}, nil
 	}
 
 	// TaskStatus failed against an existing container: the container record

--- a/internal/controller/runner/container_status_timestamps_test.go
+++ b/internal/controller/runner/container_status_timestamps_test.go
@@ -1,0 +1,121 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises unexported exitSignalName and the ExitTime plumbing on GetContainerObservation
+package runner
+
+import (
+	"testing"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestExitSignalName pins the 128+signum decode containerd/runc use for a
+// signal-terminated task (issue #1137). Ordinary exit codes (including 0 and
+// the conventional "command not found"/"general error" codes below 128) carry
+// no signal; 128+N in the valid signal range maps to the signal name via
+// unix.SignalName; out-of-range values collapse back to "".
+func TestExitSignalName(t *testing.T) {
+	cases := []struct {
+		name     string
+		exitCode int
+		want     string
+	}{
+		{"clean_exit_no_signal", 0, ""},
+		{"general_error_no_signal", 1, ""},
+		{"exactly_128_no_signal", 128, ""},
+		{"sigkill", 137, "SIGKILL"}, // 128 + 9
+		{"sigterm", 143, "SIGTERM"}, // 128 + 15
+		{"sigint", 130, "SIGINT"},   // 128 + 2
+		{"above_signal_range_no_signal", 128 + 65, ""},
+		{"way_above_no_signal", 255, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := exitSignalName(tc.exitCode); got != tc.want {
+				t.Errorf("exitSignalName(%d) = %q, want %q", tc.exitCode, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGetContainerObservation_PopulatesExitTime confirms the
+// GetContainerObservation plumbing threads containerd.Status.ExitTime into
+// ContainerObservation.ExitTime, the source of ContainerStatus.FinishTime
+// (issue #1137). Without this, a Stopped container's FinishTime stays at the
+// zero value the long-standing TODO hardcoded.
+func TestGetContainerObservation_PopulatesExitTime(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	exitTime := time.Date(2026, 6, 7, 20, 35, 4, 0, time.UTC)
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{Status: containerd.Stopped, ExitStatus: 137, ExitTime: exitTime}, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+
+	obs, err := r.GetContainerObservation(cell, containerID)
+	if err != nil {
+		t.Fatalf("GetContainerObservation: unexpected error: %v", err)
+	}
+	if obs.State != intmodel.ContainerStateStopped {
+		t.Errorf("GetContainerObservation State = %v, want Stopped", obs.State)
+	}
+	if !obs.ExitTime.Equal(exitTime) {
+		t.Errorf("GetContainerObservation ExitTime = %v, want %v (sources ContainerStatus.FinishTime)", obs.ExitTime, exitTime)
+	}
+}
+
+// TestGetContainerObservation_ZeroExitTimeOnRunningTask locks the
+// running-task contract: a Running task carries no exit time, so ExitTime
+// stays zero and FinishTime renders as the zero value (the container has not
+// finished). Issue #1137.
+func TestGetContainerObservation_ZeroExitTimeOnRunningTask(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			return containerd.Status{Status: containerd.Running}, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+
+	obs, err := r.GetContainerObservation(cell, containerID)
+	if err != nil {
+		t.Fatalf("GetContainerObservation: unexpected error: %v", err)
+	}
+	if obs.State != intmodel.ContainerStateReady {
+		t.Errorf("GetContainerObservation State = %v, want Ready", obs.State)
+	}
+	if !obs.ExitTime.IsZero() {
+		t.Errorf("GetContainerObservation ExitTime = %v, want zero on a Running task", obs.ExitTime)
+	}
+}

--- a/internal/controller/runner/container_status_timestamps_test.go
+++ b/internal/controller/runner/container_status_timestamps_test.go
@@ -20,10 +20,13 @@
 package runner
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
@@ -117,5 +120,71 @@ func TestGetContainerObservation_ZeroExitTimeOnRunningTask(t *testing.T) {
 	}
 	if !obs.ExitTime.IsZero() {
 		t.Errorf("GetContainerObservation ExitTime = %v, want zero on a Running task", obs.ExitTime)
+	}
+}
+
+// TestPopulateCellContainerStatuses_PreservesExitInfoAcrossReap is the
+// kill->reap consistency guard (issue #1137): in the normal lifecycle a
+// SIGKILLed task is first observed Stopped with ExitStatus=137/ExitTime=T,
+// then — once containerd reaps the task record — the ErrTaskNotFound -> Stopped
+// branch reports a zero ExitCode/ExitTime while the container record survives.
+// FinishTime, ExitCode and ExitSignal must all be preserved in lockstep across
+// that reap; without the ExitCode preservation the status self-contradicts,
+// showing FinishTime=T with exit code 0 / no signal.
+func TestPopulateCellContainerStatuses_PreservesExitInfoAcrossReap(t *testing.T) {
+	realm, space, stack, cellName := "default", "kukeon", "kukeon", "web"
+	containerID, containerdID := "root", "kukeon_kukeon_web_root"
+
+	exitTime := time.Date(2026, 6, 7, 20, 35, 4, 0, time.UTC)
+
+	// Pull 1 reports the freshly-Stopped task with its exit info; pull 2 reports
+	// the same container with its task record reaped (ErrTaskNotFound -> Stopped,
+	// zero ExitCode/ExitTime).
+	pull := 0
+	fake := &deleteCellFakeClient{
+		existsContainerFn: func(_, _ string) (bool, error) { return true, nil },
+		taskStatusFn: func(_, _ string) (containerd.Status, error) {
+			pull++
+			if pull == 1 {
+				return containerd.Status{Status: containerd.Stopped, ExitStatus: 137, ExitTime: exitTime}, nil
+			}
+			return containerd.Status{}, fmt.Errorf("%w: %w", errdefs.ErrTaskNotFound, errors.New("task: not found"))
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	cell := containerStateCell(realm, space, stack, cellName, containerID, containerdID)
+
+	// Pull 1: Stopped with exit info — the exit triple is stamped from the obs.
+	if err := r.populateCellContainerStatuses(&cell); err != nil {
+		t.Fatalf("populateCellContainerStatuses (pull 1): unexpected error: %v", err)
+	}
+	if len(cell.Status.Containers) != 1 {
+		t.Fatalf("pull 1: got %d container statuses, want 1", len(cell.Status.Containers))
+	}
+	got := cell.Status.Containers[0]
+	if !got.FinishTime.Equal(exitTime) || got.ExitCode != 137 || got.ExitSignal != "SIGKILL" {
+		t.Fatalf("pull 1: FinishTime=%v ExitCode=%d ExitSignal=%q, want %v/137/SIGKILL",
+			got.FinishTime, got.ExitCode, got.ExitSignal, exitTime)
+	}
+
+	// Pull 2: task record reaped — FinishTime/ExitCode/ExitSignal must all
+	// survive rather than reset to T/0/"" (the self-contradictory status).
+	if err := r.populateCellContainerStatuses(&cell); err != nil {
+		t.Fatalf("populateCellContainerStatuses (pull 2): unexpected error: %v", err)
+	}
+	got = cell.Status.Containers[0]
+	if got.State != intmodel.ContainerStateStopped {
+		t.Errorf("pull 2: State = %v, want Stopped", got.State)
+	}
+	if !got.FinishTime.Equal(exitTime) {
+		t.Errorf("pull 2: FinishTime = %v, want preserved %v across the reap", got.FinishTime, exitTime)
+	}
+	if got.ExitCode != 137 {
+		t.Errorf("pull 2: ExitCode = %d, want preserved 137 across the reap (a reset 0 would contradict FinishTime=%v)", got.ExitCode, exitTime)
+	}
+	if got.ExitSignal != "SIGKILL" {
+		t.Errorf("pull 2: ExitSignal = %q, want preserved SIGKILL across the reap", got.ExitSignal)
 	}
 }

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -706,9 +706,18 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 	// `kuke get container` survives the unconditional overwrite below.
 	// Issue #605.
 	priorCreatedAt := make(map[string]time.Time, len(cell.Status.Containers))
+	// Snapshot prior StartTime/FinishTime by container ID, same observe-and-
+	// preserve contract as CreatedAt: containerd's task status carries no start
+	// time, and a Stopped task's ExitTime is lost once its record is reaped, so
+	// both timestamps must survive the unconditional overwrite below rather than
+	// reset to the zero value on every pull. Issue #1137.
+	priorStartTime := make(map[string]time.Time, len(cell.Status.Containers))
+	priorFinishTime := make(map[string]time.Time, len(cell.Status.Containers))
 	for _, prev := range cell.Status.Containers {
 		priorStages[prev.ID] = prev.Stages
 		priorCreatedAt[prev.ID] = prev.CreatedAt
+		priorStartTime[prev.ID] = prev.StartTime
+		priorFinishTime[prev.ID] = prev.FinishTime
 	}
 
 	statuses := make([]intmodel.ContainerStatus, 0, len(cell.Spec.Containers))
@@ -737,19 +746,43 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 			createdAt = now
 		}
 
-		// TODO: Get additional status fields (RestartCount, StartTime, etc.) from containerd
-		// For now, populate with basic state + exit code
+		// StartTime: containerd's task status exposes no start time, so stamp
+		// it the first time the container is observed Ready (Running) and
+		// preserve thereafter — the same observe-and-preserve contract as
+		// CreatedAt (#605). A container that has never been Ready keeps a zero
+		// StartTime. Issue #1137.
+		startTime := priorStartTime[containerSpec.ID]
+		if startTime.IsZero() && obs.State == intmodel.ContainerStateReady {
+			startTime = now
+		}
+
+		// FinishTime: the wall-clock time containerd recorded the task's death
+		// (obs.ExitTime, non-zero only once Stopped). Cleared when the container
+		// is Ready again (a running task has not finished); preserved across
+		// transient NotCreated/Unknown observations that would otherwise lose
+		// the reaped task's exit time. Issue #1137.
+		finishTime := priorFinishTime[containerSpec.ID]
+		switch {
+		case obs.State == intmodel.ContainerStateReady:
+			finishTime = time.Time{}
+		case !obs.ExitTime.IsZero():
+			finishTime = obs.ExitTime
+		}
+
+		// RestartCount/RestartTime require restart bookkeeping the runner does
+		// not yet track; deferred to #1146 per issue #1137's "scope that part
+		// separately". They stay at their zero values for now.
 		status := intmodel.ContainerStatus{
 			Name:         containerSpec.ID,
 			ID:           containerSpec.ID,
 			CreatedAt:    createdAt,
 			State:        obs.State,
-			RestartCount: 0,           // TODO: retrieve from containerd
-			RestartTime:  time.Time{}, // TODO: retrieve from containerd
-			StartTime:    time.Time{}, // TODO: retrieve from containerd
-			FinishTime:   time.Time{}, // TODO: retrieve from containerd
+			RestartCount: 0,           // TODO(#1146): restart bookkeeping
+			RestartTime:  time.Time{}, // TODO(#1146): restart bookkeeping
+			StartTime:    startTime,
+			FinishTime:   finishTime,
 			ExitCode:     obs.ExitCode,
-			ExitSignal:   "", // TODO: retrieve from containerd
+			ExitSignal:   exitSignalName(obs.ExitCode),
 		}
 		// Pull per-repo clone/fetch and per-create-stage outcomes over the
 		// kuketty control socket (issues #642, #689) in a single dial.

--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -713,11 +713,19 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 	// reset to the zero value on every pull. Issue #1137.
 	priorStartTime := make(map[string]time.Time, len(cell.Status.Containers))
 	priorFinishTime := make(map[string]time.Time, len(cell.Status.Containers))
+	// Snapshot prior ExitCode under the same contract as FinishTime: once a
+	// Stopped task's record is reaped, the ErrTaskNotFound -> Stopped branch
+	// reports a zero ExitCode/ExitTime, so a preserved FinishTime would otherwise
+	// pair with a reset ExitCode/ExitSignal (a SIGKILLed container showing
+	// FinishTime=T with exit code 0 / no signal — a self-contradictory status).
+	// Preserving ExitCode in lockstep keeps the exit triple consistent. Issue #1137.
+	priorExitCode := make(map[string]int, len(cell.Status.Containers))
 	for _, prev := range cell.Status.Containers {
 		priorStages[prev.ID] = prev.Stages
 		priorCreatedAt[prev.ID] = prev.CreatedAt
 		priorStartTime[prev.ID] = prev.StartTime
 		priorFinishTime[prev.ID] = prev.FinishTime
+		priorExitCode[prev.ID] = prev.ExitCode
 	}
 
 	statuses := make([]intmodel.ContainerStatus, 0, len(cell.Spec.Containers))
@@ -756,17 +764,24 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 			startTime = now
 		}
 
-		// FinishTime: the wall-clock time containerd recorded the task's death
-		// (obs.ExitTime, non-zero only once Stopped). Cleared when the container
-		// is Ready again (a running task has not finished); preserved across
-		// transient NotCreated/Unknown observations that would otherwise lose
-		// the reaped task's exit time. Issue #1137.
+		// FinishTime / ExitCode move in lockstep: the wall-clock time containerd
+		// recorded the task's death (obs.ExitTime, non-zero only once Stopped) and
+		// the matching exit code. Both are cleared when the container is Ready
+		// again (a running task has not finished and has no meaningful exit code);
+		// both are refreshed only on a genuine exit observation (non-zero ExitTime,
+		// i.e. the TaskStatus-success Stopped branch); otherwise both are preserved
+		// across transient NotCreated/Unknown/reaped-task observations. Preserving
+		// ExitCode here — not re-reading the obs value below — is what keeps a
+		// reaped SIGKILL from showing FinishTime=T with exit code 0. Issue #1137.
 		finishTime := priorFinishTime[containerSpec.ID]
+		exitCode := priorExitCode[containerSpec.ID]
 		switch {
 		case obs.State == intmodel.ContainerStateReady:
 			finishTime = time.Time{}
+			exitCode = 0
 		case !obs.ExitTime.IsZero():
 			finishTime = obs.ExitTime
+			exitCode = obs.ExitCode
 		}
 
 		// RestartCount/RestartTime require restart bookkeeping the runner does
@@ -781,8 +796,8 @@ func (r *Exec) populateCellContainerStatuses(cell *intmodel.Cell) error {
 			RestartTime:  time.Time{}, // TODO(#1146): restart bookkeeping
 			StartTime:    startTime,
 			FinishTime:   finishTime,
-			ExitCode:     obs.ExitCode,
-			ExitSignal:   exitSignalName(obs.ExitCode),
+			ExitCode:     exitCode,
+			ExitSignal:   exitSignalName(exitCode),
 		}
 		// Pull per-repo clone/fetch and per-create-stage outcomes over the
 		// kuketty control socket (issues #642, #689) in a single dial.


### PR DESCRIPTION
## Summary

Container status persisted zero-value timestamps/counters for healthy `Ready` containers — `StartTime`/`FinishTime`/`ExitSignal` (and `RestartCount`/`RestartTime`) were hardcoded behind long-standing TODOs in `populateCellContainerStatuses` and never wired from containerd. The repro: a `Ready` container showing `startTime: 0001-01-01T00:00:00Z`.

This PR wires the three fields the issue scopes as the minimum set:

- **`ExitTime` threaded through `ContainerObservation`** (`container_state.go`) from `taskStatus.ExitTime` on the `TaskStatus`-success branch; zero on every other branch (consistent with the existing `ExitCode` contract).
- **`FinishTime` / `ExitCode` / `ExitSignal` move in lockstep** ← `obs.ExitTime` / `obs.ExitCode` (real containerd exit info); cleared when the container is `Ready` again, refreshed only on a genuine exit observation (non-zero `ExitTime`), and otherwise **preserved together** across transient `NotCreated`/`Unknown` *and reaped-task* observations. (Review fix — see below.)
- **`StartTime`** stamped via observe-and-preserve — stamp on first `Ready` observation, preserve thereafter — mirroring the `CreatedAt` pattern (#605).
- **`ExitSignal`** derived from the (now preserved) exit code via the runc/containerd `128+signum` convention (e.g. `137` → `SIGKILL`), rendered with `unix.SignalName`. Matches the existing `cmd/kuke/get/container` wide-column test fixture (`ExitCode: 137, ExitSignal: "SIGKILL"`).

## Review fix: ExitCode/ExitSignal consistency across task reap

Reviewer flagged that the original diff preserved `FinishTime` across a reaped task but re-read `ExitCode`/`ExitSignal` from the current obs, which the `ErrTaskNotFound` → `Stopped` branch reports as `0`/zero. In the normal kill→reap lifecycle a SIGKILLed container then showed `FinishTime=T` with exit code `0` / no signal — a self-contradictory status. Fixed by snapshotting `priorExitCode` alongside `priorFinishTime` and preserving it under the same switch, so the exit triple (`FinishTime`/`ExitCode`/`ExitSignal`) stays consistent across the reap. New test `TestPopulateCellContainerStatuses_PreservesExitInfoAcrossReap` exercises the Stopped-with-code → task-gone transition.

## AC-specifics divergence (heads-up posted on the issue)

The issue's "Suggested fix" said *"`StartTime`/`FinishTime` come from the containerd task status"*. Verified against the pinned `github.com/containerd/containerd/v2` `client.Status`: that struct exposes only `Status`, `ExitStatus`, and `ExitTime` — there is **no** start-time field. So:
- `FinishTime` ← `ExitTime`: wired as suggested.
- `StartTime`: **not** sourced from task status (it isn't there) — stamped via the observe-and-preserve pattern already used for `CreatedAt` (#605). Documented in the issue heads-up comment for reviewer pushback.

## Deferred (per the issue's explicit "scope that part separately")

`RestartCount`/`RestartTime` require restart bookkeeping the runner does not yet track — containerd's task status carries neither. Left at zero with a `TODO(#1146)` marker and filed as follow-up **#1146**.

## Test plan
- [x] `make test` (full CI suite, `GOWORK=off`) — exit 0; re-run post-rebase onto `origin/main` (5003365), still exit 0
- [x] `GOWORK=off go vet ./internal/controller/runner/` — clean
- [x] New unit tests: `TestExitSignalName` (128+signum decode table), `TestGetContainerObservation_PopulatesExitTime`, `TestGetContainerObservation_ZeroExitTimeOnRunningTask`, `TestPopulateCellContainerStatuses_PreservesExitInfoAcrossReap` (reaped-task exit-info preservation)
- [x] `golang.org/x/sys` already a direct require — no `go mod tidy` change
- [ ] `make dev-init` parity smoke + `kuke get container` spot-check — not run on this host (non-blocking per review: it guards realm/bind-mount parity, not this field-population path; `make e2e` is green in CI). Recommended as a pre-merge spot-check on a daemon host.

Closes #1137