### PR TITLE
fix: tear down BuildKit _history companion namespaces on uninstall and flag stray ones in status

### DIFF
--- a/cmd/kuke/status/checks.go
+++ b/cmd/kuke/status/checks.go
@@ -358,10 +358,14 @@ func checkStateNamespaces(ctx context.Context, rc *runCtx) Result {
 	// Filter to namespaces under the kukeon suffix — that's what
 	// `kuke init` provisions and what `kuke uninstall` removes. Other
 	// namespaces on the same containerd (e.g. user docker namespaces)
-	// are not ours to police.
+	// are not ours to police. BuildKit history-store companions
+	// (<realm-ns>_history, created by `kuke build`) are included so a
+	// companion stranded by a half-cleaned uninstall surfaces as residue
+	// (issue #1183) — when its owning realm is still live the companion is
+	// added to the expected set below and renders clean.
 	var kukeonNS []string
 	for _, ns := range nsList {
-		if consts.IsKukeonNamespace(ns) {
+		if consts.IsKukeonNamespace(ns) || consts.IsBuildKitHistoryNamespace(ns) {
 			kukeonNS = append(kukeonNS, ns)
 		}
 	}
@@ -382,9 +386,15 @@ func checkStateNamespaces(ctx context.Context, rc *runCtx) Result {
 		return r
 	}
 
+	// A live realm is expected to carry both its namespace and — if it has
+	// ever been built into — that namespace's BuildKit history companion, so
+	// add both forms. A <realm-ns>_history whose owning realm is gone is not
+	// in this set and falls through to the residual list below (issue #1183).
 	expectedNS := make(map[string]bool, len(realms))
 	for i := range realms {
-		expectedNS[consts.RealmNamespace(realms[i].Metadata.Name)] = true
+		ns := consts.RealmNamespace(realms[i].Metadata.Name)
+		expectedNS[ns] = true
+		expectedNS[consts.BuildKitHistoryNamespace(ns)] = true
 	}
 
 	var residual []string

--- a/cmd/kuke/status/status_test.go
+++ b/cmd/kuke/status/status_test.go
@@ -144,6 +144,48 @@ func TestCheckParity_DaemonDownIsWARN(t *testing.T) {
 	}
 }
 
+// TestCheckStateNamespaces_StrayHistoryIsResidual pins issue #1183: a
+// BuildKit history-store companion (<realm-ns>_history) whose owning realm is
+// gone — the post-uninstall leak — surfaces as residue, even though it does
+// not carry the bare .kukeon.io suffix the residual check used to filter on.
+func TestCheckStateNamespaces_StrayHistoryIsResidual(t *testing.T) {
+	rc := &runCtx{
+		// No realms: mirrors a host after `kuke uninstall` removed the realm
+		// namespaces but left kuke-system.kukeon.io_history behind.
+		daemonClient: newFakeClient(),
+		ctrClient:    &fakeCtrClient{namespaces: []string{"kuke-system.kukeon.io_history"}},
+		logger:       testLogger(),
+	}
+
+	r := checkStateNamespaces(context.Background(), rc)
+	if r.Status != StatusWARN {
+		t.Fatalf("expected WARN on stray history namespace; got %s (%q)", r.Status, r.Detail)
+	}
+	if !strings.Contains(r.Detail, "kuke-system.kukeon.io_history") {
+		t.Errorf("Detail should name the stray history namespace; got %q", r.Detail)
+	}
+}
+
+// TestCheckStateNamespaces_LiveRealmHistoryIsClean confirms the companion is
+// not noise during normal operation: while the owning realm is live, its
+// <realm-ns>_history build byproduct is expected and renders OK.
+func TestCheckStateNamespaces_LiveRealmHistoryIsClean(t *testing.T) {
+	rc := &runCtx{
+		daemonClient: newFakeClient().withDefaultRealms(),
+		ctrClient: &fakeCtrClient{namespaces: []string{
+			"default.kukeon.io",
+			"kuke-system.kukeon.io",
+			"kuke-system.kukeon.io_history",
+		}},
+		logger: testLogger(),
+	}
+
+	r := checkStateNamespaces(context.Background(), rc)
+	if r.Status != StatusOK {
+		t.Fatalf("expected OK with a live realm's history companion; got %s (%q)", r.Status, r.Detail)
+	}
+}
+
 // TestCheckParity_NestedDescent confirms the walk recurses into the
 // realm-set intersection (spaces / stacks / cells / containers) — a
 // regression in the descent loop would silently stop reporting nested

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -318,3 +318,30 @@ func RealmFromNamespace(ns string) string {
 	}
 	return ns[:len(ns)-len(RealmNamespaceSuffix)]
 }
