### PR TITLE
fix(daemon): stop surviving containers before restarting an externally-killed daemon

### DIFF
--- a/cmd/kuke/daemon/start/start.go
+++ b/cmd/kuke/daemon/start/start.go
@@ -129,10 +129,16 @@ func runStart(cmd *cobra.Command, _ []string) error {
 		// refuses on its "has running containers and must first be stopped"
 		// precondition while those survive, so the documented heal — `daemon
 		// start` brings an externally-killed daemon back up — needs the
-		// surviving containers cleaned first. Stop the cell (the same
-		// reconcile the manual `kuke daemon stop` workaround performed) before
-		// starting fresh (#1184).
-		if _, stopErr := client.StopCell(cmd.Context(), doc); stopErr != nil {
+		// surviving containers cleaned first. Route through the same StopPhase
+		// reconcile `kuke daemon stop` runs (stop.go), not a raw StopCell: the
+		// runner's per-container stop errors are logged-and-continue rather
+		// than aggregated, so StopCell can return Stopped=true while a
+		// root/pause task ignores SIGTERM and survives — at which point a bare
+		// StopCell would report success and StartCell would refuse on the very
+		// precondition this heal targets. StopPhase adds the #868
+		// verify-or-escalate-to-KillCell guard and the grace-period→SIGKILL
+		// timeout fallback so a stubborn survivor is actually cleaned (#1184).
+		if stopErr := lifecycle.StopPhase(cmd, client, doc, lifecycle.DefaultTimeout); stopErr != nil {
 			return fmt.Errorf("stop stale kukeond cell: %w", stopErr)
 		}
 	}

--- a/cmd/kuke/daemon/start/start.go
+++ b/cmd/kuke/daemon/start/start.go
@@ -87,6 +87,7 @@ func runStart(cmd *cobra.Command, _ []string) error {
 		return errdefs.ErrHostNotInitialized
 	}
 
+	staleReady := false
 	if lifecycle.IsCellRunning(getRes.Cell) {
 		probe := lifecycle.ResolveReachableProbe(cmd)
 		socketPath := lifecycle.ResolveSocketPath()
@@ -112,6 +113,7 @@ func runStart(cmd *cobra.Command, _ []string) error {
 			"cell", consts.KukeSystemCellName,
 			"realm", consts.KukeSystemRealmName,
 		)
+		staleReady = true
 	}
 
 	// Recreate /run/kukeon (the cell's bind-mount source) if a reboot wiped
@@ -119,6 +121,20 @@ func runStart(cmd *cobra.Command, _ []string) error {
 	// fails with "open /run/kukeon: no such file or directory".
 	if ensureErr := lifecycle.ResolveEnsureSocketDir(cmd)(); ensureErr != nil {
 		return fmt.Errorf("ensure kukeond socket dir: %w", ensureErr)
+	}
+
+	if staleReady {
+		// An external kill only takes down the kukeond process; the cell's
+		// other containers (root/pause) keep running in containerd. StartCell
+		// refuses on its "has running containers and must first be stopped"
+		// precondition while those survive, so the documented heal — `daemon
+		// start` brings an externally-killed daemon back up — needs the
+		// surviving containers cleaned first. Stop the cell (the same
+		// reconcile the manual `kuke daemon stop` workaround performed) before
+		// starting fresh (#1184).
+		if _, stopErr := client.StopCell(cmd.Context(), doc); stopErr != nil {
+			return fmt.Errorf("stop stale kukeond cell: %w", stopErr)
+		}
 	}
 
 	startRes, err := client.StartCell(cmd.Context(), doc)

--- a/cmd/kuke/daemon/start/start_test.go
+++ b/cmd/kuke/daemon/start/start_test.go
@@ -143,30 +143,10 @@ func TestDaemonStart(t *testing.T) {
 			// dial-unix error. New behaviour: log the staleness and fall
 			// through to StartCell so the cell actually comes back up.
 			name: "metadata says Ready but socket is unreachable falls through to StartCell",
-			fake: &fakeClient{
-				getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-					return kukeonv1.GetCellResult{
-						Cell: v1beta1.CellDoc{
-							Status: v1beta1.CellStatus{
-								State: v1beta1.CellStateReady,
-								Containers: []v1beta1.ContainerStatus{
-									{State: v1beta1.ContainerStateReady},
-								},
-							},
-						},
-						MetadataExists: true,
-					}, nil
-				},
-				// Surviving root/pause containers from the killed daemon are
-				// stopped before the restart so StartCell's running-containers
-				// precondition does not refuse (#1184).
-				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
-					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
-				},
-				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
-					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
-				},
-			},
+			// Surviving root/pause containers from the killed daemon are
+			// reconciled through StopPhase before the restart so StartCell's
+			// running-containers precondition does not refuse (#1184).
+			fake:       newStaleReadyFake(),
 			probe:      fixedProbe(false),
 			wantOutput: "metadata reports Ready but socket",
 		},
