### PR TITLE
fix(team): gather per-harness role secrets in team init secret composition

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -460,7 +460,7 @@ func composeSecrets(
 	if bundle == nil || res == nil {
 		return nil
 	}
-	needs := teamsecrets.UnionNeedsSecrets(bundle.Roles, pt.Spec.Roles)
+	needs := teamsecrets.UnionSecretNames(bundle.Roles, pt.Spec.Roles, pt.Spec.Defaults.Harnesses)
 	if len(needs) == 0 {
 		return nil
 	}
@@ -488,8 +488,9 @@ func composeSecrets(
 	res.Secrets = composed.Secrets
 	// Reconcile the binding with the set of secrets actually created. Render
 	// skips empty merged values (no kind: Secret emitted), but the post-#1147
-	// binding in teamrender adds a CellConfigSecretFill for every
-	// role.needs.secrets entry regardless. Pruning the empty keys here — the
+	// binding in teamrender adds a CellConfigSecretFill for every effective
+	// secret name (per-harness harnesses.<h>.secrets unioned with the
+	// role.needs.secrets fallback) regardless. Pruning the empty keys here — the
 	// same keys warned about above — leaves each CellConfig referencing only
 	// secrets that exist, so a role declaring needs.secrets for credentials
 	// the operator hasn't provided no longer makes the whole cell unstartable
@@ -499,12 +500,14 @@ func composeSecrets(
 }
 
 // pruneEmptySecretBindings deletes the CellConfig secret bindings whose key is
-// in emptyKeys — the role.needs.secrets entries whose merged secrets.env value
-// was empty, which secret creation (teamsecrets.Render) skipped. Both the
-// binding map keys and emptyKeys are the raw role.needs.secrets strings (the
-// binding iterates role.Spec.Needs.Secrets; emptyKeys is the empty subset of
-// the same union), so a direct map delete is namespace-consistent. Mutates the
-// CellConfigs in place; a nil/empty input on either side is a no-op.
+// in emptyKeys — the effective secret names whose merged secrets.env value was
+// empty, which secret creation (teamsecrets.Render) skipped. Both the binding
+// map keys and emptyKeys are the raw effective secret-name strings (the binding
+// iterates teamrender.effectiveSecretNames — per-harness harnesses.<h>.secrets
+// unioned with role.Spec.Needs.Secrets; emptyKeys is the empty subset of the
+// same union, gathered by UnionSecretNames), so a direct map delete is
+// namespace-consistent. Mutates the CellConfigs in place; a nil/empty input on
+// either side is a no-op.
 func pruneEmptySecretBindings(configs []*v1beta1.CellConfigDoc, emptyKeys []string) {
 	if len(configs) == 0 || len(emptyKeys) == 0 {
 		return

--- a/internal/teamsecrets/teamsecrets.go
+++ b/internal/teamsecrets/teamsecrets.go
@@ -70,7 +70,7 @@ const (
 // path so the override lands beside the rest of the per-team state.
 //
 // Needs is the union of secret names every role in the team references —
-// see UnionNeedsSecrets. The scaffold lines are written for every Needs
+// see UnionSecretNames. The scaffold lines are written for every Needs
 // entry; merged values for keys not in Needs are dropped so a hand-edited
 // override file with extra junk doesn't leak unrelated bytes into the
 // apply bundle.
@@ -321,27 +321,47 @@ func KebabCase(s string) string {
 	return strings.ReplaceAll(strings.ToLower(s), "_", "-")
 }
 
-// UnionNeedsSecrets walks the project roster and returns the
-// lexicographically-sorted set of secret names every referenced role's
-// `needs.secrets` declares. Roles missing from roles map are skipped
-// silently — Render would surface the missing reference, but at the
-// pre-compose secret-name discovery stage there's nothing to warn about
-// (the parent renderer already surfaces missing roles).
-func UnionNeedsSecrets(roles map[string]*model.Role, roster []model.ProjectTeamRole) []string {
+// UnionSecretNames walks the project roster and returns the
+// lexicographically-sorted set of secret names every referenced role declares,
+// unioning each role's per-harness lists (role.spec.harnesses.<h>.secrets, the
+// agents#750 location) for the selected harnesses with the role-level fallback
+// (role.spec.needs.secrets, the pre-migration location). This mirrors
+// teamrender.effectiveSecretNames so the secret-composition pipeline (which
+// creates the kind: Secret objects) and the render pipeline (which emits the
+// CellConfigs referencing them) draw from the same secret set — a role that
+// declares a token only under harnesses.<h>.secrets gets a Secret materialized
+// out of secrets.env, not just a dangling CellConfig fill (#1160).
+//
+// The per-harness contribution is gated by harnesses (the team's selected set,
+// ProjectTeam.spec.defaults.harnesses), so a role's Codex/OpenCode-only secret
+// is not gathered when those harnesses aren't selected. The role-level
+// needs.secrets fallback is harness-independent and always contributes. Roles
+// missing from roles map are skipped silently — Render would surface the
+// missing reference, but at the pre-compose secret-name discovery stage there's
+// nothing to warn about (the parent renderer already surfaces missing roles).
+func UnionSecretNames(roles map[string]*model.Role, roster []model.ProjectTeamRole, harnesses []string) []string {
 	if len(roster) == 0 || len(roles) == 0 {
 		return nil
 	}
 	set := map[string]struct{}{}
+	addNonEmpty := func(names []string) {
+		for _, s := range names {
+			if k := strings.TrimSpace(s); k != "" {
+				set[k] = struct{}{}
+			}
+		}
+	}
 	for _, ptRole := range roster {
 		role, ok := roles[ptRole.Ref]
 		if !ok {
 			continue
 		}
-		for _, s := range role.Spec.Needs.Secrets {
-			if k := strings.TrimSpace(s); k != "" {
-				set[k] = struct{}{}
+		for _, h := range harnesses {
+			if rh, ok := role.Spec.Harnesses[h]; ok {
+				addNonEmpty(rh.Secrets)
 			}
 		}
+		addNonEmpty(role.Spec.Needs.Secrets)
 	}
 	if len(set) == 0 {
 		return nil

--- a/internal/teamsecrets/teamsecrets.go
+++ b/internal/teamsecrets/teamsecrets.go
@@ -112,8 +112,10 @@ type ComposeResult struct {
 // Compose runs the four-step pipeline: scaffold (skipped under DryRun),
 // load both layers, merge with per-team precedence, render every non-empty
 // entry as a SecretDoc. An empty Needs short-circuits the whole pipeline:
-// nothing is written, nothing is read, no warnings are surfaced — a team
-// whose roles declare no `needs.secrets` has no secret pipeline.
+// nothing is written, nothing is read, no warnings are surfaced — a team whose
+// roles reference no secret names (neither per-harness harnesses.<h>.secrets
+// nor the role-level needs.secrets fallback; see UnionSecretNames) has no
+// secret pipeline.
 func Compose(in ComposeInputs) (*ComposeResult, error) {
 	if len(in.Needs) == 0 {
 		return &ComposeResult{}, nil

--- a/internal/teamsecrets/teamsecrets_test.go
+++ b/internal/teamsecrets/teamsecrets_test.go
@@ -291,30 +291,96 @@ func TestRenderIsSortedByName(t *testing.T) {
 	}
 }
 
-func TestUnionNeedsSecrets(t *testing.T) {
+func TestUnionSecretNames(t *testing.T) {
 	t.Parallel()
-	roles := map[string]*model.Role{
-		"dev": {Spec: model.RoleSpec{Needs: model.RoleNeeds{Secrets: []string{"ANTHROPIC_AUTH_TOKEN"}}}},
-		"pm": {
-			Spec: model.RoleSpec{
-				Needs: model.RoleNeeds{Secrets: []string{"OPENROUTER_API_KEY", "ANTHROPIC_AUTH_TOKEN"}},
+	tests := []struct {
+		name      string
+		roles     map[string]*model.Role
+		roster    []model.ProjectTeamRole
+		harnesses []string
+		want      []string
+	}{
+		{
+			name: "needs.secrets only",
+			roles: map[string]*model.Role{
+				"dev": {Spec: model.RoleSpec{Needs: model.RoleNeeds{Secrets: []string{"ANTHROPIC_AUTH_TOKEN"}}}},
+				"pm": {
+					Spec: model.RoleSpec{
+						Needs: model.RoleNeeds{Secrets: []string{"OPENROUTER_API_KEY", "ANTHROPIC_AUTH_TOKEN"}},
+					},
+				},
 			},
+			roster: []model.ProjectTeamRole{
+				{Ref: "dev"},
+				{Ref: "pm"},
+				{Ref: "unknown-role"}, // skipped silently
+			},
+			harnesses: []string{"claude"},
+			want:      []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY"},
+		},
+		{
+			// #1160: a role that declares a token ONLY under
+			// harnesses.<name>.secrets (no needs.secrets) must still be gathered
+			// so a kind: Secret is composed from secrets.env.
+			name: "per-harness secrets only",
+			roles: map[string]*model.Role{
+				"dev": {Spec: model.RoleSpec{
+					Harnesses: map[string]model.RoleHarness{
+						"claude": {Secrets: []string{"claude-code-oauth-token"}},
+					},
+				}},
+			},
+			roster:    []model.ProjectTeamRole{{Ref: "dev"}},
+			harnesses: []string{"claude"},
+			want:      []string{"claude-code-oauth-token"},
+		},
+		{
+			// The per-harness contribution is gated by the selected harness set:
+			// an OpenCode-only secret is not gathered when only claude is on.
+			name: "unselected harness secrets dropped",
+			roles: map[string]*model.Role{
+				"dev": {Spec: model.RoleSpec{
+					Harnesses: map[string]model.RoleHarness{
+						"claude":   {Secrets: []string{"claude-code-oauth-token"}},
+						"opencode": {Secrets: []string{"opencode-api-key"}},
+					},
+				}},
+			},
+			roster:    []model.ProjectTeamRole{{Ref: "dev"}},
+			harnesses: []string{"claude"},
+			want:      []string{"claude-code-oauth-token"},
+		},
+		{
+			// Per-harness and needs.secrets unioned; the same name declared in
+			// both locations collapses to one entry.
+			name: "per-harness and needs unioned and deduped",
+			roles: map[string]*model.Role{
+				"dev": {Spec: model.RoleSpec{
+					Harnesses: map[string]model.RoleHarness{
+						"claude": {Secrets: []string{"claude-code-oauth-token", "shared-token"}},
+					},
+					Needs: model.RoleNeeds{Secrets: []string{"shared-token", "ANTHROPIC_AUTH_TOKEN"}},
+				}},
+			},
+			roster:    []model.ProjectTeamRole{{Ref: "dev"}},
+			harnesses: []string{"claude"},
+			want:      []string{"ANTHROPIC_AUTH_TOKEN", "claude-code-oauth-token", "shared-token"},
 		},
 	}
-	roster := []model.ProjectTeamRole{
-		{Ref: "dev"},
-		{Ref: "pm"},
-		{Ref: "unknown-role"}, // skipped silently
-	}
-	got := UnionNeedsSecrets(roles, roster)
-	want := []string{"ANTHROPIC_AUTH_TOKEN", "OPENROUTER_API_KEY"}
-	if len(got) != len(want) {
-		t.Fatalf("got %v, want %v", got, want)
-	}
-	for i, k := range want {
-		if got[i] != k {
-			t.Errorf("got[%d] = %q, want %q", i, got[i], k)
-		}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := UnionSecretNames(tt.roles, tt.roster, tt.harnesses)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i, k := range tt.want {
+				if got[i] != k {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], k)
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `kuke team init` never composed a `kind: Secret` for tokens a role declared **only** under `spec.harnesses.<name>.secrets`. The render pipeline (`teamrender.effectiveSecretNames`, added in #1153) reads both per-harness and `needs.secrets`, but the secret-composition gather step (`teamsecrets.UnionNeedsSecrets`) read only `needs.secrets`. The two pipelines disagreed: CellConfigs referenced a Secret that init never materialized, so cells referencing it failed to start (#1160).
- Renamed `UnionNeedsSecrets` → harness-aware `UnionSecretNames(roles, roster, harnesses)`, which unions each role's selected-harness `harnesses.<h>.secrets` with the role-level `needs.secrets` fallback — mirroring `teamrender.effectiveSecretNames` so the create side and render side draw from the same secret set.
- The per-harness contribution is gated by the team's selected harness set (`ProjectTeam.spec.defaults.harnesses`), so a role's secret declared under a harness the team hasn't selected is not gathered. The `needs.secrets` fallback stays harness-independent.
- Updated the sole caller (`composeSecrets` in `cmd/kuke/team/init.go`) to pass `pt.Spec.Defaults.Harnesses`, and refreshed the now-stale doc comments on `composeSecrets`/`pruneEmptySecretBindings` that claimed the binding sourced only `role.needs.secrets`.

## Implementation notes for the reviewer

- **Rename vs. add a variant:** the AC offered "update `UnionNeedsSecrets` (or add a harness-aware variant)". `UnionNeedsSecrets` had exactly one production caller, so I renamed it rather than adding a second near-identical function that would leave the old one dead. The narrower needs-only semantics are still covered (as the `needs.secrets only` subtest).
- **"with any per-role override":** the AC mentioned gating by the selected harness set "with any per-role override". `ProjectTeamRole` carries no per-role harness override today — selection is purely `pt.Spec.Defaults.Harnesses` (the render side at `renderTeam` ranges all roles × all default harnesses identically). The gating is written against the passed-in harness slice, so it will honor a per-role override if/when one is added; no override path exists to wire up now.

## Test plan

- [x] `go build ./...` (GOWORK=off) — clean
- [x] `go vet ./internal/teamsecrets/... ./cmd/kuke/team/...` — clean
- [x] `make test` (full CI target: test-root + test-kukebuild) — exit 0, no failures
- [x] New colocated subtests in `internal/teamsecrets/teamsecrets_test.go`: per-harness-only secret gathered (the #1160 repro), unselected-harness secret dropped, per-harness+needs unioned-and-deduped, plus the original needs-only case.
- [x] `git grep UnionNeedsSecrets` — no stale references remain tree-wide.

## Acceptance criteria

- [x] `UnionSecretNames` unions the selected harnesses' `harnesses.<name>.secrets` in addition to `needs.secrets`, mirroring `teamrender.effectiveSecretNames`.
- [x] Per-harness contribution gated by the team's selected harness set.
- [x] Colocated test covering a role that declares a secret only under `harnesses.<name>.secrets`.

Closes #1160