### PR TITLE
fix(cni): call CNI DEL unconditionally so stopped cells don't leak iptables masquerade chains

### DIFF
--- a/internal/controller/runner/helpers.go
+++ b/internal/controller/runner/helpers.go
@@ -55,17 +55,19 @@ func (r *Exec) purgeCNIForContainer(containerID, netnsPath, networkName string) 
 			)
 			if err == nil {
 				if err = cniMgr.LoadNetworkConfigList(cniConfigPath); err == nil {
-					// Attempt CNI DEL even if netnsPath is empty (best-effort cleanup)
-					// Some CNI plugins may handle this gracefully
-					if netnsPath != "" {
-						if err = cniMgr.DelContainerFromNetwork(r.ctx, containerID, netnsPath); err == nil {
-							purged = append(purged, "cni-del")
-							r.logger.DebugContext(r.ctx, "called CNI DEL for container", "container", containerID)
-						} else {
-							r.logger.DebugContext(r.ctx, "CNI DEL failed (netns may be invalid)", "container", containerID, "error", err)
-						}
+					// Attempt CNI DEL even when netnsPath is empty. libcni's
+					// DelNetworkList is netns-optional: it reconstructs teardown
+					// (including the bridge plugin's ipMasq iptables chains/rules)
+					// from the cached CNI result, which the cache-removal block
+					// below only clears *after* this DEL has run. A stopped cell
+					// has no containerd task and thus no netns path, so gating DEL
+					// on netnsPath != "" permanently leaked the per-cell CNI-*
+					// masquerade chains on every delete-while-stopped (issue #1174).
+					if err = cniMgr.DelContainerFromNetwork(r.ctx, containerID, netnsPath); err == nil {
+						purged = append(purged, "cni-del")
+						r.logger.DebugContext(r.ctx, "called CNI DEL for container", "container", containerID)
 					} else {
-						r.logger.DebugContext(r.ctx, "skipping CNI DEL (no netns path available)", "container", containerID)
+						r.logger.DebugContext(r.ctx, "CNI DEL failed (netns may be invalid)", "container", containerID, "error", err)
 					}
 				}
 			}

--- a/internal/controller/runner/helpers_test.go
+++ b/internal/controller/runner/helpers_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -303,5 +304,62 @@ func TestPurgeCNIForContainer_RemovesOnlyMatchingIPAMFile(t *testing.T) {
 		if remaining[i] != want[i] {
 			t.Fatalf("remaining files = %v, want %v", remaining, want)
 		}
+	}
+}
+
+// TestPurgeCNIForContainer_CallsDelWithEmptyNetns is the regression guard for
+// issue #1174: deleting a cell whose containerd task was already stopped left
+// netnsPath == "", and the old `if netnsPath != ""` gate skipped CNI DEL
+// entirely — permanently leaking the bridge plugin's per-cell CNI-* iptables
+// masquerade chains (88 observed on one host). libcni's DelNetworkList is
+// netns-optional, so DEL must run unconditionally. This test wires a fake CNI
+// plugin that records its invocation and asserts DEL fires even with an empty
+// netnsPath.
+func TestPurgeCNIForContainer_CallsDelWithEmptyNetns(t *testing.T) {
+	const (
+		networkName = "default-myspace"
+		containerID = "cid-100"
+	)
+
+	binDir := t.TempDir()
+	confDir := t.TempDir()
+	cacheDir := t.TempDir()
+
+	// Fake CNI plugin: records each invocation's CNI_COMMAND to a marker file
+	// and exits 0. libcni execs it by the conflist's plugin "type".
+	markerPath := filepath.Join(t.TempDir(), "del-calls")
+	pluginScript := "#!/bin/sh\nprintf '%s\\n' \"$CNI_COMMAND\" >> \"" + markerPath + "\"\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "recorddel"), []byte(pluginScript), 0o755); err != nil { //nolint:gosec // test fixture plugin must be executable
+		t.Fatalf("write fake plugin: %v", err)
+	}
+
+	// cniVersion 0.4.0+ makes a DEL cache miss non-fatal (libcni nils the
+	// cached result and still execs the plugin), so no cache seeding is needed.
+	conflist := `{
+  "cniVersion": "0.4.0",
+  "name": "` + networkName + `",
+  "plugins": [ { "type": "recorddel" } ]
+}`
+	if err := os.WriteFile(filepath.Join(confDir, networkName+".conflist"), []byte(conflist), 0o644); err != nil { //nolint:gosec // test fixture conflist
+		t.Fatalf("write conflist: %v", err)
+	}
+
+	r := &Exec{
+		ctx:     context.Background(),
+		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cniConf: &cni.Conf{CniConfigDir: confDir, CniBinDir: binDir, CniCacheDir: cacheDir},
+	}
+
+	// Empty netnsPath: the already-stopped-task delete path that used to skip DEL.
+	if err := r.purgeCNIForContainer(containerID, "", networkName); err != nil {
+		t.Fatalf("purgeCNIForContainer returned error: %v", err)
+	}
+
+	calls, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("CNI DEL was not invoked with empty netns (marker file absent): %v", err)
+	}
+	if !strings.Contains(string(calls), "DEL") {
+		t.Fatalf("expected a DEL invocation recorded, got %q", string(calls))
 	}
 }


