### PR TITLE
feat(team): override project clone dir via kuketeam.yaml spec.projectDir

### DIFF
--- a/cmd/kuke/team/init.go
+++ b/cmd/kuke/team/init.go
@@ -686,15 +686,16 @@ func renderTeam(
 
 	projectURL, _ := getProjectURL(ctx, projectDir)
 	in := teamrender.Inputs{
-		Project:        project,
-		ProjectRepoURL: strings.TrimSpace(projectURL),
-		ProjectDir:     projectDir,
-		TeamDir:        teamDir,
-		Realm:          pt.Spec.Realm,
-		Space:          pt.Spec.Space,
-		Stack:          pt.Spec.Stack,
-		Build:          doBuild,
-		SourceRef:      bundle.Source.Ref,
+		Project:         project,
+		ProjectRepoURL:  strings.TrimSpace(projectURL),
+		ProjectDir:      projectDir,
+		ProjectCloneDir: strings.TrimSpace(pt.Spec.ProjectDir),
+		TeamDir:         teamDir,
+		Realm:           pt.Spec.Realm,
+		Space:           pt.Spec.Space,
+		Stack:           pt.Spec.Stack,
+		Build:           doBuild,
+		SourceRef:       bundle.Source.Ref,
 	}
 	res, err := teamrender.Render(bundle, pt, tc, in)
 	if err != nil {

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -608,6 +608,14 @@ var (
 	ErrTeamMetadataNameUnsafe = errors.New(
 		"metadata.name must not contain path separators, NUL, '..', or a leading '.'",
 	)
+	// ErrTeamProjectDirInvalid fires when a ProjectTeam spec.projectDir is not a
+	// safe path basename (it flows into the in-cell `/home/<user>/<dir>` clone
+	// path the same way metadata.name does, so the same traversal guard
+	// applies), or when it equals the reserved `agents` repo slot dir — the
+	// collision spec.projectDir exists to avoid in the first place.
+	ErrTeamProjectDirInvalid = errors.New(
+		"spec.projectDir must be a safe path basename and must not equal the reserved \"agents\" slot dir",
+	)
 	// ErrTeamProjectFileNotFound fires when `kuke team init` finds no
 	// kuketeam.yaml in the current project directory.
 	ErrTeamProjectFileNotFound = errors.New("no kuketeam.yaml found in the current directory")

--- a/internal/kuketeams/parser.go
+++ b/internal/kuketeams/parser.go
@@ -194,6 +194,9 @@ func validateProjectTeam(pt *model.ProjectTeam) error {
 	if err := ValidateSource(pt.Spec.Source); err != nil {
 		return err
 	}
+	if err := validateProjectDir(pt.Spec.ProjectDir); err != nil {
+		return err
+	}
 	for _, h := range pt.Spec.Defaults.Harnesses {
 		if !model.IsKnownHarness(h) {
 			return fmt.Errorf("%w: %q (defaults.harnesses)", errdefs.ErrTeamHarnessUnknown, h)
@@ -372,6 +375,31 @@ func validateMetadataNameSafe(name string) error {
 	if strings.ContainsAny(trimmed, "/\\") || strings.ContainsRune(trimmed, 0) ||
 		strings.Contains(trimmed, "..") || strings.HasPrefix(trimmed, ".") {
 		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamMetadataNameUnsafe, name)
+	}
+	return nil
+}
+
+// validateProjectDir enforces the ProjectTeam spec.projectDir contract: when
+// set, it must be a safe path basename (it flows into the in-cell
+// `/home/<user>/<dir>` clone path the renderer exposes as `.project.NAME`, so
+// the same traversal guard metadata.name carries applies) and must not equal
+// the reserved `agents` repo slot dir (teamrender.AgentsRepoSlotName) — the
+// `project`/`agents` clone-time collision spec.projectDir exists to break.
+// Empty is valid: the renderer falls back to metadata.name.
+func validateProjectDir(dir string) error {
+	trimmed := strings.TrimSpace(dir)
+	if trimmed == "" {
+		return nil
+	}
+	if strings.ContainsAny(trimmed, "/\\") || strings.ContainsRune(trimmed, 0) ||
+		strings.Contains(trimmed, "..") || strings.HasPrefix(trimmed, ".") {
+		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamProjectDirInvalid, dir)
+	}
+	// "agents" mirrors teamrender.AgentsRepoSlotName — the fixed in-cell dir the
+	// `agents` repo slot clones to. Referenced as a literal to avoid a
+	// parser→renderer import dependency for a single conventional name.
+	if trimmed == "agents" {
+		return fmt.Errorf("%w (got %q)", errdefs.ErrTeamProjectDirInvalid, dir)
 	}
 	return nil
 }

--- a/internal/kuketeams/parser_test.go
+++ b/internal/kuketeams/parser_test.go
@@ -304,6 +304,26 @@ func TestParseFailureModes(t *testing.T) {
 			errdefs.ErrTeamSourceInvalid,
 		},
 		{
+			"ProjectTeam projectDir equals reserved agents slot",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: agents}\nspec: { source: {repo: eminwux/agents, branch: main}, projectDir: agents, roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamProjectDirInvalid,
+		},
+		{
+			"ProjectTeam projectDir has path separator",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, projectDir: \"a/b\", roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamProjectDirInvalid,
+		},
+		{
+			"ProjectTeam projectDir traverses parent",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, projectDir: \"../escape\", roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamProjectDirInvalid,
+		},
+		{
+			"ProjectTeam projectDir leading dot",
+			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, projectDir: \".hidden\", roles: [{ref: dev}] }\n",
+			errdefs.ErrTeamProjectDirInvalid,
+		},
+		{
 			"ProjectTeam empty role ref",
 			"apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\nspec: { source: {repo: eminwux/agents, tag: v1.4.0}, roles: [{ref: \"\"}] }\n",
 			errdefs.ErrTeamRoleRefRequired,
@@ -565,6 +585,32 @@ func TestParseProjectTeamAcceptsSourceForms(t *testing.T) {
 				t.Errorf("Floating() = %v, want %v", got, tc.wantFloating)
 			}
 		})
+	}
+}
+
+func TestParseProjectTeamAcceptsProjectDir(t *testing.T) {
+	t.Parallel()
+	// A self-referential team gives the project clone a distinct in-cell dir so
+	// it never collides with the `agents` repo slot's fixed `/home/<user>/agents`.
+	raw := "apiVersion: kuketeams.io/v1\nkind: ProjectTeam\n" +
+		"metadata: {name: agents}\n" +
+		"spec: { source: {repo: eminwux/agents, branch: main}, projectDir: agents0, roles: [{ref: dev}] }\n"
+	doc, err := Parse([]byte(raw))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := doc.ProjectTeam.Spec.ProjectDir; got != "agents0" {
+		t.Errorf("spec.projectDir = %q, want agents0", got)
+	}
+	// Omitting projectDir is valid — the renderer falls back to metadata.name.
+	bare := "apiVersion: kuketeams.io/v1\nkind: ProjectTeam\nmetadata: {name: x}\n" +
+		"spec: { source: {repo: eminwux/agents, tag: v1.4.0}, roles: [{ref: dev}] }\n"
+	doc, err = Parse([]byte(bare))
+	if err != nil {
+		t.Fatalf("Parse(bare): %v", err)
+	}
+	if got := doc.ProjectTeam.Spec.ProjectDir; got != "" {
+		t.Errorf("spec.projectDir = %q, want empty", got)
 	}
 }
 

--- a/internal/teamrender/teamrender.go
+++ b/internal/teamrender/teamrender.go
@@ -128,6 +128,16 @@ type Inputs struct {
 	// `.project.PROJECT_DIR` so the operator can reference the source-tree
 	// path without bouncing it through a CellConfig parameter.
 	ProjectDir string
+	// ProjectCloneDir overrides the in-cell project clone dir basename the
+	// renderer exposes as `.project.NAME` (the fact a blueprint's `project` repo
+	// target reads for its `/home/<user>/<dir>` clone path). Sourced from the
+	// project's kuketeam.yaml spec.projectDir; empty falls back to Project (the
+	// team label). Distinct from ProjectDir above — that is the on-host
+	// source-tree path (`.project.PROJECT_DIR`), this is the in-cell clone dir.
+	// Decoupling the two breaks the self-referential-team collision (#1166)
+	// where the `project` and `agents` slots otherwise both target
+	// `/home/<user>/agents`.
+	ProjectCloneDir string
 	// TeamDir is the per-team host-state root resolved by composeTeam
 	// (TeamEntry.spec.teamDir override, else Layout.TeamDir(team)). Exposed to
 	// blueprint templates as `.operator.TEAM_ROOT`. Per-team-scoped: two teams
@@ -812,8 +822,19 @@ func renderContextValues(
 		operatorView["REPO_OWNER"] = v
 	}
 
+	// .project.NAME is the in-cell project clone dir basename — the fact a
+	// blueprint's `project` repo target reads for `/home/<user>/<dir>`. It
+	// defaults to the team label (project) but spec.projectDir
+	// (in.ProjectCloneDir) overrides it so a self-referential team can give the
+	// project clone a distinct dir from the `agents` slot (#1166). The team
+	// label itself stays project — it drives LabelTeam and operatorValues PROJECT
+	// directly, not via this view.
+	projectName := project
+	if v := strings.TrimSpace(in.ProjectCloneDir); v != "" {
+		projectName = v
+	}
 	projectView := map[string]string{
-		"NAME": project,
+		"NAME": projectName,
 	}
 	if v := strings.TrimSpace(in.ProjectDir); v != "" {
 		projectView["PROJECT_DIR"] = v

--- a/internal/teamrender/teamrender_test.go
+++ b/internal/teamrender/teamrender_test.go
@@ -1381,6 +1381,58 @@ spec:
 	}
 }
 
+// TestRenderBlueprintProjectNameOverride confirms spec.projectDir
+// (in.ProjectCloneDir) overrides the in-cell clone dir basename the renderer
+// exposes as `.project.NAME`, decoupling it from the team label (#1166). When
+// unset, NAME falls back to the team label so the historical default holds.
+func TestRenderBlueprintProjectNameOverride(t *testing.T) {
+	t.Parallel()
+	body := `apiVersion: v1beta1
+kind: CellBlueprint
+metadata:
+  name: {{ .role.name }}-{{ .harness }}
+spec:
+  cell:
+    containers:
+      - id: {{ .role.name }}
+        image: {{ .image }}
+        env:
+          - "CLONE_DIR=/home/claude/{{ .project.NAME }}"
+`
+	image := &model.ImageCatalogEntry{Image: "registry.local/claude:latest"}
+	src := teamsource.Source{
+		Repo:      "github.com/eminwux/agents",
+		Host:      "github.com",
+		OwnerRepo: "eminwux/agents",
+		Ref:       "main",
+		Kind:      teamsource.RefBranch,
+	}
+	render := func(t *testing.T, in Inputs) string {
+		t.Helper()
+		cacheDir := t.TempDir()
+		writeHarnessFile(t, cacheDir, "claude", "blueprint.tmpl.yaml", body)
+		h := &model.Harness{Spec: model.HarnessSpec{Template: "blueprint.tmpl.yaml"}}
+		bp, err := RenderBlueprint(
+			cacheDir, h, minimalRole(), "claude", "dev",
+			[]string{"go"}, image, nil, src, in, in.Project, "default", "default", "default",
+		)
+		if err != nil {
+			t.Fatalf("RenderBlueprint: %v", err)
+		}
+		return bp.Spec.Cell.Containers[0].Env[0]
+	}
+
+	// Self-referential team: project clone dir overridden, distinct from the
+	// `agents` slot's fixed /home/claude/agents.
+	if got := render(t, Inputs{Project: "agents", ProjectCloneDir: "agents0"}); got != "CLONE_DIR=/home/claude/agents0" {
+		t.Errorf("override: env = %q, want CLONE_DIR=/home/claude/agents0", got)
+	}
+	// No override: NAME falls back to the team label (historical default).
+	if got := render(t, Inputs{Project: "sbsh"}); got != "CLONE_DIR=/home/claude/sbsh" {
+		t.Errorf("fallback: env = %q, want CLONE_DIR=/home/claude/sbsh", got)
+	}
+}
+
 // TestRenderBlueprintRepoOwnerDerivesFromAgentsSource confirms the
 // REPO_OWNER fallback: when tc.spec.repoOwner is empty, the renderer
 // derives the owner segment from the agents source's `<owner>/<repo>`

--- a/pkg/api/model/kuketeams/projectteam.go
+++ b/pkg/api/model/kuketeams/projectteam.go
@@ -35,6 +35,17 @@ type ProjectTeamSpec struct {
 	// `<owner>/<repo>@vX.Y.Z` string form is rejected at parse time with a
 	// migration error.
 	Source TeamSource `json:"source"             yaml:"source"`
+	// ProjectDir overrides the in-cell project clone dir basename, decoupling
+	// it from metadata.name (the team *label*). The renderer exposes it as
+	// `.project.NAME` — the fact a blueprint's `project` repo target reads for
+	// its `/home/<user>/<dir>` clone path — falling back to metadata.name when
+	// unset. The override exists for self-referential teams (the agents repo
+	// managing itself), where a role declares both the `project` and `agents`
+	// repo slots: without it both resolve to `/home/<user>/agents` and collide
+	// at clone time. Distinct from the on-host source-tree path the renderer
+	// surfaces as `.project.PROJECT_DIR`. Validated as a safe path basename
+	// that does not collide with the reserved `agents` repo slot dir.
+	ProjectDir string `json:"projectDir,omitempty" yaml:"projectDir,omitempty"`
 	// Realm, Space, and Stack are the optional scope coordinates the team's
 	// rendered cells bind to. Each defaults to `default` when omitted (the
 	// renderer stamps the defaulted value onto every rendered Blueprint/Config


### PR DESCRIPTION
## Summary

- Adds `spec.projectDir` to `ProjectTeam` (kuketeam.yaml), making the **in-cell project clone dir basename** overridable and decoupled from `metadata.name` (the team *label*). This breaks the self-referential-team collision (#1166): when a role declares both the `project` and `agents` repo slots and the team is `metadata.name: agents`, both otherwise resolve to `/home/<user>/agents` and collide at clone time. Setting `projectDir: agents0` gives the project clone `/home/<user>/agents0` while the `agents` slot keeps `/home/<user>/agents`. This obviates meta-dev's bespoke `agents0` slot (the `BindConfig`-has-no-fill `kuke team init` failure quoted in the issue).
- No new fill logic — the `project` slot is already filled from `Inputs.ProjectRepoURL`; only the dir name became configurable.

## Implementation notes (calls for the reviewer to push back on)

- **Folded the override into `.project.NAME` rather than adding a dedicated `.project.DIR` key.** The issue offered both ("Either fold into `NAME` or expose a dedicated `DIR` key"). Folding is the lower-cross-repo-coupling choice: it needs **no agents-repo blueprint template change** — the existing `project` target reading `/home/<user>/{{ .project.NAME }}` automatically picks up the override, so the companion #759 only adds `projectDir:` to the yaml + the meta-dev `[project, agents]` switch, with no unlisted blueprint edit. `NAME` is only ever consumed as the project clone dir basename; the team label proper is `project` directly (drives `LabelTeam` + `operatorValues` `PROJECT`), so the semantics stay clean. Unset `projectDir` ⇒ `NAME` = team label, fully backward-compatible.
- **Premise note (slightly rotted):** a recently-merged PR already introduced an `Inputs.ProjectDir` field meaning the *on-host source-tree path*, exposed as `.project.PROJECT_DIR` — distinct from this issue's in-cell-clone-dir concept. To avoid the name collision the issue's `PROJECT_DIR`-adjacent phrasing would invite, the new override is carried in a separate `Inputs.ProjectCloneDir` field and folded into `NAME` (not `PROJECT_DIR`). Intent unchanged; documented here so the reviewer can audit the divergence.
- **Validation** lives at kuketeam.yaml parse time (`validateProjectTeam`): when set, `projectDir` must be a safe path basename (same traversal guard as `metadata.name` — no separators / NUL / `..` / leading dot) and must not equal the reserved `agents` repo slot dir. New sentinel `errdefs.ErrTeamProjectDirInvalid`. The `agents` literal mirrors `teamrender.AgentsRepoSlotName`, referenced as a literal (with a comment) to avoid a parser→renderer import dependency for a single conventional name; `project`/`agents` are the only declared repo slots in the current two-slot convention.

## Test plan

- [x] `make test` (full CI test target, `GOWORK=off`) — pass
- [x] `go vet ./...` (`GOWORK=off`) — pass
- [x] `go build ./...` (`GOWORK=off`) — pass
- New tests: `TestParseProjectTeamAcceptsProjectDir` + 4 negative cases in `TestParseFailureModes` (parser), `TestRenderBlueprintProjectNameOverride` (renderer: override + fallback).
- [ ] `make dev-init` smoke — N/A: this change is `kuke team init` CLI rendering/validation logic; it does not touch the build path, the daemon, or `/opt/kukeon`, so the daemon-parity guard does not apply.

## Notes

- Companion consumer issue eminwux/agents#759 (meta-dev `needs.repos` → `[project, agents]`, add `projectDir` to `kuketeam.yaml`, doc updates) consumes this on the agents-repo side. With the fold-into-`NAME` choice above, no blueprint template change is needed there.
- Out of scope (per issue): the separate unfilled `kukeon` slot in `harnesses/README.md`.

Closes #1166