+
+// BuildKitHistoryNamespaceSuffix is the suffix BuildKit (driven by kukebuild,
+// BuildKit-as-library) appends to a containerd namespace to form its companion
+// history-store namespace. BuildKit's solver/llbsolver/history.go derives it as
+// ns + "_history", so a `kuke build` into realm R leaves both R's namespace and
+// <R-namespace>_history on the host. `kuke uninstall` drains and removes the
+// companion alongside the realm namespace, and `kuke status` flags a stray one
+// as residue (issue #1183).
+const BuildKitHistoryNamespaceSuffix = "_history"
+
+// BuildKitHistoryNamespace returns the BuildKit history-store companion
+// namespace for a containerd namespace (the realm namespace -> <ns>_history).
+func BuildKitHistoryNamespace(ns string) string {
+	return ns + BuildKitHistoryNamespaceSuffix
+}
+
+// IsBuildKitHistoryNamespace reports whether ns is a BuildKit history-store
+// companion of a kukeon-managed namespace — i.e. it carries the _history suffix
+// and, with that suffix stripped, the remainder is itself a kukeon namespace.
+// Non-kukeon companions (e.g. "moby_history") are excluded so this path never
+// claims a co-tenant's namespace.
+func IsBuildKitHistoryNamespace(ns string) bool {
+	if !strings.HasSuffix(ns, BuildKitHistoryNamespaceSuffix) {
+		return false
+	}
+	return IsKukeonNamespace(ns[:len(ns)-len(BuildKitHistoryNamespaceSuffix)])
+}

--- a/internal/consts/consts_test.go
+++ b/internal/consts/consts_test.go
@@ -58,6 +58,56 @@ func TestRealmNamespaceRoundTripDefault(t *testing.T) {
 	}
 }
 