@@ -249,22 +229,14 @@ func TestDaemonStart(t *testing.T) {
 // survivors) before StartCell, and only after printing the divergence notice.
 func TestDaemonStart_StaleReadyStopsRunningContainersBeforeStart(t *testing.T) {
 	var calls []string
+	running := true
 	fake := &fakeClient{
 		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
-			return kukeonv1.GetCellResult{
-				Cell: v1beta1.CellDoc{
-					Status: v1beta1.CellStatus{
-						State: v1beta1.CellStateReady,
-						Containers: []v1beta1.ContainerStatus{
-							{State: v1beta1.ContainerStateReady},
-						},
-					},
-				},
-				MetadataExists: true,
-			}, nil
+			return runningOrStopped(running), nil
 		},
 		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
 			calls = append(calls, "stop")
+			running = false
 			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
 		},
 		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
@@ -284,6 +256,73 @@ func TestDaemonStart_StaleReadyStopsRunningContainersBeforeStart(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), `kukeond started (cell "kukeond" in realm "kuke-system")`) {
 		t.Errorf("missing started confirmation\nGot:\n%s", buf.String())
+	}
+}
+
+// TestDaemonStart_StaleReadyEscalatesWhenStopReportsSuccessButTaskSurvives is
+// the path the PR review flagged: routing the stale-Ready heal through
+// StopPhase (not a raw StopCell) means a StopCell that returns Stopped=true
+// while a root/pause task keeps running — the runner's per-container stop
+// errors are logged-and-continue, not aggregated (#868) — is caught by
+// StopPhase's post-stop verify, which escalates to KillCell before StartCell
+// runs. A raw StopCell would have reported success and left StartCell to refuse
+// on the same running-containers precondition this heal targets.
+func TestDaemonStart_StaleReadyEscalatesWhenStopReportsSuccessButTaskSurvives(t *testing.T) {
+	var calls []string
+	running := true
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return runningOrStopped(running), nil
+		},
+		// StopCell claims success but the task survives — `running` stays true,
+		// so StopPhase's post-stop verify still sees a Ready container.
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			calls = append(calls, "stop")
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		// The escalation actually clears the survivor.
+		killCellFn: func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+			calls = append(calls, "kill")
+			running = false
+			return kukeonv1.KillCellResult{Cell: doc, Killed: true}, nil
+		},
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			calls = append(calls, "start")
+			return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+		},
+	}
+
+	buf := runStartWithFake(t, fake, fixedProbe(false))
+
+	if want := []string{"stop", "kill", "start"}; len(calls) != len(want) ||
+		calls[0] != want[0] || calls[1] != want[1] || calls[2] != want[2] {
+		t.Fatalf("call order: want %v, got %v", want, calls)
+	}
+	if !strings.Contains(buf.String(), "metadata reports Ready but socket") {
+		t.Errorf("missing stale-Ready divergence notice\nGot:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `kukeond started (cell "kukeond" in realm "kuke-system")`) {
+		t.Errorf("missing started confirmation\nGot:\n%s", buf.String())
+	}
+}
+
+// newStaleReadyFake builds a fakeClient for the stale-Ready heal happy path:
+// GetCell reports a Ready cell with a running container until StopCell cleans
+// it, after which GetCell reports Stopped so StopPhase's post-stop verify
+// (#868) passes without escalating to KillCell. StartCell then succeeds.
+func newStaleReadyFake() *fakeClient {
+	running := true
+	return &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return runningOrStopped(running), nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			running = false
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+		},
 	}
 }
 
