### PR TITLE
fix(diff): classify secrets/workingDir/securityOpts/volumes as Breaking-on-root

### DIFF
--- a/internal/controller/apply/diff.go
+++ b/internal/controller/apply/diff.go
@@ -646,13 +646,13 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bo
 		recordSpecFieldChange(&result, rootContainer, false, "ports", "ports changed")
 	}
 
-	// volumes — Compatible on root and non-root. Root-container volume
-	// edits are treated as in-place updateable for now (the apply layer
-	// reports drift so the operator sees it; the runner's UpdateCell
-	// path applies the change on the next reconcile). If runner-side
-	// gaps surface, file a follow-up to widen the Breaking domain.
+	// volumes — Breaking on root (OCI Mounts table is baked into the
+	// cell root's runtime spec at StartCell; a volume edit only reaches
+	// the container by rebuilding the spec via RecreateCell). Compatible
+	// on non-root, where UpdateCell stop-removes and recreates the child
+	// with the new mounts. Issue #1154.
 	if !volumeMountsEqual(desired.Volumes, actual.Volumes) {
-		recordSpecFieldChange(&result, rootContainer, false, "volumes", "volumes changed")
+		recordSpecFieldChange(&result, rootContainer, true, "volumes", "volumes changed")
 	}
 
 	// privileged — Breaking on root (the cap-set is baked into the cell
@@ -684,13 +684,13 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bo
 		recordSpecFieldChange(&result, rootContainer, true, "capabilities", "capabilities changed")
 	}
 
-	// securityOpts — Compatible on root and non-root. Most security-opt
-	// values (selinux/apparmor/seccomp profile names) round-trip through
-	// the runner without a baked OCI field that demands a fresh
-	// container; a stricter classification can land in a follow-up if
-	// runner gaps surface.
+	// securityOpts — Breaking on root. Security-opt values bake into the
+	// cell root's OCI Process at StartCell (no-new-privileges →
+	// Process.NoNewPrivileges, seccomp=… → Linux.Seccomp), so a change
+	// only reaches the running container via RecreateCell. Compatible on
+	// non-root, where UpdateCell recreates the child. Issue #1154.
 	if !slicesEqual(desired.SecurityOpts, actual.SecurityOpts) {
-		recordSpecFieldChange(&result, rootContainer, false, "securityOpts", "securityOpts changed")
+		recordSpecFieldChange(&result, rootContainer, true, "securityOpts", "securityOpts changed")
 	}
 
 	// tmpfs — Breaking on root (OCI Mounts table is fixed at create).
@@ -707,12 +707,17 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bo
 		recordSpecFieldChange(&result, rootContainer, true, "resources", "resource limits changed")
 	}
 
-	// secrets — Compatible on root and non-root. Secrets either flow as
-	// env (re-evaluated at start) or as bind-mounted files (the
-	// staged-file path can be re-staged before restart); no OCI field
-	// is permanently baked.
+	// secrets — Breaking on root. Env-form secrets are resolved into the
+	// OCI Process.Env at container create (ctr.CreateContainerFromSpec →
+	// resolveSecrets → EnvAdds), and file-form secrets become OCI Mounts;
+	// both are baked at create with no re-resolution on the in-place
+	// task-restart path, so a secret change only reaches the running
+	// container via RecreateCell (delete + recreate, rebuilding the spec).
+	// Compatible on non-root, where UpdateCell stop-removes and recreates
+	// the child — which re-runs resolveSecrets (see containerSpecChanged
+	// in update_cell.go, extended to gate on secrets). Issue #1154.
 	if !secretsEqual(desired.Secrets, actual.Secrets) {
-		recordSpecFieldChange(&result, rootContainer, false, "secrets", "secrets changed")
+		recordSpecFieldChange(&result, rootContainer, true, "secrets", "secrets changed")
 	}
 
 	// repos — Compatible on root and non-root. Repos are handled by
@@ -722,17 +727,13 @@ func diffContainerSpec(desired, actual *intmodel.ContainerSpec, rootContainer bo
 		recordSpecFieldChange(&result, rootContainer, false, "repos", "repos changed")
 	}
 