+func TestBuildKitHistoryNamespaceRoundTripDefault(t *testing.T) {
+	ns := consts.RealmNamespace("kuke-system")
+	historyNS := consts.BuildKitHistoryNamespace(ns)
+	if want := "kuke-system.kukeon.io_history"; historyNS != want {
+		t.Fatalf("BuildKitHistoryNamespace(%q): got %q, want %q", ns, historyNS, want)
+	}
+	if !consts.IsBuildKitHistoryNamespace(historyNS) {
+		t.Errorf("IsBuildKitHistoryNamespace(%q) = false, want true", historyNS)
+	}
+	// The realm namespace itself is not a history companion.
+	if consts.IsBuildKitHistoryNamespace(ns) {
+		t.Errorf("IsBuildKitHistoryNamespace(%q) = true, want false (realm ns, not companion)", ns)
+	}
+}
+
+func TestIsBuildKitHistoryNamespaceRejectsForeignAndBare(t *testing.T) {
+	cases := map[string]bool{
+		"kuke-system.kukeon.io_history": true,  // kukeon companion
+		"default.kukeon.io_history":     true,  // kukeon companion
+		"moby_history":                  false, // foreign base, not a kukeon ns
+		"example.com_history":           false, // foreign suffix base
+		"_history":                      false, // empty base
+		"kuke-system.kukeon.io":         false, // realm ns, no _history suffix
+		"history":                       false, // not even the suffix
+	}
+	for ns, want := range cases {
+		if got := consts.IsBuildKitHistoryNamespace(ns); got != want {
+			t.Errorf("IsBuildKitHistoryNamespace(%q) = %v, want %v", ns, got, want)
+		}
+	}
+}
+
+func TestBuildKitHistoryNamespaceHonorsCustomSuffix(t *testing.T) {
+	withRuntime(t, "dev.kukeon.io", "/kukeon-dev", func(t *testing.T) {
+		ns := consts.RealmNamespace("default")
+		historyNS := consts.BuildKitHistoryNamespace(ns)
+		if want := "default.dev.kukeon.io_history"; historyNS != want {
+			t.Fatalf("BuildKitHistoryNamespace(%q) under dev suffix: got %q, want %q",
+				ns, historyNS, want)
+		}
+		if !consts.IsBuildKitHistoryNamespace(historyNS) {
+			t.Errorf("IsBuildKitHistoryNamespace(%q) under dev suffix: got false, want true", historyNS)
+		}
+		// A default-instance companion must be rejected under the dev suffix.
+		if consts.IsBuildKitHistoryNamespace("default.kukeon.io_history") {
+			t.Errorf("IsBuildKitHistoryNamespace default-instance companion accepted under dev suffix")
+		}
+	})
+}
+
 func TestRealmNamespaceRoundTripCustomSuffix(t *testing.T) {
 	withRuntime(t, "dev.kukeon.io", "/kukeon-dev", func(t *testing.T) {
 		const realm = "default"

--- a/internal/controller/runner/delete_cell_test.go
+++ b/internal/controller/runner/delete_cell_test.go
@@ -57,19 +57,33 @@ type deleteCellFakeClient struct {
 	loadCgroupFn        func(group, mountpoint string) (*cgroup2.Manager, error)
 	newCgroupFn         func(spec ctr.CgroupSpec) (*cgroup2.Manager, error)
 	enableCellSubtreeFn func(group, mountpoint string, controllers []string) ([]string, error)
+	// Namespace teardown hooks: the PurgeRealm history-companion test (#1183)
+	// records which namespaces were drained and deleted so it can assert the
+	// <ns>_history companion is torn down alongside the realm namespace.
+	deleteNamespaceFn  func(namespace string) error
+	cleanupNamespaceFn func(namespace, snapshotter string) error
 }
 
 func (c *deleteCellFakeClient) Connect() error { return nil }
 func (c *deleteCellFakeClient) Close() error   { return nil }
 
 func (c *deleteCellFakeClient) CreateNamespace(string) error { return nil }
-func (c *deleteCellFakeClient) DeleteNamespace(string) error { return nil }
+func (c *deleteCellFakeClient) DeleteNamespace(namespace string) error {
+	if c.deleteNamespaceFn != nil {
+		return c.deleteNamespaceFn(namespace)
+	}
+	return nil
+}
+
 func (c *deleteCellFakeClient) ListNamespaces() ([]string, error) {
 	return nil, nil
 }
 func (c *deleteCellFakeClient) GetNamespace(string) (string, error)  { return "", nil }
 func (c *deleteCellFakeClient) ExistsNamespace(string) (bool, error) { return false, nil }
-func (c *deleteCellFakeClient) CleanupNamespaceResources(string, string) error {
+func (c *deleteCellFakeClient) CleanupNamespaceResources(namespace, snapshotter string) error {
+	if c.cleanupNamespaceFn != nil {
+		return c.cleanupNamespaceFn(namespace, snapshotter)
+	}
 	return nil
 }
 
@@ -446,7 +460,11 @@ func TestDeleteCell_SweepsOrphansWhenMetadataAbsent(t *testing.T) {
 			}
 		}
 		if !found {
-			t.Errorf("orphan container %q was not swept on the metadata-absent path; DeleteContainer called for %v", want, deletedIDs)
+			t.Errorf(
+				"orphan container %q was not swept on the metadata-absent path; DeleteContainer called for %v",
+				want,
+				deletedIDs,
+			)
 		}
 	}
 }

--- a/internal/controller/runner/delete_realm.go
+++ b/internal/controller/runner/delete_realm.go
@@ -127,6 +127,16 @@ func (r *Exec) DeleteRealm(realm intmodel.Realm) error {
 		return fmt.Errorf("%w: failed to delete containerd namespace: %w", errdefs.ErrDeleteRealm, err)
 	}
 
+	// Tear down the BuildKit history-store companion (<namespace>_history) with
+	// the same drain-then-delete the realm namespace got. A `kuke build` into
+	// this realm leaves the companion behind; without this `kuke delete realm`
+	// strands exactly the residue `kuke status` now flags (issue #1183). The
+	// same "a deleted realm's build history should not survive" rationale that
+	// folds this into the purge path applies verbatim here.
+	if err = r.purgeBuildKitHistoryNamespace(internalRealm.Spec.Namespace); err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrDeleteRealm, err)
+	}
+
 	// Delete realm metadata file
 	metadataFilePath := fs.RealmMetadataPath(r.opts.RunPath, internalRealm.Metadata.Name)
 	if err = metadata.DeleteMetadata(r.ctx, r.logger, metadataFilePath); err != nil {

--- a/internal/controller/runner/purge_realm.go
+++ b/internal/controller/runner/purge_realm.go
@@ -165,41 +165,14 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) (bool, error) {
 	}
 
 	// Drain and delete the BuildKit history-store companion namespace