### PR DESCRIPTION
## Summary

- `kuke delete cell` permanently leaked the bridge plugin's per-cell `CNI-*` iptables masquerade chains/rules whenever the cell's containerd task was **already stopped** at delete time (88 orphaned chains / 272 rules observed on one host — issue #1174).
- Root cause: `purgeCNIForContainer` (`internal/controller/runner/helpers.go`) guarded the CNI DEL call behind `if netnsPath != ""`. A stopped cell has no task → `getContainerNetnsPath` returns `""` → DEL was skipped, even though the in-code comment said "Attempt CNI DEL even if netnsPath is empty". The ipMasq iptables chains are only removed by a CNI DEL, so they leaked with no recovery path; worse, the function then cleared the CNI result-cache entry the next DEL would have needed.
- Fix (issue's suggested fix #1): call `cniMgr.DelContainerFromNetwork(ctx, containerID, netnsPath)` **unconditionally**. libcni's `DelNetworkList` is netns-optional — it reconstructs teardown (including the bridge plugin's iptables rules) from the cached result, so an empty-netns DEL is both safe and the correct cleanup. The existing call ordering already runs DEL **before** the cache-removal block, satisfying suggested-fix #2; the new comment documents why that ordering must be preserved.

This also fixes the analogous root-container teardown sites that already passed `netnsPath == ""` into `purgeCNIForContainer` (e.g. `delete_cell.go:179`), which were leaking for the same reason.

## Scope notes

- Suggested-fix #3 (a teardown-time sweep that reaps `CNI-*` chains whose POSTROUTING comment references an unknown cell ID, as a backstop for already-leaked hosts and non-cache-cleaning plugins) is a "Consider" item with materially larger blast radius (host-wide iptables enumeration + deletion). Deferred as out-of-scope for this minimal-risk fix; the issue's "Cleanup for already-affected hosts" note already calls for out-of-band reaping of pre-existing leaks. Recommend PM file a follow-up if the backstop sweep is wanted.

## Test plan

- [x] `make test` (full CI suite: `test-root` + `test-kukebuild`) — EXIT=0
- [x] `go test ./internal/controller/runner/ -run TestPurgeCNIForContainer -v` — both pass, including the new `TestPurgeCNIForContainer_CallsDelWithEmptyNetns` regression guard (fake CNI plugin records its DEL invocation; asserts DEL fires with an empty netnsPath — fails under the old guard)
- [x] `go vet ./internal/controller/runner/ ./internal/cni/` — clean

Closes #1174