+	// workingDir — Breaking on root (OCI Process.Cwd is baked at create
+	// via oci.WithProcessCwd; a change only reaches the running container
+	// by rebuilding the spec via RecreateCell). Compatible on non-root,
+	// where UpdateCell recreates the child. Issue #1154.
 	if desired.WorkingDir != actual.WorkingDir {
-		result.HasChanges = true
-		if result.ChangeType == ChangeTypeNone {
-			result.ChangeType = ChangeTypeCompatible
-		}
-		result.ChangedFields = append(result.ChangedFields, "workingDir")
-		result.Details["workingDir"] = fmt.Sprintf(
-			"workingDir changed from %q to %q",
-			actual.WorkingDir,
-			desired.WorkingDir,
-		)
+		recordSpecFieldChange(&result, rootContainer, true, "workingDir",
+			fmt.Sprintf("workingDir changed from %q to %q", actual.WorkingDir, desired.WorkingDir))
 	}
 
 	if !slicesEqual(desired.Networks, actual.Networks) {

--- a/internal/controller/apply/diff_test.go
+++ b/internal/controller/apply/diff_test.go
@@ -551,6 +551,110 @@ func TestDiffCell_RootContainerPrivileged_Breaking(t *testing.T) {
 	}
 }
 
+// TestDiffCell_RootContainerSecrets_Breaking pins issue #1154: a secrets
+// drift on the root container must classify as Breaking. Env-form secrets
+// resolve into the OCI Process.Env at container create (and file-form into
+// Mounts) with no re-resolution on the in-place task-restart path, so a
+// change can only reach the running container via RecreateCell. Prior to
+// #1154 secrets classified Compatible-on-root and the changed env var
+// silently never reached the container.
+func TestDiffCell_RootContainerSecrets_Breaking(t *testing.T) {
+	desired := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest",
+					Secrets: []intmodel.ContainerSecret{{Name: "tok", FromEnv: "CLAUDE_CODE_OAUTH_TOKEN"}}},
+			},
+		},
+	}
+	actual := intmodel.Cell{
+		Metadata: intmodel.CellMetadata{Name: "hello-world"},
+		Spec: intmodel.CellSpec{
+			RealmName: "default",
+			SpaceName: "default",
+			StackName: "default",
+			Containers: []intmodel.ContainerSpec{
+				{ID: "root", Root: true, Image: "busybox:latest"},
+			},
+		},
+	}
+
+	diff := apply.DiffCell(desired, actual)
+	if !diff.HasChanges {
+		t.Fatal("expected changes for root secrets edit")
+	}
+	if !diff.RootContainerChanged {
+		t.Error("expected RootContainerChanged=true for root secrets edit")
+	}
+	if diff.ChangeType != apply.ChangeTypeBreaking {
+		t.Errorf("expected breaking change for root secrets edit, got %v", diff.ChangeType)
+	}
+	foundBreaking := false
+	for _, f := range diff.BreakingChanges {
+		if f == "rootContainer.secrets" {
+			foundBreaking = true
+			break
+		}
+	}
+	if !foundBreaking {
+		t.Errorf("expected BreakingChanges to include %q, got %v", "rootContainer.secrets", diff.BreakingChanges)
+	}
+}
+
+// TestDiffCell_RootContainerWorkingDirVolumesSecurityOpts_Breaking pins the
+// remaining OCI-baked fields issue #1154 reclassifies Breaking-on-root:
+// workingDir (Process.Cwd), volumes (OCI Mounts), and securityOpts
+// (Process.NoNewPrivileges / Linux.Seccomp). Each must force a recreate.
+func TestDiffCell_RootContainerWorkingDirVolumesSecurityOpts_Breaking(t *testing.T) {
+	cases := []struct {
+		name  string
+		mut   func(s *intmodel.ContainerSpec)
+		field string
+	}{
+		{"workingDir", func(s *intmodel.ContainerSpec) { s.WorkingDir = "/opt/app" }, "rootContainer.workingDir"},
+		{"volumes", func(s *intmodel.ContainerSpec) {
+			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
+		}, "rootContainer.volumes"},
+		{"securityOpts", func(s *intmodel.ContainerSpec) {
+			s.SecurityOpts = []string{"no-new-privileges"}
+		}, "rootContainer.securityOpts"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base := intmodel.ContainerSpec{ID: "root", Root: true, Image: "busybox:latest"}
+			desiredRoot := base
+			tc.mut(&desiredRoot)
+			mk := func(root intmodel.ContainerSpec) intmodel.Cell {
+				return intmodel.Cell{
+					Metadata: intmodel.CellMetadata{Name: "hello-world"},
+					Spec: intmodel.CellSpec{
+						RealmName: "default", SpaceName: "default", StackName: "default",
+						Containers: []intmodel.ContainerSpec{root},
+					},
+				}
+			}
+			diff := apply.DiffCell(mk(desiredRoot), mk(base))
+			if diff.ChangeType != apply.ChangeTypeBreaking {
+				t.Errorf("expected breaking change for root %s edit, got %v", tc.name, diff.ChangeType)
+			}
+			found := false
+			for _, f := range diff.BreakingChanges {
+				if f == tc.field {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected BreakingChanges to include %q, got %v", tc.field, diff.BreakingChanges)
+			}
+		})
+	}
+}
+
 // TestDiffCell_RootContainerEnv_Compatible pins AC1/AC2/AC3/AC5 of issue
 // #990 on the Compatible-on-root branch: an Env edit on the root
 // container must surface as a Compatible change (not silently dropped,

