### PR TITLE
docs(cli-use-cases): replace stale Status snapshot TODO with kuke status use case

### DIFF
--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -474,9 +474,24 @@ kuke <subcommand> --help
 
 **Invariants.** Exit code 0 in all three forms. No subcommand prints the help text rather than failing — this is intentional so a bare `kuke` is discoverable.
 
-### Status snapshot — TODO (#202)
+### Status snapshot (`kuke status`)
 
-A single command that prints the daemon's view of every realm/space/stack/cell in one screen will land with issue #202. Until then, compose `kuke get realms && kuke get spaces && kuke get stacks && kuke get cells` for the same picture, or `kuke daemon logs -f` for live activity.
+**Intent.** Run a single post-`kuke init` health walk that covers daemon liveness, host pre-flight, run-dir state, per-realm storage footprint, and the daemon-vs-in-process parity check across every resource kind — the consolidated equivalent of the manual `kuke get realms` vs `kuke get realms --no-daemon` diff ritual. Full reference: [`docs/site/cli/kuke-status.md`](site/cli/kuke-status.md).
+
+**Sequence.**
+
+```bash
+sudo kuke status                                 # human-readable health table
+sudo kuke status --json                          # machine-readable shape for CI
+sudo kuke status --verbose                       # remediation hint on OK rows too
+```
+
+**Invariants.**
+
+- Exit code 0 when every check is OK (or OK mixed with WARN); non-zero when any row is FAIL. The structured report on stdout is the operator-visible failure marker; the non-zero exit is the CI-visible one.
+- Sections, in fixed order: `DAEMON` (socket dialable, RPC round-trip, version), `HOST` (containerd reachable, cgroup-v2 mounted with required controllers delegated, CNI plugins under `/opt/cni/bin`), `STATE` (no orphan run-dir sockets, no residual containerd namespaces), `STORAGE` (per-realm snapshot / lease / content-blob counts + summed bytes), `PARITY` (daemon view matches in-process view for `realm`, `space`, `stack`, `cell`, `container`, `secret`, `blueprint`, `config`).
+- The `PARITY` section is the cross-kind generalization of the two-line `kuke get realms` daemon-parity diff the `make dev-init` smoke pins — a divergence on any kind is the same regression class.
+- `--json` emits the `Report` shape (top-level `ok` bool plus a flat `checks` array; each row carries `section`, `name`, `status` as the `"OK"`/`"WARN"`/`"FAIL"` label, `detail`, optional `remediation`, and on storage rows an optional `storage` payload). `--verbose` prints the remediation hint on OK rows too, not just WARN/FAIL.
 
 ### `--no-daemon` future
 


### PR DESCRIPTION
## Summary

- `docs/cli-use-cases.md` still carried `### Status snapshot — TODO (#202)`, claiming a future command. `kuke status` shipped with a full reference page (`docs/site/cli/kuke-status.md`, #940), so the TODO marker was stale — and it made `/test-cli` skip the section as "documented as unsupported", leaving the doc's status invariants unexercised.
- Replaces the TODO with a real `### Status snapshot (\`kuke status\`)` subsection following the doc's Intent / Sequence / Invariants convention, sourced from the reference page: the post-init health walk intent, the command sequence, exit-code contract, the fixed section list (DAEMON/HOST/STATE/STORAGE/PARITY), the `PARITY` daemon-parity tie-in, and the `--json` / `--verbose` shapes.

## Verbatim-wording correction (heads-up posted on the issue)

The issue's Proposal listed `sudo kuke status -o json`, but `kuke status` has **no** `-o`/`--output` flag — the JSON form is a boolean `--json` (`cmd/kuke/status/status.go:217`, `cmd.Flags().BoolVar(&jsonOut, "json", ...)`), matching the reference page. `-o {yaml,json}` is `kuke get`'s pattern, not `status`'s. Verified against the built binary: `kuke status --help` lists only `--json` and `--verbose` (plus global flags), and `kuke status -o json` exits non-zero. Since AC item 2 requires the commands to run verbatim, the Sequence uses `sudo kuke status --json`. Flagged on the issue (comment) so the reviewer can push back if `-o json` was intended as a future addition.

## Out of scope

- The healthy-host FAIL/WARN behavior of `kuke status` (separate issues, per the issue's Out of scope).

## Test plan

- [x] `make kuke` — built the binary to verify the documented commands parse.
- [x] `kuke status --help` — confirms `--json` and `--verbose` are the real flags; `kuke status -o json` exits non-zero (no `-o`/`--output` flag exists).
- [x] `git grep "TODO (#202)" docs/cli-use-cases.md` — marker is gone (AC item 1).
- [x] Relative link `[...](site/cli/kuke-status.md)` resolves to the existing `docs/site/cli/kuke-status.md`.
- [x] `pre-commit run --files docs/cli-use-cases.md` — the new section is prettier-clean (prettier touched only pre-existing unrelated lines, which were intentionally left out of this diff per the no-unrelated-cleanups rule).
- [ ] `make test` / `make e2e` — not run; markdown-only change, no Go code touched. CI runs Go tests + e2e only (no prettier/docs gate); mkdocs builds `docs/site/**` only and this file is at `docs/` root.

Closes #1190