### PR TITLE
fix(reconcile): version the spec-hash domain so a daemon upgrade re-stamps cells instead of stranding them

### DIFF
--- a/internal/controller/runner/provision.go
+++ b/internal/controller/runner/provision.go
@@ -1573,9 +1573,7 @@ func (r *Exec) createCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
 			buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
-			buildOpts = append(buildOpts, ctr.WithExtraLabels(map[string]string{
-				SpecHashLabelKey: ComputeContainerSpecHash(containerSpec),
-			}))
+			buildOpts = append(buildOpts, ctr.WithExtraLabels(specHashLabels(containerSpec)))
 			// Merge `kuke run --env` runtime env into the attachable
 			// container's spec env (issue #834). Returns containerSpec
 			// unchanged for non-attachable containers or when
@@ -2051,9 +2049,7 @@ func (r *Exec) ensureCellContainers(cell *intmodel.Cell) (containerd.Container, 
 				return nil, fmt.Errorf("failed to prepare attachable container %s: %w", containerdID, attachErr)
 			}
 			buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
-			buildOpts = append(buildOpts, ctr.WithExtraLabels(map[string]string{
-				SpecHashLabelKey: ComputeContainerSpecHash(containerSpec),
-			}))
+			buildOpts = append(buildOpts, ctr.WithExtraLabels(specHashLabels(containerSpec)))
 			createdContainer, containerCreateErr := r.ctrClient.CreateContainerFromSpec(
 				internalRealm.Spec.Namespace,
 				containerSpec,

--- a/internal/controller/runner/spec_hash.go
+++ b/internal/controller/runner/spec_hash.go
@@ -38,6 +38,28 @@ import (
 // containerd state, so steady-state restarts always match. Issue #867.
 const SpecHashLabelKey = "kukeon.io/spec-hash"
 
+// SpecHashVersionLabelKey pins the *domain version* the SpecHashLabelKey value
+// was computed under — the field set in containerSpecHashPayload. A bare hash
+// cannot distinguish "the spec drifted" (genuine out-of-band tampering, which
+// must refuse) from "the hashing algorithm changed" (a daemon upgrade widened
+// the payload, which must NOT refuse). Without this label, any change to the
+// hash domain made every pre-existing cell look tampered and stranded the
+// whole fleet on the next start with no migration path. The guard now keys its
+// refuse-vs-re-stamp decision on whether this version matches the running
+// daemon's SpecHashDomainVersion. Issue #1171.
+const SpecHashVersionLabelKey = "kukeon.io/spec-hash-version"
+
+// SpecHashDomainVersion is the current hash-domain version. Bump it whenever
+// containerSpecHashPayload's field set changes — the
+// TestSpecHashDomainVersionPinsToPayload regression guard forces the bump in
+// the same edit by pinning the version to the payload's reflected field set.
+// History: "1" (issue #867, original domain) → "2" (#1001, widened the
+// root-container diff to all spec fields) → "3" (#1155, added Volumes,
+// Secrets, WorkingDir, SecurityOpts). A cell stamped under an older version
+// is re-stamped from its authoritative on-disk spec on the next start rather
+// than refused. Issue #1171.
+const SpecHashDomainVersion = "3"
+
 // containerSpecHashPayload is the deterministic projection of an
 // intmodel.ContainerSpec that ComputeContainerSpecHash hashes. The field set
 // must match exactly what `apply.DiffCell` classifies as "requires containerd
@@ -245,16 +267,103 @@ func projectSecretRef(r *intmodel.ContainerSecretRef) *secretRefHashPayload {
 	}
 }
 
-// stampSpecHashOnLabels writes the SpecHashLabelKey into labels (allocating
-// the map if nil) and returns it. Used by every root-container create path
-// where the runner builds the labels map up front and passes it through
-// ctr.BuildRootContainerSpec.
+// specHashLabels is the single source of truth for the (hash, version) label
+// pair every create and re-stamp path writes. Both labels move together so a
+// record can never carry a hash from one domain and a version from another.
+// Issue #1171.
+func specHashLabels(spec intmodel.ContainerSpec) map[string]string {
+	return map[string]string{
+		SpecHashLabelKey:        ComputeContainerSpecHash(spec),
+		SpecHashVersionLabelKey: SpecHashDomainVersion,
+	}
+}
+
+// stampSpecHashOnLabels writes the SpecHashLabelKey + SpecHashVersionLabelKey
+// pair into labels (allocating the map if nil) and returns it. Used by every
+// root-container create path where the runner builds the labels map up front
+// and passes it through ctr.BuildRootContainerSpec.
 func stampSpecHashOnLabels(labels map[string]string, spec intmodel.ContainerSpec) map[string]string {
 	if labels == nil {
-		labels = make(map[string]string, 1)
+		// specHashLabels already returns a fresh map carrying exactly the
+		// (hash, version) pair — reuse it rather than allocate-then-copy.
+		return specHashLabels(spec)
 	}
-	labels[SpecHashLabelKey] = ComputeContainerSpecHash(spec)
+	for k, v := range specHashLabels(spec) {
+		labels[k] = v
+	}
 	return labels
+}
+
+// specHashReuseAction is the verdict of the versioned spec-hash guard for an
+// existing containerd record on the reuse (stop/start) path. Issue #1171.
+type specHashReuseAction int
+
+const (
+	// specHashReuseAsIs: the stamped version matches the running daemon's
+	// domain and the stamped hash matches (or is absent) — reuse the snapshot
+	// without touching the labels.
+	specHashReuseAsIs specHashReuseAction = iota
+	// specHashRestamp: the stamped version is legacy-absent or from a prior
+	// hash domain. The on-disk spec (which `kuke apply -f` writes back) is
+	// authoritative, so there is nothing to recover — re-stamp the fresh
+	// (hash, version) pair and reuse. Tamper detection is suspended for this
+	// one start across the upgrade boundary; an upgrade is already a trust
+	// boundary, so that is acceptable. This arm turns a domain bump from a
+	// fleet-wide outage into a one-time silent re-stamp, and auto-heals cells
+	// stamped with a bare pre-#1171 hash.
+	specHashRestamp
+	// specHashRefuse: the stamped version matches the current domain but the
+	// hash diverges — genuine out-of-band tampering. The caller refuses with
+	// ErrCellSpecHashDrift.
+	specHashRefuse
+)
+
+// classifySpecHashReuse turns an existing record's labels and the freshly
+// computed desiredHash into the three-way reuse verdict. The version gate is
+// what distinguishes a changed hashing algorithm (re-stamp) from a changed
+// spec (refuse): a hash mismatch only refuses when the record was stamped
+// under the running daemon's own domain version. Issue #1171.
+func classifySpecHashReuse(labels map[string]string, desiredHash string) specHashReuseAction {
+	if labels[SpecHashVersionLabelKey] != SpecHashDomainVersion {
+		// Legacy-absent or prior-domain stamp — the on-disk spec is the
+		// source of truth, so re-stamp rather than refuse.
+		return specHashRestamp
+	}
+	stampedHash := labels[SpecHashLabelKey]
+	if stampedHash != "" && stampedHash != desiredHash {
+		return specHashRefuse
+	}
+	return specHashReuseAsIs
+}
+
+// restampSpecHashLabels writes the current (hash, version) label pair onto an
+// existing containerd record on the reuse path. Best-effort by contract: the
+// labels are a tripwire, not a source of truth, so a write failure is logged
+// and the start proceeds (the next start re-attempts the re-stamp). Issue
+// #1171.
+func (r *Exec) restampSpecHashLabels(
+	container containerd.Container,
+	namespace, ctrContainerID, cellName string,
+	spec intmodel.ContainerSpec,
+) {
+	nsCtx := namespaces.WithNamespace(r.ctx, namespace)
+	if _, err := container.SetLabels(nsCtx, specHashLabels(spec)); err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"failed to re-stamp spec-hash labels on reuse path, continuing (labels are a tripwire, not source of truth)",
+			"id",
+			ctrContainerID,
+			"cell",
+			cellName,
+			"err",
+			err.Error(),
+		)
+		return
+	}
+	r.logger.InfoContext(r.ctx,
+		"re-stamped spec-hash to current domain version on reuse path",
+		"id", ctrContainerID, "cell", cellName,
+		"version", SpecHashDomainVersion, "spec-hash", ComputeContainerSpecHash(spec))
 }
 
 // reuseOrRefuseExistingChildContainer is the child-container counterpart of