--- a/internal/controller/runner/spec_hash.go
+++ b/internal/controller/runner/spec_hash.go
@@ -46,23 +46,31 @@ const SpecHashLabelKey = "kukeon.io/spec-hash"
 // definitions together so they cannot silently drift apart. Issues #867,
 // #990.
 //
-// Args is normalized to a non-nil empty slice on the in-payload side so a
-// nil-vs-empty distinction in the source spec does not change the hash —
-// containerd treats both as "no args". The Capabilities, Tmpfs, and
-// Resources projections normalize nil pointers / slices to zero values so
-// "field unset" and "field set to its zero value" hash identically
-// (matches the equality semantics in `internal/controller/apply/diff.go`'s
-// `capabilitiesEqual`, `tmpfsEqual`, and `resourcesEqual`).
+// Args (and SecurityOpts) is normalized to a non-nil empty slice on the
+// in-payload side so a nil-vs-empty distinction in the source spec does not
+// change the hash — containerd treats both as "no args". The Capabilities,
+// Tmpfs, Resources, Volumes, and Secrets projections normalize nil pointers /
+// slices to zero values so "field unset" and "field set to its zero value"
+// hash identically (matches the equality semantics in
+// `internal/controller/apply/diff.go`'s `capabilitiesEqual`, `tmpfsEqual`,
+// `resourcesEqual`, `volumeMountsEqual`, and `secretsEqual`).
+//
+// WorkingDir, SecurityOpts, Volumes, and Secrets were added by issue #1154
+// when their diff.go classification widened to Breaking-on-root.
 type containerSpecHashPayload struct {
 	Image                  string                  `json:"image"`
 	Command                string                  `json:"command"`
 	Args                   []string                `json:"args"`
+	WorkingDir             string                  `json:"workingDir"`
 	Privileged             bool                    `json:"privileged"`
 	User                   string                  `json:"user"`
 	ReadOnlyRootFilesystem bool                    `json:"readOnlyRootFilesystem"`
 	Capabilities           capabilitiesHashPayload `json:"capabilities"`
+	SecurityOpts           []string                `json:"securityOpts"`
 	Tmpfs                  []tmpfsHashPayload      `json:"tmpfs"`
 	Resources              resourcesHashPayload    `json:"resources"`
+	Volumes                []volumeHashPayload     `json:"volumes"`
+	Secrets                []secretHashPayload     `json:"secrets"`
 }
 
 type capabilitiesHashPayload struct {
@@ -82,6 +90,36 @@ type resourcesHashPayload struct {
 	PidsLimit        int64 `json:"pidsLimit"`
 }
 
+type volumeHashPayload struct {
+	Kind      string `json:"kind"`
+	Source    string `json:"source"`
+	Target    string `json:"target"`
+	ReadOnly  bool   `json:"readOnly"`
+	SizeBytes int64  `json:"sizeBytes"`
+	Mode      uint32 `json:"mode"`
+}
+
+// secretHashPayload flattens the intmodel.ContainerSecret reference set the
+// runner bakes into the OCI spec at create — the env-injected Process.Env
+// adds and the file-form Mounts. Only the reference is hashed (never the
+// resolved value), matching the equality semantics in
+// `internal/controller/apply/diff.go`'s `secretsEqual`. Issue #1154.
+type secretHashPayload struct {
+	Name      string                `json:"name"`
+	FromFile  string                `json:"fromFile"`
+	FromEnv   string                `json:"fromEnv"`
+	MountPath string                `json:"mountPath"`
+	SecretRef *secretRefHashPayload `json:"secretRef"`
+}
+
+type secretRefHashPayload struct {
+	Name  string `json:"name"`
+	Realm string `json:"realm"`
+	Space string `json:"space"`
+	Stack string `json:"stack"`
+	Cell  string `json:"cell"`
+}
+
 // ComputeContainerSpecHash returns a hex-encoded SHA-256 over the
 // containerSpecHashPayload projection of spec. Pure function; no
 // containerd access. Same hash for root and non-root containers — the
@@ -91,12 +129,16 @@ func ComputeContainerSpecHash(spec intmodel.ContainerSpec) string {
 		Image:                  spec.Image,
 		Command:                spec.Command,
 		Args:                   normalizeStrings(spec.Args),
+		WorkingDir:             spec.WorkingDir,
 		Privileged:             spec.Privileged,
 		User:                   spec.User,
 		ReadOnlyRootFilesystem: spec.ReadOnlyRootFilesystem,
 		Capabilities:           projectCapabilities(spec.Capabilities),
+		SecurityOpts:           normalizeStrings(spec.SecurityOpts),
 		Tmpfs:                  projectTmpfs(spec.Tmpfs),
 		Resources:              projectResources(spec.Resources),
+		Volumes:                projectVolumes(spec.Volumes),
+		Secrets:                projectSecrets(spec.Secrets),
 	}
 	// json.Marshal on a struct with a fixed field order is deterministic.
 	// Errors are not possible here (payload is plain comparable types).
@@ -153,6 +195,54 @@ func derefInt64(p *int64) int64 {
 		return 0
 	}
 	return *p
+}
+
+// projectVolumes flattens a VolumeMount slice in declaration order (the
+// equality semantics in diff.go's `volumeMountsEqual` are order-sensitive).
+// An empty Kind is left as-is so it hashes identically to the diff layer's
+// bare struct comparison.
+func projectVolumes(v []intmodel.VolumeMount) []volumeHashPayload {
+	out := make([]volumeHashPayload, len(v))
+	for i := range v {
+		out[i] = volumeHashPayload{
+			Kind:      string(v[i].Kind),
+			Source:    v[i].Source,
+			Target:    v[i].Target,
+			ReadOnly:  v[i].ReadOnly,
+			SizeBytes: v[i].SizeBytes,
+			Mode:      v[i].Mode,
+		}
+	}
+	return out
+}
+
+// projectSecrets flattens a ContainerSecret slice in declaration order,
+// mirroring `secretsEqual`'s order-sensitive, reference-only comparison.
+func projectSecrets(s []intmodel.ContainerSecret) []secretHashPayload {
+	out := make([]secretHashPayload, len(s))
+	for i := range s {
+		out[i] = secretHashPayload{
+			Name:      s[i].Name,
+			FromFile:  s[i].FromFile,
+			FromEnv:   s[i].FromEnv,
+			MountPath: s[i].MountPath,
+			SecretRef: projectSecretRef(s[i].SecretRef),
+		}
+	}
+	return out
+}
+
+func projectSecretRef(r *intmodel.ContainerSecretRef) *secretRefHashPayload {
+	if r == nil {
+		return nil
+	}
+	return &secretRefHashPayload{
+		Name:  r.Name,
+		Realm: r.Realm,
+		Space: r.Space,
+		Stack: r.Stack,
+		Cell:  r.Cell,
+	}
 }
 
 // stampSpecHashOnLabels writes the SpecHashLabelKey into labels (allocating

