### PR TITLE
fix(delete): sweep orphan containers/snapshots/IPAM when cell metadata is already gone

### DIFF
--- a/internal/controller/runner/delete_cell.go
+++ b/internal/controller/runner/delete_cell.go
@@ -61,8 +61,20 @@ func (r *Exec) deleteCellLocked(cell intmodel.Cell) error {
 	internalCell, err := r.GetCell(cell)
 	if err != nil {
 		if errors.Is(err, errdefs.ErrCellNotFound) {
-			// Idempotent: cell doesn't exist, consider it deleted
-			return nil
+			// Idempotent at the host-resource level, not just metadata
+			// (issue #1175). The cell document is gone, but its containerd
+			// container, active overlay snapshot, and CNI/IPAM reservation
+			// can still be orphaned on the host — e.g. when a
+			// non-deleteCellLocked path (stack/space teardown, daemon reset,
+			// team teardown) removed metadata without per-cell teardown, or a
+			// prior deleteCellLocked partially progressed. A bare `return nil`
+			// here used to declare success and leak those resources
+			// permanently (surviving containerd ID blocks re-init, Active
+			// snapshot pins disk, IPAM reservation exhausts the subnet). The
+			// deterministic containerd ID prefix and network name are pure
+			// functions of the request, so sweep any survivors before
+			// returning.
+			return r.sweepOrphansForMissingCell(cell)
 		}
 		return fmt.Errorf("%w: %w", errdefs.ErrGetCell, err)
 	}
@@ -139,45 +151,13 @@ func (r *Exec) deleteCellLocked(cell intmodel.Cell) error {
 		}
 	}
 
-	// Root container.
-	rootContainerID, err := naming.BuildRootContainerdID(cellSpaceName, cellStackName, cellID)
-	if err != nil {
-		return fmt.Errorf("failed to build root container containerd ID: %w", err)
-	}
-	if delErr := r.stopAndDeleteContainer(namespace, rootContainerID, networkName, true); delErr != nil {
-		deleteErrors = append(deleteErrors,
-			fmt.Errorf("delete root container %q: %w", rootContainerID, delErr))
-	}
-
-	// Belt-and-suspenders: enumerate every containerd container in the realm
-	// namespace whose ID matches `<space>_<stack>_<cell>_*` and tear it down
-	// too. Catches the partial-init case where the cell spec was persisted
-	// with an empty ContainerdID, and the rare race where a non-NotFound
-	// DeleteContainer error above leaves a survivor we then mop up here.
-	namePrefix := fmt.Sprintf("%s_%s_%s_", cellSpaceName, cellStackName, cellID)
-	orphans, scanErr := r.findOrphanContainerIDs(namespace, namePrefix)
-	if scanErr != nil {
-		deleteErrors = append(deleteErrors,
-			fmt.Errorf("scan orphan containers with prefix %q: %w", namePrefix, scanErr))
-	}
-	for _, orphanID := range orphans {
-		r.logger.InfoContext(
-			r.ctx,
-			"reconciling orphan container left by partial init or prior failed delete",
-			"container", orphanID,
-			"namespace", namespace,
-		)
-		if delErr := r.stopAndDeleteContainer(namespace, orphanID, networkName, true); delErr != nil {
-			deleteErrors = append(deleteErrors,
-				fmt.Errorf("delete orphan container %q: %w", orphanID, delErr))
-		}
-	}
-
-	// Always run comprehensive CNI cleanup after root container deletion as a safety net.
-	// This ensures IPAM allocations are cleaned up even if earlier cleanup succeeded or failed.
-	if networkName != "" {
-		_ = r.purgeCNIForContainer(rootContainerID, "", networkName)
-	}
+	// Root container, name-prefix orphan scan, and the post-delete CNI/IPAM
+	// purge — all derivable from (space, stack, cellID, networkName), so the
+	// same sweep also runs on the metadata-absent idempotent path above.
+	deleteErrors = append(
+		deleteErrors,
+		r.sweepCellContainerResources(namespace, cellSpaceName, cellStackName, cellID, networkName)...,
+	)
 
 	// If any container-tier failure remains, refuse to remove the cell
 	// cgroup or metadata: leaving the metadata file in place is what makes
@@ -234,6 +214,113 @@ func (r *Exec) deleteCellLocked(cell intmodel.Cell) error {
 	}
 
 	return nil
