### PR TITLE
fix(init): report 'already running' for idempotent re-run's cell-containers phase

### DIFF
--- a/docs/cli-use-cases.md
+++ b/docs/cli-use-cases.md
@@ -31,7 +31,7 @@ sudo kuke init --kukeond-image docker.io/library/<img>:<tag>
 - Exit code 0 on success; non-zero with a message naming the failed phase otherwise.
 - Side effect: `/opt/kukeon/data/{default,kuke-system}/...` populated; `/run/kukeon/{kukeond.sock,kukeond.pid}` created; containerd namespaces `default.kukeon.io` and `kuke-system.kukeon.io` exist; cgroup subtree `/kukeon/...` populated.
 - After success, `kuke get realms` and `kuke get realms --no-daemon` both list **at least** `default` and `kuke-system` in `Ready` state with their canonical namespaces. The two outputs must agree — divergence indicates the daemon's view of `/opt/kukeon` is stale (the bind-mount regression AGENTS.md guards against).
-- Second invocation on a healthy host is idempotent: every phase reports "already existed", exit code 0, the daemon stays up.
+- Second invocation on a healthy host is idempotent: each provisioning phase reports "already existed" and the container-start phase reports "already running" (no bare "started" — that wording is reserved for a phase that actually created or transitioned something), exit code 0, the daemon stays up.
 - `kuke doctor cgroups` on the same host exits 0 once cgroup controllers are delegated; non-zero output names which controller is missing and whether the kernel lacks support or the parent didn't delegate.
 
 ### Lightweight teardown (dev loop)
@@ -522,7 +522,7 @@ These are the negative paths most likely to surface a UX regression. Each is ver
 
 **Invariants.**
 
-- Idempotent. Every phase reports `already existed`; exit code 0; daemon stays up.
+- Idempotent. Each provisioning phase reports `already existed` and the container-start phase reports `already running` (never a bare `started` on a healthy re-run); exit code 0; daemon stays up.
 
 ### Image references
 

--- a/internal/controller/bootstrap.go
+++ b/internal/controller/bootstrap.go
@@ -668,7 +668,18 @@ func (b *Exec) bootstrapCell(section *CellSection, cellDoc *v1beta1.CellDoc) err
 			return fmt.Errorf("failed to check if root container exists: %w", rootErr)
 		}
 		section.CellRootContainerExistsPre = rootExistsPre
-		section.CellStartedPre = false
+		// Probe whether the cell's containers were already running before the
+		// EnsureCell+StartCell pass below. GetCell populated live container
+		// statuses off containerd, so this distinguishes a healthy idempotent
+		// re-run (containers already up → StartCell is a no-op, report "already
+		// running") from a re-run after a crash/stop (containers down → StartCell
+		// genuinely transitions them, report "started"). Without this the phase
+		// always reported a bare "started", misstating a no-op re-run as a
+		// (re)start of the daemon's containers. Issue #1186. The image-drift
+		// recreate branch overrides this back to false below — there the running
+		// containers are torn down and rebuilt, so "started" is the correct
+		// wording even though they were running pre.
+		section.CellStartedPre = cellContainersRunning(internalCellPre)
 	}
 
 	// When the cell record survives from a prior `kuke init` (or a
@@ -729,6 +740,11 @@ func (b *Exec) bootstrapCell(section *CellSection, cellDoc *v1beta1.CellDoc) err
 		}
 		section.CellRecreatedDueToImageDrift = true
 		startCellAfterEnsure = false
+		// RecreateCell tore down the running container and started a fresh one,
+		// so the container-start phase genuinely transitioned — render "started",
+		// not "already running", regardless of the pre-StartCell probe. Issue
+		// #1186.
+		section.CellStartedPre = false
 	case section.CellMetadataExistsPre:
 		ensuredCell, err = b.runner.EnsureCell(internalCellPre)
 		if err != nil {
@@ -796,6 +812,41 @@ func (b *Exec) bootstrapCell(section *CellSection, cellDoc *v1beta1.CellDoc) err
 	section.CellStarted = !section.CellStartedPre && section.CellStartedPost
 
 	return nil
+}
+
+// cellContainersRunning reports whether every container in the cell's spec is
+// observed running in the cell's populated live status. It mirrors the runner's
+// cellTasksAllRunningFn idempotency guard (issue #149): StartCell no-ops only
+// when every task is already running, so the bootstrap container-start phase
+// must report "already running" rather than "started" exactly in that case
+// (issue #1186). An empty container spec returns false — there is nothing whose
+// running-ness could make StartCell a no-op. A spec container missing from the
+// status slice (or in any non-running state) returns false so a partial /
+// stopped cell renders "started" once StartCell transitions it.
+func cellContainersRunning(cell intmodel.Cell) bool {
+	if len(cell.Spec.Containers) == 0 {
+		return false
+	}
+	for _, spec := range cell.Spec.Containers {
+		if !containerStatusRunning(spec.ID, cell.Status.Containers) {
+			return false
+		}
+	}
+	return true
+}
+
+// containerStatusRunning reports whether the status carrying id is in a running
+// state. Only ContainerStateReady counts — that is the intmodel mapping of
+// containerd.Running, the state cellTasksAllRunningFn tests, so the
+// "already running" verdict tracks StartCell's no-op condition exactly. A
+// missing id (status not populated) is treated as not-running.
+func containerStatusRunning(id string, statuses []intmodel.ContainerStatus) bool {
+	for i := range statuses {
+		if statuses[i].ID == id {
+			return statuses[i].State == intmodel.ContainerStateReady
+		}
+	}
+	return false
 }
 
 // lookupContainerImage returns the Image of the container in cell whose ID