@@ -423,6 +462,7 @@ type fakeClient struct {
 	getCellFn   func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
 	startCellFn func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
 	stopCellFn  func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
+	killCellFn  func(doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error)
 }
 
 func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
@@ -444,4 +484,38 @@ func (f *fakeClient) StopCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.
 		return kukeonv1.StopCellResult{}, errors.New("unexpected StopCell call")
 	}
 	return f.stopCellFn(doc)
+}
+
+func (f *fakeClient) KillCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.KillCellResult, error) {
+	if f.killCellFn == nil {
+		return kukeonv1.KillCellResult{}, errors.New("unexpected KillCell call")
+	}
+	return f.killCellFn(doc)
+}
+
+// runningOrStopped builds the GetCellResult the stale-Ready fakes return: a
+// Ready cell with a running container while `running`, otherwise a Stopped
+// cell with none. StopPhase's post-stop verify (#868) re-reads the cell after
+// StopCell, so the stop/kill fakes flip `running` to drive whether that verify
+// passes cleanly or escalates to KillCell.
+func runningOrStopped(running bool) kukeonv1.GetCellResult {
+	if running {
+		return kukeonv1.GetCellResult{
+			Cell: v1beta1.CellDoc{
+				Status: v1beta1.CellStatus{
+					State: v1beta1.CellStateReady,
+					Containers: []v1beta1.ContainerStatus{
+						{State: v1beta1.ContainerStateReady},
+					},
+				},
+			},
+			MetadataExists: true,
+		}
+	}
+	return kukeonv1.GetCellResult{
+		Cell: v1beta1.CellDoc{
+			Status: v1beta1.CellStatus{State: v1beta1.CellStateStopped},
+		},
+		MetadataExists: true,
+	}
 }

--- a/cmd/kuke/daemon/start/start_test.go
+++ b/cmd/kuke/daemon/start/start_test.go
@@ -157,6 +157,12 @@ func TestDaemonStart(t *testing.T) {
 						MetadataExists: true,
 					}, nil
 				},
+				// Surviving root/pause containers from the killed daemon are
+				// stopped before the restart so StartCell's running-containers
+				// precondition does not refuse (#1184).
+				stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+					return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+				},
 				startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
 					return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
 				},
@@ -234,6 +240,122 @@ func TestDaemonStart(t *testing.T) {
 	}
 }
 