--- a/internal/controller/runner/spec_hash_test.go
+++ b/internal/controller/runner/spec_hash_test.go
@@ -106,6 +106,18 @@ func TestComputeContainerSpecHash_BreakingFieldsChangeHash(t *testing.T) {
 			limit := int64(64 << 20)
 			s.Resources = &intmodel.ContainerResources{MemoryLimitBytes: &limit}
 		}},
+		// OCI-baked fields reclassified Breaking-on-root by issue #1154.
+		{"workingDir", func(s *intmodel.ContainerSpec) { s.WorkingDir = "/opt/app" }},
+		{"securityOpts", func(s *intmodel.ContainerSpec) { s.SecurityOpts = []string{"no-new-privileges"} }},
+		{"volumes", func(s *intmodel.ContainerSpec) {
+			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
+		}},
+		{"secrets", func(s *intmodel.ContainerSpec) {
+			s.Secrets = []intmodel.ContainerSecret{{Name: "db", FromEnv: "DB_PASS"}}
+		}},
+		{"secretsRef", func(s *intmodel.ContainerSpec) {
+			s.Secrets = []intmodel.ContainerSecret{{Name: "db", SecretRef: &intmodel.ContainerSecretRef{Name: "creds", Realm: "prod"}}}
+		}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -119,11 +131,12 @@ func TestComputeContainerSpecHash_BreakingFieldsChangeHash(t *testing.T) {
 }
 
 // TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash locks that
-// fields `apply.DiffCell` classifies as Compatible (env, ports, volumes,
-// securityOpts, secrets, repos) are *not* part of the hash. Hashing them
-// would force a recreate-or-refuse on every `kuke apply -f` that only
-// tweaked a compatible field, defeating the in-place UpdateCell path the
-// apply layer already exercises for those fields.
+// fields `apply.DiffCell` classifies as Compatible (env, ports, repos) are
+// *not* part of the hash. Hashing them would force a recreate-or-refuse on
+// every `kuke apply -f` that only tweaked a compatible field, defeating the
+// in-place UpdateCell path the apply layer already exercises for those
+// fields. (volumes, securityOpts, and secrets moved to the Breaking set in
+// issue #1154 — they are OCI-baked at create and now change the hash.)
 func TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash(t *testing.T) {
 	base := intmodel.ContainerSpec{
 		Image:   "alpine",
@@ -138,15 +151,6 @@ func TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash(t *testing.T) 
 	}{
 		{"env", func(s *intmodel.ContainerSpec) { s.Env = []string{"FOO=bar"} }},
 		{"ports", func(s *intmodel.ContainerSpec) { s.Ports = []string{"8080:80"} }},
-		{"volumes", func(s *intmodel.ContainerSpec) {
-			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
-		}},
-		{"securityOpts", func(s *intmodel.ContainerSpec) {
-			s.SecurityOpts = []string{"no-new-privileges"}
-		}},
-		{"secrets", func(s *intmodel.ContainerSpec) {
-			s.Secrets = []intmodel.ContainerSecret{{Name: "db", FromEnv: "DB_PASS"}}
-		}},
 		{"repos", func(s *intmodel.ContainerSpec) {
 			s.Repos = []intmodel.ContainerRepo{{Name: "app", URL: "https://example.com/app.git", Target: "/src"}}
 		}},
@@ -223,16 +227,19 @@ func TestSpecHashDomainPinsToDiffCellBreakingFields(t *testing.T) {
 			limit := int64(64 << 20)
 			s.Resources = &intmodel.ContainerResources{MemoryLimitBytes: &limit}
 		}, true},
+		// OCI-baked fields reclassified Breaking-on-root by issue #1154 —
+		// must change the hash so the bare-start drift guard catches them too.
+		{"workingDir", func(s *intmodel.ContainerSpec) { s.WorkingDir = "/opt/app" }, true},
+		{"securityOpts", func(s *intmodel.ContainerSpec) { s.SecurityOpts = []string{"no-new-privileges"} }, true},
+		{"volumes", func(s *intmodel.ContainerSpec) {
+			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
+		}, true},
+		{"secrets", func(s *intmodel.ContainerSpec) {
+			s.Secrets = []intmodel.ContainerSecret{{Name: "db", FromEnv: "DB_PASS"}}
+		}, true},
 		// Compatible domain — must NOT change the hash.
 		{"env", func(s *intmodel.ContainerSpec) { s.Env = []string{"FOO=bar"} }, false},
 		{"ports", func(s *intmodel.ContainerSpec) { s.Ports = []string{"8080:80"} }, false},
-		{"volumes", func(s *intmodel.ContainerSpec) {
-			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
-		}, false},
-		{"securityOpts", func(s *intmodel.ContainerSpec) { s.SecurityOpts = []string{"no-new-privileges"} }, false},
-		{"secrets", func(s *intmodel.ContainerSpec) {
-			s.Secrets = []intmodel.ContainerSecret{{Name: "db", FromEnv: "DB_PASS"}}
-		}, false},
 		{"repos", func(s *intmodel.ContainerSpec) {
 			s.Repos = []intmodel.ContainerRepo{{Name: "app", URL: "https://example.com/app.git", Target: "/src"}}
 		}, false},

--- a/internal/controller/runner/update_cell.go
+++ b/internal/controller/runner/update_cell.go
@@ -278,11 +278,73 @@ func (r *Exec) UpdateCell(desired intmodel.Cell) (intmodel.Cell, error) {
 	return existing, nil
 }
 
-// containerSpecChanged checks if a container spec has breaking changes (image, command, args).
+// containerSpecChanged reports whether a non-root container must be
+// stop-removed and recreated for the change to take effect, rather than
+// updated in place. The gate covers the OCI-baked fields whose values the
+// runner fixes at container create and never re-resolves on the in-place
+// task-restart path: image/command/args (snapshot + Process), workingDir
+// (Process.Cwd), securityOpts (Process.NoNewPrivileges / Linux.Seccomp),
+// volumes (OCI Mounts), and secrets (env-injected Process.Env via
+// resolveSecrets, plus file-form Mounts). Without recreating, a secrets edit
+// on a workload container never reaches the running OCI Process.Env — the
+// defect issue #1154 fixes on the non-root side (the root side routes through
+// RecreateCell via the Breaking-on-root diff classification).
+//
+// Other Breaking-on-root fields (privileged, user, readOnlyRootFilesystem,
+// capabilities, tmpfs, resources) are not yet gated here; their non-root
+// in-place gap predates #1154 and is tracked separately.
 func containerSpecChanged(desired, actual *intmodel.ContainerSpec) bool {
 	return desired.Image != actual.Image ||
 		desired.Command != actual.Command ||
-		!stringSlicesEqual(desired.Args, actual.Args)
+		!stringSlicesEqual(desired.Args, actual.Args) ||
+		desired.WorkingDir != actual.WorkingDir ||
+		!stringSlicesEqual(desired.SecurityOpts, actual.SecurityOpts) ||
+		!volumeMountsEqual(desired.Volumes, actual.Volumes) ||
+		!containerSecretsEqual(desired.Secrets, actual.Secrets)
+}
+
+// volumeMountsEqual reports whether two VolumeMount slices are equal in
+// declaration order. VolumeMount is a flat struct of comparable fields, so
+// `==` matches the diff layer's `volumeMountsEqual` semantics.
+func volumeMountsEqual(a, b []intmodel.VolumeMount) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// containerSecretsEqual reports whether two ContainerSecret slices carry
+// the same references in declaration order, mirroring the diff layer's
+// `secretsEqual` (reference-only, never the resolved value).
+func containerSecretsEqual(a, b []intmodel.ContainerSecret) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name ||
+			a[i].FromFile != b[i].FromFile ||
+			a[i].FromEnv != b[i].FromEnv ||
+			a[i].MountPath != b[i].MountPath ||
+			!secretRefsEqual(a[i].SecretRef, b[i].SecretRef) {
+			return false
+		}
+	}
+	return true
+}
+
+func secretRefsEqual(a, b *intmodel.ContainerSecretRef) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 func stringSlicesEqual(a, b []string) bool {

--- a/internal/controller/runner/update_cell_test.go
+++ b/internal/controller/runner/update_cell_test.go
@@ -1,0 +1,93 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runner
+
+import (
+	"testing"
+
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestContainerSpecChanged_OCIBakedFields pins issue #1154's non-root side:
+// the UpdateCell recreate gate must fire for every OCI-baked field the runner
+// resolves at container create and never re-resolves on the in-place
+// task-restart path. A secrets-only edit on a workload (non-root) container
+// must recreate it so resolveSecrets re-runs and the new env var reaches the
+// running OCI Process.Env — the symptom #1154 fixes.
+func TestContainerSpecChanged_OCIBakedFields(t *testing.T) {
+	base := intmodel.ContainerSpec{
+		Image:   "busybox:latest",
+		Command: "sleep",
+		Args:    []string{"60"},
+	}
+
+	cases := []struct {
+		name string
+		mut  func(s *intmodel.ContainerSpec)
+		want bool
+	}{
+		// Pre-existing gate fields — must still trigger a recreate.
+		{"image", func(s *intmodel.ContainerSpec) { s.Image = "busybox:1.36" }, true},
+		{"command", func(s *intmodel.ContainerSpec) { s.Command = "echo" }, true},
+		{"args", func(s *intmodel.ContainerSpec) { s.Args = []string{"120"} }, true},
+		// Fields newly gated by #1154 — must trigger a recreate.
+		{"workingDir", func(s *intmodel.ContainerSpec) { s.WorkingDir = "/opt/app" }, true},
+		{"securityOpts", func(s *intmodel.ContainerSpec) { s.SecurityOpts = []string{"no-new-privileges"} }, true},
+		{"volumes", func(s *intmodel.ContainerSpec) {
+			s.Volumes = []intmodel.VolumeMount{{Source: "/host", Target: "/cell"}}
+		}, true},
+		{"secretsFromEnv", func(s *intmodel.ContainerSpec) {
+			s.Secrets = []intmodel.ContainerSecret{{Name: "tok", FromEnv: "CLAUDE_CODE_OAUTH_TOKEN"}}
+		}, true},
+		{"secretsRef", func(s *intmodel.ContainerSpec) {
+			s.Secrets = []intmodel.ContainerSecret{{Name: "db", SecretRef: &intmodel.ContainerSecretRef{Name: "creds", Realm: "default"}}}
+		}, true},
+		// Compatible field — must NOT trigger a recreate (rebuilt at start).
+		{"env", func(s *intmodel.ContainerSpec) { s.Env = []string{"FOO=bar"} }, false},
+		// No diff — must NOT trigger a recreate.
+		{"identical", func(_ *intmodel.ContainerSpec) {}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			desired := base
+			tc.mut(&desired)
+			if got := containerSpecChanged(&desired, &base); got != tc.want {
+				t.Errorf("containerSpecChanged(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestContainerSpecChanged_SecretRefScopeChange guards the SecretRef
+// pointer-value comparison: a scope-only change (Realm default→prod, same
+// ref name) must still recreate so the daemon re-resolves against the new
+// scope coordinate. Mirrors the diff layer's secretRefEqual semantics.
+func TestContainerSpecChanged_SecretRefScopeChange(t *testing.T) {
+	actual := intmodel.ContainerSpec{
+		Image:   "busybox:latest",
+		Secrets: []intmodel.ContainerSecret{{Name: "db", SecretRef: &intmodel.ContainerSecretRef{Name: "creds", Realm: "default"}}},
+	}
+	desired := actual
+	desired.Secrets = []intmodel.ContainerSecret{{Name: "db", SecretRef: &intmodel.ContainerSecretRef{Name: "creds", Realm: "prod"}}}
+
+	if !containerSpecChanged(&desired, &actual) {
+		t.Error("expected containerSpecChanged=true for a SecretRef scope change")
+	}
+}


### PR DESCRIPTION
## Summary

`internal/controller/apply/diff.go` classified a root container's `secrets`
change as **Compatible** (in-place). But env-form secrets are resolved into the
OCI `Process.Env` at **container create** (`ctr.CreateContainerFromSpec` →
`resolveSecrets` → `EnvAdds`) and file-form secrets become OCI Mounts — both
baked at create with no re-resolution on the in-place task-restart path. So a
secret change never reached the running container (the `CLAUDE_CODE_OAUTH_TOKEN`
-missing symptom of #1152/#1153: the Cell model read `Synced`, the live OCI spec
lacked the env var). The audit in #1154 verified the same defect for three
sibling OCI-baked fields. This PR reclassifies all four as **Breaking-on-root**
so a change routes through `RecreateCell`, and threads them through the
spec-hash drift guard and the non-root recreate gate.

### What changed

- **`diff.go`** — `secrets`, `workingDir`, `securityOpts`, `volumes` now record
  `breakingOnRoot=true`, so a root-container change classifies `Breaking` and the
  apply layer drives `RecreateCell` (which rebuilds the OCI spec and re-resolves
  secrets). Non-root stays `Compatible` (routes to `UpdateCell`). The four
  now-false caveat comments are corrected.
- **`spec_hash.go`** — `containerSpecHashPayload` gains `WorkingDir`,
  `SecurityOpts`, `Volumes`, `Secrets` (reference-only for secrets, never the
  resolved value), with projections matching diff.go's equality semantics. This
  keeps the bare-`start`-of-stopped-cell drift guard in lock-step with the
  widened Breaking domain — required by `TestSpecHashDomainPinsToDiffCellBreakingFields`.
- **`update_cell.go`** — `containerSpecChanged` (the non-root recreate gate used
  by `UpdateCell` and `UpdateContainer`) now fires on these four OCI-baked
  fields too. **This closes item 4 of the issue**: previously a secrets-only edit
  on a workload (non-root) container never recreated it, so `resolveSecrets`
  never re-ran and the defect persisted for workload containers. Verified by code
  trace: the recreate path calls `CreateContainerFromSpec` → `resolveSecrets`.

### Scope notes (for reviewer push-back)

- The issue's AC is centered on `secrets`; the title and audit section also call
  for `workingDir`/`securityOpts`/`volumes` "in the same pass" (each verified in
  the issue body). All four are the same OCI-baked defect class, so they ship
  together.
- **File-form secrets (issue item 5):** handled by the same reclassification — a
  secrets change (env or file form) now forces a recreate that rebuilds the OCI
  Mounts table; no separate change needed.
- **Deferred (documented, not fixed here):** the other already-`Breaking`-on-root
  fields (`privileged`, `user`, `readOnlyRootFilesystem`, `capabilities`,
  `tmpfs`, `resources`) are *not* yet in the non-root `containerSpecChanged`
  gate — their non-root in-place gap predates #1154 and is out of this issue's
  scope. Likewise the lower-confidence host-namespace fields (`hostNetwork`,
  `hostPID`, `hostCgroup`, `nestedCgroupRuntime`) the issue flags as "to verify"
  remain `Breaking` but absent from the spec-hash; I left them as-is rather than
  bundle an uncertain change. Both are worth a PM follow-up.

## Test plan

- [x] `make test` (full CI suite: `test-root` + `test-kukebuild`) — exit 0
- [x] `go vet` on `./internal/controller/apply/...` and `./internal/controller/runner/...` (GOWORK=off) — clean
- [x] `TestSpecHashDomainPinsToDiffCellBreakingFields` passes with the four fields in both the Breaking domain and the hash payload
- [x] New `TestDiffCell_RootContainerSecrets_Breaking` + `TestDiffCell_RootContainerWorkingDirVolumesSecurityOpts_Breaking`: a secrets-only (and each sibling) root diff yields `ChangeType == Breaking` on the root container
- [x] New `TestContainerSpecChanged_OCIBakedFields` / `_SecretRefScopeChange`: the non-root recreate gate fires for each OCI-baked field (item 4)
- [ ] Live `ctr container info` env verification on a running cell — not run; requires a provisioned daemon/host the dev environment doesn't have. The runtime-delivery path is covered by code trace (recreate → `CreateContainerFromSpec` → `resolveSecrets`) plus the unit tests above.

Closes #1154