--- a/internal/controller/bootstrap_cell_drift_test.go
+++ b/internal/controller/bootstrap_cell_drift_test.go
@@ -95,6 +95,105 @@ func persistedKukeondCell(image string) intmodel.Cell {
 	}
 }
 
+// persistedKukeondCellWithState builds the same persisted cell record as
+// persistedKukeondCell but with the root container's live status populated to
+// the given state — simulating what fakeRunner.GetCell would observe off
+// containerd on the pre-StartCell lookup. Used to drive the issue #1186
+// container-start-phase wording: a Ready root means the daemon was already up
+// (StartCell no-ops → "already running"); a Stopped root means it must be
+// (re)started → "started".
+func persistedKukeondCellWithState(image string, state intmodel.ContainerState) intmodel.Cell {
+	cell := persistedKukeondCell(image)
+	cell.Status.Containers = []intmodel.ContainerStatus{
+		{
+			ID:    consts.KukeSystemContainerName,
+			Name:  consts.KukeSystemContainerName,
+			State: state,
+		},
+	}
+	return cell
+}
+
+// TestBootstrapCell_IdempotentRerunReportsAlreadyRunning covers issue #1186:
+// a healthy re-run where the persisted cell's containers are already running
+// must record CellStartedPre=true so the container-start phase renders
+// "already running" rather than a bare "started" (which would misstate the
+// no-op re-run as a (re)start of the daemon's containers).
+func TestBootstrapCell_IdempotentRerunReportsAlreadyRunning(t *testing.T) {
+	const image = "docker.io/library/kukeon-local:dev"
+
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return persistedKukeondCellWithState(image, intmodel.ContainerStateReady), nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		EnsureCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(image)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if !section.CellStartedPre {
+		t.Errorf("CellSection.CellStartedPre = false; want true (containers already running on a healthy re-run)")
+	}
+	if section.CellStarted {
+		t.Errorf("CellSection.CellStarted = true; want false (no-op re-run must render \"already running\", not \"started\")")
+	}
+}
+
+// TestBootstrapCell_RerunWithStoppedContainersReportsStarted is the contrast
+// to the already-running case (issue #1186): when the persisted cell's
+// containers are not running (a re-run after a crash/stop), StartCell genuinely
+// transitions them, so CellStartedPre stays false and the phase renders
+// "started".
+func TestBootstrapCell_RerunWithStoppedContainersReportsStarted(t *testing.T) {
+	const image = "docker.io/library/kukeon-local:dev"
+
+	mockRunner := &fakeRunner{
+		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
+			return persistedKukeondCellWithState(image, intmodel.ContainerStateStopped), nil
+		},
+		ExistsCgroupFn: func(_ any) (bool, error) {
+			return true, nil
+		},
+		ExistsCellRootContainerFn: func(_ intmodel.Cell) (bool, error) {
+			return true, nil
+		},
+		EnsureCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			return c, nil
+		},
+		StartCellFn: func(c intmodel.Cell) (intmodel.Cell, error) {
+			return c, nil
+		},
+	}
+
+	ctrl := setupTestController(t, mockRunner)
+	var section controller.CellSection
+	if err := ctrl.BootstrapCellForTest(&section, kukeondCellDocForTest(image)); err != nil {
+		t.Fatalf("BootstrapCellForTest: %v", err)
+	}
+
+	if section.CellStartedPre {
+		t.Errorf("CellSection.CellStartedPre = true; want false (containers were not running pre-StartCell)")
+	}
+	if !section.CellStarted {
+		t.Errorf("CellSection.CellStarted = false; want true (StartCell transitioned stopped containers → \"started\")")
+	}
+}
+
 // TestBootstrapCell_ImageDriftRecreatesCell covers issue #868: a persisted
 // kukeond cell whose root container image diverges from the desired
 // `--kukeond-image` must be torn down and rebuilt rather than re-used in
