### PR TITLE
fix(run): fail fast on permanent EACCES against a present attach socket

### DIFF
--- a/cmd/kuke/run/attach.go
+++ b/cmd/kuke/run/attach.go
@@ -227,17 +227,29 @@ func resolveRun(cmd *cobra.Command) runFn {
 //     is cancelled (returns ctx.Err), or attachPingRetryBudget is
 //     exhausted (returns the last runErr wrapped with the matching
 //     sentinel — errdefs.ErrAttachPingTimeout for the ping-deadline
-//     class, errdefs.ErrAttachStaleSocket for the EACCES/ENOENT
-//     class — so callers can errors.Is either class without
-//     string-matching sbsh's wrap or sniffing for raw errno values).
+//     class, errdefs.ErrAttachStaleSocket for the absent-socket
+//     EACCES/ENOENT class — so callers can errors.Is either class
+//     without string-matching sbsh's wrap or sniffing for raw errno
+//     values).
+//   - EACCES against a socket that is *present on disk* is a permanent
+//     wrong-mode condition, not a race: attachBootRaceSentinel returns
+//     errdefs.ErrAttachPermissionDenied with retry=false and the loop
+//     surfaces it immediately rather than burning the full budget
+//     (#1170).
 func runWithPingRetry(ctx context.Context, run runFn, opts attach.Options) error {
 	deadline := time.Now().Add(attachPingRetryBudget)
 	var lastErr error
 	for {
 		lastErr = run(ctx, opts)
-		sentinel := attachBootRaceSentinel(ctx, lastErr)
+		sentinel, retry := attachBootRaceSentinel(ctx, lastErr, opts.SocketPath)
 		if sentinel == nil {
 			return lastErr
+		}
+		if !retry {
+			// Permanent failure (e.g. a present socket with the wrong
+			// mode): retrying cannot resolve it, so surface the matching
+			// sentinel immediately instead of waiting out the budget.
+			return fmt.Errorf("%w: %w", sentinel, lastErr)
 		}
 		if !time.Now().Before(deadline) {
 			return fmt.Errorf("%w: %w", sentinel, lastErr)
@@ -250,34 +262,64 @@ func runWithPingRetry(ctx context.Context, run runFn, opts attach.Options) error
 	}
 }
 
-// attachBootRaceSentinel classifies err as one of the kuketty boot-race
-// classes runWithPingRetry treats as a readiness handshake rather than
-// a hard failure, returning the matching errdefs sentinel — or nil
-// when err is not retryable. The classifier is conservative on purpose:
+// attachBootRaceSentinel classifies err for runWithPingRetry, returning
+// the matching errdefs sentinel plus whether the failure is retryable.
+// A nil sentinel means err is not a recognised boot-race / socket class
+// and should propagate unchanged; a non-nil sentinel with retry=false
+// is a permanent failure runWithPingRetry surfaces immediately rather
+// than waiting out the budget. The classifier is conservative on purpose:
 //
 //   - err must be non-nil (a clean detach is not a retry condition);
 //   - ctx must not be done (a cancelled outer ctx surfaces as
 //     DeadlineExceeded on the inner WithTimeout child, but is the
 //     operator's ^C not kuketty's boot race — don't retry);
 //   - context.DeadlineExceeded in the chain maps to ErrAttachPingTimeout
-//     (the only bounded-timeout in sbsh's attach.Run setup is the 3 s
-//     ping window in clientrunner/io.go dialTerminalCtrlSocket);
-//   - syscall.EACCES / syscall.ENOENT in the chain map to
-//     ErrAttachStaleSocket (the stale pre-fix tty socket window —
-//     EACCES against a 0o640 stale inode, or ENOENT against the
-//     Remove→Listen gap inside kuketty's init path; #933).
-func attachBootRaceSentinel(ctx context.Context, err error) error {
+//     and retries (the only bounded-timeout in sbsh's attach.Run setup
+//     is the 3 s ping window in clientrunner/io.go dialTerminalCtrlSocket);
+//   - syscall.ENOENT in the chain maps to ErrAttachStaleSocket and
+//     retries (the Remove→Listen gap inside kuketty's init path; #933);
+//   - syscall.EACCES in the chain is split by stat(2) on socketPath
+//     (#1170): a stale/absent inode (stat ENOENT) is the transient
+//     pre-fix window — maps to ErrAttachStaleSocket and retries; a
+//     socket that is *present on disk* is a permanent wrong-mode
+//     condition retrying cannot fix — maps to ErrAttachPermissionDenied
+//     with retry=false so the loop fails fast with a message naming the
+//     actual cause instead of burning the 10 s budget blaming a stale
+//     socket.
+func attachBootRaceSentinel(ctx context.Context, err error, socketPath string) (error, bool) {
 	if err == nil {
-		return nil
+		return nil, false
 	}
 	if ctx.Err() != nil {
-		return nil
+		return nil, false
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		return errdefs.ErrAttachPingTimeout
+		return errdefs.ErrAttachPingTimeout, true
 	}
-	if errors.Is(err, syscall.EACCES) || errors.Is(err, syscall.ENOENT) {
-		return errdefs.ErrAttachStaleSocket
+	if errors.Is(err, syscall.ENOENT) {
+		return errdefs.ErrAttachStaleSocket, true
 	}
-	return nil
+	if errors.Is(err, syscall.EACCES) {
+		if socketPresent(socketPath) {
+			return errdefs.ErrAttachPermissionDenied, false
+		}
+		return errdefs.ErrAttachStaleSocket, true
+	}
+	return nil, false
+}
+
+// socketPresent reports whether socketPath currently resolves to an
+// existing inode. Used by attachBootRaceSentinel to tell a permanent
+// wrong-mode socket (present + EACCES on connect) from the transient
+// pre-fix stale-socket window (absent + EACCES/ENOENT). Any stat error
+// other than a clean success is treated as "not present" so the
+// classifier falls back to the conservative retry path rather than
+// failing fast on an ambiguous signal (e.g. EACCES walking the parent
+// directory).
+func socketPresent(socketPath string) bool {
+	if socketPath == "" {
+		return false
+	}
+	_, err := os.Stat(socketPath)
+	return err == nil
 }

--- a/cmd/kuke/run/run_test.go
+++ b/cmd/kuke/run/run_test.go
@@ -3636,6 +3636,70 @@ func TestRun_Attach_StaleSocket_ENOENT_RetriesWithinBudget(t *testing.T) {
 	}
 }
 
+// TestRun_Attach_PermissionDenied_PresentSocket_FailsFast pins the
+// #1170 split: when dial(2) returns EACCES against a control socket
+// that is *present on disk* (a live listener with the wrong mode, e.g.
+// 0o640 without group-write), runWithPingRetry must fail fast with
+// errdefs.ErrAttachPermissionDenied on the first attempt instead of
+// retrying for the full budget. Pre-fix the classifier lumped every
+// EACCES into the transient stale-socket class, so this hung for the
+// 10 s budget and then surfaced a misleading "stale socket" message.
+func TestRun_Attach_PermissionDenied_PresentSocket_FailsFast(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	// A generous budget proves the fail-fast path does not depend on the
+	// budget elapsing: if the classifier wrongly retried, the test would
+	// either spin to >1 call or hang well past its own runtime.
+	restore := runcmd.SetAttachPingRetryForTest(10*time.Second, 10*time.Millisecond)
+	t.Cleanup(restore)
+
+	// A real on-disk path so attachBootRaceSentinel's stat(2) sees the
+	// socket as present and classifies the EACCES as permanent.
+	presentSocket := filepath.Join(t.TempDir(), "tty.socket")
+	if err := os.WriteFile(presentSocket, nil, 0o600); err != nil {
+		t.Fatalf("seed present socket: %v", err)
+	}
+
+	var calls int
+	var mu sync.Mutex
+	runFn := runcmd.RunFn(func(_ context.Context, _ sbshattach.Options) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		return fmt.Errorf("ping failed: dial unix %s: connect: %w", presentSocket, syscall.EACCES)
+	})
+
+	fc := &fakeClient{
+		createCellFn: func(doc v1beta1.CellDoc) (kukeonv1.CreateCellResult, error) {
+			return successCreateResult(doc), nil
+		},
+		attachContainerFn: func(_ v1beta1.ContainerDoc) (kukeonv1.AttachContainerResult, error) {
+			return kukeonv1.AttachContainerResult{HostSocketPath: presentSocket}, nil
+		},
+	}
+	cmd, _ := newCmdWithRunFn(t, fc, runFn)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, attachableCellYAML)})
+
+	err := cmd.Execute()
+	if !errors.Is(err, errdefs.ErrAttachPermissionDenied) {
+		t.Fatalf("err=%v, want chain to include errdefs.ErrAttachPermissionDenied", err)
+	}
+	if !errors.Is(err, syscall.EACCES) {
+		t.Errorf(
+			"err=%v, want chain to preserve syscall.EACCES so operators can still see the underlying cause",
+			err,
+		)
+	}
+	if errors.Is(err, errdefs.ErrAttachStaleSocket) {
+		t.Errorf("err=%v, must NOT be wrapped with ErrAttachStaleSocket — a present-socket EACCES is permanent, not the stale-socket race", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Errorf("attach loop calls=%d, want 1 (permanent EACCES must fail fast, no retry)", calls)
+	}
+}
+
 // --- epic:cell-identity #1025: cell-positional + fused create+start+attach ---
 
 // sourceConfigCellForRun is a Config-lineage source cell (provenance points at

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -330,6 +330,26 @@ var (
 	// without sniffing for raw errno values (#933).
 	ErrAttachStaleSocket = errors.New("attach stale socket: kuketty has not yet unlinked the pre-fix tty socket")
 
+	// ErrAttachPermissionDenied is returned by the post-StartCell attach
+	// loop in cmd/kuke/run when dial(2) fails with EACCES against a tty
+	// control socket that is *present on disk* — a permanent permission
+	// condition (the socket inode carries the wrong mode, e.g. 0o640
+	// without group-write for the operator), not the transient pre-fix
+	// stale-socket race ErrAttachStaleSocket covers. Retrying cannot
+	// resolve a wrong-mode inode, so the loop fails fast instead of
+	// burning the full retry budget on a 10 s hang followed by a
+	// misleading "stale socket" message. Split from ErrAttachStaleSocket
+	// by stat(2) at classification time — socket absent (stat ENOENT) is
+	// the transient class worth retrying; socket present + EACCES is this
+	// permanent class — so callers can errors.Is the permanent failure
+	// and operators get a message that names the socket mode and points
+	// at the heal (`kuke restart <cell>`) rather than a stale socket
+	// (#1170).
+	ErrAttachPermissionDenied = errors.New(
+		"attach permission denied: kuketty control socket is present but not accessible (wrong mode); " +
+			"retrying cannot fix this — heal the socket with `kuke restart <cell>`",
+	)
+
 	// ErrSocketPathTooLong fires when the resolved host-side path of a
 	// per-container kuketty control socket would overflow Linux's
 	// sockaddr_un.sun_path buffer (consts.KukeonMaxSocketPath bytes plus


### PR DESCRIPTION
## Summary

- `attachBootRaceSentinel` previously lumped **any** `syscall.EACCES` into the transient stale-socket boot-race class, so the post-`StartCell` attach loop retried for the full `attachPingRetryBudget = 10s` before surfacing a misleading `attach stale socket: kuketty has not yet unlinked the pre-fix tty socket` error. But EACCES against a socket inode that is *present with a live listener* is a permanent wrong-mode condition (e.g. `0o640` without group-write) — retrying cannot resolve it, so the 10s hang is pure wasted latency and the message points diagnosis the wrong way.
- This splits the two errnos by whether the socket path currently exists, per the issue's proposal:
  - **ENOENT** (in the dial chain) → genuinely transient (the `Remove→Listen` gap inside kuketty init, #933). Keep retrying.
  - **EACCES on a *present* socket** (`os.Stat` succeeds) → permanent. Fail fast on the first attempt with the new `errdefs.ErrAttachPermissionDenied`, whose message names the actual cause (socket mode / missing group-access) and points at the heal (`kuke restart <cell>`).
  - **EACCES on an *absent* socket** (`os.Stat` → ENOENT, or any stat error) → conservatively still treated as the transient stale-socket class and retried — preserving prior behavior on the ambiguous signal rather than failing fast.
- The classifier now returns `(sentinel, retry bool)`; `runWithPingRetry` surfaces a non-retryable sentinel immediately instead of waiting out the budget. EACCES preserves `syscall.EACCES` in the wrapped chain so operators still see the underlying cause.

## Implementation notes

- New sentinel `errdefs.ErrAttachPermissionDenied` added alongside `ErrAttachStaleSocket` (`internal/errdefs/errdefs.go`).
- Existing `staleSocket{,ENOENT}Err` tests use a non-existent socket path (`/opt/kukeon/r/s/st/c/work/tty/socket`), so `os.Stat` reports absent → they remain classified transient and still pass unchanged. New test `TestRun_Attach_PermissionDenied_PresentSocket_FailsFast` seeds a real on-disk socket file so the stat sees it present and asserts: 1 call (no retry), chain includes `ErrAttachPermissionDenied` + `syscall.EACCES`, and is NOT wrapped with `ErrAttachStaleSocket`.
- Scope: CLI-side error classification in the `kuke run` post-start attach retry loop only. No daemon, build-path, or `/opt/kukeon` layout change, so the `make dev-init` smoke is not implicated; the companion daemon-side heal is #1169 (out of scope here).

## Test plan

- [x] `GOWORK=off go test ./cmd/kuke/run/ -run Attach` — all attach tests pass, including the new fail-fast test
- [x] `GOWORK=off go vet ./cmd/kuke/run/ ./internal/errdefs/`
- [x] `make test` (full CI target: `test-root` + `test-kukebuild`) — EXIT=0

Closes #1170