-	// (<namespace>_history). kukebuild (BuildKit-as-library) creates it for
-	// BuildKit's history store — solver/llbsolver/history.go derives it as
-	// ns + "_history" — so a `kuke build` into this realm leaves the companion
-	// behind. Tear it down with the same drain-then-delete the realm namespace
+	// (<namespace>_history) with the same drain-then-delete the realm namespace
 	// gets so a full uninstall leaves no `*.kukeon.io*` namespaces (issue
-	// #1183). DeleteNamespace is idempotent (a no-op when the companion never
-	// existed, i.e. the realm was never built into), so this is safe on every
-	// purge. A companion that survives folds into namespaceRemoved so the
+	// #1183). A companion that survives folds into namespaceRemoved so the
 	// uninstall half-cleaned-host gate still sees residual containerd state.
-	if realmForOps.Spec.Namespace != "" {
-		historyNS := consts.BuildKitHistoryNamespace(realmForOps.Spec.Namespace)
-		if err = r.ctrClient.CleanupNamespaceResources(historyNS, ""); err != nil {
-			r.logger.WarnContext(
-				r.ctx,
-				"failed to cleanup buildkit history namespace resources",
-				"namespace",
-				historyNS,
-				"error",
-				err,
-			)
-			// Continue with namespace deletion attempt anyway.
-		}
-		if err = r.ctrClient.DeleteNamespace(historyNS); err != nil {
-			namespaceRemoved = false
-			if nsErr == nil {
-				nsErr = fmt.Errorf("failed to delete buildkit history namespace %q: %w", historyNS, err)
-			}
-			r.logger.WarnContext(
-				r.ctx,
-				"failed to delete buildkit history namespace",
-				"namespace",
-				historyNS,
-				"error",
-				err,
-			)
+	if histErr := r.purgeBuildKitHistoryNamespace(realmForOps.Spec.Namespace); histErr != nil {
+		namespaceRemoved = false
+		if nsErr == nil {
+			nsErr = histErr
 		}
 	}
 
@@ -223,4 +196,46 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) (bool, error) {
 	}
 
 	return namespaceRemoved, nsErr
+}
+
+// purgeBuildKitHistoryNamespace drains and deletes the BuildKit history-store
+// companion namespace (<namespace>_history) belonging to the realm namespace
+// ns. kukebuild (BuildKit-as-library) creates it for BuildKit's history store
+// — solver/llbsolver/history.go derives it as ns + "_history" — so a
+// `kuke build` into a realm leaves the companion behind, and every
+// namespace-teardown seam (uninstall/purge via PurgeRealm, and DeleteRealm)
+// must tear it down too or it strands the exact residue `kuke status` now
+// flags (issue #1183). DeleteNamespace is idempotent (a no-op when the
+// companion never existed, i.e. the realm was never built into), so this is
+// safe to call on every teardown. An empty ns is a no-op. Returns a non-nil
+// error only when DeleteNamespace itself fails; resource-drain failures are
+// logged best-effort like the realm namespace's own drain.
+func (r *Exec) purgeBuildKitHistoryNamespace(ns string) error {
+	if ns == "" {
+		return nil
+	}
+	historyNS := consts.BuildKitHistoryNamespace(ns)
+	if err := r.ctrClient.CleanupNamespaceResources(historyNS, ""); err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"failed to cleanup buildkit history namespace resources",
+			"namespace",
+			historyNS,
+			"error",
+			err,
+		)
+		// Continue with namespace deletion attempt anyway.
+	}
+	if err := r.ctrClient.DeleteNamespace(historyNS); err != nil {
+		r.logger.WarnContext(
+			r.ctx,
+			"failed to delete buildkit history namespace",
+			"namespace",
+			historyNS,
+			"error",
+			err,
+		)
+		return fmt.Errorf("failed to delete buildkit history namespace %q: %w", historyNS, err)
+	}
+	return nil
 }

--- a/internal/controller/runner/purge_realm.go
+++ b/internal/controller/runner/purge_realm.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/eminwux/kukeon/internal/cni"
+	"github.com/eminwux/kukeon/internal/consts"
 	"github.com/eminwux/kukeon/internal/ctr"
 	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
