### PR TITLE
fix(status): skip not-loaded snapshotter probe error, not just ErrNotFound

### DIFF
--- a/internal/ctr/storage.go
+++ b/internal/ctr/storage.go
@@ -96,12 +96,11 @@ func (c *client) NamespaceStorage(namespace string) (StorageStats, error) {
 			return nil
 		})
 		if walkErr != nil {
-			// An unregistered snapshotter on the host surfaces as
-			// errdefs.ErrNotFound (or a wrapped variant) — skip it
-			// rather than fail the whole probe. Real users only ever
-			// populate one snapshotter, so the rest are misses on
-			// every healthy host.
-			if errors.Is(walkErr, errdefs.ErrNotFound) {
+			// A snapshotter that isn't present/loaded on this host —
+			// skip it rather than fail the whole probe. Real users
+			// only ever populate one snapshotter, so the rest are
+			// misses on every healthy host.
+			if snapshotterAbsent(walkErr) {
 				continue
 			}
 			return stats, fmt.Errorf("snapshots/%s: %w", snapshotter, walkErr)
@@ -110,4 +109,25 @@ func (c *client) NamespaceStorage(namespace string) (StorageStats, error) {
 	}
 
 	return stats, nil
+}
+
+// snapshotterAbsent reports whether a snapshotter Walk error means the
+// snapshotter simply isn't present on this host — and so should be
+// skipped — rather than a genuine probe failure worth surfacing.
+//
+// An unregistered snapshotter surfaces as errdefs.ErrNotFound (or a
+// wrapped variant). A snapshotter that is configured-known but not
+// loaded into containerd surfaces, on containerd v2, as an
+// ErrInvalidArgument-class error ("snapshotter not loaded: <name>:
+// invalid argument"); the typed-error filter at storage.go was
+// originally too narrow (ErrNotFound only), so the not-loaded case
+// failed the whole probe and degraded every realm row to WARN on a
+// healthy host. Both classes mean "absent here".
+//
+// Genuine failures (boltdb corruption, an I/O error walking the
+// metadata store) are neither class and fall through to a hard error,
+// keeping a real probe failure visible as WARN/FAIL.
+func snapshotterAbsent(err error) bool {
+	return errors.Is(err, errdefs.ErrNotFound) ||
+		errors.Is(err, errdefs.ErrInvalidArgument)
 }

--- a/internal/ctr/storage_test.go
+++ b/internal/ctr/storage_test.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctr
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/containerd/errdefs"
+)
+
+func TestSnapshotterAbsent(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "unregistered snapshotter (ErrNotFound)",
+			err:  errdefs.ErrNotFound,
+			want: true,
+		},
+		{
+			name: "wrapped ErrNotFound",
+			err:  fmt.Errorf("snapshotter btrfs: %w", errdefs.ErrNotFound),
+			want: true,
+		},
+		{
+			// containerd v2 shape for a configured-known but
+			// not-loaded snapshotter — "snapshotter not loaded:
+			// btrfs: invalid argument" — which is an
+			// ErrInvalidArgument-class error.
+			name: "not-loaded snapshotter (ErrInvalidArgument)",
+			err:  fmt.Errorf("snapshotter not loaded: btrfs: %w", errdefs.ErrInvalidArgument),
+			want: true,
+		},
+		{
+			name: "bare ErrInvalidArgument",
+			err:  errdefs.ErrInvalidArgument,
+			want: true,
+		},
+		{
+			// A genuine probe failure (e.g. boltdb corruption) is
+			// neither class and must surface, not be skipped.
+			name: "genuine probe failure (boltdb corruption)",
+			err:  fmt.Errorf("snapshots/overlayfs: %w", errdefs.ErrFailedPrecondition),
+			want: false,
+		},
+		{
+			name: "opaque I/O error",
+			err:  errors.New("read /var/lib/containerd: input/output error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := snapshotterAbsent(tt.err); got != tt.want {
+				t.Errorf("snapshotterAbsent(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- On a healthy containerd-v2 host, a configured-known but *not-loaded* snapshotter (e.g. btrfs/zfs/devmapper when only overlayfs is in use) makes `SnapshotService.Walk` return `snapshotter not loaded: <name>: invalid argument` — an `errdefs.ErrInvalidArgument`-class error. `NamespaceStorage` only skipped `errdefs.ErrNotFound`, so the probe failed the whole walk and every per-realm storage row in `kuke status` degraded to WARN even though overlayfs walked fine.
- Broadens the skip to treat both `ErrNotFound` (unregistered) and `ErrInvalidArgument` (configured-known but not loaded) as "snapshotter absent on this host". Genuine probe failures (boltdb corruption, I/O errors) are neither class and still fall through to a hard error → WARN/FAIL.
- Extracts the decision into a small testable predicate `snapshotterAbsent(err)` so the skip logic — which is the actual runtime branch in the walk loop — is unit-coverable without a full containerd mock.

## Implementation notes

- The issue's Proposal offered "broaden to `errdefs.ErrInvalidArgument` (and/or the `"snapshotter not loaded"` wrapped form)". I took the typed-error-class reading (`errors.Is(err, errdefs.ErrInvalidArgument)`) rather than a substring match on the wrapped message: it's idiomatic (the existing filter already uses `errors.Is`), robust against containerd message-wording drift, and for a snapshotter `Walk` specifically the only realistic source of `ErrInvalidArgument` is the not-loaded case. The reviewer can push back if the narrower string-gated form is preferred.

## Test plan

- [x] `GOWORK=off go build ./internal/ctr/` — passes (the repo's `go.work` pulls an incompatible transitive `cgroups/v2`; `make`/CI export `GOWORK=off`, matching single-module resolution).
- [x] `GOWORK=off go vet ./internal/ctr/` — passes.
- [x] `go test ./internal/ctr/ -run TestSnapshotterAbsent -v` — new test passes; covers the not-loaded `ErrInvalidArgument` shape, the existing `ErrNotFound` (bare + wrapped) skip, and two genuine-failure cases (`ErrFailedPrecondition` boltdb-corruption-class + opaque I/O error) that must NOT be skipped.
- [x] `make test` — full suite passes (exit 0).
- [ ] AC #1 on-host `kuke status` observation (storage rows report OK on a host where btrfs/zfs/devmapper are not loaded) — **not run**: this dev host has no `/run/containerd/containerd.sock` and reproducing the not-loaded-snapshotter condition requires a full containerd-v2 bootstrap. The runtime branch (`snapshotterAbsent`, called directly in the walk loop) is covered by the unit test with the exact `snapshotter not loaded: btrfs: invalid argument` error shape; the `kuke status` row is a thin render over `NamespaceStorage`'s return.

## Acceptance criteria

- [x] `kuke status` storage rows report OK (with overlayfs counts) on a host where btrfs/zfs/devmapper are not loaded — predicate verified by unit test (on-host render deferred per test plan above).
- [x] A genuine probe failure (e.g. boltdb corruption) still surfaces as WARN/FAIL — `snapshotterAbsent` returns false for `ErrFailedPrecondition`/opaque errors; covered by test.
- [x] Unit test covering the not-loaded error shape alongside the existing ErrNotFound skip.

Closes #1181