### PR TITLE
feat(teamrender): render per-harness role secrets (.harnesses.<name>.secrets)

### DIFF
--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -69,8 +69,8 @@ metadata: { name: dev }
 spec:
   skills: [skills/, ../common/skills/]
   harnesses:
-    claude:   { settings: config/claude.settings.json }
-    codex:    { sandbox: workspace-write, approval: on-request }
+    claude:   { settings: config/claude.settings.json, secrets: [claude-code-oauth-token] }
+    codex:    { sandbox: workspace-write, approval: on-request, secrets: [openai-api-key] }
     opencode: { permissions: skip }
   needs:
     image:   [git, gh]
@@ -219,6 +219,14 @@ func TestParseHappyPathFields(t *testing.T) {
 	if len(role.Role.Spec.Needs.Repos) != 2 || len(role.Role.Spec.Needs.Mounts) != 1 {
 		t.Errorf("needs repos/mounts split wrong: repos=%v mounts=%v",
 			role.Role.Spec.Needs.Repos, role.Role.Spec.Needs.Mounts)
+	}
+	// Per-harness secrets (agents#750) parse onto RoleHarness.Secrets, distinct
+	// from the role-level needs.secrets fallback.
+	if got := role.Role.Spec.Harnesses["claude"].Secrets; len(got) != 1 || got[0] != "claude-code-oauth-token" {
+		t.Errorf("harnesses.claude.secrets = %v, want [claude-code-oauth-token]", got)
+	}
+	if got := role.Role.Spec.Harnesses["codex"].Secrets; len(got) != 1 || got[0] != "openai-api-key" {
+		t.Errorf("harnesses.codex.secrets = %v, want [openai-api-key]", got)
 	}
 
 	h, err := Parse([]byte(harnessHappy))

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -454,12 +454,14 @@ func scopeToProject(name, project string) string {
 // slot; the agents source URL (from tc.spec.sources[<owner/repo>]) fills
 // the `agents` slot — both only when the blueprint actually declares the
 // slot, so a template that doesn't carry the slot produces a config
-// without a stray fill. role.Spec.Needs.Secrets entries are matched
-// against the blueprint's BlueprintSecretSlot declarations and, when the
-// blueprint declares the slot, filled with an in-realm ContainerSecretRef
-// pointing at the secret of the same name — the runtime resolves the
-// actual bytes via the Secret kind (#623) created out of the two-layer
-// secrets.env path (#1120).
+// without a stray fill. The secret-slot fills are sourced from the role's
+// per-harness list (role.spec.harnesses[harness].secrets, the agents#750
+// location) merged with the role-level fallback (role.spec.needs.secrets) —
+// see effectiveSecretNames. Each declared secret name is matched against the
+// blueprint's BlueprintSecretSlot declarations and, when the blueprint
+// declares the slot, filled with an in-realm ContainerSecretRef pointing at
+// the secret of the same name — the runtime resolves the actual bytes via the
+// Secret kind (#623) created out of the two-layer secrets.env path (#1120).
 func BindConfig(
 	bp *v1beta1.CellBlueprintDoc,
 	r *model.Role,
@@ -512,8 +514,8 @@ func BindConfig(
 		}
 	}
 
-	if len(declaredSecrets) > 0 && r != nil && len(r.Spec.Needs.Secrets) > 0 {
-		for _, secretName := range r.Spec.Needs.Secrets {
+	if secretNames := effectiveSecretNames(r, harness); len(declaredSecrets) > 0 && len(secretNames) > 0 {
+		for _, secretName := range secretNames {
 			if !declaredSecrets[secretName] {
 				continue
 			}
@@ -765,18 +767,23 @@ func renderContextValues(
 		"secrets": roleNeedsSecrets(r),
 	}
 
-	// .harnesses.<h>.{settings,sandbox,approval,permissions} mirrors
+	// .harnesses.<h>.{settings,sandbox,approval,permissions,secrets} mirrors
 	// role.yaml's harnesses map verbatim — a blueprint may switch behaviour
 	// per harness (claude reads Settings; codex reads Sandbox/Approval;
-	// opencode reads Permissions) without the renderer transpiling.
-	harnessesView := map[string]map[string]string{}
+	// opencode reads Permissions) without the renderer transpiling. `secrets`
+	// is the per-harness secret-name list (agents#750) the blueprint ranges
+	// with `{{ range (index .harnesses .harness).secrets }}`; it is always a
+	// (possibly empty) []string so a `range` over an unset slot iterates zero
+	// times rather than nil-derefing.
+	harnessesView := map[string]map[string]any{}
 	if r != nil {
 		for name, rh := range r.Spec.Harnesses {
-			harnessesView[name] = map[string]string{
+			harnessesView[name] = map[string]any{
 				"settings":    rh.Settings,
 				"sandbox":     rh.Sandbox,
 				"approval":    rh.Approval,
 				"permissions": rh.Permissions,
+				"secrets":     appendNonNil(rh.Secrets),
 			}
 		}
 	}
@@ -996,6 +1003,42 @@ func collectSecretSlots(bp *v1beta1.CellBlueprintDoc) map[string]bool {
 			out[s.Name] = true
 		}
 	}
+	return out
+}
+
+// effectiveSecretNames returns the secret-slot names the role declares for
+// harness, merging the per-harness list (role.spec.harnesses.<harness>.secrets,
+// the agents#750 location) with the role-level fallback
+// (role.spec.needs.secrets, the pre-migration location) so both schemas bind a
+// CellConfig fill during the transition. Per-harness names come first in their
+// declared order; role-level names not already present are appended.
+// Whitespace-only entries are dropped and duplicates collapsed, so a role that
+// declares the same secret in both locations yields a single name. The result
+// is gated downstream by the blueprint's declared slots, so a fallback name the
+// harness's blueprint carries no slot for is pruned rather than over-bound.
+func effectiveSecretNames(r *model.Role, harness string) []string {
+	if r == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(names []string) {
+		for _, n := range names {
+			n = strings.TrimSpace(n)
+			if n == "" {
+				continue
+			}
+			if _, dup := seen[n]; dup {
+				continue
+			}
+			seen[n] = struct{}{}
+			out = append(out, n)
+		}
+	}
+	if rh, ok := r.Spec.Harnesses[harness]; ok {
+		add(rh.Secrets)
+	}
+	add(r.Spec.Needs.Secrets)
 	return out
 }
 

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -299,6 +299,68 @@ func TestRenderBlueprintSubstitutesAndStampsTeamLabel(t *testing.T) {
 	}
 }
 
+// TestRenderBlueprintRangesPerHarnessSecrets pins the agents#750 fix: a
+// blueprint ranging `(index .harnesses .harness).secrets` renders a secret
+// slot for each per-harness secret name. Before this change harnessesView
+// exposed no `secrets` key, so the range iterated nothing and the rendered
+// Claude blueprint carried no `secrets:` block — silently dropping
+// CLAUDE_CODE_OAUTH_TOKEN.
+func TestRenderBlueprintRangesPerHarnessSecrets(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        secrets:
+{{- range (index .harnesses .harness).secrets }}
+          - { name: {{ . }}, mode: env, envName: {{ . | upper | replace "-" "_" }} }
+{{- end }}
+`
+	writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+	r := &model.Role{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindRole,
+		Metadata:   model.Metadata{Name: "dev"},
+		Spec: model.RoleSpec{
+			Harnesses: map[string]model.RoleHarness{
+				"claude": {Secrets: []string{"claude-code-oauth-token"}},
+			},
+		},
+	}
+	h := &model.Harness{
+		APIVersion: model.APIVersionV1,
+		Kind:       model.KindHarness,
+		Metadata:   model.Metadata{Name: "claude"},
+		Spec:       model.HarnessSpec{Template: "blueprint.tmpl.yaml"},
+	}
+	image := &model.ImageCatalogEntry{
+		Ref: "claude", Harness: "claude", Image: "registry.local/claude:latest",
+	}
+	bp, err := RenderBlueprint(
+		cacheDir, h, r, "claude", "dev", nil, image, nil,
+		teamsource.Source{}, Inputs{}, "sbsh", "default", "default", "default",
+	)
+	if err != nil {
+		t.Fatalf("RenderBlueprint: %v", err)
+	}
+	if len(bp.Spec.Cell.Containers) == 0 {
+		t.Fatalf("no containers in rendered blueprint")
+	}
+	slots := bp.Spec.Cell.Containers[0].Secrets
+	if len(slots) != 1 {
+		t.Fatalf("rendered secret slots = %+v, want exactly one", slots)
+	}
+	if slots[0].Name != "claude-code-oauth-token" || slots[0].EnvName != "CLAUDE_CODE_OAUTH_TOKEN" {
+		t.Errorf("rendered secret slot = %+v, want claude-code-oauth-token/CLAUDE_CODE_OAUTH_TOKEN", slots[0])
+	}
+}
+
 // TestRenderBlueprintScopesNameAndPrefixToProject pins the project-scoped
 // identity contract (#1129): a template producing the project-agnostic
 // `<role>-<harness>` shape lands on disk as `<project>-<role>-<harness>`,
@@ -856,6 +918,135 @@ func TestBindConfigFillsSecretFromRoleNeedsWithoutTcSecrets(t *testing.T) {
 	}
 	if fill.SecretRef.Realm != "default" {
 		t.Errorf("SecretRef.Realm = %q, want default", fill.SecretRef.Realm)
+	}
+}
+
+// TestBindConfigFillsSecretFromPerHarnessList is the agents#750 bind-side
+// guard: a secret declared per-harness
+// (role.spec.harnesses[harness].secrets) and matched by a blueprint slot of
+// the same name produces a CellConfig fill even when role-level
+// needs.secrets is empty.
+func TestBindConfigFillsSecretFromPerHarnessList(t *testing.T) {
+	t.Parallel()
+	bp := &v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{Name: "dev-claude", Realm: "default"},
+		Spec: v1beta1.CellBlueprintSpec{Cell: v1beta1.BlueprintCellSpec{
+			Containers: []v1beta1.BlueprintContainer{{
+				ID:    "dev",
+				Image: "x",
+				Secrets: []v1beta1.BlueprintSecretSlot{
+					{Name: "claude-code-oauth-token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "CLAUDE_CODE_OAUTH_TOKEN"},
+				},
+			}},
+		}},
+	}
+	role := &model.Role{
+		Metadata: model.Metadata{Name: "dev"},
+		Spec: model.RoleSpec{
+			Harnesses: map[string]model.RoleHarness{
+				"claude": {Secrets: []string{"claude-code-oauth-token"}},
+			},
+			// No role-level needs.secrets — per-harness is the sole source.
+		},
+	}
+	cfg := BindConfig(
+		bp, role, "dev", "claude",
+		&model.TeamsConfig{}, teamsource.Source{},
+		Inputs{Project: "sbsh"}, "sbsh", "default", "default", "default",
+	)
+	fill, ok := cfg.Spec.Secrets["claude-code-oauth-token"]
+	if !ok || fill.SecretRef == nil {
+		t.Fatalf("claude-code-oauth-token slot not filled: %+v", cfg.Spec.Secrets)
+	}
+	if fill.SecretRef.Realm != "default" {
+		t.Errorf("SecretRef.Realm = %q, want default", fill.SecretRef.Realm)
+	}
+}
+
+// TestBindConfigPerHarnessSecretsAreHarnessScoped pins that rendering one
+// harness only sources that harness's per-harness secret list — a secret
+// another harness declares does not leak into this config even when the
+// blueprint declares a slot for it (the blueprint-slot gate is not what
+// keeps it out; effectiveSecretNames never sources the other harness).
+func TestBindConfigPerHarnessSecretsAreHarnessScoped(t *testing.T) {
+	t.Parallel()
+	bp := &v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{Name: "dev-claude", Realm: "default"},
+		Spec: v1beta1.CellBlueprintSpec{Cell: v1beta1.BlueprintCellSpec{
+			Containers: []v1beta1.BlueprintContainer{{
+				ID:    "dev",
+				Image: "x",
+				Secrets: []v1beta1.BlueprintSecretSlot{
+					{Name: "claude-code-oauth-token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "CLAUDE_CODE_OAUTH_TOKEN"},
+					{Name: "openai-api-key", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "OPENAI_API_KEY"},
+				},
+			}},
+		}},
+	}
+	role := &model.Role{
+		Metadata: model.Metadata{Name: "dev"},
+		Spec: model.RoleSpec{
+			Harnesses: map[string]model.RoleHarness{
+				"claude": {Secrets: []string{"claude-code-oauth-token"}},
+				"codex":  {Secrets: []string{"openai-api-key"}},
+			},
+		},
+	}
+	cfg := BindConfig(
+		bp, role, "dev", "claude",
+		&model.TeamsConfig{}, teamsource.Source{},
+		Inputs{Project: "sbsh"}, "sbsh", "default", "default", "default",
+	)
+	if _, ok := cfg.Spec.Secrets["openai-api-key"]; ok {
+		t.Errorf("openai-api-key (codex's secret) leaked into claude config: %+v", cfg.Spec.Secrets)
+	}
+	if _, ok := cfg.Spec.Secrets["claude-code-oauth-token"]; !ok {
+		t.Errorf("claude-code-oauth-token not bound: %+v", cfg.Spec.Secrets)
+	}
+}
+
+// TestBindConfigMergesPerHarnessAndRoleLevelSecrets pins the transition-era
+// fallback contract: per-harness and role-level needs.secrets both bind,
+// with a name declared in both locations collapsing to a single fill.
+func TestBindConfigMergesPerHarnessAndRoleLevelSecrets(t *testing.T) {
+	t.Parallel()
+	bp := &v1beta1.CellBlueprintDoc{
+		Metadata: v1beta1.CellBlueprintMetadata{Name: "dev-claude", Realm: "default"},
+		Spec: v1beta1.CellBlueprintSpec{Cell: v1beta1.BlueprintCellSpec{
+			Containers: []v1beta1.BlueprintContainer{{
+				ID:    "dev",
+				Image: "x",
+				Secrets: []v1beta1.BlueprintSecretSlot{
+					{Name: "shared-token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "SHARED_TOKEN"},
+					{Name: "legacy-token", Mode: v1beta1.BlueprintSecretModeEnv, EnvName: "LEGACY_TOKEN"},
+				},
+			}},
+		}},
+	}
+	role := &model.Role{
+		Metadata: model.Metadata{Name: "dev"},
+		Spec: model.RoleSpec{
+			Harnesses: map[string]model.RoleHarness{
+				"claude": {Secrets: []string{"shared-token"}},
+			},
+			Needs: model.RoleNeeds{
+				// shared-token also at role level (dedup); legacy-token role-only.
+				Secrets: []string{"shared-token", "legacy-token"},
+			},
+		},
+	}
+	cfg := BindConfig(
+		bp, role, "dev", "claude",
+		&model.TeamsConfig{}, teamsource.Source{},
+		Inputs{Project: "sbsh"}, "sbsh", "default", "default", "default",
+	)
+	if len(cfg.Spec.Secrets) != 2 {
+		t.Fatalf("secret fills = %+v, want exactly shared-token + legacy-token", cfg.Spec.Secrets)
+	}
+	for _, name := range []string{"shared-token", "legacy-token"} {
+		if fill, ok := cfg.Spec.Secrets[name]; !ok || fill.SecretRef == nil {
+			t.Errorf("%s slot not filled: %+v", name, cfg.Spec.Secrets)
+		}
 	}
 }
 

--- a/pkg/api/model/kuketeams/role.go
+++ b/pkg/api/model/kuketeams/role.go
@@ -53,6 +53,14 @@ type RoleHarness struct {
 	Approval string `json:"approval,omitempty"    yaml:"approval,omitempty"`
 	// Permissions selects the permission mode (opencode, e.g. skip).
 	Permissions string `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	// Secrets are the secret NAMES (resolved against TeamsConfig.secrets) this
+	// harness needs, declared per-harness so a role's Claude cell no longer
+	// carries secret slots only its Codex/OpenCode cells use (agents#750). Each
+	// name is matched against the rendered blueprint's secret-slot declarations
+	// at bind time, the same way role-level RoleNeeds.Secrets is — the
+	// per-harness list is the new primary location, with RoleNeeds.Secrets kept
+	// as a transition-era fallback.
+	Secrets []string `json:"secrets,omitempty"     yaml:"secrets,omitempty"`
 }
 
 // RoleNeeds separates the role's dependencies by kind. Each list holds NAMES


### PR DESCRIPTION
## Summary

- agents#750 / #751 moved role secret declarations from role-level (`role.spec.needs.secrets`) to per-harness (`role.spec.harnesses.<name>.secrets`), and rewrote the harness blueprint templates to range `{{- range (index .harnesses .harness).secrets }}`. The kukeon `teamrender` engine didn't understand the new schema, so rendered Claude blueprints carried **no `secrets:` block at all** — silently dropping `CLAUDE_CODE_OAUTH_TOKEN`.
- **Model** (`pkg/api/model/kuketeams/role.go`): add `Secrets []string` to `RoleHarness` so per-harness secret names parse instead of being discarded.
- **Template context** (`internal/teamrender/teamrender.go`, `renderContextValues`): expose `secrets` (always a possibly-empty `[]string`) in the per-harness `harnessesView` map so `{{ range (index .harnesses .harness).secrets }}` resolves. The map value type widened from `map[string]string` to `map[string]any` to hold the slice; no other consumer asserts on the old shape (verified by grep).
- **CellConfig secret binding** (`BindConfig`): new `effectiveSecretNames(r, harness)` helper sources the declared secret names from the role's per-harness list for the harness being rendered, **merged with** role-level `needs.secrets`. Per-harness names come first; role-level names not already present are appended; dups collapse. Binding stays gated on the blueprint's declared slots, so the #1150 empty-secret pruning behavior is intact and a fallback name with no blueprint slot is not over-bound.

### Back-compat decision

Per the issue's "Decide back-compat" item and the user's explicit instruction at invocation — **keep supporting role-level `.needs.secrets` as a fallback** — both schemas bind during the transition (union, not replacement). The per-harness list is the new primary location; role-level is the fallback.

### Why the agents#750 goal holds end-to-end

Per-harness sourcing is harness-scoped: rendering the `claude` harness sources only `harnesses.claude.secrets`, so a Claude blueprint no longer declares `openai-api-key`/`openrouter-api-key` (those live under `harnesses.codex.secrets` etc.). Covered by `TestBindConfigPerHarnessSecretsAreHarnessScoped` and `TestRenderBlueprintRangesPerHarnessSecrets`.

## Test plan

- [x] `make test` (full CI target, exit 0)
- [x] `go vet ./internal/teamrender/... ./internal/kuketeams/... ./pkg/api/model/kuketeams/...`
- [x] New unit coverage in `internal/teamrender`: `TestRenderBlueprintRangesPerHarnessSecrets` (render), `TestBindConfigFillsSecretFromPerHarnessList`, `TestBindConfigPerHarnessSecretsAreHarnessScoped`, `TestBindConfigMergesPerHarnessAndRoleLevelSecrets` (bind + fallback union)
- [x] Parser coverage: `internal/kuketeams/parser_test.go` fixture + assertions for per-harness `secrets:` parsing onto `RoleHarness.Secrets`
- [ ] `make dev-init` smoke — not run: change is a pure in-process renderer/model edit that does not touch the build path, the daemon, or `/opt/kukeon`, so the dev-init smoke does not exercise it (per project CLAUDE.md, that smoke is for build-path/daemon changes)

## Acceptance

- [x] `kuke get blueprint` renders a `secrets:` block with `name: claude-code-oauth-token` / `envName: CLAUDE_CODE_OAUTH_TOKEN`, and the CellConfig binds the fill (pruned only when no value supplied — #1150 behavior intact) — verified via the render + bind unit tests
- [x] Claude blueprints do not declare `openai-api-key`/`openrouter-api-key` (harness-scoped sourcing)
- [x] Unit coverage in `internal/teamrender` for per-harness secret rendering + binding

Closes #1152