### PR TITLE
fix(dev-init): build attach-smoke image locally instead of external amd64-only busybox

### DIFF
--- a/hack/attach-smoke/Dockerfile
+++ b/hack/attach-smoke/Dockerfile
@@ -1,0 +1,16 @@
+# Minimal busybox image for dev-init's attach smoke (the
+# dev-init-attach/ds/dks/cattach cell). Built locally into the attach realm
+# by scripts/dev-init.sh and tagged kukeon.internal/attach-smoke, mirroring
+# the kukeon.internal/kukeond local-build convention.
+#
+# Based on the multi-arch docker.io/library/busybox so `kuke build` resolves
+# the build host's architecture and produces a host-arch image — fixing the
+# arm64 breakage from the former single-arch-amd64 registry.eminwux.com/busybox
+# pin, whose amd64 `sleep` ELF could not exec on arm64 and surfaced as an
+# opaque CNI netns ENOENT (issue #1158). Building locally also drops the dev
+# loop's dependency on the external registry.eminwux.com; the reserved
+# kukeon.internal TLD makes a stray runtime pull fail fast instead of
+# silently hitting an external host. busybox provides the /bin/sh the
+# attachable container's kuketty/sbsh wrapper needs plus the `sleep` the
+# root and work containers run.
+FROM docker.io/library/busybox:latest

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -456,6 +456,11 @@ ATTACH_SMOKE_SPACE="ds"
 ATTACH_SMOKE_STACK="dks"
 ATTACH_SMOKE_CELL="cattach"
 ATTACH_SMOKE_CONTAINER="work"
+# Local-only attach-smoke image ref, mirroring KUKEOND_IMAGE_REF above. Built
+# from hack/attach-smoke/Dockerfile into the attach realm below so the smoke
+# no longer pins the single-arch-amd64 external registry.eminwux.com/busybox
+# that broke on arm64 hosts (#1158).
+ATTACH_SMOKE_IMAGE_REF="kukeon.internal/attach-smoke:${KUKEOND_VERSION}"
 ATTACH_SMOKE_BASE="${METADATA_ROOT}/${ATTACH_SMOKE_REALM}/${ATTACH_SMOKE_SPACE}/${ATTACH_SMOKE_STACK}/${ATTACH_SMOKE_CELL}/${ATTACH_SMOKE_CONTAINER}"
 ATTACH_SMOKE_SOCKET="${ATTACH_SMOKE_BASE}/tty/socket"
 ATTACH_SMOKE_METADATA="${ATTACH_SMOKE_BASE}/kuketty-metadata.json"