+}
+
+// sweepOrphansForMissingCell runs the container/CNI/IPAM orphan sweep for a
+// cell whose metadata is already gone (GetCell returned ErrCellNotFound),
+// using only request-derived identifiers. It returns nil when the host is
+// clean (or when the realm itself is gone, since its containerd namespace —
+// and therefore any orphan it could have held — went with it) and a wrapped
+// ErrDeleteCell when any orphan teardown failed, so the idempotent delete path
+// is genuinely idempotent at the host-resource level (issue #1175).
+func (r *Exec) sweepOrphansForMissingCell(cell intmodel.Cell) error {
+	if err := r.ensureClientConnected(); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrConnectContainerd, err)
+	}
+
+	realmName := strings.TrimSpace(cell.Spec.RealmName)
+	spaceName := strings.TrimSpace(cell.Spec.SpaceName)
+	stackName := strings.TrimSpace(cell.Spec.StackName)
+	// The cell document is gone, so fall back to the request name for the ID
+	// the same way the metadata path falls back to internalCell.Metadata.Name.
+	cellID := strings.TrimSpace(cell.Spec.ID)
+	if cellID == "" {
+		cellID = strings.TrimSpace(cell.Metadata.Name)
+	}
+
+	lookupRealm := intmodel.Realm{Metadata: intmodel.RealmMetadata{Name: realmName}}
+	internalRealm, err := r.GetRealm(lookupRealm)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrRealmNotFound) {
+			// No realm means no containerd namespace, hence no orphans to
+			// sweep — preserve the historical idempotent success.
+			return nil
+		}
+		return fmt.Errorf("failed to get realm: %w", err)
+	}
+	namespace := internalRealm.Spec.Namespace
+
+	// Resolve the network name deterministically from realm+space (issue #685);
+	// it's a pure function of (realm, space) and needs no cell metadata.
+	networkName := r.buildRootCNINetworkName(realmName, spaceName)
+
+	if deleteErrors := r.sweepCellContainerResources(
+		namespace, spaceName, stackName, cellID, networkName,
+	); len(deleteErrors) > 0 {
+		return fmt.Errorf("%w: %w", errdefs.ErrDeleteCell, errors.Join(deleteErrors...))
+	}
+	return nil
+}
+
+// sweepCellContainerResources tears down the root container, scans for and
+// reaps any orphan containerd containers matching the cell's deterministic
+// `<space>_<stack>_<cell>_*` ID prefix, and runs the post-delete CNI/IPAM
+// purge keyed on the root container ID. It returns the aggregated set of
+// container-tier failures (nil when the host is clean). Every input is a pure
+// function of the delete request, so this runs identically whether or not the
+// cell metadata still exists — that's what lets the ErrCellNotFound idempotent
+// path mop up orphans instead of declaring success on a still-dirty host
+// (issue #1175).
+func (r *Exec) sweepCellContainerResources(
+	namespace, spaceName, stackName, cellID, networkName string,
+) []error {
+	var deleteErrors []error
+
+	// Root container.
+	rootContainerID, err := naming.BuildRootContainerdID(spaceName, stackName, cellID)
+	if err != nil {
+		// Inputs are validated non-empty upstream, so this is effectively
+		// unreachable; aggregate rather than abort so the orphan scan below
+		// still runs and the caller still preserves any cell metadata.
+		deleteErrors = append(deleteErrors,
+			fmt.Errorf("build root container containerd ID: %w", err))
+	} else if delErr := r.stopAndDeleteContainer(namespace, rootContainerID, networkName, true); delErr != nil {
+		deleteErrors = append(deleteErrors,
+			fmt.Errorf("delete root container %q: %w", rootContainerID, delErr))
+	}
+
+	// Belt-and-suspenders: enumerate every containerd container in the realm
+	// namespace whose ID matches `<space>_<stack>_<cell>_*` and tear it down
+	// too. Catches the partial-init case where the cell spec was persisted
+	// with an empty ContainerdID, the rare race where a non-NotFound
+	// DeleteContainer error above leaves a survivor, and (issue #1175) the
+	// orphans left when metadata was removed without per-cell teardown.
+	namePrefix := fmt.Sprintf("%s_%s_%s_", spaceName, stackName, cellID)
+	orphans, scanErr := r.findOrphanContainerIDs(namespace, namePrefix)
+	if scanErr != nil {
+		deleteErrors = append(deleteErrors,
+			fmt.Errorf("scan orphan containers with prefix %q: %w", namePrefix, scanErr))
+	}
+	for _, orphanID := range orphans {
+		r.logger.InfoContext(
+			r.ctx,
+			"reconciling orphan container left by partial init or prior failed delete",
+			"container", orphanID,
+			"namespace", namespace,
+		)
+		if delErr := r.stopAndDeleteContainer(namespace, orphanID, networkName, true); delErr != nil {
+			deleteErrors = append(deleteErrors,
+				fmt.Errorf("delete orphan container %q: %w", orphanID, delErr))
+		}
+	}
+
+	// Always run comprehensive CNI cleanup after root container deletion as a safety net.
+	// This ensures IPAM allocations are cleaned up even if earlier cleanup succeeded or failed.
+	if networkName != "" && rootContainerID != "" {
+		_ = r.purgeCNIForContainer(rootContainerID, "", networkName)
+	}
+
+	return deleteErrors
 }
 
 // stopAndDeleteContainer purges CNI state, stops the task (best effort), then

