### PR TITLE
fix(team): prune empty-secret bindings from rendered CellConfigs

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -486,7 +486,43 @@ func composeSecrets(
 		fmt.Fprintf(errOut, "warning: secrets.env key %q is empty; cells referencing it will fail to start\n", k)
 	}
 	res.Secrets = composed.Secrets
+	// Reconcile the binding with the set of secrets actually created. Render
+	// skips empty merged values (no kind: Secret emitted), but the post-#1147
+	// binding in teamrender adds a CellConfigSecretFill for every
+	// role.needs.secrets entry regardless. Pruning the empty keys here — the
+	// same keys warned about above — leaves each CellConfig referencing only
+	// secrets that exist, so a role declaring needs.secrets for credentials
+	// the operator hasn't provided no longer makes the whole cell unstartable
+	// (#1149).
+	pruneEmptySecretBindings(res.Configs, composed.EmptyKeys)
 	return nil
+}
+
+// pruneEmptySecretBindings deletes the CellConfig secret bindings whose key is
+// in emptyKeys — the role.needs.secrets entries whose merged secrets.env value
+// was empty, which secret creation (teamsecrets.Render) skipped. Both the
+// binding map keys and emptyKeys are the raw role.needs.secrets strings (the
+// binding iterates role.Spec.Needs.Secrets; emptyKeys is the empty subset of
+// the same union), so a direct map delete is namespace-consistent. Mutates the
+// CellConfigs in place; a nil/empty input on either side is a no-op.
+func pruneEmptySecretBindings(configs []*v1beta1.CellConfigDoc, emptyKeys []string) {
+	if len(configs) == 0 || len(emptyKeys) == 0 {
+		return
+	}
+	empty := make(map[string]struct{}, len(emptyKeys))
+	for _, k := range emptyKeys {
+		empty[k] = struct{}{}
+	}
+	for _, cfg := range configs {
+		if cfg == nil || len(cfg.Spec.Secrets) == 0 {
+			continue
+		}
+		for key := range cfg.Spec.Secrets {
+			if _, isEmpty := empty[key]; isEmpty {
+				delete(cfg.Spec.Secrets, key)
+			}
+		}
+	}
 }
 
 // rosterPairs flattens pt.Spec.Roles × pt.Spec.Defaults.Harnesses into the

--- a/cmd/kuke/team/init_test.go
+++ b/cmd/kuke/team/init_test.go
@@ -520,6 +520,69 @@ func TestComposeTeamRendersOnNonDryRun(t *testing.T) {
 	}
 }
 
