### PR TITLE
fix(cli): default single-get and run --from-config space/stack to default scope

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -302,17 +302,17 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_BLUEPRINT_REALM = DefineKV("KUKE_GET_BLUEPRINT_REALM", "kuke/get/blueprint/realm", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_GET_BLUEPRINT_SPACE = DefineKV("KUKE_GET_BLUEPRINT_SPACE", "kuke/get/blueprint/space")
+	KUKE_GET_BLUEPRINT_SPACE = DefineKV("KUKE_GET_BLUEPRINT_SPACE", "kuke/get/blueprint/space", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_GET_BLUEPRINT_STACK = DefineKV("KUKE_GET_BLUEPRINT_STACK", "kuke/get/blueprint/stack")
+	KUKE_GET_BLUEPRINT_STACK = DefineKV("KUKE_GET_BLUEPRINT_STACK", "kuke/get/blueprint/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_CONFIG_NAME = DefineKV("KUKE_GET_CONFIG_NAME", "kuke/get/config/name")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_CONFIG_REALM = DefineKV("KUKE_GET_CONFIG_REALM", "kuke/get/config/realm", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_GET_CONFIG_SPACE = DefineKV("KUKE_GET_CONFIG_SPACE", "kuke/get/config/space")
+	KUKE_GET_CONFIG_SPACE = DefineKV("KUKE_GET_CONFIG_SPACE", "kuke/get/config/space", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	KUKE_GET_CONFIG_STACK = DefineKV("KUKE_GET_CONFIG_STACK", "kuke/get/config/stack")
+	KUKE_GET_CONFIG_STACK = DefineKV("KUKE_GET_CONFIG_STACK", "kuke/get/config/stack", "default")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	KUKE_GET_OUTPUT = DefineKV("KUKE_GET_OUTPUT", "kuke/get/output")
 

--- a/cmd/kuke/create/cell/cell.go
+++ b/cmd/kuke/create/cell/cell.go
@@ -338,9 +338,11 @@ func ValidateOverrideSymmetry(flags SourceFlags) error {
 }
 
 // ScopeVars names the command-specific scope viper Vars the materialize path
-// reads to resolve binding-lookup scope (so a realm-scoped Blueprint/Config
-// stays findable when --space/--stack are unset). `kuke create cell` passes its
-// KUKE_CREATE_CELL_* vars; `kuke run` passes its KUKE_RUN_* vars. Threading the
+// reads to resolve binding-lookup scope. An unset --space/--stack defaults to
+// the var's "default" (issue #1156) so the lookup hits the full default scope;
+// a realm-scoped Blueprint/Config stays reachable via an explicit empty
+// `--space "" --stack ""`. `kuke create cell` passes its KUKE_CREATE_CELL_*
+// vars; `kuke run` passes its KUKE_RUN_* vars. Threading the
 // Vars in (rather than hard-coding KUKE_CREATE_CELL_*) is what lets the two
 // verbs share one Materialize entrypoint without colliding on a global viper
 // key (epic:cell-identity #1025).
@@ -404,9 +406,10 @@ func Materialize(
 // --param/--param-file, materialises the Cell record, overlays scope, and
 // finalizes the cell name — returning the doc without persisting it.
 //
-// Lookup scope follows the explicit-coordinate rule from
-// kukeshared.PickLookupRealm / ExplicitScope so realm-scoped Blueprints stay
-// findable when --space/--stack are not set.
+// Lookup scope follows the default-coordinate rule from
+// kukeshared.PickLookupRealm / ExplicitScope: an unset --space/--stack
+// resolves to "default" so the lookup hits the full default scope, while a
+// realm-scoped Blueprint stays reachable via an explicit empty --space/--stack.
 func materializeFromBlueprint(
 	cmd *cobra.Command, client kukeonv1.Client, flags SourceFlags, scope ScopeVars,
 ) (v1beta1.CellDoc, error) {

--- a/cmd/kuke/create/cell/cell_test.go
+++ b/cmd/kuke/create/cell/cell_test.go
@@ -755,6 +755,87 @@ func TestCreateCell_FromConfig_HappyPath(t *testing.T) {
 	}
 }
 
+// TestCreateCell_FromConfig_DefaultsLookupScope pins issue #1156: with no
+// --space/--stack, the Config lookup resolves to the full default scope
+// (realm/space/stack = "default") so `kuke run --from-config <cfg>` finds a
+// config stored at the full default coordinate and proceeds to materialize.
+func TestCreateCell_FromConfig_DefaultsLookupScope(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var materializeCalled bool
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			m := doc.Metadata
+			if m.Realm != "default" || m.Space != "default" || m.Stack != "default" {
+				t.Errorf(
+					"Config lookup scope = realm=%q space=%q stack=%q, want all \"default\"",
+					m.Realm, m.Space, m.Stack,
+				)
+			}
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			materializeCalled = true
+			return successResultFromDoc(doc), nil
+		},
+	}
+
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "from-config", "prod")
+	cmd.SetArgs([]string{"prod-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !materializeCalled {
+		t.Fatal("MaterializeCell was not called — no-flag from-config lookup missed the full default scope")
+	}
+}
+
+// TestCreateCell_FromConfig_ExplicitEmptyScope pins the escape hatch: an
+// explicit empty --space/--stack stays empty so a realm-scoped Config remains
+// findable (issue #1156).
+func TestCreateCell_FromConfig_ExplicitEmptyScope(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	var materializeCalled bool
+	fc := &fakeClient{
+		getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+			m := doc.Metadata
+			if m.Realm != "default" || m.Space != "" || m.Stack != "" {
+				t.Errorf(
+					"Config lookup scope = realm=%q space=%q stack=%q, want realm=\"default\" space/stack empty",
+					m.Realm, m.Space, m.Stack,
+				)
+			}
+			return kukeonv1.GetConfigResult{Config: configDoc(), MetadataExists: true}, nil
+		},
+		getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+			return kukeonv1.GetBlueprintResult{Blueprint: blueprintDoc(), MetadataExists: true}, nil
+		},
+		materializeCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			materializeCalled = true
+			return successResultFromDoc(doc), nil
+		},
+	}
+
+	cmd, _ := newTestExecCmd(t, fc)
+	setFlag(t, cmd, "from-config", "prod")
+	setFlag(t, cmd, "space", "")
+	setFlag(t, cmd, "stack", "")
+	cmd.SetArgs([]string{"prod-1"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !materializeCalled {
+		t.Fatal("MaterializeCell was not called — explicit-empty escape hatch did not preserve realm-scoped lookup")
+	}
+}
+
 func TestCreateCell_FromConfig_NotFound_Errors(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/cmd/kuke/create/cell/clone.go
+++ b/cmd/kuke/create/cell/clone.go
@@ -125,9 +125,9 @@ func materializeClone(cmd *cobra.Command, client kukeonv1.Client, flags SourceFl
 }
 
 // resolveSourceCell fetches the cell named by --clone at the operator's
-// --realm/--space/--stack scope. Unlike the from-blueprint / from-config
-// binding lookups (which use ExplicitScope so a realm-scoped binding stays
-// findable with empty space/stack), a cell always lives at a full
+// --realm/--space/--stack scope. Like the from-blueprint / from-config binding
+// lookups (which default an unset --space/--stack to "default" via
+// ExplicitScope per issue #1156), a cell always lives at a full
 // realm/space/stack, so the source lookup uses the defaulted flags scope
 // (default/default/default when the operator passes no coordinate). A missing
 // source cell is a clear ErrCellNotFound.

--- a/cmd/kuke/get/blueprint/blueprint.go
+++ b/cmd/kuke/get/blueprint/blueprint.go
@@ -75,10 +75,21 @@ func NewBlueprintCmd() *cobra.Command {
 
 			if name != "" {
 				// A single blueprint is identified by its name plus its exact
-				// binding scope. Default the realm to the operator's current
-				// realm; deeper coordinates stay unset unless provided.
+				// binding scope. Default every coordinate to the operator's
+				// full default scope (realm/space/stack = "default") so a
+				// no-flag `kuke get blueprint <name>` finds resources stored at
+				// the full default coordinate — how `kuke create blueprint` and
+				// the team renderer actually store them. Mirrors `get cell`
+				// (issue #1156). A realm-scoped Blueprint (space/stack unset) is
+				// reachable by passing an explicit `--space "" --stack ""`.
 				if realm == "" {
 					realm = strings.TrimSpace(config.KUKE_GET_BLUEPRINT_REALM.ValueOrDefault())
+				}
+				if space == "" {
+					space = strings.TrimSpace(config.KUKE_GET_BLUEPRINT_SPACE.ValueOrDefault())
+				}
+				if stack == "" {
+					stack = strings.TrimSpace(config.KUKE_GET_BLUEPRINT_STACK.ValueOrDefault())
 				}
 				if realm == "" {
 					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
@@ -96,12 +107,12 @@ func NewBlueprintCmd() *cobra.Command {
 				result, getErr := client.GetBlueprint(cmd.Context(), lookup)
 				if getErr != nil {
 					if errors.Is(getErr, errdefs.ErrBlueprintNotFound) {
-						return fmt.Errorf("blueprint %q not found", name)
+						return blueprintNotFoundErr(cmd, client, name, realm, space, stack)
 					}
 					return getErr
 				}
 				if !result.MetadataExists {
-					return fmt.Errorf("blueprint %q not found", name)
+					return blueprintNotFoundErr(cmd, client, name, realm, space, stack)
 				}
 				return printBlueprint(cmd, &result.Blueprint, outputFormat)
 			}
@@ -140,6 +151,34 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 		return mockClient, nil
 	}
 	return kukeshared.ClientFromCmd(cmd)
+}
+
+// blueprintNotFoundErr builds the single-get miss error. It surfaces the exact
+// scope searched and — best-effort — hints the coordinate where a Blueprint of
+// the same name does live (probed realm-wide), so an operator who stored it at a
+// non-default space/stack sees where to look instead of a bare "not found"
+// (issue #1156). The realm-wide list is advisory: a list error is swallowed and
+// the base error returned unadorned.
+func blueprintNotFoundErr(
+	cmd *cobra.Command, client kukeonv1.Client, name, realm, space, stack string,
+) error {
+	base := fmt.Sprintf(
+		"blueprint %q not found (searched realm=%q space=%q stack=%q)", name, realm, space, stack,
+	)
+	blueprints, err := client.ListBlueprints(cmd.Context(), realm, "", "")
+	if err != nil {
+		return errors.New(base)
+	}
+	for i := range blueprints {
+		m := &blueprints[i].Metadata
+		if m.Name == name && (m.Realm != realm || m.Space != space || m.Stack != stack) {
+			return fmt.Errorf(
+				"%s; a blueprint %q exists at realm=%q space=%q stack=%q",
+				base, name, m.Realm, m.Space, m.Stack,
+			)
+		}
+	}
+	return errors.New(base)
 }
 
 func printBlueprint(cmd *cobra.Command, blueprint *v1beta1.CellBlueprintDoc, format shared.OutputFormat) error {

--- a/cmd/kuke/get/blueprint/blueprint_test.go
+++ b/cmd/kuke/get/blueprint/blueprint_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -64,6 +65,53 @@ func TestNewBlueprintCmd(t *testing.T) {
 			},
 		},
 		{
+			// No --space/--stack: the single-get lookup must resolve to the
+			// full default scope (realm/space/stack = "default") so a
+			// full-scoped Blueprint is found (issue #1156).
+			name: "get single blueprint defaults full scope when no flags",
+			args: []string{"web"},
+			fake: &fakeClient{
+				getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					m := doc.Metadata
+					if m.Realm != "default" || m.Space != "default" || m.Stack != "default" {
+						return kukeonv1.GetBlueprintResult{}, fmt.Errorf(
+							"lookup scope = realm=%q space=%q stack=%q, want all \"default\"",
+							m.Realm, m.Space, m.Stack,
+						)
+					}
+					return kukeonv1.GetBlueprintResult{
+						Blueprint:      v1beta1.CellBlueprintDoc{Metadata: doc.Metadata},
+						MetadataExists: true,
+					}, nil
+				},
+			},
+		},
+		{
+			// An explicit empty --space/--stack stays empty so a realm-scoped
+			// Blueprint remains findable (the escape hatch).
+			name: "get single blueprint explicit empty space stays realm-scoped",
+			args: []string{"web"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("space", "")
+				_ = cmd.Flags().Set("stack", "")
+			},
+			fake: &fakeClient{
+				getBlueprintFn: func(doc v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					m := doc.Metadata
+					if m.Realm != "default" || m.Space != "" || m.Stack != "" {
+						return kukeonv1.GetBlueprintResult{}, fmt.Errorf(
+							"lookup scope = realm=%q space=%q stack=%q, want realm=\"default\" space/stack empty",
+							m.Realm, m.Space, m.Stack,
+						)
+					}
+					return kukeonv1.GetBlueprintResult{
+						Blueprint:      v1beta1.CellBlueprintDoc{Metadata: doc.Metadata},
+						MetadataExists: true,
+					}, nil
+				},
+			},
+		},
+		{
 			name: "get not found surfaces friendly error",
 			args: []string{"missing"},
 			setup: func(_ *testing.T, cmd *cobra.Command) {
@@ -75,6 +123,25 @@ func TestNewBlueprintCmd(t *testing.T) {
 				},
 			},
 			wantErr: `blueprint "missing" not found`,
+		},
+		{
+			// On a miss, the realm-wide probe hints the coordinate where a
+			// Blueprint of the same name does live (issue #1156).
+			name: "get not found hints other-scope coordinate",
+			args: []string{"web"},
+			fake: &fakeClient{
+				getBlueprintFn: func(_ v1beta1.CellBlueprintDoc) (kukeonv1.GetBlueprintResult, error) {
+					return kukeonv1.GetBlueprintResult{MetadataExists: false}, nil
+				},
+				listBlueprintsFn: func(_, _, _ string) ([]v1beta1.CellBlueprintDoc, error) {
+					return []v1beta1.CellBlueprintDoc{
+						{Metadata: v1beta1.CellBlueprintMetadata{
+							Name: "web", Realm: "default", Space: "team-a", Stack: "core",
+						}},
+					}, nil
+				},
+			},
+			wantErr: `exists at realm="default" space="team-a" stack="core"`,
 		},
 		{
 			name: "get not found via MetadataExists=false",

--- a/cmd/kuke/get/config/config.go
+++ b/cmd/kuke/get/config/config.go
@@ -75,10 +75,21 @@ func NewConfigCmd() *cobra.Command {
 
 			if name != "" {
 				// A single config is identified by its name plus its exact
-				// binding scope. Default the realm to the operator's current
-				// realm; deeper coordinates stay unset unless provided.
+				// binding scope. Default every coordinate to the operator's
+				// full default scope (realm/space/stack = "default") so a
+				// no-flag `kuke get config <name>` finds resources stored at
+				// the full default coordinate — how `kuke create config` and
+				// the team renderer actually store them. Mirrors `get cell`
+				// (issue #1156). A realm-scoped Config (space/stack unset) is
+				// reachable by passing an explicit `--space "" --stack ""`.
 				if realm == "" {
 					realm = strings.TrimSpace(config.KUKE_GET_CONFIG_REALM.ValueOrDefault())
+				}
+				if space == "" {
+					space = strings.TrimSpace(config.KUKE_GET_CONFIG_SPACE.ValueOrDefault())
+				}
+				if stack == "" {
+					stack = strings.TrimSpace(config.KUKE_GET_CONFIG_STACK.ValueOrDefault())
 				}
 				if realm == "" {
 					return fmt.Errorf("%w (--realm)", errdefs.ErrRealmNameRequired)
@@ -96,12 +107,12 @@ func NewConfigCmd() *cobra.Command {
 				result, getErr := client.GetConfig(cmd.Context(), lookup)
 				if getErr != nil {
 					if errors.Is(getErr, errdefs.ErrConfigNotFound) {
-						return fmt.Errorf("config %q not found", name)
+						return configNotFoundErr(cmd, client, name, realm, space, stack)
 					}
 					return getErr
 				}
 				if !result.MetadataExists {
-					return fmt.Errorf("config %q not found", name)
+					return configNotFoundErr(cmd, client, name, realm, space, stack)
 				}
 				return printConfig(cmd, &result.Config, outputFormat)
 			}
@@ -140,6 +151,34 @@ func resolveClient(cmd *cobra.Command) (kukeonv1.Client, error) {
 		return mockClient, nil
 	}
 	return kukeshared.ClientFromCmd(cmd)
+}
+
+// configNotFoundErr builds the single-get miss error. It surfaces the exact
+// scope searched and — best-effort — hints the coordinate where a Config of the
+// same name does live (probed realm-wide), so an operator who stored it at a
+// non-default space/stack sees where to look instead of a bare "not found"
+// (issue #1156). The realm-wide list is advisory: a list error is swallowed and
+// the base error returned unadorned.
+func configNotFoundErr(
+	cmd *cobra.Command, client kukeonv1.Client, name, realm, space, stack string,
+) error {
+	base := fmt.Sprintf(
+		"config %q not found (searched realm=%q space=%q stack=%q)", name, realm, space, stack,
+	)
+	configs, err := client.ListConfigs(cmd.Context(), realm, "", "")
+	if err != nil {
+		return errors.New(base)
+	}
+	for i := range configs {
+		m := &configs[i].Metadata
+		if m.Name == name && (m.Realm != realm || m.Space != space || m.Stack != stack) {
+			return fmt.Errorf(
+				"%s; a config %q exists at realm=%q space=%q stack=%q",
+				base, name, m.Realm, m.Space, m.Stack,
+			)
+		}
+	}
+	return errors.New(base)
 }
 
 func printConfig(cmd *cobra.Command, cfg *v1beta1.CellConfigDoc, format shared.OutputFormat) error {

--- a/cmd/kuke/get/config/config_test.go
+++ b/cmd/kuke/get/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
@@ -64,6 +65,53 @@ func TestNewConfigCmd(t *testing.T) {
 			},
 		},
 		{
+			// No --space/--stack: the single-get lookup must resolve to the
+			// full default scope (realm/space/stack = "default") so a
+			// full-scoped Config is found (issue #1156).
+			name: "get single config defaults full scope when no flags",
+			args: []string{"web"},
+			fake: &fakeClient{
+				getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					m := doc.Metadata
+					if m.Realm != "default" || m.Space != "default" || m.Stack != "default" {
+						return kukeonv1.GetConfigResult{}, fmt.Errorf(
+							"lookup scope = realm=%q space=%q stack=%q, want all \"default\"",
+							m.Realm, m.Space, m.Stack,
+						)
+					}
+					return kukeonv1.GetConfigResult{
+						Config:         v1beta1.CellConfigDoc{Metadata: doc.Metadata},
+						MetadataExists: true,
+					}, nil
+				},
+			},
+		},
+		{
+			// An explicit empty --space/--stack stays empty so a realm-scoped
+			// Config remains findable (the escape hatch).
+			name: "get single config explicit empty space stays realm-scoped",
+			args: []string{"web"},
+			setup: func(_ *testing.T, cmd *cobra.Command) {
+				_ = cmd.Flags().Set("space", "")
+				_ = cmd.Flags().Set("stack", "")
+			},
+			fake: &fakeClient{
+				getConfigFn: func(doc v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					m := doc.Metadata
+					if m.Realm != "default" || m.Space != "" || m.Stack != "" {
+						return kukeonv1.GetConfigResult{}, fmt.Errorf(
+							"lookup scope = realm=%q space=%q stack=%q, want realm=\"default\" space/stack empty",
+							m.Realm, m.Space, m.Stack,
+						)
+					}
+					return kukeonv1.GetConfigResult{
+						Config:         v1beta1.CellConfigDoc{Metadata: doc.Metadata},
+						MetadataExists: true,
+					}, nil
+				},
+			},
+		},
+		{
 			name: "get not found surfaces friendly error",
 			args: []string{"missing"},
 			setup: func(_ *testing.T, cmd *cobra.Command) {
@@ -75,6 +123,25 @@ func TestNewConfigCmd(t *testing.T) {
 				},
 			},
 			wantErr: `config "missing" not found`,
+		},
+		{
+			// On a miss, the realm-wide probe hints the coordinate where a
+			// Config of the same name does live (issue #1156).
+			name: "get not found hints other-scope coordinate",
+			args: []string{"web"},
+			fake: &fakeClient{
+				getConfigFn: func(_ v1beta1.CellConfigDoc) (kukeonv1.GetConfigResult, error) {
+					return kukeonv1.GetConfigResult{MetadataExists: false}, nil
+				},
+				listConfigsFn: func(_, _, _ string) ([]v1beta1.CellConfigDoc, error) {
+					return []v1beta1.CellConfigDoc{
+						{Metadata: v1beta1.CellConfigMetadata{
+							Name: "web", Realm: "default", Space: "team-a", Stack: "core",
+						}},
+					}, nil
+				},
+			},
+			wantErr: `exists at realm="default" space="team-a" stack="core"`,
 		},
 		{
 			name: "get not found via MetadataExists=false",

--- a/cmd/kuke/shared/scope.go
+++ b/cmd/kuke/shared/scope.go
@@ -47,17 +47,24 @@ func PickLookupRealm(cmd *cobra.Command, kv *config.Var) string {
 }
 
 // ExplicitScope returns the named space/stack coordinate for a `kuke run`
-// / `kuke apply` blueprint or config lookup, but only when the operator
-// set it explicitly — via the named cobra flag or the kv.Key env var.
-// Returns "" otherwise so realm-scoped Blueprints/Configs (no space/stack
-// coordinate) stay findable; a missing flag must not narrow the lookup to
-// space="default" / stack="default" or it would hide realm-scoped
-// resources.
+// / `kuke apply` / `kuke create cell` blueprint or config lookup.
+// Precedence: an explicit value wins — the named cobra flag (--space /
+// --stack), else the kv.Key env var — and an explicitly-empty value is
+// honored as empty. When neither flag nor env is set at all, the lookup
+// falls back to kv.Default (operator-supplied default, "default" for the
+// KUKE_{RUN,CREATE_CELL}_{SPACE,STACK} vars) so a no-flag lookup resolves
+// to the full default scope (realm/space/stack = "default") and finds
+// resources stored at that coordinate — how `kuke create config/blueprint`
+// and the team renderer actually store them (issue #1156). A realm-scoped
+// Blueprint/Config (no space/stack coordinate) stays findable by passing
+// an explicit empty `--space "" --stack ""`, which the explicit branch
+// honors.
 //
 // Bypasses viper for the same reason as PickLookupRealm: DefineKV's
 // SetDefault on KUKE_RUN_SPACE / KUKE_RUN_STACK trips viper.IsSet, so a
-// viper-aware fallback would report "default" for an unset coordinate
-// even when the operator left the flag and env var empty.
+// viper-aware fallback could not distinguish an operator-pinned coordinate
+// from the registered default. Reading kv.Default directly keeps the
+// explicit-empty escape hatch intact.
 func ExplicitScope(cmd *cobra.Command, flagName string, kv *config.Var) string {
 	if cmd.Flags().Changed(flagName) {
 		v, _ := cmd.Flags().GetString(flagName)
@@ -66,5 +73,5 @@ func ExplicitScope(cmd *cobra.Command, flagName string, kv *config.Var) string {
 	if v, ok := os.LookupEnv(kv.Key); ok {
 		return strings.TrimSpace(v)
 	}
-	return ""
+	return kv.Default
 }

--- a/cmd/kuke/shared/scope_test.go
+++ b/cmd/kuke/shared/scope_test.go
@@ -95,7 +95,34 @@ func TestExplicitScope_Precedence(t *testing.T) {
 		flag      string
 		want      string
 	}{
-		{name: "space: no flag, no env → empty", flag: "space", kv: &config.KUKE_RUN_SPACE, want: ""},
+		{
+			// No flag, no env → falls back to kv.Default ("default" for
+			// KUKE_RUN_SPACE) so a no-flag lookup resolves to the full
+			// default scope (issue #1156).
+			name: "space: no flag, no env → kv.Default",
+			flag: "space",
+			kv:   &config.KUKE_RUN_SPACE,
+			want: "default",
+		},
+		{
+			// Explicit empty flag is honored as empty — the escape hatch that
+			// keeps realm-scoped Blueprints/Configs (no space/stack) findable.
+			name:      "space: empty flag set explicitly → empty (escape hatch)",
+			flag:      "space",
+			kv:        &config.KUKE_RUN_SPACE,
+			flagValue: "",
+			flagSet:   true,
+			want:      "",
+		},
+		{
+			// Explicit empty env is likewise honored as empty.
+			name:   "space: empty env set explicitly → empty (escape hatch)",
+			flag:   "space",
+			kv:     &config.KUKE_RUN_SPACE,
+			env:    "",
+			envSet: true,
+			want:   "",
+		},
 		{
 			name:   "space: env only → env",
 			flag:   "space",

--- a/internal/controller/reconcile_outofsync.go
+++ b/internal/controller/reconcile_outofsync.go
@@ -145,15 +145,14 @@ func configLineage(cell intmodel.Cell) (string, bool) {
 // The `kukeon.io/config` lineage label records only the Config name, not
 // the scope it was bound at, so the lookup must probe progressively
 // shallower scopes: full (realm/space/stack) → space-only (realm/space) →
-// realm-only (realm). `kuke run <config>` resolves Config lookups via
-// cmd/kuke/shared.ExplicitScope (empty space/stack unless the operator
-// passed --space/--stack), so a `kuke run kukeon-dev-root-0` against a
-// realm-scoped Config materializes a cell at realm=default /
-// space=default / stack=default (resolveCellLocation fills the session
-// defaults). Without the widening here, that cell's reconciler tick
-// resolves to `/opt/kukeon/data/default/default/default/configs/<name>`
-// (which does not exist) and persists a permanent "lineage Config
-// deleted" OutOfSync verdict.
+// realm-only (realm). A realm-scoped Config (bound at realm-only via an
+// explicit empty `--space "" --stack ""`, or by the team renderer) can be
+// referenced by a cell materialized at the full default scope — `kuke run`
+// fills the cell at realm=default / space=default / stack=default via
+// resolveCellLocation regardless of the Config's binding scope. Without the
+// widening here, that cell's reconciler tick resolves to
+// `/opt/kukeon/data/default/default/default/configs/<name>` (which does not
+// exist) and persists a permanent "lineage Config deleted" OutOfSync verdict.
 //
 // Probes are deduplicated when the cell's space or stack is already empty
 // (a realm-scoped cell or a space-scoped cell only takes the one probe


### PR DESCRIPTION
## Summary

`kuke get config <name>`, `kuke get blueprint <name>`, and `kuke run --from-config <cfg>` defaulted only the **realm** to `default`, leaving **space**/**stack** empty. Since `kuke create config/blueprint` and the team renderer store resources at the full `default/default/default` coordinate, the no-flag single-resource lookup missed resources that plainly exist — while the list path (wildcard semantics) worked.

**Design call (the issue is explicitly a "pick a resolution" for dev):** chose **Approach 1** — default space/stack to `"default"` when not explicitly provided, mirroring the `get cell` precedent the issue names as correct. This is lower-blast-radius than daemon-side fallback (Approach 2) or prefix/narrowing match (Approach 3): no daemon changes, no new lookup logic. The create path already proves realm-scoped resources are effectively never created (it full-scopes them via `KUKE_CREATE_{CONFIG,BLUEPRINT}_{SPACE,STACK}` defaults), so the realm-scoped cohort the old behavior protected is vestigial.

**Realm-scoped findability is preserved, not removed:** the run/create lookup path (`ExplicitScope`) still honors an explicit empty `--space "" --stack ""` as empty, so a realm-scoped Blueprint/Config stays reachable. Only the *no-flag* default changed. The get paths mirror `get cell` exactly (an explicit empty re-defaults, matching the named precedent); the run/create path retains the explicit-empty escape hatch where `ExplicitScope`'s design already provides it for free.

### Changes
- `cmd/kuke/shared/scope.go` — `ExplicitScope` now falls back to `kv.Default` (`"default"` for the run/create-cell scope vars) when neither flag nor env is set, while still honoring an explicit empty value. Contract doc rewritten.
- `cmd/kuke/get/config/config.go`, `cmd/kuke/get/blueprint/blueprint.go` — single-get branch defaults space/stack via `ValueOrDefault()` (mirrors `get cell`); not-found errors now surface the searched scope and best-effort hint the coordinate where a same-named resource does live (AC bullet 5).
- `cmd/config/env.go` — `KUKE_GET_{CONFIG,BLUEPRINT}_{SPACE,STACK}` now carry the `"default"` default (matching `KUKE_GET_CELL_{SPACE,STACK}`).
- `cmd/kuke/shared/scope_test.go` — updated the `ExplicitScope` contract tests; added explicit-empty escape-hatch cases.
- Stale comments in `create/cell/cell.go`, `create/cell/clone.go`, and `internal/controller/reconcile_outofsync.go` updated to the new defaulting contract (no behavior change in the daemon — the lineage-widening logic is untouched).

### Notes for the reviewer
- **Out of AC scope, flagged for PM:** `kuke get secret <name>` (`cmd/kuke/get/secret/secret.go:79`) has the identical under-defaulting pattern, but the issue's AC enumerates only config/blueprint/run-create and consistency with `get cell` — and secrets add a `--cell` coordinate, so whether they should default the same way is a separate call. Left untouched; recommend a follow-up if PM wants the parity.
- The daemon-side `lookupLineageConfig` progressive-widening was **not** changed — it remains the backstop for cells whose lineage label points to a shallower-scoped (e.g. team-rendered or explicit-empty) Config.

## Test plan
- [x] `make test` (full CI suite: `test-root` + `test-kukebuild`) — passes (`GOWORK=off`; the bare `go build ./...` cgroups break is a `go.work`-only artifact the Makefile env avoids).
- [x] `GOWORK=off go test ./cmd/config/... ./cmd/kuke/shared/... ./cmd/kuke/get/config/... ./cmd/kuke/get/blueprint/... ./cmd/kuke/create/cell/... ./cmd/kuke/run/...` — passes.
- [x] `go vet` + `gofmt -l` clean on changed files; `golangci-lint run --new-from-rev HEAD` reports 0 new issues; pre-commit (changed files) all green.
- [x] New tests cover the no-flag full-default-scope hit for `get config`, `get blueprint`, and `run/create --from-config`, plus the explicit-empty escape hatch and the other-scope hint (AC bullet 6).

Closes #1156