+// TestDaemonStart_StaleReadyStopsRunningContainersBeforeStart is the headline
+// fix for #1184: a `kill -9` of the kukeond process leaves the cell's other
+// containers (root/pause) running in containerd while the socket goes dead.
+// Without first stopping those survivors, StartCell refuses on its "has
+// running containers and must first be stopped" precondition and the daemon
+// stays down. The stale-Ready fall-through must StopCell (cleaning the
+// survivors) before StartCell, and only after printing the divergence notice.
+func TestDaemonStart_StaleReadyStopsRunningContainersBeforeStart(t *testing.T) {
+	var calls []string
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			calls = append(calls, "stop")
+			return kukeonv1.StopCellResult{Cell: doc, Stopped: true}, nil
+		},
+		startCellFn: func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			calls = append(calls, "start")
+			return kukeonv1.StartCellResult{Cell: doc, Started: true}, nil
+		},
+	}
+
+	buf := runStartWithFake(t, fake, fixedProbe(false))
+
+	if want := []string{"stop", "start"}; len(calls) != 2 || calls[0] != want[0] || calls[1] != want[1] {
+		t.Fatalf("call order: want %v, got %v", want, calls)
+	}
+	// The divergence notice must precede the reconciling action (AC item 3).
+	if !strings.Contains(buf.String(), "metadata reports Ready but socket") {
+		t.Errorf("missing stale-Ready divergence notice\nGot:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `kukeond started (cell "kukeond" in realm "kuke-system")`) {
+		t.Errorf("missing started confirmation\nGot:\n%s", buf.String())
+	}
+}
+
+// TestDaemonStart_StaleReadyStopError surfaces a failure to clean the surviving
+// containers as a wrapped error rather than charging ahead into a StartCell
+// that would refuse on the running-containers precondition.
+func TestDaemonStart_StaleReadyStopError(t *testing.T) {
+	fake := &fakeClient{
+		getCellFn: func(_ v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
+			return kukeonv1.GetCellResult{
+				Cell: v1beta1.CellDoc{
+					Status: v1beta1.CellStatus{
+						State: v1beta1.CellStateReady,
+						Containers: []v1beta1.ContainerStatus{
+							{State: v1beta1.ContainerStateReady},
+						},
+					},
+				},
+				MetadataExists: true,
+			}, nil
+		},
+		stopCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+			return kukeonv1.StopCellResult{}, errors.New("containerd unreachable")
+		},
+		startCellFn: func(_ v1beta1.CellDoc) (kukeonv1.StartCellResult, error) {
+			t.Fatalf("StartCell must not run after StopCell failed")
+			return kukeonv1.StartCellResult{}, nil
+		},
+	}
+
+	cmd := start.NewStartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, kukeonv1.Client(fake))
+	ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
+	ctx = context.WithValue(ctx, lifecycle.ReachableProbeKey{}, fixedProbe(false))
+	cmd.SetContext(ctx)
+	cmd.SetArgs(nil)
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "stop stale kukeond cell:") {
+		t.Fatalf("want wrapped stop error, got %v", err)
+	}
+}
+
+// runStartWithFake executes `kuke daemon start` against the given fake client
+// and probe, returning the captured combined output buffer. It fails the test
+// on any execution error — callers that expect an error drive the command
+// inline instead.
+func runStartWithFake(t *testing.T, fake kukeonv1.Client, probe lifecycle.ReachableProbe) *bytes.Buffer {
+	t.Helper()
+	cmd := start.NewStartCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, lifecycle.MockClientKey{}, fake)
+	ctx = context.WithValue(ctx, lifecycle.EnsureSocketDirKey{}, func() error { return nil })
+	ctx = context.WithValue(ctx, lifecycle.ReachableProbeKey{}, probe)
+	cmd.SetContext(ctx)
+	cmd.SetArgs(nil)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return buf
+}
+
 // TestDaemonStart_NonRootIsRejected confirms the fail-fast UID gate rejects
 // non-root invocations before any side effect (cell lookup, in-process
 // controller construction). Symmetric with the same guard on `kuke daemon
@@ -300,6 +422,7 @@ type fakeClient struct {
 
 	getCellFn   func(doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error)
 	startCellFn func(doc v1beta1.CellDoc) (kukeonv1.StartCellResult, error)
+	stopCellFn  func(doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error)
 }
 
 func (f *fakeClient) GetCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.GetCellResult, error) {
@@ -314,4 +437,11 @@ func (f *fakeClient) StartCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1
 		return kukeonv1.StartCellResult{}, errors.New("unexpected StartCell call")
 	}
 	return f.startCellFn(doc)
+}
+
+func (f *fakeClient) StopCell(_ context.Context, doc v1beta1.CellDoc) (kukeonv1.StopCellResult, error) {
+	if f.stopCellFn == nil {
+		return kukeonv1.StopCellResult{}, errors.New("unexpected StopCell call")
+	}
+	return f.stopCellFn(doc)
 }