+// TestPruneEmptySecretBindings is the #1149 regression: a role needs 3
+// secrets but the operator provided only 1, so secret creation skipped the 2
+// empty values while the post-#1147 binding bound all 3. The prune must leave
+// the CellConfig referencing only the single secret that was actually created,
+// so the cell starts instead of dying on the first missing ref.
+func TestPruneEmptySecretBindings(t *testing.T) {
+	t.Parallel()
+	secretFill := func(name string) v1beta1.CellConfigSecretFill {
+		return v1beta1.CellConfigSecretFill{
+			SecretRef: &v1beta1.ContainerSecretRef{Name: name, Realm: "default"},
+		}
+	}
+	cfg := &v1beta1.CellConfigDoc{
+		Spec: v1beta1.CellConfigSpec{
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"claude-code-oauth-token": secretFill("claude-code-oauth-token"),
+				"openai-api-key":          secretFill("openai-api-key"),
+				"openrouter-api-key":      secretFill("openrouter-api-key"),
+			},
+		},
+	}
+
+	// Only claude-code-oauth-token had a value; the other two were empty and
+	// never created.
+	pruneEmptySecretBindings(
+		[]*v1beta1.CellConfigDoc{cfg},
+		[]string{"openai-api-key", "openrouter-api-key"},
+	)
+
+	if len(cfg.Spec.Secrets) != 1 {
+		t.Fatalf("secrets after prune = %v, want only claude-code-oauth-token", cfg.Spec.Secrets)
+	}
+	if _, ok := cfg.Spec.Secrets["claude-code-oauth-token"]; !ok {
+		t.Errorf("provided secret was pruned: %v", cfg.Spec.Secrets)
+	}
+	for _, gone := range []string{"openai-api-key", "openrouter-api-key"} {
+		if _, ok := cfg.Spec.Secrets[gone]; ok {
+			t.Errorf("empty secret %q was not pruned: %v", gone, cfg.Spec.Secrets)
+		}
+	}
+}
+
+// TestPruneEmptySecretBindingsNoOps confirms the prune leaves a CellConfig
+// untouched when no keys are empty, and tolerates nil/empty inputs.
+func TestPruneEmptySecretBindingsNoOps(t *testing.T) {
+	t.Parallel()
+	cfg := &v1beta1.CellConfigDoc{
+		Spec: v1beta1.CellConfigSpec{
+			Secrets: map[string]v1beta1.CellConfigSecretFill{
+				"claude-code-oauth-token": {SecretRef: &v1beta1.ContainerSecretRef{Name: "claude-code-oauth-token", Realm: "default"}},
+			},
+		},
+	}
+	// Empty key set: nothing pruned.
+	pruneEmptySecretBindings([]*v1beta1.CellConfigDoc{cfg}, nil)
+	if len(cfg.Spec.Secrets) != 1 {
+		t.Errorf("empty emptyKeys pruned a binding: %v", cfg.Spec.Secrets)
+	}
+	// Nil configs and a nil entry must not panic.
+	pruneEmptySecretBindings(nil, []string{"x"})
+	pruneEmptySecretBindings([]*v1beta1.CellConfigDoc{nil}, []string{"x"})
+}
+
 // TestComposeTeamApplyTotalFailureExitsNonZeroSkipsEntry confirms that when
 // every applied document comes back `failed`, composeTeam exits non-zero
 // (ErrTeamApplyFailed) and does not persist the drop-in entry for a team with


### PR DESCRIPTION
## Summary
- #1147 fixed the #1145 "bind nothing" bug by binding a `CellConfigSecretFill` for **every** `role.needs.secrets` entry — but it overshot to "bind everything". Secret *creation* (`teamsecrets.Render`) skips empty merged `secrets.env` values (no `kind: Secret` emitted), while *binding* (`internal/teamrender/teamrender.go:515`) bound them unconditionally. A role that needs a secret the operator never provided then made the whole cell unstartable: `readSecretRefValue` (`internal/ctr/secrets.go:190`) fails on the first missing ref, so even the valid secrets are never injected.
- Reconciles the two paths at the post-compose layer the issue points at: `composeSecrets` in `cmd/kuke/team/init.go` already holds both `res.Configs` and `composed.EmptyKeys`, so a new `pruneEmptySecretBindings` helper deletes each empty key from every `cfg.Spec.Secrets` after render. The CellConfig is left referencing exactly the secrets that exist. Render itself can't do this — it runs before composition knows the merged values — so the post-compose prune is the right layer.
- **Namespace note:** the binding map keys and `EmptyKeys` are the *same raw* `role.Spec.Needs.Secrets` strings — `teamrender.BindConfig` iterates `role.Spec.Needs.Secrets`, and `EmptyKeys` is the empty subset of `UnionNeedsSecrets(bundle.Roles, …)` over the same role objects — so a direct map `delete` is namespace-consistent (no kebab/SCREAMING_SNAKE translation needed at the prune layer).
- The prune runs on both the apply and dry-run paths (it mutates in-memory `res.Configs`), so the dry-run output reflects the same pruned bindings the apply uses.

## Out of scope
- The issue's "secondary hazard" (a stale empty `secrets.env`-derived file lingering under `/opt/kukeon/data/.../secrets/`) is sidestepped by pruning the binding — a pruned secret is never referenced, so iteration order can never resolve a stale value. A standalone cleanup of orphaned secret files on re-init is a separate concern and not addressed here.

## Test plan
- [x] `make test` (full suite, `test-root` + `test-kukebuild`) — exit 0
- [x] `TestPruneEmptySecretBindings` — the #1149 regression: role needs 3 secrets, only `claude-code-oauth-token` provided → pruned CellConfig binds only that one
- [x] `TestPruneEmptySecretBindingsNoOps` — empty-key set / nil configs / nil entry are no-ops, no panic
- [x] `go build ./cmd/kuke/team/` (GOWORK=off, per Makefile) — exit 0

Closes #1149