@@ -161,6 +162,45 @@ func (r *Exec) PurgeRealm(realm intmodel.Realm) (bool, error) {
 		)
 		// Continue with other cleanup so a single failure does not strand
 		// metadata/cgroup state on disk.
+	}
+
+	// Drain and delete the BuildKit history-store companion namespace
+	// (<namespace>_history). kukebuild (BuildKit-as-library) creates it for
+	// BuildKit's history store — solver/llbsolver/history.go derives it as
+	// ns + "_history" — so a `kuke build` into this realm leaves the companion
+	// behind. Tear it down with the same drain-then-delete the realm namespace
+	// gets so a full uninstall leaves no `*.kukeon.io*` namespaces (issue
+	// #1183). DeleteNamespace is idempotent (a no-op when the companion never
+	// existed, i.e. the realm was never built into), so this is safe on every
+	// purge. A companion that survives folds into namespaceRemoved so the
+	// uninstall half-cleaned-host gate still sees residual containerd state.
+	if realmForOps.Spec.Namespace != "" {
+		historyNS := consts.BuildKitHistoryNamespace(realmForOps.Spec.Namespace)
+		if err = r.ctrClient.CleanupNamespaceResources(historyNS, ""); err != nil {
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to cleanup buildkit history namespace resources",
+				"namespace",
+				historyNS,
+				"error",
+				err,
+			)
+			// Continue with namespace deletion attempt anyway.
+		}
+		if err = r.ctrClient.DeleteNamespace(historyNS); err != nil {
+			namespaceRemoved = false
+			if nsErr == nil {
+				nsErr = fmt.Errorf("failed to delete buildkit history namespace %q: %w", historyNS, err)
+			}
+			r.logger.WarnContext(
+				r.ctx,
+				"failed to delete buildkit history namespace",
+				"namespace",
+				historyNS,
+				"error",
+				err,
+			)
+		}
 	}
 
 	// Remove all metadata directories for realm and children

--- a/internal/controller/runner/purge_realm_history_test.go
+++ b/internal/controller/runner/purge_realm_history_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/eminwux/kukeon/internal/consts"
+	"github.com/eminwux/kukeon/internal/errdefs"
 	intmodel "github.com/eminwux/kukeon/internal/modelhub"
 )
 
