### PR TITLE
docs(cli-use-cases): require a source flag on the create cell hierarchy example

### DIFF
--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -188,7 +188,7 @@ sudo kuke create realm myrealm
 sudo kuke create realm myrealm --namespace custom.kukeon.io
 sudo kuke create space myspace --realm myrealm
 sudo kuke create stack mystack --realm myrealm --space myspace
-sudo kuke create cell mycell --realm myrealm --space myspace --stack mystack
+sudo kuke create cell mycell --from-blueprint <bp> --realm myrealm --space myspace --stack mystack
 ```
 
 **Invariants.**
@@ -196,6 +196,7 @@ sudo kuke create cell mycell --realm myrealm --space myspace --stack mystack
 - Exit code 0 on success. Each phase (metadata, containerd namespace, cgroup) reports `created` or `already existed`.
 - Idempotent: re-running with the same arguments succeeds and reports `already existed` on every phase. The CLI does not re-create or mutate an existing object.
 - `kuke create realm myrealm` does **not** create a default space/stack inside the new realm; the operator builds the inner hierarchy explicitly. (Only `kuke init` creates the `default/default/default` triple in the `default` realm.)
+- Unlike realms/spaces/stacks, **cells require a source**: `kuke create cell` takes exactly one of `--from-blueprint`/`--from-config`/`--clone` (the bare scaffold form is retired). Omitting all three exits non-zero with `kuke create cell requires --from-blueprint, --from-config, or --clone (use 'kuke apply -f <file>' for a full manifest)`.
 - A child resource without its parent (e.g. `kuke create space x --realm does-not-exist`) errors with a parent-not-found message; exit code non-zero.
 
 ### Purging a realm / space / stack / cell


### PR DESCRIPTION
## Summary
- The § *Creating a custom realm / space / stack* Sequence block showed the retired bare `kuke create cell mycell …` form. Since the 1:N model rework, `kuke create cell` requires exactly one of `--from-blueprint`/`--from-config`/`--clone`, and the bare invocation exits non-zero (verified against `cmd/kuke/create/cell/cell.go:237-241`).
- Updated the example to `--from-blueprint <bp>` (the issue's proposed form) and added an invariant noting cells require a source — unlike realms/spaces/stacks — quoting the exact missing-source error verbatim from the code.

## Test plan
- [x] Docs-only edit; no executable code, tests, or behavior text changed.
- [x] Error string in the new invariant matches `cmd/kuke/create/cell/cell.go:237-241` verbatim.
- [x] `git grep "create cell" docs/cli-use-cases.md` — remaining hits are prose command-name mentions, not bare-invocation examples.
- [ ] AC#1 ("every command runs exit-0 verbatim") — the Sequence block uses scaffold placeholders (`myrealm`, `<bp>`, …) throughout, so verbatim exit-0 is not literally runnable; the edit makes the *form* correct (named source flag present) per AC#2 and the section's scaffold-walk intent.

Closes #1188