### PR DESCRIPTION
## Summary
- `docs/cli-use-cases.md` § Daemon lifecycle promises `daemon start` heals an externally-killed daemon (OOM, host reboot mid-run, `kill -9`) — liveness-keyed idempotence, not persisted state. The CLI already detects the stale-Ready divergence (socket dead, metadata `Ready`) and prints the notice, then falls through to `StartCell`. But `kill -9` only kills the kukeond *process*; the cell's root/pause containers keep running in containerd, so `StartCell` refuses on its `cell %q has running containers and must first be stopped` precondition (`internal/controller/start_cell.go:71`) and the daemon stays down. The documented heal does not hold; the operator must manually `kuke daemon stop` first.
- Fix is scoped to the `daemon start` CLI path (`cmd/kuke/daemon/start/start.go` `runStart`): when the stale-Ready divergence is detected, route through `lifecycle.StopPhase(cmd, client, doc, lifecycle.DefaultTimeout)` — the **same** reconcile `kuke daemon stop` runs (`stop.go:127`) — to clean the surviving containers *before* `StartCell`. The notice still prints first (AC item 3). A stop error is wrapped as `stop stale kukeond cell:` rather than charging into a `StartCell` that would refuse.
- **Review fix-up (`c9fb339`):** the prior commit used a raw `client.StopCell`, which is weaker than what `daemon stop` actually runs. The runner's per-container stop errors are logged-and-continue, not aggregated (#868), so `StopCell` can return `Stopped=true` while a root/pause task ignores SIGTERM and survives — and the next `StartCell` then refuses on the same precondition this heal targets, silently breaking the documented heal. Routing through `StopPhase` adds the #868 verify-or-escalate-to-`KillCell` guard **and** the grace-period→SIGKILL timeout fallback (a hung `StopCell` no longer blocks `daemon start` with no escalation). New test `TestDaemonStart_StaleReadyEscalatesWhenStopReportsSuccessButTaskSurvives` covers the StopCell-reports-success-but-task-survives → KillCell → StartCell path.
- **Blast-radius note:** the general `StartCell` running-containers precondition is left intact — it's a legitimate guard for a normal `kuke start <cell>` against a genuinely-running cell. Only the daemon-start stale-Ready branch reconciles by stopping first, gated on the existing socket-probe divergence. No doc change needed: `docs/cli-use-cases.md:139` already describes this exact behavior; the fix makes the code match the doc.

## Test plan
- [x] `GOWORK=off go test ./cmd/kuke/daemon/start/` — `TestDaemonStart_StaleReadyStopsRunningContainersBeforeStart` asserts stop→start ordering + the divergence notice precedes the action; `TestDaemonStart_StaleReadyEscalatesWhenStopReportsSuccessButTaskSurvives` asserts the stop→kill→start escalation when a task survives a "successful" stop; `TestDaemonStart_StaleReadyStopError` asserts the wrapped error path; the table stale-Ready case uses the stateful `newStaleReadyFake` so `StopPhase`'s post-stop verify passes.
- [x] `GOWORK=off go test $(go list ./... | grep -v /e2e)` (the `make test-root` CI target) — all packages pass, exit 0. (`GOWORK=off` per `go.work`'s own directive: the workspace deliberately mixes incompatible module graphs; `make`/CI build each module standalone.)
- [ ] `make dev-init` end-to-end smoke — not run: the diff touches only the `kuke daemon start` CLI branch (no daemon image, no `/opt/kukeon` layout, no build-path change), so the rebuild/re-init smoke does not exercise it. The behavioral path (kill -9 → daemon start) is covered by the unit tests against the injected fake client; an on-host kill-9 repro needs a running nested daemon not available on this dev host.

## Acceptance criteria
- [x] `kill -9` of the kukeond process followed by `kuke daemon start` brings the daemon back up, exit 0, no manual stop required — the stale-Ready branch now reconciles the survivors via `StopPhase` (escalating to `KillCell` if needed) then `StartCell`s (unit-verified via call-order tests).
- [x] A genuinely-live daemon still gets "already running", exit 0 — that path returns before the reconcile call; `IsCellRunning` + reachable probe branch unchanged.
- [x] The stale-Ready divergence notice still prints before the reconciling action — notice `Printf` precedes the `StopPhase` call; asserted by the ordering test.

Closes #1184