### PR TITLE
docs(cli-use-cases): update kuke version invariant for client/daemon split

### DIFF
--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -462,7 +462,7 @@ sudo kuke refresh
 kuke version
 ```
 
-**Invariants.** Exit code 0. Prints a single line. Format is the build's resolved version (`vMAJOR.MINOR.PATCH[-<offset>-g<sha>][-dirty]`). Suitable for `kuke version | grep` in CI.
+**Invariants.** Exit code 0 by default (including when the daemon is unreachable). Prints `Client: <version>` on stdout always, and — when the daemon is reachable — `Daemon: <version>` on stdout, each version in the build's resolved format (`vMAJOR.MINOR.PATCH[-<offset>-g<sha>][-dirty]`). When the daemon is unreachable the `Daemon:` line is replaced by a `Warning: daemon unreachable: <err>` on stderr while the `Client:` line still prints. A `Warning: version mismatch (…)` line is emitted on stderr when the two versions differ; passing `--strict` makes a mismatch exit non-zero. `--no-daemon` skips the daemon query and prints only the `Client:` line. Both warnings go to stderr, so `kuke version | grep '^Client:'` is suitable for CI.
 
 ### Top-level help / no-args invocation
 


### PR DESCRIPTION
## Summary

- The `kuke version` invariant in `docs/cli-use-cases.md` (§ Inspection › Version) still claimed "Prints a single line" with a single bare resolved version. That contract is stale: the client/daemon split + mismatch warning (#897/#946) makes `kuke version` print `Client:` / `Daemon:` lines plus a stderr `Warning:` on mismatch.
- Replaced the invariant with wording matching today's contract, verified against `cmd/kuke/version/version.go` and the canonical reference `docs/site/cli/kuke-version.md`.

## Correction to the issue's proposed wording (verbatim-wording check)

The issue's proposed text said, for the daemon-unreachable case, *"the Daemon line then reports the dial failure."* That claim does not match the implementation. Per `cmd/kuke/version/version.go:58,71` (and `docs/site/cli/kuke-version.md:19`):

- On an unreachable daemon there is **no** `Daemon:` line. The command prints `Warning: daemon unreachable: <err>` to **stderr**, the `Client:` line still prints to stdout, and the exit code stays 0.
- `Client:` / `Daemon:` go to **stdout**; both `Warning:` lines (unreachable + mismatch) go to **stderr** — which is what makes `kuke version | grep '^Client:'` work cleanly in CI.
- `--strict` makes a mismatch exit non-zero, and `--no-daemon` prints only the `Client:` line — both bound the "exit code 0" / line-count claims, so the corrected wording mentions them.

Heads-up posted on the issue before coding: https://github.com/eminwux/kukeon/issues/1187#issuecomment-4670579976 (the issue body itself invited pm to adjust the daemon-unreachable phrasing against the real behavior).

## Test plan
- [x] `git grep -n "single line" -- docs/` — no remaining stale "single line" version references.
- [x] Verified corrected wording against `cmd/kuke/version/version.go` and `docs/site/cli/kuke-version.md` (stdout/stderr split, exit codes, `--strict`/`--no-daemon`).
- [x] Confirmed the CI-grep suggestion `kuke version | grep '^Client:'` is valid — `Client:` prints to stdout, warnings to stderr.

Docs-only change (pure markdown, no executable code) → trivial-edit shortcut.

Closes #1187