--- a/internal/controller/runner/delete_cell_test.go
+++ b/internal/controller/runner/delete_cell_test.go
@@ -404,6 +404,105 @@ func TestDeleteCell_ReconcilesOrphanFromEmptyContainerdID(t *testing.T) {
 	}
 }
 
+// TestDeleteCell_SweepsOrphansWhenMetadataAbsent is the regression guard for
+// issue #1175. When the cell metadata is already gone (GetCell returns
+// ErrCellNotFound), DeleteCell used to bare-`return nil` and declare success
+// while the cell's containerd container, Active snapshot, and IPAM reservation
+// survived on the host. The idempotent path must now run the name-prefix
+// orphan scan and tear down any survivors using request-derived identifiers.
+func TestDeleteCell_SweepsOrphansWhenMetadataAbsent(t *testing.T) {
+	realm, space, stack, cellName := "default", "default", "default", "kukeon-pr-3"
+	rootID := space + "_" + stack + "_" + cellName + "_root"
+	workID := space + "_" + stack + "_" + cellName + "_work"
+
+	var deletedIDs []string
+	fake := &deleteCellFakeClient{
+		deleteContainerFn: func(_, id string, _ ctr.ContainerDeleteOptions) error {
+			deletedIDs = append(deletedIDs, id)
+			return nil
+		},
+		listContainersFn: func(string, ...string) ([]containerd.Container, error) {
+			return []containerd.Container{
+				stubContainer{id: rootID},
+				stubContainer{id: workID},
+			}, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+	// Deliberately do NOT seed the cell metadata — GetCell returns
+	// ErrCellNotFound, the exact entry point the fix targets.
+
+	if err := r.DeleteCell(buildDeleteCellRequest(realm, space, stack, cellName)); err != nil {
+		t.Fatalf("DeleteCell: unexpected error on metadata-absent path: %v", err)
+	}
+
+	for _, want := range []string{rootID, workID} {
+		var found bool
+		for _, id := range deletedIDs {
+			if id == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("orphan container %q was not swept on the metadata-absent path; DeleteContainer called for %v", want, deletedIDs)
+		}
+	}
+}
+
+// TestDeleteCell_MetadataAbsentSurfacesSweepFailure locks the host-resource
+// idempotency contract (issue #1175): when an orphan teardown fails on the
+// metadata-absent path, DeleteCell must surface a wrapped ErrDeleteCell rather
+// than silently declare success, so an operator (or the next reset) sees the
+// host is still dirty.
+func TestDeleteCell_MetadataAbsentSurfacesSweepFailure(t *testing.T) {
+	realm, space, stack, cellName := "default", "default", "default", "kukeon-dev-2"
+	rootID := space + "_" + stack + "_" + cellName + "_root"
+
+	fake := &deleteCellFakeClient{
+		deleteContainerFn: func(_, id string, _ ctr.ContainerDeleteOptions) error {
+			if id == rootID {
+				return errors.New("containerd busy")
+			}
+			return nil
+		},
+		listContainersFn: func(string, ...string) ([]containerd.Container, error) {
+			return []containerd.Container{stubContainer{id: rootID}}, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realm)
+
+	err := r.DeleteCell(buildDeleteCellRequest(realm, space, stack, cellName))
+	if err == nil {
+		t.Fatal("DeleteCell: want non-nil error when an orphan teardown fails on the metadata-absent path, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrDeleteCell) {
+		t.Errorf("metadata-absent sweep failure must wrap ErrDeleteCell; got %v", err)
+	}
+}
+
+// TestDeleteCell_MetadataAndRealmAbsentIsIdempotent confirms the historical
+// idempotent success is preserved when both the cell and its realm are gone:
+// no realm means no containerd namespace, hence nothing to sweep (issue #1175).
+func TestDeleteCell_MetadataAndRealmAbsentIsIdempotent(t *testing.T) {
+	realm, space, stack, cellName := "default", "default", "default", "kukeon-pr-3"
+
+	fake := &deleteCellFakeClient{
+		listContainersFn: func(string, ...string) ([]containerd.Container, error) {
+			t.Fatal("ListContainers must not run when the realm is absent")
+			return nil, nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	// Seed neither realm nor cell metadata.
+
+	if err := r.DeleteCell(buildDeleteCellRequest(realm, space, stack, cellName)); err != nil {
+		t.Fatalf("DeleteCell: want nil (idempotent) when both cell and realm are gone, got %v", err)
+	}
+}
+
 // TestFindOrphanContainerIDs locks the prefix-filter behavior the orphan
 // scan relies on. The prefix is `<space>_<stack>_<cell>_` and must match
 // both `_root` and `_<workload>` IDs while excluding unrelated containers


### PR DESCRIPTION
## Summary

- `kuke delete cell`'s idempotent path short-circuited at the top of `deleteCellLocked` (`internal/controller/runner/delete_cell.go`): when `GetCell` returned `ErrCellNotFound`, it `return nil`-ed **before** any of the containerd/snapshot/CNI/IPAM safety nets ran. So a cell whose metadata was removed (by a non-`deleteCellLocked` path — stack/space teardown, `daemon reset`, team teardown — or a partially-progressed prior delete) while its containerd container / Active overlay snapshot / IPAM reservation still existed would be declared "deleted" with those host resources orphaned **permanently**. This is the latent defect behind #1175 (surviving container blocks re-init, Active snapshot pins disk, IPAM reservation leaks the `/24`).
- The fix makes the idempotent path idempotent at the **host-resource** level, not just the metadata level: the deterministic containerd ID prefix (`<space>_<stack>_<cell>_`) and CNI network name are pure functions of the delete request, so the orphan sweep can run with no metadata at all.

### What changed
- New `sweepOrphansForMissingCell(cell)` runs on the `ErrCellNotFound` branch: resolves namespace + network name + cellID from the **request** (cellID falls back to `Metadata.Name` exactly as the metadata path falls back to `internalCell.Metadata.Name`), then runs the shared sweep. Returns `nil` on a clean host; surfaces a wrapped `ErrDeleteCell` if any orphan teardown fails (so the host-dirty state isn't silently swallowed).
- If the **realm** is also gone (`GetRealm` → `ErrRealmNotFound`), returns `nil`: no realm means no containerd namespace, hence nothing to sweep — preserving the historical idempotent success.
- Extracted the root-container teardown + name-prefix orphan scan + post-delete CNI/IPAM purge (previously inline in the happy path) into `sweepCellContainerResources(...)`, now shared by both the happy path and the metadata-absent path — no copy-paste of the ~35-line sweep.

### Non-obvious call (documented for reviewer pushback)
- The extracted helper turns the happy path's `naming.BuildRootContainerdID` failure from an early `return` into an aggregated `deleteError`. That error is effectively unreachable (inputs are validated non-empty upstream), and aggregating is strictly better — it still surfaces an error (cell metadata preserved for retry) **and** still runs the orphan scan instead of aborting before it. Flagging in case the reviewer prefers preserving the early-return.

## Test plan
- [x] `make test` (full CI target, `GOWORK=off`) — green
- [x] `go build` / `go vet` on `internal/controller/runner` — clean
- [x] New unit tests in `delete_cell_test.go`, all passing:
  - `TestDeleteCell_SweepsOrphansWhenMetadataAbsent` — orphan root+work containers are torn down on the `ErrCellNotFound` path (reproduces the #1175 `kukeon-pr-3` survival)
  - `TestDeleteCell_MetadataAbsentSurfacesSweepFailure` — a failed orphan teardown surfaces a wrapped `ErrDeleteCell` instead of silent success
  - `TestDeleteCell_MetadataAndRealmAbsentIsIdempotent` — both cell and realm gone returns `nil` and never calls `ListContainers`
- [x] `make dev-init` end-to-end smoke (touches daemon-read code) — exit 0; daemon-parity check shows both `kuke get realms` views identical (`default`/`kuke-system` both `Ready`); kuke attach smoke exited cleanly; parent attach plumbing intact post-flight

Closes #1175