@@ -480,11 +485,13 @@ teardown_attach_smoke_state() {
     # the purge and strands the next run's `kuke apply` image-pull→
     # snapshot-unpack with "parent snapshot ... does not exist". Removing
     # the namespace by hand makes the teardown idempotent across N runs.
-    # The attach smoke never targets this realm with `kuke build`, so no
-    # `/var/lib/kukebuild/<ns>/` cache exists to wipe alongside it
-    # (the #904 lane only applies to realms that have been a `kuke build`
-    # target).
     sudo ctr namespaces remove "${ATTACH_SMOKE_NS}" 2>/dev/null || true
+    # Since #1158 the attach smoke *is* a `kuke build` target (it builds
+    # kukeon.internal/attach-smoke into this realm), so the #904 lane now
+    # applies: wipe the per-namespace BuildKit cache at
+    # /var/lib/kukebuild/<ns>/ alongside the containerd namespace so the
+    # teardown stays idempotent across runs.
+    sudo rm -rf "/var/lib/kukebuild/${ATTACH_SMOKE_NS}" 2>/dev/null || true
 }
 
 cleanup_attach_smoke() {
@@ -509,6 +516,19 @@ sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke create realm "${ATTACH_SMO
 sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke create space "${ATTACH_SMOKE_SPACE}" --realm "${ATTACH_SMOKE_REALM}"
 sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke create stack "${ATTACH_SMOKE_STACK}" --realm "${ATTACH_SMOKE_REALM}" --space "${ATTACH_SMOKE_SPACE}"
 
+# Build the attach-smoke image into the attach realm's containerd namespace,
+# mirroring the kukeon.internal/kukeond build above (the kuke-system realm at
+# line ~329). This replaces the former external registry.eminwux.com/busybox
+# pin, which was single-arch amd64 and broke the smoke on arm64 hosts (#1158).
+# docker.io/library/busybox is multi-arch, so `kuke build` resolves the host's
+# architecture and the resulting kukeon.internal/attach-smoke image matches the
+# build host automatically. Runs after the realm exists (its namespace must be
+# present for kukebuild to write into) and before the `kuke apply` below.
+step "Build ${ATTACH_SMOKE_IMAGE_REF} into the ${ATTACH_SMOKE_REALM} realm"
+sudo --preserve-env="${PRESERVE_ENV_WORKLOAD}" ./kuke build \
+    -t "${ATTACH_SMOKE_IMAGE_REF}" \
+    --realm "${ATTACH_SMOKE_REALM}" hack/attach-smoke
+
 cat > "${ATTACH_SMOKE_TMP}/cell.yaml" <<EOF
 apiVersion: v1beta1
 kind: Cell
@@ -522,11 +542,11 @@ spec:
   containers:
     - id: root
       root: true
-      image: registry.eminwux.com/busybox:latest
+      image: ${ATTACH_SMOKE_IMAGE_REF}
       command: sleep
       args: ["3600"]
     - id: ${ATTACH_SMOKE_CONTAINER}
-      image: registry.eminwux.com/busybox:latest
+      image: ${ATTACH_SMOKE_IMAGE_REF}
       command: sleep
       args: ["3600"]
       attachable: true


### PR DESCRIPTION
## Summary

- The `make dev-init` attach smoke (`dev-init-attach/ds/dks/cattach`) pinned both cell containers to `registry.eminwux.com/busybox:latest`, a **single-arch amd64** image. On arm64 hosts the amd64 `sleep` ELF can't exec, the root task dies immediately, and the CNI bridge plugin's `Statfs("/proc/<pid>/ns/net")` surfaces an opaque netns ENOENT (issue #1158). It also made the dev loop depend on an external registry, contrary to the `kukeon.internal/...` "build locally, never pull from outside" convention dev-init already follows for `kukeond`.
- Mirror the `kukeon.internal/kukeond` approach: add an in-repo `hack/attach-smoke/Dockerfile` (based on multi-arch `docker.io/library/busybox`), build it into the `dev-init-attach` realm via `kuke build` as `kukeon.internal/attach-smoke:v0.0.0-dev`, and point the `cattach` cell.yaml at that local ref. `kuke build` resolves the build host's architecture, so the resulting image is host-arch on both amd64 and arm64.

## Implementation notes

- **Dockerfile base choice (build-vs-flip):** the issue offered two options — base on `docker.io/library/busybox:latest` or build a tiny static `sleep`/shell. I chose the busybox base (lower blast radius): it preserves the exact prior runtime behavior (real `sleep` for the root/work containers, real `/bin/sh` that the attachable container's kuketty/sbsh wrapper needs), where a `FROM scratch` static `sleep` would drop the shell and risk the attach path. The build-time base pull from `docker.io` is consistent with the root `kukeond` Dockerfile (which pulls `golang`/`debian` bases from `docker.io`); the *runtime* dependency on the external registry is what's removed — the cell now pulls the local `kukeon.internal/attach-smoke` ref.
- **#904 teardown lane:** the issue flagged that `scripts/dev-init.sh`'s teardown comment asserted the attach realm is *never* a `kuke build` target. That's now false — `teardown_attach_smoke_state` wipes the per-namespace BuildKit cache at `/var/lib/kukebuild/<ns>/` alongside the containerd namespace so the teardown stays idempotent across runs, and the comment is updated.
- **Optional follow-up not included:** the issue's "Optional follow-up (separate issue)" — making `internal/controller/runner/start.go` wait for the root task RUNNING / stat the netns before CNI ADD — is explicitly out of scope here.

## Test plan

- [x] `make test` (test-root + test-kukebuild) — exit 0.
- [x] `make dev-init` end-to-end (nested `kukeon-dev-0` cell, amd64 host) — exit 0. Confirmed: `kukeon.internal/attach-smoke:v0.0.0-dev` builds from `docker.io/library/busybox:latest` into the `dev-init-attach` realm, `Cell "cattach": created`, `kuke attach exited cleanly`, daemon-parity tail and parent-attach plumbing intact.
- [ ] arm64-host exec of the foreign-arch path — not runnable on this amd64 dev host. The original bug is amd64-`sleep`-can't-exec-on-arm64; the fix makes `kuke build` produce a host-arch image, so on arm64 it builds an arm64 image. The local-build + cell-start path (the entirety of the diff) is validated on amd64 above; the arch-specific exec failure can only reproduce on an arm64 host (or CI arm64 runner).
- [x] Tree-wide `git grep registry.eminwux.com` — the only remaining hits are unit-test fixtures / docs examples that exercise spec-parsing (no runtime pulls) and my own explanatory comments; the dev-init attach smoke (the issue's scope) no longer references the external registry.

Closes #1158