### PR TITLE
fix(run): heal wrong-mode attachable tty socket on the attach path

### DIFF
--- a/internal/client/local/local.go
+++ b/internal/client/local/local.go
@@ -1150,6 +1150,16 @@ func (c *Client) AttachContainer(_ context.Context, doc v1beta1.ContainerDoc) (k
 		return kukeonv1.AttachContainerResult{}, err
 	}
 	spec := container.Spec
+	// Heal a wrong-mode live tty socket in place before handing back its
+	// path (#1169). `kuke run` against an already-Ready cell short-circuits
+	// to attach without re-entering StartCell, so the #935 StartCell-skip
+	// heal never runs on the path run/attach take: a socket an old kuketty
+	// bound 0o640 (group-read only) stays undialable forever, while
+	// `kuke restart` heals it via its stop+start rebind. Re-chmod'ing the
+	// live inode here closes that asymmetry without bouncing the workload or
+	// re-entering the #630-prone start-on-running path. Best-effort and
+	// idempotent: a socket already at 0o660 is left untouched.
+	c.ctrl.ReapplyAttachableSocketPerms(spec)
 	return kukeonv1.AttachContainerResult{
 		HostSocketPath: fs.ContainerSocketSymlinkPath(
 			c.ctrl.RunPath(),

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -91,6 +91,8 @@ type fakeRunner struct {
 	ExistsCellRootContainerFn func(cell intmodel.Cell) (bool, error)
 	UpdateCellMetadataFn      func(cell intmodel.Cell) error
 
+	ReapplyAttachableSocketPermsFn func(spec intmodel.ContainerSpec)
+
 	// Container methods
 	ListContainersFn    func(realmName, spaceName, stackName, cellName string) ([]intmodel.ContainerSpec, error)
 	CreateContainerFn   func(cell intmodel.Cell, container intmodel.ContainerSpec) (intmodel.Cell, error)
@@ -451,6 +453,12 @@ func (f *fakeRunner) UpdateCellMetadata(cell intmodel.Cell) error {
 		return f.UpdateCellMetadataFn(cell)
 	}
 	return errors.New("unexpected call to UpdateCellMetadata")
+}
+
+func (f *fakeRunner) ReapplyAttachableSocketPerms(spec intmodel.ContainerSpec) {
+	if f.ReapplyAttachableSocketPermsFn != nil {
+		f.ReapplyAttachableSocketPermsFn(spec)
+	}
 }
 
 // Container methods

--- a/internal/controller/get_container.go
+++ b/internal/controller/get_container.go
@@ -200,3 +200,16 @@ func stageStatusesForContainer(cell intmodel.Cell, name string) []intmodel.Stage
 func (b *Exec) ListContainers(realmName, spaceName, stackName, cellName string) ([]intmodel.ContainerSpec, error) {
 	return b.runner.ListContainers(realmName, spaceName, stackName, cellName)
 }
+
+// ReapplyAttachableSocketPerms heals a single attachable container's live
+// tty control socket inode to the connect(2)-able mode/group on the attach
+// path (#1169). AttachContainer calls it before handing back the socket
+// path so a `kuke run` against an already-Ready cell — which short-circuits
+// past StartCell and so past the #935 StartCell-skip heal — still corrects a
+// wrong-mode (pre-sbsh#361 0o640) live socket in place, matching
+// `kuke restart` without reintroducing the #630 start-on-running hazard.
+// Best-effort and root-owned (the daemon runs as root); a chmod miss is
+// logged by the runner and never surfaced, so a healthy socket is untouched.
+func (b *Exec) ReapplyAttachableSocketPerms(spec intmodel.ContainerSpec) {
+	b.runner.ReapplyAttachableSocketPerms(spec)
+}

--- a/internal/controller/get_container_test.go
+++ b/internal/controller/get_container_test.go
@@ -1006,3 +1006,36 @@ func TestListContainers_RunnerError(t *testing.T) {
 		t.Fatal("expected error but got none")
 	}
 }
+
+// TestReapplyAttachableSocketPerms_DelegatesToRunner locks the controller →
+// runner delegation for the #1169 attach-path socket heal: AttachContainer
+// calls (*Exec).ReapplyAttachableSocketPerms, which must forward the spec
+// verbatim to the runner so a wrong-mode live socket gets healed on the
+// `kuke run`-against-Ready path that skips StartCell (and so skips the #935
+// StartCell-skip heal).
+func TestReapplyAttachableSocketPerms_DelegatesToRunner(t *testing.T) {
+	mockRunner := &fakeRunner{}
+	var got intmodel.ContainerSpec
+	called := false
+	mockRunner.ReapplyAttachableSocketPermsFn = func(spec intmodel.ContainerSpec) {
+		called = true
+		got = spec
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+
+	want := intmodel.ContainerSpec{
+		ID: "work", RealmName: "r1", SpaceName: "s1", StackName: "st1", CellName: "c1",
+		Attachable: true,
+	}
+	ctrl.ReapplyAttachableSocketPerms(want)
+
+	if !called {
+		t.Fatal("controller did not delegate to runner.ReapplyAttachableSocketPerms")
+	}
+	if got.ID != want.ID || got.RealmName != want.RealmName ||
+		got.SpaceName != want.SpaceName || got.StackName != want.StackName ||
+		got.CellName != want.CellName || got.Attachable != want.Attachable {
+		t.Errorf("runner received spec %+v, want %+v", got, want)
+	}
+}

--- a/internal/controller/runner/attachable.go
+++ b/internal/controller/runner/attachable.go
@@ -625,28 +625,67 @@ func (r *Exec) reapplyAttachableSocketPerms(cell intmodel.Cell) {
 		if !spec.Attachable {
 			continue
 		}
-		socketPath := fs.ContainerSocketPath(
-			r.opts.RunPath,
-			spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
-		)
-		if chmodErr := os.Chmod(socketPath, attachableSocketReapplyMode); chmodErr != nil {
-			if errors.Is(chmodErr, os.ErrNotExist) {
-				continue
-			}
-			r.logger.WarnContext(r.ctx,
-				"failed to re-chmod attachable socket on idempotent StartCell skip",
-				"socket", socketPath, "error", chmodErr)
-			continue
+		r.reapplyAttachableSocketPerm(spec, "idempotent StartCell skip")
+	}
+}
+
+// ReapplyAttachableSocketPerms re-asserts the mode and group of a single
+// live attachable container's tty socket inode on the attach path (#1169).
+//
+// `kuke run` against an already-Ready cell short-circuits straight to
+// attach without re-entering StartCell — that Ready branch exists to dodge
+// the #630 CNI duplicate-allocation re-entry — so the #935 heal wired into
+// StartCell's idempotent no-op path never runs on the path `run`/`attach`
+// actually take. A socket an old kuketty bound 0o640 (group-read only, the
+// pre-sbsh#361 mode) is therefore undialable forever on `kuke run`, while
+// `kuke restart` heals it because its stop+start rebinds the socket fresh
+// at 0o660. Healing the live inode in place at attach time — a root-owned
+// chmod+chown, no workload bounce — closes that asymmetry without
+// reintroducing the #630 start-on-running hazard.
+//
+// A non-Attachable spec is a no-op (only sbsh-wrapped containers bind a tty
+// control socket). Best-effort, mirroring the StartCell-skip heal: a
+// per-socket failure is logged and swallowed rather than surfaced to the
+// caller, because the attach path must not regress when the socket is
+// already healthy. A socket kuketty has not bound yet (ENOENT) is a benign
+// no-op — the normal startup chown sets the mode when the listener appears.
+func (r *Exec) ReapplyAttachableSocketPerms(spec intmodel.ContainerSpec) {
+	if !spec.Attachable {
+		return
+	}
+	r.reapplyAttachableSocketPerm(spec, "attach")
+}
+
+// reapplyAttachableSocketPerm re-chmods + re-chowns one attachable
+// container's live tty socket inode to attachableSocketReapplyMode and the
+// kukeon group. `via` labels the calling path in the warn log so an
+// operator can tell a StartCell-skip heal from an attach-path heal. ENOENT
+// is a benign no-op (the socket is not bound yet; the normal startup chown
+// will set the mode when the listener appears). connect(2) on a Unix socket
+// requires write permission on the inode, so this is what makes a wrong-mode
+// live listener dialable again without bouncing the workload.
+func (r *Exec) reapplyAttachableSocketPerm(spec intmodel.ContainerSpec, via string) {
+	socketPath := fs.ContainerSocketPath(
+		r.opts.RunPath,
+		spec.RealmName, spec.SpaceName, spec.StackName, spec.CellName, spec.ID,
+	)
+	if chmodErr := os.Chmod(socketPath, attachableSocketReapplyMode); chmodErr != nil {
+		if errors.Is(chmodErr, os.ErrNotExist) {
+			return
 		}
-		// Leave the owning uid untouched (-1); only re-assert the kukeon
-		// group when one is configured, mirroring attachablePostCreateChown.
-		if gid := r.opts.KukeonGroupGID; gid > 0 {
-			if chownErr := os.Chown(socketPath, -1, gid); chownErr != nil &&
-				!errors.Is(chownErr, os.ErrNotExist) {
-				r.logger.WarnContext(r.ctx,
-					"failed to re-chown attachable socket group on idempotent StartCell skip",
-					"socket", socketPath, "gid", gid, "error", chownErr)
-			}
+		r.logger.WarnContext(r.ctx,
+			"failed to re-chmod attachable socket",
+			"socket", socketPath, "via", via, "error", chmodErr)
+		return
+	}
+	// Leave the owning uid untouched (-1); only re-assert the kukeon
+	// group when one is configured, mirroring attachablePostCreateChown.
+	if gid := r.opts.KukeonGroupGID; gid > 0 {
+		if chownErr := os.Chown(socketPath, -1, gid); chownErr != nil &&
+			!errors.Is(chownErr, os.ErrNotExist) {
+			r.logger.WarnContext(r.ctx,
+				"failed to re-chown attachable socket group",
+				"socket", socketPath, "gid", gid, "via", via, "error", chownErr)
 		}
 	}
 }

--- a/internal/controller/runner/attachable_test.go
+++ b/internal/controller/runner/attachable_test.go
@@ -1022,6 +1022,105 @@ func TestReapplyAttachableSocketPerms_TolerantMissingSocket(t *testing.T) {
 	r.reapplyAttachableSocketPerms(cell)
 }
 
+// TestReapplyAttachableSocketPermsSpec_CorrectsWrongMode locks the #1169
+// fix: the per-spec attach-path heal (the path `kuke run` against an
+// already-Ready cell takes — it short-circuits past StartCell and so past
+// the #935 StartCell-skip heal) must re-chmod a live attach socket an old
+// kuketty bound 0o640 up to the connect(2)-able 0o660.
+func TestReapplyAttachableSocketPermsSpec_CorrectsWrongMode(t *testing.T) {
+	r := newTestRunner(t)
+	runPath := t.TempDir()
+	r.opts.RunPath = runPath
+
+	spec := intmodel.ContainerSpec{
+		ID: "work", RealmName: "r1", SpaceName: "s1", StackName: "st1", CellName: "c1",
+		Attachable: true,
+	}
+	socketPath := seedAttachableSocket(t, runPath, spec, 0o640)
+
+	r.ReapplyAttachableSocketPerms(spec)
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat socket after reapply: %v", err)
+	}
+	if got := info.Mode().Perm(); got != attachableSocketReapplyMode {
+		t.Errorf("socket mode = %o, want %o (attach-path heal must correct the pre-#361 0o640 socket)",
+			got, attachableSocketReapplyMode)
+	}
+}
+
+// TestReapplyAttachableSocketPermsSpec_IdempotentOnCorrectMode locks the
+// idempotency contract for the per-spec attach-path heal: a socket a
+// post-sbsh#361 kuketty already bound at 0o660 is left at 0o660, so a
+// healthy `kuke run`/`kuke attach` never perturbs the live socket.
+func TestReapplyAttachableSocketPermsSpec_IdempotentOnCorrectMode(t *testing.T) {
+	r := newTestRunner(t)
+	runPath := t.TempDir()
+	r.opts.RunPath = runPath
+
+	spec := intmodel.ContainerSpec{
+		ID: "work", RealmName: "r1", SpaceName: "s1", StackName: "st1", CellName: "c1",
+		Attachable: true,
+	}
+	socketPath := seedAttachableSocket(t, runPath, spec, 0o660)
+
+	r.ReapplyAttachableSocketPerms(spec)
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat socket after reapply: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Errorf("socket mode = %o, want 0660 (already-correct socket must be left untouched)", got)
+	}
+}
+
+// TestReapplyAttachableSocketPermsSpec_SkipsNonAttachable locks the
+// !Attachable short-circuit on the exported per-spec heal: a non-sbsh
+// container has no tty control socket, so the deep socket path (even if a
+// stray inode exists there) must be left untouched.
+func TestReapplyAttachableSocketPermsSpec_SkipsNonAttachable(t *testing.T) {
+	r := newTestRunner(t)
+	runPath := t.TempDir()
+	r.opts.RunPath = runPath
+
+	spec := intmodel.ContainerSpec{
+		ID: "root", RealmName: "r1", SpaceName: "s1", StackName: "st1", CellName: "c1",
+		Root:       true,
+		Attachable: false,
+	}
+	socketPath := seedAttachableSocket(t, runPath, spec, 0o640)
+
+	r.ReapplyAttachableSocketPerms(spec)
+
+	info, err := os.Stat(socketPath)
+	if err != nil {
+		t.Fatalf("stat socket after reapply: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Errorf("non-attachable socket mode = %o, want 0640 (per-spec heal must short-circuit on !Attachable)", got)
+	}
+}
+
+// TestReapplyAttachableSocketPermsSpec_TolerantMissingSocket locks the
+// best-effort contract for the per-spec attach-path heal: an Attachable
+// container whose kuketty has not yet bound the socket (ENOENT) must be a
+// silent no-op, not a panic.
+func TestReapplyAttachableSocketPermsSpec_TolerantMissingSocket(t *testing.T) {
+	r := newTestRunner(t)
+	r.opts.RunPath = t.TempDir()
+
+	spec := intmodel.ContainerSpec{
+		ID: "work", RealmName: "r1", SpaceName: "s1", StackName: "st1", CellName: "c1",
+		Attachable: true,
+	}
+
+	// No socket inode seeded — the deep path resolves to ENOENT. The call
+	// must complete without panicking; there is nothing on disk to assert.
+	r.ReapplyAttachableSocketPerms(spec)
+}
+
 func readDoc(t *testing.T, path string) extmodel.ContainerDoc {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/internal/controller/runner/runner.go
+++ b/internal/controller/runner/runner.go
@@ -97,6 +97,16 @@ type Runner interface {
 	ExistsCellRootContainer(cell intmodel.Cell) (bool, error)
 	DeleteCell(cell intmodel.Cell) error
 
+	// ReapplyAttachableSocketPerms re-asserts the mode and group of a single
+	// live attachable container's tty control socket inode on the attach
+	// path (#1169). `kuke run` against an already-Ready cell short-circuits
+	// to attach without re-entering StartCell, so the #935 heal wired into
+	// StartCell's idempotent no-op path never runs on the path run/attach
+	// take; calling this from the daemon's AttachContainer RPC heals a
+	// wrong-mode (pre-sbsh#361 0o640) live socket in place. Non-Attachable
+	// specs are a no-op; best-effort (failures logged, never returned).
+	ReapplyAttachableSocketPerms(spec intmodel.ContainerSpec)
+
 	GetStack(stack intmodel.Stack) (intmodel.Stack, error)
 	ListStacks(realmName, spaceName string) ([]intmodel.Stack, error)
 	CreateStack(stack intmodel.Stack) (intmodel.Stack, error)


### PR DESCRIPTION
## Summary

- `kuke run` against an already-**Ready** cell short-circuits straight to attach without re-entering `StartCell` (the Ready branch deliberately avoids the #630 CNI duplicate-allocation re-entry). The #935/#936 heal that re-chmods a wrong-mode live tty socket was wired only into `runner.StartCell`'s idempotent no-op path — so it never runs on the path `run`/`attach` actually take. A socket an old kuketty bound `0o640` (group-read only, pre-sbsh#361) stays undialable forever on `kuke run` (`connect: permission denied`), while `kuke restart` heals it because its stop+start rebinds the socket fresh at `0o660`.
- Fix wires the existing heal into the daemon's `AttachContainer` RPC (`internal/client/local/local.go`), so a live wrong-mode socket is re-chmod'd in place — no workload bounce, no #630-prone start-on-running re-entry. This makes both `kuke run` (Ready branch) and plain `kuke attach` self-healing for this class, matching `kuke restart`.
- Implementation: extracted a per-spec heal helper from the existing cell-level `reapplyAttachableSocketPerms`, added an exported `ReapplyAttachableSocketPerms(spec)` on the runner (gated on `spec.Attachable`), threaded it through the `Runner` interface and a delegating `controller.Exec` method, and called it from `AttachContainer` after the task-liveness gate. Best-effort and idempotent: a socket already at `0o660` is left untouched; ENOENT is a benign no-op; the daemon runs as root so the chmod/chown succeeds.

## Notes for reviewer

- The cell-level `reapplyAttachableSocketPerms(cell)` behavior is preserved (it now delegates to the shared per-spec helper). The only behavioral delta on that path is the warn-log message text, which now carries a `via` field ("idempotent StartCell skip" vs "attach") to distinguish the two callers; no test asserts on the message text.
- Healing on `AttachContainer` (rather than only the `run` Ready branch) is the issue's proposed approach and intentionally also benefits plain `kuke attach` — both verbs route through this RPC, both should self-heal.

## Test plan

- [x] `make test` (project CI target, `GOWORK=off`) — all 107 packages `ok`, 0 FAIL.
- [x] `GOWORK=off go build ./...` — clean.
- [x] `GOWORK=off go vet ./internal/controller/... ./internal/client/local/...` — clean.
- [x] New runner unit tests cover the per-spec heal: wrong-mode `0o640`→`0o660` correction, idempotency on already-correct `0o660`, `!Attachable` short-circuit, and tolerant-missing-socket (ENOENT) no-op.
- [x] New controller test asserts `AttachContainer`'s `(*Exec).ReapplyAttachableSocketPerms` delegates the spec verbatim to the runner.

Closes #1169