### PR TITLE
fix(image): add iproute2 to kukeond image so CNI bridge teardown finds ip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,12 @@ ARG TARGETARCH
 # iptables: required by the bridge plugin's ipMasq rules and by
 # internal/netpolicy/enforcer's egress chains, which both shell out to
 # iptables in-process from the daemon container.
+# iproute2: provides `ip`, which internal/cni/bridge.go's DeleteBridge shells
+# out to (`ip link delete <bridge> type bridge`) on space/realm/network
+# teardown. Without it, daemon-driven CNI teardown fails and leaks the host
+# bridge (issue #1179).
 RUN DEBIAN_FRONTEND=noninteractive apt update \
- && apt install -y procps ca-certificates iptables \
+ && apt install -y procps ca-certificates iptables iproute2 \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=cni-plugins /opt/cni/bin /opt/cni/bin


### PR DESCRIPTION
## Summary

- The `kukeond` image shipped `iptables` but not `iproute2`, so `ip` was absent from `$PATH` inside the daemon container.
- `internal/cni/bridge.go:48`'s `DeleteBridge` shells out to `ip link delete <bridge> type bridge` on every daemon-driven CNI teardown (`teardownSpaceCNI` / `teardownRealmCNI`). With `ip` missing, teardown failed with `exec: "ip": executable file not found in $PATH` and leaked the host bridge — surfaced only as a best-effort WARN (`bridge.go:41`), so no operator-visible signal.
- Fix: add `iproute2` to the existing `apt install` line in the final `debian:bookworm-slim` stage of the `Dockerfile`, alongside the `iptables` that #95 added on the attach path. `iproute2` is a standard bookworm main-repo package providing `/usr/sbin/ip`; no new `RUN` layer, just one package added to the existing list.

## Implementation notes

- Took the issue's primary suggested fix (add the package) rather than the *optional* netlink rewrite (`vishvananda/netlink` `LinkDel`). The netlink rewrite is a larger, separable change touching production Go and its own test surface; the package add is the lower-blast-radius fix that resolves the AC. The netlink hardening remains a reasonable follow-up if the project wants to drop the runtime `ip`/`iptables` binary dependencies entirely.
- The e2e harness (`KUKEON_E2E_IMAGE`) builds from this same root `Dockerfile`, so no separate image needed updating. Confirmed via `git grep` that `bridge.go:48` is the only production `ip` exec and this is the only kukeond image build.

## Test plan

- [x] `make test` (test-root + test-kukebuild) — passes (Dockerfile-only change; Go suites unaffected, run to satisfy the named CI target).
- [ ] Image-build smoke (`make dev-init` / `make e2e` rebuilding the kukeond image and probing `command -v ip` in the running daemon container) — not run: requires root + standalone containerd + network egress for the image build, which this dev host can't host without disrupting unrelated state. The reviewer's clean-host environment is where the image-build + in-container `ip` probe should run. The change itself adds a standard bookworm package to an existing apt install line.

Closes #1179