@@ -103,6 +104,83 @@ func TestPurgeRealm_HistoryCompanionFailureFoldsIntoNamespaceRemoved(t *testing.
 	}
 	if err == nil {
 		t.Fatal("expected an error naming the stranded history companion")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error chain should wrap the delete failure; got %v", err)
+	}
+}
+
+// TestDeleteRealm_DrainsAndDeletesBuildKitHistoryCompanion pins the sibling
+// teardown seam flagged in PR #1205 review: `kuke delete realm` must tear down
+// the realm namespace's BuildKit history-store companion (<namespace>_history)
+// with the same drain-then-delete PurgeRealm gives it, or it strands exactly
+// the residue `kuke status`'s #1183 check now WARNs on.
+func TestDeleteRealm_DrainsAndDeletesBuildKitHistoryCompanion(t *testing.T) {
+	var deleted, drained []string
+	fake := &deleteCellFakeClient{
+		deleteNamespaceFn: func(ns string) error {
+			deleted = append(deleted, ns)
+			return nil
+		},
+		cleanupNamespaceFn: func(ns, _ string) error {
+			drained = append(drained, ns)
+			return nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+
+	const realmName = "kuke-system"
+	// seedDeleteCellRealm writes Spec.Namespace = realmName + ".kukeon.io", which
+	// is what DeleteRealm reads back via GetRealm and tears down.
+	seedDeleteCellRealm(t, r, realmName)
+	namespace := realmName + ".kukeon.io"
+	historyNS := consts.BuildKitHistoryNamespace(namespace)
+
+	if err := r.DeleteRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: realmName},
+	}); err != nil {
+		t.Fatalf("DeleteRealm returned error: %v", err)
+	}
+
+	if !slices.Contains(deleted, namespace) {
+		t.Errorf("realm namespace %q not deleted; deleted=%v", namespace, deleted)
+	}
+	if !slices.Contains(deleted, historyNS) {
+		t.Errorf("history companion %q not deleted; deleted=%v", historyNS, deleted)
+	}
+	if !slices.Contains(drained, historyNS) {
+		t.Errorf("history companion %q not drained before delete; drained=%v", historyNS, drained)
+	}
+}
+
+// TestDeleteRealm_HistoryCompanionFailureSurfacesError confirms a stranded
+// history companion fails the delete: DeleteRealm wraps the companion delete
+// failure under ErrDeleteRealm rather than reporting a clean teardown.
+func TestDeleteRealm_HistoryCompanionFailureSurfacesError(t *testing.T) {
+	const realmName = "kuke-system"
+	namespace := realmName + ".kukeon.io"
+	historyNS := consts.BuildKitHistoryNamespace(namespace)
+	wantErr := errors.New("namespace not empty")
+
+	fake := &deleteCellFakeClient{
+		deleteNamespaceFn: func(ns string) error {
+			if ns == historyNS {
+				return wantErr
+			}
+			return nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+	seedDeleteCellRealm(t, r, realmName)
+
+	err := r.DeleteRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: realmName},
+	})
+	if err == nil {
+		t.Fatal("expected an error naming the stranded history companion")
+	}
+	if !errors.Is(err, errdefs.ErrDeleteRealm) {
+		t.Errorf("error should wrap ErrDeleteRealm; got %v", err)
 	}
 	if !errors.Is(err, wantErr) {
 		t.Errorf("error chain should wrap the delete failure; got %v", err)

--- a/internal/controller/runner/purge_realm_history_test.go
+++ b/internal/controller/runner/purge_realm_history_test.go
@@ -1,0 +1,110 @@
+//go:build !integration
+
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // exercises *Exec.PurgeRealm against an in-package ctr.Client fake
+package runner
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/eminwux/kukeon/internal/consts"
+	intmodel "github.com/eminwux/kukeon/internal/modelhub"
+)
+
+// TestPurgeRealm_DrainsAndDeletesBuildKitHistoryCompanion pins issue #1183:
+// runner.PurgeRealm tears down the realm namespace's BuildKit history-store
+// companion (<namespace>_history) with the same drain-then-delete the realm
+// namespace gets, so a full uninstall (which routes every realm through this
+// path) leaves no `*.kukeon.io*` namespaces behind.
+func TestPurgeRealm_DrainsAndDeletesBuildKitHistoryCompanion(t *testing.T) {
+	var deleted, drained []string
+	fake := &deleteCellFakeClient{
+		deleteNamespaceFn: func(ns string) error {
+			deleted = append(deleted, ns)
+			return nil
+		},
+		cleanupNamespaceFn: func(ns, _ string) error {
+			drained = append(drained, ns)
+			return nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+
+	const namespace = "kuke-system.kukeon.io"
+	historyNS := consts.BuildKitHistoryNamespace(namespace)
+
+	// No metadata is seeded, so GetRealm returns ErrRealmNotFound and PurgeRealm
+	// falls back to the provided realm — exactly the partial-uninstall path the
+	// companion leak was observed on.
+	removed, err := r.PurgeRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: "kuke-system"},
+		Spec:     intmodel.RealmSpec{Namespace: namespace},
+	})
+	if err != nil {
+		t.Fatalf("PurgeRealm returned error: %v", err)
+	}
+	if !removed {
+		t.Error("expected namespaceRemoved=true on a clean purge")
+	}
+
+	if !slices.Contains(deleted, namespace) {
+		t.Errorf("realm namespace %q not deleted; deleted=%v", namespace, deleted)
+	}
+	if !slices.Contains(deleted, historyNS) {
+		t.Errorf("history companion %q not deleted; deleted=%v", historyNS, deleted)
+	}
+	if !slices.Contains(drained, historyNS) {
+		t.Errorf("history companion %q not drained before delete; drained=%v", historyNS, drained)
+	}
+}
+
+// TestPurgeRealm_HistoryCompanionFailureFoldsIntoNamespaceRemoved confirms a
+// stranded history companion blocks the uninstall half-cleaned-host gate: when
+// the companion fails to delete, namespaceRemoved is false even though the
+// realm namespace itself was removed, and the error names the companion.
+func TestPurgeRealm_HistoryCompanionFailureFoldsIntoNamespaceRemoved(t *testing.T) {
+	const namespace = "kuke-system.kukeon.io"
+	historyNS := consts.BuildKitHistoryNamespace(namespace)
+	wantErr := errors.New("namespace not empty")
+
+	fake := &deleteCellFakeClient{
+		deleteNamespaceFn: func(ns string) error {
+			if ns == historyNS {
+				return wantErr
+			}
+			return nil
+		},
+	}
+	r := newDeleteCellTestExec(t, fake)
+
+	removed, err := r.PurgeRealm(intmodel.Realm{
+		Metadata: intmodel.RealmMetadata{Name: "kuke-system"},
+		Spec:     intmodel.RealmSpec{Namespace: namespace},
+	})
+	if removed {
+		t.Error("expected namespaceRemoved=false when the history companion survives")
+	}
+	if err == nil {
+		t.Fatal("expected an error naming the stranded history companion")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error chain should wrap the delete failure; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- `kuke build` (kukebuild / BuildKit-as-library) creates a companion containerd namespace `<ns>_history` for BuildKit's history store (BuildKit derives it as `ns + "_history"`). A full `kuke uninstall -y` removed the `*.kukeon.io` realm namespaces but left `<realm-ns>_history` behind, and `kuke status`'s residual-namespace check never flagged it — the `_history` suffix doesn't match the `.kukeon.io` shape the check filters on (issue #1183).
- **Uninstall (AC 1):** `runner.PurgeRealm` now drains-then-deletes the `<namespace>_history` companion with the same `CleanupNamespaceResources` + `DeleteNamespace` the realm namespace gets. `DeleteNamespace` is idempotent (no-op when the realm was never built into), so this is safe on every purge. A companion that fails to delete folds into the returned `namespaceRemoved=false` so the uninstall half-cleaned-host gate (#287) still leaves the filesystem intact when containerd residue survives.
- **Status (AC 2):** `checkStateNamespaces` now includes `_history` companions in its candidate set; a live realm's companion is added to the expected set (no noise during normal operation), while a companion whose owning realm is gone falls through to the residual list and renders WARN.

## Design notes (for the reviewer to push back on)
- **Placement in `runner.PurgeRealm`, not just the uninstall loop.** Uninstall routes every realm through `controller.PurgeRealm` → `runner.PurgeRealm`, so this is the single cohesive teardown seam and satisfies AC 1. A side effect is that `kuke purge <realm>` (which shares the path) now also removes that realm's `_history` companion — this is correct: a deleted realm's build history should not survive, and it closes the same leak for the purge verb. Lower-blast-radius alternative (special-casing the uninstall loop only) would have left `kuke purge` leaking the companion.
- **Status flags a companion only when its realm is gone**, not whenever a `_history` namespace exists. Flagging it during normal operation (realm live, just built into) would WARN on every post-build dev host. The issue frames this as catching residue from a half-cleaned uninstall, so "stray" == owning realm absent.
- New consts helpers `BuildKitHistoryNamespace` / `IsBuildKitHistoryNamespace` honor the operator-configured `RealmNamespaceSuffix`, so the companion match works under a non-default suffix (e.g. `dev.kukeon.io`) too.

## Test plan
- [x] `GOWORK=off go test ./internal/consts/...` — new round-trip + suffix + foreign-base rejection tests for the history-namespace helpers.
- [x] `GOWORK=off go test ./cmd/kuke/status/...` — new `checkStateNamespaces` tests: stray companion → WARN naming it; live-realm companion → OK.
- [x] `GOWORK=off go test ./internal/controller/runner/...` — new `PurgeRealm` tests: companion is drained+deleted alongside the realm namespace; a companion delete failure folds into `namespaceRemoved=false` and surfaces in the error.
- [x] `make test-root` (full root CI test target, `GOWORK=off`) — exit 0, no failures.
- [x] `go vet` (affected packages) and `pre-commit run --files <changed>` (go-fmt, golangci-lint, addlicense) — all pass.
- [ ] `make dev-init` end-to-end smoke (`kuke build` + `kuke uninstall` + `ctr ns ls`) — not run: requires a host containerd at `/run/containerd/containerd.sock` and root; deferred to the reviewer's clean-host environment. The on-host `_history` leak is reproduced in the unit tests above against the real teardown seam.

## Acceptance criteria
- [x] After `kuke build --realm kuke-system` + full `kuke uninstall -y`, no `*.kukeon.io*` namespaces survive, including `_history` companions — covered by the `runner.PurgeRealm` teardown + unit test (CLI end-to-end deferred per test plan).
- [x] `kuke status` flags a stray `<realm-ns>_history` namespace as residue when present — covered by `checkStateNamespaces` + unit test.

Closes #1183