@@ -291,13 +400,18 @@ func (r *Exec) reuseOrRefuseExistingChildContainer(
 			"failed to read existing container labels, treating as match for reuse",
 			"id", ctrContainerID, "cell", cellName, "err", labelErr.Error())
 	}
-	onDiskHash := existingLabels[SpecHashLabelKey]
-	if onDiskHash != "" && onDiskHash != desiredHash {
+	switch classifySpecHashReuse(existingLabels, desiredHash) {
+	case specHashRefuse:
+		onDiskHash := existingLabels[SpecHashLabelKey]
 		return false, fmt.Errorf(
 			"%w: cell %q: container %q carries spec-hash %q but cell spec hashes to %q — "+
 				"run `kuke apply -f` to reconcile",
 			errdefs.ErrCellSpecHashDrift, cellName, ctrContainerID, onDiskHash, desiredHash,
 		)
+	case specHashRestamp:
+		r.restampSpecHashLabels(container, namespace, ctrContainerID, cellName, spec)
+	case specHashReuseAsIs:
+		// Stamped (hash, version) match the running domain — reuse untouched.
 	}
 	// Drop any stale task so StartContainer can create a fresh one. The
 	// container's snapshot is preserved across the call — only the task

--- a/internal/controller/runner/spec_hash_guard_test.go
+++ b/internal/controller/runner/spec_hash_guard_test.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"reflect"
+	"sort"
 	"testing"
 
 	cgroup2 "github.com/containerd/cgroups/v2/cgroup2"
@@ -45,12 +47,26 @@ type stubLabeledContainer struct {
 
 	id     string
 	labels map[string]string
+	// stamped, when non-nil, captures the labels written by SetLabels on the
+	// guard's re-stamp path so tests can assert the (hash, version) pair the
+	// reuse branch wrote. Issue #1171.
+	stamped *map[string]string
 }
 
 func (c stubLabeledContainer) ID() string { return c.id }
 
 func (c stubLabeledContainer) Labels(context.Context) (map[string]string, error) {
 	return c.labels, nil
+}
+
+// SetLabels records the re-stamp the guard performs on the reuse path. The
+// real containerd.Container merges and returns the full label set; the stub
+// echoes the written pair, which is all the guard tests assert. Issue #1171.
+func (c stubLabeledContainer) SetLabels(_ context.Context, labels map[string]string) (map[string]string, error) {
+	if c.stamped != nil {
+		*c.stamped = labels
+	}
+	return labels, nil
 }
 
 func (c stubLabeledContainer) Task(context.Context, cio.Attach) (containerd.Task, error) {
@@ -174,6 +190,7 @@ func (c *specHashFakeClient) DeleteImage(string, string) error                  
 func (c *specHashFakeClient) PruneImages(string) (ctr.PruneResult, error) {
 	return ctr.PruneResult{}, nil
 }
+
 func (c *specHashFakeClient) NamespaceStorage(string) (ctr.StorageStats, error) {
 	return ctr.StorageStats{}, nil
 }
@@ -218,11 +235,16 @@ func TestReuseOrRefuseExistingChildContainer_AbsentRecordFallsThrough(t *testing
 func TestReuseOrRefuseExistingChildContainer_MatchingHashReuses(t *testing.T) {
 	spec := intmodel.ContainerSpec{Image: "alpine", Command: "sleep", Args: []string{"infinity"}}
 	matchingHash := ComputeContainerSpecHash(spec)
+	var stamped map[string]string
 	fake := &specHashFakeClient{
 		getContainerFn: func(_, id string) (containerd.Container, error) {
 			return stubLabeledContainer{
-				id:     id,
-				labels: map[string]string{SpecHashLabelKey: matchingHash},
+				id: id,
+				labels: map[string]string{
+					SpecHashLabelKey:        matchingHash,
+					SpecHashVersionLabelKey: SpecHashDomainVersion,
+				},
+				stamped: &stamped,
 			}, nil
 		},
 	}
@@ -235,52 +257,74 @@ func TestReuseOrRefuseExistingChildContainer_MatchingHashReuses(t *testing.T) {
 	if !reuse {
 		t.Errorf("matching spec-hash must return reuse=true (overlay preserved); got reuse=false")
 	}
+	if stamped != nil {
+		t.Errorf(
+			"a record stamped under the current version with a matching hash must reuse untouched; got re-stamp %v",
+			stamped,
+		)
+	}
 }
 
-// TestReuseOrRefuseExistingChildContainer_LegacyRecordReuses locks the
-// backward-compatibility branch: a record with no SpecHashLabelKey label
-// (created by pre-#867 kukeon) is treated as a match so the operator's first
-// restart after the upgrade does not refuse with ErrCellSpecHashDrift on a
-// healthy cell.
-func TestReuseOrRefuseExistingChildContainer_LegacyRecordReuses(t *testing.T) {
+// TestReuseOrRefuseExistingChildContainer_LegacyRecordReusesAndRestamps locks
+// the legacy-absent branch: a record with no version label (created by a
+// pre-#1171 daemon, possibly carrying a bare hash from an older domain) is
+// reused AND re-stamped to the current (hash, version) pair, so the first
+// restart after the upgrade heals the record instead of refusing with
+// ErrCellSpecHashDrift. Issues #867, #1171.
+func TestReuseOrRefuseExistingChildContainer_LegacyRecordReusesAndRestamps(t *testing.T) {
+	spec := intmodel.ContainerSpec{Image: "alpine"}
+	var stamped map[string]string
 	fake := &specHashFakeClient{
 		getContainerFn: func(_, id string) (containerd.Container, error) {
 			return stubLabeledContainer{
-				id:     id,
-				labels: map[string]string{"kukeon.io/cell": "demo"}, // unrelated label
+				id: id,
+				// Bare pre-#1171 hash from an older domain + no version label —
+				// exactly the shape of the live-incident stranded cells.
+				labels:  map[string]string{SpecHashLabelKey: "6271df3bstale"},
+				stamped: &stamped,
 			}, nil
 		},
 	}
 	r := newSpecHashTestExec(fake)
 
-	reuse, err := r.reuseOrRefuseExistingChildContainer(
-		"ns", "id", "cell",
-		intmodel.ContainerSpec{Image: "alpine"},
-	)
+	reuse, err := r.reuseOrRefuseExistingChildContainer("ns", "id", "cell", spec)
 	if err != nil {
 		t.Fatalf("legacy record must not error; got %v", err)
 	}
 	if !reuse {
+		t.Errorf("legacy record (no version label) must be reused after re-stamp; got reuse=false")
+	}
+	if stamped[SpecHashVersionLabelKey] != SpecHashDomainVersion {
 		t.Errorf(
-			"legacy record (no kukeon.io/spec-hash label) must be treated as match (safe default for first post-upgrade restart); got reuse=false",
+			"legacy record must be re-stamped to the current domain version %q; got %v",
+			SpecHashDomainVersion,
+			stamped,
 		)
+	}
+	if stamped[SpecHashLabelKey] != ComputeContainerSpecHash(spec) {
+		t.Errorf("legacy record must be re-stamped to the current spec hash; got %v", stamped)
 	}
 }
 
 // TestReuseOrRefuseExistingChildContainer_DivergedHashRefuses is the
-// regression guard for AC #6 of issue #867: a containerd record whose
-// SpecHashLabelKey value disagrees with the freshly-computed hash must
-// refuse with ErrCellSpecHashDrift instead of silently resuming a stale
-// snapshot. The wrapped error must name both hashes and point at
-// `kuke apply -f` so the operator has an actionable next step.
+// regression guard for AC #6 of issue #867 and AC #2 of #1171: a containerd
+// record stamped under the *current* domain version whose SpecHashLabelKey
+// value disagrees with the freshly-computed hash is genuine out-of-band
+// tampering and must refuse with ErrCellSpecHashDrift instead of silently
+// resuming a stale snapshot. The wrapped error must name both hashes and point
+// at `kuke apply -f` so the operator has an actionable next step.
 func TestReuseOrRefuseExistingChildContainer_DivergedHashRefuses(t *testing.T) {
 	desired := intmodel.ContainerSpec{Image: "alpine", Command: "sleep"}
 	staleHash := "deadbeef" // intentionally not the hash of desired
 	fake := &specHashFakeClient{
 		getContainerFn: func(_, id string) (containerd.Container, error) {
 			return stubLabeledContainer{
-				id:     id,
-				labels: map[string]string{SpecHashLabelKey: staleHash},
+				id: id,
+				// Current version + diverged hash == within-version tamper.
+				labels: map[string]string{
+					SpecHashLabelKey:        staleHash,
+					SpecHashVersionLabelKey: SpecHashDomainVersion,
+				},
 			}, nil
 		},
 	}
@@ -304,6 +348,168 @@ func TestReuseOrRefuseExistingChildContainer_DivergedHashRefuses(t *testing.T) {
 	}
 	if !contains(msg, "kuke apply -f") {
 		t.Errorf("error message must point at `kuke apply -f` as the reconcile next step; got %q", msg)
+	}
+}
+
+// TestReuseOrRefuseExistingChildContainer_PriorDomainVersionRestamps locks the
+// upgrade path: a record stamped under a prior domain version — even when its
+// stale hash disagrees with the current spec — is re-stamped and reused, not
+// refused. This is the fix's core arm: a daemon upgrade that crosses a
+// hash-domain change must not strand pre-existing cells. Issue #1171.
+func TestReuseOrRefuseExistingChildContainer_PriorDomainVersionRestamps(t *testing.T) {
+	spec := intmodel.ContainerSpec{Image: "alpine", Command: "sleep"}
+	var stamped map[string]string
+	fake := &specHashFakeClient{
+		getContainerFn: func(_, id string) (containerd.Container, error) {
+			return stubLabeledContainer{
+				id: id,
+				labels: map[string]string{
+					// Older domain: a hash that would refuse under a bare guard.
+					SpecHashLabelKey:        "priordomainstalehash",
+					SpecHashVersionLabelKey: "2",
+				},
+				stamped: &stamped,
+			}, nil
+		},
+	}
+	r := newSpecHashTestExec(fake)
+
+	reuse, err := r.reuseOrRefuseExistingChildContainer("ns", "id", "cell", spec)
+	if err != nil {
+		t.Fatalf("prior-domain record must re-stamp + reuse, not error; got %v", err)
+	}
+	if !reuse {
+		t.Errorf("prior-domain record must be reused after re-stamp; got reuse=false")
+	}
+	if stamped[SpecHashVersionLabelKey] != SpecHashDomainVersion ||
+		stamped[SpecHashLabelKey] != ComputeContainerSpecHash(spec) {
+		t.Errorf("prior-domain record must be re-stamped to the current (hash, version) pair; got %v", stamped)
+	}
+}
+
+// TestClassifySpecHashReuse is the table-driven guard for the three-way reuse
+// decision at the heart of #1171: absent (legacy) / same-version-match /
+// same-version-mismatch / different-version.
+func TestClassifySpecHashReuse(t *testing.T) {
+	const desired = "currenthash"
+	cases := []struct {
+		name   string
+		labels map[string]string
+		want   specHashReuseAction
+	}{
+		{
+			name:   "absent legacy version re-stamps",
+			labels: map[string]string{SpecHashLabelKey: "anyoldhash"},
+			want:   specHashRestamp,
+		},
+		{
+			name:   "no labels at all re-stamps",
+			labels: map[string]string{},
+			want:   specHashRestamp,
+		},
+		{
+			name: "different version re-stamps even on hash mismatch",
+			labels: map[string]string{
+				SpecHashLabelKey:        "priorhash",
+				SpecHashVersionLabelKey: "2",
+			},
+			want: specHashRestamp,
+		},
+		{
+			name: "same version matching hash reuses as-is",
+			labels: map[string]string{
+				SpecHashLabelKey:        desired,
+				SpecHashVersionLabelKey: SpecHashDomainVersion,
+			},
+			want: specHashReuseAsIs,
+		},
+		{
+			name: "same version diverged hash refuses",
+			labels: map[string]string{
+				SpecHashLabelKey:        "tampered",
+				SpecHashVersionLabelKey: SpecHashDomainVersion,
+			},
+			want: specHashRefuse,
+		},
+		{
+			name: "same version empty hash reuses as-is",
+			labels: map[string]string{
+				SpecHashVersionLabelKey: SpecHashDomainVersion,
+			},
+			want: specHashReuseAsIs,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifySpecHashReuse(tc.labels, desired); got != tc.want {
+				t.Errorf("classifySpecHashReuse(%v) = %d, want %d", tc.labels, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSpecHashDomainVersionPinsToPayload forces a SpecHashDomainVersion bump in
+// the same edit as any change to containerSpecHashPayload's field set. The hash
+// domain *is* the payload's JSON field set, so this test reflects that set and
+// pins it to the current version: adding, removing, or renaming a payload field
+// changes the reflected set, fails this test, and the only green fix is to bump
+// SpecHashDomainVersion and register the new field set below. This is the
+// versioned counterpart of TestSpecHashDomainPinsToDiffCellBreakingFields (which
+// pins the payload to apply.DiffCell's breaking domain); kept in-package because
+// the payload struct is unexported. Issue #1171.
+func TestSpecHashDomainVersionPinsToPayload(t *testing.T) {
+	// domainFieldSets records, per version, the sorted JSON field set the hash
+	// domain carried at that version. Append a new entry whenever you bump
+	// SpecHashDomainVersion; never edit an existing entry (prior domains are
+	// historical fact, and the re-stamp path relies on old versions staying
+	// distinct from the current one).
+	domainFieldSets := map[string][]string{
+		"3": {
+			"args", "capabilities", "command", "image", "privileged",
+			"readOnlyRootFilesystem", "resources", "secrets", "securityOpts",
+			"tmpfs", "user", "volumes", "workingDir",
+		},
+	}
+
+	want, ok := domainFieldSets[SpecHashDomainVersion]
+	if !ok {
+		t.Fatalf(
+			"no domain field set registered for SpecHashDomainVersion %q — append one to domainFieldSets in the same edit that bumped the version",
+			SpecHashDomainVersion,
+		)
+	}
+
+	pt := reflect.TypeOf(containerSpecHashPayload{})
+	got := make([]string, 0, pt.NumField())
+	for i := range pt.NumField() {
+		tag := pt.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			t.Fatalf(
+				"containerSpecHashPayload field %q has no json tag — the hash domain must be fully tagged",
+				pt.Field(i).Name,
+			)
+		}
+		got = append(got, tag)
+	}
+	sort.Strings(got)
+
+	if len(got) != len(want) {
+		t.Fatalf(
+			"containerSpecHashPayload field set changed without a SpecHashDomainVersion bump: got %v, registered for version %q is %v — bump SpecHashDomainVersion and register the new set",
+			got,
+			SpecHashDomainVersion,
+			want,
+		)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf(
+				"containerSpecHashPayload field set changed without a SpecHashDomainVersion bump: got %v, registered for version %q is %v — bump SpecHashDomainVersion and register the new set",
+				got,
+				SpecHashDomainVersion,
+				want,
+			)
+		}
 	}
 }
 

--- a/internal/controller/runner/spec_hash_test.go
+++ b/internal/controller/runner/spec_hash_test.go
@@ -183,6 +183,13 @@ func TestComputeContainerSpecHash_CompatibleFieldsDoNotChangeHash(t *testing.T) 
 // refuse). Mirrors `apply.DiffCell`'s root-side classification — see
 // `diffContainerSpec`'s per-field Breaking-vs-Compatible calls in
 // `internal/controller/apply/diff.go`. Issues #867, #990.
+//
+// Companion guard: TestSpecHashDomainVersionPinsToPayload (in-package, beside
+// the unexported payload it reflects over) forces a SpecHashDomainVersion bump
+// in the same edit as any payload field-set change — together the two keep the
+// payload pinned to both the apply-layer breaking domain and a domain version,
+// so a domain widening can never strand pre-existing cells unversioned. Issue
+// #1171.
 func TestSpecHashDomainPinsToDiffCellBreakingFields(t *testing.T) {
 	makeCell := func(root intmodel.ContainerSpec) intmodel.Cell {
 		root.Root = true

--- a/internal/controller/runner/start.go
+++ b/internal/controller/runner/start.go
@@ -698,13 +698,21 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 				"failed to read existing root container labels, treating as match for reuse",
 				fields...)
 		}
-		onDiskRootHash := existingLabels[SpecHashLabelKey]
-		if onDiskRootHash != "" && onDiskRootHash != desiredRootSpecHash {
+		switch classifySpecHashReuse(existingLabels, desiredRootSpecHash) {
+		case specHashRefuse:
+			onDiskRootHash := existingLabels[SpecHashLabelKey]
 			return intmodel.Cell{}, fmt.Errorf(
 				"%w: cell %q: containerd record carries spec-hash %q but cell spec hashes to %q — "+
 					"run `kuke apply -f` to reconcile",
 				internalerrdefs.ErrCellSpecHashDrift, cellName, onDiskRootHash, desiredRootSpecHash,
 			)
+		case specHashRestamp:
+			// Upgrade across a hash-domain change (or a bare pre-#1171 hash):
+			// the on-disk root spec is authoritative, so re-stamp rather than
+			// strand the cell. Issue #1171.
+			r.restampSpecHashLabels(container, namespace, containerID, cellName, rootContainerSpec)
+		case specHashReuseAsIs:
+			// Stamped (hash, version) match the running domain — reuse untouched.
 		}
 		reuseExistingRoot = true
 		// Drop any stale task on the existing record. Reaching this branch
@@ -1084,9 +1092,7 @@ func (r *Exec) startCellLocked(cell intmodel.Cell) (_ intmodel.Cell, retErr erro
 		}
 		if !reuseExistingChild {
 			buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
-			buildOpts = append(buildOpts, ctr.WithExtraLabels(map[string]string{
-				SpecHashLabelKey: ComputeContainerSpecHash(containerSpec),
-			}))
+			buildOpts = append(buildOpts, ctr.WithExtraLabels(specHashLabels(containerSpec)))
 			// `kuke run --env` runtime-env merge (issue #834). Same shape as the
 			// CreateCell-side merge in provision.go: returns containerSpec
 			// unchanged for non-attachable containers or when RuntimeEnv is
@@ -1399,9 +1405,7 @@ func (r *Exec) StartContainer(cell intmodel.Cell, containerID string) (_ intmode
 	}
 	if !reuseExistingChild {
 		buildOpts := append(r.daemonDefaultBuildOpts(), attachOpts...)
-		buildOpts = append(buildOpts, ctr.WithExtraLabels(map[string]string{
-			SpecHashLabelKey: ComputeContainerSpecHash(*foundContainerSpec),
-		}))
+		buildOpts = append(buildOpts, ctr.WithExtraLabels(specHashLabels(*foundContainerSpec)))
 		_, err = r.ctrClient.CreateContainerFromSpec(namespace, *foundContainerSpec, creds, buildOpts...)
 		if err != nil {
 			fields := appendCellLogFields([]any{"id", containerdID}, cellID, cellName)


### PR DESCRIPTION
## Summary

- The cell spec-hash drift guard was **unversioned**: a bare `kukeon.io/spec-hash` label cannot tell "the spec drifted" (genuine tampering → refuse) from "the hashing algorithm changed" (a daemon upgrade widened `containerSpecHashPayload` → must NOT refuse). After a rebuild that crossed a domain change (#1001, #1155), every pre-existing cell looked tampered and the guard hard-refused to start them — a fleet-wide outage with no migration path (the live incident in #1171: 5 cells stranded).
- Adds a companion `kukeon.io/spec-hash-version` label (`SpecHashVersionLabelKey`) stamped alongside the hash, pinned to `SpecHashDomainVersion = "3"`. Both guard sites (root container in `start.go`, child container in `spec_hash.go`'s `reuseOrRefuseExistingChildContainer`) now make a **three-way** decision instead of two-way:

  | stamped version | hash compare | action |
  |---|---|---|
  | absent (legacy) / != current | — | **re-stamp** from on-disk spec, reuse (log INFO) |
  | == current | mismatch | **refuse** with `ErrCellSpecHashDrift` (unchanged) |
  | == current | match | reuse untouched (unchanged) |

- A domain bump is now a one-time silent re-stamp on the next start, not an outage. The on-disk `metadata.json` (exactly what `apply -f` writes back) is authoritative; the hash is a tripwire, so on an algorithm change there is nothing to recover — the daemon re-derives the label. Tamper detection is suspended only for the *first* start across an upgrade, which is already a trust boundary.
- **Bonus (#1171 AC):** the legacy-absent arm auto-heals the currently-stranded bare-hash cells on their next `kuke start` — no `ctr label` surgery.
- Single source of truth `specHashLabels(spec)` now feeds all six create/re-stamp sites (4 `WithExtraLabels` call sites in `start.go`/`provision.go` + `stampSpecHashOnLabels` + the reuse-path re-stamp), so the hash and version can never be written out of lockstep.

## Design notes / non-obvious calls

- **Version-pin test placement.** The AC asked to "wire `SpecHashDomainVersion` into the existing `TestSpecHashDomainPinsToDiffCellBreakingFields`". That test lives in the *external* `runner_test` package and pins the payload to `apply.DiffCell`'s breaking domain. The new `TestSpecHashDomainVersionPinsToPayload` reflects over the **unexported** `containerSpecHashPayload`, which an external-package test cannot reach — so it lives in-package (`spec_hash_guard_test.go`) as a dedicated companion guard, with a cross-reference comment added to the existing DiffCell test. It pins the version to the payload's reflected JSON field set: adding/removing/renaming a payload field changes the set, fails the test, and the only green fix is to bump `SpecHashDomainVersion` and register the new field set — forcing the bump in the same edit, as the AC intends.
- **Re-stamp is best-effort.** `restampSpecHashLabels` logs a WARN and proceeds if `SetLabels` fails — the labels are a tripwire, not a source of truth, and the next start re-attempts. Failing the start over a label write would reintroduce the fragility this fix removes.
- **Optional secondary fix deferred.** AC item 5 (`kuke apply -f --restamp` / `kuke repair` operator escape hatch, plus the separate `apply -f` no-op-on-identical-root bug) is explicitly marked Optional in the issue. The primary self-heal path (re-stamp on next start) already resolves the outage and auto-heals the stranded cells, so the escape hatch is left for a follow-up. Recommend PM file it separately if still wanted.

## Test plan

- [x] `make test` (full CI target: test-root + test-kukebuild) — all packages pass
- [x] `GOWORK=off go build ./internal/controller/runner/` + `go vet` — clean
- [x] `pre-commit run --files <changed>` — golangci-lint, go-fmt, go-mod-tidy, addlicense all pass
- [x] New/updated unit tests:
  - `TestClassifySpecHashReuse` — table test for the three-way guard (absent / no-labels / different-version / same-version-match / same-version-mismatch / same-version-empty-hash)
  - `TestReuseOrRefuseExistingChildContainer_PriorDomainVersionRestamps` — a prior-domain stamp (even with a diverged hash) re-stamps + reuses, not refuses
  - `TestReuseOrRefuseExistingChildContainer_LegacyRecordReusesAndRestamps` — bare pre-#1171 hash (the stranded-cell shape) is reused after re-stamp to the current (hash, version) pair
  - `TestReuseOrRefuseExistingChildContainer_DivergedHashRefuses` — updated: within-version tamper (current version + diverged hash) still refuses with `ErrCellSpecHashDrift`
  - `TestReuseOrRefuseExistingChildContainer_MatchingHashReuses` — updated: current version + matching hash reuses untouched (no re-stamp)
  - `TestSpecHashDomainVersionPinsToPayload` — bump-forces `SpecHashDomainVersion` on any payload field-set change

## Acceptance criteria

- [x] A cell stamped by a prior hash domain starts cleanly under a newer daemon and is re-stamped to the current domain.
- [x] Genuine within-version tampering still refuses with `ErrCellSpecHashDrift`.
- [x] Both root and child guard sites re-stamp on the reuse path.
- [x] `SpecHashDomainVersion` is bump-forced by the domain-pinning test.
- [ ] (Optional) `kuke apply -f --restamp` / `kuke repair` re-stamps without recreate — deferred to a follow-up (see Design notes); the primary self-heal path already resolves the outage.

Closes #1171