@@ -112,7 +211,10 @@ func TestBootstrapCell_ImageDriftRecreatesCell(t *testing.T) {
 	)
 	mockRunner := &fakeRunner{
 		GetCellFn: func(_ intmodel.Cell) (intmodel.Cell, error) {
-			return persistedKukeondCell(priorImage), nil
+			// Root is Ready pre — the daemon was up before this drift re-run.
+			// The recreate path must still render "started" (issue #1186): the
+			// running container is torn down and a fresh one started.
+			return persistedKukeondCellWithState(priorImage, intmodel.ContainerStateReady), nil
 		},
 		ExistsCgroupFn: func(_ any) (bool, error) {
 			return true, nil
@@ -175,6 +277,12 @@ func TestBootstrapCell_ImageDriftRecreatesCell(t *testing.T) {
 	}
 	if !section.CellRootContainerCreated {
 		t.Errorf("CellSection.CellRootContainerCreated = false; want true (drift recreate is a rebuild)")
+	}
+	if section.CellStartedPre {
+		t.Errorf("CellSection.CellStartedPre = true; want false (recreate genuinely (re)starts → \"started\")")
+	}
+	if !section.CellStarted {
+		t.Errorf("CellSection.CellStarted = false; want true (drift recreate started a fresh container)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- `kuke init`'s cell-containers phase reported a bare `started` even on a healthy idempotent re-run where the daemon's containers were already running and stayed up — making a no-op re-run indistinguishable from one that actually (re)started the daemon. Issue #1186.
- Root cause: `bootstrapCell` hardcoded `section.CellStartedPre = false` (and `CellStartedPost = true`), so `CellStarted = !Pre && Post` was always `true` when the cell existed. The `printStartAction` "already running" branch (pre && post) was therefore unreachable from init.
- Fix: probe the actual pre-StartCell running state. `GetCell` already populates live container statuses off containerd on the pre-lookup, so `CellStartedPre` is now `cellContainersRunning(internalCellPre)` — true only when every spec container is observed `Ready` (the intmodel mapping of `containerd.Running`, matching StartCell's `cellTasksAllRunningFn` no-op condition, issue #149). A healthy re-run now renders `already running`; a re-run after a crash/stop still renders `started`.
- The image-drift recreate branch overrides `CellStartedPre` back to `false`: there the running container is torn down and a fresh one started, so `started` remains correct (and the out-of-scope post-`daemon reset` create path is unaffected — it has no pre-existing cell, so `CellStartedPre` stays false → `started`).
- Aligned `docs/cli-use-cases.md`'s two idempotency invariants (§ Bootstrap & teardown and § Double `kuke init`) to state provisioning phases report `already existed` and the container-start phase reports `already running`.

AGENTS.md's `cell containers: started` sample tail (line 127) is left unchanged — it documents the fresh-create (post-`daemon reset`) path, which the issue explicitly marks out of scope (wording correct there).

## Test plan

- [x] `make test` (full CI suite: `test-root` + `test-kukebuild`) — all packages pass
- [x] `GOWORK=off go build ./...` and `go vet ./internal/controller/... ./cmd/kuke/init/...` (the Makefile exports `GOWORK=off`; bare workspace build fails on an unrelated `cgroups/v2` dep skew)
- [x] New unit tests in `internal/controller/bootstrap_cell_drift_test.go`:
  - `TestBootstrapCell_IdempotentRerunReportsAlreadyRunning` — Ready containers pre → `CellStartedPre=true`, `CellStarted=false` ("already running")
  - `TestBootstrapCell_RerunWithStoppedContainersReportsStarted` — Stopped containers pre → `CellStartedPre=false`, `CellStarted=true` ("started")
  - `TestBootstrapCell_ImageDriftRecreatesCell` extended: Ready pre but recreate forces `CellStartedPre=false` → `CellStarted=true` ("started")

## Acceptance criteria

- [x] Re-running `kuke init` on a healthy host reports an idempotent no-op wording for the cell-containers phase (no bare `started`) — `already running`.
- [x] Exit 0 and daemon-stays-up behavior unchanged (no code path other than the report flag was touched; StartCell's no-op idempotency is preserved).
- [x] `docs/cli-use-cases.md` invariant and the actual phase wording agree.

Closes #1186